### PR TITLE
chore(ci): recalibrate lighthouse total-byte-weight budget

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -24,13 +24,48 @@
     },
     "assert": {
       "assertions": {
-        "total-byte-weight": ["error", { "maxNumericValue": 349580 }],
-        "resource-summary:script:size": ["error", { "maxNumericValue": 329757 }],
-        "first-contentful-paint": ["warn", { "maxNumericValue": 800 }],
-        "largest-contentful-paint": ["warn", { "maxNumericValue": 1300 }],
-        "total-blocking-time": ["warn", { "maxNumericValue": 200 }],
-        "speed-index": ["warn", { "maxNumericValue": 1100 }],
-        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }],
+        "total-byte-weight": [
+          "error",
+          {
+            "maxNumericValue": 368000
+          }
+        ],
+        "resource-summary:script:size": [
+          "error",
+          {
+            "maxNumericValue": 329757
+          }
+        ],
+        "first-contentful-paint": [
+          "warn",
+          {
+            "maxNumericValue": 800
+          }
+        ],
+        "largest-contentful-paint": [
+          "warn",
+          {
+            "maxNumericValue": 1300
+          }
+        ],
+        "total-blocking-time": [
+          "warn",
+          {
+            "maxNumericValue": 200
+          }
+        ],
+        "speed-index": [
+          "warn",
+          {
+            "maxNumericValue": 1100
+          }
+        ],
+        "cumulative-layout-shift": [
+          "error",
+          {
+            "maxNumericValue": 0.1
+          }
+        ],
         "is-on-https": "off",
         "uses-http2": "off",
         "redirects-http": "off",


### PR DESCRIPTION
The absolute total-byte-weight budget (349580) predates recent legitimate bundle growth (#1614 SSE status, #1662 terminal keymap). Current main is ~350.6KB, so every web PR now trips the absolute assert regardless of its own delta — #1662 failed on a 984-byte increase. Recalibrates to 368000 (~5% headroom over current, same margin as the original calibration). Per-PR bloat is still caught by the 5% delta gate, which remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted performance monitoring thresholds for improved readability.
  * Preserved existing Lighthouse performance limits and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->