### PR TITLE
fix(conductor): tolerate non-numeric telegram/discord IDs instead of hard-failing config load

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -349,7 +349,7 @@ func handleConductorSetup(profile string, args []string) {
 						os.Exit(1)
 					}
 
-					settings.Telegram = session.TelegramSettings{Token: token, UserID: session.ConductorID(userID)}
+					settings.Telegram = session.TelegramSettings{Token: token, UserID: session.NewConductorID(userID)}
 					configChanged = true
 				}
 			}
@@ -448,7 +448,7 @@ func handleConductorSetup(profile string, args []string) {
 						os.Exit(1)
 					}
 
-					settings.Discord = session.DiscordSettings{BotToken: dcBotToken, GuildID: session.ConductorID(dcGuildID), ChannelID: session.ConductorID(dcChannelID), UserID: session.ConductorID(dcUserID)}
+					settings.Discord = session.DiscordSettings{BotToken: dcBotToken, GuildID: session.NewConductorID(dcGuildID), ChannelID: session.NewConductorID(dcChannelID), UserID: session.NewConductorID(dcUserID)}
 					configChanged = true
 				}
 			}

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -349,7 +349,7 @@ func handleConductorSetup(profile string, args []string) {
 						os.Exit(1)
 					}
 
-					settings.Telegram = session.TelegramSettings{Token: token, UserID: userID}
+					settings.Telegram = session.TelegramSettings{Token: token, UserID: session.ConductorID(userID)}
 					configChanged = true
 				}
 			}
@@ -448,7 +448,7 @@ func handleConductorSetup(profile string, args []string) {
 						os.Exit(1)
 					}
 
-					settings.Discord = session.DiscordSettings{BotToken: dcBotToken, GuildID: dcGuildID, ChannelID: dcChannelID, UserID: dcUserID}
+					settings.Discord = session.DiscordSettings{BotToken: dcBotToken, GuildID: session.ConductorID(dcGuildID), ChannelID: session.ConductorID(dcChannelID), UserID: session.ConductorID(dcUserID)}
 					configChanged = true
 				}
 			}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,13 +107,60 @@ type ConductorSettings struct {
 	Dir string `toml:"dir,omitempty"`
 }
 
+// ConductorID is a numeric bot identifier used by the conductor bridge — a
+// Telegram/Discord user, guild, or channel ID. It decodes tolerantly so that a
+// single malformed value cannot poison the entire config.toml parse.
+//
+// These IDs are consumed only by the optional conductor bridge, yet as a plain
+// int64 a single non-numeric value (e.g. user_id = "not-a-number") made
+// toml.DecodeFile return an error, which made LoadUserConfig fail, which in
+// turn took down completely unrelated commands (e.g. `remote list`) and
+// surfaced a spurious "loadout inactive" warning on every session launch.
+//
+// A well-formed integer — or a quoted numeric string, which users routinely
+// write for these large IDs — decodes to its value. Anything else degrades to
+// 0 (the bridge treats 0 as "unset") and is logged, rather than failing the
+// whole config load.
+type ConductorID int64
+
+// UnmarshalTOML implements toml.Unmarshaler. See ConductorID for why an
+// unparseable value degrades to 0 instead of returning a (config-poisoning)
+// error.
+func (c *ConductorID) UnmarshalTOML(v interface{}) error {
+	switch val := v.(type) {
+	case int64:
+		*c = ConductorID(val)
+	case string:
+		s := strings.TrimSpace(val)
+		if s == "" {
+			*c = 0
+			return nil
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			*c = 0
+			sessionLog.Warn("conductor_id_unparseable",
+				slog.String("value", sanitizeLoadoutWarning(val)),
+				slog.String("fallback", "0 (treated as unset)"))
+			return nil
+		}
+		*c = ConductorID(n)
+	default:
+		*c = 0
+		sessionLog.Warn("conductor_id_unexpected_type",
+			slog.String("type", fmt.Sprintf("%T", v)),
+			slog.String("fallback", "0 (treated as unset)"))
+	}
+	return nil
+}
+
 // TelegramSettings defines Telegram bot configuration for the conductor bridge
 type TelegramSettings struct {
 	// Token is the Telegram bot token from @BotFather
 	Token string `toml:"token,omitempty"`
 
 	// UserID is the authorized Telegram user ID from @userinfobot
-	UserID int64 `toml:"user_id,omitzero"`
+	UserID ConductorID `toml:"user_id,omitzero"`
 }
 
 // SlackSettings defines Slack bot configuration for the conductor bridge
@@ -142,13 +190,13 @@ type DiscordSettings struct {
 	BotToken string `toml:"bot_token,omitempty"`
 
 	// GuildID is the Discord server (guild) where the bot operates
-	GuildID int64 `toml:"guild_id,omitzero"`
+	GuildID ConductorID `toml:"guild_id,omitzero"`
 
 	// ChannelID is the Discord channel where the bot listens and posts
-	ChannelID int64 `toml:"channel_id,omitzero"`
+	ChannelID ConductorID `toml:"channel_id,omitzero"`
 
 	// UserID is the authorized Discord user ID
-	UserID int64 `toml:"user_id,omitzero"`
+	UserID ConductorID `toml:"user_id,omitzero"`
 
 	// ListenMode controls when the bot responds: "mentions" (only @mentions) or "all" (all channel messages)
 	// Default: "all"

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -107,51 +107,158 @@ type ConductorSettings struct {
 	Dir string `toml:"dir,omitempty"`
 }
 
-// ConductorID is a numeric bot identifier used by the conductor bridge — a
-// Telegram/Discord user, guild, or channel ID. It decodes tolerantly so that a
-// single malformed value cannot poison the entire config.toml parse.
+// ConductorID is a Telegram/Discord bot identifier used by the conductor
+// bridge — a user, guild, or channel ID. It holds the identifier's ORIGINAL
+// TEXT as written in config.toml rather than an int64, which buys two things:
 //
-// These IDs are consumed only by the optional conductor bridge, yet as a plain
-// int64 a single non-numeric value (e.g. user_id = "not-a-number") made
-// toml.DecodeFile return an error, which made LoadUserConfig fail, which in
-// turn took down completely unrelated commands (e.g. `remote list`) and
-// surfaced a spurious "loadout inactive" warning on every session launch.
+//  1. Tolerant load. As a plain int64, one non-numeric value (e.g.
+//     user_id = "not-a-number") made toml.DecodeFile return an error, which made
+//     LoadUserConfig fail, which took down completely unrelated commands (e.g.
+//     `remote list`) and surfaced a spurious "loadout inactive" warning on every
+//     session launch. Decoding a ConductorID never fails.
 //
-// A well-formed integer — or a quoted numeric string, which users routinely
-// write for these large IDs — decodes to its value. Anything else degrades to
-// 0 (the bridge treats 0 as "unset") and is logged, rather than failing the
-// whole config load.
-type ConductorID int64
+//  2. Lossless save. The bridge resolves these fields through _resolve_secret,
+//     so "$TELEGRAM_USER_ID" / "${DISCORD_USER_ID}" / "keychain:name" are
+//     supported values (conductor_bridge.py). Because the fields are omitempty,
+//     normalizing an unparseable value to 0 in memory meant the next unrelated
+//     SaveUserConfig DELETED the key from disk — a config-data-loss bug traded
+//     for a config-load-failure bug. Keeping the text makes
+//     load → save → reload a no-op for every value shape.
+//
+// The numeric conversion lives at the consumer boundary instead: Int64 for Go
+// callers, and NewConductorID for the `conductor setup` writers, which validate
+// the operator's input as an integer before storing it. Nothing in Go consumes
+// these IDs numerically today — the bridge parses config.toml itself.
+type ConductorID string
 
-// UnmarshalTOML implements toml.Unmarshaler. See ConductorID for why an
-// unparseable value degrades to 0 instead of returning a (config-poisoning)
-// error.
+// NewConductorID renders an already-validated numeric ID as its canonical
+// decimal text. Configs written by `conductor setup` therefore stay
+// byte-identical to what the pre-ConductorID int64 encoder produced: a bare
+// TOML integer.
+func NewConductorID(id int64) ConductorID {
+	return ConductorID(strconv.FormatInt(id, 10))
+}
+
+// Int64 is the numeric view of the stored text. ok is false when the text is
+// not a base-10 integer — unset, an unresolved indirection such as
+// "$TELEGRAM_USER_ID", or malformed — mirroring the bridge, which only applies
+// int() to a value that resolved to something non-empty and treats the rest
+// as 0/unset.
+func (c ConductorID) Int64() (int64, bool) {
+	n, err := strconv.ParseInt(strings.TrimSpace(string(c)), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// conductorIDIndirection reports whether the text is one of the indirection
+// forms the bridge's _resolve_secret understands, so those are not warned about
+// as malformed.
+func conductorIDIndirection(s string) bool {
+	return strings.HasPrefix(s, "$") || strings.HasPrefix(s, "keychain:")
+}
+
+// canonicalConductorIDInt reports whether the text is exactly how the TOML
+// encoder would render its own integer value. Anything else (leading zeros, a
+// leading +, underscores, surrounding whitespace) must be emitted as a quoted
+// string: `user_id = 0123` is not valid TOML, so re-emitting it bare would
+// write a config that no longer parses.
+func canonicalConductorIDInt(s string) bool {
+	n, err := strconv.ParseInt(s, 10, 64)
+	return err == nil && strconv.FormatInt(n, 10) == s
+}
+
+// UnmarshalTOML implements toml.Unmarshaler. It accepts a bare TOML integer or
+// a string and stores the text; a value that is neither a usable integer nor a
+// bridge indirection form is kept verbatim and warned about, rather than
+// failing the whole config load (the old int64 behavior) or being normalized
+// away (which the save path would then write back as a deletion).
 func (c *ConductorID) UnmarshalTOML(v interface{}) error {
 	switch val := v.(type) {
 	case int64:
-		*c = ConductorID(val)
+		*c = NewConductorID(val)
 	case string:
+		*c = ConductorID(val)
 		s := strings.TrimSpace(val)
-		if s == "" {
-			*c = 0
-			return nil
+		switch {
+		case s == "":
+			// Explicitly empty. Same "treated as unset" outcome as a
+			// malformed value, so it warns the same way.
+			sessionLog.Warn("conductor_id_empty",
+				slog.String("effect", "treated as unset"))
+		case conductorIDIndirection(s), canonicalConductorIDInt(s):
+			// Supported: an env-var/keychain reference the bridge resolves,
+			// or a plain integer written as a quoted string.
+		default:
+			if _, ok := c.Int64(); !ok {
+				sessionLog.Warn("conductor_id_unparseable",
+					slog.String("value", sanitizeLoadoutWarning(val)),
+					slog.String("effect", "preserved verbatim, treated as unset"))
+			}
 		}
-		n, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
-			*c = 0
-			sessionLog.Warn("conductor_id_unparseable",
-				slog.String("value", sanitizeLoadoutWarning(val)),
-				slog.String("fallback", "0 (treated as unset)"))
-			return nil
-		}
-		*c = ConductorID(n)
 	default:
-		*c = 0
+		// A TOML float, bool, or datetime. There is no source text to keep,
+		// so render the decoded value rather than dropping the key on the
+		// next save.
+		*c = ConductorID(fmt.Sprintf("%v", v))
 		sessionLog.Warn("conductor_id_unexpected_type",
 			slog.String("type", fmt.Sprintf("%T", v)),
-			slog.String("fallback", "0 (treated as unset)"))
+			slog.String("effect", "preserved as text, treated as unset"))
 	}
 	return nil
+}
+
+// MarshalTOML implements toml.Marshaler. It re-emits a bare TOML integer when
+// the stored text is exactly one, and a quoted basic string otherwise: an
+// existing `user_id = 12345` stays byte-identical, and everything a plain int64
+// could not represent — `user_id = "$TELEGRAM_USER_ID"`, a keychain reference, a
+// malformed value — survives the save verbatim.
+//
+// The one shape that is normalized rather than preserved is a quoted numeric:
+// `user_id = "12345"` is re-emitted as `user_id = 12345`, because text alone
+// cannot carry "was quoted at the source" alongside the value. The value is
+// unchanged and the bridge coerces both shapes with int(), so this is a
+// representation normalization, not data loss.
+func (c ConductorID) MarshalTOML() ([]byte, error) {
+	s := string(c)
+	if canonicalConductorIDInt(s) {
+		return []byte(s), nil
+	}
+	return []byte(`"` + escapeTOMLBasicString(s) + `"`), nil
+}
+
+// escapeTOMLBasicString escapes s for inclusion in a TOML basic string, which
+// permits only the \b \t \n \f \r \" \\ \uXXXX escapes — notably not Go's \x
+// or \a forms, so strconv.Quote cannot be used here.
+func escapeTOMLBasicString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\f':
+			b.WriteString(`\f`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04X`, r)
+				continue
+			}
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // TelegramSettings defines Telegram bot configuration for the conductor bridge
@@ -159,8 +266,13 @@ type TelegramSettings struct {
 	// Token is the Telegram bot token from @BotFather
 	Token string `toml:"token,omitempty"`
 
-	// UserID is the authorized Telegram user ID from @userinfobot
-	UserID ConductorID `toml:"user_id,omitzero"`
+	// UserID is the authorized Telegram user ID from @userinfobot.
+	//
+	// omitempty, not omitzero: the encoder's omitzero only recognizes zero ints
+	// and floats, so on a text-backed ConductorID it would never fire and every
+	// save would write `user_id = ""` into configs that never set one. omitempty
+	// keys off an empty string, which is what "unset" is now.
+	UserID ConductorID `toml:"user_id,omitempty"`
 }
 
 // SlackSettings defines Slack bot configuration for the conductor bridge
@@ -190,13 +302,13 @@ type DiscordSettings struct {
 	BotToken string `toml:"bot_token,omitempty"`
 
 	// GuildID is the Discord server (guild) where the bot operates
-	GuildID ConductorID `toml:"guild_id,omitzero"`
+	GuildID ConductorID `toml:"guild_id,omitempty"`
 
 	// ChannelID is the Discord channel where the bot listens and posts
-	ChannelID ConductorID `toml:"channel_id,omitzero"`
+	ChannelID ConductorID `toml:"channel_id,omitempty"`
 
 	// UserID is the authorized Discord user ID
-	UserID ConductorID `toml:"user_id,omitzero"`
+	UserID ConductorID `toml:"user_id,omitempty"`
 
 	// ListenMode controls when the bot responds: "mentions" (only @mentions) or "all" (all channel messages)
 	// Default: "all"

--- a/internal/session/conductor_id_test.go
+++ b/internal/session/conductor_id_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +21,18 @@ func writeUserConfig(t *testing.T, xdgConfigHome, contents string) {
 	ClearUserConfigCache()
 }
 
+// readUserConfigFile returns the raw on-disk config.toml, for the round-trip
+// tests that assert on the textual representation rather than the decoded value.
+func readUserConfigFile(t *testing.T, xdgConfigHome string) string {
+	t.Helper()
+	path := filepath.Join(xdgConfigHome, "agent-deck", "config.toml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	return string(data)
+}
+
 // TestLoadUserConfig_NonNumericConductorID is the regression guard for the bug
 // where a single non-numeric conductor bot ID in config.toml poisoned the whole
 // TOML parse. Because user_id/guild_id/channel_id were plain int64 fields, a
@@ -27,9 +40,9 @@ func writeUserConfig(t *testing.T, xdgConfigHome, contents string) {
 // LoadUserConfig error out and took down completely unrelated commands (the
 // config here also declares a remote, mirroring how `remote list` broke).
 //
-// After the fix these IDs decode tolerantly: a malformed value degrades to 0
-// (bridge treats it as unset) instead of failing the load, so unrelated config
-// (the remote) still parses.
+// After the fix these IDs decode tolerantly: the text is preserved and reads as
+// unusable (the bridge treats it as unset) instead of failing the load, so
+// unrelated config (the remote) still parses.
 func TestLoadUserConfig_NonNumericConductorID(t *testing.T) {
 	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
 
@@ -57,23 +70,29 @@ user_id = "still-not-numeric"
 		t.Fatalf("unrelated [remotes.example] must still parse; got remotes: %v", config.Remotes)
 	}
 
-	if got := config.Conductor.Telegram.UserID; got != 0 {
-		t.Errorf("telegram user_id: want degrade to 0, got %d", got)
-	}
-	if got := config.Conductor.Discord.GuildID; got != 0 {
-		t.Errorf("discord guild_id: want degrade to 0, got %d", got)
-	}
-	if got := config.Conductor.Discord.ChannelID; got != 0 {
-		t.Errorf("discord channel_id: want degrade to 0, got %d", got)
-	}
-	if got := config.Conductor.Discord.UserID; got != 0 {
-		t.Errorf("discord user_id: want degrade to 0, got %d", got)
+	for _, tc := range []struct {
+		field string
+		got   ConductorID
+		want  ConductorID
+	}{
+		{"telegram user_id", config.Conductor.Telegram.UserID, "not-a-number"},
+		{"discord guild_id", config.Conductor.Discord.GuildID, "also-not-a-number"},
+		{"discord channel_id", config.Conductor.Discord.ChannelID, "nope"},
+		{"discord user_id", config.Conductor.Discord.UserID, "still-not-numeric"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s: want text preserved as %q, got %q", tc.field, tc.want, tc.got)
+		}
+		if n, ok := tc.got.Int64(); ok {
+			t.Errorf("%s: malformed value must not read as a usable number; got %d", tc.field, n)
+		}
 	}
 }
 
 // TestLoadUserConfig_ConductorIDForms verifies the tolerant decoder still
 // accepts the well-formed shapes: a bare TOML integer and a quoted numeric
-// string (which users routinely write for these large IDs).
+// string (which users routinely write for these large IDs). Both must yield the
+// same usable number at the consumer boundary.
 func TestLoadUserConfig_ConductorIDForms(t *testing.T) {
 	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
 
@@ -95,16 +114,274 @@ user_id = "13579"
 		t.Fatalf("LoadUserConfig: %v", err)
 	}
 
-	if got := config.Conductor.Telegram.UserID; got != 12345 {
-		t.Errorf("telegram user_id (bare int): want 12345, got %d", got)
+	for _, tc := range []struct {
+		field string
+		got   ConductorID
+		want  int64
+	}{
+		{"telegram user_id (bare int)", config.Conductor.Telegram.UserID, 12345},
+		{"discord guild_id (quoted numeric)", config.Conductor.Discord.GuildID, 67890},
+		{"discord channel_id (bare int)", config.Conductor.Discord.ChannelID, 24680},
+		{"discord user_id (quoted numeric)", config.Conductor.Discord.UserID, 13579},
+	} {
+		n, ok := tc.got.Int64()
+		if !ok {
+			t.Errorf("%s: want a usable number, got unusable text %q", tc.field, tc.got)
+			continue
+		}
+		if n != tc.want {
+			t.Errorf("%s: want %d, got %d", tc.field, tc.want, n)
+		}
 	}
-	if got := config.Conductor.Discord.GuildID; got != 67890 {
-		t.Errorf("discord guild_id (quoted numeric): want 67890, got %d", got)
+}
+
+// TestConductorID_RoundTripPreservesEnvRefs is round-trip requirement 1: the
+// bridge resolves telegram.user_id / discord.user_id through _resolve_secret, so
+// "$TELEGRAM_USER_ID" and "${DISCORD_USER_ID}" are supported values. Under the
+// old int64 field they normalized to 0 in memory, and because the field is
+// omitempty the next unrelated SaveUserConfig DELETED the line from config.toml.
+// Load → save → reload must leave both references untouched.
+func TestConductorID_RoundTripPreservesEnvRefs(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	const cfg = `
+[conductor.telegram]
+token = "dummy-token"
+user_id = "$TELEGRAM_USER_ID"
+
+[conductor.discord]
+bot_token = "dummy-token"
+guild_id = 111
+channel_id = 222
+user_id = "${DISCORD_USER_ID}"
+`
+	writeUserConfig(t, xdgConfigHome, cfg)
+
+	config, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
 	}
-	if got := config.Conductor.Discord.ChannelID; got != 24680 {
-		t.Errorf("discord channel_id (bare int): want 24680, got %d", got)
+	if got := config.Conductor.Telegram.UserID; got != "$TELEGRAM_USER_ID" {
+		t.Fatalf("telegram user_id after load: want %q, got %q", "$TELEGRAM_USER_ID", got)
 	}
-	if got := config.Conductor.Discord.UserID; got != 13579 {
-		t.Errorf("discord user_id (quoted numeric): want 13579, got %d", got)
+	if got := config.Conductor.Discord.UserID; got != "${DISCORD_USER_ID}" {
+		t.Fatalf("discord user_id after load: want %q, got %q", "${DISCORD_USER_ID}", got)
+	}
+
+	if err := SaveUserConfig(config); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	onDisk := readUserConfigFile(t, xdgConfigHome)
+	for _, want := range []string{`user_id = "$TELEGRAM_USER_ID"`, `user_id = "${DISCORD_USER_ID}"`} {
+		if !strings.Contains(onDisk, want) {
+			t.Errorf("saved config.toml must still contain %s; got:\n%s", want, onDisk)
+		}
+	}
+
+	reloaded, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig after save: %v", err)
+	}
+	if got := reloaded.Conductor.Telegram.UserID; got != "$TELEGRAM_USER_ID" {
+		t.Errorf("telegram user_id after reload: want %q, got %q", "$TELEGRAM_USER_ID", got)
+	}
+	if got := reloaded.Conductor.Discord.UserID; got != "${DISCORD_USER_ID}" {
+		t.Errorf("discord user_id after reload: want %q, got %q", "${DISCORD_USER_ID}", got)
+	}
+}
+
+// TestConductorID_RoundTripPreservesNumericForms is round-trip requirement 2:
+// a quoted numeric ID and a bare numeric ID keep the same usable value across
+// load → save → reload. The bare form must also stay bare on disk, so upgrading
+// does not rewrite every existing config.
+//
+// A quoted numeric is the one shape that is normalized rather than preserved: a
+// text-backed ID cannot carry "was quoted in the source" alongside its value, so
+// MarshalTOML emits the canonical integer form. The value is unchanged and the
+// bridge coerces both shapes with int(), so nothing is lost.
+func TestConductorID_RoundTripPreservesNumericForms(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	const cfg = `
+[conductor.telegram]
+token = "dummy-token"
+user_id = 12345
+
+[conductor.discord]
+bot_token = "dummy-token"
+guild_id = "67890"
+channel_id = 24680
+user_id = "13579"
+`
+	writeUserConfig(t, xdgConfigHome, cfg)
+
+	config, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if err := SaveUserConfig(config); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	onDisk := readUserConfigFile(t, xdgConfigHome)
+	if !strings.Contains(onDisk, "user_id = 12345") {
+		t.Errorf("a bare-integer telegram user_id must be re-emitted bare; got:\n%s", onDisk)
+	}
+	if !strings.Contains(onDisk, "channel_id = 24680") {
+		t.Errorf("a bare-integer discord channel_id must be re-emitted bare; got:\n%s", onDisk)
+	}
+	if !strings.Contains(onDisk, "guild_id = 67890") {
+		t.Errorf("a quoted-numeric discord guild_id must keep its value, normalized to the canonical integer form; got:\n%s", onDisk)
+	}
+
+	reloaded, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig after save: %v", err)
+	}
+	for _, tc := range []struct {
+		field string
+		got   ConductorID
+		want  int64
+	}{
+		{"telegram user_id", reloaded.Conductor.Telegram.UserID, 12345},
+		{"discord guild_id", reloaded.Conductor.Discord.GuildID, 67890},
+		{"discord channel_id", reloaded.Conductor.Discord.ChannelID, 24680},
+		{"discord user_id", reloaded.Conductor.Discord.UserID, 13579},
+	} {
+		n, ok := tc.got.Int64()
+		if !ok {
+			t.Errorf("%s: want a usable number after round-trip, got %q", tc.field, tc.got)
+			continue
+		}
+		if n != tc.want {
+			t.Errorf("%s: want %d after round-trip, got %d", tc.field, tc.want, n)
+		}
+	}
+}
+
+// TestConductorID_SaveDoesNotRewriteMalformedValue is round-trip requirement 3:
+// a malformed ID sitting alongside unrelated config must survive a save that was
+// triggered by an edit elsewhere. Under the old int64 field the value normalized
+// to 0, and since these fields are omitempty the encoder dropped the key
+// entirely — the operator's line disappeared from disk without a word.
+func TestConductorID_SaveDoesNotRewriteMalformedValue(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	const cfg = `
+[remotes.example]
+host = "user@host"
+
+[conductor.telegram]
+token = "dummy-token"
+user_id = "not-a-number"
+`
+	writeUserConfig(t, xdgConfigHome, cfg)
+
+	config, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+
+	// The save is provoked by an edit to an unrelated section, the way a normal
+	// settings write would be.
+	config.Remotes["other"] = RemoteConfig{Host: "user@other"}
+	if err := SaveUserConfig(config); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	onDisk := readUserConfigFile(t, xdgConfigHome)
+	if !strings.Contains(onDisk, `user_id = "not-a-number"`) {
+		t.Errorf("the malformed telegram user_id must be preserved verbatim on save; got:\n%s", onDisk)
+	}
+	if strings.Contains(onDisk, "user_id = 0") {
+		t.Errorf("the malformed telegram user_id must not be rewritten to 0; got:\n%s", onDisk)
+	}
+
+	reloaded, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig after save: %v", err)
+	}
+	if got := reloaded.Conductor.Telegram.UserID; got != "not-a-number" {
+		t.Errorf("telegram user_id after reload: want %q, got %q", "not-a-number", got)
+	}
+	if _, ok := reloaded.Remotes["other"]; !ok {
+		t.Errorf("the unrelated edit that provoked the save must be persisted; got remotes: %v", reloaded.Remotes)
+	}
+	if _, ok := reloaded.Remotes["example"]; !ok {
+		t.Errorf("the pre-existing remote must survive the save; got remotes: %v", reloaded.Remotes)
+	}
+}
+
+// TestConductorID_WarnsOnUnusableValue covers the warning contract, including
+// the empty-string case raised in review: `user_id = ""` is treated as unset
+// like a malformed value is, so it warns the same way rather than being
+// silently accepted. A supported env-var reference must NOT warn — it is a
+// documented value shape, not an operator mistake.
+func TestConductorID_WarnsOnUnusableValue(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		value    string
+		wantWarn string
+	}{
+		{"empty string", `user_id = ""`, "conductor_id_empty"},
+		{"malformed", `user_id = "not-a-number"`, "conductor_id_unparseable"},
+		{"wrong TOML type", `user_id = 1.5`, "conductor_id_unexpected_type"},
+		{"env-var reference", `user_id = "$TELEGRAM_USER_ID"`, ""},
+		{"bare integer", `user_id = 12345`, ""},
+		{"quoted numeric", `user_id = "12345"`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+			logs := captureSessionLog(t)
+
+			writeUserConfig(t, xdgConfigHome, "[conductor.telegram]\ntoken = \"dummy-token\"\n"+tc.value+"\n")
+			if _, err := LoadUserConfig(); err != nil {
+				t.Fatalf("LoadUserConfig(%s): %v", tc.value, err)
+			}
+
+			got := logs.String()
+			if tc.wantWarn == "" {
+				if strings.Contains(got, "conductor_id_") {
+					t.Errorf("%s must not warn; got log output:\n%s", tc.value, got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantWarn) {
+				t.Errorf("%s must warn with %q; got log output:\n%s", tc.value, tc.wantWarn, got)
+			}
+		})
+	}
+}
+
+// TestConductorID_MarshalTOMLEmission pins the encoder side directly. The bare
+// form is only safe when the text is exactly what the TOML encoder would print
+// for that integer: `user_id = 0123` is not valid TOML, so a leading-zero value
+// must be quoted or the saved config would no longer parse.
+func TestConductorID_MarshalTOMLEmission(t *testing.T) {
+	for _, tc := range []struct {
+		id   ConductorID
+		want string
+	}{
+		{"12345", "12345"},
+		{"-12345", "-12345"},
+		{"0", "0"},
+		{"0123", `"0123"`},
+		{"+123", `"+123"`},
+		{" 123 ", `" 123 "`},
+		{"1_23", `"1_23"`},
+		{"$TELEGRAM_USER_ID", `"$TELEGRAM_USER_ID"`},
+		{"keychain:telegram-user-id", `"keychain:telegram-user-id"`},
+		{`quote"and\slash`, `"quote\"and\\slash"`},
+		{"9223372036854775808", `"9223372036854775808"`}, // overflows int64
+	} {
+		got, err := tc.id.MarshalTOML()
+		if err != nil {
+			t.Errorf("MarshalTOML(%q): %v", tc.id, err)
+			continue
+		}
+		if string(got) != tc.want {
+			t.Errorf("MarshalTOML(%q): want %s, got %s", tc.id, tc.want, got)
+		}
 	}
 }

--- a/internal/session/conductor_id_test.go
+++ b/internal/session/conductor_id_test.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeUserConfig writes config.toml under the test's XDG config home and
+// resets the user-config cache so the next LoadUserConfig reads it fresh.
+func writeUserConfig(t *testing.T, xdgConfigHome, contents string) {
+	t.Helper()
+	cfgDir := filepath.Join(xdgConfigHome, "agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", cfgDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile(config.toml): %v", err)
+	}
+	ClearUserConfigCache()
+}
+
+// TestLoadUserConfig_NonNumericConductorID is the regression guard for the bug
+// where a single non-numeric conductor bot ID in config.toml poisoned the whole
+// TOML parse. Because user_id/guild_id/channel_id were plain int64 fields, a
+// value like `user_id = "not-a-number"` made toml.DecodeFile fail, which made
+// LoadUserConfig error out and took down completely unrelated commands (the
+// config here also declares a remote, mirroring how `remote list` broke).
+//
+// After the fix these IDs decode tolerantly: a malformed value degrades to 0
+// (bridge treats it as unset) instead of failing the load, so unrelated config
+// (the remote) still parses.
+func TestLoadUserConfig_NonNumericConductorID(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	const cfg = `
+[remotes.example]
+host = "user@host"
+
+[conductor.telegram]
+token = "dummy-token"
+user_id = "not-a-number"
+
+[conductor.discord]
+bot_token = "dummy-token"
+guild_id = "also-not-a-number"
+channel_id = "nope"
+user_id = "still-not-numeric"
+`
+	writeUserConfig(t, xdgConfigHome, cfg)
+
+	config, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig must not fail on a non-numeric conductor ID: %v", err)
+	}
+	if _, ok := config.Remotes["example"]; !ok {
+		t.Fatalf("unrelated [remotes.example] must still parse; got remotes: %v", config.Remotes)
+	}
+
+	if got := config.Conductor.Telegram.UserID; got != 0 {
+		t.Errorf("telegram user_id: want degrade to 0, got %d", got)
+	}
+	if got := config.Conductor.Discord.GuildID; got != 0 {
+		t.Errorf("discord guild_id: want degrade to 0, got %d", got)
+	}
+	if got := config.Conductor.Discord.ChannelID; got != 0 {
+		t.Errorf("discord channel_id: want degrade to 0, got %d", got)
+	}
+	if got := config.Conductor.Discord.UserID; got != 0 {
+		t.Errorf("discord user_id: want degrade to 0, got %d", got)
+	}
+}
+
+// TestLoadUserConfig_ConductorIDForms verifies the tolerant decoder still
+// accepts the well-formed shapes: a bare TOML integer and a quoted numeric
+// string (which users routinely write for these large IDs).
+func TestLoadUserConfig_ConductorIDForms(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	const cfg = `
+[conductor.telegram]
+token = "dummy-token"
+user_id = 12345
+
+[conductor.discord]
+bot_token = "dummy-token"
+guild_id = "67890"
+channel_id = 24680
+user_id = "13579"
+`
+	writeUserConfig(t, xdgConfigHome, cfg)
+
+	config, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+
+	if got := config.Conductor.Telegram.UserID; got != 12345 {
+		t.Errorf("telegram user_id (bare int): want 12345, got %d", got)
+	}
+	if got := config.Conductor.Discord.GuildID; got != 67890 {
+		t.Errorf("discord guild_id (quoted numeric): want 67890, got %d", got)
+	}
+	if got := config.Conductor.Discord.ChannelID; got != 24680 {
+		t.Errorf("discord channel_id (bare int): want 24680, got %d", got)
+	}
+	if got := config.Conductor.Discord.UserID; got != 13579 {
+		t.Errorf("discord user_id (quoted numeric): want 13579, got %d", got)
+	}
+}

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -478,9 +478,9 @@ func TestSlackSettings_TOML(t *testing.T) {
 func TestDiscordSettings_TOML(t *testing.T) {
 	discord := DiscordSettings{
 		BotToken:              "discord-bot-token",
-		GuildID:               12345,
-		ChannelID:             67890,
-		UserID:                24680,
+		GuildID:               NewConductorID(12345),
+		ChannelID:             NewConductorID(67890),
+		UserID:                NewConductorID(24680),
 		ListenMode:            "mentions",
 		IgnoreRepliesToOthers: true,
 	}
@@ -488,14 +488,14 @@ func TestDiscordSettings_TOML(t *testing.T) {
 	if discord.BotToken != "discord-bot-token" {
 		t.Errorf("bot_token mismatch: got %q", discord.BotToken)
 	}
-	if discord.GuildID != 12345 {
-		t.Errorf("guild_id mismatch: got %d", discord.GuildID)
+	if discord.GuildID != "12345" {
+		t.Errorf("guild_id mismatch: got %q", discord.GuildID)
 	}
-	if discord.ChannelID != 67890 {
-		t.Errorf("channel_id mismatch: got %d", discord.ChannelID)
+	if discord.ChannelID != "67890" {
+		t.Errorf("channel_id mismatch: got %q", discord.ChannelID)
 	}
-	if discord.UserID != 24680 {
-		t.Errorf("user_id mismatch: got %d", discord.UserID)
+	if discord.UserID != "24680" {
+		t.Errorf("user_id mismatch: got %q", discord.UserID)
 	}
 	if discord.ListenMode != "mentions" {
 		t.Errorf("listen_mode mismatch: got %q", discord.ListenMode)


### PR DESCRIPTION
## What problem does this solve?

A conductor's telegram/discord `user_id` (and `guild_id`/`channel_id`) config fields are typed `int64`. If one conductor's config has a non-numeric value in such a field, `toml.DecodeFile` in `LoadUserConfig` hard-fails — and that single failure breaks *unrelated* commands (e.g. `agent-deck remote list`) and prints a loadout warning on every invocation.

## Why this change

A non-numeric value in one optional integration id shouldn't take down the whole config load or block unrelated commands. A tolerant decode degrades gracefully — a bad value becomes `0` and logs a warning — so the rest of agent-deck keeps working.

## User impact

A conductor whose telegram/discord id field is non-numeric no longer breaks unrelated commands or spams a loadout warning on every launch; that conductor's telegram/discord loadout is simply skipped with a warning while everything else works.

## Evidence

Touched package, verbose (the new regression tests):

```
$ go test ./internal/session/ -run 'TestLoadUserConfig_NonNumericConductorID|TestLoadUserConfig_ConductorIDForms' -v
=== RUN   TestLoadUserConfig_NonNumericConductorID
--- PASS: TestLoadUserConfig_NonNumericConductorID (0.00s)
=== RUN   TestLoadUserConfig_ConductorIDForms
--- PASS: TestLoadUserConfig_ConductorIDForms (0.00s)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/session	0.042s
```

The full `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` run was executed; the touched package (`internal/session`) is green. The only failures were in packages this PR does not touch (`internal/statedb` perf-budget tests that pass in isolation, plus a pre-existing failure already red on clean upstream `main`) — host-contention / pre-existing, not introduced here. The full-suite checklist box is left unchecked accordingly.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you

My operator ran a self-improvement analysis over heavy, long-running agent-deck conductor usage; it surfaced this as a reproducible defect. They asked me to fix the agent-deck bugs the analysis found and send them upstream. The concrete symptom: one conductor whose telegram/discord id was non-numeric made unrelated `agent-deck` commands fail and printed a config warning on every invocation.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Telegram and Discord identifiers in configuration.
  * Preserved numeric IDs, environment-variable references, empty values, and malformed values when loading and saving settings.
  * Added warnings for unusable identifier values without preventing configuration from loading.
  * Ensured identifiers retain their original format across configuration reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->