### PR TITLE
perf(session): cache group DefaultPath resolution (~800ms reload freeze)

### DIFF
--- a/internal/session/group_default_path_cache_test.go
+++ b/internal/session/group_default_path_cache_test.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// resolveGroupDefaultPathCached is the stale-while-revalidate variant used by
+// updateGroupDefaultPath on the reload hot path (see resolveGroupDefaultPath's
+// header). These tests pin its contract: a warm entry is served WITHOUT
+// re-resolving (the whole point — the reload path must not touch git), and a
+// stale entry is served immediately while a background refresh corrects it.
+
+func resetDefaultPathCache(t *testing.T) {
+	t.Helper()
+	defaultPathCacheMu.Lock()
+	defaultPathCache = map[string]*resolvedDefaultPathEntry{}
+	defaultPathCacheMu.Unlock()
+	t.Cleanup(func() {
+		defaultPathCacheMu.Lock()
+		defaultPathCache = map[string]*resolvedDefaultPathEntry{}
+		defaultPathCacheMu.Unlock()
+	})
+}
+
+// An empty path resolves to "" and never creates a cache entry.
+func TestResolveGroupDefaultPathCached_EmptyNoEntry(t *testing.T) {
+	resetDefaultPathCache(t)
+	if got := resolveGroupDefaultPathCached("   "); got != "" {
+		t.Fatalf("empty/whitespace path: got %q, want \"\"", got)
+	}
+	defaultPathCacheMu.Lock()
+	n := len(defaultPathCache)
+	defaultPathCacheMu.Unlock()
+	if n != 0 {
+		t.Fatalf("empty path must not create a cache entry; map has %d entries", n)
+	}
+}
+
+// A warm (fresh) entry is served verbatim WITHOUT re-resolving. Seeding a bogus
+// result the real resolver would never produce proves the cache short-circuits
+// the git subprocesses — the property that makes reloads cheap.
+func TestResolveGroupDefaultPathCached_WarmHitSkipsResolve(t *testing.T) {
+	resetDefaultPathCache(t)
+	const key = "/no/such/path/for/this/test"
+	const sentinel = "SENTINEL-cached-result"
+
+	defaultPathCacheMu.Lock()
+	defaultPathCache[key] = &resolvedDefaultPathEntry{result: sentinel, computedAt: time.Now()}
+	defaultPathCacheMu.Unlock()
+
+	if got := resolveGroupDefaultPathCached(key); got != sentinel {
+		t.Fatalf("warm cache hit re-resolved instead of serving the cached value: got %q, want %q", got, sentinel)
+	}
+}
+
+// A stale entry is served immediately (stale-while-revalidate) and a background
+// refresh replaces it with the truly-resolved value. For a nonexistent path,
+// resolveGroupDefaultPath returns the path verbatim (os.Stat fails), so the
+// background refresh must overwrite the sentinel with the key itself.
+func TestResolveGroupDefaultPathCached_StaleServesThenRefreshes(t *testing.T) {
+	resetDefaultPathCache(t)
+	const key = "/no/such/path/stale/test"
+	const sentinel = "SENTINEL-stale-result"
+
+	defaultPathCacheMu.Lock()
+	defaultPathCache[key] = &resolvedDefaultPathEntry{
+		result:     sentinel,
+		computedAt: time.Now().Add(-2 * defaultPathCacheTTL), // past TTL
+	}
+	defaultPathCacheMu.Unlock()
+
+	// Immediate call serves the stale value (no blocking on the refresh).
+	if got := resolveGroupDefaultPathCached(key); got != sentinel {
+		t.Fatalf("stale entry should be served immediately: got %q, want %q", got, sentinel)
+	}
+
+	// The background refresh eventually replaces it with the real resolution
+	// (the verbatim path for a nonexistent dir).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		defaultPathCacheMu.Lock()
+		entry := defaultPathCache[key]
+		result := ""
+		if entry != nil {
+			result = entry.result
+		}
+		defaultPathCacheMu.Unlock()
+		if result == key {
+			break // refreshed
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresh did not update the stale entry within 2s (result=%q, want %q)", result, key)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 	"unicode"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
@@ -1644,6 +1646,79 @@ func resolveGroupDefaultPath(defaultPath string) string {
 	return baseRoot
 }
 
+// resolveGroupDefaultPath does an os.Stat plus up to three git subprocess calls
+// (IsGitRepo, IsLinkedWorktree, GetWorktreeBaseRoot). updateGroupDefaultPath
+// calls it once per group on EVERY tree build, and a tree build runs on the
+// bubbletea main goroutine inside the loadSessionsMsg handler (fired on each
+// storage change). On a large deck this measured ~21ms × N groups ≈ 800ms of
+// main-goroutine freeze per reload — the same subprocess-storm class as the
+// nav-freeze fix, just in the group-tree path.
+//
+// The result is a pure function of the path's on-disk git/worktree state, which
+// is effectively static across reloads (a repo does not flip linked-worktree
+// status every 30s). So cache it stale-while-revalidate: serve the last known
+// result to the main goroutine instantly and, when the entry is past TTL,
+// refresh it once in the background. Only the first-ever resolution of a path
+// blocks (cold cache, one-time splash cost); every subsequent reload is O(map
+// lookup). The background refresher touches ONLY this mutex-guarded map — never
+// a GroupTree/Group/Instance — so it cannot corrupt group state.
+//
+// Set-time callers (SetDefaultPathForGroup, ReconcileDeclarativeGroups,
+// DefaultPathForGroup) deliberately keep using resolveGroupDefaultPath directly
+// so an explicit "use this path" always resolves fresh; only the defensive
+// per-load re-normalization in updateGroupDefaultPath goes through the cache.
+
+const defaultPathCacheTTL = 60 * time.Second
+
+type resolvedDefaultPathEntry struct {
+	result     string
+	computedAt time.Time
+	refreshing bool
+}
+
+var (
+	defaultPathCacheMu sync.Mutex
+	defaultPathCache   = map[string]*resolvedDefaultPathEntry{}
+)
+
+// resolveGroupDefaultPathCached is the reload-path variant of
+// resolveGroupDefaultPath: non-blocking after the first resolution of a given
+// path (stale-while-revalidate). See resolveGroupDefaultPath's header.
+func resolveGroupDefaultPathCached(defaultPath string) string {
+	if strings.TrimSpace(defaultPath) == "" {
+		return ""
+	}
+
+	defaultPathCacheMu.Lock()
+	if entry, ok := defaultPathCache[defaultPath]; ok {
+		if time.Since(entry.computedAt) > defaultPathCacheTTL && !entry.refreshing {
+			entry.refreshing = true
+			go refreshGroupDefaultPathCache(defaultPath)
+		}
+		result := entry.result
+		defaultPathCacheMu.Unlock()
+		return result
+	}
+	defaultPathCacheMu.Unlock()
+
+	// Cold cache: resolve synchronously (first-ever lookup of this path).
+	result := resolveGroupDefaultPath(defaultPath)
+	defaultPathCacheMu.Lock()
+	defaultPathCache[defaultPath] = &resolvedDefaultPathEntry{result: result, computedAt: time.Now()}
+	defaultPathCacheMu.Unlock()
+	return result
+}
+
+// refreshGroupDefaultPathCache re-resolves a path off the main goroutine and
+// replaces its cache entry. Runs only via resolveGroupDefaultPathCached, one at
+// a time per path (guarded by the entry.refreshing flag).
+func refreshGroupDefaultPathCache(defaultPath string) {
+	result := resolveGroupDefaultPath(defaultPath)
+	defaultPathCacheMu.Lock()
+	defaultPathCache[defaultPath] = &resolvedDefaultPathEntry{result: result, computedAt: time.Now()}
+	defaultPathCacheMu.Unlock()
+}
+
 // DefaultPathForGroup returns the effective default path for creating new sessions
 // in the group: explicit configured default_path first, then most recent session path.
 func (t *GroupTree) DefaultPathForGroup(groupPath string) string {
@@ -1679,6 +1754,10 @@ func (t *GroupTree) updateGroupDefaultPath(groupPath string) {
 	}
 
 	if group.DefaultPath != "" {
-		group.DefaultPath = resolveGroupDefaultPath(group.DefaultPath)
+		// Cached (stale-while-revalidate): this runs once per group on every
+		// tree build, which happens on the bubbletea main goroutine during the
+		// loadSessionsMsg handler. The uncached resolveGroupDefaultPath here was
+		// ~800ms of main-thread freeze per reload on a large deck.
+		group.DefaultPath = resolveGroupDefaultPathCached(group.DefaultPath)
 	}
 }


### PR DESCRIPTION
## Problem

Every session-list reload rebuilds the group tree, and `NewGroupTreeWithGroups` calls `resolveGroupDefaultPath()` once per group. That resolution **shells out to git**, so a deck with a couple dozen groups pays one git subprocess per group on *every* reload.

Measured at ~800ms of frozen UI per reload. Note the cost scales with **group count, not session count** — which is why it survived earlier session-oriented perf work and looked like "the deck is just big."

## Fix

Resolve through a stale-while-revalidate cache: serve the cached path immediately, refresh in the background.

## Tradeoff

A group whose default path changes on disk is picked up on the next reload rather than instantly. For a path that's almost always a stable git root, that's a fair trade against a subprocess-per-group on every reload.

Independent of #1600 — different subsystem, different root cause, no shared files.

`internal/session` passes with `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Group default paths are now cached during reloads, reducing repeated path normalization and resolution work.
  * Expired cache entries continue serving the last known result while refreshed values are resolved in the background.
  * Git worktree and linked-worktree paths continue to resolve consistently during group reloads.

* **Tests**
  * Added coverage for empty paths, fresh cache hits, and background refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->