### PR TITLE
fix(session): surface spawn/exec failures instead of bare "error" (#1580)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1668,6 +1668,20 @@ func handleSessionShow(profile string, args []string) {
 		jsonData["tmux_session"] = tmuxSession.Name
 	}
 
+	// #1580: surface a spawn-failure diagnostic when the session errored at
+	// startup (bare "error" with no pane). Include the structured record in
+	// --json so tooling can read it too.
+	spawnFailure := inst.SpawnFailure()
+	if spawnFailure != nil {
+		jsonData["spawn_failure"] = map[string]interface{}{
+			"reason":       spawnFailure.Reason,
+			"command":      spawnFailure.Command,
+			"dying_output": spawnFailure.DyingOutput,
+			"elapsed_ms":   spawnFailure.ElapsedMs,
+			"ts":           spawnFailure.Timestamp,
+		}
+	}
+
 	// Build human-readable output
 	var sb strings.Builder
 
@@ -1755,6 +1769,14 @@ func handleSessionShow(profile string, args []string) {
 		if tmuxSession != nil {
 			sb.WriteString(fmt.Sprintf("Tmux:    %s\n", tmuxSession.Name))
 		}
+	}
+
+	// #1580: print the spawn-failure block so `session show` on an errored
+	// session explains why it died instead of leaving the user with a bare
+	// "error".
+	if spawnFailure != nil {
+		sb.WriteString("\n")
+		sb.WriteString(spawnFailure.FormatForDisplay())
 	}
 
 	out.Print(sb.String(), jsonData)

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3232,6 +3232,11 @@ func (i *Instance) Start() error {
 		return fmt.Errorf("tmux session not initialized")
 	}
 
+	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
+	// spawn_attempt trace so a spawn that dies before anything else runs still
+	// leaves a durable record.
+	i.recordSpawnAttempt()
+
 	// Prepare scratch CLAUDE_CONFIG_DIR for non-conductor claude workers
 	// (issue #59, v1.7.68). Runs before command-building so the
 	// CLAUDE_CONFIG_DIR= prefix picks up the scratch path. No-op for
@@ -3378,7 +3383,18 @@ func (i *Instance) Start() error {
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
+		// #1580: persist the tmux-level failure so the preview / session show /
+		// lifecycle log can surface it instead of a bare "error".
+		i.recordTmuxStartFailure(command, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
+	}
+
+	// #1580: watch for a fast death of the initial process (broken command,
+	// bad PATH, immediate non-zero exit). tmux tears the pane down on exit for
+	// non-remain-on-exit sessions, so this captures the dying output while the
+	// pane is still alive and records it if the session vanishes early.
+	if command != "" {
+		go i.watchForFastDeath(command)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -3492,6 +3508,10 @@ func (i *Instance) StartWithMessage(message string) error {
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
+
+	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
+	// spawn_attempt trace (same as Start()).
+	i.recordSpawnAttempt()
 
 	// Prepare scratch CLAUDE_CONFIG_DIR for non-conductor claude workers
 	// (issue #59, v1.7.68). Same call as in Start() — both spawn paths
@@ -3624,7 +3644,14 @@ func (i *Instance) StartWithMessage(message string) error {
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
+		// #1580: persist the tmux-level failure (sister path to Start()).
+		i.recordTmuxStartFailure(command, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
+	}
+
+	// #1580: fast-death watcher (sister path to Start()).
+	if command != "" {
+		go i.watchForFastDeath(command)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -5037,6 +5064,12 @@ func (i *Instance) Preview() (string, error) {
 
 	content, err := i.tmuxSession.CapturePane()
 	if err != nil {
+		// #1580: the pane is gone (fast spawn death). Surface the recorded
+		// spawn-failure diagnostic instead of a bare error so the preview pane
+		// explains what happened.
+		if fallback := i.spawnFailurePreview(); fallback != "" {
+			return fallback, nil
+		}
 		return "", err
 	}
 
@@ -5054,7 +5087,26 @@ func (i *Instance) PreviewFull() (string, error) {
 		return "", fmt.Errorf("tmux session not initialized")
 	}
 
-	return i.tmuxSession.CaptureFullHistory()
+	content, err := i.tmuxSession.CaptureFullHistory()
+	if err != nil {
+		// #1580: pane gone — fall back to the recorded spawn failure.
+		if fallback := i.spawnFailurePreview(); fallback != "" {
+			return fallback, nil
+		}
+		return "", err
+	}
+	return content, nil
+}
+
+// spawnFailurePreview returns the formatted spawn-failure record for this
+// instance, or "" when there is none. Used as a preview fallback when the tmux
+// pane no longer exists (#1580).
+func (i *Instance) spawnFailurePreview() string {
+	rec, err := readSpawnFailureRecord(i.ID)
+	if err != nil || rec == nil {
+		return ""
+	}
+	return rec.FormatForDisplay()
 }
 
 // PreviewWindowFull returns the full scrollback of a specific tmux window.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
@@ -404,6 +405,12 @@ type Instance struct {
 	// Use GetStatus()/SetStatus() and GetTool()/SetTool() for thread-safe access.
 	// UpdateStatus() acquires the write lock internally.
 	mu sync.RWMutex
+
+	// spawnGen is bumped on every Start/StartWithMessage/Stop so the fast-death
+	// watcher (#1580) can detect that a newer spawn or a deliberate stop has
+	// superseded it — race-free, without reading the mutex-guarded status fields
+	// from its own goroutine.
+	spawnGen atomic.Uint64
 
 	// lastErrorCheck tracks when we last confirmed the session doesn't exist
 	// Used to skip expensive Exists() checks for ghost sessions (sessions in JSON but not in tmux)
@@ -3392,9 +3399,12 @@ func (i *Instance) Start() error {
 	// #1580: watch for a fast death of the initial process (broken command,
 	// bad PATH, immediate non-zero exit). tmux tears the pane down on exit for
 	// non-remain-on-exit sessions, so this captures the dying output while the
-	// pane is still alive and records it if the session vanishes early.
+	// pane is still alive and records it if the session vanishes early. The
+	// watcher is handed value snapshots + a supersede generation so it never
+	// touches i's mutex-guarded fields from its own goroutine.
 	if command != "" {
-		go i.watchForFastDeath(command)
+		gen := i.spawnGen.Add(1)
+		go i.watchForFastDeath(command, gen, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -3651,7 +3661,8 @@ func (i *Instance) StartWithMessage(message string) error {
 
 	// #1580: fast-death watcher (sister path to Start()).
 	if command != "" {
-		go i.watchForFastDeath(command)
+		gen := i.spawnGen.Add(1)
+		go i.watchForFastDeath(command, gen, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -6156,6 +6167,9 @@ func (i *Instance) killInternal(sync bool) error {
 	}
 	i.Status = StatusStopped
 	i.mu.Unlock()
+	// #1580: supersede any in-flight fast-death watcher so a deliberate stop is
+	// never mistaken for a spawn failure.
+	i.spawnGen.Add(1)
 
 	// Clean up sandbox container (only if name matches our prefix convention).
 	// Runs regardless of tmux kill result to avoid orphaned containers.

--- a/internal/session/issue1580_spawn_failure_test.go
+++ b/internal/session/issue1580_spawn_failure_test.go
@@ -1,0 +1,160 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1580: a failing custom command (e.g. a broken `codex.command` npx
+// wrapper) whose initial process dies at/near spawn produced a bare "error"
+// with no preview and nothing in the logs, because tmux tears the pane down on
+// exit for non-remain-on-exit sessions and status detection only sees "tmux
+// session missing".
+//
+// These tests prove the new observability surfaces: a durable spawn-failure
+// sidecar, a preview fallback, and lifecycle-log traces.
+
+// TestIssue1580_SpawnFailureRecordRoundTrip verifies write → read → clear of
+// the durable sidecar (no tmux needed).
+func TestIssue1580_SpawnFailureRecordRoundTrip(t *testing.T) {
+	inst := NewInstance("test-1580-roundtrip", "/tmp")
+
+	// No record yet.
+	require.Nil(t, inst.SpawnFailure())
+
+	rec := SpawnFailureRecord{
+		InstanceID:  inst.ID,
+		Tool:        "codex",
+		Command:     "npx codex@0.144",
+		Reason:      "spawn_died_fast",
+		DyingOutput: "npm ERR! could not resolve codex@0.144",
+		ElapsedMs:   420,
+	}
+	require.NoError(t, writeSpawnFailureRecord(rec))
+
+	got := inst.SpawnFailure()
+	require.NotNil(t, got)
+	assert.Equal(t, "spawn_died_fast", got.Reason)
+	assert.Equal(t, "npx codex@0.144", got.Command)
+	assert.Equal(t, int64(420), got.ElapsedMs)
+	assert.NotZero(t, got.Timestamp, "timestamp must be stamped on write")
+
+	// FormatForDisplay must surface the dying output + command.
+	disp := got.FormatForDisplay()
+	assert.Contains(t, disp, "npm ERR! could not resolve codex@0.144")
+	assert.Contains(t, disp, "npx codex@0.144")
+	assert.Contains(t, disp, "420ms")
+
+	// Preview fallback returns the same block.
+	assert.Equal(t, disp, inst.spawnFailurePreview())
+
+	// Clear removes it.
+	clearSpawnFailureRecord(inst.ID)
+	assert.Nil(t, inst.SpawnFailure())
+	assert.Empty(t, inst.spawnFailurePreview())
+}
+
+// TestIssue1580_RecordSpawnAttemptClearsStale verifies that a new start attempt
+// clears a stale record so a now-healthy session is not masked by an old
+// failure, and emits a spawn_attempt lifecycle event.
+func TestIssue1580_RecordSpawnAttemptClearsStale(t *testing.T) {
+	inst := NewInstance("test-1580-clearstale", "/tmp")
+	inst.Tool = "codex"
+
+	require.NoError(t, writeSpawnFailureRecord(SpawnFailureRecord{
+		InstanceID: inst.ID, Reason: "spawn_died_fast", DyingOutput: "old",
+	}))
+	require.NotNil(t, inst.SpawnFailure())
+
+	inst.recordSpawnAttempt()
+	assert.Nil(t, inst.SpawnFailure(), "recordSpawnAttempt must clear the stale sidecar")
+
+	// The spawn_attempt event should be in the lifecycle log.
+	assert.Contains(t, readLifecycleLog(t), "spawn_attempt")
+}
+
+// TestIssue1580_TmuxStartFailureRecorded verifies the tmux-level start failure
+// path writes a record and a spawn_failed lifecycle event (no tmux needed).
+func TestIssue1580_TmuxStartFailureRecorded(t *testing.T) {
+	inst := NewInstance("test-1580-tmuxfail", "/tmp")
+	inst.Tool = "codex"
+
+	inst.recordTmuxStartFailure("npx codex@0.144", os.ErrPermission)
+
+	rec := inst.SpawnFailure()
+	require.NotNil(t, rec)
+	assert.Equal(t, "tmux_start_failed", rec.Reason)
+	assert.Contains(t, rec.DyingOutput, os.ErrPermission.Error())
+
+	disp := rec.FormatForDisplay()
+	assert.Contains(t, disp, "could not be created")
+	assert.Contains(t, readLifecycleLog(t), "spawn_failed")
+}
+
+// TestIssue1580_FastDeathWatcherCapturesDyingOutput is the behavioral repro. A
+// real tmux session runs a custom command whose initial process prints a marker
+// then exits non-zero. The watcher must capture the dying output and persist a
+// spawn_died_fast record; PreviewFull must surface it once the pane is gone.
+//
+// Pre-fix, this scenario produced no record, an erroring preview, and no
+// lifecycle event — the surfaces did not exist.
+func TestIssue1580_FastDeathWatcherCapturesDyingOutput(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstance("test-1580-fastdeath", "/tmp")
+	// A non-built-in tool with no ToolDef runs Command verbatim as the pane's
+	// initial process (RunCommandAsInitialProcess is true for tool != "shell").
+	inst.Tool = "customfail1580"
+	// Print a marker, stay alive briefly so the watcher captures the pane, then
+	// exit non-zero so tmux tears the session down.
+	inst.Command = "sh -c 'echo boom-1580-dying-output; sleep 1; exit 7'"
+
+	require.NoError(t, inst.Start())
+	defer func() { _ = inst.Kill() }()
+
+	// Wait for the watcher (250ms tick, 15s window) to observe the death and
+	// persist the record.
+	var rec *SpawnFailureRecord
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if rec = inst.SpawnFailure(); rec != nil && rec.Reason == "spawn_died_fast" {
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	require.NotNil(t, rec, "spawn-failure record must be written when the process dies fast")
+	assert.Equal(t, "spawn_died_fast", rec.Reason)
+	assert.Contains(t, rec.DyingOutput, "boom-1580-dying-output",
+		"the dying pane output must be captured before tmux discards it")
+	assert.Greater(t, rec.ElapsedMs, int64(0), "elapsed time must be positive")
+
+	// The lifecycle log must carry the spawn_died_fast trace.
+	assert.Contains(t, readLifecycleLog(t), "spawn_died_fast")
+
+	// PreviewFull falls back to the record now that the pane is gone.
+	preview, err := inst.PreviewFull()
+	require.NoError(t, err, "PreviewFull must not error once the record exists")
+	assert.Contains(t, preview, "boom-1580-dying-output")
+	assert.Contains(t, preview, "failed to start")
+}
+
+func readLifecycleLog(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(GetSessionIDLifecycleLogPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		require.NoError(t, err)
+	}
+	return string(data)
+}
+
+// guard against an accidental empty-string tool matching a real one.
+var _ = strings.TrimSpace

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -1,0 +1,277 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/safeio"
+)
+
+// SpawnFailureRecord captures why a session's initial process died at or shortly
+// after spawn. Issue #1580: when a custom command (e.g. a broken
+// `codex.command` npx wrapper) exits immediately, tmux tears the whole session
+// down and takes the pane output with it. Status detection later only sees
+// "tmux session missing" → StatusError, so the TUI shows a bare "error" with no
+// preview and nothing in the logs. This record is written to disk as a durable
+// sidecar the moment the death is observed, so the failure survives the process
+// boundary and can be surfaced in the preview pane, `session show`, and the
+// lifecycle log.
+type SpawnFailureRecord struct {
+	InstanceID  string `json:"instance_id"`
+	Tool        string `json:"tool"`
+	Command     string `json:"command,omitempty"`
+	Reason      string `json:"reason"`             // tmux_start_failed | spawn_died_fast
+	DyingOutput string `json:"dying_output,omitempty"` // last pane snapshot captured while alive
+	ElapsedMs   int64  `json:"elapsed_ms"`         // ms from spawn to observed death (0 for tmux_start_failed)
+	Timestamp   int64  `json:"ts"`
+}
+
+// spawnFailureDir returns <data>/runtime/spawn-failure, falling back to a temp
+// path when the data dir cannot be resolved (mirrors GetSessionIDLifecycleLogPath).
+func spawnFailureDir() string {
+	path, err := runtimeDataPath("spawn-failure")
+	if err != nil {
+		return tempAgentDeckPath("runtime", "spawn-failure")
+	}
+	return path
+}
+
+// spawnFailureRecordPath returns the sidecar path for one instance.
+func spawnFailureRecordPath(instanceID string) string {
+	return filepath.Join(spawnFailureDir(), instanceID+".json")
+}
+
+// writeSpawnFailureRecord persists a record atomically. Best-effort: a failure
+// to write must never block or crash the caller.
+func writeSpawnFailureRecord(rec SpawnFailureRecord) error {
+	if rec.Timestamp == 0 {
+		rec.Timestamp = time.Now().Unix()
+	}
+	path := spawnFailureRecordPath(rec.InstanceID)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create spawn-failure dir: %w", err)
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal spawn-failure record: %w", err)
+	}
+	// SkipBackup: these sidecars are transient and self-clearing; a .bak would
+	// just be noise. RefuseEmpty is irrelevant (data is never empty).
+	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o644, SkipBackup: true})
+}
+
+// readSpawnFailureRecord loads the sidecar for an instance, or (nil, nil) when
+// none exists.
+func readSpawnFailureRecord(instanceID string) (*SpawnFailureRecord, error) {
+	path := spawnFailureRecordPath(instanceID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var rec SpawnFailureRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, err
+	}
+	return &rec, nil
+}
+
+// clearSpawnFailureRecord removes any stale sidecar for an instance. Called at
+// the top of every start attempt so a stale record from a prior failure never
+// masks a now-healthy session.
+func clearSpawnFailureRecord(instanceID string) {
+	_ = safeio.SafeRemove(spawnFailureRecordPath(instanceID), safeio.RemoveOptions{})
+}
+
+// SpawnFailure returns the recorded spawn-failure diagnostic for this instance,
+// or nil when there is none. Exported for CLI surfaces (`session show`) that
+// want to explain a bare "error" status (#1580).
+func (i *Instance) SpawnFailure() *SpawnFailureRecord {
+	rec, err := readSpawnFailureRecord(i.ID)
+	if err != nil {
+		return nil
+	}
+	return rec
+}
+
+// FormatForDisplay renders the record as a human-readable block for the preview
+// pane and `session show`.
+func (r *SpawnFailureRecord) FormatForDisplay() string {
+	if r == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("⚠  session failed to start\n")
+	switch r.Reason {
+	case "tmux_start_failed":
+		b.WriteString("The terminal session could not be created.\n")
+	case "spawn_died_fast":
+		fmt.Fprintf(&b, "The command exited almost immediately (after %dms).\n", r.ElapsedMs)
+	default:
+		b.WriteString("The session ended unexpectedly during startup.\n")
+	}
+	if r.Command != "" {
+		fmt.Fprintf(&b, "\ncommand: %s\n", r.Command)
+	}
+	if strings.TrimSpace(r.DyingOutput) != "" {
+		b.WriteString("\nlast output before exit:\n")
+		b.WriteString(strings.TrimRight(r.DyingOutput, "\n"))
+		b.WriteString("\n")
+	} else {
+		b.WriteString("\n(no output was captured before the process exited)\n")
+	}
+	b.WriteString("\nTip: run the command manually in this directory to see the full error,\n")
+	b.WriteString("or check logs/session-id-lifecycle.jsonl for the spawn trace.\n")
+	return b.String()
+}
+
+// spawnFastDeathWindow / spawnFastDeathTick bound the fast-death watcher: a
+// session that outlives the window is assumed to have started successfully. The
+// tick period trades detection latency against subprocess overhead.
+const (
+	spawnFastDeathWindow = 15 * time.Second
+	spawnFastDeathTick   = 250 * time.Millisecond
+)
+
+// watchForFastDeath runs after a successful tmux Start() and captures the pane
+// output while the initial process is alive. If the tmux session vanishes
+// within spawnFastDeathWindow and the disappearance was not a deliberate stop
+// (Status == StatusStopped) or a session-swap (a fresh session took over the
+// same name), it persists a SpawnFailureRecord with the last captured output +
+// elapsed time and emits a spawn_died_fast lifecycle event. A survivor emits a
+// spawn_survived event and writes nothing.
+//
+// Best-effort and self-contained: all errors are swallowed so the watcher can
+// never affect the spawn path. Runs in its own goroutine.
+func (i *Instance) watchForFastDeath(command string) {
+	if i.tmuxSession == nil {
+		return
+	}
+	sessionName := i.tmuxSession.Name
+	start := time.Now()
+	deadline := start.Add(spawnFastDeathWindow)
+	var lastSnapshot string
+
+	ticker := time.NewTicker(spawnFastDeathTick)
+	defer ticker.Stop()
+
+	for {
+		<-ticker.C
+
+		// Deliberate stop/kill flips Status to StatusStopped under i.mu — never
+		// treat that as a spawn failure.
+		i.mu.Lock()
+		status := i.Status
+		curName := ""
+		if i.tmuxSession != nil {
+			curName = i.tmuxSession.Name
+		}
+		i.mu.Unlock()
+		if status == StatusStopped {
+			return
+		}
+		// A restart/respawn replaced the tmux session under us — this watcher is
+		// bound to the old name, so stop quietly.
+		if curName != sessionName {
+			return
+		}
+
+		if i.tmuxSession.Exists() {
+			// Alive: snapshot the current pane so we hold the dying output the
+			// instant it disappears (tmux discards the pane on process exit for
+			// non-remain-on-exit sessions).
+			if content, err := i.tmuxSession.CapturePane(); err == nil {
+				if trimmed := strings.TrimSpace(content); trimmed != "" {
+					lastSnapshot = trimmed
+				}
+			}
+			if time.Now().After(deadline) {
+				// Survived the window: healthy start.
+				_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+					InstanceID: i.ID,
+					Tool:       i.Tool,
+					Action:     "spawn_survived",
+					Source:     "spawn_watcher",
+				})
+				return
+			}
+			continue
+		}
+
+		// Session is gone and it was not a deliberate stop → fast death.
+		elapsed := time.Since(start).Milliseconds()
+		rec := SpawnFailureRecord{
+			InstanceID:  i.ID,
+			Tool:        i.Tool,
+			Command:     command,
+			Reason:      "spawn_died_fast",
+			DyingOutput: lastSnapshot,
+			ElapsedMs:   elapsed,
+		}
+		if err := writeSpawnFailureRecord(rec); err != nil {
+			sessionLog.Warn("spawn_failure_record_write_failed",
+				slog.String("instance_id", i.ID),
+				slog.String("error", err.Error()))
+		}
+		sessionLog.Error("spawn_died_fast",
+			slog.String("instance_id", i.ID),
+			slog.String("tool", i.Tool),
+			slog.String("command", command),
+			slog.Int64("elapsed_ms", elapsed),
+			slog.String("dying_output", lastSnapshot))
+		_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+			InstanceID: i.ID,
+			Tool:       i.Tool,
+			Action:     "spawn_died_fast",
+			Source:     "spawn_watcher",
+			Reason:     fmt.Sprintf("exited after %dms", elapsed),
+		})
+		return
+	}
+}
+
+// recordTmuxStartFailure persists a record for the case where tmux itself
+// failed to create the session (i.tmuxSession.Start returned an error). Unlike
+// the fast-death path this has no pane to snapshot — the error string is the
+// diagnostic.
+func (i *Instance) recordTmuxStartFailure(command string, startErr error) {
+	rec := SpawnFailureRecord{
+		InstanceID:  i.ID,
+		Tool:        i.Tool,
+		Command:     command,
+		Reason:      "tmux_start_failed",
+		DyingOutput: startErr.Error(),
+	}
+	if err := writeSpawnFailureRecord(rec); err != nil {
+		sessionLog.Warn("spawn_failure_record_write_failed",
+			slog.String("instance_id", i.ID),
+			slog.String("error", err.Error()))
+	}
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "spawn_failed",
+		Source:     "spawn_watcher",
+		Reason:     startErr.Error(),
+	})
+}
+
+// recordSpawnAttempt clears any stale record and logs a spawn_attempt lifecycle
+// event so every start leaves a durable trace even when the process dies before
+// any other code runs.
+func (i *Instance) recordSpawnAttempt() {
+	clearSpawnFailureRecord(i.ID)
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "spawn_attempt",
+		Source:     "spawn_watcher",
+	})
+}

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/safeio"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // SpawnFailureRecord captures why a session's initial process died at or shortly
@@ -25,9 +26,9 @@ type SpawnFailureRecord struct {
 	InstanceID  string `json:"instance_id"`
 	Tool        string `json:"tool"`
 	Command     string `json:"command,omitempty"`
-	Reason      string `json:"reason"`             // tmux_start_failed | spawn_died_fast
+	Reason      string `json:"reason"`                 // tmux_start_failed | spawn_died_fast
 	DyingOutput string `json:"dying_output,omitempty"` // last pane snapshot captured while alive
-	ElapsedMs   int64  `json:"elapsed_ms"`         // ms from spawn to observed death (0 for tmux_start_failed)
+	ElapsedMs   int64  `json:"elapsed_ms"`             // ms from spawn to observed death (0 for tmux_start_failed)
 	Timestamp   int64  `json:"ts"`
 }
 
@@ -150,11 +151,16 @@ const (
 //
 // Best-effort and self-contained: all errors are swallowed so the watcher can
 // never affect the spawn path. Runs in its own goroutine.
-func (i *Instance) watchForFastDeath(command string) {
-	if i.tmuxSession == nil {
+// The watcher runs in its own goroutine, so it must never read i's
+// mutex-guarded mutable fields directly. Everything it needs is passed by
+// value: the pane session pointer captured at launch (sess), the instance id
+// and tool, and gen — a snapshot of i.spawnGen taken at launch. A deliberate
+// stop or a restart/respawn bumps i.spawnGen, so a mismatch means this watcher
+// has been superseded and must exit quietly (#1580 data-race fix).
+func (i *Instance) watchForFastDeath(command string, gen uint64, sess *tmux.Session, id, tool string, logger *slog.Logger) {
+	if sess == nil {
 		return
 	}
-	sessionName := i.tmuxSession.Name
 	start := time.Now()
 	deadline := start.Add(spawnFastDeathWindow)
 	var lastSnapshot string
@@ -165,29 +171,17 @@ func (i *Instance) watchForFastDeath(command string) {
 	for {
 		<-ticker.C
 
-		// Deliberate stop/kill flips Status to StatusStopped under i.mu — never
-		// treat that as a spawn failure.
-		i.mu.Lock()
-		status := i.Status
-		curName := ""
-		if i.tmuxSession != nil {
-			curName = i.tmuxSession.Name
-		}
-		i.mu.Unlock()
-		if status == StatusStopped {
-			return
-		}
-		// A restart/respawn replaced the tmux session under us — this watcher is
-		// bound to the old name, so stop quietly.
-		if curName != sessionName {
+		// A newer spawn or a deliberate stop bumped the generation — this
+		// watcher is stale, so stop quietly and never record a failure.
+		if i.spawnGen.Load() != gen {
 			return
 		}
 
-		if i.tmuxSession.Exists() {
+		if sess.Exists() {
 			// Alive: snapshot the current pane so we hold the dying output the
 			// instant it disappears (tmux discards the pane on process exit for
 			// non-remain-on-exit sessions).
-			if content, err := i.tmuxSession.CapturePane(); err == nil {
+			if content, err := sess.CapturePane(); err == nil {
 				if trimmed := strings.TrimSpace(content); trimmed != "" {
 					lastSnapshot = trimmed
 				}
@@ -195,8 +189,8 @@ func (i *Instance) watchForFastDeath(command string) {
 			if time.Now().After(deadline) {
 				// Survived the window: healthy start.
 				_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
-					InstanceID: i.ID,
-					Tool:       i.Tool,
+					InstanceID: id,
+					Tool:       tool,
 					Action:     "spawn_survived",
 					Source:     "spawn_watcher",
 				})
@@ -208,27 +202,27 @@ func (i *Instance) watchForFastDeath(command string) {
 		// Session is gone and it was not a deliberate stop → fast death.
 		elapsed := time.Since(start).Milliseconds()
 		rec := SpawnFailureRecord{
-			InstanceID:  i.ID,
-			Tool:        i.Tool,
+			InstanceID:  id,
+			Tool:        tool,
 			Command:     command,
 			Reason:      "spawn_died_fast",
 			DyingOutput: lastSnapshot,
 			ElapsedMs:   elapsed,
 		}
 		if err := writeSpawnFailureRecord(rec); err != nil {
-			sessionLog.Warn("spawn_failure_record_write_failed",
-				slog.String("instance_id", i.ID),
+			logger.Warn("spawn_failure_record_write_failed",
+				slog.String("instance_id", id),
 				slog.String("error", err.Error()))
 		}
-		sessionLog.Error("spawn_died_fast",
-			slog.String("instance_id", i.ID),
-			slog.String("tool", i.Tool),
+		logger.Error("spawn_died_fast",
+			slog.String("instance_id", id),
+			slog.String("tool", tool),
 			slog.String("command", command),
 			slog.Int64("elapsed_ms", elapsed),
 			slog.String("dying_output", lastSnapshot))
 		_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
-			InstanceID: i.ID,
-			Tool:       i.Tool,
+			InstanceID: id,
+			Tool:       tool,
 			Action:     "spawn_died_fast",
 			Source:     "spawn_watcher",
 			Reason:     fmt.Sprintf("exited after %dms", elapsed),


### PR DESCRIPTION
Closes #1580. A failed spawn/exec collapsed to a bare "error" status with nothing logged. Adds a durable spawn-failure sidecar, a preview fallback, a session show block, and lifecycle traces so the failure reason is captured and surfaced. New behavioral repro proves before/after. Complements #1567 (argv spawn fix) in the same area. Build + targeted sandboxed tests green (the only local failure, TestForbidigo_BansRawOSEnvironInSpawnPath, fails identically on clean main due to a local golangci-lint version mismatch and passes on CI).