### PR TITLE
chore(ci): pin remaining third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       # the same PR — SQL parameterization annotated, pprof timeouts added,
       # G115/G117/G118/G122/G306/G703/G704 false positives carry // #nosec
       # explanations, testutil/eval paths excluded via .golangci.yml.
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with: { version: latest, args: --timeout=5m }

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run GoReleaser (snapshot, no publish)
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: '~> v2'
           args: release --snapshot --skip=publish --clean


### PR DESCRIPTION
## What

Pins the two remaining floating third-party action references to full commit SHAs, matching the pinning style already used in `release.yml`:

- `.github/workflows/release-snapshot.yml`: `goreleaser/goreleaser-action@v7` -> `f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7` (resolved from the `v7` tag via the GitHub API)
- `.github/workflows/golangci-lint.yml`: `golangci/golangci-lint-action@v9` -> `ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9` (the `v9` annotated tag dereferenced to its commit, which is the v9.3.0 release)

## Why

SECURITY.md states "GitHub Actions are pinned by SHA where third-party." Before this change that was not true for these two workflows. After this change, every non-GitHub-owned action across all workflows is SHA-pinned (`actions/*` and `github/codeql-action` are GitHub-owned and remain tag-pinned), so the SECURITY.md claim needs no wording change and now matches reality.

No behavior change: both SHAs resolve to exactly the code the floating tags pointed at when resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned CI linting and release snapshot tools to specific versions for more consistent and reliable automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->