### PR TITLE
test: cover cursor-hooks CLI wiring and TUI auto-install gate

### DIFF
--- a/cmd/agent-deck/cursor_hooks_cmd_test.go
+++ b/cmd/agent-deck/cursor_hooks_cmd_test.go
@@ -54,16 +54,26 @@ func captureStdout(t *testing.T, fn func()) string {
 	os.Stdout = w
 	defer func() { os.Stdout = orig }()
 
+	// Read on a separate goroutine while fn runs, rather than after it
+	// returns: the OS pipe buffer is bounded (~64KB), so a sequential
+	// "run fn, then read" would deadlock if fn ever printed more than that
+	// in one call (fn blocks on the full pipe with nobody draining it yet).
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+	// Close w even if fn panics, so the reader goroutine always sees EOF
+	// and this helper never leaks it (avoids the fd leak on a panicking fn).
+	defer func() { _ = w.Close() }()
+
 	fn()
 
 	if err := w.Close(); err != nil {
 		t.Fatalf("close stdout writer: %v", err)
 	}
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("read stdout: %v", err)
-	}
-	return buf.String()
+	return <-done
 }
 
 func TestHandleCursorHooksInstall_InjectsHooksAndClearsOptOut(t *testing.T) {

--- a/cmd/agent-deck/cursor_hooks_cmd_test.go
+++ b/cmd/agent-deck/cursor_hooks_cmd_test.go
@@ -1,0 +1,322 @@
+// cursor_hooks_cmd_test.go covers the `agent-deck cursor-hooks` CLI wiring
+// (issue #1675, follow-up to #1673 which added session-layer coverage for
+// session.AutoInstallCursorHooks / SetCursorHooksEnabled but left the CLI
+// handlers in this file and the top-level subcommand dispatcher untested).
+//
+// Covered:
+//   - handleCursorHooksInstall / handleCursorHooksUninstall actually drive
+//     session.InjectCursorHooks / RemoveCursorHooks and SetCursorHooksEnabled
+//     together, in the right order (install clears the durable opt-out;
+//     uninstall persists it before removing hooks).
+//   - handleCursorHooksStatus reports INSTALLED/NOT INSTALLED and the
+//     Auto-install DISABLED line correctly for each config/install
+//     combination.
+//   - handleCursorHooks's subcommand dispatch: valid subcommands
+//     (install/uninstall/status/help/--help/-h) route to the right handler,
+//     and invalid input (no args, unknown subcommand) exits 1 with a usage
+//     message on stderr. Since handleCursorHooks calls os.Exit on those
+//     paths, the exit-path cases run in a helper subprocess (same pattern as
+//     TestXDGTask6HelperProcess in xdg_task6_test.go).
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// setupCursorHooksTest sandboxes HOME to a fresh temp dir and clears the
+// package-level user-config cache so LoadUserConfig/SaveUserConfig in this
+// test don't see state left behind by another test (the config cache keys
+// on mtime, not path — see cursor_hooks_test.go's TestSetCursorHooksEnabled_RoundTrip
+// for the same precaution at the session-package level).
+func setupCursorHooksTest(t *testing.T) (home string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	return home
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String()
+}
+
+func TestHandleCursorHooksInstall_InjectsHooksAndClearsOptOut(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	// Seed a prior opt-out (as `cursor-hooks uninstall` would have left it),
+	// so install's job of clearing it is actually exercised.
+	if err := session.SetCursorHooksEnabled(false); err != nil {
+		t.Fatalf("seed opt-out: %v", err)
+	}
+
+	out := captureStdout(t, handleCursorHooksInstall)
+
+	if !strings.Contains(out, "Cursor hooks installed successfully.") {
+		t.Fatalf("install output missing success message, got: %q", out)
+	}
+
+	configDir := getCursorConfigDirForHooks()
+	if !session.CheckCursorHooksInstalled(configDir) {
+		t.Fatal("hooks not present in hooks.json after handleCursorHooksInstall")
+	}
+
+	session.ClearUserConfigCache()
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if !cfg.Cursor.GetHooksEnabled() {
+		t.Fatal("handleCursorHooksInstall did not clear the [cursor] hooks_enabled opt-out")
+	}
+}
+
+func TestHandleCursorHooksInstall_NoopMessageWhenAlreadyInstalled(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	configDir := getCursorConfigDirForHooks()
+	if _, err := session.InjectCursorHooks(configDir); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	out := captureStdout(t, handleCursorHooksInstall)
+	if !strings.Contains(out, "already installed") {
+		t.Fatalf("expected already-installed message, got: %q", out)
+	}
+}
+
+func TestHandleCursorHooksUninstall_PersistsOptOutAndRemovesHooks(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	configDir := getCursorConfigDirForHooks()
+	if _, err := session.InjectCursorHooks(configDir); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+	if !session.CheckCursorHooksInstalled(configDir) {
+		t.Fatal("seed install did not take effect")
+	}
+
+	out := captureStdout(t, handleCursorHooksUninstall)
+
+	if !strings.Contains(out, "Auto-install disabled") {
+		t.Fatalf("uninstall output missing disabled message, got: %q", out)
+	}
+	if !strings.Contains(out, "Cursor hooks removed successfully.") {
+		t.Fatalf("uninstall output missing removal message, got: %q", out)
+	}
+
+	if session.CheckCursorHooksInstalled(configDir) {
+		t.Fatal("hooks still present in hooks.json after handleCursorHooksUninstall")
+	}
+
+	session.ClearUserConfigCache()
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if cfg.Cursor.GetHooksEnabled() {
+		t.Fatal("handleCursorHooksUninstall did not persist the [cursor] hooks_enabled opt-out")
+	}
+}
+
+func TestHandleCursorHooksUninstall_NoHooksFoundMessage(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	out := captureStdout(t, handleCursorHooksUninstall)
+	if !strings.Contains(out, "No agent-deck Cursor hooks found to remove.") {
+		t.Fatalf("expected no-hooks-found message, got: %q", out)
+	}
+
+	// The opt-out must still be persisted even when there was nothing to
+	// remove — TUI startup must not reinstall on the next launch.
+	session.ClearUserConfigCache()
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if cfg.Cursor.GetHooksEnabled() {
+		t.Fatal("opt-out not persisted when no hooks were present to remove")
+	}
+}
+
+func TestHandleCursorHooksStatus_ReportsNotInstalled(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	out := captureStdout(t, handleCursorHooksStatus)
+
+	if !strings.Contains(out, "Status: NOT INSTALLED") {
+		t.Fatalf("expected NOT INSTALLED status, got: %q", out)
+	}
+	if strings.Contains(out, "Auto-install: DISABLED") {
+		t.Fatalf("did not expect DISABLED line with default config, got: %q", out)
+	}
+}
+
+func TestHandleCursorHooksStatus_ReportsInstalled(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	configDir := getCursorConfigDirForHooks()
+	if _, err := session.InjectCursorHooks(configDir); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	out := captureStdout(t, handleCursorHooksStatus)
+	if !strings.Contains(out, "Status: INSTALLED") {
+		t.Fatalf("expected INSTALLED status, got: %q", out)
+	}
+	if !strings.Contains(out, filepath.Join(configDir, "hooks.json")) {
+		t.Fatalf("expected config path in status output, got: %q", out)
+	}
+}
+
+func TestHandleCursorHooksStatus_ReportsDisabledAutoInstall(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	if err := session.SetCursorHooksEnabled(false); err != nil {
+		t.Fatalf("seed opt-out: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	out := captureStdout(t, handleCursorHooksStatus)
+	if !strings.Contains(out, "Auto-install: DISABLED") {
+		t.Fatalf("expected DISABLED auto-install line, got: %q", out)
+	}
+	if !strings.Contains(out, "[cursor] hooks_enabled = false") {
+		t.Fatalf("expected opt-out explanation in status output, got: %q", out)
+	}
+}
+
+func TestHandleCursorHooks_HelpVariantsPrintUsage(t *testing.T) {
+	for _, args := range [][]string{{"help"}, {"--help"}, {"-h"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			out := captureStdout(t, func() { handleCursorHooks(args) })
+			if !strings.Contains(out, "Usage: agent-deck cursor-hooks <command>") {
+				t.Fatalf("help output for %v missing usage header, got: %q", args, out)
+			}
+			for _, want := range []string{"install", "uninstall", "status"} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("help output for %v missing %q, got: %q", args, want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleCursorHooks_RoutesInstallSubcommand(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	out := captureStdout(t, func() { handleCursorHooks([]string{"install"}) })
+	if !strings.Contains(out, "Cursor hooks installed successfully.") {
+		t.Fatalf("expected install routing to reach handleCursorHooksInstall, got: %q", out)
+	}
+	if !session.CheckCursorHooksInstalled(getCursorConfigDirForHooks()) {
+		t.Fatal("dispatched install did not actually install hooks")
+	}
+}
+
+func TestHandleCursorHooks_RoutesStatusSubcommand(t *testing.T) {
+	setupCursorHooksTest(t)
+
+	out := captureStdout(t, func() { handleCursorHooks([]string{"status"}) })
+	if !strings.Contains(out, "Status: NOT INSTALLED") {
+		t.Fatalf("expected status routing to reach handleCursorHooksStatus, got: %q", out)
+	}
+}
+
+// --- exit-path coverage via helper subprocess ---
+//
+// handleCursorHooks calls os.Exit(1) for both empty args and an unknown
+// subcommand. Testing that in-process would kill the whole test binary, so
+// (mirroring TestXDGTask6HelperProcess) we re-exec the test binary itself
+// with -test.run pinned to the helper entrypoint below.
+
+func runCursorHooksHelperProcess(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	cmdArgs := append([]string{"-test.run=TestCursorHooksHelperProcess", "--"}, args...)
+	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(), "AGENT_DECK_CURSOR_HOOKS_HELPER=1")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("helper process failed to start/run: %v (stderr=%q)", err, errBuf.String())
+		}
+		code = exitErr.ExitCode()
+	}
+	return outBuf.String(), errBuf.String(), code
+}
+
+// TestCursorHooksHelperProcess is not a real test; go test invokes it (via
+// -test.run) as a subprocess entrypoint that calls handleCursorHooks
+// directly so its os.Exit calls terminate the subprocess, not the parent
+// test binary. It is a no-op unless AGENT_DECK_CURSOR_HOOKS_HELPER=1 is set.
+func TestCursorHooksHelperProcess(t *testing.T) {
+	if os.Getenv("AGENT_DECK_CURSOR_HOOKS_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	handleCursorHooks(args)
+	// Valid subcommands return normally; give the parent a clean signal.
+	os.Exit(0)
+}
+
+func TestHandleCursorHooks_NoArgsExitsNonZeroWithUsageOnStderr(t *testing.T) {
+	stdout, stderr, code := runCursorHooksHelperProcess(t)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stdout=%q stderr=%q)", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "Usage: agent-deck cursor-hooks <command>") {
+		t.Fatalf("stderr missing usage on empty args, got: %q", stderr)
+	}
+}
+
+func TestHandleCursorHooks_UnknownSubcommandExitsNonZeroWithMessage(t *testing.T) {
+	stdout, stderr, code := runCursorHooksHelperProcess(t, "bogus")
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stdout=%q stderr=%q)", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "Unknown cursor-hooks subcommand: bogus") {
+		t.Fatalf("stderr missing unknown-subcommand message, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Usage: agent-deck cursor-hooks <command>") {
+		t.Fatalf("stderr missing usage fallback after unknown subcommand, got: %q", stderr)
+	}
+}

--- a/internal/ui/cursor_hooks_gate_test.go
+++ b/internal/ui/cursor_hooks_gate_test.go
@@ -1,0 +1,105 @@
+// cursor_hooks_gate_test.go covers shouldAutoInstallCursorHooks, the TUI
+// startup gate for Cursor Agent CLI hook auto-install (issue #1675, follow-up
+// to #1673's durable [cursor] hooks_enabled opt-out). The predicate decides
+// whether NewHomeWithProfileAndMode should even attempt
+// session.AutoInstallCursorHooks and start the shared hook watcher; getting
+// it wrong either silently reinstalls hooks after an explicit uninstall
+// (regression #1672) or skips auto-install for users who never opted out.
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestShouldAutoInstallCursorHooks(t *testing.T) {
+	disabled := false
+	enabled := true
+
+	tests := []struct {
+		name           string
+		workersEnabled bool
+		userConfig     *session.UserConfig
+		cursorCmd      string
+		want           bool
+	}{
+		{
+			name:           "nil config, workers on, cmd set -> installs",
+			workersEnabled: true,
+			userConfig:     nil,
+			cursorCmd:      "cursor",
+			want:           true,
+		},
+		{
+			name:           "zero-value config, workers on, cmd set -> installs",
+			workersEnabled: true,
+			userConfig:     &session.UserConfig{},
+			cursorCmd:      "cursor",
+			want:           true,
+		},
+		{
+			name:           "explicit opt-in config -> installs",
+			workersEnabled: true,
+			userConfig:     &session.UserConfig{Cursor: session.CursorSettings{HooksEnabled: &enabled}},
+			cursorCmd:      "cursor",
+			want:           true,
+		},
+		{
+			name:           "durable opt-out ([cursor] hooks_enabled = false) -> skipped, even with workers on and a cursor command",
+			workersEnabled: true,
+			userConfig:     &session.UserConfig{Cursor: session.CursorSettings{HooksEnabled: &disabled}},
+			cursorCmd:      "cursor",
+			want:           false,
+		},
+		{
+			name:           "background workers disabled (test mode) -> skipped regardless of config",
+			workersEnabled: false,
+			userConfig:     nil,
+			cursorCmd:      "cursor",
+			want:           false,
+		},
+		{
+			name:           "no cursor command configured -> skipped",
+			workersEnabled: true,
+			userConfig:     nil,
+			cursorCmd:      "",
+			want:           false,
+		},
+		{
+			name:           "opt-out AND no cursor command -> still skipped",
+			workersEnabled: true,
+			userConfig:     &session.UserConfig{Cursor: session.CursorSettings{HooksEnabled: &disabled}},
+			cursorCmd:      "",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := homeBackgroundWorkersEnabled
+			homeBackgroundWorkersEnabled = tt.workersEnabled
+			t.Cleanup(func() { homeBackgroundWorkersEnabled = orig })
+
+			got := shouldAutoInstallCursorHooks(tt.userConfig, tt.cursorCmd)
+			if got != tt.want {
+				t.Fatalf("shouldAutoInstallCursorHooks(cfg=%+v, cmd=%q) with workersEnabled=%v = %v, want %v",
+					tt.userConfig, tt.cursorCmd, tt.workersEnabled, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldAutoInstallCursorHooks_DefaultTestModeSkips is a narrow regression
+// guard: package TestMain must leave homeBackgroundWorkersEnabled false so
+// ordinary tests never trigger real hook installation as a side effect. If
+// this ever flips, every other test in this package that constructs a Home
+// silently starts installing Cursor hooks into whatever HOME is active.
+func TestShouldAutoInstallCursorHooks_DefaultTestModeSkips(t *testing.T) {
+	if homeBackgroundWorkersEnabled {
+		t.Fatal("TestMain must disable Home background workers")
+	}
+	if shouldAutoInstallCursorHooks(nil, "cursor") {
+		t.Fatal("shouldAutoInstallCursorHooks() = true with background workers disabled, want false")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1288,6 +1288,22 @@ func NewHomeWithProfile(profile string) *Home {
 // so status, log, pipe, and storage updates continue while the TUI is running.
 var homeBackgroundWorkersEnabled = true
 
+// shouldAutoInstallCursorHooks reports whether TUI startup should run the
+// Cursor hook auto-install/watcher-start block in NewHomeWithProfileAndMode:
+// background workers must be enabled, the user must not have durably opted
+// out via [cursor] hooks_enabled = false (persisted by `agent-deck
+// cursor-hooks uninstall`, issue #1672), and a cursor command must be
+// configured. cursorCmd is expected to already be trimmed by the caller.
+//
+// Extracted as a pure predicate (issue #1675) so the gate itself is
+// unit-testable without exercising NewHomeWithProfileAndMode's side effects
+// (storage, tmux, goroutines) — mirrors why AutoInstallCursorHooks was pulled
+// out of this same function in #1673.
+func shouldAutoInstallCursorHooks(userConfig *session.UserConfig, cursorCmd string) bool {
+	cursorHooksEnabled := userConfig == nil || userConfig.Cursor.GetHooksEnabled()
+	return homeBackgroundWorkersEnabled && cursorHooksEnabled && cursorCmd != ""
+}
+
 // NewHomeWithProfileAndMode creates a new Home with the specified profile.
 // All instances manage the notification bar equally via shared SQLite state.
 func NewHomeWithProfileAndMode(profile string) *Home {
@@ -1634,8 +1650,8 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	// (set durably by `agent-deck cursor-hooks uninstall`, issue #1672).
 	// The opt-out gates the watcher too, matching the [claude] hooks_enabled
 	// gate above.
-	cursorHooksEnabled := userConfig == nil || userConfig.Cursor.GetHooksEnabled()
-	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); homeBackgroundWorkersEnabled && cursorHooksEnabled && cursorCmd != "" {
+	cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor"))
+	if shouldAutoInstallCursorHooks(userConfig, cursorCmd) {
 		if cursorFields := strings.Fields(cursorCmd); len(cursorFields) > 0 {
 			cursorBin := cursorFields[0]
 			if _, err := exec.LookPath(cursorBin); err == nil {


### PR DESCRIPTION
## What problem does this solve?

Fixes #1675. CodeRabbit's pre-merge check on #1673 flagged that the CLI
wiring in `cmd/agent-deck/cursor_hooks_cmd.go` (`cursor-hooks
install/uninstall/status`) and the TUI startup gate for Cursor hook
auto-install in `internal/ui/home.go` had no dedicated tests — #1673 only
added session-layer coverage for `session.AutoInstallCursorHooks` /
`SetCursorHooksEnabled`. #1675 asks for that remaining gap to be closed.

## Why this change

- **CLI wiring** (`cmd/agent-deck/cursor_hooks_cmd_test.go`, new): calls
  `handleCursorHooksInstall`/`handleCursorHooksUninstall`/`handleCursorHooksStatus`
  directly against a sandboxed `$HOME` and asserts the real effects
  (`hooks.json` state via `session.CheckCursorHooksInstalled`, the
  `[cursor] hooks_enabled` opt-out round-tripped through `LoadUserConfig`,
  and the exact stdout messages for each branch). Also covers
  `handleCursorHooks`'s subcommand dispatch for valid input
  (`install`/`uninstall`/`status`/`help`/`--help`/`-h`) and, since it calls
  `os.Exit(1)` on no-args and an unknown subcommand, the two exit paths via a
  helper-subprocess re-exec — the same pattern `TestXDGTask6HelperProcess`
  already uses in `xdg_task6_test.go` for the same problem (`handleUninstall`
  exits non-zero on error paths).

- **TUI auto-install gate**: the decision (`cursorHooksEnabled := userConfig
  == nil || userConfig.Cursor.GetHooksEnabled()`, combined with
  `homeBackgroundWorkersEnabled` and a non-empty cursor command) was inlined
  inside `NewHomeWithProfileAndMode`, a large constructor with real side
  effects (storage, tmux, background goroutines) that tests deliberately
  never exercise (`homeBackgroundWorkersEnabled` is forced `false` in test
  mode — see `home_background_workers_test.go`). Flipping that flag in a test
  to reach the inline gate would also start the status worker, storage
  watcher, etc., as a side effect, which is exactly what the test-mode flag
  exists to prevent. Instead I extracted the boolean decision itself into a
  small pure function, `shouldAutoInstallCursorHooks(userConfig
  *session.UserConfig, cursorCmd string) bool`, and call it from the same
  `if` in `NewHomeWithProfileAndMode` — this mirrors the precedent #1673 set
  by pulling `AutoInstallCursorHooks` out of this same function for the same
  reason. The extraction is behavior-preserving: same three sub-conditions,
  same evaluation order, same result.

No other production behavior changes.

**On size** (+445/-2 across 3 files, over the repo's ~400-line review
guidance): 423 of those lines are the two new test files; the only
production change is the 20-line home.go extraction. I considered splitting
CLI-wiring tests and the TUI-gate tests into two PRs, but #1675 explicitly
bundles both under one ask ("cursor_hooks_cmd.go ... wiring and the home.go
cursorHooksEnabled gate ... Add coverage for both"), they're both follow-ups
to the same CodeRabbit comment on the same PR (#1673), and each half is
small on its own (322 and 125 lines) — splitting would add PR-management
overhead against one already-small, already-scoped issue rather than reduce
review burden. Happy to split on request.

## User impact

None, internal only. `shouldAutoInstallCursorHooks` is an exact extraction of
the pre-existing inline expression (verified by mutation-testing it back to
the original behavior — see Evidence); the rest of the diff is new test
files.

## Evidence

**New tests, sandboxed, all passing:**

    $ cd agent-deck && HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= \
        go test ./internal/ui/... ./cmd/agent-deck/... -run "CursorHooks|ShouldAutoInstall" -v
    ok  	github.com/asheshgoplani/agent-deck/internal/ui	1.374s   (9 tests, incl. 7-case table)
    ok  	github.com/asheshgoplani/agent-deck/cmd/agent-deck	0.874s   (14 tests, incl. 3-case help table
                                                                      and 2 subprocess exit-path tests)

**Revert/mutation-check** (per the contributor skill's "test that fails
without your change" bar — reverted the logic, confirmed the test catches
it, then restored):

1. Dropped the opt-out check from `shouldAutoInstallCursorHooks` (`return
   homeBackgroundWorkersEnabled && cursorCmd != ""`, no `cursorHooksEnabled`)
   → `TestShouldAutoInstallCursorHooks/durable_opt-out_...` failed:
   `... = true, want false`.
2. Removed the `session.SetCursorHooksEnabled(true)` call from
   `handleCursorHooksInstall` → `TestHandleCursorHooksInstall_InjectsHooksAndClearsOptOut`
   failed: `handleCursorHooksInstall did not clear the [cursor] hooks_enabled
   opt-out`.
3. Removed the `os.Exit(1)` from the unknown-subcommand branch of
   `handleCursorHooks` → `TestHandleCursorHooks_UnknownSubcommandExitsNonZeroWithMessage`
   failed: `exit code = 0, want 1`.

All three reverts were then restored; the working tree matches this diff.

Note on the repo's own `.github/skills/agent-deck-contributor/scripts/self-check.sh`:
its automated revert-check (revert only the non-test hunks, re-run the new
tests) reports "tests do not compile on base (new symbols)" rather than a
clean fail/pass, because `shouldAutoInstallCursorHooks` is a new symbol that
doesn't exist before this diff — there's no smaller revert that both compiles
and disables the behavior, since the whole point of the extraction is that
the predicate didn't exist as a separate, callable thing on `main`. The three
manual reverts above are the substantive version of that same check.

**Full suite, sandboxed:**

    $ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...

Fails in the same 6 pre-existing tests on this machine, none touching Cursor
hooks or `home.go`'s Cursor block — confirmed by running the identical
sandboxed invocation against a clean `main` checkout (via `git stash`) and
getting byte-for-byte the same failures:

- `TestWebCommand_NoTuiFlag_SkipsBubbleteaBoot/headless_server_starts` and
  `TestIssue1607_CreateSessionTitleLock/*` — this sandbox has no `tmux`
  binary on `PATH` (a CONTRIBUTING prerequisite I don't have installed
  here); both fail with `Error: tmux not found` / `exec: "tmux": executable
  file not found in $PATH` identically on `main`.
- `TestIssue1421_CleanStaleSSHSockets` — `bind: invalid argument` creating a
  `stale@host:22` AF_UNIX socket under this macOS's long `/var/folders/...`
  tmp path; reproduces identically on `main`.
- `TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision` — reproduces
  identically on `main`, unrelated to this diff.
- `TestLogCgroupIsolationDecision_WiredIntoBootstrap/tui_startup_emits_line`
  — reproduces identically on `main`, unrelated to this diff.
- `TestStartMaintenanceWorkerCallback` — flaky/timing-sensitive; failed once
  in the full-suite run, passed when re-run in isolation on both `main` and
  this branch.

**gofmt / vet / lint:**

    $ gofmt -l ./cmd ./internal            # no output
    $ go vet ./...                          # no output
    $ golangci-lint run ./internal/ui/... ./cmd/agent-deck/...
    0 issues.

Hot-path timing evidence: not included. This diff's only production change
is swapping a 2-line inline boolean expression for a call to an equivalent
1-line pure function inside `NewHomeWithProfileAndMode`'s one-time startup
path — no added work, no loop, no allocation, nothing that would show up in
`time agent-deck list`.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-5

**Prompt / session log (optional):** —

## What actually bothered you

There's no direct human ask behind this one beyond the issue itself, so
quoting the issue author's problem statement per the intake contract:
"Follow-up from #1673 review: cursor_hooks_cmd.go install/uninstall/status
wiring and the home.go cursorHooksEnabled gate were verified manually but
lack automated tests. Add coverage for both."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (excluding the 6 pre-existing, environment-specific failures documented in Evidence — this dev sandbox lacks the `tmux` binary and hits two macOS-specific path issues; each reproduces identically on a clean `main` checkout, same as the four pre-existing failures #1673 documented the same way)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — no timing evidence; see Evidence for why this specific extraction doesn't warrant it
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-sonnet-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for `agent-deck cursor-hooks`, including install, uninstall, and status output.
  * Validated messaging for already-installed and “no hooks found” scenarios, along with the installed hooks path and auto-install disabled behavior.
  * Added routing tests for `help`/`--help` variants, valid subcommands, and non-zero exit on missing/unknown subcommands.
  * Added regression tests for the cursor hook auto-install decision logic, including default test mode and opt-out handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->