### PR TITLE
fix(ui): make settings tail reachable + surface resolved config path (closes #1659)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3296,6 +3296,15 @@ func printHelp() {
 	fmt.Println("  AGENTDECK_PROFILE    Default profile to use")
 	fmt.Println("  AGENTDECK_COLOR      Color mode: truecolor, 256, 16, none")
 	fmt.Println()
+	fmt.Println("Configuration:")
+	if configPath, err := session.GetUserConfigPath(); err == nil {
+		fmt.Printf("  Config file: %s\n", configPath)
+	} else {
+		fmt.Println("  Config file: $XDG_CONFIG_HOME/agent-deck/config.toml (default ~/.config/agent-deck/config.toml)")
+	}
+	fmt.Println("  Since v1.9.49 config lives under the XDG base dirs, not ~/.agent-deck.")
+	fmt.Println("  Run 'agent-deck migrate-paths' to copy legacy ~/.agent-deck files across.")
+	fmt.Println()
 	fmt.Println("Keyboard shortcuts (in TUI):")
 	fmt.Println("  n          New session")
 	fmt.Println("  g          New group")

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -1228,8 +1228,24 @@ func (s *SettingsPanel) View() string {
 		if s.scrollOffset < 0 {
 			s.scrollOffset = 0
 		}
-		if maxOff := totalLines - availHeight; s.scrollOffset > maxOff {
+		maxOff := totalLines - availHeight
+		if s.scrollOffset > maxOff {
 			s.scrollOffset = maxOff
+		}
+		// When the cursor sits on the last navigable setting, scroll all the
+		// way to the bottom so the trailing info lines (MCP config-path hint +
+		// help bar) come into view and the "▼ more below" indicator clears.
+		// Scrolling is cursor-anchored, so without this the tail is
+		// unreachable (issue #1659). Never scroll past the cursor's context
+		// window, in case the tail ever grows taller than the viewport.
+		if s.cursor == settingsCount-1 && s.scrollOffset < maxOff {
+			bottomOff := maxOff
+			if lim := cursorLine - 2; bottomOff > lim {
+				bottomOff = lim
+			}
+			if s.scrollOffset < bottomOff {
+				s.scrollOffset = bottomOff
+			}
 		}
 
 		// Determine visible window, replacing edge content lines with scroll indicators

--- a/internal/ui/settings_panel_scroll_tail_test.go
+++ b/internal/ui/settings_panel_scroll_tail_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #1659: scrolling in the settings panel is cursor-anchored, and the
+// content below the last navigable setting (MCP config-path hint + help bar)
+// was permanently unreachable — "▼ more below" never cleared even with the
+// cursor on the last setting. With the fix, parking the cursor on the last
+// setting scrolls the tail into view.
+func TestSettingsPanel_LastSetting_ScrollsTailIntoView(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	panel := NewSettingsPanel()
+	// Height short enough to force scroll-windowing in View().
+	panel.SetSize(100, 20)
+	panel.Show()
+	panel.cursor = settingsCount - 1
+
+	view := panel.View()
+
+	// Sanity: the panel must actually be in scroll mode, and scrolled down.
+	if !containsString(view, "more above") {
+		t.Fatal("test must run with a small enough height to force scroll mode; " +
+			"'▲ more above' did not appear in the view")
+	}
+	// The tail must be fully visible: no "more below" indicator...
+	if containsString(view, "more below") {
+		t.Errorf("'▼ more below' must clear when the cursor is on the last setting. Got:\n%s", view)
+	}
+	// ...and the trailing info lines must be on screen.
+	if !containsString(view, "MCP SERVERS & CUSTOM TOOLS") {
+		t.Errorf("trailing MCP section must scroll into view at the last setting. Got:\n%s", view)
+	}
+	// (token chosen to survive lipgloss word-wrapping of the help bar)
+	if !containsString(view, "j/k Navigate") {
+		t.Errorf("help bar must scroll into view at the last setting. Got:\n%s", view)
+	}
+	// The cursor's own row must still be visible.
+	if !containsString(view, "Visible tools") {
+		t.Errorf("last setting row must remain visible after scrolling to the tail. Got:\n%s", view)
+	}
+}


### PR DESCRIPTION
## What

Two small, related fixes for settings + config discoverability, both reported by Jay OConnor.

### 1. Settings tail is now reachable (closes #1659)

Scrolling in the settings panel is exclusively cursor-anchored, and the bottom-context rule capped `scrollOffset` below `maxOff`, so the ~6 trailing lines (the MCP config-path hint plus the help bar) were permanently unreachable and the "▼ more below" indicator never cleared even at the bottom of the list. When the cursor sits on the last navigable setting we now clamp `scrollOffset` up to `maxOff` (bounded by the cursor's context window) so the tail scrolls into view and the false indicator clears.

Regression test `settings_panel_scroll_tail_test.go` renders the panel at height 20 with the cursor on the last setting and asserts the tail is visible and the indicator clears; it fails without the fix.

### 2. Surface the resolved config path (addresses #1660)

Since v1.9.49 config lives under the XDG base dirs (default `~/.config/agent-deck/config.toml`), not `~/.agent-deck/config.toml`. Users who looked in the old location thought settings were never saved. `agent-deck help` now has a Configuration section that prints the resolved path via `agentpaths.EffectiveConfigPath` and points at `migrate-paths`, so the real location is always discoverable. The same resolved path is now reachable in the settings panel too, thanks to fix 1.

## Testing

- `gofmt` and `go vet` clean on the changed packages
- `TestSettingsPanel_LastSetting_ScrollsTailIntoView` passes (sandboxed HOME/XDG)
- `agent-deck help` prints the resolved config path

## Credit

Both issues reported by Jay OConnor (@jdoconnor). Thanks Jay for the clear repro steps.

## AI model disclosure

Per our INTAKE contract: this change was prepared with AI assistance (model: Fable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings scrolling so the final setting and trailing content remain visible when navigating to the bottom.
  * Prevented the settings panel from scrolling beyond the relevant cursor context.

* **Documentation**
  * Updated help output with the resolved configuration path.
  * Added guidance about XDG configuration locations and migrating legacy files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->