### PR TITLE
feat: mouse drag-and-drop reorder for sessions within a group

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7014,7 +7014,7 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				return h, nil
 			}
 			itemIndex := h.mouseYToItemIndex(msg.Y)
-			if itemIndex >= 0 && itemIndex < len(h.flatItems) && h.flatItems[itemIndex].Type != session.ItemTypeDivider {
+			if itemIndex >= 0 && itemIndex < len(h.flatItems) && h.flatItems[itemIndex].Type == session.ItemTypeSession && h.flatItems[itemIndex].Session != nil {
 				if itemIndex != h.dragStartIndex {
 					h.dragMovedAway = true
 				}
@@ -7132,18 +7132,33 @@ func (h *Home) performDragMove(startIdx, hoverIdx int, _ string) {
 		return
 	}
 	hoverItem := h.flatItems[hoverIdx]
+	if hoverItem.Type != session.ItemTypeSession || hoverItem.Session == nil {
+		return
+	}
 	if startItem.Session.GroupPath != hoverItem.Session.GroupPath {
 		return
 	}
 
 	sess := startItem.Session
-	diff := hoverIdx - startIdx
-	if diff > 0 {
-		for i := 0; i < diff; i++ {
+	moves := 0
+	if hoverIdx > startIdx {
+		for i := startIdx + 1; i <= hoverIdx; i++ {
+			if h.flatItems[i].Type == session.ItemTypeSession && h.flatItems[i].Session != nil &&
+				h.flatItems[i].Session.ParentSessionID == sess.ParentSessionID {
+				moves++
+			}
+		}
+		for i := 0; i < moves; i++ {
 			h.groupTree.MoveSessionDown(sess)
 		}
 	} else {
-		for i := diff; i < 0; i++ {
+		for i := hoverIdx; i < startIdx; i++ {
+			if h.flatItems[i].Type == session.ItemTypeSession && h.flatItems[i].Session != nil &&
+				h.flatItems[i].Session.ParentSessionID == sess.ParentSessionID {
+				moves++
+			}
+		}
+		for i := 0; i < moves; i++ {
 			h.groupTree.MoveSessionUp(sess)
 		}
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -417,6 +417,12 @@ type Home struct {
 	lastClickIndex  int       // flatItems index of last click (-1 = none)
 	lastClickItemID string    // Session ID or group path at last click (guards against stale index)
 
+	// Mouse drag-drop reorder tracking
+	dragStartIndex  int    // flatItems index where drag began (-1 = idle)
+	dragStartSessID string // stable session ID at drag start
+	dragHoverIndex  int    // flatItems index under cursor during drag (-1 = no hover yet)
+	dragMovedAway   bool   // true once cursor left the start row (distinguishes drag from stationary click)
+
 	// Navigation tracking (PERFORMANCE: suspend background updates during rapid navigation)
 	lastNavigationTime time.Time // When user last navigated (up/down/j/k)
 	isNavigating       bool      // True if user is rapidly navigating
@@ -1147,6 +1153,8 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		pendingTitleChanges:       make(map[string]string),
 		debugMode:                 logging.IsDebugEnabled(),
 		lastClickIndex:            -1,
+		dragStartIndex:            -1,
+		dragHoverIndex:            -1,
 	}
 	h.sessionRenderSnapshot.Store(make(map[string]sessionRenderState))
 
@@ -6992,9 +7000,45 @@ func (h *Home) clickedItemID(index int) string {
 	return ""
 }
 
-// handleMouse handles mouse events (click to select, double-click to activate)
+// handleMouse handles mouse events (click to select, double-click to activate,
+// and drag-and-drop to reorder sessions within a group).
 func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if h.hasModalVisible() {
+		return h, nil
+	}
+
+	// Motion while left button is held: track drag hover position.
+	if msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionMotion {
+		if h.dragStartIndex >= 0 {
+			if h.getLayoutMode() == LayoutModeDual && msg.X >= h.sessionsPaneWidth() {
+				return h, nil
+			}
+			itemIndex := h.mouseYToItemIndex(msg.Y)
+			if itemIndex >= 0 && itemIndex < len(h.flatItems) && h.flatItems[itemIndex].Type != session.ItemTypeDivider {
+				if itemIndex != h.dragStartIndex {
+					h.dragMovedAway = true
+				}
+				h.dragHoverIndex = itemIndex
+			}
+		}
+		return h, nil
+	}
+
+	// On release, commit a drag if one occurred. Non-drag releases are
+	// no-ops (the click was already handled on press).
+	if msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionRelease {
+		startIdx := h.dragStartIndex
+		hoverIdx := h.dragHoverIndex
+		movedAway := h.dragMovedAway
+
+		h.dragStartIndex = -1
+		h.dragStartSessID = ""
+		h.dragHoverIndex = -1
+		h.dragMovedAway = false
+
+		if movedAway && hoverIdx >= 0 && hoverIdx != startIdx {
+			h.performDragMove(startIdx, hoverIdx, "")
+		}
 		return h, nil
 	}
 
@@ -7023,6 +7067,11 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		h.lastUserInputTime = time.Now()
 
+		// Record drag start so Motion/Release can detect a drag.
+		h.dragStartIndex = itemIndex
+		h.dragStartSessID = h.clickedItemID(itemIndex)
+		h.dragMovedAway = false
+
 		// Double-click detection: same item within threshold, verified by stable ID
 		now := time.Now()
 		clickedID := h.clickedItemID(itemIndex)
@@ -7035,6 +7084,7 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		if isDoubleClick {
 			h.lastClickIndex = -1 // Reset to prevent triple-click
+			h.dragStartIndex = -1 // Double-click attach takes priority over drag
 			item := h.flatItems[itemIndex]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
 				if h.hasActiveAnimation(item.Session.ID) {
@@ -7042,7 +7092,7 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 					return h, nil
 				}
 				if item.Session.Exists() {
-					h.isAttaching.Store(true) // Prevent View() output during transition (atomic)
+					h.isAttaching.Store(true)
 					return h, h.attachSession(item.Session)
 				}
 			} else if item.Type == session.ItemTypeGroup {
@@ -7068,6 +7118,38 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return h, nil
+}
+
+// performDragMove moves the session at startIdx in flatItems to hoverIdx by
+// calling MoveSessionUp/Down repeatedly within the same group. Cross-group
+// drags are silently ignored (use M for cross-group moves).
+func (h *Home) performDragMove(startIdx, hoverIdx int, _ string) {
+	if startIdx < 0 || startIdx >= len(h.flatItems) || hoverIdx < 0 || hoverIdx >= len(h.flatItems) {
+		return
+	}
+	startItem := h.flatItems[startIdx]
+	if startItem.Type != session.ItemTypeSession || startItem.Session == nil {
+		return
+	}
+	hoverItem := h.flatItems[hoverIdx]
+	if startItem.Session.GroupPath != hoverItem.Session.GroupPath {
+		return
+	}
+
+	sess := startItem.Session
+	diff := hoverIdx - startIdx
+	if diff > 0 {
+		for i := 0; i < diff; i++ {
+			h.groupTree.MoveSessionDown(sess)
+		}
+	} else {
+		for i := diff; i < 0; i++ {
+			h.groupTree.MoveSessionUp(sess)
+		}
+	}
+	h.rebuildFlatItems()
+	h.moveCursorToSession(sess.ID)
+	h.saveInstances()
 }
 
 // getListContentStartY returns the Y coordinate where list items begin rendering

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2810,6 +2810,49 @@ func TestMouseDoubleClickVerifiesItemIdentity(t *testing.T) {
 	}
 }
 
+// TestMouseDragReorder verifies that performDragMove reorders a session
+// within its group when called after a press→motion→release drag cycle.
+func TestMouseDragReorder(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	inst1 := session.NewInstance("session-1", "/tmp/a")
+	inst2 := session.NewInstance("session-2", "/tmp/b")
+	inst3 := session.NewInstance("session-3", "/tmp/c")
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst1, inst2, inst3}
+	home.instanceByID[inst1.ID] = inst1
+	home.instanceByID[inst2.ID] = inst2
+	home.instanceByID[inst3.ID] = inst3
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	if len(home.flatItems) != 4 {
+		t.Fatalf("expected 4 flat items (group + 3 sessions), got %d", len(home.flatItems))
+	}
+	if home.flatItems[1].Session.ID != inst1.ID || home.flatItems[2].Session.ID != inst2.ID || home.flatItems[3].Session.ID != inst3.ID {
+		t.Fatal("initial session order not as expected")
+	}
+
+	home.performDragMove(1, 3, "")
+
+	if home.flatItems[3].Session.ID != inst1.ID {
+		var ids []string
+		for _, fi := range home.flatItems {
+			if fi.Session != nil {
+				ids = append(ids, fi.Session.ID)
+			}
+		}
+		t.Errorf("after drag, inst1 should be at index 3, got order: %v", ids)
+	}
+	if home.flatItems[1].Session.ID != inst2.ID || home.flatItems[2].Session.ID != inst3.ID {
+		t.Error("other sessions should have shifted up after drag")
+	}
+}
+
 func TestHomeViewAllLayoutModes(t *testing.T) {
 	testCases := []struct {
 		name       string


### PR DESCRIPTION
## Summary

Fixes #1591.

Adds mouse drag-and-drop reorder for sessions within a group. Press left button on a session row, drag it up or down within its group, release to drop it at the new position. The move persists through the existing `saveInstances` path (the `sort_order` column already exists on the `instances` table since the initial schema).

This is a **parallel** surface to the existing keyboard reorder cluster (`K`/`J`/`+`/`-`/`Shift+↑`/`Shift+↓`/`Shift+←`/`Shift+→`). All existing keyboard reorder paths are untouched.

### How it works

1. **Press** left button on a session row → records `dragStartIndex`, `dragStartSessID`. Normal click/double-click behavior proceeds immediately on Press (unchanged from before).
2. **Motion** (button held, cell-motion event from existing `tea.EnableMouseCellMotion`) → if cursor crosses into a different row, sets `dragMovedAway = true` and tracks `dragHoverIndex`.
3. **Release** → if `dragMovedAway` and `dragHoverIndex != dragStartIndex`, calls `performDragMove(startIdx, hoverIdx)` which calls the existing `h.groupTree.MoveSessionUp`/`MoveSessionDown` repeatedly (O(1) per step), then `rebuildFlatItems()` + `moveCursorToSession()` + `saveInstances()`.
4. If no drag occurred (release on same row, or no motion), the Release is a no-op (click was already handled on Press).

### No mouse-capture posture change

Drag uses **cell-motion** events (button-held motion), which are already captured by `tea.EnableMouseCellMotion`. `EnableMouseAllMotion` is **NOT** required. Text-selection posture is unchanged vs status quo — users who disable mouse capture for text selection (the `[tmux] mouse = false` escape from #730) continue unaffected.

### Scope

- Intra-group session reorder only (mirrors what `K`/`J` already do).
- Group headers cannot be dragged — only sessions.
- Cross-group drag out of scope for v1 (use `M` picker).
- No visual feedback yet (insertion caret, dim source row) — followup PR.

### Files

- `internal/ui/home.go`: 4 drag-tracking fields on Home struct + init, Motion handler, Release handler, `performDragMove` helper (~100 LOC).
- `internal/ui/home_test.go`: `TestMouseDragReorder` verifies dragging a session from index 1 to index 3 correctly repositions it within the group.

### Verification

- `gofmt -l` clean.
- `go vet ./internal/ui/` clean.
- `go build ./...` clean.
- All 12 existing mouse tests pass (unchanged behavior: click, double-click, click-in-preview-panel, release-ignored, etc.).
- New `TestMouseDragReorder` passes.

### Risks

- Terminal drag support: cell-motion is supported in iTerm2, Ghostty, Kitty, WezTerm, Alacritty, and tmux (when `set -g mouse on`, which agent-deck already sets).
- Double-click during a rapid click → tiny drag: handled by `dragMovedAway` check — the mouse must actually cross a row boundary for the drag to be committed. A wobbly click on the same row is still treated as a normal click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mouse drag-and-drop support for reordering sessions within the same group.
  - Session order is preserved after changes, and the selected session remains in focus.

- **Bug Fixes**
  - Improved interaction handling so double-click actions take priority over dragging.

- **Tests**
  - Added coverage verifying session reordering and item placement after a drag operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->