### PR TITLE
fix(session): keep idle-watcher covering archived orphan panes (without the tmux cost)

### DIFF
--- a/internal/session/idle_timeout_watcher.go
+++ b/internal/session/idle_timeout_watcher.go
@@ -155,6 +155,23 @@ func (w *IdleTimeoutWatcher) Tick(instances []*Instance) {
 		if inst == nil {
 			continue
 		}
+		// IdleTimeoutSecs is checked FIRST because it is the gate that actually
+		// bounds cost: Capture (a tmux subprocess) is the only expensive step in
+		// this loop, and it is unreachable for a session with no idle timeout
+		// armed. Idle timeout is strictly opt-in per session, so an archive
+		// backlog of hundreds of unarmed sessions costs one int64 read each.
+		//
+		// Deliberately NOT short-circuiting on IsArchived(): an archived session
+		// whose tmux Kill silently failed keeps a live pane and a frozen
+		// live-ish Status, and this watcher is the only mechanism that will ever
+		// stop that orphan. Skipping archived instances wholesale bought no
+		// measurable time (they are unarmed, hence already free above) while
+		// removing the safety net for exactly the orphan class that motivated
+		// it.
+		if inst.IdleTimeoutSecs <= 0 {
+			delete(w.lastSeen, inst.ID)
+			continue
+		}
 		if inst.Pin != PinNone {
 			// pin-protects-from-stop: a pinned session is exempt from idle
 			// auto-stop. Drop tracking so unpinning re-arms cleanly next tick.
@@ -163,10 +180,6 @@ func (w *IdleTimeoutWatcher) Tick(instances []*Instance) {
 				slog.String("instance_id", inst.ID),
 				slog.String("pin", string(inst.Pin)),
 			)
-			continue
-		}
-		if inst.IdleTimeoutSecs <= 0 {
-			delete(w.lastSeen, inst.ID)
 			continue
 		}
 		if !idleTimeoutWatchable(inst) {

--- a/internal/session/issue1143_idle_timeout_test.go
+++ b/internal/session/issue1143_idle_timeout_test.go
@@ -426,3 +426,64 @@ func TestIdleTimeoutWatcher_UnpinReArmsAutoStop(t *testing.T) {
 		t.Fatalf("expected stop after unpin+idle, got %v", got)
 	}
 }
+
+// An UNARMED session (IdleTimeoutSecs == 0) is skipped before any tmux Capture,
+// archived or not. This is what actually bounds the watcher's cost across a
+// large archive backlog: idle timeout is opt-in, so the archived thousands are
+// unarmed and cost one field read each — no tmux subprocess.
+func TestIdleTimeoutWatcher_SkipsUnarmedArchivedBeforeCapture(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	stopper := &recordingStopper{}
+
+	t.Setenv("HOME", t.TempDir())
+
+	inst := newRunningInstance("inst-archived-unarmed", "worker-archived", 0) // unarmed
+	inst.ArchivedAt = clock.Now()
+
+	failingCapture := func(*Instance) (string, error) {
+		t.Fatalf("Capture called for unarmed session %q — should have been skipped", inst.ID)
+		return "", nil
+	}
+
+	w := NewIdleTimeoutWatcher(IdleTimeoutWatcherConfig{
+		Now: clock.Now, Capture: failingCapture, Stop: stopper.Stop,
+	})
+
+	w.Tick([]*Instance{inst})
+	clock.Advance(11 * time.Second)
+	w.Tick([]*Instance{inst})
+
+	if got := stopper.StoppedIDs(); len(got) != 0 {
+		t.Fatalf("unarmed session must never be idle-stopped, got %v", got)
+	}
+}
+
+// Safety net: an ARMED archived session whose tmux Kill silently failed keeps a
+// live pane and a frozen live-ish Status. The watcher is the only mechanism
+// that will ever stop that orphan, so being archived must NOT exempt it.
+// Regression test for the archived-skip that removed this net.
+func TestIdleTimeoutWatcher_ArmedArchivedOrphanIsStopped(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	capture := newFakeCapture()
+	stopper := &recordingStopper{}
+
+	t.Setenv("HOME", t.TempDir())
+
+	// Archived, but Kill failed: status frozen at running, idle timeout armed.
+	inst := newRunningInstance("inst-archived-orphan", "worker-orphan", 10)
+	inst.ArchivedAt = clock.Now()
+	capture.Set(inst.ID, "orphaned agent, no output change")
+
+	w := NewIdleTimeoutWatcher(IdleTimeoutWatcherConfig{
+		Now: clock.Now, Capture: capture.Capture, Stop: stopper.Stop,
+	})
+
+	w.Tick([]*Instance{inst}) // baseline
+	clock.Advance(11 * time.Second)
+	w.Tick([]*Instance{inst}) // idle threshold exceeded → stop the orphan
+
+	stopped := stopper.StoppedIDs()
+	if len(stopped) != 1 || stopped[0] != inst.ID {
+		t.Fatalf("armed archived orphan must be idle-stopped, got %v", stopped)
+	}
+}


### PR DESCRIPTION
## What

Reorders the idle-timeout watcher's per-instance checks so the **cost gate** (`IdleTimeoutSecs <= 0`) runs first.

`Capture()` is a tmux subprocess and the only expensive step in this loop, and it's unreachable for a session with no idle timeout armed. Idle timeout is opt-in per session, so a backlog of hundreds of unarmed archived sessions now costs one `int64` read each.

## Why not just skip archived sessions

That's the obvious optimization, and it's wrong — worth stating explicitly so nobody "simplifies" it back later.

An archived session whose tmux `Kill` silently failed keeps a **live pane** and a frozen live-ish status. This watcher is the only mechanism that will ever stop that orphan. Skipping archived instances wholesale buys no measurable time — they're unarmed, hence already free after the reorder — while removing the safety net for exactly the orphan class that motivated the watcher.

So the reorder gets the performance win *and* keeps the coverage. The reasoning is captured in a comment at the call site.

Independent of #1600 / #1601 / #1602. `internal/session` passes with `-race`.