### PR TITLE
feat(fleet): add `agent-deck fleet recover` — sequential, verified recovery from a fleet-wide session death

### DIFF
--- a/cmd/agent-deck/fleet_cmd.go
+++ b/cmd/agent-deck/fleet_cmd.go
@@ -115,7 +115,8 @@ func handleFleetStatus(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+	// See handleFleetRecover: -q must not silence a --json payload.
+	out := NewCLIOutput(*jsonOutput, (*quiet || *quietShort) && !*jsonOutput)
 
 	_, instances, _, err := loadSessionData(profile)
 	if err != nil {
@@ -145,6 +146,8 @@ func handleFleetRecover(profile string, args []string) {
 	verifyTimeout := fs.Duration("verify-timeout", fleet.DefaultVerifyTimeout, "How long to wait for one session to prove it booted")
 	verifyPoll := fs.Duration("verify-poll", fleet.DefaultVerifyPoll, "Verification poll interval")
 	maxFailures := fs.Int("max-failures", fleet.DefaultMaxFailures, "Halt after this many consecutive failed restarts")
+	maxDeadBoots := fs.Int("max-dead-boots", fleet.DefaultMaxDeadBoots,
+		"Halt after this many consecutive sessions restart and then die immediately (pane gone; 0 disables)")
 	authHaltAfter := fs.Int("auth-halt-after", fleet.DefaultAuthHaltAfter, "Halt after this many sessions boot into an auth failure (0 disables the auth breaker)")
 	det := registerFleetDetectorFlags(fs)
 
@@ -160,7 +163,8 @@ func handleFleetRecover(profile string, args []string) {
 		fmt.Println("without restarting anything.")
 		fmt.Println()
 		fmt.Println("The sweep halts early when the failures look systemic: N consecutive")
-		fmt.Println("failed restarts (--max-failures), or sessions booting into an auth")
+		fmt.Println("failed restarts (--max-failures), N consecutive sessions that restart and")
+		fmt.Println("then die immediately (--max-dead-boots), or sessions booting into an auth")
 		fmt.Println("failure (--auth-halt-after) — restarting the rest of the fleet against a")
 		fmt.Println("broken credential only deepens the cascade.")
 		fmt.Println()
@@ -176,7 +180,10 @@ func handleFleetRecover(profile string, args []string) {
 	}
 
 	quietMode := *quiet || *quietShort
-	out := NewCLIOutput(*jsonOutput, quietMode)
+	// --json is machine output and must not be silenced by -q: a quiet
+	// CLIOutput drops Success entirely, so `--json -q` would print nothing at
+	// all and a wrapper would read the empty payload as a clean no-op.
+	out := NewCLIOutput(*jsonOutput, quietMode && !*jsonOutput)
 
 	storage, instances, _, err := loadSessionData(profile)
 	if err != nil {
@@ -192,6 +199,7 @@ func handleFleetRecover(profile string, args []string) {
 		jitter:        *jitter,
 		limit:         *limit,
 		maxFailures:   *maxFailures,
+		maxDeadBoots:  *maxDeadBoots,
 		authHaltAfter: *authHaltAfter,
 		verifyTimeout: *verifyTimeout,
 		verifyPoll:    *verifyPoll,
@@ -207,17 +215,19 @@ func handleFleetRecover(profile string, args []string) {
 
 	summary := rec.Recover(as)
 
-	if *jsonOutput {
+	switch {
+	case *jsonOutput:
 		out.Success("", fleetRecoverJSON(summary, plan))
-		return
-	}
-	if quietMode {
+	case quietMode:
 		fmt.Println(summary.Format())
-	} else {
+	default:
 		fmt.Print(formatFleetRecover(summary, plan))
 	}
 	// A halted sweep is not a success: exit non-zero so a wrapper script or
-	// conductor notices without parsing the text.
+	// conductor notices without parsing anything. This deliberately covers the
+	// --json path too — a machine caller is the one most likely to check only
+	// the exit status, so that path must not be the one that reports a halted
+	// fleet as success.
 	if summary.Halted {
 		os.Exit(1)
 	}
@@ -233,6 +243,7 @@ type fleetRecoverConfig struct {
 	jitter        float64
 	limit         int
 	maxFailures   int
+	maxDeadBoots  int
 	authHaltAfter int
 	verifyTimeout time.Duration
 	verifyPoll    time.Duration
@@ -249,6 +260,15 @@ func (c fleetRecoverConfig) recoverer() *fleet.Recoverer {
 	rec.Jitter = c.jitter
 	rec.Limit = c.limit
 	rec.MaxFailures = c.maxFailures
+	// The recoverer reads 0 as "unset, use the default" and a negative value as
+	// the explicit opt-out, so `--max-dead-boots 0` has to be translated rather
+	// than passed through — otherwise asking for the brake to be off would
+	// silently re-enable it at the default.
+	if c.maxDeadBoots <= 0 {
+		rec.MaxDeadBoots = -1
+	} else {
+		rec.MaxDeadBoots = c.maxDeadBoots
+	}
 	if c.authHaltAfter <= 0 {
 		rec.AuthGate = nil
 	} else {
@@ -304,8 +324,12 @@ func formatFleetRecover(s fleet.Summary, plan bool) string {
 	}
 	for i, r := range s.Results {
 		switch {
-		case plan:
+		case plan && r.Outcome == fleet.OutcomePlanned:
 			fmt.Fprintf(&b, "  %2d. %-40s wait=%s\n", i+1, truncateFleetTitle(r.Title, 40), r.WaitedBefore)
+		case plan:
+			// Down, but the plan will not touch it (--limit). Numbering these
+			// alongside the planned boots would misreport the sweep's scope.
+			fmt.Fprintf(&b, "      %-40s not in this run: %s\n", truncateFleetTitle(r.Title, 40), r.Reason)
 		case r.Outcome == fleet.OutcomeRecovered:
 			fmt.Fprintf(&b, "  ok         %-40s status=%s in %s\n", truncateFleetTitle(r.Title, 40), r.Report.Status, r.Report.Elapsed.Round(time.Second))
 		case r.Outcome == fleet.OutcomeUnverified:

--- a/cmd/agent-deck/fleet_cmd.go
+++ b/cmd/agent-deck/fleet_cmd.go
@@ -407,12 +407,17 @@ func groupOrRoot(inst *session.Instance) string {
 	return inst.GroupPath
 }
 
+// truncateFleetTitle shortens a title to max DISPLAY characters. It counts and
+// cuts by rune, not byte: session titles are user-supplied and routinely contain
+// non-ASCII, and a byte-slice would split a multi-byte rune into mojibake in the
+// middle of a recovery report.
 func truncateFleetTitle(title string, max int) string {
-	if len(title) <= max {
+	runes := []rune(title)
+	if len(runes) <= max {
 		return title
 	}
 	if max <= 3 {
-		return title[:max]
+		return string(runes[:max])
 	}
-	return title[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }

--- a/cmd/agent-deck/fleet_cmd.go
+++ b/cmd/agent-deck/fleet_cmd.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/fleet"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleFleet dispatches `agent-deck fleet <status|recover>`.
+//
+// The command productizes the hand-rolled recovery sweep the maintainer ran
+// twice on 2026-07-26 after the whole ~65-session fleet died: find the sessions
+// whose panes are gone, restart them ONE AT A TIME with a few seconds between
+// boots, check each came up before starting the next, and stop early if the
+// failures look systemic. See internal/fleet for the mechanics.
+func handleFleet(profile string, args []string) {
+	if len(args) == 0 {
+		printFleetHelp()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "status":
+		handleFleetStatus(profile, args[1:])
+	case "recover":
+		handleFleetRecover(profile, args[1:])
+	case "help", "--help", "-h":
+		printFleetHelp()
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown fleet command: %s\n", args[0])
+		printFleetHelp()
+		os.Exit(1)
+	}
+}
+
+func printFleetHelp() {
+	fmt.Println("Usage: agent-deck fleet <command> [options]")
+	fmt.Println()
+	fmt.Println("Detect and recover from a fleet-wide session death (every managed")
+	fmt.Println("pane gone at once: a killed tmux server, a host reboot, or an auth")
+	fmt.Println("cascade that made the agents exit).")
+	fmt.Println()
+	fmt.Println("Commands:")
+	fmt.Println("  status     Report which sessions are down (read-only, never writes)")
+	fmt.Println("  recover    Restart the down sessions sequentially, verifying each boot")
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  agent-deck fleet status")
+	fmt.Println("  agent-deck fleet recover                 # plan only (dry run)")
+	fmt.Println("  agent-deck fleet recover --yes           # actually recover")
+	fmt.Println("  agent-deck fleet recover --yes --spacing 8s --limit 10")
+	fmt.Println("  agent-deck fleet recover --yes --group agent-deck")
+}
+
+// fleetDetectorFlags are the scan knobs shared by `status` and `recover`, so a
+// plan and the recovery it authorizes always classify sessions identically.
+type fleetDetectorFlags struct {
+	group         *string
+	includeIdle   *bool
+	confirmProbes *int
+	confirmDelay  *time.Duration
+	minDead       *int
+	deadFraction  *float64
+}
+
+func registerFleetDetectorFlags(fs *flag.FlagSet) fleetDetectorFlags {
+	return fleetDetectorFlags{
+		group:       fs.String("group", "", "Only consider sessions in this group path (and its descendants)"),
+		includeIdle: fs.Bool("include-idle", false, "Also treat status=idle sessions as down (off by default: idle is also the status of a session that was never started)"),
+		confirmProbes: fs.Int("confirm-probes", fleet.DefaultConfirmProbes,
+			"Independent tmux probes that must agree a session is gone before it counts as down"),
+		confirmDelay: fs.Duration("confirm-delay", fleet.DefaultConfirmDelay, "Delay between confirming probes"),
+		minDead:      fs.Int("min-dead", fleet.DefaultMinDead, "Minimum down sessions for the shape to be reported as a mass death"),
+		deadFraction: fs.Float64("dead-fraction", fleet.DefaultDeadFraction,
+			"Share of should-be-alive sessions that must be down for a mass-death verdict"),
+	}
+}
+
+func (f fleetDetectorFlags) detector() *fleet.Detector {
+	d := fleet.NewDetector()
+	d.Group = *f.group
+	d.IncludeIdle = *f.includeIdle
+	d.ConfirmProbes = *f.confirmProbes
+	d.ConfirmDelay = *f.confirmDelay
+	d.MinDead = *f.minDead
+	d.DeadFraction = *f.deadFraction
+	return d
+}
+
+// handleFleetStatus reports the assessment and exits. It performs no writes at
+// all — safe to run on a live host, and the thing to run first when the TUI
+// looks wrong.
+func handleFleetStatus(profile string, args []string) {
+	fs := flag.NewFlagSet("fleet status", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	det := registerFleetDetectorFlags(fs)
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck fleet status [options]")
+		fmt.Println()
+		fmt.Println("Report sessions the registry believes are alive whose tmux session is")
+		fmt.Println("gone. Read-only: no restarts, no writes.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	as := det.detector().Assess(instances)
+	if *jsonOutput {
+		out.Success("", fleetStatusJSON(as))
+		return
+	}
+	fmt.Print(formatFleetStatus(as))
+}
+
+// handleFleetRecover plans (default) or runs the recovery sweep.
+func handleFleetRecover(profile string, args []string) {
+	fs := flag.NewFlagSet("fleet recover", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	yes := fs.Bool("yes", false, "Actually restart the down sessions (without this the command only prints the plan)")
+	dryRun := fs.Bool("dry-run", false, "Force plan-only mode even with --yes")
+	spacing := fs.Duration("spacing", fleet.DefaultSpacing, "Gap between consecutive boots (0 disables spacing — not recommended)")
+	jitter := fs.Float64("jitter", fleet.DefaultJitter, "Random +/- fraction applied to each gap (0 disables)")
+	limit := fs.Int("limit", 0, "Restart at most N sessions (0 = all)")
+	verifyTimeout := fs.Duration("verify-timeout", fleet.DefaultVerifyTimeout, "How long to wait for one session to prove it booted")
+	verifyPoll := fs.Duration("verify-poll", fleet.DefaultVerifyPoll, "Verification poll interval")
+	maxFailures := fs.Int("max-failures", fleet.DefaultMaxFailures, "Halt after this many consecutive failed restarts")
+	authHaltAfter := fs.Int("auth-halt-after", fleet.DefaultAuthHaltAfter, "Halt after this many sessions boot into an auth failure (0 disables the auth breaker)")
+	det := registerFleetDetectorFlags(fs)
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck fleet recover [options]")
+		fmt.Println()
+		fmt.Println("Restart every session whose tmux session is gone but whose registry")
+		fmt.Println("status claims it should be running. Sessions are restarted ONE AT A")
+		fmt.Println("TIME with --spacing between boots, and each boot is verified before the")
+		fmt.Println("next one starts.")
+		fmt.Println()
+		fmt.Println("DRY RUN BY DEFAULT: without --yes the command prints the plan and exits")
+		fmt.Println("without restarting anything.")
+		fmt.Println()
+		fmt.Println("The sweep halts early when the failures look systemic: N consecutive")
+		fmt.Println("failed restarts (--max-failures), or sessions booting into an auth")
+		fmt.Println("failure (--auth-halt-after) — restarting the rest of the fleet against a")
+		fmt.Println("broken credential only deepens the cascade.")
+		fmt.Println()
+		fmt.Println("Sessions the operator stopped or queued, and archived sessions, are")
+		fmt.Println("never touched.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	storage, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	as := det.detector().Assess(instances)
+
+	cfg := fleetRecoverConfig{
+		plan:          *dryRun || !*yes,
+		spacing:       *spacing,
+		jitter:        *jitter,
+		limit:         *limit,
+		maxFailures:   *maxFailures,
+		authHaltAfter: *authHaltAfter,
+		verifyTimeout: *verifyTimeout,
+		verifyPoll:    *verifyPoll,
+	}
+	plan := cfg.plan
+	rec := cfg.recoverer()
+	rec.Persist = storage.PersistRecoveredInstances
+	if !plan && !*jsonOutput && !quietMode {
+		rec.Progress = func(index, total int, c fleet.Candidate) {
+			fmt.Printf("[%d/%d] restarting %s...\n", index, total, c.Title())
+		}
+	}
+
+	summary := rec.Recover(as)
+
+	if *jsonOutput {
+		out.Success("", fleetRecoverJSON(summary, plan))
+		return
+	}
+	if quietMode {
+		fmt.Println(summary.Format())
+	} else {
+		fmt.Print(formatFleetRecover(summary, plan))
+	}
+	// A halted sweep is not a success: exit non-zero so a wrapper script or
+	// conductor notices without parsing the text.
+	if summary.Halted {
+		os.Exit(1)
+	}
+}
+
+// fleetRecoverConfig is the parsed flag set for a sweep. It exists so the
+// wiring of flags → recoverer (including the two safety-critical mappings:
+// "no --yes means plan only" and "--spacing 0 is the explicit opt-out") is a
+// pure function the tests can assert on.
+type fleetRecoverConfig struct {
+	plan          bool
+	spacing       time.Duration
+	jitter        float64
+	limit         int
+	maxFailures   int
+	authHaltAfter int
+	verifyTimeout time.Duration
+	verifyPoll    time.Duration
+}
+
+func (c fleetRecoverConfig) recoverer() *fleet.Recoverer {
+	rec := fleet.NewRecoverer()
+	rec.DryRun = c.plan
+	rec.Spacing = c.spacing
+	// Distinguish "flag omitted" from "operator asked for no gap": the
+	// recoverer treats Spacing<=0 as unset and falls back to the default, so
+	// only this explicit opt-out can remove the gap.
+	rec.NoSpacing = c.spacing == 0
+	rec.Jitter = c.jitter
+	rec.Limit = c.limit
+	rec.MaxFailures = c.maxFailures
+	if c.authHaltAfter <= 0 {
+		rec.AuthGate = nil
+	} else {
+		rec.AuthGate = &fleet.SubstateAuthGate{HaltAfter: c.authHaltAfter}
+	}
+	verifier := fleet.NewVerifier()
+	verifier.Timeout = c.verifyTimeout
+	verifier.Poll = c.verifyPoll
+	rec.Verify = verifier.Verify
+	return rec
+}
+
+// formatFleetStatus renders the human-readable assessment.
+func formatFleetStatus(as fleet.Assessment) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Fleet: %d sessions — %d alive, %d down, %d not running\n",
+		as.Total, as.Alive, as.Down, as.Skipped)
+	if as.MassDeath {
+		fmt.Fprintf(&b, "MASS DEATH detected (%d of %d should-be-alive sessions are gone)\n",
+			as.Down, as.Down+as.Alive)
+	}
+	if as.Down == 0 {
+		fmt.Fprintln(&b, "Nothing to recover.")
+		return b.String()
+	}
+	fmt.Fprintln(&b, "\nDown sessions:")
+	for _, c := range as.Candidates {
+		fmt.Fprintf(&b, "  %-40s status=%-8s group=%s\n", truncateFleetTitle(c.Title(), 40), c.Status, groupOrRoot(c.Instance))
+	}
+	fmt.Fprintf(&b, "\nRun `agent-deck fleet recover` to see the recovery plan, then add --yes to run it.\n")
+	return b.String()
+}
+
+// formatFleetRecover renders the human-readable sweep result.
+func formatFleetRecover(s fleet.Summary, plan bool) string {
+	var b strings.Builder
+	as := s.Assessment
+	fmt.Fprintf(&b, "Fleet: %d sessions — %d alive, %d down, %d not running\n",
+		as.Total, as.Alive, as.Down, as.Skipped)
+	if as.MassDeath {
+		fmt.Fprintf(&b, "MASS DEATH detected (%d of %d should-be-alive sessions are gone)\n",
+			as.Down, as.Down+as.Alive)
+	}
+	if as.Down == 0 {
+		fmt.Fprintln(&b, "Nothing to recover.")
+		return b.String()
+	}
+
+	if plan {
+		fmt.Fprintf(&b, "\nDRY RUN — nothing was restarted. Plan (%d session(s), sequential):\n", s.Attempted)
+	} else {
+		fmt.Fprintf(&b, "\nRecovery results:\n")
+	}
+	for i, r := range s.Results {
+		switch {
+		case plan:
+			fmt.Fprintf(&b, "  %2d. %-40s wait=%s\n", i+1, truncateFleetTitle(r.Title, 40), r.WaitedBefore)
+		case r.Outcome == fleet.OutcomeRecovered:
+			fmt.Fprintf(&b, "  ok         %-40s status=%s in %s\n", truncateFleetTitle(r.Title, 40), r.Report.Status, r.Report.Elapsed.Round(time.Second))
+		case r.Outcome == fleet.OutcomeUnverified:
+			fmt.Fprintf(&b, "  unverified %-40s pane_alive=%t status=%s substate=%s\n",
+				truncateFleetTitle(r.Title, 40), r.Report.PaneAlive, r.Report.Status, r.Report.Substate)
+		case r.Outcome == fleet.OutcomeFailed:
+			fmt.Fprintf(&b, "  FAILED     %-40s %v\n", truncateFleetTitle(r.Title, 40), r.Err)
+		default:
+			fmt.Fprintf(&b, "  skipped    %-40s %s\n", truncateFleetTitle(r.Title, 40), r.Reason)
+		}
+	}
+
+	fmt.Fprintf(&b, "\n%s\n", s.Format())
+	if plan {
+		fmt.Fprintf(&b, "Estimated sequential runtime: %s (plus up to %s verification per session)\n",
+			s.TotalWaited.Round(time.Second), fleet.DefaultVerifyTimeout)
+		fmt.Fprintln(&b, "Re-run with --yes to recover.")
+	}
+	if s.Halted {
+		fmt.Fprintf(&b, "HALTED: %s\n", s.HaltReason)
+	}
+	return b.String()
+}
+
+func fleetStatusJSON(as fleet.Assessment) map[string]interface{} {
+	return map[string]interface{}{
+		"success":    true,
+		"total":      as.Total,
+		"alive":      as.Alive,
+		"down":       as.Down,
+		"skipped":    as.Skipped,
+		"mass_death": as.MassDeath,
+		"probes":     as.Probes,
+		"sessions":   fleetCandidatesJSON(as.Candidates),
+	}
+}
+
+func fleetCandidatesJSON(candidates []fleet.Candidate) []map[string]interface{} {
+	outs := make([]map[string]interface{}, 0, len(candidates))
+	for _, c := range candidates {
+		outs = append(outs, map[string]interface{}{
+			"id":     c.ID(),
+			"title":  c.Title(),
+			"status": c.Status,
+			"group":  groupOrRoot(c.Instance),
+		})
+	}
+	return outs
+}
+
+func fleetRecoverJSON(s fleet.Summary, plan bool) map[string]interface{} {
+	results := make([]map[string]interface{}, 0, len(s.Results))
+	for _, r := range s.Results {
+		entry := map[string]interface{}{
+			"id":            r.ID,
+			"title":         r.Title,
+			"status_before": r.Status,
+			"outcome":       string(r.Outcome),
+			"waited_ms":     r.WaitedBefore.Milliseconds(),
+		}
+		if r.Err != nil {
+			entry["error"] = r.Err.Error()
+		}
+		if r.Reason != "" {
+			entry["reason"] = r.Reason
+		}
+		if r.Outcome == fleet.OutcomeRecovered || r.Outcome == fleet.OutcomeUnverified {
+			entry["pane_alive"] = r.Report.PaneAlive
+			entry["tool_started"] = r.Report.ToolStarted
+			entry["status_after"] = r.Report.Status
+			entry["substate"] = r.Report.Substate
+			entry["verify_ms"] = r.Report.Elapsed.Milliseconds()
+		}
+		results = append(results, entry)
+	}
+	return map[string]interface{}{
+		"success":     !s.Halted,
+		"dry_run":     plan,
+		"total":       s.Assessment.Total,
+		"alive":       s.Assessment.Alive,
+		"down":        s.Assessment.Down,
+		"mass_death":  s.Assessment.MassDeath,
+		"attempted":   s.Attempted,
+		"recovered":   s.Recovered,
+		"unverified":  s.Unverified,
+		"failed":      s.Failed,
+		"skipped":     s.Skipped,
+		"halted":      s.Halted,
+		"halt_reason": s.HaltReason,
+		"summary":     s.Format(),
+		"sessions":    results,
+	}
+}
+
+func groupOrRoot(inst *session.Instance) string {
+	if inst == nil || inst.GroupPath == "" {
+		return session.DefaultGroupPath
+	}
+	return inst.GroupPath
+}
+
+func truncateFleetTitle(title string, max int) string {
+	if len(title) <= max {
+		return title
+	}
+	if max <= 3 {
+		return title[:max]
+	}
+	return title[:max-3] + "..."
+}

--- a/cmd/agent-deck/fleet_cmd_test.go
+++ b/cmd/agent-deck/fleet_cmd_test.go
@@ -85,6 +85,50 @@ func TestFormatFleetRecover_DryRunIsLabelledAndActionable(t *testing.T) {
 	}
 }
 
+// A plan must not number sessions it is not going to touch. With --limit the
+// rest of the down set is still listed (the operator needs to know it is down)
+// but visibly outside this run — printing all 65 as numbered plan lines would
+// misreport what --yes is about to do.
+func TestFormatFleetRecover_PlanSeparatesSessionsOutsideTheLimit(t *testing.T) {
+	sum := fleet.Summary{
+		Assessment:  fleet.Assessment{Total: 3, Down: 3},
+		DryRun:      true,
+		Attempted:   1,
+		Skipped:     2,
+		TotalWaited: 0,
+		Results: []fleet.Result{
+			{Title: "in-plan", Outcome: fleet.OutcomePlanned},
+			{Title: "out-one", Outcome: fleet.OutcomeSkipped, Reason: "beyond --limit 1"},
+			{Title: "out-two", Outcome: fleet.OutcomeSkipped, Reason: "beyond --limit 1"},
+		},
+	}
+
+	got := formatFleetRecover(sum, true)
+
+	if !strings.Contains(got, " 1. in-plan") {
+		t.Errorf("planned session is not numbered:\n%s", got)
+	}
+	for _, title := range []string{"out-one", "out-two"} {
+		line := fleetLineContaining(got, title)
+		if !strings.Contains(line, "not in this run: beyond --limit 1") {
+			t.Errorf("session outside the limit reported as %q", line)
+		}
+		if strings.Contains(line, "wait=") {
+			t.Errorf("session outside the limit shown with a planned wait: %q", line)
+		}
+	}
+}
+
+// fleetLineContaining returns the first line of out containing needle.
+func fleetLineContaining(out, needle string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}
+
 func TestFormatFleetRecover_DistinguishesEveryOutcome(t *testing.T) {
 	sum := fleet.Summary{
 		Assessment: fleet.Assessment{Total: 4, Down: 4},
@@ -292,6 +336,18 @@ func TestFleetRecoverConfigWiring(t *testing.T) {
 		rec := fleetRecoverConfig{limit: 7, maxFailures: 2, jitter: 0.35}.recoverer()
 		if rec.Limit != 7 || rec.MaxFailures != 2 || rec.Jitter != 0.35 {
 			t.Fatalf("recoverer = limit %d, maxFailures %d, jitter %v", rec.Limit, rec.MaxFailures, rec.Jitter)
+		}
+	})
+
+	// The recoverer reads MaxDeadBoots 0 as "unset → default", so the flag value
+	// 0 (meaning "off") has to be translated to the negative opt-out. Passing it
+	// through would silently re-enable the brake the operator asked to disable.
+	t.Run("dead-boot brake: 0 disables, positive is forwarded", func(t *testing.T) {
+		if rec := (fleetRecoverConfig{maxDeadBoots: 0}).recoverer(); rec.MaxDeadBoots >= 0 {
+			t.Errorf("MaxDeadBoots = %d for --max-dead-boots 0, want a negative opt-out", rec.MaxDeadBoots)
+		}
+		if rec := (fleetRecoverConfig{maxDeadBoots: 5}).recoverer(); rec.MaxDeadBoots != 5 {
+			t.Errorf("MaxDeadBoots = %d, want 5", rec.MaxDeadBoots)
 		}
 	})
 

--- a/cmd/agent-deck/fleet_cmd_test.go
+++ b/cmd/agent-deck/fleet_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/asheshgoplani/agent-deck/internal/fleet"
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -209,6 +210,27 @@ func TestTruncateFleetTitle(t *testing.T) {
 	}
 	if got := truncateFleetTitle("abcdef", 2); got != "ab" {
 		t.Errorf("tiny max = %q", got)
+	}
+}
+
+// Titles are user-supplied and often non-ASCII; truncation must cut on rune
+// boundaries so a report never prints a mangled half-character.
+func TestTruncateFleetTitle_IsRuneSafe(t *testing.T) {
+	title := "工作会话-日本語-ほげほげ"
+	got := truncateFleetTitle(title, 6)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated title is not valid UTF-8: %q", got)
+	}
+	if want := "工作会..."; got != want {
+		t.Errorf("truncateFleetTitle = %q, want %q", got, want)
+	}
+	// A title that fits by rune count must survive untouched even though its
+	// byte length exceeds the limit.
+	if got := truncateFleetTitle("日本語", 3); got != "日本語" {
+		t.Errorf("truncateFleetTitle = %q, want the title unchanged", got)
+	}
+	if got := truncateFleetTitle("日本語です", 2); got != "日本" {
+		t.Errorf("tiny max on multibyte = %q, want %q", got, "日本")
 	}
 }
 

--- a/cmd/agent-deck/fleet_cmd_test.go
+++ b/cmd/agent-deck/fleet_cmd_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/fleet"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func fleetTestCandidate(title, group string, st session.Status) fleet.Candidate {
+	return fleet.Candidate{
+		Instance: &session.Instance{ID: "id-" + title, Title: title, GroupPath: group, Status: st},
+		Health:   fleet.HealthDown,
+		Status:   string(st),
+	}
+}
+
+func TestFormatFleetStatus_MassDeath(t *testing.T) {
+	as := fleet.Assessment{
+		Total:     10,
+		Alive:     1,
+		Down:      2,
+		Skipped:   7,
+		MassDeath: true,
+		Candidates: []fleet.Candidate{
+			fleetTestCandidate("conductor-one", "conductor", session.StatusError),
+			fleetTestCandidate("worker-a", "agent-deck", session.StatusRunning),
+		},
+	}
+
+	got := formatFleetStatus(as)
+
+	for _, want := range []string{
+		"10 sessions", "1 alive", "2 down", "7 not running",
+		"MASS DEATH detected", "conductor-one", "worker-a",
+		"status=error", "group=agent-deck", "fleet recover",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatFleetStatus_HealthyFleetSaysNothingToDo(t *testing.T) {
+	got := formatFleetStatus(fleet.Assessment{Total: 5, Alive: 5})
+	if !strings.Contains(got, "Nothing to recover.") {
+		t.Errorf("healthy output = %q", got)
+	}
+	if strings.Contains(got, "MASS DEATH") {
+		t.Errorf("healthy fleet must not claim a mass death:\n%s", got)
+	}
+}
+
+// The default (no --yes) path must make it unmistakable that nothing happened
+// and must say how to actually run the sweep.
+func TestFormatFleetRecover_DryRunIsLabelledAndActionable(t *testing.T) {
+	as := fleet.Assessment{Total: 3, Down: 2, MassDeath: true,
+		Candidates: []fleet.Candidate{
+			fleetTestCandidate("a", "g", session.StatusError),
+			fleetTestCandidate("b", "g", session.StatusError),
+		}}
+	sum := fleet.Summary{
+		Assessment:  as,
+		DryRun:      true,
+		Attempted:   2,
+		TotalWaited: 5 * time.Second,
+		Results: []fleet.Result{
+			{Title: "a", Outcome: fleet.OutcomePlanned},
+			{Title: "b", Outcome: fleet.OutcomePlanned, WaitedBefore: 5 * time.Second},
+		},
+	}
+
+	got := formatFleetRecover(sum, true)
+
+	for _, want := range []string{
+		"DRY RUN — nothing was restarted", "wait=5s",
+		"dry-run down=2 attempted=2", "Estimated sequential runtime", "Re-run with --yes",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatFleetRecover_DistinguishesEveryOutcome(t *testing.T) {
+	sum := fleet.Summary{
+		Assessment: fleet.Assessment{Total: 4, Down: 4},
+		Attempted:  3,
+		Recovered:  1,
+		Unverified: 1,
+		Failed:     1,
+		Skipped:    1,
+		Halted:     true,
+		HaltReason: "3 consecutive restarts failed",
+		Results: []fleet.Result{
+			{Title: "ok-one", Outcome: fleet.OutcomeRecovered,
+				Report: fleet.VerifyReport{PaneAlive: true, ToolStarted: true, Status: "running", Elapsed: 4 * time.Second}},
+			{Title: "half-one", Outcome: fleet.OutcomeUnverified,
+				Report: fleet.VerifyReport{PaneAlive: true, Status: "starting", Substate: "auth-401"}},
+			{Title: "broken-one", Outcome: fleet.OutcomeFailed, Err: errFleetTest},
+			{Title: "untried-one", Outcome: fleet.OutcomeSkipped, Reason: "halted"},
+		},
+	}
+
+	got := formatFleetRecover(sum, false)
+
+	for _, want := range []string{
+		"ok         ok-one", "unverified half-one", "auth-401",
+		"FAILED     broken-one", "tmux exploded",
+		"skipped    untried-one",
+		"halted=true", "HALTED: 3 consecutive restarts failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("recover output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatFleetRecover_NothingDown(t *testing.T) {
+	got := formatFleetRecover(fleet.Summary{Assessment: fleet.Assessment{Total: 4, Alive: 4}}, false)
+	if !strings.Contains(got, "Nothing to recover.") {
+		t.Errorf("output = %q", got)
+	}
+}
+
+func TestFleetRecoverJSON_ShapeIsMachineCheckable(t *testing.T) {
+	sum := fleet.Summary{
+		Assessment: fleet.Assessment{Total: 2, Alive: 0, Down: 2, MassDeath: true},
+		Attempted:  2,
+		Recovered:  1,
+		Unverified: 1,
+		Halted:     true,
+		HaltReason: "auth circuit open",
+		Results: []fleet.Result{
+			{ID: "id-a", Title: "a", Status: "error", Outcome: fleet.OutcomeRecovered,
+				WaitedBefore: 5 * time.Second,
+				Report:       fleet.VerifyReport{PaneAlive: true, ToolStarted: true, Status: "running", Elapsed: 2 * time.Second}},
+			{ID: "id-b", Title: "b", Status: "error", Outcome: fleet.OutcomeSkipped, Reason: "halted"},
+		},
+	}
+
+	payload := fleetRecoverJSON(sum, false)
+
+	if payload["success"] != false {
+		t.Error("a halted sweep must not report success=true")
+	}
+	if payload["mass_death"] != true || payload["halted"] != true {
+		t.Errorf("payload = %+v", payload)
+	}
+	if payload["halt_reason"] != "auth circuit open" {
+		t.Errorf("halt_reason = %v", payload["halt_reason"])
+	}
+	sessions, ok := payload["sessions"].([]map[string]interface{})
+	if !ok || len(sessions) != 2 {
+		t.Fatalf("sessions = %#v", payload["sessions"])
+	}
+	first := sessions[0]
+	if first["outcome"] != string(fleet.OutcomeRecovered) {
+		t.Errorf("outcome = %v", first["outcome"])
+	}
+	if first["waited_ms"] != int64(5000) || first["verify_ms"] != int64(2000) {
+		t.Errorf("timings = %v / %v", first["waited_ms"], first["verify_ms"])
+	}
+	if first["tool_started"] != true || first["status_after"] != "running" {
+		t.Errorf("verification fields = %+v", first)
+	}
+	// A skipped session carries a reason and NO verification fields — the
+	// payload must never imply we looked at a session we never touched.
+	second := sessions[1]
+	if second["reason"] != "halted" {
+		t.Errorf("reason = %v", second["reason"])
+	}
+	if _, present := second["pane_alive"]; present {
+		t.Errorf("skipped session must not carry verification fields: %+v", second)
+	}
+}
+
+func TestFleetStatusJSON_Shape(t *testing.T) {
+	as := fleet.Assessment{Total: 3, Alive: 1, Down: 1, Skipped: 1, MassDeath: false, Probes: 2,
+		Candidates: []fleet.Candidate{fleetTestCandidate("a", "", session.StatusError)}}
+
+	payload := fleetStatusJSON(as)
+
+	if payload["total"] != 3 || payload["down"] != 1 || payload["probes"] != 2 {
+		t.Errorf("payload = %+v", payload)
+	}
+	sessions := payload["sessions"].([]map[string]interface{})
+	if len(sessions) != 1 || sessions[0]["title"] != "a" {
+		t.Fatalf("sessions = %#v", sessions)
+	}
+	// An empty group must render as the default group, never as "".
+	if sessions[0]["group"] != session.DefaultGroupPath {
+		t.Errorf("group = %v, want %q", sessions[0]["group"], session.DefaultGroupPath)
+	}
+}
+
+func TestTruncateFleetTitle(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{in: "short", want: "short"},
+		{in: "0123456789", want: "0123456789"},
+		{in: "0123456789a", want: "0123456..."},
+	}
+	for _, tc := range tests {
+		if got := truncateFleetTitle(tc.in, 10); got != tc.want {
+			t.Errorf("truncateFleetTitle(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	if got := truncateFleetTitle("abcdef", 2); got != "ab" {
+		t.Errorf("tiny max = %q", got)
+	}
+}
+
+// SAFETY DEFAULT. `fleet recover` restarts processes. Without an explicit --yes
+// it must only ever print a plan — this is the guard that keeps a typo from
+// restarting 65 sessions.
+func TestFleetRecoverIsDryRunUnlessYes(t *testing.T) {
+	tests := []struct {
+		name     string
+		yes      bool
+		dryRun   bool
+		wantPlan bool
+	}{
+		{name: "default is a plan", wantPlan: true},
+		{name: "--yes acts", yes: true, wantPlan: false},
+		{name: "--dry-run wins over --yes", yes: true, dryRun: true, wantPlan: true},
+		{name: "--dry-run alone is a plan", dryRun: true, wantPlan: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := fleetRecoverConfig{plan: tc.dryRun || !tc.yes}
+			if cfg.plan != tc.wantPlan {
+				t.Fatalf("plan = %t, want %t", cfg.plan, tc.wantPlan)
+			}
+			if got := cfg.recoverer().DryRun; got != tc.wantPlan {
+				t.Fatalf("recoverer DryRun = %t, want %t", got, tc.wantPlan)
+			}
+		})
+	}
+}
+
+func TestFleetRecoverConfigWiring(t *testing.T) {
+	t.Run("spacing 0 is an explicit opt-out, not an unset field", func(t *testing.T) {
+		rec := fleetRecoverConfig{spacing: 0}.recoverer()
+		if !rec.NoSpacing {
+			t.Fatal("NoSpacing = false for --spacing 0")
+		}
+		rec = fleetRecoverConfig{spacing: 8 * time.Second}.recoverer()
+		if rec.NoSpacing || rec.Spacing != 8*time.Second {
+			t.Fatalf("Spacing = %s NoSpacing = %t", rec.Spacing, rec.NoSpacing)
+		}
+	})
+
+	t.Run("auth breaker can be disabled and tuned", func(t *testing.T) {
+		if rec := (fleetRecoverConfig{authHaltAfter: 0}).recoverer(); rec.AuthGate != nil {
+			t.Error("AuthGate should be nil when --auth-halt-after is 0")
+		}
+		rec := fleetRecoverConfig{authHaltAfter: 4}.recoverer()
+		gate, ok := rec.AuthGate.(*fleet.SubstateAuthGate)
+		if !ok {
+			t.Fatalf("AuthGate = %T, want *fleet.SubstateAuthGate", rec.AuthGate)
+		}
+		if gate.HaltAfter != 4 {
+			t.Errorf("HaltAfter = %d, want 4", gate.HaltAfter)
+		}
+	})
+
+	t.Run("limits and brakes are forwarded", func(t *testing.T) {
+		rec := fleetRecoverConfig{limit: 7, maxFailures: 2, jitter: 0.35}.recoverer()
+		if rec.Limit != 7 || rec.MaxFailures != 2 || rec.Jitter != 0.35 {
+			t.Fatalf("recoverer = limit %d, maxFailures %d, jitter %v", rec.Limit, rec.MaxFailures, rec.Jitter)
+		}
+	})
+
+	t.Run("a real verifier is always wired", func(t *testing.T) {
+		if (fleetRecoverConfig{}).recoverer().Verify == nil {
+			t.Fatal("Verify is nil — a sweep would report every boot as unverified")
+		}
+	})
+}
+
+var errFleetTest = fleetTestError("tmux exploded")
+
+type fleetTestError string
+
+func (e fleetTestError) Error() string { return string(e) }

--- a/cmd/agent-deck/fleet_recover_persist_cli_test.go
+++ b/cmd/agent-deck/fleet_recover_persist_cli_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/fleet"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// newFleetCLIStorage opens a real Storage handle on the isolated test profile.
+// Each call returns a fresh handle on the SAME on-disk state.db so we can
+// simulate two concurrent processes the way production does (a recovery sweep
+// running for minutes while the operator adds a session in the TUI).
+func newFleetCLIStorage(t *testing.T) *session.Storage {
+	t.Helper()
+	s, err := session.NewStorageWithProfile("")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func fleetPersistInstance(id, title string, st session.Status) *session.Instance {
+	return &session.Instance{
+		ID:          id,
+		Title:       title,
+		ProjectPath: "/tmp/" + title,
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      st,
+		CreatedAt:   time.Now().Add(-2 * time.Minute),
+	}
+}
+
+// DATA-SAFETY REGRESSION GUARD for the whole recovery command.
+//
+// A 65-session sweep runs for minutes, so the snapshot it loaded is stale by the
+// time it writes. The 2026-06-04 incident was exactly this shape: a stale
+// snapshot written back through a sweeping save deleted rows another process had
+// added. This test drives the EXACT seam the CLI wires (a fleet.Recoverer whose
+// Persist is storage.PersistRecoveredInstances) and asserts a session added
+// mid-sweep survives.
+//
+// A regression that swaps the persist back to saveSessionData / SaveWithGroups /
+// SaveInstances is caught here, not only in a storage unit test.
+func TestFleetRecoverCLI_PersistDoesNotClobberConcurrentAdd(t *testing.T) {
+	// Own profile: saves are upsert-only, so rows written by other tests in the
+	// shared _test profile would otherwise leak into this snapshot.
+	t.Setenv("AGENTDECK_PROFILE", "_test_fleet_recover_persist")
+	sweepStorage := newFleetCLIStorage(t)
+
+	down := fleetPersistInstance("fleet-down", "down", session.StatusError)
+	require.NoError(t, sweepStorage.SaveWithGroups(
+		[]*session.Instance{down},
+		session.NewGroupTree([]*session.Instance{down}),
+	))
+
+	// Step 1: the sweep loads its snapshot (one down session).
+	snapshot, _, err := sweepStorage.LoadWithGroups()
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
+
+	// Step 2: a concurrent process inserts a brand-new session.
+	addStorage := newFleetCLIStorage(t)
+	added := fleetPersistInstance("fleet-added-concurrently", "added", session.StatusRunning)
+	require.NoError(t, addStorage.InsertSessionAndVerify(
+		added,
+		session.NewGroupTree([]*session.Instance{down, added}),
+	))
+
+	// Step 3: the sweep restarts + persists through the production seam.
+	as := fleet.Assessment{Total: 1, Down: 1, Candidates: []fleet.Candidate{{
+		Instance: snapshot[0],
+		Health:   fleet.HealthDown,
+		Status:   string(session.StatusError),
+	}}}
+	rec := &fleet.Recoverer{
+		Restart: func(inst *session.Instance) error {
+			// Mirror what a real restart mutates: the session comes back running.
+			inst.Status = session.StatusRunning
+			return nil
+		},
+		Verify: func(*session.Instance) fleet.VerifyReport {
+			return fleet.VerifyReport{PaneAlive: true, ToolStarted: true, Status: string(session.StatusRunning)}
+		},
+		Persist:   sweepStorage.PersistRecoveredInstances,
+		Sleep:     func(time.Duration) {},
+		NoSpacing: true,
+	}
+
+	sum := rec.Recover(as)
+	require.Equal(t, 1, sum.Recovered, "sweep summary: %+v", sum)
+
+	// Invariant 1: the concurrently-added session still exists.
+	verifyStorage := newFleetCLIStorage(t)
+	after, _, err := verifyStorage.LoadWithGroups()
+	require.NoError(t, err)
+
+	byID := map[string]*session.Instance{}
+	for _, inst := range after {
+		byID[inst.ID] = inst
+	}
+	require.Contains(t, byID, "fleet-added-concurrently",
+		"recovery clobbered a session added during the sweep (the 2026-06-04 data-loss class)")
+
+	// Invariant 2: the restarted session's new status was persisted.
+	recovered := byID["fleet-down"]
+	require.NotNil(t, recovered)
+	require.Equal(t, session.StatusRunning, recovered.Status)
+
+	// Invariant 3: the untouched row was not rewritten from the sweep's stale
+	// snapshot — its own status survives.
+	require.Equal(t, session.StatusRunning, byID["fleet-added-concurrently"].Status)
+}
+
+// PersistRecoveredInstances must ignore nils and report per-row failures without
+// dropping the rows it can write.
+func TestPersistRecoveredInstances_ToleratesNilEntries(t *testing.T) {
+	t.Setenv("AGENTDECK_PROFILE", "_test_fleet_persist_nil")
+	storage := newFleetCLIStorage(t)
+
+	inst := fleetPersistInstance("fleet-nil-tolerant", "nil-tolerant", session.StatusRunning)
+	require.NoError(t, storage.PersistRecoveredInstances([]*session.Instance{nil, inst, nil}))
+
+	after, _, err := newFleetCLIStorage(t).LoadWithGroups()
+	require.NoError(t, err)
+	var found bool
+	for _, got := range after {
+		if got.ID == inst.ID {
+			found = true
+		}
+	}
+	require.True(t, found, "the non-nil instance was not persisted")
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -276,6 +276,9 @@ func main() {
 		case "session":
 			handleSession(profile, args[1:])
 			return
+		case "fleet":
+			handleFleet(profile, args[1:])
+			return
 		case "mcp":
 			handleMCP(profile, args[1:])
 			return
@@ -3186,6 +3189,7 @@ func printHelp() {
 	fmt.Println("  rename, mv       Rename a session")
 	fmt.Println("  status           Show session status summary")
 	fmt.Println("  session          Manage session lifecycle")
+	fmt.Println("  fleet            Detect and recover from a fleet-wide session death")
 	fmt.Println("  mcp              Manage MCP servers")
 	fmt.Println("  skill            Manage project skills")
 	fmt.Println("  codex-hooks      Manage Codex notify hook integration")
@@ -3213,6 +3217,10 @@ func printHelp() {
 	fmt.Println("  session fork <id>         Fork Claude or Pi session with context")
 	fmt.Println("  session attach <id>       Attach to session interactively")
 	fmt.Println("  session show [id]         Show session details")
+	fmt.Println()
+	fmt.Println("Fleet Recovery Commands:")
+	fmt.Println("  fleet status              Report sessions whose panes are gone (read-only)")
+	fmt.Println("  fleet recover             Plan a sequential recovery sweep (add --yes to run it)")
 	fmt.Println()
 	fmt.Println("MCP Commands:")
 	fmt.Println("  mcp list                  List available MCPs from config.toml")

--- a/internal/fleet/authgate.go
+++ b/internal/fleet/authgate.go
@@ -1,0 +1,74 @@
+package fleet
+
+import (
+	"fmt"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// AuthGate is the circuit-breaker seam a recovery sweep consults before every
+// boot and reports every boot to.
+//
+// INTEGRATION POINT. The auth-cascade half of the 2026-07-26 fleet deaths is
+// being fixed separately: N sessions share one rotating OAuth refresh token, so
+// a burst of restarts can fork the token and 401 the whole fleet (see
+// bug_oauth_multisession_rotation_race_rootcause). When that breaker lands it
+// should be adapted to this interface and passed as Recoverer.AuthGate — no
+// change to the sequencing logic is needed. Until then Recoverer defaults to
+// SubstateAuthGate below, which reads the same signal from the pane the TUI
+// already classifies (Honest-Status v2 substate "auth-401") and halts the sweep
+// rather than grinding through 60 doomed boots.
+type AuthGate interface {
+	// Allow is consulted BEFORE each boot. Returning false halts the sweep;
+	// the string is the operator-facing reason. It must be cheap and must not
+	// block.
+	Allow() (bool, string)
+
+	// Observe is called after each boot with what verification saw. err is the
+	// restart error (nil when the restart itself succeeded).
+	Observe(inst *session.Instance, rep VerifyReport, err error)
+}
+
+// SubstateAuthGate is the built-in auth breaker: it counts boots whose pane
+// came up showing an auth-failure banner and opens after HaltAfter of them.
+//
+// It deliberately does NOT count SubstateModelUnavailable (a dead model is not
+// a credential problem and recovers on its own when the model returns) and does
+// not count restart errors (those are handled by the consecutive-failure brake,
+// which is about tmux/spawn health rather than credentials).
+type SubstateAuthGate struct {
+	// HaltAfter is the number of auth-failed boots that opens the circuit.
+	// <=0 uses DefaultAuthHaltAfter.
+	HaltAfter int
+
+	seen int
+}
+
+// Allow reports whether another boot may proceed.
+func (g *SubstateAuthGate) Allow() (bool, string) {
+	limit := g.limit()
+	if g.seen < limit {
+		return true, ""
+	}
+	return false, fmt.Sprintf(
+		"auth circuit open: %d session(s) booted into an auth failure (substate %q) — recovering the rest would keep re-forking the shared credential; re-authenticate, then re-run",
+		g.seen, session.SubstateAuth401)
+}
+
+// Observe records one boot's verification result.
+func (g *SubstateAuthGate) Observe(_ *session.Instance, rep VerifyReport, _ error) {
+	if rep.Substate == string(session.SubstateAuth401) {
+		g.seen++
+	}
+}
+
+// AuthFailures returns how many auth-failed boots have been observed. Exposed
+// for the CLI summary.
+func (g *SubstateAuthGate) AuthFailures() int { return g.seen }
+
+func (g *SubstateAuthGate) limit() int {
+	if g.HaltAfter <= 0 {
+		return DefaultAuthHaltAfter
+	}
+	return g.HaltAfter
+}

--- a/internal/fleet/authgate.go
+++ b/internal/fleet/authgate.go
@@ -9,15 +9,31 @@ import (
 // AuthGate is the circuit-breaker seam a recovery sweep consults before every
 // boot and reports every boot to.
 //
-// INTEGRATION POINT. The auth-cascade half of the 2026-07-26 fleet deaths is
-// being fixed separately: N sessions share one rotating OAuth refresh token, so
-// a burst of restarts can fork the token and 401 the whole fleet (see
-// bug_oauth_multisession_rotation_race_rootcause). When that breaker lands it
-// should be adapted to this interface and passed as Recoverer.AuthGate — no
-// change to the sequencing logic is needed. Until then Recoverer defaults to
-// SubstateAuthGate below, which reads the same signal from the pane the TUI
-// already classifies (Honest-Status v2 substate "auth-401") and halts the sweep
-// rather than grinding through 60 doomed boots.
+// INTEGRATION POINT (deliberate, and mechanical to complete). The auth-cascade
+// half of the 2026-07-26 fleet deaths is fixed on a separate branch: N sessions
+// share one rotating OAuth refresh token, so a burst of restarts forks the token
+// and 401s the whole fleet (bug_oauth_multisession_rotation_race_rootcause).
+// That work adds a per-session auth HOLD plus a paced bulk-boot breaker in
+// internal/session (Instance.IsAuthHeld / RecordAuthBootFailure and
+// session.BootSweep). It is not on main yet, so this package cannot reference it
+// without breaking the build; when it lands, the adapter is:
+//
+//	type heldAuthGate struct{ sweep *session.BootSweep; consecutive, limit int }
+//	// Allow():   consecutive < limit
+//	// Observe(): if inst.IsAuthHeld() (or rep.AuthFailed()) → consecutive++,
+//	//            inst.RecordAuthBootFailure(); else consecutive = 0
+//
+// plus one line in Detector.Classify to report an auth-held session as
+// HealthSkipped ("auth hold: <remedy>") so a sweep never restarts a session the
+// hold has already parked. Nothing in the sequencing logic changes: that is what
+// the AuthGate seam is for.
+//
+// Until then Recoverer defaults to SubstateAuthGate below, which reads the same
+// signal from the pane the TUI already classifies (Honest-Status v2 substate
+// "auth-401") and halts the sweep rather than grinding through 60 doomed boots.
+// The complementary case — a session that does not sit in a 401 banner but
+// EXITS on the failed refresh, leaving no pane and no substate — is covered by
+// the recoverer's dead-boot brake (Recoverer.MaxDeadBoots), not here.
 type AuthGate interface {
 	// Allow is consulted BEFORE each boot. Returning false halts the sweep;
 	// the string is the operator-facing reason. It must be cheap and must not

--- a/internal/fleet/detect.go
+++ b/internal/fleet/detect.go
@@ -1,0 +1,245 @@
+package fleet
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Assessment is the read-only verdict of a fleet scan.
+type Assessment struct {
+	// Total is the number of instances scanned.
+	Total int
+	// Alive is how many have a live tmux session.
+	Alive int
+	// Down is how many are recovery candidates (len(Candidates)).
+	Down int
+	// Skipped is how many were intentionally not running (stopped/queued/archived).
+	Skipped int
+	// MassDeath is true when the down set is large enough, both absolutely and
+	// as a share of should-be-alive sessions, to read as a fleet-wide event
+	// rather than one crashed session.
+	MassDeath bool
+	// Candidates are the down sessions in recovery order.
+	Candidates []Candidate
+	// Probes is how many confirming tmux probes were required.
+	Probes int
+}
+
+// Detector finds sessions the registry believes are alive whose tmux session is
+// gone. All I/O is behind function fields so tests never touch a tmux server.
+type Detector struct {
+	// TmuxExists probes one session on its own socket. Signature mirrors
+	// session.Reviver.TmuxExists: the socket must be passed explicitly or
+	// sessions on an isolated socket look dead on the default server.
+	TmuxExists func(name, socketName string) bool
+	// Sleep separates confirming probes.
+	Sleep func(time.Duration)
+
+	// ConfirmProbes / ConfirmDelay implement the "one miss is not proof of
+	// death" rule (see DefaultConfirmProbes). Values below 1 are treated as 1.
+	ConfirmProbes int
+	ConfirmDelay  time.Duration
+
+	// MinDead / DeadFraction tune the MassDeath verdict.
+	MinDead      int
+	DeadFraction float64
+
+	// IncludeIdle adds status=idle sessions to the candidate set. Off by
+	// default: a pane that died maps to error (or stopped for opencode), while
+	// idle is also the status of a session that was added but never started, so
+	// including it turns "recover the fleet" into "launch things the operator
+	// never launched".
+	IncludeIdle bool
+
+	// Group, when set, restricts the scan to that group path and its
+	// descendants. Everything outside is classified HealthSkipped.
+	Group string
+}
+
+// NewDetector returns a Detector wired to real tmux probes and defaults.
+func NewDetector() *Detector {
+	return &Detector{
+		// Argument order is flipped on purpose: tmux.HasSessionOnSocket takes
+		// (socket, name) while the probe seam mirrors session.Reviver's
+		// (name, socket) shape.
+		TmuxExists: func(name, socketName string) bool {
+			return tmux.HasSessionOnSocket(socketName, name)
+		},
+		Sleep:         time.Sleep,
+		ConfirmProbes: DefaultConfirmProbes,
+		ConfirmDelay:  DefaultConfirmDelay,
+		MinDead:       DefaultMinDead,
+		DeadFraction:  DefaultDeadFraction,
+	}
+}
+
+// Assess classifies every instance and returns the verdict. It performs no
+// writes and mutates no instance — safe to run on a live host at any time.
+func (d *Detector) Assess(instances []*session.Instance) Assessment {
+	probes := d.confirmProbes()
+	as := Assessment{Probes: probes}
+
+	// First pass: classify without probing anything that cannot be a candidate,
+	// so a scan costs one tmux probe per should-be-alive session and zero for
+	// the rest.
+	type pending struct {
+		inst   *session.Instance
+		status string
+	}
+	var maybeDown []pending
+
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		as.Total++
+		status := string(inst.Status)
+
+		if d.skipReason(inst) != "" {
+			as.Skipped++
+			continue
+		}
+
+		if d.exists(inst) {
+			as.Alive++
+			continue
+		}
+		maybeDown = append(maybeDown, pending{inst: inst, status: status})
+	}
+
+	// Second pass: re-probe the misses. A session that reappears on any
+	// confirming probe was never dead (tmux server restart race) and is counted
+	// alive instead of being restarted.
+	for round := 1; round < probes && len(maybeDown) > 0; round++ {
+		if d.ConfirmDelay > 0 && d.Sleep != nil {
+			d.Sleep(d.ConfirmDelay)
+		}
+		kept := maybeDown[:0]
+		for _, p := range maybeDown {
+			if d.exists(p.inst) {
+				as.Alive++
+				continue
+			}
+			kept = append(kept, p)
+		}
+		maybeDown = kept
+	}
+
+	for _, p := range maybeDown {
+		as.Candidates = append(as.Candidates, Candidate{
+			Instance: p.inst,
+			Health:   HealthDown,
+			Status:   p.status,
+		})
+	}
+	as.Down = len(as.Candidates)
+
+	// Recover oldest-first (stable by created-at, then title) so a partial
+	// sweep is reproducible and the operator can predict what a --limit run
+	// will touch.
+	sort.SliceStable(as.Candidates, func(i, j int) bool {
+		a, b := as.Candidates[i].Instance, as.Candidates[j].Instance
+		if !a.CreatedAt.Equal(b.CreatedAt) {
+			return a.CreatedAt.Before(b.CreatedAt)
+		}
+		return a.Title < b.Title
+	})
+
+	as.MassDeath = d.isMassDeath(as)
+	return as
+}
+
+// isMassDeath applies both thresholds: an absolute floor (a single crash is not
+// a fleet death) and a share of the should-be-alive population (30 down out of
+// 500 healthy is a bad afternoon, not a fleet death).
+func (d *Detector) isMassDeath(as Assessment) bool {
+	minDead := d.MinDead
+	if minDead <= 0 {
+		minDead = DefaultMinDead
+	}
+	if as.Down < minDead {
+		return false
+	}
+	shouldBeAlive := as.Down + as.Alive
+	if shouldBeAlive == 0 {
+		return false
+	}
+	frac := d.DeadFraction
+	if frac <= 0 {
+		frac = DefaultDeadFraction
+	}
+	return float64(as.Down)/float64(shouldBeAlive) >= frac
+}
+
+func (d *Detector) confirmProbes() int {
+	if d.ConfirmProbes < 1 {
+		return 1
+	}
+	return d.ConfirmProbes
+}
+
+func (d *Detector) exists(inst *session.Instance) bool {
+	if d.TmuxExists == nil {
+		return false
+	}
+	return d.TmuxExists(TmuxName(inst), inst.TmuxSocketName)
+}
+
+// skipReason returns a non-empty explanation when a session must not be
+// recovered, or "" when it is eligible for a liveness probe.
+func (d *Detector) skipReason(inst *session.Instance) string {
+	if !inst.ArchivedAt.IsZero() {
+		return "archived"
+	}
+	if d.Group != "" && !inGroup(inst.GroupPath, d.Group) {
+		return "outside --group"
+	}
+	if !d.shouldBeAlive(inst.Status) {
+		return "status " + string(inst.Status)
+	}
+	if !inst.CanRestart() {
+		return "not restartable"
+	}
+	return ""
+}
+
+// shouldBeAlive reports whether a status is a claim that the session's process
+// is running. StatusStopped/StatusQueued are operator intent and never
+// recovered; StatusIdle is opt-in (see Detector.IncludeIdle).
+func (d *Detector) shouldBeAlive(st session.Status) bool {
+	switch st {
+	case session.StatusRunning, session.StatusWaiting, session.StatusStarting, session.StatusError:
+		return true
+	case session.StatusIdle:
+		return d.IncludeIdle
+	}
+	return false
+}
+
+// inGroup reports whether groupPath is want or a descendant of it.
+func inGroup(groupPath, want string) bool {
+	groupPath = strings.Trim(groupPath, "/")
+	want = strings.Trim(want, "/")
+	if want == "" {
+		return true
+	}
+	return groupPath == want || strings.HasPrefix(groupPath, want+"/")
+}
+
+// TmuxName resolves the tmux session name to probe for an instance. Mirrors
+// session.instanceTmuxName (unexported there): the attached tmux.Session is
+// authoritative, with the title as the legacy fallback for records built
+// without one.
+func TmuxName(inst *session.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	if ts := inst.GetTmuxSession(); ts != nil && ts.Name != "" {
+		return ts.Name
+	}
+	return inst.Title
+}

--- a/internal/fleet/detect.go
+++ b/internal/fleet/detect.go
@@ -99,16 +99,14 @@ func (d *Detector) Assess(instances []*session.Instance) Assessment {
 		as.Total++
 		status := string(inst.Status)
 
-		if d.skipReason(inst) != "" {
+		switch health, _ := d.Classify(inst); health {
+		case HealthSkipped:
 			as.Skipped++
-			continue
-		}
-
-		if d.exists(inst) {
+		case HealthAlive:
 			as.Alive++
-			continue
+		default:
+			maybeDown = append(maybeDown, pending{inst: inst, status: status})
 		}
-		maybeDown = append(maybeDown, pending{inst: inst, status: status})
 	}
 
 	// Second pass: re-probe the misses. A session that reappears on any
@@ -182,29 +180,47 @@ func (d *Detector) confirmProbes() int {
 	return d.ConfirmProbes
 }
 
+// exists probes one session's liveness.
+//
+// A missing probe reports ALIVE, not dead. Every default in this package leans
+// toward doing nothing: a Detector built without a probe (a future caller
+// constructing Detector{} directly) would otherwise classify the entire fleet as
+// down, and a `--yes` sweep on that assessment would restart every live session
+// on the host. Failing this way makes such a bug a no-op instead.
 func (d *Detector) exists(inst *session.Instance) bool {
 	if d.TmuxExists == nil {
-		return false
+		return true
 	}
 	return d.TmuxExists(TmuxName(inst), inst.TmuxSocketName)
 }
 
-// skipReason returns a non-empty explanation when a session must not be
-// recovered, or "" when it is eligible for a liveness probe.
-func (d *Detector) skipReason(inst *session.Instance) string {
+// Classify reports one session's recovery-oriented health, plus a human-readable
+// reason when the verdict is HealthSkipped.
+//
+// It performs at most ONE liveness probe, so a HealthDown verdict from Classify
+// alone is not yet proof of death — Assess is the entry point that applies the
+// confirming re-probe (see DefaultConfirmProbes) before a session becomes a
+// recovery candidate.
+func (d *Detector) Classify(inst *session.Instance) (Health, string) {
+	if inst == nil {
+		return HealthSkipped, "no instance"
+	}
 	if !inst.ArchivedAt.IsZero() {
-		return "archived"
+		return HealthSkipped, "archived"
 	}
 	if d.Group != "" && !inGroup(inst.GroupPath, d.Group) {
-		return "outside --group"
+		return HealthSkipped, "outside --group"
 	}
 	if !d.shouldBeAlive(inst.Status) {
-		return "status " + string(inst.Status)
+		return HealthSkipped, "status " + string(inst.Status)
 	}
 	if !inst.CanRestart() {
-		return "not restartable"
+		return HealthSkipped, "not restartable"
 	}
-	return ""
+	if d.exists(inst) {
+		return HealthAlive, ""
+	}
+	return HealthDown, ""
 }
 
 // shouldBeAlive reports whether a status is a claim that the session's process

--- a/internal/fleet/detect_test.go
+++ b/internal/fleet/detect_test.go
@@ -1,0 +1,303 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// testInstance builds a minimal Instance. No tmux session is attached, so
+// TmuxName falls back to the title — which is what the probe stub keys on.
+func testInstance(title string, st session.Status) *session.Instance {
+	return &session.Instance{
+		ID:        "id-" + title,
+		Title:     title,
+		Status:    st,
+		Tool:      "claude",
+		GroupPath: "root",
+		CreatedAt: time.Unix(1000, 0),
+	}
+}
+
+// aliveOnly returns a probe stub reporting only the named sessions as present.
+func aliveOnly(names ...string) func(string, string) bool {
+	set := map[string]bool{}
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(name, _ string) bool { return set[name] }
+}
+
+func newTestDetector(exists func(string, string) bool) *Detector {
+	return &Detector{
+		TmuxExists:    exists,
+		Sleep:         func(time.Duration) {},
+		ConfirmProbes: 1,
+		MinDead:       DefaultMinDead,
+		DeadFraction:  DefaultDeadFraction,
+	}
+}
+
+func candidateTitles(as Assessment) []string {
+	titles := make([]string, 0, len(as.Candidates))
+	for _, c := range as.Candidates {
+		titles = append(titles, c.Title())
+	}
+	return titles
+}
+
+func TestAssessClassifiesByStatusAndTmuxPresence(t *testing.T) {
+	instances := []*session.Instance{
+		testInstance("live-running", session.StatusRunning),
+		testInstance("dead-running", session.StatusRunning),
+		testInstance("dead-error", session.StatusError),
+		testInstance("dead-waiting", session.StatusWaiting),
+		testInstance("dead-starting", session.StatusStarting),
+		testInstance("stopped", session.StatusStopped),
+		testInstance("queued", session.StatusQueued),
+		testInstance("idle", session.StatusIdle),
+	}
+	archived := testInstance("archived", session.StatusError)
+	archived.ArchivedAt = time.Unix(2000, 0)
+	instances = append(instances, archived)
+
+	d := newTestDetector(aliveOnly("live-running"))
+	as := d.Assess(instances)
+
+	if as.Total != len(instances) {
+		t.Fatalf("Total = %d, want %d", as.Total, len(instances))
+	}
+	if as.Alive != 1 {
+		t.Errorf("Alive = %d, want 1", as.Alive)
+	}
+	// stopped + queued + idle + archived are all intentionally-not-running.
+	if as.Skipped != 4 {
+		t.Errorf("Skipped = %d, want 4", as.Skipped)
+	}
+	want := []string{"dead-error", "dead-running", "dead-starting", "dead-waiting"}
+	got := candidateTitles(as)
+	if len(got) != len(want) {
+		t.Fatalf("candidates = %v, want %v", got, want)
+	}
+	set := map[string]bool{}
+	for _, g := range got {
+		set[g] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			t.Errorf("missing candidate %q (got %v)", w, got)
+		}
+	}
+}
+
+// A dead pane is reported as error/stopped, while `idle` is ALSO the status of a
+// session that was added but never started. Recovering idle by default would
+// launch sessions the operator never launched, so it must be opt-in.
+func TestAssessIdleIsOptIn(t *testing.T) {
+	instances := []*session.Instance{testInstance("idle", session.StatusIdle)}
+
+	d := newTestDetector(aliveOnly())
+	if as := d.Assess(instances); as.Down != 0 {
+		t.Fatalf("Down = %d with idle excluded, want 0", as.Down)
+	}
+
+	d.IncludeIdle = true
+	as := d.Assess(instances)
+	if as.Down != 1 {
+		t.Fatalf("Down = %d with --include-idle, want 1", as.Down)
+	}
+}
+
+// The destructive direction of this tool is restarting sessions that are ALIVE.
+// A single has-session miss is not proof of death (a tmux server that just
+// restarted answers "no such session" for a moment), so a session that
+// reappears on a confirming probe must be counted alive, never restarted.
+func TestAssessRequiresConfirmingProbes(t *testing.T) {
+	flaky := testInstance("flaky", session.StatusRunning)
+	reallyDead := testInstance("really-dead", session.StatusError)
+
+	calls := map[string]int{}
+	d := newTestDetector(func(name, _ string) bool {
+		calls[name]++
+		// "flaky" misses the first probe and answers on the second.
+		return name == "flaky" && calls[name] >= 2
+	})
+	d.ConfirmProbes = 2
+	slept := 0
+	d.ConfirmDelay = 10 * time.Millisecond
+	d.Sleep = func(time.Duration) { slept++ }
+
+	as := d.Assess([]*session.Instance{flaky, reallyDead})
+
+	if got := candidateTitles(as); len(got) != 1 || got[0] != "really-dead" {
+		t.Fatalf("candidates = %v, want [really-dead]", got)
+	}
+	if as.Alive != 1 {
+		t.Errorf("Alive = %d, want 1 (the flaky session recovered on probe 2)", as.Alive)
+	}
+	if slept != 1 {
+		t.Errorf("confirm delay slept %d times, want 1", slept)
+	}
+	if as.Probes != 2 {
+		t.Errorf("Probes = %d, want 2", as.Probes)
+	}
+}
+
+func TestAssessSingleProbeSkipsConfirmRound(t *testing.T) {
+	d := newTestDetector(aliveOnly())
+	d.ConfirmProbes = 1
+	d.Sleep = func(time.Duration) { t.Fatal("single-probe scan must not sleep") }
+
+	as := d.Assess([]*session.Instance{testInstance("dead", session.StatusError)})
+	if as.Down != 1 {
+		t.Fatalf("Down = %d, want 1", as.Down)
+	}
+}
+
+func TestMassDeathThresholds(t *testing.T) {
+	mk := func(n int, st session.Status, prefix string) []*session.Instance {
+		out := make([]*session.Instance, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, testInstance(prefix+string(rune('a'+i)), st))
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		dead     int
+		alive    int
+		minDead  int
+		fraction float64
+		want     bool
+	}{
+		{name: "whole fleet gone", dead: 10, alive: 0, want: true},
+		{name: "one crash is not a fleet death", dead: 1, alive: 9, want: false},
+		{name: "below absolute floor even at 100%", dead: 2, alive: 0, want: false},
+		{name: "at floor and at fraction", dead: 3, alive: 3, want: true},
+		{name: "above floor but below fraction", dead: 4, alive: 40, want: false},
+		{name: "custom lower floor trips", dead: 2, alive: 0, minDead: 2, want: true},
+		{name: "custom fraction trips", dead: 4, alive: 40, minDead: 3, fraction: 0.05, want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deadInsts := mk(tc.dead, session.StatusError, "dead-")
+			aliveInsts := mk(tc.alive, session.StatusRunning, "alive-")
+			aliveNames := make([]string, 0, len(aliveInsts))
+			for _, a := range aliveInsts {
+				aliveNames = append(aliveNames, a.Title)
+			}
+			d := newTestDetector(aliveOnly(aliveNames...))
+			if tc.minDead != 0 {
+				d.MinDead = tc.minDead
+			}
+			if tc.fraction != 0 {
+				d.DeadFraction = tc.fraction
+			}
+			as := d.Assess(append(deadInsts, aliveInsts...))
+			if as.MassDeath != tc.want {
+				t.Fatalf("MassDeath = %t (down=%d alive=%d), want %t", as.MassDeath, as.Down, as.Alive, tc.want)
+			}
+		})
+	}
+}
+
+func TestAssessNoSessionsIsNotMassDeath(t *testing.T) {
+	d := newTestDetector(aliveOnly())
+	as := d.Assess(nil)
+	if as.MassDeath || as.Down != 0 || as.Total != 0 {
+		t.Fatalf("empty fleet assessed as %+v", as)
+	}
+}
+
+func TestAssessGroupFilter(t *testing.T) {
+	inGroupInst := testInstance("in-group", session.StatusError)
+	inGroupInst.GroupPath = "agent-deck/workers"
+	sameGroup := testInstance("same-group", session.StatusError)
+	sameGroup.GroupPath = "agent-deck"
+	other := testInstance("other", session.StatusError)
+	other.GroupPath = "other-project"
+
+	d := newTestDetector(aliveOnly())
+	d.Group = "agent-deck"
+	as := d.Assess([]*session.Instance{inGroupInst, sameGroup, other})
+
+	if as.Down != 2 {
+		t.Fatalf("Down = %d, want 2 (group + descendants)", as.Down)
+	}
+	if as.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", as.Skipped)
+	}
+}
+
+func TestAssessOrdersCandidatesOldestFirst(t *testing.T) {
+	newer := testInstance("newer", session.StatusError)
+	newer.CreatedAt = time.Unix(3000, 0)
+	older := testInstance("older", session.StatusError)
+	older.CreatedAt = time.Unix(1000, 0)
+	tieA := testInstance("a-tie", session.StatusError)
+	tieA.CreatedAt = time.Unix(2000, 0)
+	tieB := testInstance("b-tie", session.StatusError)
+	tieB.CreatedAt = time.Unix(2000, 0)
+
+	d := newTestDetector(aliveOnly())
+	as := d.Assess([]*session.Instance{newer, tieB, older, tieA})
+
+	want := []string{"older", "a-tie", "b-tie", "newer"}
+	got := candidateTitles(as)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAssessNeverMutatesInstances(t *testing.T) {
+	inst := testInstance("dead", session.StatusError)
+	beforeStatus, beforeTitle := inst.Status, inst.Title
+	d := newTestDetector(aliveOnly())
+	d.Assess([]*session.Instance{inst})
+	if inst.Status != beforeStatus || inst.Title != beforeTitle {
+		t.Fatalf("Assess mutated the instance: status %q -> %q, title %q -> %q",
+			beforeStatus, inst.Status, beforeTitle, inst.Title)
+	}
+}
+
+func TestAssessTolerantOfNilEntries(t *testing.T) {
+	d := newTestDetector(aliveOnly())
+	as := d.Assess([]*session.Instance{nil, testInstance("dead", session.StatusError), nil})
+	if as.Total != 1 || as.Down != 1 {
+		t.Fatalf("assessment = %+v, want total=1 down=1", as)
+	}
+}
+
+func TestInGroup(t *testing.T) {
+	tests := []struct {
+		path, want string
+		ok         bool
+	}{
+		{path: "agent-deck", want: "agent-deck", ok: true},
+		{path: "agent-deck/workers", want: "agent-deck", ok: true},
+		{path: "agent-deckery", want: "agent-deck", ok: false},
+		{path: "other-project", want: "agent-deck", ok: false},
+		{path: "anything", want: "", ok: true},
+		{path: "/agent-deck/", want: "agent-deck", ok: true},
+	}
+	for _, tc := range tests {
+		if got := inGroup(tc.path, tc.want); got != tc.ok {
+			t.Errorf("inGroup(%q, %q) = %t, want %t", tc.path, tc.want, got, tc.ok)
+		}
+	}
+}
+
+func TestTmuxNameFallsBackToTitle(t *testing.T) {
+	if got := TmuxName(nil); got != "" {
+		t.Errorf("TmuxName(nil) = %q, want empty", got)
+	}
+	inst := testInstance("my-session", session.StatusError)
+	if got := TmuxName(inst); got != "my-session" {
+		t.Errorf("TmuxName = %q, want the title fallback", got)
+	}
+}

--- a/internal/fleet/detect_test.go
+++ b/internal/fleet/detect_test.go
@@ -204,6 +204,23 @@ func TestMassDeathThresholds(t *testing.T) {
 	}
 }
 
+// FAIL-SAFE DEFAULT. A Detector with no liveness probe must report every
+// session ALIVE, so a misconstructed detector produces a no-op assessment
+// instead of a plan to restart the entire live fleet.
+func TestAssessWithoutProbeTreatsEverythingAsAlive(t *testing.T) {
+	d := &Detector{ConfirmProbes: 1}
+	as := d.Assess([]*session.Instance{
+		testInstance("one", session.StatusRunning),
+		testInstance("two", session.StatusError),
+	})
+	if as.Down != 0 || as.MassDeath {
+		t.Fatalf("assessment = %+v, want nothing down", as)
+	}
+	if as.Alive != 2 {
+		t.Errorf("Alive = %d, want 2", as.Alive)
+	}
+}
+
 func TestAssessNoSessionsIsNotMassDeath(t *testing.T) {
 	d := newTestDetector(aliveOnly())
 	as := d.Assess(nil)
@@ -270,6 +287,43 @@ func TestAssessTolerantOfNilEntries(t *testing.T) {
 	as := d.Assess([]*session.Instance{nil, testInstance("dead", session.StatusError), nil})
 	if as.Total != 1 || as.Down != 1 {
 		t.Fatalf("assessment = %+v, want total=1 down=1", as)
+	}
+}
+
+func TestClassifyReportsWhySessionsAreOutOfScope(t *testing.T) {
+	archived := testInstance("archived", session.StatusError)
+	archived.ArchivedAt = time.Unix(2000, 0)
+	outside := testInstance("outside", session.StatusError)
+	outside.GroupPath = "elsewhere"
+
+	tests := []struct {
+		name       string
+		inst       *session.Instance
+		group      string
+		wantHealth Health
+		wantReason string
+	}{
+		{name: "nil", inst: nil, wantHealth: HealthSkipped, wantReason: "no instance"},
+		{name: "archived", inst: archived, wantHealth: HealthSkipped, wantReason: "archived"},
+		{name: "outside group", inst: outside, group: "agent-deck", wantHealth: HealthSkipped, wantReason: "outside --group"},
+		{name: "stopped", inst: testInstance("stopped", session.StatusStopped), wantHealth: HealthSkipped, wantReason: "status stopped"},
+		{name: "queued", inst: testInstance("queued", session.StatusQueued), wantHealth: HealthSkipped, wantReason: "status queued"},
+		{name: "down", inst: testInstance("down", session.StatusError), wantHealth: HealthDown},
+		{name: "alive", inst: testInstance("live", session.StatusRunning), wantHealth: HealthAlive},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDetector(aliveOnly("live"))
+			d.Group = tc.group
+			health, reason := d.Classify(tc.inst)
+			if health != tc.wantHealth {
+				t.Fatalf("health = %s, want %s", health, tc.wantHealth)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
 	}
 }
 

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -152,4 +152,21 @@ const (
 	// halt the sweep. Two rather than one so a single stale-credential session
 	// cannot stop a recovery that is otherwise working.
 	DefaultAuthHaltAfter = 2
+
+	// DefaultMaxDeadBoots is how many CONSECUTIVE boots may come up with their
+	// pane already gone before the sweep halts.
+	//
+	// This is the brake for the failure actually observed on 2026-07-26: a
+	// session whose credential is dead does not sit in the pane showing a
+	// banner, it EXITS — the agent quits on the 401 and tmux tears the pane
+	// down with it. Such a boot produces no auth substate for the auth breaker
+	// to see and no restart error for the failure brake to count, so without
+	// this brake a credential outage would let the sweep restart all 65
+	// sessions, each burning a full verify timeout — the exact amplification
+	// this command exists to prevent.
+	//
+	// Only pane-is-gone boots count. A pane that is up but still `starting`
+	// when the timeout expires is a slow boot, not a dead one, and must not
+	// stop a recovery that is merely taking its time.
+	DefaultMaxDeadBoots = 3
 )

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,0 +1,157 @@
+// Package fleet implements first-class recovery from a fleet-wide session
+// death: the failure mode where every managed tmux pane on the host dies at
+// once and agent-deck is left holding a registry full of sessions whose
+// processes are gone.
+//
+// # Why this exists
+//
+// Twice on 2026-07-26 the maintainer's ~65-session fleet died at once (a
+// process reaper matching tmux by argv took down the shared server; separately
+// an auth-token cascade made sessions exit on their own). Both times recovery
+// was a hand-rolled shell sweep: list the error sessions, restart them one at a
+// time with a few seconds of spacing so the OAuth refresh-token rotation race
+// does not fork the token, eyeball each pane, keep going. That sweep is the
+// thing this package productizes, so the next fleet death is one command
+// instead of an improvised loop under pressure.
+//
+// The two halves
+//
+//   - Detector (detect.go) answers "did the fleet die?" — it finds sessions the
+//     registry believes are alive whose tmux session is gone, and reports
+//     whether the shape is a mass death or a one-off.
+//   - Recoverer (recover.go) restarts those sessions SEQUENTIALLY with spacing
+//     plus jitter, verifies each boot before starting the next, and halts the
+//     sweep when an auth circuit breaker says further boots would make things
+//     worse.
+//
+// Safety posture (2026-06-04 data-loss lessons)
+//
+//   - Nothing in this package deletes or sweeps rows. The persist seam takes
+//     ONLY the instances a boot actually mutated, and the CLI wires it to a
+//     targeted per-row write (no DELETE-NOT-IN, no whole-table rewrite from a
+//     stale snapshot).
+//   - Recovery is opt-in at the CLI: `fleet recover` plans without acting
+//     unless the operator passes --yes, and DryRun is a first-class field here
+//     so the planning path runs the exact same code as the acting path.
+//   - Every side effect (restart, verify, sleep, jitter, clock, persist) is an
+//     injectable function field, so the unit tests exercise the real sequencing
+//     logic without spawning a single tmux server.
+package fleet
+
+import (
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Health is a recovery-oriented liveness classification for one session.
+type Health int
+
+const (
+	// HealthAlive means the session's tmux session is present. Nothing to do:
+	// a live pane whose control pipe is broken is `session revive`'s job, not
+	// ours (see internal/session/reviver.go).
+	HealthAlive Health = iota
+
+	// HealthDown means the registry believes the session should be alive
+	// (status running/waiting/starting/error) but its tmux session is gone.
+	// This is the fleet-death signature and the only class we recover.
+	HealthDown
+
+	// HealthSkipped means the session is legitimately not running — stopped or
+	// queued by the operator, or archived. Recovery never touches these: a
+	// mass restart that also "recovers" every session the user deliberately
+	// stopped would be a footgun, not a fix.
+	HealthSkipped
+)
+
+func (h Health) String() string {
+	switch h {
+	case HealthAlive:
+		return "alive"
+	case HealthDown:
+		return "down"
+	case HealthSkipped:
+		return "skipped"
+	}
+	return "unknown"
+}
+
+// Candidate is one classified session.
+type Candidate struct {
+	Instance *session.Instance
+	Health   Health
+	// Status is the registry status at classification time, kept as a string
+	// so summaries and JSON payloads do not have to re-read the (mutating)
+	// instance after a restart.
+	Status string
+	// Reason explains a HealthSkipped classification (empty otherwise).
+	Reason string
+}
+
+// ID returns the candidate's instance id ("" when the instance is nil).
+func (c Candidate) ID() string {
+	if c.Instance == nil {
+		return ""
+	}
+	return c.Instance.ID
+}
+
+// Title returns the candidate's title ("" when the instance is nil).
+func (c Candidate) Title() string {
+	if c.Instance == nil {
+		return ""
+	}
+	return c.Instance.Title
+}
+
+// Defaults for the detector and the recoverer. Kept in one block so a reviewer
+// can retune the whole tool without hunting through the logic.
+const (
+	// DefaultConfirmProbes is how many independent tmux probes must agree that
+	// a session is gone before it becomes a recovery candidate. Two, because a
+	// single has-session miss is NOT proof of death: right after a tmux server
+	// restart an existing session can briefly probe as absent (the race called
+	// out in reviver.go's TODO(revive-liveness)), and acting on one miss would
+	// restart sessions that are in fact alive — the destructive direction of
+	// this tool's error budget.
+	DefaultConfirmProbes = 2
+
+	// DefaultConfirmDelay separates those probes.
+	DefaultConfirmDelay = 750 * time.Millisecond
+
+	// DefaultMinDead is the smallest number of down sessions that can be called
+	// a mass death rather than an isolated crash.
+	DefaultMinDead = 3
+
+	// DefaultDeadFraction is the share of should-be-alive sessions that must be
+	// down for the shape to read as fleet-wide.
+	DefaultDeadFraction = 0.5
+
+	// DefaultSpacing is the gap between two consecutive boots. ~5s is what the
+	// hand-rolled 2026-07-26 sweeps used: enough that N Claude processes do not
+	// all refresh the single rotating OAuth refresh token inside one window
+	// (the fork-the-token race that produces the 401 cascade).
+	DefaultSpacing = 5 * time.Second
+
+	// DefaultJitter spreads each gap by ±20% so a recovery never lands on a
+	// perfectly periodic cadence that could resonate with a remote rate limit.
+	DefaultJitter = 0.2
+
+	// DefaultVerifyTimeout bounds how long one boot may take to prove itself.
+	DefaultVerifyTimeout = 30 * time.Second
+
+	// DefaultVerifyPoll is the verification poll interval.
+	DefaultVerifyPoll = 500 * time.Millisecond
+
+	// DefaultMaxFailures is how many CONSECUTIVE failed boots halt the sweep.
+	// A fleet where the first three restarts all fail is a fleet with a common
+	// cause (tmux wedged, disk full, binary missing); grinding through the
+	// remaining 60 just multiplies the damage.
+	DefaultMaxFailures = 3
+
+	// DefaultAuthHaltAfter is how many boots showing an auth failure banner
+	// halt the sweep. Two rather than one so a single stale-credential session
+	// cannot stop a recovery that is otherwise working.
+	DefaultAuthHaltAfter = 2
+)

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -85,8 +85,6 @@ type Candidate struct {
 	// so summaries and JSON payloads do not have to re-read the (mutating)
 	// instance after a restart.
 	Status string
-	// Reason explains a HealthSkipped classification (empty otherwise).
-	Reason string
 }
 
 // ID returns the candidate's instance id ("" when the instance is nil).

--- a/internal/fleet/recover.go
+++ b/internal/fleet/recover.go
@@ -117,6 +117,15 @@ type Recoverer struct {
 	// MaxFailures halts the sweep after this many CONSECUTIVE failed restarts
 	// (<=0 uses DefaultMaxFailures).
 	MaxFailures int
+	// MaxDeadBoots halts the sweep after this many CONSECUTIVE boots whose pane
+	// was gone again by the time verification looked — the signature of sessions
+	// exiting immediately on boot (see DefaultMaxDeadBoots).
+	//
+	// Zero means "use the safe default"; a NEGATIVE value is the explicit
+	// opt-out. Zero must not mean "off": a partially-configured Recoverer that
+	// silently lost this brake would restart a whole fleet against a dead
+	// credential, which is the outage itself.
+	MaxDeadBoots int
 	// AuthGate halts the sweep when further boots would deepen an auth
 	// cascade. nil means no auth gating.
 	AuthGate AuthGate
@@ -134,14 +143,15 @@ func NewRecoverer() *Recoverer {
 		StillDown: func(inst *session.Instance) bool {
 			return !tmux.HasSessionOnSocket(inst.TmuxSocketName, TmuxName(inst))
 		},
-		Verify:      v.Verify,
-		Sleep:       time.Sleep,
-		Rand:        defaultJitterSource,
-		Log:         slog.Default(),
-		Spacing:     DefaultSpacing,
-		Jitter:      DefaultJitter,
-		MaxFailures: DefaultMaxFailures,
-		AuthGate:    &SubstateAuthGate{HaltAfter: DefaultAuthHaltAfter},
+		Verify:       v.Verify,
+		Sleep:        time.Sleep,
+		Rand:         defaultJitterSource,
+		Log:          slog.Default(),
+		Spacing:      DefaultSpacing,
+		Jitter:       DefaultJitter,
+		MaxFailures:  DefaultMaxFailures,
+		MaxDeadBoots: DefaultMaxDeadBoots,
+		AuthGate:     &SubstateAuthGate{HaltAfter: DefaultAuthHaltAfter},
 	}
 }
 
@@ -157,8 +167,11 @@ func NewRecoverer() *Recoverer {
 //  3. Spacing (+ jitter) is slept BEFORE every boot except the first.
 //  4. Every candidate is re-probed immediately before its restart, so a session
 //     that recovered on its own during the sweep is never killed by it.
-//  5. Each boot is verified before the next one starts. Verification failure
-//     does not abort the sweep; a run of failed RESTARTS does (MaxFailures).
+//  5. Each boot is verified before the next one starts. A single verification
+//     failure does not abort the sweep; a run of failed RESTARTS does
+//     (MaxFailures), and so does a run of boots that came up with the pane
+//     already gone (MaxDeadBoots) — sessions exiting on boot is how a
+//     credential outage actually presents.
 //  6. Each mutated session is persisted immediately, individually.
 func (r *Recoverer) Recover(as Assessment) Summary {
 	sum := Summary{Assessment: as, DryRun: r.DryRun}
@@ -170,6 +183,7 @@ func (r *Recoverer) Recover(as Assessment) Summary {
 	}
 
 	consecutiveFailures := 0
+	consecutiveDeadBoots := 0
 	attempts := 0
 
 	for i, c := range as.Candidates {
@@ -283,7 +297,10 @@ func (r *Recoverer) Recover(as Assessment) Summary {
 		if rep.Booted() {
 			res.Outcome = OutcomeRecovered
 			sum.Recovered++
+			// A session that booted and reached a live-agent state proves the
+			// host and the credential still work, so both runs are broken.
 			consecutiveFailures = 0
+			consecutiveDeadBoots = 0
 			r.logf("fleet_recover_booted", c, slog.Duration("waited", rep.Elapsed))
 		} else {
 			res.Outcome = OutcomeUnverified
@@ -296,6 +313,25 @@ func (r *Recoverer) Recover(as Assessment) Summary {
 				slog.Bool("pane_alive", rep.PaneAlive),
 				slog.String("status", rep.Status),
 				slog.String("substate", rep.Substate))
+
+			// Pane gone after a successful restart = the session started and
+			// exited. One is a crash; a run of them is systemic (dead
+			// credential, wedged tmux, missing binary) and every further boot
+			// makes it worse — this is the brake the 2026-07-26 auth cascade
+			// needed, since an exiting session leaves no substate for the auth
+			// breaker to read.
+			if !rep.PaneAlive {
+				consecutiveDeadBoots++
+				if limit := r.maxDeadBoots(); limit > 0 && consecutiveDeadBoots >= limit {
+					sum.Halted = true
+					sum.HaltReason = fmt.Sprintf(
+						"%d consecutive sessions restarted and then died immediately (pane gone before verification) — "+
+							"that is a host- or credential-level fault, and each further boot deepens it; "+
+							"attach one of them by hand, re-authenticate if it shows a 401, then re-run",
+						consecutiveDeadBoots)
+					r.logHalt(sum.HaltReason)
+				}
+			}
 		}
 
 		// Verification may have refined the status (starting → running/waiting);
@@ -394,6 +430,16 @@ func (r *Recoverer) maxFailures() int {
 		return DefaultMaxFailures
 	}
 	return r.MaxFailures
+}
+
+// maxDeadBoots resolves the dead-boot brake: unset (0) takes the default, a
+// negative value is the explicit opt-out, and 0 is never "off" (see the field
+// doc). A non-positive return disables the brake.
+func (r *Recoverer) maxDeadBoots() int {
+	if r.MaxDeadBoots == 0 {
+		return DefaultMaxDeadBoots
+	}
+	return r.MaxDeadBoots
 }
 
 // defaultJitterSource returns a fraction in [0,1) derived from the wall clock's

--- a/internal/fleet/recover.go
+++ b/internal/fleet/recover.go
@@ -1,0 +1,432 @@
+package fleet
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Outcome is what happened to one candidate during a sweep.
+type Outcome string
+
+const (
+	// OutcomeRecovered — restarted and verified booted.
+	OutcomeRecovered Outcome = "recovered"
+	// OutcomeUnverified — the restart call succeeded but the session did not
+	// prove it booted within the verify timeout. Deliberately distinct from
+	// "recovered": the sweep continues, but the summary never claims a session
+	// is back when it only claims a pane exists.
+	OutcomeUnverified Outcome = "unverified"
+	// OutcomeFailed — the restart call itself returned an error.
+	OutcomeFailed Outcome = "failed"
+	// OutcomeSkipped — never attempted (halt, --limit, or dry run).
+	OutcomeSkipped Outcome = "skipped"
+	// OutcomePlanned — dry run: this is what a real sweep would restart.
+	OutcomePlanned Outcome = "planned"
+)
+
+// Result is the per-session record of a sweep.
+type Result struct {
+	ID      string
+	Title   string
+	Status  string // registry status before the restart
+	Outcome Outcome
+	// Err is the restart error for OutcomeFailed (nil otherwise).
+	Err error
+	// Report is the verification reading (zero value for skipped/planned).
+	Report VerifyReport
+	// WaitedBefore is the spacing actually slept before this boot.
+	WaitedBefore time.Duration
+	// Reason explains a skip.
+	Reason string
+}
+
+// Summary is the whole sweep, suitable for both the human one-liner and the
+// --json payload.
+type Summary struct {
+	Assessment  Assessment
+	DryRun      bool
+	Attempted   int
+	Recovered   int
+	Unverified  int
+	Failed      int
+	Skipped     int
+	Halted      bool
+	HaltReason  string
+	Results     []Result
+	TotalWaited time.Duration
+}
+
+// Format returns the stable one-line summary. Key order and spelling are a
+// contract — the CLI tests assert on this substring.
+func (s Summary) Format() string {
+	base := fmt.Sprintf("down=%d attempted=%d recovered=%d unverified=%d failed=%d skipped=%d",
+		s.Assessment.Down, s.Attempted, s.Recovered, s.Unverified, s.Failed, s.Skipped)
+	if s.DryRun {
+		return "dry-run " + base
+	}
+	if s.Halted {
+		return base + " halted=true"
+	}
+	return base
+}
+
+// Recoverer restarts down sessions one at a time, verifying each before moving
+// on. Every side effect is an injectable field; see the package doc for why.
+type Recoverer struct {
+	// Restart performs the actual restart of one session.
+	Restart func(*session.Instance) error
+	// StillDown re-probes a candidate immediately before its restart. A sweep
+	// over 65 sessions runs for minutes, so the assessment is stale by the time
+	// the last candidates come up: the operator (or the TUI's own recovery) may
+	// have brought a session back in the meantime, and restarting it then would
+	// KILL a live session — the one genuinely destructive thing this command
+	// could do. nil disables the re-check.
+	StillDown func(*session.Instance) bool
+	// Verify proves (or fails to prove) that a restarted session booted.
+	Verify func(*session.Instance) VerifyReport
+	// Persist durably records the sessions a boot mutated. It is called with a
+	// ONE-element slice after each attempt so a sweep interrupted at session 40
+	// of 65 leaves the first 39 persisted. Wire it to a targeted, sweep-free
+	// write (see session.Storage.PersistRecoveredInstances) — never to a
+	// whole-table save from a stale snapshot (2026-06-04).
+	Persist func([]*session.Instance) error
+	// Progress, when set, is called before each attempt (1-based index) so the
+	// CLI can stream a line per session during a multi-minute sweep.
+	Progress func(index, total int, c Candidate)
+	// Sleep implements spacing.
+	Sleep func(time.Duration)
+	// Rand returns a value in [0,1) for jitter (see defaultJitterSource).
+	Rand func() float64
+	Log  *slog.Logger
+
+	// Spacing is the base gap between consecutive boots. <=0 means "unset" and
+	// falls back to DefaultSpacing — spacing is the safety property of this
+	// command, so an unset field must never silently mean "no spacing".
+	Spacing time.Duration
+	// NoSpacing is the ONLY way to disable the gap: tests, and an operator who
+	// explicitly passed --spacing 0.
+	NoSpacing bool
+	// Jitter is the ± fraction of Spacing applied per gap (0 disables).
+	Jitter float64
+	// Limit caps how many sessions the sweep attempts (0 = all).
+	Limit int
+	// MaxFailures halts the sweep after this many CONSECUTIVE failed restarts
+	// (<=0 uses DefaultMaxFailures).
+	MaxFailures int
+	// AuthGate halts the sweep when further boots would deepen an auth
+	// cascade. nil means no auth gating.
+	AuthGate AuthGate
+	// DryRun plans without restarting anything.
+	DryRun bool
+}
+
+// NewRecoverer returns a Recoverer wired to real restarts, real verification,
+// and the built-in auth breaker. Persist is intentionally left nil: the caller
+// owns storage and must opt in.
+func NewRecoverer() *Recoverer {
+	v := NewVerifier()
+	return &Recoverer{
+		Restart: func(inst *session.Instance) error { return inst.Restart() },
+		StillDown: func(inst *session.Instance) bool {
+			return !tmux.HasSessionOnSocket(inst.TmuxSocketName, TmuxName(inst))
+		},
+		Verify:      v.Verify,
+		Sleep:       time.Sleep,
+		Rand:        defaultJitterSource,
+		Log:         slog.Default(),
+		Spacing:     DefaultSpacing,
+		Jitter:      DefaultJitter,
+		MaxFailures: DefaultMaxFailures,
+		AuthGate:    &SubstateAuthGate{HaltAfter: DefaultAuthHaltAfter},
+	}
+}
+
+// Recover runs the sweep over an assessment's candidates.
+//
+// Sequencing contract (this is the whole point of the command):
+//
+//  1. One session at a time, in assessment order. Never concurrent — the
+//     failure this recovers from is partly caused by too many agents booting
+//     at once.
+//  2. The auth gate is consulted BEFORE each boot; a closed circuit halts and
+//     marks every remaining candidate skipped rather than pretending it tried.
+//  3. Spacing (+ jitter) is slept BEFORE every boot except the first.
+//  4. Every candidate is re-probed immediately before its restart, so a session
+//     that recovered on its own during the sweep is never killed by it.
+//  5. Each boot is verified before the next one starts. Verification failure
+//     does not abort the sweep; a run of failed RESTARTS does (MaxFailures).
+//  6. Each mutated session is persisted immediately, individually.
+func (r *Recoverer) Recover(as Assessment) Summary {
+	sum := Summary{Assessment: as, DryRun: r.DryRun}
+
+	total := len(as.Candidates)
+	limit := total
+	if r.Limit > 0 && r.Limit < limit {
+		limit = r.Limit
+	}
+
+	consecutiveFailures := 0
+	attempts := 0
+
+	for i, c := range as.Candidates {
+		res := Result{ID: c.ID(), Title: c.Title(), Status: c.Status}
+
+		if sum.Halted {
+			res.Outcome = OutcomeSkipped
+			res.Reason = sum.HaltReason
+			sum.Skipped++
+			sum.Results = append(sum.Results, res)
+			continue
+		}
+		if attempts >= limit {
+			res.Outcome = OutcomeSkipped
+			res.Reason = fmt.Sprintf("beyond --limit %d", limit)
+			sum.Skipped++
+			sum.Results = append(sum.Results, res)
+			continue
+		}
+		if c.Instance == nil {
+			res.Outcome = OutcomeSkipped
+			res.Reason = "no instance"
+			sum.Skipped++
+			sum.Results = append(sum.Results, res)
+			continue
+		}
+
+		if r.AuthGate != nil {
+			if ok, reason := r.AuthGate.Allow(); !ok {
+				sum.Halted = true
+				sum.HaltReason = reason
+				res.Outcome = OutcomeSkipped
+				res.Reason = reason
+				sum.Skipped++
+				sum.Results = append(sum.Results, res)
+				r.logHalt(reason)
+				continue
+			}
+		}
+
+		if r.DryRun {
+			res.Outcome = OutcomePlanned
+			res.WaitedBefore = r.plannedWait(attempts)
+			sum.TotalWaited += res.WaitedBefore
+			attempts++
+			sum.Attempted++
+			sum.Results = append(sum.Results, res)
+			continue
+		}
+
+		if r.Progress != nil {
+			r.Progress(i+1, total, c)
+		}
+
+		wait := r.spacingFor(attempts)
+		if wait > 0 {
+			r.sleep(wait)
+		}
+		res.WaitedBefore = wait
+		sum.TotalWaited += wait
+
+		// Freshness re-check, AFTER the wait so the reading is as close to the
+		// restart as possible. A session that came back on its own is left
+		// alone: restarting a live session is the only way this command could
+		// destroy work. It does not consume an attempt — spacing paces BOOTS,
+		// and no boot happened here.
+		if r.StillDown != nil && !r.StillDown(c.Instance) {
+			res.Outcome = OutcomeSkipped
+			res.Reason = "came back on its own before the sweep reached it"
+			sum.Skipped++
+			sum.Results = append(sum.Results, res)
+			r.logf("fleet_recover_skipped_recovered_itself", c)
+			continue
+		}
+
+		attempts++
+		sum.Attempted++
+
+		if err := r.restart(c.Instance); err != nil {
+			res.Outcome = OutcomeFailed
+			res.Err = err
+			sum.Failed++
+			consecutiveFailures++
+			r.logf("fleet_recover_restart_failed", c, slog.String("error", err.Error()))
+			if r.AuthGate != nil {
+				r.AuthGate.Observe(c.Instance, VerifyReport{}, err)
+			}
+			sum.Results = append(sum.Results, res)
+			if consecutiveFailures >= r.maxFailures() {
+				sum.Halted = true
+				sum.HaltReason = fmt.Sprintf(
+					"%d consecutive restarts failed — halting instead of failing through the rest of the fleet (last error: %v)",
+					consecutiveFailures, err)
+				r.logHalt(sum.HaltReason)
+			}
+			continue
+		}
+
+		// The restart succeeded, so the session mutated (status, tmux name,
+		// tool session id). Persist before verifying: verification can take
+		// tens of seconds and an interrupt in that window must not lose the
+		// fact that this session was restarted.
+		r.persist(c.Instance)
+
+		rep := r.verify(c.Instance)
+		res.Report = rep
+		if r.AuthGate != nil {
+			r.AuthGate.Observe(c.Instance, rep, nil)
+		}
+
+		if rep.Booted() {
+			res.Outcome = OutcomeRecovered
+			sum.Recovered++
+			consecutiveFailures = 0
+			r.logf("fleet_recover_booted", c, slog.Duration("waited", rep.Elapsed))
+		} else {
+			res.Outcome = OutcomeUnverified
+			sum.Unverified++
+			// An unverified boot is not a restart failure, so it does not feed
+			// the consecutive-failure brake — but it does not reset it either:
+			// a fleet that keeps coming up unverified should still trip on the
+			// next real failure.
+			r.logf("fleet_recover_unverified", c,
+				slog.Bool("pane_alive", rep.PaneAlive),
+				slog.String("status", rep.Status),
+				slog.String("substate", rep.Substate))
+		}
+
+		// Verification may have refined the status (starting → running/waiting);
+		// persist again so storage reflects the settled state.
+		r.persist(c.Instance)
+
+		sum.Results = append(sum.Results, res)
+	}
+
+	return sum
+}
+
+func (r *Recoverer) restart(inst *session.Instance) error {
+	if r.Restart == nil {
+		return fmt.Errorf("recoverer has no Restart action configured")
+	}
+	return r.Restart(inst)
+}
+
+func (r *Recoverer) verify(inst *session.Instance) VerifyReport {
+	if r.Verify == nil {
+		return VerifyReport{}
+	}
+	return r.Verify(inst)
+}
+
+// persist is best-effort and never aborts a sweep: a storage hiccup on session
+// 3 must not strand the other 62 down sessions. The failure is logged loudly.
+func (r *Recoverer) persist(inst *session.Instance) {
+	if r.Persist == nil || inst == nil {
+		return
+	}
+	if err := r.Persist([]*session.Instance{inst}); err != nil && r.Log != nil {
+		r.Log.Warn("fleet_recover_persist_failed",
+			slog.String("instance_id", inst.ID),
+			slog.String("title", inst.Title),
+			slog.String("error", err.Error()))
+	}
+}
+
+// spacingFor returns the gap to sleep before the attempt with the given
+// zero-based index. The first boot never waits.
+func (r *Recoverer) spacingFor(attemptIndex int) time.Duration {
+	if attemptIndex == 0 {
+		return 0
+	}
+	base := r.baseSpacing()
+	if base <= 0 {
+		return 0
+	}
+	j := r.Jitter
+	if j <= 0 {
+		return base
+	}
+	if j > 1 {
+		j = 1
+	}
+	rnd := 0.5
+	if r.Rand != nil {
+		rnd = r.Rand()
+	}
+	// Map [0,1) → [-1,1) so the gap spreads symmetrically around base.
+	factor := 1 + j*(2*rnd-1)
+	out := time.Duration(float64(base) * factor)
+	if out < 0 {
+		return 0
+	}
+	return out
+}
+
+// plannedWait is the spacing a dry run REPORTS without sleeping. Jitter is
+// excluded so the plan is deterministic and reviewable.
+func (r *Recoverer) plannedWait(attemptIndex int) time.Duration {
+	if attemptIndex == 0 {
+		return 0
+	}
+	base := r.baseSpacing()
+	if base < 0 {
+		return 0
+	}
+	return base
+}
+
+func (r *Recoverer) baseSpacing() time.Duration {
+	if r.NoSpacing {
+		return 0
+	}
+	if r.Spacing <= 0 {
+		return DefaultSpacing
+	}
+	return r.Spacing
+}
+
+func (r *Recoverer) maxFailures() int {
+	if r.MaxFailures <= 0 {
+		return DefaultMaxFailures
+	}
+	return r.MaxFailures
+}
+
+// defaultJitterSource returns a fraction in [0,1) derived from the wall clock's
+// sub-millisecond digits.
+//
+// Deliberately not math/rand: the jitter here is scheduling noise — it spreads
+// boots so a recovery never lands on a perfectly periodic cadence — not a
+// security or statistical primitive, and this keeps a one-shot CLI from seeding
+// a global RNG (and keeps gosec's weak-RNG rule honest, since a weak RNG here is
+// the correct engineering choice rather than a suppressed warning).
+func defaultJitterSource() float64 {
+	return float64(time.Now().UnixNano()%1_000) / 1_000
+}
+
+func (r *Recoverer) sleep(d time.Duration) {
+	if r.Sleep != nil {
+		r.Sleep(d)
+		return
+	}
+	time.Sleep(d)
+}
+
+func (r *Recoverer) logf(msg string, c Candidate, attrs ...any) {
+	if r.Log == nil {
+		return
+	}
+	base := []any{slog.String("instance_id", c.ID()), slog.String("title", c.Title())}
+	r.Log.Info(msg, append(base, attrs...)...)
+}
+
+func (r *Recoverer) logHalt(reason string) {
+	if r.Log == nil {
+		return
+	}
+	r.Log.Warn("fleet_recover_halted", slog.String("reason", reason))
+}

--- a/internal/fleet/recover_test.go
+++ b/internal/fleet/recover_test.go
@@ -342,6 +342,110 @@ func TestRecoverAuthGateCanBeDisabled(t *testing.T) {
 	}
 }
 
+// The 2026-07-26 shape the substate gate CANNOT see: a session whose credential
+// is dead does not sit in the pane showing a 401 banner, it exits — so the
+// restart "succeeds", the pane is gone by verification time, there is no
+// substate, and neither the auth gate nor the failed-restart brake fires. The
+// dead-boot brake is what stops the sweep from burning the whole fleet.
+func TestRecoverHaltsAfterConsecutiveDeadBoots(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport {
+		// Restart returned nil, but the pane is gone again: the session started
+		// and immediately exited.
+		return VerifyReport{PaneAlive: false, Status: string(session.StatusError)}
+	})
+	rec.MaxDeadBoots = 3
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d", "e", "f"))
+
+	if len(r.restarts) != 3 {
+		t.Fatalf("restarts = %v, want the sweep to stop after 3 dead boots", r.restarts)
+	}
+	if !sum.Halted {
+		t.Fatal("Halted = false, want true")
+	}
+	if !strings.Contains(sum.HaltReason, "died immediately") {
+		t.Errorf("HaltReason = %q, want it to name the failure shape", sum.HaltReason)
+	}
+	if sum.Unverified != 3 || sum.Skipped != 3 || sum.Failed != 0 {
+		t.Errorf("summary = %+v, want 3 unverified / 3 skipped / 0 failed", sum)
+	}
+}
+
+// Zero is "use the default", not "off" — an under-configured Recoverer must
+// keep the brake that stops a fleet-wide amplification.
+func TestRecoverDeadBootBrakeDefaultsWhenUnset(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return VerifyReport{} })
+	rec.MaxDeadBoots = 0
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d", "e"))
+
+	if len(r.restarts) != DefaultMaxDeadBoots {
+		t.Fatalf("restarts = %v, want %d (the default brake)", r.restarts, DefaultMaxDeadBoots)
+	}
+	if !sum.Halted {
+		t.Fatal("Halted = false, want the default brake to trip")
+	}
+}
+
+// Turning the brake off has to be explicit and visible.
+func TestRecoverDeadBootBrakeCanBeDisabled(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return VerifyReport{} })
+	rec.MaxDeadBoots = -1
+	rec.AuthGate = nil
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d"))
+
+	if sum.Halted || len(r.restarts) != 4 {
+		t.Fatalf("with the brake disabled all sessions must be attempted: restarts=%v halted=%t", r.restarts, sum.Halted)
+	}
+}
+
+// A slow boot is not a dead one. A pane that is up but still `starting` when the
+// verify timeout expires must never stop a recovery that is merely taking its
+// time — otherwise a loaded host looks like a credential outage.
+func TestRecoverSlowBootsDoNotTripTheDeadBootBrake(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport {
+		return VerifyReport{PaneAlive: true, Status: string(session.StatusStarting), Elapsed: DefaultVerifyTimeout}
+	})
+	rec.MaxDeadBoots = 2
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d"))
+
+	if sum.Halted {
+		t.Fatalf("Halted = true (%s), want slow boots to be tolerated", sum.HaltReason)
+	}
+	if sum.Unverified != 4 || len(r.restarts) != 4 {
+		t.Errorf("summary = %+v restarts = %v, want all four attempted and unverified", sum, r.restarts)
+	}
+}
+
+// One session dying on boot is a crash, not a cascade: a verified boot in
+// between proves the host and the credential still work.
+func TestRecoverVerifiedBootResetsTheDeadBootRun(t *testing.T) {
+	r := &recorder{}
+	dead := map[string]bool{"a": true, "b": true, "d": true, "e": true}
+	rec := newTestRecoverer(r, func(inst *session.Instance) VerifyReport {
+		if dead[inst.Title] {
+			return VerifyReport{}
+		}
+		return bootedReport()
+	})
+	rec.MaxDeadBoots = 3
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d", "e"))
+
+	if sum.Halted {
+		t.Fatalf("Halted = true (%s), want the run broken by the boot that worked", sum.HaltReason)
+	}
+	if len(r.restarts) != 5 || sum.Recovered != 1 || sum.Unverified != 4 {
+		t.Errorf("summary = %+v restarts = %v, want all 5 attempted", sum, r.restarts)
+	}
+}
+
 // A model outage is not a credential problem: it clears on its own and must not
 // stop a recovery that is otherwise working.
 func TestSubstateAuthGateIgnoresModelUnavailable(t *testing.T) {

--- a/internal/fleet/recover_test.go
+++ b/internal/fleet/recover_test.go
@@ -1,0 +1,547 @@
+package fleet
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// recorder captures the full interleaving of a sweep's side effects, so the
+// tests can assert on SEQUENCING (the actual product requirement) and not just
+// on counts.
+type recorder struct {
+	events   []string
+	sleeps   []time.Duration
+	restarts []string
+	verified []string
+	persists [][]string
+}
+
+func (r *recorder) log(format string, args ...any) {
+	r.events = append(r.events, fmt.Sprintf(format, args...))
+}
+
+func (r *recorder) sleep(d time.Duration) {
+	r.sleeps = append(r.sleeps, d)
+	r.log("sleep %s", d)
+}
+
+func (r *recorder) persist(instances []*session.Instance) error {
+	titles := make([]string, 0, len(instances))
+	for _, inst := range instances {
+		titles = append(titles, inst.Title)
+	}
+	r.persists = append(r.persists, titles)
+	r.log("persist %s", strings.Join(titles, ","))
+	return nil
+}
+
+// downAssessment builds an Assessment as the Detector would, without probing.
+func downAssessment(titles ...string) Assessment {
+	as := Assessment{Total: len(titles), Down: len(titles), MassDeath: true}
+	for _, ti := range titles {
+		inst := testInstance(ti, session.StatusError)
+		as.Candidates = append(as.Candidates, Candidate{
+			Instance: inst,
+			Health:   HealthDown,
+			Status:   string(session.StatusError),
+		})
+	}
+	return as
+}
+
+// bootedReport is the verification result of a healthy boot.
+func bootedReport() VerifyReport {
+	return VerifyReport{PaneAlive: true, ToolStarted: true, Status: string(session.StatusRunning)}
+}
+
+// newTestRecoverer wires a recoverer to the recorder with deterministic timing.
+func newTestRecoverer(r *recorder, verify func(*session.Instance) VerifyReport) *Recoverer {
+	return &Recoverer{
+		Restart: func(inst *session.Instance) error {
+			r.restarts = append(r.restarts, inst.Title)
+			r.log("restart %s", inst.Title)
+			return nil
+		},
+		Verify: func(inst *session.Instance) VerifyReport {
+			r.verified = append(r.verified, inst.Title)
+			r.log("verify %s", inst.Title)
+			return verify(inst)
+		},
+		Persist:     r.persist,
+		Sleep:       r.sleep,
+		Rand:        func() float64 { return 0.5 }, // jitter-neutral
+		Spacing:     5 * time.Second,
+		Jitter:      0,
+		MaxFailures: DefaultMaxFailures,
+	}
+}
+
+// The core contract: one session at a time, spacing before every boot except
+// the first, and each boot fully verified BEFORE the next restart begins.
+func TestRecoverIsSequentialSpacedAndVerifiedPerSession(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+
+	sum := rec.Recover(downAssessment("one", "two", "three"))
+
+	want := []string{
+		"restart one", "persist one", "verify one", "persist one",
+		"sleep 5s",
+		"restart two", "persist two", "verify two", "persist two",
+		"sleep 5s",
+		"restart three", "persist three", "verify three", "persist three",
+	}
+	if got := strings.Join(r.events, "|"); got != strings.Join(want, "|") {
+		t.Fatalf("sweep interleaving:\n got %v\nwant %v", r.events, want)
+	}
+	if sum.Recovered != 3 || sum.Attempted != 3 {
+		t.Errorf("summary = %+v, want 3 attempted/3 recovered", sum)
+	}
+	if sum.Failed != 0 || sum.Unverified != 0 || sum.Halted {
+		t.Errorf("unexpected failure signals in %+v", sum)
+	}
+	if got := sum.Format(); got != "down=3 attempted=3 recovered=3 unverified=0 failed=0 skipped=0" {
+		t.Errorf("Format() = %q", got)
+	}
+}
+
+func TestRecoverFirstBootDoesNotWait(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+
+	rec.Recover(downAssessment("only"))
+
+	if len(r.sleeps) != 0 {
+		t.Fatalf("first boot slept %v, want no wait", r.sleeps)
+	}
+}
+
+// Spacing is the safety property of this command: an unset field must fall back
+// to the default, and only the explicit opt-out may disable it.
+func TestRecoverSpacingDefaultsAndOptOut(t *testing.T) {
+	t.Run("unset spacing uses the default", func(t *testing.T) {
+		r := &recorder{}
+		rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+		rec.Spacing = 0
+		rec.Recover(downAssessment("a", "b"))
+		if len(r.sleeps) != 1 || r.sleeps[0] != DefaultSpacing {
+			t.Fatalf("sleeps = %v, want one %s gap", r.sleeps, DefaultSpacing)
+		}
+	})
+
+	t.Run("explicit opt-out disables spacing", func(t *testing.T) {
+		r := &recorder{}
+		rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+		rec.NoSpacing = true
+		rec.Recover(downAssessment("a", "b"))
+		if len(r.sleeps) != 0 {
+			t.Fatalf("sleeps = %v, want none", r.sleeps)
+		}
+	})
+}
+
+func TestDefaultJitterSourceStaysInRange(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		if got := defaultJitterSource(); got < 0 || got >= 1 {
+			t.Fatalf("defaultJitterSource() = %v, want [0,1)", got)
+		}
+	}
+}
+
+func TestRecoverJitterStaysWithinBand(t *testing.T) {
+	base := 10 * time.Second
+	for _, rnd := range []float64{0, 0.25, 0.5, 0.75, 0.999} {
+		rec := &Recoverer{Spacing: base, Jitter: 0.2, Rand: func() float64 { return rnd }}
+		got := rec.spacingFor(1)
+		low, high := time.Duration(float64(base)*0.8), time.Duration(float64(base)*1.2)
+		if got < low || got > high {
+			t.Errorf("rand=%v gap=%s, want within [%s,%s]", rnd, got, low, high)
+		}
+	}
+
+	// Jitter is clamped so an absurd flag value can never produce a negative
+	// (or unbounded) gap.
+	rec := &Recoverer{Spacing: base, Jitter: 5, Rand: func() float64 { return 0 }}
+	if got := rec.spacingFor(1); got < 0 {
+		t.Errorf("clamped jitter produced negative gap %s", got)
+	}
+}
+
+// Dry run must exercise the same planning path while touching nothing.
+func TestRecoverDryRunPlansWithoutSideEffects(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport {
+		t.Fatal("dry run must not verify")
+		return VerifyReport{}
+	})
+	rec.Restart = func(*session.Instance) error {
+		t.Fatal("dry run must not restart")
+		return nil
+	}
+	rec.DryRun = true
+
+	sum := rec.Recover(downAssessment("a", "b", "c"))
+
+	if len(r.events) != 0 {
+		t.Fatalf("dry run produced side effects: %v", r.events)
+	}
+	if sum.Attempted != 3 || sum.Recovered != 0 {
+		t.Errorf("summary = %+v, want 3 planned and 0 recovered", sum)
+	}
+	for i, res := range sum.Results {
+		if res.Outcome != OutcomePlanned {
+			t.Errorf("result %d outcome = %q, want %q", i, res.Outcome, OutcomePlanned)
+		}
+	}
+	// The plan reports the (jitter-free) wait it would have used so the
+	// operator can estimate runtime.
+	if sum.Results[0].WaitedBefore != 0 || sum.Results[1].WaitedBefore != 5*time.Second {
+		t.Errorf("planned waits = %s, %s", sum.Results[0].WaitedBefore, sum.Results[1].WaitedBefore)
+	}
+	if want := 10 * time.Second; sum.TotalWaited != want {
+		t.Errorf("TotalWaited = %s, want %s", sum.TotalWaited, want)
+	}
+	if !strings.HasPrefix(sum.Format(), "dry-run ") {
+		t.Errorf("Format() = %q, want a dry-run prefix", sum.Format())
+	}
+}
+
+// A pane that exists is not a booted agent. An unverified boot must be reported
+// as its own outcome — never counted as a recovery.
+func TestRecoverReportsUnverifiedBootSeparately(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(inst *session.Instance) VerifyReport {
+		if inst.Title == "slow" {
+			return VerifyReport{PaneAlive: true, Status: string(session.StatusStarting), Elapsed: DefaultVerifyTimeout}
+		}
+		return bootedReport()
+	})
+
+	sum := rec.Recover(downAssessment("slow", "fine"))
+
+	if sum.Recovered != 1 || sum.Unverified != 1 {
+		t.Fatalf("summary = %+v, want 1 recovered / 1 unverified", sum)
+	}
+	if sum.Results[0].Outcome != OutcomeUnverified {
+		t.Errorf("outcome = %q, want %q", sum.Results[0].Outcome, OutcomeUnverified)
+	}
+	if sum.Halted {
+		t.Error("an unverified boot must not halt the sweep")
+	}
+	// The sweep continued to the next session.
+	if len(r.restarts) != 2 {
+		t.Errorf("restarts = %v, want both sessions attempted", r.restarts)
+	}
+}
+
+func TestRecoverHaltsAfterConsecutiveRestartFailures(t *testing.T) {
+	r := &recorder{}
+	boom := errors.New("tmux: no server running")
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	rec.Restart = func(inst *session.Instance) error {
+		r.restarts = append(r.restarts, inst.Title)
+		return boom
+	}
+	rec.MaxFailures = 3
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d", "e"))
+
+	if len(r.restarts) != 3 {
+		t.Fatalf("restarts = %v, want the sweep to stop after 3 failures", r.restarts)
+	}
+	if !sum.Halted {
+		t.Fatal("Halted = false, want true")
+	}
+	if sum.Failed != 3 || sum.Skipped != 2 {
+		t.Errorf("summary = %+v, want 3 failed / 2 skipped", sum)
+	}
+	if !strings.Contains(sum.HaltReason, "consecutive") {
+		t.Errorf("HaltReason = %q", sum.HaltReason)
+	}
+	if !strings.Contains(sum.Format(), "halted=true") {
+		t.Errorf("Format() = %q, want the halted marker", sum.Format())
+	}
+	// Skipped sessions are reported as skipped, never as failed: the operator
+	// must be able to tell "we tried and it broke" from "we never tried".
+	for _, res := range sum.Results[3:] {
+		if res.Outcome != OutcomeSkipped {
+			t.Errorf("result %q outcome = %q, want skipped", res.Title, res.Outcome)
+		}
+	}
+}
+
+func TestRecoverSuccessResetsTheFailureRun(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	fail := map[string]bool{"a": true, "b": true, "d": true, "e": true}
+	rec.Restart = func(inst *session.Instance) error {
+		r.restarts = append(r.restarts, inst.Title)
+		if fail[inst.Title] {
+			return errors.New("nope")
+		}
+		return nil
+	}
+	rec.MaxFailures = 3
+
+	// a,b fail; c succeeds (resetting the run); d,e fail — never 3 in a row.
+	sum := rec.Recover(downAssessment("a", "b", "c", "d", "e"))
+
+	if sum.Halted {
+		t.Fatalf("Halted = true, want false: %s", sum.HaltReason)
+	}
+	if len(r.restarts) != 5 {
+		t.Errorf("restarts = %v, want all 5 attempted", r.restarts)
+	}
+	if sum.Failed != 4 || sum.Recovered != 1 {
+		t.Errorf("summary = %+v, want 4 failed / 1 recovered", sum)
+	}
+}
+
+// The auth cascade case: once sessions start booting into an auth failure,
+// restarting the remaining 60 only re-forks the shared credential. The sweep
+// must stop and say so.
+func TestRecoverHaltsOnAuthCircuit(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport {
+		return VerifyReport{PaneAlive: true, Substate: string(session.SubstateAuth401)}
+	})
+	rec.AuthGate = &SubstateAuthGate{HaltAfter: 2}
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d"))
+
+	if len(r.restarts) != 2 {
+		t.Fatalf("restarts = %v, want the sweep to stop after 2 auth failures", r.restarts)
+	}
+	if !sum.Halted {
+		t.Fatal("Halted = false, want true")
+	}
+	if !strings.Contains(sum.HaltReason, "auth circuit open") {
+		t.Errorf("HaltReason = %q", sum.HaltReason)
+	}
+	if sum.Unverified != 2 || sum.Skipped != 2 {
+		t.Errorf("summary = %+v, want 2 unverified / 2 skipped", sum)
+	}
+}
+
+func TestRecoverAuthGateCanBeDisabled(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport {
+		return VerifyReport{PaneAlive: true, Substate: string(session.SubstateAuth401)}
+	})
+	rec.AuthGate = nil
+
+	sum := rec.Recover(downAssessment("a", "b", "c"))
+
+	if sum.Halted || len(r.restarts) != 3 {
+		t.Fatalf("with the gate disabled all sessions must be attempted: restarts=%v halted=%t", r.restarts, sum.Halted)
+	}
+}
+
+// A model outage is not a credential problem: it clears on its own and must not
+// stop a recovery that is otherwise working.
+func TestSubstateAuthGateIgnoresModelUnavailable(t *testing.T) {
+	g := &SubstateAuthGate{HaltAfter: 1}
+	g.Observe(nil, VerifyReport{PaneAlive: true, Substate: string(session.SubstateModelUnavailable)}, nil)
+	g.Observe(nil, VerifyReport{PaneAlive: true, Substate: string(session.SubstateModelUnavailable)}, nil)
+	if ok, reason := g.Allow(); !ok {
+		t.Fatalf("gate opened on model-unavailable: %s", reason)
+	}
+	if g.AuthFailures() != 0 {
+		t.Errorf("AuthFailures = %d, want 0", g.AuthFailures())
+	}
+}
+
+func TestSubstateAuthGateDefaultsHaltAfter(t *testing.T) {
+	g := &SubstateAuthGate{}
+	for i := 0; i < DefaultAuthHaltAfter; i++ {
+		if ok, _ := g.Allow(); !ok {
+			t.Fatalf("gate closed after %d observations, want %d", i, DefaultAuthHaltAfter)
+		}
+		g.Observe(nil, VerifyReport{PaneAlive: true, Substate: string(session.SubstateAuth401)}, nil)
+	}
+	if ok, _ := g.Allow(); ok {
+		t.Fatalf("gate still open after %d auth failures", DefaultAuthHaltAfter)
+	}
+}
+
+// THE destructive direction. A 65-session sweep runs for minutes; if a session
+// comes back on its own (or the operator restarts it) in that window, restarting
+// it again would kill a live agent mid-work. The pre-restart re-probe is the
+// guard, and it must not consume a spacing slot for a session it skipped.
+func TestRecoverSkipsSessionsThatCameBackOnTheirOwn(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	rec.StillDown = func(inst *session.Instance) bool { return inst.Title != "self-healed" }
+
+	sum := rec.Recover(downAssessment("self-healed", "still-dead"))
+
+	if len(r.restarts) != 1 || r.restarts[0] != "still-dead" {
+		t.Fatalf("restarts = %v, want only [still-dead]", r.restarts)
+	}
+	if sum.Skipped != 1 || sum.Recovered != 1 {
+		t.Errorf("summary = %+v, want 1 skipped / 1 recovered", sum)
+	}
+	if !strings.Contains(sum.Results[0].Reason, "came back on its own") {
+		t.Errorf("skip reason = %q", sum.Results[0].Reason)
+	}
+	// The skipped session did not consume a boot slot, so the first real boot
+	// still starts immediately.
+	if len(r.sleeps) != 0 {
+		t.Errorf("sleeps = %v, want none (no boot preceded the only restart)", r.sleeps)
+	}
+	if len(r.persists) != 2 {
+		t.Errorf("persist batches = %v, want only the restarted session (pre+post verify)", r.persists)
+	}
+}
+
+func TestRecoverReProbesAfterTheSpacingWait(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	rec.StillDown = func(inst *session.Instance) bool {
+		r.log("probe %s", inst.Title)
+		return true
+	}
+
+	rec.Recover(downAssessment("a", "b"))
+
+	// The freshness reading must be the LAST thing before the restart, i.e.
+	// after the wait — otherwise it is as stale as the assessment was.
+	want := "sleep 5s|probe b|restart b"
+	if got := strings.Join(r.events, "|"); !strings.Contains(got, want) {
+		t.Fatalf("events = %v, want the subsequence %q", r.events, want)
+	}
+}
+
+func TestRecoverLimit(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	rec.Limit = 2
+
+	sum := rec.Recover(downAssessment("a", "b", "c", "d"))
+
+	if len(r.restarts) != 2 {
+		t.Fatalf("restarts = %v, want 2", r.restarts)
+	}
+	if sum.Skipped != 2 {
+		t.Errorf("Skipped = %d, want 2", sum.Skipped)
+	}
+	if !strings.Contains(sum.Results[2].Reason, "--limit") {
+		t.Errorf("skip reason = %q, want it to name --limit", sum.Results[2].Reason)
+	}
+}
+
+// DATA-SAFETY REGRESSION GUARD (2026-06-04). The persist seam must only ever
+// receive the single session a boot just mutated. A sweep that hands storage its
+// whole stale snapshot is how the profile index got wiped.
+func TestRecoverPersistsOnlyTheSessionItJustRestarted(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+
+	rec.Recover(downAssessment("a", "b"))
+
+	if len(r.persists) == 0 {
+		t.Fatal("nothing was persisted")
+	}
+	for i, batch := range r.persists {
+		if len(batch) != 1 {
+			t.Fatalf("persist batch %d = %v, want exactly one session", i, batch)
+		}
+	}
+}
+
+// A failed restart did not mutate the session, so it must not be persisted:
+// writing a row we did not change is pure clobber risk.
+func TestRecoverDoesNotPersistFailedRestarts(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	rec.Restart = func(*session.Instance) error { return errors.New("nope") }
+	rec.MaxFailures = 99
+
+	rec.Recover(downAssessment("a", "b"))
+
+	if len(r.persists) != 0 {
+		t.Fatalf("persisted %v after failed restarts, want nothing", r.persists)
+	}
+}
+
+// Storage trouble on one session must not strand the other 60.
+func TestRecoverContinuesWhenPersistFails(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	rec.Persist = func([]*session.Instance) error { return errors.New("database is locked") }
+
+	sum := rec.Recover(downAssessment("a", "b"))
+
+	if sum.Recovered != 2 {
+		t.Fatalf("summary = %+v, want both recovered despite persist errors", sum)
+	}
+}
+
+func TestRecoverWithoutRestartActionFailsLoudly(t *testing.T) {
+	rec := &Recoverer{Sleep: func(time.Duration) {}, MaxFailures: 99}
+	sum := rec.Recover(downAssessment("a"))
+	if sum.Failed != 1 {
+		t.Fatalf("summary = %+v, want the missing action reported as a failure", sum)
+	}
+	if sum.Results[0].Err == nil {
+		t.Fatal("expected an error on the result")
+	}
+}
+
+func TestRecoverSkipsNilInstances(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	as := downAssessment("a")
+	as.Candidates = append(as.Candidates, Candidate{Health: HealthDown})
+	as.Down = len(as.Candidates)
+
+	sum := rec.Recover(as)
+
+	if sum.Recovered != 1 || sum.Skipped != 1 {
+		t.Fatalf("summary = %+v, want 1 recovered / 1 skipped", sum)
+	}
+}
+
+func TestRecoverEmptyAssessment(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	sum := rec.Recover(Assessment{})
+	if sum.Attempted != 0 || len(sum.Results) != 0 || sum.Halted {
+		t.Fatalf("summary = %+v, want an empty no-op", sum)
+	}
+}
+
+func TestRecoverProgressReportsEveryAttempt(t *testing.T) {
+	r := &recorder{}
+	rec := newTestRecoverer(r, func(*session.Instance) VerifyReport { return bootedReport() })
+	var lines []string
+	rec.Progress = func(index, total int, c Candidate) {
+		lines = append(lines, fmt.Sprintf("%d/%d %s", index, total, c.Title()))
+	}
+
+	rec.Recover(downAssessment("a", "b"))
+
+	want := []string{"1/2 a", "2/2 b"}
+	if strings.Join(lines, ",") != strings.Join(want, ",") {
+		t.Fatalf("progress = %v, want %v", lines, want)
+	}
+}
+
+func TestHealthString(t *testing.T) {
+	cases := map[Health]string{
+		HealthAlive:   "alive",
+		HealthDown:    "down",
+		HealthSkipped: "skipped",
+		Health(99):    "unknown",
+	}
+	for h, want := range cases {
+		if got := h.String(); got != want {
+			t.Errorf("Health(%d).String() = %q, want %q", h, got, want)
+		}
+	}
+}

--- a/internal/fleet/testmain_test.go
+++ b/internal/fleet/testmain_test.go
@@ -1,0 +1,27 @@
+package fleet
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// TestMain holds only the os.Exit call; setup and cleanups live in runTestMain
+// because os.Exit does not run deferred functions. Mirrors
+// internal/atomicfile/testmain_test.go.
+//
+// This package's tests drive every side effect through injected function
+// fields and never spawn tmux or touch storage, but the isolation is
+// mandatory anyway: it is what stops a future test in this package from
+// silently reaching the real ~/.agent-deck (2026-06-04) or the default tmux
+// server (2026-04-17), and internal/testutil's testmain audit enforces it.
+func TestMain(m *testing.M) { os.Exit(runTestMain(m)) }
+
+func runTestMain(m *testing.M) int {
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+	return m.Run()
+}

--- a/internal/fleet/verify.go
+++ b/internal/fleet/verify.go
@@ -1,0 +1,168 @@
+package fleet
+
+import (
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// VerifyReport is what one boot proved about itself.
+type VerifyReport struct {
+	// PaneAlive is true when the tmux session came back and its pane is not dead.
+	PaneAlive bool
+	// ToolStarted is true when the pane additionally reached a state that only a
+	// booted agent produces (see Verifier.Verify).
+	ToolStarted bool
+	// Status is the registry status observed at the end of verification.
+	Status string
+	// Substate is the Honest-Status-v2 refinement observed (may be "").
+	Substate string
+	// Elapsed is how long verification waited.
+	Elapsed time.Duration
+}
+
+// Booted reports whether the boot is fully verified.
+func (r VerifyReport) Booted() bool { return r.PaneAlive && r.ToolStarted }
+
+// AuthFailed reports whether the pane came up showing an auth-failure banner.
+func (r VerifyReport) AuthFailed() bool { return r.Substate == string(session.SubstateAuth401) }
+
+// ProbeResult is one instantaneous reading of a session's pane.
+type ProbeResult struct {
+	PaneAlive bool
+	Status    session.Status
+	Substate  session.Substate
+}
+
+// Verifier polls a freshly restarted session until it proves it booted, or the
+// timeout expires. The single Probe seam keeps every tmux call in one place so
+// tests drive the polling logic with a scripted sequence of readings.
+type Verifier struct {
+	Probe func(*session.Instance) ProbeResult
+	Sleep func(time.Duration)
+	Now   func() time.Time
+
+	// Timeout bounds one verification (<=0 uses DefaultVerifyTimeout).
+	Timeout time.Duration
+	// Poll is the interval between readings (<=0 uses DefaultVerifyPoll).
+	Poll time.Duration
+}
+
+// NewVerifier returns a Verifier wired to real tmux/status probes.
+func NewVerifier() *Verifier {
+	return &Verifier{
+		Probe:   defaultProbe,
+		Sleep:   time.Sleep,
+		Now:     time.Now,
+		Timeout: DefaultVerifyTimeout,
+		Poll:    DefaultVerifyPoll,
+	}
+}
+
+// Verify blocks until the session is verified booted, is decisively broken, or
+// the timeout expires. It always returns the last reading it took — an
+// unverified boot is reported, never guessed at.
+//
+// "Booted" requires more than a live pane: a pane exists the instant tmux
+// creates it, long before the agent's TUI is up. So verification waits for a
+// state only a running agent produces — a registry status past `starting`
+// (running/waiting/idle) or a substate the pane classifier only emits for a
+// live agent TUI. A pane that is still `starting` when the timeout expires is
+// reported as PaneAlive && !ToolStarted, which the recoverer surfaces as
+// "unverified" rather than as a success or a failure.
+//
+// An auth-failure substate short-circuits the wait: it is a decisive verdict,
+// and waiting out the full timeout on each of 60 sessions would turn a fast
+// halt into a 30-minute one.
+func (v *Verifier) Verify(inst *session.Instance) VerifyReport {
+	now := v.now
+	sleep := v.sleep
+	timeout := v.Timeout
+	if timeout <= 0 {
+		timeout = DefaultVerifyTimeout
+	}
+	poll := v.Poll
+	if poll <= 0 {
+		poll = DefaultVerifyPoll
+	}
+
+	start := now()
+	for {
+		p := ProbeResult{}
+		if v.Probe != nil {
+			p = v.Probe(inst)
+		}
+		rep := VerifyReport{
+			PaneAlive: p.PaneAlive,
+			Status:    string(p.Status),
+			Substate:  string(p.Substate),
+			Elapsed:   now().Sub(start),
+		}
+		if p.PaneAlive {
+			if rep.AuthFailed() {
+				return rep
+			}
+			if bootedState(p.Status, p.Substate) {
+				rep.ToolStarted = true
+				return rep
+			}
+		}
+		if rep.Elapsed >= timeout {
+			return rep
+		}
+		sleep(poll)
+	}
+}
+
+func (v *Verifier) now() time.Time {
+	if v.Now != nil {
+		return v.Now()
+	}
+	return time.Now()
+}
+
+func (v *Verifier) sleep(d time.Duration) {
+	if v.Sleep != nil {
+		v.Sleep(d)
+		return
+	}
+	time.Sleep(d)
+}
+
+// bootedState reports whether a (status, substate) pair can only come from a
+// session whose agent process is actually up.
+func bootedState(st session.Status, sub session.Substate) bool {
+	switch st {
+	case session.StatusRunning, session.StatusWaiting, session.StatusIdle:
+		return true
+	}
+	switch sub {
+	case session.SubstateRunning, session.SubstateIdleAtEmptyPrompt:
+		return true
+	}
+	return false
+}
+
+// defaultProbe reads ground truth from tmux and the instance's own status
+// machinery. It never creates or kills anything.
+func defaultProbe(inst *session.Instance) ProbeResult {
+	if inst == nil {
+		return ProbeResult{}
+	}
+	if !tmux.HasSessionOnSocket(inst.TmuxSocketName, TmuxName(inst)) {
+		return ProbeResult{}
+	}
+	if ts := inst.GetTmuxSession(); ts != nil && ts.IsPaneDead() {
+		return ProbeResult{}
+	}
+	// UpdateStatus is the canonical pane-content classifier (the same one the
+	// TUI and notify daemon use). Its error is advisory: a failed read just
+	// leaves the previous status in place and we poll again.
+	_ = inst.UpdateStatus()
+	return ProbeResult{
+		PaneAlive: true,
+		Status:    inst.GetStatusThreadSafe(),
+		Substate:  inst.Substate(),
+	}
+}

--- a/internal/fleet/verify_test.go
+++ b/internal/fleet/verify_test.go
@@ -1,0 +1,170 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// fakeClock advances only when the verifier sleeps, so timeout behavior is
+// deterministic and the test suite never actually waits.
+type fakeClock struct {
+	now    time.Time
+	sleeps []time.Duration
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) Sleep(d time.Duration) {
+	c.sleeps = append(c.sleeps, d)
+	c.now = c.now.Add(d)
+}
+
+func newTestVerifier(probes []ProbeResult) (*Verifier, *fakeClock, *int) {
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	calls := 0
+	v := &Verifier{
+		Probe: func(*session.Instance) ProbeResult {
+			idx := calls
+			if idx > len(probes)-1 {
+				idx = len(probes) - 1
+			}
+			calls++
+			return probes[idx]
+		},
+		Sleep:   clock.Sleep,
+		Now:     clock.Now,
+		Timeout: 3 * time.Second,
+		Poll:    time.Second,
+	}
+	return v, clock, &calls
+}
+
+// A pane exists the instant tmux creates it — long before the agent is up. So a
+// freshly created pane sitting in `starting` must NOT count as booted; the
+// verifier has to keep polling until the agent's own state shows up.
+func TestVerifyWaitsForTheAgentNotJustThePane(t *testing.T) {
+	v, clock, calls := newTestVerifier([]ProbeResult{
+		{}, // tmux session not back yet
+		{PaneAlive: true, Status: session.StatusStarting}, // pane up, agent not
+		{PaneAlive: true, Status: session.StatusRunning},  // agent up
+		{PaneAlive: true, Status: session.StatusRunning},  // (unused)
+	})
+
+	rep := v.Verify(nil)
+
+	if !rep.Booted() {
+		t.Fatalf("report = %+v, want booted", rep)
+	}
+	if *calls != 3 {
+		t.Errorf("probes = %d, want 3", *calls)
+	}
+	if len(clock.sleeps) != 2 {
+		t.Errorf("sleeps = %v, want 2 polls", clock.sleeps)
+	}
+	if rep.Elapsed != 2*time.Second {
+		t.Errorf("Elapsed = %s, want 2s", rep.Elapsed)
+	}
+}
+
+func TestVerifyTimesOutUnverifiedRatherThanGuessing(t *testing.T) {
+	v, _, _ := newTestVerifier([]ProbeResult{{PaneAlive: true, Status: session.StatusStarting}})
+
+	rep := v.Verify(nil)
+
+	if rep.Booted() {
+		t.Fatal("a session stuck in `starting` must not verify as booted")
+	}
+	if !rep.PaneAlive {
+		t.Error("PaneAlive = false, want the pane fact preserved in the report")
+	}
+	if rep.Status != string(session.StatusStarting) {
+		t.Errorf("Status = %q, want the last observed status", rep.Status)
+	}
+	if rep.Elapsed < 3*time.Second {
+		t.Errorf("Elapsed = %s, want at least the timeout", rep.Elapsed)
+	}
+}
+
+// An auth failure is decisive. Waiting out the full timeout on each of 65
+// sessions would turn a fast halt into a half-hour one.
+func TestVerifyShortCircuitsOnAuthFailure(t *testing.T) {
+	v, clock, calls := newTestVerifier([]ProbeResult{
+		{PaneAlive: true, Status: session.StatusRunning, Substate: session.SubstateAuth401},
+	})
+
+	rep := v.Verify(nil)
+
+	if !rep.AuthFailed() {
+		t.Fatalf("report = %+v, want AuthFailed", rep)
+	}
+	if rep.ToolStarted {
+		t.Error("ToolStarted = true, want false for an auth-failed boot")
+	}
+	if *calls != 1 || len(clock.sleeps) != 0 {
+		t.Errorf("auth failure took %d probes and %v sleeps, want 1 probe and no wait", *calls, clock.sleeps)
+	}
+}
+
+// A dead pane never satisfies verification even when the stale status looks fine.
+func TestVerifyIgnoresStatusWhenThePaneIsGone(t *testing.T) {
+	v, _, _ := newTestVerifier([]ProbeResult{{PaneAlive: false, Status: session.StatusRunning}})
+
+	if rep := v.Verify(nil); rep.Booted() {
+		t.Fatalf("report = %+v, want not booted", rep)
+	}
+}
+
+func TestVerifyAcceptsSubstateEvidenceOfALiveAgent(t *testing.T) {
+	v, _, _ := newTestVerifier([]ProbeResult{
+		{PaneAlive: true, Status: session.StatusStarting, Substate: session.SubstateIdleAtEmptyPrompt},
+	})
+
+	if rep := v.Verify(nil); !rep.Booted() {
+		t.Fatalf("report = %+v, want booted (agent prompt is up)", rep)
+	}
+}
+
+func TestVerifyZeroConfigUsesDefaults(t *testing.T) {
+	v := &Verifier{
+		Probe: func(*session.Instance) ProbeResult {
+			return ProbeResult{PaneAlive: true, Status: session.StatusRunning}
+		},
+		Sleep: func(time.Duration) { t.Fatal("a booted session must not poll again") },
+	}
+	if rep := v.Verify(nil); !rep.Booted() {
+		t.Fatalf("report = %+v, want booted", rep)
+	}
+}
+
+func TestVerifyWithoutProbeIsNotBooted(t *testing.T) {
+	v := &Verifier{Sleep: func(time.Duration) {}, Now: time.Now, Timeout: time.Nanosecond}
+	if rep := v.Verify(nil); rep.Booted() {
+		t.Fatalf("report = %+v, want not booted", rep)
+	}
+}
+
+func TestBootedState(t *testing.T) {
+	tests := []struct {
+		status session.Status
+		sub    session.Substate
+		want   bool
+	}{
+		{status: session.StatusRunning, want: true},
+		{status: session.StatusWaiting, want: true},
+		{status: session.StatusIdle, want: true},
+		{status: session.StatusStarting, want: false},
+		{status: session.StatusError, want: false},
+		{status: session.StatusStopped, want: false},
+		{status: session.StatusStarting, sub: session.SubstateRunning, want: true},
+		{status: session.StatusStarting, sub: session.SubstateIdleAtEmptyPrompt, want: true},
+		{status: session.StatusError, sub: session.SubstateAuth401, want: false},
+		{status: session.StatusError, sub: session.SubstateModelUnavailable, want: false},
+	}
+	for _, tc := range tests {
+		if got := bootedState(tc.status, tc.sub); got != tc.want {
+			t.Errorf("bootedState(%q, %q) = %t, want %t", tc.status, tc.sub, got, tc.want)
+		}
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -820,6 +820,44 @@ func (s *Storage) PersistRevivedInstances(instances []*Instance) error {
 	return s.db.PersistInstanceStatusesTx(updates)
 }
 
+// PersistRecoveredInstances persists the rows a fleet-recovery sweep restarted,
+// and ONLY those rows.
+//
+// Why it is not PersistRevivedInstances: a revive mutates exactly one field
+// (Status), so that method can use a status-only UPDATE. A restart replaces the
+// process — status, tmux session name, socket, and the tool conversation id in
+// tool_data can all change — so the recovered rows need a full-row write.
+//
+// Why it is not SaveWithGroups: that path converts and rewrites EVERY instance
+// in the caller's snapshot. During a 65-session recovery the sweep runs for
+// minutes, so its snapshot is stale by construction, and a full rewrite would
+// push stale columns over any edit another process made to a session the sweep
+// never touched. Writing one targeted row per restarted session (via
+// statedb.SaveInstance, which merges tool_data extras and auto-name fields
+// rather than blindly replacing them) keeps the blast radius to the sessions
+// the sweep actually owns. No path here deletes anything: there is no
+// DELETE-NOT-IN sweep, so a session added concurrently can never be lost
+// (the 2026-06-04 data-loss class).
+//
+// Errors are per-row and returned joined, so one bad row does not hide the rest.
+func (s *Storage) PersistRecoveredInstances(instances []*Instance) error {
+	var errs []error
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		row, err := instanceToRow(inst)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("convert %s: %w", inst.ID, err))
+			continue
+		}
+		if err := s.saveSingleInstance(row); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // instanceToRow converts a session.Instance into the statedb row shape.
 // Shared by SaveWithGroups (bulk path) and InsertSessionAndVerify
 // (targeted single-row path) so the marshal/normalize logic stays in

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -357,9 +357,13 @@ The sweep halts early when the trouble looks systemic:
 | Brake | Flag | Default | Why |
 |-------|------|---------|-----|
 | Consecutive failed restarts | `--max-failures` | 3 | Three failures in a row means a common cause; grinding through the rest multiplies the damage |
+| Sessions that restart and then die immediately | `--max-dead-boots` | 3 | A pane that is gone again by verification time means the session exited on boot — the way a dead credential actually presents (the agent quits on the 401, so there is no banner to read). Three in a row is a host- or credential-level fault (`0` disables) |
 | Sessions booting into an auth failure | `--auth-halt-after` | 2 | Restarting the fleet against a broken credential deepens the cascade (`0` disables) |
 
-A halted sweep exits non-zero and reports the reason.
+A slow boot is not a dead one: a pane that is up but still `starting` when the
+verify timeout expires is reported `unverified` and does not trip any brake.
+
+A halted sweep exits non-zero (with `--json` too) and reports the reason.
 
 Options:
 
@@ -372,6 +376,7 @@ Options:
 --verify-timeout <dur>   How long one session may take to prove it booted (default 30s)
 --verify-poll <dur>      Verification poll interval (default 500ms)
 --max-failures <n>       Halt after N consecutive failed restarts (default 3)
+--max-dead-boots <n>     Halt after N consecutive boots whose pane died immediately (default 3, 0 disables)
 --auth-halt-after <n>    Halt after N auth-failed boots (default 2, 0 disables)
 --group <path>           Only consider sessions in this group and its descendants
 --include-idle           Also treat status=idle sessions as down

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -8,6 +8,7 @@ Complete reference for all agent-deck CLI commands.
 - [Basic Commands](#basic-commands)
 - [Web Command](#web-command)
 - [Session Commands](#session-commands)
+- [Fleet Recovery Commands](#fleet-recovery-commands)
 - [Worktree Commands](#worktree-commands)
 - [MCP Commands](#mcp-commands)
 - [Skill Commands](#skill-commands)
@@ -302,6 +303,88 @@ agent-deck session switch-account "My Project" work
 ```
 
 Accounts are the profiles named in `config.toml` (`[profiles.<name>.claude].config_dir`).
+
+## Fleet Recovery Commands
+
+Recovery from a *fleet-wide* session death: every managed pane on the host gone
+at once (a killed tmux server, a host reboot, an auth cascade that made the
+agents exit). For a single session use `session restart`; for sessions whose
+pane is still alive but whose control pipe broke use `session revive`.
+
+### fleet status
+
+```bash
+agent-deck fleet status [--group <path>] [--include-idle] [--json]
+```
+
+Reports which sessions the registry believes are alive but whose tmux session is
+gone. **Read-only** — no restarts, no writes. Prints a `MASS DEATH detected` line
+when the down set is large enough (both in absolute count and as a share of
+should-be-alive sessions) to be a fleet-wide event rather than one crash.
+
+A session is only counted as down after two independent tmux probes agree it is
+gone (`--confirm-probes`), because a single `has-session` miss right after a tmux
+server restart is not proof of death.
+
+Sessions you stopped or queued, and archived sessions, are never counted. Status
+`idle` is excluded by default (it is also the status of a session that was added
+but never started) — `--include-idle` opts in.
+
+### fleet recover
+
+```bash
+agent-deck fleet recover                       # plan only (dry run)
+agent-deck fleet recover --yes                 # actually recover
+agent-deck fleet recover --yes --spacing 8s --limit 10
+agent-deck fleet recover --yes --group agent-deck --json
+```
+
+Restarts the down sessions **one at a time**, waiting `--spacing` (default 5s,
+jittered) between boots and verifying each boot before starting the next.
+Sequential spacing is the point: a burst of simultaneous agent boots is what
+forks a shared rotating OAuth refresh token and 401s the whole fleet.
+
+**Dry run by default.** Without `--yes` the command prints the plan (order,
+waits, estimated runtime) and exits without restarting anything.
+
+Each boot is verified before the next begins: the pane must be back AND the
+session must reach a state only a booted agent produces. A restart that returns
+successfully but never proves it booted is reported as `unverified`, never as
+`recovered`.
+
+The sweep halts early when the trouble looks systemic:
+
+| Brake | Flag | Default | Why |
+|-------|------|---------|-----|
+| Consecutive failed restarts | `--max-failures` | 3 | Three failures in a row means a common cause; grinding through the rest multiplies the damage |
+| Sessions booting into an auth failure | `--auth-halt-after` | 2 | Restarting the fleet against a broken credential deepens the cascade (`0` disables) |
+
+A halted sweep exits non-zero and reports the reason.
+
+Options:
+
+```bash
+--yes                    Actually restart (without it, plan only)
+--dry-run                Force plan-only mode even with --yes
+--spacing <dur>          Gap between boots (default 5s; 0 disables — not recommended)
+--jitter <fraction>      Random +/- fraction applied to each gap (default 0.2)
+--limit <n>              Restart at most N sessions (0 = all)
+--verify-timeout <dur>   How long one session may take to prove it booted (default 30s)
+--verify-poll <dur>      Verification poll interval (default 500ms)
+--max-failures <n>       Halt after N consecutive failed restarts (default 3)
+--auth-halt-after <n>    Halt after N auth-failed boots (default 2, 0 disables)
+--group <path>           Only consider sessions in this group and its descendants
+--include-idle           Also treat status=idle sessions as down
+--confirm-probes <n>     Probes that must agree a session is gone (default 2)
+--confirm-delay <dur>    Delay between confirming probes (default 750ms)
+--min-dead <n>           Minimum down sessions for a mass-death verdict (default 3)
+--dead-fraction <f>      Share of should-be-alive sessions that must be down (default 0.5)
+--json, -q               Machine-readable / minimal output
+```
+
+Recovery only ever writes the rows it restarted, one at a time, through a
+targeted write with no table sweep — a session added by another process during
+the (multi-minute) sweep can never be lost.
 
 ## Worktree Commands
 

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -286,6 +286,35 @@ Use this template:
 
 ## Recovery
 
+### Every Session Died At Once
+
+Symptom: the whole deck flips to red (or the panes are simply gone) after a tmux
+server was killed, the host rebooted, or an auth failure cascaded through the
+fleet.
+
+```bash
+agent-deck fleet status          # read-only: what is actually down?
+agent-deck fleet recover         # dry run: the plan, in order, with waits
+agent-deck fleet recover --yes   # run it
+```
+
+`fleet recover` restarts the down sessions **one at a time** with ~5s between
+boots and verifies each boot before starting the next. Do not replace it with a
+loop that restarts everything at once: simultaneous agent boots are what fork a
+shared rotating OAuth refresh token, which turns a recoverable outage into a
+fleet-wide 401.
+
+The sweep stops on its own if three restarts fail in a row, or if sessions come
+up showing an auth-failure banner (re-authenticate first, then re-run). Sessions
+you stopped or archived are never touched.
+
+If the panes are still ALIVE and only agent-deck thinks they are broken (a
+killed control pipe, e.g. after an SSH logout), the cheaper fix is:
+
+```bash
+agent-deck session revive --all
+```
+
 ### Session Metadata Lost
 
 Data stored in SQLite:


### PR DESCRIPTION
## Problem

When every managed pane on a host dies at once — a killed tmux server, a host reboot, an auth cascade that makes the agents exit — agent-deck is left holding a registry full of sessions whose processes are gone, and there is no command for that.

`session restart <id>` fixes one session. `session revive --all` fixes sessions whose pane is still ALIVE but whose control pipe broke; it explicitly refuses the mass-death case (`ClassDead` is never auto-revived, by design). So recovery of a whole fleet has been an improvised shell loop: list the error sessions, restart them one at a time with a few seconds of spacing so N agents do not all refresh the single rotating OAuth refresh token inside one window, eyeball each pane, keep going. That loop was run twice in one day recently, under pressure, by hand.

This PR productizes it.

## What this adds

New `internal/fleet` package, in two halves.

**Detector** — finds sessions whose registry status claims they are running (`running`/`waiting`/`starting`/`error`) but whose tmux session is gone.

- Requires **two independent probes** to agree before calling a session dead. One `has-session` miss is not proof of death: right after a tmux server restart an existing session briefly probes as absent (the race already flagged in `reviver.go`'s `TODO(revive-liveness)`), and acting on a single miss would restart sessions that are alive. That is the only genuinely destructive thing this command could do, so it is guarded twice (see also the pre-restart re-probe below).
- Reports a mass-death verdict from an absolute floor (`--min-dead`, default 3) **and** a share of the should-be-alive population (`--dead-fraction`, default 0.5), so "4 down out of 44" is not announced as a fleet death.
- Never considers sessions the operator stopped or queued, archived sessions, or non-restartable ones. `idle` is excluded by default and opt-in via `--include-idle`, because `idle` is also the status of a session that was added but never started — recovering it by default would *launch* things nobody launched.

**Recoverer** — restarts the candidates.

1. **Sequential**, never concurrent. Too many agents booting at once is part of what causes the failure being recovered from.
2. **Spacing + jitter** (default 5s, ±20%) before every boot except the first. `Spacing <= 0` means "unset" and falls back to the default; only the explicit `--spacing 0` opt-out removes the gap, so an unset field can never silently mean "no spacing".
3. **Pre-restart re-probe.** A 65-session sweep runs for minutes, so the assessment is stale by the end. Each candidate is re-probed immediately *after* its wait and *before* its restart; a session that came back on its own is skipped, not killed. It does not consume a boot slot.
4. **Per-boot verification before the next boot.** A pane exists the instant tmux creates it, long before the agent's TUI is up, so verification waits for a state only a booted agent produces (a status past `starting`, or a pane substate the classifier only emits for a live agent). A restart that returns successfully but never proves itself is reported as `unverified` — never counted as `recovered`.
5. **Early halt when the trouble is systemic**: three consecutive failed restarts (`--max-failures`), or sessions booting into an auth-failure banner (`--auth-halt-after`, using the existing Honest-Status-v2 `auth-401` substate). Restarting the remaining 60 sessions against a broken credential only deepens the cascade. Remaining sessions are reported `skipped`, never `failed` — the operator can tell "we tried and it broke" from "we never tried".

### Auth breaker integration point

The auth brake sits behind an `AuthGate` interface (`Allow()` before each boot, `Observe()` after each boot). The built-in `SubstateAuthGate` reads the `auth-401` substate that already exists on main. A dedicated auth circuit breaker for the shared-rotating-refresh-token race can be adapted to this interface and passed as `Recoverer.AuthGate` with **no change to the sequencing logic** — that is the seam to plug into. `--auth-halt-after 0` disables the built-in gate. Model-unavailable is deliberately NOT counted as an auth failure (it clears on its own).

## CLI

```bash
agent-deck fleet status          # read-only: what is actually down
agent-deck fleet recover         # dry run: the plan, in order, with waits
agent-deck fleet recover --yes   # run it
agent-deck fleet recover --yes --spacing 8s --limit 10 --group agent-deck
```

`fleet recover` is **dry run by default**, matching the existing `session cleanup` / `worktree cleanup` convention: without `--yes` it prints the plan (order, waits, estimated runtime) and restarts nothing. `--dry-run` forces plan-only even with `--yes`. A halted sweep exits non-zero so a wrapper can notice without parsing text. `--json` gives per-session outcomes; `-q` gives the one-line summary.

`fleet status` performs no writes at all.

## Data safety

Following the 2026-06-04 data-loss postmortem:

- Recovery persists **only the rows it restarted**, one at a time, through a new `Storage.PersistRecoveredInstances`. That method uses the targeted single-row path (`statedb.SaveInstance`, which merges `tool_data` extras and auto-name fields) — **no `DELETE FROM instances WHERE id NOT IN (...)` sweep and no whole-table rewrite from the sweep's minutes-old snapshot**. A session another process adds mid-sweep cannot be lost, and rows the sweep never touched are never rewritten.
- A restart that FAILED did not mutate the session, so it is not persisted at all (writing an unchanged row is pure clobber risk).
- Each session is persisted immediately (before verification, which can take tens of seconds, and again after), so a sweep interrupted at session 40 of 65 leaves the first 39 recorded.
- Persist failures are logged and do not abort the sweep — a locked database on session 3 must not strand the other 62.

## Tests

Every side effect in the package — restart, liveness probe, verification, sleep, jitter, clock, persist — is an injectable function field, so the unit tests assert on real **sequencing** without spawning a single tmux server or writing to a real profile. Highlights:

- Exact event interleaving of a 3-session sweep (`restart → persist → verify → persist → sleep → restart …`), proving one-at-a-time + verify-before-next.
- A session that answers the *second* probe is counted alive and never restarted.
- A session that comes back mid-sweep is skipped; the re-probe happens after the wait, not before it.
- Auth-circuit halt, consecutive-failure halt, failure-run reset on success, `--limit`, dry-run purity, unverified-vs-recovered accounting, jitter bounds and clamping.
- CLI-level: the dry-run-unless-`--yes` default, flag→recoverer wiring (including `--spacing 0` as an explicit opt-out and `--auth-halt-after 0` disabling the gate), and every human/JSON output shape.
- `cmd/agent-deck/fleet_recover_persist_cli_test.go` is a real-storage regression guard modelled on the existing revive test: a session added by a "concurrent process" mid-sweep must survive the recovery persist. A regression that swaps the persist back to `saveSessionData`/`SaveWithGroups` fails there.
- `internal/fleet/testmain_test.go` isolates HOME + XDG + the tmux socket (required by the `internal/testutil` testmain audit).

Verified locally with `go build ./...` and `go vet ./...`; the suite runs in CI (this touches `internal/session/storage.go`, so the session-persistence gate runs too).

## Not included

- No TUI surface yet (a key binding for "recover the fleet" is a natural follow-up).
- Detection is on-demand, not automatic — nothing here restarts anything without an explicit `--yes`.

## Review pass (second commit)

Three real gaps, found reviewing this branch against the failure it is for.

**1. The auth breaker could not see the failure it exists for.** A session whose credential is dead does not sit in its pane showing a 401 banner — it EXITS, and tmux tears the pane down with it. That boot produces no substate for `SubstateAuthGate` to read and no error for the failed-restart brake to count, so a credential outage would have let the sweep restart all 65 sessions, each burning a full 30s verify timeout: precisely the amplification this command exists to prevent. Added `Recoverer.MaxDeadBoots` (`--max-dead-boots`, default 3): halt after N consecutive boots whose pane is **gone again** by verification time.

Only pane-is-gone counts. A pane that is up but still `starting` when the timeout expires is a slow boot, not a dead one, and must never stop a recovery that is merely taking its time — otherwise a loaded host reads as a credential outage. Zero means "use the default" and a negative value is the explicit opt-out (the convention the auth-resilience branch settled on), so an under-configured `Recoverer` keeps the brake; the CLI translates `--max-dead-boots 0` into that opt-out rather than passing a value the recoverer would read as "unset".

**2. A halted sweep exited 0 under `--json`.** The exit-code contract sat after the JSON return, so the caller most likely to check only the exit status — a wrapper script or the conductor — was the one being told a halted fleet recovery had succeeded. The halt check now covers every output mode.

**3. `--json -q` printed nothing at all.** A quiet `CLIOutput` drops `Success` entirely, so the combination emitted an empty payload a wrapper would read as a clean no-op. `-q` now only silences human output; `--json` is always emitted.

Plus: a `--limit` plan numbered the down sessions it was *not* going to touch as if they were part of the run (they are now listed as `not in this run: beyond --limit N`, unnumbered and without a planned wait).

New tests: dead-boot halt, default-when-unset, explicit disable, slow boots not tripping it, a verified boot breaking the run, the flag→field translation, and the plan/limit formatting split.

### Auth breaker integration, now concrete

The auth-resilience work (#1743) has landed its half on its own branch: `Instance.IsAuthHeld()` / `RecordAuthBootFailure()` and `session.BootSweep`. Those symbols are not on `main` yet, so this package cannot reference them without breaking the build; `internal/fleet/authgate.go` now names them and spells out the adapter, which is two lines of `Allow`/`Observe` over the existing `AuthGate` seam plus one `Detector.Classify` line reporting an auth-held session as `HealthSkipped` so a sweep never restarts a session the hold has already parked. No sequencing logic changes either way — that is what the seam is for. Whichever of the two PRs merges second can complete it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `fleet status` to report fleet health (including mass-death detection) in text or JSON, with quiet mode.
  * Added `fleet recover` to sequentially restart down sessions with verification, optional dry-run planning, and JSON output.
  * Added safety controls: `--yes`, `--dry-run`, `--limit`, spacing/jitter pacing, `--max-failures`, `--max-dead-boots`, and auth-failure halting.
  * Added recovery persistence that won’t clobber concurrent updates.
* **Documentation**
  * Updated top-level CLI help to include Fleet Recovery commands.
* **Tests**
  * Added extensive coverage for status/recovery formatting, JSON shape, safety/halting, and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
