### PR TITLE
feat(config): add [interval_hooks] — run shell commands on a wall-clock interval

### DIFF
--- a/internal/intervalhook/runner.go
+++ b/internal/intervalhook/runner.go
@@ -71,6 +71,13 @@ type Runner struct {
 	// race-free. Tests set it on their instance before calling Start.
 	rescanInterval time.Duration
 
+	// rootCtx is the parent of every hook run's timeout context; rootCancel
+	// cancels it. Stop() calls rootCancel so an in-flight CombinedOutput is
+	// killed (via the per-run process-group kill + WaitDelay) as soon as the
+	// app quits, instead of continuing to run detached until its own timeout.
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+
 	mu     sync.Mutex
 	stopCh chan struct{}
 	// running guards against overlapping runs of the SAME hook: if a hook's
@@ -86,10 +93,13 @@ type Runner struct {
 // New builds a Runner. logger may be nil (panics are still recovered, log
 // records dropped). Call Start to launch the supervisor.
 func New(logger *slog.Logger) *Runner {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Runner{
 		logger:         logger,
 		load:           defaultLoader,
 		rescanInterval: defaultRescanInterval,
+		rootCtx:        ctx,
+		rootCancel:     cancel,
 		stopCh:         make(chan struct{}),
 		running:        make(map[string]bool),
 		supervised:     make(map[string]bool),
@@ -124,18 +134,22 @@ func (r *Runner) Start() {
 	})
 }
 
-// Stop terminates the supervisor and all hook goroutines. Safe to call once.
+// Stop terminates the supervisor and all hook loops, and cancels any in-flight
+// hook run: closing stopCh ends the loops, and rootCancel cancels the shared
+// context every runOnce derives its timeout from, so a command mid-execution is
+// killed (via its process-group kill + WaitDelay) rather than left running
+// detached until its own TimeoutSeconds. Safe to call once; idempotent.
 func (r *Runner) Stop() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if !r.started {
-		return
-	}
 	select {
 	case <-r.stopCh:
 		// already closed
 	default:
 		close(r.stopCh)
+	}
+	if r.rootCancel != nil {
+		r.rootCancel()
 	}
 }
 
@@ -243,7 +257,9 @@ func (r *Runner) runOnce(name string, cfg session.IntervalHookSettings) {
 	}()
 
 	timeout := time.Duration(cfg.GetTimeoutSeconds()) * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	// Derive from the Runner's root context (set in New) so Stop() cancels an
+	// in-flight run instead of leaving it to finish detached.
+	ctx, cancel := context.WithTimeout(r.rootCtx, timeout)
 	defer cancel()
 
 	// The command is user-authored config (config.toml

--- a/internal/intervalhook/runner.go
+++ b/internal/intervalhook/runner.go
@@ -9,9 +9,17 @@
 //
 // Design mirrors internal/sysinfo.Collector (background goroutine +
 // time.NewTicker + stopCh) and internal/session.StartMaintenanceWorker
-// (config re-read each tick so edits to config.toml take effect without a
-// restart). Each hook runs on its own goroutine, wrapped in safego.Go so a
-// panicking command can never take down the TUI.
+// (config re-read so edits to config.toml take effect without a restart).
+//
+// A single SUPERVISOR goroutine rescans config on an interval and reconciles
+// the set of running hook goroutines: it starts a loop for each newly-enabled
+// hook and lets removed/disabled hooks' loops exit. This is what makes live
+// add / pause / resume work without a restart (a hook goroutine started once at
+// boot would never notice a hook added later, and a disabled hook's loop that
+// simply returned could never come back). Each hook loop runs on its own
+// goroutine wrapped in safego.Go so a panicking command can never take down the
+// TUI. Hook commands run in their own process group with a bounded timeout so a
+// daemonizing command cannot wedge its slot forever.
 package intervalhook
 
 import (
@@ -20,19 +28,31 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/safego"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// configLoader returns the current set of interval hooks. It is called once
-// per tick so config.toml edits are picked up live (add/remove/pause a hook,
-// change its cadence) without restarting the TUI. Injected for testability.
+// rescanInterval is how often the supervisor re-reads config to pick up
+// hooks added / removed / enabled / disabled since the last scan. A var (not
+// const) so tests can shorten it; production callers never change it.
+var rescanInterval = 15 * time.Second
+
+// waitDelay bounds how long we wait for a hook's pipes to close after its
+// context is cancelled (i.e. after the timeout kill). Without this, a command
+// that forks a daemon holding stdout/stderr open would block CombinedOutput
+// forever even after the parent is killed.
+const waitDelay = 3 * time.Second
+
+// configLoader returns the current set of interval hooks. It is called by the
+// supervisor each rescan and by each hook loop each tick so config.toml edits
+// are picked up live. Injected for testability.
 type configLoader func() map[string]session.IntervalHookSettings
 
 // defaultLoader reads the hooks from the on-disk user config (mtime-cached by
-// session.LoadUserConfig, so per-tick calls are cheap).
+// session.LoadUserConfig, so frequent calls are cheap).
 func defaultLoader() map[string]session.IntervalHookSettings {
 	cfg, err := session.LoadUserConfig()
 	if err != nil || cfg == nil {
@@ -52,24 +72,28 @@ type Runner struct {
 	// previous invocation is still executing when its next tick fires, the
 	// tick is skipped rather than piling up. Keyed by hook name.
 	running map[string]bool
-	started bool
+	// supervised tracks which hooks currently have a live loop goroutine, so
+	// the supervisor starts a loop only for newly-enabled hooks. Keyed by name.
+	supervised map[string]bool
+	started    bool
 }
 
 // New builds a Runner. logger may be nil (panics are still recovered, log
-// records dropped). Call Start to launch the supervising goroutines.
+// records dropped). Call Start to launch the supervisor.
 func New(logger *slog.Logger) *Runner {
 	return &Runner{
-		logger:  logger,
-		load:    defaultLoader,
-		stopCh:  make(chan struct{}),
-		running: make(map[string]bool),
+		logger:     logger,
+		load:       defaultLoader,
+		stopCh:     make(chan struct{}),
+		running:    make(map[string]bool),
+		supervised: make(map[string]bool),
 	}
 }
 
-// Start launches one supervising goroutine per configured hook. It is a no-op
-// if there are no enabled hooks, and safe to call once (subsequent calls are
-// ignored). Non-blocking: all work happens on background goroutines, so it is
-// safe to call on the UI's critical path (Home.Init).
+// Start launches the supervisor goroutine, which reconciles the running hook
+// set against config now and every rescanInterval thereafter. Safe to call
+// once (subsequent calls are ignored). Non-blocking — safe on the UI critical
+// path (Home.Init).
 func (r *Runner) Start() {
 	r.mu.Lock()
 	if r.started {
@@ -77,21 +101,24 @@ func (r *Runner) Start() {
 		return
 	}
 	r.started = true
-	hooks := r.load()
 	r.mu.Unlock()
 
-	for name, cfg := range hooks {
-		if !cfg.GetEnabled() {
-			continue
+	safego.Go(r.logger, "interval_hook:supervisor", func() {
+		r.reconcile() // start any hooks enabled at boot immediately
+		ticker := time.NewTicker(rescanInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.stopCh:
+				return
+			case <-ticker.C:
+				r.reconcile()
+			}
 		}
-		name, cfg := name, cfg // capture
-		safego.Go(r.logger, "interval_hook:"+name, func() {
-			r.runLoop(name, cfg.RunAtStartup)
-		})
-	}
+	})
 }
 
-// Stop terminates all hook goroutines. Safe to call once.
+// Stop terminates the supervisor and all hook goroutines. Safe to call once.
 func (r *Runner) Stop() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -106,19 +133,49 @@ func (r *Runner) Stop() {
 	}
 }
 
+// reconcile scans config and launches a loop goroutine for each enabled hook
+// that isn't already supervised. Disabled/removed hooks are left to their own
+// loops to notice and exit (which clears their supervised flag). This is the
+// mechanism behind live add / pause / resume.
+func (r *Runner) reconcile() {
+	hooks := r.load()
+	for name, cfg := range hooks {
+		if !cfg.GetEnabled() || strings.TrimSpace(cfg.Command) == "" {
+			continue
+		}
+		r.mu.Lock()
+		alreadyUp := r.supervised[name]
+		if !alreadyUp {
+			r.supervised[name] = true
+		}
+		r.mu.Unlock()
+		if alreadyUp {
+			continue
+		}
+		name, runAtStartup := name, cfg.RunAtStartup // capture
+		safego.Go(r.logger, "interval_hook:"+name, func() {
+			r.runLoop(name, runAtStartup)
+		})
+	}
+}
+
 // runLoop drives a single hook. The cadence and command are re-read from config
 // each tick (via r.currentHook) so live edits take effect; if the hook is
-// removed or disabled, the loop exits cleanly.
+// removed or disabled, the loop exits and clears its supervised flag so the
+// supervisor will restart it on re-enable.
 func (r *Runner) runLoop(name string, runAtStartup bool) {
+	defer func() {
+		r.mu.Lock()
+		delete(r.supervised, name)
+		r.mu.Unlock()
+	}()
+
 	if runAtStartup {
 		if cfg, ok := r.currentHook(name); ok {
 			r.runOnce(name, cfg)
 		}
 	}
 
-	// Seed the ticker from the current interval; re-arm it if the interval
-	// changes across ticks (StartMaintenanceWorker re-reads config per tick,
-	// but its cadence is fixed — here the cadence itself is user-tunable).
 	cfg, ok := r.currentHook(name)
 	if !ok {
 		return
@@ -134,7 +191,8 @@ func (r *Runner) runLoop(name string, runAtStartup bool) {
 		case <-ticker.C:
 			cfg, ok := r.currentHook(name)
 			if !ok {
-				// Hook removed or disabled at runtime — stop supervising it.
+				// Hook removed or disabled at runtime — exit; the supervisor
+				// re-launches this loop if the hook is re-enabled later.
 				return
 			}
 			r.runOnce(name, cfg)
@@ -182,26 +240,50 @@ func (r *Runner) runOnce(name string, cfg session.IntervalHookSettings) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// #nosec G204 -- The command is user-authored config (config.toml
+	// The command is user-authored config (config.toml
 	// [interval_hooks.<name>].command), run intentionally on the user's own
 	// machine, exactly like a crontab entry. It is passed as a single argv
 	// element to `bash -lc`, matching the vetted convention in
 	// internal/tmux.buildBashLCCommand. No external/untrusted input reaches it.
+	// #nosec G204
 	cmd := exec.CommandContext(ctx, bashPath(), "-lc", cfg.Command)
+	// Run the command in its OWN process group so a hook that forks children
+	// (e.g. daemonizes) can be killed as a group on timeout, not just the
+	// direct child. CommandContext kills only cmd.Process; the negative-PID
+	// kill below reaches the whole group.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Kill the process GROUP (negative pgid). Falls back to the single
+		// process if the group signal fails.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	// Bound how long we wait for pipes to close after Cancel fires, so a
+	// forked daemon holding stdout/stderr open cannot block us forever.
+	cmd.WaitDelay = waitDelay
+
 	start := time.Now()
 	out, err := cmd.CombinedOutput()
 	elapsed := time.Since(start)
 
 	if r.logger != nil {
-		if err != nil {
+		switch {
+		case err != nil:
 			r.logger.Warn("interval_hook_failed",
 				slog.String("hook", name),
 				slog.Duration("elapsed", elapsed),
 				slog.Any("error", err),
 				slog.String("output", truncate(string(out), 500)),
 			)
-		} else {
-			r.logger.Debug("interval_hook_ran",
+		default:
+			// INFO (not DEBUG): a periodic exec primitive should leave a
+			// visible trace each time it fires, per maintainer review on #1628.
+			r.logger.Info("interval_hook_ran",
 				slog.String("hook", name),
 				slog.Duration("elapsed", elapsed),
 			)

--- a/internal/intervalhook/runner.go
+++ b/internal/intervalhook/runner.go
@@ -35,10 +35,11 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// rescanInterval is how often the supervisor re-reads config to pick up
-// hooks added / removed / enabled / disabled since the last scan. A var (not
-// const) so tests can shorten it; production callers never change it.
-var rescanInterval = 15 * time.Second
+// defaultRescanInterval is how often the supervisor re-reads config to pick up
+// hooks added / removed / enabled / disabled since the last scan. Held per-Runner
+// (r.rescanInterval) rather than as a mutable global so tests can shorten it on
+// their own instance without a data race against the supervisor goroutine.
+const defaultRescanInterval = 15 * time.Second
 
 // waitDelay bounds how long we wait for a hook's pipes to close after its
 // context is cancelled (i.e. after the timeout kill). Without this, a command
@@ -65,6 +66,10 @@ func defaultLoader() map[string]session.IntervalHookSettings {
 type Runner struct {
 	logger *slog.Logger
 	load   configLoader
+	// rescanInterval is the supervisor's config-rescan cadence. Set once in New
+	// and never mutated after Start, so the supervisor goroutine reads it
+	// race-free. Tests set it on their instance before calling Start.
+	rescanInterval time.Duration
 
 	mu     sync.Mutex
 	stopCh chan struct{}
@@ -82,11 +87,12 @@ type Runner struct {
 // records dropped). Call Start to launch the supervisor.
 func New(logger *slog.Logger) *Runner {
 	return &Runner{
-		logger:     logger,
-		load:       defaultLoader,
-		stopCh:     make(chan struct{}),
-		running:    make(map[string]bool),
-		supervised: make(map[string]bool),
+		logger:         logger,
+		load:           defaultLoader,
+		rescanInterval: defaultRescanInterval,
+		stopCh:         make(chan struct{}),
+		running:        make(map[string]bool),
+		supervised:     make(map[string]bool),
 	}
 }
 
@@ -105,7 +111,7 @@ func (r *Runner) Start() {
 
 	safego.Go(r.logger, "interval_hook:supervisor", func() {
 		r.reconcile() // start any hooks enabled at boot immediately
-		ticker := time.NewTicker(rescanInterval)
+		ticker := time.NewTicker(r.rescanInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/internal/intervalhook/runner.go
+++ b/internal/intervalhook/runner.go
@@ -1,0 +1,227 @@
+// Package intervalhook runs user-configured shell commands on a wall-clock
+// interval while the TUI is running, independent of session activity.
+//
+// It is a general-purpose "cron inside the TUI" primitive: each configured
+// hook (see session.IntervalHookSettings) is a shell command plus a cadence.
+// Typical uses are a periodic sync, a health probe, or a poll that dispatches
+// work to sessions via the `agent-deck session` CLI. The runner owns no domain
+// logic — it just executes the command on schedule and logs the outcome.
+//
+// Design mirrors internal/sysinfo.Collector (background goroutine +
+// time.NewTicker + stopCh) and internal/session.StartMaintenanceWorker
+// (config re-read each tick so edits to config.toml take effect without a
+// restart). Each hook runs on its own goroutine, wrapped in safego.Go so a
+// panicking command can never take down the TUI.
+package intervalhook
+
+import (
+	"context"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/safego"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// configLoader returns the current set of interval hooks. It is called once
+// per tick so config.toml edits are picked up live (add/remove/pause a hook,
+// change its cadence) without restarting the TUI. Injected for testability.
+type configLoader func() map[string]session.IntervalHookSettings
+
+// defaultLoader reads the hooks from the on-disk user config (mtime-cached by
+// session.LoadUserConfig, so per-tick calls are cheap).
+func defaultLoader() map[string]session.IntervalHookSettings {
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		return nil
+	}
+	return cfg.IntervalHooks
+}
+
+// Runner supervises all configured interval hooks.
+type Runner struct {
+	logger *slog.Logger
+	load   configLoader
+
+	mu     sync.Mutex
+	stopCh chan struct{}
+	// running guards against overlapping runs of the SAME hook: if a hook's
+	// previous invocation is still executing when its next tick fires, the
+	// tick is skipped rather than piling up. Keyed by hook name.
+	running map[string]bool
+	started bool
+}
+
+// New builds a Runner. logger may be nil (panics are still recovered, log
+// records dropped). Call Start to launch the supervising goroutines.
+func New(logger *slog.Logger) *Runner {
+	return &Runner{
+		logger:  logger,
+		load:    defaultLoader,
+		stopCh:  make(chan struct{}),
+		running: make(map[string]bool),
+	}
+}
+
+// Start launches one supervising goroutine per configured hook. It is a no-op
+// if there are no enabled hooks, and safe to call once (subsequent calls are
+// ignored). Non-blocking: all work happens on background goroutines, so it is
+// safe to call on the UI's critical path (Home.Init).
+func (r *Runner) Start() {
+	r.mu.Lock()
+	if r.started {
+		r.mu.Unlock()
+		return
+	}
+	r.started = true
+	hooks := r.load()
+	r.mu.Unlock()
+
+	for name, cfg := range hooks {
+		if !cfg.GetEnabled() {
+			continue
+		}
+		name, cfg := name, cfg // capture
+		safego.Go(r.logger, "interval_hook:"+name, func() {
+			r.runLoop(name, cfg.RunAtStartup)
+		})
+	}
+}
+
+// Stop terminates all hook goroutines. Safe to call once.
+func (r *Runner) Stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.started {
+		return
+	}
+	select {
+	case <-r.stopCh:
+		// already closed
+	default:
+		close(r.stopCh)
+	}
+}
+
+// runLoop drives a single hook. The cadence and command are re-read from config
+// each tick (via r.currentHook) so live edits take effect; if the hook is
+// removed or disabled, the loop exits cleanly.
+func (r *Runner) runLoop(name string, runAtStartup bool) {
+	if runAtStartup {
+		if cfg, ok := r.currentHook(name); ok {
+			r.runOnce(name, cfg)
+		}
+	}
+
+	// Seed the ticker from the current interval; re-arm it if the interval
+	// changes across ticks (StartMaintenanceWorker re-reads config per tick,
+	// but its cadence is fixed — here the cadence itself is user-tunable).
+	cfg, ok := r.currentHook(name)
+	if !ok {
+		return
+	}
+	interval := time.Duration(cfg.GetIntervalSeconds()) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-ticker.C:
+			cfg, ok := r.currentHook(name)
+			if !ok {
+				// Hook removed or disabled at runtime — stop supervising it.
+				return
+			}
+			r.runOnce(name, cfg)
+			if newInterval := time.Duration(cfg.GetIntervalSeconds()) * time.Second; newInterval != interval {
+				interval = newInterval
+				ticker.Reset(interval)
+			}
+		}
+	}
+}
+
+// currentHook re-reads the named hook from config, returning false if it is
+// gone or disabled.
+func (r *Runner) currentHook(name string) (session.IntervalHookSettings, bool) {
+	hooks := r.load()
+	cfg, ok := hooks[name]
+	if !ok || !cfg.GetEnabled() || strings.TrimSpace(cfg.Command) == "" {
+		return session.IntervalHookSettings{}, false
+	}
+	return cfg, true
+}
+
+// runOnce executes the hook's command once, bounded by its timeout. Overlapping
+// runs of the same hook are skipped: if the previous invocation is still going
+// when this tick fires, we log and return rather than stack processes.
+func (r *Runner) runOnce(name string, cfg session.IntervalHookSettings) {
+	r.mu.Lock()
+	if r.running[name] {
+		r.mu.Unlock()
+		if r.logger != nil {
+			r.logger.Warn("interval_hook_overlap_skipped", slog.String("hook", name))
+		}
+		return
+	}
+	r.running[name] = true
+	r.mu.Unlock()
+
+	defer func() {
+		r.mu.Lock()
+		delete(r.running, name)
+		r.mu.Unlock()
+	}()
+
+	timeout := time.Duration(cfg.GetTimeoutSeconds()) * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// #nosec G204 -- The command is user-authored config (config.toml
+	// [interval_hooks.<name>].command), run intentionally on the user's own
+	// machine, exactly like a crontab entry. It is passed as a single argv
+	// element to `bash -lc`, matching the vetted convention in
+	// internal/tmux.buildBashLCCommand. No external/untrusted input reaches it.
+	cmd := exec.CommandContext(ctx, bashPath(), "-lc", cfg.Command)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if r.logger != nil {
+		if err != nil {
+			r.logger.Warn("interval_hook_failed",
+				slog.String("hook", name),
+				slog.Duration("elapsed", elapsed),
+				slog.Any("error", err),
+				slog.String("output", truncate(string(out), 500)),
+			)
+		} else {
+			r.logger.Debug("interval_hook_ran",
+				slog.String("hook", name),
+				slog.Duration("elapsed", elapsed),
+			)
+		}
+	}
+}
+
+// bashPath resolves the bash binary, falling back to the conventional path.
+func bashPath() string {
+	if p, err := exec.LookPath("bash"); err == nil {
+		return p
+	}
+	return "/bin/bash"
+}
+
+// truncate bounds captured output in a log line.
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…(truncated)"
+}

--- a/internal/intervalhook/runner_test.go
+++ b/internal/intervalhook/runner_test.go
@@ -14,11 +14,12 @@ import (
 // and a fresh stop channel.
 func newTestRunner(load configLoader) *Runner {
 	return &Runner{
-		logger:     nil,
-		load:       load,
-		stopCh:     make(chan struct{}),
-		running:    make(map[string]bool),
-		supervised: make(map[string]bool),
+		logger:         nil,
+		load:           load,
+		rescanInterval: defaultRescanInterval,
+		stopCh:         make(chan struct{}),
+		running:        make(map[string]bool),
+		supervised:     make(map[string]bool),
 	}
 }
 
@@ -161,11 +162,11 @@ func TestSupervisor_LiveReEnable(t *testing.T) {
 			},
 		}
 	}
-	// Short rescan so the test doesn't wait the production 15s.
+	// Short rescan so the test doesn't wait the production 15s. Set on the
+	// instance BEFORE Start (never mutated after), so the supervisor goroutine
+	// reads it race-free.
 	r := newTestRunner(load)
-	origInterval := rescanInterval
-	rescanInterval = 150 * time.Millisecond
-	defer func() { rescanInterval = origInterval }()
+	r.rescanInterval = 150 * time.Millisecond
 
 	r.Start()
 	defer r.Stop()

--- a/internal/intervalhook/runner_test.go
+++ b/internal/intervalhook/runner_test.go
@@ -1,6 +1,7 @@
 package intervalhook
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -10,13 +11,17 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// newTestRunner builds a Runner with an injected loader (no config.toml I/O)
-// and a fresh stop channel.
+// newTestRunner builds a Runner with an injected loader (no config.toml I/O),
+// mirroring New's field init (incl. the root context) so runOnce/Stop behave
+// exactly as in production.
 func newTestRunner(load configLoader) *Runner {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Runner{
 		logger:         nil,
 		load:           load,
 		rescanInterval: defaultRescanInterval,
+		rootCtx:        ctx,
+		rootCancel:     cancel,
 		stopCh:         make(chan struct{}),
 		running:        make(map[string]bool),
 		supervised:     make(map[string]bool),
@@ -65,6 +70,46 @@ func TestRunOnce_TimeoutKillsCommand(t *testing.T) {
 	r.runOnce("slow", hook)
 	if elapsed := time.Since(start); elapsed > 3*time.Second {
 		t.Fatalf("timeout not enforced: runOnce took %v (want < 3s)", elapsed)
+	}
+}
+
+// TestStop_CancelsInFlightRun is the regression test for the #1628 review item:
+// Stop() must cancel a hook mid-execution (via the shared root context), not
+// leave it running until its own (long) timeout. A `sleep 30` hook with a large
+// timeout is started; Stop() during the run must let runOnce return promptly.
+func TestStop_CancelsInFlightRun(t *testing.T) {
+	r := newTestRunner(nil)
+	// Long command + long timeout: without cancellation, runOnce would block ~30s.
+	hook := session.IntervalHookSettings{Command: "sleep 30", TimeoutSeconds: 30}
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		r.runOnce("inflight", hook)
+		done <- time.Since(start)
+	}()
+
+	// Wait for the run to actually start (the running flag is set under mu).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		up := r.running["inflight"]
+		r.mu.Unlock()
+		if up {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	r.Stop() // must cancel the in-flight run's context
+
+	select {
+	case elapsed := <-done:
+		if elapsed > 5*time.Second {
+			t.Fatalf("Stop did not cancel the in-flight run: runOnce took %v (want < 5s)", elapsed)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("in-flight run did not return within 6s after Stop (not cancelled)")
 	}
 }
 

--- a/internal/intervalhook/runner_test.go
+++ b/internal/intervalhook/runner_test.go
@@ -14,10 +14,11 @@ import (
 // and a fresh stop channel.
 func newTestRunner(load configLoader) *Runner {
 	return &Runner{
-		logger:  nil,
-		load:    load,
-		stopCh:  make(chan struct{}),
-		running: make(map[string]bool),
+		logger:     nil,
+		load:       load,
+		stopCh:     make(chan struct{}),
+		running:    make(map[string]bool),
+		supervised: make(map[string]bool),
 	}
 }
 
@@ -118,23 +119,74 @@ func TestStart_DisabledHookDoesNotRun(t *testing.T) {
 }
 
 func TestStart_Idempotent(t *testing.T) {
-	var calls int
-	var mu sync.Mutex
-	load := func() map[string]session.IntervalHookSettings {
-		mu.Lock()
-		calls++
-		mu.Unlock()
-		return nil
-	}
+	// Start launches an async supervisor; calling it twice must not launch a
+	// second one. We can't count loader calls (the supervisor loads on its own
+	// goroutine + on a timer), so assert the started guard directly.
+	load := func() map[string]session.IntervalHookSettings { return nil }
 	r := newTestRunner(load)
 	r.Start()
 	r.Start() // second call must be a no-op (started guard)
 	defer r.Stop()
 
-	mu.Lock()
-	got := calls
-	mu.Unlock()
-	if got != 1 {
-		t.Fatalf("Start called loader %d times, want 1 (not idempotent)", got)
+	r.mu.Lock()
+	started := r.started
+	r.mu.Unlock()
+	if !started {
+		t.Fatal("Start did not set the started guard")
 	}
+	// A second Start must not have re-armed anything: Stop must cleanly close
+	// once (a double-close would panic). This exercises the guard end-to-end.
+}
+
+// TestSupervisor_LiveReEnable is the regression test for the #1628 review item:
+// a hook disabled at boot must START running once it is re-enabled in config,
+// without a restart. The supervisor rescans, so re-enabling brings it to life.
+func TestSupervisor_LiveReEnable(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "reenabled")
+
+	var mu sync.Mutex
+	enabled := false // starts DISABLED
+	load := func() map[string]session.IntervalHookSettings {
+		mu.Lock()
+		en := enabled
+		mu.Unlock()
+		e := en
+		return map[string]session.IntervalHookSettings{
+			"toggle": {
+				Command:         "printf on > " + marker,
+				RunAtStartup:    true,
+				IntervalSeconds: 3600, // only the run-at-startup fire matters
+				Enabled:         &e,
+			},
+		}
+	}
+	// Short rescan so the test doesn't wait the production 15s.
+	r := newTestRunner(load)
+	origInterval := rescanInterval
+	rescanInterval = 150 * time.Millisecond
+	defer func() { rescanInterval = origInterval }()
+
+	r.Start()
+	defer r.Stop()
+
+	// While disabled, the marker must NOT appear.
+	time.Sleep(300 * time.Millisecond)
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("disabled hook ran before being enabled")
+	}
+
+	// Re-enable in config; the supervisor's next rescan should launch it.
+	mu.Lock()
+	enabled = true
+	mu.Unlock()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return // success: hook came to life after re-enable, no restart
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("re-enabled hook did not start within 3s (live re-enable broken)")
 }

--- a/internal/intervalhook/runner_test.go
+++ b/internal/intervalhook/runner_test.go
@@ -1,0 +1,140 @@
+package intervalhook
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// newTestRunner builds a Runner with an injected loader (no config.toml I/O)
+// and a fresh stop channel.
+func newTestRunner(load configLoader) *Runner {
+	return &Runner{
+		logger:  nil,
+		load:    load,
+		stopCh:  make(chan struct{}),
+		running: make(map[string]bool),
+	}
+}
+
+func TestRunOnce_ExecutesCommand(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+	hook := session.IntervalHookSettings{
+		Command: "printf ok > " + marker,
+	}
+	r := newTestRunner(nil)
+	r.runOnce("test", hook)
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("command did not run (marker not written): %v", err)
+	}
+	if string(got) != "ok" {
+		t.Fatalf("marker = %q, want %q", string(got), "ok")
+	}
+}
+
+func TestRunOnce_OverlapSkipped(t *testing.T) {
+	// Mark a hook as already running; runOnce must skip (not write the marker).
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ran")
+	r := newTestRunner(nil)
+	r.mu.Lock()
+	r.running["busy"] = true
+	r.mu.Unlock()
+
+	r.runOnce("busy", session.IntervalHookSettings{Command: "printf ok > " + marker})
+
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("overlapping run was not skipped: marker was written")
+	}
+}
+
+func TestRunOnce_TimeoutKillsCommand(t *testing.T) {
+	// A 1s-timeout hook running `sleep 5` must return well before 5s.
+	r := newTestRunner(nil)
+	hook := session.IntervalHookSettings{Command: "sleep 5", TimeoutSeconds: 1}
+	start := time.Now()
+	r.runOnce("slow", hook)
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("timeout not enforced: runOnce took %v (want < 3s)", elapsed)
+	}
+}
+
+func TestStart_RunAtStartupFiresImmediately(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "startup")
+	load := func() map[string]session.IntervalHookSettings {
+		return map[string]session.IntervalHookSettings{
+			"boot": {
+				Command:      "printf up > " + marker,
+				RunAtStartup: true,
+				// Large interval so only the startup run fires during the test.
+				IntervalSeconds: 3600,
+			},
+		}
+	}
+	r := newTestRunner(load)
+	r.Start()
+	defer r.Stop()
+
+	// Poll briefly for the startup run.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			return // success
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("run_at_startup command did not fire within 2s")
+}
+
+func TestStart_DisabledHookDoesNotRun(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "should-not-exist")
+	disabled := false
+	load := func() map[string]session.IntervalHookSettings {
+		return map[string]session.IntervalHookSettings{
+			"off": {
+				Command:      "printf x > " + marker,
+				RunAtStartup: true,
+				Enabled:      &disabled,
+			},
+		}
+	}
+	r := newTestRunner(load)
+	r.Start()
+	defer r.Stop()
+
+	time.Sleep(300 * time.Millisecond)
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("disabled hook ran")
+	}
+}
+
+func TestStart_Idempotent(t *testing.T) {
+	var calls int
+	var mu sync.Mutex
+	load := func() map[string]session.IntervalHookSettings {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return nil
+	}
+	r := newTestRunner(load)
+	r.Start()
+	r.Start() // second call must be a no-op (started guard)
+	defer r.Stop()
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("Start called loader %d times, want 1 (not idempotent)", got)
+	}
+}

--- a/internal/session/interval_hooks_test.go
+++ b/internal/session/interval_hooks_test.go
@@ -1,0 +1,65 @@
+package session
+
+import "testing"
+
+// boolPtr is defined in gemini_yolo_test.go (same package).
+
+func TestIntervalHookSettings_GetEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		h    IntervalHookSettings
+		want bool
+	}{
+		{"command set, enabled unset -> true", IntervalHookSettings{Command: "echo hi"}, true},
+		{"command empty, enabled unset -> false", IntervalHookSettings{}, false},
+		{"command whitespace only -> false", IntervalHookSettings{Command: "   "}, false},
+		{"explicit enabled=false pauses", IntervalHookSettings{Command: "echo hi", Enabled: boolPtr(false)}, false},
+		{"explicit enabled=true with no command -> true", IntervalHookSettings{Enabled: boolPtr(true)}, true},
+	}
+	for _, c := range cases {
+		if got := c.h.GetEnabled(); got != c.want {
+			t.Errorf("%s: GetEnabled() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIntervalHookSettings_GetIntervalSeconds(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{0, DefaultIntervalHookSeconds},                     // unset -> default
+		{-5, DefaultIntervalHookSeconds},                    // negative -> default
+		{1, MinIntervalHookSeconds},                         // below floor -> clamp up
+		{5, 5},                                              // at floor
+		{60, 60},                                            // normal
+		{999999, MaxIntervalHookSeconds},                    // above ceiling -> clamp down
+	}
+	for _, c := range cases {
+		h := IntervalHookSettings{IntervalSeconds: c.in}
+		if got := h.GetIntervalSeconds(); got != c.want {
+			t.Errorf("GetIntervalSeconds(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIntervalHookSettings_GetTimeoutSeconds(t *testing.T) {
+	cases := []struct {
+		name            string
+		intervalSeconds int
+		timeoutSeconds  int
+		want            int
+	}{
+		{"unset -> min(default, interval)", 60, 0, DefaultIntervalHookTimeout},
+		{"unset, small interval -> interval", 10, 0, 10},
+		{"explicit within bounds", 60, 15, 15},
+		{"explicit exceeds interval -> clamp to interval", 30, 120, 30},
+		{"negative -> default", 60, -3, DefaultIntervalHookTimeout},
+	}
+	for _, c := range cases {
+		h := IntervalHookSettings{IntervalSeconds: c.intervalSeconds, TimeoutSeconds: c.timeoutSeconds}
+		if got := h.GetTimeoutSeconds(); got != c.want {
+			t.Errorf("%s: GetTimeoutSeconds() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/session/interval_hooks_test.go
+++ b/internal/session/interval_hooks_test.go
@@ -28,12 +28,12 @@ func TestIntervalHookSettings_GetIntervalSeconds(t *testing.T) {
 		in   int
 		want int
 	}{
-		{0, DefaultIntervalHookSeconds},                     // unset -> default
-		{-5, DefaultIntervalHookSeconds},                    // negative -> default
-		{1, MinIntervalHookSeconds},                         // below floor -> clamp up
-		{5, 5},                                              // at floor
-		{60, 60},                                            // normal
-		{999999, MaxIntervalHookSeconds},                    // above ceiling -> clamp down
+		{0, DefaultIntervalHookSeconds},  // unset -> default
+		{-5, DefaultIntervalHookSeconds}, // negative -> default
+		{1, MinIntervalHookSeconds},      // below floor -> clamp up
+		{5, 5},                           // at floor
+		{60, 60},                         // normal
+		{999999, MaxIntervalHookSeconds}, // above ceiling -> clamp down
 	}
 	for _, c := range cases {
 		h := IntervalHookSettings{IntervalSeconds: c.in}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -220,6 +220,11 @@ type UserConfig struct {
 	// Watcher defines event watcher settings
 	Watcher WatcherSettings `toml:"watcher,omitempty"`
 
+	// IntervalHooks defines shell commands run on a wall-clock interval while
+	// the TUI is running, independent of session activity. Keyed by a
+	// user-chosen name (used in logs). See IntervalHookSettings.
+	IntervalHooks map[string]IntervalHookSettings `toml:"interval_hooks,omitempty"`
+
 	// Feedback defines in-product feedback prompt settings (v1.7.38+).
 	// Mirrors the opt-out in ~/.agent-deck/feedback-state.json so it is visible
 	// to the user and editable without running `agent-deck feedback`.
@@ -4638,6 +4643,86 @@ func (s SystemStatsSettings) GetShow() []string {
 		return s.Show
 	}
 	return []string{"cpu", "ram", "disk", "network"}
+}
+
+// IntervalHookSettings configures a single interval hook: a shell command run
+// on a wall-clock cadence while the TUI is running, independent of any session
+// activity. This is a general-purpose "cron inside the TUI" primitive — e.g. a
+// periodic sync, a health probe, or a poll that dispatches work to sessions via
+// the `agent-deck session` CLI. The command runs through `bash -lc`.
+type IntervalHookSettings struct {
+	// Command is the shell command to run each tick (via `bash -lc <command>`).
+	Command string `toml:"command,omitempty"`
+
+	// IntervalSeconds is the cadence between runs. Clamped to [5, 86400].
+	// Default: 60.
+	IntervalSeconds int `toml:"interval_seconds,omitzero"`
+
+	// Enabled gates the hook. Defaults to true when a Command is set, so a
+	// bare [interval_hooks.name] with a command is live without extra config;
+	// set false to keep the config but pause it.
+	Enabled *bool `toml:"enabled,omitempty"`
+
+	// TimeoutSeconds bounds a single run; a hook exceeding it is killed so a
+	// wedged command can't pile up. Clamped to [1, IntervalSeconds]. Default:
+	// min(30, interval).
+	TimeoutSeconds int `toml:"timeout_seconds,omitzero"`
+
+	// RunAtStartup runs the command once immediately when the TUI starts,
+	// before the first interval elapses. Default: false.
+	RunAtStartup bool `toml:"run_at_startup,omitempty"`
+}
+
+// Interval-hook bounds. IntervalSeconds has a 5s floor so a misconfigured hook
+// can't busy-loop, and a 1-day ceiling.
+const (
+	DefaultIntervalHookSeconds = 60
+	MinIntervalHookSeconds     = 5
+	MaxIntervalHookSeconds     = 86400
+	DefaultIntervalHookTimeout = 30
+)
+
+// GetEnabled reports whether the hook should run. A hook with a non-empty
+// Command defaults to enabled; an explicit `enabled = false` pauses it.
+func (h IntervalHookSettings) GetEnabled() bool {
+	if h.Enabled != nil {
+		return *h.Enabled
+	}
+	return strings.TrimSpace(h.Command) != ""
+}
+
+// GetIntervalSeconds returns the cadence, clamped to
+// [MinIntervalHookSeconds, MaxIntervalHookSeconds]. Unset falls back to
+// DefaultIntervalHookSeconds.
+func (h IntervalHookSettings) GetIntervalSeconds() int {
+	if h.IntervalSeconds <= 0 {
+		return DefaultIntervalHookSeconds
+	}
+	if h.IntervalSeconds < MinIntervalHookSeconds {
+		return MinIntervalHookSeconds
+	}
+	if h.IntervalSeconds > MaxIntervalHookSeconds {
+		return MaxIntervalHookSeconds
+	}
+	return h.IntervalSeconds
+}
+
+// GetTimeoutSeconds returns the per-run timeout, clamped to
+// [1, GetIntervalSeconds()]. Unset falls back to min(DefaultIntervalHookTimeout,
+// interval) so a run never outlives its own cadence.
+func (h IntervalHookSettings) GetTimeoutSeconds() int {
+	interval := h.GetIntervalSeconds()
+	t := h.TimeoutSeconds
+	if t <= 0 {
+		t = DefaultIntervalHookTimeout
+	}
+	if t > interval {
+		t = interval
+	}
+	if t < 1 {
+		t = 1
+	}
+	return t
 }
 
 // WatcherSettings configures the event watcher system.

--- a/internal/tmux/softkill_test.go
+++ b/internal/tmux/softkill_test.go
@@ -121,6 +121,25 @@ func waitForPidAlive(pid int, d time.Duration) {
 	}
 }
 
+// waitForFile polls until path exists or the deadline passes, returning the
+// last os.Stat error (nil on success). Used to assert on marker files a child
+// writes asynchronously from a signal handler — the write can be delayed on a
+// loaded CI runner under -race, so a fixed sleep-then-Stat flakes; polling
+// asserts the liveness property ("the file eventually appears") without racing.
+func waitForFile(path string, d time.Duration) error {
+	deadline := time.Now().Add(d)
+	var err error
+	for {
+		if _, err = os.Stat(path); err == nil {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestKillStaleControlClients_TerminatesCleanlyOnSIGTERM asserts that
 // softKillProcess sends SIGTERM first and allows the target to shut down
 // cleanly — proven by a marker file the child writes from its SIGTERM
@@ -177,7 +196,15 @@ func TestKillStaleControlClients_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 	// cleanly. Asserting on marker-existence captures the real
 	// regression guarantee (SIGTERM ran before SIGKILL) without the
 	// test-specific zombie race.
-	_, err := os.Stat(marker)
+	//
+	// POLL for the marker rather than a single Stat: the child writes it
+	// from an async SIGTERM handler, and on a loaded CI runner under -race
+	// that write can land after the fixed grace windows above. The property
+	// under test is liveness ("the handler eventually ran"), so poll until
+	// present with a generous deadline — a genuinely-missing marker (the #737
+	// straight-to-SIGKILL regression) still fails after the timeout, while a
+	// merely-slow write no longer flakes.
+	err := waitForFile(marker, 5*time.Second)
 	assert.NoError(t, err, "child's SIGTERM handler must have run (marker file must exist)")
 
 	// Process should be gone.
@@ -284,8 +311,9 @@ func TestControlPipeClose_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 
 	// Marker existence proves the SIGTERM handler ran — SIGKILL cannot
 	// be trapped, so a missing marker means softKillProcessGroup
-	// skipped SIGTERM and went straight to SIGKILL.
-	_, err = os.Stat(marker)
+	// skipped SIGTERM and went straight to SIGKILL. Poll (not a single
+	// Stat) for the async handler write — see waitForFile.
+	err = waitForFile(marker, 5*time.Second)
 	assert.NoError(t, err, "child's SIGTERM handler must have run (marker file must exist)")
 
 	err = syscall.Kill(pid, 0)

--- a/internal/tmux/softkill_test.go
+++ b/internal/tmux/softkill_test.go
@@ -207,6 +207,14 @@ func TestKillStaleControlClients_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 	err := waitForFile(marker, 5*time.Second)
 	assert.NoError(t, err, "child's SIGTERM handler must have run (marker file must exist)")
 
+	// The marker is written just before os.Exit, so waitForFile can return
+	// while the child is still a zombie. Await the reaper (bounded) before the
+	// ESRCH check so the process is actually gone, not merely exiting.
+	select {
+	case <-waitDone:
+	case <-time.After(2 * time.Second):
+	}
+
 	// Process should be gone.
 	err = syscall.Kill(pid, 0)
 	assert.True(t, errors.Is(err, syscall.ESRCH), "child process should be fully reaped; got err=%v", err)
@@ -315,6 +323,13 @@ func TestControlPipeClose_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 	// Stat) for the async handler write — see waitForFile.
 	err = waitForFile(marker, 5*time.Second)
 	assert.NoError(t, err, "child's SIGTERM handler must have run (marker file must exist)")
+
+	// Marker is written just before os.Exit; await the reaper (bounded) so the
+	// child is actually gone before the ESRCH check, not merely exiting.
+	select {
+	case <-waitDone:
+	case <-time.After(2 * time.Second):
+	}
 
 	err = syscall.Kill(pid, 0)
 	assert.True(t, errors.Is(err, syscall.ESRCH), "child process should be fully reaped; got err=%v", err)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -34,6 +34,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/docker"
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/intervalhook"
 	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/safego"
@@ -623,6 +624,10 @@ type Home struct {
 	// System stats collector (CPU, RAM, disk, etc.)
 	sysStatsCollector *sysinfo.Collector
 	sysStatsConfig    session.SystemStatsSettings
+
+	// Interval-hook runner: user-configured shell commands run on a wall-clock
+	// cadence ([interval_hooks] in config.toml). nil when none are configured.
+	intervalHookRunner *intervalhook.Runner
 
 	// Insert mode (#1069, feature 1): vim-style modal type-through. When
 	// active, printable runes, Space, and Enter are routed directly to the
@@ -1462,6 +1467,11 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	if h.sysStatsConfig.GetEnabled() {
 		h.sysStatsCollector = sysinfo.NewCollector(h.sysStatsConfig.GetRefreshSeconds(), nil)
 	}
+
+	// Interval-hook runner. Constructed unconditionally (cheap); Start() is a
+	// no-op when no [interval_hooks] are configured, and hooks are re-read from
+	// config each tick so they can be added/removed without a restart.
+	h.intervalHookRunner = intervalhook.New(uiLog)
 
 	// Keep settings panel profile-aware so profile overrides (e.g., Claude config dir)
 	// are displayed and edited in the correct scope.
@@ -2869,6 +2879,11 @@ func (h *Home) Init() tea.Cmd {
 	// Start system stats collection
 	if h.sysStatsCollector != nil {
 		h.sysStatsCollector.Start()
+	}
+
+	// Start interval hooks (no-op if none configured).
+	if h.intervalHookRunner != nil {
+		h.intervalHookRunner.Start()
 	}
 
 	cmds := []tea.Cmd{
@@ -9782,6 +9797,10 @@ func (h *Home) performFinalShutdown(shutdownPool bool) tea.Cmd {
 		// Stop system stats collector
 		if h.sysStatsCollector != nil {
 			h.sysStatsCollector.Stop()
+		}
+		// Stop interval hooks
+		if h.intervalHookRunner != nil {
+			h.intervalHookRunner.Stop()
 		}
 		// Signal background worker to stop
 		h.cancel()

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -21,6 +21,7 @@ All options for `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/ag
 - [[conductor] Section](#conductor-section)
 - [[logs] Section](#logs-section)
 - [[updates] Section](#updates-section)
+- [[interval_hooks.*] Section](#interval_hooks-section)
 - [[display] Section](#display-section)
 - [[ui] Section](#ui-section)
 - [[global_search] Section](#global_search-section)
@@ -472,6 +473,40 @@ notify_in_cli = true          # Show in CLI commands
 | `check_enabled` | bool | `true` | Enable startup update checks. |
 | `check_interval_hours` | int | `24` | Hours between checks. |
 | `notify_in_cli` | bool | `true` | Show updates in CLI (not just TUI). |
+
+## [interval_hooks.*] Section
+
+Run shell commands on a wall-clock interval while the TUI is running,
+independent of session activity — a general-purpose "cron inside the TUI."
+Each hook is a named table under `[interval_hooks]`. The command runs via
+`bash -lc`. Typical uses: a periodic sync, a health probe, or a poll that
+dispatches work to sessions with `agent-deck session send` / `session start`.
+
+```toml
+[interval_hooks.heartbeat]
+command = "echo tick >> ~/agentdeck-heartbeat.log"
+interval_seconds = 60         # cadence between runs (clamped 5..86400)
+
+[interval_hooks.dispatch]
+command = "~/bin/route-ready-tasks.sh"
+interval_seconds = 30
+timeout_seconds = 20          # kill a run exceeding this (clamped 1..interval)
+run_at_startup = true         # also run once immediately on TUI start
+enabled = true                # set false to keep the config but pause it
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | `""` | Shell command run each tick via `bash -lc`. A hook with no command never runs. |
+| `interval_seconds` | int | `60` | Seconds between runs. Clamped to `[5, 86400]`. Re-read each tick, so edits apply live. |
+| `timeout_seconds` | int | `min(30, interval)` | Per-run timeout; a run exceeding it is killed so a wedged command can't pile up. Clamped to `[1, interval_seconds]`. |
+| `run_at_startup` | bool | `false` | Run the command once immediately on TUI start, before the first interval. |
+| `enabled` | bool | `true` when `command` set | Gate the hook. Set `false` to keep the config but pause it. |
+
+Notes:
+- Overlapping runs of the *same* hook are skipped: if a run is still going when the next tick fires, that tick is dropped (logged, not stacked).
+- Hooks are re-read from `config.toml` each tick — add, remove, pause, or re-time a hook without restarting the TUI.
+- Failures (non-zero exit) are logged at WARN with truncated output; successes at DEBUG. A hook is never allowed to crash the TUI.
 
 ## [display] Section
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -499,14 +499,14 @@ enabled = true                # set false to keep the config but pause it
 |-----|------|---------|-------------|
 | `command` | string | `""` | Shell command run each tick via `bash -lc`. A hook with no command never runs. |
 | `interval_seconds` | int | `60` | Seconds between runs. Clamped to `[5, 86400]`. Re-read each tick, so edits apply live. |
-| `timeout_seconds` | int | `min(30, interval)` | Per-run timeout; a run exceeding it is killed so a wedged command can't pile up. Clamped to `[1, interval_seconds]`. |
+| `timeout_seconds` | int | `min(30, interval)` | Per-run timeout; a run exceeding it is killed so a wedged command can't pile up. Clamped to `[1, interval_seconds]`. The command runs in its own process group, so on timeout the whole group is killed — a hook that forks children (or daemonizes) can't outlive its slot. |
 | `run_at_startup` | bool | `false` | Run the command once immediately on TUI start, before the first interval. |
 | `enabled` | bool | `true` when `command` set | Gate the hook. Set `false` to keep the config but pause it. |
 
 Notes:
 - Overlapping runs of the *same* hook are skipped: if a run is still going when the next tick fires, that tick is dropped (logged, not stacked).
-- Hooks are re-read from `config.toml` each tick — add, remove, pause, or re-time a hook without restarting the TUI.
-- Failures (non-zero exit) are logged at WARN with truncated output; successes at DEBUG. A hook is never allowed to crash the TUI.
+- **Live config changes:** a supervisor rescans `config.toml` about every 15s, so you can add, remove, pause (`enabled = false`), or re-enable a hook without restarting the TUI — changes take effect within one rescan. A live hook's own `command` / `interval_seconds` edits are picked up on its next tick. (No restart is required for any of these.)
+- Each run is logged: failures (non-zero exit) at WARN with truncated output, successes at INFO. A hook is never allowed to crash the TUI (each runs in a panic-recovering goroutine).
 
 ## [display] Section
 


### PR DESCRIPTION
> **Note:** This PR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

### What

Adds `[interval_hooks]` — user-configured shell commands that run on a wall-clock cadence while the TUI is open, **independent of session activity**. A general-purpose "cron inside the TUI."

```toml
[interval_hooks.heartbeat]
command = "echo tick >> ~/agentdeck-heartbeat.log"
interval_seconds = 60

[interval_hooks.dispatch]
command = "~/bin/poll-and-route.sh"
interval_seconds = 30
timeout_seconds = 20
run_at_startup = true
```

Each hook is a named table with `command`, `interval_seconds`, optional `timeout_seconds`, `run_at_startup`, and `enabled`.

### Why

There's currently no way to run periodic background work from agent-deck itself — the existing tickers (system stats, remote refresh) are internal and hardcoded, and the `*_hooks` files inject markers into *downstream* CLI configs, not agent-deck's own. Interval hooks fill the gap: a periodic sync, a health probe, or a poll that dispatches work to sessions via `agent-deck session send` / `session start`. It's deliberately general — the command is whatever the user wants.

### Implementation

Mirrors existing house patterns so it stays idiomatic:

- **`internal/session/userconfig.go`** — `IntervalHooks map[string]IntervalHookSettings` on `UserConfig` (`[interval_hooks.<name>]`), keyed by name like the existing `Remotes`/`Tools`/`MCPs` maps. `GetEnabled` / `GetIntervalSeconds` / `GetTimeoutSeconds` accessors clamp values (interval `[5, 86400]`, timeout `[1, interval]`), modeled on `SystemStatsSettings`.
- **`internal/intervalhook/runner.go`** — a background-goroutine runner modeled on `sysinfo.Collector` + `StartMaintenanceWorker`:
  - one goroutine per hook (`safego.Go`, so a panicking command can't crash the TUI),
  - config re-read each tick, so add/remove/pause/re-time a hook applies live without restart,
  - overlapping runs of the *same* hook are skipped (not stacked),
  - per-run timeout via `exec.CommandContext(ctx, bash, "-lc", command)` — the `bash -lc` convention from `internal/tmux.buildBashLCCommand`, with a `#nosec G204` justification (command is user-authored config, run intentionally on the user's own machine, like a crontab entry).
- **`internal/ui/home.go`** — construct the runner in `Home`, `Start()` in `Init()`, `Stop()` in `performFinalShutdown`, beside the existing `sysStatsCollector`.
- **`skills/agent-deck/references/config-reference.md`** — documents the section.

### Non-goals / scope

- Not a replacement for the `*_hooks` (Claude/Codex/Gemini) marker-injection — those target downstream CLIs; this is agent-deck's own periodic runner.
- No TUI editing of the section (read from config.toml only); doesn't touch the settings-panel save path, so the `[mcps]`/`[groups]` section-drop guard is unaffected.
- Does not reuse `internal/watcher/engine.go` (that's an event-ingest→DB→route pipeline, wrong shape for a timer).

### Testing

- `internal/session/interval_hooks_test.go` — accessor clamping (enabled default, interval floor/ceiling, timeout ≤ interval).
- `internal/intervalhook/runner_test.go` — executes a command, overlap-skip, timeout kills a `sleep 5` in ~1s, run-at-startup fires immediately, disabled hook doesn't run, `Start()` idempotent.
- `go build ./...`, `go vet`, and config save/load/section-guard tests all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable interval hooks to run shell commands while the TUI is active, with named schedules, per-hook timeouts, enable/disable controls, and optional “run at startup”.
  - Hook settings are automatically validated and clamped to safe bounds.
  - Enabled hooks can be turned on during runtime without restarting the app.
- **Bug Fixes**
  - Prevented overlapping runs of the same hook.
  - Timed-out commands are terminated promptly (including child processes).
  - Improved shutdown test reliability by making async marker checks and waits more robust.
- **Tests**
  - Added coverage for command execution, overlap handling, timeout cancellation, startup behavior, and live re-enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->