### PR TITLE
fix(cursor-hooks): durable uninstall via [cursor] hooks_enabled opt-out (#1672)

### DIFF
--- a/cmd/agent-deck/cursor_hooks_cmd.go
+++ b/cmd/agent-deck/cursor_hooks_cmd.go
@@ -49,6 +49,11 @@ func handleCursorHooksInstall() {
 		fmt.Fprintf(os.Stderr, "Error installing Cursor hooks: %v\n", err)
 		os.Exit(1)
 	}
+	// Explicit install clears the durable opt-out so TUI startup may
+	// auto-reinstall again (issue #1672).
+	if err := session.SetCursorHooksEnabled(true); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not update config.toml: %v\n", err)
+	}
 	if installed {
 		fmt.Println("Cursor hooks installed successfully.")
 		fmt.Printf("Config: %s/hooks.json\n", configDir)
@@ -63,6 +68,15 @@ func handleCursorHooksUninstall() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error removing Cursor hooks: %v\n", err)
 		os.Exit(1)
+	}
+	// Persist the opt-out so TUI startup does not silently reinstall the
+	// hooks on the next launch (issue #1672).
+	if err := session.SetCursorHooksEnabled(false); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not persist opt-out to config.toml: %v\n", err)
+		fmt.Fprintln(os.Stderr, "TUI startup may reinstall the hooks. Set [cursor] hooks_enabled = false manually.")
+	} else {
+		fmt.Println("Auto-install disabled ([cursor] hooks_enabled = false in config.toml).")
+		fmt.Println("Run 'agent-deck cursor-hooks install' to re-enable.")
 	}
 	if removed {
 		fmt.Println("Cursor hooks removed successfully.")
@@ -82,6 +96,9 @@ func handleCursorHooksStatus() {
 	} else {
 		fmt.Println("Status: NOT INSTALLED")
 		fmt.Println("Run 'agent-deck cursor-hooks install' to install.")
+	}
+	if cfg, err := session.LoadUserConfig(); err == nil && cfg != nil && !cfg.Cursor.GetHooksEnabled() {
+		fmt.Println("Auto-install: DISABLED ([cursor] hooks_enabled = false in config.toml)")
 	}
 }
 

--- a/cmd/agent-deck/cursor_hooks_cmd.go
+++ b/cmd/agent-deck/cursor_hooks_cmd.go
@@ -49,34 +49,41 @@ func handleCursorHooksInstall() {
 		fmt.Fprintf(os.Stderr, "Error installing Cursor hooks: %v\n", err)
 		os.Exit(1)
 	}
-	// Explicit install clears the durable opt-out so TUI startup may
-	// auto-reinstall again (issue #1672).
-	if err := session.SetCursorHooksEnabled(true); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not update config.toml: %v\n", err)
-	}
 	if installed {
 		fmt.Println("Cursor hooks installed successfully.")
 		fmt.Printf("Config: %s/hooks.json\n", configDir)
 	} else {
 		fmt.Println("Cursor hooks are already installed.")
 	}
+	// Explicit install clears the durable opt-out so TUI startup may
+	// auto-reinstall again (issue #1672). Failing to clear it would leave
+	// the just-installed hooks in a state the next uninstall+restart cycle
+	// cannot reason about, so it is a hard error.
+	if err := session.SetCursorHooksEnabled(true); err != nil {
+		fmt.Fprintf(os.Stderr, "Error clearing [cursor] hooks_enabled opt-out in config.toml: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func handleCursorHooksUninstall() {
+	// Persist the opt-out FIRST so TUI startup cannot silently reinstall the
+	// hooks on the next launch (issue #1672). Durability is the point of this
+	// command, so failure to persist is a hard error; on partial failure the
+	// safe state is "opt-out recorded, hooks still present".
+	if err := session.SetCursorHooksEnabled(false); err != nil {
+		fmt.Fprintf(os.Stderr, "Error persisting opt-out to config.toml: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Hooks were NOT removed (TUI startup would reinstall them).")
+		fmt.Fprintln(os.Stderr, "Set [cursor] hooks_enabled = false manually, then rerun uninstall.")
+		os.Exit(1)
+	}
+	fmt.Println("Auto-install disabled ([cursor] hooks_enabled = false in config.toml).")
+	fmt.Println("Run 'agent-deck cursor-hooks install' to re-enable.")
+
 	configDir := getCursorConfigDirForHooks()
 	removed, err := session.RemoveCursorHooks(configDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error removing Cursor hooks: %v\n", err)
 		os.Exit(1)
-	}
-	// Persist the opt-out so TUI startup does not silently reinstall the
-	// hooks on the next launch (issue #1672).
-	if err := session.SetCursorHooksEnabled(false); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not persist opt-out to config.toml: %v\n", err)
-		fmt.Fprintln(os.Stderr, "TUI startup may reinstall the hooks. Set [cursor] hooks_enabled = false manually.")
-	} else {
-		fmt.Println("Auto-install disabled ([cursor] hooks_enabled = false in config.toml).")
-		fmt.Println("Run 'agent-deck cursor-hooks install' to re-enable.")
 	}
 	if removed {
 		fmt.Println("Cursor hooks removed successfully.")
@@ -97,7 +104,11 @@ func handleCursorHooksStatus() {
 		fmt.Println("Status: NOT INSTALLED")
 		fmt.Println("Run 'agent-deck cursor-hooks install' to install.")
 	}
-	if cfg, err := session.LoadUserConfig(); err == nil && cfg != nil && !cfg.Cursor.GetHooksEnabled() {
+	cfg, err := session.LoadUserConfig()
+	switch {
+	case err != nil:
+		fmt.Printf("Auto-install: UNKNOWN (could not read config.toml: %v)\n", err)
+	case cfg != nil && !cfg.Cursor.GetHooksEnabled():
 		fmt.Println("Auto-install: DISABLED ([cursor] hooks_enabled = false in config.toml)")
 	}
 }

--- a/internal/session/cursor_hooks.go
+++ b/internal/session/cursor_hooks.go
@@ -110,6 +110,11 @@ func SetCursorHooksEnabled(enabled bool) error {
 	if err != nil {
 		return err
 	}
+	// No-op when the effective state already matches: skips a full
+	// config.toml rewrite (which drops comments/formatting).
+	if cfg.Cursor.GetHooksEnabled() == enabled {
+		return nil
+	}
 	updated := *cfg
 	if enabled {
 		updated.Cursor.HooksEnabled = nil

--- a/internal/session/cursor_hooks.go
+++ b/internal/session/cursor_hooks.go
@@ -84,6 +84,42 @@ func InjectCursorHooks(configDir string) (bool, error) {
 	return true, nil
 }
 
+// AutoInstallCursorHooks is the TUI-startup entry point for silent Cursor hook
+// injection. Unlike InjectCursorHooks (the explicit `cursor-hooks install`
+// path), it honors the user's durable opt-out: [cursor] hooks_enabled = false,
+// which `cursor-hooks uninstall` persists. Without this gate, TUI startup
+// silently re-created the hooks on every launch after an uninstall (issue #1672).
+// Returns true if hooks were newly installed.
+func AutoInstallCursorHooks(cfg *UserConfig, configDir string) (bool, error) {
+	if cfg != nil && !cfg.Cursor.GetHooksEnabled() {
+		return false, nil
+	}
+	if CheckCursorHooksInstalled(configDir) {
+		return false, nil
+	}
+	return InjectCursorHooks(configDir)
+}
+
+// SetCursorHooksEnabled persists the Cursor hooks opt-in/opt-out to config.toml.
+// enabled=false writes [cursor] hooks_enabled = false (durable opt-out honored
+// by AutoInstallCursorHooks); enabled=true removes the key, restoring the
+// default. Works on a shallow copy so the LoadUserConfig cache is not mutated
+// before the save lands.
+func SetCursorHooksEnabled(enabled bool) error {
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		return err
+	}
+	updated := *cfg
+	if enabled {
+		updated.Cursor.HooksEnabled = nil
+	} else {
+		disabled := false
+		updated.Cursor.HooksEnabled = &disabled
+	}
+	return SaveUserConfig(&updated)
+}
+
 // RemoveCursorHooks removes agent-deck hook entries from ~/.cursor/hooks.json.
 // Returns true if hooks were removed, false if none found.
 func RemoveCursorHooks(configDir string) (bool, error) {

--- a/internal/session/cursor_hooks_test.go
+++ b/internal/session/cursor_hooks_test.go
@@ -113,3 +113,104 @@ func TestCheckCursorHooksInstalled(t *testing.T) {
 		t.Fatal("expected installed after inject")
 	}
 }
+
+// Regression test for issue #1672: TUI startup silently reinstalled Cursor
+// hooks after `cursor-hooks uninstall`. AutoInstallCursorHooks must honor the
+// durable opt-out ([cursor] hooks_enabled = false) instead of unconditionally
+// injecting whenever the cursor binary is on PATH.
+func TestAutoInstallCursorHooks_RespectsDurableOptOut(t *testing.T) {
+	tmpDir := t.TempDir()
+	disabled := false
+	cfg := &UserConfig{Cursor: CursorSettings{HooksEnabled: &disabled}}
+
+	installed, err := AutoInstallCursorHooks(cfg, tmpDir)
+	if err != nil {
+		t.Fatalf("AutoInstallCursorHooks failed: %v", err)
+	}
+	if installed {
+		t.Fatal("hooks were installed despite [cursor] hooks_enabled = false")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "hooks.json")); !os.IsNotExist(err) {
+		t.Fatal("hooks.json was created despite [cursor] hooks_enabled = false")
+	}
+}
+
+func TestAutoInstallCursorHooks_InstallsByDefault(t *testing.T) {
+	for _, cfg := range []*UserConfig{nil, {}} {
+		tmpDir := t.TempDir()
+		installed, err := AutoInstallCursorHooks(cfg, tmpDir)
+		if err != nil {
+			t.Fatalf("AutoInstallCursorHooks failed: %v", err)
+		}
+		if !installed {
+			t.Fatalf("expected hooks to be installed for cfg=%v", cfg)
+		}
+		if !CheckCursorHooksInstalled(tmpDir) {
+			t.Fatal("hooks not present after AutoInstallCursorHooks")
+		}
+	}
+}
+
+func TestAutoInstallCursorHooks_NoopWhenAlreadyInstalled(t *testing.T) {
+	tmpDir := t.TempDir()
+	if _, err := InjectCursorHooks(tmpDir); err != nil {
+		t.Fatalf("seed install failed: %v", err)
+	}
+	installed, err := AutoInstallCursorHooks(&UserConfig{}, tmpDir)
+	if err != nil {
+		t.Fatalf("AutoInstallCursorHooks failed: %v", err)
+	}
+	if installed {
+		t.Fatal("expected no reinstall when hooks already present")
+	}
+}
+
+func TestCursorSettings_GetHooksEnabled(t *testing.T) {
+	var c CursorSettings
+	if !c.GetHooksEnabled() {
+		t.Fatal("default GetHooksEnabled() = false, want true")
+	}
+	v := false
+	c.HooksEnabled = &v
+	if c.GetHooksEnabled() {
+		t.Fatal("GetHooksEnabled() = true with hooks_enabled = false")
+	}
+	v2 := true
+	c.HooksEnabled = &v2
+	if !c.GetHooksEnabled() {
+		t.Fatal("GetHooksEnabled() = false with hooks_enabled = true")
+	}
+}
+
+// The `cursor-hooks uninstall` opt-out must survive a config round-trip: it is
+// written to config.toml and read back by LoadUserConfig on the next TUI start.
+func TestSetCursorHooksEnabled_RoundTrip(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	isolateConfigHomeXDG(t)
+
+	if err := SetCursorHooksEnabled(false); err != nil {
+		t.Fatalf("SetCursorHooksEnabled(false) failed: %v", err)
+	}
+	ClearUserConfigCache()
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig failed: %v", err)
+	}
+	if cfg.Cursor.GetHooksEnabled() {
+		t.Fatal("opt-out did not persist: GetHooksEnabled() = true after SetCursorHooksEnabled(false)")
+	}
+
+	// Explicit install clears the opt-out back to the default.
+	if err := SetCursorHooksEnabled(true); err != nil {
+		t.Fatalf("SetCursorHooksEnabled(true) failed: %v", err)
+	}
+	ClearUserConfigCache()
+	cfg, err = LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig failed: %v", err)
+	}
+	if !cfg.Cursor.GetHooksEnabled() {
+		t.Fatal("SetCursorHooksEnabled(true) did not restore the default")
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -142,6 +142,9 @@ type UserConfig struct {
 	// Codex defines Codex CLI integration settings
 	Codex CodexSettings `toml:"codex,omitempty"`
 
+	// Cursor defines Cursor Agent CLI integration settings (Issue #1672)
+	Cursor CursorSettings `toml:"cursor,omitempty"`
+
 	// Copilot defines GitHub Copilot CLI integration settings (Issue #556)
 	Copilot CopilotSettings `toml:"copilot,omitempty"`
 
@@ -1830,6 +1833,26 @@ func (c *UserConfig) GetProfileCodexConfigDir(profile string) string {
 		return ""
 	}
 	return ExpandPath(profileCfg.Codex.ConfigDir)
+}
+
+// CursorSettings defines Cursor Agent CLI integration configuration (Issue #1672).
+type CursorSettings struct {
+	// HooksEnabled enables Cursor Agent CLI hooks for real-time status detection.
+	// When enabled, agent-deck silently injects lifecycle hooks into
+	// ~/.cursor/hooks.json on TUI startup whenever the cursor binary is on PATH.
+	// Set false to durably opt out of that auto-install; `agent-deck
+	// cursor-hooks uninstall` persists this automatically so the uninstall
+	// survives TUI restarts. Mirrors [claude] hooks_enabled.
+	// Default: true (nil = use default true, set false to disable)
+	HooksEnabled *bool `toml:"hooks_enabled,omitempty"`
+}
+
+// GetHooksEnabled returns whether Cursor Agent hooks are enabled, defaulting to true
+func (c *CursorSettings) GetHooksEnabled() bool {
+	if c.HooksEnabled == nil {
+		return true
+	}
+	return *c.HooksEnabled
 }
 
 // CopilotSettings defines GitHub Copilot CLI configuration (Issue #556).

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1629,20 +1629,22 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		}
 	}
 
-	// Cursor Agent CLI hooks: auto-inject silently when the cursor binary is available.
+	// Cursor Agent CLI hooks: auto-inject silently when the cursor binary is
+	// available, unless the user opted out via [cursor] hooks_enabled = false
+	// (set durably by `agent-deck cursor-hooks uninstall`, issue #1672).
 	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); homeBackgroundWorkersEnabled && cursorCmd != "" {
 		if cursorFields := strings.Fields(cursorCmd); len(cursorFields) > 0 {
 			cursorBin := cursorFields[0]
 			if _, err := exec.LookPath(cursorBin); err == nil {
 				cursorConfigDir := session.GetCursorConfigDir()
-				if !session.CheckCursorHooksInstalled(cursorConfigDir) {
-					if _, err := session.InjectCursorHooks(cursorConfigDir); err != nil {
-						uiLog.Warn("cursor_hooks_inject_failed", slog.String("error", err.Error()))
-					} else {
-						uiLog.Info("cursor_hooks_installed", slog.String("config_dir", cursorConfigDir))
-					}
+				if installed, err := session.AutoInstallCursorHooks(userConfig, cursorConfigDir); err != nil {
+					uiLog.Warn("cursor_hooks_inject_failed", slog.String("error", err.Error()))
+				} else if installed {
+					uiLog.Info("cursor_hooks_installed", slog.String("config_dir", cursorConfigDir))
 				}
-				if h.hookWatcher == nil {
+				// Watch only when hooks are actually present (opt-out leaves
+				// none behind, so no watcher is needed on the cursor path).
+				if h.hookWatcher == nil && session.CheckCursorHooksInstalled(cursorConfigDir) {
 					if hookWatcher, err := session.NewStatusFileWatcher(nil); err == nil {
 						h.hookWatcher = hookWatcher
 						go hookWatcher.Start()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1632,7 +1632,10 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	// Cursor Agent CLI hooks: auto-inject silently when the cursor binary is
 	// available, unless the user opted out via [cursor] hooks_enabled = false
 	// (set durably by `agent-deck cursor-hooks uninstall`, issue #1672).
-	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); homeBackgroundWorkersEnabled && cursorCmd != "" {
+	// The opt-out gates the watcher too, matching the [claude] hooks_enabled
+	// gate above.
+	cursorHooksEnabled := userConfig == nil || userConfig.Cursor.GetHooksEnabled()
+	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); homeBackgroundWorkersEnabled && cursorHooksEnabled && cursorCmd != "" {
 		if cursorFields := strings.Fields(cursorCmd); len(cursorFields) > 0 {
 			cursorBin := cursorFields[0]
 			if _, err := exec.LookPath(cursorBin); err == nil {
@@ -1642,9 +1645,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 				} else if installed {
 					uiLog.Info("cursor_hooks_installed", slog.String("config_dir", cursorConfigDir))
 				}
-				// Watch only when hooks are actually present (opt-out leaves
-				// none behind, so no watcher is needed on the cursor path).
-				if h.hookWatcher == nil && session.CheckCursorHooksInstalled(cursorConfigDir) {
+				if h.hookWatcher == nil {
 					if hookWatcher, err := session.NewStatusFileWatcher(nil); err == nil {
 						h.hookWatcher = hookWatcher
 						go hookWatcher.Start()

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -13,6 +13,7 @@ All options for `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/ag
 - [[opencode] Section](#opencode-section)
 - [[codex] Section](#codex-section)
 - [[copilot] Section](#copilot-section)
+- [[cursor] Section](#cursor-section)
 - [[hermes] Section](#hermes-section)
 - [[docker] Section](#docker-section)
 - [[worktree] Section](#worktree-section)
@@ -115,6 +116,7 @@ config_dir = "~/.claude-team"      # Optional override for profile "work"
 | `vim_mode` | bool | `false` | Set when the inner Claude Code prompt uses vim keybindings (`"editorMode": "vim"`). Each `session send` then prepends an Escape + `i` insert-mode guarantee so a message sent while the prompt is in vim NORMAL mode actually submits instead of being typed-but-unsent (issue #1264). Only affects Claude-compatible tools. |
 | `extra_args` | array of strings | `[]` | Extra Claude CLI flags remembered from the New Session dialog and appended to new/restarted Claude sessions. Do not store secrets here. |
 | `env_file` | string | `""` | A .env file sourced for Claude sessions only. Sourced after global `[shell].env_files`. See [Path Resolution](#path-resolution). |
+| `hooks_enabled` | bool | `true` | Enables Claude Code lifecycle hooks for real-time status detection. Set `false` to opt out of hook-based detection and the TUI install prompt. |
 | `command` | string | `"claude"` | Override the binary/invocation (e.g., `"cdw"` for a wrapper that sets `CLAUDE_CONFIG_DIR`). |
 
 Config resolution order for Claude config dir:
@@ -278,6 +280,19 @@ command = "copilot"
 |-----|------|---------|-------------|
 | `env_file` | string | `""` | A .env file sourced for Copilot sessions only. See [Path Resolution](#path-resolution). |
 | `command` | string | `"copilot"` | Override the binary/invocation. |
+
+## [cursor] Section
+
+Cursor Agent CLI integration settings.
+
+```toml
+[cursor]
+hooks_enabled = false  # Disable automatic Cursor hook injection on TUI startup
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `hooks_enabled` | bool | `true` | When `true`, TUI startup silently injects agent-deck lifecycle hooks into `~/.cursor/hooks.json` whenever the `cursor` binary is on `PATH` (real-time status detection). Set `false` to durably opt out; `agent-deck cursor-hooks uninstall` writes this automatically so the uninstall survives TUI restarts (issue #1672). Re-enable with `agent-deck cursor-hooks install` or by removing the key. Mirrors `[claude] hooks_enabled`. |
 
 ## [hermes] Section
 


### PR DESCRIPTION
Fixes #1672.

## Problem

`agent-deck cursor-hooks uninstall` reported success, but the next TUI start silently rewrote `~/.cursor/hooks.json` (all six lifecycle events) whenever the `cursor` binary was on `PATH`. The auto-inject block in `internal/ui/home.go` was unconditional: it never consulted config and had no way to learn the user had uninstalled on purpose. Claude hooks already had a durable opt-out (`[claude] hooks_enabled = false`); Cursor had no equivalent.

Credit to @goggi for an exceptional report: the compositor event capture pinning the transient `alacritty -e agent-deck hook-handler` windows to hook invocations, the exact uninstall→TUI-start→reinstalled repro, and pointing at the unconditional injection on current `main` in `internal/ui/home.go` made the root cause unambiguous before any debugging started. The suggested `[cursor] hooks_enabled` design is exactly what this PR implements.

## Fix

Mirrors the Claude opt-out UX and naming exactly:

- **New config option** `[cursor] hooks_enabled` (default `true`), documented in the config reference. When `false`, TUI startup skips both hook injection and the cursor-path hook watcher — same shape as the `[claude] hooks_enabled` gate a few lines above.
- **Durable uninstall**: `cursor-hooks uninstall` now persists `hooks_enabled = false` to `config.toml` *before* removing the hooks, and fails hard (exit 1) if it cannot persist, so a partial failure leaves the safe "opt-out recorded, hooks still present" state. `cursor-hooks install` clears the opt-out; `cursor-hooks status` reports `Auto-install: DISABLED` / `UNKNOWN (config unreadable)`.
- TUI injection goes through new `session.AutoInstallCursorHooks(cfg, configDir)`, which honors the opt-out and is unit-testable.

When `config.toml` is unreadable, startup fails open (hooks enabled) — deliberately identical to the existing Claude gate.

## Tests

- `TestAutoInstallCursorHooks_RespectsDurableOptOut` — **regression test**: fails on `main`'s behavior (verified by temporarily removing the gate: `hooks were installed despite [cursor] hooks_enabled = false`).
- `TestAutoInstallCursorHooks_InstallsByDefault`, `_NoopWhenAlreadyInstalled`, `TestCursorSettings_GetHooksEnabled`, `TestSetCursorHooksEnabled_RoundTrip` (config round-trip through `SaveUserConfig`/`LoadUserConfig`).
- End-to-end in a sandboxed `HOME`: install → uninstall persists `[cursor] hooks_enabled = false` → status shows DISABLED → install re-enables and removes the key.
- `go build ./...`, `go vet`, and the `internal/session` + `cmd/agent-deck` suites pass locally (four pre-existing failures — `TestCanRestartCursor`, `TestForbidigo_*`, `TestGetJSONLPathChecked_*`, `TestIssue1421_*` — reproduce identically on clean `main` in this macOS sandbox and are unrelated).

## Codex review findings (dual review)

Codex reviewed the diff; all findings addressed in the second commit:

1. *Fail-open when config unreadable* — kept intentionally; matches the Claude gate exactly (noted above).
2. *`hooks_enabled = false` didn't gate the watcher when hooks remain installed* — fixed: the whole cursor block is now gated, matching Claude.
3. *Uninstall exited 0 when the opt-out couldn't be persisted* — fixed: persist first, hard-fail otherwise; install also hard-fails if it cannot clear the opt-out.
4. *Status hid config read errors* — fixed: prints `Auto-install: UNKNOWN (...)`.
5. *Install always rewrote config.toml* — fixed: `SetCursorHooksEnabled` no-ops when the effective state already matches.

## Not included (follow-up)

The flashing terminal windows themselves (`alacritty -e agent-deck hook-handler`) are spawned by Cursor's hook runner on the reporter's setup, not by agent-deck — nothing in this repo launches a terminal for hooks, and `hooks.json` only carries a command string, so there is no cheap agent-deck-side fix. With the opt-out honored, no hooks means no windows. A follow-up issue draft for investigating a Cursor-side/quieter invocation is in the conductor's RESULTS.md.

Do not merge: awaiting Claude+Codex dual review sign-off and green CI; conductor merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cursor hooks are now installed automatically by default when needed.
  * Added a persistent setting to disable or re-enable automatic Cursor hook installation.
  * Cursor hook status now reports when automatic installation is disabled or unavailable.

* **Bug Fixes**
  * Re-enabling Cursor hooks through the install command now clears the saved opt-out setting.
  * Existing hook installations are preserved without unnecessary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->