### PR TITLE
chore(mcp): scope MCP servers to this repo via .mcp.json (No Issue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ Thumbs.db
 .serena/
 
 # Personal/local files
-.mcp.json
 .playwright-mcp/
 *.screenstudio/
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,10 @@
 {
   "mcpServers": {
     "mcpdoc": {
+      "type": "stdio",
       "command": "uvx",
-      "args": ["--urls", "agent-deck:./llms.txt"]
+      "args": ["--from", "mcpdoc", "mcpdoc", "--urls", "agent-deck:./llms.txt", "--transport", "stdio"],
+      "env": { "PYTHONUTF8": "1" }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mcpdoc": {
+      "command": "uvx",
+      "args": ["--urls", "agent-deck:./llms.txt"]
+    }
+  }
+}


### PR DESCRIPTION
This repo now declares its own MCP servers via a root-level .mcp.json file, as part of moving servers off global config to per-repo scoping. The change is additive and requires a one-time approval (enabledMcpjsonServers or in-session prompt) when a Claude Code session starts in this repo.

Also removes .mcp.json from .gitignore so the file can be tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository tracking so the local MCP configuration file is no longer ignored and will be included in version control.
  * Added a new MCP server configuration for a documentation-related service, configured to run via standard input/output and point to the project’s `llms.txt` resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->