### PR TITLE
feat: first-class support for omp (oh-my-pi) as a built-in tool

### DIFF
--- a/docs/specs/OMP-TOOL-SUPPORT-SPEC.md
+++ b/docs/specs/OMP-TOOL-SUPPORT-SPEC.md
@@ -1,0 +1,222 @@
+# Design: Tool-Agnostic Orchestration on omp (oh-my-pi)
+
+Date: 2026-07-16
+Status: Approved pending user review
+Author: conductor-ops session (Claude) with riplash
+
+## Motivation
+
+The orchestration layer (agent-deck conductor sessions + conductor bridge) currently
+assumes Claude Code as the agent runtime. Every time a better model ships — from any
+provider — swapping it in means touching orchestration plumbing. omp (oh-my-pi,
+https://github.com/can1357/oh-my-pi, a fork of Mario Zechner's Pi) supports 40+
+providers with role-based model routing (`default`/`smol`/`slow`/`plan`) and fallback
+chains configured in `~/.omp/agent/models.yml`. Running the conductor on omp makes
+model choice a config edit instead of an orchestration change.
+
+## Goals
+
+- Conductor sessions run on omp instead of Claude Code.
+- bridge.py has no hardcoded agent tool anywhere; the tool is config-driven per
+  conductor.
+- agent-deck gains first-class omp session support (status detection, resume).
+- All agent-deck/bridge changes are self-contained and submitted as PRs to
+  `asheshgoplani/agent-deck` (upstream is not ours; we run a fork locally until
+  merged).
+- Model/provider changes after this migration require editing only omp's
+  `models.yml`.
+
+## Non-Goals (day one)
+
+- Porting Claude Code-specific conductor machinery: Stop-hook child-waiting nudges,
+  PreCompact state persistence, auto-memory, superpowers skills, the PreToolUse
+  credential safety shield. Explicitly deferred ("core loop only" decision).
+- Moving worker/teammate sessions to omp by default. Workers keep whatever tool
+  fits the task; this migration covers orchestration. (Adapter work makes omp
+  workers *possible* later for free.)
+- omp RPC-mode (NDJSON) integration with agent-deck. Named as the fallback if
+  pane-scraping proves unworkable, but out of scope now.
+- Multi-provider model config. Day one is Anthropic via existing subscription
+  OAuth; other providers come later via `models.yml` edits (that being the point).
+
+## Decisions Made (with user, 2026-07-16)
+
+- Scope: everything — conductor on omp, bridge fully tool-agnostic, agent-deck
+  adapter upstreamed.
+- Adapter shape: first-class built-in tool in agent-deck (Approach A), built in a
+  local fork, PR'd upstream. Not `compatible_with="pi"` inheritance (omp's Rust
+  TUI differs from Pi's; inherited patterns could silently misread status — fatal
+  for a conductor). Not config-only patterns (brittle, no resume/fork).
+- Parity bar: core loop only (heartbeats, [EVENT] triage, agent-deck CLI via bash,
+  state.json/task-log.md discipline, POLICY.md tiers, caveman replies).
+- Cutover: parallel observe-only canary first, then in-place swap of conductor-ops.
+- Models/auth: Anthropic via existing Claude subscription OAuth. `default` role =
+  big Anthropic model; `smol` = Haiku-class for routine turns.
+
+## Verified Facts (2026-07-16)
+
+- agent-deck v1.9.73 installed; Pi is a built-in tool (upstream #674, #1197, #1287,
+  #1565) but omp is not; `compatible_with` accepts only "claude" and "codex".
+- Tool registry: `internal/session/builtins.go` (`builtinTools()` slice, precedence
+  order is load-bearing). Custom tools live in `[tools.<name>]` config with
+  busy/prompt/detect pattern overrides — this is the local escape hatch if
+  upstream stalls.
+- Status detection: per-tool `RawPatterns` (BusyPatterns / PromptPatterns /
+  SpinnerChars) in `internal/tmux/patterns.go`; Pi's arm matches
+  `pi>` prompts, `ctrl+c to interrupt`, subagent markers, spinner glyphs.
+- bridge.py is upstream code (`internal/session/conductor_bridge.py`), deployed to
+  `~/.agent-deck/conductor/bridge.py`. Local-only patches would be clobbered by
+  agent-deck updates — changes must land upstream.
+- bridge.py has exactly one hardcoded tool: `"-c", "claude"` inside
+  `ensure_conductor_running()` (~line 706), the conductor auto-(re)create path.
+- `discover_conductors()` already parses each conductor's `meta.json` and
+  normalizes `name`/`profile`. `meta.json` already carries an `"agent"` field
+  (ops has `"agent": "claude"`) that the bridge currently ignores.
+- omp verified from upstream README: Anthropic OAuth (subscription) supported;
+  inherits rules/skills/MCP from `.claude`, `.cursor`, etc. on first run; AGENTS.md
+  project instructions; `--resume` flag; headless `omp -p` one-shot mode and
+  `omp --mode rpc` (NDJSON); model roles in `~/.omp/agent/models.yml`.
+- omp is NOT currently installed on this host. No local clone of agent-deck exists
+  yet; fork + clone is part of the work.
+
+## Architecture
+
+Four components, four phases of change:
+
+### Component 1: agent-deck omp adapter (fork → PR #1)
+
+- Fork `asheshgoplani/agent-deck` under the procrypto account; clone to
+  `~/projects/agent-deck`.
+- `internal/session/builtins.go`: add `{Name: "omp", Icon: "⌥", detectTokens:
+  []string{"omp"}}`. Token match (like Pi's) so short-name substring collisions
+  ("compose", "stomp") cannot false-match. Insert position: adjacent to "pi" in
+  the precedence slice; order is load-bearing, so the new entry must not sit in
+  front of a tool whose command strings could contain "omp" as a token (none do).
+- `internal/tmux/patterns.go`: new `case "omp":` returning RawPatterns derived
+  empirically from phase-0 tmux probes of the real omp TUI (idle prompt, busy
+  spinner, streaming, permission prompt, subagent activity). Patterns are NOT
+  copied from Pi.
+- Resume support: wire omp's `--resume` the same way Pi resume landed in #1197.
+- Tests: `patterns_test.go`-style cases using pane-content fixtures captured
+  during phase 0; registry tests for detect-token matching (3+ true matches,
+  3+ false-positive candidates per global boundary-testing rules).
+- Keep the diff additive (new registry entry, new case arms, new fixtures) so the
+  PR is reviewable and self-contained.
+- Until the PR merges: build from the fork (`make`/`go build`) and run the fork
+  binary locally. Rebase the fork on upstream releases as needed.
+
+### Component 2: bridge tool-agnostic conductor (PR #2, small)
+
+- `ensure_conductor_running()`: accept the conductor's meta dict (or an `agent`
+  parameter threaded from callers) and use `meta.get("agent") or "claude"` for the
+  `-c` argument when creating a missing conductor session. Default preserves
+  existing behavior for every current conductor.
+- `discover_conductors()` gains the same normalization for `agent` it already does
+  for `name`/`profile`: `meta["agent"] = meta.get("agent") or "claude"`.
+- Extend upstream conductor tests (`conductor/tests/`) with an agent-field case.
+- Deploy: upstream PR to `internal/session/conductor_bridge.py`; locally, apply the
+  same change to `~/.agent-deck/conductor/bridge.py` (with a dated backup copy,
+  matching existing convention: bridge.py.backup) so the canary can run before the
+  PR merges. Restarting the bridge service to load it is a user-approved action
+  (Tier 1 infra). A bridge restart is separately pending for the rotated Telegram
+  token; if that restart has not happened by deploy time, one restart covers both.
+
+### Component 3: omp conductor runtime
+
+- Install omp (npm or shell-script installer, pinned version recorded in the plan).
+- User performs `omp` Anthropic OAuth login interactively (subscription billing; no
+  new API keys; no secrets handled by the agent).
+- `~/.omp/agent/models.yml`: `default` = the strongest Anthropic model exposed via
+  subscription OAuth at setup time (Fable 5 / Opus 4.8-class), `smol` =
+  Haiku 4.5-class. Fallback chains left empty day one (single provider).
+- Write an explicit `AGENTS.md` for the canary conductor directory porting the
+  core loop from the shared conductor CLAUDE.md + ops CLAUDE.md: heartbeat
+  protocol and response format, NEED/OPEN dedupe, POLICY.md tier rules (referenced,
+  not duplicated), state.json/task-log.md discipline, caveman-mode reply rules,
+  agent-deck CLI reference. omp's auto-inheritance of `.claude` rules is treated
+  as a bonus, not relied upon.
+- Explicitly dropped day one (per parity decision): Stop-hook nudges, PreCompact
+  state save (omp compaction behavior observed during canary instead), auto-memory,
+  superpowers skills, PreToolUse safety shield. The conductor's credential-hygiene
+  obligations remain in force at the prompt level via AGENTS.md text.
+
+### Component 4: canary rollout and cutover
+
+- Canary: new directory `~/.agent-deck/conductor/omp-canary/` containing
+  `meta.json` (`{"name": "omp-canary", "agent": "omp", "profile": "default",
+  "heartbeat_enabled": true, ...}`), `AGENTS.md`, and an observe-only `POLICY.md`.
+  The bridge auto-discovers it and creates session `conductor-omp-canary` with
+  `-c omp`.
+- Double-conductor conflict: conductors monitor a profile, and ops already owns
+  `default`. The canary's POLICY.md therefore forbids ALL interventions: no
+  `session send` to any session, no NEED lines (no user pings), no restarts. It
+  only reads statuses/output and emits `[STATUS]`-style observation reports.
+  conductor-ops remains the sole actor during the canary period.
+- Validation criteria (all must hold over ≥3 days of live heartbeats):
+  - agent-deck status detection for the omp session is correct across
+    running/waiting/idle (spot-checked against tmux reality, not self-reported).
+  - Bridge `session send --wait` round-trips reliably (heartbeat prompt in,
+    parseable reply out) with no stuck sends.
+  - `agent-deck session output -q` returns the canary's replies intact.
+  - Canary's triage reports substantively agree with conductor-ops's decisions on
+    the same heartbeats (tier classification, NEED-vs-OPEN, auto-response calls).
+  - No omp crashes/hangs requiring manual restart.
+- Cutover (user-approved, Tier 1): set `"agent": "omp"` in ops/meta.json, port
+  AGENTS.md/POLICY into `~/.agent-deck/conductor/ops/`, stop `conductor-ops`; the
+  bridge auto-recreates it on omp. state.json + task-log.md are the context
+  handoff (they already serve this role across restarts). The Claude conductor
+  session is retired, not deleted, until the omp conductor has survived its first
+  week.
+- Rollback: revert `"agent"` to `"claude"` in ops/meta.json, stop the omp session;
+  bridge recreates on Claude Code. One-field, one-restart rollback at every stage.
+- Cleanup: after cutover has held for a week, remove the canary conductor dir and
+  its session.
+
+## Error Handling
+
+- Pattern misdetection (conductor stuck "running" or falsely "waiting"): caught by
+  canary validation before cutover; post-cutover, the bridge's existing error
+  handling (status probe + restart path) still applies. Escape hatch: a
+  `[tools.omp-patched]` custom tool entry in config.toml with corrected patterns
+  can override without waiting on a new binary.
+- omp version drift breaking the TUI patterns: pin the omp version; record it in
+  the canary AGENTS.md; upgrades to omp are deliberate, tested actions.
+- Upstream PR rejected/stalled: fork binary keeps running locally indefinitely;
+  periodic rebases. No functional dependency on merge timing.
+- Bridge deploy vs upstream update race: local bridge.py edit is identical to the
+  PR content, so an agent-deck update that ships the merged PR is a no-op; an
+  update that ships WITHOUT the PR (clobbering the local edit) is detected because
+  the canary/omp conductor fails to auto-recreate — re-apply the patch from the
+  fork.
+
+## Testing
+
+- Phase 0 probe (before any Go code): run omp inside a bare tmux session; capture
+  pane content for idle, busy/streaming, tool-permission prompt, subagent
+  activity, and post-compaction states; save as fixtures. This gates the whole
+  design: if omp's TUI proves hostile to pane-scraping, stop and re-plan around
+  RPC mode instead of building a bad adapter.
+- Go unit tests: patterns (fixtures, true/false-positive cases), registry
+  detect-token matching, resume flag wiring.
+- Bridge tests: agent-field selection incl. missing-field default ("claude"),
+  extending the existing upstream conductor test suite.
+- Live validation: the canary period itself (criteria above).
+
+## Sequencing (small, reviewable increments)
+
+1. Phase 0: install omp, OAuth login (user), tmux probe, capture fixtures.
+   Go/no-go on pane-scraping.
+2. PR #1 branch: agent-deck omp adapter + tests; build fork binary; verify
+   `agent-deck add -c omp` + status detection locally against a scratch session.
+3. PR #2 branch: bridge agent-field support + tests; deploy patched bridge.py
+   locally alongside the pending Telegram-token bridge restart (one restart).
+4. Canary: create omp-canary conductor dir; observe ≥3 days; compare triage.
+5. Cutover: flip ops meta.json to omp (user-approved); retire Claude conductor
+   after a stable week; remove canary.
+
+## Open Questions
+
+- omp's exact TUI strings/spinner glyphs — deliberately unresolved until the
+  phase 0 probe; the design treats them as a deliverable, not an assumption.
+- Whether upstream prefers one combined PR or two — ask in the PR description;
+  the branches are structured to work either way.

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -60,6 +60,7 @@ func builtinTools() []builtinTool {
 		{Name: "gemini", Icon: "✨", detectSubstrings: []string{"gemini"}},
 		{Name: "codex", Icon: "💻", detectSubstrings: []string{"codex"}},
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
+		{Name: "omp", Icon: "⌥", detectTokens: []string{"omp"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
 		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}},

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1822,7 +1822,7 @@ func resolveDynamicTool(current, detected string, preserveCustom bool) string {
 		return current
 	}
 	switch detected {
-	case "claude", "gemini", "opencode", "codex":
+	case "claude", "gemini", "opencode", "codex", "omp":
 		return detected
 	case "shell":
 		switch current {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1809,6 +1809,30 @@ func (i *Instance) buildOmpCommand(baseCommand string) string {
 	)
 }
 
+// resolveDynamicTool returns the tool identity an instance should carry after
+// dynamic detection reported detected, given its current identity. preserveCustom
+// is true when the instance carries a configured custom (non-builtin) tool name.
+// omp is pinned: it drives other agent CLIs (codex, claude) as subprocesses, so
+// child-process detection must never rewrite its identity.
+func resolveDynamicTool(current, detected string, preserveCustom bool) string {
+	if preserveCustom {
+		return current
+	}
+	if current == "omp" {
+		return current
+	}
+	switch detected {
+	case "claude", "gemini", "opencode", "codex":
+		return detected
+	case "shell":
+		switch current {
+		case "", "shell", "claude", "gemini", "opencode", "codex":
+			return detected
+		}
+	}
+	return current
+}
+
 func (i *Instance) buildPiForkCommandForTarget(target *Instance, baseCommand string) (string, error) {
 	if target == nil {
 		return "", fmt.Errorf("cannot build Pi fork command: target instance is nil")
@@ -4445,19 +4469,11 @@ func (i *Instance) UpdateStatus() error {
 	// "my-codex" should keep their configured identity even when tmux correctly
 	// detects the wrapped CLI as Codex.
 	if detectedTool := i.tmuxSession.DetectTool(); detectedTool != "" {
-		if !isBuiltinToolName(i.Tool) && GetToolDef(i.Tool) != nil {
-			// Preserve configured custom tool names.
-		} else {
-			switch detectedTool {
-			case "claude", "gemini", "opencode", "codex":
-				i.Tool = detectedTool
-			case "shell":
-				switch i.Tool {
-				case "", "shell", "claude", "gemini", "opencode", "codex":
-					i.Tool = detectedTool
-				}
-			}
-		}
+		i.Tool = resolveDynamicTool(
+			i.Tool,
+			detectedTool,
+			!isBuiltinToolName(i.Tool) && GetToolDef(i.Tool) != nil,
+		)
 	}
 
 	// Update session metadata tracking only for active/waiting sessions.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1774,6 +1774,41 @@ func (i *Instance) buildPiCommand(baseCommand string) string {
 	)
 }
 
+// ompAgentDeckSessionDirExpr mirrors piAgentDeckSessionDirExpr for omp
+// (oh-my-pi), which stores sessions under ~/.omp. Same target-side $HOME
+// rationale as the Pi variant.
+func ompAgentDeckSessionDirExpr(instanceID string) string {
+	return "${HOME}/.omp/agent-deck/" + shellescape.Quote(instanceID)
+}
+
+// buildOmpCommand builds the launch command for omp (oh-my-pi), a Pi fork.
+// Same strategy as buildPiCommand: scope the session directory to this Agent
+// Deck instance and launch with --continue so restarts resume in place.
+// Fork support is intentionally not wired for omp (Pi-only for now).
+func (i *Instance) buildOmpCommand(baseCommand string) string {
+	if i.Tool != "omp" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" {
+		cmd = "omp"
+	}
+
+	sessionDir := ompAgentDeckSessionDirExpr(i.ID)
+	quotedInstanceID := shellescape.Quote(i.ID)
+	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
+
+	return envPrefix + fmt.Sprintf(
+		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --continue --session-dir \"$session_dir\"",
+		sessionDir,
+		quotedInstanceID,
+		quotedProfile,
+		cmd,
+	)
+}
+
 func (i *Instance) buildPiForkCommandForTarget(target *Instance, baseCommand string) (string, error) {
 	if target == nil {
 		return "", fmt.Errorf("cannot build Pi fork command: target instance is nil")
@@ -3429,6 +3464,8 @@ func (i *Instance) Start() error {
 			break
 		}
 		command = i.buildPiCommand(i.Command)
+	case i.Tool == "omp":
+		command = i.buildOmpCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "cursor":
@@ -3696,6 +3733,8 @@ func (i *Instance) StartWithMessage(message string) error {
 			break
 		}
 		command = i.buildPiCommand(i.Command)
+	case i.Tool == "omp":
+		command = i.buildOmpCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "crush":
@@ -6785,6 +6824,8 @@ func (i *Instance) restart(env map[string]string) error {
 			i.CodexStartedAt = time.Now().UnixMilli()
 		case i.Tool == "pi":
 			command = i.buildPiCommand(i.Command)
+		case i.Tool == "omp":
+			command = i.buildOmpCommand(i.Command)
 		case i.Tool == "copilot":
 			command = i.buildCopilotCommand(i.Command)
 		case i.Tool == "crush":

--- a/internal/session/instance_omp_test.go
+++ b/internal/session/instance_omp_test.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+func TestBuildOmpCommand_UsesInstanceScopedSessionDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	inst := &Instance{ID: "test-instance-id", Tool: "omp"}
+	got := inst.buildOmpCommand("omp")
+
+	wantSessionDir := "${HOME}/.omp/agent-deck/test-instance-id"
+	for _, want := range []string{
+		"session_dir=" + wantSessionDir,
+		"mkdir -p \"$session_dir\"",
+		"AGENTDECK_INSTANCE_ID=test-instance-id",
+		"omp --continue --session-dir \"$session_dir\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildOmpCommand output missing %q\ngot: %s", want, got)
+		}
+	}
+}
+
+func TestBuildOmpCommand_QuotesInstanceIDPathComponent(t *testing.T) {
+	inst := &Instance{ID: "test instance'id", Tool: "omp"}
+	got := inst.buildOmpCommand("omp")
+
+	wantSessionDir := `${HOME}/.omp/agent-deck/` + shellescape.Quote(inst.ID)
+	if !strings.Contains(got, "session_dir="+wantSessionDir) {
+		t.Errorf("buildOmpCommand() should quote instance ID path component %q, got %q", wantSessionDir, got)
+	}
+}
+
+func TestBuildOmpCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	got := inst.buildOmpCommand("some-command")
+	if got != "some-command" {
+		t.Errorf("buildOmpCommand with wrong tool = %q, want %q", got, "some-command")
+	}
+}
+
+func TestBuildOmpCommand_DefaultsBinary(t *testing.T) {
+	inst := &Instance{ID: "tid", Tool: "omp"}
+	got := inst.buildOmpCommand("")
+	if !strings.Contains(got, " omp --continue") {
+		t.Errorf("empty command must default to omp binary, got %q", got)
+	}
+}

--- a/internal/session/instance_omp_test.go
+++ b/internal/session/instance_omp_test.go
@@ -86,3 +86,11 @@ func TestResolveDynamicToolUpstreamBehaviorUnchanged(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveDynamicToolUpgradesShellToOmp(t *testing.T) {
+	// A shell session that starts omp inside it should be re-typed as omp
+	// (same wrapped-tool upgrade the other builtin CLIs get).
+	if got := resolveDynamicTool("shell", "omp", false); got != "omp" {
+		t.Errorf("resolveDynamicTool(shell, omp) = %q, want omp", got)
+	}
+}

--- a/internal/session/instance_omp_test.go
+++ b/internal/session/instance_omp_test.go
@@ -55,3 +55,34 @@ func TestBuildOmpCommand_DefaultsBinary(t *testing.T) {
 		t.Errorf("empty command must default to omp binary, got %q", got)
 	}
 }
+
+func TestResolveDynamicToolPreservesOmp(t *testing.T) {
+	// omp drives other agent CLIs (codex, claude) as subprocesses; child
+	// detection must never rewrite its identity.
+	for _, detected := range []string{"codex", "claude", "gemini", "opencode", "shell"} {
+		if got := resolveDynamicTool("omp", detected, false); got != "omp" {
+			t.Errorf("resolveDynamicTool(omp, %q) = %q, want omp", detected, got)
+		}
+	}
+}
+
+func TestResolveDynamicToolUpstreamBehaviorUnchanged(t *testing.T) {
+	cases := []struct {
+		current, detected string
+		preserveCustom    bool
+		want              string
+	}{
+		{"shell", "codex", false, "codex"},
+		{"claude", "codex", false, "codex"},
+		{"codex", "shell", false, "shell"},
+		{"pi", "shell", false, "pi"},
+		{"my-codex", "codex", true, "my-codex"},
+		{"", "claude", false, "claude"},
+	}
+	for _, c := range cases {
+		if got := resolveDynamicTool(c.current, c.detected, c.preserveCustom); got != c.want {
+			t.Errorf("resolveDynamicTool(%q, %q, %v) = %q, want %q",
+				c.current, c.detected, c.preserveCustom, got, c.want)
+		}
+	}
+}

--- a/internal/session/toolregistry_omp_test.go
+++ b/internal/session/toolregistry_omp_test.go
@@ -1,0 +1,26 @@
+package session
+
+import "testing"
+
+// omp is a short name like "pi": it must match only as a whitespace token,
+// never as a substring ("docker compose", "stomp-server" contain "omp").
+func TestRegistryMatchesOmp(t *testing.T) {
+	r := Init(nil)
+	cases := []struct {
+		cmd  string
+		want string
+	}{
+		{"omp", "omp"},
+		{"omp --resume", "omp"},
+		{"OMP", "omp"},                     // Match lowercases input
+		{"docker compose up", "shell"},     // substring must not match
+		{"stomp-server --port 1", "shell"}, // hyphenated token must not match
+		{"my-omp-wrapper", "shell"},        // token boundaries respected
+		{"pi", "pi"},                       // pi unaffected by insertion
+	}
+	for _, tc := range cases {
+		if got := r.Match(tc.cmd); got != tc.want {
+			t.Errorf("Match(%q) = %q, want %q", tc.cmd, got, tc.want)
+		}
+	}
+}

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -5,14 +5,16 @@ import (
 	"testing"
 )
 
-// canonicalBuiltins is the canonical 11, in the precedence order that
-// Registry.Match() (and the legacy detectTool() switch) walk.
+// canonicalBuiltins is the canonical built-in list, in the precedence order
+// that Registry.Match() (and the legacy detectTool() switch) walk. omp sits
+// directly after pi: both are short names detected by token match, and nothing
+// earlier in the slice token-matches "omp".
 var canonicalBuiltins = []string{
-	"claude", "opencode", "gemini", "codex", "pi",
+	"claude", "opencode", "gemini", "codex", "pi", "omp",
 	"copilot", "crush", "cursor", "hermes", "aider", "shell",
 }
 
-func TestRegistry_AllReturnsCanonical11(t *testing.T) {
+func TestRegistry_AllReturnsCanonicalBuiltins(t *testing.T) {
 	all := Init(nil).All()
 	if len(all) != len(canonicalBuiltins) {
 		t.Fatalf("All() returned %d entries, want %d", len(all), len(canonicalBuiltins))

--- a/internal/tmux/omp_detect_test.go
+++ b/internal/tmux/omp_detect_test.go
@@ -1,0 +1,42 @@
+package tmux
+
+import "testing"
+
+func TestDetectToolFromCommand_Omp(t *testing.T) {
+	cases := []string{
+		"omp",
+		"omp --profile wsl-pilot",
+		`session_dir=${HOME}/.omp/agent-deck/abc; mkdir -p "$session_dir" && AGENTDECK_PROFILE=default omp --profile wsl-pilot --continue --session-dir "$session_dir"`,
+	}
+	for _, cmd := range cases {
+		if got := detectToolFromCommand(cmd); got != "omp" {
+			t.Errorf("detectToolFromCommand(%q) = %q, want omp", cmd, got)
+		}
+	}
+}
+
+func TestDetectToolFromCommand_Omp_Negative(t *testing.T) {
+	// "wsl-pilot" must not trip the pi arm; unrelated commands must not become omp.
+	cases := map[string]string{
+		"stomp-server --port 8080": "",
+		"docker compose up":        "",
+	}
+	for cmd, want := range cases {
+		if got := detectToolFromCommand(cmd); got != want {
+			t.Errorf("detectToolFromCommand(%q) = %q, want %q", cmd, got, want)
+		}
+	}
+}
+
+func TestDetectToolFromContent_Omp(t *testing.T) {
+	// omp welcome banner must detect as omp, not codex, even when provider
+	// text like "openai" or "codex" appears elsewhere on the screen.
+	content := `╭─── omp v17.0.1 ─────────────────────────╮
+│      Welcome back!    │ Tips            │
+│     Claude Opus 4.8   │ # for prompts   │
+│        anthropic      │                 │
+Failed: codex_apps: HTTP 401 token_expired; openai provider ready`
+	if got := detectToolFromContent(content); got != "omp" {
+		t.Errorf("detectToolFromContent(omp banner) = %q, want omp", got)
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -113,6 +113,29 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			PromptPatterns: []string{`re:(?m)^\s*pi>\s*`},
 			SpinnerChars:   []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
 		}
+	case "omp":
+		// omp (oh-my-pi, a Pi fork with a Rust TUI). Patterns derived from
+		// captured pane fixtures in testdata/omp/ (omp v17.0.1, see
+		// patterns_omp_test.go for the capture conditions).
+		//
+		// Busy is a spinner line "<braille> <verb> ⟦esc⟧" above the input box.
+		// The verb is model-generated per task ("Working…", "Running echo
+		// probe", …) so the ONLY stable busy token is the "⟦esc⟧" interrupt
+		// hint. It must stay exact: finished tool calls leave "⟦Wall: 0.05s |
+		// Timeout: 300s⟧" timing lines in scrollback, so a bare "⟦" would
+		// false-positive on idle panes.
+		//
+		// The input box ("╭── π  > …") is visible in every state, including
+		// busy — same structural overlap as codewhale above; busy precedence
+		// in the detector is what keeps status reads correct.
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"⟦esc⟧", // interrupt hint: present while thinking AND while tools execute
+				`re:(?m)^\s*[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\s`, // spinner-led status line (backup)
+			},
+			PromptPatterns: []string{"╭── π "},
+			SpinnerChars:   []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+		}
 	case "copilot":
 		// GitHub Copilot CLI (the standalone `copilot` binary, Issue #556).
 		// Patterns are based on real-world Copilot CLI TUI transcripts.

--- a/internal/tmux/patterns_omp_test.go
+++ b/internal/tmux/patterns_omp_test.go
@@ -1,0 +1,95 @@
+package tmux
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Fixtures in testdata/omp/ are real pane captures of omp v17.0.1 (oh-my-pi,
+// 200x50 pane), with MCP server names scrubbed:
+//
+//   idle.txt            fresh start, welcome box, prompt rendered, no task yet
+//   busy.txt            two snapshots while thinking/streaming ("⠧ Working… ⟦esc⟧")
+//   permission.txt      a bash tool call executing. omp AUTO-APPROVES tool calls
+//                       by default, so there is no separate waiting-for-approval
+//                       state: this pane is BUSY ("⠼ Running echo probe ⟦esc⟧")
+//                       with the finished call's output box above it.
+//   idle-after-task.txt back at the prompt after a completed task. The border
+//                       task label ("◀ <task> ──") and tool-output timing lines
+//                       ("⟦Wall: 0.05s | Timeout: 300s⟧") PERSIST here — only
+//                       the spinner + "⟦esc⟧" interrupt hint disappear.
+//
+// Like Claude Code's and codewhale's TUIs, omp keeps its input box visible in
+// every state, so PromptPatterns intentionally match busy panes too. Busy is
+// authoritative in the detector (checked before prompt), which is what makes
+// that safe — see the codewhale comment in patterns.go (#1577).
+
+func ompFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile("testdata/omp/" + name)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func ompAnyPatternMatches(t *testing.T, patterns []string, content string) bool {
+	t.Helper()
+	for _, p := range patterns {
+		if rest, ok := strings.CutPrefix(p, "re:"); ok {
+			re, err := regexp.Compile(rest)
+			if err != nil {
+				t.Fatalf("bad regex %q: %v", p, err)
+			}
+			if re.MatchString(content) {
+				return true
+			}
+		} else if strings.Contains(content, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOmpDefaultPatternsExist(t *testing.T) {
+	if DefaultRawPatterns("omp") == nil {
+		t.Fatal("DefaultRawPatterns(\"omp\") returned nil — omp has no built-in patterns")
+	}
+}
+
+func TestOmpBusyDetection(t *testing.T) {
+	rp := DefaultRawPatterns("omp")
+
+	// True positives: thinking/streaming AND tool-execution phases. The busy
+	// verb is model-generated per task ("Working…", "Running echo probe", …),
+	// so only the trailing "⟦esc⟧" interrupt hint is stable across both.
+	for _, name := range []string{"busy.txt", "permission.txt"} {
+		if !ompAnyPatternMatches(t, rp.BusyPatterns, ompFixture(t, name)) {
+			t.Errorf("no BusyPattern matched %s", name)
+		}
+	}
+
+	// False-positive candidates: idle-after-task.txt still shows the border
+	// task label and "⟦Wall: …⟧" timing lines from finished tool calls — a
+	// bare "⟦" (or the label) as a busy pattern would misread it as running,
+	// leaving the conductor waiting forever.
+	for _, name := range []string{"idle.txt", "idle-after-task.txt"} {
+		if ompAnyPatternMatches(t, rp.BusyPatterns, ompFixture(t, name)) {
+			t.Errorf("a BusyPattern false-positived on %s", name)
+		}
+	}
+}
+
+func TestOmpPromptDetection(t *testing.T) {
+	rp := DefaultRawPatterns("omp")
+
+	for _, name := range []string{"idle.txt", "idle-after-task.txt"} {
+		if !ompAnyPatternMatches(t, rp.PromptPatterns, ompFixture(t, name)) {
+			t.Errorf("no PromptPattern matched %s", name)
+		}
+	}
+	// No "prompt must not match busy" assertion: omp's input box is visible
+	// while busy (structural, like codewhale). Busy precedence resolves it.
+}

--- a/internal/tmux/testdata/omp/busy.txt
+++ b/internal/tmux/testdata/omp/busy.txt
@@ -1,0 +1,89 @@
+│                          │ / for commands                                                        │
+│       ▀██████████▀       │ ! to run bash                                                         │
+│        ╘██    ██         │ $ to run python                                                       │
+│         ██    ██         │ ───────────────────────────────────────────────────────────────────── │
+│         ██    ██         │ LSP Servers                                                           │
+│        ▄██▄  ▄██▄        │ No LSP servers                                                        │
+│                          │                                                                       │
+│     Claude Opus 4.8      │                                                                       │
+│        anthropic         │                                                                       │
+│                          │ ───────────────────────────────────────────────────────────────────── │
+│                          │ Recent sessions                                                       │
+│                          │ No recent sessions                                                    │
+│                          │                                                                       │
+│                          │                                                                       │
+│                          │                                                                       │
+│                          │                                                                       │
+╰──────────────────────────┴───────────────────────────────────────────────────────────────────────╯
+ Tip: Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow ->
+      etc
+
+ Connected: svc-a:svc-a, svc-b:svc-b. Failed: svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…. Still connecting: svc-h:svc-h, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k, svc-l:svc-l…
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Update Available
+ New version 17.0.5 is available. Run: omp update
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ MCP finished with failures. Connected: svc-a:svc-a, svc-b:svc-b, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k. Failed: svc-h:svc-h: HTTP 400: bad request:
+ Authorization header is badly formatted  [WWW-Authentica…; svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP
+ 401: {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-l:svc-l: HTTP 401: {"error":"Authentication required"} [WWW-Authenticate: Bearer resourc…
+
+
+ write a 300 word essay about tmux, do not use any tools
+
+
+ ⠧ Working… ⟦esc⟧
+
+╭── π  > ⬢ Opus 4.8 · ◒ high > 🗑 omp-probe-KJPDw9 > ◫ 5.7%/1M ⟲ > (sub) ▶─────────────────────────────────────────────────────────────────────────────◀ Write essay about tmux ──╮
+╰─                                                                                                                                                                              ─╯
+----SNAPSHOT-2----
+│                          │ / for commands                                                        │
+│       ▀██████████▀       │ ! to run bash                                                         │
+│        ╘██    ██         │ $ to run python                                                       │
+│         ██    ██         │ ───────────────────────────────────────────────────────────────────── │
+│         ██    ██         │ LSP Servers                                                           │
+│        ▄██▄  ▄██▄        │ No LSP servers                                                        │
+│                          │                                                                       │
+│     Claude Opus 4.8      │                                                                       │
+│        anthropic         │                                                                       │
+│                          │ ───────────────────────────────────────────────────────────────────── │
+│                          │ Recent sessions                                                       │
+│                          │ No recent sessions                                                    │
+│                          │                                                                       │
+│                          │                                                                       │
+│                          │                                                                       │
+│                          │                                                                       │
+╰──────────────────────────┴───────────────────────────────────────────────────────────────────────╯
+ Tip: Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow ->
+      etc
+
+ Connected: svc-a:svc-a, svc-b:svc-b. Failed: svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…. Still connecting: svc-h:svc-h, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k, svc-l:svc-l…
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Update Available
+ New version 17.0.5 is available. Run: omp update
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ MCP finished with failures. Connected: svc-a:svc-a, svc-b:svc-b, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k. Failed: svc-h:svc-h: HTTP 400: bad request:
+ Authorization header is badly formatted  [WWW-Authentica…; svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP
+ 401: {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-l:svc-l: HTTP 401: {"error":"Authentication required"} [WWW-Authenticate: Bearer resourc…
+
+
+ write a 300 word essay about tmux, do not use any tools
+
+
+ ⠹ Working… ⟦esc⟧
+
+╭── π  > ⬢ Opus 4.8 · ◒ high > 🗑 omp-probe-KJPDw9 > ◫ 5.7%/1M ⟲ > (sub) ▶─────────────────────────────────────────────────────────────────────────────◀ Write essay about tmux ──╮
+╰─                                                                                                                                                                              ─╯

--- a/internal/tmux/testdata/omp/idle-after-task.txt
+++ b/internal/tmux/testdata/omp/idle-after-task.txt
@@ -1,0 +1,44 @@
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Update Available
+ New version 17.0.5 is available. Run: omp update
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ MCP finished with failures. Connected: svc-a:svc-a, svc-b:svc-b, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k. Failed: svc-h:svc-h: HTTP 400: bad request:
+ Authorization header is badly formatted  [WWW-Authentica…; svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP
+ 401: {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-l:svc-l: HTTP 401: {"error":"Authentication required"} [WWW-Authenticate: Bearer resourc…
+
+
+ write a 300 word essay about tmux, do not use any tools
+
+
+ The user is asking me to write a 300-word essay about tmux without using any tools, so I'll compose it directly.
+
+ tmux: The Terminal Multiplexer
+
+ tmux is a terminal multiplexer, a tool that lets a single terminal window host multiple independent sessions, windows, and panes. For anyone who lives in the command line, it
+ transforms a flat, single-stream terminal into a persistent, organized workspace. Its power lies in a deceptively simple idea: decoupling the terminal session from the terminal
+ emulator that displays it.
+
+ The most celebrated feature is session persistence. Because tmux runs a server in the background, your sessions survive even when you disconnect. This is invaluable for remote
+ work over SSH. If your connection drops mid-task—a long compile, a database migration, a training run—the process keeps running. You simply reconnect and reattach with tmux
+ attach, finding everything exactly as you left it. This resilience alone justifies its place in any developer's toolkit.
+
+ Beyond persistence, tmux excels at spatial organization. A single window can be split into multiple panes, letting you edit code in one, watch logs in another, and run a shell
+ in a third, all visible simultaneously. Windows function like browser tabs, grouping related panes, while sessions hold collections of windows for entirely separate projects.
+ Navigation happens through a prefix key, by default Ctrl-b, followed by a command—% to split vertically, " to split horizontally, or arrow keys to move between panes.
+
+ tmux is also highly configurable through a .tmux.conf file. Users commonly remap the prefix to Ctrl-a, enable mouse support, tweak the status bar, and set intuitive
+ keybindings. Plugins extend it further, adding session saving, system monitoring, and themes.
+
+ While the learning curve can feel steep, the investment pays dividends. tmux rewards muscle memory, turning routine terminal work into a fluid, keyboard-driven experience. For
+ remote administration, pair programming, and everyday development, it remains an indispensable, quietly powerful companion for serious terminal users everywhere.
+
+ I see the system just notified me about new tools, but the user's original request was already completed. There's no new task here—just an informational notice. I'll keep my
+ response brief since there's nothing new to address.
+
+ The essay above is complete (300 words on tmux). The notice just reflects newly available tools — no action needed. Let me know if you'd like any edits to the essay.
+
+╭── π  > ⬢ Opus 4.8 · ◒ high > 🗑 omp-probe-KJPDw9 > ◫ 9.5%/1M ⟲ > $0.66 (sub) ▶───────────────────────────────────────────────────────────────────────◀ Write essay about tmux ──╮
+╰─                                                                                                                                                                              ─╯

--- a/internal/tmux/testdata/omp/idle.txt
+++ b/internal/tmux/testdata/omp/idle.txt
@@ -1,0 +1,44 @@
+
+╭─── omp v17.0.1 ──────────────────────────────────────────────────────────────────────────────────╮
+│                          │ Tips                                                                  │
+│      Welcome back!       │ # for prompt actions                                                  │
+│                          │ / for commands                                                        │
+│       ▀██████████▀       │ ! to run bash                                                         │
+│        ╘██    ██         │ $ to run python                                                       │
+│         ██    ██         │ ───────────────────────────────────────────────────────────────────── │
+│         ██    ██         │ LSP Servers                                                           │
+│        ▄██▄  ▄██▄        │ No LSP servers                                                        │
+│                          │                                                                       │
+│     Claude Opus 4.8      │                                                                       │
+│        anthropic         │                                                                       │
+│                          │ ───────────────────────────────────────────────────────────────────── │
+│                          │ Recent sessions                                                       │
+│                          │ No recent sessions                                                    │
+│                          │                                                                       │
+│                          │                                                                       │
+│                          │                                                                       │
+│                          │                                                                       │
+╰──────────────────────────┴───────────────────────────────────────────────────────────────────────╯
+ Tip: Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow ->
+      etc
+
+ Connected: svc-a:svc-a, svc-b:svc-b. Failed: svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…. Still connecting: svc-h:svc-h, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k, svc-l:svc-l…
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Update Available
+ New version 17.0.5 is available. Run: omp update
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ MCP finished with failures. Connected: svc-a:svc-a, svc-b:svc-b, svc-i:svc-i, svc-j:svc-j, svc-j:svc-k. Failed: svc-h:svc-h: HTTP 400: bad request:
+ Authorization header is badly formatted  [WWW-Authentica…; svc-c:svc-c: HTTP 401: {"jsonrpc":"2.0","id":null,"error":{"code":-32001,"message":"missing_…; svc-d:svc-d: HTTP
+ 401: {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-e:svc-e: HTTP 401: Unauthorized [WWW-Authenticate: Bearer
+ resource_metadata="https://svc…; svc-f:svc-f: HTTP 401: No token provided, please provide a valid API token. View the documen…; svc-g:svc-g: HTTP 401:
+ {"error":"invalid_token","error_description":"Missing or invalid acce…; svc-l:svc-l: HTTP 401: {"error":"Authentication required"} [WWW-Authenticate: Bearer resourc…
+
+╭── π  > ⬢ Opus 4.8 · ◒ high > 🗑 omp-probe-KJPDw9 > ◫ 5.7%/1M ⟲ > (sub) ▶────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+╰─                                                                                                                                                                              ─╯
+
+

--- a/internal/tmux/testdata/omp/permission.txt
+++ b/internal/tmux/testdata/omp/permission.txt
@@ -1,0 +1,44 @@
+
+
+ The user is asking me to write a 300-word essay about tmux without using any tools, so I'll compose it directly.
+
+ tmux: The Terminal Multiplexer
+
+ tmux is a terminal multiplexer, a tool that lets a single terminal window host multiple independent sessions, windows, and panes. For anyone who lives in the command line, it
+ transforms a flat, single-stream terminal into a persistent, organized workspace. Its power lies in a deceptively simple idea: decoupling the terminal session from the terminal
+ emulator that displays it.
+
+ The most celebrated feature is session persistence. Because tmux runs a server in the background, your sessions survive even when you disconnect. This is invaluable for remote
+ work over SSH. If your connection drops mid-task—a long compile, a database migration, a training run—the process keeps running. You simply reconnect and reattach with tmux
+ attach, finding everything exactly as you left it. This resilience alone justifies its place in any developer's toolkit.
+
+ Beyond persistence, tmux excels at spatial organization. A single window can be split into multiple panes, letting you edit code in one, watch logs in another, and run a shell
+ in a third, all visible simultaneously. Windows function like browser tabs, grouping related panes, while sessions hold collections of windows for entirely separate projects.
+ Navigation happens through a prefix key, by default Ctrl-b, followed by a command—% to split vertically, " to split horizontally, or arrow keys to move between panes.
+
+ tmux is also highly configurable through a .tmux.conf file. Users commonly remap the prefix to Ctrl-a, enable mouse support, tweak the status bar, and set intuitive
+ keybindings. Plugins extend it further, adding session saving, system monitoring, and themes.
+
+ While the learning curve can feel steep, the investment pays dividends. tmux rewards muscle memory, turning routine terminal work into a fluid, keyboard-driven experience. For
+ remote administration, pair programming, and everyday development, it remains an indispensable, quietly powerful companion for serious terminal users everywhere.
+
+ I see the system just notified me about new tools, but the user's original request was already completed. There's no new task here—just an informational notice. I'll keep my
+ response brief since there's nothing new to address.
+
+ The essay above is complete (300 words on tmux). The notice just reflects newly available tools — no action needed. Let me know if you'd like any edits to the essay.
+
+
+ run the command: echo hello-from-probe
+
+
+╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ $ echo hello-from-probe                                                                                                                                                        │
+├─── Output ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ hello-from-probe                                                                                                                                                               │
+│ ⟦Wall: 0.05s | Timeout: 300s⟧                                                                                                                                                  │
+╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+ ⠼ Running echo probe ⟦esc⟧
+
+╭── π  > ⬢ Opus 4.8 · ◒ high > 🗑 omp-probe-KJPDw9 > ◫ 9.6%/1M ⟲ > $0.71 (sub) ▶───────────────────────────────────────────────────────────────────────◀ Write essay about tmux ──╮
+╰─                                                                                                                                                                              ─╯

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -741,9 +741,15 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "omp", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
+	"omp": {
+		// omp (oh-my-pi) version banner, e.g. "╭─── omp v17.0.1". Must rank
+		// before codex: omp panes routinely show provider text like "openai"
+		// or "codex" that codex's loose patterns would otherwise claim.
+		regexp.MustCompile(`(?i)\bomp v\d+\.\d+\.\d+`),
+	},
 	"claude": {
 		// Avoid matching bare words like "claude-deck" in shell prompts/paths.
 		regexp.MustCompile(`(?i)\bclaude\s+code\b`),
@@ -820,10 +826,17 @@ func detectToolFromCommand(command string) string {
 			return "hermes"
 		case "pi":
 			return "pi"
+		case "omp":
+			return "omp"
 		}
 	}
 
 	switch {
+	// omp launch commands may name other tools in flags (e.g. --models
+	// claude-sonnet) or paths (~/.omp/agent-deck), so the token-boundary omp
+	// check must run before the loose substring matches below.
+	case strings.Contains(cmdLower, " omp ") || strings.HasPrefix(cmdLower, "omp "):
+		return "omp"
 	case strings.Contains(cmdLower, "claude"):
 		return "claude"
 	case strings.Contains(cmdLower, "gemini"):


### PR DESCRIPTION
## What problem does this solve?

agent-deck has no first-class support for omp (oh-my-pi, https://github.com/can1357/oh-my-pi, npm `@oh-my-pi/pi-coding-agent`) — a Pi fork with 40+ providers and role-based model routing. Sessions launched with `omp` fall through to the generic shell tool: no status detection, no instance-scoped resume, and (because omp drives other agent CLIs as subprocesses) dynamic tool detection re-classifies a running omp session as `codex`, flipping status detection to the wrong pattern set.

## Why this change

omp cannot ride the existing Pi adapter: `compatible_with` only accepts claude/codex, and omp's TUI chrome differs from Pi's, so it needs its own registry entry, status patterns, and spawn builder. The patterns are transcribed from real tmux captures of omp 17.0.1 (fixtures committed), the spawn builder mirrors `buildPiCommand` (`--continue --session-dir` scoped to the Agent Deck instance ID), and `resolveDynamicTool()` pins omp's identity so child-process detection (omp running the codex CLI as a subprocess) cannot rewrite it. Fork support is intentionally excluded from this first PR — core loop parity only.

## User impact

Users can run `agent-deck add <path> -c omp` (or launch) and get correct busy/waiting/permission-prompt status, instance-scoped session resume across restarts, and a stable tool identity. No behavior change for any other tool (covered by tests).

## Evidence

- Fixture-driven pattern tests against real captured panes: `internal/tmux/testdata/omp/{busy,idle,idle-after-task,permission}.txt`.
- Live validation on a deployed build: session created with `-c omp` spawns `bun ~/.local/bin/omp --continue --session-dir ~/.omp/agent-deck/<instance-id>`; status transitions running→waiting observed against tmux ground truth during real bridge heartbeats; restart resumes prior context.
- Re-detection regression observed live before the pin fix: an idle omp session that spawned the codex CLI child was rewritten to `tool=codex` within ~90 minutes; after the fix the identity is stable.
- Targeted packages pass in solo runs: `go test ./internal/session/ ./internal/tmux/` — ok (55s / 27s), including the new registry, pattern-fixture, spawn, and resolveDynamicTool tests.
- Full sandboxed suite is not reliable in my environment (WSL2 hosting a live agent-deck tmux fleet): several tmux-timing tests fail identically on a clean `upstream/main` worktree (e.g. TestCanRestartCursor, TestKillStaleControlClients_PreservesLiveSibling), so I'm treating CI as authoritative for the full matrix and have left that checklist box unchecked.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

## What actually bothered you

My human asked: "i want the orchestration layer of this setup to use omp instead of claude code which will give us the flexibility to change models as new ones emerge without disrupting the orchestration, bridge, etc."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — environment-flaky here (same tmux-timing tests fail on clean upstream/main; see Evidence); targeted packages pass solo, deferring full matrix to CI
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016z2ZLXk2dtZHVywp45RK41

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->
