### PR TITLE
fix(ui): recompute IsLastInGroup so the last visible group row renders └─

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2322,6 +2322,38 @@ func (h *Home) rebuildFlatItems() {
 		h.flatItems = session.PartitionByViewMode(h.flatItems, h.groupViewMode, activity)
 	}
 
+	// Recompute IsLastInGroup on the final visible list. GroupTree.Flatten sets
+	// it over a group's full session list (archived sessions included), but the
+	// archived/status filtering and view-mode partitioning above can drop or
+	// reorder the trailing rows — leaving the flag on a session that is no longer
+	// visually last, so the last VISIBLE row renders ├─ instead of └─ (seen when
+	// a group's trailing sessions are archived). A group's session rows share the
+	// group's Path; walking backwards, the first row seen for a Path is the true
+	// last row of that group's current segment. Only top-level sessions drive the
+	// └─ connector (sub-sessions use IsLastSubSession), so only they are rewritten
+	// here. Runs before window injection so injected windows inherit the flag.
+	seenLaterRowInGroup := make(map[string]bool)
+	for i := len(h.flatItems) - 1; i >= 0; i-- {
+		it := &h.flatItems[i]
+		if it.Type == session.ItemTypeGroup {
+			// A group header starts a fresh segment for its Path. View-mode
+			// partitioning can duplicate a header and split one group's rows into
+			// separate top/bottom sections that each end with their own └─, so a
+			// later section's "seen" must not leak backward across the header into
+			// an earlier section of the same Path.
+			delete(seenLaterRowInGroup, it.Path)
+			continue
+		}
+		if it.Type != session.ItemTypeSession || it.Session == nil {
+			continue
+		}
+		isLastRow := !seenLaterRowInGroup[it.Path]
+		seenLaterRowInGroup[it.Path] = true
+		if !it.IsSubSession {
+			it.IsLastInGroup = isLastRow
+		}
+	}
+
 	// Inject window items after sessions that have 2+ windows
 	if len(h.flatItems) > 0 {
 		expanded := make([]session.Item, 0, len(h.flatItems)+8)

--- a/internal/ui/islastingroup_archived_test.go
+++ b/internal/ui/islastingroup_archived_test.go
@@ -1,0 +1,112 @@
+// The last VISIBLE session in a group must render └─ (IsLastInGroup=true) even
+// when the group's trailing sessions are archived.
+//
+// GroupTree.Flatten() sets IsLastInGroup over a group's full session list —
+// archived sessions included — so a trailing archived session gets the "last"
+// flag. rebuildFlatItems then filters archived sessions out, leaving the last
+// VISIBLE session with a stale IsLastInGroup=false, which renders ├─ instead of
+// └─ (observed on the ops/home groups, 2026-07-18). rebuildFlatItems recomputes
+// the flag on the final visible list to fix this.
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestIsLastInGroup_ArchivedSessionAtGroupEnd_LastVisibleRendersLast(t *testing.T) {
+	home := NewHome()
+	home.width, home.height = 120, 40
+	home.initialLoading = false
+
+	a1 := session.NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	a2 := session.NewInstanceWithTool("a2", "/tmp/a2", "claude")
+	a3 := session.NewInstanceWithTool("a3", "/tmp/a3", "claude")
+	for _, in := range []*session.Instance{a1, a2, a3} {
+		in.GroupPath = "alpha"
+		in.Status = session.StatusIdle
+	}
+	// a3 is the trailing session in the group AND archived — this is the one
+	// Flatten marks IsLastInGroup, then rebuildFlatItems filters it away.
+	a3.ArchivedAt = time.Now()
+
+	instances := []*session.Instance{a1, a2, a3}
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(instances)
+	home.rebuildFlatItems()
+
+	// Archived a3 must be filtered out of the visible list.
+	if idx := sessionIndexByTitle(home, "a3"); idx >= 0 {
+		t.Fatalf("archived session a3 should be filtered from the visible list, found at index %d", idx)
+	}
+
+	// a2 is now the last VISIBLE session in "alpha" → must be flagged last (└─).
+	a2idx := sessionIndexByTitle(home, "a2")
+	if a2idx < 0 {
+		t.Fatalf("a2 not present in flatItems")
+	}
+	if !home.flatItems[a2idx].IsLastInGroup {
+		t.Errorf("last visible session a2 has IsLastInGroup=false → renders ├─ instead of └─ " +
+			"(stale flag from archived a3 at group end)")
+	}
+
+	// a1 is not last → must not be flagged.
+	a1idx := sessionIndexByTitle(home, "a1")
+	if a1idx < 0 {
+		t.Fatalf("a1 not present in flatItems")
+	}
+	if home.flatItems[a1idx].IsLastInGroup {
+		t.Errorf("non-last session a1 has IsLastInGroup=true")
+	}
+}
+
+// View-mode partitioning (ActiveTop/PopulatedTop) can duplicate a group header
+// and split one group's rows into separate top/bottom sections that share the
+// same Path. Each section ends with its own └─, so the recompute must track
+// last-row per header segment — not leak a later section's "seen" backward into
+// an earlier one. Regression for the header-duplication case.
+func TestIsLastInGroup_ViewModeSplit_EachSectionEndsWithLast(t *testing.T) {
+	home := NewHome()
+	home.width, home.height = 120, 40
+	home.initialLoading = false
+
+	c := session.NewInstanceWithTool("c-idle", "/tmp/c", "claude")
+	a := session.NewInstanceWithTool("a-active", "/tmp/a", "claude")
+	c.GroupPath, a.GroupPath = "alpha", "alpha"
+	c.Status = session.StatusIdle
+	// a is active (→ top section) AND last in the group's tree order, so Flatten
+	// marks it IsLastInGroup=true; the recompute must not flip it to false just
+	// because c (same Path) sits in the duplicated bottom section.
+	a.Status = session.StatusRunning
+
+	instances := []*session.Instance{c, a}
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(instances)
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	// Sanity: the view mode actually split the list (a divider is present).
+	if dividerIndex(home) < 0 {
+		t.Fatalf("expected ActiveTop to split the group with a divider; flatItems=%d", len(home.flatItems))
+	}
+
+	aidx := sessionIndexByTitle(home, "a-active")
+	if aidx < 0 {
+		t.Fatalf("a-active not in flatItems")
+	}
+	if !home.flatItems[aidx].IsLastInGroup {
+		t.Errorf("a-active is the last row of the top section but IsLastInGroup=false → renders ├─ " +
+			"(header-duplication leaked the bottom section's flag backward)")
+	}
+	cidx := sessionIndexByTitle(home, "c-idle")
+	if cidx < 0 || !home.flatItems[cidx].IsLastInGroup {
+		t.Errorf("c-idle is the last row of the bottom section but IsLastInGroup=false")
+	}
+}


### PR DESCRIPTION
## Problem

The last visible session of a group renders the mid-tree connector `├─` instead of the last-item connector `└─` when the group's trailing sessions are archived:

```
▾ ops
  ├─ ○ appcloud troubleshoot
  ├─ ○ setup SSH Auth
  ├─ ◐ appcloud aws
  ├─ ○ argocd            ← last VISIBLE row, but shows ├─ (should be └─)
```

Reproduces on any group whose highest-`sort_order` sessions are archived (ops, home, research); groups whose last session is active (development, shell) are unaffected.

## Root cause

`GroupTree.Flatten()` sets `IsLastInGroup` over a group's **full** session list — archived sessions included — so a trailing *archived* session gets the "last" flag. `rebuildFlatItems` then filters archived sessions out (and applies the status filter / view-mode partition) **after** the flag is baked in, leaving the last *visible* session with a stale `IsLastInGroup=false`. The connector (`renderSessionItem`) only consults `IsLastInGroup` for top-level sessions, so that row renders `├─`.

## Fix

A single backward pass in `rebuildFlatItems`, after view-mode partitioning and before window injection, recomputes `IsLastInGroup` on the **final visible list**. A group's session rows share the group's `Path`; walking backwards, the first row seen per `Path` **segment** is the true last row.

A group-header reset (`delete(seen, header.Path)`) scopes the tracking per segment, because `PartitionByViewMode` duplicates a group header and splits a group's rows into top/bottom sections that share the same `Path` — each section must end with its own `└─`.

Only top-level sessions are rewritten (sub-sessions use `IsLastSubSession`). In the unsplit, unfiltered case this reproduces `Flatten`'s own result exactly, so it's a no-op there; it only corrects the flag when filtering/partitioning changed which row is actually last.

## Tests

`internal/ui/islastingroup_archived_test.go`:
- **archived at group end** → the last visible row has `IsLastInGroup=true` (the reported bug).
- **ActiveTop split** → both the top-section and bottom-section last rows are flagged (guards the header-duplication case).

Both pass under `-race`; the full group/tree/view-mode-wiring/nav/nesting/window suite passes; `go build`/`gofmt`/`vet` clean.

## Review

Went through two rounds of adversarial Go review. Round 1 caught a real regression in the view-mode-partition path (a `Path`-keyed pass without the header reset flipped a correct `└─` to `├─` for a split group's top section); fixed with the header-reset and a dedicated regression test (verified via negative control that the test fails without the fix). Round 2 confirmed resolved with no new issues.

Out of scope (pre-existing, noted): `IsLastSubSession` has the same staleness one level deeper for a trailing archived *sub*-session — not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected group connector indicators when filtering removes the final session.
  * Fixed connector rendering for groups split across separate view sections.
  * Ensured the last visible session in each group section displays the appropriate ending indicator.

* **Tests**
  * Added regression coverage for archived sessions and split view layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->