### PR TITLE
docs(skills): agent-deck-contributor skill — contributor-side mirror of the PR gate

### DIFF
--- a/.github/skills/agent-deck-contributor/SKILL.md
+++ b/.github/skills/agent-deck-contributor/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: agent-deck-contributor
+description: Contribute to agent-deck (github.com/asheshgoplani/agent-deck) the way the maintainer's intake gate and review machine expect. Use when opening an issue or PR against agent-deck, fixing an agent-deck issue, responding to an intake or review comment on an agent-deck PR, or preparing a contribution on a human's behalf. Covers the full loop: claim, implement, self-verify, open, respond to verdicts.
+metadata:
+  compatibility: "any agent (Claude, Codex, Gemini, or human); no agent-deck-specific tooling required"
+---
+
+# agent-deck contributor
+
+This skill is the contributor-side mirror of agent-deck's PR gate. The repo's intake
+check (`.github/workflows/pr-intake.yml`), its field contract (`.github/INTAKE.md`),
+and the maintainer's four-lens review machine are one spec read from the receiving
+side; this skill is the same spec read from the sending side. An agent that follows
+it passes intake on the first try and scores well on all four review lenses:
+**correctness, security, fit, and intent**.
+
+One principle before anything else: every field the gate requires is trivial for a
+legitimate human+agent pair and impossible for intent-less slop. The one thing that
+cannot be faked is a real human's ask. So the very first thing you capture, before
+any code, is **what your human actually asked for, in their words**. Keep the quote.
+It goes in the PR body verbatim.
+
+## Script path resolution
+
+This skill ships `scripts/self-check.sh`. Resolve it from the skill's own base
+directory (shown when the skill loads), not the project root:
+
+```bash
+SKILL_DIR="/path/shown/in/base-directory-line"   # e.g. <repo>/.github/skills/agent-deck-contributor
+"$SKILL_DIR/scripts/self-check.sh" pr-body.md
+```
+
+When working inside an agent-deck clone the path is
+`.github/skills/agent-deck-contributor/scripts/self-check.sh`.
+
+## Phase 1 — Claim and understand the issue
+
+1. **Capture the human ask first.** Write down, verbatim, what your human asked for
+   (one sentence is enough). If you are working from an issue with no direct human
+   instruction, quote the issue author's problem statement instead. This becomes the
+   `## What actually bothered you` section. Intake fails a PR whose intent section is
+   empty; it never fails an honest one-liner.
+2. **Reproduce before you touch code.** For bugs: build agent-deck, reproduce the
+   reported behavior, and save the capture (terminal output, log lines). The review
+   machine's intent lens asks "did the submitter supply real observed behavior, not
+   just claims?" — your reproduction is that evidence. If you cannot reproduce
+   reliably, say so honestly: "can't reproduce reliably, happens when ..." passes;
+   silence does not.
+3. **Comment on the issue to claim it** before starting, so the maintainer's fleet
+   can tell you if someone (human or agent) is already on it.
+4. **Check scope before committing effort:**
+   - Features go to a Discussion first; feature PRs that arrive as surprises take
+     longer, not shorter.
+   - agent-deck holds a lean-scope line: no net-new tool adapters or bolt-on UIs
+     without demonstrated demand. If your idea adds a new integration surface, open
+     a Discussion and get a yes before writing it.
+   - Anticipated diff over ~3000 added lines? Link an issue or Discussion agreeing
+     the shape first, or the gate flags it `needs-discussion`.
+   - You may have at most 5 open PRs on the repo at a time.
+   - Security issues go through the private advisory route in `SECURITY.md`, never
+     a public issue or PR.
+
+## Phase 2 — Implement to the bar
+
+1. **One problem per PR, scoped diff.** No unrelated churn, no drive-by refactors,
+   no formatting sweeps of untouched files. The fit lens flags diffs over ~400
+   changed lines as oversized; if your change is genuinely bigger, say in the PR
+   body what could split out and why it didn't.
+2. **Match the codebase style.** Read the surrounding package before writing. Go
+   code: standard library first, existing helpers over new ones, table-driven tests
+   like the neighbors have.
+3. **Write a test that FAILS without your change.** This is the centerpiece of the
+   correctness lens: the reviewer reverts your non-test hunks and re-runs your
+   tests — a test that still passes proves nothing. Write the test first, watch it
+   fail, then make it pass. `scripts/self-check.sh` automates this revert-check
+   locally.
+4. **Every changed hunk should be exercised by some test.** The correctness lens
+   spot-checks changed-lines coverage and names untested hunks as flags.
+5. **Run the exact CI sandbox invocation.** agent-deck tests must never run against
+   a real home directory (they can destroy live user data), and CI runs them
+   sandboxed. Use precisely:
+
+   ```bash
+   HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...
+   ```
+
+6. **Format and vet before every push:**
+
+   ```bash
+   gofmt -w $(git diff --name-only origin/main -- '*.go')
+   go vet ./...
+   ```
+
+   Lint CI treats formatting as a failure; the 2-second local pass saves a CI
+   round-trip.
+7. **Never touch `CHANGELOG.md`** — entries are added at landing time.
+8. **Hot paths need timing evidence.** If you touch `list`, `status`,
+   `session output`, startup, or the tmux layer, include simple before/after timing
+   (even `time agent-deck list` runs) in the Evidence section.
+9. **Avoid the tripwires** (details in `references/security-self-scan.md`):
+   - New or bumped dependencies from a community PR are an automatic
+     extra-scrutiny stop. If the fix truly needs a new module, justify it in the PR
+     body (why this module, why it's canonical, where it's used) and expect a
+     human gate. Never add a `replace` directive or a `GOPROXY` override.
+   - Anything under `.github/` never auto-merges; it always waits for the
+     maintainer personally. Keep workflow changes out of unrelated PRs.
+   - No `curl | bash`, no downloaded-and-executed tooling, no new outbound network
+     calls in production paths, no exec of shell-interpolated strings, no
+     world-writable file modes, no `InsecureSkipVerify`.
+
+## Phase 3 — Self-verify against the gate BEFORE opening
+
+Draft your PR body into a file (start from `references/pr-body-template.md`), then
+run the pre-open gate from the repo root:
+
+```bash
+.github/skills/agent-deck-contributor/scripts/self-check.sh pr-body.md
+```
+
+It mirrors, check for check, what the repo-side gate and review machine will do:
+gofmt/vet/build, sandboxed tests, the revert-check, diff-size and forbidden-path
+checks, the hidden-logic security sweep, and a lint of the PR body against the
+intake contract (required headings, exactly one AI-disclosure box, model named when
+AI helped, non-empty human intent, consistent gate marker).
+
+**Fix every FAIL before opening.** WARNs are judgment calls: resolve them or
+explain them in the PR body (a stated, honest imperfection passes review; a silent
+one becomes a flag). The full check-by-check mapping, with the exact fix for each,
+is in `references/gate-spec.md`.
+
+## Phase 4 — Open the PR
+
+1. Use `.github/PULL_REQUEST_TEMPLATE.md` verbatim — the intake Action parses the
+   body by exact `## ` headings. Fill every required section:
+   `What problem does this solve?`, `Why this change`, `User impact`, `Evidence`,
+   `AI disclosure`, `What actually bothered you`, `Checklist`.
+2. **AI disclosure:** check exactly one box, and if AI helped, name the model(s)
+   (e.g. `claude-opus-4-x`, `gpt-5-codex`). `unsure` is a valid answer; blank is
+   not. Disclosure is a quality signal that feeds a per-model track record — models
+   that land clean earn lighter-touch review over time. It is never a filter.
+3. **What actually bothered you:** paste the human ask you captured in Phase 1,
+   quoted. This is the first thing a reviewer reads.
+4. **Evidence, inline:** your reproduction capture, before/after behavior, the
+   sandboxed test-suite result, and the revert-check result ("reverting the fix
+   makes TestX fail: <one line of output>"). Real observed output, not claims;
+   mock-only proof is insufficient for user-visible changes.
+5. **End the body with the machine-readable marker** (last line, exact format):
+
+   ```
+   <!-- gate:ai=<human|assisted|authored> model=<name-or-unsure> intent=<yes|no> -->
+   ```
+
+   The visible sections are authoritative; the marker is a parse-stable
+   confirmation that speeds routing. Make it agree with the checkboxes.
+6. Check only the checklist boxes that are true. Leave "Allow edits from
+   maintainers" enabled so urgent fixes can be taken over the line for you.
+7. Do not mark anything `CRITICAL`/`URGENT`/`SECURITY` unless the body carries a
+   concrete reproduction — urgency language plus scanner-style output with no repro
+   is a named slop signal and gets deprioritized.
+
+## Phase 5 — Respond to verdicts
+
+Within about a day the PR gets a structured validation result. The loop from here:
+
+1. **Intake comment (`needs-info`):** the bot names the exact missing field in
+   machine-readable form. Edit the PR description — the check re-runs automatically
+   and the label flips. No new commit needed for body-only fixes.
+2. **Rank-up moves are the whole loop.** A `needs-work` verdict arrives with 1–3
+   concrete actions that upgrade the verdict. Do exactly those, nothing else, then
+   say so in a comment. needs-work is a loop with a re-review trigger, not a
+   rejection.
+3. **Verdicts are SHA-bound.** Every review verdict applies to one exact head SHA.
+   Any push voids it and triggers re-review — so batch your fixes into one push
+   rather than trickling commits, and never force-push over a reviewed SHA without
+   saying what changed.
+4. **Answer questions about the code.** Disclosed AI PRs are welcome on three
+   conditions, and the third is that you (or your human) can defend the change when
+   asked. The intent lens explicitly scores author understanding.
+5. **If the gate misfires on your good-faith PR**, say so plainly in a comment and
+   point at the evidence — the maintainer overrides bot mistakes by hand (there is
+   a `bad-gate` label for exactly this) and the heuristic gets tuned. The gate is
+   deliberately biased toward false-clean, so a wrong flag is rare and taken
+   seriously.
+6. **Silence is the only thing that auto-closes.** Any reply from you resets the
+   clock. If life intervenes, one comment keeps the PR open; a closed PR can be
+   reopened the moment you can add the missing piece.
+7. **If your diff is declined but the problem is real**, the fleet may reimplement
+   the intent with credit to you. A rejected diff is never a rejected idea — a
+   well-evidenced problem statement is the most valuable thing you can leave
+   behind.
+
+## Hard rules (never do)
+
+- Never open a PR with an empty or boilerplate `What actually bothered you`
+  section. One real, quoted human sentence.
+- Never claim AI-free authorship when a model wrote the code. Undisclosed
+  bulk-generated PRs get closed; disclosed AI PRs get equal standing.
+- Never run agent-deck tests against a real `$HOME` — always the sandbox
+  invocation above.
+- Never edit `CHANGELOG.md`; never fold `.github/` changes into an unrelated PR.
+- Never add or bump a dependency without stating why in the PR body; never add
+  `replace` directives or proxy overrides.
+- Never introduce `curl | bash`, exec-of-constructed-strings, new outbound network
+  calls in production paths, world-writable modes, weak crypto, or non-ASCII
+  homoglyph/invisible characters in code.
+- Never use urgency language (`CRITICAL`/`SECURITY`) without a concrete repro;
+  real vulnerabilities go through `SECURITY.md` privately.
+- Never exceed 5 open PRs; never open a >3000-added-line PR without a linked
+  issue or Discussion.
+- Never check a checklist box that is not true.
+- Never expect a bot to merge: merges are always human, and a green gate is
+  necessary but never sufficient.
+
+## Traceability matrix
+
+Every rule above traces to a named check on the maintainer's side. If the gate
+changes, this skill changes with it — they are one spec.
+
+| Skill rule | Gate-side source |
+|---|---|
+| Required `## ` headings, filled | `pr-intake.yml` check 1 (missing-headings) / `INTAKE.md` §PR body contract |
+| Exactly one AI-disclosure box | `pr-intake.yml` check 2 (checked-boxes == 1) |
+| Non-empty human intent, quote the ask | `pr-intake.yml` check 3 (meaningful intent) / gate design: human-provenance is the anti-slop asymmetry |
+| Model named when AI helped; `unsure` valid | `INTAKE.md` marker contract; review-machine model provenance ledger (per-model track record) |
+| Gate marker as last line, consistent | `INTAKE.md` §Machine-readable marker; `pr-intake.yml` marker parse |
+| Test fails without the change (revert-check) | review machine, correctness lens: revert-check centerpiece |
+| Changed hunks exercised by tests | review machine, correctness lens: diff-coverage spot-check |
+| Exact sandbox test invocation | CONTRIBUTING §What makes a PR land fast; security gates: sandbox-everything rule (Gate 6) |
+| gofmt + go vet before push | maintainer shipping rule (lint CI fails on formatting) |
+| Scoped diff; ~400-line oversize flag | review machine, fit lens: oversized-pr flag |
+| >3000 added lines needs linked discussion | intake gate: giant-undiscussed-diff check; `INTAKE.md` house rules |
+| Lean-scope check before new adapters/UIs | review machine, fit lens: lean-scope line |
+| Real repro/evidence, mock-only insufficient | review machine, intent lens: behavior-evidence test; `INTAKE.md` Evidence row |
+| No urgency language without repro | intake gate: urgency-scanner-slop check |
+| Dependency changes justified; no replace/GOPROXY | security gates, Gate 1 (dependency vet) + Gate 6 red flags |
+| `.github/` changes always human-gated | security gates, Gate 2 |
+| Hidden-logic self-scan (network/exec/homoglyph/perms/time-bomb/crypto) | security gates, Gate 3 sweep + Gate 6 red flags (author-side version: `references/security-self-scan.md`) |
+| No CHANGELOG edits; ≤5 open PRs | `INTAKE.md` house rules; CONTRIBUTING house rules |
+| Hot-path timing evidence | PR template checklist (hot-path row); CONTRIBUTING rule 6 |
+| SHA-bound verdicts; push = re-review | review machine: SHA binding invariant |
+| Rank-up loop on needs-work | review machine: rank-up doctrine (needs-work is a loop, not a wall) |
+| Misfire → say so, human overrides | gate design: `bad-gate` override; false-clean bias |
+| Silence-only close; reply resets clock | gate design: reaction ladder |
+| Merges always human | branch protection + CODEOWNERS; every gate necessary-not-sufficient |
+
+## References
+
+- `references/gate-spec.md` — every intake check and review criterion, with the
+  exact fix for each; the machine-readable companion to `.github/INTAKE.md`.
+- `references/pr-body-template.md` — one complete example of a passing PR body,
+  including the gate marker block.
+- `references/security-self-scan.md` — the security sweeps rewritten as
+  author-side greps you run on your own diff.
+- Repo-side: `.github/INTAKE.md` (field contract), `CONTRIBUTING.md` (policy),
+  `.github/PULL_REQUEST_TEMPLATE.md` (the body you fill).

--- a/.github/skills/agent-deck-contributor/references/gate-spec.md
+++ b/.github/skills/agent-deck-contributor/references/gate-spec.md
@@ -1,0 +1,99 @@
+# gate-spec.md — every check your PR will face, and the exact fix
+
+> Machine-readable companion to [`.github/INTAKE.md`](../../../INTAKE.md). Field
+> names and heading strings are exact; the intake Action parses them literally.
+> Layers run in order: **intake gate** (instant, on open/edit) → **review
+> machine** (four lenses, within ~a day) → **security gates** (merge time) →
+> **human merge** (always). A green earlier layer is necessary, never sufficient.
+
+## Layer 1 — intake gate (`.github/workflows/pr-intake.yml`, instant)
+
+Observe-only today: labels + one kind comment, never closes on content. Editing
+the PR description re-runs it automatically.
+
+| Check | Condition that fails it | Label | Exact fix |
+|---|---|---|---|
+| Required headings | any of `## What problem does this solve?`, `## Why this change`, `## User impact`, `## AI disclosure`, `## What actually bothered you`, `## Checklist` absent | `needs-info` | Use `.github/PULL_REQUEST_TEMPLATE.md` verbatim; headings must match character-for-character at `## ` level |
+| AI-disclosure box | zero or 2+ checked `- [x]` boxes inside the `## AI disclosure` section | `needs-info` | Check exactly one of Human-written / AI-assisted / AI-authored |
+| Human intent | `## What actually bothered you` empty after stripping HTML comments and checkbox lines | `needs-info` | One real sentence. Agent-opened PR: quote the human's ask verbatim. This is the one field intake cannot accept blank |
+| Gate marker (informational) | trailing `<!-- gate:ai=... model=... intent=... -->` missing or placeholder | none (slows routing) | Last line of the body, real values, agreeing with the visible checkboxes |
+| Clean | none of the above | `intake:clean` | — fast-lane into validation |
+
+Marker grammar: `<!-- gate:ai=<human|assisted|authored> model=<name-or-unsure> intent=<yes|no> -->`
+(`model=none` when `ai=human`; visible sections are authoritative on any disagreement).
+
+## Layer 2 — review machine (four lenses, ~a day)
+
+Each lens scores 0–10 with confidence-tiered flags; the verdict is `good`
+(validate-and-merge lane), `needs-work` (arrives with 1–3 rank-up moves — do
+exactly those, re-review triggers on your push), or `slop` (kind decline; only
+genuine no-human-behind-it submissions).
+
+### Cheap mechanical pre-gate (before any lens spends compute)
+
+| Check | Condition | Fix |
+|---|---|---|
+| Template gutted | no problem statement, no intent, no evidence content at all | fill the template; see Layer 1 |
+| Giant undiscussed diff | additions > 3000 AND no linked issue/Discussion | open a Discussion, agree the shape, link it — the check clears |
+| Urgency-scanner slop | `CRITICAL`/`URGENT`/`SECURITY` language + scanner-style output + zero repro | add a concrete reproduction, drop the urgency language; real vulns → `SECURITY.md` privately |
+
+### Correctness lens
+
+| Criterion | What it does | How you pre-pass it |
+|---|---|---|
+| Build + test | applies your diff, builds, runs touched packages sandboxed | `self-check.sh` runs the identical invocation: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` |
+| **Revert-check (centerpiece)** | reverts your non-test hunks and re-runs your tests; a test that still passes proves nothing | write the test first, watch it fail, then fix; `self-check.sh` automates this and put the result in `## Evidence` |
+| Diff-coverage spot-check | which changed hunks are exercised by ANY test; untested hunks become named flags | every changed hunk behind at least one test, or say in the body why a hunk is untestable |
+
+### Security lens (diff-scoped security gates)
+
+| Criterion | Trips on | Fix |
+|---|---|---|
+| Dependency vet (Gate 1) | go.mod/go.sum touched by a community PR; any `replace` directive or GOPROXY override (automatic stop) | avoid new deps when stdlib suffices; if truly needed: canonical upstream, pinned version, justify in body, expect a human gate |
+| `.github/` human gate (Gate 2) | any change under `.github/` | never auto-merges — keep out of unrelated PRs and expect the maintainer personally |
+| Hidden-logic sweep (Gate 3) | network calls, constructed exec, non-ASCII/homoglyph/invisible chars, env exfil, broad file perms, time-bombs, weak crypto in added lines | run `references/security-self-scan.md` on your own diff before opening |
+
+### Fit lens
+
+| Criterion | Trips on | Fix |
+|---|---|---|
+| Lean-scope line | net-new tool adapters / bolt-on UIs without demonstrated demand | Discussion first; get a yes before building |
+| Overlap | duplicates existing code or a recent merge | check `git log --oneline -30` on main and existing helpers before writing |
+| Oversized PR | over ~400 changed lines | split what can split; otherwise name in the body what could split out and why it didn't |
+| Style match | code that ignores the surrounding package's conventions | read neighbors first; table-driven tests, existing helpers |
+| CHANGELOG edit | any change to CHANGELOG.md | drop it; entries are added at landing |
+
+### Intent lens (slop-vs-genuine)
+
+| Criterion | Question asked | How you pre-pass it |
+|---|---|---|
+| Disclosure honesty | AI help declared? model named? | one checked box + model name (`unsure` is valid); undisclosed bulk-generation gets closed, disclosed AI gets equal standing |
+| Author understanding | does the body show you understand your own change and could defend it? | write `## Why this change` yourself; answer review questions substantively |
+| Behavior evidence | real observed behavior (repro, logs, before/after), not just claims? | reproduction capture + before/after output in `## Evidence`; mock-only proof is insufficient for user-visible changes |
+| Human need | is there a real human ask behind this? | the quoted ask in `## What actually bothered you` |
+
+## Layer 3 — house rules (enforced across layers)
+
+| Rule | Number | Source |
+|---|---|---|
+| Open-PR cap | max 5 per author | CONTRIBUTING / INTAKE house rules |
+| Big-diff discussion | > 3000 added lines needs linked issue/Discussion | intake pre-gate |
+| One problem per PR | 1 | fit lens |
+| CHANGELOG untouched | always | house rules |
+| Hot-path timing | before/after timing when touching list, status, session output, startup, tmux layer | PR template checklist |
+| gofmt + go vet | before every push | lint CI fails on formatting |
+
+## Layer 4 — verdict protocol (how the loop behaves)
+
+- **SHA-bound:** every verdict binds to one exact head SHA; any push voids it and
+  triggers re-review. Batch fixes into one push.
+- **Rank-up:** `needs-work` always names 1–3 concrete upgrading actions. Doing
+  exactly those and saying so is the fastest path to `good`.
+- **Silence-only close:** nothing closes on content; only ~2 weeks of author
+  silence on a `needs-*` PR closes it, and reopening is always available. Any
+  reply resets the clock.
+- **Misfire path:** the gate is biased toward false-clean; if it wrongs a
+  good-faith PR, say so with evidence — humans override (`bad-gate`) and the
+  heuristic gets tuned.
+- **Merge:** two independent AI reviews clean AND CI green AND the human
+  maintainer lands it. No bot merges. Ever.

--- a/.github/skills/agent-deck-contributor/references/pr-body-template.md
+++ b/.github/skills/agent-deck-contributor/references/pr-body-template.md
@@ -1,0 +1,85 @@
+# pr-body-template.md — one complete passing PR body
+
+> Copy the structure exactly: the intake gate parses `## ` headings
+> character-for-character, and the last line must be the gate marker. This
+> example is a realistic bug-fix PR; replace the content, keep every heading.
+
+```markdown
+## What problem does this solve?
+
+`agent-deck list` keeps showing `running` for OpenCode sessions up to 40s after
+the session actually finished, so users attach to dead sessions. Fixes #1614.
+
+## Why this change
+
+Status for OpenCode came from tmux pane-content sniffing, which only updates on
+the next poll tick. OpenCode exposes an authoritative SSE status endpoint; this
+switches the OpenCode preset to consume it and falls back to sniffing only when
+the endpoint is unreachable. I tried shortening the poll interval first, but
+that raised idle CPU for every session type to fix one tool — scoped this to the
+OpenCode preset instead.
+
+## User impact
+
+OpenCode sessions show the correct status within ~1s of a state change. No
+change for any other tool preset.
+
+## Evidence
+
+Reproduction on main (v1.9.71), then with this branch:
+
+    # before: session exited at 14:02:11, list still shows running
+    $ agent-deck list
+    opencode-fix   running   ~/src/app      # 14:02:49
+
+    # after: same scenario
+    $ agent-deck list
+    opencode-fix   idle      ~/src/app      # 14:02:12
+
+Sandboxed suite: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` → ok, all packages.
+
+Revert-check: with the non-test hunks reverted, `TestOpenCodeStatusFromSSE`
+fails as expected (`status_test.go:88: got "running", want "idle"`), so the
+test proves the fix.
+
+## AI disclosure
+
+- [x] AI-authored (a model wrote most of it)
+
+**Model(s), if AI helped:** claude-opus-4-x
+
+**Prompt / session log (optional):** —
+
+## What actually bothered you
+
+My human asked: "opencode sessions always show running in the deck even after
+they finish — can you fix the status so I stop attaching to dead sessions?"
+
+## Checklist
+
+- [x] Targeted diff: one problem, no unrelated changes
+- [x] Tests added or updated for new behavior
+- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
+- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
+- [x] CHANGELOG.md untouched (entries are added at landing)
+- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
+- [x] "Allow edits from maintainers" is enabled
+
+<!-- gate:ai=authored model=claude-opus-4-x intent=yes -->
+```
+
+## Rules the example demonstrates
+
+1. **Headings verbatim** — all six required sections present, exact `## ` text.
+2. **Exactly one AI-disclosure box checked**, model named (`unsure` is also
+   valid; blank is not; `model=none` only when `ai=human`).
+3. **Intent is a real quoted human ask** — the one field intake cannot accept
+   blank. An agent with a real user always has this.
+4. **Evidence is observed output**, including the revert-check result — not
+   claims, not mock-only proof.
+5. **Checklist boxes only where true.** An unchecked box with an honest note
+   beats a false check every time.
+6. **Marker is the last line**, real values, agreeing with the checkboxes.
+7. **Timing box checked because `status` is a hot path** — the before/after
+   capture doubles as the timing evidence; for perf-sensitive diffs add
+   explicit `time agent-deck list` runs.

--- a/.github/skills/agent-deck-contributor/references/security-self-scan.md
+++ b/.github/skills/agent-deck-contributor/references/security-self-scan.md
@@ -1,0 +1,132 @@
+# security-self-scan.md — the maintainer's security sweeps, author-side
+
+> Before a merge wave, the maintainer's pipeline runs a hidden-logic sweep and a
+> set of red-flag checks over community diffs. This file is the same sweep
+> rewritten as greps you run on your own branch before opening the PR, so
+> nothing in your diff surprises the security lens. `scripts/self-check.sh`
+> automates most of these; this is the full manual list with the reasoning.
+>
+> All commands assume: `MB=$(git merge-base HEAD origin/main)`.
+
+Helper — added lines only:
+
+```bash
+added() { git diff "$MB" HEAD -- "$@" | grep '^+' | grep -v '^+++' | sed 's/^+//'; }
+```
+
+## 1. Invisible characters and homoglyphs (automatic reject)
+
+Zero-width, RTL-override, and look-alike Unicode in code are backdoor tooling.
+Legit em-dashes in comments and glyphs inside quoted UI strings are fine —
+confirm each hit is one of those.
+
+```bash
+added | perl -ne 'print "$.: $_" if /[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2060}\x{FEFF}]/'   # must print nothing
+added -- '*.go' | perl -ne 'print "$.: $_" if /[^\x00-\x7F]/'                                  # confirm each hit
+```
+
+## 2. Downloaded-and-executed code (automatic stop-for-human)
+
+```bash
+added | grep -nE 'curl[^|;&]*\|[[:space:]]*(ba|z)?sh|wget[^|;&]*\|[[:space:]]*sh'   # must print nothing
+added | grep -nE 'base64 (-d|--decode)'                                             # confirm each hit
+```
+
+Documentation that quotes a hunted pattern (like this file) is the
+confirmed-benign case; `self-check.sh` scopes its automated pattern scans to
+non-markdown code lines for exactly that reason.
+
+## 3. Network calls in production paths
+
+No unexpected outbound network in non-test code. Test fixtures (`example.com`)
+and Unix-socket tmux operations are fine; anything else needs a sentence of
+justification in the PR body, and the destination must be user-configured, never
+hardcoded.
+
+```bash
+added -- '*.go' ':!*_test.go' | grep -nE 'net\.Dial|http\.(Get|Post|NewRequest)|websocket|smtp\.'
+```
+
+## 4. Exec of constructed strings
+
+`exec.Command` on a built string is the classic injection surface. Arguments
+must be validated and passed via argv or STDIN — never a shell-interpolated
+string. Paths get shell-quoted and traversal-guarded (`..` and separators
+rejected).
+
+```bash
+added -- '*.go' | grep -nE 'exec\.Command(Context)?\([^)]*(\+|fmt\.Sprintf)'
+added -- '*.go' | grep -nE '"(ba|z)?sh",[[:space:]]*"-c"'    # read each in full
+```
+
+## 5. Environment / secret exfiltration
+
+`os.Getenv` for PATH, documented feature flags, and test shims are fine. Reads
+of tokens/keys/credentials that then travel toward any network call are not.
+
+```bash
+added -- '*.go' | grep -nE 'os\.Getenv\([^)]*(TOKEN|KEY|SECRET|CRED|AUTH)'
+```
+
+## 6. File permissions
+
+Secrets and control directories are `0600`/`0700`. World-writable modes and
+permission-broadening `Chmod` calls get rejected.
+
+```bash
+added | grep -nE '0o?777|0o?666'          # must print nothing (or justify each)
+added -- '*.go' | grep -nE 'Chmod'        # confirm each never broadens
+```
+
+## 7. Time-bombs and weak crypto
+
+Hardcoded-date gates are only acceptable as fixed clocks inside `_test.go`.
+
+```bash
+added -- '*.go' ':!*_test.go' | grep -nE 'time\.Now\(\)\.Unix\(\)[[:space:]]*>[[:space:]]*[0-9]{6,}'
+added -- '*.go' | grep -nE 'InsecureSkipVerify|crypto/(md5|rc4|des)'
+```
+
+## 8. Config injection
+
+Code that writes user config (e.g. `config.toml`) must source entries only from
+the user's own registry — never inject a hardcoded external server, URL, or
+command.
+
+```bash
+added -- '*.go' | grep -nE '(config\.toml|WriteConfig|SaveUserConfig)' | grep -nE 'https?://'
+```
+
+## 9. Dependency hygiene (if go.mod/go.sum changed at all)
+
+A community PR that adds or bumps a dependency is unusual and gets extra
+scrutiny by policy. Pre-answer the questions: why does this need a new module?
+is the path the real, canonical upstream (no typosquats, no look-alike orgs)?
+is it pinned? is it actually used?
+
+```bash
+git diff "$MB" HEAD -- go.mod | grep -E '^\+\s*replace\s'      # must print nothing — automatic stop
+added | grep -n 'GOPROXY'                                       # must print nothing — automatic stop
+HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go mod verify   # "all modules verified"
+# optional but appreciated as PR evidence:
+HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= govulncheck ./...
+```
+
+## 10. Workflow safety (if you must touch `.github/` — separate PR, human-gated)
+
+- Never introduce or widen `pull_request_target` / `workflow_run` /
+  `issue_comment` triggers; never check out PR-head code under an elevated token.
+- Never interpolate attacker-controlled fields (`${{ github.event.pull_request.title }}`
+  etc.) inside a `run:` script — pass via `env:` and reference as quoted shell vars.
+- Third-party actions (anything not `actions/*` or `github/*`) are pinned by full
+  commit SHA, never a mutable tag; converting a SHA pin back to a tag is rejected.
+- No `permissions:` block granting `write` to a job that runs untrusted code.
+- No new outbound `curl`/`wget` to external hosts.
+
+## Reading the results
+
+Every hit is either **removed**, **confirmed-benign with one sentence in the PR
+body saying why** ("the `http.Get` is the new SSE status endpoint, host comes
+from the user's session config"), or it becomes a review flag against your PR.
+The security lens reads each hit in full — pre-explaining costs one sentence;
+being discovered costs a review round.

--- a/.github/skills/agent-deck-contributor/scripts/self-check.sh
+++ b/.github/skills/agent-deck-contributor/scripts/self-check.sh
@@ -89,9 +89,17 @@ if [ -n "$GO_CHANGED" ] && [ "$HAVE_GO" = 1 ]; then
   if OUT=$(sandboxed go test $PKGS 2>&1); then PASS sandboxed-tests "$PKGS"
   else FAIL sandboxed-tests "$(echo "$OUT" | grep -E '^(--- FAIL|FAIL|# )' | head -5 | tr '\n' ' | ')"; fi
 
-  # 5. a test exists for production changes
+  # 5. a test exists for production changes, in a package you actually touched
   if [ -n "$GO_PROD_CHANGED" ] && [ -z "$GO_TESTS_CHANGED" ]; then
     WARN test-added "production .go changed but no *_test.go changed — new behavior needs a test that fails without it"
+  elif [ -n "$GO_PROD_CHANGED" ] && [ -n "$GO_TESTS_CHANGED" ]; then
+    PROD_DIRS=$(printf '%s\n' "$GO_PROD_CHANGED" | xargs -n1 dirname | sort -u)
+    TEST_DIRS=$(printf '%s\n' "$GO_TESTS_CHANGED" | xargs -n1 dirname | sort -u)
+    if [ -n "$(comm -12 <(printf '%s\n' "$PROD_DIRS") <(printf '%s\n' "$TEST_DIRS"))" ]; then
+      PASS test-added
+    else
+      WARN test-added "changed tests live only in packages your production change didn't touch — cover the changed packages"
+    fi
   elif [ -n "$GO_TESTS_CHANGED" ]; then
     PASS test-added
   fi
@@ -223,7 +231,11 @@ else
     case "$LINE" in
       *authored*) AI_KIND=authored ;; *assisted*) AI_KIND=assisted ;; *human*) AI_KIND=human ;;
     esac
-    PASS ai-disclosure "$AI_KIND"
+    if [ -n "$AI_KIND" ]; then
+      PASS ai-disclosure "$AI_KIND"
+    else
+      FAIL ai-disclosure "checked box not recognized — use the template's Human-written / AI-assisted / AI-authored lines"
+    fi
   elif [ "$BOXES" = 0 ]; then
     FAIL ai-disclosure "no box checked — check exactly one (Human-written / AI-assisted / AI-authored)"
   else
@@ -249,8 +261,11 @@ else
     FAIL gate-marker "marker still has template placeholders — fill in real values"
   else
     M_AI=$(printf '%s' "$MARKER" | sed -E 's/.*gate:ai=([^ ]+).*/\1/')
+    LAST_LINE=$(printf '%s\n' "$BODY" | grep -v '^[[:space:]]*$' | tail -1)
     if [ -n "$AI_KIND" ] && [ "$M_AI" != "$AI_KIND" ]; then
       FAIL gate-marker "marker says ai=$M_AI but the checked box says $AI_KIND — make them agree (visible sections are authoritative)"
+    elif [ "$LAST_LINE" != "$MARKER" ]; then
+      WARN gate-marker "marker present but not the last line of the body — move it to the very end"
     else
       PASS gate-marker "$MARKER"
     fi

--- a/.github/skills/agent-deck-contributor/scripts/self-check.sh
+++ b/.github/skills/agent-deck-contributor/scripts/self-check.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# self-check.sh — agent-deck contributor pre-open gate.
+#
+# Runs, on your own branch and PR-body draft, the same checks the repo-side
+# intake gate (.github/workflows/pr-intake.yml + .github/INTAKE.md) and the
+# maintainer's review machine will run. Fix every FAIL before opening the PR;
+# resolve or explain every WARN in the PR body.
+#
+# Usage:   scripts/self-check.sh [pr-body.md]
+#          (run from anywhere inside the agent-deck repo)
+# Env:     BASE_REF=origin/main   comparison base
+#          FULL_TESTS=1           run the whole suite, not just touched packages
+#          LINKED_ISSUE=<n|url>   set when a >3000-line diff has an agreed issue/Discussion
+#          SKIP_REVERT_CHECK=1    skip the revert-check (e.g. pure test-infra PRs)
+#
+# Needs: git, grep, awk, perl. Go checks are skipped automatically on non-Go diffs.
+# Exit 0 = no FAIL.
+
+set -u
+
+BODY_FILE="${1:-pr-body.md}"
+BASE_REF="${BASE_REF:-origin/main}"
+
+pass=0; fail=0; warn=0; skip=0
+PASS() { printf 'PASS  %-24s %s\n' "$1" "${2:-}"; pass=$((pass+1)); }
+FAIL() { printf 'FAIL  %-24s %s\n' "$1" "${2:-}"; fail=$((fail+1)); }
+WARN() { printf 'WARN  %-24s %s\n' "$1" "${2:-}"; warn=$((warn+1)); }
+SKIP() { printf 'skip  %-24s %s\n' "$1" "${2:-}"; skip=$((skip+1)); }
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "not inside a git repo"; exit 2; }
+cd "$ROOT" || exit 2
+MB=$(git merge-base HEAD "$BASE_REF" 2>/dev/null) || { echo "no merge-base with $BASE_REF — run: git fetch origin main"; exit 2; }
+
+CHANGED_ALL=$(git diff --name-only "$MB" HEAD)
+if [ -z "$CHANGED_ALL" ]; then echo "no changes vs $BASE_REF — nothing to check"; exit 2; fi
+GO_CHANGED=$(git diff --name-only --diff-filter=d "$MB" HEAD -- '*.go')
+GO_TESTS_CHANGED=$(git diff --name-only --diff-filter=d "$MB" HEAD -- '*_test.go')
+GO_PROD_CHANGED=$(printf '%s\n' "$GO_CHANGED" | grep -v '_test\.go$' || true)
+
+ADDED_LINES=$(git diff "$MB" HEAD | grep '^+' | grep -v '^+++' | sed 's/^+//')
+# Pattern scans read added CODE lines only: documentation (*.md) legitimately
+# quotes the very patterns this sweep hunts, and this script necessarily
+# contains its own regexes — both are excluded. The invisible-chars check
+# still covers every file, and .github/ changes are human-gated regardless.
+SELF_REL=".github/skills/agent-deck-contributor/scripts/self-check.sh"
+ADDED_CODE=$(git diff "$MB" HEAD -- . ':!*.md' ":!$SELF_REL" | grep '^+' | grep -v '^+++' | sed 's/^+//')
+
+HAVE_GO=1
+command -v go >/dev/null 2>&1 || HAVE_GO=0
+
+# Sandbox: throwaway HOME + cleared XDG, but keep Go caches so runs stay fast.
+SANDBOX_HOME=$(mktemp -d)
+GOMODCACHE_SAVED=""; GOCACHE_SAVED=""
+if [ "$HAVE_GO" = 1 ]; then
+  GOMODCACHE_SAVED=$(go env GOMODCACHE); GOCACHE_SAVED=$(go env GOCACHE)
+fi
+sandboxed() {
+  HOME="$SANDBOX_HOME" XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= CLAUDE_CONFIG_DIR= \
+    GOMODCACHE="$GOMODCACHE_SAVED" GOCACHE="$GOCACHE_SAVED" "$@"
+}
+cleanup() { rm -rf "$SANDBOX_HOME" 2>/dev/null; }
+trap cleanup EXIT
+
+echo "== agent-deck contributor self-check =="
+echo "   base: $BASE_REF ($(git rev-parse --short "$MB"))   body: $BODY_FILE"
+echo
+
+# ---------------------------------------------------------------- code checks
+if [ -n "$GO_CHANGED" ] && [ "$HAVE_GO" = 1 ]; then
+  # 1. gofmt — lint CI fails on formatting.
+  UNFMT=$(gofmt -l $GO_CHANGED 2>/dev/null)
+  if [ -z "$UNFMT" ]; then PASS gofmt
+  else FAIL gofmt "run: gofmt -w $(echo $UNFMT | tr '\n' ' ')"; fi
+
+  # 2. go vet
+  if OUT=$(sandboxed go vet ./... 2>&1); then PASS go-vet
+  else FAIL go-vet "$(echo "$OUT" | head -3 | tr '\n' ' | ')"; fi
+
+  # 3. go build
+  if OUT=$(sandboxed go build ./... 2>&1); then PASS go-build
+  else FAIL go-build "$(echo "$OUT" | head -3 | tr '\n' ' | ')"; fi
+
+  # 4. sandboxed tests (CI invocation; touched packages by default, FULL_TESTS=1 for all)
+  if [ "${FULL_TESTS:-0}" = 1 ]; then
+    PKGS="./..."
+  else
+    PKGS=$(printf '%s\n' "$GO_CHANGED" | xargs -n1 dirname | sort -u | sed 's|^|./|' | tr '\n' ' ')
+  fi
+  if OUT=$(sandboxed go test $PKGS 2>&1); then PASS sandboxed-tests "$PKGS"
+  else FAIL sandboxed-tests "$(echo "$OUT" | grep -E '^(--- FAIL|FAIL|# )' | head -5 | tr '\n' ' | ')"; fi
+
+  # 5. a test exists for production changes
+  if [ -n "$GO_PROD_CHANGED" ] && [ -z "$GO_TESTS_CHANGED" ]; then
+    WARN test-added "production .go changed but no *_test.go changed — new behavior needs a test that fails without it"
+  elif [ -n "$GO_TESTS_CHANGED" ]; then
+    PASS test-added
+  fi
+
+  # 6. revert-check — your changed tests must FAIL on the base without your fix.
+  #    (Mirrors the correctness lens: revert the core hunks, re-run the tests.)
+  if [ -n "$GO_PROD_CHANGED" ] && [ -n "$GO_TESTS_CHANGED" ] && [ "${SKIP_REVERT_CHECK:-0}" != 1 ]; then
+    WT=$(mktemp -d)/wt
+    if git worktree add -q "$WT" "$MB" 2>/dev/null; then
+      RC_OK=1
+      for f in $GO_TESTS_CHANGED; do
+        mkdir -p "$WT/$(dirname "$f")"; cp "$f" "$WT/$f"
+      done
+      RC_PKGS=$(printf '%s\n' "$GO_TESTS_CHANGED" | xargs -n1 dirname | sort -u | sed 's|^|./|' | tr '\n' ' ')
+      if OUT=$( cd "$WT" && sandboxed go test $RC_PKGS 2>&1 ); then
+        FAIL revert-check "your tests still PASS without your change — they prove nothing; make at least one fail on base"
+        RC_OK=0
+      else
+        if echo "$OUT" | grep -q 'build failed\|cannot find\|undefined:'; then
+          WARN revert-check "tests do not compile on base (new symbols) — acceptable, but note it in Evidence"
+        else
+          PASS revert-check "tests fail without the change, as they should"
+        fi
+      fi
+      git worktree remove -f "$WT" 2>/dev/null; rm -rf "$(dirname "$WT")" 2>/dev/null
+      : "$RC_OK"
+    else
+      WARN revert-check "could not create base worktree — run manually: revert non-test hunks, re-run tests, expect failure"
+    fi
+  elif [ "${SKIP_REVERT_CHECK:-0}" = 1 ]; then
+    SKIP revert-check "SKIP_REVERT_CHECK=1"
+  fi
+elif [ -n "$GO_CHANGED" ]; then
+  WARN go-toolchain "Go not installed — gofmt/vet/build/test/revert checks NOT run"
+else
+  SKIP go-checks "no .go files changed"
+fi
+
+# ------------------------------------------------------------- diff hygiene
+ADD=$(git diff --numstat "$MB" HEAD | awk '{a+=$1} END {print a+0}')
+DEL=$(git diff --numstat "$MB" HEAD | awk '{d+=$2} END {print d+0}')
+TOTAL=$((ADD + DEL))
+if [ "$ADD" -gt 3000 ] && [ -z "${LINKED_ISSUE:-}" ]; then
+  FAIL diff-size "+$ADD lines with no linked issue/Discussion — gate flags this needs-discussion; agree the shape first (or set LINKED_ISSUE=<n>)"
+elif [ "$TOTAL" -gt 400 ]; then
+  WARN diff-size "+$ADD/-$DEL — over ~400 changed lines review quality measurably degrades; split what can split, or justify the size in the PR body"
+else
+  PASS diff-size "+$ADD/-$DEL"
+fi
+
+if echo "$CHANGED_ALL" | grep -qx 'CHANGELOG.md'; then
+  FAIL forbidden-paths "CHANGELOG.md is edited — entries are added at landing time; drop it from the diff"
+else
+  PASS no-changelog
+fi
+if echo "$CHANGED_ALL" | grep -q '^\.github/'; then
+  WARN dot-github ".github/ changes never auto-merge (human security gate) — keep them out of unrelated PRs"
+fi
+if echo "$CHANGED_ALL" | grep -qE '^go\.(mod|sum)$'; then
+  WARN dependency-change "go.mod/go.sum touched — community dependency changes get extra scrutiny; justify the module in the PR body"
+  if [ "$HAVE_GO" = 1 ]; then
+    if OUT=$(sandboxed go mod verify 2>&1) && echo "$OUT" | grep -q 'all modules verified'; then
+      PASS go-mod-verify
+    else
+      FAIL go-mod-verify "$(echo "$OUT" | head -2 | tr '\n' ' | ')"
+    fi
+  fi
+  if git diff "$MB" HEAD -- go.mod | grep -qE '^\+\s*replace\s'; then
+    FAIL replace-directive "a 'replace' directive is an automatic stop-for-human — remove it"
+  fi
+fi
+if printf '%s\n' "$ADDED_CODE" | grep -q 'GOPROXY'; then
+  FAIL goproxy-override "GOPROXY/module-proxy override introduced — automatic stop-for-human; remove it"
+fi
+
+# --------------------------------------------------- hidden-logic self-scan
+# Author-side version of the maintainer's hidden-logic sweep (see
+# references/security-self-scan.md for the full manual list). ADDED_LINES and
+# ADDED_CODE are defined near the top of the script.
+scan_hits() { printf '%s\n' "$ADDED_CODE" | grep -nE "$1" | head -3; }
+
+HITS=$(printf '%s\n' "$ADDED_LINES" | perl -ne 'print if /[\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2060}\x{FEFF}]/' | head -3)
+if [ -n "$HITS" ]; then FAIL invisible-chars "zero-width/RTL-override characters in added lines — remove them"; else PASS invisible-chars; fi
+
+HITS=$(scan_hits 'curl[^|;&]*\|[[:space:]]*(ba|z)?sh|wget[^|;&]*\|[[:space:]]*sh')
+if [ -n "$HITS" ]; then FAIL curl-pipe-sh "curl|bash / wget|sh introduced — automatic stop-for-human: $HITS"; else PASS curl-pipe-sh; fi
+
+HITS=$(scan_hits '0o?777|0o?666')
+if [ -n "$HITS" ]; then WARN file-perms "world-writable mode in added lines — secrets/control dirs need 0600/0700: $HITS"; fi
+
+HITS=$(scan_hits 'InsecureSkipVerify|crypto/(md5|rc4|des)')
+if [ -n "$HITS" ]; then WARN weak-crypto "weak crypto / TLS-verify bypass in added lines — confirm or remove: $HITS"; fi
+
+HITS=$(scan_hits 'time\.Now\(\)\.Unix\(\)[[:space:]]*>[[:space:]]*[0-9]{6,}')
+if [ -n "$HITS" ]; then WARN time-bomb "literal-timestamp gate in added code — only OK as a fixed clock inside _test.go: $HITS"; fi
+
+PROD_ADDED=$(git diff "$MB" HEAD -- '*.go' ':!*_test.go' | grep '^+' | grep -v '^+++' | sed 's/^+//')
+HITS=$(printf '%s\n' "$PROD_ADDED" | grep -nE 'net\.Dial|http\.(Get|Post)\(|websocket|smtp\.' | head -3)
+if [ -n "$HITS" ]; then WARN network-calls "new network calls in production paths — the security lens reads each one; justify in the PR body: $HITS"; fi
+HITS=$(printf '%s\n' "$PROD_ADDED" | grep -nE 'exec\.Command(Context)?\([^)]*(\+|fmt\.Sprintf)' | head -3)
+if [ -n "$HITS" ]; then WARN constructed-exec "exec of a constructed string — pass validated argv, never a shell-interpolated string: $HITS"; fi
+
+# --------------------------------------------------------------- PR-body lint
+# Mirrors .github/workflows/pr-intake.yml checks 1-3 + the INTAKE.md marker contract.
+if [ ! -f "$BODY_FILE" ]; then
+  WARN pr-body "no PR body draft at '$BODY_FILE' — write one from references/pr-body-template.md, then re-run: self-check.sh $BODY_FILE"
+else
+  BODY=$(cat "$BODY_FILE")
+  section() {  # text of "## <h>" up to next "## "
+    printf '%s\n' "$BODY" | awk -v h="## $1" '
+      /^## / { f = ($0 == h) ? 1 : 0; next } f { print }'
+  }
+  meaningful() {  # strip HTML comments, checkbox lines, blanks
+    printf '%s\n' "$1" | perl -0pe 's/<!--.*?-->//gs' | grep -vE '^[-*][[:space:]]*\[[ xX]\]' | grep -q '[^[:space:]]'
+  }
+
+  MISSING=""
+  for h in "What problem does this solve?" "Why this change" "User impact" "AI disclosure" "What actually bothered you" "Checklist"; do
+    printf '%s\n' "$BODY" | grep -q "^## $h" || MISSING="$MISSING '## $h'"
+  done
+  if [ -z "$MISSING" ]; then PASS body-headings
+  else FAIL body-headings "missing required section(s):$MISSING (exact headings from .github/PULL_REQUEST_TEMPLATE.md)"; fi
+
+  AI_SECTION=$(section "AI disclosure")
+  BOXES=$(printf '%s\n' "$AI_SECTION" | grep -cE '^[-*][[:space:]]*\[[xX]\]' || true)
+  AI_KIND=""
+  if [ "$BOXES" = 1 ]; then
+    LINE=$(printf '%s\n' "$AI_SECTION" | grep -E '^[-*][[:space:]]*\[[xX]\]' | tr '[:upper:]' '[:lower:]')
+    case "$LINE" in
+      *authored*) AI_KIND=authored ;; *assisted*) AI_KIND=assisted ;; *human*) AI_KIND=human ;;
+    esac
+    PASS ai-disclosure "$AI_KIND"
+  elif [ "$BOXES" = 0 ]; then
+    FAIL ai-disclosure "no box checked — check exactly one (Human-written / AI-assisted / AI-authored)"
+  else
+    FAIL ai-disclosure "$BOXES boxes checked — check exactly one"
+  fi
+
+  if [ "$AI_KIND" = assisted ] || [ "$AI_KIND" = authored ]; then
+    MODEL_LINE=$(printf '%s\n' "$AI_SECTION" | grep -i 'Model(s), if AI helped' | perl -pe 's/<!--.*?-->//g; s/.*helped:\**//i')
+    if printf '%s' "$MODEL_LINE" | grep -q '[^[:space:]]'; then PASS model-named "$(echo $MODEL_LINE)"
+    else FAIL model-named "AI helped but no model named — name it (e.g. claude-opus-4-x) or write 'unsure'"; fi
+  fi
+
+  if meaningful "$(section 'What actually bothered you')"; then PASS human-intent
+  else FAIL human-intent "empty — one real sentence; if an agent opened this, quote what the human asked for (the one field intake cannot accept blank)"; fi
+
+  if meaningful "$(section 'Evidence')"; then PASS evidence
+  else WARN evidence "empty — required for behavior changes: real output, capture, or before/after logs (mock-only proof is insufficient)"; fi
+
+  MARKER=$(printf '%s\n' "$BODY" | grep -oE '<!--[[:space:]]*gate:ai=[^[:space:]]+[[:space:]]+model=[^[:space:]]+[[:space:]]+intent=[^[:space:]]+[[:space:]]*-->' | tail -1)
+  if [ -z "$MARKER" ]; then
+    WARN gate-marker "no gate marker — add as the LAST line: <!-- gate:ai=$AI_KIND model=<name-or-unsure> intent=yes -->"
+  elif printf '%s' "$MARKER" | grep -q '<[a-z|-]*>'; then
+    FAIL gate-marker "marker still has template placeholders — fill in real values"
+  else
+    M_AI=$(printf '%s' "$MARKER" | sed -E 's/.*gate:ai=([^ ]+).*/\1/')
+    if [ -n "$AI_KIND" ] && [ "$M_AI" != "$AI_KIND" ]; then
+      FAIL gate-marker "marker says ai=$M_AI but the checked box says $AI_KIND — make them agree (visible sections are authoritative)"
+    else
+      PASS gate-marker "$MARKER"
+    fi
+  fi
+
+  if printf '%s\n' "$BODY" | grep -qE 'CRITICAL|URGENT|\bSECURITY\b'; then
+    WARN urgency-language "urgency language in the body — without a concrete repro this trips the slop check; real vulnerabilities go through SECURITY.md privately"
+  fi
+fi
+
+# ----------------------------------------------------------------- summary
+echo
+echo "== summary: $pass PASS, $fail FAIL, $warn WARN, $skip skipped =="
+if [ "$fail" -gt 0 ]; then
+  echo "Fix every FAIL before opening the PR (exact fixes: references/gate-spec.md)."
+  exit 1
+fi
+if [ "$warn" -gt 0 ]; then
+  echo "Resolve each WARN or explain it honestly in the PR body — stated imperfections pass; silent ones become review flags."
+fi
+echo "Ready to open. Use the PR body you just linted, marker line last."
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for being here. agent-deck ships community fixes in nearly every release,
 
 This page tells you how the project actually works, what makes a PR land fast, and where to start. If you are an AI agent contributing on a human's behalf, read [.github/INTAKE.md](.github/INTAKE.md): it is the field-level contract, and following it means you pass intake on the first try.
 
+**Contributing with an AI agent?** Point it at the [agent-deck contributor skill](.github/skills/agent-deck-contributor/SKILL.md). It packages this whole page, the intake contract, and the review criteria as an agent skill, including a `self-check.sh` that runs every gate check locally before you open the PR. An agent that follows it opens a PR we can merge on the first try.
+
 ## How this project works (the honest version)
 
 agent-deck has one human maintainer and a fleet of AI agents that do the heavy lifting on intake. That is not a gimmick, it is the reason your PR does not sit for weeks:


### PR DESCRIPTION
## What problem does this solve?

Contributors using AI agents currently have to reverse-engineer what the intake gate (`.github/workflows/pr-intake.yml` + `.github/INTAKE.md`) and the four-lens review machine expect, and most first PRs bounce on a missing field, a tautological test, or an unexplained WARN-class issue. This adds the contributor-side mirror of the whole gate as a repo-shipped agent skill: `.github/skills/agent-deck-contributor/` (SKILL.md + gate-spec + PR-body template + security self-scan + `scripts/self-check.sh`), linked from CONTRIBUTING.md.

## Why this change

The gate and the review criteria already exist and are documented from the receiving side. The cheapest way to raise first-try pass rate is to publish the same spec from the sending side, in the format agents actually consume (a skill directory a contributor can point any agent at). `self-check.sh` runs the identical checks locally: gofmt/vet/build, the sandboxed CI test invocation, the revert-check (reverts non-test hunks against base, expects the new tests to fail), diff-size and forbidden-path checks, the hidden-logic security sweep, and a lint of the PR body against the intake heading/marker contract. Alternative considered: a docs page only — rejected because the executable self-check is where the value is (agents run it, prose gets skimmed).

## User impact

No runtime change; docs-and-tooling only. Contributors (human or agent) get a pre-open gate that tells them exactly what will fail and how to fix it before they open the PR. Maintainer side gets fewer intake bounces.

## Evidence

Dry-run against a real change (issue #1652, Shift+T fresh-restart of an archived session, in a throwaway branch against pre-fix base 8c0a4d9f, before #1654 landed the fix):

    # good change (real fix + test locking the behavior):
    == summary: 15 PASS, 0 FAIL, 1 WARN, 0 skipped ==   exit 0
    (the 1 WARN is the revert-check new-symbol case, explained in that draft body)

    # deliberately bad change (same fix, test replaced with one that passes on base):
    FAIL  revert-check   your tests still PASS without your change — they prove nothing
    == summary: 15 PASS, 1 FAIL, 0 WARN ==   exit 1

    # deliberately gutted PR body (no AI box checked, empty human-intent):
    FAIL  ai-disclosure  no box checked — check exactly one
    FAIL  human-intent   empty — one real sentence
    == summary: 10 PASS, 2 FAIL, 3 WARN ==   exit 1

This PR's own body was linted with the same script (`self-check.sh` on this file: body checks all PASS; Go checks skip on a no-Go diff). `bash -n` passes on the script. No Go code is touched, so no test/revert-check applies; `SKIP_REVERT_CHECK` rationale does not arise.

Note: this PR adds files under `.github/`, which per the repo's own security gates never auto-merges and waits for the maintainer personally — expected and intended here. On size: +838 lines, but the skill is one coherent unit (spec + references + the executable check that makes it real); splitting SKILL.md from its self-check would ship a spec agents cannot verify against. Dogfooding note: the first self-check run on this very PR FAILed its own hidden-logic scan — the scanner matched the skill's documentation and its own regex strings quoting `curl | bash`/GOPROXY/TLS-bypass patterns. Fixed by scoping the automated pattern scans to non-markdown code lines and excluding the scanner itself (invisible-chars still covers every file; `.github/` stays human-gated regardless), which kills that false-positive class for all future docs PRs too.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):** —

## What actually bothered you

The maintainer asked: "if a contributor's agent has agent-deck skills, it could do the whole thing properly: solve the issue, open a clean PR we can merge easily."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior (no Go code changed; the shipped script was validated by the three-scenario dry-run above)
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated pre-open validation step for contributions.
  * Produces clear PASS/WARN/SKIP results and blocks submissions when checks fail.
  * Validates code formatting/build/test outcomes, diff hygiene, security-sensitive patterns, and required pull request content.

* **Chores**
  * Provides guidance to review and resolve validation results before opening a pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->