### PR TITLE
fix(tmux): prefer pane command for runtime tool detection

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3159,6 +3159,24 @@ func (s *Session) DetectTool() string {
 		return tool
 	}
 
+	// Everything below is a promotion-only signal. tmux reports the pane's
+	// foreground process, which is frequently a child the agent spawned for a
+	// tool call (see AnalyzePaneTitle), and pane content routinely names other
+	// tools in ordinary conversation. Neither signal can tell "a different
+	// runtime is in charge now" apart from "the same runtime is running a
+	// subprocess", so they may only give a runtime identity to a session that
+	// has none yet ("" or "shell"). They never replace one that was already
+	// recognized. Cross-runtime switching needs a durable process-root identity
+	// rather than a single foreground sample (#1718). ForceDetectTool clears the
+	// previous detection, so an explicit re-detect still runs the full sequence.
+	s.mu.Lock()
+	if previous := s.detectedTool; previous != "" && previous != "shell" {
+		s.toolDetectedAt = time.Now()
+		s.mu.Unlock()
+		return previous
+	}
+	s.mu.Unlock()
+
 	// A session created as "shell" can later launch a supported tool. Prefer the
 	// pane's current command over terminal content so conversation text that
 	// mentions another tool cannot rewrite the running tool's identity.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3159,6 +3159,19 @@ func (s *Session) DetectTool() string {
 		return tool
 	}
 
+	// A session created as "shell" can later launch a supported tool. Prefer the
+	// pane's current command over terminal content so conversation text that
+	// mentions another tool cannot rewrite the running tool's identity.
+	if paneInfo, ok := GetCachedPaneInfo(s.Name); ok {
+		if tool := detectToolFromCommand(paneInfo.CurrentCommand); tool != "" {
+			s.mu.Lock()
+			s.detectedTool = tool
+			s.toolDetectedAt = time.Now()
+			s.mu.Unlock()
+			return tool
+		}
+	}
+
 	// Fallback to content detection
 	content, err := s.CapturePane()
 	if err != nil {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -559,29 +559,71 @@ func TestDetectTool(t *testing.T) {
 	}
 }
 
-func TestDetectToolPrefersPaneCommandOverConversationContent(t *testing.T) {
-	sess := NewSession("tool-detection-precedence", "/tmp")
-	sess.Command = "shell"
-	sess.cacheContent = "A Gemini API key can be used for image generation."
-	sess.cacheTime = time.Now()
+// seedPaneCommand installs a fresh pane-info cache entry reporting cmd as the
+// session's tmux foreground command, restoring the previous cache on cleanup.
+func seedPaneCommand(t *testing.T, sessionName, cmd string) {
+	t.Helper()
 
 	paneCacheMu.Lock()
 	previousData := paneCacheData
 	previousTime := paneCacheTime
 	paneCacheData = map[string]PaneInfo{
-		sess.Name: {CurrentCommand: "claude"},
+		sessionName: {CurrentCommand: cmd},
 	}
 	paneCacheTime = time.Now()
 	paneCacheMu.Unlock()
+
 	t.Cleanup(func() {
 		paneCacheMu.Lock()
 		paneCacheData = previousData
 		paneCacheTime = previousTime
 		paneCacheMu.Unlock()
 	})
+}
+
+func TestDetectToolPrefersPaneCommandOverConversationContent(t *testing.T) {
+	sess := NewSession("tool-detection-precedence", "/tmp")
+	sess.Command = "shell"
+	sess.cacheContent = "A Gemini API key can be used for image generation."
+	sess.cacheTime = time.Now()
+
+	seedPaneCommand(t, sess.Name, "claude")
 
 	if got := sess.DetectTool(); got != "claude" {
 		t.Fatalf("DetectTool() = %q, want %q when pane command identifies the running tool", got, "claude")
+	}
+}
+
+// A recognized runtime must survive detection-cache expiry: tmux reports the
+// child process Claude spawned for a tool call as the foreground command, so a
+// single `codex` sample must not relabel the session.
+func TestDetectToolKeepsRecognizedRuntimeWhenPaneCommandIsChildTool(t *testing.T) {
+	sess := NewSession("tool-detection-child-command", "/tmp")
+	sess.Command = "shell"
+	sess.detectedTool = "claude"
+	sess.toolDetectedAt = time.Now().Add(-time.Hour) // detection cache expired
+
+	seedPaneCommand(t, sess.Name, "codex")
+
+	if got := sess.DetectTool(); got != "claude" {
+		t.Fatalf("DetectTool() = %q, want %q when a recognized runtime runs another tool as a child", got, "claude")
+	}
+}
+
+// Same guard for the content fallback: an unrecognized foreground command must
+// not open the door for conversation text to relabel a recognized runtime.
+func TestDetectToolKeepsRecognizedRuntimeWhenContentMentionsOtherTool(t *testing.T) {
+	sess := NewSession("tool-detection-child-shell", "/tmp")
+	sess.Command = "shell"
+	sess.detectedTool = "claude"
+	sess.toolDetectedAt = time.Now().Add(-time.Hour) // detection cache expired
+	sess.cacheContent = "A Gemini API key can be used for image generation."
+	sess.cacheTime = time.Now()
+
+	seedPaneCommand(t, sess.Name, "bash")
+
+	if got := sess.DetectTool(); got != "claude" {
+		t.Fatalf("DetectTool() = %q, want %q when pane content merely mentions another tool", got, "claude")
 	}
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -559,6 +559,32 @@ func TestDetectTool(t *testing.T) {
 	}
 }
 
+func TestDetectToolPrefersPaneCommandOverConversationContent(t *testing.T) {
+	sess := NewSession("tool-detection-precedence", "/tmp")
+	sess.Command = "shell"
+	sess.cacheContent = "A Gemini API key can be used for image generation."
+	sess.cacheTime = time.Now()
+
+	paneCacheMu.Lock()
+	previousData := paneCacheData
+	previousTime := paneCacheTime
+	paneCacheData = map[string]PaneInfo{
+		sess.Name: {CurrentCommand: "claude"},
+	}
+	paneCacheTime = time.Now()
+	paneCacheMu.Unlock()
+	t.Cleanup(func() {
+		paneCacheMu.Lock()
+		paneCacheData = previousData
+		paneCacheTime = previousTime
+		paneCacheMu.Unlock()
+	})
+
+	if got := sess.DetectTool(); got != "claude" {
+		t.Fatalf("DetectTool() = %q, want %q when pane command identifies the running tool", got, "claude")
+	}
+}
+
 func TestDetectToolFromCommand(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## What problem does this solve?

A shell-launched Claude session can be relabeled as Gemini or Codex when its
conversation merely mentions those tools. Fixes #1718.

## Why this change

`Session.DetectTool()` already prefers the configured launch command, but a
session created as `shell` has no tool identity there. It then falls through to
pane-content regexes, where broad markers such as `gemini` can match ordinary
conversation text.

The tmux pane-info cache already records `pane_current_command`. This change
consults that cached command before pane content. An identified foreground tool
is authoritative; content remains the fallback for wrappers and other cases
where the command is not recognizable. No additional tmux subprocess or poll is
introduced.

## User impact

Sessions launched from an Agent Deck shell retain the identity of the tool that
is actually running. Discussing Gemini or Codex inside Claude no longer changes
the session label or tool-specific behavior.

## Evidence

Live reproduction on v1.10.10:

```text
Agent Deck persisted tool: gemini
tmux pane_current_command: claude
direct process tree: shell -> claude
recent pane text: contained "Gemini API key"
```

After installing this branch against the same still-running session and the same
retained conversation:

```json
{
  "title": "fern-cliff",
  "tool": "claude",
  "tmux_session": "agentdeck_fern-cliff_10b03bf2"
}
```

```text
$ tmux display-message -p -t agentdeck_fern-cliff_10b03bf2 '#{pane_current_command}'
claude
```

Regression test:

```text
# Fix reverted
--- FAIL: TestDetectToolPrefersPaneCommandOverConversationContent
DetectTool() = "gemini", want "claude" when pane command identifies the running tool

# Fix restored
ok github.com/asheshgoplani/agent-deck/internal/tmux 0.027s
```

Validation:

```text
go test ./internal/tmux -count=1
ok github.com/asheshgoplani/agent-deck/internal/tmux 26.629s

go vet ./...
ok
```

Hot-path check: the reverted focused run took 0.030s and the fixed run took
0.027s (single runs, dominated by test startup). The implementation adds only a
read from the existing pane cache and does not spawn a process.

The repository-wide sandboxed suite was also attempted. It reached unrelated
existing failures in `internal/session` and performance-budget tests, so the
full-suite checklist item is intentionally left unchecked; the changed package
and repository-wide vet both pass.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "I think 2 (misclassification) could be the most interesting
for us. bento is now mapped as 'gemini' even tho I'm still inside a claude??"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool detection accuracy by using the currently running pane command ahead of terminal conversation text.
  * Prevented previously recognized tools from being overwritten by unrelated content, even when pane commands differ (while honoring cache freshness).
* **Tests**
  * Added unit tests covering precedence between pane command and conversation content, plus cache behavior to ensure recognized tools remain stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->