### PR TITLE
feat(send): session send --defer-if-busy — hold delivery until the target is turn-finished (#1578)

### DIFF
--- a/cmd/agent-deck/issue1578_defer_if_busy_test.go
+++ b/cmd/agent-deck/issue1578_defer_if_busy_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/send"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// seedDeferHookFile writes an on-disk hook status file for instanceID, the same
+// artifact Claude's UserPromptSubmit/Stop hooks write and that `list --json`
+// reads. ts=now keeps it inside the hook fast-path freshness window.
+func seedDeferHookFile(t *testing.T, instanceID, event, sessionID, status string) {
+	t.Helper()
+	dir := session.GetHooksDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	payload := map[string]any{
+		"status":     status,
+		"session_id": sessionID,
+		"event":      event,
+		"ts":         time.Now().Unix(),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal hook payload: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, instanceID+".json"), data, 0o644); err != nil {
+		t.Fatalf("write hook file: %v", err)
+	}
+}
+
+func setupDeferTest(t *testing.T, profile string) *session.Instance {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("new storage: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inst := &session.Instance{
+		ID:          "inst-defer-1578",
+		Title:       "busy-parent",
+		Tool:        "claude",
+		ProjectPath: projectDir,
+		Command:     "claude",
+		// A bound session id so the seeded hook (carrying the same id) is
+		// accepted by UpdateHookStatus's ownership guard rather than rejected as
+		// a foreign ephemeral.
+		ClaudeSessionID: "sid-defer-1578",
+	}
+	if err := storage.Save([]*session.Instance{inst}); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+	return inst
+}
+
+// The core #1578 correctness claim: fetchHookDrivenStatus reports the target as
+// busy ("running") while its hook file shows the UserPromptSubmit edge, and as
+// not-busy ("waiting") once the Stop hook fires — the true turn-finished signal,
+// available even without a live tmux handle.
+func TestFetchHookDrivenStatus_BusyThenIdle(t *testing.T) {
+	profile := "defer_hook_status"
+	inst := setupDeferTest(t, profile)
+
+	seedDeferHookFile(t, inst.ID, "UserPromptSubmit", inst.ClaudeSessionID, "running")
+	got, err := fetchHookDrivenStatus(profile, inst.Title)
+	if err != nil {
+		t.Fatalf("fetchHookDrivenStatus (running): %v", err)
+	}
+	if !send.StatusIsBusy(got) {
+		t.Fatalf("status = %q, want a busy status while the hook shows running", got)
+	}
+
+	seedDeferHookFile(t, inst.ID, "Stop", inst.ClaudeSessionID, "waiting")
+	got, err = fetchHookDrivenStatus(profile, inst.Title)
+	if err != nil {
+		t.Fatalf("fetchHookDrivenStatus (waiting): %v", err)
+	}
+	if send.StatusIsBusy(got) {
+		t.Fatalf("status = %q, want a non-busy status after the Stop hook", got)
+	}
+}
+
+// End-to-end gate: the real fetchHookDrivenStatus wired into the real
+// WaitUntilNotBusy hold loop. The delivery gate stays closed across busy polls
+// and opens only after the Stop-hook edge flips the hook file — proving the
+// message is HELD (not interrupt-delivered) mid-turn.
+func TestDeferIfBusy_GateOpensOnlyAfterStopHook(t *testing.T) {
+	profile := "defer_gate"
+	inst := setupDeferTest(t, profile)
+	seedDeferHookFile(t, inst.ID, "UserPromptSubmit", inst.ClaudeSessionID, "running")
+
+	var polls int32
+	fetch := func() (string, error) {
+		n := atomic.AddInt32(&polls, 1)
+		// Flip to the Stop edge on the 3rd poll; earlier polls must keep the
+		// gate closed.
+		if n == 3 {
+			seedDeferHookFile(t, inst.ID, "Stop", inst.ClaudeSessionID, "waiting")
+		}
+		return fetchHookDrivenStatus(profile, inst.Title)
+	}
+
+	err := send.WaitUntilNotBusy(fetch, 30*time.Minute, 10*time.Millisecond, func(time.Duration) {})
+	if err != nil {
+		t.Fatalf("WaitUntilNotBusy returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&polls); got < 3 {
+		t.Fatalf("gate opened after %d polls, want >= 3 (must hold through busy polls)", got)
+	}
+}
+
+// Timeout path: a target that never leaves "running" is never delivered to;
+// the hold returns a non-zero error (drop-on-timeout).
+func TestDeferIfBusy_TimeoutDropsMessage(t *testing.T) {
+	profile := "defer_timeout"
+	inst := setupDeferTest(t, profile)
+	seedDeferHookFile(t, inst.ID, "UserPromptSubmit", inst.ClaudeSessionID, "running")
+
+	fetch := func() (string, error) { return fetchHookDrivenStatus(profile, inst.Title) }
+	err := send.WaitUntilNotBusy(fetch, 1*time.Nanosecond, 10*time.Millisecond, func(time.Duration) {})
+	if err == nil {
+		t.Fatal("WaitUntilNotBusy returned nil for a perpetually-busy target; message must be dropped")
+	}
+}
+
+// A ref that resolves to no session surfaces an error from fetchHookDrivenStatus
+// (which the fail-fast path in WaitUntilNotBusy then bounds).
+func TestFetchHookDrivenStatus_UnknownSession(t *testing.T) {
+	profile := "defer_unknown"
+	setupDeferTest(t, profile)
+	if _, err := fetchHookDrivenStatus(profile, "no-such-session-xyz"); err == nil {
+		t.Fatal("fetchHookDrivenStatus returned nil error for an unknown session")
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2510,6 +2510,44 @@ func handleSessionSetTitleLock(profile string, args []string) {
 	})
 }
 
+// fetchHookDrivenStatus reloads the target from storage and reports the same
+// hook-driven status string that `agent-deck list --json` shows. `session send
+// --defer-if-busy` polls this so its hold gate keys off the turn-finished
+// Stop-hook signal (a true edge) rather than WaitForAgentReady's pane-diff
+// readiness heuristic, which false-positives to idle during tool calls and
+// thinking pauses (#1578).
+//
+// It mirrors handleList's status pipeline exactly: reload -> warm caches +
+// cold-load hook files via RefreshInstancesForCLIStatus -> UpdateStatus. The
+// reload each poll is deliberate: a fresh OS process has no StatusFileWatcher,
+// so the only way to observe the target's newest hook edge is to re-read it
+// from disk.
+func fetchHookDrivenStatus(profile, sessionRef string) (string, error) {
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		return "", err
+	}
+	inst, errMsg, _ := ResolveSession(sessionRef, instances)
+	if inst == nil {
+		return "", fmt.Errorf("%s", errMsg)
+	}
+	// Cold-load the on-disk hook file into the instance — a fresh CLI process
+	// has no StatusFileWatcher, so the target's newest hook edge only reaches us
+	// by re-reading it from disk each poll.
+	session.RefreshInstancesForCLIStatus([]*session.Instance{inst})
+	// Prefer the FRESH hook-driven signal. It is the true turn-finished edge
+	// (Claude's UserPromptSubmit hook -> "running", Stop hook -> "waiting") and,
+	// unlike UpdateStatus, is not gated on a live tmux handle — exactly the
+	// property #1578 needs so the hold gate keys off "turn finished" rather than
+	// a pane-diff heuristic. Fall back to the full list --json pipeline when no
+	// fresh hook signal exists (non-hook tools, or a stale/absent hook file).
+	if hs, fresh := inst.GetHookStatus(); fresh && hs != "" {
+		return hs, nil
+	}
+	_ = inst.UpdateStatus()
+	return StatusString(inst.Status), nil
+}
+
 // handleSessionSend sends a message to a running session
 // Waits for the agent to be ready before sending (Claude, Gemini, etc.)
 func handleSessionSend(profile string, args []string) {
@@ -2522,6 +2560,8 @@ func handleSessionSend(profile string, args []string) {
 	stream := fs.Bool("stream", false, "Stream JSONL events (Claude only) to stdout instead of returning a snapshot")
 	draft := fs.Bool("draft", false, "Pre-fill the prompt without submitting (incompatible with --wait/--stream/--no-wait)")
 	messageFile := fs.String("message-file", "", "Read the message from a file ('-' for stdin) instead of a positional argument; avoids shell quoting of long prompts")
+	deferIfBusy := fs.Bool("defer-if-busy", false, "Hold delivery until the target is idle (turn-finished, hook-driven) instead of interrupting a mid-generation turn (incompatible with --no-wait)")
+	deferTimeout := fs.Duration("defer-timeout", 30*time.Minute, "Max time --defer-if-busy holds a busy target before dropping the message with a non-zero exit")
 	timeout := fs.Duration("timeout", 10*time.Minute, "Max time to wait for the agent to become ready and (with --wait) to finish processing")
 	streamIdle := fs.Duration("stream-idle", 10*time.Second, "Max idle time before --stream aborts with error")
 	streamCharBudget := fs.Int("stream-char-budget", 4000, "Char budget for text flush in --stream mode")
@@ -2543,6 +2583,7 @@ func handleSessionSend(profile string, args []string) {
 		fmt.Println("  agent-deck session send my-project \"cwd: /path/to/dir\" --draft")
 		fmt.Println("  agent-deck session send my-project --message-file answer.md   # long reply from file")
 		fmt.Println("  git diff | agent-deck session send my-project --message-file -   # message from stdin")
+		fmt.Println("  agent-deck session send parent \"child done\" --defer-if-busy --defer-timeout 30m")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -2566,6 +2607,13 @@ func handleSessionSend(profile string, args []string) {
 
 	if *draft && (*wait || *stream || *noWait) {
 		out.Error("--draft is incompatible with --wait, --stream, and --no-wait", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// #1578: --defer-if-busy holds delivery until the target is turn-finished;
+	// --no-wait fires immediately. They are opposites.
+	if *deferIfBusy && *noWait {
+		out.Error("--defer-if-busy is incompatible with --no-wait", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 
@@ -2625,6 +2673,20 @@ func handleSessionSend(profile string, args []string) {
 	if tmuxSess == nil {
 		out.Error("could not determine tmux session", ErrCodeInvalidOperation)
 		os.Exit(1)
+	}
+
+	// #1578: --defer-if-busy holds delivery until the target is turn-finished.
+	// Runs BEFORE WaitForAgentReady + the composer-draft Ctrl+C guard, so a
+	// mid-generation target is never interrupted. Keys off the hook-driven
+	// status (the same turn-finished signal `list --json` reports), not the
+	// pane-diff readiness heuristic that false-positives idle mid-turn.
+	if *deferIfBusy {
+		if err := send.WaitUntilNotBusy(func() (string, error) {
+			return fetchHookDrivenStatus(profile, sessionRef)
+		}, *deferTimeout, send.DeferPollInterval, time.Sleep); err != nil {
+			out.Error(err.Error(), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
 	}
 
 	// Wait for agent to be ready (unless --no-wait is specified).

--- a/internal/send/deferbusy.go
+++ b/internal/send/deferbusy.go
@@ -1,0 +1,85 @@
+package send
+
+import (
+	"fmt"
+	"time"
+)
+
+// DeferPollInterval is the fixed cadence at which `session send --defer-if-busy`
+// re-checks the target's hook-driven status while holding delivery.
+const DeferPollInterval = 2 * time.Second
+
+// maxConsecutiveFetchErrors bounds transient status-fetch failures before
+// WaitUntilNotBusy gives up. Without this, a removed or renamed target would
+// spin returning an error on every poll for the entire defer timeout.
+const maxConsecutiveFetchErrors = 3
+
+// StatusIsBusy reports whether a hook-driven status string represents a target
+// that is mid-turn (actively generating) or still booting. These are the only
+// states `--defer-if-busy` holds for; every other state
+// (waiting/idle/error/stopped/queued/unknown) means the composer is free and
+// delivery may proceed.
+//
+// This keys off the SAME hook-driven signal `agent-deck list --json` reports
+// (Claude's UserPromptSubmit hook writes "running", the Stop hook writes
+// "waiting"), which is a true turn-finished edge — unlike WaitForAgentReady's
+// pane-content-diff heuristic that false-positives to idle during tool calls
+// and thinking pauses (issue #1578).
+func StatusIsBusy(status string) bool {
+	switch status {
+	case "running", "starting":
+		return true
+	default:
+		return false
+	}
+}
+
+// WaitUntilNotBusy polls fetchStatus until the target is no longer busy (see
+// StatusIsBusy), the timeout elapses, or the fetch fails persistently.
+//
+// It is the core of `session send --defer-if-busy`: rather than interrupting a
+// generating target with the composer-draft Ctrl+C guard (GuardComposerDraft,
+// issue #1409), the sender holds until the target's hook-driven status shows
+// the turn is over, then lets the normal readiness/guard/send pipeline run.
+//
+// sleep is injected so tests run without real delay; production passes
+// time.Sleep. A nil sleep defaults to time.Sleep; a non-positive poll defaults
+// to DeferPollInterval. On timeout the message is NOT delivered and a non-zero
+// error is returned (drop-on-timeout semantics).
+func WaitUntilNotBusy(fetchStatus func() (string, error), timeout, poll time.Duration, sleep func(time.Duration)) error {
+	if poll <= 0 {
+		poll = DeferPollInterval
+	}
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
+	deadline := time.Now().Add(timeout)
+	consecutiveErrs := 0
+	lastStatus := ""
+
+	for {
+		status, err := fetchStatus()
+		if err != nil {
+			consecutiveErrs++
+			if consecutiveErrs >= maxConsecutiveFetchErrors {
+				return fmt.Errorf("defer-if-busy: giving up after %d consecutive status-fetch errors: %w", consecutiveErrs, err)
+			}
+		} else {
+			consecutiveErrs = 0
+			lastStatus = status
+			if !StatusIsBusy(status) {
+				return nil
+			}
+		}
+
+		if timeout > 0 && !time.Now().Before(deadline) {
+			if lastStatus == "" {
+				lastStatus = "unknown"
+			}
+			return fmt.Errorf("defer-if-busy: target still busy (%s) after %s", lastStatus, timeout)
+		}
+
+		sleep(poll)
+	}
+}

--- a/internal/send/deferbusy_test.go
+++ b/internal/send/deferbusy_test.go
@@ -1,0 +1,135 @@
+package send
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStatusIsBusy(t *testing.T) {
+	busy := []string{"running", "starting"}
+	free := []string{"waiting", "idle", "error", "stopped", "queued", "unknown", ""}
+	for _, s := range busy {
+		if !StatusIsBusy(s) {
+			t.Errorf("StatusIsBusy(%q) = false, want true", s)
+		}
+	}
+	for _, s := range free {
+		if StatusIsBusy(s) {
+			t.Errorf("StatusIsBusy(%q) = true, want false", s)
+		}
+	}
+}
+
+// Holds while the target reports "running", then delivers the instant the
+// hook-driven status flips to "waiting" (the Stop-hook turn-finished edge).
+func TestWaitUntilNotBusy_HoldsThenDelivers(t *testing.T) {
+	statuses := []string{"running", "running", "running", "waiting"}
+	calls := 0
+	fetch := func() (string, error) {
+		s := statuses[calls]
+		calls++
+		return s, nil
+	}
+	sleeps := 0
+	sleep := func(time.Duration) { sleeps++ }
+
+	if err := WaitUntilNotBusy(fetch, 30*time.Minute, 10*time.Millisecond, sleep); err != nil {
+		t.Fatalf("WaitUntilNotBusy returned error: %v", err)
+	}
+	if calls != 4 {
+		t.Errorf("polled %d times, want 4 (held through 3 running polls, delivered on waiting)", calls)
+	}
+	if sleeps != 3 {
+		t.Errorf("slept %d times, want 3 (once per busy poll, none after the delivering poll)", sleeps)
+	}
+}
+
+// Already-idle target: returns immediately, never sleeps.
+func TestWaitUntilNotBusy_ImmediateWhenIdle(t *testing.T) {
+	calls := 0
+	fetch := func() (string, error) {
+		calls++
+		return "waiting", nil
+	}
+	sleeps := 0
+	sleep := func(time.Duration) { sleeps++ }
+
+	if err := WaitUntilNotBusy(fetch, 30*time.Minute, 10*time.Millisecond, sleep); err != nil {
+		t.Fatalf("WaitUntilNotBusy returned error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("polled %d times, want 1", calls)
+	}
+	if sleeps != 0 {
+		t.Errorf("slept %d times, want 0", sleeps)
+	}
+}
+
+// Target never leaves "running": the timeout elapses and the message is
+// dropped (non-nil error), never delivered.
+func TestWaitUntilNotBusy_TimeoutDrops(t *testing.T) {
+	fetch := func() (string, error) { return "running", nil }
+	// Injected sleep that advances a fake clock is unnecessary: a tiny real
+	// timeout with a no-op sleep makes the deadline fire on the second poll.
+	sleep := func(time.Duration) {}
+
+	err := WaitUntilNotBusy(fetch, 1*time.Nanosecond, 10*time.Millisecond, sleep)
+	if err == nil {
+		t.Fatal("WaitUntilNotBusy returned nil, want timeout error (message must be dropped, not delivered)")
+	}
+	if got := err.Error(); got == "" || !contains(got, "still busy") {
+		t.Errorf("error = %q, want it to mention the target is still busy", got)
+	}
+}
+
+// Transient fetch errors are tolerated: fewer than the fail-fast threshold do
+// not abort, and a subsequent good idle reading delivers.
+func TestWaitUntilNotBusy_TransientErrorTolerated(t *testing.T) {
+	seq := []struct {
+		status string
+		err    error
+	}{
+		{"", errors.New("transient")},
+		{"", errors.New("transient")},
+		{"waiting", nil},
+	}
+	calls := 0
+	fetch := func() (string, error) {
+		s := seq[calls]
+		calls++
+		return s.status, s.err
+	}
+	if err := WaitUntilNotBusy(fetch, 30*time.Minute, 10*time.Millisecond, func(time.Duration) {}); err != nil {
+		t.Fatalf("WaitUntilNotBusy returned error on tolerable transient errors: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("polled %d times, want 3", calls)
+	}
+}
+
+// Persistent fetch errors (removed/renamed target) fail fast at the threshold
+// instead of spinning for the full defer timeout.
+func TestWaitUntilNotBusy_PersistentErrorFailsFast(t *testing.T) {
+	calls := 0
+	fetch := func() (string, error) {
+		calls++
+		return "", errors.New("session not found")
+	}
+	err := WaitUntilNotBusy(fetch, 30*time.Minute, 10*time.Millisecond, func(time.Duration) {})
+	if err == nil {
+		t.Fatal("WaitUntilNotBusy returned nil, want fail-fast error")
+	}
+	if calls != maxConsecutiveFetchErrors {
+		t.Errorf("polled %d times, want %d (fail-fast threshold)", calls, maxConsecutiveFetchErrors)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #1578. Opt-in flag holds delivery until the target's hook-driven status is turn-finished, instead of interrupting a mid-generation turn (#1409). --defer-timeout bounds the hold before dropping with a non-zero exit. Adds internal/send/deferbusy.go with unit tests (gate, timeout, transient-error tolerance). Rebased on current main (coexists with the merged --message-file flag). Build + targeted sandboxed tests green.