### PR TITLE
docs: add maintainers & contributors wanted section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@
 
 https://github.com/user-attachments/assets/e4f55917-435c-45ba-92cc-89737d0d1401
 
+## Maintainers & contributors wanted
+
+agent-deck is actively maintained by [Ashesh](https://github.com/asheshgoplani), and it welcomes both contributors and co-maintainers. PRs here don't sit: every incoming PR is validated (applied, built, tested) within about a day, and good ones merge in the next release batch. Recent releases have shipped dozens of community fixes.
+
+Beyond one-off PRs, we're looking for 1-2 regular co-maintainers: people who want to own an area (a tool integration, the TUI, the web view, CI) and help triage and review. The validation pipeline does the heavy lifting; maintainers steer.
+
+To get started:
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) for how the review pipeline works.
+- Start at the pinned issue: [Looking for contributors — start here (#1650)](https://github.com/asheshgoplani/agent-deck/issues/1650).
+- The [agent-deck-contributor skill](.github/skills/agent-deck-contributor) walks an AI agent (or you) through building, testing, and shaping a clean PR.
+
+If you've had a couple of PRs land here and want to help steer, say so on #1650 or open an issue titled "maintainer: your area". We'd love the help.
+
 ## Installation
 
 **Works on:** macOS, Linux, Windows (WSL)


### PR DESCRIPTION
Adds a concise "Maintainers & contributors wanted" section near the top of the README (after the intro/video, before Installation).

It states the project is actively maintained by Ashesh, welcomes contributors and 1-2 co-maintainers, and points readers to:
- CONTRIBUTING.md (the review pipeline)
- the pinned start-here issue #1650
- the agent-deck-contributor skill

Plain prose, no em-dash separators. Rides in the v1.10.10 release batch.

Committed by Ashesh Goplani