### PR TITLE
fix(ui): isolate SGR state across incremental row repaints

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -14153,6 +14153,10 @@ func clampViewToViewport(content string, width, height int) string {
 		}
 	}
 
+	const sgrReset = "\x1b[0m"
+	var rendered strings.Builder
+	rendered.Grow(len(content) + len(lines)*2*len(sgrReset))
+
 	for i, line := range lines {
 		// #937 v2: cellWidth/cellTruncate (not ansi.*) so this final
 		// viewport-clamp safety net sees keycap clusters at their true
@@ -14166,10 +14170,24 @@ func clampViewToViewport(content string, width, height int) string {
 		// glyphs — the iTerm2 "ghost line" artifact on session-list scroll
 		// (#607 row-offset drift). fitCellWidth does both, on cellWidth so
 		// this post-join clamp stays a true terminal-cell net.
-		lines[i] = fitCellWidth(line, width)
+		//
+		// #699 follow-up: isolate SGR state at BOTH row boundaries. Bubble
+		// Tea's incremental renderer skips unchanged rows and repaints only
+		// changed ones. A captured preview background can therefore still be
+		// active when a later row starts rendering, even though the original
+		// fix appended a reset to every preview line. Prefixing and suffixing
+		// the final physical rows makes repaint order irrelevant. SGR resets
+		// occupy zero terminal cells, so the exact viewport dimensions are
+		// unchanged.
+		if i > 0 {
+			rendered.WriteByte('\n')
+		}
+		rendered.WriteString(sgrReset)
+		rendered.WriteString(fitCellWidth(line, width))
+		rendered.WriteString(sgrReset)
 	}
 
-	return strings.Join(lines, "\n")
+	return rendered.String()
 }
 
 // ensureExactWidth ensures each line in content has exactly the specified visual width.

--- a/internal/ui/preview_ansi_bleed_test.go
+++ b/internal/ui/preview_ansi_bleed_test.go
@@ -114,3 +114,29 @@ func TestPreviewPane_TruncatedLineDoesNotLeakSGRState_Issue699(t *testing.T) {
 		}
 	}
 }
+
+// Regression for the incremental-rendering variant of #699. The original fix
+// closed SGR state at the end of each preview line, which makes a complete
+// frame safe. Bubble Tea can skip unchanged rows, however, and later repaint a
+// different row while the terminal still carries an SGR background from a
+// captured preview line. Every final physical row must therefore start from
+// default SGR state as well as leave it in default state.
+func TestClampViewToViewport_ResetsEveryPhysicalRowAtBothBoundaries_Issue699(t *testing.T) {
+	rendered := clampViewToViewport(
+		"plain row\n\x1b[48;5;22mgreen diff row without captured reset",
+		80,
+		2,
+	)
+
+	for i, row := range strings.Split(rendered, "\n") {
+		if !strings.HasPrefix(row, "\x1b[0m") {
+			t.Fatalf("row %d has no leading SGR reset — incremental repaint can inherit preview background\nrow=%q", i, row)
+		}
+		if !strings.HasSuffix(row, "\x1b[0m") {
+			t.Fatalf("row %d has no trailing SGR reset — next incremental repaint can inherit preview background\nrow=%q", i, row)
+		}
+		if sgrActiveAt(row) {
+			t.Fatalf("row %d leaves SGR active at its boundary\nrow=%q", i, row)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Captured diff backgrounds can still leak from the right PREVIEW pane into rows
of the left SESSIONS pane during incremental redraws. This is a follow-up to
#699, which fixed complete-frame row endings but not this incremental repaint
variant.

## Why this change

The original #699 fix appends an SGR reset to each preview line. That makes the
composed frame safe at newline boundaries, but Bubble Tea skips unchanged rows
and repaints only changed rows. A row repaint can therefore begin while the
terminal still carries a captured preview background.

This change isolates every final physical viewport row at both boundaries:
one reset before its first cell and one after its last cell. It does this in
the final viewport builder, after width clamping, so it covers every layout and
does not change terminal-cell dimensions.

## User impact

Green/red diff highlights and highlighted prompt rows remain visible in the
preview, but no longer paint blank space or session rows in the left sidebar
during live updates.

## Evidence

Reproduced with Agent Deck v1.10.10 in iTerm2 over SSH, with the persistent
console wrapped in tmux using `AGENT_DECK_ALLOW_OUTER_TMUX=1`. The selected
remote preview contained an unclosed 256-color green diff background.

Before the fix, a 15-second tmux cell-state probe caught the preview background
before the pane separator:

    ESC[38;5;231m ESC[48;5;22m    ▾ remotes/bento ... ESC[49m ... │ fern-cliff

That `ESC[48;5;22m` occurs in the left-side portion of the row. The visual
result was a bright green band across the SESSIONS pane.

With the fix, the same live preview at 197x56 retained green diff backgrounds
in the right pane and produced zero left-side background hits over 20 seconds.
The optimized installed build was then restarted in the persistent console and
remained clean during incremental updates.

Regression test:

    go test ./internal/ui -run 'Issue699|Test_clampViewToViewport_PadsEveryRow' -count=1
    ok github.com/asheshgoplani/agent-deck/internal/ui

    go test -tags eval_smoke ./internal/ui -run Issue699 -count=1
    ok github.com/asheshgoplani/agent-deck/internal/ui

Revert-check: with the production hunk absent, the new test fails:

    row 0 has no leading SGR reset — incremental repaint can inherit preview background

Hot-path benchmark, 56x197 ANSI frame, five runs:

- upstream median: about 247.5 µs/op, 2 allocs/op
- fixed median: about 241.1 µs/op, 2 allocs/op

The full `internal/ui` package also passed in the repository-wide run. The
complete repository run had unrelated host-sensitive tmux/session performance
failures on this shared server, so the full-suite checklist remains unchecked.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human reported: "there's still issues of the diff green/red leaking on the
left sidebar" and asked me to install the verified fix, open a PR, and update
#699 because it had previously been marked fixed.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styled preview rendering so ANSI colors and backgrounds no longer bleed between rows during incremental updates.
  * Prevented styling artifacts from causing viewport or table layout drift.

* **Tests**
  * Added coverage to verify that every rendered row starts and ends with a clean styling state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->