### PR TITLE
fix(tmux): prove per-session ownership before stopping a service-mode unit

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2263,6 +2263,12 @@ func handleRemove(profile string, args []string) {
 	removedID := inst.ID
 	removedTitle := inst.Title
 
+	// Snapshot service-unit ownership BEFORE teardown (issue #1721): the
+	// pid of the tmux server generation this session belongs to is only
+	// observable while the session is still live, and it is what proves
+	// the unit we may stop later is the one we actually retired.
+	serviceUnitOwnership := inst.ServiceUnitOwnership()
+
 	// Always attempt to kill the tmux session, even if Exists() returns false.
 	// The saved status may be stale (e.g., "error" in DB but tmux session still alive).
 	// KillAndWait is safe to call on non-existent sessions (returns error which we handle).
@@ -2283,7 +2289,12 @@ func handleRemove(profile string, args []string) {
 	// stop + reset-failed the unit here so `agent-deck remove` is truly
 	// terminal. No-op on non-service-mode sessions and on non-systemd
 	// hosts.
-	_ = inst.StopServiceUnit()
+	//
+	// Gated on proven exclusive ownership (issue #1721): the unit
+	// supervises a tmux SERVER, which on the default socket is shared by
+	// every sibling session, so an unconditional stop could kill sessions
+	// this removal was never allowed to touch.
+	_ = inst.RetireServiceUnit(serviceUnitOwnership)
 
 	// Clean up worktree directory if this is a worktree session
 	if inst.IsWorktree() {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6429,19 +6429,33 @@ func parseGenericOutput(content, tool string) (*ResponseOutput, error) {
 	}, nil
 }
 
-// StopServiceUnit best-effort stops + resets-failed the transient
-// systemd-user service unit associated with this instance's tmux
-// server (if LaunchAs=service was used). Intended for the remove/delete
-// code path ONLY — NOT for restart, which needs the unit to persist so
-// it can re-spawn tmux.
+// ServiceUnitOwnership snapshots the evidence needed to decide whether
+// this instance may retire its transient systemd-user service unit
+// (issue #1721). MUST be called BEFORE teardown: it reads the pid of the
+// tmux server generation this session belongs to, which is unobservable
+// once the session is killed.
 //
-// No-ops on non-systemd hosts. Returns nil when the unit doesn't exist
-// or was never started (best-effort semantics per v1.7.21 spec).
-func (i *Instance) StopServiceUnit() error {
+// Returns a zero value (which always skips the stop) when the instance has
+// no tmux session.
+func (i *Instance) ServiceUnitOwnership() tmux.ServiceUnitOwnership {
 	if i.tmuxSession == nil {
-		return nil
+		return tmux.ServiceUnitOwnership{}
 	}
-	return tmux.StopServiceUnit(i.tmuxSession.Name)
+	return i.tmuxSession.ServiceUnitOwnership()
+}
+
+// RetireServiceUnit stops + resets-failed the transient systemd-user
+// service unit associated with this instance's tmux server (if
+// LaunchAs=service was used) — but ONLY when `own` proves this session was
+// its exclusive owner. Intended for the remove/delete code path ONLY —
+// NOT for restart, which needs the unit to persist so it can re-spawn tmux.
+//
+// `own` must come from ServiceUnitOwnership() called BEFORE teardown. The
+// returned decision reports whether the unit was stopped and why (see the
+// tmux.UnitStop* reasons); a skip is never an error — leaving a transient
+// unit behind is recoverable, killing a sibling session is not.
+func (i *Instance) RetireServiceUnit(own tmux.ServiceUnitOwnership) tmux.ServiceUnitDecision {
+	return tmux.StopServiceUnitOwned(own)
 }
 
 // Kill terminates the tmux session and cleans up sandbox container if present.

--- a/internal/session/service_unit_ownership_test.go
+++ b/internal/session/service_unit_ownership_test.go
@@ -1,0 +1,45 @@
+// Instance-level guards for the service-mode unit ownership lease
+// (issue #1721). The lease itself is exercised in internal/tmux; what
+// matters here is that the remove path can never hand the gate an
+// ownership record that names somebody else's unit.
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// TestInstanceServiceUnitOwnership_NoTmuxSession_YieldsSkipRecord: an
+// instance with no tmux session (never started, or loaded from the DB
+// without one) must produce the always-skip zero record. Sanitizing an
+// empty name would otherwise resolve to the "session" fallback and stop
+// agentdeck-tmux-session.service — a unit that belongs to somebody else.
+func TestInstanceServiceUnitOwnership_NoTmuxSession_YieldsSkipRecord(t *testing.T) {
+	inst := &Instance{}
+
+	own := inst.ServiceUnitOwnership()
+	require.Equal(t, tmux.ServiceUnitOwnership{}, own,
+		"a session-less instance must not name any tmux session or socket")
+
+	dec := inst.RetireServiceUnit(own)
+	assert.False(t, dec.Stopped, "no unit may be stopped for a session-less instance")
+	assert.Equal(t, tmux.UnitStopSkipNoTmuxSession, dec.Reason)
+	assert.Empty(t, dec.Unit, "no unit name may be derived from an empty session name")
+}
+
+// TestInstanceServiceUnitOwnership_CarriesSessionAndSocket: the record the
+// remove path snapshots before teardown must identify both the session
+// (which unit) and the socket (which server's occupancy proves ownership).
+func TestInstanceServiceUnitOwnership_CarriesSessionAndSocket(t *testing.T) {
+	sess := tmux.NewSession("ownership-record", "/tmp")
+	sess.SocketName = "ad-test-1721"
+	inst := &Instance{tmuxSession: sess, TmuxSocketName: sess.SocketName}
+
+	own := inst.ServiceUnitOwnership()
+	assert.Equal(t, sess.Name, own.SessionName)
+	assert.Equal(t, "ad-test-1721", own.SocketName)
+}

--- a/internal/tmux/service_unit_ownership.go
+++ b/internal/tmux/service_unit_ownership.go
@@ -1,0 +1,318 @@
+// Package tmux — per-session ownership lease for service-mode unit
+// teardown (issue #1721).
+//
+// Service-mode sessions (LaunchAs="service") are spawned as transient
+// systemd-user units:
+//
+//	systemd-run --user --unit agentdeck-tmux-<session>.service \
+//	    --property=Restart=on-failure ... tmux new-session -d -s <session>
+//
+// The unit supervises a tmux SERVER, not a tmux session. On the default
+// socket every agent-deck session shares ONE server, and that server's
+// cgroup is anchored by whichever session's unit happened to spawn it
+// first. `agent-deck remove` used to `systemctl --user stop` the unit
+// derived from the removed session's name unconditionally, which meant a
+// single deletion could:
+//
+//  1. stop the shared server and kill every sibling session on it
+//     (KillMode=control-group takes the whole cgroup),
+//  2. cancel the restart protection a sibling still relies on, or
+//  3. tear down a REPLACEMENT generation that Restart=on-failure had
+//     already brought up after the generation we meant to retire died.
+//
+// Name derivation makes co-tenancy worse, not better:
+// sanitizeSystemdUnitComponent lowercases, collapses every non-alphanumeric
+// byte to '-' and truncates at 48 bytes, so two distinct sessions with long
+// similar titles can map to the SAME unit name.
+//
+// StopServiceUnitOwned replaces the unconditional stop with an ownership
+// lease check. The unit is retired ONLY when the terminating lifecycle is
+// proven to be its exclusive owner: no other live session remains on the
+// server, the unit has no live main process, and no start job is in flight.
+// Anything indeterminate skips the stop — leaving a transient unit behind
+// is recoverable, killing a sibling session is not.
+package tmux
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// serviceUnitBase returns the transient systemd-user unit BASE name used
+// by both spawn forms (scope mode uses the base, service mode appends
+// ".service"). Single derivation point so spawn and teardown cannot drift.
+func serviceUnitBase(sessionName string) string {
+	return "agentdeck-tmux-" + sanitizeSystemdUnitComponent(sessionName)
+}
+
+// ServiceUnitName returns the transient systemd-user service unit name a
+// service-mode spawn uses for the given tmux session name. Exported so the
+// teardown path and tests derive it exactly like startCommandSpec does.
+func ServiceUnitName(sessionName string) string {
+	return serviceUnitBase(sessionName) + ".service"
+}
+
+// Reasons recorded on a ServiceUnitDecision. Stable strings — they appear
+// in logs and are asserted by tests.
+const (
+	// UnitStopReasonExclusive: ownership proven, unit stopped.
+	UnitStopReasonExclusive = "exclusive_owner"
+	// UnitStopSkipNoTmuxSession: caller had no tmux session name, so no
+	// unit can be attributed. Never guess a unit name.
+	UnitStopSkipNoTmuxSession = "no_tmux_session"
+	// UnitStopSkipNoSystemctl: host has no systemctl — nothing to stop.
+	UnitStopSkipNoSystemctl = "no_systemctl"
+	// UnitStopSkipIndeterminate: the unit state or the server session list
+	// could not be read. Ownership unproven → never stop.
+	UnitStopSkipIndeterminate = "ownership_indeterminate"
+	// UnitStopSkipSessionStillLive: our own session is still on the server,
+	// so teardown did not complete; stopping now would be the shared-unit
+	// hammer instead of a session kill.
+	UnitStopSkipSessionStillLive = "session_still_live"
+	// UnitStopSkipServerShared: other live sessions remain on the tmux
+	// server this unit supervises — the unit is co-tenanted (gate #1/#2).
+	UnitStopSkipServerShared = "tmux_server_shared"
+	// UnitStopSkipStartJobInFlight: systemd is currently (re)starting the
+	// unit; MainPID is not published yet, so a stop could kill a
+	// replacement generation mid-spawn (gate #3).
+	UnitStopSkipStartJobInFlight = "unit_start_job_in_flight"
+	// UnitStopSkipReplacementGeneration: the unit's live main process is a
+	// DIFFERENT generation than the one we retired (gate #3).
+	UnitStopSkipReplacementGeneration = "replacement_generation"
+	// UnitStopSkipProcessAlive: the unit still supervises a live process we
+	// cannot prove is exclusively ours.
+	UnitStopSkipProcessAlive = "unit_process_alive"
+)
+
+// ServiceUnitOwnership is the evidence a caller supplies to prove it may
+// retire a service-mode unit. Callers MUST capture it BEFORE teardown:
+// once the tmux session is killed the server generation it belonged to is
+// no longer observable.
+type ServiceUnitOwnership struct {
+	// SessionName is the tmux session name being retired. Empty means
+	// "no tmux session" and always skips the stop.
+	SessionName string
+
+	// SocketName is the tmux `-L` socket of the server hosting
+	// SessionName ("" = default socket, i.e. the shared one).
+	SocketName string
+
+	// RetiredServerPID is the pid of the tmux server generation the caller
+	// retired. 0 when it could not be determined; a nonzero value lets the
+	// gate distinguish "our generation is somehow still alive" from
+	// "systemd already spawned a replacement generation".
+	RetiredServerPID int
+}
+
+// ServiceUnitDecision reports what the ownership gate decided.
+type ServiceUnitDecision struct {
+	// Unit is the derived unit name the decision applies to.
+	Unit string
+	// Stopped is true only when `systemctl --user stop` was actually issued.
+	Stopped bool
+	// Reason is one of the UnitStop* constants above.
+	Reason string
+}
+
+// serviceUnitState is the subset of `systemctl --user show` we need.
+type serviceUnitState struct {
+	ActiveState  string
+	MainPID      int
+	MainPIDAlive bool
+}
+
+// systemctlLookPath is a swappable seam so tests can simulate a host with
+// (or without) systemctl regardless of the platform they run on.
+var systemctlLookPath = func() error {
+	_, err := exec.LookPath("systemctl")
+	return err
+}
+
+// unitPIDAlive reports whether pid is still running (signal-0 probe: the
+// kernel existence check with no delivery). Swappable for tests.
+var unitPIDAlive = func(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// liveSessionsOnSocket is the ownership gate's view of server occupancy.
+// A package var so tests can inject occupancy without a live tmux server;
+// production always uses the bounded single `list-sessions` probe.
+var liveSessionsOnSocket = ListSessionNamesOnSocket
+
+// readServiceUnitState reads ActiveState + MainPID for one unit. Returns
+// an error when systemctl cannot be consulted — an unknown unit is NOT an
+// error (systemd reports ActiveState=inactive / MainPID=0 for not-found).
+var readServiceUnitState = func(unit string) (serviceUnitState, error) {
+	out, err := execCommand("systemctl", "--user", "show", unit,
+		"-p", "ActiveState", "-p", "MainPID").Output()
+	if err != nil {
+		return serviceUnitState{}, err
+	}
+	return parseServiceUnitState(string(out)), nil
+}
+
+// parseServiceUnitState parses `systemctl show -p ActiveState -p MainPID`
+// key=value output. Extracted so the parsing is testable without systemd.
+func parseServiceUnitState(out string) serviceUnitState {
+	var st serviceUnitState
+	for _, line := range strings.Split(out, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "ActiveState":
+			st.ActiveState = strings.TrimSpace(value)
+		case "MainPID":
+			if n, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && n > 0 {
+				st.MainPID = n
+			}
+		}
+	}
+	st.MainPIDAlive = unitPIDAlive(st.MainPID)
+	return st
+}
+
+// unitStartJobInFlight reports whether systemd is bringing the unit up
+// right now. In those states MainPID is not published yet, so a dead-pid
+// reading must NOT be mistaken for "nothing left to protect".
+func unitStartJobInFlight(activeState string) bool {
+	switch strings.ToLower(strings.TrimSpace(activeState)) {
+	case "activating", "reloading", "refreshing":
+		return true
+	}
+	return false
+}
+
+// evaluateServiceUnitOwnership is the pure ownership predicate: given the
+// unit's observed state and the authoritative list of live sessions on the
+// server, decide whether own.SessionName exclusively owns the unit.
+//
+// liveErr non-nil means the session probe was indeterminate; per
+// ListSessionNamesOnSocket's contract that must be read as "assume alive",
+// never as "no sessions".
+func evaluateServiceUnitOwnership(
+	own ServiceUnitOwnership,
+	state serviceUnitState,
+	live map[string]struct{},
+	liveErr error,
+) (bool, string) {
+	if liveErr != nil {
+		return false, UnitStopSkipIndeterminate
+	}
+	if _, stillThere := live[own.SessionName]; stillThere {
+		return false, UnitStopSkipSessionStillLive
+	}
+	if len(live) > 0 {
+		// Any remaining session — sibling agent-deck session OR one of the
+		// user's own — shares the server this unit supervises.
+		return false, UnitStopSkipServerShared
+	}
+	if unitStartJobInFlight(state.ActiveState) {
+		return false, UnitStopSkipStartJobInFlight
+	}
+	if state.MainPIDAlive {
+		if own.RetiredServerPID != 0 && state.MainPID != own.RetiredServerPID {
+			return false, UnitStopSkipReplacementGeneration
+		}
+		return false, UnitStopSkipProcessAlive
+	}
+	return true, UnitStopReasonExclusive
+}
+
+// StopServiceUnitOwned stops + resets-failed the transient systemd-user
+// service unit for own.SessionName ONLY when that session is proven to be
+// its exclusive owner (issue #1721). It replaces the unconditional
+// StopServiceUnit call the remove path used to make.
+//
+// Best-effort by design: every skip path and every non-systemd host is a
+// no-op, never an error. The returned decision carries the reason so
+// callers can log/report and tests can assert the gate.
+func StopServiceUnitOwned(own ServiceUnitOwnership) ServiceUnitDecision {
+	if strings.TrimSpace(own.SessionName) == "" {
+		return ServiceUnitDecision{Reason: UnitStopSkipNoTmuxSession}
+	}
+	unit := ServiceUnitName(own.SessionName)
+	if err := systemctlLookPath(); err != nil {
+		return ServiceUnitDecision{Unit: unit, Reason: UnitStopSkipNoSystemctl}
+	}
+
+	state, err := readServiceUnitState(unit)
+	if err != nil {
+		statusLog.Warn("service_unit_stop_skipped",
+			slog.String("unit", unit),
+			slog.String("session", own.SessionName),
+			slog.String("reason", UnitStopSkipIndeterminate),
+			slog.String("error", err.Error()))
+		return ServiceUnitDecision{Unit: unit, Reason: UnitStopSkipIndeterminate}
+	}
+
+	live, liveErr := liveSessionsOnSocket(own.SocketName)
+	allowed, reason := evaluateServiceUnitOwnership(own, state, live, liveErr)
+	if !allowed {
+		statusLog.Info("service_unit_stop_skipped",
+			slog.String("unit", unit),
+			slog.String("session", own.SessionName),
+			slog.String("reason", reason),
+			slog.String("active_state", state.ActiveState),
+			slog.Int("unit_main_pid", state.MainPID),
+			slog.Int("retired_server_pid", own.RetiredServerPID),
+			slog.Int("live_sessions_on_socket", len(live)))
+		return ServiceUnitDecision{Unit: unit, Reason: reason}
+	}
+
+	// Exclusive owner: stop first (cancels Restart=on-failure), then clear
+	// any failed state so the unit name is reusable. `stop` returns
+	// non-zero for a unit that was never started — a no-op for us.
+	_ = execCommand("systemctl", "--user", "stop", unit).Run()
+	_ = execCommand("systemctl", "--user", "reset-failed", unit).Run()
+
+	statusLog.Info("service_unit_stopped",
+		slog.String("unit", unit),
+		slog.String("session", own.SessionName),
+		slog.String("reason", reason),
+		slog.Int("retired_server_pid", own.RetiredServerPID))
+
+	return ServiceUnitDecision{Unit: unit, Stopped: true, Reason: reason}
+}
+
+// ServiceUnitOwnership snapshots the ownership evidence for this session's
+// service unit. MUST be called while the session is still live — it reads
+// the pid of the tmux server generation the session belongs to, which is
+// unobservable after teardown.
+func (s *Session) ServiceUnitOwnership() ServiceUnitOwnership {
+	if s == nil {
+		return ServiceUnitOwnership{}
+	}
+	return ServiceUnitOwnership{
+		SessionName:      s.Name,
+		SocketName:       s.SocketName,
+		RetiredServerPID: s.ServerPID(),
+	}
+}
+
+// ServerPID returns the pid of the tmux server hosting this session, or 0
+// when it cannot be determined (server gone, wedged, or probe timeout).
+// Bounded like every other read-only probe in this package.
+func (s *Session) ServerPID() int {
+	out, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{pid}")
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}

--- a/internal/tmux/service_unit_ownership_test.go
+++ b/internal/tmux/service_unit_ownership_test.go
@@ -1,0 +1,462 @@
+// Tests for the per-session ownership lease that gates service-mode unit
+// teardown (issue #1721).
+//
+// The landing gate on the issue is behavioural:
+//
+//  1. two live sibling sessions share the service-mode unit,
+//  2. removing one never stops, respawns, or changes the other,
+//  3. stale-generation teardown cannot affect the replacement generation,
+//  4. unit shutdown occurs only after exclusive ownership is established.
+//
+// Those four are pinned here without systemd and without a live tmux
+// server: server occupancy, unit state, pid liveness and systemctl
+// presence all come in through package seams, so the cases run identically
+// on the macOS CI jobs (no systemd at all) and on Linux.
+package tmux
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveSet builds the authoritative "sessions on this socket" set.
+func liveSet(names ...string) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return set
+}
+
+// withServiceUnitSeams pins every external dependency of the gate:
+// systemctl presence, unit state, server occupancy and pid liveness. It
+// returns a pointer to the recorded systemctl argv so a test can assert
+// that NO stop was issued (the whole point of the gate).
+func withServiceUnitSeams(
+	t *testing.T,
+	state serviceUnitState,
+	stateErr error,
+	live map[string]struct{},
+	liveErr error,
+) *[][]string {
+	t.Helper()
+
+	origExec := execCommand
+	origLook := systemctlLookPath
+	origState := readServiceUnitState
+	origLive := liveSessionsOnSocket
+	t.Cleanup(func() {
+		execCommand = origExec
+		systemctlLookPath = origLook
+		readServiceUnitState = origState
+		liveSessionsOnSocket = origLive
+	})
+
+	var calls [][]string
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, arg...))
+		// Never touch the host's systemd: run a harmless no-op instead.
+		return exec.Command("true")
+	}
+	systemctlLookPath = func() error { return nil }
+	readServiceUnitState = func(string) (serviceUnitState, error) { return state, stateErr }
+	liveSessionsOnSocket = func(string) (map[string]struct{}, error) { return live, liveErr }
+
+	return &calls
+}
+
+// systemctlStopCalls returns the recorded `systemctl --user stop` argv.
+func systemctlStopCalls(calls [][]string) [][]string {
+	var stops [][]string
+	for _, c := range calls {
+		if len(c) >= 4 && c[0] == "systemctl" && c[1] == "--user" && c[2] == "stop" {
+			stops = append(stops, c)
+		}
+	}
+	return stops
+}
+
+// --- gate #1: the shared unit is reachable in the first place -------------
+
+// TestServiceUnitName_TwoSessionsCanShareOneUnit is the precondition the
+// issue describes: unit names are derived from a sanitized, 48-byte-
+// truncated session name, so two DISTINCT sessions can map to one unit.
+// Unconditional teardown of that unit is therefore never safe.
+func TestServiceUnitName_TwoSessionsCanShareOneUnit(t *testing.T) {
+	a := "agentdeck_release_candidate_verification_worker_alpha_a1b2c3d4"
+	b := "agentdeck_release_candidate_verification_worker_beta_e5f6a7b8"
+	require.NotEqual(t, a, b, "sessions must be distinct for the case to mean anything")
+
+	require.Equal(t, ServiceUnitName(a), ServiceUnitName(b),
+		"long sibling session names collapse to ONE unit name — the shared-unit precondition")
+	require.True(t, strings.HasSuffix(ServiceUnitName(a), ".service"))
+	require.Equal(t, serviceUnitBase(a)+".service", ServiceUnitName(a),
+		"spawn (base) and teardown (base+.service) must share one derivation")
+}
+
+// --- gate #2: removing one session never touches the sibling --------------
+
+// TestStopServiceUnitOwned_SiblingOnSharedServer_IssuesNoStop is the core
+// case: our session is gone but a sibling still lives on the tmux server
+// the unit supervises. No systemctl stop may be issued — KillMode=
+// control-group would take the sibling down with the server.
+func TestStopServiceUnitOwned_SiblingOnSharedServer_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "active", MainPID: 4242, MainPIDAlive: true},
+		nil,
+		liveSet("agentdeck_sibling_b2b2b2b2"),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{
+		SessionName:      "agentdeck_removed_a1a1a1a1",
+		RetiredServerPID: 4242,
+	})
+
+	assert.False(t, dec.Stopped, "a co-tenanted unit must never be stopped")
+	assert.Equal(t, UnitStopSkipServerShared, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls),
+		"no systemctl stop may be issued while a sibling session shares the server")
+}
+
+// TestStopServiceUnitOwned_DeadUnitButSiblingRegistered: even when the
+// unit has no live main process, a sibling still on the socket blocks the
+// stop — stopping would cancel the restart protection the sibling relies
+// on ("never ... respawns, or changes the other").
+func TestStopServiceUnitOwned_DeadUnitButSiblingLive_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "inactive", MainPID: 0, MainPIDAlive: false},
+		nil,
+		liveSet("agentdeck_sibling_b2b2b2b2"),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "agentdeck_removed_a1a1a1a1"})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipServerShared, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// TestStopServiceUnitOwned_OwnSessionStillLive_IssuesNoStop: teardown did
+// not complete. Stopping the unit now would substitute a cgroup-wide kill
+// for a session kill.
+func TestStopServiceUnitOwned_OwnSessionStillLive_IssuesNoStop(t *testing.T) {
+	const name = "agentdeck_removed_a1a1a1a1"
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "active", MainPID: 4242, MainPIDAlive: true},
+		nil,
+		liveSet(name),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: name, RetiredServerPID: 4242})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipSessionStillLive, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// --- gate #3: stale teardown cannot hit the replacement generation -------
+
+// TestStopServiceUnitOwned_ReplacementGeneration_IssuesNoStop: the pid we
+// retired is gone and Restart=on-failure already brought up a NEW tmux
+// server generation. A stop now would kill that replacement.
+func TestStopServiceUnitOwned_ReplacementGeneration_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "active", MainPID: 9999, MainPIDAlive: true},
+		nil,
+		liveSet(), // replacement server has no agent-deck session (yet)
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{
+		SessionName:      "agentdeck_removed_a1a1a1a1",
+		RetiredServerPID: 4242, // the generation we killed, not 9999
+	})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipReplacementGeneration, dec.Reason,
+		"a live main pid that is not the generation we retired is a replacement")
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// TestStopServiceUnitOwned_StartJobInFlight_IssuesNoStop: systemd is
+// activating the unit, so MainPID is not published yet. A dead-pid reading
+// must not be mistaken for "nothing left to protect".
+func TestStopServiceUnitOwned_StartJobInFlight_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "activating", MainPID: 0, MainPIDAlive: false},
+		nil,
+		liveSet(),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "agentdeck_removed_a1a1a1a1"})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipStartJobInFlight, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// TestStopServiceUnitOwned_UnitProcessAlive_IssuesNoStop: the supervised
+// process is alive and we have no generation identity to attribute it to.
+// Unproven ownership must skip.
+func TestStopServiceUnitOwned_UnitProcessAlive_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "active", MainPID: 4242, MainPIDAlive: true},
+		nil,
+		liveSet(),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "agentdeck_removed_a1a1a1a1"})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipProcessAlive, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// --- indeterminate evidence is never treated as "safe" -------------------
+
+// TestStopServiceUnitOwned_IndeterminateSessionProbe_IssuesNoStop: a
+// wedged server makes the occupancy probe time out. ListSessionNamesOnSocket's
+// contract says treat that as "assume alive", never as "no sessions".
+func TestStopServiceUnitOwned_IndeterminateSessionProbe_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "inactive", MainPID: 0, MainPIDAlive: false},
+		nil,
+		nil,
+		errors.New("probe timed out"),
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "agentdeck_removed_a1a1a1a1"})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipIndeterminate, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// TestStopServiceUnitOwned_UnreadableUnitState_IssuesNoStop: systemctl show
+// failed, so the unit's state is unknown. Skip.
+func TestStopServiceUnitOwned_UnreadableUnitState_IssuesNoStop(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{},
+		errors.New("systemctl show: connection refused"),
+		liveSet(),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "agentdeck_removed_a1a1a1a1"})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipIndeterminate, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// TestStopServiceUnitOwned_EmptySessionName_NeverGuessesAUnit: an instance
+// with no tmux session must not resolve to the sanitizer's "session"
+// fallback unit and stop somebody else's unit.
+func TestStopServiceUnitOwned_EmptySessionName_NeverGuessesAUnit(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "inactive"},
+		nil,
+		liveSet(),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "  "})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipNoTmuxSession, dec.Reason)
+	assert.Empty(t, dec.Unit, "no unit may be derived from an empty session name")
+	assert.Empty(t, *calls, "no systemctl call at all for a session-less instance")
+}
+
+// TestStopServiceUnitOwned_NoSystemctl_IsANoOp: non-systemd hosts (every
+// macOS user) must short-circuit without touching anything.
+func TestStopServiceUnitOwned_NoSystemctl_IsANoOp(t *testing.T) {
+	calls := withServiceUnitSeams(t, serviceUnitState{}, nil, liveSet(), nil)
+	systemctlLookPath = func() error { return exec.ErrNotFound }
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: "agentdeck_removed_a1a1a1a1"})
+
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipNoSystemctl, dec.Reason)
+	assert.Equal(t, ServiceUnitName("agentdeck_removed_a1a1a1a1"), dec.Unit)
+	assert.Empty(t, *calls)
+}
+
+// --- gate #4: shutdown only once ownership is established ----------------
+
+// TestStopServiceUnitOwned_ExclusiveOwner_StopsAndResetsFailed: the server
+// is empty, the unit has no live process and no start job is in flight —
+// ownership is exclusive, so removal stays terminal (Restart=on-failure
+// must not resurrect the session).
+func TestStopServiceUnitOwned_ExclusiveOwner_StopsAndResetsFailed(t *testing.T) {
+	const name = "agentdeck_removed_a1a1a1a1"
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "failed", MainPID: 0, MainPIDAlive: false},
+		nil,
+		liveSet(),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: name, RetiredServerPID: 4242})
+
+	require.True(t, dec.Stopped, "exclusive ownership must retire the unit")
+	assert.Equal(t, UnitStopReasonExclusive, dec.Reason)
+	unit := ServiceUnitName(name)
+	assert.Equal(t, [][]string{
+		{"systemctl", "--user", "stop", unit},
+		{"systemctl", "--user", "reset-failed", unit},
+	}, *calls, "exclusive teardown is exactly stop + reset-failed on OUR unit")
+}
+
+// TestStopServiceUnitOwned_ExclusiveOwner_OurGenerationStillTracked: the
+// unit's recorded main pid IS the generation we retired and it is dead.
+// Still exclusive — stop is allowed.
+func TestStopServiceUnitOwned_ExclusiveOwner_DeadOwnGeneration(t *testing.T) {
+	calls := withServiceUnitSeams(t,
+		serviceUnitState{ActiveState: "active", MainPID: 4242, MainPIDAlive: false},
+		nil,
+		liveSet(),
+		nil,
+	)
+
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{
+		SessionName:      "agentdeck_removed_a1a1a1a1",
+		RetiredServerPID: 4242,
+	})
+
+	require.True(t, dec.Stopped)
+	assert.Equal(t, UnitStopReasonExclusive, dec.Reason)
+	assert.Len(t, systemctlStopCalls(*calls), 1)
+}
+
+// --- predicate + parser units -------------------------------------------
+
+// TestEvaluateServiceUnitOwnership_Table pins the predicate itself, including
+// precedence between the skip reasons.
+func TestEvaluateServiceUnitOwnership_Table(t *testing.T) {
+	const self = "agentdeck_self_a1a1a1a1"
+
+	cases := []struct {
+		name       string
+		own        ServiceUnitOwnership
+		state      serviceUnitState
+		live       map[string]struct{}
+		liveErr    error
+		wantStop   bool
+		wantReason string
+	}{
+		{
+			name:       "indeterminate probe wins over everything",
+			own:        ServiceUnitOwnership{SessionName: self},
+			state:      serviceUnitState{ActiveState: "inactive"},
+			liveErr:    errors.New("timeout"),
+			wantReason: UnitStopSkipIndeterminate,
+		},
+		{
+			name:       "own session still live wins over sibling count",
+			own:        ServiceUnitOwnership{SessionName: self},
+			state:      serviceUnitState{ActiveState: "inactive"},
+			live:       liveSet(self, "agentdeck_other_b2b2b2b2"),
+			wantReason: UnitStopSkipSessionStillLive,
+		},
+		{
+			name:       "sibling blocks even when unit looks idle",
+			own:        ServiceUnitOwnership{SessionName: self},
+			state:      serviceUnitState{ActiveState: "inactive"},
+			live:       liveSet("agentdeck_other_b2b2b2b2"),
+			wantReason: UnitStopSkipServerShared,
+		},
+		{
+			name:       "non-agentdeck session on the shared server also blocks",
+			own:        ServiceUnitOwnership{SessionName: self},
+			state:      serviceUnitState{ActiveState: "inactive"},
+			live:       liveSet("my-own-tmux-session"),
+			wantReason: UnitStopSkipServerShared,
+		},
+		{
+			name:       "start job in flight blocks",
+			own:        ServiceUnitOwnership{SessionName: self},
+			state:      serviceUnitState{ActiveState: "activating"},
+			live:       liveSet(),
+			wantReason: UnitStopSkipStartJobInFlight,
+		},
+		{
+			name:       "replacement generation blocks",
+			own:        ServiceUnitOwnership{SessionName: self, RetiredServerPID: 1},
+			state:      serviceUnitState{ActiveState: "active", MainPID: 2, MainPIDAlive: true},
+			live:       liveSet(),
+			wantReason: UnitStopSkipReplacementGeneration,
+		},
+		{
+			name:       "live process without generation identity blocks",
+			own:        ServiceUnitOwnership{SessionName: self},
+			state:      serviceUnitState{ActiveState: "active", MainPID: 2, MainPIDAlive: true},
+			live:       liveSet(),
+			wantReason: UnitStopSkipProcessAlive,
+		},
+		{
+			name:       "exclusive owner",
+			own:        ServiceUnitOwnership{SessionName: self, RetiredServerPID: 1},
+			state:      serviceUnitState{ActiveState: "failed"},
+			live:       liveSet(),
+			wantStop:   true,
+			wantReason: UnitStopReasonExclusive,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stop, reason := evaluateServiceUnitOwnership(tc.own, tc.state, tc.live, tc.liveErr)
+			assert.Equal(t, tc.wantStop, stop)
+			assert.Equal(t, tc.wantReason, reason)
+		})
+	}
+}
+
+// TestParseServiceUnitState pins the systemctl show parsing, including the
+// not-found shape (MainPID=0) and a pid that is not alive.
+func TestParseServiceUnitState(t *testing.T) {
+	orig := unitPIDAlive
+	unitPIDAlive = func(pid int) bool { return pid == 4242 }
+	t.Cleanup(func() { unitPIDAlive = orig })
+
+	alive := parseServiceUnitState("ActiveState=active\nMainPID=4242\n")
+	assert.Equal(t, "active", alive.ActiveState)
+	assert.Equal(t, 4242, alive.MainPID)
+	assert.True(t, alive.MainPIDAlive)
+
+	notFound := parseServiceUnitState("ActiveState=inactive\nMainPID=0\n")
+	assert.Equal(t, "inactive", notFound.ActiveState)
+	assert.Zero(t, notFound.MainPID)
+	assert.False(t, notFound.MainPIDAlive)
+
+	stale := parseServiceUnitState("MainPID=777\nActiveState=active\n")
+	assert.Equal(t, 777, stale.MainPID)
+	assert.False(t, stale.MainPIDAlive, "a recorded pid that is gone is not alive")
+}
+
+// TestSessionServiceUnitOwnership_CapturesSocketAndName: the snapshot the
+// remove path takes must carry the socket (so occupancy is probed on the
+// right server) and the session name (so the unit is derived, not guessed).
+func TestSessionServiceUnitOwnership_CapturesSocketAndName(t *testing.T) {
+	s := NewSession("ownership-snapshot", "/tmp")
+	s.SocketName = "ad-test-socket"
+
+	own := s.ServiceUnitOwnership()
+	assert.Equal(t, s.Name, own.SessionName)
+	assert.Equal(t, "ad-test-socket", own.SocketName)
+
+	var nilSession *Session
+	assert.Equal(t, ServiceUnitOwnership{}, nilSession.ServiceUnitOwnership(),
+		"a nil session must yield the always-skip zero value")
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1295,7 +1295,7 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		tmuxArgs = append(tmuxArgs, bashBinary, "-c", command)
 	}
 
-	unitBase := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(s.Name)
+	unitBase := serviceUnitBase(s.Name)
 
 	switch s.resolveLaunchMode() {
 	case launchModeService:
@@ -1341,7 +1341,7 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 // when service-mode spawn fails and we retry with scope mode before
 // falling all the way back to direct tmux.
 func buildScopeArgsFromTmuxArgs(sessionName string, tmuxArgs []string) []string {
-	unitBase := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(sessionName)
+	unitBase := serviceUnitBase(sessionName)
 	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux"}
 	return append(scopeArgs, tmuxArgs...)
 }
@@ -1370,29 +1370,12 @@ func wasScopeModeArgs(args []string) bool {
 	return false
 }
 
-// StopServiceUnit best-effort stops + resets-failed the transient
-// user-level service for the given session name. Called by
-// agent-deck remove on service-mode sessions to guarantee the unit
-// does not Restart=on-failure its way back into existence after
-// removal. Errors are returned but callers typically log-and-continue.
-//
-// Returns nil on non-systemd hosts (no-op), on already-stopped units,
-// and on hosts where systemctl is missing — removal must not block on
-// systemd availability.
-//
-// The unit name derivation mirrors startCommandSpec's service branch:
-// "agentdeck-tmux-" + sanitized(sessionName) + ".service".
-func StopServiceUnit(sessionName string) error {
-	if _, err := exec.LookPath("systemctl"); err != nil {
-		return nil // no systemctl → nothing to stop
-	}
-	unit := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(sessionName) + ".service"
-	// `stop` returns non-zero if the unit was never started; that's a
-	// no-op for our purposes — swallow and continue to reset-failed.
-	_ = execCommand("systemctl", "--user", "stop", unit).Run()
-	_ = execCommand("systemctl", "--user", "reset-failed", unit).Run()
-	return nil
-}
+// Service-unit teardown lives in service_unit_ownership.go: it must go
+// through StopServiceUnitOwned, which proves exclusive ownership of the
+// unit before stopping it. The unconditional StopServiceUnit(sessionName)
+// this file used to export was removed in issue #1721 — on the shared
+// default socket it could stop the tmux server (and every sibling session
+// in its cgroup) that one deleted session merely happened to name.
 
 // stripSystemdRunPrefix removes the leading systemd-run flags from args
 // produced by startCommandSpec (either scope-mode or service-mode form)

--- a/internal/tmux/tmux_service_integration_test.go
+++ b/internal/tmux/tmux_service_integration_test.go
@@ -170,16 +170,16 @@ func TestTmuxService_ExplicitStopDoesNotTriggerRestart(t *testing.T) {
 		"expected tmux daemon to stay dead after systemctl stop; got PID %d", after)
 }
 
-// TestStopServiceUnit_HandlesMissingSystemd: on hosts without systemctl
-// the helper must return nil (no-op) so `agent-deck remove` on a
-// non-systemd host doesn't spew errors.
-func TestStopServiceUnit_HandlesMissingSystemd(t *testing.T) {
-	// We can't easily remove systemctl from PATH in a test without
-	// mutating global state. Instead, call StopServiceUnit with a
-	// name that will never match an existing unit and verify it
-	// returns nil (best-effort semantics).
-	err := StopServiceUnit("does-not-exist-" + randomServerSuffix(t))
-	require.NoError(t, err, "StopServiceUnit must never return an error — it's best-effort cleanup")
+// TestStopServiceUnitOwned_UnknownSessionNeverErrors: the teardown gate is
+// best-effort on every host — an unknown session name (and therefore an
+// unknown unit) must produce a decision, never a panic or an error, so
+// `agent-deck remove` on a non-systemd host doesn't spew errors.
+func TestStopServiceUnitOwned_UnknownSessionNeverErrors(t *testing.T) {
+	name := "does-not-exist-" + randomServerSuffix(t)
+	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: name})
+	require.Equal(t, ServiceUnitName(name), dec.Unit,
+		"decision must name the unit derived from the session")
+	require.NotEmpty(t, dec.Reason, "every decision must carry a reason")
 }
 
 // waitForServicePID polls systemctl show until MainPID becomes non-zero


### PR DESCRIPTION
## Problem

`agent-deck remove` called `tmux.StopServiceUnit(sessionName)` unconditionally (`cmd/agent-deck/main.go`), which `systemctl --user stop`ped the transient unit derived from the removed session's name.

That unit supervises a tmux **server**, not a session. On the default socket every agent-deck session shares one server, whose cgroup is anchored by whichever session's unit happened to spawn it first, and the unit is created with `KillMode=control-group`. So a single deletion could:

1. stop the shared server and kill every sibling session in its cgroup,
2. cancel the restart protection a sibling still relied on, or
3. tear down a **replacement generation** that `Restart=on-failure` had already brought up after the generation we meant to retire died.

Unit-name derivation makes co-tenancy worse rather than better: `sanitizeSystemdUnitComponent` lowercases, collapses every non-alphanumeric byte to `-` and truncates at 48 bytes, so two distinct sessions with long similar titles map to the **same** unit name (pinned by a test in this PR).

## Fix

An ownership lease at the stop/delete path. `tmux.StopServiceUnitOwned(ServiceUnitOwnership)` retires the unit only when the terminating lifecycle is proven to be its exclusive owner:

| Condition | Decision |
| --- | --- |
| session/unit probe indeterminate (timeout, unreadable unit state) | skip `ownership_indeterminate` |
| our own session still on the server (teardown incomplete) | skip `session_still_live` |
| any other session on the server (sibling or the user's own) | skip `tmux_server_shared` |
| systemd start job in flight (`activating`) — MainPID not published yet | skip `unit_start_job_in_flight` |
| live MainPID that is not the generation we retired | skip `replacement_generation` |
| live MainPID we cannot attribute to ourselves | skip `unit_process_alive` |
| empty server, no start job, no live main process | **stop + reset-failed** `exclusive_owner` |

Every skip is a no-op, never an error: leaving a transient unit loaded is recoverable, killing a sibling session is not. Each decision is logged with the unit, reason, active state, unit MainPID, retired server pid and live-session count.

The ownership record is snapshotted **before** teardown (`inst.ServiceUnitOwnership()`), because the tmux server generation a session belonged to is unobservable once the session is killed. An instance with no tmux session yields a record that can never name a unit, so the sanitizer's `session` fallback (`agentdeck-tmux-session.service`) can no longer be stopped by accident.

Terminal removal is preserved where it actually mattered: a server that died abnormally leaves a dead MainPID on an empty socket — exactly the exclusive-owner case — so `Restart=on-failure` still cannot resurrect the last session. A server that exited cleanly does not trigger `on-failure` at all.

The unsafe `StopServiceUnit` export is removed rather than deprecated, and unit-name derivation is centralised in `serviceUnitBase` / `ServiceUnitName` so spawn and teardown cannot drift.

## Landing gate from the issue

1. **Two live sibling sessions share the service-mode unit** — `TestServiceUnitName_TwoSessionsCanShareOneUnit` pins that two distinct long session names collapse to one unit name.
2. **Removing one never stops, respawns, or changes the other** — `TestStopServiceUnitOwned_SiblingOnSharedServer_IssuesNoStop` and `..._DeadUnitButSiblingLive_IssuesNoStop` assert `Stopped == false` **and** that zero `systemctl --user stop` calls were issued.
3. **Stale generation teardown cannot affect the replacement generation** — `..._ReplacementGeneration_IssuesNoStop` (live MainPID != retired pid) and `..._StartJobInFlight_IssuesNoStop` (dead pid must not be read as "nothing to protect" while systemd is activating).
4. **Unit shutdown only after exclusive ownership is established** — `..._ExclusiveOwner_StopsAndResetsFailed` asserts the exact argv pair on our own unit, plus a predicate table pinning skip precedence.

## Tests

`internal/tmux/service_unit_ownership_test.go` (13 cases incl. a precedence table) and `internal/session/service_unit_ownership_test.go`. Systemctl presence, unit state, pid liveness and server occupancy all come in through package seams, so the whole suite runs identically on the macOS CI jobs (no systemd) and on Linux — no systemd, no live tmux server, no host state touched. The pre-existing `TestStopServiceUnit_HandlesMissingSystemd` is rewritten against the new entry point.

Local verification was `go build ./...` + `go vet` + `gofmt`; the test suite runs in CI.

Refs #1721