### PR TITLE
fix: lock user-typed session titles against folder-derived Claude name sync

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10679,6 +10679,15 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		inst.Command = command
 		inst.SetAutoName(autoName) // quick-create paths pass true; see render substitution
 
+		// A title the user typed into the full create dialog (autoName=false) is
+		// explicit intent, so lock it against the Claude session-name sync (#572).
+		// Otherwise the next hook event or attach reconcile would overwrite it with
+		// Claude's cwd-derived name — for a worktree that is the "<repo>-<branch>"
+		// folder basename (e.g. "linqalpha-e7"), silently renaming the session.
+		if !autoName && strings.TrimSpace(name) != "" {
+			inst.TitleLocked = true
+		}
+
 		// Set worktree fields if provided
 		if worktreePath != "" {
 			inst.WorktreePath = worktreePath


### PR DESCRIPTION
## Problem

When a user creates a session with a manually-typed title, the title gets silently overwritten with the worktree folder basename (e.g. `linqalpha-e7`, `linqalpha-c3` — the `<repo>-<branch>` folder name).

<img width="220" alt="renamed sessions" src="https://github.com/user-attachments/assets/placeholder" />

### Root cause

1. Creating a worktree session makes a `<repo>-<branch>` folder; Claude Code adopts that cwd folder name as its session name.
2. `ReconcileTitleFromClaude` (`internal/session/claude_title_reconcile.go`) runs on **every hook event** and **on attach**, reading Claude's session name and writing it into `inst.Title`.
3. The only guard against this overwrite is the `TitleLocked` flag — but a title typed into the **new-session dialog** was stored while `TitleLocked` stayed `false`. It was only ever set on runtime renames (`mutators.SetField`) and forks (`LockTitle`).

So an explicitly-named session was left unlocked and got clobbered by the folder-derived name on the next hook/attach.

## Fix

Lock the title when the user goes through the full create dialog (`autoName=false`) with a non-empty name, mirroring the existing rename/fork behavior:

```go
if !autoName && strings.TrimSpace(name) != "" {
    inst.TitleLocked = true
}
```

Quick-create (zoxide, `autoName=true`) and blank-name paths keep syncing from Claude as before.

## Notes

- Affects **newly created** sessions only. Already-renamed sessions can be fixed by renaming them once (that path locks the title).
- I couldn't run `go build`/`go test` locally (no Go toolchain in my environment) — please verify in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-entered session titles when creating a session with a custom name.
  * Prevented automatically generated names from overwriting manually provided titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->