### PR TITLE
feat: inject environment variables on session restart

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -25,6 +25,9 @@ func (e *envVarFlags) Set(val string) error {
 	if len(parts) != 2 || parts[0] == "" {
 		return fmt.Errorf("invalid env format %q, expected KEY=VALUE", val)
 	}
+	if !session.IsValidEnvKey(parts[0]) {
+		return fmt.Errorf("invalid environment variable name %q", parts[0])
+	}
 	(*e)[parts[0]] = parts[1]
 	return nil
 }

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -111,7 +111,7 @@ func printSessionHelp() {
 	fmt.Println("  remove <id>             Remove session from registry (stopped/error only; --force to bypass)")
 	fmt.Println("  archive <id|title>      Stop session and hide it from active lists (retained in storage)")
 	fmt.Println("  unarchive <id|title>    Restore an archived session (does not restart it)")
-	fmt.Println("  restart [id] [--all]    Restart session (Claude: reload MCPs)")
+	fmt.Println("  restart [id] [--all] [--env KEY=VALUE]  Restart session (Claude: reload MCPs)")
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
 	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
 	fmt.Println("  attach <id>             Attach to session interactively")
@@ -633,6 +633,8 @@ func handleSessionRestart(profile string, args []string) {
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
 	force := fs.Bool("force", false, "Restart even if the session is already healthy and fresh (bypasses issue #30 guard)")
 	all := fs.Bool("all", false, "Restart all active sessions")
+	envFlags := make(envVarFlags)
+	fs.Var(&envFlags, "env", "Environment variable in KEY=VALUE format for the restarted process (can be repeated)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session restart [id|title] [options]")
@@ -649,6 +651,8 @@ func handleSessionRestart(profile string, args []string) {
 		fmt.Println()
 		fmt.Println("Examples:")
 		fmt.Println("  agent-deck session restart my-project")
+		fmt.Println("  agent-deck session restart my-project --env API_URL=https://api.example.com")
+		fmt.Println("  agent-deck session restart my-project --env FOO=one --env BAR=two")
 		fmt.Println("  agent-deck session restart --all")
 	}
 
@@ -667,7 +671,7 @@ func handleSessionRestart(profile string, args []string) {
 	}
 
 	if *all {
-		restartAllSessions(out, storage, instances, groups)
+		restartAllSessions(out, storage, instances, groups, envFlags)
 		return
 	}
 
@@ -693,7 +697,7 @@ func handleSessionRestart(profile string, args []string) {
 	// scope intact) when the session is healthy and was started very
 	// recently. A watchdog racing `start` → `restart` on the same session
 	// must not tear down the fresh scope.
-	if skip, reason := session.ShouldSkipRestart(inst, time.Now(), *force); skip {
+	if skip, reason := session.ShouldSkipRestart(inst, time.Now(), *force || len(envFlags) > 0); skip {
 		data := map[string]interface{}{
 			"success": true,
 			"skipped": true,
@@ -706,7 +710,7 @@ func handleSessionRestart(profile string, args []string) {
 	}
 
 	// Restart the session
-	if err := inst.Restart(); err != nil {
+	if err := inst.RestartWithEnv(envFlags); err != nil {
 		out.Error(fmt.Sprintf("failed to restart session: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
@@ -742,7 +746,7 @@ func handleSessionRestart(profile string, args []string) {
 }
 
 // restartAllSessions restarts every active session one by one.
-func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*session.Instance, groups []*session.GroupData) {
+func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*session.Instance, groups []*session.GroupData, env map[string]string) {
 	var active []*session.Instance
 	for _, inst := range instances {
 		if inst.Exists() {
@@ -768,7 +772,7 @@ func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*s
 			fmt.Printf("Restarting %s...\n", inst.Title)
 		}
 
-		if err := inst.Restart(); err != nil {
+		if err := inst.RestartWithEnv(env); err != nil {
 			errMsg := fmt.Sprintf("failed to restart session '%s': %v", inst.Title, err)
 			if !out.jsonMode {
 				fmt.Fprintf(os.Stderr, "  Error: %s\n", errMsg)

--- a/cmd/agent-deck/session_restart_env_test.go
+++ b/cmd/agent-deck/session_restart_env_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestEnvVarFlags(t *testing.T) {
+	env := make(envVarFlags)
+
+	for _, value := range []string{"API_URL=https://example.com?a=b", "EMPTY=", "API_URL=override"} {
+		if err := env.Set(value); err != nil {
+			t.Fatalf("Set(%q): %v", value, err)
+		}
+	}
+
+	if got := env["API_URL"]; got != "override" {
+		t.Fatalf("duplicate key should use the last value, got %q", got)
+	}
+	if got, ok := env["EMPTY"]; !ok || got != "" {
+		t.Fatalf("empty value should be retained, got %q (present=%v)", got, ok)
+	}
+}
+
+func TestEnvVarFlagsRejectsInvalidInput(t *testing.T) {
+	for _, value := range []string{"MISSING_EQUALS", "=value", "BAD-KEY=value", "1KEY=value"} {
+		env := make(envVarFlags)
+		if err := env.Set(value); err == nil {
+			t.Errorf("Set(%q) unexpectedly succeeded", value)
+		}
+	}
+}

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -19,7 +19,8 @@ import (
 //  5. Per-group / per-conductor inline env ([groups.X.claude].env, [conductors.X.claude].env)
 //  6. Inline env vars from [tools.X].env
 //  7. Conductor-specific env from meta.json (highest priority, overrides tool env)
-//  8. Strip TELEGRAM_STATE_DIR (v1.7.40, S8)
+//  8. One-shot restart overrides (`session restart --env`)
+//  9. Strip TELEGRAM_STATE_DIR (v1.7.40, S8)
 //
 // Note: This does NOT handle [shell].launch_shell wrapping — that happens at the
 // prepareCommand layer (instance.go) after env sourcing, so the shell startup
@@ -52,6 +53,12 @@ func (i *Instance) buildEnvSourceCommand() string {
 		sources = append(sources, paneWarning("config.toml error — overrides inactive: "+cfgErr.Error()))
 	}
 	if config == nil {
+		if restartEnv := buildEnvExports(i.restartEnv); restartEnv != "" {
+			sources = append(sources, restartEnv)
+		}
+		if stripExpr := telegramStateDirStripExpr(i); stripExpr != "" {
+			sources = append(sources, stripExpr)
+		}
 		if len(sources) == 0 {
 			return ""
 		}
@@ -132,7 +139,13 @@ func (i *Instance) buildEnvSourceCommand() string {
 		sources = append(sources, conductorEnv)
 	}
 
-	// 8. S8 (v1.7.40) — strip TELEGRAM_STATE_DIR on every non-channel-owning
+	// 8. Explicit restart overrides are applied after every configured source,
+	//    so the command-line value wins for this replacement process.
+	if restartEnv := buildEnvExports(i.restartEnv); restartEnv != "" {
+		sources = append(sources, restartEnv)
+	}
+
+	// 9. S8 (v1.7.40) — strip TELEGRAM_STATE_DIR on every non-channel-owning
 	// claude spawn. Fires AFTER all sources and inline env so it wins
 	// over any env_file / inline export that set the variable, and
 	// runs even when no env_file is in play (covers `agent-deck
@@ -470,6 +483,38 @@ func (i *Instance) getToolInlineEnv() string {
 	return strings.Join(exports, " && ")
 }
 
+// buildEnvExports returns deterministic, shell-quoted export statements.
+// Invalid keys are omitted defensively; public callers validate and report
+// them before a restart begins.
+func buildEnvExports(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	exports := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if !IsValidEnvKey(key) {
+			continue
+		}
+		escaped := strings.ReplaceAll(env[key], "'", "'\\''")
+		exports = append(exports, fmt.Sprintf("export %s='%s'", key, escaped))
+	}
+	return strings.Join(exports, " && ")
+}
+
+func (i *Instance) buildRestartEnvPrefix() string {
+	exports := buildEnvExports(i.restartEnv)
+	if exports == "" {
+		return ""
+	}
+	return exports + " && "
+}
+
 // getClaudeInlineEnv returns shell export statements for the merged
 // per-group / per-conductor inline env map ([groups.X.claude].env,
 // [conductors.X.claude].env). Merge order (later wins per key): ancestor
@@ -504,7 +549,7 @@ func (i *Instance) getClaudeInlineEnv(config *UserConfig) string {
 
 	exports := make([]string, 0, len(keys))
 	for _, k := range keys {
-		if !isValidEnvKey(k) {
+		if !IsValidEnvKey(k) {
 			continue // skip invalid env var names
 		}
 		escaped := strings.ReplaceAll(merged[k], "'", "'\\''")
@@ -599,7 +644,7 @@ func (i *Instance) getConductorEnv(ignoreMissing bool) string {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			if !isValidEnvKey(k) {
+			if !IsValidEnvKey(k) {
 				continue // skip invalid env var names
 			}
 			parts = append(parts, fmt.Sprintf("export %s='%s'", k, strings.ReplaceAll(meta.Env[k], "'", "'\\''")))
@@ -609,8 +654,9 @@ func (i *Instance) getConductorEnv(ignoreMissing bool) string {
 	return strings.Join(parts, " && ")
 }
 
-// isValidEnvKey checks that a string is a valid environment variable name.
-func isValidEnvKey(key string) bool {
+// IsValidEnvKey reports whether key is a valid POSIX-style environment
+// variable name.
+func IsValidEnvKey(key string) bool {
 	if key == "" {
 		return false
 	}

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -636,14 +636,47 @@ func TestStatEnvFileProbe(t *testing.T) {
 func TestIsValidEnvKey(t *testing.T) {
 	valid := []string{"HOME", "MY_VAR", "_private", "A", "API_KEY_123"}
 	for _, k := range valid {
-		if !isValidEnvKey(k) {
+		if !IsValidEnvKey(k) {
 			t.Errorf("expected %q to be valid", k)
 		}
 	}
 	invalid := []string{"", "123BAD", "HAS SPACE", "key=val", "semi;colon", "a'b"}
 	for _, k := range invalid {
-		if isValidEnvKey(k) {
+		if IsValidEnvKey(k) {
 			t.Errorf("expected %q to be invalid", k)
 		}
+	}
+}
+
+func TestBuildEnvExports_SortsQuotesAndSkipsInvalidKeys(t *testing.T) {
+	got := buildEnvExports(map[string]string{
+		"Z_LAST":  "two words",
+		"A_FIRST": "it's",
+		"BAD-KEY": "ignored",
+	})
+	want := `export A_FIRST='it'\''s' && export Z_LAST='two words'`
+	if got != want {
+		t.Fatalf("buildEnvExports() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildRestartEnvPrefix(t *testing.T) {
+	inst := &Instance{restartEnv: map[string]string{"RESTART_ONLY": "value"}}
+	if got, want := inst.buildRestartEnvPrefix(), "export RESTART_ONLY='value' && "; got != want {
+		t.Fatalf("buildRestartEnvPrefix() = %q, want %q", got, want)
+	}
+	inst.restartEnv = nil
+	if got := inst.buildRestartEnvPrefix(); got != "" {
+		t.Fatalf("cleared restart env produced prefix %q", got)
+	}
+}
+
+func TestRestartWithEnvRejectsInvalidKeyBeforeRestart(t *testing.T) {
+	inst := &Instance{ID: "invalid-env-test"}
+	if err := inst.RestartWithEnv(map[string]string{"BAD-KEY": "value"}); err == nil {
+		t.Fatal("RestartWithEnv accepted an invalid environment variable name")
+	}
+	if inst.restartEnv != nil {
+		t.Fatalf("invalid restart populated transient environment: %#v", inst.restartEnv)
 	}
 }

--- a/internal/session/groupclaude_overrides_test.go
+++ b/internal/session/groupclaude_overrides_test.go
@@ -174,6 +174,25 @@ env = { AGENT_ROLE = "inline-wins" }
 	}
 }
 
+func TestRestartEnvOverridesConfiguredInlineEnv(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[groups."personal".claude]
+env = { AGENT_ROLE = "configured" }
+`)
+	inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "personal", "claude")
+	inst.restartEnv = map[string]string{"AGENT_ROLE": "restart"}
+	cmd := inst.buildEnvSourceCommand()
+
+	configuredIdx := strings.Index(cmd, "export AGENT_ROLE='configured'")
+	restartIdx := strings.Index(cmd, "export AGENT_ROLE='restart'")
+	if configuredIdx == -1 || restartIdx == -1 {
+		t.Fatalf("missing configured (%d) or restart (%d) export in:\n%s", configuredIdx, restartIdx, cmd)
+	}
+	if restartIdx < configuredIdx {
+		t.Errorf("restart env must be exported after configured env so it wins:\n%s", cmd)
+	}
+}
+
 func TestGroupClaude_InlineEnvSkipsInvalidKeysAndEscapesQuotes(t *testing.T) {
 	withIsolatedHomeAndConfig(t, `
 [groups."work".claude]

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -207,6 +207,9 @@ type Instance struct {
 	// pendingCodexRestartWarning is consumed by UI/CLI after Restart() succeeds.
 	// It is intentionally transient and never persisted.
 	pendingCodexRestartWarning string `json:"-"`
+	// restartEnv contains one-shot environment overrides while RestartWithEnv is
+	// building the replacement process. It is cleared before the call returns.
+	restartEnv map[string]string
 
 	// GitHub Copilot CLI integration
 	CopilotSessionID  string    `json:"copilot_session_id,omitempty"`
@@ -6033,16 +6036,43 @@ func (i *Instance) killInternal(sync bool) error {
 // same instance. A legitimate manual restart still proceeds because the
 // stamp from any prior spawn pre-dates the new caller's beforeLock.
 func (i *Instance) Restart() error {
+	return i.restart(nil)
+}
+
+// RestartWithEnv restarts the session with one-shot environment overrides.
+// The values apply to the replacement process only and are not persisted in
+// the Instance or tmux session environment for future restarts.
+func (i *Instance) RestartWithEnv(env map[string]string) error {
+	for key := range env {
+		if !IsValidEnvKey(key) {
+			return fmt.Errorf("invalid environment variable name %q", key)
+		}
+	}
+	return i.restart(env)
+}
+
+func (i *Instance) restart(env map[string]string) error {
 	beforeLock := nowFn()
 	release, lockErr := acquireInstanceSpawnLock(i.ID)
 	if lockErr != nil {
 		return lockErr
 	}
 	defer release()
-	if spawnedSince(i.ID, beforeLock) {
+	// A one-shot environment request is explicit operator intent. If another
+	// spawn won while this call waited for the lock, restart that fresh process
+	// so the requested environment is not silently discarded.
+	if spawnedSince(i.ID, beforeLock) && len(env) == 0 {
 		return nil
 	}
 	defer recordInstanceSpawn(i.ID)
+
+	if len(env) > 0 {
+		i.restartEnv = make(map[string]string, len(env))
+		for key, value := range env {
+			i.restartEnv[key] = value
+		}
+		defer func() { i.restartEnv = nil }()
+	}
 
 	mcpLog.Debug(
 		"restart_called",
@@ -6197,6 +6227,7 @@ func (i *Instance) Restart() error {
 			rawCmd = "opencode"
 			i.OpenCodeStartedAt = time.Now().UnixMilli()
 		}
+		rawCmd = i.buildRestartEnvPrefix() + rawCmd
 		resumeCmd, containerName, err := i.prepareCommand(rawCmd)
 		if err != nil {
 			return err
@@ -6340,6 +6371,7 @@ func (i *Instance) Restart() error {
 			rawCmd = fmt.Sprintf("%s %s %s",
 				i.Command, toolDef.ResumeFlag, sessionID)
 		}
+		rawCmd = i.buildRestartEnvPrefix() + rawCmd
 		resumeCmd, containerName, err := i.prepareCommand(rawCmd)
 		if err != nil {
 			return err
@@ -6427,7 +6459,17 @@ func (i *Instance) Restart() error {
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {
 				command = i.buildGenericCommand(i.Command)
 			} else {
-				command = i.Command
+				command = i.buildRestartEnvPrefix() + i.Command
+				if i.Command == "" && command != "" {
+					shell := ""
+					if !i.IsSandboxed() && i.SSHHost == "" {
+						shell = os.Getenv("SHELL")
+					}
+					if shell == "" {
+						shell = "/bin/sh"
+					}
+					command += "exec " + shellescape.Quote(shell)
+				}
 			}
 		}
 	}

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -158,10 +158,24 @@ agent-deck session stop <id|title>
 ### session restart
 
 ```bash
-agent-deck session restart <id|title>
+agent-deck session restart <id|title> [--env KEY=VALUE ...]
 ```
 
 Reloads MCPs without losing conversation (Claude/Gemini).
+
+`--env` injects an environment variable into the replacement process for this
+restart only. It can be repeated, and a command-line value overrides configured
+environment sources with the same name. The value is not saved to the session:
+
+```bash
+agent-deck session restart my-project --env API_URL=https://api.example.com
+agent-deck session restart my-project --env FOO=one --env BAR="two words"
+```
+
+Supplying `--env` forces the requested restart past the recent-session guard.
+Use `--all --env KEY=VALUE` to inject the variable into every active session.
+Claude's existing protection that removes `TELEGRAM_*` variables from sessions
+that do not own a Telegram channel remains in effect.
 
 ### session fork (Claude, OpenCode, Pi, Codex)
 


### PR DESCRIPTION
## Summary

- add repeatable `--env KEY=VALUE` flags to `agent-deck session restart`
- apply one-shot overrides to the replacement process without persisting them
- preserve environment precedence, shell quoting, Telegram isolation, and restart concurrency semantics
- support single-session and `--all` restarts, with documentation and validation tests

## Use Case

During the mid session, I need to give agent access to a system with access token. I don't want save it in a file and allow agent always have access. When it is needed, the env var can be injected with a session restart.

## Testing

- `go test ./cmd/agent-deck -run 'TestEnvVarFlags' -count=1`\n- `go test ./internal/session -run 'Test(IsValidEnvKey|BuildEnvExports_SortsQuotesAndSkipsInvalidKeys|BuildRestartEnvPrefix|RestartWithEnvRejectsInvalidKeyBeforeRestart|RestartEnvOverridesConfiguredInlineEnv)$' -count=1`\n- `go vet ./cmd/agent-deck ./internal/session`\n- `go build ./cmd/agent-deck`\n- `git diff --check`\n\n## Usage\n\n```bash\nagent-deck session restart my-project --env API_URL=https://api.example.com\nagent-deck session restart my-project --env FOO=one --env BAR="two words"\n```