### PR TITLE
feat: per-session environment variables for every tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-session environment variables for every tool.** Set `KEY=VALUE` pairs on a single session — at create (`add`/`launch --env`, the TUI/web new-session dialogs) or later (`session set <id> env KEY=VALUE`, the edit dialogs) — exported into the spawned process for any tool (claude, gemini, codex, opencode, copilot, hermes, crush, pi, cursor, custom). As the most specific scope they **win** over `env_file`/inline/group/conductor env and `~/.zshrc` on a key collision. Persisted plaintext in the session DB (keys validated; values shell-escaped; the prepared command is suppressed from logs); inherited by forks; not applied to remote-path SSH sessions. ([#1547](https://github.com/asheshgoplani/agent-deck/pull/1547))
+
 ## [1.10.8] - 2026-07-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -215,6 +215,27 @@ Closes [issue #602](https://github.com/asheshgoplani/agent-deck/issues/602).
 
 `agent-deck session switch-account <session> <account>` moves an existing session to another Claude account — **conversation included**. The session stops, its conversation file is migrated into the target account's config dir (copy-only, with a destination backup and size verification), the account is set, and the session restarts with `--resume`. `session set <session> account <name>` auto-migrates too.
 
+### Per-session environment variables
+
+Attach environment variables to a single session — for **any** tool (claude, gemini, codex, opencode, copilot, crush, cursor, pi, hermes, custom). As the most specific scope they **win** on a key collision: they are exported after the config env layers (`env_file`, inline `[tools.X].env`, group/conductor env) and after `~/.zshrc`/`~/.bashrc`, so a per-session value overrides all of those. They survive restarts, forks, and Docker wrapping. (Applied to local, Docker, and direct-SSH sessions; not to remote-working-path or remote-mode-created sessions — see config reference.)
+
+Set them at create time or edit them later:
+
+```bash
+# At creation (repeatable, applies to all tools)
+agent-deck add . -c claude --env HTTPS_PROXY=http://127.0.0.1:8080 --env AGENT_ROLE=reviewer
+agent-deck launch -c codex --env OPENAI_BASE_URL=https://proxy.internal -m "audit the diff"
+
+# On an existing session: upsert a key …
+agent-deck session set my-project env HTTPS_PROXY=http://127.0.0.1:8080
+# … or unset it (empty value clears the key)
+agent-deck session set my-project env HTTPS_PROXY=
+```
+
+In the TUI, the **New Session** dialog has a multi-line `KEY=VALUE` field (one per line) and the **Edit Session** dialog (`P`) exposes an `Env` field; in **Web Mode** both the create and edit dialogs have a key/value editor. Env changes are **restart-required**: the TUI edit dialog auto-restarts the session when possible, while the Web edit dialog saves the change and you click **Restart** to apply it.
+
+> ⚠️ **Stored in plaintext.** Per-session env values are persisted unencrypted in the session state DB and are intended for non-secret configuration (proxies, feature flags, role hints). Avoid secrets you can't rotate. When a session carries per-session env, agent-deck suppresses the full prepared command from its logs (logging only the env **key names**) so values don't leak there. Env keys must match `[A-Za-z_][A-Za-z0-9_]*`; an invalid key is rejected. Conductor session-registration is out of scope and is not wired for per-session env.
+
 ### MCP Socket Pool
 
 Running many sessions? Socket pooling shares MCP processes across all sessions via Unix sockets, reducing MCP memory usage by 85-90%. Connections auto-recover from MCP crashes in ~3 seconds via a reconnecting proxy. Enable with `pool_all = true` in [config.toml](skills/agent-deck/references/config-reference.md).
@@ -668,6 +689,21 @@ Agent Deck works with any terminal-based AI tool:
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 
 Hide tools you don't use from the new-session picker with `[ui].hidden_tools` (applies to TUI and web; `shell` is always available).
+
+### Running a wrapper binary (e.g. Claude Code on Codex)
+
+To launch a tool through a drop-in wrapper — for example [`claudodex`](https://github.com/bassner/claudodex) to run Claude Code on an OpenAI Codex subscription, side by side with normal Claude — point the tool's command at the wrapper. This uses agent-deck's existing per-tool command configuration; agent-deck already suppresses the `CLAUDE_CONFIG_DIR=` prefix for a non-`claude` command (the wrapper is assumed to handle it).
+
+- **All Claude sessions:** set `command = "claudodex"` under `[claude]` in `config.toml`.
+- **A subset:** scope it per-group or per-conductor (`[groups."codex-work".claude].command = "claudodex"`), or define a claude-compatible custom tool and pick it per session:
+
+  ```toml
+  [tools.claudodex]
+  command = "claudodex"
+  compatible_with = "claude"
+  ```
+
+  Then create sessions with `-c claudodex` right next to normal `-c claude` sessions — side by side, in any group. See the [config reference](skills/agent-deck/references/config-reference.md) for the full resolution order (`conductor > group > [claude].command > "claude"`).
 
 ### Cost Tracking Dashboard
 

--- a/cmd/agent-deck/env_cmd_test.go
+++ b/cmd/agent-deck/env_cmd_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAddEnvFlag asserts that `agent-deck add --env KEY=VALUE` is parsed
+// (repeatable) and the env vars persist on the new session (all tools).
+func TestAddEnvFlag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add",
+		"-t", "env-add-test",
+		"-c", "gemini",
+		"--env", "FOO=bar",
+		"--env", "HTTPS_PROXY=http://127.0.0.1:8080",
+		"--no-parent",
+		"--json",
+		projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("agent-deck add --env failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	// Plaintext warning must be emitted on stderr.
+	if !strings.Contains(stderr, "plaintext") {
+		t.Errorf("expected plaintext warning on stderr; got: %s", stderr)
+	}
+
+	listJSON := readSessionsJSON(t, home)
+	if !strings.Contains(listJSON, "FOO=bar") {
+		t.Errorf("persisted sessions missing FOO=bar; got:\n%s", listJSON)
+	}
+	if !strings.Contains(listJSON, "HTTPS_PROXY=http://127.0.0.1:8080") {
+		t.Errorf("persisted sessions missing HTTPS_PROXY; got:\n%s", listJSON)
+	}
+}
+
+// TestAddEnvFlag_InvalidKeyRejected asserts an invalid env key is rejected by
+// the flag validator before the session is created.
+func TestAddEnvFlag_InvalidKeyRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, code := runAgentDeck(t, home,
+		"add",
+		"-t", "env-bad-test",
+		"-c", "claude",
+		"--env", "1BAD=x",
+		"--no-parent",
+		projectDir,
+	)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for invalid env key; stderr: %s", stderr)
+	}
+}
+
+// TestSessionSetEnv asserts `session set <id> env KEY=VALUE` upserts and
+// `env KEY=` unsets, delegating to session.SetField.
+func TestSessionSetEnv(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "-t", "env-set-test", "-c", "claude", "--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("agent-deck add failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var addResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &addResp); err != nil {
+		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
+	}
+
+	// Upsert.
+	_, stderr, code = runAgentDeck(t, home, "session", "set", "--json", addResp.ID, "env", "FOO=bar")
+	if code != 0 {
+		t.Fatalf("session set env FOO=bar failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	listJSON := readSessionsJSON(t, home)
+	if !strings.Contains(listJSON, "FOO=bar") {
+		t.Errorf("session set env did not persist FOO=bar; list:\n%s", listJSON)
+	}
+
+	// Replace value.
+	_, stderr, code = runAgentDeck(t, home, "session", "set", "--json", addResp.ID, "env", "FOO=baz")
+	if code != 0 {
+		t.Fatalf("session set env FOO=baz failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	listJSON = readSessionsJSON(t, home)
+	if strings.Contains(listJSON, "FOO=bar") || !strings.Contains(listJSON, "FOO=baz") {
+		t.Errorf("replace did not take effect; list:\n%s", listJSON)
+	}
+
+	// Unset via empty value.
+	_, stderr, code = runAgentDeck(t, home, "session", "set", "--json", addResp.ID, "env", "FOO=")
+	if code != 0 {
+		t.Fatalf("session set env FOO= (unset) failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	listJSON = readSessionsJSON(t, home)
+	if strings.Contains(listJSON, "FOO=baz") {
+		t.Errorf("unset did not remove FOO; list:\n%s", listJSON)
+	}
+
+	// Invalid key rejected (both set and unset).
+	_, _, code = runAgentDeck(t, home, "session", "set", addResp.ID, "env", "1BAD=x")
+	if code == 0 {
+		t.Errorf("expected non-zero exit for invalid env key on set")
+	}
+	_, _, code = runAgentDeck(t, home, "session", "set", addResp.ID, "env", "1BAD=")
+	if code == 0 {
+		t.Errorf("expected non-zero exit for invalid env key on unset")
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -116,6 +116,20 @@ func handleLaunch(profile string, args []string) {
 		return nil
 	})
 
+	// Per-session env vars — repeatable, all tools. Validated via
+	// ParseSessionEnvPair; injected at spawn by prepareCommand. Persisted
+	// plaintext in state.db (warning emitted below).
+	var envFlags []string
+	fs.Func("env", "Per-session environment variable KEY=VALUE (can specify multiple times); applies to all tools; persisted plaintext", func(s string) error {
+		// UpsertSessionEnv validates via ParseSessionEnvPair and replaces a
+		// repeated key in place, so `--env FOO=1 --env FOO=2` keeps only FOO=2
+		// (matching the mutation path's upsert contract) instead of persisting
+		// duplicate keys where only the last export would win at spawn.
+		var err error
+		envFlags, err = session.UpsertSessionEnv(envFlags, s)
+		return err
+	})
+
 	// Resume session flag
 	resumeSession := fs.String("resume-session", "", "Claude session ID to resume")
 	modelID := fs.String("model", "", "Model ID/version to use for this session (claude, codex, gemini, opencode)")
@@ -432,6 +446,12 @@ func handleLaunch(profile string, args []string) {
 			os.Exit(1)
 		}
 		newInstance.ExtraArgs = extraArgFlags
+	}
+
+	// Apply --env flags (all tools). Persisted plaintext — warn the operator.
+	if len(envFlags) > 0 {
+		newInstance.Env = envFlags
+		fmt.Fprintln(os.Stderr, "warning: per-session env is stored in plaintext in state.db — avoid secrets you can't rotate")
 	}
 
 	if sessionWrapperResolved != "" {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1021,6 +1021,7 @@ func reorderArgsForFlagParsing(args []string) []string {
 		"channel":        true,
 		"plugin":         true,
 		"extra-arg":      true,
+		"env":            true,
 		"wrapper":        true,
 		"model":          true,
 		"w":              true,
@@ -1250,6 +1251,20 @@ func handleAdd(profile string, args []string) {
 		}
 		extraArgFlags = append(extraArgFlags, s)
 		return nil
+	})
+
+	// Per-session env vars — repeatable, all tools. Validated via
+	// ParseSessionEnvPair; injected at spawn by prepareCommand. Persisted
+	// plaintext in state.db (warning emitted below).
+	var envFlags []string
+	fs.Func("env", "Per-session environment variable KEY=VALUE (can specify multiple times); applies to all tools; persisted plaintext", func(s string) error {
+		// UpsertSessionEnv validates via ParseSessionEnvPair and replaces a
+		// repeated key in place, so `add --env FOO=1 --env FOO=2` persists only
+		// FOO=2 (matching the mutation path's upsert contract) instead of storing
+		// duplicate keys where only the last export would win at spawn.
+		var err error
+		envFlags, err = session.UpsertSessionEnv(envFlags, s)
+		return err
 	})
 
 	// Sandbox flags
@@ -1656,6 +1671,12 @@ func handleAdd(profile string, args []string) {
 		newInstance.ExtraArgs = extraArgFlags
 	}
 
+	// Apply --env flags (all tools). Persisted plaintext — warn the operator.
+	if len(envFlags) > 0 {
+		newInstance.Env = envFlags
+		fmt.Fprintln(os.Stderr, "warning: per-session env is stored in plaintext in state.db — avoid secrets you can't rotate")
+	}
+
 	// Set wrapper if provided
 	if sessionWrapperResolved != "" {
 		newInstance.Wrapper = sessionWrapperResolved
@@ -1699,6 +1720,13 @@ func handleAdd(profile string, args []string) {
 		}
 		newInstance.SSHHost = *sshHost
 		newInstance.SSHRemotePath = *sshRemotePath
+		// Per-session env is not applied to remote-path SSH sessions (the remote
+		// re-quoting mangles inline exports), so reject it rather than silently
+		// dropping it — mirrors the TUI remote-create guard.
+		if newInstance.SSHRemotePath != "" && len(newInstance.Env) > 0 {
+			fmt.Println("Error: per-session env (--env) is not supported for SSH sessions with a remote path; set it on the remote host instead")
+			os.Exit(1)
+		}
 	}
 
 	// Handle --resume-session: set Claude session ID and resume mode
@@ -1950,6 +1978,7 @@ func handleList(profile string, args []string) {
 			SSHRemotePath string    `json:"ssh_remote_path,omitempty"`
 			Channels      []string  `json:"channels,omitempty"`
 			ExtraArgs     []string  `json:"extra_args,omitempty"`
+			Env           []string  `json:"env,omitempty"`   // per-session env vars
 			Color         string    `json:"color,omitempty"` // issue #391
 		}
 		// Warm tmux pane-title cache + load hook statuses so the CLI
@@ -1973,6 +2002,7 @@ func handleList(profile string, args []string) {
 				SSHRemotePath: inst.SSHRemotePath,
 				Channels:      inst.Channels,
 				ExtraArgs:     inst.ExtraArgs,
+				Env:           inst.Env,
 				Color:         inst.Color,
 			}
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1363,6 +1363,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  channels           Comma-separated plugin channel ids (claude only)")
 		fmt.Printf("  plugins            Comma-separated plugin catalog names (claude only) — see [plugins.<name>] in %s\n", effectiveUserConfigPathForHelp())
 		fmt.Println("  extra-args         Extra claude CLI tokens (claude only; use `-- --flag value` for tokens starting with -; persisted plaintext — no secrets)")
+		fmt.Println("  env                KEY=VALUE to set, KEY= to unset; per-session env var for any tool; restart required (injected at spawn); persisted plaintext — no secrets")
 		fmt.Println("  model              Per-session model override (e.g. opus/sonnet/haiku or a gemini model); persists across restart (#1436). Empty clears it.")
 		fmt.Println("  color              Optional TUI row tint: '#RRGGBB' or ANSI '0'..'255' or '' (issue #391)")
 		fmt.Println("  claude-session-id  Claude conversation ID")

--- a/cmd/agent-deck/web_cmd_test.go
+++ b/cmd/agent-deck/web_cmd_test.go
@@ -14,7 +14,7 @@ import (
 // only used to verify that buildWebServer wires whatever is passed in.
 type noopMutator struct{}
 
-func (noopMutator) CreateSession(string, string, string, string, string) (string, error) {
+func (noopMutator) CreateSession(string, string, string, string, string, []string) (string, error) {
 	return "", nil
 }
 func (noopMutator) StartSession(string) error          { return nil }

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -132,6 +132,30 @@ func (i *Instance) buildEnvSourceCommand() string {
 		sources = append(sources, conductorEnv)
 	}
 
+	// 7b. Per-session env (Instance.Env) — exported AFTER all config-level env
+	// (env_file / inline / conductor) so an explicit per-session value WINS over
+	// a colliding config key. This is the most-specific scope, so least surprise
+	// is that it beats config. (prepareCommand also prepends these exports for
+	// universal coverage — including raw/custom sessions that never reach this
+	// builder — but that earlier copy loses to the config sourcing above; this
+	// later copy is the one that wins.) Stays BEFORE the telegram strip (step 8)
+	// so TELEGRAM_* neutralisation still wins over a per-session value. Skipped
+	// for SSHRemotePath sessions, whose remote re-quoting mangles inline exports
+	// (mirrors prepareCommand's skip).
+	if i.SSHRemotePath == "" {
+		if sessionExports := strings.TrimSpace(buildSessionEnvExports(i.Env)); sessionExports != "" {
+			// buildSessionEnvExports returns "export A='1'; export B='2'; " — a
+			// semicolon-separated list. The `sources` slice is joined with " && ",
+			// so appending it raw would yield `prev && export A; export B && main`,
+			// where the bare `;` breaks the fail-fast chain (main runs even if prev
+			// failed, and only B is applied). Wrap the whole list in a brace group
+			// so it acts as ONE &&-chainable unit; braces run in the CURRENT shell
+			// (unlike a subshell) so the exports persist to the launched command.
+			grouped := "{ " + strings.TrimRight(sessionExports, " ") + " }"
+			sources = append(sources, grouped)
+		}
+	}
+
 	// 8. S8 (v1.7.40) — strip TELEGRAM_STATE_DIR on every non-channel-owning
 	// claude spawn. Fires AFTER all sources and inline env so it wins
 	// over any env_file / inline export that set the variable, and
@@ -624,6 +648,120 @@ func isValidEnvKey(key string) bool {
 		return false
 	}
 	return true
+}
+
+// ValidateSessionEnvKey reports whether key is a valid environment variable
+// name, returning a descriptive error otherwise. It is the exported wrapper over
+// isValidEnvKey so surface packages (CLI/web/TUI) share one source of truth.
+func ValidateSessionEnvKey(key string) error {
+	if !isValidEnvKey(key) {
+		return fmt.Errorf("invalid environment variable name %q (must match [A-Za-z_][A-Za-z0-9_]*)", key)
+	}
+	return nil
+}
+
+// ParseSessionEnvPair splits "KEY=VALUE" on the first '=' and validates the key.
+// A trailing-empty value ("KEY=") is permitted (used to signal unset upstream).
+func ParseSessionEnvPair(kv string) (string, string, error) {
+	eq := strings.IndexByte(kv, '=')
+	if eq <= 0 {
+		return "", "", fmt.Errorf("expected KEY=VALUE, got %q", kv)
+	}
+	key, val := kv[:eq], kv[eq+1:]
+	if err := ValidateSessionEnvKey(key); err != nil {
+		return "", "", err
+	}
+	// Reject CR/LF in the value at the single shared choke point. The web
+	// transport joins the env list with "\n" and splits it back on the same
+	// delimiter, so a value containing a raw newline could not round-trip a
+	// POST→PATCH cycle; the TUI textareas likewise treat "\n" as the entry
+	// separator. Banning it here keeps newline-as-separator lossless on every
+	// surface. Multi-line secrets (rare) belong in an env_file, not inline.
+	if strings.ContainsAny(val, "\r\n") {
+		return "", "", fmt.Errorf("environment value for %q must not contain a newline", key)
+	}
+	return key, val, nil
+}
+
+// UpsertSessionEnv replaces the "KEY=..." entry matching kv's key with kv and
+// removes any later duplicates of the same key, or appends kv when the key is
+// absent. Insertion order is otherwise preserved. Collapsing trailing dupes
+// matters because buildSessionEnvExports exports in order (last wins): a list
+// that already carried "FOO=1","FOO=2" (e.g. from a pre-fix session or a web
+// POST array) would otherwise still export the stale "FOO=2" after upserting
+// "FOO=3".
+func UpsertSessionEnv(env []string, kv string) ([]string, error) {
+	key, _, err := ParseSessionEnvPair(kv)
+	if err != nil {
+		return env, err
+	}
+	out := env[:0:0]
+	replaced := false
+	for _, e := range env {
+		if eq := strings.IndexByte(e, '='); eq > 0 && e[:eq] == key {
+			if replaced {
+				continue // drop later duplicate of the same key
+			}
+			out = append(out, kv)
+			replaced = true
+			continue
+		}
+		out = append(out, e)
+	}
+	if !replaced {
+		out = append(out, kv)
+	}
+	return out, nil
+}
+
+// DedupeSessionEnv collapses duplicate keys in a whole submitted list to their
+// LAST value (matching buildSessionEnvExports' in-order "last wins" export),
+// keeping each key's first-seen position; blank/unparseable entries are dropped
+// and each kept entry is trimmed. The single-entry mutation path uses
+// UpsertSessionEnv; the whole-list surfaces (web create/PATCH, TUI new-session)
+// use this so a submitted ["FOO=1","FOO=2"] is stored as one canonical
+// ["FOO=2"] instead of persisting duplicate keys.
+func DedupeSessionEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		if _, _, err := ParseSessionEnvPair(kv); err != nil {
+			continue
+		}
+		out, _ = UpsertSessionEnv(out, kv)
+	}
+	return out
+}
+
+// UnsetSessionEnv removes any "KEY=..." entry matching key, preserving order.
+func UnsetSessionEnv(env []string, key string) []string {
+	out := env[:0:0]
+	for _, e := range env {
+		if eq := strings.IndexByte(e, '='); eq > 0 && e[:eq] == key {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// buildSessionEnvExports renders per-session env as shell-escaped
+// `export KEY='VALUE'; ` clauses in input order. Invalid pairs are skipped, and
+// "" is returned when there is nothing to export.
+func buildSessionEnvExports(env []string) string {
+	var b strings.Builder
+	for _, kv := range env {
+		key, val, err := ParseSessionEnvPair(kv)
+		if err != nil {
+			continue
+		}
+		escaped := strings.ReplaceAll(val, "'", "'\\''")
+		fmt.Fprintf(&b, "export %s='%s'; ", key, escaped)
+	}
+	return b.String()
 }
 
 // telegramEnvVarsToStrip lists every TELEGRAM_* env var that the

--- a/internal/session/env_precedence_test.go
+++ b/internal/session/env_precedence_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func withTestToolConfig(t *testing.T, toolEnv map[string]string) {
+	t.Helper()
+	userConfigCacheMu.Lock()
+	orig := userConfigCache
+	userConfigCache = &UserConfig{
+		Tools: map[string]ToolDef{"testtool": {Env: toolEnv}},
+		MCPs:  make(map[string]MCPDef),
+	}
+	userConfigCacheMu.Unlock()
+	t.Cleanup(func() {
+		userConfigCacheMu.Lock()
+		userConfigCache = orig
+		userConfigCacheMu.Unlock()
+	})
+}
+
+// TestBuildEnvSourceCommand_PerSessionEnvWinsOverConfig: a per-session env value
+// must win over a colliding config-level value ([tools.X].env / env_file). The
+// per-session export is emitted AFTER the config env in the same shell, so the
+// later assignment wins.
+func TestBuildEnvSourceCommand_PerSessionEnvWinsOverConfig(t *testing.T) {
+	withTestToolConfig(t, map[string]string{"KEY": "fromconfig"})
+	inst := &Instance{Tool: "testtool", Env: []string{"KEY=fromsession"}}
+
+	out := inst.buildEnvSourceCommand()
+	cfgIdx := strings.Index(out, "export KEY='fromconfig'")
+	sessIdx := strings.Index(out, "export KEY='fromsession'")
+	if cfgIdx < 0 || sessIdx < 0 {
+		t.Fatalf("both config and session exports must be present: %q", out)
+	}
+	if sessIdx < cfgIdx {
+		t.Fatalf("per-session export must come AFTER config export so it wins; got: %q", out)
+	}
+}
+
+// TestBuildEnvSourceCommand_SkipsPerSessionEnvForSSHRemotePath: per-session env
+// must NOT be injected here for remote-path SSH sessions (remote re-quoting
+// mangles inline exports), matching prepareCommand's skip.
+func TestBuildEnvSourceCommand_SkipsPerSessionEnvForSSHRemotePath(t *testing.T) {
+	withTestToolConfig(t, nil)
+	inst := &Instance{Tool: "testtool", Env: []string{"KEY=fromsession"}, SSHRemotePath: "/remote/path"}
+
+	if out := inst.buildEnvSourceCommand(); strings.Contains(out, "fromsession") {
+		t.Fatalf("per-session env must be skipped for SSHRemotePath sessions: %q", out)
+	}
+}

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -3,9 +3,86 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestValidateSessionEnvKey(t *testing.T) {
+	if err := ValidateSessionEnvKey("FOO_1"); err != nil {
+		t.Fatalf("valid key rejected: %v", err)
+	}
+	if err := ValidateSessionEnvKey("1BAD"); err == nil {
+		t.Fatal("expected error for 1BAD")
+	}
+	if err := ValidateSessionEnvKey(""); err == nil {
+		t.Fatal("expected error for empty")
+	}
+}
+
+func TestParseSessionEnvPair(t *testing.T) {
+	k, v, err := ParseSessionEnvPair("HTTPS_PROXY=http://h:8080")
+	if err != nil || k != "HTTPS_PROXY" || v != "http://h:8080" {
+		t.Fatalf("got %q %q %v", k, v, err)
+	}
+	if _, _, err := ParseSessionEnvPair("NOEQ"); err == nil {
+		t.Fatal("expected error (no =)")
+	}
+	if _, _, err := ParseSessionEnvPair("=x"); err == nil {
+		t.Fatal("expected error (empty key)")
+	}
+}
+
+func TestUpsertUnsetSessionEnv(t *testing.T) {
+	e, _ := UpsertSessionEnv([]string{"A=1"}, "B=2") // append
+	e, _ = UpsertSessionEnv(e, "A=9")                // replace in place
+	if !reflect.DeepEqual(e, []string{"A=9", "B=2"}) {
+		t.Fatalf("upsert order wrong: %v", e)
+	}
+	e = UnsetSessionEnv(e, "A")
+	if !reflect.DeepEqual(e, []string{"B=2"}) {
+		t.Fatalf("unset wrong: %v", e)
+	}
+}
+
+// TestUpsertSessionEnv_CollapsesTrailingDuplicates guards the review fix: a list
+// that already carries duplicate keys (e.g. from a pre-fix session or a web POST
+// array) must not leave a stale later duplicate after upserting — buildSession
+// EnvExports exports in order, so the last entry would otherwise win.
+func TestUpsertSessionEnv_CollapsesTrailingDuplicates(t *testing.T) {
+	e, err := UpsertSessionEnv([]string{"FOO=1", "BAR=x", "FOO=2"}, "FOO=3")
+	if err != nil {
+		t.Fatalf("upsert error: %v", err)
+	}
+	if !reflect.DeepEqual(e, []string{"FOO=3", "BAR=x"}) {
+		t.Fatalf("upsert must replace first and drop later duplicate: got %v", e)
+	}
+}
+
+// TestDedupeSessionEnv guards the whole-list normalizer used by web create/PATCH
+// and the TUI new-session dialog: duplicate keys collapse to their last value at
+// their first-seen position, blank/invalid entries drop, and entries are trimmed.
+func TestDedupeSessionEnv(t *testing.T) {
+	got := DedupeSessionEnv([]string{"  FOO=1  ", "BAR=x", "", "1BAD=y", "FOO=2"})
+	if !reflect.DeepEqual(got, []string{"FOO=2", "BAR=x"}) {
+		t.Fatalf("DedupeSessionEnv = %v, want [FOO=2 BAR=x]", got)
+	}
+	if got := DedupeSessionEnv(nil); len(got) != 0 {
+		t.Fatalf("DedupeSessionEnv(nil) = %v, want empty", got)
+	}
+}
+
+func TestBuildSessionEnvExports(t *testing.T) {
+	if got := buildSessionEnvExports([]string{"FOO=bar", "BAZ=a b"}); got != `export FOO='bar'; export BAZ='a b'; ` {
+		t.Fatalf("unexpected: %q", got)
+	}
+	if got := buildSessionEnvExports([]string{"1BAD=x", "Q=a'b"}); strings.Contains(got, "1BAD") || got != `export Q='a'\''b'; ` {
+		t.Fatalf("escape/skip wrong: %q", got)
+	}
+	if buildSessionEnvExports(nil) != "" {
+		t.Fatal("expected empty")
+	}
+}
 
 func TestExpandPath(t *testing.T) {
 	home, err := os.UserHomeDir()

--- a/internal/session/fork_env_test.go
+++ b/internal/session/fork_env_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestForkInheritsEnv verifies a forked claude session carries the parent's
+// per-session env (Feature B fork-inheritance half of the launch-overrides work).
+func TestForkInheritsEnv(t *testing.T) {
+	parent := NewInstanceWithTool("parent", t.TempDir(), "claude")
+	parent.ClaudeSessionID = "00000000-0000-0000-0000-000000000001"
+	parent.ClaudeDetectedAt = time.Now() // satisfy CanFork freshness
+	parent.Env = []string{"FOO=bar", "BAZ=qux"}
+
+	forked, _, err := parent.CreateForkedInstanceWithOptions("fork", "", nil)
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	if !reflect.DeepEqual(forked.Env, []string{"FOO=bar", "BAZ=qux"}) {
+		t.Fatalf("fork did not inherit env: got %v", forked.Env)
+	}
+	// Copied, not aliased: mutating the parent must not affect the fork.
+	parent.Env[0] = "FOO=changed"
+	if forked.Env[0] != "FOO=bar" {
+		t.Fatalf("fork env aliased parent slice: %v", forked.Env)
+	}
+}
+
+// TestForkInheritsEnv_NonClaudeTools closes the coverage gap flagged in review:
+// the OpenCode/Pi/Codex fork constructors must also inherit per-session env
+// (copied, not aliased), not just claude.
+func TestForkInheritsEnv_NonClaudeTools(t *testing.T) {
+	want := []string{"FOO=bar", "BAZ=qux"}
+	assertInherited := func(t *testing.T, parent, forked *Instance) {
+		t.Helper()
+		if !reflect.DeepEqual(forked.Env, want) {
+			t.Fatalf("fork did not inherit env: got %v want %v", forked.Env, want)
+		}
+		parent.Env[0] = "FOO=changed"
+		if forked.Env[0] != "FOO=bar" {
+			t.Fatalf("fork env aliased parent slice: %v", forked.Env)
+		}
+	}
+
+	t.Run("opencode", func(t *testing.T) {
+		parent := NewInstanceWithTool("parent", t.TempDir(), "opencode")
+		parent.OpenCodeSessionID = "ses_parent_123"
+		parent.OpenCodeDetectedAt = time.Now()
+		parent.Env = append([]string(nil), want...)
+		forked, _, err := parent.CreateForkedOpenCodeInstanceWithOptions("fork", "", nil)
+		if err != nil {
+			t.Fatalf("fork: %v", err)
+		}
+		assertInherited(t, parent, forked)
+	})
+
+	t.Run("pi", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		parent := NewInstanceWithTool("parent", "/tmp/project", "pi")
+		parent.ID = "parent-pi-id"
+		parent.Command = "pi"
+		parent.Env = append([]string(nil), want...)
+		seedLocalPiSessionFile(t, parent)
+		forked, _, err := parent.CreateForkedPiInstance("fork", "")
+		if err != nil {
+			t.Fatalf("fork: %v", err)
+		}
+		assertInherited(t, parent, forked)
+	})
+
+	t.Run("codex", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("CODEX_HOME", home)
+		sid := "11111111-2222-3333-4444-555555555555"
+		seedCodexRollout(t, home, sid)
+		parent := NewInstanceWithTool("parent", "/tmp/project", "codex")
+		parent.CodexSessionID = sid
+		parent.CodexDetectedAt = time.Now()
+		parent.Env = append([]string(nil), want...)
+		forked, _, err := parent.CreateForkedCodexInstanceWithOptions("fork", "", nil)
+		if err != nil {
+			t.Fatalf("fork: %v", err)
+		}
+		assertInherited(t, parent, forked)
+	})
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -352,6 +352,11 @@ type Instance struct {
 	// survive the bash -c wrapper.
 	ExtraArgs []string `json:"extra_args,omitempty"`
 
+	// Env holds per-session environment variables ("KEY=VALUE") exported into the
+	// spawned process for every tool. Persisted via tool_data like ExtraArgs.
+	// Values may be secrets (plaintext at rest; redacted in logs).
+	Env []string `json:"env,omitempty"`
+
 	// ExitToShell is the per-session override for the [shell] exit_to_shell
 	// toggle (issue #1161). nil → inherit the global config default (off);
 	// non-nil → force on/off for this session regardless of config. When on
@@ -5966,7 +5971,7 @@ func (i *Instance) Restart() error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
-		mcpLog.Debug("respawn_pane_claude", slog.String("command", resumeCmd))
+		mcpLog.Debug("respawn_pane_claude", slog.String("command", i.loggableCommand(resumeCmd)))
 
 		// Use respawn-pane for atomic restart
 		// This is more reliable than Ctrl+C + wait for shell + send command
@@ -6013,7 +6018,7 @@ func (i *Instance) Restart() error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
-		sessionLog.Info("restart_gemini_respawn", slog.String("command", resumeCmd))
+		sessionLog.Info("restart_gemini_respawn", slog.String("command", i.loggableCommand(resumeCmd)))
 
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_gemini_respawn_failed", slog.String("error", err.Error()))
@@ -6067,7 +6072,7 @@ func (i *Instance) Restart() error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
-		sessionLog.Info("restart_opencode_respawn", slog.String("command", resumeCmd))
+		sessionLog.Info("restart_opencode_respawn", slog.String("command", i.loggableCommand(resumeCmd)))
 
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_opencode_respawn_failed", slog.String("error", err.Error()))
@@ -6136,7 +6141,7 @@ func (i *Instance) Restart() error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
-		sessionLog.Info("restart_codex_respawn", slog.String("command", resumeCmd))
+		sessionLog.Info("restart_codex_respawn", slog.String("command", i.loggableCommand(resumeCmd)))
 
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_codex_respawn_failed", slog.String("error", err.Error()))
@@ -6174,7 +6179,7 @@ func (i *Instance) Restart() error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
-		sessionLog.Info("restart_cursor_respawn", slog.String("command", resumeCmd))
+		sessionLog.Info("restart_cursor_respawn", slog.String("command", i.loggableCommand(resumeCmd)))
 
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_cursor_respawn_failed", slog.String("error", err.Error()))
@@ -6211,7 +6216,7 @@ func (i *Instance) Restart() error {
 			i.SandboxContainer = containerName
 		}
 
-		sessionLog.Info("restart_generic_respawn", slog.String("tool", i.Tool), slog.String("command", resumeCmd))
+		sessionLog.Info("restart_generic_respawn", slog.String("tool", i.Tool), slog.String("command", i.loggableCommand(resumeCmd)))
 
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info(
@@ -6311,7 +6316,7 @@ func (i *Instance) Restart() error {
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.applyLaunchSettingsFromConfig()
 
-	mcpLog.Debug("restart_starting_new_session", slog.String("command", command))
+	mcpLog.Debug("restart_starting_new_session", slog.String("command", i.loggableCommand(command)))
 
 	if err := i.tmuxSession.Start(command); err != nil {
 		mcpLog.Debug("restart_start_failed", slog.String("error", err.Error()))
@@ -6892,6 +6897,11 @@ func (i *Instance) CreateForkedInstanceWithOptions(
 	if len(i.ExtraArgs) > 0 {
 		forked.ExtraArgs = append([]string(nil), i.ExtraArgs...)
 	}
+	// Per-session env inherits onto the fork (copied, not aliased) so the
+	// forked session launches with the same environment as its parent.
+	if len(i.Env) > 0 {
+		forked.Env = append([]string(nil), i.Env...)
+	}
 
 	cmd, err := i.buildClaudeForkCommandForTarget(forked, opts)
 	if err != nil {
@@ -7088,6 +7098,9 @@ func (i *Instance) CreateForkedOpenCodeInstanceWithOptionsAndWorkDir(
 	forked.ForkStartCommand = cmd
 	forked.IsForkAwaitingStart = true
 	forked.Tool = "opencode"
+	if len(i.Env) > 0 {
+		forked.Env = append([]string(nil), i.Env...)
+	}
 	if worktreeRepoRoot != "" {
 		forked.WorktreePath = workDir
 		forked.WorktreeRepoRoot = worktreeRepoRoot
@@ -7130,6 +7143,9 @@ func (i *Instance) CreateForkedPiInstanceWithOptions(
 	}
 	forked.Tool = "pi"
 	forked.Wrapper = i.Wrapper
+	if len(i.Env) > 0 {
+		forked.Env = append([]string(nil), i.Env...)
+	}
 
 	baseCommand := strings.TrimSpace(i.Command)
 	if baseCommand == "" {
@@ -7217,6 +7233,9 @@ func (i *Instance) CreateForkedCodexInstanceWithOptions(
 	}
 	forked.Tool = i.Tool
 	forked.Wrapper = i.Wrapper
+	if len(i.Env) > 0 {
+		forked.Env = append([]string(nil), i.Env...)
+	}
 
 	baseCommand := strings.TrimSpace(i.Command)
 	if baseCommand == "" {
@@ -8170,12 +8189,47 @@ func (i *Instance) wrapLaunchShell(command string) string {
 // Returns the wrapped command, the sandbox container name (empty if not sandboxed), and an error.
 // All code paths that launch or respawn a tmux pane should use this instead of calling
 // applyWrapper/wrapForSandbox/wrapIgnoreSuspend individually.
+// loggableCommand returns a log-safe representation of a prepared command. When
+// the session carries per-session env (possible secrets), the full command is
+// suppressed because downstream wrappers re-escape the inline exports
+// unpredictably (launch shell, bash -c, SSH, docker). Only the non-secret env
+// KEYS are logged. See spec §Security.
+func (i *Instance) loggableCommand(cmd string) string {
+	if len(i.Env) == 0 {
+		return cmd
+	}
+	keys := make([]string, 0, len(i.Env))
+	for _, kv := range i.Env {
+		if eq := strings.IndexByte(kv, '='); eq > 0 {
+			keys = append(keys, kv[:eq])
+		}
+	}
+	return fmt.Sprintf("<command suppressed: session has per-session env keys [%s]>", strings.Join(keys, ","))
+}
+
 func (i *Instance) prepareCommand(cmd string) (string, string, error) {
 	// Exit-to-shell wrap FIRST, on the bare agent command, so the agent's own
 	// `exec ` launcher is still visible to neutralise and the trailing shell
 	// exec stays the outermost statement before any user-wrapper / bash -c /
 	// SSH layering. No-op unless opt-in for a built-in agent (issue #1161).
 	cmd = i.wrapExitToShell(cmd)
+
+	// Per-session env: prepend exports so they run AFTER interactive shell startup
+	// (wrapLaunchShell sources ~/.zshrc next, then runs this cmd) — user env wins —
+	// and BEFORE the SSH/sandbox wrappers below, so they ride into the
+	// local/container command. Values are shell-escaped; invalid keys dropped.
+	// See spec §Feature B.
+	//
+	// SSHRemotePath sessions are skipped: wrapForSSH re-escapes the whole command
+	// for the `cd '<path>' && <cmd>` remote shape, which mangles the inline
+	// `export KEY='value'` quoting. Per-session env is therefore not applied to
+	// remote-path SSH sessions (documented limitation); local and container
+	// sessions are unaffected.
+	if i.SSHRemotePath == "" {
+		if prefix := buildSessionEnvExports(i.Env); prefix != "" {
+			cmd = prefix + cmd
+		}
+	}
 
 	// Launch-shell wrap SECOND, before user wrapper, so the interactive shell
 	// loads its startup files and then executes the complete command (with

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -4589,3 +4589,71 @@ func TestInstance_RefreshLiveSessionIDs_NoOpForNonAgenticTool(t *testing.T) {
 		t.Errorf("GeminiSessionID mutated for non-agentic tool: got %q", inst.GeminiSessionID)
 	}
 }
+
+// --- Feature B: per-session env injection (Task 7) ---
+
+func TestPrepareCommand_InjectsEnvForAllTools(t *testing.T) {
+	for _, tool := range []string{"claude", "gemini", "codex"} {
+		inst := NewInstanceWithTool("e-"+tool, t.TempDir(), tool)
+		inst.Env = []string{"FOO=bar"}
+		out, _, err := inst.prepareCommand("exec " + tool)
+		if err != nil {
+			t.Fatalf("[%s] prepareCommand: %v", tool, err)
+		}
+		if !strings.Contains(out, "export FOO='bar';") {
+			t.Fatalf("[%s] missing env: %s", tool, out)
+		}
+	}
+}
+
+func TestPrepareCommand_NoEnvWhenEmpty(t *testing.T) {
+	inst := NewInstanceWithTool("none", t.TempDir(), "claude")
+	out, _, err := inst.prepareCommand("exec claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "export FOO") {
+		t.Fatalf("unexpected env: %s", out)
+	}
+}
+
+func TestPrepareCommand_EnvInsideLaunchShellPayload(t *testing.T) {
+	inst := NewInstanceWithTool("ord", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar"}
+	on := true
+	inst.LaunchShell = &on // force wrapLaunchShell active
+	out, _, err := inst.prepareCommand("exec claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cIdx := strings.Index(out, " -c ")
+	envIdx := strings.Index(out, "export FOO")
+	if cIdx == -1 || envIdx == -1 || envIdx < cIdx {
+		t.Fatalf("env must be inside launch-shell -c payload: %s", out)
+	}
+}
+
+// --- Feature B: log suppression when per-session env present (Task 8) ---
+
+func TestLoggableCommand_SuppressesWhenEnvPresent(t *testing.T) {
+	inst := NewInstanceWithTool("s", t.TempDir(), "claude")
+	inst.Env = []string{"TOKEN=supersecret", "Q=a'b"}
+	// Simulate a fully-wrapped command containing the re-escaped secret.
+	wrapped := `bash -c 'export TOKEN='"'"'supersecret'"'"'; export Q='"'"'a'\''b'"'"'; exec claude'`
+	got := inst.loggableCommand(wrapped)
+	for _, secret := range []string{"supersecret", "a'b"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("secret %q leaked: %s", secret, got)
+		}
+	}
+	if !strings.Contains(got, "TOKEN") || !strings.Contains(got, "Q") {
+		t.Fatalf("expected env keys in marker: %s", got)
+	}
+}
+
+func TestLoggableCommand_PassThroughWhenNoEnv(t *testing.T) {
+	inst := NewInstanceWithTool("s", t.TempDir(), "claude")
+	if got := inst.loggableCommand("exec claude --session-id x"); got != "exec claude --session-id x" {
+		t.Fatalf("should pass through: %s", got)
+	}
+}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -43,6 +43,10 @@ const (
 	// baked/default model. Restart-required (the running process keeps the
 	// model it launched with).
 	FieldModel = "model"
+	// FieldEnv sets/clears a single per-session environment variable via a
+	// "KEY=VALUE" payload ("KEY=" clears it). Tool-agnostic; injected at spawn by
+	// prepareCommand. Restart-required (the running process keeps its launch env).
+	FieldEnv = "env"
 )
 
 var ValidMutableFields = []string{
@@ -68,6 +72,7 @@ var ValidMutableFields = []string{
 	FieldIdleTimeout,
 	FieldPin,
 	FieldModel,
+	FieldEnv,
 }
 
 type FieldRestartPolicy int
@@ -80,7 +85,7 @@ const (
 func RestartPolicyFor(field string) FieldRestartPolicy {
 	switch field {
 	case FieldCommand, FieldWrapper, FieldTool, FieldChannels, FieldPlugins, FieldExtraArgs, FieldPath,
-		FieldSkipPermissions, FieldAutoMode, FieldAccount, FieldModel:
+		FieldSkipPermissions, FieldAutoMode, FieldAccount, FieldModel, FieldEnv:
 		return FieldRestartRequired
 	default:
 		return FieldLive
@@ -274,6 +279,35 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 			inst.ExtraArgs = nil
 		} else {
 			inst.ExtraArgs = cleaned
+		}
+
+	case FieldEnv:
+		// Parse FIRST so an invalid key is rejected for BOTH set and unset
+		// ("1BAD=" must error, not silently no-op). A "KEY=" payload (empty
+		// value) clears the variable; otherwise upsert it.
+		oldValue = strings.Join(inst.Env, " ")
+		key, val, perr := ParseSessionEnvPair(value)
+		if perr != nil {
+			return oldValue, nil, &MutationError{Field: field, Msg: perr.Error()}
+		}
+		// Per-session env is not applied to SSH remote-path sessions: wrapForSSH
+		// re-escapes the whole command for the `cd '<path>' && <cmd>` remote
+		// shape, which would mangle the inline `export KEY='value'` quoting. The
+		// proactive create surfaces (CLI add, TUI/web remote-create) already
+		// reject it; reject SETTING here too so `session set env` / web PATCH
+		// can't create a session whose env is silently dropped at spawn. Clearing
+		// (KEY=, val=="") stays allowed so stale env can always be removed.
+		if val != "" && inst.SSHRemotePath != "" {
+			return oldValue, nil, &MutationError{Field: field, Msg: "per-session env is not supported for SSH remote-path sessions"}
+		}
+		if val == "" {
+			inst.Env = UnsetSessionEnv(inst.Env, key)
+		} else {
+			updated, uerr := UpsertSessionEnv(inst.Env, value)
+			if uerr != nil {
+				return oldValue, nil, &MutationError{Field: field, Msg: uerr.Error()}
+			}
+			inst.Env = updated
 		}
 
 	case FieldClaudeSessionID:

--- a/internal/session/mutators_test.go
+++ b/internal/session/mutators_test.go
@@ -2,9 +2,41 @@ package session
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestSetField_EnvUpsertUnsetAndValidation(t *testing.T) {
+	inst := NewInstanceWithTool("s", t.TempDir(), "claude")
+	if _, _, err := SetField(inst, FieldEnv, "FOO=bar", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := SetField(inst, FieldEnv, "FOO=baz", nil); err != nil {
+		t.Fatal(err)
+	} // replace
+	if !reflect.DeepEqual(inst.Env, []string{"FOO=baz"}) {
+		t.Fatalf("env: %v", inst.Env)
+	}
+	if _, _, err := SetField(inst, FieldEnv, "FOO=", nil); err != nil {
+		t.Fatal(err)
+	} // unset
+	if len(inst.Env) != 0 {
+		t.Fatalf("expected unset: %v", inst.Env)
+	}
+	if _, _, err := SetField(inst, FieldEnv, "1BAD=x", nil); err == nil {
+		t.Fatal("expected invalid-key error")
+	}
+	if _, _, err := SetField(inst, FieldEnv, "1BAD=", nil); err == nil {
+		t.Fatal("expected invalid-key error on unset too")
+	}
+}
+
+func TestSetField_Env_RestartRequired(t *testing.T) {
+	if RestartPolicyFor(FieldEnv) != FieldRestartRequired {
+		t.Fatal("env should require restart")
+	}
+}
 
 func TestSetField_Title_UpdatesAndReturnsOldValue(t *testing.T) {
 	inst := &Instance{Title: "old-title"}

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -1638,9 +1638,10 @@ auto_install = false
 		original.PluginChannelLinkDisabled,
 		original.AutoLinkedChannels,
 		original.Color,
+		original.Env,
 	)
 	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-		_, _, _, _, _, _, restoredPlugins, restoredLinkDisabled, _, _ := statedb.UnmarshalToolData(marshalled)
+		_, _, _, _, _, _, restoredPlugins, restoredLinkDisabled, _, _, _ := statedb.UnmarshalToolData(marshalled)
 	if !reflect.DeepEqual(restoredPlugins, []string{"octopus"}) {
 		t.Fatalf("state.db round-trip: Plugins = %v, want [octopus]", restoredPlugins)
 	}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -126,6 +126,10 @@ type InstanceData struct {
 	// command. Persisted so restarts preserve custom flags like --agent/--model.
 	ExtraArgs []string `json:"extra_args,omitempty"`
 
+	// Env holds per-session environment variables ("KEY=VALUE"). Persisted via
+	// tool_data like ExtraArgs.
+	Env []string `json:"env,omitempty"`
+
 	// Color is an optional per-session TUI row tint (issue #391). Empty = no tint.
 	Color string `json:"color,omitempty"`
 
@@ -714,6 +718,7 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 		inst.PluginChannelLinkDisabled, // RFC §4.7
 		inst.AutoLinkedChannels,        // RFC §4.7 (G4/C2 fix)
 		inst.Color,                     // issue #391
+		inst.Env,                       // per-session env vars
 	)
 	// #1143: idle_timeout_secs lives in the tool_data extras zone — outside
 	// the positional MarshalToolData signature so legacy binaries that don't
@@ -832,7 +837,8 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			plugins2,
 			pluginChannelLinkDisabled2,
 			autoLinkedChannels2,
-			color2 := statedb.UnmarshalToolData(r.ToolData)
+			color2,
+			env2 := statedb.UnmarshalToolData(r.ToolData)
 		sandboxCfg := decodeSandboxConfig(sandboxJSON)
 
 		instances[i] = &InstanceData{
@@ -885,6 +891,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			MultiRepoWorktrees:        mrWorktrees2,
 			Channels:                  channels2,
 			ExtraArgs:                 extraArgs2,
+			Env:                       env2,
 			Plugins:                   plugins2,
 			PluginChannelLinkDisabled: pluginChannelLinkDisabled2,
 			AutoLinkedChannels:        autoLinkedChannels2,
@@ -951,7 +958,8 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			plugins,
 			pluginChannelLinkDisabled,
 			autoLinkedChannels,
-			color := statedb.UnmarshalToolData(r.ToolData)
+			color,
+			env := statedb.UnmarshalToolData(r.ToolData)
 		sandboxCfg := decodeSandboxConfig(sandboxJSON)
 
 		data.Instances[i] = &InstanceData{
@@ -1004,6 +1012,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			MultiRepoWorktrees:        mrWorktrees,
 			Channels:                  channels,
 			ExtraArgs:                 extraArgs,
+			Env:                       env,
 			Plugins:                   plugins,
 			PluginChannelLinkDisabled: pluginChannelLinkDisabled,
 			AutoLinkedChannels:        autoLinkedChannels,
@@ -1250,6 +1259,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			LoadedMCPNames:            instData.LoadedMCPNames,
 			Channels:                  instData.Channels,
 			ExtraArgs:                 instData.ExtraArgs,
+			Env:                       instData.Env,
 			Plugins:                   instData.Plugins,
 			PluginChannelLinkDisabled: instData.PluginChannelLinkDisabled,
 			AutoLinkedChannels:        instData.AutoLinkedChannels,

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -2,11 +2,39 @@ package session
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
+
+// TestInstanceEnvRoundTrip verifies per-session Env persists through SQLite via
+// the tool_data JSON blob, just like ExtraArgs.
+func TestInstanceEnvRoundTrip(t *testing.T) {
+	s := newTestStorage(t)
+	inst := NewInstanceWithTool("env-rt", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar", "HTTPS_PROXY=http://127.0.0.1:8080"}
+	if err := s.SaveWithGroups([]*Instance{inst}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, _, err := s.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var got *Instance
+	for _, in := range loaded {
+		if in.ID == inst.ID {
+			got = in
+		}
+	}
+	if got == nil {
+		t.Fatal("instance not reloaded")
+	}
+	if !reflect.DeepEqual(got.Env, inst.Env) {
+		t.Fatalf("Env mismatch: got %v want %v", got.Env, inst.Env)
+	}
+}
 
 // newTestStorage creates a Storage backed by an in-memory-like temp dir SQLite database.
 func newTestStorage(t *testing.T) *Storage {

--- a/internal/statedb/migrate.go
+++ b/internal/statedb/migrate.go
@@ -57,6 +57,7 @@ type jsonInstanceData struct {
 	PluginChannelLinkDisabled bool            `json:"plugin_channel_link_disabled,omitempty"`
 	AutoLinkedChannels        []string        `json:"auto_linked_channels,omitempty"`
 	ExtraArgs                 []string        `json:"extra_args,omitempty"`
+	Env                       []string        `json:"env,omitempty"`
 	Sandbox                   json.RawMessage `json:"sandbox,omitempty"`
 	SandboxContainer          string          `json:"sandbox_container,omitempty"`
 }
@@ -91,6 +92,7 @@ type toolDataBlob struct {
 	PluginChannelLinkDisabled bool            `json:"plugin_channel_link_disabled,omitempty"`
 	AutoLinkedChannels        []string        `json:"auto_linked_channels,omitempty"`
 	ExtraArgs                 []string        `json:"extra_args,omitempty"`
+	Env                       []string        `json:"env,omitempty"`
 	ToolOptions               json.RawMessage `json:"tool_options,omitempty"`
 	Sandbox                   json.RawMessage `json:"sandbox,omitempty"`
 	SandboxContainer          string          `json:"sandbox_container,omitempty"`
@@ -141,6 +143,7 @@ func MigrateFromJSON(jsonPath string, db *StateDB) (int, int, error) {
 			LoadedMCPNames:            inst.LoadedMCPNames,
 			Channels:                  inst.Channels,  // pre-existing omission, fixed alongside Plugins
 			ExtraArgs:                 inst.ExtraArgs, // pre-existing omission, fixed alongside Plugins
+			Env:                       inst.Env,
 			Plugins:                   inst.Plugins,
 			PluginChannelLinkDisabled: inst.PluginChannelLinkDisabled,
 			AutoLinkedChannels:        inst.AutoLinkedChannels,
@@ -241,6 +244,7 @@ func MarshalToolData(
 	pluginChannelLinkDisabled bool, // RFC docs/rfc/PLUGIN_ATTACH.md §4.7
 	autoLinkedChannels []string, // RFC §4.7 — fixes G4/C2 stale autolink retention
 	color string, // issue #391
+	env []string, // per-session environment variables
 ) json.RawMessage {
 	td := toolDataBlob{
 		ClaudeSessionID:           claudeSessionID,
@@ -257,6 +261,7 @@ func MarshalToolData(
 		PluginChannelLinkDisabled: pluginChannelLinkDisabled,
 		AutoLinkedChannels:        autoLinkedChannels,
 		ExtraArgs:                 extraArgs,
+		Env:                       env,
 		ToolOptions:               toolOptionsJSON,
 		Sandbox:                   sandboxJSON,
 		SandboxContainer:          sandboxContainer,
@@ -306,6 +311,7 @@ func UnmarshalToolData(data json.RawMessage) (
 	pluginChannelLinkDisabled bool, // RFC docs/rfc/PLUGIN_ATTACH.md §4.7
 	autoLinkedChannels []string, // RFC §4.7 — fixes G4/C2 stale autolink retention
 	color string, // issue #391
+	env []string, // per-session environment variables
 ) {
 	if len(data) == 0 {
 		return
@@ -341,6 +347,7 @@ func UnmarshalToolData(data json.RawMessage) (
 	pluginChannelLinkDisabled = td.PluginChannelLinkDisabled
 	autoLinkedChannels = td.AutoLinkedChannels
 	extraArgs = td.ExtraArgs
+	env = td.Env
 	toolOptionsJSON = td.ToolOptions
 	sandboxJSON = td.Sandbox
 	sandboxContainer = td.SandboxContainer

--- a/internal/statedb/multi_repo_test.go
+++ b/internal/statedb/multi_repo_test.go
@@ -29,10 +29,11 @@ func TestMarshalUnmarshalToolData_MultiRepo(t *testing.T) {
 		false, // plugin_channel_link_disabled
 		nil,   // auto_linked_channels (RFC §4.7 G4/C2 fix)
 		"",    // color (issue #391)
+		nil,   // env (per-session env vars)
 	)
 
 	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-		mrEnabled, addPaths, mrTempDir, mrWorktrees, _, _, _, _, _, _ := UnmarshalToolData(data)
+		mrEnabled, addPaths, mrTempDir, mrWorktrees, _, _, _, _, _, _, _ := UnmarshalToolData(data)
 
 	assert.True(t, mrEnabled)
 	assert.Equal(t, []string{"/path/additional1", "/path/additional2"}, addPaths)
@@ -60,10 +61,11 @@ func TestMarshalUnmarshalToolData_NoMultiRepo(t *testing.T) {
 		false, // plugin_channel_link_disabled
 		nil,   // auto_linked_channels (RFC §4.7 G4/C2 fix)
 		"",    // color (issue #391)
+		nil,   // env (per-session env vars)
 	)
 
 	claudeSID, _, _, _, _, _, _, _, _, _, prompt, notes, mcps, _, _, _, _, _,
-		mrEnabled, addPaths, mrTempDir, mrWorktrees, _, _, _, _, _, _ := UnmarshalToolData(data)
+		mrEnabled, addPaths, mrTempDir, mrWorktrees, _, _, _, _, _, _, _ := UnmarshalToolData(data)
 
 	assert.Equal(t, "claude-123", claudeSID)
 	assert.Equal(t, "prompt", prompt)
@@ -96,10 +98,11 @@ func TestMarshalUnmarshalToolData_Plugins(t *testing.T) {
 		false,                          // plugin_channel_link_disabled
 		nil,                            // auto_linked_channels
 		"",                             // color
+		nil,                            // env (per-session env vars)
 	)
 
 	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-		_, _, _, _, _, _, plugins, _, _, _ := UnmarshalToolData(data)
+		_, _, _, _, _, _, plugins, _, _, _, _ := UnmarshalToolData(data)
 
 	assert.Equal(t, []string{"octopus", "discord"}, plugins,
 		"Plugins must round-trip through MarshalToolData/UnmarshalToolData unchanged — Restart relies on this for enabledPlugins re-application")

--- a/internal/tmux/redact_inline_test.go
+++ b/internal/tmux/redact_inline_test.go
@@ -1,0 +1,36 @@
+package tmux
+
+import "testing"
+
+func TestRedactInlineExports(t *testing.T) {
+	in := `bash -lc 'export AGENTDECK_INSTANCE_ID='\''x'\''; export TOKEN='supersecret'; exec claude'`
+	got := redactInlineExports(in)
+	if want := "supersecret"; contains(got, want) {
+		t.Fatalf("secret leaked: %s", got)
+	}
+	if !contains(got, "export TOKEN='***'") {
+		t.Fatalf("not redacted: %s", got)
+	}
+}
+
+// A value with an embedded (shell-escaped) single quote must be redacted WHOLE —
+// the escaped tail must not leak. buildSessionEnvExports renders a literal quote
+// in a value as `'\”`, so TOKEN=a'secret becomes export TOKEN='a'\”secret'.
+func TestRedactInlineExports_EscapedQuoteValue(t *testing.T) {
+	in := `export TOKEN='a'\''secret'; exec claude`
+	got := redactInlineExports(in)
+	if contains(got, "secret") {
+		t.Fatalf("escaped-quote value leaked: %s", got)
+	}
+	if !contains(got, "export TOKEN='***'") {
+		t.Fatalf("not redacted: %s", got)
+	}
+}
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2574,14 +2574,19 @@ func (s *Session) RespawnPane(command string) error {
 		args = append(args, wrapped)
 	}
 
-	mcpLog.Debug("respawn_pane_executing", slog.Any("args", args))
+	// Do NOT log the wrapped command payload: it may contain per-session env
+	// `export KEY='secret'` exports, and wrapRespawnCommand shell-quotes the
+	// whole command (escaping the inner quotes), so no regex can reliably redact
+	// it. The session layer already logs a safe summary via loggableCommand, so
+	// the command is omitted here and we log only the non-secret invocation shape.
+	mcpLog.Debug("respawn_pane_executing", slog.String("target", target), slog.Bool("has_command", command != ""))
 	cmd := s.tmuxCmd(args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		mcpLog.Debug("respawn_pane_error", slog.String("error", err.Error()), slog.String("output", string(output)))
-		return fmt.Errorf("failed to respawn pane: %w (output: %s)", err, string(output))
+		mcpLog.Debug("respawn_pane_error", slog.String("error", err.Error()), slog.String("output", redactInlineExports(string(output))))
+		return fmt.Errorf("failed to respawn pane: %w (output: %s)", err, redactInlineExports(string(output)))
 	}
-	mcpLog.Debug("respawn_pane_output", slog.String("output", string(output)))
+	mcpLog.Debug("respawn_pane_output", slog.String("output", redactInlineExports(string(output))))
 
 	// Get the NEW pane PID so we don't accidentally kill the fresh process
 	newPanePID, _ := s.getPaneProcessTree()
@@ -2614,6 +2619,23 @@ func (s *Session) RespawnPane(command string) error {
 	s.mu.Unlock()
 
 	return nil
+}
+
+// inlineExportRe matches a shell `export NAME='value'` assignment, including
+// values that contain shell-escaped single quotes (`'\”`, how buildSession
+// EnvExports escapes a literal quote). Per-session env and other secrets are
+// injected this way; the value token is redacted whole in debug logs without
+// touching the executed command. The value body is a run of non-quote chars or
+// the 4-char `'\”` escape sequence, bounded by the opening/closing quotes.
+var inlineExportRe = regexp.MustCompile(`(export [A-Za-z_][A-Za-z0-9_]*=)'(?:[^']|'\\'')*'`)
+
+// redactInlineExports replaces the values of unwrapped `export NAME='...'`
+// assignments with *** for safe logging of tmux output messages. It operates on
+// the LOGGED copy only; the command actually executed is never altered. Note it
+// only handles the unwrapped form — the prepared command itself is never logged
+// (see respawn_pane_executing), so wrapped/escaped exports never reach a log.
+func redactInlineExports(s string) string {
+	return inlineExportRe.ReplaceAllString(s, "${1}'***'")
 }
 
 func wrapRespawnCommand(command string) (string, error) {

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -62,6 +62,7 @@ type ConfirmDialog struct {
 	pendingClaudeExtraArgs   []string        // User-supplied claude CLI tokens
 	pendingClaudeStartQuery  string          // Per-session claude startup query (v1.7.67, #725)
 	pendingLaunchModelID     string          // Optional per-session model/version override.
+	pendingSessionEnv        []string        // Per-session env vars ("KEY=VALUE"), all tools.
 	pendingParentSessionID   string
 	pendingParentProjectPath string
 }
@@ -208,6 +209,7 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	claudeExtraArgs []string,
 	claudeStartQuery string,
 	launchModelID string,
+	env []string,
 	parentSessionID string,
 	parentProjectPath string,
 ) {
@@ -223,6 +225,7 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	c.pendingClaudeExtraArgs = claudeExtraArgs
 	c.pendingClaudeStartQuery = claudeStartQuery
 	c.pendingLaunchModelID = launchModelID
+	c.pendingSessionEnv = env
 	c.pendingParentSessionID = parentSessionID
 	c.pendingParentProjectPath = parentProjectPath
 	c.buttonCount = 2
@@ -240,8 +243,8 @@ func (c *ConfirmDialog) ShowInstallHooks() {
 }
 
 // GetPendingSession returns the pending session creation data
-func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, claudeExtraArgs []string, claudeStartQuery, launchModelID string, parentSessionID, parentProjectPath string) {
-	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
+func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, claudeExtraArgs []string, claudeStartQuery, launchModelID string, env []string, parentSessionID, parentProjectPath string) {
+	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingLaunchModelID, c.pendingSessionEnv, c.pendingParentSessionID, c.pendingParentProjectPath
 }
 
 // Hide hides the dialog.

--- a/internal/ui/edit_session_dialog.go
+++ b/internal/ui/edit_session_dialog.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -17,13 +19,33 @@ const (
 	editFieldText editFieldKind = iota
 	editFieldPills
 	editFieldCheckbox
+	// editFieldEnv is a multi-line textarea holding one "KEY=VALUE" per line
+	// (mirrors the New Session dialog's env textarea). Newline-separation lets a
+	// value contain spaces (e.g. "MSG=hello world") — a single-line, space-split
+	// view could not round-trip that. GetChanges emits one FieldEnv upsert Change
+	// per line plus a "KEY=" Change per removed key.
+	editFieldEnv
 )
 
+// isTextLike reports whether a field kind is edited via a single-line text input
+// (focus, typing, and rendering). editFieldEnv is handled separately because it
+// is backed by a multi-line textarea, not a textinput.
+func isTextLike(kind editFieldKind) bool {
+	return kind == editFieldText
+}
+
 type editField struct {
-	key         string
-	label       string
-	kind        editFieldKind
-	input       textinput.Model
+	key   string
+	label string
+	kind  editFieldKind
+	input textinput.Model
+	// area backs editFieldEnv (multi-line KEY=VALUE, one per line). Unused for
+	// every other kind.
+	area textarea.Model
+	// orig is the field's initial value at dialog-build time. Used by Validate
+	// and the GetChanges no-op guard to skip a field the user has not touched
+	// (for editFieldEnv, orig is the newline-joined env list).
+	orig        string
 	pillOptions []string
 	// pillLabels, when set, supplies human display text for each pillOption
 	// (e.g. "Off"/"Top"/"Bottom" for the pin field). The committed value is
@@ -77,6 +99,13 @@ func (d *EditSessionDialog) Show(inst *session.Instance) {
 			pillOptions: []string{string(session.PinNone), string(session.PinTop), string(session.PinBottom)},
 			pillLabels:  []string{"Off", "Top", "Bottom"},
 			pillCursor:  pinCursorFor(inst.Pin)},
+		// Per-session env (all tools). Multi-line textarea, one KEY=VALUE per
+		// line (matches the New Session dialog) so values may contain spaces.
+		{key: session.FieldEnv,
+			label: "Env (restart) — one KEY=VALUE per line; stored in plaintext",
+			kind:  editFieldEnv,
+			orig:  strings.Join(inst.Env, "\n"),
+			area:  mkEnvArea(strings.Join(inst.Env, "\n"), d.width)},
 	}
 	if session.IsClaudeCompatible(inst.Tool) {
 		skip, auto := readClaudeFlags(inst)
@@ -176,11 +205,43 @@ func mkInput(placeholder string, charLimit int, initial string) textinput.Model 
 	return ti
 }
 
+// mkEnvArea builds the multi-line env textarea (one KEY=VALUE per line). Mirrors
+// the New Session dialog's env textarea so both surfaces round-trip values that
+// contain spaces. dialogWidth is the outer dialog width (0 before first layout);
+// the textarea width is derived from it, matching the View's rendering box.
+func mkEnvArea(initial string, dialogWidth int) textarea.Model {
+	ta := textarea.New()
+	ta.Placeholder = "KEY=VALUE (one per line)"
+	ta.ShowLineNumbers = false
+	ta.CharLimit = 4096
+	ta.SetHeight(3)
+	ta.SetWidth(envAreaWidth(dialogWidth))
+	ta.SetValue(initial)
+	ta.Blur()
+	return ta
+}
+
+// envAreaWidth derives the env textarea's inner width from the outer dialog
+// width, clamped to a sane range so it is usable before the first SetSize.
+func envAreaWidth(dialogWidth int) int {
+	w := dialogWidth - 16
+	if w < 40 {
+		w = 40
+	}
+	if w > 64 {
+		w = 64
+	}
+	return w
+}
+
 func (d *EditSessionDialog) Hide() {
 	d.visible = false
 	for i := range d.fields {
-		if d.fields[i].kind == editFieldText {
+		switch {
+		case isTextLike(d.fields[i].kind):
 			d.fields[i].input.Blur()
+		case d.fields[i].kind == editFieldEnv:
+			d.fields[i].area.Blur()
 		}
 	}
 }
@@ -194,8 +255,16 @@ func (d *EditSessionDialog) IsVisible() bool {
 	return d.visible
 }
 
-func (d *EditSessionDialog) SessionID() string   { return d.sessionID }
-func (d *EditSessionDialog) SetSize(w, h int)    { d.width, d.height = w, h }
+func (d *EditSessionDialog) SessionID() string { return d.sessionID }
+func (d *EditSessionDialog) SetSize(w, h int) {
+	d.width, d.height = w, h
+	// Keep the env textarea width in sync with the (possibly resized) dialog.
+	for i := range d.fields {
+		if d.fields[i].kind == editFieldEnv {
+			d.fields[i].area.SetWidth(envAreaWidth(w))
+		}
+	}
+}
 func (d *EditSessionDialog) SetError(msg string) { d.validationErr = msg }
 func (d *EditSessionDialog) ClearError()         { d.validationErr = "" }
 
@@ -231,6 +300,41 @@ func (d *EditSessionDialog) GetChanges(inst *session.Instance) []Change {
 			if newVal != fieldInitialValue(inst, f.key) {
 				changes = append(changes, Change{Field: f.key, Value: newVal, IsLive: isLive})
 			}
+		case editFieldEnv:
+			// Untouched guard FIRST (before canonicalization): if the textarea
+			// still holds exactly what Show() seeded, emit nothing. This preserves
+			// a value that canonicalization would otherwise mutate — e.g. a stored
+			// "FOO=bar " (trailing space in the value) must survive an untouched
+			// save rather than being trimmed to "FOO=bar".
+			if f.area.Value() == f.orig {
+				continue
+			}
+			// This textarea holds the WHOLE env list (one KEY=VALUE per line).
+			// Canonicalize — trim each line, drop blank/unparseable lines — so a
+			// cosmetic edit (trailing newline, blank line, padded line) that leaves
+			// the effective env unchanged does not emit a spurious change.
+			desired := make([]string, 0)
+			for _, line := range strings.Split(f.area.Value(), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				if _, _, err := session.ParseSessionEnvPair(line); err != nil {
+					continue
+				}
+				desired = append(desired, line)
+			}
+			// No-op guard: the canonical desired list equals the current env
+			// (inst.Env is already canonical — validated on the way in).
+			joined := strings.Join(desired, "\n")
+			if joined == strings.Join(inst.Env, "\n") {
+				continue
+			}
+			// Emit ONE whole-list Change (newline-joined). The commit path replaces
+			// inst.Env wholesale (like the web PATCH) rather than routing rows
+			// through SetField's single-pair upsert/unset — which would treat a
+			// desired empty-valued entry ("FOO=") as an unset and drop it.
+			changes = append(changes, Change{Field: session.FieldEnv, Value: joined, IsLive: isLive})
 		}
 	}
 	return changes
@@ -249,12 +353,24 @@ func (d *EditSessionDialog) HasRestartRequiredChanges(inst *session.Instance) bo
 // authoritatively at commit time.
 func (d *EditSessionDialog) Validate() string {
 	for _, f := range d.fields {
-		if f.kind != editFieldText {
-			continue
-		}
-		if f.key == session.FieldTitle {
+		if f.kind == editFieldText && f.key == session.FieldTitle {
 			if strings.TrimSpace(f.input.Value()) == "" {
 				return "Title cannot be empty"
+			}
+		}
+		// Env field: validate each KEY=VALUE line so an invalid entry surfaces a
+		// clear error instead of silently dropping pairs / unsetting existing keys
+		// (the commit path only applies GetChanges when Validate passes). Skip when
+		// unchanged so the GetChanges no-op guard leaves it untouched.
+		if f.kind == editFieldEnv && f.area.Value() != f.orig {
+			for _, line := range strings.Split(f.area.Value(), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				if _, _, err := session.ParseSessionEnvPair(line); err != nil {
+					return fmt.Sprintf("Invalid env entry %q (use KEY=VALUE, one per line)", line)
+				}
 			}
 		}
 	}
@@ -271,6 +387,8 @@ func fieldInitialValue(inst *session.Instance, field string) string {
 		return inst.Tool
 	case session.FieldExtraArgs:
 		return strings.Join(inst.ExtraArgs, " ")
+	case session.FieldEnv:
+		return strings.Join(inst.Env, "\n")
 	case session.FieldPlugins:
 		return strings.Join(inst.Plugins, ",")
 	case session.FieldSkipPermissions:
@@ -287,14 +405,44 @@ func fieldInitialValue(inst *session.Instance, field string) string {
 
 func (d *EditSessionDialog) updateFocus() {
 	for i := range d.fields {
-		if d.fields[i].kind == editFieldText {
-			if i == d.focusIndex {
+		focused := i == d.focusIndex
+		switch {
+		case isTextLike(d.fields[i].kind):
+			if focused {
 				d.fields[i].input.Focus()
 			} else {
 				d.fields[i].input.Blur()
 			}
+		case d.fields[i].kind == editFieldEnv:
+			if focused {
+				d.fields[i].area.Focus()
+			} else {
+				d.fields[i].area.Blur()
+			}
 		}
 	}
+}
+
+// envFieldFocused reports whether the currently focused field is the multi-line
+// env textarea. The outer key router (home.go) uses this so Enter inserts a
+// newline in the textarea instead of committing the dialog.
+func (d *EditSessionDialog) envFieldFocused() bool {
+	return d.focusIndex >= 0 && d.focusIndex < len(d.fields) &&
+		d.fields[d.focusIndex].kind == editFieldEnv
+}
+
+func (d *EditSessionDialog) focusNext() {
+	if len(d.fields) > 0 {
+		d.focusIndex = (d.focusIndex + 1) % len(d.fields)
+	}
+	d.updateFocus()
+}
+
+func (d *EditSessionDialog) focusPrev() {
+	if len(d.fields) > 0 {
+		d.focusIndex = (d.focusIndex - 1 + len(d.fields)) % len(d.fields)
+	}
+	d.updateFocus()
 }
 
 // Update returns nil cmd on esc/enter so the outer key router can decide
@@ -309,19 +457,28 @@ func (d *EditSessionDialog) Update(msg tea.Msg) (*EditSessionDialog, tea.Cmd) {
 	}
 
 	switch keyMsg.String() {
-	case "tab", "down":
-		if len(d.fields) > 0 {
-			d.focusIndex = (d.focusIndex + 1) % len(d.fields)
-		}
-		d.updateFocus()
+	case "tab":
+		d.focusNext()
 		return d, nil
 
-	case "shift+tab", "up":
-		if len(d.fields) > 0 {
-			d.focusIndex = (d.focusIndex - 1 + len(d.fields)) % len(d.fields)
-		}
-		d.updateFocus()
+	case "shift+tab":
+		d.focusPrev()
 		return d, nil
+
+	case "down":
+		// Inside the multi-line env textarea, ↓ moves the cursor between lines;
+		// fall through to the textarea update. Elsewhere it navigates fields
+		// (Tab/Shift+Tab always navigate, so the env field is still escapable).
+		if !d.envFieldFocused() {
+			d.focusNext()
+			return d, nil
+		}
+
+	case "up":
+		if !d.envFieldFocused() {
+			d.focusPrev()
+			return d, nil
+		}
 
 	case "left":
 		if d.isPillsFocused() {
@@ -348,14 +505,31 @@ func (d *EditSessionDialog) Update(msg tea.Msg) (*EditSessionDialog, tea.Cmd) {
 			return d, nil
 		}
 
-	case "esc", "enter":
+	case "esc":
 		return d, nil
+
+	case "enter":
+		// When the env textarea is focused, Enter inserts a newline (one
+		// KEY=VALUE per line) — fall through to the textarea update below. The
+		// router (home.go) only delegates Enter here in that case; otherwise it
+		// handles Enter as save and this dialog never sees it. ^S saves from the
+		// textarea.
+		if !d.envFieldFocused() {
+			return d, nil
+		}
 	}
 
-	if d.focusIndex >= 0 && d.focusIndex < len(d.fields) && d.fields[d.focusIndex].kind == editFieldText {
-		var cmd tea.Cmd
-		d.fields[d.focusIndex].input, cmd = d.fields[d.focusIndex].input.Update(msg)
-		return d, cmd
+	if d.focusIndex >= 0 && d.focusIndex < len(d.fields) {
+		switch {
+		case isTextLike(d.fields[d.focusIndex].kind):
+			var cmd tea.Cmd
+			d.fields[d.focusIndex].input, cmd = d.fields[d.focusIndex].input.Update(msg)
+			return d, cmd
+		case d.fields[d.focusIndex].kind == editFieldEnv:
+			var cmd tea.Cmd
+			d.fields[d.focusIndex].area, cmd = d.fields[d.focusIndex].area.Update(msg)
+			return d, cmd
+		}
 	}
 
 	return d, nil
@@ -422,6 +596,10 @@ func (d *EditSessionDialog) View() string {
 		switch f.kind {
 		case editFieldText:
 			content.WriteString(f.input.View())
+		case editFieldEnv:
+			// Indent every textarea line to match the field column (the "\n  "
+			// prefix above indents only the first line).
+			content.WriteString(strings.ReplaceAll(f.area.View(), "\n", "\n  "))
 		case editFieldPills:
 			if f.pillLabels != nil {
 				content.WriteString(renderLabelPills(f.pillLabels, f.pillCursor))
@@ -440,7 +618,13 @@ func (d *EditSessionDialog) View() string {
 	}
 
 	content.WriteString("\n")
-	content.WriteString(helpStyle.Render("Enter save │ Esc cancel │ Tab next │ ←/→ options │ Space toggle"))
+	// The env textarea consumes Enter as a newline, so advertise ^S for save
+	// while it is focused (mirrors the New Session dialog).
+	helpText := "Enter save │ ^S save │ Esc cancel │ Tab next │ ←/→ options │ Space toggle"
+	if d.envFieldFocused() {
+		helpText = "^S save │ Enter newline │ Esc cancel │ Tab next"
+	}
+	content.WriteString(helpStyle.Render(helpText))
 
 	dialog := dialogStyle.Render(content.String())
 	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, dialog)

--- a/internal/ui/edit_session_dialog_test.go
+++ b/internal/ui/edit_session_dialog_test.go
@@ -562,3 +562,149 @@ func TestEditSessionDialog_ReShowResetsError(t *testing.T) {
 		t.Error("Show() should clear any inline error from a prior Show()")
 	}
 }
+
+// setEnvField locates the editFieldEnv field by key and sets its raw value.
+// setEnvField sets the env textarea's raw value. raw uses newline-separated
+// "KEY=VALUE" entries (one per line), matching the dialog's multi-line editor.
+func setEnvField(t *testing.T, d *EditSessionDialog, raw string) {
+	t.Helper()
+	for i := range d.fields {
+		if d.fields[i].key == session.FieldEnv {
+			d.fields[i].area.SetValue(raw)
+			return
+		}
+	}
+	t.Fatal("env field not found in dialog")
+}
+
+// envChangeValues returns the Values of all FieldEnv changes, in order. With the
+// whole-list model there is at most one FieldEnv change (a newline-joined list).
+func envChangeValues(changes []Change) []string {
+	var out []string
+	for _, c := range changes {
+		if c.Field == session.FieldEnv {
+			out = append(out, c.Value)
+		}
+	}
+	return out
+}
+
+// envChangeList returns the entries of the single whole-list FieldEnv change
+// (newline-joined), preserving order; nil if there is no FieldEnv change.
+func envChangeList(changes []Change) []string {
+	for _, c := range changes {
+		if c.Field == session.FieldEnv {
+			if c.Value == "" {
+				return []string{}
+			}
+			return strings.Split(c.Value, "\n")
+		}
+	}
+	return nil
+}
+
+// No-op guard: an instance with a pre-existing env, opened and saved without
+// edits, must produce zero changes. The value carries a space so the test also
+// guards the whitespace-sensitive path the multi-line textarea now supports.
+func TestEditSessionDialog_GetChanges_EnvUntouchedNoOp(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar baz"}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+
+	changes := d.GetChanges(inst)
+	if len(envChangeValues(changes)) != 0 {
+		t.Errorf("untouched env produced changes: %v", changes)
+	}
+}
+
+// A value containing a space round-trips through the multi-line textarea: after
+// editing another line, the space-bearing entry is preserved verbatim (the old
+// single-line, space-split editor corrupted it).
+func TestEditSessionDialog_GetChanges_EnvSpaceValueRoundTrips(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"MSG=hello world"}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	// Append a second entry; the first (with its space) must survive intact.
+	setEnvField(t, d, "MSG=hello world\nNEW=1")
+
+	if got := strings.Join(envChangeList(d.GetChanges(inst)), "\n"); got != "MSG=hello world\nNEW=1" {
+		t.Fatalf("env whole-list change = %q, want %q", got, "MSG=hello world\nNEW=1")
+	}
+}
+
+// Editing the env field emits ONE whole-list FieldEnv change with the desired
+// entries in order.
+func TestEditSessionDialog_GetChanges_EnvUpserts(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar"}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	setEnvField(t, d, "FOO=baz\nNEW=1")
+
+	if got := envChangeValues(d.GetChanges(inst)); len(got) != 1 {
+		t.Fatalf("expected exactly one whole-list env change, got %v", got)
+	}
+	if got := strings.Join(envChangeList(d.GetChanges(inst)), "\n"); got != "FOO=baz\nNEW=1" {
+		t.Fatalf("env whole-list change = %q, want %q", got, "FOO=baz\nNEW=1")
+	}
+}
+
+// Removing a key drops it from the whole-list change (no separate "KEY=" unset).
+func TestEditSessionDialog_GetChanges_EnvUnset(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar", "BAZ=qux"}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	setEnvField(t, d, "FOO=bar")
+
+	if got := strings.Join(envChangeList(d.GetChanges(inst)), "\n"); got != "FOO=bar" {
+		t.Fatalf("env whole-list change = %q, want %q (BAZ removed)", got, "FOO=bar")
+	}
+}
+
+// A desired empty-valued entry ("FOO=") must be PRESERVED, not dropped — the
+// whole-list commit path replaces inst.Env instead of treating "FOO=" as an
+// unset the way single-pair SetField would.
+func TestEditSessionDialog_GetChanges_EnvEmptyValuePreserved(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar"}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	setEnvField(t, d, "FOO=") // change FOO to an empty value (not an unset)
+
+	if got := strings.Join(envChangeList(d.GetChanges(inst)), "\n"); got != "FOO=" {
+		t.Fatalf("env whole-list change = %q, want %q (empty value preserved)", got, "FOO=")
+	}
+}
+
+// An untouched env whose value carries a trailing space must survive a no-op
+// save verbatim: the raw untouched-guard runs before canonicalization, so the
+// value is not trimmed to "FOO=bar".
+func TestEditSessionDialog_GetChanges_EnvTrailingSpaceUntouchedNoOp(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar "} // trailing space in the value
+	d := NewEditSessionDialog()
+	d.Show(inst)
+
+	if got := envChangeValues(d.GetChanges(inst)); len(got) != 0 {
+		t.Errorf("untouched trailing-space env produced changes: %v", got)
+	}
+}
+
+// A cosmetic env edit (trailing newline / blank line) that leaves the effective
+// env unchanged must not emit a spurious restart-required change — the no-op
+// guard canonicalizes the textarea before diffing.
+func TestEditSessionDialog_GetChanges_EnvCosmeticEditNoOp(t *testing.T) {
+	inst := session.NewInstanceWithTool("t", t.TempDir(), "claude")
+	inst.Env = []string{"FOO=bar", "BAZ=qux"}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	// Same entries, but with a blank line and a trailing newline.
+	setEnvField(t, d, "FOO=bar\n\nBAZ=qux\n")
+
+	if got := envChangeValues(d.GetChanges(inst)); len(got) != 0 {
+		t.Errorf("cosmetic-only env edit produced changes: %v", got)
+	}
+}

--- a/internal/ui/env_validation_fix_test.go
+++ b/internal/ui/env_validation_fix_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestEditDialogValidate_RejectsInvalidEnv ensures an edited env field with an
+// invalid entry is blocked (not silently dropped / unsetting existing keys).
+func TestEditDialogValidate_RejectsInvalidEnv(t *testing.T) {
+	inst := &session.Instance{ID: "x", Title: "t", Tool: "claude", Env: []string{"FOO=bar"}}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	for i := range d.fields {
+		if d.fields[i].key == session.FieldEnv {
+			d.fields[i].area.SetValue("1BAD=x") // invalid key, changed from orig
+		}
+	}
+	if msg := d.Validate(); msg == "" || !strings.Contains(msg, "Invalid env") {
+		t.Fatalf("expected invalid-env validation error, got %q", msg)
+	}
+}
+
+// TestEditDialogValidate_UnchangedEnvPasses ensures an untouched env field (here
+// a space-bearing value the multi-line textarea round-trips) does not block edits.
+func TestEditDialogValidate_UnchangedEnvPasses(t *testing.T) {
+	inst := &session.Instance{ID: "x", Title: "t", Tool: "claude", Env: []string{"MSG=hello world"}}
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	if msg := d.Validate(); msg != "" {
+		t.Fatalf("untouched env must not block validation, got %q", msg)
+	}
+}
+
+// TestNewDialogValidate_RejectsInvalidEnv ensures a bad env line in the new
+// dialog surfaces an error instead of being silently dropped at create.
+func TestNewDialogValidate_RejectsInvalidEnv(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	d.nameInput.SetValue("demo")
+	d.pathInput.SetValue("/tmp/project")
+	d.envInput.SetValue("FOO=ok\n1BAD=x")
+	if msg := d.Validate(); msg == "" || !strings.Contains(msg, "Invalid env") {
+		t.Fatalf("expected invalid-env validation error, got %q", msg)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6526,6 +6526,14 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// check, local create) must be skipped — it would act on the LOCAL
 		// filesystem (#743).
 		if h.pendingRemoteName != "" {
+			// Remote-mode create shells `agent-deck add` on the remote host and
+			// does not forward per-session env, so reject it here rather than
+			// silently dropping the user's input. (Direct-SSH and local/Docker
+			// sessions created normally still receive per-session env.)
+			if len(h.newDialog.GetSessionEnv()) > 0 {
+				h.newDialog.SetError("Per-session env is not supported for remote (SSH) sessions — set it on the remote host instead")
+				return h, nil
+			}
 			remoteName := h.pendingRemoteName
 			name, path, command := h.newDialog.GetRemoteValues()
 			groupPath := h.newDialog.GetSelectedGroup()
@@ -6548,6 +6556,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		groupPath := h.newDialog.GetSelectedGroup()
 		claudeOpts := h.newDialog.GetClaudeOptions() // Get Claude options if applicable.
 		launchModelID := h.newDialog.GetLaunchModelID()
+		env := h.newDialog.GetSessionEnv() // per-session env vars (all tools).
 
 		// Resolve worktree/workspace target if enabled; actual creation runs in async command.
 		var worktreePath, worktreeRepoRoot string
@@ -6598,7 +6607,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !worktreeEnabled {
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				h.newDialog.Hide()
-				h.confirmDialog.ShowCreateDirectory(path, name, command, groupPath, toolOptionsJSON, claudeExtraArgs, claudeStartQuery, launchModelID, parentSessionID, parentProjectPath)
+				h.confirmDialog.ShowCreateDirectory(path, name, command, groupPath, toolOptionsJSON, claudeExtraArgs, claudeStartQuery, launchModelID, env, parentSessionID, parentProjectPath)
 				return h, nil
 			}
 		}
@@ -6652,6 +6661,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			claudeExtraArgs,
 			claudeStartQuery,
 			launchModelID,
+			env,
 			multiRepoEnabled,
 			additionalPaths,
 			parentSessionID,
@@ -8711,7 +8721,7 @@ func (h *Home) confirmAction() tea.Cmd {
 
 // confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
 func (h *Home) confirmCreateDirectory() tea.Cmd {
-	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingLaunchModelID, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
+	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingLaunchModelID, pendingEnv, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
 	h.confirmDialog.Hide()
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		h.setError(fmt.Errorf("failed to create directory: %w", err))
@@ -8731,6 +8741,7 @@ func (h *Home) confirmCreateDirectory() tea.Cmd {
 		pendingExtraArgs,
 		pendingStartQuery,
 		pendingLaunchModelID,
+		pendingEnv,
 		false,
 		nil,
 		parentSessionID,
@@ -9340,109 +9351,20 @@ func (h *Home) handleEditPathsDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (h *Home) handleEditSessionDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
+	case "ctrl+s":
+		// ^S commits from anywhere, including while the multi-line env textarea
+		// has focus (where Enter inserts a newline instead of saving).
+		return h.commitEditSessionDialog()
+
 	case "enter":
-		if errMsg := h.editSessionDialog.Validate(); errMsg != "" {
-			h.editSessionDialog.SetError(errMsg)
-			return h, nil
+		// The env textarea consumes Enter as a newline (one KEY=VALUE per line);
+		// deliver it to the dialog rather than committing. ^S saves in that case.
+		if h.editSessionDialog.envFieldFocused() {
+			var cmd tea.Cmd
+			h.editSessionDialog, cmd = h.editSessionDialog.Update(msg)
+			return h, cmd
 		}
-
-		sessionID := h.editSessionDialog.SessionID()
-		inst := h.getInstanceByID(sessionID)
-		if inst == nil {
-			h.editSessionDialog.Hide()
-			return h, nil
-		}
-
-		changes := h.editSessionDialog.GetChanges(inst)
-		fields := make([]string, len(changes))
-		for i, c := range changes {
-			fields[i] = c.Field
-		}
-		uiLog.Debug("edit_session_commit",
-			slog.String("session_id", sessionID),
-			slog.Any("fields", fields))
-		if len(changes) == 0 {
-			h.editSessionDialog.Hide()
-			return h, nil
-		}
-
-		// Apply Tool last so claude-only validation (Skip/Auto/ExtraArgs)
-		// sees the pre-edit Tool — otherwise Tool=claude→shell with a
-		// Skip toggle in the same submit fails IsClaudeCompatible on
-		// the toggle.
-		orderedChanges := make([]Change, 0, len(changes))
-		for _, c := range changes {
-			if c.Field != session.FieldTool {
-				orderedChanges = append(orderedChanges, c)
-			}
-		}
-		for _, c := range changes {
-			if c.Field == session.FieldTool {
-				orderedChanges = append(orderedChanges, c)
-			}
-		}
-
-		titleChanged := false
-		hadRestartRequired := false
-		var postCommits []func()
-		h.instancesMu.Lock()
-		for _, c := range orderedChanges {
-			_, postCommit, err := session.SetField(inst, c.Field, c.Value, nil)
-			if err != nil {
-				h.instancesMu.Unlock()
-				h.editSessionDialog.SetError(err.Error())
-				return h, nil
-			}
-			if postCommit != nil {
-				postCommits = append(postCommits, postCommit)
-			}
-			if c.Field == session.FieldTitle {
-				titleChanged = true
-			}
-			if !c.IsLive {
-				hadRestartRequired = true
-			}
-		}
-		h.instancesMu.Unlock()
-		// postCommits run AFTER unlocking so slow tmux subprocesses don't
-		// stall the status worker / preview cache / reconciler.
-		for _, fn := range postCommits {
-			fn()
-		}
-
-		// Mirror the rename-path #697 race fix: queue title so a watcher
-		// reload can re-apply it after the load swap.
-		if titleChanged {
-			h.pendingTitleChanges[sessionID] = inst.Title
-			h.invalidatePreviewCache(sessionID)
-		}
-		h.rebuildFlatItems()
-		// forceSaveInstances bypasses the isReloading no-op in
-		// saveInstances. Title-only loss is caught by pendingTitleChanges
-		// re-application; non-Title fields have no such net.
-		h.forceSaveInstances()
-
-		h.editSessionDialog.Hide()
-		// Auto-restart on restart-required edits — Tool/Skip/Auto/ExtraArgs
-		// only take effect on next launch, so deferring would just leave
-		// the user staring at old behavior. Mirrors the manual `R` path,
-		// skipping when an animation is in flight or CanRestart says no.
-		if hadRestartRequired {
-			if h.hasActiveAnimation(sessionID) {
-				uiLog.Debug("edit_session_skip_restart_active_anim", slog.String("session_id", sessionID))
-				h.setError(fmt.Errorf("saved — restart skipped, session is starting; press R when ready"))
-				return h, nil
-			}
-			if !inst.CanRestart() {
-				uiLog.Debug("edit_session_skip_restart_cannot", slog.String("session_id", sessionID))
-				h.setError(fmt.Errorf("saved — start the session to apply tool/extra-args/permission changes"))
-				return h, nil
-			}
-			uiLog.Debug("edit_session_auto_restart", slog.String("session_id", sessionID))
-			h.resumingSessions[sessionID] = time.Now()
-			return h, h.restartSession(inst)
-		}
-		return h, nil
+		return h.commitEditSessionDialog()
 
 	case "esc":
 		h.editSessionDialog.Hide()
@@ -9453,6 +9375,136 @@ func (h *Home) handleEditSessionDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.editSessionDialog, cmd = h.editSessionDialog.Update(msg)
 		return h, cmd
 	}
+}
+
+// commitEditSessionDialog validates and applies the edit-session dialog's
+// pending changes, then hides it (auto-restarting on restart-required edits).
+// Shared by the Enter and ^S key paths.
+func (h *Home) commitEditSessionDialog() (tea.Model, tea.Cmd) {
+	if errMsg := h.editSessionDialog.Validate(); errMsg != "" {
+		h.editSessionDialog.SetError(errMsg)
+		return h, nil
+	}
+
+	sessionID := h.editSessionDialog.SessionID()
+	inst := h.getInstanceByID(sessionID)
+	if inst == nil {
+		h.editSessionDialog.Hide()
+		return h, nil
+	}
+
+	changes := h.editSessionDialog.GetChanges(inst)
+	fields := make([]string, len(changes))
+	for i, c := range changes {
+		fields[i] = c.Field
+	}
+	uiLog.Debug("edit_session_commit",
+		slog.String("session_id", sessionID),
+		slog.Any("fields", fields))
+	if len(changes) == 0 {
+		h.editSessionDialog.Hide()
+		return h, nil
+	}
+
+	// Apply Tool last so claude-only validation (Skip/Auto/ExtraArgs)
+	// sees the pre-edit Tool — otherwise Tool=claude→shell with a
+	// Skip toggle in the same submit fails IsClaudeCompatible on
+	// the toggle.
+	orderedChanges := make([]Change, 0, len(changes))
+	for _, c := range changes {
+		if c.Field != session.FieldTool {
+			orderedChanges = append(orderedChanges, c)
+		}
+	}
+	for _, c := range changes {
+		if c.Field == session.FieldTool {
+			orderedChanges = append(orderedChanges, c)
+		}
+	}
+
+	titleChanged := false
+	hadRestartRequired := false
+	var postCommits []func()
+	h.instancesMu.Lock()
+	for _, c := range orderedChanges {
+		// Env is applied as an atomic WHOLE-LIST replacement (the dialog emits one
+		// newline-joined FieldEnv change), mirroring WebMutator.UpdateSession.
+		// Routing rows through SetField's single-pair path would treat a desired
+		// empty-valued entry ("FOO=") as an unset and silently drop it.
+		if c.Field == session.FieldEnv {
+			newEnv, perr := parseWebEnvList(c.Value)
+			if perr != nil {
+				h.instancesMu.Unlock()
+				h.editSessionDialog.SetError(perr.Error())
+				return h, nil
+			}
+			if len(newEnv) > 0 && inst.SSHRemotePath != "" {
+				h.instancesMu.Unlock()
+				h.editSessionDialog.SetError("per-session env is not supported for SSH remote-path sessions")
+				return h, nil
+			}
+			inst.Env = newEnv
+			if !c.IsLive {
+				hadRestartRequired = true
+			}
+			continue
+		}
+		_, postCommit, err := session.SetField(inst, c.Field, c.Value, nil)
+		if err != nil {
+			h.instancesMu.Unlock()
+			h.editSessionDialog.SetError(err.Error())
+			return h, nil
+		}
+		if postCommit != nil {
+			postCommits = append(postCommits, postCommit)
+		}
+		if c.Field == session.FieldTitle {
+			titleChanged = true
+		}
+		if !c.IsLive {
+			hadRestartRequired = true
+		}
+	}
+	h.instancesMu.Unlock()
+	// postCommits run AFTER unlocking so slow tmux subprocesses don't
+	// stall the status worker / preview cache / reconciler.
+	for _, fn := range postCommits {
+		fn()
+	}
+
+	// Mirror the rename-path #697 race fix: queue title so a watcher
+	// reload can re-apply it after the load swap.
+	if titleChanged {
+		h.pendingTitleChanges[sessionID] = inst.Title
+		h.invalidatePreviewCache(sessionID)
+	}
+	h.rebuildFlatItems()
+	// forceSaveInstances bypasses the isReloading no-op in
+	// saveInstances. Title-only loss is caught by pendingTitleChanges
+	// re-application; non-Title fields have no such net.
+	h.forceSaveInstances()
+
+	h.editSessionDialog.Hide()
+	// Auto-restart on restart-required edits — Tool/Skip/Auto/ExtraArgs
+	// only take effect on next launch, so deferring would just leave
+	// the user staring at old behavior. Mirrors the manual `R` path,
+	// skipping when an animation is in flight or CanRestart says no.
+	if hadRestartRequired {
+		if h.hasActiveAnimation(sessionID) {
+			uiLog.Debug("edit_session_skip_restart_active_anim", slog.String("session_id", sessionID))
+			h.setError(fmt.Errorf("saved — restart skipped, session is starting; press R when ready"))
+			return h, nil
+		}
+		if !inst.CanRestart() {
+			uiLog.Debug("edit_session_skip_restart_cannot", slog.String("session_id", sessionID))
+			h.setError(fmt.Errorf("saved — start the session to apply tool/extra-args/permission changes"))
+			return h, nil
+		}
+		uiLog.Debug("edit_session_auto_restart", slog.String("session_id", sessionID))
+		h.resumingSessions[sessionID] = time.Now()
+		return h, h.restartSession(inst)
+	}
+	return h, nil
 }
 
 // applyMultiRepoPathChanges updates the symlink directory and restarts the session.
@@ -10001,6 +10053,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	claudeExtraArgs []string,
 	claudeStartQuery string,
 	launchModelID string,
+	env []string,
 	multiRepoEnabled bool,
 	additionalPaths []string,
 	parentSessionID, parentProjectPath string,
@@ -10077,6 +10130,11 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			if err := inst.ApplyLaunchModel(launchModelID); err != nil {
 				return sessionCreatedMsg{err: fmt.Errorf("failed to apply model override: %w", err), tempID: tempID}
 			}
+		}
+
+		// Apply per-session environment variables (all tools, restart-required).
+		if len(env) > 0 {
+			inst.Env = env
 		}
 
 		// Apply claude extra CLI tokens (claude-only, ignored for other tools).
@@ -10515,6 +10573,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		nil,        // no extra claude args (recent-session path)
 		"",         // no claude startup query (recent-session path)
 		"",         // no explicit model override
+		nil,        // no per-session env (recent-session path)
 		false, nil, // no multi-repo
 		"", "", // no parent
 		"",   // no placeholder
@@ -10598,6 +10657,7 @@ func (h *Home) quickCreateSessionAt(projectPath string) tea.Cmd {
 		nil, // no extra claude args
 		"",  // no claude startup query
 		"",  // no explicit model override
+		nil, // no per-session env
 		false, nil,
 		"", "",
 		"",

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -133,6 +134,7 @@ const (
 	focusMultiRepo             // multi-repo toggle (transforms path into list when enabled).
 	focusInherited             // inherited Docker settings toggle (conditional).
 	focusBranch                // branch input (conditional — only when worktree enabled).
+	focusEnv                   // per-session environment variables (multi-line KEY=VALUE; all tools).
 	focusOptions               // tool-specific options panel (conditional).
 )
 
@@ -159,6 +161,7 @@ type NewDialog struct {
 	pathInput             textinput.Model
 	commandInput          textinput.Model
 	modelInput            textinput.Model
+	envInput              textarea.Model      // per-session env vars (one "KEY=VALUE" per line; all tools).
 	claudeOptions         *ClaudeOptionsPanel // Claude-specific options (concrete for value extraction).
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
@@ -229,6 +232,7 @@ type dialogSnapshot struct {
 	commandCursor    int
 	commandInput     string
 	modelInput       string
+	env              string
 	sandboxEnabled   bool
 	worktreeEnabled  bool
 	worktreeToggled  bool
@@ -356,6 +360,15 @@ func NewNewDialog() *NewDialog {
 	modelInput.Placeholder = "tool default"
 	modelInput.CharLimit = 128
 
+	// Optional per-session environment variables (one "KEY=VALUE" per line),
+	// applied to all tools. Multi-line so each var stays on its own row.
+	envInput := textarea.New()
+	envInput.Placeholder = "KEY=VALUE (one per line)"
+	envInput.ShowLineNumbers = false
+	envInput.CharLimit = 4096
+	envInput.SetHeight(3)
+	envInput.Blur()
+
 	// Create branch input for worktree
 	branchInput := textinput.New()
 	branchInput.Placeholder = "feature/branch-name"
@@ -366,6 +379,7 @@ func NewNewDialog() *NewDialog {
 		pathInput:       pathInput,
 		commandInput:    commandInput,
 		modelInput:      modelInput,
+		envInput:        envInput,
 		branchInput:     branchInput,
 		branchPicker:    NewBranchPickerDialog(),
 		claudeOptions:   NewClaudeOptionsPanel(),
@@ -424,6 +438,8 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.pathInput.Blur()
 	d.modelInput.SetValue("")
 	d.modelInput.Blur()
+	d.envInput.SetValue("")
+	d.envInput.Blur()
 	d.claudeOptions.Blur()
 	d.claudeOptions.ResetStartQuery() // #741: per-session query must not leak across openings
 	d.geminiOptions.Blur()
@@ -536,6 +552,7 @@ func (d *NewDialog) syncInputWidths() {
 	d.pathInput.Width = iw
 	d.commandInput.Width = iw
 	d.modelInput.Width = iw
+	d.envInput.SetWidth(iw)
 	d.branchInput.Width = iw
 }
 
@@ -628,6 +645,9 @@ func (d *NewDialog) shouldHandleEnterLocally() bool {
 	switch d.currentTarget() {
 	// Path/Model open their own dropdown on Enter.
 	case focusPath, focusModel:
+		return true
+	// Env is a multi-line textarea: Enter inserts a newline (never submits).
+	case focusEnv:
 		return true
 	// Name/Branch are free-text fields. When the opt-in
 	// [ui].new_session_enter_advances toggle is on, Enter advances to the next
@@ -736,6 +756,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		commandCursor:    d.commandCursor,
 		commandInput:     d.commandInput.Value(),
 		modelInput:       d.modelInput.Value(),
+		env:              d.envInput.Value(),
 		sandboxEnabled:   d.sandboxEnabled,
 		worktreeEnabled:  d.worktreeEnabled,
 		worktreeToggled:  d.worktreeToggled,
@@ -758,6 +779,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 	d.commandCursor = s.commandCursor
 	d.commandInput.SetValue(s.commandInput)
 	d.modelInput.SetValue(s.modelInput)
+	d.envInput.SetValue(s.env)
 	d.sandboxEnabled = s.sandboxEnabled
 	d.worktreeEnabled = s.worktreeEnabled
 	d.worktreeToggled = s.worktreeToggled
@@ -787,6 +809,8 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 	d.commandCursor = 0
 	d.commandInput.SetValue("")
 	d.modelInput.SetValue("")
+	// Recent sessions never carry per-session env — keep the field cleared.
+	d.envInput.SetValue("")
 
 	// Set command/tool.
 	if rs.Tool == "" || rs.Tool == "shell" {
@@ -1238,6 +1262,16 @@ func (d *NewDialog) GetLaunchModelID() string {
 	return strings.TrimSpace(d.modelInput.Value())
 }
 
+// GetSessionEnv returns the validated per-session env entries entered in the
+// dialog, one "KEY=VALUE" per non-blank line. Lines whose key fails
+// session.ValidateSessionEnvKey are skipped (the field is best-effort; the
+// mutator path re-validates). Values may contain '='; only the first '=' splits.
+func (d *NewDialog) GetSessionEnv() []string {
+	// DedupeSessionEnv trims, drops blank/invalid lines, and collapses duplicate
+	// keys (last wins) so two "FOO=" lines don't persist as duplicate entries.
+	return session.DedupeSessionEnv(strings.Split(d.envInput.Value(), "\n"))
+}
+
 // GetClaudeOptions returns the Claude-specific options (only relevant if command is "claude")
 func (d *NewDialog) GetClaudeOptions() *session.ClaudeOptions {
 	if !d.isClaudeSelected() {
@@ -1329,6 +1363,18 @@ func (d *NewDialog) Validate() string {
 		}
 	}
 
+	// Validate per-session env lines so an invalid entry surfaces a clear error
+	// instead of being silently dropped at create time (GetSessionEnv skips
+	// unparseable lines). One KEY=VALUE per line; values may contain spaces.
+	for _, line := range strings.Split(d.envInput.Value(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if _, _, err := session.ParseSessionEnvPair(strings.TrimSpace(line)); err != nil {
+			return fmt.Sprintf("Invalid env entry %q (use KEY=VALUE)", strings.TrimSpace(line))
+		}
+	}
+
 	return "" // Valid
 }
 
@@ -1386,6 +1432,8 @@ func (d *NewDialog) rebuildFocusTargets() {
 	if d.worktreeEnabled {
 		targets = append(targets, focusBranch)
 	}
+	// Per-session env (all tools) lives below the fold, just above multi-repo.
+	targets = append(targets, focusEnv)
 	// Multi-repo toggle below the fold (its path list renders here when enabled).
 	targets = append(targets, focusMultiRepo)
 	if d.toolOptions != nil {
@@ -1430,6 +1478,7 @@ func (d *NewDialog) updateFocus() {
 	d.pathInput.Blur()
 	d.commandInput.Blur()
 	d.modelInput.Blur()
+	d.envInput.Blur()
 	d.branchInput.Blur()
 	d.claudeOptions.Blur()
 	d.geminiOptions.Blur()
@@ -1459,6 +1508,8 @@ func (d *NewDialog) updateFocus() {
 		}
 	case focusModel:
 		d.modelInput.Focus()
+	case focusEnv:
+		d.envInput.Focus()
 	case focusWorktree, focusSandbox, focusConductor, focusInherited:
 		// Checkbox/toggle rows and conductor dropdown — no text input to focus.
 	case focusBranch:
@@ -1502,7 +1553,7 @@ func isNewDialogShiftTabKey(msg tea.KeyMsg) bool {
 // keystrokes. Single-letter shortcuts must be suppressed in this state.
 func (d *NewDialog) isTextInputFocused() bool {
 	switch d.currentTarget() {
-	case focusName, focusPath, focusModel, focusBranch:
+	case focusName, focusPath, focusModel, focusBranch, focusEnv:
 		return true
 	case focusCommand:
 		return d.commandCursor == 0 // custom command input
@@ -1984,6 +2035,13 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.moveFocus(1)
 				return d, nil
 			}
+			// Env is a multi-line textarea: Enter inserts a newline rather than
+			// submitting (shouldHandleEnterLocally routes Enter here). Ctrl+S
+			// still submits globally via WantsSubmit.
+			if cur == focusEnv {
+				d.envInput, cmd = d.envInput.Update(msg)
+				return d, cmd
+			}
 			if cur == focusPath {
 				d.suggestionsActive = true
 				d.suggestionsHidden = false
@@ -2200,6 +2258,8 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			d.modelNavigated = false
 			d.filterModelSuggestions()
 		}
+	case focusEnv:
+		d.envInput, cmd = d.envInput.Update(msg)
 	case focusMultiRepo:
 		// When editing a multi-repo path, forward keystrokes to pathInput.
 		if d.multiRepoEditing {
@@ -2685,6 +2745,21 @@ func (d *NewDialog) View() string {
 		}
 	}
 
+	// Per-session environment variables (all tools, below the fold). One
+	// "KEY=VALUE" per line; applied to the launched tool. Plaintext at rest.
+	content.WriteString("\n")
+	if cur == focusEnv {
+		content.WriteString(activeLabelStyle.Render("▶ Env vars:"))
+	} else {
+		content.WriteString(labelStyle.Render("  Env vars:"))
+	}
+	content.WriteString("\n  ")
+	content.WriteString(strings.ReplaceAll(d.envInput.View(), "\n", "\n  "))
+	content.WriteString("\n  ")
+	envHintStyle := lipgloss.NewStyle().Foreground(ColorComment)
+	content.WriteString(envHintStyle.Render("Stored in plaintext at rest — avoid secrets you can't rotate."))
+	content.WriteString("\n")
+
 	// Multi-repo toggle (below the fold, UX top-3 #3). Its path list renders
 	// here when enabled; in the common single-repo case it's just a checkbox.
 	content.WriteString("\n")
@@ -2750,6 +2825,10 @@ func (d *NewDialog) View() string {
 		} else {
 			helpText = "Type custom model ID │ Enter browse known IDs │ Tab next"
 		}
+	} else if cur == focusEnv {
+		// The env textarea consumes Enter as a newline (one KEY=VALUE per line),
+		// so advertise ^S for create rather than the generic "Enter create".
+		helpText = "KEY=VALUE per line │ Enter newline │ Tab next │ ^S create │ Esc cancel"
 	} else if cur == focusConductor {
 		helpText = "↑↓ select parent │ Tab next │ Enter/^S create │ Esc cancel"
 	} else if cur == focusWorktree || cur == focusSandbox {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2530,3 +2530,31 @@ func TestNewDialog_CtrlSSubmitsInBothModes(t *testing.T) {
 		}
 	}
 }
+
+// GetSessionEnv parses one "KEY=VALUE" per non-blank line and skips lines whose
+// key is invalid (best-effort; the mutator re-validates authoritatively).
+func TestNewDialog_GetSessionEnv(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	d.envInput.SetValue("FOO=bar\nBAZ=qux")
+
+	got := d.GetSessionEnv()
+	want := []string{"FOO=bar", "BAZ=qux"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetSessionEnv() = %v, want %v", got, want)
+	}
+}
+
+func TestNewDialog_GetSessionEnv_SkipsInvalidAndBlankLines(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	// "1BAD" is an invalid env key (leading digit); blank lines are dropped;
+	// values may contain '=' (only the first splits).
+	d.envInput.SetValue("FOO=bar\n\n1BAD=x\nURL=https://a.b?x=1")
+
+	got := d.GetSessionEnv()
+	want := []string{"FOO=bar", "URL=https://a.b?x=1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetSessionEnv() = %v, want %v", got, want)
+	}
+}

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -92,7 +93,7 @@ func (m *WebMutator) beginHeadlessTx() (unlock func(), err error) {
 }
 
 // CreateSession creates and starts a new session, persisting it to storage.
-func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
 	unlock, err := m.beginHeadlessTx()
 	if err != nil {
 		return "", err
@@ -112,6 +113,13 @@ func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID 
 		if err := inst.ApplyLaunchModel(modelID); err != nil {
 			return "", err
 		}
+	}
+
+	// Per-session env ("KEY=VALUE", all tools). Keys are validated at the API
+	// boundary (handlers_sessions.go validateSessionEnv); store the validated
+	// list verbatim. Values persist in plaintext at rest.
+	if validEnv := sanitizeSessionEnv(env); len(validEnv) > 0 {
+		inst.Env = validEnv
 	}
 
 	if err := inst.Start(); err != nil {
@@ -134,6 +142,37 @@ func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID 
 		return "", fmt.Errorf("save session: %w", err)
 	}
 	return inst.ID, nil
+}
+
+// sanitizeSessionEnv drops blank entries and keeps only entries that parse as a
+// valid "KEY=VALUE" pair (key validated via session.ParseSessionEnvPair). The
+// web API boundary already validates keys (400 on bad key), so this is a
+// defensive normalization for the create path.
+func sanitizeSessionEnv(env []string) []string {
+	// Trim, drop blank/invalid, AND collapse duplicate keys (last wins) so the
+	// create path persists env identically to the PATCH path (parseWebEnvList)
+	// and never stores duplicate keys from a POST array like ["FOO=1","FOO=2"].
+	return session.DedupeSessionEnv(env)
+}
+
+// parseWebEnvList decodes the newline-joined desired env list submitted by the
+// web edit form (see handlers_sessions.go updatesFromRequest) into a validated
+// "KEY=VALUE" slice. An invalid key returns a *session.MutationError so the
+// PATCH handler maps it to 400. Duplicate keys are collapsed to their last value
+// (via UpsertSessionEnv). An empty payload clears all env (returns nil).
+func parseWebEnvList(joined string) ([]string, error) {
+	var out []string
+	for _, line := range strings.Split(joined, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if _, _, err := session.ParseSessionEnvPair(line); err != nil {
+			return nil, &session.MutationError{Field: session.FieldEnv, Msg: err.Error()}
+		}
+		out, _ = session.UpsertSessionEnv(out, line) // last value wins on dup key
+	}
+	return out, nil
 }
 
 // StartSession starts a stopped/idle session by ID.
@@ -442,9 +481,67 @@ func (m *WebMutator) UpdateSession(id string, updates map[string]string) ([]stri
 	var postCommits []func()
 
 	m.h.instancesMu.Lock()
-	for field, value := range updates {
+	// Atomicity: SetField mutates the live Instance field-by-field AND has
+	// cross-field SIDE EFFECTS (e.g. FieldTool clears ToolOptionsJSON), so a
+	// per-field rollback is insufficient — a later field failing would leave
+	// earlier writes/side-effects in memory (e.g. PATCH {tool, plugins} clears
+	// ToolOptionsJSON, then plugins rejects). Take a FULL before-snapshot of
+	// every field a web PATCH (updatesFromRequest) can touch directly or
+	// indirectly, and restore them all on any error so a failed multi-field
+	// PATCH leaves the live instance exactly unchanged.
+	// NOTE: keep this snapshot in sync with updatesFromRequest's fields and
+	// SetField's side effects.
+	snap := struct {
+		title, notes, color, tool         string
+		extraArgs, plugins, channels, env []string
+		toolOptions                       []byte
+	}{
+		title: inst.Title, notes: inst.Notes, color: inst.Color, tool: inst.Tool,
+		extraArgs: inst.ExtraArgs, plugins: inst.Plugins, channels: inst.Channels, env: inst.Env,
+		toolOptions: inst.ToolOptionsJSON,
+	}
+	rollbackAll := func() {
+		inst.Title, inst.Notes, inst.Color, inst.Tool = snap.title, snap.notes, snap.color, snap.tool
+		inst.ExtraArgs, inst.Plugins, inst.Channels, inst.Env = snap.extraArgs, snap.plugins, snap.channels, snap.env
+		inst.ToolOptionsJSON = snap.toolOptions
+	}
+	for _, field := range orderedUpdateFields(updates) {
+		value := updates[field]
+		// FieldEnv from the web is a whole-list replacement (the edit form
+		// submits the full desired env, newline-joined by updatesFromRequest),
+		// not the single KEY=VALUE upsert/unset that session.SetField(FieldEnv)
+		// expects. Handle it separately so the web replaces the env atomically.
+		if field == session.FieldEnv {
+			newEnv, perr := parseWebEnvList(value)
+			if perr != nil {
+				rollbackAll()
+				m.h.instancesMu.Unlock()
+				return nil, false, perr
+			}
+			// This path bypasses session.SetField, so re-apply its SSH remote-path
+			// guard here: per-session env is silently dropped at spawn for
+			// SSHRemotePath sessions (wrapForSSH re-escaping mangles the inline
+			// export quoting), so reject a non-empty replacement instead of
+			// persisting env that would never take effect. An empty list (clear)
+			// stays allowed.
+			if len(newEnv) > 0 && inst.SSHRemotePath != "" {
+				rollbackAll()
+				m.h.instancesMu.Unlock()
+				return nil, false, &session.MutationError{Field: session.FieldEnv, Msg: "per-session env is not supported for SSH remote-path sessions"}
+			}
+			if strings.Join(inst.Env, "\n") == strings.Join(newEnv, "\n") {
+				continue
+			}
+			inst.Env = newEnv
+			changed = append(changed, field)
+			if session.RestartPolicyFor(field) == session.FieldRestartRequired {
+				restartRequired = true
+			}
+			continue
+		}
 		oldValue, postCommit, err := session.SetField(inst, field, value, nil)
 		if err != nil {
+			rollbackAll()
 			m.h.instancesMu.Unlock()
 			return nil, false, err
 		}
@@ -484,6 +581,18 @@ func (m *WebMutator) UpdateSession(id string, updates map[string]string) ([]stri
 		return nil, false, fmt.Errorf("save session: %w", err)
 	}
 	return changed, restartRequired, nil
+}
+
+// orderedUpdateFields returns the PATCH update fields in a deterministic order
+// so a multi-field update applies consistently regardless of Go's random map
+// iteration order.
+func orderedUpdateFields(updates map[string]string) []string {
+	fields := make([]string, 0, len(updates))
+	for f := range updates {
+		fields = append(fields, f)
+	}
+	sort.Strings(fields)
+	return fields
 }
 
 // CreateGroup creates a new group (or subgroup if parentPath is non-empty) and

--- a/internal/ui/web_mutator_rollback_test.go
+++ b/internal/ui/web_mutator_rollback_test.go
@@ -1,0 +1,130 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestWebMutator_FailedMultiFieldPATCH_RollsBack: a multi-field PATCH where a
+// later field is rejected must leave the live Instance UNCHANGED (atomicity).
+// Here env applies first (orderedUpdateFields), then plugins — claude-only —
+// fails on a gemini session, so the whole PATCH must roll back including env.
+func TestWebMutator_FailedMultiFieldPATCH_RollsBack(t *testing.T) {
+	h, _ := newHeadlessHomeForTest(t, "_test_rollback")
+	inst := &session.Instance{
+		ID:          "rb-1",
+		Title:       "t",
+		ProjectPath: "/tmp/rb-proj",
+		GroupPath:   session.DefaultGroupPath,
+		Command:     "gemini",
+		Tool:        "gemini",
+		Status:      session.StatusStopped,
+		CreatedAt:   time.Now(),
+		Env:         []string{"OLD=1"},
+	}
+	h.instances = append(h.instances, inst)
+	h.instanceByID[inst.ID] = inst
+
+	m := NewWebMutator(h)
+	_, _, err := m.UpdateSession("rb-1", map[string]string{
+		session.FieldEnv:     "NEW=2",
+		session.FieldPlugins: "octo",
+	})
+	if err == nil {
+		t.Fatal("expected the PATCH to fail (plugins unsupported on a gemini session)")
+	}
+	if got := strings.Join(inst.Env, ","); got != "OLD=1" {
+		t.Fatalf("env must roll back to OLD=1 after a failed multi-field PATCH; got %q", got)
+	}
+}
+
+// TestWebMutator_FailedPATCH_RollsBackToolOptions covers a cross-field SIDE
+// EFFECT: SetField(FieldTool) clears ToolOptionsJSON when leaving claude. PATCH
+// {tool:gemini, plugins:octo} applies tool first (clears claude options), then
+// plugins rejects (not claude) — the full-snapshot rollback must restore BOTH
+// Tool and ToolOptionsJSON, not just the field's own value.
+func TestWebMutator_FailedPATCH_RollsBackToolOptions(t *testing.T) {
+	h, _ := newHeadlessHomeForTest(t, "_test_rollback_opts")
+	inst := &session.Instance{
+		ID:          "rb-2",
+		Title:       "t",
+		ProjectPath: "/tmp/rb2-proj",
+		GroupPath:   session.DefaultGroupPath,
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      session.StatusStopped,
+		CreatedAt:   time.Now(),
+	}
+	// Populate ToolOptionsJSON via a claude-only field.
+	if _, _, err := session.SetField(inst, session.FieldSkipPermissions, "true", nil); err != nil {
+		t.Fatalf("seed skip-permissions: %v", err)
+	}
+	wantOpts := string(inst.ToolOptionsJSON)
+	if wantOpts == "" {
+		t.Fatal("precondition: ToolOptionsJSON should be populated")
+	}
+
+	h.instances = append(h.instances, inst)
+	h.instanceByID[inst.ID] = inst
+	m := NewWebMutator(h)
+
+	_, _, err := m.UpdateSession("rb-2", map[string]string{
+		session.FieldTool:    "gemini",
+		session.FieldPlugins: "octo",
+	})
+	if err == nil {
+		t.Fatal("expected the PATCH to fail (plugins unsupported once tool is gemini)")
+	}
+	if inst.Tool != "claude" {
+		t.Fatalf("tool must roll back to claude, got %q", inst.Tool)
+	}
+	if string(inst.ToolOptionsJSON) != wantOpts {
+		t.Fatalf("ToolOptionsJSON must roll back; got %q want %q", inst.ToolOptionsJSON, wantOpts)
+	}
+}
+
+// TestWebMutator_PATCH_RejectsEnvOnSSHRemotePath: the web PATCH FieldEnv path
+// bypasses session.SetField, so it must re-apply the SSH remote-path guard —
+// otherwise env would persist on a session where it is silently dropped at
+// spawn. A non-empty env set is rejected; an empty-list clear is allowed. The
+// session is seeded into storage because the headless mutator hydrates from it.
+func TestWebMutator_PATCH_RejectsEnvOnSSHRemotePath(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_ssh_env")
+	inst := &session.Instance{
+		ID:            "ssh-1",
+		Title:         "t",
+		ProjectPath:   "/tmp/ssh-proj",
+		GroupPath:     session.DefaultGroupPath,
+		Command:       "claude",
+		Tool:          "claude",
+		Status:        session.StatusStopped,
+		CreatedAt:     time.Now(),
+		SSHHost:       "host",
+		SSHRemotePath: "/remote/path",
+		Env:           []string{"OLD=1"},
+	}
+	all := []*session.Instance{inst}
+	if err := storage.SaveWithGroups(all, session.NewGroupTree(all)); err != nil {
+		t.Fatalf("seed SaveWithGroups: %v", err)
+	}
+	m := NewWebMutator(h)
+
+	// Non-empty set is rejected and leaves the persisted env untouched.
+	if _, _, err := m.UpdateSession("ssh-1", map[string]string{session.FieldEnv: "NEW=2"}); err == nil {
+		t.Fatal("expected env set on an SSH remote-path session to be rejected")
+	}
+	if got := strings.Join(h.instanceByID["ssh-1"].Env, ","); got != "OLD=1" {
+		t.Fatalf("env must be unchanged after a rejected set; got %q", got)
+	}
+
+	// Clearing (empty list) is still allowed so stale env can be removed.
+	if _, _, err := m.UpdateSession("ssh-1", map[string]string{session.FieldEnv: ""}); err != nil {
+		t.Fatalf("clearing env on an SSH remote-path session must be allowed; got %v", err)
+	}
+	if got := h.instanceByID["ssh-1"].Env; len(got) != 0 {
+		t.Fatalf("env must be cleared; got %v", got)
+	}
+}

--- a/internal/ui/web_mutator_test.go
+++ b/internal/ui/web_mutator_test.go
@@ -1,0 +1,39 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestParseWebEnvList(t *testing.T) {
+	got, err := parseWebEnvList("FOO=bar\n  BAZ=qux  \n\nHTTPS_PROXY=http://h:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"FOO=bar", "BAZ=qux", "HTTPS_PROXY=http://h:8080"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseWebEnvList = %v, want %v", got, want)
+	}
+
+	if out, err := parseWebEnvList(""); err != nil || out != nil {
+		t.Fatalf("empty payload should clear env: got %v, err %v", out, err)
+	}
+
+	out, err := parseWebEnvList("1BAD=x")
+	if err == nil {
+		t.Fatalf("expected error for invalid key, got %v", out)
+	}
+	if _, ok := err.(*session.MutationError); !ok {
+		t.Fatalf("expected *session.MutationError so the handler maps to 400, got %T", err)
+	}
+}
+
+func TestSanitizeSessionEnv(t *testing.T) {
+	got := sanitizeSessionEnv([]string{"FOO=bar", "  ", "1BAD=x", "OK_2=y"})
+	want := []string{"FOO=bar", "OK_2=y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sanitizeSessionEnv = %v, want %v", got, want)
+	}
+}

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -23,6 +23,10 @@ type CreateSessionRequest struct {
 	ProjectPath string `json:"projectPath"`
 	GroupPath   string `json:"groupPath,omitempty"`
 	ModelID     string `json:"modelId,omitempty"`
+	// Env holds per-session environment variables ("KEY=VALUE") exported into
+	// the spawned process for every tool. Keys are validated server-side (400 on
+	// a bad key). Values may be secrets — they persist in plaintext at rest.
+	Env []string `json:"env,omitempty"`
 }
 
 // CreateGroupRequest is the body for POST /api/groups.
@@ -54,6 +58,11 @@ type UpdateSessionRequest struct {
 	Channels        *string `json:"channels,omitempty"`
 	SkipPermissions *bool   `json:"skipPermissions,omitempty"`
 	AutoMode        *bool   `json:"autoMode,omitempty"`
+	// Env, when non-nil, replaces the session's full per-session environment
+	// ("KEY=VALUE" entries) for every tool. Keys are validated server-side (400
+	// on a bad key). Values persist in plaintext at rest. A non-nil empty slice
+	// clears all per-session env. Restart required to take effect.
+	Env *[]string `json:"env,omitempty"`
 }
 
 // UpdateSessionResponse confirms a PATCH succeeded. RestartRequired is true

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -72,7 +72,11 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 			writeAPIError(w, http.StatusServiceUnavailable, ErrCodeNotImplemented, "mutations not available")
 			return
 		}
-		sessionID, err := s.mutator.CreateSession(req.Title, req.Tool, req.ProjectPath, req.GroupPath, req.ModelID)
+		if err := validateSessionEnv(req.Env); err != nil {
+			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, err.Error())
+			return
+		}
+		sessionID, err := s.mutator.CreateSession(req.Title, req.Tool, req.ProjectPath, req.GroupPath, req.ModelID, req.Env)
 		if err != nil {
 			writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
 			return
@@ -310,6 +314,13 @@ func (s *Server) handleSessionPatch(w http.ResponseWriter, r *http.Request, sess
 		return
 	}
 
+	if req.Env != nil {
+		if err := validateSessionEnv(*req.Env); err != nil {
+			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, err.Error())
+			return
+		}
+	}
+
 	updates := updatesFromRequest(req)
 	if len(updates) == 0 {
 		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "at least one field is required")
@@ -321,7 +332,6 @@ func (s *Server) handleSessionPatch(w http.ResponseWriter, r *http.Request, sess
 		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "title cannot be empty")
 		return
 	}
-
 	changed, restartRequired, err := s.mutator.UpdateSession(sessionID, updates)
 	if err != nil {
 		// session.MutationError signals client-side bad input; "not found"
@@ -380,7 +390,35 @@ func updatesFromRequest(req UpdateSessionRequest) map[string]string {
 	if req.AutoMode != nil {
 		out[session.FieldAutoMode] = strconv.FormatBool(*req.AutoMode)
 	}
+	if req.Env != nil {
+		// The web edit form submits the FULL desired env list, but
+		// session.SetField's FieldEnv path is single KEY=VALUE upsert/unset.
+		// Encode the whole list newline-joined under FieldEnv; the mutator
+		// (WebMutator.UpdateSession) decodes it and replaces the session's env
+		// wholesale. A non-nil empty slice → "" → clears all env.
+		out[session.FieldEnv] = strings.Join(*req.Env, "\n")
+	}
 	return out
+}
+
+// validateSessionEnv checks every "KEY=VALUE" entry's key with the shared
+// session validator so a bad key is rejected at the API boundary as a 400
+// rather than surfacing later as a spawn-time surprise. nil/empty is valid.
+func validateSessionEnv(env []string) error {
+	for _, kv := range env {
+		// Trim before validating so surrounding whitespace is accepted here
+		// exactly as the update path normalizes it (parseWebEnvList /
+		// sanitizeSessionEnv). Otherwise "  FOO=bar  " would 400 on create but
+		// round-trip fine on PATCH — an inconsistent boundary.
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		if _, _, err := session.ParseSessionEnvPair(kv); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type archivedSessionsResponse struct {

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -15,7 +15,7 @@ import (
 // fakeMutator is a test double for SessionMutator that delegates to function fields.
 // If a function field is nil, the method returns an error indicating it is unconfigured.
 type fakeMutator struct {
-	createSessionFn    func(title, tool, projectPath, groupPath, modelID string) (string, error)
+	createSessionFn    func(title, tool, projectPath, groupPath, modelID string, env []string) (string, error)
 	startSessionFn     func(id string) error
 	stopSessionFn      func(id string) error
 	restartSessionFn   func(id string) error
@@ -32,11 +32,11 @@ type fakeMutator struct {
 	finishWorktreeFn   func(id string, opts WorktreeFinishOptions) (WorktreeFinishResult, error)
 }
 
-func (f *fakeMutator) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (f *fakeMutator) CreateSession(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
 	if f.createSessionFn == nil {
 		return "", fmt.Errorf("createSession not configured")
 	}
-	return f.createSessionFn(title, tool, projectPath, groupPath, modelID)
+	return f.createSessionFn(title, tool, projectPath, groupPath, modelID, env)
 }
 
 func (f *fakeMutator) StartSession(id string) error {
@@ -191,7 +191,7 @@ func TestSessionsCollectionPOSTCreatesSession(t *testing.T) {
 	})
 	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
 	srv.mutator = &fakeMutator{
-		createSessionFn: func(title, tool, projectPath, groupPath, modelID string) (string, error) {
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
 			return "new-id", nil
 		},
 	}
@@ -219,7 +219,7 @@ func TestSessionsCollectionPOSTForwardsModelID(t *testing.T) {
 
 	var gotModel string
 	srv.mutator = &fakeMutator{
-		createSessionFn: func(title, tool, projectPath, groupPath, modelID string) (string, error) {
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
 			gotModel = modelID
 			return "new-id", nil
 		},
@@ -893,6 +893,139 @@ func TestSessionPatchEmptyBodyRejected(t *testing.T) {
 	}
 
 	body := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+}
+
+// TestSessionsCollectionPOSTForwardsEnv verifies the per-session env list flows
+// from the create request body through to the mutator.
+func TestSessionsCollectionPOSTForwardsEnv(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	var gotEnv []string
+	srv.mutator = &fakeMutator{
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
+			gotEnv = env
+			return "new-id", nil
+		},
+	}
+
+	body := strings.NewReader(`{"title":"T","tool":"claude","projectPath":"/tmp","env":["FOO=bar","HTTPS_PROXY=http://h:8080"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	if len(gotEnv) != 2 || gotEnv[0] != "FOO=bar" || gotEnv[1] != "HTTPS_PROXY=http://h:8080" {
+		t.Fatalf("env not forwarded: %v", gotEnv)
+	}
+}
+
+// TestSessionsCollectionPOSTRejectsBadEnvKey verifies a malformed env key is a
+// 400 at the API boundary, before the mutator is invoked.
+func TestSessionsCollectionPOSTRejectsBadEnvKey(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
+			t.Fatal("mutator must not be called for an invalid env key")
+			return "", nil
+		},
+	}
+
+	body := strings.NewReader(`{"title":"T","tool":"claude","projectPath":"/tmp","env":["1BAD=x"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), ErrCodeBadRequest) {
+		t.Errorf("expected INVALID_REQUEST error, got: %s", rr.Body.String())
+	}
+}
+
+// TestSessionPatchForwardsEnv verifies the full desired env list is newline-encoded
+// under FieldEnv for the mutator (whole-list replace).
+func TestSessionPatchForwardsEnv(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	var gotUpdates map[string]string
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			gotUpdates = updates
+			return []string{session.FieldEnv}, true, nil
+		},
+	}
+
+	body := strings.NewReader(`{"env":["FOO=bar","BAZ=qux"]}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if got := gotUpdates[session.FieldEnv]; got != "FOO=bar\nBAZ=qux" {
+		t.Fatalf("env encoding = %q, want %q", got, "FOO=bar\nBAZ=qux")
+	}
+}
+
+// TestSessionPatchEmptyEnvClears verifies a non-nil empty env slice is forwarded
+// (clearing all env), distinct from an omitted env field.
+func TestSessionPatchEmptyEnvClears(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	var sawEnv bool
+	var envVal string
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			envVal, sawEnv = updates[session.FieldEnv]
+			return []string{session.FieldEnv}, true, nil
+		},
+	}
+
+	body := strings.NewReader(`{"env":[]}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if !sawEnv || envVal != "" {
+		t.Fatalf("expected empty FieldEnv update to be present, sawEnv=%v val=%q", sawEnv, envVal)
+	}
+}
+
+// TestSessionPatchRejectsBadEnvKey verifies a malformed env key on PATCH is 400.
+func TestSessionPatchRejectsBadEnvKey(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			t.Fatal("mutator must not be called for an invalid env key")
+			return nil, false, nil
+		},
+	}
+
+	body := strings.NewReader(`{"env":["1BAD=x"]}`)
 	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()

--- a/internal/web/parity_test.go
+++ b/internal/web/parity_test.go
@@ -59,7 +59,7 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 				_ = json.NewDecoder(w.Body).Decode(&resp)
 
 				// Direct mutator path.
-				_, err := directFx.store.CreateSession("parity-create", "claude", "/srv/parity", "work", "")
+				_, err := directFx.store.CreateSession("parity-create", "claude", "/srv/parity", "work", "", nil)
 				if err != nil {
 					t.Fatalf("direct CreateSession: %v", err)
 				}
@@ -69,8 +69,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "stop_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
 				// Both stores generated the same id deterministically (sess-005).
 				const id = "sess-005"
 
@@ -90,8 +90,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "start_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
 				const id = "sess-005"
 
 				req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/start", nil)
@@ -109,8 +109,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "delete_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
 				const id = "sess-005"
 
 				req := httptest.NewRequest(http.MethodDelete, "/api/sessions/"+id, nil)
@@ -167,8 +167,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "archive_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
 				const id = "sess-005"
 
 				req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/archive", nil)
@@ -186,8 +186,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "unarchive_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", nil)
 				const id = "sess-005"
 				_ = webFx.store.ArchiveSession(id)
 				_ = directFx.store.ArchiveSession(id)
@@ -331,7 +331,7 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 func TestParity_TUIChangeVisibleViaWebAPI(t *testing.T) {
 	t.Parallel()
 	fx := newParityFixture()
-	_, _ = fx.store.CreateSession("ts", "claude", "/srv/ts", "work", "")
+	_, _ = fx.store.CreateSession("ts", "claude", "/srv/ts", "work", "", nil)
 	const id = "sess-005"
 
 	// "TUI" path: mutate the store directly.
@@ -488,13 +488,14 @@ func (s *parityStore) LoadArchivedMenuSnapshot() (*MenuSnapshot, error) {
 
 // SessionMutator implementation.
 
-func (s *parityStore) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (s *parityStore) CreateSession(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	id := nextDeterministicID(&s.nextID)
 	s.sessions[id] = &MenuSession{
 		ID: id, Title: title, Tool: tool,
 		Status: session.StatusIdle, GroupPath: groupPath, ProjectPath: projectPath,
+		Env:   env,
 		Order: len(s.order), CreatedAt: s.now(),
 	}
 	s.order = append(s.order, id)
@@ -574,6 +575,17 @@ func (s *parityStore) UpdateSession(id string, updates map[string]string) ([]str
 			session.FieldPlugins, session.FieldChannels,
 			session.FieldSkipPermissions, session.FieldAutoMode:
 			oldValue = value
+		case session.FieldEnv:
+			// Env PATCHes arrive newline-joined (the whole desired list) so the
+			// parity harness must actually apply them — modeling FieldEnv as a
+			// no-op would make every env edit look unchanged and defeat the
+			// web/TUI parity check for the edit-session env flow.
+			oldValue = strings.Join(sess.Env, "\n")
+			if value == "" {
+				sess.Env = nil
+			} else {
+				sess.Env = strings.Split(value, "\n")
+			}
 		default:
 			return nil, false, parityErr("invalid field: " + field)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -99,7 +99,7 @@ type MenuDataLoader interface {
 // SessionMutator is implemented by internal/ui.WebMutator and injected at startup.
 // It bridges web HTTP handlers to the TUI session/group management methods.
 type SessionMutator interface {
-	CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error)
+	CreateSession(title, tool, projectPath, groupPath, modelID string, env []string) (string, error)
 	StartSession(sessionID string) error
 	StopSession(sessionID string) error
 	RestartSession(sessionID string) error

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -108,6 +108,16 @@ type MenuSession struct {
 	ExtraArgs       []string        `json:"extraArgs,omitempty"`
 	ToolOptionsJSON json.RawMessage `json:"toolOptions,omitempty"`
 
+	// Env holds per-session environment variables ("KEY=VALUE") for every tool.
+	// Surfaced so the web EditSessionDialog can seed its env editor (there is no
+	// separate per-session detail endpoint to fetch it lazily). This ships env in
+	// the general list payload, so values (which the UI/CLI already document as
+	// plaintext-at-rest) travel to the same-user, token-authenticated web client
+	// on every refresh — an accepted tradeoff for a localhost tool, not a
+	// cross-user disclosure. A dedicated redacted-list + detail-fetch split is a
+	// possible future hardening if agent-deck ever serves multiple users.
+	Env []string `json:"env,omitempty"`
+
 	Sandbox          *session.SandboxConfig `json:"sandbox,omitempty"`
 	SandboxContainer string                 `json:"sandboxContainer,omitempty"`
 	SSHHost          string                 `json:"sshHost,omitempty"`
@@ -264,6 +274,7 @@ func toMenuSession(inst *session.Instance) *MenuSession {
 		Wrapper:            inst.Wrapper,
 		Channels:           inst.Channels,
 		ExtraArgs:          inst.ExtraArgs,
+		Env:                inst.Env,
 		ToolOptionsJSON:    inst.ToolOptionsJSON,
 		Sandbox:            inst.Sandbox,
 		SandboxContainer:   inst.SandboxContainer,

--- a/internal/web/static/app/CreateSessionDialog.js
+++ b/internal/web/static/app/CreateSessionDialog.js
@@ -73,12 +73,31 @@ function modelIDsForTool(tool) {
   return MODEL_ID_CATALOG[tool] || []
 }
 
+// envRowsToList collapses the {key,value} editor rows into the wire format the
+// API expects (["KEY=VALUE", …]), dropping rows with a blank key.
+export function envRowsToList(rows) {
+  return rows
+    .map(r => ({ key: (r.key || '').trim(), value: r.value || '' }))
+    .filter(r => r.key !== '')
+    .map(r => `${r.key}=${r.value}`)
+}
+
+// listToEnvRows parses a ["KEY=VALUE", …] list (as seeded from MenuSession.env)
+// back into editor rows, splitting on the first '='.
+export function listToEnvRows(list) {
+  return (list || []).map(kv => {
+    const i = kv.indexOf('=')
+    return i < 0 ? { key: kv, value: '' } : { key: kv.slice(0, i), value: kv.slice(i + 1) }
+  })
+}
+
 export function CreateSessionDialog() {
   const [title, setTitle] = useState('')
   const [tool, setTool] = useState('claude')
   const [modelId, setModelId] = useState('')
   const [customModel, setCustomModel] = useState('')
   const [path, setPath] = useState('')
+  const [envRows, setEnvRows] = useState([])
   const [error, setError] = useState(null)
   const [submitting, setSubmitting] = useState(false)
 
@@ -95,6 +114,8 @@ export function CreateSessionDialog() {
       const payload = { title, tool, projectPath: path }
       const modelId = selectedModelId()
       if (modelId) payload.modelId = modelId
+      const env = envRowsToList(envRows)
+      if (env.length) payload.env = env
       await apiFetch('POST', '/api/sessions', payload)
       createSessionDialogSignal.value = false
     } catch (err) {
@@ -113,6 +134,12 @@ export function CreateSessionDialog() {
   function selectedModelId() {
     if (modelId === CUSTOM_MODEL) return customModel.trim()
     return modelId || ''
+  }
+
+  function addEnvRow() { setEnvRows([...envRows, { key: '', value: '' }]) }
+  function removeEnvRow(i) { setEnvRows(envRows.filter((_, idx) => idx !== i)) }
+  function updateEnvRow(i, field, val) {
+    setEnvRows(envRows.map((r, idx) => (idx === i ? { ...r, [field]: val } : r)))
   }
 
   const close = () => (createSessionDialogSignal.value = false)
@@ -175,6 +202,22 @@ export function CreateSessionDialog() {
               </div>
             `}
           `}
+          <div class="field" data-testid="create-session-env">
+            <label>ENV VARS</label>
+            ${envRows.map((row, i) => html`
+              <div class="seg-row" key=${i} style="gap: 6px; margin-bottom: 6px;">
+                <input placeholder="KEY" value=${row.key}
+                       onInput=${e => updateEnvRow(i, 'key', e.target.value)} style="flex: 1;"/>
+                <input placeholder="value" value=${row.value}
+                       onInput=${e => updateEnvRow(i, 'value', e.target.value)} style="flex: 2;"/>
+                <button type="button" class="btn ghost" onClick=${() => removeEnvRow(i)} aria-label="Remove variable">✕</button>
+              </div>
+            `)}
+            <button type="button" class="btn ghost" onClick=${addEnvRow}>+ Add variable</button>
+            <div style="font-family: var(--mono); font-size: 11px; color: var(--tn-comment, #888); margin-top: 6px;">
+              Per-session env vars are stored in plaintext at rest — avoid secrets you can't rotate.
+            </div>
+          </div>
           ${error && html`
             <div style="font-family: var(--mono); font-size: 11.5px; color: var(--tn-red); padding: 8px 10px;
                         border: 1px solid rgba(247,118,142,0.3); border-radius: 4px; background: rgba(247,118,142,0.06);">

--- a/internal/web/static/app/EditSessionDialog.js
+++ b/internal/web/static/app/EditSessionDialog.js
@@ -15,6 +15,7 @@ import { menuModelSignal } from './dataModel.js'
 import { Icon, ICONS } from './icons.js'
 import { apiFetch } from './api.js'
 import { displayLabelForTool, resolveEditSessionPickerTools } from './pickerTools.js'
+import { envRowsToList, listToEnvRows } from './CreateSessionDialog.js'
 
 // Build PATCH body from form state. Only includes fields that differ from
 // the original — mirrors the TUI EditSessionDialog.GetChanges diff logic so
@@ -25,6 +26,11 @@ function diffUpdates(form, original) {
   if (form.notes !== (original.notes || '')) out.notes = form.notes
   if (form.color !== (original.color || '')) out.color = form.color
   if (form.tool !== (original.tool || '')) out.tool = form.tool
+  // Per-session env applies to every tool. Diff the full desired list against
+  // the seeded list; send the whole replacement only when it changed.
+  const nextEnv = envRowsToList(form.envRows)
+  const prevEnv = original.env || []
+  if (JSON.stringify(nextEnv) !== JSON.stringify(prevEnv)) out.env = nextEnv
   if (form.tool === 'claude') {
     if (form.extraArgs !== (original.extraArgs || '')) out.extraArgs = form.extraArgs
     if (form.plugins !== (original.plugins || '')) out.plugins = form.plugins
@@ -55,6 +61,7 @@ export function EditSessionDialog() {
   const [channels, setChannels] = useState(seed.channels || '')
   const [skipPermissions, setSkipPermissions] = useState(!!seed.skipPermissions)
   const [autoMode, setAutoMode] = useState(!!seed.autoMode)
+  const [envRows, setEnvRows] = useState(listToEnvRows(seed.env))
   const [error, setError] = useState(null)
   const [submitting, setSubmitting] = useState(false)
   const [seededFor, setSeededFor] = useState(open ? open.sessionId : null)
@@ -72,6 +79,7 @@ export function EditSessionDialog() {
     setChannels(session.channels || '')
     setSkipPermissions(!!session.skipPermissions)
     setAutoMode(!!session.autoMode)
+    setEnvRows(listToEnvRows(session.env))
     setError(null)
     setSeededFor(open.sessionId)
   }
@@ -85,7 +93,7 @@ export function EditSessionDialog() {
     e.preventDefault()
     setError(null)
     const updates = diffUpdates(
-      { title, notes, color, tool, extraArgs, plugins, channels, skipPermissions, autoMode },
+      { title, notes, color, tool, extraArgs, plugins, channels, skipPermissions, autoMode, envRows },
       session,
     )
     if (Object.keys(updates).length === 0) {
@@ -106,6 +114,12 @@ export function EditSessionDialog() {
   function close() {
     editSessionDialogSignal.value = null
     setSeededFor(null)
+  }
+
+  function addEnvRow() { setEnvRows([...envRows, { key: '', value: '' }]) }
+  function removeEnvRow(i) { setEnvRows(envRows.filter((_, idx) => idx !== i)) }
+  function updateEnvRow(i, field, val) {
+    setEnvRows(envRows.map((r, idx) => (idx === i ? { ...r, [field]: val } : r)))
   }
   const handleBackdropClick = (e) => { if (e.target === e.currentTarget) close() }
   const submitDisabled = submitting || !title.trim()
@@ -154,6 +168,22 @@ export function EditSessionDialog() {
                         class=${`seg-btn ${tool === t ? 'on' : ''}`}
                         onClick=${() => setTool(t)}>${displayLabelForTool(t)}</button>
               `)}
+            </div>
+          </div>
+          <div class="field" data-testid="edit-session-env">
+            <label>ENV VARS (restart required)</label>
+            ${envRows.map((row, i) => html`
+              <div class="seg-row" key=${i} style="gap: 6px; margin-bottom: 6px;">
+                <input placeholder="KEY" value=${row.key}
+                       onInput=${e => updateEnvRow(i, 'key', e.target.value)} style="flex: 1;"/>
+                <input placeholder="value" value=${row.value}
+                       onInput=${e => updateEnvRow(i, 'value', e.target.value)} style="flex: 2;"/>
+                <button type="button" class="btn ghost" onClick=${() => removeEnvRow(i)} aria-label="Remove variable">✕</button>
+              </div>
+            `)}
+            <button type="button" class="btn ghost" onClick=${addEnvRow}>+ Add variable</button>
+            <div style="font-family: var(--mono); font-size: 11px; color: var(--tn-comment, #888); margin-top: 6px;">
+              Per-session env vars are stored in plaintext at rest — avoid secrets you can't rotate.
             </div>
           </div>
           ${tool === 'claude' && html`

--- a/internal/web/static_files_test.go
+++ b/internal/web/static_files_test.go
@@ -190,6 +190,42 @@ func TestCreateSessionDialogUsesModelIDCatalog(t *testing.T) {
 	}
 }
 
+// TestSessionDialogsHavePerSessionEnvEditor pins the per-session env editor in
+// both the create and edit dialogs (Feature B — per-session environment
+// variables), including the "stored in plaintext" warning.
+func TestSessionDialogsHavePerSessionEnvEditor(t *testing.T) {
+	for _, f := range []string{
+		"static/app/CreateSessionDialog.js",
+		"static/app/EditSessionDialog.js",
+	} {
+		data, err := embeddedStaticFiles.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		body := string(data)
+		for _, want := range []string{
+			"ENV VARS",
+			"envRows",
+			"+ Add variable",
+			"stored in plaintext",
+		} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("%s missing %q", f, want)
+			}
+		}
+	}
+
+	// The create dialog sends env on the wire; the edit dialog diffs/submits it.
+	create, _ := embeddedStaticFiles.ReadFile("static/app/CreateSessionDialog.js")
+	if !strings.Contains(string(create), "payload.env = env") {
+		t.Fatal("CreateSessionDialog.js must send env in the POST payload")
+	}
+	edit, _ := embeddedStaticFiles.ReadFile("static/app/EditSessionDialog.js")
+	if !strings.Contains(string(edit), "out.env = nextEnv") {
+		t.Fatal("EditSessionDialog.js must diff/submit env in the PATCH body")
+	}
+}
+
 // TestNoTailwindPlayCDN is the regression gate for Phase 1 / Plan 03 (PERF-01).
 // The Tailwind Play CDN runtime (vendor/tailwind.js, 397 KB) was deleted in
 // favor of a build-time compiled /static/styles.css file (~8 KB gzipped).

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -67,7 +67,8 @@ What agent-deck does, at the noun level (independent of which surface — CLI / 
 | **Channel routing** | Telegram / Slack inbound delivery to the right conductor, with `--channels` per-session binding | CLI ✅ |
 | **Attach MCPs** | Per-session or global MCP plugin attach / detach / status, with optional pooling | CLI ✅ · TUI ✅ · Web UI ⚪ |
 | **Attach skills** | Pool-based on-demand skill loading per Claude session | CLI ✅ · TUI ✅ |
-| **Session-metadata mutation** | `session set` for `claude-session-id`, `path`, `wrapper`, `channels`, `parent`; `session unset-parent` | CLI ✅ |
+| **Session-metadata mutation** | `session set` for `claude-session-id`, `path`, `wrapper`, `channels`, `parent`, `env`; `session unset-parent` | CLI ✅ |
+| **Per-session env vars** | Per-session environment variables for every tool, set at create (`add`/`launch --env`) or later (`session set <id> env KEY=VALUE`, the edit dialogs) | CLI ✅ · TUI ✅ · Web UI ✅ |
 | **State persistence** | `state.json` + `task-log.md` + `LEARNINGS.md` + `HANDOFF.md` survive Claude Code compaction/restart | CLI ✅ |
 | **GitHub pipeline oversight** | Conductor-driven release flow: PR merge → tag → goreleaser → release | CLI ✅ |
 | **Remote sessions** | SSH-based remote register / list / attach across hosts | CLI ✅ |

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -41,6 +41,9 @@ agent-deck add [path] [options]
 | `--parent` | Parent session (creates child) |
 | `--no-parent` | Disable automatic parent linking |
 | `--mcp` | Attach MCP (repeatable) |
+| `--env` | Per-session env var `KEY=VALUE` (repeatable); all tools; persisted plaintext; wins over `env_file`/`~/.zshrc` |
+
+(`--env` is also accepted by `launch`.)
 
 ```bash
 agent-deck add -t "My Project" -c claude .
@@ -228,9 +231,15 @@ agent-deck session current --json
 agent-deck session set <id|title> <field> <value>
 ```
 
-**Fields:** title, path, command, tool, claude-session-id, gemini-session-id, account
+**Fields:** title, path, command, tool, claude-session-id, gemini-session-id, account, env
 
 Setting `account` auto-migrates the Claude conversation into the target account's config dir (same migration as `session switch-account`, but without the automatic stop/restart).
+
+`env` takes a single `KEY=VALUE` (or `KEY=` to unset that key) and applies to **every** tool (including `shell`/`aider`). It is restart-required:
+
+```bash
+agent-deck session set my-sess env HTTPS_PROXY=http://localhost:8080
+```
 
 ### session send
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -68,19 +68,80 @@ launch_shell = false                        # Wrap commands with interactive she
 
 ### Sourcing order
 
-Environment sources are applied in this order (later overrides earlier):
+The **config-sourced** layers below are applied in this order (later overrides
+earlier), all sourced *inside* the spawned command:
 
 1. Global `[shell].env_files` (in order)
 2. `[shell].init_script`
 3. Tool-specific `env_file` (`[claude].env_file`, `[gemini].env_file`, `[tools.X].env_file` — for Claude, the group/conductor `env_file` overrides the global one; see [Per-group / per-conductor Claude overrides](#per-group--per-conductor-claude-overrides))
 4. Per-group / per-conductor inline env (`[groups.X.claude].env`, `[conductors.X.claude].env`) — exported after the env_file source, so an inline key wins over the same key from the file
-5. Inline env vars from `[tools.X].env` (highest priority)
+5. Inline env vars from `[tools.X].env`
+
+**Per-session env** (`agent-deck session set <id> env KEY=VALUE`, `add`/`launch
+--env`, or the TUI/Web new/edit dialogs) is the **most specific** scope and
+**wins** on a key collision. It is exported *after* the config-sourced layers
+(1–5) — so a per-session value overrides the same key from an `env_file`, inline
+`[tools.X].env`, or per-group/conductor env — and after the interactive shell
+startup files (`~/.zshrc`/`~/.bashrc` via `launch_shell`), so it overrides those
+too. (`TELEGRAM_*` neutralisation for non-channel-owning claude sessions still
+applies last, for safety.) See
+[Per-session environment variables](#per-session-environment-variables)
 
 A configured `env_file` that does not exist at spawn prints an
 `agent-deck: warning: env_file not found: <path>` line in the session pane
 (and a debug-log warning) instead of being silently skipped. A config.toml
 that fails to parse is also surfaced in the pane at spawn — in that state
 every override is inactive and sessions launch on defaults.
+
+### Per-session environment variables
+
+Unlike the config.toml layers above (which apply to every session matching a
+tool/group/conductor), per-session env is attached to **one** session and works
+for **every** tool. Entries are `KEY=VALUE`; keys must match
+`[A-Za-z_][A-Za-z0-9_]*`. They are exported after the config-sourced env layers
+and after the interactive shell startup (`~/.zshrc`/`~/.bashrc`), so a
+per-session value **wins** over a colliding `env_file`/inline-env/`~/.zshrc`
+value, and before any Docker wrapping so they ride into the container command.
+They persist across restart and fork.
+
+Precedence note: per-session env is the most specific scope and **wins** on a
+key collision. It is exported after the config env layers (`env_file`/inline/
+group/conductor env) and after the interactive shell startup files, so a
+per-session value overrides all of them. (The `TELEGRAM_*` strip for
+non-channel-owning claude sessions still runs last, for safety.)
+
+Limitation: per-session env applies to local, Docker/sandboxed, and direct SSH
+sessions (`--ssh` without a remote path), but **not** to two remote cases:
+(1) sessions with a remote working path (`SSHRemotePath`) skip env injection
+(the `cd '<path>' && …` remote wrapping would re-escape the inline exports), and
+(2) creating a session **on** a remote host (remote-mode create) rejects
+per-session env with an error rather than silently dropping it — set such
+variables on the remote host instead.
+
+Manage them via the CLI:
+
+```bash
+# Create with env (repeatable; both add and launch accept --env)
+agent-deck add . -c claude --env HTTPS_PROXY=http://127.0.0.1:8080 --env AGENT_ROLE=reviewer
+agent-deck launch -c codex --env OPENAI_BASE_URL=https://proxy.internal -m "audit"
+
+# Set / change a single key on an existing session
+agent-deck session set <id> env HTTPS_PROXY=http://127.0.0.1:8080
+
+# Unset a key (empty value clears it)
+agent-deck session set <id> env HTTPS_PROXY=
+```
+
+The TUI new-session dialog (multi-line `KEY=VALUE`) and edit dialog (`P` →
+`Env`), plus the Web create/edit dialogs, expose the same field. Edits are
+restart-required.
+
+> **Plaintext at rest.** Per-session env is stored unencrypted in the session
+> state DB (`tool_data` blob), so use it for non-secret configuration. When a
+> session carries per-session env, agent-deck suppresses the full prepared
+> command from its logs (it logs only the env key **names**) so values don't
+> leak there. Conductor session-registration is intentionally **out of scope**
+> and does not carry per-session env.
 
 ## [claude] Section
 
@@ -695,6 +756,23 @@ env = { API_KEY = "token", BASE_URL = "https://api.example.com" }
 | `env` | map | No | Inline environment variables exported for this tool. These take highest priority, overriding both `[shell].env_files` and `env_file`. Values are single-quoted to prevent shell expansion. |
 
 **Built-in icons:** claude=🤖, gemini=✨, opencode=🌐, codex=💻, copilot=🐙, hermes=☤, cursor=📝, shell=🐚
+
+## Running a wrapper binary (e.g. Claude Code on Codex)
+
+To launch a tool through a drop-in wrapper — for example [`claudodex`](https://github.com/bassner/claudodex) to run Claude Code on an OpenAI Codex subscription, side by side with normal Claude — set the tool's `command` to the wrapper. No per-session flag is needed; this uses the per-tool `command` configuration documented above, and agent-deck already suppresses the `CLAUDE_CONFIG_DIR=` prefix for a non-`claude` command (the wrapper is assumed to handle it).
+
+- **All Claude sessions:** `command = "claudodex"` under `[claude]`.
+- **A subset, side by side with normal Claude:**
+  - scope it per-group or per-conductor — `[groups."codex-work".claude].command = "claudodex"` (resolution order: `conductor > group > [claude].command > "claude"`); **or**
+  - define a claude-compatible custom tool and pick it per session:
+
+    ```toml
+    [tools.claudodex]
+    command = "claudodex"
+    compatible_with = "claude"
+    ```
+
+    Then `agent-deck add -c claudodex …` runs Claude Code on Codex while `-c claude` sessions keep the real `claude` binary — any group, no global change.
 
 ## Path Resolution
 

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -86,7 +86,10 @@ Complete reference for agent-deck Terminal UI features.
 - Command (claude/gemini/opencode/codex/custom) — the dialog remembers the last-used tool (persisted per profile, never written to config.toml; an explicit `default_tool` in config wins)
 - Project path (required, supports `~/`)
 - Parent group (auto-selected)
+- Env vars (all tools): per-session `KEY=VALUE` environment variables, one per line; persisted plaintext, restart-required
 - Claude options (when Claude is selected): permission mode, Chrome, teammate mode, extra args, and start query
+
+The Env vars field is also editable on an existing session via the edit-session dialog.
 
 **Controls:** `Tab` move fields | `Enter` advance to next field (on free-text Name/Branch fields) | `Ctrl+S` create from any field | `Esc` cancel
 

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -312,7 +312,7 @@ func (s *fixtureStore) LoadArchivedMenuSnapshot() (*web.MenuSnapshot, error) {
 }
 
 // CreateSession implements web.SessionMutator.
-func (s *fixtureStore) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (s *fixtureStore) CreateSession(title, tool, projectPath, groupPath, modelID string, env []string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	id := fmt.Sprintf("sess-%03d", s.nextID)
@@ -320,6 +320,7 @@ func (s *fixtureStore) CreateSession(title, tool, projectPath, groupPath, modelI
 	s.sessions[id] = &web.MenuSession{
 		ID: id, Title: title, Tool: tool,
 		Status: session.StatusIdle, GroupPath: groupPath, ProjectPath: projectPath,
+		Env:   env,
 		Order: len(s.order), CreatedAt: s.now(),
 	}
 	s.order = append(s.order, id)


### PR DESCRIPTION
## Summary

Adds **per-session environment variables** for every supported tool — `KEY=VALUE` pairs attached to a single session (at creation or later) that are exported into the spawned process.

This closes a real gap: env previously came only from group/tool `env_file`s and a few hardcoded vars, so a one-off `HTTPS_PROXY`, feature flag, or API-base override for a *single* session was impossible. Per-session env is the most-specific scope, so it **wins** over the config-level env layers on a key collision.

> **Note:** this PR originally also proposed a per-session *command override*. That was dropped — agent-deck already ships a per-tool command/wrapper mechanism (`[claude].command`, per-group/per-conductor `command`, and claude-compatible `[tools.*]`, all from #1483/#1044) that covers running a wrapper like [`claudodex`](https://github.com/bassner/claudodex) side-by-side with normal Claude, and even handles the `CLAUDE_CONFIG_DIR=` suppression. The README and config reference now document that path instead.

## What's included

- New persisted field `Instance.Env []string` (`KEY=VALUE`, stored in the `tool_data` JSON blob; no schema migration), modeled on `ExtraArgs`.
- Exported helpers so every surface validates identically: `ValidateSessionEnvKey`, `ParseSessionEnvPair`, `UpsertSessionEnv`, `UnsetSessionEnv`, `DedupeSessionEnv`, `buildSessionEnvExports`.
- Injection at the universal `prepareCommand` chokepoint (covering raw/custom sessions) plus, for builder paths, as the final grouped clause in `buildEnvSourceCommand`'s precedence chain — so a per-session value is exported after the config env layers and the login shell, and therefore **wins** over a colliding `env_file`/inline/group/conductor/`~/.zshrc` value, for all tools. Survives SSH/Docker wrapping; skipped for remote-path SSH.
- Inherited by forks (copied, not aliased) across every tool's fork constructor.
- Log safety: when a session carries per-session env, the restart/respawn command is suppressed from agent-deck's own logs (keys logged, values not), and tmux inline `export` values are redacted.

**Surfaces**
- CLI: `agent-deck session set <id> env KEY=VALUE` / `env KEY=` (unset); `add`/`launch --env KEY=VALUE` (repeatable, upserts on repeat); `list --json` exposes it.
- TUI: new-session dialog (multi-line `KEY=VALUE`, one per line) and edit-session dialog (`P` → `Env`).
- Web: create/patch API + `MenuSession` projection + server-side validation, and the create/edit dialogs (key/value editor).
- Docs: `README.md` and `skills/agent-deck/references/*` (precedence, plaintext-at-rest note, remote-path limitation).

## Security & safety

- Env keys are validated (`[A-Za-z_][A-Za-z0-9_]*`); values are shell-escaped at every injection site; CR/LF in values is rejected at the shared validator so the newline-joined web transport round-trips losslessly.
- **Allow + warn:** per-session env persists in plaintext in the session DB (no secret store), and the UI/CLI say so. The restart/respawn command is suppressed from logs whenever a session carries env, so values don't leak into debug logs.

## Known limitations & scope

- Per-session env is **not** applied to SSH sessions that use a remote working path (`SSHRemotePath`) — the remote `cd '<path>' && …` re-quoting would mangle the inline exports. The proactive surfaces (CLI `add --ssh --remote-path --env`, TUI/web remote-create) reject it up front; `session set`/web PATCH also reject setting env on such a session.
- As the most specific scope, per-session env **wins** on a key collision with `env_file`/inline/group/conductor env and with `~/.zshrc`; `TELEGRAM_*` neutralisation still applies last for safety.
- Conductor-registered sessions are intentionally not wired for per-session env.

## Validation

- `go build ./...`, `go vet ./...`, and `golangci-lint` (v2) are clean.
- TDD throughout: unit tests cover the env helpers (incl. hostile values and CR/LF rejection), injection across tools and the `&&`-chain grouping, precedence, log suppression, tmux redaction, persistence round-trips, fork inheritance, dedup of duplicate keys, the mutators (set/unset/invalid-key, SSH-remote-path rejection), CLI flags, web create/patch (+ rollback atomicity), and the TUI/web dialogs.
- Cross-vendor reviewed (Codex, `xhigh`) across multiple rounds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-session environment variables for creating, viewing, and editing sessions in both CLI and web workflows.
  * Environment values now appear in session details and can be set, updated, or cleared.

* **Bug Fixes**
  * Improved validation for environment entries and rejected invalid keys earlier.
  * Preserved environment settings across restarts and session forks.
  * Added safer logging and output redaction to avoid exposing sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->