### PR TITLE
fix(ui): guard MoveSessionToGroup against creating-session placeholder (#1540)

### DIFF
--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -967,6 +967,12 @@ func (t *GroupTree) DemoteSession(inst *Instance) {
 
 // MoveSessionToGroup moves a session to a different group
 func (t *GroupTree) MoveSessionToGroup(inst *Instance, newGroupPath string) {
+	// Defense in depth: a creating-session placeholder row (Item.Type ==
+	// ItemTypeSession but Item.Session == nil) can reach a caller that forgets
+	// to nil-check. Refuse to dereference a nil instance instead of panicking.
+	if inst == nil {
+		return
+	}
 	oldGroupPath := inst.GroupPath
 
 	// Remove from old group

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -725,6 +725,22 @@ func TestMoveSessionToGroup(t *testing.T) {
 	}
 }
 
+// TestMoveSessionToGroupNilInstance verifies the #1540 defense-in-depth guard:
+// a creating-session placeholder row surfaces a nil *Instance to the move path;
+// MoveSessionToGroup must no-op instead of panicking on inst.GroupPath.
+func TestMoveSessionToGroupNilInstance(t *testing.T) {
+	tree := NewGroupTree(nil)
+	tree.CreateGroup("target")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("MoveSessionToGroup panicked on nil instance: %v", r)
+		}
+	}()
+
+	tree.MoveSessionToGroup(nil, "target") // must not panic
+}
+
 func TestGroupDefaultPath(t *testing.T) {
 	now := time.Now()
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8361,8 +8361,15 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Move session to different group
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
+			// Guard against creating-session placeholder rows (Type ==
+			// ItemTypeSession but Session == nil) — moving one would panic
+			// (#1540). Tell the user the session is still being created.
 			if item.Type == session.ItemTypeSession {
-				h.groupDialog.ShowMove(h.scopedGroupPaths())
+				if item.Session == nil {
+					h.setError(fmt.Errorf("session is still being created, try again in a moment"))
+				} else {
+					h.groupDialog.ShowMove(h.scopedGroupPaths())
+				}
 			}
 		}
 		return h, nil
@@ -10421,7 +10428,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			targetGroupPath := h.groupDialog.GetSelectedGroup()
 			if targetGroupPath != "" && h.cursor < len(h.flatItems) {
 				item := h.flatItems[h.cursor]
-				if item.Type == session.ItemTypeSession {
+				// A creating-session placeholder (Type == ItemTypeSession,
+				// Session == nil) must not reach MoveSessionToGroup or the
+				// item.Session.ID deref below — both panic (#1540).
+				if item.Type == session.ItemTypeSession && item.Session != nil {
 					h.groupTree.MoveSessionToGroup(item.Session, targetGroupPath)
 					h.pendingGroupOps = append(h.pendingGroupOps, pendingGroupOp{
 						kind: groupOpMove, sessionID: item.Session.ID, targetPath: targetGroupPath,


### PR DESCRIPTION
Closes #1540. M (move) over a creating-session placeholder passed a nil *Instance into MoveSessionToGroup, causing a nil-pointer panic. Adds a nil guard in MoveSessionToGroup plus item.Session!=nil checks in the M-key and GroupDialogMove-enter paths, with a regression test. Build + targeted sandboxed tests green.