### PR TITLE
fix(storage): make routine saves upsert-only — stale TUI snapshots can no longer delete concurrent sessions

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -867,10 +867,16 @@ func handleConductorTeardown(_ string, args []string) {
 					}
 					if len(removedIDs) > 0 {
 						groupTree := session.NewGroupTreeWithGroups(filtered, groups)
+						removeFailed := false
 						for _, id := range removedIDs {
-							_ = storage.RemoveSessionAndVerify(id, filtered, groupTree)
+							if rmErr := storage.RemoveSessionAndVerify(id, filtered, groupTree); rmErr != nil {
+								removeFailed = true
+								if !*jsonOutput {
+									fmt.Fprintf(os.Stderr, "  Warning: failed to remove session '%s' (%s) from %s: %v\n", sessionTitle, id, meta.Profile, rmErr)
+								}
+							}
 						}
-						if !*jsonOutput {
+						if !removeFailed && !*jsonOutput {
 							fmt.Printf("  [ok] Removed session '%s' from %s\n", sessionTitle, meta.Profile)
 						}
 					}

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -850,22 +850,26 @@ func handleConductorTeardown(_ string, args []string) {
 				fmt.Printf("  [ok] Removed directory for %s\n", meta.Name)
 			}
 
-			// Remove session from storage
+			// Remove session from storage. #1550: SaveWithGroups is upsert-only
+			// (saving a filtered list no longer drops the missing rows), so
+			// removal goes through the targeted verify path (#909).
 			if storage != nil {
 				instances, groups, err := storage.LoadWithGroups()
 				if err == nil {
 					var filtered []*session.Instance
-					sessionRemoved := false
+					var removedIDs []string
 					for _, inst := range instances {
 						if inst.Title == sessionTitle {
-							sessionRemoved = true
+							removedIDs = append(removedIDs, inst.ID)
 							continue
 						}
 						filtered = append(filtered, inst)
 					}
-					if sessionRemoved {
+					if len(removedIDs) > 0 {
 						groupTree := session.NewGroupTreeWithGroups(filtered, groups)
-						_ = storage.SaveWithGroups(filtered, groupTree)
+						for _, id := range removedIDs {
+							_ = storage.RemoveSessionAndVerify(id, filtered, groupTree)
+						}
 						if !*jsonOutput {
 							fmt.Printf("  [ok] Removed session '%s' from %s\n", sessionTitle, meta.Profile)
 						}

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -669,14 +669,11 @@ func handleWorktreeFinish(profile string, args []string) {
 	// Step 5: Remove session from agent-deck.
 	//
 	// #1396: this must use the targeted RemoveSessionAndVerify path (the same
-	// one `session remove` uses), NOT saveSessionData/SaveWithGroups. When the
-	// finished worktree is the LAST session in the registry, `remaining` is
-	// empty and SaveWithGroups → SaveInstances([]) trips the S1 empty-sweep
-	// data-loss guard (ErrRefusingEmptySweep) — but only AFTER the irreversible
-	// merge/remove-worktree/delete-branch steps have already run, leaving an
-	// orphaned row pointing at a deleted worktree. RemoveSessionAndVerify
-	// issues a targeted DELETE + SaveGroupsOnly, so the last-session delete
-	// succeeds without ever calling SaveInstances([]).
+	// one `session remove` uses), NOT saveSessionData/SaveWithGroups.
+	// Historically SaveWithGroups(remaining) with an empty `remaining` tripped
+	// the S1 empty-sweep guard AFTER the irreversible git steps, orphaning the
+	// row; since #1550 SaveWithGroups is upsert-only and would not delete the
+	// row at all. Either way, removal requires the targeted DELETE.
 	remaining := dropInstance(instances, inst.ID)
 	groupTree := session.NewGroupTreeWithGroups(remaining, groups)
 	if err := storage.RemoveSessionAndVerify(inst.ID, remaining, groupTree); err != nil {

--- a/internal/session/issue1396_worktree_finish_last_test.go
+++ b/internal/session/issue1396_worktree_finish_last_test.go
@@ -1,12 +1,10 @@
 package session
 
 import (
-	"errors"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,20 +44,21 @@ func TestIssue1396_FinishLastWorktreeDoesNotTripEmptySweepGuard(t *testing.T) {
 	require.NoError(t, seed.SaveWithGroups([]*Instance{only}, NewGroupTree([]*Instance{only})))
 	require.True(t, only.IsWorktree(), "seed instance must be a worktree session")
 
-	// Sanity: the OLD persistence path (the pre-fix bug) trips the guard when
-	// removing the last session. This locks in WHY the targeted path is needed.
-	t.Run("old SaveWithGroups path trips the empty-sweep guard", func(t *testing.T) {
+	// Sanity: the OLD persistence path cannot remove the last session. At #1396
+	// time SaveWithGroups([]) tripped the S1 empty-sweep guard
+	// (ErrRefusingEmptySweep); since #1550 SaveWithGroups is upsert-only, so an
+	// empty save is a benign no-op that deletes nothing. Either way the row
+	// survives — locking in WHY removal needs the targeted path.
+	t.Run("SaveWithGroups path cannot remove the last session", func(t *testing.T) {
 		s := rmTestStorage(t, dbPath)
 		var remaining []*Instance // empty: the finished session was the only one
 		err := s.SaveWithGroups(remaining, NewGroupTreeWithGroups(remaining, nil))
-		require.Error(t, err, "SaveWithGroups([]) on a populated table must be refused")
-		require.True(t, errors.Is(err, statedb.ErrRefusingEmptySweep),
-			"expected ErrRefusingEmptySweep, got: %v", err)
+		require.NoError(t, err, "upsert-only SaveWithGroups([]) must be a benign no-op (#1550)")
 
-		// And the row is still present — proving the orphan in the bug report.
+		// The row is still present — an empty save must never wipe the table.
 		exists, exErr := s.InstanceExists(only.ID)
 		require.NoError(t, exErr)
-		require.True(t, exists, "row must still exist after the guard rejection (the orphan)")
+		require.True(t, exists, "row must survive an empty save (the #1396 orphan / #1550 no-sweep)")
 	})
 
 	// The FIX: RemoveSessionAndVerify cleanly removes the last session's row

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -301,7 +301,15 @@ func (s *Storage) Save(instances []*Instance) error {
 }
 
 // SaveWithGroups persists instances and groups to SQLite.
-// Converts Instance objects to database rows, then batch-inserts in a transaction.
+// Converts Instance objects to database rows, then batch-upserts in a transaction.
+//
+// UPSERT-ONLY (#1550): this path never deletes rows. It used to route through
+// statedb.SaveInstances, whose `DELETE FROM instances WHERE id NOT IN (...)`
+// sweep let any process holding a stale snapshot silently delete sessions a
+// concurrent process created after that snapshot was loaded (the TUI-side twin
+// of #909/#1031). Deletions must be explicit and targeted instead:
+// DeleteInstance / RemoveSessionAndVerify at the moment the user deletes a
+// session, or statedb.ClearAllInstances for an intentional full wipe.
 func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -324,7 +332,7 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 		rows[i] = row
 	}
 
-	if err := s.db.SaveInstances(rows); err != nil {
+	if err := s.db.UpsertInstances(rows); err != nil {
 		return fmt.Errorf("failed to save instances: %w", err)
 	}
 

--- a/internal/session/storage_concurrent_test.go
+++ b/internal/session/storage_concurrent_test.go
@@ -80,14 +80,19 @@ func TestConcurrentStorageWrites(t *testing.T) {
 	require.NoError(t, err1, "s1 SaveWithGroups should succeed")
 	require.NoError(t, err2, "s2 SaveWithGroups should succeed")
 
-	// 4. Load from a third independent storage and verify dedup semantics.
-	//    After SaveWithGroups runs UpdateClaudeSessionsWithDedup on each slice,
-	//    the combined DB state should contain at most one session with the shared ID.
+	// 4. Load from a third independent storage. Both rows must survive: #1550
+	//    made SaveWithGroups upsert-only, so neither concurrent writer can
+	//    sweep the other's row. (Before that fix this test observed only one
+	//    surviving row — the "dedup" was really the destructive DELETE-NOT-IN.)
 	s3 := openStorage()
 	loaded, err := s3.Load()
 	require.NoError(t, err)
+	require.Len(t, loaded, 2, "both concurrently-written sessions must survive (#1550)")
 
-	// Count how many sessions retained the shared ClaudeSessionID after dedup.
+	// 5. Dedup is a read-side invariant: each writer only dedups its own slice,
+	//    so cross-process duplicates are resolved when a full set is loaded
+	//    (the TUI runs UpdateClaudeSessionsWithDedup after every reload).
+	UpdateClaudeSessionsWithDedup(loaded)
 	holdersCount := 0
 	for _, inst := range loaded {
 		if inst.ClaudeSessionID == sharedClaudeID {
@@ -95,5 +100,5 @@ func TestConcurrentStorageWrites(t *testing.T) {
 		}
 	}
 	assert.LessOrEqual(t, holdersCount, 1,
-		"at most one session should retain the shared ClaudeSessionID after concurrent writes and dedup")
+		"at most one session should retain the shared ClaudeSessionID after load-time dedup")
 }

--- a/internal/session/storage_save_sweep_clobber_test.go
+++ b/internal/session/storage_save_sweep_clobber_test.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveWithGroupsDoesNotClobberConcurrentlyAddedSession reproduces issue
+// #1550: concurrent TUIs silently delete each other's sessions because the
+// routine TUI save path rewrote the whole instances table from a stale
+// in-memory snapshot.
+//
+// The exact production sequence (see home.go saveInstancesWithForce):
+//
+//  1. TUI A loads the full instances snapshot (LoadWithGroups).
+//  2. TUI B creates a NEW session via the targeted single-row path
+//     (InsertSessionAndVerify -> SaveInstance, no sweep — the #1031 fix).
+//  3. TUI A performs any routine save (rename, cursor move, detection
+//     result, ...) with its STALE snapshot. On origin/main this went through
+//     SaveWithGroups -> SaveInstances, whose `DELETE FROM instances WHERE id
+//     NOT IN (<stale ids>)` sweep deleted B's row because it was never in
+//     A's snapshot — while B's tmux session and agent kept running.
+//
+// This test drives that sequence deterministically against a shared SQLite
+// file. It FAILS before the #1550 fix (B's row is gone) and PASSES once
+// SaveWithGroups is upsert-only (statedb.UpsertInstances, no sweep).
+func TestSaveWithGroupsDoesNotClobberConcurrentlyAddedSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "state.db")
+
+	openStorage := func() *Storage {
+		db, err := statedb.Open(dbPath)
+		require.NoError(t, err)
+		require.NoError(t, db.Migrate())
+		t.Cleanup(func() { db.Close() })
+		return &Storage{db: db, dbPath: dbPath, profile: "_test"}
+	}
+
+	tuiA := openStorage()
+	tuiB := openStorage()
+
+	// Seed one pre-existing session both TUIs know about.
+	existing := &Instance{
+		ID:          "sess-existing",
+		Title:       "existing",
+		ProjectPath: "/tmp/existing",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   time.Now().Add(-2 * time.Minute),
+	}
+	require.NoError(t, tuiA.SaveWithGroups(
+		[]*Instance{existing}, NewGroupTree([]*Instance{existing})))
+
+	// Step 1: TUI A loads its snapshot (only knows about sess-existing).
+	snapshot, _, err := tuiA.LoadWithGroups()
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1, "TUI A should load exactly the pre-existing session")
+
+	// Step 2: TUI B creates a brand-new session via the targeted single-row
+	// path (the production path InsertSessionAndVerify uses).
+	added := &Instance{
+		ID:          "sess-added-by-other-tui",
+		Title:       "added-by-other-tui",
+		ProjectPath: "/tmp/added",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      StatusRunning,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, tuiB.InsertSessionAndVerify(added, nil))
+
+	// Step 3: TUI A performs a routine save with its stale snapshot (this is
+	// what every rename / reorder / detection-result save in the TUI does).
+	snapshot[0].Title = "existing-renamed"
+	require.NoError(t, tuiA.SaveWithGroups(snapshot, NewGroupTree(snapshot)))
+
+	// Assert: B's session must survive A's stale save.
+	loaded, err := openStorage().Load()
+	require.NoError(t, err)
+
+	ids := map[string]string{}
+	for _, inst := range loaded {
+		ids[inst.ID] = inst.Title
+	}
+	assert.Contains(t, ids, "sess-added-by-other-tui",
+		"session created by a concurrent TUI must survive another TUI's stale full-snapshot save (issue #1550)")
+	assert.Equal(t, "existing-renamed", ids["sess-existing"],
+		"TUI A's own edit must still persist")
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -765,6 +765,9 @@ func (s *StateDB) UpsertInstances(insts []*InstanceRow) error {
 	})
 }
 
+// saveInstancesOnce persists insts. When sweep is true, rows present in the
+// database but absent from insts are deleted (see SaveInstances); when false,
+// they are left untouched (see UpsertInstances).
 func (s *StateDB) saveInstancesOnce(insts []*InstanceRow, sweep bool) error {
 	// Upsert path with nothing to upsert: no-op without taking the write lock.
 	if !sweep && len(insts) == 0 {

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -736,8 +736,12 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 }
 
 // SaveInstances inserts or replaces multiple instances in a single transaction.
-// It also removes any rows from the database that are not in the provided list,
-// ensuring deleted sessions don't reappear on reload.
+// It also removes any rows from the database that are not in the provided list.
+//
+// DANGER (#1550): the DELETE-NOT-IN sweep deletes any row a concurrent
+// process inserted after the caller loaded its snapshot. Routine saves must
+// use UpsertInstances instead; SaveInstances is reserved for whole-table
+// replaces where the payload is authoritative (JSON->SQLite migration).
 //
 // Wrapped in withBusyRetry because parallel writers (CLI + TUI + heartbeat
 // daemons) contend on the WAL writer slot. The whole save is idempotent at
@@ -745,11 +749,28 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 // outer transaction on SQLITE_BUSY is safe. Part of the v1.9.1 #909 fix.
 func (s *StateDB) SaveInstances(insts []*InstanceRow) error {
 	return withBusyRetry(func() error {
-		return s.saveInstancesOnce(insts)
+		return s.saveInstancesOnce(insts, true)
 	})
 }
 
-func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
+// UpsertInstances inserts or replaces the given instances WITHOUT the
+// DELETE-NOT-IN sweep: rows absent from the payload are left untouched, so a
+// writer holding a stale snapshot can never delete sessions another process
+// created after that snapshot was loaded (#1550). Deletions must be explicit
+// and targeted: DeleteInstance / RemoveSessionAndVerify (#909), or
+// ClearAllInstances for an intentional full wipe. An empty payload is a no-op.
+func (s *StateDB) UpsertInstances(insts []*InstanceRow) error {
+	return withBusyRetry(func() error {
+		return s.saveInstancesOnce(insts, false)
+	})
+}
+
+func (s *StateDB) saveInstancesOnce(insts []*InstanceRow, sweep bool) error {
+	// Upsert path with nothing to upsert: no-op without taking the write lock.
+	if !sweep && len(insts) == 0 {
+		return nil
+	}
+
 	// Pre-fetch existing mutable columns per instance ID so we can preserve state
 	// written by targeted UPDATE paths. Without this merge, every INSERT OR
 	// REPLACE can silently drop fresher data from another process.
@@ -806,7 +827,7 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 	// covers the large-but-not-empty replaces S1 cannot catch. The backup is
 	// best-effort: a failed copy is logged, never fatal — the caller asked to
 	// save, and the insurance copy must not become a new failure mode.
-	if len(insts) > 0 && s.path != "" {
+	if sweep && len(insts) > 0 && s.path != "" {
 		placeholders := make([]string, len(insts))
 		args := make([]any, len(insts))
 		for i, inst := range insts {
@@ -831,24 +852,27 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Delete rows not in the new list to prevent deleted sessions from reappearing.
-	if len(insts) == 0 {
-		// S1 guard: an empty payload would `DELETE FROM instances`, wiping the
-		// whole table. If rows already exist this is almost certainly a bug in
-		// the caller (a stray empty save), not an intentional clear — refuse it
-		// rather than silently destroying the index. Intentional clears go
-		// through ClearAllInstances. An empty payload on an already-empty table
-		// is a benign no-op.
-		var existing int
-		if err := tx.QueryRow("SELECT COUNT(*) FROM instances").Scan(&existing); err != nil {
-			return err
+	// Delete rows not in the new list (sweep callers only, see SaveInstances).
+	// The upsert path (#1550) never deletes: rows it doesn't know about are
+	// left alone, and an empty payload simply inserts nothing.
+	if sweep {
+		if len(insts) == 0 {
+			// S1 guard: an empty payload would `DELETE FROM instances`, wiping the
+			// whole table. If rows already exist this is almost certainly a bug in
+			// the caller (a stray empty save), not an intentional clear — refuse it
+			// rather than silently destroying the index. Intentional clears go
+			// through ClearAllInstances. An empty payload on an already-empty table
+			// is a benign no-op.
+			var existing int
+			if err := tx.QueryRow("SELECT COUNT(*) FROM instances").Scan(&existing); err != nil {
+				return err
+			}
+			if existing > 0 {
+				return ErrRefusingEmptySweep
+			}
+			// Already empty: nothing to delete, nothing to insert.
+			return tx.Commit()
 		}
-		if existing > 0 {
-			return ErrRefusingEmptySweep
-		}
-		// Already empty: nothing to delete, nothing to insert.
-		return tx.Commit()
-	} else {
 		placeholders := make([]string, len(insts))
 		args := make([]any, len(insts))
 		for i, inst := range insts {

--- a/internal/statedb/upsert_instances_test.go
+++ b/internal/statedb/upsert_instances_test.go
@@ -1,0 +1,70 @@
+package statedb
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// #1550: UpsertInstances is the sweep-free write path used by every routine save
+// (Storage.SaveWithGroups). These tests pin the property the fix depends on:
+// a row absent from the payload is NEVER deleted, so a writer holding a stale
+// snapshot cannot destroy sessions another process created after that
+// snapshot was loaded. SaveInstances (the DELETE-NOT-IN sweep, kept for
+// whole-table replaces like the JSON->SQLite migration) retains its S1/S2
+// guards and tests unchanged.
+
+// A payload missing existing rows must leave them untouched (no sweep).
+func TestUpsertInstances_PreservesRowsAbsentFromPayload(t *testing.T) {
+	db := newTestDB(t)
+	seedInstances(t, db, "a", "b", "c")
+
+	// Upsert a payload that only knows about "a" (stale snapshot) plus a new
+	// row "d" — b and c must survive, unlike SaveInstances' sweep.
+	now := time.Now()
+	rows := []*InstanceRow{
+		{ID: "a", Title: "a-renamed", ProjectPath: "/a", GroupPath: "grp", Order: 0, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+		{ID: "d", Title: "d", ProjectPath: "/d", GroupPath: "grp", Order: 3, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+	}
+	if err := db.UpsertInstances(rows); err != nil {
+		t.Fatalf("UpsertInstances: %v", err)
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	byID := map[string]*InstanceRow{}
+	for _, r := range loaded {
+		byID[r.ID] = r
+	}
+	if len(loaded) != 4 {
+		t.Fatalf("expected 4 rows (a,b,c,d) after upsert, got %d", len(loaded))
+	}
+	for _, id := range []string{"b", "c"} {
+		if byID[id] == nil {
+			t.Fatalf("row %q absent from the upsert payload must survive, but was deleted", id)
+		}
+	}
+	if byID["a"] == nil || byID["a"].Title != "a-renamed" {
+		t.Fatalf("expected row a updated to title %q, got %+v", "a-renamed", byID["a"])
+	}
+	if byID["d"] == nil {
+		t.Fatalf("expected new row d inserted")
+	}
+}
+
+// An empty upsert payload is a benign no-op on a populated table — no error,
+// no rows touched (contrast S1: SaveInstances([]) refuses with
+// ErrRefusingEmptySweep because its sweep WOULD wipe the table).
+func TestUpsertInstances_EmptyPayload_NoOp(t *testing.T) {
+	db := newTestDB(t)
+	seedInstances(t, db, "a", "b")
+
+	if err := db.UpsertInstances(nil); err != nil {
+		t.Fatalf("expected empty upsert to be a no-op, got %v", err)
+	}
+	if n := countInstances(t, db); n != 2 {
+		t.Fatalf("expected 2 rows preserved after empty upsert, got %d", n)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4834,7 +4834,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Save both instances AND groups (critical fix: was losing groups!)
-			// Use forceSave to bypass mtime check - new session creation MUST persist
+			// Use forceSave to bypass the external-change abort - new session creation MUST persist
 			h.forceSaveInstances()
 
 			// Start fetching preview for the new session
@@ -4901,7 +4901,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Save both instances AND groups
-			// Use forceSave to bypass mtime check - forked session MUST persist
+			// Use forceSave to bypass the external-change abort - forked session MUST persist
 			h.forceSaveInstances()
 
 			// forceSaveInstances can setError on a failed persist; fold the
@@ -4978,7 +4978,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			uiLog.Warn("delete_instance_db_err", slog.String("id", msg.deletedID), slog.String("err", err.Error()))
 		}
 		// Save both instances AND groups (critical fix: was losing groups!)
-		// Use forceSave to bypass mtime check - delete MUST persist
+		// Use forceSave to bypass the external-change abort - delete MUST persist
 		h.forceSaveInstances()
 
 		// Show undo hint (using setError as a transient message)
@@ -5079,7 +5079,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// Use forceSave to bypass mtime check - restore MUST persist
+		// Use forceSave to bypass the external-change abort - restore MUST persist
 		h.forceSaveInstances()
 		if msg.warning != "" {
 			h.setError(fmt.Errorf("restored '%s' (%s)", msg.instance.Title, msg.warning))
@@ -9795,26 +9795,32 @@ func (h *Home) saveInstancesWithForce(force bool) {
 	// EXTERNAL CHANGE DETECTION: Check if file was modified since we last loaded.
 	// This catches external changes (e.g., from CLI) even when fsnotify fails
 	// (common on 9p/NFS filesystems in WSL2).
-	// NOTE: Skip this check when force=true because critical saves MUST happen
-	// (e.g., new session creation, fork, delete - these would lose data if skipped)
-	if !force {
-		h.reloadMu.Lock()
-		ourLoadMtime := h.lastLoadMtime
-		h.reloadMu.Unlock()
+	// #1550: force saves no longer skip this check. They still persist (they
+	// carry critical mutations like create/fork/delete, and the save is now
+	// upsert-only so it cannot delete another process's rows), but a detected
+	// external change schedules a reload after the save so this TUI stops
+	// holding a stale snapshot.
+	externalChange := false
+	h.reloadMu.Lock()
+	ourLoadMtime := h.lastLoadMtime
+	h.reloadMu.Unlock()
 
-		if h.storage != nil && !ourLoadMtime.IsZero() {
-			currentMtime, err := h.storage.GetFileMtime()
-			if err == nil && !currentMtime.IsZero() && currentMtime.After(ourLoadMtime) {
-				uiLog.Warn("save_abort_external_change",
-					slog.Time("our_load", ourLoadMtime),
-					slog.Time("current_mtime", currentMtime))
-				// File was modified externally - trigger reload instead of overwriting
-				if h.storageWatcher != nil {
-					h.storageWatcher.TriggerReload()
-				}
-				return
-			}
+	if h.storage != nil && !ourLoadMtime.IsZero() {
+		currentMtime, err := h.storage.GetFileMtime()
+		if err == nil && !currentMtime.IsZero() && currentMtime.After(ourLoadMtime) {
+			externalChange = true
+			uiLog.Warn("save_external_change_detected",
+				slog.Bool("force", force),
+				slog.Time("our_load", ourLoadMtime),
+				slog.Time("current_mtime", currentMtime))
 		}
+	}
+	if externalChange && !force {
+		// Routine save: abort and reload instead of overwriting with stale rows.
+		if h.storageWatcher != nil {
+			h.storageWatcher.TriggerReload()
+		}
+		return
 	}
 
 	if h.storage != nil {
@@ -9899,6 +9905,12 @@ func (h *Home) saveInstancesWithForce(force bool) {
 			// Clear pending title changes on successful save (rename was persisted)
 			if len(h.pendingTitleChanges) > 0 {
 				h.pendingTitleChanges = make(map[string]string)
+			}
+			// #1550: a force save raced an external change. Our rows are now
+			// persisted (upsert-only, nothing deleted); reload to pick up what
+			// the other process wrote while we were stale.
+			if externalChange && h.storageWatcher != nil {
+				h.storageWatcher.TriggerReload()
 			}
 		}
 	}

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -652,11 +652,10 @@ func (m *WebMutator) FinishWorktree(id string, opts web.WorktreeFinishOptions) (
 	}
 	m.h.instancesMu.RUnlock()
 	// #1396: use the targeted RemoveSessionAndVerify path, NOT
-	// SaveWithGroups(existing, ...). When the finished worktree is the LAST
-	// session, `existing` is empty and SaveWithGroups → SaveInstances([]) trips
-	// the S1 empty-sweep data-loss guard AFTER the irreversible git steps,
-	// orphaning the row. The targeted DELETE + SaveGroupsOnly path persists the
-	// last-session removal without ever calling SaveInstances([]).
+	// SaveWithGroups(existing, ...). Historically an empty `existing` tripped
+	// the S1 empty-sweep guard AFTER the irreversible git steps, orphaning the
+	// row; since #1550 SaveWithGroups is upsert-only and would not delete the
+	// row at all. Either way, removal requires the targeted DELETE.
 	if sErr := storage.RemoveSessionAndVerify(id, existing, m.h.groupTree); sErr != nil {
 		return web.WorktreeFinishResult{}, fmt.Errorf("save session data: %w", sErr)
 	}


### PR DESCRIPTION
Fixes #1550.

## Problem

When several TUIs run against the same profile, a TUI holding a stale in-memory snapshot could silently delete sessions created by another process. Every routine TUI save (`saveInstancesWithForce` → `SaveWithGroups` → `statedb.SaveInstances`) rewrote the whole `instances` table, and the `DELETE FROM instances WHERE id NOT IN (<in-memory ids>)` sweep deleted any row another process inserted after this TUI last loaded. The external-change mtime guard didn't cover the saves most likely to race because `force=true` (create/fork/delete/detection) skipped it entirely. This is the TUI-side twin of #909/#1031, which fixed the CLI `rm`/`add` paths but left the aggressor sweep in place.

## Fix (option 1 from the issue: upsert-only saves)

- **`statedb.UpsertInstances`** (new): identical to `SaveInstances` — same pre-read merge of `tool_data`/`auto_name`, same `INSERT OR REPLACE` batch, same busy-retry — but with **no DELETE-NOT-IN sweep**. Rows absent from the payload are left untouched; an empty payload is a no-op. `SaveInstances` keeps the sweep and its S1 (`ErrRefusingEmptySweep`) / S2 (pre-sweep `.bak`) guards, but is now reserved for whole-table replaces where the payload is authoritative (the JSON→SQLite migration); its doc comment says so.
- **`Storage.SaveWithGroups` routes through `UpsertInstances`**. Deletions are now exclusively explicit and targeted: `DeleteInstance` / `RemoveSessionAndVerify` (#909) at the moment the user deletes a session, or `ClearAllInstances` for an intentional wipe. The TUI's delete paths already issued targeted `DeleteInstance` calls before saving (home.go `instanceDeletedMsg` / worktree-finish handlers), so no TUI flow relied on the sweep — an audit of every `SaveWithGroups` caller found exactly one that did:
- **`conductor teardown --remove-all`** removed sessions by saving a filtered list; it now uses `RemoveSessionAndVerify`, consistent with the #909/#1396 precedents.
- **Force saves no longer skip external-change detection** (root cause 2 in the issue). They still persist — they carry critical mutations, and an upsert-only save can no longer delete another process's rows — but a detected external change now schedules a `TriggerReload` after the save, so a stale TUI merges in what other processes wrote instead of staying stale until fsnotify happens to fire. Non-force saves keep the existing abort+reload behavior.

## Why "deleted sessions reappearing" doesn't regress

The sweep's stated purpose only ever protected the *deleting* process's own save (its list lacks the row) — and that's covered by the explicit targeted DELETE the TUI already performs. A *different* process holding the deleted row in memory re-inserted it via `INSERT OR REPLACE` under the old semantics too; that resurrection window is unchanged and remains handled by `RemoveSessionAndVerify`'s verify loop.

## Tests

- `internal/session/storage_save_sweep_clobber_test.go` (new): deterministic repro of the incident — TUI A loads a snapshot, TUI B inserts via `InsertSessionAndVerify`, TUI A saves its stale snapshot; B's row must survive. Fails on `main`, passes here.
- `internal/statedb/upsert_instances_test.go` (new): pins the sweep-free property (rows absent from the payload survive; stale row updates and new inserts still land) and the empty-payload no-op.
- `TestConcurrentStorageWrites` updated: it previously "passed" its dedup assertion because one concurrent writer *destroyed* the other's row. It now asserts both rows survive (#1550) and that the shared-`ClaudeSessionID` dedup holds after load-time dedup (`UpdateClaudeSessionsWithDedup`, which the TUI runs on every reload) — matching how the invariant is actually enforced for the targeted #1031 insert path.
- `TestIssue1396_FinishLastWorktree...` updated: the negative-witness subtest asserted `SaveWithGroups([])` trips S1; upsert-only makes it a benign no-op. The subtest now pins the property that actually matters: an empty save never wipes the table, and removal requires the targeted path.
- S1/S2 guard tests (`save_instances_empty_guard_test.go`, `save_instances_backup_test.go`) pass unchanged — the sweep path keeps its safeguards.
- `go test ./internal/statedb/... ./internal/session/... ./internal/ui/... ./cmd/agent-deck/... ./internal/integration/... -race`, `TestPersistence_*` gate, and `golangci-lint` (0 issues) are green. Pre-existing environment-dependent failures (`TestOutputCollision_*`, `TestGetJSONLPathChecked_*`, `TestIssue1421_CleanStaleSSHSockets` — they fail identically on a clean checkout of `main` on this macOS host) are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session data from being overwritten or lost when multiple app instances save at the same time by making group saves upsert-only.
  * Fixed session removal so the last remaining session is deleted reliably after worktree or conductor cleanup.
  * Improved forced-save behavior so the UI reloads fresh data after saving.
  * Updated handling of empty saves so they no longer cause unexpected errors or data loss.
* **Tests**
  * Updated and added regression and concurrency coverage to validate the new upsert and targeted-removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->