### PR TITLE
fix: restart archived sessions from TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ branch_prefix       = "fork/" # auto branch name = <branch_prefix><sanitized-tit
 Done with a session but not ready to delete it? Archive it. Archiving stops the tmux process and hides the session from the default list — the conversation, metadata, worktree, and parent linkage are all preserved.
 
 - `A` archives the selected session; `Shift+U` restores it to the active list **without** auto-starting the process
+- `R` on an archived session restores it to the active list and restarts its process
 - `^` filters the TUI to archived sessions; the web UI has a dedicated **Archived** tab
 - Search and filters work across archived sessions
 - Deleting (`d`) is the destructive cousin — it removes the session from the registry (with a 30-second `Ctrl+Z` undo window)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5665,10 +5665,18 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			session.UpdateClaudeSessionsWithDedup(h.instances)
 			h.instancesMu.Unlock()
 			h.invalidatePreviewCache(msg.sessionID)
+			if msg.unarchived {
+				h.cachedStatusCounts.valid.Store(false)
+				h.rebuildFlatItems()
+			}
 			// Save the updated session state (new tmux session name)
 			h.saveInstances()
 			if msg.warning != "" {
 				h.setError(fmt.Errorf("%s", msg.warning))
+			} else if msg.unarchived {
+				if inst := h.getInstanceByID(msg.sessionID); inst != nil {
+					h.setError(fmt.Errorf("unarchived and restarted '%s'", inst.Title))
+				}
 			}
 		}
 		// Clear animation so ENTER can attach immediately.
@@ -12407,10 +12415,11 @@ func (h *Home) bulkRemoveErrored() tea.Cmd {
 
 // sessionRestartedMsg signals that a session was restarted.
 type sessionRestartedMsg struct {
-	sessionID string
-	err       error
-	warning   string
-	fresh     bool
+	sessionID  string
+	err        error
+	warning    string
+	fresh      bool
+	unarchived bool
 }
 
 // mcpRestartedMsg signals that an MCP-triggered restart completed and should auto-attach
@@ -12419,7 +12428,37 @@ type mcpRestartedMsg struct {
 	err     error
 }
 
-// restartSession restarts a dead/errored session by creating a new tmux session.
+// restartWithArchiveTransition makes restart from the archived view a durable
+// unarchive + restart operation. If restart fails, it restores the exact archive
+// timestamp so the session does not move lists without a running process.
+func restartWithArchiveTransition(
+	inst *session.Instance,
+	persist func(*session.Instance) error,
+	restart func() error,
+) (bool, error) {
+	if !inst.IsArchived() {
+		return false, restart()
+	}
+
+	archivedAt := inst.ArchivedAt
+	inst.ArchivedAt = time.Time{}
+	if err := persist(inst); err != nil {
+		inst.ArchivedAt = archivedAt
+		return false, fmt.Errorf("failed to unarchive session before restart: %w", err)
+	}
+
+	if err := restart(); err != nil {
+		inst.ArchivedAt = archivedAt
+		if rollbackErr := persist(inst); rollbackErr != nil {
+			return false, fmt.Errorf("restart failed: %w; restoring archive state failed: %v", err, rollbackErr)
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// restartSession restarts a session, unarchiving it first when invoked from
+// the archived view.
 func (h *Home) restartSession(inst *session.Instance) tea.Cmd {
 	id := inst.ID
 	mcpUILog.Debug(
@@ -12442,12 +12481,13 @@ func (h *Home) restartSession(inst *session.Instance) tea.Cmd {
 			return sessionRestartedMsg{sessionID: id, err: err}
 		}
 
-		err := current.Restart()
+		unarchived, err := restartWithArchiveTransition(current, h.persistArchived, current.Restart)
 		mcpUILog.Debug("restart_session_result", slog.String("id", id), slog.Any("error", err))
 		return sessionRestartedMsg{
-			sessionID: id,
-			err:       err,
-			warning:   current.ConsumeCodexRestartWarning(),
+			sessionID:  id,
+			err:        err,
+			warning:    current.ConsumeCodexRestartWarning(),
+			unarchived: unarchived,
 		}
 	}
 }

--- a/internal/ui/restart_archived_test.go
+++ b/internal/ui/restart_archived_test.go
@@ -1,0 +1,133 @@
+package ui
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestRestartWithArchiveTransitionActiveSession(t *testing.T) {
+	inst := &session.Instance{ID: "active"}
+	persisted := false
+	restarted := false
+
+	unarchived, err := restartWithArchiveTransition(inst, func(*session.Instance) error {
+		persisted = true
+		return nil
+	}, func() error {
+		restarted = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("restartWithArchiveTransition: %v", err)
+	}
+	if unarchived || persisted || !restarted {
+		t.Fatalf("active restart: unarchived=%v persisted=%v restarted=%v", unarchived, persisted, restarted)
+	}
+}
+
+func TestRestartWithArchiveTransitionUnarchivesBeforeRestart(t *testing.T) {
+	archivedAt := time.Date(2026, time.July, 17, 8, 0, 0, 0, time.UTC)
+	inst := &session.Instance{ID: "archived", ArchivedAt: archivedAt}
+	var events []string
+
+	unarchived, err := restartWithArchiveTransition(inst, func(current *session.Instance) error {
+		if current.IsArchived() {
+			events = append(events, "persist-archived")
+		} else {
+			events = append(events, "persist-unarchived")
+		}
+		return nil
+	}, func() error {
+		events = append(events, "restart")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("restartWithArchiveTransition: %v", err)
+	}
+	if !unarchived || inst.IsArchived() {
+		t.Fatalf("successful restart should leave session unarchived: unarchived=%v archivedAt=%v", unarchived, inst.ArchivedAt)
+	}
+	want := []string{"persist-unarchived", "restart"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestRestartWithArchiveTransitionRestoresArchiveOnFailure(t *testing.T) {
+	archivedAt := time.Date(2026, time.July, 17, 8, 0, 0, 0, time.UTC)
+	inst := &session.Instance{ID: "archived", ArchivedAt: archivedAt}
+	var persisted []time.Time
+	restartErr := errors.New("spawn failed")
+
+	unarchived, err := restartWithArchiveTransition(inst, func(current *session.Instance) error {
+		persisted = append(persisted, current.ArchivedAt)
+		return nil
+	}, func() error {
+		return restartErr
+	})
+	if !errors.Is(err, restartErr) {
+		t.Fatalf("error = %v, want %v", err, restartErr)
+	}
+	if unarchived || !inst.ArchivedAt.Equal(archivedAt) {
+		t.Fatalf("failed restart should restore archive: unarchived=%v archivedAt=%v", unarchived, inst.ArchivedAt)
+	}
+	if len(persisted) != 2 || !persisted[0].IsZero() || !persisted[1].Equal(archivedAt) {
+		t.Fatalf("persisted timestamps = %v, want [zero, %v]", persisted, archivedAt)
+	}
+}
+
+func TestRestartWithArchiveTransitionDoesNotRestartWhenUnarchivePersistenceFails(t *testing.T) {
+	archivedAt := time.Date(2026, time.July, 17, 8, 0, 0, 0, time.UTC)
+	inst := &session.Instance{ID: "archived", ArchivedAt: archivedAt}
+	restarted := false
+
+	unarchived, err := restartWithArchiveTransition(inst, func(*session.Instance) error {
+		return errors.New("database unavailable")
+	}, func() error {
+		restarted = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to unarchive session before restart") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if unarchived || restarted || !inst.ArchivedAt.Equal(archivedAt) {
+		t.Fatalf("persistence failure: unarchived=%v restarted=%v archivedAt=%v", unarchived, restarted, inst.ArchivedAt)
+	}
+}
+
+func TestSessionRestartedMsgMovesUnarchivedSessionOutOfArchivedView(t *testing.T) {
+	home := NewHome()
+	home.storage = nil
+	home.statusFilter = FilterModeArchived
+	inst := &session.Instance{
+		ID:         "archived",
+		Title:      "agent deck dev",
+		Tool:       "shell",
+		Status:     session.StatusStopped,
+		GroupPath:  session.DefaultGroupPath,
+		CreatedAt:  time.Now(),
+		ArchivedAt: time.Date(2026, time.July, 17, 8, 0, 0, 0, time.UTC),
+	}
+	home.instances = []*session.Instance{inst}
+	home.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+	if got := visibleSessionIDsFromFlat(home); !sliceContainsString(got, inst.ID) {
+		t.Fatalf("setup: archived session not visible: %v", got)
+	}
+
+	inst.ArchivedAt = time.Time{}
+	model, _ := home.Update(sessionRestartedMsg{sessionID: inst.ID, unarchived: true})
+	h := model.(*Home)
+	if got := visibleSessionIDsFromFlat(h); sliceContainsString(got, inst.ID) {
+		t.Fatalf("restarted session remained in archived view: %v", got)
+	}
+	if h.err == nil || !strings.Contains(h.err.Error(), "unarchived and restarted 'agent deck dev'") {
+		t.Fatalf("missing restart confirmation: %v", h.err)
+	}
+}


### PR DESCRIPTION
## Summary

- make `R` on an archived TUI row durably unarchive the session before restarting it
- restore the exact archive timestamp if persistence or process restart fails
- rebuild the archived/active partition after success and show an explicit confirmation
- document the archived-session restart behavior

## Problem

The archived view advertised `R`, and `CanRestart()` allowed the action, but the restart path never cleared `ArchivedAt`. This could start a process that remained hidden in the archived view and excluded from status polling.

## Testing

- `go test ./internal/ui -run 'Test(RestartWithArchiveTransition|SessionRestartedMsgMovesUnarchivedSessionOutOfArchivedView|SessionRestartedMsgErrorClearsResumingAnimation|RestartSessionCmdSessionMissingReturnsError)' -count=1`\n- `go test ./internal/ui -count=1`\n- `go vet ./internal/ui`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restarting a session from the archived view now automatically unarchives it.
  - Archived sessions are restored to their original state if restarting fails.
  - The interface now refreshes archived-session lists and status counts correctly after a restart.
  - Clearer success, warning, and error messages are shown for unarchive and restart outcomes.

- **Tests**
  - Added coverage for successful restarts, persistence failures, rollback behavior, and archived-view updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->