### PR TITLE
fix(auth): private auth-hold sidecar + staleness check on death adoption (closes #1746)

### DIFF
--- a/internal/session/auth_hold.go
+++ b/internal/session/auth_hold.go
@@ -60,7 +60,10 @@ type AuthHoldRecord struct {
 	// Evidence is the retained pane tail showing the banner. For auth_death it is
 	// the last snapshot taken while the pane still existed.
 	Evidence string `json:"evidence,omitempty"`
-	// Timestamp is when the condition was (re-)observed, unix seconds.
+	// Timestamp is when the condition was (re-)observed, unix seconds. It is
+	// load-bearing, not decorative: the death path uses it to decide whether a
+	// live-banner record is recent enough to explain a death happening NOW, so a
+	// still-observed hold is re-stamped (see authHoldObservationRefresh).
 	Timestamp int64 `json:"ts"`
 	// BootAttempts counts automatic boots that have landed back in auth-death
 	// since the hold was armed. Purely diagnostic — the hold itself blocks after
@@ -87,6 +90,14 @@ const (
 // falls outside it.
 const authHoldDeathWindow = 10 * time.Minute
 
+// authHoldObservationRefresh bounds how stale a still-observed record's
+// Timestamp may get. The death path reads Timestamp as "when the credential
+// failure was last seen", so a session wedged on the banner for an hour must
+// keep re-stamping it — otherwise its eventual death would fall outside
+// authHoldDeathWindow and read as an unrelated crash. One write per minute per
+// wedged session; every status sample in between stays free.
+const authHoldObservationRefresh = time.Minute
+
 // authHoldDir returns <data>/runtime/auth-hold, mirroring spawnFailureDir's
 // fallback so a data-dir resolution failure degrades to temp rather than
 // panicking a status sweep.
@@ -109,15 +120,24 @@ func writeAuthHoldRecord(rec AuthHoldRecord) error {
 		rec.Timestamp = time.Now().Unix()
 	}
 	path := authHoldRecordPath(rec.InstanceID)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// 0o700: the directory listing alone leaks which sessions are failing to
+	// authenticate, and authHoldDir() falls back to a shared /tmp when the data
+	// dir cannot be resolved.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("create auth-hold dir: %w", err)
 	}
 	data, err := json.MarshalIndent(rec, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal auth-hold record: %w", err)
 	}
-	// SkipBackup: the record is transient and self-clearing, a .bak is noise.
-	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o644, SkipBackup: true})
+	// Perm 0o600: Evidence is a verbatim pane tail captured at the moment of a
+	// credential failure — agent output, prompt text, error bodies. It is
+	// per-user runtime state that no other account has any business reading,
+	// and the temp-dir fallback can put it in a shared /tmp.
+	//
+	// SkipBackup: the record is transient and self-clearing, a .bak is noise
+	// (and a .bak would be a second copy of the same evidence).
+	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o600, SkipBackup: true})
 }
 
 // readAuthHoldRecord loads the sidecar for an instance, or (nil, nil) when none
@@ -190,6 +210,44 @@ func (r *AuthHoldRecord) Remedy() string {
 	)
 }
 
+// ObservedAt returns the record's observation time, or the zero time when the
+// record carries no usable timestamp (a hand-edited or truncated sidecar).
+func (r *AuthHoldRecord) ObservedAt() time.Time {
+	if r == nil || r.Timestamp <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(r.Timestamp, 0)
+}
+
+// canExplainDeathAt reports whether this record is recent enough to attribute a
+// death observed at now to authentication.
+//
+// A DEATH record always can: the process already exited on the banner, and that
+// verdict is never revoked by a clock — only by observing the session healthy or
+// by the user stopping it.
+//
+// A LIVE-banner record must be inside authHoldDeathWindow, the same freshness
+// window authDeathObservedLocked applies to its in-memory twin
+// (i.authFailureSeenAt). Without this, a sidecar written hours ago by a process
+// that then died — before it could observe the recovery that cleared the 401 —
+// would make a LATER, unrelated crash look like an auth death and hold a session
+// a plain restart would have fixed. A record with no usable timestamp cannot
+// prove freshness, so it is treated as stale: over-holding is the failure mode
+// with no escape hatch on the automatic paths.
+func (r *AuthHoldRecord) canExplainDeathAt(now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	if r.Reason == AuthHoldReasonDeath {
+		return true
+	}
+	observed := r.ObservedAt()
+	if observed.IsZero() {
+		return false
+	}
+	return now.Sub(observed) < authHoldDeathWindow
+}
+
 // FormatForDisplay renders the record as a preview-pane / `session show` block.
 func (r *AuthHoldRecord) FormatForDisplay() string {
 	if r == nil {
@@ -227,12 +285,28 @@ func (r *AuthHoldRecord) FormatForDisplay() string {
 //
 // Idempotent and cheap on the steady state: when a hold with the same reason is
 // already on disk, nothing is rewritten, so a status sweep that sees the same
-// wedged session every second does not thrash the filesystem.
+// wedged session every second does not thrash the filesystem. Once per
+// authHoldObservationRefresh it re-stamps Timestamp (and only Timestamp — the
+// first sample is the cleanest evidence, and BootAttempts must survive), because
+// the death path reads Timestamp as "last seen" to decide whether this record can
+// explain a death happening now.
 func (i *Instance) noteAuthHoldLocked(reason, evidence string) {
 	now := time.Now()
 	i.authFailureSeenAt = now
 
 	if existing, err := readAuthHoldRecord(i.ID); err == nil && existing != nil && existing.Reason == reason {
+		if observed := existing.ObservedAt(); !observed.IsZero() && now.Sub(observed) < authHoldObservationRefresh {
+			return
+		}
+		existing.Timestamp = now.Unix()
+		// The path is derived from InstanceID: pin it to this instance so a
+		// record with a missing/foreign id can never be re-stamped elsewhere.
+		existing.InstanceID = i.ID
+		if err := writeAuthHoldRecord(*existing); err != nil {
+			sessionLog.Warn("auth_hold_restamp_failed",
+				slog.String("instance_id", i.ID),
+				slog.String("error", err.Error()))
+		}
 		return
 	}
 
@@ -292,9 +366,13 @@ const authHoldRecheckInterval = 5 * time.Second
 //
 //  1. Already known held in-memory → nothing to do (no I/O).
 //  2. A sidecar exists (possibly written by ANOTHER process — the TUI observed
-//     the banner, this CLI invocation did not) → adopt it, and promote a
-//     live-banner hold to a death hold now that the pane is confirmed gone.
-//  3. No sidecar → ask the evidence: did the pane show a credential banner
+//     the banner, this CLI invocation did not) and is recent enough to explain
+//     this death (canExplainDeathAt) → adopt it, and promote a live-banner hold
+//     to a death hold now that the pane is confirmed gone. A STALE live-banner
+//     record is discarded instead: it describes a 401 that was current hours ago,
+//     not this death, and leaving it on disk would gate every automatic boot of a
+//     session a plain restart can fix.
+//  3. No usable sidecar → ask the evidence: did the pane show a credential banner
 //     before it vanished (authDeathObservedLocked)?
 //
 // Caller holds i.mu.
@@ -302,17 +380,32 @@ func (i *Instance) refreshAuthHoldOnDeathLocked() {
 	if i.authHeld {
 		return
 	}
-	if !i.authHoldCheckedAt.IsZero() && time.Since(i.authHoldCheckedAt) < authHoldRecheckInterval {
+	now := time.Now()
+	if !i.authHoldCheckedAt.IsZero() && now.Sub(i.authHoldCheckedAt) < authHoldRecheckInterval {
 		return
 	}
-	i.authHoldCheckedAt = time.Now()
+	i.authHoldCheckedAt = now
 
 	if rec := i.AuthHold(); rec != nil {
-		if rec.Reason != AuthHoldReasonDeath {
-			i.noteAuthHoldLocked(AuthHoldReasonDeath, rec.Evidence)
+		if rec.canExplainDeathAt(now) {
+			if rec.Reason != AuthHoldReasonDeath {
+				i.noteAuthHoldLocked(AuthHoldReasonDeath, rec.Evidence)
+			}
+			i.authHeld = true
+			return
 		}
-		i.authHeld = true
-		return
+		// Unlink, don't just ignore: IsAuthHeld (the cross-process CLI gate) reads
+		// the sidecar directly, so a record left in place would keep holding the
+		// session even though this path just concluded it explains nothing.
+		sessionLog.Info("auth_hold_stale_record_discarded",
+			slog.String("instance_id", i.ID),
+			slog.String("title", i.Title),
+			slog.String("reason", rec.Reason),
+			slog.Time("observed_at", rec.ObservedAt()))
+		clearAuthHoldRecord(i.ID)
+		// Fall through rather than returning: i.authFailureSeenAt and the pane's
+		// retained sample are independent, in-process evidence about THIS death,
+		// and authDeathObservedLocked applies the same window to them.
 	}
 	if i.authDeathObservedLocked() {
 		i.authHeld = true

--- a/internal/session/auth_hold.go
+++ b/internal/session/auth_hold.go
@@ -123,8 +123,16 @@ func writeAuthHoldRecord(rec AuthHoldRecord) error {
 	// 0o700: the directory listing alone leaks which sessions are failing to
 	// authenticate, and authHoldDir() falls back to a shared /tmp when the data
 	// dir cannot be resolved.
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create auth-hold dir: %w", err)
+	}
+	// MkdirAll does not narrow a dir that already exists, so an install upgraded
+	// from the 0o755 era would keep the world-listable directory. Narrow it on the
+	// next write. Lstat-gated so a symlink planted at the fallback path is never
+	// chmod'd through, and best-effort: a dir we do not own must not fail the write.
+	if fi, err := os.Lstat(dir); err == nil && fi.IsDir() && fi.Mode().Perm()&0o077 != 0 {
+		_ = os.Chmod(dir, 0o700)
 	}
 	data, err := json.MarshalIndent(rec, "", "  ")
 	if err != nil {
@@ -294,7 +302,11 @@ func (i *Instance) noteAuthHoldLocked(reason, evidence string) {
 	now := time.Now()
 	i.authFailureSeenAt = now
 
-	if existing, err := readAuthHoldRecord(i.ID); err == nil && existing != nil && existing.Reason == reason {
+	existing, err := readAuthHoldRecord(i.ID)
+	if err != nil {
+		existing = nil
+	}
+	if existing != nil && existing.Reason == reason {
 		if observed := existing.ObservedAt(); !observed.IsZero() && now.Sub(observed) < authHoldObservationRefresh {
 			return
 		}
@@ -316,6 +328,13 @@ func (i *Instance) noteAuthHoldLocked(reason, evidence string) {
 		Reason:     reason,
 		Evidence:   evidence,
 		Timestamp:  now.Unix(),
+	}
+	if existing != nil {
+		// Carry the cumulative counter across a reason change (the live → death
+		// promotion). It is not merely diagnostic: AuthHoldSurvivedBoot gates
+		// self-heal, so zeroing it would re-advertise as machine-recoverable a
+		// session whose automatic boot already died on the same credential.
+		rec.BootAttempts = existing.BootAttempts
 	}
 	if err := writeAuthHoldRecord(rec); err != nil {
 		sessionLog.Warn("auth_hold_write_failed",

--- a/internal/session/auth_hold_test.go
+++ b/internal/session/auth_hold_test.go
@@ -634,3 +634,58 @@ func TestAuthHoldRecord_CanExplainDeathAt(t *testing.T) {
 		})
 	}
 }
+
+// TestNoteAuthHold_PromotionPreservesBootAttempts asserts the live → death
+// promotion carries the cumulative boot counter. AuthHoldSurvivedBoot gates
+// self-heal on it, so resetting the counter would re-advertise as machine-
+// recoverable a session whose automatic boot already died on this credential.
+func TestNoteAuthHold_PromotionPreservesBootAttempts(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-promotion-counter")
+	inst.noteAuthHoldLocked(AuthHoldReasonLive, "API Error: 401")
+	inst.RecordAuthBootFailure()
+	inst.RecordAuthBootFailure()
+
+	inst.noteAuthHoldLocked(AuthHoldReasonDeath, "dying output")
+
+	rec := inst.AuthHold()
+	if rec == nil || rec.Reason != AuthHoldReasonDeath {
+		t.Fatalf("promotion must be recorded, got %+v", rec)
+	}
+	if rec.BootAttempts != 2 {
+		t.Fatalf("boot attempts must survive the promotion, got %d", rec.BootAttempts)
+	}
+	if rec.Evidence != "dying output" {
+		t.Fatalf("promotion must carry the new evidence, got %q", rec.Evidence)
+	}
+	if !inst.AuthHoldSurvivedBoot() {
+		t.Fatal("a promoted hold that already ate a boot must still report as survived")
+	}
+}
+
+// TestWriteAuthHoldRecord_NarrowsLegacyDirPerms asserts an install upgraded from
+// the 0o755 era gets its auth-hold directory narrowed on the next write —
+// MkdirAll alone never touches an existing directory.
+func TestWriteAuthHoldRecord_NarrowsLegacyDirPerms(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-legacy-dir")
+	dir := authHoldDir()
+	if dir == tempAgentDeckPath("runtime", "auth-hold") {
+		t.Skip("data dir resolution fell back to temp; the directory is not this call's to chmod")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("seed legacy dir mode: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	inst.noteAuthHoldLocked(AuthHoldReasonDeath, "API Error: 401")
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat auth-hold dir: %v", err)
+	}
+	if got := di.Mode().Perm(); got&0o077 != 0 {
+		t.Fatalf("legacy dir perm = %#o, want narrowed to no group/other bits", got)
+	}
+}

--- a/internal/session/auth_hold_test.go
+++ b/internal/session/auth_hold_test.go
@@ -1,6 +1,9 @@
 package session
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -412,5 +415,222 @@ func TestSpawnFailurePreview_PrefersAuthHold(t *testing.T) {
 	}
 	if strings.Contains(preview, "generic dying output") {
 		t.Fatalf("the generic spawn-failure block must not be shown instead, got:\n%s", preview)
+	}
+}
+
+// TestWriteAuthHoldRecord_PrivatePerms asserts the sidecar is 0o600 and its
+// directory carries no group/other bits. Evidence is a verbatim pane tail taken
+// at the moment of a credential failure (agent output, prompt text, error
+// bodies), and authHoldDir() falls back to a shared /tmp when the data dir cannot
+// be resolved — so the record must never be world-readable.
+func TestWriteAuthHoldRecord_PrivatePerms(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-perms")
+	inst.noteAuthHoldLocked(AuthHoldReasonDeath, "API Error: 401 · Please run /login")
+
+	path := authHoldRecordPath(inst.ID)
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sidecar: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("sidecar perm = %#o, want 0600", got)
+	}
+
+	dir := filepath.Dir(path)
+	if dir == tempAgentDeckPath("runtime", "auth-hold") {
+		// The shared-/tmp fallback dir may pre-exist with foreign perms and
+		// MkdirAll does not chmod an existing dir; only the file mode is ours.
+		t.Skip("data dir resolution fell back to temp; directory mode is not this call's to assert")
+	}
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat auth-hold dir: %v", err)
+	}
+	if got := di.Mode().Perm(); got&0o077 != 0 {
+		t.Fatalf("auth-hold dir perm = %#o, want no group/other bits", got)
+	}
+}
+
+// TestWriteAuthHoldRecord_TightensLegacyPerms asserts a record left behind by an
+// older build (0o644) is narrowed the next time it is touched, so upgrading is
+// enough to close the exposure on an already-held session.
+func TestWriteAuthHoldRecord_TightensLegacyPerms(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-legacy-perms")
+	path := authHoldRecordPath(inst.ID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacy, err := json.Marshal(AuthHoldRecord{
+		InstanceID: inst.ID,
+		Reason:     AuthHoldReasonLive,
+		Evidence:   "API Error: 401",
+		Timestamp:  time.Now().Add(-2 * authHoldObservationRefresh).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, legacy, 0o644); err != nil {
+		t.Fatalf("write legacy record: %v", err)
+	}
+
+	// Re-observing the same condition re-stamps the record, which rewrites it.
+	inst.noteAuthHoldLocked(AuthHoldReasonLive, "API Error: 401")
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat sidecar: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Fatalf("rewritten sidecar perm = %#o, want 0600", got)
+	}
+}
+
+// TestNoteAuthHold_RestampsStillObservedRecord asserts a session wedged on the
+// banner for a long time keeps its Timestamp current. The death path reads
+// Timestamp as "last seen", so without the re-stamp an hour-long wedge would die
+// outside authHoldDeathWindow and read as an unrelated crash. The re-stamp must
+// touch nothing else: the first sample is the cleanest evidence and the boot
+// counter is cumulative.
+func TestNoteAuthHold_RestampsStillObservedRecord(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-restamp")
+	stale := time.Now().Add(-2 * authHoldObservationRefresh)
+	if err := writeAuthHoldRecord(AuthHoldRecord{
+		InstanceID:   inst.ID,
+		Reason:       AuthHoldReasonLive,
+		Evidence:     "first evidence",
+		Timestamp:    stale.Unix(),
+		BootAttempts: 3,
+	}); err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+
+	inst.noteAuthHoldLocked(AuthHoldReasonLive, "later evidence")
+
+	rec := inst.AuthHold()
+	if rec == nil {
+		t.Fatal("expected the record to survive")
+	}
+	if rec.Timestamp <= stale.Unix() {
+		t.Fatalf("timestamp must be re-stamped, got %d (seeded %d)", rec.Timestamp, stale.Unix())
+	}
+	if rec.Evidence != "first evidence" {
+		t.Fatalf("the re-stamp must keep the original evidence, got %q", rec.Evidence)
+	}
+	if rec.BootAttempts != 3 {
+		t.Fatalf("the re-stamp must preserve the boot counter, got %d", rec.BootAttempts)
+	}
+	if rec.Reason != AuthHoldReasonLive {
+		t.Fatalf("the re-stamp must keep the reason, got %q", rec.Reason)
+	}
+}
+
+// TestRefreshAuthHoldOnDeath_DiscardsStaleLiveRecord is the staleness half of the
+// hardening. A live-banner sidecar written hours ago by a process that then died
+// — before it could observe the recovery that cleared the 401 — must NOT make a
+// later, unrelated crash look like an auth death. The stale record is unlinked,
+// not merely ignored: IsAuthHeld is the cross-process CLI gate and reads the
+// sidecar directly, so leaving it would strand a session a plain restart fixes.
+func TestRefreshAuthHoldOnDeath_DiscardsStaleLiveRecord(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-stale-live")
+	if err := writeAuthHoldRecord(AuthHoldRecord{
+		InstanceID: inst.ID,
+		Reason:     AuthHoldReasonLive,
+		Evidence:   "API Error: 401",
+		Timestamp:  time.Now().Add(-2 * authHoldDeathWindow).Unix(),
+	}); err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+
+	reader := &Instance{ID: inst.ID, Title: inst.Title, Status: StatusError}
+	reader.refreshAuthHoldOnDeathLocked()
+
+	if reader.authHeld {
+		t.Fatal("a stale live-banner record must not attribute this death to auth")
+	}
+	if rec := reader.AuthHold(); rec != nil {
+		t.Fatalf("the stale record must be unlinked, still on disk: %+v", rec)
+	}
+	if held, _ := reader.IsAuthHeld(); held {
+		t.Fatal("the CLI gate must no longer hold the session")
+	}
+}
+
+// TestRefreshAuthHoldOnDeath_AdoptsRecentLiveRecord pins the other side of the
+// window: a banner seen moments before the pane vanished is exactly the evidence
+// the hold exists for, and must still be adopted and promoted.
+func TestRefreshAuthHoldOnDeath_AdoptsRecentLiveRecord(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-recent-live")
+	if err := writeAuthHoldRecord(AuthHoldRecord{
+		InstanceID: inst.ID,
+		Reason:     AuthHoldReasonLive,
+		Evidence:   "API Error: 401",
+		Timestamp:  time.Now().Add(-authHoldDeathWindow / 2).Unix(),
+	}); err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+
+	reader := &Instance{ID: inst.ID, Title: inst.Title, Status: StatusError}
+	reader.refreshAuthHoldOnDeathLocked()
+
+	if !reader.authHeld {
+		t.Fatal("a recent live-banner record must still be adopted on death")
+	}
+	rec := reader.AuthHold()
+	if rec == nil || rec.Reason != AuthHoldReasonDeath {
+		t.Fatalf("the hold must be promoted to %q, got %+v", AuthHoldReasonDeath, rec)
+	}
+}
+
+// TestRefreshAuthHoldOnDeath_KeepsOldDeathRecord asserts the staleness check does
+// NOT turn the hold into a timer. A death record is the post-mortem: the process
+// already exited on the banner, and only observing the session healthy (or the
+// user stopping it) may release that verdict — never the passage of time.
+func TestRefreshAuthHoldOnDeath_KeepsOldDeathRecord(t *testing.T) {
+	inst := newAuthHoldTestInstance(t, "auth-hold-old-death")
+	if err := writeAuthHoldRecord(AuthHoldRecord{
+		InstanceID: inst.ID,
+		Reason:     AuthHoldReasonDeath,
+		Evidence:   "API Error: 401",
+		Timestamp:  time.Now().Add(-72 * time.Hour).Unix(),
+	}); err != nil {
+		t.Fatalf("seed record: %v", err)
+	}
+
+	reader := &Instance{ID: inst.ID, Title: inst.Title, Status: StatusError}
+	reader.refreshAuthHoldOnDeathLocked()
+
+	if !reader.authHeld {
+		t.Fatal("an aged death record must still hold: nothing has proven the credential works")
+	}
+	if reader.AuthHold() == nil {
+		t.Fatal("an aged death record must not be discarded by age")
+	}
+}
+
+// TestAuthHoldRecord_CanExplainDeathAt tabulates the freshness rule the death
+// path depends on, including the corrupt-record case: a record that cannot prove
+// when it was observed cannot justify a hold, because over-holding has no escape
+// hatch on the automatic paths.
+func TestAuthHoldRecord_CanExplainDeathAt(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		rec  *AuthHoldRecord
+		want bool
+	}{
+		{"nil", nil, false},
+		{"death always explains", &AuthHoldRecord{Reason: AuthHoldReasonDeath, Timestamp: now.Add(-72 * time.Hour).Unix()}, true},
+		{"death without timestamp", &AuthHoldRecord{Reason: AuthHoldReasonDeath}, true},
+		{"fresh live", &AuthHoldRecord{Reason: AuthHoldReasonLive, Timestamp: now.Unix()}, true},
+		{"live inside window", &AuthHoldRecord{Reason: AuthHoldReasonLive, Timestamp: now.Add(-authHoldDeathWindow / 2).Unix()}, true},
+		{"live outside window", &AuthHoldRecord{Reason: AuthHoldReasonLive, Timestamp: now.Add(-2 * authHoldDeathWindow).Unix()}, false},
+		{"live without timestamp", &AuthHoldRecord{Reason: AuthHoldReasonLive}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rec.canExplainDeathAt(now); got != tc.want {
+				t.Fatalf("canExplainDeathAt = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What problem does this solve?

Two hardening follow-ups on the auth-hold sidecar from the #1743 review.

1. **The record was world-readable.** It embeds `Evidence`: a verbatim pane tail captured at the moment of a credential failure — agent output, prompt text, error bodies. It was written `0o644` into a directory created `0o755`, and `authHoldDir()` falls back to a shared `/tmp` when the data dir cannot be resolved.
2. **The death path adopted any sidecar it found, with no freshness check.** A live-banner record written hours ago by a process that then died — before it could observe the recovery that cleared the 401 — made a **later, unrelated crash** read as an auth death, holding a session out of every automatic boot when a plain restart would have fixed it. The in-memory twin of that evidence (`i.authFailureSeenAt`) was already bounded by `authHoldDeathWindow`; the durable one was not.

Closes #1746

## Why this change

**Permissions.** `0o600` file in a `0o700` directory. Because `atomicfile` chmods on every write, a record left behind by an older build is narrowed the next time it is touched, so upgrading is enough to close the exposure on an already-held session.

**Staleness.** The record must now *explain the death* (`canExplainDeathAt`):

- a **live-banner** record only inside `authHoldDeathWindow` — the same window `authDeathObservedLocked` already applies to the in-memory evidence, so the two sources of the same fact are bounded identically;
- a **death** record always, aged or not. That verdict is never revoked by a clock, only by observing the session healthy or by the user stopping it. The hold must not become a timer — "the token was fixed" is not something a clock can know;
- a record with **no usable timestamp** cannot prove freshness, so it is treated as stale. Over-holding is the failure mode with no escape hatch on the automatic paths.

A stale live record is **unlinked**, not merely ignored: `IsAuthHeld` is the cross-process CLI gate and reads the sidecar directly, so leaving it in place would keep gating boots this path just concluded it cannot justify. After unlinking, the code falls through to the evidence check rather than returning — `i.authFailureSeenAt` and the pane's retained sample are independent, in-process evidence about *this* death.

For that window to mean "last seen", `Timestamp` has to actually track observation, as its doc comment always claimed but the code did not do (the same-reason short-circuit never rewrote the record). `noteAuthHoldLocked` now re-stamps a still-observed record once per `authHoldObservationRefresh` (one minute) — `Timestamp` only, since the first sample is the cleanest evidence and `BootAttempts` is cumulative. Without it, a session wedged on the banner for an hour would age out of the window and its eventual death would read as unrelated. Cost is one write per minute per wedged session; the per-second status samples in between still short-circuit for free.

Considered and rejected: applying the same staleness check inside `IsAuthHeld`. A genuinely wedged live session is legitimately held for as long as it is wedged, and expiring the hold there would reintroduce exactly the restart flapping #1743 fixed. The check belongs only where the record is used as evidence *about a death*.

## User impact

- The auth-hold sidecar is no longer readable by other accounts on the host (existing records are narrowed on their next write).
- A session that hit a 401 hours ago, recovered, and then crashed for an unrelated reason is now restartable by automation again instead of being pinned by a stale hold. A real auth death still holds exactly as before, and no hold expires on a timer.
- New debug log line when a stale record is discarded: `auth_hold_stale_record_discarded`.

## Evidence

Internal state hardening with no new user-visible surface, so the proof is in the tests, which are written against the real sidecar on disk (isolated HOME) rather than mocks:

- `TestWriteAuthHoldRecord_PrivatePerms` — stats the actual file (`0o600`) and its directory (no group/other bits).
- `TestWriteAuthHoldRecord_TightensLegacyPerms` — seeds a real `0o644` record like an older build would leave, re-observes, asserts it is narrowed.
- `TestRefreshAuthHoldOnDeath_DiscardsStaleLiveRecord` — the regression: stale live record → not attributed, record unlinked, `IsAuthHeld` released.
- `TestRefreshAuthHoldOnDeath_AdoptsRecentLiveRecord` / `TestRefreshAuthHoldOnDeath_KeepsOldDeathRecord` — both other sides of the rule, so the fix cannot drift into "holds expire".
- `TestNoteAuthHold_RestampsStillObservedRecord` — re-stamp bumps `Timestamp`, preserves evidence, reason and boot counter.
- `TestAuthHoldRecord_CanExplainDeathAt` — the rule tabulated, including the no-timestamp case.

Local verification was `go build ./...` + `go vet ./...` only; test execution is left to CI, since this host's `$HOME` is a live agent-deck data directory and the session package's tests must not run against it.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-x

**Prompt / session log (optional):** n/a

## What actually bothered you

The maintainer's ask, verbatim: "auth-hold sidecar perms 0o600 (internal/session/auth_hold.go) + Timestamp staleness check on the death-path adoption (auth_hold.go:301-320). Surgical, tests." The staleness half is the one that bites in production: the whole point of #1743 was to stop holding sessions a restart could fix, and a sidecar with no expiry on the *live* reason quietly reintroduces that on the next unrelated crash.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — not run locally (this host's HOME is live agent-deck data); `go build` + `go vet` clean, CI runs the suite
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — the status path is touched only on already-failing sessions; the added work is one re-stamp write per minute per *wedged* session, and healthy/steady-state samples still short-circuit with no I/O change
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-x intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated authentication evidence from incorrectly keeping sessions on hold.
  * Recent authentication warnings are now correctly preserved and promoted when a session ends.
  * Existing diagnostic information is retained when authentication status is refreshed.

* **Security**
  * Authentication records and their containing directories now use stricter private permissions.

* **Tests**
  * Added coverage for record freshness, stale-record cleanup, permission tightening, and authentication hold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->