### PR TITLE
feat(antigravity): add CLI support and integration tests

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "current_objective": "Complete Antigravity (agy) lifecycle and integration parity across agent-deck (session discovery, readiness detection, skills catalog, and status reporting).",
+  "global_context": "Go project agent-deck. Multi-tool TUI dashboard for AI CLI agents.",
+  "task_queue": [
+    {
+      "id": "T1",
+      "agent": "developer",
+      "desc": "Add Antigravity detection to detectToolFromName in internal/session/discovery.go and project skills support in internal/session/skills_catalog.go (ShouldRestartProjectSkills and GetProjectSkillsDir). Acceptance: unit tests in discovery_test.go and skills_catalog_test.go pass for 'antigravity'.",
+      "status": "done",
+      "depends_on": []
+    },
+    {
+      "id": "T2",
+      "agent": "developer",
+      "desc": "Add 'antigravity' to IsHookEmittingTool in internal/sessionstatus/sessionstatus.go. Acceptance: IsHookEmittingTool('antigravity') returns true and unit tests pass.",
+      "status": "done",
+      "depends_on": []
+    },
+    {
+      "id": "T3",
+      "agent": "developer",
+      "desc": "Update internal/ui/home.go launch animation stopping logic (animTool == 'antigravity' checking for agy> or antigravity> prompts around line 3060) and exclude selected.Tool != 'antigravity' from custom tool header fallthrough around line 16301. Acceptance: go test ./internal/ui passes.",
+      "status": "done",
+      "depends_on": []
+    },
+    {
+      "id": "T4",
+      "agent": "tester",
+      "desc": "Run full test suite across agent-deck to verify no regressions in session discovery, UI rendering, or skills catalog resolution. Acceptance: go test ./... passes cleanly.",
+      "status": "done",
+      "depends_on": ["T1", "T2", "T3"]
+    },
+    {
+      "id": "T5",
+      "agent": "critical-reviewer",
+      "desc": "Perform final code review over all Antigravity integration changes against acceptance criteria. Acceptance: APPROVED verdict.",
+      "status": "done",
+      "depends_on": ["T4"]
+    }
+  ],
+  "history": [
+    "T1 dispatched",
+    "T2 dispatched",
+    "T3 dispatched",
+    "T1 done",
+    "T2 done",
+    "T3 done",
+    "T4 dispatched",
+    "T4 done",
+    "T5 dispatched",
+    "T5 done (APPROVED)"
+  ]
+}

--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1972,3 +1972,58 @@ tests:
   run:
     command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_live_mode_invokes_session_send -v
     expected: pass
+- id: agy-build-command
+  added: '2026-06-23'
+  task: antigravity-integration
+  file: internal/session/antigravity_test.go
+  test_name: TestBuildAntigravityCommand
+  purpose: 'Antigravity CLI launch contract — buildAntigravityCommand emits `agy --conversation <uuid>`, `--dangerously-skip-permissions` when YoloMode is on, and `--model` when AntigravityModel is set. Guards the resume path (must NOT use --continue) and the YOLO/model wiring exposed via TUI/CLI.'
+  source: docs/in-progress.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestBuildAntigravityCommand -count=1 -v
+    expected: pass
+- id: agy-hooks-roundtrip
+  added: '2026-06-23'
+  task: antigravity-integration
+  file: internal/session/antigravity_test.go
+  test_name: TestInjectAntigravityHooks
+  purpose: 'Antigravity hooks install/uninstall round-trip in ~/.gemini/config/hooks.json — Inject adds the agent-deck block, Check returns true, Remove restores the file, Check returns false. Pins the `agent-deck antigravity-hooks install` UX and prevents foreign-hook clobbering.'
+  source: docs/in-progress.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestInjectAntigravityHooks -count=1 -v
+    expected: pass
+- id: agy-tool-data-roundtrip
+  added: '2026-06-23'
+  task: antigravity-integration
+  file: internal/session/antigravity_test.go
+  test_name: TestAntigravityToolDataRoundTrip
+  purpose: 'Antigravity persistence — conversation ID, YOLO, model, detected-at survive JSON round-trip through the tool_data extras zone. Pins the cross-restart resume contract; regressions here mean a relaunched session would forget which conversation to resume.'
+  source: docs/in-progress.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestAntigravityToolDataRoundTrip -count=1 -v
+    expected: pass
+- id: agy-cli-yolo-override
+  added: '2026-06-23'
+  task: antigravity-integration
+  file: cmd/agent-deck/add_test.go
+  test_name: TestApplyCLIYoloOverride
+  purpose: 'CLI parity — `agent-deck add -c agy --yolo` sets AntigravityYoloMode and propagates --dangerously-skip-permissions to the command line, mirroring the Gemini/Codex/Hermes flag handling.'
+  source: docs/in-progress.md
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestApplyCLIYoloOverride -count=1 -v
+    expected: pass
+- id: agy-tui-create-session
+  added: '2026-06-23'
+  task: antigravity-integration
+  file: internal/ui/home_test.go
+  test_name: TestCreateSessionTool_Antigravity
+  purpose: 'TUI create-session path resolves the `agy` / `antigravity` command into a session whose Tool is `antigravity`, with default YOLO and MCP/hook paths wired. Guards the new-session dialog → home.createSessionTool flow.'
+  source: docs/in-progress.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestCreateSessionTool_Antigravity -count=1 -v
+    expected: pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Antigravity (`agy`) CLI support.** New built-in tool wired through TUI, CLI, web API, sandbox, MCP, and hooks. Sessions launch via `agy`, resume by conversation UUID across restarts, support per-session and global YOLO (`--dangerously-skip-permissions`), and surface a model picker (Ctrl+G) backed by `agy models`. Hooks (`PreInvocation`, `Stop`) install into `~/.gemini/config/hooks.json` via `agent-deck antigravity-hooks install`. Configure under `[antigravity]` in `config.toml` (`YoloMode`, `DefaultModel`, `EnvFile`, `Command`).
+
 ## [1.9.76] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< HEAD
 ### Added
 
 - **Antigravity (`agy`) CLI support.** New built-in tool wired through TUI, CLI, web API, sandbox, MCP, and hooks. Sessions launch via `agy`, resume by conversation UUID across restarts, support per-session and global YOLO (`--dangerously-skip-permissions`), and surface a model picker (Ctrl+G) backed by `agy models`. Hooks (`PreInvocation`, `Stop`) install into `~/.gemini/config/hooks.json` via `agent-deck antigravity-hooks install`. Configure under `[antigravity]` in `config.toml` (`YoloMode`, `DefaultModel`, `EnvFile`, `Command`).
-=======
+
 ## [1.10.9] - 2026-07-02
 
 ### Fixed
@@ -53,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Fleet fan-out CLI: launch parented children and track completions.** `agent-deck launch` gains `--inherit-group` (child inherits parent's group instead of cwd-derived), `--assert-done` / `--no-assert-done` (appends a done-signal instruction to the initial `-m` message for claude children, opt-out), and a new `agent-deck session children` subcommand listing direct children of a session with their status and completion time. A new file-based completion ledger (`completion-ledger/`) records when children finish so `session children` can report outcomes without touching the SQLite schema. The `fleet` skill is now included in the marketplace plugin. ([#1518](https://github.com/asheshgoplani/agent-deck/pull/1518))
->>>>>>> upstream/main
 
 ## [1.9.77] - 2026-06-25
 

--- a/cmd/agent-deck/add_test.go
+++ b/cmd/agent-deck/add_test.go
@@ -20,6 +20,16 @@ func TestApplyCLIYoloOverride(t *testing.T) {
 		}
 	})
 
+	t.Run("enabled for antigravity sets override", func(t *testing.T) {
+		inst := session.NewInstanceWithTool("antigravity-test", "/tmp/test", "antigravity")
+		if err := applyCLIYoloOverride(inst, true); err != nil {
+			t.Fatalf("applyCLIYoloOverride() error = %v", err)
+		}
+		if inst.AntigravityYoloMode == nil || !*inst.AntigravityYoloMode {
+			t.Fatalf("AntigravityYoloMode = %v, want true override", inst.AntigravityYoloMode)
+		}
+	})
+
 	t.Run("enabled for codex sets override", func(t *testing.T) {
 		inst := session.NewInstanceWithTool("codex-test", "/tmp/test", "codex")
 		if err := applyCLIYoloOverride(inst, true); err != nil {

--- a/cmd/agent-deck/antigravity_hook_handler.go
+++ b/cmd/agent-deck/antigravity_hook_handler.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// antigravityHookPayload is the JSON Antigravity CLI sends on stdin for hooks.
+// Field names are camelCase per official Antigravity hooks documentation.
+type antigravityHookPayload struct {
+	ConversationID string `json:"conversationId"`
+	TranscriptPath string `json:"transcriptPath"`
+	HookEventName  string `json:"hookEventName"`
+}
+
+// handleAntigravityHook processes Antigravity CLI hook invocations.
+// Usage: agent-deck antigravity-hook [PreInvocation|Stop]
+// Reads agy JSON from stdin, maps to agent-deck hook status, emits allow decision.
+func handleAntigravityHook(args []string) {
+	event := "PreInvocation"
+	if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+		event = strings.TrimSpace(args[0])
+	}
+
+	instanceID := os.Getenv("AGENTDECK_INSTANCE_ID")
+	if instanceID == "" || !validInstanceID.MatchString(instanceID) || strings.Contains(instanceID, "..") {
+		fmt.Println(`{"decision":"allow"}`)
+		return
+	}
+
+	data, err := io.ReadAll(io.LimitReader(os.Stdin, maxHookPayloadSize))
+	if err != nil || len(data) == 0 {
+		fmt.Println(`{"decision":"allow"}`)
+		return
+	}
+
+	var payload antigravityHookPayload
+	_ = json.Unmarshal(data, &payload)
+
+	sessionID := strings.TrimSpace(payload.ConversationID)
+	status := mapEventToStatus(event)
+	if status == "" {
+		fmt.Println(`{"decision":"allow"}`)
+		return
+	}
+
+	// Synthesize hook-handler compatible payload for session ID extraction
+	synthetic := hookPayload{
+		HookEventName:  event,
+		ConversationID: sessionID,
+		SessionID:      sessionID,
+	}
+	if isStopHookEvent(event) {
+		writeHookStatusWithScan(instanceID, status, sessionID, event, detectDoneSentinel(mustJSON(synthetic)))
+	} else {
+		writeHookStatus(instanceID, status, sessionID, event)
+	}
+
+	fmt.Println(`{"decision":"allow"}`)
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/cmd/agent-deck/antigravity_hook_handler.go
+++ b/cmd/agent-deck/antigravity_hook_handler.go
@@ -38,7 +38,10 @@ func handleAntigravityHook(args []string) {
 	}
 
 	var payload antigravityHookPayload
-	_ = json.Unmarshal(data, &payload)
+	if err := json.Unmarshal(data, &payload); err != nil {
+		fmt.Println(`{"decision":"allow"}`)
+		return
+	}
 
 	sessionID := strings.TrimSpace(payload.ConversationID)
 	status := mapEventToStatus(event)

--- a/cmd/agent-deck/antigravity_hooks_cmd.go
+++ b/cmd/agent-deck/antigravity_hooks_cmd.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func handleAntigravityHooks(args []string) {
+	if len(args) == 0 {
+		printAntigravityHooksUsage(os.Stderr)
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "help", "--help", "-h":
+		printAntigravityHooksUsage(os.Stdout)
+	case "install":
+		handleAntigravityHooksInstall()
+	case "uninstall":
+		handleAntigravityHooksUninstall()
+	case "status":
+		handleAntigravityHooksStatus()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown antigravity-hooks subcommand: %s\n", args[0])
+		printAntigravityHooksUsage(os.Stderr)
+		os.Exit(1)
+	}
+}
+
+func printAntigravityHooksUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: agent-deck antigravity-hooks <command>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Manage Antigravity CLI (agy) hook integration.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  install      Install agent-deck Antigravity hooks")
+	fmt.Fprintln(w, "  uninstall    Remove agent-deck Antigravity hooks")
+	fmt.Fprintln(w, "  status       Show Antigravity hooks install status")
+}
+
+func handleAntigravityHooksInstall() {
+	configDir := session.GetAntigravityConfigDir()
+	installed, err := session.InjectAntigravityHooks(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error installing Antigravity hooks: %v\n", err)
+		os.Exit(1)
+	}
+	if installed {
+		fmt.Println("Antigravity hooks installed successfully.")
+		fmt.Printf("Config: %s/hooks.json\n", configDir)
+	} else {
+		fmt.Println("Antigravity hooks are already installed.")
+	}
+}
+
+func handleAntigravityHooksUninstall() {
+	configDir := session.GetAntigravityConfigDir()
+	removed, err := session.RemoveAntigravityHooks(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error removing Antigravity hooks: %v\n", err)
+		os.Exit(1)
+	}
+	if removed {
+		fmt.Println("Antigravity hooks removed successfully.")
+	} else {
+		fmt.Println("No agent-deck Antigravity hooks found to remove.")
+	}
+}
+
+func handleAntigravityHooksStatus() {
+	configDir := session.GetAntigravityConfigDir()
+	installed := session.CheckAntigravityHooksInstalled(configDir)
+	configPath := filepath.Join(configDir, "hooks.json")
+
+	if installed {
+		fmt.Println("Status: INSTALLED")
+		fmt.Printf("Config: %s\n", configPath)
+	} else {
+		fmt.Println("Status: NOT INSTALLED")
+		fmt.Println("Run 'agent-deck antigravity-hooks install' to install.")
+	}
+}

--- a/cmd/agent-deck/gemini_yolo.go
+++ b/cmd/agent-deck/gemini_yolo.go
@@ -13,6 +13,8 @@ func applyCLIYoloOverride(inst *session.Instance, enabled bool) error {
 	switch inst.Tool {
 	case "gemini":
 		inst.SetGeminiYoloMode(true)
+	case "antigravity":
+		inst.SetAntigravityYoloMode(true)
 	case "codex":
 		yolo := true
 		opts := inst.GetCodexOptions()
@@ -24,7 +26,7 @@ func applyCLIYoloOverride(inst *session.Instance, enabled bool) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("--yolo only works with Gemini or Codex sessions")
+		return fmt.Errorf("--yolo only works with Gemini, Antigravity, or Codex sessions")
 	}
 	return nil
 }

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -100,8 +100,8 @@ func mapEventToStatus(event string) string {
 	switch normalizeHookEventKey(event) {
 	case "sessionstart":
 		return "waiting" // at initial prompt, waiting for user input
-	case "beforeagent":
-		return "running" // Gemini received user input and is processing
+	case "beforeagent", "preinvocation":
+		return "running" // Gemini / Antigravity agent turn started
 	case "afteragent":
 		return "waiting" // Gemini completed response, back to waiting
 	case "pretoolcall", "pretooluse":

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -344,6 +344,12 @@ func main() {
 		case "gemini-hooks":
 			handleGeminiHooks(args[1:])
 			return
+		case "antigravity-hooks":
+			handleAntigravityHooks(args[1:])
+			return
+		case "antigravity-hook":
+			handleAntigravityHook(args[1:])
+			return
 		case "hermes-hooks":
 			handleHermesHooks(args[1:])
 			return
@@ -3061,6 +3067,7 @@ func printHelp() {
 	fmt.Println("  skill            Manage project skills")
 	fmt.Println("  codex-hooks      Manage Codex notify hook integration")
 	fmt.Println("  gemini-hooks     Manage Gemini hook integration")
+	fmt.Println("  antigravity-hooks Manage Antigravity (agy) hook integration")
 	fmt.Println("  hermes-hooks     Manage Hermes Agent hook integration")
 	fmt.Println("  cursor-hooks     Manage Cursor Agent CLI hook integration")
 	fmt.Println("  group            Manage groups")
@@ -3105,6 +3112,9 @@ func printHelp() {
 	fmt.Println("  gemini-hooks install      Install Gemini hooks")
 	fmt.Println("  gemini-hooks uninstall    Remove Gemini hooks")
 	fmt.Println("  gemini-hooks status       Show Gemini hooks install status")
+	fmt.Println("  antigravity-hooks install Install Antigravity hooks")
+	fmt.Println("  antigravity-hooks uninstall Remove Antigravity hooks")
+	fmt.Println("  antigravity-hooks status  Show Antigravity hooks install status")
 	fmt.Println("  hermes-hooks install      Install Hermes Agent hooks")
 	fmt.Println("  hermes-hooks uninstall    Remove Hermes Agent hooks")
 	fmt.Println("  hermes-hooks status       Show Hermes hooks install status")

--- a/internal/session/antigravity.go
+++ b/internal/session/antigravity.go
@@ -1,0 +1,246 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var antigravityConfigDirOverride string
+
+// SetAntigravityAppDataDirOverrideForTest overrides ~/.gemini/antigravity-cli for tests.
+func SetAntigravityAppDataDirOverrideForTest(dir string) {
+	antigravityConfigDirOverride = dir
+}
+
+// GetAntigravityAppDataDir returns ~/.gemini/antigravity-cli
+func GetAntigravityAppDataDir() string {
+	if antigravityConfigDirOverride != "" {
+		return antigravityConfigDirOverride
+	}
+	return filepath.Join(GetGeminiConfigDir(), "antigravity-cli")
+}
+
+// GetAntigravityBrainDir returns ~/.gemini/antigravity-cli/brain
+func GetAntigravityBrainDir() string {
+	return filepath.Join(GetAntigravityAppDataDir(), "brain")
+}
+
+// GetAntigravityConfigDir returns ~/.gemini/config (shared Antigravity config root)
+func GetAntigravityConfigDir() string {
+	return filepath.Join(GetGeminiConfigDir(), "config")
+}
+
+// AntigravityConversationInfo holds parsed conversation metadata
+type AntigravityConversationInfo struct {
+	ConversationID string
+	LastUpdated    time.Time
+}
+
+// antigravityConversationHasData reports whether a conversation ID has on-disk data
+func antigravityConversationHasData(conversationID string) bool {
+	if conversationID == "" {
+		return false
+	}
+	brainDir := filepath.Join(GetAntigravityBrainDir(), conversationID)
+	info, err := os.Stat(brainDir)
+	return err == nil && info.IsDir()
+}
+
+// ListAntigravityConversations scans brain/ for conversation directories
+func ListAntigravityConversations() ([]AntigravityConversationInfo, error) {
+	brainDir := GetAntigravityBrainDir()
+	entries, err := os.ReadDir(brainDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var conversations []AntigravityConversationInfo
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+		if !looksLikeUUID(id) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		conversations = append(conversations, AntigravityConversationInfo{
+			ConversationID: id,
+			LastUpdated:    info.ModTime(),
+		})
+	}
+
+	sort.Slice(conversations, func(i, j int) bool {
+		return conversations[i].LastUpdated.After(conversations[j].LastUpdated)
+	})
+	return conversations, nil
+}
+
+// findMostRecentAntigravityConversation returns the most recently modified conversation ID
+func findMostRecentAntigravityConversation() string {
+	conversations, err := ListAntigravityConversations()
+	if err != nil || len(conversations) == 0 {
+		return ""
+	}
+	return conversations[0].ConversationID
+}
+
+// parseAntigravityHistoryIndex reads history.jsonl for conversation IDs (fallback discovery)
+func parseAntigravityHistoryIndex() []string {
+	historyPath := filepath.Join(GetAntigravityAppDataDir(), "history.jsonl")
+	f, err := os.Open(historyPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var ids []string
+	seen := make(map[string]struct{})
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record struct {
+			ConversationID string `json:"conversationId"`
+			ID             string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		id := strings.TrimSpace(record.ConversationID)
+		if id == "" {
+			id = strings.TrimSpace(record.ID)
+		}
+		if id == "" || !looksLikeUUID(id) {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func looksLikeUUID(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var (
+	antigravityModelCacheMu   sync.Mutex
+	antigravityModelCacheList []string
+	antigravityModelCacheTime time.Time
+	antigravityModelCacheTTL  = 1 * time.Hour
+)
+
+var antigravityModelFallback = []string{
+	"gemini-2.5-flash",
+	"gemini-2.5-pro",
+	"gemini-3-flash-preview",
+	"gemini-3.1-pro-preview",
+}
+
+// GetAvailableAntigravityModels returns models from `agy models` with caching and fallback
+func GetAvailableAntigravityModels() ([]string, error) {
+	if override := os.Getenv("ANTIGRAVITY_MODELS_OVERRIDE"); override != "" {
+		var result []string
+		for _, m := range strings.Split(override, ",") {
+			m = strings.TrimSpace(m)
+			if m != "" {
+				result = append(result, m)
+			}
+		}
+		sort.Strings(result)
+		return result, nil
+	}
+
+	antigravityModelCacheMu.Lock()
+	defer antigravityModelCacheMu.Unlock()
+	if len(antigravityModelCacheList) > 0 && time.Since(antigravityModelCacheTime) < antigravityModelCacheTTL {
+		result := make([]string, len(antigravityModelCacheList))
+		copy(result, antigravityModelCacheList)
+		return result, nil
+	}
+
+	cmd := exec.Command(GetToolCommand("antigravity"), "models")
+	out, err := cmd.Output()
+	if err != nil {
+		return antigravityModelFallback, fmt.Errorf("agy models: %w", err)
+	}
+
+	var models []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Usage") {
+			continue
+		}
+		// Take first column / token
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			models = append(models, fields[0])
+		}
+	}
+	if len(models) == 0 {
+		return antigravityModelFallback, nil
+	}
+	sort.Strings(models)
+	antigravityModelCacheList = models
+	antigravityModelCacheTime = time.Now()
+	result := make([]string, len(models))
+	copy(result, models)
+	return result, nil
+}
+
+// ExtractAntigravityConversationIDFromPane scans tmux pane text for agy resume hint
+func ExtractAntigravityConversationIDFromPane(text string) string {
+	// Resume: agy --conversation=d1d8a55b-cc27-4dd4-bc62-2f73015960d2 (or -c)
+	const prefix = "--conversation="
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if idx := strings.Index(line, prefix); idx >= 0 {
+			rest := line[idx+len(prefix):]
+			rest = strings.TrimSpace(rest)
+			rest = strings.Trim(rest, "=)")
+			if end := strings.IndexAny(rest, " \t("); end > 0 {
+				rest = rest[:end]
+			}
+			if looksLikeUUID(rest) {
+				return rest
+			}
+		}
+	}
+	return ""
+}

--- a/internal/session/antigravity.go
+++ b/internal/session/antigravity.go
@@ -2,8 +2,10 @@ package session
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,17 +15,25 @@ import (
 	"time"
 )
 
-var antigravityConfigDirOverride string
+var (
+	antigravityConfigDirOverrideMu sync.RWMutex
+	antigravityConfigDirOverride   string
+)
 
 // SetAntigravityAppDataDirOverrideForTest overrides ~/.gemini/antigravity-cli for tests.
 func SetAntigravityAppDataDirOverrideForTest(dir string) {
+	antigravityConfigDirOverrideMu.Lock()
 	antigravityConfigDirOverride = dir
+	antigravityConfigDirOverrideMu.Unlock()
 }
 
 // GetAntigravityAppDataDir returns ~/.gemini/antigravity-cli
 func GetAntigravityAppDataDir() string {
-	if antigravityConfigDirOverride != "" {
-		return antigravityConfigDirOverride
+	antigravityConfigDirOverrideMu.RLock()
+	override := antigravityConfigDirOverride
+	antigravityConfigDirOverrideMu.RUnlock()
+	if override != "" {
+		return override
 	}
 	return filepath.Join(GetGeminiConfigDir(), "antigravity-cli")
 }
@@ -111,6 +121,9 @@ func parseAntigravityHistoryIndex() []string {
 	var ids []string
 	seen := make(map[string]struct{})
 	scanner := bufio.NewScanner(f)
+	// Same rationale as parseAntigravityLatestUserPrompt: default 64 KiB token
+	// limit would silently truncate large history.jsonl lines.
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -135,6 +148,9 @@ func parseAntigravityHistoryIndex() []string {
 		}
 		seen[id] = struct{}{}
 		ids = append(ids, id)
+	}
+	if err := scanner.Err(); err != nil {
+		sessionLog.Warn("antigravity_history_scan_error", slog.String("error", err.Error()))
 	}
 	return ids
 }
@@ -188,14 +204,19 @@ func GetAvailableAntigravityModels() ([]string, error) {
 	}
 
 	antigravityModelCacheMu.Lock()
-	defer antigravityModelCacheMu.Unlock()
 	if len(antigravityModelCacheList) > 0 && time.Since(antigravityModelCacheTime) < antigravityModelCacheTTL {
 		result := make([]string, len(antigravityModelCacheList))
 		copy(result, antigravityModelCacheList)
+		antigravityModelCacheMu.Unlock()
 		return result, nil
 	}
+	antigravityModelCacheMu.Unlock()
 
-	cmd := exec.Command(GetToolCommand("antigravity"), "models")
+	// Run `agy models` without holding the cache lock — a hung agy must not
+	// block every concurrent caller. 10s is plenty for a local CLI subcommand.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, GetToolCommand("antigravity"), "models")
 	out, err := cmd.Output()
 	if err != nil {
 		return antigravityModelFallback, fmt.Errorf("agy models: %w", err)
@@ -207,7 +228,6 @@ func GetAvailableAntigravityModels() ([]string, error) {
 		if line == "" || strings.HasPrefix(line, "Usage") {
 			continue
 		}
-		// Take first column / token
 		fields := strings.Fields(line)
 		if len(fields) > 0 {
 			models = append(models, fields[0])
@@ -217,8 +237,12 @@ func GetAvailableAntigravityModels() ([]string, error) {
 		return antigravityModelFallback, nil
 	}
 	sort.Strings(models)
+
+	antigravityModelCacheMu.Lock()
 	antigravityModelCacheList = models
 	antigravityModelCacheTime = time.Now()
+	antigravityModelCacheMu.Unlock()
+
 	result := make([]string, len(models))
 	copy(result, models)
 	return result, nil
@@ -226,19 +250,41 @@ func GetAvailableAntigravityModels() ([]string, error) {
 
 // ExtractAntigravityConversationIDFromPane scans tmux pane text for agy resume hint
 func ExtractAntigravityConversationIDFromPane(text string) string {
-	// Resume: agy --conversation=d1d8a55b-cc27-4dd4-bc62-2f73015960d2 (or -c)
-	const prefix = "--conversation="
+	// Resume hints come in two shapes:
+	//   agy --conversation=<uuid>
+	//   agy -c <uuid>          (or -c=<uuid>)
+	trimUUID := func(rest string) string {
+		rest = strings.TrimSpace(rest)
+		rest = strings.Trim(rest, "=)")
+		if end := strings.IndexAny(rest, " \t()"); end > 0 {
+			rest = rest[:end]
+		}
+		return rest
+	}
 	for _, line := range strings.Split(text, "\n") {
 		line = strings.TrimSpace(line)
-		if idx := strings.Index(line, prefix); idx >= 0 {
-			rest := line[idx+len(prefix):]
-			rest = strings.TrimSpace(rest)
-			rest = strings.Trim(rest, "=)")
-			if end := strings.IndexAny(rest, " \t("); end > 0 {
-				rest = rest[:end]
+		if idx := strings.Index(line, "--conversation="); idx >= 0 {
+			if id := trimUUID(line[idx+len("--conversation="):]); looksLikeUUID(id) {
+				return id
 			}
-			if looksLikeUUID(rest) {
-				return rest
+		}
+		// Match `-c <uuid>` or `-c=<uuid>` but reject `-cfoo`. Anchor on
+		// a leading space or start-of-line so we don't catch `--cdir` etc.
+		for _, marker := range []string{" -c ", " -c="} {
+			if idx := strings.Index(line, marker); idx >= 0 {
+				if id := trimUUID(line[idx+len(marker):]); looksLikeUUID(id) {
+					return id
+				}
+			}
+		}
+		if strings.HasPrefix(line, "-c ") {
+			if id := trimUUID(line[3:]); looksLikeUUID(id) {
+				return id
+			}
+		}
+		if strings.HasPrefix(line, "-c=") {
+			if id := trimUUID(line[3:]); looksLikeUUID(id) {
+				return id
 			}
 		}
 	}

--- a/internal/session/antigravity.go
+++ b/internal/session/antigravity.go
@@ -102,8 +102,16 @@ func ListAntigravityConversations() ([]AntigravityConversationInfo, error) {
 
 // findMostRecentAntigravityConversation returns the most recently modified conversation ID
 func findMostRecentAntigravityConversation() string {
+	return findMostRecentAntigravityConversationAfter(time.Time{})
+}
+
+// findMostRecentAntigravityConversationAfter returns the most recently modified conversation ID updated after the threshold
+func findMostRecentAntigravityConversationAfter(after time.Time) string {
 	conversations, err := ListAntigravityConversations()
 	if err != nil || len(conversations) == 0 {
+		return ""
+	}
+	if !after.IsZero() && conversations[0].LastUpdated.Before(after) {
 		return ""
 	}
 	return conversations[0].ConversationID

--- a/internal/session/antigravity_hooks.go
+++ b/internal/session/antigravity_hooks.go
@@ -1,0 +1,154 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+const (
+	agentDeckAntigravityHookBlockName = "agent-deck"
+)
+
+type antigravityFlatHookEntry struct {
+	Type    string `json:"type,omitempty"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+type antigravityNamedHooks struct {
+	Enabled       bool                       `json:"enabled,omitempty"`
+	PreInvocation []antigravityFlatHookEntry `json:"PreInvocation,omitempty"`
+	Stop          []antigravityFlatHookEntry `json:"Stop,omitempty"`
+}
+
+func antigravityAgentDeckHookEntry(event string) antigravityFlatHookEntry {
+	return antigravityFlatHookEntry{
+		Type:    "command",
+		Command: "agent-deck antigravity-hook " + event,
+		Timeout: 5,
+	}
+}
+
+// InjectAntigravityHooks injects agent-deck hooks into ~/.gemini/config/hooks.json
+func InjectAntigravityHooks(configDir string) (bool, error) {
+	hooksPath := filepath.Join(configDir, "hooks.json")
+
+	var raw map[string]json.RawMessage
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read hooks.json: %w", err)
+		}
+		raw = make(map[string]json.RawMessage)
+	} else if err := json.Unmarshal(data, &raw); err != nil {
+		return false, fmt.Errorf("parse hooks.json: %w", err)
+	}
+
+	if antigravityHooksAlreadyInstalled(raw) {
+		return false, nil
+	}
+
+	block := antigravityNamedHooks{Enabled: true}
+	block.PreInvocation = []antigravityFlatHookEntry{antigravityAgentDeckHookEntry("PreInvocation")}
+	block.Stop = []antigravityFlatHookEntry{antigravityAgentDeckHookEntry("Stop")}
+
+	blockRaw, err := json.Marshal(block)
+	if err != nil {
+		return false, fmt.Errorf("marshal agent-deck hook block: %w", err)
+	}
+	raw[agentDeckAntigravityHookBlockName] = blockRaw
+
+	finalData, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal hooks.json: %w", err)
+	}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return false, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := atomicfile.WriteFile(hooksPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write hooks.json: %w", err)
+	}
+
+	sessionLog.Info("antigravity_hooks_installed", slog.String("config_dir", configDir))
+	return true, nil
+}
+
+// RemoveAntigravityHooks removes agent-deck hooks from hooks.json
+func RemoveAntigravityHooks(configDir string) (bool, error) {
+	hooksPath := filepath.Join(configDir, "hooks.json")
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read hooks.json: %w", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false, fmt.Errorf("parse hooks.json: %w", err)
+	}
+
+	if _, ok := raw[agentDeckAntigravityHookBlockName]; !ok {
+		return false, nil
+	}
+	delete(raw, agentDeckAntigravityHookBlockName)
+
+	finalData, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal hooks.json: %w", err)
+	}
+	if len(raw) == 0 {
+		if err := os.Remove(hooksPath); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("remove empty hooks.json: %w", err)
+		}
+	} else if err := atomicfile.WriteFile(hooksPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write hooks.json: %w", err)
+	}
+
+	sessionLog.Info("antigravity_hooks_removed", slog.String("config_dir", configDir))
+	return true, nil
+}
+
+// CheckAntigravityHooksInstalled reports whether agent-deck agy hooks are present
+func CheckAntigravityHooksInstalled(configDir string) bool {
+	hooksPath := filepath.Join(configDir, "hooks.json")
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return false
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	return antigravityHooksAlreadyInstalled(raw)
+}
+
+func antigravityHooksAlreadyInstalled(raw map[string]json.RawMessage) bool {
+	blockRaw, ok := raw[agentDeckAntigravityHookBlockName]
+	if !ok {
+		return false
+	}
+	var block antigravityNamedHooks
+	if err := json.Unmarshal(blockRaw, &block); err != nil {
+		return false
+	}
+	return antigravityBlockHasAgentDeckHook(block.PreInvocation) &&
+		antigravityBlockHasAgentDeckHook(block.Stop)
+}
+
+func antigravityBlockHasAgentDeckHook(entries []antigravityFlatHookEntry) bool {
+	for _, e := range entries {
+		if strings.Contains(e.Command, "agent-deck") && strings.Contains(e.Command, "antigravity-hook") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/session/antigravity_instance.go
+++ b/internal/session/antigravity_instance.go
@@ -1,0 +1,233 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+func (i *Instance) buildAntigravityCommand(baseCommand string) string {
+	if i.Tool != "antigravity" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+
+	yoloMode := false
+	if i.AntigravityYoloMode != nil {
+		yoloMode = *i.AntigravityYoloMode
+	} else {
+		userConfig, _ := LoadUserConfig()
+		if userConfig != nil {
+			yoloMode = userConfig.Antigravity.YoloMode
+		}
+	}
+
+	yoloFlag := ""
+	if yoloMode {
+		yoloFlag = " --dangerously-skip-permissions"
+	}
+
+	modelFlag := ""
+	if i.AntigravityModel != "" {
+		modelFlag = " --model " + i.AntigravityModel
+	} else if i.AntigravityConversationID == "" {
+		userConfig, _ := LoadUserConfig()
+		if userConfig != nil && userConfig.Antigravity.DefaultModel != "" {
+			modelFlag = " --model " + userConfig.Antigravity.DefaultModel
+		}
+	}
+
+	if baseCommand == "agy" || baseCommand == "antigravity" {
+		cmd := GetToolCommand("antigravity")
+		if i.AntigravityConversationID != "" {
+			return envPrefix + fmt.Sprintf(
+				"%s --conversation %s%s%s",
+				cmd,
+				i.AntigravityConversationID,
+				yoloFlag,
+				modelFlag,
+			)
+		}
+		return envPrefix + fmt.Sprintf("%s%s%s", cmd, yoloFlag, modelFlag)
+	}
+
+	return envPrefix + baseCommand
+}
+
+func (i *Instance) syncAntigravityEnvToTmux() {
+	if i.tmuxSession == nil {
+		return
+	}
+	if i.AntigravityConversationID != "" {
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", i.AntigravityConversationID)
+	}
+	if i.AntigravityYoloMode != nil {
+		val := "false"
+		if *i.AntigravityYoloMode {
+			val = "true"
+		}
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_YOLO_MODE", val)
+	}
+}
+
+func (i *Instance) bindAntigravitySessionFromHook(conversationID, hookEvent string) {
+	sessionLog.Debug("antigravity_session_update_from_hook",
+		slog.String("old_id", i.AntigravityConversationID),
+		slog.String("new_id", conversationID),
+		slog.String("event", hookEvent),
+	)
+	i.AntigravityConversationID = conversationID
+	i.AntigravityDetectedAt = time.Now()
+	i.hookSessionID = conversationID
+
+	if i.tmuxSession != nil && i.tmuxSession.Exists() {
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", conversationID)
+	}
+
+	if db := statedb.GetGlobal(); db != nil {
+		if err := db.WriteAntigravitySessionBinding(i.ID, conversationID, i.AntigravityDetectedAt); err != nil {
+			sessionLog.Warn("antigravity_session_rebind_persist_failed",
+				slog.String("instance_id", i.ID),
+				slog.String("new_id", conversationID),
+				slog.String("error", err.Error()))
+		}
+	}
+}
+
+func (i *Instance) UpdateAntigravitySession() {
+	if i.Tool != "antigravity" {
+		return
+	}
+	i.syncAntigravitySessionFromTmux()
+	i.syncAntigravitySessionFromDisk()
+	i.syncAntigravityConversationFromPane()
+	i.updateAntigravityLatestPrompt()
+}
+
+func (i *Instance) syncAntigravitySessionFromTmux() {
+	if i.tmuxSession == nil {
+		return
+	}
+	if id, err := i.tmuxSession.GetEnvironment("ANTIGRAVITY_CONVERSATION_ID"); err == nil && id != "" {
+		if i.AntigravityConversationID != id {
+			i.AntigravityConversationID = id
+		}
+		i.AntigravityDetectedAt = time.Now()
+	}
+	if yoloEnv, err := i.tmuxSession.GetEnvironment("ANTIGRAVITY_YOLO_MODE"); err == nil && yoloEnv != "" {
+		enabled := yoloEnv == "true"
+		i.AntigravityYoloMode = &enabled
+	}
+}
+
+func (i *Instance) syncAntigravitySessionFromDisk() {
+	if i.AntigravityConversationID != "" && antigravityConversationHasData(i.AntigravityConversationID) {
+		return
+	}
+	id := findMostRecentAntigravityConversation()
+	if id == "" {
+		return
+	}
+	if id != i.AntigravityConversationID {
+		sessionLog.Debug("antigravity_session_update",
+			slog.String("old_id", i.AntigravityConversationID),
+			slog.String("new_id", id),
+		)
+	}
+	i.AntigravityConversationID = id
+	i.AntigravityDetectedAt = time.Now()
+	if i.tmuxSession != nil && i.tmuxSession.Exists() {
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", id)
+	}
+}
+
+func (i *Instance) syncAntigravityConversationFromPane() {
+	if i.tmuxSession == nil || i.AntigravityConversationID != "" {
+		return
+	}
+	content, err := i.tmuxSession.CaptureFullHistory()
+	if err != nil {
+		return
+	}
+	if id := ExtractAntigravityConversationIDFromPane(content); id != "" {
+		i.AntigravityConversationID = id
+		i.AntigravityDetectedAt = time.Now()
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", id)
+	}
+}
+
+// SetAntigravityModel sets the Antigravity model for this session and restarts if running.
+func (i *Instance) SetAntigravityModel(model string) error {
+	i.AntigravityModel = model
+	sessionLog.Debug(
+		"antigravity_model_set",
+		slog.String("model", model),
+		slog.String("session_id", i.ID),
+		slog.String("title", i.Title),
+	)
+	if i.Exists() {
+		return i.Restart()
+	}
+	return nil
+}
+
+func (i *Instance) SetAntigravityYoloMode(enabled bool) {
+	if i.Tool != "antigravity" {
+		return
+	}
+	i.AntigravityYoloMode = &enabled
+	if i.tmuxSession != nil && i.tmuxSession.Exists() {
+		val := "false"
+		if enabled {
+			val = "true"
+		}
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_YOLO_MODE", val)
+	}
+}
+
+func (i *Instance) updateAntigravityLatestPrompt() {
+	if i.AntigravityConversationID == "" {
+		return
+	}
+	if prompt := parseAntigravityLatestUserPrompt(i.AntigravityConversationID); prompt != "" {
+		i.LatestPrompt = prompt
+	}
+}
+
+func parseAntigravityLatestUserPrompt(conversationID string) string {
+	logPath := filepath.Join(GetAntigravityBrainDir(), conversationID, ".system_generated", "logs", "transcript.jsonl")
+	f, err := os.Open(logPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	var lastUser string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var step struct {
+			Type    string `json:"type"`
+			Source  string `json:"source"`
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal([]byte(line), &step); err != nil {
+			continue
+		}
+		if step.Type == "USER_INPUT" || step.Source == "USER_EXPLICIT" {
+			lastUser = strings.TrimSpace(step.Content)
+		}
+	}
+	return lastUser
+}

--- a/internal/session/antigravity_instance.go
+++ b/internal/session/antigravity_instance.go
@@ -212,6 +212,9 @@ func parseAntigravityLatestUserPrompt(conversationID string) string {
 
 	var lastUser string
 	scanner := bufio.NewScanner(f)
+	// Default 64 KiB bufio.Scanner buf truncates large USER_INPUT pastes; raise
+	// to 8 MiB so multi-megabyte prompts don't silently leave lastUser stale.
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {

--- a/internal/session/antigravity_instance.go
+++ b/internal/session/antigravity_instance.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
 
@@ -37,11 +38,11 @@ func (i *Instance) buildAntigravityCommand(baseCommand string) string {
 
 	modelFlag := ""
 	if i.AntigravityModel != "" {
-		modelFlag = " --model " + i.AntigravityModel
+		modelFlag = " --model " + shellescape.Quote(i.AntigravityModel)
 	} else if i.AntigravityConversationID == "" {
 		userConfig, _ := LoadUserConfig()
 		if userConfig != nil && userConfig.Antigravity.DefaultModel != "" {
-			modelFlag = " --model " + userConfig.Antigravity.DefaultModel
+			modelFlag = " --model " + shellescape.Quote(userConfig.Antigravity.DefaultModel)
 		}
 	}
 
@@ -51,7 +52,7 @@ func (i *Instance) buildAntigravityCommand(baseCommand string) string {
 			return envPrefix + fmt.Sprintf(
 				"%s --conversation %s%s%s",
 				cmd,
-				i.AntigravityConversationID,
+				shellescape.Quote(i.AntigravityConversationID),
 				yoloFlag,
 				modelFlag,
 			)
@@ -102,13 +103,14 @@ func (i *Instance) bindAntigravitySessionFromHook(conversationID, hookEvent stri
 	}
 }
 
+// UpdateAntigravitySession syncs conversation ID, YOLO mode, and latest prompt from tmux and disk.
 func (i *Instance) UpdateAntigravitySession() {
 	if i.Tool != "antigravity" {
 		return
 	}
 	i.syncAntigravitySessionFromTmux()
-	i.syncAntigravitySessionFromDisk()
 	i.syncAntigravityConversationFromPane()
+	i.syncAntigravitySessionFromDisk()
 	i.updateAntigravityLatestPrompt()
 }
 
@@ -132,7 +134,11 @@ func (i *Instance) syncAntigravitySessionFromDisk() {
 	if i.AntigravityConversationID != "" && antigravityConversationHasData(i.AntigravityConversationID) {
 		return
 	}
-	id := findMostRecentAntigravityConversation()
+	threshold := i.LastStartedAt
+	if threshold.IsZero() {
+		threshold = i.CreatedAt
+	}
+	id := findMostRecentAntigravityConversationAfter(threshold)
 	if id == "" {
 		return
 	}
@@ -179,6 +185,7 @@ func (i *Instance) SetAntigravityModel(model string) error {
 	return nil
 }
 
+// SetAntigravityYoloMode configures YOLO mode for this Antigravity session and updates tmux env.
 func (i *Instance) SetAntigravityYoloMode(enabled bool) {
 	if i.Tool != "antigravity" {
 		return

--- a/internal/session/antigravity_mcp.go
+++ b/internal/session/antigravity_mcp.go
@@ -1,0 +1,103 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+// AntigravityMCPConfig represents ~/.gemini/config/mcp_config.json structure
+type AntigravityMCPConfig struct {
+	MCPServers map[string]MCPServerConfig `json:"mcpServers"`
+}
+
+// GetAntigravityMCPInfo reads MCP configuration from mcp_config.json
+func GetAntigravityMCPInfo(_ string) *MCPInfo {
+	configFile := filepath.Join(GetAntigravityConfigDir(), "mcp_config.json")
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return &MCPInfo{}
+	}
+
+	var config AntigravityMCPConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return &MCPInfo{}
+	}
+
+	info := &MCPInfo{}
+	for name := range config.MCPServers {
+		info.Global = append(info.Global, name)
+	}
+	sort.Strings(info.Global)
+	return info
+}
+
+// WriteAntigravityMCPSettings writes MCPs to ~/.gemini/config/mcp_config.json
+func WriteAntigravityMCPSettings(enabledNames []string) error {
+	configFile := filepath.Join(GetAntigravityConfigDir(), "mcp_config.json")
+
+	var rawConfig map[string]interface{}
+	if data, err := os.ReadFile(configFile); err == nil {
+		if err := json.Unmarshal(data, &rawConfig); err != nil {
+			rawConfig = make(map[string]interface{})
+		}
+	} else {
+		rawConfig = make(map[string]interface{})
+	}
+
+	availableMCPs := GetAvailableMCPs()
+	pool := GetGlobalPool()
+
+	mcpServers := make(map[string]MCPServerConfig)
+	for _, name := range enabledNames {
+		if def, ok := availableMCPs[name]; ok {
+			if pool != nil && pool.ShouldPool(name) && pool.IsRunning(name) {
+				socketPath := pool.GetSocketPath(name)
+				mcpServers[name] = MCPServerConfig{
+					Command: "nc",
+					Args:    []string{"-U", socketPath},
+				}
+			} else {
+				args := def.Args
+				if args == nil {
+					args = []string{}
+				}
+				env := def.Env
+				if env == nil {
+					env = map[string]string{}
+				}
+				mcpServers[name] = MCPServerConfig{
+					Command: def.Command,
+					Args:    args,
+					Env:     env,
+				}
+			}
+		}
+	}
+
+	rawConfig["mcpServers"] = mcpServers
+
+	newData, err := json.MarshalIndent(rawConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configFile), 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := atomicfile.WriteFile(configFile, newData, 0600); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
+}
+
+// GetAntigravityMCPNames returns configured MCP server names
+func GetAntigravityMCPNames() []string {
+	info := GetAntigravityMCPInfo("")
+	return info.Global
+}

--- a/internal/session/antigravity_persist.go
+++ b/internal/session/antigravity_persist.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Antigravity tool_data fields live in the statedb extras zone (like
+// idle_timeout_secs) so we can round-trip without changing the positional
+// MarshalToolData / UnmarshalToolData signatures.
+
+type antigravityToolData struct {
+	AntigravityConversationID string `json:"antigravity_conversation_id,omitempty"`
+	AntigravityDetectedAt     int64  `json:"antigravity_detected_at,omitempty"`
+	AntigravityYoloMode       *bool  `json:"antigravity_yolo_mode,omitempty"`
+	AntigravityModel          string `json:"antigravity_model,omitempty"`
+}
+
+// WriteAntigravityToToolData merges Antigravity session fields into tool_data.
+func WriteAntigravityToToolData(td json.RawMessage, inst *Instance) json.RawMessage {
+	if inst == nil {
+		return td
+	}
+	m := map[string]json.RawMessage{}
+	if len(td) > 0 {
+		_ = json.Unmarshal(td, &m)
+	}
+
+	merge := func(key string, value any) {
+		if value == nil {
+			delete(m, key)
+			return
+		}
+		switch v := value.(type) {
+		case string:
+			if v == "" {
+				delete(m, key)
+				return
+			}
+		case int64:
+			if v == 0 {
+				delete(m, key)
+				return
+			}
+		case *bool:
+			if v == nil {
+				delete(m, key)
+				return
+			}
+		}
+		raw, _ := json.Marshal(value)
+		m[key] = raw
+	}
+
+	merge("antigravity_conversation_id", inst.AntigravityConversationID)
+	if !inst.AntigravityDetectedAt.IsZero() {
+		merge("antigravity_detected_at", inst.AntigravityDetectedAt.Unix())
+	} else {
+		delete(m, "antigravity_detected_at")
+	}
+	merge("antigravity_yolo_mode", inst.AntigravityYoloMode)
+	merge("antigravity_model", inst.AntigravityModel)
+
+	out, _ := json.Marshal(m)
+	return out
+}
+
+// ReadAntigravityFromToolData extracts Antigravity fields from tool_data.
+func ReadAntigravityFromToolData(td json.RawMessage) (
+	conversationID string,
+	detectedAt time.Time,
+	yoloMode *bool,
+	model string,
+) {
+	if len(td) == 0 {
+		return
+	}
+	var blob antigravityToolData
+	if err := json.Unmarshal(td, &blob); err != nil {
+		return
+	}
+	conversationID = blob.AntigravityConversationID
+	if blob.AntigravityDetectedAt > 0 {
+		detectedAt = time.Unix(blob.AntigravityDetectedAt, 0)
+	}
+	yoloMode = blob.AntigravityYoloMode
+	model = blob.AntigravityModel
+	return
+}

--- a/internal/session/antigravity_persist.go
+++ b/internal/session/antigravity_persist.go
@@ -23,7 +23,11 @@ func WriteAntigravityToToolData(td json.RawMessage, inst *Instance) json.RawMess
 	}
 	m := map[string]json.RawMessage{}
 	if len(td) > 0 {
-		_ = json.Unmarshal(td, &m)
+		// Tolerate corrupt or `null` tool_data — start with an empty map rather
+		// than wiping unrelated extras-zone fields on parse failure.
+		if err := json.Unmarshal(td, &m); err != nil || m == nil {
+			m = map[string]json.RawMessage{}
+		}
 	}
 
 	merge := func(key string, value any) {
@@ -48,7 +52,10 @@ func WriteAntigravityToToolData(td json.RawMessage, inst *Instance) json.RawMess
 				return
 			}
 		}
-		raw, _ := json.Marshal(value)
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return
+		}
 		m[key] = raw
 	}
 
@@ -61,7 +68,10 @@ func WriteAntigravityToToolData(td json.RawMessage, inst *Instance) json.RawMess
 	merge("antigravity_yolo_mode", inst.AntigravityYoloMode)
 	merge("antigravity_model", inst.AntigravityModel)
 
-	out, _ := json.Marshal(m)
+	out, err := json.Marshal(m)
+	if err != nil {
+		return td
+	}
 	return out
 }
 

--- a/internal/session/antigravity_test.go
+++ b/internal/session/antigravity_test.go
@@ -1,0 +1,139 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInjectAntigravityHooks(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	installed, err := InjectAntigravityHooks(configDir)
+	if err != nil {
+		t.Fatalf("InjectAntigravityHooks: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected hooks to be newly installed")
+	}
+
+	installed, err = InjectAntigravityHooks(configDir)
+	if err != nil {
+		t.Fatalf("InjectAntigravityHooks second call: %v", err)
+	}
+	if installed {
+		t.Fatal("expected hooks to already be installed")
+	}
+
+	if !CheckAntigravityHooksInstalled(configDir) {
+		t.Fatal("CheckAntigravityHooksInstalled = false")
+	}
+
+	removed, err := RemoveAntigravityHooks(configDir)
+	if err != nil {
+		t.Fatalf("RemoveAntigravityHooks: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected hooks to be removed")
+	}
+	if CheckAntigravityHooksInstalled(configDir) {
+		t.Fatal("hooks still reported installed after remove")
+	}
+}
+
+func TestBuildAntigravityCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	inst := NewInstanceWithTool("agy-test", "/tmp/project", "antigravity")
+	inst.Command = "agy"
+	inst.AntigravityConversationID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	enabled := true
+	inst.AntigravityYoloMode = &enabled
+	inst.AntigravityModel = "gemini-2.5-flash"
+
+	cmd := inst.buildAntigravityCommand("agy")
+	if cmd == "" {
+		t.Fatal("empty command")
+	}
+	for _, want := range []string{
+		"--conversation aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		"--dangerously-skip-permissions",
+		"--model gemini-2.5-flash",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("command %q missing %q", cmd, want)
+		}
+	}
+}
+
+func TestAntigravityToolDataRoundTrip(t *testing.T) {
+	enabled := true
+	inst := NewInstanceWithTool("agy-persist", "/tmp/project", "antigravity")
+	inst.AntigravityConversationID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	inst.AntigravityDetectedAt = time.Unix(1700000000, 0)
+	inst.AntigravityYoloMode = &enabled
+	inst.AntigravityModel = "gemini-2.5-flash"
+
+	td := WriteAntigravityToToolData(nil, inst)
+	id, at, yolo, model := ReadAntigravityFromToolData(td)
+	if id != inst.AntigravityConversationID {
+		t.Fatalf("conversation id = %q, want %q", id, inst.AntigravityConversationID)
+	}
+	if !at.Equal(inst.AntigravityDetectedAt) {
+		t.Fatalf("detected at = %v, want %v", at, inst.AntigravityDetectedAt)
+	}
+	if yolo == nil || !*yolo {
+		t.Fatalf("yolo = %v, want true", yolo)
+	}
+	if model != inst.AntigravityModel {
+		t.Fatalf("model = %q, want %q", model, inst.AntigravityModel)
+	}
+}
+
+func TestAntigravityConversationHasData(t *testing.T) {
+	tmp := t.TempDir()
+	SetAntigravityAppDataDirOverrideForTest(tmp)
+	t.Cleanup(func() { SetAntigravityAppDataDirOverrideForTest("") })
+
+	id := "11111111-2222-3333-4444-555555555555"
+	brain := filepath.Join(tmp, "brain", id)
+	if err := os.MkdirAll(brain, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !antigravityConversationHasData(id) {
+		t.Fatal("expected conversation data")
+	}
+}
+
+func TestExtractAntigravityConversationIDFromPane(t *testing.T) {
+	text := "Thanks for using agy\nResume: agy --conversation=d1d8a55b-cc27-4dd4-bc62-2f73015960d2 (or -c)\n"
+	got := ExtractAntigravityConversationIDFromPane(text)
+	want := "d1d8a55b-cc27-4dd4-bc62-2f73015960d2"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestAntigravityHooksJSONShape(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	if _, err := InjectAntigravityHooks(configDir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(configDir, "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := raw["agent-deck"]; !ok {
+		t.Fatalf("missing agent-deck block: %s", string(data))
+	}
+}

--- a/internal/session/antigravity_test.go
+++ b/internal/session/antigravity_test.go
@@ -111,11 +111,21 @@ func TestAntigravityConversationHasData(t *testing.T) {
 }
 
 func TestExtractAntigravityConversationIDFromPane(t *testing.T) {
-	text := "Thanks for using agy\nResume: agy --conversation=d1d8a55b-cc27-4dd4-bc62-2f73015960d2 (or -c)\n"
-	got := ExtractAntigravityConversationIDFromPane(text)
-	want := "d1d8a55b-cc27-4dd4-bc62-2f73015960d2"
-	if got != want {
-		t.Fatalf("got %q want %q", got, want)
+	const uuid = "d1d8a55b-cc27-4dd4-bc62-2f73015960d2"
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"long form", "Thanks for using agy\nResume: agy --conversation=" + uuid + " (or -c)\n"},
+		{"short -c space", "Resume: agy -c " + uuid + "\n"},
+		{"short -c=", "Resume: agy -c=" + uuid + "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExtractAntigravityConversationIDFromPane(tc.text); got != uuid {
+				t.Fatalf("got %q want %q", got, uuid)
+			}
+		})
 	}
 }
 

--- a/internal/session/antigravity_test.go
+++ b/internal/session/antigravity_test.go
@@ -71,6 +71,25 @@ func TestBuildAntigravityCommand(t *testing.T) {
 	}
 }
 
+func TestBuildAntigravityCommand_Quoting(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	inst := NewInstanceWithTool("agy-quote-test", "/tmp/project", "antigravity")
+	inst.Command = "agy"
+	inst.AntigravityConversationID = "conv id with space"
+	inst.AntigravityModel = "model with space"
+
+	cmd := inst.buildAntigravityCommand("agy")
+	if !strings.Contains(cmd, "--conversation 'conv id with space'") {
+		t.Fatalf("expected quoted conversation id in %q", cmd)
+	}
+	if !strings.Contains(cmd, "--model 'model with space'") {
+		t.Fatalf("expected quoted model in %q", cmd)
+	}
+}
+
 func TestAntigravityToolDataRoundTrip(t *testing.T) {
 	enabled := true
 	inst := NewInstanceWithTool("agy-persist", "/tmp/project", "antigravity")

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -58,6 +58,7 @@ func builtinTools() []builtinTool {
 		{Name: "claude", Icon: "🤖", detectSubstrings: []string{"claude"}},
 		{Name: "opencode", Icon: "🌐", detectSubstrings: []string{"opencode", "open-code"}},
 		{Name: "gemini", Icon: "✨", detectSubstrings: []string{"gemini"}},
+		{Name: "antigravity", Icon: "🛸", detectSubstrings: []string{"agy", "antigravity"}},
 		{Name: "codex", Icon: "💻", detectSubstrings: []string{"codex"}},
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -58,7 +58,7 @@ func builtinTools() []builtinTool {
 		{Name: "claude", Icon: "🤖", detectSubstrings: []string{"claude"}},
 		{Name: "opencode", Icon: "🌐", detectSubstrings: []string{"opencode", "open-code"}},
 		{Name: "gemini", Icon: "✨", detectSubstrings: []string{"gemini"}},
-		{Name: "antigravity", Icon: "🛸", detectSubstrings: []string{"agy", "antigravity"}},
+		{Name: "antigravity", Icon: "🛸", detectSubstrings: []string{"antigravity"}, detectTokens: []string{"agy"}},
 		{Name: "codex", Icon: "💻", detectSubstrings: []string{"codex"}},
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},

--- a/internal/session/cli_status_refresh.go
+++ b/internal/session/cli_status_refresh.go
@@ -31,7 +31,7 @@ func RefreshInstancesForCLIStatus(instances []*Instance) {
 		if inst == nil {
 			continue
 		}
-		if !IsClaudeCompatible(inst.Tool) && inst.Tool != "codex" && inst.Tool != "gemini" {
+		if !IsClaudeCompatible(inst.Tool) && inst.Tool != "codex" && inst.Tool != "gemini" && inst.Tool != "antigravity" {
 			continue
 		}
 		if hs := readHookStatusFile(inst.ID); hs != nil {

--- a/internal/session/discovery.go
+++ b/internal/session/discovery.go
@@ -154,6 +154,9 @@ func detectToolFromName(name string) string {
 	if strings.Contains(nameLower, "gemini") {
 		return "gemini"
 	}
+	if strings.Contains(nameLower, "antigravity") || strings.Contains(nameLower, "agy") {
+		return "antigravity"
+	}
 	if strings.Contains(nameLower, "opencode") || strings.Contains(nameLower, "open-code") {
 		return "opencode"
 	}

--- a/internal/session/discovery.go
+++ b/internal/session/discovery.go
@@ -154,7 +154,7 @@ func detectToolFromName(name string) string {
 	if strings.Contains(nameLower, "gemini") {
 		return "gemini"
 	}
-	if strings.Contains(nameLower, "antigravity") || strings.Contains(nameLower, "agy") {
+	if strings.Contains(nameLower, "antigravity") || nameLower == "agy" || strings.HasPrefix(nameLower, "agy-") || strings.HasPrefix(nameLower, "agy_") || strings.Contains(nameLower, "-agy") || strings.Contains(nameLower, "_agy") || strings.Contains(nameLower, " agy") {
 		return "antigravity"
 	}
 	if strings.Contains(nameLower, "opencode") || strings.Contains(nameLower, "open-code") {

--- a/internal/session/discovery_test.go
+++ b/internal/session/discovery_test.go
@@ -91,6 +91,8 @@ func TestDetectToolFromName(t *testing.T) {
 		{"Claude uppercase", "CLAUDE-session", "claude"},
 		{"claude lowercase", "my-claude-session", "claude"},
 		{"Gemini mixed case", "Gemini-AI", "gemini"},
+		{"Antigravity", "antigravity-session", "antigravity"},
+		{"Agy", "my-agy-project", "antigravity"},
 		{"OpenCode", "opencode-session", "opencode"},
 		{"Codex", "codex-test", "codex"},
 		{"Unknown", "random-session", "shell"},
@@ -123,6 +125,26 @@ func TestExtractProjectName(t *testing.T) {
 			result := extractProjectName(tt.path)
 			if result != tt.expected {
 				t.Errorf("extractProjectName(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDiscovery_DetectToolFromName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"antigravity", "my-antigravity-session", "antigravity"},
+		{"agy", "agy-test-session", "antigravity"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectToolFromName(tt.input)
+			if result != tt.expected {
+				t.Errorf("detectToolFromName(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/internal/session/discovery_test.go
+++ b/internal/session/discovery_test.go
@@ -93,6 +93,8 @@ func TestDetectToolFromName(t *testing.T) {
 		{"Gemini mixed case", "Gemini-AI", "gemini"},
 		{"Antigravity", "antigravity-session", "antigravity"},
 		{"Agy", "my-agy-project", "antigravity"},
+		{"Agy standalone", "agy", "antigravity"},
+		{"Strategy should not match agy", "strategy-plan", "shell"},
 		{"OpenCode", "opencode-session", "opencode"},
 		{"Codex", "codex-test", "codex"},
 		{"Unknown", "random-session", "shell"},

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -276,6 +276,8 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Claude.EnvFile
 	case "gemini":
 		return config.Gemini.EnvFile
+	case "antigravity":
+		return config.Antigravity.EnvFile
 	case "opencode":
 		return config.OpenCode.EnvFile
 	case "codex":

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -192,6 +192,12 @@ type Instance struct {
 	GeminiModel      string                  `json:"gemini_model,omitempty"`     // Active model for this session
 	GeminiAnalytics  *GeminiSessionAnalytics `json:"gemini_analytics,omitempty"` // Per-session analytics
 
+	// Antigravity CLI (agy) integration
+	AntigravityConversationID string    `json:"antigravity_conversation_id,omitempty"`
+	AntigravityDetectedAt     time.Time `json:"antigravity_detected_at,omitempty"`
+	AntigravityYoloMode       *bool     `json:"antigravity_yolo_mode,omitempty"`
+	AntigravityModel          string    `json:"antigravity_model,omitempty"`
+
 	// OpenCode CLI integration
 	OpenCodeSessionID  string    `json:"opencode_session_id,omitempty"`
 	OpenCodeDetectedAt time.Time `json:"opencode_detected_at,omitempty"`
@@ -2783,6 +2789,8 @@ func (i *Instance) DisplaySessionID() string {
 		return i.ClaudeSessionID
 	case i.Tool == "gemini":
 		return i.GeminiSessionID
+	case i.Tool == "antigravity":
+		return i.AntigravityConversationID
 	case i.Tool == "opencode":
 		return i.OpenCodeSessionID
 	case i.Tool == "codex":
@@ -3109,6 +3117,8 @@ func (i *Instance) Start() error {
 		}
 	case i.Tool == "gemini":
 		command = i.buildGeminiCommand(i.Command)
+	case i.Tool == "antigravity":
+		command = i.buildAntigravityCommand(i.Command)
 	case i.Tool == "copilot":
 		command = buildCopilotCommand(i)
 		// Record start time for session ID detection (Unix millis)
@@ -3235,6 +3245,16 @@ func (i *Instance) Start() error {
 		}
 		_ = i.tmuxSession.SetEnvironment("GEMINI_YOLO_MODE", yoloVal)
 	}
+	if i.AntigravityConversationID != "" {
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", i.AntigravityConversationID)
+	}
+	if i.Tool == "antigravity" {
+		yoloVal := "false"
+		if i.AntigravityYoloMode != nil && *i.AntigravityYoloMode {
+			yoloVal = "true"
+		}
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_YOLO_MODE", yoloVal)
+	}
 	// OpenCode and Codex IDs are detected asynchronously; SyncSessionIDsToTmux() handles
 	// propagation once they are available.
 	// Copilot session ID propagation (if already known from prior session)
@@ -3358,6 +3378,8 @@ func (i *Instance) StartWithMessage(message string) error {
 		}
 	case i.Tool == "gemini":
 		command = i.buildGeminiCommand(i.Command)
+	case i.Tool == "antigravity":
+		command = i.buildAntigravityCommand(i.Command)
 	case i.Tool == "opencode":
 		if i.IsForkAwaitingStart {
 			command = i.buildOpenCodeCommand(i.consumeForkStartCommand())
@@ -3470,6 +3492,16 @@ func (i *Instance) StartWithMessage(message string) error {
 			yoloVal = "true"
 		}
 		_ = i.tmuxSession.SetEnvironment("GEMINI_YOLO_MODE", yoloVal)
+	}
+	if i.AntigravityConversationID != "" {
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", i.AntigravityConversationID)
+	}
+	if i.Tool == "antigravity" {
+		yoloVal := "false"
+		if i.AntigravityYoloMode != nil && *i.AntigravityYoloMode {
+			yoloVal = "true"
+		}
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_YOLO_MODE", yoloVal)
 	}
 
 	// Propagate COLORFGBG into the tmux session environment so that any new
@@ -3789,7 +3821,7 @@ func (i *Instance) UpdateStatus() error {
 
 	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
 	// Read the hook file from disk once to give CLI the same fast path as the TUI.
-	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "antigravity" || i.Tool == "hermes" || i.Tool == "cursor") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
 			i.hookEvent = hs.Event
@@ -3808,7 +3840,7 @@ func (i *Instance) UpdateStatus() error {
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
 	// polling and tool-specific session sync (tmux env/process-files/disk).
-	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") &&
+	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "antigravity" || i.Tool == "hermes" || i.Tool == "cursor") &&
 		i.hookStatus != "" &&
 		time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus) {
 		switch i.hookStatus {
@@ -3859,6 +3891,11 @@ func (i *Instance) UpdateStatus() error {
 				if i.hookSessionID != i.GeminiSessionID {
 					i.GeminiSessionID = i.hookSessionID
 					i.GeminiDetectedAt = time.Now()
+				}
+			case i.Tool == "antigravity":
+				if i.hookSessionID != i.AntigravityConversationID {
+					i.AntigravityConversationID = i.hookSessionID
+					i.AntigravityDetectedAt = time.Now()
 				}
 			}
 		}
@@ -4039,6 +4076,10 @@ func (i *Instance) UpdateStatus() error {
 			if i.GeminiSessionID == "" {
 				interval = 500 * time.Millisecond
 			}
+		case i.Tool == "antigravity":
+			if i.AntigravityConversationID == "" {
+				interval = 500 * time.Millisecond
+			}
 		case IsCodexCompatible(i.Tool):
 			if i.CodexSessionID == "" {
 				interval = 500 * time.Millisecond
@@ -4053,6 +4094,9 @@ func (i *Instance) UpdateStatus() error {
 			// Update Gemini session tracking (non-blocking, best-effort)
 			if i.Tool == "gemini" {
 				i.UpdateGeminiSession(nil)
+			}
+			if i.Tool == "antigravity" {
+				i.UpdateAntigravitySession()
 			}
 
 			// Update Codex session tracking (non-blocking, best-effort)
@@ -4301,6 +4345,13 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		// OR when current session is empty (first detection/bootstrap).
 		if i.GeminiSessionID == "" || geminiSessionHasConversationData(sessionID, i.ProjectPath) {
 			i.bindGeminiSessionFromHook(sessionID, status.Event)
+		}
+	case i.Tool == "antigravity":
+		if sessionID == i.AntigravityConversationID {
+			return
+		}
+		if i.AntigravityConversationID == "" || antigravityConversationHasData(sessionID) {
+			i.bindAntigravitySessionFromHook(sessionID, status.Event)
 		}
 	}
 }
@@ -4721,6 +4772,8 @@ func (i *Instance) PostStartSync(maxWait time.Duration) {
 		i.autoConfirmClaudeResumePicker()
 	case i.Tool == "gemini":
 		i.UpdateGeminiSession(nil)
+	case i.Tool == "antigravity":
+		i.UpdateAntigravitySession()
 	case i.Tool == "copilot":
 		// Copilot uses async detection via detectCopilotSessionAsync().
 		// If the session was not yet detected, attempt a quick sync check.
@@ -4833,6 +4886,11 @@ func (i *Instance) SyncSessionIDsToTmux() {
 		_ = i.tmuxSession.SetEnvironment("GEMINI_SESSION_ID", i.GeminiSessionID)
 	}
 
+	// Sync Antigravity conversation ID
+	if i.AntigravityConversationID != "" {
+		_ = i.tmuxSession.SetEnvironment("ANTIGRAVITY_CONVERSATION_ID", i.AntigravityConversationID)
+	}
+
 	// Sync OpenCodeSessionID
 	if i.OpenCodeSessionID != "" {
 		_ = i.tmuxSession.SetEnvironment("OPENCODE_SESSION_ID", i.OpenCodeSessionID)
@@ -4858,6 +4916,11 @@ func (i *Instance) clearSessionBindingForFreshStart() {
 	if i.Tool == "gemini" {
 		i.GeminiSessionID = ""
 		i.GeminiDetectedAt = time.Time{}
+	}
+
+	if i.Tool == "antigravity" {
+		i.AntigravityConversationID = ""
+		i.AntigravityDetectedAt = time.Time{}
 	}
 
 	if i.Tool == "opencode" {
@@ -5641,6 +5704,8 @@ func (i *Instance) getTerminalLastResponse() (*ResponseOutput, error) {
 	switch {
 	case i.Tool == "gemini":
 		return parseGeminiOutput(content)
+	case i.Tool == "antigravity":
+		return parseGeminiOutput(content)
 	case IsCodexCompatible(i.Tool):
 		return parseCodexOutput(content)
 	default:
@@ -5999,6 +6064,37 @@ func (i *Instance) Restart() error {
 		i.UpdateGeminiSession(nil)
 	}
 
+	if i.Tool == "gemini" {
+		i.UpdateGeminiSession(nil)
+	}
+	if i.Tool == "antigravity" {
+		i.UpdateAntigravitySession()
+	}
+
+	// If Antigravity session with known ID AND tmux session exists, use respawn-pane.
+	if i.Tool == "antigravity" && i.AntigravityConversationID != "" && i.tmuxSession != nil && i.tmuxSession.Exists() {
+		resumeCmd, containerName, err := i.prepareCommand(i.buildAntigravityCommand("agy"))
+		if err != nil {
+			return err
+		}
+		if containerName != "" {
+			i.SandboxContainer = containerName
+		}
+		sessionLog.Info("restart_antigravity_respawn", slog.String("command", resumeCmd))
+
+		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
+			sessionLog.Info("restart_antigravity_respawn_failed", slog.String("error", err.Error()))
+			return fmt.Errorf("failed to restart Antigravity session: %w", err)
+		}
+
+		sessionLog.Info("restart_antigravity_respawn_succeeded")
+		i.ensureProfileEnv()
+		WriteHookSessionAnchor(i.ID, i.AntigravityConversationID)
+		i.sweepDuplicateToolSessions()
+		i.Status = StatusWaiting
+		return nil
+	}
+
 	// If Gemini session with known ID AND tmux session exists, use respawn-pane.
 	if i.Tool == "gemini" && i.GeminiSessionID != "" && i.tmuxSession != nil && i.tmuxSession.Exists() {
 		resumeCmd, containerName, err := i.prepareCommand(i.buildGeminiCommand("gemini"))
@@ -6251,6 +6347,8 @@ func (i *Instance) Restart() error {
 		command = i.buildClaudeResumeCommand()
 	} else if i.Tool == "gemini" && i.GeminiSessionID != "" {
 		command = i.buildGeminiCommand("gemini")
+	} else if i.Tool == "antigravity" && i.AntigravityConversationID != "" {
+		command = i.buildAntigravityCommand("agy")
 	} else if i.Tool == "opencode" && i.OpenCodeSessionID != "" {
 		command = i.buildOpenCodeCommand("opencode")
 	} else if IsCodexCompatible(i.Tool) && i.CodexSessionID != "" {
@@ -6262,6 +6360,8 @@ func (i *Instance) Restart() error {
 			command = i.buildClaudeCommand(i.Command)
 		case i.Tool == "gemini":
 			command = i.buildGeminiCommand(i.Command)
+		case i.Tool == "antigravity":
+			command = i.buildAntigravityCommand(i.Command)
 		case i.Tool == "opencode":
 			command = i.buildOpenCodeCommand(i.Command)
 			// Record start time for async session ID detection
@@ -6521,7 +6621,7 @@ func (i *Instance) SetGeminiModel(model string) error {
 // SupportsLaunchModel reports whether a newly-created session can receive an
 // explicit model override through Agent Deck's generic session creation path.
 func SupportsLaunchModel(tool string) bool {
-	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "opencode" || IsCodexCompatible(tool)
+	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "antigravity" || tool == "opencode" || IsCodexCompatible(tool)
 }
 
 // ApplyLaunchModel stores a per-session model override in the tool-specific
@@ -6543,6 +6643,9 @@ func (i *Instance) ApplyLaunchModel(model string) error {
 		return i.SetClaudeOptions(opts)
 	case i.Tool == "gemini":
 		i.GeminiModel = model
+		return nil
+	case i.Tool == "antigravity":
+		i.AntigravityModel = model
 		return nil
 	case i.Tool == "opencode":
 		opts := i.GetOpenCodeOptions()
@@ -6584,6 +6687,9 @@ func (i *Instance) ClearLaunchModel() error {
 	case i.Tool == "gemini":
 		i.GeminiModel = ""
 		return nil
+	case i.Tool == "antigravity":
+		i.AntigravityModel = ""
+		return nil
 	case i.Tool == "opencode":
 		opts := i.GetOpenCodeOptions()
 		if opts == nil {
@@ -6613,6 +6719,14 @@ func (i *Instance) ClearLaunchModel() error {
 func (i *Instance) CanRestart() bool {
 	// Gemini sessions with known session ID can always be restarted
 	if i.Tool == "gemini" && i.GeminiSessionID != "" {
+		return true
+	}
+
+	// Antigravity sessions with known conversation ID can always be restarted
+	if i.Tool == "antigravity" && i.AntigravityConversationID != "" {
+		return true
+	}
+	if i.Tool == "antigravity" {
 		return true
 	}
 
@@ -6684,6 +6798,9 @@ func (i *Instance) CanRestartFresh() bool {
 	if i.Tool == "gemini" {
 		return i.GeminiSessionID != ""
 	}
+	if i.Tool == "antigravity" {
+		return i.AntigravityConversationID != ""
+	}
 	if i.Tool == "opencode" {
 		return i.OpenCodeSessionID != ""
 	}
@@ -6697,6 +6814,9 @@ func (i *Instance) CanRestartFresh() bool {
 func (i *Instance) CanFork() bool {
 	// Gemini CLI doesn't support forking
 	if i.Tool == "gemini" {
+		return false
+	}
+	if i.Tool == "antigravity" {
 		return false
 	}
 
@@ -7436,6 +7556,9 @@ func (i *Instance) RefreshLiveSessionIDs() {
 	if i.Tool == "gemini" {
 		i.syncGeminiSessionFromTmux()
 	}
+	if i.Tool == "antigravity" {
+		i.syncAntigravitySessionFromTmux()
+	}
 }
 
 // GetMCPInfo returns MCP server information for this session.
@@ -7449,6 +7572,8 @@ func (i *Instance) GetMCPInfo() *MCPInfo {
 		return GetMCPInfo(i.ProjectPath)
 	case i.Tool == "gemini":
 		return GetGeminiMCPInfo(i.ProjectPath)
+	case i.Tool == "antigravity":
+		return GetAntigravityMCPInfo(i.ProjectPath)
 	case i.Tool == "cursor":
 		return GetCursorMCPInfo(i.ProjectPath)
 	default:

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6063,10 +6063,6 @@ func (i *Instance) Restart() error {
 	if i.Tool == "gemini" {
 		i.UpdateGeminiSession(nil)
 	}
-
-	if i.Tool == "gemini" {
-		i.UpdateGeminiSession(nil)
-	}
 	if i.Tool == "antigravity" {
 		i.UpdateAntigravitySession()
 	}
@@ -6091,6 +6087,9 @@ func (i *Instance) Restart() error {
 		i.ensureProfileEnv()
 		WriteHookSessionAnchor(i.ID, i.AntigravityConversationID)
 		i.sweepDuplicateToolSessions()
+		// Mirror the Claude respawn path: MCPs may have changed since the
+		// session started, so re-capture them now or LoadedMCPNames goes stale.
+		i.CaptureLoadedMCPs()
 		i.Status = StatusWaiting
 		return nil
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3920,8 +3920,9 @@ func (i *Instance) UpdateStatus() error {
 				}
 			case i.Tool == "antigravity":
 				if i.hookSessionID != i.AntigravityConversationID {
-					i.AntigravityConversationID = i.hookSessionID
-					i.AntigravityDetectedAt = time.Now()
+					if i.AntigravityConversationID == "" || antigravityConversationHasData(i.hookSessionID) {
+						i.bindAntigravitySessionFromHook(i.hookSessionID, i.hookEvent)
+					}
 				}
 			}
 		}

--- a/internal/session/instance_mcp.go
+++ b/internal/session/instance_mcp.go
@@ -7,7 +7,7 @@ import (
 
 // ToolSupportsMCPManager reports whether the TUI/CLI MCP surfaces apply to this tool.
 func ToolSupportsMCPManager(toolName string) bool {
-	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "cursor" || toolName == "opencode"
+	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "antigravity" || toolName == "cursor" || toolName == "opencode"
 }
 
 // MCPLocalConfigPathForTool returns the project-local MCP config path for display and writes.
@@ -35,6 +35,8 @@ func MCPGlobalConfigPathForTool(toolName string) string {
 		return filepath.Join(GetClaudeConfigDir(), ".claude.json")
 	case toolName == "gemini":
 		return filepath.Join(GetGeminiConfigDir(), "settings.json")
+	case toolName == "antigravity":
+		return filepath.Join(GetAntigravityConfigDir(), "mcp_config.json")
 	case toolName == "cursor":
 		return filepath.Join(GetCursorConfigDir(), "mcp.json")
 	case toolName == "opencode":
@@ -84,6 +86,8 @@ func WriteGlobalMCPConfigForTool(toolName string, names []string) error {
 		return WriteGlobalMCP(names)
 	case toolName == "gemini":
 		return WriteGeminiMCPSettings(names)
+	case toolName == "antigravity":
+		return WriteAntigravityMCPSettings(names)
 	case toolName == "cursor":
 		return WriteCursorGlobalMCP(names)
 	case toolName == "opencode":

--- a/internal/session/model_info.go
+++ b/internal/session/model_info.go
@@ -28,6 +28,8 @@ func (i *Instance) LaunchModelID() string {
 		}
 	case i.Tool == "gemini":
 		return strings.TrimSpace(i.GeminiModel)
+	case i.Tool == "antigravity":
+		return strings.TrimSpace(i.AntigravityModel)
 	case i.Tool == "opencode":
 		if opts := i.GetOpenCodeOptions(); opts != nil {
 			return strings.TrimSpace(opts.Model)

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -25,7 +25,8 @@ const (
 	FieldColor              = "color"
 	FieldNotes              = "notes"
 	FieldClaudeSessionID    = "claude-session-id"
-	FieldGeminiSessionID    = "gemini-session-id"
+	FieldGeminiSessionID           = "gemini-session-id"
+	FieldAntigravityConversationID = "antigravity-conversation-id"
 	FieldOpenCodeSessionID  = "opencode-session-id"
 	FieldCodexSessionID     = "codex-session-id"
 	FieldTitleLocked        = "title-locked"
@@ -58,6 +59,7 @@ var ValidMutableFields = []string{
 	FieldNotes,
 	FieldClaudeSessionID,
 	FieldGeminiSessionID,
+	FieldAntigravityConversationID,
 	FieldOpenCodeSessionID,
 	FieldCodexSessionID,
 	FieldTitleLocked,
@@ -297,6 +299,12 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		inst.GeminiSessionID = value
 		inst.GeminiDetectedAt = time.Now()
 		postCommit = makeSessionEnvPostCommit(inst, "GEMINI_SESSION_ID", value)
+
+	case FieldAntigravityConversationID:
+		oldValue = inst.AntigravityConversationID
+		inst.AntigravityConversationID = value
+		inst.AntigravityDetectedAt = time.Now()
+		postCommit = makeSessionEnvPostCommit(inst, "ANTIGRAVITY_CONVERSATION_ID", value)
 
 	case FieldOpenCodeSessionID:
 		oldValue = inst.OpenCodeSessionID

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -299,12 +299,18 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		inst.GeminiSessionID = value
 		inst.GeminiDetectedAt = time.Now()
 		postCommit = makeSessionEnvPostCommit(inst, "GEMINI_SESSION_ID", value)
+		if value == "" {
+			ClearHookSessionAnchor(inst.ID)
+		}
 
 	case FieldAntigravityConversationID:
 		oldValue = inst.AntigravityConversationID
 		inst.AntigravityConversationID = value
 		inst.AntigravityDetectedAt = time.Now()
 		postCommit = makeSessionEnvPostCommit(inst, "ANTIGRAVITY_CONVERSATION_ID", value)
+		if value == "" {
+			ClearHookSessionAnchor(inst.ID)
+		}
 
 	case FieldOpenCodeSessionID:
 		oldValue = inst.OpenCodeSessionID

--- a/internal/session/restart_sweep.go
+++ b/internal/session/restart_sweep.go
@@ -55,6 +55,8 @@ func (i *Instance) sweepDuplicateToolSessions() {
 		killDuplicateSessionsFn("CLAUDE_SESSION_ID", i.ClaudeSessionID, keepName)
 	case i.Tool == "gemini" && i.GeminiSessionID != "":
 		killDuplicateSessionsFn("GEMINI_SESSION_ID", i.GeminiSessionID, keepName)
+	case i.Tool == "antigravity" && i.AntigravityConversationID != "":
+		killDuplicateSessionsFn("ANTIGRAVITY_CONVERSATION_ID", i.AntigravityConversationID, keepName)
 	case i.Tool == "opencode" && i.OpenCodeSessionID != "":
 		killDuplicateSessionsFn("OPENCODE_SESSION_ID", i.OpenCodeSessionID, keepName)
 	case i.Tool == "codex" && i.CodexSessionID != "":

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -137,7 +137,7 @@ func SupportsProjectSkills(tool string) bool {
 // ShouldRestartProjectSkills reports whether agent-deck should auto-restart the session
 // after project skill changes for this runtime.
 func ShouldRestartProjectSkills(tool string) bool {
-	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "codex" || tool == "hermes"
+	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "codex" || tool == "hermes" || tool == "antigravity"
 }
 
 // GetProjectSkillsDir returns the runtime-managed project skill directory.
@@ -145,7 +145,7 @@ func GetProjectSkillsDir(tool string) (string, bool) {
 	switch {
 	case IsClaudeCompatible(tool):
 		return projectClaudeSkillsDir, true
-	case tool == "gemini" || tool == "codex" || tool == "pi":
+	case tool == "gemini" || tool == "codex" || tool == "pi" || tool == "antigravity":
 		return projectAgentsSkillsDir, true
 	case tool == "hermes":
 		return projectHermesSkillsDir, true

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -688,3 +688,17 @@ func TestApplyProjectSkills_SyncsAttachments(t *testing.T) {
 		t.Fatalf("expected manifest to contain only 'two', got %+v", manifest.Skills)
 	}
 }
+
+func TestSkill_AntigravityProjectSkillsSupport(t *testing.T) {
+	if !ShouldRestartProjectSkills("antigravity") {
+		t.Errorf("ShouldRestartProjectSkills(\"antigravity\") = false, want true")
+	}
+
+	dir, ok := GetProjectSkillsDir("antigravity")
+	if !ok {
+		t.Fatalf("GetProjectSkillsDir(\"antigravity\") ok = false, want true")
+	}
+	if dir != projectAgentsSkillsDir {
+		t.Errorf("GetProjectSkillsDir(\"antigravity\") = %q, want %q", dir, projectAgentsSkillsDir)
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -84,6 +84,12 @@ type InstanceData struct {
 	GeminiYoloMode   *bool     `json:"gemini_yolo_mode,omitempty"`
 	GeminiModel      string    `json:"gemini_model,omitempty"`
 
+	// Antigravity CLI (agy) session (persisted for resume after app restart)
+	AntigravityConversationID string    `json:"antigravity_conversation_id,omitempty"`
+	AntigravityDetectedAt     time.Time `json:"antigravity_detected_at,omitempty"`
+	AntigravityYoloMode       *bool     `json:"antigravity_yolo_mode,omitempty"`
+	AntigravityModel          string    `json:"antigravity_model,omitempty"`
+
 	// OpenCode session (persisted for resume after app restart)
 	OpenCodeSessionID  string    `json:"opencode_session_id,omitempty"`
 	OpenCodeDetectedAt time.Time `json:"opencode_detected_at,omitempty"`
@@ -719,6 +725,7 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	// the positional MarshalToolData signature so legacy binaries that don't
 	// know the key preserve it via MergeToolDataExtras.
 	toolData = WriteIdleTimeoutSecsToToolData(toolData, inst.IdleTimeoutSecs)
+	toolData = WriteAntigravityToToolData(toolData, inst)
 
 	return &statedb.InstanceRow{
 		ID:                  inst.ID,
@@ -833,6 +840,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			pluginChannelLinkDisabled2,
 			autoLinkedChannels2,
 			color2 := statedb.UnmarshalToolData(r.ToolData)
+		agySID, agyAt, agyYolo, agyModel := ReadAntigravityFromToolData(r.ToolData)
 		sandboxCfg := decodeSandboxConfig(sandboxJSON)
 
 		instances[i] = &InstanceData{
@@ -867,6 +875,10 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			GeminiDetectedAt:          geminiAt,
 			GeminiYoloMode:            geminiYolo,
 			GeminiModel:               geminiModel,
+			AntigravityConversationID: agySID,
+			AntigravityDetectedAt:     agyAt,
+			AntigravityYoloMode:       agyYolo,
+			AntigravityModel:          agyModel,
 			OpenCodeSessionID:         opencodeSID,
 			OpenCodeDetectedAt:        opencodeAt,
 			CodexSessionID:            codexSID,
@@ -952,6 +964,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			pluginChannelLinkDisabled,
 			autoLinkedChannels,
 			color := statedb.UnmarshalToolData(r.ToolData)
+		agySID, agyAt, agyYolo, agyModel := ReadAntigravityFromToolData(r.ToolData)
 		sandboxCfg := decodeSandboxConfig(sandboxJSON)
 
 		data.Instances[i] = &InstanceData{
@@ -986,6 +999,10 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			GeminiDetectedAt:          geminiAt,
 			GeminiYoloMode:            geminiYolo,
 			GeminiModel:               geminiModel,
+			AntigravityConversationID: agySID,
+			AntigravityDetectedAt:     agyAt,
+			AntigravityYoloMode:       agyYolo,
+			AntigravityModel:          agyModel,
 			OpenCodeSessionID:         opencodeSID,
 			OpenCodeDetectedAt:        opencodeAt,
 			CodexSessionID:            codexSID,
@@ -1038,15 +1055,16 @@ func (s *Storage) SaveRecentSession(inst *Instance) error {
 	}
 
 	row := &statedb.RecentSessionRow{
-		Title:          inst.Title,
-		ProjectPath:    inst.ProjectPath,
-		GroupPath:      inst.GroupPath,
-		Command:        inst.Command,
-		Wrapper:        inst.Wrapper,
-		Tool:           inst.Tool,
-		ToolOptions:    inst.ToolOptionsJSON,
-		SandboxEnabled: inst.Sandbox != nil,
-		GeminiYoloMode: inst.GeminiYoloMode,
+		Title:               inst.Title,
+		ProjectPath:         inst.ProjectPath,
+		GroupPath:           inst.GroupPath,
+		Command:             inst.Command,
+		Wrapper:             inst.Wrapper,
+		Tool:                inst.Tool,
+		ToolOptions:         inst.ToolOptionsJSON,
+		SandboxEnabled:      inst.Sandbox != nil,
+		GeminiYoloMode:      inst.GeminiYoloMode,
+		AntigravityYoloMode: inst.AntigravityYoloMode,
 	}
 
 	return s.db.SaveRecentSession(row)
@@ -1240,6 +1258,10 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			GeminiDetectedAt:          instData.GeminiDetectedAt,
 			GeminiYoloMode:            instData.GeminiYoloMode,
 			GeminiModel:               instData.GeminiModel,
+			AntigravityConversationID: instData.AntigravityConversationID,
+			AntigravityDetectedAt:     instData.AntigravityDetectedAt,
+			AntigravityYoloMode:       instData.AntigravityYoloMode,
+			AntigravityModel:          instData.AntigravityModel,
 			OpenCodeSessionID:         instData.OpenCodeSessionID,
 			OpenCodeDetectedAt:        instData.OpenCodeDetectedAt,
 			CodexSessionID:            instData.CodexSessionID,

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -435,7 +435,7 @@ func ConfiguredHiddenToolNames() []string {
 }
 
 // pickerPresetOrder matches buildPresetCommands in internal/ui/newdialog.go.
-var pickerPresetOrder = []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+var pickerPresetOrder = []string{"", "claude", "gemini", "antigravity", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
 
 // PickerToolNames returns tool names for the new-session picker after applying
 // hidden_tools and show_only_installed_tools. The empty command "" is mapped

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -8,7 +8,7 @@ import (
 // canonicalBuiltins is the canonical 11, in the precedence order that
 // Registry.Match() (and the legacy detectTool() switch) walk.
 var canonicalBuiltins = []string{
-	"claude", "opencode", "gemini", "codex", "pi",
+	"claude", "opencode", "gemini", "antigravity", "codex", "pi",
 	"copilot", "crush", "cursor", "hermes", "aider", "shell",
 }
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -131,6 +131,9 @@ type UserConfig struct {
 	// Gemini defines Gemini CLI integration settings
 	Gemini GeminiSettings `toml:"gemini,omitempty"`
 
+	// Antigravity CLI (agy) settings
+	Antigravity AntigravitySettings `toml:"antigravity,omitempty"`
+
 	// OpenCode defines OpenCode CLI integration settings
 	OpenCode OpenCodeSettings `toml:"opencode,omitempty"`
 
@@ -1403,6 +1406,21 @@ type GeminiSettings struct {
 
 	// Command overrides the default binary/invocation for Gemini sessions.
 	// Supports flags (e.g., "gemini --custom-flag"). Default: "gemini"
+	Command string `toml:"command,omitempty"`
+}
+
+// AntigravitySettings defines Antigravity CLI (agy) configuration
+type AntigravitySettings struct {
+	// YoloMode enables --dangerously-skip-permissions for Antigravity sessions
+	YoloMode bool `toml:"yolo_mode,omitempty"`
+
+	// DefaultModel is the model for new Antigravity sessions
+	DefaultModel string `toml:"default_model,omitempty"`
+
+	// EnvFile is a .env file specific to Antigravity sessions
+	EnvFile string `toml:"env_file,omitempty"`
+
+	// Command overrides the default binary/invocation. Default: "agy"
 	Command string `toml:"command,omitempty"`
 }
 
@@ -2942,6 +2960,11 @@ func GetToolCommand(toolName string) string {
 		if config.Gemini.Command != "" {
 			return config.Gemini.Command
 		}
+	case "antigravity":
+		if config.Antigravity.Command != "" {
+			return config.Antigravity.Command
+		}
+		return "agy"
 	case "opencode":
 		if config.OpenCode.Command != "" {
 			return config.OpenCode.Command
@@ -2979,6 +3002,8 @@ func GetToolIcon(toolName string) string {
 		return "🤖"
 	case "gemini":
 		return "✨"
+	case "antigravity":
+		return "🛸"
 	case "opencode":
 		return "🌐"
 	case "codex":
@@ -3575,6 +3600,13 @@ func CreateExampleConfig() error {
 # [gemini]
 # Enable --yolo (auto-approve all actions) by default (default: false)
 # yolo_mode = true
+
+# Antigravity CLI (agy) integration
+# [antigravity]
+# Enable --dangerously-skip-permissions by default (default: false)
+# yolo_mode = true
+# default_model = "gemini-2.5-flash"
+# command = "agy"
 
 # OpenCode CLI integration
 # [opencode]

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2949,6 +2949,12 @@ func GetCustomToolNames() []string {
 func GetToolCommand(toolName string) string {
 	config, _ := LoadUserConfig()
 	if config == nil {
+		// Antigravity's binary name ("agy") differs from its tool name, so the
+		// "just return toolName" shortcut would resolve to a non-existent binary
+		// when config load fails. All other built-ins share name and binary.
+		if toolName == "antigravity" {
+			return "agy"
+		}
 		return toolName
 	}
 	switch toolName {
@@ -3538,7 +3544,7 @@ func CreateExampleConfig() error {
 
 # Default AI tool for new sessions
 # When creating a new session (pressing 'n'), this tool will be pre-selected
-# Valid values: "claude", "gemini", "opencode", "codex", "pi", or any custom tool name
+# Valid values: "claude", "gemini", "antigravity", "opencode", "codex", "pi", or any custom tool name
 # Leave commented out or empty to default to shell (no pre-selection)
 # default_tool = "claude"
 

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -434,6 +434,38 @@ func TestCreateExampleConfigDocumentsCompatibleWith(t *testing.T) {
 	}
 }
 
+func TestCreateExampleConfigIncludesAntigravity(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
+
+	if err := CreateExampleConfig(); err != nil {
+		t.Fatalf("CreateExampleConfig: %v", err)
+	}
+
+	configPath, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", configPath, err)
+	}
+	config := string(data)
+
+	for _, want := range []string{
+		`# [antigravity]`,
+		`# default_model = "gemini-2.5-flash"`,
+		`# command = "agy"`,
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("example config missing %q", want)
+		}
+	}
+}
+
 func TestGlobalSearchConfig(t *testing.T) {
 	// Create temp config with global search settings
 	tmpDir := t.TempDir()

--- a/internal/sessionstatus/sessionstatus.go
+++ b/internal/sessionstatus/sessionstatus.go
@@ -94,7 +94,7 @@ func IsHookEmittingTool(tool string) bool {
 	if session.IsClaudeCompatible(tool) {
 		return true
 	}
-	return tool == "codex" || tool == "gemini" || tool == "hermes" || tool == "cursor"
+	return tool == "codex" || tool == "gemini" || tool == "hermes" || tool == "cursor" || tool == "antigravity"
 }
 
 // freshnessFor returns the freshness window for a (tool, hookStatus) pair.

--- a/internal/sessionstatus/sessionstatus_test.go
+++ b/internal/sessionstatus/sessionstatus_test.go
@@ -449,3 +449,10 @@ func TestDerive_ToolGate_CodexAndGemini(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHookEmittingTool_Antigravity(t *testing.T) {
+	t.Parallel()
+	if !sessionstatus.IsHookEmittingTool("antigravity") {
+		t.Fatalf("IsHookEmittingTool(%q) = false, want true", "antigravity")
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -267,9 +267,10 @@ type RecentSessionRow struct {
 	Wrapper        string
 	Tool           string
 	ToolOptions    json.RawMessage // serialized ToolOptionsWrapper
-	SandboxEnabled bool
-	GeminiYoloMode *bool
-	DeletedAt      time.Time
+	SandboxEnabled      bool
+	GeminiYoloMode      *bool
+	AntigravityYoloMode *bool
+	DeletedAt           time.Time
 }
 
 // global singleton for cross-package access (status writes from background worker)
@@ -438,6 +439,7 @@ func (s *StateDB) Migrate() error {
 			tool_options    TEXT NOT NULL DEFAULT '{}',
 			sandbox_enabled INTEGER NOT NULL DEFAULT 0,
 			gemini_yolo     INTEGER,
+			antigravity_yolo INTEGER,
 			deleted_at      INTEGER NOT NULL
 		)
 	`); err != nil {
@@ -552,6 +554,10 @@ func (s *StateDB) Migrate() error {
 		// deliberate-idle (never a self-heal candidate). Additive + targeted-write
 		// only (WriteLastSentAt); never part of a whole-row REPLACE/SaveInstances.
 		"ALTER TABLE instances ADD COLUMN last_sent_at INTEGER NOT NULL DEFAULT 0",
+		// Antigravity (agy) CLI integration: per-session YOLO mode for the
+		// recent-sessions picker, mirroring gemini_yolo. Nullable so legacy
+		// rows are indistinguishable from "unset".
+		"ALTER TABLE recent_sessions ADD COLUMN antigravity_yolo INTEGER",
 	}
 	for _, stmt := range alterMigrations {
 		if _, err := tx.Exec(stmt); err != nil {
@@ -1301,6 +1307,21 @@ func (s *StateDB) WriteGeminiSessionBinding(id, sessionID string, detectedAt tim
 	})
 }
 
+func (s *StateDB) WriteAntigravitySessionBinding(id, conversationID string, detectedAt time.Time) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances
+			   SET tool_data = json_set(
+			         COALESCE(tool_data, '{}'),
+			         '$.antigravity_conversation_id', ?,
+			         '$.antigravity_detected_at', ?)
+			 WHERE id = ?`,
+			conversationID, detectedAt.Unix(), id,
+		)
+		return err
+	})
+}
+
 // ReadAllStatuses returns status + acknowledged flag for every instance.
 func (s *StateDB) ReadAllStatuses() (map[string]StatusRow, error) {
 	rows, err := s.db.Query("SELECT id, status, tool, acknowledged FROM instances")
@@ -1531,6 +1552,11 @@ func recentSessionDedupID(row *RecentSessionRow) string {
 		geminiYolo = strconv.FormatBool(*row.GeminiYoloMode)
 	}
 
+	antigravityYolo := "unset"
+	if row.AntigravityYoloMode != nil {
+		antigravityYolo = strconv.FormatBool(*row.AntigravityYoloMode)
+	}
+
 	payload := strings.Join([]string{
 		row.Title,
 		row.ProjectPath,
@@ -1541,6 +1567,7 @@ func recentSessionDedupID(row *RecentSessionRow) string {
 		toolOpts,
 		strconv.FormatBool(row.SandboxEnabled),
 		geminiYolo,
+		antigravityYolo,
 	}, "\x00")
 
 	h := sha256.Sum256([]byte(payload))
@@ -1576,6 +1603,15 @@ func (s *StateDB) SaveRecentSession(row *RecentSessionRow) error {
 		geminiYolo = &v
 	}
 
+	var antigravityYolo *int
+	if row.AntigravityYoloMode != nil {
+		v := 0
+		if *row.AntigravityYoloMode {
+			v = 1
+		}
+		antigravityYolo = &v
+	}
+
 	return withBusyRetry(func() error {
 		tx, err := s.db.Begin()
 		if err != nil {
@@ -1587,12 +1623,12 @@ func (s *StateDB) SaveRecentSession(row *RecentSessionRow) error {
 			INSERT OR REPLACE INTO recent_sessions (
 				id, title, project_path, group_path,
 				command, wrapper, tool, tool_options,
-				sandbox_enabled, gemini_yolo, deleted_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				sandbox_enabled, gemini_yolo, antigravity_yolo, deleted_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`,
 			id, row.Title, row.ProjectPath, row.GroupPath,
 			row.Command, row.Wrapper, row.Tool, string(toolOpts),
-			sandbox, geminiYolo, time.Now().Unix(),
+			sandbox, geminiYolo, antigravityYolo, time.Now().Unix(),
 		); err != nil {
 			return err
 		}
@@ -1614,7 +1650,7 @@ func (s *StateDB) LoadRecentSessions() ([]*RecentSessionRow, error) {
 	rows, err := s.db.Query(`
 		SELECT id, title, project_path, group_path,
 			command, wrapper, tool, tool_options,
-			sandbox_enabled, gemini_yolo, deleted_at
+			sandbox_enabled, gemini_yolo, antigravity_yolo, deleted_at
 		FROM recent_sessions ORDER BY deleted_at DESC
 	`)
 	if err != nil {
@@ -1628,11 +1664,12 @@ func (s *StateDB) LoadRecentSessions() ([]*RecentSessionRow, error) {
 		var toolOptsStr string
 		var sandbox int
 		var geminiYolo *int
+		var antigravityYolo *int
 		var deletedUnix int64
 		if err := rows.Scan(
 			&r.ID, &r.Title, &r.ProjectPath, &r.GroupPath,
 			&r.Command, &r.Wrapper, &r.Tool, &toolOptsStr,
-			&sandbox, &geminiYolo, &deletedUnix,
+			&sandbox, &geminiYolo, &antigravityYolo, &deletedUnix,
 		); err != nil {
 			return nil, err
 		}
@@ -1641,6 +1678,10 @@ func (s *StateDB) LoadRecentSessions() ([]*RecentSessionRow, error) {
 		if geminiYolo != nil {
 			v := *geminiYolo != 0
 			r.GeminiYoloMode = &v
+		}
+		if antigravityYolo != nil {
+			v := *antigravityYolo != 0
+			r.AntigravityYoloMode = &v
 		}
 		r.DeletedAt = time.Unix(deletedUnix, 0)
 		result = append(result, r)

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -48,6 +48,19 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			SpinnerChars:   defaultSpinnerChars(),
 			WhimsicalWords: defaultWhimsicalWords(),
 		}
+	case "antigravity":
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"esc to cancel",
+				"ctrl+c to interrupt",
+				"ctrl+o to expand",
+			},
+			PromptPatterns: []string{
+				"Type your message",
+				"press enter to send",
+				"> ",
+			},
+		}
 	case "gemini":
 		return &RawPatterns{
 			BusyPatterns:   []string{"esc to cancel"},

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -58,7 +58,7 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			PromptPatterns: []string{
 				"Type your message",
 				"press enter to send",
-				"> ",
+				`re:(?m)^\s*>\s*$`,
 			},
 		}
 	case "gemini":

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -577,7 +577,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
+var toolDetectionOrder = []string{"claude", "antigravity", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -585,6 +585,11 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		regexp.MustCompile(`(?i)\bclaude\s+code\b`),
 		regexp.MustCompile(`(?i)\bno,\s*and\s*tell\s+claude\s+what\s+to\s+do\s+differently\b`),
 		regexp.MustCompile(`(?i)\bdo you trust the files in this folder\??`),
+	},
+	"antigravity": {
+		regexp.MustCompile(`(?i)\bantigravity\b`),
+		regexp.MustCompile(`(?i)\bagy\b`),
+		regexp.MustCompile(`(?i)^agy>\s*`),
 	},
 	"gemini": {
 		regexp.MustCompile(`(?i)gemini`),
@@ -640,6 +645,8 @@ func detectToolFromCommand(command string) string {
 		switch base {
 		case "claude":
 			return "claude"
+		case "antigravity", "agy":
+			return "antigravity"
 		case "gemini":
 			return "gemini"
 		case "opencode", "open-code":
@@ -662,6 +669,8 @@ func detectToolFromCommand(command string) string {
 	switch {
 	case strings.Contains(cmdLower, "claude"):
 		return "claude"
+	case strings.Contains(cmdLower, "antigravity") || strings.Contains(cmdLower, " agy ") || strings.HasPrefix(cmdLower, "agy ") || strings.HasSuffix(cmdLower, " agy") || cmdLower == "agy":
+		return "antigravity"
 	case strings.Contains(cmdLower, "gemini"):
 		return "gemini"
 	case strings.Contains(cmdLower, "opencode") || strings.Contains(cmdLower, "open code") || strings.Contains(cmdLower, "open-code"):

--- a/internal/ui/gemini_model_dialog.go
+++ b/internal/ui/gemini_model_dialog.go
@@ -20,7 +20,7 @@ type modelSelectedMsg struct {
 	instanceID string
 }
 
-// GeminiModelDialog allows selecting a Gemini model for the current session
+// GeminiModelDialog allows selecting a Gemini or Antigravity model for the current session
 type GeminiModelDialog struct {
 	visible    bool
 	width      int
@@ -31,6 +31,8 @@ type GeminiModelDialog struct {
 	err        error
 	instanceID string // ID of the session to change model for
 	current    string // Currently active model
+	title      string // Dialog title (defaults to Gemini)
+	fetcher    func() ([]string, error)
 }
 
 // NewGeminiModelDialog creates a new model selection dialog
@@ -38,8 +40,17 @@ func NewGeminiModelDialog() *GeminiModelDialog {
 	return &GeminiModelDialog{}
 }
 
-// Show opens the dialog and triggers async model fetching
+// Show opens the dialog and triggers async model fetching for Gemini sessions.
 func (d *GeminiModelDialog) Show(instanceID, currentModel string) tea.Cmd {
+	return d.showWith(instanceID, currentModel, "Select Gemini Model", session.GetAvailableGeminiModels)
+}
+
+// ShowAntigravity opens the dialog for Antigravity (agy) sessions.
+func (d *GeminiModelDialog) ShowAntigravity(instanceID, currentModel string) tea.Cmd {
+	return d.showWith(instanceID, currentModel, "Select Antigravity Model", session.GetAvailableAntigravityModels)
+}
+
+func (d *GeminiModelDialog) showWith(instanceID, currentModel, title string, fetcher func() ([]string, error)) tea.Cmd {
 	d.visible = true
 	d.cursor = 0
 	d.models = nil
@@ -47,9 +58,11 @@ func (d *GeminiModelDialog) Show(instanceID, currentModel string) tea.Cmd {
 	d.err = nil
 	d.instanceID = instanceID
 	d.current = currentModel
+	d.title = title
+	d.fetcher = fetcher
 
 	return func() tea.Msg {
-		models, err := session.GetAvailableGeminiModels()
+		models, err := fetcher()
 		return modelsFetchedMsg{models: models, err: err}
 	}
 }
@@ -153,7 +166,11 @@ func (d *GeminiModelDialog) View() string {
 	var content strings.Builder
 
 	// Title
-	content.WriteString(titleStyle.Render("Select Gemini Model"))
+	title := d.title
+	if title == "" {
+		title = "Select Gemini Model"
+	}
+	content.WriteString(titleStyle.Render(title))
 	content.WriteString(dimStyle.Render("            [Esc] Cancel"))
 	content.WriteString("\n")
 	content.WriteString(strings.Repeat("-", dialogWidth-4))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2967,7 +2967,7 @@ func (h *Home) cleanupExpiredAnimations(
 		// Use appropriate timeout based on tool
 		// Claude and Gemini use longer timeout (MCP loading can be slow)
 		timeout := defaultTimeout
-		if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "gemini" {
+		if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "gemini" || inst.Tool == "antigravity" {
 			timeout = claudeTimeout
 		}
 		if time.Since(startTime) > timeout {
@@ -2981,7 +2981,7 @@ func (h *Home) cleanupExpiredAnimations(
 }
 
 func launchAnimationMinDuration(tool string) time.Duration {
-	if session.IsClaudeCompatible(tool) || tool == "gemini" {
+	if session.IsClaudeCompatible(tool) || tool == "gemini" || tool == "antigravity" {
 		return minLaunchAnimationDurationClaude
 	}
 	return minLaunchAnimationDurationDefault
@@ -3787,7 +3787,7 @@ func (h *Home) backgroundStatusUpdate() {
 	// Feed hook statuses from watcher to instances (enables hook fast path in UpdateStatus)
 	if h.hookWatcher != nil {
 		for _, inst := range instances {
-			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "hermes" || inst.Tool == "cursor" {
+			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "antigravity" || inst.Tool == "hermes" || inst.Tool == "cursor" {
 				if hs := h.hookWatcher.GetHookStatus(inst.ID); hs != nil {
 					inst.UpdateHookStatus(hs)
 				}
@@ -5323,7 +5323,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		inst := h.instanceByID[msg.instanceID]
 		h.instancesMu.RUnlock()
 		if inst != nil {
-			if err := inst.SetGeminiModel(msg.model); err != nil {
+			var err error
+			switch inst.Tool {
+			case "gemini":
+				err = inst.SetGeminiModel(msg.model)
+			case "antigravity":
+				err = inst.SetAntigravityModel(msg.model)
+			default:
+				err = fmt.Errorf("model selection is not supported for tool %q", inst.Tool)
+			}
+			if err != nil {
 				h.err = fmt.Errorf("failed to set model: %w", err)
 				h.errTime = time.Now()
 			}
@@ -8392,10 +8401,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "ctrl+g":
-		// Open Gemini model selection dialog (only for Gemini sessions)
-		if inst := h.getSelectedSession(); inst != nil && inst.Tool == "gemini" {
-			cmd := h.geminiModelDialog.Show(inst.ID, inst.GeminiModel)
-			return h, cmd
+		// Open model selection dialog (Gemini / Antigravity sessions)
+		if inst := h.getSelectedSession(); inst != nil {
+			switch inst.Tool {
+			case "gemini":
+				cmd := h.geminiModelDialog.Show(inst.ID, inst.GeminiModel)
+				return h, cmd
+			case "antigravity":
+				cmd := h.geminiModelDialog.ShowAntigravity(inst.ID, inst.AntigravityModel)
+				return h, cmd
+			}
 		}
 		return h, nil
 
@@ -10225,6 +10240,8 @@ func createSessionTool(command string) (string, string) {
 		tool = "claude"
 	case "gemini":
 		tool = "gemini"
+	case "agy", "antigravity":
+		tool = "antigravity"
 	case "aider":
 		tool = "aider"
 	case "codex":
@@ -10257,6 +10274,9 @@ func applyCreateSessionToolOverrides(inst *session.Instance, tool string, gemini
 	}
 	if tool == "gemini" {
 		inst.SetGeminiYoloMode(geminiYoloMode)
+	}
+	if tool == "antigravity" {
+		inst.SetAntigravityYoloMode(geminiYoloMode)
 	}
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3057,7 +3057,7 @@ func (h *Home) hasActiveAnimation(sessionID string) bool {
 	// Strip ANSI for reliable pattern matching (preview cache now contains ANSI-rich content)
 	plainPreview := ansi.Strip(previewContent)
 
-	if animTool == "claude" || animTool == "gemini" {
+	if animTool == "claude" || animTool == "gemini" || animTool == "antigravity" {
 		// Claude ready indicators
 		agentReady := strings.Contains(plainPreview, "ctrl+c to interrupt") ||
 			strings.Contains(plainPreview, "No, and tell Claude what to do differently") ||
@@ -3073,6 +3073,13 @@ func (h *Home) hasActiveAnimation(sessionID string) bool {
 			agentReady = agentReady ||
 				strings.Contains(plainPreview, "▸") ||
 				strings.Contains(plainPreview, "gemini>")
+		}
+
+		if animTool == "antigravity" {
+			agentReady = agentReady ||
+				strings.Contains(plainPreview, "▸") ||
+				strings.Contains(plainPreview, "agy>") ||
+				strings.Contains(plainPreview, "antigravity>")
 		}
 
 		if agentReady {
@@ -3473,7 +3480,7 @@ func cleanPaneTitle(title string) string {
 	})
 	cleaned = strings.TrimSpace(cleaned)
 	switch cleaned {
-	case "", "Claude Code", "Gemini CLI", "Codex CLI":
+	case "", "Claude Code", "Gemini CLI", "Codex CLI", "Antigravity CLI":
 		return ""
 	}
 	return cleaned
@@ -6645,6 +6652,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.clearError()
 
 		geminiYoloMode := h.newDialog.IsGeminiYoloMode()
+		antigravityYoloMode := h.newDialog.IsAntigravityYoloMode()
 		sandboxMode := h.newDialog.IsSandboxEnabled()
 		multiRepoPaths, multiRepoEnabled := h.newDialog.GetMultiRepoPaths()
 		var additionalPaths []string
@@ -6685,6 +6693,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			worktreeRepoRoot,
 			branchName,
 			geminiYoloMode,
+			antigravityYoloMode,
 			sandboxMode,
 			toolOptionsJSON,
 			claudeExtraArgs,
@@ -8274,6 +8283,20 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					inst.GeminiYoloMode = &newYolo
 					toggled = true
 
+				case "antigravity":
+					currentYolo := false
+					if inst.AntigravityYoloMode != nil {
+						currentYolo = *inst.AntigravityYoloMode
+					} else {
+						userConfig, _ := session.LoadUserConfig()
+						if userConfig != nil {
+							currentYolo = userConfig.Antigravity.YoloMode
+						}
+					}
+					newYolo := !currentYolo
+					inst.AntigravityYoloMode = &newYolo
+					toggled = true
+
 				case "codex":
 					currentYolo := false
 					opts := inst.GetCodexOptions()
@@ -8769,6 +8792,7 @@ func (h *Home) confirmCreateDirectory() tea.Cmd {
 		"",
 		"",
 		"",
+		false,
 		false,
 		false,
 		pendingToolOpts,
@@ -10040,6 +10064,7 @@ func (h *Home) loadUIState() {
 func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	name, path, command, groupPath, worktreePath, worktreeRepoRoot, worktreeBranch string,
 	geminiYoloMode bool,
+	antigravityYoloMode bool,
 	sandboxEnabled bool,
 	toolOptionsJSON json.RawMessage,
 	claudeExtraArgs []string,
@@ -10110,7 +10135,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			}
 		}
 
-		applyCreateSessionToolOverrides(inst, tool, geminiYoloMode)
+		applyCreateSessionToolOverrides(inst, tool, geminiYoloMode, antigravityYoloMode)
 
 		// Apply generic tool options (claude, codex, etc.)
 		if len(toolOptionsJSON) > 0 {
@@ -10301,7 +10326,7 @@ func createSessionTool(command string) (string, string) {
 	return tool, command
 }
 
-func applyCreateSessionToolOverrides(inst *session.Instance, tool string, geminiYoloMode bool) {
+func applyCreateSessionToolOverrides(inst *session.Instance, tool string, geminiYoloMode, antigravityYoloMode bool) {
 	if inst == nil {
 		return
 	}
@@ -10309,7 +10334,7 @@ func applyCreateSessionToolOverrides(inst *session.Instance, tool string, gemini
 		inst.SetGeminiYoloMode(geminiYoloMode)
 	}
 	if tool == "antigravity" {
-		inst.SetAntigravityYoloMode(geminiYoloMode)
+		inst.SetAntigravityYoloMode(antigravityYoloMode)
 	}
 }
 
@@ -10560,7 +10585,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 	return h.createSessionInGroupWithWorktreeAndOptions(
 		name, projectPath, command, groupPath,
 		"", "", "", // no worktree
-		geminiYoloMode, false, toolOptionsJSON,
+		geminiYoloMode, false, false, toolOptionsJSON,
 		nil,        // no extra claude args (recent-session path)
 		"",         // no claude startup query (recent-session path)
 		"",         // no explicit model override
@@ -10643,7 +10668,7 @@ func (h *Home) quickCreateSessionAt(projectPath string) tea.Cmd {
 		name, projectPath, command,
 		"",         // empty group → creator derives from path via extractGroupPath
 		"", "", "", // no worktree
-		false, false, nil,
+		false, false, false, nil,
 		nil, // no extra claude args
 		"",  // no claude startup query
 		"",  // no explicit model override
@@ -14814,6 +14839,8 @@ func (h *Home) renderSessionItem(
 	showYolo := false
 	if instTool == "gemini" && inst.GeminiYoloMode != nil && *inst.GeminiYoloMode {
 		showYolo = true
+	} else if instTool == "antigravity" && inst.AntigravityYoloMode != nil && *inst.AntigravityYoloMode {
+		showYolo = true
 	} else if instTool == "codex" {
 		if opts := inst.GetCodexOptions(); opts != nil && opts.YoloMode != nil && *opts.YoloMode {
 			showYolo = true
@@ -15339,6 +15366,13 @@ func (h *Home) renderLaunchingState(inst *session.Instance, width int, startTime
 		} else {
 			toolDesc = "Connecting to Gemini..."
 		}
+	case "antigravity":
+		toolName = "Antigravity CLI"
+		if isResuming {
+			toolDesc = "Resuming Antigravity session..."
+		} else {
+			toolDesc = "Connecting to Antigravity..."
+		}
 	case "aider":
 		toolName = "Aider"
 		if isResuming {
@@ -15630,6 +15664,9 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 	sessionID := inst.ClaudeSessionID
 	if sessionID == "" {
 		sessionID = inst.GeminiSessionID
+	}
+	if sessionID == "" {
+		sessionID = inst.AntigravityConversationID
 	}
 	if sessionID == "" {
 		sessionID = inst.OpenCodeSessionID
@@ -16146,6 +16183,37 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		}
 	}
 
+	// Antigravity-specific info (conversation ID)
+	if selected.Tool == "antigravity" {
+		agyHeader := renderSectionDivider("Antigravity", width-4)
+		b.WriteString(agyHeader)
+		b.WriteString("\n")
+
+		labelStyle := lipgloss.NewStyle().Foreground(ColorText)
+		valueStyle := lipgloss.NewStyle().Foreground(ColorText)
+
+		if selected.AntigravityConversationID != "" {
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selectedStatus)
+			b.WriteString(labelStyle.Render("Status:  "))
+			b.WriteString(statusStyle.Render(statusText))
+			b.WriteString("\n")
+
+			b.WriteString(labelStyle.Render("Conversation: "))
+			b.WriteString(valueStyle.Render(selected.AntigravityConversationID))
+			b.WriteString("\n")
+			renderLaunchModelInfoLines(&b, selected)
+
+			mcpInfo := selected.GetMCPInfo()
+			renderSimpleMCPLine(&b, mcpInfo, width)
+		} else {
+			statusStyle := lipgloss.NewStyle().Foreground(ColorText)
+			b.WriteString(labelStyle.Render("Status:  "))
+			b.WriteString(statusStyle.Render("○ Not connected"))
+			b.WriteString("\n")
+			renderLaunchModelInfoLines(&b, selected)
+		}
+	}
+
 	// Cursor Agent CLI — MCP configuration for `cursor agent`
 	if selected.Tool == "cursor" {
 		cursorHeader := renderSectionDivider("Cursor", width-4)
@@ -16238,7 +16306,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 
 	// Custom tool info (tools defined in config.toml that aren't built-in)
 	if !session.IsClaudeCompatible(selected.Tool) && selected.Tool != "gemini" && selected.Tool != "opencode" &&
-		selected.Tool != "codex" {
+		selected.Tool != "codex" && selected.Tool != "antigravity" {
 		if toolDef := session.GetToolDef(selected.Tool); toolDef != nil {
 			toolName := selected.Tool
 			if toolDef.Icon != "" {

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -153,6 +153,13 @@ func TestCreateSessionTool_Crush(t *testing.T) {
 	}
 }
 
+func TestCreateSessionTool_Antigravity(t *testing.T) {
+	tool, command := createSessionTool("agy")
+	if tool != "antigravity" || command != "agy" {
+		t.Fatalf("createSessionTool(\"agy\") = (%q, %q), want (\"antigravity\", \"agy\")", tool, command)
+	}
+}
+
 // TUI session creation must produce Tool="hermes" rather than
 // Tool="shell" with Command="hermes", matching the tmux/userconfig
 // wiring for the Hermes Agent CLI integration.

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -50,7 +50,7 @@ func TestNewHome_DisablesTmuxNotificationsWhenStatusInjectionDisabled(t *testing
 
 func TestApplyCreateSessionToolOverrides_GeminiExplicitFalsePersists(t *testing.T) {
 	inst := session.NewInstanceWithTool("gemini-test", "/tmp/test", "gemini")
-	applyCreateSessionToolOverrides(inst, "gemini", false)
+	applyCreateSessionToolOverrides(inst, "gemini", false, false)
 	if inst.GeminiYoloMode == nil {
 		t.Fatal("GeminiYoloMode should be set when Gemini YOLO is explicitly disabled")
 	}
@@ -59,11 +59,25 @@ func TestApplyCreateSessionToolOverrides_GeminiExplicitFalsePersists(t *testing.
 	}
 }
 
+func TestApplyCreateSessionToolOverrides_AntigravityExplicitFalsePersists(t *testing.T) {
+	inst := session.NewInstanceWithTool("agy-test", "/tmp/test", "antigravity")
+	applyCreateSessionToolOverrides(inst, "antigravity", false, false)
+	if inst.AntigravityYoloMode == nil {
+		t.Fatal("AntigravityYoloMode should be set when Antigravity YOLO is explicitly disabled")
+	}
+	if *inst.AntigravityYoloMode {
+		t.Fatal("AntigravityYoloMode should be false when Antigravity YOLO is explicitly disabled")
+	}
+}
+
 func TestApplyCreateSessionToolOverrides_NonGeminiNoop(t *testing.T) {
 	inst := session.NewInstanceWithTool("claude-test", "/tmp/test", "claude")
-	applyCreateSessionToolOverrides(inst, "claude", true)
+	applyCreateSessionToolOverrides(inst, "claude", true, true)
 	if inst.GeminiYoloMode != nil {
 		t.Fatalf("GeminiYoloMode = %v, want nil for non-gemini tools", inst.GeminiYoloMode)
+	}
+	if inst.AntigravityYoloMode != nil {
+		t.Fatalf("AntigravityYoloMode = %v, want nil for non-antigravity tools", inst.AntigravityYoloMode)
 	}
 }
 

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -172,9 +172,14 @@ func (m *MCPDialog) Show(projectPath string, sessionID string, tool string) erro
 	m.userAttached = nil
 	m.userAvailable = nil
 
-	if tool == "gemini" {
-		// Gemini: Only global MCPs from settings.json
-		mcpInfo := session.GetGeminiMCPInfo(projectPath)
+	if tool == "gemini" || tool == "antigravity" {
+		// Gemini / Antigravity: Only global MCPs from settings.json or mcp_config.json
+		var mcpInfo *session.MCPInfo
+		if tool == "antigravity" {
+			mcpInfo = session.GetAntigravityMCPInfo(projectPath)
+		} else {
+			mcpInfo = session.GetGeminiMCPInfo(projectPath)
+		}
 		globalAttachedNames := make(map[string]bool)
 		for _, name := range mcpInfo.Global {
 			globalAttachedNames[name] = true
@@ -339,8 +344,8 @@ func (m *MCPDialog) Show(projectPath string, sessionID string, tool string) erro
 
 	m.visible = true
 	m.projectPath = projectPath
-	// Gemini only has global scope; Cursor uses LOCAL+GLOBAL (no USER); Claude uses all three
-	if tool == "gemini" {
+	// Gemini / Antigravity only have global scope; Cursor uses LOCAL+GLOBAL (no USER); Claude uses all three
+	if tool == "gemini" || tool == "antigravity" {
 		m.scope = MCPScopeGlobal
 	} else if tool == "cursor" {
 		switch session.GetMCPDefaultScope() {
@@ -586,15 +591,21 @@ func (m *MCPDialog) Apply() error {
 		slog.Bool("user_changed", m.userChanged),
 		slog.String("project_path", m.projectPath))
 
-	if m.tool == "gemini" {
-		// Gemini: Only global scope, write to settings.json
+	if m.tool == "gemini" || m.tool == "antigravity" {
+		// Gemini / Antigravity: Only global scope
 		if m.globalChanged {
 			enabledNames := make([]string, len(m.globalAttached))
 			for i, item := range m.globalAttached {
 				enabledNames[i] = item.Name
 			}
 
-			if err := session.WriteGeminiMCPSettings(enabledNames); err != nil {
+			var err error
+			if m.tool == "antigravity" {
+				err = session.WriteAntigravityMCPSettings(enabledNames)
+			} else {
+				err = session.WriteGeminiMCPSettings(enabledNames)
+			}
+			if err != nil {
 				m.err = err
 				return err
 			}
@@ -704,7 +715,7 @@ func (m *MCPDialog) Update(msg tea.KeyMsg) (*MCPDialog, tea.Cmd) {
 		// Switch scope: LOCAL -> GLOBAL -> USER -> LOCAL (Claude only)
 		// Gemini only has global scope, so Tab does nothing
 		// Cursor: LOCAL <-> GLOBAL only
-		if m.tool == "gemini" {
+		if m.tool == "gemini" || m.tool == "antigravity" {
 			// no-op
 		} else if m.tool == "cursor" {
 			switch m.scope {
@@ -771,6 +782,8 @@ func (m *MCPDialog) View() string {
 	switch m.tool {
 	case "gemini":
 		title = "MCP Manager (Gemini)"
+	case "antigravity":
+		title = "MCP Manager (Antigravity)"
 	case "cursor":
 		title = "MCP Manager (Cursor)"
 	}
@@ -778,7 +791,7 @@ func (m *MCPDialog) View() string {
 	// Scope tabs - Gemini only global; Cursor LOCAL+GLOBAL; Claude all three
 	var tabs string
 	switch m.tool {
-	case "gemini":
+	case "gemini", "antigravity":
 		globalTab := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent).Render("[GLOBAL]")
 		tabs = "──────────────── " + globalTab + " ────────────────"
 	case "cursor":
@@ -860,6 +873,8 @@ func (m *MCPDialog) View() string {
 	switch m.tool {
 	case "gemini":
 		scopeDesc = DimStyle.Render("Writes to: ~/.gemini/settings.json")
+	case "antigravity":
+		scopeDesc = DimStyle.Render("Writes to: ~/.gemini/config/mcp_config.json")
 	case "cursor":
 		switch m.scope {
 		case MCPScopeLocal:
@@ -898,7 +913,7 @@ func (m *MCPDialog) View() string {
 	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	var hint string
 	switch m.tool {
-	case "gemini":
+	case "gemini", "antigravity":
 		hint = hintStyle.Render("←→ column │ Type jump │ Space move │ Enter apply │ Esc cancel")
 	case "cursor":
 		hint = hintStyle.Render("Tab scope │ ←→ column │ Type jump │ Space move │ Enter apply │ Esc cancel")

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -261,7 +261,7 @@ func displayCommandPreset(cmd string) string {
 // flag off FilterVisibleToolNames is a no-op, so the list is byte-identical to
 // before.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	presets := []string{"", "claude", "gemini", "antigravity", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}
@@ -909,6 +909,14 @@ func knownModelIDsForTool(tool string) []string {
 			"gemini-2.5-flash",
 			"gemini-2.5-flash-lite",
 		}
+	case tool == "antigravity":
+		return []string{
+			"gemini-2.5-pro",
+			"gemini-2.5-flash",
+			"gemini-2.5-flash-lite",
+			"gemini-3-flash-preview",
+			"gemini-3.1-pro-preview",
+		}
 	case tool == "opencode":
 		return []string{
 			"openai/gpt-5.5",
@@ -969,6 +977,8 @@ func preselectDefaultModel(config *session.UserConfig, tool string) string {
 	switch {
 	case session.IsClaudeCompatible(tool):
 		configured = config.Claude.DefaultModel
+	case tool == "antigravity":
+		configured = config.Antigravity.DefaultModel
 	default:
 		return ""
 	}
@@ -1206,6 +1216,8 @@ func (d *NewDialog) updateModelPlaceholder() {
 		d.modelInput.Placeholder = "claude-sonnet-4-6"
 	case cmd == "gemini":
 		d.modelInput.Placeholder = "gemini-3.1-pro-preview"
+	case cmd == "antigravity":
+		d.modelInput.Placeholder = "gemini-2.5-flash"
 	case cmd == "opencode":
 		d.modelInput.Placeholder = "openai/gpt-5.5"
 	case session.IsCodexCompatible(cmd):
@@ -1221,6 +1233,8 @@ func (d *NewDialog) modelInputHint() string {
 		return "Examples: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5"
 	case cmd == "gemini":
 		return "Examples: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-2.5-pro"
+	case cmd == "antigravity":
+		return "Examples: gemini-2.5-flash, gemini-2.5-pro, gemini-3-flash-preview"
 	case cmd == "opencode":
 		return "Examples: openai/gpt-5.5, openai/gpt-5.4, anthropic/claude-sonnet-4-6"
 	case session.IsCodexCompatible(cmd):
@@ -1413,7 +1427,7 @@ func (d *NewDialog) updateToolOptions() {
 	switch {
 	case session.IsClaudeCompatible(cmd):
 		d.toolOptions = d.claudeOptions
-	case cmd == "gemini":
+	case cmd == "gemini", cmd == "antigravity":
 		d.toolOptions = d.geminiOptions
 	case cmd == "codex":
 		d.toolOptions = d.codexOptions
@@ -2122,7 +2136,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		case "y":
 			if !d.isTextInputFocused() {
 				selectedCmd := d.GetSelectedCommand()
-				if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "codex" || selectedCmd == "hermes") && d.toolOptions != nil {
+				if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "antigravity" || selectedCmd == "codex" || selectedCmd == "hermes") && d.toolOptions != nil {
 					d.toolOptions.Update(msg)
 					return d, nil
 				}
@@ -2739,7 +2753,7 @@ func (d *NewDialog) View() string {
 		}
 	} else if cur == focusCommand {
 		selectedCmd := d.GetSelectedCommand()
-		if selectedCmd == "gemini" || selectedCmd == "codex" || selectedCmd == "hermes" {
+		if selectedCmd == "gemini" || selectedCmd == "antigravity" || selectedCmd == "codex" || selectedCmd == "hermes" {
 			helpText = "←→ command │ w worktree │ s sandbox │ y yolo │ Tab next │ ^S create │ Esc cancel"
 		} else {
 			helpText = "←→ command │ w worktree │ s sandbox │ Tab next │ ^S create │ Esc cancel"

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -161,6 +161,7 @@ type NewDialog struct {
 	modelInput            textinput.Model
 	claudeOptions         *ClaudeOptionsPanel // Claude-specific options (concrete for value extraction).
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
+	antigravityOptions    *YoloOptionsPanel   // Antigravity YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
 	hermesOptions         *YoloOptionsPanel   // Hermes YOLO panel (concrete for value extraction).
 	toolOptions           OptionsPanel        // Currently active tool options panel (nil if none).
@@ -236,6 +237,7 @@ type dialogSnapshot struct {
 	branchAutoSet    bool
 	claudeOptions    *session.ClaudeOptions
 	geminiYolo       bool
+	antigravityYolo  bool
 	codexYolo        bool
 	hermesYolo       bool
 	multiRepoEnabled bool
@@ -370,6 +372,7 @@ func NewNewDialog() *NewDialog {
 		branchPicker:    NewBranchPickerDialog(),
 		claudeOptions:   NewClaudeOptionsPanel(),
 		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
+		antigravityOptions: NewYoloOptionsPanel("Antigravity", "YOLO mode - auto-approve all"),
 		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
 		hermesOptions:   NewYoloOptionsPanel("Hermes", "YOLO mode - auto-approve all tool calls"),
 		focusIndex:      0,
@@ -427,6 +430,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.claudeOptions.Blur()
 	d.claudeOptions.ResetStartQuery() // #741: per-session query must not leak across openings
 	d.geminiOptions.Blur()
+	d.antigravityOptions.Blur()
 	d.codexOptions.Blur()
 	if d.branchPicker != nil {
 		d.branchPicker.Hide()
@@ -460,10 +464,12 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.pathSoftSelected = true // activate soft-select for pre-filled path.
 	// Initialize tool options from global config.
 	d.geminiOptions.SetDefaults(false)
+	d.antigravityOptions.SetDefaults(false)
 	d.codexOptions.SetDefaults(false)
 	d.hermesOptions.SetDefaults(false)
 	if userConfig, err := session.LoadUserConfig(); err == nil && userConfig != nil {
 		d.geminiOptions.SetDefaults(userConfig.Gemini.YoloMode)
+		d.antigravityOptions.SetDefaults(userConfig.Antigravity.YoloMode)
 		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode)
 		d.hermesOptions.SetDefaults(userConfig.Hermes.YoloMode)
 		d.claudeOptions.SetDefaults(userConfig)
@@ -743,6 +749,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		branchAutoSet:    d.branchAutoSet,
 		claudeOptions:    claudeOpts,
 		geminiYolo:       d.geminiOptions.GetYoloMode(),
+		antigravityYolo:  d.antigravityOptions.GetYoloMode(),
 		codexYolo:        d.codexOptions.GetYoloMode(),
 		hermesYolo:       d.hermesOptions.GetYoloMode(),
 		multiRepoEnabled: d.multiRepoEnabled,
@@ -767,6 +774,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 		d.claudeOptions.SetFromOptions(s.claudeOptions)
 	}
 	d.geminiOptions.SetDefaults(s.geminiYolo)
+	d.antigravityOptions.SetDefaults(s.antigravityYolo)
 	d.codexOptions.SetDefaults(s.codexYolo)
 	d.hermesOptions.SetDefaults(s.hermesYolo)
 	d.multiRepoEnabled = s.multiRepoEnabled
@@ -825,6 +833,10 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 		case rs.Tool == "gemini":
 			if rs.GeminiYoloMode != nil {
 				d.geminiOptions.SetDefaults(*rs.GeminiYoloMode)
+			}
+		case rs.Tool == "antigravity":
+			if rs.AntigravityYoloMode != nil {
+				d.antigravityOptions.SetDefaults(*rs.AntigravityYoloMode)
 			}
 		case rs.Tool == "codex":
 			var wrapper session.ToolOptionsWrapper
@@ -1122,6 +1134,11 @@ func (d *NewDialog) GetValuesWithWorktree() (name, path, command, branch string,
 // IsGeminiYoloMode returns whether YOLO mode is enabled for Gemini
 func (d *NewDialog) IsGeminiYoloMode() bool {
 	return d.geminiOptions.GetYoloMode()
+}
+
+// IsAntigravityYoloMode returns whether YOLO mode is enabled for Antigravity
+func (d *NewDialog) IsAntigravityYoloMode() bool {
+	return d.antigravityOptions.GetYoloMode()
 }
 
 // GetCodexYoloMode returns the Codex YOLO mode state
@@ -1427,8 +1444,10 @@ func (d *NewDialog) updateToolOptions() {
 	switch {
 	case session.IsClaudeCompatible(cmd):
 		d.toolOptions = d.claudeOptions
-	case cmd == "gemini", cmd == "antigravity":
+	case cmd == "gemini":
 		d.toolOptions = d.geminiOptions
+	case cmd == "antigravity":
+		d.toolOptions = d.antigravityOptions
 	case cmd == "codex":
 		d.toolOptions = d.codexOptions
 	case cmd == "hermes":

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -23,6 +23,7 @@ const (
 	SettingGeminiYoloMode
 	SettingCodexYoloMode
 	SettingHermesYoloMode
+	SettingAntigravityYoloMode
 	SettingCheckForUpdates
 	SettingAutoUpdate
 	SettingLogMaxSize
@@ -53,7 +54,7 @@ const (
 )
 
 // Total number of navigable settings.
-const settingsCount = 34
+const settingsCount = 35
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -77,6 +78,7 @@ type SettingsPanel struct {
 	geminiYoloMode      bool
 	codexYoloMode       bool
 	hermesYoloMode      bool
+	antigravityYoloMode bool
 	checkForUpdates     bool
 	autoUpdate          bool
 	logMaxSizeMB        int
@@ -267,6 +269,9 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 	// Hermes settings
 	s.hermesYoloMode = config.Hermes.YoloMode
 
+	// Antigravity settings
+	s.antigravityYoloMode = config.Antigravity.YoloMode
+
 	// Update settings
 	s.checkForUpdates = config.Updates.GetCheckEnabled()
 	s.autoUpdate = config.Updates.AutoUpdate
@@ -407,6 +412,9 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 
 	// Hermes settings
 	config.Hermes.YoloMode = s.hermesYoloMode
+
+	// Antigravity settings
+	config.Antigravity.YoloMode = s.antigravityYoloMode
 
 	// Update settings
 	checkForUpdates := s.checkForUpdates
@@ -674,6 +682,10 @@ func (s *SettingsPanel) toggleValue() bool {
 		s.hermesYoloMode = !s.hermesYoloMode
 		return true
 
+	case SettingAntigravityYoloMode:
+		s.antigravityYoloMode = !s.antigravityYoloMode
+		return true
+
 	case SettingCheckForUpdates:
 		s.checkForUpdates = !s.checkForUpdates
 		return true
@@ -928,6 +940,17 @@ func (s *SettingsPanel) View() string {
 	// YOLO mode checkbox
 	line = s.renderCheckbox("YOLO mode", s.hermesYoloMode) + " - Auto-approve all tool calls"
 	if s.cursor == int(SettingHermesYoloMode) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
+
+	// ANTIGRAVITY
+	content.WriteString(sectionStyle.Render("ANTIGRAVITY"))
+	content.WriteString("\n")
+
+	// YOLO mode checkbox
+	line = s.renderCheckbox("YOLO mode", s.antigravityYoloMode) + " - Auto-approve all actions"
+	if s.cursor == int(SettingAntigravityYoloMode) {
 		line = highlightStyle.Render(line)
 	}
 	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
@@ -1188,33 +1211,34 @@ func (s *SettingsPanel) View() string {
 			15, // SettingGeminiYoloMode
 			18, // SettingCodexYoloMode
 			21, // SettingHermesYoloMode
-			24, // SettingCheckForUpdates
-			25, // SettingAutoUpdate
-			28, // SettingLogMaxSize
-			28, // SettingLogMaxLines (shares line with LogMaxSize)
-			29, // SettingRemoveOrphans
-			32, // SettingGlobalSearchEnabled
-			33, // SettingSearchTier
-			34, // SettingRecentDays
-			37, // SettingShowOutput
-			38, // SettingShowAnalytics
-			39, // SettingShowNotes
-			40, // SettingNotesOutputSplit
-			43, // SettingMaintenanceEnabled
-			46, // SettingStatsEnabled
-			47, // SettingStatsRefresh
-			48, // SettingStatsFormat
-			50, // SettingStatsShowCPU (row with RAM, Disk)
-			50, // SettingStatsShowRAM
-			50, // SettingStatsShowDisk
-			51, // SettingStatsShowNetwork (row with GPU, Load)
-			51, // SettingStatsShowGPU
-			51, // SettingStatsShowLoad
-			54, // SettingSyncTitle (SESSIONS section, after stats)
-			57, // SettingShowSessionTimestamps (DISPLAY section, after SESSIONS)
-			58, // SettingShowPaneTitles (DISPLAY section, after timestamps)
-			61, // SettingShowOnlyInstalledTools (TOOL PICKER section)
-			62, // SettingVisibleTools
+			24, // SettingAntigravityYoloMode
+			27, // SettingCheckForUpdates
+			28, // SettingAutoUpdate
+			31, // SettingLogMaxSize
+			31, // SettingLogMaxLines (shares line with LogMaxSize)
+			32, // SettingRemoveOrphans
+			35, // SettingGlobalSearchEnabled
+			36, // SettingSearchTier
+			37, // SettingRecentDays
+			40, // SettingShowOutput
+			41, // SettingShowAnalytics
+			42, // SettingShowNotes
+			43, // SettingNotesOutputSplit
+			46, // SettingMaintenanceEnabled
+			49, // SettingStatsEnabled
+			50, // SettingStatsRefresh
+			51, // SettingStatsFormat
+			53, // SettingStatsShowCPU (row with RAM, Disk)
+			53, // SettingStatsShowRAM
+			53, // SettingStatsShowDisk
+			54, // SettingStatsShowNetwork (row with GPU, Load)
+			54, // SettingStatsShowGPU
+			54, // SettingStatsShowLoad
+			57, // SettingSyncTitle (SESSIONS section, after stats)
+			60, // SettingShowSessionTimestamps (DISPLAY section, after SESSIONS)
+			61, // SettingShowPaneTitles (DISPLAY section, after timestamps)
+			64, // SettingShowOnlyInstalledTools (TOOL PICKER section)
+			65, // SettingVisibleTools
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -413,7 +413,12 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 	// Hermes settings
 	config.Hermes.YoloMode = s.hermesYoloMode
 
-	// Antigravity settings
+	// Antigravity settings — preserve the full struct so DefaultModel,
+	// EnvFile, and Command survive a Settings TUI save. Without this, the
+	// panel-managed YoloMode toggle would zero out unrelated fields.
+	if s.originalConfig != nil {
+		config.Antigravity = s.originalConfig.Antigravity
+	}
 	config.Antigravity.YoloMode = s.antigravityYoloMode
 
 	// Update settings

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"},
+		toolOptions:         []string{"claude", "gemini", "antigravity", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,
@@ -387,7 +387,8 @@ func (w *SetupWizard) View() string {
 
 		toolDescriptions := map[string]string{
 			"claude":   "Claude Code - Anthropic's AI coding assistant",
-			"gemini":   "Gemini CLI - Google's AI assistant",
+			"gemini":      "Gemini CLI - Google's AI assistant",
+			"antigravity": "Antigravity CLI (agy) - Google's terminal agent harness",
 			"opencode": "OpenCode - Open source AI coding tool",
 			"codex":    "Codex CLI - OpenAI's coding assistant",
 			"pi":       "Pi CLI - lightweight coding assistant",

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"}
+	expectedTools := []string{"claude", "gemini", "antigravity", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -598,6 +598,8 @@ func ToolIcon(tool string) string {
 		return IconClaude
 	case "gemini":
 		return IconGemini
+	case "antigravity":
+		return "🛸"
 	case "opencode":
 		return IconOpenCode
 	case "codex":
@@ -627,6 +629,8 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorOrange // Anthropic's orange
 	case "gemini":
 		return ColorPurple // Google AI purple
+	case "antigravity":
+		return ColorPurple
 	case "codex":
 		return ColorCyan // Light blue for OpenAI
 	case "copilot":

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -518,8 +518,9 @@ func initStyles() {
 
 	// ToolStyleCache - reinitialize with current theme colors
 	ToolStyleCache = map[string]lipgloss.Style{
-		"claude":   lipgloss.NewStyle().Foreground(ColorOrange),
-		"gemini":   lipgloss.NewStyle().Foreground(ColorPurple),
+		"claude":      lipgloss.NewStyle().Foreground(ColorOrange),
+		"gemini":      lipgloss.NewStyle().Foreground(ColorPurple),
+		"antigravity": lipgloss.NewStyle().Foreground(ColorCyan),
 		"codex":    lipgloss.NewStyle().Foreground(ColorCyan),
 		"copilot":  lipgloss.NewStyle().Foreground(ColorAccent),
 		"hermes":   lipgloss.NewStyle().Foreground(ColorYellow),

--- a/internal/ui/tool_visibility_panel.go
+++ b/internal/ui/tool_visibility_panel.go
@@ -13,7 +13,7 @@ import (
 
 // pickerToolNames lists built-in tools shown in the new-session picker (shell excluded).
 var pickerToolNames = []string{
-	"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes",
+	"claude", "gemini", "antigravity", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes",
 }
 
 // ToolVisibilityPanel edits [ui].hidden_tools via a checklist overlay.

--- a/internal/ui/tool_visibility_panel.go
+++ b/internal/ui/tool_visibility_panel.go
@@ -77,7 +77,7 @@ func (p *ToolVisibilityPanel) LoadConfig(config *session.UserConfig) {
 	names := append([]string{}, pickerToolNames...)
 	if config != nil && len(config.Tools) > 0 {
 		builtins := map[string]bool{
-			"claude": true, "gemini": true, "opencode": true, "codex": true,
+			"claude": true, "gemini": true, "antigravity": true, "opencode": true, "codex": true,
 			"pi": true, "copilot": true, "crush": true, "cursor": true, "hermes": true,
 			"shell": true, "aider": true,
 		}

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -94,6 +94,9 @@ type MenuSession struct {
 	GeminiSessionID   string `json:"geminiSessionId,omitempty"`
 	GeminiModel       string `json:"geminiModel,omitempty"`
 	GeminiYoloMode    *bool  `json:"geminiYoloMode,omitempty"`
+	AntigravityConversationID string `json:"antigravityConversationId,omitempty"`
+	AntigravityModel          string `json:"antigravityModel,omitempty"`
+	AntigravityYoloMode       *bool  `json:"antigravityYoloMode,omitempty"`
 	CodexSessionID    string `json:"codexSessionId,omitempty"`
 	OpenCodeSessionID string `json:"opencodeSessionId,omitempty"`
 
@@ -255,6 +258,9 @@ func toMenuSession(inst *session.Instance) *MenuSession {
 		GeminiSessionID:    inst.GeminiSessionID,
 		GeminiModel:        inst.GeminiModel,
 		GeminiYoloMode:     inst.GeminiYoloMode,
+		AntigravityConversationID: inst.AntigravityConversationID,
+		AntigravityModel:          inst.AntigravityModel,
+		AntigravityYoloMode:       inst.AntigravityYoloMode,
 		CodexSessionID:     inst.CodexSessionID,
 		OpenCodeSessionID:  inst.OpenCodeSessionID,
 		LatestPrompt:       inst.LatestPrompt,

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -59,6 +59,9 @@ RUN npm install -g @openai/codex@0
 # Pin major version; update periodically.
 RUN npm install -g @google/gemini-cli@0
 
+# ── Antigravity CLI (Google) ──────────────────────────────────────
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
+
 # Pre-create credential directories for auth volume mounts.
 RUN mkdir -p /root/.claude \
     /root/.config/opencode \

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -8,6 +8,7 @@ All options for `~/.agent-deck/config.toml`.
 - [[shell] Section](#shell-section)
 - [[claude] Section](#claude-section)
 - [[gemini] Section](#gemini-section)
+- [[antigravity] Section](#antigravity-section)
 - [[opencode] Section](#opencode-section)
 - [[codex] Section](#codex-section)
 - [[copilot] Section](#copilot-section)
@@ -160,6 +161,27 @@ command = "gemini"                   # Binary/invocation override
 | `default_model` | string | `""` | Model to use (e.g., `"gemini-2.5-flash"`). Empty uses Gemini's default. |
 | `env_file` | string | `""` | A .env file sourced for Gemini sessions only. See [Path Resolution](#path-resolution). |
 | `command` | string | `"gemini"` | Override the binary/invocation. Supports flags. |
+
+## [antigravity] Section
+
+Antigravity CLI (`agy`) integration settings. Shares the `~/.gemini/` config root with Gemini CLI.
+
+```toml
+[antigravity]
+yolo_mode = true                         # Enable --dangerously-skip-permissions
+default_model = "gemini-2.5-flash"       # Model override for new conversations
+env_file = "~/.antigravity.env"          # .env file for Antigravity sessions
+command = "agy"                          # Binary/invocation override
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `yolo_mode` | bool | `false` | Maps to `agy --dangerously-skip-permissions`. |
+| `default_model` | string | `""` | Model for new conversations. Empty uses Antigravity's default. |
+| `env_file` | string | `""` | A .env file sourced for Antigravity sessions only. See [Path Resolution](#path-resolution). |
+| `command` | string | `"agy"` | Override the binary/invocation. Supports flags. |
+
+Resume uses `agy --conversation <uuid>` (not `--continue`). Install hooks with `agent-deck antigravity-hooks install`.
 
 ## [opencode] Section
 


### PR DESCRIPTION
Introduces Antigravity (`agy`) CLI support, enabling session management through TUI, CLI, and web API. New features include session launching via `agy`, conversation UUID persistence, and YOLO mode configuration. Added integration tests for CLI commands, hooks, and session data persistence. Updates to documentation and configuration files reflect these changes.

- New built-in tool support for Antigravity
- Integration tests for CLI commands and hooks
- Configuration updates for Antigravity settings

Re-opened from a clean feature branch (replaces #1520) so CI runs properly — the previous PR was based on `main` directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class Antigravity (agy) support across session lifecycle, TUI, tmux syncing, model selection, hook management, MCP settings, and the web session view.
  * Introduced `antigravity-hooks` / `antigravity-hook` commands with install/uninstall/status and hook event handling.
  * Added YOLO-mode controls and persistent Antigravity session/resume state.
* **Bug Fixes**
  * Improved hook/status handling and expanded “agent turn started” status mapping for more consistent session state.
* **Tests / Chores**
  * Expanded Antigravity integration test coverage and updated the sandbox image to include the Antigravity CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->