### PR TITLE
fix(codex): gate subagent-thread rebinds and fork subagent bindings

### DIFF
--- a/internal/session/codex_subagent_gate.go
+++ b/internal/session/codex_subagent_gate.go
@@ -1,0 +1,176 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Codex subagent-thread rebind poisoning (incident 2026-07-15, ares fleet).
+//
+// Codex spawns subagent threads (collab tool) whose rollouts live beside user
+// threads under codexHome/sessions and whose notify hooks fire the same
+// agent-turn-complete events. bindCodexSessionFromHook had no quality gate
+// (unlike the Claude clear-rebind heuristics), so a completing subagent's
+// hook payload rebound tool_data.codex_session_id to the child thread id.
+// While the main process lives the lsof probe flips the binding back within
+// its poll interval, but a `session restart` reads whichever id won the last
+// race and respawns `codex resume <child>`. A subagent thread that already
+// delivered its final_answer refuses new turns: codex exits status 1 with
+// "Error: turn/start failed in TUI" on the first input, the tmux session
+// dies, and the instance error-loops until the binding is repaired by hand.
+//
+// Empirical refinement (same incident, later the same day): finalization is
+// irrelevant. Codex refuses USER-initiated turns on any thread whose
+// session_meta says thread_source=subagent — `codex resume` loads such a
+// thread and even auto-continues goal-mode work, but the first typed message
+// dies identically. A session bound to a subagent thread therefore can never
+// accept operator input, no matter how the binding got there. `codex fork
+// <sid>` is the escape: it mints a fresh thread_source=user thread carrying
+// the full context, which accepts turns indefinitely.
+//
+// Three defenses, all keyed off the rollout's session_meta head line:
+//  1. Rebind gate — never rebind to a thread whose rollout says
+//     thread_source=subagent (shouldRejectCodexSubagentRebind). This guards
+//     every id-rotation path that can pick a subagent rollout: the notify
+//     hook (a completing subagent fires agent-turn-complete), the
+//     live-process FD probe (a codex TUI holds its spawned subagents'
+//     rollouts open alongside the main thread), and the cold-start disk scan.
+//  2. Restart safety net — when the bound thread is subagent-sourced,
+//     buildCodexCommand emits `codex fork <sid>` instead of `codex resume
+//     <sid>`. The forked thread keeps the bound thread's entire context (a
+//     session legitimately living on an adopted subagent thread loses
+//     nothing), and the session-id probe rebinds to the fork's fresh
+//     thread_source=user id as soon as the process is up.
+//
+// The rebind gate stops the poisoning at the source; the safety net is the
+// backstop for any binding poisoned before the gate existed or by a path the
+// gate does not cover.
+
+// codexThreadMeta is the subset of a rollout's session_meta payload the
+// gate/safety-net decisions need.
+type codexThreadMeta struct {
+	ThreadSource   string
+	ParentThreadID string
+}
+
+// codexThreadMetaCache memoizes session_meta head reads. A thread's origin
+// metadata is immutable for the life of the rollout file, and hook events are
+// redelivered every few seconds per session, so positive lookups are cached
+// forever. Keyed by session id only: ids are UUIDv7, collision across codex
+// homes is not a practical concern. Absence is NOT cached — a rollout may
+// flush after the first hook event referencing it.
+var codexThreadMetaCache sync.Map // sessionID string -> codexThreadMeta
+
+// codexRolloutPathInHome returns the flushed rollout JSONL path for a session
+// ID under codexHome/sessions, or "" when none exists.
+//
+// Codex layout: codexHome/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+func codexRolloutPathInHome(sessionID, codexHome string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return ""
+	}
+	pattern := filepath.Join(codexHome, "sessions", "*", "*", "*",
+		"rollout-*-"+sessionID+".jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+// readCodexRolloutThreadMeta parses the session_meta head line of a rollout.
+// Returns the zero value on any read/parse failure (fail-open: an unreadable
+// head is treated as a user thread).
+func readCodexRolloutThreadMeta(path string) codexThreadMeta {
+	f, err := os.Open(path)
+	if err != nil {
+		return codexThreadMeta{}
+	}
+	defer f.Close()
+
+	// session_meta lines embed full base_instructions and can exceed
+	// bufio.Scanner's 64KB default token size by a wide margin.
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	if !scanner.Scan() {
+		return codexThreadMeta{}
+	}
+
+	var head struct {
+		Type    string `json:"type"`
+		Payload struct {
+			ThreadSource   string          `json:"thread_source"`
+			ParentThreadID string          `json:"parent_thread_id"`
+			Source         json.RawMessage `json:"source"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(scanner.Bytes(), &head); err != nil || head.Type != "session_meta" {
+		return codexThreadMeta{}
+	}
+
+	meta := codexThreadMeta{
+		ThreadSource:   head.Payload.ThreadSource,
+		ParentThreadID: head.Payload.ParentThreadID,
+	}
+	// Older payloads carry parenthood only inside source.subagent.thread_spawn.
+	if meta.ParentThreadID == "" && len(head.Payload.Source) > 0 {
+		var src struct {
+			Subagent struct {
+				ThreadSpawn struct {
+					ParentThreadID string `json:"parent_thread_id"`
+				} `json:"thread_spawn"`
+			} `json:"subagent"`
+		}
+		// source is the string "cli" for user threads; ignore unmarshal errors.
+		if err := json.Unmarshal(head.Payload.Source, &src); err == nil {
+			meta.ParentThreadID = src.Subagent.ThreadSpawn.ParentThreadID
+		}
+	}
+	return meta
+}
+
+// codexThreadMetaForSession resolves (with caching) the thread metadata for a
+// session id. ok is false when no rollout is flushed for the id yet.
+func codexThreadMetaForSession(sessionID, codexHome string) (codexThreadMeta, bool) {
+	if v, ok := codexThreadMetaCache.Load(sessionID); ok {
+		return v.(codexThreadMeta), true
+	}
+	path := codexRolloutPathInHome(sessionID, codexHome)
+	if path == "" {
+		return codexThreadMeta{}, false
+	}
+	meta := readCodexRolloutThreadMeta(path)
+	codexThreadMetaCache.Store(sessionID, meta)
+	return meta, true
+}
+
+// shouldRejectCodexSubagentRebind reports whether a candidate session id from
+// any rotation source (notify hook, live-process FD probe, disk scan) must be
+// rejected because it names a subagent-spawned thread. Candidates without a
+// flushed rollout are allowed through (fail-open, matching the pre-gate
+// behavior for freshly created sessions).
+func (i *Instance) shouldRejectCodexSubagentRebind(candidateID string) bool {
+	meta, ok := codexThreadMetaForSession(candidateID, i.getCodexHomeDir())
+	return ok && meta.ThreadSource == "subagent"
+}
+
+// codexSessionNeedsFork reports whether the bound session id names a
+// subagent-sourced thread, which `codex resume` would load but never accept
+// operator input on. buildCodexCommand launches such bindings with `codex
+// fork <sid>` instead: the fork carries the thread's full context into a
+// fresh thread_source=user thread, and the live-process probe rebinds the
+// instance to the fork's new id once the process is up. Bindings without a
+// flushed rollout return false (the #756 existence gate already handled
+// them).
+func codexSessionNeedsFork(sessionID, codexHome string) bool {
+	path := codexRolloutPathInHome(sessionID, codexHome)
+	if path == "" {
+		return false
+	}
+	return readCodexRolloutThreadMeta(path).ThreadSource == "subagent"
+}

--- a/internal/session/codex_subagent_gate_test.go
+++ b/internal/session/codex_subagent_gate_test.go
@@ -1,0 +1,324 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for the codex subagent-thread rebind gate and restart safety net
+// (incident 2026-07-15). See codex_subagent_gate.go for the failure story.
+
+// seedCodexRollout writes a minimal rollout JSONL under
+// codexHome/sessions/2026/07/15 with the requested thread pedigree.
+// finalized appends a final_answer-phase message followed by task_complete,
+// matching what codex writes when a subagent delivers its answer.
+func seedCodexRolloutWithMeta(t *testing.T, codexHome, sid, threadSource, parentID string, finalized bool) string {
+	t.Helper()
+
+	dir := filepath.Join(codexHome, "sessions", "2026", "07", "15")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+
+	payload := map[string]any{
+		"id":  sid,
+		"cwd": "/tmp/project",
+	}
+	if threadSource != "" {
+		payload["thread_source"] = threadSource
+	}
+	if parentID != "" {
+		payload["parent_thread_id"] = parentID
+	}
+	lines := []map[string]any{
+		{"timestamp": "2026-07-15T20:00:00.000Z", "type": "session_meta", "payload": payload},
+		{"timestamp": "2026-07-15T20:00:01.000Z", "type": "response_item", "payload": map[string]any{
+			"type": "message", "role": "assistant",
+			"content": []map[string]any{{"type": "output_text", "text": "working"}},
+		}},
+	}
+	if finalized {
+		lines = append(lines,
+			map[string]any{"timestamp": "2026-07-15T21:00:00.000Z", "type": "response_item", "payload": map[string]any{
+				"type": "message", "role": "assistant", "phase": "final_answer",
+				"content": []map[string]any{{"type": "output_text", "text": "CLEAN."}},
+			}},
+			map[string]any{"timestamp": "2026-07-15T21:00:00.100Z", "type": "event_msg", "payload": map[string]any{
+				"type": "task_complete", "last_agent_message": "CLEAN.",
+			}},
+		)
+	}
+
+	var b strings.Builder
+	for _, l := range lines {
+		enc, err := json.Marshal(l)
+		if err != nil {
+			t.Fatalf("marshal rollout line: %v", err)
+		}
+		b.Write(enc)
+		b.WriteByte('\n')
+	}
+	path := filepath.Join(dir, "rollout-2026-07-15T20-00-00-"+sid+".jsonl")
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+	return path
+}
+
+// newCodexGateInstance builds a codex instance rooted in an isolated
+// CODEX_HOME. Session ids are uniqued per test because the thread-meta cache
+// is keyed by id for the life of the process.
+func newCodexGateInstance(t *testing.T) (*Instance, string) {
+	t.Helper()
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	codexHome := filepath.Join(tmpHome, ".codex")
+	t.Setenv("CODEX_HOME", codexHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	return NewInstanceWithTool("codex-gate", projectPath, "codex"), codexHome
+}
+
+// uniqueSID returns a UUID-shaped session id unique across the test binary,
+// so the package-level thread-meta cache cannot leak state between tests.
+var sidCounter int
+
+func uniqueSID(t *testing.T) string {
+	t.Helper()
+	sidCounter++
+	return fmt.Sprintf("019f0000-0000-7000-8000-%012d", sidCounter)
+}
+
+func TestCodexHookRebind_RejectsSubagentThread(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	mainSID := uniqueSID(t)
+	childSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, mainSID, "", "", false)
+	seedCodexRolloutWithMeta(t, codexHome, childSID, "subagent", mainSID, true)
+
+	inst.CodexSessionID = mainSID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: childSID,
+		Event:     "agent-turn-complete",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.CodexSessionID != mainSID {
+		t.Fatalf("subagent turn-complete hook must not usurp the binding: "+
+			"got %q, want %q (the 2026-07-15 poisoning)", inst.CodexSessionID, mainSID)
+	}
+}
+
+func TestCodexHookRebind_ColdStartRejectsSubagentThread(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	childSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, childSID, "subagent", uniqueSID(t), false)
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: childSID,
+		Event:     "agent-turn-complete",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.CodexSessionID != "" {
+		t.Fatalf("cold start must not bind a subagent thread (the probe finds "+
+			"the owning thread instead): got %q, want empty", inst.CodexSessionID)
+	}
+}
+
+func TestCodexHookRebind_AllowsUserThread(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	oldSID := uniqueSID(t)
+	newSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, oldSID, "", "", false)
+	seedCodexRolloutWithMeta(t, codexHome, newSID, "user", "", false)
+
+	inst.CodexSessionID = oldSID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newSID,
+		Event:     "agent-turn-complete",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.CodexSessionID != newSID {
+		t.Fatalf("user-thread rebind (e.g. /new rotation) must still work: got %q, want %q",
+			inst.CodexSessionID, newSID)
+	}
+}
+
+func TestCodexHookRebind_AllowsUnflushedCandidate(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	oldSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, oldSID, "", "", false)
+	newSID := uniqueSID(t) // no rollout on disk yet
+
+	inst.CodexSessionID = oldSID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newSID,
+		Event:     "agent-turn-complete",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.CodexSessionID != newSID {
+		t.Fatalf("candidate without a flushed rollout must bind (fail-open, "+
+			"pre-gate behavior): got %q, want %q", inst.CodexSessionID, newSID)
+	}
+}
+
+func TestBuildCodexCommand_ForksFinalizedSubagentBinding(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	mainSID := uniqueSID(t)
+	childSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, mainSID, "user", "", false)
+	seedCodexRolloutWithMeta(t, codexHome, childSID, "subagent", mainSID, true)
+
+	inst.CodexSessionID = childSID
+	cmd := inst.buildCodexCommand("codex")
+
+	if !strings.Contains(cmd, "fork "+childSID) {
+		t.Fatalf("a subagent-sourced binding must launch with `codex fork` "+
+			"(resume loads it but the first typed message dies with "+
+			"\"turn/start failed in TUI\"); got command %q", cmd)
+	}
+}
+
+func TestBuildCodexCommand_ForksUnfinalizedSubagentBinding(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	mainSID := uniqueSID(t)
+	childSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, mainSID, "user", "", false)
+	seedCodexRolloutWithMeta(t, codexHome, childSID, "subagent", mainSID, false)
+
+	inst.CodexSessionID = childSID
+	cmd := inst.buildCodexCommand("codex")
+
+	if !strings.Contains(cmd, "fork "+childSID) {
+		t.Fatalf("finalization is irrelevant — codex refuses user turns on any "+
+			"subagent-sourced thread (ares-attn died on send while its adopted "+
+			"thread was mid-flight), so fork is required; got %q", cmd)
+	}
+}
+
+func TestBuildCodexCommand_ResumesUserThreadBinding(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	mainSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, mainSID, "user", "", false)
+
+	inst.CodexSessionID = mainSID
+	cmd := inst.buildCodexCommand("codex")
+
+	if !strings.Contains(cmd, "resume "+mainSID) {
+		t.Fatalf("user-thread bindings must keep plain resume: got %q", cmd)
+	}
+	if strings.Contains(cmd, "fork ") {
+		t.Fatalf("user-thread bindings must not be forked: got %q", cmd)
+	}
+}
+
+func TestShouldRejectCodexSubagentRebind(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	subSID := uniqueSID(t)
+	userSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, subSID, "subagent", uniqueSID(t), false)
+	seedCodexRolloutWithMeta(t, codexHome, userSID, "user", "", false)
+	unflushedSID := uniqueSID(t) // no rollout on disk
+
+	if !inst.shouldRejectCodexSubagentRebind(subSID) {
+		t.Fatalf("subagent-sourced candidate must be rejected")
+	}
+	if inst.shouldRejectCodexSubagentRebind(userSID) {
+		t.Fatalf("user-sourced candidate must be allowed")
+	}
+	if inst.shouldRejectCodexSubagentRebind(unflushedSID) {
+		t.Fatalf("candidate without a flushed rollout must be allowed (fail-open)")
+	}
+}
+
+// seedCodexRolloutCwd writes a realistic rollout-<ts>-<sid>.jsonl whose
+// session_meta head carries both cwd (for the disk scan's project match) and
+// thread_source (for the subagent gate). Distinct from seedCodexRolloutWithMeta,
+// which hard-codes cwd — the disk-scan gate needs the cwd to match ProjectPath.
+func seedCodexRolloutCwd(t *testing.T, codexHome, sid, threadSource, cwd string) {
+	t.Helper()
+	dir := filepath.Join(codexHome, "sessions", "2026", "07", "15")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions dir: %v", err)
+	}
+	head := map[string]any{
+		"timestamp": "2026-07-15T20:00:00.000Z",
+		"type":      "session_meta",
+		"payload":   map[string]any{"id": sid, "cwd": cwd, "thread_source": threadSource},
+	}
+	enc, err := json.Marshal(head)
+	if err != nil {
+		t.Fatalf("marshal head: %v", err)
+	}
+	path := filepath.Join(dir, "rollout-2026-07-15T20-00-00-"+sid+".jsonl")
+	if err := os.WriteFile(path, append(enc, '\n'), 0o600); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+}
+
+func TestUpdateCodexSession_DiskScan_PrefersUserOverSubagent(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+	if err := os.MkdirAll(inst.ProjectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	userSID := uniqueSID(t)
+	subSID := uniqueSID(t)
+	// Both scoped to the instance's project; the subagent rollout is written
+	// last so a naive most-recent-wins scan would prefer it.
+	seedCodexRolloutCwd(t, codexHome, userSID, "user", inst.ProjectPath)
+	seedCodexRolloutCwd(t, codexHome, subSID, "subagent", inst.ProjectPath)
+
+	inst.UpdateCodexSession(nil)
+
+	if inst.CodexSessionID == subSID {
+		t.Fatalf("disk scan adopted the subagent thread %q — codex refuses user "+
+			"turns on it", subSID)
+	}
+	if inst.CodexSessionID != userSID {
+		t.Fatalf("disk scan should bind the user thread %q, got %q", userSID, inst.CodexSessionID)
+	}
+}
+
+func TestUpdateCodexSession_DiskScan_RejectsLoneSubagent(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+	if err := os.MkdirAll(inst.ProjectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	subSID := uniqueSID(t)
+	seedCodexRolloutCwd(t, codexHome, subSID, "subagent", inst.ProjectPath)
+
+	inst.UpdateCodexSession(nil)
+
+	if inst.CodexSessionID != "" {
+		t.Fatalf("disk scan must leave the session unbound when only a subagent "+
+			"rollout matches; got %q", inst.CodexSessionID)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1575,6 +1575,25 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 		ClearHookSessionAnchor(i.ID)
 	}
 
+	// Safety net (incident 2026-07-15): codex loads subagent-sourced threads
+	// via `resume` but refuses user-initiated turns on them — the TUI exits
+	// status 1 with "turn/start failed in TUI" on the first typed message,
+	// killing the tmux session in an error loop. This bites bindings
+	// poisoned by a subagent turn-complete hook before the gate existed (or
+	// raced past it) AND sessions legitimately living on an adopted subagent
+	// thread from an earlier mid-flight restart. `codex fork` carries the
+	// thread's full context into a fresh thread_source=user thread that
+	// accepts input; the live-process probe then rebinds the instance to the
+	// fork's new id. See codex_subagent_gate.go.
+	if i.CodexSessionID != "" && codexSessionNeedsFork(i.CodexSessionID, codexHome) {
+		sessionLog.Warn("codex_subagent_binding_forked",
+			slog.String("instance_id", i.ID),
+			slog.String("title", i.Title),
+			slog.String("sid", i.CodexSessionID))
+		return envPrefix + fmt.Sprintf("%s%s%s fork %s",
+			command, yoloFlag, modelFlag, i.CodexSessionID)
+	}
+
 	if i.CodexSessionID != "" {
 		return envPrefix + fmt.Sprintf("%s%s%s resume %s",
 			command, yoloFlag, modelFlag, i.CodexSessionID)
@@ -1745,17 +1764,7 @@ func (i *Instance) buildCopilotCommand(baseCommand string) string {
 //
 // Codex layout: codexHome/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
 func codexRolloutExistsInHome(sessionID, codexHome string) bool {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return false
-	}
-	pattern := filepath.Join(codexHome, "sessions", "*", "*", "*",
-		"rollout-*-"+sessionID+".jsonl")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return false
-	}
-	return len(matches) > 0
+	return codexRolloutPathInHome(sessionID, codexHome) != ""
 }
 
 // detectOpenCodeSessionAsync detects the OpenCode session ID after startup
@@ -2167,6 +2176,17 @@ func (i *Instance) queryCodexSession(excludeIDs map[string]bool, allowUnscoped b
 				return nil
 			}
 			if excludeIDs != nil && excludeIDs[sessionID] {
+				return nil
+			}
+
+			// Subagent-thread gate (incident 2026-07-15): never let the
+			// bootstrap disk scan adopt a subagent rollout as the session's
+			// main thread — codex refuses user turns on it. Skipping it here
+			// (rather than after selection) lets the walk fall through to the
+			// best user-sourced match instead of returning nothing when the
+			// most-recent match happens to be a subagent. See
+			// codex_subagent_gate.go.
+			if i.shouldRejectCodexSubagentRebind(sessionID) {
 				return nil
 			}
 
@@ -2683,20 +2703,39 @@ func (i *Instance) updateCodexSession(excludeIDs map[string]bool, forceProbe boo
 	missingProbeDep := ""
 	if i.shouldRunCodexProcessProbe(forceProbe) {
 		if sessionID, missingDep := i.queryCodexSessionFromProcessFiles(); sessionID != "" {
-			changed := sessionID != i.CodexSessionID
-			if changed {
-				sessionLog.Debug(
-					"codex_session_update_from_probe",
+			// Subagent-thread gate (incident 2026-07-15): a codex TUI holds the
+			// rollouts of the subagents it spawned open alongside its main
+			// thread, so the FD probe can surface a subagent id. Binding it here
+			// is the same poisoning the hook gate prevents, reached by the other
+			// rotation path — and once bound, a restart resumes a thread codex
+			// refuses user turns on. Reject it and keep the current binding; the
+			// probe will pick the main thread on a later cycle. See
+			// codex_subagent_gate.go.
+			if i.shouldRejectCodexSubagentRebind(sessionID) {
+				_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+					InstanceID: i.ID, Tool: i.Tool, Action: "reject",
+					Source: "process_probe", OldID: i.CodexSessionID, Candidate: sessionID,
+					Reason: "candidate_is_subagent_thread",
+				})
+				sessionLog.Debug("codex_session_probe_rejected_subagent",
 					slog.String("old_id", i.CodexSessionID),
-					slog.String("new_id", sessionID),
-				)
+					slog.String("candidate", sessionID))
+			} else {
+				changed := sessionID != i.CodexSessionID
+				if changed {
+					sessionLog.Debug(
+						"codex_session_update_from_probe",
+						slog.String("old_id", i.CodexSessionID),
+						slog.String("new_id", sessionID),
+					)
+				}
+				i.CodexSessionID = sessionID
+				i.CodexDetectedAt = time.Now()
+				if i.tmuxSession != nil && i.tmuxSession.Exists() && (changed || envSessionID == "") {
+					_ = i.tmuxSession.SetEnvironment("CODEX_SESSION_ID", i.CodexSessionID)
+				}
+				return ""
 			}
-			i.CodexSessionID = sessionID
-			i.CodexDetectedAt = time.Now()
-			if i.tmuxSession != nil && i.tmuxSession.Exists() && (changed || envSessionID == "") {
-				_ = i.tmuxSession.SetEnvironment("CODEX_SESSION_ID", i.CodexSessionID)
-			}
-			return ""
 		} else if missingDep != "" {
 			missingProbeDep = missingDep
 		}
@@ -2728,6 +2767,8 @@ func (i *Instance) updateCodexSession(excludeIDs map[string]bool, forceProbe boo
 	}
 
 	if sessionID := i.queryCodexSession(excludeIDs, allowUnscoped); sessionID != "" {
+		// queryCodexSession already filters subagent rollouts out of candidacy
+		// (incident 2026-07-15), so sessionID here is always a user thread.
 		changed := sessionID != i.CodexSessionID
 		if sessionID != i.CodexSessionID {
 			sessionLog.Debug(
@@ -4415,6 +4456,25 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		i.bindClaudeSessionFromHook(sessionID, hookSource, status.Event, "rebind")
 	case IsCodexCompatible(i.Tool):
 		if sessionID == i.CodexSessionID {
+			return
+		}
+		// Quality gate (incident 2026-07-15): codex subagent threads fire
+		// the same agent-turn-complete notify as the main thread, and a
+		// completing subagent's payload id would otherwise usurp the
+		// binding. Restarting then resumes a finalized child thread, which
+		// refuses turn/start and error-loops the session. See
+		// codex_subagent_gate.go.
+		if i.shouldRejectCodexSubagentRebind(sessionID) {
+			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
+				Source: hookSource, OldID: i.CodexSessionID, Candidate: sessionID,
+				HookEvent: status.Event, Reason: "candidate_is_subagent_thread",
+			})
+			sessionLog.Debug("codex_session_rebind_rejected_subagent",
+				slog.String("old_id", i.CodexSessionID),
+				slog.String("candidate", sessionID),
+				slog.String("event", status.Event),
+			)
 			return
 		}
 		i.bindCodexSessionFromHook(sessionID, status.Event)


### PR DESCRIPTION
Earlier today my whole fleet of Codex sessions started dying in the strangest way. A session would hum along for hours doing goal-mode work, and the moment I typed a message at it, the TUI would exit with `Error: turn/start failed in TUI` -- taking the tmux session with it. agent-deck flips the session to error, a restart just arms the next death, and recovery means hand-editing `tool_data.codex_session_id` in SQLite plus the `.sid` sidecar. Having now done that dance more times than I'd like, I'd rather nobody ever has to again.

It took a few hours of tracing (and several sacrificial tmux sessions with `remain-on-exit` turned on) before the mechanism fell out, and it's really two problems stacked on each other.

First, codex refuses user-initiated turns on any thread whose rollout head says `"thread_source": "subagent"`. `codex resume` loads such a thread just fine -- goal mode even auto-continues its work -- but the first *typed* message fails turn/start and exits with status 1. I first assumed only *finalized* subagent threads did this; that theory died when a mid-flight one killed a session the same way. Finalization is irrelevant (codex 0.144.1).

Second, agent-deck rebinds `tool_data.codex_session_id` to whatever id a rotation source hands it, and there was no quality gate on the Codex path the way there is for the Claude clear-rebind heuristics. Three different sources can hand it a subagent id:

- The notify hook: a completing subagent fires the same `agent-turn-complete` event as the main thread.
- The live-process FD probe: a codex TUI keeps the rollouts of the subagents it spawned open right alongside the main thread, so the probe that reads open FDs can pick one of them.
- The cold-start disk scan: the most recently modified rollout for a project can easily be a subagent's.

While the process is alive the probe usually flips the binding back within a poll interval, but a restart reads whatever won the last race and resumes it. And a session can end up *adopted* onto a subagent thread a fourth way -- an earlier mid-flight restart that resumed one directly, which then runs happily until you send it a message.

The fix keys everything off the rollout's `session_meta` head line, in a new `internal/session/codex_subagent_gate.go`:

- A rebind gate (`shouldRejectCodexSubagentRebind`) sits on all three rotation paths and refuses to bind a subagent-sourced candidate. The hook path logs a lifecycle reject event; the disk scan filters subagent rollouts out of candidacy *inside the walk*, so it still lands on the best user-sourced match instead of returning nothing; candidates with no flushed rollout still bind, so freshly created sessions behave exactly as before.
- A restart safety net launches any binding that is still subagent-sourced with `codex fork <sid>` instead of `resume`. The fork carries the thread's whole context into a fresh `thread_source=user` thread that accepts input, and the probe rebinds the instance to the fork's new id once it's up. That heals bindings that were poisoned before the gate existed, and adopted ones, with no context loss.

If you want to see the underlying codex behavior yourself:

```
codex resume <any-subagent-thread-id>   # loads; goal work may even continue
# type anything, press Enter
#   => Error: turn/start failed in TUI  (exit status 1)
codex fork <same-id>                    # loads, accepts input indefinitely
```

There are twelve tests: the rebind gate (warm and cold start on the hook path; user-thread and unflushed candidates still binding; the predicate directly), the disk scan (prefers a user thread over a more-recent subagent one, and stays unbound when only a subagent matches), and the launch path (finalized and mid-flight subagent bindings fork; user threads keep plain resume). `go build`, `go vet`, and the full `internal/session` suite show no new failures -- the handful that fail on my machine fail identically on a clean checkout of main, so they're host-sensitive rather than related. This has been running on my eight-session fleet since this afternoon: the gate has been rejecting subagent rebinds ever since, and the fork path is what un-bricked the sessions that started all this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect rebinding to Codex subagent-spawned threads.
  * Improved restart safety by using **fork** for subagent-sourced sessions instead of **resume**.
  * Ensured user-thread sessions continue to resume normally.
  * Improved safety when rollout metadata is missing or unreadable, avoiding risky bindings.
  * Updated session selection to prefer user rollouts when both exist, and to reject lone subagent matches.

* **Tests**
  * Added unit and integration-style coverage for rebinding gates, cold-start behavior, and fork/resume command selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->