### PR TITLE
feat: add Goose Agent CLI support

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -841,6 +841,25 @@ func main() {
 	ui.EnableModifyOtherKeys(os.Stdout)
 	defer ui.DisableModifyOtherKeys(os.Stdout)
 
+	// Check for atuin pty-proxy incompatibility (#1558).
+	// Atuin pty-proxy intercepts PTY I/O and breaks Bubble Tea's TUI rendering.
+	// The alternate screen, mouse tracking, and raw-mode interactions all fail
+	// because os.Stdin/os.Stdout are proxied pipes, not direct terminal FDs.
+	if tmux.IsAtuinPTYProxy() {
+		fmt.Fprintf(os.Stderr, `WARNING: Agent Deck's TUI is incompatible with atuin pty-proxy.
+The TUI may appear blank or fail to render.
+
+To fix this, replace:
+  eval "$(atuin pty-proxy init zsh)"
+with:
+  eval "$(atuin init zsh)"
+
+in your shell configuration file (.zshrc / .bashrc / config.fish).
+Atuin pty-proxy is only needed for the atuin TUI overlay feature,
+and is not required for normal atuin shell history functionality.
+`+"\n")
+	}
+
 	p := tea.NewProgram(
 		homeModel,
 		tea.WithAltScreen(),

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -846,18 +846,16 @@ func main() {
 	// The alternate screen, mouse tracking, and raw-mode interactions all fail
 	// because os.Stdin/os.Stdout are proxied pipes, not direct terminal FDs.
 	if tmux.IsAtuinPTYProxy() {
-		fmt.Fprintf(os.Stderr, `WARNING: Agent Deck's TUI is incompatible with atuin pty-proxy.
-The TUI may appear blank or fail to render.
-
-To fix this, replace:
-  eval "$(atuin pty-proxy init zsh)"
-with:
-  eval "$(atuin init zsh)"
-
-in your shell configuration file (.zshrc / .bashrc / config.fish).
-Atuin pty-proxy is only needed for the atuin TUI overlay feature,
-and is not required for normal atuin shell history functionality.
-`+"\n")
+		fmt.Fprint(os.Stderr, "WARNING: Agent Deck's TUI is incompatible with atuin pty-proxy.\n"+
+			"The TUI may appear blank or fail to render.\n"+
+			"\n"+
+			"To fix this, replace the pty-proxy init with the normal init in your shell config:\n"+
+			"  - zsh:   replace 'eval \"$(atuin pty-proxy init zsh)\"' with 'eval \"$(atuin init zsh)\"' in .zshrc\n"+
+			"  - bash:  replace 'eval \"$(atuin pty-proxy init bash)\"' with 'eval \"$(atuin init bash)\"' in .bashrc\n"+
+			"  - fish:  replace 'atuin pty-proxy init fish | source' with 'atuin init fish | source' in config.fish\n"+
+			"\n"+
+			"Atuin pty-proxy is only needed for the atuin TUI overlay feature,\n"+
+			"and is not required for normal atuin shell history functionality.\n")
 	}
 
 	p := tea.NewProgram(

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -64,6 +64,7 @@ func builtinTools() []builtinTool {
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
 		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}},
 		{Name: "hermes", Icon: "☤", detectSubstrings: []string{"hermes"}},
+		{Name: "goose", Icon: "🪿", detectSubstrings: []string{"goose"}}, // ponytail: new tool
 		{Name: "aider", Icon: "🐚"},
 		{Name: "shell", Icon: "🐚"},
 	}

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -32,7 +32,7 @@ func TestGetToolCommand_NoConfig(t *testing.T) {
 	ClearUserConfigCache()
 	defer ClearUserConfigCache()
 
-	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes"}
+	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes", "goose"}
 	for _, tool := range tools {
 		got := GetToolCommand(tool)
 		if got != tool {
@@ -49,6 +49,7 @@ func TestGetToolCommand_WithOverride(t *testing.T) {
 		Codex:    CodexSettings{Command: "codex --experimental"},
 		Copilot:  CopilotSettings{Command: "gh copilot"},
 		Hermes:   HermesSettings{Command: "hermes --model gpt-5.5-pro --provider openai"},
+		Goose:    GooseSettings{Command: "goose --model gpt-4o"},
 	}
 	restore := resetUserConfigCache(t, cfg)
 	defer restore()
@@ -63,6 +64,7 @@ func TestGetToolCommand_WithOverride(t *testing.T) {
 		{"codex", "codex --experimental"},
 		{"copilot", "gh copilot"},
 		{"hermes", "hermes --model gpt-5.5-pro --provider openai"},
+		{"goose", "goose --model gpt-4o"},
 	}
 
 	for _, tt := range tests {
@@ -82,11 +84,12 @@ func TestGetToolCommand_EmptyOverrideFallsBack(t *testing.T) {
 		Codex:    CodexSettings{Command: ""},
 		Copilot:  CopilotSettings{Command: ""},
 		Hermes:   HermesSettings{Command: ""},
+		Goose:    GooseSettings{Command: ""},
 	}
 	restore := resetUserConfigCache(t, cfg)
 	defer restore()
 
-	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes"}
+	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes", "goose"}
 	for _, tool := range tools {
 		got := GetToolCommand(tool)
 		if got != tool {
@@ -307,6 +310,7 @@ func TestGetToolEnvFile_AllBuiltins(t *testing.T) {
 		Codex:    CodexSettings{EnvFile: "/tmp/codex.env"},
 		Copilot:  CopilotSettings{EnvFile: "/tmp/copilot.env"},
 		Hermes:   HermesSettings{EnvFile: "/tmp/hermes.env"},
+		Goose:    GooseSettings{EnvFile: "/tmp/goose.env"},
 	}
 	restore := resetUserConfigCache(t, cfg)
 	defer restore()
@@ -321,6 +325,7 @@ func TestGetToolEnvFile_AllBuiltins(t *testing.T) {
 		{"codex", "/tmp/codex.env"},
 		{"copilot", "/tmp/copilot.env"},
 		{"hermes", "/tmp/hermes.env"},
+		{"goose", "/tmp/goose.env"},
 	}
 
 	for _, tt := range tests {

--- a/internal/session/discovery.go
+++ b/internal/session/discovery.go
@@ -160,6 +160,9 @@ func detectToolFromName(name string) string {
 	if strings.Contains(nameLower, "codex") {
 		return "codex"
 	}
+	if strings.Contains(nameLower, "goose") { // ponytail: new tool
+		return "goose"
+	}
 
 	return "shell"
 }

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -558,6 +558,8 @@ func (i *Instance) getToolEnvFile() string {
 			return groupEnv
 		}
 		return config.Hermes.EnvFile
+	case "goose": // ponytail: new tool
+		return config.Goose.EnvFile
 	default:
 		// Check custom tools
 		if def := GetToolDef(i.Tool); def != nil {

--- a/internal/session/goose.go
+++ b/internal/session/goose.go
@@ -42,6 +42,9 @@ func BuildGooseCommand(settings *GooseSettings, projectPath string, profile stri
 
 	// ponytail: split command string so flags in Command are preserved
 	args := strings.Fields(cmd)
+	if len(args) == 0 {
+		args = []string{"goose"}
+	}
 	cmd = args[0]
 
 	// Add --auto if YoloMode is enabled (goose's equivalent of auto-approve).
@@ -135,6 +138,23 @@ func HasGooseBusyIndicator(output string) bool {
 // sessions. Falls back to ~/.config/goose/.env.
 func GetGooseDefaultEnvFile() string {
 	return filepath.Join(gooseDefaultConfigDir(), ".env")
+}
+
+// GooseSettingsFromConfig returns GooseSettings with user config values
+// merged over defaults. Only Command defaults to "goose" when empty;
+// other fields (YoloMode, EnvFile, ConfigDir) are preserved as-is from
+// user config even when empty (zero value = not configured).
+func GooseSettingsFromConfig() *GooseSettings {
+	def := DefaultGooseSettings()
+	cfg, _ := LoadUserConfig()
+	if cfg == nil {
+		return def
+	}
+	merged := cfg.Goose
+	if merged.Command == "" {
+		merged.Command = def.Command
+	}
+	return &merged
 }
 
 // GetGooseConfigDir returns the Goose config directory. Checks the user

--- a/internal/session/goose.go
+++ b/internal/session/goose.go
@@ -1,0 +1,148 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultGooseSettings returns GooseSettings with sensible defaults.
+// Command defaults to "goose"; ConfigDir defaults to gooseDefaultConfigDir().
+func DefaultGooseSettings() *GooseSettings {
+	return &GooseSettings{
+		Command:   "goose",
+		ConfigDir: gooseDefaultConfigDir(),
+	}
+}
+
+// gooseDefaultConfigDir returns the Goose config directory.
+// Respects XDG_CONFIG_HOME; falls back to ~/.config/goose.
+func gooseDefaultConfigDir() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "goose")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".config", "goose")
+	}
+	return filepath.Join(home, ".config", "goose")
+}
+
+// BuildGooseCommand builds the launch command for Goose CLI.
+// Returns a string slice suitable for exec.Command (first element is the
+// binary, rest are arguments).
+//
+// Goose opens in the current working directory, so projectPath is used as
+// the CWD rather than a CLI argument.
+func BuildGooseCommand(settings *GooseSettings, projectPath string, profile string) []string {
+	cmd := "goose"
+	if settings != nil && settings.Command != "" {
+		cmd = settings.Command
+	}
+
+	// ponytail: split command string so flags in Command are preserved
+	args := strings.Fields(cmd)
+	cmd = args[0]
+
+	// Add --auto if YoloMode is enabled (goose's equivalent of auto-approve).
+	if settings != nil && settings.YoloMode {
+		args = append(args, "--auto")
+	}
+
+	// Add profile flag if specified. Goose uses --profile to select
+	// a named profile from profiles.yaml.
+	if profile != "" {
+		args = append(args, "--profile", profile)
+	}
+
+	return args
+}
+
+// HasGoosePrompt checks whether the goose TUI output indicates an idle
+// prompt (ready for user input). Goose uses a simple ">_" or ">"
+// prompt at the bottom of its interactive interface.
+func HasGoosePrompt(output string) bool {
+	if output == "" {
+		return false
+	}
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return false
+	}
+
+	// Goose prompt indicators: ">_" or ">" at the end of output.
+	// Check last non-empty line for prompt patterns.
+	lines := strings.Split(trimmed, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		// goose shows ">_" as its primary prompt indicator
+		if line == ">_" || line == ">" {
+			return true
+		}
+		// goose prompt with cursor indicator
+		if strings.HasSuffix(line, ">_") || strings.HasSuffix(line, "> ") {
+			return true
+		}
+		break
+	}
+
+	return false
+}
+
+// HasGooseBusyIndicator checks whether the goose TUI output indicates
+// the agent is actively processing (working on a task).
+func HasGooseBusyIndicator(output string) bool {
+	if output == "" {
+		return false
+	}
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return false
+	}
+
+	// Goose busy indicators — text that appears while the agent is thinking
+	// or executing tool calls.
+	busyPatterns := []string{
+		"thinking...",
+		"Thinking...",
+		"executing...",
+		"Running...",
+		"running...",
+		"Processing...",
+		"processing...",
+		"Planning...",
+		"planning...",
+		"Generating...",
+		"generating...",
+		"ctrl+c to interrupt",
+		"esc to interrupt",
+	}
+
+	lower := strings.ToLower(trimmed)
+	for _, pattern := range busyPatterns {
+		if strings.Contains(lower, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetGooseDefaultEnvFile returns the default .env file path for Goose
+// sessions. Falls back to ~/.config/goose/.env.
+func GetGooseDefaultEnvFile() string {
+	return filepath.Join(gooseDefaultConfigDir(), ".env")
+}
+
+// GetGooseConfigDir returns the Goose config directory. Checks the user
+// config for an explicit override; otherwise returns the default.
+func GetGooseConfigDir() string {
+	config, _ := LoadUserConfig()
+	if config != nil && config.Goose.ConfigDir != "" {
+		return config.Goose.ConfigDir
+	}
+	return gooseDefaultConfigDir()
+}

--- a/internal/session/goose_hooks.go
+++ b/internal/session/goose_hooks.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// InjectGooseHooks injects goose-specific configuration for a session.
+//
+// Goose manages its own MCP extensions via config.yaml (~/.config/goose/).
+// This function currently handles only lightweight pre-flight tasks:
+//  1. Ensure the env file exists when settings.EnvFile is set.
+//
+// More sophisticated hook injection (config.yaml merge, MCP wiring) is
+// deferred until the goose integration matures — goose already supports
+// extensions natively through its own config.
+//
+// ponytail: minimal integration; goose's config.yaml is user-managed for now.
+func InjectGooseHooks(sessionDir string, projectPath string, settings *GooseSettings) error {
+	if settings == nil {
+		return nil
+	}
+
+	// If an env file is specified, ensure it exists so goose doesn't fail
+	// on startup trying to source a missing file.
+	if settings.EnvFile != "" {
+		envPath, err := expandGoosePath(settings.EnvFile)
+		if err != nil {
+			return err
+		}
+		if err := ensureFileExists(envPath); err != nil {
+			sessionLog.Warn("goose_env_file_missing",
+				slog.String("path", envPath),
+				slog.String("session_dir", sessionDir),
+			)
+			// Not fatal — goose can run without an env file.
+		}
+	}
+
+	return nil
+}
+
+// RemoveGooseHooks removes agent-deck injected configuration for goose.
+// Currently a no-op since goose manages its own config.yaml, but exists
+// for symmetry with InjectGooseHooks and future use.
+func RemoveGooseHooks(configDir string) (bool, error) {
+	// ponytail: no-op for now — goose config is user-managed
+	return false, nil
+}
+
+// CheckGooseHooksInstalled reports whether agent-deck hooks are installed
+// for goose. Currently always returns false since we don't inject into
+// goose's config.yaml yet.
+func CheckGooseHooksInstalled(configDir string) bool {
+	// ponytail: no-op for now — goose config is user-managed
+	return false
+}
+
+// expandGoosePath expands ~ and environment variables in a goose file path.
+func expandGoosePath(p string) (string, error) {
+	if p == "" {
+		return "", nil
+	}
+
+	// Expand ~ to home directory
+	if p[0] == '~' {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		p = filepath.Join(home, p[1:])
+	}
+
+	// Expand environment variables ($VAR or ${VAR})
+	expanded := os.ExpandEnv(p)
+	return expanded, nil
+}
+
+// ensureFileExists creates the file (and parent directories) if it doesn't
+// exist. If the file already exists, this is a no-op.
+func ensureFileExists(path string) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err == nil {
+		return nil // already exists
+	}
+	// Create parent directory
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	// Create empty file
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/internal/session/goose_test.go
+++ b/internal/session/goose_test.go
@@ -1,0 +1,197 @@
+package session
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// Goose Agent CLI support.
+// These tests define the Tool="goose" contract: BuildGooseCommand,
+// prompt/busy detection, options marshalling, and identity gates.
+
+func TestBuildGooseCommand_BareName(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	settings := DefaultGooseSettings()
+	args := BuildGooseCommand(settings, "/tmp/project", "")
+	if len(args) == 0 {
+		t.Fatal("BuildGooseCommand returned empty")
+	}
+	if args[0] != "goose" {
+		t.Errorf("BuildGooseCommand args[0] = %q, want %q", args[0], "goose")
+	}
+}
+
+func TestBuildGooseCommand_YoloMode(t *testing.T) {
+	settings := DefaultGooseSettings()
+	settings.YoloMode = true
+	args := BuildGooseCommand(settings, "/tmp/project", "")
+
+	found := false
+	for _, a := range args {
+		if a == "--auto" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("BuildGooseCommand with YoloMode=true should include --auto, got %v", args)
+	}
+}
+
+func TestBuildGooseCommand_Profile(t *testing.T) {
+	settings := DefaultGooseSettings()
+	args := BuildGooseCommand(settings, "/tmp/project", "work")
+
+	found := false
+	for i, a := range args {
+		if a == "--profile" && i+1 < len(args) && args[i+1] == "work" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("BuildGooseCommand with profile=work should include --profile work, got %v", args)
+	}
+}
+
+func TestBuildGooseCommand_CustomCommand(t *testing.T) {
+	settings := &GooseSettings{Command: "/opt/goose/bin/goose --verbose"}
+	args := BuildGooseCommand(settings, "/tmp/project", "")
+	if args[0] != "/opt/goose/bin/goose" {
+		t.Errorf("BuildGooseCommand custom command binary = %q, want %q", args[0], "/opt/goose/bin/goose")
+	}
+	found := false
+	for _, a := range args {
+		if a == "--verbose" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("BuildGooseCommand custom command should preserve --verbose, got %v", args)
+	}
+}
+
+func TestBuildGooseCommand_NilSettings(t *testing.T) {
+	args := BuildGooseCommand(nil, "/tmp/project", "")
+	if len(args) == 0 {
+		t.Fatal("BuildGooseCommand(nil) returned empty")
+	}
+	if args[0] != "goose" {
+		t.Errorf("BuildGooseCommand(nil) args[0] = %q, want %q", args[0], "goose")
+	}
+}
+
+func TestHasGoosePrompt(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"empty", "", false},
+		{"just underscore prompt", ">_", true},
+		{"just angle prompt", ">", true},
+		{"prompt with trailing space", "> ", true},
+		{"banner then prompt", "Welcome to Goose\n\n>_", true},
+		{"busy text", "thinking...", false},
+		{"random text", "Hello world", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasGoosePrompt(tt.output); got != tt.want {
+				t.Errorf("HasGoosePrompt(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasGooseBusyIndicator(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"empty", "", false},
+		{"thinking", "thinking...", true},
+		{"executing", "executing...", true},
+		{"ctrl+c", "ctrl+c to interrupt", true},
+		{"esc", "esc to interrupt", true},
+		{"random text", "Hello world", false},
+		{"prompt only", ">_", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasGooseBusyIndicator(tt.output); got != tt.want {
+				t.Errorf("HasGooseBusyIndicator(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGooseSettings_MarshalUnmarshalRoundtrip(t *testing.T) {
+	orig := &GooseSettings{
+		Command:   "goose --model gpt-4o",
+		EnvFile:   "/tmp/goose.env",
+		YoloMode:  true,
+		ConfigDir: "/custom/config",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got GooseSettings
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(orig, &got) {
+		t.Errorf("roundtrip mismatch:\n  orig: %+v\n  got:  %+v", orig, got)
+	}
+}
+
+func TestDefaultGooseSettings(t *testing.T) {
+	settings := DefaultGooseSettings()
+	if settings == nil {
+		t.Fatal("DefaultGooseSettings() returned nil")
+	}
+	if settings.Command != "goose" {
+		t.Errorf("DefaultGooseSettings().Command = %q, want %q", settings.Command, "goose")
+	}
+	if settings.ConfigDir == "" {
+		t.Error("DefaultGooseSettings().ConfigDir should not be empty")
+	}
+}
+
+func TestIsClaudeCompatible_GooseNotCompatible(t *testing.T) {
+	if IsClaudeCompatible("goose") {
+		t.Error("IsClaudeCompatible(\"goose\") must be false")
+	}
+}
+
+func TestGetToolIcon_Goose(t *testing.T) {
+	icon := GetToolIcon("goose")
+	if icon == "" {
+		t.Error("GetToolIcon(\"goose\") returned empty")
+	}
+	if icon == GetToolIcon("shell") {
+		t.Errorf("GetToolIcon(\"goose\") = %q equals shell fallback (want a distinct icon)", icon)
+	}
+}
+
+func TestNewInstanceWithTool_Goose(t *testing.T) {
+	inst := NewInstanceWithTool("goose-test", "/tmp/goose-test-proj", "goose")
+	if inst == nil {
+		t.Fatal("NewInstanceWithTool returned nil")
+	}
+	if inst.Tool != "goose" {
+		t.Errorf("inst.Tool = %q, want %q", inst.Tool, "goose")
+	}
+}

--- a/internal/session/goose_test.go
+++ b/internal/session/goose_test.go
@@ -11,10 +11,6 @@ import (
 // prompt/busy detection, options marshalling, and identity gates.
 
 func TestBuildGooseCommand_BareName(t *testing.T) {
-	oldCache := userConfigCache
-	defer func() { userConfigCache = oldCache }()
-	userConfigCache = &UserConfig{}
-
 	settings := DefaultGooseSettings()
 	args := BuildGooseCommand(settings, "/tmp/project", "")
 	if len(args) == 0 {
@@ -55,6 +51,28 @@ func TestBuildGooseCommand_Profile(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("BuildGooseCommand with profile=work should include --profile work, got %v", args)
+	}
+}
+
+func TestBuildGooseCommand_WhitespaceCommand(t *testing.T) {
+	settings := &GooseSettings{Command: "   "}
+	args := BuildGooseCommand(settings, "/tmp/project", "")
+	if len(args) == 0 {
+		t.Fatal("BuildGooseCommand with whitespace command returned empty")
+	}
+	if args[0] != "goose" {
+		t.Errorf("BuildGooseCommand with whitespace command args[0] = %q, want %q", args[0], "goose")
+	}
+}
+
+func TestBuildGooseCommand_EmptyCommand(t *testing.T) {
+	settings := &GooseSettings{Command: ""}
+	args := BuildGooseCommand(settings, "/tmp/project", "")
+	if len(args) == 0 {
+		t.Fatal("BuildGooseCommand with empty command returned empty")
+	}
+	if args[0] != "goose" {
+		t.Errorf("BuildGooseCommand with empty command args[0] = %q, want %q", args[0], "goose")
 	}
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3168,6 +3168,16 @@ func (i *Instance) Start() error {
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
+	case i.Tool == "goose": // ponytail: new tool
+		settings := DefaultGooseSettings()
+		if cfg, _ := LoadUserConfig(); cfg != nil {
+			settings = &cfg.Goose
+			if settings.Command == "" {
+				settings = DefaultGooseSettings()
+			}
+		}
+		args := BuildGooseCommand(settings, i.ProjectPath, "")
+		command = strings.Join(args, " ")
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -3409,6 +3419,16 @@ func (i *Instance) StartWithMessage(message string) error {
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
+	case i.Tool == "goose": // ponytail: new tool
+		settings := DefaultGooseSettings()
+		if cfg, _ := LoadUserConfig(); cfg != nil {
+			settings = &cfg.Goose
+			if settings.Command == "" {
+				settings = DefaultGooseSettings()
+			}
+		}
+		args := BuildGooseCommand(settings, i.ProjectPath, "")
+		command = strings.Join(args, " ")
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -4039,11 +4059,11 @@ func (i *Instance) UpdateStatus() error {
 			// Preserve configured custom tool names.
 		} else {
 			switch detectedTool {
-			case "claude", "gemini", "opencode", "codex":
+			case "claude", "gemini", "opencode", "codex", "goose":
 				i.Tool = detectedTool
 			case "shell":
 				switch i.Tool {
-				case "", "shell", "claude", "gemini", "opencode", "codex":
+				case "", "shell", "claude", "gemini", "opencode", "codex", "goose":
 					i.Tool = detectedTool
 				}
 			}
@@ -6306,6 +6326,16 @@ func (i *Instance) Restart() error {
 			command = i.buildCursorCommand(i.Command, true)
 		case i.Tool == "hermes":
 			command = i.buildHermesCommand(i.Command)
+		case i.Tool == "goose": // ponytail: new tool
+			settings := DefaultGooseSettings()
+			if cfg, _ := LoadUserConfig(); cfg != nil {
+				settings = &cfg.Goose
+				if settings.Command == "" {
+					settings = DefaultGooseSettings()
+				}
+			}
+			args := BuildGooseCommand(settings, i.ProjectPath, "")
+			command = strings.Join(args, " ")
 		default:
 			// Check if this is a custom tool with session resume config
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3169,13 +3169,7 @@ func (i *Instance) Start() error {
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
 	case i.Tool == "goose": // ponytail: new tool
-		settings := DefaultGooseSettings()
-		if cfg, _ := LoadUserConfig(); cfg != nil {
-			settings = &cfg.Goose
-			if settings.Command == "" {
-				settings = DefaultGooseSettings()
-			}
-		}
+		settings := GooseSettingsFromConfig()
 		args := BuildGooseCommand(settings, i.ProjectPath, "")
 		command = strings.Join(args, " ")
 	default:
@@ -3420,13 +3414,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
 	case i.Tool == "goose": // ponytail: new tool
-		settings := DefaultGooseSettings()
-		if cfg, _ := LoadUserConfig(); cfg != nil {
-			settings = &cfg.Goose
-			if settings.Command == "" {
-				settings = DefaultGooseSettings()
-			}
-		}
+		settings := GooseSettingsFromConfig()
 		args := BuildGooseCommand(settings, i.ProjectPath, "")
 		command = strings.Join(args, " ")
 	default:

--- a/internal/session/instance_mcp.go
+++ b/internal/session/instance_mcp.go
@@ -7,7 +7,7 @@ import (
 
 // ToolSupportsMCPManager reports whether the TUI/CLI MCP surfaces apply to this tool.
 func ToolSupportsMCPManager(toolName string) bool {
-	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "cursor" || toolName == "opencode"
+	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "cursor" || toolName == "opencode" || toolName == "goose"
 }
 
 // MCPLocalConfigPathForTool returns the project-local MCP config path for display and writes.
@@ -23,6 +23,8 @@ func MCPLocalConfigPathForTool(toolName, projectPath string) string {
 		return filepath.Join(projectPath, ".cursor", "mcp.json")
 	case toolName == "opencode":
 		return filepath.Join(projectPath, "opencode.json")
+	case toolName == "goose": // ponytail: new tool — no project-local MCP
+		return ""
 	default:
 		return ""
 	}
@@ -39,6 +41,8 @@ func MCPGlobalConfigPathForTool(toolName string) string {
 		return filepath.Join(GetCursorConfigDir(), "mcp.json")
 	case toolName == "opencode":
 		return filepath.Join(GetOpenCodeConfigDir(), "opencode.json")
+	case toolName == "goose": // ponytail: new tool
+		return filepath.Join(GetGooseConfigDir(), "config.yaml")
 	default:
 		return ""
 	}

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -435,7 +435,7 @@ func ConfiguredHiddenToolNames() []string {
 }
 
 // pickerPresetOrder matches buildPresetCommands in internal/ui/newdialog.go.
-var pickerPresetOrder = []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+var pickerPresetOrder = []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "goose"}
 
 // PickerToolNames returns tool names for the new-session picker after applying
 // hidden_tools and show_only_installed_tools. The empty command "" is mapped

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 )
 
-// canonicalBuiltins is the canonical 11, in the precedence order that
-// Registry.Match() (and the legacy detectTool() switch) walk.
+// canonicalBuiltins is the canonical 12, in the precedence order that
+// Registry.Match() (and the legacy detectTool()) switch) walk.
 var canonicalBuiltins = []string{
 	"claude", "opencode", "gemini", "codex", "pi",
-	"copilot", "crush", "cursor", "hermes", "aider", "shell",
+	"copilot", "crush", "cursor", "hermes", "goose", "aider", "shell",
 }
 
 func TestRegistry_AllReturnsCanonical11(t *testing.T) {

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -151,6 +151,9 @@ type UserConfig struct {
 	// Hermes defines Hermes Agent CLI integration settings
 	Hermes HermesSettings `toml:"hermes,omitempty"`
 
+	// Goose defines Goose Agent CLI integration settings
+	Goose GooseSettings `toml:"goose,omitempty"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree,omitempty"`
 
@@ -1774,6 +1777,28 @@ type CrushSettings struct {
 	YoloMode bool `toml:"yolo_mode,omitempty"`
 }
 
+// GooseSettings defines Goose Agent CLI configuration.
+// Binary: `goose` from github.com/block/goose-ai (Apache-2.0).
+// Goose is a CLI AI agent by Block. Interactive TUI with MCP extension
+// support via config.yaml in ~/.config/goose/.
+type GooseSettings struct {
+	// Command is the Goose CLI command or invocation to use.
+	// Supports flags (e.g., "goose --model gpt-4o"). Default: "goose"
+	Command string `toml:"command,omitempty"`
+
+	// EnvFile is a .env file specific to Goose sessions (sourced before
+	// the `goose` command runs). Optional.
+	EnvFile string `toml:"env_file,omitempty"`
+
+	// YoloMode enables --auto flag for Goose sessions (auto-approve all
+	// tool calls / skip permission prompts). Default: false
+	YoloMode bool `toml:"yolo_mode,omitempty"`
+
+	// ConfigDir overrides the default Goose config directory (~/.config/goose).
+	// When set, Goose reads config.yaml and profiles.yaml from this path.
+	ConfigDir string `toml:"config_dir,omitempty"`
+}
+
 // WorktreeSettings contains git worktree preferences.
 type WorktreeSettings struct {
 	// AutoCleanup: remove worktree when session is deleted (default: true, nil = true)
@@ -3219,6 +3244,10 @@ func GetToolCommand(toolName string) string {
 		if config.Hermes.Command != "" {
 			return config.Hermes.Command
 		}
+	case "goose": // ponytail: new tool
+		if config.Goose.Command != "" {
+			return config.Goose.Command
+		}
 	}
 	return toolName
 }
@@ -3252,6 +3281,8 @@ func GetToolIcon(toolName string) string {
 		return "📝"
 	case "hermes":
 		return "☤"
+	case "goose": // ponytail: new tool
+		return "🪿"
 	case "pi":
 		return "π"
 	case "shell":

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -731,21 +731,14 @@ func StripANSI(content string) string {
 // hasGoosePrompt detects if Goose is waiting for input.
 // Goose uses ">_" or ">" at the bottom of its interactive interface.
 func (d *PromptDetector) hasGoosePrompt(content string) bool {
-	// Use the exported helper from the session package.
-	// Delegate to content-based detection for consistency.
 	lines := strings.Split(content, "\n")
 	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
 		line := strings.TrimSpace(lines[i])
 		if line == "" {
 			continue
 		}
-		if line == ">_" || line == ">" {
-			return true
-		}
-		if strings.HasSuffix(line, ">_") || strings.HasSuffix(line, "> ") {
-			return true
-		}
-		break
+		// Goose prompt markers all end with ">"
+		return strings.HasSuffix(line, ">")
 	}
 	return false
 }

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -84,6 +84,9 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 	case "cursor":
 		return d.hasCursorPrompt(content)
 
+	case "goose": // ponytail: new tool
+		return d.hasGoosePrompt(content)
+
 	default:
 		// Generic shell - check for common prompts
 		return d.hasShellPrompt(content)
@@ -723,4 +726,26 @@ func StripANSI(content string) string {
 	}
 
 	return b.String()
+}
+
+// hasGoosePrompt detects if Goose is waiting for input.
+// Goose uses ">_" or ">" at the bottom of its interactive interface.
+func (d *PromptDetector) hasGoosePrompt(content string) bool {
+	// Use the exported helper from the session package.
+	// Delegate to content-based detection for consistency.
+	lines := strings.Split(content, "\n")
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if line == ">_" || line == ">" {
+			return true
+		}
+		if strings.HasSuffix(line, ">_") || strings.HasSuffix(line, "> ") {
+			return true
+		}
+		break
+	}
+	return false
 }

--- a/internal/tmux/goose_test.go
+++ b/internal/tmux/goose_test.go
@@ -1,0 +1,80 @@
+package tmux
+
+import "testing"
+
+// Goose Agent CLI support — tmux-layer detection tests.
+
+func TestDetectToolFromCommand_Goose(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare goose", "goose", "goose"},
+		{"goose with auto flag", "goose --auto", "goose"},
+		{"goose absolute path", "/usr/local/bin/goose", "goose"},
+		{"goose home path", "/home/user/.local/bin/goose", "goose"},
+		{"uppercase binary", "GOOSE", "goose"},
+		{"goose with model flag", "goose --model gpt-4o", "goose"},
+		{"goose with profile", "goose --profile work", "goose"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromCommand_Goose_Negative(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"empty", ""},
+		{"unrelated tool", "ls -la"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectToolFromCommand(tt.command)
+			if got == "goose" {
+				t.Fatalf("detectToolFromCommand(%q) = %q, should NOT match goose", tt.command, got)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromContent_Goose(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"goose agent banner", "Welcome to Goose Agent", "goose"},
+		{"goose prompt", "> what should I do? goose>", "goose"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromContent(tt.content); got != tt.want {
+				t.Fatalf("detectToolFromContent(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRawPatterns_Goose(t *testing.T) {
+	patterns := DefaultRawPatterns("goose")
+	if patterns == nil {
+		t.Fatal("DefaultRawPatterns(\"goose\") returned nil")
+	}
+	if len(patterns.BusyPatterns) == 0 {
+		t.Error("goose busy patterns should not be empty")
+	}
+	if len(patterns.PromptPatterns) == 0 {
+		t.Error("goose prompt patterns should not be empty")
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -134,6 +134,17 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			BusyPatterns:   []string{"[PROCESSING]", "[CONNECTING]", "[RECONNECTING]"},
 			PromptPatterns: []string{"openclaw> "},
 		}
+	case "goose": // ponytail: new tool
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"ctrl+c to interrupt",
+				"esc to interrupt",
+				"thinking...",
+				"executing...",
+				"generating...",
+			},
+			PromptPatterns: []string{">_", `re:(?m)^\s*>\s*$`},
+		}
 	default:
 		return nil
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -429,6 +429,21 @@ type TerminalInfo struct {
 	SupportsTrueColor bool   // Supports 24-bit color
 }
 
+// IsAtuinPTYProxy checks if the current shell session is running under atuin's
+// pty-proxy. Atuin pty-proxy acts as a PTY MITM between the terminal and the
+// shell, intercepting all I/O. It sets ATUIN_PTY_PROXY_ACTIVE when active.
+//
+// agent-deck's Bubble Tea TUI is incompatible with atuin pty-proxy because:
+//   - os.Stdin/os.Stdout are pipes to atuin's proxy, not direct terminal FDs
+//   - Alternate screen sequences (tea.WithAltScreen) may be swallowed
+//   - Mouse tracking sequences (tea.WithMouseCellMotion) may not be forwarded
+//
+// Users should use `atuin init zsh` (or bash/fish) instead of
+// `atuin pty-proxy init zsh` when running agent-deck.
+func IsAtuinPTYProxy() bool {
+	return os.Getenv("ATUIN_PTY_PROXY_ACTIVE") != ""
+}
+
 // DetectTerminal identifies the current terminal emulator from environment variables
 // Returns terminal name: "warp", "iterm2", "kitty", "alacritty", "vscode", "windows-terminal", or "unknown"
 func DetectTerminal() string {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -592,7 +592,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "goose", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -641,6 +641,10 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		regexp.MustCompile(`(?i)\bcursor\s+agent\b`),
 		regexp.MustCompile(`(?i)cursor\s+cli\b`),
 	},
+	"goose": { // ponytail: new tool
+		regexp.MustCompile(`(?i)\bgoose\s+agent\b`),
+		regexp.MustCompile(`(?i)\bgoose>\s*`),
+	},
 }
 
 func detectToolFromCommand(command string) string {
@@ -669,6 +673,8 @@ func detectToolFromCommand(command string) string {
 			return "cursor"
 		case "hermes":
 			return "hermes"
+		case "goose": // ponytail: new tool
+			return "goose"
 		case "pi":
 			return "pi"
 		}
@@ -691,6 +697,8 @@ func detectToolFromCommand(command string) string {
 		return "cursor"
 	case strings.Contains(cmdLower, "hermes"):
 		return "hermes"
+	case strings.Contains(cmdLower, "goose"): // ponytail: new tool
+		return "goose"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
 	default:

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10275,6 +10275,8 @@ func createSessionTool(command string) (string, string) {
 		command = "cursor agent"
 	case "hermes":
 		tool = "hermes"
+	case "goose": // ponytail: new tool
+		tool = "goose"
 	default:
 		if toolDef := session.GetToolDef(command); toolDef != nil {
 			tool = command

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -773,6 +773,8 @@ func (m *MCPDialog) View() string {
 		title = "MCP Manager (Gemini)"
 	case "cursor":
 		title = "MCP Manager (Cursor)"
+	case "goose": // ponytail: new tool
+		title = "MCP Manager (Goose)"
 	}
 
 	// Scope tabs - Gemini only global; Cursor LOCAL+GLOBAL; Claude all three
@@ -860,6 +862,8 @@ func (m *MCPDialog) View() string {
 	switch m.tool {
 	case "gemini":
 		scopeDesc = DimStyle.Render("Writes to: ~/.gemini/settings.json")
+	case "goose": // ponytail: new tool
+		scopeDesc = DimStyle.Render("Writes to: ~/.config/goose/config.yaml (global only)")
 	case "cursor":
 		switch m.scope {
 		case MCPScopeLocal:

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -247,6 +247,14 @@ func (m *MCPDialog) Show(projectPath string, sessionID string, tool string) erro
 				})
 			}
 		}
+	} else if tool == "goose" {
+		// Goose: global-only MCPs from config.yaml (~/.config/goose/)
+		// Goose manages its own extensions; we show the pool but can't
+		// parse config.yaml, so nothing is pre-attached.
+		for _, name := range allNames {
+			item := itemsMap[name]
+			m.globalAvailable = append(m.globalAvailable, item)
+		}
 	} else {
 		// Claude: Load LOCAL attached from .mcp.json
 		localAttachedNames := make(map[string]bool)
@@ -339,8 +347,8 @@ func (m *MCPDialog) Show(projectPath string, sessionID string, tool string) erro
 
 	m.visible = true
 	m.projectPath = projectPath
-	// Gemini only has global scope; Cursor uses LOCAL+GLOBAL (no USER); Claude uses all three
-	if tool == "gemini" {
+	// Gemini only has global scope; Cursor uses LOCAL+GLOBAL (no USER); Goose global-only; Claude uses all three
+	if tool == "gemini" || tool == "goose" {
 		m.scope = MCPScopeGlobal
 	} else if tool == "cursor" {
 		switch session.GetMCPDefaultScope() {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -261,7 +261,7 @@ func displayCommandPreset(cmd string) string {
 // flag off FilterVisibleToolNames is a no-op, so the list is byte-identical to
 // before.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "goose"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -120,8 +120,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Goose"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "goose"}
 )
 
 // Search tier names for radio selection

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -199,8 +199,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Goose", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "goose", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -391,9 +391,12 @@ func (w *SetupWizard) View() string {
 			"opencode": "OpenCode - Open source AI coding tool",
 			"codex":    "Codex CLI - OpenAI's coding assistant",
 			"pi":       "Pi CLI - lightweight coding assistant",
+			"copilot":  "Copilot - GitHub's AI pair programmer",
 			"crush":    "Crush - Charm's terminal-first AI coding assistant",
-			"shell":    "Shell - No AI tool (plain terminal)",
 			"cursor":   "Cursor Agent - Cursor CLI (cursor agent)",
+			"hermes":   "Hermes - OpenAI's agentic coding CLI",
+			"goose":    "Goose - Block's AI agent with MCP extension support",
+			"shell":    "Shell - No AI tool (plain terminal)",
 		}
 
 		for i, tool := range w.toolOptions {

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "goose"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "goose"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -610,6 +610,8 @@ func ToolIcon(tool string) string {
 		return "📝"
 	case "hermes":
 		return "☤"
+	case "goose": // ponytail: new tool
+		return "🪿"
 	case "pi":
 		return IconPi
 	case "shell":
@@ -637,6 +639,8 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorAccent // Blue for Cursor
 	case "hermes":
 		return ColorYellow // Gold for Hermes Agent
+	case "goose": // ponytail: new tool
+		return ColorGreen // Green/teal for Goose Agent (Block)
 	case "pi":
 		return ColorAccent
 	case "aider":

--- a/internal/ui/tool_visibility_panel.go
+++ b/internal/ui/tool_visibility_panel.go
@@ -13,7 +13,7 @@ import (
 
 // pickerToolNames lists built-in tools shown in the new-session picker (shell excluded).
 var pickerToolNames = []string{
-	"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes",
+	"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "goose",
 }
 
 // ToolVisibilityPanel edits [ui].hidden_tools via a checklist overlay.

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -70,6 +70,34 @@ If you use multiple profiles, set the same under the profile override:
 allow_dangerous_mode = true
 ```
 
+### Atuin Pty-Proxy Incompatibility
+
+**Problem:** TUI shows a blank screen or fails to render when `eval "$(atuin pty-proxy init zsh)"` is in `.zshrc`.
+
+**Cause:** Atuin pty-proxy acts as a PTY MITM between the terminal and the shell. Agent Deck's Bubble Tea TUI requires direct terminal access for alternate screen mode, mouse tracking, and raw-mode I/O. These all break when stdin/stdout are proxied pipes.
+
+**Fix:** Replace the pty-proxy init line with standard atuin init:
+
+```bash
+# REMOVE this line:
+eval "$(atuin pty-proxy init zsh)"
+
+# REPLACE with this:
+eval "$(atuin init zsh)"
+```
+
+For bash:
+```bash
+eval "$(atuin init bash)"
+```
+
+For fish:
+```fish
+atuin init fish | source
+```
+
+Atuin pty-proxy is only needed for the atuin TUI overlay feature and is not required for normal shell history functionality. Agent Deck works fine with standard `atuin init`.
+
 ### High CPU Usage
 
 **With many sessions:** Normal if batched updates. Check:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Goose as a supported AI tool for creating, launching, restarting, and discovering sessions.
  * Introduced Goose configuration (custom command, profile support, auto-approval, env file, and config directory) and created/ensured its env file when configured.
  * Added Goose detection and status tracking (prompt/busy signals), plus MCP configuration support.
  * Updated UI elements: distinctive Goose icon/color, setup wizard, tool pickers/visibility panel, and MCP dialog.
* **Bug Fixes**
  * Added a warning when running under atuin’s proxied PTY, with guidance if the TUI renders blank or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->