### PR TITLE
fix(tmux): spawn pane commands as argv tokens, not a $SHELL-wrapped string (#1567)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1163,11 +1163,6 @@ func bashCWrap(command string) string {
 	return bashCPrefix + escaped + "'"
 }
 
-func isBashCWrapped(command string) bool {
-	trimmed := strings.TrimSpace(command)
-	return strings.HasPrefix(trimmed, bashCPrefix)
-}
-
 const (
 	bashBinary  = "bash"
 	bashCPrefix = "bash -c '"
@@ -1249,15 +1244,28 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	// (buildInnerTmuxArgs returns the args unchanged).
 	tmuxArgs := buildInnerTmuxArgs(s.SocketName, "new-session", "-d", "-s", s.Name, "-c", workDir)
 	if startWithInitialProcess {
-		// Keep commands under bash for fish/zsh compatibility, but avoid
-		// double-wrapping payloads that are already `bash -c '…'`.
-		// wrapIgnoreSuspend() already returns that shape; re-wrapping it can
-		// corrupt quoting for nested payloads like docker exec bash -c ... .
-		if isBashCWrapped(command) {
-			tmuxArgs = append(tmuxArgs, command)
-		} else {
-			tmuxArgs = append(tmuxArgs, bashCWrap(command))
-		}
+		// Deliver the pane command as SEPARATE argv tokens (bash, -c, command)
+		// rather than a single shell-quoted string. This is the crux of the
+		// #1567 / #1580 fix.
+		//
+		// tmux treats a single trailing string command as a shell-command and
+		// delivers it through the server's default-shell: `$SHELL -c "…"`.
+		// That implicit wrap kills fast-TTY-acquiring tools within
+		// milliseconds — Hermes Agent dies <100ms (#1567), `npx codex` dies
+		// instantly (#1580) — because the tool is no longer the pane leader
+		// tmux execvp()'d, and $SHELL's controlling-terminal handoff differs.
+		//
+		// Passing separate argv tokens makes tmux execvp() `bash` directly as
+		// the pane's initial process (the default-shell is never involved),
+		// and bash then runs the command with a well-defined TTY, exactly like
+		// the surviving `tmux new-session -d bash -c hermes` repro. bash is
+		// kept as the interpreter for fish/zsh compatibility (#526).
+		//
+		// Payloads already shaped `bash -c '…'` (e.g. from wrapIgnoreSuspend)
+		// pass through as the command argument verbatim — bash -c "bash -c '…'"
+		// tail-exec's the inner bash, so no extra lingering process and no
+		// re-escaping of the nested single quotes.
+		tmuxArgs = append(tmuxArgs, bashBinary, "-c", command)
 	}
 
 	unitBase := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(s.Name)
@@ -2787,7 +2795,11 @@ func (s *Session) RespawnPane(command string) error {
 		if wrapErr != nil {
 			return wrapErr
 		}
-		args = append(args, wrapped)
+		// Deliver as separate argv tokens (bash, -lc, command) so tmux
+		// execvp()s bash directly as the new pane leader instead of routing
+		// the restart command through the server default-shell. Same #1567 /
+		// #1580 rationale as the initial-process spawn in startCommandSpec.
+		args = append(args, wrapped...)
 	}
 
 	mcpLog.Debug("respawn_pane_executing", slog.Any("args", args))
@@ -2832,20 +2844,20 @@ func (s *Session) RespawnPane(command string) error {
 	return nil
 }
 
-func wrapRespawnCommand(command string) (string, error) {
+// wrapRespawnCommand returns the argv tokens ({bash, -lc, command}) that
+// respawn-pane appends so tmux execvp()s bash directly as the new pane leader
+// rather than routing the command through the server default-shell. See the
+// #1567 / #1580 fix rationale in startCommandSpec.
+func wrapRespawnCommand(command string) ([]string, error) {
 	return wrapRespawnCommandWithResolver(command, exec.LookPath)
 }
 
-func wrapRespawnCommandWithResolver(command string, lookPath func(string) (string, error)) (string, error) {
+func wrapRespawnCommandWithResolver(command string, lookPath func(string) (string, error)) ([]string, error) {
 	bashPath, err := lookPath(bashBinary)
 	if err != nil {
-		return "", fmt.Errorf("bash not found in PATH: %w", err)
+		return nil, fmt.Errorf("bash not found in PATH: %w", err)
 	}
-	return buildBashLCCommand(bashPath, command), nil
-}
-
-func buildBashLCCommand(bashPath, command string) string {
-	return fmt.Sprintf("%s -lc %s", bashPath, shellescape.Quote(command))
+	return []string{bashPath, "-lc", command}, nil
 }
 
 // GetWindowActivity returns Unix timestamp of last tmux window activity

--- a/internal/tmux/tmux_argv_spawn_1567_test.go
+++ b/internal/tmux/tmux_argv_spawn_1567_test.go
@@ -1,0 +1,147 @@
+package tmux
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression guard for #1567 (Hermes Agent dies <100ms) and #1580 (`npx codex`
+// dies instantly).
+//
+// Root cause: tmux delivers a SINGLE trailing string command to new-session /
+// respawn-pane through the server's default-shell (`$SHELL -c "…"`). That
+// implicit wrap kills fast-TTY-acquiring tools within milliseconds, because
+// the tool is no longer the pane leader tmux execvp()'d directly. When the
+// command is instead passed as SEPARATE argv tokens, tmux execvp()s the first
+// token as the pane's initial process and the default-shell is never involved
+// — the exact form the #1567 reporter proved survives.
+//
+// The production-environment death depends on the tool's controlling-terminal
+// timing, which is not deterministic in CI. These tests substitute a HOSTILE
+// default-shell (`false(1)`) on an isolated tmux server: any spawn routed
+// through the default-shell dies instantly and deterministically, while a
+// direct-argv spawn is untouched by it. That cleanly separates the two tmux
+// code paths:
+//
+//   - single-string spawn  → default-shell wrap → dies under the hostile shell
+//   - argv-token spawn     → direct execvp      → survives the hostile shell
+//
+// TestIssue1567_StartCommandSpecSpawnSurvivesHostileShell exercises the exact
+// production arg vector and FAILS on the pre-fix code (which appended one
+// shell-quoted `bash -c '…'` string).
+
+// hostileShellServer starts a detached tmux server on a private -L socket and
+// sets its global default-shell to false(1), so any command tmux routes
+// through the default-shell dies instantly. Returns the socket name.
+func hostileShellServer(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	falsePath, err := exec.LookPath("false")
+	if err != nil {
+		t.Skip("false(1) not available")
+	}
+
+	socket := fmt.Sprintf("ad%x", sha256.Sum256([]byte(t.Name())))[:14]
+	kill := func() {
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	}
+	// Deterministic socket per test — clear any server leaked by a prior
+	// aborted run before creating a fresh one.
+	kill()
+
+	// Keeper session holds the server alive while test sessions come and go.
+	// Spawned via argv tokens so it is immune to the hostile shell we set next.
+	if out, err := exec.Command("tmux", "-L", socket, "new-session",
+		"-d", "-x", "80", "-y", "24", "-s", "keeper", "bash").CombinedOutput(); err != nil {
+		t.Fatalf("create keeper session: %v: %s", err, out)
+	}
+	t.Cleanup(kill)
+
+	if out, err := exec.Command("tmux", "-L", socket, "set-option",
+		"-g", "default-shell", falsePath).CombinedOutput(); err != nil {
+		t.Fatalf("set hostile default-shell: %v: %s", err, out)
+	}
+	return socket
+}
+
+// sessionAlive reports whether the named session still exists on the socket
+// after a short grace period (long enough for a default-shell wrapped command
+// to die — production deaths are <100ms; we allow 10x that).
+func sessionAlive(t *testing.T, socket, name string) bool {
+	t.Helper()
+	time.Sleep(1 * time.Second)
+	err := exec.Command("tmux", "-L", socket, "has-session", "-t", "="+name).Run()
+	return err == nil
+}
+
+// TestIssue1567_SingleStringSpawnDiesUnderHostileShell pins the FAILING code
+// path: a single-string command is delivered through the default-shell, so
+// under the hostile shell the pane (and session) dies instantly. This is the
+// deterministic stand-in for the <100ms Hermes death in #1567.
+func TestIssue1567_SingleStringSpawnDiesUnderHostileShell(t *testing.T) {
+	socket := hostileShellServer(t)
+
+	// Session may be created and then die within milliseconds; new-session
+	// itself can succeed either way, so only the aliveness check matters.
+	_ = exec.Command("tmux", "-L", socket, "new-session",
+		"-d", "-s", "single", "sleep 30").Run()
+
+	if sessionAlive(t, socket, "single") {
+		t.Fatal("single-string spawn survived under hostile default-shell; " +
+			"expected the default-shell wrap to kill it — the #1567 failure " +
+			"mode stand-in no longer reproduces")
+	}
+}
+
+// TestIssue1567_ArgvSpawnSurvivesHostileShell proves the FIXED code path: argv
+// tokens make tmux execvp() the command directly, bypassing the default-shell
+// entirely, so the hostile shell cannot kill it.
+func TestIssue1567_ArgvSpawnSurvivesHostileShell(t *testing.T) {
+	socket := hostileShellServer(t)
+
+	if out, err := exec.Command("tmux", "-L", socket, "new-session",
+		"-d", "-s", "argv", "bash", "-c", "sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("argv new-session: %v: %s", err, out)
+	}
+
+	if !sessionAlive(t, socket, "argv") {
+		t.Fatal("argv-token spawn died under hostile default-shell; " +
+			"direct execvp must not involve the default-shell")
+	}
+}
+
+// TestIssue1567_StartCommandSpecSpawnSurvivesHostileShell executes the EXACT
+// arg vector startCommandSpec produces against the hostile server. On the
+// pre-fix code (single shell-quoted `bash -c '…'` string) the session dies;
+// with the argv-token fix it survives. This is the production regression
+// guard for #1567/#1580.
+func TestIssue1567_StartCommandSpecSpawnSurvivesHostileShell(t *testing.T) {
+	socket := hostileShellServer(t)
+
+	s := &Session{
+		Name:                       "prodspec",
+		SocketName:                 socket,
+		RunCommandAsInitialProcess: true,
+	}
+	launcher, args := s.startCommandSpec("/tmp", "sleep 30")
+	if launcher != "tmux" {
+		t.Fatalf("expected tmux launcher in direct mode, got %q (args: %v)", launcher, args)
+	}
+
+	if out, err := exec.Command(launcher, args...).CombinedOutput(); err != nil {
+		t.Fatalf("startCommandSpec spawn failed: %v: %s\nargs: %v", err, out, args)
+	}
+
+	if !sessionAlive(t, socket, "prodspec") {
+		t.Fatalf("session spawned via startCommandSpec died under hostile "+
+			"default-shell — the command is being routed through the server "+
+			"default-shell instead of direct argv execvp (#1567/#1580)\nargs: %s",
+			strings.Join(args, " | "))
+	}
+}

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -181,11 +181,11 @@ func TestStartCommandSpec_LaunchAs_ServiceWithInitialProcess(t *testing.T) {
 
 	require.Equal(t, "systemd-run", launcher)
 	tmuxArgs := stripSystemdRunPrefix(args)
-	// Last element must be the bash-wrapped command
-	require.NotEmpty(t, tmuxArgs)
-	last := tmuxArgs[len(tmuxArgs)-1]
-	assert.True(t, strings.HasPrefix(last, "bash -c '"), "initial process must be bash-wrapped")
-	assert.Contains(t, last, "claude --resume xyz")
+	// #1567/#1580: initial process delivered as argv tokens bash -c COMMAND.
+	require.GreaterOrEqual(t, len(tmuxArgs), 3)
+	assert.Equal(t, "bash", tmuxArgs[len(tmuxArgs)-3], "initial process must be exec'd under bash")
+	assert.Equal(t, "-c", tmuxArgs[len(tmuxArgs)-2])
+	assert.Equal(t, "claude --resume xyz", tmuxArgs[len(tmuxArgs)-1])
 }
 
 // TestStripSystemdRunPrefix_RecoversTmuxArgsFromServiceForm is the

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3010,37 +3010,32 @@ func TestStartCommandSpec_InitialProcess_WrapsBashRegardlessOfContent(t *testing
 
 			launcher, args := s.startCommandSpec("/tmp/project", tc.cmd)
 			require.Equal(t, "tmux", launcher)
-			require.Equal(t, 7, len(args), "expected 7 args (new-session -d -s NAME -c DIR COMMAND)")
+			// #1567/#1580: the command is delivered as SEPARATE argv tokens
+			// (bash, -c, COMMAND) so tmux execvp()s bash directly instead of
+			// wrapping the string through the server default-shell. That is 9
+			// args total: new-session -d -s NAME -c DIR bash -c COMMAND.
+			require.Equal(t, 9, len(args),
+				"expected 9 args (new-session -d -s NAME -c DIR bash -c COMMAND)")
 
-			wrapped := args[len(args)-1]
-			require.True(t, strings.HasPrefix(wrapped, "bash -c '"),
-				"command should always be wrapped in bash -c to guarantee fish/zsh/bash compatibility; got: %s", wrapped)
-			require.True(t, strings.HasSuffix(wrapped, "'"),
-				"wrapped command should end with closing single-quote; got: %s", wrapped)
-
-			// The unquoted payload (between the leading `bash -c '` and trailing `'`)
-			// must be a valid shell string — i.e. running it through `bash -c` must
-			// not produce a syntax error. We verify by running `bash -n` (no-exec)
-			// against the same string that would be passed to bash at runtime.
-			payload := wrapped[len("bash -c '") : len(wrapped)-1]
-			// Undo the '\'' escaping to recover the original command bash will see.
-			unescaped := strings.ReplaceAll(payload, `'\''`, `'`)
-			require.Equal(t, tc.cmd, unescaped,
-				"unescaping should recover the original command; got: %s", unescaped)
+			require.Equal(t, "bash", args[len(args)-3],
+				"command must be exec'd under bash for fish/zsh/bash compatibility")
+			require.Equal(t, "-c", args[len(args)-2])
+			// The command token is passed VERBATIM — no shell-quote escaping,
+			// because it is a distinct argv element, not embedded in a string.
+			require.Equal(t, tc.cmd, args[len(args)-1],
+				"command token must be the original command verbatim; got: %s", args[len(args)-1])
 		})
 	}
 }
 
 // TestStartCommandSpec_InitialProcess_ShellSyntaxValid verifies that the
-// wrapped command (the full `bash -c '…'` string) is itself syntactically
-// valid when invoked via `sh -c`, which is how tmux delivers it. This is
-// the end-to-end guarantee that #526 is fixed.
+// command token tmux hands to `bash -c` is itself syntactically valid. Since
+// the token is now delivered verbatim as a distinct argv element (#1567/#1580),
+// we run `bash -n` directly against that token — the exact string bash sees at
+// runtime. This is the end-to-end guarantee that #526 stays fixed.
 func TestStartCommandSpec_InitialProcess_ShellSyntaxValid(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not available")
-	}
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skip("sh not available")
 	}
 
 	cmds := []string{
@@ -3058,13 +3053,15 @@ func TestStartCommandSpec_InitialProcess_ShellSyntaxValid(t *testing.T) {
 				RunCommandAsInitialProcess: true,
 			}
 			_, args := s.startCommandSpec("/tmp", cmd)
-			wrapped := args[len(args)-1]
+			require.Equal(t, "bash", args[len(args)-3])
+			require.Equal(t, "-c", args[len(args)-2])
+			payload := args[len(args)-1]
 
-			// `sh -n <string>` parses but does not execute. If the wrapped
-			// command is malformed (stray quotes), sh will exit non-zero.
-			shSyntax := exec.Command("sh", "-n", "-c", wrapped)
+			// `bash -n <string>` parses but does not execute. If the command
+			// token is malformed (stray quotes), bash will exit non-zero.
+			shSyntax := exec.Command("bash", "-n", "-c", payload)
 			if out, err := shSyntax.CombinedOutput(); err != nil {
-				t.Fatalf("sh -n rejected wrapped command: %v\nwrapped: %s\noutput: %s", err, wrapped, string(out))
+				t.Fatalf("bash -n rejected command token: %v\npayload: %s\noutput: %s", err, payload, string(out))
 			}
 		})
 	}
@@ -3075,8 +3072,12 @@ func TestWrapRespawnCommand_UsesBashRegardlessOfShellEnv(t *testing.T) {
 
 	wrapped, err := wrapRespawnCommand("claude --session-id abc")
 	require.NoError(t, err)
-	require.Contains(t, wrapped, " -lc ")
-	require.Contains(t, wrapped, "claude --session-id abc")
+	// #1567/#1580: returns argv tokens {bash, -lc, command}, not a string.
+	require.Len(t, wrapped, 3)
+	require.True(t, strings.HasSuffix(wrapped[0], "bash"),
+		"first token must be the resolved bash path; got: %s", wrapped[0])
+	require.Equal(t, "-lc", wrapped[1])
+	require.Equal(t, "claude --session-id abc", wrapped[2])
 }
 
 func TestWrapRespawnCommand_PreservesQuotedPayloads(t *testing.T) {
@@ -3104,11 +3105,16 @@ func TestWrapRespawnCommand_PreservesQuotedPayloads(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			wrapped, err := wrapRespawnCommand(tc.cmd)
 			require.NoError(t, err)
-			require.Contains(t, wrapped, " -lc ")
+			require.Len(t, wrapped, 3)
+			require.Equal(t, "-lc", wrapped[1])
+			require.Equal(t, tc.cmd, wrapped[2],
+				"command token must be passed verbatim as a distinct argv element")
 
-			run := exec.Command("sh", "-c", wrapped)
+			// Execute the exact argv tmux would exec — bash directly, no
+			// intervening shell — and confirm the payload runs cleanly.
+			run := exec.Command(wrapped[0], wrapped[1], wrapped[2])
 			out, err := run.CombinedOutput()
-			require.NoError(t, err, "wrapped command failed: %s", string(out))
+			require.NoError(t, err, "argv command failed: %s", string(out))
 		})
 	}
 }
@@ -3141,9 +3147,13 @@ func TestStartCommandSpec_WrapsNonBashCommands(t *testing.T) {
 		RunCommandAsInitialProcess: true,
 	}
 
-	_, args := s.startCommandSpec("/tmp", `export COLORFGBG='15;0' && opencode -s ses_abc`)
+	cmd := `export COLORFGBG='15;0' && opencode -s ses_abc`
+	_, args := s.startCommandSpec("/tmp", cmd)
 	require.NotEmpty(t, args)
-	require.True(t, strings.HasPrefix(args[len(args)-1], "bash -c '"))
+	// #1567/#1580: bash -c COMMAND as three trailing argv tokens.
+	require.Equal(t, "bash", args[len(args)-3])
+	require.Equal(t, "-c", args[len(args)-2])
+	require.Equal(t, cmd, args[len(args)-1])
 }
 
 func TestResolvedAgentDeckTheme_COLORFGBG(t *testing.T) {


### PR DESCRIPTION
Closes #1567. tmux delivered a single-string command through the server default-shell ($SHELL -c), killing fast-TTY-acquiring tools (Hermes death <100ms, instant npx codex death). Commands are now delivered as argv tokens (bash, -c, cmd) so tmux execvp()s bash directly as the pane leader; same for respawn-pane. Regression guard: hostile default-shell tmux server; startCommandSpec test fails on pre-fix main, passes with the fix. Refs #1580 (same spawn area). Build + targeted sandboxed tests green.