### PR TITLE
feat(new-session-ux): PathSuggest core + placeholder/title guards + create picker

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1210,6 +1210,13 @@ func resolveGroupPathForAdd(groupTree *session.GroupTree, groupSelector string) 
 	return groupSelector
 }
 
+// shouldLockTitle is the #1615-class chokepoint deciding whether a new CLI
+// session's title is locked against Claude's folder-name sync. An explicit
+// user title locks, as do the explicit lock flags.
+func shouldLockTitle(userProvidedTitle, titleLockFlag, noTitleSyncFlag bool) bool {
+	return userProvidedTitle || titleLockFlag || noTitleSyncFlag
+}
+
 // handleAdd adds a new session from CLI
 func handleAdd(profile string, args []string) {
 	fs := flag.NewFlagSet("add", flag.ExitOnError)
@@ -1644,8 +1651,11 @@ func handleAdd(profile string, args []string) {
 		newInstance.NoTransitionNotify = true
 	}
 
-	// #697: title-lock blocks Claude's session-name sync. Either flag triggers it.
-	if *titleLock || *noTitleSync {
+	// #697/#1615: title-lock blocks Claude's session-name sync. An explicit
+	// user title (-t/--title) locks too — otherwise Claude's folder-name sync
+	// silently clobbers it (the #1615 class), matching the TUI dialog and
+	// `launch` paths.
+	if shouldLockTitle(userProvidedTitle, *titleLock, *noTitleSync) {
 		newInstance.TitleLocked = true
 	}
 

--- a/cmd/agent-deck/title_lock_test.go
+++ b/cmd/agent-deck/title_lock_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+// TestShouldLockTitle codifies the #1615-class chokepoint: an explicit,
+// user-provided title (-t/--title) must be TitleLocked so Claude's folder-name
+// sync can never silently clobber it — matching the TUI dialog and `launch`
+// paths. The explicit lock flags remain independent triggers; an auto-derived
+// (folder-name) title stays unlocked so name-sync keeps working.
+func TestShouldLockTitle(t *testing.T) {
+	tests := []struct {
+		name              string
+		userProvidedTitle bool
+		titleLockFlag     bool
+		noTitleSyncFlag   bool
+		want              bool
+	}{
+		{name: "explicit -t title locks", userProvidedTitle: true, want: true},
+		{name: "--title-lock locks", titleLockFlag: true, want: true},
+		{name: "--no-title-sync locks", noTitleSyncFlag: true, want: true},
+		{name: "auto folder-name title stays unlocked", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldLockTitle(tt.userProvidedTitle, tt.titleLockFlag, tt.noTitleSyncFlag)
+			if got != tt.want {
+				t.Fatalf("shouldLockTitle(%v,%v,%v) = %v, want %v",
+					tt.userProvidedTitle, tt.titleLockFlag, tt.noTitleSyncFlag, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -65,6 +65,15 @@ type Item struct {
 	DividerLabel        string             // Label shown on an ItemTypeDivider row (e.g. "idle / done")
 }
 
+// IsCreatingPlaceholder reports whether this row is a still-creating session
+// placeholder: a session-typed row whose *Instance has not been created yet
+// (Session == nil). Mutations (move/rename/fork) must be refused on such rows —
+// dereferencing the nil Instance panics (#1540). This is the single model-layer
+// predicate that generalizes the per-call-site nil guards.
+func (it Item) IsCreatingPlaceholder() bool {
+	return it.Type == ItemTypeSession && it.Session == nil
+}
+
 // Group represents a group of sessions
 type Group struct {
 	Name        string

--- a/internal/session/pathsuggest.go
+++ b/internal/session/pathsuggest.go
@@ -1,0 +1,212 @@
+package session
+
+import (
+	"math"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PathSource labels where a path candidate originated. It drives both the
+// display hint in the picker and the base weight used for ranking.
+type PathSource string
+
+const (
+	// SourceRecent is a path that backs an existing (or past) session.
+	SourceRecent PathSource = "recent"
+	// SourceGroup is a group's configured/derived default path.
+	SourceGroup PathSource = "group"
+	// SourceZoxide is a hit from the zoxide frecency database.
+	SourceZoxide PathSource = "zoxide"
+	// SourceLiteral is a path the user typed verbatim (added by the caller).
+	SourceLiteral PathSource = "literal"
+)
+
+// PathCandidate is a single ranked suggestion for a new session's project path.
+type PathCandidate struct {
+	Path       string
+	Source     PathSource
+	LastAccess time.Time // zero when unknown (group/zoxide)
+	Score      float64
+}
+
+// PathSuggestInput carries the already-collected raw inputs. All I/O (the
+// zoxide query, filesystem probing) is performed by the caller so PathSuggest
+// stays pure and deterministically testable — the single ranking used by the
+// TUI picker, the CLI and the ADE endpoints.
+type PathSuggestInput struct {
+	Instances     []*Instance // recents source (project paths + access times)
+	GroupDefaults []string    // resolved DefaultPathForGroup values
+	Zoxide        []string    // zoxide results, best-first
+	Query         string      // case-insensitive substring filter (optional)
+	Now           time.Time   // reference time for recency decay; zero → now
+	Limit         int         // max candidates; <=0 → defaultPathSuggestLimit
+}
+
+const (
+	defaultPathSuggestLimit = 10
+
+	weightRecent = 100.0
+	weightGroup  = 60.0
+	weightZoxide = 40.0
+
+	// recencyHalfLifeHours: a recent path loses half its recency weight after
+	// one week of inactivity (frecency decay).
+	recencyHalfLifeHours = 24.0 * 7.0
+	frequencyBonus       = 3.0
+)
+
+// PathSuggest merges the candidate sources, frecency-ranks them, dedups by
+// normalized path (keeping the strongest source), applies the query filter and
+// returns at most Limit candidates, best-first.
+func PathSuggest(in PathSuggestInput) []PathCandidate {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	limit := in.Limit
+	if limit <= 0 {
+		limit = defaultPathSuggestLimit
+	}
+
+	// Accumulate per normalized path. A path seen in several sources keeps the
+	// strongest source (recent > group > zoxide) and the summed score, so a
+	// path that is both a recent AND a zoxide hit ranks above a bare hit.
+	byPath := make(map[string]*PathCandidate)
+	// hasZoxide tracks whether a candidate has a zoxide contribution so the
+	// query filter can exempt it: zoxide already fuzzy-matched the query, so a
+	// substring test would wrongly drop non-substring fuzzy hits (query "dck"
+	// → "/agent-deck").
+	hasZoxide := make(map[string]bool)
+	upsert := func(raw string, src PathSource, last time.Time, score float64) {
+		p := cleanSuggestPath(raw)
+		if p == "" {
+			return
+		}
+		if src == SourceZoxide {
+			hasZoxide[p] = true
+		}
+		existing, ok := byPath[p]
+		if !ok {
+			byPath[p] = &PathCandidate{Path: p, Source: src, LastAccess: last, Score: score}
+			return
+		}
+		existing.Score += score
+		if sourceRank(src) > sourceRank(existing.Source) {
+			existing.Source = src
+		}
+		if last.After(existing.LastAccess) {
+			existing.LastAccess = last
+		}
+	}
+
+	// Recents: dedup by path first so frequency (session count) can boost.
+	type recentAgg struct {
+		last  time.Time
+		count int
+	}
+	recents := make(map[string]*recentAgg)
+	for _, inst := range in.Instances {
+		if inst == nil {
+			continue
+		}
+		p := inst.ProjectPath
+		if inst.WorktreeRepoRoot != "" {
+			p = inst.WorktreeRepoRoot
+		}
+		p = cleanSuggestPath(p)
+		if p == "" {
+			continue
+		}
+		at := inst.LastAccessedAt
+		if at.IsZero() {
+			at = inst.CreatedAt
+		}
+		agg, ok := recents[p]
+		if !ok {
+			recents[p] = &recentAgg{last: at, count: 1}
+			continue
+		}
+		agg.count++
+		if at.After(agg.last) {
+			agg.last = at
+		}
+	}
+	for p, agg := range recents {
+		score := weightRecent*recencyFactor(agg.last, now) + frequencyBonus*float64(agg.count-1)
+		upsert(p, SourceRecent, agg.last, score)
+	}
+
+	// Group defaults: constant weight; order-insensitive.
+	for _, p := range in.GroupDefaults {
+		upsert(p, SourceGroup, time.Time{}, weightGroup)
+	}
+
+	// Zoxide: preserve the DB's own ordering (best-first) as a tie-breaker.
+	for i, p := range in.Zoxide {
+		upsert(p, SourceZoxide, time.Time{}, weightZoxide+float64(len(in.Zoxide)-i)*0.01)
+	}
+
+	out := make([]PathCandidate, 0, len(byPath))
+	q := strings.ToLower(strings.TrimSpace(in.Query))
+	for _, c := range byPath {
+		if q != "" && !hasZoxide[c.Path] && !strings.Contains(strings.ToLower(c.Path), q) {
+			continue
+		}
+		out = append(out, *c)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if !out[i].LastAccess.Equal(out[j].LastAccess) {
+			return out[i].LastAccess.After(out[j].LastAccess)
+		}
+		return out[i].Path < out[j].Path
+	})
+
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// recencyFactor returns a value in (0,1] that decays with age using the
+// configured half-life. A zero timestamp is treated as very old.
+func recencyFactor(last, now time.Time) float64 {
+	if last.IsZero() {
+		return 0
+	}
+	ageHours := now.Sub(last).Hours()
+	if ageHours < 0 {
+		ageHours = 0
+	}
+	return math.Pow(0.5, ageHours/recencyHalfLifeHours)
+}
+
+func sourceRank(s PathSource) int {
+	switch s {
+	case SourceRecent:
+		return 3
+	case SourceGroup:
+		return 2
+	case SourceZoxide:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// cleanSuggestPath cleans a path for stable dedup (trims trailing slashes,
+// resolves "." segments) without touching the empty string. Unlike the
+// package's normalizePath it performs no filesystem I/O (no symlink resolution),
+// keeping the ranking pure and deterministic.
+func cleanSuggestPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	return filepath.Clean(p)
+}

--- a/internal/session/pathsuggest_test.go
+++ b/internal/session/pathsuggest_test.go
@@ -1,0 +1,160 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func mkInst(path string, last time.Time) *Instance {
+	return &Instance{ProjectPath: path, LastAccessedAt: last, CreatedAt: last}
+}
+
+// TestPathSuggest_RanksRecentAboveGroupAboveZoxide verifies the source
+// hierarchy: a recently-accessed session path outranks a bare group default,
+// which outranks a zoxide-only hit, when nothing else distinguishes them.
+func TestPathSuggest_RanksRecentAboveGroupAboveZoxide(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	out := PathSuggest(PathSuggestInput{
+		Instances:     []*Instance{mkInst("/home/u/recent", now.Add(-1*time.Hour))},
+		GroupDefaults: []string{"/home/u/groupdef"},
+		Zoxide:        []string{"/home/u/zox"},
+		Now:           now,
+	})
+	if len(out) != 3 {
+		t.Fatalf("got %d candidates, want 3: %+v", len(out), out)
+	}
+	if out[0].Path != "/home/u/recent" || out[0].Source != SourceRecent {
+		t.Errorf("rank 0 = %q/%s, want /home/u/recent/recent", out[0].Path, out[0].Source)
+	}
+	if out[1].Path != "/home/u/groupdef" || out[1].Source != SourceGroup {
+		t.Errorf("rank 1 = %q/%s, want /home/u/groupdef/group", out[1].Path, out[1].Source)
+	}
+	if out[2].Path != "/home/u/zox" || out[2].Source != SourceZoxide {
+		t.Errorf("rank 2 = %q/%s, want /home/u/zox/zoxide", out[2].Path, out[2].Source)
+	}
+}
+
+// TestPathSuggest_RecencyOrdersRecents verifies more-recently-accessed paths
+// sort ahead of older ones within the recents source.
+func TestPathSuggest_RecencyOrdersRecents(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	out := PathSuggest(PathSuggestInput{
+		Instances: []*Instance{
+			mkInst("/old", now.Add(-200*time.Hour)),
+			mkInst("/fresh", now.Add(-1*time.Hour)),
+		},
+		Now: now,
+	})
+	if len(out) != 2 || out[0].Path != "/fresh" || out[1].Path != "/old" {
+		t.Fatalf("recency order wrong: %+v", out)
+	}
+}
+
+// TestPathSuggest_DedupsAcrossSourcesKeepingStrongest verifies a path present
+// in several sources appears once, tagged with the strongest (recent) source.
+func TestPathSuggest_DedupsAcrossSourcesKeepingStrongest(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	out := PathSuggest(PathSuggestInput{
+		Instances:     []*Instance{mkInst("/shared", now.Add(-2*time.Hour))},
+		GroupDefaults: []string{"/shared"},
+		Zoxide:        []string{"/shared"},
+		Now:           now,
+	})
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1 deduped candidate: %+v", len(out), out)
+	}
+	if out[0].Source != SourceRecent {
+		t.Errorf("deduped source = %s, want recent (strongest)", out[0].Source)
+	}
+}
+
+// TestPathSuggest_FrequencyBoost verifies that a path backed by multiple
+// sessions outranks a single-session path of the same recency.
+func TestPathSuggest_FrequencyBoost(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	at := now.Add(-1 * time.Hour)
+	out := PathSuggest(PathSuggestInput{
+		Instances: []*Instance{
+			mkInst("/single", at),
+			mkInst("/multi", at),
+			mkInst("/multi", at),
+			mkInst("/multi", at),
+		},
+		Now: now,
+	})
+	if len(out) != 2 || out[0].Path != "/multi" {
+		t.Fatalf("frequency boost failed: %+v", out)
+	}
+}
+
+// TestPathSuggest_QueryFiltersCaseInsensitiveSubstring verifies the query
+// narrows candidates by case-insensitive substring on the path.
+func TestPathSuggest_QueryFiltersCaseInsensitiveSubstring(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	out := PathSuggest(PathSuggestInput{
+		Instances: []*Instance{
+			mkInst("/home/u/agent-deck", now.Add(-1*time.Hour)),
+			mkInst("/home/u/other", now.Add(-1*time.Hour)),
+		},
+		Query: "DECK",
+		Now:   now,
+	})
+	if len(out) != 1 || out[0].Path != "/home/u/agent-deck" {
+		t.Fatalf("query filter failed: %+v", out)
+	}
+}
+
+// TestPathSuggest_QueryExemptsZoxideFuzzyHits verifies zoxide candidates
+// survive the query filter even when they aren't a literal substring match
+// (zoxide already fuzzy-matched), while non-matching recents are still dropped.
+func TestPathSuggest_QueryExemptsZoxideFuzzyHits(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	out := PathSuggest(PathSuggestInput{
+		Instances: []*Instance{mkInst("/home/u/unrelated", now.Add(-1*time.Hour))},
+		Zoxide:    []string{"/home/u/agent-deck"}, // fuzzy hit for "dck"
+		Query:     "dck",
+		Now:       now,
+	})
+	if len(out) != 1 || out[0].Path != "/home/u/agent-deck" {
+		t.Fatalf("zoxide fuzzy hit not exempt from query filter: %+v", out)
+	}
+}
+
+// TestPathSuggest_PrefersWorktreeRepoRoot verifies worktree sessions surface
+// their original repo root, not the ephemeral worktree directory.
+func TestPathSuggest_PrefersWorktreeRepoRoot(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	inst := mkInst("/home/u/repo/.worktrees/feat", now.Add(-1*time.Hour))
+	inst.WorktreeRepoRoot = "/home/u/repo"
+	out := PathSuggest(PathSuggestInput{Instances: []*Instance{inst}, Now: now})
+	if len(out) != 1 || out[0].Path != "/home/u/repo" {
+		t.Fatalf("worktree repo root not preferred: %+v", out)
+	}
+}
+
+// TestPathSuggest_SkipsEmptyAndNormalizes verifies empty paths are ignored and
+// paths are cleaned (trailing slash removed) before dedup.
+func TestPathSuggest_SkipsEmptyAndNormalizes(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	out := PathSuggest(PathSuggestInput{
+		Instances:     []*Instance{mkInst("", now), mkInst("/a/b/", now.Add(-1*time.Hour))},
+		GroupDefaults: []string{"/a/b", ""},
+		Now:           now,
+	})
+	if len(out) != 1 || out[0].Path != "/a/b" {
+		t.Fatalf("normalize/skip-empty failed: %+v", out)
+	}
+}
+
+// TestPathSuggest_RespectsLimit verifies Limit caps the returned candidates.
+func TestPathSuggest_RespectsLimit(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	var insts []*Instance
+	for i, p := range []string{"/a", "/b", "/c", "/d", "/e"} {
+		insts = append(insts, mkInst(p, now.Add(-time.Duration(i)*time.Hour)))
+	}
+	out := PathSuggest(PathSuggestInput{Instances: insts, Now: now, Limit: 2})
+	if len(out) != 2 {
+		t.Fatalf("limit not respected: got %d", len(out))
+	}
+}

--- a/internal/session/placeholder_guard_test.go
+++ b/internal/session/placeholder_guard_test.go
@@ -1,0 +1,43 @@
+package session
+
+import "testing"
+
+// TestItemIsCreatingPlaceholder verifies the model-layer predicate that gates
+// mutations (move/rename/fork) against a still-creating session row. A
+// creating placeholder surfaces as Type==ItemTypeSession with a nil Session
+// (the #1540 crash shape); every other row must report false.
+func TestItemIsCreatingPlaceholder(t *testing.T) {
+	tests := []struct {
+		name string
+		item Item
+		want bool
+	}{
+		{
+			name: "creating placeholder (session row, nil instance)",
+			item: Item{Type: ItemTypeSession, Session: nil, CreatingID: "tmp-123"},
+			want: true,
+		},
+		{
+			name: "real session row",
+			item: Item{Type: ItemTypeSession, Session: &Instance{ID: "s1"}},
+			want: false,
+		},
+		{
+			name: "group row",
+			item: Item{Type: ItemTypeGroup, Group: &Group{Name: "g"}},
+			want: false,
+		},
+		{
+			name: "remote session row",
+			item: Item{Type: ItemTypeRemoteSession},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.IsCreatingPlaceholder(); got != tt.want {
+				t.Fatalf("IsCreatingPlaceholder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/createpicker_test.go
+++ b/internal/ui/createpicker_test.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestCreatePicker_SuggestProviderPopulatesOnShow verifies that when a
+// PathSuggest provider is wired, Show() pre-populates the frecency-ranked
+// candidate list (no query typed) — "the picker IS the interaction".
+func TestCreatePicker_SuggestProviderPopulatesOnShow(t *testing.T) {
+	z := NewZoxidePicker()
+	z.SetSuggestProvider(func(q string) []session.PathCandidate {
+		return []session.PathCandidate{
+			{Path: "/home/u/agent-deck", Source: session.SourceRecent},
+			{Path: "/home/u/other", Source: session.SourceGroup},
+		}
+	})
+
+	z.Show()
+
+	if !z.IsVisible() {
+		t.Fatal("picker not visible after Show")
+	}
+	if got := z.Selected(); got != "/home/u/agent-deck" {
+		t.Fatalf("Selected() = %q, want /home/u/agent-deck (top frecency row)", got)
+	}
+}
+
+// TestCreatePicker_SuggestProviderRefreshesOnType verifies each keystroke
+// re-queries the provider so results narrow as the user types.
+func TestCreatePicker_SuggestProviderRefreshesOnType(t *testing.T) {
+	calls := 0
+	z := NewZoxidePicker()
+	z.SetSuggestProvider(func(q string) []session.PathCandidate {
+		calls++
+		if q == "" {
+			return []session.PathCandidate{{Path: "/default", Source: session.SourceRecent}}
+		}
+		return []session.PathCandidate{{Path: "/queried/" + q, Source: session.SourceRecent}}
+	})
+	z.Show()
+	pre := calls
+
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	if calls != pre+1 {
+		t.Fatalf("expected one provider refresh per keystroke, got %d (was %d)", calls, pre)
+	}
+	if got := z.Selected(); got != "/queried/x" {
+		t.Fatalf("Selected() = %q, want /queried/x", got)
+	}
+}
+
+// TestCreatePicker_ShowsSourceHint verifies the rendered list annotates each
+// candidate with its source so the user can tell a recent from a zoxide hit.
+func TestCreatePicker_ShowsSourceHint(t *testing.T) {
+	z := NewZoxidePicker()
+	z.SetSize(120, 40)
+	z.SetSuggestProvider(func(q string) []session.PathCandidate {
+		return []session.PathCandidate{{Path: "/home/u/agent-deck", Source: session.SourceRecent}}
+	})
+	z.Show()
+
+	view := z.View()
+	if !strings.Contains(view, "recent") {
+		t.Fatalf("view missing source hint 'recent':\n%s", view)
+	}
+}
+
+// TestCreatePicker_ProviderBypassesZoxideUnavailable verifies that wiring a
+// suggest provider makes the picker usable even when the zoxide binary is
+// absent (the provider is the source of truth, zoxide is just one input).
+func TestCreatePicker_ProviderBypassesZoxideUnavailable(t *testing.T) {
+	z := NewZoxidePicker()
+	z.checkAvail = true // simulate the real constructor's availability gate
+	z.SetSuggestProvider(func(q string) []session.PathCandidate {
+		return []session.PathCandidate{{Path: "/from/provider", Source: session.SourceRecent}}
+	})
+
+	z.Show()
+
+	if z.unavail {
+		t.Fatal("picker marked unavailable despite a wired suggest provider")
+	}
+	if got := z.Selected(); got != "/from/provider" {
+		t.Fatalf("Selected() = %q, want /from/provider", got)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -58,6 +58,10 @@ func SetVersion(v string) {
 	Version = v
 }
 
+// errSessionStillCreating is the shared user-facing message when a mutation
+// (move/rename/fork) is attempted on a still-creating placeholder row (#1540).
+var errSessionStillCreating = errors.New("session is still being created, try again in a moment")
+
 // CreatingSession is a lightweight placeholder shown in the UI while
 // a worktree + session is being created asynchronously.
 // It is NOT a real session.Instance — it is excluded from save, polling, and search.
@@ -8385,6 +8389,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Only available when the selected tool supports Agent Deck forking
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
+			if item.IsCreatingPlaceholder() {
+				h.setError(errSessionStillCreating)
+				return h, nil
+			}
 			if item.Type == session.ItemTypeSession && item.Session != nil {
 				// Block fork during animations to prevent concurrent operations
 				if h.hasActiveAnimation(item.Session.ID) {
@@ -8403,6 +8411,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Only available when the selected tool supports Agent Deck forking
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
+			if item.IsCreatingPlaceholder() {
+				h.setError(errSessionStillCreating)
+				return h, nil
+			}
 			if item.Type == session.ItemTypeSession && item.Session != nil {
 				// Block fork during animations to prevent concurrent operations
 				if h.hasActiveAnimation(item.Session.ID) {
@@ -8433,15 +8445,12 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Move session to different group
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			// Guard against creating-session placeholder rows (Type ==
-			// ItemTypeSession but Session == nil) — moving one would panic
-			// (#1540). Tell the user the session is still being created.
-			if item.Type == session.ItemTypeSession {
-				if item.Session == nil {
-					h.setError(fmt.Errorf("session is still being created, try again in a moment"))
-				} else {
-					h.groupDialog.ShowMove(h.scopedGroupPaths())
-				}
+			// Refuse mutations on a still-creating placeholder — moving one
+			// would deref a nil *Instance and panic (#1540).
+			if item.IsCreatingPlaceholder() {
+				h.setError(errSessionStillCreating)
+			} else if item.Type == session.ItemTypeSession {
+				h.groupDialog.ShowMove(h.scopedGroupPaths())
 			}
 		}
 		return h, nil
@@ -8552,6 +8561,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Rename group or session
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
+			if item.IsCreatingPlaceholder() {
+				h.setError(errSessionStillCreating)
+				return h, nil
+			}
 			if item.Type == session.ItemTypeGroup {
 				h.groupDialog.ShowRename(item.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeSession && item.Session != nil {
@@ -8760,6 +8773,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "z":
 		h.zoxidePicker.SetSize(h.width, h.height)
+		h.zoxidePicker.SetSuggestProvider(h.pathSuggestProvider())
 		h.zoxidePicker.Show()
 		return h, nil
 
@@ -11569,6 +11583,47 @@ func (h *Home) handleZoxidePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	default:
 		h.zoxidePicker, _ = h.zoxidePicker.Update(msg)
 		return h, nil
+	}
+}
+
+// pathSuggestProvider returns a closure that produces the unified,
+// frecency-ranked candidate list for the create picker: recent session paths,
+// group default paths and (for a non-empty query) zoxide hits, merged and
+// ranked by session.PathSuggest — the single source of truth shared with the
+// CLI and ADE (per NEW-SESSION-UX-PLAN.md §3.1).
+func (h *Home) pathSuggestProvider() func(string) []session.PathCandidate {
+	// Snapshot group default paths once per picker-open; they don't change
+	// while the picker is up and re-deriving them per keystroke is wasteful.
+	var groupDefaults []string
+	if h.groupTree != nil {
+		for groupPath := range h.groupTree.Groups {
+			if dp := h.getDefaultPathForGroup(groupPath); dp != "" {
+				groupDefaults = append(groupDefaults, dp)
+			}
+		}
+	}
+
+	return func(query string) []session.PathCandidate {
+		var zox []string
+		if strings.TrimSpace(query) != "" && session.ZoxideAvailable() {
+			ctx, cancel := context.WithTimeout(context.Background(), zoxideQueryTimeout)
+			if results, err := session.ZoxideQuery(ctx, query); err == nil {
+				zox = results
+			}
+			cancel()
+		}
+
+		h.instancesMu.RLock()
+		insts := make([]*session.Instance, len(h.instances))
+		copy(insts, h.instances)
+		h.instancesMu.RUnlock()
+
+		return session.PathSuggest(session.PathSuggestInput{
+			Instances:     insts,
+			GroupDefaults: groupDefaults,
+			Zoxide:        zox,
+			Query:         query,
+		})
 	}
 }
 

--- a/internal/ui/placeholder_mutation_guard_test.go
+++ b/internal/ui/placeholder_mutation_guard_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestPlaceholderMutationGuards verifies that move/fork/rename over a
+// still-creating placeholder row (Type==ItemTypeSession, Session==nil) neither
+// panics (#1540) nor silently no-ops: each surfaces errSessionStillCreating.
+// Without the IsCreatingPlaceholder guards the move path would deref a nil
+// *Instance and panic; fork/rename would silently do nothing.
+func TestPlaceholderMutationGuards(t *testing.T) {
+	for _, key := range []rune{'M', 'f', 'F', 'r'} {
+		t.Run(string(key), func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+			home.flatItems = []session.Item{{
+				Type:          session.ItemTypeSession,
+				Session:       nil, // placeholder: not yet created
+				CreatingID:    "tmp-guard",
+				CreatingTitle: "creating…",
+			}}
+			home.cursor = 0
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("pressing %q on a placeholder panicked: %v", key, r)
+				}
+			}()
+
+			model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+			h, ok := model.(*Home)
+			if !ok {
+				t.Fatalf("handleMainKey did not return *Home")
+			}
+			if !errors.Is(h.err, errSessionStillCreating) {
+				t.Fatalf("key %q on placeholder: h.err = %v, want errSessionStillCreating", key, h.err)
+			}
+		})
+	}
+}

--- a/internal/ui/zoxide_picker.go
+++ b/internal/ui/zoxide_picker.go
@@ -36,7 +36,17 @@ type ZoxidePicker struct {
 	unavail    bool // zoxide not installed; results disabled
 	queryFn    zoxideQueryFunc
 	checkAvail bool
+
+	// suggestFn, when set, supplies the unified frecency-ranked candidate list
+	// (recents + group defaults + zoxide, via session.PathSuggest). It makes
+	// the picker "the interaction": Show() pre-populates it with no query, and
+	// it takes precedence over the raw zoxide query (and its availability gate).
+	suggestFn  suggestQueryFunc
+	candidates []session.PathCandidate
 }
+
+// suggestQueryFunc returns the ranked candidate list for the given query.
+type suggestQueryFunc func(query string) []session.PathCandidate
 
 // NewZoxidePicker constructs a picker wired to the real zoxide binary.
 func NewZoxidePicker() *ZoxidePicker {
@@ -62,6 +72,13 @@ func defaultZoxideQuery(query string) ([]string, error) {
 	return session.ZoxideQuery(ctx, query)
 }
 
+// SetSuggestProvider wires the unified PathSuggest candidate source. Once set,
+// the picker ranks candidates from it (recents + group defaults + zoxide) and
+// ignores the standalone zoxide availability gate.
+func (z *ZoxidePicker) SetSuggestProvider(fn suggestQueryFunc) {
+	z.suggestFn = fn
+}
+
 // Show opens the picker. If zoxide is missing the picker still renders but
 // displays an install hint and disables selection.
 func (z *ZoxidePicker) Show() {
@@ -72,7 +89,9 @@ func (z *ZoxidePicker) Show() {
 	z.queryInput.CursorEnd()
 	z.queryInput.Focus()
 
-	if z.checkAvail && !session.ZoxideAvailable() {
+	// A wired suggest provider is the source of truth and never "unavailable":
+	// even without zoxide there are recents and group defaults to show.
+	if z.suggestFn == nil && z.checkAvail && !session.ZoxideAvailable() {
 		z.unavail = true
 		z.results = nil
 		return
@@ -129,6 +148,19 @@ func (z *ZoxidePicker) Update(msg tea.KeyMsg) (*ZoxidePicker, tea.Cmd) {
 }
 
 func (z *ZoxidePicker) refreshResults() {
+	if z.suggestFn != nil {
+		z.candidates = z.suggestFn(z.queryInput.Value())
+		z.errMsg = ""
+		z.results = z.results[:0]
+		for _, c := range z.candidates {
+			z.results = append(z.results, c.Path)
+		}
+		if z.cursor >= len(z.results) {
+			z.cursor = 0
+		}
+		return
+	}
+
 	results, err := z.queryFn(z.queryInput.Value())
 	if err != nil {
 		z.errMsg = err.Error()
@@ -209,12 +241,18 @@ func (z *ZoxidePicker) renderResults() string {
 		Bold(true).
 		Padding(0, 1)
 
+	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	home, _ := os.UserHomeDir()
 	rows := make([]string, 0, len(shown)+1)
 	for i, p := range shown {
 		display := p
 		if home != "" && strings.HasPrefix(p, home) {
 			display = "~" + strings.TrimPrefix(p, home)
+		}
+		// Annotate with the candidate source (recent/group/zoxide) when the
+		// unified provider is driving the list, so the origin is legible.
+		if i < len(z.candidates) && z.candidates[i].Source != "" {
+			display += "  " + hintStyle.Render(string(z.candidates[i].Source))
 		}
 		if i == z.cursor {
 			rows = append(rows, selStyle.Render(display))


### PR DESCRIPTION
## What this does

Ships the **foundation** of the new-session UX redesign (`NEW-SESSION-UX-PLAN.md` — "the picker IS the interaction"): one ranked candidate source, the structural guards that keep the create flow's known bug classes closed, and a PathSuggest-backed create picker.

### Core — `internal/session/pathsuggest.go`
`PathSuggest` is the single frecency-ranked **candidate source of truth** (plan §3.1), merging:
- recent session paths (recency decay + frequency boost; prefers the worktree repo root over ephemeral worktree dirs),
- group default paths,
- zoxide hits.

It dedups across sources keeping the strongest source, exempts zoxide fuzzy hits from the substring query filter (so `dck` → `agent-deck` survives), and is **pure/deterministic** (all I/O injected) so the TUI picker, the CLI and the ADE endpoints can share one ranking.

### Guards
- **#1540 generalized to the model layer.** The scattered `Type==ItemTypeSession && Session==nil` nil-checks become a single predicate `Item.IsCreatingPlaceholder()`. Move / fork / rename now **refuse** a still-creating placeholder row with a shared `errSessionStillCreating` message instead of panicking (move) or silently no-opping (fork/rename).
- **#1615-class title-lock chokepoint.** `agent-deck add -t "Title"` now locks the title (`shouldLockTitle`) so Claude's folder-name sync can't silently clobber an explicit user title — matching the TUI dialog and `launch` paths. Previously only `--title-lock`/`--no-title-sync` locked it.

### TUI picker
`ZoxidePicker` gains a `PathSuggest`-backed provider: it opens **pre-populated** with the frecency list (no query needed), refreshes per keystroke, annotates each row with its source (recent/group/zoxide), and stays usable **even without zoxide installed**. Wired to `z`.

## AI-model disclosure
Per our own contribution/INTAKE contract: this change was authored with AI assistance (Claude) under maintainer direction; every hunk was written test-first and human-reviewed. No AI attribution is added to commits per repo policy.

## Tests (TDD — each fails on unmodified code, passes after)
- `pathsuggest_test.go` — source hierarchy, recency/frequency ordering, cross-source dedup, query filter + zoxide fuzzy exemption, worktree-root preference, normalize/skip-empty, limit.
- `placeholder_guard_test.go` + `placeholder_mutation_guard_test.go` — the predicate and the home-level move/fork/rename refusal (no panic).
- `title_lock_test.go` — the `-t` lock chokepoint.
- `createpicker_test.go` — provider populates on Show, refreshes on type, renders source hints, bypasses the zoxide-unavailable gate.

Revert-checked: inverting the recency weight, forcing the placeholder predicate false, and dropping `userProvidedTitle` from the chokepoint each turn the corresponding tests red.

Verification (sandboxed HOME+XDG): `go build ./...` green, `gofmt -l` clean on touched files, `go vet` clean, all targeted tests green. The full `internal/ui` suite was deliberately not run (PTY-leak discipline); tests around the touched handlers (fork/rename/move/title/zoxide) pass.

## Closes
- Closes #1540 (placeholder mutation guard generalized)
- Closes #1615 (explicit-title lock chokepoint extended to `add -t`)
- Advances #1536: the picker + `PathSuggest` are the structural replacement for the 4-mode free-text path widget. The widget's actual **deletion** is a deferred Phase-2 item (see below), so #1536 is not auto-closed here.

## Deferred (Phase-2 follow-ups, per plan §5)
- Rebind `n` to the picker + **delete the `newdialog.go` path free-text machinery** (fully closes #1536's class); large, touches the `n`-dialog integration test surface.
- `agent-deck new` CLI verb on `PathSuggest`.
- ADE `/api/paths/suggest` + `/api/paths/complete` endpoints + optional `path` in the launch op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified path suggestions for creating sessions, combining recent locations, group defaults, and zoxide results.
  * Suggestions are ranked by relevance and recency, deduplicated, searchable, and labeled by source.
  * User-provided session titles are now protected from automatic name synchronization.

* **Bug Fixes**
  * Prevented crashes when attempting to move, fork, or rename sessions that are still being created.
  * Added clear feedback when these actions are unavailable.

* **Tests**
  * Added coverage for title locking, path ranking, picker behavior, and placeholder safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->