### PR TITLE
test(ui): stop eager Home workers leaking across tests

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1075,6 +1075,10 @@ func NewHomeWithProfile(profile string) *Home {
 	return NewHomeWithProfileAndMode(profile)
 }
 
+// TestMain disables eager workers for unit tests. Production keeps the default
+// so status, log, pipe, and storage updates continue while the TUI is running.
+var homeBackgroundWorkersEnabled = true
+
 // NewHomeWithProfileAndMode creates a new Home with the specified profile.
 // All instances manage the notification bar equally via shared SQLite state.
 func NewHomeWithProfileAndMode(profile string) *Home {
@@ -1103,6 +1107,11 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	actualProfile := session.DefaultProfile
 	if storage != nil {
 		actualProfile = storage.Profile()
+	}
+
+	var statusWorkerDone chan struct{}
+	if homeBackgroundWorkersEnabled {
+		statusWorkerDone = make(chan struct{})
 	}
 
 	h := &Home{
@@ -1161,7 +1170,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		worktreeDirtyCache:        make(map[string]bool),
 		worktreeDirtyCacheTs:      make(map[string]time.Time),
 		statusTrigger:             make(chan statusUpdateRequest, 1), // Buffered to avoid blocking
-		statusWorkerDone:          make(chan struct{}),
+		statusWorkerDone:          statusWorkerDone,
 		idleTimeoutWatcher:        session.NewIdleTimeoutWatcher(session.IdleTimeoutWatcherConfig{}),
 		lastPersistedStatus:       make(map[string]string),
 		lastPersistedAutoNameDesc: make(map[string]string),
@@ -1249,55 +1258,44 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	h.liveSet = newPipeLiveSet(livePipeLRUCapacity)
 
-	// Initialize event-driven status detection
-	// Output callback: invoked when PipeManager detects %output from a session
-	outputCallback := func(sessionName string) {
-		h.instancesMu.RLock()
-		for _, inst := range h.instances {
-			if inst.GetTmuxSession() != nil && inst.GetTmuxSession().Name == sessionName {
-				h.logActivityMu.Lock()
-				lastUpdate := h.lastLogActivity[inst.ID]
-				if time.Since(lastUpdate) < logOutputDebounce {
+	if homeBackgroundWorkersEnabled {
+		// Initialize event-driven status detection. The output callback is invoked
+		// when PipeManager detects output from a session.
+		outputCallback := func(sessionName string) {
+			h.instancesMu.RLock()
+			for _, inst := range h.instances {
+				if inst.GetTmuxSession() != nil && inst.GetTmuxSession().Name == sessionName {
+					h.logActivityMu.Lock()
+					lastUpdate := h.lastLogActivity[inst.ID]
+					if time.Since(lastUpdate) < logOutputDebounce {
+						h.logActivityMu.Unlock()
+						break
+					}
+					h.lastLogActivity[inst.ID] = time.Now()
 					h.logActivityMu.Unlock()
+
+					select {
+					case h.logUpdateChan <- inst:
+					default:
+					}
 					break
 				}
-				h.lastLogActivity[inst.ID] = time.Now()
-				h.logActivityMu.Unlock()
-
-				select {
-				case h.logUpdateChan <- inst:
-				default:
-				}
-				break
 			}
+			h.instancesMu.RUnlock()
 		}
-		h.instancesMu.RUnlock()
+
+		// Control mode pipes provide event-driven, zero-subprocess status detection.
+		pm := tmux.NewPipeManager(h.ctx, outputCallback)
+		pm.SetWindowChangeCallback(func() {
+			tmux.RefreshSessionCache()
+		})
+		tmux.SetPipeManager(pm)
+		pm.SetWantPipe(func(name string) bool { return h.liveSet.want(name) })
+
+		go h.livePipeReconciler()
+		go h.statusWorker()
+		h.startLogWorkers()
 	}
-
-	// Control mode pipes: event-driven, zero-subprocess status detection
-	pm := tmux.NewPipeManager(h.ctx, outputCallback)
-
-	// Window change callback: refresh window cache immediately when tabs are added/closed
-	pm.SetWindowChangeCallback(func() {
-		tmux.RefreshSessionCache()
-	})
-
-	tmux.SetPipeManager(pm)
-
-	// Only the focused / attached / recently-viewed sessions hold a live pipe.
-	pm.SetWantPipe(func(name string) bool { return h.liveSet.want(name) })
-
-	// Live pipes are managed lazily by the reconciler: it connects the focused/
-	// attached session (and a few recent ones) and lets everything else ride the
-	// 2s status poll. This replaces the old "connect every session at startup"
-	// burst that opened ~N pipes at once and triggered attach-storm freezes.
-	go h.livePipeReconciler()
-
-	// Start background status worker (Priority 1C)
-	go h.statusWorker()
-
-	// Start log worker pool (Priority 2)
-	h.startLogWorkers()
 
 	// Initialize global search
 	// DISABLED: Global search opens 884+ directory watchers and loads 4.4 GB of JSONL
@@ -1323,7 +1321,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	// Initialize storage watcher for auto-reload
 	// Polls SQLite metadata for external changes (CLI commands, other instances)
 	// and triggers reload with state preservation
-	if storage != nil {
+	if homeBackgroundWorkersEnabled && storage != nil {
 		watcher, err := NewStorageWatcher(storage.GetDB())
 		if err != nil {
 			uiLog.Warn("storage_watcher_init_failed", slog.String("error", err.Error()))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1334,7 +1334,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	// Hook-based status detection (Claude Code lifecycle hooks)
 	userConfig, _ := session.LoadUserConfig()
 	hooksEnabled := userConfig == nil || userConfig.Claude.GetHooksEnabled()
-	if hooksEnabled {
+	if homeBackgroundWorkersEnabled && hooksEnabled {
 		configDir := session.GetClaudeConfigDir()
 		alreadyInstalled := session.CheckClaudeHooksInstalled(configDir)
 
@@ -1381,7 +1381,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	// No user prompt needed — config.yaml is Hermes's own config file, not a
 	// shared settings file. The shared hook watcher (h.hookWatcher) covers all
 	// tools, so start it here if Claude hooks didn't already start it.
-	if hermesCmd := strings.TrimSpace(session.GetToolCommand("hermes")); hermesCmd != "" {
+	if hermesCmd := strings.TrimSpace(session.GetToolCommand("hermes")); homeBackgroundWorkersEnabled && hermesCmd != "" {
 		// GetToolCommand may return a full command string with arguments
 		// (e.g. "hermes --gateway-url=..."). LookPath needs the binary name only.
 		// Trim first because Fields("") and Fields("   ") both return [], and
@@ -1408,7 +1408,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	}
 
 	// Cursor Agent CLI hooks: auto-inject silently when the cursor binary is available.
-	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); cursorCmd != "" {
+	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); homeBackgroundWorkersEnabled && cursorCmd != "" {
 		if cursorFields := strings.Fields(cursorCmd); len(cursorFields) > 0 {
 			cursorBin := cursorFields[0]
 			if _, err := exec.LookPath(cursorBin); err == nil {

--- a/internal/ui/home_background_workers_test.go
+++ b/internal/ui/home_background_workers_test.go
@@ -1,0 +1,24 @@
+package ui
+
+import "testing"
+
+func TestNewHomeDoesNotStartBackgroundWorkersInTests(t *testing.T) {
+	if homeBackgroundWorkersEnabled {
+		t.Fatal("TestMain must disable Home background workers")
+	}
+
+	home := NewHome()
+	t.Cleanup(func() {
+		home.cancel()
+		if home.storage != nil {
+			_ = home.storage.Close()
+		}
+	})
+
+	if home.statusWorkerDone != nil {
+		t.Fatal("status worker channel is active in test mode")
+	}
+	if home.storageWatcher != nil {
+		t.Fatal("storage watcher started in test mode")
+	}
+}

--- a/internal/ui/home_background_workers_test.go
+++ b/internal/ui/home_background_workers_test.go
@@ -1,14 +1,26 @@
 package ui
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
 
 func TestNewHomeDoesNotStartBackgroundWorkersInTests(t *testing.T) {
 	if homeBackgroundWorkersEnabled {
 		t.Fatal("TestMain must disable Home background workers")
 	}
+	claudeConfigDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeConfigDir)
+	if _, err := session.InjectClaudeHooks(claudeConfigDir); err != nil {
+		t.Fatalf("install test Claude hooks: %v", err)
+	}
 
 	home := NewHome()
 	t.Cleanup(func() {
+		if home.hookWatcher != nil {
+			home.hookWatcher.Stop()
+		}
 		home.cancel()
 		if home.storage != nil {
 			_ = home.storage.Close()
@@ -20,5 +32,8 @@ func TestNewHomeDoesNotStartBackgroundWorkersInTests(t *testing.T) {
 	}
 	if home.storageWatcher != nil {
 		t.Fatal("storage watcher started in test mode")
+	}
+	if home.hookWatcher != nil {
+		t.Fatal("hook watcher started in test mode")
 	}
 }

--- a/internal/ui/testmain_test.go
+++ b/internal/ui/testmain_test.go
@@ -48,6 +48,10 @@ func runTestMain(m *testing.M) int {
 
 	// Force _test profile for all tests in this package
 	os.Setenv("AGENTDECK_PROFILE", "_test")
+	// Unit tests construct hundreds of Home models for synchronous behavior
+	// checks. Their production workers are unrelated to those assertions and
+	// must not outlive each test.
+	homeBackgroundWorkersEnabled = false
 
 	// v1.7.38: stub syncOptOutToConfig to a no-op by default so feedback
 	// dialog tests that exercise stepRating 'n' / stepConfirm decline do
@@ -89,15 +93,12 @@ func cleanupTestSessions() {
 // armOrphanWatchdog installs an independent, os.Exit-based deadline that
 // guarantees this test binary terminates, and returns a func that disarms it.
 //
-// Why -test.timeout is not enough: this package starts background workers
-// eagerly in NewHomeWithProfileAndMode (statusWorker, the logWorker pool, and
-// StorageWatcher.pollLoop) and most tests never tear them down, so a full run
-// leaks hundreds of busy worker goroutines. When -test.timeout fires it panics
-// and dumps every goroutine stack under a stop-the-world; a heap of runnable
-// leaked workers can wedge that STW so the dump never completes and the process
-// lives on, pinning a CPU core. On 2026-06-21 seven such `ui.test` binaries —
-// reparented to PID 1 after their `go test` parent was interrupted — spun at
-// ~100% CPU for over two days and overheated the machine.
+// Why -test.timeout is not enough: before TestMain disabled Home's production
+// workers, every model started statusWorker, the log-worker pool, and
+// StorageWatcher.pollLoop, while most tests never tore them down. A timed-out
+// run then tried to dump hundreds of thousands of goroutine stacks and could
+// wedge before exiting. The worker gate prevents that leak; this watchdog stays
+// as a backstop for explicit worker tests and any future lifecycle regression.
 //
 // os.Exit performs no stop-the-world and terminates immediately, so it is the
 // only reliable backstop. The watchdog is armed for -test.timeout + grace, so


### PR DESCRIPTION
## Summary

Stop `internal/ui` unit tests from starting production Home background workers that outlive the test which created them.

Each `NewHome()` previously started a status worker, two log workers, a live-pipe reconciler, a global PipeManager, and a storage watcher. Hundreds of synchronous UI tests construct Home models without running the production shutdown path, so the package accumulated hundreds of thousands of goroutines and tmux subprocesses. Unrelated PRs then hit the exact 3-minute package timeout with whichever test happened to start last.

## Changes

* keep production behavior unchanged through a default-enabled worker gate
* disable eager Home workers in the UI package TestMain
* leave synchronous status and rendering methods available to unit tests
* avoid creating a status-worker completion channel or storage watcher in test mode
* update the watchdog postmortem comment to describe the preventative gate
* add a regression test for the TestMain worker lifecycle

## Verification

* red test first: the new lifecycle test did not compile before the worker gate existed
* exact UI Eval smoke package command with `-race`, `eval_smoke`, and the original 3-minute timeout passes in 32.7 seconds
* rerun after current main merge passes in 31.4 seconds
* sandboxed `go build ./...` passes

This repairs the shared timeout seen in unrelated #1560 and #1565 runs:

* https://github.com/asheshgoplani/agent-deck/actions/runs/29202351190
* https://github.com/asheshgoplani/agent-deck/actions/runs/29203548506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by preventing background workers and automatic storage reload watchers from starting during tests.
  * Reduced the risk of leaked goroutines and related test failures.

* **Tests**
  * Added coverage to verify background services remain inactive in test mode.
  * Updated test watchdog documentation for clearer timeout and goroutine failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->