### PR TITLE
fix(send): detect an unsent multi-line initial prompt with a short first line

### DIFF
--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -26,6 +26,41 @@ func firstNonEmptyLine(s string) string {
 	return ""
 }
 
+// messageTail returns the normalized content of message that follows its first
+// non-empty physical line. For a multi-line message this "tail" is the part that
+// makes it identifiable beyond an opening line another draft might share, and is
+// used to corroborate a first-line match before recovering (see
+// HasUnsentComposerPrompt).
+func messageTail(message string) string {
+	lines := strings.Split(message, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			return NormalizePromptText(strings.Join(lines[i+1:], " "))
+		}
+	}
+	return ""
+}
+
+// maxTailNeedleLen bounds how much of a multi-line message's tail must be
+// visible in the pane to corroborate a first-line match: long enough to be
+// message-specific, short enough to tolerate terminal wrapping of the content.
+const maxTailNeedleLen = 48
+
+// paneContainsTail reports whether a bounded, message-specific fragment of a
+// multi-line message's tail is visible in the pane content. It corroborates a
+// first-line match so an unrelated draft that merely shares the same opening
+// line is not mistaken for this message.
+func paneContainsTail(content, tail string) bool {
+	if tail == "" {
+		return false
+	}
+	needle := []rune(tail)
+	if len(needle) > maxTailNeedleLen {
+		needle = needle[:maxTailNeedleLen]
+	}
+	return strings.Contains(NormalizePromptText(content), string(needle))
+}
+
 // NormalizePromptText normalizes whitespace in prompt text by replacing NBSP
 // with regular spaces, trimming, and collapsing multiple whitespace runs.
 func NormalizePromptText(s string) string {
@@ -194,20 +229,25 @@ func HasUnsentComposerPrompt(content, message string) bool {
 	// Multi-line messages: CurrentComposerPrompt stops collecting at the first
 	// blank line, so the composer body it recovers is only the message's first
 	// physical line. This is the shape of every `launch -m` / `session send`
-	// prompt once the completion-sentinel instruction is appended — it begins
-	// with a blank line ("\n\n## Final step …"). On a cold first start the
-	// initial Enter can be swallowed while the child's TUI is still mounting,
-	// leaving that first line sitting unsent in the composer; when it is
-	// shorter than minWrappedPrefixLen the whole-message comparisons above all
-	// miss it and the send-verify loop never fires a recovery Enter. Match the
-	// message's first physical line so that stuck state is detected regardless
-	// of first-line length. Only engages for genuinely multi-line messages
-	// (firstLine != msg), so single-line behavior is unchanged.
+	// prompt once the completion-sentinel instruction is appended — its trailing
+	// "\n\n## Final step …" block introduces a blank line. On a cold first start
+	// the initial Enter can be swallowed while the child's TUI is still mounting,
+	// leaving the whole message sitting unsent in the composer; when the first
+	// line is shorter than minWrappedPrefixLen the whole-message comparisons
+	// above all miss it and the send-verify loop never fires a recovery Enter.
+	//
+	// Match the message's first physical line so that stuck state is detected
+	// regardless of first-line length — but a first-line match alone is
+	// ambiguous: two different messages can open with the same line, so acting
+	// on it risks firing a recovery Enter that submits an unrelated draft. Guard
+	// it with corroborating message-specific content: a fragment of the tail
+	// (everything past the first line) must also be visible in the pane. Only
+	// engages for genuinely multi-line messages (firstLine != msg), so
+	// single-line behavior is unchanged.
 	if firstLine := NormalizePromptText(firstNonEmptyLine(message)); firstLine != "" && firstLine != msg {
-		if promptBody == firstLine {
-			return true
-		}
-		if len(promptBody) >= minWrappedPrefixLen && strings.HasPrefix(firstLine, promptBody) {
+		firstLineMatch := promptBody == firstLine ||
+			(len(promptBody) >= minWrappedPrefixLen && strings.HasPrefix(firstLine, promptBody))
+		if firstLineMatch && paneContainsTail(content, messageTail(message)) {
 			return true
 		}
 	}

--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -13,6 +13,19 @@ func HasUnsentPastedPrompt(content string) bool {
 	return strings.Contains(strings.ToLower(content), "[pasted text")
 }
 
+// firstNonEmptyLine returns the first physical line of s that is non-empty
+// after trimming. Used to reconstruct what the composer actually renders for a
+// multi-line message: Claude's input box shows the message's first physical
+// line and truncates the rest behind a blank line (see HasUnsentComposerPrompt).
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			return line
+		}
+	}
+	return ""
+}
+
 // NormalizePromptText normalizes whitespace in prompt text by replacing NBSP
 // with regular spaces, trimming, and collapsing multiple whitespace runs.
 func NormalizePromptText(s string) string {
@@ -176,6 +189,27 @@ func HasUnsentComposerPrompt(content, message string) bool {
 	const minWrappedPrefixLen = 16
 	if len(promptBody) >= minWrappedPrefixLen && strings.HasPrefix(msg, promptBody) {
 		return true
+	}
+
+	// Multi-line messages: CurrentComposerPrompt stops collecting at the first
+	// blank line, so the composer body it recovers is only the message's first
+	// physical line. This is the shape of every `launch -m` / `session send`
+	// prompt once the completion-sentinel instruction is appended — it begins
+	// with a blank line ("\n\n## Final step …"). On a cold first start the
+	// initial Enter can be swallowed while the child's TUI is still mounting,
+	// leaving that first line sitting unsent in the composer; when it is
+	// shorter than minWrappedPrefixLen the whole-message comparisons above all
+	// miss it and the send-verify loop never fires a recovery Enter. Match the
+	// message's first physical line so that stuck state is detected regardless
+	// of first-line length. Only engages for genuinely multi-line messages
+	// (firstLine != msg), so single-line behavior is unchanged.
+	if firstLine := NormalizePromptText(firstNonEmptyLine(message)); firstLine != "" && firstLine != msg {
+		if promptBody == firstLine {
+			return true
+		}
+		if len(promptBody) >= minWrappedPrefixLen && strings.HasPrefix(firstLine, promptBody) {
+			return true
+		}
 	}
 
 	// Fallback: compare a short message prefix to handle truncation/formatting

--- a/internal/send/send_test.go
+++ b/internal/send/send_test.go
@@ -42,6 +42,59 @@ func TestHasUnsentComposerPrompt(t *testing.T) {
 	}
 }
 
+// TestHasUnsentComposerPrompt_ColdLaunchMultilineShortFirstLine covers the
+// cold-first-launch send/enter race: on a fresh start the trailing Enter can be
+// swallowed while the child's TUI is still mounting, so the initial message is
+// typed into the composer but never submitted and the session sits in "waiting".
+// The send-verify loop only recovers if it can detect the message is still in
+// the composer. A multi-line message renders with only its first physical line
+// visible (the composer parser truncates at the first blank line), which is the
+// shape of every `-m` prompt once the appended completion sentinel — beginning
+// "\n\n## Final step …" — is present. When that first line is short, detection
+// must still fire. Synthetic pane + message; no tmux, no timing.
+func TestHasUnsentComposerPrompt_ColdLaunchMultilineShortFirstLine(t *testing.T) {
+	message := "Summarize\n\n## Final step — assert completion\n" +
+		"When the task is fully done, print exactly this as the last line: DONE"
+	composer := strings.Join([]string{
+		"────────────────",
+		"❯ Summarize",
+		"",
+		"## Final step — assert completion",
+		"When the task is fully done, print exactly this as the last line: DONE",
+		"────────────────",
+		"[Opus 4.6] Context: 0%",
+	}, "\n")
+	if !HasUnsentComposerPrompt(composer, message) {
+		t.Fatal("expected a still-in-composer multi-line message with a short first line to be detected as unsent")
+	}
+
+	// A composer holding an unrelated short first line must NOT match this
+	// multi-line message — the first-line branch stays type-specific.
+	other := strings.Join([]string{
+		"────────────────",
+		"❯ ls -la",
+		"────────────────",
+		"[Opus 4.6] Context: 0%",
+	}, "\n")
+	if HasUnsentComposerPrompt(other, message) {
+		t.Fatal("did not expect an unrelated composer line to match a different multi-line message")
+	}
+
+	// Once submitted, the composer is empty again — must read as consumed even
+	// though the multi-line first-line branch is now active.
+	consumed := strings.Join([]string{
+		"❯ Summarize",
+		"✳ Tempering…",
+		"────────────────",
+		"❯",
+		"────────────────",
+		"[Opus 4.6] Context: 0%",
+	}, "\n")
+	if HasUnsentComposerPrompt(consumed, message) {
+		t.Fatal("did not expect a submitted (empty-composer) pane to be treated as unsent")
+	}
+}
+
 func TestHasUnsentComposerPrompt_SubmittedHistory(t *testing.T) {
 	// Submitted messages can appear in history; only current composer should count.
 	submitted := "❯ Write one line: LAUNCH_OK\n✳ Tempering…\n────────────────\n❯\n────────────────\n[Opus 4.6] Context: 0%"

--- a/internal/send/send_test.go
+++ b/internal/send/send_test.go
@@ -95,6 +95,43 @@ func TestHasUnsentComposerPrompt_ColdLaunchMultilineShortFirstLine(t *testing.T)
 	}
 }
 
+// TestHasUnsentComposerPrompt_SameFirstLineDifferentBody guards against the
+// first-line recovery match submitting an unrelated draft. Two multi-line
+// messages can open with an identical short first line while their bodies
+// differ. When the composer holds a draft for one of them, a recovery check for
+// the *other* must reject it — otherwise the send-verify loop would fire Enter
+// and submit the wrong draft. Detection therefore requires corroborating
+// message-specific content (a fragment of the tail past the first line) to be
+// visible in the pane. Synthetic pane + messages; no tmux, no timing.
+func TestHasUnsentComposerPrompt_SameFirstLineDifferentBody(t *testing.T) {
+	present := "Run\n\nDeploy the billing service and report the run id.\n\n" +
+		"## Final step\nprint DONE"
+	unrelated := "Run\n\nRoll back the auth migration and confirm it.\n\n" +
+		"## Final step\nprint DONE"
+
+	// Composer holds the draft for `present`.
+	composer := strings.Join([]string{
+		"────────────────",
+		"❯ Run",
+		"",
+		"Deploy the billing service and report the run id.",
+		"",
+		"## Final step",
+		"print DONE",
+		"────────────────",
+		"[Opus 4.6] Context: 0%",
+	}, "\n")
+
+	if !HasUnsentComposerPrompt(composer, present) {
+		t.Fatal("expected the message whose body is in the composer to be detected as unsent")
+	}
+	// The unrelated message shares the first line ("Run") but its body is not in
+	// the pane — recovery must NOT treat this draft as the unrelated message.
+	if HasUnsentComposerPrompt(composer, unrelated) {
+		t.Fatal("did not expect a draft sharing only the first line to match an unrelated multi-line message")
+	}
+}
+
 func TestHasUnsentComposerPrompt_SubmittedHistory(t *testing.T) {
 	// Submitted messages can appear in history; only current composer should count.
 	submitted := "❯ Write one line: LAUNCH_OK\n✳ Tempering…\n────────────────\n❯\n────────────────\n[Opus 4.6] Context: 0%"


### PR DESCRIPTION
## What problem does this solve?

A session launched with a multi-line initial prompt can sit idle in "waiting": on a cold first start the trailing Enter is sometimes swallowed while the child's TUI is still mounting, so the prompt is typed into the composer but never submitted. The send-verify loop could not detect that stuck state when the message's first physical line was short, and — once it did — an ambiguous first-line match risked submitting an unrelated draft.

## Why this change

The composer only reliably exposes a multi-line message's first physical line (the parser stops at the first blank line), so detection has to key off that line. Matching the first line alone is ambiguous, so the match is corroborated with message-specific content from the tail before any recovery keystroke is sent — the smallest change that makes recovery both fire when it should and stay silent when the draft isn't ours.

## User impact

A stuck multi-line initial prompt is now recovered even when its first line is short, so sessions no longer hang in "waiting" after launch. Recovery will not fire an Enter for a composer holding an unrelated draft that merely happens to share the same opening line, so it can't submit the wrong text.

## Evidence

Touched package, verbose (shows the new regression test):

```
$ go test ./internal/send/ -run 'TestHasUnsentComposerPrompt' -v
=== RUN   TestHasUnsentComposerPrompt
--- PASS: TestHasUnsentComposerPrompt (0.00s)
=== RUN   TestHasUnsentComposerPrompt_ColdLaunchMultilineShortFirstLine
--- PASS: TestHasUnsentComposerPrompt_ColdLaunchMultilineShortFirstLine (0.00s)
=== RUN   TestHasUnsentComposerPrompt_SameFirstLineDifferentBody
--- PASS: TestHasUnsentComposerPrompt_SameFirstLineDifferentBody (0.00s)
=== RUN   TestHasUnsentComposerPrompt_SubmittedHistory
--- PASS: TestHasUnsentComposerPrompt_SubmittedHistory (0.00s)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/send	0.028s
```

Touched package, sandboxed (isolated HOME/XDG so no host config leaks in):

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/send/
ok  	.../internal/send	1.958s
```

The full `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` run
was executed. All failures were confined to packages this PR does not touch
(`internal/statedb`, `internal/tmux`, `internal/testutil`) and are host-contention artifacts, not
regressions: `SQLITE_BUSY ... database is locked`, `tmux bootstrap not ready within 10s`, and
perf-budget timeouts under concurrent test load. Re-run in isolation they pass, e.g.:

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/statedb/ -run TestPerf_StateDB
ok  	.../internal/statedb	12.479s
```

This change is confined to `internal/send`; `go build ./...`, `go vet ./...`, and
`gofmt -l ./cmd ./internal` are clean.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you

My operator ran a self-improvement analysis over heavy, long-running agent-deck conductor usage; it surfaced this as a reproducible defect. They asked me to fix the agent-deck bugs the analysis found and send them upstream. The concrete symptom: a freshly launched session with a multi-line initial prompt could sit stuck in "waiting" because the prompt was left unsent in the composer and never recovered.

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — touched package (`internal/send`) passes sandboxed; the full run's only failures are host-contention flakes in untouched packages (see Evidence), which pass in isolation
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of unsent multi-line messages after application launch.
  * Reduced false positives by verifying that recovered composer content matches the intended message.
  * Preserved correct handling when a message has already been submitted or consumed.

* **Tests**
  * Added coverage for short first lines, unrelated composer content, and submitted multi-line messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->