### PR TITLE
fix: detect atuin pty-proxy and warn about TUI incompatibility

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -841,6 +841,25 @@ func main() {
 	ui.EnableModifyOtherKeys(os.Stdout)
 	defer ui.DisableModifyOtherKeys(os.Stdout)
 
+	// Check for atuin pty-proxy incompatibility (#1558).
+	// Atuin pty-proxy intercepts PTY I/O and breaks Bubble Tea's TUI rendering.
+	// The alternate screen, mouse tracking, and raw-mode interactions all fail
+	// because os.Stdin/os.Stdout are proxied pipes, not direct terminal FDs.
+	if tmux.IsAtuinPTYProxy() {
+		fmt.Fprintf(os.Stderr, `WARNING: Agent Deck's TUI is incompatible with atuin pty-proxy.
+The TUI may appear blank or fail to render.
+
+To fix this, replace:
+  eval "$(atuin pty-proxy init zsh)"
+with:
+  eval "$(atuin init zsh)"
+
+in your shell configuration file (.zshrc / .bashrc / config.fish).
+Atuin pty-proxy is only needed for the atuin TUI overlay feature,
+and is not required for normal atuin shell history functionality.
+`+"\n")
+	}
+
 	p := tea.NewProgram(
 		homeModel,
 		tea.WithAltScreen(),

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -846,18 +846,16 @@ func main() {
 	// The alternate screen, mouse tracking, and raw-mode interactions all fail
 	// because os.Stdin/os.Stdout are proxied pipes, not direct terminal FDs.
 	if tmux.IsAtuinPTYProxy() {
-		fmt.Fprintf(os.Stderr, `WARNING: Agent Deck's TUI is incompatible with atuin pty-proxy.
-The TUI may appear blank or fail to render.
-
-To fix this, replace:
-  eval "$(atuin pty-proxy init zsh)"
-with:
-  eval "$(atuin init zsh)"
-
-in your shell configuration file (.zshrc / .bashrc / config.fish).
-Atuin pty-proxy is only needed for the atuin TUI overlay feature,
-and is not required for normal atuin shell history functionality.
-`+"\n")
+		fmt.Fprint(os.Stderr, "WARNING: Agent Deck's TUI is incompatible with atuin pty-proxy.\n"+
+			"The TUI may appear blank or fail to render.\n"+
+			"\n"+
+			"To fix this, replace the pty-proxy init with the normal init in your shell config:\n"+
+			"  - zsh:   replace 'eval \"$(atuin pty-proxy init zsh)\"' with 'eval \"$(atuin init zsh)\"' in .zshrc\n"+
+			"  - bash:  replace 'eval \"$(atuin pty-proxy init bash)\"' with 'eval \"$(atuin init bash)\"' in .bashrc\n"+
+			"  - fish:  replace 'atuin pty-proxy init fish | source' with 'atuin init fish | source' in config.fish\n"+
+			"\n"+
+			"Atuin pty-proxy is only needed for the atuin TUI overlay feature,\n"+
+			"and is not required for normal atuin shell history functionality.\n")
 	}
 
 	p := tea.NewProgram(

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -429,6 +429,21 @@ type TerminalInfo struct {
 	SupportsTrueColor bool   // Supports 24-bit color
 }
 
+// IsAtuinPTYProxy checks if the current shell session is running under atuin's
+// pty-proxy. Atuin pty-proxy acts as a PTY MITM between the terminal and the
+// shell, intercepting all I/O. It sets ATUIN_PTY_PROXY_ACTIVE when active.
+//
+// agent-deck's Bubble Tea TUI is incompatible with atuin pty-proxy because:
+//   - os.Stdin/os.Stdout are pipes to atuin's proxy, not direct terminal FDs
+//   - Alternate screen sequences (tea.WithAltScreen) may be swallowed
+//   - Mouse tracking sequences (tea.WithMouseCellMotion) may not be forwarded
+//
+// Users should use `atuin init zsh` (or bash/fish) instead of
+// `atuin pty-proxy init zsh` when running agent-deck.
+func IsAtuinPTYProxy() bool {
+	return os.Getenv("ATUIN_PTY_PROXY_ACTIVE") != ""
+}
+
 // DetectTerminal identifies the current terminal emulator from environment variables
 // Returns terminal name: "warp", "iterm2", "kitty", "alacritty", "vscode", "windows-terminal", or "unknown"
 func DetectTerminal() string {

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -70,6 +70,34 @@ If you use multiple profiles, set the same under the profile override:
 allow_dangerous_mode = true
 ```
 
+### Atuin Pty-Proxy Incompatibility
+
+**Problem:** TUI shows a blank screen or fails to render when `eval "$(atuin pty-proxy init zsh)"` is in `.zshrc`.
+
+**Cause:** Atuin pty-proxy acts as a PTY MITM between the terminal and the shell. Agent Deck's Bubble Tea TUI requires direct terminal access for alternate screen mode, mouse tracking, and raw-mode I/O. These all break when stdin/stdout are proxied pipes.
+
+**Fix:** Replace the pty-proxy init line with standard atuin init:
+
+```bash
+# REMOVE this line:
+eval "$(atuin pty-proxy init zsh)"
+
+# REPLACE with this:
+eval "$(atuin init zsh)"
+```
+
+For bash:
+```bash
+eval "$(atuin init bash)"
+```
+
+For fish:
+```fish
+atuin init fish | source
+```
+
+Atuin pty-proxy is only needed for the atuin TUI overlay feature and is not required for normal shell history functionality. Agent Deck works fine with standard `atuin init`.
+
 ### High CPU Usage
 
 **With many sessions:** Normal if batched updates. Check:


### PR DESCRIPTION
Atuin pty-proxy acts as a PTY MITM between the terminal and the shell, intercepting all I/O. Agent Deck's Bubble Tea TUI requires direct terminal access for alternate screen mode, mouse tracking, and raw-mode I/O, which all break when stdin/stdout are proxied pipes.

Changes:
- Add IsAtuinPTYProxy() detection function to internal/tmux
- Show stderr warning before TUI init when ATUIN_PTY_PROXY_ACTIVE is set
- Add troubleshooting entry for atuin pty-proxy incompatibility

Closes #1558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup compatibility warning when running the TUI in an unsupported terminal-proxy session.
  * Automatically detects the environment and offers guidance to prevent a blank or broken interface.

* **Bug Fixes**
  * Improved user-facing feedback for terminal setups that can interfere with Bubble Tea rendering.
  * Provides a clear command change to help resolve the issue quickly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->