### PR TITLE
fix(ui): unarchive sessions before fresh restart

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12515,6 +12515,14 @@ func (h *Home) restartSession(inst *session.Instance) tea.Cmd {
 
 // restartSessionFresh restarts a session without resuming the previous tool session.
 func (h *Home) restartSessionFresh(inst *session.Instance) tea.Cmd {
+	return h.restartSessionFreshWith(inst, h.persistArchived, (*session.Instance).RestartFresh)
+}
+
+func (h *Home) restartSessionFreshWith(
+	inst *session.Instance,
+	persist func(*session.Instance) error,
+	restartFresh func(*session.Instance) error,
+) tea.Cmd {
 	id := inst.ID
 	mcpUILog.Debug(
 		"restart_session_fresh_called",
@@ -12534,13 +12542,16 @@ func (h *Home) restartSessionFresh(inst *session.Instance) tea.Cmd {
 			return sessionRestartedMsg{sessionID: id, err: err, fresh: true}
 		}
 
-		err := current.RestartFresh()
+		unarchived, err := restartWithArchiveTransition(current, persist, func() error {
+			return restartFresh(current)
+		})
 		mcpUILog.Debug("restart_session_fresh_result", slog.String("id", id), slog.Any("error", err))
 		return sessionRestartedMsg{
-			sessionID: id,
-			err:       err,
-			warning:   current.ConsumeCodexRestartWarning(),
-			fresh:     true,
+			sessionID:  id,
+			err:        err,
+			warning:    current.ConsumeCodexRestartWarning(),
+			fresh:      true,
+			unarchived: unarchived,
 		}
 	}
 }

--- a/internal/ui/restart_archived_test.go
+++ b/internal/ui/restart_archived_test.go
@@ -100,6 +100,95 @@ func TestRestartWithArchiveTransitionDoesNotRestartWhenUnarchivePersistenceFails
 	}
 }
 
+func TestRestartFreshWithArchiveTransitionUnarchivesBeforeRestart(t *testing.T) {
+	archivedAt := time.Date(2026, time.July, 18, 8, 0, 0, 0, time.UTC)
+	inst := &session.Instance{ID: "archived-fresh", ArchivedAt: archivedAt}
+	home := NewHome()
+	home.instanceByID[inst.ID] = inst
+	var events []string
+
+	cmd := home.restartSessionFreshWith(inst, func(current *session.Instance) error {
+		if current.IsArchived() {
+			events = append(events, "persist-archived")
+		} else {
+			events = append(events, "persist-unarchived")
+		}
+		return nil
+	}, func(*session.Instance) error {
+		events = append(events, "restart-fresh")
+		return nil
+	})
+	msg, ok := cmd().(sessionRestartedMsg)
+	if !ok {
+		t.Fatalf("expected sessionRestartedMsg")
+	}
+	if msg.err != nil {
+		t.Fatalf("fresh restart archive transition: %v", msg.err)
+	}
+	if !msg.fresh || !msg.unarchived || inst.IsArchived() {
+		t.Fatalf("successful fresh restart: fresh=%v unarchived=%v archivedAt=%v", msg.fresh, msg.unarchived, inst.ArchivedAt)
+	}
+	want := []string{"persist-unarchived", "restart-fresh"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestRestartFreshWithArchiveTransitionRestoresArchiveOnFailure(t *testing.T) {
+	archivedAt := time.Date(2026, time.July, 18, 8, 0, 0, 0, time.UTC)
+	inst := &session.Instance{ID: "archived-fresh", ArchivedAt: archivedAt}
+	home := NewHome()
+	home.instanceByID[inst.ID] = inst
+	var persisted []time.Time
+	restartErr := errors.New("fresh spawn failed")
+
+	cmd := home.restartSessionFreshWith(inst, func(current *session.Instance) error {
+		persisted = append(persisted, current.ArchivedAt)
+		return nil
+	}, func(*session.Instance) error {
+		return restartErr
+	})
+	msg, ok := cmd().(sessionRestartedMsg)
+	if !ok {
+		t.Fatalf("expected sessionRestartedMsg")
+	}
+	if !errors.Is(msg.err, restartErr) {
+		t.Fatalf("error = %v, want %v", msg.err, restartErr)
+	}
+	if !msg.fresh || msg.unarchived || !inst.ArchivedAt.Equal(archivedAt) {
+		t.Fatalf("failed fresh restart: fresh=%v unarchived=%v archivedAt=%v", msg.fresh, msg.unarchived, inst.ArchivedAt)
+	}
+	if len(persisted) != 2 || !persisted[0].IsZero() || !persisted[1].Equal(archivedAt) {
+		t.Fatalf("persisted timestamps = %v, want [zero, %v]", persisted, archivedAt)
+	}
+}
+
+func TestRestartFreshWithArchiveTransitionActiveSessionSkipsPersistence(t *testing.T) {
+	inst := &session.Instance{ID: "active-fresh"}
+	home := NewHome()
+	home.instanceByID[inst.ID] = inst
+	persisted := false
+	restarted := false
+
+	cmd := home.restartSessionFreshWith(inst, func(*session.Instance) error {
+		persisted = true
+		return nil
+	}, func(*session.Instance) error {
+		restarted = true
+		return nil
+	})
+	msg, ok := cmd().(sessionRestartedMsg)
+	if !ok {
+		t.Fatalf("expected sessionRestartedMsg")
+	}
+	if msg.err != nil {
+		t.Fatalf("fresh restart archive transition: %v", msg.err)
+	}
+	if !msg.fresh || msg.unarchived || persisted || !restarted {
+		t.Fatalf("active fresh restart: fresh=%v unarchived=%v persisted=%v restarted=%v", msg.fresh, msg.unarchived, persisted, restarted)
+	}
+}
+
 func TestSessionRestartedMsgMovesUnarchivedSessionOutOfArchivedView(t *testing.T) {
 	home := NewHome()
 	home.storage = nil


### PR DESCRIPTION
## What problem does this solve?

Shift+T on an archived session could start a fresh process while leaving `ArchivedAt` persisted, keeping the live session hidden. Fixes #1652.

## Why this change

Route `RestartFresh` through the archive transition introduced by #1647: persist the unarchive before restarting and restore the exact archive timestamp if the fresh restart fails.

## User impact

Fresh-restarting an archived session now moves it back to the active list. A failed restart leaves it archived instead of losing its prior metadata state. Non-archived fresh restarts retain their existing behavior.

## Evidence

- Focused fresh-restart archive regressions pass.
- `go test ./internal/ui -count=1` passes in 81.795s.
- The changed `internal/ui` package also passes inside the isolated-HOME full-suite run in 72.391s.
- `golangci-lint run`: 0 issues.
- `gofmt` and `git diff --check` pass.
- The repository-wide isolated-HOME suite was run but remains red in unrelated existing `cmd/agent-deck`, `internal/session`, `internal/testutil`, and `internal/tmux` tests, including the existing 40ms cold-start budget check.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** Not public; validation details are included above.

## What actually bothered you

My human asked: "Давай больше pull-requests к разным репозиториям делать." I selected this open, bounded bug and reviewed the implementation and validation before submission.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fresh restarts from archived sessions now automatically unarchive the session before restarting.
  - Archive state is restored if the restart fails.
  - Restart status now clearly indicates whether the session was unarchived.

- **Bug Fixes**
  - Prevented unnecessary archive-state persistence for sessions that are already active.

- **Tests**
  - Added coverage for successful restarts, restart failures, archive restoration, and active-session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->