### PR TITLE
chore(hygiene): reaper covers eval bins + wider socket families, with a DRY_RUN smoke test and a fixed launchd deployment

### DIFF
--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -21,6 +21,8 @@ on:
       - 'internal/session/instance.go'
       - 'internal/feedback/**'
       - 'internal/session/userconfig.go'
+      - 'scripts/reap-stale-tmux.sh'
+      - 'tests/ci/reap-stale-tmux.test.sh'
       - '.github/workflows/eval-smoke.yml'
       - 'go.mod'
       - 'go.sum'
@@ -67,3 +69,28 @@ jobs:
         run: |
           go test -tags eval_smoke -race -count=1 -timeout 3m \
             ./tests/eval/... ./internal/ui/...
+
+  # The hygiene half of the same problem: scripts/reap-stale-tmux.sh cleans up
+  # what leaks past this harness (test tmux servers, agent-deck-eval-bin
+  # processes). It is also the script that killed the whole session fleet twice
+  # on 2026-07-26 by matching processes on argv, so issue #1744 makes a green
+  # DRY_RUN smoke test the precondition for ever re-enabling the launchd job.
+  #
+  # No Go, no toolchain: the test is pure bash and seeds its own sandbox.
+  reaper-smoke:
+    name: reap-stale-tmux.sh DRY_RUN smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # tmux ships on ubuntu-latest; assert it rather than let the test degrade
+      # to skipping every socket-family assertion.
+      - name: Verify tmux available
+        run: |
+          which tmux
+          tmux -V
+
+      - name: Run reaper DRY_RUN smoke test
+        run: bash tests/ci/reap-stale-tmux.test.sh

--- a/docs/tmux-reaper.md
+++ b/docs/tmux-reaper.md
@@ -1,0 +1,146 @@
+# The tmux/eval reaper (maintainer hosts only)
+
+`scripts/reap-stale-tmux.sh` cleans up what leaks out of the test suite on a
+machine that runs it a lot:
+
+- **test tmux servers.** A leaked server holds one pty per pane. Enough of them
+  and the host's pty pool runs dry — roughly 50 leaked servers once held 507 of
+  511 ptys and every `tmux attach` on the machine failed with
+  `fork failed: Device not configured`.
+- **leaked eval binaries.** A `tests/eval` invocation that starts the TUI and
+  never exits leaves an `agent-deck` process running out of its
+  `agent-deck-eval-bin-*` temp dir, polling forever. Four of those were found
+  running for eleven days in one sweep (#1747).
+
+It is **not** part of the product, it is **not** installed by
+`install.sh`, and it is **off by default**. Nothing in agent-deck needs it; it
+exists for hosts that accumulate this debt.
+
+## Why it is opt-in, and gated
+
+The reaper's earlier version identified tmux servers by process name
+(`pgrep -fx "tmux -C"`). On macOS a process keeps the argv it was exec'd with,
+so the *default-socket server* auto-started by a bare `tmux -C` client was
+itself named exactly `tmux -C` — the main server wearing a client's name. The
+hourly job matched it and killed it. Every live session on the host died at
+once, twice in one day.
+
+The rewrite (#1736) replaced name matching with **path** matching, which is the
+only identity that cannot be spoofed by a process's own argv:
+
+| Target | Identity used | Never used |
+| --- | --- | --- |
+| tmux server | socket path (`tmux -S <sock> list-sessions`, then `kill-server` through the same path) | pid, process name, argv, `pgrep`/`pkill` |
+| leaked eval binary | executing image path (`/proc/<pid>/exe` on Linux, lsof's `txt` descriptor on darwin) | `ps -o comm`, argv, basename |
+
+Two consequences worth knowing:
+
+- The socket named `default` is filtered out by name, in the candidate list
+  itself, so it cannot be reached even if it somehow appears under a swept dir.
+- A leaked eval binary whose temp dir has already been deleted is **not**
+  reaped. Without the on-disk path there is no path-based identity left, and
+  falling back to a name match is exactly the mistake that killed the fleet.
+
+## What it reaps
+
+Scan roots: `$TMUX_TMPDIR`, `/tmp`, `$TMPDIR` (deduplicated, symlinks
+resolved). Go's `os.MkdirTemp("")` uses `$TMPDIR`, which on darwin is a
+per-user `/var/folders/...` path, so both places have to be swept.
+
+| Family | Where | Minted by |
+| --- | --- | --- |
+| `ad1031-*` | `<root>/tmux-<uid>/` | issue-1031 launch-race tests |
+| `ad-attach-*` | `<root>/tmux-<uid>/` | `tests/eval/session` attach/restart isolation |
+| `ad-fork-*` | `<root>/tmux-<uid>/` | `tests/eval/session` fork-PI isolation |
+| `ad-tmux-*/`, `ad-sock-*/`, `agent-deck-test-sock-*/` | `<root>/` | `testutil.IsolateTmuxSocket` / `ShortTmuxSocket` |
+| `agent-deck-eval-bin-*/agent-deck` | `<root>/` | `tests/eval/harness` build dir |
+
+Every name is a test-only convention. Eval-bin processes are additionally
+required to be older than `AGENT_DECK_EVAL_BIN_MAX_AGE_SECONDS` (default 1 day)
+and owned by the current uid.
+
+## Knobs
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `DRY_RUN` | `0` | `1` logs every kill it *would* make and kills nothing. Also mirrors the log to stderr. |
+| `AGENT_DECK_REAPER_LOG` | `$HOME/.agent-deck/logs/tmux-reaper.log` | Log file. Falls back to `$TMPDIR` with a warning when `HOME` is unset. |
+| `AGENT_DECK_EVAL_BIN_MAX_AGE_SECONDS` | `86400` | Minimum age before a leaked eval binary is killed. |
+| `AGENT_DECK_PTY_WARN_THRESHOLD` | `400` | Log (and notify) when pty usage exceeds this. |
+| `AGENT_DECK_REAPER_TMP_ROOTS` | unset | Colon-separated list that **replaces** the default scan roots. Used by the smoke test to confine the script to its own sandbox. |
+
+`--list-candidates` prints the target set and exits without probing or killing:
+
+```
+socket /tmp/ad-tmux-9f2a/tmux-501/s
+evalbin 41207 1039288 /var/folders/.../agent-deck-eval-bin-8123/agent-deck
+```
+
+## Re-enabling it safely
+
+The gate from #1744: **the smoke test must be green before the job runs
+unattended.**
+
+1. **CI must be green** on the `reap-stale-tmux.sh DRY_RUN smoke` job
+   (`.github/workflows/eval-smoke.yml`, backed by
+   `tests/ci/reap-stale-tmux.test.sh`). It seeds a live tmux server per socket
+   family inside one throwaway sandbox, plus a decoy server named `default` and
+   a same-named-but-wrong-path process, and asserts that every family is found,
+   that no default socket is ever a target, and that `DRY_RUN` kills nothing.
+
+2. **Run the same test locally on the machine you are enabling it on** — the
+   darwin identity path (lsof) is a different code path from Linux CI:
+
+   ```bash
+   bash tests/ci/reap-stale-tmux.test.sh
+   ```
+
+3. **Dry-run by hand** and read the output before any plist exists:
+
+   ```bash
+   DRY_RUN=1 bash scripts/reap-stale-tmux.sh --list-candidates
+   DRY_RUN=1 bash scripts/reap-stale-tmux.sh
+   tail -20 ~/.agent-deck/logs/tmux-reaper.log
+   ```
+
+   Confirm with your own eyes that your live agent-deck sockets are not in the
+   list. `agent-deck list` should be unchanged afterwards.
+
+4. **Install the plist** from `scripts/launchd/com.agent-deck.tmux-reaper.plist.example`,
+   with `DRY_RUN=1` still set:
+
+   ```bash
+   sed "s#/Users/REPLACE_ME#$HOME#g" \
+     scripts/launchd/com.agent-deck.tmux-reaper.plist.example \
+     > ~/Library/LaunchAgents/com.agent-deck.tmux-reaper.plist
+   launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.agent-deck.tmux-reaper.plist
+   launchctl kickstart -k "gui/$(id -u)/com.agent-deck.tmux-reaper"
+   tail -20 ~/.agent-deck/logs/tmux-reaper.log
+   ```
+
+5. **Observe for a week.** Only then remove the `DRY_RUN` entry from the plist
+   and reload it. An hourly job that kills things is worth having only after a
+   week of evidence that it names the right targets.
+
+Disable at any time:
+
+```bash
+launchctl bootout "gui/$(id -u)/com.agent-deck.tmux-reaper"
+launchctl disable "gui/$(id -u)/com.agent-deck.tmux-reaper"
+```
+
+If you previously installed a personally-labelled version of this job, boot out
+that label too — two reapers on one host is one reaper too many.
+
+## Changing the script
+
+Any change to the rules is a change to something that can kill every session on
+a developer's machine. The bar:
+
+- Add the new family to `tests/ci/reap-stale-tmux.test.sh` **first**, seeded as
+  a live server, and watch it fail.
+- Never introduce a name/argv match, not even as a fallback. If path identity is
+  unavailable, the correct behaviour is to skip and log — which is what the
+  script does.
+- Keep `DRY_RUN` covering every phase. A phase that ignores `DRY_RUN` is a phase
+  nobody can review before it runs.

--- a/scripts/launchd/com.agent-deck.tmux-reaper.plist.example
+++ b/scripts/launchd/com.agent-deck.tmux-reaper.plist.example
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Example launchd agent for scripts/reap-stale-tmux.sh (macOS maintainer hosts).
+
+  Copy to ~/Library/LaunchAgents/com.agent-deck.tmux-reaper.plist, replace every
+  REPLACE_ME with your short username, and read docs/tmux-reaper.md BEFORE
+  loading it. The reaper is opt-in and stays unloaded until that checklist is
+  satisfied.
+
+  What was wrong with the plist this replaces:
+
+    * No EnvironmentVariables at all. launchd hands an agent almost no
+      environment, so $HOME was empty, the script's default log path expanded to
+      "/.agent-deck/logs/tmux-reaper.log", every append failed, and the job ran
+      hourly for weeks with no record of what it did. When it eventually killed
+      the whole session fleet there was nothing to read.
+    * No StandardOutPath / StandardErrPath, so anything the script printed
+      outside its own log — including shell errors — went nowhere.
+    * RunAtLoad true, which means a mistake in the rules reaches every server on
+      the host the moment the plist is loaded, before any dry run.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agent-deck.tmux-reaper</string>
+
+  <!-- Absolute paths only: launchd provides no useful PATH. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/REPLACE_ME/.agent-deck/scripts/reap-stale-tmux.sh</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- The script's default log path is built from HOME. Set it explicitly;
+         without it the log silently goes nowhere. -->
+    <key>HOME</key>
+    <string>/Users/REPLACE_ME</string>
+    <!-- tmux is what identifies and kills servers; lsof (/usr/sbin) is what
+         proves which executable a pid is running on darwin. Both must be
+         reachable or the corresponding phase is skipped. -->
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <!-- Observation period: log every target, kill nothing. Start here, read a
+         week of logs, and only then remove these two lines. -->
+    <key>DRY_RUN</key>
+    <string>1</string>
+  </dict>
+
+  <!-- Anything the script writes outside its own log lands here instead of
+       being discarded. -->
+  <key>StandardOutPath</key>
+  <string>/Users/REPLACE_ME/.agent-deck/logs/tmux-reaper.out.log</string>
+  <key>StandardErrPath</key>
+  <string>/Users/REPLACE_ME/.agent-deck/logs/tmux-reaper.err.log</string>
+
+  <key>WorkingDirectory</key>
+  <string>/tmp</string>
+
+  <key>StartInterval</key>
+  <integer>3600</integer>
+
+  <!-- Deliberately false: a load should not immediately sweep the host. Trigger
+       the first pass by hand (`launchctl kickstart -k gui/$(id -u)/com.agent-deck.tmux-reaper`)
+       once you have read the dry-run output. -->
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/reap-stale-tmux.sh
+++ b/scripts/reap-stale-tmux.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 #
-# reap-stale-tmux.sh — reap leaked agent-deck TEST tmux servers.
+# reap-stale-tmux.sh — reap leaked agent-deck TEST tmux servers and leaked
+# eval-harness binaries.
 #
 # Test-spawned tmux servers outlive `go test` and hold one pty per pane. Enough
 # of them and the host's pty pool runs dry: on 2026-07-18 roughly 50 leaked
 # servers held 507 of 511 ptys and every attach on the machine failed with
 # "fork failed: Device not configured".
 #
+# Leaked eval binaries are the same class of debt with a different shape: a
+# `tests/eval` invocation that starts the TUI and never exits leaves an
+# `agent-deck` process running out of its `agent-deck-eval-bin-*` temp dir,
+# polling forever. A 2026-07-26 host sweep found four of them running since
+# mid-July alongside eight leaked test tmux servers (#1747).
+#
 #
 # ─── THE ONE RULE ────────────────────────────────────────────────────────────
 #
-# Identify servers by SOCKET PATH. Never by process name, never by argv, never
-# by pgrep/pkill.
+# Identify what to kill by PATH. Never by process name, never by argv, never by
+# pgrep/pkill.
+#
+# For tmux servers the path is the SOCKET PATH. For eval binaries it is the
+# EXECUTABLE PATH, read from the kernel (`/proc/<pid>/exe`, or lsof's `txt`
+# descriptor on darwin) — never from argv, and never from `ps -o comm`.
 #
 # A previous version of this script reaped `pgrep -fx "tmux -C"`, reasoning that
 # genuine control clients are `tmux -C attach-session ...` and so could not
@@ -25,96 +36,330 @@
 # On 2026-07-26 at 13:35:04 this script matched three processes. One of them was
 # the main tmux server. All ~65 live agent-deck sessions died at once.
 #
-# Argv is not identity. A socket path is: it says which server, and the probe
-# that reads it (`tmux -S <sock> list-sessions`) is the same call that proves
-# the server is reachable before anything is killed.
+# Argv is not identity. A path is: it says which server or which image, and the
+# probe that reads it (`tmux -S <sock> list-sessions`, `readlink /proc/<pid>/exe`)
+# is the same call that proves the target is real before anything is killed.
 #
 #
 # ─── WHAT IT REAPS ───────────────────────────────────────────────────────────
 #
-#   1. ad1031-*  — sockets from the issue-1031 launch-race tests, under tmux's
-#                  default base dir (the tests strip TMUX* from their children).
-#   2. /tmp/ad-tmux-*/  and  /tmp/ad-sock-*/  — per-run socket dirs from
-#                  testutil.IsolateTmuxSocket / ShortTmuxSocket.
+# tmux servers, by socket path, under every scan root (see SCAN ROOTS):
 #
-# Both are minted exclusively by tests. The default socket (`default`) is
-# excluded explicitly and by construction; so is every socket this script was
-# not told about.
+#   1. <root>/tmux-<uid>/ad1031-*    — issue-1031 launch-race tests.
+#   2. <root>/tmux-<uid>/ad-attach-* — tests/eval attach/restart isolation.
+#   3. <root>/tmux-<uid>/ad-fork-*   — tests/eval fork-PI isolation.
+#      (2 and 3 are `[tmux] socket_name` values the eval tests write into a
+#      sandbox config, i.e. `tmux -L <name>`, so they land in the default base
+#      dir the same way ad1031-* does.)
+#   4. <root>/ad-tmux-*/  <root>/ad-sock-*/  <root>/agent-deck-test-sock-*/
+#      — per-run socket dirs from testutil.IsolateTmuxSocket / ShortTmuxSocket
+#      (and the latter's fallback name).
 #
-# Set DRY_RUN=1 to log what would be reaped without killing anything.
+# Eval binaries, by executable path:
 #
-# Usage: reap-stale-tmux.sh
+#   5. <root>/agent-deck-eval-bin-*/agent-deck — processes whose executing image
+#      is one of these, older than AGENT_DECK_EVAL_BIN_MAX_AGE_SECONDS (1 day).
+#      A leak whose temp dir has already been deleted is deliberately NOT
+#      reaped: without the on-disk path there is no path-based identity left,
+#      and argv matching is what caused the 2026-07-26 fleet kill.
+#
+# Every name above is minted exclusively by tests. The default socket
+# (`default`) is excluded explicitly and by construction; so is every socket
+# and every process this script was not told about.
+#
+#
+# ─── SCAN ROOTS ──────────────────────────────────────────────────────────────
+#
+# $TMUX_TMPDIR, /tmp and $TMPDIR (deduplicated, symlinks resolved). tmux's
+# default base is $TMUX_TMPDIR else /tmp; Go's os.MkdirTemp("") — which mints
+# the eval-bin dirs — uses $TMPDIR, which on darwin is a per-user
+# /var/folders/... path. Both places therefore have to be swept.
+#
+# AGENT_DECK_REAPER_TMP_ROOTS (colon-separated) REPLACES that default set
+# entirely. It exists so the smoke test can point the whole script at its own
+# sandbox; nothing is appended to it.
+#
+#
+# ─── MODES ───────────────────────────────────────────────────────────────────
+#
+#   DRY_RUN=1            log every kill it would make, kill nothing.
+#   --list-candidates    print the target list and exit (no probing, no kills):
+#                          socket <path>
+#                          evalbin <pid> <age-seconds> <exe>
+#
+# Covered by tests/ci/reap-stale-tmux.test.sh — see docs/tmux-reaper.md before
+# re-enabling the launchd job.
+#
+# Usage: reap-stale-tmux.sh [--list-candidates]
 set -uo pipefail
 
-LOG="${AGENT_DECK_REAPER_LOG:-$HOME/.agent-deck/logs/tmux-reaper.log}"
+# HOME is not guaranteed: a launchd agent inherits almost no environment, and
+# the plist that ran this script until 2026-07-26 set none — so the default log
+# path expanded to "/.agent-deck/logs/..." and every line was silently dropped.
+# Fall back to a writable path and say so instead of logging into the void.
+# HOME itself is deliberately NOT set here: tmux would then read a config from
+# whatever fallback dir we picked (a world-writable /tmp/.tmux.conf is not a
+# thing this script should ever load).
+home_missing=0
+log_home="${HOME:-}"
+if [ -z "$log_home" ]; then
+  home_missing=1
+  log_home="${TMPDIR:-/tmp}"
+fi
+LOG="${AGENT_DECK_REAPER_LOG:-$log_home/.agent-deck/logs/tmux-reaper.log}"
 PTY_WARN_THRESHOLD="${AGENT_DECK_PTY_WARN_THRESHOLD:-400}"
+EVAL_BIN_MAX_AGE_SECONDS="${AGENT_DECK_EVAL_BIN_MAX_AGE_SECONDS:-86400}"
 DRY_RUN="${DRY_RUN:-0}"
+LIST_ONLY=0
+[ "${1:-}" = "--list-candidates" ] && LIST_ONLY=1
 
 mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
 ts() { date "+%F %T"; }
-log() { echo "$(ts) $*" >>"$LOG"; }
+# In DRY_RUN the same line goes to stderr, so an interactive dry run shows its
+# work without the caller having to tail the log. stdout stays clean because
+# --list-candidates writes its machine-readable list there.
+log() {
+  echo "$(ts) $*" >>"$LOG"
+  [ "$DRY_RUN" = "1" ] && echo "$(ts) $*" >&2
+  return 0
+}
 
-command -v tmux >/dev/null 2>&1 || exit 0
+[ "$home_missing" = "1" ] && log "WARNING HOME unset; logging to $LOG"
 
-# Resolve /tmp through any symlink before handing it to find. On macOS /tmp is
+uid=$(id -u)
+
+# Resolve a dir through any symlink before handing it to find. On macOS /tmp is
 # a symlink to private/tmp, and find(1) does not descend into a symlinked
 # starting point — searching "/tmp" directly silently matches nothing.
-tmp_root=$(cd /tmp 2>/dev/null && pwd -P) || tmp_root=/tmp
+resolve_dir() { (cd "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"; }
 
-# tmux's default socket base: $TMUX_TMPDIR, else /tmp. Sockets live one level
-# down in tmux-<uid>/. Resolve it from THIS script's env deliberately — the
-# leaking tests run with TMUX* stripped, so their servers land under /tmp.
-default_base="${TMUX_TMPDIR:-$tmp_root}/tmux-$(id -u)"
+scan_roots() {
+  if [ -n "${AGENT_DECK_REAPER_TMP_ROOTS:-}" ]; then
+    printf '%s\n' "${AGENT_DECK_REAPER_TMP_ROOTS//:/$'\n'}" |
+      while IFS= read -r root; do
+        [ -n "$root" ] && [ -d "$root" ] && resolve_dir "$root"
+      done
+    return
+  fi
+  for root in "${TMUX_TMPDIR:-}" /tmp "${TMPDIR:-}"; do
+    [ -n "$root" ] && [ -d "$root" ] && resolve_dir "$root"
+  done
+}
+
+# Deduplicate while preserving order; /tmp and $TMPDIR are the same dir on most
+# Linux hosts and there is no point sweeping it twice.
+roots=$(scan_roots | awk 'NF && !seen[$0]++')
+
+# Socket NAME families that live directly in a tmux base dir (`tmux -L <name>`).
+socket_name_families=('ad1031-*' 'ad-attach-*' 'ad-fork-*')
+# Per-run socket DIR families (`tmux -S <dir>/s` or TMUX_TMPDIR=<dir>).
+socket_dir_families=('ad-tmux-*' 'ad-sock-*' 'agent-deck-test-sock-*')
 
 # candidate_sockets prints every socket path eligible for reaping, one per line.
 # Everything here is a test-only naming convention; nothing else is listed, so
-# nothing else can be killed.
+# nothing else can be killed. The `default` filter lives in here rather than in
+# the reap loop so that --list-candidates shows exactly the final target set.
 candidate_sockets() {
-  # 1. issue-1031 launch-race test servers, by socket NAME under the default base.
-  find "$default_base" -maxdepth 1 -name 'ad1031-*' -type s 2>/dev/null
+  printf '%s\n' "$roots" | while IFS= read -r root; do
+    [ -n "$root" ] || continue
 
-  # 2. Per-run isolated socket dirs from the Go test helpers. The socket sits
-  #    either directly in the dir (ShortTmuxSocket, an explicit `-S <dir>/s`)
-  #    or one level down in tmux-<uid>/ (IsolateTmuxSocket, which points
-  #    TMUX_TMPDIR at the dir and lets tmux nest as usual).
-  find "$tmp_root" -maxdepth 1 -type d \
-    \( -name 'ad-tmux-*' -o -name 'ad-sock-*' \) 2>/dev/null |
-    while IFS= read -r dir; do
-      find "$dir" -maxdepth 2 -type s 2>/dev/null
+    # 1-3. By socket NAME under this root's tmux base dir.
+    for pattern in "${socket_name_families[@]}"; do
+      find "$root/tmux-$uid" -maxdepth 1 -type s -name "$pattern" 2>/dev/null
     done
+
+    # 4. Per-run isolated socket dirs from the Go test helpers. The socket sits
+    #    either directly in the dir (ShortTmuxSocket, an explicit `-S <dir>/s`)
+    #    or one level down in tmux-<uid>/ (IsolateTmuxSocket, which points
+    #    TMUX_TMPDIR at the dir and lets tmux nest as usual).
+    for pattern in "${socket_dir_families[@]}"; do
+      find "$root" -maxdepth 1 -type d -name "$pattern" 2>/dev/null |
+        while IFS= read -r dir; do
+          find "$dir" -maxdepth 2 -type s 2>/dev/null
+        done
+    done
+  done | while IFS= read -r sock; do
+    [ -n "$sock" ] || continue
+    # Never the default socket, whatever else may have matched.
+    [ "$(basename "$sock")" = "default" ] && continue
+    printf '%s\n' "$sock"
+  done | sort -u
 }
+
+# ─── eval-bin identity ───────────────────────────────────────────────────────
+
+# eval_bin_executables prints every on-disk eval binary under the scan roots.
+eval_bin_executables() {
+  printf '%s\n' "$roots" | while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    find "$root" -maxdepth 2 -type f \
+      -path "$root/agent-deck-eval-bin-*/agent-deck" 2>/dev/null
+  done | sort -u
+}
+
+# exe_matches reports whether pid $1 is EXECUTING the image at path $2, asking
+# the kernel — /proc/<pid>/exe on linux, lsof's txt descriptor on darwin. Never
+# argv, never `ps -o comm`.
+exe_matches() {
+  local pid="$1" exe="$2" path
+  if [ -d /proc/"$pid" ]; then
+    path=$(readlink "/proc/$pid/exe" 2>/dev/null) || return 1
+    [ "${path% (deleted)}" = "$exe" ]
+    return
+  fi
+  command -v lsof >/dev/null 2>&1 || return 1
+  # darwin lsof reports txt for mapped images too, so test membership rather
+  # than the first line — but only txt: a file the process merely has open
+  # must never qualify it as a target.
+  lsof -a -p "$pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | grep -qxF -- "$exe"
+}
+
+# path_identity_available reports whether this host can prove which image a pid
+# is running. Without it, eval-bin reaping is skipped entirely — there is no
+# argv fallback, by design.
+path_identity_available() {
+  [ -d /proc/$$ ] || command -v lsof >/dev/null 2>&1
+}
+
+# pids_for_exe prints pids whose executing image is exactly $1.
+pids_for_exe() {
+  local exe="$1" pid proc
+  if [ -d /proc/$$ ]; then
+    for proc in /proc/[0-9]*; do
+      pid=${proc#/proc/}
+      exe_matches "$pid" "$exe" && printf '%s\n' "$pid"
+    done
+    return 0
+  fi
+  # darwin: ask which pids hold this file open at all, then confirm each one is
+  # actually *executing* it.
+  lsof -t -- "$exe" 2>/dev/null | while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    exe_matches "$pid" "$exe" && printf '%s\n' "$pid"
+  done
+}
+
+# proc_age_seconds prints a pid's elapsed run time in seconds. `ps -o etime`
+# is the portable spelling (linux `etimes` does not exist on darwin) and comes
+# back as [[dd-]hh:]mm:ss.
+proc_age_seconds() {
+  local etime days=0 rest h=0 m=0 s=0 a b c
+  etime=$(ps -p "$1" -o etime= 2>/dev/null | tr -d '[:space:]') || return 1
+  [ -n "$etime" ] || return 1
+  rest="$etime"
+  case "$rest" in *-*)
+    days="${rest%%-*}"
+    rest="${rest#*-}"
+    ;;
+  esac
+  IFS=: read -r a b c <<<"$rest"
+  if [ -n "${c:-}" ]; then
+    h="$a" m="$b" s="$c"
+  else
+    m="${a:-0}" s="${b:-0}"
+  fi
+  printf '%s\n' "$((10#${days:-0} * 86400 + 10#${h:-0} * 3600 + 10#${m:-0} * 60 + 10#${s:-0}))"
+}
+
+# candidate_eval_bins prints "<pid> <age-seconds> <exe>" for every process that
+# is executing a leaked eval binary and is older than the age threshold.
+candidate_eval_bins() {
+  path_identity_available || return 0
+  local exe pid age
+  while IFS= read -r exe; do
+    [ -n "$exe" ] || continue
+    while IFS= read -r pid; do
+      [ -n "$pid" ] || continue
+      [ "$pid" = "$$" ] && continue
+      # Same-user only. The reaper never touches another account's processes.
+      [ "$(ps -p "$pid" -o uid= 2>/dev/null | tr -d '[:space:]')" = "$uid" ] || continue
+      age=$(proc_age_seconds "$pid") || continue
+      [ "$age" -ge "$EVAL_BIN_MAX_AGE_SECONDS" ] || continue
+      printf '%s %s %s\n' "$pid" "$age" "$exe"
+    done < <(pids_for_exe "$exe")
+  done < <(eval_bin_executables)
+}
+
+# ─── --list-candidates ───────────────────────────────────────────────────────
+
+# Announced in every mode, listing included, so a host that cannot prove which
+# image a pid runs says so instead of quietly reaping nothing.
+if ! path_identity_available; then
+  log "WARNING no path-based process identity available (no /proc, no lsof); skipping eval-bin reaping"
+fi
+
+if [ "$LIST_ONLY" = "1" ]; then
+  while IFS= read -r sock; do
+    [ -n "$sock" ] && printf 'socket %s\n' "$sock"
+  done < <(candidate_sockets)
+  while IFS= read -r line; do
+    [ -n "$line" ] && printf 'evalbin %s\n' "$line"
+  done < <(candidate_eval_bins)
+  exit 0
+fi
+
+# ─── reap: tmux servers ──────────────────────────────────────────────────────
 
 reaped=0
 skipped=0
-while IFS= read -r sock; do
-  [ -n "$sock" ] || continue
-  # Never the default socket, whatever else may have matched.
-  [ "$(basename "$sock")" = "default" ] && continue
+if command -v tmux >/dev/null 2>&1; then
+  while IFS= read -r sock; do
+    [ -n "$sock" ] || continue
 
-  # Probe by socket path. This both identifies the server and proves it is
-  # reachable; a stale socket file with no listener is silently dropped.
-  if ! sessions=$(tmux -S "$sock" list-sessions -F '#{session_name}' 2>/dev/null); then
-    skipped=$((skipped + 1))
-    continue
-  fi
-  count=$(printf '%s\n' "$sessions" | grep -c . || true)
+    # Probe by socket path. This both identifies the server and proves it is
+    # reachable; a stale socket file with no listener is silently dropped.
+    if ! sessions=$(tmux -S "$sock" list-sessions -F '#{session_name}' 2>/dev/null); then
+      skipped=$((skipped + 1))
+      continue
+    fi
+    count=$(printf '%s\n' "$sessions" | grep -c . || true)
 
-  if [ "$DRY_RUN" = "1" ]; then
-    log "DRY_RUN would reap $sock ($count session(s))"
-    reaped=$((reaped + 1))
-    continue
-  fi
+    if [ "$DRY_RUN" = "1" ]; then
+      log "DRY_RUN would reap $sock ($count session(s))"
+      reaped=$((reaped + 1))
+      continue
+    fi
 
-  # Kill through the SAME socket path we probed. No pid, no name, no argv.
-  if tmux -S "$sock" kill-server 2>/dev/null; then
-    log "reaped $sock ($count session(s))"
-    reaped=$((reaped + 1))
-  else
-    log "WARNING kill-server failed for $sock"
-  fi
-done < <(candidate_sockets | sort -u)
+    # Kill through the SAME socket path we probed. No pid, no name, no argv.
+    if tmux -S "$sock" kill-server 2>/dev/null; then
+      log "reaped $sock ($count session(s))"
+      reaped=$((reaped + 1))
+    else
+      log "WARNING kill-server failed for $sock"
+    fi
+  done < <(candidate_sockets)
+fi
 
-[ "$reaped" -gt 0 ] && log "reap pass complete: $reaped server(s) reaped, $skipped stale socket(s) ignored"
+# ─── reap: leaked eval binaries ──────────────────────────────────────────────
+
+killed_bins=0
+if path_identity_available; then
+  while read -r pid age exe; do
+    [ -n "${pid:-}" ] || continue
+    if [ "$DRY_RUN" = "1" ]; then
+      log "DRY_RUN would kill eval-bin pid $pid (age ${age}s, exe $exe)"
+      killed_bins=$((killed_bins + 1))
+      continue
+    fi
+    # TERM first so the TUI can restore the terminal, then KILL if it lingers.
+    kill -TERM "$pid" 2>/dev/null
+    for _ in 1 2 3 4 5; do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null
+      log "killed eval-bin pid $pid SIGKILL (age ${age}s, exe $exe)"
+    else
+      log "killed eval-bin pid $pid SIGTERM (age ${age}s, exe $exe)"
+    fi
+    killed_bins=$((killed_bins + 1))
+  done < <(candidate_eval_bins)
+fi
+
+if [ "$reaped" -gt 0 ] || [ "$killed_bins" -gt 0 ] || [ "$DRY_RUN" = "1" ]; then
+  log "reap pass complete: $reaped server(s) reaped, $skipped stale socket(s) ignored, $killed_bins eval-bin process(es) killed"
+fi
 
 # Early warning well before the host cap: leaks build slowly, so alert with
 # room to act rather than at the point of failure.

--- a/tests/ci/reap-stale-tmux.test.sh
+++ b/tests/ci/reap-stale-tmux.test.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+#
+# reap-stale-tmux.test.sh — DRY_RUN smoke test for scripts/reap-stale-tmux.sh.
+#
+# Issue #1744. This is the script class that killed the whole agent-deck fleet
+# twice on 2026-07-26 by matching processes on argv, so it does not get to run
+# unattended again without automated proof of two things:
+#
+#   1. it FINDS every test-only socket/process family it claims to reap, and
+#   2. it never, under any seeding, names the DEFAULT tmux socket as a target.
+#
+# Everything happens inside one mktemp sandbox. The script is pointed at that
+# sandbox through AGENT_DECK_REAPER_TMP_ROOTS, so the host's real socket dir
+# (${TMUX_TMPDIR:-/tmp}/tmux-<uid>) is not even in scope — and every invocation
+# passes DRY_RUN=1, so nothing anywhere is killed. The tmux servers this test
+# starts are its own, on explicit sandbox socket paths, and teardown kills each
+# one through the same socket path it started it with (never kill-server on the
+# default socket, never a pkill).
+#
+# Usage: tests/ci/reap-stale-tmux.test.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/reap-stale-tmux.sh"
+
+failures=0
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+skip() { echo "SKIP: $1"; }
+
+[ -f "$SCRIPT" ] || {
+  echo "FAIL: $SCRIPT not found" >&2
+  exit 1
+}
+bash -n "$SCRIPT" || {
+  echo "FAIL: $SCRIPT does not parse" >&2
+  exit 1
+}
+
+uid=$(id -u)
+
+# Resolve the sandbox through symlinks (/tmp -> /private/tmp on darwin): the
+# script resolves its roots the same way, and the assertions compare paths.
+# Keep the prefix short — unix socket paths cap at 104 bytes on darwin.
+sandbox=$(cd "$(mktemp -d /tmp/ad-reap-t.XXXXXX)" && pwd -P)
+root_a="$sandbox/a"
+root_b="$sandbox/b"
+log="$sandbox/reaper.log"
+mkdir -p "$root_a/tmux-$uid" "$root_b/tmux-$uid"
+
+# The one path that must never show up anywhere in the script's output.
+real_default="${TMUX_TMPDIR:-/tmp}/tmux-$uid/default"
+
+servers=()
+fake_pids=()
+
+tmux_q() { env -u TMUX -u TMUX_TMPDIR tmux "$@"; }
+
+cleanup() {
+  local rc=$?
+  local sock pid leaked=0
+  for sock in ${servers[@]+"${servers[@]}"}; do
+    tmux_q -S "$sock" kill-server >/dev/null 2>&1
+    # Do not discard the outcome: a surviving test server is exactly the leak
+    # this whole script exists to prevent.
+    if tmux_q -S "$sock" list-sessions >/dev/null 2>&1; then
+      echo "FAIL: leaked test tmux server at $sock" >&2
+      leaked=1
+    fi
+  done
+  for pid in ${fake_pids[@]+"${fake_pids[@]}"}; do
+    kill -KILL "$pid" 2>/dev/null
+  done
+  case "$sandbox" in
+  /tmp/ad-reap-t.* | /private/tmp/ad-reap-t.*) rm -rf "$sandbox" ;;
+  *) echo "WARNING refusing to remove unexpected sandbox path $sandbox" >&2 ;;
+  esac
+  [ "$leaked" = "1" ] && [ "$rc" = "0" ] && rc=1
+  exit "$rc"
+}
+trap cleanup EXIT
+
+# start_server brings up a real tmux server on an explicit sandbox socket path.
+start_server() {
+  local sock="$1"
+  mkdir -p "$(dirname "$sock")"
+  if ! tmux_q -S "$sock" new-session -d -s smoke "sleep 900" 2>/dev/null; then
+    return 1
+  fi
+  servers+=("$sock")
+}
+
+# ── seed: one live server per socket family the script claims to reap ────────
+
+if ! command -v tmux >/dev/null 2>&1; then
+  skip "tmux not on PATH — socket families not exercised"
+  tmux_present=0
+else
+  tmux_present=1
+fi
+
+# Socket NAME families, in a tmux base dir (what `tmux -L <name>` produces).
+sock_ad1031="$root_a/tmux-$uid/ad1031-smoke"
+sock_adattach="$root_a/tmux-$uid/ad-attach-smoke"
+sock_adfork="$root_b/tmux-$uid/ad-fork-smoke"
+# Socket DIR families (testutil.IsolateTmuxSocket / ShortTmuxSocket).
+sock_adtmux="$root_a/ad-tmux-smoke/tmux-$uid/s"
+sock_adsock="$root_a/ad-sock-smoke/s"
+sock_testsock="$root_a/agent-deck-test-sock-smoke/s"
+# Decoys named `default`: one inside a reaped DIR family (where the dir scan
+# lists every socket it finds, so only the name filter can save it) and one in
+# a tmux base dir. Neither may ever be a target.
+sock_default_in_family="$root_a/ad-tmux-smoke/tmux-$uid/default"
+sock_default_in_base="$root_a/tmux-$uid/default"
+
+expected_targets=(
+  "$sock_ad1031"
+  "$sock_adattach"
+  "$sock_adfork"
+  "$sock_adtmux"
+  "$sock_adsock"
+  "$sock_testsock"
+)
+forbidden_targets=(
+  "$sock_default_in_family"
+  "$sock_default_in_base"
+  "$real_default"
+)
+
+seeded=0
+if [ "$tmux_present" = "1" ]; then
+  for sock in "${expected_targets[@]}" "$sock_default_in_family" "$sock_default_in_base"; do
+    if start_server "$sock"; then
+      seeded=$((seeded + 1))
+    else
+      fail "could not start sandbox tmux server at $sock"
+    fi
+  done
+fi
+
+# A socket FILE with no server behind it: must be ignored, never reported as a
+# reap. Bound and closed by python3; the file survives the process.
+stale_sock="$root_a/ad-sock-stale/s"
+mkdir -p "$(dirname "$stale_sock")"
+if command -v python3 >/dev/null 2>&1 &&
+  python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1]); s.close()' "$stale_sock" 2>/dev/null; then
+  stale_seeded=1
+else
+  stale_seeded=0
+  skip "python3 unavailable — stale-socket case not exercised"
+fi
+
+# ── seed: a leaked eval binary, plus a same-named decoy elsewhere ────────────
+#
+# Both fakes are named `agent-deck`; only one of them sits in an
+# agent-deck-eval-bin-* dir. That is the 2026-07-26 lesson as an assertion:
+# identity is the executable path, never the process name.
+#
+# The binary is compiled rather than copied from /bin/sleep: darwin SIGKILLs a
+# copy of a platform binary on exec (code signing), so a copy cannot stand in
+# for a long-lived leak there. cp is kept as a fallback for hosts with no
+# compiler, and the launch is verified either way.
+
+# Can this host prove which image a pid is running? Mirrors the script's own
+# test; without it the script skips eval-bin reaping by design.
+if [ -d /proc/$$ ] || command -v lsof >/dev/null 2>&1; then
+  identity_ok=1
+else
+  identity_ok=0
+fi
+
+cc_bin=$(command -v cc || command -v clang || command -v gcc || true)
+sleep_bin=$(command -v sleep || true)
+eval_exe="$root_a/agent-deck-eval-bin-smoke/agent-deck"
+decoy_exe="$root_a/not-an-eval-bin/agent-deck"
+eval_pid=""
+decoy_pid=""
+
+cat >"$sandbox/fake.c" <<'EOF'
+#include <unistd.h>
+int main(void) {
+  for (;;) {
+    sleep(60);
+  }
+  return 0;
+}
+EOF
+
+make_fake_bin() {
+  local dest="$1"
+  mkdir -p "$(dirname "$dest")"
+  if [ -n "$cc_bin" ] && "$cc_bin" -o "$dest" "$sandbox/fake.c" 2>/dev/null && [ -x "$dest" ]; then
+    return 0
+  fi
+  [ -n "$sleep_bin" ] || return 1
+  cp "$sleep_bin" "$dest" 2>/dev/null && chmod +x "$dest" && return 0
+  return 1
+}
+
+# launch_fake starts $1 and prints its pid, or nothing if it did not survive.
+launch_fake() {
+  local exe="$1" pid
+  # stdout must not be the caller's command-substitution pipe: the fake outlives
+  # this function and would hold the pipe open forever.
+  "$exe" 900 >/dev/null 2>&1 &
+  pid=$!
+  # Give the kernel a moment to reject an unsigned/copied image before
+  # treating the process as a usable stand-in.
+  sleep 0.5
+  if kill -0 "$pid" 2>/dev/null; then
+    printf '%s\n' "$pid"
+    return 0
+  fi
+  wait "$pid" 2>/dev/null
+  return 1
+}
+
+if make_fake_bin "$eval_exe"; then
+  eval_pid=$(launch_fake "$eval_exe" || true)
+  [ -n "$eval_pid" ] && fake_pids+=("$eval_pid")
+fi
+if make_fake_bin "$decoy_exe"; then
+  decoy_pid=$(launch_fake "$decoy_exe" || true)
+  [ -n "$decoy_pid" ] && fake_pids+=("$decoy_pid")
+fi
+
+# ── invoke ───────────────────────────────────────────────────────────────────
+
+# Every run is DRY_RUN, scoped to the sandbox roots, logging into the sandbox,
+# with the pty warning silenced so a busy CI host cannot add noise. $eval_age
+# is the age gate under test and is set by each caller.
+eval_age=86400
+run_reaper() {
+  env -u TMUX -u TMUX_TMPDIR \
+    AGENT_DECK_REAPER_TMP_ROOTS="$root_a:$root_b" \
+    AGENT_DECK_REAPER_LOG="$log" \
+    AGENT_DECK_PTY_WARN_THRESHOLD=1000000 \
+    AGENT_DECK_EVAL_BIN_MAX_AGE_SECONDS="$eval_age" \
+    DRY_RUN=1 \
+    bash "$SCRIPT" "$@"
+}
+
+# 1. Candidate listing, eval-bin age gate wide open so the fresh fake counts.
+eval_age=0
+listing=$(run_reaper --list-candidates 2>/dev/null)
+
+if [ "$tmux_present" = "1" ] && [ "$seeded" -gt 0 ]; then
+  for sock in "${expected_targets[@]}"; do
+    if grep -qxF "socket $sock" <<<"$listing"; then
+      pass "lists $(basename "$(dirname "$sock")")/$(basename "$sock")"
+    else
+      fail "socket family not listed as a target: $sock"
+    fi
+  done
+fi
+
+for sock in "${forbidden_targets[@]}"; do
+  if grep -qF -- "$sock" <<<"$listing"; then
+    fail "default socket listed as a target: $sock"
+  else
+    pass "never targets default socket: $sock"
+  fi
+done
+
+# Nothing outside the sandbox may appear at all — the strongest form of "the
+# host's real sockets are out of scope".
+outside_re="^socket $sandbox/|^evalbin [0-9]+ [0-9]+ $sandbox/"
+outside=$(grep -Ev "$outside_re" <<<"$listing" | grep -c . || true)
+if [ "$outside" = "0" ]; then
+  pass "every target lives under the sandbox roots"
+else
+  fail "listing contains $outside target(s) outside the sandbox:"
+  grep -Ev "$outside_re" <<<"$listing" >&2
+fi
+
+if [ "$stale_seeded" = "1" ]; then
+  if grep -qxF "socket $stale_sock" <<<"$listing"; then
+    pass "stale socket file is a candidate (reachability is decided by probe)"
+  else
+    fail "stale socket file missing from candidates: $stale_sock"
+  fi
+fi
+
+# 2. eval-bin identity: matched by executable path, not by process name.
+if [ "$identity_ok" = "0" ]; then
+  skip "host has neither /proc nor lsof — eval-bin identity not exercised"
+elif [ -z "$eval_pid" ]; then
+  skip "could not launch a fake eval binary — eval-bin cases not exercised"
+elif grep -qE "^evalbin $eval_pid [0-9]+ $eval_exe$" <<<"$listing"; then
+  pass "leaked eval binary listed by executable path (pid $eval_pid)"
+else
+  fail "leaked eval binary not listed: pid $eval_pid exe $eval_exe"
+fi
+
+if [ -n "$decoy_pid" ] && [ "$identity_ok" = "1" ]; then
+  if grep -qF "evalbin $decoy_pid " <<<"$listing"; then
+    fail "process matched by NAME, not path: decoy pid $decoy_pid ($decoy_exe)"
+  else
+    pass "same-named process outside an eval-bin dir is never a target"
+  fi
+fi
+
+# 3. The age gate: with the production threshold the fresh fake is too young.
+eval_age=86400
+young=$(run_reaper --list-candidates 2>/dev/null | grep -c '^evalbin ' || true)
+if [ -n "$eval_pid" ] && [ "$identity_ok" = "1" ]; then
+  if [ "$young" = "0" ]; then
+    pass "eval-bin age gate spares processes younger than the threshold"
+  else
+    fail "age gate ignored: $young eval-bin target(s) at the 1-day threshold"
+  fi
+fi
+
+# 4. Full DRY_RUN pass: log every kill it would make, kill nothing.
+: >"$log"
+eval_age=0
+run_reaper >/dev/null 2>&1
+log_body=$(cat "$log" 2>/dev/null || true)
+
+if [ "$tmux_present" = "1" ] && [ "$seeded" -gt 0 ]; then
+  for sock in "${expected_targets[@]}"; do
+    if grep -qF "DRY_RUN would reap $sock " <<<"$log_body"; then
+      pass "DRY_RUN reports $sock"
+    else
+      fail "DRY_RUN did not report reachable target $sock"
+    fi
+  done
+  if grep -qE "DRY_RUN would reap .*/default " <<<"$log_body"; then
+    fail "DRY_RUN reported a default socket as a reap target"
+  else
+    pass "DRY_RUN never reports a default socket"
+  fi
+  if grep -qE "^[0-9-]+ [0-9:]+ reaped " <<<"$log_body"; then
+    fail "DRY_RUN logged a real reap"
+  else
+    pass "DRY_RUN logs no real reap"
+  fi
+  # The seeded servers must all still be up: DRY_RUN kills nothing.
+  alive=0
+  for sock in "${servers[@]}"; do
+    tmux_q -S "$sock" list-sessions >/dev/null 2>&1 && alive=$((alive + 1))
+  done
+  if [ "$alive" = "$seeded" ]; then
+    pass "DRY_RUN killed nothing ($alive/$seeded sandbox servers still up)"
+  else
+    fail "DRY_RUN killed servers: only $alive/$seeded still up"
+  fi
+fi
+
+if [ -n "$eval_pid" ] && [ "$identity_ok" = "1" ]; then
+  if grep -qF "DRY_RUN would kill eval-bin pid $eval_pid " <<<"$log_body"; then
+    pass "DRY_RUN reports the leaked eval binary"
+  else
+    fail "DRY_RUN did not report leaked eval-bin pid $eval_pid"
+  fi
+  if kill -0 "$eval_pid" 2>/dev/null; then
+    pass "DRY_RUN left the eval-bin process running"
+  else
+    fail "DRY_RUN killed the eval-bin process"
+  fi
+fi
+
+if grep -qF "reap pass complete" <<<"$log_body"; then
+  pass "DRY_RUN writes a summary line"
+else
+  fail "DRY_RUN wrote no summary line"
+fi
+
+# The default socket path, in any form, must not appear in the log either.
+if grep -qF -- "$real_default" <<<"$log_body"; then
+  fail "log mentions the real default socket path: $real_default"
+else
+  pass "log never mentions the real default socket path"
+fi
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "$failures check(s) failed" >&2
+  exit 1
+fi
+echo "all reap-stale-tmux.sh smoke checks passed"


### PR DESCRIPTION
## What problem does this solve?

Two follow-ups from the tmux/pty-exhaustion incident family, in one change
because they are the same artifact: the reaper script and the test that is
supposed to make it trustworthy.

**Leaks the reaper could not see (#1747).** A host-health sweep on 2026-07-26
found, accumulated over ~13 days: four `agent-deck-eval-bin` TUI instances
running from temp dirs since mid-July and polling constantly, eight leaked test
tmux servers, ~40 stale sockets and 137 ptys in use — the same shape as the
July-18 pty exhaustion where ~50 leaked servers held 507 of 511 ptys and every
`tmux attach` on the machine failed with `fork failed: Device not configured`.
The reaper knew only `ad1031-*` plus `ad-tmux-*`/`ad-sock-*` dirs under `/tmp`,
and did not look at processes at all.

**No coverage on the script that killed the fleet (#1744).** The rewritten
reaper (#1736) had no automated test — and this is the exact script class that
killed every live session on a developer machine twice on 2026-07-26 by matching
processes on argv. `#1744`'s gate: the launchd job stays unloaded until a
DRY_RUN smoke test passes.

## Why this change

### 1. Wider families, and processes (`scripts/reap-stale-tmux.sh`)

Sockets: adds the families the eval suite mints — `ad-attach-*`
(`tests/eval/session` attach/restart isolation) and `ad-fork-*` (fork-PI
isolation), both written as `[tmux] socket_name` into a sandbox config, i.e.
`tmux -L <name>` — plus `agent-deck-test-sock-*`, `ShortTmuxSocket`'s fallback
dir name. Scan roots grow from "`$TMUX_TMPDIR` else `/tmp`" to `$TMUX_TMPDIR`,
`/tmp` **and** `$TMPDIR`: Go's `os.MkdirTemp("")`, which mints the eval-bin
dirs, uses `$TMPDIR`, which on darwin is a per-user `/var/folders/...` path that
was never swept.

Processes: eval-binary reaping under the same rule that governs the sockets —
**identity is a path, never argv.** A process qualifies only if the kernel says
its executing image is `<root>/agent-deck-eval-bin-*/agent-deck`
(`/proc/<pid>/exe` on linux, lsof's `txt` descriptor on darwin), it is older
than `AGENT_DECK_EVAL_BIN_MAX_AGE_SECONDS` (default 1 day), and it is owned by
the current uid. Two deliberate refusals:

- Where neither identity source exists, the phase is **skipped and logged**.
  There is no name-matching fallback, because a name match is what killed the
  fleet.
- A leak whose temp dir has already been deleted is left alone — without the
  on-disk path there is no path-based identity left.

Also in this pass: `DRY_RUN` now covers both phases and mirrors the log to
stderr; the `default`-socket filter moved into the candidate list so a listing
shows exactly what would be killed; `--list-candidates` prints the target set
without probing or killing; `AGENT_DECK_REAPER_TMP_ROOTS` confines the script to
given roots so it is testable; and an unset `HOME` — how the launchd job
actually ran — falls back to a writable log path with a warning instead of
silently dropping every line.

### 2. The smoke test (`tests/ci/reap-stale-tmux.test.sh`)

Pure bash, no toolchain. Seeds one live tmux server per socket family inside a
single `mktemp` sandbox, plus two decoys named `default` (one *inside* a swept
socket dir, where only the name filter can save it), a socket file with no
server behind it, a fake leaked eval binary, and a same-named process at a path
outside any eval-bin dir. Asserts:

- every family is listed as a target;
- no `default` socket ever is, and no target lies outside the sandbox;
- the leaked eval binary is matched by executable path while the same-named
  decoy is not — the argv lesson, as an assertion;
- the age gate spares a fresh process at the 1-day threshold;
- `DRY_RUN` kills nothing: all eight seeded servers and the fake process are
  still alive after the pass.

Safety of the test itself: the script is pointed at the sandbox with
`AGENT_DECK_REAPER_TMP_ROOTS`, so the host's real socket dir is not in scope;
every invocation sets `DRY_RUN=1`; teardown kills each server **through the same
socket path it was started with** and fails the test if one survives (the
`kill-server`-before-`RemoveAll` rule from the July-18 incident); `rm -rf` is
guarded by a pattern check on the sandbox path. The fake binary is compiled
rather than copied from `/bin/sleep` because darwin SIGKILLs a copy of a
platform binary on exec.

Wired into `eval-smoke.yml` as a separate job, next to the harness whose leaks
the reaper cleans up. Ubuntu-only, deliberately: the job is toolchain-free and
adds no macOS runner minutes to a per-PR gate, and the re-enable checklist
requires the maintainer to run the same script locally on the darwin host they
are enabling it on (the lsof identity path differs from Linux `/proc`).

### 3. The launchd deployment (docs + example plist)

The plist that ran the reaper hourly set **no environment at all**. launchd
hands an agent almost nothing, so `HOME` was empty, the default log path
expanded to `/.agent-deck/logs/tmux-reaper.log`, every append failed, and the
job ran for weeks with no record of what it did — so when it killed the fleet
there was nothing to read. It also had no `StandardOutPath`/`StandardErrPath`,
and `RunAtLoad` true, which sweeps the host the moment a bad rule loads.

`scripts/launchd/com.agent-deck.tmux-reaper.plist.example` fixes all four:
absolute paths, explicit `HOME` and `PATH` (tmux and `/usr/sbin/lsof` both have
to be reachable), both standard streams pointed at files, `RunAtLoad` false, and
`DRY_RUN=1` preset so a fresh install observes instead of kills.
`docs/tmux-reaper.md` documents what is identified and how, why identity is a
path, the env knobs, and the five-step re-enable checklist: CI green on the
smoke job → the same test run locally on the target machine → a hand dry run
compared against `agent-deck list` → the plist with `DRY_RUN` still on → a week
of logs before it is allowed to kill anything.

## User impact

None on the product: the reaper is a maintainer-host script, not installed by
`install.sh`, off by default, and nothing in agent-deck depends on it.
Maintainers whose machines accumulate test debt get a reaper that covers the
families that actually leak, and a documented, gated path to running it
unattended.

## Evidence

Smoke test on darwin (bash 3.2, the version launchd's `/bin/bash` is), full
output — 27 checks:

```
$ bash tests/ci/reap-stale-tmux.test.sh
PASS: lists tmux-501/ad1031-smoke
PASS: lists tmux-501/ad-attach-smoke
PASS: lists tmux-501/ad-fork-smoke
PASS: lists tmux-501/s
PASS: lists ad-sock-smoke/s
PASS: lists agent-deck-test-sock-smoke/s
PASS: never targets default socket: <sandbox>/a/ad-tmux-smoke/tmux-501/default
PASS: never targets default socket: <sandbox>/a/tmux-501/default
PASS: never targets default socket: /tmp/tmux-501/default
PASS: every target lives under the sandbox roots
PASS: stale socket file is a candidate (reachability is decided by probe)
PASS: leaked eval binary listed by executable path (pid 11506)
PASS: same-named process outside an eval-bin dir is never a target
PASS: eval-bin age gate spares processes younger than the threshold
PASS: DRY_RUN reports <sandbox>/a/tmux-501/ad1031-smoke
PASS: DRY_RUN reports <sandbox>/a/tmux-501/ad-attach-smoke
PASS: DRY_RUN reports <sandbox>/b/tmux-501/ad-fork-smoke
PASS: DRY_RUN reports <sandbox>/a/ad-tmux-smoke/tmux-501/s
PASS: DRY_RUN reports <sandbox>/a/ad-sock-smoke/s
PASS: DRY_RUN reports <sandbox>/a/agent-deck-test-sock-smoke/s
PASS: DRY_RUN never reports a default socket
PASS: DRY_RUN logs no real reap
PASS: DRY_RUN killed nothing (8/8 sandbox servers still up)
PASS: DRY_RUN reports the leaked eval binary
PASS: DRY_RUN left the eval-bin process running
PASS: DRY_RUN writes a summary line
PASS: log never mentions the real default socket path

all reap-stale-tmux.sh smoke checks passed
```

Fails without the fix — the same test against the pre-change script
(`git show origin/main:scripts/reap-stale-tmux.sh`), 16 failures:

```
FAIL: socket family not listed as a target: .../tmux-501/ad1031-smoke
FAIL: socket family not listed as a target: .../tmux-501/ad-attach-smoke
FAIL: socket family not listed as a target: .../tmux-501/ad-fork-smoke
FAIL: socket family not listed as a target: .../ad-tmux-smoke/tmux-501/s
FAIL: socket family not listed as a target: .../ad-sock-smoke/s
FAIL: socket family not listed as a target: .../agent-deck-test-sock-smoke/s
FAIL: stale socket file missing from candidates: .../ad-sock-stale/s
FAIL: leaked eval binary not listed: pid 19874 exe .../agent-deck-eval-bin-smoke/agent-deck
FAIL: DRY_RUN did not report reachable target .../tmux-501/ad1031-smoke
... (6 more DRY_RUN misses)
FAIL: DRY_RUN did not report leaked eval-bin pid 19874
FAIL: DRY_RUN wrote no summary line
16 check(s) failed
```

Exit code and leak check after a clean run: `exit=0`, no `ad-reap-t.*` sandbox
left, no test tmux server and no fake process surviving.

Other checks:

```
bash -n scripts/reap-stale-tmux.sh
bash -n tests/ci/reap-stale-tmux.test.sh
plutil -lint scripts/launchd/com.agent-deck.tmux-reaper.plist.example   # OK
python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/eval-smoke.yml"))'
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/eval-smoke.yml   # clean
```

No Go files are touched, so the Go suite is unaffected by this diff.

## Not in this PR

`#1747`'s third ask — the cold-start CPU ramp (a freshly started TUI briefly hit
400% with 56 sessions before settling, even after `#1735`'s miss-caching) — is a
runtime change in the TUI's first sweep, not reaper hygiene, and is deliberately
left out of a shell-only diff. Worth re-filing as its own issue with a probe
budget proposal.

Closes #1744
Closes #1747
Refs #1736

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked for this as a leak-prevention job: "LEAK-PREVENTION for
asheshgoplani/agent-deck. Implement issues #1747 and #1744 in ONE PR." The
concrete thing behind it is his own machine: a host sweep found four
`agent-deck-eval-bin` TUI instances polling since mid-July and eight leaked test
tmux servers, on a host where the same class of leak had already made every
`tmux attach` fail with `fork failed: Device not configured` — and where the
script meant to clean that up had, days earlier, killed all ~65 of his live
sessions at once because it matched processes by name. He wanted the reaper to
cover what actually leaks, and he wanted it under test before it is ever allowed
to run unattended again.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed — no Go files touched; the new shell test is
      run above, sandboxed to its own `mktemp` dir
- [x] Not a hot path: maintainer-host script, off by default
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
