### PR TITLE
fix(codewhale): add deepseek TUI readiness preset (#1577)

### DIFF
--- a/internal/session/mergetoolpatterns_compatiblewith_test.go
+++ b/internal/session/mergetoolpatterns_compatiblewith_test.go
@@ -1,0 +1,82 @@
+package session
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #1577: a custom tool that declares `compatible_with` but has no
+// built-in patterns of its own should inherit the compatible preset's
+// busy/prompt patterns. Explicit replace fields still override; built-in
+// tools are never affected because the fallback only fires when the tool name
+// has no defaults of its own.
+
+func busyStrings(t *testing.T, name string) []string {
+	t.Helper()
+	raw := MergeToolPatterns(name)
+	if raw == nil {
+		t.Fatalf("MergeToolPatterns(%q) = nil", name)
+	}
+	return raw.BusyPatterns
+}
+
+func TestMergeToolPatterns_CompatibleWithFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	cfg := &UserConfig{
+		Tools: map[string]ToolDef{
+			// inherits the codewhale preset purely by compatible_with
+			"whale": {
+				Command:        "codewhale",
+				CompatibleWith: "codewhale",
+			},
+			// explicit busy patterns must win over the inherited preset
+			"whale-override": {
+				Command:        "codewhale",
+				CompatibleWith: "codewhale",
+				BusyPatterns:   []string{"CUSTOM-BUSY"},
+			},
+		},
+	}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	// by compatible_with: inherits "waiting for deepseek"
+	got := strings.Join(busyStrings(t, "whale"), "|")
+	if !strings.Contains(got, "waiting for deepseek") {
+		t.Errorf("whale should inherit codewhale busy patterns via compatible_with, got %q", got)
+	}
+
+	// explicit override wins
+	gotOverride := busyStrings(t, "whale-override")
+	if len(gotOverride) != 1 || gotOverride[0] != "CUSTOM-BUSY" {
+		t.Errorf("explicit busy_patterns must override the inherited preset, got %v", gotOverride)
+	}
+}
+
+// TestMergeToolPatterns_BuiltinUnaffectedByFallback proves the fallback cannot
+// change any built-in tool's behavior: a name with its own defaults never
+// consults compatible_with.
+func TestMergeToolPatterns_BuiltinUnaffectedByFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	codex := MergeToolPatterns("codex")
+	if codex == nil {
+		t.Fatal("codex patterns unexpectedly nil")
+	}
+	joined := strings.Join(codex.BusyPatterns, "|")
+	if strings.Contains(joined, "waiting for deepseek") {
+		t.Errorf("built-in codex must not inherit codewhale patterns, got %q", joined)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -3382,6 +3382,15 @@ func MergeToolPatterns(toolName string) *tmux.RawPatterns {
 		return nil
 	}
 
+	// #1577: a custom tool with no built-in defaults of its own inherits the
+	// preset it declares via `compatible_with`. This only fires when the tool
+	// name has no built-in patterns (defaults == nil), so every built-in tool
+	// is byte-identical in behavior. Explicit replace/extra fields on the
+	// ToolDef still override below.
+	if defaults == nil && toolDef != nil && strings.TrimSpace(toolDef.CompatibleWith) != "" {
+		defaults = tmux.DefaultRawPatterns(toolDef.CompatibleWith)
+	}
+
 	// Build overrides from ToolDef's replace fields (BusyPatterns, PromptPatterns, SpinnerChars)
 	var overrides *tmux.RawPatterns
 	if toolDef != nil && (toolDef.BusyPatterns != nil || toolDef.PromptPatterns != nil || toolDef.SpinnerChars != nil) {

--- a/internal/tmux/codewhale_preset_test.go
+++ b/internal/tmux/codewhale_preset_test.go
@@ -1,0 +1,85 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #1577: the `codex` preset's busy/prompt patterns never matched the
+// codewhale (deepseek-v4-pro) TUI, so a conductor-driven codewhale worker was
+// always misread as idle and `session send --wait` timed out. These tests lock
+// the reporter-captured footers to the new `codewhale` preset.
+
+// Live-captured pane footers from the issue.
+const (
+	codewhaleBusyWaiting = "yolo · deepseek-v4-pro · tool checklist_write · 0 active · 1 done · 106s · Alt+V  (waiting for deepseek deepseek-v4-pro, 2s/300s idle timeout)"
+	codewhaleBusyWorking = "yolo · deepseek-v4-pro · ... · working (2s)"
+	codewhaleIdleFooter  = "yolo · deepseek-v4-pro · 1 done · Alt+V"
+	codewhalePlaceholder = "Write a task or use /."
+)
+
+func anyBusyStringMatches(raw *RawPatterns, text string) bool {
+	res, err := CompilePatterns(raw)
+	if err != nil {
+		return false
+	}
+	for _, s := range res.BusyStrings {
+		if strings.Contains(text, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyPromptStringMatches(raw *RawPatterns, text string) bool {
+	res, err := CompilePatterns(raw)
+	if err != nil {
+		return false
+	}
+	for _, s := range res.PromptStrings {
+		if strings.Contains(text, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCodewhalePresetExists(t *testing.T) {
+	raw := DefaultRawPatterns("codewhale")
+	if raw == nil {
+		t.Fatal("expected a non-nil codewhale preset")
+	}
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("codewhale preset should define busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("codewhale preset should define prompt patterns")
+	}
+}
+
+func TestCodewhalePresetMatchesCapturedFooters(t *testing.T) {
+	raw := DefaultRawPatterns("codewhale")
+
+	if !anyBusyStringMatches(raw, codewhaleBusyWaiting) {
+		t.Errorf("codewhale busy patterns must match the 'waiting for deepseek' footer:\n%s", codewhaleBusyWaiting)
+	}
+	if !anyBusyStringMatches(raw, codewhaleBusyWorking) {
+		t.Errorf("codewhale busy patterns must match the 'working (' footer:\n%s", codewhaleBusyWorking)
+	}
+	if anyBusyStringMatches(raw, codewhaleIdleFooter) {
+		t.Errorf("codewhale busy patterns must NOT match the idle footer:\n%s", codewhaleIdleFooter)
+	}
+	if !anyPromptStringMatches(raw, codewhalePlaceholder) {
+		t.Errorf("codewhale prompt patterns must match the composer placeholder:\n%s", codewhalePlaceholder)
+	}
+}
+
+// TestCodexPresetDoesNotMatchCodewhaleFooters reproduces the pre-fix broken
+// state: the codex preset a codewhale tool inherited by default never matched
+// the real deepseek footers, so readiness was never detected.
+func TestCodexPresetDoesNotMatchCodewhaleFooters(t *testing.T) {
+	codex := DefaultRawPatterns("codex")
+	if anyBusyStringMatches(codex, codewhaleBusyWaiting) || anyBusyStringMatches(codex, codewhaleBusyWorking) {
+		t.Error("codex preset unexpectedly matched a codewhale busy footer — the #1577 repro no longer holds")
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -80,6 +80,22 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			},
 			PromptPatterns: []string{"How can I help", "codex>", "Continue?", `re:(?m)^\s*›\s`},
 		}
+	case "codewhale":
+		// codewhale CLI (deepseek-v4-pro TUI, #1577). The codex preset's
+		// patterns never match the deepseek TUI, so a codewhale worker driven
+		// by a conductor was always misread as idle and `session send --wait`
+		// timed out. Busy is authoritative in the detector (checked before
+		// prompt), so the always-visible composer placeholder "Write a task
+		// or use /." cannot mask a working session.
+		//
+		// Captured live:
+		//   busy footer:  "... (waiting for deepseek deepseek-v4-pro, 2s/300s idle timeout)"
+		//                 "... · working (2s)"
+		//   idle footer:  no busy marker; composer placeholder visible
+		return &RawPatterns{
+			BusyPatterns:   []string{"waiting for deepseek", "working (", "idle timeout"},
+			PromptPatterns: []string{"Write a task or use"},
+		}
 	case "pi":
 		return &RawPatterns{
 			BusyPatterns: []string{


### PR DESCRIPTION
Closes #1577.

## Problem
The `codex` preset's busy/prompt patterns never matched codewhale's deepseek-v4-pro TUI. A conductor-driven codewhale worker was therefore always misread as idle, and `session send --wait` timed out. (Part 2 of the issue — char-drop on `--no-wait` — is already blunted by the installed send-verify fix; this covers the preset half.)

## Change (schema-neutral, no shared status-path changes)
- `internal/tmux/patterns.go`: new `codewhale` case in `DefaultRawPatterns` with the reporter-captured footers — busy `["waiting for deepseek", "working (", "idle timeout"]`, prompt `["Write a task or use"]`. Busy is authoritative in the detector (checked before prompt), so the always-visible composer placeholder cannot mask a working session.
- `internal/session/userconfig.go` `MergeToolPatterns`: a custom tool with no built-in patterns of its own now inherits the preset it declares via `compatible_with`. Guarded by `defaults == nil`, so every built-in tool is byte-identical in behavior; explicit `busy_patterns`/`prompt_patterns` still override.

## Verification (sandboxed HOME + XDG cleared)
- `go build ./...` green; `go vet ./internal/tmux ./internal/session` clean.
- New tests pass: `TestCodewhalePresetExists`, `TestCodewhalePresetMatchesCapturedFooters` (busy matches both captured footers, does NOT match idle, prompt matches placeholder), `TestCodexPresetDoesNotMatchCodewhaleFooters` (pre-fix repro), `TestMergeToolPatterns_CompatibleWithFallback`, `TestMergeToolPatterns_BuiltinUnaffectedByFallback`.

Reporter can either name the tool `[tools.codewhale]` (patterns apply by name) or keep any name with `compatible_with = "codewhale"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added built-in detection support for the CodeWhale tool, including busy-state and prompt indicators.
  - Custom tools can inherit detection patterns from a compatible built-in tool when no specific patterns are configured.
  - Explicit custom patterns continue to take precedence over inherited defaults.

- **Bug Fixes**
  - Prevented built-in tool detection patterns from being incorrectly affected by compatibility fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->