### PR TITLE
fix: claude title sync reverting locked renames

### DIFF
--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -89,14 +89,24 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		// Instance IDs are globally unique: once found, this profile owns the
 		// session — act and stop, never fall through to another profile.
 		//
-		// newName/changed reflect ReconcileTitleFromClaude's decision against
+		// newName/changed reflect ResolveTitleFromClaude's decision against
 		// THIS process's (possibly stale) in-memory snapshot — that's only a
 		// fast local check. The actual persistence below is a single targeted
 		// UPDATE ... WHERE title_locked = 0, so even if a user rename landed
 		// and locked the title after this snapshot was loaded, the write is a
 		// silent no-op instead of clobbering it (unlike the old whole-instance
 		// SaveWithGroups round-trip, which had no such guard).
-		newName, changed := target.ReconcileTitleFromClaude(sessionID)
+		//
+		// Deliberately uses ResolveTitleFromClaude (pure decision), NOT
+		// ReconcileTitleFromClaude (which also renames the live tmux window
+		// and writes the badge-update file immediately). If we ran those side
+		// effects on every "decided to rename" and then discovered the DB
+		// write was rejected as locked, the tmux window title and iTerm badge
+		// would already show Claude's name while the stored title correctly
+		// stayed put — visible chrome out of sync with the persisted value.
+		// So: decide, persist, and only apply the tmux/badge side effects once
+		// persistence is confirmed.
+		newName, changed := target.ResolveTitleFromClaude(sessionID)
 		applied := false
 		if changed {
 			applied, _ = storage.UpdateTitleIfUnlocked(instanceID, newName)
@@ -104,10 +114,15 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		_ = storage.Close()
 
 		if applied {
-			// #1114: ReconcileTitleFromClaude already wrote the badge-update
-			// file the attached process watches (the path that works without a
-			// controlling tty). Also attempt the direct via-tty emit for the
-			// rare hook that DOES own a tty — silent no-op otherwise.
+			target.Title = newName
+			target.SyncTmuxDisplayName()
+			if tmuxSess := target.GetTmuxSession(); tmuxSess != nil && tmuxSess.Name != "" {
+				_ = tmux.WriteBadgeUpdate(tmuxSess.Name, newName)
+			}
+			// #1114: WriteBadgeUpdate above wrote the file the attached
+			// process watches (the path that works without a controlling
+			// tty). Also attempt the direct via-tty emit for the rare hook
+			// that DOES own a tty — silent no-op otherwise.
 			tmux.EmitITermBadgeViaTty(newName, session.GetTerminalSettings().GetITermBadge())
 		}
 		return

--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -69,7 +69,7 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		if err != nil {
 			continue
 		}
-		instances, groups, err := storage.LoadWithGroups()
+		instances, _, err := storage.LoadWithGroups()
 		if err != nil {
 			_ = storage.Close()
 			continue
@@ -88,15 +88,22 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 
 		// Instance IDs are globally unique: once found, this profile owns the
 		// session — act and stop, never fall through to another profile.
+		//
+		// newName/changed reflect ReconcileTitleFromClaude's decision against
+		// THIS process's (possibly stale) in-memory snapshot — that's only a
+		// fast local check. The actual persistence below is a single targeted
+		// UPDATE ... WHERE title_locked = 0, so even if a user rename landed
+		// and locked the title after this snapshot was loaded, the write is a
+		// silent no-op instead of clobbering it (unlike the old whole-instance
+		// SaveWithGroups round-trip, which had no such guard).
 		newName, changed := target.ReconcileTitleFromClaude(sessionID)
+		applied := false
 		if changed {
-			target.SetAutoName(false) // Claude/user-chosen name replaces the auto handle
-			groupTree := session.NewGroupTreeWithGroups(instances, groups)
-			_ = storage.SaveWithGroups(instances, groupTree)
+			applied, _ = storage.UpdateTitleIfUnlocked(instanceID, newName)
 		}
 		_ = storage.Close()
 
-		if changed {
+		if applied {
 			// #1114: ReconcileTitleFromClaude already wrote the badge-update
 			// file the attached process watches (the path that works without a
 			// controlling tty). Also attempt the direct via-tty emit for the

--- a/internal/session/claude_title_reconcile.go
+++ b/internal/session/claude_title_reconcile.go
@@ -97,6 +97,35 @@ func ClaudeSessionName(sessionID string) string {
 	return ClaudeSessionNameIn(filepath.Join(home, ".claude"), sessionID)
 }
 
+// ResolveTitleFromClaude is the pure decision half of ReconcileTitleFromClaude:
+// it answers "does Claude's session name warrant a rename" without mutating i
+// or touching tmux. Honors the same sync_title switch and TitleLocked flag.
+//
+// Split out for the hook-triggered sync (cmd/agent-deck/hook_name_sync.go),
+// which persists via a conditional UPDATE ... WHERE title_locked = 0 that can
+// legitimately no-op if a user rename landed and locked the title first. The
+// combined ReconcileTitleFromClaude fires tmux/badge side effects unconditionally
+// on a decision to rename, before the caller's persistence attempt is even
+// known to have succeeded — a hook whose write gets rejected would still have
+// already overwritten the live tmux window title and iTerm badge with Claude's
+// name, leaving the terminal chrome out of sync with the correctly-preserved
+// stored title. Callers in that situation should call this instead and only
+// run the equivalent of ReconcileTitleFromClaude's side effects once their own
+// write is confirmed applied.
+func (i *Instance) ResolveTitleFromClaude(sessionID string) (string, bool) {
+	if i == nil || i.TitleLocked {
+		return "", false
+	}
+	if cfg, err := LoadUserConfig(); err == nil && cfg != nil && !cfg.GetSyncTitle() {
+		return "", false
+	}
+	name := ClaudeSessionName(sessionID)
+	if name == "" || name == i.Title {
+		return "", false
+	}
+	return name, true
+}
+
 // ReconcileTitleFromClaude refreshes i.Title from the agent's current Claude
 // session name. It is the shared core behind both the hook-event sync (#572)
 // and the on-attach reconcile (#1114 follow-up): Claude's /rename fires no
@@ -111,16 +140,14 @@ func ClaudeSessionName(sessionID string) string {
 // catch-up re-emits the fresh name instead of clobbering it with the old one.
 //
 // Returns the new name and true iff the title changed; the CALLER is
-// responsible for persisting the instance to storage.
+// responsible for persisting the instance to storage. The on-attach caller
+// (internal/ui/home.go) saves under the same in-process lock it just read
+// TitleLocked from, so applying side effects immediately here is safe for
+// that caller; the hook-triggered sync is NOT that caller — see
+// ResolveTitleFromClaude.
 func (i *Instance) ReconcileTitleFromClaude(sessionID string) (string, bool) {
-	if i == nil || i.TitleLocked {
-		return "", false
-	}
-	if cfg, err := LoadUserConfig(); err == nil && cfg != nil && !cfg.GetSyncTitle() {
-		return "", false
-	}
-	name := ClaudeSessionName(sessionID)
-	if name == "" || name == i.Title {
+	name, ok := i.ResolveTitleFromClaude(sessionID)
+	if !ok {
 		return "", false
 	}
 	i.Title = name

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -360,6 +360,28 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 	return nil
 }
 
+// UpdateTitleIfUnlocked sets an instance's title with a single conditional
+// UPDATE that only applies while the row is still unlocked at write time —
+// see StateDB.UpdateTitleIfUnlocked for why this must be a targeted write
+// rather than a full instance-list round-trip.
+func (s *Storage) UpdateTitleIfUnlocked(id, title string) (applied bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return false, fmt.Errorf("storage database not initialized")
+	}
+
+	applied, err = s.db.UpdateTitleIfUnlocked(id, title)
+	if err != nil {
+		return false, fmt.Errorf("failed to update title for instance %s: %w", id, err)
+	}
+	if applied {
+		_ = s.db.Touch()
+	}
+	return applied, nil
+}
+
 // DeleteInstance removes a single instance from the database by ID.
 // This ensures the row is immediately removed, preventing resurrection on reload.
 func (s *Storage) DeleteInstance(id string) error {

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -194,6 +194,18 @@ func mergeAutoNameFields(inst *InstanceRow, existing existingAutoNameFields) (bo
 	return autoName, description
 }
 
+// NOTE: title/title_locked are deliberately NOT merge-protected the way
+// auto_name is. auto_name's merge is safe because it only blocks one
+// direction (stale payload resurrecting true after a fresher writer cleared
+// it) — a row-level heuristic can't safely do that for title_locked, because
+// an incoming "unlocked" payload is ambiguous: it's either a stale snapshot
+// from a racing writer (must be rejected) or a deliberate `session
+// set-title-lock off` (must be honored), and both look identical as plain
+// row data. That ambiguity can only be resolved at the write site that
+// actually knows its own freshness — see UpdateTitleIfUnlocked, used by the
+// hook-triggered Claude title sync (cmd/agent-deck/hook_name_sync.go) instead
+// of a full stale-snapshot round-trip through UpsertInstances.
+
 // WatcherRow represents a watcher row in the database.
 type WatcherRow struct {
 	ID         string
@@ -1017,6 +1029,44 @@ func (s *StateDB) DeleteInstance(id string) error {
 		_, err := s.db.Exec("DELETE FROM instances WHERE id = ?", id)
 		return err
 	})
+}
+
+// UpdateTitleIfUnlocked sets an instance's title (and clears auto_name, since
+// a synced title replaces the auto-generated handle) with a single
+// conditional UPDATE, atomic at the SQL level: the WHERE clause is evaluated
+// by SQLite as part of the same statement, so there is no read-then-write gap
+// a concurrent lock can land in. Returns applied=false (no error) when the
+// row is already locked or doesn't exist — the caller made no change.
+//
+// This exists for writers that only intend to touch the title based on a
+// possibly-stale decision — namely the hook-triggered Claude title sync
+// (cmd/agent-deck/hook_name_sync.go), which loads a full instance snapshot in
+// a separate process and used to save it back wholesale via UpsertInstances.
+// If a user rename (which sets title_locked) landed between that process's
+// load and its save, the stale wholesale save would silently revert the
+// rename — the "session name keeps getting overwritten" bug. A general
+// storage-layer guard against this is unsafe: an incoming "unlocked" payload
+// is ambiguous between "stale snapshot" (reject) and "deliberate `session
+// set-title-lock off`" (honor), and both look identical as row data. Only the
+// write site itself can resolve that, by asking SQLite to apply the change
+// solely if the row is STILL unlocked at the moment of the write.
+func (s *StateDB) UpdateTitleIfUnlocked(id, title string) (applied bool, err error) {
+	err = withBusyRetry(func() error {
+		res, execErr := s.db.Exec(
+			"UPDATE instances SET title = ?, auto_name = 0 WHERE id = ? AND title_locked = 0",
+			title, id,
+		)
+		if execErr != nil {
+			return execErr
+		}
+		n, raErr := res.RowsAffected()
+		if raErr != nil {
+			return raErr
+		}
+		applied = n > 0
+		return nil
+	})
+	return applied, err
 }
 
 // InstanceExists returns true iff a row with the given id is present.

--- a/internal/statedb/update_title_if_unlocked_test.go
+++ b/internal/statedb/update_title_if_unlocked_test.go
@@ -1,0 +1,131 @@
+package statedb
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// UpdateTitleIfUnlocked is the fix for the "session name keeps getting
+// overwritten" bug: the hook-triggered Claude title sync
+// (cmd/agent-deck/hook_name_sync.go) runs as a separate process, decides
+// whether to rename based on a possibly-stale snapshot, and used to persist
+// via a full instance-list round-trip (UpsertInstances) with no freshness
+// check — so a user rename landing in between could be silently reverted.
+// This method closes that gap with a single conditional UPDATE instead.
+
+func seedTitleRow(t *testing.T, db *StateDB, id, title string, locked bool) {
+	t.Helper()
+	row := &InstanceRow{
+		ID: id, Title: title, ProjectPath: "/p", GroupPath: "",
+		Order: 0, Tool: "claude", Status: "idle", CreatedAt: time.Now(),
+		ToolData: json.RawMessage("{}"), TitleLocked: locked,
+	}
+	if err := db.UpsertInstances([]*InstanceRow{row}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+// The core race: the write must be a no-op once the row is locked, even
+// though the caller's own decision to write was made before the lock existed
+// (that staleness is exactly the scenario — the guard is enforced at write
+// time, not decision time).
+func TestUpdateTitleIfUnlocked_NoopWhenLocked(t *testing.T) {
+	db := newTestDB(t)
+	seedTitleRow(t, db, "s1", "my-custom-name", true)
+
+	applied, err := db.UpdateTitleIfUnlocked("s1", "claude-derived-name")
+	if err != nil {
+		t.Fatalf("UpdateTitleIfUnlocked: %v", err)
+	}
+	if applied {
+		t.Fatalf("expected no-op against a locked row, got applied=true")
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if loaded[0].Title != "my-custom-name" {
+		t.Errorf("locked title was overwritten: got %q, want %q", loaded[0].Title, "my-custom-name")
+	}
+	if !loaded[0].TitleLocked {
+		t.Errorf("lock was cleared by a title-only update")
+	}
+}
+
+// The normal case: an unlocked row's title updates freely (this is the
+// legitimate Claude-name-sync path when no user rename has happened).
+func TestUpdateTitleIfUnlocked_AppliesWhenUnlocked(t *testing.T) {
+	db := newTestDB(t)
+	seedTitleRow(t, db, "s1", "old-name", false)
+
+	applied, err := db.UpdateTitleIfUnlocked("s1", "claude-derived-name")
+	if err != nil {
+		t.Fatalf("UpdateTitleIfUnlocked: %v", err)
+	}
+	if !applied {
+		t.Fatalf("expected update to apply against an unlocked row")
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if loaded[0].Title != "claude-derived-name" {
+		t.Errorf("title = %q, want %q", loaded[0].Title, "claude-derived-name")
+	}
+}
+
+// Critical: session set-title-lock off (or any other writer that legitimately
+// wants to unlock+retitle) must NOT go through this method's WHERE guard and
+// must still be able to change a locked row. UpdateTitleIfUnlocked is only
+// for the specific "sync while possibly stale" case; a deliberate unlock is a
+// normal UpsertInstances/SaveInstance call with TitleLocked=false, which must
+// still succeed unconditionally (regression check for the overly-broad
+// merge-based approach this replaced, which blocked legitimate unlocks too).
+func TestUpsertInstances_DeliberateUnlockStillApplies(t *testing.T) {
+	db := newTestDB(t)
+	seedTitleRow(t, db, "s1", "locked-name", true)
+
+	unlock := &InstanceRow{
+		ID: "s1", Title: "locked-name", ProjectPath: "/p", GroupPath: "",
+		Order: 0, Tool: "claude", Status: "idle", CreatedAt: time.Now(),
+		ToolData: json.RawMessage("{}"), TitleLocked: false,
+	}
+	if err := db.UpsertInstances([]*InstanceRow{unlock}); err != nil {
+		t.Fatalf("UpsertInstances unlock: %v", err)
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if loaded[0].TitleLocked {
+		t.Fatalf("deliberate unlock via UpsertInstances did not apply — title_locked still true")
+	}
+}
+
+// Sequential legitimate renames (both explicitly locked, e.g. the user
+// renames twice) must both apply — this is not the stale-writer scenario.
+func TestUpsertInstances_SequentialLockedRenamesBothApply(t *testing.T) {
+	db := newTestDB(t)
+	seedTitleRow(t, db, "s1", "first-name", true)
+
+	second := &InstanceRow{
+		ID: "s1", Title: "second-name", ProjectPath: "/p", GroupPath: "",
+		Order: 0, Tool: "claude", Status: "idle", CreatedAt: time.Now(),
+		ToolData: json.RawMessage("{}"), TitleLocked: true,
+	}
+	if err := db.UpsertInstances([]*InstanceRow{second}); err != nil {
+		t.Fatalf("UpsertInstances second rename: %v", err)
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if loaded[0].Title != "second-name" || !loaded[0].TitleLocked {
+		t.Fatalf("expected second locked rename to apply, got %+v", loaded[0])
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10254,14 +10254,22 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						postCommit()
 					}
 					// Store pending title change so it survives reload races.
-					// If saveInstances() is skipped (isReloading=true), the reload
-					// replaces h.instances from disk, losing the in-memory rename
-					// AND its lock. loadSessionsMsg re-applies both after reload.
+					// pendingTitleChanges is the reload-recovery net (see the
+					// reapply block in loadSessionsMsg), but it only helps AFTER
+					// a reload happens. Use forceSaveInstances (not saveInstances)
+					// so the lock reaches disk immediately: otherwise the row
+					// sits unlocked on disk for however long it takes a reload to
+					// trigger and reapply, and a Claude hook firing in that
+					// window sees a genuinely-unlocked row (not a stale read) and
+					// legitimately syncs Claude's own name over it before the
+					// rename ever lands — the "first rename doesn't take"
+					// variant of #572/#697. Mirrors the edit-dialog rename path,
+					// which already force-saves for the same reason.
 					h.pendingTitleChanges[sessionID] = pendingTitle{title: newName, locked: locked}
 					// Invalidate preview cache since title changed
 					h.invalidatePreviewCache(sessionID)
 					h.rebuildFlatItems()
-					h.saveInstances()
+					h.forceSaveInstances()
 				}
 			}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10249,6 +10249,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.instancesMu.Unlock()
 					if setErr != nil {
 						h.setError(setErr)
+						break
 					}
 					if postCommit != nil {
 						postCommit()


### PR DESCRIPTION
## What

A renamed session's title could silently revert to Claude's own name (or the folder+number default) sometime after you renamed it.

## Why

Every Claude Code hook spawns a separate `agent-deck hook` process that loads the full instance list, checks `TitleLocked`, and (if unlocked) saves the whole list back. If a rename landed and locked the title between that process's load and its save, the save still wrote the pre-lock state and clobbered the rename.

Second bug, same symptom: the quick-rename path (`r` key) persisted with a save that the reload guard can skip, leaving the row unlocked on disk until a later reload happened to reapply it — a Claude hook firing in that window would win legitimately, since the lock genuinely wasn't on disk yet.

## Fix

- Hook-triggered title sync now writes with `UPDATE ... WHERE title_locked = 0` instead of a full round-trip save, so it can't clobber a lock no matter how stale its read was.
- Quick-rename now force-saves immediately instead of relying on a later reload, matching what the edit-dialog rename path already does.

## Testing

- `go test ./internal/statedb/... ./internal/ui/... ./cmd/agent-deck/...` — all pass
- Added regression tests in `internal/statedb/update_title_if_unlocked_test.go` covering: locked row is a no-op, unlocked row applies, deliberate unlock via `session set-title-lock off` still works, sequential renames still apply
- Manually verified against a built binary: rename, re-rename, unlock, re-lock all behave correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude-derived session titles now persist in a guarded way, updating only when the target session is currently eligible—avoiding overwrites of unrelated changes.
  * Automatic title synchronization no longer interferes with manually locked session titles.
  * Local session renames are saved immediately, preventing brief “unlocked” windows that could trigger unintended sync.
  * iTerm badge and tmux title updates now occur only after the database title change is confirmed.
* **Tests**
  * Added targeted coverage for conditional title updates, lock-state behavior, and related rename/unlock scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->