### PR TITLE
fix(title-sync): ignore Claude's auto-derived session names (nameSource=derived)

### DIFF
--- a/internal/session/claude_title_reconcile.go
+++ b/internal/session/claude_title_reconcile.go
@@ -14,7 +14,11 @@ import (
 type claudeSessionMeta struct {
 	SessionID string `json:"sessionId"`
 	Name      string `json:"name"`
-	UpdatedAt *int64 `json:"updatedAt"` // unix ms; nil when absent
+	// NameSource distinguishes a user rename ("user", or absent on older Claude)
+	// from a name Claude Code 2.1.19x auto-derives from the cwd folder
+	// ("derived"). Only user renames are real intent; see ClaudeSessionNameIn.
+	NameSource string `json:"nameSource"`
+	UpdatedAt  *int64 `json:"updatedAt"` // unix ms; nil when absent
 }
 
 // ClaudeSessionNameIn scans claudeDir/sessions/*.json and returns the trimmed
@@ -30,6 +34,12 @@ type claudeSessionMeta struct {
 // Issue #572: Claude Code writes per-process metadata here when the user starts
 // with `claude --name X` or runs `/rename X` mid-session. claudeDir is an
 // explicit parameter so tests can point it at a temp dir.
+//
+// Claude Code 2.1.19x also auto-derives a name from the cwd folder and stamps
+// nameSource="derived". That is not a user rename, so a derived name is treated
+// as no name at all — including on the freshest entry, where it suppresses any
+// stale user name (mirrors the freshest-unnamed rule). A name with no
+// nameSource (older Claude) is always a user rename, so it is honored.
 func ClaudeSessionNameIn(claudeDir, sessionID string) string {
 	claudeDir = strings.TrimSpace(claudeDir)
 	sessionID = strings.TrimSpace(sessionID)
@@ -65,7 +75,13 @@ func ClaudeSessionNameIn(claudeDir, sessionID string) string {
 		}
 		if ts > bestTime {
 			bestTime = ts
-			bestName = strings.TrimSpace(meta.Name)
+			// A folder-derived name is not user intent: treat it as unnamed so it
+			// neither syncs nor lets a stale named entry win.
+			if meta.NameSource == "derived" {
+				bestName = ""
+			} else {
+				bestName = strings.TrimSpace(meta.Name)
+			}
 		}
 	}
 	return bestName

--- a/internal/session/claude_title_reconcile_test.go
+++ b/internal/session/claude_title_reconcile_test.go
@@ -188,6 +188,65 @@ func TestClaudeSessionNameIn_MtimeFallbackWhenNoUpdatedAt(t *testing.T) {
 	}
 }
 
+// TestClaudeSessionNameIn_DerivedNameIgnored: Claude Code 2.1.19x auto-derives a
+// session name from the cwd folder and stamps nameSource="derived". That is not a
+// user rename, so the title sync (#572) must ignore it — otherwise every quick
+// session's auto_name handle gets clobbered by the folder name.
+func TestClaudeSessionNameIn_DerivedNameIgnored(t *testing.T) {
+	home := t.TempDir()
+	seedClaudeSessionFile(t, home, "1234.json", map[string]any{
+		"sessionId": "sid-d", "name": "doozyx-apps-5d", "nameSource": "derived", "updatedAt": int64(1000),
+	})
+
+	if got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-d"); got != "" {
+		t.Errorf("ClaudeSessionNameIn = %q, want empty (derived names are not user renames)", got)
+	}
+}
+
+// TestClaudeSessionNameIn_DerivedFreshestSuppressesStaleUserName: a freshest
+// derived entry must suppress an older user-chosen name (mirrors the
+// freshest-unnamed-suppresses rule) so the sync neither resurrects the stale
+// name nor adopts the derived one.
+func TestClaudeSessionNameIn_DerivedFreshestSuppressesStaleUserName(t *testing.T) {
+	home := t.TempDir()
+	seedClaudeSessionFile(t, home, "1111.json", map[string]any{
+		"sessionId": "sid-e", "name": "my chosen name", "updatedAt": int64(1000),
+	})
+	seedClaudeSessionFile(t, home, "2222.json", map[string]any{
+		"sessionId": "sid-e", "name": "ui-c1", "nameSource": "derived", "updatedAt": int64(2000),
+	})
+
+	if got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-e"); got != "" {
+		t.Errorf("ClaudeSessionNameIn = %q, want empty (derived freshest suppresses stale user name)", got)
+	}
+}
+
+// TestClaudeSessionNameIn_UserNameSourceHonored: an explicit nameSource="user"
+// (claude --name / /rename) is still synced.
+func TestClaudeSessionNameIn_UserNameSourceHonored(t *testing.T) {
+	home := t.TempDir()
+	seedClaudeSessionFile(t, home, "1234.json", map[string]any{
+		"sessionId": "sid-u", "name": "Sprint Planning", "nameSource": "user", "updatedAt": int64(1000),
+	})
+
+	if got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-u"); got != "Sprint Planning" {
+		t.Errorf("ClaudeSessionNameIn = %q, want %q", got, "Sprint Planning")
+	}
+}
+
+// TestClaudeSessionNameIn_NoNameSourceBackCompat: older Claude versions wrote a
+// name with no nameSource field; those were always user-set, so honor them.
+func TestClaudeSessionNameIn_NoNameSourceBackCompat(t *testing.T) {
+	home := t.TempDir()
+	seedClaudeSessionFile(t, home, "1234.json", map[string]any{
+		"sessionId": "sid-b", "name": "legacy name", "updatedAt": int64(1000),
+	})
+
+	if got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-b"); got != "legacy name" {
+		t.Errorf("ClaudeSessionNameIn = %q, want %q (no nameSource = legacy user name)", got, "legacy name")
+	}
+}
+
 // TestReconcileTitleFromClaude_NoopWhenNoName: no Claude session file → no-op.
 func TestReconcileTitleFromClaude_NoopWhenNoName(t *testing.T) {
 	home := t.TempDir()


### PR DESCRIPTION
Claude Code (2.1.19x+) auto-derives a session name and reports it with `nameSource=derived`. The #572 title-sync reconciler read `name` without checking `nameSource`, so an auto-derived name overwrote the user/agent-deck auto_name with a generic derived title.

Fix: `ClaudeSessionNameIn` now skips reconciliation when `nameSource==derived`, so agent-deck's auto_name is preserved and only user-set Claude names sync.

Single-commit, carries tests. `go test ./internal/session/` green.