### PR TITLE
fix(claude): group config_dir beats ambient CLAUDE_CONFIG_DIR (#1508)

### DIFF
--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -294,7 +294,7 @@ func getMCPInfoUncached(projectPath string) *MCPInfo {
 
 // resolveOpts selects which priority chain resolveClaudeConfigDir walks.
 //   - inst != nil  → instance chain: conductor > group > env > profile > global > default
-//   - inst == nil  → group chain:    env > group > profile > global > default
+//   - inst == nil  → group chain:    group > env > profile > global > default (#1508)
 //
 // groupPath is consulted in both chains; for the instance chain it falls
 // back to inst.GroupPath when not set explicitly.
@@ -320,7 +320,9 @@ type resolveOpts struct {
 //
 // On the instance chain Account is the most-specific level (beats
 // conductor/group/env). Conductor and group beat env (the #881 fix); see
-// GetClaudeConfigDirForInstance doc for the rationale.
+// GetClaudeConfigDirForInstance doc for the rationale. On the group chain a
+// group config_dir also beats env (#1508) so both chains agree that a
+// config.toml-scoped group override wins over a shell-wide CLAUDE_CONFIG_DIR.
 func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 	userConfig, _ := LoadUserConfig()
 
@@ -355,14 +357,21 @@ func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 			return envDir, "env"
 		}
 	} else {
-		// Group chain: env wins.
-		if envDir := envClaudeConfigDirIgnoringScratchLeak(); envDir != "" {
-			return envDir, "env"
-		}
+		// Group chain: group beats env (#1508). A
+		// [groups."<groupPath>".claude].config_dir is a config.toml-scoped
+		// override and is strictly more specific than a shell-wide
+		// CLAUDE_CONFIG_DIR (which dev shells commonly export via aliases).
+		// This mirrors the instance chain so a grouped child launched from a
+		// shell exporting a stale ambient account still resolves to its
+		// group's configured account. Env still wins when the group has no
+		// config_dir to assert.
 		if userConfig != nil {
 			if groupDir := userConfig.GetGroupClaudeConfigDir(groupPath); groupDir != "" {
 				return groupDir, "group"
 			}
+		}
+		if envDir := envClaudeConfigDirIgnoringScratchLeak(); envDir != "" {
+			return envDir, "env"
 		}
 	}
 

--- a/internal/session/claude_resolve_test.go
+++ b/internal/session/claude_resolve_test.go
@@ -69,7 +69,8 @@ config_dir = "~/.claude-coordinator"
 		groupPath   string
 		wantSource  string
 	}{
-		{"env wins", filepath.Join(tmpHome, ".claude-env"), "team-a", "env"},
+		{"group beats env (#1508)", filepath.Join(tmpHome, ".claude-env"), "team-a", "group"},
+		{"env wins when no group match (#1508)", filepath.Join(tmpHome, ".claude-env"), "unknown", "env"},
 		{"group beats profile (no env)", "", "team-a", "group"},
 		{"profile wins when no group match", "", "unknown", "profile"},
 		{"default when no profile", "", "", "profile"}, // profile=work matches

--- a/internal/session/claude_test.go
+++ b/internal/session/claude_test.go
@@ -754,11 +754,19 @@ config_dir = "~/.claude-team-a"
 		t.Errorf("GetClaudeConfigDirForGroup('') = %s, want %s", got, want)
 	}
 
-	// CLAUDE_CONFIG_DIR env var always wins
+	// #1508: a group config_dir beats ambient CLAUDE_CONFIG_DIR — a
+	// config.toml-scoped override is strictly more specific than a shell-wide
+	// env var, so a grouped child stays on its group's account.
 	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/env-override")
 	got = GetClaudeConfigDirForGroup("team-a")
+	if want := filepath.Join(tmpHome, ".claude-team-a"); got != want {
+		t.Errorf("GetClaudeConfigDirForGroup(team-a) with env = %s, want %s", got, want)
+	}
+
+	// #1508: env still wins when the group has no config_dir to assert.
+	got = GetClaudeConfigDirForGroup("unknown")
 	if got != "/env-override" {
-		t.Errorf("GetClaudeConfigDirForGroup with env = %s, want /env-override", got)
+		t.Errorf("GetClaudeConfigDirForGroup(unknown) with env = %s, want /env-override", got)
 	}
 }
 

--- a/internal/session/pergroupconfig_test.go
+++ b/internal/session/pergroupconfig_test.go
@@ -489,7 +489,10 @@ func TestPerGroupConfig_ClaudeConfigDirSourceLabel(t *testing.T) {
 	}
 	_ = os.Setenv("HOME", tmpHome)
 
-	t.Run("env_var_wins", func(t *testing.T) {
+	t.Run("group_wins_over_env", func(t *testing.T) {
+		// #1508: a config.toml group override is strictly more specific than
+		// a shell-wide CLAUDE_CONFIG_DIR, so the group must win when it has a
+		// config_dir to assert.
 		_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-dir")
 		_ = os.Setenv("AGENTDECK_PROFILE", "p")
 		writeConfig(t, `
@@ -502,6 +505,29 @@ config_dir = "~/.claude-global"
 `)
 		ClearUserConfigCache()
 		path, source := GetClaudeConfigDirSourceForGroup("g")
+		if source != "group" {
+			t.Errorf("source=%q want %q", source, "group")
+		}
+		if want := filepath.Join(tmpHome, ".claude-g"); path != want {
+			t.Errorf("path=%q want %q", path, want)
+		}
+		_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	})
+
+	t.Run("env_var_wins_without_group_match", func(t *testing.T) {
+		// #1508: env still wins when the group has no config_dir to assert.
+		_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-dir")
+		_ = os.Setenv("AGENTDECK_PROFILE", "p")
+		writeConfig(t, `
+[groups."g".claude]
+config_dir = "~/.claude-g"
+[profiles.p.claude]
+config_dir = "~/.claude-p"
+[claude]
+config_dir = "~/.claude-global"
+`)
+		ClearUserConfigCache()
+		path, source := GetClaudeConfigDirSourceForGroup("unknown-group")
 		if source != "env" {
 			t.Errorf("source=%q want %q", source, "env")
 		}


### PR DESCRIPTION
Closes #1508. Reorders the inst==nil group chain in resolveClaudeConfigDir to group > env, so a -g <group> child stays on its group's configured account instead of inheriting an ambient CLAUDE_CONFIG_DIR. Tests locked RED-before/GREEN-after. Build + targeted sandboxed tests green.