### PR TITLE
fix: reap leaked tmux terminal bridge on dead websocket peer

### DIFF
--- a/internal/web/handlers_ws.go
+++ b/internal/web/handlers_ws.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -37,6 +38,15 @@ var wsUpgrader = websocket.Upgrader{
 	WriteBufferSize: 4096,
 	CheckOrigin:     allowWSOrigin,
 }
+
+// WebSocket keepalive tunables. The terminal socket sends protocol-level pings
+// every wsPingPeriod and tears the connection down if no pong (or any message)
+// arrives within wsPongWait, so a vanished peer can't leave the read loop — and
+// its tmux attach bridge — blocked forever. Overridable in tests.
+var (
+	wsPongWait   = 60 * time.Second
+	wsPingPeriod = (wsPongWait * 9) / 10
+)
 
 func allowWSOrigin(r *http.Request) bool {
 	origin := strings.TrimSpace(r.Header.Get("Origin"))
@@ -87,6 +97,42 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+
+	// Keepalive so dead peers are detected and the deferred bridge teardown
+	// actually runs. Without this, an idle session whose client vanished
+	// (network drop, mobile app killed) leaves the read loop below blocked
+	// forever in ReadMessage, so `defer bridge.Close()` never fires and the
+	// tmux attach client leaks. Under `window-size largest` a single leaked
+	// wide client then pins the shared window geometry for every other viewer
+	// — the symptom being a phone terminal that stops wrapping to its screen.
+	// We send protocol-level pings and require a pong within pongWait; both
+	// browsers and URLSessionWebSocketTask answer pings automatically.
+	pongWait, pingPeriod := wsPongWait, wsPingPeriod
+	_ = conn.SetReadDeadline(time.Now().Add(pongWait))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+	stopPing := make(chan struct{})
+	defer close(stopPing)
+	go func() {
+		ticker := time.NewTicker(pingPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopPing:
+				return
+			case <-ticker.C:
+				// WriteControl may be called concurrently with the writer. A
+				// transient send failure (e.g. brief writer-lock contention)
+				// must not permanently stop pings and strand a healthy peer —
+				// the read deadline is the sole liveness arbiter, so just retry
+				// on the next tick. A genuinely dead conn is reaped read-side,
+				// after which close(stopPing) ends this goroutine.
+				_ = conn.WriteControl(websocket.PingMessage, nil,
+					time.Now().Add(10*time.Second))
+			}
+		}
+	}()
 
 	writer := newWSConnWriter(conn)
 
@@ -146,7 +192,16 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 	for {
 		_, payload, err := conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(
+			// A keepalive read-deadline reap surfaces as a net.Error timeout,
+			// which IsUnexpectedCloseError treats as expected — so log it
+			// explicitly, otherwise a dead-peer teardown leaves no trace and is
+			// indistinguishable from a normal close in production logs.
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				logging.ForComponent(logging.CompWeb).Warn("websocket_keepalive_timeout",
+					slog.String("session_id", sessionID),
+					slog.String("error", err.Error()))
+			} else if websocket.IsUnexpectedCloseError(
 				err,
 				websocket.CloseNormalClosure,
 				websocket.CloseGoingAway,
@@ -158,6 +213,8 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
+		// A real message is also liveness — extend the deadline alongside pongs.
+		_ = conn.SetReadDeadline(time.Now().Add(pongWait))
 
 		var msg wsClientMessage
 		if err := json.Unmarshal(payload, &msg); err != nil {

--- a/internal/web/handlers_ws_keepalive_test.go
+++ b/internal/web/handlers_ws_keepalive_test.go
@@ -1,0 +1,163 @@
+//go:build !windows
+
+package web
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// tmuxClientCount returns how many clients are attached to a tmux session on the
+// default (env-selected) server. Errors — including "no server" — count as 0.
+func tmuxClientCount(session string) int {
+	out, err := exec.Command("tmux", "list-clients", "-t", session, "-F", "x").CombinedOutput()
+	if err != nil {
+		return 0
+	}
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return 0
+	}
+	return len(strings.Split(s, "\n"))
+}
+
+// waitForClientCount polls until the session has exactly want clients (tmux
+// registers/removes attach clients slightly after the process starts/dies).
+func waitForClientCount(session string, want int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if tmuxClientCount(session) == want {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return tmuxClientCount(session) == want
+}
+
+func newKeepaliveTestServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+
+	sessionName := fmt.Sprintf("agentdeck_ws_keepalive_%d", time.Now().UnixNano())
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", sessionName).CombinedOutput(); err != nil {
+		t.Skipf("tmux new-session unavailable: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", sessionName).Run() })
+
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Profile: "work"})
+	srv.menuData = &fakeMenuDataLoader{
+		snapshot: &MenuSnapshot{
+			Profile: "work",
+			Items: []MenuItem{{
+				Type:    MenuItemTypeSession,
+				Session: &MenuSession{ID: "sess-ka", TmuxSession: sessionName},
+			}},
+		},
+	}
+	testServer := httptest.NewServer(srv.Handler())
+	t.Cleanup(testServer.Close)
+	return testServer, sessionName
+}
+
+// TestWSKeepaliveReapsDeadPeer proves the leak fix: a client that stops
+// answering pings (a vanished peer — network drop / killed mobile app) is
+// detected via the read deadline, so the handler returns and its deferred
+// bridge.Close() kills the tmux attach instead of leaking it forever.
+func TestWSKeepaliveReapsDeadPeer(t *testing.T) {
+	requireTmuxForWebIntegration(t)
+
+	origWait, origPeriod := wsPongWait, wsPingPeriod
+	wsPongWait, wsPingPeriod = 700*time.Millisecond, 250*time.Millisecond
+	defer func() { wsPongWait, wsPingPeriod = origWait, origPeriod }()
+
+	testServer, sessionName := newKeepaliveTestServer(t)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL(testServer.URL, "/ws/session/sess-ka"), nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("dial failed with status %d: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Attach while healthy (gorilla auto-pongs during these reads), and confirm
+	// the bridge's tmux client is present before we simulate the peer dying.
+	waitForStatusOrSkipOnAttachFailure(t, conn, "terminal_attached")
+	if !waitForClientCount(sessionName, 1, time.Second) {
+		t.Fatalf("expected an attached tmux client after terminal_attached, got %d", tmuxClientCount(sessionName))
+	}
+
+	// Now the peer "vanishes": stop answering pings. Keep reading so control
+	// frames are processed; expect the server to close once the pong deadline
+	// lapses.
+	conn.SetPingHandler(func(string) error { return nil })
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("server did not close the dead-peer connection within timeout")
+	}
+
+	if !waitForClientCount(sessionName, 0, 2*time.Second) {
+		t.Fatalf("tmux attach client leaked: still attached after keepalive teardown")
+	}
+}
+
+// TestWSKeepaliveHealthyClientSurvives guards against over-aggressive teardown:
+// a client that answers pings (gorilla auto-pongs while reading) must stay
+// attached well past pongWait.
+func TestWSKeepaliveHealthyClientSurvives(t *testing.T) {
+	requireTmuxForWebIntegration(t)
+
+	origWait, origPeriod := wsPongWait, wsPingPeriod
+	wsPongWait, wsPingPeriod = 300*time.Millisecond, 100*time.Millisecond
+	defer func() { wsPongWait, wsPingPeriod = origWait, origPeriod }()
+
+	testServer, sessionName := newKeepaliveTestServer(t)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL(testServer.URL, "/ws/session/sess-ka"), nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("dial failed with status %d: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	waitForStatusOrSkipOnAttachFailure(t, conn, "terminal_attached")
+
+	// Drain frames in the background so gorilla auto-pongs the server's pings.
+	// A single blocking ReadMessage services all inbound control frames; the
+	// deferred conn.Close() unblocks it at test end. (gorilla forbids re-reading
+	// after a read-deadline timeout, so we set one deadline past the test.)
+	go func() {
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Several pongWait intervals later the connection should still be attached.
+	time.Sleep(5 * wsPongWait)
+	if tmuxClientCount(sessionName) == 0 {
+		t.Fatalf("healthy ponging client was reaped: tmux attach dropped before it should")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

A dead WebSocket terminal client (network drop, mobile app killed) is never cleaned up when the session is idle, so its `tmux attach` client leaks. Under `window-size=largest` a single leaked client pins the shared window geometry for every other viewer — the visible symptom is a phone/web terminal that stops wrapping to its own screen.

## Why this change

`handleSessionWS` blocks in `conn.ReadMessage()` with no read deadline and no ping/pong. `streamOutput` only notices a dead peer when it *writes* output, so an idle session (no output) never trips it — the goroutine hangs forever and the deferred `bridge.Close()` never runs, leaking the attach client. This adds protocol-level ping/pong keepalive with a read deadline (the standard gorilla pattern) so a vanished peer is detected and torn down. A failed ping send doesn't tear anything down by itself — the read deadline is the sole liveness arbiter — so a transient write hiccup can't strand a healthy connection. Browsers and `URLSessionWebSocketTask` answer pings automatically, so no client change is needed.

The one new "network call" the security sweep flags — `conn.WriteControl(websocket.PingMessage, ...)` — is a WebSocket ping *control frame sent on the already-established connection*, not a new outbound connection or a call to any external host. It carries no payload.

## User impact

Dead terminal viewers are reaped instead of leaking their tmux attach client indefinitely. No change for a healthy connection.

## Evidence

Observed leak on a running server: a phone that had disconnected left a `tmux attach` client alive for 2h+ across app relaunches, pinning the window at its old (wider) size so other viewers couldn't get their own geometry:

    $ tmux -L agent-deck list-clients -t <session>
    /dev/ttys004  187x47  (attached)     # pid 71834, 2h15m old — the dead phone's bridge

Sandboxed (touched package):

    $ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/web/
    ok  github.com/asheshgoplani/agent-deck/internal/web

`TestWSKeepaliveReapsDeadPeer` drives a non-ponging client and asserts the tmux attach client disappears; `TestWSKeepaliveHealthyClientSurvives` guards against reaping a healthy peer.

Revert-check: reverting the production hunk in `handlers_ws.go` removes the keepalive (and the `wsPongWait`/`wsPingPeriod` tunables the test drives), so the package no longer builds and the test cannot pass — the test is inseparable from the fix:

    internal/web/handlers_ws_keepalive_test.go:129: undefined: wsPongWait
    FAIL  github.com/asheshgoplani/agent-deck/internal/web [build failed]

No hot-path timing evidence: the keepalive is a background ticker (one ping per ~54s per connection) and adds nothing to the per-output-byte path.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

**Prompt / session log (optional):** —

## What actually bothered you

My human was debugging their iPhone agent-deck terminal and said, verbatim: "the terminal is still not fully wrapping the text, pinching is not working as it should". The root cause was a leaked tmux attach client from an earlier, wider phone connection that the server never cleaned up because the peer had vanished without a clean WebSocket close.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — background ticker only, no per-output overhead (noted in Evidence)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket connection keepalive/liveness monitoring with periodic ping/pong handling.
  * Automatically closes and reaps unresponsive peers to keep sessions healthy.

* **Tests**
  * Added a WebSocket keepalive test to confirm dead peers are reaped and underlying session attachments are released.
  * Added a WebSocket keepalive test to confirm healthy clients remain connected during sustained activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->