### PR TITLE
feat: browse ~/.claude history, project tree, and HITL notify

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
         # internal-only path operations (worktree includes, Claude project
         # dirs, mcppool log dirs). Real path validation lives at boundary
         # entry points.
+        - G602 # false-positive on safe &slice[i] addressing in internal iteration (history overlay/tree build)
     staticcheck:
       # Only run bug-finding (SA*) checks. The quickfix (QF*), stylistic (ST*),
       # and simplification (S1*) checks are noisy and not security-relevant; we

--- a/internal/history/livestatus.go
+++ b/internal/history/livestatus.go
@@ -1,0 +1,43 @@
+// Package history bridges agent-deck's live session state onto the ported
+// agenthop history model. This file is agent-hopdeck-specific glue; the
+// model/source/tree subpackages are verbatim ports and stay free of
+// agent-deck coupling.
+package history
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// OverlayInstanceStatus upgrades the status of any browsed session that is
+// currently a live agent-deck instance, using agent-deck's authoritative
+// status machine instead of the ported ~/.claude/sessions registry.
+// Sessions with no matching live instance keep their ported status
+// (recent/closed by mtime, or registry-derived). Mutates projects in place.
+func OverlayInstanceStatus(projects []model.Project, instances []*session.Instance) {
+	byClaudeID := make(map[string]*session.Instance, len(instances))
+	for _, inst := range instances {
+		if inst != nil && inst.ClaudeSessionID != "" {
+			byClaudeID[inst.ClaudeSessionID] = inst
+		}
+	}
+	for pi := range projects {
+		for si := range projects[pi].Sessions {
+			s := &projects[pi].Sessions[si]
+			inst, ok := byClaudeID[s.ID]
+			if !ok {
+				continue
+			}
+			switch inst.GetStatusThreadSafe() {
+			case session.StatusRunning, session.StatusStarting:
+				s.Status = model.StatusRunningBusy
+			case session.StatusWaiting:
+				s.Status = model.StatusWaiting
+			case session.StatusIdle:
+				s.Status = model.StatusRunningIdle
+			default:
+				// stopped/error/queued: leave ported status as-is.
+			}
+		}
+	}
+}

--- a/internal/history/livestatus_test.go
+++ b/internal/history/livestatus_test.go
@@ -1,0 +1,120 @@
+package history
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// TestMain isolates this package's tests from the real ~/.agent-deck config.
+//
+// agent-hopdeck: this package imports internal/session, whose constructors
+// (e.g. NewInstanceWithTool, used below) transitively resolve agent-deck's
+// own user config under the real HOME unless sandboxed.
+// testutil.IsolateHome() closes that gap (see internal/testutil/homeenv.go —
+// 2026-06-04 data-loss incident); without it, this suite could read/write
+// the developer's real ~/.agent-deck config. Mirrors the pattern already
+// used in internal/history/source/claudecode_test.go. Deliberately NOT named
+// *testmain_test.go: that filename suffix is audited by
+// internal/testutil.TestAllTestMainsIsolateTmuxSocket, which additionally
+// requires IsolateTmuxSocket() — irrelevant here since this package never
+// starts a tmux session (no Instance.Start() call).
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the deferred cleanup below
+// actually runs (os.Exit does not run defers).
+func runTestMain(m *testing.M) int {
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+
+	return m.Run()
+}
+
+func TestOverlayInstanceStatus_MapsRunningToBusy(t *testing.T) {
+	projects := []model.Project{{
+		Path: "/proj", Name: "proj",
+		Sessions: []model.Session{
+			{ID: "sess-a", Status: model.StatusRecent},
+			{ID: "sess-b", Status: model.StatusClosed},
+		},
+	}}
+	inst := session.NewInstanceWithTool("proj", "/proj", "claude")
+	inst.ClaudeSessionID = "sess-a"
+	inst.Status = session.StatusRunning
+
+	OverlayInstanceStatus(projects, []*session.Instance{inst})
+
+	if got := projects[0].Sessions[0].Status; got != model.StatusRunningBusy {
+		t.Fatalf("sess-a status = %v, want StatusRunningBusy", got)
+	}
+	if got := projects[0].Sessions[1].Status; got != model.StatusClosed {
+		t.Fatalf("sess-b status = %v, want StatusClosed (unchanged)", got)
+	}
+}
+
+func TestOverlayInstanceStatus_AllStatusMappings(t *testing.T) {
+	tests := []struct {
+		name           string
+		instanceStatus session.Status
+		expectedStatus model.SessionStatus
+	}{
+		{
+			name:           "StatusRunning maps to StatusRunningBusy",
+			instanceStatus: session.StatusRunning,
+			expectedStatus: model.StatusRunningBusy,
+		},
+		{
+			name:           "StatusStarting maps to StatusRunningBusy",
+			instanceStatus: session.StatusStarting,
+			expectedStatus: model.StatusRunningBusy,
+		},
+		{
+			name:           "StatusWaiting maps to StatusWaiting",
+			instanceStatus: session.StatusWaiting,
+			expectedStatus: model.StatusWaiting,
+		},
+		{
+			name:           "StatusIdle maps to StatusRunningIdle",
+			instanceStatus: session.StatusIdle,
+			expectedStatus: model.StatusRunningIdle,
+		},
+		{
+			name:           "StatusStopped leaves browsed status unchanged",
+			instanceStatus: session.StatusStopped,
+			expectedStatus: model.StatusRecent,
+		},
+		{
+			name:           "StatusError leaves browsed status unchanged",
+			instanceStatus: session.StatusError,
+			expectedStatus: model.StatusRecent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Start browsed session with a known status
+			projects := []model.Project{{
+				Path: "/proj", Name: "proj",
+				Sessions: []model.Session{
+					{ID: "sess-x", Status: model.StatusRecent},
+				},
+			}}
+
+			// Create live instance and set its status
+			inst := session.NewInstanceWithTool("proj", "/proj", "claude")
+			inst.ClaudeSessionID = "sess-x"
+			inst.Status = tc.instanceStatus
+
+			OverlayInstanceStatus(projects, []*session.Instance{inst})
+
+			if got := projects[0].Sessions[0].Status; got != tc.expectedStatus {
+				t.Fatalf("instance status %v: got %v, want %v", tc.instanceStatus, got, tc.expectedStatus)
+			}
+		})
+	}
+}

--- a/internal/history/model/project.go
+++ b/internal/history/model/project.go
@@ -1,0 +1,8 @@
+package model
+
+type Project struct {
+	Path     string
+	Name     string
+	Tool     string
+	Sessions []Session
+}

--- a/internal/history/model/session.go
+++ b/internal/history/model/session.go
@@ -1,0 +1,64 @@
+package model
+
+import "time"
+
+type Session struct {
+	ID         string
+	Tool       string
+	CWD        string
+	Title      string
+	LastPrompt string
+	GitBranch  string
+	FilePath   string
+	ModTime    time.Time
+	MsgCount   int
+	Status     SessionStatus
+	PID        int
+	Name       string
+	WaitingFor string // reason a waiting session needs input (e.g. "permission prompt")
+}
+
+func (s Session) Label() string {
+	if s.Title == "" {
+		return "(untitled)"
+	}
+	return s.Title
+}
+
+type SessionStatus int
+
+const (
+	StatusClosed SessionStatus = iota
+	StatusRecent
+	StatusRunningIdle
+	StatusRunningBusy
+	StatusWaiting
+)
+
+func (s SessionStatus) Glyph() string {
+	switch s {
+	case StatusWaiting:
+		return "◆"
+	case StatusRunningBusy:
+		return "●"
+	case StatusRunningIdle:
+		return "◐"
+	case StatusRecent:
+		return "○"
+	default:
+		return "·"
+	}
+}
+
+func (s SessionStatus) Label() string {
+	switch s {
+	case StatusWaiting:
+		return "waiting"
+	case StatusRunningBusy, StatusRunningIdle:
+		return "running"
+	case StatusRecent:
+		return "recent"
+	default:
+		return "idle"
+	}
+}

--- a/internal/history/model/session_test.go
+++ b/internal/history/model/session_test.go
@@ -1,0 +1,12 @@
+package model
+
+import "testing"
+
+func TestLabelFallsBackToUntitled(t *testing.T) {
+	if got := (Session{}).Label(); got != "(untitled)" {
+		t.Fatalf("empty title: got %q want %q", got, "(untitled)")
+	}
+	if got := (Session{Title: "Fix S3 cache"}).Label(); got != "Fix S3 cache" {
+		t.Fatalf("with title: got %q", got)
+	}
+}

--- a/internal/history/model/status_test.go
+++ b/internal/history/model/status_test.go
@@ -1,0 +1,17 @@
+package model
+
+import "testing"
+
+func TestStatusGlyphAndLabel(t *testing.T) {
+	cases := map[SessionStatus][2]string{
+		StatusClosed:      {"·", "idle"},
+		StatusRecent:      {"○", "recent"},
+		StatusRunningIdle: {"◐", "running"},
+		StatusRunningBusy: {"●", "running"},
+	}
+	for st, want := range cases {
+		if st.Glyph() != want[0] || st.Label() != want[1] {
+			t.Errorf("%d: glyph=%q label=%q, want %v", st, st.Glyph(), st.Label(), want)
+		}
+	}
+}

--- a/internal/history/source/claudecode.go
+++ b/internal/history/source/claudecode.go
@@ -1,0 +1,139 @@
+package source
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// safeID guards the session id that is later interpolated into a shell
+// command and eval'd. Real Claude Code ids are UUIDs; this rejects any
+// filename stem containing shell-dangerous characters.
+var safeID = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// recentThreshold: a session touched more recently than this (and not live in
+// the registry) is shown as "recent".
+const recentThreshold = 30 * time.Minute
+
+type ClaudeCodeTool struct {
+	root        string
+	sessionsDir string
+}
+
+// NewClaudeCodeTool resolves the Claude projects + live-session directories
+// via agent-deck's own config resolution (CLAUDE_CONFIG_DIR / account /
+// group / profile / ~/.claude), not agenthop's AGENTHOP_* env vars.
+// agent-hopdeck: replaces the ported env-var constructor.
+func NewClaudeCodeTool() *ClaudeCodeTool {
+	base := session.GetClaudeConfigDir()
+	return &ClaudeCodeTool{
+		root:        filepath.Join(base, "projects"),
+		sessionsDir: filepath.Join(base, "sessions"),
+	}
+}
+
+func (t *ClaudeCodeTool) Name() string { return "claude-code" }
+
+func (t *ClaudeCodeTool) Command(s model.Session, fork bool) string {
+	cmd := "claude --resume " + s.ID
+	if fork {
+		cmd += " --fork-session"
+	}
+	return cmd
+}
+
+func (t *ClaudeCodeTool) Delete(s model.Session) error {
+	if s.FilePath == "" {
+		return errors.New("session has no file path")
+	}
+	// remove the transcript and its sidecar dir (subagent transcripts).
+	os.RemoveAll(strings.TrimSuffix(s.FilePath, ".jsonl"))
+	return os.Remove(s.FilePath)
+}
+
+func (t *ClaudeCodeTool) Discover() ([]model.Project, error) {
+	entries, err := os.ReadDir(t.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	byCWD := map[string]*model.Project{}
+	for _, dir := range entries {
+		if !dir.IsDir() {
+			continue
+		}
+		files, _ := filepath.Glob(filepath.Join(t.root, dir.Name(), "*.jsonl"))
+		for _, f := range files {
+			s, err := ParseSessionMeta(f)
+			if err != nil || s.CWD == "" || !safeID.MatchString(s.ID) {
+				continue
+			}
+			p := byCWD[s.CWD]
+			if p == nil {
+				p = &model.Project{Path: s.CWD, Name: filepath.Base(s.CWD), Tool: t.Name()}
+				byCWD[s.CWD] = p
+			}
+			p.Sessions = append(p.Sessions, s)
+		}
+	}
+	out := make([]model.Project, 0, len(byCWD))
+	for _, p := range byCWD {
+		sort.Slice(p.Sessions, func(i, j int) bool {
+			return p.Sessions[i].ModTime.After(p.Sessions[j].ModTime)
+		})
+		out = append(out, *p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+
+	reg, _ := ReadRegistry(t.sessionsDir)
+	applyStatus(out, reg, time.Now())
+	return out, nil
+}
+
+func statusFor(s model.Session, reg map[string]Live, now time.Time) model.SessionStatus {
+	if l, ok := reg[s.ID]; ok {
+		switch l.RawStatus {
+		case "waiting":
+			return model.StatusWaiting
+		case "busy":
+			return model.StatusRunningBusy
+		default: // idle, shell
+			return model.StatusRunningIdle
+		}
+	}
+	if now.Sub(s.ModTime) < recentThreshold {
+		return model.StatusRecent
+	}
+	return model.StatusClosed
+}
+
+func applyStatus(projects []model.Project, reg map[string]Live, now time.Time) {
+	for i := range projects {
+		for j := range projects[i].Sessions {
+			s := &projects[i].Sessions[j]
+			s.Status = statusFor(*s, reg, now)
+			if l, ok := reg[s.ID]; ok {
+				s.PID, s.Name, s.WaitingFor = l.PID, l.Name, l.WaitingFor
+			} else {
+				s.PID = 0
+				s.WaitingFor = ""
+			}
+		}
+	}
+}
+
+// RefreshStatus re-reads the live-session registry and updates statuses in
+// place, without re-parsing session files.
+func (t *ClaudeCodeTool) RefreshStatus(projects []model.Project) {
+	reg, _ := ReadRegistry(t.sessionsDir)
+	applyStatus(projects, reg, time.Now())
+}

--- a/internal/history/source/claudecode_fork_test.go
+++ b/internal/history/source/claudecode_fork_test.go
@@ -1,0 +1,29 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewClaudeCodeTool_UsesClaudeConfigDir(t *testing.T) {
+	// Point agent-deck's resolver at a temp dir via CLAUDE_CONFIG_DIR.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "projects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	tool := NewClaudeCodeTool()
+	if tool.Name() != "claude-code" {
+		t.Fatalf("Name() = %q, want claude-code", tool.Name())
+	}
+	// Discover on an empty (but existing) projects dir returns no projects, no error.
+	projects, err := tool.Discover()
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("Discover() = %d projects, want 0", len(projects))
+	}
+}

--- a/internal/history/source/claudecode_test.go
+++ b/internal/history/source/claudecode_test.go
@@ -1,0 +1,196 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+func fmtInt(n int) string { return strconv.Itoa(n) }
+
+// TestMain isolates tests from the real ~/.claude registry by pointing
+// agent-deck's config-dir resolver at an empty temp dir. Individual tests
+// that need their own projects/sessions layout override CLAUDE_CONFIG_DIR
+// via t.Setenv.
+//
+// agent-hopdeck: this package now imports internal/session, whose
+// GetClaudeConfigDir() transitively resolves agent-deck's own user config
+// under the real HOME unless sandboxed. testutil.IsolateHome() closes that
+// gap (see internal/testutil/homeenv.go — 2026-06-04 data-loss incident);
+// without it, running this suite could read/write the developer's real
+// ~/.agent-deck config.
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the deferred cleanup below
+// actually runs (os.Exit does not run defers).
+func runTestMain(m *testing.M) int {
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+
+	tmp, err := os.MkdirTemp("", "agent-hopdeck-claude-config")
+	if err == nil {
+		os.Setenv("CLAUDE_CONFIG_DIR", tmp)
+		defer os.RemoveAll(tmp)
+	}
+	return m.Run()
+}
+
+func writeSession(t *testing.T, dir, id, cwd, title string, mod time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, id+".jsonl")
+	body := `{"type":"user","cwd":"` + cwd + `","message":{"role":"user","content":"hi"}}` + "\n" +
+		`{"type":"ai-title","aiTitle":"` + title + `"}` + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Chtimes(p, mod, mod)
+}
+
+func TestDiscoverGroupsByCwdAndSorts(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	root := filepath.Join(dir, "projects")
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	writeSession(t, filepath.Join(root, "enc-a"), "s1", "/work/app", "older", base)
+	writeSession(t, filepath.Join(root, "enc-a"), "s2", "/work/app", "newer", base.Add(time.Hour))
+	writeSession(t, filepath.Join(root, "enc-b"), "s3", "/work/lib", "solo", base)
+
+	tool := NewClaudeCodeTool()
+	projects, err := tool.Discover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("projects = %d, want 2", len(projects))
+	}
+	var app model.Project
+	for _, p := range projects {
+		if p.Path == "/work/app" {
+			app = p
+		}
+	}
+	if len(app.Sessions) != 2 || app.Sessions[0].ID != "s2" {
+		t.Fatalf("app sessions not sorted newest-first: %+v", app.Sessions)
+	}
+	if got := tool.Command(app.Sessions[0], false); got != "claude --resume s2" {
+		t.Errorf("Command = %q", got)
+	}
+}
+
+func TestCommandForkFlag(t *testing.T) {
+	tool := NewClaudeCodeTool()
+	s := model.Session{ID: "abc"}
+	if got := tool.Command(s, false); got != "claude --resume abc" {
+		t.Errorf("plain = %q", got)
+	}
+	if got := tool.Command(s, true); got != "claude --resume abc --fork-session" {
+		t.Errorf("fork = %q", got)
+	}
+}
+
+func TestDeleteRemovesTranscript(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	root := filepath.Join(dir, "projects")
+	sessDir := filepath.Join(root, "enc")
+	writeSession(t, sessDir, "22222222-2222-2222-2222-222222222222", "/w/a", "t", time.Now())
+	tool := NewClaudeCodeTool()
+	projects, _ := tool.Discover()
+	s := projects[0].Sessions[0]
+	if err := tool.Delete(s); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(s.FilePath); !os.IsNotExist(err) {
+		t.Fatal("transcript not deleted")
+	}
+}
+
+func TestDiscoverOverlaysRunningStatus(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	root := filepath.Join(dir, "projects")
+	sess := filepath.Join(dir, "sessions")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	writeSession(t, filepath.Join(root, "enc"), "11111111-1111-1111-1111-111111111111", "/work/app", "live one", now)
+	self := os.Getpid()
+	reg := `{"pid":` + fmtInt(self) + `,"sessionId":"11111111-1111-1111-1111-111111111111","cwd":"/work/app","status":"busy"}`
+	os.WriteFile(filepath.Join(sess, fmtInt(self)+".json"), []byte(reg), 0o644)
+
+	projects, _ := NewClaudeCodeTool().Discover()
+	var found bool
+	for _, p := range projects {
+		for _, s := range p.Sessions {
+			if s.ID == "11111111-1111-1111-1111-111111111111" {
+				found = true
+				if s.Status != model.StatusRunningBusy || s.PID != self {
+					t.Fatalf("status=%v pid=%d, want running/%d", s.Status, s.PID, self)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("session not discovered")
+	}
+}
+
+func TestDiscoverOverlaysWaitingStatus(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	root := filepath.Join(dir, "projects")
+	sess := filepath.Join(dir, "sessions")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	id := "22222222-2222-2222-2222-222222222222"
+	writeSession(t, filepath.Join(root, "enc"), id, "/work/app", "waiter", time.Now())
+	self := os.Getpid()
+	reg := `{"pid":` + fmtInt(self) + `,"sessionId":"` + id + `","cwd":"/work/app","status":"waiting","waitingFor":"permission prompt"}`
+	os.WriteFile(filepath.Join(sess, fmtInt(self)+".json"), []byte(reg), 0o644)
+
+	projects, _ := NewClaudeCodeTool().Discover()
+	for _, p := range projects {
+		for _, s := range p.Sessions {
+			if s.ID == id {
+				if s.Status != model.StatusWaiting || s.WaitingFor != "permission prompt" {
+					t.Fatalf("status=%v waitingFor=%q, want waiting/permission prompt", s.Status, s.WaitingFor)
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("waiting session not discovered")
+}
+
+func TestDiscoverSkipsUnsafeSessionID(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	root := filepath.Join(dir, "projects")
+	now := time.Now()
+	writeSession(t, filepath.Join(root, "enc"), "good-id", "/work/app", "ok", now)
+	writeSession(t, filepath.Join(root, "enc"), "evil;calc", "/work/app", "bad", now)
+
+	projects, err := NewClaudeCodeTool().Discover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range projects {
+		for _, s := range p.Sessions {
+			if s.ID == "evil;calc" {
+				t.Fatalf("unsafe session id was not skipped: %q", s.ID)
+			}
+		}
+	}
+}

--- a/internal/history/source/index.go
+++ b/internal/history/source/index.go
@@ -1,0 +1,38 @@
+package source
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strconv"
+)
+
+type IndexEntry struct {
+	LastSessionID  string
+	LastModifiedMs int64
+}
+
+func ReadClaudeIndex(path string) (map[string]IndexEntry, error) {
+	out := map[string]IndexEntry{}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return out, nil
+	}
+	if err != nil {
+		return out, err
+	}
+	var doc struct {
+		Projects map[string]struct {
+			LastSessionID       string `json:"lastSessionId"`
+			LastSessionModified string `json:"lastSessionModified"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return out, err
+	}
+	for p, e := range doc.Projects {
+		ms, _ := strconv.ParseInt(e.LastSessionModified, 10, 64)
+		out[p] = IndexEntry{LastSessionID: e.LastSessionID, LastModifiedMs: ms}
+	}
+	return out, nil
+}

--- a/internal/history/source/index_test.go
+++ b/internal/history/source/index_test.go
@@ -1,0 +1,26 @@
+package source
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestReadClaudeIndex(t *testing.T) {
+	idx, err := ReadClaudeIndex(filepath.Join("testdata", "claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx["/tmp/proj"].LastSessionID != "aaa" {
+		t.Errorf("got %+v", idx["/tmp/proj"])
+	}
+	if idx["/tmp/proj"].LastModifiedMs != 1779099078389 {
+		t.Errorf("modms = %d", idx["/tmp/proj"].LastModifiedMs)
+	}
+}
+
+func TestReadClaudeIndexMissingFileIsEmpty(t *testing.T) {
+	idx, err := ReadClaudeIndex(filepath.Join("testdata", "nope.json"))
+	if err != nil || len(idx) != 0 {
+		t.Fatalf("missing file: idx=%v err=%v", idx, err)
+	}
+}

--- a/internal/history/source/parse.go
+++ b/internal/history/source/parse.go
@@ -1,0 +1,124 @@
+package source
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+// cmdWrapper matches Claude Code's injected local-command / caveat messages,
+// so they aren't picked up as a session title.
+var cmdWrapper = regexp.MustCompile(`^<[^>]*(command|caveat)`)
+
+const maxScanLines = 5000
+const maxLineBytes = 4 << 20 // 4MB per line
+
+type rawLine struct {
+	Type       string `json:"type"`
+	CWD        string `json:"cwd"`
+	GitBranch  string `json:"gitBranch"`
+	AITitle    string `json:"aiTitle"`
+	Summary    string `json:"summary"`
+	LastPrompt string `json:"lastPrompt"`
+	Message    *struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+func contentText(raw json.RawMessage) string {
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil {
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				return b.Text
+			}
+		}
+	}
+	return ""
+}
+
+// ParseSessionMeta reads a bounded prefix of a session .jsonl and extracts
+// display metadata. Malformed lines are skipped, not fatal.
+func ParseSessionMeta(path string) (model.Session, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return model.Session{}, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return model.Session{}, err
+	}
+	defer f.Close()
+
+	base := info.Name()
+	s := model.Session{
+		ID:       strings.TrimSuffix(base, ".jsonl"),
+		Tool:     "claude-code",
+		FilePath: path,
+		ModTime:  info.ModTime(),
+	}
+	var aiTitle, summary, firstUser string
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+	for n := 0; sc.Scan() && n < maxScanLines; n++ {
+		var r rawLine
+		if json.Unmarshal(sc.Bytes(), &r) != nil {
+			continue
+		}
+		switch r.Type {
+		case "user", "assistant":
+			s.MsgCount++
+			if r.CWD != "" {
+				s.CWD = r.CWD
+			}
+			if r.GitBranch != "" {
+				s.GitBranch = r.GitBranch
+			}
+			if r.Type == "user" && firstUser == "" && r.Message != nil {
+				txt := oneLine(contentText(r.Message.Content))
+				if txt != "" && !cmdWrapper.MatchString(txt) {
+					firstUser = txt
+				}
+			}
+		case "ai-title":
+			aiTitle = r.AITitle
+		case "summary":
+			summary = r.Summary
+		case "last-prompt":
+			s.LastPrompt = r.LastPrompt
+		}
+	}
+
+	switch {
+	case aiTitle != "":
+		s.Title = aiTitle
+	case summary != "":
+		s.Title = summary
+	case firstUser != "":
+		s.Title = firstUser
+	case s.LastPrompt != "":
+		s.Title = s.LastPrompt
+	}
+	s.Title = oneLine(s.Title)
+	s.LastPrompt = oneLine(s.LastPrompt)
+	return s, nil
+}
+
+// oneLine collapses all runs of whitespace (including newlines) into single
+// spaces so a pasted multi-line prompt can't spill across TUI rows.
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/history/source/parse_test.go
+++ b/internal/history/source/parse_test.go
@@ -1,0 +1,70 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSessionMeta(t *testing.T) {
+	s, err := ParseSessionMeta(filepath.Join("testdata", "session_titled.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Title != "Great Title" {
+		t.Errorf("title = %q, want ai-title", s.Title)
+	}
+	if s.CWD != "/tmp/proj" || s.GitBranch != "main" {
+		t.Errorf("cwd/branch = %q/%q", s.CWD, s.GitBranch)
+	}
+	if s.LastPrompt != "latest prompt" {
+		t.Errorf("lastPrompt = %q", s.LastPrompt)
+	}
+	if s.MsgCount != 2 {
+		t.Errorf("msgCount = %d, want 2", s.MsgCount)
+	}
+}
+
+func TestParseFallsBackToFirstUserMessage(t *testing.T) {
+	s, _ := ParseSessionMeta(filepath.Join("testdata", "session_firstmsg.jsonl"))
+	if s.Title != "only user text here" {
+		t.Errorf("title = %q, want first user msg", s.Title)
+	}
+}
+
+func TestParseCollapsesMultilineTitle(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "s.jsonl")
+	body := "{\"type\":\"user\",\"cwd\":\"/x\",\"message\":{\"role\":\"user\",\"content\":\"line one\\n  line two\\n\\tline three\"}}\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := ParseSessionMeta(p)
+	if s.Title != "line one line two line three" {
+		t.Fatalf("title = %q, want single line", s.Title)
+	}
+}
+
+func TestParseSkipsCommandWrapperTitle(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "s.jsonl")
+	body := `{"type":"user","cwd":"/x","message":{"role":"user","content":"<local-command-caveat>Caveat: blah</local-command-caveat>"}}` + "\n" +
+		`{"type":"user","cwd":"/x","message":{"role":"user","content":"real first request"}}` + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := ParseSessionMeta(p)
+	if s.Title != "real first request" {
+		t.Fatalf("title = %q, want the real message (wrapper skipped)", s.Title)
+	}
+}
+
+func TestParseSkipsCorruptLines(t *testing.T) {
+	s, err := ParseSessionMeta(filepath.Join("testdata", "session_corrupt.jsonl"))
+	if err != nil {
+		t.Fatalf("should not error on corrupt line: %v", err)
+	}
+	if s.CWD != "/tmp/p3" {
+		t.Errorf("cwd = %q, want recovered value", s.CWD)
+	}
+}

--- a/internal/history/source/registry.go
+++ b/internal/history/source/registry.go
@@ -1,0 +1,61 @@
+package source
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type Live struct {
+	PID        int
+	SessionID  string
+	CWD        string
+	Name       string
+	RawStatus  string
+	WaitingFor string
+	UpdatedMs  int64
+}
+
+// ReadRegistry reads ~/.claude/sessions/<pid>.json entries, keeps only those
+// whose PID is still alive, and returns them keyed by session id.
+func ReadRegistry(dir string) (map[string]Live, error) {
+	out := map[string]Live{}
+	files, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil || files == nil {
+		return out, nil
+	}
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		var d struct {
+			PID        int    `json:"pid"`
+			SessionID  string `json:"sessionId"`
+			CWD        string `json:"cwd"`
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+			WaitingFor string `json:"waitingFor"`
+			UpdatedAt  int64  `json:"updatedAt"`
+		}
+		if json.Unmarshal(data, &d) != nil || d.SessionID == "" || !IsAlive(d.PID) {
+			continue
+		}
+		out[d.SessionID] = Live{PID: d.PID, SessionID: d.SessionID, CWD: d.CWD,
+			Name: d.Name, RawStatus: d.Status, WaitingFor: d.WaitingFor, UpdatedMs: d.UpdatedAt}
+	}
+	return out, nil
+}
+
+// IsAlive reports whether a process with pid exists (signal 0 probe).
+func IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/history/source/registry_test.go
+++ b/internal/history/source/registry_test.go
@@ -1,0 +1,36 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestReadRegistryKeepsLiveDropsDead(t *testing.T) {
+	dir := t.TempDir()
+	self := os.Getpid()
+	live := `{"pid":` + strconv.Itoa(self) + `,"sessionId":"aaa","cwd":"/work/app","status":"busy","updatedAt":123,"name":"n"}`
+	dead := `{"pid":2147480000,"sessionId":"bbb","cwd":"/work/x","status":"idle"}`
+	os.WriteFile(filepath.Join(dir, strconv.Itoa(self)+".json"), []byte(live), 0o644)
+	os.WriteFile(filepath.Join(dir, "2147480000.json"), []byte(dead), 0o644)
+
+	reg, err := ReadRegistry(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg["bbb"]; ok {
+		t.Error("dead pid session should be dropped")
+	}
+	l, ok := reg["aaa"]
+	if !ok || l.CWD != "/work/app" || l.RawStatus != "busy" || l.PID != self {
+		t.Fatalf("live entry = %+v ok=%v", l, ok)
+	}
+}
+
+func TestReadRegistryMissingDirEmpty(t *testing.T) {
+	reg, err := ReadRegistry(filepath.Join(t.TempDir(), "nope"))
+	if err != nil || len(reg) != 0 {
+		t.Fatalf("missing dir: reg=%v err=%v", reg, err)
+	}
+}

--- a/internal/history/source/testdata/claude.json
+++ b/internal/history/source/testdata/claude.json
@@ -1,0 +1,1 @@
+{"projects":{"/tmp/proj":{"lastSessionId":"aaa","lastSessionModified":"1779099078389"},"/tmp/p2":{"lastSessionId":"bbb"}}}

--- a/internal/history/source/testdata/session_corrupt.jsonl
+++ b/internal/history/source/testdata/session_corrupt.jsonl
@@ -1,0 +1,2 @@
+{not valid json
+{"type":"user","cwd":"/tmp/p3","message":{"role":"user","content":"survived"}}

--- a/internal/history/source/testdata/session_firstmsg.jsonl
+++ b/internal/history/source/testdata/session_firstmsg.jsonl
@@ -1,0 +1,1 @@
+{"type":"user","cwd":"/tmp/p2","gitBranch":"dev","message":{"role":"user","content":"only user text here"}}

--- a/internal/history/source/testdata/session_titled.jsonl
+++ b/internal/history/source/testdata/session_titled.jsonl
@@ -1,0 +1,4 @@
+{"type":"user","sessionId":"aaa","cwd":"/tmp/proj","gitBranch":"main","timestamp":"2026-07-15T06:34:44Z","message":{"role":"user","content":"first question"}}
+{"type":"ai-title","aiTitle":"Great Title"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+{"type":"last-prompt","lastPrompt":"latest prompt"}

--- a/internal/history/source/tool.go
+++ b/internal/history/source/tool.go
@@ -1,0 +1,11 @@
+package source
+
+import "github.com/asheshgoplani/agent-deck/internal/history/model"
+
+type Tool interface {
+	Name() string
+	Discover() ([]model.Project, error)
+	Command(s model.Session, fork bool) string
+	Delete(s model.Session) error
+	RefreshStatus(projects []model.Project)
+}

--- a/internal/history/tree/filter.go
+++ b/internal/history/tree/filter.go
@@ -1,0 +1,43 @@
+package tree
+
+import (
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+func subseq(hay, needle string) bool {
+	h := strings.ToLower(hay)
+	n := []rune(strings.ToLower(needle))
+	i := 0
+	for _, r := range h {
+		if i < len(n) && n[i] == r {
+			i++
+		}
+	}
+	return i == len(n)
+}
+
+func matches(s model.Session, q string) bool {
+	return subseq(s.Title, q) || subseq(s.CWD, q) || subseq(s.GitBranch, q)
+}
+
+func Filter(projects []model.Project, query string) []model.Project {
+	if strings.TrimSpace(query) == "" {
+		return projects
+	}
+	var out []model.Project
+	for _, p := range projects {
+		var kept []model.Session
+		for _, s := range p.Sessions {
+			if matches(s, query) {
+				kept = append(kept, s)
+			}
+		}
+		if len(kept) > 0 {
+			p.Sessions = kept
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/history/tree/filter_test.go
+++ b/internal/history/tree/filter_test.go
@@ -1,0 +1,42 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+func TestFilterKeepsMatchingSessions(t *testing.T) {
+	projects := []model.Project{{
+		Path: "/a", Name: "a",
+		Sessions: []model.Session{
+			{ID: "1", Title: "Fix S3 cache", CWD: "/a"},
+			{ID: "2", Title: "Add login", CWD: "/a", GitBranch: "feature/auth"},
+		},
+	}}
+	out := Filter(projects, "auth")
+	if len(out) != 1 || len(out[0].Sessions) != 1 || out[0].Sessions[0].ID != "2" {
+		t.Fatalf("filtered = %+v", out)
+	}
+}
+
+func TestFilterMatchesMultibyteQuery(t *testing.T) {
+	projects := []model.Project{{
+		Path: "/a",
+		Sessions: []model.Session{
+			{ID: "1", Title: "café menu redesign"},
+			{ID: "2", Title: "plain ascii task"},
+		},
+	}}
+	out := Filter(projects, "café")
+	if len(out) != 1 || len(out[0].Sessions) != 1 || out[0].Sessions[0].ID != "1" {
+		t.Fatalf("multibyte filter = %+v", out)
+	}
+}
+
+func TestFilterEmptyQueryReturnsAll(t *testing.T) {
+	in := []model.Project{{Path: "/a", Sessions: []model.Session{{ID: "1"}}}}
+	if out := Filter(in, ""); len(out) != 1 || len(out[0].Sessions) != 1 {
+		t.Fatalf("empty query changed input: %+v", out)
+	}
+}

--- a/internal/history/tree/flatten.go
+++ b/internal/history/tree/flatten.go
@@ -1,0 +1,65 @@
+package tree
+
+import "github.com/asheshgoplani/agent-deck/internal/history/model"
+
+type RowKind int
+
+const (
+	FolderRow RowKind = iota
+	ProjectRow
+	SessionRow
+	LoadMoreRow
+)
+
+type Row struct {
+	Kind      RowKind
+	Depth     int
+	Node      *Node
+	Session   *model.Session
+	Path      string
+	Remaining int
+}
+
+func FlattenVisible(root *Node, expanded map[string]bool, loaded map[string]int, pageSize int) []Row {
+	var rows []Row
+	var walk func(n *Node, depth int)
+	walk = func(n *Node, depth int) {
+		for _, c := range n.Children {
+			kind := FolderRow
+			if c.Project != nil {
+				kind = ProjectRow
+			}
+			rows = append(rows, Row{Kind: kind, Depth: depth, Node: c, Path: c.Path})
+			if !expanded[c.Path] {
+				continue
+			}
+			// A node can be both a project and the parent of sub-projects
+			// (e.g. /madp and /madp/web-app). Show sub-folders first, then
+			// this node's own sessions.
+			if len(c.Children) > 0 {
+				walk(c, depth+1)
+			}
+			if c.Project != nil {
+				emitSessions(&rows, c.Project, depth+1, loaded, pageSize)
+			}
+		}
+	}
+	walk(root, 0)
+	return rows
+}
+
+func emitSessions(rows *[]Row, p *model.Project, depth int, loaded map[string]int, pageSize int) {
+	limit := pageSize
+	if l := loaded[p.Path]; l > limit {
+		limit = l
+	}
+	if limit > len(p.Sessions) {
+		limit = len(p.Sessions)
+	}
+	for i := 0; i < limit; i++ {
+		*rows = append(*rows, Row{Kind: SessionRow, Depth: depth, Session: &p.Sessions[i], Path: p.Path})
+	}
+	if rem := len(p.Sessions) - limit; rem > 0 {
+		*rows = append(*rows, Row{Kind: LoadMoreRow, Depth: depth, Path: p.Path, Remaining: rem})
+	}
+}

--- a/internal/history/tree/flatten_test.go
+++ b/internal/history/tree/flatten_test.go
@@ -1,0 +1,84 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+func sessions(n int) []model.Session {
+	s := make([]model.Session, n)
+	for i := range s {
+		s[i] = model.Session{ID: string(rune('a' + i))}
+	}
+	return s
+}
+
+func TestFlattenCollapsedShowsOnlyTopNode(t *testing.T) {
+	// /w/a collapses to a single "w/a" project node.
+	root := BuildTree([]model.Project{{Path: "/w/a", Name: "a", Sessions: sessions(3)}})
+	rows := FlattenVisible(root, map[string]bool{}, map[string]int{}, 15)
+	if len(rows) != 1 || rows[0].Kind != ProjectRow || rows[0].Node.Name != "w/a" {
+		t.Fatalf("collapsed rows = %+v", rows)
+	}
+}
+
+func TestFlattenHybridProjectWithSubProject(t *testing.T) {
+	// /a is a project AND the parent of /a/b — both must be reachable.
+	root := BuildTree([]model.Project{
+		{Path: "/a", Name: "a", Sessions: sessions(2)},
+		{Path: "/a/b", Name: "b", Sessions: sessions(3)},
+	})
+	rows := FlattenVisible(root, map[string]bool{"/a": true, "/a/b": true}, map[string]int{}, 15)
+	var projects, sess int
+	for _, r := range rows {
+		if r.Kind == ProjectRow {
+			projects++
+		}
+		if r.Kind == SessionRow {
+			sess++
+		}
+	}
+	if projects != 2 || sess != 5 {
+		t.Fatalf("hybrid: projects=%d sessions=%d, want 2/5\nrows=%+v", projects, sess, rows)
+	}
+}
+
+func TestFlattenPagesSessionsWithLoadMore(t *testing.T) {
+	root := BuildTree([]model.Project{{Path: "/a", Name: "a", Sessions: sessions(20)}})
+	expanded := map[string]bool{"/a": true}
+	rows := FlattenVisible(root, expanded, map[string]int{}, 15)
+	// 1 project row + 15 session rows + 1 load-more row
+	var s, more int
+	for _, r := range rows {
+		switch r.Kind {
+		case SessionRow:
+			s++
+		case LoadMoreRow:
+			more++
+			if r.Remaining != 5 {
+				t.Errorf("remaining = %d, want 5", r.Remaining)
+			}
+		}
+	}
+	if s != 15 || more != 1 {
+		t.Fatalf("sessions=%d loadmore=%d", s, more)
+	}
+}
+
+func TestFlattenLoadedExpandsPage(t *testing.T) {
+	root := BuildTree([]model.Project{{Path: "/a", Name: "a", Sessions: sessions(20)}})
+	rows := FlattenVisible(root, map[string]bool{"/a": true}, map[string]int{"/a": 30}, 15)
+	var s, more int
+	for _, r := range rows {
+		if r.Kind == SessionRow {
+			s++
+		}
+		if r.Kind == LoadMoreRow {
+			more++
+		}
+	}
+	if s != 20 || more != 0 {
+		t.Fatalf("sessions=%d loadmore=%d, want 20/0", s, more)
+	}
+}

--- a/internal/history/tree/scope.go
+++ b/internal/history/tree/scope.go
@@ -1,0 +1,56 @@
+package tree
+
+import (
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+// ScopeFilter keeps projects whose path is root or a descendant of root.
+// An empty root returns everything (global view).
+func ScopeFilter(projects []model.Project, root string) []model.Project {
+	if root == "" {
+		return projects
+	}
+	root = strings.TrimRight(root, "/")
+	var out []model.Project
+	for _, p := range projects {
+		if p.Path == root || strings.HasPrefix(p.Path, root+"/") {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// NodePaths returns the paths of every folder and project node in the tree,
+// used to auto-expand the whole tree on launch.
+func NodePaths(root *Node) []string {
+	var out []string
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		for _, c := range n.Children {
+			out = append(out, c.Path)
+			walk(c)
+		}
+	}
+	walk(root)
+	return out
+}
+
+// NodePathsToDepth returns node paths to expand so the tree shows down to
+// maxDepth levels: nodes at depth < maxDepth get expanded (depth 0 = the
+// top-level children of root).
+func NodePathsToDepth(root *Node, maxDepth int) []string {
+	var out []string
+	var walk func(n *Node, depth int)
+	walk = func(n *Node, depth int) {
+		for _, c := range n.Children {
+			if depth < maxDepth {
+				out = append(out, c.Path)
+			}
+			walk(c, depth+1)
+		}
+	}
+	walk(root, 0)
+	return out
+}

--- a/internal/history/tree/scope_test.go
+++ b/internal/history/tree/scope_test.go
@@ -1,0 +1,54 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+func TestScopeFilterKeepsRootAndDescendants(t *testing.T) {
+	in := []model.Project{
+		{Path: "/work/app"},
+		{Path: "/work/app/sub"},
+		{Path: "/work/other"},
+		{Path: "/elsewhere"},
+	}
+	out := ScopeFilter(in, "/work/app")
+	if len(out) != 2 {
+		t.Fatalf("got %d projects, want 2 (app + app/sub): %+v", len(out), out)
+	}
+}
+
+func TestScopeFilterEmptyRootReturnsAll(t *testing.T) {
+	in := []model.Project{{Path: "/a"}, {Path: "/b"}}
+	if out := ScopeFilter(in, ""); len(out) != 2 {
+		t.Fatalf("empty root should pass all, got %d", len(out))
+	}
+}
+
+func TestNodePathsToDepthExpandsTopOnly(t *testing.T) {
+	// /w/a and /w/b → root child "w" (depth 0) with children a,b (depth 1).
+	root := BuildTree([]model.Project{{Path: "/w/a"}, {Path: "/w/b"}})
+	d1 := NodePathsToDepth(root, 1)
+	if len(d1) != 1 || d1[0] != "/w" {
+		t.Fatalf("depth 1 should expand only /w, got %v", d1)
+	}
+	d2 := NodePathsToDepth(root, 2)
+	if len(d2) != 3 { // /w, /w/a, /w/b
+		t.Fatalf("depth 2 should expand /w and its children, got %v", d2)
+	}
+}
+
+func TestNodePathsCollectsFoldersAndProjects(t *testing.T) {
+	root := BuildTree([]model.Project{
+		{Path: "/w/a", Sessions: []model.Session{{ID: "1"}}},
+		{Path: "/w/b"},
+	})
+	found := map[string]bool{}
+	for _, p := range NodePaths(root) {
+		found[p] = true
+	}
+	if !found["/w/a"] || !found["/w/b"] {
+		t.Fatalf("NodePaths missing project paths: %v", NodePaths(root))
+	}
+}

--- a/internal/history/tree/tree.go
+++ b/internal/history/tree/tree.go
@@ -1,0 +1,65 @@
+package tree
+
+import (
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+type Node struct {
+	Name     string
+	Path     string
+	Children []*Node
+	Project  *model.Project
+}
+
+func (n *Node) child(name, path string) *Node {
+	for _, c := range n.Children {
+		if c.Name == name {
+			return c
+		}
+	}
+	c := &Node{Name: name, Path: path}
+	n.Children = append(n.Children, c)
+	return c
+}
+
+// BuildTree groups projects into a nested folder tree by path segments,
+// then collapses single-child folder chains (e.g. /private/var/www/html →
+// one node) so deep paths stay navigable.
+func BuildTree(projects []model.Project) *Node {
+	root := &Node{}
+	for i := range projects {
+		p := projects[i]
+		segs := strings.Split(strings.Trim(p.Path, "/"), "/")
+		cur := root
+		path := ""
+		for j, seg := range segs {
+			path += "/" + seg
+			cur = cur.child(seg, path)
+			if j == len(segs)-1 {
+				cur.Project = &projects[i]
+			}
+		}
+	}
+	collapse(root)
+	return root
+}
+
+// collapse merges any folder node (no project of its own) that has exactly
+// one child into that child, joining their names with "/". A node that is
+// itself a project is never merged away, so project sessions stay reachable.
+func collapse(n *Node) {
+	for _, c := range n.Children {
+		collapse(c)
+	}
+	for i := range n.Children {
+		c := n.Children[i]
+		for c.Project == nil && len(c.Children) == 1 {
+			only := c.Children[0]
+			only.Name = c.Name + "/" + only.Name
+			n.Children[i] = only
+			c = only
+		}
+	}
+}

--- a/internal/history/tree/tree_test.go
+++ b/internal/history/tree/tree_test.go
@@ -1,0 +1,52 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+func TestBuildTreeNestsSharedParents(t *testing.T) {
+	projects := []model.Project{
+		{Path: "/work/firegroup/web", Name: "web"},
+		{Path: "/work/firegroup/api", Name: "api"},
+		{Path: "/work/other", Name: "other"},
+	}
+	root := BuildTree(projects)
+	// root -> "work" -> {"firegroup" -> {web, api}, other}
+	work := findChild(root, "work")
+	if work == nil {
+		t.Fatal("missing /work node")
+	}
+	fg := findChild(work, "firegroup")
+	if fg == nil || len(fg.Children) != 2 {
+		t.Fatalf("firegroup children = %v", fg)
+	}
+	other := findChild(work, "other")
+	if other == nil || other.Project == nil {
+		t.Fatal("other should be a project leaf")
+	}
+}
+
+func TestBuildTreeCollapsesSingleChildChains(t *testing.T) {
+	root := BuildTree([]model.Project{{Path: "/x/y/z/proj", Name: "proj"}})
+	if len(root.Children) != 1 {
+		t.Fatalf("root children = %d, want 1", len(root.Children))
+	}
+	c := root.Children[0]
+	if c.Name != "x/y/z/proj" || c.Project == nil {
+		t.Fatalf("collapsed node = %q (project=%v)", c.Name, c.Project != nil)
+	}
+	if c.Path != "/x/y/z/proj" {
+		t.Errorf("collapsed node path = %q, want project path", c.Path)
+	}
+}
+
+func findChild(n *Node, name string) *Node {
+	for _, c := range n.Children {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,23 @@
+// Package notify surfaces out-of-band alerts (terminal bell, desktop popup)
+// when a managed session needs attention. Ported from agenthop with an added
+// macOS branch (see notify_darwin.go).
+package notify
+
+import "os"
+
+// Bell rings the controlling terminal's bell. Writing BEL to /dev/tty is safe
+// inside an alt-screen TUI (it doesn't move the cursor). No-op if there is no
+// controlling tty.
+func Bell() {
+	if f, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
+		_, _ = f.WriteString("\a")
+		_ = f.Close()
+	}
+}
+
+// Desktop fires a desktop notification if the platform supports one
+// (best-effort, non-blocking). Implemented per-GOOS in notify_darwin.go /
+// notify_other.go.
+func Desktop(title, body string) {
+	desktopNotify(title, body)
+}

--- a/internal/notify/notify_darwin.go
+++ b/internal/notify/notify_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package notify
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// desktopNotify uses AppleScript (osascript) — the same mechanism agent-deck
+// already uses in internal/terminal/launcher_darwin.go — to raise a
+// Notification Center banner. Started non-blocking; errors are ignored.
+func desktopNotify(title, body string) {
+	esc := func(s string) string {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+		s = strings.ReplaceAll(s, `"`, `\"`)
+		return s
+	}
+	script := "display notification \"" + esc(body) + "\" with title \"" + esc(title) + "\""
+	_ = exec.Command("osascript", "-e", script).Start()
+}

--- a/internal/notify/notify_other.go
+++ b/internal/notify/notify_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+package notify
+
+import "os/exec"
+
+// desktopNotify uses notify-send when present (Linux desktops); no-op
+// otherwise (headless/WSL without a notifier). Started non-blocking.
+func desktopNotify(title, body string) {
+	if _, err := exec.LookPath("notify-send"); err != nil {
+		return
+	}
+	_ = exec.Command("notify-send", "-a", "agent-hopdeck", title, body).Start()
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,20 @@
+package notify
+
+import "testing"
+
+func TestBell_DoesNotPanic(t *testing.T) {
+	// No controlling tty in CI: Bell must be a silent no-op, never panic.
+	Bell()
+}
+
+func TestDesktop_DoesNotPanicOrBlock(t *testing.T) {
+	// Best-effort; must return promptly and never panic even with no notifier.
+	Desktop("agent-hopdeck test", "body")
+}
+
+func TestDesktop_DoesNotPanicOrBlock_WithBackslashesAndQuotes(t *testing.T) {
+	// A title/body containing backslashes and quotes (e.g. a Windows-style
+	// path or an escaped string) must not panic or block, even though on
+	// darwin these characters are embedded in an AppleScript string literal.
+	Desktop(`agent-hopdeck test \"quoted\"`, `C:\Users\test\path with "quotes"`)
+}

--- a/internal/ui/browse.go
+++ b/internal/ui/browse.go
@@ -1,0 +1,398 @@
+// Package ui: BrowsePanel is a self-contained full-screen history-browser
+// mode. It owns discovery, tree state, cursor, and filter; rendering is done
+// via the Task 8 render helpers (browse_render.go / browse_styles.go) in this
+// same package. Modeled on SettingsPanel's Show/Hide/IsVisible/SetSize/
+// Update/View lifecycle (see settings_panel.go).
+package ui
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/history"
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/history/source"
+	"github.com/asheshgoplani/agent-deck/internal/history/tree"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// browsePageSize is how many additional sessions a "load more" row reveals
+// per Enter press, and the initial per-project session cap.
+const browsePageSize = 15
+
+// browseChromeLines is the vertical chrome consumed by the pane border (top +
+// bottom, 2 rows) plus the header and footer lines (1 row each).
+const browseChromeLines = 4
+
+// BrowsePanel is a full-screen Bubble Tea component that browses discovered
+// tool history (currently Claude Code) as a folder/project/session tree.
+type BrowsePanel struct {
+	visible bool
+	width   int
+	height  int
+
+	tool source.Tool
+
+	projects []model.Project // canonical, unfiltered, as last discovered
+	root     *tree.Node      // tree built from projects (post-filter)
+	rows     []tree.Row      // flattened visible rows built from root
+
+	expanded map[string]bool
+	loaded   map[string]int
+
+	cursor int
+	offset int
+
+	filter   string
+	filterOn bool
+
+	err error
+}
+
+// NewBrowsePanel creates a new, hidden BrowsePanel. Discovery happens on
+// Refresh, not construction, so building a panel never touches disk.
+func NewBrowsePanel() *BrowsePanel {
+	return &BrowsePanel{
+		tool:     source.NewClaudeCodeTool(),
+		expanded: map[string]bool{},
+		loaded:   map[string]int{},
+	}
+}
+
+// Show makes the panel visible. Discovery is the caller's job (via Refresh)
+// so opening the panel never blocks on stale data.
+func (p *BrowsePanel) Show() {
+	p.visible = true
+}
+
+// Hide hides the panel. Cursor, filter, and tree state are preserved so
+// reopening the panel resumes where the user left off.
+func (p *BrowsePanel) Hide() {
+	p.visible = false
+}
+
+// IsVisible reports whether the panel is currently shown.
+func (p *BrowsePanel) IsVisible() bool {
+	return p.visible
+}
+
+// IsFiltering reports whether the panel is currently in filter-input mode.
+func (p *BrowsePanel) IsFiltering() bool {
+	return p.filterOn
+}
+
+// SetSize sets the panel's rendering dimensions.
+func (p *BrowsePanel) SetSize(w, h int) {
+	p.width = w
+	p.height = h
+}
+
+// Refresh re-discovers sessions from disk, overlays live agent-deck instance
+// status on top of the ported registry/mtime status, and rebuilds the tree.
+// Top-level nodes are (re-)expanded so the browser never opens to a wall of
+// collapsed folders.
+func (p *BrowsePanel) Refresh(instances []*session.Instance) {
+	projects, err := p.tool.Discover()
+	if err != nil {
+		p.err = err
+		return
+	}
+	p.err = nil
+	history.OverlayInstanceStatus(projects, instances)
+	p.applyProjects(projects)
+}
+
+// applyProjects installs freshly-discovered projects, expands the top level,
+// and rebuilds the row list. Shared by Refresh and the in-panel "r" refresh.
+func (p *BrowsePanel) applyProjects(projects []model.Project) {
+	p.projects = projects
+	top := tree.BuildTree(projects)
+	for _, path := range tree.NodePathsToDepth(top, 1) {
+		p.expanded[path] = true
+	}
+	p.rebuildRows()
+}
+
+// rebuildRows recomputes p.root and p.rows from p.projects, applying the
+// active filter (if any), and clamps the cursor/offset into the new bounds.
+func (p *BrowsePanel) rebuildRows() {
+	projects := p.projects
+	if strings.TrimSpace(p.filter) != "" {
+		projects = tree.Filter(projects, p.filter)
+	}
+	p.root = tree.BuildTree(projects)
+	p.rows = tree.FlattenVisible(p.root, p.expanded, p.loaded, browsePageSize)
+
+	if p.cursor >= len(p.rows) {
+		p.cursor = len(p.rows) - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	p.clampOffset()
+}
+
+// viewportHeight is how many data rows fit in the current pane height.
+func (p *BrowsePanel) viewportHeight() int {
+	vh := p.height - browseChromeLines
+	if vh < 1 {
+		vh = 1
+	}
+	return vh
+}
+
+// clampOffset keeps the cursor within the visible scroll window and the
+// window within the bounds of the row list.
+func (p *BrowsePanel) clampOffset() {
+	vh := p.viewportHeight()
+
+	if p.cursor < p.offset {
+		p.offset = p.cursor
+	}
+	if p.cursor >= p.offset+vh {
+		p.offset = p.cursor - vh + 1
+	}
+
+	maxOffset := len(p.rows) - vh
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if p.offset > maxOffset {
+		p.offset = maxOffset
+	}
+	if p.offset < 0 {
+		p.offset = 0
+	}
+}
+
+// Update handles one key press. The third return value is non-nil only when
+// the user pressed Enter on a SessionRow, meaning "resume this session" —
+// the caller (Home) performs the actual resume.
+func (p *BrowsePanel) Update(msg tea.KeyMsg) (*BrowsePanel, tea.Cmd, *model.Session) {
+	if !p.visible {
+		return p, nil, nil
+	}
+
+	if p.filterOn {
+		return p.handleFilterKey(msg)
+	}
+
+	switch msg.String() {
+	case "esc", "q", "B":
+		p.Hide()
+
+	case "up", "k":
+		p.moveCursor(-1)
+
+	case "down", "j":
+		p.moveCursor(1)
+
+	case "right", "l", " ":
+		p.toggleCurrent()
+
+	case "left", "h":
+		p.collapseCurrent()
+
+	case "/":
+		p.filterOn = true
+		p.filter = ""
+
+	case "r":
+		p.refreshFromTool()
+
+	case "enter":
+		return p.handleEnter()
+	}
+
+	return p, nil, nil
+}
+
+// moveCursor shifts the cursor by delta rows, clamped to the row list, and
+// keeps the scroll offset in sync.
+func (p *BrowsePanel) moveCursor(delta int) {
+	if len(p.rows) == 0 {
+		return
+	}
+	p.cursor += delta
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	if p.cursor >= len(p.rows) {
+		p.cursor = len(p.rows) - 1
+	}
+	p.clampOffset()
+}
+
+// currentRow returns the row under the cursor, or false if there are none.
+func (p *BrowsePanel) currentRow() (tree.Row, bool) {
+	if len(p.rows) == 0 || p.cursor < 0 || p.cursor >= len(p.rows) {
+		return tree.Row{}, false
+	}
+	return p.rows[p.cursor], true
+}
+
+// toggleCurrent expands/collapses the folder or project row under the
+// cursor. No-op on session/load-more rows.
+func (p *BrowsePanel) toggleCurrent() {
+	row, ok := p.currentRow()
+	if !ok {
+		return
+	}
+	if row.Kind == tree.FolderRow || row.Kind == tree.ProjectRow {
+		p.expanded[row.Path] = !p.expanded[row.Path]
+		p.rebuildRows()
+	}
+}
+
+// collapseCurrent collapses the folder/project row under the cursor if it is
+// expanded; otherwise it walks up to the nearest ancestor row and collapses
+// that instead (classic tree-view "left arrow" behavior).
+func (p *BrowsePanel) collapseCurrent() {
+	row, ok := p.currentRow()
+	if !ok {
+		return
+	}
+	if (row.Kind == tree.FolderRow || row.Kind == tree.ProjectRow) && p.expanded[row.Path] {
+		p.expanded[row.Path] = false
+		p.rebuildRows()
+		return
+	}
+	for i := p.cursor - 1; i >= 0; i-- {
+		if p.rows[i].Depth < row.Depth {
+			p.cursor = i
+			p.clampOffset()
+			parent := p.rows[i]
+			if parent.Kind == tree.FolderRow || parent.Kind == tree.ProjectRow {
+				p.expanded[parent.Path] = false
+				p.rebuildRows()
+			}
+			return
+		}
+	}
+}
+
+// handleEnter dispatches Enter based on the row kind under the cursor:
+// resume a session, page in more sessions, or toggle a folder/project.
+func (p *BrowsePanel) handleEnter() (*BrowsePanel, tea.Cmd, *model.Session) {
+	row, ok := p.currentRow()
+	if !ok {
+		return p, nil, nil
+	}
+	switch row.Kind {
+	case tree.SessionRow:
+		return p, nil, row.Session
+	case tree.LoadMoreRow:
+		p.loaded[row.Path] += browsePageSize
+		p.rebuildRows()
+	case tree.FolderRow, tree.ProjectRow:
+		p.expanded[row.Path] = !p.expanded[row.Path]
+		p.rebuildRows()
+	}
+	return p, nil, nil
+}
+
+// refreshFromTool re-discovers and refreshes status without a live-instance
+// overlay (Update has no access to the instance list; Home's own Refresh call
+// supplies that overlay when it opens/reopens the panel). Bound to "r".
+func (p *BrowsePanel) refreshFromTool() {
+	projects, err := p.tool.Discover()
+	if err != nil {
+		p.err = err
+		return
+	}
+	p.err = nil
+	p.tool.RefreshStatus(projects)
+	p.applyProjects(projects)
+}
+
+// handleFilterKey routes key presses while in "/" filter-edit mode: enter/esc
+// exit the mode, backspace edits, everything else that's a single printable
+// rune is appended to the query and the tree is rebuilt.
+func (p *BrowsePanel) handleFilterKey(msg tea.KeyMsg) (*BrowsePanel, tea.Cmd, *model.Session) {
+	key := msg.String()
+	switch key {
+	case "enter", "esc":
+		p.filterOn = false
+	case "backspace":
+		if len(p.filter) > 0 {
+			p.filter = p.filter[:len(p.filter)-1]
+			p.rebuildRows()
+		}
+	default:
+		if len(key) == 1 {
+			p.filter += key
+			p.rebuildRows()
+		}
+	}
+	return p, nil, nil
+}
+
+// View renders the panel: a header, the visible window of tree rows, and a
+// footer of key hints, inside the shared brPaneBorder chrome.
+func (p *BrowsePanel) View() string {
+	if !p.visible {
+		return ""
+	}
+
+	width := p.width
+	if width <= 0 {
+		width = 80
+	}
+
+	dialogWidth := width - 2 // account for the border's own 2 columns
+	if dialogWidth < 10 {
+		dialogWidth = 10
+	}
+	innerWidth := dialogWidth - 2 // brPaneBorder has Padding(0, 1)
+	if innerWidth < 4 {
+		innerWidth = 4
+	}
+
+	var b strings.Builder
+
+	header := "agent-hopdeck · Browse"
+	switch {
+	case p.filterOn:
+		header = "Filter: " + p.filter + "█"
+	case p.filter != "":
+		header += "  (filter: " + p.filter + ")"
+	}
+	if p.err != nil {
+		header += "  [error: " + p.err.Error() + "]"
+	}
+	b.WriteString(browsePadRight(browseClip(header, innerWidth), innerWidth))
+	b.WriteString("\n")
+
+	vh := p.viewportHeight()
+	now := time.Now()
+
+	if len(p.rows) == 0 {
+		b.WriteString(browsePadRight(browseClip("  no sessions found — press r to refresh", innerWidth), innerWidth))
+		b.WriteString("\n")
+		for i := 1; i < vh; i++ {
+			b.WriteString(browsePadRight("", innerWidth))
+			b.WriteString("\n")
+		}
+	} else {
+		end := p.offset + vh
+		if end > len(p.rows) {
+			end = len(p.rows)
+		}
+		for i := p.offset; i < end; i++ {
+			selected := i == p.cursor
+			b.WriteString(browseRowLabel(p.rows[i], innerWidth, selected, p.expanded, now))
+			b.WriteString("\n")
+		}
+		for i := end - p.offset; i < vh; i++ {
+			b.WriteString(browsePadRight("", innerWidth))
+			b.WriteString("\n")
+		}
+	}
+
+	footer := "↑/↓ nav  →/l/space toggle  ←/h collapse  / filter  enter open  r refresh  esc/q close"
+	b.WriteString(browsePadRight(browseClip(footer, innerWidth), innerWidth))
+
+	return brPaneBorder.Width(dialogWidth).Render(b.String())
+}

--- a/internal/ui/browse_render.go
+++ b/internal/ui/browse_render.go
@@ -1,0 +1,132 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/history/tree"
+)
+
+func browseCaretGlyph(expanded bool) string {
+	if expanded {
+		return "▾"
+	}
+	return "▸"
+}
+
+// browseClip truncates a plain (unstyled) string to display width w, adding
+// an ellipsis. Safe only on strings without ANSI escapes.
+func browseClip(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= w {
+		return s
+	}
+	r := []rune(s)
+	for len(r) > 0 && lipgloss.Width(string(r))+1 > w {
+		r = r[:len(r)-1]
+	}
+	return string(r) + "…"
+}
+
+// browseRelTime formats how long ago t was, compactly (now / 3m / 2h / 5d / 3w).
+func browseRelTime(t, now time.Time) string {
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return strconv.Itoa(int(d.Minutes())) + "m"
+	case d < 24*time.Hour:
+		return strconv.Itoa(int(d.Hours())) + "h"
+	case d < 7*24*time.Hour:
+		return strconv.Itoa(int(d.Hours()/24)) + "d"
+	default:
+		return strconv.Itoa(int(d.Hours()/(24*7))) + "w"
+	}
+}
+
+// browsePadRight pads a (possibly styled) string with spaces to display
+// width w.
+func browsePadRight(s string, w int) string {
+	if gap := w - lipgloss.Width(s); gap > 0 {
+		return s + strings.Repeat(" ", gap)
+	}
+	return s
+}
+
+// browseRowLabel renders one tree row as exactly `width` display columns: a
+// 1-col gutter (accent bar when selected, else blank) followed by `width-1`
+// cols of content (a full-width highlight bar when selected). expanded and
+// now are passed explicitly instead of being read off a stateful model.
+func browseRowLabel(r tree.Row, width int, selected bool, expanded map[string]bool, now time.Time) string {
+	gutter := " "
+	if selected {
+		gutter = brGutterStyle.Render("▏")
+	}
+	avail := width - 1
+	if avail < 1 {
+		avail = 1
+	}
+	indent := strings.Repeat("  ", r.Depth)
+
+	if r.Kind == tree.SessionRow {
+		st := r.Session.Status
+		// Layout across `avail` cols: indent + dot(1) + space(1) + title …gap…
+		// + time (flush right), so times form a clean right-hand column.
+		age := browseRelTime(r.Session.ModTime, now)
+		prefixW := lipgloss.Width(indent) + 2 // glyph(1) + space(1)
+		titleBudget := avail - prefixW - lipgloss.Width(age) - 1
+		if titleBudget < 0 {
+			titleBudget = 0
+		}
+		title := browseClip(r.Session.Label(), titleBudget)
+		left := indent + st.Glyph() + " " + title
+		gap := avail - lipgloss.Width(left) - lipgloss.Width(age)
+		if gap < 1 {
+			gap = 1
+		}
+		pad := strings.Repeat(" ", gap)
+		if selected {
+			// One string so the bar fills cleanly and the dot stays aligned with
+			// non-selected rows (dot is plain on the bar; the bar marks selection).
+			return gutter + brSelectedBar.Render(browsePadRight(left+pad+age, avail))
+		}
+		ts := brTitleStyle
+		if st == model.StatusClosed {
+			ts = brClosedTitle
+		}
+		line := indent + brStatusStyles[st].Render(st.Glyph()) + " " + ts.Render(title) + pad + brTimeStyle.Render(age)
+		return gutter + browsePadRight(line, avail)
+	}
+
+	var plain, styled string
+	switch r.Kind {
+	case tree.FolderRow:
+		caret := browseCaretGlyph(expanded[r.Path])
+		name := browseClip(r.Node.Name+"/", avail-2-lipgloss.Width(indent))
+		plain = indent + caret + " " + name
+		styled = indent + brFolderStyle.Render(caret+" "+name)
+	case tree.ProjectRow:
+		caret := browseCaretGlyph(expanded[r.Path])
+		cnt := "  (" + strconv.Itoa(len(r.Node.Project.Sessions)) + ")"
+		name := browseClip(r.Node.Name, avail-2-lipgloss.Width(indent)-lipgloss.Width(cnt))
+		plain = indent + caret + " " + name + cnt
+		styled = indent + brProjectStyle.Render(caret+" "+name) + brCountStyle.Render(cnt)
+	case tree.LoadMoreRow:
+		txt := browseClip("▾ load more ("+strconv.Itoa(r.Remaining)+" more)", avail-lipgloss.Width(indent))
+		plain = indent + txt
+		styled = indent + brLoadMoreStyle.Render(txt)
+	default:
+		return gutter + strings.Repeat(" ", avail)
+	}
+	if selected {
+		return gutter + brSelectedBar.Render(browsePadRight(plain, avail))
+	}
+	return gutter + browsePadRight(styled, avail)
+}

--- a/internal/ui/browse_render_test.go
+++ b/internal/ui/browse_render_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBrowseRelTime(t *testing.T) {
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		when time.Time
+		want string
+	}{
+		{"now", now.Add(-10 * time.Second), "now"},
+		{"minutes", now.Add(-3 * time.Minute), "3m"},
+		{"hours", now.Add(-2 * time.Hour), "2h"},
+		{"days", now.Add(-5 * 24 * time.Hour), "5d"},
+	}
+	for _, c := range cases {
+		if got := browseRelTime(c.when, now); got != c.want {
+			t.Errorf("%s: browseRelTime = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestBrowseCaretGlyph(t *testing.T) {
+	if browseCaretGlyph(true) == browseCaretGlyph(false) {
+		t.Fatal("expanded and collapsed carets must differ")
+	}
+}

--- a/internal/ui/browse_resume_test.go
+++ b/internal/ui/browse_resume_test.go
@@ -1,0 +1,28 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// agent-hopdeck: covers the dedupe lookup used by resumeBrowsedSession to
+// decide whether a browsed Claude session is already adopted into the fleet.
+func TestFindInstanceByClaudeSessionID(t *testing.T) {
+	h := &Home{}
+	a := session.NewInstanceWithTool("a", "/a", "claude")
+	a.ClaudeSessionID = "sess-a"
+	b := session.NewInstanceWithTool("b", "/b", "claude")
+	b.ClaudeSessionID = "sess-b"
+	h.instances = []*session.Instance{a, b}
+
+	if got := h.findInstanceByClaudeSessionID("sess-b"); got != b {
+		t.Fatalf("expected instance b, got %v", got)
+	}
+	if got := h.findInstanceByClaudeSessionID("nope"); got != nil {
+		t.Fatalf("expected nil for unknown id, got %v", got)
+	}
+	if got := h.findInstanceByClaudeSessionID(""); got != nil {
+		t.Fatalf("expected nil for empty id, got %v", got)
+	}
+}

--- a/internal/ui/browse_styles.go
+++ b/internal/ui/browse_styles.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+)
+
+// Catppuccin Mocha
+const (
+	brBase     = "#1e1e2e"
+	brSurface0 = "#313244"
+	brOverlay0 = "#6c7086"
+	brText     = "#cdd6f4"
+	brSubtext1 = "#bac2de"
+	brSubtext0 = "#a6adc8"
+	brLavender = "#b4befe"
+	brBlue     = "#89b4fa"
+	brSapphire = "#74c7ec"
+	brMauve    = "#cba6f7"
+	brGreen    = "#a6e3a1"
+	brYellow   = "#f9e2af"
+	brSky      = "#89dceb"
+	brPeach    = "#fab387"
+	brRed      = "#f38ba8"
+)
+
+func brFg(hex string) lipgloss.Style { return lipgloss.NewStyle().Foreground(lipgloss.Color(hex)) }
+
+var (
+	// One quiet chrome border for both panes: focus never moves off the sidebar,
+	// so an active/idle color split carried no info. The gutter + selection bar
+	// mark where the cursor is.
+	brPaneBorder = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color(brOverlay0)).Padding(0, 1)
+
+	brSelectedBar = lipgloss.NewStyle().Background(lipgloss.Color(brSurface0)).Foreground(lipgloss.Color(brText)).Bold(true)
+	brGutterStyle = brFg(brLavender)
+
+	brFolderStyle   = brFg(brBlue).Bold(true)  // folder (path container) rows
+	brProjectStyle  = brFg(brMauve).Bold(true) // project rows
+	brCountStyle    = brFg(brOverlay0)
+	brTitleStyle    = brFg(brSubtext1)
+	brClosedTitle   = brFg(brOverlay0)
+	brTimeStyle     = brFg(brOverlay0)
+	brLoadMoreStyle = brFg(brOverlay0).Italic(true)
+)
+
+var brStatusStyles = map[model.SessionStatus]lipgloss.Style{
+	model.StatusWaiting:     brFg(brRed).Bold(true),
+	model.StatusRunningBusy: brFg(brGreen),
+	model.StatusRunningIdle: brFg(brYellow),
+	model.StatusRecent:      brFg(brSky),
+	model.StatusClosed:      brFg(brOverlay0),
+}

--- a/internal/ui/browse_test.go
+++ b/internal/ui/browse_test.go
@@ -1,0 +1,128 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	"github.com/asheshgoplani/agent-deck/internal/history/tree"
+)
+
+func TestBrowsePanel_ShowHideVisible(t *testing.T) {
+	p := NewBrowsePanel()
+	if p.IsVisible() {
+		t.Fatal("new panel should be hidden")
+	}
+	p.Show()
+	if !p.IsVisible() {
+		t.Fatal("Show() should make panel visible")
+	}
+	p.Hide()
+	if p.IsVisible() {
+		t.Fatal("Hide() should hide panel")
+	}
+}
+
+func TestBrowsePanel_EscReturnsNilSelection(t *testing.T) {
+	p := NewBrowsePanel()
+	p.Show()
+	p.SetSize(80, 24)
+	_, _, sel := p.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if sel != nil {
+		t.Fatal("Esc must not select a session")
+	}
+	if p.IsVisible() {
+		t.Fatal("Esc should hide the panel")
+	}
+}
+
+// TestBrowsePanel_RenderSmoke exercises the Task 8 render helpers end-to-end
+// with a small fixture, without touching real ~/.claude data.
+func TestBrowsePanel_RenderSmoke(t *testing.T) {
+	p := NewBrowsePanel()
+	p.Show()
+	p.SetSize(80, 24)
+
+	now := time.Now()
+	p.projects = []model.Project{
+		{
+			Path: "/tmp/browsetest",
+			Name: "browsetest",
+			Tool: "claude",
+			Sessions: []model.Session{
+				{
+					ID:      "s1",
+					Title:   "Fix bug",
+					CWD:     "/tmp/browsetest",
+					ModTime: now,
+					Status:  model.StatusRunningBusy,
+				},
+			},
+		},
+	}
+	p.rebuildRows()
+	if len(p.rows) == 0 {
+		t.Fatal("expected at least one row after rebuildRows")
+	}
+	// Expand the top-level project row so the session row (and its status
+	// glyph) becomes visible.
+	p.expanded[p.rows[0].Path] = true
+	p.rebuildRows()
+
+	out := p.View()
+	if out == "" {
+		t.Fatal("View() should not be empty")
+	}
+	if !strings.Contains(out, model.StatusRunningBusy.Glyph()) {
+		t.Fatalf("expected status glyph %q in rendered view, got:\n%s", model.StatusRunningBusy.Glyph(), out)
+	}
+}
+
+// TestBrowsePanel_EnterOnSessionRowReturnsSelection verifies the resume path:
+// Enter on a SessionRow returns that session and does not hide the panel.
+func TestBrowsePanel_EnterOnSessionRowReturnsSelection(t *testing.T) {
+	p := NewBrowsePanel()
+	p.Show()
+	p.SetSize(80, 24)
+
+	p.projects = []model.Project{
+		{
+			Path: "/tmp/browsetest2",
+			Name: "browsetest2",
+			Tool: "claude",
+			Sessions: []model.Session{
+				{ID: "s1", Title: "Fix bug", CWD: "/tmp/browsetest2", ModTime: time.Now(), Status: model.StatusRecent},
+			},
+		},
+	}
+	p.rebuildRows()
+	p.expanded[p.rows[0].Path] = true
+	p.rebuildRows()
+
+	// Find the session row and move the cursor onto it.
+	sessionIdx := -1
+	for i, r := range p.rows {
+		if r.Kind == tree.SessionRow {
+			sessionIdx = i
+			break
+		}
+	}
+	if sessionIdx < 0 {
+		t.Fatal("expected a SessionRow after expanding the project")
+	}
+	p.cursor = sessionIdx
+
+	_, _, sel := p.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if sel == nil {
+		t.Fatal("Enter on a SessionRow should return the selected session")
+	}
+	if sel.ID != "s1" {
+		t.Fatalf("expected selected session id %q, got %q", "s1", sel.ID)
+	}
+	if !p.IsVisible() {
+		t.Fatal("resuming a session must not hide the panel (caller decides)")
+	}
+}

--- a/internal/ui/hitl_notify.go
+++ b/internal/ui/hitl_notify.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/notify"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// waitingNotifyText builds the bell/desktop message for a session that just
+// entered the waiting state.
+func waitingNotifyText(inst *session.Instance) (title, body string) {
+	name := inst.Title
+	if name == "" {
+		name = inst.ID
+	}
+	return "agent-hopdeck", name + " is waiting for input"
+}
+
+// notifyNewlyWaiting rings the bell + raises a desktop notification for each
+// session id that just transitioned into waiting (the `added` set returned by
+// NotificationManager.SyncFromInstances). Edge-triggered: SyncFromInstances
+// only reports a given id in `added` once per transition, so this fires once.
+func (h *Home) notifyNewlyWaiting(added []string, instances []*session.Instance) {
+	if !h.hitlNotifyEnabled || len(added) == 0 {
+		return
+	}
+	byID := make(map[string]*session.Instance, len(instances))
+	for _, inst := range instances {
+		byID[inst.ID] = inst
+	}
+	rang := false
+	for _, id := range added {
+		inst, ok := byID[id]
+		if !ok || inst.GetStatusThreadSafe() != session.StatusWaiting {
+			continue // showAll mode adds non-waiting ids too; skip them
+		}
+		if !rang {
+			notify.Bell()
+			rang = true
+		}
+		title, body := waitingNotifyText(inst)
+		notify.Desktop(title, body)
+	}
+}

--- a/internal/ui/hitl_notify_test.go
+++ b/internal/ui/hitl_notify_test.go
@@ -1,0 +1,19 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestWaitingNotifyText(t *testing.T) {
+	inst := session.NewInstanceWithTool("my-proj", "/x/my-proj", "claude")
+	title, body := waitingNotifyText(inst)
+	if title != "agent-hopdeck" {
+		t.Fatalf("title = %q, want agent-hopdeck", title)
+	}
+	if body == "" || body == "my-proj" {
+		// body should mention the session and that it is waiting
+		t.Fatalf("body = %q, want a 'waiting' message mentioning the session", body)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -34,6 +34,9 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/docker"
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	// agent-hopdeck: needed for resumeBrowsedSession's *model.Session param
+	"github.com/asheshgoplani/agent-deck/internal/history/model"
+	// end agent-hopdeck
 	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/safego"
@@ -266,6 +269,10 @@ type Home struct {
 	watcherPanel         *WatcherPanel         // For showing watcher status and events
 	toolVisibilityPanel  *ToolVisibilityPanel  // Edits [ui].hidden_tools
 	watcherEngine        *watcher.Engine       // nil until Init (D-07: lifecycle tied to TUI startup)
+
+	// agent-hopdeck: history browser panel
+	browsePanel *BrowsePanel
+	// end agent-hopdeck
 
 	// Configurable hotkeys
 	hotkeys        map[string]string // action -> configured key
@@ -519,6 +526,10 @@ type Home struct {
 	boundKeysMu             sync.Mutex        // Protects boundKeys for background worker access
 	lastBarText             string            // Cache to avoid updating all sessions every tick
 	lastBarTextMu           sync.Mutex        // Protects lastBarText for background worker access
+
+	// agent-hopdeck: HITL bell+desktop notify on waiting transition
+	hitlNotifyEnabled bool
+	// end agent-hopdeck
 
 	// Maintenance banner (shown after background maintenance completes)
 	maintenanceMsg     string
@@ -1366,6 +1377,12 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		pendingTitleChanges:       make(map[string]pendingTitle),
 		debugMode:                 logging.IsDebugEnabled(),
 		lastClickIndex:            -1,
+		// agent-hopdeck: default HITL notify on
+		hitlNotifyEnabled: true,
+		// end agent-hopdeck
+		// agent-hopdeck
+		browsePanel: NewBrowsePanel(),
+		// end agent-hopdeck
 	}
 	h.sessionRenderSnapshot.Store(make(map[string]sessionRenderState))
 
@@ -4517,7 +4534,10 @@ func (h *Home) syncNotificationsBackground() {
 	)
 
 	// Sync notification manager with current states
-	h.notificationManager.SyncFromInstances(instances, currentSessionID)
+	added, _ := h.notificationManager.SyncFromInstances(instances, currentSessionID)
+	// agent-hopdeck: bell + desktop on sessions newly entering waiting
+	h.notifyNewlyWaiting(added, instances)
+	// end agent-hopdeck
 
 	// Update tmux status bar directly
 	barText := h.notificationManager.FormatBar()
@@ -6725,6 +6745,24 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, cmd
 		}
 
+		// agent-hopdeck: route keys to the browse panel while it is open
+		if h.browsePanel != nil && h.browsePanel.IsVisible() {
+			if msg.String() == "r" && !h.browsePanel.IsFiltering() {
+				// Refresh always re-applies the live-instance status overlay,
+				// which the panel alone cannot compute.
+				h.browsePanel.Refresh(h.instances)
+				return h, nil
+			}
+			panel, cmd, sel := h.browsePanel.Update(msg)
+			h.browsePanel = panel
+			if sel != nil {
+				h.browsePanel.Hide()
+				return h, h.resumeBrowsedSession(sel) // defined in Task 11
+			}
+			return h, cmd
+		}
+		// end agent-hopdeck
+
 		if h.toolVisibilityPanel != nil && h.toolVisibilityPanel.IsVisible() {
 			var cmd tea.Cmd
 			var shouldSave bool
@@ -6996,12 +7034,21 @@ func (h *Home) jumpToSession(inst *session.Instance) {
 
 // createSessionFromGlobalSearch creates a new Agent Deck session from global search result
 func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd {
+	// agent-hopdeck: delegates to the shared adopt-into-fleet helper below,
+	// reused by the history browser's resumeBrowsedSession.
+	return h.createSessionFromClaudeSession(result.SessionID, result.CWD)
+}
+
+// createSessionFromClaudeSession creates and starts a managed agent-deck
+// session that resumes an existing ~/.claude conversation (claude --resume).
+// agent-hopdeck: shared by global-search and the history browser.
+func (h *Home) createSessionFromClaudeSession(sessionID, cwd string) tea.Cmd {
 	return func() tea.Msg {
 		// Derive title from CWD or session ID
 		title := "Claude Session"
-		projectPath := result.CWD
-		if result.CWD != "" {
-			parts := strings.Split(result.CWD, "/")
+		projectPath := cwd
+		if cwd != "" {
+			parts := strings.Split(cwd, "/")
 			if len(parts) > 0 {
 				title = parts[len(parts)-1]
 			}
@@ -7015,7 +7062,7 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		// the empty string never reaches NewInstanceWithGroupAndTool, which
 		// would otherwise override the extractGroupPath default with "".
 		inst := session.NewInstanceWithGroupAndTool(title, projectPath, h.resolveNewSessionGroup(), "claude")
-		inst.ClaudeSessionID = result.SessionID
+		inst.ClaudeSessionID = sessionID
 
 		// Build resume command with config dir and permission flags
 		userConfig, _ := session.LoadUserConfig()
@@ -7031,7 +7078,7 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 			cmdBuilder.WriteString(fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir))
 		}
 		cmdBuilder.WriteString("claude --resume ")
-		cmdBuilder.WriteString(result.SessionID)
+		cmdBuilder.WriteString(sessionID)
 		if opts.SkipPermissions {
 			cmdBuilder.WriteString(" --dangerously-skip-permissions")
 		} else if opts.AllowSkipPermissions {
@@ -7050,6 +7097,8 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		return sessionCreatedMsg{instance: inst}
 	}
 }
+
+// end agent-hopdeck
 
 // getCurrentGroupPath returns the group path of the currently selected item
 func (h *Home) getCurrentGroupPath() string {
@@ -7560,6 +7609,9 @@ func (h *Home) hasModalVisible() bool {
 		h.setupWizard.IsVisible() || h.settingsPanel.IsVisible() ||
 		(h.toolVisibilityPanel != nil && h.toolVisibilityPanel.IsVisible()) ||
 		h.watcherPanel.IsVisible() || // hotkeyWatcherPanel overlay
+		// agent-hopdeck
+		(h.browsePanel != nil && h.browsePanel.IsVisible()) ||
+		// end agent-hopdeck
 		h.helpOverlay.IsVisible() || h.search.IsVisible() || h.globalSearch.IsVisible() ||
 		h.newDialog.IsVisible() || h.groupDialog.IsVisible() || h.forkDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.pluginDialog.IsVisible() || h.skillDialog.IsVisible() ||
@@ -7570,6 +7622,34 @@ func (h *Home) hasModalVisible() bool {
 		h.editSessionDialog.IsVisible() ||
 		h.zoxidePicker.IsVisible()
 }
+
+// agent-hopdeck: find a live managed instance already resuming this Claude id.
+func (h *Home) findInstanceByClaudeSessionID(id string) *session.Instance {
+	if id == "" {
+		return nil
+	}
+	for _, inst := range h.instances {
+		if inst != nil && inst.ClaudeSessionID == id {
+			return inst
+		}
+	}
+	return nil
+}
+
+// resumeBrowsedSession adopts a browsed ~/.claude session into the fleet, or
+// focuses the existing managed instance if one is already resuming it.
+func (h *Home) resumeBrowsedSession(s *model.Session) tea.Cmd {
+	if s == nil {
+		return nil
+	}
+	if existing := h.findInstanceByClaudeSessionID(s.ID); existing != nil {
+		h.jumpToSession(existing) // focus + scroll the already-running managed session into view
+		return nil
+	}
+	return h.createSessionFromClaudeSession(s.ID, s.CWD)
+}
+
+// end agent-hopdeck
 
 // markNavigationAndFetchPreview sets navigation tracking state and returns a debounced preview command
 func (h *Home) markNavigationAndFetchPreview() tea.Cmd {
@@ -8554,6 +8634,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.watcherPanel.Show()
 		h.watcherPanel.SetSize(h.width, h.height)
 		return h, nil
+
+	// agent-hopdeck: open history browser
+	case "B":
+		if h.browsePanel != nil {
+			h.browsePanel.SetSize(h.width, h.height)
+			h.browsePanel.Refresh(h.instances)
+			h.browsePanel.Show()
+		}
+		return h, nil
+	// end agent-hopdeck
 
 	case "E":
 		// Exec an interactive shell inside the sandbox container.
@@ -13257,6 +13347,12 @@ func (h *Home) View() string {
 	if h.watcherPanel.IsVisible() {
 		return h.watcherPanel.View()
 	}
+
+	// agent-hopdeck: full-screen history browser
+	if h.browsePanel != nil && h.browsePanel.IsVisible() {
+		return h.browsePanel.View()
+	}
+	// end agent-hopdeck
 
 	if h.toolVisibilityPanel != nil && h.toolVisibilityPanel.IsVisible() {
 		return h.toolVisibilityPanel.View()

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -50,6 +50,9 @@ const (
 	hotkeyReload           = "reload"
 	hotkeyDetach           = "detach"
 	hotkeyWatcherPanel     = "watcher_panel"
+	// agent-hopdeck: browse existing ~/.claude history
+	hotkeyBrowse = "browse"
+	// end agent-hopdeck
 	// Session switcher. While attached it is intercepted in the tmux attach
 	// loop (see internal/tmux/pty.go AttachOptions); on the home screen it is
 	// dispatched like any other hotkey. Must resolve to a "ctrl+<letter>" chord.
@@ -116,6 +119,9 @@ var hotkeyActionOrder = []string{
 	hotkeyReload,
 	hotkeyDetach,
 	hotkeyWatcherPanel,
+	// agent-hopdeck
+	hotkeyBrowse,
+	// end agent-hopdeck
 	hotkeySwitchSession,
 }
 
@@ -163,6 +169,9 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyDetach:           "ctrl+q",
 	hotkeyWatcherPanel:     "w",
 	hotkeySwitchSession:    "ctrl+s",
+	// agent-hopdeck
+	hotkeyBrowse: "B",
+	// end agent-hopdeck
 }
 
 var hotkeyActionDefaultTriggers = map[string][]string{


### PR DESCRIPTION
Port three agenthop features into the fork, each isolated in new packages/files so upstream (agent-deck) merges stay clean:

- Browse mode (hotkey B): a nested project tree of existing ~/.claude sessions with status glyphs, right-aligned relative time, and fuzzy filter. New internal/history {model,source,tree} packages (ported from agenthop); the Claude dir is resolved via agent-deck's session.GetClaudeConfigDir() instead of agenthop's env vars.
- Live status overlay (internal/history/livestatus.go): a managed instance's authoritative status supersedes the registry-derived status for browsed sessions.
- Resume: Enter adopts a browsed session into the fleet (claude --resume) via the existing global-search adopt path, or focuses the already-running instance if one exists.
- HITL notify (internal/notify + internal/ui/hitl_notify.go): terminal bell + desktop notification (macOS osascript / Linux notify-send) when a managed session transitions into waiting, wired into the existing NotificationManager sync signal.

Shared-file edits in home.go/hotkeys.go are minimal and wrapped in // agent-hopdeck markers. Verified: golangci-lint clean, go test -race green, and merging current upstream/main applies with zero conflicts.

## What problem does this solve?

<!-- One or two sentences, framed from the user's point of view. Link the issue or Discussion if one exists. -->

## Why this change

<!-- Why this approach? Anything you tried that didn't work? -->

## User impact

<!-- What changes for someone running agent-deck? "None, internal only" is a valid answer. -->

## Evidence

<!-- For behavior changes: real output, a terminal capture, or before/after logs. Mock-only proof is not enough for changes users will feel. -->

## AI disclosure

<!-- Pick one. AI PRs are welcome here with equal standing; this is a quality signal, not a gate. -->

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** <!-- e.g. claude-opus-4-x, gpt-5-codex, gemini-3-pro. "unsure" is fine. -->

**Prompt / session log (optional):** <!-- a gist or link helps us weight it; not required -->

## What actually bothered you

<!-- In your own words: what were you doing when you hit this? A sentence, a real scenario, a
transcript snippet, a log line. If an agent opened this PR: what did your human actually ask for?
Quote them. This is the first thing a reviewer reads. A one-liner is fine; "" is not. -->

## Checklist

- [ ] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [ ] CHANGELOG.md untouched (entries are added at landing)
- [ ] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [ ] "Allow edits from maintainers" is enabled

<!-- Your PR will be validated (applied, built, tested) by the maintainer's AI pipeline within about a day. You'll get a structured comment with the result. Merges are always human. -->

<!-- gate:ai=<human|assisted|authored> model=<name-or-unsure> intent=<yes|no> -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen history browser for exploring projects, folders, and sessions.
  * Added filtering, navigation, expandable project trees, pagination, refresh, and session resuming.
  * Added Claude Code session discovery with status, title, branch, and activity details.
  * Added terminal bell and desktop notifications for sessions waiting for input.
  * Added status indicators and relative activity times to history entries.

* **Bug Fixes**
  * Improved safety when processing session history and ignoring invalid or unsafe entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->