### PR TITLE
feat(ui): add pin-cycle hotkey with stable selection

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -169,6 +169,7 @@ func (h *HelpOverlay) View() string {
 	reorderUpKeys := "+ / K / Shift+↑"
 	reorderDownKeys := "- / J / Shift+↓"
 	indentKeys := "Shift+→/←"
+	pinKeys := ","
 	searchKey := h.key(hotkeySearch, "/")
 	settingsKey := h.key(hotkeySettings, "S")
 	helpKey := h.key(hotkeyHelp, "?")
@@ -266,6 +267,7 @@ func (h *HelpOverlay) View() string {
 				{reorderUpKeys, "Reorder up (auto-promote at edge)"},
 				{reorderDownKeys, "Reorder down (auto-promote at edge)"},
 				{indentKeys, "Indent / outdent (in group)"},
+				{pinKeys, "Pin (cycle off→top→bottom→off)"},
 				{forkKeys, "Fork session (Claude/Pi)"},
 				{copyKey, "Copy output to clipboard"},
 				{"C", "Copy preview info (Repo / Path / Branch)"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12143,6 +12143,7 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 			h.pendingTitleChanges[inst.ID] = pendingTitle{title: newName, locked: inst.TitleLocked}
 			h.invalidatePreviewCache(inst.ID)
 			h.rebuildFlatItems()
+			h.moveCursorToSession(inst.ID)
 			h.saveInstances()
 			uiLog.Info("title_reconciled_on_attach",
 				slog.String("session_id", inst.ID),

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7846,6 +7846,26 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case ",":
+		// Cycle pin: off → top → bottom → off (pin-sessions #1335).
+		if h.cursor < len(h.flatItems) {
+			item := h.flatItems[h.cursor]
+			if item.Type == session.ItemTypeSession && item.Session != nil {
+				inst := item.Session
+				switch inst.Pin {
+				case session.PinNone:
+					inst.Pin = session.PinTop
+				case session.PinTop:
+					inst.Pin = session.PinBottom
+				case session.PinBottom:
+					inst.Pin = session.PinNone
+				}
+				h.rebuildFlatItems()
+				h.saveInstances()
+			}
+		}
+		return h, nil
+
 	case "p":
 		// Edit multi-repo paths
 		if h.cursor < len(h.flatItems) {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7861,6 +7861,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					inst.Pin = session.PinNone
 				}
 				h.rebuildFlatItems()
+				h.moveCursorToSession(inst.ID)
 				h.saveInstances()
 			}
 		}
@@ -12143,7 +12144,6 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 			h.pendingTitleChanges[inst.ID] = pendingTitle{title: newName, locked: inst.TitleLocked}
 			h.invalidatePreviewCache(inst.ID)
 			h.rebuildFlatItems()
-			h.moveCursorToSession(inst.ID)
 			h.saveInstances()
 			uiLog.Info("title_reconciled_on_attach",
 				slog.String("session_id", inst.ID),

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -493,6 +493,9 @@ func TestHomeRenameSessionComplete(t *testing.T) {
 // pin state PinNone → PinTop → PinBottom → PinNone.  Pin-sessions was
 // shipped in #1335; the hotkey is the TUI surface for quick cycling.
 func TestHomePinCycleHotkey(t *testing.T) {
+	// RemoteSession items are ItemTypeRemoteSession and structurally
+	// cannot reach the pin-cycle path (handler gates on ItemTypeSession
+	// && item.Session != nil). No separate test is required.
 	home := NewHome()
 	home.width = 100
 	home.height = 30

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -500,9 +500,11 @@ func TestHomePinCycleHotkey(t *testing.T) {
 	home.width = 100
 	home.height = 30
 
-	inst := session.NewInstance("test-session", "/tmp/project")
+	other := session.NewInstance("alpha-session", "/tmp/project")
+	inst := session.NewInstance("target-session", "/tmp/project")
 	home.instancesMu.Lock()
-	home.instances = []*session.Instance{inst}
+	home.instances = []*session.Instance{other, inst}
+	home.instanceByID[other.ID] = other
 	home.instanceByID[inst.ID] = inst
 	home.instancesMu.Unlock()
 	home.groupTree = session.NewGroupTree(home.instances)
@@ -510,33 +512,48 @@ func TestHomePinCycleHotkey(t *testing.T) {
 
 	sessionIdx := -1
 	for i, item := range home.flatItems {
-		if item.Type == session.ItemTypeSession {
+		if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.ID == inst.ID {
 			sessionIdx = i
 			break
 		}
 	}
+	if sessionIdx == -1 {
+		t.Fatal("target session missing from flat items")
+	}
 	home.cursor = sessionIdx
+	assertTargetSelected := func(h *Home, step string) {
+		t.Helper()
+		if h.cursor >= len(h.flatItems) || h.flatItems[h.cursor].Session == nil {
+			t.Fatalf("%s: cursor %d does not select a session", step, h.cursor)
+		}
+		if got := h.flatItems[h.cursor].Session.ID; got != inst.ID {
+			t.Fatalf("%s: cursor selects %q, want target %q", step, got, inst.ID)
+		}
+	}
 
 	// Press ',' once: PinNone → PinTop
 	model1, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{','}})
 	h1 := model1.(*Home)
-	if h1.instances[0].Pin != session.PinTop {
-		t.Errorf("after 1st press: pin = %q, want %q", h1.instances[0].Pin, session.PinTop)
+	if inst.Pin != session.PinTop {
+		t.Errorf("after 1st press: pin = %q, want %q", inst.Pin, session.PinTop)
 	}
+	assertTargetSelected(h1, "after 1st press")
 
 	// Press ',' again: PinTop → PinBottom
 	model2, _ := h1.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{','}})
 	h2 := model2.(*Home)
-	if h2.instances[0].Pin != session.PinBottom {
-		t.Errorf("after 2nd press: pin = %q, want %q", h2.instances[0].Pin, session.PinBottom)
+	if inst.Pin != session.PinBottom {
+		t.Errorf("after 2nd press: pin = %q, want %q", inst.Pin, session.PinBottom)
 	}
+	assertTargetSelected(h2, "after 2nd press")
 
 	// Press ',' a third time: PinBottom → PinNone
 	model3, _ := h2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{','}})
 	h3 := model3.(*Home)
-	if h3.instances[0].Pin != session.PinNone {
-		t.Errorf("after 3rd press: pin = %q, want %q", h3.instances[0].Pin, session.PinNone)
+	if inst.Pin != session.PinNone {
+		t.Errorf("after 3rd press: pin = %q, want %q", inst.Pin, session.PinNone)
 	}
+	assertTargetSelected(h3, "after 3rd press")
 }
 
 func TestHomeMoveSessionWithDuplicateGroupNamesUsesSelectedPath(t *testing.T) {

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -489,6 +489,53 @@ func TestHomeRenameSessionComplete(t *testing.T) {
 	}
 }
 
+// TestHomePinCycleHotkey verifies that pressing ',' cycles the session
+// pin state PinNone → PinTop → PinBottom → PinNone.  Pin-sessions was
+// shipped in #1335; the hotkey is the TUI surface for quick cycling.
+func TestHomePinCycleHotkey(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	inst := session.NewInstance("test-session", "/tmp/project")
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	sessionIdx := -1
+	for i, item := range home.flatItems {
+		if item.Type == session.ItemTypeSession {
+			sessionIdx = i
+			break
+		}
+	}
+	home.cursor = sessionIdx
+
+	// Press ',' once: PinNone → PinTop
+	model1, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{','}})
+	h1 := model1.(*Home)
+	if h1.instances[0].Pin != session.PinTop {
+		t.Errorf("after 1st press: pin = %q, want %q", h1.instances[0].Pin, session.PinTop)
+	}
+
+	// Press ',' again: PinTop → PinBottom
+	model2, _ := h1.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{','}})
+	h2 := model2.(*Home)
+	if h2.instances[0].Pin != session.PinBottom {
+		t.Errorf("after 2nd press: pin = %q, want %q", h2.instances[0].Pin, session.PinBottom)
+	}
+
+	// Press ',' a third time: PinBottom → PinNone
+	model3, _ := h2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{','}})
+	h3 := model3.(*Home)
+	if h3.instances[0].Pin != session.PinNone {
+		t.Errorf("after 3rd press: pin = %q, want %q", h3.instances[0].Pin, session.PinNone)
+	}
+}
+
 func TestHomeMoveSessionWithDuplicateGroupNamesUsesSelectedPath(t *testing.T) {
 	home := NewHome()
 	home.width = 100


### PR DESCRIPTION
## Summary

Integrate YoanWai's pin-cycle hotkey from #1592 while fixing the cursor drift found during maintainer validation.

The original two contributor commits are preserved with their authorship. The maintainer follow-up moves `moveCursorToSession` from the unrelated title-reconciliation path into the comma-key pin handler.

## Behavior

Pressing `,` cycles the selected local session through unpinned, top, bottom, and unpinned again. The same session remains selected when rebuilding the flattened list moves it between pin zones.

## Verification

* added a two-session regression test that failed before the cursor repair
* `TestHomePinCycleHotkey` and `TestHomeRenameSessionComplete` pass after the repair
* sandboxed `go build ./...` passes

Closes #1590.
Supersedes #1592 after this integration merges.
