### PR TITLE
fix(tmux): let explicit user tmux config win over forced key options (#1625)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1998,6 +1998,42 @@ func isSocketAcceptingConnections(socketPath string) bool {
 	return true
 }
 
+// gatedTmuxKeyOptionArgs returns the tmux argument chunks for agent-deck's
+// key-handling defaults — escape-time, extended-keys, extended-keys-format and
+// terminal-features — each gated through OptionOverrides so an explicit user
+// setting wins (#1625). Every chunk begins with a ";" chain separator, so
+// callers append the result after an existing set-option in the same tmux
+// command (the same shape the window-size default already uses).
+//
+// extended-keys / extended-keys-format are *server* options (set -s). Emitting
+// them unconditionally on every spawn overrode a deliberate
+// `set -s extended-keys off` in the user's ~/.tmux.conf server-wide, which on
+// some terminals (e.g. Windows Terminal + WSL2) stops Enter from submitting in
+// the pane. terminal-features uses -a (append), so re-emitting it every spawn
+// also grew that server-wide option unbounded. Gating each key through
+// OptionOverrides lets config.toml [tmux] options — and by extension the user's
+// own tmux config — take effect instead of being silently clobbered.
+func gatedTmuxKeyOptionArgs(name string, overrides map[string]string) []string {
+	args := make([]string, 0, 20)
+	if _, ok := overrides["escape-time"]; !ok {
+		args = append(args, ";", "set-option", "-t", name, "escape-time", "10")
+	}
+	if _, ok := overrides["extended-keys"]; !ok {
+		args = append(args, ";", "set", "-sq", "extended-keys", "on")
+	}
+	if _, ok := overrides["extended-keys-format"]; !ok {
+		// csi-u so modified keys reach the pane as ESC[13;2u (the kitty
+		// keyboard-protocol form Claude Code reads) rather than the default
+		// xterm modifyOtherKeys ESC[27;2;13~, which Claude Code ignores —
+		// otherwise Shift+Enter collapses to a bare Enter and submits.
+		args = append(args, ";", "set", "-sq", "extended-keys-format", "csi-u")
+	}
+	if _, ok := overrides["terminal-features"]; !ok {
+		args = append(args, ";", "set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
+	}
+	return args
+}
+
 // Start creates and starts a tmux session.
 // By default, command is sent after session creation (legacy behavior).
 // When RunCommandAsInitialProcess is true, command is passed directly to tmux
@@ -2174,15 +2210,10 @@ func (s *Session) Start(command string) error {
 	}
 	startArgs = append(startArgs,
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
-		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
-		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set", "-sq", "extended-keys", "on", ";",
-		// csi-u so modified keys reach the pane as ESC[13;2u (the kitty
-		// keyboard-protocol form Claude Code reads) rather than the default
-		// xterm modifyOtherKeys ESC[27;2;13~, which Claude Code ignores —
-		// otherwise Shift+Enter collapses to a bare Enter and submits.
-		"set", "-sq", "extended-keys-format", "csi-u", ";",
-		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
+		"set-option", "-t", s.Name, "set-clipboard", "on")
+	// #1625: the key-handling defaults are gated through OptionOverrides so an
+	// explicit user tmux setting wins (see gatedTmuxKeyOptionArgs).
+	startArgs = append(startArgs, gatedTmuxKeyOptionArgs(s.Name, s.OptionOverrides)...)
 	// Multi-client size negotiation. Web's xterm.js connects via a tmux -C
 	// control client (controlpipe.go) at the same time as native `tmux attach`
 	// clients (Ghostty, iTerm). Default `window-size latest` makes the window
@@ -2548,17 +2579,14 @@ func (s *Session) EnableMouseMode() error {
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
 	//
 	// Uses -q flag where supported to silently ignore on older tmux versions
-	enhanceCmd := s.tmuxCmd(
+	enhanceArgs := []string{
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
-		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
-		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set", "-sq", "extended-keys", "on", ";",
-		// csi-u so modified keys reach the pane as ESC[13;2u (the kitty
-		// keyboard-protocol form Claude Code reads) rather than the default
-		// xterm modifyOtherKeys ESC[27;2;13~, which Claude Code ignores —
-		// otherwise Shift+Enter collapses to a bare Enter and submits.
-		"set", "-sq", "extended-keys-format", "csi-u", ";",
-		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
+		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on",
+	}
+	// #1625: gate the key-handling defaults through OptionOverrides so an explicit
+	// user tmux setting wins (mirrors Start; see gatedTmuxKeyOptionArgs).
+	enhanceArgs = append(enhanceArgs, gatedTmuxKeyOptionArgs(s.Name, s.OptionOverrides)...)
+	enhanceCmd := s.tmuxCmd(enhanceArgs...)
 	// Ignore errors - all these are non-fatal enhancements
 	// Older tmux versions may not support some options
 	_ = enhanceCmd.Run()

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3228,3 +3228,65 @@ func TestKillSessionsWithEnvValue_NoMatch(t *testing.T) {
 
 	assert.NoError(t, exec.Command("tmux", "has-session", "-t", sess).Run(), "session should not be killed")
 }
+
+// TestGatedTmuxKeyOptionArgs verifies #1625: the key-handling tmux defaults
+// (escape-time, extended-keys, extended-keys-format, terminal-features) are
+// gated through OptionOverrides so an explicit user setting wins instead of
+// being force-set on every spawn.
+func TestGatedTmuxKeyOptionArgs(t *testing.T) {
+	joined := func(args []string) string { return strings.Join(args, " ") }
+
+	// Default (no overrides): all four defaults are emitted, each chained with
+	// a leading ";" separator, and extended-keys is a server option (set -s).
+	def := gatedTmuxKeyOptionArgs("sess", nil)
+	got := joined(def)
+	for _, want := range []string{
+		"; set-option -t sess escape-time 10",
+		"; set -sq extended-keys on",
+		"; set -sq extended-keys-format csi-u",
+		"; set -asq terminal-features ,*:hyperlinks:extkeys",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("default args missing %q; got: %s", want, got)
+		}
+	}
+	// Every chunk must start with a ";" so it chains onto the preceding
+	// set-option in the same tmux command.
+	if len(def) > 0 && def[0] != ";" {
+		t.Errorf("first arg must be a chain separator, got %q", def[0])
+	}
+
+	// User opts extended-keys out (e.g. config.toml [tmux].extended-keys="off",
+	// mirroring `set -s extended-keys off` in ~/.tmux.conf). agent-deck must NOT
+	// emit its forced `set -sq extended-keys on`, so the user value survives.
+	off := gatedTmuxKeyOptionArgs("sess", map[string]string{"extended-keys": "off"})
+	if strings.Contains(joined(off), "extended-keys on") {
+		t.Errorf("extended-keys override ignored — agent-deck still forces it on: %s", joined(off))
+	}
+	// The other defaults are unaffected by that single override.
+	if !strings.Contains(joined(off), "extended-keys-format csi-u") ||
+		!strings.Contains(joined(off), "escape-time 10") {
+		t.Errorf("unrelated defaults dropped by extended-keys override: %s", joined(off))
+	}
+
+	// terminal-features override: the unbounded-append `set -asq` is suppressed.
+	tf := gatedTmuxKeyOptionArgs("sess", map[string]string{"terminal-features": "xterm*"})
+	if strings.Contains(joined(tf), "-asq terminal-features") {
+		t.Errorf("terminal-features override ignored — still appends: %s", joined(tf))
+	}
+
+	// escape-time override: user's explicit value (e.g. 0) is not clobbered.
+	et := gatedTmuxKeyOptionArgs("sess", map[string]string{"escape-time": "0"})
+	if strings.Contains(joined(et), "escape-time 10") {
+		t.Errorf("escape-time override ignored — still forces 10: %s", joined(et))
+	}
+
+	// All four opted out: nothing is emitted, so ~/.tmux.conf fully decides.
+	all := gatedTmuxKeyOptionArgs("sess", map[string]string{
+		"escape-time": "0", "extended-keys": "off",
+		"extended-keys-format": "xterm", "terminal-features": "xterm*",
+	})
+	if len(all) != 0 {
+		t.Errorf("expected no forced args when all keys overridden, got: %s", joined(all))
+	}
+}


### PR DESCRIPTION
Closes #1625. agent-deck force-set extended-keys / extended-keys-format / escape-time / terminal-features on every spawn, so a deliberate `set -s extended-keys off` could never win (Enter stopped submitting). These are now gated through OptionOverrides at both spawn sites (Start + EnableMouseMode), same as window-style; also removes the two-site duplication. Build + targeted sandboxed tests green.