### PR TITLE
feat(ui): surface worktree setup-script failures in TUI

### DIFF
--- a/internal/ui/fork_state_submit_test.go
+++ b/internal/ui/fork_state_submit_test.go
@@ -92,7 +92,7 @@ func TestForkWithStateWorktree_RefusesExistingPathBeforeCreate(t *testing.T) {
 		return true, nil
 	}
 
-	err := forkWithStateWorktree("parent", "repo", "existing-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	_, err := forkWithStateWorktree("parent", "repo", "existing-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
 	if err == nil || !strings.Contains(err.Error(), "worktree path already exists") {
 		t.Fatalf("error = %v, want existing-path refusal", err)
 	}
@@ -113,7 +113,7 @@ func TestForkWithStateWorktree_RefusesMidOperationBeforeCreate(t *testing.T) {
 		return true, nil
 	}
 
-	err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	_, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
 	if err == nil || !strings.Contains(err.Error(), "git rebase --abort") {
 		t.Fatalf("error = %v, want actionable rebase abort hint", err)
 	}
@@ -137,7 +137,7 @@ func TestForkWithStateWorktree_CleansUpMaterializeFailure(t *testing.T) {
 	deps.removeWorktree = func(string, string, bool) error { removed = true; return nil }
 	deps.deleteBranch = func(string, string, bool) error { deleted = true; return nil }
 
-	err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	_, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
 	if err == nil || !strings.Contains(err.Error(), "new worktree cleaned up") {
 		t.Fatalf("error = %v, want cleaned-up materialize failure", err)
 	}
@@ -159,7 +159,7 @@ func TestForkWithStateWorktree_ReportsManualCleanupWhenCleanupFails(t *testing.T
 	deps.removeWorktree = func(string, string, bool) error { return errors.New("remove failed") }
 	deps.deleteBranch = func(string, string, bool) error { return errors.New("delete failed") }
 
-	err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	_, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
 	if err == nil || !strings.Contains(err.Error(), "manual cleanup required") {
 		t.Fatalf("error = %v, want manual cleanup hint", err)
 	}
@@ -210,7 +210,7 @@ func TestForkWithStateWorktree_UsesParentHead(t *testing.T) {
 	}
 
 	forkPath := filepath.Join(root, "fork")
-	err := forkWithStateWorktree(parent, base, forkPath, "fork/from-parent", git.WorktreeStateOptions{WithState: true}, defaultForkWithStateWorktreeDeps())
+	_, err := forkWithStateWorktree(parent, base, forkPath, "fork/from-parent", git.WorktreeStateOptions{WithState: true}, defaultForkWithStateWorktreeDeps())
 	if err != nil {
 		t.Fatalf("forkWithStateWorktree: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestForkWithStateWorktree_FailsClosedWhenDetectErrors(t *testing.T) {
 		return true, nil
 	}
 
-	err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	_, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
 	if err == nil || !strings.Contains(err.Error(), "failed to inspect parent session state") {
 		t.Fatalf("error = %v, want fail-closed inspect error", err)
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10889,8 +10889,9 @@ const setupWarningMaxLen = 300
 // verbose output stays in the log (see createWorktreeWithSetupAndLog).
 func formatSetupWarning(setupErr error) string {
 	msg := strings.Join(strings.Fields(tmux.StripANSI(setupErr.Error())), " ")
-	if len(msg) > setupWarningMaxLen {
-		msg = msg[:setupWarningMaxLen] + "…"
+	// Truncate by rune, not byte, so a multi-byte character is never split.
+	if runes := []rune(msg); len(runes) > setupWarningMaxLen {
+		msg = string(runes[:setupWarningMaxLen]) + "…"
 	}
 	return "worktree setup script failed: " + msg
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1008,16 +1008,18 @@ type loadSessionsMsg struct {
 }
 
 type sessionCreatedMsg struct {
-	instance *session.Instance
-	err      error
-	tempID   string // matches creatingSessions key for placeholder removal
+	instance     *session.Instance
+	err          error
+	tempID       string // matches creatingSessions key for placeholder removal
+	setupWarning string // non-fatal worktree setup-script failure, shown after a successful create
 }
 
 type sessionForkedMsg struct {
-	instance *session.Instance
-	sourceID string // ID of the source session that was forked (for cleanup)
-	notice   string // non-fatal degradation notice shown after a successful fork
-	err      error
+	instance     *session.Instance
+	sourceID     string // ID of the source session that was forked (for cleanup)
+	notice       string // non-fatal degradation notice shown after a successful fork
+	err          error
+	setupWarning string // non-fatal worktree setup-script failure, shown after a successful fork
 }
 
 type refreshMsg struct{}
@@ -5108,6 +5110,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.instancesMu.Unlock()
 			// Force save to persist the session even during reload
 			h.forceSaveInstances()
+			// Surface a non-fatal setup-script warning without masking any
+			// persistence error forceSaveInstances may have set.
+			if msg.setupWarning != "" {
+				h.setError(noticeError(h.err, msg.setupWarning))
+			}
 			// Trigger another reload to pick up the new session in the UI
 			if h.storageWatcher != nil {
 				h.storageWatcher.TriggerReload()
@@ -5155,6 +5162,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Use forceSave to bypass the external-change abort - new session creation MUST persist
 			h.forceSaveInstances()
 
+			// Surface a non-fatal setup-script warning, folded into any
+			// persistence error so an unsaved session never looks merely degraded.
+			if msg.setupWarning != "" {
+				h.setError(noticeError(h.err, msg.setupWarning))
+			}
+
 			// Auto-attach to the new session when [ui].attach_on_create is set,
 			// so creating a session "instantly opens" it instead of only moving
 			// the cursor to it. The session was just Start()ed (see
@@ -5162,7 +5175,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// attachSession returns nil when there is no local tmux pane to
 			// attach (e.g. a session whose tmux session could not be resolved);
 			// in that case we fall through to today's select-only behavior.
-			if h.attachOnCreate {
+			// Skip auto-attach when a setup warning is pending: attaching would
+			// hide the footer before the user can read it.
+			if h.attachOnCreate && msg.setupWarning == "" {
 				if attachTo := h.attachSession(msg.instance); attachTo != nil {
 					return h, tea.Batch(h.fetchPreview(msg.instance, msg.instance.ID, -1), attachTo)
 				}
@@ -5190,6 +5205,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.instances = append(h.instances, msg.instance)
 			h.instancesMu.Unlock()
 			h.forceSaveInstances()
+			// Surface a non-fatal setup-script warning without masking any
+			// persistence error forceSaveInstances may have set.
+			if msg.setupWarning != "" {
+				h.setError(noticeError(h.err, msg.setupWarning))
+			}
 			if h.storageWatcher != nil {
 				h.storageWatcher.TriggerReload()
 			}
@@ -5240,6 +5260,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// fork that wasn't actually saved doesn't look successful (#1299 review).
 			if msg.notice != "" {
 				h.setError(noticeError(h.err, msg.notice))
+			}
+			// Same for a non-fatal setup-script warning; folding composes it with
+			// any existing error/notice rather than overwriting.
+			if msg.setupWarning != "" {
+				h.setError(noticeError(h.err, msg.setupWarning))
 			}
 
 			// Start fetching preview for the forked session
@@ -10631,6 +10656,8 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	autoName bool,
 ) tea.Cmd {
 	return func() tea.Msg {
+		var setupWarning string // non-fatal worktree setup-script failure, if any
+
 		uiLog.Info("create_session_start",
 			slog.String("name", name),
 			slog.String("path", path),
@@ -10661,8 +10688,12 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 				if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create parent directory: %w", err), tempID: tempID}
 				}
-				if err := createWorktreeWithSetupAndLog(backend, worktreePath, worktreeBranch); err != nil {
+				setupErr, err := createWorktreeWithSetupAndLog(backend, worktreePath, worktreeBranch)
+				if err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create worktree: %w", err), tempID: tempID}
+				}
+				if setupErr != nil {
+					setupWarning = formatSetupWarning(setupErr)
 				}
 			}
 			path = worktreePath
@@ -10824,25 +10855,44 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			return sessionCreatedMsg{err: err, tempID: tempID}
 		}
 		uiLog.Info("session_create_succeeded", slog.String("id", inst.ID))
-		return sessionCreatedMsg{instance: inst, tempID: tempID}
+		return sessionCreatedMsg{instance: inst, tempID: tempID, setupWarning: setupWarning}
 	}
 }
 
 // createWorktreeWithSetupAndLog creates a worktree via the supplied backend.
 // For git backends it also runs .worktreeinclude and worktree-setup.sh; for
 // jujutsu backends only the workspace is created (setup-script behavior is
-// git-only per the vcsbackend convention). Returns only the creation error;
-// setup failures are non-fatal and logged to uiLog.
-func createWorktreeWithSetupAndLog(backend vcs.Backend, wtPath, branch string) error {
+// git-only per the vcsbackend convention).
+//
+// setupErr is the non-fatal setup-script failure (nil on success): the worktree
+// is created regardless, but the caller surfaces setupErr to the user. err is
+// the fatal worktree-creation error. The full setup output is logged here; only
+// the concise setupErr is returned for display (see formatSetupWarning).
+func createWorktreeWithSetupAndLog(backend vcs.Backend, wtPath, branch string) (setupErr error, err error) {
 	var buf bytes.Buffer
-	setupErr, err := vcsbackend.CreateWorktreeWithSetup(backend, wtPath, branch, &buf, &buf, session.GetWorktreeSettings().SetupTimeout())
+	setupErr, err = vcsbackend.CreateWorktreeWithSetup(backend, wtPath, branch, &buf, &buf, session.GetWorktreeSettings().SetupTimeout())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if setupErr != nil {
 		uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", buf.String()))
 	}
-	return nil
+	return setupErr, nil
+}
+
+// setupWarningMaxLen bounds the setup-script failure text shown in the footer,
+// which is height-constrained and auto-dismisses. The full output is in uiLog.
+const setupWarningMaxLen = 300
+
+// formatSetupWarning turns a non-fatal setup-script error into a single bounded,
+// sanitized footer line: ANSI stripped, whitespace collapsed, capped. The
+// verbose output stays in the log (see createWorktreeWithSetupAndLog).
+func formatSetupWarning(setupErr error) string {
+	msg := strings.Join(strings.Fields(tmux.StripANSI(setupErr.Error())), " ")
+	if len(msg) > setupWarningMaxLen {
+		msg = msg[:setupWarningMaxLen] + "…"
+	}
+	return "worktree setup script failed: " + msg
 }
 
 // createSessionTool maps a free-form command to (tool, command). Built-in
@@ -11591,6 +11641,8 @@ func (h *Home) forkSessionCmdWithOptions(
 	sourceID := source.ID // Capture for closure
 
 	return func() tea.Msg {
+		var setupWarning string // non-fatal worktree setup-script failure, if any
+
 		// Check tmux availability before forking
 		if err := tmux.IsTmuxAvailable(); err != nil {
 			return sessionForkedMsg{err: fmt.Errorf("cannot fork session: %w", err), sourceID: sourceID}
@@ -11626,15 +11678,19 @@ func (h *Home) forkSessionCmdWithOptions(
 			if forkState.WithState {
 				switch backend.Type() {
 				case vcs.TypeGit:
-					if err := forkWithStateWorktree(
+					setupErr, err := forkWithStateWorktree(
 						source.ProjectPath,
 						opts.WorktreeRepoRoot,
 						opts.WorktreePath,
 						opts.WorktreeBranch,
 						forkState,
 						defaultForkWithStateWorktreeDeps(),
-					); err != nil {
+					)
+					if err != nil {
 						return sessionForkedMsg{err: err, sourceID: sourceID}
+					}
+					if setupErr != nil {
+						setupWarning = formatSetupWarning(setupErr)
 					}
 				case vcs.TypeJujutsu:
 					if err := forkWithStateWorkspaceJJ(
@@ -11664,8 +11720,12 @@ func (h *Home) forkSessionCmdWithOptions(
 				if err := os.MkdirAll(filepath.Dir(opts.WorktreePath), 0o755); err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("failed to create directory: %w", err), sourceID: sourceID}
 				}
-				if err := createWorktreeWithSetupAndLog(backend, opts.WorktreePath, opts.WorktreeBranch); err != nil {
+				setupErr, err := createWorktreeWithSetupAndLog(backend, opts.WorktreePath, opts.WorktreeBranch)
+				if err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("worktree creation failed: %w", err), sourceID: sourceID}
+				}
+				if setupErr != nil {
+					setupWarning = formatSetupWarning(setupErr)
 				}
 			}
 		}
@@ -11675,7 +11735,7 @@ func (h *Home) forkSessionCmdWithOptions(
 			return sessionForkedMsg{err: err, sourceID: sourceID}
 		}
 
-		return sessionForkedMsg{instance: inst, sourceID: sourceID, notice: forkNotice}
+		return sessionForkedMsg{instance: inst, sourceID: sourceID, notice: forkNotice, setupWarning: setupWarning}
 	}
 }
 
@@ -11722,12 +11782,15 @@ func rollbackForkWithStateWorktree(repoRoot, worktreePath, branch string) error 
 // session's HEAD, and materializes the parent's working-tree state, mirroring
 // the CLI safeguards from #1263. Defined after forkSessionCmdWithOptions so the
 // call site (not this definition) is the structurally-first reference.
-func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, state git.WorktreeStateOptions, deps forkWithStateWorktreeDeps) error {
+//
+// setupErr is the non-fatal setup-script failure (nil on success); the fork is
+// complete regardless, but the caller surfaces it. err is the fatal error.
+func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, state git.WorktreeStateOptions, deps forkWithStateWorktreeDeps) (setupErr error, err error) {
 	if state.WithIgnored {
 		state.WithState = true
 	}
 	if !state.WithState {
-		return errors.New("forkWithStateWorktree called without WithState")
+		return nil, errors.New("forkWithStateWorktree called without WithState")
 	}
 	// Destination collision is the more actionable refusal, so check it before
 	// the local path-existence guard (mirrors #1263's CLI precedence).
@@ -11736,21 +11799,21 @@ func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, st
 		if errors.As(err, &collErr) {
 			switch collErr.Kind {
 			case git.CollisionWorktreeExists:
-				return fmt.Errorf("branch %q already has a worktree at %s; choose a new destination branch for --with-state", collErr.Branch, collErr.Path)
+				return nil, fmt.Errorf("branch %q already has a worktree at %s; choose a new destination branch for --with-state", collErr.Branch, collErr.Path)
 			case git.CollisionBranchExists:
-				return fmt.Errorf("branch %q already exists; choose a new destination branch for --with-state", collErr.Branch)
+				return nil, fmt.Errorf("branch %q already exists; choose a new destination branch for --with-state", collErr.Branch)
 			}
 		}
-		return fmt.Errorf("failed to validate destination: %w", err)
+		return nil, fmt.Errorf("failed to validate destination: %w", err)
 	}
 	if _, statErr := deps.statPath(worktreePath); statErr == nil {
-		return fmt.Errorf("worktree path already exists: %s", worktreePath)
+		return nil, fmt.Errorf("worktree path already exists: %s", worktreePath)
 	} else if !errors.Is(statErr, os.ErrNotExist) {
-		return fmt.Errorf("failed to stat worktree path: %w", statErr)
+		return nil, fmt.Errorf("failed to stat worktree path: %w", statErr)
 	}
 	kind, detectErr := deps.detectInProgressOperation(parentPath)
 	if detectErr != nil {
-		return fmt.Errorf("failed to inspect parent session state: %w", detectErr)
+		return nil, fmt.Errorf("failed to inspect parent session state: %w", detectErr)
 	}
 	if kind != "" {
 		abortCmd := map[string]string{
@@ -11760,21 +11823,21 @@ func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, st
 			"revert":      "git revert --abort",
 			"bisect":      "git bisect reset",
 		}[kind]
-		return fmt.Errorf("parent session is mid-%s; finish or abort the %s before forking with state (cd %q && %s)", kind, kind, parentPath, abortCmd)
+		return nil, fmt.Errorf("parent session is mid-%s; finish or abort the %s before forking with state (cd %q && %s)", kind, kind, parentPath, abortCmd)
 	}
 	if err := deps.mkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
+		return nil, fmt.Errorf("failed to create directory: %w", err)
 	}
 	if deps.hasSubmodules(parentPath) {
 		uiLog.Warn("fork_with_state_submodules_detected", slog.String("parent", parentPath))
 	}
 	parentHead, err := deps.headCommit(parentPath)
 	if err != nil {
-		return fmt.Errorf("failed to resolve parent session HEAD: %w", err)
+		return nil, fmt.Errorf("failed to resolve parent session HEAD: %w", err)
 	}
 	createdBranch, err := deps.createAtStartPoint(repoRoot, worktreePath, branch, parentHead)
 	if err != nil {
-		return fmt.Errorf("worktree creation failed: %w", err)
+		return nil, fmt.Errorf("worktree creation failed: %w", err)
 	}
 	if err := deps.materialize(parentPath, worktreePath, state.WithIgnored); err != nil {
 		var cleanupErrs []string
@@ -11787,24 +11850,27 @@ func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, st
 			}
 		}
 		if len(cleanupErrs) == 0 {
-			return fmt.Errorf("failed to materialize parent state: %w; new worktree cleaned up", err)
+			return nil, fmt.Errorf("failed to materialize parent state: %w; new worktree cleaned up", err)
 		}
 		branchHint := ""
 		if createdBranch {
 			branchHint = fmt.Sprintf(" && git -C %q branch -D %q", repoRoot, branch)
 		}
-		return fmt.Errorf("failed to materialize parent state: %w; cleanup also failed (%s); manual cleanup required: rm -rf %q%s", err, strings.Join(cleanupErrs, "; "), worktreePath, branchHint)
+		return nil, fmt.Errorf("failed to materialize parent state: %w; cleanup also failed (%s); manual cleanup required: rm -rf %q%s", err, strings.Join(cleanupErrs, "; "), worktreePath, branchHint)
 	}
 	if err := deps.processInclude(repoRoot, worktreePath, io.Discard); err != nil {
 		uiLog.Warn("fork_with_state_worktreeinclude_failed", slog.String("path", worktreePath), slog.String("err", err.Error()))
 	}
-	if err := deps.runSetup(repoRoot, worktreePath, io.Discard, io.Discard, session.GetWorktreeSettings().SetupTimeout()); err != nil {
+	var setupBuf bytes.Buffer
+	if scriptErr := deps.runSetup(repoRoot, worktreePath, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout()); scriptErr != nil {
 		// Non-fatal: the worktree and parent state are already created. Mirror
 		// #1263's CLI, which warns on a failed setup script rather than failing
-		// the whole fork.
-		uiLog.Warn("fork_with_state_setup_failed", slog.String("path", worktreePath), slog.String("err", err.Error()))
+		// the whole fork. The full output is logged; the concise error is
+		// returned so the caller can surface it in the UI.
+		uiLog.Warn("fork_with_state_setup_failed", slog.String("path", worktreePath), slog.String("err", scriptErr.Error()), slog.String("output", setupBuf.String()))
+		return scriptErr, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // forkWithStateWorkspaceJJ is the jujutsu equivalent of forkWithStateWorktree:

--- a/internal/ui/worktree_setup_warning_test.go
+++ b/internal/ui/worktree_setup_warning_test.go
@@ -1,0 +1,134 @@
+package ui
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+)
+
+// formatSetupWarning must produce a single bounded, sanitized footer line so a
+// failed worktree setup script can't flood or corrupt the height-constrained,
+// auto-dismissing footer. The full output stays in the log, not here.
+func TestFormatSetupWarning(t *testing.T) {
+	const prefix = "worktree setup script failed: "
+
+	t.Run("plain error keeps its message", func(t *testing.T) {
+		got := formatSetupWarning(errors.New("exit status 1"))
+		if got != prefix+"exit status 1" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("ANSI escapes are stripped", func(t *testing.T) {
+		got := formatSetupWarning(errors.New("\x1b[31mboom\x1b[0m"))
+		if got != prefix+"boom" {
+			t.Fatalf("got %q, want ANSI stripped", got)
+		}
+	})
+
+	t.Run("newlines and runs of whitespace collapse to single spaces", func(t *testing.T) {
+		got := formatSetupWarning(errors.New("line one\n\n  line two\t line three\n"))
+		if got != prefix+"line one line two line three" {
+			t.Fatalf("got %q, want collapsed whitespace", got)
+		}
+	})
+
+	t.Run("long output is truncated with an ellipsis", func(t *testing.T) {
+		got := formatSetupWarning(errors.New(strings.Repeat("x", setupWarningMaxLen+50)))
+		body := strings.TrimPrefix(got, prefix)
+		if !strings.HasSuffix(body, "…") {
+			t.Fatalf("want ellipsis suffix, got %q", body)
+		}
+		// setupWarningMaxLen runes of content + the ellipsis rune.
+		if runes := []rune(body); len(runes) != setupWarningMaxLen+1 {
+			t.Fatalf("body rune length = %d, want %d", len(runes), setupWarningMaxLen+1)
+		}
+	})
+}
+
+// forkWithStateSetupDeps stubs every dependency up to (and including) runSetup so
+// a with-state fork reaches the setup step deterministically without touching a
+// real git repo. runSetup is left for the caller to set.
+func forkWithStateSetupDeps() forkWithStateWorktreeDeps {
+	deps := defaultForkWithStateWorktreeDeps()
+	deps.statPath = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	deps.mkdirAll = func(string, os.FileMode) error { return nil }
+	deps.validateDestination = func(string, string) error { return nil }
+	deps.detectInProgressOperation = func(string) (string, error) { return "", nil }
+	deps.hasSubmodules = func(string) bool { return false }
+	deps.headCommit = func(string) (string, error) { return "abc123", nil }
+	deps.createAtStartPoint = func(string, string, string, string) (bool, error) { return true, nil }
+	deps.materialize = func(string, string, bool) error { return nil }
+	deps.processInclude = func(string, string, io.Writer) error { return nil }
+	return deps
+}
+
+// A failing setup script must NOT fail the with-state fork: the worktree and
+// parent state are already created. The failure is returned as the non-fatal
+// setupErr so the caller can surface it, with the fatal err staying nil.
+func TestForkWithStateWorktree_SetupFailureIsNonFatal(t *testing.T) {
+	deps := forkWithStateSetupDeps()
+	deps.runSetup = func(string, string, io.Writer, io.Writer, time.Duration) error {
+		return errors.New("setup boom")
+	}
+
+	setupErr, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	if err != nil {
+		t.Fatalf("fatal err = %v, want nil (setup failure is non-fatal)", err)
+	}
+	if setupErr == nil || !strings.Contains(setupErr.Error(), "setup boom") {
+		t.Fatalf("setupErr = %v, want the setup-script failure", setupErr)
+	}
+}
+
+// When the setup script succeeds (or is absent), neither error is set.
+func TestForkWithStateWorktree_SetupSuccessNoWarning(t *testing.T) {
+	deps := forkWithStateSetupDeps()
+	deps.runSetup = func(string, string, io.Writer, io.Writer, time.Duration) error { return nil }
+
+	setupErr, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	if err != nil {
+		t.Fatalf("fatal err = %v, want nil", err)
+	}
+	if setupErr != nil {
+		t.Fatalf("setupErr = %v, want nil on setup success", setupErr)
+	}
+}
+
+// A fatal step (here: worktree creation) must return via err, never as a setup
+// warning — the two channels must not be conflated.
+func TestForkWithStateWorktree_FatalErrorIsNotASetupWarning(t *testing.T) {
+	deps := forkWithStateSetupDeps()
+	deps.createAtStartPoint = func(string, string, string, string) (bool, error) {
+		return false, errors.New("create failed")
+	}
+	// runSetup must never run once creation fails.
+	deps.runSetup = func(string, string, io.Writer, io.Writer, time.Duration) error {
+		t.Fatal("runSetup ran after a fatal creation failure")
+		return nil
+	}
+
+	setupErr, err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	if setupErr != nil {
+		t.Fatalf("setupErr = %v, want nil on a fatal failure", setupErr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "worktree creation failed") {
+		t.Fatalf("err = %v, want fatal creation failure", err)
+	}
+}
+
+// Structural guard: the create-session handler must skip auto-attach while a
+// setup warning is pending, otherwise attaching hides the footer before it can
+// be read. Asserted on source because the handler is not unit-testable in
+// isolation (it drives tmux, storage, and preview fetches).
+func TestCreateHandler_SkipsAutoAttachWhenSetupWarningPending(t *testing.T) {
+	src := extractUIFuncBodySource(t, "home.go", "updateInner")
+	if !strings.Contains(src, `h.attachOnCreate && msg.setupWarning == ""`) {
+		t.Fatal("auto-attach must be guarded by msg.setupWarning == \"\" so the warning stays visible")
+	}
+}

--- a/internal/ui/worktree_setup_warning_test.go
+++ b/internal/ui/worktree_setup_warning_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
 )
@@ -45,6 +46,18 @@ func TestFormatSetupWarning(t *testing.T) {
 			t.Fatalf("want ellipsis suffix, got %q", body)
 		}
 		// setupWarningMaxLen runes of content + the ellipsis rune.
+		if runes := []rune(body); len(runes) != setupWarningMaxLen+1 {
+			t.Fatalf("body rune length = %d, want %d", len(runes), setupWarningMaxLen+1)
+		}
+	})
+
+	t.Run("multi-byte output truncates on rune boundaries, stays valid UTF-8", func(t *testing.T) {
+		// Each 'é' is 2 bytes; byte-slicing would split one and corrupt the string.
+		got := formatSetupWarning(errors.New(strings.Repeat("é", setupWarningMaxLen+50)))
+		body := strings.TrimPrefix(got, prefix)
+		if !utf8.ValidString(body) {
+			t.Fatalf("truncated body is not valid UTF-8: %q", body)
+		}
 		if runes := []rune(body); len(runes) != setupWarningMaxLen+1 {
 			t.Fatalf("body rune length = %d, want %d", len(runes), setupWarningMaxLen+1)
 		}


### PR DESCRIPTION
## What

Surface worktree **setup-script failures** (`worktree-setup.sh`) in the TUI. Today they are only logged (`uiLog.Warn`) — the user never learns their new worktree may be incomplete. This shows them as a **non-fatal** warning after a successful session create/fork, without failing the session.

Covered paths:

- ordinary **create** with a worktree
- ordinary **fork** with a worktree
- **with-state git fork** (`forkWithStateWorktree`) — previously sent setup output to `io.Discard` and only logged; now captures it and surfaces the failure

## Why

A failing setup hook silently leaves a half-provisioned worktree. Making the failure visible — while keeping creation successful, matching the CLI's warn-don't-fail behavior from #1263 — lets the user react.

## How

- `createWorktreeWithSetupAndLog` and `forkWithStateWorktree` now use **named returns `(setupErr, err error)`** — a non-fatal setup failure is separate from the fatal creation error. Full setup output stays in the log; only the concise error is returned for display.
- New `setupWarning` field on `sessionCreatedMsg` / `sessionForkedMsg`.
- `formatSetupWarning` produces a single **bounded, ANSI-stripped, whitespace-collapsed** footer line (the footer is height-constrained and auto-dismisses).
- The warning is folded into any existing error via the existing `noticeError` helper (create + fork, normal + reload branches) so it **never masks a fatal persistence error**.
- Auto-attach on create is **skipped while a warning is pending**, otherwise attaching would hide the footer before it can be read.

### Note on severity

`h.setError` renders `ErrorStyle` and logs at error level, so a "warning" is recorded via the error channel. Reusing that channel keeps the change small; happy to switch to a dedicated notice style if preferred.

### Scope

`.worktreeinclude` failures are intentionally **out of scope** — only setup-script failures are propagated.

## Tests

- `formatSetupWarning`: plain / ANSI / multiline / truncation.
- `forkWithStateWorktree`: setup failure is non-fatal (returned as `setupErr`), setup success yields no warning, and a fatal step returns via `err` (never as a warning).
- Structural guard that auto-attach is gated on `msg.setupWarning == ""`.

`go build ./...`, the full `internal/ui` suite, and the new tests all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Worktree setup-script failures now display as sanitized, bounded warnings while keeping session creation and forking unblocked.
  - Automatic attachment is deferred when a setup warning is pending, so the warning stays visible.
- **Bug Fixes**
  - More accurate separation of non-fatal setup warnings vs fatal worktree errors, including fork and cleanup-related flows.
- **Tests**
  - Added tests for warning formatting (ANSI stripping, whitespace cleanup, truncation) and for non-fatal vs fatal behavior, plus auto-attach skipping when warnings exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->