### PR TITLE
fix(conductor): stop bridge.py from spawning duplicate conductor sessions

### DIFF
--- a/conductor/tests/test_bridge_task_resilience.py
+++ b/conductor/tests/test_bridge_task_resilience.py
@@ -98,3 +98,49 @@ def test_backoff_doubles_and_caps_at_max():
 
     _run(scenario())
     assert delays == [5, 10, 20, 20]
+
+
+def test_retry_never_overlaps_platform_task_instances():
+    active = 0
+    peak_active = 0
+    attempts = 0
+
+    async def flaky():
+        nonlocal active, peak_active, attempts
+        attempts += 1
+        active += 1
+        peak_active = max(peak_active, active)
+        try:
+            if attempts < 3:
+                raise RuntimeError("temporary failure")
+        finally:
+            active -= 1
+
+    async def scenario():
+        with mock.patch("bridge.asyncio.sleep", new=mock.AsyncMock()):
+            await _run_platform_task("test-task", flaky)
+
+    _run(scenario())
+    assert attempts == 3
+    assert peak_active == 1
+
+
+def test_retry_logs_each_failure_with_capped_delay():
+    attempts = 0
+
+    async def flaky():
+        nonlocal attempts
+        attempts += 1
+        if attempts < 4:
+            raise RuntimeError("network unavailable")
+
+    async def scenario():
+        with mock.patch("bridge.asyncio.sleep", new=mock.AsyncMock()), mock.patch(
+            "bridge.log.error"
+        ) as log_error:
+            await _run_platform_task("Telegram polling", flaky, max_backoff=5)
+        return log_error
+
+    log_error = _run(scenario())
+    assert log_error.call_count == 3
+    assert all(call.args[-1] == 5 for call in log_error.call_args_list)

--- a/conductor/tests/test_bridge_task_resilience.py
+++ b/conductor/tests/test_bridge_task_resilience.py
@@ -1,0 +1,100 @@
+"""Regression tests for platform-task crash isolation in main()'s gather().
+
+main() awaits every platform task (Telegram/Slack/Discord) via a single
+asyncio.gather(). Previously, an uncaught exception from any one of them
+(e.g. a TelegramNetworkError from a proxy timeout) killed gather() and thus
+the whole bridge process; the OS service manager then respawned the process
+in a tight loop, and every respawn re-ran the conductor pre-start step.
+_run_platform_task must contain the failure and retry with backoff instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+try:
+    import toml  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["toml"] = types.SimpleNamespace(load=lambda *_args, **_kwargs: {})
+
+from bridge import _run_platform_task  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_failing_task_is_retried_instead_of_raising():
+    attempts = []
+
+    async def flaky():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("network timeout")
+        return "done"
+
+    async def scenario():
+        with mock.patch("bridge.asyncio.sleep", new=mock.AsyncMock()):
+            await _run_platform_task("test-task", flaky)
+
+    _run(scenario())
+    assert len(attempts) == 3
+
+
+def test_successful_task_returns_without_retry():
+    calls = []
+
+    async def succeeds_immediately():
+        calls.append(1)
+
+    async def scenario():
+        with mock.patch("bridge.asyncio.sleep", new=mock.AsyncMock()) as mock_sleep:
+            await _run_platform_task("test-task", succeeds_immediately)
+        return mock_sleep
+
+    mock_sleep = _run(scenario())
+    assert calls == [1]
+    mock_sleep.assert_not_called()
+
+
+def test_cancelled_error_propagates_without_retry():
+    async def cancelled():
+        raise asyncio.CancelledError()
+
+    async def scenario():
+        with mock.patch("bridge.asyncio.sleep", new=mock.AsyncMock()):
+            await _run_platform_task("test-task", cancelled)
+
+    with mock.patch("bridge.log"):
+        try:
+            _run(scenario())
+            raised = False
+        except asyncio.CancelledError:
+            raised = True
+    assert raised
+
+
+def test_backoff_doubles_and_caps_at_max():
+    delays = []
+
+    async def sleep_recorder(seconds):
+        delays.append(seconds)
+
+    attempts = []
+
+    async def flaky():
+        attempts.append(1)
+        if len(attempts) < 5:
+            raise RuntimeError("still failing")
+
+    async def scenario():
+        with mock.patch("bridge.asyncio.sleep", new=sleep_recorder):
+            await _run_platform_task("test-task", flaky, max_backoff=20)
+
+    _run(scenario())
+    assert delays == [5, 10, 20, 20]

--- a/conductor/tests/test_conductor_title_lock.py
+++ b/conductor/tests/test_conductor_title_lock.py
@@ -1,0 +1,65 @@
+"""Regression tests for the conductor-session title-drift bug.
+
+Without --title-lock, agent-deck's title-sync overwrites a freshly created
+conductor session's title with the agent's own session name on its first
+hook event. The bridge's exact-title lookups (get_session_status and
+_find_session_by_title's dedupe) then stop matching that session on every
+later call, so ensure_conductor_running concludes it's "not running" and
+creates a brand new one -- forever, once per restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+try:
+    import toml  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["toml"] = types.SimpleNamespace(load=lambda *_args, **_kwargs: {})
+
+from bridge import ensure_conductor_running  # noqa: E402
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _completed(returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(["agent-deck"], returncode, "", stderr)
+
+
+def _run(coro):
+    with mock.patch("bridge.asyncio.sleep", new=_no_sleep):
+        return asyncio.run(coro)
+
+
+def _calls_for(mock_cli: mock.Mock, *prefix: str) -> list[tuple]:
+    return [
+        call.args
+        for call in mock_cli.call_args_list
+        if call.args[: len(prefix)] == prefix
+    ]
+
+
+def test_conductor_creation_passes_title_lock():
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "running"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=[],
+    ), mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(0), _completed(0)],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("monitor", "default")) is True
+
+    add_calls = _calls_for(mock_cli, "add")
+    assert len(add_calls) == 1
+    assert "--title-lock" in add_calls[0]

--- a/conductor/tests/test_conductor_title_lock.py
+++ b/conductor/tests/test_conductor_title_lock.py
@@ -162,3 +162,10 @@ def test_malformed_list_json_fails_closed():
     malformed.stdout = "unexpected output"
     with mock.patch("bridge.run_cli", return_value=malformed):
         assert get_sessions_list("default", fail_closed=True) is None
+
+
+def test_malformed_list_json_schema_fails_closed():
+    malformed = _completed(0)
+    malformed.stdout = '{"sessions": "not-a-list"}'
+    with mock.patch("bridge.run_cli", return_value=malformed):
+        assert get_sessions_list("default", fail_closed=True) is None

--- a/conductor/tests/test_conductor_title_lock.py
+++ b/conductor/tests/test_conductor_title_lock.py
@@ -114,6 +114,37 @@ def test_ambiguous_canonical_path_fails_closed_without_add():
     assert not _calls_for(mock_cli, "session", "set")
 
 
+def test_drifted_path_and_different_exact_title_fail_closed():
+    sessions = [
+        {
+            "id": "drifted-id",
+            "title": "drifted-agent-title",
+            "path": str(CONDUCTOR_DIR / "monitor"),
+            "profile": "default",
+        },
+        {
+            "id": "exact-id",
+            "title": "conductor-monitor",
+            "path": "/tmp/unrelated-project",
+            "profile": "default",
+        },
+    ]
+    with mock.patch(
+        "bridge.get_session_status",
+        return_value="unknown",
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=sessions,
+    ), mock.patch(
+        "bridge.run_cli",
+        return_value=_completed(1, "not found"),
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("monitor", "default")) is False
+
+    assert not _calls_for(mock_cli, "add")
+    assert not _calls_for(mock_cli, "session", "set")
+
+
 def test_exact_title_path_retries_by_current_title_without_add():
     sessions = [{
         "id": "canonical-id",

--- a/conductor/tests/test_conductor_title_lock.py
+++ b/conductor/tests/test_conductor_title_lock.py
@@ -23,7 +23,7 @@ try:
 except ModuleNotFoundError:
     sys.modules["toml"] = types.SimpleNamespace(load=lambda *_args, **_kwargs: {})
 
-from bridge import ensure_conductor_running  # noqa: E402
+from bridge import CONDUCTOR_DIR, ensure_conductor_running, get_sessions_list  # noqa: E402
 
 
 async def _no_sleep(_seconds: float) -> None:
@@ -63,3 +63,102 @@ def test_conductor_creation_passes_title_lock():
     add_calls = _calls_for(mock_cli, "add")
     assert len(add_calls) == 1
     assert "--title-lock" in add_calls[0]
+
+
+def test_drifted_title_reuses_unique_canonical_path_by_stable_id():
+    session_path = str(CONDUCTOR_DIR / "monitor")
+    sessions = [{
+        "id": "stable-session-id",
+        "title": "drifted-agent-title",
+        "path": session_path,
+        "profile": "default",
+    }]
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "running"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=sessions,
+    ), mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(0), _completed(0)],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("monitor", "default")) is True
+
+    assert _calls_for(
+        mock_cli, "session", "set", "stable-session-id", "title", "conductor-monitor"
+    )
+    assert _calls_for(mock_cli, "session", "start", "stable-session-id")
+    assert not _calls_for(mock_cli, "add")
+
+
+def test_ambiguous_canonical_path_fails_closed_without_add():
+    session_path = str(CONDUCTOR_DIR / "monitor")
+    sessions = [
+        {"id": "one", "title": "first-drift", "path": session_path},
+        {"id": "two", "title": "second-drift", "path": session_path},
+    ]
+    with mock.patch(
+        "bridge.get_session_status",
+        return_value="unknown",
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=sessions,
+    ), mock.patch(
+        "bridge.run_cli",
+        return_value=_completed(1, "not found"),
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("monitor", "default")) is False
+
+    assert not _calls_for(mock_cli, "add")
+    assert not _calls_for(mock_cli, "session", "set")
+
+
+def test_exact_title_path_retries_by_current_title_without_add():
+    sessions = [{
+        "id": "canonical-id",
+        "title": "conductor-monitor",
+        "path": str(CONDUCTOR_DIR / "monitor"),
+        "profile": "default",
+    }]
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "running"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=sessions,
+    ), mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(0)],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("monitor", "default")) is True
+
+    assert len(_calls_for(mock_cli, "session", "start", "conductor-monitor")) == 2
+    assert not _calls_for(mock_cli, "add")
+
+
+def test_list_failure_fails_closed_without_add():
+    with mock.patch(
+        "bridge.get_sessions_list",
+        return_value=None,
+    ), mock.patch(
+        "bridge.run_cli", return_value=_completed(1, "not found")
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("monitor", "default")) is False
+
+    assert len(_calls_for(mock_cli, "session", "start", "conductor-monitor")) == 1
+    assert not _calls_for(mock_cli, "add")
+
+
+def test_verified_empty_profile_allows_first_conductor_creation():
+    empty = _completed(0)
+    empty.stdout = "No sessions found in profile 'default'.\n"
+    with mock.patch("bridge.run_cli", return_value=empty):
+        assert get_sessions_list("default", fail_closed=True) == []
+
+
+def test_malformed_list_json_fails_closed():
+    malformed = _completed(0)
+    malformed.stdout = "unexpected output"
+    with mock.patch("bridge.run_cli", return_value=malformed):
+        assert get_sessions_list("default", fail_closed=True) is None

--- a/conductor/tests/test_issue1351_conductor_dedupe.py
+++ b/conductor/tests/test_issue1351_conductor_dedupe.py
@@ -19,7 +19,7 @@ try:
 except ModuleNotFoundError:
     sys.modules["toml"] = types.SimpleNamespace(load=lambda *_args, **_kwargs: {})
 
-from bridge import ensure_conductor_running  # noqa: E402
+from bridge import CONDUCTOR_DIR, ensure_conductor_running  # noqa: E402
 
 
 async def _no_sleep(_seconds: float) -> None:
@@ -56,7 +56,7 @@ def test_existing_conductor_title_retries_start_without_add():
     ) as mock_cli:
         assert _run(ensure_conductor_running("ops", "work")) is True
 
-    mock_sessions.assert_called_once_with(profile="work")
+    mock_sessions.assert_called_once_with(profile="work", fail_closed=True)
     assert _calls_for(mock_cli, "add") == []
     assert len(_calls_for(mock_cli, "session", "start", "conductor-ops")) == 2
 
@@ -77,7 +77,7 @@ def test_fresh_setup_creates_session_then_starts_it():
     commands = [call.args[:3] for call in mock_cli.call_args_list]
     assert commands == [
         ("session", "start", "conductor-ops"),
-        ("add", str(Path.home() / ".agent-deck" / "conductor" / "ops"), "-t"),
+        ("add", str(CONDUCTOR_DIR / "ops"), "-t"),
         ("session", "start", "conductor-ops"),
     ]
     assert len(_calls_for(mock_cli, "add")) == 1

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -979,6 +979,22 @@ async def ensure_conductor_running(name: str, profile: str) -> bool:
         return False
 
     exact_match = _find_session_by_title(sessions, session_title, profile)
+    if path_match is not None and exact_match is not None:
+        path_id = path_match.get("id")
+        exact_id = exact_match.get("id")
+        same_session = path_match is exact_match or (
+            path_id is not None and path_id == exact_id
+        )
+        if not same_session:
+            log.error(
+                "Conductor path %s and exact title %s identify different "
+                "sessions in profile %s; refusing migration",
+                session_path,
+                session_title,
+                profile,
+            )
+            return False
+
     existing = path_match or exact_match
     session_ref = session_title
     if existing is not None:

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -934,6 +934,11 @@ async def ensure_conductor_running(name: str, profile: str) -> bool:
                     )
             else:
                 # Session is absent from this profile, so create it.
+                # --title-lock is required: without it, agent-deck's title-sync
+                # overwrites session_title with the agent's own session name on
+                # its first hook event, so the exact-title lookups above (and
+                # _find_session_by_title's dedupe) stop matching this session on
+                # every later call, and we'd keep creating new ones forever.
                 log.info("Creating conductor session for %s...", name)
                 session_path = str(CONDUCTOR_DIR / name)
                 result = await loop.run_in_executor(
@@ -943,6 +948,7 @@ async def ensure_conductor_running(name: str, profile: str) -> bool:
                         "-t", session_title,
                         "-c", "claude",
                         "-g", "conductor",
+                        "--title-lock",
                         profile=profile,
                         timeout=60,
                     )
@@ -2878,6 +2884,28 @@ async def heartbeat_loop(
 # ---------------------------------------------------------------------------
 
 
+async def _run_platform_task(name: str, coro_factory, max_backoff: int = 300) -> None:
+    """Run a platform task, restarting it with backoff instead of raising.
+
+    main() awaits every platform task via a single asyncio.gather(), so a
+    transient failure (e.g. a proxy timeout on Telegram's getMe call) must
+    not escape here: an uncaught exception kills gather(), which kills the
+    whole bridge process. The OS service manager then respawns the process
+    in a tight loop, and every respawn re-runs the conductor pre-start step.
+    """
+    backoff = 5
+    while True:
+        try:
+            await coro_factory()
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.error("%s task failed: %s; retrying in %ds", name, e, backoff)
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, max_backoff)
+
+
 async def main():
     log.info("Loading config from %s", CONFIG_PATH)
     config = load_config()
@@ -2961,13 +2989,21 @@ async def main():
     # Run all concurrently
     tasks = [heartbeat_task]
     if telegram_dp and telegram_bot:
-        tasks.append(asyncio.create_task(telegram_dp.start_polling(telegram_bot)))
+        tasks.append(asyncio.create_task(_run_platform_task(
+            "Telegram polling",
+            lambda: telegram_dp.start_polling(telegram_bot),
+        )))
         log.info("Telegram bot polling started")
     if slack_handler:
-        tasks.append(asyncio.create_task(slack_handler.start_async()))
+        tasks.append(asyncio.create_task(_run_platform_task(
+            "Slack Socket Mode", slack_handler.start_async,
+        )))
         log.info("Slack Socket Mode handler started")
     if discord_bot:
-        tasks.append(asyncio.create_task(discord_bot.start(config["discord"]["bot_token"])))
+        tasks.append(asyncio.create_task(_run_platform_task(
+            "Discord bot",
+            lambda: discord_bot.start(config["discord"]["bot_token"]),
+        )))
         log.info("Discord bot started")
 
     try:

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -2884,7 +2884,9 @@ async def heartbeat_loop(
 # ---------------------------------------------------------------------------
 
 
-async def _run_platform_task(name: str, coro_factory, max_backoff: int = 300) -> None:
+async def _run_platform_task(
+    name: str, coro_factory: Callable[[], Coroutine[Any, Any, None]], max_backoff: int = 300
+) -> None:
     """Run a platform task, restarting it with backoff instead of raising.
 
     main() awaits every platform task via a single asyncio.gather(), so a

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -846,11 +846,13 @@ def get_status_summary_all(profiles: list[str]) -> dict:
     return {"totals": totals, "per_profile": per_profile}
 
 
-def get_sessions_list(profile: str | None = None) -> list:
+def get_sessions_list(
+    profile: str | None = None, *, fail_closed: bool = False
+) -> list | None:
     """Get list of all sessions for a single profile."""
     result = run_cli("list", "--json", profile=profile, timeout=30)
     if result.returncode != 0:
-        return []
+        return None if fail_closed else []
     try:
         data = json.loads(result.stdout)
         # list --json returns {"sessions": [...]}
@@ -858,7 +860,9 @@ def get_sessions_list(profile: str | None = None) -> list:
             return data.get("sessions", [])
         return data if isinstance(data, list) else []
     except json.JSONDecodeError:
-        return []
+        if result.stdout.strip().startswith("No sessions found in profile "):
+            return []
+        return None if fail_closed else []
 
 
 def get_sessions_list_all(profiles: list[str]) -> list[tuple[str, dict]]:
@@ -866,7 +870,7 @@ def get_sessions_list_all(profiles: list[str]) -> list[tuple[str, dict]]:
     all_sessions = []
     for profile in profiles:
         sessions = get_sessions_list(profile)
-        for s in sessions:
+        for s in sessions or []:
             all_sessions.append((profile, s))
     return all_sessions
 
@@ -884,102 +888,190 @@ def _find_session_by_title(sessions: list, title: str, profile: str) -> dict | N
     return None
 
 
+def _normalized_session_path(path: object) -> str | None:
+    """Normalize a list-JSON path without requiring it to exist."""
+    if not isinstance(path, str) or not path:
+        return None
+    return os.path.normcase(os.path.abspath(os.path.expanduser(path)))
+
+
+def _find_conductor_session_by_path(
+    sessions: list, session_path: str, profile: str
+) -> tuple[dict | None, bool]:
+    """Return the unique profile-scoped session at path and ambiguity state."""
+    canonical_path = _normalized_session_path(session_path)
+    matches = []
+    for session in sessions:
+        if not isinstance(session, dict):
+            continue
+        session_profile = session.get("profile")
+        if session_profile not in (None, "", profile):
+            continue
+        if _normalized_session_path(session.get("path")) == canonical_path:
+            matches.append(session)
+    if len(matches) > 1:
+        return None, True
+    return (matches[0] if matches else None), False
+
+
 async def ensure_conductor_running(name: str, profile: str) -> bool:
     """Ensure the conductor session exists and is running."""
     session_title = conductor_session_title(name)
+    session_path = str(CONDUCTOR_DIR / name)
     loop = asyncio.get_running_loop()
     status = await loop.run_in_executor(
         None, functools.partial(get_session_status, session_title, profile=profile)
     )
+    if status in ("waiting", "running", "idle", "active", "starting"):
+        return True
 
-    if status not in ("waiting", "running", "idle", "active", "starting"):
-        log.info("Conductor %s not running (status=%s), attempting to start...", name, status)
-        # Try starting first (session might exist but be stopped)
-        result = await loop.run_in_executor(
-            None, functools.partial(
-                run_cli, "session", "start", session_title, profile=profile, timeout=60
-            )
-        )
-        if result.returncode != 0:
-            log.warning(
-                "Failed to start conductor %s before dedupe: %s",
-                name,
-                result.stderr.strip(),
-            )
-            sessions = await loop.run_in_executor(
-                None, functools.partial(get_sessions_list, profile=profile)
-            )
-            existing = _find_session_by_title(sessions, session_title, profile)
-            if existing is not None:
-                log.info(
-                    "Reusing existing conductor session %s in profile %s",
-                    session_title,
-                    profile,
-                )
-                retry = await loop.run_in_executor(
-                    None, functools.partial(
-                        run_cli,
-                        "session",
-                        "start",
-                        session_title,
-                        profile=profile,
-                        timeout=60,
-                    )
-                )
-                if retry.returncode != 0:
-                    log.warning(
-                        "Failed to start existing conductor %s: %s",
-                        name,
-                        retry.stderr.strip(),
-                    )
-            else:
-                # Session is absent from this profile, so create it.
-                # --title-lock is required: without it, agent-deck's title-sync
-                # overwrites session_title with the agent's own session name on
-                # its first hook event, so the exact-title lookups above (and
-                # _find_session_by_title's dedupe) stop matching this session on
-                # every later call, and we'd keep creating new ones forever.
-                log.info("Creating conductor session for %s...", name)
-                session_path = str(CONDUCTOR_DIR / name)
-                result = await loop.run_in_executor(
-                    None, functools.partial(
-                        run_cli,
-                        "add", session_path,
-                        "-t", session_title,
-                        "-c", "claude",
-                        "-g", "conductor",
-                        "--title-lock",
-                        profile=profile,
-                        timeout=60,
-                    )
-                )
-                if result.returncode != 0:
-                    log.error(
-                        "Failed to create conductor %s: %s",
-                        name,
-                        result.stderr.strip(),
-                    )
-                    return False
-                # Start the newly created session
-                await loop.run_in_executor(
-                    None, functools.partial(
-                        run_cli,
-                        "session",
-                        "start",
-                        session_title,
-                        profile=profile,
-                        timeout=60,
-                    )
-                )
-
-        # Wait a moment for the session to initialize (non-blocking)
+    initial_start = await loop.run_in_executor(
+        None,
+        functools.partial(
+            run_cli,
+            "session",
+            "start",
+            session_title,
+            profile=profile,
+            timeout=60,
+        ),
+    )
+    if initial_start.returncode == 0:
         await asyncio.sleep(5)
         final_status = await loop.run_in_executor(
-            None, functools.partial(get_session_status, session_title, profile=profile)
+            None,
+            functools.partial(get_session_status, session_title, profile=profile),
         )
         return final_status not in ("error", "unknown")
 
-    return True
+    log.warning(
+        "Failed to start conductor %s before dedupe: %s",
+        name,
+        initial_start.stderr.strip(),
+    )
+    sessions = await loop.run_in_executor(
+        None,
+        functools.partial(get_sessions_list, profile=profile, fail_closed=True),
+    )
+    if sessions is None:
+        log.error(
+            "Cannot verify conductor %s identity because list --json failed; "
+            "refusing to create a possibly duplicate session",
+            name,
+        )
+        return False
+
+    path_match, ambiguous = _find_conductor_session_by_path(
+        sessions, session_path, profile
+    )
+    if ambiguous:
+        log.error(
+            "Multiple sessions in profile %s use conductor path %s; "
+            "refusing to select one or create another",
+            profile,
+            session_path,
+        )
+        return False
+
+    exact_match = _find_session_by_title(sessions, session_title, profile)
+    existing = path_match or exact_match
+    session_ref = session_title
+    if existing is not None:
+        session_ref = existing.get("id") or existing.get("title")
+        if not session_ref:
+            log.error(
+                "Conductor session at %s has neither id nor title; refusing migration",
+                session_path,
+            )
+            return False
+
+        if existing.get("title") != session_title:
+            log.info(
+                "Restoring drifted conductor title %r to %r using session %s",
+                existing.get("title"),
+                session_title,
+                session_ref,
+            )
+            rename_result = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    run_cli,
+                    "session",
+                    "set",
+                    session_ref,
+                    "title",
+                    session_title,
+                    profile=profile,
+                    timeout=60,
+                ),
+            )
+            if rename_result.returncode != 0:
+                log.error(
+                    "Failed to restore conductor %s identity: %s",
+                    name,
+                    rename_result.stderr.strip(),
+                )
+                return False
+        else:
+            session_ref = session_title
+
+        log.info(
+            "Reusing existing conductor session %s in profile %s",
+            session_ref,
+            profile,
+        )
+    else:
+        log.info("Creating conductor session for %s...", name)
+        result = await loop.run_in_executor(
+            None,
+            functools.partial(
+                run_cli,
+                "add",
+                session_path,
+                "-t",
+                session_title,
+                "-c",
+                "claude",
+                "-g",
+                "conductor",
+                "--title-lock",
+                profile=profile,
+                timeout=60,
+            ),
+        )
+        if result.returncode != 0:
+            log.error(
+                "Failed to create conductor %s: %s",
+                name,
+                result.stderr.strip(),
+            )
+            return False
+
+    result = await loop.run_in_executor(
+        None,
+        functools.partial(
+            run_cli,
+            "session",
+            "start",
+            session_ref,
+            profile=profile,
+            timeout=60,
+        ),
+    )
+    if result.returncode != 0:
+        log.warning(
+            "Failed to start conductor %s using %s: %s",
+            name,
+            session_ref,
+            result.stderr.strip(),
+        )
+        return False
+
+    await asyncio.sleep(5)
+    final_status = await loop.run_in_executor(
+        None, functools.partial(get_session_status, session_ref, profile=profile)
+    )
+    return final_status not in ("error", "unknown")
 
 
 # ---------------------------------------------------------------------------

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -857,8 +857,13 @@ def get_sessions_list(
         data = json.loads(result.stdout)
         # list --json returns {"sessions": [...]}
         if isinstance(data, dict):
-            return data.get("sessions", [])
-        return data if isinstance(data, list) else []
+            sessions = data.get("sessions")
+            if isinstance(sessions, list):
+                return sessions
+            return None if fail_closed else []
+        if isinstance(data, list):
+            return data
+        return None if fail_closed else []
     except json.JSONDecodeError:
         if result.stdout.strip().startswith("No sessions found in profile "):
             return []


### PR DESCRIPTION
Fixes #1608.

Original implementation and authorship by @youling66. Maintainer integration commits add migration safety and regression coverage without squashing the contributor commits.

## Root cause

The bridge identified conductor sessions only by the expected `conductor-<name>` title. Existing sessions whose title had already drifted were invisible to that lookup, so an upgrade could still create another row. Separately, an uncaught Telegram, Slack, or Discord polling exception escaped `asyncio.gather()` and caused the service manager to restart the bridge repeatedly.

## Fix

- Keep `--title-lock` on every newly created conductor session.
- Preserve the healthy exact-title fast path from #1351.
- Fall back to the profile-scoped `list --json` record and canonical conductor project path for drifted sessions.
- Require a unique canonical-path match, then restore the title through the stable session ID. The title mutation also locks future synchronization.
- Fail closed when list output is unavailable, malformed, has an invalid schema, the canonical path is ambiguous, or canonical-path and exact-title matches identify different sessions.
- Wrap Telegram, Slack, and Discord polling with one sequential retry loop per platform. `CancelledError` propagates, normal return ends the wrapper, failures log loudly, and backoff grows from 5 seconds to a 300 second cap.

## Surfaces

- Conductor bridge lifecycle: covered by `conductor/tests/test_conductor_title_lock.py`, `conductor/tests/test_bridge_task_resilience.py`, and the updated #1351 compatibility tests.
- CLI: no new command or output shape. The bridge consumes existing profile-scoped `id`, `title`, and `path` fields from `list --json` and existing `session set` behavior.
- Persistence: no schema change.
- TUI, Web UI, remote sessions, and cross-platform Go behavior: no user-interface or session-model change.

## Verification

- Full conductor Python suite: 72 passed, 8 dependency-gated skips.
- Bridge compile and import: Python 3.9, 3.12, and 3.13 passed locally. GitHub compatibility checks passed on Python 3.8 through 3.12.
- Relevant conductor Go tests: passed under isolated HOME and XDG directories.
- `go build ./...`: passed.
- golangci-lint v2.12.2: passed locally and in GitHub Actions.
- `govulncheck ./...`: zero reachable vulnerabilities locally and passed in GitHub Actions.
- Full race suite: all packages passed except two failures that reproduce identically on untouched current `main`: `TestForbidigo_BansRawOSEnvironInSpawnPath` and `TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision`.
- `git diff --check`: passed.
- CodeQL, diff-scope, and CodeRabbit checks: passed.

Do not merge as part of this integration task.
