### PR TITLE
fix(status): read pane exit code so a clean one-shot exit isn't an error

### DIFF
--- a/internal/session/apply_terminated_pane_status_test.go
+++ b/internal/session/apply_terminated_pane_status_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestApplyTerminatedPaneStatus_HoldsLockOnReturn verifies the lock handoff
+// contract: applyTerminatedPaneStatus is entered with i.mu held, drops it for
+// the (potentially slow) tmux exit-status probe, and must hold i.mu again on
+// return so the caller's deferred Unlock stays balanced. With a nil tmux
+// session no subprocess runs, so this exercises the unlock/reacquire path
+// without a live tmux server.
+func TestApplyTerminatedPaneStatus_HoldsLockOnReturn(t *testing.T) {
+	i := &Instance{Tool: "claude", Status: StatusRunning}
+
+	i.mu.Lock()
+	i.applyTerminatedPaneStatus()
+
+	// The helper must have reacquired the lock; TryLock on an already-held
+	// mutex returns false.
+	if i.mu.TryLock() {
+		i.mu.Unlock()
+		t.Fatal("applyTerminatedPaneStatus returned without holding i.mu")
+	}
+	got := i.Status
+	i.mu.Unlock()
+
+	// nil tmux → no exit code → per-tool heuristic; a hook-emitting tool's
+	// vanished pane is a crash.
+	if got != StatusError {
+		t.Errorf("Status = %q, want %q", got, StatusError)
+	}
+}
+
+// TestApplyTerminatedPaneStatus_StoppedGuard pins the stopped-state guard.
+// Because i.mu is dropped during the probe, a concurrent Stop() may set
+// StatusStopped while the query is in flight; the result must not clobber it.
+// Here the session is already StatusStopped before the call, standing in for
+// that window — the terminated-pane classification (which for "claude" would be
+// StatusError) must be suppressed.
+func TestApplyTerminatedPaneStatus_StoppedGuard(t *testing.T) {
+	i := &Instance{Tool: "claude", Status: StatusStopped}
+
+	i.mu.Lock()
+	i.applyTerminatedPaneStatus()
+	got := i.Status
+	i.mu.Unlock()
+
+	if got != StatusStopped {
+		t.Errorf("Status = %q, want %q (stopped-state guard must hold)", got, StatusStopped)
+	}
+}
+
+// TestApplyTerminatedPaneStatus_ConcurrentRaceSafe drives the helper from many
+// goroutines contending on the same i.mu. It is a no-op assertion-wise; its
+// value is under `go test -race`, which flags any unsynchronized access or a
+// lock-handoff imbalance (double unlock / unbalanced reacquire).
+func TestApplyTerminatedPaneStatus_ConcurrentRaceSafe(t *testing.T) {
+	i := &Instance{Tool: "opencode", Status: StatusRunning}
+
+	var wg sync.WaitGroup
+	for n := 0; n < 50; n++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			i.mu.Lock()
+			i.applyTerminatedPaneStatus()
+			i.mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	i.mu.Lock()
+	got := i.Status
+	i.mu.Unlock()
+	// opencode's hookless vanished pane classifies as stopped.
+	if got != StatusStopped {
+		t.Errorf("Status = %q, want %q", got, StatusStopped)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4035,17 +4035,39 @@ func shouldDebounceTmuxFlipForTool(tool string) bool {
 // terminatedPaneStatus classifies a session whose tmux pane/session has
 // vanished (or gone dead under remain-on-exit) AFTER having been started.
 //
-// For hook-emitting tools a dead pane genuinely means a crash, so it maps to
-// StatusError. OpenCode, however, emits no lifecycle hooks (issue #1617): it is
-// not in IsHookEmittingTool, so status detection falls back to tmux content
-// sniffing. An in-session `/exit` closes the OpenCode pane exactly like a crash
-// would, and without remain-on-exit there is no exit code left to inspect — so
-// a clean exit is misread as an error banner (✕) instead of a clean shutdown.
-// A vanished OpenCode pane is overwhelmingly a user-initiated exit, so classify
-// it as StatusStopped (done, ■) rather than StatusError. Error stays reserved
+// Exit code first: when tmux still holds the dead pane (remain-on-exit — set
+// for sandbox sessions, and opt-in via [tmux] options for any session) the
+// real process exit code is available. A one-shot worker that finishes and
+// exits 0 is a clean shutdown (done, ■ StatusStopped), NOT a crash — reporting
+// it as StatusError (✕) makes a successful completion indistinguishable from a
+// real failure. A non-zero exit is a genuine crash → StatusError.
+//
+// No exit code available (pane torn down without remain-on-exit, so tmux
+// discarded the exit status) falls back to a per-tool heuristic. For
+// hook-emitting tools a vanished pane genuinely means a crash → StatusError.
+// OpenCode emits no lifecycle hooks (issue #1617), so an in-session `/exit`
+// closes its pane exactly like a crash would; a vanished OpenCode pane is
+// overwhelmingly a user-initiated exit → StatusStopped. Error stays reserved
 // for a LIVE pane that renders an actual error banner.
 func (i *Instance) terminatedPaneStatus() Status {
-	if i.Tool == "opencode" {
+	exitCode, haveExitCode := 0, false
+	if i.tmuxSession != nil {
+		exitCode, haveExitCode = i.tmuxSession.PaneDeadExitStatus()
+	}
+	return classifyTerminatedPane(exitCode, haveExitCode, i.Tool)
+}
+
+// classifyTerminatedPane is the pure decision behind terminatedPaneStatus,
+// split out so the clean-exit-vs-crash rule can be exercised without a live
+// tmux server. See terminatedPaneStatus for the full rationale.
+func classifyTerminatedPane(exitCode int, haveExitCode bool, tool string) Status {
+	if haveExitCode {
+		if exitCode == 0 {
+			return StatusStopped
+		}
+		return StatusError
+	}
+	if tool == "opencode" {
 		return StatusStopped
 	}
 	return StatusError
@@ -4342,9 +4364,11 @@ func (i *Instance) UpdateStatus() error {
 		// progress without user action — report error, not waiting.
 		i.Status = StatusError
 	case "inactive":
-		// Pane is gone/dead. A crash for hook tools, but a clean `/exit` for
-		// OpenCode (no hooks, no exit code to read) — classify per tool so a
-		// clean OpenCode shutdown reads as stopped (■), not error (✕). #1617.
+		// Pane is dead/gone. terminatedPaneStatus prefers the real exit code
+		// when remain-on-exit still holds the dead pane — a clean exit 0 reads
+		// as stopped (■), a non-zero exit or an unknowable exit falls back to a
+		// per-tool heuristic (crash → ✕ for hook tools, clean `/exit` → ■ for
+		// OpenCode). #1617, and clean one-shot completions.
 		i.Status = i.terminatedPaneStatus()
 	default:
 		i.Status = StatusError

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4049,12 +4049,48 @@ func shouldDebounceTmuxFlipForTool(tool string) bool {
 // closes its pane exactly like a crash would; a vanished OpenCode pane is
 // overwhelmingly a user-initiated exit → StatusStopped. Error stays reserved
 // for a LIVE pane that renders an actual error banner.
+//
+// NOTE: PaneDeadExitStatus shells out to tmux and can block up to its probe
+// timeout. Callers on the UpdateStatus path (which run under i.mu) must NOT use
+// this directly when a live tmux session may be queried — use
+// applyTerminatedPaneStatus, which drops i.mu around the query. This method is
+// safe to call under i.mu only when i.tmuxSession is nil (no subprocess runs).
 func (i *Instance) terminatedPaneStatus() Status {
 	exitCode, haveExitCode := 0, false
 	if i.tmuxSession != nil {
 		exitCode, haveExitCode = i.tmuxSession.PaneDeadExitStatus()
 	}
 	return classifyTerminatedPane(exitCode, haveExitCode, i.Tool)
+}
+
+// applyTerminatedPaneStatus writes the terminated-pane classification to
+// i.Status without holding i.mu across the (potentially slow) tmux query.
+//
+// PaneDeadExitStatus can block for the full tmux probe timeout, and every
+// UpdateStatus caller runs under i.mu — so querying tmux under the lock lets a
+// wedged tmux server stall concurrent lifecycle operations. Instead: snapshot
+// the tmux session and tool under the lock, release i.mu for the query, then
+// reacquire and apply the result. The caller MUST hold i.mu on entry; i.mu is
+// held again on return.
+//
+// Because the lock is dropped, i.Status may change under us (e.g. a concurrent
+// Stop()), so the stopped-state guard is re-evaluated after reacquiring: a
+// session the user stopped mid-query must not be clobbered with error/stopped.
+func (i *Instance) applyTerminatedPaneStatus() {
+	tmuxSession := i.tmuxSession
+	tool := i.Tool
+
+	i.mu.Unlock()
+	exitCode, haveExitCode := 0, false
+	if tmuxSession != nil {
+		exitCode, haveExitCode = tmuxSession.PaneDeadExitStatus()
+	}
+	status := classifyTerminatedPane(exitCode, haveExitCode, tool)
+	i.mu.Lock()
+
+	if i.Status != StatusStopped {
+		i.Status = status
+	}
 }
 
 // classifyTerminatedPane is the pure decision behind terminatedPaneStatus,
@@ -4121,8 +4157,11 @@ func (i *Instance) UpdateStatus() error {
 			// Added but never started: no tmux session was ever created, so an
 			// absent tmux is expected — classify as idle, not error (✕ → ○).
 			i.Status = StatusIdle
-		} else if i.Status != StatusStopped {
-			i.Status = i.terminatedPaneStatus()
+		} else {
+			// tmux session is non-nil here, so the exit-status probe can block;
+			// applyTerminatedPaneStatus drops i.mu for the query and keeps the
+			// stopped-state guard on write.
+			i.applyTerminatedPaneStatus()
 		}
 		i.lastErrorCheck = time.Now() // Record when we confirmed error/stopped
 		return nil
@@ -4368,8 +4407,9 @@ func (i *Instance) UpdateStatus() error {
 		// when remain-on-exit still holds the dead pane — a clean exit 0 reads
 		// as stopped (■), a non-zero exit or an unknowable exit falls back to a
 		// per-tool heuristic (crash → ✕ for hook tools, clean `/exit` → ■ for
-		// OpenCode). #1617, and clean one-shot completions.
-		i.Status = i.terminatedPaneStatus()
+		// OpenCode). #1617, and clean one-shot completions. The probe can block,
+		// so applyTerminatedPaneStatus runs it without holding i.mu.
+		i.applyTerminatedPaneStatus()
 	default:
 		i.Status = StatusError
 	}

--- a/internal/session/oneshot_exit_status_test.go
+++ b/internal/session/oneshot_exit_status_test.go
@@ -1,0 +1,68 @@
+package session
+
+import "testing"
+
+// TestClassifyTerminatedPane_CleanExitVsCrash pins the classification of a
+// session whose tmux pane has terminated after having been started.
+//
+// A one-shot worker runs a command that finishes and exits. When tmux still
+// holds the dead pane (remain-on-exit), the real process exit code is
+// available: exit 0 is a clean completion (■ StatusStopped), not a crash — the
+// bug was that every terminated pane read as StatusError (✕), making a
+// successful one-shot exit indistinguishable from a genuine failure. A
+// non-zero exit is a real crash → StatusError.
+//
+// When no exit code is available (pane torn down without remain-on-exit, so
+// tmux discarded the exit status), classification falls back to the per-tool
+// heuristic: OpenCode's hookless `/exit` reads as stopped (#1617); every other
+// tool's vanished pane stays a crash signal.
+func TestClassifyTerminatedPane_CleanExitVsCrash(t *testing.T) {
+	tests := []struct {
+		name         string
+		exitCode     int
+		haveExitCode bool
+		tool         string
+		want         Status
+	}{
+		// Exit code known (remain-on-exit): the code decides, tool is irrelevant.
+		{"clean exit 0 (shell)", 0, true, "shell", StatusStopped},
+		{"clean exit 0 (claude)", 0, true, "claude", StatusStopped},
+		{"clean exit 0 (sandboxed worker)", 0, true, "codex", StatusStopped},
+		{"crash exit 1", 1, true, "shell", StatusError},
+		{"crash exit 137 (SIGKILL)", 137, true, "claude", StatusError},
+		{"crash exit 2 (opencode)", 2, true, "opencode", StatusError},
+
+		// No exit code (pane torn down): fall back to the per-tool heuristic.
+		{"no exit code, opencode clean /exit", 0, false, "opencode", StatusStopped},
+		{"no exit code, claude crash", 0, false, "claude", StatusError},
+		{"no exit code, shell", 0, false, "shell", StatusError},
+		{"no exit code, unknown tool", 0, false, "", StatusError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyTerminatedPane(tt.exitCode, tt.haveExitCode, tt.tool)
+			if got != tt.want {
+				t.Errorf("classifyTerminatedPane(%d, %v, %q) = %q, want %q",
+					tt.exitCode, tt.haveExitCode, tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTerminatedPaneStatus_NilTmuxFallsBackToTool guards the no-tmux path: with
+// no session to read an exit code from, terminatedPaneStatus must degrade to
+// the per-tool heuristic rather than assume a clean exit.
+func TestTerminatedPaneStatus_NilTmuxFallsBackToTool(t *testing.T) {
+	cases := map[string]Status{
+		"opencode": StatusStopped,
+		"claude":   StatusError,
+		"shell":    StatusError,
+		"":         StatusError,
+	}
+	for tool, want := range cases {
+		i := &Instance{Tool: tool}
+		if got := i.terminatedPaneStatus(); got != want {
+			t.Errorf("terminatedPaneStatus() nil tmux, tool %q = %q, want %q", tool, got, want)
+		}
+	}
+}

--- a/internal/tmux/pane_dead_status_test.go
+++ b/internal/tmux/pane_dead_status_test.go
@@ -1,0 +1,33 @@
+package tmux
+
+import "testing"
+
+// TestParsePaneDeadStatus covers the "#{pane_dead}|#{pane_dead_status}" parsing
+// that lets status detection tell a clean one-shot exit (code 0) from a crash.
+func TestParsePaneDeadStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantCode int
+		wantOK   bool
+	}{
+		{"clean exit 0", "1|0\n", 0, true},
+		{"crash exit 1", "1|1", 1, true},
+		{"crash exit 137", "1|137\n", 137, true},
+		{"live pane", "0|", 0, false},
+		{"live pane with stale status", "0|0", 0, false},
+		{"dead pane, no remain-on-exit (empty status)", "1|", 0, false},
+		{"dead pane, non-numeric status", "1|foo", 0, false},
+		{"malformed, no separator", "1", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, ok := parsePaneDeadStatus(tt.raw)
+			if code != tt.wantCode || ok != tt.wantOK {
+				t.Errorf("parsePaneDeadStatus(%q) = (%d, %v), want (%d, %v)",
+					tt.raw, code, ok, tt.wantCode, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2441,6 +2441,46 @@ func (s *Session) IsPaneDead() bool {
 	return strings.TrimSpace(string(out)) == "1"
 }
 
+// PaneDeadExitStatus returns the exit code of the process that ran in the
+// session's primary pane, and true, but ONLY when the pane died while
+// remain-on-exit was enabled so tmux still holds the dead pane and its exit
+// status (#{pane_dead_status}).
+//
+// The second return is false whenever no exit code is available: the pane is
+// still alive, the session is gone, or the pane was torn down without
+// remain-on-exit (in which case tmux discards the exit status along with the
+// pane, and #{pane_dead_status} comes back empty). Callers use the (code, ok)
+// pair to distinguish a clean exit (0) from a crash (non-zero) instead of
+// treating every terminated pane as an error.
+func (s *Session) PaneDeadExitStatus() (int, bool) {
+	// Bounded like IsPaneDead: this runs on the notify-daemon poll loop, so a
+	// wedged tmux server must not stall it.
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+	out, err := s.tmuxCmdContext(ctx, "list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}|#{pane_dead_status}").Output()
+	if err != nil {
+		return 0, false
+	}
+	return parsePaneDeadStatus(string(out))
+}
+
+// parsePaneDeadStatus interprets the "#{pane_dead}|#{pane_dead_status}" line
+// tmux emits for a pane. It returns (code, true) only for a dead pane whose
+// exit status is a parseable integer — i.e. one preserved by remain-on-exit.
+// A live pane ("0|..."), or a dead pane with an empty status field (no
+// remain-on-exit), yields (0, false). Pure so the parsing is unit-testable.
+func parsePaneDeadStatus(raw string) (int, bool) {
+	dead, status, ok := strings.Cut(strings.TrimSpace(raw), "|")
+	if !ok || dead != "1" {
+		return 0, false // pane not dead → no meaningful exit status
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(status))
+	if err != nil {
+		return 0, false // remain-on-exit off → pane_dead_status is empty
+	}
+	return code, true
+}
+
 // buildStatusBarArgs returns the tmux command args for configuring the status bar.
 // Returns nil if status bar injection is disabled.
 // Skips any option key that exists in s.OptionOverrides — user-defined options take precedence.


### PR DESCRIPTION
## What problem does this solve?
When a session's tmux pane terminates, agent-deck reads the pane's exit code to tell a clean one-shot exit from a crash. That read shells out to tmux, and it was happening while the per-session status lock was held. If the tmux server was slow or wedged, every other status update and lifecycle action on that session stalled for up to the probe timeout.

## Why this change
The lock only needs to protect the session fields, not the external tmux call. Snapshotting those fields under the lock and releasing it for the probe removes the head-of-line blocking while keeping the write path race-safe.

## User impact
Under a slow or unresponsive tmux server, session status and lifecycle operations no longer freeze while the exit-code probe runs. Status classification is unchanged; only the locking around the probe changed.

## Evidence
Touched package, new test:

    $ go test ./internal/session/ -run ApplyTerminatedPaneStatus -v
    === RUN   TestApplyTerminatedPaneStatus_HoldsLockOnReturn
    --- PASS: TestApplyTerminatedPaneStatus_HoldsLockOnReturn (0.00s)
    === RUN   TestApplyTerminatedPaneStatus_StoppedGuard
    --- PASS: TestApplyTerminatedPaneStatus_StoppedGuard (0.00s)
    === RUN   TestApplyTerminatedPaneStatus_ConcurrentRaceSafe
    --- PASS: TestApplyTerminatedPaneStatus_ConcurrentRaceSafe (0.00s)
    PASS
    ok  	github.com/asheshgoplani/agent-deck/internal/session	0.126s

Same package under the race detector (the concurrency test drives the helper from 50 goroutines contending on the lock):

    $ go test -race ./internal/session/ -run 'ApplyTerminatedPaneStatus|TerminatedPaneStatus|ClassifyTerminatedPane'
    ok  	github.com/asheshgoplani/agent-deck/internal/session	1.536s

Sandboxed full suite (`HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`): most packages pass, but this host has pre-existing, environment-only failures that reproduce **identically on clean upstream/main** — so they are not introduced by this change and are outside the changed code path:

- `internal/session` / `internal/ui`: file-watcher and search-index tests (`TestStatusEventWatcher_*`, `TestStatusFileWatcher_*`, `TestGlobalSearchIndex*`, `TestHome*Search*`) fail with `couldn't initialize inotify: too many open files` — a host fd/inotify limit, not a logic failure.
- `internal/tmux` / `internal/testutil`: `TestTmuxBootstrap_ServerIsRunning`, `TestTestMainDoesNotLeakBootstrapServer` fail because no tmux server can bootstrap under the throwaway sandbox HOME (`list-sessions: exit status 1`).
- `internal/session`: `TestUpdateStatus_ShellForegroundPromotion` is a timing-sensitive grace-period test that also fails on upstream/main.

None involve the terminated-pane/status-locking path this PR changes; the new tests above pass, and the changed package's terminated-pane tests pass under `-race`.

Hot path (status): before, the exit-code probe (`PaneDeadExitStatus`, a tmux subprocess bounded to a ~2s timeout) ran while `i.mu` was held, so a wedged tmux server could hold the lock for the full timeout and block every concurrent status/lifecycle caller on that session. After, `i.mu` is held only to snapshot the session and tool (sub-microsecond), the probe runs lock-free, and the lock is reacquired to write the result — a slow tmux no longer blocks concurrent status updates, and the fast path adds no latency.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you
My operator ran a self-improvement analysis over heavy, long-running agent-deck conductor usage; it surfaced this as a reproducible defect. They asked me to fix the agent-deck bugs the analysis found and send them upstream. A slow or unresponsive tmux server would freeze unrelated session status updates because the pane exit-code probe ran while the session status lock was held.

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — see Evidence: only pre-existing, environment-only failures remain (inotify fd limit, tmux bootstrap, one timing flake), all reproducing on clean upstream/main; the changed package's targeted tests pass under `-race`.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->
