### PR TITLE
fix: preserve TitleLocked when re-applying rename after reload race

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4704,6 +4704,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 								slog.String("title", title))
 						}
 						inst.SetAutoName(false) // pending title is a genuine rename; keep the user-chosen name
+						// Mirror SetField(FieldTitle) at mutators.go:147: an explicit
+						// rename is user intent, so re-lock the title. Without this,
+						// ReconcileTitleFromClaude on the next attach sees an unlocked
+						// title and overwrites the rename with the Claude session name.
+						inst.TitleLocked = true
 					}
 				}
 				// Clear pending changes and persist if any were re-applied

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -686,6 +686,55 @@ func TestHomeRenamePendingChangeClearsAutoName(t *testing.T) {
 	}
 }
 
+// TestHomeRenamePendingChangeLocksTitle pins the fix for the "rename lost
+// after attach+detach" regression. The reload-race re-apply at home.go's
+// loadSessionsMsg handler restores Title and clears AutoName but MUST also
+// re-assert TitleLocked=true; otherwise the next attach runs
+// Instance.ReconcileTitleFromClaude against an unlocked title and silently
+// overwrites the user's rename with the Claude session name (issue: rename
+// resets after entering a session and going back).
+func TestHomeRenamePendingChangeLocksTitle(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	inst := session.NewInstance("original-name", "/tmp/project")
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	// User renamed; save was skipped (isReloading) so the rename only lives
+	// in pendingTitleChanges.
+	home.pendingTitleChanges[inst.ID] = "my-chosen-name"
+
+	// Reload replays stale disk state: old title AND TitleLocked=false (the
+	// rename's SetField, which sets TitleLocked, never reached disk).
+	reloadInst := session.NewInstance("original-name", "/tmp/project")
+	reloadInst.ID = inst.ID
+	reloadInst.TitleLocked = false
+
+	reloadMsg := loadSessionsMsg{
+		instances:    []*session.Instance{reloadInst},
+		groups:       nil,
+		restoreState: &reloadState{cursorSessionID: inst.ID},
+	}
+
+	model, _ := home.Update(reloadMsg)
+	h := model.(*Home)
+
+	if h.instances[0].Title != "my-chosen-name" {
+		t.Errorf("Session title = %q, want %q", h.instances[0].Title, "my-chosen-name")
+	}
+	// TitleLocked MUST be re-asserted so ReconcileTitleFromClaude (claude_title_reconcile.go)
+	// treats the rename as user intent and does NOT clobber it on the next attach.
+	if !h.instances[0].TitleLocked {
+		t.Error("TitleLocked = false after pending-rename re-apply, want true (rename must survive attach+detach)")
+	}
+}
+
 func TestHomeRenamePendingChangesNoop(t *testing.T) {
 	home := NewHome()
 	home.width = 100


### PR DESCRIPTION
## Summary

Fixes #1588.

Renamed session titles were silently reverted the next time the user attached to the session and detached back to the list. The user-chosen title was overwritten by the Claude-derived session name.

## Root cause

When a rename's save was skipped due to an in-progress storage reload (`isReloading=true` or external mtime change), the reload-race recovery block in the `loadSessionsMsg` handler re-applied the pending `Title` and cleared `AutoName`, but **did not re-assert `TitleLocked`**. `forceSaveInstances()` then persisted `TitleLocked=false` alongside the restored title.

On the next attach, `attachSession` → `Instance.ReconcileTitleFromClaude` (`internal/session/claude_title_reconcile.go:115`) saw an unlocked title, read Claude's session name from `~/.claude/sessions/*.json`, and overwrote the user's rename. That is the only writer to `i.Title` outside `SetField`, which is why the regression was specifically routed through attach.

Full chain (all file:line cited in #1588):

1. Rename handler routes through `SetField(FieldTitle)` → `mutators.go:147` sets `TitleLocked=true` in-memory.
2. `saveInstances()` (non-force) is skipped because `isReloading` or external mtime change (`home.go:9816`/`9829`).
3. `pendingTitleChanges` is NOT cleared (only cleared on successful save, `home.go:9928`).
4. Next `loadSessionsMsg` replaces `h.instances` from stale disk, then runs the re-apply block at `home.go:4694-4714`.
5. Re-apply restores `Title` (`home.go:4699`) and clears `AutoName` (`home.go:4706`) but not `TitleLocked`.
6. `forceSaveInstances()` (`home.go:4712`) persists `Title=newName` with `TitleLocked=false`.
7. Next attach: `ReconcileTitleFromClaude` (`claude_title_reconcile.go:115-126`) clobbers `Title` with the Claude name.

## Fix

One line added at `internal/ui/home.go:4706`, mirroring `SetField(FieldTitle)` at `mutators.go:147`:

```go
inst.SetAutoName(false)
// Mirror SetField(FieldTitle) at mutators.go:147: an explicit
// rename is user intent, so re-lock the title. Without this,
// ReconcileTitleFromClaude on the next attach sees an unlocked
// title and overwrites the rename with the Claude session name.
inst.TitleLocked = true
```

The primary rename path and the reload-recovery path now apply the same three mutations (`Title`, `AutoName=false`, `TitleLocked=true`), closing the parity gap.

## Test

Adds `TestHomeRenamePendingChangeLocksTitle` next to the existing `TestHomeRenamePendingChangeClearsAutoName`, asserting that after the reload-race re-apply `TitleLocked == true`. Verified:
- **RED before fix**: `TitleLocked = false after pending-rename re-apply, want true`.
- **GREEN after fix**: passes.

All existing rename/fork/title-lock tests continue to pass:
- `TestHomeRenamePendingChangesSurviveReload`
- `TestHomeRenamePendingChangeClearsAutoName`
- `TestHomeRenamePendingChangesNoop`
- `TestHomeRenameSessionWithR` / `TestHomeRenameSessionComplete` / `TestHomeRenameGroupWithR`
- `TestCompleteFork_LockTitleSetsTitleLocked`

## Verification

- `gofmt -l` clean.
- `go vet ./internal/ui/` clean.
- `go build ./...` clean.
- Targeted test run: `ok internal/ui`.

## Scope

Minimal: 1 production line + 1 regression test. No behavior change for sessions that are not in the reload-race window; for those, the primary `SetField` path already set `TitleLocked=true` and the re-apply is a no-op (title already matches, `applied` stays false, no save).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed renamed session titles being overwritten after a reload or reconnect.
  * User-selected titles now remain preserved during subsequent automatic title updates.

* **Tests**
  * Added regression coverage to verify renamed titles and their locked state persist correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->