### PR TITLE
test(status): pin lock drop during slow tmux probe

### DIFF
--- a/internal/session/apply_terminated_pane_status_test.go
+++ b/internal/session/apply_terminated_pane_status_test.go
@@ -3,6 +3,9 @@ package session
 import (
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // TestApplyTerminatedPaneStatus_HoldsLockOnReturn verifies the lock handoff
@@ -77,5 +80,64 @@ func TestApplyTerminatedPaneStatus_ConcurrentRaceSafe(t *testing.T) {
 	// opencode's hookless vanished pane classifies as stopped.
 	if got != StatusStopped {
 		t.Errorf("Status = %q, want %q", got, StatusStopped)
+	}
+}
+
+// TestUpdateStatus_DropsLockDuringSlowPaneStatusProbe pins the UpdateStatus
+// lock handoff with a probe that cannot finish until the test releases it.
+// A mutation that keeps i.mu held across the probe makes the concurrent lock
+// acquisition time out, while the correct unlock/relock handoff lets it finish.
+func TestUpdateStatus_DropsLockDuringSlowPaneStatusProbe(t *testing.T) {
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseProbe) }) }
+	t.Cleanup(release)
+
+	i := &Instance{
+		Tool:        "claude",
+		Status:      StatusRunning,
+		CreatedAt:   time.Now().Add(-time.Minute),
+		tmuxSession: &tmux.Session{Name: "issue-1732-missing-session"},
+		paneDeadExitStatusForTest: func() (int, bool) {
+			close(probeStarted)
+			<-releaseProbe
+			return 0, true
+		},
+	}
+
+	updateDone := make(chan error, 1)
+	go func() { updateDone <- i.UpdateStatus() }()
+
+	select {
+	case <-probeStarted:
+	case err := <-updateDone:
+		t.Fatalf("UpdateStatus returned before the pane-status probe started: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the pane-status probe to start")
+	}
+
+	lockAcquired := make(chan struct{})
+	lockStarted := time.Now()
+	go func() {
+		i.SetStatusThreadSafe(StatusWaiting)
+		close(lockAcquired)
+	}()
+
+	select {
+	case <-lockAcquired:
+		t.Logf("i.mu remained available during blocked pane-status probe (acquired in %v)", time.Since(lockStarted))
+	case <-time.After(2 * time.Second):
+		release()
+		<-updateDone
+		t.Fatal("i.mu stayed locked while the pane-status probe was blocked")
+	}
+
+	release()
+	if err := <-updateDone; err != nil {
+		t.Fatalf("UpdateStatus() error = %v", err)
+	}
+	if got := i.GetStatusThreadSafe(); got != StatusStopped {
+		t.Fatalf("Status = %q, want %q", got, StatusStopped)
 	}
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -408,6 +408,8 @@ type Instance struct {
 
 	tmuxSession *tmux.Session // Internal tmux session
 
+	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
+
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
 	hookStatus     string    // running, idle, waiting, dead (empty = no hook data)
 	hookEvent      string    // Hook event name that caused the last status (e.g. "PermissionRequest")
@@ -4146,11 +4148,15 @@ func (i *Instance) terminatedPaneStatus() Status {
 func (i *Instance) applyTerminatedPaneStatus() {
 	tmuxSession := i.tmuxSession
 	tool := i.Tool
+	paneDeadExitStatus := i.paneDeadExitStatusForTest
 
 	i.mu.Unlock()
 	exitCode, haveExitCode := 0, false
 	if tmuxSession != nil {
-		exitCode, haveExitCode = tmuxSession.PaneDeadExitStatus()
+		if paneDeadExitStatus == nil {
+			paneDeadExitStatus = tmuxSession.PaneDeadExitStatus
+		}
+		exitCode, haveExitCode = paneDeadExitStatus()
 	}
 	status := classifyTerminatedPane(exitCode, haveExitCode, tool)
 	i.mu.Lock()


### PR DESCRIPTION
## What problem does this solve?

The `UpdateStatus` unlock/relock handoff added in #1725 had no deterministic
regression test: a mutation that held `i.mu` across a slow tmux exit-status
probe could pass the existing nil-probe and contention tests. Fixes #1732.

## Why this change

This adds a per-instance probe seam so the test can pause exactly at
`PaneDeadExitStatus` without a global override that could race with parallel
tests. The test drives the real `UpdateStatus` path, blocks the injected probe,
and requires a concurrent write-locking status operation to finish before the
probe is released. With no injected probe, production still calls
`tmuxSession.PaneDeadExitStatus` exactly as before.

## User impact

None, internal test coverage only. The existing non-blocking status behavior is
now protected against regression.

## Evidence

Focused test and neighboring lock-handoff coverage:

    $ go test ./internal/session -run '^(TestUpdateStatus_DropsLockDuringSlowPaneStatusProbe|TestApplyTerminatedPaneStatus_)' -count=1 -v
    --- PASS: TestUpdateStatus_DropsLockDuringSlowPaneStatusProbe (0.00s)
    PASS

Race detector, five consecutive runs:

    $ go test -race ./internal/session -run '^(TestUpdateStatus_DropsLockDuringSlowPaneStatusProbe|TestApplyTerminatedPaneStatus_)' -count=5
    ok github.com/asheshgoplani/agent-deck/internal/session

Failing mutation: removing the existing `i.mu.Unlock()` / `i.mu.Lock()` handoff
while leaving the probe blocked fails deterministically:

    apply_terminated_pane_status_test.go:133: i.mu stayed locked while the pane-status probe was blocked
    --- FAIL: TestUpdateStatus_DropsLockDuringSlowPaneStatusProbe (2.00s)

The automated revert-check also reports the expected compile failure when it
copies the new test onto base without the per-instance injection seam. The
lock-held mutation above provides the behavioral failure proof.

Hot-path timing: with the correct handoff, the concurrent write lock completed
while the probe remained blocked in 1.25 microseconds normally and 3–18
microseconds across race-detector runs. Under the lock-held mutation it remained
blocked through the full 2.00-second regression guard.

Formatting, vet, build, and lint:

    gofmt -l internal/session/instance.go internal/session/apply_terminated_pane_status_test.go
    # no output
    go vet ./...
    go build ./...
    GOTOOLCHAIN=go1.25.12 golangci-lint run
    0 issues.

The sandboxed full suite was run. It remains non-green on this macOS host only
for pre-existing environment failures that reproduce on clean `origin/main`:
tmux is not installed (`TestWebCommand_NoTuiFlag_SkipsBubbleteaBoot` and
`TestIssue1607_CreateSessionTitleLock`), the related bootstrap debug-log test,
and two long macOS temp-path/socket tests
(`TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision` and
`TestIssue1421_CleanStaleSSHSockets`). The changed lock tests pass sandboxed and
under `-race`.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "keep solving the issues , thats the new goal"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — only the clean-main environment failures listed above remain
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status updates when terminal pane checks are slow.
  * Status changes can now proceed without waiting unnecessarily for a pane status check to finish.
  * Improved reliability when determining whether a terminated pane should be marked stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->