### PR TITLE
feat(focus): drive the running TUI — 'session focus' + notification-click switch (incl. across tmux sockets)

### DIFF
--- a/cmd/agent-deck/attach.go
+++ b/cmd/agent-deck/attach.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/ui"
+)
+
+// errAttachNoTTY signals that an interactive attach was requested (e.g. via
+// `--attach`) without a usable terminal: stdin and stdout must BOTH be TTYs.
+// Callers map this to a non-zero exit while leaving the session created and
+// running — only the interactive attach step is refused, never silently.
+var errAttachNoTTY = errors.New("attach requires an interactive terminal")
+
+// stdinStdoutIsTerminal reports whether both stdin and stdout are connected to
+// an interactive terminal. Attach drives a PTY against the current terminal, so
+// both must be TTYs; a pipe/redirect on either side (scripts, CI, conductor,
+// `--json` consumers) makes interactive attach impossible.
+func stdinStdoutIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// attachInstanceInteractive attaches the current process to inst's local tmux
+// pane and blocks until the user detaches (with the configured detach key).
+//
+// It returns errAttachNoTTY when there is no interactive terminal, so the
+// caller can report it loudly and exit non-zero while leaving the (already
+// created/started) session intact. Any other error (no tmux pane, attach
+// failure) is returned verbatim. The session must already be started before
+// this is called.
+func attachInstanceInteractive(inst *session.Instance) error {
+	if !stdinStdoutIsTerminal() {
+		return errAttachNoTTY
+	}
+	tmuxSession := inst.GetTmuxSession()
+	if tmuxSession == nil {
+		return fmt.Errorf("no tmux session for '%s'", inst.Title)
+	}
+	detachByte := ui.ResolvedDetachByte(session.GetHotkeyOverrides())
+	return tmuxSession.Attach(context.Background(), detachByte)
+}

--- a/cmd/agent-deck/attach_test.go
+++ b/cmd/agent-deck/attach_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Under `go test`, stdin/stdout are pipes, not a terminal. The attach guard
+// must therefore refuse with errAttachNoTTY BEFORE touching tmux — this is the
+// exact path that protects scripts/CI/conductor callers of `--attach`.
+func TestAttachInstanceInteractive_NoTTYReturnsSentinel(t *testing.T) {
+	if stdinStdoutIsTerminal() {
+		t.Skip("test stdio is a terminal; the no-TTY guard cannot be exercised here")
+	}
+
+	inst := session.NewInstance("attach-guard", "/tmp")
+	err := attachInstanceInteractive(inst)
+	if !errors.Is(err, errAttachNoTTY) {
+		t.Fatalf("attachInstanceInteractive without a TTY = %v, want errAttachNoTTY", err)
+	}
+}
+
+// stdinStdoutIsTerminal must be false in the test harness (piped stdio). This
+// pins the contract the callers rely on for the no-TTY exit path.
+func TestStdinStdoutIsTerminal_FalseUnderTest(t *testing.T) {
+	if stdinStdoutIsTerminal() {
+		t.Skip("test stdio unexpectedly a terminal; nothing to assert")
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -1203,6 +1204,7 @@ func handleAdd(profile string, args []string) {
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	attach := fs.Bool("attach", false, "Start and attach to the session immediately after creating it (requires an interactive terminal; not supported with --ssh)")
 
 	// Worktree flags
 	worktreeBranch := fs.String("w", "", "Create session in git worktree for branch")
@@ -1764,6 +1766,40 @@ func handleAdd(profile string, args []string) {
 
 	quietMode := *quiet || *quietShort
 	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	// --attach: create → start → attach, so `add --attach` "instantly opens"
+	// the new session in one step. Refused loudly (never silently) under
+	// --json or without an interactive terminal; the session is left created
+	// and started in those cases. Remote (ssh) sessions use a different attach
+	// path and are out of scope here.
+	if *attach {
+		if *jsonOutput {
+			out.Error("--attach cannot be combined with --json; session was created", ErrCodeInvalidOperation)
+			os.Exit(3)
+		}
+		if *sshHost != "" {
+			out.Error("--attach is not supported with --ssh (remote sessions); session was created", ErrCodeInvalidOperation)
+			os.Exit(3)
+		}
+		if err := newInstance.Start(); err != nil {
+			out.Error(fmt.Sprintf("failed to start session: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		newInstance.PostStartSync(3 * time.Second)
+		if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to save session state: %v\n", err)
+			os.Exit(1)
+		}
+		if err := attachInstanceInteractive(newInstance); err != nil {
+			if errors.Is(err, errAttachNoTTY) {
+				fmt.Fprintf(os.Stderr, "Error: %v; session was created and started\n", err)
+				os.Exit(3)
+			}
+			fmt.Fprintf(os.Stderr, "Error: failed to attach: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	// Build human-readable output
 	var humanLines []string

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -209,6 +209,12 @@ func initColorProfile() {
 }
 
 func main() {
+	// Make bare `tmux` invocations resolve even when launched from a minimal
+	// environment (notably a `terminal-notifier -execute` notification click,
+	// whose launchd PATH omits Homebrew's /opt/homebrew/bin). Must run before any
+	// tmux probe below. No-op when tmux is already on PATH.
+	ensureTmuxOnPath()
+
 	// Extract global -p/--profile flag before subcommand dispatch
 	profile, args := extractProfileFlag(os.Args[1:])
 	if profile != "" {

--- a/cmd/agent-deck/model_status.go
+++ b/cmd/agent-deck/model_status.go
@@ -27,6 +27,20 @@ func addModelInfoJSON(target map[string]interface{}, info session.ModelInfo) {
 	}
 }
 
+// addAutoNameJSON surfaces a session's auto-name state on `session show --json`
+// so consumers (notably the notification hook) can show the meaningful task
+// description instead of the machine-generated handle in Title. auto_name is
+// always present; auto_name_description only when a description was captured.
+func addAutoNameJSON(target map[string]interface{}, inst *session.Instance) {
+	if inst == nil {
+		return
+	}
+	target["auto_name"] = inst.GetAutoName()
+	if desc := inst.GetAutoNameDescription(); desc != "" {
+		target["auto_name_description"] = desc
+	}
+}
+
 func modelStatusDisplay(inst *session.Instance) string {
 	if inst == nil {
 		return "-"

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1161,6 +1161,26 @@ func (tmuxLiveSwitcher) switchInto(inst *session.Instance) (bool, error) {
 	return tmux.SwitchAttachedClients(inst.TmuxSocketName, ts.Name, inst.ID)
 }
 
+// clientDetacher detaches the user's currently-attached tmux client when the
+// live switch could not move it. switch-client cannot cross tmux servers, so a
+// notification target on a different socket than the attached session yields
+// switched=false; detaching that client makes the paused TUI resume and consume
+// the focus_request (attaching the target on its own socket) instead of the
+// switch silently waiting for a manual Ctrl+Q. Injected into routeFocus so the
+// cross-socket routing is unit-testable without a real tmux server.
+type clientDetacher interface {
+	// detachClientsOn detaches every real (non-control) client attached on any
+	// of sockets. Returns detached=true iff at least one client was detached.
+	detachClientsOn(sockets []string) (bool, error)
+}
+
+// tmuxClientDetacher is the production clientDetacher.
+type tmuxClientDetacher struct{}
+
+func (tmuxClientDetacher) detachClientsOn(sockets []string) (bool, error) {
+	return tmux.DetachClientsOnSockets(sockets...)
+}
+
 // findFocusInstance returns the instance with the given id, or nil.
 func findFocusInstance(instances []*session.Instance, id string) *session.Instance {
 	for _, inst := range instances {
@@ -1171,6 +1191,24 @@ func findFocusInstance(instances []*session.Instance, id string) *session.Instan
 	return nil
 }
 
+// focusOtherSockets returns the distinct tmux socket names used by instances,
+// excluding exclude (the target's own socket, where the live switch already
+// looked). Order-preserving and deduped. These are the sockets that may host
+// the user's currently-attached client when the target lives elsewhere.
+func focusOtherSockets(instances []*session.Instance, exclude string) []string {
+	seen := map[string]bool{exclude: true}
+	var out []string
+	for _, inst := range instances {
+		s := inst.TmuxSocketName
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
 // routeFocus drives `session focus <id>`. With --attach it first tries a live
 // switch-while-attached (so the click lands you straight in the session even
 // when the TUI is paused inside another attach); if no client is attached to the
@@ -1178,7 +1216,7 @@ func findFocusInstance(instances []*session.Instance, id string) *session.Instan
 // the TUI consumes on its next tick. Without --attach it always writes the
 // (select-only) focus_request. Split out of handleSessionFocus so it is
 // unit-testable without os.Exit; switcher is injected for the same reason.
-func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool, switcher liveSwitcher) error {
+func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool, switcher liveSwitcher, detacher clientDetacher) error {
 	if id == "" {
 		return fmt.Errorf("session focus requires an <id>")
 	}
@@ -1190,6 +1228,21 @@ func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, n
 		if switched, _ := switcher.switchInto(inst); switched {
 			return nil
 		}
+		// Live switch couldn't move the client: it's attached to a different tmux
+		// server than the target (switch-client can't cross servers). Write the
+		// focus_request FIRST, then detach that client so agent-deck's paused
+		// attach returns and the resumed TUI consumes the row on its next tick —
+		// attaching the target on its own socket, instead of waiting for a manual
+		// Ctrl+Q. When no client is attached elsewhere (e.g. the TUI is already in
+		// the list view), the detach is a harmless no-op and the row is consumed
+		// normally.
+		if detacher != nil {
+			if err := session.WriteFocusRequestAttach(db, id, nowNano, attach); err != nil {
+				return err
+			}
+			_, _ = detacher.detachClientsOn(focusOtherSockets(instances, inst.TmuxSocketName))
+			return nil
+		}
 	}
 	return session.WriteFocusRequestAttach(db, id, nowNano, attach)
 }
@@ -1198,7 +1251,7 @@ func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, n
 // match, writes the focus_request row. Retained as the switcher-less path
 // (select-only / no live switch); delegates to routeFocus.
 func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool) error {
-	return routeFocus(db, instances, id, nowNano, attach, nil)
+	return routeFocus(db, instances, id, nowNano, attach, nil, nil)
 }
 
 // handleSessionFocus signals the running TUI (same profile) to select <id> on
@@ -1234,10 +1287,12 @@ func handleSessionFocus(profile string, args []string) {
 	}
 
 	var switcher liveSwitcher
+	var detacher clientDetacher
 	if *attach {
 		switcher = tmuxLiveSwitcher{}
+		detacher = tmuxClientDetacher{}
 	}
-	if err := routeFocus(db, instances, id, time.Now().UnixNano(), *attach, switcher); err != nil {
+	if err := routeFocus(db, instances, id, time.Now().UnixNano(), *attach, switcher, detacher); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		if errors.Is(err, errFocusNotFound) {
 			os.Exit(2)
@@ -1342,6 +1397,7 @@ func handleSessionShow(profile string, args []string) {
 	}
 	modelInfo := inst.LaunchModelInfo()
 	addModelInfoJSON(jsonData, modelInfo)
+	addAutoNameJSON(jsonData, inst)
 
 	if inst.Command != "" {
 		jsonData["command"] = inst.Command

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -49,6 +49,8 @@ func handleSession(profile string, args []string) {
 		handleSessionFork(profile, args[1:])
 	case "attach":
 		handleSessionAttach(profile, args[1:])
+	case "focus":
+		handleSessionFocus(profile, args[1:])
 	case "show":
 		handleSessionShow(profile, args[1:])
 	case "current":
@@ -105,6 +107,7 @@ func printSessionHelp() {
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
 	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
 	fmt.Println("  attach <id>             Attach to session interactively")
+	fmt.Println("  focus <id>              Signal the running TUI to select a session")
 	fmt.Println("  show [id]               Show session details (auto-detect current if no id)")
 	fmt.Println("  current                 Show current session and profile (auto-detect)")
 	fmt.Println("  set <id> <field> <value>  Update session property")
@@ -1095,6 +1098,67 @@ func handleSessionAttach(profile string, args []string) {
 
 	if err := tmuxSession.Attach(ctx, detachByte); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to attach: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// errFocusNotFound signals that `session focus` was given an id absent from the
+// current profile. Callers map it to a distinct (exit 2) "not found" code.
+var errFocusNotFound = errors.New("session not found")
+
+// resolveAndWriteFocus validates id against the loaded instances and, on a
+// match, writes the focus_request row. Split out of handleSessionFocus so it is
+// unit-testable without os.Exit.
+func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64) error {
+	if id == "" {
+		return fmt.Errorf("session focus requires an <id>")
+	}
+	found := false
+	for _, inst := range instances {
+		if inst.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("%w: %q", errFocusNotFound, id)
+	}
+	return session.WriteFocusRequest(db, id, nowNano)
+}
+
+// handleSessionFocus signals the running TUI (same profile) to select <id> on
+// its next poll. Fire-and-forget: no stdout on success. Unknown id exits 2.
+func handleSessionFocus(profile string, args []string) {
+	fs := flag.NewFlagSet("session focus", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session focus <id>")
+		fmt.Println()
+		fmt.Println("Signal the running agent-deck TUI (same profile) to reveal and")
+		fmt.Println("select the session with the given instance id on its next refresh.")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	id := fs.Arg(0)
+
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	db := storage.GetDB()
+	if db == nil {
+		fmt.Fprintln(os.Stderr, "Error: no state database available")
+		os.Exit(1)
+	}
+
+	if err := resolveAndWriteFocus(db, instances, id, time.Now().UnixNano()); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if errors.Is(err, errFocusNotFound) {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -107,7 +107,7 @@ func printSessionHelp() {
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
 	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
 	fmt.Println("  attach <id>             Attach to session interactively")
-	fmt.Println("  focus <id>              Signal the running TUI to select a session")
+	fmt.Println("  focus <id> [--attach]   Signal the running TUI to select (or --attach) a session")
 	fmt.Println("  show [id]               Show session details (auto-detect current if no id)")
 	fmt.Println("  current                 Show current session and profile (auto-detect)")
 	fmt.Println("  set <id> <field> <value>  Update session property")
@@ -172,6 +172,7 @@ func handleSessionStart(profile string, args []string) {
 	message := fs.String("message", "", "Initial message to send once agent is ready")
 	messageShort := fs.String("m", "", "Initial message to send once agent is ready (short)")
 	yoloMode := fs.Bool("yolo", false, "Enable YOLO mode when starting Gemini or Codex sessions")
+	attach := fs.Bool("attach", false, "Attach to the session after starting (requires an interactive terminal)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session start <id|title> [options]")
@@ -274,6 +275,27 @@ func handleSessionStart(profile string, args []string) {
 	if err := saveSessionData(storage, instances, groups); err != nil {
 		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
+	}
+
+	// --attach: drop the user into the freshly started session's pane. This
+	// suspends the CLI into tmux and blocks until the user detaches, so the
+	// normal success output below is skipped. Refused loudly (never silently)
+	// without an interactive terminal or under --json; the session stays
+	// started in both cases.
+	if *attach {
+		if *jsonOutput {
+			out.Error("--attach cannot be combined with --json; session was started", ErrCodeInvalidOperation)
+			os.Exit(3)
+		}
+		if err := attachInstanceInteractive(inst); err != nil {
+			if errors.Is(err, errAttachNoTTY) {
+				fmt.Fprintf(os.Stderr, "Error: %v; session was started\n", err)
+				os.Exit(3)
+			}
+			fmt.Fprintf(os.Stderr, "Error: failed to attach: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	// Output success
@@ -1109,7 +1131,7 @@ var errFocusNotFound = errors.New("session not found")
 // resolveAndWriteFocus validates id against the loaded instances and, on a
 // match, writes the focus_request row. Split out of handleSessionFocus so it is
 // unit-testable without os.Exit.
-func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64) error {
+func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool) error {
 	if id == "" {
 		return fmt.Errorf("session focus requires an <id>")
 	}
@@ -1123,18 +1145,22 @@ func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id
 	if !found {
 		return fmt.Errorf("%w: %q", errFocusNotFound, id)
 	}
-	return session.WriteFocusRequest(db, id, nowNano)
+	return session.WriteFocusRequestAttach(db, id, nowNano, attach)
 }
 
 // handleSessionFocus signals the running TUI (same profile) to select <id> on
 // its next poll. Fire-and-forget: no stdout on success. Unknown id exits 2.
+// With --attach, the TUI opens/attaches the session instead of only selecting it.
 func handleSessionFocus(profile string, args []string) {
 	fs := flag.NewFlagSet("session focus", flag.ExitOnError)
+	attach := fs.Bool("attach", false, "Open/attach the session, not just select it")
 	fs.Usage = func() {
-		fmt.Println("Usage: agent-deck session focus <id>")
+		fmt.Println("Usage: agent-deck session focus <id> [--attach]")
 		fmt.Println()
 		fmt.Println("Signal the running agent-deck TUI (same profile) to reveal and")
 		fmt.Println("select the session with the given instance id on its next refresh.")
+		fmt.Println("With --attach, the TUI opens/attaches the session (as if you")
+		fmt.Println("pressed Enter on it) instead of only moving the cursor.")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
@@ -1154,7 +1180,7 @@ func handleSessionFocus(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	if err := resolveAndWriteFocus(db, instances, id, time.Now().UnixNano()); err != nil {
+	if err := resolveAndWriteFocus(db, instances, id, time.Now().UnixNano(), *attach); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		if errors.Is(err, errFocusNotFound) {
 			os.Exit(2)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1128,24 +1128,77 @@ func handleSessionAttach(profile string, args []string) {
 // current profile. Callers map it to a distinct (exit 2) "not found" code.
 var errFocusNotFound = errors.New("session not found")
 
-// resolveAndWriteFocus validates id against the loaded instances and, on a
-// match, writes the focus_request row. Split out of handleSessionFocus so it is
-// unit-testable without os.Exit.
-func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool) error {
+// liveSwitcher attempts to move the attached terminal straight into a session's
+// tmux pane (the Ctrl+b N quick-switch path), so a notification click lands you
+// in the session even while the TUI is paused inside another attach. Injected
+// into routeFocus so the attached-vs-list routing is unit-testable without a
+// real tmux server.
+type liveSwitcher interface {
+	// switchInto moves the client attached to inst's tmux server into inst's
+	// pane. Returns switched=true iff a client was attached and moved; false
+	// (no error) when inst has no live pane or no client is attached on its
+	// socket, signalling the caller to fall back to a focus_request row.
+	switchInto(inst *session.Instance) (bool, error)
+}
+
+// tmuxLiveSwitcher is the production liveSwitcher. It mirrors the Ctrl+b N
+// quick-switch: tmux switch-client + an ack-signal write, both of which work
+// while the Bubble Tea TUI is suspended during tea.Exec.
+type tmuxLiveSwitcher struct{}
+
+func (tmuxLiveSwitcher) switchInto(inst *session.Instance) (bool, error) {
+	if inst == nil || !inst.Exists() {
+		return false, nil
+	}
+	ts := inst.GetTmuxSession()
+	if ts == nil || ts.Name == "" {
+		return false, nil
+	}
+	// Query/switch on the target's own socket: switch-client only works when the
+	// attached client and the target session share a tmux server, so a client on
+	// a different socket simply yields switched=false and the focus_request
+	// fallback takes over (matches the Ctrl+b N same-server limitation).
+	return tmux.SwitchAttachedClients(inst.TmuxSocketName, ts.Name, inst.ID)
+}
+
+// findFocusInstance returns the instance with the given id, or nil.
+func findFocusInstance(instances []*session.Instance, id string) *session.Instance {
+	for _, inst := range instances {
+		if inst.ID == id {
+			return inst
+		}
+	}
+	return nil
+}
+
+// routeFocus drives `session focus <id>`. With --attach it first tries a live
+// switch-while-attached (so the click lands you straight in the session even
+// when the TUI is paused inside another attach); if no client is attached to the
+// target's tmux server it falls back to the foreground focus_request row, which
+// the TUI consumes on its next tick. Without --attach it always writes the
+// (select-only) focus_request. Split out of handleSessionFocus so it is
+// unit-testable without os.Exit; switcher is injected for the same reason.
+func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool, switcher liveSwitcher) error {
 	if id == "" {
 		return fmt.Errorf("session focus requires an <id>")
 	}
-	found := false
-	for _, inst := range instances {
-		if inst.ID == id {
-			found = true
-			break
-		}
-	}
-	if !found {
+	inst := findFocusInstance(instances, id)
+	if inst == nil {
 		return fmt.Errorf("%w: %q", errFocusNotFound, id)
 	}
+	if attach && switcher != nil {
+		if switched, _ := switcher.switchInto(inst); switched {
+			return nil
+		}
+	}
 	return session.WriteFocusRequestAttach(db, id, nowNano, attach)
+}
+
+// resolveAndWriteFocus validates id against the loaded instances and, on a
+// match, writes the focus_request row. Retained as the switcher-less path
+// (select-only / no live switch); delegates to routeFocus.
+func resolveAndWriteFocus(db *statedb.StateDB, instances []*session.Instance, id string, nowNano int64, attach bool) error {
+	return routeFocus(db, instances, id, nowNano, attach, nil)
 }
 
 // handleSessionFocus signals the running TUI (same profile) to select <id> on
@@ -1180,7 +1233,11 @@ func handleSessionFocus(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	if err := resolveAndWriteFocus(db, instances, id, time.Now().UnixNano(), *attach); err != nil {
+	var switcher liveSwitcher
+	if *attach {
+		switcher = tmuxLiveSwitcher{}
+	}
+	if err := routeFocus(db, instances, id, time.Now().UnixNano(), *attach, switcher); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		if errors.Is(err, errFocusNotFound) {
 			os.Exit(2)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1225,7 +1225,15 @@ func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, n
 		return fmt.Errorf("%w: %q", errFocusNotFound, id)
 	}
 	if attach && switcher != nil {
-		if switched, _ := switcher.switchInto(inst); switched {
+		// The contract reserves (false, nil) for the benign fallback (no live
+		// pane / no client attached on the socket); a non-nil error is a real
+		// tmux failure that must surface, not be silently swallowed into the
+		// fallback path.
+		switched, err := switcher.switchInto(inst)
+		if err != nil {
+			return err
+		}
+		if switched {
 			return nil
 		}
 		// Live switch couldn't move the client: it's attached to a different tmux
@@ -1240,7 +1248,12 @@ func routeFocus(db *statedb.StateDB, instances []*session.Instance, id string, n
 			if err := session.WriteFocusRequestAttach(db, id, nowNano, attach); err != nil {
 				return err
 			}
-			_, _ = detacher.detachClientsOn(focusOtherSockets(instances, inst.TmuxSocketName))
+			// The focus_request is already persisted, so a detach failure still
+			// leaves the row to be consumed on the next tick — but surface it so
+			// the immediate-switch path's failure isn't hidden.
+			if _, err := detacher.detachClientsOn(focusOtherSockets(instances, inst.TmuxSocketName)); err != nil {
+				return err
+			}
 			return nil
 		}
 	}

--- a/cmd/agent-deck/session_focus_test.go
+++ b/cmd/agent-deck/session_focus_test.go
@@ -28,7 +28,7 @@ func TestResolveAndWriteFocus_ValidID(t *testing.T) {
 	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
 	now := time.Now().UnixNano()
 
-	if err := resolveAndWriteFocus(db, []*session.Instance{inst}, inst.ID, now); err != nil {
+	if err := resolveAndWriteFocus(db, []*session.Instance{inst}, inst.ID, now, false); err != nil {
 		t.Fatalf("resolveAndWriteFocus valid id: %v", err)
 	}
 
@@ -36,9 +36,28 @@ func TestResolveAndWriteFocus_ValidID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	id, fresh := session.DecodeFocusRequest(raw, now, session.FocusRequestTTL)
-	if id != inst.ID || !fresh {
-		t.Fatalf("stored request = (%q, %v), want (%q, true)", id, fresh, inst.ID)
+	id, attach, fresh := session.DecodeFocusRequestAttach(raw, now, session.FocusRequestTTL)
+	if id != inst.ID || !fresh || attach {
+		t.Fatalf("stored request = (%q, attach=%v, fresh=%v), want (%q, false, true)", id, attach, fresh, inst.ID)
+	}
+}
+
+func TestResolveAndWriteFocus_Attach(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	now := time.Now().UnixNano()
+
+	if err := resolveAndWriteFocus(db, []*session.Instance{inst}, inst.ID, now, true); err != nil {
+		t.Fatalf("resolveAndWriteFocus attach: %v", err)
+	}
+
+	raw, err := session.ReadFocusRequest(db)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	id, attach, fresh := session.DecodeFocusRequestAttach(raw, now, session.FocusRequestTTL)
+	if id != inst.ID || !fresh || !attach {
+		t.Fatalf("stored request = (%q, attach=%v, fresh=%v), want (%q, true, true)", id, attach, fresh, inst.ID)
 	}
 }
 
@@ -46,7 +65,7 @@ func TestResolveAndWriteFocus_UnknownID(t *testing.T) {
 	db := newTempStateDB(t)
 	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
 
-	err := resolveAndWriteFocus(db, []*session.Instance{inst}, "does-not-exist", time.Now().UnixNano())
+	err := resolveAndWriteFocus(db, []*session.Instance{inst}, "does-not-exist", time.Now().UnixNano(), false)
 	if !errors.Is(err, errFocusNotFound) {
 		t.Fatalf("unknown id err = %v, want errFocusNotFound", err)
 	}
@@ -58,7 +77,7 @@ func TestResolveAndWriteFocus_UnknownID(t *testing.T) {
 
 func TestResolveAndWriteFocus_EmptyID(t *testing.T) {
 	db := newTempStateDB(t)
-	if err := resolveAndWriteFocus(db, nil, "", time.Now().UnixNano()); err == nil {
+	if err := resolveAndWriteFocus(db, nil, "", time.Now().UnixNano(), false); err == nil {
 		t.Fatal("empty id: want error, got nil")
 	}
 }

--- a/cmd/agent-deck/session_focus_test.go
+++ b/cmd/agent-deck/session_focus_test.go
@@ -104,7 +104,7 @@ func TestRouteFocus_AttachLiveSwitch_NoFocusRow(t *testing.T) {
 	sw := &fakeSwitcher{switched: true}
 	now := time.Now().UnixNano()
 
-	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, true, sw); err != nil {
+	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, true, sw, nil); err != nil {
 		t.Fatalf("routeFocus: %v", err)
 	}
 	if sw.calls != 1 || sw.gotInst != inst {
@@ -123,7 +123,7 @@ func TestRouteFocus_AttachFallback_WritesFocusRow(t *testing.T) {
 	sw := &fakeSwitcher{switched: false}
 	now := time.Now().UnixNano()
 
-	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, true, sw); err != nil {
+	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, true, sw, nil); err != nil {
 		t.Fatalf("routeFocus: %v", err)
 	}
 	raw, err := session.ReadFocusRequest(db)
@@ -144,7 +144,7 @@ func TestRouteFocus_NoAttach_SkipsSwitcher(t *testing.T) {
 	sw := &fakeSwitcher{switched: true}
 	now := time.Now().UnixNano()
 
-	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, false, sw); err != nil {
+	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, false, sw, nil); err != nil {
 		t.Fatalf("routeFocus: %v", err)
 	}
 	if sw.calls != 0 {
@@ -163,7 +163,7 @@ func TestRouteFocus_UnknownID(t *testing.T) {
 	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
 	sw := &fakeSwitcher{switched: true}
 
-	err := routeFocus(db, []*session.Instance{inst}, "nope", time.Now().UnixNano(), true, sw)
+	err := routeFocus(db, []*session.Instance{inst}, "nope", time.Now().UnixNano(), true, sw, nil)
 	if !errors.Is(err, errFocusNotFound) {
 		t.Fatalf("unknown id err = %v, want errFocusNotFound", err)
 	}
@@ -172,5 +172,101 @@ func TestRouteFocus_UnknownID(t *testing.T) {
 	}
 	if raw, _ := session.ReadFocusRequest(db); raw != "" {
 		t.Fatalf("unknown id wrote a row: %q", raw)
+	}
+}
+
+// fakeDetacher records the sockets it was asked to detach clients on, so
+// routeFocus's cross-socket detach-and-reattach wiring is testable without a
+// real tmux server.
+type fakeDetacher struct {
+	calls      int
+	gotSockets []string
+	detached   bool
+}
+
+func (f *fakeDetacher) detachClientsOn(sockets []string) (bool, error) {
+	f.calls++
+	f.gotSockets = sockets
+	return f.detached, nil
+}
+
+func instOnSocket(id, socket string) *session.Instance {
+	inst := session.NewInstanceWithTool(id, "/tmp/"+id, "claude")
+	inst.TmuxSocketName = socket
+	return inst
+}
+
+// When the live switch fails (target on a different socket than the attached
+// client), routeFocus must BOTH write the focus_request AND detach the client on
+// the other socket(s) — so the paused TUI resumes and consumes the row, instead
+// of waiting for a manual Ctrl+Q. The focus_request must be written before the
+// detach, so the resumed TUI finds it on the next tick.
+func TestRouteFocus_CrossSocketFallback_DetachesOtherSocket(t *testing.T) {
+	db := newTempStateDB(t)
+	target := instOnSocket("t1", "agent-deck") // notification target
+	other := instOnSocket("o1", "")            // attached session on the default socket
+	sw := &fakeSwitcher{switched: false}       // no client on the target's socket
+	det := &fakeDetacher{detached: true}
+	now := time.Now().UnixNano()
+
+	if err := routeFocus(db, []*session.Instance{target, other}, target.ID, now, true, sw, det); err != nil {
+		t.Fatalf("routeFocus: %v", err)
+	}
+
+	// The focus_request --attach must be written so the resumed TUI attaches it.
+	raw, err := session.ReadFocusRequest(db)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	id, attach, fresh := session.DecodeFocusRequestAttach(raw, now, session.FocusRequestTTL)
+	if id != target.ID || !attach || !fresh {
+		t.Fatalf("row = (%q, attach=%v, fresh=%v), want (%q, true, true)", id, attach, fresh, target.ID)
+	}
+
+	// The client on the OTHER socket must be detached so the TUI resumes.
+	if det.calls != 1 {
+		t.Fatalf("detacher calls=%d, want 1", det.calls)
+	}
+	if len(det.gotSockets) != 1 || det.gotSockets[0] != "" {
+		t.Fatalf("detached sockets=%v, want [\"\"] (the other socket, target's own excluded)", det.gotSockets)
+	}
+}
+
+// When the live switch succeeds (same socket), no detach happens and no
+// focus_request is written.
+func TestRouteFocus_LiveSwitch_SkipsDetacher(t *testing.T) {
+	db := newTempStateDB(t)
+	target := instOnSocket("t1", "agent-deck")
+	sw := &fakeSwitcher{switched: true}
+	det := &fakeDetacher{detached: true}
+
+	if err := routeFocus(db, []*session.Instance{target}, target.ID, time.Now().UnixNano(), true, sw, det); err != nil {
+		t.Fatalf("routeFocus: %v", err)
+	}
+	if det.calls != 0 {
+		t.Fatalf("detacher consulted %d times after a successful live switch, want 0", det.calls)
+	}
+	if raw, _ := session.ReadFocusRequest(db); raw != "" {
+		t.Fatalf("live switch must not write a focus_request, got %q", raw)
+	}
+}
+
+func TestFocusOtherSockets_DedupExcludesTarget(t *testing.T) {
+	instances := []*session.Instance{
+		instOnSocket("a", "agent-deck"),
+		instOnSocket("b", "agent-deck"),
+		instOnSocket("c", ""),
+		instOnSocket("d", "default"),
+		instOnSocket("e", ""),
+	}
+	got := focusOtherSockets(instances, "agent-deck")
+	want := []string{"", "default"}
+	if len(got) != len(want) {
+		t.Fatalf("focusOtherSockets = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("focusOtherSockets = %v, want %v", got, want)
+		}
 	}
 }

--- a/cmd/agent-deck/session_focus_test.go
+++ b/cmd/agent-deck/session_focus_test.go
@@ -81,3 +81,96 @@ func TestResolveAndWriteFocus_EmptyID(t *testing.T) {
 		t.Fatal("empty id: want error, got nil")
 	}
 }
+
+// fakeSwitcher records calls and returns a canned switched result, so routeFocus's
+// attached-vs-list routing is testable without a real tmux server.
+type fakeSwitcher struct {
+	switched bool
+	calls    int
+	gotInst  *session.Instance
+}
+
+func (f *fakeSwitcher) switchInto(inst *session.Instance) (bool, error) {
+	f.calls++
+	f.gotInst = inst
+	return f.switched, nil
+}
+
+// When a client is attached to the target's tmux server, the live switch wins and
+// no focus_request row is written (otherwise the row would re-attach on detach).
+func TestRouteFocus_AttachLiveSwitch_NoFocusRow(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	sw := &fakeSwitcher{switched: true}
+	now := time.Now().UnixNano()
+
+	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, true, sw); err != nil {
+		t.Fatalf("routeFocus: %v", err)
+	}
+	if sw.calls != 1 || sw.gotInst != inst {
+		t.Fatalf("switcher calls=%d gotInst=%v, want 1 call with the target instance", sw.calls, sw.gotInst)
+	}
+	if raw, _ := session.ReadFocusRequest(db); raw != "" {
+		t.Fatalf("live switch must not write a focus_request, got %q", raw)
+	}
+}
+
+// When no client is attached on the target's server (switched=false), routeFocus
+// falls back to the foreground focus_request --attach path.
+func TestRouteFocus_AttachFallback_WritesFocusRow(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	sw := &fakeSwitcher{switched: false}
+	now := time.Now().UnixNano()
+
+	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, true, sw); err != nil {
+		t.Fatalf("routeFocus: %v", err)
+	}
+	raw, err := session.ReadFocusRequest(db)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	id, attach, fresh := session.DecodeFocusRequestAttach(raw, now, session.FocusRequestTTL)
+	if id != inst.ID || !attach || !fresh {
+		t.Fatalf("fallback row = (%q, attach=%v, fresh=%v), want (%q, true, true)", id, attach, fresh, inst.ID)
+	}
+}
+
+// Without --attach there is nothing to switch into (the list isn't on screen), so
+// the live switcher must never be consulted.
+func TestRouteFocus_NoAttach_SkipsSwitcher(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	sw := &fakeSwitcher{switched: true}
+	now := time.Now().UnixNano()
+
+	if err := routeFocus(db, []*session.Instance{inst}, inst.ID, now, false, sw); err != nil {
+		t.Fatalf("routeFocus: %v", err)
+	}
+	if sw.calls != 0 {
+		t.Fatalf("switcher consulted %d times for a non-attach focus, want 0", sw.calls)
+	}
+	raw, _ := session.ReadFocusRequest(db)
+	id, attach, _ := session.DecodeFocusRequestAttach(raw, now, session.FocusRequestTTL)
+	if id != inst.ID || attach {
+		t.Fatalf("row = (%q, attach=%v), want (%q, false)", id, attach, inst.ID)
+	}
+}
+
+// An unknown id is rejected before any switch attempt or row write.
+func TestRouteFocus_UnknownID(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	sw := &fakeSwitcher{switched: true}
+
+	err := routeFocus(db, []*session.Instance{inst}, "nope", time.Now().UnixNano(), true, sw)
+	if !errors.Is(err, errFocusNotFound) {
+		t.Fatalf("unknown id err = %v, want errFocusNotFound", err)
+	}
+	if sw.calls != 0 {
+		t.Fatalf("switcher consulted on unknown id (%d calls)", sw.calls)
+	}
+	if raw, _ := session.ReadFocusRequest(db); raw != "" {
+		t.Fatalf("unknown id wrote a row: %q", raw)
+	}
+}

--- a/cmd/agent-deck/session_focus_test.go
+++ b/cmd/agent-deck/session_focus_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+func newTempStateDB(t *testing.T) *statedb.StateDB {
+	t.Helper()
+	db, err := statedb.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestResolveAndWriteFocus_ValidID(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	now := time.Now().UnixNano()
+
+	if err := resolveAndWriteFocus(db, []*session.Instance{inst}, inst.ID, now); err != nil {
+		t.Fatalf("resolveAndWriteFocus valid id: %v", err)
+	}
+
+	raw, err := session.ReadFocusRequest(db)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	id, fresh := session.DecodeFocusRequest(raw, now, session.FocusRequestTTL)
+	if id != inst.ID || !fresh {
+		t.Fatalf("stored request = (%q, %v), want (%q, true)", id, fresh, inst.ID)
+	}
+}
+
+func TestResolveAndWriteFocus_UnknownID(t *testing.T) {
+	db := newTempStateDB(t)
+	inst := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+
+	err := resolveAndWriteFocus(db, []*session.Instance{inst}, "does-not-exist", time.Now().UnixNano())
+	if !errors.Is(err, errFocusNotFound) {
+		t.Fatalf("unknown id err = %v, want errFocusNotFound", err)
+	}
+	// No row should have been written.
+	if raw, _ := session.ReadFocusRequest(db); raw != "" {
+		t.Fatalf("unknown id wrote a row: %q", raw)
+	}
+}
+
+func TestResolveAndWriteFocus_EmptyID(t *testing.T) {
+	db := newTempStateDB(t)
+	if err := resolveAndWriteFocus(db, nil, "", time.Now().UnixNano()); err == nil {
+		t.Fatal("empty id: want error, got nil")
+	}
+}

--- a/cmd/agent-deck/session_show_autoname_test.go
+++ b/cmd/agent-deck/session_show_autoname_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// `session show --json` must surface the auto-name fields so the notification
+// hook can show the meaningful task description (auto_name_description) instead
+// of the machine-generated handle (title). The description key is present only
+// when non-empty; auto_name is always present.
+func TestAddAutoNameJSON_PresentWhenSet(t *testing.T) {
+	inst := session.NewInstanceWithTool("azure-spruce", "/tmp/x", "claude")
+	inst.SetAutoName(true)
+	inst.SetAutoNameDescription("Add activity logging for projects")
+
+	jsonData := map[string]interface{}{}
+	addAutoNameJSON(jsonData, inst)
+
+	if got, ok := jsonData["auto_name"].(bool); !ok || !got {
+		t.Fatalf("auto_name = %v (ok=%v), want true", jsonData["auto_name"], ok)
+	}
+	if got := jsonData["auto_name_description"]; got != "Add activity logging for projects" {
+		t.Fatalf("auto_name_description = %v, want the task description", got)
+	}
+}
+
+// When there is no captured description, the description key is omitted (absence
+// is unambiguous) but auto_name still reports the flag.
+func TestAddAutoNameJSON_OmitsEmptyDescription(t *testing.T) {
+	inst := session.NewInstanceWithTool("plain", "/tmp/y", "claude")
+
+	jsonData := map[string]interface{}{}
+	addAutoNameJSON(jsonData, inst)
+
+	if got, ok := jsonData["auto_name"].(bool); !ok || got {
+		t.Fatalf("auto_name = %v (ok=%v), want false", jsonData["auto_name"], ok)
+	}
+	if _, present := jsonData["auto_name_description"]; present {
+		t.Fatalf("auto_name_description must be omitted when empty, got %v", jsonData["auto_name_description"])
+	}
+}

--- a/cmd/agent-deck/tmux_path.go
+++ b/cmd/agent-deck/tmux_path.go
@@ -48,7 +48,10 @@ func ensureTmuxOnPath() {
 	_, err := exec.LookPath("tmux")
 	newPath := resolveTmuxPATH(os.Getenv("PATH"), err == nil, tmuxInstallDirs, func(dir string) bool {
 		info, statErr := os.Stat(filepath.Join(dir, "tmux"))
-		return statErr == nil && !info.IsDir()
+		// Require a regular, executable file: a non-executable file named "tmux"
+		// can't satisfy a bare `tmux` invocation, so adding its dir to PATH is
+		// pointless (exec.LookPath would reject it anyway).
+		return statErr == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
 	})
 	if newPath != os.Getenv("PATH") {
 		_ = os.Setenv("PATH", newPath)

--- a/cmd/agent-deck/tmux_path.go
+++ b/cmd/agent-deck/tmux_path.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// tmuxInstallDirs are the well-known locations a `tmux` binary lands in but that
+// the launchd default PATH (/usr/bin:/bin:/usr/sbin:/sbin) omits: Homebrew on
+// Apple Silicon and Intel, then MacPorts.
+var tmuxInstallDirs = []string{"/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"}
+
+// resolveTmuxPATH returns path augmented with the first candidate dir that holds
+// a tmux binary, when tmux is not already resolvable on path. It never
+// duplicates a dir already present and is a no-op when tmux is resolvable or no
+// candidate has it. Pure (deps injected) so it is unit-testable.
+func resolveTmuxPATH(path string, tmuxResolvable bool, candidates []string, hasTmux func(dir string) bool) string {
+	if tmuxResolvable {
+		return path
+	}
+	onPath := map[string]bool{}
+	for _, d := range strings.Split(path, string(os.PathListSeparator)) {
+		onPath[d] = true
+	}
+	for _, dir := range candidates {
+		if onPath[dir] || !hasTmux(dir) {
+			continue
+		}
+		if path == "" {
+			return dir
+		}
+		return dir + string(os.PathListSeparator) + path
+	}
+	return path
+}
+
+// ensureTmuxOnPath augments the process $PATH so bare `tmux` invocations resolve
+// even when agent-deck was launched from a minimal environment. The critical
+// case: a notification click runs `terminal-notifier -execute "... agent-deck
+// session focus <id> --attach"`, which inherits the launchd default PATH with no
+// Homebrew dir — so every tmux call (switch-client, detach-client, list-clients)
+// silently fails and the notification switch can never fire (it falls back to a
+// focus_request the paused TUI only consumes on Ctrl+Q). Idempotent and a no-op
+// when tmux is already resolvable.
+func ensureTmuxOnPath() {
+	_, err := exec.LookPath("tmux")
+	newPath := resolveTmuxPATH(os.Getenv("PATH"), err == nil, tmuxInstallDirs, func(dir string) bool {
+		info, statErr := os.Stat(filepath.Join(dir, "tmux"))
+		return statErr == nil && !info.IsDir()
+	})
+	if newPath != os.Getenv("PATH") {
+		_ = os.Setenv("PATH", newPath)
+	}
+}

--- a/cmd/agent-deck/tmux_path_test.go
+++ b/cmd/agent-deck/tmux_path_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+// agent-deck shells out to `tmux` by bare name. When launched from a minimal
+// environment — most importantly a `terminal-notifier -execute` notification
+// click, whose PATH is the launchd default /usr/bin:/bin:/usr/sbin:/sbin —
+// Homebrew's /opt/homebrew/bin is absent and every tmux call fails (no session
+// switch, no detach, status flips to error). resolveTmuxPATH prepends the first
+// known tmux install dir so those calls resolve.
+
+func TestResolveTmuxPATH_PrependsMissingDir(t *testing.T) {
+	hasTmux := func(dir string) bool { return dir == "/opt/homebrew/bin" }
+	got := resolveTmuxPATH("/usr/bin:/bin", false, []string{"/opt/homebrew/bin", "/usr/local/bin"}, hasTmux)
+	want := "/opt/homebrew/bin:/usr/bin:/bin"
+	if got != want {
+		t.Fatalf("resolveTmuxPATH = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTmuxPATH_NoopWhenAlreadyResolvable(t *testing.T) {
+	hasTmux := func(string) bool { return true }
+	got := resolveTmuxPATH("/usr/bin:/bin", true, []string{"/opt/homebrew/bin"}, hasTmux)
+	if got != "/usr/bin:/bin" {
+		t.Fatalf("resolveTmuxPATH must not change PATH when tmux already resolvable, got %q", got)
+	}
+}
+
+func TestResolveTmuxPATH_NoopWhenCandidateAlreadyOnPath(t *testing.T) {
+	hasTmux := func(string) bool { return true }
+	path := "/opt/homebrew/bin:/usr/bin"
+	got := resolveTmuxPATH(path, false, []string{"/opt/homebrew/bin"}, hasTmux)
+	if got != path {
+		t.Fatalf("resolveTmuxPATH must not duplicate a dir already on PATH, got %q", got)
+	}
+}
+
+func TestResolveTmuxPATH_NoopWhenNoCandidateHasTmux(t *testing.T) {
+	hasTmux := func(string) bool { return false }
+	path := "/usr/bin:/bin"
+	got := resolveTmuxPATH(path, false, []string{"/opt/homebrew/bin", "/usr/local/bin"}, hasTmux)
+	if got != path {
+		t.Fatalf("resolveTmuxPATH must not change PATH when no candidate has tmux, got %q", got)
+	}
+}
+
+func TestResolveTmuxPATH_EmptyPathBecomesDir(t *testing.T) {
+	hasTmux := func(dir string) bool { return dir == "/opt/homebrew/bin" }
+	got := resolveTmuxPATH("", false, []string{"/opt/homebrew/bin"}, hasTmux)
+	if got != "/opt/homebrew/bin" {
+		t.Fatalf("resolveTmuxPATH with empty PATH = %q, want %q", got, "/opt/homebrew/bin")
+	}
+}

--- a/internal/session/attach_on_create_test.go
+++ b/internal/session/attach_on_create_test.go
@@ -1,0 +1,43 @@
+package session
+
+// [ui].attach_on_create controls whether the TUI attaches to a newly created
+// session immediately (instead of only selecting it). It is opt-IN: default
+// false preserves today's select-only behavior so existing users see no change.
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Default: key absent → select-only (false).
+func TestAttachOnCreate_DefaultsOffWhenUnset(t *testing.T) {
+	var ui UISettings // zero value: key never set in config.toml.
+	if ui.GetAttachOnCreate() {
+		t.Fatalf("GetAttachOnCreate() on unset config = true, want false (attach-on-create is opt-in)")
+	}
+}
+
+// Opt-IN: explicit `= true` enables attach-on-create.
+func TestAttachOnCreate_ExplicitTrueEnables(t *testing.T) {
+	const doc = "[ui]\nattach_on_create = true\n"
+	var cfg UserConfig
+	if _, err := toml.Decode(doc, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !cfg.UI.GetAttachOnCreate() {
+		t.Fatalf("explicit attach_on_create=true reported GetAttachOnCreate()=false")
+	}
+}
+
+// Explicit `= false` stays select-only.
+func TestAttachOnCreate_ExplicitFalseStaysOff(t *testing.T) {
+	const doc = "[ui]\nattach_on_create = false\n"
+	var cfg UserConfig
+	if _, err := toml.Decode(doc, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.UI.GetAttachOnCreate() {
+		t.Fatalf("explicit attach_on_create=false reported GetAttachOnCreate()=true")
+	}
+}

--- a/internal/session/focus.go
+++ b/internal/session/focus.go
@@ -64,7 +64,12 @@ func DecodeFocusRequestAttach(val string, nowNano int64, ttl time.Duration) (id 
 	if fr.ID == "" {
 		return "", false, false
 	}
-	if nowNano-fr.TS > int64(ttl) {
+	// Stale when older than the TTL, and also when the timestamp is more than a
+	// TTL in the future: a backward clock jump or corrupted payload must not be
+	// honored as a fresh focus request (which would trigger a spurious switch)
+	// indefinitely until wall-clock catches up. A modest skew within ±ttl still
+	// counts as fresh.
+	if age := nowNano - fr.TS; age > int64(ttl) || age < -int64(ttl) {
 		return fr.ID, fr.Attach, false
 	}
 	return fr.ID, fr.Attach, true
@@ -94,4 +99,12 @@ func ReadFocusRequest(db *statedb.StateDB) (string, error) {
 // DeleteMeta, so an empty value is the documented "no request" sentinel.
 func ClearFocusRequest(db *statedb.StateDB) error {
 	return db.SetMeta(FocusRequestKey, "")
+}
+
+// TakeFocusRequest atomically reads and clears the pending request in one
+// statement (consume-once). Prefer it over ReadFocusRequest+ClearFocusRequest:
+// the separate read+clear has a window where a concurrent CLI `session focus`
+// write lands between them and is wiped by the clear. Returns "" when none.
+func TakeFocusRequest(db *statedb.StateDB) (string, error) {
+	return db.TakeMeta(FocusRequestKey)
 }

--- a/internal/session/focus.go
+++ b/internal/session/focus.go
@@ -20,11 +20,21 @@ const FocusRequestTTL = 10 * time.Second
 type FocusRequest struct {
 	ID string `json:"id"`
 	TS int64  `json:"ts"` // unix nanoseconds when the request was written
+	// Attach asks the TUI to open/attach the session (as if the user pressed
+	// Enter), not merely move the cursor to it. omitempty keeps a plain
+	// select-only request byte-identical to the pre-attach format.
+	Attach bool `json:"attach,omitempty"`
 }
 
-// EncodeFocusRequest serializes a focus request payload.
+// EncodeFocusRequest serializes a select-only focus request payload.
 func EncodeFocusRequest(id string, nowNano int64) (string, error) {
-	b, err := json.Marshal(FocusRequest{ID: id, TS: nowNano})
+	return EncodeFocusRequestAttach(id, nowNano, false)
+}
+
+// EncodeFocusRequestAttach serializes a focus request, optionally asking the TUI
+// to attach the session rather than just selecting it.
+func EncodeFocusRequestAttach(id string, nowNano int64, attach bool) (string, error) {
+	b, err := json.Marshal(FocusRequest{ID: id, TS: nowNano, Attach: attach})
 	if err != nil {
 		return "", err
 	}
@@ -36,25 +46,39 @@ func EncodeFocusRequest(id string, nowNano int64) (string, error) {
 // A stale-but-parseable payload returns its id with fresh=false so the caller
 // can still log/clear it.
 func DecodeFocusRequest(val string, nowNano int64, ttl time.Duration) (id string, fresh bool) {
+	id, _, fresh = DecodeFocusRequestAttach(val, nowNano, ttl)
+	return id, fresh
+}
+
+// DecodeFocusRequestAttach parses a stored payload and additionally reports
+// whether the request asked to attach the session. attach is only meaningful
+// when fresh is true.
+func DecodeFocusRequestAttach(val string, nowNano int64, ttl time.Duration) (id string, attach bool, fresh bool) {
 	if val == "" {
-		return "", false
+		return "", false, false
 	}
 	var fr FocusRequest
 	if err := json.Unmarshal([]byte(val), &fr); err != nil {
-		return "", false
+		return "", false, false
 	}
 	if fr.ID == "" {
-		return "", false
+		return "", false, false
 	}
 	if nowNano-fr.TS > int64(ttl) {
-		return fr.ID, false
+		return fr.ID, fr.Attach, false
 	}
-	return fr.ID, true
+	return fr.ID, fr.Attach, true
 }
 
-// WriteFocusRequest stores a focus request for the running TUI to consume.
+// WriteFocusRequest stores a select-only focus request for the running TUI to consume.
 func WriteFocusRequest(db *statedb.StateDB, id string, nowNano int64) error {
-	val, err := EncodeFocusRequest(id, nowNano)
+	return WriteFocusRequestAttach(db, id, nowNano, false)
+}
+
+// WriteFocusRequestAttach stores a focus request, optionally flagged to attach
+// the session on consume.
+func WriteFocusRequestAttach(db *statedb.StateDB, id string, nowNano int64, attach bool) error {
+	val, err := EncodeFocusRequestAttach(id, nowNano, attach)
 	if err != nil {
 		return err
 	}

--- a/internal/session/focus.go
+++ b/internal/session/focus.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// FocusRequestKey is the metadata key the CLI writes and the TUI polls to drive
+// session selection. The state.db is per-profile, so the key needs no profile
+// suffix — the CLI and TUI operate on the same profile's db.
+const FocusRequestKey = "focus_request"
+
+// FocusRequestTTL bounds how long a focus request stays actionable. A TUI that
+// starts minutes after a click must not jump on the stale request.
+const FocusRequestTTL = 10 * time.Second
+
+// FocusRequest is the JSON payload stored under FocusRequestKey.
+type FocusRequest struct {
+	ID string `json:"id"`
+	TS int64  `json:"ts"` // unix nanoseconds when the request was written
+}
+
+// EncodeFocusRequest serializes a focus request payload.
+func EncodeFocusRequest(id string, nowNano int64) (string, error) {
+	b, err := json.Marshal(FocusRequest{ID: id, TS: nowNano})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodeFocusRequest parses a stored payload. fresh is true only when the
+// payload is well-formed, has a non-empty id, and ts is within ttl of nowNano.
+// A stale-but-parseable payload returns its id with fresh=false so the caller
+// can still log/clear it.
+func DecodeFocusRequest(val string, nowNano int64, ttl time.Duration) (id string, fresh bool) {
+	if val == "" {
+		return "", false
+	}
+	var fr FocusRequest
+	if err := json.Unmarshal([]byte(val), &fr); err != nil {
+		return "", false
+	}
+	if fr.ID == "" {
+		return "", false
+	}
+	if nowNano-fr.TS > int64(ttl) {
+		return fr.ID, false
+	}
+	return fr.ID, true
+}
+
+// WriteFocusRequest stores a focus request for the running TUI to consume.
+func WriteFocusRequest(db *statedb.StateDB, id string, nowNano int64) error {
+	val, err := EncodeFocusRequest(id, nowNano)
+	if err != nil {
+		return err
+	}
+	return db.SetMeta(FocusRequestKey, val)
+}
+
+// ReadFocusRequest returns the raw stored payload ("" if none).
+func ReadFocusRequest(db *statedb.StateDB) (string, error) {
+	return db.GetMeta(FocusRequestKey)
+}
+
+// ClearFocusRequest consumes the request (consume-once). statedb has no
+// DeleteMeta, so an empty value is the documented "no request" sentinel.
+func ClearFocusRequest(db *statedb.StateDB) error {
+	return db.SetMeta(FocusRequestKey, "")
+}

--- a/internal/session/focus_test.go
+++ b/internal/session/focus_test.go
@@ -80,3 +80,35 @@ func TestFocusRequestDBRoundTrip(t *testing.T) {
 		t.Fatalf("ReadFocusRequest after clear = (%q, %v), want (\"\", nil)", got, err)
 	}
 }
+
+func TestFocusRequestAttachRoundTrip(t *testing.T) {
+	now := int64(2_000_000_000_000)
+	ttl := 10 * time.Second
+
+	// attach=true survives encode→decode.
+	withAttach, err := EncodeFocusRequestAttach("sess-1", now, true)
+	if err != nil {
+		t.Fatalf("encode attach: %v", err)
+	}
+	if id, attach, fresh := DecodeFocusRequestAttach(withAttach, now, ttl); id != "sess-1" || !attach || !fresh {
+		t.Fatalf("decode attach = (%q, %v, %v), want (sess-1, true, true)", id, attach, fresh)
+	}
+
+	// Select-only request decodes attach=false and stays byte-identical to the
+	// pre-attach format (omitempty drops the field).
+	selectOnly, err := EncodeFocusRequest("sess-1", now)
+	if err != nil {
+		t.Fatalf("encode select-only: %v", err)
+	}
+	if want := `{"id":"sess-1","ts":2000000000000}`; selectOnly != want {
+		t.Fatalf("select-only payload = %q, want %q", selectOnly, want)
+	}
+	if id, attach, fresh := DecodeFocusRequestAttach(selectOnly, now, ttl); id != "sess-1" || attach || !fresh {
+		t.Fatalf("decode select-only = (%q, %v, %v), want (sess-1, false, true)", id, attach, fresh)
+	}
+
+	// A stale attach request still surfaces attach for logging, but fresh=false.
+	if id, attach, fresh := DecodeFocusRequestAttach(withAttach, now+int64(11*time.Second), ttl); id != "sess-1" || !attach || fresh {
+		t.Fatalf("decode stale attach = (%q, %v, %v), want (sess-1, true, false)", id, attach, fresh)
+	}
+}

--- a/internal/session/focus_test.go
+++ b/internal/session/focus_test.go
@@ -1,0 +1,82 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+func TestDecodeFocusRequest(t *testing.T) {
+	now := int64(1_000_000_000_000) // arbitrary fixed "now" in unix nanos
+	ttl := 10 * time.Second
+
+	fresh, err := EncodeFocusRequest("abc123", now)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		val      string
+		now      int64
+		wantID   string
+		wantFresh bool
+	}{
+		{"fresh", fresh, now, "abc123", true},
+		{"within ttl", fresh, now + int64(9*time.Second), "abc123", true},
+		{"stale beyond ttl", fresh, now + int64(11*time.Second), "abc123", false},
+		{"empty", "", now, "", false},
+		{"malformed json", "{not json", now, "", false},
+		{"empty id", `{"id":"","ts":1}`, now, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := DecodeFocusRequest(tc.val, tc.now, ttl)
+			if id != tc.wantID || ok != tc.wantFresh {
+				t.Fatalf("DecodeFocusRequest(%q) = (%q, %v), want (%q, %v)",
+					tc.val, id, ok, tc.wantID, tc.wantFresh)
+			}
+		})
+	}
+}
+
+func TestFocusRequestDBRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := statedb.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// No request yet.
+	if got, err := ReadFocusRequest(db); err != nil || got != "" {
+		t.Fatalf("ReadFocusRequest empty = (%q, %v), want (\"\", nil)", got, err)
+	}
+
+	// Write, then read back and decode.
+	now := time.Now().UnixNano()
+	if err := WriteFocusRequest(db, "sess-1", now); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	raw, err := ReadFocusRequest(db)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	id, fresh := DecodeFocusRequest(raw, now, FocusRequestTTL)
+	if id != "sess-1" || !fresh {
+		t.Fatalf("decode after write = (%q, %v), want (sess-1, true)", id, fresh)
+	}
+
+	// Clear (consume-once).
+	if err := ClearFocusRequest(db); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got, err := ReadFocusRequest(db); err != nil || got != "" {
+		t.Fatalf("ReadFocusRequest after clear = (%q, %v), want (\"\", nil)", got, err)
+	}
+}

--- a/internal/session/focus_test.go
+++ b/internal/session/focus_test.go
@@ -18,10 +18,10 @@ func TestDecodeFocusRequest(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		val      string
-		now      int64
-		wantID   string
+		name      string
+		val       string
+		now       int64
+		wantID    string
 		wantFresh bool
 	}{
 		{"fresh", fresh, now, "abc123", true},

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -383,6 +383,15 @@ type UISettings struct {
 	// (`new_session_enter_advances = false` → restores the legacy Enter-submits
 	// behavior). Set `= true` (or leave unset) to keep the new default.
 	NewSessionEnterAdvances *bool `toml:"new_session_enter_advances"`
+
+	// AttachOnCreate controls whether creating a session in the TUI (the `n`
+	// new-session dialog) immediately attaches to the new session's pane
+	// instead of only moving the cursor to it. Default false: creating a
+	// session selects it (today's behavior) and the user presses Enter to
+	// attach. Set `= true` to "instantly open" each new session. CLI
+	// `add`/`session start` are unaffected by this flag — they attach only
+	// with an explicit `--attach`.
+	AttachOnCreate bool `toml:"attach_on_create,omitempty"`
 }
 
 // normalizeUIHiddenTools lowercases, dedupes, and drops unknown entries from
@@ -540,6 +549,12 @@ func (u UISettings) GetNewSessionEnterAdvances() bool {
 		return true // Default: ON (Enter advances; Ctrl+S submits).
 	}
 	return *u.NewSessionEnterAdvances
+}
+
+// GetAttachOnCreate reports whether the TUI should attach to a newly created
+// session immediately instead of only selecting it. Default false.
+func (u UISettings) GetAttachOnCreate() bool {
+	return u.AttachOnCreate
 }
 
 // GetRemoteLatencyRefreshSecs returns the remote latency refresh interval

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1497,6 +1497,27 @@ func (s *StateDB) GetMeta(key string) (string, error) {
 	return value, err
 }
 
+// TakeMeta reads a metadata value and clears it (sets to "") for consume-once
+// signals (e.g. focus_request). Use it instead of GetMeta-then-SetMeta(""): the
+// clear is a compare-and-clear that only wipes the row when it still holds the
+// value just read, so a newer value written by a concurrent writer between the
+// read and the clear is preserved rather than lost. Returns "" when the key is
+// absent or already empty. (RETURNING isn't usable here — the modernc sqlite
+// driver routes UPDATE through exec and discards RETURNING rows.)
+func (s *StateDB) TakeMeta(key string) (string, error) {
+	value, err := s.GetMeta(key)
+	if err != nil || value == "" {
+		return "", err
+	}
+	if _, err := s.db.Exec(
+		"UPDATE metadata SET value = '' WHERE key = ? AND value = ?",
+		key, value,
+	); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
 // --- Change Detection (replaces fsnotify) ---
 
 // Touch updates a metadata timestamp that other instances can poll to detect changes.

--- a/internal/statedb/statedb_test.go
+++ b/internal/statedb/statedb_test.go
@@ -1966,3 +1966,28 @@ func createV9SchemaDB(t *testing.T) *StateDB {
 	t.Cleanup(func() { db.Close() })
 	return db
 }
+
+func TestTakeMeta(t *testing.T) {
+	db := newTestDB(t)
+
+	// Absent key → "" and no error.
+	if got, err := db.TakeMeta("focus_request"); err != nil || got != "" {
+		t.Fatalf("absent TakeMeta = (%q, %v), want (\"\", nil)", got, err)
+	}
+
+	// Set then take → returns the value and clears it atomically.
+	if err := db.SetMeta("focus_request", "payload"); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	got, err := db.TakeMeta("focus_request")
+	if err != nil || got != "payload" {
+		t.Fatalf("TakeMeta = (%q, %v), want (\"payload\", nil)", got, err)
+	}
+	// Cleared: a second take yields "" (consume-once).
+	if got, err := db.TakeMeta("focus_request"); err != nil || got != "" {
+		t.Fatalf("second TakeMeta = (%q, %v), want (\"\", nil)", got, err)
+	}
+	if got, err := db.GetMeta("focus_request"); err != nil || got != "" {
+		t.Fatalf("GetMeta after take = (%q, %v), want (\"\", nil)", got, err)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5188,6 +5188,80 @@ func ReadAndClearAckSignal() string {
 	return strings.TrimSpace(string(data))
 }
 
+// WriteAckSignal writes sessionID to the ack-signal file so the TUI's background
+// sync (which runs even while the TUI is paused inside tea.Exec) acknowledges the
+// session, updates the notification bar, and records the switch for detach
+// cursor-sync. This is the programmatic equivalent of the `echo <id> > signal`
+// step in buildAckSwitchScript; pairs with SwitchAttachedClients.
+func WriteAckSignal(sessionID string) error {
+	signalFile, err := GetAckSignalPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(signalFile), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(signalFile, []byte(sessionID+"\n"), 0o600)
+}
+
+// attachedClientNames lists the names of non-control clients attached on socket
+// ("" = default server). Control-mode clients (PipeManager pipes) are excluded.
+// Returns nil when no server is running or no client is attached.
+func attachedClientNames(socket string) []string {
+	// client_name is free-text (a pts path) so it goes LAST, after the 0/1
+	// control-mode flag, to stay collision-safe under tmuxFieldSep.
+	cmd := tmuxExec(socket, "list-clients", "-F", tmuxFmt("#{client_control_mode}", "#{client_name}"))
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		parts := strings.SplitN(line, tmuxFieldSep, 2)
+		if len(parts) != 2 || parts[1] == "" {
+			continue
+		}
+		if parts[0] == "1" { // control mode
+			continue
+		}
+		names = append(names, parts[1])
+	}
+	return names
+}
+
+// SwitchAttachedClients moves every non-control client attached on socket into
+// targetSession and writes the ack-signal for sessionID. Returns switched=true
+// iff at least one client was attached and switched.
+//
+// This is the programmatic equivalent of the Ctrl+b N quick-switch: like that
+// path it works while the TUI is suspended inside tea.Exec (tmux drives the
+// switch, not Bubble Tea). And like that path it only works when the attached
+// client and target session share a tmux server — querying clients on the
+// target's own socket means a client attached elsewhere yields switched=false,
+// so the caller falls back to a focus_request rather than mis-switching.
+func SwitchAttachedClients(socket, targetSession, sessionID string) (bool, error) {
+	clients := attachedClientNames(socket)
+	if len(clients) == 0 {
+		return false, nil
+	}
+	// Best-effort: the bar/cursor sync degrades without it, but the switch below
+	// is what the user actually asked for, so a failed ack must not abort it.
+	_ = WriteAckSignal(sessionID)
+
+	switched := false
+	var firstErr error
+	for _, c := range clients {
+		if err := tmuxExec(socket, "switch-client", "-c", c, "-t", targetSession).Run(); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		switched = true
+	}
+	return switched, firstErr
+}
+
 // UnbindKey removes a key binding and restores default behavior.
 // After unbinding, attempts to restore the default behavior where number keys
 // select windows. The restore is best-effort since it may fail in environments

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5201,7 +5201,18 @@ func WriteAckSignal(sessionID string) error {
 	if err := os.MkdirAll(filepath.Dir(signalFile), 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(signalFile, []byte(sessionID+"\n"), 0o600)
+	// Write atomically: the reader does ReadFile-then-Remove, so a plain
+	// truncating WriteFile could be observed mid-write as an empty/partial file
+	// and the ack would be lost. Stage to a temp file and rename into place.
+	tmp := signalFile + ".tmp"
+	if err := os.WriteFile(tmp, []byte(sessionID+"\n"), 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, signalFile); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // attachedClientNames lists the names of non-control clients attached on socket

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5262,6 +5262,34 @@ func SwitchAttachedClients(socket, targetSession, sessionID string) (bool, error
 	return switched, firstErr
 }
 
+// DetachClientsOnSockets detaches every non-control client attached on any of
+// the given sockets ("" = default server). Returns detached=true iff at least
+// one client was detached.
+//
+// This is the cross-server companion to SwitchAttachedClients: switch-client
+// cannot move a client between tmux servers, so when a notification target lives
+// on a different socket than the attached session, detaching that client makes
+// agent-deck's paused attach (tea.Exec) return. The TUI then resumes and
+// consumes the focus_request to attach the target on its OWN socket — a
+// detach-and-reattach, which is the only way to "switch while attached" across
+// servers. Control-mode clients (PipeManager pipes) are left alone.
+func DetachClientsOnSockets(sockets ...string) (bool, error) {
+	detached := false
+	var firstErr error
+	for _, socket := range sockets {
+		for _, c := range attachedClientNames(socket) {
+			if err := tmuxExec(socket, "detach-client", "-c", c).Run(); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			detached = true
+		}
+	}
+	return detached, firstErr
+}
+
 // UnbindKey removes a key binding and restores default behavior.
 // After unbinding, attempts to restore the default behavior where number keys
 // select windows. The restore is best-effort since it may fail in environments

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1579,6 +1579,28 @@ func (h *Home) SelectSessionByID(id string) bool {
 	return false
 }
 
+// consumeFocusRequest honors a pending `agent-deck session focus <id>` request.
+// It is called once per tick. The row is cleared unconditionally (consume-once)
+// so an unknown, stale, or foreign id never re-fires on a later tick or lingers
+// past its purpose.
+func (h *Home) consumeFocusRequest(db *statedb.StateDB) {
+	if db == nil {
+		return
+	}
+	raw, err := session.ReadFocusRequest(db)
+	if err != nil || raw == "" {
+		return
+	}
+	// Clear first: even a stale/unknown id must be consumed exactly once.
+	_ = session.ClearFocusRequest(db)
+
+	id, fresh := session.DecodeFocusRequest(raw, time.Now().UnixNano(), session.FocusRequestTTL)
+	if !fresh {
+		return
+	}
+	h.SelectSessionByID(id)
+}
+
 // isInGroupScope returns true if the given path is within the active group scope.
 // Returns true for all paths when no scope is set.
 func (h *Home) isInGroupScope(path string) bool {
@@ -5928,6 +5950,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case tickMsg:
+		// Honor a pending `agent-deck session focus <id>` request from the CLI.
+		h.consumeFocusRequest(statedb.GetGlobal())
+
 		var remoteFetchCmd tea.Cmd
 		var remoteLatencyCmd tea.Cmd
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1596,12 +1596,13 @@ func (h *Home) consumeFocusRequest(db *statedb.StateDB) tea.Cmd {
 	if db == nil {
 		return nil
 	}
-	raw, err := session.ReadFocusRequest(db)
+	// Atomic read-and-clear: a separate read-then-clear has a window where a
+	// concurrent CLI `session focus` write lands between them and gets wiped.
+	// Consume-once still holds — a stale/unknown id is cleared by the take below.
+	raw, err := session.TakeFocusRequest(db)
 	if err != nil || raw == "" {
 		return nil
 	}
-	// Clear first: even a stale/unknown id must be consumed exactly once.
-	_ = session.ClearFocusRequest(db)
 
 	id, attach, fresh := session.DecodeFocusRequestAttach(raw, time.Now().UnixNano(), session.FocusRequestTTL)
 	if !fresh {
@@ -1619,7 +1620,11 @@ func (h *Home) consumeFocusRequest(db *statedb.StateDB) tea.Cmd {
 	if inst == nil || !inst.Exists() {
 		return nil
 	}
-	h.isAttaching.Store(true) // suppress View() output during the transition (matches the Enter path)
+	// attachSession returns nil when there's no local tmux pane to attach (e.g.
+	// GetTmuxSession()==nil on a cross-socket session) and sets h.isAttaching
+	// itself on the real attach path. Don't pre-set it here: a premature set
+	// followed by a nil return would leave isAttaching stuck true and suppress
+	// View() forever. Mirror the attach_on_create path and guard on the cmd.
 	return h.attachSession(inst)
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1484,23 +1484,95 @@ func (h *Home) SetInitialSelection(idOrTitle string) {
 // h.initialSelect, if any. Returns true if a match was found and the cursor
 // was moved, false otherwise. Idempotent — after one successful apply, further
 // calls are no-ops so normal cursor navigation is not overridden.
+//
+// Unlike SelectSessionByID this method does NOT clear group scope or status
+// filters — the caller may have set a scope intentionally via -g/--group, and
+// --select must respect that constraint. Only sessions visible in the current
+// flat view are eligible.
 func (h *Home) applyInitialSelection() bool {
 	if h.initialSelectDone || h.initialSelect == "" {
 		return false
 	}
+	// Try id-path first: searches only the visible flat view, so group scope
+	// and status filters are naturally honoured (no reveal behaviour here).
+	if idx := h.flatItemIndexByID(h.initialSelect); idx >= 0 {
+		h.cursor = idx
+		h.initialSelectDone = true
+		h.syncViewport()
+		return true
+	}
+	// Fall back to a title match — initialSelect may be a title, not an id.
 	wanted := strings.ToLower(strings.TrimSpace(h.initialSelect))
 	for i, fi := range h.flatItems {
 		if fi.Type != session.ItemTypeSession || fi.Session == nil {
 			continue
 		}
-		if fi.Session.ID == h.initialSelect ||
-			strings.EqualFold(fi.Session.Title, h.initialSelect) ||
+		if strings.EqualFold(fi.Session.Title, h.initialSelect) ||
 			strings.ToLower(fi.Session.Title) == wanted {
 			h.cursor = i
 			h.initialSelectDone = true
 			h.syncViewport()
 			return true
 		}
+	}
+	return false
+}
+
+// flatItemIndexByID returns the flatItems index of the session row with the
+// given id, or -1 if it is not present in the current flat view.
+func (h *Home) flatItemIndexByID(id string) int {
+	for i, fi := range h.flatItems {
+		if fi.Type == session.ItemTypeSession && fi.Session != nil && fi.Session.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// SelectSessionByID reveals and selects the session with the given id within
+// the active (non-archived) view: if the target is hidden by a status filter or
+// group scope it clears them, and if its group is collapsed it expands the
+// group (and parents), then moves the cursor. Returns true if the session was
+// found and selected. Archived sessions and unknown/foreign ids return false
+// and leave the cursor unchanged.
+func (h *Home) SelectSessionByID(id string) bool {
+	if id == "" {
+		return false
+	}
+
+	// Fast path: already visible in the current flat view.
+	if idx := h.flatItemIndexByID(id); idx >= 0 {
+		h.cursor = idx
+		h.syncViewport()
+		return true
+	}
+
+	// Confirm the target exists in this profile, is not archived, and learn its
+	// group path for expansion.
+	var target *session.Instance
+	for _, inst := range h.instances {
+		if inst.ID == id {
+			target = inst
+			break
+		}
+	}
+	if target == nil || target.IsArchived() {
+		return false
+	}
+
+	// Reveal within the active view: drop filters that could hide the target and
+	// expand its containing group, then rebuild and locate it.
+	h.statusFilter = ""
+	h.groupScope = ""
+	if target.GroupPath != "" {
+		h.groupTree.ExpandGroupWithParents(target.GroupPath)
+	}
+	h.rebuildFlatItems()
+
+	if idx := h.flatItemIndexByID(id); idx >= 0 {
+		h.cursor = idx
+		h.syncViewport()
+		return true
 	}
 	return false
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -476,6 +476,12 @@ type Home struct {
 	// it only changes WHAT the footer advertises, never a keybinding.
 	footerMode string
 
+	// attachOnCreate, when true, makes creating a session via the new-session
+	// dialog attach to the new session's pane immediately instead of only
+	// moving the cursor to it (config.toml [ui] attach_on_create). Default
+	// false: today's select-only behavior. See sessionCreatedMsg handling.
+	attachOnCreate bool
+
 	// Performance observability (debug mode only, zero cost when off)
 	debugMode          bool         // true when AGENTDECK_DEBUG=1, enables perf overlay
 	lastRenderDuration atomic.Int64 // microseconds, for debug status bar
@@ -1169,6 +1175,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.remoteLatencyRefreshSec = cfg.UI.GetRemoteLatencyRefreshSecs(cfg.SystemStats.GetRefreshSeconds())
 		h.remoteSessionRefreshSec = cfg.UI.GetRemoteSessionRefreshSecs()
 		h.footerMode = cfg.UI.GetFooter()
+		h.attachOnCreate = cfg.UI.GetAttachOnCreate()
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
 		h.activeFilterExcludes = (session.DisplaySettings{}).GetActiveFilterExcludes()
@@ -1582,23 +1589,38 @@ func (h *Home) SelectSessionByID(id string) bool {
 // consumeFocusRequest honors a pending `agent-deck session focus <id>` request.
 // It is called once per tick. The row is cleared unconditionally (consume-once)
 // so an unknown, stale, or foreign id never re-fires on a later tick or lingers
-// past its purpose.
-func (h *Home) consumeFocusRequest(db *statedb.StateDB) {
+// past its purpose. It returns a non-nil tea.Cmd only when the request asked to
+// --attach the session and that session is live: the caller runs the cmd to
+// open it (the same path as pressing Enter). A select-only request returns nil.
+func (h *Home) consumeFocusRequest(db *statedb.StateDB) tea.Cmd {
 	if db == nil {
-		return
+		return nil
 	}
 	raw, err := session.ReadFocusRequest(db)
 	if err != nil || raw == "" {
-		return
+		return nil
 	}
 	// Clear first: even a stale/unknown id must be consumed exactly once.
 	_ = session.ClearFocusRequest(db)
 
-	id, fresh := session.DecodeFocusRequest(raw, time.Now().UnixNano(), session.FocusRequestTTL)
+	id, attach, fresh := session.DecodeFocusRequestAttach(raw, time.Now().UnixNano(), session.FocusRequestTTL)
 	if !fresh {
-		return
+		return nil
 	}
-	h.SelectSessionByID(id)
+	if !h.SelectSessionByID(id) {
+		return nil
+	}
+	if !attach {
+		return nil
+	}
+	// Attach intent: open the session as if the user pressed Enter on it. Skip
+	// when the session has no live tmux pane (attachSession would no-op anyway).
+	inst := h.getInstanceByID(id)
+	if inst == nil || !inst.Exists() {
+		return nil
+	}
+	h.isAttaching.Store(true) // suppress View() output during the transition (matches the Enter path)
+	return h.attachSession(inst)
 }
 
 // isInGroupScope returns true if the given path is within the active group scope.
@@ -4933,6 +4955,19 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Use forceSave to bypass mtime check - new session creation MUST persist
 			h.forceSaveInstances()
 
+			// Auto-attach to the new session when [ui].attach_on_create is set,
+			// so creating a session "instantly opens" it instead of only moving
+			// the cursor to it. The session was just Start()ed (see
+			// createSessionInGroupWithWorktreeAndOptions), so its pane is live.
+			// attachSession returns nil when there is no local tmux pane to
+			// attach (e.g. a session whose tmux session could not be resolved);
+			// in that case we fall through to today's select-only behavior.
+			if h.attachOnCreate {
+				if attachTo := h.attachSession(msg.instance); attachTo != nil {
+					return h, tea.Batch(h.fetchPreview(msg.instance, msg.instance.ID, -1), attachTo)
+				}
+			}
+
 			// Start fetching preview for the new session
 			return h, h.fetchPreview(msg.instance, msg.instance.ID, -1)
 		}
@@ -5951,7 +5986,14 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		// Honor a pending `agent-deck session focus <id>` request from the CLI.
-		h.consumeFocusRequest(statedb.GetGlobal())
+		// A non-nil cmd means the request asked to --attach the session: open it
+		// now (same as Enter) and skip the rest of this tick's background work,
+		// which is moot once we hand the terminal to the session. Re-arm the tick
+		// (h.tick()) here too — unlike the Enter key path, returning early from the
+		// tickMsg case would otherwise break the self-rescheduling tick chain.
+		if focusCmd := h.consumeFocusRequest(statedb.GetGlobal()); focusCmd != nil {
+			return h, tea.Batch(focusCmd, h.tick())
+		}
 
 		var remoteFetchCmd tea.Cmd
 		var remoteLatencyCmd tea.Cmd

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1550,12 +1550,14 @@ func (h *Home) SelectSessionByID(id string) bool {
 	// Confirm the target exists in this profile, is not archived, and learn its
 	// group path for expansion.
 	var target *session.Instance
+	h.instancesMu.RLock()
 	for _, inst := range h.instances {
 		if inst.ID == id {
 			target = inst
 			break
 		}
 	}
+	h.instancesMu.RUnlock()
 	if target == nil || target.IsArchived() {
 		return false
 	}

--- a/internal/ui/session_focus_test.go
+++ b/internal/ui/session_focus_test.go
@@ -1,10 +1,12 @@
 package ui
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
 
 // buildFocusHome returns a Home with two groups (alpha: a1,a2; beta: b1,b2) and
@@ -34,6 +36,19 @@ func buildFocusHome(t *testing.T) (*Home, []*session.Instance) {
 	home.groupTree = session.NewGroupTree(instances)
 	home.rebuildFlatItems()
 	return home, instances
+}
+
+func newUITempStateDB(t *testing.T) *statedb.StateDB {
+	t.Helper()
+	db, err := statedb.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
 }
 
 func TestSelectSessionByID_Visible(t *testing.T) {
@@ -113,4 +128,64 @@ func TestSelectSessionByID_Archived(t *testing.T) {
 	if home.cursor != before {
 		t.Fatalf("cursor moved selecting archived session: %d -> %d", before, home.cursor)
 	}
+}
+
+func TestConsumeFocusRequest_Fresh(t *testing.T) {
+	home, inst := buildFocusHome(t)
+	db := newUITempStateDB(t)
+
+	// Collapse beta so the target needs revealing — proves consume drives reveal.
+	home.groupTree.CollapseGroup("beta")
+	home.rebuildFlatItems()
+
+	if err := session.WriteFocusRequest(db, inst[3].ID, time.Now().UnixNano()); err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+
+	home.consumeFocusRequest(db)
+
+	idx := home.flatItemIndexByID(inst[3].ID)
+	if idx < 0 || home.cursor != idx {
+		t.Fatalf("fresh request not selected: cursor=%d idx=%d", home.cursor, idx)
+	}
+	if raw, _ := session.ReadFocusRequest(db); raw != "" {
+		t.Fatalf("row not cleared after consume: %q", raw)
+	}
+}
+
+func TestConsumeFocusRequest_Stale(t *testing.T) {
+	home, inst := buildFocusHome(t)
+	db := newUITempStateDB(t)
+	before := home.cursor
+
+	staleTS := time.Now().Add(-time.Hour).UnixNano()
+	if err := session.WriteFocusRequest(db, inst[3].ID, staleTS); err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+
+	home.consumeFocusRequest(db)
+
+	if home.cursor != before {
+		t.Fatalf("stale request moved cursor: %d -> %d", before, home.cursor)
+	}
+	if raw, _ := session.ReadFocusRequest(db); raw != "" {
+		t.Fatalf("stale row not cleared: %q", raw)
+	}
+}
+
+func TestConsumeFocusRequest_Empty(t *testing.T) {
+	home, _ := buildFocusHome(t)
+	db := newUITempStateDB(t)
+	before := home.cursor
+
+	home.consumeFocusRequest(db) // no row present
+
+	if home.cursor != before {
+		t.Fatalf("empty request moved cursor: %d -> %d", before, home.cursor)
+	}
+}
+
+func TestConsumeFocusRequest_NilDB(t *testing.T) {
+	home, _ := buildFocusHome(t)
+	home.consumeFocusRequest(nil) // must not panic
 }

--- a/internal/ui/session_focus_test.go
+++ b/internal/ui/session_focus_test.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// buildFocusHome returns a Home with two groups (alpha: a1,a2; beta: b1,b2) and
+// the instances slice so tests can read generated IDs.
+func buildFocusHome(t *testing.T) (*Home, []*session.Instance) {
+	t.Helper()
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	instances := []*session.Instance{
+		session.NewInstanceWithTool("a1", "/tmp/a1", "claude"),
+		session.NewInstanceWithTool("a2", "/tmp/a2", "claude"),
+		session.NewInstanceWithTool("b1", "/tmp/b1", "claude"),
+		session.NewInstanceWithTool("b2", "/tmp/b2", "claude"),
+	}
+	instances[0].GroupPath = "alpha"
+	instances[1].GroupPath = "alpha"
+	instances[2].GroupPath = "beta"
+	instances[3].GroupPath = "beta"
+
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(instances)
+	home.rebuildFlatItems()
+	return home, instances
+}
+
+func TestSelectSessionByID_Visible(t *testing.T) {
+	home, inst := buildFocusHome(t)
+	want := home.flatItemIndexByID(inst[2].ID) // b1, currently visible
+	if want < 0 {
+		t.Fatal("precondition: b1 should be visible")
+	}
+	if !home.SelectSessionByID(inst[2].ID) {
+		t.Fatal("SelectSessionByID returned false for visible session")
+	}
+	if home.cursor != want {
+		t.Fatalf("cursor = %d, want %d", home.cursor, want)
+	}
+}
+
+func TestSelectSessionByID_CollapsedGroup(t *testing.T) {
+	home, inst := buildFocusHome(t)
+	home.groupTree.CollapseGroup("beta")
+	home.rebuildFlatItems()
+	if home.flatItemIndexByID(inst[3].ID) >= 0 {
+		t.Fatal("precondition: b2 should be hidden in collapsed group")
+	}
+
+	if !home.SelectSessionByID(inst[3].ID) {
+		t.Fatal("SelectSessionByID returned false for collapsed-group session")
+	}
+	idx := home.flatItemIndexByID(inst[3].ID)
+	if idx < 0 || home.cursor != idx {
+		t.Fatalf("after select: cursor=%d, idx=%d (want equal, >=0)", home.cursor, idx)
+	}
+}
+
+func TestSelectSessionByID_HiddenByStatusFilter(t *testing.T) {
+	home, inst := buildFocusHome(t)
+	// Give the target a status the filter excludes, and a sibling the filter
+	// keeps (so the filter is not auto-cleared for matching nothing).
+	inst[0].Status = session.StatusIdle    // a1 — target
+	inst[1].Status = session.StatusRunning // a2 — keeps the filter alive
+	home.statusFilter = session.StatusRunning
+	home.rebuildFlatItems()
+	if home.flatItemIndexByID(inst[0].ID) >= 0 {
+		t.Fatal("precondition: a1 should be hidden by the running filter")
+	}
+
+	if !home.SelectSessionByID(inst[0].ID) {
+		t.Fatal("SelectSessionByID returned false for filter-hidden session")
+	}
+	if home.statusFilter != "" {
+		t.Fatalf("statusFilter = %q, want cleared", home.statusFilter)
+	}
+	idx := home.flatItemIndexByID(inst[0].ID)
+	if idx < 0 || home.cursor != idx {
+		t.Fatalf("after select: cursor=%d, idx=%d (want equal, >=0)", home.cursor, idx)
+	}
+}
+
+func TestSelectSessionByID_UnknownID(t *testing.T) {
+	home, _ := buildFocusHome(t)
+	before := home.cursor
+	if home.SelectSessionByID("no-such-id") {
+		t.Fatal("SelectSessionByID returned true for unknown id")
+	}
+	if home.cursor != before {
+		t.Fatalf("cursor moved on unknown id: %d -> %d", before, home.cursor)
+	}
+}
+
+func TestSelectSessionByID_Archived(t *testing.T) {
+	home, inst := buildFocusHome(t)
+	inst[2].ArchivedAt = time.Now() // b1 archived
+	home.rebuildFlatItems()
+	before := home.cursor
+	if home.SelectSessionByID(inst[2].ID) {
+		t.Fatal("SelectSessionByID returned true for archived session")
+	}
+	if home.cursor != before {
+		t.Fatalf("cursor moved selecting archived session: %d -> %d", before, home.cursor)
+	}
+}

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -41,6 +41,7 @@ agent-deck add [path] [options]
 | `--parent` | Parent session (creates child) |
 | `--no-parent` | Disable automatic parent linking |
 | `--mcp` | Attach MCP (repeatable) |
+| `--attach` | Start and attach to the session immediately after creating it (requires an interactive terminal; not supported with `--ssh`/`--json`) |
 
 ```bash
 agent-deck add -t "My Project" -c claude .
@@ -48,10 +49,12 @@ agent-deck add -t "Child" --parent "Parent" -c claude /tmp/x
 agent-deck add -g ard --parent "conductor-ard" -c claude .
 agent-deck add -c "codex --dangerously-bypass-approvals-and-sandbox" .
 agent-deck add -t "Research" -c claude --mcp exa --mcp firecrawl /tmp/r
+agent-deck add -t "Quick" -c claude --attach .   # create → start → drop into the pane
 ```
 
 Notes:
 - Parent auto-link is enabled by default when `AGENT_DECK_SESSION_ID` is present and neither `--parent` nor `--no-parent` is passed.
+- `--attach` does create → start → attach in one step. Without an interactive terminal (or with `--json`) it exits non-zero with a clear error, leaving the session created and started so you can attach later.
 - `--parent` and `--no-parent` are mutually exclusive.
 - Explicit `-g/--group` overrides inherited parent group.
 - If `--cmd` contains extra args and no explicit `--wrapper` is provided, agent-deck auto-generates a wrapper to preserve those args.
@@ -139,10 +142,11 @@ http://127.0.0.1:8420/?token=my-secret
 ### session start
 
 ```bash
-agent-deck session start <id|title> [-m "message"] [--json] [-q]
+agent-deck session start <id|title> [-m "message"] [--attach] [--json] [-q]
 ```
 
 `-m` sends initial message after agent is ready.
+`--attach` drops you into the session's pane after it starts (requires an interactive terminal; refused under `--json`). On a clean detach you return to the shell; without a TTY it exits non-zero, leaving the session started.
 Flags can be placed before or after the session identifier.
 
 ### session stop

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -486,6 +486,7 @@ footer = "full"                               # Footer hint bar: "full", "curate
 hidden_tools = ["gemini", "opencode", "pi"]   # Denylist: hide these from the picker
 show_only_installed_tools = true              # Also hide tools not found on PATH
 new_session_enter_advances = false            # Opt OUT: restore Enter-submits behavior
+attach_on_create = true                       # Opt IN: instantly attach to a newly created session
 ```
 
 | Key | Type | Default | Description |
@@ -494,6 +495,7 @@ new_session_enter_advances = false            # Opt OUT: restore Enter-submits b
 | `hidden_tools` | []string | `[]` | Tool names to hide from the new-session picker. `shell` is always shown and cannot be hidden. Unknown names log a warning and are ignored. Edit via TUI **Settings (`S`) → Visible tools…** or by hand in `config.toml`. |
 | `show_only_installed_tools` | bool | `false` | When `true`, hides built-in and custom tools whose command does not resolve on the host `PATH`. `shell` stays visible. If nothing else resolves, the picker falls back to showing all tools with a one-line hint. Toggle in TUI Settings under **TOOL PICKER**. |
 | `new_session_enter_advances` | bool | `true` | Controls what **Enter** does on the free-text **Name** / **Branch** fields of the new-session dialog. Default `true`: Enter **advances** to the next field, so typing a name and pressing Enter no longer silently creates a session with all defaults. **Ctrl+S** is the explicit "create now" shortcut and submits from any field in both modes. Set `false` to restore the legacy behavior where Enter on Name/Branch submits the form. |
+| `attach_on_create` | bool | `false` | When `true`, creating a session in the TUI (`n` new-session dialog) **immediately attaches** to the new session's pane instead of only moving the cursor to it — "instantly open". Default `false`: today's select-only behavior (press **Enter** to attach). Does not affect the CLI; `agent-deck add` / `session start` attach only with an explicit `--attach`. |
 
 Filters compose: `hidden_tools` is applied first, then `show_only_installed_tools` (when enabled).
 


### PR DESCRIPTION
Lets an external trigger (notably a notification click) reveal/select or attach to a specific session in the already-running TUI.

- **focus_request contract** — shared encode/decode + DB helpers (`internal/session/focus.go`).
- **`session focus <id>`** CLI signals the running TUI; `--attach` opens the session on consume.
- **TUI** consumes `focus_request` on tick via `SelectSessionByID` (reveal-and-select; instance scan guarded by `instancesMu.RLock`).
- **attach-on-create** — TUI `attach_on_create` + CLI `--attach` instantly open new sessions.
- **notification-click switch** — switches into the target session even while attached, **including across separate tmux sockets** (tmux path detection + cross-socket switch).

Self-contained chain; applies cleanly on main. Build/vet/tests green (`internal/session`, `internal/ui`, `cmd/agent-deck`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional attach-on-create flow for new sessions (configurable) and an `--attach` option for starting sessions.
  * Added a session focus action to jump to a session by ID, with optional attach behavior.
  * Enhanced `session show --json` to include auto-name description details when available.
* **Bug Fixes**
  * Improved tmux discovery when `PATH` is incomplete.
  * Added safeguards to prevent interactive attach when terminal input/output isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->