### PR TITLE
feat(hermes): make R/restart resume the hermes session instead of a silent no-op

### DIFF
--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -1,14 +1,96 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
+
+	"al.essio.dev/pkg/shellescape"
 )
+
+// hermesSessionIDPattern matches a hermes session ID (e.g. "20260720_143254_a3db50"):
+// {YYYYMMDD}_{HHMMSS}_{hex}. Used to pick the ID column out of `hermes sessions
+// list` output and to reject header/garbage rows.
+var hermesSessionIDPattern = regexp.MustCompile(`^[0-9]{8}_[0-9]{6}_[0-9a-fA-F]+$`)
+
+// parseHermesSessionsLatestID returns the session ID of the first data row in
+// `hermes sessions list` output (the most recent, since the list is sorted
+// recent-first / queried with --limit 1). Columns are Title, Workspace, Last
+// Active, ID; the ID is the last whitespace-delimited token and is the only
+// column with no spaces, so it parses deterministically. Header and box-drawing
+// separator rows are skipped. Returns "" when no session row is present.
+func parseHermesSessionsLatestID(listOutput string) string {
+	seenHeader := false
+	for _, line := range strings.Split(listOutput, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 0 {
+			continue
+		}
+		last := fields[len(fields)-1]
+		if !seenHeader {
+			// Only read rows AFTER the table header (whose ID column is literally
+			// labelled "ID"), so a banner/notice printed above the table can't be
+			// mistaken for a session row. No header => not the expected table =>
+			// return "" (fail closed to a fresh restart).
+			if last == "ID" {
+				seenHeader = true
+			}
+			continue
+		}
+		if hermesSessionIDPattern.MatchString(last) {
+			return last
+		}
+	}
+	return ""
+}
+
+// hermesSessionsListTimeout bounds the `hermes sessions list` capture so a
+// wedged hermes binary can never hang a restart. Overridable in tests.
+var hermesSessionsListTimeout = 5 * time.Second
+
+// captureHermesSessionID queries hermes for the most-recent CLI session in the
+// given workspace and returns its ID, or "" if none is found or hermes errors.
+// This is how agent-deck learns the ID of the session running in a pane, since
+// hermes doesn't export it. workspace scopes the lookup to the pane's directory
+// so it doesn't pick up an unrelated session; empty workspace = most recent CLI
+// session overall (best-effort fallback). Any failure returns "" so restart
+// falls back to a fresh launch and never blocks.
+//
+// The hermes binary is taken as the first whitespace-delimited token of
+// GetToolCommand("hermes"); a custom `[hermes] command` must therefore be a
+// plain binary/path token (no shell quoting or embedded spaces), else the
+// lookup falls back to "" (fresh restart) rather than resuming.
+func captureHermesSessionID(workspace string) string {
+	// GetToolCommand may be "hermes" or a path; take the first token as the binary.
+	bin := strings.Fields(GetToolCommand("hermes"))
+	if len(bin) == 0 {
+		return ""
+	}
+	args := append(bin[1:], "sessions", "list", "--source", "cli", "--limit", "1")
+	if workspace != "" {
+		args = append(args, "--workspace", workspace)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), hermesSessionsListTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin[0], args...)
+	// WaitDelay force-closes the I/O pipes shortly after the context is
+	// cancelled, so a wedged hermes (or a lingering grandchild holding stdout)
+	// can't keep Output() blocked past the timeout — Output() otherwise waits on
+	// the pipe, not just the direct child.
+	cmd.WaitDelay = time.Second
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return parseHermesSessionsLatestID(string(out))
+}
 
 // HermesOptions holds launch options for Hermes Agent CLI sessions.
 // Binary: `hermes` from github.com/NousResearch/hermes-agent (MIT, v0.13.0+).
@@ -85,6 +167,14 @@ func (i *Instance) buildHermesCommand(baseCommand string) string {
 	}
 
 	cmd := GetToolCommand("hermes")
+
+	// Resume the captured hermes session when known. Hermes mints a fresh ID per
+	// launch and never exports it, so HermesSessionID is captured from
+	// `hermes sessions list` at restart time (see Instance.Restart). Empty on a
+	// first launch or an intentional fresh restart, which starts a new session.
+	if i.HermesSessionID != "" {
+		cmd += " --resume " + shellescape.Quote(i.HermesSessionID)
+	}
 
 	// Apply flags from ToolOptionsJSON (includes --yolo if set at session creation)
 	if len(i.ToolOptionsJSON) > 0 {

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -79,6 +79,9 @@ func captureHermesSessionID(workspace string) string {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), hermesSessionsListTimeout)
 	defer cancel()
+	// #nosec G204 -- bin[0] is the configured/built-in hermes binary (GetToolCommand),
+	// not runtime user input; args are fixed subcommand literals plus workspace, a
+	// filesystem path passed as an argv element (no shell), so no injection surface.
 	cmd := exec.CommandContext(ctx, bin[0], args...)
 	// WaitDelay force-closes the I/O pipes shortly after the context is
 	// cancelled, so a wedged hermes (or a lingering grandchild holding stdout)

--- a/internal/session/hermes_resume_test.go
+++ b/internal/session/hermes_resume_test.go
@@ -1,0 +1,121 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withFakeHermes puts a fake `hermes` executable (running the given /bin/sh
+// body) at the front of PATH for the test, so captureHermesSessionID invokes it
+// instead of a real hermes. HOME is already isolated by the package TestMain, so
+// GetToolCommand("hermes") resolves to the bare name and PATH lookup wins.
+func withFakeHermes(t *testing.T, shBody string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hermes"), []byte("#!/bin/sh\n"+shBody+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake hermes: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestCaptureHermesSessionID(t *testing.T) {
+	t.Run("normal output returns the id", func(t *testing.T) {
+		withFakeHermes(t, `printf 'Title Workspace LastActive ID\n--- --- --- ---\nFoo compass 1m 20260720_145826_0e92e7\n'`)
+		if got := captureHermesSessionID("/some/dir"); got != "20260720_145826_0e92e7" {
+			t.Errorf("capture = %q, want 20260720_145826_0e92e7", got)
+		}
+	})
+
+	t.Run("non-zero exit returns empty (fresh restart, no block)", func(t *testing.T) {
+		withFakeHermes(t, `exit 1`)
+		if got := captureHermesSessionID(""); got != "" {
+			t.Errorf("capture on hermes error = %q, want empty", got)
+		}
+	})
+
+	t.Run("hang is bounded by the timeout", func(t *testing.T) {
+		orig := hermesSessionsListTimeout
+		hermesSessionsListTimeout = 200 * time.Millisecond
+		t.Cleanup(func() { hermesSessionsListTimeout = orig })
+		withFakeHermes(t, `sleep 10`)
+
+		start := time.Now()
+		got := captureHermesSessionID("")
+		elapsed := time.Since(start)
+		if got != "" {
+			t.Errorf("capture on hang = %q, want empty", got)
+		}
+		if elapsed > 3*time.Second {
+			t.Errorf("capture took %v — timeout did not bound the wedged binary", elapsed)
+		}
+	})
+}
+
+// Hermes mints a new session ID each launch and never exports it (env/hook), so
+// agent-deck captures it from `hermes sessions list` and resumes with --resume.
+// These tests cover the two pure pieces: parsing the list output and building
+// the resume command.
+
+func TestParseHermesSessionsLatestID(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "typical list — first data row's ID (last column)",
+			out: "Title                        Workspace          Last Active   ID\n" +
+				"──────────────────────────────────────────────────────────────\n" +
+				"Slack Triage Summary         compass            16m ago       20260720_143254_a3db50\n" +
+				"—                            slackbot           20m ago       20260720_142828_287a92\n",
+			want: "20260720_143254_a3db50",
+		},
+		{
+			name: "row with dashes for empty title/workspace",
+			out: "Title  Workspace  Last Active  ID\n" +
+				"----------------------------------\n" +
+				"—      —          yesterday    20260718_230951_14294a78\n",
+			want: "20260718_230951_14294a78",
+		},
+		{"empty output", "", ""},
+		{"header + separator only", "Title Workspace Last Active ID\n──────────────\n", ""},
+		{"garbage last column ignored", "Title Workspace Last Active ID\n──────\nsome free text without an id\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseHermesSessionsLatestID(tc.out); got != tc.want {
+				t.Errorf("parseHermesSessionsLatestID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildHermesCommand_ResumeWhenSessionIDKnown(t *testing.T) {
+	// Package TestMain isolates HOME, so LoadUserConfig sees a clean config.
+	withID := &Instance{Tool: "hermes", Command: "hermes", HermesSessionID: "20260720_143254_a3db50"}
+	cmd := withID.buildHermesCommand("hermes")
+	if !strings.Contains(cmd, "--resume 20260720_143254_a3db50") {
+		t.Errorf("resume command = %q, want it to contain `--resume 20260720_143254_a3db50`", cmd)
+	}
+
+	fresh := (&Instance{Tool: "hermes", Command: "hermes"}).buildHermesCommand("hermes")
+	if strings.Contains(fresh, "--resume") {
+		t.Errorf("fresh command = %q, must NOT contain --resume when no session id is known", fresh)
+	}
+}
+
+func TestCanRestart_Hermes_ResumableWhileAlive(t *testing.T) {
+	// The reported bug: a live hermes session couldn't be restarted (silent
+	// no-op) because hermes had no resume support declared. Hermes does support
+	// resume, so it must be restartable regardless of liveness.
+	i := &Instance{Tool: "hermes", Status: StatusIdle}
+	if !i.CanRestart() {
+		t.Errorf("hermes CanRestart() = false, want true (hermes supports --resume)")
+	}
+	if !i.CanRestartFresh() {
+		t.Errorf("hermes CanRestartFresh() = false, want true")
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -225,8 +225,11 @@ type Instance struct {
 
 	// Hermes CLI integration. Hermes mints a new session ID each launch and does
 	// not export it (no env var / hook), so agent-deck captures it from
-	// `hermes sessions list` at restart time and resumes with --resume.
-	HermesSessionID string `json:"hermes_session_id,omitempty"`
+	// `hermes sessions list` at restart time and resumes with --resume. Not
+	// persisted (json:"-"): it is re-captured on every restart, so it needs no
+	// lifetime beyond a single Restart() call — which also keeps it out of the
+	// JSON marshaling that could otherwise race the restart-time write.
+	HermesSessionID string `json:"-"`
 	// restartEnv contains one-shot environment overrides while RestartWithEnv is
 	// building the replacement process. It is cleared before the call returns.
 	restartEnv map[string]string

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -222,6 +222,11 @@ type Instance struct {
 	// pendingCodexRestartWarning is consumed by UI/CLI after Restart() succeeds.
 	// It is intentionally transient and never persisted.
 	pendingCodexRestartWarning string `json:"-"`
+
+	// Hermes CLI integration. Hermes mints a new session ID each launch and does
+	// not export it (no env var / hook), so agent-deck captures it from
+	// `hermes sessions list` at restart time and resumes with --resume.
+	HermesSessionID string `json:"hermes_session_id,omitempty"`
 	// restartEnv contains one-shot environment overrides while RestartWithEnv is
 	// building the replacement process. It is cleared before the call returns.
 	restartEnv map[string]string
@@ -5323,6 +5328,12 @@ func (i *Instance) clearSessionBindingForFreshStart() {
 		i.CopilotDetectedAt = time.Time{}
 		i.CopilotStartedAt = 0
 	}
+
+	if i.Tool == "hermes" {
+		// Drop the captured resume ID so the next launch starts a new session
+		// and Restart() re-captures rather than resuming the old conversation.
+		i.HermesSessionID = ""
+	}
 }
 
 func (i *Instance) recreateTmuxSession() {
@@ -6768,6 +6779,15 @@ func (i *Instance) restart(env map[string]string) error {
 		command = i.buildOpenCodeCommand("opencode")
 	} else if IsCodexCompatible(i.Tool) && i.CodexSessionID != "" {
 		command = i.buildCodexCommand(i.Command)
+	} else if i.Tool == "hermes" {
+		// Re-capture the pane's hermes session ID on EVERY restart (hermes
+		// doesn't export it). Overwriting rather than caching once self-heals a
+		// stale ID: if the previously-resumed session was pruned, the query
+		// returns the current most-recent session, or "" — in which case
+		// buildHermesCommand starts fresh instead of resuming a dead ID forever.
+		// Scoped to the working dir to avoid picking up an unrelated session.
+		i.HermesSessionID = captureHermesSessionID(i.EffectiveWorkingDir())
+		command = i.buildHermesCommand(i.Command)
 	} else {
 		// Route to appropriate command builder based on tool
 		switch {
@@ -6791,8 +6811,6 @@ func (i *Instance) restart(env map[string]string) error {
 			command = i.buildCrushCommand(i.Command)
 		case i.Tool == "cursor":
 			command = i.buildCursorCommand(i.Command, true)
-		case i.Tool == "hermes":
-			command = i.buildHermesCommand(i.Command)
 		default:
 			// Check if this is a custom tool with session resume config
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -7194,6 +7212,14 @@ func (i *Instance) CanRestart() bool {
 		return true
 	}
 
+	// Hermes resumes via `--resume <id>`; the ID is captured from
+	// `hermes sessions list` at restart time. Always restartable (resumes when a
+	// session is found, else starts fresh) rather than only when dead/errored,
+	// which left a live hermes session silently un-restartable.
+	if i.Tool == "hermes" {
+		return true
+	}
+
 	// Custom tools: check if they have session resume support
 	if i.CanRestartGeneric() {
 		return true
@@ -7217,6 +7243,10 @@ func (i *Instance) CanRestartFresh() bool {
 	}
 	if i.Tool == "codex" {
 		return i.CodexSessionID != ""
+	}
+	// Hermes fresh-restart discards the resume binding and starts a new session.
+	if i.Tool == "hermes" {
+		return true
 	}
 	return i.CanRestartGeneric()
 }


### PR DESCRIPTION
## What problem does this solve?

Pressing `R` (restart) on a live **hermes** tool session does nothing — a silent no-op with no error. `CanRestart()` only allowed restarting non-resume tools when dead/errored, and hermes had no resume support wired up, so a running hermes session couldn't be restarted and nothing explained why.

## Why this change

Hermes *does* support resume (`hermes --resume <id>`), but it mints a new session ID each launch and never exposes it to a launcher: no env var, no hook, and `--pass-session-id` only injects the ID into the agent's system prompt. Its only machine-readable source of the current ID is `hermes sessions list` (the `ID` column is the only space-free column). So the model has to be: let hermes mint the ID, capture it at restart time, and resume by it.

- `CanRestart()`/`CanRestartFresh()` now return true for hermes.
- `Restart()` re-captures the pane's session ID via `hermes sessions list --source cli --limit 1 --workspace <cwd>` into a new `HermesSessionID` field; `buildHermesCommand` then appends `--resume <id>`. Empty capture → fresh launch.
- **Re-capturing every restart** (rather than caching once) self-heals a stale ID: if the prior session was pruned, the query returns the current most-recent or `""` → fresh, so `R` can never wedge on a dead ID.
- The capture shell-out is bounded by a context timeout **and** `cmd.WaitDelay`, so a wedged hermes (or a grandchild holding stdout) can't block a restart.
- `T`/restart-fresh clears `HermesSessionID` to start a new session.

Known limitation (documented in code): if you run two hermes panes in the *same* directory, the workspace-scoped "most-recent" lookup could resume the wrong one.

## User impact

`R` on a hermes session now restarts it and resumes the same conversation (`hermes --resume <id>`); `T` restarts fresh. Previously `R`/`T` silently did nothing on a live hermes session. Other tools are unaffected.

## Evidence

Before: `case "R"` gated on `CanRestart()`, which returned false for a live hermes session, falling through to `return h, nil` with no `setError` — silent no-op.

After — the capture works against a real hermes install (session ID redacted to its shape):

    $ hermes sessions list --source cli --limit 1
    Title                        Workspace   Last Active   ID
    ─────────────────────────────────────────────────────────
    Slack Message Triage and D   compass     10m ago       <YYYYMMDD_HHMMSS_hex>
    # parser extracts the last (space-free) column → builds:  hermes --resume <YYYYMMDD_HHMMSS_hex>

Sandboxed tests for the changed package pass:

    $ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= \
        go test ./internal/session/ -run 'Hermes|CanRestart|ParseHermes|CaptureHermes'
    ok  github.com/asheshgoplani/agent-deck/internal/session

The new `TestCaptureHermesSessionID/hang_is_bounded_by_the_timeout` (fake hermes that `sleep`s while a child holds stdout) surfaced a real bug — `exec.CommandContext(...).Output()` was **not** bounded by the timeout until `cmd.WaitDelay` was added — and now passes at ~0.2s.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you

My human asked: *"the restart button 'R' doesn't work on home/hermes session"*, and when I proposed a fresh-relaunch fix, corrected me: *"hermes cli allow you to resume a session with -r PROJECT_NAME"* — i.e. they want `R` to actually resume the hermes conversation, not just relaunch it.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed (changed package `./internal/session/` verified sandboxed above; full `./...` left to the validation pipeline — the `internal/ui` suite exceeds 10m locally)
- [ ] Hot-path timing evidence — N/A: the added `hermes sessions list` shell-out runs only on a user-initiated restart (bounded by timeout+WaitDelay), not on any list/status/render path
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes sessions can now resume previous conversations after a restart.
  * Added support for fresh restarts that begin without the previous Hermes conversation.
  * Hermes sessions are now recognized as restartable.
* **Bug Fixes**
  * Improved session recovery by refreshing the active Hermes session ID on each restart.
  * Hermes resume is only applied when a valid session ID is available, with timeouts and safer parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->