### PR TITLE
test: pin restart-all JSON contract

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -836,26 +836,11 @@ func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*s
 		return nil
 	})
 
-	// Fold skip/auth-death verdicts into the per-session records so --json
-	// consumers see WHY a session was left alone rather than a silent omission.
-	ordered := make([]map[string]interface{}, 0, len(sweepResult.Attempts))
+	ordered := restartAllSessionRecords(results, sweepResult.Attempts)
 	for _, attempt := range sweepResult.Attempts {
-		result := results[attempt.InstanceID]
-		if result == nil {
-			result = map[string]interface{}{"id": attempt.InstanceID, "title": attempt.Title}
+		if attempt.Skipped && !out.jsonMode && !out.quietMode {
+			fmt.Printf("Skipped %s: %s\n", attempt.Title, attempt.SkipReason)
 		}
-		if attempt.Skipped {
-			result["success"] = true
-			result["skipped"] = true
-			result["reason"] = attempt.SkipReason
-			if !out.jsonMode && !out.quietMode {
-				fmt.Printf("Skipped %s: %s\n", attempt.Title, attempt.SkipReason)
-			}
-		}
-		if attempt.AuthDeath {
-			result["auth_death"] = true
-		}
-		ordered = append(ordered, result)
 	}
 
 	// Save updated state after all restarts
@@ -869,18 +854,7 @@ func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*s
 	}
 
 	if out.jsonMode {
-		out.Success("", map[string]interface{}{
-			"success":      sweepResult.Failed == 0 && !sweepResult.Tripped,
-			"total":        len(active),
-			"restarted":    sweepResult.Booted,
-			"failed":       sweepResult.Failed,
-			"skipped_auth": sweepResult.SkippedHeld,
-			"auth_deaths":  sweepResult.AuthDeaths,
-			"abandoned":    sweepResult.Abandoned,
-			"auth_tripped": sweepResult.Tripped,
-			"trip_message": sweepResult.TripMessage,
-			"sessions":     ordered,
-		})
+		out.Success("", restartAllSessionsJSONPayload(len(active), sweepResult, ordered))
 	} else if !out.quietMode {
 		fmt.Printf("Restarted %d/%d sessions", sweepResult.Booted, len(active))
 		if sweepResult.Failed > 0 {
@@ -895,7 +869,7 @@ func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*s
 		fmt.Println()
 	}
 
-	if sweepResult.Failed > 0 || sweepResult.Tripped {
+	if restartAllSessionsExitCode(sweepResult) != 0 {
 		os.Exit(1)
 	}
 }

--- a/cmd/agent-deck/session_restart_all.go
+++ b/cmd/agent-deck/session_restart_all.go
@@ -1,0 +1,45 @@
+package main
+
+import "github.com/asheshgoplani/agent-deck/internal/session"
+
+func restartAllSessionRecords(results map[string]map[string]interface{}, attempts []session.BootAttempt) []map[string]interface{} {
+	ordered := make([]map[string]interface{}, 0, len(attempts))
+	for _, attempt := range attempts {
+		result := results[attempt.InstanceID]
+		if result == nil {
+			result = map[string]interface{}{"id": attempt.InstanceID, "title": attempt.Title}
+		}
+		if attempt.Skipped {
+			result["success"] = true
+			result["skipped"] = true
+			result["reason"] = attempt.SkipReason
+		}
+		if attempt.AuthDeath {
+			result["auth_death"] = true
+		}
+		ordered = append(ordered, result)
+	}
+	return ordered
+}
+
+func restartAllSessionsJSONPayload(total int, sweepResult session.BootSweepResult, sessions []map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"success":      restartAllSessionsExitCode(sweepResult) == 0,
+		"total":        total,
+		"restarted":    sweepResult.Booted,
+		"failed":       sweepResult.Failed,
+		"skipped_auth": sweepResult.SkippedHeld,
+		"auth_deaths":  sweepResult.AuthDeaths,
+		"abandoned":    sweepResult.Abandoned,
+		"auth_tripped": sweepResult.Tripped,
+		"trip_message": sweepResult.TripMessage,
+		"sessions":     sessions,
+	}
+}
+
+func restartAllSessionsExitCode(sweepResult session.BootSweepResult) int {
+	if sweepResult.Failed > 0 || sweepResult.Tripped {
+		return 1
+	}
+	return 0
+}

--- a/cmd/agent-deck/session_restart_all_test.go
+++ b/cmd/agent-deck/session_restart_all_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestRestartAllSessionsJSONPayload_reportsSkippedAuthAndTrip(t *testing.T) {
+	results := map[string]map[string]interface{}{
+		"booted": {"id": "booted", "title": "booted", "success": true},
+	}
+	sweepResult := session.BootSweepResult{
+		Attempts: []session.BootAttempt{
+			{InstanceID: "held", Title: "held", Skipped: true, SkipReason: "held: run /login"},
+			{InstanceID: "booted", Title: "booted", AuthDeath: true},
+			{InstanceID: "left", Title: "left", Skipped: true, SkipReason: "circuit tripped: preceding boots died on authentication"},
+		},
+		Booted:      1,
+		SkippedHeld: 1,
+		AuthDeaths:  1,
+		Abandoned:   1,
+		Tripped:     true,
+		TripMessage: "STOPPED after auth deaths",
+	}
+
+	sessions := restartAllSessionRecords(results, sweepResult.Attempts)
+	payload := restartAllSessionsJSONPayload(3, sweepResult, sessions)
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	var got struct {
+		Success     bool `json:"success"`
+		Total       int  `json:"total"`
+		Restarted   int  `json:"restarted"`
+		SkippedAuth int  `json:"skipped_auth"`
+		AuthDeaths  int  `json:"auth_deaths"`
+		Abandoned   int  `json:"abandoned"`
+		AuthTripped bool `json:"auth_tripped"`
+		Sessions    []struct {
+			ID        string `json:"id"`
+			Title     string `json:"title"`
+			Success   bool   `json:"success"`
+			Skipped   bool   `json:"skipped"`
+			Reason    string `json:"reason"`
+			AuthDeath bool   `json:"auth_death"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, encoded)
+	}
+
+	if got.Success {
+		t.Fatal("tripped restart-all JSON must report success=false")
+	}
+	if got.Total != 3 || got.Restarted != 1 || got.SkippedAuth != 1 || got.AuthDeaths != 1 || got.Abandoned != 1 || !got.AuthTripped {
+		t.Fatalf("summary counters did not round-trip: %+v", got)
+	}
+	if len(got.Sessions) != 3 {
+		t.Fatalf("sessions length = %d, want 3", len(got.Sessions))
+	}
+	if got.Sessions[0].ID != "held" || !got.Sessions[0].Success || !got.Sessions[0].Skipped || got.Sessions[0].Reason != "held: run /login" {
+		t.Fatalf("held skip record missing machine-readable reason: %+v", got.Sessions[0])
+	}
+	if got.Sessions[1].ID != "booted" || !got.Sessions[1].Success || !got.Sessions[1].AuthDeath {
+		t.Fatalf("auth-death record lost existing boot result: %+v", got.Sessions[1])
+	}
+	if got.Sessions[2].ID != "left" || !got.Sessions[2].Success || !got.Sessions[2].Skipped || got.Sessions[2].Reason == "" {
+		t.Fatalf("abandoned skip record missing reason: %+v", got.Sessions[2])
+	}
+}
+
+func TestRestartAllSessionsExitCode_reflectsFailuresAndAuthTrips(t *testing.T) {
+	tests := []struct {
+		name        string
+		sweepResult session.BootSweepResult
+		want        int
+	}{
+		{name: "all restarts clean", sweepResult: session.BootSweepResult{Booted: 2}, want: 0},
+		{name: "plain restart failure", sweepResult: session.BootSweepResult{Failed: 1}, want: 1},
+		{name: "auth circuit tripped", sweepResult: session.BootSweepResult{Tripped: true}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := restartAllSessionsExitCode(tt.sweepResult)
+			if got != tt.want {
+				t.Fatalf("exit code = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Pins the `session restart --all` incident-path output contract requested in #1745: JSON shape, non-zero exit-code conditions, and machine-readable skip reporting for auth-held/abandoned sessions.

## Why this change

`restartAllSessions` already had the runtime behavior, but the JSON/session-record folding and exit-code decision were embedded inside the command body. I extracted those pure pieces into a tiny helper file so the contract can be tested without spawning real tmux sessions or restarting user processes.

## User impact

None, internal test coverage only. Runtime behavior should be unchanged.

## Evidence

Passing local checks:

```bash
PATH=/home/c436zhan/oss-work/agent-deck-go-toolchain/go/bin:$PATH gofmt -l ./cmd ./internal
# no output

PATH=/home/c436zhan/oss-work/agent-deck-go-toolchain/go/bin:$PATH GOMODCACHE=/home/c436zhan/oss-work/agent-deck-go-modcache GOCACHE=/home/c436zhan/oss-work/agent-deck-go-buildcache go vet ./...
# no output

PATH=/home/c436zhan/oss-work/agent-deck-go-toolchain/go/bin:$PATH GOMODCACHE=/home/c436zhan/oss-work/agent-deck-go-modcache GOCACHE=/home/c436zhan/oss-work/agent-deck-go-buildcache HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./cmd/agent-deck -run 'TestRestartAllSessions' -count=1
# ok   github.com/asheshgoplani/agent-deck/cmd/agent-deck 0.073s

PATH=/home/c436zhan/oss-work/agent-deck-go-toolchain/go/bin:$PATH GOMODCACHE=/home/c436zhan/oss-work/agent-deck-go-modcache GOCACHE=/home/c436zhan/oss-work/agent-deck-go-buildcache HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test -race ./cmd/agent-deck -run 'TestRestartAllSessions' -count=1
# ok   github.com/asheshgoplani/agent-deck/cmd/agent-deck 1.093s

PATH=/home/c436zhan/oss-work/agent-deck-go-toolchain/go/bin:$PATH GOMODCACHE=/home/c436zhan/oss-work/agent-deck-go-modcache GOCACHE=/home/c436zhan/oss-work/agent-deck-go-buildcache go build ./cmd/agent-deck
# passed
```

I also ran the documented sandboxed full suite:

```bash
PATH=/home/c436zhan/oss-work/agent-deck-go-toolchain/go/bin:$PATH GOMODCACHE=/home/c436zhan/oss-work/agent-deck-go-modcache GOCACHE=/home/c436zhan/oss-work/agent-deck-go-buildcache HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...
```

It did not pass locally, but the failures were outside the changed package: `internal/session` (`TestIssue1580_FastDeathWatcherCapturesDyingOutput` missing `spawn_died_fast`), `internal/statedb` perf budget (`TestPerf_StateDB_InsertN` just over budget), `internal/testutil` bootstrap leak sentinel, and `internal/tmux` bootstrap/control-pipe failures. The changed package `cmd/agent-deck` passed within that run.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** openai/gpt-5.5

**Prompt / session log (optional):** not provided

## What actually bothered you

My human asked: "make sure you don't use the `Plan` subagent please as it is known to be not working"

The issue itself asked to pin `restartAllSessions` JSON output, exit code, and skip reporting after the #1743 incident-path rewrite.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=openai/gpt-5.5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `restart-all` result reporting for skipped sessions, authentication failures, and circuit-trip conditions.
  * Standardized JSON output with complete session details and aggregate restart statistics.
  * Ensured command exit codes consistently reflect restart failures and authentication circuit trips.

* **Tests**
  * Added coverage for JSON output fields, summary counters, skip reasons, authentication details, and exit-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->