### PR TITLE
feat: add agentbox remote workspace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ agent-deck remote update dev      # specific remote
 
 Remote configuration is stored under `[remotes]` in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`). All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.
 
-Pressing `n` on a remote group or session opens the full new-session dialog in **remote mode**. SSH remotes keep the existing tool-based session flow. Agentbox remotes switch the dialog into explicit workspace mode and require `orchestrator`, `agent`, `model`, and `runtime` before create — those values are never silently defaulted. Sessions/workspaces are never accidentally created on localhost.
+Pressing `n` on a remote group or session opens the full new-session dialog in **remote mode**. SSH remotes keep the existing tool-based session flow. Agentbox remotes switch the dialog into explicit workspace mode and require `orchestrator`, `agent`, `model`, and `runtime` before create — those values are never silently defaulted. The optional Agentbox path starts empty and Agent Deck never reuses an existing Workspace row’s root automatically. Sessions/workspaces are never accidentally created on localhost.
 
 For running Agentbox workspaces, `Shift+Enter` / “open in new terminal” resolves the attach command through Agentbox's authoritative attach endpoint at launch time. If the workspace is stopped, Agent Deck keeps the stopped-before-attach error instead of launching a dead terminal.
 

--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ Remote configuration is stored under `[remotes]` in `$XDG_CONFIG_HOME/agent-deck
 
 Pressing `n` on a remote group or session opens the full new-session dialog in **remote mode**. SSH remotes keep the existing tool-based session flow. Agentbox remotes switch the dialog into explicit workspace mode and require `orchestrator`, `agent`, `model`, and `runtime` before create — those values are never silently defaulted. Sessions/workspaces are never accidentally created on localhost.
 
-For running Agentbox workspaces, `Shift+Enter` / “open in new terminal” uses the exact attach command returned by Agentbox. If the workspace is stopped, Agent Deck keeps the stopped-before-attach error instead of launching a dead terminal.
+For running Agentbox workspaces, `Shift+Enter` / “open in new terminal” resolves the attach command through Agentbox's authoritative attach endpoint at launch time. If the workspace is stopped, Agent Deck keeps the stopped-before-attach error instead of launching a dead terminal.
 
 #### Security
 

--- a/README.md
+++ b/README.md
@@ -802,14 +802,17 @@ Feedback posts to a public GitHub Discussion at [Feedback Hub](https://github.co
 
 ### Remote Instances
 
-Manage agent-deck instances running on remote SSH servers from your local terminal. Remote sessions appear alongside local sessions in the TUI and all CLI commands.
+Manage agent-deck instances running on remote SSH servers or Agentbox workspace APIs from your local terminal. Remote sessions appear alongside local sessions in the TUI and all CLI commands.
 
 ```bash
-# Register a remote
+# Register an SSH remote
 agent-deck remote add dev user@dev-box
 
 # agent-deck is installed automatically if missing on the remote
 agent-deck remote add prod user@prod-server --agent-deck-path /usr/local/bin/agent-deck
+
+# Register an Agentbox remote
+agent-deck remote add lab --kind agentbox --url https://agentbox.example/agentbox
 
 # List configured remotes
 agent-deck remote list
@@ -821,6 +824,14 @@ agent-deck remote sessions dev
 # Attach to a remote session
 agent-deck remote attach dev my-session
 
+# Create an Agentbox workspace with explicit fields
+agent-deck remote create lab \
+  --name research-one \
+  --orchestrator wisp \
+  --agent codex \
+  --model openai/codex \
+  --runtime docker
+
 # Keep remote binaries up to date
 agent-deck remote update          # all remotes
 agent-deck remote update dev      # specific remote
@@ -828,7 +839,9 @@ agent-deck remote update dev      # specific remote
 
 Remote configuration is stored under `[remotes]` in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`). All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.
 
-Pressing `n` on a remote group or session opens the full new-session dialog in **remote mode**: path suggestions come from the remote host, the remote session's group is pre-filled, and the create routes over SSH with your chosen tool — sessions are never accidentally created on localhost.
+Pressing `n` on a remote group or session opens the full new-session dialog in **remote mode**. SSH remotes keep the existing tool-based session flow. Agentbox remotes switch the dialog into explicit workspace mode and require `orchestrator`, `agent`, `model`, and `runtime` before create — those values are never silently defaulted. Sessions/workspaces are never accidentally created on localhost.
+
+For running Agentbox workspaces, `Shift+Enter` / “open in new terminal” uses the exact attach command returned by Agentbox. If the workspace is stopped, Agent Deck keeps the stopped-before-attach error instead of launching a dead terminal.
 
 #### Security
 

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -312,7 +312,7 @@ func handleRemoteList(args []string) {
 func handleRemoteSessions(args []string) {
 	fs := flag.NewFlagSet("remote sessions", flag.ExitOnError)
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
-	_ = fs.Parse(args)
+	_ = fs.Parse(reorderRemoteArgs(fs, args))
 
 	config, err := session.LoadUserConfig()
 	if err != nil {

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/update"
@@ -30,6 +31,8 @@ func handleRemote(profile string, args []string) {
 		handleRemoteList(args[1:])
 	case "sessions":
 		handleRemoteSessions(args[1:])
+	case "create":
+		handleRemoteCreate(args[1:])
 	case "attach":
 		handleRemoteAttach(args[1:])
 	case "rename":
@@ -50,18 +53,21 @@ func printRemoteUsage() {
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  add <name> <user@host>    Add a remote agent-deck instance")
+	fmt.Println("  create <name>             Create a remote session/workspace")
 	fmt.Println("  remove <name>             Remove a remote")
 	fmt.Println("  list                      List configured remotes")
 	fmt.Println("  sessions [name]           Fetch sessions from remote(s)")
-	fmt.Println("  attach <name> <session>   Attach to a remote session")
+	fmt.Println("  attach <name> <session>   Attach to a remote session/workspace")
 	fmt.Println("  rename <name> <session> <new-title>  Rename a remote session")
 	fmt.Println("  update [name]             Install/update agent-deck on remote(s)")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  agent-deck remote add dev user@dev-box")
+	fmt.Println("  agent-deck remote add agentbox --kind agentbox --url https://agentbox.example/agentbox")
 	fmt.Println("  agent-deck remote add prod user@prod-server --agent-deck-path /usr/local/bin/agent-deck")
 	fmt.Println("  agent-deck remote list")
 	fmt.Println("  agent-deck remote sessions dev")
+	fmt.Println("  agent-deck remote create agentbox --name research-one --orchestrator wisp --agent pi-fireworks --model accounts/fireworks/models/glm-5p2 --runtime docker")
 	fmt.Println("  agent-deck remote attach dev my-session")
 	fmt.Println("  agent-deck remote rename dev my-session new-name")
 	fmt.Println("  agent-deck remote update          # Update all remotes")
@@ -74,11 +80,16 @@ func isValidRemoteName(name string) bool {
 
 func handleRemoteAdd(args []string) {
 	fs := flag.NewFlagSet("remote add", flag.ExitOnError)
+	kind := fs.String("kind", session.RemoteKindSSH, "Remote kind: ssh or agentbox")
+	url := fs.String("url", "", "Agentbox API base URL (required for --kind agentbox)")
+	token := fs.String("token", "", "Optional bearer token for Agentbox remotes")
 	agentDeckPath := fs.String("agent-deck-path", "", "Path to agent-deck on the remote (default: agent-deck)")
 	remoteProfile := fs.String("profile", "", "Remote profile to use (default: default)")
 
 	fs.Usage = func() {
-		fmt.Println("Usage: agent-deck remote add <name> <user@host> [options]")
+		fmt.Println("Usage:")
+		fmt.Println("  agent-deck remote add <name> <user@host> [options]")
+		fmt.Println("  agent-deck remote add <name> --kind agentbox --url https://agentbox.example/agentbox [options]")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -91,14 +102,41 @@ func handleRemoteAdd(args []string) {
 	}
 
 	remaining := fs.Args()
-	if len(remaining) < 2 {
-		fmt.Println("Error: requires <name> and <user@host> arguments")
+	remoteKind := strings.TrimSpace(strings.ToLower(*kind))
+	if remoteKind == "" {
+		remoteKind = session.RemoteKindSSH
+	}
+	if remoteKind != session.RemoteKindSSH && remoteKind != session.RemoteKindAgentbox {
+		fmt.Printf("Error: unsupported remote kind %q\n", *kind)
+		os.Exit(1)
+	}
+	if len(remaining) < 1 {
+		fmt.Println("Error: requires a remote name")
 		fs.Usage()
 		os.Exit(1)
 	}
 
 	name := remaining[0]
-	host := remaining[1]
+	host := ""
+	if remoteKind == session.RemoteKindSSH {
+		if len(remaining) < 2 {
+			fmt.Println("Error: ssh remotes require <user@host>")
+			fs.Usage()
+			os.Exit(1)
+		}
+		host = remaining[1]
+	} else {
+		if strings.TrimSpace(*url) == "" {
+			fmt.Println("Error: agentbox remotes require --url")
+			fs.Usage()
+			os.Exit(1)
+		}
+		if len(remaining) > 1 {
+			fmt.Println("Error: agentbox remotes do not accept <user@host>")
+			fs.Usage()
+			os.Exit(1)
+		}
+	}
 
 	// Validate name (no spaces, slashes, dots, or colons).
 	// Colon is reserved by the UI's internal remote session identifier format.
@@ -123,7 +161,10 @@ func handleRemoteAdd(args []string) {
 	}
 
 	rc := session.RemoteConfig{
-		Host: host,
+		Kind:  remoteKind,
+		Host:  host,
+		URL:   strings.TrimSpace(*url),
+		Token: strings.TrimSpace(*token),
 	}
 	if *agentDeckPath != "" {
 		rc.AgentDeckPath = *agentDeckPath
@@ -137,6 +178,11 @@ func handleRemoteAdd(args []string) {
 	if err := session.SaveUserConfig(config); err != nil {
 		fmt.Printf("Error: failed to save config: %v\n", err)
 		os.Exit(1)
+	}
+
+	if remoteKind == session.RemoteKindAgentbox {
+		fmt.Printf("Added remote '%s' (agentbox %s)\n", name, rc.GetURL())
+		return
 	}
 
 	fmt.Printf("Added remote '%s' (%s)\n", name, host)
@@ -221,7 +267,9 @@ func handleRemoteList(args []string) {
 	if *jsonOutput {
 		type remoteJSON struct {
 			Name          string `json:"name"`
+			Kind          string `json:"kind"`
 			Host          string `json:"host"`
+			URL           string `json:"url,omitempty"`
 			AgentDeckPath string `json:"agent_deck_path"`
 			Profile       string `json:"profile"`
 		}
@@ -230,7 +278,9 @@ func handleRemoteList(args []string) {
 		for name, rc := range config.Remotes {
 			remotes = append(remotes, remoteJSON{
 				Name:          name,
+				Kind:          rc.GetKind(),
 				Host:          rc.Host,
+				URL:           rc.GetURL(),
 				AgentDeckPath: rc.GetAgentDeckPath(),
 				Profile:       rc.GetProfile(),
 			})
@@ -245,10 +295,16 @@ func handleRemoteList(args []string) {
 		return
 	}
 
-	fmt.Printf("%-15s %-30s %-20s %s\n", "NAME", "HOST", "PATH", "PROFILE")
-	fmt.Println(strings.Repeat("-", 70))
+	fmt.Printf("%-15s %-10s %-36s %-20s %s\n", "NAME", "KIND", "TARGET", "PATH", "PROFILE")
+	fmt.Println(strings.Repeat("-", 96))
 	for name, rc := range config.Remotes {
-		fmt.Printf("%-15s %-30s %-20s %s\n", name, rc.Host, rc.GetAgentDeckPath(), rc.GetProfile())
+		target := rc.Host
+		path := rc.GetAgentDeckPath()
+		if rc.GetKind() == session.RemoteKindAgentbox {
+			target = rc.GetURL()
+			path = "-"
+		}
+		fmt.Printf("%-15s %-10s %-36s %-20s %s\n", name, rc.GetKind(), target, path, rc.GetProfile())
 	}
 	fmt.Printf("\nTotal: %d remotes\n", len(config.Remotes))
 }
@@ -288,7 +344,7 @@ func handleRemoteSessions(args []string) {
 			continue
 		}
 
-		runner := session.NewSSHRunner(name, rc)
+		runner := session.NewRemoteRunner(name, rc)
 		sessions, err := runner.FetchSessions(ctx)
 		if err != nil {
 			if !*jsonOutput {
@@ -303,22 +359,43 @@ func handleRemoteSessions(args []string) {
 		allSessions = append(allSessions, sessions...)
 
 		if !*jsonOutput {
-			fmt.Printf("\n═══ Remote: %s (%s) ═══\n\n", name, rc.Host)
+			target := rc.Host
+			if rc.GetKind() == session.RemoteKindAgentbox {
+				target = rc.GetURL()
+			}
+			fmt.Printf("\n═══ Remote: %s (%s) [%s] ═══\n\n", name, target, rc.GetKind())
 			if len(sessions) == 0 {
 				fmt.Println("  No sessions found.")
 			} else {
+				if rc.GetKind() == session.RemoteKindAgentbox {
+					fmt.Printf("  %-18s %-8s %-12s %-24s %-8s %-14s %-5s %-7s %s\n", "NAME", "ORCH", "AGENT", "MODEL", "RUNTIME", "STATUS", "TASKS", "ATTACH", "ID")
+					fmt.Printf("  %s\n", strings.Repeat("-", 120))
+					for _, s := range sessions {
+						nameCol := truncateRemoteColumn(s.Title, 18)
+						orchCol := truncateRemoteColumn(s.Orchestrator, 8)
+						agentCol := truncateRemoteColumn(s.Agent, 12)
+						modelCol := truncateRemoteColumn(s.Model, 24)
+						runtimeCol := truncateRemoteColumn(s.Runtime, 8)
+						statusCol := truncateRemoteColumn(remoteLifecycleStatus(s), 14)
+						attachCol := "no"
+						if s.Attachable {
+							attachCol = "yes"
+						}
+						fmt.Printf("  %-18s %-8s %-12s %-24s %-8s %-14s %-5d %-7s %s\n",
+							nameCol, orchCol, agentCol, modelCol, runtimeCol, statusCol, s.ClaimedTaskCount, attachCol, shortRemoteID(s.ID))
+					}
+					continue
+				}
+
 				fmt.Printf("  %-20s %-15s %-10s %s\n", "TITLE", "TOOL", "STATUS", "ID")
 				fmt.Printf("  %s\n", strings.Repeat("-", 60))
 				for _, s := range sessions {
-					title := s.Title
-					if len(title) > 20 {
-						title = title[:17] + "..."
-					}
-					id := s.ID
-					if len(id) > 8 {
-						id = id[:8]
-					}
-					fmt.Printf("  %-20s %-15s %-10s %s\n", title, s.Tool, s.Status, id)
+					fmt.Printf("  %-20s %-15s %-10s %s\n",
+						truncateRemoteColumn(s.Title, 20),
+						truncateRemoteColumn(s.Tool, 15),
+						truncateRemoteColumn(s.Status, 10),
+						shortRemoteID(s.ID),
+					)
 				}
 			}
 		}
@@ -338,6 +415,102 @@ func handleRemoteSessions(args []string) {
 			os.Exit(1)
 		}
 		fmt.Println(string(output))
+	}
+}
+
+func handleRemoteCreate(args []string) {
+	fs := flag.NewFlagSet("remote create", flag.ExitOnError)
+	name := fs.String("name", "", "Session/workspace name")
+	cwd := fs.String("cwd", "", "Remote working directory / workspace cwd")
+	group := fs.String("group", "", "Remote group (SSH remotes)")
+	tool := fs.String("tool", "", "Remote tool (SSH remotes)")
+	agent := fs.String("agent", "", "Agentbox agent (required for agentbox remotes)")
+	model := fs.String("model", "", "Model identifier")
+	orchestrator := fs.String("orchestrator", "", "Agentbox orchestrator (required for agentbox remotes)")
+	runtimeFlag := fs.String("runtime", "", "Agentbox runtime (required for agentbox remotes)")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck remote create <remote-name> [options]")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck remote create agentbox --name research-one --orchestrator wisp --agent pi-fireworks --model accounts/fireworks/models/glm-5p2 --runtime docker")
+		fmt.Println("  agent-deck remote create dev --name remote-task --tool codex --model gpt-5.5 --cwd /srv/project")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+	reordered := reorderRemoteArgs(fs, args)
+	if err := fs.Parse(reordered); err != nil {
+		os.Exit(1)
+	}
+	remaining := fs.Args()
+	if len(remaining) < 1 {
+		fmt.Println("Error: requires <remote-name>")
+		fs.Usage()
+		os.Exit(1)
+	}
+	remoteName := remaining[0]
+
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		fmt.Printf("Error: failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+	if config.Remotes == nil {
+		fmt.Printf("Error: remote '%s' not found\n", remoteName)
+		os.Exit(1)
+	}
+	rc, exists := config.Remotes[remoteName]
+	if !exists {
+		fmt.Printf("Error: remote '%s' not found\n", remoteName)
+		os.Exit(1)
+	}
+
+	createOpts := session.RemoteCreateOptions{
+		Tool:         strings.TrimSpace(*tool),
+		Title:        strings.TrimSpace(*name),
+		Path:         strings.TrimSpace(*cwd),
+		Group:        strings.TrimSpace(*group),
+		ModelID:      strings.TrimSpace(*model),
+		Orchestrator: strings.TrimSpace(*orchestrator),
+		Agent:        strings.TrimSpace(*agent),
+		Runtime:      strings.TrimSpace(*runtimeFlag),
+	}
+
+	if rc.GetKind() == session.RemoteKindAgentbox {
+		if createOpts.Title == "" || createOpts.Orchestrator == "" || createOpts.Agent == "" || createOpts.ModelID == "" || createOpts.Runtime == "" {
+			fmt.Println("Error: agentbox create requires --name, --orchestrator, --agent, --model, and --runtime")
+			fs.Usage()
+			os.Exit(1)
+		}
+	}
+
+	runner := session.NewRemoteRunner(remoteName, rc)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	sessionID, err := runner.CreateSession(ctx, createOpts)
+	if err != nil {
+		fmt.Printf("Error: failed to create remote session: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Created remote %s '%s' (%s)\n", rc.GetKind(), remoteName, sessionID)
+
+	if rc.GetKind() == session.RemoteKindAgentbox {
+		sessions, fetchErr := runner.FetchSessions(ctx)
+		if fetchErr == nil {
+			for _, s := range sessions {
+				if s.ID == sessionID {
+					fmt.Printf("  Attachable: %t\n", s.Attachable)
+					if strings.TrimSpace(s.AttachCommand) != "" {
+						fmt.Printf("  Remote attach: %s\n", s.AttachCommand)
+					}
+					if strings.TrimSpace(s.LocalAttachCommand) != "" {
+						fmt.Printf("  Local attach: %s\n", s.LocalAttachCommand)
+					}
+					break
+				}
+			}
+		}
 	}
 }
 
@@ -368,7 +541,7 @@ func handleRemoteAttach(args []string) {
 	}
 
 	// Try to resolve session reference (could be title or ID)
-	runner := session.NewSSHRunner(remoteName, rc)
+	runner := session.NewRemoteRunner(remoteName, rc)
 
 	ctx := context.Background()
 	sessions, err := runner.FetchSessions(ctx)
@@ -389,6 +562,19 @@ func handleRemoteAttach(args []string) {
 	if matchID == "" {
 		fmt.Printf("Error: session '%s' not found on remote '%s'\n", sessionRef, remoteName)
 		os.Exit(1)
+	}
+
+	if agentboxRunner, ok := runner.(*session.AgentboxRunner); ok {
+		intent, err := agentboxRunner.ResolveAttach(ctx, matchID)
+		if err != nil {
+			fmt.Printf("Error: failed to resolve attach command: %v\n", err)
+			os.Exit(1)
+		}
+		if intent.Local {
+			fmt.Printf("Local attach command: %s\n", intent.Command)
+		} else {
+			fmt.Printf("Remote attach command: %s\n", intent.Command)
+		}
 	}
 
 	if err := runner.Attach(matchID); err != nil {
@@ -424,7 +610,7 @@ func handleRemoteRename(args []string) {
 		os.Exit(1)
 	}
 
-	runner := session.NewSSHRunner(remoteName, rc)
+	runner := session.NewRemoteRunner(remoteName, rc)
 	ctx := context.Background()
 
 	// Resolve session reference
@@ -448,8 +634,7 @@ func handleRemoteRename(args []string) {
 		os.Exit(1)
 	}
 
-	_, err = runner.RunCommand(ctx, "rename", matchID, newTitle)
-	if err != nil {
+	if err := runner.RenameSession(ctx, matchID, newTitle); err != nil {
 		fmt.Printf("Error: failed to rename session: %v\n", err)
 		os.Exit(1)
 	}
@@ -483,6 +668,11 @@ func handleRemoteUpdate(args []string) {
 		}
 
 		fmt.Printf("\n═══ Remote: %s (%s) ═══\n", name, rc.Host)
+
+		if rc.GetKind() == session.RemoteKindAgentbox {
+			fmt.Printf("  Agentbox API remotes do not run an agent-deck binary. No update needed.\n")
+			continue
+		}
 
 		runner := session.NewSSHRunner(name, rc)
 
@@ -531,6 +721,10 @@ func updateRemotesAfterLocalUpdate(newVersion string) {
 	ctx := context.Background()
 	for name, rc := range config.Remotes {
 		fmt.Printf("\n═══ Remote: %s (%s) ═══\n", name, rc.Host)
+		if rc.GetKind() == session.RemoteKindAgentbox {
+			fmt.Printf("  Agentbox API remotes do not run an agent-deck binary. No update needed.\n")
+			continue
+		}
 		runner := session.NewSSHRunner(name, rc)
 
 		remoteVersion, found := runner.CheckBinary(ctx)
@@ -551,6 +745,33 @@ func updateRemotesAfterLocalUpdate(newVersion string) {
 			fmt.Printf("  ✓ Installed v%s\n", newVersion)
 		}
 	}
+}
+
+func truncateRemoteColumn(value string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(value) <= max {
+		return value
+	}
+	if max <= 3 {
+		return value[:max]
+	}
+	return value[:max-3] + "..."
+}
+
+func shortRemoteID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}
+
+func remoteLifecycleStatus(s session.RemoteSessionInfo) string {
+	if strings.TrimSpace(s.LifecycleStatus) != "" {
+		return s.LifecycleStatus
+	}
+	return s.Status
 }
 
 func shouldProceedWithRemoteUpdate(response string, readErr error) bool {

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -487,29 +487,22 @@ func handleRemoteCreate(args []string) {
 	runner := session.NewRemoteRunner(remoteName, rc)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	sessionID, err := runner.CreateSession(ctx, createOpts)
+	result, err := runner.CreateSession(ctx, createOpts)
 	if err != nil {
 		fmt.Printf("Error: failed to create remote session: %v\n", err)
 		os.Exit(1)
 	}
 
+	sessionID := result.SessionID
 	fmt.Printf("Created remote %s '%s' (%s)\n", rc.GetKind(), remoteName, sessionID)
 
 	if rc.GetKind() == session.RemoteKindAgentbox {
-		sessions, fetchErr := runner.FetchSessions(ctx)
-		if fetchErr == nil {
-			for _, s := range sessions {
-				if s.ID == sessionID {
-					fmt.Printf("  Attachable: %t\n", s.Attachable)
-					if strings.TrimSpace(s.AttachCommand) != "" {
-						fmt.Printf("  Remote attach: %s\n", s.AttachCommand)
-					}
-					if strings.TrimSpace(s.LocalAttachCommand) != "" {
-						fmt.Printf("  Local attach: %s\n", s.LocalAttachCommand)
-					}
-					break
-				}
-			}
+		fmt.Printf("  Attachable: %t\n", result.Attachable)
+		if strings.TrimSpace(result.AttachCommand) != "" {
+			fmt.Printf("  Remote attach: %s\n", result.AttachCommand)
+		}
+		if strings.TrimSpace(result.LocalAttachCommand) != "" {
+			fmt.Printf("  Local attach: %s\n", result.LocalAttachCommand)
 		}
 	}
 }

--- a/cmd/agent-deck/remote_cmd_test.go
+++ b/cmd/agent-deck/remote_cmd_test.go
@@ -130,6 +130,39 @@ func TestHandleRemoteSessions_AgentboxPrintsWorkspaceColumns(t *testing.T) {
 	}
 }
 
+func TestHandleRemoteSessions_JSONFlagWorksAfterRemoteName(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"id":     "ws-json",
+			"name":   "research-one",
+			"status": "running",
+		}})
+	}))
+	defer srv.Close()
+
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Remotes: map[string]session.RemoteConfig{
+			"lab": {Kind: session.RemoteKindAgentbox, URL: srv.URL},
+		},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	output := captureStdout(t, func() {
+		handleRemoteSessions([]string{"lab", "--json"})
+	})
+
+	var sessions []map[string]any
+	if err := json.Unmarshal([]byte(output), &sessions); err != nil {
+		t.Fatalf("output = %q, want JSON: %v", output, err)
+	}
+	if len(sessions) != 1 || sessions[0]["id"] != "ws-json" {
+		t.Fatalf("sessions = %#v, want ws-json", sessions)
+	}
+}
+
 func TestHandleRemoteCreate_AgentboxPrintsAttachCommandsFromCreateResponse(t *testing.T) {
 	withTempHomeAndConfig(t, "")
 

--- a/cmd/agent-deck/remote_cmd_test.go
+++ b/cmd/agent-deck/remote_cmd_test.go
@@ -1,8 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func TestIsValidRemoteName(t *testing.T) {
@@ -60,4 +68,159 @@ func TestShouldProceedWithRemoteUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleRemoteAdd_AgentboxPersistsConfig(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+
+	output := captureStdout(t, func() {
+		handleRemoteAdd([]string{"lab", "--kind", "agentbox", "--url", "https://agentbox.example/agentbox", "--token", "top-secret"})
+	})
+
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	rc, ok := cfg.Remotes["lab"]
+	if !ok {
+		t.Fatalf("remotes = %#v, want lab entry", cfg.Remotes)
+	}
+	if rc.GetKind() != session.RemoteKindAgentbox || rc.GetURL() != "https://agentbox.example/agentbox" || rc.Token != "top-secret" {
+		t.Fatalf("remote config = %#v", rc)
+	}
+	if !strings.Contains(output, "Added remote 'lab'") {
+		t.Fatalf("output = %q, want added message", output)
+	}
+}
+
+func TestHandleRemoteSessions_AgentboxPrintsWorkspaceColumns(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"id":               "ws-123456789",
+			"name":             "research-one",
+			"orchestrator":     "wisp",
+			"agent":            "pi-fireworks",
+			"model":            "accounts/fireworks/models/glm-5p2",
+			"runtime":          "docker",
+			"status":           "running",
+			"attachCommand":    "ssh remote tmux attach -t ws-1",
+			"claimedTaskCount": 2,
+		}})
+	}))
+	defer srv.Close()
+
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Remotes: map[string]session.RemoteConfig{
+			"lab": {Kind: session.RemoteKindAgentbox, URL: srv.URL},
+		},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	output := captureStdout(t, func() {
+		handleRemoteSessions([]string{"lab"})
+	})
+
+	for _, want := range []string{"Remote: lab", "ORCH", "AGENT", "MODEL", "ATTACH", "research-one", "wisp", "pi-fireworks", "yes"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestHandleRemoteCreate_AgentboxPostsExplicitFields(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+
+	var createPayload map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces":
+			if err := json.NewDecoder(r.Body).Decode(&createPayload); err != nil {
+				t.Fatalf("decode create payload: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ws-new"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                 "ws-new",
+				"name":               "research-one",
+				"orchestrator":       "wisp",
+				"agent":              "pi-fireworks",
+				"model":              "accounts/fireworks/models/glm-5p2",
+				"runtime":            "docker",
+				"status":             "running",
+				"attachCommand":      "ssh remote tmux attach -t ws-new",
+				"localAttachCommand": "ssh localhost tmux attach -t ws-new",
+				"claimedTaskCount":   1,
+			}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Remotes: map[string]session.RemoteConfig{
+			"lab": {Kind: session.RemoteKindAgentbox, URL: srv.URL},
+		},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	output := captureStdout(t, func() {
+		handleRemoteCreate([]string{
+			"lab",
+			"--name", "research-one",
+			"--cwd", "/srv/research",
+			"--orchestrator", "wisp",
+			"--agent", "pi-fireworks",
+			"--model", "accounts/fireworks/models/glm-5p2",
+			"--runtime", "docker",
+		})
+	})
+
+	wantPayload := map[string]string{
+		"name":         "research-one",
+		"cwd":          "/srv/research",
+		"orchestrator": "wisp",
+		"agent":        "pi-fireworks",
+		"model":        "accounts/fireworks/models/glm-5p2",
+		"runtime":      "docker",
+	}
+	for key, want := range wantPayload {
+		if createPayload[key] != want {
+			t.Fatalf("payload[%q] = %q, want %q (payload=%#v)", key, createPayload[key], want, createPayload)
+		}
+	}
+	for _, want := range []string{"Created remote agentbox 'lab' (ws-new)", "Attachable: true", "Remote attach:", "Local attach:"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	outputCh := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, reader)
+		outputCh <- buf.String()
+	}()
+
+	fn()
+
+	_ = writer.Close()
+	return <-outputCh
 }

--- a/cmd/agent-deck/remote_cmd_test.go
+++ b/cmd/agent-deck/remote_cmd_test.go
@@ -130,33 +130,29 @@ func TestHandleRemoteSessions_AgentboxPrintsWorkspaceColumns(t *testing.T) {
 	}
 }
 
-func TestHandleRemoteCreate_AgentboxPostsExplicitFields(t *testing.T) {
+func TestHandleRemoteCreate_AgentboxPrintsAttachCommandsFromCreateResponse(t *testing.T) {
 	withTempHomeAndConfig(t, "")
 
 	var createPayload map[string]string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces":
-			if err := json.NewDecoder(r.Body).Decode(&createPayload); err != nil {
-				t.Fatalf("decode create payload: %v", err)
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ws-new"})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces":
-			_ = json.NewEncoder(w).Encode([]map[string]any{{
-				"id":                 "ws-new",
-				"name":               "research-one",
-				"orchestrator":       "wisp",
-				"agent":              "pi-fireworks",
-				"model":              "accounts/fireworks/models/glm-5p2",
-				"runtime":            "docker",
-				"status":             "running",
-				"attachCommand":      "ssh remote tmux attach -t ws-new",
-				"localAttachCommand": "ssh localhost tmux attach -t ws-new",
-				"claimedTaskCount":   1,
-			}})
-		default:
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces" {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
+		if err := json.NewDecoder(r.Body).Decode(&createPayload); err != nil {
+			t.Fatalf("decode create payload: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                 "ws-new",
+			"name":               "research-one",
+			"orchestrator":       "wisp",
+			"agent":              "pi-fireworks",
+			"model":              "accounts/fireworks/models/glm-5p2",
+			"runtime":            "docker",
+			"status":             "running",
+			"attachCommand":      "ssh remote tmux attach -t ws-new",
+			"localAttachCommand": "ssh localhost tmux attach -t ws-new",
+			"claimedTaskCount":   1,
+		})
 	}))
 	defer srv.Close()
 

--- a/docs/internal/agentbox-remote.md
+++ b/docs/internal/agentbox-remote.md
@@ -24,6 +24,8 @@ No `agent-deck` binary is installed or required inside an Agentbox Workspace.
 - Agentbox create requires explicit `name`, `orchestrator`, `agent`, `model`, and `runtime`.
   - We do not invent defaults in Agent Deck because those values are part of the user’s intentional workspace contract.
   - The CLI, web create route, and remote TUI dialog all enforce those required fields.
+  - The remote TUI dialog also leaves the optional cwd/path empty by default and never reuses the selected Workspace row’s existing root.
+  - Local remembered/configured model defaults are ignored in Agentbox create mode so the Workspace model remains explicitly chosen per create.
 - Agent Deck preserves the full `POST /v1/workspaces` create response.
   - `agent-deck remote create <agentbox-remote> ...` prints attachability plus the exact returned remote/local attach commands without doing a follow-up list request.
   - The TUI immediate create-and-attach path also uses those returned commands directly instead of doing a redundant follow-up `/v1/workspaces/:id/attach` lookup.

--- a/docs/internal/agentbox-remote.md
+++ b/docs/internal/agentbox-remote.md
@@ -23,19 +23,25 @@ No `agent-deck` binary is installed or required inside an Agentbox Workspace.
 
 - Agentbox create requires explicit `name`, `orchestrator`, `agent`, `model`, and `runtime`.
   - We do not invent defaults in Agent Deck because those values are part of the user’s intentional workspace contract.
+  - The CLI, web create route, and remote TUI dialog all enforce those required fields.
+- Agent Deck preserves the full `POST /v1/workspaces` create response.
+  - `agent-deck remote create <agentbox-remote> ...` prints attachability plus the exact returned remote/local attach commands without doing a follow-up list request.
 - Attach preserves stopped-before-attach semantics.
   - Agent Deck does not auto-start a stopped Workspace during attach.
   - When Agentbox returns `workspace_not_running` or `workspace_not_attachable`, the error is translated into a clearer user-facing message.
 - When the configured Agentbox URL resolves to localhost/the local machine, Agent Deck prefers `localAttachCommand`.
   - Otherwise it uses the regular remote attach command.
+- Shift+Enter / “open in new terminal” for a running Agentbox remote uses the exact attach command already returned by Agentbox.
+  - SSH remotes keep the existing `agent-deck session attach ...` SSH launcher path unchanged.
+- Web remote-create errors preserve upstream meaning instead of collapsing to generic 500s.
+  - `invalid_request` → 400
+  - `workspace_root_conflict` / `workspace_disk_exhausted` / `invalid_state` → 409/507 as appropriate
+  - `workspace_root_unconfigured` / `workspace_unavailable` / `workspace_runtime_unavailable` → 503
 
 ## Current non-goals
 
 - Agentbox remote preview/output scraping is not implemented.
   - Existing SSH remotes still support remote preview and insert-mode key streaming.
-- The legacy TUI remote-create dialog is not yet Agentbox-aware.
-  - It does not collect `orchestrator`, `agent`, `model`, or `runtime`.
-  - The supported minimal Agentbox create flow is the CLI/Warp path (`agent-deck remote create ...`).
 
 ## Files to read first
 
@@ -43,3 +49,4 @@ No `agent-deck` binary is installed or required inside an Agentbox Workspace.
 - `cmd/agent-deck/remote_cmd.go`
 - `internal/web/handlers_sessions.go`
 - `internal/ui/home.go`
+- `internal/ui/newdialog.go`

--- a/docs/internal/agentbox-remote.md
+++ b/docs/internal/agentbox-remote.md
@@ -26,12 +26,14 @@ No `agent-deck` binary is installed or required inside an Agentbox Workspace.
   - The CLI, web create route, and remote TUI dialog all enforce those required fields.
 - Agent Deck preserves the full `POST /v1/workspaces` create response.
   - `agent-deck remote create <agentbox-remote> ...` prints attachability plus the exact returned remote/local attach commands without doing a follow-up list request.
+  - The TUI immediate create-and-attach path also uses those returned commands directly instead of doing a redundant follow-up `/v1/workspaces/:id/attach` lookup.
 - Attach preserves stopped-before-attach semantics.
   - Agent Deck does not auto-start a stopped Workspace during attach.
   - When Agentbox returns `workspace_not_running` or `workspace_not_attachable`, the error is translated into a clearer user-facing message.
 - When the configured Agentbox URL resolves to localhost/the local machine, Agent Deck prefers `localAttachCommand`.
   - Otherwise it uses the regular remote attach command.
-- Shift+Enter / “open in new terminal” for a running Agentbox remote uses the exact attach command already returned by Agentbox.
+- Shift+Enter / “open in new terminal” for a running Agentbox remote resolves attach through the authoritative `/v1/workspaces/:id/attach` endpoint at launch time.
+  - This avoids launching from stale cached list data when the Workspace stopped, was destroyed, or became otherwise unattached elsewhere.
   - SSH remotes keep the existing `agent-deck session attach ...` SSH launcher path unchanged.
 - Web remote-create errors preserve upstream meaning instead of collapsing to generic 500s.
   - `invalid_request` → 400

--- a/docs/internal/agentbox-remote.md
+++ b/docs/internal/agentbox-remote.md
@@ -1,0 +1,45 @@
+# Agentbox remote implementation note
+
+Date: July 22, 2026
+
+## What this adds
+
+Agent Deck now supports two remote kinds:
+
+- `ssh`: the existing remote `agent-deck` binary model
+- `agentbox`: an HTTP API model that talks directly to Agentbox Workspace routes
+
+The Agentbox path is intentionally small and Warp-oriented:
+
+- register a remote with `kind = "agentbox"` plus `url` and optional `token`
+- list Workspaces via `/v1/workspaces`
+- create Workspaces via `/v1/workspaces`
+- start/stop/destroy via the Workspace lifecycle routes
+- attach via `/v1/workspaces/:id/attach`
+
+No `agent-deck` binary is installed or required inside an Agentbox Workspace.
+
+## Important behavior choices
+
+- Agentbox create requires explicit `name`, `orchestrator`, `agent`, `model`, and `runtime`.
+  - We do not invent defaults in Agent Deck because those values are part of the user’s intentional workspace contract.
+- Attach preserves stopped-before-attach semantics.
+  - Agent Deck does not auto-start a stopped Workspace during attach.
+  - When Agentbox returns `workspace_not_running` or `workspace_not_attachable`, the error is translated into a clearer user-facing message.
+- When the configured Agentbox URL resolves to localhost/the local machine, Agent Deck prefers `localAttachCommand`.
+  - Otherwise it uses the regular remote attach command.
+
+## Current non-goals
+
+- Agentbox remote preview/output scraping is not implemented.
+  - Existing SSH remotes still support remote preview and insert-mode key streaming.
+- The legacy TUI remote-create dialog is not yet Agentbox-aware.
+  - It does not collect `orchestrator`, `agent`, `model`, or `runtime`.
+  - The supported minimal Agentbox create flow is the CLI/Warp path (`agent-deck remote create ...`).
+
+## Files to read first
+
+- `internal/session/agentbox.go`
+- `cmd/agent-deck/remote_cmd.go`
+- `internal/web/handlers_sessions.go`
+- `internal/ui/home.go`

--- a/internal/session/agentbox.go
+++ b/internal/session/agentbox.go
@@ -1,0 +1,415 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+)
+
+const (
+	RemoteKindSSH      = "ssh"
+	RemoteKindAgentbox = "agentbox"
+)
+
+type RemoteCreateOptions struct {
+	Tool         string
+	Title        string
+	Path         string
+	Group        string
+	ModelID      string
+	Orchestrator string
+	Agent        string
+	Runtime      string
+}
+
+type RemoteRunner interface {
+	FetchSessions(ctx context.Context) ([]RemoteSessionInfo, error)
+	FetchSessionOutput(ctx context.Context, sessionID string) (string, error)
+	FetchSessionPane(ctx context.Context, sessionID string) (string, error)
+	FetchCostSummary(ctx context.Context) (*costs.RemoteCostSummary, error)
+	MeasureLatency(ctx context.Context) (time.Duration, error)
+	CreateSession(ctx context.Context, opts RemoteCreateOptions) (string, error)
+	DeleteSession(ctx context.Context, sessionID string) error
+	StopSession(ctx context.Context, sessionID string) error
+	RestartSession(ctx context.Context, sessionID string) error
+	RenameSession(ctx context.Context, sessionID string, newTitle string) error
+	Attach(sessionID string) error
+}
+
+func NewRemoteRunner(name string, rc RemoteConfig) RemoteRunner {
+	if rc.GetKind() == RemoteKindAgentbox {
+		return NewAgentboxRunner(name, rc)
+	}
+	return NewSSHRunner(name, rc)
+}
+
+type AgentboxRunner struct {
+	RemoteName string
+	BaseURL    string
+	Token      string
+
+	client      *http.Client
+	execCommand func(command string) error
+	hostname    func() (string, error)
+}
+
+func NewAgentboxRunner(name string, rc RemoteConfig) *AgentboxRunner {
+	return &AgentboxRunner{
+		RemoteName: name,
+		BaseURL:    strings.TrimRight(strings.TrimSpace(rc.GetURL()), "/"),
+		Token:      strings.TrimSpace(rc.Token),
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		execCommand: runLocalAttachCommand,
+		hostname:    os.Hostname,
+	}
+}
+
+type agentboxWorkspace struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Orchestrator       string `json:"orchestrator"`
+	Agent              string `json:"agent"`
+	Model              string `json:"model"`
+	Runtime            string `json:"runtime"`
+	Cwd                string `json:"cwd"`
+	Status             string `json:"status"`
+	AttachCommand      string `json:"attachCommand"`
+	LocalAttachCommand string `json:"localAttachCommand"`
+	ClaimedTaskCount   int    `json:"claimedTaskCount"`
+	CreatedAt          string `json:"createdAt"`
+}
+
+type agentboxAttachResponse struct {
+	ID                 string `json:"id"`
+	Status             string `json:"status"`
+	AttachCommand      string `json:"attachCommand"`
+	LocalAttachCommand string `json:"localAttachCommand"`
+}
+
+type agentboxErrorResponse struct {
+	Error  string `json:"error"`
+	Status string `json:"status"`
+}
+
+type ResolvedAttachCommand struct {
+	Command string
+	Local   bool
+}
+
+func (r *AgentboxRunner) FetchSessions(ctx context.Context) ([]RemoteSessionInfo, error) {
+	var workspaces []agentboxWorkspace
+	if err := r.doJSON(ctx, http.MethodGet, "/v1/workspaces", nil, &workspaces); err != nil {
+		return nil, err
+	}
+	sessions := make([]RemoteSessionInfo, 0, len(workspaces))
+	for _, workspace := range workspaces {
+		sessions = append(sessions, r.workspaceToRemoteSession(workspace))
+	}
+	return sessions, nil
+}
+
+func (r *AgentboxRunner) FetchSessionOutput(ctx context.Context, sessionID string) (string, error) {
+	return "", fmt.Errorf("agentbox remote preview is unavailable for workspace %s", sessionID)
+}
+
+func (r *AgentboxRunner) FetchSessionPane(ctx context.Context, sessionID string) (string, error) {
+	return "", fmt.Errorf("agentbox remote pane preview is unavailable for workspace %s", sessionID)
+}
+
+func (r *AgentboxRunner) FetchCostSummary(ctx context.Context) (*costs.RemoteCostSummary, error) {
+	return nil, nil
+}
+
+func (r *AgentboxRunner) MeasureLatency(ctx context.Context) (time.Duration, error) {
+	start := time.Now()
+	var workspaces []agentboxWorkspace
+	if err := r.doJSON(ctx, http.MethodGet, "/v1/workspaces", nil, &workspaces); err != nil {
+		return 0, err
+	}
+	return time.Since(start), nil
+}
+
+func (r *AgentboxRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions) (string, error) {
+	if strings.TrimSpace(opts.Title) == "" {
+		return "", fmt.Errorf("agentbox create requires --name")
+	}
+	if strings.TrimSpace(opts.Orchestrator) == "" {
+		return "", fmt.Errorf("agentbox create requires --orchestrator")
+	}
+	if strings.TrimSpace(opts.Agent) == "" {
+		return "", fmt.Errorf("agentbox create requires --agent")
+	}
+	if strings.TrimSpace(opts.ModelID) == "" {
+		return "", fmt.Errorf("agentbox create requires --model")
+	}
+	if strings.TrimSpace(opts.Runtime) == "" {
+		return "", fmt.Errorf("agentbox create requires --runtime")
+	}
+
+	payload := map[string]string{
+		"name":         strings.TrimSpace(opts.Title),
+		"orchestrator": strings.TrimSpace(opts.Orchestrator),
+		"agent":        strings.TrimSpace(opts.Agent),
+		"model":        strings.TrimSpace(opts.ModelID),
+		"runtime":      strings.TrimSpace(opts.Runtime),
+	}
+	if cwd := strings.TrimSpace(opts.Path); cwd != "" && cwd != "." {
+		payload["cwd"] = cwd
+	}
+
+	var workspace agentboxWorkspace
+	if err := r.doJSON(ctx, http.MethodPost, "/v1/workspaces", payload, &workspace); err != nil {
+		return "", err
+	}
+	if workspace.ID == "" {
+		return "", fmt.Errorf("agentbox create returned an empty workspace ID")
+	}
+	return workspace.ID, nil
+}
+
+func (r *AgentboxRunner) DeleteSession(ctx context.Context, sessionID string) error {
+	return r.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/workspaces/%s/destroy", url.PathEscape(sessionID)), map[string]bool{"force": false}, nil)
+}
+
+func (r *AgentboxRunner) StopSession(ctx context.Context, sessionID string) error {
+	return r.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/workspaces/%s/stop", url.PathEscape(sessionID)), map[string]any{}, nil)
+}
+
+func (r *AgentboxRunner) RestartSession(ctx context.Context, sessionID string) error {
+	return r.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/workspaces/%s/start", url.PathEscape(sessionID)), map[string]any{}, nil)
+}
+
+func (r *AgentboxRunner) RenameSession(ctx context.Context, sessionID string, newTitle string) error {
+	return fmt.Errorf("agentbox workspaces do not support rename through agent-deck yet")
+}
+
+func (r *AgentboxRunner) ResolveAttach(ctx context.Context, sessionID string) (ResolvedAttachCommand, error) {
+	var response agentboxAttachResponse
+	if err := r.doJSON(ctx, http.MethodGet, fmt.Sprintf("/v1/workspaces/%s/attach", url.PathEscape(sessionID)), nil, &response); err != nil {
+		return ResolvedAttachCommand{}, err
+	}
+	useLocal := r.shouldUseLocalAttachCommand()
+	command := strings.TrimSpace(response.AttachCommand)
+	if useLocal && strings.TrimSpace(response.LocalAttachCommand) != "" {
+		command = strings.TrimSpace(response.LocalAttachCommand)
+	}
+	if command == "" {
+		return ResolvedAttachCommand{}, fmt.Errorf("agentbox attach for workspace %s returned no attach command", sessionID)
+	}
+	return ResolvedAttachCommand{Command: command, Local: useLocal}, nil
+}
+
+func (r *AgentboxRunner) Attach(sessionID string) error {
+	intent, err := r.ResolveAttach(context.Background(), sessionID)
+	if err != nil {
+		return err
+	}
+	return r.execCommand(intent.Command)
+}
+
+func (r *AgentboxRunner) workspaceToRemoteSession(workspace agentboxWorkspace) RemoteSessionInfo {
+	attachable := workspace.Status == "running" &&
+		(strings.TrimSpace(workspace.AttachCommand) != "" || strings.TrimSpace(workspace.LocalAttachCommand) != "")
+	return RemoteSessionInfo{
+		ID:                 workspace.ID,
+		Title:              workspace.Name,
+		Path:               workspace.Cwd,
+		Group:              workspace.Orchestrator,
+		Tool:               normalizeAgentboxTool(workspace.Agent),
+		Agent:              workspace.Agent,
+		Model:              workspace.Model,
+		Runtime:            workspace.Runtime,
+		Orchestrator:       workspace.Orchestrator,
+		Status:             remoteStatusFromLifecycle(workspace.Status),
+		LifecycleStatus:    workspace.Status,
+		ClaimedTaskCount:   workspace.ClaimedTaskCount,
+		Attachable:         attachable,
+		AttachCommand:      workspace.AttachCommand,
+		LocalAttachCommand: workspace.LocalAttachCommand,
+		CreatedAt:          workspace.CreatedAt,
+		RemoteName:         r.RemoteName,
+	}
+}
+
+func normalizeAgentboxTool(agent string) string {
+	switch strings.TrimSpace(agent) {
+	case "claude", "claude-code":
+		return "claude"
+	case "pi", "pi-fireworks":
+		return "pi"
+	default:
+		return strings.TrimSpace(agent)
+	}
+}
+
+func remoteStatusFromLifecycle(status string) string {
+	switch strings.TrimSpace(status) {
+	case "running":
+		return "running"
+	case "stopped":
+		return "stopped"
+	case "cleanup_required", "destroying", "destroyed":
+		return "error"
+	default:
+		return strings.TrimSpace(status)
+	}
+}
+
+func (r *AgentboxRunner) doJSON(ctx context.Context, method string, requestPath string, body any, out any) error {
+	if err := validateAgentboxURL(r.BaseURL); err != nil {
+		return err
+	}
+
+	fullURL := r.BaseURL + requestPath
+	var payload io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("agentbox %s %s: encode request: %w", method, requestPath, err)
+		}
+		payload = bytes.NewReader(raw)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, payload)
+	if err != nil {
+		return fmt.Errorf("agentbox %s %s: build request: %w", method, requestPath, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if r.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+r.Token)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("agentbox %s %s: %w", method, requestPath, err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("agentbox %s %s: read response: %w", method, requestPath, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return translateAgentboxHTTPError(method, requestPath, resp.StatusCode, responseBody)
+	}
+	if out == nil || len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return fmt.Errorf("agentbox %s %s: decode response: %w", method, requestPath, err)
+	}
+	return nil
+}
+
+func validateAgentboxURL(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("agentbox remote is missing a URL")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid agentbox URL %q: %w", raw, err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("invalid agentbox URL %q: missing host", raw)
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	if parsed.Scheme != "http" {
+		return fmt.Errorf("invalid agentbox URL %q: unsupported scheme %q", raw, parsed.Scheme)
+	}
+	host := parsed.Hostname()
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return nil
+	}
+	return fmt.Errorf("invalid agentbox URL %q: remote cleartext HTTP is only allowed for localhost", raw)
+}
+
+func translateAgentboxHTTPError(method string, requestPath string, statusCode int, body []byte) error {
+	var payload agentboxErrorResponse
+	_ = json.Unmarshal(body, &payload)
+
+	message := strings.TrimSpace(payload.Error)
+	switch payload.Error {
+	case "workspace_not_running":
+		if payload.Status != "" {
+			message = fmt.Sprintf("workspace is %s; start it before attaching", payload.Status)
+		} else {
+			message = "workspace is not running"
+		}
+	case "workspace_not_attachable":
+		if payload.Status != "" {
+			message = fmt.Sprintf("workspace is %s and cannot be attached", payload.Status)
+		} else {
+			message = "workspace cannot be attached"
+		}
+	case "workspace_runtime_unavailable":
+		message = "workspace runtime is unavailable"
+	case "workspace_running":
+		message = "workspace is still running; stop it before destroying"
+	case "workspace_destroyed":
+		message = "workspace is destroyed"
+	case "workspaces_unavailable":
+		message = "agentbox workspaces are unavailable"
+	case "invalid_request":
+		message = "agentbox rejected the request"
+	case "not_found":
+		message = "workspace not found"
+	}
+	if message == "" {
+		message = strings.TrimSpace(string(body))
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	return fmt.Errorf("agentbox %s %s: %s", method, requestPath, message)
+}
+
+func (r *AgentboxRunner) shouldUseLocalAttachCommand() bool {
+	parsed, err := url.Parse(r.BaseURL)
+	if err != nil {
+		return false
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	localHost, err := r.hostname()
+	if err != nil {
+		return false
+	}
+	localHost = strings.TrimSpace(localHost)
+	if localHost == "" {
+		return false
+	}
+	return strings.EqualFold(host, localHost) || strings.HasPrefix(strings.ToLower(host), strings.ToLower(localHost)+".")
+}
+
+func runLocalAttachCommand(command string) error {
+	if strings.TrimSpace(command) == "" {
+		return errors.New("empty attach command")
+	}
+	cmd := exec.Command("sh", "-lc", command)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/session/agentbox.go
+++ b/internal/session/agentbox.go
@@ -247,6 +247,18 @@ func (r *AgentboxRunner) Attach(sessionID string) error {
 	return r.execCommand(intent.Command)
 }
 
+func (r *AgentboxRunner) AttachCreatedResult(result RemoteCreateResult) error {
+	useLocal := r.shouldUseLocalAttachCommand()
+	command := strings.TrimSpace(result.AttachCommand)
+	if useLocal && strings.TrimSpace(result.LocalAttachCommand) != "" {
+		command = strings.TrimSpace(result.LocalAttachCommand)
+	}
+	if command == "" {
+		return fmt.Errorf("agentbox create for workspace %s returned no attach command", result.SessionID)
+	}
+	return r.execCommand(command)
+}
+
 func (r *AgentboxRunner) workspaceToRemoteSession(workspace agentboxWorkspace) RemoteSessionInfo {
 	attachable := workspace.Status == "running" &&
 		(strings.TrimSpace(workspace.AttachCommand) != "" || strings.TrimSpace(workspace.LocalAttachCommand) != "")

--- a/internal/session/agentbox.go
+++ b/internal/session/agentbox.go
@@ -33,13 +33,20 @@ type RemoteCreateOptions struct {
 	Runtime      string
 }
 
+type RemoteCreateResult struct {
+	SessionID          string
+	Attachable         bool
+	AttachCommand      string
+	LocalAttachCommand string
+}
+
 type RemoteRunner interface {
 	FetchSessions(ctx context.Context) ([]RemoteSessionInfo, error)
 	FetchSessionOutput(ctx context.Context, sessionID string) (string, error)
 	FetchSessionPane(ctx context.Context, sessionID string) (string, error)
 	FetchCostSummary(ctx context.Context) (*costs.RemoteCostSummary, error)
 	MeasureLatency(ctx context.Context) (time.Duration, error)
-	CreateSession(ctx context.Context, opts RemoteCreateOptions) (string, error)
+	CreateSession(ctx context.Context, opts RemoteCreateOptions) (RemoteCreateResult, error)
 	DeleteSession(ctx context.Context, sessionID string) error
 	StopSession(ctx context.Context, sessionID string) error
 	RestartSession(ctx context.Context, sessionID string) error
@@ -100,13 +107,27 @@ type agentboxAttachResponse struct {
 }
 
 type agentboxErrorResponse struct {
-	Error  string `json:"error"`
-	Status string `json:"status"`
+	Error   string `json:"error"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }
 
 type ResolvedAttachCommand struct {
 	Command string
 	Local   bool
+}
+
+type AgentboxHTTPError struct {
+	Method         string
+	RequestPath    string
+	StatusCode     int
+	RemoteError    string
+	WorkspaceState string
+	Message        string
+}
+
+func (e *AgentboxHTTPError) Error() string {
+	return fmt.Sprintf("agentbox %s %s: %s", e.Method, e.RequestPath, e.Message)
 }
 
 func (r *AgentboxRunner) FetchSessions(ctx context.Context) ([]RemoteSessionInfo, error) {
@@ -142,21 +163,21 @@ func (r *AgentboxRunner) MeasureLatency(ctx context.Context) (time.Duration, err
 	return time.Since(start), nil
 }
 
-func (r *AgentboxRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions) (string, error) {
+func (r *AgentboxRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions) (RemoteCreateResult, error) {
 	if strings.TrimSpace(opts.Title) == "" {
-		return "", fmt.Errorf("agentbox create requires --name")
+		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --name")
 	}
 	if strings.TrimSpace(opts.Orchestrator) == "" {
-		return "", fmt.Errorf("agentbox create requires --orchestrator")
+		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --orchestrator")
 	}
 	if strings.TrimSpace(opts.Agent) == "" {
-		return "", fmt.Errorf("agentbox create requires --agent")
+		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --agent")
 	}
 	if strings.TrimSpace(opts.ModelID) == "" {
-		return "", fmt.Errorf("agentbox create requires --model")
+		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --model")
 	}
 	if strings.TrimSpace(opts.Runtime) == "" {
-		return "", fmt.Errorf("agentbox create requires --runtime")
+		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --runtime")
 	}
 
 	payload := map[string]string{
@@ -172,12 +193,18 @@ func (r *AgentboxRunner) CreateSession(ctx context.Context, opts RemoteCreateOpt
 
 	var workspace agentboxWorkspace
 	if err := r.doJSON(ctx, http.MethodPost, "/v1/workspaces", payload, &workspace); err != nil {
-		return "", err
+		return RemoteCreateResult{}, err
 	}
 	if workspace.ID == "" {
-		return "", fmt.Errorf("agentbox create returned an empty workspace ID")
+		return RemoteCreateResult{}, fmt.Errorf("agentbox create returned an empty workspace ID")
 	}
-	return workspace.ID, nil
+	sessionInfo := r.workspaceToRemoteSession(workspace)
+	return RemoteCreateResult{
+		SessionID:          workspace.ID,
+		Attachable:         sessionInfo.Attachable,
+		AttachCommand:      sessionInfo.AttachCommand,
+		LocalAttachCommand: sessionInfo.LocalAttachCommand,
+	}, nil
 }
 
 func (r *AgentboxRunner) DeleteSession(ctx context.Context, sessionID string) error {
@@ -346,7 +373,10 @@ func translateAgentboxHTTPError(method string, requestPath string, statusCode in
 	var payload agentboxErrorResponse
 	_ = json.Unmarshal(body, &payload)
 
-	message := strings.TrimSpace(payload.Error)
+	message := strings.TrimSpace(payload.Message)
+	if message == "" {
+		message = strings.TrimSpace(payload.Error)
+	}
 	switch payload.Error {
 	case "workspace_not_running":
 		if payload.Status != "" {
@@ -368,8 +398,20 @@ func translateAgentboxHTTPError(method string, requestPath string, statusCode in
 		message = "workspace is destroyed"
 	case "workspaces_unavailable":
 		message = "agentbox workspaces are unavailable"
+	case "workspace_root_unconfigured":
+		message = "agentbox workspace root is unconfigured"
+	case "workspace_root_conflict":
+		message = "agentbox workspace root conflicts with an existing checkout"
+	case "workspace_disk_exhausted":
+		message = "agentbox workspace disk budget is exhausted"
+	case "workspace_unavailable":
+		message = "agentbox workspace is unavailable"
 	case "invalid_request":
 		message = "agentbox rejected the request"
+	case "invalid_state":
+		if message == "" || message == payload.Error {
+			message = "agentbox rejected the workspace state transition"
+		}
 	case "not_found":
 		message = "workspace not found"
 	}
@@ -379,7 +421,14 @@ func translateAgentboxHTTPError(method string, requestPath string, statusCode in
 	if message == "" {
 		message = http.StatusText(statusCode)
 	}
-	return fmt.Errorf("agentbox %s %s: %s", method, requestPath, message)
+	return &AgentboxHTTPError{
+		Method:         method,
+		RequestPath:    requestPath,
+		StatusCode:     statusCode,
+		RemoteError:    strings.TrimSpace(payload.Error),
+		WorkspaceState: strings.TrimSpace(payload.Status),
+		Message:        message,
+	}
 }
 
 func (r *AgentboxRunner) shouldUseLocalAttachCommand() bool {
@@ -401,6 +450,21 @@ func (r *AgentboxRunner) shouldUseLocalAttachCommand() bool {
 		return false
 	}
 	return strings.EqualFold(host, localHost) || strings.HasPrefix(strings.ToLower(host), strings.ToLower(localHost)+".")
+}
+
+func (r *AgentboxRunner) ResolveListedAttach(sessionInfo RemoteSessionInfo) (ResolvedAttachCommand, error) {
+	command := strings.TrimSpace(sessionInfo.AttachCommand)
+	useLocal := r.shouldUseLocalAttachCommand()
+	if useLocal && strings.TrimSpace(sessionInfo.LocalAttachCommand) != "" {
+		command = strings.TrimSpace(sessionInfo.LocalAttachCommand)
+	}
+	if command == "" {
+		if strings.TrimSpace(sessionInfo.LifecycleStatus) != "" {
+			return ResolvedAttachCommand{}, fmt.Errorf("workspace is %s; start it before attaching", sessionInfo.LifecycleStatus)
+		}
+		return ResolvedAttachCommand{}, fmt.Errorf("agentbox attach for workspace %s returned no attach command", sessionInfo.ID)
+	}
+	return ResolvedAttachCommand{Command: command, Local: useLocal}, nil
 }
 
 func runLocalAttachCommand(command string) error {

--- a/internal/session/agentbox.go
+++ b/internal/session/agentbox.go
@@ -22,6 +22,17 @@ const (
 	RemoteKindAgentbox = "agentbox"
 )
 
+// IsCanonicalAgentboxAgent reports whether agent names one of the runtimes
+// exposed by the Agentbox workspace image.
+func IsCanonicalAgentboxAgent(agent string) bool {
+	switch strings.TrimSpace(agent) {
+	case "claude-code", "codex", "pi-fireworks":
+		return true
+	default:
+		return false
+	}
+}
+
 type RemoteCreateOptions struct {
 	Tool         string
 	Title        string
@@ -172,6 +183,9 @@ func (r *AgentboxRunner) CreateSession(ctx context.Context, opts RemoteCreateOpt
 	}
 	if strings.TrimSpace(opts.Agent) == "" {
 		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --agent")
+	}
+	if !IsCanonicalAgentboxAgent(opts.Agent) {
+		return RemoteCreateResult{}, fmt.Errorf("agentbox agent must be exactly one of: claude-code, codex, or pi-fireworks")
 	}
 	if strings.TrimSpace(opts.ModelID) == "" {
 		return RemoteCreateResult{}, fmt.Errorf("agentbox create requires --model")

--- a/internal/session/agentbox.go
+++ b/internal/session/agentbox.go
@@ -222,7 +222,7 @@ func (r *AgentboxRunner) CreateSession(ctx context.Context, opts RemoteCreateOpt
 }
 
 func (r *AgentboxRunner) DeleteSession(ctx context.Context, sessionID string) error {
-	return r.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/workspaces/%s/destroy", url.PathEscape(sessionID)), map[string]bool{"force": false}, nil)
+	return r.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/workspaces/%s/destroy", url.PathEscape(sessionID)), map[string]bool{"force": true}, nil)
 }
 
 func (r *AgentboxRunner) StopSession(ctx context.Context, sessionID string) error {

--- a/internal/session/agentbox_test.go
+++ b/internal/session/agentbox_test.go
@@ -156,6 +156,29 @@ func TestAgentboxRunnerCreateSession_PostsExpectedPayload(t *testing.T) {
 	}
 }
 
+func TestAgentboxRunnerDeleteSessionForcesRunningWorkspaceDestroy(t *testing.T) {
+	var payload map[string]bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces/ws-running/destroy" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
+	if err := runner.DeleteSession(context.Background(), "ws-running"); err != nil {
+		t.Fatalf("DeleteSession unexpected error: %v", err)
+	}
+	if !payload["force"] {
+		t.Fatalf("destroy payload = %#v, want force=true", payload)
+	}
+}
+
 func TestAgentboxRunnerResolveAttach_PrefersLocalCommandForLocalhost(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/session/agentbox_test.go
+++ b/internal/session/agentbox_test.go
@@ -212,3 +212,30 @@ func TestAgentboxRunnerResolveAttach_TranslatesInvalidAttachState(t *testing.T) 
 		t.Fatalf("ResolveAttach error = %v, want invalid-attach guidance", err)
 	}
 }
+
+func TestAgentboxRunnerAttachCreatedResult_UsesReturnedCommandsWithoutLookup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("AttachCreatedResult must not call follow-up attach lookup: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
+	var gotCommand string
+	runner.execCommand = func(command string) error {
+		gotCommand = command
+		return nil
+	}
+
+	err := runner.AttachCreatedResult(RemoteCreateResult{
+		SessionID:          "ws-new",
+		Attachable:         true,
+		AttachCommand:      "ssh remote-host tmux attach -t ws-new",
+		LocalAttachCommand: "tmux attach -t ws-new",
+	})
+	if err != nil {
+		t.Fatalf("AttachCreatedResult unexpected error: %v", err)
+	}
+	if gotCommand != "tmux attach -t ws-new" {
+		t.Fatalf("exec command = %q, want local attach command from create response", gotCommand)
+	}
+}

--- a/internal/session/agentbox_test.go
+++ b/internal/session/agentbox_test.go
@@ -1,0 +1,200 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAgentboxRunnerFetchSessions_MapsWorkspaceFieldsAndAuth(t *testing.T) {
+	var authHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		if r.URL.Path != "/v1/workspaces" {
+			t.Fatalf("path = %q, want /v1/workspaces", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{
+			"id":                 "ws-123456789",
+			"name":               "research-one",
+			"orchestrator":       "wisp",
+			"agent":              "pi-fireworks",
+			"model":              "accounts/fireworks/models/glm-5p2",
+			"runtime":            "docker",
+			"cwd":                "/srv/research",
+			"status":             "running",
+			"attachCommand":      "ssh host tmux attach -t ws-123",
+			"localAttachCommand": "ssh localhost tmux attach -t ws-123",
+			"claimedTaskCount":   3,
+			"createdAt":          "2026-07-22T00:00:00.000Z",
+		}})
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{
+		Kind:  RemoteKindAgentbox,
+		URL:   srv.URL,
+		Token: "top-secret",
+	})
+
+	sessions, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("FetchSessions unexpected error: %v", err)
+	}
+	if authHeader != "Bearer top-secret" {
+		t.Fatalf("Authorization = %q, want bearer token", authHeader)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions) = %d, want 1", len(sessions))
+	}
+	got := sessions[0]
+	if got.Title != "research-one" || got.Orchestrator != "wisp" || got.Agent != "pi-fireworks" {
+		t.Fatalf("mapped identity fields wrong: %+v", got)
+	}
+	if got.Model != "accounts/fireworks/models/glm-5p2" || got.Runtime != "docker" || got.Path != "/srv/research" {
+		t.Fatalf("mapped model/runtime/path wrong: %+v", got)
+	}
+	if got.Tool != "pi" {
+		t.Fatalf("Tool = %q, want pi", got.Tool)
+	}
+	if got.Status != "running" || got.LifecycleStatus != "running" {
+		t.Fatalf("status mapping wrong: %+v", got)
+	}
+	if !got.Attachable {
+		t.Fatalf("Attachable = false, want true: %+v", got)
+	}
+	if got.ClaimedTaskCount != 3 || got.RemoteName != "lab" {
+		t.Fatalf("task-count/remote mapping wrong: %+v", got)
+	}
+}
+
+func TestAgentboxRunnerCreateSession_RequiresExplicitFields(t *testing.T) {
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: "http://127.0.0.1:1"})
+
+	cases := []struct {
+		name string
+		opts RemoteCreateOptions
+		want string
+	}{
+		{name: "missing name", opts: RemoteCreateOptions{Orchestrator: "wisp", Agent: "pi-fireworks", ModelID: "m", Runtime: "docker"}, want: "--name"},
+		{name: "missing orchestrator", opts: RemoteCreateOptions{Title: "x", Agent: "pi-fireworks", ModelID: "m", Runtime: "docker"}, want: "--orchestrator"},
+		{name: "missing agent", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", ModelID: "m", Runtime: "docker"}, want: "--agent"},
+		{name: "missing model", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", Agent: "pi-fireworks", Runtime: "docker"}, want: "--model"},
+		{name: "missing runtime", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", Agent: "pi-fireworks", ModelID: "m"}, want: "--runtime"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runner.CreateSession(context.Background(), tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CreateSession error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentboxRunnerCreateSession_PostsExpectedPayload(t *testing.T) {
+	var payload map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ws-new"})
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
+	id, err := runner.CreateSession(context.Background(), RemoteCreateOptions{
+		Title:        "research-one",
+		Path:         "/srv/research",
+		ModelID:      "accounts/fireworks/models/glm-5p2",
+		Orchestrator: "wisp",
+		Agent:        "pi-fireworks",
+		Runtime:      "docker",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession unexpected error: %v", err)
+	}
+	if id != "ws-new" {
+		t.Fatalf("CreateSession id = %q, want ws-new", id)
+	}
+	want := map[string]string{
+		"name":         "research-one",
+		"cwd":          "/srv/research",
+		"model":        "accounts/fireworks/models/glm-5p2",
+		"orchestrator": "wisp",
+		"agent":        "pi-fireworks",
+		"runtime":      "docker",
+	}
+	if len(payload) != len(want) {
+		t.Fatalf("payload = %#v, want %#v", payload, want)
+	}
+	for key, wantValue := range want {
+		if payload[key] != wantValue {
+			t.Fatalf("payload[%q] = %q, want %q (payload=%#v)", key, payload[key], wantValue, payload)
+		}
+	}
+}
+
+func TestAgentboxRunnerResolveAttach_PrefersLocalCommandForLocalhost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                 "ws-1",
+			"status":             "running",
+			"attachCommand":      "ssh remote-host tmux attach -t ws-1",
+			"localAttachCommand": "ssh localhost tmux attach -t ws-1",
+		})
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
+	intent, err := runner.ResolveAttach(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("ResolveAttach unexpected error: %v", err)
+	}
+	if !intent.Local {
+		t.Fatalf("Local = false, want true")
+	}
+	if intent.Command != "ssh localhost tmux attach -t ws-1" {
+		t.Fatalf("Command = %q, want local attach command", intent.Command)
+	}
+}
+
+func TestAgentboxRunnerResolveAttach_TranslatesStoppedWorkspace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":  "workspace_not_running",
+			"status": "stopped",
+		})
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
+	_, err := runner.ResolveAttach(context.Background(), "ws-1")
+	if err == nil || !strings.Contains(err.Error(), "start it before attaching") {
+		t.Fatalf("ResolveAttach error = %v, want stopped-before-attach guidance", err)
+	}
+}
+
+func TestAgentboxRunnerResolveAttach_TranslatesInvalidAttachState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":  "workspace_not_attachable",
+			"status": "cleanup_required",
+		})
+	}))
+	defer srv.Close()
+
+	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
+	_, err := runner.ResolveAttach(context.Background(), "ws-1")
+	if err == nil || !strings.Contains(err.Error(), "cannot be attached") {
+		t.Fatalf("ResolveAttach error = %v, want invalid-attach guidance", err)
+	}
+}

--- a/internal/session/agentbox_test.go
+++ b/internal/session/agentbox_test.go
@@ -104,12 +104,17 @@ func TestAgentboxRunnerCreateSession_PostsExpectedPayload(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ws-new"})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                 "ws-new",
+			"status":             "running",
+			"attachCommand":      "ssh remote-host tmux attach -t ws-new",
+			"localAttachCommand": "ssh localhost tmux attach -t ws-new",
+		})
 	}))
 	defer srv.Close()
 
 	runner := NewAgentboxRunner("lab", RemoteConfig{Kind: RemoteKindAgentbox, URL: srv.URL})
-	id, err := runner.CreateSession(context.Background(), RemoteCreateOptions{
+	result, err := runner.CreateSession(context.Background(), RemoteCreateOptions{
 		Title:        "research-one",
 		Path:         "/srv/research",
 		ModelID:      "accounts/fireworks/models/glm-5p2",
@@ -120,8 +125,17 @@ func TestAgentboxRunnerCreateSession_PostsExpectedPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession unexpected error: %v", err)
 	}
-	if id != "ws-new" {
-		t.Fatalf("CreateSession id = %q, want ws-new", id)
+	if result.SessionID != "ws-new" {
+		t.Fatalf("CreateSession session id = %q, want ws-new", result.SessionID)
+	}
+	if !result.Attachable {
+		t.Fatalf("CreateSession result should preserve attachability: %+v", result)
+	}
+	if result.AttachCommand != "ssh remote-host tmux attach -t ws-new" {
+		t.Fatalf("AttachCommand = %q, want create response attach command", result.AttachCommand)
+	}
+	if result.LocalAttachCommand != "ssh localhost tmux attach -t ws-new" {
+		t.Fatalf("LocalAttachCommand = %q, want create response local attach command", result.LocalAttachCommand)
 	}
 	want := map[string]string{
 		"name":         "research-one",

--- a/internal/session/agentbox_test.go
+++ b/internal/session/agentbox_test.go
@@ -81,6 +81,7 @@ func TestAgentboxRunnerCreateSession_RequiresExplicitFields(t *testing.T) {
 		{name: "missing name", opts: RemoteCreateOptions{Orchestrator: "wisp", Agent: "pi-fireworks", ModelID: "m", Runtime: "docker"}, want: "--name"},
 		{name: "missing orchestrator", opts: RemoteCreateOptions{Title: "x", Agent: "pi-fireworks", ModelID: "m", Runtime: "docker"}, want: "--orchestrator"},
 		{name: "missing agent", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", ModelID: "m", Runtime: "docker"}, want: "--agent"},
+		{name: "unsupported agent", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", Agent: "pi", ModelID: "m", Runtime: "docker"}, want: "claude-code, codex, or pi-fireworks"},
 		{name: "missing model", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", Agent: "pi-fireworks", Runtime: "docker"}, want: "--model"},
 		{name: "missing runtime", opts: RemoteCreateOptions{Title: "x", Orchestrator: "wisp", Agent: "pi-fireworks", ModelID: "m"}, want: "--runtime"},
 	}

--- a/internal/session/remote_config_test.go
+++ b/internal/session/remote_config_test.go
@@ -1,0 +1,31 @@
+package session
+
+import "testing"
+
+func TestRemoteConfigGetKindNormalizesKnownKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want string
+	}{
+		{name: "agentbox mixed case", kind: "AgentBox", want: RemoteKindAgentbox},
+		{name: "ssh mixed case", kind: "SSH", want: RemoteKindSSH},
+		{name: "url defaults to agentbox", want: RemoteKindAgentbox},
+		{name: "host defaults to ssh", want: RemoteKindSSH},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := RemoteConfig{Kind: tt.kind}
+			if tt.name == "url defaults to agentbox" {
+				rc.URL = "https://agentbox.example"
+			}
+			if tt.name == "host defaults to ssh" {
+				rc.Host = "root@agentbox"
+			}
+			if got := rc.GetKind(); got != tt.want {
+				t.Fatalf("GetKind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -808,8 +808,8 @@ func (r *SSHRunner) buildAttachArgs(sessionID string) []string {
 	return append(args, r.Host, remoteCmd)
 }
 
-// CreateSession creates and starts a quick new session on the remote, returning its ID.
-func (r *SSHRunner) CreateSession(ctx context.Context) (string, error) {
+// CreateQuickSession creates and starts a quick new session on the remote, returning its ID.
+func (r *SSHRunner) CreateQuickSession(ctx context.Context) (string, error) {
 	return r.CreateSessionWithOptions(ctx, "", "", "", "")
 }
 
@@ -817,7 +817,7 @@ func (r *SSHRunner) CreateSession(ctx context.Context) (string, error) {
 // session on a remote with explicit dialog values (#1353). Empty values fall
 // back to remote defaults: no -c means shell, no -t means --quick
 // (auto-generated name), and an empty or "." path means remote CWD.
-func remoteAddArgs(tool, title, path, group string) []string {
+func remoteAddArgs(tool, title, path, group, modelID string) []string {
 	args := []string{"add", "--json"}
 	if t := strings.TrimSpace(title); t != "" {
 		args = append(args, "-t", t)
@@ -830,6 +830,9 @@ func remoteAddArgs(tool, title, path, group string) []string {
 	if c := strings.TrimSpace(tool); c != "" {
 		args = append(args, "-c", c)
 	}
+	if model := strings.TrimSpace(modelID); model != "" {
+		args = append(args, "--model", model)
+	}
 	if p := strings.TrimSpace(path); p != "" && p != "." {
 		args = append(args, p)
 	}
@@ -840,8 +843,18 @@ func remoteAddArgs(tool, title, path, group string) []string {
 // an explicit tool/title/path/group from the new-session dialog (#1353),
 // returning its ID. Empty values fall back to remote defaults (see remoteAddArgs).
 func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path, group string) (string, error) {
+	return r.CreateSession(ctx, RemoteCreateOptions{
+		Tool:  tool,
+		Title: title,
+		Path:  path,
+		Group: group,
+	})
+}
+
+// CreateSession creates and starts a new remote agent-deck session.
+func (r *SSHRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions) (string, error) {
 	// Step 1: Create the session
-	output, err := r.Run(ctx, remoteAddArgs(tool, title, path, group)...)
+	output, err := r.Run(ctx, remoteAddArgs(opts.Tool, opts.Title, opts.Path, opts.Group, opts.ModelID)...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create remote session: %w", err)
 	}
@@ -899,15 +912,30 @@ func (r *SSHRunner) RestartSession(ctx context.Context, sessionID string) error 
 	return err
 }
 
+// RenameSession renames a remote SSH-backed agent-deck session.
+func (r *SSHRunner) RenameSession(ctx context.Context, sessionID string, newTitle string) error {
+	_, err := r.RunCommand(ctx, "rename", sessionID, newTitle)
+	return err
+}
+
 // RemoteSessionInfo represents a session from a remote agent-deck instance.
 type RemoteSessionInfo struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Path      string `json:"path"`
-	Group     string `json:"group"`
-	Tool      string `json:"tool"`
-	Status    string `json:"status"`
-	CreatedAt string `json:"created_at"`
+	ID                 string `json:"id"`
+	Title              string `json:"title"`
+	Path               string `json:"path"`
+	Group              string `json:"group"`
+	Tool               string `json:"tool"`
+	Agent              string `json:"agent,omitempty"`
+	Model              string `json:"model,omitempty"`
+	Runtime            string `json:"runtime,omitempty"`
+	Orchestrator       string `json:"orchestrator,omitempty"`
+	Status             string `json:"status"`
+	LifecycleStatus    string `json:"lifecycle_status,omitempty"`
+	ClaimedTaskCount   int    `json:"claimed_task_count,omitempty"`
+	Attachable         bool   `json:"attachable,omitempty"`
+	AttachCommand      string `json:"attach_command,omitempty"`
+	LocalAttachCommand string `json:"local_attach_command,omitempty"`
+	CreatedAt          string `json:"created_at"`
 
 	// Set locally, not from JSON
 	RemoteName string `json:"-"`

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -843,20 +843,24 @@ func remoteAddArgs(tool, title, path, group, modelID string) []string {
 // an explicit tool/title/path/group from the new-session dialog (#1353),
 // returning its ID. Empty values fall back to remote defaults (see remoteAddArgs).
 func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path, group string) (string, error) {
-	return r.CreateSession(ctx, RemoteCreateOptions{
+	result, err := r.CreateSession(ctx, RemoteCreateOptions{
 		Tool:  tool,
 		Title: title,
 		Path:  path,
 		Group: group,
 	})
+	if err != nil {
+		return "", err
+	}
+	return result.SessionID, nil
 }
 
 // CreateSession creates and starts a new remote agent-deck session.
-func (r *SSHRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions) (string, error) {
+func (r *SSHRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions) (RemoteCreateResult, error) {
 	// Step 1: Create the session
 	output, err := r.Run(ctx, remoteAddArgs(opts.Tool, opts.Title, opts.Path, opts.Group, opts.ModelID)...)
 	if err != nil {
-		return "", fmt.Errorf("failed to create remote session: %w", err)
+		return RemoteCreateResult{}, fmt.Errorf("failed to create remote session: %w", err)
 	}
 
 	var result struct {
@@ -864,10 +868,10 @@ func (r *SSHRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions)
 		Title string `json:"title"`
 	}
 	if err := json.Unmarshal(output, &result); err != nil {
-		return "", fmt.Errorf("failed to parse remote add output: %w", err)
+		return RemoteCreateResult{}, fmt.Errorf("failed to parse remote add output: %w", err)
 	}
 	if result.ID == "" {
-		return "", fmt.Errorf("remote add returned empty session ID")
+		return RemoteCreateResult{}, fmt.Errorf("remote add returned empty session ID")
 	}
 
 	// Step 2: Start the session so it has a tmux process to attach to.
@@ -882,16 +886,16 @@ func (r *SSHRunner) CreateSession(ctx context.Context, opts RemoteCreateOptions)
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cleanupCancel()
 		_ = r.DeleteSession(cleanupCtx, result.ID)
-		return "", fmt.Errorf("failed to start remote session: %w", err)
+		return RemoteCreateResult{}, fmt.Errorf("failed to start remote session: %w", err)
 	}
 	var startResult struct {
 		Status string `json:"status"`
 	}
 	if err := json.Unmarshal(bytes.TrimSpace(startOutput), &startResult); err == nil && startResult.Status == string(StatusQueued) {
-		return "", fmt.Errorf("remote session %q was queued and is not ready to attach", result.Title)
+		return RemoteCreateResult{}, fmt.Errorf("remote session %q was queued and is not ready to attach", result.Title)
 	}
 
-	return result.ID, nil
+	return RemoteCreateResult{SessionID: result.ID}, nil
 }
 
 // DeleteSession removes a session on the remote host.

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -115,7 +115,7 @@ func TestSSHRunnerCreateSession_CleansOrphanOnStartFailure(t *testing.T) {
 		},
 	}
 
-	_, err := runner.CreateSession(context.Background())
+	_, err := runner.CreateQuickSession(context.Background())
 	if err == nil {
 		t.Fatal("expected CreateSession to surface the start failure, got nil")
 	}
@@ -149,7 +149,7 @@ func TestSSHRunnerCreateSession_NoCleanupOnSuccess(t *testing.T) {
 		},
 	}
 
-	id, err := runner.CreateSession(context.Background())
+	id, err := runner.CreateQuickSession(context.Background())
 	if err != nil {
 		t.Fatalf("CreateSession unexpected error: %v", err)
 	}
@@ -171,9 +171,9 @@ func TestSSHRunnerCreateSession_NoCleanupOnSuccess(t *testing.T) {
 // argument is sent.
 func TestRemoteAddArgs(t *testing.T) {
 	cases := []struct {
-		name                     string
-		tool, title, path, group string
-		want                     []string
+		name                            string
+		tool, title, path, group, model string
+		want                            []string
 	}{
 		{
 			name: "defaults (quick shell, remote CWD)",
@@ -200,6 +200,13 @@ func TestRemoteAddArgs(t *testing.T) {
 			want: []string{"add", "--json", "--quick", "-c", "pi"},
 		},
 		{
+			name:  "model flag is forwarded",
+			tool:  "codex",
+			title: "my task",
+			model: "gpt-5.5",
+			want:  []string{"add", "--json", "-t", "my task", "-c", "codex", "--model", "gpt-5.5"},
+		},
+		{
 			name: "whitespace-only values fall back to defaults",
 			tool: "  ", title: " ", group: " ", path: " . ",
 			want: []string{"add", "--json", "--quick"},
@@ -207,13 +214,13 @@ func TestRemoteAddArgs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := remoteAddArgs(tc.tool, tc.title, tc.path, tc.group)
+			got := remoteAddArgs(tc.tool, tc.title, tc.path, tc.group, tc.model)
 			if len(got) != len(tc.want) {
-				t.Fatalf("remoteAddArgs(%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, got, tc.want)
+				t.Fatalf("remoteAddArgs(%q,%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, tc.model, got, tc.want)
 			}
 			for i := range got {
 				if got[i] != tc.want[i] {
-					t.Fatalf("remoteAddArgs(%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, got, tc.want)
+					t.Fatalf("remoteAddArgs(%q,%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, tc.model, got, tc.want)
 				}
 			}
 		})

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -695,14 +695,34 @@ type OpenClawSettings struct {
 
 // RemoteConfig defines a remote agent-deck instance accessible via SSH.
 type RemoteConfig struct {
+	// Kind selects the remote provider ("ssh" or "agentbox"). Empty defaults to SSH.
+	Kind string `toml:"kind,omitempty"`
+
 	// Host is the SSH destination (e.g., "user@host" or "user@host:port")
 	Host string `toml:"host,omitempty"`
+
+	// URL is the Agentbox API base URL (for example https://host/agentbox).
+	URL string `toml:"url,omitempty"`
+
+	// Token is an optional bearer token sent to the Agentbox API.
+	Token string `toml:"token,omitempty"`
 
 	// AgentDeckPath is the path to agent-deck binary on the remote (default: "agent-deck")
 	AgentDeckPath string `toml:"agent_deck_path,omitempty"`
 
 	// Profile is the remote profile to use (default: "default")
 	Profile string `toml:"profile,omitempty"`
+}
+
+// GetKind returns the remote kind, defaulting to "ssh".
+func (rc RemoteConfig) GetKind() string {
+	if strings.TrimSpace(rc.Kind) != "" {
+		return strings.TrimSpace(rc.Kind)
+	}
+	if strings.TrimSpace(rc.URL) != "" && strings.TrimSpace(rc.Host) == "" {
+		return RemoteKindAgentbox
+	}
+	return RemoteKindSSH
 }
 
 // GetAgentDeckPath returns the agent-deck binary path, defaulting to "agent-deck".
@@ -719,6 +739,11 @@ func (rc RemoteConfig) GetProfile() string {
 		return rc.Profile
 	}
 	return "default"
+}
+
+// GetURL returns the Agentbox API URL.
+func (rc RemoteConfig) GetURL() string {
+	return strings.TrimSpace(rc.URL)
 }
 
 // ProfileSettings defines per-profile configuration overrides.

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -716,8 +716,15 @@ type RemoteConfig struct {
 
 // GetKind returns the remote kind, defaulting to "ssh".
 func (rc RemoteConfig) GetKind() string {
-	if strings.TrimSpace(rc.Kind) != "" {
-		return strings.TrimSpace(rc.Kind)
+	if kind := strings.ToLower(strings.TrimSpace(rc.Kind)); kind != "" {
+		switch kind {
+		case RemoteKindAgentbox:
+			return RemoteKindAgentbox
+		case RemoteKindSSH:
+			return RemoteKindSSH
+		default:
+			return kind
+		}
 	}
 	if strings.TrimSpace(rc.URL) != "" && strings.TrimSpace(rc.Host) == "" {
 		return RemoteKindAgentbox

--- a/internal/terminal/launcher.go
+++ b/internal/terminal/launcher.go
@@ -31,6 +31,11 @@ var ErrUnsupported = errors.New("terminal: opening a new window is not yet suppo
 // SocketName may be empty (meaning the default tmux server), matching the
 // semantics of tmux.Session.SocketName.
 type AttachRequest struct {
+	// Command, when non-empty, is executed verbatim in the spawned terminal.
+	// This is used for agentbox workspaces, which already return an exact
+	// attach command via the Agentbox API.
+	Command string
+
 	// Name is the tmux session name (the `-t` argument of `tmux attach`)
 	// for local sessions, or the remote agent-deck session ID when
 	// Remote != nil.
@@ -96,6 +101,9 @@ const SSHControlDir = "/tmp/agent-deck-ssh"
 // share the exact same string-building logic without depending on
 // os/exec.
 func BuildAttachCommand(req AttachRequest) string {
+	if command := strings.TrimSpace(req.Command); command != "" {
+		return command
+	}
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
 		return ""

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1018,6 +1018,33 @@ func buildRemoteAttachRequest(remoteName, sessionID, openAs string) (terminal.At
 	}, true
 }
 
+func buildRemoteAttachRequestForItem(item session.Item, openAs string) (terminal.AttachRequest, error) {
+	if item.RemoteSession == nil || item.RemoteName == "" {
+		return terminal.AttachRequest{}, fmt.Errorf("remote session is unavailable")
+	}
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil || cfg.Remotes == nil {
+		return terminal.AttachRequest{}, fmt.Errorf("failed to load remote config")
+	}
+	rc, ok := cfg.Remotes[item.RemoteName]
+	if !ok {
+		return terminal.AttachRequest{}, fmt.Errorf("remote %q is unavailable", item.RemoteName)
+	}
+	if rc.GetKind() == session.RemoteKindAgentbox {
+		runner := session.NewAgentboxRunner(item.RemoteName, rc)
+		intent, err := runner.ResolveListedAttach(*item.RemoteSession)
+		if err != nil {
+			return terminal.AttachRequest{}, err
+		}
+		return terminal.AttachRequest{Command: intent.Command, OpenAs: openAs}, nil
+	}
+	req, ok := buildRemoteAttachRequest(item.RemoteName, item.RemoteSession.ID, openAs)
+	if !ok {
+		return terminal.AttachRequest{}, fmt.Errorf("remote %q is unavailable", item.RemoteName)
+	}
+	return req, nil
+}
+
 func (h *Home) normalizeMainKey(pressed string) string {
 	// Shift+Enter relay: csiuReader emits the Private-Use rune
 	// shiftEnterMarker (U+E5E5) when it sees a Shift+Enter CSI u or
@@ -7257,14 +7284,15 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// filesystem (#743).
 		if h.pendingRemoteName != "" {
 			remoteName := h.pendingRemoteName
-			name, path, command := h.newDialog.GetRemoteValues()
-			groupPath := h.newDialog.GetSelectedGroup()
+			createOpts := h.newDialog.GetRemoteCreateOptions()
 			// Remember the submitted tool for the next dialog open (UX top-3 #2).
-			rememberTool(h.stateDB(), command)
+			if strings.TrimSpace(createOpts.Tool) != "" {
+				rememberTool(h.stateDB(), createOpts.Tool)
+			}
 			h.newDialog.Hide()
 			h.pendingRemoteName = ""
 			h.clearError()
-			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path, groupPath)
+			return h, h.createRemoteSessionWithOptions(remoteName, createOpts)
 		}
 
 		// Get values including worktree settings.
@@ -7423,6 +7451,12 @@ func (h *Home) showRemoteNewSessionDialog(item session.Item) {
 	// Preselect the last-used tool (UX top-3 #2); explicit [default_tool] wins.
 	h.newDialog.SetDefaultTool(resolveInitialTool(session.GetDefaultTool(), rememberedTool(h.stateDB())))
 	h.pendingRemoteName = remoteName
+	h.newDialog.SetRemoteMode(session.RemoteKindSSH)
+	if config, err := session.LoadUserConfig(); err == nil && config != nil && config.Remotes != nil {
+		if rc, ok := config.Remotes[remoteName]; ok {
+			h.newDialog.SetRemoteMode(rc.GetKind())
+		}
+	}
 
 	groupPath := session.DefaultGroupPath
 	groupName := session.DefaultGroupName
@@ -8132,10 +8166,12 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 			case item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil:
-				if req, ok := buildRemoteAttachRequest(item.RemoteName, item.RemoteSession.ID, openAs); ok {
+				if req, err := buildRemoteAttachRequestForItem(item, openAs); err == nil {
 					if err := h.openInNewWindow(req, true); err != nil {
 						h.setError(fmt.Errorf("open remote in new window: %w", err))
 					}
+				} else {
+					h.setError(err)
 				}
 			}
 		}
@@ -8792,6 +8828,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		defaultPath := h.getDefaultPathForGroup(groupPath)
 		conductors := h.activeConductorSessions()
 		suggestedParentID := h.suggestConductorParent()
+		h.newDialog.SetRemoteMode("")
 		h.newDialog.ShowInGroup(groupPath, groupName, defaultPath, conductors, suggestedParentID)
 		return h, nil
 
@@ -13011,17 +13048,14 @@ func (a attachCmd) SetStderr(w io.Writer) {}
 // createRemoteSession creates a new session on a remote and auto-attaches to it.
 // Used by quick-create (N): auto-generated name, remote defaults (shell).
 func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
-	return h.createRemoteSessionWithOptions(remoteName, "", "", "", "")
+	return h.createRemoteSessionWithOptions(remoteName, session.RemoteCreateOptions{})
 }
 
 // remoteCreateAndAttachCmd creates a session on the remote, then attaches to it.
 type remoteCreateAndAttachCmd struct {
-	runner    session.RemoteRunner
-	tool      string
-	title     string
-	path      string
-	group     string
-	createCtx context.Context
+	runner     session.RemoteRunner
+	createOpts session.RemoteCreateOptions
+	createCtx  context.Context
 }
 
 type remoteAttachFailedError struct {
@@ -13043,16 +13077,11 @@ func (r remoteCreateAndAttachCmd) Run() error {
 	}
 	ctx, cancel := context.WithTimeout(baseCtx, 20*time.Second)
 	defer cancel()
-	sessionID, err := r.runner.CreateSession(ctx, session.RemoteCreateOptions{
-		Tool:  r.tool,
-		Title: r.title,
-		Path:  r.path,
-		Group: r.group,
-	})
+	result, err := r.runner.CreateSession(ctx, r.createOpts)
 	if err != nil {
 		return err
 	}
-	if err := r.runner.Attach(sessionID); err != nil {
+	if err := r.runner.Attach(result.SessionID); err != nil {
 		return remoteAttachFailedError{err: err}
 	}
 	return nil
@@ -13066,7 +13095,7 @@ func (r remoteCreateAndAttachCmd) SetStderr(writer io.Writer) {}
 // explicit tool/title/path/group from the new-session dialog (#1353), then
 // auto-attaches to it. Empty values fall back to remote defaults (shell,
 // auto-generated name, remote CWD).
-func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, group string) tea.Cmd {
+func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.RemoteCreateOptions) tea.Cmd {
 	config, err := session.LoadUserConfig()
 	if err != nil || config == nil || config.Remotes == nil {
 		return func() tea.Msg {
@@ -13081,7 +13110,11 @@ func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, gro
 	}
 	runner := session.NewRemoteRunner(remoteName, rc)
 	h.isAttaching.Store(true)
-	return tea.Exec(remoteCreateAndAttachCmd{runner: runner, tool: tool, title: title, path: path, group: group, createCtx: h.ctx}, func(err error) tea.Msg {
+	return tea.Exec(remoteCreateAndAttachCmd{
+		runner:     runner,
+		createOpts: opts,
+		createCtx:  h.ctx,
+	}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
 		if err != nil {
 			var attachErr remoteAttachFailedError

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7451,10 +7451,12 @@ func (h *Home) showRemoteNewSessionDialog(item session.Item) {
 	// Preselect the last-used tool (UX top-3 #2); explicit [default_tool] wins.
 	h.newDialog.SetDefaultTool(resolveInitialTool(session.GetDefaultTool(), rememberedTool(h.stateDB())))
 	h.pendingRemoteName = remoteName
+	isAgentboxRemote := false
 	h.newDialog.SetRemoteMode(session.RemoteKindSSH)
 	if config, err := session.LoadUserConfig(); err == nil && config != nil && config.Remotes != nil {
 		if rc, ok := config.Remotes[remoteName]; ok {
 			h.newDialog.SetRemoteMode(rc.GetKind())
+			isAgentboxRemote = rc.GetKind() == session.RemoteKindAgentbox
 		}
 	}
 
@@ -7466,20 +7468,24 @@ func (h *Home) showRemoteNewSessionDialog(item session.Item) {
 			groupPath = item.RemoteSession.Group
 			groupName = item.RemoteSession.Group
 		}
-		defaultPath = item.RemoteSession.Path
+		if !isAgentboxRemote {
+			defaultPath = item.RemoteSession.Path
+		}
 	} else if item.Type == session.ItemTypeRemoteGroup {
 		// "remotes/<host>" is a synthetic local UI bucket, not a user-defined
 		// remote group. Keep the default group so handleNewDialogKey doesn't
 		// forward it to CreateSessionWithOptions and create a bogus remote group.
 		groupPath = session.DefaultGroupPath
 		groupName = session.DefaultGroupName
-		defaultPath = "."
-	} else if len(paths) > 0 {
+		if !isAgentboxRemote {
+			defaultPath = "."
+		}
+	} else if len(paths) > 0 && !isAgentboxRemote {
 		defaultPath = paths[0]
 	}
 
 	h.newDialog.ShowInGroup(groupPath, groupName, defaultPath, nil, "")
-	if defaultPath == "" {
+	if defaultPath == "" && !isAgentboxRemote {
 		h.newDialog.pathInput.SetValue(".")
 		h.newDialog.pathSoftSelected = true
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1032,7 +1032,7 @@ func buildRemoteAttachRequestForItem(item session.Item, openAs string) (terminal
 	}
 	if rc.GetKind() == session.RemoteKindAgentbox {
 		runner := session.NewAgentboxRunner(item.RemoteName, rc)
-		intent, err := runner.ResolveListedAttach(*item.RemoteSession)
+		intent, err := runner.ResolveAttach(context.Background(), item.RemoteSession.ID)
 		if err != nil {
 			return terminal.AttachRequest{}, err
 		}
@@ -13058,6 +13058,10 @@ type remoteCreateAndAttachCmd struct {
 	createCtx  context.Context
 }
 
+type createResultAttacher interface {
+	AttachCreatedResult(session.RemoteCreateResult) error
+}
+
 type remoteAttachFailedError struct {
 	err error
 }
@@ -13080,6 +13084,13 @@ func (r remoteCreateAndAttachCmd) Run() error {
 	result, err := r.runner.CreateSession(ctx, r.createOpts)
 	if err != nil {
 		return err
+	}
+	if attacher, ok := r.runner.(createResultAttacher); ok &&
+		(strings.TrimSpace(result.AttachCommand) != "" || strings.TrimSpace(result.LocalAttachCommand) != "") {
+		if err := attacher.AttachCreatedResult(result); err != nil {
+			return remoteAttachFailedError{err: err}
+		}
+		return nil
 	}
 	if err := r.runner.Attach(result.SessionID); err != nil {
 		return remoteAttachFailedError{err: err}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3108,7 +3108,7 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
 			defer cancel()
 
-			runner := session.NewSSHRunner(name, rc)
+			runner := session.NewRemoteRunner(name, rc)
 			sessions, err := runner.FetchSessions(ctx)
 			if err != nil {
 				mu.Lock()
@@ -3199,7 +3199,7 @@ func (h *Home) measureRemoteLatencies() tea.Msg {
 		wg.Add(1)
 		go func(name string, rc session.RemoteConfig) {
 			defer wg.Done()
-			runner := session.NewSSHRunner(name, rc)
+			runner := session.NewRemoteRunner(name, rc)
 			d, err := runner.MeasureLatency(ctx)
 			lat := session.RemoteLatency{MeasuredAt: time.Now()}
 			if err != nil {
@@ -3613,7 +3613,7 @@ func (h *Home) fetchRemotePreview(remoteName, sessionID, key string) tea.Cmd {
 			return previewFetchedMsg{previewKey: key, err: fmt.Errorf("remote '%s' not found", remoteName)}
 		}
 
-		runner := session.NewSSHRunner(remoteName, rc)
+		runner := session.NewRemoteRunner(remoteName, rc)
 		ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
 		defer cancel()
 
@@ -10587,10 +10587,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 							if !ok {
 								return
 							}
-							runner := session.NewSSHRunner(remoteName, rc)
+							runner := session.NewRemoteRunner(remoteName, rc)
 							ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 							defer cancel()
-							_, _ = runner.RunCommand(ctx, "rename", remoteID, newName)
+							_ = runner.RenameSession(ctx, remoteID, newName)
 						}()
 						// Update local cache immediately for responsiveness
 						h.remoteSessionsMu.Lock()
@@ -12728,7 +12728,7 @@ func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd 
 				err:        fmt.Errorf("remote '%s' not found", remoteName),
 			}
 		}
-		runner := session.NewSSHRunner(remoteName, rc)
+		runner := session.NewRemoteRunner(remoteName, rc)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		err = runner.DeleteSession(ctx, sessionID)
@@ -12757,7 +12757,7 @@ func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 				err:        fmt.Errorf("remote '%s' not found", remoteName),
 			}
 		}
-		runner := session.NewSSHRunner(remoteName, rc)
+		runner := session.NewRemoteRunner(remoteName, rc)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		err = runner.StopSession(ctx, sessionID)
@@ -12786,7 +12786,7 @@ func (h *Home) restartRemoteSession(remoteName, sessionID, title string) tea.Cmd
 				err:        fmt.Errorf("remote '%s' not found", remoteName),
 			}
 		}
-		runner := session.NewSSHRunner(remoteName, rc)
+		runner := session.NewRemoteRunner(remoteName, rc)
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 		err = runner.RestartSession(ctx, sessionID)
@@ -13016,7 +13016,7 @@ func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
 
 // remoteCreateAndAttachCmd creates a session on the remote, then attaches to it.
 type remoteCreateAndAttachCmd struct {
-	runner    *session.SSHRunner
+	runner    session.RemoteRunner
 	tool      string
 	title     string
 	path      string
@@ -13043,7 +13043,12 @@ func (r remoteCreateAndAttachCmd) Run() error {
 	}
 	ctx, cancel := context.WithTimeout(baseCtx, 20*time.Second)
 	defer cancel()
-	sessionID, err := r.runner.CreateSessionWithOptions(ctx, r.tool, r.title, r.path, r.group)
+	sessionID, err := r.runner.CreateSession(ctx, session.RemoteCreateOptions{
+		Tool:  r.tool,
+		Title: r.title,
+		Path:  r.path,
+		Group: r.group,
+	})
 	if err != nil {
 		return err
 	}
@@ -13074,7 +13079,7 @@ func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, gro
 			return sessionCreatedMsg{err: fmt.Errorf("remote '%s' not found", remoteName)}
 		}
 	}
-	runner := session.NewSSHRunner(remoteName, rc)
+	runner := session.NewRemoteRunner(remoteName, rc)
 	h.isAttaching.Store(true)
 	return tea.Exec(remoteCreateAndAttachCmd{runner: runner, tool: tool, title: title, path: path, group: group, createCtx: h.ctx}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
@@ -13105,7 +13110,7 @@ func (a attachWindowCmd) SetStdin(r io.Reader)  {}
 func (a attachWindowCmd) SetStdout(w io.Writer) {}
 func (a attachWindowCmd) SetStderr(w io.Writer) {}
 
-// attachRemoteSession attaches to a remote session via SSH, suspending the TUI.
+// attachRemoteSession attaches to a remote session, suspending the TUI.
 func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 	config, err := session.LoadUserConfig()
 	if err != nil || config == nil || config.Remotes == nil {
@@ -13115,7 +13120,7 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 	if !ok {
 		return nil
 	}
-	runner := session.NewSSHRunner(remoteName, rc)
+	runner := session.NewRemoteRunner(remoteName, rc)
 	h.isAttaching.Store(true)
 	return tea.Exec(remoteAttachCmd{runner: runner, sessionID: sessionID}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
@@ -13123,9 +13128,9 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 	})
 }
 
-// remoteAttachCmd implements tea.ExecCommand for remote SSH attach
+// remoteAttachCmd implements tea.ExecCommand for remote attach.
 type remoteAttachCmd struct {
-	runner    *session.SSHRunner
+	runner    session.RemoteRunner
 	sessionID string
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1018,7 +1018,7 @@ func buildRemoteAttachRequest(remoteName, sessionID, openAs string) (terminal.At
 	}, true
 }
 
-func buildRemoteAttachRequestForItem(item session.Item, openAs string) (terminal.AttachRequest, error) {
+func buildRemoteAttachRequestForItem(ctx context.Context, item session.Item, openAs string) (terminal.AttachRequest, error) {
 	if item.RemoteSession == nil || item.RemoteName == "" {
 		return terminal.AttachRequest{}, fmt.Errorf("remote session is unavailable")
 	}
@@ -1032,7 +1032,7 @@ func buildRemoteAttachRequestForItem(item session.Item, openAs string) (terminal
 	}
 	if rc.GetKind() == session.RemoteKindAgentbox {
 		runner := session.NewAgentboxRunner(item.RemoteName, rc)
-		intent, err := runner.ResolveAttach(context.Background(), item.RemoteSession.ID)
+		intent, err := runner.ResolveAttach(ctx, item.RemoteSession.ID)
 		if err != nil {
 			return terminal.AttachRequest{}, err
 		}
@@ -5887,6 +5887,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.setError(fmt.Errorf("restarted '%s' on %s", msg.title, msg.remoteName))
 		return h, h.fetchRemoteSessions
 
+	case remoteWindowOpenedMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+		}
+		return h, nil
+
 	case remoteSessionCreatedMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
@@ -8172,13 +8178,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 			case item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil:
-				if req, err := buildRemoteAttachRequestForItem(item, openAs); err == nil {
-					if err := h.openInNewWindow(req, true); err != nil {
-						h.setError(fmt.Errorf("open remote in new window: %w", err))
-					}
-				} else {
-					h.setError(err)
-				}
+				return h, h.openRemoteSessionInNewWindow(item, openAs)
 			}
 		}
 		return h, nil
@@ -12750,6 +12750,10 @@ type remoteSessionCreatedMsg struct {
 	err error
 }
 
+type remoteWindowOpenedMsg struct {
+	err error
+}
+
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	return func() tea.Msg {
@@ -13175,6 +13179,39 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 	return tea.Exec(remoteAttachCmd{runner: runner, sessionID: sessionID}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
 		return statusUpdateMsg{}
+	})
+}
+
+// remoteOpenInNewWindowCmd resolves remote attach metadata outside Bubble
+// Tea's Update path, then launches the native terminal tab/window.
+type remoteOpenInNewWindowCmd struct {
+	home   *Home
+	item   session.Item
+	openAs string
+}
+
+func (r remoteOpenInNewWindowCmd) Run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := buildRemoteAttachRequestForItem(ctx, r.item, r.openAs)
+	if err != nil {
+		return err
+	}
+	return r.home.openInNewWindow(req, true)
+}
+
+func (r remoteOpenInNewWindowCmd) SetStdin(reader io.Reader)  {}
+func (r remoteOpenInNewWindowCmd) SetStdout(writer io.Writer) {}
+func (r remoteOpenInNewWindowCmd) SetStderr(writer io.Writer) {}
+
+func (h *Home) openRemoteSessionInNewWindow(item session.Item, openAs string) tea.Cmd {
+	h.isAttaching.Store(true)
+	return tea.Exec(remoteOpenInNewWindowCmd{home: h, item: item, openAs: openAs}, func(err error) tea.Msg {
+		h.isAttaching.Store(false)
+		if err != nil {
+			return remoteWindowOpenedMsg{err: fmt.Errorf("open remote in new window: %w", err)}
+		}
+		return remoteWindowOpenedMsg{}
 	})
 }
 

--- a/internal/ui/insert_keysender.go
+++ b/internal/ui/insert_keysender.go
@@ -84,6 +84,9 @@ func openRemoteInsertKeySender(remoteName, sessionID string) (insertKeySender, e
 	if !ok {
 		return nil, errInsertNoRemoteConfig
 	}
+	if rc.GetKind() != session.RemoteKindSSH {
+		return nil, errInsertNoRemoteConfig
+	}
 	runner := session.NewSSHRunner(remoteName, rc)
 	if streamer, err := session.OpenStreamingRemoteKeySender(runner, sessionID, context.Background()); err == nil {
 		return streamer, nil

--- a/internal/ui/issue1100_shift_enter_remote_test.go
+++ b/internal/ui/issue1100_shift_enter_remote_test.go
@@ -104,6 +104,78 @@ func TestIssue1100_HomeDispatch_ShiftEnterRemoteCallsLauncher(t *testing.T) {
 	}
 }
 
+func TestIssue1100_HomeDispatch_ShiftEnterAgentboxUsesWorkspaceAttachCommand(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "https://agentbox.example/agentbox"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+	home.flatItems = []session.Item{{
+		Type:       session.ItemTypeRemoteSession,
+		RemoteName: "lab",
+		RemoteSession: &session.RemoteSessionInfo{
+			ID:                 "ws-1",
+			Title:              "research-one",
+			Status:             "running",
+			Attachable:         true,
+			AttachCommand:      "ssh agentbox tmux attach -t ws-1",
+			LocalAttachCommand: "tmux attach -t ws-1",
+		},
+	}}
+
+	var captured terminal.AttachRequest
+	var called bool
+	home.openInNewWindowSink = func(req terminal.AttachRequest) error {
+		called = true
+		captured = req
+		return nil
+	}
+
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+
+	if !called {
+		t.Fatal("Shift+Enter on a running agentbox workspace must call the launcher")
+	}
+	if got, want := terminal.BuildAttachCommand(captured), "ssh agentbox tmux attach -t ws-1"; got != want {
+		t.Fatalf("BuildAttachCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestIssue1100_HomeDispatch_ShiftEnterAgentboxStoppedDoesNotLaunch(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "https://agentbox.example/agentbox"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+	home.flatItems = []session.Item{{
+		Type:       session.ItemTypeRemoteSession,
+		RemoteName: "lab",
+		RemoteSession: &session.RemoteSessionInfo{
+			ID:         "ws-1",
+			Title:      "research-one",
+			Status:     "stopped",
+			Attachable: false,
+		},
+	}}
+
+	home.openInNewWindowSink = func(req terminal.AttachRequest) error {
+		t.Fatalf("launcher should not run for a stopped agentbox workspace: %+v", req)
+		return nil
+	}
+
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+}
+
 // TestIssue1100_HomeDispatch_ShiftEnterDefaultsToTab pins fix (b): the
 // dispatch path must read [ui] iterm_open_as from user config and pass
 // it through to the launcher, with "tab" as the default when unset.

--- a/internal/ui/issue1100_shift_enter_remote_test.go
+++ b/internal/ui/issue1100_shift_enter_remote_test.go
@@ -86,7 +86,13 @@ func TestIssue1100_HomeDispatch_ShiftEnterRemoteCallsLauncher(t *testing.T) {
 	}
 
 	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}}
-	_, _ = home.handleMainKey(keyMsg)
+	_, cmd := home.handleMainKey(keyMsg)
+	if cmd == nil {
+		t.Fatal("Shift+Enter on remote session did not schedule an async launcher command")
+	}
+	if err := (remoteOpenInNewWindowCmd{home: home, item: home.flatItems[0], openAs: "tab"}).Run(); err != nil {
+		t.Fatalf("remote open command failed: %v", err)
+	}
 
 	if !called {
 		t.Fatal("Shift+Enter on remote session did NOT call the new-window launcher (the #1100a regression)")
@@ -153,7 +159,13 @@ url = "`+srv.URL+`"
 		return nil
 	}
 
-	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+	_, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+	if cmd == nil {
+		t.Fatal("Shift+Enter on Agentbox did not schedule an async launcher command")
+	}
+	if err := (remoteOpenInNewWindowCmd{home: home, item: home.flatItems[0], openAs: "tab"}).Run(); err != nil {
+		t.Fatalf("Agentbox open command failed: %v", err)
+	}
 
 	if !called {
 		t.Fatal("Shift+Enter on a running agentbox workspace must call the launcher")
@@ -204,12 +216,16 @@ url = "`+srv.URL+`"
 		return nil
 	}
 
-	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
-	if home.err == nil {
-		t.Fatal("expected authoritative attach failure to surface an error")
+	_, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+	if cmd == nil {
+		t.Fatal("Shift+Enter on stopped Agentbox did not schedule an async launcher command")
 	}
-	if !strings.Contains(home.err.Error(), "start it before attaching") {
-		t.Fatalf("error = %v, want stopped-before-attach guidance", home.err)
+	err := (remoteOpenInNewWindowCmd{home: home, item: home.flatItems[0], openAs: "tab"}).Run()
+	if err == nil {
+		t.Fatal("expected authoritative attach failure")
+	}
+	if !strings.Contains(err.Error(), "start it before attaching") {
+		t.Fatalf("error = %v, want stopped-before-attach guidance", err)
 	}
 }
 

--- a/internal/ui/issue1100_shift_enter_remote_test.go
+++ b/internal/ui/issue1100_shift_enter_remote_test.go
@@ -1,6 +1,10 @@
 package ui
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -105,10 +109,23 @@ func TestIssue1100_HomeDispatch_ShiftEnterRemoteCallsLauncher(t *testing.T) {
 }
 
 func TestIssue1100_HomeDispatch_ShiftEnterAgentboxUsesWorkspaceAttachCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspaces/ws-1/attach" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                 "ws-1",
+			"status":             "running",
+			"attachCommand":      "ssh agentbox tmux attach -t ws-1-fresh",
+			"localAttachCommand": "tmux attach -t ws-1-fresh",
+		})
+	}))
+	defer srv.Close()
+
 	withTempAgentDeckHome(t, `
 [remotes.lab]
 kind = "agentbox"
-url = "https://agentbox.example/agentbox"
+url = "`+srv.URL+`"
 `)
 
 	home := NewHome()
@@ -123,8 +140,8 @@ url = "https://agentbox.example/agentbox"
 			Title:              "research-one",
 			Status:             "running",
 			Attachable:         true,
-			AttachCommand:      "ssh agentbox tmux attach -t ws-1",
-			LocalAttachCommand: "tmux attach -t ws-1",
+			AttachCommand:      "ssh agentbox tmux attach -t ws-1-stale",
+			LocalAttachCommand: "tmux attach -t ws-1-stale",
 		},
 	}}
 
@@ -141,16 +158,28 @@ url = "https://agentbox.example/agentbox"
 	if !called {
 		t.Fatal("Shift+Enter on a running agentbox workspace must call the launcher")
 	}
-	if got, want := terminal.BuildAttachCommand(captured), "ssh agentbox tmux attach -t ws-1"; got != want {
+	if got, want := terminal.BuildAttachCommand(captured), "tmux attach -t ws-1-fresh"; got != want {
 		t.Fatalf("BuildAttachCommand() = %q, want %q", got, want)
 	}
 }
 
 func TestIssue1100_HomeDispatch_ShiftEnterAgentboxStoppedDoesNotLaunch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspaces/ws-1/attach" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":  "workspace_not_running",
+			"status": "stopped",
+		})
+	}))
+	defer srv.Close()
+
 	withTempAgentDeckHome(t, `
 [remotes.lab]
 kind = "agentbox"
-url = "https://agentbox.example/agentbox"
+url = "`+srv.URL+`"
 `)
 
 	home := NewHome()
@@ -161,10 +190,12 @@ url = "https://agentbox.example/agentbox"
 		Type:       session.ItemTypeRemoteSession,
 		RemoteName: "lab",
 		RemoteSession: &session.RemoteSessionInfo{
-			ID:         "ws-1",
-			Title:      "research-one",
-			Status:     "stopped",
-			Attachable: false,
+			ID:                 "ws-1",
+			Title:              "research-one",
+			Status:             "running",
+			Attachable:         true,
+			AttachCommand:      "ssh agentbox tmux attach -t ws-1-stale",
+			LocalAttachCommand: "tmux attach -t ws-1-stale",
 		},
 	}}
 
@@ -174,6 +205,12 @@ url = "https://agentbox.example/agentbox"
 	}
 
 	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+	if home.err == nil {
+		t.Fatal("expected authoritative attach failure to surface an error")
+	}
+	if !strings.Contains(home.err.Error(), "start it before attaching") {
+		t.Fatalf("error = %v, want stopped-before-attach guidance", home.err)
+	}
 }
 
 // TestIssue1100_HomeDispatch_ShiftEnterDefaultsToTab pins fix (b): the

--- a/internal/ui/issue1353_remote_create_attach_test.go
+++ b/internal/ui/issue1353_remote_create_attach_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+type fakeRemoteCreateRunner struct {
+	createResult session.RemoteCreateResult
+	createErr    error
+	attachErr    error
+
+	createCalls int
+	attachCalls int
+
+	attachedResult session.RemoteCreateResult
+}
+
+func (f *fakeRemoteCreateRunner) FetchSessions(context.Context) ([]session.RemoteSessionInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeRemoteCreateRunner) FetchSessionOutput(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeRemoteCreateRunner) FetchSessionPane(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeRemoteCreateRunner) FetchCostSummary(context.Context) (*costs.RemoteCostSummary, error) {
+	return nil, nil
+}
+
+func (f *fakeRemoteCreateRunner) MeasureLatency(context.Context) (time.Duration, error) {
+	return 0, nil
+}
+
+func (f *fakeRemoteCreateRunner) CreateSession(context.Context, session.RemoteCreateOptions) (session.RemoteCreateResult, error) {
+	f.createCalls++
+	return f.createResult, f.createErr
+}
+
+func (f *fakeRemoteCreateRunner) DeleteSession(context.Context, string) error { return nil }
+func (f *fakeRemoteCreateRunner) StopSession(context.Context, string) error   { return nil }
+func (f *fakeRemoteCreateRunner) RestartSession(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeRemoteCreateRunner) RenameSession(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeRemoteCreateRunner) Attach(string) error {
+	f.attachCalls++
+	return f.attachErr
+}
+
+func (f *fakeRemoteCreateRunner) AttachCreatedResult(result session.RemoteCreateResult) error {
+	f.attachedResult = result
+	return nil
+}
+
+func TestIssue1353_RemoteCreateAndAttachCmd_UsesCreateResponseWhenAvailable(t *testing.T) {
+	runner := &fakeRemoteCreateRunner{
+		createResult: session.RemoteCreateResult{
+			SessionID:          "ws-1",
+			Attachable:         true,
+			AttachCommand:      "ssh agentbox tmux attach -t ws-1",
+			LocalAttachCommand: "tmux attach -t ws-1",
+		},
+		attachErr: errors.New("follow-up attach lookup failed"),
+	}
+
+	err := (remoteCreateAndAttachCmd{runner: runner}).Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if runner.createCalls != 1 {
+		t.Fatalf("CreateSession calls = %d, want 1", runner.createCalls)
+	}
+	if runner.attachCalls != 0 {
+		t.Fatalf("Attach calls = %d, want 0 when create already returned attach commands", runner.attachCalls)
+	}
+	if runner.attachedResult.SessionID != "ws-1" {
+		t.Fatalf("attached create result = %+v, want preserved create response", runner.attachedResult)
+	}
+}
+
+func TestIssue1353_RemoteCreateAndAttachCmd_FallsBackToAttachForSSH(t *testing.T) {
+	runner := &fakeRemoteCreateRunner{
+		createResult: session.RemoteCreateResult{SessionID: "remote-session-1"},
+	}
+
+	err := (remoteCreateAndAttachCmd{runner: runner}).Run()
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if runner.attachCalls != 1 {
+		t.Fatalf("Attach calls = %d, want 1 for non-agentbox create results", runner.attachCalls)
+	}
+}

--- a/internal/ui/issue1353_remote_new_dialog_test.go
+++ b/internal/ui/issue1353_remote_new_dialog_test.go
@@ -253,6 +253,60 @@ url = "http://127.0.0.1:1"
 	}
 }
 
+func TestIssue1353_AgentboxRemoteDialogFromWorkspaceRow_DoesNotReuseWorkspacePath(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{{
+		Type:       session.ItemTypeRemoteSession,
+		RemoteName: "lab",
+		RemoteSession: &session.RemoteSessionInfo{
+			ID:         "ws-123",
+			Title:      "existing-workspace",
+			RemoteName: "lab",
+			Path:       "/srv/agentbox/workspaces/existing-workspace",
+		},
+	}}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	_, path, _ := h.newDialog.GetValues()
+	if path != "" {
+		t.Fatalf("agentbox remote dialog path = %q, want empty so create cannot silently reuse the existing workspace root", path)
+	}
+}
+
+func TestIssue1353_AgentboxRemoteDialog_DoesNotPreselectConfiguredModel(t *testing.T) {
+	withTempAgentDeckHome(t, `
+default_tool = "claude"
+
+[claude]
+default_model = "claude-opus-4-7"
+
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("lab")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	if got := h.newDialog.modelInput.Value(); got != "" {
+		t.Fatalf("agentbox remote dialog modelInput = %q, want empty so model selection stays explicit", got)
+	}
+	if got := h.newDialog.GetRemoteCreateOptions().ModelID; got != "" {
+		t.Fatalf("agentbox remote create model = %q, want empty until the user explicitly selects one", got)
+	}
+}
+
 // TestIssue1353_LocalNUnaffected: `n` on a local group keeps the existing
 // behavior and must not leave any stale remote target around.
 func TestIssue1353_LocalNUnaffected(t *testing.T) {

--- a/internal/ui/issue1353_remote_new_dialog_test.go
+++ b/internal/ui/issue1353_remote_new_dialog_test.go
@@ -221,6 +221,101 @@ url = "http://127.0.0.1:1"
 	}
 }
 
+func TestIssue1353_AgentboxRemoteDialogUsesCanonicalAgentPlaceholderAndHelp(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("lab")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	if got := h.newDialog.agentInput.Placeholder; got != "claude-code | codex | pi-fireworks" {
+		t.Fatalf("agent placeholder = %q, want canonical values", got)
+	}
+
+	h.newDialog.focusIndex = 2 // Name, Orchestrator, Agent
+	view := h.newDialog.View()
+	for _, want := range []string{"claude-code", "codex", "pi-fireworks"} {
+		if strings.Contains(view, want) {
+			continue
+		}
+		t.Fatalf("agent help text should show canonical value %q:\n%s", want, view)
+	}
+}
+
+func TestIssue1353_AgentboxRemoteDialogRejectsShorthandAgents(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	tests := []struct {
+		name  string
+		agent string
+	}{
+		{name: "claude shorthand", agent: "claude"},
+		{name: "pi shorthand", agent: "pi"},
+		{name: "other value", agent: "gemini"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+			home.flatItems = []session.Item{remoteGroupItem("lab")}
+			home.cursor = 0
+
+			h := pressN(t, home)
+			h.newDialog.nameInput.SetValue("research-one")
+			h.newDialog.orchestratorInput.SetValue("wisp")
+			h.newDialog.agentInput.SetValue(tt.agent)
+			h.newDialog.modelInput.SetValue("accounts/fireworks/models/glm-5p2")
+			h.newDialog.runtimeInput.SetValue("docker")
+
+			got := h.newDialog.Validate()
+			if !strings.Contains(got, "claude-code, codex, or pi-fireworks") {
+				t.Fatalf("Validate() = %q, want canonical-agent guidance", got)
+			}
+		})
+	}
+}
+
+func TestIssue1353_AgentboxRemoteDialogAcceptsCanonicalAgents(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	tests := []string{"claude-code", "codex", "pi-fireworks"}
+
+	for _, agent := range tests {
+		t.Run(agent, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+			home.flatItems = []session.Item{remoteGroupItem("lab")}
+			home.cursor = 0
+
+			h := pressN(t, home)
+			h.newDialog.nameInput.SetValue("research-one")
+			h.newDialog.orchestratorInput.SetValue("wisp")
+			h.newDialog.agentInput.SetValue(agent)
+			h.newDialog.modelInput.SetValue("accounts/fireworks/models/glm-5p2")
+			h.newDialog.runtimeInput.SetValue("docker")
+
+			if got := h.newDialog.Validate(); got != "" {
+				t.Fatalf("Validate() = %q, want empty for canonical agent %q", got, agent)
+			}
+		})
+	}
+}
+
 func TestIssue1353_AgentboxRemoteDialogBuildsExplicitCreateOptions(t *testing.T) {
 	withTempAgentDeckHome(t, `
 [remotes.lab]

--- a/internal/ui/issue1353_remote_new_dialog_test.go
+++ b/internal/ui/issue1353_remote_new_dialog_test.go
@@ -178,6 +178,81 @@ func TestIssue1353_SubmitRoutesToRemote(t *testing.T) {
 	}
 }
 
+func TestIssue1353_AgentboxRemoteDialogShowsExplicitWorkspaceFields(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("lab")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	view := h.newDialog.View()
+	for _, want := range []string{"Orchestrator:", "Agent:", "Model ID:", "Runtime:", "Path:"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("agentbox remote dialog missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Command:") {
+		t.Fatalf("agentbox remote dialog should not render the SSH/local command picker:\n%s", view)
+	}
+}
+
+func TestIssue1353_AgentboxRemoteDialogRequiresExplicitFields(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("lab")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	h.newDialog.nameInput.SetValue("research-one")
+	if got := h.newDialog.Validate(); !strings.Contains(strings.ToLower(got), "orchestrator") {
+		t.Fatalf("Validate() = %q, want explicit orchestrator guidance", got)
+	}
+}
+
+func TestIssue1353_AgentboxRemoteDialogBuildsExplicitCreateOptions(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+kind = "agentbox"
+url = "http://127.0.0.1:1"
+`)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("lab")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	h.newDialog.nameInput.SetValue("research-one")
+	h.newDialog.orchestratorInput.SetValue("wisp")
+	h.newDialog.agentInput.SetValue("pi-fireworks")
+	h.newDialog.modelInput.SetValue("accounts/fireworks/models/glm-5p2")
+	h.newDialog.runtimeInput.SetValue("docker")
+	h.newDialog.pathInput.SetValue("/srv/research")
+
+	opts := h.newDialog.GetRemoteCreateOptions()
+	if opts.Title != "research-one" || opts.Orchestrator != "wisp" || opts.Agent != "pi-fireworks" {
+		t.Fatalf("remote create identity fields = %+v", opts)
+	}
+	if opts.ModelID != "accounts/fireworks/models/glm-5p2" || opts.Runtime != "docker" || opts.Path != "/srv/research" {
+		t.Fatalf("remote create model/runtime/path fields = %+v", opts)
+	}
+	if opts.Tool != "" || opts.Group != "" {
+		t.Fatalf("agentbox remote create should not leak SSH/local defaults: %+v", opts)
+	}
+}
+
 // TestIssue1353_LocalNUnaffected: `n` on a local group keeps the existing
 // behavior and must not leave any stale remote target around.
 func TestIssue1353_LocalNUnaffected(t *testing.T) {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -484,8 +484,12 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.sandboxEnabled = false
 	d.inheritedExpanded = false
 	d.inheritedSettings = nil
-	// Set path input to group's default path if provided, otherwise use current working directory.
-	if defaultPath != "" {
+	// Agentbox workspace roots are optional and must stay intentional: do not
+	// synthesize a cwd/path in create mode. SSH/local keep the existing path
+	// defaults.
+	if d.isAgentboxRemoteMode() {
+		d.pathInput.SetValue(strings.TrimSpace(defaultPath))
+	} else if defaultPath != "" {
 		d.pathInput.SetValue(defaultPath)
 	} else {
 		cwd, err := os.Getwd()
@@ -493,7 +497,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 			d.pathInput.SetValue(cwd)
 		}
 	}
-	d.pathSoftSelected = true // activate soft-select for pre-filled path.
+	d.pathSoftSelected = strings.TrimSpace(d.pathInput.Value()) != ""
 	// Initialize tool options from global config.
 	d.geminiOptions.SetDefaults(false)
 	d.codexOptions.SetDefaults(false)
@@ -510,12 +514,16 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 		}
 		d.inheritedSettings = buildInheritedSettings(userConfig.Docker)
 		d.branchPrefix = userConfig.Worktree.Prefix()
-		// #1172: preselect the configured default model so users who set
-		// [claude].default_model aren't forced to switch off Sonnet on every
-		// new session. Overrides the empty value set above; left empty when
-		// no (valid, in-catalog) default is configured.
-		if dm := preselectDefaultModel(userConfig, d.GetSelectedCommand()); dm != "" {
-			d.modelInput.SetValue(dm)
+		// Local/SSH sessions may inherit a configured default model. Agentbox
+		// workspaces must keep model selection explicit.
+		if !d.isAgentboxRemoteMode() {
+			// #1172: preselect the configured default model so users who set
+			// [claude].default_model aren't forced to switch off Sonnet on every
+			// new session. Overrides the empty value set above; left empty when
+			// no (valid, in-catalog) default is configured.
+			if dm := preselectDefaultModel(userConfig, d.GetSelectedCommand()); dm != "" {
+				d.modelInput.SetValue(dm)
+			}
 		}
 	}
 	d.branchInput.Placeholder = d.branchPrefix + "branch-name"

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -123,17 +123,20 @@ func sliceVisibleFrom(s string, n int) string {
 type focusTarget int
 
 const (
-	focusName      focusTarget = iota
-	focusPath                  // project path input (hidden when multi-repo enabled).
-	focusCommand               // tool/command picker.
-	focusModel                 // optional per-session model/version override.
-	focusWorktree              // worktree checkbox.
-	focusSandbox               // sandbox checkbox.
-	focusConductor             // conducting parent dropdown (conditional — only when conductors exist).
-	focusMultiRepo             // multi-repo toggle (transforms path into list when enabled).
-	focusInherited             // inherited Docker settings toggle (conditional).
-	focusBranch                // branch input (conditional — only when worktree enabled).
-	focusOptions               // tool-specific options panel (conditional).
+	focusName         focusTarget = iota
+	focusPath                     // project path input (hidden when multi-repo enabled).
+	focusCommand                  // tool/command picker.
+	focusOrchestrator             // agentbox orchestrator input.
+	focusAgent                    // agentbox agent input.
+	focusModel                    // optional per-session model/version override.
+	focusRuntime                  // agentbox runtime input.
+	focusWorktree                 // worktree checkbox.
+	focusSandbox                  // sandbox checkbox.
+	focusConductor                // conducting parent dropdown (conditional — only when conductors exist).
+	focusMultiRepo                // multi-repo toggle (transforms path into list when enabled).
+	focusInherited                // inherited Docker settings toggle (conditional).
+	focusBranch                   // branch input (conditional — only when worktree enabled).
+	focusOptions                  // tool-specific options panel (conditional).
 )
 
 // New session dialog: outer box and textinput widths stay in sync so long
@@ -153,12 +156,23 @@ type settingDisplay struct {
 	value string
 }
 
+type remoteCreateMode int
+
+const (
+	remoteCreateModeLocal remoteCreateMode = iota
+	remoteCreateModeSSH
+	remoteCreateModeAgentbox
+)
+
 // NewDialog represents the new session creation dialog.
 type NewDialog struct {
 	nameInput             textinput.Model
 	pathInput             textinput.Model
 	commandInput          textinput.Model
+	orchestratorInput     textinput.Model
+	agentInput            textinput.Model
 	modelInput            textinput.Model
+	runtimeInput          textinput.Model
 	claudeOptions         *ClaudeOptionsPanel // Claude-specific options (concrete for value extraction).
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
@@ -173,6 +187,7 @@ type NewDialog struct {
 	commandCursor         int
 	parentGroupPath       string
 	parentGroupName       string
+	remoteMode            remoteCreateMode
 	pathSuggestions       []string // filtered subset of path suggestions shown in dropdown.
 	allPathSuggestions    []string // full unfiltered set of path suggestions.
 	pathSuggestionCursor  int      // tracks selected entry in dropdown (0 = "Type custom", 1.. = suggestions).
@@ -351,10 +366,22 @@ func NewNewDialog() *NewDialog {
 	commandInput.Placeholder = "custom command"
 	commandInput.CharLimit = 100
 
+	orchestratorInput := textinput.New()
+	orchestratorInput.Placeholder = "wisp"
+	orchestratorInput.CharLimit = 64
+
+	agentInput := textinput.New()
+	agentInput.Placeholder = "claude | codex | pi"
+	agentInput.CharLimit = 64
+
 	// Optional per-session model/version override for supported tools.
 	modelInput := textinput.New()
 	modelInput.Placeholder = "tool default"
 	modelInput.CharLimit = 128
+
+	runtimeInput := textinput.New()
+	runtimeInput.Placeholder = "docker | tmux"
+	runtimeInput.CharLimit = 64
 
 	// Create branch input for worktree
 	branchInput := textinput.New()
@@ -362,25 +389,28 @@ func NewNewDialog() *NewDialog {
 	branchInput.CharLimit = 100
 
 	dlg := &NewDialog{
-		nameInput:       nameInput,
-		pathInput:       pathInput,
-		commandInput:    commandInput,
-		modelInput:      modelInput,
-		branchInput:     branchInput,
-		branchPicker:    NewBranchPickerDialog(),
-		claudeOptions:   NewClaudeOptionsPanel(),
-		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
-		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
-		hermesOptions:   NewYoloOptionsPanel("Hermes", "YOLO mode - auto-approve all tool calls"),
-		focusIndex:      0,
-		visible:         false,
-		presetCommands:  buildPresetCommands(),
-		commandCursor:   0,
-		parentGroupPath: "default",
-		parentGroupName: "default",
-		worktreeEnabled: false,
-		branchPrefix:    "feature/",
-		enterAdvances:   newSessionEnterAdvancesFromConfig(),
+		nameInput:         nameInput,
+		pathInput:         pathInput,
+		commandInput:      commandInput,
+		orchestratorInput: orchestratorInput,
+		agentInput:        agentInput,
+		modelInput:        modelInput,
+		runtimeInput:      runtimeInput,
+		branchInput:       branchInput,
+		branchPicker:      NewBranchPickerDialog(),
+		claudeOptions:     NewClaudeOptionsPanel(),
+		geminiOptions:     NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
+		codexOptions:      NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
+		hermesOptions:     NewYoloOptionsPanel("Hermes", "YOLO mode - auto-approve all tool calls"),
+		focusIndex:        0,
+		visible:           false,
+		presetCommands:    buildPresetCommands(),
+		commandCursor:     0,
+		parentGroupPath:   "default",
+		parentGroupName:   "default",
+		worktreeEnabled:   false,
+		branchPrefix:      "feature/",
+		enterAdvances:     newSessionEnterAdvancesFromConfig(),
 	}
 	dlg.syncInputWidths()
 	dlg.updateToolOptions() // Also calls rebuildFocusTargets.
@@ -422,8 +452,14 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 		}
 	}
 	d.pathInput.Blur()
+	d.orchestratorInput.SetValue("")
+	d.orchestratorInput.Blur()
+	d.agentInput.SetValue("")
+	d.agentInput.Blur()
 	d.modelInput.SetValue("")
 	d.modelInput.Blur()
+	d.runtimeInput.SetValue("")
+	d.runtimeInput.Blur()
 	d.claudeOptions.Blur()
 	d.claudeOptions.ResetStartQuery() // #741: per-session query must not leak across openings
 	d.geminiOptions.Blur()
@@ -508,6 +544,24 @@ func (d *NewDialog) SetDefaultTool(tool string) {
 	d.updateToolOptions()
 }
 
+func (d *NewDialog) SetRemoteMode(kind string) {
+	switch strings.TrimSpace(kind) {
+	case session.RemoteKindAgentbox:
+		d.remoteMode = remoteCreateModeAgentbox
+	default:
+		if kind != "" {
+			d.remoteMode = remoteCreateModeSSH
+		} else {
+			d.remoteMode = remoteCreateModeLocal
+		}
+	}
+	d.updateToolOptions()
+}
+
+func (d *NewDialog) isAgentboxRemoteMode() bool {
+	return d.remoteMode == remoteCreateModeAgentbox
+}
+
 // GetSelectedGroup returns the parent group path
 func (d *NewDialog) GetSelectedGroup() string {
 	return d.parentGroupPath
@@ -535,7 +589,10 @@ func (d *NewDialog) syncInputWidths() {
 	d.nameInput.Width = iw
 	d.pathInput.Width = iw
 	d.commandInput.Width = iw
+	d.orchestratorInput.Width = iw
+	d.agentInput.Width = iw
 	d.modelInput.Width = iw
+	d.runtimeInput.Width = iw
 	d.branchInput.Width = iw
 }
 
@@ -1064,6 +1121,28 @@ func (d *NewDialog) GetRemoteValues() (name, path, command string) {
 	return name, path, command
 }
 
+func (d *NewDialog) GetRemoteCreateOptions() session.RemoteCreateOptions {
+	name := strings.TrimSpace(d.nameInput.Value())
+	path := d.sanitizePath(d.pathInput.Value())
+	if d.isAgentboxRemoteMode() {
+		return session.RemoteCreateOptions{
+			Title:        name,
+			Path:         path,
+			ModelID:      strings.TrimSpace(d.modelInput.Value()),
+			Orchestrator: strings.TrimSpace(d.orchestratorInput.Value()),
+			Agent:        strings.TrimSpace(d.agentInput.Value()),
+			Runtime:      strings.TrimSpace(d.runtimeInput.Value()),
+		}
+	}
+	return session.RemoteCreateOptions{
+		Tool:    d.resolveCommand(),
+		Title:   name,
+		Path:    path,
+		Group:   d.GetSelectedGroup(),
+		ModelID: d.GetLaunchModelID(),
+	}
+}
+
 // ToggleWorktree toggles the worktree checkbox.
 // When enabling, auto-populates the branch name from the session name.
 func (d *NewDialog) ToggleWorktree() {
@@ -1197,10 +1276,17 @@ func (d *NewDialog) GetSelectedCommand() string {
 }
 
 func (d *NewDialog) selectedToolSupportsModel() bool {
+	if d.isAgentboxRemoteMode() {
+		return true
+	}
 	return session.SupportsLaunchModel(d.GetSelectedCommand())
 }
 
 func (d *NewDialog) updateModelPlaceholder() {
+	if d.isAgentboxRemoteMode() {
+		d.modelInput.Placeholder = "provider/model-or-version"
+		return
+	}
 	switch cmd := d.GetSelectedCommand(); {
 	case session.IsClaudeCompatible(cmd):
 		d.modelInput.Placeholder = "claude-sonnet-4-6"
@@ -1216,6 +1302,9 @@ func (d *NewDialog) updateModelPlaceholder() {
 }
 
 func (d *NewDialog) modelInputHint() string {
+	if d.isAgentboxRemoteMode() {
+		return ""
+	}
 	switch cmd := d.GetSelectedCommand(); {
 	case session.IsClaudeCompatible(cmd):
 		return "Examples: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5"
@@ -1292,6 +1381,23 @@ func (d *NewDialog) Validate() string {
 		return fmt.Sprintf("Session name too long (max %d characters)", MaxNameLength)
 	}
 
+	if d.isAgentboxRemoteMode() {
+		if strings.TrimSpace(d.orchestratorInput.Value()) == "" {
+			return "Orchestrator is required for Agentbox workspaces"
+		}
+		if strings.TrimSpace(d.agentInput.Value()) == "" {
+			return "Agent is required for Agentbox workspaces"
+		}
+		if strings.TrimSpace(d.modelInput.Value()) == "" {
+			return "Model ID is required for Agentbox workspaces"
+		}
+		if strings.TrimSpace(d.runtimeInput.Value()) == "" {
+			return "Runtime is required for Agentbox workspaces"
+		}
+		_ = path
+		return ""
+	}
+
 	// Check for empty path
 	if path == "" && !d.multiRepoEnabled {
 		return "Project path cannot be empty"
@@ -1363,6 +1469,16 @@ func (d *NewDialog) indexOf(target focusTarget) int {
 // rebuildFocusTargets builds the ordered list of active focusable elements
 // based on current dialog state (sandbox, worktree, tool options visibility).
 func (d *NewDialog) rebuildFocusTargets() {
+	if d.isAgentboxRemoteMode() {
+		d.focusTargets = []focusTarget{focusName, focusOrchestrator, focusAgent, focusModel, focusRuntime, focusPath}
+		if d.focusIndex >= len(d.focusTargets) {
+			d.focusIndex = len(d.focusTargets) - 1
+		}
+		if d.focusIndex < 0 {
+			d.focusIndex = 0
+		}
+		return
+	}
 	// UX top-3 #3: the hot path is Name -> Tool -> (Model) -> Path. The Model
 	// override stays grouped with the tool selector; Path follows. The Multi-repo
 	// toggle moves below the common fields ("below the fold") so the 90% flow
@@ -1429,7 +1545,10 @@ func (d *NewDialog) updateFocus() {
 	d.nameInput.Blur()
 	d.pathInput.Blur()
 	d.commandInput.Blur()
+	d.orchestratorInput.Blur()
+	d.agentInput.Blur()
 	d.modelInput.Blur()
+	d.runtimeInput.Blur()
 	d.branchInput.Blur()
 	d.claudeOptions.Blur()
 	d.geminiOptions.Blur()
@@ -1457,8 +1576,14 @@ func (d *NewDialog) updateFocus() {
 		if d.commandCursor == 0 { // shell.
 			d.commandInput.Focus()
 		}
+	case focusOrchestrator:
+		d.orchestratorInput.Focus()
+	case focusAgent:
+		d.agentInput.Focus()
 	case focusModel:
 		d.modelInput.Focus()
+	case focusRuntime:
+		d.runtimeInput.Focus()
 	case focusWorktree, focusSandbox, focusConductor, focusInherited:
 		// Checkbox/toggle rows and conductor dropdown — no text input to focus.
 	case focusBranch:
@@ -1502,7 +1627,7 @@ func isNewDialogShiftTabKey(msg tea.KeyMsg) bool {
 // keystrokes. Single-letter shortcuts must be suppressed in this state.
 func (d *NewDialog) isTextInputFocused() bool {
 	switch d.currentTarget() {
-	case focusName, focusPath, focusModel, focusBranch:
+	case focusName, focusPath, focusOrchestrator, focusAgent, focusModel, focusRuntime, focusBranch:
 		return true
 	case focusCommand:
 		return d.commandCursor == 0 // custom command input
@@ -2212,6 +2337,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		if d.commandCursor == 0 {
 			d.commandInput, cmd = d.commandInput.Update(msg)
 		}
+	case focusOrchestrator:
+		d.orchestratorInput, cmd = d.orchestratorInput.Update(msg)
+	case focusAgent:
+		d.agentInput, cmd = d.agentInput.Update(msg)
 	case focusModel:
 		oldValue := d.modelInput.Value()
 		d.modelInput, cmd = d.modelInput.Update(msg)
@@ -2222,6 +2351,8 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			d.modelNavigated = false
 			d.filterModelSuggestions()
 		}
+	case focusRuntime:
+		d.runtimeInput, cmd = d.runtimeInput.Update(msg)
 	case focusMultiRepo:
 		// When editing a multi-repo path, forward keystrokes to pathInput.
 		if d.multiRepoEditing {
@@ -2367,6 +2498,19 @@ func (d *NewDialog) renderModelSection(content *strings.Builder, cur focusTarget
 	content.WriteString("\n\n")
 }
 
+func renderTextInputSection(content *strings.Builder, cur focusTarget, target focusTarget, label string, input textinput.Model) {
+	labelStyle := lipgloss.NewStyle().Foreground(ColorText)
+	activeLabelStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+	if cur == target {
+		content.WriteString(activeLabelStyle.Render("▶ " + label))
+	} else {
+		content.WriteString(labelStyle.Render("  " + label))
+	}
+	content.WriteString("\n  ")
+	content.WriteString(input.View())
+	content.WriteString("\n\n")
+}
+
 // renderSinglePathSection renders the single project-path input (the common
 // case). In multi-repo mode this is skipped — the path list renders under the
 // Multi-repo toggle below the fold instead.
@@ -2505,8 +2649,11 @@ func (d *NewDialog) View() string {
 	// Build content
 	var content strings.Builder
 
-	// Title with parent group info
-	content.WriteString(titleStyle.Render("New Session"))
+	titleText := "New Session"
+	if d.isAgentboxRemoteMode() {
+		titleText = "New Workspace"
+	}
+	content.WriteString(titleStyle.Render(titleText))
 	content.WriteString("\n")
 	groupInfoStyle := lipgloss.NewStyle().Foreground(ColorPurple) // Purple for group context
 	content.WriteString(groupInfoStyle.Render("  in group: " + d.parentGroupName))
@@ -2584,138 +2731,147 @@ func (d *NewDialog) View() string {
 	content.WriteString(d.nameInput.View())
 	content.WriteString("\n\n")
 
-	// Hot path (UX top-3 #3): Tool -> (Model) -> Path render right after Name.
-	// The Multi-repo toggle and its path list move below the common fields
-	// (see renderMultiRepoSection, called after the Branch input). In multi-repo
-	// mode the single Path field is hidden — its list renders below the fold.
-	d.renderCommandSection(&content, cur)
-	d.renderModelSection(&content, cur, dialogWidth)
-	if !d.multiRepoEnabled {
+	if d.isAgentboxRemoteMode() {
+		renderTextInputSection(&content, cur, focusOrchestrator, "Orchestrator:", d.orchestratorInput)
+		renderTextInputSection(&content, cur, focusAgent, "Agent:", d.agentInput)
+		d.renderModelSection(&content, cur, dialogWidth)
+		renderTextInputSection(&content, cur, focusRuntime, "Runtime:", d.runtimeInput)
 		d.renderSinglePathSection(&content, cur, dialogWidth)
-	}
-
-	// (Tool, Model, and the single Path field render above, right after Name —
-	// see renderCommandSection / renderModelSection / renderSinglePathSection.)
-
-	// Worktree checkbox — individually focusable.
-	worktreeLabel := "Create in worktree"
-	if cur == focusCommand {
-		worktreeLabel = "Create in worktree (w)"
-	}
-	content.WriteString(renderCheckboxLine(worktreeLabel, d.worktreeEnabled, cur == focusWorktree))
-
-	// Docker sandbox checkbox — individually focusable.
-	sandboxLabel := "Run in Docker sandbox"
-	if cur == focusCommand {
-		sandboxLabel = "Run in Docker sandbox (s)"
-	}
-	content.WriteString(renderCheckboxLine(sandboxLabel, d.sandboxEnabled, cur == focusSandbox))
-
-	// Inherited Docker settings (only visible when sandbox is enabled).
-	if d.sandboxEnabled && len(d.inheritedSettings) > 0 {
-		focused := cur == focusInherited
-		dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
-		settingStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
-
-		// Render toggle line.
-		arrow := "▸"
-		if d.inheritedExpanded {
-			arrow = "▾"
+	} else {
+		// Hot path (UX top-3 #3): Tool -> (Model) -> Path render right after Name.
+		// The Multi-repo toggle and its path list move below the common fields
+		// (see renderMultiRepoSection, called after the Branch input). In multi-repo
+		// mode the single Path field is hidden — its list renders below the fold.
+		d.renderCommandSection(&content, cur)
+		d.renderModelSection(&content, cur, dialogWidth)
+		if !d.multiRepoEnabled {
+			d.renderSinglePathSection(&content, cur, dialogWidth)
 		}
-		summary := fmt.Sprintf("%d active", len(d.inheritedSettings))
-		toggleLine := fmt.Sprintf("%s Docker Settings (%s)", arrow, summary)
-		if focused {
-			content.WriteString(activeLabelStyle.Render("▶ " + toggleLine))
-		} else {
-			content.WriteString("  " + dimStyle.Render(toggleLine))
-		}
-		content.WriteString("\n")
 
-		// Render expanded settings.
-		if d.inheritedExpanded {
-			for _, s := range d.inheritedSettings {
-				content.WriteString(settingStyle.Render(fmt.Sprintf("    %s: %s", s.label, s.value)))
+		// (Tool, Model, and the single Path field render above, right after Name —
+		// see renderCommandSection / renderModelSection / renderSinglePathSection.)
+
+		// Worktree checkbox — individually focusable.
+		worktreeLabel := "Create in worktree"
+		if cur == focusCommand {
+			worktreeLabel = "Create in worktree (w)"
+		}
+		content.WriteString(renderCheckboxLine(worktreeLabel, d.worktreeEnabled, cur == focusWorktree))
+
+		// Docker sandbox checkbox — individually focusable.
+		sandboxLabel := "Run in Docker sandbox"
+		if cur == focusCommand {
+			sandboxLabel = "Run in Docker sandbox (s)"
+		}
+		content.WriteString(renderCheckboxLine(sandboxLabel, d.sandboxEnabled, cur == focusSandbox))
+
+		// Inherited Docker settings (only visible when sandbox is enabled).
+		if d.sandboxEnabled && len(d.inheritedSettings) > 0 {
+			focused := cur == focusInherited
+			dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
+			settingStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+
+			// Render toggle line.
+			arrow := "▸"
+			if d.inheritedExpanded {
+				arrow = "▾"
+			}
+			summary := fmt.Sprintf("%d active", len(d.inheritedSettings))
+			toggleLine := fmt.Sprintf("%s Docker Settings (%s)", arrow, summary)
+			if focused {
+				content.WriteString(activeLabelStyle.Render("▶ " + toggleLine))
+			} else {
+				content.WriteString("  " + dimStyle.Render(toggleLine))
+			}
+			content.WriteString("\n")
+
+			// Render expanded settings.
+			if d.inheritedExpanded {
+				for _, s := range d.inheritedSettings {
+					content.WriteString(settingStyle.Render(fmt.Sprintf("    %s: %s", s.label, s.value)))
+					content.WriteString("\n")
+				}
+			}
+		} else if d.sandboxEnabled {
+			// Sandbox enabled but all defaults — show informational line.
+			dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
+			content.WriteString("  " + dimStyle.Render("Docker Settings (all defaults)"))
+			content.WriteString("\n")
+		}
+
+		// Conducting parent selector (only visible when conductor sessions exist).
+		if len(d.conductorSessions) > 0 {
+			focused := cur == focusConductor
+			if focused {
+				content.WriteString(activeLabelStyle.Render("▶ Conducting parent:"))
+			} else {
+				content.WriteString(labelStyle.Render("  Conducting parent:"))
+			}
+			content.WriteString("\n")
+
+			selectedStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+			itemStyle := lipgloss.NewStyle().Foreground(ColorComment)
+
+			// Build item list: "None" + one entry per conductor session.
+			type conductorItem struct {
+				label string
+				idx   int // 0 = None, 1..N = session index
+			}
+			items := make([]conductorItem, 0, len(d.conductorSessions)+1)
+			items = append(items, conductorItem{label: "None", idx: 0})
+			for i, inst := range d.conductorSessions {
+				name := strings.TrimPrefix(inst.Title, "conductor-")
+				shortPath := inst.ProjectPath
+				if home, err := os.UserHomeDir(); err == nil {
+					shortPath = strings.Replace(shortPath, home, "~", 1)
+				}
+				label := name
+				if shortPath != "" {
+					label = fmt.Sprintf("%s  (%s)", name, shortPath)
+				}
+				items = append(items, conductorItem{label: label, idx: i + 1})
+			}
+
+			for _, item := range items {
+				if item.idx == d.conductorCursor {
+					content.WriteString(selectedStyle.Render("  ▶ " + item.label))
+				} else {
+					content.WriteString(itemStyle.Render("    " + item.label))
+				}
 				content.WriteString("\n")
 			}
 		}
-	} else if d.sandboxEnabled {
-		// Sandbox enabled but all defaults — show informational line.
-		dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
-		content.WriteString("  " + dimStyle.Render("Docker Settings (all defaults)"))
+
 		content.WriteString("\n")
-	}
-
-	// Conducting parent selector (only visible when conductor sessions exist).
-	if len(d.conductorSessions) > 0 {
-		focused := cur == focusConductor
-		if focused {
-			content.WriteString(activeLabelStyle.Render("▶ Conducting parent:"))
-		} else {
-			content.WriteString(labelStyle.Render("  Conducting parent:"))
-		}
-		content.WriteString("\n")
-
-		selectedStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
-		itemStyle := lipgloss.NewStyle().Foreground(ColorComment)
-
-		// Build item list: "None" + one entry per conductor session.
-		type conductorItem struct {
-			label string
-			idx   int // 0 = None, 1..N = session index
-		}
-		items := make([]conductorItem, 0, len(d.conductorSessions)+1)
-		items = append(items, conductorItem{label: "None", idx: 0})
-		for i, inst := range d.conductorSessions {
-			name := strings.TrimPrefix(inst.Title, "conductor-")
-			shortPath := inst.ProjectPath
-			if home, err := os.UserHomeDir(); err == nil {
-				shortPath = strings.Replace(shortPath, home, "~", 1)
-			}
-			label := name
-			if shortPath != "" {
-				label = fmt.Sprintf("%s  (%s)", name, shortPath)
-			}
-			items = append(items, conductorItem{label: label, idx: i + 1})
-		}
-
-		for _, item := range items {
-			if item.idx == d.conductorCursor {
-				content.WriteString(selectedStyle.Render("  ▶ " + item.label))
+		// Branch input (only visible when worktree is enabled).
+		if d.worktreeEnabled {
+			content.WriteString("\n")
+			if cur == focusBranch {
+				content.WriteString(activeLabelStyle.Render("▶ Branch:"))
 			} else {
-				content.WriteString(itemStyle.Render("    " + item.label))
+				content.WriteString(labelStyle.Render("  Branch:"))
 			}
 			content.WriteString("\n")
-		}
-	}
-
-	// Branch input (only visible when worktree is enabled).
-	if d.worktreeEnabled {
-		content.WriteString("\n")
-		if cur == focusBranch {
-			content.WriteString(activeLabelStyle.Render("▶ Branch:"))
-		} else {
-			content.WriteString(labelStyle.Render("  Branch:"))
-		}
-		content.WriteString("\n")
-		content.WriteString("  ")
-		content.WriteString(d.branchInput.View())
-		content.WriteString("\n")
-		if d.branchPicker != nil && d.branchPicker.IsVisible() {
 			content.WriteString("  ")
-			content.WriteString(strings.ReplaceAll(d.branchPicker.View(), "\n", "\n  "))
+			content.WriteString(d.branchInput.View())
 			content.WriteString("\n")
+			if d.branchPicker != nil && d.branchPicker.IsVisible() {
+				content.WriteString("  ")
+				content.WriteString(strings.ReplaceAll(d.branchPicker.View(), "\n", "\n  "))
+				content.WriteString("\n")
+			}
 		}
-	}
 
-	// Multi-repo toggle (below the fold, UX top-3 #3). Its path list renders
-	// here when enabled; in the common single-repo case it's just a checkbox.
-	content.WriteString("\n")
-	d.renderMultiRepoSection(&content, cur)
-
-	// Tool options panel
-	if d.toolOptions != nil {
+		// Multi-repo toggle (below the fold, UX top-3 #3). Its path list renders
+		// here when enabled; in the common single-repo case it's just a checkbox.
 		content.WriteString("\n")
-		content.WriteString(d.toolOptions.View())
+		d.renderMultiRepoSection(&content, cur)
+
+		// Tool options panel
+		if d.toolOptions != nil {
+			content.WriteString("\n")
+			content.WriteString(d.toolOptions.View())
+		}
 	}
 
 	// Inline validation error
@@ -2769,6 +2925,8 @@ func (d *NewDialog) View() string {
 		} else {
 			helpText = "←→ command │ w worktree │ s sandbox │ Tab next │ ^S create │ Esc cancel"
 		}
+	} else if cur == focusOrchestrator || cur == focusAgent || cur == focusRuntime {
+		helpText = "Tab next │ ^S create │ Esc cancel"
 	} else if cur == focusModel {
 		if d.modelSuggestionActive {
 			helpText = "↑/↓ navigate │ Space/Enter select │ Esc back │ Tab next"

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -164,6 +164,12 @@ const (
 	remoteCreateModeAgentbox
 )
 
+var canonicalAgentboxAgents = map[string]struct{}{
+	"claude-code":  {},
+	"codex":        {},
+	"pi-fireworks": {},
+}
+
 // NewDialog represents the new session creation dialog.
 type NewDialog struct {
 	nameInput             textinput.Model
@@ -371,7 +377,7 @@ func NewNewDialog() *NewDialog {
 	orchestratorInput.CharLimit = 64
 
 	agentInput := textinput.New()
-	agentInput.Placeholder = "claude | codex | pi"
+	agentInput.Placeholder = "claude-code | codex | pi-fireworks"
 	agentInput.CharLimit = 64
 
 	// Optional per-session model/version override for supported tools.
@@ -1393,8 +1399,12 @@ func (d *NewDialog) Validate() string {
 		if strings.TrimSpace(d.orchestratorInput.Value()) == "" {
 			return "Orchestrator is required for Agentbox workspaces"
 		}
-		if strings.TrimSpace(d.agentInput.Value()) == "" {
+		agent := strings.TrimSpace(d.agentInput.Value())
+		if agent == "" {
 			return "Agent is required for Agentbox workspaces"
+		}
+		if _, ok := canonicalAgentboxAgents[agent]; !ok {
+			return "Agent must be exactly one of: claude-code, codex, or pi-fireworks"
 		}
 		if strings.TrimSpace(d.modelInput.Value()) == "" {
 			return "Model ID is required for Agentbox workspaces"
@@ -2933,6 +2943,8 @@ func (d *NewDialog) View() string {
 		} else {
 			helpText = "←→ command │ w worktree │ s sandbox │ Tab next │ ^S create │ Esc cancel"
 		}
+	} else if cur == focusAgent && d.isAgentboxRemoteMode() {
+		helpText = "Use claude-code, codex, or pi-fireworks │ Tab next │ ^S create │ Esc cancel"
 	} else if cur == focusOrchestrator || cur == focusAgent || cur == focusRuntime {
 		helpText = "Tab next │ ^S create │ Esc cancel"
 	} else if cur == focusModel {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -164,12 +164,6 @@ const (
 	remoteCreateModeAgentbox
 )
 
-var canonicalAgentboxAgents = map[string]struct{}{
-	"claude-code":  {},
-	"codex":        {},
-	"pi-fireworks": {},
-}
-
 // NewDialog represents the new session creation dialog.
 type NewDialog struct {
 	nameInput             textinput.Model
@@ -1403,7 +1397,7 @@ func (d *NewDialog) Validate() string {
 		if agent == "" {
 			return "Agent is required for Agentbox workspaces"
 		}
-		if _, ok := canonicalAgentboxAgents[agent]; !ok {
+		if !session.IsCanonicalAgentboxAgent(agent) {
 			return "Agent must be exactly one of: claude-code, codex, or pi-fireworks"
 		}
 		if strings.TrimSpace(d.modelInput.Value()) == "" {

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -4,16 +4,19 @@ import "github.com/asheshgoplani/agent-deck/internal/session"
 
 // Error code constants for API error responses.
 const (
-	ErrCodeUnauthorized     = "UNAUTHORIZED"
-	ErrCodeForbidden        = "MUTATIONS_DISABLED"
-	ErrCodeCSRF             = "CROSS_ORIGIN_BLOCKED"
-	ErrCodeNotFound         = "NOT_FOUND"
-	ErrCodeBadRequest       = "INVALID_REQUEST"
-	ErrCodeMethodNotAllowed = "METHOD_NOT_ALLOWED"
-	ErrCodeRateLimited      = "RATE_LIMITED"
-	ErrCodeInternalError    = "INTERNAL_ERROR"
-	ErrCodeNotImplemented   = "NOT_IMPLEMENTED"
-	ErrCodeReadOnly         = "READ_ONLY"
+	ErrCodeUnauthorized        = "UNAUTHORIZED"
+	ErrCodeForbidden           = "MUTATIONS_DISABLED"
+	ErrCodeCSRF                = "CROSS_ORIGIN_BLOCKED"
+	ErrCodeNotFound            = "NOT_FOUND"
+	ErrCodeBadRequest          = "INVALID_REQUEST"
+	ErrCodeConflict            = "CONFLICT"
+	ErrCodeMethodNotAllowed    = "METHOD_NOT_ALLOWED"
+	ErrCodeRateLimited         = "RATE_LIMITED"
+	ErrCodeInternalError       = "INTERNAL_ERROR"
+	ErrCodeInsufficientStorage = "INSUFFICIENT_STORAGE"
+	ErrCodeNotImplemented      = "NOT_IMPLEMENTED"
+	ErrCodeReadOnly            = "READ_ONLY"
+	ErrCodeServiceUnavailable  = "SERVICE_UNAVAILABLE"
 )
 
 // CreateSessionRequest is the body for POST /api/sessions.

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -18,11 +18,15 @@ const (
 
 // CreateSessionRequest is the body for POST /api/sessions.
 type CreateSessionRequest struct {
-	Title       string `json:"title"`
-	Tool        string `json:"tool"`
-	ProjectPath string `json:"projectPath"`
-	GroupPath   string `json:"groupPath,omitempty"`
-	ModelID     string `json:"modelId,omitempty"`
+	Title        string `json:"title"`
+	Tool         string `json:"tool"`
+	ProjectPath  string `json:"projectPath"`
+	GroupPath    string `json:"groupPath,omitempty"`
+	ModelID      string `json:"modelId,omitempty"`
+	RemoteName   string `json:"remoteName,omitempty"`
+	Orchestrator string `json:"orchestrator,omitempty"`
+	Agent        string `json:"agent,omitempty"`
+	Runtime      string `json:"runtime,omitempty"`
 }
 
 // CreateGroupRequest is the body for POST /api/groups.

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -94,7 +94,7 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 			runner := session.NewRemoteRunner(req.RemoteName, rc)
 			ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 			defer cancel()
-			sessionID, err := runner.CreateSession(ctx, session.RemoteCreateOptions{
+			result, err := runner.CreateSession(ctx, session.RemoteCreateOptions{
 				Tool:         req.Tool,
 				Title:        req.Title,
 				Path:         req.ProjectPath,
@@ -105,10 +105,11 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 				Runtime:      req.Runtime,
 			})
 			if err != nil {
-				writeAPIError(w, remoteCreateStatusCode(err), ErrCodeInternalError, err.Error())
+				status, code := remoteCreateErrorResponse(err)
+				writeAPIError(w, status, code, err.Error())
 				return
 			}
-			writeJSON(w, http.StatusCreated, SessionActionResponse{SessionID: sessionID})
+			writeJSON(w, http.StatusCreated, SessionActionResponse{SessionID: result.SessionID})
 			return
 		}
 		if req.ProjectPath == "" {
@@ -132,25 +133,51 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 	}
 }
 
-func remoteCreateStatusCode(err error) int {
+func remoteCreateErrorResponse(err error) (int, string) {
 	if err == nil {
-		return http.StatusCreated
+		return http.StatusCreated, ErrCodeInternalError
+	}
+	var agentboxErr *session.AgentboxHTTPError
+	if errors.As(err, &agentboxErr) {
+		switch agentboxErr.StatusCode {
+		case http.StatusBadRequest:
+			return http.StatusBadRequest, ErrCodeBadRequest
+		case http.StatusNotFound:
+			return http.StatusNotFound, ErrCodeNotFound
+		case http.StatusConflict:
+			return http.StatusConflict, ErrCodeConflict
+		case http.StatusServiceUnavailable:
+			return http.StatusServiceUnavailable, ErrCodeServiceUnavailable
+		case http.StatusInsufficientStorage:
+			return http.StatusInsufficientStorage, ErrCodeInsufficientStorage
+		default:
+			if agentboxErr.StatusCode > 0 {
+				return agentboxErr.StatusCode, ErrCodeInternalError
+			}
+		}
 	}
 	message := strings.ToLower(err.Error())
 	switch {
 	case strings.Contains(message, "not found"):
-		return http.StatusNotFound
+		return http.StatusNotFound, ErrCodeNotFound
 	case strings.Contains(message, "requires --"),
 		strings.Contains(message, "missing a url"),
 		strings.Contains(message, "invalid agentbox url"),
 		strings.Contains(message, "agentbox rejected the request"):
-		return http.StatusBadRequest
+		return http.StatusBadRequest, ErrCodeBadRequest
+	case strings.Contains(message, "disk budget is exhausted"):
+		return http.StatusInsufficientStorage, ErrCodeInsufficientStorage
+	case strings.Contains(message, "workspace root conflicts"),
+		strings.Contains(message, "rejected the workspace state transition"):
+		return http.StatusConflict, ErrCodeConflict
 	case strings.Contains(message, "workspace is "),
 		strings.Contains(message, "workspace runtime is unavailable"),
+		strings.Contains(message, "workspace root is unconfigured"),
+		strings.Contains(message, "workspace is unavailable"),
 		strings.Contains(message, "workspaces are unavailable"):
-		return http.StatusBadGateway
+		return http.StatusServiceUnavailable, ErrCodeServiceUnavailable
 	default:
-		return http.StatusInternalServerError
+		return http.StatusInternalServerError, ErrCodeInternalError
 	}
 }
 

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -1,12 +1,14 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -64,6 +66,51 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "title is required")
 			return
 		}
+		if req.RemoteName != "" {
+			config, err := session.LoadUserConfig()
+			if err != nil {
+				writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, "failed to load remote config")
+				return
+			}
+			if config == nil || config.Remotes == nil {
+				writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, fmt.Sprintf("remote '%s' not found", req.RemoteName))
+				return
+			}
+			rc, ok := config.Remotes[req.RemoteName]
+			if !ok {
+				writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, fmt.Sprintf("remote '%s' not found", req.RemoteName))
+				return
+			}
+			if rc.GetKind() == session.RemoteKindAgentbox {
+				if req.Orchestrator == "" || req.Agent == "" || req.ModelID == "" || req.Runtime == "" {
+					writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "agentbox create requires title, orchestrator, agent, modelId, and runtime")
+					return
+				}
+			} else if req.ProjectPath == "" {
+				writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "projectPath is required")
+				return
+			}
+
+			runner := session.NewRemoteRunner(req.RemoteName, rc)
+			ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+			defer cancel()
+			sessionID, err := runner.CreateSession(ctx, session.RemoteCreateOptions{
+				Tool:         req.Tool,
+				Title:        req.Title,
+				Path:         req.ProjectPath,
+				Group:        req.GroupPath,
+				ModelID:      req.ModelID,
+				Orchestrator: req.Orchestrator,
+				Agent:        req.Agent,
+				Runtime:      req.Runtime,
+			})
+			if err != nil {
+				writeAPIError(w, remoteCreateStatusCode(err), ErrCodeInternalError, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusCreated, SessionActionResponse{SessionID: sessionID})
+			return
+		}
 		if req.ProjectPath == "" {
 			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "projectPath is required")
 			return
@@ -82,6 +129,28 @@ func (s *Server) handleSessionsCollection(w http.ResponseWriter, r *http.Request
 
 	default:
 		writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
+	}
+}
+
+func remoteCreateStatusCode(err error) int {
+	if err == nil {
+		return http.StatusCreated
+	}
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "not found"):
+		return http.StatusNotFound
+	case strings.Contains(message, "requires --"),
+		strings.Contains(message, "missing a url"),
+		strings.Contains(message, "invalid agentbox url"),
+		strings.Contains(message, "agentbox rejected the request"):
+		return http.StatusBadRequest
+	case strings.Contains(message, "workspace is "),
+		strings.Contains(message, "workspace runtime is unavailable"),
+		strings.Contains(message, "workspaces are unavailable"):
+		return http.StatusBadGateway
+	default:
+		return http.StatusInternalServerError
 	}
 }
 

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -339,6 +339,104 @@ func TestSessionsCollectionPOSTRemoteAgentboxRequiresExplicitFields(t *testing.T
 	}
 }
 
+func TestSessionsCollectionPOSTRemoteAgentboxMapsCreateFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "root conflict",
+			statusCode: http.StatusConflict,
+			body:       `{"error":"workspace_root_conflict"}`,
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "disk exhausted",
+			statusCode: http.StatusConflict,
+			body:       `{"error":"workspace_disk_exhausted"}`,
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "root unconfigured",
+			statusCode: http.StatusServiceUnavailable,
+			body:       `{"error":"workspace_root_unconfigured"}`,
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "workspace unavailable",
+			statusCode: http.StatusServiceUnavailable,
+			body:       `{"error":"workspace_unavailable"}`,
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "runtime unavailable",
+			statusCode: http.StatusServiceUnavailable,
+			body:       `{"error":"workspace_runtime_unavailable"}`,
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "invalid request",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_request","message":"bad input"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid state",
+			statusCode: http.StatusConflict,
+			body:       `{"error":"invalid_state","message":"workspace is already destroying"}`,
+			wantStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			t.Setenv("HOME", tempDir)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, ".config"))
+			t.Setenv("XDG_DATA_HOME", filepath.Join(tempDir, ".local", "share"))
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(tempDir, ".cache"))
+			session.ClearUserConfigCache()
+			t.Cleanup(session.ClearUserConfigCache)
+
+			agentbox := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer agentbox.Close()
+
+			if err := session.SaveUserConfig(&session.UserConfig{
+				Remotes: map[string]session.RemoteConfig{
+					"lab": {Kind: session.RemoteKindAgentbox, URL: agentbox.URL},
+				},
+			}); err != nil {
+				t.Fatalf("SaveUserConfig: %v", err)
+			}
+
+			srv := NewServer(Config{
+				ListenAddr:   "127.0.0.1:0",
+				WebMutations: true,
+			})
+			srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+			body := strings.NewReader(`{"remoteName":"lab","title":"Research One","projectPath":"/srv/research","orchestrator":"wisp","agent":"pi-fireworks","modelId":"accounts/fireworks/models/glm-5p2","runtime":"docker"}`)
+			req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+			if strings.Contains(rr.Body.String(), ErrCodeInternalError) {
+				t.Fatalf("response should not fall back to INTERNAL_ERROR for %s: %s", tc.name, rr.Body.String())
+			}
+		})
+	}
+}
+
 func TestSessionsCollectionPOSTNilMutatorReturns503(t *testing.T) {
 	srv := NewServer(Config{
 		ListenAddr:   "127.0.0.1:0",

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -236,6 +237,105 @@ func TestSessionsCollectionPOSTForwardsModelID(t *testing.T) {
 	}
 	if gotModel != "claude-sonnet-4-6" {
 		t.Fatalf("modelID = %q, want %q", gotModel, "claude-sonnet-4-6")
+	}
+}
+
+func TestSessionsCollectionPOSTRemoteAgentboxCreatesWorkspace(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tempDir, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tempDir, ".cache"))
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	var payload map[string]string
+	agentbox := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces" {
+			t.Fatalf("unexpected remote request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ws-remote"})
+	}))
+	defer agentbox.Close()
+
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Remotes: map[string]session.RemoteConfig{
+			"lab": {Kind: session.RemoteKindAgentbox, URL: agentbox.URL},
+		},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	body := strings.NewReader(`{"remoteName":"lab","title":"Research One","projectPath":"/srv/research","orchestrator":"wisp","agent":"pi-fireworks","modelId":"accounts/fireworks/models/glm-5p2","runtime":"docker"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "ws-remote") {
+		t.Fatalf("response = %s, want workspace id", rr.Body.String())
+	}
+	want := map[string]string{
+		"name":         "Research One",
+		"cwd":          "/srv/research",
+		"orchestrator": "wisp",
+		"agent":        "pi-fireworks",
+		"model":        "accounts/fireworks/models/glm-5p2",
+		"runtime":      "docker",
+	}
+	for key, wantValue := range want {
+		if payload[key] != wantValue {
+			t.Fatalf("payload[%q] = %q, want %q (payload=%#v)", key, payload[key], wantValue, payload)
+		}
+	}
+}
+
+func TestSessionsCollectionPOSTRemoteAgentboxRequiresExplicitFields(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tempDir, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tempDir, ".cache"))
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Remotes: map[string]session.RemoteConfig{
+			"lab": {Kind: session.RemoteKindAgentbox, URL: "http://127.0.0.1:1"},
+		},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	body := strings.NewReader(`{"remoteName":"lab","title":"Research One","orchestrator":"wisp","agent":"pi-fireworks"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "agentbox create requires") {
+		t.Fatalf("response = %s, want explicit-fields guidance", rr.Body.String())
 	}
 }
 

--- a/tests/web/PARITY_MATRIX.md
+++ b/tests/web/PARITY_MATRIX.md
@@ -17,7 +17,7 @@ Every keyboard action in the TUI that mutates state or navigates must have a web
 | Action | TUI Trigger | Web Endpoint | Mutator Method | Test | Notes |
 |--------|-------------|--------------|-----------------|------|-------|
 | **SESSION LIFECYCLE** |
-| Create session | `internal/ui/home.go:6179` (`n` key) | POST `/api/sessions` | `CreateSession` | `handlers_sessions_test.go` | NewDialog spawns, initiates session creation |
+| Create session | `internal/ui/home.go:6179` (`n` key) | POST `/api/sessions` | `CreateSession` | `handlers_sessions_test.go` | NewDialog spawns, initiates session creation. Remote Agentbox creation requires `remoteName`, `title`, `orchestrator`, `agent`, `modelId`, and `runtime`; SSH creation requires `remoteName` and `projectPath`. |
 | Quick create session | `internal/ui/home.go:6286` (`N` key) | POST `/api/sessions` | `CreateSession` | `handlers_sessions_test.go` | Auto-generated name, smart group context |
 | Start session | `internal/ui/home.go:6284` (via dialog/menu) | POST `/api/sessions/{id}/start` | `StartSession` | `handlers_sessions_test.go` | Resumes stopped/idle session |
 | Stop session | `internal/ui/home.go:6284` (via dialog/menu) | POST `/api/sessions/{id}/stop` | `StopSession` | `handlers_sessions_test.go` | Kills running tmux session |


### PR DESCRIPTION
## What problem does this solve?

Deleting a running AgentBox Workspace from Agent Deck does not remove it. The
delete request is rejected by AgentBox, so the Workspace remains visible in the
remote session list.

## Why this change

AgentBox requires `force: true` when destroying a running Workspace. Agent
Deck already treats its delete action as the destructive operation, so the
AgentBox adapter should send the force flag instead of asking the API to reject
the request. Stopped Workspaces continue through the same idempotent destroy
endpoint.

## User impact

Deleting a running AgentBox Workspace from the Agent Deck TUI now destroys the
isolated Workspace and removes it from the remote list on the next refresh.

## Evidence

Before the fix, the exact request sent by Agent Deck returned:

    POST /v1/workspaces/abae9c16-e390-4d3d-8ebe-7fdf2583712d/destroy
    {"force":false}
    409 {"error":"workspace_running"}

The regression test fails with the old payload and passes with the fix:

    go test ./internal/session -run TestAgentboxRunnerDeleteSessionForcesRunningWorkspaceDestroy -count=1
    ok

Focused AgentBox/session, web, UI, and build checks also pass. The full
sandboxed suite was attempted but currently hits the unrelated existing
`TestLogCgroupIsolationDecision_WiredIntoBootstrap/tui_startup_emits_line`
failure because its `debug.log` is missing.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

## What actually bothered you

Alex asked: “When I delete environments here, they don't seem to go away right away.”

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] “Allow edits from maintainers” is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agentbox remote kind support, including `remote create`, kind-aware `remote add`, workspace/session creation, and kind-aware attachment commands.
  * Remote session listings now include the remote kind in JSON and show the correct target column; Shift+Enter attachment uses fresh Agentbox attach commands.
  * Expanded the new-workspace dialog for Agentbox with explicit orchestrator/agent/model/runtime inputs and stricter validation.
* **Bug Fixes**
  * Improved remote session/rename/update behavior to be remote-kind aware, including Agentbox “no update needed”.
  * `AttachRequest` now honors an explicit command override.
* **Tests**
  * Added/expanded coverage across CLI, UI, session runners, and web API for Agentbox create/list/attach flows and error mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->