### PR TITLE
fix(ui): park New Session path cursor at the end on reopen (closes #1702)

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -461,6 +461,13 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 			d.pathInput.SetValue(cwd)
 		}
 	}
+	// #1702: the dialog is a reused singleton, so pathInput still carries the
+	// previous open's cursor. bubbles' SetValue only snaps the cursor to the end
+	// when the old value was empty or the old cursor sat past the new value's
+	// end, so a reopen on a longer path left the cursor stale mid-string and
+	// scrolled the path tail out of view. Park it at the end explicitly, as
+	// every other pathInput prefill in this file does.
+	d.pathInput.CursorEnd()
 	d.pathSoftSelected = true // activate soft-select for pre-filled path.
 	// Initialize tool options from global config.
 	d.geminiOptions.SetDefaults(false)

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1018,6 +1018,80 @@ func TestNewDialog_ShowInGroup_EmptyDefaultPath(t *testing.T) {
 	}
 }
 
+// TestNewDialog_ShowInGroup_MovesCursorToEndOfPrefilledPath is the #1702
+// regression test.
+//
+// The dialog is a reused singleton, so on every open but the first pathInput
+// still holds the previous open's value AND its cursor position. bubbles'
+// textinput.setValueInternal only snaps the cursor to the end when the OLD
+// value was empty or the old cursor sat past the new value's end
+// (`(pos == 0 && empty) || pos > len(value)`). Reopening on a path longer than
+// the old cursor position therefore left the cursor stale mid-string, and
+// handleOverflow scrolled the view around it — hiding the path tail until the
+// user pressed Ctrl+K or jumped to the end by hand.
+func TestNewDialog_ShowInGroup_MovesCursorToEndOfPrefilledPath(t *testing.T) {
+	// firstPath is deliberately short so the carried-over cursor lands inside
+	// reopenPath, which is the condition bubbles does not correct for us.
+	const firstPath = "/tmp/b"
+
+	tests := []struct {
+		name       string
+		reopenPath string
+	}{
+		{"deeper local path", "/Users/dev/work/deep/nested/project-alpha"},
+		{"remote session path", "/srv/remote/host/checkouts/agent-deck"},
+		{"non-ascii path", "/Users/dev/projekte/größer/ünïcode-checkout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialog := NewNewDialog()
+
+			dialog.ShowInGroup("projects", "Projects", firstPath, nil, "")
+			// Normal editing state after the first open: cursor at the end of
+			// the current value.
+			dialog.pathInput.SetCursor(len(firstPath))
+			if got, want := dialog.pathInput.Position(), len(firstPath); got != want {
+				t.Fatalf("setup: cursor should start at end of %q, got %d want %d", firstPath, got, want)
+			}
+			dialog.Hide()
+
+			// Reopen the reused dialog on a longer path.
+			dialog.ShowInGroup("projects", "Projects", tt.reopenPath, nil, "")
+
+			if got := dialog.pathInput.Value(); got != tt.reopenPath {
+				t.Fatalf("pathInput value = %q, want %q", got, tt.reopenPath)
+			}
+			// Cursor position is measured in runes by bubbles.
+			if got, want := dialog.pathInput.Position(), len([]rune(tt.reopenPath)); got != want {
+				t.Errorf("cursor should sit at the end of the pre-filled path so the tail stays visible: got %d, want %d (value %q)", got, want, tt.reopenPath)
+			}
+		})
+	}
+}
+
+// TestNewDialog_ShowInGroup_MovesCursorToEndOfCwdFallback covers the other
+// prefill branch of ShowInGroup (#1702): the cwd fallback taken when the group
+// has no default path.
+func TestNewDialog_ShowInGroup_MovesCursorToEndOfCwdFallback(t *testing.T) {
+	dialog := NewNewDialog()
+
+	const firstPath = "/a"
+	dialog.ShowInGroup("projects", "Projects", firstPath, nil, "")
+	dialog.pathInput.SetCursor(len(firstPath))
+	dialog.Hide()
+
+	dialog.ShowInGroup("projects", "Projects", "", nil, "")
+
+	value := dialog.pathInput.Value()
+	if len(value) <= len(firstPath) {
+		t.Skipf("cwd %q is not longer than %q, so the stale cursor cannot be observed", value, firstPath)
+	}
+	if got, want := dialog.pathInput.Position(), len([]rune(value)); got != want {
+		t.Errorf("cursor should sit at the end of the cwd fallback path: got %d, want %d (value %q)", got, want, value)
+	}
+}
+
 func TestNewDialog_BranchInputInitialized(t *testing.T) {
 	dialog := NewNewDialog()
 


### PR DESCRIPTION
## Summary

Fixes #1702: the New Session dialog (`n`) pre-filled the path correctly but left the cursor mid-string, so `textinput`'s viewport scrolled around that stale position and hid the tail of the path. The field looked like a short, correct path while actually holding a longer one, and the only way out was `Ctrl+K` and retyping.

Full credit to @yashiel-stitch for an unusually precise report: the root cause below is his analysis, verified here before fixing.

## Root cause

`NewDialog` is a reused singleton, so `pathInput` carries the previous open's value **and cursor** into the next open. bubbles' `textinput.setValueInternal` only snaps the cursor to the end when the old value was empty or the old cursor sat past the new value's end:

```go
if (m.pos == 0 && empty) || m.pos > len(m.value) {
    m.SetCursor(len(m.value))
}
```

Reopening on a path **longer** than the carried-over cursor position satisfies neither condition, so the cursor stays put and `handleOverflow` scrolls the view around it. `ShowInGroup` (`internal/ui/newdialog.go`) was the one `pathInput` prefill in the file that did not pair its `SetValue` with an explicit cursor move.

Confirmed against the render path too: the soft-select branch renders `d.pathInput.View()`, whose visible window follows the cursor — which is exactly why the tail disappeared.

## Fix

One call after both prefill branches (group default path and the cwd fallback):

```go
d.pathInput.CursorEnd()
```

Small deviation from the proposal in the issue, which suggested `SetCursor(len(d.pathInput.Value()))`: `CursorEnd()` is the same package's API for this exact invariant, avoids the byte-length-vs-rune-position mismatch on non-ASCII paths, and needs no arithmetic. Behaviour is identical for ASCII (`SetCursor` clamps), so this is purely a readability choice.

Because the remote-session dialog routes through `ShowInGroup`, it is fixed by the same line, as the issue predicted. Uppercase `N` (quick-create) has no path field and is unaffected.

## Tests

Two regression tests in `internal/ui/newdialog_test.go`, both of which fail without the fix:

- `TestNewDialog_ShowInGroup_MovesCursorToEndOfPrefilledPath` — opens the dialog twice (short path, then longer) and asserts the second value plus a cursor at the end. Subtests cover a deeper local path, a remote-session-shaped path, and a non-ASCII path (which pins the rune-vs-byte behaviour).
- `TestNewDialog_ShowInGroup_MovesCursorToEndOfCwdFallback` — covers the other prefill branch, taken when the group has no default path.

Fail-without-fix evidence (on `main`, before the one-line change):

```
--- FAIL: TestNewDialog_ShowInGroup_MovesCursorToEndOfPrefilledPath/deeper_local_path
    cursor should sit at the end of the pre-filled path so the tail stays
    visible: got 6, want 41 (value "/Users/dev/work/deep/nested/project-alpha")
--- FAIL: TestNewDialog_ShowInGroup_MovesCursorToEndOfCwdFallback
    cursor should sit at the end of the cwd fallback path: got 2, want 43
```

With the fix:

```
ok  github.com/asheshgoplani/agent-deck/internal/ui   26.625s   (full package, -count=1)
go vet ./internal/ui/   clean
gofmt                   clean
```

All test runs were sandboxed (`HOME=$(mktemp -d)`, cleared `XDG_*`, isolated tmux socket) per the repo's test-safety rules.

## Note on authorship

@yashiel-stitch, this was offered to you first and you are still very welcome to it. If you would rather land your own fix, say so and we will close this in favour of your PR without hesitation — the issue write-up already did the hard part.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the New dialog’s path field cursor to always jump to the end of the prefilled path when the dialog is reopened.
  * Prevented stale cursor positions and unwanted horizontal scrolling so the tail of long or special-character paths remains visible.

* **Tests**
  * Added regression tests validating end-cursor behavior for both prefilled paths and current-directory fallback paths, including reused singleton dialog openings and non-ASCII paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->