### PR TITLE
fix(tmux): treat client/server protocol version mismatch as alive, not a dead session

### DIFF
--- a/internal/tmux/exists_mismatch_verdict_test.go
+++ b/internal/tmux/exists_mismatch_verdict_test.go
@@ -166,8 +166,16 @@ func TestSession_Exists_ClassificationIsAmortizedAcrossSessionsOnASocket(t *test
 	resetSocketMismatchCacheForTest()
 	t.Cleanup(resetSocketMismatchCacheForTest)
 
+	// Unique names: Exists() short-circuits on a live PipeManager connection, and
+	// that manager is package-level state shared with every other test in
+	// internal/tmux. A generic name that a sibling test happens to register would
+	// skip the subprocess probe and break the count below for an unrelated reason.
 	const socket = "agent-deck-amortized-test"
-	for _, name := range []string{"alpha", "beta", "gamma"} {
+	for _, name := range []string{
+		"agent-deck-amortized-alpha",
+		"agent-deck-amortized-beta",
+		"agent-deck-amortized-gamma",
+	} {
 		s := &Session{Name: name, SocketName: socket}
 		if !s.Exists() {
 			t.Fatalf("Exists() reported %q gone on a mismatched socket; a refusal from the "+

--- a/internal/tmux/exists_mismatch_verdict_test.go
+++ b/internal/tmux/exists_mismatch_verdict_test.go
@@ -1,0 +1,297 @@
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The tests in this file cover the OUT-OF-BAND half of the protocol-mismatch
+// fix: the liveness probes stay on cmd.Run() with no stdio to capture, and the
+// one exchange that must read tmux's error text to classify it is settled once
+// per socket per TTL.
+//
+// Why that split matters, and why these tests assert on timing: socket.go
+// documents the EOF hang where a forked child of tmux inherits the subprocess's
+// output descriptors and never closes them (the tmux server's terminal
+// pass-through dups under bridged stdio — Claude Code /remote-control, ssh
+// ControlMaster). cmd.Output()/CombinedOutput() then wait for an EOF that never
+// arrives, bounded only by cmd.WaitDelay (tmuxSubprocessWaitDelay = 2s). Doing
+// that capture inside Session.Exists() would put up to 2s on the status hot
+// path, per probe. Run() with nil stdio has no pipe and no copy goroutine, so
+// there is nothing to wait for at all.
+
+// TestSocketHasProtocolMismatch_ClassifiesOncePerSocketPerTTL pins the caching
+// contract: the verdict is a property of the client/server binary pair, so it is
+// settled once per socket and reused, and two sockets never share a verdict.
+func TestSocketHasProtocolMismatch_ClassifiesOncePerSocketPerTTL(t *testing.T) {
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	t.Cleanup(setSocketMismatchProbeForTest(func(socket string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		calls[socket]++
+		return socket == "mismatched-socket"
+	}))
+
+	for i := 0; i < 5; i++ {
+		if !socketHasProtocolMismatch("mismatched-socket") {
+			t.Fatalf("call %d: mismatched socket reported as matching", i)
+		}
+		if socketHasProtocolMismatch("healthy-socket") {
+			t.Fatalf("call %d: healthy socket reported as mismatched", i)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls["mismatched-socket"] != 1 || calls["healthy-socket"] != 1 {
+		t.Fatalf("classifier ran %v; want exactly 1 per socket within the TTL — "+
+			"a per-probe classification is what put a stdio capture on the hot path",
+			calls)
+	}
+}
+
+// TestSocketHasProtocolMismatch_SingleFlightsConcurrentCallers guards the burst
+// case: every session on a wedged socket reads "gone" at the same time on a
+// status pass, and that burst must cost ONE classification, not one per session.
+func TestSocketHasProtocolMismatch_SingleFlightsConcurrentCallers(t *testing.T) {
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
+
+	var mu sync.Mutex
+	calls := 0
+	release := make(chan struct{})
+	t.Cleanup(setSocketMismatchProbeForTest(func(string) bool {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		<-release // hold the winner inside the probe so the losers must queue
+		return true
+	}))
+
+	const callers = 16
+	var wg sync.WaitGroup
+	verdicts := make([]bool, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			verdicts[i] = socketHasProtocolMismatch("busy-socket")
+		}(i)
+	}
+	// Give the goroutines time to pile up on the single-flight lock, then let the
+	// in-flight classification finish.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("classifier ran %d times for %d concurrent callers on one socket; want 1", got, callers)
+	}
+	for i, v := range verdicts {
+		if !v {
+			t.Fatalf("caller %d got verdict false; every caller must see the single-flighted result", i)
+		}
+	}
+}
+
+// TestSocketHasProtocolMismatch_ReclassifiesAfterTTL is the other half of the
+// caching contract: a stale verdict must not pin a socket forever. The direction
+// that matters is a mismatch appearing while "no mismatch" is still cached —
+// sessions there read gone until the entry expires.
+func TestSocketHasProtocolMismatch_ReclassifiesAfterTTL(t *testing.T) {
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
+
+	var mu sync.Mutex
+	calls := 0
+	mismatched := false
+	t.Cleanup(setSocketMismatchProbeForTest(func(string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return mismatched
+	}))
+
+	if socketHasProtocolMismatch("aging-socket") {
+		t.Fatal("first classification should report no mismatch")
+	}
+
+	// Age the entry past the TTL, then flip what the classifier would say.
+	socketMismatchMu.Lock()
+	aged := socketMismatchCache["aging-socket"]
+	aged.checkedAt = time.Now().Add(-2 * socketMismatchCacheTTL)
+	socketMismatchCache["aging-socket"] = aged
+	socketMismatchMu.Unlock()
+	mu.Lock()
+	mismatched = true
+	mu.Unlock()
+
+	if !socketHasProtocolMismatch("aging-socket") {
+		t.Fatal("expired entry was reused; a mismatch that appears later must be picked up")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("classifier ran %d times; want 2 (once before the TTL, once after)", calls)
+	}
+}
+
+// TestSession_Exists_ClassificationIsAmortizedAcrossSessionsOnASocket is the
+// same contract observed through the real code path, with a fake tmux recording
+// every subcommand: N sessions on a mismatched socket cost N cheap has-session
+// probes and ONE classification.
+func TestSession_Exists_ClassificationIsAmortizedAcrossSessionsOnASocket(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "calls.log")
+	// Fake tmux: every invocation refuses with tmux's real mismatch text, as a
+	// too-old client does for every command on that socket.
+	writeFakeTmux(t, dir, "printf '%s\\n' \"$*\" >> "+shellQuote(log)+"\n"+
+		"echo 'protocol version mismatch (client 8, server 7)' >&2\n"+
+		"exit 1\n")
+
+	restoreTimeout := hasSessionProbeTimeout
+	hasSessionProbeTimeout = 2 * time.Second
+	t.Cleanup(func() { hasSessionProbeTimeout = restoreTimeout })
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
+
+	const socket = "agent-deck-amortized-test"
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		s := &Session{Name: name, SocketName: socket}
+		if !s.Exists() {
+			t.Fatalf("Exists() reported %q gone on a mismatched socket; a refusal from the "+
+				"server is not evidence of absence", name)
+		}
+	}
+
+	recorded, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read fake tmux log: %v", err)
+	}
+	var hasSession, listSessions int
+	for _, line := range strings.Split(strings.TrimSpace(string(recorded)), "\n") {
+		switch {
+		case strings.Contains(line, "has-session"):
+			hasSession++
+		case strings.Contains(line, "list-sessions"):
+			listSessions++
+		}
+	}
+	if hasSession != 3 {
+		t.Fatalf("saw %d has-session probes, want 3 (one per session)", hasSession)
+	}
+	if listSessions != 1 {
+		t.Fatalf("saw %d classification probes for 3 sessions on one socket, want 1: %s",
+			listSessions, string(recorded))
+	}
+}
+
+// TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors is the
+// end-to-end budget regression. Every tmux invocation here orphans a child that
+// inherits the subprocess's output descriptors and holds them well past tmux's
+// own exit — the bridged-stdio pattern socket.go documents, and the reason
+// eval_smoke's TestEval_Session_StatusUnderBridgedStdio_NoHang exists.
+//
+// In the same build it also pins the two verdicts, so a fix for the hang cannot
+// quietly trade away the classification it was added for: a live session still
+// reads true, a genuine mismatch still reads indeterminate (true), and an
+// authoritative "can't find session" still reads false.
+func TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors(t *testing.T) {
+	// Half of tmuxSubprocessWaitDelay: comfortably above two shell forks even on
+	// a loaded CI runner, and strictly below the drain any pipe-backed capture
+	// would pay here. It is deliberately expressed against that constant — the
+	// point of the assertion is "no stdio drain", not a wall-clock number.
+	//
+	// This budget applies to EVERY case, including the two that classify the
+	// socket. The classification is out of band and amortized, but it still runs
+	// on the caller's goroutine, so it captures tmux's stderr into an *os.File
+	// rather than a pipe and has nothing to drain either.
+	budget := tmuxSubprocessWaitDelay / 2
+
+	cases := []struct {
+		name       string
+		reply      string // shell emitting tmux's stderr text
+		exit       string
+		wantExists bool
+	}{
+		{
+			name:       "live session",
+			reply:      "",
+			exit:       "exit 0\n",
+			wantExists: true,
+		},
+		{
+			name:       "protocol version mismatch",
+			reply:      "echo 'protocol version mismatch (client 8, server 7)' >&2\n",
+			exit:       "exit 1\n",
+			wantExists: true,
+		},
+		{
+			name:       "authoritative absence",
+			reply:      "echo \"can't find session: leaky\" >&2\n",
+			exit:       "exit 1\n",
+			wantExists: false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// `sleep 30 &` inherits this script's stdout/stderr and keeps them open
+			// for 30s — far longer than tmuxSubprocessWaitDelay — so any pipe-backed
+			// capture in the code under test blocks on an EOF that never comes.
+			writeFakeTmux(t, dir, "sleep 30 &\n"+c.reply+c.exit)
+
+			restoreTimeout := hasSessionProbeTimeout
+			hasSessionProbeTimeout = 2 * time.Second
+			t.Cleanup(func() { hasSessionProbeTimeout = restoreTimeout })
+			resetSocketMismatchCacheForTest()
+			t.Cleanup(resetSocketMismatchCacheForTest)
+
+			s := &Session{
+				Name:       "leaky",
+				SocketName: "agent-deck-leaky-test-" + itoa(i),
+			}
+
+			start := time.Now()
+			got := s.Exists()
+			elapsed := time.Since(start)
+
+			if got != c.wantExists {
+				t.Fatalf("Exists() = %v, want %v", got, c.wantExists)
+			}
+			if elapsed > budget {
+				t.Fatalf("Exists() took %v, over its %v budget, while a child held the "+
+					"output descriptors — liveness must not depend on that child closing them",
+					elapsed, budget)
+			}
+		})
+	}
+}
+
+// writeFakeTmux drops an executable `tmux` shim in dir and puts dir first on
+// PATH for the duration of the test. body is /bin/sh.
+func writeFakeTmux(t *testing.T, dir, body string) {
+	t.Helper()
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// shellQuote single-quotes s for embedding in the /bin/sh shims above.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/tmux/exists_protocol_mismatch_test.go
+++ b/internal/tmux/exists_protocol_mismatch_test.go
@@ -1,0 +1,103 @@
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestIsTmuxProtocolMismatch is a pure classification test for the tmux
+// "protocol version mismatch" signal (case-insensitive, substring match), and
+// confirms unrelated failures are not misclassified.
+func TestIsTmuxProtocolMismatch(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"canonical", "protocol version mismatch (client 8, server 7)", true},
+		{"uppercased", "PROTOCOL VERSION MISMATCH (client 8, server 7)", true},
+		{"embedded", "tmux: protocol version mismatch (client 8, server 7)\n", true},
+		{"no server", "no server running on /tmp/tmux-1000/default", false},
+		{"cant find session", "can't find session: agentdeck_a", false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isTmuxProtocolMismatch(c.output); got != c.want {
+				t.Fatalf("isTmuxProtocolMismatch(%q) = %v, want %v", c.output, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSession_Exists_ProtocolMismatchIsNotTreatedAsAbsent is the regression for
+// the false-error cascade seen when the running tmux server was started by a
+// newer tmux binary (e.g. one from a Nix profile) but the client's PATH resolves
+// an OLDER system tmux. The old client's `has-session` probe fails fast with a
+// non-zero exit, printing "protocol version mismatch (client X, server Y)". The
+// old code treated any non-timeout failure as "session gone", so UpdateStatus
+// flipped the still-alive session to StatusError (via terminatedPaneStatus) even
+// though nothing crashed.
+//
+// A mismatch reply proves the server — and therefore this session — is alive:
+// only the client binary is wrong. Exists() must treat it as indeterminate and
+// assume the session still exists, exactly like a probe timeout.
+//
+// Contrast with #755 (exists_socket_test.go): a probe that COMPLETES with an
+// authoritative "gone" (e.g. "can't find session") must still report false —
+// covered by the sibling test below.
+func TestSession_Exists_ProtocolMismatchIsNotTreatedAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "tmux")
+	// Fake tmux that emits tmux's real mismatch message and exits non-zero,
+	// fast (no hang — this is NOT the timeout path).
+	script := "#!/bin/sh\n" +
+		"echo 'protocol version mismatch (client 8, server 7)' >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	restore := hasSessionProbeTimeout
+	hasSessionProbeTimeout = 2 * time.Second
+	t.Cleanup(func() { hasSessionProbeTimeout = restore })
+
+	// Non-default socket skips the session cache; a unique name guarantees no
+	// live pipe connection — so Exists() reaches the subprocess probe.
+	s := &Session{Name: "mismatch-session", SocketName: "agent-deck-mismatch-test"}
+
+	if !s.Exists() {
+		t.Fatalf("Exists() returned false on a protocol-version-mismatch probe; " +
+			"a mismatch proves the server is alive and must not be treated as a dead session")
+	}
+}
+
+// TestSession_Exists_AuthoritativeAbsentStillReportsFalse guards the mismatch
+// fix from over-broadening: a probe that COMPLETES with an ordinary non-zero
+// exit (no mismatch marker) — the shape of tmux's "can't find session" — must
+// still report the session as gone.
+func TestSession_Exists_AuthoritativeAbsentStillReportsFalse(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "tmux")
+	script := "#!/bin/sh\n" +
+		"echo \"can't find session: mismatch-session\" >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	restore := hasSessionProbeTimeout
+	hasSessionProbeTimeout = 2 * time.Second
+	t.Cleanup(func() { hasSessionProbeTimeout = restore })
+
+	s := &Session{Name: "gone-session", SocketName: "agent-deck-gone-test"}
+
+	if s.Exists() {
+		t.Fatalf("Exists() returned true for an authoritative absent probe; " +
+			"only a protocol mismatch (server alive) may be treated as indeterminate")
+	}
+}

--- a/internal/tmux/exists_protocol_mismatch_test.go
+++ b/internal/tmux/exists_protocol_mismatch_test.go
@@ -69,6 +69,11 @@ func TestSession_Exists_ProtocolMismatchIsNotTreatedAsAbsent(t *testing.T) {
 	hasSessionProbeTimeout = 2 * time.Second
 	t.Cleanup(func() { hasSessionProbeTimeout = restore })
 
+	// The mismatch verdict is cached per socket; start from a clean slate so
+	// this test's socket cannot inherit a verdict from a sibling test.
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
+
 	// Non-default socket skips the session cache; a unique name guarantees no
 	// live pipe connection — so Exists() reaches the subprocess probe.
 	s := &Session{Name: "mismatch-session", SocketName: "agent-deck-mismatch-test"}
@@ -98,6 +103,11 @@ func TestSession_Exists_AuthoritativeAbsentStillReportsFalse(t *testing.T) {
 	hasSessionProbeTimeout = 2 * time.Second
 	t.Cleanup(func() { hasSessionProbeTimeout = restore })
 
+	// The mismatch verdict is cached per socket; start from a clean slate so
+	// this test's socket cannot inherit a verdict from a sibling test.
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
+
 	s := &Session{Name: "gone-session", SocketName: "agent-deck-gone-test"}
 
 	if s.Exists() {
@@ -126,6 +136,11 @@ func TestSession_Exists_AbsentSessionNamedLikeMarkerReportsFalse(t *testing.T) {
 	restore := hasSessionProbeTimeout
 	hasSessionProbeTimeout = 2 * time.Second
 	t.Cleanup(func() { hasSessionProbeTimeout = restore })
+
+	// The mismatch verdict is cached per socket; start from a clean slate so
+	// this test's socket cannot inherit a verdict from a sibling test.
+	resetSocketMismatchCacheForTest()
+	t.Cleanup(resetSocketMismatchCacheForTest)
 
 	s := &Session{Name: "protocol version mismatch", SocketName: "agent-deck-named-marker-test"}
 

--- a/internal/tmux/exists_protocol_mismatch_test.go
+++ b/internal/tmux/exists_protocol_mismatch_test.go
@@ -21,6 +21,10 @@ func TestIsTmuxProtocolMismatch(t *testing.T) {
 		{"embedded", "tmux: protocol version mismatch (client 8, server 7)\n", true},
 		{"no server", "no server running on /tmp/tmux-1000/default", false},
 		{"cant find session", "can't find session: agentdeck_a", false},
+		// Adversarial: an authoritative absence reply echoes the session name, so
+		// a session NAMED like the marker must NOT be classified as a mismatch —
+		// absence wins over the substring.
+		{"cant find session named like marker", "can't find session: protocol version mismatch", false},
 		{"empty", "", false},
 	}
 	for _, c := range cases {
@@ -99,5 +103,34 @@ func TestSession_Exists_AuthoritativeAbsentStillReportsFalse(t *testing.T) {
 	if s.Exists() {
 		t.Fatalf("Exists() returned true for an authoritative absent probe; " +
 			"only a protocol mismatch (server alive) may be treated as indeterminate")
+	}
+}
+
+// TestSession_Exists_AbsentSessionNamedLikeMarkerReportsFalse is the adversarial
+// regression: tmux echoes the target in "can't find session: <name>", so a
+// session NAMED "protocol version mismatch" produces an absence reply that
+// literally contains the mismatch marker. Absence is authoritative and must win
+// — the classifier's bare substring match would otherwise keep this dead
+// session alive.
+func TestSession_Exists_AbsentSessionNamedLikeMarkerReportsFalse(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "tmux")
+	script := "#!/bin/sh\n" +
+		"echo \"can't find session: protocol version mismatch\" >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	restore := hasSessionProbeTimeout
+	hasSessionProbeTimeout = 2 * time.Second
+	t.Cleanup(func() { hasSessionProbeTimeout = restore })
+
+	s := &Session{Name: "protocol version mismatch", SocketName: "agent-deck-named-marker-test"}
+
+	if s.Exists() {
+		t.Fatalf("Exists() returned true for an absent session named like the mismatch marker; " +
+			"an authoritative \"can't find session\" reply must win over the substring match")
 	}
 }

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -960,13 +960,24 @@ func softKillProcessGroup(pgid int, grace time.Duration) bool {
 // The probe is bounded by hasSessionProbeTimeout: a tmux server that is briefly
 // busy can make `has-session` stall, and a stalled probe is indeterminate — we
 // assume the session still exists (return true) rather than blocking the caller
-// or reporting a live session as gone. A probe that completes is trusted.
+// or reporting a live session as gone. A probe that completes is trusted, unless
+// the client could not reach the server at all (see below).
 func tmuxSessionExistsOnSocket(socketName, name string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
 	defer cancel()
 	err := tmuxExecContext(ctx, socketName, "has-session", "-t", name).Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		return true // probe timed out: indeterminate, assume the session still exists
+	}
+	// Same mismatch caveat as Session.Exists: a client/server protocol version
+	// mismatch refuses every command on this socket with a non-zero exit, which
+	// is not evidence of absence — the refusal came FROM the server. This probe
+	// backs the watchPipe reconnect loop and public HasSession/HasSessionOnSocket,
+	// so reading a mismatch as absence here tears control pipes down for sessions
+	// that are alive. The verdict is cached per socket, so consulting it adds no
+	// subprocess per call.
+	if err != nil && socketHasProtocolMismatch(socketName) {
+		return true
 	}
 	return err == nil
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -2518,12 +2519,183 @@ var hasSessionProbeTimeout = 2 * time.Second
 // a dead session alive. A real mismatch means the client never reached the
 // server, so it can't also carry an authoritative absence — the two are
 // mutually exclusive, and giving absence precedence is safe.
+//
+// defaultProbeSocketProtocolMismatch, the only production caller, additionally
+// keeps operator-controlled session names out of the bytes handed here (it
+// classifies `list-sessions -F ""` stderr, which echoes no target). The
+// short-circuit above is therefore belt-and-braces for that path — and load-
+// bearing for any caller that ever classifies has-session output again.
 func isTmuxProtocolMismatch(output string) bool {
 	lower := strings.ToLower(output)
 	if strings.Contains(lower, "can't find session") {
 		return false
 	}
 	return strings.Contains(lower, "protocol version mismatch")
+}
+
+// socketMismatchCacheTTL bounds how long one socket's protocol-mismatch verdict
+// is reused. A mismatch is a property of the client/server BINARY PAIR — the
+// tmux on PATH versus the tmux that started the server on this socket — not of
+// an individual session, so it is stable for the lifetime of that pair.
+//
+// Keep the window short anyway. The direction that costs the user is a mismatch
+// appearing while a "no mismatch" verdict is still warm: sessions on that socket
+// keep reading gone for up to one TTL, exactly as they do today. Recovery in the
+// other direction (the operator fixes PATH, or the server restarts) is benign —
+// sessions merely stay "assume alive" for one more TTL. 5s matches
+// socketSessionCacheTTL and the negative-cache reasoning in #1728.
+const socketMismatchCacheTTL = 5 * time.Second
+
+// socketMismatchVerdict is one socket's cached classification.
+type socketMismatchVerdict struct {
+	mismatched bool
+	checkedAt  time.Time
+}
+
+var (
+	socketMismatchMu    sync.Mutex
+	socketMismatchCache = map[string]socketMismatchVerdict{}
+
+	// socketMismatchSf collapses a burst of classifications for the same socket
+	// into one, the way captureSf does for CapturePane: every session on a
+	// refusing socket reads "gone" in the same status pass, and that burst must
+	// cost ONE classification, not one per session.
+	socketMismatchSf singleflight.Group
+
+	// probeSocketProtocolMismatch is a package var so tests can drive the cache
+	// without a live tmux server. Read/written under socketMismatchMu.
+	probeSocketProtocolMismatch = defaultProbeSocketProtocolMismatch
+)
+
+// socketHasProtocolMismatch reports whether the tmux client agent-deck spawns
+// can talk to the server on socketName at all, or is refused for speaking a
+// different protocol version.
+//
+// This is the out-of-band half of the mismatch fix. The liveness probes
+// (Session.Exists, tmuxSessionExistsOnSocket) stay on cmd.Run() with no stdio to
+// capture, so nothing on the status hot path can block waiting for an EOF that a
+// forked child of tmux holds open (see tmuxSubprocessWaitDelay in socket.go).
+// The one exchange that has to READ tmux's error text to classify it happens
+// here instead: at most once per socket per TTL, and only after a probe has
+// already come back "gone".
+func socketHasProtocolMismatch(socketName string) bool {
+	socket := strings.TrimSpace(socketName)
+
+	if verdict, fresh := cachedSocketMismatch(socket); fresh {
+		return verdict
+	}
+
+	// Slow path: classify, deduplicating concurrent callers for this socket.
+	result, _, _ := socketMismatchSf.Do(socket, func() (any, error) {
+		// Double-check inside the singleflight: a caller that queued here just
+		// before the winner stored its verdict must reuse it, not re-classify.
+		if verdict, fresh := cachedSocketMismatch(socket); fresh {
+			return verdict, nil
+		}
+
+		socketMismatchMu.Lock()
+		probe := probeSocketProtocolMismatch
+		socketMismatchMu.Unlock()
+
+		mismatched := probe(socket)
+
+		socketMismatchMu.Lock()
+		socketMismatchCache[socket] = socketMismatchVerdict{mismatched: mismatched, checkedAt: time.Now()}
+		socketMismatchMu.Unlock()
+
+		return mismatched, nil
+	})
+
+	mismatched, _ := result.(bool)
+	return mismatched
+}
+
+// cachedSocketMismatch returns a socket's verdict and whether it is still fresh.
+func cachedSocketMismatch(socket string) (verdict, fresh bool) {
+	socketMismatchMu.Lock()
+	defer socketMismatchMu.Unlock()
+
+	entry, ok := socketMismatchCache[socket]
+	if !ok || time.Since(entry.checkedAt) >= socketMismatchCacheTTL {
+		return false, false
+	}
+	return entry.mismatched, true
+}
+
+// defaultProbeSocketProtocolMismatch settles one client/server exchange on
+// socketName. Every client command against a server of a different protocol
+// version is refused with tmux's "protocol version mismatch (client X, server
+// Y)" on stderr, so a single `list-sessions` decides it.
+//
+// Three deliberate choices:
+//
+//   - stderr is captured into a REAL FILE, never a pipe. os/exec hands an
+//     *os.File to the child as its fd 2 unchanged — no os.Pipe, no copy
+//     goroutine — so nothing here can wait on an EOF that a forked child of tmux
+//     is holding open (socket.go's tmuxSubprocessWaitDelay). Moving the capture
+//     off the liveness probes is what keeps that wait off the status hot path;
+//     using a pipe HERE would put the same bounded-but-real 2s drain back, once
+//     per socket per TTL, and `agent-deck status` under bridged stdio measurably
+//     pays it.
+//   - Only tmux's own stderr is classified, and `-F ""` makes tmux print an
+//     empty line per session instead of session names. Session names are
+//     operator-controlled text, so keeping them out of the classified bytes is
+//     what makes this probe structurally immune to the echo problem
+//     isTmuxProtocolMismatch has to guard against in has-session output.
+//   - Only a FAILED exchange can be a mismatch: a server that answers is by
+//     definition speaking our protocol. Anything else that fails (deadline,
+//     exec failure, an unwritable temp dir) reads as "no mismatch" — the
+//     conservative answer, since it leaves the caller's own verdict untouched.
+func defaultProbeSocketProtocolMismatch(socketName string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+
+	sink, err := os.CreateTemp("", "agent-deck-tmux-mismatch-*")
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = sink.Close()
+		_ = os.Remove(sink.Name())
+	}()
+
+	cmd := tmuxExecContext(ctx, socketName, "list-sessions", "-F", "")
+	cmd.Stderr = sink // *os.File: passed through to the child, not proxied
+	if err := cmd.Run(); err == nil {
+		return false
+	}
+
+	if _, err := sink.Seek(0, io.SeekStart); err != nil {
+		return false
+	}
+	// tmux's refusal is one short line; cap the read so a pathological server
+	// cannot make this allocate.
+	stderr, err := io.ReadAll(io.LimitReader(sink, 4096))
+	if err != nil {
+		return false
+	}
+	return isTmuxProtocolMismatch(string(stderr))
+}
+
+// resetSocketMismatchCacheForTest clears every cached verdict.
+func resetSocketMismatchCacheForTest() {
+	socketMismatchMu.Lock()
+	defer socketMismatchMu.Unlock()
+	socketMismatchCache = map[string]socketMismatchVerdict{}
+}
+
+// setSocketMismatchProbeForTest swaps the classifier and returns a restore func.
+func setSocketMismatchProbeForTest(probe func(string) bool) func() {
+	socketMismatchMu.Lock()
+	defer socketMismatchMu.Unlock()
+
+	prev := probeSocketProtocolMismatch
+	probeSocketProtocolMismatch = probe
+	return func() {
+		socketMismatchMu.Lock()
+		defer socketMismatchMu.Unlock()
+		probeSocketProtocolMismatch = prev
+	}
 }
 
 // Exists checks if the tmux session exists
@@ -2565,17 +2737,23 @@ func (s *Session) Exists() bool {
 	// that actually completes with a non-success status means "gone".
 	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
 	defer cancel()
-	out, err := s.tmuxCmdContext(ctx, "has-session", "-t", s.Name).CombinedOutput()
+	err := s.tmuxCmdContext(ctx, "has-session", "-t", s.Name).Run()
 	if ctx.Err() == context.DeadlineExceeded {
 		return true // probe timed out: indeterminate, assume still alive
 	}
-	// A client/server protocol version mismatch fails the probe fast with a
-	// non-zero exit, but it does NOT mean the session is gone: the mismatch reply
-	// proves the server (and this session) is alive — only the client binary is
+	// A completed non-zero exit is only AUTHORITATIVE if the client reached the
+	// server. A client/server protocol version mismatch fails every command on
+	// this socket fast with a non-zero exit, and the refusal itself proves the
+	// server — and therefore this session — is alive: only the client binary is
 	// wrong. Treating it as "gone" flipped live sessions to StatusError (via
 	// terminatedPaneStatus) even though nothing crashed. Assume alive, like the
 	// timeout branch, and let a later poll with a matching client resolve it.
-	if err != nil && isTmuxProtocolMismatch(string(out)) {
+	//
+	// The verdict is a property of the client/server binary pair, not of this
+	// session, so it is settled out of band and cached per socket. That keeps
+	// this probe on Run() with nil stdio: no pipe, no copy goroutine, nothing
+	// for WaitDelay to bound on the status hot path.
+	if err != nil && socketHasProtocolMismatch(s.SocketName) {
 		return true
 	}
 	return err == nil

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2510,8 +2510,20 @@ var hasSessionProbeTimeout = 2 * time.Second
 // failure is purely in the client binary, not in the session. Callers must
 // therefore treat a mismatch as indeterminate (assume alive), never as an
 // authoritative "session gone".
+//
+// An authoritative absence reply always wins over the mismatch marker. tmux
+// echoes the requested target in "can't find session: <name>", so a session
+// NAMED like the marker (e.g. "protocol version mismatch") would otherwise make
+// the bare substring test below fire on a genuine "gone" reply and wrongly keep
+// a dead session alive. A real mismatch means the client never reached the
+// server, so it can't also carry an authoritative absence — the two are
+// mutually exclusive, and giving absence precedence is safe.
 func isTmuxProtocolMismatch(output string) bool {
-	return strings.Contains(strings.ToLower(output), "protocol version mismatch")
+	lower := strings.ToLower(output)
+	if strings.Contains(lower, "can't find session") {
+		return false
+	}
+	return strings.Contains(lower, "protocol version mismatch")
 }
 
 // Exists checks if the tmux session exists

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2500,6 +2500,20 @@ func (s *Session) Start(command string) error {
 // tests.
 var hasSessionProbeTimeout = 2 * time.Second
 
+// isTmuxProtocolMismatch reports whether tmux output signals a client/server
+// protocol version mismatch. tmux prints "protocol version mismatch (client X,
+// server Y)" when a client binary of one protocol version talks to a server
+// started by a binary of a different version — common when the running server
+// uses a newer tmux (e.g. one installed under a Nix profile) while the client's
+// PATH resolves an older system tmux. Crucially, a mismatch response is proof
+// that the SERVER is alive and reachable: it answered with its version. The
+// failure is purely in the client binary, not in the session. Callers must
+// therefore treat a mismatch as indeterminate (assume alive), never as an
+// authoritative "session gone".
+func isTmuxProtocolMismatch(output string) bool {
+	return strings.Contains(strings.ToLower(output), "protocol version mismatch")
+}
+
 // Exists checks if the tmux session exists
 // Uses cached session list when available (refreshed by RefreshExistingSessions)
 // Falls back to direct tmux call if cache is stale
@@ -2539,9 +2553,18 @@ func (s *Session) Exists() bool {
 	// that actually completes with a non-success status means "gone".
 	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
 	defer cancel()
-	err := s.tmuxCmdContext(ctx, "has-session", "-t", s.Name).Run()
+	out, err := s.tmuxCmdContext(ctx, "has-session", "-t", s.Name).CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return true // probe timed out: indeterminate, assume still alive
+	}
+	// A client/server protocol version mismatch fails the probe fast with a
+	// non-zero exit, but it does NOT mean the session is gone: the mismatch reply
+	// proves the server (and this session) is alive — only the client binary is
+	// wrong. Treating it as "gone" flipped live sessions to StatusError (via
+	// terminatedPaneStatus) even though nothing crashed. Assume alive, like the
+	// timeout branch, and let a later poll with a matching client resolve it.
+	if err != nil && isTmuxProtocolMismatch(string(out)) {
+		return true
 	}
 	return err == nil
 }


### PR DESCRIPTION
## What problem does this solve?

`main` has no protocol-version-mismatch handling at all — `git grep -i "protocol version mismatch"` over `main` returns nothing. `Session.Exists()` treats **any** `tmux has-session` probe that completes with a non-zero exit as "the session is gone".

That reading is wrong for one class of failure. When the running tmux server was started by a different tmux binary than the one the client's PATH resolves — a server started from a Nix profile while the client is the older system tmux, or an upgrade that replaced the binary under a long-lived server — tmux refuses **every** client command on that socket with

```
protocol version mismatch (client 8, server 7)
```

and a non-zero exit. That refusal came *from the server*: it proves the server, and therefore the session, is alive. Only the client binary is wrong. `Exists()` files it under "gone".

## Why this change

`Exists()` already distinguishes "indeterminate" from "authoritatively gone" — a probe that times out returns `true` on exactly that reasoning. A mismatch belongs in the same bucket, and for a stronger reason: a timeout is silence, a mismatch is the server answering.

What makes it safe to act on is that the two signals are mutually exclusive. A real mismatch means the client never got far enough to ask about a session, so it cannot also carry an authoritative absence. tmux echoes the requested target in `can't find session: <name>`, so absence has to win over the marker or a session *named* like the marker would be pinned alive — `isTmuxProtocolMismatch` short-circuits on absence for that reason.

Where the verdict is computed matters as much as the verdict itself. A mismatch is a property of the **client/server binary pair**, not of an individual session, so it is settled per socket instead of being read out of each session's probe:

- `Session.Exists()` and `tmuxSessionExistsOnSocket()` run `cmd.Run()` with nil stdio — no pipe, no copy goroutine. Their hot-path shape is what `main` has today.
- `socketHasProtocolMismatch()` settles the verdict once per socket, cached for 5s (`socketSessionCacheTTL`'s window) and deduplicated through the same `singleflight.Group` idiom `CapturePane` uses. It is consulted only on the `err != nil` branch, where the session already looks gone.
- That classification captures tmux's stderr into an `*os.File` from `os.CreateTemp`, which `os/exec` hands to the child unchanged, so it has no pipe to drain either. It classifies `list-sessions -F ""` stderr, which echoes no caller-supplied target — operator-controlled session names never reach the classifier.

The capture mechanism is spelled out because `internal/tmux/socket.go` documents the hazard: a forked child of tmux inherits the subprocess's output descriptors and never closes them (the server's terminal pass-through dups under bridged stdio — `/remote-control`, `ssh ControlMaster`). A pipe-backed capture then waits for an EOF that never arrives, bounded only by `cmd.WaitDelay` = 2s. An earlier revision of this PR captured inside `Exists()` and paid that on the status path; the cost is measured under Evidence.

`tmuxSessionExistsOnSocket()` in `internal/tmux/pipemanager.go` had the identical `Run()` / timeout-alive / `err == nil` shape and backs the `watchPipe` reconnect loop plus the public `HasSession` / `HasSessionOnSocket`, so it was equally mismatch-blind: a refusal read as absence there tears down control pipes for sessions that are alive. Both probes now consult the one helper. Happy to split that into its own PR if you'd rather keep this diff to `Exists()`.

## User impact

Under a client/server mismatch, live and healthy sessions read as errored: `Exists() == false` → `terminatedPaneStatus` / `classifyTerminatedPane` (`internal/session/instance.go`) → for claude-family tools with no exit code → `StatusError`. `PaneDeadExitStatus` fails under the same mismatch, so no exit code is available, so the error verdict is what you get. Everything keyed on status follows it: the ✕ in the list, notifications, `status --json`.

Since #1768 the watchdog re-confirms liveness immediately before a restart, so a mismatch no longer tears the session down. What remains is a false error state, and that is what this removes.

Unchanged: an absent session still reports gone, including one whose name contains the text `protocol version mismatch`.

## Evidence

New and existing coverage in the touched package (real run):

```
$ go test ./internal/tmux/ -run 'TestIsTmuxProtocolMismatch|TestSocketHasProtocolMismatch|TestSession_Exists_' -v
=== RUN   TestSocketHasProtocolMismatch_ClassifiesOncePerSocketPerTTL
--- PASS: TestSocketHasProtocolMismatch_ClassifiesOncePerSocketPerTTL (0.00s)
=== RUN   TestSocketHasProtocolMismatch_SingleFlightsConcurrentCallers
--- PASS: TestSocketHasProtocolMismatch_SingleFlightsConcurrentCallers (0.05s)
=== RUN   TestSocketHasProtocolMismatch_ReclassifiesAfterTTL
--- PASS: TestSocketHasProtocolMismatch_ReclassifiesAfterTTL (0.00s)
=== RUN   TestSession_Exists_ClassificationIsAmortizedAcrossSessionsOnASocket
--- PASS: TestSession_Exists_ClassificationIsAmortizedAcrossSessionsOnASocket (0.00s)
=== RUN   TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors
--- PASS: TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors (0.00s)
    --- PASS: TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors/live_session (0.00s)
    --- PASS: TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors/protocol_version_mismatch (0.00s)
    --- PASS: TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors/authoritative_absence (0.00s)
=== RUN   TestIsTmuxProtocolMismatch
--- PASS: TestIsTmuxProtocolMismatch (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/canonical (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/uppercased (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/embedded (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/no_server (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/cant_find_session (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/cant_find_session_named_like_marker (0.00s)
    --- PASS: TestIsTmuxProtocolMismatch/empty (0.00s)
=== RUN   TestSession_Exists_ProtocolMismatchIsNotTreatedAsAbsent
--- PASS: TestSession_Exists_ProtocolMismatchIsNotTreatedAsAbsent (0.00s)
=== RUN   TestSession_Exists_AuthoritativeAbsentStillReportsFalse
--- PASS: TestSession_Exists_AuthoritativeAbsentStillReportsFalse (0.00s)
=== RUN   TestSession_Exists_AbsentSessionNamedLikeMarkerReportsFalse
--- PASS: TestSession_Exists_AbsentSessionNamedLikeMarkerReportsFalse (0.00s)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/tmux	0.098s
```

`TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors` is the budget regression: every tmux invocation orphans a `sleep 30` that inherits the subprocess's output descriptors, and in that one build a live session reads true, a mismatch reads indeterminate, and an authoritative `can't find session` reads false — each inside `tmuxSubprocessWaitDelay / 2`. The budget is expressed against that constant on purpose: the assertion is "no stdio drain", not a wall-clock number.

`eval_smoke`, the suite that was red on the previous head, run as CI runs it:

```
$ go test -tags eval_smoke -race -count=1 -timeout 3m ./tests/eval/... ./internal/ui/...
ok  	github.com/asheshgoplani/agent-deck/tests/eval/feedback	4.912s
ok  	github.com/asheshgoplani/agent-deck/tests/eval/harness	1.716s
ok  	github.com/asheshgoplani/agent-deck/tests/eval/session	42.539s
ok  	github.com/asheshgoplani/agent-deck/internal/ui	57.039s
```

Its `TestEval_Session_StatusUnderBridgedStdio_NoHang` is the reason the capture moved off the probe. Same box, same shim, `agent-deck status` wall time against its 10s ceiling:

| head | status wall time |
|---|---|
| `main` (46300807) | 6.16s |
| this fix, capture inside `Exists()` (pipe-backed) | 8.77s |
| this fix, classification out of band (fd-backed) | 6.72s |

Sandboxed full suite (`HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= PERF_BUDGET_MULTIPLIER=2.0 go test -race -timeout 20m ./...`): the touched package passes — `ok github.com/asheshgoplani/agent-deck/internal/tmux 73.030s`. Four tests failed in packages this PR does not touch, all of them latency-budget or rate-timing tests that trip under the concurrent load of a full `./...` run on a busy box and pass when run in isolation: `TestPerf_ColdStart_Help`, `TestPerf_ColdStart_Version` (`cmd/agent-deck`), `TestPerf_Group_CreateDelete` (`internal/session`), `TestPerf_StateDB_ReadByID` (`internal/statedb`), `TestTriageLoop_RateLimitSixthQueued` (`internal/watcher`). Not claiming a fully-green local suite that isn't; CI on Linux with `--rerun-fails=2` is the signal that counts.

Also verified: `gofmt -l ./cmd ./internal ./tests` prints nothing, `go vet ./...` is clean, `golangci-lint run ./internal/tmux/...` (v2.12.2, repo `.golangci.yml`) reports 0 issues.

## Hot path

`Exists()` and `tmuxSessionExistsOnSocket()` spawn exactly what they spawn on `main`: one bounded `has-session` with nil stdio. On the success path nothing else runs at all.

The added cost is one `list-sessions` per socket per 5s TTL, and only for a socket where a probe already came back "gone" — `O(sockets)`, never `O(sessions)`, the same shape as `ListSessionNamesOnSocket`'s per-socket refresh. A burst of sessions reading gone in one status pass collapses to a single classification via `singleflight`; `TestSession_Exists_ClassificationIsAmortizedAcrossSessionsOnASocket` pins that at 3 `has-session` probes to 1 classification.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8 (initial), claude-opus-5 (rework)

## What actually bothered you

My operator ran a self-improvement analysis over heavy, long-running agent-deck usage; it surfaced this as a reproducible defect. They asked me to fix the agent-deck bugs the analysis found and send them upstream. The concrete symptom: sessions that were alive and healthy showed as errored, on a box where the tmux server had been started by a newer tmux than the one on the client's PATH.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [~] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — touched package (`internal/tmux`) passes, as does the whole `eval_smoke` tier; the only failures are load-sensitive perf/timing tests in untouched packages that pass in isolation (see Evidence). Not claiming a fully-green suite that isn't.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8,claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux session detection when client and server protocol versions differ.
  * Prevented protocol mismatch errors from being incorrectly reported as missing sessions.
  * Preserved accurate “session not found” results, including names containing mismatch-related text.
  * Added bounded checks and caching to improve responsiveness and reduce repeated detection overhead.
* **Tests**
  * Expanded coverage for mismatch detection, concurrent checks, cache expiration, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->