### PR TITLE
ci(release): notify via ntfy on release workflow failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,3 +243,17 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: 'dist-attest/*'
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          REF_NAME: ${{ env.REF_NAME }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -s \
+            -H "Title: Release ${REF_NAME} failed" \
+            -H "Priority: high" \
+            -H "Tags: github,release,failure" \
+            -d "Release workflow failed for ${REF_NAME}. Check logs: ${RUN_URL}" \
+            "https://ntfy.sh/${NTFY_TOPIC}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,12 +246,15 @@ jobs:
 
       - name: Notify on failure
         if: failure()
+        timeout-minutes: 2
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
           REF_NAME: ${{ env.REF_NAME }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl -s \
+          curl --fail --show-error --silent \
+            --connect-timeout 5 \
+            --max-time 15 \
             -H "Title: Release ${REF_NAME} failed" \
             -H "Priority: high" \
             -H "Tags: github,release,failure" \


### PR DESCRIPTION
## Problem

Release failures are silent. When `v1.9.73` failed with a `401 Bad credentials` error on `HOMEBREW_TAP_GITHUB_TOKEN`, nothing alerted — the pipeline stalled for weeks and 17 version bumps went unpublished before anyone noticed. (See #1537 for the full diagnosis.)

## Change

Adds a `Notify on failure` step at the end of the release job that fires when any prior step fails. Uses the same `NTFY_TOPIC` secret and ntfy endpoint already wired up in `issue-notify.yml`.

```yaml
- name: Notify on failure
  if: failure()
  ...
  run: |
    curl -s \
      -H "Title: Release ${REF_NAME} failed" \
      -H "Priority: high" \
      -H "Tags: github,release,failure" \
      -d "Release workflow failed for ${REF_NAME}. Check logs: ${RUN_URL}" \
      "https://ntfy.sh/${NTFY_TOPIC}"
```

No new secrets required.

Closes #1537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Notify on failure” step for release workflow runs.
  * When a release fails, an alert is sent to the configured NTFY endpoint including the failing branch/tag name and a direct link to the GitHub Actions run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->