### PR TITLE
perf(ui): keep tmux liveness probes off the bubbletea goroutine (multi-second TUI freezes)

### DIFF
--- a/internal/tmux/exists_cached_test.go
+++ b/internal/tmux/exists_cached_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -102,6 +103,33 @@ func primeSessionCache(names ...string) {
 	sessionCacheData = m
 	sessionCacheTime = time.Now()
 	sessionCacheMu.Unlock()
+}
+
+func TestIsEmptyTmuxServerResult_ClassifiesOnlyExpectedTmuxErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{name: "no server", stderr: "no server running on /tmp/tmux.sock", want: true},
+		{name: "no sessions", stderr: "no sessions", want: true},
+		{name: "unexpected failure", stderr: "permission denied", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("sh", "-c", "printf '%s' \"$1\" >&2; exit 1", "sh", tt.stderr)
+			_, err := cmd.Output()
+			if err == nil {
+				t.Fatal("fixture command unexpectedly succeeded")
+			}
+			if got := isEmptyTmuxServerResult(err); got != tt.want {
+				t.Fatalf("isEmptyTmuxServerResult() = %v, want %v for stderr %q", got, tt.want, tt.stderr)
+			}
+		})
+	}
 }
 
 // A fresh positive cache hit on the default socket means the session is live.

--- a/internal/tmux/exists_cached_test.go
+++ b/internal/tmux/exists_cached_test.go
@@ -1,0 +1,255 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ExistsCached() is the cheap liveness check used by hot periodic loops (the
+// background configure loop and theme propagation). It must answer ONLY from
+// in-process state — a positive session-cache hit on the session's own socket
+// or a live pipe — and NEVER spawn a `tmux has-session` subprocess. That
+// subprocess, multiplied over ~1000 sessions per tick, is the exact main-loop
+// storm the nav-freeze fix eliminated. These cases pin the contract.
+
+func withCleanSessionCache(t *testing.T) {
+	t.Helper()
+	origLister := listSessionsOnSocket
+	t.Cleanup(func() {
+		SetDefaultSocketName("")
+		sessionCacheMu.Lock()
+		sessionCacheData = nil
+		sessionCacheTime = time.Time{}
+		sessionCacheMu.Unlock()
+		// Drain any in-flight background refresh before swapping the lister
+		// back, or a goroutine from this test writes into the next test's cache.
+		drainSocketRefreshes(t)
+		listSessionsOnSocket = origLister
+		ResetSocketSessionCacheForTest()
+	})
+	SetDefaultSocketName("")
+	drainSocketRefreshes(t)
+	ResetSocketSessionCacheForTest()
+	// Default: no isolated socket has any session, and never touch real tmux.
+	listSessionsOnSocket = func(string) (map[string]struct{}, error) {
+		return map[string]struct{}{}, nil
+	}
+}
+
+// stubSocketSessions makes the per-socket lister return a fixed live set and
+// signals (via the returned channel) each time it is invoked, so tests can wait
+// for the asynchronous stale-while-revalidate refresh to land.
+func stubSocketSessions(t *testing.T, names map[string][]string) <-chan string {
+	t.Helper()
+	calls := make(chan string, 16)
+	listSessionsOnSocket = func(socket string) (map[string]struct{}, error) {
+		set := map[string]struct{}{}
+		for _, n := range names[socket] {
+			set[n] = struct{}{}
+		}
+		select {
+		case calls <- socket:
+		default:
+		}
+		return set, nil
+	}
+	return calls
+}
+
+// drainSocketRefreshes blocks until no per-socket refresh goroutine is in
+// flight, so one test's background probe cannot land in the next test's cache.
+func drainSocketRefreshes(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		socketSessionCacheMu.Lock()
+		inFlight := false
+		for _, e := range socketSessionCache {
+			if e.refreshing {
+				inFlight = true
+				break
+			}
+		}
+		socketSessionCacheMu.Unlock()
+		if !inFlight {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out draining in-flight per-socket refreshes")
+}
+
+// waitForSocketCache polls cond until true or the deadline elapses.
+func waitForSocketCache(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+func primeSessionCache(names ...string) {
+	sessionCacheMu.Lock()
+	m := make(map[string]int64, len(names))
+	for _, n := range names {
+		m[n] = time.Now().Unix()
+	}
+	sessionCacheData = m
+	sessionCacheTime = time.Now()
+	sessionCacheMu.Unlock()
+}
+
+// A fresh positive cache hit on the default socket means the session is live.
+func TestExistsCached_PositiveDefaultSocketHit(t *testing.T) {
+	withCleanSessionCache(t)
+	primeSessionCache("cached-foo")
+
+	s := &Session{Name: "cached-foo"} // SocketName == "" == default
+	if !s.ExistsCached() {
+		t.Fatalf("ExistsCached() must return true for a fresh positive cache hit on the default socket")
+	}
+}
+
+// A cache miss (session absent from a fresh cache) must return false WITHOUT
+// probing — the deliberate under-report that keeps the periodic loops cheap.
+func TestExistsCached_MissReturnsFalseNoProbe(t *testing.T) {
+	withCleanSessionCache(t)
+	primeSessionCache("someone-else")
+
+	s := &Session{Name: "not-in-cache"}
+	// If this ever fell through to a has-session subprocess it would hang/slow;
+	// the cache-only contract guarantees an immediate false.
+	done := make(chan bool, 1)
+	go func() { done <- s.ExistsCached() }()
+	select {
+	case got := <-done:
+		if got {
+			t.Fatalf("ExistsCached() must return false on a cache miss")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("ExistsCached() blocked on a cache miss — it must never subprocess-probe")
+	}
+}
+
+// A stale/empty cache is not evidence of anything; return false, never probe.
+func TestExistsCached_StaleCacheReturnsFalse(t *testing.T) {
+	withCleanSessionCache(t)
+	sessionCacheMu.Lock()
+	sessionCacheData = map[string]int64{"cached-foo": time.Now().Unix()}
+	sessionCacheTime = time.Now().Add(-1 * time.Hour) // past TTL
+	sessionCacheMu.Unlock()
+
+	s := &Session{Name: "cached-foo"}
+	if s.ExistsCached() {
+		t.Fatalf("ExistsCached() must return false when the cache is stale")
+	}
+}
+
+// Socket guard (#755 / multi-socket aliasing): a same-named entry on the
+// default-socket cache is not evidence a session on a DIFFERENT socket exists.
+// ExistsCached must ignore the cache for a non-default socket and, when that
+// socket genuinely has no such session, return false — without a subprocess on
+// the calling goroutine.
+func TestExistsCached_NonDefaultSocketIgnoresDefaultCache(t *testing.T) {
+	withCleanSessionCache(t)
+	primeSessionCache("iso-foo")
+	stubSocketSessions(t, nil) // isolated socket has no sessions
+
+	s := &Session{Name: "iso-foo", SocketName: "agent-deck-iso-not-real"}
+	if s.ExistsCached() {
+		t.Fatalf("ExistsCached() trusted the default-socket cache for a session on socket %q — "+
+			"a same-named default-socket entry is not evidence of a session on another socket", s.SocketName)
+	}
+}
+
+// Regression: a LIVE session on an isolated socket must eventually read true.
+// Before the per-socket cache, ExistsCached() had no source of truth for such a
+// session (the default cache is off-limits per #755, and PipeManager only
+// connects wanted sessions), so it returned false on EVERY tick forever —
+// silently starving those sessions of EnsureConfigured and theme propagation.
+func TestExistsCached_LiveSessionOnIsolatedSocketBecomesTrue(t *testing.T) {
+	withCleanSessionCache(t)
+	stubSocketSessions(t, map[string][]string{"iso-sock": {"iso-live"}})
+
+	s := &Session{Name: "iso-live", SocketName: "iso-sock"}
+
+	// Cold cache: the first call under-reports (false) but kicks a background
+	// refresh. It must not block on the probe.
+	done := make(chan bool, 1)
+	go func() { done <- s.ExistsCached() }()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("ExistsCached() blocked on a cold isolated-socket cache — it must never probe inline")
+	}
+
+	// Once the background refresh lands, the live session reads true and STAYS
+	// true. A permanent false here is the bug this test pins.
+	waitForSocketCache(t, s.ExistsCached, "live isolated-socket session to be seen after background refresh")
+	if !s.ExistsCached() {
+		t.Fatalf("ExistsCached() must stay true for a live session on an isolated socket")
+	}
+}
+
+// A dead session on an isolated socket stays false even after the cache warms.
+func TestExistsCached_DeadSessionOnIsolatedSocketStaysFalse(t *testing.T) {
+	withCleanSessionCache(t)
+	calls := stubSocketSessions(t, map[string][]string{"iso-sock": {"some-other-session"}})
+
+	s := &Session{Name: "iso-gone", SocketName: "iso-sock"}
+	_ = s.ExistsCached() // kick the refresh
+
+	select {
+	case <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("background per-socket refresh never ran")
+	}
+	waitForSocketCache(t, func() bool {
+		socketSessionCacheMu.Lock()
+		defer socketSessionCacheMu.Unlock()
+		e, ok := socketSessionCache["iso-sock"]
+		return ok && e.warm
+	}, "per-socket cache to warm")
+
+	if s.ExistsCached() {
+		t.Fatalf("ExistsCached() must stay false for a session absent from its own socket")
+	}
+}
+
+// An indeterminate probe (timeout) must not flap a previously-live session to
+// false: the last known name set is retained.
+func TestExistsCached_IndeterminateProbeKeepsLastKnownSet(t *testing.T) {
+	withCleanSessionCache(t)
+	stubSocketSessions(t, map[string][]string{"iso-sock": {"iso-live"}})
+
+	s := &Session{Name: "iso-live", SocketName: "iso-sock"}
+	_ = s.ExistsCached()
+	waitForSocketCache(t, s.ExistsCached, "initial warm cache showing the live session")
+
+	// Now every probe fails. Force the entry stale so the next read re-probes.
+	listSessionsOnSocket = func(string) (map[string]struct{}, error) {
+		return nil, context.DeadlineExceeded
+	}
+	socketSessionCacheMu.Lock()
+	socketSessionCache["iso-sock"].refreshedAt = time.Now().Add(-1 * time.Hour)
+	socketSessionCacheMu.Unlock()
+
+	if !s.ExistsCached() {
+		t.Fatalf("a stale entry must still answer from the last known set, not false")
+	}
+	// Let the failing refresh land; the previous set must survive it.
+	waitForSocketCache(t, func() bool {
+		socketSessionCacheMu.Lock()
+		defer socketSessionCacheMu.Unlock()
+		return !socketSessionCache["iso-sock"].refreshing
+	}, "failing refresh to complete")
+
+	if !s.ExistsCached() {
+		t.Fatalf("an indeterminate probe must retain the last known set, not report the session gone")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -427,7 +427,10 @@ func defaultListSessionsOnSocket(socketName string) (map[string]struct{}, error)
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, ctx.Err()
 		}
-		return map[string]struct{}{}, nil
+		if isEmptyTmuxServerResult(err) {
+			return map[string]struct{}{}, nil
+		}
+		return nil, err
 	}
 
 	names := map[string]struct{}{}
@@ -437,6 +440,18 @@ func defaultListSessionsOnSocket(socketName string) (map[string]struct{}, error)
 		}
 	}
 	return names, nil
+}
+
+// isEmptyTmuxServerResult distinguishes tmux's expected empty-server exits
+// from launch, permission, and other probe failures. exec.Cmd.Output stores
+// the command's stderr on ExitError; err.Error() alone does not include it.
+func isEmptyTmuxServerResult(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	stderr := strings.ToLower(string(exitErr.Stderr))
+	return strings.Contains(stderr, "no server running") || strings.Contains(stderr, "no sessions")
 }
 
 // sessionExistsOnSocketCached answers "is <name> live on <socketName>?" from

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -363,6 +363,140 @@ func HasSessionOnSocket(socketName, name string) bool {
 	return tmuxSessionExistsOnSocket(socketName, name)
 }
 
+// Per-socket session cache — backs ExistsCached() for sessions that live on an
+// ISOLATED socket (SocketName != DefaultSocketName()).
+//
+// The shared sessionCache above describes DefaultSocketName() only, and #755
+// forbids answering an isolated-socket session from it (a same-named entry is a
+// different session). PipeManager only holds control connections for wanted
+// (focused/attached) sessions. So without this cache, ExistsCached() had no
+// source of truth at all for an isolated-socket session and returned false on
+// every tick forever — silently starving those sessions of EnsureConfigured /
+// SyncSessionIDsToTmux and of COLORFGBG theme propagation.
+//
+// Refresh is stale-while-revalidate and keyed by SOCKET: one `list-sessions`
+// subprocess per distinct socket per TTL, spawned on a background goroutine.
+// Readers never block and never spawn — preserving the invariant that made
+// ExistsCached() safe for loops that walk every session each tick. Socket count
+// is O(1)-ish (a handful), never O(sessions), so this cannot recreate the
+// subprocess storm.
+const socketSessionCacheTTL = 5 * time.Second
+
+type socketSessionsEntry struct {
+	names       map[string]struct{}
+	refreshedAt time.Time
+	refreshing  bool
+	warm        bool // a probe has completed at least once (success or failure)
+}
+
+var (
+	socketSessionCacheMu sync.Mutex
+	socketSessionCache   = map[string]*socketSessionsEntry{}
+
+	// listSessionsOnSocket is a package var so tests can exercise the cache
+	// without a live tmux server.
+	listSessionsOnSocket = defaultListSessionsOnSocket
+)
+
+// ListSessionNamesOnSocket returns the set of live session names on one tmux
+// socket using a SINGLE bounded `list-sessions`. It is the socket-complete
+// alternative to probing each session with `has-session`: callers that need
+// liveness for N sessions should group them by socket and call this once per
+// distinct socket (O(sockets) subprocesses instead of O(sessions)).
+//
+// An error means the probe was indeterminate (timed out). Callers MUST treat
+// that as "assume alive" — never as "no sessions" — or a briefly-wedged server
+// will look like a pile of dead sessions. A successful probe returning an empty
+// set is authoritative (server present, no sessions / no server running).
+func ListSessionNamesOnSocket(socketName string) (map[string]struct{}, error) {
+	return listSessionsOnSocket(socketName)
+}
+
+// defaultListSessionsOnSocket returns the set of session names on the given
+// tmux socket via a single bounded `list-sessions`. A server with no sessions
+// (or no server at all) is an empty set, not an error.
+func defaultListSessionsOnSocket(socketName string) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+
+	out, err := tmuxExecContext(ctx, socketName, "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		// "no server running" / "no sessions" are legitimate empty results; any
+		// other failure (timeout, exec error) is reported so the caller keeps
+		// the previous entry instead of flapping every session to "gone".
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, ctx.Err()
+		}
+		return map[string]struct{}{}, nil
+	}
+
+	names := map[string]struct{}{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names[line] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+// sessionExistsOnSocketCached answers "is <name> live on <socketName>?" from
+// the per-socket cache, never blocking. On a cold or stale entry it kicks a
+// single background refresh for that socket (at most one in flight per socket)
+// and answers from whatever it currently knows: false when cold.
+func sessionExistsOnSocketCached(socketName, name string) bool {
+	socket := strings.TrimSpace(socketName)
+
+	socketSessionCacheMu.Lock()
+	defer socketSessionCacheMu.Unlock()
+
+	entry, ok := socketSessionCache[socket]
+	if !ok {
+		entry = &socketSessionsEntry{names: map[string]struct{}{}}
+		socketSessionCache[socket] = entry
+	}
+
+	stale := !entry.warm || time.Since(entry.refreshedAt) > socketSessionCacheTTL
+	if stale && !entry.refreshing {
+		entry.refreshing = true
+		// Snapshot the lister under the lock: the background goroutine must not
+		// read the package var concurrently with a test swapping it.
+		go refreshSocketSessionCache(socket, listSessionsOnSocket)
+	}
+
+	_, exists := entry.names[name]
+	return exists
+}
+
+// refreshSocketSessionCache re-lists one socket off the caller's goroutine and
+// replaces its entry. A probe error (timeout) leaves the previous name set in
+// place so a briefly-wedged server does not flap every session to "not found";
+// a successful probe is authoritative, including an empty result.
+func refreshSocketSessionCache(socket string, list func(string) (map[string]struct{}, error)) {
+	names, err := list(socket)
+
+	socketSessionCacheMu.Lock()
+	defer socketSessionCacheMu.Unlock()
+
+	entry, ok := socketSessionCache[socket]
+	if !ok {
+		entry = &socketSessionsEntry{names: map[string]struct{}{}}
+		socketSessionCache[socket] = entry
+	}
+	entry.refreshing = false
+	entry.refreshedAt = time.Now()
+	entry.warm = true
+	if err == nil {
+		entry.names = names
+	}
+}
+
+// ResetSocketSessionCacheForTest clears the per-socket cache between tests.
+func ResetSocketSessionCacheForTest() {
+	socketSessionCacheMu.Lock()
+	defer socketSessionCacheMu.Unlock()
+	socketSessionCache = map[string]*socketSessionsEntry{}
+}
+
 // sessionExistsFromCache checks if a session exists using the cached data
 // Returns (exists, cacheValid) - if cache is stale/empty, cacheValid is false
 func sessionExistsFromCache(name string) (bool, bool) {
@@ -2178,6 +2312,48 @@ func (s *Session) Exists() bool {
 		return true // probe timed out: indeterminate, assume still alive
 	}
 	return err == nil
+}
+
+// ExistsCached is a cheap, non-blocking liveness check for hot periodic loops
+// that iterate over ALL sessions every tick (e.g. the background configure loop
+// and theme propagation). It NEVER spawns a subprocess on the calling
+// goroutine: a single wedged/absent server multiplied by ~1000 sessions is the
+// exact subprocess-storm that froze the UI main goroutine 4–7s per tick (see
+// the nav-freeze fix). It answers only from in-process state:
+//
+//   - a POSITIVE session-cache hit on the session's OWN socket, or
+//   - a live PipeManager control connection, or
+//   - a POSITIVE hit in the per-socket cache (isolated sockets).
+//
+// The socket guard mirrors Exists(): the shared sessionCache describes
+// DefaultSocketName() only, so a same-named entry on a different socket is not
+// this session (#755 / multi-socket cache aliasing). Sessions on an isolated
+// socket are therefore answered from a SEPARATE per-socket cache, refreshed in
+// the background by one `list-sessions` per socket per TTL. Without it those
+// sessions would read false FOREVER (never in the default cache; PipeManager
+// only connects wanted/attached sessions), permanently starving them of
+// EnsureConfigured and theme propagation — a bug the "retries next tick"
+// framing hid. Bounding the refresh by SOCKET count, not session count, keeps
+// the no-storm invariant that motivated this method.
+//
+// A false is still a deliberate under-report (cold cache, dead server, probe
+// failure): the only cost is that a cosmetic loop skips this session until the
+// cache warms. Callers MUST NOT feed ExistsCached() into destructive/restart
+// machinery — use Exists() (which confirms a negative with a real probe).
+func (s *Session) ExistsCached() bool {
+	if strings.TrimSpace(s.SocketName) == DefaultSocketName() {
+		if exists, cacheValid := sessionExistsFromCache(s.Name); cacheValid && exists {
+			return true
+		}
+	} else if sessionExistsOnSocketCached(s.SocketName, s.Name) {
+		return true
+	}
+	if pm := GetPipeManager(); pm != nil {
+		if pm.IsConnected(s.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsPaneDead returns true if the session's pane process has exited.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6221,7 +6221,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if !t.ts.Exists() {
 							return
 						}
-						_ = pm.Connect(t.ts.Name, t.socket)
+						if err := pm.Connect(t.ts.Name, t.socket); err != nil {
+							uiLog.Debug("pipe_reconnect_failed",
+								slog.String("session", t.ts.Name),
+								slog.String("socket", t.socket),
+								slog.String("error", err.Error()))
+						}
 					})
 				}
 			}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2787,7 +2787,13 @@ func (h *Home) propagateThemeToSessions() {
 
 	safego.Go(uiLog, "apply_theme_to_sessions", func() {
 		for _, inst := range instances {
-			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && tmuxSess.Exists() {
+			// ExistsCached() (cache/pipe only): iterating every instance with
+			// Exists() would subprocess-probe each uncached/dead session, storming
+			// the tmux server on a theme toggle. This runs off the UI goroutine so
+			// it can't freeze the main loop, but the storm class is the same one
+			// the tickMsg fix eliminates. A live-but-uncached session keeps its
+			// stale COLORFGBG until the next theme change — cosmetic only.
+			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && tmuxSess.ExistsCached() {
 				_ = tmuxSess.SetEnvironment("COLORFGBG", colorfgbg)
 				_ = tmuxSess.ApplyThemeOptions()
 			}
@@ -3907,6 +3913,14 @@ func (h *Home) backgroundStatusUpdate() {
 	copy(instances, h.instances)
 	h.instancesMu.RUnlock()
 
+	// Active (non-archived) subset, computed once and reused by the loops that
+	// only concern live sessions. Archived sessions have torn-down panes, so
+	// walking them here only burns tmux subprocesses (Exists() / Capture())
+	// without changing anything the UI shows — with a large archive backlog that
+	// was the dominant cost in this sweep. Loops that need the full set (status
+	// skip-counting, idle lastSeen cleanup) keep using `instances`.
+	activeInstances := session.FilterInstancesByArchive(instances, false)
+
 	// Issue #1143: rate-limit the idle-timeout watcher to one tick per minute.
 	// The background sweep runs every 2s; capture-pane on every session every
 	// 2s would add unnecessary tmux load. 60s is the same cadence the spec
@@ -3925,9 +3939,15 @@ func (h *Home) backgroundStatusUpdate() {
 	// PERFORMANCE: Gradually configure unconfigured sessions in background
 	// Configure one session per tick to avoid blocking the status update
 	// This ensures all sessions get configured within ~1 minute even without user interaction
-	for _, inst := range instances {
+	for _, inst := range activeInstances {
 		if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-			if !tmuxSess.IsConfigured() && tmuxSess.Exists() {
+			// ExistsCached() (cache/pipe only, never a has-session subprocess):
+			// this loop evaluates the liveness check for EVERY unconfigured
+			// session each tick until it finds one to configure. With hundreds
+			// of unconfigured dead sessions, Exists() here would subprocess-probe
+			// each one — the same storm the tickMsg fix kills. A live-but-uncached
+			// session simply gets configured a tick later.
+			if !tmuxSess.IsConfigured() && tmuxSess.ExistsCached() {
 				tmuxSess.EnsureConfigured()
 				inst.SyncSessionIDsToTmux()
 				break // Only one per tick to avoid blocking
@@ -6165,17 +6185,45 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// connects focused/attached sessions; this only reconnects wanted
 			// sessions whose pipe dropped.
 			if pm := tmux.GetPipeManager(); pm != nil {
+				// Two-phase so NOTHING that can block runs on the bubbletea
+				// goroutine. Phase 1 (under RLock) filters with cheap map/slice
+				// lookups only: a session needs reconnecting iff it is WANTED
+				// (focused/attached) and its pipe has dropped. Phase 2 does the
+				// liveness probe and the reconnect off-thread.
+				//
+				// ts.Exists() must not run here: it falls back to a
+				// `tmux has-session` subprocess (up to hasSessionProbeTimeout=2s)
+				// for any session the pipe/cache doesn't cover — and a
+				// wanted-but-disconnected session on a wedged server is exactly
+				// the state that reaches this loop. Probing on the main goroutine
+				// (while holding instancesMu, stalling writers too) is what froze
+				// the UI for seconds at a time on every tick.
+				type reconnectTarget struct {
+					ts     *tmux.Session
+					socket string
+				}
+				var targets []reconnectTarget
 				h.instancesMu.RLock()
 				for _, inst := range h.instances {
-					if ts := inst.GetTmuxSession(); ts != nil && ts.Exists() {
-						if h.liveSet.want(ts.Name) && !pm.IsConnected(ts.Name) {
-							go func(name, socket string) {
-								_ = pm.Connect(name, socket)
-							}(ts.Name, inst.TmuxSocketName)
-						}
+					ts := inst.GetTmuxSession()
+					if ts == nil {
+						continue
 					}
+					if !h.liveSet.want(ts.Name) || pm.IsConnected(ts.Name) {
+						continue
+					}
+					targets = append(targets, reconnectTarget{ts: ts, socket: inst.TmuxSocketName})
 				}
 				h.instancesMu.RUnlock()
+
+				for _, t := range targets {
+					safego.Go(uiLog, "pipe_reconnect", func() {
+						if !t.ts.Exists() {
+							return
+						}
+						_ = pm.Connect(t.ts.Name, t.socket)
+					})
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

The TUI freezes for seconds at a time on a ~20s cadence, and again on theme toggles and on decks with a large archive backlog.

All three share one root cause. `Session.Exists()` falls back to a `tmux has-session` **subprocess** (up to `hasSessionProbeTimeout` = 2s) whenever the pipe/cache doesn't already cover the session — and it was being called in per-instance loops **on the bubbletea goroutine**.

The worst offender is the `tickMsg` pipe-reconnect loop: it walked every instance calling `Exists()` *while holding `instancesMu`*, so it stalled writers too. And a wanted-but-disconnected session on a wedged tmux server is precisely the state that reaches that loop — so the slow path was the common path, not the edge case. On a large deck this was 4–7s of frozen UI every tick.

## Fix

- **`tickMsg` reconnect is now two-phase.** Phase 1 filters reconnect targets under `RLock` using only cheap map/slice lookups (`wanted && !connected`). Phase 2 does the liveness probe and the reconnect off-thread. Nothing that can block runs on the main goroutine.
- **New `Session.ExistsCached()`** — cache/pipe only, never a subprocess. It's backed by a **per-socket** session-name cache: a single flat name-keyed cache built from one socket would report sessions on an isolated socket as missing, which is a dangerous false negative (it reads as "tmux session gone").
- **The periodic configure and theme-propagation loops** use `ExistsCached()` and skip archived sessions, whose panes are torn down anyway. These already ran off the UI goroutine, but they storm the tmux server in the same way.

## Notes for review

- **No new instrumentation.** The existing `perfLog` counters (`slow_refresh`, `slow_status_loop`, `background_status_update_slow`, `slow_view_render`) are untouched — no lines added or removed.
- Behavior tradeoff, deliberate: a live-but-uncached session may get configured one tick later, or keep a stale `COLORFGBG` until the next theme change. Both are cosmetic and self-correcting; neither is worth a subprocess storm.
- `ExistsCached()` ships with 255 lines of tests (`internal/tmux/exists_cached_test.go`) covering the per-socket cache, including the isolated-socket case.
- `internal/ui` and `internal/tmux` pass with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster, non-blocking session availability checks, including support for sessions on isolated sockets.
  * Improved background session monitoring and reconnection to keep the interface responsive.

* **Bug Fixes**
  * Reduced unnecessary tmux activity during theme changes and status updates.
  * Prevented temporary probe failures from incorrectly marking live sessions as unavailable.
  * Avoided unnecessary checks for archived or inactive sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->