### PR TITLE
ci: green main after the upsert-only save merge and the toolchain bump

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ before:
     # avoid requiring tailwindcss in the CI environment.
 
 env:
-  - GOTOOLCHAIN=go1.25.11
+  - GOTOOLCHAIN=go1.25.12
 
 builds:
   - id: agent-deck

--- a/cmd/agent-deck/revive_persist_cli_test.go
+++ b/cmd/agent-deck/revive_persist_cli_test.go
@@ -59,6 +59,9 @@ func stubReviverHealingErrored(t *testing.T) *session.Reviver {
 // Invariant: the concurrently-added session survives, and the errored session
 // is now running.
 func TestReviveCLI_PersistViaTargetedPath_DoesNotClobberConcurrentAdd(t *testing.T) {
+	// Own profile: saves are upsert-only (#1551), so rows written by other
+	// tests in the shared _test profile would leak into this test's snapshot.
+	t.Setenv("AGENTDECK_PROFILE", "_test_revive_clobber")
 	reviveStorage := newReviveCLIStorage(t)
 
 	existing := &session.Instance{
@@ -121,6 +124,9 @@ func TestReviveCLI_PersistViaTargetedPath_DoesNotClobberConcurrentAdd(t *testing
 // REPLACE from revive's stale snapshot would clobber that edit; the targeted
 // status UPDATE must leave it intact.
 func TestReviveCLI_TargetedUpdate_PreservesConcurrentEditToRevivedRow(t *testing.T) {
+	// Own profile: saves are upsert-only (#1551), so rows written by other
+	// tests in the shared _test profile would leak into this test's snapshot.
+	t.Setenv("AGENTDECK_PROFILE", "_test_revive_edit")
 	reviveStorage := newReviveCLIStorage(t)
 
 	existing := &session.Instance{

--- a/internal/tuitest/smoke_test.go
+++ b/internal/tuitest/smoke_test.go
@@ -20,7 +20,7 @@ func skipIfNoTmuxServer(t *testing.T) {
 	}
 }
 
-// buildBinary builds the agent-deck binary into a temp directory with GOTOOLCHAIN=go1.25.11.
+// buildBinary builds the agent-deck binary into a temp directory with GOTOOLCHAIN=go1.25.12.
 // Returns the path to the built binary.
 func buildBinary(t *testing.T) string {
 	t.Helper()
@@ -29,7 +29,7 @@ func buildBinary(t *testing.T) string {
 
 	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/agent-deck")
 	cmd.Dir = repoRoot(t)
-	cmd.Env = append(os.Environ(), "GOTOOLCHAIN=go1.25.11")
+	cmd.Env = append(os.Environ(), "GOTOOLCHAIN=go1.25.12")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Main went red after this morning's merge wave. Two follow-ups:

1. **Revive CLI persist tests: per-test profiles.** Since #1551 made routine saves upsert-only, rows written by earlier tests in the shared `_test` profile leak into these tests' snapshots (`require.Len(snapshot, 1)` saw 3 rows in full-suite runs; both tests pass in isolation). Each test now sets its own `AGENTDECK_PROFILE`, the established pattern in `hook_name_sync_test.go`.

2. **Finish the Go 1.25.12 toolchain bump** (d9b51e59): `.goreleaser.yml` and the tuitest smoke build still pinned `GOTOOLCHAIN=go1.25.11`, which fails now that go.mod requires 1.25.12 (`TestSmoke_BuildVersion`).

Verified locally: full `./cmd/agent-deck` package run is green under a sandboxed HOME.