### PR TITLE
feat(cli): session children --follow — JSONL event stream for fleet supervision

### DIFF
--- a/cmd/agent-deck/session_children_follow.go
+++ b/cmd/agent-deck/session_children_follow.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// childRow is one child in `session children` output — shared by the one-shot
+// listing and the --follow stream.
+type childRow struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Status      string `json:"status"`
+	DoneStatus  string `json:"done_status,omitempty"`
+	DoneSummary string `json:"done_summary,omitempty"`
+	DoneAt      string `json:"done_at,omitempty"`
+}
+
+// followEvent is one JSONL line on the --follow stream. Consumers key off
+// .event: snapshot|added|status|done|removed|error.
+type followEvent struct {
+	Event       string `json:"event"`
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Status      string `json:"status,omitempty"`
+	From        string `json:"from,omitempty"`
+	To          string `json:"to,omitempty"`
+	DoneStatus  string `json:"done_status,omitempty"`
+	DoneSummary string `json:"done_summary,omitempty"`
+	DoneAt      string `json:"done_at,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// followSummary is the heartbeat/complete line. Counts have no omitempty so a
+// zero reads as a zero, not a missing key.
+type followSummary struct {
+	Event    string `json:"event"`
+	Children int    `json:"children"`
+	Running  int    `json:"running"`
+	Waiting  int    `json:"waiting"`
+	DoneOK   int    `json:"done_ok"`
+	DoneFail int    `json:"done_fail"`
+}
+
+// buildChildRows converts refreshed child instances into rows. Callers must
+// have run session.RefreshInstancesForCLIStatus on kids first so UpdateStatus
+// sees warm tmux caches and hook statuses (issue #610).
+func buildChildRows(kids []*session.Instance) []childRow {
+	rows := make([]childRow, 0, len(kids))
+	for _, k := range kids {
+		_ = k.UpdateStatus()
+		row := childRow{ID: k.ID, Title: k.Title, Status: StatusString(k.Status)}
+		if e, ok := session.ReadLedgerEntry(k.ID); ok {
+			row.DoneStatus = e.Status
+			row.DoneSummary = e.Summary
+			if !e.FinishedAt.IsZero() {
+				row.DoneAt = e.FinishedAt.Format(time.RFC3339)
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func snapshotEvent(event string, r childRow) followEvent {
+	return followEvent{
+		Event: event, ID: r.ID, Title: r.Title, Status: r.Status,
+		DoneStatus: r.DoneStatus, DoneSummary: r.DoneSummary, DoneAt: r.DoneAt,
+	}
+}
+
+// diffChildEvents computes the events between two polls. Order: current
+// children first (added, then status, then done per child), removals last.
+func diffChildEvents(prev, curr []childRow) []followEvent {
+	prevByID := make(map[string]childRow, len(prev))
+	for _, r := range prev {
+		prevByID[r.ID] = r
+	}
+	currIDs := make(map[string]bool, len(curr))
+	var events []followEvent
+	for _, r := range curr {
+		currIDs[r.ID] = true
+		old, seen := prevByID[r.ID]
+		if !seen {
+			events = append(events, snapshotEvent("added", r))
+			continue
+		}
+		if old.Status != r.Status {
+			events = append(events, followEvent{
+				Event: "status", ID: r.ID, Title: r.Title, From: old.Status, To: r.Status,
+			})
+		}
+		if r.DoneStatus != "" &&
+			(old.DoneStatus != r.DoneStatus || old.DoneSummary != r.DoneSummary || old.DoneAt != r.DoneAt) {
+			events = append(events, followEvent{
+				Event: "done", ID: r.ID, Title: r.Title,
+				DoneStatus: r.DoneStatus, DoneSummary: r.DoneSummary, DoneAt: r.DoneAt,
+			})
+		}
+	}
+	for _, r := range prev {
+		if !currIDs[r.ID] {
+			events = append(events, followEvent{Event: "removed", ID: r.ID, Title: r.Title})
+		}
+	}
+	return events
+}
+
+// childTerminal reports whether a child needs no further supervision: it
+// asserted the completion sentinel (ok or fail), or its process is gone.
+// idle WITHOUT a sentinel is not terminal — an agent parked at the prompt may
+// just be between turns, and treating it as done would end --until-done early.
+func childTerminal(r childRow) bool {
+	if r.DoneStatus != "" {
+		return true
+	}
+	return r.Status == "error" || r.Status == "stopped"
+}
+
+func allChildrenTerminal(rows []childRow) bool {
+	for _, r := range rows {
+		if !childTerminal(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func summarizeChildren(event string, rows []childRow) followSummary {
+	s := followSummary{Event: event, Children: len(rows)}
+	for _, r := range rows {
+		switch r.Status {
+		case "running":
+			s.Running++
+		case "waiting":
+			s.Waiting++
+		}
+		switch r.DoneStatus {
+		case "ok":
+			s.DoneOK++
+		case "fail":
+			s.DoneFail++
+		}
+	}
+	return s
+}
+
+// loadChildRows does one full poll: fresh DB read, parent existence check,
+// status refresh, row build. Storage is closed before returning so the poll
+// loop never accumulates DB handles.
+func loadChildRows(profile, parentID string) ([]childRow, error) {
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = storage.Close() }()
+
+	parentExists := false
+	for _, inst := range instances {
+		if inst != nil && inst.ID == parentID {
+			parentExists = true
+			break
+		}
+	}
+	if !parentExists {
+		return nil, fmt.Errorf("parent session %s no longer exists", parentID)
+	}
+
+	kids := childrenOf(parentID, instances)
+	session.RefreshInstancesForCLIStatus(kids)
+	return buildChildRows(kids), nil
+}
+
+// runChildrenFollow streams child state changes as JSONL until interrupted,
+// --until-done is satisfied, or polling fails repeatedly. Every terminal state
+// is visible on the stream (done ok/fail, error, stopped, removed) so silence
+// only ever means "nothing changed" — the heartbeat line proves liveness.
+func runChildrenFollow(profile, parentID string, interval, heartbeat time.Duration, untilDone bool, w io.Writer) int {
+	emit := func(v interface{}) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		fmt.Fprintln(w, string(b))
+	}
+
+	const maxConsecutiveFailures = 5
+	var prev []childRow
+	first := true
+	failures := 0
+	lastHeartbeat := time.Now()
+
+	for {
+		rows, err := loadChildRows(profile, parentID)
+		if err != nil {
+			failures++
+			emit(followEvent{Event: "error", Error: err.Error()})
+			if failures >= maxConsecutiveFailures {
+				return 1
+			}
+		} else {
+			failures = 0
+			if first {
+				for _, r := range rows {
+					emit(snapshotEvent("snapshot", r))
+				}
+				first = false
+			} else {
+				for _, e := range diffChildEvents(prev, rows) {
+					emit(e)
+				}
+			}
+			prev = rows
+			if untilDone && allChildrenTerminal(rows) {
+				emit(summarizeChildren("complete", rows))
+				return 0
+			}
+		}
+
+		if heartbeat > 0 && time.Since(lastHeartbeat) >= heartbeat {
+			emit(summarizeChildren("heartbeat", prev))
+			lastHeartbeat = time.Now()
+		}
+		time.Sleep(interval)
+	}
+}

--- a/cmd/agent-deck/session_children_follow.go
+++ b/cmd/agent-deck/session_children_follow.go
@@ -149,6 +149,10 @@ func summarizeChildren(event string, rows []childRow) followSummary {
 	return s
 }
 
+// pollChildRows is the poll runChildrenFollow performs each tick. It is a var
+// so tests can drive the loop without standing up storage.
+var pollChildRows = loadChildRows
+
 // loadChildRows does one full poll: fresh DB read, parent existence check,
 // status refresh, row build. Storage is closed before returning so the poll
 // loop never accumulates DB handles.
@@ -179,13 +183,24 @@ func loadChildRows(profile, parentID string) ([]childRow, error) {
 // --until-done is satisfied, or polling fails repeatedly. Every terminal state
 // is visible on the stream (done ok/fail, error, stopped, removed) so silence
 // only ever means "nothing changed" — the heartbeat line proves liveness.
+//
+// interval must be positive; the caller validates it, since a non-positive
+// sleep would turn the poll into a busy-loop that reopens storage every pass.
+//
+// With untilDone, a parent that currently has no children is already "all
+// terminal" and completes immediately. Callers that mean to watch for children
+// yet to be spawned must attach after at least one child exists.
 func runChildrenFollow(profile, parentID string, interval, heartbeat time.Duration, untilDone bool, w io.Writer) int {
-	emit := func(v interface{}) {
+	// emit reports whether the stream is still writable. A consumer that goes
+	// away mid-stream (`... | head -1`) makes every later write fail; without
+	// this the loop would keep polling the DB forever with nowhere to write.
+	emit := func(v interface{}) bool {
 		b, err := json.Marshal(v)
 		if err != nil {
-			return
+			return true // Malformed event, not a dead stream: keep polling.
 		}
-		fmt.Fprintln(w, string(b))
+		_, err = fmt.Fprintln(w, string(b))
+		return err == nil
 	}
 
 	const maxConsecutiveFailures = 5
@@ -195,10 +210,12 @@ func runChildrenFollow(profile, parentID string, interval, heartbeat time.Durati
 	lastHeartbeat := time.Now()
 
 	for {
-		rows, err := loadChildRows(profile, parentID)
+		rows, err := pollChildRows(profile, parentID)
 		if err != nil {
 			failures++
-			emit(followEvent{Event: "error", Error: err.Error()})
+			if !emit(followEvent{Event: "error", Error: err.Error()}) {
+				return 0
+			}
 			if failures >= maxConsecutiveFailures {
 				return 1
 			}
@@ -206,23 +223,29 @@ func runChildrenFollow(profile, parentID string, interval, heartbeat time.Durati
 			failures = 0
 			if first {
 				for _, r := range rows {
-					emit(snapshotEvent("snapshot", r))
+					if !emit(snapshotEvent("snapshot", r)) {
+						return 0
+					}
 				}
 				first = false
 			} else {
 				for _, e := range diffChildEvents(prev, rows) {
-					emit(e)
+					if !emit(e) {
+						return 0
+					}
 				}
 			}
 			prev = rows
 			if untilDone && allChildrenTerminal(rows) {
-				emit(summarizeChildren("complete", rows))
+				_ = emit(summarizeChildren("complete", rows))
 				return 0
 			}
 		}
 
 		if heartbeat > 0 && time.Since(lastHeartbeat) >= heartbeat {
-			emit(summarizeChildren("heartbeat", prev))
+			if !emit(summarizeChildren("heartbeat", prev)) {
+				return 0
+			}
 			lastHeartbeat = time.Now()
 		}
 		time.Sleep(interval)

--- a/cmd/agent-deck/session_children_follow_test.go
+++ b/cmd/agent-deck/session_children_follow_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestDiffChildEvents(t *testing.T) {
+	running := func(id, title string) childRow {
+		return childRow{ID: id, Title: title, Status: "running"}
+	}
+
+	t.Run("no changes emits nothing", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a")}
+		curr := []childRow{running("a", "child-a")}
+		if events := diffChildEvents(prev, curr); len(events) != 0 {
+			t.Errorf("expected no events, got %+v", events)
+		}
+	})
+
+	t.Run("new child emits added", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a")}
+		curr := []childRow{running("a", "child-a"), running("b", "child-b")}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "added", ID: "b", Title: "child-b", Status: "running"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("status change emits transition", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a")}
+		curr := []childRow{{ID: "a", Title: "child-a", Status: "waiting"}}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "status", ID: "a", Title: "child-a", From: "running", To: "waiting"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("new ledger entry emits done", func(t *testing.T) {
+		prev := []childRow{{ID: "a", Title: "child-a", Status: "running"}}
+		curr := []childRow{{ID: "a", Title: "child-a", Status: "idle",
+			DoneStatus: "ok", DoneSummary: "all lint fixed", DoneAt: "2026-07-15T10:00:00Z"}}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{
+			{Event: "status", ID: "a", Title: "child-a", From: "running", To: "idle"},
+			{Event: "done", ID: "a", Title: "child-a",
+				DoneStatus: "ok", DoneSummary: "all lint fixed", DoneAt: "2026-07-15T10:00:00Z"},
+		}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("re-asserted done emits done again", func(t *testing.T) {
+		prev := []childRow{{ID: "a", Title: "child-a", Status: "idle",
+			DoneStatus: "ok", DoneSummary: "round 1", DoneAt: "2026-07-15T10:00:00Z"}}
+		curr := []childRow{{ID: "a", Title: "child-a", Status: "idle",
+			DoneStatus: "fail", DoneSummary: "round 2 broke", DoneAt: "2026-07-15T11:00:00Z"}}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "done", ID: "a", Title: "child-a",
+			DoneStatus: "fail", DoneSummary: "round 2 broke", DoneAt: "2026-07-15T11:00:00Z"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("removed child emits removed", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a"), running("b", "child-b")}
+		curr := []childRow{running("a", "child-a")}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "removed", ID: "b", Title: "child-b"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+}
+
+func TestChildTerminal(t *testing.T) {
+	cases := []struct {
+		name string
+		row  childRow
+		want bool
+	}{
+		{"running is not terminal", childRow{Status: "running"}, false},
+		{"waiting is not terminal", childRow{Status: "waiting"}, false},
+		{"idle without sentinel is not terminal", childRow{Status: "idle"}, false},
+		{"done sentinel is terminal", childRow{Status: "idle", DoneStatus: "ok"}, true},
+		{"done fail sentinel is terminal", childRow{Status: "idle", DoneStatus: "fail"}, true},
+		{"error is terminal", childRow{Status: "error"}, true},
+		{"stopped is terminal", childRow{Status: "stopped"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := childTerminal(tc.row); got != tc.want {
+				t.Errorf("childTerminal(%+v) = %v, want %v", tc.row, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllChildrenTerminal(t *testing.T) {
+	if !allChildrenTerminal([]childRow{{Status: "error"}, {Status: "idle", DoneStatus: "ok"}}) {
+		t.Error("expected all terminal")
+	}
+	if allChildrenTerminal([]childRow{{Status: "idle", DoneStatus: "ok"}, {Status: "running"}}) {
+		t.Error("expected not all terminal while one is running")
+	}
+	if !allChildrenTerminal(nil) {
+		t.Error("empty set is vacuously terminal")
+	}
+}
+
+// The JSONL contract: every event marshals to a single flat object with
+// stable keys — consumers (Monitor filters, jq) key off .event.
+func TestFollowEventJSONShape(t *testing.T) {
+	b, err := json.Marshal(followEvent{Event: "status", ID: "a", Title: "t", From: "running", To: "waiting"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"event", "id", "title", "from", "to"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing key %q in %s", key, b)
+		}
+	}
+	if _, ok := m["done_status"]; ok {
+		t.Errorf("empty done_status should be omitted: %s", b)
+	}
+}

--- a/cmd/agent-deck/session_children_follow_test.go
+++ b/cmd/agent-deck/session_children_follow_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestDiffChildEvents(t *testing.T) {
@@ -110,6 +113,91 @@ func TestAllChildrenTerminal(t *testing.T) {
 	}
 	if !allChildrenTerminal(nil) {
 		t.Error("empty set is vacuously terminal")
+	}
+}
+
+// summarizeChildren drives both the heartbeat and complete lines, so every
+// counter it reports is part of the JSONL contract.
+func TestSummarizeChildren(t *testing.T) {
+	rows := []childRow{
+		{Status: "running"},
+		{Status: "waiting"},
+		{Status: "waiting"},
+		{Status: "idle", DoneStatus: "ok"},
+		{Status: "error", DoneStatus: "fail"},
+		{Status: "idle"}, // Neither running/waiting nor done: counted only in Children.
+	}
+	got := summarizeChildren("heartbeat", rows)
+	want := followSummary{Event: "heartbeat", Children: 6, Running: 1, Waiting: 2, DoneOK: 1, DoneFail: 1}
+	if got != want {
+		t.Errorf("summarizeChildren() = %+v, want %+v", got, want)
+	}
+
+	empty := summarizeChildren("complete", nil)
+	if empty != (followSummary{Event: "complete"}) {
+		t.Errorf("empty summary = %+v, want zeroed counts with event=complete", empty)
+	}
+}
+
+// errWriter fails every write, standing in for a consumer that went away
+// mid-stream (`agent-deck session children --follow | head -1`).
+type errWriter struct{ writes int }
+
+func (e *errWriter) Write(p []byte) (int, error) {
+	e.writes++
+	return 0, io.ErrClosedPipe
+}
+
+// A dead stream must end the poll loop. Before emit reported write failures,
+// the loop kept polling forever with nowhere to write the results.
+func TestRunChildrenFollowStopsOnDeadStream(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		poll func(profile, parentID string) ([]childRow, error)
+	}{
+		{
+			name: "snapshot write fails",
+			poll: func(string, string) ([]childRow, error) {
+				return []childRow{{ID: "a", Status: "running"}}, nil
+			},
+		},
+		{
+			name: "error-event write fails",
+			poll: func(string, string) ([]childRow, error) {
+				return nil, errors.New("poll failed")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			polls := 0
+			restore := pollChildRows
+			pollChildRows = func(profile, parentID string) ([]childRow, error) {
+				polls++
+				return tc.poll(profile, parentID)
+			}
+			t.Cleanup(func() { pollChildRows = restore })
+
+			w := &errWriter{}
+			done := make(chan int, 1)
+			go func() {
+				done <- runChildrenFollow("p", "parent", time.Millisecond, 0, false, w)
+			}()
+
+			select {
+			case code := <-done:
+				if code != 0 {
+					t.Errorf("exit code = %d, want 0 (stream closed, not a poll failure)", code)
+				}
+				if w.writes != 1 {
+					t.Errorf("writes = %d, want 1 — loop kept emitting after the stream died", w.writes)
+				}
+				if polls != 1 {
+					t.Errorf("polls = %d, want 1 — loop kept polling after the stream died", polls)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("runChildrenFollow kept polling after the stream closed")
+			}
+		})
 	}
 }
 

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3950,6 +3950,10 @@ func handleSessionChildren(profile string, args []string) {
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	follow := fs.Bool("follow", false, "Stream child state changes as JSONL (one event per line) until interrupted")
+	interval := fs.Duration("interval", 2*time.Second, "Poll interval for --follow")
+	heartbeat := fs.Duration("heartbeat", 60*time.Second, "Heartbeat event interval for --follow (0 disables)")
+	untilDone := fs.Bool("until-done", false, "With --follow: exit 0 once every child is terminal (done sentinel, error, or stopped)")
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session children [id|title] [options]")
 		fmt.Println()
@@ -3958,6 +3962,15 @@ func handleSessionChildren(profile string, args []string) {
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("--follow emits JSONL events: snapshot (initial state per child), added,")
+		fmt.Println("status (from/to transition), done (completion sentinel), removed, error,")
+		fmt.Println("plus periodic heartbeat and a final complete line with --until-done.")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session children --json")
+		fmt.Println("  agent-deck session children --follow                    # live fleet event stream")
+		fmt.Println("  agent-deck session children --follow --until-done      # exits when all children finish")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
@@ -3988,36 +4001,27 @@ func handleSessionChildren(profile string, args []string) {
 		os.Exit(2)
 	}
 
+	if *untilDone && !*follow {
+		out.Error("--until-done requires --follow", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if *follow {
+		// The stream is JSONL by contract; --json/-q are irrelevant here.
+		os.Exit(runChildrenFollow(profile, parent.ID, *interval, *heartbeat, *untilDone, os.Stdout))
+	}
+
 	kids := childrenOf(parent.ID, instances)
 	session.RefreshInstancesForCLIStatus(kids)
 
-	type childRow struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		DoneStatus  string `json:"done_status,omitempty"`
-		DoneSummary string `json:"done_summary,omitempty"`
-		DoneAt      string `json:"done_at,omitempty"`
-	}
-	rows := make([]childRow, 0, len(kids))
+	rows := buildChildRows(kids)
 	var human strings.Builder
 	fmt.Fprintf(&human, "Children of %s (%s):\n", parent.Title, parent.ID)
-	for _, k := range kids {
-		_ = k.UpdateStatus()
-		row := childRow{ID: k.ID, Title: k.Title, Status: StatusString(k.Status)}
-		if e, ok := session.ReadLedgerEntry(k.ID); ok {
-			row.DoneStatus = e.Status
-			row.DoneSummary = e.Summary
-			if !e.FinishedAt.IsZero() {
-				row.DoneAt = e.FinishedAt.Format(time.RFC3339)
-			}
-		}
-		rows = append(rows, row)
+	for _, row := range rows {
 		done := row.DoneStatus
 		if done == "" {
 			done = "-"
 		}
-		fmt.Fprintf(&human, "  %s  %-20s  %-8s  done=%s  %s\n", k.ID, k.Title, row.Status, done, row.DoneSummary)
+		fmt.Fprintf(&human, "  %s  %-20s  %-8s  done=%s  %s\n", row.ID, row.Title, row.Status, done, row.DoneSummary)
 	}
 	if len(kids) == 0 {
 		human.WriteString("  (no sub-sessions)\n")

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -4005,6 +4005,13 @@ func handleSessionChildren(profile string, args []string) {
 		out.Error("--until-done requires --follow", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
+	// A non-positive interval makes time.Sleep a no-op, turning the poll into a
+	// busy-loop that reopens storage every pass. Reject rather than clamp: a
+	// silently different interval than asked for is its own surprise.
+	if *follow && *interval <= 0 {
+		out.Error("--interval must be positive", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 	if *follow {
 		// The stream is JSONL by contract; --json/-q are irrelevant here.
 		os.Exit(runChildrenFollow(profile, parent.ID, *interval, *heartbeat, *untilDone, os.Stdout))

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -106,6 +106,39 @@ disturbing the conductor or other readers.
 
 A child with a `done_status` has finished and asserted its result.
 
+**Prefer push over polling when your harness supports it.** Instead of
+re-running the check yourself, let the fleet notify you:
+
+```bash
+# One-shot "wake me when the whole fleet is finished" — run this in the
+# BACKGROUND (e.g. Claude Code's run_in_background Bash): it streams JSONL
+# events and exits 0 once every child is terminal (done sentinel, error,
+# or stopped). The harness notifies you when it exits.
+agent-deck session children --follow --until-done
+
+# Live event stream for a long-running fleet — attach a stream watcher
+# (e.g. Claude Code's Monitor tool) to this; each line is one event:
+agent-deck session children --follow
+```
+
+`--follow` emits one JSON object per line: `snapshot` (initial state per
+child), `added`, `status` (from/to transition — including `running → waiting`,
+so you see a child stall on a question), `done` (completion sentinel, ok or
+fail), `removed`, `error`, plus a periodic `heartbeat` (default 60s,
+`--heartbeat 0` disables) so silence always means "nothing changed", never
+"the watcher died". `--interval` tunes the poll cadence (default 2s). Failure
+states are on the stream too — filter for `done` alone and you'll miss
+crashed children; key off `.event` instead.
+
+On older builds without `--follow`, fall back to a background until-loop:
+
+```bash
+until agent-deck session children --json | jq -e 'all(.children[]; .done_status != null)' >/dev/null; do sleep 15; done
+```
+
+(Cloud-side schedulers — e.g. Claude Code routines — run on remote infra and
+cannot reach your local tmux/state.db; fleet supervision stays local.)
+
 ### 4. Unblock a child that's waiting on you
 
 A child in `waiting` status has stopped and is asking for input (a question, a
@@ -200,6 +233,11 @@ All read-only / on-demand — none of them block your session:
 - `agent-deck session children [id] --json` — **the default monitor.** Live
   status + last completion per child. Non-destructive (never clears the inbox),
   so poll it as often as you like. Start here every heartbeat.
+- `agent-deck session children --follow [--until-done]` — **the push monitor.**
+  Streams JSONL child events (snapshot/added/status/done/removed/error +
+  heartbeat) until interrupted; with `--until-done` it exits 0 once every child
+  is terminal. Run it in the background for a completion wake-up, or attach a
+  stream watcher for live events. Read-only like the plain form.
 - `agent-deck session output <id> --json` — a child's latest full response.
 - `agent-deck session send <id> "<msg>" [--wait|--stream|--no-wait|--draft]` —
   send a follow-up / answer a `waiting` child.


### PR DESCRIPTION
## Why

A conductor supervising a fleet only has pull-based checks today: re-run `session children --json` and diff by eye. Agent harnesses (e.g. Claude Code) can consume a push stream instead — a stream watcher for live events, or a background `--until-done` run whose exit fires a single completion notification — but agent-deck had no stream to attach to, so every consumer had to hand-write a poll-and-diff script.

## What

`agent-deck session children --follow` polls internally (default 2s, `--interval`) and emits one JSON object per line on every child state change:

- `snapshot` — initial state per child on startup
- `added` / `removed` — child appears / disappears
- `status` — from/to transition (including `running → waiting`, so a child stalling on a question is visible)
- `done` — completion sentinel asserted (ok **or fail**)
- `error` — poll failure (transient errors tolerated; 5 consecutive → exit 1)
- `heartbeat` — periodic liveness line (default 60s, `--heartbeat 0` disables) so silence always means "nothing changed", never "the watcher died"
- `complete` — final summary with `--until-done`

`--until-done` exits 0 once every child is terminal: done sentinel set, or status error/stopped. Idle **without** a sentinel is deliberately not terminal — an agent parked at its prompt may just be between turns. Zero children completes immediately.

```bash
# one-shot completion wake-up (run in a background shell):
agent-deck session children --follow --until-done
# live fleet event stream (attach tail/Monitor-style watchers):
agent-deck session children --follow
```

Design notes: all terminal/failure states are on the stream, not just successes — a consumer filtering only for `done` is warned in the docs. The poll tick reuses the existing one-shot listing path (`loadSessionData` + `RefreshInstancesForCLIStatus` + ledger read, extracted as `buildChildRows`) and closes storage every tick, so the loop uses the bulk tmux cache warms and never accumulates DB handles. Read-only like the plain form — never touches the inbox.

## Docs

Fleet skill now teaches push-based supervision: `--follow --until-done` in a background shell, stream watchers for live events, the `jq` until-loop fallback for older builds, and a caveat that cloud-side schedulers can't reach local tmux/state.db.

## Testing

- Unit tests for the pure diff/terminal helpers (`diffChildEvents`, `childTerminal`, `allChildrenTerminal`, JSONL shape contract).
- Full `./cmd/agent-deck` suite, `go vet`, gofmt clean.
- Manually exercised the built binary: `--until-done` without `--follow` errors; `--follow --until-done` with zero children emits `complete` and exits 0; live stream emits heartbeats on schedule and survives kill cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `session children --follow` to stream child-session updates as JSONL.
  * Added `--until-done` to stop automatically when all children reach terminal states.
  * Added `--interval` polling and `--heartbeat` cadence (with optional disable).
  * Emits snapshot, status, completion (`done`), removal, error, and periodic heartbeat/complete events.

* **Improvements**
  * Updated command help and JSONL event schema documentation.
  * Added safer flag validation (rejects `--until-done` without `--follow`).
  * Ensures follow mode stops when the output stream becomes unavailable.

* **Tests**
  * Added coverage for event diffing, terminal-state handling, summaries, JSON shape, and stream-death behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->