### PR TITLE
fix(ci): write clean Playwright JSON report

### DIFF
--- a/.github/workflows/weekly-regression.yml
+++ b/.github/workflows/weekly-regression.yml
@@ -138,11 +138,11 @@ jobs:
         continue-on-error: true
         working-directory: tests/e2e
         run: |
-          npx playwright test --config=pw-visual-regression.config.ts --reporter=json 2>&1 | tee /tmp/visual-results.json || true
-          # Re-run to capture exit code properly (tee swallows it)
-          npx playwright test --config=pw-visual-regression.config.ts --reporter=list > /dev/null 2>&1
+          npx playwright test --config=pw-visual-regression.config.ts --reporter=json
         env:
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:18420/?token=test
+          PLAYWRIGHT_JSON_OUTPUT_DIR: /tmp
+          PLAYWRIGHT_JSON_OUTPUT_NAME: visual-results.json
 
       - name: Regenerate visual baselines
         # Baseline-regeneration mode (workflow_dispatch + update_baselines).

--- a/tests/ci/weekly-regression-workflow.test.sh
+++ b/tests/ci/weekly-regression-workflow.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Guards the visual-regression step's JSON output and exit-code contract.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/weekly-regression.yml"
+ERRORS=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+VISUAL_STEP=$(awk '
+  /- name: Run visual regression tests/ { in_step = 1 }
+  in_step { print }
+  in_step && /- name: Regenerate visual baselines/ { exit }
+' "$WORKFLOW")
+
+if grep -Fq 'PLAYWRIGHT_JSON_OUTPUT_DIR: /tmp' <<<"$VISUAL_STEP" &&
+  grep -Fq 'PLAYWRIGHT_JSON_OUTPUT_NAME: visual-results.json' <<<"$VISUAL_STEP"; then
+  pass "Playwright writes JSON directly to the artifact path"
+else
+  fail "visual step must write Playwright JSON directly to /tmp/visual-results.json"
+fi
+
+if grep -Fq -- '--reporter=json' <<<"$VISUAL_STEP"; then
+  pass "visual step selects Playwright's JSON reporter"
+else
+  fail "visual step must use Playwright's JSON reporter"
+fi
+
+if grep -Fq 'tee /tmp/visual-results.json' <<<"$VISUAL_STEP"; then
+  fail "tee pollutes the JSON report with stderr"
+else
+  pass "JSON report does not pass through tee"
+fi
+
+RUN_COUNT=$(grep -cF 'npx playwright test --config=pw-visual-regression.config.ts' <<<"$VISUAL_STEP" || true)
+if [[ "$RUN_COUNT" == "1" ]]; then
+  pass "visual suite runs exactly once"
+else
+  fail "visual suite must run once, got $RUN_COUNT invocations"
+fi
+
+if grep -Fq '|| true' <<<"$VISUAL_STEP"; then
+  fail "visual command must preserve its nonzero exit for the step outcome"
+else
+  pass "visual command preserves its exit code"
+fi
+
+if [[ "$ERRORS" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## What problem does this solve?

The weekly visual-regression workflow could suppress a real alert. Playwright’s
JSON was piped through `tee` with stderr merged into stdout, so a warning could
make the report unparseable; the renderer then classified a nonzero test run as
`NO DATA (skipped)` and filed no issue. Fixes #1679.

## Why this change

Playwright’s JSON reporter already supports direct file output. The workflow now
sets `PLAYWRIGHT_JSON_OUTPUT_DIR=/tmp` and
`PLAYWRIGHT_JSON_OUTPUT_NAME=visual-results.json`, runs the suite once, and
preserves that command’s exit status for `steps.visual.outcome`. This removes
both JSON pollution and the previous duplicate run, whose result could differ
from the report-producing run.

The workflow change is isolated in its own PR because `.github/` changes require
the repository’s human security gate.

## User impact

Weekly regression failures reliably produce parseable details and a countable
failure outcome instead of being silently skipped. The visual suite also runs
once rather than twice.

## Evidence

The new workflow regression guard on unchanged `origin/main`:

    FAIL: visual step must write Playwright JSON directly to /tmp/visual-results.json
    FAIL: tee pollutes the JSON report with stderr
    FAIL: visual suite must run once, got 2 invocations
    FAIL: visual command must preserve its nonzero exit for the step outcome

With this change:

    $ tests/ci/weekly-regression-workflow.test.sh
    PASS: Playwright writes JSON directly to the artifact path
    PASS: visual step selects Playwright's JSON reporter
    PASS: JSON report does not pass through tee
    PASS: visual suite runs exactly once
    PASS: visual command preserves its exit code

Reporter compatibility was exercised with the repository’s pinned Playwright
1.59.1. A `--list` run using the two output environment variables produced
`/tmp/.../visual-results.json`; `JSON.parse` succeeded and the report contained
four suites.

Other checks:

    tests/ci/render-visual-details.test.sh
    All 7 render-visual-details tests passed.

    bash -n tests/ci/weekly-regression-workflow.test.sh
    ruby -e 'require "yaml"; YAML.load_file(".github/workflows/weekly-regression.yml")'
    go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/weekly-regression.yml
    go vet ./...
    go build ./...
    # all passed

The sandboxed full Go suite was also run. It remains non-green only for the same
clean-main macOS host failures documented on #1739/#1740: tmux is absent for
three tests, one related bootstrap debug-log test cannot emit its file, and two
long temporary-path/socket tests fail. This workflow-only diff cannot affect
those Go paths.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "keep solving the issues , thats the new goal"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — only clean-main host/environment failures remain
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — not a runtime hot path
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual regression test reporting in weekly CI runs.
  * Preserved accurate test failure statuses while generating JSON results directly.
* **Tests**
  * Added CI checks to verify the visual regression workflow uses the expected reporting and failure-handling behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->