### PR TITLE
feat(session): handoff prompt builder + read-only `session handoff` command (runtime-switch phase 1)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -53,6 +53,8 @@ func handleSession(profile string, args []string) {
 		handleSessionRevive(profile, args[1:])
 	case "fork":
 		handleSessionFork(profile, args[1:])
+	case "handoff":
+		handleSessionHandoff(profile, args[1:])
 	case "attach":
 		handleSessionAttach(profile, args[1:])
 	case "focus":
@@ -117,6 +119,7 @@ func printSessionHelp() {
 	fmt.Println("  restart [id] [--all] [--env KEY=VALUE]  Restart session (Claude: reload MCPs)")
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
 	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
+	fmt.Println("  handoff <id>            Build a cross-tool handoff prompt from the session's conversation (read-only)")
 	fmt.Println("  attach <id>             Attach to session interactively")
 	fmt.Println("  focus <id> [--attach]   Signal the running TUI to select (or --attach) a session")
 	fmt.Println("  show [id]               Show session details (auto-detect current if no id)")

--- a/cmd/agent-deck/session_handoff.go
+++ b/cmd/agent-deck/session_handoff.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleSessionHandoff builds a cross-tool handoff prompt from a session's
+// conversation history. Read-only: it never mutates the source session; the
+// caller (or a future `session switch`) feeds the prompt to a new session.
+func handleSessionHandoff(profile string, args []string) {
+	fs := flag.NewFlagSet("session handoff", flag.ExitOnError)
+	maxChars := fs.Int("max-chars", session.DefaultHandoffMaxChars, "Maximum transcript characters to include (tail-truncated)")
+	outPath := fs.String("out", "", "Write the prompt to a file instead of stdout")
+	jsonOutput := fs.Bool("json", false, "Output prompt + info as JSON")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session handoff <id|title> [options]")
+		fmt.Println()
+		fmt.Println("Build a handoff prompt carrying the session's Claude conversation into")
+		fmt.Println("another runtime (e.g. a fresh Codex session). Read-only: the source")
+		fmt.Println("session is not modified. Pair with `add` + `session send` to complete")
+		fmt.Println("the handoff, or use higher-level tooling that wraps this command.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	identifier := fs.Arg(0)
+	out := NewCLIOutput(*jsonOutput, false)
+
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	inst, errMsg, errCode := ResolveSessionOrCurrent(identifier, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		os.Exit(1)
+	}
+
+	prompt, info, err := session.BuildClaudeToCodexHandoffPrompt(inst, *maxChars)
+	if err != nil {
+		out.Error(fmt.Sprintf("build handoff prompt: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	if *jsonOutput {
+		payload := struct {
+			Prompt string              `json:"prompt"`
+			Info   session.HandoffInfo `json:"info"`
+		}{Prompt: prompt, Info: info}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(payload); err != nil {
+			out.Error(err.Error(), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, []byte(prompt), 0o600); err != nil {
+			out.Error(fmt.Sprintf("write %s: %v", *outPath, err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Println(prompt)
+	}
+	fmt.Fprintf(os.Stderr, "handoff: %d/%d messages included (truncated=%v, max %d chars) from %s\n",
+		info.IncludedCount, info.MessageCount, info.Truncated, info.MaxChars, info.TranscriptPath)
+}

--- a/cmd/agent-deck/session_handoff.go
+++ b/cmd/agent-deck/session_handoff.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -70,6 +71,10 @@ func handleSessionHandoff(profile string, args []string) {
 	}
 
 	if *outPath != "" {
+		if samePath(*outPath, info.TranscriptPath) {
+			out.Error("--out refuses to overwrite the source transcript", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
 		if err := os.WriteFile(*outPath, []byte(prompt), 0o600); err != nil {
 			out.Error(fmt.Sprintf("write %s: %v", *outPath, err), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -79,4 +84,20 @@ func handleSessionHandoff(profile string, args []string) {
 	}
 	fmt.Fprintf(os.Stderr, "handoff: %d/%d messages included (truncated=%v, max %d chars) from %s\n",
 		info.IncludedCount, info.MessageCount, info.Truncated, info.MaxChars, info.TranscriptPath)
+}
+
+// samePath reports whether two paths refer to the same file, following
+// symlinks when the targets exist.
+func samePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	ra, errA := filepath.EvalSymlinks(a)
+	rb, errB := filepath.EvalSymlinks(b)
+	if errA == nil && errB == nil {
+		return ra == rb
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	return errA == nil && errB == nil && filepath.Clean(absA) == filepath.Clean(absB)
 }

--- a/internal/session/handoff.go
+++ b/internal/session/handoff.go
@@ -1,0 +1,255 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const DefaultHandoffMaxChars = 32000
+
+// HandoffInfo describes the source transcript used to build a tool handoff.
+type HandoffInfo struct {
+	TranscriptPath string `json:"transcript_path"`
+	MessageCount   int    `json:"message_count"`
+	IncludedCount  int    `json:"included_count"`
+	Truncated      bool   `json:"truncated"`
+	MaxChars       int    `json:"max_chars"`
+}
+
+type handoffMessage struct {
+	Role    string
+	Content string
+}
+
+// BuildClaudeToCodexHandoffPrompt builds a prompt that carries a Claude
+// transcript into a fresh Codex session. This intentionally does not try to
+// write Codex's private rollout JSONL format; the stable cross-tool contract is
+// a plain initial prompt containing the prior conversation tail.
+func BuildClaudeToCodexHandoffPrompt(inst *Instance, maxChars int) (string, HandoffInfo, error) {
+	if inst == nil {
+		return "", HandoffInfo{}, fmt.Errorf("session is nil")
+	}
+	if maxChars <= 0 {
+		maxChars = DefaultHandoffMaxChars
+	}
+	if inst.ClaudeSessionID == "" {
+		return "", HandoffInfo{}, fmt.Errorf("session %q has no Claude session ID", inst.Title)
+	}
+
+	transcriptPath := ClaudeTranscriptPathForInstance(inst)
+	messages, err := readClaudeTranscriptMessages(transcriptPath)
+	if err != nil {
+		return "", HandoffInfo{TranscriptPath: transcriptPath, MaxChars: maxChars}, err
+	}
+	if len(messages) == 0 {
+		return "", HandoffInfo{TranscriptPath: transcriptPath, MaxChars: maxChars}, fmt.Errorf("Claude transcript has no readable messages: %s", transcriptPath)
+	}
+
+	included, truncated := tailMessagesByChars(messages, maxChars)
+	var body strings.Builder
+	for idx, msg := range included {
+		if idx > 0 {
+			body.WriteString("\n\n")
+		}
+		body.WriteString("[")
+		body.WriteString(strings.ToUpper(msg.Role))
+		body.WriteString("]\n")
+		body.WriteString(msg.Content)
+	}
+
+	prompt := fmt.Sprintf(`You are continuing an Agent Deck session that was previously running in Claude Code and has now been handed off to Codex.
+
+Original session:
+- title: %s
+- project: %s
+- previous tool: %s
+- previous Claude session ID: %s
+
+The transcript below is prior conversation context. Treat it as conversation history for this handoff and continue from it. Do not claim you cannot access prior messages; this handoff prompt is the transferred history.
+
+--- BEGIN TRANSFERRED TRANSCRIPT ---
+%s
+--- END TRANSFERRED TRANSCRIPT ---
+
+This message is context initialization only. Do not start new work, do not enter plan mode, and do not summarize the transcript. Reply exactly: HANDOFF RECEIVED.`, inst.Title, inst.ProjectPath, inst.Tool, inst.ClaudeSessionID, body.String())
+
+	return prompt, HandoffInfo{
+		TranscriptPath: transcriptPath,
+		MessageCount:   len(messages),
+		IncludedCount:  len(included),
+		Truncated:      truncated,
+		MaxChars:       maxChars,
+	}, nil
+}
+
+// ClaudeTranscriptPathForInstance returns the expected JSONL transcript path
+// for the instance's Claude session ID.
+func ClaudeTranscriptPathForInstance(inst *Instance) string {
+	if inst == nil || inst.ClaudeSessionID == "" {
+		return ""
+	}
+	projectPath := inst.ProjectPath
+	if resolved, err := filepath.EvalSymlinks(projectPath); err == nil {
+		projectPath = resolved
+	}
+	return filepath.Join(
+		GetClaudeConfigDirForInstance(inst),
+		"projects",
+		ConvertToClaudeDirName(projectPath),
+		inst.ClaudeSessionID+".jsonl",
+	)
+}
+
+func readClaudeTranscriptMessages(path string) ([]handoffMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read Claude transcript: %w", err)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	var messages []handoffMessage
+	for scanner.Scan() {
+		msg, ok := parseClaudeTranscriptLine(scanner.Bytes())
+		if ok {
+			messages = append(messages, msg)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan Claude transcript: %w", err)
+	}
+	return messages, nil
+}
+
+func parseClaudeTranscriptLine(line []byte) (handoffMessage, bool) {
+	var raw struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return handoffMessage{}, false
+	}
+
+	role := strings.TrimSpace(raw.Message.Role)
+	if role == "" {
+		role = strings.TrimSpace(raw.Type)
+	}
+	switch role {
+	case "user", "assistant", "system":
+	default:
+		return handoffMessage{}, false
+	}
+
+	content := strings.TrimSpace(renderClaudeContent(raw.Message.Content))
+	if content == "" {
+		return handoffMessage{}, false
+	}
+	return handoffMessage{Role: role, Content: content}, true
+}
+
+func renderClaudeContent(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+
+	var blocks []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			part := renderClaudeContentBlock(block)
+			if part != "" {
+				parts = append(parts, part)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return compactJSON(raw)
+	}
+	return string(raw)
+}
+
+func renderClaudeContentBlock(block map[string]json.RawMessage) string {
+	var typ string
+	_ = json.Unmarshal(block["type"], &typ)
+
+	switch typ {
+	case "text":
+		var text string
+		_ = json.Unmarshal(block["text"], &text)
+		return strings.TrimSpace(text)
+	case "thinking":
+		return ""
+	case "tool_use":
+		var name string
+		_ = json.Unmarshal(block["name"], &name)
+		input := compactJSON(block["input"])
+		if input == "" {
+			return fmt.Sprintf("[tool_use %s]", name)
+		}
+		return fmt.Sprintf("[tool_use %s] %s", name, input)
+	case "tool_result":
+		content := renderClaudeContent(block["content"])
+		if content == "" {
+			return "[tool_result]"
+		}
+		return "[tool_result]\n" + content
+	default:
+		if typ != "" {
+			return "[" + typ + "] " + compactJSONMust(block)
+		}
+		return compactJSONMust(block)
+	}
+}
+
+func tailMessagesByChars(messages []handoffMessage, maxChars int) ([]handoffMessage, bool) {
+	if maxChars <= 0 || len(messages) == 0 {
+		return messages, false
+	}
+	total := 0
+	start := len(messages)
+	for i := len(messages) - 1; i >= 0; i-- {
+		cost := len(messages[i].Role) + len(messages[i].Content) + 8
+		if total > 0 && total+cost > maxChars {
+			break
+		}
+		total += cost
+		start = i
+	}
+	return messages[start:], start > 0
+}
+
+func compactJSON(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}
+
+func compactJSONMust(v any) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return compactJSON(raw)
+}

--- a/internal/session/handoff.go
+++ b/internal/session/handoff.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +42,7 @@ func BuildClaudeToCodexHandoffPrompt(inst *Instance, maxChars int) (string, Hand
 		return "", HandoffInfo{}, fmt.Errorf("session %q has no Claude session ID", inst.Title)
 	}
 
-	transcriptPath := ClaudeTranscriptPathForInstance(inst)
+	transcriptPath := locateHandoffTranscript(inst)
 	messages, err := readClaudeTranscriptMessages(transcriptPath)
 	if err != nil {
 		return "", HandoffInfo{TranscriptPath: transcriptPath, MaxChars: maxChars}, err
@@ -88,54 +89,102 @@ This message is context initialization only. Do not start new work, do not enter
 }
 
 // ClaudeTranscriptPathForInstance returns the expected JSONL transcript path
-// for the instance's Claude session ID.
+// for the instance's Claude session ID, using the same cwd encoding as the
+// rest of the codebase (issue #663: multi-repo sessions log under
+// EffectiveWorkingDir, and only then may symlinks be resolved).
 func ClaudeTranscriptPathForInstance(inst *Instance) string {
 	if inst == nil || inst.ClaudeSessionID == "" {
 		return ""
 	}
-	projectPath := inst.ProjectPath
+	return claudeTranscriptPathIn(GetClaudeConfigDirForInstance(inst), inst, inst.ClaudeSessionID)
+}
+
+func claudeTranscriptPathIn(configDir string, inst *Instance, sessionID string) string {
+	projectPath := inst.EffectiveWorkingDir()
 	if resolved, err := filepath.EvalSymlinks(projectPath); err == nil {
 		projectPath = resolved
 	}
-	return filepath.Join(
-		GetClaudeConfigDirForInstance(inst),
-		"projects",
-		ConvertToClaudeDirName(projectPath),
-		inst.ClaudeSessionID+".jsonl",
-	)
+	encoded := ConvertToClaudeDirName(projectPath)
+	if encoded == "" {
+		encoded = "-"
+	}
+	return filepath.Join(configDir, "projects", encoded, sessionID+".jsonl")
+}
+
+// locateHandoffTranscript picks the transcript to hand off. The disk is
+// authoritative: account-switched or pre-account sessions may keep their
+// conversation in a different config dir than the resolver's answer, so scan
+// all configured dirs (issue #1571 machinery) and fall back to the resolver
+// path when nothing is found.
+func locateHandoffTranscript(inst *Instance) string {
+	fallback := ClaudeTranscriptPathForInstance(inst)
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		return fallback
+	}
+	dir, sid, _ := LocateConversationConfigDir(cfg, inst, GetClaudeConfigDirForInstance(inst))
+	if dir == "" {
+		return fallback
+	}
+	if sid == "" {
+		sid = inst.ClaudeSessionID
+	}
+	// LocateConversationConfigDir matches on the raw ProjectPath encoding;
+	// prefer the canonical encoding when it exists in the located dir.
+	canonical := claudeTranscriptPathIn(dir, inst, sid)
+	if _, statErr := os.Stat(canonical); statErr == nil {
+		return canonical
+	}
+	raw := filepath.Join(dir, "projects", ConvertToClaudeDirName(inst.ProjectPath), sid+".jsonl")
+	if _, statErr := os.Stat(raw); statErr == nil {
+		return raw
+	}
+	return fallback
 }
 
 func readClaudeTranscriptMessages(path string) ([]handoffMessage, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("read Claude transcript: %w", err)
 	}
+	defer f.Close()
 
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
-
+	// ReadString instead of a fixed-buffer Scanner: transcripts can contain
+	// multi-megabyte records (file-history snapshots, compaction), and a
+	// single oversized line must not abort the whole handoff.
+	reader := bufio.NewReaderSize(f, 64*1024)
 	var messages []handoffMessage
-	for scanner.Scan() {
-		msg, ok := parseClaudeTranscriptLine(scanner.Bytes())
-		if ok {
-			messages = append(messages, msg)
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			if msg, ok := parseClaudeTranscriptLine([]byte(line)); ok {
+				messages = append(messages, msg)
+			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan Claude transcript: %w", err)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("scan Claude transcript: %w", err)
+		}
 	}
 	return messages, nil
 }
 
 func parseClaudeTranscriptLine(line []byte) (handoffMessage, bool) {
 	var raw struct {
-		Type    string `json:"type"`
-		Message struct {
+		Type        string `json:"type"`
+		IsSidechain bool   `json:"isSidechain"`
+		Message     struct {
 			Role    string          `json:"role"`
 			Content json.RawMessage `json:"content"`
 		} `json:"message"`
 	}
 	if err := json.Unmarshal(line, &raw); err != nil {
+		return handoffMessage{}, false
+	}
+	if raw.IsSidechain {
+		// Subagent sidechain records are not main-conversation turns.
 		return handoffMessage{}, false
 	}
 
@@ -226,7 +275,21 @@ func tailMessagesByChars(messages []handoffMessage, maxChars int) ([]handoffMess
 	start := len(messages)
 	for i := len(messages) - 1; i >= 0; i-- {
 		cost := len(messages[i].Role) + len(messages[i].Content) + 8
-		if total > 0 && total+cost > maxChars {
+		if total+cost > maxChars {
+			if total == 0 {
+				// Even the newest message alone exceeds the budget: keep its
+				// tail (most recent content) so maxChars is a real ceiling.
+				trimmed := messages[i]
+				keep := maxChars - len(trimmed.Role) - 8
+				if keep < 0 {
+					keep = 0
+				}
+				if keep < len(trimmed.Content) {
+					trimmed.Content = "[…earlier content truncated…]\n" +
+						strings.ToValidUTF8(trimmed.Content[len(trimmed.Content)-keep:], "")
+				}
+				return []handoffMessage{trimmed}, true
+			}
 			break
 		}
 		total += cost

--- a/internal/session/handoff_test.go
+++ b/internal/session/handoff_test.go
@@ -1,0 +1,145 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildClaudeToCodexHandoffPrompt_ReadsClaudeTranscript(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	project := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(project); err == nil {
+		project = resolved
+	}
+	sessionID := "11111111-2222-3333-4444-555555555555"
+	transcriptDir := filepath.Join(claudeDir, "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := strings.Join([]string{
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Remember BLUE LANTERN."}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"private scratch"},{"type":"text","text":"Stored."}]}}`,
+		`{"type":"user","message":{"role":"user","content":"What was the phrase?"}}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(transcriptDir, sessionID+".jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &Instance{
+		Title:           "history-test",
+		ProjectPath:     project,
+		Tool:            "claude",
+		ClaudeSessionID: sessionID,
+	}
+	prompt, info, err := BuildClaudeToCodexHandoffPrompt(inst, 32000)
+	if err != nil {
+		t.Fatalf("BuildClaudeToCodexHandoffPrompt: %v", err)
+	}
+
+	if !strings.Contains(prompt, "BLUE LANTERN") {
+		t.Fatalf("prompt missing transcript content:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "previous Claude session ID: "+sessionID) {
+		t.Fatalf("prompt missing source session id:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "private scratch") || strings.Contains(prompt, "[thinking]") {
+		t.Fatalf("prompt leaked thinking metadata:\n%s", prompt)
+	}
+	if info.MessageCount != 3 || info.IncludedCount != 3 || info.Truncated {
+		t.Fatalf("info = %+v, want 3 included untruncated", info)
+	}
+}
+
+func TestBuildClaudeToCodexHandoffPrompt_TruncatesToTail(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	project := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(project); err == nil {
+		project = resolved
+	}
+	sessionID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	transcriptDir := filepath.Join(claudeDir, "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := strings.Join([]string{
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"old context that should drop"}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"latest context should remain"}]}}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(transcriptDir, sessionID+".jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &Instance{Title: "trim-test", ProjectPath: project, Tool: "claude", ClaudeSessionID: sessionID}
+	prompt, info, err := BuildClaudeToCodexHandoffPrompt(inst, 80)
+	if err != nil {
+		t.Fatalf("BuildClaudeToCodexHandoffPrompt: %v", err)
+	}
+
+	if strings.Contains(prompt, "old context that should drop") {
+		t.Fatalf("prompt retained old context despite tight max chars:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "latest context should remain") {
+		t.Fatalf("prompt dropped latest context:\n%s", prompt)
+	}
+	if !info.Truncated || info.IncludedCount != 1 {
+		t.Fatalf("info = %+v, want truncated with one included", info)
+	}
+}
+
+func TestBuildClaudeToCodexHandoffPrompt_ComplexClaudeContent(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	project := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(project); err == nil {
+		project = resolved
+	}
+	sessionID := "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+	transcriptDir := filepath.Join(claudeDir, "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := strings.Join([]string{
+		`{"type":"summary","summary":"summary records are not conversation turns"}`,
+		`not json`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"Please inspect the repo and remember SILVER COMPASS 1782726200."}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"do not leak this"},{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/example.go"}},{"type":"text","text":"I will inspect the file."}]}}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"package main\nfunc main() {}"}]}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The repo note is SILVER COMPASS 1782726200."}]}}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(transcriptDir, sessionID+".jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &Instance{Title: "complex-test", ProjectPath: project, Tool: "claude", ClaudeSessionID: sessionID}
+	prompt, info, err := BuildClaudeToCodexHandoffPrompt(inst, 32000)
+	if err != nil {
+		t.Fatalf("BuildClaudeToCodexHandoffPrompt: %v", err)
+	}
+
+	for _, want := range []string{
+		"SILVER COMPASS 1782726200",
+		"[tool_use Read]",
+		`"file_path":"/tmp/example.go"`,
+		"[tool_result]",
+		"package main",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, unwanted := range []string{"do not leak this", "summary records", "not json"} {
+		if strings.Contains(prompt, unwanted) {
+			t.Fatalf("prompt included unwanted %q:\n%s", unwanted, prompt)
+		}
+	}
+	if info.MessageCount != 4 || info.IncludedCount != 4 || info.Truncated {
+		t.Fatalf("info = %+v, want 4 readable conversation turns untruncated", info)
+	}
+}

--- a/internal/session/handoff_test.go
+++ b/internal/session/handoff_test.go
@@ -143,3 +143,83 @@ func TestBuildClaudeToCodexHandoffPrompt_ComplexClaudeContent(t *testing.T) {
 		t.Fatalf("info = %+v, want 4 readable conversation turns untruncated", info)
 	}
 }
+
+func TestBuildClaudeToCodexHandoffPrompt_SkipsSidechainRecords(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	project := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(project); err == nil {
+		project = resolved
+	}
+	sessionID := "cccccccc-dddd-eeee-ffff-000000000000"
+	transcriptDir := filepath.Join(claudeDir, "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := strings.Join([]string{
+		`{"type":"user","message":{"role":"user","content":"main conversation GOLD ANCHOR"}}`,
+		`{"type":"assistant","isSidechain":true,"message":{"role":"assistant","content":"sidechain subagent noise"}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":"main reply"}}`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(transcriptDir, sessionID+".jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &Instance{Title: "sidechain-test", ProjectPath: project, Tool: "claude", ClaudeSessionID: sessionID}
+	prompt, info, err := BuildClaudeToCodexHandoffPrompt(inst, 32000)
+	if err != nil {
+		t.Fatalf("BuildClaudeToCodexHandoffPrompt: %v", err)
+	}
+	if strings.Contains(prompt, "sidechain subagent noise") {
+		t.Fatalf("prompt leaked sidechain record:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "GOLD ANCHOR") || !strings.Contains(prompt, "main reply") {
+		t.Fatalf("prompt missing main conversation:\n%s", prompt)
+	}
+	if info.MessageCount != 2 {
+		t.Fatalf("info = %+v, want 2 main-conversation messages", info)
+	}
+}
+
+func TestBuildClaudeToCodexHandoffPrompt_MaxCharsIsARealCeiling(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	project := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(project); err == nil {
+		project = resolved
+	}
+	sessionID := "dddddddd-eeee-ffff-0000-111111111111"
+	transcriptDir := filepath.Join(claudeDir, "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	huge := strings.Repeat("filler ", 2000) + "NEWEST TAIL MARKER"
+	transcript := `{"type":"user","message":{"role":"user","content":"` + huge + `"}}`
+	if err := os.WriteFile(filepath.Join(transcriptDir, sessionID+".jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &Instance{Title: "ceiling-test", ProjectPath: project, Tool: "claude", ClaudeSessionID: sessionID}
+	maxChars := 500
+	prompt, info, err := BuildClaudeToCodexHandoffPrompt(inst, maxChars)
+	if err != nil {
+		t.Fatalf("BuildClaudeToCodexHandoffPrompt: %v", err)
+	}
+	if !info.Truncated || info.IncludedCount != 1 {
+		t.Fatalf("info = %+v, want truncated single message", info)
+	}
+	if !strings.Contains(prompt, "NEWEST TAIL MARKER") {
+		t.Fatalf("prompt lost the newest tail:\n%s", prompt)
+	}
+	// The transcript body must respect the ceiling (plus small truncation banner).
+	begin := strings.Index(prompt, "--- BEGIN TRANSFERRED TRANSCRIPT ---")
+	end := strings.Index(prompt, "--- END TRANSFERRED TRANSCRIPT ---")
+	if begin < 0 || end < 0 {
+		t.Fatal("prompt missing transcript markers")
+	}
+	if body := end - begin; body > maxChars+200 {
+		t.Fatalf("transcript body %d chars exceeds max %d", body, maxChars)
+	}
+}


### PR DESCRIPTION
## What
Lands the June-29 handoff WIP (`internal/session/handoff.go` + tests) and wires a **read-only** CLI entry point:

```
agent-deck session handoff <id|title> [--max-chars N] [--out FILE] [--json]
```

It builds a cross-tool handoff prompt from the session's Claude transcript (tail-truncated, thinking stripped, tool calls/results compacted). It never mutates the source session — pair with `add` + `session send`, or with the upcoming `session switch` orchestration (design + eval matrix in the runtime-switch eval report, 2026-07-19).

## Why
Runtime switching (Claude↔Codex) is currently done by skills/scripts that shell out to `skills/pool/codex-handoff/scripts/handoff.py` — a Python re-implementation of exactly this Go code. In-place `session set tool/command` conversion is broken (tool flip-flops, stale rollout resume — the Ryan conductor incident). Landing the native builder is phase 1: one canonical implementation, testable, and the building block for a safe generic `session switch`.

## Testing
- `go test ./internal/session/ -run TestBuildClaudeToCodexHandoffPrompt` — 3/3 pass (sandboxed HOME).
- Full `./internal/session` package: only pre-existing macOS-environment failures (TestForbidigo_BansRawOSEnvironInSpawnPath, TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision, TestIssue1421_CleanStaleSSHSockets) which fail identically on clean main; zero regressions from this branch.
- Test fix vs the WIP: resolve macOS symlinked TempDir (`/var` → `/private/var`) before deriving the transcript dir, matching `ClaudeTranscriptPathForInstance`.

## Review / merge protocol
- ⚠️ **Do NOT merge from automation** — conductor merges after CI is green.
- Requires dual review (Claude + Codex) per merge bar; reviews to be noted here before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `session handoff` command to generate a Codex-ready prompt from a selected session’s conversation tail.
  - Supports configurable max character limits, plain-text output, optional JSON output, and saving the result to a file.
  - Reports included message count, truncation status, character budget, and the source transcript path.
  - Preserves conversation content (including tool activity) while excluding hidden/private “thinking” information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->