### PR TITLE
fix(tmux): cache show-environment misses to stop the per-sweep fork storm (#1728)

### DIFF
--- a/internal/session/issue1728_fork_storm_test.go
+++ b/internal/session/issue1728_fork_storm_test.go
@@ -1,0 +1,165 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Issue #1728: with ~60 sessions the TUI sustained 150-350% CPU forking tmux
+// subprocesses continuously. The dominant per-cycle fork source that scales
+// with both session count AND sweep rate is GetEnvironment("CLAUDE_SESSION_ID"):
+// its 30s cache only stores positive results, so every Claude-compatible
+// session whose tmux env lacks the variable forks `tmux show-environment` on
+// every metadata sync (down to a 500ms cadence while the session ID is
+// unbound — exactly the un-cached case).
+//
+// This test measures real tmux forks across status sweeps via a PATH shim
+// that logs every invocation before exec'ing the real tmux. It fails when
+// show-environment forks scale with the number of sweeps instead of being
+// absorbed by the (negative) env cache after the first sweep.
+//
+// The full-size profile (60 sessions, the #1728 shape) is opt-in:
+//
+//	AGENTDECK_FORKSTORM_N=60 go test ./internal/session -run TestIssue1728 -v
+func TestIssue1728StatusSweepForkStorm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fork-storm harness spawns a real tmux server; skipped in -short")
+	}
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not available")
+	}
+
+	n := 8
+	if env := os.Getenv("AGENTDECK_FORKSTORM_N"); env != "" {
+		if _, err := fmt.Sscanf(env, "%d", &n); err != nil || n < 1 {
+			t.Fatalf("bad AGENTDECK_FORKSTORM_N=%q", env)
+		}
+	}
+	const sweeps = 4
+	const sweepGap = 600 * time.Millisecond // > the 500ms unbound-ID metaSync cadence
+
+	// PATH shim: every tmux fork appends its argv to a log, then execs the
+	// real binary. exec.Command("tmux", ...) resolves via PATH at call time,
+	// so the count is exact — no sampling.
+	shimDir := t.TempDir()
+	forkLog := filepath.Join(shimDir, "forks.log")
+	shim := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"" + forkLog + "\"\nexec \"" + realTmux + "\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "tmux"), []byte(shim), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// N live sessions with continuously-changing pane content so the busy
+	// check (CapturePane) stays on its hot path, created via the real tmux
+	// binary directly (bypassing the shim) so setup doesn't pollute counts.
+	instances := make([]*Instance, 0, n)
+	for i := 0; i < n; i++ {
+		inst := NewInstance(fmt.Sprintf("forkstorm-%02d", i), t.TempDir())
+		inst.Tool = "claude"
+		inst.Status = StatusRunning
+		inst.lastStartTime = time.Now().Add(-time.Minute) // past the tmux-init grace window
+		name := inst.tmuxSession.Name
+		// Storage-loaded shape (the ~60-session #1728 fleet is all reconnects):
+		// no startup grace window, and a declared claude command so DetectTool
+		// doesn't re-classify the sh pane as "shell" and skip the Claude
+		// metadata sync whose show-environment probe is under test.
+		inst.tmuxSession = tmux.ReconnectSessionLazy(name, inst.Title, inst.ProjectPath, "claude", "active")
+		cmd := exec.Command(realTmux, "new-session", "-d", "-s", name,
+			"sh", "-c", "while :; do date; sleep 0.2; done")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("new-session %s: %v: %s", name, err, out)
+		}
+		t.Cleanup(func() {
+			_ = exec.Command(realTmux, "kill-session", "-t", name).Run()
+		})
+		instances = append(instances, inst)
+	}
+
+	// Model the TUI's backgroundStatusUpdate: O(1) batched cache refreshes,
+	// then per-instance UpdateStatus through a bounded worker pool.
+	runSweep := func() {
+		tmux.RefreshExistingSessions()
+		tmux.RefreshPaneInfoCache()
+		sem := make(chan struct{}, 10)
+		var wg sync.WaitGroup
+		for _, inst := range instances {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(inst *Instance) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				_ = inst.UpdateStatus()
+			}(inst)
+		}
+		wg.Wait()
+	}
+
+	// Reset the fork log so only sweep-driven forks are counted.
+	if err := os.WriteFile(forkLog, nil, 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	start := time.Now()
+	for s := 0; s < sweeps; s++ {
+		// The storm state: sessions are running/waiting, so the metadata sync
+		// (and its show-environment probe) is live on every pass.
+		for _, inst := range instances {
+			inst.mu.Lock()
+			if inst.Status != StatusRunning && inst.Status != StatusWaiting {
+				inst.Status = StatusRunning
+			}
+			inst.mu.Unlock()
+		}
+		runSweep()
+		time.Sleep(sweepGap)
+	}
+	elapsed := time.Since(start)
+
+	data, err := os.ReadFile(forkLog) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int{}
+	total := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		total++
+		sub := "other"
+		for _, cand := range []string{
+			"show-environment", "capture-pane", "has-session", "list-panes",
+			"list-windows", "list-sessions", "list-clients", "display-message",
+		} {
+			if strings.Contains(line, cand) {
+				sub = cand
+				break
+			}
+		}
+		counts[sub]++
+	}
+	t.Logf("issue #1728 fork profile: n=%d sweeps=%d elapsed=%s total_forks=%d (%.1f forks/sec)",
+		n, sweeps, elapsed.Round(time.Millisecond), total, float64(total)/elapsed.Seconds())
+	for sub, c := range counts {
+		t.Logf("  %-18s %d", sub, c)
+	}
+
+	// Regression gate: show-environment must not scale with sweep count.
+	// Un-fixed, every sweep forks one probe per session (n*sweeps, minus the
+	// first sweep's near-misses); fixed, the first sweep's negative result is
+	// cached and later sweeps are absorbed. n + n/2 leaves slack for cache
+	// expiry racing the final sweep while still failing hard at n*sweeps.
+	limit := n + n/2
+	if got := counts["show-environment"]; got > limit {
+		t.Errorf("show-environment forked %d times across %d sweeps of %d sessions (limit %d): negative env-cache results are not being cached (issue #1728)",
+			got, sweeps, n, limit)
+	}
+}

--- a/internal/tmux/issue1728_env_negative_cache_test.go
+++ b/internal/tmux/issue1728_env_negative_cache_test.go
@@ -1,0 +1,122 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// countShimForks returns how many tmux invocations the PATH shim logged.
+func countShimForks(t *testing.T, forkLog string) int {
+	t.Helper()
+	data, err := os.ReadFile(forkLog) //nolint:gosec
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(strings.Fields(strings.TrimSpace(string(data))))
+}
+
+// installTmuxCountingShim prepends a PATH shim that logs one line per tmux
+// invocation before exec'ing the real binary, and returns the log path.
+// exec.Command("tmux", ...) resolves via PATH at call time, so the count is
+// an exact fork count, not a sample.
+func installTmuxCountingShim(t *testing.T, realTmux string) string {
+	t.Helper()
+	shimDir := t.TempDir()
+	forkLog := filepath.Join(shimDir, "forks.log")
+	shim := "#!/bin/sh\necho x >> \"" + forkLog + "\"\nexec \"" + realTmux + "\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "tmux"), []byte(shim), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return forkLog
+}
+
+// Issue #1728: GetEnvironment cached only positive results, so every session
+// WITHOUT the requested variable in its tmux env (the steady state for any
+// session whose ID never binds via tmux env) forked `tmux show-environment`
+// on every single call — at status-poll cadence, across ~60 sessions, that
+// was the larger half of a sustained 150-350% CPU subprocess storm.
+func TestGetEnvironment_CachesNegativeResult(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not available")
+	}
+
+	name := fmt.Sprintf("agentdeck_envneg_%d", time.Now().UnixNano())
+	if out, err := exec.Command(realTmux, "new-session", "-d", "-s", name, "sleep", "60").CombinedOutput(); err != nil {
+		t.Fatalf("new-session: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command(realTmux, "kill-session", "-t", name).Run() })
+
+	forkLog := installTmuxCountingShim(t, realTmux)
+	s := &Session{Name: name}
+
+	if _, err := s.GetEnvironment("AGENTDECK_TEST_UNSET_VAR"); err == nil {
+		t.Fatal("expected error for unset variable")
+	}
+	if got := countShimForks(t, forkLog); got != 1 {
+		t.Fatalf("first miss: %d forks, want 1", got)
+	}
+
+	// Second miss inside envNegativeCacheTTL must be served from cache.
+	if _, err := s.GetEnvironment("AGENTDECK_TEST_UNSET_VAR"); err == nil {
+		t.Fatal("expected cached miss to still report an error")
+	}
+	if got := countShimForks(t, forkLog); got != 1 {
+		t.Fatalf("cached miss re-forked show-environment: %d forks, want 1 (issue #1728)", got)
+	}
+
+	// An expired negative entry must re-probe (rewind its timestamp past the TTL).
+	s.envCacheMu.Lock()
+	entry := s.envCache["AGENTDECK_TEST_UNSET_VAR"]
+	entry.time = time.Now().Add(-envNegativeCacheTTL - time.Second)
+	s.envCache["AGENTDECK_TEST_UNSET_VAR"] = entry
+	s.envCacheMu.Unlock()
+	if _, err := s.GetEnvironment("AGENTDECK_TEST_UNSET_VAR"); err == nil {
+		t.Fatal("expected error for still-unset variable")
+	}
+	if got := countShimForks(t, forkLog); got != 2 {
+		t.Fatalf("expired negative entry: %d forks, want 2", got)
+	}
+}
+
+// SetEnvironment must invalidate a cached miss immediately: the bind path
+// (hook or capture-resume) writes the variable through this process, and the
+// next read has to see it without waiting out envNegativeCacheTTL.
+func TestGetEnvironment_SetInvalidatesNegativeEntry(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not available")
+	}
+
+	name := fmt.Sprintf("agentdeck_envset_%d", time.Now().UnixNano())
+	if out, err := exec.Command(realTmux, "new-session", "-d", "-s", name, "sleep", "60").CombinedOutput(); err != nil {
+		t.Fatalf("new-session: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command(realTmux, "kill-session", "-t", name).Run() })
+
+	s := &Session{Name: name}
+	if _, err := s.GetEnvironment("AGENTDECK_TEST_BIND_VAR"); err == nil {
+		t.Fatal("expected miss before set")
+	}
+	if err := s.SetEnvironment("AGENTDECK_TEST_BIND_VAR", "bound-id"); err != nil {
+		t.Fatalf("set-environment: %v", err)
+	}
+	got, err := s.GetEnvironment("AGENTDECK_TEST_BIND_VAR")
+	if err != nil {
+		t.Fatalf("read after set still served the stale cached miss: %v", err)
+	}
+	if got != "bound-id" {
+		t.Fatalf("got %q, want %q", got, "bound-id")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1116,12 +1116,25 @@ type Session struct {
 
 type envCacheEntry struct {
 	value string
+	// found distinguishes a cached value from a cached miss. Issue #1728: the
+	// cache stored only successes, so every Claude-compatible session WITHOUT
+	// the variable in its tmux env forked `tmux show-environment` on every
+	// metadata sync — down to a 500ms cadence while the session ID is unbound,
+	// which is exactly the always-miss case. With ~60 sessions that was the
+	// larger half of a sustained 150-350% CPU subprocess storm.
+	found bool
 	time  time.Time
 }
 
 const (
-	envCacheTTL        = 30 * time.Second
-	startupStateWindow = 2 * time.Minute
+	envCacheTTL = 30 * time.Second
+	// envNegativeCacheTTL bounds how long a miss ("variable not set", dead
+	// session, probe timeout) is trusted. Shorter than envCacheTTL so a
+	// session that gains CLAUDE_SESSION_ID out-of-process is still noticed
+	// within seconds; in-process SetEnvironment invalidates the entry
+	// immediately, so the common bind path never waits this out.
+	envNegativeCacheTTL = 5 * time.Second
+	startupStateWindow  = 2 * time.Minute
 )
 
 func sanitizeSystemdUnitComponent(raw string) string {
@@ -1863,15 +1876,27 @@ func (s *Session) ApplyThemeOptions() error {
 }
 
 // GetEnvironment gets an environment variable from this tmux session.
-// Uses a 30-second cache to avoid spawning tmux show-environment subprocesses
-// on every poll cycle. Call InvalidateEnvCache() after SetEnvironment to clear.
+// Uses a cache (30s for hits, 5s for misses — issue #1728) to avoid spawning
+// tmux show-environment subprocesses on every poll cycle. Call
+// InvalidateEnvCache() after SetEnvironment to clear.
 func (s *Session) GetEnvironment(key string) (string, error) {
-	// Check cache first
+	// Check cache first. Misses are cached too: an absent variable is the
+	// steady state for every session whose ID never binds via tmux env, and
+	// un-cached misses re-fork show-environment on every status pass (#1728).
 	s.envCacheMu.RLock()
 	if s.envCache != nil {
-		if entry, ok := s.envCache[key]; ok && time.Since(entry.time) < envCacheTTL {
-			s.envCacheMu.RUnlock()
-			return entry.value, nil
+		if entry, ok := s.envCache[key]; ok {
+			ttl := envCacheTTL
+			if !entry.found {
+				ttl = envNegativeCacheTTL
+			}
+			if time.Since(entry.time) < ttl {
+				s.envCacheMu.RUnlock()
+				if !entry.found {
+					return "", fmt.Errorf("variable not found: %s", key)
+				}
+				return entry.value, nil
+			}
 		}
 	}
 	s.envCacheMu.RUnlock()
@@ -1881,6 +1906,7 @@ func (s *Session) GetEnvironment(key string) (string, error) {
 	cmd := s.tmuxCmdContext(ctx, "show-environment", "-t", s.Name, key)
 	output, err := cmd.Output()
 	if err != nil {
+		s.storeEnvCacheEntry(key, envCacheEntry{time: time.Now()})
 		return "", fmt.Errorf("variable not found or session doesn't exist: %s", key)
 	}
 	// Output format: "KEY=value\n"
@@ -1888,16 +1914,20 @@ func (s *Session) GetEnvironment(key string) (string, error) {
 	prefix := key + "="
 	if strings.HasPrefix(line, prefix) {
 		value := strings.TrimPrefix(line, prefix)
-		// Store in cache
-		s.envCacheMu.Lock()
-		if s.envCache == nil {
-			s.envCache = make(map[string]envCacheEntry)
-		}
-		s.envCache[key] = envCacheEntry{value: value, time: time.Now()}
-		s.envCacheMu.Unlock()
+		s.storeEnvCacheEntry(key, envCacheEntry{value: value, found: true, time: time.Now()})
 		return value, nil
 	}
+	s.storeEnvCacheEntry(key, envCacheEntry{time: time.Now()})
 	return "", fmt.Errorf("variable not found: %s", key)
+}
+
+func (s *Session) storeEnvCacheEntry(key string, entry envCacheEntry) {
+	s.envCacheMu.Lock()
+	if s.envCache == nil {
+		s.envCache = make(map[string]envCacheEntry)
+	}
+	s.envCache[key] = entry
+	s.envCacheMu.Unlock()
 }
 
 // InvalidateEnvCache clears the environment variable cache for this session.


### PR DESCRIPTION
## What problem does this solve?

Issue #1728: with ~60 registered sessions the TUI sustained 150-350% CPU for ~2 hours after a system stall, forking tmux subprocesses continuously (~418 forks observed in a 5s `sample` window), with the tmux server itself pushed to ~30% serving the queries.

Profiling on a sandboxed repro (isolated tmux socket, 60 live sessions, PATH shim counting every real tmux fork) shows the status sweep forks two per-session subprocesses per pass: `capture-pane` (busy check) and `show-environment` (Claude session-ID sync). The second one is pure waste: `GetEnvironment` documents a 30-second cache, but only successes were ever stored. Any session whose tmux env lacks `CLAUDE_SESSION_ID` misses the cache on every call and forks `tmux show-environment` on every metadata sync, and the sync cadence drops to 500ms exactly when the ID is unbound, which is exactly the always-miss case. The waste scales with session count times sweep rate, which is why the storm amplified instead of settling after the stall.

## Why this change

Cache misses too. A miss ("variable not set", dead session, probe timeout) is stored with a shorter 5s TTL (`envNegativeCacheTTL`) so a session that gains its ID out-of-process is still noticed within seconds. The in-process bind paths (hook bind, capture-resume) go through `SetEnvironment`, which already invalidates the entry, so the common path never waits out the TTL. Positive-result behavior (30s TTL) is unchanged.

## User impact

Measured with the included fork-storm harness (60 sessions, 4 sweeps, ~600ms apart, exact fork counts via a PATH shim):

| | before | after |
|---|---|---|
| total tmux forks | 368 (117.5 forks/sec) | 265 (90.0 forks/sec) |
| `show-environment` forks | 180 (60 per sweep, unbounded) | 60 (first sweep only) |
| `show-environment` steady state | ~30/sec at the 2s cadence, up to ~114/sec at the 500ms unbound-ID cadence | 0 between refreshes (≤12/sec worst case at the 5s negative TTL; ~2/min once bound) |

The remaining per-session fork (`capture-pane`, ~1 per active session per sweep) is the pre-existing busy-check cost that the control-mode pipe already eliminates for piped sessions; its capacity (`livePipeLRUCapacity = 3`) is a separate discussion and deliberately untouched here.

## Interaction with in-flight work

- #1686 / #1687 attack the Codex probe surface (steady-state probe cadence, lsof→libproc). This PR is the Claude-side counterpart of the same #1552/#1728 CPU surface and overlaps with neither diff: they touch `shouldRunCodexProcessProbe` and process-fd discovery; this touches the tmux env cache. All three compose.
- #1731 (issue #1729) stops undeclared hook cwds from rewriting `project_path` and blocking foreign-cwd session binding. The rebind/reject flap it addresses shares this fork site (`GetSessionIDFromTmux` → `GetEnvironment`), so the two fixes are complementary: #1731 reduces how often IDs flap to unbound; this PR makes the unbound state stop forking.

## Evidence

Focused verification on macOS (Apple Silicon), Go 1.25.12, sandboxed (`HOME=$(mktemp -d)`, isolated tmux socket):

```
$ go test ./internal/tmux -run 'TestGetEnvironment_CachesNegativeResult|TestGetEnvironment_SetInvalidatesNegativeEntry' -count=1
ok  github.com/asheshgoplani/agent-deck/internal/tmux   0.607s

$ go test ./internal/session -run TestIssue1728StatusSweepForkStorm -count=1
ok  github.com/asheshgoplani/agent-deck/internal/session   3.2s
```

With the production hunk reverted, `TestIssue1728StatusSweepForkStorm` fails (`show-environment forked 24 times across 4 sweeps of 8 sessions (limit 12)`) and `TestGetEnvironment_CachesNegativeResult` fails on the second call re-forking. The harness's full-size #1728 shape is opt-in: `AGENTDECK_FORKSTORM_N=60 go test ./internal/session -run TestIssue1728 -v`.

Full `./internal/tmux ./internal/session` suites pass sandboxed at the same base.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** Claude (Anthropic)

## What actually bothered you

The TUI was the top CPU consumer on the machine for two hours and made the terminal feel laggy, and it recovered only by luck (the backlog draining), not by design.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/tmux ./internal/session`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable lookups by caching missing variables briefly, reducing repeated tmux queries.
  * Ensured cached missing results expire and are refreshed automatically.
  * Updated environment variables now immediately replace previously cached missing results.

* **Tests**
  * Added regression coverage for environment caching and high-load session status refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->