### PR TITLE
fix(tui): session status accuracy — archived not 'Connected', skip archived sweep, bg-only stays green

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3835,13 +3835,34 @@ func (i *Instance) UpdateStatus() error {
 				}
 				i.Status = StatusWaiting
 			} else {
-				// Check acknowledgment: orange (waiting) vs gray (idle)
-				// Acknowledge() is called when user attaches to a session.
-				// ResetAcknowledged() is called by UpdateHookStatus on any new
-				// waiting event, and by the u key / new activity.
-				if i.tmuxSession != nil && i.tmuxSession.IsAcknowledged() {
+				// Claude fires its Stop hook (→ "waiting") when the FOREGROUND turn
+				// ends, even while run_in_background shells or a background agent the
+				// turn is awaiting keep running. Treat the session as still running
+				// so it stays green and the daemon emits no premature "finished"
+				// notification; it settles to waiting (and notifies) once the
+				// background work completes — so "done" means foreground AND
+				// background. BackgroundWorkPending captures the pane (the fast path
+				// has no captured content), so release i.mu around it like the
+				// GetStatus call below, then re-check for a concurrent Kill().
+				bgWorkPending := false
+				if i.tmuxSession != nil && IsClaudeCompatible(i.Tool) {
+					i.mu.Unlock()
+					bgWorkPending = i.tmuxSession.BackgroundWorkPending()
+					i.mu.Lock()
+					if i.Status == StatusStopped {
+						return nil
+					}
+				}
+				switch {
+				case bgWorkPending:
+					i.Status = StatusRunning
+				case i.tmuxSession != nil && i.tmuxSession.IsAcknowledged():
+					// Check acknowledgment: orange (waiting) vs gray (idle).
+					// Acknowledge() is called when user attaches to a session.
+					// ResetAcknowledged() is called by UpdateHookStatus on any new
+					// waiting event, and by the u key / new activity.
 					i.Status = StatusIdle
-				} else {
+				default:
 					i.Status = StatusWaiting
 				}
 			}

--- a/internal/tmux/background_work.go
+++ b/internal/tmux/background_work.go
@@ -1,0 +1,40 @@
+package tmux
+
+import (
+	"regexp"
+	"strings"
+)
+
+// claudeBackgroundWorkRe matches Claude Code's at-the-prompt indicators that the
+// FOREGROUND turn finished but background work is still in flight. Claude prints
+// these on the turn-completion (✻) summary line and in the footer:
+//
+//	✻ Churned for 6m 24s · 2 shells still running
+//	✻ Waiting for 1 background agent to finish
+//	⏵⏵ bypass permissions on · 2 shells · ← for agents   (footer; segment present iff shells>0)
+//
+// run_in_background shells and a background agent the turn awaits are the two
+// "still working after Stop" cases. Without recognizing them, agent-deck maps
+// Claude's Stop hook to "waiting" (yellow) and fires a premature "finished"
+// notification while work is still running. See the background-work-stop-signal
+// investigation (issue: bg-only sessions flagged yellow + notified).
+var claudeBackgroundWorkRe = regexp.MustCompile(`(?i)` +
+	`\d+\s+shells?\s+still\s+running` + // completion line: shells
+	`|waiting\s+for\s+\d+\s+background\s+agents?\s+to\s+finish` + // completion line: background agent
+	`|·\s*\d+\s+shells?\s*·`) // footer shell counter
+
+// backgroundWorkScanLines bounds the scan to the pane tail (completion line +
+// input box + footer) so a transcript that merely mentions "shells" in prose
+// further up the scrollback cannot trip the detector.
+const backgroundWorkScanLines = 20
+
+// claudeBackgroundWorkPending reports whether the (ANSI-stripped) Claude pane
+// content shows in-flight background work at the prompt. Pure and Claude-shaped;
+// callers gate it to Claude sessions.
+func claudeBackgroundWorkPending(content string) bool {
+	if content == "" {
+		return false
+	}
+	recent := strings.Join(lastNLines(content, backgroundWorkScanLines), "\n")
+	return claudeBackgroundWorkRe.MatchString(recent)
+}

--- a/internal/tmux/background_work_test.go
+++ b/internal/tmux/background_work_test.go
@@ -1,0 +1,106 @@
+package tmux
+
+import "testing"
+
+// Fixtures captured live from a Claude Code pane (tmux capture-pane) in the
+// three states that matter for the bg-work-after-Stop false-yellow bug:
+//   - foreground turn ended with run_in_background shells still running
+//   - foreground turn ended while awaiting a background agent
+//   - foreground turn ended with nothing pending (the must-stay-waiting case)
+
+const paneShellsStillRunning = `⏺ Decision noted: default-on for everyone.
+
+✻ Churned for 6m 24s · 2 shells still running
+                                                                           123608 tokens
+─────────────────────────────────────────────────────────────────────────────────────────
+❯
+─────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.8  Ctx: 123.1k  ⎇ feat/context-budget-handoff  (+0,-0)  𖠰 main
+  ⏵⏵ bypass permissions on · 2 shells · ← for agents`
+
+const paneSingleShell = `  ⏺ I have a background task running.
+
+✳ Meandering… (28s · ↓ 1.5k tokens)
+  ⎿  Tip: Use /feedback to help us improve!
+                                                                            90874 tokens
+─────────────────────────────────────────────────────────────────────────────────────────
+❯
+─────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.8  Ctx: 90.9k  ⎇ feat/context-budget-handoff  (+0,-0)  𖠰 main
+  ⏵⏵ bypass permissions on · 1 shell · ← for agents`
+
+const paneAwaitingAgent = `⏺ Probe launched. Ending my turn.
+
+✻ Waiting for 1 background agent to finish
+
+⏺ main
+  ◯ Explore  Long idle agent for probe                               15s · ↑ 13.9k tokens
+─────────────────────────────────────────────────────────────────────────────────────────
+❯
+─────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.8  Ctx: 136.9k  ⎇ feat/context-budget-handoff  (+0,-0)  𖠰 main
+  ⏵⏵ bypass permissions on · 1 shell · ← for agents`
+
+const paneIdleNoBackground = `⏺ All done — your tests pass.
+
+✻ Churned for 1m 2s
+                                                                            42100 tokens
+─────────────────────────────────────────────────────────────────────────────────────────
+❯
+─────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.8  Ctx: 42.1k  ⎇ feat/context-budget-handoff  (+0,-0)  𖠰 main
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents`
+
+// A completed (frozen) agent row plus a no-background footer must NOT count as
+// pending: the row "◯ Explore ... 5s" persists after the agent finishes, so it
+// is unreliable and we rely on the footer/completion line instead.
+const paneCompletedAgentRowNoBackground = `⏺ Here are the results.
+
+✻ Churned for 12s
+                                                                            42100 tokens
+─────────────────────────────────────────────────────────────────────────────────────────
+❯
+─────────────────────────────────────────────────────────────────────────────────────────
+   Model: Opus 4.8  Ctx: 42.1k  ⎇ feat/context-budget-handoff  (+0,-0)  𖠰 main
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents
+
+  ⏺ main
+  ◯ Explore  Idle probe agent                                         5s · ↓ 14.2k tokens`
+
+func TestClaudeBackgroundWorkPending(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"shells still running (plural)", paneShellsStillRunning, true},
+		{"single shell footer", paneSingleShell, true},
+		{"awaiting background agent", paneAwaitingAgent, true},
+		{"idle, nothing pending", paneIdleNoBackground, false},
+		{"completed agent row, no background", paneCompletedAgentRowNoBackground, false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := claudeBackgroundWorkPending(c.content); got != c.want {
+				t.Fatalf("claudeBackgroundWorkPending(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// Prose far up the scrollback that merely mentions shells must not trip the
+// detector — only the tail (completion line + footer) is authoritative.
+func TestClaudeBackgroundWorkPending_IgnoresScrollbackProse(t *testing.T) {
+	prose := "I launched 3 shells still running earlier in the session.\n"
+	var content string
+	for i := 0; i < 40; i++ {
+		content += "line of unrelated transcript output here\n"
+	}
+	content = prose + content + `❯
+   Model: Opus 4.8  Ctx: 42.1k
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents`
+	if claudeBackgroundWorkPending(content) {
+		t.Fatal("scrollback prose mentioning shells must not be detected as pending background work")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -844,6 +844,13 @@ type Session struct {
 	toolDetectedAt   time.Time
 	toolDetectExpiry time.Duration // How long before re-detecting (default 30s)
 
+	// Cached background-work probe (BackgroundWorkPending). The hook fast path in
+	// UpdateStatus has no captured pane content, so it must capture separately to
+	// check for in-flight background shells/agents; this bounds that to one
+	// capture per bgWorkCacheTTL while a session sits at the prompt.
+	bgWorkPending   bool
+	bgWorkCheckedAt time.Time
+
 	// Simple state tracking (hash-based)
 	stateTracker *StateTracker
 
@@ -3140,6 +3147,26 @@ func (s *Session) GetStatus() (string, error) {
 				return "active", nil
 			}
 
+			// Foreground turn ended but background work is still in flight: a
+			// run_in_background shell, or a background agent the turn is awaiting.
+			// Claude shows this at the prompt ("N shells still running" /
+			// "Waiting for N background agent to finish") with no spinner, so the
+			// busy check above misses it and the session would flip to waiting
+			// (yellow) and fire a premature "finished" notification. Keep it green
+			// until the work actually completes (then the next poll settles to
+			// waiting and notifies — "done" now means foreground AND background).
+			if s.isClaudeTool() && claudeBackgroundWorkPending(content) {
+				s.stateTracker.lastChangeTime = time.Now()
+				s.stateTracker.realActivityConfirmed = true
+				s.stateTracker.acknowledged = false
+				s.resetPromptNoBusyHoldLocked()
+				s.stateTracker.lastActivityTimestamp = currentTS
+				s.lastStableStatus = "active"
+				s.startupAt = time.Time{}
+				statusLog.Debug("background_work_active", slog.String("session", shortName))
+				return "active", nil
+			}
+
 			// Update content hash for spike detection (deferred until after early return above).
 			// The 500ms CapturePane cache means the spike path gets the same content,
 			// so we store the normalized result once and reuse it via cachedNormContent.
@@ -3747,6 +3774,48 @@ func (s *Session) GetWaitingSince() time.Time {
 func (s *Session) hasBusyIndicator(content string) bool {
 	// Always use spinner movement detection regardless of resolvedPatterns
 	return s.hasBusyIndicatorResolved(content)
+}
+
+// isClaudeTool reports whether this session is running Claude Code, used to gate
+// Claude-shaped pane heuristics (e.g. the background-work footer). Reads cached
+// tool fields without locking; GetStatus callers already hold s.mu.
+func (s *Session) isClaudeTool() bool {
+	return strings.EqualFold(inferToolFromSessionFields(s.detectedTool, s.customToolName, s.Command), "claude")
+}
+
+// bgWorkCacheTTL bounds how often BackgroundWorkPending captures the pane while a
+// session sits at the prompt. CapturePane has its own 500ms cache; this adds a
+// coarser ceiling so the per-tick hook-fast-path probe stays cheap at scale.
+const bgWorkCacheTTL = 3 * time.Second
+
+// BackgroundWorkPending reports whether a Claude session at the prompt still has
+// background work in flight (run_in_background shells or a background agent the
+// turn is awaiting). It captures the pane itself — for the UpdateStatus hook fast
+// path, which short-circuits before GetStatus and so has no captured content —
+// and caches the result briefly (bgWorkCacheTTL). Returns false for non-Claude
+// sessions. Safe to call WITHOUT holding s.mu (acquires it internally; releases
+// it for the slow capture).
+func (s *Session) BackgroundWorkPending() bool {
+	s.mu.Lock()
+	if !s.isClaudeTool() {
+		s.mu.Unlock()
+		return false
+	}
+	if !s.bgWorkCheckedAt.IsZero() && time.Since(s.bgWorkCheckedAt) < bgWorkCacheTTL {
+		pending := s.bgWorkPending
+		s.mu.Unlock()
+		return pending
+	}
+	s.mu.Unlock()
+
+	rawContent, err := s.CapturePane()
+	pending := err == nil && claudeBackgroundWorkPending(StripANSI(rawContent))
+
+	s.mu.Lock()
+	s.bgWorkPending = pending
+	s.bgWorkCheckedAt = time.Now()
+	s.mu.Unlock()
+	return pending
 }
 
 var defaultResolvedPatternsCache sync.Map // map[string]*ResolvedPatterns

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3155,15 +3155,7 @@ func (s *Session) GetStatus() (string, error) {
 			// (yellow) and fire a premature "finished" notification. Keep it green
 			// until the work actually completes (then the next poll settles to
 			// waiting and notifies — "done" now means foreground AND background).
-			if s.isClaudeTool() && claudeBackgroundWorkPending(content) {
-				s.stateTracker.lastChangeTime = time.Now()
-				s.stateTracker.realActivityConfirmed = true
-				s.stateTracker.acknowledged = false
-				s.resetPromptNoBusyHoldLocked()
-				s.stateTracker.lastActivityTimestamp = currentTS
-				s.lastStableStatus = "active"
-				s.startupAt = time.Time{}
-				statusLog.Debug("background_work_active", slog.String("session", shortName))
+			if s.markBackgroundWorkActiveLocked(content, currentTS, shortName) {
 				return "active", nil
 			}
 
@@ -3336,6 +3328,16 @@ func (s *Session) GetStatus() (string, error) {
 						s.startupAt = time.Time{}
 						statusLog.Debug("sustained_error_banner", slog.String("session", shortName))
 						return "error", nil
+					}
+
+					// Background work in flight keeps the session green here too:
+					// a bg shell's output drives the spike, so without this the
+					// prompt check below would flip it to waiting and fire a
+					// premature completion (mirrors the busy-check path above).
+					if s.markBackgroundWorkActiveLocked(content, currentTS, shortName) {
+						s.stateTracker.activityCheckStart = time.Time{}
+						s.stateTracker.activityChangeCount = 0
+						return "active", nil
 					}
 
 					if s.hasPromptIndicator(content) {
@@ -3809,13 +3811,43 @@ func (s *Session) BackgroundWorkPending() bool {
 	s.mu.Unlock()
 
 	rawContent, err := s.CapturePane()
-	pending := err == nil && claudeBackgroundWorkPending(StripANSI(rawContent))
+	if err != nil {
+		// Don't cache a capture failure as "no background work": refreshing the
+		// TTL would suppress retries for the full window and could let the
+		// waiting hook fire a premature completion. Keep the previous value and
+		// leave bgWorkCheckedAt unchanged so the next call re-captures.
+		s.mu.Lock()
+		pending := s.bgWorkPending
+		s.mu.Unlock()
+		return pending
+	}
+	pending := claudeBackgroundWorkPending(StripANSI(rawContent))
 
 	s.mu.Lock()
 	s.bgWorkPending = pending
 	s.bgWorkCheckedAt = time.Now()
 	s.mu.Unlock()
 	return pending
+}
+
+// markBackgroundWorkActiveLocked applies the "keep green while background work is
+// in flight" state update when a Claude session is at the prompt but still has
+// run_in_background shells / an awaited background agent. Returns true when it
+// fired (caller should return "active"). Accepts raw or stripped content
+// (StripANSI is idempotent). Must be called with s.mu held.
+func (s *Session) markBackgroundWorkActiveLocked(content string, currentTS int64, shortName string) bool {
+	if !s.isClaudeTool() || !claudeBackgroundWorkPending(StripANSI(content)) {
+		return false
+	}
+	s.stateTracker.lastChangeTime = time.Now()
+	s.stateTracker.realActivityConfirmed = true
+	s.stateTracker.acknowledged = false
+	s.resetPromptNoBusyHoldLocked()
+	s.stateTracker.lastActivityTimestamp = currentTS
+	s.lastStableStatus = "active"
+	s.startupAt = time.Time{}
+	statusLog.Debug("background_work_active", slog.String("session", shortName))
+	return true
 }
 
 var defaultResolvedPatternsCache sync.Map // map[string]*ResolvedPatterns

--- a/internal/ui/connection_status.go
+++ b/internal/ui/connection_status.go
@@ -1,0 +1,67 @@
+package ui
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// connectionStatusLine decides the preview-pane "Status:" line for a tool
+// section whose conversation/session id is on record.
+//
+// A tool's session id is retained even after a session is archived or stopped
+// (so the conversation can be resumed), so its mere presence does NOT mean the
+// agent is live. Archived and stopped sessions have had their tmux pane torn
+// down and must not claim "Connected".
+func connectionStatusLine(archived bool, status session.Status) (text string, style lipgloss.Style) {
+	switch {
+	case archived:
+		return "■ Archived", SessionStatusStopped
+	case status == session.StatusStopped:
+		return "■ Stopped", SessionStatusStopped
+	default:
+		return "● Connected", lipgloss.NewStyle().Foreground(ColorGreen).Bold(true)
+	}
+}
+
+// rowStatusGlyph decides the session-list row status indicator (glyph + style).
+//
+// The coarse status comes from a render snapshot of the session's last-known
+// state. Archiving tears down the tmux pane but does NOT reset Status, so an
+// archived row would otherwise keep a live glyph (e.g. ● running); the archived
+// override forces the stopped glyph regardless of the stale status/substate.
+func rowStatusGlyph(status session.Status, substate session.Substate, archived bool) (icon string, style lipgloss.Style) {
+	switch status {
+	case session.StatusRunning:
+		icon, style = "●", SessionStatusRunning
+	case session.StatusWaiting:
+		icon, style = "◐", SessionStatusWaiting
+	case session.StatusIdle:
+		icon, style = "○", SessionStatusIdle
+	case session.StatusError:
+		icon, style = "✕", SessionStatusError
+	case session.StatusStopped:
+		icon, style = "■", SessionStatusStopped
+	default:
+		icon, style = "○", SessionStatusIdle
+	}
+
+	// Honest Status v2: a distinct glyph for the two error substates a
+	// supervisor must act on differently — a dead-model no-op loop and an
+	// auth/login failure both render as "error", but a generic "✕" hides which.
+	// "⚡" = model unavailable (the Fable-down no-op), "🔒" = auth/login needed.
+	// Gated on StatusError so a stale cached substate cannot leak the glyph onto
+	// a session that is no longer in error (e.g. a stopped session).
+	if status == session.StatusError {
+		switch substate {
+		case session.SubstateModelUnavailable:
+			icon = "⚡"
+		case session.SubstateAuth401:
+			icon = "🔒"
+		}
+	}
+
+	if archived {
+		icon, style = "■", SessionStatusStopped
+	}
+	return icon, style
+}

--- a/internal/ui/connection_status_test.go
+++ b/internal/ui/connection_status_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// A recorded session/conversation id is kept even after a session is archived
+// or stopped (so it can be resumed), so its presence must NOT be reported as
+// "Connected" — the tmux pane is gone. These tests pin the honest mapping.
+func TestConnectionStatusLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		archived bool
+		status   session.Status
+		wantText string
+	}{
+		{"live running session is connected", false, session.StatusRunning, "● Connected"},
+		{"live waiting session is connected", false, session.StatusWaiting, "● Connected"},
+		{"live idle session is connected", false, session.StatusIdle, "● Connected"},
+		{"stopped session is not connected", false, session.StatusStopped, "■ Stopped"},
+		{"archived session is not connected", true, session.StatusRunning, "■ Archived"},
+		{"archived wins over stopped", true, session.StatusStopped, "■ Archived"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, _ := connectionStatusLine(tt.archived, tt.status)
+			if text != tt.wantText {
+				t.Errorf("connectionStatusLine(%v, %q) text = %q, want %q",
+					tt.archived, tt.status, text, tt.wantText)
+			}
+		})
+	}
+}
+
+// The list row status dot reads the session's last-known coarse status from a
+// render snapshot. Archiving tears down tmux but does NOT reset Status, so an
+// archived row would otherwise keep a live glyph (e.g. ● running). Pin the
+// existing glyph mapping plus the archived override.
+func TestRowStatusGlyph(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   session.Status
+		substate session.Substate
+		archived bool
+		wantIcon string
+	}{
+		{"running", session.StatusRunning, "", false, "●"},
+		{"waiting", session.StatusWaiting, "", false, "◐"},
+		{"idle", session.StatusIdle, "", false, "○"},
+		{"error", session.StatusError, "", false, "✕"},
+		{"stopped", session.StatusStopped, "", false, "■"},
+		{"unknown status falls back to idle glyph", session.Status("weird"), "", false, "○"},
+		{"error + model-unavailable substate", session.StatusError, session.SubstateModelUnavailable, false, "⚡"},
+		{"error + auth substate", session.StatusError, session.SubstateAuth401, false, "🔒"},
+		{"substate glyph only applies in error status", session.StatusRunning, session.SubstateAuth401, false, "●"},
+		{"archived overrides a live status", session.StatusRunning, "", true, "■"},
+		{"archived overrides an error substate glyph", session.StatusError, session.SubstateAuth401, true, "■"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			icon, _ := rowStatusGlyph(tt.status, tt.substate, tt.archived)
+			if icon != tt.wantIcon {
+				t.Errorf("rowStatusGlyph(%q, %q, %v) icon = %q, want %q",
+					tt.status, tt.substate, tt.archived, icon, tt.wantIcon)
+			}
+		})
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -15883,7 +15883,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 
 		// Status line
 		if selected.ClaudeSessionID != "" {
-			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selectedStatus)
 			b.WriteString(labelStyle.Render("Status:  "))
 			b.WriteString(statusStyle.Render(statusText))
 			b.WriteString("\n")
@@ -16079,7 +16079,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 
 		if selected.GeminiSessionID != "" {
-			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selectedStatus)
 			b.WriteString(labelStyle.Render("Status:  "))
 			b.WriteString(statusStyle.Render(statusText))
 			b.WriteString("\n")
@@ -16135,7 +16135,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		)
 
 		if selected.OpenCodeSessionID != "" {
-			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selectedStatus)
 			b.WriteString(labelStyle.Render("Status:  "))
 			b.WriteString(statusStyle.Render(statusText))
 			b.WriteString("\n")
@@ -16207,7 +16207,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 
 			genericID := selected.GetGenericSessionID()
 			if genericID != "" {
-				statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
+				statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selectedStatus)
 				valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 				b.WriteString(labelStyle.Render("Status:  "))
 				b.WriteString(statusStyle.Render(statusText))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -13199,14 +13199,16 @@ func renderSectionDivider(label string, width int) string {
 // sessionID is the detected session ID (empty = not connected).
 // detectedAt is when detection ran (zero = still detecting, used only when threeState is true).
 // threeState enables the "Detecting..." intermediate state (for tools like OpenCode/Codex).
-func renderToolStatusLine(b *strings.Builder, sessionID string, detectedAt time.Time, threeState bool) {
+// archived/status drive the honest connected-vs-archived-vs-stopped label when a
+// session id is on record (the id outlives the live pane).
+func renderToolStatusLine(b *strings.Builder, sessionID string, detectedAt time.Time, threeState, archived bool, status session.Status) {
 	labelStyle := lipgloss.NewStyle().Foreground(ColorText)
 	valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 
 	if sessionID != "" {
-		statusStyle := lipgloss.NewStyle().Foreground(ColorGreen).Bold(true)
+		statusText, statusStyle := connectionStatusLine(archived, status)
 		b.WriteString(labelStyle.Render("Status:  "))
-		b.WriteString(statusStyle.Render("● Connected"))
+		b.WriteString(statusStyle.Render(statusText))
 		b.WriteString("\n")
 
 		b.WriteString(labelStyle.Render("Session: "))
@@ -14666,44 +14668,11 @@ func (h *Home) renderSessionItem(
 		treeConnector = treeLast
 	}
 
-	// Status indicator with consistent sizing
-	var statusIcon string
-	var statusStyle lipgloss.Style
-	switch instStatus {
-	case session.StatusRunning:
-		statusIcon = "●"
-		statusStyle = SessionStatusRunning
-	case session.StatusWaiting:
-		statusIcon = "◐"
-		statusStyle = SessionStatusWaiting
-	case session.StatusIdle:
-		statusIcon = "○"
-		statusStyle = SessionStatusIdle
-	case session.StatusError:
-		statusIcon = "✕"
-		statusStyle = SessionStatusError
-	case session.StatusStopped:
-		statusIcon = "■"
-		statusStyle = SessionStatusStopped
-	default:
-		statusIcon = "○"
-		statusStyle = SessionStatusIdle
-	}
-
-	// Honest Status v2: a distinct glyph for the two error substates a
-	// supervisor must act on differently — a dead-model no-op loop and an
-	// auth/login failure both render as "error", but a generic "✕" hides which.
-	// "⚡" = model unavailable (the Fable-down no-op), "🔒" = auth/login needed.
-	// Gated on StatusError so a stale cached substate cannot leak the glyph onto
-	// a session that is no longer in error (e.g. a stopped session).
-	if instStatus == session.StatusError {
-		switch instSubstate {
-		case session.SubstateModelUnavailable:
-			statusIcon = "⚡"
-		case session.SubstateAuth401:
-			statusIcon = "🔒"
-		}
-	}
+	// Status indicator with consistent sizing. rowStatusGlyph maps the coarse
+	// status (plus the Honest-Status-v2 error substates) to a glyph, and forces
+	// the stopped glyph for archived sessions whose snapshot still carries a
+	// stale live status.
+	statusIcon, statusStyle := rowStatusGlyph(instStatus, instSubstate, inst.IsArchived())
 
 	status := statusStyle.Render(statusIcon)
 
@@ -15894,12 +15863,13 @@ func (h *Home) renderPreviewPane(width, height int) string {
 
 		// Status line
 		if selected.ClaudeSessionID != "" {
-			statusStyle := lipgloss.NewStyle().Foreground(ColorGreen).Bold(true)
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
 			b.WriteString(labelStyle.Render("Status:  "))
-			b.WriteString(statusStyle.Render("● Connected"))
+			b.WriteString(statusStyle.Render(statusText))
 			b.WriteString("\n")
 
-			// Full session ID on its own line
+			// Full session ID on its own line (kept even when archived/stopped so
+			// the conversation can be resumed)
 			b.WriteString(labelStyle.Render("Session: "))
 			b.WriteString(valueStyle.Render(selected.ClaudeSessionID))
 			b.WriteString("\n")
@@ -16089,9 +16059,9 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 
 		if selected.GeminiSessionID != "" {
-			statusStyle := lipgloss.NewStyle().Foreground(ColorGreen).Bold(true)
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
 			b.WriteString(labelStyle.Render("Status:  "))
-			b.WriteString(statusStyle.Render("● Connected"))
+			b.WriteString(statusStyle.Render(statusText))
 			b.WriteString("\n")
 
 			b.WriteString(labelStyle.Render("Session: "))
@@ -16145,9 +16115,9 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		)
 
 		if selected.OpenCodeSessionID != "" {
-			statusStyle := lipgloss.NewStyle().Foreground(ColorGreen).Bold(true)
+			statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
 			b.WriteString(labelStyle.Render("Status:  "))
-			b.WriteString(statusStyle.Render("● Connected"))
+			b.WriteString(statusStyle.Render(statusText))
 			b.WriteString("\n")
 
 			b.WriteString(labelStyle.Render("Session: "))
@@ -16194,7 +16164,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		b.WriteString(codexHeader)
 		b.WriteString("\n")
 
-		renderToolStatusLine(&b, selected.CodexSessionID, selected.CodexDetectedAt, true)
+		renderToolStatusLine(&b, selected.CodexSessionID, selected.CodexDetectedAt, true, selected.IsArchived(), selected.Status)
 		renderLaunchModelInfoLines(&b, selected)
 		if selected.CodexSessionID != "" {
 			renderDetectedAtLine(&b, selected.CodexDetectedAt)
@@ -16217,10 +16187,10 @@ func (h *Home) renderPreviewPane(width, height int) string {
 
 			genericID := selected.GetGenericSessionID()
 			if genericID != "" {
-				statusStyle := lipgloss.NewStyle().Foreground(ColorGreen).Bold(true)
+				statusText, statusStyle := connectionStatusLine(selected.IsArchived(), selected.Status)
 				valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 				b.WriteString(labelStyle.Render("Status:  "))
-				b.WriteString(statusStyle.Render("● Connected"))
+				b.WriteString(statusStyle.Render(statusText))
 				b.WriteString("\n")
 
 				b.WriteString(labelStyle.Render("Session: "))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3710,6 +3710,14 @@ func (h *Home) logWorker() {
 	}
 }
 
+// shouldPollStatusInLoop reports whether the per-tick background status sweep
+// should run UpdateStatus() on inst. Archived sessions are skipped: their tmux
+// pane is torn down and their row status is display-frozen, so a poll can only
+// spend a serialized tmux subprocess without changing anything the UI renders.
+func shouldPollStatusInLoop(inst *session.Instance) bool {
+	return inst != nil && !inst.IsArchived()
+}
+
 // backgroundStatusUpdate runs independently of the TUI
 // Updates session statuses and syncs notification bar directly to tmux
 // This is called by the internal ticker even when TUI is paused (tea.Exec)
@@ -3842,7 +3850,7 @@ func (h *Home) backgroundStatusUpdate() {
 	var slowMu sync.Mutex
 	var slowSessions []string
 	pm := tmux.GetPipeManager()
-	var skipped int
+	var skipped int // sessions not polled this tick (archived + idle fast-path)
 
 	tracker := h.getTransitionTracker()
 
@@ -3851,6 +3859,18 @@ func (h *Home) backgroundStatusUpdate() {
 
 	for _, inst := range instances {
 		inst := inst // capture loop variable
+
+		// Skip archived sessions: their tmux pane is torn down and their row
+		// status is display-frozen (rowStatusGlyph forces the stopped glyph
+		// regardless of Status), so UpdateStatus can only burn a serialized tmux
+		// subprocess without changing anything the UI shows. With a large archive
+		// backlog this dominated the loop (observed: 723 archived of 742 total
+		// pushed the sweep to multi-second spikes). Unarchiving runs its own
+		// refresh, so the periodic loop never needs to poll archived sessions.
+		if !shouldPollStatusInLoop(inst) {
+			skipped++
+			continue
+		}
 
 		// Skip idle sessions when PipeManager knows they haven't produced output.
 		// Only skip if pipe is alive (otherwise we need UpdateStatus for Error detection).

--- a/internal/ui/status_poll_skip_test.go
+++ b/internal/ui/status_poll_skip_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Perf: the per-tick background status loop walks every loaded instance and
+// runs UpdateStatus() (a tmux subprocess). Archived sessions have had their
+// tmux pane torn down and their row status is display-frozen (rowStatusGlyph
+// forces the stopped glyph regardless of Status), so polling them can never
+// change anything the UI shows — it only burns a serialized tmux call. With a
+// large archive backlog (observed: 723 archived of 742 total) this dominated
+// the loop and pushed it to multi-second spikes. shouldPollStatusInLoop pins
+// the contract that archived sessions are skipped and active ones are not.
+func TestShouldPollStatusInLoop_SkipsArchived(t *testing.T) {
+	active := &session.Instance{ID: "a", Title: "active"}
+	archived := &session.Instance{ID: "b", Title: "archived", ArchivedAt: time.Now().UTC()}
+
+	if !shouldPollStatusInLoop(active) {
+		t.Fatalf("active session must be polled")
+	}
+	if shouldPollStatusInLoop(archived) {
+		t.Fatalf("archived session must be skipped (no live pane, frozen status)")
+	}
+	if shouldPollStatusInLoop(nil) {
+		t.Fatalf("nil instance must not be polled")
+	}
+}


### PR DESCRIPTION
Three independent status/display correctness fixes.

### 1. Archived/stopped sessions no longer show '● Connected'
Connection badge derived 'Connected' purely from a live tmux pane, so archived/stopped sessions still rendered green '● Connected'. Adds `connection_status.go` so archived/stopped sessions report disconnected regardless of pane state.

### 2. Skip archived sessions in background status sweep (perf)
The periodic background status poll iterated every session including archived ones. Archived sessions are now skipped, cutting needless tmux/capture work on large decks.

### 3. Keep sessions green when only background work is running
A session running *only* background work (shells/agents, no foreground turn) was flipping yellow/idle. New `internal/tmux/background_work.go` detects background-only activity so these sessions stay green.

Self-contained, tested, applies cleanly on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session status display with clearer connected, stopped, archived, and error indicators across preview and session lists.
  * Added Claude-specific background-work detection so sessions remain marked active while relevant work is still running.

* **Bug Fixes**
  * Prevented Claude sessions from transitioning to idle/complete prematurely when background work is pending.
  * Archived sessions now skip status polling and no longer render as connected/live.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->