### PR TITLE
fix(sysinfo): don't block TUI startup on a wedged netstat

### DIFF
--- a/internal/sysinfo/collector.go
+++ b/internal/sysinfo/collector.go
@@ -29,14 +29,22 @@ func NewCollector(intervalSeconds int, onUpdate func()) *Collector {
 }
 
 // Start begins the background collection goroutine.
+//
+// Everything — the one-time GPU probe and the initial collection — runs inside
+// the goroutine. Start() must never block its caller: it runs on the UI's
+// critical path (Home.Init, before the first paint), and a slow stat source
+// (e.g. a wedged `netstat -ib` on macOS) would otherwise freeze the TUI on a
+// blank screen until it returned.
 func (c *Collector) Start() {
-	// Probe GPU availability once at startup
-	probeGPU()
-
-	// Initial collection
-	c.collect()
-
 	go func() {
+		// Probe GPU availability once, then take an initial snapshot so the
+		// first refresh has data without waiting a full interval.
+		probeGPU()
+		c.collect()
+		if c.onUpdate != nil {
+			c.onUpdate()
+		}
+
 		ticker := time.NewTicker(c.interval)
 		defer ticker.Stop()
 

--- a/internal/sysinfo/network.go
+++ b/internal/sysinfo/network.go
@@ -1,6 +1,7 @@
 package sysinfo
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -80,8 +81,15 @@ func ParseNetDev(content string) (rxTotal, txTotal uint64) {
 }
 
 // collectNetworkDarwin uses netstat -ib to get network counters on macOS.
+// netstat -ib was observed to intermittently wedge for tens of seconds (cause
+// unconfirmed; likely degraded interface state), so it is bounded by a context
+// timeout: on timeout the process is killed and the cycle reports stats
+// unavailable rather than hanging the collector.
 func collectNetworkDarwin() NetworkStat {
-	out, err := exec.Command("netstat", "-ib").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "netstat", "-ib").Output()
 	if err != nil {
 		return NetworkStat{}
 	}

--- a/internal/sysinfo/startup_test.go
+++ b/internal/sysinfo/startup_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 )
@@ -28,7 +29,12 @@ func TestCollectorStart_NonBlocking(t *testing.T) {
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	c := NewCollector(5, nil)
+	// onUpdate fires once the first collection cycle finishes. Wait on it so the
+	// background collect against the wedged netstat is observed deterministically
+	// before t.TempDir()/t.Setenv() cleanup removes the fake binary and reverts PATH.
+	firstCycle := make(chan struct{})
+	var once sync.Once
+	c := NewCollector(5, func() { once.Do(func() { close(firstCycle) }) })
 	defer c.Stop()
 
 	done := make(chan struct{})
@@ -42,6 +48,14 @@ func TestCollectorStart_NonBlocking(t *testing.T) {
 		// Start() returned promptly despite the wedged netstat — correct.
 	case <-time.After(3 * time.Second):
 		t.Fatal("Collector.Start() blocked on a slow netstat; it must be non-blocking so the TUI can paint")
+	}
+
+	// The initial collect runs the wedged netstat; it must complete (bounded by
+	// the 2s context timeout in collectNetworkDarwin), not hang the goroutine.
+	select {
+	case <-firstCycle:
+	case <-time.After(3 * time.Second):
+		t.Fatal("initial collection cycle never completed; collector goroutine is wedged")
 	}
 }
 

--- a/internal/sysinfo/startup_test.go
+++ b/internal/sysinfo/startup_test.go
@@ -1,0 +1,68 @@
+package sysinfo
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestCollectorStart_NonBlocking guards the regression where the initial stats
+// collection ran synchronously inside Start(). The TUI calls Start() from
+// Home.Init, which Bubble Tea runs before the first paint, so a wedged
+// `netstat -ib` (a real macOS pathology with flapping VPN utun* interfaces)
+// would freeze the UI on a blank, input-dead screen until netstat returned.
+// Start() must spawn its work and return immediately regardless of how slow a
+// stat source is.
+func TestCollectorStart_NonBlocking(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("network collection only shells out to netstat on darwin")
+	}
+
+	// A fake netstat that hangs, placed first on PATH.
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "netstat")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	c := NewCollector(5, nil)
+	defer c.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		c.Start()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Start() returned promptly despite the wedged netstat — correct.
+	case <-time.After(3 * time.Second):
+		t.Fatal("Collector.Start() blocked on a slow netstat; it must be non-blocking so the TUI can paint")
+	}
+}
+
+// TestCollectNetworkDarwin_TimesOut verifies that a wedged netstat is bounded
+// by the context timeout rather than hanging the collector goroutine forever
+// (which also leaked zombie netstat processes across launches).
+func TestCollectNetworkDarwin_TimesOut(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("collectNetworkDarwin only runs on darwin")
+	}
+
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "netstat")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	start := time.Now()
+	_ = collectNetworkDarwin() // should return ~timeout, not after 30s
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("collectNetworkDarwin took %s; expected it to be bounded by the ~2s context timeout", elapsed)
+	}
+}


### PR DESCRIPTION
# fix(sysinfo): don't block TUI startup on a wedged `netstat`

## Problem

agent-deck intermittently launches to a **blank, input-dead screen** on macOS — sometimes for ~30 seconds, sometimes instantly. It's not reproducible on demand and flips with no change to agent-deck, tmux, or the session set. Notably, `agent-deck status` (the CLI) is always instant; only the TUI stalls.

## Root cause

The system-stats collector runs its first collection **synchronously inside `Collector.Start()`**, and `Start()` is called from `Home.Init()` — which Bubble Tea runs *before the first paint*. On macOS that collection path shells out to `netstat -ib`, which on the affected machine was observed to **intermittently wedge in the kernel** — 11.9s on one run versus ~0.2s on adjacent runs, with stuck instances parked in a `kevent`/`select` wait. The exact trigger is unconfirmed; the most likely candidate is degraded network-interface state (e.g. `utun*` churn from VPN connect/disconnect, a documented source of slow interface enumeration on macOS), but that has not been pinned down for this case. While netstat hangs, `Init()` can't return, so Bubble Tea never paints frame one and never processes input — the blank screen. The intermittency tracks live system state, not anything inside agent-deck, which is why the CLI `agent-deck status` (which never gathers stats) is always unaffected.

The fix below does not depend on identifying why netstat wedges — only on the fact that a startup stat collection must not be able to block the UI.

The `netstat -ib` call also had no timeout, so a wedged invocation froze the collector goroutine indefinitely and leaked zombie `netstat` processes that accumulated across launches.

## Fix

Two changes in `internal/sysinfo/`:

- **`collector.go`** — move the one-time GPU probe and the initial `collect()` into the background goroutine so `Start()` returns immediately. The UI's first paint no longer waits on *any* stat source, slow or otherwise.
- **`network.go`** — bound the darwin `netstat -ib` call with a 2s `exec.CommandContext` timeout. A wedged invocation is killed and that cycle reports stats unavailable, instead of hanging the collector (and leaking a process) forever. This also protects the web `Collect()` path (`handlers_system.go`), where a hang previously blocked an HTTP request.

## Testing

Added `internal/sysinfo/startup_test.go` with two regression guards (darwin-gated):

- `TestCollectorStart_NonBlocking` — with a hanging fake `netstat` on `PATH`, `Start()` must return promptly.
- `TestCollectNetworkDarwin_TimesOut` — `collectNetworkDarwin` must be bounded by the context timeout, not run to the hang.

Both **fail on the prior code** (Start blocks; netstat runs the full 30s) and **pass after the fix**. Verified end-to-end against built binaries with a deliberately-hanging `netstat`: the old binary's event loop stays frozen ~30s, while the fixed binary paints in 0.01s, quits on Ctrl+C in 0.14s, and reaps the wedged netstat at the 2s timeout. `go test -race ./internal/sysinfo/` is clean — the goroutine write and `Get()` reads are mutex-protected.

## Scope

The timeout is intentionally limited to `netstat -ib`, the only command observed to hang. Other darwin collectors (`ps`, `vm_stat`, `sysctl`) issue the same unbounded `exec` pattern on the same goroutine, but they don't touch the network and weren't observed to wedge; the async `Start()` change already prevents any of them from blocking the UI. Generalizing the timeout to all of them is a reasonable follow-up but is out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup responsiveness so system info collection no longer blocks the UI while the first snapshot initializes in the background.
  * Added a fixed timeout for macOS network stats collection to prevent potential hangs from slow system commands.
* **Tests**
  * Added darwin regression tests to ensure startup returns promptly and the first refresh completes within a bounded time.
  * Added a darwin test confirming network stats collection times out instead of hanging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->