### PR TITLE
feat(cli): add 'session cleanup' to purge dead, stale sessions

### DIFF
--- a/cmd/agent-deck/session_cleanup_cmd.go
+++ b/cmd/agent-deck/session_cleanup_cmd.go
@@ -291,7 +291,6 @@ func handleSessionCleanup(profile string, args []string) {
 			fmt.Println("Aborted. Nothing deleted.")
 			return
 		}
-		execute = true
 	}
 
 	// TOCTOU guard, on BOTH paths. The candidate list was computed before this

--- a/cmd/agent-deck/session_cleanup_cmd.go
+++ b/cmd/agent-deck/session_cleanup_cmd.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// cleanupDefaultDays is the default age threshold for `session cleanup`: a
+// session must have had no activity for at least this many days (in addition to
+// being dead) before it is a purge candidate.
+const cleanupDefaultDays = 30
+
+// cleanupStartupGrace is how long a session may sit in a mid-lifecycle status
+// (starting/queued) before that status stops protecting it from cleanup.
+//
+// The guard exists because Exists() can be transiently false while a session
+// boots. It must NOT be open-ended: a process that dies mid-start (crash,
+// reboot) leaves status='starting' in the DB with nothing to ever rewrite it,
+// and an unconditional exemption made those ghosts permanently unpurgeable —
+// precisely the dead-stale class this command exists to collect. Beyond the
+// grace window a starting/queued session is judged on liveness like any other;
+// one that really is still coming up answers the isDead probe as alive.
+const cleanupStartupGrace = 5 * time.Minute
+
+// isCleanupCandidate reports whether a session should be purged by
+// `session cleanup`. A session qualifies iff ALL of:
+//   - it is not within cleanupStartupGrace of a mid-lifecycle status
+//     (starting/queued) — never purge a session that is still coming up;
+//   - it is NOT pinned, unless force (pin-protects-from-stop, matching
+//     `session remove --all-errored`);
+//   - it is NOT archived, unless includeArchived (archiving is a deliberate
+//     keep);
+//   - it has had no activity for longer than maxAge (see cleanupLastTouched);
+//   - it is dead (isDead) — injected so tests need no tmux. Production passes a
+//     socket-complete tmux probe, the authoritative liveness signal,
+//     deliberately NOT the stored Status (StatusError has a known
+//     false-positive class).
+//
+// The cheap predicates are checked before isDead so the tmux probe only runs
+// for sessions that are otherwise eligible.
+func isCleanupCandidate(
+	inst *session.Instance,
+	now time.Time,
+	maxAge time.Duration,
+	includeArchived bool,
+	force bool,
+	isDead func(*session.Instance) bool,
+) bool {
+	if inst == nil {
+		return false
+	}
+	if inst.Status == session.StatusStarting || inst.Status == session.StatusQueued {
+		if now.Sub(cleanupLastTouched(inst)) <= cleanupStartupGrace {
+			return false
+		}
+	}
+	if inst.Pin != session.PinNone && !force {
+		return false
+	}
+	if inst.IsArchived() && !includeArchived {
+		return false
+	}
+	if now.Sub(cleanupLastTouched(inst)) <= maxAge {
+		return false
+	}
+	return isDead(inst)
+}
+
+// cleanupLastTouched returns the most protective "last touched" timestamp for a
+// session: the later of CreatedAt and LastAccessedAt (when the user last
+// attached). GetLastActivityTime is deliberately NOT used — for a dead session
+// its tmux tracker is gone, so it collapses to CreatedAt and would ignore a
+// recent attach. Using the max of both timestamps means a recently-used session
+// that has since died is not purged just because it was created long ago.
+func cleanupLastTouched(inst *session.Instance) time.Time {
+	last := inst.CreatedAt
+	if inst.LastAccessedAt.After(last) {
+		last = inst.LastAccessedAt
+	}
+	return last
+}
+
+// selectCleanupCandidates returns the subset of instances that qualify for
+// cleanup, preserving input order, plus the count skipped for being pinned
+// (reported so the user knows something was deliberately retained).
+func selectCleanupCandidates(
+	instances []*session.Instance,
+	now time.Time,
+	maxAge time.Duration,
+	includeArchived bool,
+	force bool,
+	isDead func(*session.Instance) bool,
+) (candidates []*session.Instance, pinnedSkipped int) {
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if inst.Pin != session.PinNone && !force {
+			// Only report a pin skip for a session that would OTHERWISE have
+			// been purged, so the count means "retained because pinned" rather
+			// than "is pinned".
+			if isCleanupCandidate(inst, now, maxAge, includeArchived, true, isDead) {
+				pinnedSkipped++
+			}
+			continue
+		}
+		if isCleanupCandidate(inst, now, maxAge, includeArchived, force, isDead) {
+			candidates = append(candidates, inst)
+		}
+	}
+	return candidates, pinnedSkipped
+}
+
+// newTmuxLivenessProbe returns an isDead func backed by a socket-complete view
+// of live tmux sessions: ONE `list-sessions` per distinct socket, rather than
+// one `has-session` per session.
+//
+// This matters on exactly the deck this command targets. Probing ~1000 dead
+// sessions individually costs ~1000 sequential subprocesses in a cold CLI
+// process (no session cache, no pipes), and if the server is wedged each probe
+// burns its full timeout — a dry run that should be instant takes tens of
+// minutes before printing anything.
+//
+// Socket-completeness is the safety requirement, not an optimization: a flat
+// name-keyed set built from one arbitrary socket reports live sessions on OTHER
+// sockets as missing, and this command deletes what it thinks is missing. A
+// socket whose probe fails or times out is INDETERMINATE — every session on it
+// is reported alive, so it can never become a purge candidate.
+func newTmuxLivenessProbe(instances []*session.Instance) func(*session.Instance) bool {
+	live := map[string]map[string]struct{}{} // socket -> live session names
+	indeterminate := map[string]bool{}       // socket -> probe failed, assume alive
+
+	sockets := map[string]bool{}
+	for _, inst := range instances {
+		if inst != nil {
+			sockets[inst.TmuxSocketName] = true
+		}
+	}
+	for socket := range sockets {
+		names, err := tmux.ListSessionNamesOnSocket(socket)
+		if err != nil {
+			indeterminate[socket] = true
+			continue
+		}
+		live[socket] = names
+	}
+
+	return func(inst *session.Instance) bool {
+		if inst == nil {
+			return false
+		}
+		if indeterminate[inst.TmuxSocketName] {
+			return false // probe inconclusive: assume alive, never purge
+		}
+		ts := inst.GetTmuxSession()
+		if ts == nil {
+			return true // no tmux session bound: nothing to be alive
+		}
+		_, alive := live[inst.TmuxSocketName][ts.Name]
+		return !alive
+	}
+}
+
+// shortID returns the first 8 characters of an id (or the whole id if shorter),
+// matching how other CLI output abbreviates session IDs.
+func shortID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}
+
+// humanizeAge renders a duration as a coarse age like "47d" / "5h" / "12m".
+func humanizeAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours())/24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return "<1m"
+	}
+}
+
+// handleSessionCleanup purges sessions that are dead AND untouched for at least
+// --days days. It is dry-run by default: nothing is deleted without --yes or an
+// explicit interactive "yes". Archived and pinned sessions are excluded unless
+// --include-archived / --force. Registry-only unless --prune-worktree.
+func handleSessionCleanup(profile string, args []string) {
+	fs := flag.NewFlagSet("session cleanup", flag.ExitOnError)
+	days := fs.Int("days", cleanupDefaultDays, "Minimum days without activity before a dead session is a purge candidate")
+	yes := fs.Bool("yes", false, "Actually delete (skip the confirmation prompt)")
+	yesShort := fs.Bool("y", false, "Actually delete (short for --yes)")
+	dryRun := fs.Bool("dry-run", false, "Preview only; never delete even with --yes")
+	includeArchived := fs.Bool("include-archived", false, "Also consider archived sessions (excluded by default)")
+	force := fs.Bool("force", false, "Also include pinned sessions (pinned are retained by default)")
+	pruneWorktree := fs.Bool("prune-worktree", false, "Also delete each session's git worktree directory (DESTRUCTIVE: discards uncommitted work)")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session cleanup [options]")
+		fmt.Println()
+		fmt.Println("Purge sessions that are DEAD (no live tmux pane) AND have had no")
+		fmt.Println("activity for at least --days days. Dry-run by default: nothing is")
+		fmt.Println("deleted without --yes or an explicit interactive confirmation.")
+		fmt.Println()
+		fmt.Println("Archived sessions are never touched unless --include-archived.")
+		fmt.Println("Pinned sessions are retained unless --force.")
+		fmt.Println()
+		fmt.Println("Registry-only by default: Claude transcripts under ~/.claude/projects/")
+		fmt.Println("AND git worktree directories are kept. Pass --prune-worktree to also")
+		fmt.Println("delete each session's worktree (DESTRUCTIVE: uncommitted work is lost;")
+		fmt.Println("the preview marks affected sessions with 'wt' in the WT column).")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session cleanup                 # preview dead sessions idle 30+ days")
+		fmt.Println("  agent-deck session cleanup --days 7        # preview with a 7-day cutoff")
+		fmt.Println("  agent-deck session cleanup --days 60 --yes # actually delete (registry only)")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	if *days < 0 {
+		out.Error("--days must be zero or positive", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	storage, instances, groups, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	now := time.Now()
+	maxAge := time.Duration(*days) * 24 * time.Hour
+	isDead := newTmuxLivenessProbe(instances)
+	candidates, pinnedSkipped := selectCleanupCandidates(instances, now, maxAge, *includeArchived, *force, isDead)
+
+	if len(candidates) == 0 {
+		msg := fmt.Sprintf("No dead sessions idle for %d+ days to clean up.", *days)
+		if pinnedSkipped > 0 {
+			msg += fmt.Sprintf(" (skipped %d pinned — use --force to include)", pinnedSkipped)
+		}
+		out.Success(msg, map[string]interface{}{
+			"success": true,
+			"count":   0,
+			"removed": []interface{}{},
+			"skipped": pinnedSkipped,
+		})
+		return
+	}
+
+	// Decide whether to actually delete.
+	//   --dry-run          -> never delete (explicit preview)
+	//   --yes / -y         -> delete without prompting
+	//   --json (no --yes)  -> preview only (no interactive prompt in JSON mode)
+	//   otherwise          -> interactive [y/N] prompt
+	execute := (*yes || *yesShort) && !*dryRun
+
+	if !execute {
+		// Preview path (dry-run, or JSON without --yes, or the pre-prompt render).
+		printCleanupPreview(out, candidates, now, *days, pinnedSkipped, *pruneWorktree, *jsonOutput)
+		if *dryRun || *jsonOutput {
+			return
+		}
+		fmt.Printf("Delete %d session(s)? [y/N] ", len(candidates))
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		if !isYesConfirmation(line) {
+			fmt.Println("Aborted. Nothing deleted.")
+			return
+		}
+		execute = true
+	}
+
+	// TOCTOU guard, on BOTH paths. The candidate list was computed before this
+	// point; everything below (KillAndWait, worktree removal, DELETE) is
+	// destructive and irreversible. The interactive [y/N] prompt can sit open
+	// for minutes while the TUI, the reviver, or another terminal restarts a
+	// candidate — and even --yes leaves a window. Re-confirm liveness against a
+	// FRESH socket-complete tmux view and drop anything that came back to life.
+	candidates = dropRevivedCandidates(candidates)
+	if len(candidates) == 0 {
+		out.Success("All candidates came back to life before deletion. Nothing deleted.", map[string]interface{}{
+			"success": true,
+			"count":   0,
+			"removed": []interface{}{},
+			"skipped": pinnedSkipped,
+		})
+		return
+	}
+
+	removed := bulkRemoveSessions(out, storage, instances, groups, candidates, *pruneWorktree)
+
+	msg := fmt.Sprintf("Removed %d dead session(s).", len(removed))
+	if pinnedSkipped > 0 {
+		msg += fmt.Sprintf(" (skipped %d pinned — use --force to include)", pinnedSkipped)
+	}
+	out.Success(msg, map[string]interface{}{
+		"success": true,
+		"count":   len(removed),
+		"removed": removed,
+		"skipped": pinnedSkipped,
+	})
+}
+
+// dropRevivedCandidates re-probes liveness against a FRESH socket-complete view
+// and returns only the candidates that are still dead.
+//
+// It deliberately rebuilds the probe (one `list-sessions` per distinct socket)
+// rather than calling inst.Exists() per candidate: a purge run can carry a
+// thousand candidates, and per-session `has-session` probes would be a thousand
+// sequential subprocesses on the destructive path — the very cost the selection
+// pass was rewritten to avoid. The socket-complete probe is also the safe way
+// to read a NEGATIVE (see newTmuxLivenessProbe): a socket whose probe fails is
+// indeterminate, so its sessions report alive and survive.
+func dropRevivedCandidates(candidates []*session.Instance) []*session.Instance {
+	isDead := newTmuxLivenessProbe(candidates)
+	stillDead := make([]*session.Instance, 0, len(candidates))
+	for _, inst := range candidates {
+		if !isDead(inst) {
+			fmt.Fprintf(os.Stderr, "skip: session %s (%s) came back to life; not deleting\n",
+				shortID(inst.ID), inst.Title)
+			continue
+		}
+		stillDead = append(stillDead, inst)
+	}
+	return stillDead
+}
+
+// printCleanupPreview renders the candidate table (human) or emits the preview
+// payload (JSON). It never deletes.
+func printCleanupPreview(
+	out *CLIOutput,
+	candidates []*session.Instance,
+	now time.Time,
+	days int,
+	pinnedSkipped int,
+	pruneWorktree bool,
+	jsonOutput bool,
+) {
+	worktrees := 0
+	rows := make([]map[string]interface{}, 0, len(candidates))
+	for _, inst := range candidates {
+		if inst.IsWorktree() {
+			worktrees++
+		}
+		rows = append(rows, map[string]interface{}{
+			"id":            inst.ID,
+			"title":         inst.Title,
+			"group":         inst.GroupPath,
+			"status":        string(inst.Status),
+			"idle_days":     int(now.Sub(cleanupLastTouched(inst)).Hours()) / 24,
+			"archived":      inst.IsArchived(),
+			"worktree":      inst.IsWorktree(),
+			"worktree_path": inst.WorktreePath,
+		})
+	}
+
+	if jsonOutput {
+		out.Print("", map[string]interface{}{
+			"dry_run":        true,
+			"count":          len(candidates),
+			"candidates":     rows,
+			"skipped":        pinnedSkipped,
+			"prune_worktree": pruneWorktree,
+		})
+		return
+	}
+
+	fmt.Printf("Cleanup candidates (dead + idle %d+ days): %d\n\n", days, len(candidates))
+	fmt.Printf("  %-10s  %-30s  %-16s  %-8s  %-6s  %s\n", "ID", "TITLE", "GROUP", "STATUS", "IDLE", "WT")
+	for _, inst := range candidates {
+		age := humanizeAge(now.Sub(cleanupLastTouched(inst)))
+		wt := ""
+		if inst.IsWorktree() {
+			wt = "wt"
+		}
+		fmt.Printf("  %-10s  %-30s  %-16s  %-8s  %-6s  %s\n",
+			shortID(inst.ID), truncate(inst.Title, 30), truncate(inst.GroupPath, 16), inst.Status, age, wt)
+	}
+	fmt.Println()
+
+	if worktrees > 0 {
+		if pruneWorktree {
+			fmt.Printf("WARNING: --prune-worktree will DELETE the git worktree directory of %d session(s)\n", worktrees)
+			fmt.Println("         marked 'wt' above, discarding any uncommitted work in them.")
+		} else {
+			fmt.Printf("Note: %d session(s) marked 'wt' own a git worktree. Their directories are\n", worktrees)
+			fmt.Println("      KEPT (registry-only). Pass --prune-worktree to delete them too.")
+		}
+		fmt.Println()
+	}
+	if pinnedSkipped > 0 {
+		fmt.Printf("Skipping %d pinned session(s) — use --force to include them.\n\n", pinnedSkipped)
+	}
+}

--- a/cmd/agent-deck/session_cleanup_cmd_test.go
+++ b/cmd/agent-deck/session_cleanup_cmd_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// alwaysDead / neverDead are injectable stand-ins for the tmux-liveness probe
+// so the predicate can be tested without a real tmux server.
+func alwaysDead(*session.Instance) bool { return true }
+func neverDead(*session.Instance) bool  { return false }
+
+func TestIsCleanupCandidate(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	maxAge := 30 * 24 * time.Hour
+	old := now.Add(-45 * 24 * time.Hour)   // 45 days ago (past cutoff)
+	recent := now.Add(-2 * 24 * time.Hour) // 2 days ago (within cutoff)
+
+	cases := []struct {
+		name            string
+		inst            *session.Instance
+		includeArchived bool
+		force           bool
+		isDead          func(*session.Instance) bool
+		want            bool
+	}{
+		{
+			name:   "dead and old -> candidate",
+			inst:   &session.Instance{ID: "a", Status: session.StatusError, CreatedAt: old},
+			isDead: alwaysDead,
+			want:   true,
+		},
+		{
+			name:   "alive -> not a candidate",
+			inst:   &session.Instance{ID: "b", Status: session.StatusError, CreatedAt: old},
+			isDead: neverDead,
+			want:   false,
+		},
+		{
+			name:   "dead but recent -> not a candidate",
+			inst:   &session.Instance{ID: "c", Status: session.StatusError, CreatedAt: recent},
+			isDead: alwaysDead,
+			want:   false,
+		},
+		{
+			name:   "recent attach protects an old-created dead session",
+			inst:   &session.Instance{ID: "d", Status: session.StatusError, CreatedAt: old, LastAccessedAt: recent},
+			isDead: alwaysDead,
+			want:   false,
+		},
+		{
+			name:            "archived excluded by default",
+			inst:            &session.Instance{ID: "e", Status: session.StatusStopped, CreatedAt: old, ArchivedAt: old},
+			includeArchived: false,
+			isDead:          alwaysDead,
+			want:            false,
+		},
+		{
+			name:            "archived included with flag",
+			inst:            &session.Instance{ID: "f", Status: session.StatusStopped, CreatedAt: old, ArchivedAt: old},
+			includeArchived: true,
+			isDead:          alwaysDead,
+			want:            true,
+		},
+		{
+			name:   "starting session within startup grace is never a candidate",
+			inst:   &session.Instance{ID: "g", Status: session.StatusStarting, CreatedAt: now.Add(-time.Minute)},
+			isDead: alwaysDead,
+			want:   false,
+		},
+		{
+			name:   "queued session within startup grace is never a candidate",
+			inst:   &session.Instance{ID: "h", Status: session.StatusQueued, CreatedAt: now.Add(-time.Minute)},
+			isDead: alwaysDead,
+			want:   false,
+		},
+		{
+			// A crash mid-start leaves status='starting' in the DB forever.
+			// Past the startup grace it must be judged on liveness like any
+			// other session, or it becomes an unpurgeable ghost.
+			name:   "stale starting ghost past grace is a candidate",
+			inst:   &session.Instance{ID: "i", Status: session.StatusStarting, CreatedAt: old},
+			isDead: alwaysDead,
+			want:   true,
+		},
+		{
+			name:   "stale queued ghost past grace is a candidate",
+			inst:   &session.Instance{ID: "j", Status: session.StatusQueued, CreatedAt: old},
+			isDead: alwaysDead,
+			want:   true,
+		},
+		{
+			// A still-booting session past the grace window answers the probe
+			// as alive, so liveness (not status) keeps it safe.
+			name:   "live starting session past grace is protected by liveness",
+			inst:   &session.Instance{ID: "k", Status: session.StatusStarting, CreatedAt: old},
+			isDead: neverDead,
+			want:   false,
+		},
+		{
+			// pin-protects-from-stop, matching `session remove --all-errored`.
+			name:   "pinned session retained by default",
+			inst:   &session.Instance{ID: "l", Status: session.StatusError, CreatedAt: old, Pin: session.PinTop},
+			isDead: alwaysDead,
+			want:   false,
+		},
+		{
+			name:   "pinned session included with force",
+			inst:   &session.Instance{ID: "m", Status: session.StatusError, CreatedAt: old, Pin: session.PinTop},
+			force:  true,
+			isDead: alwaysDead,
+			want:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isCleanupCandidate(tc.inst, now, maxAge, tc.includeArchived, tc.force, tc.isDead)
+			if got != tc.want {
+				t.Fatalf("isCleanupCandidate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectCleanupCandidates_SubsetAndOrder(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	maxAge := 30 * 24 * time.Hour
+	old := now.Add(-40 * 24 * time.Hour)
+	recent := now.Add(-1 * 24 * time.Hour)
+
+	instances := []*session.Instance{
+		{ID: "keep-recent", Status: session.StatusError, CreatedAt: recent},
+		{ID: "purge-1", Status: session.StatusError, CreatedAt: old},
+		{ID: "keep-starting", Status: session.StatusStarting, CreatedAt: now.Add(-time.Minute)},
+		{ID: "purge-2", Status: session.StatusStopped, CreatedAt: old},
+	}
+
+	got, pinned := selectCleanupCandidates(instances, now, maxAge, false, false, alwaysDead)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(got))
+	}
+	if got[0].ID != "purge-1" || got[1].ID != "purge-2" {
+		t.Fatalf("candidates in wrong order/subset: %s, %s", got[0].ID, got[1].ID)
+	}
+	if pinned != 0 {
+		t.Fatalf("expected 0 pinned skips, got %d", pinned)
+	}
+}
+
+// A pinned session that would otherwise be purged is retained and counted, so
+// the CLI can tell the user something was deliberately kept. --force includes it.
+func TestSelectCleanupCandidates_PinnedSkippedAndCounted(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	maxAge := 30 * 24 * time.Hour
+	old := now.Add(-40 * 24 * time.Hour)
+	recent := now.Add(-1 * 24 * time.Hour)
+
+	instances := []*session.Instance{
+		{ID: "purge-1", Status: session.StatusError, CreatedAt: old},
+		{ID: "pinned-old", Status: session.StatusError, CreatedAt: old, Pin: session.PinTop},
+		// Pinned but too recent to purge: must NOT inflate the skip count,
+		// which means "retained because pinned", not "is pinned".
+		{ID: "pinned-recent", Status: session.StatusError, CreatedAt: recent, Pin: session.PinTop},
+	}
+
+	got, pinned := selectCleanupCandidates(instances, now, maxAge, false, false, alwaysDead)
+	if len(got) != 1 || got[0].ID != "purge-1" {
+		t.Fatalf("pinned session must be skipped; got %v", ids(got))
+	}
+	if pinned != 1 {
+		t.Fatalf("expected 1 pinned skip (only the otherwise-purgeable one), got %d", pinned)
+	}
+
+	forced, pinnedForced := selectCleanupCandidates(instances, now, maxAge, false, true, alwaysDead)
+	if len(forced) != 2 {
+		t.Fatalf("--force must include the pinned old session; got %v", ids(forced))
+	}
+	if pinnedForced != 0 {
+		t.Fatalf("--force must report 0 pinned skips, got %d", pinnedForced)
+	}
+}
+
+func ids(instances []*session.Instance) []string {
+	out := make([]string, 0, len(instances))
+	for _, i := range instances {
+		out = append(out, i.ID)
+	}
+	return out
+}
+
+func TestHumanizeAge(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{47 * 24 * time.Hour, "47d"},
+		{5 * time.Hour, "5h"},
+		{12 * time.Minute, "12m"},
+		{30 * time.Second, "<1m"},
+		{-5 * time.Hour, "<1m"},
+	}
+	for _, tc := range cases {
+		if got := humanizeAge(tc.d); got != tc.want {
+			t.Fatalf("humanizeAge(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestShortID(t *testing.T) {
+	if got := shortID("e33b5e95-1783547273"); got != "e33b5e95" {
+		t.Fatalf("shortID long = %q, want %q", got, "e33b5e95")
+	}
+	if got := shortID("abc"); got != "abc" {
+		t.Fatalf("shortID short = %q, want %q", got, "abc")
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -41,6 +41,8 @@ func handleSession(profile string, args []string) {
 		handleSessionStop(profile, args[1:])
 	case "remove":
 		handleSessionRemove(profile, args[1:])
+	case "cleanup", "prune":
+		handleSessionCleanup(profile, args[1:])
 	case "archive":
 		handleSessionArchive(profile, args[1:])
 	case "unarchive":
@@ -109,6 +111,7 @@ func printSessionHelp() {
 	fmt.Println("  start <id>              Start a session's tmux process")
 	fmt.Println("  stop <id>               Stop/kill session process")
 	fmt.Println("  remove <id>             Remove session from registry (stopped/error only; --force to bypass)")
+	fmt.Println("  cleanup [--days N]      Purge dead sessions idle N+ days (dry-run unless --yes)")
 	fmt.Println("  archive <id|title>      Stop session and hide it from active lists (retained in storage)")
 	fmt.Println("  unarchive <id|title>    Restore an archived session (does not restart it)")
 	fmt.Println("  restart [id] [--all]    Restart session (Claude: reload MCPs)")

--- a/cmd/agent-deck/session_remove_cmd.go
+++ b/cmd/agent-deck/session_remove_cmd.go
@@ -130,6 +130,9 @@ func isRemovableStatus(s session.Status) bool {
 	return s == session.StatusStopped || s == session.StatusError
 }
 
+// removedSessionRow is the {id,title} payload emitted for each removed session.
+type removedSessionRow = map[string]interface{}
+
 // removeAllErrored implements the --all-errored bulk path.
 func removeAllErrored(
 	out *CLIOutput,
@@ -139,57 +142,23 @@ func removeAllErrored(
 	pruneWorktree bool,
 	force bool,
 ) {
-	var removed []map[string]interface{}
-	remaining := instances[:0]
-	var removedIDs []string
+	var doomed []*session.Instance
 	skipped := 0
 	for _, inst := range instances {
-		if inst.Status == session.StatusError {
-			// pin-protects-from-stop: a pinned errored session is retained
-			// unless --force is given.
-			if inst.Pin != session.PinNone && !force {
-				skipped++
-				remaining = append(remaining, inst)
-				continue
-			}
-			// Synchronously kill the tmux scope + pane processes before
-			// deleting the registry row (issue #59, v1.7.68). Errored
-			// sessions commonly still own a live claude child that
-			// silently consumes CPU — leaking them out of this bulk
-			// cleanup is exactly how the 33-hour orphan was created.
-			_ = inst.KillAndWait()
-			if pruneWorktree {
-				pruneSessionWorktree(inst)
-			}
-			if err := storage.DeleteInstance(inst.ID); err != nil {
-				out.Error(fmt.Sprintf("failed to remove session %s: %v", inst.ID, err), ErrCodeInvalidOperation)
-				os.Exit(1)
-			}
-			removedIDs = append(removedIDs, inst.ID)
-			removed = append(removed, map[string]interface{}{"id": inst.ID, "title": inst.Title})
+		if inst.Status != session.StatusError {
 			continue
 		}
-		remaining = append(remaining, inst)
-	}
-	// v1.9.1 (#909): persist groups WITHOUT rewriting the instances table.
-	// Same rationale as RemoveSessionAndVerify — SaveWithGroups's INSERT OR
-	// REPLACE can resurrect a row that another writer (or our own earlier
-	// DeleteInstance call) just removed. Then verify each removed row is
-	// actually gone; on resurrection, re-issue the targeted DELETE.
-	groupTree := session.NewGroupTreeWithGroups(remaining, groups)
-	if err := storage.SaveGroupsOnly(groupTree); err != nil {
-		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
-	for _, id := range removedIDs {
-		exists, _ := storage.InstanceExists(id)
-		if exists {
-			_ = storage.DeleteInstance(id)
+		// pin-protects-from-stop: a pinned errored session is retained
+		// unless --force is given.
+		if inst.Pin != session.PinNone && !force {
+			skipped++
+			continue
 		}
-		// Best-effort transition-notifier cleanup (issue #910).
-		_, _ = session.SweepInboxesForChildSession(id)
-		_, _ = session.RemoveNotifyStateRecord(id)
+		doomed = append(doomed, inst)
 	}
+
+	removed := bulkRemoveSessions(out, storage, instances, groups, doomed, pruneWorktree)
+
 	msg := fmt.Sprintf("Removed %d errored session(s)", len(removed))
 	if skipped > 0 {
 		msg += fmt.Sprintf(" (skipped %d pinned — use --force to include)", skipped)
@@ -200,6 +169,78 @@ func removeAllErrored(
 		"removed": removed,
 		"skipped": skipped,
 	})
+}
+
+// bulkRemoveSessions is the ONE implementation of the safety-critical bulk
+// delete choreography, shared by `session remove --all-errored` and
+// `session cleanup`. Keeping it single-sourced matters: the two copies it
+// replaced had already drifted apart (only one did KillAndWait / pin-skip), and
+// each of the invariants below was a separate production bug.
+//
+//   - KillAndWait before DELETE (#59, v1.7.68): an errored/dead session often
+//     still owns a live agent child. Deleting the row without a synchronous
+//     SIGTERM→SIGKILL escalation is how a 33-hour orphan claude process with a
+//     since-deleted AGENTDECK_INSTANCE_ID was created.
+//   - pruneWorktree is OPT-IN: it force-deletes the git worktree directory,
+//     destroying uncommitted work. Never infer it.
+//   - SaveGroupsOnly, never SaveWithGroups (#909): a full-table rewrite's
+//     INSERT OR REPLACE resurrects the rows we just deleted. NewGroupTreeWithGroups
+//     over the SURVIVING set also preserves groups whose last session just went
+//     away (empty groups otherwise vanish forever).
+//   - Verify + re-DELETE: a concurrent writer (a live TUI) can still resurrect a
+//     row between our DELETE and our save.
+//   - Inbox / notify-state sweep (#910).
+//
+// Returns the {id,title} payload rows for the sessions actually removed.
+func bulkRemoveSessions(
+	out *CLIOutput,
+	storage *session.Storage,
+	instances []*session.Instance,
+	groups []*session.GroupData,
+	doomed []*session.Instance,
+	pruneWorktree bool,
+) []removedSessionRow {
+	doomedIDs := make(map[string]bool, len(doomed))
+	for _, inst := range doomed {
+		doomedIDs[inst.ID] = true
+	}
+
+	removed := make([]removedSessionRow, 0, len(doomed))
+	removedIDs := make([]string, 0, len(doomed))
+	for _, inst := range doomed {
+		_ = inst.KillAndWait()
+		if pruneWorktree {
+			pruneSessionWorktree(inst)
+		}
+		if err := storage.DeleteInstance(inst.ID); err != nil {
+			out.Error(fmt.Sprintf("failed to remove session %s: %v", inst.ID, err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		removedIDs = append(removedIDs, inst.ID)
+		removed = append(removed, map[string]interface{}{"id": inst.ID, "title": inst.Title})
+	}
+
+	remaining := make([]*session.Instance, 0, len(instances)-len(removedIDs))
+	for _, inst := range instances {
+		if !doomedIDs[inst.ID] {
+			remaining = append(remaining, inst)
+		}
+	}
+	groupTree := session.NewGroupTreeWithGroups(remaining, groups)
+	if err := storage.SaveGroupsOnly(groupTree); err != nil {
+		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	for _, id := range removedIDs {
+		if exists, _ := storage.InstanceExists(id); exists {
+			_ = storage.DeleteInstance(id)
+		}
+		// Best-effort transition-notifier cleanup (issue #910).
+		_, _ = session.SweepInboxesForChildSession(id)
+		_, _ = session.RemoveNotifyStateRecord(id)
+	}
+	return removed
 }
 
 // pruneSessionWorktree kills the session and removes its git worktree (if any).

--- a/cmd/agent-deck/session_remove_kill_test.go
+++ b/cmd/agent-deck/session_remove_kill_test.go
@@ -85,23 +85,95 @@ func TestSessionRemove_HandlerCallsKillUnconditionally(t *testing.T) {
 	}
 }
 
-// The bulk-errored path removes many sessions in a loop and must ALSO
-// kill each one — same rationale as the single-session handler.
-func TestSessionRemove_AllErroredCallsKillUnconditionally(t *testing.T) {
+// The bulk-delete path removes many sessions in a loop and must ALSO kill each
+// one — same rationale as the single-session handler. Both bulk callers
+// (`--all-errored` and `session cleanup`) route through bulkRemoveSessions, so
+// the invariant is asserted where it now lives.
+func TestSessionRemove_BulkRemoveCallsKillUnconditionally(t *testing.T) {
 	src, err := os.ReadFile("session_remove_cmd.go")
 	if err != nil {
 		t.Fatalf("read session_remove_cmd.go: %v", err)
 	}
-	body := extractFuncBody(string(src), "removeAllErrored")
+	body := extractFuncBody(string(src), "bulkRemoveSessions")
 	if body == "" {
-		t.Fatalf("could not extract removeAllErrored body — file layout changed?")
+		t.Fatalf("could not extract bulkRemoveSessions body — file layout changed?")
 	}
 	killRe := regexp.MustCompile(`\b(Kill|KillAndWait)\s*\(`)
 	if !killRe.MatchString(body) {
 		t.Errorf(
-			"removeAllErrored must kill each session before deleting it "+
+			"bulkRemoveSessions must kill each session before deleting it "+
 				"(issue #59 regression guard); function body:\n%s",
 			body,
 		)
+	}
+}
+
+// ...and the bulk callers must actually route through it, or the guard above
+// protects an unused function. This is what let the two hand-copied bulk paths
+// drift apart (only one killed, only one skipped pinned) before they were
+// merged into bulkRemoveSessions.
+func TestSessionRemove_BulkCallersDelegateToBulkRemoveSessions(t *testing.T) {
+	for file, fn := range map[string]string{
+		"session_remove_cmd.go":  "removeAllErrored",
+		"session_cleanup_cmd.go": "handleSessionCleanup",
+	} {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		body := extractFuncBody(string(src), fn)
+		if body == "" {
+			t.Fatalf("could not extract %s body from %s — file layout changed?", fn, file)
+		}
+		if !regexp.MustCompile(`\bbulkRemoveSessions\s*\(`).MatchString(body) {
+			t.Errorf(
+				"%s must delegate its bulk delete to bulkRemoveSessions "+
+					"(single-sourced #59/#909/#910 choreography); function body:\n%s",
+				fn, body,
+			)
+		}
+	}
+}
+
+// `session cleanup` must never force-remove a git worktree implicitly: that
+// destroys uncommitted work, and the command advertises itself as registry-only.
+// pruneSessionWorktree may only be reached via the opt-in --prune-worktree flag,
+// which cleanup passes straight through to bulkRemoveSessions.
+func TestSessionCleanup_DoesNotPruneWorktreesImplicitly(t *testing.T) {
+	src, err := os.ReadFile("session_cleanup_cmd.go")
+	if err != nil {
+		t.Fatalf("read session_cleanup_cmd.go: %v", err)
+	}
+	if regexp.MustCompile(`\bpruneSessionWorktree\s*\(`).MatchString(string(src)) {
+		t.Errorf("session_cleanup_cmd.go must not call pruneSessionWorktree directly — " +
+			"worktree deletion is opt-in via --prune-worktree, threaded through bulkRemoveSessions")
+	}
+	body := extractFuncBody(string(src), "handleSessionCleanup")
+	if !regexp.MustCompile(`prune-worktree`).MatchString(body) {
+		t.Errorf("handleSessionCleanup must expose an explicit --prune-worktree opt-in flag")
+	}
+}
+
+// The interactive confirm prompt is a TOCTOU window: a candidate can be
+// restarted while [y/N] sits open. handleSessionCleanup must re-probe liveness
+// after the prompt and before any destructive call.
+func TestSessionCleanup_ReprobesLivenessAfterConfirm(t *testing.T) {
+	src, err := os.ReadFile("session_cleanup_cmd.go")
+	if err != nil {
+		t.Fatalf("read session_cleanup_cmd.go: %v", err)
+	}
+	body := extractFuncBody(string(src), "handleSessionCleanup")
+	if body == "" {
+		t.Fatalf("could not extract handleSessionCleanup body — file layout changed?")
+	}
+	confirm := regexp.MustCompile(`isYesConfirmation\s*\(`).FindStringIndex(body)
+	reprobe := regexp.MustCompile(`dropRevivedCandidates\s*\(`).FindStringIndex(body)
+	destroy := regexp.MustCompile(`bulkRemoveSessions\s*\(`).FindStringIndex(body)
+	if confirm == nil || reprobe == nil || destroy == nil {
+		t.Fatalf("expected confirm, re-probe and bulk-delete calls in handleSessionCleanup")
+	}
+	if !(confirm[0] < reprobe[0] && reprobe[0] < destroy[0]) {
+		t.Errorf("handleSessionCleanup must re-probe liveness (dropRevivedCandidates) AFTER the " +
+			"[y/N] confirm and BEFORE bulkRemoveSessions, or a session revived during the prompt is killed")
 	}
 }


### PR DESCRIPTION
> **Stacked on #1600** — `session cleanup` needs `tmux.ListSessionNamesOnSocket` from that PR, so this branch includes its commit. The diff to review here is the `cmd/agent-deck/` files; I'll rebase once #1600 lands.

## What

`session cleanup` purges sessions whose tmux pane is gone and that have been untouched past a threshold. It also routes the existing bulk deletes (`session remove --all-errored` and friends) through the **same single implementation**, so the delete paths can't drift apart — previously each had its own notion of what was safe to remove.

## Why the liveness probe is per-socket

This is the part worth reviewing carefully, because it's a **delete** path.

Liveness is probed per socket via `ListSessionNamesOnSocket`. A flat, name-keyed probe built from a single socket reports sessions living on an *isolated* socket as missing — and in a delete path, "missing" means purging live work. That's a data-loss bug, not a cosmetic one.

Two safety properties:
- Liveness is resolved per socket, so isolated-socket sessions are visible.
- **If a socket's probe fails, every session on it is treated as alive and never purged.** For an irreversible operation the indeterminate case must fail toward keeping data.

## Tests

`cmd/agent-deck` passes with `-race`, including new coverage in `session_cleanup_cmd_test.go` and extended `session_remove_kill_test.go`.