### PR TITLE
feat: add Claude and Codex reasoning effort pickers

### DIFF
--- a/cmd/agent-deck/web_cmd_test.go
+++ b/cmd/agent-deck/web_cmd_test.go
@@ -14,7 +14,7 @@ import (
 // only used to verify that buildWebServer wires whatever is passed in.
 type noopMutator struct{}
 
-func (noopMutator) CreateSession(string, string, string, string, string) (string, error) {
+func (noopMutator) CreateSession(string, string, string, string, string, string) (string, error) {
 	return "", nil
 }
 func (noopMutator) StartSession(string) error          { return nil }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1239,6 +1239,10 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 		}
 	}
 
+	if opts != nil && strings.TrimSpace(opts.Effort) != "" {
+		flags = append(flags, "--effort "+shellescape.Quote(strings.TrimSpace(opts.Effort)))
+	}
+
 	// Options-level flags
 	if opts != nil {
 		if opts.SkipPermissions {
@@ -1511,6 +1515,15 @@ func (i *Instance) resolveCodexModelFlag() string {
 	return ""
 }
 
+func (i *Instance) resolveCodexReasoningEffortFlag() string {
+	opts := i.GetCodexOptions()
+	if opts != nil && strings.TrimSpace(opts.ReasoningEffort) != "" {
+		value := "model_reasoning_effort=" + strings.TrimSpace(opts.ReasoningEffort)
+		return " --config " + shellescape.Quote(value)
+	}
+	return ""
+}
+
 func (i *Instance) resolveCodexCommand(baseCommand string) string {
 	command := strings.TrimSpace(baseCommand)
 	if i.Tool == "codex" && (command == "" || command == "codex") {
@@ -1646,6 +1659,7 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 
 	yoloFlag := i.resolveCodexYoloFlag()
 	modelFlag := i.resolveCodexModelFlag()
+	reasoningFlag := i.resolveCodexReasoningEffortFlag()
 	command := i.resolveCodexCommand(baseCommand)
 	codexHome := getCodexHomeDirForCommand(command)
 
@@ -1683,16 +1697,16 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 			slog.String("instance_id", i.ID),
 			slog.String("title", i.Title),
 			slog.String("sid", i.CodexSessionID))
-		return envPrefix + fmt.Sprintf("%s%s%s fork %s",
-			command, yoloFlag, modelFlag, i.CodexSessionID)
+		return envPrefix + fmt.Sprintf("%s%s%s%s fork %s",
+			command, yoloFlag, modelFlag, reasoningFlag, i.CodexSessionID)
 	}
 
 	if i.CodexSessionID != "" {
-		return envPrefix + fmt.Sprintf("%s%s%s resume %s",
-			command, yoloFlag, modelFlag, i.CodexSessionID)
+		return envPrefix + fmt.Sprintf("%s%s%s%s resume %s",
+			command, yoloFlag, modelFlag, reasoningFlag, i.CodexSessionID)
 	}
 
-	return envPrefix + command + yoloFlag + modelFlag
+	return envPrefix + command + yoloFlag + modelFlag + reasoningFlag
 }
 
 // buildCodexCommandWithPrompt builds the Codex launch command with an initial
@@ -7663,6 +7677,7 @@ func (i *Instance) buildCodexForkCommandForTarget(target *Instance, baseCommand 
 		shellescape.Quote(target.ID), shellescape.Quote(target.Title), shellescape.Quote(target.Tool), shellescape.Quote(sessionProfileEnvValue()))
 	yoloFlag := target.resolveCodexYoloFlag()
 	modelFlag := target.resolveCodexModelFlag()
+	reasoningFlag := target.resolveCodexReasoningEffortFlag()
 	command := target.resolveCodexCommand(baseCommand)
 	if isCodexHomeExplicit() {
 		codexHome := strings.TrimSpace(getCodexHomeDir())
@@ -7675,7 +7690,7 @@ func (i *Instance) buildCodexForkCommandForTarget(target *Instance, baseCommand 
 			envPrefix += "CODEX_HOME=" + shellescape.Quote(codexHome) + " "
 		}
 	}
-	return envPrefix + fmt.Sprintf("%s%s%s fork %s", command, yoloFlag, modelFlag, shellescape.Quote(i.CodexSessionID)), nil
+	return envPrefix + fmt.Sprintf("%s%s%s%s fork %s", command, yoloFlag, modelFlag, reasoningFlag, shellescape.Quote(i.CodexSessionID)), nil
 }
 
 // CreateForkedCodexInstanceWithOptions creates a forked Codex instance. Mirrors
@@ -7704,6 +7719,12 @@ func (i *Instance) CreateForkedCodexInstanceWithOptions(
 		baseCommand = "codex"
 	}
 	forked.Command = baseCommand
+	if parentOpts := i.GetCodexOptions(); parentOpts != nil && parentOpts.ReasoningEffort != "" {
+		forkOpts := &CodexOptions{ReasoningEffort: parentOpts.ReasoningEffort}
+		if err := forked.SetCodexOptions(forkOpts); err != nil {
+			return nil, "", fmt.Errorf("persist fork reasoning effort: %w", err)
+		}
+	}
 
 	cmd, err := i.buildCodexForkCommandForTarget(forked, baseCommand)
 	if err != nil {

--- a/internal/session/instance_codex_fork_test.go
+++ b/internal/session/instance_codex_fork_test.go
@@ -75,6 +75,31 @@ func TestCreateForkedCodexInstance_UsesWorktreeAndForkCommand(t *testing.T) {
 	}
 }
 
+func TestCreateForkedCodexInstance_PreservesReasoningEffort(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	sid := "11111111-2222-3333-4444-555555555555"
+	seedCodexRollout(t, home, sid)
+
+	parent := NewInstanceWithTool("cx parent", "/tmp/original", "codex")
+	parent.CodexSessionID = sid
+	parent.CodexDetectedAt = time.Now()
+	if err := parent.ApplyLaunchReasoningEffort("high"); err != nil {
+		t.Fatalf("ApplyLaunchReasoningEffort: %v", err)
+	}
+
+	forked, cmd, err := parent.CreateForkedCodexInstanceWithOptions("cx fork", "", nil)
+	if err != nil {
+		t.Fatalf("CreateForkedCodexInstanceWithOptions: %v", err)
+	}
+	if got := forked.LaunchReasoningEffort(); got != "high" {
+		t.Fatalf("forked LaunchReasoningEffort() = %q, want high", got)
+	}
+	if !strings.Contains(cmd, "--config model_reasoning_effort=high") {
+		t.Fatalf("fork command missing reasoning effort: %s", cmd)
+	}
+}
+
 func TestCreateForkedCodexInstance_UsesConfiguredCodexHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/session/launch_command_benchmark_test.go
+++ b/internal/session/launch_command_benchmark_test.go
@@ -1,0 +1,30 @@
+package session
+
+import "testing"
+
+func BenchmarkBuildClaudeExtraFlagsDefault(b *testing.B) {
+	home := b.TempDir()
+	b.Setenv("HOME", home)
+	b.Setenv("XDG_CONFIG_HOME", "")
+	ClearUserConfigCache()
+	b.Cleanup(ClearUserConfigCache)
+	inst := NewInstanceWithTool("bench-claude", home, "claude")
+	opts := &ClaudeOptions{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = inst.buildClaudeExtraFlags(opts)
+	}
+}
+
+func BenchmarkBuildCodexCommandDefault(b *testing.B) {
+	home := b.TempDir()
+	b.Setenv("HOME", home)
+	b.Setenv("XDG_CONFIG_HOME", "")
+	ClearUserConfigCache()
+	b.Cleanup(ClearUserConfigCache)
+	inst := NewInstanceWithTool("bench-codex", home, "codex")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = inst.buildCodexCommand("codex")
+	}
+}

--- a/internal/session/reasoning_effort.go
+++ b/internal/session/reasoning_effort.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var (
+	claudeReasoningEfforts = []string{"low", "medium", "high", "xhigh", "max"}
+	codexReasoningEfforts  = []string{"minimal", "low", "medium", "high", "xhigh"}
+)
+
+// LaunchReasoningEffortsForTool returns the supported per-session effort
+// overrides in display order. An empty selection means the tool default.
+func LaunchReasoningEffortsForTool(tool string) []string {
+	var efforts []string
+	switch {
+	case IsClaudeCompatible(tool):
+		efforts = claudeReasoningEfforts
+	case IsCodexCompatible(tool):
+		efforts = codexReasoningEfforts
+	}
+	return append([]string(nil), efforts...)
+}
+
+// SupportsLaunchReasoningEffort reports whether Agent Deck can pass a native
+// per-session reasoning/effort override to the selected tool.
+func SupportsLaunchReasoningEffort(tool string) bool {
+	return len(LaunchReasoningEffortsForTool(tool)) > 0
+}
+
+// ValidateLaunchReasoningEffort checks a user-supplied override without
+// mutating a session. Empty is always valid and means tool default.
+func ValidateLaunchReasoningEffort(tool, effort string) error {
+	effort = strings.TrimSpace(effort)
+	if effort == "" {
+		return nil
+	}
+	valid := LaunchReasoningEffortsForTool(tool)
+	if len(valid) == 0 {
+		return fmt.Errorf("reasoning effort is not supported for tool %q", tool)
+	}
+	if !slices.Contains(valid, effort) {
+		return fmt.Errorf("invalid reasoning effort %q for %s (expected one of: %s)",
+			effort, tool, strings.Join(valid, ", "))
+	}
+	return nil
+}
+
+// LaunchReasoningEffort returns the persisted per-session override. Empty
+// means the underlying tool chooses its default.
+func (i *Instance) LaunchReasoningEffort() string {
+	if i == nil {
+		return ""
+	}
+	switch {
+	case IsClaudeCompatible(i.Tool):
+		if opts := i.GetClaudeOptions(); opts != nil {
+			return strings.TrimSpace(opts.Effort)
+		}
+	case IsCodexCompatible(i.Tool):
+		if opts := i.GetCodexOptions(); opts != nil {
+			return strings.TrimSpace(opts.ReasoningEffort)
+		}
+	}
+	return ""
+}
+
+// ApplyLaunchReasoningEffort validates and persists a per-session override in
+// the tool-specific options store. Empty clears the override.
+func (i *Instance) ApplyLaunchReasoningEffort(effort string) error {
+	if i == nil {
+		return fmt.Errorf("cannot set reasoning effort on a nil session")
+	}
+	effort = strings.TrimSpace(effort)
+	valid := LaunchReasoningEffortsForTool(i.Tool)
+	if len(valid) == 0 {
+		return fmt.Errorf("reasoning effort is not supported for tool %q", i.Tool)
+	}
+	if err := ValidateLaunchReasoningEffort(i.Tool, effort); err != nil {
+		return err
+	}
+
+	switch {
+	case IsClaudeCompatible(i.Tool):
+		opts := i.GetClaudeOptions()
+		if opts == nil {
+			userConfig, _ := LoadUserConfig()
+			opts = NewClaudeOptions(userConfig)
+		}
+		opts.Effort = effort
+		return i.SetClaudeOptions(opts)
+	case IsCodexCompatible(i.Tool):
+		opts := i.GetCodexOptions()
+		if opts == nil {
+			userConfig, _ := LoadUserConfig()
+			opts = NewCodexOptions(userConfig)
+		}
+		opts.ReasoningEffort = effort
+		return i.SetCodexOptions(opts)
+	default:
+		return fmt.Errorf("reasoning effort is not supported for tool %q", i.Tool)
+	}
+}

--- a/internal/session/reasoning_effort_test.go
+++ b/internal/session/reasoning_effort_test.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestApplyLaunchReasoningEffort_ClaudePersistsAndLaunches(t *testing.T) {
+	extraArgsTestEnv(t)
+	inst := NewInstanceWithTool("effort-claude", t.TempDir(), "claude")
+
+	if err := inst.ApplyLaunchReasoningEffort("high"); err != nil {
+		t.Fatalf("ApplyLaunchReasoningEffort(high): %v", err)
+	}
+	if got := inst.LaunchReasoningEffort(); got != "high" {
+		t.Fatalf("LaunchReasoningEffort() = %q, want high", got)
+	}
+	if cmd := inst.buildClaudeCommand("claude"); !strings.Contains(cmd, "--effort high") {
+		t.Fatalf("Claude launch command missing --effort high:\n%s", cmd)
+	}
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	revived := &Instance{}
+	if err := json.Unmarshal(data, revived); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := revived.LaunchReasoningEffort(); got != "high" {
+		t.Fatalf("revived LaunchReasoningEffort() = %q, want high", got)
+	}
+}
+
+func TestApplyLaunchReasoningEffort_CodexPersistsAndLaunches(t *testing.T) {
+	inst := NewInstanceWithTool("effort-codex", t.TempDir(), "codex")
+
+	if err := inst.ApplyLaunchReasoningEffort("xhigh"); err != nil {
+		t.Fatalf("ApplyLaunchReasoningEffort(xhigh): %v", err)
+	}
+	if got := inst.LaunchReasoningEffort(); got != "xhigh" {
+		t.Fatalf("LaunchReasoningEffort() = %q, want xhigh", got)
+	}
+	cmd := inst.buildCodexCommand("codex")
+	if !strings.Contains(cmd, "--config model_reasoning_effort=xhigh") {
+		t.Fatalf("Codex launch command missing reasoning override:\n%s", cmd)
+	}
+}
+
+func TestApplyLaunchReasoningEffort_ValidatesPerToolValues(t *testing.T) {
+	tests := []struct {
+		tool   string
+		effort string
+	}{
+		{tool: "claude", effort: "minimal"},
+		{tool: "codex", effort: "max"},
+		{tool: "shell", effort: "high"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tool+"/"+tt.effort, func(t *testing.T) {
+			inst := NewInstanceWithTool("invalid-effort", t.TempDir(), tt.tool)
+			if err := inst.ApplyLaunchReasoningEffort(tt.effort); err == nil {
+				t.Fatalf("ApplyLaunchReasoningEffort(%q) for %s succeeded, want validation error", tt.effort, tt.tool)
+			}
+		})
+	}
+}
+
+func TestLaunchReasoningEffortsForTool(t *testing.T) {
+	if got := LaunchReasoningEffortsForTool("claude"); strings.Join(got, ",") != "low,medium,high,xhigh,max" {
+		t.Fatalf("Claude efforts = %v", got)
+	}
+	if got := LaunchReasoningEffortsForTool("codex"); strings.Join(got, ",") != "minimal,low,medium,high,xhigh" {
+		t.Fatalf("Codex efforts = %v", got)
+	}
+}

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -24,6 +24,8 @@ type ClaudeOptions struct {
 	// "opus", and "haiku" let Claude Code resolve the latest version; full
 	// model IDs pin a specific version.
 	Model string `json:"model,omitempty"`
+	// Effort sets Claude Code's per-session --effort level.
+	Effort string `json:"effort,omitempty"`
 	// SkipPermissions adds --dangerously-skip-permissions flag
 	SkipPermissions bool `json:"skip_permissions,omitempty"`
 	// AllowSkipPermissions adds --allow-dangerously-skip-permissions flag
@@ -68,6 +70,9 @@ func (o *ClaudeOptions) ToArgs() []string {
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)
 	}
+	if o.Effort != "" {
+		args = append(args, "--effort", o.Effort)
+	}
 
 	// Permission flags (mutually exclusive, SkipPermissions takes precedence)
 	if o.SkipPermissions {
@@ -94,6 +99,9 @@ func (o *ClaudeOptions) ToArgsForFork() []string {
 
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)
+	}
+	if o.Effort != "" {
+		args = append(args, "--effort", o.Effort)
 	}
 	if o.SkipPermissions {
 		args = append(args, "--dangerously-skip-permissions")
@@ -137,6 +145,8 @@ func NewClaudeOptions(config *UserConfig) *ClaudeOptions {
 type CodexOptions struct {
 	// Model overrides the Codex model for this session (for example, "gpt-5").
 	Model string `json:"model,omitempty"`
+	// ReasoningEffort overrides Codex model_reasoning_effort for this session.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// YoloMode enables --yolo flag (bypass approvals and sandbox)
 	// nil = inherit from global config, true/false = explicit override
 	YoloMode *bool `json:"yolo_mode,omitempty"`
@@ -152,6 +162,9 @@ func (o *CodexOptions) ToArgs() []string {
 	var args []string
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)
+	}
+	if o.ReasoningEffort != "" {
+		args = append(args, "--config", "model_reasoning_effort="+o.ReasoningEffort)
 	}
 	if o.YoloMode != nil && *o.YoloMode {
 		args = append(args, "--yolo")

--- a/internal/session/tooloptions_test.go
+++ b/internal/session/tooloptions_test.go
@@ -68,6 +68,11 @@ func TestClaudeOptions_ToArgs(t *testing.T) {
 			expected: []string{"--model", "claude-sonnet-4-6"},
 		},
 		{
+			name:     "effort only",
+			opts:     ClaudeOptions{Effort: "high"},
+			expected: []string{"--effort", "high"},
+		},
+		{
 			name: "chrome only",
 			opts: ClaudeOptions{
 				UseChrome: true,
@@ -86,11 +91,12 @@ func TestClaudeOptions_ToArgs(t *testing.T) {
 			opts: ClaudeOptions{
 				SessionMode:     "continue",
 				Model:           "claude-sonnet-4-6",
+				Effort:          "xhigh",
 				SkipPermissions: true,
 				UseChrome:       true,
 				UseTeammateMode: true,
 			},
-			expected: []string{"-c", "--model", "claude-sonnet-4-6", "--dangerously-skip-permissions", "--chrome", "--teammate-mode", "tmux"},
+			expected: []string{"-c", "--model", "claude-sonnet-4-6", "--effort", "xhigh", "--dangerously-skip-permissions", "--chrome", "--teammate-mode", "tmux"},
 		},
 		{
 			name: "allow skip permissions only",
@@ -175,6 +181,11 @@ func TestClaudeOptions_ToArgsForFork(t *testing.T) {
 			expected: []string{"--model", "claude-sonnet-4-6"},
 		},
 		{
+			name:     "effort",
+			opts:     ClaudeOptions{Effort: "max"},
+			expected: []string{"--effort", "max"},
+		},
+		{
 			name: "chrome",
 			opts: ClaudeOptions{
 				UseChrome: true,
@@ -193,10 +204,11 @@ func TestClaudeOptions_ToArgsForFork(t *testing.T) {
 			opts: ClaudeOptions{
 				SkipPermissions: true,
 				Model:           "claude-sonnet-4-6",
+				Effort:          "high",
 				UseChrome:       true,
 				UseTeammateMode: true,
 			},
-			expected: []string{"--model", "claude-sonnet-4-6", "--dangerously-skip-permissions", "--chrome", "--teammate-mode", "tmux"},
+			expected: []string{"--model", "claude-sonnet-4-6", "--effort", "high", "--dangerously-skip-permissions", "--chrome", "--teammate-mode", "tmux"},
 		},
 		{
 			name: "allow skip permissions for fork",
@@ -494,6 +506,11 @@ func TestCodexOptions_ToArgs(t *testing.T) {
 			opts:     CodexOptions{Model: "gpt-5"},
 			expected: []string{"--model", "gpt-5"},
 		},
+		{
+			name:     "reasoning effort",
+			opts:     CodexOptions{ReasoningEffort: "high"},
+			expected: []string{"--config", "model_reasoning_effort=high"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -534,7 +551,7 @@ func TestNewCodexOptions_NilConfig(t *testing.T) {
 }
 
 func TestCodexOptions_MarshalUnmarshal(t *testing.T) {
-	original := &CodexOptions{Model: "gpt-5", YoloMode: boolPtr(true)}
+	original := &CodexOptions{Model: "gpt-5", ReasoningEffort: "xhigh", YoloMode: boolPtr(true)}
 
 	data, err := MarshalToolOptions(original)
 	if err != nil {
@@ -551,6 +568,9 @@ func TestCodexOptions_MarshalUnmarshal(t *testing.T) {
 	}
 	if restored.Model != "gpt-5" {
 		t.Errorf("expected Model=gpt-5 after roundtrip, got %q", restored.Model)
+	}
+	if restored.ReasoningEffort != "xhigh" {
+		t.Errorf("expected ReasoningEffort=xhigh after roundtrip, got %q", restored.ReasoningEffort)
 	}
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7313,7 +7313,10 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			claudeStartQuery = h.newDialog.GetClaudeStartQuery()
 		} else if command == "codex" {
 			yolo := h.newDialog.GetCodexYoloMode()
-			codexOpts := &session.CodexOptions{YoloMode: &yolo}
+			codexOpts := &session.CodexOptions{
+				YoloMode:        &yolo,
+				ReasoningEffort: h.newDialog.GetLaunchReasoningEffort(),
+			}
 			toolOptionsJSON, _ = session.MarshalToolOptions(codexOpts)
 		} else if command == "hermes" {
 			yolo := h.newDialog.GetHermesYoloMode()

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -123,17 +123,18 @@ func sliceVisibleFrom(s string, n int) string {
 type focusTarget int
 
 const (
-	focusName      focusTarget = iota
-	focusPath                  // project path input (hidden when multi-repo enabled).
-	focusCommand               // tool/command picker.
-	focusModel                 // optional per-session model/version override.
-	focusWorktree              // worktree checkbox.
-	focusSandbox               // sandbox checkbox.
-	focusConductor             // conducting parent dropdown (conditional — only when conductors exist).
-	focusMultiRepo             // multi-repo toggle (transforms path into list when enabled).
-	focusInherited             // inherited Docker settings toggle (conditional).
-	focusBranch                // branch input (conditional — only when worktree enabled).
-	focusOptions               // tool-specific options panel (conditional).
+	focusName            focusTarget = iota
+	focusPath                        // project path input (hidden when multi-repo enabled).
+	focusCommand                     // tool/command picker.
+	focusModel                       // optional per-session model/version override.
+	focusReasoningEffort             // optional per-session reasoning/effort override.
+	focusWorktree                    // worktree checkbox.
+	focusSandbox                     // sandbox checkbox.
+	focusConductor                   // conducting parent dropdown (conditional — only when conductors exist).
+	focusMultiRepo                   // multi-repo toggle (transforms path into list when enabled).
+	focusInherited                   // inherited Docker settings toggle (conditional).
+	focusBranch                      // branch input (conditional — only when worktree enabled).
+	focusOptions                     // tool-specific options panel (conditional).
 )
 
 // New session dialog: outer box and textinput widths stay in sync so long
@@ -159,6 +160,7 @@ type NewDialog struct {
 	pathInput             textinput.Model
 	commandInput          textinput.Model
 	modelInput            textinput.Model
+	reasoningEffort       string
 	claudeOptions         *ClaudeOptionsPanel // Claude-specific options (concrete for value extraction).
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
@@ -229,6 +231,7 @@ type dialogSnapshot struct {
 	commandCursor    int
 	commandInput     string
 	modelInput       string
+	reasoningEffort  string
 	sandboxEnabled   bool
 	worktreeEnabled  bool
 	worktreeToggled  bool
@@ -423,6 +426,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	}
 	d.pathInput.Blur()
 	d.modelInput.SetValue("")
+	d.reasoningEffort = ""
 	d.modelInput.Blur()
 	d.claudeOptions.Blur()
 	d.claudeOptions.ResetStartQuery() // #741: per-session query must not leak across openings
@@ -736,6 +740,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		commandCursor:    d.commandCursor,
 		commandInput:     d.commandInput.Value(),
 		modelInput:       d.modelInput.Value(),
+		reasoningEffort:  d.reasoningEffort,
 		sandboxEnabled:   d.sandboxEnabled,
 		worktreeEnabled:  d.worktreeEnabled,
 		worktreeToggled:  d.worktreeToggled,
@@ -758,6 +763,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 	d.commandCursor = s.commandCursor
 	d.commandInput.SetValue(s.commandInput)
 	d.modelInput.SetValue(s.modelInput)
+	d.reasoningEffort = s.reasoningEffort
 	d.sandboxEnabled = s.sandboxEnabled
 	d.worktreeEnabled = s.worktreeEnabled
 	d.worktreeToggled = s.worktreeToggled
@@ -820,6 +826,7 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 					if opts.Model != "" {
 						d.modelInput.SetValue(opts.Model)
 					}
+					d.reasoningEffort = opts.Effort
 				}
 			}
 		case rs.Tool == "gemini":
@@ -837,6 +844,7 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 					if opts.Model != "" {
 						d.modelInput.SetValue(opts.Model)
 					}
+					d.reasoningEffort = opts.ReasoningEffort
 				}
 			}
 		case rs.Tool == "opencode":
@@ -1200,6 +1208,31 @@ func (d *NewDialog) selectedToolSupportsModel() bool {
 	return session.SupportsLaunchModel(d.GetSelectedCommand())
 }
 
+func (d *NewDialog) selectedToolSupportsReasoningEffort() bool {
+	return session.SupportsLaunchReasoningEffort(d.GetSelectedCommand())
+}
+
+func (d *NewDialog) reasoningEffortChoices() []string {
+	return append([]string{""}, session.LaunchReasoningEffortsForTool(d.GetSelectedCommand())...)
+}
+
+func (d *NewDialog) cycleReasoningEffort(delta int) {
+	choices := d.reasoningEffortChoices()
+	if len(choices) <= 1 {
+		d.reasoningEffort = ""
+		return
+	}
+	idx := 0
+	for i, choice := range choices {
+		if choice == d.reasoningEffort {
+			idx = i
+			break
+		}
+	}
+	idx = (idx + delta + len(choices)) % len(choices)
+	d.reasoningEffort = choices[idx]
+}
+
 func (d *NewDialog) updateModelPlaceholder() {
 	switch cmd := d.GetSelectedCommand(); {
 	case session.IsClaudeCompatible(cmd):
@@ -1238,12 +1271,23 @@ func (d *NewDialog) GetLaunchModelID() string {
 	return strings.TrimSpace(d.modelInput.Value())
 }
 
+// GetLaunchReasoningEffort returns the optional native effort override for
+// Claude- and Codex-compatible tools. Empty means tool default.
+func (d *NewDialog) GetLaunchReasoningEffort() string {
+	if !d.selectedToolSupportsReasoningEffort() {
+		return ""
+	}
+	return d.reasoningEffort
+}
+
 // GetClaudeOptions returns the Claude-specific options (only relevant if command is "claude")
 func (d *NewDialog) GetClaudeOptions() *session.ClaudeOptions {
 	if !d.isClaudeSelected() {
 		return nil
 	}
-	return d.claudeOptions.GetOptions()
+	opts := d.claudeOptions.GetOptions()
+	opts.Effort = d.GetLaunchReasoningEffort()
+	return opts
 }
 
 // GetClaudeExtraArgs returns the user-supplied claude CLI tokens from the
@@ -1373,6 +1417,9 @@ func (d *NewDialog) rebuildFocusTargets() {
 	if d.selectedToolSupportsModel() {
 		targets = append(targets, focusModel)
 	}
+	if d.selectedToolSupportsReasoningEffort() {
+		targets = append(targets, focusReasoningEffort)
+	}
 	if !d.multiRepoEnabled {
 		targets = append(targets, focusPath)
 	}
@@ -1410,6 +1457,16 @@ func (d *NewDialog) updateToolOptions() {
 	d.modelSuggestionHidden = false
 	d.modelNavigated = false
 	d.filterModelSuggestions()
+	validEffort := d.reasoningEffort == ""
+	for _, effort := range session.LaunchReasoningEffortsForTool(cmd) {
+		if effort == d.reasoningEffort {
+			validEffort = true
+			break
+		}
+	}
+	if !validEffort {
+		d.reasoningEffort = ""
+	}
 	switch {
 	case session.IsClaudeCompatible(cmd):
 		d.toolOptions = d.claudeOptions
@@ -1459,7 +1516,7 @@ func (d *NewDialog) updateFocus() {
 		}
 	case focusModel:
 		d.modelInput.Focus()
-	case focusWorktree, focusSandbox, focusConductor, focusInherited:
+	case focusReasoningEffort, focusWorktree, focusSandbox, focusConductor, focusInherited:
 		// Checkbox/toggle rows and conductor dropdown — no text input to focus.
 	case focusBranch:
 		d.branchInput.Focus()
@@ -2053,6 +2110,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.updateFocus()
 				return d, nil
 			}
+			if cur == focusReasoningEffort {
+				d.cycleReasoningEffort(-1)
+				return d, nil
+			}
 			if cur == focusOptions && d.toolOptions != nil {
 				return d, d.toolOptions.Update(msg)
 			}
@@ -2063,6 +2124,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.modelInput.SetValue("")
 				d.updateToolOptions()
 				d.updateFocus()
+				return d, nil
+			}
+			if cur == focusReasoningEffort {
+				d.cycleReasoningEffort(1)
 				return d, nil
 			}
 			if cur == focusOptions && d.toolOptions != nil {
@@ -2155,6 +2220,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case " ":
+			if cur == focusReasoningEffort {
+				d.cycleReasoningEffort(1)
+				return d, nil
+			}
 			if cur == focusWorktree {
 				d.ToggleWorktree()
 				d.rebuildFocusTargets()
@@ -2363,6 +2432,38 @@ func (d *NewDialog) renderModelSection(content *strings.Builder, cur focusTarget
 		dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
 		content.WriteString("\n  ")
 		content.WriteString(dimStyle.Render(hint))
+	}
+	content.WriteString("\n\n")
+}
+
+func reasoningEffortLabel(effort string) string {
+	switch effort {
+	case "":
+		return "Tool default"
+	case "xhigh":
+		return "Extra high (xhigh)"
+	case "max":
+		return "Max"
+	default:
+		return strings.ToUpper(effort[:1]) + effort[1:]
+	}
+}
+
+func (d *NewDialog) renderReasoningEffortSection(content *strings.Builder, cur focusTarget) {
+	if !d.selectedToolSupportsReasoningEffort() {
+		return
+	}
+	labelStyle := lipgloss.NewStyle().Foreground(ColorText)
+	activeLabelStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+	valueStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	if cur == focusReasoningEffort {
+		content.WriteString(activeLabelStyle.Render("▶ Reasoning effort:"))
+		content.WriteString(" ")
+		content.WriteString(activeLabelStyle.Render("← " + reasoningEffortLabel(d.reasoningEffort) + " →"))
+	} else {
+		content.WriteString(labelStyle.Render("  Reasoning effort:"))
+		content.WriteString(" ")
+		content.WriteString(valueStyle.Render(reasoningEffortLabel(d.reasoningEffort)))
 	}
 	content.WriteString("\n\n")
 }
@@ -2590,6 +2691,7 @@ func (d *NewDialog) View() string {
 	// mode the single Path field is hidden — its list renders below the fold.
 	d.renderCommandSection(&content, cur)
 	d.renderModelSection(&content, cur, dialogWidth)
+	d.renderReasoningEffortSection(&content, cur)
 	if !d.multiRepoEnabled {
 		d.renderSinglePathSection(&content, cur, dialogWidth)
 	}
@@ -2775,6 +2877,8 @@ func (d *NewDialog) View() string {
 		} else {
 			helpText = "Type custom model ID │ Enter browse known IDs │ Tab next"
 		}
+	} else if cur == focusReasoningEffort {
+		helpText = "←→/Space choose effort │ Tab next │ Enter/^S create │ Esc cancel"
 	} else if cur == focusConductor {
 		helpText = "↑↓ select parent │ Tab next │ Enter/^S create │ Esc cancel"
 	} else if cur == focusWorktree || cur == focusSandbox {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -126,10 +126,10 @@ func TestNewDialog_ModelSuggestions_FilterAndSelectCodex(t *testing.T) {
 	if got := d.GetLaunchModelID(); got != "gpt-5.5" {
 		t.Fatalf("GetLaunchModelID() = %q, want gpt-5.5", got)
 	}
-	// UX top-3 #3: order is Tool -> Model -> Path, so accepting a model advances
-	// focus to the Path field (previously Worktree).
-	if d.currentTarget() != focusPath {
-		t.Fatalf("currentTarget after accepting model = %v, want focusPath", d.currentTarget())
+	// Reasoning effort is grouped directly after the model, so accepting a
+	// model advances to the effort picker before Path.
+	if d.currentTarget() != focusReasoningEffort {
+		t.Fatalf("currentTarget after accepting model = %v, want focusReasoningEffort", d.currentTarget())
 	}
 }
 
@@ -155,6 +155,46 @@ func TestNewDialog_ModelDropdownVisibleOnFocus(t *testing.T) {
 	}
 	if d.modelSuggestionCursor != 1 {
 		t.Fatalf("modelSuggestionCursor = %d, want 1", d.modelSuggestionCursor)
+	}
+}
+
+func TestNewDialog_ReasoningEffortPickerUsesToolSpecificChoices(t *testing.T) {
+	tests := []struct {
+		tool string
+		want string
+	}{
+		{tool: "claude", want: "low"},
+		{tool: "codex", want: "minimal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			d := NewNewDialog()
+			d.SetDefaultTool(tt.tool)
+			d.Show()
+			idx := d.indexOf(focusReasoningEffort)
+			if idx < 0 {
+				t.Fatalf("%s dialog missing reasoning-effort focus target", tt.tool)
+			}
+			d.focusIndex = idx
+			d.updateFocus()
+			d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRight})
+			if got := d.GetLaunchReasoningEffort(); got != tt.want {
+				t.Fatalf("GetLaunchReasoningEffort() = %q, want %q", got, tt.want)
+			}
+			view := d.View()
+			if !strings.Contains(view, "Reasoning effort") || !strings.Contains(strings.ToLower(view), tt.want) {
+				t.Fatalf("reasoning picker not rendered for %s: %q", tt.tool, view)
+			}
+		})
+	}
+}
+
+func TestNewDialog_ReasoningEffortHiddenForUnsupportedTool(t *testing.T) {
+	d := NewNewDialog()
+	d.SetDefaultTool("gemini")
+	d.Show()
+	if idx := d.indexOf(focusReasoningEffort); idx >= 0 {
+		t.Fatalf("Gemini dialog unexpectedly has reasoning-effort focus target at %d", idx)
 	}
 }
 
@@ -200,10 +240,9 @@ func TestNewDialog_ModelDropdown_TabAndShiftTabMoveFocus(t *testing.T) {
 	if d.IsModelSuggestionsActive() {
 		t.Fatal("tab should close the model dropdown")
 	}
-	// UX top-3 #3: the order is Tool -> Model -> Path, so Tab from Model lands
-	// on the Path field (previously it advanced to Worktree).
-	if d.currentTarget() != focusPath {
-		t.Fatalf("currentTarget after tab from model dropdown = %v, want focusPath", d.currentTarget())
+	// The effort picker follows Model, so Tab lands there before Path.
+	if d.currentTarget() != focusReasoningEffort {
+		t.Fatalf("currentTarget after tab from model dropdown = %v, want focusReasoningEffort", d.currentTarget())
 	}
 }
 
@@ -984,21 +1023,24 @@ func TestNewDialog_FocusOrder_HotPathNameToolPath(t *testing.T) {
 	}
 }
 
-// With a model-capable tool the Model field sits between Tool and Path, keeping
-// it grouped with the tool selector while preserving Name -> Tool -> ... -> Path.
-func TestNewDialog_FocusOrder_ModelBetweenToolAndPath(t *testing.T) {
+// With a reasoning-capable tool, Model and Reasoning sit between Tool and Path.
+func TestNewDialog_FocusOrder_ModelAndReasoningBetweenToolAndPath(t *testing.T) {
 	d := NewNewDialog()
 	d.SetDefaultTool("claude")
 	d.Show()
 
 	cmdIdx := d.indexOf(focusCommand)
 	modelIdx := d.indexOf(focusModel)
+	reasoningIdx := d.indexOf(focusReasoningEffort)
 	pathIdx := d.indexOf(focusPath)
 	if modelIdx < 0 {
 		t.Fatal("focusModel should be present for a model-capable tool (claude)")
 	}
-	if !(cmdIdx < modelIdx && modelIdx < pathIdx) {
-		t.Fatalf("want Tool(%d) < Model(%d) < Path(%d)", cmdIdx, modelIdx, pathIdx)
+	if reasoningIdx < 0 {
+		t.Fatal("focusReasoningEffort should be present for Claude")
+	}
+	if !(cmdIdx < modelIdx && modelIdx < reasoningIdx && reasoningIdx < pathIdx) {
+		t.Fatalf("want Tool(%d) < Model(%d) < Reasoning(%d) < Path(%d)", cmdIdx, modelIdx, reasoningIdx, pathIdx)
 	}
 }
 

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -92,7 +92,7 @@ func (m *WebMutator) beginHeadlessTx() (unlock func(), err error) {
 }
 
 // CreateSession creates and starts a new session, persisting it to storage.
-func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
 	unlock, err := m.beginHeadlessTx()
 	if err != nil {
 		return "", err
@@ -110,6 +110,11 @@ func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID 
 
 	if modelID = strings.TrimSpace(modelID); modelID != "" {
 		if err := inst.ApplyLaunchModel(modelID); err != nil {
+			return "", err
+		}
+	}
+	if reasoningEffort = strings.TrimSpace(reasoningEffort); reasoningEffort != "" {
+		if err := inst.ApplyLaunchReasoningEffort(reasoningEffort); err != nil {
 			return "", err
 		}
 	}

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -18,11 +18,12 @@ const (
 
 // CreateSessionRequest is the body for POST /api/sessions.
 type CreateSessionRequest struct {
-	Title       string `json:"title"`
-	Tool        string `json:"tool"`
-	ProjectPath string `json:"projectPath"`
-	GroupPath   string `json:"groupPath,omitempty"`
-	ModelID     string `json:"modelId,omitempty"`
+	Title           string `json:"title"`
+	Tool            string `json:"tool"`
+	ProjectPath     string `json:"projectPath"`
+	GroupPath       string `json:"groupPath,omitempty"`
+	ModelID         string `json:"modelId,omitempty"`
+	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 }
 
 // CreateGroupRequest is the body for POST /api/groups.

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -72,7 +72,11 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 			writeAPIError(w, http.StatusServiceUnavailable, ErrCodeNotImplemented, "mutations not available")
 			return
 		}
-		sessionID, err := s.mutator.CreateSession(req.Title, req.Tool, req.ProjectPath, req.GroupPath, req.ModelID)
+		if err := session.ValidateLaunchReasoningEffort(req.Tool, req.ReasoningEffort); err != nil {
+			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, err.Error())
+			return
+		}
+		sessionID, err := s.mutator.CreateSession(req.Title, req.Tool, req.ProjectPath, req.GroupPath, req.ModelID, req.ReasoningEffort)
 		if err != nil {
 			writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
 			return

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -15,7 +15,7 @@ import (
 // fakeMutator is a test double for SessionMutator that delegates to function fields.
 // If a function field is nil, the method returns an error indicating it is unconfigured.
 type fakeMutator struct {
-	createSessionFn    func(title, tool, projectPath, groupPath, modelID string) (string, error)
+	createSessionFn    func(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error)
 	startSessionFn     func(id string) error
 	stopSessionFn      func(id string) error
 	restartSessionFn   func(id string) error
@@ -32,11 +32,11 @@ type fakeMutator struct {
 	finishWorktreeFn   func(id string, opts WorktreeFinishOptions) (WorktreeFinishResult, error)
 }
 
-func (f *fakeMutator) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (f *fakeMutator) CreateSession(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
 	if f.createSessionFn == nil {
 		return "", fmt.Errorf("createSession not configured")
 	}
-	return f.createSessionFn(title, tool, projectPath, groupPath, modelID)
+	return f.createSessionFn(title, tool, projectPath, groupPath, modelID, reasoningEffort)
 }
 
 func (f *fakeMutator) StartSession(id string) error {
@@ -191,7 +191,7 @@ func TestSessionsCollectionPOSTCreatesSession(t *testing.T) {
 	})
 	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
 	srv.mutator = &fakeMutator{
-		createSessionFn: func(title, tool, projectPath, groupPath, modelID string) (string, error) {
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
 			return "new-id", nil
 		},
 	}
@@ -219,7 +219,7 @@ func TestSessionsCollectionPOSTForwardsModelID(t *testing.T) {
 
 	var gotModel string
 	srv.mutator = &fakeMutator{
-		createSessionFn: func(title, tool, projectPath, groupPath, modelID string) (string, error) {
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
 			gotModel = modelID
 			return "new-id", nil
 		},
@@ -236,6 +236,59 @@ func TestSessionsCollectionPOSTForwardsModelID(t *testing.T) {
 	}
 	if gotModel != "claude-sonnet-4-6" {
 		t.Fatalf("modelID = %q, want %q", gotModel, "claude-sonnet-4-6")
+	}
+}
+
+func TestSessionsCollectionPOSTForwardsReasoningEffort(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	var gotEffort string
+	srv.mutator = &fakeMutator{
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
+			gotEffort = reasoningEffort
+			return "new-id", nil
+		},
+	}
+
+	body := strings.NewReader(`{"title":"Test","tool":"codex","projectPath":"/tmp","reasoningEffort":"high"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	if gotEffort != "high" {
+		t.Fatalf("reasoningEffort = %q, want high", gotEffort)
+	}
+}
+
+func TestSessionsCollectionPOSTRejectsInvalidReasoningEffort(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		createSessionFn: func(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
+			t.Fatal("mutator called for invalid reasoning effort")
+			return "", nil
+		},
+	}
+
+	body := strings.NewReader(`{"title":"Test","tool":"claude","projectPath":"/tmp","reasoningEffort":"minimal"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/web/parity_test.go
+++ b/internal/web/parity_test.go
@@ -59,7 +59,7 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 				_ = json.NewDecoder(w.Body).Decode(&resp)
 
 				// Direct mutator path.
-				_, err := directFx.store.CreateSession("parity-create", "claude", "/srv/parity", "work", "")
+				_, err := directFx.store.CreateSession("parity-create", "claude", "/srv/parity", "work", "", "")
 				if err != nil {
 					t.Fatalf("direct CreateSession: %v", err)
 				}
@@ -69,8 +69,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "stop_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
 				// Both stores generated the same id deterministically (sess-005).
 				const id = "sess-005"
 
@@ -90,8 +90,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "start_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
 				const id = "sess-005"
 
 				req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/start", nil)
@@ -109,8 +109,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "delete_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
 				const id = "sess-005"
 
 				req := httptest.NewRequest(http.MethodDelete, "/api/sessions/"+id, nil)
@@ -167,8 +167,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "archive_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
 				const id = "sess-005"
 
 				req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/archive", nil)
@@ -186,8 +186,8 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 		{
 			name: "unarchive_session",
 			fire: func(t *testing.T, webFx, directFx *parityFixture) string {
-				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
-				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "")
+				_, _ = webFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
+				_, _ = directFx.store.CreateSession("seed", "claude", "/srv/seed", "work", "", "")
 				const id = "sess-005"
 				_ = webFx.store.ArchiveSession(id)
 				_ = directFx.store.ArchiveSession(id)
@@ -331,7 +331,7 @@ func TestParity_WebActionMatchesDirectMutator(t *testing.T) {
 func TestParity_TUIChangeVisibleViaWebAPI(t *testing.T) {
 	t.Parallel()
 	fx := newParityFixture()
-	_, _ = fx.store.CreateSession("ts", "claude", "/srv/ts", "work", "")
+	_, _ = fx.store.CreateSession("ts", "claude", "/srv/ts", "work", "", "")
 	const id = "sess-005"
 
 	// "TUI" path: mutate the store directly.
@@ -488,7 +488,7 @@ func (s *parityStore) LoadArchivedMenuSnapshot() (*MenuSnapshot, error) {
 
 // SessionMutator implementation.
 
-func (s *parityStore) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (s *parityStore) CreateSession(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	id := nextDeterministicID(&s.nextID)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -99,7 +99,7 @@ type MenuDataLoader interface {
 // SessionMutator is implemented by internal/ui.WebMutator and injected at startup.
 // It bridges web HTTP handlers to the TUI session/group management methods.
 type SessionMutator interface {
-	CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error)
+	CreateSession(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error)
 	StartSession(sessionID string) error
 	StopSession(sessionID string) error
 	RestartSession(sessionID string) error

--- a/internal/web/static/app/CreateSessionDialog.js
+++ b/internal/web/static/app/CreateSessionDialog.js
@@ -13,6 +13,23 @@ import { displayLabelForTool, resolveCreateSessionPickerTools } from './pickerTo
 
 const CUSTOM_MODEL = '__custom__'
 
+const REASONING_EFFORT_CATALOG = {
+  claude: [
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'Extra high' },
+    { value: 'max', label: 'Max' },
+  ],
+  codex: [
+    { value: 'minimal', label: 'Minimal' },
+    { value: 'low', label: 'Low' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'high', label: 'High' },
+    { value: 'xhigh', label: 'Extra high' },
+  ],
+}
+
 const MODEL_ID_CATALOG = {
   claude: [
     { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
@@ -73,11 +90,16 @@ function modelIDsForTool(tool) {
   return MODEL_ID_CATALOG[tool] || []
 }
 
+function reasoningEffortsForTool(tool) {
+  return REASONING_EFFORT_CATALOG[tool] || []
+}
+
 export function CreateSessionDialog() {
   const [title, setTitle] = useState('')
   const [tool, setTool] = useState('claude')
   const [modelId, setModelId] = useState('')
   const [customModel, setCustomModel] = useState('')
+  const [reasoningEffort, setReasoningEffort] = useState('')
   const [path, setPath] = useState('')
   const [error, setError] = useState(null)
   const [submitting, setSubmitting] = useState(false)
@@ -95,6 +117,7 @@ export function CreateSessionDialog() {
       const payload = { title, tool, projectPath: path }
       const modelId = selectedModelId()
       if (modelId) payload.modelId = modelId
+      if (reasoningEffort) payload.reasoningEffort = reasoningEffort
       await apiFetch('POST', '/api/sessions', payload)
       createSessionDialogSignal.value = false
     } catch (err) {
@@ -108,6 +131,7 @@ export function CreateSessionDialog() {
     setTool(nextTool)
     setModelId('')
     setCustomModel('')
+    setReasoningEffort('')
   }
 
   function selectedModelId() {
@@ -118,6 +142,7 @@ export function CreateSessionDialog() {
   const close = () => (createSessionDialogSignal.value = false)
   const handleBackdropClick = (e) => { if (e.target === e.currentTarget) close() }
   const modelIDs = modelIDsForTool(tool)
+  const reasoningEfforts = reasoningEffortsForTool(tool)
   const shownTools = resolveCreateSessionPickerTools(pickerToolsSignal.value)
   const needsCustomModel = modelId === CUSTOM_MODEL
   const submitDisabled = submitting || !title || !path || (needsCustomModel && !customModel.trim())
@@ -174,6 +199,17 @@ export function CreateSessionDialog() {
                 <input required value=${customModel} onInput=${e => setCustomModel(e.target.value)} placeholder="provider/model-or-version"/>
               </div>
             `}
+          `}
+          ${reasoningEfforts.length > 0 && html`
+            <div class="field">
+              <label>REASONING EFFORT</label>
+              <select value=${reasoningEffort} onInput=${e => setReasoningEffort(e.target.value)}>
+                <option value="">Tool default</option>
+                ${reasoningEfforts.map(effort => html`
+                  <option key=${effort.value} value=${effort.value}>${effort.label} — ${effort.value}</option>
+                `)}
+              </select>
+            </div>
           `}
           ${error && html`
             <div style="font-family: var(--mono); font-size: 11.5px; color: var(--tn-red); padding: 8px 10px;

--- a/internal/web/static_files_test.go
+++ b/internal/web/static_files_test.go
@@ -190,6 +190,25 @@ func TestCreateSessionDialogUsesModelIDCatalog(t *testing.T) {
 	}
 }
 
+func TestCreateSessionDialogUsesToolSpecificReasoningEffortCatalog(t *testing.T) {
+	data, err := embeddedStaticFiles.ReadFile("static/app/CreateSessionDialog.js")
+	if err != nil {
+		t.Fatalf("read CreateSessionDialog.js: %v", err)
+	}
+	source := string(data)
+	for _, want := range []string{
+		"REASONING EFFORT",
+		"reasoningEffort",
+		"minimal",
+		"xhigh",
+		"max",
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("CreateSessionDialog.js missing expected content %q", want)
+		}
+	}
+}
+
 // TestNoTailwindPlayCDN is the regression gate for Phase 1 / Plan 03 (PERF-01).
 // The Tailwind Play CDN runtime (vendor/tailwind.js, 397 KB) was deleted in
 // favor of a build-time compiled /static/styles.css file (~8 KB gzipped).

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -312,7 +312,7 @@ func (s *fixtureStore) LoadArchivedMenuSnapshot() (*web.MenuSnapshot, error) {
 }
 
 // CreateSession implements web.SessionMutator.
-func (s *fixtureStore) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+func (s *fixtureStore) CreateSession(title, tool, projectPath, groupPath, modelID, reasoningEffort string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	id := fmt.Sprintf("sess-%03d", s.nextID)


### PR DESCRIPTION
## What problem does this solve?

Agent Deck lets users choose a Claude or Codex model when creating a session, but it cannot choose the corresponding reasoning/effort level. Users currently have to change tool configuration or wrap launch commands manually. Proposed in [Discussion #1698](https://github.com/asheshgoplani/agent-deck/discussions/1698).

## Why this change

Claude Code and Codex expose the same user concept through different native interfaces: Claude uses `--effort`, while Codex uses `model_reasoning_effort`. This change adds one shared Agent Deck field with tool-specific catalogs, validation, persistence, and command emission rather than treating the values as interchangeable strings.

The TUI keeps Model and Reasoning together in the hot-path order (`Tool -> Model -> Reasoning -> Path`). The web dialog uses the same tool-specific choices. Empty means “Tool default,” so existing sessions and defaults remain unchanged.

The diff crosses the session, TUI, and web packages because the selected value must be accepted, validated, persisted, and emitted on every relevant launch path. Those layers are covered together so the UI cannot offer a choice that the launcher silently drops.

## User impact

When creating Claude or Codex sessions from either the TUI or web UI, users can independently select a model and reasoning effort.

- Claude: Tool default, Low, Medium, High, Extra high (`xhigh`), Max
- Codex: Tool default, Minimal, Low, Medium, High, Extra high (`xhigh`)

Claude launches receive `--effort <value>`. Codex launches receive `--config model_reasoning_effort=<value>`. Selections survive persistence and resume; Codex forks preserve the parent's reasoning effort.

## Evidence

Installed-tool contract checked before implementation:

```text
$ claude --version
2.1.216 (Claude Code)

$ claude --help
--effort <level>  Effort level for the current session (low, medium, high, xhigh, max)

$ codex --help
--config <key=value>  Override a configuration value from config.toml
```

Test-first failures before production code:

```text
ApplyLaunchReasoningEffort undefined
undefined: focusReasoningEffort
CreateSessionDialog.js missing expected content "REASONING EFFORT"
```

The contributor revert-check copies the changed tests onto `origin/main`; they fail to compile there because the new effort API and focus target do not exist, which is the expected proof that the tests require the production change.

Focused tests after implementation:

```text
ok github.com/asheshgoplani/agent-deck/internal/session 0.014s
ok github.com/asheshgoplani/agent-deck/internal/ui      0.015s
ok github.com/asheshgoplani/agent-deck/internal/web     0.007s
```

Broader validation:

```text
ok github.com/asheshgoplani/agent-deck/internal/ui      37.661s
ok github.com/asheshgoplani/agent-deck/internal/web      1.643s
ok github.com/asheshgoplani/agent-deck/internal/session 113.078s
$ go vet ./...
$ go build ./...
```

Agent Deck contributor self-check, with affected packages serialized to avoid the repository's load-sensitive watcher test:

```text
PASS sandboxed-tests ./cmd/agent-deck ./internal/session ./internal/ui ./internal/web ./tests/web/fixtures/cmd/web-fixture
summary: 14 PASS, 0 FAIL, 2 WARN, 0 skipped
```

The two warnings are the documented revert-check compile failure and the cross-layer diff size explained above.

The initial complete touched-package run under root reported host-sensitive tmux/conductor/watcher timing tests plus a read-only-directory assertion that cannot fail as root. The serial unprivileged contributor-gate run above then passed every affected-package test; no new effort test failed.

Startup hot-path benchmark, median of five runs at 10,000 iterations:

```text
                                      origin/main    this branch
BuildClaudeExtraFlagsDefault           11,771 ns/op  11,771 ns/op
BuildCodexCommandDefault               49,768 ns/op  50,274 ns/op (+1.0%)
```

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol

**Prompt / session log (optional):** N/A

## What actually bothered you

The human asked: “implement it as a different upstream feature PR” and then clarified: “same thing should apply for Claude (model AND reasoning)”.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5.6-sol intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-session reasoning effort selection for supported Claude and Codex tools.
  * Reasoning effort choices are available in new-session dialogs and web session creation.
  * Selected settings are preserved when sessions are resumed or forked.
  * Launch commands now apply the chosen effort level.

* **Bug Fixes**
  * Invalid reasoning effort values are rejected with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->