### PR TITLE
fix(tmux): birth detached sessions at the real terminal size (#1694)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8740,10 +8740,17 @@ func (i *Instance) OpenContainerShell() (string, error) {
 	// Omit -w flag: the container's workdir was set during create (respects worktree path).
 	// Pass the docker exec command as discrete tmux args to avoid shell interpolation of
 	// the container name (defence-in-depth against state file tampering).
+	//
+	// #1694: -x/-y are mandatory on every detached new-session — without them
+	// the pane is born at tmux's 80x24 default and the shell (plus anything the
+	// user runs in it) paints its first frames clipped. See
+	// tmux.InitialWindowSize.
+	cols, rows := tmux.InitialWindowSize()
 	newCtx, newCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer newCancel()
 	out, err := tmux.ExecContext(newCtx, i.TmuxSocketName,
 		"new-session", "-d", "-s", tmuxName,
+		"-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows),
 		"docker", "exec", "-it", i.SandboxContainer, "/bin/sh",
 	).CombinedOutput()
 	if err != nil {

--- a/internal/tmux/initialsize.go
+++ b/internal/tmux/initialsize.go
@@ -1,0 +1,82 @@
+package tmux
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// Birth size for a detached `tmux new-session`.
+//
+// #1694: a detached new-session with no -x/-y is born at tmux's 80x24
+// default-size, and agent-deck runs the tool as the pane's INITIAL PROCESS
+// (RunCommandAsInitialProcess), so the tool paints its first frames into an
+// 80x24 window. The attach client arrives later at the real terminal size and
+// window-size=largest grows the window — but a TUI that fixed its layout
+// geometry on the first paint keeps drawing the 80-column layout into the
+// wider pane. OpenCode does exactly that and renders visibly clipped; tools
+// that reflow on SIGWINCH (Claude Code, Codex) hid the gap for two releases.
+//
+// This is the other half of #1167, which pre-sized only the ATTACH client's
+// PTY (see StartAttachPTY) and left the session's own creation at the default.
+// aggressive-resize cannot rescue the birth size either: it is a no-op under
+// window-size=largest, which Session.Start pins.
+const (
+	// tmuxDefaultCols/Rows are tmux's own birth size for a detached session.
+	// They are a floor, not a target: a host terminal narrower than this must
+	// not birth a pane MORE clipped than tmux's default already is, and
+	// window-size=largest shrinks the window to the real client on attach.
+	tmuxDefaultCols = 80
+	tmuxDefaultRows = 24
+
+	// headlessInitialCols/Rows are the birth size when no controlling
+	// terminal is reachable: web/xterm.js sessions, watcher- and cron-spawned
+	// launches, `agent-deck launch` with redirected output. Deliberately
+	// generous — wider than any realistic client — so the first paint is
+	// never the clipped one.
+	headlessInitialCols = 200
+	headlessInitialRows = 50
+)
+
+// terminalSizeProbe reports the size of the terminal agent-deck itself runs
+// on. Swappable seam so tests can drive both the TTY and the no-TTY branch
+// deterministically, without needing a real terminal.
+var terminalSizeProbe = probeTerminalSize
+
+// probeTerminalSize tries stdout, then stderr, then stdin — the first that is
+// a terminal wins. stdout is the TUI's terminal; stderr survives `>file`
+// redirection; stdin covers the rest. /dev/tty is deliberately NOT opened: in
+// a daemonized parent that can block, and it would leak a descriptor on every
+// session spawn.
+func probeTerminalSize() (cols, rows int, ok bool) {
+	for _, f := range []*os.File{os.Stdout, os.Stderr, os.Stdin} {
+		if f == nil {
+			continue
+		}
+		w, h, err := term.GetSize(int(f.Fd()))
+		if err == nil && w > 0 && h > 0 {
+			return w, h, true
+		}
+	}
+	return 0, 0, false
+}
+
+// InitialWindowSize returns the cols/rows a detached `new-session` must be
+// born at: the real terminal size when there is one (floored at tmux's own
+// 80x24 default), else the generous headless size.
+//
+// Every `new-session` spawn in this repo has to pass these as -x/-y —
+// enforced by TestNewSessionSpawnsCarryExplicitSize.
+func InitialWindowSize() (cols, rows int) {
+	cols, rows, ok := terminalSizeProbe()
+	if !ok {
+		return headlessInitialCols, headlessInitialRows
+	}
+	if cols < tmuxDefaultCols {
+		cols = tmuxDefaultCols
+	}
+	if rows < tmuxDefaultRows {
+		rows = tmuxDefaultRows
+	}
+	return cols, rows
+}

--- a/internal/tmux/issue1167_attach_width_test.go
+++ b/internal/tmux/issue1167_attach_width_test.go
@@ -38,9 +38,14 @@ func tmuxCtl1167(t *testing.T, socket string, args ...string) {
 	}
 }
 
-// newDetachedSession1167 reproduces production session birth: a detached
-// session with NO -x/-y (so tmux uses its 80x24 default-size) plus the
-// window-size=largest / aggressive-resize=on options Session.Start pins.
+// newDetachedSession1167 builds the worst-case window this fix has to survive:
+// a detached session with NO -x/-y (so tmux uses its 80x24 default-size) plus
+// the window-size=largest / aggressive-resize=on options Session.Start pins.
+//
+// Production no longer births sessions this way — startCommandSpec passes
+// -x/-y from InitialWindowSize (#1694) — but the attach client must still
+// pre-size itself, or it would shrink a correctly-sized window back down. The
+// unsized birth is kept here deliberately: it isolates the attach half.
 func newDetachedSession1167(t *testing.T, name string) string {
 	t.Helper()
 	if _, err := exec.LookPath("tmux"); err != nil {

--- a/internal/tmux/issue1694_initial_size_test.go
+++ b/internal/tmux/issue1694_initial_size_test.go
@@ -1,0 +1,274 @@
+package tmux
+
+// Regression tests for #1694: OpenCode renders clipped under agent-deck, but
+// not in plain iTerm/WezTerm and not under native tmux.
+//
+// Root cause: `Session.startCommandSpec` created the session detached with no
+// -x/-y, so the window was born at tmux's 80x24 default-size. agent-deck runs
+// the tool as the pane's INITIAL process, so the tool's first frames land in an
+// 80-column window; the attach client arrives later at the real terminal size
+// and window-size=largest grows the window, but a TUI that fixed its layout on
+// frame one keeps drawing the 80-column layout into the wider pane. Native
+// tmux never shows it because `tmux new-session` without -d is born at the
+// attached client's real size.
+//
+// #1167 fixed the sibling half of this (the ATTACH client's PTY size, see
+// StartAttachPTY) and its comment already named the 80x24 birth default — the
+// creation side was never given the same treatment.
+//
+// Coverage here, cheapest first:
+//   - InitialWindowSize: TTY, floor, and headless-fallback branches.
+//   - startCommandSpec: the argv contract (-x/-y present, values from the
+//     probe) in both the plain and initial-process forms.
+//   - a real tmux server: the window is BORN at the requested size, checked
+//     before any client attaches. This is the test that fails on pre-fix code
+//     with window_width == 80.
+//   - a repo-wide lint so no future `new-session` spawn omits the size again.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pinInitialWindowSize forces the terminal-size probe to a fixed answer for the
+// duration of the test, so argv assertions do not depend on whether the test
+// binary happens to own a terminal. hasTTY=false exercises the headless branch.
+func pinInitialWindowSize(t *testing.T, cols, rows int, hasTTY bool) {
+	t.Helper()
+	prev := terminalSizeProbe
+	terminalSizeProbe = func() (int, int, bool) { return cols, rows, hasTTY }
+	t.Cleanup(func() { terminalSizeProbe = prev })
+}
+
+func TestInitialWindowSize_UsesRealTerminalSize(t *testing.T) {
+	pinInitialWindowSize(t, 214, 57, true)
+
+	cols, rows := InitialWindowSize()
+	assert.Equal(t, 214, cols, "birth width must be the real terminal width so the first paint is not clipped (#1694)")
+	assert.Equal(t, 57, rows)
+}
+
+// A host terminal smaller than tmux's own default must not birth an even more
+// clipped pane: 80x24 is the floor. window-size=largest shrinks the window to
+// the real client on attach anyway.
+func TestInitialWindowSize_FloorsAtTmuxDefault(t *testing.T) {
+	pinInitialWindowSize(t, 40, 10, true)
+
+	cols, rows := InitialWindowSize()
+	assert.Equal(t, tmuxDefaultCols, cols)
+	assert.Equal(t, tmuxDefaultRows, rows)
+}
+
+// No controlling terminal (web/xterm.js sessions, watchers, cron, redirected
+// output) must not silently fall back to 80x24 — that is the bug. The fallback
+// is deliberately wider than any realistic client.
+func TestInitialWindowSize_HeadlessFallbackIsGenerous(t *testing.T) {
+	pinInitialWindowSize(t, 0, 0, false)
+
+	cols, rows := InitialWindowSize()
+	assert.Equal(t, headlessInitialCols, cols)
+	assert.Equal(t, headlessInitialRows, rows)
+	assert.Greater(t, cols, tmuxDefaultCols,
+		"a headless birth size of 80 columns is the #1694 bug, not a fallback")
+}
+
+// TestStartCommandSpec_CarriesBirthSize pins the production argv contract in
+// both spawn forms. On pre-fix code both subtests fail: no -x/-y at all.
+func TestStartCommandSpec_CarriesBirthSize(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		initialProcess   bool
+		command          string
+		probeCols        int
+		probeRows        int
+		hasTTY           bool
+		wantCols         string
+		wantRows         string
+		wantTrailingArgs []string
+	}{
+		{
+			name:      "shell pane on a real terminal",
+			probeCols: 214, probeRows: 57, hasTTY: true,
+			wantCols: "214", wantRows: "57",
+		},
+		{
+			name:           "tool as initial process, headless",
+			initialProcess: true,
+			command:        "opencode",
+			hasTTY:         false,
+			wantCols:       strconv.Itoa(headlessInitialCols),
+			wantRows:       strconv.Itoa(headlessInitialRows),
+			// The #1567/#1580 argv-token delivery must stay intact and stay LAST.
+			wantTrailingArgs: []string{"bash", "-c", "opencode"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pinInitialWindowSize(t, tc.probeCols, tc.probeRows, tc.hasTTY)
+
+			s := &Session{
+				Name:                       "agentdeck_test-1694_1234abcd",
+				WorkDir:                    "/tmp/project",
+				RunCommandAsInitialProcess: tc.initialProcess,
+			}
+			launcher, args := s.startCommandSpec("/tmp/project", tc.command)
+			require.Equal(t, "tmux", launcher)
+
+			x := indexOfArg(args, "-x")
+			y := indexOfArg(args, "-y")
+			require.NotEqual(t, -1, x, "new-session must carry -x; without it the window is born at tmux's 80-column default (#1694). argv: %v", args)
+			require.NotEqual(t, -1, y, "new-session must carry -y (#1694). argv: %v", args)
+			require.Less(t, x+1, len(args))
+			require.Less(t, y+1, len(args))
+			assert.Equal(t, tc.wantCols, args[x+1])
+			assert.Equal(t, tc.wantRows, args[y+1])
+
+			if len(tc.wantTrailingArgs) > 0 {
+				assert.Equal(t, tc.wantTrailingArgs, args[len(args)-len(tc.wantTrailingArgs):],
+					"the bash -c COMMAND argv tokens must remain the LAST args (#1567/#1580)")
+			}
+		})
+	}
+}
+
+func indexOfArg(args []string, flag string) int {
+	for i, a := range args {
+		if a == flag {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestStartCommandSpec_WindowIsBornAtRequestedSize runs the exact production
+// arg vector against a private tmux server and reads the window width BEFORE
+// any client attaches — i.e. the size the tool's first frame is painted into.
+// Pre-fix this reports 80 (tmux's default-size) no matter how wide the
+// terminal is; that 80 is what OpenCode locked its layout to.
+func TestStartCommandSpec_WindowIsBornAtRequestedSize(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	socket := privateSocketName1694(t)
+	pinInitialWindowSize(t, 173, 41, true)
+
+	s := &Session{
+		Name:       "birthsize",
+		SocketName: socket,
+		WorkDir:    "/tmp",
+	}
+	launcher, args := s.startCommandSpec("/tmp", "")
+	require.Equal(t, "tmux", launcher, "direct mode expected; argv: %v", args)
+	if out, err := exec.Command(launcher, args...).CombinedOutput(); err != nil {
+		t.Fatalf("new-session failed: %v\n%s\nargs: %v", err, out, args)
+	}
+
+	assert.Equal(t, "173", tmuxDisplay1694(t, socket, "birthsize", "#{window_width}"),
+		"the window must be BORN at the terminal width — a pane that starts at tmux's "+
+			"80-column default keeps OpenCode's layout clipped even after "+
+			"window-size=largest grows it (#1694)")
+	assert.Equal(t, "41", tmuxDisplay1694(t, socket, "birthsize", "#{window_height}"))
+}
+
+// privateSocketName1694 returns a deterministic -L socket name for this test
+// and registers teardown that kills the server on the SAME socket (an env
+// mismatch between spawn and cleanup makes kill-server a silent no-op and
+// leaks a server plus its ptys — the 2026-07-18 incident).
+func privateSocketName1694(t *testing.T) string {
+	t.Helper()
+	socket := "ad1694-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+	kill := func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() }
+	kill() // clear anything a previously aborted run stranded
+	t.Cleanup(kill)
+	return socket
+}
+
+func tmuxDisplay1694(t *testing.T, socket, target, format string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", "-L", socket, "display-message",
+		"-p", "-t", target, format).Output()
+	if err != nil {
+		t.Fatalf("display-message %s: %v", format, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestNewSessionSpawnsCarryExplicitSize is the repo-wide lint that keeps #1694
+// fixed. Every function in non-test code that spawns `new-session` must also
+// name -x and -y; a detached new-session without them is born at 80x24 and any
+// TUI that fixes its layout on the first paint stays clipped for the life of
+// the pane.
+//
+// The check is per enclosing function rather than per call expression because
+// production argv is assembled across several appends (startCommandSpec).
+func TestNewSessionSpawnsCarryExplicitSize(t *testing.T) {
+	root := moduleRoot(t)
+
+	var violations []string
+	err := walkGoFiles(root, func(path string) error {
+		if strings.HasSuffix(filepath.Base(path), "_test.go") {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+		if strings.HasPrefix(rel, "vendor/") || strings.HasPrefix(rel, ".worktrees/") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			return nil
+		}
+
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			var spawns bool
+			var hasX, hasY bool
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok {
+					return true
+				}
+				switch s, _ := stringLiteral(lit); s {
+				case "new-session":
+					spawns = true
+				case "-x":
+					hasX = true
+				case "-y":
+					hasY = true
+				}
+				return true
+			})
+			if spawns && (!hasX || !hasY) {
+				violations = append(violations,
+					rel+":"+itoa(fset.Position(fn.Pos()).Line)+" ("+fn.Name.Name+")")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("%d `new-session` spawn(s) without an explicit -x/-y size — the window "+
+			"is born at tmux's 80x24 default and a TUI that fixes its layout on the first "+
+			"paint renders clipped for the life of the pane (#1694). Pass the size from "+
+			"tmux.InitialWindowSize():\n  %s",
+			len(violations), strings.Join(violations, "\n  "))
+	}
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -258,12 +258,16 @@ func emitScrollbackClear(w io.Writer) {
 // StartAttachPTY starts cmd attached to a new PTY pre-sized to tty's current
 // dimensions.
 //
-// #1167: tmux clients connect at their PTY's size. A detached `new-session`
-// (no -x/-y) is born at tmux's 80x24 default-size, and a bare pty.Start creates
-// the attach client's PTY at the same 80x24 default — so window-size=largest
-// pins the window to 80 cols, ~half of a wide terminal, until an async SIGWINCH
-// grows it. Reading the controlling terminal's real size up front and starting
-// the PTY with it makes the client full-width from frame one.
+// #1167: tmux clients connect at their PTY's size, and a bare pty.Start creates
+// the attach client's PTY at tmux's 80x24 default — so window-size=largest pins
+// the window to 80 cols, ~half of a wide terminal, until an async SIGWINCH grows
+// it. Reading the controlling terminal's real size up front and starting the PTY
+// with it makes the client full-width from frame one.
+//
+// The session's own birth size is the other half of this and is fixed
+// separately: see InitialWindowSize (#1694). Both are needed — this one keeps
+// the attaching client from shrinking a correctly-sized window, that one keeps
+// the tool's very first paint from being laid out at 80 columns.
 //
 // When tty is not a terminal (size probe fails), it falls back to a plain start
 // at the default size: a degraded attach is still better than no attach.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1269,7 +1269,16 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	// which DO carry -L — would probe the isolated server and find
 	// nothing. Empty SocketName preserves pre-v1.7.50 behavior exactly
 	// (buildInnerTmuxArgs returns the args unchanged).
-	tmuxArgs := buildInnerTmuxArgs(s.SocketName, "new-session", "-d", "-s", s.Name, "-c", workDir)
+	//
+	// #1694: -x/-y birth the window at the terminal agent-deck runs on
+	// (generous fallback when there is no TTY) so the tool's FIRST paint is
+	// already full-width. Without them tmux uses its 80x24 default and a TUI
+	// that fixes its layout on frame one stays clipped forever — see
+	// InitialWindowSize. Appended AFTER -c so the argv prefix that callers and
+	// fallback helpers key on is unchanged.
+	cols, rows := InitialWindowSize()
+	tmuxArgs := buildInnerTmuxArgs(s.SocketName, "new-session", "-d", "-s", s.Name, "-c", workDir,
+		"-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows))
 	if startWithInitialProcess {
 		// Deliver the pane command as SEPARATE argv tokens (bash, -c, command)
 		// rather than a single shell-quoted string. This is the crux of the

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -32,6 +32,7 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 		WorkDir:  "/tmp/project",
 		LaunchAs: "service",
 	}
+	pinInitialWindowSize(t, 173, 41, true) // #1694 birth size
 
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	require.Equal(t, "systemd-run", launcher, "service mode must spawn via systemd-run")
@@ -56,7 +57,8 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 	// The tmux args shape after the systemd-run prefix must match the scope
 	// form's tmux args shape exactly. We use stripSystemdRunPrefix to verify.
 	tmuxArgs := stripSystemdRunPrefix(args)
-	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-service_1234abcd", "-c", "/tmp/project"}, tmuxArgs)
+	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-service_1234abcd", "-c", "/tmp/project",
+		"-x", "173", "-y", "41"}, tmuxArgs)
 }
 
 // TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm explicitly pins the
@@ -95,10 +97,12 @@ func TestStartCommandSpec_LaunchAs_Direct_UsesDirectTmux(t *testing.T) {
 		LaunchAs:          "direct",
 		LaunchInUserScope: true, // explicit override must WIN
 	}
+	pinInitialWindowSize(t, 173, 41, true) // #1694 birth size
 
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	assert.Equal(t, "tmux", launcher, "LaunchAs=direct must override LaunchInUserScope=true")
-	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-direct_1234abcd", "-c", "/tmp/project"}, args)
+	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-direct_1234abcd", "-c", "/tmp/project",
+		"-x", "173", "-y", "41"}, args)
 }
 
 // TestStartCommandSpec_LaunchAs_Empty_RespectsLegacyLaunchInUserScope

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3008,9 +3008,13 @@ func TestStartCommandSpec_Default(t *testing.T) {
 		WorkDir: "/tmp/project",
 	}
 
+	// #1694: -x/-y are part of the argv contract now.
+	pinInitialWindowSize(t, 173, 41, true)
+
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	assert.Equal(t, "tmux", launcher)
-	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project"}, args)
+	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
+		"-x", "173", "-y", "41"}, args)
 }
 
 func TestStartCommandSpec_UserScope(t *testing.T) {
@@ -3020,12 +3024,15 @@ func TestStartCommandSpec_UserScope(t *testing.T) {
 		LaunchInUserScope: true,
 	}
 
+	pinInitialWindowSize(t, 173, 41, true)
+
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	require.Equal(t, "systemd-run", launcher)
 	require.GreaterOrEqual(t, len(args), 8)
 	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
 	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[5])
-	assert.Equal(t, []string{"tmux", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project"}, args[6:])
+	assert.Equal(t, []string{"tmux", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
+		"-x", "173", "-y", "41"}, args[6:])
 }
 
 // TestStartCommandSpec_InitialProcess_WrapsBashRegardlessOfContent is the
@@ -3080,10 +3087,11 @@ func TestStartCommandSpec_InitialProcess_WrapsBashRegardlessOfContent(t *testing
 			require.Equal(t, "tmux", launcher)
 			// #1567/#1580: the command is delivered as SEPARATE argv tokens
 			// (bash, -c, COMMAND) so tmux execvp()s bash directly instead of
-			// wrapping the string through the server default-shell. That is 9
-			// args total: new-session -d -s NAME -c DIR bash -c COMMAND.
-			require.Equal(t, 9, len(args),
-				"expected 9 args (new-session -d -s NAME -c DIR bash -c COMMAND)")
+			// wrapping the string through the server default-shell. With the
+			// #1694 birth size that is 13 args total:
+			// new-session -d -s NAME -c DIR -x COLS -y ROWS bash -c COMMAND.
+			require.Equal(t, 13, len(args),
+				"expected 13 args (new-session -d -s NAME -c DIR -x COLS -y ROWS bash -c COMMAND)")
 
 			require.Equal(t, "bash", args[len(args)-3],
 				"command must be exec'd under bash for fish/zsh/bash compatibility")


### PR DESCRIPTION
## What problem does this solve?

OpenCode renders clipped under agent-deck (#1694) — its layout is drawn at ~80 columns no matter how wide the terminal is. The same OpenCode is fine in plain iTerm/WezTerm and fine under native tmux, so the discriminator is agent-deck's session creation.

The bug is the size the pane is **born** at, not the size it ends up. `Session.startCommandSpec` created the session detached with no `-x`/`-y`, so the window was born at tmux's 80x24 default-size. agent-deck runs the tool as the pane's **initial process** (`RunCommandAsInitialProcess`), so OpenCode painted its first frames into an 80-column window. The attach client then arrived at the real terminal size and `window-size largest` grew the window — but a TUI that fixed its layout geometry on the first paint keeps rendering the 80-column layout into the wider pane. Native tmux never shows it because `tmux new-session` without `-d` is born at the attached client's real size.

Closes #1694

## Why this change

This is the same defect class as #1167, which fixed only the sibling half: `StartAttachPTY` pre-sizes the **attach client's** PTY, and its comment already named the 80x24 birth default — session creation itself was never given the same treatment. Tools that reflow cleanly on SIGWINCH (Claude Code, Codex) hid the gap for two releases.

So the fix is at the birth, not after it:

- `tmux.InitialWindowSize()` resolves the size a detached `new-session` must be born at: the real terminal (probing stdout, then stderr, then stdin — stderr survives `>file`; `/dev/tty` is deliberately not opened, since in a daemonized parent that can block and it would leak a descriptor per spawn).
- Floored at tmux's own 80x24, so a host terminal narrower than the default never births a *more* clipped pane than tmux already would — and `window-size largest` shrinks the window to the real client on attach anyway.
- A generous 200x50 when no controlling terminal is reachable: web/xterm.js sessions, watcher- and cron-spawned launches, `agent-deck launch` with redirected output. Matching the real terminal exactly is what keeps the common path resize-free, and the wide fallback keeps the headless path from being born at the clipped size.

Both detached `new-session` spawn sites now pass it as `-x`/`-y`: `startCommandSpec` (`internal/tmux/tmux.go`) and `OpenContainerShell` (`internal/session/instance.go`), which had the same defect. `-x`/`-y` are appended **after** `-c` so the argv prefix the systemd fallback helpers and the default-socket guard key on is unchanged, and so the `bash -c COMMAND` argv tokens from #1567/#1580 stay last.

Two things ruled out: `aggressive-resize on` cannot rescue the birth size (it is a no-op under `window-size largest`, which `Session.Start` pins), and no post-attach refresh is added — pre-sizing alone makes the first paint correct, which is the reported symptom.

## User impact

Sessions are born at the terminal's real size, so a TUI that fixes its layout on the first frame (OpenCode) is no longer clipped. Tools that reflow on SIGWINCH also stop showing the brief 80-column first frame. Headless/web-spawned sessions start at 200x50 instead of 80x24.

## Evidence

Behavior verified directly against tmux 3.7b on an isolated socket (birth size read before any client attaches, i.e. the size the tool's first frame is painted into):

```
$ tmux -L <sock> new-session -d -s nosize   -c /tmp
$ tmux -L <sock> new-session -d -s withsize -c /tmp -x 173 -y 41
nosize:   80x24        <- what agent-deck produced before this PR
withsize: 173x41       <- what it produces now

$ tmux -L <sock> new-session -d -s withcmd -c /tmp -x 173 -y 41 bash -c 'stty size > out; sleep 2'
pane initial process sees: 41 173
```

That last line is the fix in one measurement: the tool's *initial process* now sees the real geometry on its first read, instead of 24 80.

The repo-wide lint added here was also run against the pre-fix tree and reports exactly the two real spawn sites, and zero after the fix:

```
violations: 2
internal/session/instance.go:8708 (OpenContainerShell)
internal/tmux/tmux.go:1263 (startCommandSpec)
```

Test-suite verification for this PR runs on CI (including the macOS jobs, which is where the reporter's platform is covered) rather than locally — see the checklist note below.

Tests in the diff (`internal/tmux/issue1694_initial_size_test.go`):

1. `TestInitialWindowSize_*` — the TTY, the 80x24 floor and the headless-fallback branches, through a swappable probe seam so nothing depends on whether the test binary owns a terminal.
2. `TestStartCommandSpec_CarriesBirthSize` — the production argv contract in both spawn forms (plain pane on a real terminal; tool-as-initial-process headless), including that the `bash -c COMMAND` tokens remain last. Fails pre-fix: no `-x`/`-y` at all.
3. `TestStartCommandSpec_WindowIsBornAtRequestedSize` — runs the exact production arg vector against a private `-L` server and reads `#{window_width}`/`#{window_height}` before any client attaches. Reports `80` pre-fix. Teardown kills the server on the same socket it was spawned on.
4. `TestNewSessionSpawnsCarryExplicitSize` — repo-wide AST lint: any non-test function that spawns `new-session` must also name `-x` and `-y`, so this cannot regress by way of a new spawn site.

The existing `new-session` argv assertions (`TestStartCommandSpec_Default`, `_UserScope`, `_InitialProcess_WrapsBashRegardlessOfContent`, and the `LaunchAs` service/direct shapes) are updated to the new contract with the probe pinned, so they stay exact rather than being loosened.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

The reporter's words in #1694: "Only seems to happen in Agent-Deck, works fine in base terminal in both Wezterm and iTerm2... ALSO, doesn't happen w/ native TMUX", with two screenshots showing OpenCode's panel cut off.

My human's instruction, after triaging that thread himself: "Root cause on-thread: internal/tmux/tmux.go:1263 new-session without -x/-y births panes at 80x24; the attach half was fixed in #1167 (pty.go:261-267) but creation never was. Fix: pass -x/-y from real terminal size with generous non-TTY fallback; update the lint test covering new-session argv."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — **not run on this machine, deliberately.** Per the repo's own `CLAUDE.md`, the suite must not run from a checkout whose `$HOME` resolves to a populated agent-deck data dir (the three data-loss incidents logged there), and test-spawned tmux servers have exhausted a host's PTY pool before. Local verification was `gofmt -l ./cmd ./internal` (clean), `go build ./...`, `go vet ./internal/tmux ./internal/session`, the isolated-socket tmux probe above, and the new lint run against the pre-fix tree. The suite itself runs here on CI, macOS jobs included.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — no timing change: one `TIOCGWINSZ` ioctl per session spawn, on a path that already forks tmux.
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
