### PR TITLE
fix(tmux): bound every cadence tmux command with a deadline

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -8,9 +9,32 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
+
+// tmuxProbeTimeout bounds the plain-argv tmux probes the CLI fires to identify
+// the caller's own session. These deliberately omit -L so tmux auto-routes via
+// $TMUX (see the display-message entries in TestNoRawTmuxExec_OutsideAllowlist),
+// which is why they cannot use tmux.OutputBounded — that helper always emits
+// -L <name>. They still need a deadline: on tmux 3.0a a client leaks an epoll
+// fd per event-loop iteration, and once it hits RLIMIT_NOFILE it spins at 100%
+// CPU in EMFILE retries and never exits. These probes run on conductor-polled
+// CLI paths, so an unbounded one accumulates wedged clients exactly like the
+// cadence pollers in internal/tmux did.
+const tmuxProbeTimeout = 3 * time.Second
+
+// tmuxProbeBounded runs `tmux <args…>` under tmuxProbeTimeout and returns
+// stdout. exec.CommandContext SIGKILLs a wedged client at the deadline; the
+// WaitDelay bounds the post-kill stdio drain.
+func tmuxProbeBounded(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", args...)
+	cmd.WaitDelay = 2 * time.Second
+	return cmd.Output()
+}
 
 // normalizeArgs reorders args so flags come before positional arguments.
 // Go's flag package stops parsing at the first non-flag argument, which means
@@ -354,9 +378,8 @@ func GetCurrentSessionID() string {
 		return ""
 	}
 
-	// Get current tmux session name
-	cmd := exec.Command("tmux", "display-message", "-p", "#S")
-	output, err := cmd.Output()
+	// Get current tmux session name (bounded — see tmuxProbeTimeout)
+	output, err := tmuxProbeBounded("display-message", "-p", "#S")
 	if err != nil {
 		return ""
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1994,9 +1994,8 @@ func findSessionByTmuxAcrossProfiles() (*session.Instance, string) {
 
 // findSessionByTmux tries to find a session by matching tmux session name or working directory
 func findSessionByTmux(instances []*session.Instance) *session.Instance {
-	// Get current tmux session name
-	cmd := exec.Command("tmux", "display-message", "-p", "#{session_name}\t#{pane_current_path}")
-	output, err := cmd.Output()
+	// Get current tmux session name (bounded — see tmuxProbeTimeout)
+	output, err := tmuxProbeBounded("display-message", "-p", "#{session_name}\t#{pane_current_path}")
 	if err != nil {
 		return nil
 	}
@@ -2050,10 +2049,9 @@ func findSessionByTmux(instances []*session.Instance) *session.Instance {
 
 // showTmuxSessionInfo shows information about the current tmux session (unregistered)
 func showTmuxSessionInfo(out *CLIOutput, jsonOutput bool) {
-	// Get tmux session info
-	cmd := exec.Command("tmux", "display-message", "-p",
+	// Get tmux session info (bounded — see tmuxProbeTimeout)
+	output, err := tmuxProbeBounded("display-message", "-p",
 		"#{session_name}\t#{pane_current_path}\t#{session_created}\t#{window_name}")
-	output, err := cmd.Output()
 	if err != nil {
 		out.Error("failed to get tmux session info", ErrCodeNotFound)
 		os.Exit(1)
@@ -3969,8 +3967,8 @@ func handleSessionCurrent(profileArg string, args []string) {
 
 // getCurrentTmuxSessionName gets the current tmux session name (single subprocess call)
 func getCurrentTmuxSessionName() (string, error) {
-	cmd := exec.Command("tmux", "display-message", "-p", "#{session_name}")
-	output, err := cmd.Output()
+	// Bounded — see tmuxProbeTimeout.
+	output, err := tmuxProbeBounded("display-message", "-p", "#{session_name}")
 	if err != nil {
 		return "", err
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2543,7 +2543,10 @@ func (i *Instance) collectTmuxPaneProcessTreePIDs() []int {
 	// Target the same tmux server the session was created on (issue #687).
 	// A session on an isolated agent-deck socket would return no panes from
 	// the default server and we would mistakenly treat it as empty.
-	out, err := tmux.Exec(i.TmuxSocketName, "list-panes", "-t", target, "-F", "#{pane_pid}").Output()
+	// Bounded — see tmux.OutputBounded. Exec(...).Output() has no deadline, and
+	// a tmux client that has exhausted its fd table never exits, so this probe
+	// would hang the caller forever.
+	out, err := tmux.OutputBounded(i.TmuxSocketName, "list-panes", "-t", target, "-F", "#{pane_pid}")
 	if err != nil {
 		return nil
 	}

--- a/internal/session/mcp_child_reap.go
+++ b/internal/session/mcp_child_reap.go
@@ -144,8 +144,17 @@ func (i *Instance) discoverMCPChildrenFromPaneTree() {
 // collectTmuxPaneProcessTreePIDs (which also takes its own snapshot).
 func (i *Instance) readPanePID() int {
 	target := i.tmuxSession.Name + ":"
-	out, err := tmux.Exec(i.TmuxSocketName, "list-panes", "-t", target, "-F", "#{pane_pid}").Output()
+	// Bounded — see tmux.OutputBounded. This runs on the MCP child-reap path;
+	// an unbounded probe would leave orphaned children unreaped indefinitely.
+	out, err := tmux.OutputBounded(i.TmuxSocketName, "list-panes", "-t", target, "-F", "#{pane_pid}")
 	if err != nil {
+		// Returning 0 no-ops MCP child discovery in killInternal, which is
+		// single-shot with no retry — so a timeout here silently resurrects the
+		// setsid-MCP orphan leak (#965) for that kill. Log it rather than
+		// letting the reap quietly do nothing.
+		slog.Warn("pane_pid_probe_failed",
+			slog.String("session", i.Title),
+			slog.String("error", err.Error()))
 		return 0
 	}
 	pidStr := strings.TrimSpace(string(out))

--- a/internal/tmux/ensure_pids_dead.go
+++ b/internal/tmux/ensure_pids_dead.go
@@ -17,6 +17,7 @@
 package tmux
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -168,8 +169,15 @@ func (s *Session) KillAndWait() error {
 
 	_, oldPIDs := s.getPaneProcessTree()
 
-	cmd := execCommand("tmux", "kill-session", "-t", s.Name)
-	killErr := cmd.Run()
+	// Bounded — see tmuxMutationTimeout. This is the CLI path (`agent-deck
+	// remove`), where an unbounded wedge hangs the user's terminal outright
+	// rather than a background goroutine. The argv stays plain (no -L): keeping
+	// the execCommand seam's exact shape is what the launcher-fallback tests
+	// assert on, and which server this targets is a separate question from
+	// whether it terminates.
+	killCtx, cancelKill := context.WithTimeout(context.Background(), tmuxMutationTimeout)
+	defer cancelKill()
+	killErr := execCommandContext(killCtx, "tmux", "kill-session", "-t", s.Name).Run()
 
 	if len(oldPIDs) > 0 {
 		EnsurePIDsDead(oldPIDs, 3*time.Second)

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -569,10 +569,13 @@ func killStaleControlClients(sessionName, socketName string) {
 	// reach. See reapOrphanedPollClients.
 	orphanReapOnce.Do(reapOrphanedPollClients)
 
-	out, err := tmuxExec(socketName,
+	// Bounded — see tmuxPollTimeout. This is the sweep that reaps stale
+	// clients; if its own enumeration hangs on an fd-exhausted client, the
+	// cleanup path becomes another leak source instead of a fix.
+	out, err := runBoundedOutput(socketName,
 		"list-clients", "-t", sessionName,
 		"-F", "#{client_control_mode} #{client_pid}",
-	).Output()
+	)
 	if err != nil {
 		return // session may not exist or no clients attached
 	}

--- a/internal/tmux/probe_contract_test.go
+++ b/internal/tmux/probe_contract_test.go
@@ -1,0 +1,101 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+// socket_waitdelay_test.go pins the RUNTIME half of the WaitDelay contract:
+// that Cmd.WaitDelay fires on a lingering-child fd and that the bytes written
+// before the I/O goroutine was abandoned survive in the captured stdout.
+//
+// This file pins the CALLER half, which nothing covered. tmuxSubprocessWaitDelay
+// documents it: "when errors.Is(err, exec.ErrWaitDelay) and the captured stdout
+// looks valid (non-empty, parses cleanly), treat it as success." Under the
+// bridged-stdio setups that motivated WaitDelay (Claude Code /remote-control,
+// ssh ControlMaster), ignoring that turns every pane-PID probe into a failure
+// even though the PID is sitting in the buffer — which now decides whether the
+// SIGTERM->SIGKILL escalation runs at all, so orphans would accumulate on every
+// kill in exactly those environments.
+
+func TestParsePanePID_AcceptsWaitDelayWithValidOutput(t *testing.T) {
+	pid, err := parsePanePID([]byte("4242\n"), fmt.Errorf("wrapped: %w", exec.ErrWaitDelay))
+	if err != nil {
+		t.Fatalf("ErrWaitDelay with a parseable pane_pid must be treated as success; got err %v", err)
+	}
+	if pid != 4242 {
+		t.Fatalf("pane_pid = %d, want 4242", pid)
+	}
+}
+
+func TestParsePanePID_RejectsWaitDelayWithUnusableOutput(t *testing.T) {
+	if _, err := parsePanePID([]byte("  \n"), exec.ErrWaitDelay); err == nil {
+		t.Fatal("ErrWaitDelay with no usable pane_pid must stay an error: a " +
+			"buffer holding nothing is indeterminate, not 'no processes'")
+	}
+}
+
+func TestParsePanePID_RejectsGenuineFailure(t *testing.T) {
+	// A client killed at the deadline reports a plain ExitError. That is a real
+	// failure and must not be rescued just because the buffer has bytes.
+	if _, err := parsePanePID([]byte("4242\n"), errors.New("signal: killed")); err == nil {
+		t.Fatal("a non-WaitDelay error must propagate")
+	}
+}
+
+func TestParsePanePID_RejectsNonPositivePID(t *testing.T) {
+	if _, err := parsePanePID([]byte("0\n"), nil); err == nil {
+		t.Fatal("pane_pid 0 must be an error: it is the value the old code " +
+			"degraded to, and it matches no live process")
+	}
+}
+
+func TestParsePanePID_TakesFirstLineOnly(t *testing.T) {
+	pid, err := parsePanePID([]byte("101\n202\n303\n"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 101 {
+		t.Fatalf("multi-pane output must yield the first pane_pid; got %d", pid)
+	}
+}
+
+// annotateDeadline is what lets a caller tell "we gave up on tmux" from "tmux
+// told us no". Without it every timeout looks like a hard tmux failure, and
+// SwitchAttachedClients cannot honor its documented fallback contract.
+
+func TestAnnotateDeadline_MarksDeadlineFailures(t *testing.T) {
+	cause := errors.New("signal: killed")
+	err := annotateDeadline(context.DeadlineExceeded, cause)
+	if !errors.Is(err, errTmuxTimeout) {
+		t.Fatalf("a run that failed while its context deadline had fired must be "+
+			"identifiable as a timeout; got %v", err)
+	}
+	// The underlying cause must stay readable for logs.
+	if !errors.Is(err, cause) {
+		t.Fatalf("the original error must be preserved alongside the sentinel; got %q", err)
+	}
+}
+
+func TestAnnotateDeadline_LeavesGenuineFailuresAlone(t *testing.T) {
+	cause := errors.New("can't find session: agentdeck-nope")
+	err := annotateDeadline(nil, cause)
+	if errors.Is(err, errTmuxTimeout) {
+		t.Fatal("a tmux-reported failure must not be disguised as a timeout: " +
+			"callers treat timeouts as benign and would swallow a real error")
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("cause must pass through unchanged; got %v", err)
+	}
+}
+
+func TestAnnotateDeadline_SuccessStaysSuccess(t *testing.T) {
+	// A context can be past its deadline by the time the command returns and
+	// still have succeeded; only an actual failure gets annotated.
+	if err := annotateDeadline(context.DeadlineExceeded, nil); err != nil {
+		t.Fatalf("nil run error must stay nil; got %v", err)
+	}
+}

--- a/internal/tmux/respawn_escalation_test.go
+++ b/internal/tmux/respawn_escalation_test.go
@@ -1,0 +1,191 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The post-respawn `getPaneProcessTree` probe is now bounded (2026-07-21 fd-leak
+// incident). Bounding introduced a new failure mode: a timed-out probe returns
+// panePID 0, and 0 never matches a real PID, so the `pid == newPanePID` guard in
+// ensureProcessesDead silently disengages. If tmux hands the fresh pane process
+// a PID that was in the pre-respawn tree — the reuse case the guard exists for —
+// the escalation SIGTERM→SIGKILLs the process the user just restarted.
+//
+// The rule these tests pin: an INDETERMINATE probe must not be read as
+// "the new pane is not among the old PIDs". Skipping the escalation leaves at
+// worst a logged orphan; guessing kills a live agent mid-work.
+
+// startSigtermImmuneChild spawns a child that survives SIGTERM but not SIGKILL,
+// so "still alive after the escalation" is an unambiguous signal that the
+// escalation never reached its SIGKILL stage.
+//
+// Two things about the command are load-bearing, both learned the hard way:
+//
+// bash, not sh: the respawn path consults isOurProcess (tmux.go), whose narrow
+// allowlist matches "bash" but not the "dash" that /bin/sh is on Debian/Ubuntu.
+//
+// A LOOP, not a bare `sleep 30`: bash exec-optimizes `bash -c '<single
+// command>'` into the command itself, replacing the process — so the child's
+// comm becomes "sleep", which isOurProcess does not match, and the escalation
+// skips it. Whether that fires depends on the bash version (5.0 kept bash
+// resident, the CI runner's newer bash did not), so it flipped between
+// developer machines and CI. The loop keeps a real bash in place everywhere.
+// isOurProcessLoose (ensure_pids_dead.go) carries "sleep"/"dash" in its
+// allowlist for this same harness hazard.
+func startSigtermImmuneChild(t *testing.T) int {
+	t.Helper()
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skipf("posix signal semantics only; GOOS=%s", runtime.GOOS)
+	}
+
+	cmd := exec.Command("bash", "-c", "trap '' TERM HUP; while :; do sleep 1; done")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	// Reap on exit so kill(pid, 0) reports ESRCH instead of finding a zombie
+	// that Go has not waited on yet.
+	reaped := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(reaped)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-reaped
+	})
+
+	time.Sleep(150 * time.Millisecond) // let the trap install
+	pid := cmd.Process.Pid
+	if !pidIsAlive(pid) {
+		t.Fatalf("setup: child %d not alive", pid)
+	}
+
+	// Guard the guard. Every assertion below reduces to "did ensureProcessesDead
+	// signal this PID", and it only signals PIDs isOurProcess vouches for — so if
+	// the child is not recognized, the survival tests pass while proving nothing
+	// and the reap test fails for a reason that looks nothing like its message.
+	// Both happened here before this check existed.
+	comm, psErr := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if psErr != nil {
+		t.Skipf("ps unavailable (%v): isOurProcess cannot classify anything on this "+
+			"host, so the escalation is a no-op by construction and nothing here is testable", psErr)
+	}
+	if !isOurProcess(pid) {
+		t.Fatalf("setup: child comm is %q, which isOurProcess does not match — the "+
+			"escalation would skip it and every assertion in this file would be vacuous",
+			strings.TrimSpace(string(comm)))
+	}
+	return pid
+}
+
+func pidIsAlive(pid int) bool {
+	return syscall.Kill(pid, syscall.Signal(0)) == nil
+}
+
+// waitForDeath polls rather than sleeping a fixed span: the escalation SIGKILLs
+// and the reaper goroutine clears the zombie asynchronously.
+//
+// It is also the correct way to assert the NEGATIVE. kill(pid, 0) keeps
+// succeeding for the moment between SIGKILL and the wait() that clears the
+// zombie, so a bare pidIsAlive() immediately after the escalation returns "alive"
+// even for a process that was just killed — that false green is exactly what
+// this helper exists to prevent.
+func waitForDeath(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !pidIsAlive(pid) {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+// survivalGrace is how long a killed process is given to actually disappear
+// before "still alive" is believed. SIGKILL + wait() is sub-millisecond; 500ms
+// is generous.
+const survivalGrace = 500 * time.Millisecond
+
+// deadSessionForEscalation returns a Session whose tmux session does not exist,
+// so the escalation's own re-probe fails for real (no stubbing): `list-panes`
+// against a missing session exits non-zero immediately.
+func deadSessionForEscalation() *Session {
+	return &Session{
+		Name:       "agentdeck-escalation-probe-absent",
+		SocketName: DefaultSocketName(),
+	}
+}
+
+// An indeterminate post-respawn probe must NOT be treated as "new pane PID is
+// not in oldPIDs". This is M1: the freshly respawned process must survive.
+func TestEscalateAfterRespawn_SkipsEscalationWhenPanePIDUnknown(t *testing.T) {
+	pid := startSigtermImmuneChild(t)
+
+	s := deadSessionForEscalation()
+	// probeErr non-nil == the bounded pane probe timed out or failed, so the
+	// new process tree is unknown (nil).
+	s.escalateAfterRespawn([]int{pid}, nil, errors.New("signal: killed"))
+
+	if waitForDeath(pid, survivalGrace) {
+		t.Fatal("escalation killed a process while the new pane PID was unknown: " +
+			"an indeterminate probe must skip the SIGTERM→SIGKILL stage, not assume " +
+			"the fresh process is absent from oldPIDs")
+	}
+}
+
+// The guard the unknown-PID case disengages: a PID that IS the new pane process
+// must never be escalated against.
+func TestEscalateAfterRespawn_SparesTheNewPaneProcess(t *testing.T) {
+	pid := startSigtermImmuneChild(t)
+
+	s := deadSessionForEscalation()
+	s.escalateAfterRespawn([]int{pid}, []int{pid}, nil)
+
+	if waitForDeath(pid, survivalGrace) {
+		t.Fatal("escalation killed the process it was told is the new pane process")
+	}
+}
+
+// The pane process is not the only thing the respawn creates: `bash -lc <agent>`
+// forks children (node, claude) that pass isOurProcess just as readily. Sparing
+// only the pane PID leaves those exposed to a PID collision with the old tree,
+// so the whole new tree is excluded, not just its root.
+func TestEscalateAfterRespawn_SparesEveryPIDInTheNewTree(t *testing.T) {
+	paneLike := startSigtermImmuneChild(t)
+	childLike := startSigtermImmuneChild(t)
+
+	s := deadSessionForEscalation()
+	// Both appear in the stale tree AND in the fresh one — the collision case.
+	s.escalateAfterRespawn([]int{paneLike, childLike}, []int{paneLike, childLike}, nil)
+
+	if waitForDeath(childLike, survivalGrace) {
+		t.Fatal("escalation killed a descendant of the freshly respawned process: " +
+			"the exclusion must cover the whole new tree, not just the pane PID")
+	}
+	if !pidIsAlive(paneLike) {
+		t.Fatal("escalation killed the new pane process")
+	}
+}
+
+// Negative control: with a resolved pane PID that is genuinely not in the old
+// tree, the escalation must still do its job — the SIGHUP-immune-agent reap
+// (Claude Code 2.1.27+) is why this code exists at all.
+func TestEscalateAfterRespawn_StillReapsSurvivorsWhenPanePIDKnown(t *testing.T) {
+	pid := startSigtermImmuneChild(t)
+
+	s := deadSessionForEscalation()
+	// os.Getpid() is a live PID that is certainly not the child.
+	s.escalateAfterRespawn([]int{pid}, []int{os.Getpid()}, nil)
+
+	if !waitForDeath(pid, 2*time.Second) {
+		t.Fatal("escalation left a SIGTERM-immune survivor alive")
+	}
+}

--- a/internal/tmux/socket.go
+++ b/internal/tmux/socket.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -314,6 +315,62 @@ func (s *Session) runBoundedOutput(args ...string) ([]byte, error) {
 // commands that produce no output.
 func (s *Session) runBoundedRun(args ...string) error {
 	return runBoundedRun(s.SocketName, args...)
+}
+
+// tmuxMutationTimeout bounds the state-CHANGING tmux commands: kill-session,
+// switch-client, detach-client. The fd leak that motivates every deadline in
+// this file is a property of the tmux CLIENT, not of the subcommand it carries,
+// so a mutation client wedges exactly like a poll client — and these run on the
+// same cadences (the notification-bar sweep issues one switch/detach per
+// attached client; kill-session runs on every teardown).
+//
+// It is deliberately longer than tmuxPollTimeout. The asymmetry is in what a
+// FALSE timeout costs: a read that gives up too early is re-issued by the next
+// poll a second later, while a kill-session abandoned early can leave a session
+// the user asked to be gone lingering until the next sweep. Both directions are
+// tolerated at the call sites — Kill/KillAndWait re-probe Exists() and treat
+// "gone" as success, SwitchAttachedClients falls back to a focus_request,
+// DetachClientsOnSockets leaves the TUI attached where it was — so the failure
+// mode is a no-op, never a corrupted half-state.
+var tmuxMutationTimeout = 5 * time.Second
+
+// errTmuxTimeout marks a command we abandoned at its deadline, as opposed to
+// one tmux answered with a failure. Callers need the distinction: "we gave up"
+// is a benign, retryable non-event that should fall through to a slower path,
+// while "tmux said no" is a real error that must surface. Without it every
+// timeout arrives as an opaque `signal: killed` ExitError and gets treated as
+// the latter.
+var errTmuxTimeout = errors.New("tmux command exceeded its deadline")
+
+// annotateDeadline wraps a failed run with errTmuxTimeout when the command's
+// context deadline had fired, preserving the original error for logs. The
+// deadline only matters for a run that FAILED: a command can complete
+// successfully just as its deadline expires, and that is a success.
+func annotateDeadline(ctxErr, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", errTmuxTimeout, err)
+	}
+	return err
+}
+
+// runBoundedMutation runs a state-changing tmux command under
+// tmuxMutationTimeout. Timeout-guarded replacement for the bare
+// tmuxExec(socket, args...).Run() / s.tmuxCmd(args...).Run() mutation sites.
+// A deadline failure comes back wrapped in errTmuxTimeout.
+func runBoundedMutation(socketName string, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxMutationTimeout)
+	defer cancel()
+	err := tmuxExecContext(ctx, socketName, args...).Run()
+	return annotateDeadline(ctx.Err(), err)
+}
+
+// runBoundedMutation is the per-Session convenience wrapper, targeting the
+// session's own socket (see tmuxCmd for why the socket must not drift).
+func (s *Session) runBoundedMutation(args ...string) error {
+	return runBoundedMutation(s.SocketName, args...)
 }
 
 // OutputBounded is the public counterpart to runBoundedOutput, for cadence

--- a/internal/tmux/socket.go
+++ b/internal/tmux/socket.go
@@ -316,6 +316,16 @@ func (s *Session) runBoundedRun(args ...string) error {
 	return runBoundedRun(s.SocketName, args...)
 }
 
+// OutputBounded is the public counterpart to runBoundedOutput, for cadence
+// queries fired from outside internal/tmux (internal/session pane-PID probes,
+// CLI helpers). Prefer it over Exec(...).Output() for anything on a timer:
+// Exec has no deadline, and a tmux client that has leaked its fd table spins
+// at 100% CPU forever rather than exiting, so an unbounded .Output() never
+// returns. See tmuxPollTimeout.
+func OutputBounded(socketName string, args ...string) ([]byte, error) {
+	return runBoundedOutput(socketName, args...)
+}
+
 // Exec is the public package counterpart to tmuxExec. Call sites outside
 // internal/tmux (the session package, CLI helpers, web terminal bridge) use
 // this when they have a socket name — typically Instance.TmuxSocketName —

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1744,7 +1744,18 @@ func AnyAgentDeckSessionWithEnvValue(envKey, envValue string) (string, bool) {
 	}
 
 	socket := DefaultSocketName()
-	out, err := tmuxExec(socket, "list-sessions", "-F", "#{session_name}").Output()
+	// Bounded — see tmuxPollTimeout.
+	//
+	// CAUTION before wiring this to SpawnAttempt.AlreadyAlive (it has no
+	// production caller today): the bool return conflates "probed, found
+	// nothing" with "probe failed or timed out". A timeout therefore reads as
+	// "no live session", which is the permissive answer — the opposite of what
+	// a spawn guard wants, and the opposite of what Exists() does, where an
+	// indeterminate probe is deliberately treated as "still alive" so a live
+	// session is never flipped to error. Give this a three-state result
+	// (found / not-found / indeterminate) before making a spawn decision
+	// depend on it.
+	out, err := runBoundedOutput(socket, "list-sessions", "-F", "#{session_name}")
 	if err != nil {
 		return "", false
 	}
@@ -1753,7 +1764,7 @@ func AnyAgentDeckSessionWithEnvValue(envKey, envValue string) (string, bool) {
 		if name == "" || !strings.HasPrefix(name, SessionPrefix) {
 			continue
 		}
-		val, err := tmuxExec(socket, "show-environment", "-t", name, envKey).Output()
+		val, err := runBoundedOutput(socket, "show-environment", "-t", name, envKey)
 		if err != nil {
 			continue
 		}
@@ -1777,7 +1788,8 @@ func KillSessionsWithEnvValue(envKey, envValue, excludeName string) {
 	}
 
 	socket := DefaultSocketName()
-	out, err := tmuxExec(socket, "list-sessions", "-F", "#{session_name}").Output()
+	// Bounded — see tmuxPollTimeout.
+	out, err := runBoundedOutput(socket, "list-sessions", "-F", "#{session_name}")
 	if err != nil {
 		return
 	}
@@ -1789,7 +1801,7 @@ func KillSessionsWithEnvValue(envKey, envValue, excludeName string) {
 		if !strings.HasPrefix(name, SessionPrefix) {
 			continue
 		}
-		val, err := tmuxExec(socket, "show-environment", "-t", name, envKey).Output()
+		val, err := runBoundedOutput(socket, "show-environment", "-t", name, envKey)
 		if err != nil {
 			continue
 		}
@@ -1929,7 +1941,10 @@ func recoverFromStaleDefaultSocketIfNeeded(startErrOutput string) (bool, error) 
 	}
 
 	// If tmux can already answer list-sessions, don't touch any socket file.
-	if err := tmuxExec(DefaultSocketName(), "list-sessions").Run(); err == nil {
+	// Bounded — see tmuxPollTimeout. This is the recovery path for a server
+	// that already misbehaved, so it is exactly where a client is most likely
+	// to hang; an unbounded probe here would block recovery indefinitely.
+	if err := runBoundedRun(DefaultSocketName(), "list-sessions"); err == nil {
 		return false, nil
 	}
 
@@ -2657,8 +2672,19 @@ func (s *Session) Kill() error {
 // Used before respawn to track processes that must die.
 func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 	target := s.Name + ":"
-	out, err := s.tmuxCmd("list-panes", "-t", target, "-F", "#{pane_pid}").Output()
+	// Bounded — see tmuxPollTimeout. Runs on the respawn path: a hang here
+	// stalls the restart that is supposed to clear the bad state.
+	out, err := s.runBoundedOutput("list-panes", "-t", target, "-F", "#{pane_pid}")
 	if err != nil {
+		// A failed probe is indistinguishable from "no panes" to our callers,
+		// and they respond by SKIPPING the SIGTERM->SIGKILL escalation that
+		// exists because Claude Code 2.1.27+ ignores tmux's SIGHUP. Degrading
+		// to "no PIDs" is the right trade against the old infinite hang, but it
+		// must not be silent: on a loaded box this is how a SIGHUP-immune agent
+		// survives a Kill() as an orphan.
+		statusLog.Warn("pane_process_tree_probe_failed",
+			slog.String("session", s.Name),
+			slog.String("error", err.Error()))
 		return 0, nil
 	}
 	// Take only the first line (handles multi-pane sessions safely)
@@ -3049,8 +3075,10 @@ func (s *Session) CapturePaneFresh() (string, error) {
 func (s *Session) CaptureFullHistory() (string, error) {
 	// Limit to last 2000 lines to balance content availability with memory usage
 	// AI agent conversations can be long - 2000 lines captures ~40-80 screens of content
-	cmd := s.tmuxCmd("capture-pane", "-t", s.Name, "-p", "-e", "-S", "-2000")
-	output, err := cmd.Output()
+	// Bounded — see tmuxPollTimeout. The TUI calls this on a cadence, and it
+	// was the single largest CPU sink in the 2026-07-21 incident: three
+	// concurrent `capture-pane -S -2000` clients, each spinning >20 minutes.
+	output, err := s.runBoundedOutput("capture-pane", "-t", s.Name, "-p", "-e", "-S", "-2000")
 	if err != nil {
 		return "", fmt.Errorf("failed to capture history: %w", err)
 	}
@@ -3086,8 +3114,8 @@ func (s *Session) CaptureHistoryLines(n int) (string, error) {
 // CaptureWindowFullHistory captures the scrollback history of a specific window (last 2000 lines).
 func (s *Session) CaptureWindowFullHistory(windowIndex int) (string, error) {
 	target := fmt.Sprintf("%s:%d", s.Name, windowIndex)
-	cmd := s.tmuxCmd("capture-pane", "-t", target, "-p", "-e", "-S", "-2000")
-	output, err := cmd.Output()
+	// Bounded — see tmuxPollTimeout.
+	output, err := s.runBoundedOutput("capture-pane", "-t", target, "-p", "-e", "-S", "-2000")
 	if err != nil {
 		return "", fmt.Errorf("failed to capture window %d history: %w", windowIndex, err)
 	}
@@ -5106,8 +5134,8 @@ func (s *Session) SplitShellPane(workdir string) error {
 // ListAllSessions returns all Agent Deck tmux sessions
 func ListAllSessions() ([]*Session, error) {
 	socket := DefaultSocketName()
-	cmd := tmuxExec(socket, "list-sessions", "-F", "#{session_name}")
-	output, err := cmd.Output()
+	// Bounded — see tmuxPollTimeout.
+	output, err := runBoundedOutput(socket, "list-sessions", "-F", "#{session_name}")
 	if err != nil {
 		// No sessions exist
 		if strings.Contains(err.Error(), "no server running") ||
@@ -5329,8 +5357,9 @@ func RunLogMaintenance(maxSizeMB int, maxLines int, removeOrphans bool) {
 // those in the current profile. This ensures consistent notification bars
 // when users switch between sessions.
 func ListAgentDeckSessions() ([]string, error) {
-	cmd := tmuxExec(DefaultSocketName(), "list-sessions", "-F", "#{session_name}")
-	output, err := cmd.Output()
+	// Bounded — see tmuxPollTimeout. Drives the cross-profile notification-bar
+	// refresh, i.e. it runs on a timer for every session.
+	output, err := runBoundedOutput(DefaultSocketName(), "list-sessions", "-F", "#{session_name}")
 	if err != nil {
 		// No sessions exist
 		if strings.Contains(err.Error(), "no server running") ||
@@ -5649,8 +5678,9 @@ func WriteAckSignal(sessionID string) error {
 func attachedClientNames(socket string) []string {
 	// client_name is free-text (a pts path) so it goes LAST, after the 0/1
 	// control-mode flag, to stay collision-safe under tmuxFieldSep.
-	cmd := tmuxExec(socket, "list-clients", "-F", tmuxFmt("#{client_control_mode}", "#{client_name}"))
-	output, err := cmd.Output()
+	// Bounded — see tmuxPollTimeout. list-clients against a wedged server was
+	// one of the observed spin sources.
+	output, err := runBoundedOutput(socket, "list-clients", "-F", tmuxFmt("#{client_control_mode}", "#{client_name}"))
 	if err != nil {
 		return nil
 	}
@@ -5775,8 +5805,8 @@ func GetActiveSession() (string, error) {
 
 // DiscoverAllTmuxSessions returns all tmux sessions (including non-Agent Deck ones)
 func DiscoverAllTmuxSessions() ([]*Session, error) {
-	cmd := tmuxExec(DefaultSocketName(), "list-sessions", "-F", "#{session_name}:#{pane_current_path}")
-	output, err := cmd.Output()
+	// Bounded — see tmuxPollTimeout.
+	output, err := runBoundedOutput(DefaultSocketName(), "list-sessions", "-F", "#{session_name}:#{pane_current_path}")
 	if err != nil {
 		// No sessions exist
 		if strings.Contains(err.Error(), "no server running") ||

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2272,9 +2272,11 @@ func (s *Session) Start(command string) error {
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where
 	// XON/XOFF flow control intercepts the key before it reaches the PTY stdin
 	// reader (e.g. iTerm2 on macOS). Only binds on agentdeck-managed sessions.
-	_ = s.tmuxCmd("bind-key", "-n", "-T", "root", "C-q",
+	// Bounded — see tmuxMutationTimeout. Best-effort already, and it runs on
+	// the session-create path where a wedged client would stall the create.
+	_ = s.runBoundedMutation("bind-key", "-n", "-T", "root", "C-q",
 		"if-shell", fmt.Sprintf("[ \"#{session_name}\" = \"%s\" ]", s.Name),
-		"detach-client", "").Run()
+		"detach-client", "")
 
 	// Apply user-specified tmux option overrides from config (after defaults).
 	// These are batched into a single call when multiple overrides are present.
@@ -2597,8 +2599,9 @@ func (s *Session) EnableMouseMode() error {
 	if s.mouse {
 		// CRITICAL: Mouse mode must succeed - keep as separate call for error handling
 		// This is the only essential feature; all others are enhancements
-		mouseCmd := s.tmuxCmd("set-option", "-t", s.Name, "mouse", "on")
-		if err := mouseCmd.Run(); err != nil {
+		// Bounded — see tmuxMutationTimeout. The one option whose failure is
+		// fatal, so it must not be the one that hangs forever.
+		if err := s.runBoundedMutation("set-option", "-t", s.Name, "mouse", "on"); err != nil {
 			return err
 		}
 	}
@@ -5503,16 +5506,16 @@ func ListAgentDeckSessions() ([]string, error) {
 func SetStatusLeft(sessionName, text string) error {
 	// Escape single quotes for tmux by replacing ' with '\''
 	escaped := strings.ReplaceAll(text, "'", "'\\''")
-	cmd := tmuxExec(DefaultSocketName(), "set-option", "-t", sessionName, "status-left", escaped)
-	return cmd.Run()
+	// Bounded — see tmuxMutationTimeout. Driven by the notification sweep.
+	return runBoundedMutation(DefaultSocketName(), "set-option", "-t", sessionName, "status-left", escaped)
 }
 
 // ClearStatusLeft resets status-left to default for a session.
 // Called when notifications are cleared or acknowledged.
 func ClearStatusLeft(sessionName string) error {
 	// -u flag unsets the option, reverting to tmux default
-	cmd := tmuxExec(DefaultSocketName(), "set-option", "-t", sessionName, "-u", "status-left")
-	return cmd.Run()
+	// Bounded — see tmuxMutationTimeout.
+	return runBoundedMutation(DefaultSocketName(), "set-option", "-t", sessionName, "-u", "status-left")
 }
 
 // savedStatusLeft holds the original global status-left value before agent-deck overwrites it.
@@ -5527,7 +5530,9 @@ var savedStatusLeft struct {
 // captureOriginalStatusLeft reads and stores the current global status-left value.
 // Called once on first SetStatusLeftGlobal to preserve the user's existing value.
 func captureOriginalStatusLeft() {
-	out, err := tmuxExec(DefaultSocketName(), "show-option", "-gv", "status-left").Output()
+	// Bounded — see tmuxPollTimeout. A read, and the only chance to capture the
+	// user's theme value: if it hangs, SetStatusLeftGlobal never runs either.
+	out, err := runBoundedOutput(DefaultSocketName(), "show-option", "-gv", "status-left")
 	if err == nil {
 		savedStatusLeft.value = strings.TrimRight(string(out), "\n")
 		savedStatusLeft.captured = true
@@ -5541,8 +5546,8 @@ func captureOriginalStatusLeft() {
 func SetStatusLeftGlobal(text string) error {
 	savedStatusLeft.Do(captureOriginalStatusLeft)
 	escaped := strings.ReplaceAll(text, "'", "'\\''")
-	cmd := tmuxExec(DefaultSocketName(), "set-option", "-g", "status-left", escaped)
-	return cmd.Run()
+	// Bounded — see tmuxMutationTimeout. Driven by the notification sweep.
+	return runBoundedMutation(DefaultSocketName(), "set-option", "-g", "status-left", escaped)
 }
 
 // ClearStatusLeftGlobal restores the original global status-left value.
@@ -5553,10 +5558,11 @@ func ClearStatusLeftGlobal() error {
 	socket := DefaultSocketName()
 	if savedStatusLeft.captured {
 		escaped := strings.ReplaceAll(savedStatusLeft.value, "'", "'\\''")
-		return tmuxExec(socket, "set-option", "-g", "status-left", escaped).Run()
+		// Bounded — see tmuxMutationTimeout.
+		return runBoundedMutation(socket, "set-option", "-g", "status-left", escaped)
 	}
 	// No saved value — fall back to unset (original behavior)
-	return tmuxExec(socket, "set-option", "-gu", "status-left").Run()
+	return runBoundedMutation(socket, "set-option", "-gu", "status-left")
 }
 
 // InitializeStatusBarOptions sets optimal status bar options for agent-deck.
@@ -5565,7 +5571,8 @@ func ClearStatusLeftGlobal() error {
 func InitializeStatusBarOptions() error {
 	// Set adequate status-left-length globally (default is only 10 chars!)
 	// This ensures the notification bar content is not truncated
-	return tmuxExec(DefaultSocketName(), "set-option", "-g", "status-left-length", "120").Run()
+	// Bounded — see tmuxMutationTimeout.
+	return runBoundedMutation(DefaultSocketName(), "set-option", "-g", "status-left-length", "120")
 }
 
 // RefreshStatusBarImmediate forces an immediate status bar redraw for ALL connected clients.
@@ -5593,7 +5600,9 @@ func RefreshStatusBarImmediate() error {
 		if parts[0] == "1" {
 			continue
 		}
-		_ = tmuxExec(socket, "refresh-client", "-S", "-t", parts[1]).Run()
+		// Bounded — see tmuxMutationTimeout. One client per iteration on the
+		// bar-refresh path: the highest-frequency spawn site in the codebase.
+		_ = runBoundedMutation(socket, "refresh-client", "-S", "-t", parts[1])
 	}
 	return nil
 }
@@ -5671,8 +5680,8 @@ func attachedSessionsOnSocket(socket string) ([]string, error) {
 // The key should be a single character like "1", "2", etc.
 // Deprecated: Use BindSwitchKeyWithAck for notification bar integration.
 func BindSwitchKey(key, targetSession string) error {
-	cmd := tmuxExec(DefaultSocketName(), "bind-key", key, "switch-client", "-t", targetSession)
-	return cmd.Run()
+	// Bounded — see tmuxMutationTimeout. agent-deck rebinds these keys every 2s.
+	return runBoundedMutation(DefaultSocketName(), "bind-key", key, "switch-client", "-t", targetSession)
 }
 
 // BindSwitchKeyWithAck binds a number key to switch to target session AND
@@ -5692,8 +5701,8 @@ func BindSwitchKeyWithAck(key, targetSession, sessionID string) error {
 	_ = os.MkdirAll(filepath.Dir(signalFile), 0o700)
 
 	script := buildAckSwitchScript(signalFile, sessionID, targetSession)
-	cmd := tmuxExec(DefaultSocketName(), "bind-key", key, "run-shell", script)
-	return cmd.Run()
+	// Bounded — see tmuxMutationTimeout. agent-deck rebinds these keys every 2s.
+	return runBoundedMutation(DefaultSocketName(), "bind-key", key, "run-shell", script)
 }
 
 // buildAckSwitchScript builds the run-shell command bound to a quick-switch key.
@@ -5901,11 +5910,12 @@ func DetachClientsOnSockets(sockets ...string) (bool, error) {
 func UnbindKey(key string) error {
 	socket := DefaultSocketName()
 	// First unbind our custom binding
-	_ = tmuxExec(socket, "unbind-key", key).Run()
+	// Bounded — see tmuxMutationTimeout. Both are best-effort already.
+	_ = runBoundedMutation(socket, "unbind-key", key)
 
 	// Best-effort restore default: number keys select windows
 	// bind-key 1 select-window -t :1
-	_ = tmuxExec(socket, "bind-key", key, "select-window", "-t", ":"+key).Run()
+	_ = runBoundedMutation(socket, "bind-key", key, "select-window", "-t", ":"+key)
 	return nil
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -44,6 +44,11 @@ var (
 // tmux_fallback_test.go for the contract.
 var execCommand = exec.Command
 
+// execCommandContext is the deadline-carrying counterpart to execCommand, kept
+// as its own seam so a bounded call site stays overridable by the same tests.
+// Use it for any tmux invocation that must terminate — see tmuxMutationTimeout.
+var execCommandContext = exec.CommandContext
+
 type tmuxThemeStyle struct {
 	windowStyle       string
 	windowActiveStyle string
@@ -1814,7 +1819,9 @@ func KillSessionsWithEnvValue(envKey, envValue, excludeName string) {
 					slog.String("env_key", envKey),
 					slog.String("env_value", envValue),
 					slog.String("kept", excludeName))
-				_ = tmuxExec(socket, "kill-session", "-t", name).Run()
+				// Bounded — see tmuxMutationTimeout. Best-effort already (error
+				// discarded), so a timeout changes nothing but the wait.
+				_ = runBoundedMutation(socket, "kill-session", "-t", name)
 			}
 		}
 	}
@@ -2645,13 +2652,16 @@ func (s *Session) Kill() error {
 		respawnLog.Info("pre_kill_process_tree", slog.String("session", s.Name), slog.Any("pids", oldPIDs))
 	}
 
-	// Kill the tmux session
-	cmd := s.tmuxCmd("kill-session", "-t", s.Name)
-	err := cmd.Run()
+	// Kill the tmux session. Bounded — see tmuxMutationTimeout. A client
+	// SIGKILLed at the deadline yields a non-nil err, which the Exists() re-probe
+	// below resolves: if the server did process the kill, the session is gone and
+	// this returns success anyway.
+	err := s.runBoundedMutation("kill-session", "-t", s.Name)
 
-	// Verify old processes are dead; escalate to SIGKILL if needed
+	// Verify old processes are dead; escalate to SIGKILL if needed. No new
+	// process exists on this path — the session is gone — so nothing is spared.
 	if len(oldPIDs) > 0 {
-		go s.ensureProcessesDead(oldPIDs, 0)
+		go s.ensureProcessesDead(oldPIDs, nil)
 	}
 
 	// Killing a session that no longer exists is success, not failure: tmux
@@ -2669,12 +2679,11 @@ func (s *Session) Kill() error {
 }
 
 // getPaneProcessTree returns the pane's direct PID and all descendant PIDs.
-// Used before respawn to track processes that must die.
+// Used before respawn to track processes that must die. A probe that fails is
+// reported as an empty tree; callers that can act on the difference between
+// "no processes" and "could not tell" must use paneProcessTree instead.
 func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
-	target := s.Name + ":"
-	// Bounded — see tmuxPollTimeout. Runs on the respawn path: a hang here
-	// stalls the restart that is supposed to clear the bad state.
-	out, err := s.runBoundedOutput("list-panes", "-t", target, "-F", "#{pane_pid}")
+	panePID, allPIDs, err := s.paneProcessTree()
 	if err != nil {
 		// A failed probe is indistinguishable from "no panes" to our callers,
 		// and they respond by SKIPPING the SIGTERM->SIGKILL escalation that
@@ -2687,14 +2696,25 @@ func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 			slog.String("error", err.Error()))
 		return 0, nil
 	}
-	// Take only the first line (handles multi-pane sessions safely)
-	pidStr := strings.TrimSpace(string(out))
-	if idx := strings.IndexByte(pidStr, '\n'); idx >= 0 {
-		pidStr = pidStr[:idx]
-	}
-	panePID, err = strconv.Atoi(pidStr)
+	return panePID, allPIDs
+}
+
+// paneProcessTree is getPaneProcessTree with the probe outcome preserved.
+//
+// The distinction matters on exactly one path: the post-respawn probe in
+// RespawnPane. Its result feeds the `pid == newPanePID` guard in
+// ensureProcessesDead, and a degraded panePID of 0 matches no real process — so
+// an indeterminate probe silently disengages the guard and the escalation can
+// SIGTERM->SIGKILL the process the user just restarted. See
+// escalateAfterRespawn.
+func (s *Session) paneProcessTree() (panePID int, allPIDs []int, err error) {
+	target := s.Name + ":"
+	// Bounded — see tmuxPollTimeout. Runs on the respawn path: a hang here
+	// stalls the restart that is supposed to clear the bad state.
+	out, err := s.runBoundedOutput("list-panes", "-t", target, "-F", "#{pane_pid}")
+	panePID, err = parsePanePID(out, err)
 	if err != nil {
-		return 0, nil
+		return 0, nil, err
 	}
 
 	// Collect the pane PID plus all descendants via pgrep -P (recursive)
@@ -2714,7 +2734,40 @@ func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 			}
 		}
 	}
-	return panePID, allPIDs
+	return panePID, allPIDs, nil
+}
+
+// parsePanePID turns a `list-panes -F #{pane_pid}` result into the pane's PID.
+//
+// It honors the WaitDelay contract documented at tmuxSubprocessWaitDelay: when
+// cmd.Wait abandons the I/O goroutine mid-read (exec.ErrWaitDelay), the bytes
+// the subprocess already wrote are still in the buffer, so a body that parses
+// cleanly is authoritative and the error is not. That case is the norm, not an
+// edge, under the bridged-stdio setups WaitDelay exists for — Claude Code
+// /remote-control, ssh ControlMaster — where treating it as failure would make
+// every probe indeterminate and permanently skip the reap.
+//
+// Everything else is indeterminate: a client killed at its deadline, a missing
+// session, an empty or garbled body. None of them may be reported as "the pane
+// has no process", because callers answer an empty tree by skipping the
+// SIGTERM->SIGKILL escalation.
+func parsePanePID(out []byte, err error) (int, error) {
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
+		return 0, err
+	}
+	// Take only the first line (handles multi-pane sessions safely)
+	pidStr := strings.TrimSpace(string(out))
+	if idx := strings.IndexByte(pidStr, '\n'); idx >= 0 {
+		pidStr = strings.TrimSpace(pidStr[:idx])
+	}
+	pid, convErr := strconv.Atoi(pidStr)
+	if convErr != nil || pid <= 0 {
+		if err != nil {
+			return 0, fmt.Errorf("no usable pane_pid in %q: %w", pidStr, err)
+		}
+		return 0, fmt.Errorf("unparseable pane_pid %q", pidStr)
+	}
+	return pid, nil
 }
 
 // isOurProcess checks if a PID still belongs to a process we spawned
@@ -2737,7 +2790,14 @@ func isOurProcess(pid int) bool {
 // ensureProcessesDead checks if any of the given PIDs are still alive and
 // escalates from SIGTERM to SIGKILL. This prevents zombie/orphan process
 // accumulation when CLI tools (e.g. Claude Code) ignore SIGHUP from tmux.
-func (s *Session) ensureProcessesDead(oldPIDs []int, newPanePID int) {
+//
+// newPIDs is the process tree the respawn just created, and is excluded from
+// the escalation: tmux reuses the pane PID slot sometimes, and `bash -lc
+// <agent>` forks children (node, claude) that pass isOurProcess just as
+// readily as the ones being reaped — so sparing only the pane process would
+// still leave a fresh descendant killable on a PID collision. Pass nil when no
+// new process exists (Kill), which spares nothing.
+func (s *Session) ensureProcessesDead(oldPIDs []int, newPIDs []int) {
 	if len(oldPIDs) == 0 {
 		return
 	}
@@ -2745,10 +2805,15 @@ func (s *Session) ensureProcessesDead(oldPIDs []int, newPanePID int) {
 	// Wait briefly for respawn-pane's SIGHUP to take effect
 	time.Sleep(500 * time.Millisecond)
 
+	spared := make(map[int]struct{}, len(newPIDs))
+	for _, pid := range newPIDs {
+		spared[pid] = struct{}{}
+	}
+
 	var survivors []int
 	for _, pid := range oldPIDs {
-		// Skip the new pane process (respawn reuses the pane PID slot sometimes)
-		if pid == newPanePID {
+		// Never escalate against anything the respawn just created
+		if _, isNew := spared[pid]; isNew {
 			continue
 		}
 		// Check if process is still alive (signal 0 = existence check)
@@ -2807,6 +2872,57 @@ func (s *Session) ensureProcessesDead(oldPIDs []int, newPanePID int) {
 		}
 	}
 	respawnLog.Info("sigkill_cleanup_complete", slog.Int("count", len(stubborn)))
+}
+
+// respawnPanePIDRetryDelay is how long escalateAfterRespawn waits before
+// re-probing a pane PID the first probe could not resolve. One deadline's worth
+// of grace: the client that ate the first probe is SIGKILLed at
+// tmuxPollTimeout, and its replacement talks to a server that is not itself
+// wedged (the 2026-07-21 leak is per-client), so the retry usually lands.
+const respawnPanePIDRetryDelay = 500 * time.Millisecond
+
+// escalateAfterRespawn runs the post-respawn SIGTERM->SIGKILL escalation that
+// reaps agents ignoring tmux's SIGHUP (Claude Code 2.1.27+).
+//
+// It exists to keep one specific mistake from being possible: treating an
+// INDETERMINATE pane-PID probe as a resolved one. ensureProcessesDead's only
+// protection for the freshly respawned tree is that its PIDs are excluded, and
+// the bounded probe degrades to an empty tree on timeout. Pass that through and
+// the guard is off; if tmux handed the new pane a PID from the pre-respawn tree
+// (the reuse case the guard was written for), the escalation kills the process
+// the user just restarted.
+//
+// So a probe failure is retried once, off RespawnPane's critical path, and if
+// it still cannot be resolved the escalation is skipped entirely.
+//
+// That trade is deliberate and asymmetric, but be clear about its cost: the
+// skipped escalation LEAKS a SIGHUP-immune survivor permanently. Nothing else
+// reaps it — reapOrphanedPollClients only kills processes whose comm is "tmux",
+// and after `respawn-pane -k` the survivor is reparented out of the pane, so no
+// later getPaneProcessTree walk will ever include it. It needs a manual kill,
+// which is why the skip logs at Warn. We accept a leak that is logged and
+// visible in `ps` over destroying live work on a guess, with no warning and no
+// recovery.
+func (s *Session) escalateAfterRespawn(oldPIDs []int, newPIDs []int, probeErr error) {
+	if len(oldPIDs) == 0 {
+		return
+	}
+
+	if probeErr != nil {
+		time.Sleep(respawnPanePIDRetryDelay)
+		_, retryPIDs, retryErr := s.paneProcessTree()
+		if retryErr != nil {
+			respawnLog.Warn("respawn_escalation_skipped_unknown_pane_pid",
+				slog.String("session", s.Name),
+				slog.Any("old_pids", oldPIDs),
+				slog.String("probe_error", probeErr.Error()),
+				slog.String("retry_error", retryErr.Error()))
+			return
+		}
+		newPIDs = retryPIDs
+	}
+
+	s.ensureProcessesDead(oldPIDs, newPIDs)
 }
 
 // RespawnPane kills the current process in the pane and starts a new command.
@@ -2873,14 +2989,15 @@ func (s *Session) RespawnPane(command string) error {
 	}
 	mcpLog.Debug("respawn_pane_output", slog.String("output", string(output)))
 
-	// Get the NEW pane PID so we don't accidentally kill the fresh process
-	newPanePID, _ := s.getPaneProcessTree()
+	// Capture the NEW process tree so we don't accidentally kill anything the
+	// respawn just created. Keep the probe error: "could not tell" must not be
+	// spent as an empty tree, which would silently disable that very guard
+	// (see escalateAfterRespawn).
+	_, newPIDs, newTreeErr := s.paneProcessTree()
 
 	// Verify old processes are dead; escalate to SIGKILL if needed
 	// Run in background so RespawnPane returns quickly
-	if len(oldPIDs) > 0 {
-		go s.ensureProcessesDead(oldPIDs, newPanePID)
-	}
+	go s.escalateAfterRespawn(oldPIDs, newPIDs, newTreeErr)
 
 	// Reconnect control mode pipe (respawn changes the pane process)
 	if pm := GetPipeManager(); pm != nil {
@@ -5720,7 +5837,23 @@ func SwitchAttachedClients(socket, targetSession, sessionID string) (bool, error
 	switched := false
 	var firstErr error
 	for _, c := range clients {
-		if err := tmuxExec(socket, "switch-client", "-c", c, "-t", targetSession).Run(); err != nil {
+		// Bounded — see tmuxMutationTimeout. One client per iteration, so an
+		// unbounded wedge here stalls the whole sweep.
+		if err := runBoundedMutation(socket, "switch-client", "-c", c, "-t", targetSession); err != nil {
+			// A timeout is NOT a tmux failure, and the difference decides the
+			// caller's behaviour: routeFocus returns on any non-nil error and
+			// only reaches the focus_request fallback for (false, nil). Report a
+			// client we gave up on as simply not switched, so the slower path —
+			// write the row, let the TUI consume it on the next tick — still
+			// runs. Reporting it as an error instead would turn a wedged client
+			// into a hard `session focus --attach` failure with nothing written.
+			if errors.Is(err, errTmuxTimeout) {
+				statusLog.Warn("switch_client_timed_out",
+					slog.String("client", c),
+					slog.String("target", targetSession),
+					slog.String("error", err.Error()))
+				continue
+			}
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -5747,7 +5880,9 @@ func DetachClientsOnSockets(sockets ...string) (bool, error) {
 	var firstErr error
 	for _, socket := range sockets {
 		for _, c := range attachedClientNames(socket) {
-			if err := tmuxExec(socket, "detach-client", "-c", c).Run(); err != nil {
+			// Bounded — see tmuxMutationTimeout. Same shape as the switch sweep
+			// above: per-client, and a timeout degrades to detached=false.
+			if err := runBoundedMutation(socket, "detach-client", "-c", c); err != nil {
 				if firstErr == nil {
 					firstErr = err
 				}

--- a/internal/tmux/tmux_exec_lint_test.go
+++ b/internal/tmux/tmux_exec_lint_test.go
@@ -81,13 +81,15 @@ func TestNoRawTmuxExec_OutsideAllowlist(t *testing.T) {
 		// is passed; adding -L based on DefaultSocketName would over-
 		// restrict and break users who run `agent-deck session current`
 		// from a non-agent-deck tmux pane. Documented at each call site.
+		//
+		// All four former display-message sites now funnel through the single
+		// bounded helper tmuxProbeBounded (cli_utils.go), so the argv arrives
+		// here as a variadic <expr> rather than a literal. That consolidation is
+		// deliberate: one sanctioned bypass is auditable, four scattered ones
+		// were not — and the scattered ones silently escaped the deadline rule
+		// in TestPollCommandsAreBounded until the 2026-07-21 fd-leak incident.
 		"cmd/agent-deck/cli_utils.go": {
-			{"tmux", "display-message", "-p", "#S"},
-		},
-		"cmd/agent-deck/session_cmd.go": {
-			{"tmux", "display-message", "-p", "#{session_name}\t#{pane_current_path}"},
-			{"tmux", "display-message", "-p", ""}, // multi-field variant (empty sentinel; matched loosely below)
-			{"tmux", "display-message", "-p", "#{session_name}"},
+			{"tmux", "<expr>"},
 		},
 	}
 

--- a/internal/tmux/tmux_poll_bounded_lint_test.go
+++ b/internal/tmux/tmux_poll_bounded_lint_test.go
@@ -36,6 +36,44 @@ var pollSubcommands = map[string]struct{}{
 	"show-environment": {},
 }
 
+// mutationSubcommands are the state-CHANGING tmux commands agent-deck runs.
+// The first round of fixes bounded only reads, on the reasoning that a
+// half-applied mutation has murkier semantics than a re-runnable query. That
+// reasoning was wrong about the risk: the fd leak is a property of the tmux
+// CLIENT, not of the subcommand it carries, so a `kill-session` client wedges
+// exactly like a `capture-pane` one — and these run on the same cadences (the
+// notification-bar switch/detach sweep fires once per attached client,
+// kill-session on every session teardown).
+//
+// What the murkier semantics actually demand is that each call site tolerate a
+// timeout, not that it stay unbounded:
+//   - kill-session — Session.Kill and KillAndWait already re-probe Exists() and
+//     treat "gone" as success, so a client SIGKILLed mid-exchange resolves to
+//     the same answer on the next probe.
+//   - switch-client — SwitchAttachedClients returns switched=false and the
+//     caller falls back to a focus_request.
+//   - detach-client — DetachClientsOnSockets returns detached=false; the TUI
+//     stays attached where it already was.
+//
+// All three are re-issued on the next user action, so a timeout degrades to a
+// no-op rather than a corrupted half-state.
+var mutationSubcommands = map[string]struct{}{
+	"detach-client": {},
+	"kill-session":  {},
+	"switch-client": {},
+}
+
+// requiresDeadline reports whether a tmux subcommand must be spawned through a
+// deadline-carrying factory. Both sets qualify; they are kept separate only
+// because their justifications differ (see each var's doc).
+func requiresDeadline(sub string) bool {
+	if _, ok := pollSubcommands[sub]; ok {
+		return true
+	}
+	_, ok := mutationSubcommands[sub]
+	return ok
+}
+
 // TestPollCommandsAreBounded fails the build if any cadence tmux query is
 // spawned through an unbounded factory (tmuxExec / s.tmuxCmd / tmux.Exec)
 // instead of a deadline-carrying one (runBoundedOutput / runBoundedRun /
@@ -131,10 +169,10 @@ func scanForUnboundedPolls(t *testing.T, root string) []unboundedPollSite {
 			if !ok || len(call.Args) <= subIdx {
 				return true
 			}
-			// exec.Command is generic: only flag it when argv[0] is literally
-			// "tmux", or every exec.Command whose second arg happens to collide
-			// with a tmux subcommand name would be reported.
-			if callee == "exec.Command" {
+			// exec.Command and its execCommand seam are generic: only flag them
+			// when argv[0] is literally "tmux", or every call whose second arg
+			// happens to collide with a tmux subcommand name would be reported.
+			if callee == "exec.Command" || callee == "execCommand" {
 				if bin, isLit := stringLiteral(call.Args[0]); !isLit || bin != "tmux" {
 					return true
 				}
@@ -143,7 +181,7 @@ func scanForUnboundedPolls(t *testing.T, root string) []unboundedPollSite {
 			if !ok {
 				return true
 			}
-			if _, isPoll := pollSubcommands[sub]; !isPoll {
+			if !requiresDeadline(sub) {
 				return true
 			}
 
@@ -186,6 +224,12 @@ func unboundedTmuxCallee(fun ast.Expr) (name string, subIdx int, ok bool) {
 			// raw-exec lint allowlists wholesale:
 			//   tmuxCommand(socketName, "has-session", …)
 			return "tmuxCommand", 1, true
+		case "execCommand":
+			// The package-level swappable seam (tmux.go: `var execCommand =
+			// exec.Command`) that the launcher-fallback tests override. It is
+			// exec.Command by another name, so it inherits exec.Command's
+			// deadline-free semantics — and the argv[0]=="tmux" filter below.
+			return "execCommand", 1, true
 		}
 	case *ast.SelectorExpr:
 		switch fn.Sel.Name {

--- a/internal/tmux/tmux_poll_bounded_lint_test.go
+++ b/internal/tmux/tmux_poll_bounded_lint_test.go
@@ -1,0 +1,213 @@
+package tmux
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// pollSubcommands are the read-only tmux queries agent-deck fires on a
+// cadence. Every one of them was observed spinning at ~100% CPU in the
+// 2026-07-21 incident: a tmux 3.0a client leaks an epoll fd per event-loop
+// iteration, and once it hits RLIMIT_NOFILE (1024) epoll_create returns
+// EMFILE forever. The client retries without backoff, so it burns a core in
+// pure system time (utime=0, stime=30298 on a 22-minute-old capture-pane)
+// and can never exit on its own.
+//
+// The server is NOT wedged when this happens — a fresh `tmux ls` returns in
+// milliseconds. Only clients that have already leaked their fd table are
+// stuck, which is why the poller kept spawning replacements that each got
+// stuck in turn: 14 live spinners, ~590% CPU, load average 28 on 8 cores.
+//
+// A deadline is the only defense that works, because the stuck client is
+// unreachable by any in-band means. exec.CommandContext SIGKILLs it at
+// tmuxPollTimeout, capping the damage at 3 core-seconds per leak.
+var pollSubcommands = map[string]struct{}{
+	"capture-pane":     {},
+	"display-message":  {},
+	"has-session":      {},
+	"list-clients":     {},
+	"list-panes":       {},
+	"list-sessions":    {},
+	"show-environment": {},
+}
+
+// TestPollCommandsAreBounded fails the build if any cadence tmux query is
+// spawned through an unbounded factory (tmuxExec / s.tmuxCmd / tmux.Exec)
+// instead of a deadline-carrying one (runBoundedOutput / runBoundedRun /
+// OutputBounded / tmuxExecContext / s.tmuxCmdContext).
+//
+// This is the companion to TestNoRawTmuxExec_OutsideAllowlist: that lint
+// enforces WHICH SERVER a command talks to, this one enforces that the
+// command is guaranteed to TERMINATE. v1.7.56 ("Part A") bounded some of
+// these sites by hand and the rest silently stayed unbounded — hence a lint
+// rather than a comment.
+//
+// Adding a new call site? Use the bounded helper. If a command genuinely
+// must run unbounded (an interactive attach, a blocking pipe-pane), add it
+// to allowedUnbounded with a one-line reason.
+func TestPollCommandsAreBounded(t *testing.T) {
+	root := moduleRoot(t)
+
+	// Module-relative file path -> reason the file's poll calls may be
+	// unbounded. Keep sorted for diffability.
+	allowedUnbounded := map[string]string{
+		// The bounded helpers themselves call the unbounded factory — that is
+		// the whole point of the indirection.
+		"internal/tmux/socket.go": "defines the bounded helpers; its factory calls are the sanctioned unbounded layer",
+	}
+
+	violations := scanForUnboundedPolls(t, root)
+
+	var unallowed []string
+	for _, v := range violations {
+		rel, err := filepath.Rel(root, v.file)
+		if err != nil {
+			rel = v.file
+		}
+		rel = filepath.ToSlash(rel)
+
+		if _, ok := allowedUnbounded[rel]; ok {
+			continue
+		}
+		unallowed = append(unallowed, rel+":"+itoa(v.line)+": "+v.callee+"(… \""+v.sub+"\" …)")
+	}
+
+	sort.Strings(unallowed)
+
+	if len(unallowed) > 0 {
+		t.Fatalf(
+			"%d unbounded cadence tmux poll(s) — a tmux client that leaks its fd table "+
+				"spins at 100%% CPU forever and cannot be reaped in-band. Use "+
+				"runBoundedOutput / runBoundedRun (in-package), OutputBounded (external), "+
+				"or thread a context via tmuxExecContext / s.tmuxCmdContext:\n  %s",
+			len(unallowed), strings.Join(unallowed, "\n  "))
+	}
+}
+
+// unboundedPollSite is one cadence query spawned without a deadline.
+type unboundedPollSite struct {
+	file   string
+	line   int
+	callee string // "tmuxExec", "s.tmuxCmd", "tmux.Exec"
+	sub    string // the tmux subcommand literal
+}
+
+func scanForUnboundedPolls(t *testing.T, root string) []unboundedPollSite {
+	t.Helper()
+
+	var sites []unboundedPollSite
+	err := walkGoFiles(root, func(path string) error {
+		if strings.HasSuffix(filepath.Base(path), "_test.go") {
+			// Tests drive tmux directly and are torn down by the harness.
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		slash := filepath.ToSlash(rel)
+		if strings.HasPrefix(slash, ".worktrees/") ||
+			strings.HasPrefix(slash, "vendor/") ||
+			strings.HasPrefix(slash, "tests/") ||
+			strings.HasPrefix(slash, "internal/testutil/") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			callee, subIdx, ok := unboundedTmuxCallee(call.Fun)
+			if !ok || len(call.Args) <= subIdx {
+				return true
+			}
+			// exec.Command is generic: only flag it when argv[0] is literally
+			// "tmux", or every exec.Command whose second arg happens to collide
+			// with a tmux subcommand name would be reported.
+			if callee == "exec.Command" {
+				if bin, isLit := stringLiteral(call.Args[0]); !isLit || bin != "tmux" {
+					return true
+				}
+			}
+			sub, ok := stringLiteral(call.Args[subIdx])
+			if !ok {
+				return true
+			}
+			if _, isPoll := pollSubcommands[sub]; !isPoll {
+				return true
+			}
+
+			sites = append(sites, unboundedPollSite{
+				file:   path,
+				line:   fset.Position(call.Pos()).Line,
+				callee: callee,
+				sub:    sub,
+			})
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk module: %v", err)
+	}
+	return sites
+}
+
+// unboundedTmuxCallee reports whether fun is one of the deadline-free tmux
+// command factories, and at which argument index the subcommand literal sits
+// (the package-level factories take a socket name first; the Session method
+// does not).
+//
+// The *Context variants (tmuxExecContext, s.tmuxCmdContext, tmux.ExecContext,
+// exec.CommandContext, tmuxCommandContext) are all treated as bounded. That is
+// a deliberate simplification: a context argument is assumed to carry a
+// deadline. This lint does not verify that — a context.Background() passed
+// straight through would slip by. Every such call site was audited by hand when
+// this lint was written; if you add one, give it a real timeout.
+func unboundedTmuxCallee(fun ast.Expr) (name string, subIdx int, ok bool) {
+	switch fn := fun.(type) {
+	case *ast.Ident:
+		switch fn.Name {
+		case "tmuxExec":
+			// In-package: tmuxExec(socket, "list-sessions", …)
+			return "tmuxExec", 1, true
+		case "tmuxCommand":
+			// internal/web's private socket-aware wrapper, which the
+			// raw-exec lint allowlists wholesale:
+			//   tmuxCommand(socketName, "has-session", …)
+			return "tmuxCommand", 1, true
+		}
+	case *ast.SelectorExpr:
+		switch fn.Sel.Name {
+		case "tmuxCmd":
+			// Per-Session: s.tmuxCmd("capture-pane", …)
+			return "s.tmuxCmd", 0, true
+		case "Exec":
+			// External packages: tmux.Exec(socketName, "list-panes", …)
+			if pkg, isIdent := fn.X.(*ast.Ident); isIdent && pkg.Name == "tmux" {
+				return "tmux.Exec", 1, true
+			}
+		case "Command":
+			// Raw exec.Command("tmux", "display-message", …). These bypass the
+			// argv factory entirely — TestNoRawTmuxExec_OutsideAllowlist
+			// permits a handful for socket-routing reasons, and that allowance
+			// silently exempted them from the deadline rule too. It must not:
+			// the fd-leak spin is a property of the tmux CLIENT, so a plain-argv
+			// client wedges exactly like a -L one.
+			if pkg, isIdent := fn.X.(*ast.Ident); isIdent && pkg.Name == "exec" {
+				return "exec.Command", 1, true
+			}
+		}
+	}
+	return "", 0, false
+}

--- a/internal/tmux/tmux_poll_bounded_lint_test.go
+++ b/internal/tmux/tmux_poll_bounded_lint_test.go
@@ -34,6 +34,7 @@ var pollSubcommands = map[string]struct{}{
 	"list-panes":       {},
 	"list-sessions":    {},
 	"show-environment": {},
+	"show-option":      {},
 }
 
 // mutationSubcommands are the state-CHANGING tmux commands agent-deck runs.
@@ -57,10 +58,21 @@ var pollSubcommands = map[string]struct{}{
 //
 // All three are re-issued on the next user action, so a timeout degrades to a
 // no-op rather than a corrupted half-state.
+// The status-bar and key-binding commands join them for the same reason, one
+// round later: the notification sweep (syncNotificationsBackground) drives
+// SetStatusLeft / ClearStatusLeftGlobal / RefreshStatusBarImmediate and the
+// Ctrl+b N rebinds on a timer, and refresh-client spawns one client per
+// attached client per bar change. They are change-gated, but flapping
+// running/waiting statuses fire them repeatedly — a cadence by any other name.
+// Leaving them out let the lint imply coverage the campaign did not have.
 var mutationSubcommands = map[string]struct{}{
-	"detach-client": {},
-	"kill-session":  {},
-	"switch-client": {},
+	"bind-key":       {},
+	"detach-client":  {},
+	"kill-session":   {},
+	"refresh-client": {},
+	"set-option":     {},
+	"switch-client":  {},
+	"unbind-key":     {},
 }
 
 // requiresDeadline reports whether a tmux subcommand must be spawned through a

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -222,8 +223,17 @@ func (b *tmuxPTYBridge) Close() {
 	})
 }
 
+// tmuxHasSessionProbeTimeout bounds the has-session existence probe. The web
+// bridge re-probes on every (re)connect, which is a cadence: on tmux 3.0a a
+// client that has exhausted its fd table spins at 100% CPU in EMFILE retries
+// and never exits, so an unbounded probe both hangs the connect request and
+// leaks a core-burning orphan per reconnect attempt.
+const tmuxHasSessionProbeTimeout = 3 * time.Second
+
 func tmuxSessionExists(name, socketName string) (bool, error) {
-	cmd := tmuxCommand(socketName, "has-session", "-t", name)
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxHasSessionProbeTimeout)
+	defer cancel()
+	cmd := tmuxCommandContext(ctx, socketName, "has-session", "-t", name)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil
@@ -249,11 +259,21 @@ func tmuxSessionExists(name, socketName string) (bool, error) {
 // legacy env-based fallback is preserved so running `agent-deck web` inside
 // an existing tmux pane keeps working for users who haven't opted into the
 // new per-session socket config (issue #687 phase 1).
+// Callers that poll on a cadence must use tmuxCommandContext with a deadline
+// instead — see tmuxHasSessionProbeTimeout. This unbounded form is correct only
+// for long-lived interactive commands such as attach-session.
 func tmuxCommand(socketName string, args ...string) *exec.Cmd {
+	return tmuxCommandContext(context.Background(), socketName, args...)
+}
+
+// tmuxCommandContext is the deadline-carrying variant of tmuxCommand. A context
+// with a timeout lets exec.CommandContext SIGKILL a tmux client that has wedged
+// on its own leaked fd table rather than blocking the caller forever.
+func tmuxCommandContext(ctx context.Context, socketName string, args ...string) *exec.Cmd {
 	// Explicit per-session socket name wins — this is the v1.7.50 path.
 	if trimmed := strings.TrimSpace(socketName); trimmed != "" {
 		finalArgs := append([]string{"-L", trimmed}, args...)
-		cmd := exec.Command("tmux", finalArgs...)
+		cmd := exec.CommandContext(ctx, "tmux", finalArgs...)
 		// Unset TMUX so tmux-in-tmux guards don't trip: we are explicitly
 		// directing this to a different server than the one we're in.
 		cmd.Env = environWithoutTMUX(os.Environ())
@@ -267,7 +287,7 @@ func tmuxCommand(socketName string, args ...string) *exec.Cmd {
 		finalArgs = append([]string{"-S", socketPath}, args...)
 	}
 
-	cmd := exec.Command("tmux", finalArgs...)
+	cmd := exec.CommandContext(ctx, "tmux", finalArgs...)
 	if hasSocket {
 		cmd.Env = environWithoutTMUX(os.Environ())
 	}


### PR DESCRIPTION
## What problem does this solve?

Orphaned `tmux` client processes can pin whole CPU cores indefinitely and survive the agent-deck process that spawned them, so a restart does not clear them.

On tmux 3.0a a tmux **client** leaks an epoll fd on every event-loop iteration. Once it reaches `RLIMIT_NOFILE` (1024), `epoll_create` returns `EMFILE` forever and the client retries with no backoff, burning a full core in pure kernel time. It can never exit on its own and cannot be reached by any in-band means. When the owning agent-deck exits, the kernel reparents the spinner to `systemd --user` and nothing reaps it.

Observed on my machine: 14 concurrent spinners, ~590% CPU, load average 28 on 8 cores. Every one of them was an agent-deck cadence poll — `capture-pane`, `list-sessions`, `list-panes`, `list-clients`, `has-session`, `show-environment`, `display-message`.

The server is healthy throughout: a fresh `tmux ls` returns in milliseconds while clients are wedged. That is why the pollers kept spawning replacements that each got stuck in turn.

## Why this change

A deadline is the only defense that works, because the stuck client is unreachable by any in-band means — `exec.CommandContext`'s SIGKILL at the deadline is what stops it. Every tmux subprocess agent-deck fires on a timer now runs bounded, behind a few helpers so the rule is enforceable rather than remembered:

- `runBoundedOutput` / `runBoundedRun` — 3s `tmuxPollTimeout`, in-package reads
- `runBoundedMutation` — 5s `tmuxMutationTimeout`, state changes
- `tmux.OutputBounded` — other packages
- `tmuxProbeBounded` (`cmd/agent-deck`) and `tmuxCommandContext` (`internal/web`) — the plain-argv and web-bridge cases

The mutation timeout is deliberately longer than the poll timeout: a read that gives up early is re-issued by the next poll a second later, while a kill abandoned early can leave a session the user asked to be gone.

A new AST lint, `TestPollCommandsAreBounded`, fails the build if a cadence subcommand is spawned through a deadline-free factory. It is the companion to the existing `TestNoRawTmuxExec_OutsideAllowlist`, which enforces *which server* a command talks to. An allowlist entry there does not exempt a call from the deadline rule — that gap is exactly what let four `display-message` sites escape my first pass, which is why this is a lint and not a comment.

Two follow-on defects, both consequences of bounding a probe that previously could not fail:

1. **`RespawnPane` could SIGKILL the process it just restarted.** The post-respawn pane probe degraded to PID 0 on timeout, and 0 matches no live process — silently disabling the only guard protecting the fresh process from the SIGTERM→SIGKILL escalation that exists because Claude Code 2.1.27+ ignores tmux's SIGHUP. If tmux reused a PID from the old tree, the restart was killed. The probe outcome is now preserved: unresolved means retry once, then skip the escalation entirely rather than guess. Skipping can leave one SIGHUP-immune process for manual cleanup, which is the better half of a bad trade — the alternative destroys live work with no warning. The whole new process tree is excluded now, not just the pane PID, since `bash -lc <agent>` forks children that pass the same "is this ours" check.

2. **Probes ignored the `WaitDelay` contract** that `tmuxSubprocessWaitDelay` documents: on `exec.ErrWaitDelay` the bytes written before the I/O goroutine was abandoned are still in the buffer, so a body that parses cleanly is authoritative. Under bridged stdio (Claude Code `/remote-control`, ssh `ControlMaster`) treating it as failure would make every pane probe indeterminate and permanently skip the reap — turning a correctness fix into an orphan leak in exactly those environments.

This caps the damage at ~3 core-seconds per leaked client. **It does not fix the leak**, which is upstream in tmux 3.0a; upgrading tmux is the real fix.

## User impact

Wedged `tmux` clients are killed at their deadline instead of accumulating, so agent-deck can no longer leave core-burning orphans behind. Restarting a session can no longer kill the agent it just restarted. No configuration, no flags, no behavior change on the happy path.

## Evidence

**The incident, before the fix** — a 22-minute-old `capture-pane` client, all time in the kernel:

    $ cat /proc/<pid>/stat        # utime=0  stime=30298
    $ ls /proc/<pid>/fd | wc -l   # 1024, almost all anon_inode:[eventpoll]
    $ ps -o stat,etime,comm       # R+  22:14  tmux

while the server itself answered instantly:

    $ time tmux ls                # real 0m0.004s

**Perf, hot path (tmux layer touched).** Base = `upstream/main` @ `d639ae83`, branch = this PR, both `go build`, 15 runs per cell, three alternating rounds, against one live session on the agent-deck socket:

    round  list-base  list-new  status-base  status-new    (ms/run)
    1      11         11        146          142
    2      10         11        178          147
    3      10         11        138          134

No measurable regression: the change adds one `context.WithTimeout` per subprocess, which is noise next to the fork+exec it wraps.

**Tests.** `internal/tmux/respawn_escalation_test.go` (4 tests) pins the escalation outcomes — skip when the tree is unknown, spare the new pane process, spare every PID in the new tree, still reap a genuine survivor. `internal/tmux/probe_contract_test.go` (8 tests) pins the caller half of the `WaitDelay` contract and the timeout-vs-failure distinction. `TestPollCommandsAreBounded` is itself the regression test for the campaign; it caught 14 unbounded status-bar and key-binding sites, which the third commit fixes.

Note on the revert-check: the new tests do not compile against base, because they exercise functions this PR introduces (`escalateAfterRespawn`, `parsePanePID`, `annotateDeadline`). I verified them the other way — I first landed `escalateAfterRespawn` with the *old* behavior and watched `TestEscalateAfterRespawn_SkipsEscalationWhenPanePIDUnknown` fail on the real assertion, then fixed it. Worth knowing if you re-run that check: `kill(pid, 0)` keeps succeeding between SIGKILL and the `wait()` that clears the zombie, so asserting "survived" needs a settle window — a bare liveness check passes vacuously against the unfixed code, which is how my first version of that test passed for the wrong reason.

**Sandboxed suite:**

    HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...

passes except two failures that are environmental on my box and reproduce identically on unmodified `upstream/main`:

- `TestPersistence_TmuxDiesWithoutUserScope` — writes `cgroup.kill`, which is cgroup v2 only; this host is cgroup v1.
- `TestIssue1576_WorktreeFinishSweepsNotifierState` — uses `git init -b`, which needs git ≥ 2.28; this host has git 2.25.1.

`gofmt -l ./cmd ./internal` is clean and `go vet ./...` passes. `make lint` was **not** run — `golangci-lint` is not installed on this machine, so CI is the first thing to see it.

**On the diff size:** +1026/-122 is over the ~400-line guidance. Roughly 260 of those lines are the two new test files and the lint; the production change is mechanical and repetitive (one call-site conversion at a time). The three commits are separable if you would rather take them one at a time, but they are ordered deliberately — commits 2 and 3 fix defects that commit 1 introduces or exposes, so commit 1 alone is the worst of the three states to ship.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8 (implementation), claude-fable-5 (independent review pass, which found three real defects fixed here: two inaccurate code comments and the unhonored `ErrWaitDelay` contract)

## What actually bothered you

My human's machine ground to a halt — load average 28 on 8 cores — and the cause turned out to be fourteen orphaned `tmux` processes left behind by agent-deck, still spinning after the agent-deck that spawned them was gone. Killing agent-deck did not help; they had been reparented to `systemd --user` and each needed `kill -9`.

They asked me to follow up on the two loose ends from that investigation, in their words: *"M1 (RespawnPane can SIGKILL a freshly-respawned process when the post-respawn probe times out) and M3 (kill-session/switch-client/detach-client still unbounded)"*, and then to review the result against your contributing guide before opening this.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout-bounded tmux commands across session detection, pane/process discovery, and session lifecycle operations.
  * Prevented hangs when tmux becomes unresponsive, including safer handling of terminal and mutation-style commands.
  * Improved cleanup and escalation so newly respawned pane processes aren’t accidentally terminated.
  * Added clearer warnings when pane/process information can’t be retrieved.

* **Tests**
  * Added contract tests for timeout/parse behavior and new coverage for respawn escalation edge cases.
  * Added enforcement to ensure tmux cadence and mutation calls remain deadline-bounded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->