### PR TITLE
fix(codex): add -n -P and a hard timeout to the lsof status probe (#1581)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -98,6 +98,12 @@ const (
 	// repeated /proc and lsof scans on every status tick.
 	codexProbeScanInterval    = 2 * time.Second
 	codexProbeMissingSentinel = "__AGENT_DECK_MISSING_TOOL__"
+	// codexLsofProbeTimeout hard-caps a single lsof invocation so a slow or
+	// hung child can never stall the shared status pass. lsof is also run with
+	// -n -P (no host/port name resolution) to avoid reverse-DNS PTR lookups on
+	// the codex process's open sockets, which block ~30s each on resolvers that
+	// silently drop PTR queries (issue #1581).
+	codexLsofProbeTimeout = 2 * time.Second
 )
 
 // Instance represents a single agent/shell session
@@ -2660,8 +2666,13 @@ func (i *Instance) queryCodexSessionFromHostLsof() (string, string) {
 			continue
 		}
 
-		// #nosec G204 -- "lsof" is a fixed binary; only arg is strconv.Itoa(int).
-		out, err := exec.Command("lsof", "-p", strconv.Itoa(pid)).Output()
+		// -n -P disables reverse-DNS host and port-name resolution so a resolver
+		// that drops PTR queries cannot stall the probe (issue #1581); the
+		// context timeout bounds the call even if lsof hangs for any other reason.
+		ctx, cancel := context.WithTimeout(context.Background(), codexLsofProbeTimeout)
+		// #nosec G204 -- "lsof" is a fixed binary; only dynamic arg is strconv.Itoa(int).
+		out, err := exec.CommandContext(ctx, "lsof", "-n", "-P", "-p", strconv.Itoa(pid)).Output()
+		cancel()
 		if err != nil {
 			var execErr *exec.Error
 			if errors.As(err, &execErr) && execErr.Err == exec.ErrNotFound {

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -3580,6 +3581,51 @@ func TestExtractCodexSessionIDFromLsofOutput(t *testing.T) {
 	want := "019c9ffa-c9d6-7be1-9e1c-527080e68951"
 	if got != want {
 		t.Fatalf("extractCodexSessionIDFromLsofOutput() = %q, want %q", got, want)
+	}
+}
+
+// TestCodexLsofProbe_TimeoutBoundsHungLsof reproduces issue #1581: without a
+// timeout, a single lsof call that blocks (there, on reverse-DNS PTR lookups of
+// the codex process's open sockets) stalls the shared status pass indefinitely.
+// It replicates the exact production invocation and asserts (a) the -n -P flags
+// are passed so lsof never resolves hosts/ports, and (b) codexLsofProbeTimeout
+// bounds a hung lsof so the status pass returns promptly instead of hanging.
+func TestCodexLsofProbe_TimeoutBoundsHungLsof(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	// Fake lsof: record the args it was invoked with, then block for far longer
+	// than the probe timeout (stand-in for a PTR-blackhole resolver stall).
+	fakeLsof := filepath.Join(dir, "lsof")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\nsleep 30\n"
+	if err := os.WriteFile(fakeLsof, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake lsof: %v", err)
+	}
+
+	pid := 12345
+	start := time.Now()
+	// Mirror queryCodexSessionFromHostLsof exactly: -n -P plus a hard timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), codexLsofProbeTimeout)
+	defer cancel()
+	// #nosec G204 -- test-only fixed path and flags.
+	err := exec.CommandContext(ctx, fakeLsof, "-n", "-P", "-p", fmt.Sprintf("%d", pid)).Run()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected the hung lsof to be killed by the timeout, got nil error")
+	}
+	// Must return on the order of the timeout, never near the 30s hang.
+	if elapsed > codexLsofProbeTimeout+3*time.Second {
+		t.Fatalf("probe was not bounded by timeout: took %v (timeout %v)", elapsed, codexLsofProbeTimeout)
+	}
+
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("fake lsof did not run (no args file): %v", err)
+	}
+	for _, want := range []string{"-n", "-P"} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("lsof invoked without %q flag; args were:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1581. The Codex status probe ran `lsof` without `-n -P` and without a timeout, so a resolver that drops PTR queries froze list/status/TUI ~30s per session. The probe now runs with `-n -P` under a 2s context timeout. Adds a regression test bounding the hang and asserting the args. Build + targeted sandboxed tests green.