### PR TITLE
fix(switch-account): locate conversation across config dirs when account field is empty (#1571)

### DIFF
--- a/cmd/agent-deck/session_switch_account.go
+++ b/cmd/agent-deck/session_switch_account.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -101,11 +102,43 @@ func handleSessionSwitchAccount(profile string, args []string) {
 	// Capture the source dir BEFORE mutating the account field — afterwards
 	// the resolver would already return the target.
 	srcDir := session.GetClaudeConfigDirForInstance(inst)
+	// #1571: a pre-account-tracking session (empty account field) resolves to
+	// env/profile/global defaults, which can equal the target dir — the old
+	// code then declared "nothing to migrate" and the restarted resume died
+	// with "No conversation found". The disk is authoritative: scan every
+	// configured config dir for the conversation file and treat the dir that
+	// actually contains it as the source.
+	locatedDir, locatedSID, srcSize := session.LocateConversationConfigDir(userConfig, inst, srcDir)
+	if locatedDir != "" {
+		srcDir = locatedDir
+		if inst.ClaudeSessionID == "" && locatedSID != "" {
+			inst.ClaudeSessionID = locatedSID
+		}
+	}
 	migrated, migErr := session.MigrateConversationFrom(inst, srcDir, targetDir)
 	if migErr != nil && !errors.Is(migErr, session.ErrNoConversation) {
 		// Conversation intact in the source account; account field unchanged.
 		out.Error(fmt.Sprintf("conversation migration failed, account not switched: %v", migErr), ErrCodeInvalidOperation)
 		os.Exit(1)
+	}
+
+	// Post-switch verification (#1571): when a source conversation demonstrably
+	// exists on disk, the target dir must contain it (size within ~1%) before
+	// the account field flips. Fresh sessions (no conversation anywhere) keep
+	// the lenient path.
+	if locatedDir != "" {
+		if verifyErr := session.VerifyConversationInDir(inst, targetDir, srcSize); verifyErr != nil {
+			out.Error(fmt.Sprintf("conversation not verified in target config dir, account not switched: %v", verifyErr), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	}
+
+	// Pre-seed the folder-trust entry for (target config dir, project path)
+	// (#1571 root cause 4): the first launch of a fresh (config_dir, cwd)
+	// pair blocks interactively on "Do you trust this folder?", stalling the
+	// restarted session. Best-effort — a warning must not abort the switch.
+	if trustErr := session.PreAcceptClaudeTrust(filepath.Join(targetDir, ".claude.json"), inst.EffectiveWorkingDir()); trustErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not pre-accept folder trust in target config dir: %v\n", trustErr)
 	}
 
 	oldAccount, postCommit, setErr := session.SetField(inst, session.FieldAccount, account, nil)
@@ -142,7 +175,11 @@ func handleSessionSwitchAccount(profile string, args []string) {
 	if migrated != "" {
 		conversation = fmt.Sprintf("conversation migrated to %s", migrated)
 	} else if migErr == nil {
-		conversation = "source and target accounts share a config dir (nothing to migrate)"
+		if locatedDir != "" {
+			conversation = "conversation already present in the target config dir (nothing to migrate)"
+		} else {
+			conversation = "no conversation found on disk (nothing to migrate)"
+		}
 	}
 	out.Success(fmt.Sprintf("Switched %s: account %q -> %q; %s", inst.Title, oldAccount, account, conversation), map[string]interface{}{
 		"success":           true,

--- a/internal/session/issue1571_switch_account_test.go
+++ b/internal/session/issue1571_switch_account_test.go
@@ -1,0 +1,221 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for #1571: switch-account on a pre-account-tracking session (empty
+// account field) resolved a wrong/same source config dir, declared "nothing
+// to migrate", and the restarted `claude --resume` died with "No conversation
+// found". LocateConversationConfigDir makes the DISK authoritative; the
+// subagent dir migrates alongside the jsonl; VerifyConversationInDir gates
+// the account flip.
+
+func locateTestConfig(profiles map[string]string) *UserConfig {
+	cfg := &UserConfig{Profiles: map[string]ProfileSettings{}}
+	for name, dir := range profiles {
+		cfg.Profiles[name] = ProfileSettings{Claude: ProfileClaudeSettings{ConfigDir: dir}}
+	}
+	return cfg
+}
+
+// TestLocateConversationConfigDir_FindsAcrossProfiles is the core #1571
+// repro: the session's account field is empty, the resolver answers the
+// TARGET dir (so src == dst reads as "nothing to migrate"), but the real
+// conversation lives in another profile's config dir.
+func TestLocateConversationConfigDir_FindsAcrossProfiles(t *testing.T) {
+	realSrc, target, project := t.TempDir(), t.TempDir(), t.TempDir()
+	cfg := locateTestConfig(map[string]string{"buddii": realSrc, "seminno": target})
+
+	inst := migTestInstance(t, project)
+	inst.Account = "" // pre-account-tracking session
+	writeConversation(t, realSrc, project, migTestSID, migTestLines)
+
+	// Old behavior this locks out: resolver says target, src == dst, no-op.
+	if migrated, err := MigrateConversationFrom(inst, target, target); err != nil || migrated != "" {
+		t.Fatalf("precondition: src==dst should be a silent no-op, got (%q, %v)", migrated, err)
+	}
+
+	dir, sid, size := LocateConversationConfigDir(cfg, inst, target)
+	if dir != realSrc {
+		t.Fatalf("LocateConversationConfigDir = %q, want %q", dir, realSrc)
+	}
+	if sid != migTestSID {
+		t.Fatalf("sessionID = %q, want %q", sid, migTestSID)
+	}
+	if size != int64(len(migTestLines)) {
+		t.Fatalf("size = %d, want %d", size, len(migTestLines))
+	}
+
+	// The located dir migrates cleanly into the target.
+	migrated, err := MigrateConversationFrom(inst, dir, target)
+	if err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	if migrated == "" {
+		t.Fatal("expected a migrated path, got no-op")
+	}
+	if err := VerifyConversationInDir(inst, target, size); err != nil {
+		t.Fatalf("VerifyConversationInDir after migration: %v", err)
+	}
+}
+
+// TestLocateConversationConfigDir_SkipsTinyStub: a poisoned stub (the ~646B
+// jsonl a failed restart writes at the resume path) must lose to the real
+// conversation regardless of candidate order.
+func TestLocateConversationConfigDir_SkipsTinyStub(t *testing.T) {
+	stubDir, realDir, project := t.TempDir(), t.TempDir(), t.TempDir()
+	cfg := locateTestConfig(map[string]string{"a-stub": stubDir, "b-real": realDir})
+
+	inst := migTestInstance(t, project)
+	writeConversation(t, stubDir, project, migTestSID, strings.Repeat("x", 646))
+	realContent := strings.Repeat(migTestLines, 100)
+	writeConversation(t, realDir, project, migTestSID, realContent)
+
+	// stubDir passed as the first (resolver) candidate: largest still wins.
+	dir, _, size := LocateConversationConfigDir(cfg, inst, stubDir)
+	if dir != realDir {
+		t.Fatalf("LocateConversationConfigDir picked stub dir %q, want %q", dir, realDir)
+	}
+	if size != int64(len(realContent)) {
+		t.Fatalf("size = %d, want %d", size, len(realContent))
+	}
+}
+
+func TestLocateConversationConfigDir_NotFound(t *testing.T) {
+	cfg := locateTestConfig(map[string]string{"work": t.TempDir()})
+	inst := migTestInstance(t, t.TempDir())
+	dir, sid, size := LocateConversationConfigDir(cfg, inst, t.TempDir())
+	if dir != "" || sid != "" || size != 0 {
+		t.Fatalf("expected not-found, got (%q, %q, %d)", dir, sid, size)
+	}
+}
+
+// TestLocateConversationConfigDir_NoSessionIDUsesNewest: with no stored id,
+// the newest UUID-named conversation across all candidate dirs wins.
+func TestLocateConversationConfigDir_NoSessionIDUsesNewest(t *testing.T) {
+	oldDir, newDir, project := t.TempDir(), t.TempDir(), t.TempDir()
+	cfg := locateTestConfig(map[string]string{"old": oldDir, "new": newDir})
+
+	inst := migTestInstance(t, project)
+	inst.ClaudeSessionID = ""
+
+	oldFile := writeConversation(t, oldDir, project, migTestSID, "old\n")
+	newFile := writeConversation(t, newDir, project, migTestSID2, "newer conversation\n")
+	now := time.Now()
+	if err := os.Chtimes(oldFile, now.Add(-2*time.Hour), now.Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newFile, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, sid, size := LocateConversationConfigDir(cfg, inst)
+	if dir != newDir {
+		t.Fatalf("LocateConversationConfigDir = %q, want newest dir %q", dir, newDir)
+	}
+	if sid != migTestSID2 {
+		t.Fatalf("sessionID = %q, want %q", sid, migTestSID2)
+	}
+	if size != int64(len("newer conversation\n")) {
+		t.Fatalf("size = %d", size)
+	}
+}
+
+// TestMigrateConversationFrom_MigratesSubagentDir: the companion
+// projects/<enc>/<sid>/ subagent-transcript directory travels with the jsonl.
+func TestMigrateConversationFrom_MigratesSubagentDir(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID, migTestLines)
+
+	enc := ConvertToClaudeDirName(project)
+	subSrc := filepath.Join(src, "projects", enc, migTestSID, "nested")
+	if err := os.MkdirAll(subSrc, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	agentContent := "{\"type\":\"agent\"}\n"
+	if err := os.WriteFile(filepath.Join(subSrc, "agent-1.jsonl"), []byte(agentContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := MigrateConversationFrom(inst, src, dst); err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+
+	migratedAgent := filepath.Join(dst, "projects", enc, migTestSID, "nested", "agent-1.jsonl")
+	got, err := os.ReadFile(migratedAgent)
+	if err != nil {
+		t.Fatalf("subagent transcript not migrated: %v", err)
+	}
+	if string(got) != agentContent {
+		t.Fatalf("subagent transcript content = %q, want %q", got, agentContent)
+	}
+	// Copy-only: source keeps its subagent dir.
+	if _, err := os.Stat(filepath.Join(subSrc, "agent-1.jsonl")); err != nil {
+		t.Fatalf("source subagent transcript touched: %v", err)
+	}
+}
+
+// TestMigrateConversationFrom_OverwritesStubDestination: a poisoned stub at
+// the target resume path is replaced by the real conversation, with a .bak-
+// snapshot kept (a plain cp -n would silently keep the stub — the manual
+// recovery in #1571 hit exactly that).
+func TestMigrateConversationFrom_OverwritesStubDestination(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	realContent := strings.Repeat(migTestLines, 50)
+	writeConversation(t, src, project, migTestSID, realContent)
+	writeConversation(t, dst, project, migTestSID, strings.Repeat("s", 646))
+
+	migrated, err := MigrateConversationFrom(inst, src, dst)
+	if err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	got, err := os.ReadFile(migrated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != realContent {
+		t.Fatal("stub not replaced by real conversation")
+	}
+	baks, err := filepath.Glob(migrated + ".bak-*")
+	if err != nil || len(baks) != 1 {
+		t.Fatalf("expected exactly one stub backup, got %v (err %v)", baks, err)
+	}
+}
+
+func TestVerifyConversationInDir(t *testing.T) {
+	cfgDir, project := t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+
+	if err := VerifyConversationInDir(inst, cfgDir, 0); err == nil {
+		t.Fatal("expected error for missing conversation")
+	}
+
+	content := strings.Repeat("a", 1000)
+	writeConversation(t, cfgDir, project, migTestSID, content)
+
+	if err := VerifyConversationInDir(inst, cfgDir, 0); err != nil {
+		t.Fatalf("existence-only verify: %v", err)
+	}
+	if err := VerifyConversationInDir(inst, cfgDir, 1000); err != nil {
+		t.Fatalf("exact-size verify: %v", err)
+	}
+	if err := VerifyConversationInDir(inst, cfgDir, 995); err != nil {
+		t.Fatalf("within-1%%-band verify: %v", err)
+	}
+	if err := VerifyConversationInDir(inst, cfgDir, 646); err == nil {
+		t.Fatal("expected size-mismatch error for stub-sized expectation")
+	}
+
+	fresh := migTestInstance(t, project)
+	fresh.ClaudeSessionID = ""
+	if err := VerifyConversationInDir(fresh, cfgDir, 0); err == nil {
+		t.Fatal("expected error when no session id to verify")
+	}
+}

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -99,7 +99,43 @@ func MigrateConversationFrom(inst *Instance, srcConfigDir, targetConfigDir strin
 		}
 		return "", err
 	}
+
+	// Migrate the companion subagent directory (#1571): subagent transcripts
+	// live in projects/<encoded-path>/<sid>/ next to the jsonl. Resume works
+	// without it, but leaving it behind silently loses those transcripts.
+	// Copy-only, per-file size-verified; failure aborts before the caller
+	// flips the account field (the already-copied jsonl is harmless and a
+	// rerun is idempotent).
+	srcSubagentDir := filepath.Join(srcProjDir, sid)
+	if info, err := os.Stat(srcSubagentDir); err == nil && info.IsDir() {
+		if err := copyDirVerified(srcSubagentDir, filepath.Join(dstProjDir, sid)); err != nil {
+			return "", fmt.Errorf("copy subagent dir: %w", err)
+		}
+	}
 	return dstFile, nil
+}
+
+// copyDirVerified recursively copies the regular files under src into dst
+// (created 0700), size-verifying each copy. Symlinks and other special files
+// are skipped.
+func copyDirVerified(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		return copyFileVerified(path, target)
+	})
 }
 
 // RestoreOrphanedConversationBackup restores a conversation whose live

--- a/internal/session/migrate_locate.go
+++ b/internal/session/migrate_locate.go
@@ -1,0 +1,153 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// LocateConversationConfigDir finds the Claude config dir that actually holds
+// the instance's conversation file on disk (#1571).
+//
+// Why: legacy session records carry an empty Account field. The config-dir
+// resolver then falls through to env/profile/global defaults, which can
+// lexically equal the switch target — MigrateConversationFrom sees src == dst,
+// returns ("", nil), and switch-account declares "nothing to migrate" while
+// the real conversation sits in a different profile's config dir. The
+// restarted `claude --resume <id>` then finds no conversation and the session
+// loops in error. The disk is authoritative: scan every configured config dir
+// for projects/<encoded-cwd>/<sid>.jsonl and treat the dir that contains it
+// as the source.
+//
+// Candidates scanned (deduped, in order): extraCandidates (callers pass the
+// resolver's answer first), every [profiles.<name>.claude].config_dir, the
+// global [claude].config_dir, and ~/.claude.
+//
+// When inst.ClaudeSessionID is set, only exact <sid>.jsonl matches count and
+// the LARGEST match wins — a poisoned few-hundred-byte stub left by a failed
+// restart must never shadow the real conversation. When the id is empty, the
+// newest UUID-named conversation file across all candidates wins.
+//
+// Returns ("", "", 0) when no conversation exists anywhere (fresh session).
+func LocateConversationConfigDir(cfg *UserConfig, inst *Instance, extraCandidates ...string) (configDir, sessionID string, size int64) {
+	if inst == nil || inst.Tool != "claude" || inst.ProjectPath == "" {
+		return "", "", 0
+	}
+	candidates := conversationConfigDirCandidates(cfg, extraCandidates...)
+	projDirName := ConvertToClaudeDirName(inst.ProjectPath)
+
+	if sid := inst.ClaudeSessionID; sid != "" {
+		bestSize := int64(-1)
+		bestDir := ""
+		for _, dir := range candidates {
+			info, err := os.Stat(filepath.Join(dir, "projects", projDirName, sid+".jsonl"))
+			if err != nil || !info.Mode().IsRegular() {
+				continue
+			}
+			if info.Size() > bestSize {
+				bestSize, bestDir = info.Size(), dir
+			}
+		}
+		if bestDir == "" {
+			return "", "", 0
+		}
+		return bestDir, sid, bestSize
+	}
+
+	// No stored session id: newest conversation file across candidates.
+	var bestDir, bestID string
+	var bestSize int64
+	var bestMod time.Time
+	for _, dir := range candidates {
+		path, id := newestConversationFile(filepath.Join(dir, "projects", projDirName))
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if bestDir == "" || info.ModTime().After(bestMod) {
+			bestDir, bestID, bestSize, bestMod = dir, id, info.Size(), info.ModTime()
+		}
+	}
+	return bestDir, bestID, bestSize
+}
+
+// conversationConfigDirCandidates returns the deduped list of config dirs to
+// scan for a conversation: extras first (resolver answer), then every
+// configured profile dir (sorted for determinism), the global dir, and the
+// ~/.claude default.
+func conversationConfigDirCandidates(cfg *UserConfig, extras ...string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(dir string) {
+		dir = ExpandPath(strings.TrimSpace(dir))
+		if dir == "" {
+			return
+		}
+		dir = filepath.Clean(dir)
+		key := resolveRealPath(dir)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, dir)
+	}
+	for _, e := range extras {
+		add(e)
+	}
+	if cfg != nil {
+		names := make([]string, 0, len(cfg.Profiles))
+		for name := range cfg.Profiles {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			add(cfg.GetProfileClaudeConfigDir(name))
+		}
+		add(cfg.Claude.ConfigDir)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		add(filepath.Join(home, ".claude"))
+	}
+	return out
+}
+
+// VerifyConversationInDir confirms cfgDir holds the instance's conversation
+// file (#1571 post-switch verification: never report a successful switch when
+// the target dir cannot actually resume the conversation). wantSize > 0
+// additionally requires the file size to be within 1% of wantSize, so a
+// poisoned stub at the resume path fails loudly instead of masquerading as
+// the migrated conversation.
+func VerifyConversationInDir(inst *Instance, cfgDir string, wantSize int64) error {
+	if inst == nil || inst.ClaudeSessionID == "" {
+		return fmt.Errorf("no claude session id to verify")
+	}
+	dir := ExpandPath(strings.TrimSpace(cfgDir))
+	if dir == "" {
+		return fmt.Errorf("empty config dir")
+	}
+	path := filepath.Join(dir, "projects", ConvertToClaudeDirName(inst.ProjectPath), inst.ClaudeSessionID+".jsonl")
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("conversation missing from target: %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("conversation path is not a regular file: %s", path)
+	}
+	if wantSize > 0 {
+		diff := info.Size() - wantSize
+		if diff < 0 {
+			diff = -diff
+		}
+		tolerance := wantSize / 100
+		if diff > tolerance {
+			return fmt.Errorf("conversation size mismatch in target: %s has %d bytes, expected ~%d", path, info.Size(), wantSize)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #1571. switch-account bailed with 'nothing to migrate' on an empty account field, then resume died at the trust prompt. Adds LocateConversationConfigDir + VerifyConversationInDir + subagent-dir migration + trust pre-seed; all additive, state-schema-neutral. Build + targeted sandboxed tests green.