### PR TITLE
feat(context-budget): per-session token warnings + autonomous fork-on-budget handoff (resubmit of #1535)

### DIFF
--- a/internal/session/context_budget.go
+++ b/internal/session/context_budget.go
@@ -1,0 +1,62 @@
+package session
+
+// BudgetLevel classifies a session's context-window occupancy against the
+// configured absolute-token thresholds. Lower bounds are inclusive.
+type BudgetLevel int
+
+const (
+	// BudgetNormal: tokens < WarnTokens.
+	BudgetNormal BudgetLevel = iota
+	// BudgetWarn: WarnTokens <= tokens < HighTokens.
+	BudgetWarn
+	// BudgetHigh: HighTokens <= tokens < CeilingTokens.
+	BudgetHigh
+	// BudgetOver: tokens >= CeilingTokens.
+	BudgetOver
+)
+
+func (l BudgetLevel) String() string {
+	switch l {
+	case BudgetWarn:
+		return "warn"
+	case BudgetHigh:
+		return "high"
+	case BudgetOver:
+		return "over"
+	default:
+		return "normal"
+	}
+}
+
+// BudgetLevelForTokens maps an absolute context-token count to a BudgetLevel
+// using inclusive lower bounds (exactly WarnTokens => warn).
+func BudgetLevelForTokens(tokens int, cfg ContextBudgetSettings) BudgetLevel {
+	switch {
+	case tokens >= cfg.CeilingTokens:
+		return BudgetOver
+	case tokens >= cfg.HighTokens:
+		return BudgetHigh
+	case tokens >= cfg.WarnTokens:
+		return BudgetWarn
+	default:
+		return BudgetNormal
+	}
+}
+
+// BudgetLevel returns the budget level for this session's current context-window
+// occupancy. Callers must first confirm a usable token signal exists (Claude-
+// compatible tool + non-nil analytics); a zero CurrentContextTokens maps to
+// BudgetNormal.
+func (a *SessionAnalytics) BudgetLevel(cfg ContextBudgetSettings) BudgetLevel {
+	return BudgetLevelForTokens(a.CurrentContextTokens, cfg)
+}
+
+// GetContextBudgetSettings loads the user config (cached) and returns the
+// context-budget settings with defaults applied. Convenience for UI callers.
+func GetContextBudgetSettings() ContextBudgetSettings {
+	cfg, err := LoadUserConfig()
+	if err != nil || cfg == nil {
+		return (&UserConfig{}).GetContextBudget()
+	}
+	return cfg.GetContextBudget()
+}

--- a/internal/session/context_budget_config_test.go
+++ b/internal/session/context_budget_config_test.go
@@ -1,0 +1,53 @@
+package session
+
+import "testing"
+
+func TestGetContextBudget_DefaultsWhenUnset(t *testing.T) {
+	c := &UserConfig{} // no [context_budget] section present
+	got := c.GetContextBudget()
+
+	if !got.GetEnabled() {
+		t.Errorf("Enabled default = false, want true")
+	}
+	if !got.GetAutonomousHandoff() {
+		t.Errorf("AutonomousHandoff default = false, want true")
+	}
+	if got.WarnTokens != 150000 {
+		t.Errorf("WarnTokens = %d, want 150000", got.WarnTokens)
+	}
+	if got.HighTokens != 200000 {
+		t.Errorf("HighTokens = %d, want 200000", got.HighTokens)
+	}
+	if got.CeilingTokens != 250000 {
+		t.Errorf("CeilingTokens = %d, want 250000", got.CeilingTokens)
+	}
+	if got.HandoffTimeoutSeconds != 300 {
+		t.Errorf("HandoffTimeoutSeconds = %d, want 300", got.HandoffTimeoutSeconds)
+	}
+}
+
+func TestGetContextBudget_RespectsExplicitValues(t *testing.T) {
+	disabled := false
+	c := &UserConfig{ContextBudget: ContextBudgetSettings{
+		Enabled:               &disabled,
+		WarnTokens:            100000,
+		HighTokens:            120000,
+		CeilingTokens:         140000,
+		HandoffTimeoutSeconds: 60,
+	}}
+	got := c.GetContextBudget()
+
+	if got.GetEnabled() {
+		t.Errorf("Enabled = true, want false (explicit)")
+	}
+	if got.WarnTokens != 100000 || got.HighTokens != 120000 || got.CeilingTokens != 140000 {
+		t.Errorf("explicit thresholds not preserved: %+v", got)
+	}
+	if got.HandoffTimeoutSeconds != 60 {
+		t.Errorf("HandoffTimeoutSeconds = %d, want 60", got.HandoffTimeoutSeconds)
+	}
+	// AutonomousHandoff left nil -> defaults to true even when other fields explicit.
+	if !got.GetAutonomousHandoff() {
+		t.Errorf("AutonomousHandoff default = false, want true")
+	}
+}

--- a/internal/session/context_budget_test.go
+++ b/internal/session/context_budget_test.go
@@ -1,0 +1,38 @@
+package session
+
+import "testing"
+
+func boundaryCfg() ContextBudgetSettings {
+	// Use the defaults via GetContextBudget on an empty config.
+	return (&UserConfig{}).GetContextBudget()
+}
+
+func TestBudgetLevelForTokens_Boundaries(t *testing.T) {
+	cfg := boundaryCfg()
+	cases := []struct {
+		tokens int
+		want   BudgetLevel
+	}{
+		{0, BudgetNormal},
+		{149999, BudgetNormal},
+		{150000, BudgetWarn},
+		{199999, BudgetWarn},
+		{200000, BudgetHigh},
+		{249999, BudgetHigh},
+		{250000, BudgetOver},
+		{500000, BudgetOver},
+	}
+	for _, tc := range cases {
+		if got := BudgetLevelForTokens(tc.tokens, cfg); got != tc.want {
+			t.Errorf("BudgetLevelForTokens(%d) = %v, want %v", tc.tokens, got, tc.want)
+		}
+	}
+}
+
+func TestSessionAnalytics_BudgetLevel(t *testing.T) {
+	cfg := boundaryCfg()
+	a := &SessionAnalytics{CurrentContextTokens: 200000}
+	if got := a.BudgetLevel(cfg); got != BudgetHigh {
+		t.Errorf("BudgetLevel = %v, want BudgetHigh", got)
+	}
+}

--- a/internal/session/context_handoff.go
+++ b/internal/session/context_handoff.go
@@ -1,0 +1,76 @@
+package session
+
+import "time"
+
+// HandoffState is the persisted per-session position in the autonomous handoff
+// state machine. The zero value ("") is HandoffNormal so an unset session is
+// implicitly normal.
+type HandoffState string
+
+const (
+	HandoffNormal        HandoffState = ""
+	HandoffWrapRequested HandoffState = "wrap_requested"
+	HandoffWaiting       HandoffState = "wait_handoff"
+	HandoffDone          HandoffState = "done"
+	HandoffFailsafe      HandoffState = "failsafe"
+)
+
+// HandoffAction is the side effect the caller must perform on a transition.
+type HandoffAction int
+
+const (
+	ActionNone HandoffAction = iota
+	// ActionRequestWrap: create the handoff dir, inject the wrap-up instruction,
+	// pause new work, and record TriggeredAt = now.
+	ActionRequestWrap
+	// ActionFork: read PROMPT.md, fork the continuation session, archive the old one.
+	ActionFork
+	// ActionFailsafe: pause/stop the old session and raise the loudest alert.
+	ActionFailsafe
+)
+
+// HandoffInputs are the injected observations the pure state machine reasons
+// over. No I/O happens inside the machine.
+type HandoffInputs struct {
+	Tokens      int       // CurrentContextTokens
+	PromptReady bool      // handoff/<id>/PROMPT.md exists
+	AgentIdle   bool      // session is waiting/idle (not actively generating)
+	Now         time.Time // current clock
+	TriggeredAt time.Time // when WRAP_REQUESTED was entered (zero before that)
+}
+
+// HandoffDecision is the machine's output for one tick.
+type HandoffDecision struct {
+	Next   HandoffState
+	Action HandoffAction
+}
+
+func timeoutElapsed(in HandoffInputs, cfg ContextBudgetSettings) bool {
+	if in.TriggeredAt.IsZero() || cfg.HandoffTimeoutSeconds <= 0 {
+		return false
+	}
+	return in.Now.Sub(in.TriggeredAt) >= time.Duration(cfg.HandoffTimeoutSeconds)*time.Second
+}
+
+// NextHandoffState advances the handoff state machine by one tick. Pure.
+func NextHandoffState(cur HandoffState, in HandoffInputs, cfg ContextBudgetSettings) HandoffDecision {
+	switch cur {
+	case HandoffDone, HandoffFailsafe:
+		return HandoffDecision{Next: cur, Action: ActionNone}
+
+	case HandoffWrapRequested, HandoffWaiting:
+		if in.Tokens >= cfg.CeilingTokens || timeoutElapsed(in, cfg) {
+			return HandoffDecision{Next: HandoffFailsafe, Action: ActionFailsafe}
+		}
+		if in.PromptReady && in.AgentIdle {
+			return HandoffDecision{Next: HandoffDone, Action: ActionFork}
+		}
+		return HandoffDecision{Next: HandoffWaiting, Action: ActionNone}
+
+	default: // HandoffNormal
+		if in.Tokens >= cfg.HighTokens {
+			return HandoffDecision{Next: HandoffWrapRequested, Action: ActionRequestWrap}
+		}
+		return HandoffDecision{Next: HandoffNormal, Action: ActionNone}
+	}
+}

--- a/internal/session/context_handoff_test.go
+++ b/internal/session/context_handoff_test.go
@@ -1,0 +1,54 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func handoffCfg() ContextBudgetSettings {
+	return (&UserConfig{}).GetContextBudget() // high=200000, ceiling=250000, timeout=300s
+}
+
+func TestNextHandoffState_Table(t *testing.T) {
+	cfg := handoffCfg()
+	base := time.Unix(1_000_000, 0)
+	trig := base.Add(-10 * time.Second) // 10s into wrap
+
+	cases := []struct {
+		name       string
+		cur        HandoffState
+		in         HandoffInputs
+		wantNext   HandoffState
+		wantAction HandoffAction
+	}{
+		{"normal stays normal below high", HandoffNormal,
+			HandoffInputs{Tokens: 199999, Now: base}, HandoffNormal, ActionNone},
+		{"normal triggers wrap at high", HandoffNormal,
+			HandoffInputs{Tokens: 200000, Now: base}, HandoffWrapRequested, ActionRequestWrap},
+		{"wrap waits when not ready", HandoffWrapRequested,
+			HandoffInputs{Tokens: 210000, Now: base, TriggeredAt: trig}, HandoffWaiting, ActionNone},
+		{"waiting forks when ready+idle", HandoffWaiting,
+			HandoffInputs{Tokens: 210000, PromptReady: true, AgentIdle: true, Now: base, TriggeredAt: trig},
+			HandoffDone, ActionFork},
+		{"waiting holds when ready but busy", HandoffWaiting,
+			HandoffInputs{Tokens: 210000, PromptReady: true, AgentIdle: false, Now: base, TriggeredAt: trig},
+			HandoffWaiting, ActionNone},
+		{"ceiling crossed -> failsafe", HandoffWaiting,
+			HandoffInputs{Tokens: 250000, PromptReady: false, Now: base, TriggeredAt: trig},
+			HandoffFailsafe, ActionFailsafe},
+		{"timeout -> failsafe", HandoffWaiting,
+			HandoffInputs{Tokens: 210000, PromptReady: false, Now: base, TriggeredAt: base.Add(-301 * time.Second)},
+			HandoffFailsafe, ActionFailsafe},
+		{"done is terminal", HandoffDone,
+			HandoffInputs{Tokens: 300000, Now: base}, HandoffDone, ActionNone},
+		{"failsafe is terminal", HandoffFailsafe,
+			HandoffInputs{Tokens: 300000, Now: base}, HandoffFailsafe, ActionNone},
+	}
+	for _, tc := range cases {
+		got := NextHandoffState(tc.cur, tc.in, cfg)
+		if got.Next != tc.wantNext || got.Action != tc.wantAction {
+			t.Errorf("%s: NextHandoffState = {%v,%v}, want {%v,%v}",
+				tc.name, got.Next, got.Action, tc.wantNext, tc.wantAction)
+		}
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -175,6 +175,9 @@ type UserConfig struct {
 	// Notifications defines waiting session notification bar settings
 	Notifications NotificationsConfig `toml:"notifications,omitempty"`
 
+	// ContextBudget defines context-token usage budget and autonomous fork handling
+	ContextBudget ContextBudgetSettings `toml:"context_budget,omitempty"`
+
 	// Instances defines multiple instance behavior settings
 	Instances InstanceSettings `toml:"instances,omitempty"`
 
@@ -1036,6 +1039,62 @@ func (n NotificationsConfig) GetTransitionEventsEnabled() bool {
 		return true
 	}
 	return *n.TransitionEvents
+}
+
+// ContextBudgetSettings configures absolute-token context warnings and the
+// autonomous fork-on-budget handoff. Thresholds measure CurrentContextTokens
+// (last-turn input + cache-read), i.e. real context-window occupancy.
+type ContextBudgetSettings struct {
+	// Enabled turns the whole feature on (default: true). Pointer so an unset
+	// section still defaults to enabled.
+	Enabled *bool `toml:"enabled,omitempty"`
+	// WarnTokens is the soft-warning threshold (default: 150000).
+	WarnTokens int `toml:"warn_tokens,omitzero"`
+	// HighTokens is the loud-warning + autonomous wrap-up trigger (default: 200000).
+	HighTokens int `toml:"high_tokens,omitzero"`
+	// CeilingTokens is the hard ceiling that must not be crossed (default: 250000).
+	CeilingTokens int `toml:"ceiling_tokens,omitzero"`
+	// AutonomousHandoff enables the fork-new-session handoff on autonomous
+	// sessions (default: true). Pointer for the same unset-defaults-true reason.
+	AutonomousHandoff *bool `toml:"autonomous_handoff,omitempty"`
+	// HandoffTimeoutSeconds is the failsafe window for the wrap-up to produce
+	// its PROMPT.md (default: 300).
+	HandoffTimeoutSeconds int `toml:"handoff_timeout_seconds,omitzero"`
+}
+
+// GetEnabled returns Enabled, defaulting to true when unset.
+func (c ContextBudgetSettings) GetEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// GetAutonomousHandoff returns AutonomousHandoff, defaulting to true when unset.
+func (c ContextBudgetSettings) GetAutonomousHandoff() bool {
+	if c.AutonomousHandoff == nil {
+		return true
+	}
+	return *c.AutonomousHandoff
+}
+
+// GetContextBudget returns the context-budget settings with zero/nil fields
+// filled in with documented defaults. Mirrors the GetConductor accessor.
+func (c *UserConfig) GetContextBudget() ContextBudgetSettings {
+	cfg := c.ContextBudget
+	if cfg.WarnTokens == 0 {
+		cfg.WarnTokens = 150000
+	}
+	if cfg.HighTokens == 0 {
+		cfg.HighTokens = 200000
+	}
+	if cfg.CeilingTokens == 0 {
+		cfg.CeilingTokens = 250000
+	}
+	if cfg.HandoffTimeoutSeconds == 0 {
+		cfg.HandoffTimeoutSeconds = 300
+	}
+	return cfg
 }
 
 // InstanceSettings configures multiple agent-deck instance behavior

--- a/internal/statedb/context_handoff_state_test.go
+++ b/internal/statedb/context_handoff_state_test.go
@@ -1,0 +1,88 @@
+package statedb
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHandoffState_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	row := &InstanceRow{
+		ID:          "sess-1",
+		Title:       "worker",
+		ProjectPath: "/tmp/p",
+		GroupPath:   "my-sessions",
+		Tool:        "claude",
+		Status:      "running",
+		CreatedAt:   time.Unix(1000, 0),
+	}
+	if err := db.SaveInstances([]*InstanceRow{row}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	// Unset: empty state, zero time.
+	gotState, gotAt, err := db.ReadHandoffState("sess-1")
+	if err != nil {
+		t.Fatalf("ReadHandoffState(unset): %v", err)
+	}
+	if gotState != "" || !gotAt.IsZero() {
+		t.Errorf("unset = (%q,%v), want empty/zero", gotState, gotAt)
+	}
+
+	trig := time.Unix(1700000000, 0)
+	if err := db.WriteHandoffState("sess-1", "wait_handoff", trig); err != nil {
+		t.Fatalf("WriteHandoffState: %v", err)
+	}
+	gotState, gotAt, err = db.ReadHandoffState("sess-1")
+	if err != nil {
+		t.Fatalf("ReadHandoffState: %v", err)
+	}
+	if gotState != "wait_handoff" {
+		t.Errorf("state = %q, want wait_handoff", gotState)
+	}
+	if gotAt.Unix() != trig.Unix() {
+		t.Errorf("triggeredAt = %v, want %v", gotAt, trig)
+	}
+}
+
+func TestHandoffState_SurvivesFullSave(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	row := &InstanceRow{ID: "s", Title: "t", ProjectPath: "/p", GroupPath: "g", Tool: "claude", Status: "running", CreatedAt: time.Unix(1, 0)}
+	if err := db.SaveInstances([]*InstanceRow{row}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	if err := db.WriteHandoffState("s", "wrap_requested", time.Unix(50, 0)); err != nil {
+		t.Fatalf("WriteHandoffState: %v", err)
+	}
+	// A subsequent full-table save (e.g. status change) must not clobber the key.
+	row.Status = "waiting"
+	if err := db.SaveInstances([]*InstanceRow{row}); err != nil {
+		t.Fatalf("SaveInstances#2: %v", err)
+	}
+	gotState, _, err := db.ReadHandoffState("s")
+	if err != nil {
+		t.Fatalf("ReadHandoffState: %v", err)
+	}
+	if gotState != "wrap_requested" {
+		t.Errorf("state after full save = %q, want wrap_requested", gotState)
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1353,6 +1353,56 @@ func (s *StateDB) WriteGeminiSessionBinding(id, sessionID string, detectedAt tim
 	})
 }
 
+// WriteHandoffState atomically updates the autonomous-handoff state and trigger
+// time inside the tool_data JSON column for one instance, via a targeted
+// json_set UPDATE. Like WriteClaudeSessionBinding it avoids a whole-row INSERT
+// OR REPLACE so it cannot clobber concurrent writes to other tool_data fields,
+// and it sidesteps the full-table save's external-change guard. A zero
+// triggeredAt clears the trigger timestamp ($.handoff_triggered_at => 0).
+func (s *StateDB) WriteHandoffState(id, state string, triggeredAt time.Time) error {
+	var at int64
+	if !triggeredAt.IsZero() {
+		at = triggeredAt.Unix()
+	}
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances
+			   SET tool_data = json_set(
+			         COALESCE(tool_data, '{}'),
+			         '$.handoff_state', ?,
+			         '$.handoff_triggered_at', ?)
+			 WHERE id = ?`,
+			state, at, id,
+		)
+		return err
+	})
+}
+
+// ReadHandoffState returns the persisted handoff state and trigger time for an
+// instance. An unset key yields ("", zero time, nil) so a fresh session reads
+// as HandoffNormal. Missing row also returns ("", zero time, nil).
+func (s *StateDB) ReadHandoffState(id string) (string, time.Time, error) {
+	var state sql.NullString
+	var at sql.NullInt64
+	err := s.db.QueryRow(
+		`SELECT json_extract(tool_data, '$.handoff_state'),
+		        json_extract(tool_data, '$.handoff_triggered_at')
+		   FROM instances WHERE id = ?`,
+		id,
+	).Scan(&state, &at)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", time.Time{}, nil
+		}
+		return "", time.Time{}, err
+	}
+	var t time.Time
+	if at.Valid && at.Int64 > 0 {
+		t = time.Unix(at.Int64, 0)
+	}
+	return state.String, t, nil
+}
+
 // ReadAllStatuses returns status + acknowledged flag for every instance.
 func (s *StateDB) ReadAllStatuses() (map[string]StatusRow, error) {
 	rows, err := s.db.Query("SELECT id, status, tool, acknowledged FROM instances")

--- a/internal/tmux/exists_cached_test.go
+++ b/internal/tmux/exists_cached_test.go
@@ -1,0 +1,255 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// ExistsCached() is the cheap liveness check used by hot periodic loops (the
+// background configure loop and theme propagation). It must answer ONLY from
+// in-process state — a positive session-cache hit on the session's own socket
+// or a live pipe — and NEVER spawn a `tmux has-session` subprocess. That
+// subprocess, multiplied over ~1000 sessions per tick, is the exact main-loop
+// storm the nav-freeze fix eliminated. These cases pin the contract.
+
+func withCleanSessionCache(t *testing.T) {
+	t.Helper()
+	origLister := listSessionsOnSocket
+	t.Cleanup(func() {
+		SetDefaultSocketName("")
+		sessionCacheMu.Lock()
+		sessionCacheData = nil
+		sessionCacheTime = time.Time{}
+		sessionCacheMu.Unlock()
+		// Drain any in-flight background refresh before swapping the lister
+		// back, or a goroutine from this test writes into the next test's cache.
+		drainSocketRefreshes(t)
+		listSessionsOnSocket = origLister
+		ResetSocketSessionCacheForTest()
+	})
+	SetDefaultSocketName("")
+	drainSocketRefreshes(t)
+	ResetSocketSessionCacheForTest()
+	// Default: no isolated socket has any session, and never touch real tmux.
+	listSessionsOnSocket = func(string) (map[string]struct{}, error) {
+		return map[string]struct{}{}, nil
+	}
+}
+
+// stubSocketSessions makes the per-socket lister return a fixed live set and
+// signals (via the returned channel) each time it is invoked, so tests can wait
+// for the asynchronous stale-while-revalidate refresh to land.
+func stubSocketSessions(t *testing.T, names map[string][]string) <-chan string {
+	t.Helper()
+	calls := make(chan string, 16)
+	listSessionsOnSocket = func(socket string) (map[string]struct{}, error) {
+		set := map[string]struct{}{}
+		for _, n := range names[socket] {
+			set[n] = struct{}{}
+		}
+		select {
+		case calls <- socket:
+		default:
+		}
+		return set, nil
+	}
+	return calls
+}
+
+// drainSocketRefreshes blocks until no per-socket refresh goroutine is in
+// flight, so one test's background probe cannot land in the next test's cache.
+func drainSocketRefreshes(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		socketSessionCacheMu.Lock()
+		inFlight := false
+		for _, e := range socketSessionCache {
+			if e.refreshing {
+				inFlight = true
+				break
+			}
+		}
+		socketSessionCacheMu.Unlock()
+		if !inFlight {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out draining in-flight per-socket refreshes")
+}
+
+// waitForSocketCache polls cond until true or the deadline elapses.
+func waitForSocketCache(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+func primeSessionCache(names ...string) {
+	sessionCacheMu.Lock()
+	m := make(map[string]int64, len(names))
+	for _, n := range names {
+		m[n] = time.Now().Unix()
+	}
+	sessionCacheData = m
+	sessionCacheTime = time.Now()
+	sessionCacheMu.Unlock()
+}
+
+// A fresh positive cache hit on the default socket means the session is live.
+func TestExistsCached_PositiveDefaultSocketHit(t *testing.T) {
+	withCleanSessionCache(t)
+	primeSessionCache("cached-foo")
+
+	s := &Session{Name: "cached-foo"} // SocketName == "" == default
+	if !s.ExistsCached() {
+		t.Fatalf("ExistsCached() must return true for a fresh positive cache hit on the default socket")
+	}
+}
+
+// A cache miss (session absent from a fresh cache) must return false WITHOUT
+// probing — the deliberate under-report that keeps the periodic loops cheap.
+func TestExistsCached_MissReturnsFalseNoProbe(t *testing.T) {
+	withCleanSessionCache(t)
+	primeSessionCache("someone-else")
+
+	s := &Session{Name: "not-in-cache"}
+	// If this ever fell through to a has-session subprocess it would hang/slow;
+	// the cache-only contract guarantees an immediate false.
+	done := make(chan bool, 1)
+	go func() { done <- s.ExistsCached() }()
+	select {
+	case got := <-done:
+		if got {
+			t.Fatalf("ExistsCached() must return false on a cache miss")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("ExistsCached() blocked on a cache miss — it must never subprocess-probe")
+	}
+}
+
+// A stale/empty cache is not evidence of anything; return false, never probe.
+func TestExistsCached_StaleCacheReturnsFalse(t *testing.T) {
+	withCleanSessionCache(t)
+	sessionCacheMu.Lock()
+	sessionCacheData = map[string]int64{"cached-foo": time.Now().Unix()}
+	sessionCacheTime = time.Now().Add(-1 * time.Hour) // past TTL
+	sessionCacheMu.Unlock()
+
+	s := &Session{Name: "cached-foo"}
+	if s.ExistsCached() {
+		t.Fatalf("ExistsCached() must return false when the cache is stale")
+	}
+}
+
+// Socket guard (#755 / multi-socket aliasing): a same-named entry on the
+// default-socket cache is not evidence a session on a DIFFERENT socket exists.
+// ExistsCached must ignore the cache for a non-default socket and, when that
+// socket genuinely has no such session, return false — without a subprocess on
+// the calling goroutine.
+func TestExistsCached_NonDefaultSocketIgnoresDefaultCache(t *testing.T) {
+	withCleanSessionCache(t)
+	primeSessionCache("iso-foo")
+	stubSocketSessions(t, nil) // isolated socket has no sessions
+
+	s := &Session{Name: "iso-foo", SocketName: "agent-deck-iso-not-real"}
+	if s.ExistsCached() {
+		t.Fatalf("ExistsCached() trusted the default-socket cache for a session on socket %q — "+
+			"a same-named default-socket entry is not evidence of a session on another socket", s.SocketName)
+	}
+}
+
+// Regression: a LIVE session on an isolated socket must eventually read true.
+// Before the per-socket cache, ExistsCached() had no source of truth for such a
+// session (the default cache is off-limits per #755, and PipeManager only
+// connects wanted sessions), so it returned false on EVERY tick forever —
+// silently starving those sessions of EnsureConfigured and theme propagation.
+func TestExistsCached_LiveSessionOnIsolatedSocketBecomesTrue(t *testing.T) {
+	withCleanSessionCache(t)
+	stubSocketSessions(t, map[string][]string{"iso-sock": {"iso-live"}})
+
+	s := &Session{Name: "iso-live", SocketName: "iso-sock"}
+
+	// Cold cache: the first call under-reports (false) but kicks a background
+	// refresh. It must not block on the probe.
+	done := make(chan bool, 1)
+	go func() { done <- s.ExistsCached() }()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("ExistsCached() blocked on a cold isolated-socket cache — it must never probe inline")
+	}
+
+	// Once the background refresh lands, the live session reads true and STAYS
+	// true. A permanent false here is the bug this test pins.
+	waitForSocketCache(t, s.ExistsCached, "live isolated-socket session to be seen after background refresh")
+	if !s.ExistsCached() {
+		t.Fatalf("ExistsCached() must stay true for a live session on an isolated socket")
+	}
+}
+
+// A dead session on an isolated socket stays false even after the cache warms.
+func TestExistsCached_DeadSessionOnIsolatedSocketStaysFalse(t *testing.T) {
+	withCleanSessionCache(t)
+	calls := stubSocketSessions(t, map[string][]string{"iso-sock": {"some-other-session"}})
+
+	s := &Session{Name: "iso-gone", SocketName: "iso-sock"}
+	_ = s.ExistsCached() // kick the refresh
+
+	select {
+	case <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("background per-socket refresh never ran")
+	}
+	waitForSocketCache(t, func() bool {
+		socketSessionCacheMu.Lock()
+		defer socketSessionCacheMu.Unlock()
+		e, ok := socketSessionCache["iso-sock"]
+		return ok && e.warm
+	}, "per-socket cache to warm")
+
+	if s.ExistsCached() {
+		t.Fatalf("ExistsCached() must stay false for a session absent from its own socket")
+	}
+}
+
+// An indeterminate probe (timeout) must not flap a previously-live session to
+// false: the last known name set is retained.
+func TestExistsCached_IndeterminateProbeKeepsLastKnownSet(t *testing.T) {
+	withCleanSessionCache(t)
+	stubSocketSessions(t, map[string][]string{"iso-sock": {"iso-live"}})
+
+	s := &Session{Name: "iso-live", SocketName: "iso-sock"}
+	_ = s.ExistsCached()
+	waitForSocketCache(t, s.ExistsCached, "initial warm cache showing the live session")
+
+	// Now every probe fails. Force the entry stale so the next read re-probes.
+	listSessionsOnSocket = func(string) (map[string]struct{}, error) {
+		return nil, context.DeadlineExceeded
+	}
+	socketSessionCacheMu.Lock()
+	socketSessionCache["iso-sock"].refreshedAt = time.Now().Add(-1 * time.Hour)
+	socketSessionCacheMu.Unlock()
+
+	if !s.ExistsCached() {
+		t.Fatalf("a stale entry must still answer from the last known set, not false")
+	}
+	// Let the failing refresh land; the previous set must survive it.
+	waitForSocketCache(t, func() bool {
+		socketSessionCacheMu.Lock()
+		defer socketSessionCacheMu.Unlock()
+		return !socketSessionCache["iso-sock"].refreshing
+	}, "failing refresh to complete")
+
+	if !s.ExistsCached() {
+		t.Fatalf("an indeterminate probe must retain the last known set, not report the session gone")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -363,6 +363,140 @@ func HasSessionOnSocket(socketName, name string) bool {
 	return tmuxSessionExistsOnSocket(socketName, name)
 }
 
+// Per-socket session cache — backs ExistsCached() for sessions that live on an
+// ISOLATED socket (SocketName != DefaultSocketName()).
+//
+// The shared sessionCache above describes DefaultSocketName() only, and #755
+// forbids answering an isolated-socket session from it (a same-named entry is a
+// different session). PipeManager only holds control connections for wanted
+// (focused/attached) sessions. So without this cache, ExistsCached() had no
+// source of truth at all for an isolated-socket session and returned false on
+// every tick forever — silently starving those sessions of EnsureConfigured /
+// SyncSessionIDsToTmux and of COLORFGBG theme propagation.
+//
+// Refresh is stale-while-revalidate and keyed by SOCKET: one `list-sessions`
+// subprocess per distinct socket per TTL, spawned on a background goroutine.
+// Readers never block and never spawn — preserving the invariant that made
+// ExistsCached() safe for loops that walk every session each tick. Socket count
+// is O(1)-ish (a handful), never O(sessions), so this cannot recreate the
+// subprocess storm.
+const socketSessionCacheTTL = 5 * time.Second
+
+type socketSessionsEntry struct {
+	names       map[string]struct{}
+	refreshedAt time.Time
+	refreshing  bool
+	warm        bool // a probe has completed at least once (success or failure)
+}
+
+var (
+	socketSessionCacheMu sync.Mutex
+	socketSessionCache   = map[string]*socketSessionsEntry{}
+
+	// listSessionsOnSocket is a package var so tests can exercise the cache
+	// without a live tmux server.
+	listSessionsOnSocket = defaultListSessionsOnSocket
+)
+
+// ListSessionNamesOnSocket returns the set of live session names on one tmux
+// socket using a SINGLE bounded `list-sessions`. It is the socket-complete
+// alternative to probing each session with `has-session`: callers that need
+// liveness for N sessions should group them by socket and call this once per
+// distinct socket (O(sockets) subprocesses instead of O(sessions)).
+//
+// An error means the probe was indeterminate (timed out). Callers MUST treat
+// that as "assume alive" — never as "no sessions" — or a briefly-wedged server
+// will look like a pile of dead sessions. A successful probe returning an empty
+// set is authoritative (server present, no sessions / no server running).
+func ListSessionNamesOnSocket(socketName string) (map[string]struct{}, error) {
+	return listSessionsOnSocket(socketName)
+}
+
+// defaultListSessionsOnSocket returns the set of session names on the given
+// tmux socket via a single bounded `list-sessions`. A server with no sessions
+// (or no server at all) is an empty set, not an error.
+func defaultListSessionsOnSocket(socketName string) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+
+	out, err := tmuxExecContext(ctx, socketName, "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		// "no server running" / "no sessions" are legitimate empty results; any
+		// other failure (timeout, exec error) is reported so the caller keeps
+		// the previous entry instead of flapping every session to "gone".
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, ctx.Err()
+		}
+		return map[string]struct{}{}, nil
+	}
+
+	names := map[string]struct{}{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names[line] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+// sessionExistsOnSocketCached answers "is <name> live on <socketName>?" from
+// the per-socket cache, never blocking. On a cold or stale entry it kicks a
+// single background refresh for that socket (at most one in flight per socket)
+// and answers from whatever it currently knows: false when cold.
+func sessionExistsOnSocketCached(socketName, name string) bool {
+	socket := strings.TrimSpace(socketName)
+
+	socketSessionCacheMu.Lock()
+	defer socketSessionCacheMu.Unlock()
+
+	entry, ok := socketSessionCache[socket]
+	if !ok {
+		entry = &socketSessionsEntry{names: map[string]struct{}{}}
+		socketSessionCache[socket] = entry
+	}
+
+	stale := !entry.warm || time.Since(entry.refreshedAt) > socketSessionCacheTTL
+	if stale && !entry.refreshing {
+		entry.refreshing = true
+		// Snapshot the lister under the lock: the background goroutine must not
+		// read the package var concurrently with a test swapping it.
+		go refreshSocketSessionCache(socket, listSessionsOnSocket)
+	}
+
+	_, exists := entry.names[name]
+	return exists
+}
+
+// refreshSocketSessionCache re-lists one socket off the caller's goroutine and
+// replaces its entry. A probe error (timeout) leaves the previous name set in
+// place so a briefly-wedged server does not flap every session to "not found";
+// a successful probe is authoritative, including an empty result.
+func refreshSocketSessionCache(socket string, list func(string) (map[string]struct{}, error)) {
+	names, err := list(socket)
+
+	socketSessionCacheMu.Lock()
+	defer socketSessionCacheMu.Unlock()
+
+	entry, ok := socketSessionCache[socket]
+	if !ok {
+		entry = &socketSessionsEntry{names: map[string]struct{}{}}
+		socketSessionCache[socket] = entry
+	}
+	entry.refreshing = false
+	entry.refreshedAt = time.Now()
+	entry.warm = true
+	if err == nil {
+		entry.names = names
+	}
+}
+
+// ResetSocketSessionCacheForTest clears the per-socket cache between tests.
+func ResetSocketSessionCacheForTest() {
+	socketSessionCacheMu.Lock()
+	defer socketSessionCacheMu.Unlock()
+	socketSessionCache = map[string]*socketSessionsEntry{}
+}
+
 // sessionExistsFromCache checks if a session exists using the cached data
 // Returns (exists, cacheValid) - if cache is stale/empty, cacheValid is false
 func sessionExistsFromCache(name string) (bool, bool) {
@@ -2178,6 +2312,48 @@ func (s *Session) Exists() bool {
 		return true // probe timed out: indeterminate, assume still alive
 	}
 	return err == nil
+}
+
+// ExistsCached is a cheap, non-blocking liveness check for hot periodic loops
+// that iterate over ALL sessions every tick (e.g. the background configure loop
+// and theme propagation). It NEVER spawns a subprocess on the calling
+// goroutine: a single wedged/absent server multiplied by ~1000 sessions is the
+// exact subprocess-storm that froze the UI main goroutine 4–7s per tick (see
+// the nav-freeze fix). It answers only from in-process state:
+//
+//   - a POSITIVE session-cache hit on the session's OWN socket, or
+//   - a live PipeManager control connection, or
+//   - a POSITIVE hit in the per-socket cache (isolated sockets).
+//
+// The socket guard mirrors Exists(): the shared sessionCache describes
+// DefaultSocketName() only, so a same-named entry on a different socket is not
+// this session (#755 / multi-socket cache aliasing). Sessions on an isolated
+// socket are therefore answered from a SEPARATE per-socket cache, refreshed in
+// the background by one `list-sessions` per socket per TTL. Without it those
+// sessions would read false FOREVER (never in the default cache; PipeManager
+// only connects wanted/attached sessions), permanently starving them of
+// EnsureConfigured and theme propagation — a bug the "retries next tick"
+// framing hid. Bounding the refresh by SOCKET count, not session count, keeps
+// the no-storm invariant that motivated this method.
+//
+// A false is still a deliberate under-report (cold cache, dead server, probe
+// failure): the only cost is that a cosmetic loop skips this session until the
+// cache warms. Callers MUST NOT feed ExistsCached() into destructive/restart
+// machinery — use Exists() (which confirms a negative with a real probe).
+func (s *Session) ExistsCached() bool {
+	if strings.TrimSpace(s.SocketName) == DefaultSocketName() {
+		if exists, cacheValid := sessionExistsFromCache(s.Name); cacheValid && exists {
+			return true
+		}
+	} else if sessionExistsOnSocketCached(s.SocketName, s.Name) {
+		return true
+	}
+	if pm := GetPipeManager(); pm != nil {
+		if pm.IsConnected(s.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsPaneDead returns true if the session's pane process has exited.

--- a/internal/ui/analytics_panel.go
+++ b/internal/ui/analytics_panel.go
@@ -337,28 +337,49 @@ func (p *AnalyticsPanel) renderHeader() string {
 	return b.String()
 }
 
+// budgetBarColor maps an absolute-token BudgetLevel to a bar color. Warn is
+// yellow; high and over are both red (over is distinguished by the louder
+// label/banner, not the bar color).
+func budgetBarColor(level session.BudgetLevel) lipgloss.Color {
+	switch level {
+	case session.BudgetWarn:
+		return ColorYellow
+	case session.BudgetHigh, session.BudgetOver:
+		return ColorRed
+	default:
+		return ColorGreen
+	}
+}
+
+// renderContextBarColored renders the bar with an explicit fill color (used by
+// the absolute-token budget path). renderContextBar delegates here using the
+// percent-based color for non-budget callers.
+func renderContextBarColored(percent float64, width int, barColor lipgloss.Color) string {
+	if width < 10 {
+		width = 10
+	}
+	filledWidth := int(float64(width) * percent / 100)
+	if filledWidth > width {
+		filledWidth = width
+	}
+	if filledWidth < 0 {
+		filledWidth = 0
+	}
+	emptyWidth := width - filledWidth
+	barStyle := lipgloss.NewStyle().Foreground(barColor)
+	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	return barStyle.Render(strings.Repeat("█", filledWidth)) +
+		dimStyle.Render(strings.Repeat("░", emptyWidth))
+}
+
 // renderContextBar renders a visual bar showing context window usage
 func (p *AnalyticsPanel) renderContextBar() string {
 	labelStyle := lipgloss.NewStyle().Foreground(ColorText).Bold(true)
-	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
 
 	percent := p.analytics.ContextPercent(0) // Use default 200k limit
 	if percent > 100 {
 		percent = 100
 	}
-
-	// Choose color based on usage
-	var barColor lipgloss.Color
-	switch {
-	case percent < 60:
-		barColor = ColorGreen
-	case percent < 80:
-		barColor = ColorYellow
-	default:
-		barColor = ColorRed
-	}
-
-	barStyle := lipgloss.NewStyle().Foreground(barColor)
 
 	// Calculate bar width (max 30 chars for the bar itself)
 	maxBarWidth := 30
@@ -369,14 +390,12 @@ func (p *AnalyticsPanel) renderContextBar() string {
 		}
 	}
 
-	filledWidth := int(percent / 100 * float64(maxBarWidth))
-	if filledWidth > maxBarWidth {
-		filledWidth = maxBarWidth
-	}
-	emptyWidth := maxBarWidth - filledWidth
+	// Color by absolute budget level rather than percent breakpoints.
+	cfg := session.GetContextBudgetSettings()
+	level := p.analytics.BudgetLevel(cfg)
+	barColor := budgetBarColor(level)
 
-	bar := barStyle.Render(strings.Repeat("█", filledWidth)) +
-		dimStyle.Render(strings.Repeat("░", emptyWidth))
+	bar := renderContextBarColored(percent, maxBarWidth, barColor)
 
 	percentStr := fmt.Sprintf("%.1f%%", percent)
 	percentStyle := lipgloss.NewStyle().Foreground(barColor).Bold(true)

--- a/internal/ui/context_budget_badge_test.go
+++ b/internal/ui/context_budget_badge_test.go
@@ -1,0 +1,23 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestBudgetBadge(t *testing.T) {
+	if got := budgetBadge(session.BudgetNormal, false); got != "" {
+		t.Errorf("normal badge = %q, want empty", got)
+	}
+	for _, lvl := range []session.BudgetLevel{session.BudgetWarn, session.BudgetHigh, session.BudgetOver} {
+		got := budgetBadge(lvl, false)
+		if got == "" {
+			t.Errorf("level %v produced empty badge", lvl)
+		}
+		if !strings.Contains(got, lvl.String()) {
+			t.Errorf("badge %q does not contain level name %q", got, lvl.String())
+		}
+	}
+}

--- a/internal/ui/context_budget_eval_test.go
+++ b/internal/ui/context_budget_eval_test.go
@@ -1,0 +1,26 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestShouldNotifyBudgetCrossing(t *testing.T) {
+	cases := []struct {
+		prev, cur session.BudgetLevel
+		want      bool
+	}{
+		{session.BudgetNormal, session.BudgetWarn, false}, // warn is bar/badge only
+		{session.BudgetWarn, session.BudgetHigh, true},    // first cross into high
+		{session.BudgetHigh, session.BudgetHigh, false},   // no re-fire
+		{session.BudgetHigh, session.BudgetOver, true},    // escalate to over
+		{session.BudgetOver, session.BudgetHigh, false},   // dropping back: no fire
+		{session.BudgetHigh, session.BudgetWarn, false},   // dropping back
+	}
+	for _, tc := range cases {
+		if got := shouldNotifyBudgetCrossing(tc.prev, tc.cur); got != tc.want {
+			t.Errorf("shouldNotifyBudgetCrossing(%v,%v) = %v, want %v", tc.prev, tc.cur, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/context_budget_handoff_test.go
+++ b/internal/ui/context_budget_handoff_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestIsAutonomousSession(t *testing.T) {
+	cases := []struct {
+		name string
+		inst *session.Instance
+		want bool
+	}{
+		{"conductor flag", &session.Instance{IsConductor: true}, true},
+		{"conductor group", &session.Instance{GroupPath: "conductor"}, true},
+		{"parented child", &session.Instance{ParentSessionID: "parent-1"}, true},
+		{"plain interactive", &session.Instance{GroupPath: "my-sessions"}, false},
+	}
+	for _, tc := range cases {
+		if got := isAutonomousSession(tc.inst); got != tc.want {
+			t.Errorf("%s: isAutonomousSession = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestHandoffAgentIdle(t *testing.T) {
+	if !handoffAgentIdle(&session.Instance{Status: session.StatusWaiting}) {
+		t.Errorf("waiting session should be idle")
+	}
+	if !handoffAgentIdle(&session.Instance{Status: session.StatusIdle}) {
+		t.Errorf("idle session should be idle")
+	}
+	if handoffAgentIdle(&session.Instance{Status: session.StatusRunning}) {
+		t.Errorf("running session should not be idle")
+	}
+}

--- a/internal/ui/context_budget_panel_test.go
+++ b/internal/ui/context_budget_panel_test.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestBudgetBarColor(t *testing.T) {
+	cases := []struct {
+		level session.BudgetLevel
+		want  string // hex of expected color
+	}{
+		{session.BudgetNormal, string(ColorGreen)},
+		{session.BudgetWarn, string(ColorYellow)},
+		{session.BudgetHigh, string(ColorRed)},
+		{session.BudgetOver, string(ColorRed)},
+	}
+	for _, tc := range cases {
+		if got := string(budgetBarColor(tc.level)); got != tc.want {
+			t.Errorf("budgetBarColor(%v) = %s, want %s", tc.level, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/context_budget_ui.go
+++ b/internal/ui/context_budget_ui.go
@@ -1,0 +1,283 @@
+package ui
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/safego"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// shouldNotifyBudgetCrossing reports whether a one-time notification should fire
+// for an upward transition into BudgetHigh or BudgetOver. Warn is intentionally
+// bar/badge-only; dropping back never notifies.
+func shouldNotifyBudgetCrossing(prev, cur session.BudgetLevel) bool {
+	if cur <= prev {
+		return false
+	}
+	return cur == session.BudgetHigh || cur == session.BudgetOver
+}
+
+// budgetWarnState returns a session's budget level and whether a usable context
+// token signal exists (Claude-compatible tool + cached analytics). When ok is
+// false, callers must not warn or act.
+func (h *Home) budgetWarnState(inst *session.Instance, cfg session.ContextBudgetSettings) (session.BudgetLevel, bool) {
+	if !session.IsClaudeCompatible(inst.Tool) {
+		return session.BudgetNormal, false
+	}
+	a := h.getAnalyticsForSession(inst)
+	if a == nil {
+		return session.BudgetNormal, false
+	}
+	return a.BudgetLevel(cfg), true
+}
+
+// evaluateContextBudgetWarnings runs once per background tick over all sessions,
+// firing a debounced one-shot notification on each upward crossing into
+// high/over. Visual treatments (bar/badge) are handled in render.
+func (h *Home) evaluateContextBudgetWarnings(instances []*session.Instance) {
+	cfg := session.GetContextBudgetSettings()
+	if !cfg.GetEnabled() {
+		return
+	}
+	// Callers pass the active (non-archived) subset; archived sessions are torn
+	// down and display-frozen, so they must never emit budget crossings.
+	for _, inst := range instances {
+		level, ok := h.budgetWarnState(inst, cfg)
+		if !ok {
+			continue
+		}
+		prev := h.budgetLastLevel[inst.ID] // zero value = BudgetNormal
+		if shouldNotifyBudgetCrossing(prev, level) {
+			h.notifyBudgetCrossing(inst, level)
+		}
+		h.budgetLastLevel[inst.ID] = level
+	}
+}
+
+// notifyBudgetCrossing emits the one-time alert for a high/over crossing. It
+// logs at WARN always; visual feedback is provided by the budget bar/badge.
+// Debounce is handled by the caller's per-session last-level map.
+func (h *Home) notifyBudgetCrossing(inst *session.Instance, level session.BudgetLevel) {
+	uiLog.Warn("context_budget_crossing",
+		slog.String("session", inst.Title),
+		slog.String("id", inst.ID),
+		slog.String("level", level.String()))
+}
+
+// isAutonomousSession reports whether agent-deck launched this session non-
+// interactively: a conductor, or a parented/fleet child. Only autonomous
+// sessions get the auto wrap-up/fork; interactive sessions get warnings only.
+func isAutonomousSession(inst *session.Instance) bool {
+	if inst.IsConductor || inst.GroupPath == "conductor" {
+		return true
+	}
+	return inst.ParentSessionID != ""
+}
+
+// handoffAgentIdle reports whether the agent is idle/waiting (safe to fork).
+// Both StatusWaiting (stopped, awaiting input) and StatusIdle qualify; an
+// actively generating session (StatusRunning) does not.
+func handoffAgentIdle(inst *session.Instance) bool {
+	return inst.Status == session.StatusWaiting || inst.Status == session.StatusIdle
+}
+
+// handoffDir returns the per-session handoff directory <data-dir>/handoff/<id>.
+// The "handoff" marker keeps a pre-XDG ~/.agent-deck/handoff in use when it
+// exists, so sessions mid-handoff across the layout migration still resolve.
+func handoffDir(id string) string {
+	dir, err := agentpaths.EffectiveDataPath(filepath.Join("handoff", id), "handoff")
+	if err != nil {
+		return ""
+	}
+	return dir
+}
+
+// fileExists reports whether the path exists (used to poll for PROMPT.md).
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// evaluateContextBudgetHandoff drives the per-session handoff state machine for
+// autonomous sessions. State is persisted via statedb and resumed across
+// restarts. Runs once per background tick. Interactive sessions are skipped
+// (they receive warnings only, never auto-action).
+func (h *Home) evaluateContextBudgetHandoff(instances []*session.Instance) {
+	cfg := session.GetContextBudgetSettings()
+	if !cfg.GetEnabled() || !cfg.GetAutonomousHandoff() {
+		return
+	}
+	db := statedb.GetGlobal()
+	if db == nil {
+		return
+	}
+	for _, inst := range instances {
+		if !isAutonomousSession(inst) {
+			continue
+		}
+		// Gate on a usable context-token signal (Claude-compatible tool + cached
+		// analytics). Without it there is nothing to act on.
+		if _, ok := h.budgetWarnState(inst, cfg); !ok {
+			continue
+		}
+		a := h.getAnalyticsForSession(inst)
+		if a == nil {
+			continue
+		}
+
+		// Resume persisted state lazily the first time we see this session
+		// (survives a restart mid-wrap).
+		cur := h.handoffState[inst.ID]
+		trig := h.handoffTriggeredAt[inst.ID]
+		if _, seen := h.handoffState[inst.ID]; !seen {
+			if pState, pAt, err := db.ReadHandoffState(inst.ID); err == nil {
+				cur = session.HandoffState(pState)
+				trig = pAt
+				h.handoffState[inst.ID] = cur
+				h.handoffTriggeredAt[inst.ID] = pAt
+			}
+		}
+
+		in := session.HandoffInputs{
+			Tokens:      a.CurrentContextTokens,
+			PromptReady: fileExists(filepath.Join(handoffDir(inst.ID), "PROMPT.md")),
+			AgentIdle:   handoffAgentIdle(inst),
+			Now:         time.Now(),
+			TriggeredAt: trig,
+		}
+		dec := session.NextHandoffState(cur, in, cfg)
+		if dec.Next == cur && dec.Action == session.ActionNone {
+			continue // no change this tick
+		}
+
+		switch dec.Action {
+		case session.ActionRequestWrap:
+			now := time.Now()
+			h.handoffTriggeredAt[inst.ID] = now
+			h.requestWrap(inst)
+			_ = db.WriteHandoffState(inst.ID, string(dec.Next), now)
+		case session.ActionFork:
+			h.forkContinuation(inst)
+			_ = db.WriteHandoffState(inst.ID, string(dec.Next), h.handoffTriggeredAt[inst.ID])
+		case session.ActionFailsafe:
+			h.failsafePause(inst)
+			_ = db.WriteHandoffState(inst.ID, string(dec.Next), h.handoffTriggeredAt[inst.ID])
+		default:
+			_ = db.WriteHandoffState(inst.ID, string(dec.Next), h.handoffTriggeredAt[inst.ID])
+		}
+		h.handoffState[inst.ID] = dec.Next
+	}
+}
+
+// requestWrap creates the handoff dir and injects the wrap-up instruction,
+// telling the agent to finish, persist, and write a continuation PROMPT.md.
+func (h *Home) requestWrap(inst *session.Instance) {
+	dir := handoffDir(inst.ID)
+	_ = os.MkdirAll(dir, 0o755)
+	ts := inst.GetTmuxSession()
+	if ts == nil {
+		return
+	}
+	prompt := filepath.Join(dir, "PROMPT.md")
+	msg := "Context budget reached. Finish and save your current work now, then write a continuation prompt for a fresh session to " +
+		prompt + " (and any work notes alongside it). Do not start new work. When PROMPT.md is written, stop and wait."
+	safego.Go(uiLog, "context_budget_wrapup", func() {
+		time.Sleep(500 * time.Millisecond)
+		_ = ts.SendKeysAndEnter(msg)
+	})
+}
+
+// forkContinuation reads PROMPT.md, forks a continuation session inheriting the
+// old session's tool/profile/path/group/parent/worktree, seeds it with a short
+// preamble + the handoff prompt, registers it, and archives the old session.
+// On any failure it falls back to failsafePause (no silent data loss).
+func (h *Home) forkContinuation(inst *session.Instance) {
+	promptPath := filepath.Join(handoffDir(inst.ID), "PROMPT.md")
+
+	// Inherit worktree fields when the source ran in a worktree.
+	var opts *session.ClaudeOptions
+	if inst.WorktreePath != "" {
+		opts = &session.ClaudeOptions{
+			WorktreePath:     inst.WorktreePath,
+			WorktreeRepoRoot: inst.WorktreeRepoRoot,
+			WorktreeBranch:   inst.WorktreeBranch,
+		}
+	}
+
+	safego.Go(uiLog, "context_budget_fork", func() {
+		data, err := os.ReadFile(promptPath)
+		if err != nil {
+			uiLog.Warn("handoff_prompt_read_failed", slog.String("id", inst.ID), slog.Any("err", err))
+			h.failsafePause(inst)
+			return
+		}
+		seed := "You are a continuation of a previous session that reached its context budget. " +
+			"Resume from this handoff prompt:\n\n" + string(data)
+
+		cmd := h.forkSessionCmdWithOptions(
+			inst,
+			inst.Title+" (cont.)",
+			inst.GroupPath,
+			forkToggles{},
+			opts,
+			git.WorktreeStateOptions{},
+			inst.ParentSessionID,
+			inst.ParentProjectPath,
+			"",
+		)
+		if cmd == nil {
+			h.failsafePause(inst)
+			return
+		}
+		msg := cmd() // executes the fork; returns sessionForkedMsg
+		fm, ok := msg.(sessionForkedMsg)
+		if !ok || fm.err != nil || fm.instance == nil {
+			h.failsafePause(inst)
+			return
+		}
+
+		// Register the new (already-started-in-tmux) session via the same
+		// persist+reload path the reload branch uses to inject a forked session
+		// from a non-UI goroutine. The reload rebuilds the tree on the UI thread.
+		h.instancesMu.Lock()
+		h.instances = append(h.instances, fm.instance)
+		h.instanceByID[fm.instance.ID] = fm.instance
+		h.instancesMu.Unlock()
+		h.forceSaveInstances()
+		if h.storageWatcher != nil {
+			h.storageWatcher.TriggerReload()
+		}
+
+		// Seed the continuation prompt once the new pane is live.
+		time.Sleep(2 * time.Second)
+		if ts := fm.instance.GetTmuxSession(); ts != nil {
+			_ = ts.SendKeysAndEnter(seed)
+		}
+
+		// Archive (pause) the old session for history — targeted, idempotent.
+		_ = inst.Kill()
+		inst.ArchivedAt = time.Now().UTC()
+		if db := statedb.GetGlobal(); db != nil {
+			_ = db.SetArchived(inst.ID, inst.ArchivedAt)
+		}
+	})
+}
+
+// failsafePause stops the old session (no data loss) and raises the loudest
+// alert. It NEVER auto-/clears the context — a human must take over.
+func (h *Home) failsafePause(inst *session.Instance) {
+	uiLog.Error("context_budget_failsafe",
+		slog.String("session", inst.Title),
+		slog.String("id", inst.ID),
+		slog.String("action", "paused; manual handoff required"))
+	safego.Go(uiLog, "context_budget_failsafe_pause", func() {
+		_ = inst.Kill()
+	})
+	h.notifyBudgetCrossing(inst, session.BudgetOver)
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2787,7 +2787,13 @@ func (h *Home) propagateThemeToSessions() {
 
 	safego.Go(uiLog, "apply_theme_to_sessions", func() {
 		for _, inst := range instances {
-			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && tmuxSess.Exists() {
+			// ExistsCached() (cache/pipe only): iterating every instance with
+			// Exists() would subprocess-probe each uncached/dead session, storming
+			// the tmux server on a theme toggle. This runs off the UI goroutine so
+			// it can't freeze the main loop, but the storm class is the same one
+			// the tickMsg fix eliminates. A live-but-uncached session keeps its
+			// stale COLORFGBG until the next theme change — cosmetic only.
+			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && tmuxSess.ExistsCached() {
 				_ = tmuxSess.SetEnvironment("COLORFGBG", colorfgbg)
 				_ = tmuxSess.ApplyThemeOptions()
 			}
@@ -3907,6 +3913,14 @@ func (h *Home) backgroundStatusUpdate() {
 	copy(instances, h.instances)
 	h.instancesMu.RUnlock()
 
+	// Active (non-archived) subset, computed once and reused by the loops that
+	// only concern live sessions. Archived sessions have torn-down panes, so
+	// walking them here only burns tmux subprocesses (Exists() / Capture())
+	// without changing anything the UI shows — with a large archive backlog that
+	// was the dominant cost in this sweep. Loops that need the full set (status
+	// skip-counting, idle lastSeen cleanup) keep using `instances`.
+	activeInstances := session.FilterInstancesByArchive(instances, false)
+
 	// Issue #1143: rate-limit the idle-timeout watcher to one tick per minute.
 	// The background sweep runs every 2s; capture-pane on every session every
 	// 2s would add unnecessary tmux load. 60s is the same cadence the spec
@@ -3925,9 +3939,15 @@ func (h *Home) backgroundStatusUpdate() {
 	// PERFORMANCE: Gradually configure unconfigured sessions in background
 	// Configure one session per tick to avoid blocking the status update
 	// This ensures all sessions get configured within ~1 minute even without user interaction
-	for _, inst := range instances {
+	for _, inst := range activeInstances {
 		if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-			if !tmuxSess.IsConfigured() && tmuxSess.Exists() {
+			// ExistsCached() (cache/pipe only, never a has-session subprocess):
+			// this loop evaluates the liveness check for EVERY unconfigured
+			// session each tick until it finds one to configure. With hundreds
+			// of unconfigured dead sessions, Exists() here would subprocess-probe
+			// each one — the same storm the tickMsg fix kills. A live-but-uncached
+			// session simply gets configured a tick later.
+			if !tmuxSess.IsConfigured() && tmuxSess.ExistsCached() {
 				tmuxSess.EnsureConfigured()
 				inst.SyncSessionIDsToTmux()
 				break // Only one per tick to avoid blocking
@@ -6165,17 +6185,45 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// connects focused/attached sessions; this only reconnects wanted
 			// sessions whose pipe dropped.
 			if pm := tmux.GetPipeManager(); pm != nil {
+				// Two-phase so NOTHING that can block runs on the bubbletea
+				// goroutine. Phase 1 (under RLock) filters with cheap map/slice
+				// lookups only: a session needs reconnecting iff it is WANTED
+				// (focused/attached) and its pipe has dropped. Phase 2 does the
+				// liveness probe and the reconnect off-thread.
+				//
+				// ts.Exists() must not run here: it falls back to a
+				// `tmux has-session` subprocess (up to hasSessionProbeTimeout=2s)
+				// for any session the pipe/cache doesn't cover — and a
+				// wanted-but-disconnected session on a wedged server is exactly
+				// the state that reaches this loop. Probing on the main goroutine
+				// (while holding instancesMu, stalling writers too) is what froze
+				// the UI for seconds at a time on every tick.
+				type reconnectTarget struct {
+					ts     *tmux.Session
+					socket string
+				}
+				var targets []reconnectTarget
 				h.instancesMu.RLock()
 				for _, inst := range h.instances {
-					if ts := inst.GetTmuxSession(); ts != nil && ts.Exists() {
-						if h.liveSet.want(ts.Name) && !pm.IsConnected(ts.Name) {
-							go func(name, socket string) {
-								_ = pm.Connect(name, socket)
-							}(ts.Name, inst.TmuxSocketName)
-						}
+					ts := inst.GetTmuxSession()
+					if ts == nil {
+						continue
 					}
+					if !h.liveSet.want(ts.Name) || pm.IsConnected(ts.Name) {
+						continue
+					}
+					targets = append(targets, reconnectTarget{ts: ts, socket: inst.TmuxSocketName})
 				}
 				h.instancesMu.RUnlock()
+
+				for _, t := range targets {
+					safego.Go(uiLog, "pipe_reconnect", func() {
+						if !t.ts.Exists() {
+							return
+						}
+						_ = pm.Connect(t.ts.Name, t.socket)
+					})
+				}
 			}
 		}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -368,6 +368,14 @@ type Home struct {
 	// Context-% based /clear for conductor sessions with clear_on_compact
 	clearOnCompactSent map[string]time.Time // instanceID -> last /clear send time (debounce)
 
+	// Context-budget warning debounce: fires once per upward crossing into high/over.
+	budgetLastLevel map[string]session.BudgetLevel // instanceID -> last seen budget level
+
+	// Autonomous context-budget handoff: per-session state machine (mirrors the
+	// statedb-persisted state in memory; resumes lazily across restart).
+	handoffState       map[string]session.HandoffState // instanceID -> persisted handoff state
+	handoffTriggeredAt map[string]time.Time            // instanceID -> wrap trigger time
+
 	// File watcher for external changes (auto-reload)
 	storageWatcher *StorageWatcher
 
@@ -396,6 +404,7 @@ type Home struct {
 	resumingSessions     map[string]time.Time        // sessionID -> resume time (for restart/resume)
 	mcpLoadingSessions   map[string]time.Time        // sessionID -> MCP reload time
 	forkingSessions      map[string]time.Time        // sessionID -> fork start time (fork in progress)
+	forkingSessionsMu    sync.Mutex                  // guards forkingSessions (off-loop fork triggers, e.g. autonomous handoff)
 	setupRunningSessions map[string]time.Time        // sessionID -> setup script start time
 	creatingSessions     map[string]*CreatingSession // tempID -> placeholder for worktree creation in progress
 	animationFrame       int                         // Current frame for spinner animation
@@ -1159,6 +1168,9 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		geminiAnalyticsCache:      make(map[string]*session.GeminiSessionAnalytics),
 		analyticsCacheTime:        make(map[string]time.Time),
 		clearOnCompactSent:        make(map[string]time.Time),
+		budgetLastLevel:           make(map[string]session.BudgetLevel),
+		handoffState:              make(map[string]session.HandoffState),
+		handoffTriggeredAt:        make(map[string]time.Time),
 		launchingSessions:         make(map[string]time.Time),
 		resumingSessions:          make(map[string]time.Time),
 		mcpLoadingSessions:        make(map[string]time.Time),
@@ -3146,7 +3158,10 @@ func (h *Home) hasActiveAnimation(sessionID string) bool {
 	}
 
 	// Check forking first (always shows while tracked)
-	if _, ok := h.forkingSessions[sessionID]; ok {
+	h.forkingSessionsMu.Lock()
+	_, forking := h.forkingSessions[sessionID]
+	h.forkingSessionsMu.Unlock()
+	if forking {
 		return true
 	}
 
@@ -3913,12 +3928,12 @@ func (h *Home) backgroundStatusUpdate() {
 	copy(instances, h.instances)
 	h.instancesMu.RUnlock()
 
-	// Active (non-archived) subset, computed once and reused by the loops that
-	// only concern live sessions. Archived sessions have torn-down panes, so
-	// walking them here only burns tmux subprocesses (Exists() / Capture())
-	// without changing anything the UI shows — with a large archive backlog that
-	// was the dominant cost in this sweep. Loops that need the full set (status
-	// skip-counting, idle lastSeen cleanup) keep using `instances`.
+	// Active (non-archived) subset, computed once and reused by the pre_status
+	// loops that only concern live sessions. Archived sessions have torn-down
+	// panes, so walking them here only burns tmux subprocesses (Exists() /
+	// Capture()) without changing anything the UI shows — with a large archive
+	// backlog that was the dominant cost in this sweep. Loops that need the full
+	// set (status skip-counting, idle lastSeen cleanup) keep using `instances`.
 	activeInstances := session.FilterInstancesByArchive(instances, false)
 
 	// Issue #1143: rate-limit the idle-timeout watcher to one tick per minute.
@@ -4005,6 +4020,12 @@ func (h *Home) backgroundStatusUpdate() {
 			}
 		}
 	}
+
+	// Context-budget warnings (all sessions): debounced one-shot on high/over crossing.
+	h.evaluateContextBudgetWarnings(activeInstances)
+
+	// Autonomous context-budget handoff (conductor + parented children only).
+	h.evaluateContextBudgetHandoff(activeInstances)
 
 	// Update status for all instances in parallel (I/O bound: tmux subprocess calls)
 	// With PipeManager, skip sessions idle for >5s (no %output events = no status change)
@@ -5057,7 +5078,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionForkedMsg:
 		// Clean up forking state for source session
 		if msg.sourceID != "" {
+			h.forkingSessionsMu.Lock()
 			delete(h.forkingSessions, msg.sourceID)
+			h.forkingSessionsMu.Unlock()
 		}
 
 		// Handle reload scenario: forked session was already started in tmux, we MUST save it
@@ -6255,7 +6278,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.cleanupExpiredAnimations(h.launchingSessions, claudeTimeout, defaultTimeout)
 		h.cleanupExpiredAnimations(h.resumingSessions, claudeTimeout, defaultTimeout)
 		h.cleanupExpiredAnimations(h.mcpLoadingSessions, claudeTimeout, defaultTimeout)
+		// forkingSessions can be written off the main loop (autonomous handoff fork);
+		// guard the range+delete cleanup against a concurrent background write.
+		h.forkingSessionsMu.Lock()
 		h.cleanupExpiredAnimations(h.forkingSessions, claudeTimeout, defaultTimeout)
+		h.forkingSessionsMu.Unlock()
 		// setupRunningSessions is deliberately NOT timer-pruned: it doubles as
 		// the b-hotkey re-entrancy lock, and the setup script may legitimately
 		// run past any UI timeout (setup_timeout_seconds is user-configurable,
@@ -11465,8 +11492,11 @@ func (h *Home) forkSessionCmdWithOptions(
 		forkState.WithState = true
 	}
 
-	// Track source session as "forking" for immediate UI feedback
+	// Track source session as "forking" for immediate UI feedback.
+	// Guarded: autonomous-handoff forks call this off the main loop while View reads the map.
+	h.forkingSessionsMu.Lock()
 	h.forkingSessions[source.ID] = time.Now()
+	h.forkingSessionsMu.Unlock()
 
 	sourceID := source.ID // Capture for closure
 
@@ -15140,6 +15170,23 @@ func (h *Home) renderCreatingSessionItem(
 	b.WriteString("\n")
 }
 
+// budgetBadge renders the per-session context-budget chip for the session list.
+// Empty for BudgetNormal so unaffected rows are unchanged.
+func budgetBadge(level session.BudgetLevel, selected bool) string {
+	if level == session.BudgetNormal {
+		return ""
+	}
+	color := ColorYellow
+	if level == session.BudgetHigh || level == session.BudgetOver {
+		color = ColorRed
+	}
+	style := lipgloss.NewStyle().Foreground(color).Bold(true)
+	if selected {
+		style = SessionStatusSelStyle
+	}
+	return style.Render(" [ctx:" + level.String() + "]")
+}
+
 // renderSessionItem renders a single session row into b, including the tree
 // connector, status badge, tool label, and the dim tmux pane-title suffix.
 // The pane-title suffix appears on the selected row, or on every row when
@@ -15371,6 +15418,15 @@ func (h *Home) renderSessionItem(
 		timestampBadge = tsStyle.Render(" " + formatRelativeTime(ts))
 	}
 
+	// Context-budget badge for Claude-compatible sessions with cached analytics.
+	// Only shown when analytics are available (no-signal gate: nil = no badge).
+	ctxBadge := ""
+	if session.IsClaudeCompatible(inst.Tool) {
+		if a := h.getAnalyticsForSession(inst); a != nil {
+			ctxBadge = budgetBadge(a.BudgetLevel(session.GetContextBudgetSettings()), selected)
+		}
+	}
+
 	// Window expand/collapse chevron for sessions with 2+ windows
 	windowChevron := " " // space placeholder to keep status icons aligned
 	if h.sessionHasWindows(item) {
@@ -15412,7 +15468,7 @@ func (h *Home) renderSessionItem(
 			cellWidth(status) + 1 /* space before title */ + cellWidth(tool) +
 			cellWidth(maestroBadge) + cellWidth(yoloBadge) + cellWidth(worktreeBadge) +
 			cellWidth(sandboxBadge) + cellWidth(multiRepoBadge) + cellWidth(sshBadge) +
-			cellWidth(timestampBadge)
+			cellWidth(timestampBadge) + cellWidth(ctxBadge)
 		budget := listWidth - reserved - 1 // -1 trailing margin
 		if budget > 0 && cellWidth(displayTitle) > budget {
 			displayTitle = cellTruncate(displayTitle, budget, "…")
@@ -15424,7 +15480,7 @@ func (h *Home) renderSessionItem(
 	// The leading gutter (leftGutterWidth) keeps sessions aligned with group
 	// rows, which reserve the same gutter for root hotkey numbers.
 	row := fmt.Sprintf(
-		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s%s",
 		strings.Repeat(" ", leftGutterWidth),
 		baseIndent,
 		selectionPrefix,
@@ -15440,6 +15496,7 @@ func (h *Home) renderSessionItem(
 		multiRepoBadge,
 		sshBadge,
 		timestampBadge,
+		ctxBadge,
 	)
 
 	// Append pane title filling remaining row space (only for the selected item).
@@ -16931,7 +16988,9 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	// Check if session is launching/resuming (for animation priority)
 	_, isSessionLaunching := h.launchingSessions[selected.ID]
 	_, isSessionResuming := h.resumingSessions[selected.ID]
+	h.forkingSessionsMu.Lock()
 	_, isSessionForking := h.forkingSessions[selected.ID]
+	h.forkingSessionsMu.Unlock()
 	isStartingUp := isSessionLaunching || isSessionResuming || isSessionForking
 
 	// Analytics panel (for Claude/Gemini sessions with analytics enabled)
@@ -17005,7 +17064,9 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	launchTime, isLaunching := h.launchingSessions[selected.ID]
 	resumeTime, isResuming := h.resumingSessions[selected.ID]
 	mcpLoadTime, isMcpLoading := h.mcpLoadingSessions[selected.ID]
+	h.forkingSessionsMu.Lock()
 	forkTime, isForking := h.forkingSessions[selected.ID]
+	h.forkingSessionsMu.Unlock()
 
 	// Determine if we should show animation (launch, resume, MCP loading, or forking)
 	// For Claude: show for minimum 6 seconds, then check for ready indicators


### PR DESCRIPTION
Resubmit of #1535.

> **Stacked on #1600** — the background-sweep hook uses the `activeInstances` subset introduced there, so this branch includes its commit. The diff to review here is everything *except* `internal/tmux/`; I'll rebase once #1600 lands.

## Why #1535 was closed (and why it's back)

It was **auto-closed by the CI bot, not on review** — no maintainer objected to the design. I pulled the failing job log. The blocker was one lint test:

```
FAIL: internal/agentpaths TestNoDirectHomeAgentDeckPathConstruction
  direct filepath.Join(..., ".agent-deck", ...) legacy path construction
  found outside agentpaths:
    internal/ui/context_budget_ui.go:90
```

`context_budget_ui.go` built a `~/.agent-deck` path directly instead of going through `agentpaths`. It now resolves via `agentpaths.EffectiveDataPath` (which also keeps a pre-XDG `~/.agent-deck/handoff` working for sessions mid-handoff across the layout migration), **and that test passes.**

The only other failure in that run was `TestControlPipeClose_TerminatesCleanlyOnSIGTERM`, which is unrelated flake.

## What's in it

- `[context_budget]` config section + `GetContextBudget()`
- `BudgetLevel` threshold mapping; the analytics context bar is colored by **absolute budget level** rather than percentage-of-window
- Per-session budget badge in the session list — empty for `BudgetNormal`, so unaffected rows render byte-identically
- Debounced high/over warning notifications, one-shot per *upward* crossing (no flapping)
- Autonomous fork-on-budget handoff state machine, persisted in `tool_data` via a **targeted `json_set`** so it can't clobber concurrent writers

## Concurrency note for review

`forkingSessions` is guarded by a dedicated mutex. Autonomous-handoff forks call `forkSessionCmdWithOptions` **off the main loop** while `View` reads the map — that's a data race without the guard, and it's the kind that only shows up under load.

## Tests

`internal/ui`, `internal/statedb`, `internal/agentpaths` pass with `-race`.

Two tests fail in `internal/session` in my sandbox (`TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision`, `TestIssue1421_CleanStaleSSHSockets`) — I verified both fail identically on **clean `origin/main`** with none of these changes, so they're environmental here (missing `python3`/socket perms), not regressions. They passed in #1535's CI.