### PR TITLE
docs(design): naming/identity + proactive session lifecycle design proposals (#1703, #1704)

### DIFF
--- a/docs/design/2026-07-26-proactive-session-lifecycle.md
+++ b/docs/design/2026-07-26-proactive-session-lifecycle.md
@@ -1,0 +1,374 @@
+# Proactive session lifecycle — reap-candidate design
+
+**Date:** 2026-07-26
+**Issue:** [#1704](https://github.com/asheshgoplani/agent-deck/issues/1704) (reported by @kewtyboi)
+**Status:** Design proposed — open for feedback, nothing implemented yet
+**Labels:** `accepted`, `needs-design`, `design-proposed`
+
+## Problem
+
+Sessions are managed reactively. They accumulate for hours or days, and periodically a human
+or an orchestrating agent runs a verify-and-reap sweep to work out which are genuinely
+finished. That sweep is real work: the reporter had to check git state, PR status, and tmux
+liveness for **18 sessions individually** before any could be stopped, because nothing in
+agent-deck answers *"this session's task is complete and its output has been durably landed
+somewhere."*
+
+This is structural, not a one-off. Session creation is cheap and dispatch-heavy workflows
+spawn many bounded workers, so the list grows until something proactively manages it.
+
+The dangerous version of "fix this" is an automatic reaper. A session that *looks* finished
+but holds an uncommitted worktree is the one case where being wrong is unrecoverable. So the
+first slice is deliberately **read-only**: assist the verification, do not perform the
+removal.
+
+## What already exists
+
+### `agent-deck session cleanup` (alias `prune`) — the dead-and-old class
+
+`cmd/agent-deck/session_cleanup_cmd.go` already implements a careful purge, and its safety
+properties are the model this design follows rather than replaces:
+
+- **Dry-run by default.** Nothing is deleted without `--yes` or an explicit interactive
+  confirmation (`handleSessionCleanup`, line 200).
+- **Liveness is probed, not inferred from stored status.** `newTmuxLivenessProbe` (line 135)
+  runs one `list-sessions` per distinct socket. Stored `Status` is deliberately *not*
+  trusted, because `StatusError` has a known false-positive class.
+- **Indeterminate means alive.** A socket whose probe fails or times out marks every session
+  on it alive, so it can never become a candidate (line 158). This is the single most
+  important precedent in the file.
+- **Protective timestamps.** `cleanupLastTouched` (line 81) takes the *later* of `CreatedAt`
+  and `LastAccessedAt`, specifically so a recently-attached session that has since died is
+  not purged for having been created long ago.
+- **Startup grace.** `starting` / `queued` sessions are exempt for 5 minutes, but not
+  indefinitely — an open-ended exemption made crash-during-start ghosts permanently
+  unpurgeable (line 19).
+- **Pins and archives are respected** unless `--force` / `--include-archived`, and the count
+  retained-because-pinned is reported so the user knows something was deliberately kept.
+- **Registry-only** unless `--prune-worktree`.
+
+### Durable, non-destructive completion signal
+
+`internal/session/completion_ledger.go` persists a `CompletionLedgerEntry` per child:
+`{child_id, profile, title, status: ok|fail, summary, finished_at}`, written atomically,
+last-wins, and read with `ReadLedgerEntry` (line 80) **without consuming anything**. This is
+the piece that makes a candidate view possible at all — it is an already-shipped, already-durable
+"the worker asserted it was done" record, independent of the destructive inbox.
+
+Its upstream: the `===AGENTDECK_DONE=== status=<ok|fail> summary=<...>` sentinel
+(`internal/session/done_sentinel.go`, [#1186](https://github.com/asheshgoplani/agent-deck/issues/1186)),
+made reliable by `launch --assert-done` being **default-on for `-c claude`**
+(`cmd/agent-deck/launch_cmd.go:211`).
+
+### Other usable inputs
+
+| Input | Where |
+| --- | --- |
+| Live status + Honest-Status-v2 substate | `Instance.Status`, `Instance.Substate()` |
+| Parent/child linkage | `Instance.ParentSessionID`; `agent-deck session children [--follow]` |
+| Worktree paths and branch | `WorktreePath`, `WorktreeRepoRoot`, `WorktreeBranch`, `WorktreeType` |
+| Uncommitted-changes check | `git.HasUncommittedChanges` (`internal/git/git.go:957`); jj via `internal/jujutsu` |
+| Reversible park | `session archive` / `unarchive`, `Instance.ArchivedAt` |
+| Keep-this marker | `Instance.Pin` |
+
+## The gap
+
+`session cleanup` covers sessions that are **dead** and untouched for ≥ 30 days. The class
+that actually piles up during orchestration is the opposite: **alive but finished** — a live
+tmux pane sitting `waiting`, hours old, whose work has already landed in a merged PR. Those
+sessions are invisible to `cleanup` by construction (the liveness probe reports them alive,
+correctly), and there is no view that says *"here are the ones that look done, and here is
+the evidence"*.
+
+Secondary gap: the evidence a human gathers during a sweep (ledger entry, git cleanliness,
+PR state, parent state) is never collated anywhere, so every sweep starts from scratch.
+
+## Goals
+
+- A **read-only** view that ranks sessions as reap candidates and **shows the evidence
+  behind every classification**, so an operator or agent reviews a judgement instead of
+  re-deriving it.
+- Work offline, with no `gh`, no network, and a wedged tmux server. Degrade to `unknown`,
+  never to a wrong confident answer.
+- Never mutate anything — not the DB, not the ledger, not the inbox.
+- Define the candidate schema and the false-positive test matrix **now**, before any
+  automated action is designed on top of it.
+
+## Non-goals
+
+Explicit maintainer guidance on the issue, restated as hard constraints:
+
+- **No silent deletion. Ever.** Not on a timer, not at a score threshold, not in a daemon.
+- **No auto-stop** of a live session.
+- **No background TTL reaper** in this slice. TTL stays advisory (Stage 2 sketch below).
+- **`status = waiting` alone is never evidence of completion.** It is the normal end-of-turn
+  state for every Claude session.
+- **No hard dependency on `gh` or the network.**
+- **Not a replacement for `session cleanup`.** Different class, shared predicates.
+
+## Design — Stage 1: a read-only candidate view
+
+`agent-deck status --stale [--stale-days N] [--with-pr] [--json]`
+
+Chosen over a new top-level noun because `status` is already the "what is the state of my
+deck" command and already has `--json` / `-v` conventions. `--stale` is additive: without it,
+`status` output stays byte-identical.
+
+Behaviour: loads sessions, computes a candidate record per session, prints a table (or
+JSON), exits **0** regardless of what it finds. It is a view.
+
+### Candidate schema
+
+```json
+{
+  "id": "1a2b3c4d-1780000000",
+  "title": "fix-1701-flag-parsing",
+  "group": "work/fixes",
+  "status": "waiting",
+  "substate": "idle-at-empty-prompt",
+  "age": "5d",
+  "idle_for": "19h",
+  "verdict": "likely-reapable",
+  "score": 0.82,
+  "signals": [
+    {
+      "name": "completion_sentinel",
+      "value": "ok",
+      "confidence": "high",
+      "weight": 0.35,
+      "evidence": "ledger 2026-07-25T09:11:04Z: \"opened PR #1701, CI green\""
+    },
+    {
+      "name": "worktree_clean",
+      "value": "clean",
+      "confidence": "high",
+      "weight": 0.20,
+      "evidence": "git status --porcelain empty in <repo>/.worktrees/fix-1701"
+    },
+    {
+      "name": "branch_pushed",
+      "value": "pushed",
+      "confidence": "high",
+      "weight": 0.15,
+      "evidence": "rev-list fix/1701-slug@{u}..HEAD = 0 commits ahead"
+    },
+    {
+      "name": "idle_duration",
+      "value": "19h",
+      "confidence": "high",
+      "weight": 0.12,
+      "evidence": "last activity 2026-07-25T14:02:11Z, threshold --stale-days 1"
+    },
+    {
+      "name": "linked_pr",
+      "value": "unknown",
+      "confidence": "none",
+      "weight": 0.0,
+      "evidence": "skipped: --with-pr not set"
+    },
+    {
+      "name": "parent_state",
+      "value": "parent-finished",
+      "confidence": "medium",
+      "weight": 0.10,
+      "evidence": "parent 9f8e7d6c ledger status=ok at 2026-07-25T10:40:00Z"
+    }
+  ],
+  "blockers": [],
+  "recommendation": "review, then `agent-deck session archive 1a2b3c4d`"
+}
+```
+
+Schema rules — these are the contract, not the presentation:
+
+1. **Every signal carries `value`, `confidence`, and a human-readable `evidence` string.** A
+   row a reviewer cannot audit from the output alone is a bug. `evidence` is the whole point
+   of the feature: it is the sweep work, cached.
+2. **`unknown` is a first-class value and contributes weight `0.0`.** Absence of information
+   is never scored as "done". A missing upstream is `unknown`, not "not pushed"; an absent
+   `gh` is `unknown`, not "no PR".
+3. **`confidence` ∈ {`high`, `medium`, `low`, `none`}.** `high` means directly observed
+   (ledger entry read, `git status` run). `medium` means inferred one hop away (parent's
+   ledger, PR matched by branch name). `none` accompanies `unknown`.
+4. **`blockers` are hard vetoes.** Any non-empty `blockers` forces `verdict` away from
+   `likely-reapable` regardless of `score`. Blockers are not weighted; they are absolute.
+5. **`score` is advisory and always displayed.** It exists to *order* the review queue. It
+   must never be the sole input to an action, and no threshold in this design triggers a
+   mutation.
+6. **Additive only.** New signals may be appended; existing signal `name`s and the top-level
+   keys are stable. Consumers must tolerate unknown signal names.
+
+### Blockers (absolute vetoes)
+
+| Blocker | Why |
+| --- | --- |
+| `running` / `starting` / `queued` | actively working; verdict becomes `active` |
+| `within_startup_grace` | mirrors `cleanupStartupGrace`; boot is not idleness |
+| `pinned` | the user's explicit keep marker |
+| `archived` | archiving is already a deliberate keep (excluded unless `--include-archived`) |
+| `is_conductor` | orchestrators are long-lived by design and must never be suggested |
+| `worktree_dirty` | **the unrecoverable case.** Uncommitted work in a worktree |
+| `commits_unpushed` | work exists only on this machine |
+| `live_children` | has sub-sessions not themselves reapable |
+| `liveness_indeterminate` | tmux probe failed/timed out — same assume-alive rule as `cleanup` |
+| `sentinel_stale` | ledger `finished_at` predates last activity: the session kept working after asserting done, so the assertion no longer describes current state |
+| `sentinel_fail` | `status=fail` means unfinished work, and is *more* interesting than no signal at all |
+
+`sentinel_stale` deserves emphasis: last-wins ledger semantics mean an old `ok` can sit on a
+session that has since been given new work. Comparing `finished_at` against last activity is
+the cheap guard, and without it the highest-weight signal in the system is also the one most
+likely to be wrong.
+
+### Verdict ladder
+
+```
+any blocker AND status in {running, starting, queued}   -> "active"
+any other blocker                                       -> "needs-review"  (blockers listed)
+no blocker AND score >= 0.70 AND >= 2 high-confidence
+  signals with value != unknown                         -> "likely-reapable"
+no blocker AND some evidence                            -> "needs-review"
+nothing known beyond age                                -> "unknown"
+```
+
+The **two-independent-high-confidence-signals floor** is the false-positive control. A long
+idle time alone, or a clean tree alone, can never produce `likely-reapable` — because
+neither is evidence that work *landed*, only that nothing is happening right now.
+
+### Signal sources — no new subsystems
+
+| Signal | Source | Failure mode |
+| --- | --- | --- |
+| `completion_sentinel` | `session.ReadLedgerEntry` (`completion_ledger.go:80`) | no entry → `unknown` |
+| `idle_duration` | `cleanupLastTouched` + `GetLastActivityTime` | zero timestamps → `unknown`, never "old" |
+| `liveness` | `newTmuxLivenessProbe` (`session_cleanup_cmd.go:135`), reused verbatim | probe fails → blocker |
+| `worktree_clean` | `git.HasUncommittedChanges`; `internal/jujutsu` for `WorktreeType == "jujutsu"` | error → `unknown` **and** a `worktree_indeterminate` blocker (cannot prove clean ⇒ do not suggest) |
+| `branch_pushed` | new helper `git.AheadOfUpstream(dir)` → `git rev-list --count @{u}..HEAD` | no upstream → `unknown`; error → `unknown` |
+| `linked_pr` | **opt-in `--with-pr`.** `gh pr list --head <branch> --state all --json number,state` with a short timeout | `gh` missing / offline / timeout → `unknown`, view still renders, exit 0 |
+| `parent_state` | `ParentSessionID` + parent's ledger entry | no parent → signal omitted |
+| `live_children` | existing children lookup + each child's own verdict | — |
+
+`--with-pr` is off by default on purpose: it is the only signal that shells out to the
+network, it is the slowest, and a `status --stale` that hangs behind a network stall is
+worse than one that reports `unknown`.
+
+### Human output sketch
+
+```
+$ agent-deck status --stale --stale-days 1
+LIKELY REAPABLE (2)
+  1a2b3c4d  fix-1701-flag-parsing        waiting  idle 19h  score 0.82
+            done: ok "opened PR #1701, CI green" (2026-07-25T09:11Z)
+            worktree clean; branch fix/1701-slug 0 ahead of upstream
+            -> review, then: agent-deck session archive 1a2b3c4d
+  ...
+
+NEEDS REVIEW (3)
+  5e6f7a8b  release-cut-v1.10.11         waiting  idle 2d   score 0.55
+            BLOCKED: worktree_dirty (3 modified files in <repo>/.worktrees/release)
+            done: ok "tagged v1.10.11" (2026-07-24T18:02Z)
+            -> uncommitted work present; do not remove
+
+ACTIVE (11)   UNKNOWN (4)
+Nothing was changed. This is a read-only view.
+```
+
+The closing line is not decoration. The failure mode this feature must avoid is a user
+believing a cleanup happened.
+
+### Stage 2 (deferred — sketch only, do not implement with Stage 1)
+
+Once the candidate schema has been exercised against real decks:
+
+- `[lifecycle]` config: `stale_days`, `review_prompt = true` (advisory thresholds only).
+- `session cleanup --include-live`, reusing the *same* candidate function, prompting per
+  session and printing the full evidence block before each prompt. `--yes` still required;
+  no new bypass.
+- **The default offered action is `archive`, not `remove`.** Archive is reversible
+  (`unarchive` exists), removal is not. A lifecycle feature should push users toward the
+  reversible door.
+
+## Components touched
+
+- `internal/session/` — new `lifecycle` file (or `candidate.go`) holding the pure
+  `EvaluateCandidate(inst, deps) Candidate` function; deps injected (clock, liveness probe,
+  git checks, optional PR lookup) so it is testable with no tmux, no git, and no network.
+- `cmd/agent-deck/main.go` — `--stale`, `--stale-days`, `--with-pr`, `--include-archived` on
+  `handleStatus`; table + JSON rendering.
+- `cmd/agent-deck/session_cleanup_cmd.go` — export the liveness probe and
+  `cleanupLastTouched` for reuse; no behaviour change.
+- `internal/git/git.go` — `AheadOfUpstream`.
+- Docs: README lifecycle subsection; cross-link from the fleet/conductor docs.
+
+## Error handling
+
+- Any signal that errors becomes `unknown` with the error text in `evidence`. Nothing is
+  fatal; the view always renders.
+- Unprovable cleanliness is a blocker, not a neutral unknown. `worktree_clean: unknown`
+  implies `worktree_indeterminate` — the asymmetry is intentional, because the cost of
+  wrongly suggesting a dirty worktree is unrecoverable and the cost of wrongly withholding a
+  suggestion is one manual check.
+- `--stale-days` negative → clear error, exit 1 (matches `cleanup --days` validation).
+- Empty deck → empty candidate list, exit 0.
+- `--json` output is a single object `{"candidates": [...], "counts": {...}}` so future
+  top-level fields stay additive.
+
+## Testing
+
+The false-positive matrix the maintainer asked for before any automation. Each row is a unit
+test against `EvaluateCandidate` with injected deps — no tmux, no git, no network.
+
+| # | Scenario | Required outcome |
+| --- | --- | --- |
+| 1 | sentinel `ok` + dirty worktree | `needs-review`, blocker `worktree_dirty` |
+| 2 | sentinel `ok` + commits ahead of upstream | `needs-review`, blocker `commits_unpushed` |
+| 3 | sentinel `ok` + pinned | `needs-review`, blocker `pinned` reported |
+| 4 | sentinel `ok` + `is_conductor` | never `likely-reapable` |
+| 5 | sentinel `fail` | never `likely-reapable`; blocker `sentinel_fail` |
+| 6 | long idle + no sentinel + clean tree + no PR data | `unknown` (fails the two-signal floor) |
+| 7 | archived session | excluded unless `--include-archived` |
+| 8 | `starting`, within grace | `active`, blocker `within_startup_grace` |
+| 9 | tmux probe indeterminate | blocker `liveness_indeterminate` (assume alive) |
+| 10 | parent still running, child looks reapable | child `needs-review` |
+| 11 | ledger `finished_at` **older** than last activity | blocker `sentinel_stale` |
+| 12 | `gh` absent / times out with `--with-pr` | `linked_pr: unknown`, exit 0, view renders |
+| 13 | `git` errors on the worktree | `worktree_clean: unknown` **and** blocker |
+| 14 | zero-valued `CreatedAt` / `LastAccessedAt` | `idle_duration: unknown`, not "very old" |
+| 15 | empty deck | empty list, exit 0 |
+
+Plus two integration-level invariants that are the real safety net:
+
+- **Read-only proof.** Run `status --stale` against a populated sandbox profile and assert:
+  `state.db` mtime and size unchanged, every completion-ledger file byte-identical, and the
+  session's inbox still fully drainable afterwards (nothing consumed). This test is the
+  feature's core promise and should fail loudly if any future signal starts writing.
+- **Evidence completeness.** For every signal in every candidate, `evidence` is non-empty.
+  A signal that cannot explain itself must not ship.
+
+All test runs must be sandboxed per the repo `CLAUDE.md`
+(`HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME=`), and any tmux server a
+test spawns must be killed by teardown on the same socket it was created on.
+
+## Rollout
+
+1. `EvaluateCandidate` + the full test matrix, no CLI surface. Pure function, zero risk.
+2. `status --stale` human output.
+3. `--json` (freeze the schema here — it becomes a consumer contract).
+4. `--with-pr`.
+5. Stage 2, only after real-deck feedback, and only in the archive-first, confirm-always
+   shape above.
+
+## Open questions
+
+- **O1.** Should `status --stale` grow `--exit-nonzero-if-candidates` so a conductor
+  heartbeat can cheaply detect "the deck needs a review pass" without parsing JSON? Useful,
+  but it makes a *view* carry a signal in its exit code. Current lean: no — parse the JSON.
+- **O2.** Is `score` worth exposing at all, given every action requires human confirmation?
+  It orders the queue, but a visible number invites automation against it. Alternative: drop
+  `score` and order by (verdict, idle_for). Current lean: keep it in `--json`, omit it from
+  human output.
+- **O3.** Should `linked_pr` matching be by branch name only, or should the sentinel summary
+  be scanned for a PR URL? Branch matching is more reliable; summary scanning catches
+  non-worktree sessions. Both are `medium` confidence at best.
+- **O4.** @kewtyboi — in your 18-session sweep, which check did the most work: PR state, git
+  cleanliness, or tmux liveness? That should get the highest weight and the best evidence
+  string.

--- a/docs/design/2026-07-26-session-identity-and-group-purpose.md
+++ b/docs/design/2026-07-26-session-identity-and-group-purpose.md
@@ -1,0 +1,304 @@
+# Session identity, display title, and group purpose — design
+
+**Date:** 2026-07-26
+**Issue:** [#1703](https://github.com/asheshgoplani/agent-deck/issues/1703) (reported by @kewtyboi)
+**Status:** Design proposed — open for feedback, nothing implemented yet
+**Labels:** `needs-design`, `design-proposed`
+
+## Problem
+
+Running many concurrent sessions (the reporter had 18+ live across several groups in a
+single evening) exposes two distinct pains that both *look* like "naming":
+
+1. **Titles stop being descriptive.** A session launched with a clear `-t` title can end up
+   displayed as a short opaque handle, so the list no longer says what each session is for.
+2. **Groups accumulate ad hoc.** Five sibling groups appeared in one profile in one evening
+   with no recorded reason why any of them exists, and no way to see a group's purpose
+   without opening every session inside it.
+
+The instinct is to answer both with "define a naming convention". That is the wrong shape,
+because a title is being asked to carry three unrelated jobs at once:
+
+- a **machine handle** the launcher can rely on ("which dispatched unit of work is this?"),
+- a **human label** for the list ("what is this, at a glance?"),
+- an **organizational bucket** ("why do these belong together?").
+
+A convention can only optimize for one of those. The rest of this document separates them,
+inventories what already exists for each, and proposes the smallest additions that close
+the real gaps.
+
+## The three layers
+
+| Layer | Question it answers | Who owns it | Mutability | Machine-readable? |
+| --- | --- | --- | --- | --- |
+| **Task identity** | Which dispatched unit of work is this? | the launcher (operator or conductor) | set once, never rewritten | yes — safe to key on |
+| **Display title** | What is this session, at a glance? | the human, or the agent when title sync is on | freely mutable | **no** — never parse it |
+| **Group purpose** | Why does this bucket exist? | the operator | mutable | yes (free text, for humans to read) |
+
+A fourth relationship is already modelled separately and must not be folded into any of the
+three: **parent/child linkage** (`Instance.ParentSessionID`) answers "who dispatched whom".
+
+### Rule: parentage lives in linkage, not in names
+
+Encoding dispatch relationships a second time in group names (a `work` group plus
+`work-infra`, `work-hygiene`, `work-governance` siblings for workers dispatched by one
+orchestrator) is the sprawl mechanism, not a symptom of it. It duplicates information the
+registry already holds precisely, and the duplicate immediately drifts: reparenting a
+session updates the linkage and leaves the group name lying.
+
+Guidance, stated normatively so tooling can be built against it later:
+
+- **R1 — Never encode parentage in a group name.** Use `--parent` / the auto-parenting that
+  `launch` already applies, and read it back with `agent-deck session children`.
+- **R2 — A group is warranted when its members share a *policy*, not a topic.** Groups
+  already carry real, enforced policy: `max_concurrent` (serial vs bounded parallelism),
+  `default_path`, and per-group Claude config / account resolution. If nothing
+  policy-shaped differs between a proposed new group and its parent, the thing you have is
+  a *topic*, and topics are carried by parent linkage plus the title — not by a new bucket.
+- **R3 — Titles are for humans; identity is for machines.** Any script or agent that
+  matches on a title is relying on something the user is explicitly allowed to change.
+- **R4 — If you need a title to be stable, lock it.** Do not attempt to out-format the
+  syncer with prefixes or suffixes; there is an explicit switch (below).
+
+## What already exists
+
+Much of the requested surface is already built. The gap for layer 2 is largely
+*discoverability*, not capability.
+
+### Display-title stability (layer 2) — complete, under-documented
+
+| Control | Scope | Where |
+| --- | --- | --- |
+| `--title-lock` (alias `--no-title-sync`) on `agent-deck add` | per session, at creation | `cmd/agent-deck/main.go:1241` |
+| `--title-lock` / `--no-title-sync` on `agent-deck launch` | per session, at creation | `cmd/agent-deck/launch_cmd.go:63` |
+| `agent-deck session set-title-lock <id> <on\|off>` | per session, at runtime | `cmd/agent-deck/session_cmd.go:2452` |
+| `sync_title = false` | whole installation | `UserConfig.GetSyncTitle()`, `internal/session/userconfig.go:1331` (default `true`) — [#1254](https://github.com/asheshgoplani/agent-deck/issues/1254) |
+| Fork inherits an explicit title lock | forked sessions | `cmd/agent-deck/session_cmd.go:1225` |
+
+Two related behaviours are also already correct and worth stating because they rule out
+whole classes of suspected bug:
+
+- **Folder-derived Claude names are ignored.** Claude Code 2.1.19x stamps
+  `nameSource: "derived"` on a name it auto-derives from the cwd folder.
+  `ClaudeSessionNameIn` treats a derived name as *no name at all*, including on the
+  freshest entry, so it neither syncs nor lets a stale user name win
+  (`internal/session/claude_title_reconcile.go`). Only a real `/rename` or `claude --name`
+  can move a title.
+- **A locked title cannot be silently overwritten.** The hook-triggered sync persists via a
+  conditional `UPDATE ... WHERE title_locked = 0` and deliberately splits the *decision*
+  (`ResolveTitleFromClaude`) from the tmux/badge side effects, so a rejected write cannot
+  leave the terminal chrome showing a name the registry refused
+  (`internal/statedb/update_title_if_unlocked_test.go`, `cmd/agent-deck/hook_name_sync.go`).
+
+### Opaque titles: three different mechanisms, only one of them surprising
+
+Short opaque handles in the list can come from any of these, and they need different
+answers:
+
+1. **`add --quick` / `-Q` (TUI `Q`)** generates a machine adjective-noun handle on purpose
+   and sets `AutoName` (`cmd/agent-deck/main.go:1243`, `internal/session/namegen.go`). The
+   TUI then shows the session's *live Claude task description* in place of the handle, and
+   any explicit rename clears `AutoName` permanently. This is working as designed; the
+   handle is meant to be invisible.
+2. **Claude session-name sync** on a session whose title is not locked. Controlled by the
+   table above.
+3. **Collision suffixes.** Auto-derived names get numeric suffixes when basenames collide
+   (`DeduplicateDirnames`, `internal/session/instance.go:513`) and there is a
+   `<random8>-<unix>` fallback (`internal/session/instance.go:9202`).
+
+Class 1 accounts for handles of the shape `adjective-noun`; class 3 accounts for
+`basename-<n>`. Neither is a defect. **Open question O1** below asks the reporter for the
+exact launch command behind the observed titles so we can confirm which class was hit —
+the answer changes whether anything in layers 1–3 needs to move at all.
+
+### Group purpose (layer 3) — genuinely missing
+
+`session.Group` (`internal/session/groups.go:78`) carries `Name`, `Path`, `Expanded`,
+`Order`, `DefaultPath`, `MaxConcurrent`. The `groups` table matches
+(`internal/statedb/statedb.go:426`). There is **no field for why the group exists**, and
+`group list` / `group show` therefore cannot answer it. That is the concrete gap behind
+"no way to see group membership/purpose without cross-referencing every session".
+
+### Task identity (layer 1) — missing, and currently borrowed from the title
+
+There is no field whose contract is "stable, launcher-owned, never rewritten". Conductors
+approximate one by putting a task key in the title (`SCRUM-351`) and then locking the
+title — which works, but forces a choice between *a stable machine key* and *a title that
+tracks what the agent is actually doing*. Those are different jobs (R3); one field cannot
+serve both.
+
+## Goals
+
+- Give launchers a stable identity that no sync path can touch, **without** taking away
+  title sync, which is genuinely useful for humans watching a list.
+- Let a group state its own purpose, readable from `group list` / `group show` / `--json`.
+- Make the existing title-stability controls easy to find.
+- Make group sprawl *visible* at the moment it is created, advisorily.
+
+## Non-goals
+
+Per maintainer guidance on the issue, the first iteration stays advisory:
+
+- **No enforced title format.** No regex gate, no required prefix/suffix, no rejection of a
+  title the user chose. Hard naming enforcement is too opinionated across workflows.
+- **No rejection of group creation.** Warn, never refuse; exit codes unchanged.
+- **No automatic renaming or migration** of existing sessions or groups.
+- **No new top-level noun.** Everything lands on `add` / `launch` / `session` / `group`.
+- **No second relationship model.** Parent linkage stays the only encoding of dispatch.
+
+## Design
+
+Four changes. A, B, C are additive and independently shippable; D is documentation and
+should land first because it may be sufficient on its own for layer 2.
+
+### A. `task_id` — an explicit identity field (layer 1)
+
+A new optional string on the session record, `task_id`:
+
+- Set by `--task-id <string>` on `agent-deck add` and `agent-deck launch`. Empty by
+  default, so behaviour for every existing session is unchanged.
+- **Never** written by title sync, `AutoName`, fork, rename, or any hook path. The only
+  writers are creation and an explicit `agent-deck session set-task-id <id> <value>`.
+- Surfaced (omitempty) in `list --json`, `session show --json`, and
+  `session children --json`, so a conductor can correlate a dispatched task to a live
+  session without matching on the title.
+- Rendered in the TUI only when set, as a dim prefix badge ahead of the title, so the
+  human label stays the thing the eye lands on.
+- Not unique-constrained. Two sessions may legitimately share a task id (a retry, a
+  worktree pair). Deduplication is the caller's policy, not the registry's.
+
+This is what makes R3 affordable: with identity available separately, leaving `sync_title`
+on stops costing you your machine handle, and `--title-lock` becomes a *display* preference
+rather than load-bearing infrastructure.
+
+Rejected alternative: derive identity from a title convention (e.g. require a `[KEY]`
+prefix and parse it back out). Rejected because it re-couples the two layers, breaks the
+moment a human edits the title, and is exactly the "another title convention" the
+maintainer asked us not to add.
+
+### B. `group purpose` — one line of intent per bucket (layer 3)
+
+- New `purpose TEXT NOT NULL DEFAULT ''` column on `groups`, added with the same idempotent
+  `ALTER TABLE ... ADD COLUMN` + duplicate-column tolerance already used for
+  `max_concurrent` (`internal/statedb/statedb.go:439`). Additive, so an older binary
+  reading a newer DB is unaffected.
+- `group create --purpose "<text>"`, `group update --purpose "<text>"`,
+  `group update --clear-purpose` (mirroring the existing `--default-path` /
+  `--clear-default-path` pair at `cmd/agent-deck/group_cmd.go:641`).
+- Shown by `group show`, shown truncated by `group list`, and emitted as `purpose`
+  (omitempty) in `group list --json`.
+- Free text, length-capped (suggest 120 chars) and single-line. No schema, no vocabulary.
+
+Suggested convention for what to write in it — documentation, not enforcement: state the
+**policy** that justifies the group (R2), e.g. `serial: one release cut at a time` or
+`account=work, default-path=~/src/api`. A purpose that only restates the group name is a
+hint the group should not exist.
+
+### C. Advisory sprawl warning on `group create`
+
+Two cheap, local checks at creation time. Both print one line to **stderr** and change
+nothing else — the group is always created, exit code is always unchanged:
+
+1. **Near-duplicate sibling.** If the new group's name is within Damerau-Levenshtein
+   distance ≤ 2 of an existing sibling under the same parent, or is a prefix/suffix of one:
+   `note: sibling group 'work-infra' already exists under 'work' — reuse it if this is the same work (agent-deck group show work-infra)`
+2. **One-off accumulation.** If the profile already has ≥ N groups holding ≤ 1 session
+   (default N = 12):
+   `note: 14 groups in this profile hold one session or fewer; consider parent linkage instead of new groups (see docs/design/2026-07-26-session-identity-and-group-purpose.md)`
+
+Silenced by `--no-warn` or `[group_defaults] sprawl_warn = false`. Suppressed entirely when
+`--json` or `--quiet` is in effect, so machine consumers never see it.
+
+The distance threshold is deliberately tiny. A false warning costs one line of noise; a
+false *silence* costs nothing at all, since this check has no safety role. Tuning should
+err toward silence.
+
+### D. Documentation (do this first)
+
+- A **"Stable session titles"** subsection in the README Features area containing the
+  control table above and this decision guide:
+
+  | You want | Do this |
+  | --- | --- |
+  | This one session keeps the title I gave it | `--title-lock` at create, or `session set-title-lock <id> on` |
+  | No session ever gets renamed by its agent | `sync_title = false` in config |
+  | A stable key for scripts, but let the title track the agent | `--task-id` (change A), leave sync on |
+  | A throwaway session; show me what it is doing | `add --quick` |
+
+- A **"Groups vs parent linkage"** subsection carrying R1–R4 and the `--purpose`
+  convention.
+- Cross-link both from the existing conductor/fleet docs, since orchestrated fleets are
+  where this bites.
+
+## Components touched
+
+- `internal/session/instance.go` — `TaskID` field + JSON tag; getters/setters if it is read
+  off the render loop.
+- `internal/session/groups.go` — `Group.Purpose`.
+- `internal/statedb/statedb.go` — `instances.task_id` and `groups.purpose` columns,
+  idempotent ALTERs, save/load round-trip.
+- `cmd/agent-deck/main.go`, `launch_cmd.go` — `--task-id` flag.
+- `cmd/agent-deck/session_cmd.go` — `set-task-id`, `session show` output, help text.
+- `cmd/agent-deck/group_cmd.go` — `--purpose` / `--clear-purpose`, list/show output, JSON,
+  sprawl warning.
+- `internal/ui/` — dim task-id badge in the session row.
+- `internal/web/` — `task_id` / `purpose` in the menu payload for parity
+  (`tests/web/PARITY_MATRIX.md`).
+- `README.md`.
+
+## Error handling
+
+- `--task-id` with leading/trailing whitespace is trimmed; empty after trimming is treated
+  as unset, not an error.
+- `set-task-id` on an unknown/ambiguous session uses the existing `ResolveSession` error
+  path.
+- `--purpose` longer than the cap is rejected with a clear message rather than silently
+  truncated (silent truncation of user intent is worse than a retry).
+- The sprawl warning must never fail a create. Any error inside the check (unreadable
+  sibling list, etc.) is swallowed and the warning skipped.
+- Older binary + newer DB: both new columns have defaults and are read with `omitempty`
+  semantics, so a downgrade loses the values but never fails a load.
+
+## Testing
+
+- **`task_id` immutability:** a session with `task_id` set survives a Claude title sync, a
+  rename, a fork, and `--quick` `AutoName` display with `task_id` byte-identical. This is
+  the core contract and should be a table test over every writer of `Title`.
+- **`task_id` absent by default:** existing create paths produce empty `task_id`, and
+  `list --json` output for a pre-change session is byte-identical (omitempty).
+- **Group purpose round-trip:** create with `--purpose`, reload, assert value; `--clear-purpose`
+  empties it; migration test that opens a DB created *without* the column and asserts the
+  ALTER is idempotent and no rows are lost (mirror
+  `internal/statedb/save_groups_additive_test.go`).
+- **Sprawl warning is advisory:** warning fires on a near-duplicate sibling; group is still
+  created; exit code is 0; `--json` and `--quiet` suppress the line; and a set of
+  deliberately dissimilar names produce **no** warning (false-positive guard).
+- **Docs parity:** the README control table names flags that exist (a test that greps the
+  documented flag strings out of the flag definitions would keep this honest).
+
+## Rollout
+
+1. **D (docs).** Ship alone. If the reporter's pain was discoverability of `--title-lock` /
+   `sync_title`, this closes it with zero code.
+2. **B + C (group purpose + advisory warning).** Small, self-contained, no cross-layer risk.
+3. **A (`task_id`).** Largest surface (schema + CLI + TUI + web parity). Worth doing only if
+   O1/O2 below confirm that conductors really are being forced to choose between a stable
+   key and a live title.
+
+## Open questions
+
+- **O1.** @kewtyboi — for one of the sessions that showed an opaque title, what was the
+  exact `add` / `launch` command (specifically: was `--quick`/`-Q` involved, and was
+  `--title-lock` passed)? That distinguishes "working as designed" from a real
+  overwrite bug worth its own issue.
+- **O2.** Does `task_id` need to be visible in the TUI at all, or is `--json` enough? A
+  badge costs horizontal space in the row that is already contended.
+- **O3.** Should `launch` default `task_id` to something derived (e.g. the initial
+  message's first token, or a short random key) when the flag is omitted? Defaulting makes
+  the field reliably present for conductors; leaving it empty keeps output byte-stable.
+  Current lean: leave empty, since a derived value would be a machine key nobody chose —
+  the same failure mode as an opaque title.
+- **O4.** Is `purpose` better as a group field or as an optional `[groups.<path>]` config
+  entry? A DB column survives profile moves and is editable from the TUI; a config entry is
+  reviewable in version control. Current lean: DB column, because `default_path` and
+  `max_concurrent` set the precedent.


### PR DESCRIPTION
Design docs for #1703 and #1704, both filed by @kewtyboi. **Documentation only** — no Go changes, no behavior change. These are proposals opened for feedback, not implementation-ready specs, so the issues should stay open.

## What problem does this solve?

Two `needs-design` issues asked for work that can't be answered with a patch: "define a naming standard for session titles and groups" (#1703) and "proactively manage session lifecycle so nobody has to run manual reap sweeps" (#1704). Both need a written design before any code, and both got specific maintainer direction on the issue that needed capturing somewhere durable rather than living in a comment thread.

Adds `docs/design/` with one document each.

### `docs/design/2026-07-26-session-identity-and-group-purpose.md` (#1703)

Separates the three jobs a single title was being asked to carry:

| Layer | Question | Owner | Machine-readable? |
| --- | --- | --- | --- |
| Task identity | which dispatched unit of work is this? | the launcher | yes |
| Display title | what is this, at a glance? | human, or agent when sync is on | **no** — never parse it |
| Group purpose | why does this bucket exist? | operator | yes (free text) |

Plus the rule that parent/child linkage (`ParentSessionID`) stays the *only* encoding of dispatch relationships — re-encoding parentage in group names is the sprawl mechanism, and the duplicate drifts the moment a session is reparented.

It inventories what already exists, with `file:line`, because a lot of the requested surface is built and just hard to find: `--title-lock` / `--no-title-sync` on `add` and `launch`, `session set-title-lock`, global `sync_title` (#1254), fork lock inheritance, and the already-correct suppression of Claude's `nameSource: "derived"` folder names. It also separates the three distinct mechanisms that can produce an opaque title (`--quick` `AutoName` handles, session-name sync on an unlocked title, basename collision suffixes) — two of which are working as designed.

Proposed additions are minimal and additive: a `task_id` field no sync path may touch, a `groups.purpose` column, an advisory sprawl warning on `group create` that never rejects, and README documentation of the existing controls. **No enforced title format** — explicitly out of scope per maintainer guidance.

### `docs/design/2026-07-26-proactive-session-lifecycle.md` (#1704)

Defines the read-only first slice the maintainer asked for: `agent-deck status --stale`, plus the candidate schema.

The schema rules are the actual contract:

- every signal carries `value`, `confidence`, and a human-readable `evidence` string — a row a reviewer can't audit from the output alone is a bug;
- `unknown` is a first-class value contributing **zero** weight, so absence of information is never scored as "done";
- `blockers` are absolute vetoes that override `score` (dirty worktree, unpushed commits, pinned, conductor, indeterminate tmux probe, and `sentinel_stale` — a ledger `finished_at` older than last activity, which is how the highest-weight signal goes wrong);
- `likely-reapable` requires **two independent high-confidence signals**, so long idle time alone or a clean tree alone can never qualify.

It builds only on already-shipped inputs: the durable non-destructive completion ledger (#1186 / #1214), the socket-complete tmux liveness probe from `session cleanup` (reused verbatim, including its assume-alive-when-indeterminate rule), `git.HasUncommittedChanges`, and parent linkage. `gh`/PR lookup is opt-in behind `--with-pr` so the view works offline and never hangs behind a network stall.

It also carries the 15-row false-positive matrix and a read-only proof test (`state.db` mtime unchanged, ledger bytes identical, inbox still fully drainable afterwards) — the things the maintainer asked to have defined *before* automated cleanup is designed. Stage 2 is sketched but explicitly deferred, and offers `archive` (reversible) before `remove`.

## Why this change

The alternative was answering #1703 with a naming convention. That's the wrong shape: a convention can only optimize for one of the three jobs a title is doing, so "make titles descriptive" and "make titles a stable machine key" pull in opposite directions and whichever one wins, the other silently breaks. Separating the layers makes both affordable at once — with identity available separately, leaving `sync_title` on stops costing you your machine handle.

For #1704 the tempting shape is a TTL reaper. A session that *looks* finished but holds an uncommitted worktree is the one case where being wrong is unrecoverable, so the design inverts it: cache the verification work as auditable evidence, and let a human act. That's also why `worktree_clean: unknown` is treated as a *blocker* rather than a neutral unknown — the asymmetry is deliberate, because wrongly withholding a suggestion costs one manual check and wrongly making one costs work.

Both docs are grounded in the existing code rather than written from scratch: every claim about current behavior carries a `file:line` reference, and all of them were verified against `main` at `4b72051` before committing.

## User impact

None yet — documentation only. If the proposals land later: stable machine identity separate from display titles, a readable purpose per group, and an assisted (never automatic) reap-candidate review instead of a from-scratch sweep.

## Evidence

No behavior change, so there is nothing to capture at runtime. Verification done:

- Every `file:line` reference in both docs checked against the tree at `4b72051` (`sed -n "<line>p" <file>` on each; two were off by a few lines and corrected before commit).
- Every referenced issue number (#697, #1186, #1214, #1254) confirmed to exist and to be about what the docs claim.
- Every referenced file (`internal/statedb/save_groups_additive_test.go`, `internal/statedb/update_title_if_unlocked_test.go`, `cmd/agent-deck/hook_name_sync.go`, `tests/web/PARITY_MATRIX.md`) confirmed present.
- Diff is two new files under `docs/design/`; no `.go` file touched, so `go build` / `go test` behavior is unchanged by construction.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-x

## What actually bothered you

Two issues sat in `needs-design` with real, specific maintainer direction buried in issue comments — "separate stable task identity from display title from group purpose", "define the candidate schema and the false-positive tests before adding automated cleanup" — and nothing was going to move until someone wrote that down as a reviewable artifact. The ask was: write the two design docs into the repo so the guidance is durable and the community has something concrete to react to, instead of another round of comment-thread archaeology. The reporter had just spent an evening hand-verifying 18 sessions one at a time; that's the friction being answered.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior — n/a, documentation only (no new behavior; the test matrices the docs *specify* land with the implementation)
- [x] Test suite passes sandboxed: no Go files touched, so the suite is unaffected by this diff
- [x] If this touches a hot path: n/a, docs only

## Notes for the maintainer

Both issues should **stay open**. This PR adds the design artifact and asks for feedback; each doc ends with open questions, including two addressed directly to @kewtyboi (which launch command produced the opaque titles, and which check dominated the 18-session sweep). Merging this is not accepting the proposals — it's putting them somewhere reviewable.
