### PR TITLE
fix(codex): deliver the initial prompt as an argument instead of typing it

### DIFF
--- a/internal/session/codex_initial_prompt_test.go
+++ b/internal/session/codex_initial_prompt_test.go
@@ -1,0 +1,93 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+// A large initial prompt cannot be typed into a live Codex TUI: Agent Deck sends it
+// as one literal `tmux send-keys -l` burst followed immediately by Enter, and Codex
+// reads a large fast burst as a paste, swallowing the Enter into it. The prompt then
+// sits unsubmitted in the composer and the agent never starts. Codex accepts the
+// prompt as its own positional argument (`codex [OPTIONS] [PROMPT]`), so deliver it
+// there and type nothing.
+
+func codexInstance(tool, command string) *Instance {
+	return &Instance{ID: "i1", Title: "t", Tool: tool, Command: command}
+}
+
+func TestBuildCodexCommandWithPromptEmbedsPromptAsArgument(t *testing.T) {
+	i := codexInstance("codex", "codex")
+	cmd, embedded := i.buildCodexCommandWithPrompt("codex", "do the thing")
+	if !embedded {
+		t.Fatalf("prompt should be embedded on the plain fresh-start path; got %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, " 'do the thing'") {
+		t.Fatalf("prompt must be the last, shell-quoted argument; got %q", cmd)
+	}
+}
+
+func TestBuildCodexCommandWithPromptQuotesMetacharacters(t *testing.T) {
+	i := codexInstance("codex", "codex")
+	prompt := "IT'S \"quoted\" `tick` $VAR; rm -rf / && echo pwned"
+	cmd, embedded := i.buildCodexCommandWithPrompt("codex", prompt)
+	if !embedded {
+		t.Fatal("expected prompt to be embedded")
+	}
+	// The whole prompt must be exactly one shell-quoted operand, so nothing in it
+	// can be interpreted by the shell that runs the command.
+	if !strings.HasSuffix(cmd, shellescape.Quote(prompt)) {
+		t.Fatalf("prompt is not a single shell-quoted operand; got %q", cmd)
+	}
+	if !strings.Contains(cmd, `'"'"'`) {
+		t.Fatalf("apostrophes must be shell-escaped; got %q", cmd)
+	}
+}
+
+func TestBuildCodexCommandWithPromptEmptyPromptIsNotEmbedded(t *testing.T) {
+	i := codexInstance("codex", "codex")
+	cmd, embedded := i.buildCodexCommandWithPrompt("codex", "   ")
+	if embedded {
+		t.Fatalf("an empty prompt must not be embedded; got %q", cmd)
+	}
+}
+
+func TestBuildCodexCommandWithPromptCustomCommandFallsBackToTyping(t *testing.T) {
+	// A user-supplied wrapper is passed through verbatim and need not accept a
+	// positional prompt, so the caller must keep the existing typing path.
+	i := codexInstance("codex", "my-wrapper --flag")
+	cmd, embedded := i.buildCodexCommandWithPrompt("my-wrapper --flag", "do the thing")
+	if embedded {
+		t.Fatalf("custom commands must not get a positional prompt; got %q", cmd)
+	}
+}
+
+func TestBuildCodexCommandWithPromptResumeFallsBackToTyping(t *testing.T) {
+	// buildCodexCommand drops a session id with no rollout on disk (#756), which is a
+	// fresh start; a resumable session needs its rollout file to exist.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	sid := "11111111-2222-3333-4444-555555555555"
+	dir := filepath.Join(home, ".codex", "sessions", "2026", "07", "14")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rollout-2026-07-14T00-00-00-"+sid+".jsonl"),
+		[]byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	i := codexInstance("codex", "codex")
+	i.CodexSessionID = sid
+	cmd, embedded := i.buildCodexCommandWithPrompt("codex", "do the thing")
+	if embedded {
+		t.Fatalf("resume path must not get a positional prompt; got %q", cmd)
+	}
+	if !strings.Contains(cmd, "resume ") {
+		t.Fatalf("expected the resume command; got %q", cmd)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1583,6 +1583,48 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	return envPrefix + command + yoloFlag + modelFlag
 }
 
+// buildCodexCommandWithPrompt builds the Codex launch command with an initial
+// prompt delivered as Codex's own positional [PROMPT] argument, mirroring the
+// claude-code startup query (#725). It reports whether the prompt was embedded;
+// when it was not, the caller must fall back to the post-start typing path.
+//
+// Typing a large initial prompt into a live Codex TUI is unreliable: the message
+// is sent as one literal `tmux send-keys -l` burst followed immediately by Enter,
+// and Codex reads a large fast burst as a paste, swallowing the trailing Enter
+// into it. The prompt then sits unsubmitted in the composer and the agent never
+// starts. `codex [OPTIONS] [PROMPT]` starts the session with the prompt already
+// in hand, so nothing is typed and there is no Enter to lose.
+//
+// The prompt is only embedded on the plain fresh-start path. It is NOT embedded
+// when:
+//   - the prompt is empty (nothing to deliver);
+//   - the user supplied a custom command (buildCodexCommand passes it through
+//     verbatim, and an arbitrary wrapper need not accept a positional prompt);
+//   - the session resumes (`codex ... resume <sid>`), where a trailing operand
+//     would not be the subcommand's prompt.
+//
+// In each of those cases the caller keeps the existing behaviour unchanged.
+func (i *Instance) buildCodexCommandWithPrompt(baseCommand, prompt string) (string, bool) {
+	command := i.buildCodexCommand(baseCommand)
+	if strings.TrimSpace(prompt) == "" {
+		return command, false
+	}
+	if !IsCodexCompatible(i.Tool) {
+		return command, false
+	}
+	// Custom-command passthrough: buildCodexCommand returned the user's command
+	// as-is, so we cannot assume it takes a positional prompt.
+	trimmed := strings.TrimSpace(baseCommand)
+	if i.Tool == "codex" && trimmed != "codex" && trimmed != "" {
+		return command, false
+	}
+	// Resume path appends `resume <sid>`; leave it to the typing path.
+	if i.CodexSessionID != "" {
+		return command, false
+	}
+	return command + " " + shellescape.Quote(prompt), true
+}
+
 // piAgentDeckSessionDirExpr returns a target-shell expression for the Pi session
 // directory Agent Deck owns for an instance. It intentionally uses target-side
 // $HOME rather than resolving the Agent Deck process' home directory, keeping
@@ -3404,6 +3446,9 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Start session normally (no embedded message logic)
 	// Priority: built-in tools (claude, gemini, opencode, codex) → custom tools from config.toml → raw command
 	var command string
+	// Codex takes its initial prompt as a positional argument instead of having it
+	// typed into the TUI; when that happens there is nothing left to send.
+	codexPromptEmbedded := false
 	switch {
 	case IsClaudeCompatible(i.Tool):
 		// #745 fork guard: mirrors the Start() branch above. A fork target
@@ -3472,7 +3517,7 @@ func (i *Instance) StartWithMessage(message string) error {
 				slog.String("reason", "fork_awaiting_start"))
 			break
 		}
-		command = i.buildCodexCommand(i.Command)
+		command, codexPromptEmbedded = i.buildCodexCommandWithPrompt(i.Command, message)
 		i.CodexStartedAt = time.Now().UnixMilli()
 	case i.Tool == "pi":
 		if i.IsForkAwaitingStart {
@@ -3587,8 +3632,9 @@ func (i *Instance) StartWithMessage(message string) error {
 		go i.detectCodexSessionAsync()
 	}
 
-	// Send message synchronously (CLI will wait)
-	if message != "" {
+	// Send message synchronously (CLI will wait). Codex may already carry the
+	// prompt as a launch argument, in which case there is nothing to type.
+	if message != "" && !codexPromptEmbedded {
 		return i.sendMessageWhenReady(message)
 	}
 


### PR DESCRIPTION
## Body

### What happens

A large initial message never reaches Codex. The session starts, the worktree and branch
are created, Agent Deck reports the session as `waiting` with `message_pending: false` —
and the prompt just sits in the Codex composer, unsubmitted. The agent never starts.

Small messages work, so this looks intermittent. It is size-correlated: with
agent-deck v1.9.73 + codex-cli 0.144.3 a ~1.7KB prompt failed to submit on **4 of 4**
launches, a 55-byte one always submitted, and around ~1KB it flips between the two
(926 bytes submitted in one run and not in the next). Newlines are not the trigger — a
1685-byte single-line prompt fails just the same.

### Why

`StartWithMessage` → `sendMessageWhenReady` types the message into the live TUI as one
literal `tmux send-keys -l` burst and immediately sends Enter. Codex reads a large fast
burst as a **paste** and swallows the trailing Enter into it, so the message is inserted
but never submitted.

The delivery-verify loop that exists precisely to catch a lost Enter is Claude-only:

```go
// The verify loop below keys off Claude-specific signals ... skip it for every
// non-Claude tool (#1238 — generalizes #1228's codex-only skip).
if !UsesClaudeDeliveryVerify(i.Tool) {
    return nil
}
```

So on Codex nothing notices and nothing retries.

Simply re-enabling that loop for Codex does not fix it either: `HasUnsentComposerPrompt`
matches the message against the visible composer **prefix**, but a long prompt scrolls so
that only its *tail* is on screen. It would false-negative exactly in the failing case —
and #1238 removed it for the good reason that it Enter-spams the composer.

### The fix

Codex accepts the prompt as its own positional operand — `codex [OPTIONS] [PROMPT]`
("Optional user prompt to start the session"). Passing it there starts the session with
the prompt already in hand: nothing is typed, so there is no Enter to lose. This mirrors
what claude-code already does with its startup query (#725, `shellescape.Quote`).

New `buildCodexCommandWithPrompt` returns the command plus whether the prompt was
embedded; `StartWithMessage` skips `sendMessageWhenReady` when it was. The prompt is
`shellescape.Quote`d, so no metacharacter can escape into the surrounding command.

Embedding is deliberately limited to the plain fresh-start path. These fall back to the
existing typing behaviour, unchanged:

- empty prompt — nothing to deliver;
- custom-command passthrough — an arbitrary wrapper need not accept a positional prompt;
- `codex ... resume <sid>` — a trailing operand would not be the subcommand's prompt.

`session send` and every non-Codex tool are untouched.

### Testing

- 5 new unit tests in `internal/session/codex_initial_prompt_test.go`: prompt embedded as
  the last shell-quoted operand; metacharacters (`'`, `"`, backtick, `$VAR`, `; rm -rf /`)
  stay inside one quoted operand; and the three fall-back paths (empty / custom command /
  resume, the last with a real rollout file on disk so the #756 stale-sid drop does not
  turn it into a fresh start).
- `go build ./...`, `go vet`, `gofmt` clean.
- Full `internal/session` package passes — no regressions.
- Reproduced and confirmed against real Codex sessions: with the prompt typed, a ~1.7KB
  message stays in the composer; passed as an argument, the identical launch runs
  unattended end to end.

### How to reproduce on main

```bash
mkdir -p /tmp/adbug && cd /tmp/adbug
git init -q . && git config user.email t@t && git config user.name t
echo x > a.txt && git add -A && git commit -q -m init
# codex must trust the worktree dir (trust is per-exact-dir), or it blocks on the trust gate

BIG="Say ok and stop. Padding: $(python3 -c "print('x'*1700)")"
agent-deck -p adbug launch -t BUG -c codex -g adbug --worktree BUG --new-branch \
  --tmux-socket agentdeck-adbug -m "$BIG" --json /tmp/adbug

# ~30s later: the prompt sits in the composer behind '>' with no "Working" indicator
tmux -L agentdeck-adbug attach
```

Control: the same launch with `-m "Say ok and stop."` submits normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex now accepts the initial prompt directly when starting a new standard session.
  * Prompts containing special characters are handled safely.
  * Empty prompts, resumed sessions, and custom command setups continue using the existing input flow.

* **Bug Fixes**
  * Prevented prompts from being sent twice during Codex session startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->