### PR TITLE
fix(scrollback): don't hijack PageUp from alternate-screen apps (Claude fullscreen)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -3900,7 +3900,10 @@ func CreateExampleConfig() error {
 # without leaving agent-deck. Inside: Up/Down/j/k, PgUp/PgDn, g=start, G=live end,
 # wheel scrolls, Esc re-attaches, Ctrl+Q returns to the list.
 #   "pageup"  (default) a bare PageUp opens the pager; modified PageUp passes
-#             through to the attached program.
+#             through to the attached program. When the attached app is in the
+#             alternate screen (a full-screen TUI such as Claude fullscreen),
+#             bare PageUp also passes through so the app's own scrollback works —
+#             the pager would be empty there (alt-screen keeps no tmux history).
 #   "ctrl+<letter>"  a control chord opens it (use if a pager/editor inside the
 #             session needs PageUp). A chord that collides with detach/switch is
 #             dropped.

--- a/internal/tmux/alternate_screen_test.go
+++ b/internal/tmux/alternate_screen_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+// +build !windows
+
+package tmux
+
+import "testing"
+
+// TestParseAlternateOn verifies the tmux #{alternate_on} flag is parsed as
+// "1" => alternate screen active, everything else => normal screen. Whitespace
+// (tmux appends a trailing newline) is tolerated; only an exact "1" is truthy so
+// values like "10" never misread as active.
+func TestParseAlternateOn(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"one means alt-screen", "1", true},
+		{"trailing newline tolerated", "1\n", true},
+		{"surrounding whitespace tolerated", "  1  ", true},
+		{"zero means normal screen", "0", false},
+		{"zero with newline", "0\n", false},
+		{"empty means normal screen", "", false},
+		{"ten is not one", "10", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseAlternateOn(tt.output); got != tt.want {
+				t.Fatalf("parseAlternateOn(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -114,6 +114,16 @@ type AttachOptions struct {
 	// This is the default trigger because it is exactly the key a user presses
 	// expecting to scroll back through the session.
 	ScrollbackOnPageUp bool
+	// ScrollbackGate, when non-nil, is consulted the moment a bare PageUp is
+	// seen (with ScrollbackOnPageUp set). Returning true opens the pager — the
+	// behaviour when the gate is nil; returning false leaves the PageUp for the
+	// attached program. It exists so the pager never hijacks PageUp from a
+	// full-screen app (e.g. Claude fullscreen) that scrolls itself and keeps no
+	// tmux scrollback for the pager to show. It is invoked ONLY when a PageUp is
+	// actually present, so the per-press tmux query it typically performs is
+	// cheap and never runs on ordinary keystrokes. It is NOT consulted for the
+	// ScrollbackKeyByte chord, which is an explicit user opt-in.
+	ScrollbackGate func() bool
 }
 
 // indexSwitchKey returns the index of the switch key in data and
@@ -150,9 +160,22 @@ func indexScrollbackTrigger(data []byte, opts AttachOptions) int {
 		consider(IndexDetachKey(data, opts.ScrollbackKeyByte))
 	}
 	if opts.ScrollbackOnPageUp {
-		consider(bytes.Index(data, []byte(pageUpSeq)))
+		// Consult the gate only once a PageUp is actually present, so the tmux
+		// alternate-screen query it performs never runs on ordinary keystrokes.
+		// A closed gate suppresses the trigger, leaving PageUp for the app.
+		if idx := bytes.Index(data, []byte(pageUpSeq)); idx >= 0 && scrollbackPageUpAllowed(opts) {
+			consider(idx)
+		}
 	}
 	return best
+}
+
+// scrollbackPageUpAllowed reports whether a bare PageUp should open the pager
+// right now. With no gate configured it always does (legacy behaviour); a gate
+// lets the caller pass PageUp through to the attached program — e.g. when the
+// pane is in the alternate screen. See AttachOptions.ScrollbackGate.
+func scrollbackPageUpAllowed(opts AttachOptions) bool {
+	return opts.ScrollbackGate == nil || opts.ScrollbackGate()
 }
 
 // resolveAttachInterrupt finds the earliest interrupt key in a stdin chunk and

--- a/internal/tmux/scrollback_key_test.go
+++ b/internal/tmux/scrollback_key_test.go
@@ -83,6 +83,83 @@ func TestIndexScrollbackTrigger_CtrlByte(t *testing.T) {
 	}
 }
 
+// TestIndexScrollbackTrigger_PageUpGate verifies that ScrollbackGate suppresses
+// ONLY the bare-PageUp trigger (leaving the key for the attached program), never
+// the explicit control-byte chord, and that a nil gate preserves the legacy
+// always-open behaviour. This is the alternate-screen passthrough fix: when the
+// pane is a full-screen app (Claude fullscreen), PageUp must reach the app.
+func TestIndexScrollbackTrigger_PageUpGate(t *testing.T) {
+	const ctrlG = byte(7) // Ctrl+G
+	gateTrue := func() bool { return true }
+	gateFalse := func() bool { return false }
+
+	tests := []struct {
+		name string
+		data string
+		opts AttachOptions
+		want int
+	}{
+		{
+			name: "gate open => pageup detected",
+			data: "\x1b[5~",
+			opts: AttachOptions{ScrollbackOnPageUp: true, ScrollbackGate: gateTrue},
+			want: 0,
+		},
+		{
+			name: "gate closed => pageup suppressed (passthrough)",
+			data: "\x1b[5~",
+			opts: AttachOptions{ScrollbackOnPageUp: true, ScrollbackGate: gateFalse},
+			want: -1,
+		},
+		{
+			name: "nil gate => pageup detected (legacy)",
+			data: "\x1b[5~",
+			opts: AttachOptions{ScrollbackOnPageUp: true},
+			want: 0,
+		},
+		{
+			name: "gate closed never suppresses the ctrl-byte chord",
+			data: "\x07",
+			opts: AttachOptions{ScrollbackKeyByte: ctrlG, ScrollbackGate: gateFalse},
+			want: 0,
+		},
+		{
+			name: "gate closed suppresses pageup but chord still wins",
+			data: "\x1b[5~\x07",
+			opts: AttachOptions{ScrollbackKeyByte: ctrlG, ScrollbackOnPageUp: true, ScrollbackGate: gateFalse},
+			want: 4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := indexScrollbackTrigger([]byte(tt.data), tt.opts); got != tt.want {
+				t.Fatalf("indexScrollbackTrigger(%q) = %d, want %d", tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIndexScrollbackTrigger_GateOnlyOnPageUp verifies the gate is consulted only
+// when a bare PageUp is actually present — never on ordinary keystrokes — so the
+// per-press tmux query it performs cannot run on every input chunk.
+func TestIndexScrollbackTrigger_GateOnlyOnPageUp(t *testing.T) {
+	calls := 0
+	opts := AttachOptions{ScrollbackOnPageUp: true, ScrollbackGate: func() bool {
+		calls++
+		return true
+	}}
+	// Ordinary input with no PageUp: the gate must not be consulted.
+	indexScrollbackTrigger([]byte("hello world"), opts)
+	if calls != 0 {
+		t.Fatalf("gate consulted %d times on non-PageUp input, want 0", calls)
+	}
+	// A PageUp present: gate consulted exactly once.
+	indexScrollbackTrigger([]byte("\x1b[5~"), opts)
+	if calls != 1 {
+		t.Fatalf("gate consulted %d times on PageUp input, want 1", calls)
+	}
+}
+
 // TestResolveAttachInterrupt_Precedence verifies detach > switch > scrollback
 // precedence and earliest-index-wins semantics.
 func TestResolveAttachInterrupt_Precedence(t *testing.T) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5060,6 +5060,33 @@ func (s *Session) GetWorkDir() string {
 	return strings.TrimSpace(string(output))
 }
 
+// IsAltScreen reports whether the pane is currently showing the alternate
+// screen — i.e. a full-screen TUI such as Claude in fullscreen mode. Such panes
+// keep NO tmux scrollback (history_size stays 0 regardless of history-limit), so
+// the in-attach scrollback pager (#1491) has nothing to capture and, worse,
+// would swallow the PageUp the app itself uses to scroll. The attach loop
+// consults this (via AttachOptions.ScrollbackGate) to leave bare PageUp for the
+// app when it is fullscreen.
+//
+// Bounded so a wedged server can never hang the keystroke that triggered the
+// query. On error it returns (false, err); the caller preserves the pager on
+// error rather than silently disabling a configured feature.
+func (s *Session) IsAltScreen() (bool, error) {
+	output, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{alternate_on}")
+	if err != nil {
+		return false, err
+	}
+	return parseAlternateOn(string(output)), nil
+}
+
+// parseAlternateOn parses tmux's #{alternate_on} flag: an exact "1" means the
+// alternate screen is active, anything else means the normal screen. tmux
+// appends a trailing newline, so surrounding whitespace is trimmed. Extracted so
+// the parsing is unit-testable without a live tmux server.
+func parseAlternateOn(output string) bool {
+	return strings.TrimSpace(output) == "1"
+}
+
 // SplitShellPane adds a vertical split pane to this session running shell
 // in workdir. If workdir is empty the pane inherits the session's current
 // working directory. Issue #1470.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -733,10 +733,21 @@ func (h *Home) detachByte() byte {
 	return ResolvedDetachByte(session.GetHotkeyOverrides())
 }
 
+// openScrollbackOnPageUp is the alternate-screen gate decision for a bare
+// PageUp: open the pager on a normal-screen pane (real tmux scrollback exists),
+// pass PageUp through on an alternate-screen pane (a full-screen app such as
+// Claude fullscreen scrolls itself and keeps no tmux history), and preserve the
+// pager on a query error rather than silently disabling a configured feature.
+func openScrollbackOnPageUp(alt bool, err error) bool {
+	return err != nil || !alt
+}
+
 // attachOptions resolves the detach key plus the in-attach session-switcher
 // key for the current hotkey configuration. The detach key always wins: a
 // switch byte that collides with it is dropped so it can never shadow detach.
-func (h *Home) attachOptions() tmux.AttachOptions {
+// sess is the tmux session being attached; it is used to gate the bare-PageUp
+// scrollback trigger so a full-screen app keeps its own PageUp (#1491 fix).
+func (h *Home) attachOptions(sess *tmux.Session) tmux.AttachOptions {
 	overrides := session.GetHotkeyOverrides()
 	detach := ResolvedDetachByte(overrides)
 	switchByte := ResolvedSwitchByte(overrides)
@@ -751,12 +762,22 @@ func (h *Home) attachOptions() tmux.AttachOptions {
 	if scrollByte == detach || (switchByte != 0 && scrollByte == switchByte) {
 		scrollByte = 0
 	}
-	return tmux.AttachOptions{
+	opts := tmux.AttachOptions{
 		DetachByte:         detach,
 		SwitchKeyByte:      switchByte,
 		ScrollbackKeyByte:  scrollByte,
 		ScrollbackOnPageUp: scroll.OnPageUp,
 	}
+	// Gate the bare-PageUp trigger on the pane's screen state: when the attached
+	// app is in the alternate screen (Claude fullscreen), leave PageUp for the
+	// app instead of opening an empty pager over its (non-existent) tmux history.
+	// Only wired for the PageUp trigger — an explicit control-byte chord is a
+	// deliberate opt-in and is never gated. The gate is consulted at most once
+	// per PageUp press (see AttachOptions.ScrollbackGate).
+	if scroll.OnPageUp && sess != nil {
+		opts.ScrollbackGate = func() bool { return openScrollbackOnPageUp(sess.IsAltScreen()) }
+	}
+	return opts
 }
 
 func (h *Home) setHotkeys(bindings map[string]string) {
@@ -12660,7 +12681,7 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 	// which would lose the tmux session state)
 	h.isAttaching.Store(true) // Prevent View() output only during actual attach transition
 	res := &attachResult{}
-	return tea.Exec(attachCmd{session: tmuxSess, opts: h.attachOptions(), result: res}, func(err error) tea.Msg {
+	return tea.Exec(attachCmd{session: tmuxSess, opts: h.attachOptions(tmuxSess), result: res}, func(err error) tea.Msg {
 		// CRITICAL: Set isAttaching to false BEFORE returning the message
 		// This prevents a race condition where View() could be called with
 		// isAttaching=true before Update() processes statusUpdateMsg,

--- a/internal/ui/scrollback_gate_test.go
+++ b/internal/ui/scrollback_gate_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestOpenScrollbackOnPageUp verifies the alternate-screen gate decision: a bare
+// PageUp opens the pager on a normal-screen pane (there is real tmux scrollback),
+// passes through on an alternate-screen pane (a full-screen app such as Claude
+// fullscreen scrolls itself), and — on a query failure — preserves the pager
+// rather than silently disabling a configured feature.
+func TestOpenScrollbackOnPageUp(t *testing.T) {
+	boom := errors.New("tmux query failed")
+	tests := []struct {
+		name string
+		alt  bool
+		err  error
+		want bool
+	}{
+		{"normal screen opens pager", false, nil, true},
+		{"alt screen passes pageup through", true, nil, false},
+		{"query error preserves pager (normal)", false, boom, true},
+		{"query error preserves pager (alt)", true, boom, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := openScrollbackOnPageUp(tt.alt, tt.err); got != tt.want {
+				t.Fatalf("openScrollbackOnPageUp(%v, %v) = %v, want %v", tt.alt, tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The in-attach scrollback pager (#1491) is **empty and hijacks PageUp for full-screen agents** (Claude fullscreen, and any alternate-screen TUI). Symptom: pressing PageUp in a fullscreen Claude session "only shows one line above" instead of scrolling.

## Root cause

The pager captures pane history with `capture-pane -e -S` and steals a bare PageUp (`ESC[5~`) to open. But alternate-screen apps keep **no** tmux scrollback — the pane's `history_size` stays `0` regardless of `history-limit`. Measured on a live Claude fullscreen pane:

```
alternate_on = 1
history_size = 0        # nothing to capture
history-limit = 10000   # not a config problem
capture-pane -S -50000  → returns only pane_height lines (the current frame)
```

So the pager renders one screen, pins to the bottom, and PageUp finds ~1 line above it. Worse, #1491 swallows the very PageUp that Claude fullscreen uses for its **own** native scrollback (`PgUp`/`PgDn`, `Ctrl+Home`/`Ctrl+End`, `Ctrl+O`), so it actively breaks working scroll.

#1491's premise ("tmux scrollback is unreachable in control-mode attach, so steal PageUp") only holds for main-buffer apps. For alt-screen apps it's both useless and destructive.

## Fix

Gate the **bare-PageUp** trigger on the pane's alternate-screen state (`#{alternate_on}`):

- **alt-screen (fullscreen app)** → pass PageUp through so the app's own scroll works.
- **normal screen (shell / main-buffer tool)** → open the pager as before (real tmux history exists).
- **explicit `ctrl+<letter>` chord** → never gated (deliberate opt-in).

The gate is consulted **only when a PageUp is actually present**, so its one `display-message -p '#{alternate_on}'` query never runs on ordinary keystrokes (and is bounded, so a wedged server can't hang input). On query error it **preserves** the pager rather than silently disabling a configured feature.

### Behavior matrix

| Attached app | `alternate_on` | Bare PageUp | Result |
|---|---|---|---|
| Claude fullscreen | 1 | passes through | Claude's native scroll works |
| Shell / main-buffer tool | 0 | intercepted | pager opens over real history (unchanged) |
| Any tool, explicit `ctrl+g` trigger | — | not involved | chord still opens the pager |
| Modified PageUp (Shift/Ctrl) | — | already passed through | unchanged |

## Changes

- `internal/tmux/pty.go` — `AttachOptions.ScrollbackGate func() bool`; `indexScrollbackTrigger` consults it for the PageUp sub-trigger only, and only when a PageUp is present.
- `internal/tmux/tmux.go` — `(*Session).IsAltScreen()` (bounded `#{alternate_on}` query) + pure `parseAlternateOn` helper.
- `internal/ui/home.go` — `attachOptions(sess)` wires the gate for the PageUp trigger; pure `openScrollbackOnPageUp(alt, err)` decision (open on normal screen, pass through on alt-screen, preserve on error).
- `internal/session/userconfig.go` — documents the passthrough in the `[hotkeys].scrollback` help.

## Test plan

New unit tests (TDD, written first):

- `TestIndexScrollbackTrigger_PageUpGate` — gate open ⇒ PageUp detected; gate closed ⇒ suppressed (passthrough); nil gate ⇒ legacy detect; chord never gated.
- `TestIndexScrollbackTrigger_GateOnlyOnPageUp` — gate never consulted on non-PageUp input (guards against per-keystroke tmux queries).
- `TestParseAlternateOn` — `"1"` truthy, whitespace tolerated, `"10"`/`"0"`/`""` falsey.
- `TestOpenScrollbackOnPageUp` — normal→open, alt→passthrough, error→preserve pager.

```
go build ./...                        # clean
go vet ./internal/{tmux,ui,session}   # clean
go test ./internal/tmux ./internal/ui -run 'Scrollback|AltScreen|ParseAlternateOn|OpenScrollbackOnPageUp'  # pass
```

(Note: `TestControlPipeClose_FallsBackToSIGKILL` is a pre-existing flaky timing test unrelated to this change — it flip-flops in isolation on an unmodified tree.)

## Risk

Behavior-preserving where #1491 helps: the pager still opens exactly when the pane has real scrollback. Fullscreen apps regain their own PageUp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PageUp scrollback now detects fullscreen alternate-screen applications.
  - In alternate-screen mode, bare PageUp is passed to the attached application instead of opening an empty pager.
  - PageUp continues to open the pager in normal-screen mode, with explicit scrollback shortcuts preserved.

- **Documentation**
  - Updated the example configuration to explain alternate-screen PageUp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->