### PR TITLE
fix: preserve custom Codex session on restart

### DIFF
--- a/internal/session/cli_status_refresh.go
+++ b/internal/session/cli_status_refresh.go
@@ -31,7 +31,7 @@ func RefreshInstancesForCLIStatus(instances []*Instance) {
 		if inst == nil {
 			continue
 		}
-		if !IsClaudeCompatible(inst.Tool) && inst.Tool != "codex" && inst.Tool != "gemini" {
+		if !IsClaudeCompatible(inst.Tool) && !IsCodexCompatible(inst.Tool) && inst.Tool != "gemini" {
 			continue
 		}
 		if hs := readHookStatusFile(inst.ID); hs != nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4128,7 +4128,7 @@ func (i *Instance) UpdateStatus() error {
 
 	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
 	// Read the hook file from disk once to give CLI the same fast path as the TUI.
-	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
 			i.hookEvent = hs.Event
@@ -6390,6 +6390,28 @@ func (i *Instance) RestartWithEnv(env map[string]string) error {
 	return i.restart(env)
 }
 
+// refreshCodexSessionFromHookBeforeRestart closes the narrow race between a
+// Codex /new (whose notify hook has already written the new thread id) and a
+// restart issued before the TUI/daemon status loop has consumed that hook.
+// UpdateHookStatus applies the existing subagent/terminal-event quality gates
+// and persists an accepted rebind to SQLite.
+func (i *Instance) refreshCodexSessionFromHookBeforeRestart() {
+	if !IsCodexCompatible(i.Tool) {
+		return
+	}
+	status := readHookStatusFile(i.ID)
+	if status == nil {
+		return
+	}
+
+	i.mu.Lock()
+	isNewer := status.UpdatedAt.After(i.hookLastUpdate)
+	i.mu.Unlock()
+	if isNewer {
+		i.UpdateHookStatus(status)
+	}
+}
+
 func (i *Instance) restart(env map[string]string) error {
 	beforeLock := nowFn()
 	release, lockErr := acquireInstanceSpawnLock(i.ID)
@@ -6404,6 +6426,11 @@ func (i *Instance) restart(env map[string]string) error {
 		return nil
 	}
 	defer recordInstanceSpawn(i.ID)
+
+	// A completion hook can arrive immediately before this restart, before any
+	// background status consumer has persisted a /new thread id. Refresh here
+	// so the resume command cannot clobber the fresh sidecar with a stale DB id.
+	i.refreshCodexSessionFromHookBeforeRestart()
 
 	if len(env) > 0 {
 		i.restartEnv = make(map[string]string, len(env))

--- a/internal/session/instance_cli_parity_test.go
+++ b/internal/session/instance_cli_parity_test.go
@@ -503,3 +503,65 @@ func overrideHookEvent(t *testing.T, instanceID, status, event string, tsSeconds
 		t.Fatalf("write hook: %v", err)
 	}
 }
+
+func TestRefreshInstancesForCLIStatus_CustomCodexCompatibleConsumesHook(t *testing.T) {
+	home := os.Getenv("HOME")
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	const toolName = "codex-deep-test"
+	userConfigCacheMu.Lock()
+	userConfigCache = &UserConfig{Tools: map[string]ToolDef{
+		toolName: {Command: "codex", CompatibleWith: "codex"},
+	}}
+	userConfigCacheMtime = time.Time{}
+	userConfigCacheErr = nil
+	userConfigCacheMu.Unlock()
+
+	inst := NewInstanceWithTool("custom-codex-hook-refresh", home, toolName)
+	inst.CodexSessionID = "11111111-1111-4111-8111-111111111111"
+	writeHookFile(t, inst.ID, "waiting", 0)
+	overrideHookEvent(t, inst.ID, "waiting", "agent-turn-complete", 0)
+
+	RefreshInstancesForCLIStatus([]*Instance{inst})
+
+	if got, want := inst.CodexSessionID, "sess-876-parity"; got != want {
+		t.Fatalf("CodexSessionID = %q, want hook session %q", got, want)
+	}
+}
+
+func TestRefreshCodexSessionFromHookBeforeRestart_CustomCompatible(t *testing.T) {
+	home := os.Getenv("HOME")
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	const toolName = "codex-restart-test"
+	userConfigCacheMu.Lock()
+	userConfigCache = &UserConfig{Tools: map[string]ToolDef{
+		toolName: {Command: "codex", CompatibleWith: "codex"},
+	}}
+	userConfigCacheMtime = time.Time{}
+	userConfigCacheErr = nil
+	userConfigCacheMu.Unlock()
+
+	inst := NewInstanceWithTool("custom-codex-restart-refresh", home, toolName)
+	inst.CodexSessionID = "22222222-2222-4222-8222-222222222222"
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	const newID = "33333333-3333-4333-8333-333333333333"
+	body := fmt.Sprintf(
+		`{"status":"waiting","session_id":%q,"event":"agent-turn-complete","ts":%d}`,
+		newID, time.Now().Unix(),
+	)
+	if err := os.WriteFile(filepath.Join(hooksDir, inst.ID+".json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	inst.refreshCodexSessionFromHookBeforeRestart()
+
+	if got := inst.CodexSessionID; got != newID {
+		t.Fatalf("CodexSessionID = %q, want hook session %q", got, newID)
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -334,7 +334,7 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 	hookStatuses := make(map[string]*HookStatus, len(instances))
 	for _, inst := range instances {
 		byID[inst.ID] = inst
-		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "cursor" {
+		if IsClaudeCompatible(inst.Tool) || IsCodexCompatible(inst.Tool) || inst.Tool == "gemini" || inst.Tool == "cursor" {
 			if hs := d.hookStatusForInstance(inst.ID); hs != nil {
 				// Issue #1349: only let a hook status rebind the session id when
 				// the instance is actually LIVE (running/waiting/idle with a real

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4202,7 +4202,7 @@ func (h *Home) backgroundStatusUpdate() {
 	// Feed hook statuses from watcher to instances (enables hook fast path in UpdateStatus)
 	if h.hookWatcher != nil {
 		for _, inst := range instances {
-			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "hermes" || inst.Tool == "cursor" {
+			if session.IsClaudeCompatible(inst.Tool) || session.IsCodexCompatible(inst.Tool) || inst.Tool == "gemini" || inst.Tool == "hermes" || inst.Tool == "cursor" {
 				if hs := h.hookWatcher.GetHookStatus(inst.ID); hs != nil {
 					inst.UpdateHookStatus(hs)
 				}


### PR DESCRIPTION
Custom tools declared compatible_with = codex were excluded from several hook-consumer paths, and restart could overwrite a fresh hook sidecar with a stale persisted Codex thread id. This updates the CLI, transition daemon, TUI, and status refresh paths to use IsCodexCompatible, and refreshes an eligible Codex hook immediately before restart. Regression tests cover custom-compatible hook consumption and restart-time rebinding. Live probe: the hook held 019f89ef-1a9b-7522-81e0-1d62b1d416dd while SQLite still held stale 019f89cd-14a5-71f1-b16f-e930e069aaa4; restart promoted the hook UUID and resumed the STAGE_D_20260722 transcript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status synchronization for Codex-compatible tools and variants.
  * Hook events are now consistently recognized across supported Codex-compatible tools.
  * Fixed a restart timing issue so the latest session information is preserved when available.
* **Tests**
  * Added coverage for custom Codex-compatible tools during status refresh and restart flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->