### PR TITLE
fix(ui): persist group create/rename/move even during a reload window (fixes #1539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Creating, renaming, or moving a group no longer needs two attempts.** The `GroupDialog` create/rename/move handlers persisted via `saveInstances()`, which is skipped while a storage-watcher reload is in flight, so a group mutation landing in that window was silently dropped when the reload rebuilt the group tree from disk — the "create group has to be done twice" bug. These user-initiated group-structure mutations now use `forceSaveInstances()`, matching session creation. ([#1573](https://github.com/asheshgoplani/agent-deck/pull/1573)) (fixes [#1539](https://github.com/asheshgoplani/agent-deck/issues/1539))
+
 ## [1.10.9] - 2026-07-02
 
 ### Fixed

--- a/internal/ui/group_persist_during_reload_test.go
+++ b/internal/ui/group_persist_during_reload_test.go
@@ -64,6 +64,24 @@ func groupPersisted(t *testing.T, storage *session.Storage, name string) bool {
 	return false
 }
 
+// sessionGroupPath reads the persisted GroupPath of a session straight from
+// storage, so a move that only mutated in-memory state (but was skipped by the
+// old saveInstances during a reload) is detectable.
+func sessionGroupPath(t *testing.T, storage *session.Storage, sessionID string) string {
+	t.Helper()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	for _, inst := range instances {
+		if inst.ID == sessionID {
+			return inst.GroupPath
+		}
+	}
+	t.Fatalf("session %q not found in storage", sessionID)
+	return ""
+}
+
 func TestGroupCreatePersistsDuringReload(t *testing.T) {
 	h, storage := testHomeWithStorage(t, "_group_persist_create")
 
@@ -104,5 +122,45 @@ func TestGroupRenamePersistsDuringReload(t *testing.T) {
 	if !groupPersisted(t, storage, "new") {
 		t.Error(`renamed group "new" was not persisted during reload window; ` +
 			`rename must use forceSaveInstances`)
+	}
+}
+
+func TestGroupMovePersistsDuringReload(t *testing.T) {
+	h, storage := testHomeWithStorage(t, "_group_persist_move")
+
+	// Seed a destination group and persist the starting state while NOT reloading.
+	h.groupTree.CreateGroup("dest")
+	h.forceSaveInstances()
+	if !groupPersisted(t, storage, "dest") {
+		t.Fatal("precondition: destination group 'dest' should be persisted")
+	}
+
+	// The move handler acts on the session under the cursor, so build the flat
+	// view and park the cursor on the seed session.
+	seedID := h.instances[0].ID
+	h.rebuildFlatItems()
+	found := false
+	for i, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.ID == seedID {
+			h.cursor = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("precondition: seed session not present in flat items")
+	}
+	if got := sessionGroupPath(t, storage, seedID); got == "dest" {
+		t.Fatalf("precondition: seed session already in 'dest' (got %q)", got)
+	}
+
+	// Move the session into 'dest' during a reload window.
+	h.isReloading = true
+	h.groupDialog.ShowMove([]string{"dest"})
+	h.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if got := sessionGroupPath(t, storage, seedID); got != "dest" {
+		t.Errorf("session GroupPath = %q, want %q; move during a reload window "+
+			"must use forceSaveInstances (saveInstances is skipped while isReloading)", got, "dest")
 	}
 }

--- a/internal/ui/group_persist_during_reload_test.go
+++ b/internal/ui/group_persist_during_reload_test.go
@@ -1,0 +1,108 @@
+package ui
+
+import (
+	"os"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// These tests are the regression guard for the "new main group only works
+// every second try" / "rename group only works every second try" bug.
+//
+// Root cause: GroupDialogCreate/Rename persisted via saveInstances(), which is
+// SKIPPED while isReloading (and aborts on the mtime external-change check). A
+// group mutation that landed during a storage-watcher reload window was written
+// to memory but never to disk, so when the reload rebuilt groupTree from disk
+// the mutation vanished — hence the alternating "every second try". The fix
+// switches these paths to forceSaveInstances(), which persists regardless of
+// the reload flag (mirroring session creation's "was losing groups!" forceSave).
+
+// testHomeWithStorage builds a minimally-wired Home backed by real SQLite
+// storage under an isolated temp HOME, with one seed instance so the
+// empty-overwrite guard in saveInstancesWithForce does not refuse the write.
+func testHomeWithStorage(t *testing.T, profile string) (*Home, *session.Storage) {
+	t.Helper()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		session.ClearUserConfigCache()
+	})
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	seed := session.NewInstance("seed", "/tmp/seed")
+	h := &Home{
+		storage:     storage,
+		profile:     profile,
+		instances:   []*session.Instance{seed},
+		groupTree:   session.NewGroupTree([]*session.Instance{seed}),
+		groupDialog: NewGroupDialog(),
+	}
+	return h, storage
+}
+
+func groupPersisted(t *testing.T, storage *session.Storage, name string) bool {
+	t.Helper()
+	_, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	for _, g := range groups {
+		if g.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGroupCreatePersistsDuringReload(t *testing.T) {
+	h, storage := testHomeWithStorage(t, "_group_persist_create")
+
+	// Simulate a storage-watcher reload in flight — the window in which the old
+	// saveInstances() silently dropped the write.
+	h.isReloading = true
+
+	// Drive the real create flow: create-mode dialog + Enter.
+	h.groupDialog.Show()
+	h.groupDialog.nameInput.SetValue("alpha")
+	h.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !groupPersisted(t, storage, "alpha") {
+		t.Error(`group "alpha" created during a reload window was not persisted; ` +
+			`create must use forceSaveInstances (saveInstances is skipped while isReloading)`)
+	}
+}
+
+func TestGroupRenamePersistsDuringReload(t *testing.T) {
+	h, storage := testHomeWithStorage(t, "_group_persist_rename")
+
+	// Seed and persist a group while NOT reloading.
+	h.groupTree.CreateGroup("old")
+	h.forceSaveInstances()
+	if !groupPersisted(t, storage, "old") {
+		t.Fatal("precondition: seed group 'old' should be persisted")
+	}
+
+	// Now rename it during a reload window.
+	h.isReloading = true
+	h.groupDialog.ShowRename("old", "old")
+	h.groupDialog.nameInput.SetValue("new")
+	h.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if groupPersisted(t, storage, "old") {
+		t.Error(`old group name still present after rename during reload window`)
+	}
+	if !groupPersisted(t, storage, "new") {
+		t.Error(`renamed group "new" was not persisted during reload window; ` +
+			`rename must use forceSaveInstances`)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9619,7 +9619,14 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 				h.rebuildFlatItems()
-				h.saveInstances() // Persist the new group
+				// forceSave, not saveInstances: a save is SKIPPED while
+				// isReloading (and aborts on the mtime external-change check),
+				// so a group created during a storage-watcher reload window is
+				// dropped when the reload rebuilds groupTree from disk — the
+				// "new group only works every second try" bug. Group mutations
+				// are user-initiated and MUST persist, like session creation
+				// (see the "was losing groups!" forceSave in sessionCreatedMsg).
+				h.forceSaveInstances() // Persist the new group
 			}
 		case GroupDialogRename:
 			name := h.groupDialog.GetValue()
@@ -9629,7 +9636,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.instances = h.groupTree.GetAllInstances()
 				h.instancesMu.Unlock()
 				h.rebuildFlatItems()
-				h.saveInstances()
+				h.forceSaveInstances() // MUST persist even during reload (see GroupDialogCreate)
 			}
 		case GroupDialogMove:
 			targetGroupPath := h.groupDialog.GetSelectedGroup()
@@ -9641,7 +9648,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.instances = h.groupTree.GetAllInstances()
 					h.instancesMu.Unlock()
 					h.rebuildFlatItems()
-					h.saveInstances()
+					h.forceSaveInstances() // MUST persist even during reload (see GroupDialogCreate)
 				}
 			}
 		case GroupDialogRenameSession:


### PR DESCRIPTION
## Summary

Creating a root group with `g` (or renaming/moving one) only worked every second try — the group appeared in memory but vanished on the next storage-watcher reload. Fixes #1539.

## Root cause

The `GroupDialogCreate`/`GroupDialogRename`/`GroupDialogMove` handlers persisted via `saveInstances()`, which is a **no-op while `isReloading`** (and also aborts on the mtime external-change check). Every successful save triggers a storage-watcher reload; if the next group mutation lands inside that reload window, its save is silently skipped, and when the reload rebuilds `groupTree` from disk the mutation vanishes. That produces exactly the alternating "works every second try" behavior reported in #1539.

Session creation already uses `forceSaveInstances()` for this exact reason (the `was losing groups!` comment in `sessionCreatedMsg`), and session renames are protected by the `pendingTitleChanges` replay — group-structure mutations had neither.

## Fix

Switch the three group-structure mutations (create, rename, move) to `forceSaveInstances()` so a user-initiated group change persists regardless of the reload flag.

Tradeoff, made deliberately: `forceSaveInstances()` also bypasses the mtime external-change guard, so a group save landing in a reload window could overwrite a concurrent external write. This matches the existing precedent for session creation; if the codebase later moves group mutations to targeted UPDATEs (like the title-persist path), these sites are the candidates.

## Tests

`internal/ui/group_persist_during_reload_test.go` drives the real `handleGroupDialogKey` handler with `isReloading=true` against real SQLite storage under an isolated `$HOME`, and asserts the created/renamed group survives a `LoadWithGroups` round-trip. Both tests fail on `main` and pass with the fix.

```
go test ./internal/ui/ -run 'PersistsDuringReload|GroupDialog' -count=1
ok  	github.com/asheshgoplani/agent-deck/internal/ui	0.162s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group creation, renaming, and moving now reliably save during reloads.
  * Fixed an issue where changes to groups could be lost or only appear after retrying an action.
  * Added regression coverage to ensure group updates remain persisted after reload-related state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->