### PR TITLE
feat(groups): default new-group max_concurrent via [group_defaults] config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable default `max_concurrent` for new groups via `[group_defaults]`.** New `[group_defaults]` section with a `max_concurrent` key sets the `max_concurrent` value stamped onto newly-created groups, replacing the hardcoded serial default (`1`) introduced in v1.9.1. Precedence: explicit `group create --max-concurrent N` > `[group_defaults].max_concurrent` > built-in `1`. When the key is unset, behavior is byte-for-byte unchanged (new groups stay serial); `0` means unlimited; existing groups loaded from `state.db` are never touched. Covered by `TestGroup_NewGroupDefault_*` (internal/session/group_concurrency_test.go), `TestUserConfig_GroupDefaults_*` (internal/session/userconfig_test.go), and `TestGroupCreate_*` (cmd/agent-deck/group_cmd_test.go). ([#1541](https://github.com/asheshgoplani/agent-deck/pull/1541))
+
 ## [1.10.6] - 2026-06-28
 
 ### Fixed

--- a/cmd/agent-deck/channels_cmd_test.go
+++ b/cmd/agent-deck/channels_cmd_test.go
@@ -75,12 +75,28 @@ func runAgentDeck(
 		if strings.HasPrefix(kv, "CLAUDE_CONFIG_DIR=") {
 			continue
 		}
+		// Strip inherited XDG_*_HOME and re-point them under the temp HOME
+		// below. EffectiveConfigPath prefers $XDG_CONFIG_HOME/agent-deck/
+		// config.toml over the legacy $HOME/.agent-deck/config.toml; on a dev
+		// box with XDG_CONFIG_HOME set, the config-driven cases would read the
+		// dev's real config (and write state.db outside the temp HOME).
+		if strings.HasPrefix(kv, "XDG_CONFIG_HOME=") {
+			continue
+		}
+		if strings.HasPrefix(kv, "XDG_DATA_HOME=") {
+			continue
+		}
+		if strings.HasPrefix(kv, "XDG_CACHE_HOME=") {
+			continue
+		}
 		env = append(env, kv)
 	}
 	env = append(env,
 		"HOME="+home,
 		"AGENTDECK_PROFILE=ch_support_test",
 		"TERM=dumb",
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
 	)
 	cmd.Env = env
 

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -573,6 +573,7 @@ func handleConductorSetup(profile string, args []string) {
 
 	// Always ensure conductor group is pinned to top
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+	groupTree.DefaultMaxConcurrent = config.GroupDefaults.MaxConcurrent
 	conductorGroup := groupTree.CreateGroup("conductor")
 	conductorGroup.Order = -1
 

--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -514,7 +514,7 @@ func handleGroupCreate(profile string, args []string) {
 	defaultPath := fs.String("default-path", "", "Default working directory for new sessions in this group")
 	// v1.9.1: -1 sentinel means "flag not set; use the GroupTree default of 1 (serial)".
 	// 0 = unlimited, 1 = serial, N>=2 = bounded.
-	maxConcurrent := fs.Int("max-concurrent", -1, "Cap on simultaneous running sessions in this group (0=unlimited, 1=serial, N=cap; default 1)")
+	maxConcurrent := fs.Int("max-concurrent", -1, "Cap on simultaneous running sessions in this group (0=unlimited, 1=serial, N=cap; default: [group_defaults].max_concurrent, else 1)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
@@ -567,6 +567,11 @@ func handleGroupCreate(profile string, args []string) {
 
 	// Build group tree
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+
+	// Seed the new-group default from [group_defaults].max_concurrent. An
+	// explicit --max-concurrent flag still wins (applied post-create below).
+	cfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
 
 	var newGroup *session.Group
 	var fullPath string
@@ -1005,6 +1010,10 @@ func handleGroupMove(profile string, args []string) {
 
 	// Build group tree
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+
+	// Seed the new-group default in case the move target must be auto-created.
+	cfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
 
 	// Try to match an existing group by exact name first, then case-insensitive
 	targetGroupPath := targetGroup

--- a/cmd/agent-deck/group_cmd_test.go
+++ b/cmd/agent-deck/group_cmd_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -210,4 +213,90 @@ func groupKeys(tree *session.GroupTree) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// writeGroupDefaultsConfig writes config.toml to the legacy path under the
+// isolated HOME. runAgentDeck re-points XDG_CONFIG_HOME at an unpopulated dir,
+// so EffectiveConfigPath falls through to this legacy file deterministically.
+func writeGroupDefaultsConfig(t *testing.T, home, content string) {
+	t.Helper()
+	dir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+}
+
+// runGroupCreate runs `group create <args...> --json` under the isolated HOME
+// and returns the parsed max_concurrent from the JSON payload.
+func runGroupCreate(t *testing.T, home string, args ...string) int {
+	t.Helper()
+	full := append([]string{"group", "create"}, args...)
+	full = append(full, "--json")
+	stdout, stderr, code := runAgentDeck(t, home, full...)
+	if code != 0 {
+		t.Fatalf("group create %v failed (exit %d)\nstdout: %s\nstderr: %s", args, code, stdout, stderr)
+	}
+	var parsed struct {
+		MaxConcurrent int `json:"max_concurrent"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("parse group create JSON: %v\nstdout: %s", err, stdout)
+	}
+	return parsed.MaxConcurrent
+}
+
+// TestGroupCreate_DefaultMaxConcurrent_ConfigUnset: no config → new group is
+// serial (1), byte-for-byte v1.9.1 behavior.
+func TestGroupCreate_DefaultMaxConcurrent_ConfigUnset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI subprocess test in -short mode")
+	}
+	home := t.TempDir()
+	if got := runGroupCreate(t, home, "g"); got != 1 {
+		t.Errorf("config unset: expected max_concurrent=1, got %d", got)
+	}
+}
+
+// TestGroupCreate_DefaultMaxConcurrent_ConfigN: [group_defaults].max_concurrent = 3
+// → new group capped at 3.
+func TestGroupCreate_DefaultMaxConcurrent_ConfigN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI subprocess test in -short mode")
+	}
+	home := t.TempDir()
+	writeGroupDefaultsConfig(t, home, "[group_defaults]\nmax_concurrent = 3\n")
+	if got := runGroupCreate(t, home, "g"); got != 3 {
+		t.Errorf("config N=3: expected max_concurrent=3, got %d", got)
+	}
+}
+
+// TestGroupCreate_FlagOverridesConfigDefault: --max-concurrent beats the config
+// default (precedence: flag > config > built-in 1). Uses the --flag=value form;
+// the space-separated form is mishandled by reorderGroupArgs (a pre-existing
+// arg-parsing issue unrelated to [group_defaults]).
+func TestGroupCreate_FlagOverridesConfigDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI subprocess test in -short mode")
+	}
+	home := t.TempDir()
+	writeGroupDefaultsConfig(t, home, "[group_defaults]\nmax_concurrent = 5\n")
+	if got := runGroupCreate(t, home, "g", "--max-concurrent=2"); got != 2 {
+		t.Errorf("flag override: expected max_concurrent=2, got %d", got)
+	}
+}
+
+// TestGroupCreate_ConfigZeroUnlimited: [group_defaults].max_concurrent = 0 →
+// new group is unlimited (0). Proves *0 is not collapsed to the built-in 1.
+func TestGroupCreate_ConfigZeroUnlimited(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI subprocess test in -short mode")
+	}
+	home := t.TempDir()
+	writeGroupDefaultsConfig(t, home, "[group_defaults]\nmax_concurrent = 0\n")
+	if got := runGroupCreate(t, home, "g"); got != 0 {
+		t.Errorf("config 0: expected max_concurrent=0 (unlimited), got %d", got)
+	}
 }

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -481,6 +481,8 @@ func handleLaunch(profile string, args []string) {
 	instances = append(instances, newInstance)
 
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+	launchCfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = launchCfg.GroupDefaults.MaxConcurrent
 	if newInstance.GroupPath != "" {
 		groupTree.CreateGroupPath(newInstance.GroupPath)
 	}
@@ -583,6 +585,8 @@ func handleLaunch(profile string, args []string) {
 	// launch's row be silently DELETE'd by this rewrite's
 	// `DELETE FROM instances WHERE id NOT IN (...)` step.
 	postStartTree := session.NewGroupTreeWithGroups(instances, groups)
+	postStartCfg, _ := session.LoadUserConfig()
+	postStartTree.DefaultMaxConcurrent = postStartCfg.GroupDefaults.MaxConcurrent
 	if newInstance.GroupPath != "" {
 		postStartTree.CreateGroupPath(newInstance.GroupPath)
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1728,6 +1728,8 @@ func handleAdd(profile string, args []string) {
 
 	// Rebuild group tree and save
 	groupTree = session.NewGroupTreeWithGroups(instances, groups)
+	mainCfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = mainCfg.GroupDefaults.MaxConcurrent
 	// Ensure the session's group exists
 	if newInstance.GroupPath != "" {
 		groupTree.CreateGroupPath(newInstance.GroupPath)

--- a/cmd/agent-deck/openclaw_cmd.go
+++ b/cmd/agent-deck/openclaw_cmd.go
@@ -137,6 +137,8 @@ func handleOpenClawSync(profile string, args []string) {
 	// Save
 	groupTree := session.NewGroupTree(instances)
 	_ = groupsData // unused but loaded for completeness
+	userCfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = userCfg.GroupDefaults.MaxConcurrent
 	groupTree.CreateGroup(groupName)
 	if err := storage.SaveWithGroups(instances, groupTree); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to save sessions: %v\n", err)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1015,6 +1015,8 @@ func handleSessionFork(profile string, args []string) {
 
 	// Rebuild group tree and ensure group exists
 	groupTree := session.NewGroupTreeWithGroups(instances, groupsData)
+	forkCfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = forkCfg.GroupDefaults.MaxConcurrent
 	if forkedInst.GroupPath != "" {
 		groupTree.CreateGroupPath(forkedInst.GroupPath)
 	}

--- a/cmd/agent-deck/session_move.go
+++ b/cmd/agent-deck/session_move.go
@@ -128,6 +128,8 @@ func handleSessionMove(profile string, args []string) {
 	inst.ProjectPath = newPath
 
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+	moveCfg, _ := session.LoadUserConfig()
+	groupTree.DefaultMaxConcurrent = moveCfg.GroupDefaults.MaxConcurrent
 	if *group != "" {
 		targetGroupPath := *group
 		if targetGroupPath == "root" {

--- a/internal/session/declarative_groups.go
+++ b/internal/session/declarative_groups.go
@@ -27,6 +27,9 @@ func ReconcileDeclarativeGroups(tree *GroupTree, cfg *UserConfig) bool {
 		return false
 	}
 
+	// Groups declared with create = true inherit the new-group default.
+	tree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
+
 	changed := false
 	for key, settings := range cfg.Groups {
 		if !settings.Create && settings.DefaultPath == "" {

--- a/internal/session/group_concurrency_test.go
+++ b/internal/session/group_concurrency_test.go
@@ -98,6 +98,65 @@ func TestGroup_UnlimitedLegacy(t *testing.T) {
 	}
 }
 
+// TestGroup_NewGroupDefault_ConfigUnsetSerial verifies that with no
+// DefaultMaxConcurrent seeded on the tree (nil), CreateGroup keeps the
+// built-in serial default (1) — byte-for-byte v1.9.1 behavior.
+func TestGroup_NewGroupDefault_ConfigUnsetSerial(t *testing.T) {
+	tree := NewGroupTree(nil)
+	if tree.DefaultMaxConcurrent != nil {
+		t.Fatalf("expected nil DefaultMaxConcurrent on a fresh tree, got %v", *tree.DefaultMaxConcurrent)
+	}
+	g := tree.CreateGroup("g")
+	if g.MaxConcurrent != 1 {
+		t.Errorf("config unset: expected new group MaxConcurrent=1 (serial), got %d", g.MaxConcurrent)
+	}
+}
+
+// TestGroup_NewGroupDefault_ConfigZeroUnlimited verifies that a seeded
+// DefaultMaxConcurrent of *0 makes new groups unlimited (0), for both
+// CreateGroup and CreateSubgroup, and that 0 means "never queue".
+func TestGroup_NewGroupDefault_ConfigZeroUnlimited(t *testing.T) {
+	zero := 0
+	tree := NewGroupTree(nil)
+	tree.DefaultMaxConcurrent = &zero
+
+	g := tree.CreateGroup("g")
+	if g.MaxConcurrent != 0 {
+		t.Errorf("config 0: expected new group MaxConcurrent=0 (unlimited), got %d", g.MaxConcurrent)
+	}
+	sub := tree.CreateSubgroup(g.Path, "child")
+	if sub.MaxConcurrent != 0 {
+		t.Errorf("config 0: expected new subgroup MaxConcurrent=0 (unlimited), got %d", sub.MaxConcurrent)
+	}
+
+	// max=0 (unlimited) with two running → must NOT queue.
+	instances := []*Instance{
+		{ID: "a", GroupPath: g.Path, Status: StatusRunning},
+		{ID: "b", GroupPath: g.Path, Status: StatusRunning},
+	}
+	if ShouldQueue(instances, g.Path, g.MaxConcurrent) {
+		t.Error("config 0 (unlimited) with 2 running: expected ShouldQueue=false")
+	}
+}
+
+// TestGroup_NewGroupDefault_ConfigN verifies that a seeded DefaultMaxConcurrent
+// of *N is copied verbatim into new groups created via CreateGroup and
+// CreateSubgroup.
+func TestGroup_NewGroupDefault_ConfigN(t *testing.T) {
+	n := 4
+	tree := NewGroupTree(nil)
+	tree.DefaultMaxConcurrent = &n
+
+	g := tree.CreateGroup("g")
+	if g.MaxConcurrent != 4 {
+		t.Errorf("config 4: expected new group MaxConcurrent=4, got %d", g.MaxConcurrent)
+	}
+	sub := tree.CreateSubgroup(g.Path, "child")
+	if sub.MaxConcurrent != 4 {
+		t.Errorf("config 4: expected new subgroup MaxConcurrent=4, got %d", sub.MaxConcurrent)
+	}
+}
+
 // TestGroup_CountRunningInGroup verifies the count helper only includes
 // running sessions in the target group (not queued, not other groups).
 func TestGroup_CountRunningInGroup(t *testing.T) {

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -76,6 +76,13 @@ type GroupTree struct {
 	Groups    map[string]*Group // path -> group
 	GroupList []*Group          // Ordered list of groups
 	Expanded  map[string]bool   // Collapsed state persistence
+
+	// DefaultMaxConcurrent is the max_concurrent value copied into groups
+	// created via CreateGroup/CreateSubgroup. nil → built-in serial default (1),
+	// preserving v1.9.1 behavior when [group_defaults] is unset. Seeded by the
+	// command/UI layer from [group_defaults].max_concurrent before a create; an
+	// explicit `group create --max-concurrent` flag still wins per-group.
+	DefaultMaxConcurrent *int
 }
 
 // actionablePriority maps a session.Status to an "attention-needed" rank
@@ -1020,6 +1027,16 @@ func sanitizeGroupName(name string) string {
 	return cleaned
 }
 
+// newGroupMaxConcurrent resolves the MaxConcurrent assigned to a group made
+// via CreateGroup/CreateSubgroup. nil tree-default → 1 (serial, the v1.9.1
+// built-in). A configured value is used as-is (0 = unlimited, N = cap).
+func (t *GroupTree) newGroupMaxConcurrent() int {
+	if t.DefaultMaxConcurrent != nil {
+		return *t.DefaultMaxConcurrent
+	}
+	return 1
+}
+
 // CreateGroup creates a new empty group
 func (t *GroupTree) CreateGroup(name string) *Group {
 	// Sanitize name to prevent path traversal and security issues
@@ -1047,7 +1064,9 @@ func (t *GroupTree) CreateGroup(name string) *Group {
 		// to prevent the parallel-worker cascade observed on 2026-05-08.
 		// Pre-existing groups loaded via NewGroupTreeWithGroups keep their
 		// stored MaxConcurrent (0 → unlimited for backward compat).
-		MaxConcurrent: 1,
+		// [group_defaults].max_concurrent can override this default via the
+		// DefaultMaxConcurrent the caller seeds; nil keeps the serial 1.
+		MaxConcurrent: t.newGroupMaxConcurrent(),
 	}
 	t.Groups[path] = group
 	t.Expanded[path] = true
@@ -1081,7 +1100,8 @@ func (t *GroupTree) CreateSubgroup(parentPath, name string) *Group {
 		Sessions: []*Instance{},
 		Order:    siblingCount, // Order among siblings
 		// v1.9.1: subgroups also default to serial. See CreateGroup.
-		MaxConcurrent: 1,
+		// [group_defaults].max_concurrent overrides via DefaultMaxConcurrent.
+		MaxConcurrent: t.newGroupMaxConcurrent(),
 	}
 	t.Groups[fullPath] = group
 	t.Expanded[fullPath] = true

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -119,6 +119,10 @@ type UserConfig struct {
 	// config_dir = "~/.claude-my-group"
 	Groups map[string]GroupSettings `toml:"groups,omitempty"`
 
+	// GroupDefaults holds defaults applied to NEWLY-created groups only.
+	// Existing groups (loaded from state.db) are never affected.
+	GroupDefaults GroupDefaultsSettings `toml:"group_defaults,omitempty"`
+
 	// Conductors defines optional per-conductor overrides.
 	// Keyed by conductor name (matches Instance.Title minus "conductor-" prefix).
 	// Mirrors Groups — see ConductorOverrides for the sub-table shape.
@@ -653,6 +657,19 @@ type GroupSettings struct {
 	Claude GroupClaudeSettings `toml:"claude,omitempty"`
 	// Hermes defines Hermes overrides for a specific group.
 	Hermes GroupHermesSettings `toml:"hermes,omitempty"`
+}
+
+// GroupDefaultsSettings carries [group_defaults] — defaults stamped onto new
+// groups at creation time. Distinct from per-group [groups."<path>"] overrides.
+type GroupDefaultsSettings struct {
+	// MaxConcurrent is the max_concurrent value assigned to new groups created
+	// via `group create`, the TUI dialog, the web API, and the launch/session
+	// auto-create paths. Pointer to distinguish:
+	//   nil       → unset → built-in serial default (1)  [byte-for-byte v1.9.1]
+	//   *0        → new groups are unlimited
+	//   *N (N>0)  → new groups capped at N
+	// An explicit `group create --max-concurrent` flag overrides this.
+	MaxConcurrent *int `toml:"max_concurrent,omitempty"`
 }
 
 // GroupClaudeSettings defines group-specific Claude overrides.

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2200,6 +2201,68 @@ footer = "full"
 
 // TestSaveUserConfig_OmitsZeroValueFields verifies that SaveUserConfig does not
 // bloat config.toml with zero-value fields the user never set (issue #1360).
+// TestUserConfig_GroupDefaults_Decode verifies that [group_defaults].max_concurrent
+// decodes into a *int that distinguishes unset (nil) from explicit 0 and N.
+func TestUserConfig_GroupDefaults_Decode(t *testing.T) {
+	zero := 0
+	four := 4
+	cases := []struct {
+		name string
+		toml string
+		want *int
+	}{
+		{name: "unset", toml: "", want: nil},
+		{name: "explicit zero", toml: "[group_defaults]\nmax_concurrent = 0\n", want: &zero},
+		{name: "explicit N", toml: "[group_defaults]\nmax_concurrent = 4\n", want: &four},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg UserConfig
+			if _, err := toml.Decode(tc.toml, &cfg); err != nil {
+				t.Fatalf("toml.Decode: %v", err)
+			}
+			got := cfg.GroupDefaults.MaxConcurrent
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("expected nil MaxConcurrent, got *%d", *got)
+			case tc.want != nil && got == nil:
+				t.Errorf("expected *%d MaxConcurrent, got nil", *tc.want)
+			case tc.want != nil && got != nil && *got != *tc.want:
+				t.Errorf("expected MaxConcurrent=%d, got %d", *tc.want, *got)
+			}
+		})
+	}
+}
+
+// TestUserConfig_GroupDefaults_RoundTripZeroSurvives verifies that an explicit
+// 0 (unlimited) survives encode+decode. The [group_defaults] section has content
+// (max_concurrent = 0), so stripEmptyTOMLSections does NOT remove it, and the
+// *int field (with omitempty, NOT omitzero) keeps *0 through the round-trip.
+func TestUserConfig_GroupDefaults_RoundTripZeroSurvives(t *testing.T) {
+	zero := 0
+	cfg := &UserConfig{}
+	cfg.GroupDefaults.MaxConcurrent = &zero
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if !strings.Contains(buf.String(), "max_concurrent = 0") {
+		t.Fatalf("encoded TOML missing max_concurrent = 0:\n%s", buf.String())
+	}
+
+	var decoded UserConfig
+	if _, err := toml.Decode(buf.String(), &decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.GroupDefaults.MaxConcurrent == nil {
+		t.Fatal("round-trip lost max_concurrent (got nil, expected *0)")
+	}
+	if *decoded.GroupDefaults.MaxConcurrent != 0 {
+		t.Errorf("round-trip changed max_concurrent: expected 0, got %d", *decoded.GroupDefaults.MaxConcurrent)
+	}
+}
+
 func TestSaveUserConfig_OmitsZeroValueFields(t *testing.T) {
 	tempDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
@@ -2257,6 +2320,7 @@ func TestSaveUserConfig_OmitsZeroValueFields(t *testing.T) {
 		"[logs]",
 		"[mcp_pool]",
 		"[conductor]",
+		"[group_defaults]",
 		"[docker]",
 		"[openclaw]",
 		"[costs]",

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9570,6 +9570,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
 			if name != "" {
+				// Seed the new-group default from [group_defaults].max_concurrent.
+				if cfg, _ := session.LoadUserConfig(); cfg != nil {
+					h.groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
+				}
 				var created *session.Group
 				if h.groupDialog.HasParent() {
 					// Create subgroup under parent

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -494,6 +494,10 @@ func (m *WebMutator) CreateGroup(name, parentPath string) (string, error) {
 		return "", err
 	}
 	defer unlock()
+	// Seed the new-group default from [group_defaults].max_concurrent.
+	if cfg, _ := session.LoadUserConfig(); cfg != nil {
+		m.h.groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
+	}
 	var grp *session.Group
 	if parentPath != "" {
 		grp = m.h.groupTree.CreateSubgroup(parentPath, name)

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -8,6 +8,7 @@ All options for `~/.agent-deck/config.toml`.
 - [[shell] Section](#shell-section)
 - [[claude] Section](#claude-section)
 - [Per-group / per-conductor Claude overrides](#per-group--per-conductor-claude-overrides)
+- [[group_defaults] Section](#group_defaults-section)
 - [[gemini] Section](#gemini-section)
 - [[opencode] Section](#opencode-section)
 - [[codex] Section](#codex-section)
@@ -189,6 +190,19 @@ exists and whether config.toml parsed at all:
 agent-deck group show work --resolved
 agent-deck group show work --resolved --json
 ```
+
+## [group_defaults] Section
+
+Defaults stamped onto **newly-created** groups. Existing groups are unaffected.
+
+```toml
+[group_defaults]
+max_concurrent = 3   # new groups cap at 3 concurrent sessions
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `max_concurrent` | int | `1` (serial) | `max_concurrent` for new groups created via `group create`, the TUI/web create dialogs, and the launch/session auto-create paths. `0` = unlimited, `1` = serial, `N` = cap. Unset keeps the built-in serial default. An explicit `group create --max-concurrent N` flag overrides this per group; existing groups keep their stored value. |
 
 ## [gemini] Section
 


### PR DESCRIPTION
## Problem
New groups hardcode `max_concurrent = 1` (serial) in `GroupTree.CreateGroup`/`CreateSubgroup` (groups.go) since v1.9.1. There is no way to make new groups default to a different cap (e.g. unlimited, or N) without editing each group after creation via `group update --max-concurrent`.

## Solution
- New `[group_defaults]` section in `config.toml` with a `max_concurrent` key (`*int`, `omitempty`).
- `GroupTree` gains a `DefaultMaxConcurrent *int`; `CreateGroup`/`CreateSubgroup` resolve it via `newGroupMaxConcurrent()` (nil → built-in `1`).
- Every group-creation entry point (CLI `group create`, TUI dialog, web API, launch/session/fork/conductor/openclaw/declarative auto-create) seeds the tree default from config before creating. `CreateGroupPath` is covered transitively through the two chokepoints.

Note: the key is `[group_defaults].max_concurrent`, not `[groups].default_max_concurrent`. `[groups]` is already `map[string]GroupSettings` (per-group overrides), so a scalar there is a hard TOML decode error that would silently disable the entire config. A dedicated `[group_defaults]` section avoids the collision; semantics are unchanged.

## Precedence
`group create --max-concurrent N` (sentinel `-1` = unset) > `[group_defaults].max_concurrent` > built-in `1`. The existing post-create CLI flag override is unchanged, so the flag still wins per-group.

## Backward compatibility
- `[group_defaults]` unset → new groups stay serial (`1`), byte-for-byte identical to current behavior. No new bytes are written for users who don't set it: the encoder emits an empty `[group_defaults]` header (same as `[mcp_pool]`/`[conductor]`), and `stripEmptyTOMLSections` (already in the save path) removes the orphan header. `SaveUserConfig` is untouched.
- `max_concurrent = 0` → unlimited. The `*int` keeps `*0` through encode/decode; the section has content so it survives the strip pass and round-trips to `*0`. `omitzero` is deliberately not used (it would drop `*0`).
- Existing groups loaded from `state.db` are never modified.
- The implicit parent-creation paths (`ensureParentGroupsExist`/`AddSession`/`SyncWithInstances`) are intentionally untouched — they keep creating `MaxConcurrent: 0` (unlimited) groups, matching current behavior.

## Tests
- `internal/session/group_concurrency_test.go`: unset → 1, config 0 → 0 (unlimited, asserted via `ShouldQueue`), config N → N, for both `CreateGroup` and `CreateSubgroup`. Existing `TestGroup_MaxConcurrent_DefaultSerial` is unchanged.
- `internal/session/userconfig_test.go`: decode unset/0/N; round-trip proves `0` survives encode+decode (`*int`+`omitempty`). Unset-emits-nothing is covered by adding `[group_defaults]` to the existing `TestSaveUserConfig_OmitsZeroValueFields` deny-list, which exercises the real `SaveUserConfig` path where `stripEmptyTOMLSections` removes the empty header (`TestSaveUserConfig_ZeroValueConfigProducesNoSections` also auto-catches it).
- `cmd/agent-deck/group_cmd_test.go`: end-to-end `group create --json` — config unset → 1, config N → N, `--max-concurrent` overrides config, config 0 → 0. `runAgentDeck` is extended to isolate `XDG_CONFIG_HOME`/`XDG_DATA_HOME` under the test HOME so `EffectiveConfigPath` reads the test's config deterministically (and `state.db` stays in the temp HOME).

## Docs
`skills/agent-deck/references/config-reference.md` gains a `[group_defaults]` section; `CHANGELOG.md` Unreleased entry added.

PR opened first per workflow; tracking issue (if any) filed after and cross-linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the default concurrency limit for newly created groups.
  * New groups can now inherit a user-defined default, including unlimited mode or a custom cap.

* **Bug Fixes**
  * Improved CLI and UI consistency so group creation, moves, forks, launches, and sync flows respect the same default concurrency setting.
  * Strengthened test isolation to avoid reading or writing real local config/cache paths during CLI tests.

* **Tests**
  * Added coverage for default, overridden, and unlimited concurrency behavior, plus config round-trip handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->