### PR TITLE
feat(hooks): conductor fleet snapshot injected at turn start

### DIFF
--- a/cmd/agent-deck/hook_children_context.go
+++ b/cmd/agent-deck/hook_children_context.go
@@ -90,8 +90,11 @@ func formatChildrenContext(rows []childRow) string {
 			fmt.Fprintf(&b, "\n- …and %d more waiting", len(waiting)-maxContextBullets)
 			break
 		}
+		// Title names the child for the reader; the commands target its ID. A
+		// title is a display string — it can contain spaces, or repeat across
+		// sessions — so pasting one as an argument is what breaks the command.
 		fmt.Fprintf(&b, "\n- waiting on input: %s — see `agent-deck session output %s --json`, answer with `agent-deck session send %s \"...\"`",
-			r.Title, r.Title, r.Title)
+			r.Title, r.ID, r.ID)
 	}
 	for i, r := range done {
 		if i == maxContextBullets {
@@ -102,7 +105,7 @@ func formatChildrenContext(rows []childRow) string {
 		if r.DoneSummary != "" {
 			line += " — " + r.DoneSummary
 		}
-		line += fmt.Sprintf(" (collect: `agent-deck session output %s --json`)", r.Title)
+		line += fmt.Sprintf(" (collect: `agent-deck session output %s --json`)", r.ID)
 		b.WriteString(line)
 	}
 

--- a/cmd/agent-deck/hook_children_context.go
+++ b/cmd/agent-deck/hook_children_context.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Conductor turn-start context (the "fleet snapshot" hook). At the Claude
+// turn-start edges — UserPromptSubmit and SessionStart — a parent session gets
+// a compact snapshot of its children injected as additionalContext, so a
+// conductor always sees CURRENT fleet state without running `session children`
+// itself. This complements the issue #1225 Stop-edge drain, which delivers
+// queued transition/completion EVENTS: the drain is deltas, this is state —
+// it survives conductor restarts and events consumed by other drain paths.
+//
+// Silent no-op for sessions with no children (every leaf session), so the
+// injection costs non-parents one storage read per user prompt and adds zero
+// context. Opt out per session with AGENTDECK_NO_CHILDREN_CONTEXT=1.
+
+// maxContextBullets caps each bullet list (waiting / completed) so a huge
+// fleet cannot flood the conductor's context window.
+const maxContextBullets = 5
+
+// claudeContextEventName maps a hook event to the exact Claude-cased name
+// required in hookSpecificOutput, or "" for events (or non-Claude agents)
+// where context injection does not apply.
+func claudeContextEventName(event string) string {
+	switch normalizeHookEventKey(event) {
+	case "userpromptsubmit":
+		return "UserPromptSubmit"
+	case "sessionstart":
+		return "SessionStart"
+	default:
+		return ""
+	}
+}
+
+// childrenContextJSON renders the Claude Code hook JSON that injects context
+// without touching the prompt or blocking the turn.
+func childrenContextJSON(hookEventName, context string) string {
+	payload := map[string]map[string]string{
+		"hookSpecificOutput": {
+			"hookEventName":     hookEventName,
+			"additionalContext": context,
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// formatChildrenContext renders the fleet snapshot. Header always carries the
+// counts; bullets list only the ACTIONABLE children — waiting (stalled on a
+// question) and completed (result ready to collect) — each with the exact
+// command to run next. Running children are counted but not listed.
+func formatChildrenContext(rows []childRow) string {
+	if len(rows) == 0 {
+		return ""
+	}
+
+	var waiting, done []childRow
+	running := 0
+	for _, r := range rows {
+		switch {
+		case r.DoneStatus != "":
+			done = append(done, r)
+		case r.Status == "waiting":
+			waiting = append(waiting, r)
+		case r.Status == "running":
+			running++
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "[agent-deck fleet] %d children: %d running, %d waiting, %d done",
+		len(rows), running, len(waiting), len(done))
+	// Children in none of the three buckets (stopped, error, idle without a
+	// sentinel) — surfaced so the header math always adds up.
+	if other := len(rows) - running - len(waiting) - len(done); other > 0 {
+		fmt.Fprintf(&b, ", %d stopped/other", other)
+	}
+
+	for i, r := range waiting {
+		if i == maxContextBullets {
+			fmt.Fprintf(&b, "\n- …and %d more waiting", len(waiting)-maxContextBullets)
+			break
+		}
+		fmt.Fprintf(&b, "\n- waiting on input: %s — see `agent-deck session output %s --json`, answer with `agent-deck session send %s \"...\"`",
+			r.Title, r.Title, r.Title)
+	}
+	for i, r := range done {
+		if i == maxContextBullets {
+			fmt.Fprintf(&b, "\n- …and %d more completed", len(done)-maxContextBullets)
+			break
+		}
+		line := fmt.Sprintf("\n- completed: %s → %s", r.Title, r.DoneStatus)
+		if r.DoneSummary != "" {
+			line += " — " + r.DoneSummary
+		}
+		line += fmt.Sprintf(" (collect: `agent-deck session output %s --json`)", r.Title)
+		b.WriteString(line)
+	}
+
+	b.WriteString("\nFull list: `agent-deck session children --json`")
+	return b.String()
+}
+
+// buildChildrenContextSummary loads the caller's children and renders the
+// snapshot, or "" when the session has none (or anything fails — the hook
+// must never break a turn over supervision sugar).
+func buildChildrenContextSummary(instanceID string) string {
+	profile := session.GetEffectiveProfile("")
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = storage.Close() }()
+
+	kids := childrenOf(instanceID, instances)
+	if len(kids) == 0 {
+		return ""
+	}
+	session.RefreshInstancesForCLIStatus(kids)
+	return formatChildrenContext(buildChildRows(kids))
+}

--- a/cmd/agent-deck/hook_children_context_test.go
+++ b/cmd/agent-deck/hook_children_context_test.go
@@ -35,7 +35,7 @@ func TestFormatChildrenContext(t *testing.T) {
 		if !strings.Contains(got, "waiting on input: lint-a") {
 			t.Errorf("missing waiting bullet in %q", got)
 		}
-		if !strings.Contains(got, "session output lint-a") || !strings.Contains(got, "session send lint-a") {
+		if !strings.Contains(got, "session output a1") || !strings.Contains(got, "session send a1") {
 			t.Errorf("missing next-step commands in %q", got)
 		}
 	})
@@ -47,6 +47,41 @@ func TestFormatChildrenContext(t *testing.T) {
 		got := formatChildrenContext(rows)
 		if !strings.Contains(got, "completed: lint-a") || !strings.Contains(got, "fail") || !strings.Contains(got, "tests broke") {
 			t.Errorf("missing done details in %q", got)
+		}
+		if !strings.Contains(got, "session output a1 --json") {
+			t.Errorf("collect command should target the ID in %q", got)
+		}
+	})
+
+	// The bullets are injected into an agent's context as runnable commands, so
+	// they must target the ID: a title is a display string that may contain
+	// spaces (and may repeat across sessions under allow_multiple), which would
+	// make the command parse as the wrong session or fail outright.
+	t.Run("commands target the id, not a title with spaces", func(t *testing.T) {
+		rows := []childRow{
+			{ID: "a1", Title: "fix the flaky test", Status: "waiting"},
+			{ID: "b2", Title: "ship it", Status: "idle", DoneStatus: "ok"},
+		}
+		got := formatChildrenContext(rows)
+		for _, want := range []string{
+			"session output a1 --json", "session send a1", "session output b2 --json",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in %q", want, got)
+			}
+		}
+		for _, unwanted := range []string{
+			"session output fix the flaky test", "session send fix the flaky test",
+			"session output ship it",
+		} {
+			if strings.Contains(got, unwanted) {
+				t.Errorf("command built from a title with spaces: %q in %q", unwanted, got)
+			}
+		}
+		// The titles still name the children for the reader.
+		if !strings.Contains(got, "waiting on input: fix the flaky test") ||
+			!strings.Contains(got, "completed: ship it") {
+			t.Errorf("titles should remain as display names in %q", got)
 		}
 	})
 

--- a/cmd/agent-deck/hook_children_context_test.go
+++ b/cmd/agent-deck/hook_children_context_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormatChildrenContext(t *testing.T) {
+	t.Run("no children yields empty", func(t *testing.T) {
+		if got := formatChildrenContext(nil); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("all running yields header only", func(t *testing.T) {
+		rows := []childRow{
+			{ID: "a1", Title: "lint-a", Status: "running"},
+			{ID: "b2", Title: "lint-b", Status: "running"},
+		}
+		got := formatChildrenContext(rows)
+		if !strings.Contains(got, "2 children") || !strings.Contains(got, "2 running") {
+			t.Errorf("missing counts in %q", got)
+		}
+		if strings.Contains(got, "\n- ") {
+			t.Errorf("no bullets expected for running-only fleet: %q", got)
+		}
+	})
+
+	t.Run("waiting child gets an actionable bullet", func(t *testing.T) {
+		rows := []childRow{
+			{ID: "a1", Title: "lint-a", Status: "waiting"},
+		}
+		got := formatChildrenContext(rows)
+		if !strings.Contains(got, "waiting on input: lint-a") {
+			t.Errorf("missing waiting bullet in %q", got)
+		}
+		if !strings.Contains(got, "session output lint-a") || !strings.Contains(got, "session send lint-a") {
+			t.Errorf("missing next-step commands in %q", got)
+		}
+	})
+
+	t.Run("done child shows sentinel status and summary", func(t *testing.T) {
+		rows := []childRow{
+			{ID: "a1", Title: "lint-a", Status: "idle", DoneStatus: "fail", DoneSummary: "tests broke"},
+		}
+		got := formatChildrenContext(rows)
+		if !strings.Contains(got, "completed: lint-a") || !strings.Contains(got, "fail") || !strings.Contains(got, "tests broke") {
+			t.Errorf("missing done details in %q", got)
+		}
+	})
+
+	t.Run("mixed fleet counts each state", func(t *testing.T) {
+		rows := []childRow{
+			{ID: "a1", Title: "a", Status: "running"},
+			{ID: "b2", Title: "b", Status: "waiting"},
+			{ID: "c3", Title: "c", Status: "idle", DoneStatus: "ok", DoneSummary: "done"},
+		}
+		got := formatChildrenContext(rows)
+		for _, want := range []string{"3 children", "1 running", "1 waiting", "1 done"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in %q", want, got)
+			}
+		}
+		if strings.Contains(got, "stopped/other") {
+			t.Errorf("no other bucket expected in %q", got)
+		}
+	})
+
+	t.Run("stopped children surface in the other bucket", func(t *testing.T) {
+		rows := []childRow{
+			{ID: "a1", Title: "a", Status: "stopped"},
+			{ID: "b2", Title: "b", Status: "running"},
+		}
+		got := formatChildrenContext(rows)
+		if !strings.Contains(got, "1 stopped/other") {
+			t.Errorf("missing other bucket in %q", got)
+		}
+	})
+
+	t.Run("bullet lists are capped", func(t *testing.T) {
+		var rows []childRow
+		for i := 0; i < 12; i++ {
+			rows = append(rows, childRow{ID: string(rune('a' + i)), Title: "w", Status: "waiting"})
+		}
+		got := formatChildrenContext(rows)
+		if strings.Count(got, "waiting on input:") > maxContextBullets {
+			t.Errorf("expected at most %d waiting bullets: %q", maxContextBullets, got)
+		}
+		if !strings.Contains(got, "more") {
+			t.Errorf("expected overflow marker in %q", got)
+		}
+	})
+}
+
+func TestClaudeContextEventName(t *testing.T) {
+	cases := map[string]string{
+		"UserPromptSubmit": "UserPromptSubmit",
+		"SessionStart":     "SessionStart",
+		"Stop":             "",
+		"PreToolUse":       "",
+		"before_agent":     "",
+	}
+	for in, want := range cases {
+		if got := claudeContextEventName(in); got != want {
+			t.Errorf("claudeContextEventName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestChildrenContextJSON(t *testing.T) {
+	out := childrenContextJSON("UserPromptSubmit", "fleet: 1 running")
+	var m map[string]map[string]string
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("invalid JSON %q: %v", out, err)
+	}
+	hso := m["hookSpecificOutput"]
+	if hso["hookEventName"] != "UserPromptSubmit" {
+		t.Errorf("wrong hookEventName: %q", out)
+	}
+	if hso["additionalContext"] != "fleet: 1 running" {
+		t.Errorf("wrong additionalContext: %q", out)
+	}
+}

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -236,6 +236,20 @@ func handleHookHandler() {
 		fmt.Println(`{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"allow"}}`)
 	}
 
+	// Conductor fleet snapshot: on the Claude turn-start edges (UserPromptSubmit,
+	// SessionStart), a parent session gets a compact children-status snapshot
+	// injected as additionalContext. State, not events — complements the #1225
+	// Stop-edge drain below, which delivers queued deltas. No-op for sessions
+	// without children; AGENTDECK_NO_CHILDREN_CONTEXT=1 opts a session out.
+	if ctxEvent := claudeContextEventName(payload.HookEventName); ctxEvent != "" &&
+		os.Getenv("AGENTDECK_NO_CHILDREN_CONTEXT") != "1" {
+		if summary := buildChildrenContextSummary(instanceID); summary != "" {
+			if out := childrenContextJSON(ctxEvent, summary); out != "" {
+				fmt.Println(out)
+			}
+		}
+	}
+
 	// Issue #1225: on the Stop edge (the turn boundary), a parent drains its
 	// durable per-parent outbox and injects any pending child completions via
 	// {decision:"block",reason} — so a BUSY conductor still receives every

--- a/cmd/agent-deck/session_children_follow.go
+++ b/cmd/agent-deck/session_children_follow.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// childRow is one child in `session children` output — shared by the one-shot
+// listing and the --follow stream.
+type childRow struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Status      string `json:"status"`
+	DoneStatus  string `json:"done_status,omitempty"`
+	DoneSummary string `json:"done_summary,omitempty"`
+	DoneAt      string `json:"done_at,omitempty"`
+}
+
+// followEvent is one JSONL line on the --follow stream. Consumers key off
+// .event: snapshot|added|status|done|removed|error.
+type followEvent struct {
+	Event       string `json:"event"`
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Status      string `json:"status,omitempty"`
+	From        string `json:"from,omitempty"`
+	To          string `json:"to,omitempty"`
+	DoneStatus  string `json:"done_status,omitempty"`
+	DoneSummary string `json:"done_summary,omitempty"`
+	DoneAt      string `json:"done_at,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// followSummary is the heartbeat/complete line. Counts have no omitempty so a
+// zero reads as a zero, not a missing key.
+type followSummary struct {
+	Event    string `json:"event"`
+	Children int    `json:"children"`
+	Running  int    `json:"running"`
+	Waiting  int    `json:"waiting"`
+	DoneOK   int    `json:"done_ok"`
+	DoneFail int    `json:"done_fail"`
+}
+
+// buildChildRows converts refreshed child instances into rows. Callers must
+// have run session.RefreshInstancesForCLIStatus on kids first so UpdateStatus
+// sees warm tmux caches and hook statuses (issue #610).
+func buildChildRows(kids []*session.Instance) []childRow {
+	rows := make([]childRow, 0, len(kids))
+	for _, k := range kids {
+		_ = k.UpdateStatus()
+		row := childRow{ID: k.ID, Title: k.Title, Status: StatusString(k.Status)}
+		if e, ok := session.ReadLedgerEntry(k.ID); ok {
+			row.DoneStatus = e.Status
+			row.DoneSummary = e.Summary
+			if !e.FinishedAt.IsZero() {
+				row.DoneAt = e.FinishedAt.Format(time.RFC3339)
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func snapshotEvent(event string, r childRow) followEvent {
+	return followEvent{
+		Event: event, ID: r.ID, Title: r.Title, Status: r.Status,
+		DoneStatus: r.DoneStatus, DoneSummary: r.DoneSummary, DoneAt: r.DoneAt,
+	}
+}
+
+// diffChildEvents computes the events between two polls. Order: current
+// children first (added, then status, then done per child), removals last.
+func diffChildEvents(prev, curr []childRow) []followEvent {
+	prevByID := make(map[string]childRow, len(prev))
+	for _, r := range prev {
+		prevByID[r.ID] = r
+	}
+	currIDs := make(map[string]bool, len(curr))
+	var events []followEvent
+	for _, r := range curr {
+		currIDs[r.ID] = true
+		old, seen := prevByID[r.ID]
+		if !seen {
+			events = append(events, snapshotEvent("added", r))
+			continue
+		}
+		if old.Status != r.Status {
+			events = append(events, followEvent{
+				Event: "status", ID: r.ID, Title: r.Title, From: old.Status, To: r.Status,
+			})
+		}
+		if r.DoneStatus != "" &&
+			(old.DoneStatus != r.DoneStatus || old.DoneSummary != r.DoneSummary || old.DoneAt != r.DoneAt) {
+			events = append(events, followEvent{
+				Event: "done", ID: r.ID, Title: r.Title,
+				DoneStatus: r.DoneStatus, DoneSummary: r.DoneSummary, DoneAt: r.DoneAt,
+			})
+		}
+	}
+	for _, r := range prev {
+		if !currIDs[r.ID] {
+			events = append(events, followEvent{Event: "removed", ID: r.ID, Title: r.Title})
+		}
+	}
+	return events
+}
+
+// childTerminal reports whether a child needs no further supervision: it
+// asserted the completion sentinel (ok or fail), or its process is gone.
+// idle WITHOUT a sentinel is not terminal — an agent parked at the prompt may
+// just be between turns, and treating it as done would end --until-done early.
+func childTerminal(r childRow) bool {
+	if r.DoneStatus != "" {
+		return true
+	}
+	return r.Status == "error" || r.Status == "stopped"
+}
+
+func allChildrenTerminal(rows []childRow) bool {
+	for _, r := range rows {
+		if !childTerminal(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func summarizeChildren(event string, rows []childRow) followSummary {
+	s := followSummary{Event: event, Children: len(rows)}
+	for _, r := range rows {
+		switch r.Status {
+		case "running":
+			s.Running++
+		case "waiting":
+			s.Waiting++
+		}
+		switch r.DoneStatus {
+		case "ok":
+			s.DoneOK++
+		case "fail":
+			s.DoneFail++
+		}
+	}
+	return s
+}
+
+// loadChildRows does one full poll: fresh DB read, parent existence check,
+// status refresh, row build. Storage is closed before returning so the poll
+// loop never accumulates DB handles.
+func loadChildRows(profile, parentID string) ([]childRow, error) {
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = storage.Close() }()
+
+	parentExists := false
+	for _, inst := range instances {
+		if inst != nil && inst.ID == parentID {
+			parentExists = true
+			break
+		}
+	}
+	if !parentExists {
+		return nil, fmt.Errorf("parent session %s no longer exists", parentID)
+	}
+
+	kids := childrenOf(parentID, instances)
+	session.RefreshInstancesForCLIStatus(kids)
+	return buildChildRows(kids), nil
+}
+
+// runChildrenFollow streams child state changes as JSONL until interrupted,
+// --until-done is satisfied, or polling fails repeatedly. Every terminal state
+// is visible on the stream (done ok/fail, error, stopped, removed) so silence
+// only ever means "nothing changed" — the heartbeat line proves liveness.
+func runChildrenFollow(profile, parentID string, interval, heartbeat time.Duration, untilDone bool, w io.Writer) int {
+	emit := func(v interface{}) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		fmt.Fprintln(w, string(b))
+	}
+
+	const maxConsecutiveFailures = 5
+	var prev []childRow
+	first := true
+	failures := 0
+	lastHeartbeat := time.Now()
+
+	for {
+		rows, err := loadChildRows(profile, parentID)
+		if err != nil {
+			failures++
+			emit(followEvent{Event: "error", Error: err.Error()})
+			if failures >= maxConsecutiveFailures {
+				return 1
+			}
+		} else {
+			failures = 0
+			if first {
+				for _, r := range rows {
+					emit(snapshotEvent("snapshot", r))
+				}
+				first = false
+			} else {
+				for _, e := range diffChildEvents(prev, rows) {
+					emit(e)
+				}
+			}
+			prev = rows
+			if untilDone && allChildrenTerminal(rows) {
+				emit(summarizeChildren("complete", rows))
+				return 0
+			}
+		}
+
+		if heartbeat > 0 && time.Since(lastHeartbeat) >= heartbeat {
+			emit(summarizeChildren("heartbeat", prev))
+			lastHeartbeat = time.Now()
+		}
+		time.Sleep(interval)
+	}
+}

--- a/cmd/agent-deck/session_children_follow.go
+++ b/cmd/agent-deck/session_children_follow.go
@@ -149,6 +149,10 @@ func summarizeChildren(event string, rows []childRow) followSummary {
 	return s
 }
 
+// pollChildRows is the poll runChildrenFollow performs each tick. It is a var
+// so tests can drive the loop without standing up storage.
+var pollChildRows = loadChildRows
+
 // loadChildRows does one full poll: fresh DB read, parent existence check,
 // status refresh, row build. Storage is closed before returning so the poll
 // loop never accumulates DB handles.
@@ -179,13 +183,24 @@ func loadChildRows(profile, parentID string) ([]childRow, error) {
 // --until-done is satisfied, or polling fails repeatedly. Every terminal state
 // is visible on the stream (done ok/fail, error, stopped, removed) so silence
 // only ever means "nothing changed" — the heartbeat line proves liveness.
+//
+// interval must be positive; the caller validates it, since a non-positive
+// sleep would turn the poll into a busy-loop that reopens storage every pass.
+//
+// With untilDone, a parent that currently has no children is already "all
+// terminal" and completes immediately. Callers that mean to watch for children
+// yet to be spawned must attach after at least one child exists.
 func runChildrenFollow(profile, parentID string, interval, heartbeat time.Duration, untilDone bool, w io.Writer) int {
-	emit := func(v interface{}) {
+	// emit reports whether the stream is still writable. A consumer that goes
+	// away mid-stream (`... | head -1`) makes every later write fail; without
+	// this the loop would keep polling the DB forever with nowhere to write.
+	emit := func(v interface{}) bool {
 		b, err := json.Marshal(v)
 		if err != nil {
-			return
+			return true // Malformed event, not a dead stream: keep polling.
 		}
-		fmt.Fprintln(w, string(b))
+		_, err = fmt.Fprintln(w, string(b))
+		return err == nil
 	}
 
 	const maxConsecutiveFailures = 5
@@ -195,10 +210,12 @@ func runChildrenFollow(profile, parentID string, interval, heartbeat time.Durati
 	lastHeartbeat := time.Now()
 
 	for {
-		rows, err := loadChildRows(profile, parentID)
+		rows, err := pollChildRows(profile, parentID)
 		if err != nil {
 			failures++
-			emit(followEvent{Event: "error", Error: err.Error()})
+			if !emit(followEvent{Event: "error", Error: err.Error()}) {
+				return 0
+			}
 			if failures >= maxConsecutiveFailures {
 				return 1
 			}
@@ -206,23 +223,29 @@ func runChildrenFollow(profile, parentID string, interval, heartbeat time.Durati
 			failures = 0
 			if first {
 				for _, r := range rows {
-					emit(snapshotEvent("snapshot", r))
+					if !emit(snapshotEvent("snapshot", r)) {
+						return 0
+					}
 				}
 				first = false
 			} else {
 				for _, e := range diffChildEvents(prev, rows) {
-					emit(e)
+					if !emit(e) {
+						return 0
+					}
 				}
 			}
 			prev = rows
 			if untilDone && allChildrenTerminal(rows) {
-				emit(summarizeChildren("complete", rows))
+				_ = emit(summarizeChildren("complete", rows))
 				return 0
 			}
 		}
 
 		if heartbeat > 0 && time.Since(lastHeartbeat) >= heartbeat {
-			emit(summarizeChildren("heartbeat", prev))
+			if !emit(summarizeChildren("heartbeat", prev)) {
+				return 0
+			}
 			lastHeartbeat = time.Now()
 		}
 		time.Sleep(interval)

--- a/cmd/agent-deck/session_children_follow_test.go
+++ b/cmd/agent-deck/session_children_follow_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestDiffChildEvents(t *testing.T) {
+	running := func(id, title string) childRow {
+		return childRow{ID: id, Title: title, Status: "running"}
+	}
+
+	t.Run("no changes emits nothing", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a")}
+		curr := []childRow{running("a", "child-a")}
+		if events := diffChildEvents(prev, curr); len(events) != 0 {
+			t.Errorf("expected no events, got %+v", events)
+		}
+	})
+
+	t.Run("new child emits added", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a")}
+		curr := []childRow{running("a", "child-a"), running("b", "child-b")}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "added", ID: "b", Title: "child-b", Status: "running"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("status change emits transition", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a")}
+		curr := []childRow{{ID: "a", Title: "child-a", Status: "waiting"}}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "status", ID: "a", Title: "child-a", From: "running", To: "waiting"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("new ledger entry emits done", func(t *testing.T) {
+		prev := []childRow{{ID: "a", Title: "child-a", Status: "running"}}
+		curr := []childRow{{ID: "a", Title: "child-a", Status: "idle",
+			DoneStatus: "ok", DoneSummary: "all lint fixed", DoneAt: "2026-07-15T10:00:00Z"}}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{
+			{Event: "status", ID: "a", Title: "child-a", From: "running", To: "idle"},
+			{Event: "done", ID: "a", Title: "child-a",
+				DoneStatus: "ok", DoneSummary: "all lint fixed", DoneAt: "2026-07-15T10:00:00Z"},
+		}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("re-asserted done emits done again", func(t *testing.T) {
+		prev := []childRow{{ID: "a", Title: "child-a", Status: "idle",
+			DoneStatus: "ok", DoneSummary: "round 1", DoneAt: "2026-07-15T10:00:00Z"}}
+		curr := []childRow{{ID: "a", Title: "child-a", Status: "idle",
+			DoneStatus: "fail", DoneSummary: "round 2 broke", DoneAt: "2026-07-15T11:00:00Z"}}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "done", ID: "a", Title: "child-a",
+			DoneStatus: "fail", DoneSummary: "round 2 broke", DoneAt: "2026-07-15T11:00:00Z"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+
+	t.Run("removed child emits removed", func(t *testing.T) {
+		prev := []childRow{running("a", "child-a"), running("b", "child-b")}
+		curr := []childRow{running("a", "child-a")}
+		events := diffChildEvents(prev, curr)
+		want := []followEvent{{Event: "removed", ID: "b", Title: "child-b"}}
+		if !reflect.DeepEqual(events, want) {
+			t.Errorf("got %+v, want %+v", events, want)
+		}
+	})
+}
+
+func TestChildTerminal(t *testing.T) {
+	cases := []struct {
+		name string
+		row  childRow
+		want bool
+	}{
+		{"running is not terminal", childRow{Status: "running"}, false},
+		{"waiting is not terminal", childRow{Status: "waiting"}, false},
+		{"idle without sentinel is not terminal", childRow{Status: "idle"}, false},
+		{"done sentinel is terminal", childRow{Status: "idle", DoneStatus: "ok"}, true},
+		{"done fail sentinel is terminal", childRow{Status: "idle", DoneStatus: "fail"}, true},
+		{"error is terminal", childRow{Status: "error"}, true},
+		{"stopped is terminal", childRow{Status: "stopped"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := childTerminal(tc.row); got != tc.want {
+				t.Errorf("childTerminal(%+v) = %v, want %v", tc.row, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllChildrenTerminal(t *testing.T) {
+	if !allChildrenTerminal([]childRow{{Status: "error"}, {Status: "idle", DoneStatus: "ok"}}) {
+		t.Error("expected all terminal")
+	}
+	if allChildrenTerminal([]childRow{{Status: "idle", DoneStatus: "ok"}, {Status: "running"}}) {
+		t.Error("expected not all terminal while one is running")
+	}
+	if !allChildrenTerminal(nil) {
+		t.Error("empty set is vacuously terminal")
+	}
+}
+
+// The JSONL contract: every event marshals to a single flat object with
+// stable keys — consumers (Monitor filters, jq) key off .event.
+func TestFollowEventJSONShape(t *testing.T) {
+	b, err := json.Marshal(followEvent{Event: "status", ID: "a", Title: "t", From: "running", To: "waiting"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"event", "id", "title", "from", "to"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing key %q in %s", key, b)
+		}
+	}
+	if _, ok := m["done_status"]; ok {
+		t.Errorf("empty done_status should be omitted: %s", b)
+	}
+}

--- a/cmd/agent-deck/session_children_follow_test.go
+++ b/cmd/agent-deck/session_children_follow_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestDiffChildEvents(t *testing.T) {
@@ -110,6 +113,91 @@ func TestAllChildrenTerminal(t *testing.T) {
 	}
 	if !allChildrenTerminal(nil) {
 		t.Error("empty set is vacuously terminal")
+	}
+}
+
+// summarizeChildren drives both the heartbeat and complete lines, so every
+// counter it reports is part of the JSONL contract.
+func TestSummarizeChildren(t *testing.T) {
+	rows := []childRow{
+		{Status: "running"},
+		{Status: "waiting"},
+		{Status: "waiting"},
+		{Status: "idle", DoneStatus: "ok"},
+		{Status: "error", DoneStatus: "fail"},
+		{Status: "idle"}, // Neither running/waiting nor done: counted only in Children.
+	}
+	got := summarizeChildren("heartbeat", rows)
+	want := followSummary{Event: "heartbeat", Children: 6, Running: 1, Waiting: 2, DoneOK: 1, DoneFail: 1}
+	if got != want {
+		t.Errorf("summarizeChildren() = %+v, want %+v", got, want)
+	}
+
+	empty := summarizeChildren("complete", nil)
+	if empty != (followSummary{Event: "complete"}) {
+		t.Errorf("empty summary = %+v, want zeroed counts with event=complete", empty)
+	}
+}
+
+// errWriter fails every write, standing in for a consumer that went away
+// mid-stream (`agent-deck session children --follow | head -1`).
+type errWriter struct{ writes int }
+
+func (e *errWriter) Write(p []byte) (int, error) {
+	e.writes++
+	return 0, io.ErrClosedPipe
+}
+
+// A dead stream must end the poll loop. Before emit reported write failures,
+// the loop kept polling forever with nowhere to write the results.
+func TestRunChildrenFollowStopsOnDeadStream(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		poll func(profile, parentID string) ([]childRow, error)
+	}{
+		{
+			name: "snapshot write fails",
+			poll: func(string, string) ([]childRow, error) {
+				return []childRow{{ID: "a", Status: "running"}}, nil
+			},
+		},
+		{
+			name: "error-event write fails",
+			poll: func(string, string) ([]childRow, error) {
+				return nil, errors.New("poll failed")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			polls := 0
+			restore := pollChildRows
+			pollChildRows = func(profile, parentID string) ([]childRow, error) {
+				polls++
+				return tc.poll(profile, parentID)
+			}
+			t.Cleanup(func() { pollChildRows = restore })
+
+			w := &errWriter{}
+			done := make(chan int, 1)
+			go func() {
+				done <- runChildrenFollow("p", "parent", time.Millisecond, 0, false, w)
+			}()
+
+			select {
+			case code := <-done:
+				if code != 0 {
+					t.Errorf("exit code = %d, want 0 (stream closed, not a poll failure)", code)
+				}
+				if w.writes != 1 {
+					t.Errorf("writes = %d, want 1 — loop kept emitting after the stream died", w.writes)
+				}
+				if polls != 1 {
+					t.Errorf("polls = %d, want 1 — loop kept polling after the stream died", polls)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("runChildrenFollow kept polling after the stream closed")
+			}
+		})
 	}
 }
 

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3950,6 +3950,10 @@ func handleSessionChildren(profile string, args []string) {
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	follow := fs.Bool("follow", false, "Stream child state changes as JSONL (one event per line) until interrupted")
+	interval := fs.Duration("interval", 2*time.Second, "Poll interval for --follow")
+	heartbeat := fs.Duration("heartbeat", 60*time.Second, "Heartbeat event interval for --follow (0 disables)")
+	untilDone := fs.Bool("until-done", false, "With --follow: exit 0 once every child is terminal (done sentinel, error, or stopped)")
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session children [id|title] [options]")
 		fmt.Println()
@@ -3958,6 +3962,15 @@ func handleSessionChildren(profile string, args []string) {
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("--follow emits JSONL events: snapshot (initial state per child), added,")
+		fmt.Println("status (from/to transition), done (completion sentinel), removed, error,")
+		fmt.Println("plus periodic heartbeat and a final complete line with --until-done.")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session children --json")
+		fmt.Println("  agent-deck session children --follow                    # live fleet event stream")
+		fmt.Println("  agent-deck session children --follow --until-done      # exits when all children finish")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
@@ -3988,36 +4001,27 @@ func handleSessionChildren(profile string, args []string) {
 		os.Exit(2)
 	}
 
+	if *untilDone && !*follow {
+		out.Error("--until-done requires --follow", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if *follow {
+		// The stream is JSONL by contract; --json/-q are irrelevant here.
+		os.Exit(runChildrenFollow(profile, parent.ID, *interval, *heartbeat, *untilDone, os.Stdout))
+	}
+
 	kids := childrenOf(parent.ID, instances)
 	session.RefreshInstancesForCLIStatus(kids)
 
-	type childRow struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		DoneStatus  string `json:"done_status,omitempty"`
-		DoneSummary string `json:"done_summary,omitempty"`
-		DoneAt      string `json:"done_at,omitempty"`
-	}
-	rows := make([]childRow, 0, len(kids))
+	rows := buildChildRows(kids)
 	var human strings.Builder
 	fmt.Fprintf(&human, "Children of %s (%s):\n", parent.Title, parent.ID)
-	for _, k := range kids {
-		_ = k.UpdateStatus()
-		row := childRow{ID: k.ID, Title: k.Title, Status: StatusString(k.Status)}
-		if e, ok := session.ReadLedgerEntry(k.ID); ok {
-			row.DoneStatus = e.Status
-			row.DoneSummary = e.Summary
-			if !e.FinishedAt.IsZero() {
-				row.DoneAt = e.FinishedAt.Format(time.RFC3339)
-			}
-		}
-		rows = append(rows, row)
+	for _, row := range rows {
 		done := row.DoneStatus
 		if done == "" {
 			done = "-"
 		}
-		fmt.Fprintf(&human, "  %s  %-20s  %-8s  done=%s  %s\n", k.ID, k.Title, row.Status, done, row.DoneSummary)
+		fmt.Fprintf(&human, "  %s  %-20s  %-8s  done=%s  %s\n", row.ID, row.Title, row.Status, done, row.DoneSummary)
 	}
 	if len(kids) == 0 {
 		human.WriteString("  (no sub-sessions)\n")

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -4005,6 +4005,13 @@ func handleSessionChildren(profile string, args []string) {
 		out.Error("--until-done requires --follow", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
+	// A non-positive interval makes time.Sleep a no-op, turning the poll into a
+	// busy-loop that reopens storage every pass. Reject rather than clamp: a
+	// silently different interval than asked for is its own surprise.
+	if *follow && *interval <= 0 {
+		out.Error("--interval must be positive", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 	if *follow {
 		// The stream is JSONL by contract; --json/-q are irrelevant here.
 		os.Exit(runChildrenFollow(profile, parent.ID, *interval, *heartbeat, *untilDone, os.Stdout))

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -257,6 +257,15 @@ There is no always-on background watcher started for you — "monitored by
 default" means transition/completion events **queue** in your inbox; you still
 choose when to look (poll `session children`, or `inbox drain`).
 
+**Automatic turn-start snapshot (Claude conductors, newer builds).** A Claude
+parent session gets a compact fleet snapshot injected as context on every
+prompt submit and session start — child counts plus actionable bullets for
+`waiting` (with the exact `session output`/`session send` commands) and
+completed children. This is *state*, complementing the Stop-edge inbox drain
+(*events*): it survives conductor restarts and works even if events were
+drained elsewhere. Leaf sessions see nothing. Opt a session out by launching
+it with `AGENTDECK_NO_CHILDREN_CONTEXT=1` in its environment.
+
 ## Notes
 
 - **Completion signal:** trustworthy "done" comes from the child printing

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -106,6 +106,39 @@ disturbing the conductor or other readers.
 
 A child with a `done_status` has finished and asserted its result.
 
+**Prefer push over polling when your harness supports it.** Instead of
+re-running the check yourself, let the fleet notify you:
+
+```bash
+# One-shot "wake me when the whole fleet is finished" — run this in the
+# BACKGROUND (e.g. Claude Code's run_in_background Bash): it streams JSONL
+# events and exits 0 once every child is terminal (done sentinel, error,
+# or stopped). The harness notifies you when it exits.
+agent-deck session children --follow --until-done
+
+# Live event stream for a long-running fleet — attach a stream watcher
+# (e.g. Claude Code's Monitor tool) to this; each line is one event:
+agent-deck session children --follow
+```
+
+`--follow` emits one JSON object per line: `snapshot` (initial state per
+child), `added`, `status` (from/to transition — including `running → waiting`,
+so you see a child stall on a question), `done` (completion sentinel, ok or
+fail), `removed`, `error`, plus a periodic `heartbeat` (default 60s,
+`--heartbeat 0` disables) so silence always means "nothing changed", never
+"the watcher died". `--interval` tunes the poll cadence (default 2s). Failure
+states are on the stream too — filter for `done` alone and you'll miss
+crashed children; key off `.event` instead.
+
+On older builds without `--follow`, fall back to a background until-loop:
+
+```bash
+until agent-deck session children --json | jq -e 'all(.children[]; .done_status != null)' >/dev/null; do sleep 15; done
+```
+
+(Cloud-side schedulers — e.g. Claude Code routines — run on remote infra and
+cannot reach your local tmux/state.db; fleet supervision stays local.)
+
 ### 4. Unblock a child that's waiting on you
 
 A child in `waiting` status has stopped and is asking for input (a question, a
@@ -200,6 +233,11 @@ All read-only / on-demand — none of them block your session:
 - `agent-deck session children [id] --json` — **the default monitor.** Live
   status + last completion per child. Non-destructive (never clears the inbox),
   so poll it as often as you like. Start here every heartbeat.
+- `agent-deck session children --follow [--until-done]` — **the push monitor.**
+  Streams JSONL child events (snapshot/added/status/done/removed/error +
+  heartbeat) until interrupted; with `--until-done` it exits 0 once every child
+  is terminal. Run it in the background for a completion wake-up, or attach a
+  stream watcher for live events. Read-only like the plain form.
 - `agent-deck session output <id> --json` — a child's latest full response.
 - `agent-deck session send <id> "<msg>" [--wait|--stream|--no-wait|--draft]` —
   send a follow-up / answer a `waiting` child.


### PR DESCRIPTION
> **Stacked on #1619** (`feat/children-follow`) — reuses its `childRow`/`buildChildRows` helpers, so this diff includes that commit until #1619 merges. Review only the top commit here.

## Why

A conductor already receives queued child **events** at the Stop edge (#1225 inbox drain), but events are deltas: they miss state after a conductor restart, after another drain path consumed them, or for a child that has been sitting `waiting` since before the conversation began. The conductor still had to remember to run `session children` itself.

## What

The hook-handler now injects a compact fleet **state** snapshot as `additionalContext` on the Claude turn-start edges (`UserPromptSubmit`, `SessionStart`):

```
[agent-deck fleet] 4 children: 2 running, 1 waiting, 1 done
- waiting on input: lint-b — see `agent-deck session output lint-b --json`, answer with `agent-deck session send lint-b "..."`
- completed: lint-a → ok — all lint fixed (collect: `agent-deck session output lint-a --json`)
Full list: `agent-deck session children --json`
```

Counts always add up (a `stopped/other` bucket catches error/stopped/unsentineled-idle children); bullet lists are capped at 5 per bucket with an overflow marker so a large fleet can't flood the context window.

## Scope & safety

- **No new hook install** — piggybacks on the already-installed events; the same `hook-handler` invocation that records status also emits the snapshot.
- **Silent no-op for leaf sessions** (no children → one storage read, zero output); never blocks a turn — any failure renders as no output.
- **Opt-out**: launch a session with `AGENTDECK_NO_CHILDREN_CONTEXT=1`.
- **Deliberately no 'hold while children running' Stop hook**: #1225 bounds consecutive Stop blocks (`MaxStopHookBlocks`) precisely because keep-alive-while-pending loops burn tokens; a hold hook would reintroduce that loop. Snapshot (state) + drain (events) covers supervision without it.

## Testing

- Unit tests for the pure formatter (`formatChildrenContext`: buckets, actionable bullets, caps/overflow, other-bucket), event-name mapping, and the hookSpecificOutput JSON shape.
- Full `./cmd/agent-deck` suite, `go vet`, gofmt clean.
- E2E against an isolated $HOME: parent with 2 children emits the snapshot on `UserPromptSubmit`; leaf child emits nothing; `AGENTDECK_NO_CHILDREN_CONTEXT=1` suppresses; `Stop` events don't inject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `session children --follow` to stream child-session updates as JSONL.
  * Added `--interval`, `--heartbeat`, and `--until-done` (exits successfully once all children reach a terminal state).
  * Claude Code turn-start hooks now include a compact snapshot of actionable child-session statuses.
* **Bug Fixes**
  * Improved child-session status reporting and handling of stopped/removed children in summaries.
* **Documentation**
  * Updated `session children` help/usage for streaming behavior and flags.
* **Tests**
  * Added unit tests covering formatting, event mapping, JSON output shape, and follow-mode termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->