### PR TITLE
fix(tui): free group-create Tab and typed-path Enter (#1536)

### DIFF
--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -330,16 +330,16 @@ func (g *GroupDialog) Update(msg tea.KeyMsg) (*GroupDialog, tea.Cmd) {
 	}
 
 	// Issue #918: in Create mode, Tab cycles name ↔ path. Shift+Tab cycles back.
-	// When the Root/Subgroup toggle from #111 is available, Tab still toggles
-	// while focus is on the name field — preserving the existing #111 binding
-	// — and on the path field Tab returns focus to name.
+	// Issue #1536: Tab now ALWAYS advances focus so the Default Path field is
+	// reachable by normal Tab traversal. Previously, when the #111 Root/Subgroup
+	// toggle was available, Tab toggled on the name field and never fell through
+	// to focus the path — trapping the user. The toggle is rebound to Up/Down
+	// (see below): Space is a legal group-name character, Left/Right move the
+	// text cursor, so Up/Down is the only free binding for the Root/Subgroup
+	// toggle across both single-line inputs.
 	if g.mode == GroupDialogCreate {
 		switch msg.String() {
 		case "tab":
-			if g.CanToggle() && g.focusIndex == 0 {
-				g.ToggleRootSubgroup()
-				return g, nil
-			}
 			if g.focusIndex == 0 {
 				g.focusPath()
 			} else {
@@ -353,6 +353,14 @@ func (g *GroupDialog) Update(msg tea.KeyMsg) (*GroupDialog, tea.Cmd) {
 				g.focusName()
 			}
 			return g, nil
+		case "up", "down":
+			// Issue #1536: Root/Subgroup toggle, rebound off Tab. No-op (falls
+			// through to the text input, which ignores Up/Down) when there is no
+			// group context to toggle into.
+			if g.CanToggle() {
+				g.ToggleRootSubgroup()
+				return g, nil
+			}
 		}
 	}
 
@@ -446,7 +454,7 @@ func (g *GroupDialog) View() string {
 	var hint string
 	switch {
 	case g.mode == GroupDialogCreate && g.CanToggle():
-		hint = hintStyle.Render("Tab toggle/next │ Shift+Tab prev │ Enter confirm │ Esc cancel")
+		hint = hintStyle.Render("↑↓ Root/Subgroup │ Tab next │ Shift+Tab prev │ Enter confirm │ Esc cancel")
 	case g.mode == GroupDialogCreate:
 		hint = hintStyle.Render("Tab next │ Shift+Tab prev │ Enter confirm │ Esc cancel")
 	default:

--- a/internal/ui/issue1536_dialog_ux_test.go
+++ b/internal/ui/issue1536_dialog_ux_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Issue #1536 — TUI dialog UX pass.
+//
+// Case 1 (group create): with a group/session context open the Root/Subgroup
+// toggle was bound to Tab on the name field, so forward-Tab kept toggling and
+// never reached the Default Path field — trapping the user. Fix: Tab always
+// advances focus; the toggle is rebound to Up/Down.
+//
+// Case 2 (new-session path): after typing a custom directory, Enter on the Path
+// field re-opened the browse dropdown (only Ctrl+S proceeded), so it felt like a
+// loop. Fix: Enter on an actively-typed path that already resolves to an existing
+// directory advances focus; Enter still browses for the soft-selected pre-fill
+// and for empty/non-existent paths.
+
+// Case 1a: Tab from the name field reaches the Default Path field (does NOT
+// toggle Root/Subgroup) when a group context makes the toggle available.
+func TestIssue1536_GroupCreate_TabReachesDefaultPath(t *testing.T) {
+	g := NewGroupDialog()
+	// Cursor on a session inside a group → defaults to root, toggle available.
+	g.ShowCreateWithContextDefaultRoot("work", "work")
+
+	if !g.CanToggle() {
+		t.Fatal("precondition: CanToggle() should be true with a group context")
+	}
+	if g.focusIndex != 0 {
+		t.Fatalf("precondition: initial focus = %d, want 0 (name)", g.focusIndex)
+	}
+	rootBefore := g.GetGroupPath()
+
+	// Type the group name.
+	for _, r := range "projects" {
+		updated, _ := g.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		g = updated
+	}
+
+	// Forward Tab must move focus to the Default Path field, NOT toggle the mode.
+	updated, _ := g.Update(tea.KeyMsg{Type: tea.KeyTab})
+	g = updated
+
+	if g.focusIndex != 1 {
+		t.Fatalf("after Tab, focusIndex = %d, want 1 (Default Path) — Tab is trapped on the toggle", g.focusIndex)
+	}
+	if g.GetGroupPath() != rootBefore {
+		t.Fatalf("Tab toggled Root/Subgroup (groupPath %q → %q); Tab must only move focus", rootBefore, g.GetGroupPath())
+	}
+
+	// The path field must now accept input.
+	tmpRepo := t.TempDir()
+	for _, r := range tmpRepo {
+		updated, _ := g.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		g = updated
+	}
+	if got := g.GetDefaultPath(); got != tmpRepo {
+		t.Fatalf("GetDefaultPath() = %q, want %q — Default Path unreachable via Tab", got, tmpRepo)
+	}
+}
+
+// Case 1b: Up/Down toggles Root/Subgroup (the rebound binding) without moving
+// text-input focus.
+func TestIssue1536_GroupCreate_UpDownToggles(t *testing.T) {
+	g := NewGroupDialog()
+	g.ShowCreateWithContextDefaultRoot("work", "work")
+
+	if g.GetGroupPath() != "" {
+		t.Fatalf("precondition: expected root mode (empty groupPath), got %q", g.GetGroupPath())
+	}
+
+	// Down switches root → subgroup.
+	updated, _ := g.Update(tea.KeyMsg{Type: tea.KeyDown})
+	g = updated
+	if g.GetGroupPath() != "work" {
+		t.Fatalf("after Down, groupPath = %q, want \"work\" (subgroup)", g.GetGroupPath())
+	}
+	if g.focusIndex != 0 {
+		t.Fatalf("Down changed focus (focusIndex=%d); toggle must not move focus", g.focusIndex)
+	}
+
+	// Up switches subgroup → root.
+	updated, _ = g.Update(tea.KeyMsg{Type: tea.KeyUp})
+	g = updated
+	if g.GetGroupPath() != "" {
+		t.Fatalf("after Up, groupPath = %q, want \"\" (root)", g.GetGroupPath())
+	}
+}
+
+// Case 2a: Enter on a typed, existing-directory path advances focus instead of
+// re-opening the browse dropdown.
+func TestIssue1536_NewDialog_EnterOnValidPathAdvances(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	d.focusIndex = d.indexOf(focusPath)
+	d.updateFocus()
+
+	// Simulate a user-typed custom path (not the soft-selected pre-fill).
+	d.pathSoftSelected = false
+	d.pathInput.SetValue(tmpDir)
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if d.IsSuggestionsActive() {
+		t.Fatal("Enter on a typed existing-directory path reopened the browse dropdown (the reported loop)")
+	}
+	if d.currentTarget() == focusPath {
+		t.Fatal("Enter on a valid typed path did not advance focus off the Path field")
+	}
+}
+
+// Case 2b: Enter still opens the browse dropdown for the soft-selected pre-fill
+// and for empty/non-existent paths (browse remains useful there).
+func TestIssue1536_NewDialog_EnterStillBrowsesWhenAppropriate(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Soft-selected pre-fill → Enter browses.
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	d.focusIndex = d.indexOf(focusPath)
+	d.updateFocus()
+	d.pathSoftSelected = true
+	d.pathInput.SetValue(tmpDir)
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !d.IsSuggestionsActive() {
+		t.Fatal("Enter on the soft-selected pre-fill should still open the browse dropdown")
+	}
+
+	// Non-existent typed path → Enter browses (path not yet usable).
+	d2 := NewNewDialog()
+	d2.SetSize(100, 50)
+	d2.Show()
+	d2.focusIndex = d2.indexOf(focusPath)
+	d2.updateFocus()
+	d2.pathSoftSelected = false
+	d2.pathInput.SetValue("/no/such/directory/issue1536")
+	d2, _ = d2.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !d2.IsSuggestionsActive() {
+		t.Fatal("Enter on a non-existent typed path should still open the browse dropdown")
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1985,6 +1985,28 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				return d, nil
 			}
 			if cur == focusPath {
+				// Issue #1536: Enter on an actively-typed path (not the
+				// soft-selected pre-fill) that already resolves to an existing
+				// directory advances to the next field instead of re-opening the
+				// browse dropdown. Previously Enter here unconditionally
+				// re-activated suggestions, so after typing a custom path Enter
+				// looped straight back into browse and only Ctrl+S proceeded.
+				// This mirrors the #896 Tab guard. Enter still opens browse for
+				// the soft-selected pre-fill and for empty or not-yet-existing
+				// paths (where the dropdown is genuinely useful).
+				if !d.pathSoftSelected {
+					v := strings.Trim(strings.TrimSpace(d.pathInput.Value()), "'\"")
+					if v != "" {
+						expanded := session.ExpandPath(v)
+						if info, err := os.Stat(expanded); err == nil && info.IsDir() {
+							d.moveFocus(1)
+							if d.currentTarget() != focusPath {
+								d.suggestionNavigated = false
+							}
+							return d, nil
+						}
+					}
+				}
 				d.suggestionsActive = true
 				d.suggestionsHidden = false
 				d.pathSoftSelected = false
@@ -2727,7 +2749,10 @@ func (d *NewDialog) View() string {
 		} else if d.pathSoftSelected {
 			helpText = "Type to replace │ Enter browse list │ ← edit │ Tab next │ Esc cancel"
 		} else {
-			helpText = "Tab autocomplete │ Enter browse list │ Esc cancel"
+			// Issue #1536: on a path that resolves to an existing directory,
+			// Enter advances to the next field; otherwise it opens the browse
+			// list. Advertise both so the typed-custom-path flow is discoverable.
+			helpText = "Tab autocomplete │ Enter next/browse │ Esc cancel"
 		}
 	} else if cur == focusBranch {
 		if d.branchPicker != nil && d.branchPicker.IsVisible() {


### PR DESCRIPTION
Closes #1536. Case 1: Tab no longer trapped on the Root/Subgroup toggle (rebound to Up/Down), so the Default Path field is reachable. Case 2: Enter on a typed existing-dir path advances focus instead of re-opening browse (mirrors the #896 guard); browse preserved for pre-fill/empty/non-existent. UI-only, schema-neutral. New regression tests (3 RED before fix); build + targeted sandboxed tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation when creating groups: Tab and Shift+Tab now move predictably between fields.
  * Up and Down now switch between Root and Subgroup modes without changing field focus.
  * Pressing Enter on an existing directory advances to the next field instead of reopening browse suggestions.
  * Browse suggestions remain available when appropriate.

* **UI Updates**
  * Updated keyboard guidance to reflect the revised controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->