### PR TITLE
fix(reviver): break reconnect storms on a wedged tmux server (#1579)

### DIFF
--- a/internal/session/reviver.go
+++ b/internal/session/reviver.go
@@ -45,6 +45,10 @@ type ReviveOutcome struct {
 	Class      RevivalClass
 	Revived    bool
 	Err        error
+	// CircuitOpen is true when the futility circuit breaker skipped this
+	// instance's revive this sweep because prior revives never stabilized
+	// (a wedged tmux server that only a manual restart recovers, #1579).
+	CircuitOpen bool
 }
 
 // Reviver walks storage and re-establishes dead control pipes for instances
@@ -64,6 +68,10 @@ type Reviver struct {
 	ReviveAction func(*Instance) error
 	Stagger      time.Duration
 	Log          *slog.Logger
+	// Breaker bounds futile reconnect storms on a wedged tmux server (#1579).
+	// nil disables the breaker entirely — exact legacy behavior, relied on by
+	// unit tests that construct Reviver{} directly.
+	Breaker *ReviveBreaker
 }
 
 // NewReviver returns a Reviver wired to real tmux + PipeManager primitives.
@@ -76,6 +84,12 @@ func NewReviver() *Reviver {
 		ReviveAction: defaultReviveAction,
 		Stagger:      500 * time.Millisecond,
 		Log:          sessionLog,
+		// Process-global breaker: the TUI builds a fresh Reviver every 60s
+		// sweep (internal/ui/home.go), so per-sweep state would never
+		// accumulate. The breaker must outlive the Reviver to detect a
+		// storm across sweeps. CLI one-shots run in a short-lived process,
+		// so their global breaker starts empty and always probes.
+		Breaker: globalReviveBreaker,
 	}
 }
 
@@ -121,6 +135,9 @@ func (r *Reviver) Classify(inst *Instance) RevivalClass {
 // runReviveAll / PersistRevivedInstances — MUST be revisited so those mutations
 // are not silently dropped.
 func (r *Reviver) ReviveAll(instances []*Instance) []ReviveOutcome {
+	if r.Breaker != nil {
+		r.Breaker.Prune()
+	}
 	outcomes := make([]ReviveOutcome, 0, len(instances))
 	firstRevive := true
 	for _, inst := range instances {
@@ -148,7 +165,25 @@ func (r *Reviver) reviveOneInternal(inst *Instance, firstRevive *bool) ReviveOut
 		Title:      inst.Title,
 		Class:      class,
 	}
+
+	// Feed the classification to the breaker every sweep (not just for
+	// errored instances) so ClassAlive can reset a session's futility state
+	// and so futility from a prior sweep's revive is judged before we decide
+	// whether to attempt another one.
+	attempt := true
+	if r.Breaker != nil {
+		attempt = r.Breaker.OnClassify(inst.ID, inst.Title, class)
+	}
+
 	if class != ClassErrored {
+		return out
+	}
+
+	// Circuit open and cooling down: skip the doomed reconnect. This is the
+	// storm brake — on a wedged tmux server the breaker keeps us from
+	// respawning the same dead pipes every sweep (#1579).
+	if !attempt {
+		out.CircuitOpen = true
 		return out
 	}
 
@@ -159,12 +194,21 @@ func (r *Reviver) reviveOneInternal(inst *Instance, firstRevive *bool) ReviveOut
 
 	if err := r.ReviveAction(inst); err != nil {
 		out.Err = err
+		if r.Breaker != nil {
+			// A failed action is immediately futile — count it toward the trip.
+			r.Breaker.AfterRevive(inst.ID, inst.Title, err)
+		}
 		if r.Log != nil {
 			r.Log.Warn("reviver_action_failed",
 				slog.String("title", inst.Title),
 				slog.String("error", err.Error()))
 		}
 		return out
+	}
+	if r.Breaker != nil {
+		// Action "succeeded"; mark pending so the next sweep can tell whether
+		// the session actually stabilized or is still errored (futile).
+		r.Breaker.AfterRevive(inst.ID, inst.Title, nil)
 	}
 	out.Revived = true
 	if r.Log != nil {

--- a/internal/session/reviver_breaker.go
+++ b/internal/session/reviver_breaker.go
@@ -1,0 +1,235 @@
+package session
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// ReviveBreaker bounds futile control-pipe reconnect storms on a wedged tmux
+// server (#1579).
+//
+// The failure mode it guards: when the tmux SERVER wedges (stops serving
+// control pipes for existing sessions while `has-session` still answers yes),
+// every 60s reviver sweep classifies the affected sessions ClassErrored and
+// "successfully" reconnects their pipes — which die again immediately. Because
+// pm.Connect returns nil each time, there is no failure signal, so the reviver
+// respawns the same dead pipes forever (observed: 37 respawns of ~7 sessions in
+// 9 minutes). Pressing R in the TUI just triggers another doomed attach. Only a
+// full `pkill tmux` + relaunch recovers, and nothing tells the user that.
+//
+// The breaker detects futility by transition, not by action return code: a
+// revive is futile when the session is ClassErrored AGAIN on a later sweep
+// despite a prior "successful" revive, or when the revive action itself errors.
+// After FutilityThreshold consecutive futile revives it opens the session's
+// circuit — revives are skipped and throttled to one probe per exponential
+// cooldown (InitialCooldown → MaxCooldown). A single ClassAlive classification
+// fully resets the entry (real recovery). When several circuits are open at
+// once the shape is server-wide, not session-specific, so it emits one loud,
+// rate-limited wedge warning naming the manual remedy. It NEVER auto-kills tmux.
+type ReviveBreaker struct {
+	mu      sync.Mutex
+	entries map[string]*breakerEntry
+	log     *slog.Logger
+	now     func() time.Time
+
+	lastWedgeWarn time.Time
+}
+
+type breakerEntry struct {
+	futileCount   int
+	pendingVerify bool // a revive ran last sweep; next ClassErrored ⇒ futile
+	circuitOpen   bool
+	cooldown      time.Duration // current backoff window
+	cooldownUntil time.Time     // no probe until this instant
+	lastSeen      time.Time     // for TTL pruning
+}
+
+// Breaker tuning. Kept in one block so review can adjust N / backoff / TTL
+// without hunting through the logic.
+const (
+	// FutilityThreshold is how many consecutive futile revives trip the circuit.
+	FutilityThreshold = 3
+	// InitialCooldown is the first throttle window after the circuit opens.
+	InitialCooldown = 2 * time.Minute
+	// MaxCooldown caps the exponential backoff.
+	MaxCooldown = 30 * time.Minute
+	// WedgeMinOpenCircuits is the number of simultaneously-open circuits that
+	// looks server-wide (a wedge) rather than session-specific.
+	WedgeMinOpenCircuits = 2
+	// WedgeWarnInterval rate-limits the loud wedge warning.
+	WedgeWarnInterval = 10 * time.Minute
+	// EntryTTL prunes stale per-session state (a session removed, renamed, or
+	// long-healthy leaves no residue).
+	EntryTTL = 1 * time.Hour
+)
+
+// globalReviveBreaker is the process-wide breaker wired by NewReviver(). The
+// TUI constructs a fresh Reviver each 60s sweep, so the breaker state has to
+// outlive the Reviver to observe a storm across sweeps.
+var globalReviveBreaker = NewReviveBreaker(sessionLog)
+
+// NewReviveBreaker returns an empty breaker. log may be nil (no logging).
+func NewReviveBreaker(log *slog.Logger) *ReviveBreaker {
+	return &ReviveBreaker{
+		entries: make(map[string]*breakerEntry),
+		log:     log,
+		now:     time.Now,
+	}
+}
+
+// OnClassify records this sweep's classification for an instance and returns
+// whether a revive should be attempted (only meaningful for ClassErrored).
+//
+//   - ClassAlive  → full reset (the session actually recovered). Returns true
+//     but the caller ignores it for non-errored classes.
+//   - ClassDead   → no attempt, counters untouched (a gone server is a
+//     different condition; an errored↔dead flap must not lose futility state).
+//   - ClassErrored → if a revive from a prior sweep is pending verification and
+//     the session is still errored, that revive was futile. Then: if the
+//     circuit is open and still cooling down, returns false (skip); otherwise
+//     returns true (attempt, including the single probe at cooldown expiry).
+func (b *ReviveBreaker) OnClassify(id, title string, class RevivalClass) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := b.now()
+	e := b.entries[id]
+	if e == nil {
+		e = &breakerEntry{}
+		b.entries[id] = e
+	}
+	e.lastSeen = now
+
+	switch class {
+	case ClassAlive:
+		// Genuine recovery — wipe all breaker state for this session.
+		delete(b.entries, id)
+		return true
+	case ClassDead:
+		// Never revived; hold state without counting a futile revive.
+		e.pendingVerify = false
+		return false
+	}
+
+	// class == ClassErrored
+	if e.pendingVerify {
+		// Prior sweep's revive did not stabilize the session.
+		e.pendingVerify = false
+		b.recordFutileLocked(e, id, title, now)
+	}
+
+	if e.circuitOpen && now.Before(e.cooldownUntil) {
+		if b.log != nil {
+			b.log.Info("reviver_circuit_skip",
+				slog.String("title", title),
+				slog.String("instance_id", id),
+				slog.Int("futile_count", e.futileCount),
+				slog.Duration("cooldown_remaining", e.cooldownUntil.Sub(now).Round(time.Second)))
+		}
+		return false
+	}
+	// Circuit closed, or open but cooldown expired → allow one (probe) attempt.
+	return true
+}
+
+// AfterRevive records that a revive action ran this sweep. actionErr != nil is
+// immediately futile; a nil error arms pendingVerify so the next OnClassify can
+// judge whether the session actually stabilized.
+func (b *ReviveBreaker) AfterRevive(id, title string, actionErr error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[id]
+	if e == nil {
+		e = &breakerEntry{}
+		b.entries[id] = e
+	}
+	e.lastSeen = b.now()
+
+	if actionErr != nil {
+		e.pendingVerify = false
+		b.recordFutileLocked(e, id, title, b.now())
+		return
+	}
+	e.pendingVerify = true
+}
+
+// recordFutileLocked increments the futile counter and, at/after the threshold,
+// opens (or re-arms) the circuit with exponential backoff. Caller holds b.mu.
+func (b *ReviveBreaker) recordFutileLocked(e *breakerEntry, id, title string, now time.Time) {
+	e.futileCount++
+
+	switch {
+	case !e.circuitOpen && e.futileCount >= FutilityThreshold:
+		e.circuitOpen = true
+		e.cooldown = InitialCooldown
+	case e.circuitOpen:
+		// A probe was itself futile — back off harder.
+		e.cooldown *= 2
+		if e.cooldown > MaxCooldown {
+			e.cooldown = MaxCooldown
+		}
+	default:
+		// Below threshold, circuit still closed — nothing to arm yet.
+		return
+	}
+
+	e.cooldownUntil = now.Add(e.cooldown)
+	if b.log != nil {
+		b.log.Warn("reviver_circuit_open",
+			slog.String("title", title),
+			slog.String("instance_id", id),
+			slog.Int("futile_count", e.futileCount),
+			slog.Duration("cooldown", e.cooldown))
+	}
+	b.maybeWarnWedgeLocked(now)
+}
+
+// maybeWarnWedgeLocked emits one rate-limited wedge warning when enough circuits
+// are open simultaneously that the cause is server-wide. Caller holds b.mu.
+func (b *ReviveBreaker) maybeWarnWedgeLocked(now time.Time) {
+	open := 0
+	for _, e := range b.entries {
+		if e.circuitOpen {
+			open++
+		}
+	}
+	if open < WedgeMinOpenCircuits {
+		return
+	}
+	if !b.lastWedgeWarn.IsZero() && now.Sub(b.lastWedgeWarn) < WedgeWarnInterval {
+		return
+	}
+	b.lastWedgeWarn = now
+	if b.log != nil {
+		b.log.Warn("reviver_tmux_wedge_suspected",
+			slog.Int("open_circuits", open),
+			slog.String("remedy", "tmux server likely wedged; reconnect/R cannot recover it — run `pkill tmux` then relaunch agent-deck"))
+	}
+}
+
+// Prune drops entries not seen within EntryTTL. Called once per ReviveAll batch.
+func (b *ReviveBreaker) Prune() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	cutoff := b.now().Add(-EntryTTL)
+	for id, e := range b.entries {
+		if e.lastSeen.Before(cutoff) {
+			delete(b.entries, id)
+		}
+	}
+}
+
+// openCircuits reports how many circuits are currently open. Test helper.
+func (b *ReviveBreaker) openCircuits() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	open := 0
+	for _, e := range b.entries {
+		if e.circuitOpen {
+			open++
+		}
+	}
+	return open
+}

--- a/internal/session/reviver_breaker_test.go
+++ b/internal/session/reviver_breaker_test.go
@@ -254,7 +254,7 @@ func TestReviveBreaker_WedgeWarnOnceRateLimited(t *testing.T) {
 	// After the interval, a fresh open-circuit event may warn again.
 	clk.Advance(WedgeWarnInterval + time.Minute)
 	// Force a re-futile probe on both to re-enter recordFutile with open circuits.
-	clk.Advance(MaxCooldown) // ensure cooldown expired so probes fire
+	clk.Advance(MaxCooldown)    // ensure cooldown expired so probes fire
 	sweep(r, []*Instance{a, c}) // probes
 	sweep(r, []*Instance{a, c}) // futile → recordFutile → warn again
 	if got := h.count("reviver_tmux_wedge_suspected"); got < 2 {

--- a/internal/session/reviver_breaker_test.go
+++ b/internal/session/reviver_breaker_test.go
@@ -1,0 +1,341 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+var errTest = errors.New("revive action failed")
+
+// --- test scaffolding -------------------------------------------------------
+// (fakeClock is defined in issue1143_idle_timeout_test.go: Now()/Advance().)
+
+// recordingHandler captures slog records for assertions.
+type recordingHandler struct {
+	mu   sync.Mutex
+	recs []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.recs = append(h.recs, r)
+	return nil
+}
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *recordingHandler) count(msg string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, r := range h.recs {
+		if r.Message == msg {
+			n++
+		}
+	}
+	return n
+}
+
+// newTestBreaker returns a breaker driven by a fake clock and a recording log.
+func newTestBreaker() (*ReviveBreaker, *fakeClock, *recordingHandler) {
+	clk := newFakeClock(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC))
+	h := &recordingHandler{}
+	b := NewReviveBreaker(slog.New(h))
+	b.now = clk.Now
+	return b, clk, h
+}
+
+// wedgedReviver builds a Reviver that simulates a wedged tmux server: the
+// server answers has-session (TmuxExists=true) and the pipe is always dead
+// (PipeAlive=false), while the revive action "succeeds" (Connect returns nil)
+// but never actually stabilizes the session. calls counts revive actions.
+func wedgedReviver(b *ReviveBreaker, calls *int) *Reviver {
+	return &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		PipeAlive:    func(string) bool { return false },
+		ReviveAction: func(*Instance) error { *calls++; return nil },
+		Stagger:      0,
+		Breaker:      b,
+	}
+}
+
+// sweep runs one ReviveAll over the given instances and returns the outcomes.
+func sweep(r *Reviver, insts []*Instance) []ReviveOutcome {
+	return r.ReviveAll(insts)
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestReviveBreaker_TripsAfterThreshold verifies the circuit opens after
+// FutilityThreshold futile revives and then skips further attempts.
+func TestReviveBreaker_TripsAfterThreshold(t *testing.T) {
+	b, _, h := newTestBreaker()
+	calls := 0
+	r := wedgedReviver(b, &calls)
+	inst := newReviverTestInstance("wedged", StatusError)
+
+	// Sweep 1: attempt (pending set). Sweeps 2,3: futile #1,#2 + attempt.
+	// Sweep 4: futile #3 → circuit opens → skip.
+	var lastOut ReviveOutcome
+	for i := 0; i < 6; i++ {
+		outs := sweep(r, []*Instance{inst})
+		lastOut = outs[0]
+	}
+
+	// Attempts should have stopped at 3 (sweeps 1-3); sweeps 4-6 skipped.
+	if calls != 3 {
+		t.Fatalf("expected revive action bounded to 3 calls, got %d", calls)
+	}
+	if !lastOut.CircuitOpen {
+		t.Errorf("expected CircuitOpen=true once tripped")
+	}
+	if h.count("reviver_circuit_open") == 0 {
+		t.Errorf("expected a reviver_circuit_open log")
+	}
+	if got := b.openCircuits(); got != 1 {
+		t.Errorf("expected 1 open circuit, got %d", got)
+	}
+}
+
+// TestReviveBreaker_ExponentialBackoffAndProbe verifies that after the circuit
+// opens, exactly one probe fires per cooldown expiry and a re-futile probe
+// doubles the cooldown.
+func TestReviveBreaker_ExponentialBackoffAndProbe(t *testing.T) {
+	b, clk, _ := newTestBreaker()
+	calls := 0
+	r := wedgedReviver(b, &calls)
+	inst := newReviverTestInstance("wedged", StatusError)
+
+	// Trip the circuit (4 sweeps → 3 attempts, then open).
+	for i := 0; i < 4; i++ {
+		sweep(r, []*Instance{inst})
+	}
+	if calls != 3 {
+		t.Fatalf("setup: expected 3 attempts pre-open, got %d", calls)
+	}
+
+	// While cooling down (< InitialCooldown), extra sweeps must NOT attempt.
+	clk.Advance(1 * time.Minute)
+	sweep(r, []*Instance{inst})
+	if calls != 3 {
+		t.Fatalf("expected no probe during cooldown, got %d calls", calls)
+	}
+
+	// Cooldown expired → exactly one probe.
+	clk.Advance(2 * time.Minute) // now past InitialCooldown (2m)
+	sweep(r, []*Instance{inst})
+	if calls != 4 {
+		t.Fatalf("expected one probe at cooldown expiry, got %d calls", calls)
+	}
+
+	// The probe was futile (still errored next sweep) → cooldown doubled to 4m.
+	// At +2m it must still be cooling down.
+	clk.Advance(2 * time.Minute)
+	sweep(r, []*Instance{inst}) // detects futile probe, re-arms; no attempt
+	if calls != 4 {
+		t.Fatalf("expected no probe yet (backoff doubled), got %d calls", calls)
+	}
+	// Advance past the doubled window (cooldown re-armed to 4m at detection
+	// time) and probe again.
+	clk.Advance(5 * time.Minute)
+	sweep(r, []*Instance{inst})
+	if calls != 5 {
+		t.Fatalf("expected second probe after doubled cooldown, got %d calls", calls)
+	}
+}
+
+// TestReviveBreaker_HealthyReset verifies ClassAlive wipes futility state so a
+// recovered session revives normally again.
+func TestReviveBreaker_HealthyReset(t *testing.T) {
+	b, _, _ := newTestBreaker()
+	calls := 0
+	pipeAlive := false
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		PipeAlive:    func(string) bool { return pipeAlive },
+		ReviveAction: func(*Instance) error { calls++; return nil },
+		Stagger:      0,
+		Breaker:      b,
+	}
+	inst := newReviverTestInstance("flapper", StatusError)
+
+	// Trip the circuit.
+	for i := 0; i < 4; i++ {
+		sweep(r, []*Instance{inst})
+	}
+	if b.openCircuits() != 1 {
+		t.Fatalf("setup: expected open circuit")
+	}
+
+	// Session recovers: pipe alive AND status cleared → ClassAlive.
+	pipeAlive = true
+	inst.Status = StatusRunning
+	sweep(r, []*Instance{inst})
+	if b.openCircuits() != 0 {
+		t.Fatalf("expected circuit reset after ClassAlive")
+	}
+
+	// Regress again: fresh counting, first sweep attempts immediately.
+	pipeAlive = false
+	inst.Status = StatusError
+	callsBefore := calls
+	sweep(r, []*Instance{inst})
+	if calls != callsBefore+1 {
+		t.Fatalf("expected immediate attempt after reset, got %d (was %d)", calls, callsBefore)
+	}
+}
+
+// TestReviveBreaker_FailedActionCountsFutile verifies a revive action that
+// returns an error trips the circuit without needing the next-sweep transition.
+func TestReviveBreaker_FailedActionCountsFutile(t *testing.T) {
+	b, _, _ := newTestBreaker()
+	calls := 0
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		PipeAlive:    func(string) bool { return false },
+		ReviveAction: func(*Instance) error { calls++; return errTest },
+		Stagger:      0,
+		Breaker:      b,
+	}
+	inst := newReviverTestInstance("failer", StatusError)
+
+	// Each failed action is immediately futile → 3 sweeps trip it.
+	for i := 0; i < 3; i++ {
+		sweep(r, []*Instance{inst})
+	}
+	if b.openCircuits() != 1 {
+		t.Fatalf("expected circuit open after 3 failed actions, got %d open", b.openCircuits())
+	}
+	// Next sweep skips.
+	callsBefore := calls
+	outs := sweep(r, []*Instance{inst})
+	if calls != callsBefore {
+		t.Fatalf("expected skip after trip, got extra calls")
+	}
+	if !outs[0].CircuitOpen {
+		t.Errorf("expected CircuitOpen outcome")
+	}
+}
+
+// TestReviveBreaker_WedgeWarnOnceRateLimited verifies the wedge warning fires
+// when ≥2 circuits open and is rate-limited to once per WedgeWarnInterval.
+func TestReviveBreaker_WedgeWarnOnceRateLimited(t *testing.T) {
+	b, clk, h := newTestBreaker()
+	calls := 0
+	r := wedgedReviver(b, &calls)
+	a := newReviverTestInstance("a", StatusError)
+	c := newReviverTestInstance("c", StatusError)
+
+	// Trip both circuits.
+	for i := 0; i < 5; i++ {
+		sweep(r, []*Instance{a, c})
+	}
+	if b.openCircuits() != 2 {
+		t.Fatalf("expected 2 open circuits, got %d", b.openCircuits())
+	}
+	if got := h.count("reviver_tmux_wedge_suspected"); got != 1 {
+		t.Fatalf("expected exactly 1 wedge warning, got %d", got)
+	}
+
+	// More sweeps within the interval must not re-warn.
+	for i := 0; i < 3; i++ {
+		sweep(r, []*Instance{a, c})
+	}
+	if got := h.count("reviver_tmux_wedge_suspected"); got != 1 {
+		t.Fatalf("expected wedge warning rate-limited to 1, got %d", got)
+	}
+
+	// After the interval, a fresh open-circuit event may warn again.
+	clk.Advance(WedgeWarnInterval + time.Minute)
+	// Force a re-futile probe on both to re-enter recordFutile with open circuits.
+	clk.Advance(MaxCooldown) // ensure cooldown expired so probes fire
+	sweep(r, []*Instance{a, c}) // probes
+	sweep(r, []*Instance{a, c}) // futile → recordFutile → warn again
+	if got := h.count("reviver_tmux_wedge_suspected"); got < 2 {
+		t.Fatalf("expected wedge warning to re-fire after interval, got %d", got)
+	}
+}
+
+// TestReviveBreaker_NilBreakerLegacy verifies a Reviver with no breaker keeps
+// the exact pre-#1579 storm behavior (unbounded respawns, no CircuitOpen).
+func TestReviveBreaker_NilBreakerLegacy(t *testing.T) {
+	calls := 0
+	r := wedgedReviver(nil, &calls) // Breaker set to nil below
+	r.Breaker = nil
+	inst := newReviverTestInstance("legacy", StatusError)
+
+	for i := 0; i < 10; i++ {
+		outs := sweep(r, []*Instance{inst})
+		if outs[0].CircuitOpen {
+			t.Fatalf("nil breaker must never report CircuitOpen")
+		}
+	}
+	if calls != 10 {
+		t.Fatalf("nil breaker must respawn every sweep (10), got %d", calls)
+	}
+}
+
+// TestReviveBreaker_Prune verifies stale entries are dropped after EntryTTL.
+func TestReviveBreaker_Prune(t *testing.T) {
+	b, clk, _ := newTestBreaker()
+	calls := 0
+	r := wedgedReviver(b, &calls)
+	inst := newReviverTestInstance("stale", StatusError)
+
+	sweep(r, []*Instance{inst})
+	b.mu.Lock()
+	n := len(b.entries)
+	b.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("expected 1 tracked entry, got %d", n)
+	}
+
+	// Advance beyond TTL and prune (ReviveAll calls Prune with an empty list).
+	clk.Advance(EntryTTL + time.Minute)
+	sweep(r, nil)
+	b.mu.Lock()
+	n = len(b.entries)
+	b.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("expected stale entry pruned, got %d", n)
+	}
+}
+
+// TestIssue1579_StormBounded is the before/after pin: on a wedged server the
+// breaker caps respawns while the legacy path storms unboundedly.
+func TestIssue1579_StormBounded(t *testing.T) {
+	const sweeps = 40 // the issue observed 37 respawns in ~9 minutes
+
+	// Legacy (no breaker): one respawn per sweep, unbounded.
+	legacyCalls := 0
+	legacy := wedgedReviver(nil, &legacyCalls)
+	legacy.Breaker = nil
+	inst := newReviverTestInstance("victim", StatusError)
+	for i := 0; i < sweeps; i++ {
+		sweep(legacy, []*Instance{inst})
+	}
+	if legacyCalls != sweeps {
+		t.Fatalf("legacy should storm %d×, got %d", sweeps, legacyCalls)
+	}
+
+	// With breaker: bounded far below the sweep count.
+	b, _, _ := newTestBreaker()
+	brokenCalls := 0
+	broken := wedgedReviver(b, &brokenCalls)
+	inst2 := newReviverTestInstance("victim2", StatusError)
+	for i := 0; i < sweeps; i++ {
+		sweep(broken, []*Instance{inst2})
+	}
+	if brokenCalls > FutilityThreshold {
+		t.Fatalf("breaker should bound respawns to ≤%d before opening, got %d", FutilityThreshold, brokenCalls)
+	}
+	if brokenCalls >= legacyCalls {
+		t.Fatalf("breaker (%d) must respawn far fewer than legacy (%d)", brokenCalls, legacyCalls)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1815,7 +1815,11 @@ func (s *Session) SetEnvironment(key, value string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := s.tmuxCmdContext(ctx, "set-environment", "-t", s.Name, key, value)
-	err := cmd.Run()
+	// CombinedOutput (not Run) so tmux stderr is folded into the error. A bare
+	// "exit status 1" is useless for diagnosing a wedged server (#1579): the
+	// real cause ("no server running on ...", "can't find session") lives on
+	// stderr, which Run() discards.
+	out, err := cmd.CombinedOutput()
 	if err == nil {
 		// Invalidate cache entry so next GetEnvironment sees the new value
 		s.envCacheMu.Lock()
@@ -1823,6 +1827,10 @@ func (s *Session) SetEnvironment(key, value string) error {
 			delete(s.envCache, key)
 		}
 		s.envCacheMu.Unlock()
+		return nil
+	}
+	if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+		return fmt.Errorf("%w: %s", err, trimmed)
 	}
 	return err
 }


### PR DESCRIPTION
Closes #1579. A futility circuit breaker in the reviver bounds the silent respawn storm on a wedged tmux server (37 respawns/9min to at most 3, then throttled), surfaces one rate-limited reviver_tmux_wedge_suspected WARN naming the pkill-tmux remedy, and folds tmux stderr into SetEnvironment errors to pin the trigger. Process-global breaker (the TUI rebuilds Reviver per sweep); nil breaker = legacy. 8 new unit tests incl. before/after storm pin. Build + targeted sandboxed tests green.