### PR TITLE
feat(ui): copy visible terminal pane text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Copy visible terminal text directly from the TUI.** Select a local session and press `V` to copy its current visible pane as plain text, including links. ANSI and terminal control sequences are removed, while the existing native clipboard and OSC 52 fallback chain remains unchanged. The troubleshooting guide also documents Option-drag in iTerm2 and Shift-drag in Linux and Windows terminals. ([#1595](https://github.com/asheshgoplani/agent-deck/issues/1595))
+
 ### Fixed
 
 - **A manual session rename no longer reverts to the folder default after a reload race.** When a rename's save was skipped (`isReloading=true`), the title was queued in `pendingTitleChanges` and re-applied after the storage-watcher reload — but only the title *string* was queued, not its `TitleLocked` intent. The reapplied title therefore came back **unlocked**, so the very next `#572` Claude-name sync overwrote it with Claude Code 2.1.19x's auto-derived cwd-folder name (e.g. `myproject` → `myproject-3a`). The queue now carries the lock state alongside the title: a user rename is restored **locked** (survives the sync), while a sync-sourced title stays unlocked (keeps tracking Claude). Pinned by `TestHomeRenamePendingChangeRestoresTitleLock`. (related to [#697](https://github.com/asheshgoplani/agent-deck/issues/697))

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -193,6 +193,7 @@ func (h *HelpOverlay) View() string {
 	quickApproveKey := h.key(hotkeyQuickApprove, "a")
 	promptSessionKey := h.key(hotkeyPromptSession, "o")
 	copyKey := h.key(hotkeyCopyOutput, "c")
+	copyPaneKey := h.key(hotkeyCopyPane, "V")
 	sendKey := h.key(hotkeySendOutput, "x")
 	execShellKey := h.key(hotkeyExecShell, "E")
 	notesKey := h.key(hotkeyEditNotes, "e")
@@ -272,6 +273,7 @@ func (h *HelpOverlay) View() string {
 				{copyKey, "Copy output to clipboard"},
 				{"C", "Copy preview info (Repo / Path / Branch)"},
 				{"Y", "Copy a code block from output"},
+				{copyPaneKey, "Copy visible terminal text, including links"},
 				{sendKey, "Send output to session"},
 				{execShellKey, "Exec shell in sandbox container"},
 				{editPathsKey, "Edit multi-repo paths"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -365,6 +365,11 @@ type Home struct {
 	hookWatcher        *session.StatusFileWatcher
 	pendingHooksPrompt bool // True if user should be prompted to install hooks
 
+	// Test seams for the visible-pane clipboard action. Production leaves both
+	// nil and uses fresh tmux capture plus the shared clipboard fallback chain.
+	paneCapture   paneCaptureFunc
+	paneClipboard paneClipboardFunc
+
 	// Context-% based /clear for conductor sessions with clear_on_compact
 	clearOnCompactSent map[string]time.Time // instanceID -> last /clear send time (debounce)
 
@@ -6004,6 +6009,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case copyPaneResultMsg:
+		switch {
+		case msg.err != nil:
+			h.setError(fmt.Errorf("Could not copy visible terminal text: %w", msg.err))
+		case msg.empty:
+			h.setError(fmt.Errorf("Nothing visible to copy (%s)", msg.sessionTitle))
+		default:
+			h.setError(fmt.Errorf("Copied visible terminal text to clipboard (%d lines, %s)", msg.lineCount, msg.sessionTitle))
+		}
+		return h, nil
+
 	case sendOutputResultMsg:
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to send to %s: %v", msg.targetTitle, msg.err))
@@ -8615,6 +8631,17 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
 				return h, h.copySessionInfo(item.Session)
+			}
+		}
+		return h, nil
+
+	case defaultHotkeyBindings[hotkeyCopyPane]:
+		// Copy the selected local session's current visible tmux pane. The key
+		// reaches this canonical case through the configurable hotkey lookup.
+		if h.cursor < len(h.flatItems) {
+			item := h.flatItems[h.cursor]
+			if item.Type == session.ItemTypeSession && item.Session != nil {
+				return h, h.copyVisiblePane(item.Session)
 			}
 		}
 		return h, nil
@@ -14128,6 +14155,9 @@ func (h *Home) renderHelpBarCompact() string {
 			if key := h.actionKey(hotkeyCopyOutput); key != "" {
 				contextHints = append(contextHints, h.helpKeyShort(key, "Copy"))
 			}
+			if key := h.actionKey(hotkeyCopyPane); key != "" {
+				contextHints = append(contextHints, h.helpKeyShort(key, "Copy pane"))
+			}
 			if key := h.actionKey(hotkeySendOutput); key != "" {
 				contextHints = append(contextHints, h.helpKeyShort(key, "Send"))
 			}
@@ -14228,6 +14258,7 @@ func (h *Home) renderHelpBarFull() string {
 	previewKey := h.actionKey(hotkeyTogglePreview)
 	forkKeys := joinHotkeyLabels(h.actionKey(hotkeyQuickFork), h.actionKey(hotkeyForkWithOptions))
 	copyKey := h.actionKey(hotkeyCopyOutput)
+	copyPaneKey := h.actionKey(hotkeyCopyPane)
 	sendKey := h.actionKey(hotkeySendOutput)
 	execShellKey := h.actionKey(hotkeyExecShell)
 	notesKey := h.actionKey(hotkeyEditNotes)
@@ -14316,6 +14347,9 @@ func (h *Home) renderHelpBarFull() string {
 			}
 			if copyKey != "" {
 				primaryHints = append(primaryHints, h.helpKey(copyKey, "Copy"))
+			}
+			if copyPaneKey != "" {
+				primaryHints = append(primaryHints, h.helpKey(copyPaneKey, "Copy pane"))
 			}
 			if sendKey != "" {
 				primaryHints = append(primaryHints, h.helpKey(sendKey, "Send"))

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -33,6 +33,7 @@ const (
 	hotkeyQuickFork        = "quick_fork"
 	hotkeyForkWithOptions  = "fork_with_options"
 	hotkeyCopyOutput       = "copy_output"
+	hotkeyCopyPane         = "copy_pane"
 	hotkeySendOutput       = "send_output"
 	hotkeyExecShell        = "exec_shell"
 	hotkeyEditNotes        = "edit_notes"
@@ -85,6 +86,7 @@ var hotkeyActionOrder = []string{
 	hotkeyQuickFork,
 	hotkeyForkWithOptions,
 	hotkeyCopyOutput,
+	hotkeyCopyPane,
 	hotkeySendOutput,
 	hotkeyExecShell,
 	hotkeyEditNotes,
@@ -129,6 +131,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyQuickFork:        "f",
 	hotkeyForkWithOptions:  "F",
 	hotkeyCopyOutput:       "c",
+	hotkeyCopyPane:         "V",
 	hotkeySendOutput:       "x",
 	hotkeyExecShell:        "E",
 	hotkeyEditNotes:        "e",

--- a/internal/ui/issue1595_copy_pane_test.go
+++ b/internal/ui/issue1595_copy_pane_test.go
@@ -1,0 +1,257 @@
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/clipboard"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+func TestIssue1595CopyPaneHotkey(t *testing.T) {
+	bindings := resolveHotkeys(nil)
+	if got := bindings[hotkeyCopyPane]; got != "V" {
+		t.Fatalf("default copy_pane binding = %q, want V", got)
+	}
+	if got := bindings[hotkeyCopyOutput]; got != "c" {
+		t.Fatalf("copy_output binding changed to %q", got)
+	}
+	if got := bindings[hotkeyToggleYolo]; got != "y" {
+		t.Fatalf("toggle_yolo binding changed to %q", got)
+	}
+
+	overridden := resolveHotkeys(map[string]string{"copy_pane": "ctrl+p"})
+	if got := overridden[hotkeyCopyPane]; got != "ctrl+p" {
+		t.Fatalf("overridden copy_pane binding = %q, want ctrl+p", got)
+	}
+
+	unbound := resolveHotkeys(map[string]string{"copy_pane": ""})
+	if _, ok := unbound[hotkeyCopyPane]; ok {
+		t.Fatal("copy_pane should be absent when explicitly unbound")
+	}
+}
+
+func TestIssue1595CaptureVisiblePaneDedicatedSocket(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	socket := fmt.Sprintf("agentdeck-copy-pane-%d-%d", os.Getpid(), time.Now().UnixNano())
+	const name = "copy-pane"
+	start := exec.Command("tmux", "-L", socket, "new-session", "-d", "-s", name,
+		"printf '\\033[31mhttps://example.test/path\\033[0m\\n'; sleep 10")
+	if out, err := start.CombinedOutput(); err != nil {
+		t.Fatalf("start dedicated tmux session: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socket, "kill-session", "-t", name).Run()
+	})
+
+	sess := &tmux.Session{Name: name, SocketName: socket}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		raw, err := sess.CapturePaneFresh()
+		if err == nil && strings.Contains(normalizeVisiblePane(raw), "https://example.test/path") {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("URL was not captured before deadline: raw=%q err=%v", raw, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestIssue1595CopyPaneHelpAndFooter(t *testing.T) {
+	overlay := NewHelpOverlay()
+	overlay.SetSize(120, 80)
+	overlay.Show()
+	help := tmux.StripANSI(overlay.View())
+	if !strings.Contains(help, "V") || !strings.Contains(help, "Copy visible terminal text, including links") {
+		t.Fatalf("help does not advertise visible-pane copy:\n%s", help)
+	}
+
+	home := NewHome()
+	t.Cleanup(func() {
+		home.cancel()
+		if home.storage != nil {
+			_ = home.storage.Close()
+		}
+	})
+	home.width = 120
+	home.height = 40
+	home.flatItems = []session.Item{{
+		Type:    session.ItemTypeSession,
+		Session: &session.Instance{ID: "copy-pane", Title: "Copy Me"},
+	}}
+	footer := tmux.StripANSI(home.renderHelpBarFull())
+	if !strings.Contains(footer, "V") || !strings.Contains(footer, "Copy pane") {
+		t.Fatalf("footer does not advertise visible-pane copy:\n%s", footer)
+	}
+}
+
+func TestIssue1595CopyPaneDispatchesConfiguredAction(t *testing.T) {
+	home := NewHome()
+	t.Cleanup(func() {
+		home.cancel()
+		if home.storage != nil {
+			_ = home.storage.Close()
+		}
+	})
+	inst := &session.Instance{ID: "copy-pane", Title: "Copy Me"}
+	home.flatItems = []session.Item{{Type: session.ItemTypeSession, Session: inst}}
+	home.cursor = 0
+
+	captured := false
+	copied := ""
+	home.paneCapture = func(got *session.Instance) (string, error) {
+		captured = true
+		if got != inst {
+			t.Fatalf("capture instance = %p, want %p", got, inst)
+		}
+		return "\x1b[31mhttps://example.test\x1b[0m  \nsecond\n", nil
+	}
+	home.paneClipboard = func(text string, _ bool) (*clipboard.CopyResult, error) {
+		copied = text
+		return &clipboard.CopyResult{LineCount: 2}, nil
+	}
+
+	_, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}})
+	if cmd == nil {
+		t.Fatal("V did not dispatch copy_pane")
+	}
+	msg := cmd()
+	if !captured || copied != "https://example.test\nsecond" {
+		t.Fatalf("captured=%v copied=%q", captured, copied)
+	}
+	model, _ := home.Update(msg)
+	gotHome := model.(*Home)
+	if got := gotHome.err.Error(); got != "Copied visible terminal text to clipboard (2 lines, Copy Me)" {
+		t.Fatalf("success status = %q", got)
+	}
+
+	home.setHotkeys(resolveHotkeys(map[string]string{"copy_pane": "!"}))
+	_, cmd = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'!'}})
+	if cmd == nil {
+		t.Fatal("configured copy_pane key did not dispatch")
+	}
+
+	home.setHotkeys(resolveHotkeys(map[string]string{"copy_pane": ""}))
+	_, cmd = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}})
+	if cmd != nil {
+		t.Fatal("unbound copy_pane still dispatched")
+	}
+}
+
+func TestIssue1595CopyPaneResultMessages(t *testing.T) {
+	inst := &session.Instance{ID: "copy-pane", Title: "Copy Me"}
+	tests := []struct {
+		name      string
+		capture   func(*session.Instance) (string, error)
+		clipboard func(string, bool) (*clipboard.CopyResult, error)
+		want      string
+	}{
+		{
+			name:    "empty",
+			capture: func(*session.Instance) (string, error) { return " \n\n", nil },
+			want:    "Nothing visible to copy (Copy Me)",
+		},
+		{
+			name:    "capture failure",
+			capture: func(*session.Instance) (string, error) { return "", errors.New("pane gone") },
+			want:    "Could not copy visible terminal text: pane gone",
+		},
+		{
+			name:    "clipboard failure",
+			capture: func(*session.Instance) (string, error) { return "text", nil },
+			clipboard: func(string, bool) (*clipboard.CopyResult, error) {
+				return nil, errors.New("clipboard unavailable")
+			},
+			want: "Could not copy visible terminal text: clipboard unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := NewHome()
+			t.Cleanup(func() {
+				home.cancel()
+				if home.storage != nil {
+					_ = home.storage.Close()
+				}
+			})
+			home.paneCapture = tt.capture
+			home.paneClipboard = tt.clipboard
+			msg := home.copyVisiblePane(inst)()
+			model, _ := home.Update(msg)
+			gotHome := model.(*Home)
+			if gotHome.err == nil || gotHome.err.Error() != tt.want {
+				t.Fatalf("status = %v, want %q", gotHome.err, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssue1595NormalizeVisiblePane(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "ansi URL and tmux padding",
+			raw:  "\x1b[31mhttps://example.test/path\x1b[0m   \nsecond\tvalue  \n   \n",
+			want: "https://example.test/path\nsecond\tvalue",
+		},
+		{
+			name: "OSC title and CRLF",
+			raw:  "\x1b]0;secret title\x07first\r\n\r\nthird\r\n",
+			want: "first\n\nthird",
+		},
+		{
+			name: "unsafe controls",
+			raw:  "a\x00b\x07c\x7f",
+			want: "abc",
+		},
+		{
+			name: "bracketed paste CSI",
+			raw:  "\x1b[200~https://example.test\x1b[201~",
+			want: "https://example.test",
+		},
+		{
+			name: "DCS APC PM and SOS strings",
+			raw:  "\x1bPprivate-dcs\x1b\\\x1b_private-apc\x1b\\\x1b^private-pm\x1b\\\x1bXprivate-sos\x1b\\visible",
+			want: "visible",
+		},
+		{
+			name: "OSC terminated by ST",
+			raw:  "\x1b]0;private title\x1b\\visible",
+			want: "visible",
+		},
+		{
+			name: "C1 CSI and string controls",
+			raw:  "\x9b31mred\x9b0m\x90private\x9cvisible",
+			want: "redvisible",
+		},
+		{
+			name: "truncated string control",
+			raw:  "visible\x1bPprivate",
+			want: "visible",
+		},
+		{name: "empty", raw: " \t\n\n", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeVisiblePane(tt.raw); got != tt.want {
+				t.Fatalf("normalizeVisiblePane() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/pane_copy.go
+++ b/internal/ui/pane_copy.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/asheshgoplani/agent-deck/internal/clipboard"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+type paneCaptureFunc func(*session.Instance) (string, error)
+type paneClipboardFunc func(string, bool) (*clipboard.CopyResult, error)
+
+type copyPaneResultMsg struct {
+	sessionTitle string
+	lineCount    int
+	empty        bool
+	err          error
+}
+
+// normalizeVisiblePane turns ANSI-rich tmux capture-pane output into plain
+// clipboard text. It preserves layout inside the visible pane while removing
+// terminal controls and tmux's right and bottom padding.
+func normalizeVisiblePane(raw string) string {
+	plain := ansi.Strip(strings.ReplaceAll(raw, "\r\n", "\n"))
+	plain = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, plain)
+
+	lines := strings.Split(plain, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func captureVisiblePane(inst *session.Instance) (string, error) {
+	if inst == nil || inst.GetTmuxSession() == nil {
+		return "", fmt.Errorf("session has no tmux pane")
+	}
+	return inst.GetTmuxSession().CapturePaneFresh()
+}
+
+// copyVisiblePane captures exactly the selected local session's visible pane
+// and copies a plain-text snapshot through the existing native/OSC52 chain.
+func (h *Home) copyVisiblePane(inst *session.Instance) tea.Cmd {
+	return func() tea.Msg {
+		capture := h.paneCapture
+		if capture == nil {
+			capture = captureVisiblePane
+		}
+		copyText := h.paneClipboard
+		if copyText == nil {
+			copyText = clipboard.Copy
+		}
+
+		raw, err := capture(inst)
+		if err != nil {
+			return copyPaneResultMsg{sessionTitle: inst.Title, err: err}
+		}
+		payload := normalizeVisiblePane(raw)
+		if payload == "" {
+			return copyPaneResultMsg{sessionTitle: inst.Title, empty: true}
+		}
+
+		result, err := copyText(payload, tmux.GetTerminalInfo().SupportsOSC52)
+		if err != nil {
+			return copyPaneResultMsg{sessionTitle: inst.Title, err: err}
+		}
+		return copyPaneResultMsg{sessionTitle: inst.Title, lineCount: result.LineCount}
+	}
+}

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -15,6 +15,27 @@ Common issues and solutions for agent-deck.
 
 ## Common Issues
 
+### Cannot Select or Copy Terminal Text
+
+On the agent-deck home screen, select a local session and press `V` to copy its
+current visible terminal text, including links, as plain text.
+
+When attached to a session, tmux mouse mode owns normal drag gestures. Hold
+Option while dragging in iTerm2. Hold Shift while dragging in most Linux
+terminals and Windows Terminal, including WSL2. This bypasses application mouse
+reporting and lets the terminal perform native selection.
+
+If your terminal has no selection bypass, disable mouse mode for new and
+reconnected sessions:
+
+```toml
+[tmux]
+mouse = false
+```
+
+This restores native drag selection, but disables tmux mouse scrolling, pane
+resizing, and mouse copy mode.
+
 ### Flags Ignored
 
 **Problem:** Flags after positional arguments are silently ignored.


### PR DESCRIPTION
Closes #1595

Adds a configurable `V` hotkey that copies the selected local session’s visible tmux pane as safe plain text. It strips ANSI and terminal control sequences, trims terminal padding, and uses the existing native clipboard plus OSC 52 fallback chain.

Also documents native terminal selection workarounds for iTerm2, Linux, Windows, and WSL terminals.

Verification:
* focused UI and tmux copy tests
* isolated tmux URL capture proof
* exact `eval_smoke` race suite
* `go build ./...`
* golangci-lint v2.12.2: 0 issues
* `git diff --check`

Committed by Ashesh Goplani