### PR TITLE
fix(statedb): announce targeted archive writes so a running TUI cannot clobber them

### DIFF
--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -1201,17 +1201,17 @@ func (s *Storage) GetUpdatedAt() (time.Time, error) {
 	return time.Unix(0, ts), nil
 }
 
-// GetFileMtime returns the filesystem modification time of the database file.
-// This is useful for detecting external changes when polling.
+// GetFileMtime returns the database's last-write timestamp, for detecting that
+// another process changed the profile DB.
+//
+// It deliberately does NOT os.Stat(state.db). SQLite runs in WAL mode here, so a
+// committed write lands in state.db-wal and leaves state.db's mtime unchanged
+// until a checkpoint — statting the main file reports "no change" for every
+// out-of-process write, so the TUI's external-change guard never fired and its
+// next full-table save clobbered CLI writes. metadata.last_modified is the
+// authoritative signal, and the one StorageWatcher already polls.
 func (s *Storage) GetFileMtime() (time.Time, error) {
-	info, err := os.Stat(s.dbPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return time.Time{}, nil
-		}
-		return time.Time{}, err
-	}
-	return info.ModTime(), nil
+	return s.GetUpdatedAt()
 }
 
 // convertToInstances converts StorageData to Instance slice

--- a/internal/session/storage_mtime_test.go
+++ b/internal/session/storage_mtime_test.go
@@ -1,0 +1,61 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// GetFileMtime is the clock the TUI's save path uses to detect that another
+// process wrote to the profile DB (home.go saveInstancesWithForce). It used to
+// os.Stat(state.db) — but SQLite runs in WAL mode, so a committed write lands in
+// state.db-wal and leaves state.db's mtime untouched until a checkpoint. The
+// guard could therefore never fire, and the TUI would overwrite CLI writes.
+//
+// GetFileMtime must instead reflect the DB's own last_modified metadata, which
+// is the same signal StorageWatcher polls.
+
+func TestGetFileMtimeAdvancesAfterDBWrite(t *testing.T) {
+	s := newTestStorage(t)
+
+	before, err := s.GetFileMtime()
+	if err != nil {
+		t.Fatalf("GetFileMtime (before): %v", err)
+	}
+
+	// A committed write through the DB — exactly what a separate `agent-deck
+	// session archive` process does. In WAL mode this does not touch state.db.
+	if err := s.GetDB().Touch(); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+
+	after, err := s.GetFileMtime()
+	if err != nil {
+		t.Fatalf("GetFileMtime (after): %v", err)
+	}
+
+	if !after.After(before) {
+		t.Errorf("GetFileMtime did not advance after a committed DB write: "+
+			"before=%v after=%v (external-change detection is blind; "+
+			"the TUI will clobber out-of-process writes)", before, after)
+	}
+}
+
+// A zero baseline would make `currentMtime.After(ourLoadMtime)` in the save path
+// trivially false, so GetFileMtime must return a real timestamp for a written DB
+// rather than the zero time.
+func TestGetFileMtimeIsNonZeroAfterWrite(t *testing.T) {
+	s := newTestStorage(t)
+	if err := s.GetDB().Touch(); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	got, err := s.GetFileMtime()
+	if err != nil {
+		t.Fatalf("GetFileMtime: %v", err)
+	}
+	if got.IsZero() {
+		t.Fatal("GetFileMtime returned zero time after a write; guard would never fire")
+	}
+	if time.Since(got) > time.Minute {
+		t.Errorf("GetFileMtime returned a stale timestamp %v (now=%v)", got, time.Now())
+	}
+}

--- a/internal/statedb/change_signal_test.go
+++ b/internal/statedb/change_signal_test.go
@@ -1,0 +1,109 @@
+package statedb
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// Targeted single-row mutators must advertise their write via Touch(), the
+// metadata timestamp StorageWatcher polls to detect out-of-process changes.
+// A mutator that writes instances but leaves last_modified frozen is invisible
+// to a running TUI, which then force-saves its stale in-memory snapshot over
+// the change (SaveInstances is a DELETE-NOT-IN + INSERT OR REPLACE sweep).
+// That is how `agent-deck session archive` silently reverted: the archive
+// landed, the TUI never reloaded, and the next forced save undid every row.
+
+func seedChangeSignalInstance(t *testing.T, db *StateDB, id string) {
+	t.Helper()
+	if err := db.SaveInstance(&InstanceRow{
+		ID:          id,
+		Title:       id,
+		ProjectPath: "/tmp/project",
+		GroupPath:   "grp",
+		Tool:        "claude",
+		Status:      "stopped",
+		CreatedAt:   time.Now(),
+		ToolData:    json.RawMessage("{}"),
+	}); err != nil {
+		t.Fatalf("seed SaveInstance: %v", err)
+	}
+}
+
+// baselineLastModified seeds last_modified and returns it, so a mutator that
+// never touches the key is distinguishable from one that advances it.
+func baselineLastModified(t *testing.T, db *StateDB) int64 {
+	t.Helper()
+	if err := db.Touch(); err != nil {
+		t.Fatalf("Touch (baseline): %v", err)
+	}
+	ts, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified (baseline): %v", err)
+	}
+	if ts == 0 {
+		t.Fatalf("baseline last_modified is 0, want a seeded timestamp")
+	}
+	return ts
+}
+
+func TestSetArchivedBumpsLastModified(t *testing.T) {
+	db := newTestDB(t)
+	seedChangeSignalInstance(t, db, "arch-signal")
+	before := baselineLastModified(t, db)
+
+	if err := db.SetArchived("arch-signal", time.Unix(1783589599, 0).UTC()); err != nil {
+		t.Fatalf("SetArchived: %v", err)
+	}
+
+	after, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+	if after <= before {
+		t.Errorf("SetArchived did not bump last_modified: before=%d after=%d "+
+			"(a running TUI cannot see this write and will clobber it)", before, after)
+	}
+}
+
+func TestSetArchivedUnarchiveBumpsLastModified(t *testing.T) {
+	db := newTestDB(t)
+	seedChangeSignalInstance(t, db, "unarch-signal")
+	if err := db.SetArchived("unarch-signal", time.Unix(1783589599, 0).UTC()); err != nil {
+		t.Fatalf("SetArchived(archive): %v", err)
+	}
+	before := baselineLastModified(t, db)
+
+	// Unarchive is the zero-time write; it must announce itself too.
+	if err := db.SetArchived("unarch-signal", time.Time{}); err != nil {
+		t.Fatalf("SetArchived(unarchive): %v", err)
+	}
+
+	after, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+	if after <= before {
+		t.Errorf("SetArchived(unarchive) did not bump last_modified: before=%d after=%d",
+			before, after)
+	}
+}
+
+func TestSetAcknowledgedBumpsLastModified(t *testing.T) {
+	db := newTestDB(t)
+	seedChangeSignalInstance(t, db, "ack-signal")
+	before := baselineLastModified(t, db)
+
+	if err := db.SetAcknowledged("ack-signal", true); err != nil {
+		t.Fatalf("SetAcknowledged: %v", err)
+	}
+
+	after, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+	if after <= before {
+		t.Errorf("SetAcknowledged did not bump last_modified: before=%d after=%d",
+			before, after)
+	}
+}

--- a/internal/statedb/change_signal_test.go
+++ b/internal/statedb/change_signal_test.go
@@ -2,6 +2,7 @@ package statedb
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -86,6 +87,78 @@ func TestSetArchivedUnarchiveBumpsLastModified(t *testing.T) {
 	if after <= before {
 		t.Errorf("SetArchived(unarchive) did not bump last_modified: before=%d after=%d",
 			before, after)
+	}
+}
+
+// TestCLIArchiveIsVisibleToAnotherProcessBeforeItSaves reproduces the original
+// clobber end-to-end with two connections to one DB file: `tui` holds a snapshot
+// loaded before the archive, `cli` archives a row.
+//
+// The clobber is not that SaveInstances sweeps — it legitimately does — but that
+// the TUI had no way to learn it was holding a stale snapshot. This asserts the
+// signal it polls actually advances, and then demonstrates the data loss that
+// follows when a stale snapshot is written blind.
+func TestCLIArchiveIsVisibleToAnotherProcessBeforeItSaves(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+
+	tui, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open(tui): %v", err)
+	}
+	defer tui.Close()
+	if err := tui.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	cli, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open(cli): %v", err)
+	}
+	defer cli.Close()
+
+	seedChangeSignalInstance(t, tui, "clobber-1")
+
+	// The TUI loads its in-memory snapshot and records the change signal it saw.
+	staleSnapshot, err := tui.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	lastSeen, err := tui.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+
+	// A separate process archives the row.
+	if err := cli.SetArchived("clobber-1", time.Unix(1783589599, 0).UTC()); err != nil {
+		t.Fatalf("SetArchived: %v", err)
+	}
+
+	// The TUI's watcher must be able to observe that write. If it cannot, it
+	// keeps the stale snapshot and the next forced save silently reverts.
+	now, err := tui.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified (after): %v", err)
+	}
+	if now <= lastSeen {
+		t.Fatalf("TUI cannot observe the CLI archive (last_modified %d -> %d); "+
+			"it will save its stale snapshot and revert the archive", lastSeen, now)
+	}
+
+	// Demonstrate the loss the signal exists to prevent: writing the pre-archive
+	// snapshot blind resets archived_at. This is why detection must work.
+	if err := tui.SaveInstances(staleSnapshot); err != nil {
+		t.Fatalf("SaveInstances(stale): %v", err)
+	}
+	rows, err := tui.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances (post-sweep): %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if !rows[0].ArchivedAt.IsZero() {
+		t.Fatal("expected the stale full-table sweep to clobber archived_at; " +
+			"if it no longer does, this test's premise is stale")
 	}
 }
 

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1375,16 +1375,29 @@ func (s *StateDB) ReadAllStatuses() (map[string]StatusRow, error) {
 	return result, rows.Err()
 }
 
+// touchWithRetry stamps metadata.last_modified, retrying on SQLITE_BUSY.
+//
+// Touch() is a plain Exec, so under a concurrent writer it fails where the
+// retry-wrapped row UPDATE beside it would have succeeded — leaving the row
+// changed but the change unannounced. Every targeted writer that stamps its
+// own signal must retry the stamp as hard as it retried the write.
+func (s *StateDB) touchWithRetry() error {
+	return withBusyRetry(func() error { return s.Touch() })
+}
+
 // SetAcknowledged sets or clears the acknowledged flag for an instance.
 func (s *StateDB) SetAcknowledged(id string, ack bool) error {
 	v := 0
 	if ack {
 		v = 1
 	}
-	if _, err := s.db.Exec("UPDATE instances SET acknowledged = ? WHERE id = ?", v, id); err != nil {
+	if err := withBusyRetry(func() error {
+		_, err := s.db.Exec("UPDATE instances SET acknowledged = ? WHERE id = ?", v, id)
+		return err
+	}); err != nil {
 		return err
 	}
-	return s.Touch()
+	return s.touchWithRetry()
 }
 
 // SetArchived sets or clears the archive timestamp for a single instance via a
@@ -1406,7 +1419,7 @@ func (s *StateDB) SetArchived(id string, at time.Time) error {
 	}); err != nil {
 		return err
 	}
-	return s.Touch()
+	return s.touchWithRetry()
 }
 
 // --- Heartbeat ---

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1381,8 +1381,10 @@ func (s *StateDB) SetAcknowledged(id string, ack bool) error {
 	if ack {
 		v = 1
 	}
-	_, err := s.db.Exec("UPDATE instances SET acknowledged = ? WHERE id = ?", v, id)
-	return err
+	if _, err := s.db.Exec("UPDATE instances SET acknowledged = ? WHERE id = ?", v, id); err != nil {
+		return err
+	}
+	return s.Touch()
 }
 
 // SetArchived sets or clears the archive timestamp for a single instance via a
@@ -1391,11 +1393,20 @@ func (s *StateDB) SetAcknowledged(id string, ack bool) error {
 // that path's external-change guard aborts the save and reloads, silently
 // discarding the archive (see #archive-abort). A scoped UPDATE always lands.
 // A zero `at` clears the flag (unarchive).
+//
+// The scoped UPDATE bypasses saveInstances(), which is also the only code path
+// that calls Touch(). Touch() explicitly here: it stamps metadata.last_modified,
+// the timestamp StorageWatcher polls to notice out-of-process writes. Without it
+// a running TUI never reloads, and its next forced full-table save replays a
+// stale snapshot over this row, reverting the archive.
 func (s *StateDB) SetArchived(id string, at time.Time) error {
-	return withBusyRetry(func() error {
+	if err := withBusyRetry(func() error {
 		_, err := s.db.Exec("UPDATE instances SET archived_at = ? WHERE id = ?", archivedAtUnix(at), id)
 		return err
-	})
+	}); err != nil {
+		return err
+	}
+	return s.Touch()
 }
 
 // --- Heartbeat ---


### PR DESCRIPTION
## Problem

`agent-deck session archive` lands in the DB and then tells nobody. A running TUI never learns about it, and its next save replays a stale in-memory snapshot straight over the write — so archiving appears to work, then silently reverts. This is the "I archived it but it keeps coming back" failure.

Two compounding defects:

1. **The archive write is silent.** `SetArchived` / `SetAcknowledged` are scoped UPDATEs that deliberately bypass the full-table `saveInstances()` path (#1532). But `saveInstances()` is the only caller of `Touch()`, which stamps `metadata.last_modified` — the very timestamp `StorageWatcher` polls to notice out-of-process writes. So the targeted write never raised the flag that says "something changed." The TUI kept its startup snapshot, and its next `forceSaveInstances()` pushed that snapshot through the `DELETE-NOT-IN` + `INSERT OR REPLACE` sweep, resetting `archived_at` to 0 on every row.

2. **The save-path guard could never fire.** `Storage.GetFileMtime()` `os.Stat`'d `state.db`. SQLite runs in WAL mode, so a committed write lands in `state.db-wal` and leaves `state.db`'s mtime untouched until checkpoint — meaning the external-change guard in `saveInstancesWithForce` was structurally blind to exactly the writes it exists to catch.

## Fix

1. `SetArchived` and `SetAcknowledged` call `Touch()` after a successful UPDATE, so cross-process watchers observe the write.
2. `GetFileMtime()` delegates to `GetUpdatedAt()`, reading `metadata.last_modified` like `StorageWatcher` does, instead of stat'ing a file WAL doesn't touch.

## Tests

- `TestCLIArchiveIsVisibleToAnotherProcessBeforeItSaves` reproduces the cross-process clobber (fails without the fix).
- `TestSetArchivedBumpsLastModified`, `TestSetArchivedUnarchiveBumpsLastModified`, `TestSetAcknowledgedBumpsLastModified` pin the change signal.
- `internal/session/storage_mtime_test.go` covers the WAL-blind mtime path.

`go build ./...`, `go vet`, and `gofmt` are clean; `internal/statedb` and the archive/mtime tests in `internal/session` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of external database changes in SQLite WAL mode by relying on the database’s authoritative metadata last-write time.
  * Ensured archive and acknowledgment updates always promptly bump the shared “last modified” timestamp, preventing other sessions from being overwritten by stale saves.
  * Added resilient stamping with busy-retry behavior for targeted updates.
* **Tests**
  * Added unit and end-to-end coverage for change-signal behavior, archive/unarchive, and acknowledgment visibility across concurrent sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->