### PR TITLE
fix(handoff): reuse transcript UUID fallback

### DIFF
--- a/internal/session/handoff.go
+++ b/internal/session/handoff.go
@@ -101,6 +101,9 @@ func ClaudeTranscriptPathForInstance(inst *Instance) string {
 
 func claudeTranscriptPathIn(configDir string, inst *Instance, sessionID string) string {
 	projectPath := inst.EffectiveWorkingDir()
+	if transcript := resolveClaudeTranscriptPath(configDir, projectPath, sessionID); transcript != "" {
+		return transcript
+	}
 	if resolved, err := filepath.EvalSymlinks(projectPath); err == nil {
 		projectPath = resolved
 	}

--- a/internal/session/handoff_test.go
+++ b/internal/session/handoff_test.go
@@ -54,6 +54,40 @@ func TestBuildClaudeToCodexHandoffPrompt_ReadsClaudeTranscript(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeToCodexHandoffPrompt_FindsDifferentlyEncodedTranscript(t *testing.T) {
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+
+	project := "/home/user/proj"
+	sessionID := "eeeeeeee-ffff-0000-1111-222222222222"
+	transcriptDir := filepath.Join(claudeDir, "projects", "--wsl-localhost-Ubuntu-home-user-proj")
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcriptPath := filepath.Join(transcriptDir, sessionID+".jsonl")
+	transcript := `{"type":"user","message":{"role":"user","content":"WSL fallback found me"}}`
+	if err := os.WriteFile(transcriptPath, []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &Instance{
+		Title:           "wsl-handoff",
+		ProjectPath:     project,
+		Tool:            "claude",
+		ClaudeSessionID: sessionID,
+	}
+	prompt, info, err := BuildClaudeToCodexHandoffPrompt(inst, DefaultHandoffMaxChars)
+	if err != nil {
+		t.Fatalf("BuildClaudeToCodexHandoffPrompt: %v", err)
+	}
+	if info.TranscriptPath != transcriptPath {
+		t.Fatalf("TranscriptPath = %q, want UUID-glob match %q", info.TranscriptPath, transcriptPath)
+	}
+	if !strings.Contains(prompt, "WSL fallback found me") {
+		t.Fatalf("prompt missing differently encoded transcript content:\n%s", prompt)
+	}
+}
+
 func TestBuildClaudeToCodexHandoffPrompt_TruncatesToTail(t *testing.T) {
 	claudeDir := t.TempDir()
 	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)


### PR DESCRIPTION
## What problem does this solve?

`session handoff` could not read a Claude transcript stored under a
differently encoded project directory, such as the UNC-derived directory that
Windows-native Claude creates for a WSL project. It returned “read Claude
transcript: no such file” even though the session-ID JSONL existed. Fixes #1671.

## Why this change

The repository already has `resolveClaudeTranscriptPath`, which tries the
canonical project encoding and then locates the uniquely named
`<sessionID>.jsonl` under any project directory. The handoff helper now reuses
that resolver before returning its expected-path fallback. This keeps the
existing missing-file diagnostics while removing duplicate lookup behavior.

## User impact

Claude-to-Codex handoffs now find conversation history when Claude and
agent-deck encode the same working directory differently, including WSL/UNC
paths.

## Evidence

Reproduction on unchanged `origin/main`:

    $ go test ./internal/session -run '^TestBuildClaudeToCodexHandoffPrompt_FindsDifferentlyEncodedTranscript$' -count=1 -v
    BuildClaudeToCodexHandoffPrompt: read Claude transcript: open .../projects/-home-user-proj/eeeeeeee-ffff-0000-1111-222222222222.jsonl: no such file or directory
    --- FAIL: TestBuildClaudeToCodexHandoffPrompt_FindsDifferentlyEncodedTranscript

With this change:

    $ go test ./internal/session -run '^(TestBuildClaudeToCodexHandoffPrompt|TestResolveClaudeTranscriptPath_)' -count=1 -v
    --- PASS: TestBuildClaudeToCodexHandoffPrompt_FindsDifferentlyEncodedTranscript
    PASS

Race detector, three consecutive runs:

    $ go test -race ./internal/session -run '^(TestBuildClaudeToCodexHandoffPrompt|TestResolveClaudeTranscriptPath_)' -count=3
    ok github.com/asheshgoplani/agent-deck/internal/session

The full `internal/session` package passes after skipping only
`TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision` and
`TestIssue1421_CleanStaleSSHSockets`; both fail identically on clean
`origin/main` on this macOS host because of long temporary paths.

Formatting, vet, build, and lint:

    gofmt -l internal/session/handoff.go internal/session/handoff_test.go
    # no output
    go vet ./...
    go build ./...
    GOTOOLCHAIN=go1.25.12 golangci-lint run
    0 issues.

The repository self-check’s revert test copies the regression test onto clean
base, where it fails with the missing differently encoded transcript shown
above.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "keep solving the issues , thats the new goal"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — only clean-main host/environment failures remain
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — not a hot path
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript discovery when project paths use different encoding formats.
  * Claude-to-Codex handoffs now locate the correct session transcript and include its content reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->