### PR TITLE
fix(output): EOF-anchored last-assistant extraction survives /compact oversized records (#1568)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5551,7 +5551,14 @@ func (i *Instance) findLatestClaudeTranscriptOnDisk() (string, *ResponseOutput) 
 	return "", nil
 }
 
-// parseClaudeLastAssistantMessage parses a Claude JSONL file to extract the last assistant message
+// parseClaudeLastAssistantMessage parses a Claude JSONL file to extract the last assistant message.
+//
+// It anchors at EOF and walks lines BACKWARD over the raw bytes with no
+// line-length ceiling (issue #1568): a forward bufio.Scanner capped at 1MB
+// stopped silently (bufio.ErrTooLong) at the multi-megabyte single-line
+// records that Claude Code /compact inserts mid-file (file-history-snapshot,
+// compact summaries), so every post-compact reply was invisible and the last
+// PRE-compact assistant text was returned forever.
 func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOutput, error) {
 	// JSONL record structure (same as global_search.go)
 	type claudeMessage struct {
@@ -5570,13 +5577,15 @@ func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOu
 	var lastTimestamp string
 	var foundSessionID string
 
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	// Handle large lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
+	// Walk lines from EOF backward; the first non-sidechain assistant record
+	// with text content is the newest reply.
+	for end := len(data); end > 0; {
+		nl := bytes.LastIndexByte(data[:end], '\n')
+		line := bytes.TrimSpace(data[nl+1 : end])
+		end = nl
+		if nl < 0 {
+			end = 0
+		}
 		if len(line) == 0 {
 			continue
 		}
@@ -5592,9 +5601,19 @@ func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOu
 			continue
 		}
 
-		// Capture session ID
+		// Capture session ID (backfilled from earlier records when the
+		// assistant record itself lacks one).
 		if foundSessionID == "" && record.SessionID != "" {
 			foundSessionID = record.SessionID
+		}
+
+		// Once the newest assistant text is found, keep walking only until a
+		// session ID is known.
+		if lastAssistantContent != "" {
+			if foundSessionID != "" {
+				break
+			}
+			continue
 		}
 
 		// Only care about messages
@@ -5635,10 +5654,14 @@ func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOu
 				extractedText = strings.TrimSpace(sb.String())
 			}
 		}
-		// Only update if we found actual text content
+		// Only accept records with actual text content (tool_use-only
+		// assistant records are skipped).
 		if extractedText != "" {
 			lastAssistantContent = extractedText
 			lastTimestamp = record.Timestamp
+			if foundSessionID != "" {
+				break
+			}
 		}
 	}
 

--- a/internal/session/issue1568_compact_stale_output_test.go
+++ b/internal/session/issue1568_compact_stale_output_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #1568: after a Claude Code /compact, `session output -q` returned the
+// last PRE-compact assistant reply forever. Root cause: the extractor scanned
+// the transcript forward with a bufio.Scanner capped at a 1MB line; /compact
+// inserts multi-megabyte single-line records (file-history-snapshot, compact
+// summaries) mid-file, the oversized line hit bufio.ErrTooLong, Scan() stopped
+// silently at the compact boundary, and every post-compact record was never
+// seen. The fix anchors at EOF and walks backward with no line-length ceiling.
+
+func issue1568Record(parts ...string) string {
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+func issue1568AssistantLine(text, ts, sid string) string {
+	return issue1568Record(
+		`"type":"assistant"`,
+		`"sessionId":"`+sid+`"`,
+		`"timestamp":"`+ts+`"`,
+		`"message":{"role":"assistant","content":[{"type":"text","text":"`+text+`"}]}`,
+	)
+}
+
+// TestIssue1568_CompactOversizedMidFileLine reproduces the reported bug: a
+// >1MB single-line record between the pre-compact and post-compact assistant
+// replies must not truncate extraction at the compact boundary.
+func TestIssue1568_CompactOversizedMidFileLine(t *testing.T) {
+	huge := strings.Repeat("x", 2*1024*1024) // 2MB single-line snapshot payload
+	lines := []string{
+		issue1568AssistantLine("stale pre-compact reply", "2026-07-17T10:00:00Z", "sess-1568"),
+		issue1568Record(`"type":"file-history-snapshot"`, `"snapshot":"`+huge+`"`),
+		issue1568Record(`"type":"user"`, `"isCompactSummary":true`, `"message":{"role":"user","content":"compact summary"}`),
+		issue1568Record(`"type":"system"`, `"subtype":"compact_boundary"`),
+		issue1568AssistantLine("fresh post-compact reply", "2026-07-17T14:00:00Z", "sess-1568"),
+		// Noise after the real reply: sidechain assistant + queue-operation.
+		issue1568Record(`"type":"assistant"`, `"isSidechain":true`, `"message":{"role":"assistant","content":[{"type":"text","text":"subagent noise"}]}`),
+		issue1568Record(`"type":"queue-operation"`, `"operation":"dequeue"`),
+	}
+	data := []byte(strings.Join(lines, "\n") + "\n")
+
+	resp, err := parseClaudeLastAssistantMessage(data, "sess-1568.jsonl")
+	if err != nil {
+		t.Fatalf("parseClaudeLastAssistantMessage: %v", err)
+	}
+	if resp.Content != "fresh post-compact reply" {
+		t.Fatalf("got stale content %q, want %q", resp.Content, "fresh post-compact reply")
+	}
+	if resp.Timestamp != "2026-07-17T14:00:00Z" {
+		t.Fatalf("got timestamp %q, want post-compact timestamp", resp.Timestamp)
+	}
+	if resp.SessionID != "sess-1568" {
+		t.Fatalf("got sessionID %q, want %q", resp.SessionID, "sess-1568")
+	}
+}
+
+// TestIssue1568_OversizedFinalLine: an oversized record as the very last line
+// must not hide the assistant reply just before it.
+func TestIssue1568_OversizedFinalLine(t *testing.T) {
+	huge := strings.Repeat("y", 2*1024*1024)
+	lines := []string{
+		issue1568AssistantLine("the real reply", "2026-07-17T15:00:00Z", "sess-1568"),
+		issue1568Record(`"type":"file-history-snapshot"`, `"snapshot":"`+huge+`"`),
+	}
+	data := []byte(strings.Join(lines, "\n") + "\n")
+
+	resp, err := parseClaudeLastAssistantMessage(data, "sess-1568.jsonl")
+	if err != nil {
+		t.Fatalf("parseClaudeLastAssistantMessage: %v", err)
+	}
+	if resp.Content != "the real reply" {
+		t.Fatalf("got %q, want %q", resp.Content, "the real reply")
+	}
+}
+
+// TestIssue1568_NoAssistantText keeps the error contract: a transcript with no
+// non-sidechain assistant text still errors.
+func TestIssue1568_NoAssistantText(t *testing.T) {
+	lines := []string{
+		issue1568Record(`"type":"user"`, `"message":{"role":"user","content":"hello"}`),
+		issue1568Record(`"type":"assistant"`, `"isSidechain":true`, `"message":{"role":"assistant","content":[{"type":"text","text":"sidechain only"}]}`),
+		issue1568Record(`"type":"assistant"`, `"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"}]}`),
+	}
+	data := []byte(strings.Join(lines, "\n") + "\n")
+
+	if _, err := parseClaudeLastAssistantMessage(data, "sess-1568.jsonl"); err == nil {
+		t.Fatal("expected error for transcript without assistant text, got nil")
+	}
+}
+
+// TestIssue1568_NoTrailingNewline: the last line must be parsed even without a
+// trailing newline (file mid-write).
+func TestIssue1568_NoTrailingNewline(t *testing.T) {
+	lines := []string{
+		issue1568AssistantLine("older", "2026-07-17T09:00:00Z", "sess-1568"),
+		issue1568AssistantLine("newest", "2026-07-17T16:00:00Z", "sess-1568"),
+	}
+	data := []byte(strings.Join(lines, "\n")) // no trailing \n
+
+	resp, err := parseClaudeLastAssistantMessage(data, "sess-1568.jsonl")
+	if err != nil {
+		t.Fatalf("parseClaudeLastAssistantMessage: %v", err)
+	}
+	if resp.Content != "newest" {
+		t.Fatalf("got %q, want %q", resp.Content, "newest")
+	}
+}


### PR DESCRIPTION
Closes #1568. /compact inserts multi-MB single-line records; the forward bufio.Scanner (1MB cap) stopped silently at the boundary, so session output -q returned the last pre-compact reply forever. Rewritten to walk backward from EOF with no line-length ceiling. Regression tests reproduce the exact reported symptom. Build + targeted sandboxed tests green.