### PR TITLE
feat(ui): make Sessions/Preview divider draggable with the mouse

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -259,7 +259,7 @@ func (h *HelpOverlay) View() string {
 				{skillsKey, "Skills Manager"},
 				{"$", "Cost Dashboard"},
 				{previewKey, "Toggle preview mode (output/stats/both)"},
-				{"< / >", "Shrink / grow preview pane by 5% (issue #1092)"},
+				{"< / >", "Shrink / grow preview pane by 5% (or drag the divider with the mouse)"},
 				{unreadKey, "Mark unread"},
 				{quickApproveKey, "Quick approve (send '1' to Claude)"},
 				{promptSessionKey, "Prompt session (send a one-line prompt without attaching)"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -469,6 +469,7 @@ type Home struct {
 	// live via < and > keybindings, persisted back to config on adjustment.
 	previewPct          int       // 10-90, default 65
 	previewPctOverlayAt time.Time // when to hide the split overlay (zero = hidden)
+	draggingDivider     bool      // true while the mouse is dragging the Sessions/Preview divider
 
 	// footerMode selects the bottom hint-bar style (config.toml [ui] footer).
 	// One of session.FooterCurated (default), FooterFull, FooterCompact, or
@@ -6992,9 +6993,50 @@ func (h *Home) clickedItemID(index int) string {
 	return ""
 }
 
+// handleDividerDrag processes mouse events for the Sessions/Preview divider
+// resize drag and reports whether it consumed the event. The lifecycle is:
+// left-press on the separator grabs it, motion resizes the split live, and
+// release persists the new ratio. It keys off draggingDivider + msg.Action
+// rather than msg.Button because X10 terminals report a drag release as
+// MouseButtonNone, not MouseButtonLeft.
+func (h *Home) handleDividerDrag(msg tea.MouseMsg) bool {
+	if h.draggingDivider {
+		switch msg.Action {
+		case tea.MouseActionMotion:
+			h.lastUserInputTime = time.Now()
+			h.setPreviewPctFromMouseX(msg.X)
+		case tea.MouseActionRelease:
+			h.draggingDivider = false
+			persistPreviewPct(h.getPreviewPct())
+		}
+		return true
+	}
+
+	// Grab the divider only on a left-press over the separator, dual layout only.
+	if msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress &&
+		h.getLayoutMode() == LayoutModeDual && h.isOnDivider(msg.X) {
+		h.draggingDivider = true
+		h.lastUserInputTime = time.Now()
+		return true
+	}
+	return false
+}
+
 // handleMouse handles mouse events (click to select, double-click to activate)
 func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if h.hasModalVisible() {
+		// A modal opening mid-drag shouldn't leave the divider stuck grabbed.
+		// Treat it as a release so the dragged-to ratio is preserved.
+		if h.draggingDivider {
+			h.draggingDivider = false
+			persistPreviewPct(h.getPreviewPct())
+		}
+		return h, nil
+	}
+
+	// Divider resize drag takes precedence over list selection (the separator
+	// columns sit at x >= sessionsPaneWidth, where list clicks are ignored).
+	if h.handleDividerDrag(msg) {
 		return h, nil
 	}
 
@@ -13124,8 +13166,13 @@ func (h *Home) renderDualColumnLayout(contentHeight int) string {
 	rightContent = ensureExactHeight(rightContent, panelContentHeight)
 	rightPanel := rightTitle + "\n" + rightContent
 
-	// Build separator - must be exactly contentHeight lines
-	separatorStyle := lipgloss.NewStyle().Foreground(ColorBorder)
+	// Build separator - must be exactly contentHeight lines. Brighten it while
+	// the user is dragging it so the resize handle reads as active.
+	separatorColor := ColorBorder
+	if h.draggingDivider {
+		separatorColor = ColorAccent
+	}
+	separatorStyle := lipgloss.NewStyle().Foreground(separatorColor)
 	separatorLines := make([]string, contentHeight)
 	for i := range separatorLines {
 		separatorLines[i] = separatorStyle.Render(" │ ")

--- a/internal/ui/split_config.go
+++ b/internal/ui/split_config.go
@@ -103,6 +103,45 @@ func (h *Home) splitPaneWidths() (int, int) {
 	return left, right
 }
 
+// isOnDivider reports whether column x falls on the " │ " separator drawn
+// between the sessions and preview panes in the dual layout. The separator
+// occupies the paneSeparatorWidth columns immediately to the right of the
+// sessions pane. Used as the grab target for mouse-drag resizing.
+func (h *Home) isOnDivider(x int) bool {
+	left := h.sessionsPaneWidth()
+	return x >= left && x < left+paneSeparatorWidth
+}
+
+// setPreviewPctFromMouseX resizes the split so the divider follows the mouse
+// to column x: the sessions pane spans columns [0, x), the preview pane takes
+// the rest. The result is clamped to [MinPreviewPct, MaxPreviewPct] and the
+// ratio overlay is armed for visual feedback. This updates the in-memory value
+// only — persistence happens once on drag release, not on every motion event.
+func (h *Home) setPreviewPctFromMouseX(x int) {
+	if h.width <= 0 {
+		return
+	}
+	if x < 0 {
+		x = 0
+	}
+	if x > h.width {
+		x = h.width
+	}
+	// Floor x/width to a percent, matching splitPaneWidths' percent->column
+	// truncation. Using the same rounding rule in both directions keeps the
+	// rendered divider tracking the cursor without a systematic 1-column drift.
+	sessionsPct := x * 100 / h.width
+	previewPct := 100 - sessionsPct
+	if previewPct < session.MinPreviewPct {
+		previewPct = session.MinPreviewPct
+	}
+	if previewPct > session.MaxPreviewPct {
+		previewPct = session.MaxPreviewPct
+	}
+	h.previewPct = previewPct
+	h.previewPctOverlayAt = time.Now().Add(previewPctOverlayDuration)
+}
+
 // adjustPreviewPct shifts the preview percentage by delta (in percent
 // points), clamps to [MinPreviewPct, MaxPreviewPct], persists the new
 // value to config.toml, and arms the on-screen overlay.

--- a/internal/ui/split_divider_drag_test.go
+++ b/internal/ui/split_divider_drag_test.go
@@ -4,6 +4,11 @@
 // PREVIEW pane. Grabbing that separator with the left mouse button and dragging
 // resizes the split live; releasing persists the new ratio to config.toml.
 // This complements the existing < / > keybindings (issue #1092).
+//
+// RemoteSession note: divider dragging is a layout-level interaction that does
+// not branch on item types — the grab test and the mouse-column → preview_pct
+// math are purely geometric — so RemoteSession coverage is not applicable here
+// (no t.Skip needed; the code path is item-type-agnostic).
 
 package ui
 

--- a/internal/ui/split_divider_drag_test.go
+++ b/internal/ui/split_divider_drag_test.go
@@ -1,0 +1,189 @@
+// Mouse-draggable Sessions/Preview divider.
+//
+// The dual layout draws a " │ " separator between the SESSIONS list and the
+// PREVIEW pane. Grabbing that separator with the left mouse button and dragging
+// resizes the split live; releasing persists the new ratio to config.toml.
+// This complements the existing < / > keybindings (issue #1092).
+
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func dragTestItems() []session.Item {
+	return []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Title: "S1"}, Level: 0},
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s2", Title: "S2"}, Level: 0},
+	}
+}
+
+func TestIsOnDivider_MatchesSeparatorColumns(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+	// width 100, preview_pct 65 -> sessions pane width 35.
+	// The " │ " separator occupies columns [35, 38).
+	h := newTestHomeWithItems(100, 30, dragTestItems())
+
+	if got := h.sessionsPaneWidth(); got != 35 {
+		t.Fatalf("precondition: sessionsPaneWidth = %d, want 35", got)
+	}
+
+	cases := []struct {
+		x    int
+		want bool
+	}{
+		{34, false}, // last sessions column
+		{35, true},  // separator left space
+		{36, true},  // the │ glyph
+		{37, true},  // separator right space
+		{38, false}, // first preview column
+	}
+	for _, tc := range cases {
+		if got := h.isOnDivider(tc.x); got != tc.want {
+			t.Errorf("isOnDivider(%d) = %v, want %v", tc.x, got, tc.want)
+		}
+	}
+}
+
+func TestSetPreviewPctFromMouseX(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+	h := newTestHomeWithItems(100, 30, dragTestItems())
+
+	cases := []struct {
+		name string
+		x    int
+		want int
+	}{
+		{"middle", 50, 50},        // sessions 50% -> preview 50%
+		{"bias preview", 20, 80},  // sessions 20% -> preview 80%
+		{"bias sessions", 70, 30}, // sessions 70% -> preview 30%
+		{"clamp to max", 2, 90},   // sessions 2% -> preview 98% -> clamp 90
+		{"clamp to min", 98, 10},  // sessions 98% -> preview 2% -> clamp 10
+		{"clamp below zero", -5, 90},
+		{"clamp above width", 200, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h.previewPct = 65
+			h.setPreviewPctFromMouseX(tc.x)
+			if got := h.getPreviewPct(); got != tc.want {
+				t.Errorf("setPreviewPctFromMouseX(%d): previewPct = %d, want %d", tc.x, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDividerDrag_PressMotionRelease_ResizesAndPersists(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+	h := newTestHomeWithItems(100, 30, dragTestItems())
+
+	if h.getPreviewPct() != 65 {
+		t.Fatalf("precondition: previewPct = %d, want 65", h.getPreviewPct())
+	}
+
+	// Press on the divider (│ at column 36) -> starts drag, ratio unchanged.
+	model, _ := h.Update(tea.MouseMsg{X: 36, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	h = model.(*Home)
+	if !h.draggingDivider {
+		t.Fatalf("press on divider did not start a drag")
+	}
+	if h.getPreviewPct() != 65 {
+		t.Fatalf("press alone changed ratio to %d, want unchanged 65", h.getPreviewPct())
+	}
+
+	// Drag left to column 20 -> sessions 20%, preview 80%.
+	model, _ = h.Update(tea.MouseMsg{X: 20, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
+	h = model.(*Home)
+	if h.getPreviewPct() != 80 {
+		t.Fatalf("after drag to x=20: previewPct = %d, want 80", h.getPreviewPct())
+	}
+
+	// Release -> drag ends, ratio persists to config.
+	model, _ = h.Update(tea.MouseMsg{X: 20, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease})
+	h = model.(*Home)
+	if h.draggingDivider {
+		t.Fatalf("release did not end the drag")
+	}
+
+	session.ClearUserConfigCache()
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if cfg.UI.PreviewPct != 80 {
+		t.Fatalf("persisted preview_pct = %d, want 80", cfg.UI.PreviewPct)
+	}
+}
+
+func TestDividerDrag_ReleaseAsMouseButtonNone_EndsDrag(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+	h := newTestHomeWithItems(100, 30, dragTestItems())
+
+	model, _ := h.Update(tea.MouseMsg{X: 36, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	h = model.(*Home)
+	if !h.draggingDivider {
+		t.Fatalf("press on divider did not start a drag")
+	}
+
+	// X10 terminals report a release with MouseButtonNone. The drag must still
+	// end (we key off the drag state + action, not the button).
+	model, _ = h.Update(tea.MouseMsg{X: 30, Y: 5, Button: tea.MouseButtonNone, Action: tea.MouseActionRelease})
+	h = model.(*Home)
+	if h.draggingDivider {
+		t.Fatalf("MouseButtonNone release did not end the drag")
+	}
+}
+
+func TestDividerDrag_ModalMidDrag_EndsDragAndPersists(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+	h := newTestHomeWithItems(100, 30, dragTestItems())
+
+	// Grab and drag to preview 80%.
+	model, _ := h.Update(tea.MouseMsg{X: 36, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	h = model.(*Home)
+	model, _ = h.Update(tea.MouseMsg{X: 20, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
+	h = model.(*Home)
+	if !h.draggingDivider || h.getPreviewPct() != 80 {
+		t.Fatalf("precondition: dragging=%v pct=%d, want dragging=true pct=80", h.draggingDivider, h.getPreviewPct())
+	}
+
+	// A modal appears while the button is still held. The next mouse event is
+	// swallowed by the modal guard, but the drag must not stay stuck grabbed,
+	// and the dragged-to ratio must be preserved (release semantics win).
+	h.helpOverlay.Show()
+	model, _ = h.Update(tea.MouseMsg{X: 25, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionMotion})
+	h = model.(*Home)
+	if h.draggingDivider {
+		t.Fatalf("modal-mid-drag did not clear the drag")
+	}
+
+	session.ClearUserConfigCache()
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if cfg.UI.PreviewPct != 80 {
+		t.Fatalf("modal-mid-drag persisted preview_pct = %d, want 80", cfg.UI.PreviewPct)
+	}
+}
+
+func TestDividerDrag_PressInListStillSelects(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+	h := newTestHomeWithItems(100, 30, dragTestItems())
+	h.cursor = 0
+
+	// Click well inside the sessions list (column 10) on the second row.
+	model, _ := h.Update(tea.MouseMsg{X: 10, Y: 5, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress})
+	h = model.(*Home)
+
+	if h.draggingDivider {
+		t.Fatalf("list click erroneously started a divider drag")
+	}
+	if h.cursor != 1 {
+		t.Fatalf("list click did not select row 1 (cursor = %d)", h.cursor)
+	}
+}


### PR DESCRIPTION
## Summary

Grab the `│` divider between the **SESSIONS** and **PREVIEW** panes with the left mouse button and drag to resize the split live; releasing persists the new ratio to `config.toml`. The divider brightens while dragging. This complements the existing `<` / `>` keybindings from #1092 — same `[ui] preview_pct` setting, same `[10, 90]` bounds.

## How it works

- **Grab** — a left-press on the 3-column separator (dual layout only) starts a drag.
- **Resize** — mouse motion maps the cursor column to `preview_pct` (floored to match `splitPaneWidths` so the divider tracks the cursor), clamped to `[10, 90]`, updated in-memory only.
- **Persist** — on release, the ratio is written to `config.toml` once (not on every motion event).

The lifecycle keys off the drag state + `msg.Action` rather than `msg.Button`, so a release reported as `MouseButtonNone` on X10 terminals still ends the drag. A modal appearing mid-drag is treated as a release (ratio preserved, drag cleared).

## Changes

- `internal/ui/split_config.go` — `isOnDivider(x)` (grab hit-test) and `setPreviewPctFromMouseX(x)` (column → clamped `preview_pct`).
- `internal/ui/home.go` — `draggingDivider` field; `handleDividerDrag` lifecycle helper wired into `handleMouse`; separator highlight while dragging.
- `internal/ui/help.go` — help entry notes the drag affordance.
- `internal/ui/split_divider_drag_test.go` — new tests.

## Test plan

- [x] `go build ./...`, `go vet ./internal/ui/`, `gofmt` — clean
- [x] New unit tests (`-race`): grab → motion → release resizes & persists; bound clamping at both ends; X10 `MouseButtonNone` release ends the drag; modal-interrupt mid-drag preserves ratio & clears drag; list click-select still works (no regression)
- [x] Targeted `-race` sweep across `Divider|Split|Mouse|PreviewPct|Issue1092|Issue1113` — green
- [x] Manual: verified dragging resizes the split live in iTerm2

Note: the full `internal/ui` package suite exceeds Go's default 10-minute test timeout on some machines because it spawns real `tmux` subprocesses in background goroutines — pre-existing and unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resize the Sessions and Preview panes by dragging the divider (or using the keyboard), with the preview percentage updating live.
  * Divider highlight now reflects active resizing.
  * Keyboard shortcut help text updated to mention mouse drag and 5% increments.

* **Bug Fixes**
  * Divider dragging now terminates cleanly when the mouse button is released unexpectedly or when a modal appears mid-drag, ensuring the current ratio is correctly saved.

* **Tests**
  * Added coverage for divider hit-testing, resizing math/clamping, persistence, modal/termination behavior, and selection interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->