### PR TITLE
fix(ssh): route positional add path to --remote-path, refuse remote worktree creation

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -218,6 +218,33 @@ func resolveAddPath(rawPathArg string) (string, error) {
 	return filepath.Abs(session.ExpandPath(rawPathArg))
 }
 
+// resolveSSHAddPaths applies `agent-deck add`'s --ssh path-routing rule: the
+// project lives on the remote host, so the resolved positional path is never
+// a local path to validate or launch tmux in.
+//
+// An explicitly given positional path (explicitPathProvided) names the
+// REMOTE working directory, unless an explicit --remote-path was already
+// given, which always wins (matching the documented
+// `add --ssh <host> --remote-path <path>` pattern). Without this routing, a
+// positional path given alongside --ssh (e.g. `add <remote-worktree-path>
+// --ssh <host>`) was silently misused as the session's local ProjectPath
+// placeholder while remotePath stayed empty, so the actual SSH-wrapped
+// launch command never `cd`'d into the intended remote directory: the
+// session launched in the SSH login shell's default directory instead of the
+// registered worktree. Fixes asheshgoplani/agent-deck#1711 / #1710.
+//
+// Returns the local placeholder path (always CWD for --ssh sessions, used
+// only for local bookkeeping such as tmux pane naming, never launched into)
+// and the resolved remote path to store as Instance.SSHRemotePath.
+func resolveSSHAddPaths(explicitPathProvided bool, positionalPath, explicitRemotePath string) (localPlaceholder, remotePath string, err error) {
+	remotePath = explicitRemotePath
+	if explicitPathProvided && remotePath == "" {
+		remotePath = positionalPath
+	}
+	localPlaceholder, err = os.Getwd()
+	return localPlaceholder, remotePath, err
+}
+
 // CLIOutput handles consistent output formatting across all CLI commands
 type CLIOutput struct {
 	jsonMode  bool

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -233,16 +233,36 @@ func resolveAddPath(rawPathArg string) (string, error) {
 // session launched in the SSH login shell's default directory instead of the
 // registered worktree. Fixes asheshgoplani/agent-deck#1711 / #1710.
 //
+// rawPositionalPath must be the RAW positional argument, taken before
+// resolveAddPath runs session.ExpandPath + filepath.Abs on it: those
+// resolutions describe the controller machine, not the remote host, so
+// running them here would rewrite `~/x` or `./x` into a local filesystem
+// path (e.g. the controller's home directory or CWD) and ship that local
+// path to the remote shell as the session's working directory. wrapForSSH
+// also single-quotes SSHRemotePath verbatim before handing it to the remote
+// shell, so a stored `~/x` or `$VAR/x` reaches the remote host inert (the
+// remote shell does not expand a quoted `~` or `$VAR`); a non-absolute
+// remote path can never resolve correctly today, so it is refused outright
+// rather than stored and silently misinterpreted.
+//
 // Returns the local placeholder path (always CWD for --ssh sessions, used
 // only for local bookkeeping such as tmux pane naming, never launched into)
 // and the resolved remote path to store as Instance.SSHRemotePath.
-func resolveSSHAddPaths(explicitPathProvided bool, positionalPath, explicitRemotePath string) (localPlaceholder, remotePath string, err error) {
+func resolveSSHAddPaths(explicitPathProvided bool, rawPositionalPath, explicitRemotePath string) (localPlaceholder, remotePath string, err error) {
+	localPlaceholder, err = os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
 	remotePath = explicitRemotePath
 	if explicitPathProvided && remotePath == "" {
-		remotePath = positionalPath
+		if !strings.HasPrefix(rawPositionalPath, "/") {
+			return "", "", fmt.Errorf("--ssh remote path must be absolute (got %q); "+
+				"agent-deck cannot resolve %q against the remote host's filesystem "+
+				"(no local ~ or $VAR expansion applies there)", rawPositionalPath, rawPositionalPath)
+		}
+		remotePath = rawPositionalPath
 	}
-	localPlaceholder, err = os.Getwd()
-	return localPlaceholder, remotePath, err
+	return localPlaceholder, remotePath, nil
 }
 
 // CLIOutput handles consistent output formatting across all CLI commands

--- a/cmd/agent-deck/issue1711_ssh_worktree_path_test.go
+++ b/cmd/agent-deck/issue1711_ssh_worktree_path_test.go
@@ -15,6 +15,14 @@ import (
 // on the floor instead of using it as the remote directory, so the launched
 // session never cd'd into the intended remote worktree and instead ran in
 // the SSH login shell's default directory.
+//
+// The routing rule takes the RAW positional argument, never a locally
+// resolved one (session.ExpandPath + filepath.Abs describe the controller
+// machine, not the remote host): a `~/x` or `./x` positional path is
+// refused rather than silently misresolved, because wrapForSSH single-quotes
+// SSHRemotePath before handing it to the remote shell, so a stored `~/x` or
+// `$VAR/x` would reach the remote host inert (no tilde/variable expansion
+// happens inside single quotes).
 func TestResolveSSHAddPaths(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -27,9 +35,10 @@ func TestResolveSSHAddPaths(t *testing.T) {
 		positionalPath       string
 		explicitRemotePath   string
 		wantRemotePath       string
+		wantErr              bool
 	}{
 		{
-			name:                 "positional path with --ssh becomes the remote path",
+			name:                 "absolute positional path with --ssh becomes the remote path",
 			explicitPathProvided: true,
 			positionalPath:       "/home/liam/pt-worktrees/some-feature",
 			explicitRemotePath:   "",
@@ -56,11 +65,45 @@ func TestResolveSSHAddPaths(t *testing.T) {
 			explicitRemotePath:   "",
 			wantRemotePath:       "",
 		},
+		{
+			name:                 "tilde positional path is refused, not locally expanded",
+			explicitPathProvided: true,
+			positionalPath:       "~/pt-worktrees/tilde-feature",
+			explicitRemotePath:   "",
+			wantErr:              true,
+		},
+		{
+			name:                 "relative positional path is refused, not resolved against local CWD",
+			explicitPathProvided: true,
+			positionalPath:       "./sub/rel-feature",
+			explicitRemotePath:   "",
+			wantErr:              true,
+		},
+		{
+			name:                 "remote env-var positional path is refused",
+			explicitPathProvided: true,
+			positionalPath:       "$REMOTE_HOME/pt-worktrees/var-feature",
+			explicitRemotePath:   "",
+			wantErr:              true,
+		},
+		{
+			name:                 "non-absolute positional path is refused even when explicit --remote-path is also non-absolute-shaped but present (--remote-path still wins, no validation applied to it)",
+			explicitPathProvided: true,
+			positionalPath:       "~/ignored",
+			explicitRemotePath:   "/home/liam/other-repo",
+			wantRemotePath:       "/home/liam/other-repo",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotLocal, gotRemote, err := resolveSSHAddPaths(tt.explicitPathProvided, tt.positionalPath, tt.explicitRemotePath)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveSSHAddPaths() expected an error refusing a non-absolute remote path, got remote=%q", gotRemote)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("resolveSSHAddPaths() error = %v", err)
 			}
@@ -77,9 +120,10 @@ func TestResolveSSHAddPaths(t *testing.T) {
 }
 
 // buildAgentDeckBinaryForSSHTest builds the agent-deck binary once for the
-// subprocess tests below and returns its path. Skips (not fails) on build
-// failure so this file degrades gracefully in constrained sandboxes; the
-// unit test above already covers the routing logic directly.
+// subprocess tests below and returns its path. Fails (does not skip) on
+// build failure: a silent skip here would let this regression coverage
+// disappear without a trace whenever the build is broken, which is exactly
+// when a CI run most needs it to fail loudly instead.
 func buildAgentDeckBinaryForSSHTest(t *testing.T) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -91,7 +135,7 @@ func buildAgentDeckBinaryForSSHTest(t *testing.T) string {
 	cmd.Dir = repoRootForSSHTest(t)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Skipf("could not build agent-deck binary for subprocess test (skipping): %v\n%s", err, out)
+		t.Fatalf("could not build agent-deck binary for subprocess test: %v\n%s", err, out)
 	}
 	return binPath
 }
@@ -167,5 +211,42 @@ func TestSSHWorktreeCreationRefused(t *testing.T) {
 	}
 	if strings.Count(strings.TrimSpace(string(wtOut)), "\n") != 0 {
 		t.Fatalf("expected no worktrees to be created locally, got:\n%s", wtOut)
+	}
+}
+
+// TestSSHAddPositionalPathCLI drives the actual failure mode #1711/#1710
+// were filed about through the full CLI, not just the resolveSSHAddPaths
+// unit: `agent-deck add <remote-path> --ssh <host>` (bare positional path,
+// no --remote-path). Prior to this fix the positional path was silently
+// dropped into the session's local ProjectPath placeholder and never
+// reached SSHRemotePath. handleAdd prints the resolved remote path back on
+// the "  Remote:  <path>" line, so asserting on that output line proves the
+// raw positional path survives CLI parsing, add-command flag handling, and
+// resolveSSHAddPaths unmodified.
+func TestSSHAddPositionalPathCLI(t *testing.T) {
+	bin := buildAgentDeckBinaryForSSHTest(t)
+
+	home := t.TempDir()
+	profileDir := filepath.Join(home, ".agent-deck-test-profile")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatalf("mkdir profile dir: %v", err)
+	}
+
+	const remotePath = "/home/remote-user/pt-worktrees/some-feature"
+	cmd := exec.Command(bin,
+		"--profile", "_test_1711_positional",
+		"add", remotePath,
+		"--ssh", "test-host",
+		"-t", "positional-remote-path-case",
+		"-c", "claude",
+	)
+	cmd.Env = append(os.Environ(), "HOME="+home, "AGENTDECK_PROFILE=_test_1711_positional")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("add --ssh <host> <positional-path>: %v\n%s", err, out)
+	}
+	wantLine := "Remote:  " + remotePath
+	if !strings.Contains(string(out), wantLine) {
+		t.Fatalf("expected output to report the unmodified positional path as the remote path (%q), got:\n%s", wantLine, out)
 	}
 }

--- a/cmd/agent-deck/issue1711_ssh_worktree_path_test.go
+++ b/cmd/agent-deck/issue1711_ssh_worktree_path_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestResolveSSHAddPaths covers the --ssh path-routing rule for `agent-deck
+// add`. Regression for asheshgoplani/agent-deck#1711 / #1710: `add
+// <remote-worktree-path> --ssh <host>` silently dropped the positional path
+// on the floor instead of using it as the remote directory, so the launched
+// session never cd'd into the intended remote worktree and instead ran in
+// the SSH login shell's default directory.
+func TestResolveSSHAddPaths(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+
+	tests := []struct {
+		name                 string
+		explicitPathProvided bool
+		positionalPath       string
+		explicitRemotePath   string
+		wantRemotePath       string
+	}{
+		{
+			name:                 "positional path with --ssh becomes the remote path",
+			explicitPathProvided: true,
+			positionalPath:       "/home/liam/pt-worktrees/some-feature",
+			explicitRemotePath:   "",
+			wantRemotePath:       "/home/liam/pt-worktrees/some-feature",
+		},
+		{
+			name:                 "explicit --remote-path wins over positional path",
+			explicitPathProvided: true,
+			positionalPath:       "/home/liam/pt-worktrees/some-feature",
+			explicitRemotePath:   "/home/liam/other-repo",
+			wantRemotePath:       "/home/liam/other-repo",
+		},
+		{
+			name:                 "no positional path, only --remote-path (documented pattern)",
+			explicitPathProvided: false,
+			positionalPath:       cwd, // matches handleAdd's cwd-fallback default
+			explicitRemotePath:   "/home/liam/PointyTooling",
+			wantRemotePath:       "/home/liam/PointyTooling",
+		},
+		{
+			name:                 "neither positional path nor --remote-path given",
+			explicitPathProvided: false,
+			positionalPath:       cwd,
+			explicitRemotePath:   "",
+			wantRemotePath:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLocal, gotRemote, err := resolveSSHAddPaths(tt.explicitPathProvided, tt.positionalPath, tt.explicitRemotePath)
+			if err != nil {
+				t.Fatalf("resolveSSHAddPaths() error = %v", err)
+			}
+			if gotLocal != cwd {
+				t.Fatalf("resolveSSHAddPaths() local placeholder = %q, want CWD %q (an --ssh session's local\n"+
+					"placeholder path must always be CWD, never the remote path, so tmux never launches\n"+
+					"into a path that only exists on the remote host)", gotLocal, cwd)
+			}
+			if gotRemote != tt.wantRemotePath {
+				t.Fatalf("resolveSSHAddPaths() remote path = %q, want %q", gotRemote, tt.wantRemotePath)
+			}
+		})
+	}
+}
+
+// buildAgentDeckBinaryForSSHTest builds the agent-deck binary once for the
+// subprocess tests below and returns its path. Skips (not fails) on build
+// failure so this file degrades gracefully in constrained sandboxes; the
+// unit test above already covers the routing logic directly.
+func buildAgentDeckBinaryForSSHTest(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell/ssh-flag fixture")
+	}
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "agent-deck")
+	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/agent-deck")
+	cmd.Dir = repoRootForSSHTest(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("could not build agent-deck binary for subprocess test (skipping): %v\n%s", err, out)
+	}
+	return binPath
+}
+
+func repoRootForSSHTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	// This test file lives in cmd/agent-deck; the module root is two levels up.
+	return filepath.Join(wd, "..", "..")
+}
+
+// TestSSHWorktreeCreationRefused proves that `add --ssh <host> --remote-path
+// <path> -w <branch> -b` refuses cleanly instead of silently creating a git
+// worktree in the local checkout the test happens to run from (failure mode
+// 2 from asheshgoplani/agent-deck#1711 / #1710: this combination previously
+// created the worktree on the LOCAL Mac, ignoring --remote-path entirely).
+func TestSSHWorktreeCreationRefused(t *testing.T) {
+	bin := buildAgentDeckBinaryForSSHTest(t)
+
+	home := t.TempDir()
+	profileDir := filepath.Join(home, ".agent-deck-test-profile")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatalf("mkdir profile dir: %v", err)
+	}
+
+	// A real repo with a commit, so any accidental local worktree creation
+	// would be independently detectable (it must NOT appear).
+	repo := filepath.Join(home, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"-c", "user.name=T", "-c", "user.email=t@test", "commit", "--allow-empty", "-m", "init"},
+	} {
+		gc := exec.Command("git", args...)
+		gc.Dir = repo
+		gc.Env = append(os.Environ(), "HOME="+home)
+		if out, err := gc.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	cmd := exec.Command(bin,
+		"--profile", "_test_1711",
+		"add",
+		"--ssh", "test-host",
+		"--remote-path", "/home/remote-user/some-repo",
+		"-w", "some-feature-branch",
+		"-b",
+		"-t", "should-not-be-created",
+		"-c", "claude",
+	)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(), "HOME="+home, "AGENTDECK_PROFILE=_test_1711")
+	out, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatalf("expected `add --ssh --remote-path -w -b` to exit non-zero (refused), got success:\n%s", out)
+	}
+	if !strings.Contains(string(out), "cannot be combined with --ssh") {
+		t.Fatalf("expected a clear refusal message naming the --ssh/-w conflict, got:\n%s", out)
+	}
+
+	// The critical regression check: no worktree may have been created in
+	// the LOCAL repo the subprocess ran from.
+	wtOut, wtErr := exec.Command("git", "-C", repo, "worktree", "list").CombinedOutput()
+	if wtErr != nil {
+		t.Fatalf("git worktree list: %v\n%s", wtErr, wtOut)
+	}
+	if strings.Count(strings.TrimSpace(string(wtOut)), "\n") != 0 {
+		t.Fatalf("expected no worktrees to be created locally, got:\n%s", wtOut)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1552,14 +1552,27 @@ func handleAdd(profile string, args []string) {
 
 	// Verify path exists and is a directory (skip for SSH remote sessions)
 	if *sshHost != "" {
-		// For SSH sessions, use CWD as local placeholder path (project lives on remote)
-		if path == "" {
-			path, err = os.Getwd()
-			if err != nil {
-				fmt.Printf("Error: failed to get current directory: %v\n", err)
-				os.Exit(1)
-			}
+		// An explicitly given path (positional arg, e.g. `add <remote-path>
+		// --ssh <host>`) names the REMOTE working directory when --ssh is in
+		// play: the project lives on the remote host, so this is never a
+		// local path to validate or launch tmux in. Prior to this fix an
+		// explicit positional path was silently dropped on the floor here:
+		// it became the session's local ProjectPath placeholder (nonsensical,
+		// since it names a path that typically doesn't exist locally) while
+		// SSHRemotePath stayed empty, so wrapForSSH never `cd`'d into it and
+		// the session launched in the SSH login shell's default directory
+		// instead of the intended remote worktree. Route it into
+		// --remote-path (an explicit --remote-path flag still wins, matching
+		// the documented `--ssh --remote-path` pattern) and fall back to CWD
+		// as the local placeholder, exactly as the no-positional-path case
+		// already does. Fixes asheshgoplani/agent-deck#1711 / #1710.
+		var localPlaceholder string
+		localPlaceholder, *sshRemotePath, err = resolveSSHAddPaths(explicitPathProvided, path, *sshRemotePath)
+		if err != nil {
+			fmt.Printf("Error: failed to get current directory: %v\n", err)
+			os.Exit(1)
 		}
+		path = localPlaceholder
 	} else {
 		info, err := os.Stat(path)
 		if err != nil {
@@ -1575,6 +1588,26 @@ func handleAdd(profile string, args []string) {
 	// Handle worktree creation
 	var worktreePath, worktreeRepoRoot, worktreeType string
 	if wtBranch != "" {
+		// -w/-b worktree creation is a 100% local filesystem operation
+		// (detectAndCreateBackend + git/jj worktree add below all run against
+		// `path` on THIS machine). Combined with --ssh, `path` at this point
+		// is the local CWD placeholder (see the --ssh branch above), never
+		// the remote repo the director intended. Before this fix that meant
+		// silently creating a worktree in the local Mac's checkout instead of
+		// on the remote host, ignoring --remote-path entirely. Remote
+		// worktree creation over SSH is not yet implemented, so refuse loudly
+		// rather than repeat that silent local-Mac side effect. Workaround:
+		// create the worktree on the remote host directly
+		// (ssh <host> "cd <repo> && git worktree add <path> ..."), then
+		// register it with `agent-deck add --ssh <host> --remote-path <path>`.
+		// Tracking: asheshgoplani/agent-deck#1711 / #1710.
+		if *sshHost != "" {
+			fmt.Println("Error: -w/--worktree (and -b) cannot be combined with --ssh; agent-deck cannot create a git worktree on a remote host yet")
+			fmt.Println("Workaround: create the worktree on the remote host directly, then register it:")
+			fmt.Println("  ssh " + *sshHost + " \"cd <remote-repo> && git worktree add <remote-worktree-path> " + wtBranch + "\"")
+			fmt.Println("  agent-deck add --ssh " + *sshHost + " --remote-path <remote-worktree-path> ...")
+			os.Exit(1)
+		}
 		backend, err := detectAndCreateBackend(path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1309,9 +1309,9 @@ func handleAdd(profile string, args []string) {
 	attach := fs.Bool("attach", false, "Start and attach to the session immediately after creating it (requires an interactive terminal; not supported with --ssh)")
 
 	// Worktree flags
-	worktreeBranch := fs.String("w", "", "Create session in git worktree for branch")
-	worktreeBranchLong := fs.String("worktree", "", "Create session in git worktree for branch")
-	newBranch := fs.Bool("b", false, "Create new branch (use with --worktree)")
+	worktreeBranch := fs.String("w", "", "Create session in git worktree for branch (not supported with --ssh)")
+	worktreeBranchLong := fs.String("worktree", "", "Create session in git worktree for branch (not supported with --ssh)")
+	newBranch := fs.Bool("b", false, "Create new branch (use with --worktree; not supported with --ssh)")
 	newBranchLong := fs.Bool("new-branch", false, "Create new branch")
 	worktreeLocation := fs.String("location", "", "Worktree location: sibling, subdirectory, or custom path")
 
@@ -1418,7 +1418,8 @@ func handleAdd(profile string, args []string) {
 		fmt.Println("  agent-deck add --worktree fix/bug-123 --new-branch /path/to/repo")
 		fmt.Println()
 		fmt.Println("SSH Examples:")
-		fmt.Println("  agent-deck add --ssh user@host --remote-path ~/project -c claude")
+		fmt.Println("  agent-deck add --ssh user@host --remote-path /home/user/project -c claude")
+		fmt.Println("  agent-deck add /home/user/project --ssh user@host -c claude   # positional path shortcut for --remote-path; must be absolute")
 		fmt.Println("  agent-deck add --ssh user@host -c claude -t \"remote-dev\"")
 	}
 
@@ -1566,10 +1567,18 @@ func handleAdd(profile string, args []string) {
 		// the documented `--ssh --remote-path` pattern) and fall back to CWD
 		// as the local placeholder, exactly as the no-positional-path case
 		// already does. Fixes asheshgoplani/agent-deck#1711 / #1710.
+		// A positional path is routed as the RAW argument (rawPathArg, before
+		// resolveAddPath's local ExpandPath/Abs above), never the already
+		// locally-resolved `path`: see resolveSSHAddPaths' doc comment for why
+		// local resolution of a remote path is never correct.
+		if explicitPathProvided && *sshRemotePath != "" {
+			fmt.Fprintf(os.Stderr, "warning: both a positional path (%q) and --remote-path (%q) were given; "+
+				"the positional path is discarded, --remote-path is used\n", rawPathArg, *sshRemotePath)
+		}
 		var localPlaceholder string
-		localPlaceholder, *sshRemotePath, err = resolveSSHAddPaths(explicitPathProvided, path, *sshRemotePath)
+		localPlaceholder, *sshRemotePath, err = resolveSSHAddPaths(explicitPathProvided, rawPathArg, *sshRemotePath)
 		if err != nil {
-			fmt.Printf("Error: failed to get current directory: %v\n", err)
+			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
 		path = localPlaceholder
@@ -1602,10 +1611,10 @@ func handleAdd(profile string, args []string) {
 		// register it with `agent-deck add --ssh <host> --remote-path <path>`.
 		// Tracking: asheshgoplani/agent-deck#1711 / #1710.
 		if *sshHost != "" {
-			fmt.Println("Error: -w/--worktree (and -b) cannot be combined with --ssh; agent-deck cannot create a git worktree on a remote host yet")
-			fmt.Println("Workaround: create the worktree on the remote host directly, then register it:")
-			fmt.Println("  ssh " + *sshHost + " \"cd <remote-repo> && git worktree add <remote-worktree-path> " + wtBranch + "\"")
-			fmt.Println("  agent-deck add --ssh " + *sshHost + " --remote-path <remote-worktree-path> ...")
+			fmt.Fprintln(os.Stderr, "Error: -w/--worktree (and -b) cannot be combined with --ssh; agent-deck cannot create a git worktree on a remote host yet")
+			fmt.Fprintln(os.Stderr, "Workaround: create the worktree on the remote host directly, then register it:")
+			fmt.Fprintln(os.Stderr, "  ssh "+*sshHost+" \"cd <remote-repo> && git worktree add <remote-worktree-path> "+wtBranch+"\"")
+			fmt.Fprintln(os.Stderr, "  agent-deck add --ssh "+*sshHost+" --remote-path <remote-worktree-path> ...")
 			os.Exit(1)
 		}
 		backend, err := detectAndCreateBackend(path)


### PR DESCRIPTION
## Summary

Fixes two related failure modes of `agent-deck add --ssh` reported in #1711 (canonical) and #1710.

### Failure mode 1: positional path silently dropped when combined with --ssh

`agent-deck add <remote-worktree-path> --ssh <host>` (giving the remote path
as the positional argument, without an explicit `--remote-path` flag) does
not error, but silently misroutes the path: it becomes the session's local
`ProjectPath` placeholder instead of `Instance.SSHRemotePath`. Because
`wrapForSSH` only `cd`s into `SSHRemotePath` when that field is non-empty,
the session's SSH-wrapped launch command never `cd`'d anywhere: the session
launched in the SSH login shell's default directory instead of the intended,
genuinely-existing remote git worktree, which is what produced the
downstream "does not exist" style failures reported live against a deployed
build.

Root cause, in `cmd/agent-deck/main.go`'s `handleAdd`:

```go
if *sshHost != "" {
    // For SSH sessions, use CWD as local placeholder path (project lives on remote)
    if path == "" {
        path, err = os.Getwd()
        ...
    }
}
```

An explicitly-given positional `path` (the common case in the reported
repro) was left untouched here and later became `ProjectPath` via
`session.NewInstance(sessionTitle, path)`, while `SSHRemotePath` was only
ever populated from the separate `--remote-path` flag.

**Fix:** an explicit positional path now routes into `SSHRemotePath` when
`--ssh` is set, unless an explicit `--remote-path` was already given
(which still wins, preserving the documented
`add --ssh <host> --remote-path <path>` pattern). The local placeholder
path is always CWD, exactly as the no-positional-path case already worked.
Extracted into a small, directly-unit-tested helper,
`resolveSSHAddPaths`, in `cmd/agent-deck/cli_utils.go`.

### Failure mode 2: `-w`/`-b` + `--ssh` creates the worktree locally

`agent-deck add --ssh <host> --remote-path <path> -w <branch> -b` (asking
agent-deck to create the worktree itself on the remote host) instead
silently created the worktree on the **local** machine: worktree creation
(`detectAndCreateBackend`, `backend.WorktreePath`, `createWorktreeWithSetup`)
is a 100% local filesystem operation that never became SSH-aware, and
`--remote-path` was never read anywhere in that branch. Confirmed via
`git worktree list` on both sides.

Implementing full remote worktree creation over SSH (remote VCS backend
detection, path templating against a directory this process has no local
filesystem access to, running the repo's setup script remotely, etc.) is a
materially larger feature than this fix's scope. Per the tracking issue,
this PR instead **refuses the dangerous combination loudly** instead of
silently mutating the wrong repository:

```
Error: -w/--worktree (and -b) cannot be combined with --ssh; agent-deck cannot create a git worktree on a remote host yet
Workaround: create the worktree on the remote host directly, then register it:
  ssh <host> "cd <remote-repo> && git worktree add <remote-worktree-path> <branch>"
  agent-deck add --ssh <host> --remote-path <remote-worktree-path> ...
```

Full remote worktree creation is left as a documented follow-up; happy to
scope a separate PR/issue for it if useful.

## Test evidence

- `TestResolveSSHAddPaths` (new, `cmd/agent-deck/issue1711_ssh_worktree_path_test.go`):
  unit-tests the routing rule directly — positional path becomes the
  remote path, an explicit `--remote-path` still wins over a positional
  path, the CWD-only fallback is unchanged.
- `TestSSHWorktreeCreationRefused` (new, same file): subprocess/e2e test
  that builds the real binary, runs `add --ssh --remote-path -w -b`
  against a real throwaway git repo, asserts the command exits non-zero
  with the refusal message, and — the regression check that matters —
  asserts `git worktree list` on the local repo shows **zero** worktrees
  were created.
- `go build ./...` and `go test ./cmd/agent-deck/...` pass (one pre-existing,
  unrelated failure confirmed present on a clean `origin/main` checkout
  before this change: `TestLogCgroupIsolationDecision_WiredIntoBootstrap`,
  a TUI-startup debug-log timing issue on this sandbox, untouched by this
  diff).
- Manually verified against the built binary in an isolated `HOME`/profile:
  - `add <remote-path> --ssh <host> -t <title> -c claude` now stores
    `"ssh_remote_path": "<remote-path>"` in `list --json` (previously empty).
  - `add --ssh <host> --remote-path <path> -w <branch> -b` refuses cleanly
    with the message above and creates zero local worktrees.
- A full live end-to-end dispatch test against the actual reported remote
  host was attempted but not completed: the environment's own
  dispatch-safety preflight gate (`linux-parity-check.sh`) is currently
  fail-closed on that host for an unrelated reason (a `claude` CLI version
  drift), and per this change's own constraints no action may be taken
  against that host that could disrupt another concurrent session on it.
  Coverage instead relies on the unit + subprocess-integration tests above,
  which reproduce the exact CLI-level bug (SSHRemotePath never populated
  from a positional path; local worktree creation under `--ssh`) and prove
  both are fixed.

## Diff scope

Both changes are scoped to `cmd/agent-deck/main.go`'s `add` command flag
handling and `cmd/agent-deck/cli_utils.go`; no unrelated code touched.

Relates to #1711, #1710.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `add --ssh` path handling: positional paths now identify the remote working directory.
  * Added clear guidance when SSH is combined with local worktree creation options.

* **Bug Fixes**
  * Prevented unintended local worktree creation when using SSH with conflicting worktree flags.
  * Preserved the current directory for local bookkeeping during SSH operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->