### PR TITLE
fix(ui): align remote host header flush with local root groups

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -16258,16 +16258,28 @@ func (h *Home) renderRemotePreview(item session.Item, width, height int) string 
 	return b.String()
 }
 
+// remoteRowGutter returns the fixed-width left gutter for a remote row: the
+// selection arrow "▶ " when selected, else leftGutterWidth blanks. Both are the
+// same display width, so selecting a row never shifts it, and the Level-0 remote
+// host header lands flush with local root groups (which likewise start their
+// content right after the gutter). This replaces the separate selection-arrow
+// column (selPrefix) that over-indented the whole remote subtree by one level
+// (#1553 regression): the arrow now lives inside the gutter instead of after it.
+func remoteRowGutter(selected bool) string {
+	if selected {
+		return "▶ "
+	}
+	return strings.Repeat(" ", leftGutterWidth)
+}
+
 // renderRemoteGroupItem renders a remote group header (e.g., "remotes/dev")
 func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, selected bool) {
 	nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true) // yellow
 	countStyle := DimStyle
 	expandIcon := "▾"
-	selPrefix := "  "
 	if selected {
 		nameStyle = GroupNameSelStyle
 		countStyle = GroupCountSelStyle
-		selPrefix = "▶ "
 	}
 
 	// #1553: Level > 0 is a nested sub-group header ("remotes/<name>/<group>").
@@ -16285,9 +16297,8 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 			segName = groupPath[idx+1:]
 		}
 
-		b.WriteString(fmt.Sprintf("%s%s%s%s %s%s\n",
-			strings.Repeat(" ", leftGutterWidth), // align with group hotkey gutter
-			selPrefix,
+		b.WriteString(fmt.Sprintf("%s%s%s %s%s\n",
+			remoteRowGutter(selected),        // align with group hotkey gutter
 			strings.Repeat("  ", item.Level), // nest under the remote header
 			expandIcon,
 			nameStyle.Render(segName),
@@ -16304,9 +16315,8 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 	}
 	h.remoteSessionsMu.RUnlock()
 
-	b.WriteString(fmt.Sprintf("%s%s%s %s%s%s\n",
-		strings.Repeat(" ", leftGutterWidth), // align with group hotkey gutter
-		selPrefix,
+	b.WriteString(fmt.Sprintf("%s%s %s%s%s\n",
+		remoteRowGutter(selected), // align with group hotkey gutter (flush with local root groups)
 		expandIcon,
 		nameStyle.Render("remotes/"+item.RemoteName),
 		countStyle.Render(fmt.Sprintf(" (%d)", count)),
@@ -16409,24 +16419,16 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 		treeConnector = "└─"
 	}
 
-	selPrefix := "  "
-	if selected {
-		selPrefix = "▶ "
-	}
-
 	// #1553: indent by the item's level so sessions sit one step below their
 	// owning group header. A session directly under a Level-1 group renders at
-	// Level 2 -> `strings.Repeat("  ", 2)` == 4 spaces; the old flat layout put
-	// sessions at Level 1 with a hardcoded 2-space indent, so Level-1 rows stay
-	// byte-identical to before.
+	// Level 2 -> `strings.Repeat("  ", 2)` == 4 spaces.
 	indent := strings.Repeat("  ", item.Level)
 	if item.Level == 0 {
 		indent = "  " // defensive: never dedent past the old flat baseline
 	}
 
-	b.WriteString(fmt.Sprintf("%s%s%s%s %s %s%s\n",
-		strings.Repeat(" ", leftGutterWidth), // align with group/session hotkey gutter
-		selPrefix,
+	b.WriteString(fmt.Sprintf("%s%s%s %s %s%s\n",
+		remoteRowGutter(selected), // align with group/session hotkey gutter
 		indent,
 		DimStyle.Render(treeConnector),
 		sStyle.Render(statusIcon),

--- a/internal/ui/remote_indent_test.go
+++ b/internal/ui/remote_indent_test.go
@@ -1,0 +1,75 @@
+// Remote rows must align with local root groups.
+//
+// #1553 nested remote sessions under their group paths but rendered every remote
+// row (host header, sub-group, session) with a dedicated 2-col selection-arrow
+// column (selPrefix) that local group headers don't reserve. Since one indent
+// level is 2 cols, that column shifted the whole remote subtree — including the
+// Level-0 host header — one level to the right, so the host header rendered at
+// the visual position of Level 1 instead of flush with local root groups.
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// leadDisplayWidth returns the display width of the text before the first
+// occurrence of marker (the indent preceding a row's first glyph).
+func leadDisplayWidth(line, marker string) int {
+	idx := strings.Index(line, marker)
+	if idx < 0 {
+		return -1
+	}
+	return lipgloss.Width(line[:idx])
+}
+
+func TestRemoteRows_AlignWithRootGroups_NoExtraIndent(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {{ID: "r1", Title: "worker-1", Status: "running", Group: "work"}},
+	}
+	sessions := h.remoteSessions["dev"]
+
+	render := func(item session.Item, selected bool) string {
+		var b strings.Builder
+		switch item.Type {
+		case session.ItemTypeRemoteGroup:
+			h.renderRemoteGroupItem(&b, item, selected)
+		case session.ItemTypeRemoteSession:
+			h.renderRemoteSessionItem(&b, item, selected)
+		}
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	// Level-0 host header sits flush with local root groups: its content starts
+	// right after the leftGutterWidth gutter, with no extra arrow column.
+	header := render(session.Item{Type: session.ItemTypeRemoteGroup, RemoteName: "dev", Path: "remotes/dev", Level: 0}, false)
+	if w := leadDisplayWidth(header, "▾"); w != leftGutterWidth {
+		t.Errorf("remote host header indent = %d cols, want %d (flush with local root groups)\n  line: %q", w, leftGutterWidth, header)
+	}
+
+	// Sub-group (Level 1) nests exactly one level under the host header.
+	sub := render(session.Item{Type: session.ItemTypeRemoteGroup, RemoteName: "dev", Path: "remotes/dev/work", Level: 1}, false)
+	if w := leadDisplayWidth(sub, "▾"); w != leftGutterWidth+2 {
+		t.Errorf("remote sub-group indent = %d cols, want %d (one level under host header)\n  line: %q", w, leftGutterWidth+2, sub)
+	}
+
+	// Session (Level 2) nests exactly one level under its sub-group.
+	sessLine := render(session.Item{Type: session.ItemTypeRemoteSession, RemoteName: "dev", RemoteSession: &sessions[0], Path: "remotes/dev/work", Level: 2}, false)
+	if w := leadDisplayWidth(sessLine, "├"); w != leftGutterWidth+4 {
+		t.Errorf("remote session indent = %d cols, want %d (one level under sub-group)\n  line: %q", w, leftGutterWidth+4, sessLine)
+	}
+
+	// Selecting a row must not shift it: the arrow replaces the gutter blanks,
+	// keeping the same display width.
+	headerSel := render(session.Item{Type: session.ItemTypeRemoteGroup, RemoteName: "dev", Path: "remotes/dev", Level: 0}, true)
+	if w := leadDisplayWidth(headerSel, "▾"); w != leftGutterWidth {
+		t.Errorf("selected remote host header indent = %d cols, want %d (selection must not shift the row)\n  line: %q", w, leftGutterWidth, headerSel)
+	}
+}


### PR DESCRIPTION
## Problem

Remote sessions in the left panel render **one indent level too deep**. The Level-0 remote host header (`remotes/<name>`) sits at Level 1's visual position instead of flush with local root groups:

```
1·▾ development          ← local root group (flush at the gutter)
    ▾ remotes/dev (1)    ← remote host header — indented one level too far
```

## Root cause

The remote-row renderers (`renderRemoteGroupItem`, `renderRemoteSessionItem`) from #1553 prepend a 2-column selection-arrow field (`selPrefix` = `"  "` normally, `"▶ "` when selected) **after** the `leftGutterWidth` gutter on *every* remote row — including the host header. Local group headers (`renderGroupItem`) don't reserve that column; they show selection via style. Since one indent level is 2 columns, that extra field shifts the whole remote subtree — host header included — one level to the right.

## Fix

Replace `selPrefix` with a `remoteRowGutter(selected)` helper: the `▶` selection arrow now lives **inside** the gutter (same display width whether selected or not) instead of after it.

- Host header → flush at the gutter, aligned with local root groups.
- Sub-groups (+2) and sessions (+4) keep their one-level-per-depth nesting.
- Selecting a row no longer shifts it (arrow replaces the gutter blanks).

## Tests

`internal/ui/remote_indent_test.go` asserts, via `lipgloss.Width`, the exact indent of the host header (flush = `leftGutterWidth`), sub-group (+2), session (+4), and that selection doesn't shift the row. All existing remote-render tests (issue1091/1103/1066, #1553 nesting, view-mode wiring, selected-state) pass under `-race`; `go build ./...`, `gofmt`, `go vet` clean.

Reviewed by an adversarial Go pass: confirmed the alignment math matches `renderGroupItem`'s nesting, that the `▶`-width assumption is a pre-existing app-wide idiom (not introduced here), and that removing 2 columns breaks nothing downstream (mouse hit-testing is Y-only; no truncation/width logic depends on the offset).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment of remote hosts, groups, and sessions in the remote subtree.
  * Corrected extra indentation when selecting remote rows.
  * Preserved remote latency indicators and level-based indentation.

* **Tests**
  * Added regression coverage to verify consistent indentation and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->