### PR TITLE
feat(session): add archive/unarchive CLI commands

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1951,6 +1951,8 @@ func handleList(profile string, args []string) {
 			Channels      []string  `json:"channels,omitempty"`
 			ExtraArgs     []string  `json:"extra_args,omitempty"`
 			Color         string    `json:"color,omitempty"` // issue #391
+			Archived      bool      `json:"archived"`
+			ArchivedAt    time.Time `json:"archived_at,omitempty"`
 		}
 		// Warm tmux pane-title cache + load hook statuses so the CLI
 		// reports the same Status the TUI and /api/menu do (issue #610).
@@ -1974,6 +1976,8 @@ func handleList(profile string, args []string) {
 				Channels:      inst.Channels,
 				ExtraArgs:     inst.ExtraArgs,
 				Color:         inst.Color,
+				Archived:      inst.IsArchived(),
+				ArchivedAt:    inst.ArchivedAt,
 			}
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
 				sj.TmuxSession = tmuxSess.Name

--- a/cmd/agent-deck/session_archive_cmd_test.go
+++ b/cmd/agent-deck/session_archive_cmd_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// archivedFlag parses `list --json` and returns the archived flag for the
+// session with the given id. Fails the test if the id is absent.
+func archivedFlag(t *testing.T, home, id string) bool {
+	t.Helper()
+	listJSON := readSessionsJSON(t, home)
+	var sessions []struct {
+		ID       string `json:"id"`
+		Archived bool   `json:"archived"`
+	}
+	if err := json.Unmarshal([]byte(listJSON), &sessions); err != nil {
+		t.Fatalf("parse list --json: %v\njson: %s", err, listJSON)
+	}
+	for _, s := range sessions {
+		if s.ID == id {
+			return s.Archived
+		}
+	}
+	t.Fatalf("session %s not found in list; json:\n%s", id, listJSON)
+	return false
+}
+
+// TestSessionArchive_MarksArchived is the happy path: archiving a stopped
+// session flags it archived without removing it from the registry.
+func TestSessionArchive_MarksArchived(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	workPath := filepath.Join(home, "proj")
+	id := addTestSession(t, home, workPath, "archive-basic")
+
+	if archivedFlag(t, home, id) {
+		t.Fatalf("session %s archived before archive command ran", id)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "archive", id, "--json")
+	if code != 0 {
+		t.Fatalf("session archive failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	if !archivedFlag(t, home, id) {
+		t.Errorf("session %s not archived after archive command", id)
+	}
+}
+
+// TestSessionUnarchive_ClearsArchived confirms unarchive reverses archive.
+func TestSessionUnarchive_ClearsArchived(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	workPath := filepath.Join(home, "proj")
+	id := addTestSession(t, home, workPath, "unarchive-basic")
+
+	if _, stderr, code := runAgentDeck(t, home, "session", "archive", id, "--json"); code != 0 {
+		t.Fatalf("archive setup failed (exit %d): %s", code, stderr)
+	}
+	if !archivedFlag(t, home, id) {
+		t.Fatalf("archive setup did not take effect for %s", id)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "unarchive", id, "--json")
+	if code != 0 {
+		t.Fatalf("session unarchive failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	if archivedFlag(t, home, id) {
+		t.Errorf("session %s still archived after unarchive command", id)
+	}
+}
+
+// TestSessionArchive_NotFound_Exit2 mirrors other resolve-by-id commands:
+// an unknown session id exits 2.
+func TestSessionArchive_NotFound_Exit2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	// Seed one real session so storage exists but the target id is absent.
+	addTestSession(t, home, filepath.Join(home, "proj"), "archive-notfound")
+
+	_, _, code := runAgentDeck(t, home, "session", "archive", "does-not-exist", "--json")
+	if code != 2 {
+		t.Fatalf("expected exit 2 for unknown session, got %d", code)
+	}
+}
+
+// TestSessionUnarchive_NotArchived_Rejected: unarchiving a session that is not
+// archived is an error (mirrors WebMutator.UnarchiveSession).
+func TestSessionUnarchive_NotArchived_Rejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	id := addTestSession(t, home, filepath.Join(home, "proj"), "unarchive-noop")
+
+	_, _, code := runAgentDeck(t, home, "session", "unarchive", id, "--json")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit unarchiving a non-archived session")
+	}
+}
+
+// TestSessionArchive_AlreadyArchived_Rejected: archiving twice is an error so
+// the caller notices the no-op rather than silently re-stamping.
+func TestSessionArchive_AlreadyArchived_Rejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	id := addTestSession(t, home, filepath.Join(home, "proj"), "archive-twice")
+
+	if _, stderr, code := runAgentDeck(t, home, "session", "archive", id, "--json"); code != 0 {
+		t.Fatalf("first archive failed (exit %d): %s", code, stderr)
+	}
+	_, _, code := runAgentDeck(t, home, "session", "archive", id, "--json")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit archiving an already-archived session")
+	}
+}

--- a/cmd/agent-deck/session_archive_cmd_test.go
+++ b/cmd/agent-deck/session_archive_cmd_test.go
@@ -101,8 +101,8 @@ func TestSessionUnarchive_NotArchived_Rejected(t *testing.T) {
 	id := addTestSession(t, home, filepath.Join(home, "proj"), "unarchive-noop")
 
 	_, _, code := runAgentDeck(t, home, "session", "unarchive", id, "--json")
-	if code == 0 {
-		t.Fatalf("expected non-zero exit unarchiving a non-archived session")
+	if code != 1 {
+		t.Fatalf("expected exit 1 (INVALID_OPERATION) unarchiving a non-archived session, got %d", code)
 	}
 }
 
@@ -119,7 +119,35 @@ func TestSessionArchive_AlreadyArchived_Rejected(t *testing.T) {
 		t.Fatalf("first archive failed (exit %d): %s", code, stderr)
 	}
 	_, _, code := runAgentDeck(t, home, "session", "archive", id, "--json")
-	if code == 0 {
-		t.Fatalf("expected non-zero exit archiving an already-archived session")
+	if code != 1 {
+		t.Fatalf("expected exit 1 (INVALID_OPERATION) archiving an already-archived session, got %d", code)
+	}
+}
+
+// A missing <id|title> is a usage error (exit 1), distinct from the NOT_FOUND
+// exit 2 reserved for a genuinely unknown session.
+func TestSessionArchive_MissingArg_Exit1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	addTestSession(t, home, filepath.Join(home, "proj"), "archive-missing-arg")
+
+	_, _, code := runAgentDeck(t, home, "session", "archive", "--json")
+	if code != 1 {
+		t.Fatalf("expected exit 1 for archive with no id, got %d", code)
+	}
+}
+
+func TestSessionUnarchive_MissingArg_Exit1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	addTestSession(t, home, filepath.Join(home, "proj"), "unarchive-missing-arg")
+
+	_, _, code := runAgentDeck(t, home, "session", "unarchive", "--json")
+	if code != 1 {
+		t.Fatalf("expected exit 1 for unarchive with no id, got %d", code)
 	}
 }

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -105,8 +105,8 @@ func printSessionHelp() {
 	fmt.Println("  start <id>              Start a session's tmux process")
 	fmt.Println("  stop <id>               Stop/kill session process")
 	fmt.Println("  remove <id>             Remove session from registry (stopped/error only; --force to bypass)")
-	fmt.Println("  archive <id>            Stop session and hide it from active lists (retained in storage)")
-	fmt.Println("  unarchive <id>          Restore an archived session (does not restart it)")
+	fmt.Println("  archive <id|title>      Stop session and hide it from active lists (retained in storage)")
+	fmt.Println("  unarchive <id|title>    Restore an archived session (does not restart it)")
 	fmt.Println("  restart [id] [--all]    Restart session (Claude: reload MCPs)")
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
 	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
@@ -413,6 +413,17 @@ func handleSessionArchive(profile string, args []string) {
 	quietMode := *quiet || *quietShort
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
+	// An empty identifier is a usage error, not a missing session: exit 1 (not
+	// the ResolveSession NOT_FOUND exit 2, which is reserved for a genuinely
+	// unknown id/title).
+	if identifier == "" {
+		out.Error("session <id|title> required", ErrCodeInvalidOperation)
+		if !*jsonOutput {
+			fs.Usage()
+		}
+		os.Exit(1)
+	}
+
 	storage, instances, _, err := loadSessionData(profile)
 	if err != nil {
 		out.Error(err.Error(), ErrCodeNotFound)
@@ -436,17 +447,26 @@ func handleSessionArchive(profile string, args []string) {
 
 	// Only kill a live tmux session. Killing an already-dead session returns a
 	// fatal error that would abort the archive (see idempotent-Kill history),
-	// so gate on Exists() the way handleSessionStop does.
+	// so gate on Exists() the way handleSessionStop does. Kill() sets
+	// Status=stopped in memory only; persistArchivedCLI persists it below.
+	//
+	// Unlike handleSessionStop we deliberately do NOT SyncSessionIDsFromTmux()
+	// here: archive persists via a targeted UPDATE (to survive concurrent TUI
+	// writers), which cannot carry the whole-row tool-id fields the sync
+	// populates. Late-discovered ids are dropped rather than saved via a
+	// non-targeted write that would reintroduce the archive-clobber race. The
+	// session's normal lifecycle already persists its tool ids.
+	killed := false
 	if inst.Exists() {
-		inst.SyncSessionIDsFromTmux()
 		if err := inst.Kill(); err != nil {
 			out.Error(fmt.Sprintf("failed to stop session: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+		killed = true
 	}
 
 	inst.ArchivedAt = time.Now().UTC()
-	if err := persistArchivedCLI(storage, inst); err != nil {
+	if err := persistArchivedCLI(storage, inst, killed); err != nil {
 		out.Error(fmt.Sprintf("failed to persist archive: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
@@ -484,6 +504,15 @@ func handleSessionUnarchive(profile string, args []string) {
 	quietMode := *quiet || *quietShort
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
+	// Empty identifier is a usage error (exit 1), mirroring archive.
+	if identifier == "" {
+		out.Error("session <id|title> required", ErrCodeInvalidOperation)
+		if !*jsonOutput {
+			fs.Usage()
+		}
+		os.Exit(1)
+	}
+
 	storage, instances, _, err := loadSessionData(profile)
 	if err != nil {
 		out.Error(err.Error(), ErrCodeNotFound)
@@ -505,8 +534,9 @@ func handleSessionUnarchive(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	// unarchive never kills tmux, so there is no post-kill status to persist.
 	inst.ArchivedAt = time.Time{}
-	if err := persistArchivedCLI(storage, inst); err != nil {
+	if err := persistArchivedCLI(storage, inst, false); err != nil {
 		out.Error(fmt.Sprintf("failed to persist unarchive: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
@@ -519,15 +549,28 @@ func handleSessionUnarchive(profile string, args []string) {
 	})
 }
 
-// persistArchivedCLI writes only the archive timestamp via a targeted UPDATE.
-// It deliberately avoids saveSessionData: the full-save path has an
-// external-change guard that aborts and reloads under concurrent writers (a
-// running TUI), which would silently revert the archive. This mirrors
-// home.go's persistArchived.
-func persistArchivedCLI(storage *session.Storage, inst *session.Instance) error {
+// persistArchivedCLI writes the archive timestamp (and, when persistStatus is
+// set, the post-kill Status) via targeted UPDATEs. It deliberately avoids
+// saveSessionData: the full-save path has an external-change guard that aborts
+// and reloads under concurrent writers (a running TUI), which would silently
+// revert the archive. This mirrors home.go's persistArchived.
+//
+// persistStatus is true only when archive killed a live session: Kill() sets
+// Status=stopped in memory but writes nothing to the DB, so without this the
+// row keeps its pre-kill running/idle status and a later load misclassifies the
+// stopped session. PersistInstanceStatusesTx is the same targeted, abort-safe
+// primitive revive uses (single status column, no whole-row clobber).
+func persistArchivedCLI(storage *session.Storage, inst *session.Instance, persistStatus bool) error {
 	db := storage.GetDB()
 	if db == nil {
 		return fmt.Errorf("state database unavailable")
+	}
+	if persistStatus {
+		if err := db.PersistInstanceStatusesTx([]statedb.InstanceStatusUpdate{
+			{ID: inst.ID, Status: string(inst.Status)},
+		}); err != nil {
+			return err
+		}
 	}
 	return db.SetArchived(inst.ID, inst.ArchivedAt)
 }

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -41,6 +41,10 @@ func handleSession(profile string, args []string) {
 		handleSessionStop(profile, args[1:])
 	case "remove":
 		handleSessionRemove(profile, args[1:])
+	case "archive":
+		handleSessionArchive(profile, args[1:])
+	case "unarchive":
+		handleSessionUnarchive(profile, args[1:])
 	case "restart":
 		handleSessionRestart(profile, args[1:])
 	case "revive":
@@ -101,6 +105,8 @@ func printSessionHelp() {
 	fmt.Println("  start <id>              Start a session's tmux process")
 	fmt.Println("  stop <id>               Stop/kill session process")
 	fmt.Println("  remove <id>             Remove session from registry (stopped/error only; --force to bypass)")
+	fmt.Println("  archive <id>            Stop session and hide it from active lists (retained in storage)")
+	fmt.Println("  unarchive <id>          Restore an archived session (does not restart it)")
 	fmt.Println("  restart [id] [--all]    Restart session (Claude: reload MCPs)")
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
 	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
@@ -143,6 +149,8 @@ func printSessionHelp() {
 	fmt.Println("  agent-deck session set-title-lock SCRUM-351 off        # Re-enable title sync")
 	fmt.Println("  agent-deck session output my-project                 # Get last response from session")
 	fmt.Println("  agent-deck session output my-project --json          # Get response as JSON")
+	fmt.Println("  agent-deck session archive my-project                # Stop and hide the session")
+	fmt.Println("  agent-deck session unarchive my-project              # Restore an archived session")
 	fmt.Println()
 	fmt.Println("Set command fields:")
 	fmt.Println("  title              Session title")
@@ -377,6 +385,151 @@ func handleSessionStop(profile string, args []string) {
 		result["drained_title"] = drained.Title
 	}
 	out.Success(fmt.Sprintf("Stopped session: %s", inst.Title), result)
+}
+
+// handleSessionArchive stops a session and marks it archived so it is hidden
+// from active lists but retained in storage. Mirrors the TUI archive action
+// (home.go archiveSession) and WebMutator.ArchiveSession.
+func handleSessionArchive(profile string, args []string) {
+	fs := flag.NewFlagSet("session archive", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session archive <id|title> [options]")
+		fmt.Println()
+		fmt.Println("Stop a session and hide it from active lists (retained in storage).")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	identifier := fs.Arg(0)
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	inst, errMsg, errCode := ResolveSession(identifier, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+		return // unreachable, satisfies staticcheck SA5011
+	}
+
+	if inst.IsArchived() {
+		out.Error(fmt.Sprintf("session '%s' is already archived", inst.Title), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// Only kill a live tmux session. Killing an already-dead session returns a
+	// fatal error that would abort the archive (see idempotent-Kill history),
+	// so gate on Exists() the way handleSessionStop does.
+	if inst.Exists() {
+		inst.SyncSessionIDsFromTmux()
+		if err := inst.Kill(); err != nil {
+			out.Error(fmt.Sprintf("failed to stop session: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	}
+
+	inst.ArchivedAt = time.Now().UTC()
+	if err := persistArchivedCLI(storage, inst); err != nil {
+		out.Error(fmt.Sprintf("failed to persist archive: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	out.Success(fmt.Sprintf("Archived session: %s", inst.Title), map[string]interface{}{
+		"success":  true,
+		"id":       inst.ID,
+		"title":    inst.Title,
+		"archived": true,
+	})
+}
+
+// handleSessionUnarchive clears the archive flag without restarting tmux.
+// Mirrors the TUI unarchiveSession and WebMutator.UnarchiveSession.
+func handleSessionUnarchive(profile string, args []string) {
+	fs := flag.NewFlagSet("session unarchive", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session unarchive <id|title> [options]")
+		fmt.Println()
+		fmt.Println("Restore an archived session (does not restart its process).")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	identifier := fs.Arg(0)
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	inst, errMsg, errCode := ResolveSession(identifier, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+		return // unreachable, satisfies staticcheck SA5011
+	}
+
+	if !inst.IsArchived() {
+		out.Error(fmt.Sprintf("session '%s' is not archived", inst.Title), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	inst.ArchivedAt = time.Time{}
+	if err := persistArchivedCLI(storage, inst); err != nil {
+		out.Error(fmt.Sprintf("failed to persist unarchive: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	out.Success(fmt.Sprintf("Unarchived session: %s", inst.Title), map[string]interface{}{
+		"success":  true,
+		"id":       inst.ID,
+		"title":    inst.Title,
+		"archived": false,
+	})
+}
+
+// persistArchivedCLI writes only the archive timestamp via a targeted UPDATE.
+// It deliberately avoids saveSessionData: the full-save path has an
+// external-change guard that aborts and reloads under concurrent writers (a
+// running TUI), which would silently revert the archive. This mirrors
+// home.go's persistArchived.
+func persistArchivedCLI(storage *session.Storage, inst *session.Instance) error {
+	db := storage.GetDB()
+	if db == nil {
+		return fmt.Errorf("state database unavailable")
+	}
+	return db.SetArchived(inst.ID, inst.ArchivedAt)
 }
 
 // drainGroupQueue starts the oldest queued instance in groupPath when a slot


### PR DESCRIPTION
## What

Adds `agent-deck session archive <id|title>` and `agent-deck session unarchive <id|title>`, bringing the archive action that already exists in the TUI (`A` / `shift+u`) and the headless `WebMutator` to the CLI.

- **archive** — resolves the session, stops its tmux process (only when live, to avoid the known re-archive `Kill` abort), stamps `ArchivedAt = now (UTC)`, and persists.
- **unarchive** — clears `ArchivedAt` and persists. Does **not** restart the process, matching the TUI.

## Persistence

Uses the targeted `statedb.SetArchived` UPDATE rather than the full `saveSessionData` path. This mirrors `home.go`'s `persistArchived`: the full-save path has an external-change guard that aborts and reloads under concurrent writers (a running TUI), which would silently revert the archive.

## Observability

`list --json` now includes `archived` (bool) and `archived_at`, so archive state is scriptable and observable from the CLI (previously there was no CLI way to see it).

## Guards / exit codes

- Archiving an already-archived session → error, exit 1.
- Unarchiving a non-archived session → error, exit 1.
- Unknown session id → exit 2 (consistent with other resolve-by-id commands).

## Tests

New `cmd/agent-deck/session_archive_cmd_test.go` covers the happy path (archive → `archived:true`, unarchive → `archived:false`), unknown-id exit 2, and both guard rejections. All pass; `go vet` clean; verified end-to-end against a built binary.

> Note: `TestWaitForFreshOutput_UniquePeerStillReads` fails in the sandbox on a clean `origin/main` too (tmux output-freshness timeout) — pre-existing and unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `session archive` and `session unarchive` commands.
  * `list --json` now includes whether each session is archived and its `archived_at` timestamp.
* **Bug Fixes**
  * Archive/unarchive now validate targets and return clear errors for unknown sessions, missing ids, and invalid state transitions.
  * Archiving stops any running session and persists the archived timestamp; unarchiving clears it.
* **Tests**
  * Added CLI-style tests covering archive/unarchive behavior, `--json` output, and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->