### PR TITLE
docs(skills): embed contributor signpost in main agent-deck skill

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -733,6 +733,23 @@ cat ~/.agent-deck/config.toml | grep -v "KEY\|TOKEN\|SECRET"  # Sanitized config
 
 See [troubleshooting.md](references/troubleshooting.md) for detailed diagnostics.
 
+## Contributing to agent-deck
+
+Going beyond a bug report to a fix? agent-deck ships a dedicated contributor skill that mirrors the repo's PR intake gate and the maintainer's review machine, so an agent that follows it passes intake on the first try and scores well on all four review lenses (correctness, security, fit, intent).
+
+Load it from the repo checkout:
+
+```bash
+# In an agent-deck clone
+cat .github/skills/agent-deck-contributor/SKILL.md
+```
+
+It walks the full loop and enforces the bar: understand and reproduce the issue first, capture the human's actual ask verbatim (it goes in the PR body), one scoped problem per PR, a test that FAILS without your change, self-check locally before opening (`.github/skills/agent-deck-contributor/scripts/self-check.sh`), disclose the AI model that wrote the change, and respond directly to review verdicts. Run tests sandboxed — never against a real home directory:
+
+```bash
+HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...
+```
+
 ## Session Sharing
 
 Share Claude sessions between developers for collaboration or handoff.


### PR DESCRIPTION
## What actually bothered you

The agent-deck-contributor skill (PR #1656, `.github/skills/agent-deck-contributor/`) is a portable skill that guides a contributor's agent to open a gate-passing PR — but it only helps someone who already knows it exists. Every agent-deck user already loads the main skill (`skills/agent-deck/SKILL.md`) to drive agent-deck. That is the natural home for a pointer to the contributor skill: the skill that teaches an agent to USE agent-deck should also teach it to CONTRIBUTE to agent-deck.

## What changed

Adds a short "Contributing to agent-deck" section to `skills/agent-deck/SKILL.md`, placed right after "Report a Bug" (report → fix is the natural flow). It is a **signpost, not a copy**:

- Points to the contributor skill at `.github/skills/agent-deck-contributor/` and how to load it.
- Summarizes what it enforces: understand and reproduce the issue first, capture the human's ask verbatim, one scoped problem per PR, a test that FAILS without the change, local self-check before opening, AI-model disclosure, and responding to review verdicts.
- Repeats the sandboxed-test invocation (never against a real home directory).

The full contributor guidance is **not** duplicated inline — the contributor skill (#1656) remains the single source of truth.

## Evidence

Docs-only change to one skill file (+17 lines). No code paths touched, no tests affected.

🤖 disclosure: drafted by Claude (claude-opus-4-8).