### PR TITLE
fix(send): never treat a dim prompt autosuggestion as an operator draft

### DIFF
--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -18,12 +18,29 @@ func IsComposerPlaceholder(text string) bool {
 	return strings.HasPrefix(t, `Try "`) && strings.HasSuffix(t, `"`)
 }
 
-// ComposerDraft returns the normalized text currently sitting in the visible
-// composer and whether a composer is visible at all. Claude's idle-suggestion
-// placeholder is reported as an empty draft. Callers must pass ANSI-stripped
-// pane content (same contract as CurrentComposerPrompt).
-func ComposerDraft(content string) (draft string, composerVisible bool) {
-	body, ok := CurrentComposerPrompt(content)
+// ComposerDraft returns the normalized operator draft sitting in the visible
+// composer, and whether a composer is visible at all.
+//
+// raw must be the pane capture with ANSI attributes INTACT (tmux capture-pane
+// -e, which CapturePaneFresh already requests). The SGR dim attribute is the
+// only thing distinguishing Claude's prompt autosuggestion from real operator
+// input, so stripping before this call loses the discriminator. strip removes
+// ANSI for text extraction only (pass tmux.StripANSI; nil means identity).
+//
+// Both of Claude's non-input composer states report an empty draft:
+//
+//	❯ Try "write a test for <filepath>"     idle hint (plain text)
+//	❯ <ESC>[2mrun the tests again<ESC>[0m   autosuggestion (dim)
+func ComposerDraft(raw string, strip func(string) string) (draft string, composerVisible bool) {
+	if strip == nil {
+		strip = func(s string) string { return s }
+	}
+	// Checked against the raw bytes: a suggestion is not content, so it is
+	// never saved, cleared or restored.
+	if ComposerBodyIsSuggestion(raw) {
+		return "", true
+	}
+	body, ok := CurrentComposerPrompt(strip(raw))
 	if !ok {
 		return "", false
 	}
@@ -36,9 +53,10 @@ func ComposerDraft(content string) (draft string, composerVisible bool) {
 
 // ComposerHasDraft reports whether the visible composer holds operator input.
 // This is the shared "is the composer busy?" check automated senders must run
-// before injecting keystrokes into the pane (issue #1409).
-func ComposerHasDraft(content string) bool {
-	draft, visible := ComposerDraft(content)
+// before injecting keystrokes into the pane (issue #1409). Same raw/strip
+// contract as ComposerDraft.
+func ComposerHasDraft(raw string, strip func(string) string) bool {
+	draft, visible := ComposerDraft(raw, strip)
 	return visible && draft != ""
 }
 
@@ -125,7 +143,7 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 			// Pane not introspectable: never block delivery on it.
 			return ComposerGuardResult{Held: time.Since(start)}
 		}
-		draft, visible := ComposerDraft(strip(raw))
+		draft, visible := ComposerDraft(raw, strip)
 		if !visible || draft == "" {
 			return ComposerGuardResult{Held: time.Since(start)}
 		}
@@ -156,7 +174,7 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 		clearDeadline := time.Now().Add(opts.ClearWait)
 		for {
 			raw, err := t.CapturePaneFresh()
-			if err == nil && !ComposerHasDraft(strip(raw)) {
+			if err == nil && !ComposerHasDraft(raw, strip) {
 				res.DraftCleared = true
 				res.Held = time.Since(start)
 				return res

--- a/internal/send/guard_test.go
+++ b/internal/send/guard_test.go
@@ -15,7 +15,7 @@ func renderComposer(text string) string {
 }
 
 func TestComposerDraft_EmptyComposer(t *testing.T) {
-	draft, visible := ComposerDraft(renderComposer(""))
+	draft, visible := ComposerDraft(renderComposer(""), nil)
 	if !visible {
 		t.Fatal("expected composer to be visible")
 	}
@@ -25,7 +25,7 @@ func TestComposerDraft_EmptyComposer(t *testing.T) {
 }
 
 func TestComposerDraft_WithOperatorDraft(t *testing.T) {
-	draft, visible := ComposerDraft(renderComposer("instruct deploy ag"))
+	draft, visible := ComposerDraft(renderComposer("instruct deploy ag"), nil)
 	if !visible {
 		t.Fatal("expected composer to be visible")
 	}
@@ -38,7 +38,7 @@ func TestComposerDraft_SuggestionPlaceholderIsNotADraft(t *testing.T) {
 	// Claude's idle composer shows a hint suggestion like:
 	//   ❯ Try "write a test for <filepath>"
 	// which must not be treated as operator input (issue #1409).
-	draft, visible := ComposerDraft(renderComposer(`Try "write a test for <filepath>"`))
+	draft, visible := ComposerDraft(renderComposer(`Try "write a test for <filepath>"`), nil)
 	if !visible {
 		t.Fatal("expected composer to be visible")
 	}
@@ -48,23 +48,23 @@ func TestComposerDraft_SuggestionPlaceholderIsNotADraft(t *testing.T) {
 }
 
 func TestComposerDraft_NoComposerVisible(t *testing.T) {
-	_, visible := ComposerDraft("plain shell output\nno prompt here\n")
+	_, visible := ComposerDraft("plain shell output\nno prompt here\n", nil)
 	if visible {
 		t.Fatal("did not expect a composer in plain output")
 	}
 }
 
 func TestComposerHasDraft(t *testing.T) {
-	if ComposerHasDraft(renderComposer("")) {
+	if ComposerHasDraft(renderComposer(""), nil) {
 		t.Fatal("empty composer must not report a draft")
 	}
-	if !ComposerHasDraft(renderComposer("half-typed message")) {
+	if !ComposerHasDraft(renderComposer("half-typed message"), nil) {
 		t.Fatal("expected composer draft to be reported")
 	}
-	if ComposerHasDraft(renderComposer(`Try "fix lint errors"`)) {
+	if ComposerHasDraft(renderComposer(`Try "fix lint errors"`), nil) {
 		t.Fatal("placeholder must not report a draft")
 	}
-	if ComposerHasDraft("plain output, no composer") {
+	if ComposerHasDraft("plain output, no composer", nil) {
 		t.Fatal("no composer must not report a draft")
 	}
 }

--- a/internal/send/suggestion.go
+++ b/internal/send/suggestion.go
@@ -1,0 +1,135 @@
+package send
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Claude Code renders a prompt autosuggestion (its shell-style ghost
+// completion) in the composer using the SGR dim/faint attribute:
+//
+//	❯ <ESC>[2mrun the tests again<ESC>[0m
+//
+// A real operator draft carries no dim attribute:
+//
+//	❯ run the tests again
+//
+// That attribute is the ONLY thing distinguishing the two — the glyphs are
+// identical once ANSI is stripped. The composer-draft guard (issue #1409)
+// used to introspect stripped content only, so it classified an
+// autosuggestion as an operator draft, saved it, cleared the composer, and
+// then TYPED THE SUGGESTION BACK as real committable text. The next Enter
+// from any source (a later send, a control-plane keystroke, the operator)
+// then submitted a prompt nobody authored.
+//
+// Autosuggestions are accept-key semantics (Tab / Right arrow instantiate
+// them), NOT placeholder semantics, so they must never be treated as content
+// to preserve. The helpers below read the dim attribute off the RAW pane
+// capture (tmux capture-pane -e, which CapturePaneFresh already requests)
+// before it is stripped.
+
+// composerMarkers are the prompt glyphs Claude renders at the composer.
+var composerMarkers = []string{"❯", "›"}
+
+// composerMarkerBody returns the remainder of line following the composer
+// marker, and whether a marker was present.
+func composerMarkerBody(line string) (string, bool) {
+	for _, marker := range composerMarkers {
+		if idx := strings.Index(line, marker); idx >= 0 {
+			return line[idx+len(marker):], true
+		}
+	}
+	return "", false
+}
+
+// applySGR folds one SGR parameter list into the running dim state.
+//
+// Extended-colour introducers (38/48/58) consume their own parameters —
+// `38;5;2` is colour index 2, NOT the dim attribute — so they are skipped
+// explicitly. Without that, the bright-white `38;5;231` Claude uses for
+// submitted messages would be misread.
+func applySGR(params string, dim *bool) {
+	if params == "" {
+		// A bare CSI m is an implicit reset.
+		*dim = false
+		return
+	}
+	parts := strings.Split(params, ";")
+	for i := 0; i < len(parts); i++ {
+		switch strings.TrimSpace(parts[i]) {
+		case "38", "48", "58":
+			if i+1 < len(parts) {
+				switch strings.TrimSpace(parts[i+1]) {
+				case "5":
+					i += 2 // 5;n
+				case "2":
+					i += 4 // 2;r;g;b
+				default:
+					i++
+				}
+			}
+		case "2":
+			*dim = true
+		case "0", "00", "22":
+			*dim = false
+		}
+	}
+}
+
+// bodyStartsDim reports whether the first visible (non-whitespace) character
+// in an ANSI-bearing composer body is rendered dim. Returns false when the
+// body holds no visible character at all (an empty composer).
+func bodyStartsDim(s string) bool {
+	dim := false
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && !isCSIFinal(s[j]) {
+				j++
+			}
+			if j < len(s) {
+				if s[j] == 'm' {
+					applySGR(s[i+2:j], &dim)
+				}
+				i = j + 1
+				continue
+			}
+			return false
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if !isComposerSpace(r) {
+			return dim
+		}
+		i += size
+	}
+	return false
+}
+
+func isCSIFinal(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// isComposerSpace covers the padding Claude puts between the marker and the
+// body, including the NBSP it uses for cursor placement.
+func isComposerSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\r' || r == ' '
+}
+
+// ComposerBodyIsSuggestion reports whether the composer in raw (ANSI-bearing)
+// pane content currently shows a dim-rendered Claude autosuggestion rather
+// than operator input. The composer is the LAST marker line in the pane;
+// earlier marker lines are submitted history.
+func ComposerBodyIsSuggestion(raw string) bool {
+	lines := strings.Split(raw, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		body, ok := composerMarkerBody(lines[i])
+		if !ok {
+			continue
+		}
+		return bodyStartsDim(body)
+	}
+	return false
+}
+
+// ComposerDraft and ComposerHasDraft (guard.go) consume ComposerBodyIsSuggestion
+// directly, so every caller gets the dim check for free.

--- a/internal/send/suggestion_test.go
+++ b/internal/send/suggestion_test.go
@@ -1,0 +1,164 @@
+package send
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The fixtures below are the VERBATIM bytes captured from a live Claude Code
+// 2.1.212 session (agent-deck v1.9.73) via `tmux capture-pane -p -e` while
+// reproducing the ghost-submit bug on 2026-07-19. Keep them byte-exact —
+// they are the regression evidence for this class of defect.
+const (
+	// Composer holding Claude's dim autosuggestion (the ghost).
+	fixtureGhostComposer = "\x1b[39m❯ \x1b[2mNow reply with exactly the word: pineapple\x1b[0m"
+
+	// Composer holding a real operator draft — no dim attribute anywhere.
+	fixtureRealDraftComposer = "\x1b[39m❯ REALDRAFT typed by a human"
+
+	// Composer with nothing in it.
+	fixtureEmptyComposer = "\x1b[39m❯ "
+
+	// An ALREADY-SUBMITTED message line (scrollback history), rendered in
+	// bright white on a highlight background. Must never read as dim.
+	fixtureSubmittedHistory = "\x1b[38;5;239m\x1b[48;5;237m❯ \x1b[38;5;231mNow reply with exactly the word: mango\x1b[39m"
+)
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string { return ansiRe.ReplaceAllString(s, "") }
+
+// pane wraps composer lines in the surrounding pane furniture.
+func pane(composerLines ...string) string {
+	div := "\x1b[38;5;244m" + strings.Repeat("─", 40) + "\x1b[39m"
+	return "some prior output\n" + fixtureSubmittedHistory + "\n" + div + "\n" +
+		strings.Join(composerLines, "\n") + "\n" + div + "\n  auto mode on\n"
+}
+
+func TestComposerBodyIsSuggestion_DimGhostIsDetected(t *testing.T) {
+	if !ComposerBodyIsSuggestion(pane(fixtureGhostComposer)) {
+		t.Fatal("dim autosuggestion must be detected as a suggestion")
+	}
+}
+
+func TestComposerBodyIsSuggestion_RealDraftIsNotASuggestion(t *testing.T) {
+	if ComposerBodyIsSuggestion(pane(fixtureRealDraftComposer)) {
+		t.Fatal("a real operator draft must NOT be classified as a suggestion")
+	}
+}
+
+func TestComposerBodyIsSuggestion_EmptyComposer(t *testing.T) {
+	if ComposerBodyIsSuggestion(pane(fixtureEmptyComposer)) {
+		t.Fatal("empty composer must not be classified as a suggestion")
+	}
+}
+
+// The composer is the LAST marker line; a dim-rendered line earlier in the
+// scrollback must not leak into the classification.
+func TestComposerBodyIsSuggestion_UsesLastMarkerLine(t *testing.T) {
+	stale := "\x1b[39m❯ \x1b[2mstale suggestion from earlier\x1b[0m"
+	if ComposerBodyIsSuggestion(pane(stale, fixtureRealDraftComposer)) {
+		t.Fatal("classification must use the last marker line, not stale scrollback")
+	}
+}
+
+// Regression: SGR 38;5;N is an extended-colour introducer. Colour index 2
+// must not be mistaken for the dim attribute.
+func TestComposerBodyIsSuggestion_ExtendedColourIndexTwoIsNotDim(t *testing.T) {
+	line := "\x1b[39m❯ \x1b[38;5;2mgreen but genuinely typed"
+	if ComposerBodyIsSuggestion(pane(line)) {
+		t.Fatal("38;5;2 is colour index 2, not the dim attribute")
+	}
+}
+
+// Regression: truecolour 38;2;R;G;B likewise consumes its own parameters.
+func TestComposerBodyIsSuggestion_TrueColourIsNotDim(t *testing.T) {
+	line := "\x1b[39m❯ \x1b[38;2;10;20;30mtruecolour typed text"
+	if ComposerBodyIsSuggestion(pane(line)) {
+		t.Fatal("38;2;R;G;B is truecolour, not the dim attribute")
+	}
+}
+
+func TestComposerBodyIsSuggestion_DimResetBeforeBodyIsNotASuggestion(t *testing.T) {
+	line := "\x1b[2m\x1b[22m❯ text after dim was reset"
+	if ComposerBodyIsSuggestion(pane(line)) {
+		t.Fatal("SGR 22 resets dim; body must read as real input")
+	}
+}
+
+func TestComposerDraft_GhostYieldsNoDraft(t *testing.T) {
+	draft, visible := ComposerDraft(pane(fixtureGhostComposer), stripANSI)
+	if !visible {
+		t.Fatal("expected the composer to be visible")
+	}
+	if draft != "" {
+		t.Fatalf("autosuggestion must yield an empty draft, got %q", draft)
+	}
+}
+
+func TestComposerDraft_RealDraftPreserved(t *testing.T) {
+	draft, visible := ComposerDraft(pane(fixtureRealDraftComposer), stripANSI)
+	if !visible {
+		t.Fatal("expected the composer to be visible")
+	}
+	if draft != "REALDRAFT typed by a human" {
+		t.Fatalf("real operator draft must be preserved verbatim, got %q", draft)
+	}
+}
+
+func TestComposerHasDraft_DimVsReal(t *testing.T) {
+	if ComposerHasDraft(pane(fixtureGhostComposer), stripANSI) {
+		t.Fatal("autosuggestion must not report a draft")
+	}
+	if !ComposerHasDraft(pane(fixtureRealDraftComposer), stripANSI) {
+		t.Fatal("real draft must report a draft")
+	}
+}
+
+// THE regression test for the reported bug: with only a dim autosuggestion in
+// the composer, the guard must pass straight through — no hold, no Ctrl+C, and
+// crucially no SavedDraft, because SavedDraft is what executeSend later types
+// back into the composer as real committable text.
+func TestGuardComposerDraft_IgnoresDimAutosuggestion(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{pane(fixtureGhostComposer)}}
+	res := GuardComposerDraft(target, ComposerGuardOptions{
+		HoldWait: time.Second, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+		Strip: stripANSI,
+	})
+	if res.SavedDraft != "" {
+		t.Fatalf("autosuggestion must never be saved as a draft (it would be retyped as real text), got %q", res.SavedDraft)
+	}
+	if res.DraftCleared || res.ClearFailed {
+		t.Fatalf("autosuggestion must not trigger the clear path, got %+v", res)
+	}
+	if target.ctrlCCalls != 0 {
+		t.Fatalf("must not Ctrl+C for an autosuggestion, got %d calls", target.ctrlCCalls)
+	}
+	if target.captureCalls != 1 {
+		t.Fatalf("expected a single capture, got %d", target.captureCalls)
+	}
+}
+
+// The #1409 protection must survive intact: a real draft carrying ANSI colour
+// is still held, saved and cleared.
+func TestGuardComposerDraft_StillGuardsRealDraftWithANSI(t *testing.T) {
+	target := &fakeGuardTarget{
+		captures:     []string{pane(fixtureRealDraftComposer)},
+		clearOnCtrlC: true,
+	}
+	res := GuardComposerDraft(target, ComposerGuardOptions{
+		HoldWait: 10 * time.Millisecond, PollInterval: time.Millisecond, ClearWait: 50 * time.Millisecond,
+		Strip: stripANSI,
+	})
+	if res.SavedDraft != "REALDRAFT typed by a human" {
+		t.Fatalf("real draft must still be saved for restore, got %q", res.SavedDraft)
+	}
+	if !res.DraftCleared {
+		t.Fatalf("real draft must still be cleared before delivery, got %+v", res)
+	}
+	if target.ctrlCCalls == 0 {
+		t.Fatal("expected Ctrl+C for a real operator draft")
+	}
+}

--- a/internal/ui/issue1409_watcher_guard_test.go
+++ b/internal/ui/issue1409_watcher_guard_test.go
@@ -183,10 +183,10 @@ func TestDeliverToConductorPaneGuarded_IgnoresSuggestionPlaceholder(t *testing.T
 
 // sanity: the strings used by these tests parse the way the guard expects.
 func TestComposerFixturesParse(t *testing.T) {
-	if !send.ComposerHasDraft(composerWith("instruct deploy ag")) {
+	if !send.ComposerHasDraft(composerWith("instruct deploy ag"), nil) {
 		t.Fatal("fixture composerWith must register as a draft")
 	}
-	if send.ComposerHasDraft(emptyComposer()) {
+	if send.ComposerHasDraft(emptyComposer(), nil) {
 		t.Fatal("fixture emptyComposer must not register as a draft")
 	}
 	if !strings.Contains(emptyComposer(), "❯") {


### PR DESCRIPTION
## What problem does this solve?

`agent-deck session send` can turn Claude Code's prompt autosuggestion into real, committable composer text. Once that happens, the next `Enter` from any source submits a prompt the user never wrote.

Claude renders its autosuggestion with the SGR dim attribute (`ESC[2m`). `ComposerDraft` introspects ANSI-**stripped** pane content, where dim text is indistinguishable from typed input, and `IsComposerPlaceholder` only recognises the other idle hint form, `Try "…"`. So the #1409 composer-draft guard classifies a suggestion as an operator draft: saves it, `Ctrl+C`-clears the composer, delivers the real message (correctly), and then `executeSend` **types the saved "draft" back** as real text.

For us this was not theoretical — an automated send instantiated a stale suggestion, and a later keystroke submitted it as a genuine instruction, launching work nobody asked for.

## Why this change

Autosuggestions have **accept-key semantics** (Tab / Right arrow instantiate them), not placeholder semantics. They are not content until something accepts them, so they must never be saved and restored.

The fix goes at the point of misclassification. `CapturePaneFresh` already passes `-e`, so the dim attribute is present in the capture and merely discarded before introspection. `ComposerDraft`/`ComposerHasDraft` now take the raw capture plus the strip function and report a dim-rendered body as **no draft** — nothing saved, nothing cleared, nothing restored. Every caller inherits the check, including `deliverToConductorPaneGuarded`, which has the same save/restore shape.

Two things I deliberately did not do:

- **No blanket `C-u`/clear before typing.** We shipped that downstream and reverted it: it wipes a message the user typed while the agent was mid-turn and breaks Claude's native composer queue. The guard has to discriminate, not clear blindly.
- **No parallel "FromPane" helpers.** My first pass added those alongside the existing stripped-content pair, which left the unsafe versions callable and invited a future caller to silently reintroduce the bug. Folding the check into `ComposerDraft` itself keeps one implementation.

One parsing caveat worth flagging for review: `38`/`48`/`58` are extended-colour introducers that consume their own parameters, so `38;5;2` is colour index 2, not SGR 2. A naive scan for a `2` parameter misfires — Claude renders submitted messages with `38;5;231`. `applySGR` skips those introducers, and there are tests for both the 256-colour and truecolour forms.

## User impact

A prompt the user never typed can no longer be submitted on their behalf via the composer guard. Real operator drafts are unaffected — still held, saved, cleared and restored exactly as #1409 intended.

Secondary: sends into a session showing a suggestion get slightly faster and quieter, because the guard no longer holds and fires `Ctrl+C` against a composer that was effectively empty.

## Evidence

Reproduced against **current `main` (`c64b431d`)**, not just an older tag, with Claude Code 2.1.212. Two binaries built from the same tree, run against the same live scratch session.

Composer state is captured with `tmux capture-pane -p -e` (the `-e` is essential — without it the attribute is gone and the two states look identical).

**Stock `main` (`c64b431d`) — the bug:**

```
=== BEFORE (dim ghost) ===
^[[39m❯ ^[[2mNow reply with exactly the word: papaya^[[0m
=== SEND ===
✓ Sent message to 'upstream-ab'
=== AFTER (no dim attribute — now real, committable text) ===
^[[39m❯ Now reply with exactly the word: papaya
```

A bare `Enter` then submitted it. Session JSONL, showing the unauthored message landing as a genuine user turn:

```
Reply with exactly the word: banana
Now reply with exactly the word: mango
STOCKTEST reply with the single word: ok
Now reply with exactly the word: papaya     <-- never typed by anyone
```

**Same commit + this patch — fixed:**

```
=== BEFORE (dim ghost) ===
^[[39m❯ ^[[2mNow reply with exactly the word: kiwi^[[0m
=== SEND ===
✓ Sent message to 'upstream-ab'
=== AFTER (still dim — untouched) ===
^[[39m❯ ^[[2mNow reply with exactly the word: kiwi^[[0m
```

Bare `Enter` after that submitted nothing; the JSONL contains only the intentional `FIXEDMAIN` message.

**Keystroke audit.** Full sequence agent-deck emits for one send, captured by putting a logging shim ahead of `tmux` on `PATH`:

```
# stock main, suggestion present
send-keys C-c                                               # guard clear attempt 1
send-keys C-c                                               # guard clear attempt 2
send-keys -l -- STOCKTEST reply with the single word: ok
send-keys Enter
send-keys -l -- Now reply with exactly the word: papaya     # <-- the suggestion, retyped

# with this patch, suggestion present
send-keys -l -- FIXEDMAIN reply with the single word: ok
send-keys Enter
```

That also answers the tmux-layer question: this strictly **reduces** work on that path (5 key-emitting calls → 2, plus the clear-confirm captures those `Ctrl+C`s triggered). The dim probe itself is pure string scanning over a buffer that was already captured — no added tmux invocations, no new syscalls.

The double `Ctrl+C` is incidental but diagnostic: the suggestion re-renders after each clear, so `ComposerHasDraft` stays true, the guard exhausts `maxComposerClearAttempts` and sets `ClearFailed` — and the restore fires anyway, because `executeSend` gates only on `draftSaved != "" && delivery != deliveryTypedNotSubmitted`.

**Tests.** 13 new tests in `internal/send/suggestion_test.go`, using verbatim captured pane bytes as fixtures rather than hand-written approximations, including the real-draft-still-guarded case and the extended-colour false-positive cases.

**Sandboxed suite — full disclosure.** I ran the required command on this branch and, as a control, on unmodified `c64b431d`:

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...
```

Both runs: **45 packages ok, and the identical 3 failing packages** (the only textual difference between the two outputs is elapsed-time numbers). So this diff introduces no new failures, but the suite is not 100% green in my environment and I would rather say so than imply otherwise:

| Package | Failing test | Why (unmodified main fails the same way) |
|---|---|---|
| `internal/git` | `TestRunWorktreeSetupScript_HonorsShebangWhenExecutable` | pre-existing here |
| `internal/session` | `TestTelegram_GlobalScope_OneBunPollerOnly_RegressionFor941` | pre-existing here |
| `scripts` | 3 tests in `verify-session-persistence_test.go` | environment: the harness shells out and hits `cat: command not found` under my sandboxed PATH |

`internal/send`, `internal/ui` and `cmd/agent-deck` — the packages this change actually touches — all pass.

Note the diff also updates two call sites in `internal/ui/issue1409_watcher_guard_test.go`: `ComposerHasDraft` gained the `strip` parameter, and those fixtures carry no ANSI, so they pass `nil`. Without that the `internal/ui` test binary does not build.

**Self-check WARN, disclosed.** `.github/skills/agent-deck-contributor/scripts/self-check.sh` reports 15 PASS / 0 FAIL / 1 WARN. The WARN is `revert-check`: the new tests do not compile against the base commit, because they reference symbols this PR introduces (`ComposerBodyIsSuggestion`, and the new `ComposerDraft`/`ComposerHasDraft` signature). That is inherent to a fix whose regression tests exercise new API surface; the behavioural proof that the tests are not vacuous is the stock-vs-patched capture above, taken from real binaries rather than from the tests.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you

My human asked me to fix a recurring bug in our bridged-session fleet, in their words: *"fix the ghost-input auto-submit bug … it has launched real work the user never ordered"*, and, on how they'd been coping with it, *"usually i catch the preinput text before something does a send on it."*

What made it hard to pin down was that the damage looked decoupled from any send. They described it as: *"even before a agent deck send on a certain session, the draft has often become real, without a corresponding sent message, thats why i thought it was somethign else."* That turned out to be this bug: the restore step still runs when a send fails outright or is merely queued into a busy mid-turn session, so an automated send can leave the suggestion instantiated with no visible message anywhere.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — ran it; result is byte-identical to unmodified `main` (45 ok, same 3 pre-existing/environmental failures). See the Evidence table; touched packages all pass.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude autosuggestions are no longer mistaken for user-entered drafts.
  * Autosuggestions pass through without being saved, cleared, or triggering unnecessary interruption prompts.
  * Real drafts, including ANSI-colored text, continue to be detected and guarded correctly.
  * Placeholder and empty composers are handled more accurately.

* **Tests**
  * Added coverage for autosuggestion detection, colored text, placeholders, stale composer content, and draft handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->