### PR TITLE
fix(session): persist archive via targeted UPDATE, not abortable full save

### DIFF
--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1333,6 +1333,19 @@ func (s *StateDB) SetAcknowledged(id string, ack bool) error {
 	return err
 }
 
+// SetArchived sets or clears the archive timestamp for a single instance via a
+// targeted UPDATE. Archive/unarchive mutate one field on one row, so they must
+// NOT go through the full-table saveInstances() path: under concurrent writers
+// that path's external-change guard aborts the save and reloads, silently
+// discarding the archive (see #archive-abort). A scoped UPDATE always lands.
+// A zero `at` clears the flag (unarchive).
+func (s *StateDB) SetArchived(id string, at time.Time) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec("UPDATE instances SET archived_at = ? WHERE id = ?", archivedAtUnix(at), id)
+		return err
+	})
+}
+
 // --- Heartbeat ---
 
 // RegisterInstance records this process as an active TUI instance.

--- a/internal/statedb/statedb_test.go
+++ b/internal/statedb/statedb_test.go
@@ -107,6 +107,60 @@ func TestSaveLoadInstances(t *testing.T) {
 	}
 }
 
+func TestSetArchivedPersistsTimestampIndependently(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now()
+	if err := db.SaveInstance(&InstanceRow{
+		ID:          "arch-1",
+		Title:       "indigo-jay",
+		ProjectPath: "/tmp/project",
+		GroupPath:   "grp",
+		Tool:        "claude",
+		Status:      "error",
+		CreatedAt:   now,
+		ToolData:    json.RawMessage("{}"),
+	}); err != nil {
+		t.Fatalf("seed SaveInstance: %v", err)
+	}
+
+	rowByID := func() *InstanceRow {
+		t.Helper()
+		rows, err := db.LoadInstances()
+		if err != nil {
+			t.Fatalf("LoadInstances: %v", err)
+		}
+		for _, r := range rows {
+			if r.ID == "arch-1" {
+				return r
+			}
+		}
+		t.Fatalf("instance arch-1 not found")
+		return nil
+	}
+
+	// Precondition: not archived.
+	if got := rowByID(); !got.ArchivedAt.IsZero() {
+		t.Fatalf("expected unarchived, got archived_at=%v", got.ArchivedAt)
+	}
+
+	// Archive via the targeted update.
+	archivedAt := time.Unix(1781626272, 0).UTC()
+	if err := db.SetArchived("arch-1", archivedAt); err != nil {
+		t.Fatalf("SetArchived(archive): %v", err)
+	}
+	if got := rowByID(); got.ArchivedAt.Unix() != archivedAt.Unix() {
+		t.Errorf("archive not persisted: got archived_at=%v, want %v", got.ArchivedAt, archivedAt)
+	}
+
+	// Unarchive by setting the zero time.
+	if err := db.SetArchived("arch-1", time.Time{}); err != nil {
+		t.Fatalf("SetArchived(unarchive): %v", err)
+	}
+	if got := rowByID(); !got.ArchivedAt.IsZero() {
+		t.Errorf("unarchive not persisted: got archived_at=%v, want zero", got.ArchivedAt)
+	}
+}
+
 func TestSaveInstancesPreservesFreshAutoNameFieldsFromStaleSnapshot(t *testing.T) {
 	db := newTestDB(t)
 	now := time.Now()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5022,16 +5022,25 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.cachedStatusCounts.valid.Store(false)
 		h.invalidatePreviewCache(msg.sessionID)
 		h.rebuildFlatItems()
-		h.saveInstances()
 		if inst := h.getInstanceByID(msg.sessionID); inst != nil {
+			// Persist via a targeted UPDATE, not saveInstances(): under concurrent
+			// writers the full-table save aborts on external-change and reloads,
+			// silently discarding the archive (archived_at reverts to 0).
+			if err := h.persistArchived(inst); err != nil {
+				h.setError(fmt.Errorf("failed to persist archive: %w", err))
+				return h, nil
+			}
 			h.setError(fmt.Errorf("archived '%s' (^ to view)", inst.Title))
 		}
 		return h, nil
 
 	case sessionUnarchivedMsg:
 		h.rebuildFlatItems()
-		h.saveInstances()
 		if inst := h.getInstanceByID(msg.sessionID); inst != nil {
+			if err := h.persistArchived(inst); err != nil {
+				h.setError(fmt.Errorf("failed to persist unarchive: %w", err))
+				return h, nil
+			}
 			h.setError(fmt.Errorf("unarchived '%s'", inst.Title))
 		}
 		return h, nil
@@ -11373,6 +11382,22 @@ func (h *Home) closeSession(inst *session.Instance) tea.Cmd {
 		killErr := inst.Kill()
 		return sessionClosedMsg{sessionID: id, killErr: killErr}
 	}
+}
+
+// persistArchived writes the instance's archive timestamp to the database with a
+// targeted single-row UPDATE. This deliberately bypasses saveInstances(), whose
+// external-change guard aborts (and reloads) under concurrent writers, silently
+// reverting the archive. The in-memory inst.ArchivedAt is already set by
+// archiveSession/unarchiveSession; this only persists it.
+func (h *Home) persistArchived(inst *session.Instance) error {
+	if h.storage == nil {
+		return nil
+	}
+	db := h.storage.GetDB()
+	if db == nil {
+		return nil
+	}
+	return db.SetArchived(inst.ID, inst.ArchivedAt)
 }
 
 // archiveSession stops a session and marks it archived.


### PR DESCRIPTION
**Problem**
Archiving/unarchiving a session in the TUI sometimes silently reverts — the session "keeps coming back" unarchived. The archive handlers call `saveInstances()`, a full-table save that aborts-and-reloads on an external-change guard. Under concurrent writers (e.g. a second instance, or the idle watcher) that abort discards the in-flight `archived_at`, reverting it to `0`.

**Fix**
Persist the archive state with a targeted `SetArchived` UPDATE on the single row instead of the abortable full save. The new `persistArchived` path in `home.go` replaces `saveInstances()` in the archive/unarchive handlers, so the write can't be clobbered by a concurrent full-table reload.

**Changes**
- `internal/statedb/statedb.go` — add `SetArchived` (targeted single-row UPDATE)
- `internal/ui/home.go` — archive/unarchive handlers call `persistArchived` instead of `saveInstances()`, surfacing persist errors to the user
- `internal/statedb/statedb_test.go` — `TestSetArchivedPersistsTimestampIndependently`

**Testing**
- `go build ./...`, `go vet ./internal/statedb/... ./internal/ui/...` clean
- `go test ./internal/statedb/...` ✅ incl. `TestSetArchivedPersistsTimestampIndependently`
- `go test ./internal/ui/... -run Archive` ✅
