### PR TITLE
test(title-sync): end-to-end guard for derived-name title clobbering (follow-up to #1545)

### DIFF
--- a/internal/session/claude_title_reconcile_test.go
+++ b/internal/session/claude_title_reconcile_test.go
@@ -260,3 +260,25 @@ func TestReconcileTitleFromClaude_NoopWhenNoName(t *testing.T) {
 		t.Errorf("Title = %q, want unchanged keep-me", inst.Title)
 	}
 }
+
+// TestReconcileTitleFromClaude_NoopWhenDerived: end-to-end guard for the
+// nameSource="derived" rule — a folder-derived Claude name must not overwrite
+// the user's agent-deck title. The derived→"" mapping and the ""→no-op
+// reconcile are each unit-tested above; this pins their composition so a
+// future refactor that resolves the name without going through
+// ClaudeSessionName cannot silently reintroduce the folder-name clobbering.
+func TestReconcileTitleFromClaude_NoopWhenDerived(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	seedClaudeSessionFile(t, home, "1234.json", map[string]any{
+		"sessionId": "sid-rd", "name": "workspace-75", "nameSource": "derived",
+	})
+
+	inst := &Instance{ID: "i-rd", Title: "dev", Tool: "claude"}
+	if name, changed := inst.ReconcileTitleFromClaude("sid-rd"); changed || name != "" {
+		t.Errorf("got (%q,%v), want no-op for derived name", name, changed)
+	}
+	if inst.Title != "dev" {
+		t.Errorf("Title = %q, want unchanged dev", inst.Title)
+	}
+}


### PR DESCRIPTION
## Summary

Test-only follow-up to #1545: adds an end-to-end regression guard asserting that a `nameSource="derived"` Claude name never overwrites the user's agent-deck session title.

## Why

#1545's rule is unit-tested at both links — `ClaudeSessionNameIn` maps a derived name to `""`, and `ReconcileTitleFromClaude` no-ops on an empty name — but the *composition* was unpinned. A future refactor that resolves the name inside `ReconcileTitleFromClaude` without going through `ClaudeSessionName` (e.g. inlining the metadata read, or adding a second name source) could reintroduce the "sessions renamed to folder name" clobbering while every existing test stays green.

`TestReconcileTitleFromClaude_NoopWhenDerived` drives the real reconcile path against a seeded derived-name session file under an isolated `$HOME` and asserts both the return contract (`"", false`) and that `Instance.Title` survives.

No production code changes, no CHANGELOG entry (test-only).

```
go test ./internal/session/ -run ReconcileTitleFromClaude -count=1
ok  	github.com/asheshgoplani/agent-deck/internal/session	0.019s
```
