### PR TITLE
fix: preserve explicit session titles on creation (#1607)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10679,6 +10679,15 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		inst.Command = command
 		inst.SetAutoName(autoName) // quick-create paths pass true; see render substitution
 
+		// A title the user typed into the full create dialog (autoName=false) is
+		// explicit intent, so lock it against the Claude session-name sync (#572).
+		// Otherwise the next hook event or attach reconcile would overwrite it with
+		// Claude's cwd-derived name — for a worktree that is the "<repo>-<branch>"
+		// folder basename (e.g. "linqalpha-e7"), silently renaming the session.
+		if !autoName && strings.TrimSpace(name) != "" {
+			inst.TitleLocked = true
+		}
+
 		// Set worktree fields if provided
 		if worktreePath != "" {
 			inst.WorktreePath = worktreePath

--- a/internal/ui/issue1607_explicit_title_lock_test.go
+++ b/internal/ui/issue1607_explicit_title_lock_test.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestIssue1607_CreateSessionTitleLock verifies that the full create-dialog
+// path locks a nonblank user title while quick-create and blank-name paths keep
+// their existing unlocked behavior. The lock must also block the later Claude
+// title reconciliation that originally replaced the title with a worktree
+// folder basename.
+func TestIssue1607_CreateSessionTitleLock(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		autoName   bool
+		wantLocked bool
+	}{
+		{name: "explicit user title", title: "Release prep", wantLocked: true},
+		{name: "automatic title", title: "quiet-otter", autoName: true},
+		{name: "blank title", title: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := createIssue1607Session(t, tt.title, tt.autoName)
+			if inst.TitleLocked != tt.wantLocked {
+				t.Fatalf("TitleLocked = %v, want %v", inst.TitleLocked, tt.wantLocked)
+			}
+			if inst.GetAutoName() != tt.autoName {
+				t.Fatalf("AutoName = %v, want %v", inst.GetAutoName(), tt.autoName)
+			}
+
+			if tt.wantLocked {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				session.ClearUserConfigCache()
+				t.Cleanup(session.ClearUserConfigCache)
+				seedIssue1607ClaudeName(t, home, "sid-1607", "agent-deck-feature-branch")
+
+				if name, changed := inst.ReconcileTitleFromClaude("sid-1607"); changed || name != "" {
+					t.Fatalf("ReconcileTitleFromClaude = (%q, %v), want no-op", name, changed)
+				}
+				if inst.Title != tt.title {
+					t.Fatalf("Title = %q after reconcile, want %q", inst.Title, tt.title)
+				}
+			}
+		})
+	}
+}
+
+func createIssue1607Session(t *testing.T, title string, autoName bool) *session.Instance {
+	t.Helper()
+	h := &Home{}
+	msg := h.createSessionInGroupWithWorktreeAndOptions(
+		title,
+		t.TempDir(),
+		"sleep 30",
+		"test",
+		"", "", "",
+		false,
+		false,
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		nil,
+		"", "",
+		"",
+		autoName,
+	)().(sessionCreatedMsg)
+	if msg.err != nil {
+		t.Fatalf("create session: %v", msg.err)
+	}
+	t.Cleanup(func() {
+		if err := msg.instance.KillAndWait(); err != nil {
+			t.Errorf("cleanup session: %v", err)
+		}
+	})
+	return msg.instance
+}
+
+func seedIssue1607ClaudeName(t *testing.T, home, sessionID, name string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir Claude sessions: %v", err)
+	}
+	data, err := json.Marshal(map[string]any{"sessionId": sessionID, "name": name})
+	if err != nil {
+		t.Fatalf("marshal Claude session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "1607.json"), data, 0o644); err != nil {
+		t.Fatalf("write Claude session: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Integrates the production fix from closed contributor PR #1607 and preserves gamrom as the author of the fix commit.

- Locks nonblank titles entered through the full create dialog.
- Keeps quick-create and blank-name sessions unlocked.
- Adds a regression test for creation semantics and later Claude title reconciliation.

## Surface coverage

- TUI creation path: `internal/ui/issue1607_explicit_title_lock_test.go` covers explicit, automatic, and blank titles.
- Remote: unchanged. Remote creation does not use this local TUI helper and already preserves explicit title intent.
- Web and CLI: unchanged. Neither surface calls this full create-dialog path.
- Persistence and cross-platform behavior: unchanged. The existing `TitleLocked` field and pure boolean assignment are reused.

## Verification

- `go test -race -count=1 -run "^TestIssue1607_CreateSessionTitleLock$" ./internal/ui`
- Exact locked and folder-derived title reconciliation tests under race
- `go build ./...`
- golangci-lint v2.12.2: 0 issues
- govulncheck: 0 reachable vulnerabilities
- `git diff --check origin/main...HEAD`

The full race suite also ran. `internal/ui` passed. Current main still has unrelated failures in performance budgets and existing session, statedb, tmux, and test utility tests. The persistent non-performance failures were `TestCanRestartCursor` and `TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision`; focused tmux reruns passed.

Original contribution: #1607.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly entered session titles are now preserved and won’t be overwritten by automatic title synchronization.
  * Blank or automatically generated titles continue to behave as expected.

* **Tests**
  * Added coverage for explicit, automatic, and blank session title creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->