### PR TITLE
fix(cli): stop global -p/--profile from shadowing a subcommand's -p (--parent)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -861,13 +861,48 @@ func main() {
 	}
 }
 
-// extractProfileFlag extracts -p or --profile from args, returning the profile and remaining args
+// globalFlagSubcommands lists every token that main()'s dispatch switch treats
+// as a subcommand. extractProfileFlag stops honoring the global -p/--profile
+// flag once it reaches one of these, so a subcommand that defines its own -p
+// (launch/add --parent, group move --position) is not shadowed by the global
+// profile flag. KEEP IN SYNC with the switch in main().
+var globalFlagSubcommands = map[string]bool{
+	"add": true, "list": true, "ls": true, "remove": true, "rm": true,
+	"rename": true, "mv": true, "status": true, "profile": true, "update": true,
+	"session": true, "mcp": true, "plugin": true, "skill": true, "mcp-proxy": true,
+	"group": true, "try": true, "launch": true, "conductor": true,
+	"telegram-doctor": true, "watcher": true, "openclaw": true, "oc": true,
+	"remote": true, "worktree": true, "wt": true, "costs": true, "web": true,
+	"uninstall": true, "migrate-paths": true, "hook-handler": true,
+	"codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
+	"hermes-hooks": true, "cursor-hooks": true, "notify-daemon": true,
+	"run-task": true, "inbox": true, "feedback": true, "creds-refresh": true,
+	"debug-dump": true, "version": true, "help": true,
+}
+
+// extractProfileFlag extracts the global -p or --profile flag from args,
+// returning the profile and remaining args.
+//
+// The global flag is only honored BEFORE the subcommand token. Without this
+// boundary, `agent-deck launch . -p <parent>` had its -p swallowed here as a
+// profile: handleLaunch then opened profiles/<parent>/state.db (a phantom
+// per-id profile DB, invisible to the default-profile TUI) and the launch
+// subcommand's own --parent went unset, so the child was never linked. The
+// same collision affected `add -p <parent>` and `group move -p <position>`.
+// The long-form --parent was unaffected because it is not matched here.
 func extractProfileFlag(args []string) (string, []string) {
 	var profile string
 	var remaining []string
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+
+		// Reached the subcommand: global flag parsing is over. Everything from
+		// here belongs to the subcommand, which may define its own -p.
+		if globalFlagSubcommands[arg] {
+			remaining = append(remaining, args[i:]...)
+			return profile, remaining
+		}
 
 		// Check for -p=value or --profile=value
 		if strings.HasPrefix(arg, "-p=") {

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -104,6 +105,67 @@ func TestNestedSessionAllowsCLICommands(t *testing.T) {
 		_, args := extractProfileFlag([]string{"-p", "work"})
 		if len(args) != 0 {
 			t.Errorf("expected empty args for TUI mode with profile flag, got %v", args)
+		}
+	})
+}
+
+// TestExtractProfileFlag_SubcommandBoundary locks in that the global -p/--profile
+// flag is only honored BEFORE the subcommand token. A subcommand's own -p (launch
+// /add --parent, group move --position) must reach the subcommand untouched.
+// Regression for the collision where `launch . -p <parent>` had its -p swallowed
+// as a profile, routing the child into a phantom profiles/<parent>/state.db and
+// dropping the parent link.
+func TestExtractProfileFlag_SubcommandBoundary(t *testing.T) {
+	t.Run("launch_short_p_is_not_eaten_as_profile", func(t *testing.T) {
+		profile, args := extractProfileFlag([]string{"launch", ".", "-p", "PARENT123", "-c", "claude"})
+		if profile != "" {
+			t.Errorf("global -p must not capture the launch parent; got profile=%q", profile)
+		}
+		// The subcommand's -p PARENT123 must survive for launch's own flag parser.
+		want := []string{"launch", ".", "-p", "PARENT123", "-c", "claude"}
+		if !slices.Equal(args, want) {
+			t.Errorf("args mangled: got %v want %v", args, want)
+		}
+	})
+
+	t.Run("add_short_p_is_not_eaten_as_profile", func(t *testing.T) {
+		profile, args := extractProfileFlag([]string{"add", "/tmp/x", "-p", "PARENT123"})
+		if profile != "" {
+			t.Errorf("global -p must not capture the add parent; got profile=%q", profile)
+		}
+		if !slices.Equal(args, []string{"add", "/tmp/x", "-p", "PARENT123"}) {
+			t.Errorf("args mangled: got %v", args)
+		}
+	})
+
+	t.Run("global_p_before_subcommand_still_works", func(t *testing.T) {
+		profile, args := extractProfileFlag([]string{"-p", "work", "launch", ".", "-p", "PARENT123"})
+		if profile != "work" {
+			t.Errorf("global -p before subcommand must be honored; got profile=%q", profile)
+		}
+		// Only the leading global -p work is consumed; the launch -p PARENT123 stays.
+		if !slices.Equal(args, []string{"launch", ".", "-p", "PARENT123"}) {
+			t.Errorf("expected launch -p PARENT123 to survive, got %v", args)
+		}
+	})
+
+	t.Run("equals_form_global_before_subcommand", func(t *testing.T) {
+		profile, args := extractProfileFlag([]string{"--profile=work", "launch", ".", "-p", "PARENT123"})
+		if profile != "work" {
+			t.Errorf("got profile=%q", profile)
+		}
+		if !slices.Equal(args, []string{"launch", ".", "-p", "PARENT123"}) {
+			t.Errorf("got %v", args)
+		}
+	})
+
+	t.Run("long_parent_form_unaffected", func(t *testing.T) {
+		profile, args := extractProfileFlag([]string{"launch", ".", "--parent", "PARENT123"})
+		if profile != "" {
+			t.Errorf("got profile=%q", profile)
+		}
+		if !slices.Equal(args, []string{"launch", ".", "--parent", "PARENT123"}) {
+			t.Errorf("got %v", args)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

`extractProfileFlag` (run before subcommand dispatch in `main()`) scans the **entire** arg list for `-p`/`--profile`. But `launch`/`add` define their own `-p` (`--parent`), and `group move` defines `-p` (`--position`). The global extractor wins because it runs first.

So `agent-deck launch . -p <parent-id> ...` becomes:
- global `profile = <parent-id>` → `handleLaunch` opens `profiles/<parent-id>/state.db` — a **phantom per-id profile DB**, invisible to the default-profile TUI / `ls` / `session children`
- the launch subcommand's `--parent` is now empty → the child is **never linked** to its parent

Re-running hits "session already exists" (it checks that phantom DB). The long-form `--parent` was unaffected (not matched by the extractor), which is why it silently worked while `-p` did not. Verified against live data: phantom `profiles/<instance-id>/state.db` dirs with orphan children (empty `parent_session_id`).

## Fix

Honor the global `-p`/`--profile` flag **only before the subcommand token**, matching the convention that global flags precede the subcommand. Once a subcommand keyword is reached, the rest of the args (including any `-p`) belong to the subcommand.

- `agent-deck -p work launch . -p <parent>` → global profile `work`, launch parent `<parent>` ✅
- `agent-deck launch . -p <parent>` → no global profile, launch parent `<parent>` ✅

## Tests

Adds `TestExtractProfileFlag_SubcommandBoundary` (launch/add short `-p`, global-before-subcommand, `--profile=` form, long `--parent`). Existing `extractProfileFlag` tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CLI version to **1.10.5**.

* **Bug Fixes**
  * Improved profile flag handling so the global `-p/--profile` is only applied before a subcommand, preventing it from interfering with subcommand-specific profile options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->