### PR TITLE
feat(ui): in-attach scrollback pager for the deck view (#1491)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -3893,6 +3893,19 @@ func CreateExampleConfig() error {
 #                             # cycle forward (Ctrl+A to go back); it auto-
 #                             # attaches ~1s after you stop, Enter attaches now,
 #                             # Esc cancels. Same key opens it from the list.
+# Scrollback pager (issue #1491). The deck's Enter-attach renders the session in
+# tmux control mode, where the deck owns the viewport and tmux's own copy-mode /
+# mouse-wheel scrollback is unreachable. This trigger opens an in-view scrollable
+# pager over the pane's history so you can reach the start of a long session
+# without leaving agent-deck. Inside: Up/Down/j/k, PgUp/PgDn, g=start, G=live end,
+# wheel scrolls, Esc re-attaches, Ctrl+Q returns to the list.
+#   "pageup"  (default) a bare PageUp opens the pager; modified PageUp passes
+#             through to the attached program.
+#   "ctrl+<letter>"  a control chord opens it (use if a pager/editor inside the
+#             session needs PageUp). A chord that collides with detach/switch is
+#             dropped.
+#   ""        disables the feature.
+# scrollback = "pageup"
 
 # Instance behavior (optional)
 # [instances]

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -66,8 +66,9 @@ func IndexCtrlQ(data []byte) int {
 	return IndexDetachKey(data, 17)
 }
 
-// SwitchIntent reports whether the attach loop handed control back to the
-// caller to open the in-attach session switcher.
+// SwitchIntent reports why the attach loop handed control back to the caller:
+// a plain detach/exit, an in-attach session switch, or an in-attach scrollback
+// request (#1491).
 type SwitchIntent int
 
 const (
@@ -75,7 +76,20 @@ const (
 	SwitchNone SwitchIntent = iota
 	// SwitchRequested means the user pressed the switch key while attached.
 	SwitchRequested
+	// ScrollbackRequested means the user pressed the scrollback key while
+	// attached and the caller should open the in-view scrollback pager. The
+	// deck's Enter-attach owns the viewport, so tmux's own copy-mode is
+	// unreachable there (#1491); this intent is the escape hatch.
+	ScrollbackRequested
 )
+
+// pageUpSeq is the exact CSI sequence a bare PageUp emits. Modified variants
+// (Shift/Ctrl/Alt) carry a parameter — ESC[5;2~, ESC[5;5~, … — and do NOT match
+// this literal, so they pass through to the attached program untouched. That is
+// deliberate: the scrollback pager steals only the unmodified PageUp the issue
+// reporter pressed expecting to scroll, leaving modified PageUp for pagers and
+// editors running inside the session.
+const pageUpSeq = "\x1b[5~"
 
 // AttachOptions configures AttachWithOptions. The zero value attaches with the
 // default Ctrl+Q detach key and no session-switch key.
@@ -90,6 +104,16 @@ type AttachOptions struct {
 	// that is not reliably available during attach, so a control byte is the
 	// only portable trigger (the cycling/commit UX then lives in the TUI).
 	SwitchKeyByte byte
+	// ScrollbackKeyByte is a control byte (e.g. Ctrl+G, 0x07) that hands control
+	// back to the caller to open the in-view scrollback pager (#1491). 0
+	// disables the control-byte trigger; the PageUp trigger below is
+	// independent.
+	ScrollbackKeyByte byte
+	// ScrollbackOnPageUp, when true, makes a bare PageUp (ESC[5~) open the
+	// scrollback pager. Modified PageUp (Shift/Ctrl/Alt) always passes through.
+	// This is the default trigger because it is exactly the key a user presses
+	// expecting to scroll back through the session.
+	ScrollbackOnPageUp bool
 }
 
 // indexSwitchKey returns the index of the switch key in data and
@@ -104,6 +128,66 @@ func indexSwitchKey(data []byte, opts AttachOptions) (int, SwitchIntent) {
 		return idx, SwitchRequested
 	}
 	return -1, SwitchNone
+}
+
+// indexScrollbackTrigger returns the index in data at which a scrollback
+// request begins, or -1 if none is present or scrollback is disabled. It
+// considers both configured triggers and returns the earliest match:
+//   - the ScrollbackKeyByte control chord (raw byte + modifyOtherKeys + CSI-u
+//     encodings, via IndexDetachKey), and
+//   - a bare PageUp (ESC[5~) when ScrollbackOnPageUp is set.
+//
+// The caller resolves precedence against the detach and switch keys, both of
+// which win a collision.
+func indexScrollbackTrigger(data []byte, opts AttachOptions) int {
+	best := -1
+	consider := func(idx int) {
+		if idx >= 0 && (best == -1 || idx < best) {
+			best = idx
+		}
+	}
+	if opts.ScrollbackKeyByte != 0 {
+		consider(IndexDetachKey(data, opts.ScrollbackKeyByte))
+	}
+	if opts.ScrollbackOnPageUp {
+		consider(bytes.Index(data, []byte(pageUpSeq)))
+	}
+	return best
+}
+
+// resolveAttachInterrupt finds the earliest interrupt key in a stdin chunk and
+// reports its byte index plus the intent it maps to. Precedence on a tie is
+// detach > switch > scrollback (distinct keys can't share an index, but the
+// ordering guards against a misconfigured trigger shadowing a higher-priority
+// one). It returns (-1, SwitchNone) when no interrupt key is present.
+//
+// The intent it returns is what the caller assigns to switchOutcome:
+//   - SwitchNone         => detach (or nothing found),
+//   - SwitchRequested    => open the session switcher,
+//   - ScrollbackRequested => open the scrollback pager.
+//
+// Extracted from the stdin goroutine so the precedence is unit-testable without
+// spawning a PTY.
+func resolveAttachInterrupt(chunk []byte, detach byte, opts AttachOptions) (int, SwitchIntent) {
+	detachIdx := IndexDetachKey(chunk, detach)
+	switchIdx, switchIn := indexSwitchKey(chunk, opts)
+	scrollIdx := indexScrollbackTrigger(chunk, opts)
+
+	interruptIdx := -1
+	outcome := SwitchNone
+	if detachIdx >= 0 {
+		interruptIdx = detachIdx
+		outcome = SwitchNone
+	}
+	if switchIdx >= 0 && (interruptIdx == -1 || switchIdx < interruptIdx) {
+		interruptIdx = switchIdx
+		outcome = switchIn
+	}
+	if scrollIdx >= 0 && (interruptIdx == -1 || scrollIdx < interruptIdx) {
+		interruptIdx = scrollIdx
+		outcome = ScrollbackRequested
+	}
+	return interruptIdx, outcome
 }
 
 func waitForAttachOutputDrain(outputDone <-chan struct{}, timeout time.Duration) (bool, time.Duration) {
@@ -386,22 +470,10 @@ func (s *Session) AttachWithOptions(ctx context.Context, opts AttachOptions) (Sw
 			// the input chunk. Some terminals coalesce reads, so these must not
 			// require a single-byte read. Handles raw byte, xterm
 			// modifyOtherKeys, and kitty CSI u encodings.
-			detachIdx := IndexDetachKey(chunk, detach)
-			switchIdx, switchIn := indexSwitchKey(chunk, opts)
-
-			// Whichever interrupt key appears first in the buffer wins; detach
-			// takes precedence on a tie (distinct keys can't share an index,
-			// but guard anyway so a misconfigured switch byte can't shadow
-			// detach).
-			interruptIdx := -1
-			isSwitch := false
-			if detachIdx >= 0 {
-				interruptIdx = detachIdx
-			}
-			if switchIdx >= 0 && (interruptIdx == -1 || switchIdx < interruptIdx) {
-				interruptIdx = switchIdx
-				isSwitch = true
-			}
+			// Whichever interrupt key appears first in the buffer wins, with
+			// detach > switch > scrollback precedence on a tie. Resolved by a
+			// pure helper so the precedence is unit-testable.
+			interruptIdx, outcome := resolveAttachInterrupt(chunk, detach, opts)
 
 			if interruptIdx >= 0 {
 				// Forward any bytes before the interrupt key, then stop.
@@ -414,9 +486,7 @@ func (s *Session) AttachWithOptions(ctx context.Context, opts AttachOptions) (Sw
 						return
 					}
 				}
-				if isSwitch {
-					switchOutcome = switchIn
-				}
+				switchOutcome = outcome
 				close(detachCh)
 				cancel()
 				return

--- a/internal/tmux/scrollback_key_test.go
+++ b/internal/tmux/scrollback_key_test.go
@@ -1,0 +1,138 @@
+//go:build !windows
+// +build !windows
+
+package tmux
+
+import "testing"
+
+// TestIndexScrollbackTrigger_PageUp verifies a bare PageUp is detected only when
+// ScrollbackOnPageUp is set, and that modified PageUp variants never match.
+func TestIndexScrollbackTrigger_PageUp(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		opts AttachOptions
+		want int
+	}{
+		{
+			name: "bare pageup detected when enabled",
+			data: "\x1b[5~",
+			opts: AttachOptions{ScrollbackOnPageUp: true},
+			want: 0,
+		},
+		{
+			name: "bare pageup ignored when disabled",
+			data: "\x1b[5~",
+			opts: AttachOptions{},
+			want: -1,
+		},
+		{
+			name: "shift+pageup (ESC[5;2~) passes through",
+			data: "\x1b[5;2~",
+			opts: AttachOptions{ScrollbackOnPageUp: true},
+			want: -1,
+		},
+		{
+			name: "ctrl+pageup (ESC[5;5~) passes through",
+			data: "\x1b[5;5~",
+			opts: AttachOptions{ScrollbackOnPageUp: true},
+			want: -1,
+		},
+		{
+			name: "pageup mid-buffer detected at its offset",
+			data: "abc\x1b[5~",
+			opts: AttachOptions{ScrollbackOnPageUp: true},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := indexScrollbackTrigger([]byte(tt.data), tt.opts); got != tt.want {
+				t.Fatalf("indexScrollbackTrigger(%q) = %d, want %d", tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIndexScrollbackTrigger_CtrlByte verifies the control-byte trigger is
+// detected across the raw, modifyOtherKeys, and CSI-u encodings, and that the
+// earliest of two configured triggers wins.
+func TestIndexScrollbackTrigger_CtrlByte(t *testing.T) {
+	const ctrlG = byte(7) // Ctrl+G
+
+	// Raw byte.
+	if got := indexScrollbackTrigger([]byte{ctrlG}, AttachOptions{ScrollbackKeyByte: ctrlG}); got != 0 {
+		t.Fatalf("raw ctrl+g: got %d, want 0", got)
+	}
+	// modifyOtherKeys encoding: ESC[27;5;103~ ('g' == 103).
+	if got := indexScrollbackTrigger([]byte("\x1b[27;5;103~"), AttachOptions{ScrollbackKeyByte: ctrlG}); got != 0 {
+		t.Fatalf("modifyOtherKeys ctrl+g: got %d, want 0", got)
+	}
+	// CSI-u (kitty) encoding: ESC[103;5u.
+	if got := indexScrollbackTrigger([]byte("\x1b[103;5u"), AttachOptions{ScrollbackKeyByte: ctrlG}); got != 0 {
+		t.Fatalf("CSI-u ctrl+g: got %d, want 0", got)
+	}
+	// Disabled by default.
+	if got := indexScrollbackTrigger([]byte{ctrlG}, AttachOptions{}); got != -1 {
+		t.Fatalf("ctrl+g without trigger: got %d, want -1", got)
+	}
+	// Earliest of two triggers wins: pageup at 0, ctrl+g at 4.
+	opts := AttachOptions{ScrollbackKeyByte: ctrlG, ScrollbackOnPageUp: true}
+	if got := indexScrollbackTrigger([]byte("\x1b[5~\x07"), opts); got != 0 {
+		t.Fatalf("earliest trigger: got %d, want 0", got)
+	}
+}
+
+// TestResolveAttachInterrupt_Precedence verifies detach > switch > scrollback
+// precedence and earliest-index-wins semantics.
+func TestResolveAttachInterrupt_Precedence(t *testing.T) {
+	const (
+		detach = byte(17) // Ctrl+Q
+		swByte = byte(19) // Ctrl+S
+		sbByte = byte(7)  // Ctrl+G
+	)
+	opts := AttachOptions{SwitchKeyByte: swByte, ScrollbackKeyByte: sbByte, ScrollbackOnPageUp: true}
+
+	tests := []struct {
+		name     string
+		data     string
+		wantIdx  int
+		wantKind SwitchIntent
+	}{
+		{"nothing", "hello", -1, SwitchNone},
+		{"detach only", "\x11", 0, SwitchNone},
+		{"switch only", "\x13", 0, SwitchRequested},
+		{"scrollback pageup only", "\x1b[5~", 0, ScrollbackRequested},
+		{"scrollback ctrl byte only", "\x07", 0, ScrollbackRequested},
+		// Detach earlier than scrollback => detach wins.
+		{"detach before scrollback", "\x11\x1b[5~", 0, SwitchNone},
+		// Scrollback earlier than detach => scrollback wins (earliest index).
+		{"scrollback before detach", "\x1b[5~\x11", 0, ScrollbackRequested},
+		// Switch and scrollback: earliest wins; switch earlier here.
+		{"switch before scrollback", "\x13\x07", 0, SwitchRequested},
+		{"scrollback before switch", "\x07\x13", 0, ScrollbackRequested},
+		// Bytes before the trigger shift the index.
+		{"prefix then scrollback", "abc\x07", 3, ScrollbackRequested},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIdx, gotKind := resolveAttachInterrupt([]byte(tt.data), detach, opts)
+			if gotIdx != tt.wantIdx || gotKind != tt.wantKind {
+				t.Fatalf("resolveAttachInterrupt(%q) = (%d, %v), want (%d, %v)",
+					tt.data, gotIdx, gotKind, tt.wantIdx, tt.wantKind)
+			}
+		})
+	}
+}
+
+// TestResolveAttachInterrupt_LoneScrollback confirms a lone scrollback trigger
+// resolves to ScrollbackRequested even when the (absent) detach key is
+// configured — the detach key does not shadow scrollback when detach is not
+// actually present in the chunk.
+func TestResolveAttachInterrupt_LoneScrollback(t *testing.T) {
+	opts := AttachOptions{ScrollbackOnPageUp: true}
+	idx, kind := resolveAttachInterrupt([]byte("\x1b[5~"), 17, opts)
+	if idx != 0 || kind != ScrollbackRequested {
+		t.Fatalf("lone scrollback: got (%d,%v), want (0,ScrollbackRequested)", idx, kind)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3009,6 +3009,32 @@ func (s *Session) CaptureFullHistory() (string, error) {
 	return string(output), nil
 }
 
+// CaptureHistoryLines captures the last n lines of the pane's scrollback,
+// preserving ANSI colors (-e). Unlike CaptureFullHistory (capped at 2000 for
+// the preview pane) this is used by the in-attach scrollback pager (#1491),
+// which needs a deep enough window to reach the start of a long session, so it
+// runs with a generous timeout and an explicit -S -<n> lower bound.
+//
+// n is clamped to at least 1. A one-off subprocess with a 10s timeout keeps a
+// pathological capture from wedging the UI; on timeout it returns
+// ErrCaptureTimeout so the caller can surface a non-fatal message.
+func (s *Session) CaptureHistoryLines(n int) (string, error) {
+	if n < 1 {
+		n = 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := s.tmuxCmdContext(ctx, "capture-pane", "-t", s.Name, "-p", "-e", "-S", fmt.Sprintf("-%d", n))
+	output, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", ErrCaptureTimeout
+		}
+		return "", fmt.Errorf("failed to capture history: %w", err)
+	}
+	return string(output), nil
+}
+
 // CaptureWindowFullHistory captures the scrollback history of a specific window (last 2000 lines).
 func (s *Session) CaptureWindowFullHistory(windowIndex int) (string, error) {
 	target := fmt.Sprintf("%s:%d", s.Name, windowIndex)

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -189,6 +189,9 @@ func (h *HelpOverlay) View() string {
 	groupViewKey := h.key(hotkeyCycleGroupView, "t")
 	// Opt-in: empty when switch_session is unbound, so the filter drops the row.
 	switchKey := h.key(hotkeySwitchSession, "")
+	// In-attach scrollback pager (#1491). Its trigger is resolved directly (it is
+	// not a home-screen key); empty label when disabled drops the row.
+	scrollbackKey := ResolvedScrollbackTrigger(session.GetHotkeyOverrides()).Label()
 	unreadKey := h.key(hotkeyMarkUnread, "u")
 	quickApproveKey := h.key(hotkeyQuickApprove, "a")
 	promptSessionKey := h.key(hotkeyPromptSession, "o")
@@ -326,6 +329,7 @@ func (h *HelpOverlay) View() string {
 				{importKey, "Import tmux sessions"},
 				{"Ctrl+Q", "Detach from session"},
 				{switchKey, "Switch session (here or attached)"},
+				{scrollbackKey, "Scrollback pager (while attached)"},
 				{quitKey, "Quit"},
 				{helpKey, "This help"},
 			},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -257,6 +257,7 @@ type Home struct {
 	sessionPickerDialog  *SessionPickerDialog  // For sending output to another session
 	codeBlockDialog      *CodeBlockDialog      // For copying a fenced code block from session output (#1412)
 	sessionSwitcher      *SessionSwitcher      // In-attach session switcher (Ctrl+Tab / Ctrl+S)
+	scrollbackPager      *ScrollbackPager      // In-attach scrollback pager for the deck's control-mode view (#1491)
 	worktreeFinishDialog *WorktreeFinishDialog // For finishing worktree sessions (merge + cleanup)
 	feedbackDialog       *FeedbackDialog       // For in-app feedback popup (Phase 2)
 	zoxidePicker         *ZoxidePicker         // Quick-open picker backed by the zoxide DB
@@ -742,7 +743,20 @@ func (h *Home) attachOptions() tmux.AttachOptions {
 	if switchByte == detach {
 		switchByte = 0
 	}
-	return tmux.AttachOptions{DetachByte: detach, SwitchKeyByte: switchByte}
+	// Resolve the in-attach scrollback trigger (#1491). A control-byte trigger
+	// that collides with the detach or switch key is dropped so it can never
+	// shadow them; the PageUp trigger is independent and always safe.
+	scroll := ResolvedScrollbackTrigger(overrides)
+	scrollByte := scroll.KeyByte
+	if scrollByte == detach || (switchByte != 0 && scrollByte == switchByte) {
+		scrollByte = 0
+	}
+	return tmux.AttachOptions{
+		DetachByte:         detach,
+		SwitchKeyByte:      switchByte,
+		ScrollbackKeyByte:  scrollByte,
+		ScrollbackOnPageUp: scroll.OnPageUp,
+	}
 }
 
 func (h *Home) setHotkeys(bindings map[string]string) {
@@ -1066,6 +1080,24 @@ type openSwitcherMsg struct {
 	attachedWorkDir string // pane_current_path captured after attach returns
 }
 
+// openScrollbackMsg is emitted when the user pressed the scrollback trigger
+// while attached (#1491). It carries the same post-attach reconciliation data
+// as statusUpdateMsg; the pager opens bound to the session we came from and the
+// history capture runs asynchronously.
+type openScrollbackMsg struct {
+	fromSessionID   string // session we just detached from
+	attachedWorkDir string // pane_current_path captured after attach returns
+}
+
+// scrollbackContentMsg carries the captured pane history back to the pager. It
+// is stale-guarded by sessionID so a capture that completes after the user has
+// closed or re-opened the pager on a different session is ignored.
+type scrollbackContentMsg struct {
+	sessionID string
+	content   string
+	err       error
+}
+
 // switcherCommitMsg fires after the switcher has been idle for switcherIdleCommit.
 // gen guards against stale timers: only a message whose gen matches the
 // switcher's current generation commits (see handleSwitcherCommit).
@@ -1286,6 +1318,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		sessionPickerDialog:       NewSessionPickerDialog(),
 		codeBlockDialog:           NewCodeBlockDialog(),
 		sessionSwitcher:           NewSessionSwitcher(),
+		scrollbackPager:           NewScrollbackPager(),
 		worktreeFinishDialog:      NewWorktreeFinishDialog(),
 		feedbackDialog:            NewFeedbackDialog(),
 		zoxidePicker:              NewZoxidePicker(),
@@ -4847,6 +4880,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		h.geminiModelDialog.SetSize(msg.Width, msg.Height)
 		h.promptInputDialog.SetSize(msg.Width, msg.Height)
+		h.scrollbackPager.SetSize(msg.Width, msg.Height)
 		// Issue #1366: a resize can reveal the preview pane (single -> stacked/dual).
 		// fetchSelectedPreview self-guards to nil in single-column, so this only
 		// fetches when a preview pane is actually visible.
@@ -4873,6 +4907,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return h, nil
 			}
 			if h.helpOverlay.IsVisible() {
+				return h, nil
+			}
+			if h.scrollbackPager.IsVisible() {
+				// #1491: the wheel the deck-attach couldn't deliver now scrolls
+				// the pager. 3 lines per notch matches typical terminal wheel UX.
+				if msg.Button == tea.MouseButtonWheelUp {
+					h.scrollbackPager.ScrollUp(3)
+				} else {
+					h.scrollbackPager.ScrollDown(3)
+				}
 				return h, nil
 			}
 			if h.globalSearch.IsVisible() {
@@ -6017,6 +6061,40 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
 		)
 
+	case openScrollbackMsg:
+		// The user pressed the scrollback trigger while attached (#1491). Run the
+		// same post-attach reconciliation as the switcher, then open the pager
+		// bound to the session we came from and kick off the async history
+		// capture. Esc re-attaches; Ctrl+Q returns to the list.
+		h.isAttaching.Store(false)
+		h.beginAttachReturnGrace(time.Now())
+		h.refreshAttachedSessionStatus(msg.fromSessionID)
+		selectedBefore := h.captureSelectedItemIdentity()
+		h.rebuildFlatItemsPreservingSelection(selectedBefore)
+		h.followAttachReturnCwd(statusUpdateMsg{
+			attachedSessionID: msg.fromSessionID,
+			attachedWorkDir:   msg.attachedWorkDir,
+		})
+		captureCmd := h.openScrollbackPager(msg.fromSessionID)
+		return h, tea.Batch(
+			tea.EnableMouseCellMotion,
+			RestoreLegacyKeyboardCmd(os.Stdout),
+			tea.WindowSize(),
+			captureCmd,
+		)
+
+	case scrollbackContentMsg:
+		// Ignore a capture that finished after the pager closed or moved to a
+		// different session (stale guard).
+		if h.scrollbackPager.IsVisible() && h.scrollbackPager.SessionID() == msg.sessionID {
+			if msg.err != nil {
+				h.scrollbackPager.SetError(msg.err.Error())
+			} else {
+				h.scrollbackPager.SetContent(msg.content)
+			}
+		}
+		return h, nil
+
 	case switcherCommitMsg:
 		return h, h.handleSwitcherCommit(msg)
 
@@ -6776,6 +6854,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if h.sessionSwitcher.IsVisible() {
 			return h.handleSessionSwitcherKey(msg)
 		}
+		if h.scrollbackPager.IsVisible() {
+			return h.handleScrollbackPagerKey(msg)
+		}
 		if h.sessionPickerDialog.IsVisible() {
 			return h.handleSessionPickerDialogKey(msg)
 		}
@@ -7489,7 +7570,7 @@ func (h *Home) hasModalVisible() bool {
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.pluginDialog.IsVisible() || h.skillDialog.IsVisible() ||
 		h.geminiModelDialog.IsVisible() || h.promptInputDialog.IsVisible() || h.sessionPickerDialog.IsVisible() ||
 		h.codeBlockDialog.IsVisible() ||
-		h.sessionSwitcher.IsVisible() ||
+		h.sessionSwitcher.IsVisible() || h.scrollbackPager.IsVisible() ||
 		h.worktreeFinishDialog.IsVisible() || h.editPathsDialog.IsVisible() ||
 		h.editSessionDialog.IsVisible() ||
 		h.zoxidePicker.IsVisible()
@@ -12618,6 +12699,12 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 					}
 				}
 			}
+			if res.intent == tmux.ScrollbackRequested {
+				return openScrollbackMsg{
+					fromSessionID:   fromID,
+					attachedWorkDir: fromWorkDir,
+				}
+			}
 			return openSwitcherMsg{
 				fromSessionID:   fromID,
 				attachedWorkDir: fromWorkDir,
@@ -13210,6 +13297,9 @@ func (h *Home) View() string {
 	}
 	if h.sessionSwitcher.IsVisible() {
 		return h.sessionSwitcher.View()
+	}
+	if h.scrollbackPager.IsVisible() {
+		return h.scrollbackPager.View()
 	}
 	if h.sessionPickerDialog.IsVisible() {
 		return h.sessionPickerDialog.View()
@@ -18315,6 +18405,72 @@ func (h *Home) commitSessionSwitch() tea.Cmd {
 	}
 	h.sessionSwitcher.Hide()
 	return h.attachToSwitchTarget(target)
+}
+
+// scrollbackCaptureLines is how many trailing history lines the pager captures.
+// Deep enough to reach the banner of a long session (tmux's history-limit is
+// typically 50k-500k) while bounded so a pathological pane can't balloon memory
+// or wedge the capture. The preview pane's 2000-line cap is deliberately left
+// untouched — this is a one-off, on-demand capture.
+const scrollbackCaptureLines = 50000
+
+// openScrollbackPager opens the in-view scrollback pager (#1491) bound to the
+// session with the given ID and returns the async command that captures its
+// tmux history. The pager opens in a loading state; scrollbackContentMsg
+// installs the content (stale-guarded by session ID). Returns nil when the
+// session no longer exists.
+func (h *Home) openScrollbackPager(sessionID string) tea.Cmd {
+	if sessionID == "" || h.scrollbackPager == nil {
+		return nil
+	}
+	h.instancesMu.RLock()
+	inst := h.instanceByID[sessionID]
+	h.instancesMu.RUnlock()
+	if inst == nil {
+		return nil
+	}
+	tmuxSess := inst.GetTmuxSession()
+	if tmuxSess == nil {
+		return nil
+	}
+	title := strings.TrimSpace(inst.Title)
+	h.scrollbackPager.Show(title, sessionID, h.width, h.height)
+	return func() tea.Msg {
+		content, err := tmuxSess.CaptureHistoryLines(scrollbackCaptureLines)
+		return scrollbackContentMsg{sessionID: sessionID, content: content, err: err}
+	}
+}
+
+// handleScrollbackPagerKey handles key events while the scrollback pager is
+// visible (#1491). Navigation scrolls the captured history; Esc re-attaches to
+// the session (back to where the user was), and the detach key (Ctrl+Q) closes
+// the pager to the session list without re-attaching.
+func (h *Home) handleScrollbackPagerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	p := h.scrollbackPager
+	switch msg.String() {
+	case "up", "k":
+		p.ScrollUp(1)
+	case "down", "j":
+		p.ScrollDown(1)
+	case "pgup", "b":
+		p.PageUp()
+	case "pgdown", " ", "f":
+		p.PageDown()
+	case "home", "g":
+		p.Top()
+	case "end", "G":
+		p.Bottom()
+	case "esc", "q":
+		// Return to the session the user was reading.
+		target := p.SessionID()
+		p.Hide()
+		return h, h.attachToSwitchTarget(target)
+	case "ctrl+q":
+		// Close to the session list without re-attaching.
+		p.Hide()
+		return h, nil
+	}
+	return h, nil
 }
 
 // attachToSwitchTarget re-attaches to the session with the given ID and lands

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -59,7 +59,19 @@ const (
 	// suggested Ctrl+S collides with Claude Code (stash prompt) and XOFF
 	// flow-control. Users opt in by binding [hotkeys].switch_session.
 	hotkeySwitchSession = "switch_session" // canonical "ctrl+s" (opt-in)
+	// Scrollback pager. While attached to a session from the deck (Enter), the
+	// deck owns the viewport so tmux's own copy-mode/scrollback is unreachable
+	// (#1491). This trigger, intercepted in the attach loop, opens an in-view
+	// scrollable pager rendered from the pane's history. Unlike other hotkeys
+	// its value is not a home-screen key: it is "pageup" (default), a
+	// "ctrl+<letter>" chord, or "" (disabled). Resolved by
+	// ResolvedScrollbackTrigger, kept out of the home-screen dispatch maps.
+	hotkeyScrollback = "scrollback"
 )
+
+// defaultScrollbackTrigger is the out-of-the-box scrollback trigger: a bare
+// PageUp, exactly the key the #1491 reporter pressed expecting to scroll.
+const defaultScrollbackTrigger = "pageup"
 
 var hotkeyActionOrder = []string{
 	hotkeyQuit,
@@ -481,4 +493,62 @@ func ctrlByteFromBinding(binding string) byte {
 func ResolvedSwitchByte(overrides map[string]string) byte {
 	bindings := resolveHotkeys(overrides)
 	return ctrlByteFromBinding(actionHotkey(bindings, hotkeySwitchSession))
+}
+
+// ScrollbackTrigger describes how the in-attach scrollback pager is opened.
+// The zero value means scrollback is disabled.
+type ScrollbackTrigger struct {
+	// KeyByte is a ctrl+<letter> control byte that opens the pager, or 0.
+	KeyByte byte
+	// OnPageUp reports whether a bare PageUp opens the pager.
+	OnPageUp bool
+}
+
+// Enabled reports whether any trigger is configured.
+func (t ScrollbackTrigger) Enabled() bool {
+	return t.KeyByte != 0 || t.OnPageUp
+}
+
+// Label returns a short human-readable label for the configured trigger
+// (e.g. "PageUp", "Ctrl+G"), or "" when disabled.
+func (t ScrollbackTrigger) Label() string {
+	switch {
+	case t.OnPageUp:
+		return "PageUp"
+	case t.KeyByte != 0:
+		return DetachByteLabel(t.KeyByte)
+	default:
+		return ""
+	}
+}
+
+// ResolvedScrollbackTrigger resolves the in-attach scrollback trigger from the
+// hotkey overrides. The [hotkeys].scrollback value is one of:
+//   - "pageup"       — bare PageUp opens the pager (the default),
+//   - "ctrl+<letter>" — that chord opens the pager,
+//   - ""             — scrollback disabled.
+//
+// An unrecognized value falls back to the PageUp default rather than silently
+// disabling the feature. It is resolved directly from overrides (not through
+// resolveHotkeys) because its value is not a home-screen key and must stay out
+// of the home-screen dispatch lookup.
+func ResolvedScrollbackTrigger(overrides map[string]string) ScrollbackTrigger {
+	val := defaultScrollbackTrigger
+	for action, key := range overrides {
+		if strings.TrimSpace(strings.ToLower(action)) == hotkeyScrollback {
+			val = strings.TrimSpace(strings.ToLower(key))
+			break
+		}
+	}
+	switch val {
+	case "":
+		return ScrollbackTrigger{}
+	case "pageup":
+		return ScrollbackTrigger{OnPageUp: true}
+	default:
+		if b := ctrlByteFromBinding(val); b != 0 {
+			return ScrollbackTrigger{KeyByte: b}
+		}
+		return ScrollbackTrigger{OnPageUp: true}
+	}
 }

--- a/internal/ui/scrollback_pager.go
+++ b/internal/ui/scrollback_pager.go
@@ -1,0 +1,289 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ScrollbackPager is a full-screen, read-only pager over a session's tmux
+// scrollback history. It exists because the deck's Enter-attach renders the
+// session through tmux control mode, where agent-deck owns the viewport and
+// tmux's own copy-mode / mouse-wheel scrollback is unreachable (#1491). The
+// user presses the scrollback trigger (PageUp by default) while attached; the
+// attach loop hands control back to the TUI, which captures the pane history
+// and opens this pager so the start of a long session is reachable without
+// leaving agent-deck.
+//
+// It is deliberately display-only: it never writes state.db or config and holds
+// a snapshot, so there is no data-loss surface.
+type ScrollbackPager struct {
+	visible       bool
+	width, height int
+	title         string // session display title, shown in the header
+	sessionID     string // guards async capture against a stale session
+	loading       bool   // capture in flight
+	errText       string // non-empty => capture failed, shown in the body
+	lines         []string
+	offset        int // index of the top visible line within lines
+}
+
+// NewScrollbackPager returns a hidden pager.
+func NewScrollbackPager() *ScrollbackPager { return &ScrollbackPager{} }
+
+// IsVisible reports whether the pager is open.
+func (p *ScrollbackPager) IsVisible() bool { return p != nil && p.visible }
+
+// SessionID returns the session the pager is bound to (for stale-capture guards).
+func (p *ScrollbackPager) SessionID() string {
+	if p == nil {
+		return ""
+	}
+	return p.sessionID
+}
+
+// SetSize records the terminal dimensions and re-clamps the scroll offset so a
+// resize can never leave the view scrolled past the end.
+func (p *ScrollbackPager) SetSize(width, height int) {
+	if p == nil {
+		return
+	}
+	p.width, p.height = width, height
+	p.clamp()
+}
+
+// Show opens the pager in a loading state bound to the given session. Content
+// arrives asynchronously via SetContent / SetError.
+func (p *ScrollbackPager) Show(title, sessionID string, width, height int) {
+	if p == nil {
+		return
+	}
+	p.visible = true
+	p.title = title
+	p.sessionID = sessionID
+	p.width, p.height = width, height
+	p.loading = true
+	p.errText = ""
+	p.lines = nil
+	p.offset = 0
+}
+
+// Hide closes the pager and releases the captured content.
+func (p *ScrollbackPager) Hide() {
+	if p == nil {
+		return
+	}
+	p.visible = false
+	p.loading = false
+	p.errText = ""
+	p.lines = nil
+	p.offset = 0
+	p.sessionID = ""
+}
+
+// SetContent installs captured history and pins the view to the live end (the
+// bottom), which is where the user was looking when they opened the pager. A
+// trailing empty line (tmux capture-pane often emits one) is dropped so the
+// initial view isn't a blank screen.
+func (p *ScrollbackPager) SetContent(content string) {
+	if p == nil {
+		return
+	}
+	p.loading = false
+	p.errText = ""
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	for len(lines) > 0 && strings.TrimRight(lines[len(lines)-1], " \t") == "" {
+		lines = lines[:len(lines)-1]
+	}
+	p.lines = lines
+	p.Bottom()
+}
+
+// SetError records a capture failure to render in the body.
+func (p *ScrollbackPager) SetError(msg string) {
+	if p == nil {
+		return
+	}
+	p.loading = false
+	p.errText = msg
+	p.lines = nil
+	p.offset = 0
+}
+
+// bodyHeight is the number of content rows between the header and footer.
+func (p *ScrollbackPager) bodyHeight() int {
+	// header (1) + footer (1) are fixed chrome rows.
+	h := p.height - 2
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+// maxOffset is the largest valid top-line index.
+func (p *ScrollbackPager) maxOffset() int {
+	m := len(p.lines) - p.bodyHeight()
+	if m < 0 {
+		return 0
+	}
+	return m
+}
+
+// clamp keeps offset within [0, maxOffset].
+func (p *ScrollbackPager) clamp() {
+	if p.offset < 0 {
+		p.offset = 0
+	}
+	if m := p.maxOffset(); p.offset > m {
+		p.offset = m
+	}
+}
+
+// ScrollUp moves the view toward the start of the session by n lines.
+func (p *ScrollbackPager) ScrollUp(n int) {
+	if p == nil || n < 1 {
+		return
+	}
+	p.offset -= n
+	p.clamp()
+}
+
+// ScrollDown moves the view toward the live end by n lines.
+func (p *ScrollbackPager) ScrollDown(n int) {
+	if p == nil || n < 1 {
+		return
+	}
+	p.offset += n
+	p.clamp()
+}
+
+// PageUp / PageDown scroll by a near-full body height, keeping one line of
+// overlap for reading continuity.
+func (p *ScrollbackPager) PageUp()   { p.ScrollUp(p.pageStep()) }
+func (p *ScrollbackPager) PageDown() { p.ScrollDown(p.pageStep()) }
+
+func (p *ScrollbackPager) pageStep() int {
+	step := p.bodyHeight() - 1
+	if step < 1 {
+		step = 1
+	}
+	return step
+}
+
+// Top jumps to the start of the session; Bottom to the live end.
+func (p *ScrollbackPager) Top() {
+	if p == nil {
+		return
+	}
+	p.offset = 0
+}
+
+func (p *ScrollbackPager) Bottom() {
+	if p == nil {
+		return
+	}
+	p.offset = p.maxOffset()
+}
+
+// View renders the pager: a header (title + position), the visible slice of
+// history, and a footer of key hints. Each content line is truncated to the
+// terminal width (ANSI-aware) and gets a trailing SGR reset so a colour left
+// open by capture-pane -e cannot bleed into the next row or the chrome.
+func (p *ScrollbackPager) View() string {
+	if p == nil || !p.visible {
+		return ""
+	}
+	width := p.width
+	if width < 1 {
+		width = 1
+	}
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15")).Background(lipgloss.Color("24"))
+	footerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("236"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+
+	var b strings.Builder
+
+	// Header
+	title := p.title
+	if title == "" {
+		title = "session"
+	}
+	pos := ""
+	switch {
+	case p.loading:
+		pos = "loading…"
+	case p.errText != "":
+		pos = "error"
+	case len(p.lines) == 0:
+		pos = "empty"
+	default:
+		last := p.offset + p.bodyHeight()
+		if last > len(p.lines) {
+			last = len(p.lines)
+		}
+		pos = fmt.Sprintf("lines %d-%d/%d", p.offset+1, last, len(p.lines))
+	}
+	header := cellTruncate(fmt.Sprintf(" Scrollback · %s ", title), width-lipgloss.Width(pos)-1, "…")
+	header = header + strings.Repeat(" ", max0(width-lipgloss.Width(header)-lipgloss.Width(pos)-1)) + pos + " "
+	b.WriteString(headerStyle.Width(width).Render(header))
+	b.WriteString("\n")
+
+	// Body
+	body := p.bodyHeight()
+	switch {
+	case p.loading:
+		b.WriteString(p.renderMessage(dimStyle, "Capturing session history…", body))
+	case p.errText != "":
+		b.WriteString(p.renderMessage(dimStyle, "Could not capture history: "+p.errText, body))
+	case len(p.lines) == 0:
+		b.WriteString(p.renderMessage(dimStyle, "No scrollback history.", body))
+	default:
+		end := p.offset + body
+		if end > len(p.lines) {
+			end = len(p.lines)
+		}
+		rows := 0
+		for i := p.offset; i < end; i++ {
+			line := cellTruncate(p.lines[i], width, "")
+			b.WriteString(line)
+			b.WriteString("\x1b[0m") // reset SGR so capture colours don't bleed
+			b.WriteString("\n")
+			rows++
+		}
+		for rows < body { // pad short buffers so the footer stays pinned
+			b.WriteString("\n")
+			rows++
+		}
+	}
+
+	// Footer
+	footer := cellTruncate(" ↑/↓ scroll · PgUp/PgDn · g start · G end · Esc back to session · Ctrl+Q list ", width, "…")
+	footer = footer + strings.Repeat(" ", max0(width-lipgloss.Width(footer)))
+	b.WriteString(footerStyle.Width(width).Render(footer))
+
+	return b.String()
+}
+
+// renderMessage centers a one-line message within the body rows.
+func (p *ScrollbackPager) renderMessage(style lipgloss.Style, msg string, body int) string {
+	var b strings.Builder
+	top := body / 2
+	for i := 0; i < body; i++ {
+		if i == top {
+			b.WriteString(style.Render(cellTruncate(msg, p.width, "…")))
+		}
+		if i < body-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func max0(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}

--- a/internal/ui/scrollback_pager_test.go
+++ b/internal/ui/scrollback_pager_test.go
@@ -1,0 +1,260 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolvedScrollbackTrigger covers the [hotkeys].scrollback resolution:
+// default PageUp, a ctrl+letter chord, explicit disable, and the
+// unrecognized-value fallback.
+func TestResolvedScrollbackTrigger(t *testing.T) {
+	tests := []struct {
+		name         string
+		overrides    map[string]string
+		wantPageUp   bool
+		wantKeyByte  byte
+		wantEnabled  bool
+		wantLabelPfx string
+	}{
+		{
+			name:         "default is pageup",
+			overrides:    nil,
+			wantPageUp:   true,
+			wantEnabled:  true,
+			wantLabelPfx: "PageUp",
+		},
+		{
+			name:         "explicit pageup",
+			overrides:    map[string]string{"scrollback": "pageup"},
+			wantPageUp:   true,
+			wantEnabled:  true,
+			wantLabelPfx: "PageUp",
+		},
+		{
+			name:         "ctrl+g chord",
+			overrides:    map[string]string{"scrollback": "ctrl+g"},
+			wantKeyByte:  7,
+			wantEnabled:  true,
+			wantLabelPfx: "Ctrl+G",
+		},
+		{
+			name:        "empty string disables",
+			overrides:   map[string]string{"scrollback": ""},
+			wantEnabled: false,
+		},
+		{
+			name:         "unrecognized value falls back to pageup",
+			overrides:    map[string]string{"scrollback": "banana"},
+			wantPageUp:   true,
+			wantEnabled:  true,
+			wantLabelPfx: "PageUp",
+		},
+		{
+			name:         "action name case-insensitive",
+			overrides:    map[string]string{"SCROLLBACK": "ctrl+g"},
+			wantKeyByte:  7,
+			wantEnabled:  true,
+			wantLabelPfx: "Ctrl+G",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolvedScrollbackTrigger(tt.overrides)
+			if got.OnPageUp != tt.wantPageUp {
+				t.Errorf("OnPageUp = %v, want %v", got.OnPageUp, tt.wantPageUp)
+			}
+			if got.KeyByte != tt.wantKeyByte {
+				t.Errorf("KeyByte = %d, want %d", got.KeyByte, tt.wantKeyByte)
+			}
+			if got.Enabled() != tt.wantEnabled {
+				t.Errorf("Enabled() = %v, want %v", got.Enabled(), tt.wantEnabled)
+			}
+			if tt.wantLabelPfx != "" && got.Label() != tt.wantLabelPfx {
+				t.Errorf("Label() = %q, want %q", got.Label(), tt.wantLabelPfx)
+			}
+			if !tt.wantEnabled && got.Label() != "" {
+				t.Errorf("disabled Label() = %q, want empty", got.Label())
+			}
+		})
+	}
+}
+
+// TestScrollbackPager_LoadingAndContent verifies the pager opens in a loading
+// state, then installs content pinned to the live end (bottom).
+func TestScrollbackPager_LoadingAndContent(t *testing.T) {
+	p := NewScrollbackPager()
+	if p.IsVisible() {
+		t.Fatal("new pager should be hidden")
+	}
+	p.Show("mysession", "id-1", 80, 10)
+	if !p.IsVisible() {
+		t.Fatal("Show should make the pager visible")
+	}
+	if p.SessionID() != "id-1" {
+		t.Fatalf("SessionID = %q, want id-1", p.SessionID())
+	}
+	if !p.loading {
+		t.Fatal("pager should start in loading state")
+	}
+	if !strings.Contains(p.View(), "loading") {
+		t.Errorf("loading View should mention loading, got:\n%s", p.View())
+	}
+
+	// 20 lines into a body of 8 (height 10 - 2 chrome) => bottom offset = 12.
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, "line-"+string(rune('A'+i-1)))
+	}
+	p.SetContent(strings.Join(lines, "\n"))
+	if p.loading {
+		t.Error("SetContent should clear loading")
+	}
+	if got := p.maxOffset(); p.offset != got {
+		t.Errorf("SetContent should pin to bottom: offset=%d, maxOffset=%d", p.offset, got)
+	}
+	// Body height 8 => maxOffset 12.
+	if p.maxOffset() != 12 {
+		t.Errorf("maxOffset = %d, want 12", p.maxOffset())
+	}
+}
+
+// TestScrollbackPager_ScrollAndClamp verifies scrolling stays within bounds and
+// Top/Bottom jump to the extremes.
+func TestScrollbackPager_ScrollAndClamp(t *testing.T) {
+	p := NewScrollbackPager()
+	p.Show("s", "id", 80, 10) // body height 8
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = "row"
+	}
+	p.SetContent(strings.Join(lines, "\n"))
+
+	p.Top()
+	if p.offset != 0 {
+		t.Errorf("Top offset = %d, want 0", p.offset)
+	}
+	// Cannot scroll above the top.
+	p.ScrollUp(5)
+	if p.offset != 0 {
+		t.Errorf("ScrollUp past top: offset = %d, want 0", p.offset)
+	}
+	p.ScrollDown(3)
+	if p.offset != 3 {
+		t.Errorf("ScrollDown 3: offset = %d, want 3", p.offset)
+	}
+	p.Bottom()
+	if p.offset != 12 {
+		t.Errorf("Bottom offset = %d, want 12", p.offset)
+	}
+	// Cannot scroll below the bottom.
+	p.ScrollDown(100)
+	if p.offset != 12 {
+		t.Errorf("ScrollDown past bottom: offset = %d, want 12", p.offset)
+	}
+	// PageUp scrolls by body-1 (7) with overlap.
+	p.PageUp()
+	if p.offset != 5 {
+		t.Errorf("PageUp offset = %d, want 5", p.offset)
+	}
+	p.PageDown()
+	if p.offset != 12 {
+		t.Errorf("PageDown offset = %d, want 12", p.offset)
+	}
+}
+
+// TestScrollbackPager_ShortBuffer verifies a buffer that fits entirely on
+// screen never scrolls (maxOffset 0).
+func TestScrollbackPager_ShortBuffer(t *testing.T) {
+	p := NewScrollbackPager()
+	p.Show("s", "id", 80, 20) // body height 18
+	p.SetContent("only\ntwo lines")
+	if p.maxOffset() != 0 {
+		t.Errorf("short buffer maxOffset = %d, want 0", p.maxOffset())
+	}
+	p.ScrollUp(5)
+	if p.offset != 0 {
+		t.Errorf("short buffer offset after ScrollUp = %d, want 0", p.offset)
+	}
+}
+
+// TestScrollbackPager_TrailingBlankTrimmed verifies capture-pane's common
+// trailing blank line is trimmed so the initial view isn't blank.
+func TestScrollbackPager_TrailingBlankTrimmed(t *testing.T) {
+	p := NewScrollbackPager()
+	p.Show("s", "id", 80, 10)
+	p.SetContent("a\nb\nc\n\n")
+	if len(p.lines) != 3 {
+		t.Errorf("trailing blanks not trimmed: got %d lines %q", len(p.lines), p.lines)
+	}
+}
+
+// TestScrollbackPager_ViewStates verifies the body renders each state and that
+// content lines get an SGR reset appended.
+func TestScrollbackPager_ViewStates(t *testing.T) {
+	p := NewScrollbackPager()
+
+	// Error state (width 80 so the message isn't truncated).
+	p.Show("s", "id", 80, 8)
+	p.SetError("capture timed out")
+	if !strings.Contains(p.View(), "capture timed out") {
+		t.Errorf("error View missing message:\n%s", p.View())
+	}
+
+	// Empty state.
+	p.Show("s", "id", 80, 8)
+	p.SetContent("")
+	if !strings.Contains(p.View(), "No scrollback") {
+		t.Errorf("empty View missing message:\n%s", p.View())
+	}
+
+	// Content state.
+	p.Show("s2", "id2", 80, 8)
+	p.SetContent("hello\nworld")
+	v := p.View()
+	if !strings.Contains(v, "hello") || !strings.Contains(v, "world") {
+		t.Errorf("content View missing lines:\n%s", v)
+	}
+	if !strings.Contains(v, "\x1b[0m") {
+		t.Error("content lines should get an SGR reset")
+	}
+	if !strings.Contains(v, "s2") {
+		t.Error("header should include the session title")
+	}
+	// Footer hint present.
+	if !strings.Contains(v, "start") || !strings.Contains(v, "session") {
+		t.Errorf("footer hints missing:\n%s", v)
+	}
+}
+
+// TestScrollbackPager_Hide clears state.
+func TestScrollbackPager_Hide(t *testing.T) {
+	p := NewScrollbackPager()
+	p.Show("s", "id", 40, 8)
+	p.SetContent("a\nb\nc")
+	p.Hide()
+	if p.IsVisible() || p.SessionID() != "" || len(p.lines) != 0 {
+		t.Errorf("Hide did not fully reset: visible=%v id=%q lines=%d",
+			p.IsVisible(), p.SessionID(), len(p.lines))
+	}
+	if p.View() != "" {
+		t.Error("hidden View should be empty")
+	}
+}
+
+// TestScrollbackPager_ResizeReclamps verifies a resize re-clamps the offset so
+// it can't point past the end after the body grows.
+func TestScrollbackPager_ResizeReclamps(t *testing.T) {
+	p := NewScrollbackPager()
+	p.Show("s", "id", 40, 10) // body 8
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = "x"
+	}
+	p.SetContent(strings.Join(lines, "\n")) // offset pinned to 12
+	// Grow the terminal so the body height jumps to 30 (all lines fit).
+	p.SetSize(40, 32)
+	if p.offset != 0 {
+		t.Errorf("after grow, offset = %d, want 0 (all lines fit)", p.offset)
+	}
+}

--- a/internal/ui/scrollback_wiring_test.go
+++ b/internal/ui/scrollback_wiring_test.go
@@ -1,0 +1,114 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestScrollbackContentMsg_StaleGuard verifies a capture that completes for a
+// different (or already-closed) session does not overwrite the pager, while a
+// matching capture installs its content.
+func TestScrollbackContentMsg_StaleGuard(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 80, 10
+	h.initialLoading = false
+	h.scrollbackPager.Show("s", "id-1", h.width, h.height)
+
+	// Stale: a capture for a different session must be ignored.
+	m, _ := h.Update(scrollbackContentMsg{sessionID: "id-2", content: "other\ncontent"})
+	h = m.(*Home)
+	if !h.scrollbackPager.loading {
+		t.Error("stale capture should leave the pager in its loading state")
+	}
+
+	// Matching: installs content and clears loading.
+	m, _ = h.Update(scrollbackContentMsg{sessionID: "id-1", content: "a\nb\nc"})
+	h = m.(*Home)
+	if h.scrollbackPager.loading {
+		t.Error("matching capture should clear loading")
+	}
+	if len(h.scrollbackPager.lines) != 3 {
+		t.Errorf("matching capture: got %d lines, want 3", len(h.scrollbackPager.lines))
+	}
+
+	// Error capture surfaces the error.
+	h.scrollbackPager.Show("s", "id-3", h.width, h.height)
+	m, _ = h.Update(scrollbackContentMsg{sessionID: "id-3", err: errors.New("boom")})
+	h = m.(*Home)
+	if h.scrollbackPager.errText != "boom" {
+		t.Errorf("error capture: errText = %q, want boom", h.scrollbackPager.errText)
+	}
+}
+
+// TestScrollbackContentMsg_IgnoredWhenClosed verifies a late capture after the
+// pager closed is dropped.
+func TestScrollbackContentMsg_IgnoredWhenClosed(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 80, 10
+	h.initialLoading = false
+	// Pager not visible.
+	m, _ := h.Update(scrollbackContentMsg{sessionID: "id-1", content: "x"})
+	h = m.(*Home)
+	if h.scrollbackPager.IsVisible() {
+		t.Error("content for a closed pager must not reopen it")
+	}
+}
+
+// TestScrollbackPagerKey_Routing verifies navigation keys scroll and Ctrl+Q
+// closes the pager to the list without re-attaching.
+func TestScrollbackPagerKey_Routing(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 80, 10 // body height 8
+	h.initialLoading = false
+	h.scrollbackPager.Show("s", "id", h.width, h.height)
+	// 20 lines => maxOffset 12, pinned to bottom.
+	content := ""
+	for i := 0; i < 20; i++ {
+		content += "row\n"
+	}
+	h.scrollbackPager.SetContent(content)
+	if h.scrollbackPager.offset != 12 {
+		t.Fatalf("setup: offset = %d, want 12", h.scrollbackPager.offset)
+	}
+
+	// 'g' jumps to the top.
+	m, _ := h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	h = m.(*Home)
+	if h.scrollbackPager.offset != 0 {
+		t.Errorf("after 'g': offset = %d, want 0", h.scrollbackPager.offset)
+	}
+
+	// 'j' scrolls down one.
+	m, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	h = m.(*Home)
+	if h.scrollbackPager.offset != 1 {
+		t.Errorf("after 'j': offset = %d, want 1", h.scrollbackPager.offset)
+	}
+
+	// Ctrl+Q closes to the list without re-attaching.
+	m, _ = h.Update(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	h = m.(*Home)
+	if h.scrollbackPager.IsVisible() {
+		t.Error("Ctrl+Q should close the pager")
+	}
+}
+
+// TestScrollbackPagerKey_EscReattaches verifies Esc closes the pager (the
+// re-attach command targets the bound session).
+func TestScrollbackPagerKey_EscReattaches(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 80, 10
+	h.initialLoading = false
+	h.scrollbackPager.Show("s", "missing-id", h.width, h.height)
+	h.scrollbackPager.SetContent("a\nb")
+
+	// Esc closes the pager. The re-attach command is a no-op here because the
+	// session id isn't in the instance map, but the pager must close.
+	m, _ := h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	h = m.(*Home)
+	if h.scrollbackPager.IsVisible() {
+		t.Error("Esc should close the pager")
+	}
+}


### PR DESCRIPTION
Closes #1491. In-view scrollback pager (PageUp default, configurable via `[hotkeys].scrollback`) for the control-mode deck attach. tmux control mode owns the viewport so its native copy-mode/wheel scrollback never engages; this adds a full-screen ANSI-safe pager that captures history with `capture-pane -e -S` under a timeout. Display-only, schema-neutral. Build + vet green; targeted sandboxed tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-attach scrollback pager for viewing recent session history.
  * Supports PageUp or configurable Ctrl+letter shortcuts, with collision handling.
  * Added scrolling, navigation, mouse-wheel support, loading, empty, and error states.
  * Added help overlay guidance for the configured scrollback shortcut.
  * Users can disable the feature through configuration.

* **Documentation**
  * Updated the example configuration with scrollback pager settings and usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->