### PR TITLE
feat: preseed Codex workspace trust on session launch

### DIFF
--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -28,6 +28,12 @@ const (
 	defaultImage = "agent-deck-sandbox:latest"
 )
 
+// ContainerWorkDir returns the workspace path inside sandbox containers.
+func ContainerWorkDir() string {
+	return containerWorkDir
+}
+
+
 // claudeHomeSeed is the ~/.claude.json seeded into sandbox containers.
 // Beyond global onboarding, it pre-trusts /workspace (the sandbox project
 // mount): Claude Code discovers project-scope plugins (.claude/skills

--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -33,7 +33,6 @@ func ContainerWorkDir() string {
 	return containerWorkDir
 }
 
-
 // claudeHomeSeed is the ~/.claude.json seeded into sandbox containers.
 // Beyond global onboarding, it pre-trusts /workspace (the sandbox project
 // mount): Claude Code discovers project-scope plugins (.claude/skills

--- a/internal/session/codex_trust.go
+++ b/internal/session/codex_trust.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 
 	"github.com/BurntSushi/toml"
 	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
@@ -14,6 +16,49 @@ import (
 )
 
 const codexTrustLevelTrusted = "trusted"
+
+// codexConfigMu serializes mutations to a given Codex config.toml within this
+// process. Cross-process serialization uses advisory flock on a sibling
+// `.lock` file (see acquireCodexConfigLock), matching hermes_hooks.go.
+var codexConfigMu sync.Map // map[string]*sync.Mutex
+
+type codexConfigLock struct {
+	inProc *sync.Mutex
+	file   *os.File
+}
+
+func (l *codexConfigLock) Release() {
+	if l.file != nil {
+		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+		_ = l.file.Close()
+	}
+	if l.inProc != nil {
+		l.inProc.Unlock()
+	}
+}
+
+func acquireCodexConfigLock(configPath string) (*codexConfigLock, error) {
+	mIface, _ := codexConfigMu.LoadOrStore(configPath, &sync.Mutex{})
+	m := mIface.(*sync.Mutex)
+	m.Lock()
+
+	lockPath := configPath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("ensure codex config lock dir: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("open codex config lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		m.Unlock()
+		return nil, fmt.Errorf("flock codex config: %w", err)
+	}
+	return &codexConfigLock{inProc: m, file: f}, nil
+}
 
 // GetCodexConfigPath returns the path to Codex's user-level config.toml under codexHome.
 func GetCodexConfigPath(codexHome string) string {
@@ -47,6 +92,12 @@ func PreAcceptCodexTrust(codexConfigPath, projectDir string) error {
 		projectDir = abs
 	}
 
+	lock, err := acquireCodexConfigLock(codexConfigPath)
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+
 	cfg := map[string]any{}
 	if data, err := os.ReadFile(codexConfigPath); err == nil {
 		if len(data) > 0 {
@@ -61,6 +112,11 @@ func PreAcceptCodexTrust(codexConfigPath, projectDir string) error {
 	projects, _ := cfg["projects"].(map[string]any)
 	if projects == nil {
 		projects = map[string]any{}
+	}
+	if entry, ok := projects[projectDir].(map[string]any); ok {
+		if trust, _ := entry["trust_level"].(string); trust == codexTrustLevelTrusted {
+			return nil
+		}
 	}
 	entry, _ := projects[projectDir].(map[string]any)
 	if entry == nil {

--- a/internal/session/codex_trust.go
+++ b/internal/session/codex_trust.go
@@ -1,0 +1,128 @@
+package session
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+	"github.com/asheshgoplani/agent-deck/internal/docker"
+)
+
+const codexTrustLevelTrusted = "trusted"
+
+// GetCodexConfigPath returns the path to Codex's user-level config.toml under codexHome.
+func GetCodexConfigPath(codexHome string) string {
+	return filepath.Join(codexHome, "config.toml")
+}
+
+// PreAcceptCodexTrust adds `projects[projectDir].trust_level = "trusted"` to the
+// Codex config at codexConfigPath, preserving all existing top-level fields and
+// project entries.
+//
+// Why this exists: Codex prompts "do you trust the files in this folder?" on first
+// launch in a directory, blocking unattended TUI/headless session starts. The
+// trust state is keyed by the literal projectDir string in ~/.codex/config.toml —
+// pre-seeding the entry skips the prompt the same way accepting it in the UI would.
+//
+// projectDir must be the workspace root Codex will see (absolute on the host for
+// normal sessions, /workspace inside sandbox containers).
+func PreAcceptCodexTrust(codexConfigPath, projectDir string) error {
+	if codexConfigPath == "" {
+		return fmt.Errorf("codexConfigPath is empty")
+	}
+	projectDir = strings.TrimSpace(projectDir)
+	if projectDir == "" {
+		return fmt.Errorf("projectDir is empty")
+	}
+	if !filepath.IsAbs(projectDir) {
+		abs, err := filepath.Abs(ExpandPath(projectDir))
+		if err != nil {
+			return fmt.Errorf("resolve absolute projectDir: %w", err)
+		}
+		projectDir = abs
+	}
+
+	cfg := map[string]any{}
+	if data, err := os.ReadFile(codexConfigPath); err == nil {
+		if len(data) > 0 {
+			if err := toml.Unmarshal(data, &cfg); err != nil {
+				return fmt.Errorf("parse %s: %w", codexConfigPath, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", codexConfigPath, err)
+	}
+
+	projects, _ := cfg["projects"].(map[string]any)
+	if projects == nil {
+		projects = map[string]any{}
+	}
+	entry, _ := projects[projectDir].(map[string]any)
+	if entry == nil {
+		entry = map[string]any{}
+	}
+	entry["trust_level"] = codexTrustLevelTrusted
+	projects[projectDir] = entry
+	cfg["projects"] = projects
+
+	if err := os.MkdirAll(filepath.Dir(codexConfigPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir parent of %s: %w", codexConfigPath, err)
+	}
+
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	if err := enc.Encode(cfg); err != nil {
+		return fmt.Errorf("marshal codex config: %w", err)
+	}
+	if err := atomicfile.WriteFile(codexConfigPath, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", codexConfigPath, err)
+	}
+	return nil
+}
+
+// ApplyMultiRepoCodexContext pre-accepts the Codex workspace-trust dialog for a
+// multi-repo parent directory. Only acts when tool is Codex-compatible AND
+// multiRepoEnabled is true. For sandboxed multi-repo sessions, trust for
+// /workspace is seeded separately during sandbox config sync.
+func ApplyMultiRepoCodexContext(tool string, multiRepoEnabled bool, parentDir string) error {
+	if !IsCodexCompatible(tool) || !multiRepoEnabled {
+		return nil
+	}
+	return PreAcceptCodexTrust(GetCodexConfigPath(getCodexHomeDir()), parentDir)
+}
+
+func (i *Instance) preAcceptCodexWorkspaceTrust() {
+	if i == nil || !IsCodexCompatible(i.Tool) {
+		return
+	}
+	if i.IsSandboxed() {
+		// Sandbox trust is seeded after agent config sync in ensureSandboxContainer
+		// so a host config.toml copy does not clobber the trust entry.
+		return
+	}
+	projectDir := i.EffectiveWorkingDir()
+	configPath := GetCodexConfigPath(i.getCodexHomeDir())
+	if err := PreAcceptCodexTrust(configPath, projectDir); err != nil {
+		sessionLog.Warn("codex_preaccept_trust_failed",
+			slog.String("instance_id", i.ID),
+			slog.String("path", projectDir),
+			slog.String("config", configPath),
+			slog.String("error", err.Error()))
+	}
+}
+
+// PreAcceptCodexSandboxWorkspaceTrust seeds trust for the sandbox workspace in
+// the host-side sandbox copy of ~/.codex/config.toml. Call after
+// docker.RefreshAgentConfigs so host file sync does not overwrite the entry.
+func PreAcceptCodexSandboxWorkspaceTrust(homeDir string) error {
+	if homeDir == "" {
+		return nil
+	}
+	configPath := filepath.Join(docker.SandboxDir(homeDir, ".codex"), "config.toml")
+	return PreAcceptCodexTrust(configPath, docker.ContainerWorkDir())
+}

--- a/internal/session/codex_trust_start_test.go
+++ b/internal/session/codex_trust_start_test.go
@@ -35,12 +35,18 @@ func TestPreAcceptCodexWorkspaceTrust_SeedsHostConfig(t *testing.T) {
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("unmarshal config: %v", err)
 	}
-	projects := cfg["projects"].(map[string]any)
+	projects, ok := cfg["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("projects key missing or wrong type: %T", cfg["projects"])
+	}
 	absProject, err := filepath.Abs(projectDir)
 	if err != nil {
 		t.Fatalf("abs project: %v", err)
 	}
-	entry := projects[absProject].(map[string]any)
+	entry, ok := projects[absProject].(map[string]any)
+	if !ok {
+		t.Fatalf("no trust entry for project dir %q in %s", absProject, configPath)
+	}
 	if entry["trust_level"] != codexTrustLevelTrusted {
 		t.Fatalf("trust_level = %v, want %s", entry["trust_level"], codexTrustLevelTrusted)
 	}

--- a/internal/session/codex_trust_start_test.go
+++ b/internal/session/codex_trust_start_test.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestPreAcceptCodexWorkspaceTrust_SeedsHostConfig(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	codexHome := filepath.Join(tmpHome, ".codex")
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	projectDir := filepath.Join(tmpHome, "my-repo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	inst := NewInstance("codex-trust", projectDir)
+	inst.Tool = "codex"
+	inst.Command = "codex"
+
+	inst.preAcceptCodexWorkspaceTrust()
+
+	configPath := GetCodexConfigPath(codexHome)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", configPath, err)
+	}
+	cfg := map[string]any{}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	projects := cfg["projects"].(map[string]any)
+	absProject, err := filepath.Abs(projectDir)
+	if err != nil {
+		t.Fatalf("abs project: %v", err)
+	}
+	entry := projects[absProject].(map[string]any)
+	if entry["trust_level"] != codexTrustLevelTrusted {
+		t.Fatalf("trust_level = %v, want %s", entry["trust_level"], codexTrustLevelTrusted)
+	}
+}
+
+func TestPreAcceptCodexWorkspaceTrust_SkipsSandbox(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	projectDir := filepath.Join(tmpHome, "sandbox-repo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	inst := NewInstance("codex-sandbox", projectDir)
+	inst.Tool = "codex"
+	inst.Command = "codex"
+	inst.Sandbox = &SandboxConfig{Enabled: true, Image: "example/sandbox:latest"}
+
+	inst.preAcceptCodexWorkspaceTrust()
+
+	configPath := GetCodexConfigPath(filepath.Join(tmpHome, ".codex"))
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("sandbox preAccept should not write host config, stat err=%v", err)
+	}
+}

--- a/internal/session/codex_trust_test.go
+++ b/internal/session/codex_trust_test.go
@@ -1,8 +1,10 @@
 package session_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -74,6 +76,80 @@ func TestPreAcceptCodexTrust_RejectsMalformedConfig(t *testing.T) {
 	}
 	if err := session.PreAcceptCodexTrust(configPath, dir); err == nil {
 		t.Fatal("expected error for malformed config")
+	}
+}
+
+func TestPreAcceptCodexTrust_SkipsRewriteWhenAlreadyTrusted(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	projectDir := filepath.Join(dir, "repo")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	absProject, err := filepath.Abs(projectDir)
+	if err != nil {
+		t.Fatalf("abs project: %v", err)
+	}
+	original := fmt.Sprintf(`# keep this comment
+model = "gpt-5"
+
+[projects.%q]
+trust_level = "trusted"
+`, absProject)
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := session.PreAcceptCodexTrust(configPath, projectDir); err != nil {
+		t.Fatalf("PreAcceptCodexTrust: %v", err)
+	}
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("config rewritten when already trusted:\n--- got ---\n%s\n--- want ---\n%s", got, original)
+	}
+}
+
+func TestPreAcceptCodexTrust_ConcurrentTrustEntries(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			projectDir := filepath.Join(dir, fmt.Sprintf("proj-%d", i))
+			if err := os.MkdirAll(projectDir, 0o755); err != nil {
+				errs <- err
+				return
+			}
+			errs <- session.PreAcceptCodexTrust(configPath, projectDir)
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent PreAcceptCodexTrust: %v", err)
+		}
+	}
+
+	cfg := readCodexTrustConfig(t, configPath)
+	projects := cfg["projects"].(map[string]any)
+	if len(projects) != n {
+		t.Fatalf("projects count = %d, want %d", len(projects), n)
+	}
+	for i := 0; i < n; i++ {
+		projectDir := filepath.Join(dir, fmt.Sprintf("proj-%d", i))
+		absProject, _ := filepath.Abs(projectDir)
+		entry, ok := projects[absProject].(map[string]any)
+		if !ok || entry["trust_level"] != "trusted" {
+			t.Fatalf("project %q missing trusted entry: %v", absProject, projects[absProject])
+		}
 	}
 }
 

--- a/internal/session/codex_trust_test.go
+++ b/internal/session/codex_trust_test.go
@@ -1,0 +1,148 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/asheshgoplani/agent-deck/internal/docker"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestPreAcceptCodexTrust_CreatesTrustedProjectEntry(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	projectDir := filepath.Join(dir, "my-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	if err := session.PreAcceptCodexTrust(configPath, projectDir); err != nil {
+		t.Fatalf("PreAcceptCodexTrust: %v", err)
+	}
+
+	cfg := readCodexTrustConfig(t, configPath)
+	projects := cfg["projects"].(map[string]any)
+	absProject, err := filepath.Abs(projectDir)
+	if err != nil {
+		t.Fatalf("abs project: %v", err)
+	}
+	entry := projects[absProject].(map[string]any)
+	if entry["trust_level"] != "trusted" {
+		t.Fatalf("trust_level = %v, want trusted", entry["trust_level"])
+	}
+}
+
+func TestPreAcceptCodexTrust_PreservesExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	original := `model = "gpt-5"
+
+[projects."/other"]
+trust_level = "untrusted"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	projectDir := filepath.Join(dir, "repo")
+	if err := session.PreAcceptCodexTrust(configPath, projectDir); err != nil {
+		t.Fatalf("PreAcceptCodexTrust: %v", err)
+	}
+
+	cfg := readCodexTrustConfig(t, configPath)
+	if cfg["model"] != "gpt-5" {
+		t.Fatalf("model = %v, want gpt-5", cfg["model"])
+	}
+	projects := cfg["projects"].(map[string]any)
+	if other, ok := projects["/other"].(map[string]any); !ok || other["trust_level"] != "untrusted" {
+		t.Fatalf("existing /other project entry changed: %v", projects["/other"])
+	}
+	absProject, _ := filepath.Abs(projectDir)
+	entry := projects[absProject].(map[string]any)
+	if entry["trust_level"] != "trusted" {
+		t.Fatalf("new project trust_level = %v", entry["trust_level"])
+	}
+}
+
+func TestPreAcceptCodexTrust_RejectsMalformedConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("[[[not-toml"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := session.PreAcceptCodexTrust(configPath, dir); err == nil {
+		t.Fatal("expected error for malformed config")
+	}
+}
+
+func TestApplyMultiRepoCodexContext_CodexOnly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	codexHome := filepath.Join(dir, ".codex")
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	parentDir := filepath.Join(dir, "multi-repo-worktrees", "feature-x")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+
+	if err := session.ApplyMultiRepoCodexContext("codex", true, parentDir); err != nil {
+		t.Fatalf("ApplyMultiRepoCodexContext: %v", err)
+	}
+
+	cfg := readCodexTrustConfig(t, session.GetCodexConfigPath(codexHome))
+	projects := cfg["projects"].(map[string]any)
+	entry := projects[parentDir].(map[string]any)
+	if entry["trust_level"] != "trusted" {
+		t.Fatalf("trust_level = %v, want trusted", entry["trust_level"])
+	}
+}
+
+func TestApplyMultiRepoCodexContext_NonCodexIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	parentDir := filepath.Join(dir, "parent")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+
+	for _, tool := range []string{"claude", "gemini", ""} {
+		if err := session.ApplyMultiRepoCodexContext(tool, true, parentDir); err != nil {
+			t.Fatalf("ApplyMultiRepoCodexContext(tool=%q): %v", tool, err)
+		}
+	}
+	configPath := session.GetCodexConfigPath(filepath.Join(dir, ".codex"))
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("codex config created for non-codex tool, stat err=%v", err)
+	}
+}
+
+func TestPreAcceptCodexSandboxWorkspaceTrust(t *testing.T) {
+	home := t.TempDir()
+	if err := session.PreAcceptCodexSandboxWorkspaceTrust(home); err != nil {
+		t.Fatalf("PreAcceptCodexSandboxWorkspaceTrust: %v", err)
+	}
+	configPath := filepath.Join(docker.SandboxDir(home, ".codex"), "config.toml")
+	cfg := readCodexTrustConfig(t, configPath)
+	projects := cfg["projects"].(map[string]any)
+	entry := projects[docker.ContainerWorkDir()].(map[string]any)
+	if entry["trust_level"] != "trusted" {
+		t.Fatalf("sandbox trust_level = %v, want trusted", entry["trust_level"])
+	}
+}
+
+func readCodexTrustConfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	cfg := map[string]any{}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return cfg
+}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -694,6 +694,17 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 				slog.String("error", err.Error()))
 		}
 	}
+	// Codex conductors get the same treatment (#1359 parity): seed
+	// projects[dir].trust_level = "trusted" in ~/.codex/config.toml so
+	// first boot and heartbeat do not stall on the workspace-trust dialog.
+	if spec.Agent == ConductorAgentCodex {
+		if err := PreAcceptCodexTrust(GetCodexConfigPath(getCodexHomeDir()), dir); err != nil {
+			sessionLog.Warn("conductor_preaccept_codex_trust_failed",
+				slog.String("conductor", name),
+				slog.String("dir", dir),
+				slog.String("error", err.Error()))
+		}
+	}
 
 	targetPath := filepath.Join(dir, spec.InstructionsFileName)
 

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 // --- Systemd template generation tests ---
@@ -3051,5 +3053,39 @@ func TestSetupConductorWithAgent_NoClaudeTrustForCodex(t *testing.T) {
 	dir, _ := ConductorNameDir(name)
 	if entry := conductorTrustEntry(t, dir); entry != nil {
 		t.Fatalf("unexpected Claude trust entry for Codex conductor dir %q: %v", dir, entry)
+	}
+}
+
+// Issue #1359 parity: Codex conductors must pre-accept workspace trust for the
+// just-created conductor directory so first boot does not stall on the dialog.
+func TestSetupConductorWithAgent_PreAcceptsCodexTrust(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "trust-codex"
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "", "", "", "", nil, ""); err != nil {
+		t.Fatalf("SetupConductorWithAgent: %v", err)
+	}
+
+	dir, _ := ConductorNameDir(name)
+	configPath := GetCodexConfigPath(filepath.Join(tmpHome, ".codex"))
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read codex config: %v", err)
+	}
+	var cfg map[string]any
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal codex config: %v", err)
+	}
+	projects, ok := cfg["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("projects key missing or wrong type: %T", cfg["projects"])
+	}
+	entry, ok := projects[dir].(map[string]any)
+	if !ok {
+		t.Fatalf("no trust entry for conductor dir %q in %s", dir, configPath)
+	}
+	if entry["trust_level"] != "trusted" {
+		t.Fatalf("trust_level = %v, want trusted", entry["trust_level"])
 	}
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3066,6 +3066,11 @@ func (i *Instance) Start() error {
 	// conductors, explicit telegram channel owners, and non-claude tools.
 	i.prepareWorkerScratchConfigDirForSpawn() // also runs plugin auto-install per fix C1
 
+	// Pre-accept Codex workspace trust for non-sandbox sessions so first launch
+	// does not stall on the trust dialog. Sandbox sessions seed trust after
+	// agent config sync in ensureSandboxContainer.
+	i.preAcceptCodexWorkspaceTrust()
+
 	// Build command based on tool type
 	// Priority: claude-compatible (built-in + custom wrapping claude) → built-in tools → custom tools → raw command
 	var command string
@@ -8279,6 +8284,13 @@ func ensureSandboxContainer(inst *Instance, userCfg *UserConfig, toolCommand str
 	var homeMounts []docker.VolumeMount
 	if homeDir != "" {
 		bindMounts, homeMounts = docker.RefreshAgentConfigs(homeDir, "")
+		if IsCodexCompatible(inst.Tool) {
+			if err := PreAcceptCodexSandboxWorkspaceTrust(homeDir); err != nil {
+				sessionLog.Warn("codex_sandbox_preaccept_trust_failed",
+					slog.String("instance_id", inst.ID),
+					slog.String("error", err.Error()))
+			}
+		}
 	}
 
 	if err := ensureContainerRunning(ctx, inst, ctr, userCfg, homeDir, bindMounts, homeMounts); err != nil {

--- a/internal/session/symlink_write_regression_test.go
+++ b/internal/session/symlink_write_regression_test.go
@@ -114,6 +114,26 @@ func TestPreAcceptClaudeTrust_PreservesSymlink(t *testing.T) {
 	}
 }
 
+func TestPreAcceptCodexTrust_PreservesSymlink(t *testing.T) {
+	linkDir := t.TempDir()
+	link := filepath.Join(linkDir, "config.toml")
+	realPath := symlinkedFile(t, link, "")
+
+	projectDir := filepath.Join(linkDir, "project")
+	if err := session.PreAcceptCodexTrust(link, projectDir); err != nil {
+		t.Fatalf("PreAcceptCodexTrust: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "trust_level") {
+		t.Fatalf("trust entry not written through symlink; got: %s", data)
+	}
+}
+
 func TestWriteGlobalMCP_PreservesSymlink(t *testing.T) {
 	configFile := filepath.Join(session.GetClaudeConfigDir(), ".claude.json")
 	realPath := symlinkedFile(t, configFile, "{}")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10176,6 +10176,11 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			); ctxErr != nil {
 				uiLog.Warn("multi_repo_claude_context", slog.String("error", ctxErr.Error()))
 			}
+			if ctxErr := session.ApplyMultiRepoCodexContext(
+				inst.Tool, inst.MultiRepoEnabled, inst.MultiRepoTempDir,
+			); ctxErr != nil {
+				uiLog.Warn("multi_repo_codex_context", slog.String("error", ctxErr.Error()))
+			}
 		}
 
 		if parentSessionID != "" {


### PR DESCRIPTION
## Summary

- Add `PreAcceptCodexTrust` to seed `projects[<dir>].trust_level = "trusted"` in `~/.codex/config.toml`, mirroring Claude's `PreAcceptClaudeTrust` pattern.
- Wire preseed into Codex session start (host), Docker sandbox (`/workspace` after agent config sync), multi-repo parent dirs, and Codex conductor setup so unattended TUI/headless flows no longer stall on the workspace-trust dialog.
- Add focused tests for config merge, multi-repo/conductor/sandbox paths, and symlink-safe writes.

## Test plan

- [x] `go test ./internal/session/... -run 'Codex|Trust|1149|PreAccept' -count=1`
- [x] `go test ./internal/docker/... -run 'ClaudeHomeSeed|ContainerWorkDir' -count=1`
- [x] `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex sessions now automatically pre-approve workspace trust to reduce first-launch prompts and delays.
  * Multi-repo sessions apply Codex workspace-trust context when supported.
  * Sandbox Codex environments receive the trusted workspace setting after config sync.

* **Bug Fixes**
  * Preserves existing Codex configuration and unrelated TOML fields while safely applying the target trust level.
  * Avoids rewriting when the project is already trusted; improves concurrency safety and symlink preservation.

* **Tests**
  * Added coverage for trust seeding, multi-repo behavior, sandbox skipping, concurrency, and symlink regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->