### PR TITLE
docs: fix good-first-issue label link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ agent-deck has one human maintainer and a fleet of AI agents that do the heavy l
 
 Good places to start:
 
-- **Issues labeled [`good-first-issue`](https://github.com/asheshgoplani/agent-deck/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue).** Curated to be small and self-contained.
+- **Issues labeled [`good first issue`](https://github.com/asheshgoplani/agent-deck/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).** Curated to be small and self-contained.
 - **Tool integrations.** Readiness and preset patterns for your favorite agent CLI (see `internal/session/` presets for examples).
 - **Docs fixes.** Always welcome, always fast to land.
 


### PR DESCRIPTION
## What problem does this solve?

The good-first-issue filter link in CONTRIBUTING.md (shipped in #1649) points at label `good-first-issue`, but the repo label is `good first issue` (with spaces), so the front-door link returned an empty list.

## Why this change

One-line link fix to the actual label name.

## User impact

New contributors clicking the starter link now see the curated issues (currently #1614).

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s):** claude-fable-5

## What actually bothered you

Verifying the shipped pack end-to-end: the label view came back empty because the label name has spaces.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] CHANGELOG.md untouched

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->