### PR TITLE
fix(session): route stale-session output by transcript cwd, not mtime

### DIFF
--- a/internal/session/diskscan_shared_prefix_test.go
+++ b/internal/session/diskscan_shared_prefix_test.go
@@ -1,0 +1,165 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDiskScanRecovery_SharedPrefixDoesNotCrossRoute pins the output-routing fix
+// for sessions whose project paths share a prefix.
+//
+// ConvertToClaudeDirName maps every non-alphanumeric byte to a hyphen, so two
+// distinct project paths that differ only at a separator — /<tmp>/a/b and
+// /<tmp>/a-b, which share the prefix /<tmp>/a — encode to the SAME projects/
+// subdirectory. Both sessions' transcripts then live side by side in that one
+// directory.
+//
+// The stale-session disk-scan recovery used to pick the newest transcript by
+// mtime alone. With a shared encoded dir that returns whichever SIBLING wrote
+// last, so `session output` for session A could return session B's reply (and
+// rebind A's ClaudeSessionID to B's transcript). The fix reads the cwd Claude
+// records in each transcript and skips any whose cwd is not this instance's
+// project path.
+//
+// RED before the cwd filter (returns the newer sibling's reply); GREEN after.
+func TestDiskScanRecovery_SharedPrefixDoesNotCrossRoute(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origConfigDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	configDir := filepath.Join(tmpHome, ".claude")
+
+	// Two sibling project paths sharing the prefix <tmpHome>/a. Because "/" and
+	// "-" both encode to "-", they collide on one projects/ subdir.
+	ownPath := filepath.Join(tmpHome, "a", "b")  // /<tmp>/a/b
+	siblingPath := filepath.Join(tmpHome, "a-b") // /<tmp>/a-b
+	for _, p := range []string{ownPath, siblingPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	resolvedOwn := ownPath
+	if r, err := filepath.EvalSymlinks(ownPath); err == nil {
+		resolvedOwn = r
+	}
+	resolvedSibling := siblingPath
+	if r, err := filepath.EvalSymlinks(siblingPath); err == nil {
+		resolvedSibling = r
+	}
+
+	encOwn := ConvertToClaudeDirName(resolvedOwn)
+	encSibling := ConvertToClaudeDirName(resolvedSibling)
+	if encOwn != encSibling {
+		t.Fatalf("test precondition: expected shared encoded dir, got %q vs %q", encOwn, encSibling)
+	}
+
+	projectsDir := filepath.Join(configDir, "projects", encOwn)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+
+	writeCWDTranscript := func(id, cwd, text, ts string) {
+		body := fmt.Sprintf(
+			`{"type":"assistant","cwd":%q,"sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`+"\n",
+			cwd, id, ts, text)
+		writeTranscript(t, projectsDir, id, body)
+	}
+
+	// This instance's own transcript.
+	ownID := "11111111-1111-1111-1111-111111111111"
+	writeCWDTranscript(ownID, ownPath, "OWN SESSION REPLY", "2026-05-31T22:00:00Z")
+
+	// Sibling session's transcript in the same encoded dir, written LATER so a
+	// naive newest-mtime scan would pick it.
+	siblingID := "22222222-2222-2222-2222-222222222222"
+	writeCWDTranscript(siblingID, siblingPath, "SIBLING SESSION REPLY", "2026-05-31T22:05:00Z")
+
+	base := time.Now()
+	mustChtime(t, filepath.Join(projectsDir, ownID+".jsonl"), base.Add(-1*time.Minute))
+	mustChtime(t, filepath.Join(projectsDir, siblingID+".jsonl"), base) // newest
+
+	inst := NewInstance("shared-prefix-own", ownPath)
+	inst.Tool = "claude"
+	inst.ClaudeSessionID = "99999999-9999-9999-9999-999999999999" // stale: no such file
+	// No tmuxSession: the only viable recovery is the disk scan.
+
+	id, resp := inst.findLatestClaudeTranscriptOnDisk()
+	if resp == nil {
+		t.Fatal("expected to recover the instance's own transcript, got nil")
+	}
+	if resp.Content != "OWN SESSION REPLY" {
+		t.Fatalf("cross-route: expected own reply, got %q (id %s)", resp.Content, id)
+	}
+	if id != ownID {
+		t.Fatalf("recovered wrong transcript id: got %s want %s", id, ownID)
+	}
+}
+
+// TestDiskScanRecovery_NoCWDStillRecovers guards against over-filtering: a
+// transcript with no recorded cwd (older/truncated) must still be recoverable
+// when it is the only viable candidate, so the fix does not regress the
+// single-session /clear-rollover recovery.
+func TestDiskScanRecovery_NoCWDStillRecovers(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origConfigDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	configDir := filepath.Join(tmpHome, ".claude")
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir projectPath: %v", err)
+	}
+	resolved := projectPath
+	if r, err := filepath.EvalSymlinks(projectPath); err == nil {
+		resolved = r
+	}
+	projectsDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(resolved))
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+
+	// No cwd field on the record — mimics an older transcript.
+	id := "44444444-4444-4444-4444-444444444444"
+	body := fmt.Sprintf(
+		`{"type":"assistant","sessionId":%q,"timestamp":"2026-05-31T22:05:00Z","message":{"role":"assistant","content":[{"type":"text","text":"LEGACY REPLY"}]}}`+"\n", id)
+	writeTranscript(t, projectsDir, id, body)
+
+	inst := NewInstance("legacy-single", projectPath)
+	inst.Tool = "claude"
+	inst.ClaudeSessionID = "99999999-9999-9999-9999-999999999999"
+
+	gotID, resp := inst.findLatestClaudeTranscriptOnDisk()
+	if resp == nil || resp.Content != "LEGACY REPLY" {
+		t.Fatalf("expected legacy reply recovered, got %+v (id %s)", resp, gotID)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5717,12 +5717,81 @@ func (i *Instance) findLatestClaudeTranscriptOnDisk() (string, *ResponseOutput) 
 		if err != nil {
 			continue
 		}
+		// ConvertToClaudeDirName is lossy: it maps every non-alphanumeric byte to
+		// a hyphen, so two project paths that share a prefix but differ only at a
+		// separator (e.g. /a/b and /a-b) encode to the SAME projects/ subdir. A
+		// sibling session's transcript then sits alongside this instance's, and a
+		// pure newest-mtime pick would cross-route the sibling's reply into this
+		// session's output. Claude stamps the absolute cwd on its records, so when
+		// a transcript declares a cwd that is NOT this instance's project path we
+		// skip it — the mtime scan must never return a proven-foreign transcript.
+		if cwd, ok := claudeTranscriptCWD(data); ok && !sameClaudeCWD(cwd, resolvedPath) {
+			continue
+		}
 		resp, err := parseClaudeLastAssistantMessage(data, c.id+".jsonl")
 		if err == nil && resp != nil && strings.TrimSpace(resp.Content) != "" {
 			return c.id, resp
 		}
 	}
 	return "", nil
+}
+
+// claudeTranscriptCWD returns the working directory Claude Code recorded in a
+// transcript, scanning only the leading records (the cwd is stamped on every
+// record, so the first one that carries it is authoritative). It returns
+// ("", false) when no record within the scan window declares a cwd — e.g. an
+// older or truncated transcript — so callers can treat "unknown" as "cannot
+// prove foreign" rather than excluding it.
+func claudeTranscriptCWD(data []byte) (string, bool) {
+	const maxLines = 64
+	start := 0
+	for lines := 0; start < len(data) && lines < maxLines; lines++ {
+		var line []byte
+		if nl := bytes.IndexByte(data[start:], '\n'); nl < 0 {
+			line = data[start:]
+			start = len(data)
+		} else {
+			line = data[start : start+nl]
+			start += nl + 1
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var rec struct {
+			CWD string `json:"cwd"`
+		}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.CWD != "" {
+			return rec.CWD, true
+		}
+	}
+	return "", false
+}
+
+// sameClaudeCWD reports whether a transcript-recorded cwd names the same
+// directory as the instance's (already symlink-resolved) project path. It
+// compares cleaned paths first, then falls back to symlink resolution so a
+// transcript that recorded a pre-resolution cwd still matches.
+func sameClaudeCWD(transcriptCWD, resolvedProjectPath string) bool {
+	if transcriptCWD == resolvedProjectPath {
+		return true
+	}
+	a, b := filepath.Clean(transcriptCWD), filepath.Clean(resolvedProjectPath)
+	if a == b {
+		return true
+	}
+	if ra, err := filepath.EvalSymlinks(a); err == nil {
+		if ra == b {
+			return true
+		}
+		if rb, err := filepath.EvalSymlinks(b); err == nil && ra == rb {
+			return true
+		}
+	}
+	return false
 }
 
 // parseClaudeLastAssistantMessage parses a Claude JSONL file to extract the last assistant message.


### PR DESCRIPTION
## What problem does this solve?

When a session's Claude session id goes stale — after `/clear`, or when compaction mints a new transcript — `session output` recovers by scanning that instance's Claude `projects/` directory and returning the newest transcript. If two sessions' working directories share a path prefix, that scan can hand back a *different* session's last reply (and silently rebind this session onto the foreign transcript), so asking one session for its output returns another's.

## Why this change

Claude Code stamps the absolute `cwd` on every transcript record, so recovery can verify ownership directly instead of trusting mtime alone. Skipping any candidate whose recorded `cwd` proves it belongs to another directory is a minimal, local change that leaves the common single-session `/clear`-rollover recovery — transcripts with no recorded `cwd` — untouched.

## User impact

`session output` (and the TUI/preview read path it shares) no longer cross-routes another session's buffer when two working-directory paths collide on the lossy encoded `projects/<dir>` name. Recovery for a single session after `/clear` or compaction is unchanged. Internal read path only; no config or command surface changes.

## Evidence

Real `go test` of the touched package — the two new regression tests (synthetic paths only):

    $ go test ./internal/session/ -run 'TestDiskScanRecovery_SharedPrefixDoesNotCrossRoute|TestDiskScanRecovery_NoCWDStillRecovers' -v
    === RUN   TestDiskScanRecovery_SharedPrefixDoesNotCrossRoute
    --- PASS: TestDiskScanRecovery_SharedPrefixDoesNotCrossRoute (0.06s)
    === RUN   TestDiskScanRecovery_NoCWDStillRecovers
    --- PASS: TestDiskScanRecovery_NoCWDStillRecovers (0.00s)
    PASS
    ok  	github.com/asheshgoplani/agent-deck/internal/session	0.578s

The first test builds two sibling paths, `/tmp/a/b` and `/tmp/a-b`, that encode to the same `projects/<dir>` name with the sibling's transcript newest by mtime — before the fix the scan returns the sibling's reply, after it returns the instance's own. The second pins that a transcript with no recorded `cwd` is still recoverable (no regression to single-session `/clear`-rollover recovery).

Sandboxed full suite — `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — was run for real. It is **not** all-green on this sandbox, but not because of this change. The only failures are:

- fsnotify-backed watcher, global-search, and session-search tests that abort with `couldn't initialize inotify: too many open files` — the sandbox's `fs.inotify.max_user_instances` (128) is exhausted by the package's many watcher tests. An environment limit, not a code fault.
- one load-sensitive status-timing test, `TestUpdateStatus_ShellForegroundPromotion`.

Both reproduce on clean `upstream/main` with this change reverted (verified by reverting `instance.go` and re-running), and neither exercises the modified recovery path. Re-running the touched package with those environment-bound families excluded is green:

    $ go test ./internal/session/ -skip 'TestStatusEventWatcher|TestGlobalSearchIndex|TestStatusFileWatcher|TestUpdateStatus_ShellForegroundPromotion'
    ok  	github.com/asheshgoplani/agent-deck/internal/session	47.267s

Hot path (session output) — before/after latency: the added ownership check reads no new bytes. It runs only on the stale-session recovery branch (the primary UUID-keyed read path is untouched), over the transcript bytes the scan has already loaded, and stops at the first record — Claude stamps `cwd` on record one. Measured over a ~73 KB transcript (roughly 2× a typical one), the check costs **~8 µs per candidate** and adds **zero** new file I/O or syscalls, so steady-state `session output` latency is unchanged.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you
My operator ran a self-improvement analysis over heavy, long-running agent-deck conductor usage; it surfaced
this as a reproducible defect. They asked me to fix the agent-deck bugs the analysis found and send them
upstream. Stale-session output recovery returned a sibling session's buffer when two working directories shared a path prefix.

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — touched package is green; the only red tests are environment-bound (inotify instance cap) or a pre-existing load-sensitive timing test, both reproduce on clean upstream/main. See Evidence.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->
