### PR TITLE
feat(opencode): SSE-based status tracking via --port event stream (#1614)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -95,6 +96,12 @@ const (
 	opencodeRotationScanInterval   = 15 * time.Second
 	opencodeRotationActivityWindow = 30 * time.Second
 	opencodeStartupTimeSkew        = 5 * time.Second
+	// opencodeSSEFreshnessWindow bounds how long an SSE-derived status stays
+	// authoritative without stream traffic (issue #1614). OpenCode heartbeats
+	// its /event stream roughly every 10s, and the watcher refreshes the
+	// timestamp on every received line, so 30s of silence means the stream
+	// (and likely the process) is gone — fall back to tmux polling.
+	opencodeSSEFreshnessWindow = 30 * time.Second
 	// codexProbeScanInterval rate-limits process-file probing to avoid
 	// repeated /proc and lsof scans on every status tick.
 	codexProbeScanInterval    = 2 * time.Second
@@ -202,7 +209,8 @@ type Instance struct {
 	// OpenCode CLI integration
 	OpenCodeSessionID  string    `json:"opencode_session_id,omitempty"`
 	OpenCodeDetectedAt time.Time `json:"opencode_detected_at,omitempty"`
-	OpenCodeStartedAt  int64     `json:"-"` // Unix millis when we started OpenCode (for session matching, not persisted)
+	OpenCodeStartedAt  int64     `json:"-"`                       // Unix millis when we started OpenCode (for session matching, not persisted)
+	OpenCodePort       int       `json:"opencode_port,omitempty"` // Localhost port of OpenCode's event server (issue #1614); 0 = none
 	lastOpenCodeScanAt time.Time // Rate-limits expensive `opencode session list` scans
 
 	// Codex CLI integration
@@ -400,6 +408,11 @@ type Instance struct {
 	hookEvent      string    // Hook event name that caused the last status (e.g. "PermissionRequest")
 	hookSessionID  string    // Session ID from hook payload
 	hookLastUpdate time.Time // When hook status was last received
+
+	// SSE-based status detection for OpenCode (set by OpenCodeSSEWatcher,
+	// issue #1614). Not persisted; rebuilt from the live event stream.
+	sseStatus     string    // "running" or "waiting" (empty = no SSE data)
+	sseLastUpdate time.Time // When SSE status was last confirmed
 
 	// mu protects fields written by backgroundStatusUpdate and read by the TUI goroutine.
 	// Use GetStatus()/SetStatus() and GetTool()/SetTool() for thread-safe access.
@@ -1360,7 +1373,7 @@ func (i *Instance) buildOpenCodeCommand(baseCommand string) string {
 	// If baseCommand is just "opencode", handle specially
 	if baseCommand == "opencode" {
 		cmd := GetToolCommand("opencode")
-		extraFlags := i.buildOpenCodeExtraFlags()
+		extraFlags := i.buildOpenCodeExtraFlags() + i.buildOpenCodeSSEPortFlag()
 
 		// If we already have a session ID, use resume with -s flag.
 		// OPENCODE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
@@ -1373,7 +1386,11 @@ func (i *Instance) buildOpenCodeCommand(baseCommand string) string {
 		return envPrefix + cmd + extraFlags
 	}
 
-	// For custom commands (e.g., fork commands), return as-is
+	// For custom commands (e.g., fork commands), return as-is. No --port is
+	// injected, so clear any stale port from a prior launch — otherwise the
+	// SSE watcher could connect to a freed port later reused by an unrelated
+	// process (issue #1614). Status falls back to tmux content sniffing.
+	i.OpenCodePort = 0
 	return envPrefix + baseCommand
 }
 
@@ -1399,6 +1416,66 @@ func (i *Instance) buildOpenCodeExtraFlags() string {
 		flags += " --agent " + opts.Agent
 	}
 	return flags
+}
+
+// buildOpenCodeSSEPortFlag allocates a localhost port for OpenCode's event
+// server and returns " --port N" (issue #1614). With an explicit --port, the
+// OpenCode TUI binds a real HTTP server whose /event SSE stream publishes
+// session.status transitions; OpenCodeSSEWatcher consumes it for real-time
+// status instead of tmux content sniffing. Returns "" (and clears the stored
+// port) when disabled via [opencode].disable_sse_status or when no port could
+// be allocated — status detection then falls back to tmux polling.
+func (i *Instance) buildOpenCodeSSEPortFlag() string {
+	if config, err := LoadUserConfig(); err == nil && config != nil && config.OpenCode.DisableSSEStatus {
+		i.OpenCodePort = 0
+		return ""
+	}
+	port, err := allocateLocalPort()
+	if err != nil {
+		sessionLog.Warn("opencode_sse_port_alloc_failed", slog.String("error", err.Error()))
+		i.OpenCodePort = 0
+		return ""
+	}
+	i.OpenCodePort = port
+	return fmt.Sprintf(" --port %d", port)
+}
+
+// allocateLocalPort reserves a free 127.0.0.1 port by binding :0 and
+// immediately releasing it. The tiny window before OpenCode re-binds it is
+// the standard trade-off; a collision surfaces as a failed launch and the
+// next restart picks a fresh port.
+func allocateLocalPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port, nil
+}
+
+// GetOpenCodePort returns the event-server port with lock protection.
+func (i *Instance) GetOpenCodePort() int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.OpenCodePort
+}
+
+// UpdateOpenCodeSSEStatus feeds an SSE-derived status ("running"/"waiting")
+// into the instance for the SSE fast path in UpdateStatus (issue #1614).
+func (i *Instance) UpdateOpenCodeSSEStatus(status string, updatedAt time.Time) {
+	if status == "" {
+		return
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	// A transition means new activity/output the user hasn't seen yet: reset
+	// acknowledgment so waiting renders orange, mirroring UpdateHookStatus.
+	if status != i.sseStatus && i.tmuxSession != nil {
+		i.tmuxSession.ResetAcknowledged()
+	}
+	i.sseStatus = status
+	i.sseLastUpdate = updatedAt
 }
 
 // DetectOpenCodeSession is the public wrapper for async OpenCode session detection
@@ -4172,6 +4249,31 @@ func (i *Instance) UpdateStatus() error {
 			}
 		}
 		return nil
+	}
+
+	// SSE FAST PATH (issue #1614): OpenCode publishes session.status over its
+	// /event stream when launched with --port; OpenCodeSSEWatcher feeds the
+	// derived status here via UpdateOpenCodeSSEStatus. When the stream drops,
+	// the status ages past opencodeSSEFreshnessWindow and control falls
+	// through to tmux content sniffing — the same degradation model as hooks.
+	if i.Tool == "opencode" && i.sseStatus != "" &&
+		time.Since(i.sseLastUpdate) < opencodeSSEFreshnessWindow {
+		switch i.sseStatus {
+		case "running":
+			i.Status = StatusRunning
+			// New activity means output not yet seen (mirrors hook fast path).
+			if i.tmuxSession != nil {
+				i.tmuxSession.ResetAcknowledged()
+			}
+			return nil
+		case "waiting":
+			if i.tmuxSession != nil && i.tmuxSession.IsAcknowledged() {
+				i.Status = StatusIdle
+			} else {
+				i.Status = StatusWaiting
+			}
+			return nil
+		}
 	}
 
 	// Release lock for potentially slow tmux calls (GetStatus calls CapturePane)

--- a/internal/session/opencode_sse.go
+++ b/internal/session/opencode_sse.go
@@ -1,0 +1,302 @@
+package session
+
+// SSE-based status tracking for OpenCode sessions (issue #1614).
+//
+// OpenCode's TUI, when launched with an explicit --port, binds a real HTTP
+// server on 127.0.0.1 that streams session lifecycle events over SSE at
+// GET /event. Among them, "session.status" events carry
+// {sessionID, status:{type: "busy"|"retry"|"idle"}} and "session.idle"
+// carries {sessionID}. A GET /session/status snapshot returns the busy
+// sessions at connect time.
+//
+// OpenCodeSSEWatcher maintains one streaming connection per running OpenCode
+// instance and derives a per-instance status:
+//
+//	any session busy/retry  -> "running"
+//	all sessions idle       -> "waiting"
+//
+// The TUI feed loop (internal/ui/home.go backgroundStatusUpdate) pushes the
+// derived status into the Instance, where UpdateStatus() consumes it on an
+// SSE fast path ahead of the tmux content-sniffing fallback. When the stream
+// drops or goes silent, the status ages out of its freshness window and
+// control falls back to tmux polling — the same degradation model as the
+// Claude hook fast path.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OpenCodeSSEStatus is the latest status derived from an instance's event stream.
+type OpenCodeSSEStatus struct {
+	Status    string    // "running" or "waiting"
+	UpdatedAt time.Time // last time the stream confirmed this status
+}
+
+// SSETarget identifies one OpenCode instance's event server.
+type SSETarget struct {
+	InstanceID string
+	Port       int
+}
+
+// OpenCodeSSEWatcher manages SSE connections to OpenCode instances.
+type OpenCodeSSEWatcher struct {
+	mu       sync.Mutex
+	conns    map[string]*openCodeSSEConn // instance ID -> active connection
+	statuses map[string]*OpenCodeSSEStatus
+	onChange func() // optional TUI refresh callback
+
+	// client is overridable for tests.
+	client *http.Client
+}
+
+type openCodeSSEConn struct {
+	port   int
+	cancel context.CancelFunc
+}
+
+// NewOpenCodeSSEWatcher creates a watcher. onChange (may be nil) is invoked
+// whenever a derived status changes.
+func NewOpenCodeSSEWatcher(onChange func()) *OpenCodeSSEWatcher {
+	return &OpenCodeSSEWatcher{
+		conns:    make(map[string]*openCodeSSEConn),
+		statuses: make(map[string]*OpenCodeSSEStatus),
+		onChange: onChange,
+		client: &http.Client{
+			// Streaming reads must not time out; bound only the dial.
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{Timeout: 2 * time.Second}).DialContext,
+			},
+		},
+	}
+}
+
+// Sync reconciles active connections against the desired target set: it opens
+// connections for new targets (or targets whose port changed after a restart)
+// and tears down connections for instances no longer present.
+func (w *OpenCodeSSEWatcher) Sync(targets []SSETarget) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	want := make(map[string]int, len(targets))
+	for _, t := range targets {
+		if t.InstanceID == "" || t.Port <= 0 {
+			continue
+		}
+		want[t.InstanceID] = t.Port
+	}
+
+	for id, conn := range w.conns {
+		if port, ok := want[id]; !ok || port != conn.port {
+			conn.cancel()
+			delete(w.conns, id)
+			delete(w.statuses, id)
+		}
+	}
+
+	for id, port := range want {
+		if _, ok := w.conns[id]; ok {
+			continue
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		w.conns[id] = &openCodeSSEConn{port: port, cancel: cancel}
+		go w.run(ctx, id, port)
+	}
+}
+
+// GetStatus returns the latest derived status for an instance, or nil.
+func (w *OpenCodeSSEWatcher) GetStatus(instanceID string) *OpenCodeSSEStatus {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	s, ok := w.statuses[instanceID]
+	if !ok {
+		return nil
+	}
+	cp := *s
+	return &cp
+}
+
+// Stop tears down all connections.
+func (w *OpenCodeSSEWatcher) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for id, conn := range w.conns {
+		conn.cancel()
+		delete(w.conns, id)
+	}
+}
+
+// run maintains one instance's stream with reconnect + exponential backoff.
+func (w *OpenCodeSSEWatcher) run(ctx context.Context, instanceID string, port int) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+	for ctx.Err() == nil {
+		gotData := w.stream(ctx, instanceID, port)
+		if ctx.Err() != nil {
+			return
+		}
+		if gotData {
+			backoff = time.Second
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// openCodeEvent is the SSE payload shape (verified against the OpenCode
+// server's OpenAPI doc: Event.session.status / Event.session.idle).
+type openCodeEvent struct {
+	Type       string `json:"type"`
+	Properties struct {
+		SessionID string `json:"sessionID"`
+		Status    struct {
+			Type string `json:"type"` // "idle" | "busy" | "retry"
+		} `json:"status"`
+	} `json:"properties"`
+}
+
+// stream connects to /event and consumes it until error or cancellation.
+// Returns true if any data was received (resets the caller's backoff).
+func (w *OpenCodeSSEWatcher) stream(ctx context.Context, instanceID string, port int) bool {
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Track busy-ness per OpenCode session on this server: subagent/child
+	// sessions share the process, and the instance is "running" while ANY of
+	// them is busy. Seed from the /session/status snapshot so a stream opened
+	// mid-turn starts correct instead of waiting for the next transition.
+	busy := make(map[string]bool)
+	seeded := w.seedSnapshot(ctx, base, busy)
+	if seeded && len(busy) > 0 {
+		w.setStatus(instanceID, "running")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/event", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	sessionLog.Debug("opencode_sse_connected",
+		slog.String("instance_id", instanceID), slog.Int("port", port))
+
+	gotData := false
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		gotData = true
+		payload, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			// Comment/heartbeat line: refresh freshness of the known status.
+			w.touch(instanceID)
+			continue
+		}
+		var ev openCodeEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			w.touch(instanceID)
+			continue
+		}
+		switch ev.Type {
+		case "session.status":
+			switch ev.Properties.Status.Type {
+			case "busy", "retry":
+				// retry = provider call being retried; still working, no
+				// input needed, so it maps to running rather than waiting.
+				busy[ev.Properties.SessionID] = true
+			default: // "idle"
+				delete(busy, ev.Properties.SessionID)
+			}
+		case "session.idle":
+			delete(busy, ev.Properties.SessionID)
+		default:
+			// Unrelated event (heartbeat, tui.*, ...): liveness only.
+			w.touch(instanceID)
+			continue
+		}
+		if len(busy) > 0 {
+			w.setStatus(instanceID, "running")
+		} else {
+			w.setStatus(instanceID, "waiting")
+		}
+	}
+	return gotData
+}
+
+// seedSnapshot loads the /session/status snapshot into busy. Returns false if
+// the snapshot could not be fetched or parsed.
+func (w *OpenCodeSSEWatcher) seedSnapshot(ctx context.Context, base string, busy map[string]bool) bool {
+	snapCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(snapCtx, http.MethodGet, base+"/session/status", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	var snapshot map[string]struct {
+		Type string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		return false
+	}
+	for sid, st := range snapshot {
+		if st.Type == "busy" || st.Type == "retry" {
+			busy[sid] = true
+		}
+	}
+	return true
+}
+
+// setStatus records a derived status and fires onChange on transitions.
+func (w *OpenCodeSSEWatcher) setStatus(instanceID, status string) {
+	w.mu.Lock()
+	prev := w.statuses[instanceID]
+	changed := prev == nil || prev.Status != status
+	w.statuses[instanceID] = &OpenCodeSSEStatus{Status: status, UpdatedAt: time.Now()}
+	onChange := w.onChange
+	w.mu.Unlock()
+	if changed && onChange != nil {
+		onChange()
+	}
+}
+
+// touch refreshes the freshness timestamp of an existing status without
+// changing it, so a quiet-but-connected stream keeps the fast path alive.
+func (w *OpenCodeSSEWatcher) touch(instanceID string) {
+	w.mu.Lock()
+	if s, ok := w.statuses[instanceID]; ok {
+		s.UpdatedAt = time.Now()
+	}
+	w.mu.Unlock()
+}

--- a/internal/session/opencode_sse_test.go
+++ b/internal/session/opencode_sse_test.go
@@ -1,0 +1,229 @@
+package session
+
+// Tests for SSE-based OpenCode status tracking (issue #1614).
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sseTestServer serves a /session/status snapshot and an /event stream fed
+// from a channel, mimicking OpenCode's TUI server with --port.
+func sseTestServer(t *testing.T, snapshot string, events <-chan string) (*httptest.Server, int) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/session/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, snapshot)
+	})
+	mux.HandleFunc("/event", func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("response writer is not a flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"type\":\"server.connected\",\"properties\":{}}\n\n")
+		flusher.Flush()
+		for {
+			select {
+			case ev, ok := <-events:
+				if !ok {
+					return
+				}
+				fmt.Fprintf(w, "data: %s\n\n", ev)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	addr := srv.Listener.Addr().(*net.TCPAddr)
+	return srv, addr.Port
+}
+
+// waitForStatus polls the watcher until the instance's derived status matches
+// want or the timeout expires.
+func waitForStatus(t *testing.T, w *OpenCodeSSEWatcher, instanceID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if s := w.GetStatus(instanceID); s != nil && s.Status == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got := "<nil>"
+	if s := w.GetStatus(instanceID); s != nil {
+		got = s.Status
+	}
+	t.Fatalf("timed out waiting for status %q, got %q", want, got)
+}
+
+// TestOpenCodeSSEWatcher_StatusTransitions drives the full stream lifecycle:
+// busy -> running, idle -> waiting, and subagent aggregation (an idle event
+// for one session does not flip the instance to waiting while another session
+// on the same server is still busy).
+func TestOpenCodeSSEWatcher_StatusTransitions(t *testing.T) {
+	events := make(chan string, 8)
+	_, port := sseTestServer(t, "{}", events)
+
+	w := NewOpenCodeSSEWatcher(nil)
+	defer w.Stop()
+	w.Sync([]SSETarget{{InstanceID: "inst-1", Port: port}})
+
+	// Empty snapshot + connection banner only: no derived status yet, so the
+	// tmux fallback stays authoritative until a real transition arrives.
+	time.Sleep(100 * time.Millisecond)
+	if s := w.GetStatus("inst-1"); s != nil {
+		t.Fatalf("expected no status before first session event, got %+v", s)
+	}
+
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_A","status":{"type":"busy"}}}`
+	waitForStatus(t, w, "inst-1", "running")
+
+	// A second (sub)session goes busy, then idle: instance must stay running
+	// because ses_A is still busy.
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_B","status":{"type":"busy"}}}`
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_B","status":{"type":"idle"}}}`
+	time.Sleep(100 * time.Millisecond)
+	waitForStatus(t, w, "inst-1", "running")
+
+	// retry keeps the session working (running), not waiting.
+	events <- `{"type":"session.status","properties":{"sessionID":"ses_A","status":{"type":"retry","attempt":1,"message":"overloaded","next":123}}}`
+	time.Sleep(50 * time.Millisecond)
+	waitForStatus(t, w, "inst-1", "running")
+
+	// Legacy session.idle event ends the turn -> waiting.
+	events <- `{"type":"session.idle","properties":{"sessionID":"ses_A"}}`
+	waitForStatus(t, w, "inst-1", "waiting")
+
+	// Sync with an empty target set tears the connection down and drops state.
+	w.Sync(nil)
+	if s := w.GetStatus("inst-1"); s != nil {
+		t.Fatalf("expected status cleared after Sync(nil), got %+v", s)
+	}
+}
+
+// TestOpenCodeSSEWatcher_SnapshotSeedsBusy verifies that connecting mid-turn
+// derives running from the /session/status snapshot without waiting for the
+// next transition event.
+func TestOpenCodeSSEWatcher_SnapshotSeedsBusy(t *testing.T) {
+	events := make(chan string, 1)
+	_, port := sseTestServer(t, `{"ses_A":{"type":"busy"}}`, events)
+
+	w := NewOpenCodeSSEWatcher(nil)
+	defer w.Stop()
+	w.Sync([]SSETarget{{InstanceID: "inst-1", Port: port}})
+	waitForStatus(t, w, "inst-1", "running")
+}
+
+// TestUpdateOpenCodeSSEStatus_FastPathMapping verifies the instance-side
+// consumption: fresh SSE statuses map onto Running/Waiting, stale ones are
+// ignored so control falls through to tmux polling.
+func TestUpdateOpenCodeSSEStatus_FastPathMapping(t *testing.T) {
+	inst := &Instance{Tool: "opencode"}
+
+	inst.UpdateOpenCodeSSEStatus("running", time.Now())
+	if inst.sseStatus != "running" {
+		t.Fatalf("sseStatus = %q, want running", inst.sseStatus)
+	}
+	if time.Since(inst.sseLastUpdate) >= opencodeSSEFreshnessWindow {
+		t.Fatal("fresh update should be inside the freshness window")
+	}
+
+	inst.UpdateOpenCodeSSEStatus("waiting", time.Now())
+	if inst.sseStatus != "waiting" {
+		t.Fatalf("sseStatus = %q, want waiting", inst.sseStatus)
+	}
+
+	// Empty status is a no-op guard.
+	inst.UpdateOpenCodeSSEStatus("", time.Now())
+	if inst.sseStatus != "waiting" {
+		t.Fatalf("empty status must not clobber, got %q", inst.sseStatus)
+	}
+
+	// A stale timestamp must fall outside the freshness window.
+	stale := time.Now().Add(-2 * opencodeSSEFreshnessWindow)
+	inst.UpdateOpenCodeSSEStatus("running", stale)
+	if time.Since(inst.sseLastUpdate) < opencodeSSEFreshnessWindow {
+		t.Fatal("stale update should be outside the freshness window")
+	}
+}
+
+// TestBuildOpenCodeCommand_SSEPortFlag verifies --port injection on fresh and
+// resume launches, absence on custom-command passthrough, and the
+// [opencode].disable_sse_status escape hatch.
+func TestBuildOpenCodeCommand_SSEPortFlag(t *testing.T) {
+	fresh := &Instance{Tool: "opencode"}
+	cmd := fresh.buildOpenCodeCommand("opencode")
+	if !strings.Contains(cmd, " --port ") {
+		t.Fatalf("fresh launch missing --port: %q", cmd)
+	}
+	if fresh.OpenCodePort <= 0 {
+		t.Fatalf("OpenCodePort not recorded, got %d", fresh.OpenCodePort)
+	}
+	if !strings.Contains(cmd, fmt.Sprintf(" --port %d", fresh.OpenCodePort)) {
+		t.Fatalf("command port and OpenCodePort disagree: %q vs %d", cmd, fresh.OpenCodePort)
+	}
+
+	resume := &Instance{Tool: "opencode", OpenCodeSessionID: "ses_ABC123"}
+	cmd = resume.buildOpenCodeCommand("opencode")
+	if !strings.Contains(cmd, "-s ses_ABC123") || !strings.Contains(cmd, " --port ") {
+		t.Fatalf("resume launch missing -s or --port: %q", cmd)
+	}
+
+	// Custom commands pass through untouched (user controls their own flags),
+	// and a stale port from a prior launch is cleared so the SSE watcher can
+	// never attach to a freed port reused by an unrelated process.
+	custom := &Instance{Tool: "opencode", OpenCodePort: 999}
+	cmd = custom.buildOpenCodeCommand("opencode --model gpt-4")
+	if strings.Contains(cmd, "--port") {
+		t.Fatalf("custom command must not gain --port: %q", cmd)
+	}
+	if custom.OpenCodePort != 0 {
+		t.Fatalf("custom command must clear stale port, got %d", custom.OpenCodePort)
+	}
+}
+
+// TestBuildOpenCodeSSEPortFlag_Disabled verifies the config escape hatch.
+// The package TestMain isolates HOME, so the effective config path is a
+// sandboxed temp home — writing it never touches a real user config.
+func TestBuildOpenCodeSSEPortFlag_Disabled(t *testing.T) {
+	configPath, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+	if _, statErr := os.Stat(configPath); statErr == nil {
+		t.Fatalf("sandboxed config %s already exists; refusing to clobber", configPath)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("[opencode]\ndisable_sse_status = true\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		os.Remove(configPath)
+		ClearUserConfigCache()
+	})
+
+	inst := &Instance{Tool: "opencode", OpenCodePort: 4242}
+	cmd := inst.buildOpenCodeCommand("opencode")
+	if strings.Contains(cmd, "--port") {
+		t.Fatalf("disable_sse_status must suppress --port: %q", cmd)
+	}
+	if inst.OpenCodePort != 0 {
+		t.Fatalf("disable_sse_status must clear stored port, got %d", inst.OpenCodePort)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1790,6 +1790,14 @@ type OpenCodeSettings struct {
 	// Command overrides the default binary/invocation for OpenCode sessions.
 	// Supports flags (e.g., "opencode --custom-flag"). Default: "opencode"
 	Command string `toml:"command,omitempty"`
+
+	// DisableSSEStatus turns off SSE-based status tracking (issue #1614).
+	// By default agent-deck launches OpenCode with an explicit --port so its
+	// /event SSE stream can drive real-time status (green while busy, yellow
+	// when waiting) instead of tmux content sniffing. Set true if your
+	// OpenCode version predates the top-level --port flag or you don't want
+	// a localhost event server bound per session.
+	DisableSSEStatus bool `toml:"disable_sse_status,omitempty"`
 }
 
 // CodexSettings defines Codex CLI configuration
@@ -3985,6 +3993,9 @@ func CreateExampleConfig() error {
 # default_model = "anthropic/claude-sonnet-4-5-20250929"
 # Default agent for new sessions
 # default_agent = ""
+# Disable SSE-based status tracking (issue #1614). When disabled, OpenCode is
+# launched without --port and status falls back to tmux content sniffing.
+# disable_sse_status = true
 
 # Codex CLI integration
 # [codex]

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -366,6 +366,9 @@ type Home struct {
 	hookWatcher        *session.StatusFileWatcher
 	pendingHooksPrompt bool // True if user should be prompted to install hooks
 
+	// SSE-based status detection for OpenCode sessions (issue #1614)
+	sseWatcher *session.OpenCodeSSEWatcher
+
 	// Test seams for the visible-pane clipboard action. Production leaves both
 	// nil and uses fresh tmux capture plus the shared clipboard fallback chain.
 	paneCapture   paneCaptureFunc
@@ -1537,6 +1540,13 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 			h.storageWatcher = watcher
 			watcher.Start()
 		}
+	}
+
+	// SSE-based status detection for OpenCode sessions (issue #1614).
+	// Connections are opened lazily by backgroundStatusUpdate's Sync() call,
+	// so creating the watcher here is free when no OpenCode sessions exist.
+	if homeBackgroundWorkersEnabled {
+		h.sseWatcher = session.NewOpenCodeSSEWatcher(nil)
 	}
 
 	// Hook-based status detection (Claude Code lifecycle hooks)
@@ -4194,6 +4204,28 @@ func (h *Home) backgroundStatusUpdate() {
 				}
 			}
 		}
+	}
+
+	// Reconcile OpenCode SSE connections and feed derived statuses to
+	// instances (enables the SSE fast path in UpdateStatus, issue #1614).
+	if h.sseWatcher != nil {
+		var targets []session.SSETarget
+		for _, inst := range instances {
+			if inst.Tool != "opencode" {
+				continue
+			}
+			st := inst.GetStatusThreadSafe()
+			if st == session.StatusStopped {
+				continue
+			}
+			if port := inst.GetOpenCodePort(); port > 0 {
+				targets = append(targets, session.SSETarget{InstanceID: inst.ID, Port: port})
+				if ss := h.sseWatcher.GetStatus(inst.ID); ss != nil {
+					inst.UpdateOpenCodeSSEStatus(ss.Status, ss.UpdatedAt)
+				}
+			}
+		}
+		h.sseWatcher.Sync(targets)
 	}
 
 	// Proactive context-% monitoring: send /clear before auto-compact triggers
@@ -9572,6 +9604,10 @@ func (h *Home) performFinalShutdown(shutdownPool bool) tea.Cmd {
 		// Close hook watcher (Claude Code lifecycle hooks)
 		if h.hookWatcher != nil {
 			h.hookWatcher.Stop()
+		}
+		// Close OpenCode SSE watcher (issue #1614)
+		if h.sseWatcher != nil {
+			h.sseWatcher.Stop()
 		}
 		// Close storage watcher
 		if h.storageWatcher != nil {


### PR DESCRIPTION
Implements #1614: real-time status for OpenCode sessions from OpenCode's own event stream instead of tmux content sniffing.

## What
- Launch OpenCode with an agent-deck-allocated localhost `--port`, which makes the TUI bind its real HTTP server (verified live against OpenCode 1.1.28 and its OpenAPI doc: `Event.session.status` carries `{sessionID, status: {type: idle|busy|retry}}`).
- New `OpenCodeSSEWatcher` (`internal/session/opencode_sse.go`) mirrors the `StatusFileWatcher` pattern: one auto-reconnecting `/event` stream per running instance with exponential backoff, `/session/status` snapshot seeding so a connect mid-turn starts correct, and per-session busy aggregation so subagent sessions keep the instance green.
- SSE fast path in `UpdateStatus()` between the hook fast path and the tmux fallback, with a 30s freshness window refreshed by any stream traffic. A dropped stream ages out and control degrades to tmux content sniffing, the same layering the Claude hook path uses.
- TUI wiring in `backgroundStatusUpdate`: reconcile watcher connections against live OpenCode instances each tick, feed derived statuses, and stop the watcher with the other background workers.

## Mapping
`busy` -> running (green), `idle` -> waiting (yellow, or gray once acknowledged), `retry` -> running. Deviation from the issue plan: `retry` maps to running rather than waiting, because a provider-retry is still active work needing no user input.

## Safety and compatibility
- `[opencode] disable_sse_status = true` escape hatch for OpenCode builds that predate the top-level `--port` flag (launches without `--port`, sniffing keeps working as today).
- Custom launch commands pass through untouched and clear any stale stored port, so the watcher can never attach to a freed port reused by an unrelated process.
- Port restarts are handled: `Sync()` tears down and reconnects when an instance's port changes.
- CLI (`agent-deck list`) keeps its current tmux-based detection; the watcher runs in the TUI like the hook watcher.

## Tests
`internal/session/opencode_sse_test.go`: full stream lifecycle against an httptest SSE server (busy -> running, subagent aggregation, retry, `session.idle` -> waiting, teardown on `Sync(nil)`), snapshot seeding, instance-side freshness mapping, `--port` injection on fresh/resume launches, passthrough + stale-port clearing, and the config escape hatch. All pass sandboxed (`HOME=$(mktemp -d) ...`); the only failing tests in `internal/session` / `internal/ui` on this host (`TestForbidigo_*`, `TestGetJSONLPathChecked_*`, `TestIssue1421_*`, `TestIssue1595*`, `TestIssue1607_*`) fail identically on clean origin/main (local-environment issues).

Design follows the implementation plan contributed by zach-marto in #1614, including his file-level analysis of both codebases.

Closes #1614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster and more accurate OpenCode session status detection using live event updates.
  * OpenCode sessions now distinguish between running, waiting, and idle states with automatic fallback when live updates are unavailable.
  * Added an option to disable live status detection and use the existing status detection method instead.

* **Bug Fixes**
  * Improved status initialization for sessions already active when monitoring begins.
  * Added reconnection handling for temporary event-stream interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->