### PR TITLE
feat(cli): --message-file (path or '-' for stdin) for launch, session start, session send

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -44,6 +44,7 @@ func handleLaunch(profile string, args []string) {
 	wrapper := fs.String("wrapper", "", "Wrapper command (use {command} to include tool command; auto-generated when --cmd includes extra args)")
 	message := fs.String("message", "", "Initial message to send once agent is ready")
 	messageShort := fs.String("m", "", "Initial message to send (short)")
+	messageFile := fs.String("message-file", "", "Read the initial message from a file ('-' for stdin); avoids shell quoting of long prompts")
 	noWait := fs.Bool("no-wait", false, "Don't wait for agent to be ready before sending message")
 	assertDone := fs.Bool("assert-done", false, "Append a completion-sentinel instruction to the message (default on for -c claude)")
 	noAssertDone := fs.Bool("no-assert-done", false, "Disable the completion-sentinel instruction")
@@ -149,6 +150,7 @@ func handleLaunch(profile string, args []string) {
 		fmt.Println("  agent-deck launch . -c claude --mcp memory -m \"Research topic X\"")
 		fmt.Println("  agent-deck launch . -c claude --channel plugin:telegram@user/repo -m \"Listen for messages\"")
 		fmt.Println("  agent-deck launch . -c claude -m \"Fix bug\" --no-wait")
+		fmt.Println("  agent-deck launch . -c claude --message-file task.md   # long prompt from file, no shell quoting")
 		fmt.Println("  agent-deck launch . -c claude -m \"Refactor X\"   # auto-appends completion sentinel (see session children)")
 		fmt.Println("  agent-deck launch . -c \"codex --dangerously-bypass-approvals-and-sandbox\"")
 		fmt.Println("  agent-deck launch . -g ard --no-parent -c claude -m \"Run review\"")
@@ -194,7 +196,11 @@ func handleLaunch(profile string, args []string) {
 		out.Error("--parent and --no-parent cannot be used together", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
-	initialMessage := mergeFlags(*message, *messageShort)
+	initialMessage, err := resolveMessageInput(mergeFlags(*message, *messageShort), *messageFile, os.Stdin)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 
 	// --assert-done: append the completion-sentinel instruction so the child
 	// reliably reports back via the ledger / parent inbox. Default-on for

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1039,7 +1039,7 @@ func reorderArgsForFlagParsing(args []string) []string {
 		"t": true, "title": true,
 		"g": true, "group": true,
 		"c": true, "cmd": true,
-		"m": true, "message": true,
+		"m": true, "message": true, "message-file": true,
 		"p": true, "parent": true,
 		"mcp":            true,
 		"channel":        true,

--- a/cmd/agent-deck/message_input.go
+++ b/cmd/agent-deck/message_input.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// resolveMessageInput merges the inline -m/--message value with --message-file.
+// file may be a path or "-" to read stdin. Only one source may be set; returns
+// "" when neither is. Trailing newlines are trimmed so the tmux paste does not
+// submit a stray empty line after the message.
+//
+// The file form exists because a long multi-line prompt passed inline through
+// a shell gets mangled (backticks, $, quotes) — the documented workaround was
+// -m "$(cat task.md)", which still round-trips through shell quoting once.
+func resolveMessageInput(inline, file string, stdin io.Reader) (string, error) {
+	if file == "" {
+		return inline, nil
+	}
+	if inline != "" {
+		return "", fmt.Errorf("use either an inline message or --message-file, not both")
+	}
+	var data []byte
+	var err error
+	if file == "-" {
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(file)
+	}
+	if err != nil {
+		return "", fmt.Errorf("read message file: %w", err)
+	}
+	msg := strings.TrimRight(string(data), "\r\n")
+	if strings.TrimSpace(msg) == "" {
+		return "", fmt.Errorf("message file '%s' is empty", file)
+	}
+	return msg, nil
+}

--- a/cmd/agent-deck/message_input_test.go
+++ b/cmd/agent-deck/message_input_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveMessageInput(t *testing.T) {
+	writeTemp := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "msg.txt")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	t.Run("inline only passes through", func(t *testing.T) {
+		got, err := resolveMessageInput("hello", "", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "hello" {
+			t.Errorf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("neither returns empty without error", func(t *testing.T) {
+		got, err := resolveMessageInput("", "", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("file only reads content", func(t *testing.T) {
+		path := writeTemp(t, "line one\nline two `with` $pecial \"chars\"\n")
+		got, err := resolveMessageInput("", path, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := "line one\nline two `with` $pecial \"chars\""
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("trailing newlines trimmed but inner preserved", func(t *testing.T) {
+		path := writeTemp(t, "a\n\nb\r\n\r\n\n")
+		got, err := resolveMessageInput("", path, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "a\n\nb" {
+			t.Errorf("got %q, want %q", got, "a\n\nb")
+		}
+	})
+
+	t.Run("dash reads stdin", func(t *testing.T) {
+		got, err := resolveMessageInput("", "-", strings.NewReader("from stdin\n"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "from stdin" {
+			t.Errorf("got %q, want %q", got, "from stdin")
+		}
+	})
+
+	t.Run("both inline and file errors", func(t *testing.T) {
+		path := writeTemp(t, "content")
+		if _, err := resolveMessageInput("inline", path, nil); err == nil {
+			t.Error("expected error when both -m and --message-file are set")
+		}
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		if _, err := resolveMessageInput("", "/nonexistent/msg.txt", nil); err == nil {
+			t.Error("expected error for missing file")
+		}
+	})
+
+	t.Run("empty file errors", func(t *testing.T) {
+		path := writeTemp(t, "  \n\n")
+		if _, err := resolveMessageInput("", path, nil); err == nil {
+			t.Error("expected error for empty message file")
+		}
+	})
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -198,6 +198,8 @@ func handleSessionStart(profile string, args []string) {
 		fmt.Println("  agent-deck session start my-project")
 		fmt.Println("  agent-deck session start my-project --message \"Research MCP patterns\"")
 		fmt.Println("  agent-deck session start my-project -m \"Explain this codebase\"")
+		fmt.Println("  agent-deck session start my-project --message-file task.md   # long prompt from file, no shell quoting")
+		fmt.Println("  git diff | agent-deck session start my-project --message-file -   # initial message from stdin")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -182,6 +182,7 @@ func handleSessionStart(profile string, args []string) {
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
 	message := fs.String("message", "", "Initial message to send once agent is ready")
 	messageShort := fs.String("m", "", "Initial message to send once agent is ready (short)")
+	messageFile := fs.String("message-file", "", "Read the initial message from a file ('-' for stdin); avoids shell quoting of long prompts")
 	yoloMode := fs.Bool("yolo", false, "Enable YOLO mode when starting Gemini or Codex sessions")
 	attach := fs.Bool("attach", false, "Attach to the session after starting (requires an interactive terminal)")
 
@@ -208,7 +209,11 @@ func handleSessionStart(profile string, args []string) {
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
 	// Merge message flags
-	initialMessage := mergeFlags(*message, *messageShort)
+	initialMessage, err := resolveMessageInput(mergeFlags(*message, *messageShort), *messageFile, os.Stdin)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 
 	// Load sessions
 	storage, instances, groups, err := loadSessionData(profile)
@@ -2507,6 +2512,7 @@ func handleSessionSend(profile string, args []string) {
 	wait := fs.Bool("wait", false, "Block until agent finishes processing, then print output")
 	stream := fs.Bool("stream", false, "Stream JSONL events (Claude only) to stdout instead of returning a snapshot")
 	draft := fs.Bool("draft", false, "Pre-fill the prompt without submitting (incompatible with --wait/--stream/--no-wait)")
+	messageFile := fs.String("message-file", "", "Read the message from a file ('-' for stdin) instead of a positional argument; avoids shell quoting of long prompts")
 	timeout := fs.Duration("timeout", 10*time.Minute, "Max time to wait for the agent to become ready and (with --wait) to finish processing")
 	streamIdle := fs.Duration("stream-idle", 10*time.Second, "Max idle time before --stream aborts with error")
 	streamCharBudget := fs.Int("stream-char-budget", 4000, "Char budget for text flush in --stream mode")
@@ -2526,6 +2532,8 @@ func handleSessionSend(profile string, args []string) {
 		fmt.Println("  agent-deck session send my-project \"quick ping\" --no-wait")
 		fmt.Println("  agent-deck session send my-project \"trace progress\" --stream")
 		fmt.Println("  agent-deck session send my-project \"cwd: /path/to/dir\" --draft")
+		fmt.Println("  agent-deck session send my-project --message-file answer.md   # long reply from file")
+		fmt.Println("  git diff | agent-deck session send my-project --message-file -   # message from stdin")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -2535,9 +2543,10 @@ func handleSessionSend(profile string, args []string) {
 
 	out := NewCLIOutput(*jsonOutput, *quiet)
 
-	if len(remaining) < 2 {
+	needPositionalMessage := *messageFile == ""
+	if len(remaining) < 1 || (needPositionalMessage && len(remaining) < 2) {
 		fs.Usage()
-		out.Error("session and message are required", ErrCodeInvalidOperation)
+		out.Error("session and message (or --message-file) are required", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 
@@ -2552,7 +2561,11 @@ func handleSessionSend(profile string, args []string) {
 	}
 
 	sessionRef := remaining[0]
-	message := strings.Join(remaining[1:], " ")
+	message, err := resolveMessageInput(strings.Join(remaining[1:], " "), *messageFile, os.Stdin)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 
 	// Load sessions
 	_, instances, _, err := loadSessionData(profile)

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -112,6 +112,7 @@ The table above is what *agent-deck* does. This one is what the *CLI inside a se
 | `agent-deck add -t "Name" -c claude /path` | Create session |
 | `agent-deck session start/stop/restart <name>` | Control session |
 | `agent-deck session send <name> "message"` | Send message |
+| `agent-deck session send <name> --message-file <file>` | Send message from file (`-` = stdin); no shell quoting. Also on `launch`/`session start` |
 | `agent-deck session output <name>` | Get last response |
 | `agent-deck session current [-q\|--json]` | Auto-detect current session |
 | `agent-deck session fork <name>` | Fork Claude/Pi conversation |

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -47,9 +47,13 @@ Spell out the long form: **never use the short `-p` to set a parent** (see the
   child's `-m` prompt install them — and for a locked monorepo, install *from the
   frozen lockfile, never regenerate it* (e.g. `pnpm install --frozen-lockfile`).
   Otherwise the child's first test/build/e2e fails confusingly.
-- **Long prompts: pass via a file.** For a big multi-line task, write it to a file
-  and command-substitute: `-m "$(cat task.md)"`. Avoids the shell mangling of
-  backticks, `$`, and quotes inside an inline `-m`.
+- **Long prompts: pass via a file.** For a big multi-line task, write it to a
+  file and pass `--message-file task.md` (or `--message-file -` to read stdin)
+  instead of `-m`. The file is read directly by agent-deck, so backticks, `$`,
+  and quotes never round-trip through the shell. Also works on
+  `session start` and `session send` (there it replaces the positional
+  message). On older builds without the flag, fall back to
+  `-m "$(cat task.md)"`.
 
 ## The loop
 


### PR DESCRIPTION
## Why

Long multi-line prompts passed inline via `-m` get mangled by the shell (backticks, `$`, quotes). The documented workaround — `-m "$(cat task.md)"` — still round-trips the content through shell quoting once, and doesn't help when the message is piped from another command.

## What

- New `--message-file <path>` flag on `launch`, `session start`, and `session send`; `--message-file -` reads stdin.
- Mutually exclusive with the inline message (`-m/--message`, or the positional message for `session send`) — passing both is a hard error, as is an empty or unreadable file.
- Trailing newlines are trimmed so the tmux paste doesn't submit a stray empty line after the message.
- `message-file` registered in `reorderArgsForFlagParsing`'s `valueFlagNames` so its value (including a bare `-`) stays paired with the flag during arg reordering.
- Fleet + agent-deck skill docs updated to point at the flag instead of the `$(cat)` workaround.

## Usage

```bash
agent-deck launch . -c claude --message-file task.md
agent-deck session send my-project --message-file answer.md
git diff | agent-deck session send my-project --message-file -
```

## Testing

- Unit tests for the new `resolveMessageInput` helper (inline/file/stdin, both-set error, missing file, empty file, trailing-newline trim).
- `go build ./...`, `go vet`, full `./cmd/agent-deck` test suite green; gofmt clean.
- Manually exercised the built binary: file + stdin sourcing, both-set error, missing-file error, and the updated usage error for `session send` with no message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--message-file` support for launching agents and starting sessions.
  * Added file-based message input for sending session messages, including stdin support with `-`.
  * Updated CLI help/usage examples and input validation for message options.
* **Bug Fixes**
  * Improved handling of long, multiline messages without shell quoting issues.
  * Added clear errors for conflicting, missing/unreadable, or empty/whitespace-only message inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->