### PR TITLE
fix(ui): nest remote sessions under their groups (#1553)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2303,25 +2303,9 @@ func (h *Home) rebuildFlatItems() {
 	sort.Strings(remoteNames)
 	if len(remotes) > 0 && h.statusFilter != FilterModeArchived {
 		for _, remoteName := range remoteNames {
-			sessions := remotes[remoteName]
-			// Add remote group header
-			h.flatItems = append(h.flatItems, session.Item{
-				Type:       session.ItemTypeRemoteGroup,
-				RemoteName: remoteName,
-				Path:       "remotes/" + remoteName,
-				Level:      0,
-			})
-			// Add remote sessions
-			for i := range sessions {
-				h.flatItems = append(h.flatItems, session.Item{
-					Type:          session.ItemTypeRemoteSession,
-					RemoteSession: &sessions[i],
-					RemoteName:    remoteName,
-					Path:          "remotes/" + remoteName,
-					Level:         1,
-					IsLastInGroup: i == len(sessions)-1,
-				})
-			}
+			// #1553: nest each remote's sessions under their Group paths
+			// instead of dumping them flat at Level 1.
+			h.flatItems = append(h.flatItems, buildRemoteFlatItems(remoteName, remotes[remoteName])...)
 		}
 	}
 
@@ -15995,14 +15979,6 @@ func (h *Home) renderRemotePreview(item session.Item, width, height int) string 
 
 // renderRemoteGroupItem renders a remote group header (e.g., "remotes/dev")
 func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, selected bool) {
-	// Count sessions for this remote
-	h.remoteSessionsMu.RLock()
-	count := 0
-	if sessions, ok := h.remoteSessions[item.RemoteName]; ok {
-		count = len(sessions)
-	}
-	h.remoteSessionsMu.RUnlock()
-
 	nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // yellow
 	countStyle := DimStyle
 	expandIcon := "▾"
@@ -16012,6 +15988,40 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 		countStyle = GroupCountSelStyle
 		selPrefix = "▶ "
 	}
+
+	// #1553: Level > 0 is a nested sub-group header ("remotes/<name>/<group>").
+	// Render the last path segment with a subtree count, indented by level, and
+	// no host-latency marker (latency is a host-level metric shown on Level 0).
+	if item.Level > 0 {
+		h.remoteSessionsMu.RLock()
+		sessions := h.remoteSessions[item.RemoteName]
+		groupPath := strings.TrimPrefix(item.Path, "remotes/"+item.RemoteName+"/")
+		count := remoteSubGroupCount(sessions, groupPath)
+		h.remoteSessionsMu.RUnlock()
+
+		segName := groupPath
+		if idx := strings.LastIndex(groupPath, "/"); idx >= 0 {
+			segName = groupPath[idx+1:]
+		}
+
+		b.WriteString(fmt.Sprintf("%s%s%s%s %s%s\n",
+			strings.Repeat(" ", leftGutterWidth), // align with group hotkey gutter
+			selPrefix,
+			strings.Repeat("  ", item.Level), // nest under the remote header
+			expandIcon,
+			nameStyle.Render(segName),
+			countStyle.Render(fmt.Sprintf(" (%d)", count)),
+		))
+		return
+	}
+
+	// Level 0: the remote host header. Count all sessions for this remote.
+	h.remoteSessionsMu.RLock()
+	count := 0
+	if sessions, ok := h.remoteSessions[item.RemoteName]; ok {
+		count = len(sessions)
+	}
+	h.remoteSessionsMu.RUnlock()
 
 	b.WriteString(fmt.Sprintf("%s%s%s %s%s%s\n",
 		strings.Repeat(" ", leftGutterWidth), // align with group hotkey gutter
@@ -16123,9 +16133,20 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 		selPrefix = "▶ "
 	}
 
-	b.WriteString(fmt.Sprintf("%s%s  %s %s %s%s\n",
+	// #1553: indent by the item's level so sessions sit one step below their
+	// owning group header. A session directly under a Level-1 group renders at
+	// Level 2 -> `strings.Repeat("  ", 2)` == 4 spaces; the old flat layout put
+	// sessions at Level 1 with a hardcoded 2-space indent, so Level-1 rows stay
+	// byte-identical to before.
+	indent := strings.Repeat("  ", item.Level)
+	if item.Level == 0 {
+		indent = "  " // defensive: never dedent past the old flat baseline
+	}
+
+	b.WriteString(fmt.Sprintf("%s%s%s%s %s %s%s\n",
 		strings.Repeat(" ", leftGutterWidth), // align with group/session hotkey gutter
 		selPrefix,
+		indent,
 		DimStyle.Render(treeConnector),
 		sStyle.Render(statusIcon),
 		titleStyle.Render(titleStr),

--- a/internal/ui/issue1553_remote_group_nesting_test.go
+++ b/internal/ui/issue1553_remote_group_nesting_test.go
@@ -1,0 +1,199 @@
+// Issue #1553 — Remote sessions ignore their Group and render as a flat
+// Level-1 dump under the remote host header. RemoteSessionInfo.Group crosses
+// the wire (internal/session/ssh.go) but the remote-append loop in
+// rebuildFlatItems discarded it. These tests pin the nested-tree behavior
+// added by buildRemoteFlatItems (internal/ui/remote_tree.go).
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// findRemoteItems returns only the remote portion of a flat item list.
+func remoteItemsOf(items []session.Item) []session.Item {
+	out := make([]session.Item, 0, len(items))
+	for _, it := range items {
+		if it.Type == session.ItemTypeRemoteGroup || it.Type == session.ItemTypeRemoteSession {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func TestIssue1553_RemoteSessionsNestUnderGroups(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{ID: "a", Title: "api-1", Group: "work", Status: "running"},
+		{ID: "b", Title: "api-2", Group: "work/api", Status: "idle"},
+		{ID: "c", Title: "loose", Group: "", Status: "waiting"}, // -> my-sessions
+	}
+
+	items := buildRemoteFlatItems("dev", sessions)
+
+	// Level-0 remote header comes first, path "remotes/dev".
+	if len(items) == 0 || items[0].Type != session.ItemTypeRemoteGroup || items[0].Level != 0 || items[0].Path != "remotes/dev" {
+		t.Fatalf("first item must be the Level-0 remote header, got %+v", items[0])
+	}
+
+	// Every session must appear under a group header whose Path encodes its
+	// group — the pre-fix bug put them all at Level 1 with Path "remotes/dev".
+	byID := map[string]session.Item{}
+	headerPaths := map[string]bool{}
+	for _, it := range items {
+		switch it.Type {
+		case session.ItemTypeRemoteGroup:
+			headerPaths[it.Path] = true
+		case session.ItemTypeRemoteSession:
+			byID[it.RemoteSession.ID] = it
+		}
+	}
+
+	// The ungrouped session must nest under the default group header.
+	if !headerPaths["remotes/dev/my-sessions"] {
+		t.Errorf("missing default-group header for ungrouped session; headers=%v", headerPaths)
+	}
+	if !headerPaths["remotes/dev/work"] || !headerPaths["remotes/dev/work/api"] {
+		t.Errorf("missing group headers for work / work/api; headers=%v", headerPaths)
+	}
+
+	// Session levels must sit one below their owning group header.
+	if got := byID["a"]; got.Level != 2 || got.Path != "remotes/dev/work" {
+		t.Errorf("session a (group work) = level %d path %q, want level 2 path remotes/dev/work", got.Level, got.Path)
+	}
+	if got := byID["b"]; got.Level != 3 || got.Path != "remotes/dev/work/api" {
+		t.Errorf("session b (group work/api) = level %d path %q, want level 3 path remotes/dev/work/api", got.Level, got.Path)
+	}
+	if got := byID["c"]; got.Level != 2 || got.Path != "remotes/dev/my-sessions" {
+		t.Errorf("session c (ungrouped) = level %d path %q, want level 2 path remotes/dev/my-sessions", got.Level, got.Path)
+	}
+}
+
+// TestIssue1553_RegressionGuard_NoFlatLevelOneDump pins the exact pre-fix
+// failure: no remote session may be emitted flat at Level 1 with the bare
+// "remotes/<name>" path.
+func TestIssue1553_RegressionGuard_NoFlatLevelOneDump(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{ID: "a", Title: "grouped", Group: "work"},
+		{ID: "b", Title: "loose", Group: ""},
+	}
+	items := buildRemoteFlatItems("dev", sessions)
+	for _, it := range items {
+		if it.Type != session.ItemTypeRemoteSession {
+			continue
+		}
+		if it.Level == 1 {
+			t.Errorf("remote session %q emitted flat at Level 1 — the #1553 bug", it.RemoteSession.ID)
+		}
+		if it.Path == "remotes/dev" {
+			t.Errorf("remote session %q kept the bare remote path (group discarded) — the #1553 bug", it.RemoteSession.ID)
+		}
+	}
+}
+
+// TestIssue1553_DeepPathEmitsIntermediateHeaders ensures a/b/c yields headers
+// for a, a/b, a/b/c in that order at increasing levels.
+func TestIssue1553_DeepPathEmitsIntermediateHeaders(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{ID: "deep", Title: "deep", Group: "a/b/c"},
+	}
+	items := buildRemoteFlatItems("dev", sessions)
+
+	want := []struct {
+		path  string
+		level int
+	}{
+		{"remotes/dev", 0},
+		{"remotes/dev/a", 1},
+		{"remotes/dev/a/b", 2},
+		{"remotes/dev/a/b/c", 3},
+	}
+	headers := []session.Item{}
+	for _, it := range items {
+		if it.Type == session.ItemTypeRemoteGroup {
+			headers = append(headers, it)
+		}
+	}
+	if len(headers) != len(want) {
+		t.Fatalf("got %d headers, want %d: %+v", len(headers), len(want), headers)
+	}
+	for i, w := range want {
+		if headers[i].Path != w.path || headers[i].Level != w.level {
+			t.Errorf("header[%d] = (%q, L%d), want (%q, L%d)", i, headers[i].Path, headers[i].Level, w.path, w.level)
+		}
+	}
+	// The session sits one below a/b/c.
+	for _, it := range items {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession.ID == "deep" {
+			if it.Level != 4 || it.Path != "remotes/dev/a/b/c" {
+				t.Errorf("deep session = level %d path %q, want level 4 path remotes/dev/a/b/c", it.Level, it.Path)
+			}
+		}
+	}
+}
+
+// TestIssue1553_IntegrationThroughRebuild drives the real rebuildFlatItems and
+// confirms the nested headers reach h.flatItems, and the header renderer shows
+// the sub-group segment name + subtree count.
+func TestIssue1553_IntegrationThroughRebuild(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 40
+	home.refreshSessionRenderSnapshot(nil)
+
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "a", Title: "api-1", Group: "work", Tool: "claude", Status: "running", RemoteName: "dev"},
+			{ID: "b", Title: "api-2", Group: "work/api", Tool: "claude", Status: "idle", RemoteName: "dev"},
+			{ID: "c", Title: "loose", Group: "", Tool: "claude", Status: "waiting", RemoteName: "dev"},
+		},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	home.rebuildFlatItems()
+
+	rem := remoteItemsOf(home.flatItems)
+	if len(rem) == 0 {
+		t.Fatal("no remote items in flatItems after rebuild")
+	}
+	// At least the remote header + 3 sub-group headers (my-sessions, work,
+	// work/api) + 3 sessions.
+	headers, remoteSessions := 0, 0
+	var workHeader session.Item
+	foundWork := false
+	for _, it := range rem {
+		if it.Type == session.ItemTypeRemoteGroup {
+			headers++
+			if it.Path == "remotes/dev/work" {
+				workHeader = it
+				foundWork = true
+			}
+		} else {
+			remoteSessions++
+		}
+	}
+	if headers < 4 {
+		t.Errorf("headers = %d, want >= 4 (remote + my-sessions + work + work/api)", headers)
+	}
+	if remoteSessions != 3 {
+		t.Errorf("remote sessions = %d, want 3", remoteSessions)
+	}
+	if !foundWork {
+		t.Fatal("no remotes/dev/work sub-group header emitted")
+	}
+
+	// Render the sub-group header: it must show the segment name "work" and a
+	// subtree count of 2 (work + work/api), indented, no host-latency marker.
+	var b strings.Builder
+	home.renderRemoteGroupItem(&b, workHeader, false)
+	out := b.String()
+	if !strings.Contains(out, "work") {
+		t.Errorf("sub-group header render missing segment name: %q", out)
+	}
+	if !strings.Contains(out, "(2)") {
+		t.Errorf("sub-group header render missing subtree count (2): %q", out)
+	}
+}

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// buildRemoteFlatItems renders a single remote's sessions as a nested
+// group tree instead of a flat Level-1 dump (#1553).
+//
+// Before this helper the remote-append loop in rebuildFlatItems emitted one
+// ItemTypeRemoteGroup header per remote and appended every session flat at
+// Level 1, discarding sessions[i].Group even though RemoteSessionInfo.Group
+// crosses the wire (internal/session/ssh.go). This buckets each remote's
+// sessions by their Group path (empty Group -> session.DefaultGroupPath),
+// emits intermediate headers for nested "a/b/c" paths, and places sessions one
+// level below their owning group — mirroring how the local tree nests groups.
+//
+// The returned slice always starts with the Level-0 remote header
+// (Path = "remotes/<name>"), so callers append it directly. Sub-group headers
+// carry Path = "remotes/<name>/<group-path>" so cursor-identity restore, which
+// matches ItemTypeRemoteGroup on RemoteName+Path, keeps working unchanged.
+func buildRemoteFlatItems(remoteName string, sessions []session.RemoteSessionInfo) []session.Item {
+	items := make([]session.Item, 0, len(sessions)+2)
+
+	// Level-0 remote header. Rendering/latency for this row is unchanged.
+	items = append(items, session.Item{
+		Type:       session.ItemTypeRemoteGroup,
+		RemoteName: remoteName,
+		Path:       "remotes/" + remoteName,
+		Level:      0,
+	})
+
+	// Bucket sessions by normalized group path. Preserve input order within a
+	// bucket (the fetch layer already sorted them) by tracking indices.
+	buckets := make(map[string][]int)
+	for i := range sessions {
+		g := normalizeRemoteGroupPath(sessions[i].Group)
+		buckets[g] = append(buckets[g], i)
+	}
+
+	// Sort group paths lexicographically. Lexicographic order places a parent
+	// path directly before all of its descendants ("a" < "a/b" < "a/c" < "b"),
+	// which lets us emit intermediate headers with a simple prefix walk.
+	groupPaths := make([]string, 0, len(buckets))
+	for g := range buckets {
+		groupPaths = append(groupPaths, g)
+	}
+	sort.Strings(groupPaths)
+
+	emitted := make(map[string]bool) // group paths whose header we already wrote
+
+	for _, gp := range groupPaths {
+		// Emit a header for every not-yet-emitted prefix of this group path so
+		// nested "a/b/c" gets headers for "a", "a/b", "a/b/c" in order.
+		segments := strings.Split(gp, "/")
+		prefix := ""
+		for depth, seg := range segments {
+			if prefix == "" {
+				prefix = seg
+			} else {
+				prefix = prefix + "/" + seg
+			}
+			if emitted[prefix] {
+				continue
+			}
+			emitted[prefix] = true
+			items = append(items, session.Item{
+				Type:       session.ItemTypeRemoteGroup,
+				RemoteName: remoteName,
+				Path:       "remotes/" + remoteName + "/" + prefix,
+				Level:      depth + 1, // Level 0 is the remote header
+			})
+		}
+
+		// Sessions sit one level below their owning group header.
+		sessionLevel := len(segments) + 1
+		idxs := buckets[gp]
+		for j, idx := range idxs {
+			items = append(items, session.Item{
+				Type:          session.ItemTypeRemoteSession,
+				RemoteSession: &sessions[idx],
+				RemoteName:    remoteName,
+				Path:          "remotes/" + remoteName + "/" + gp,
+				Level:         sessionLevel,
+				IsLastInGroup: j == len(idxs)-1,
+			})
+		}
+	}
+
+	return items
+}
+
+// normalizeRemoteGroupPath maps an empty remote group to the default group
+// path so ungrouped remote sessions nest under "my-sessions" just like local
+// ungrouped sessions.
+func normalizeRemoteGroupPath(group string) string {
+	g := strings.Trim(strings.TrimSpace(group), "/")
+	if g == "" {
+		return session.DefaultGroupPath
+	}
+	return g
+}
+
+// remoteSubGroupCount counts sessions belonging to a remote sub-group header
+// (Path "remotes/<name>/<group>") or any of its descendant groups. Used by the
+// header renderer to show a subtree count without threading a count field
+// through session.Item.
+func remoteSubGroupCount(sessions []session.RemoteSessionInfo, groupPath string) int {
+	count := 0
+	for i := range sessions {
+		g := normalizeRemoteGroupPath(sessions[i].Group)
+		if g == groupPath || strings.HasPrefix(g, groupPath+"/") {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
Closes #1553. Remote sessions now render nested under their Group paths instead of a flat Level-1 dump. The append loop now reads the Group field (already on the wire), buckets sessions, sorts group paths, and emits intermediate headers for nested paths, mirroring the local tree. Display-only; adds internal/ui/remote_tree.go plus regression tests. Build + targeted sandboxed tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote sessions now appear in nested groups based on their group paths.
  - Added support for multi-level remote subgroups with clear indentation and session counts.
  - Ungrouped remote sessions are displayed under a default session group.

- **Bug Fixes**
  - Remote sessions no longer appear flattened under a single remote host entry.
  - Improved alignment between remote group headers and their sessions.

- **Tests**
  - Added coverage for nested, deep, ungrouped, and integrated remote session grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->