### PR TITLE
fix(test): make three internal/session tests host-independent on macOS (closes #1720)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5821,9 +5821,26 @@ func resolveClaudeTranscriptPath(configDir, projectPath, sessionID string) strin
 
 	// Primary: the directory name Claude derives from the project path. Claude
 	// replaces every non-alphanumeric char with a hyphen.
-	primary := filepath.Join(projectsDir, ConvertToClaudeDirName(resolvedPath), sessionID+".jsonl")
-	if _, err := os.Stat(primary); err == nil {
-		return primary
+	//
+	// Both encodings of the project path are tried as EXACT candidates, resolved
+	// first: Claude names the directory from getcwd() (the physical path), but a
+	// transcript recorded through a symlinked path — or copied from another host
+	// — can carry the unresolved form. Checking the second candidate here keeps
+	// the resolution deterministic and, more importantly, keeps it OUT of the
+	// glob fallback below, which cannot tell two projects apart when they share
+	// a session id (issue #1720).
+	candidateDirs := []string{resolvedPath}
+	if projectPath != resolvedPath {
+		candidateDirs = append(candidateDirs, projectPath)
+	}
+	for _, candidateDir := range candidateDirs {
+		if candidateDir == "" {
+			continue
+		}
+		candidate := filepath.Join(projectsDir, ConvertToClaudeDirName(candidateDir), sessionID+".jsonl")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
 	}
 
 	// Fallback: the transcript may live under a differently-encoded directory name

--- a/internal/session/issue1218_launch_shell_test.go
+++ b/internal/session/issue1218_launch_shell_test.go
@@ -27,13 +27,26 @@ import (
 // unchanged, sandbox/SSH/shell sessions are excluded, and both per-session
 // and global config levels work correctly.
 
-// launchShellTestEnv isolates HOME and SHELL for deterministic testing.
+// launchShellTestEnv isolates HOME, SHELL and ZDOTDIR for deterministic testing.
+//
+// ZDOTDIR matters (issue #1720): zsh reads its startup files from $ZDOTDIR when
+// that variable is set and only falls back to $HOME when it is not. Developer
+// setups that manage zsh through a dotfiles manager (nix home-manager, chezmoi,
+// …) export ZDOTDIR from the login shell, so the variable is INHERITED by
+// `go test` and by every child zsh it spawns. Overriding HOME alone then leaves
+// the fixture ~/.zshrc unread — the real zsh config is loaded instead — and the
+// zsh happy-path test fails on that machine while passing on CI (where ZDOTDIR
+// is unset). Pinning ZDOTDIR to the sandbox HOME makes "~/.zshrc" and
+// "$ZDOTDIR/.zshrc" the same fixture file on every host.
 func launchShellTestEnv(t *testing.T) {
 	t.Helper()
 	origHome := os.Getenv("HOME")
 	origShell := os.Getenv("SHELL")
-	os.Setenv("HOME", t.TempDir())
+	origZDotDir, hadZDotDir := os.LookupEnv("ZDOTDIR")
+	home := t.TempDir()
+	os.Setenv("HOME", home)
 	os.Setenv("SHELL", "/bin/zsh") // Set a deterministic shell for tests
+	os.Setenv("ZDOTDIR", home)     // zsh startup files must resolve inside the sandbox
 	ClearUserConfigCache()
 	t.Cleanup(func() {
 		os.Setenv("HOME", origHome)
@@ -41,6 +54,11 @@ func launchShellTestEnv(t *testing.T) {
 			os.Setenv("SHELL", origShell)
 		} else {
 			os.Unsetenv("SHELL")
+		}
+		if hadZDotDir {
+			os.Setenv("ZDOTDIR", origZDotDir)
+		} else {
+			os.Unsetenv("ZDOTDIR")
 		}
 		ClearUserConfigCache()
 	})
@@ -53,8 +71,14 @@ func runLaunchShellCommand(t *testing.T, wrapped, shell string) string {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", wrapped)
+	// ZDOTDIR is passed explicitly for the same reason it is pinned in
+	// launchShellTestEnv: an inherited value would send the child zsh looking
+	// for startup files outside the sandbox HOME (issue #1720). Later entries
+	// win in os/exec's environment de-duplication, so these override whatever
+	// os.Environ() carried in.
 	cmd.Env = append(os.Environ(),
 		"HOME="+os.Getenv("HOME"),
+		"ZDOTDIR="+os.Getenv("HOME"),
 		"SHELL="+shell,
 		"PS1=",
 		"PROMPT=",
@@ -103,14 +127,18 @@ func TestLaunchShell_ZshRCLoadedWhenEnabled(t *testing.T) {
 	inst := NewInstanceWithTool("ls-opencode", t.TempDir(), "opencode")
 	inst.LaunchShell = boolPtr(true)
 
-	raw := `printf '__AGENT_DECK__%s__' "$AGENT_DECK_LAUNCH_SHELL_TEST"`
+	// The fixture value comes first so the assertion below is a plain prefix
+	// match; the trailing startup dir is diagnostic only — if some host still
+	// redirects zsh's startup files (e.g. a system /etc/zshenv that sets
+	// ZDOTDIR), the failure output names the directory it actually read.
+	raw := `printf '__AGENT_DECK__%s__(startup_dir=%s)' "$AGENT_DECK_LAUNCH_SHELL_TEST" "${ZDOTDIR:-$HOME}"`
 	wrapped := inst.wrapLaunchShell(raw)
 
 	if !strings.HasPrefix(wrapped, "/bin/zsh -il -c '") {
 		t.Fatalf("wrapped command must start with '/bin/zsh -il -c ', got:\n%s", wrapped)
 	}
 	if out := runLaunchShellCommand(t, wrapped, "/bin/zsh"); !strings.Contains(out, "__AGENT_DECK__zshrc__") {
-		t.Fatalf("wrapped command must load ~/.zshrc, output:\n%s", out)
+		t.Fatalf("wrapped command must load the sandbox ~/.zshrc (%s), output:\n%s", os.Getenv("HOME"), out)
 	}
 }
 

--- a/internal/session/issue1349_rebind_guard_test.go
+++ b/internal/session/issue1349_rebind_guard_test.go
@@ -128,8 +128,8 @@ func bootstrapDaemonProfile(t *testing.T, profile string) (*TransitionDaemon, *S
 // instead made every lookup miss its primary path on macOS, where t.TempDir()
 // lives under /var/folders → /private/var/folders, and fall back to the
 // session-id glob — which cross-mapped two different projects onto one
-// transcript (issue #1720). writeTranscript1349Raw covers the fallback on
-// purpose.
+// transcript (issue #1720). writeTranscript1349Raw writes the other encoding on
+// purpose, to exercise the second exact candidate.
 func writeTranscript1349(t *testing.T, inst *Instance, sessionID string, n int) {
 	t.Helper()
 	dir := inst.EffectiveWorkingDir()
@@ -142,7 +142,8 @@ func writeTranscript1349(t *testing.T, inst *Instance, sessionID string, n int) 
 // writeTranscript1349Raw materializes the transcript under the UNRESOLVED
 // project-path encoding, modelling a transcript directory whose name does not
 // match the physical path (the WSL Linux-vs-Windows cwd case, and any host where
-// the project path traverses a symlink). Used to pin the fallback lookup.
+// the project path traverses a symlink). Used to pin the second exact candidate
+// in resolveClaudeTranscriptPath — the one checked before the glob fallback.
 func writeTranscript1349Raw(t *testing.T, inst *Instance, sessionID string, n int) {
 	t.Helper()
 	writeTranscript1349At(t, GetClaudeConfigDirForInstance(inst), inst.EffectiveWorkingDir(), sessionID, n)

--- a/internal/session/issue1349_rebind_guard_test.go
+++ b/internal/session/issue1349_rebind_guard_test.go
@@ -120,10 +120,37 @@ func bootstrapDaemonProfile(t *testing.T, profile string) (*TransitionDaemon, *S
 // + session id with `n` conversation records (each containing a "sessionId"
 // field, which is what sessionHasConversationData detects). Larger n => larger
 // byte size, so it can win the v1.7.23 size guard during a rebind.
+//
+// The transcript lands under the SYMLINK-RESOLVED project encoding because that
+// is what Claude Code itself produces (it derives the directory name from
+// getcwd(), which is always the physical path) and therefore what
+// resolveClaudeTranscriptPath looks up first. Writing the unresolved encoding
+// instead made every lookup miss its primary path on macOS, where t.TempDir()
+// lives under /var/folders → /private/var/folders, and fall back to the
+// session-id glob — which cross-mapped two different projects onto one
+// transcript (issue #1720). writeTranscript1349Raw covers the fallback on
+// purpose.
 func writeTranscript1349(t *testing.T, inst *Instance, sessionID string, n int) {
 	t.Helper()
-	configDir := GetClaudeConfigDirForInstance(inst)
-	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(inst.EffectiveWorkingDir()))
+	dir := inst.EffectiveWorkingDir()
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	writeTranscript1349At(t, GetClaudeConfigDirForInstance(inst), dir, sessionID, n)
+}
+
+// writeTranscript1349Raw materializes the transcript under the UNRESOLVED
+// project-path encoding, modelling a transcript directory whose name does not
+// match the physical path (the WSL Linux-vs-Windows cwd case, and any host where
+// the project path traverses a symlink). Used to pin the fallback lookup.
+func writeTranscript1349Raw(t *testing.T, inst *Instance, sessionID string, n int) {
+	t.Helper()
+	writeTranscript1349At(t, GetClaudeConfigDirForInstance(inst), inst.EffectiveWorkingDir(), sessionID, n)
+}
+
+func writeTranscript1349At(t *testing.T, configDir, projectPath, sessionID string, n int) {
+	t.Helper()
+	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(projectPath))
 	if err := os.MkdirAll(projDir, 0o755); err != nil {
 		t.Fatalf("mkdir transcript dir: %v", err)
 	}
@@ -418,6 +445,75 @@ func TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision(t *testing.T) 
 	}
 	if gotA == "" || gotB == "" || gotA == gotB {
 		t.Fatalf("expected two distinct non-empty transcript paths, got a=%q b=%q", gotA, gotB)
+	}
+}
+
+// TestResolveClaudeTranscriptPath_UnresolvedEncodingStaysPerProject pins the
+// issue #1720 hardening in resolveClaudeTranscriptPath: when a transcript
+// directory is named from the UNRESOLVED project path (project path traverses a
+// symlink — on macOS every t.TempDir() does, via /var → /private/var), the exact
+// second candidate must win. Before the fix the primary (resolved) candidate
+// missed and the session-id glob answered instead, handing two different
+// projects that share a session id the SAME transcript file — the cross-routing
+// hazard #1349 exists to prevent.
+func TestResolveClaudeTranscriptPath_UnresolvedEncodingStaysPerProject(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	// A symlinked project root guarantees resolved != unresolved on every
+	// platform, so the test pins the fallback rather than accidentally hitting
+	// the primary candidate.
+	physical := filepath.Join(home, "physical")
+	if err := os.MkdirAll(physical, 0o755); err != nil {
+		t.Fatalf("mkdir physical: %v", err)
+	}
+	linked := filepath.Join(home, "linked")
+	if err := os.Symlink(physical, linked); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	const sharedID = "UNRESOLVED-ENCODING-SESSION"
+
+	mk := func(id, sub string) *Instance {
+		pp := filepath.Join(linked, sub)
+		if err := os.MkdirAll(pp, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+		inst := &Instance{
+			ID:              id,
+			Title:           id,
+			ProjectPath:     pp,
+			GroupPath:       DefaultGroupPath,
+			Tool:            "claude",
+			Status:          StatusRunning,
+			ClaudeSessionID: sharedID,
+			CreatedAt:       time.Now(),
+		}
+		writeTranscript1349Raw(t, inst, sharedID, 2)
+		return inst
+	}
+	a := mk("inst-a-unresolved", "projA")
+	b := mk("inst-b-unresolved", "projB")
+
+	gotA := a.GetJSONLPath()
+	gotB := b.GetJSONLPath()
+	if gotA == "" || gotB == "" {
+		t.Fatalf("transcript stored under the unresolved encoding must still resolve, got a=%q b=%q", gotA, gotB)
+	}
+	if gotA == gotB {
+		t.Fatalf("two projects sharing a session id must not resolve to one transcript, got %q for both", gotA)
+	}
+	wantA := filepath.Join(GetClaudeConfigDirForInstance(a), "projects",
+		ConvertToClaudeDirName(a.ProjectPath), sharedID+".jsonl")
+	if gotA != wantA {
+		t.Fatalf("expected the exact unresolved-encoding candidate\n got:  %s\n want: %s", gotA, wantA)
 	}
 }
 

--- a/internal/session/shell_foreground_status_test.go
+++ b/internal/session/shell_foreground_status_test.go
@@ -246,6 +246,15 @@ func TestUpdateStatus_ShellForegroundPromotion(t *testing.T) {
 	// Wait past the 1.5s grace period so UpdateStatus does real detection.
 	time.Sleep(2 * time.Second)
 
+	// End the tmux-side startup window (issue #1720). Otherwise the pane only
+	// leaves "starting" when a poll recognises the login shell's prompt, and the
+	// recognised prompts are the literal "$ ", "# " and "% " — so on a machine
+	// whose shell prints anything else (fish/starship/powerlevel10k "❯", any
+	// dotfiles-managed prompt) every case below would read StatusStarting and
+	// this test would assert the developer's shell configuration rather than the
+	// promotion logic it covers.
+	tmux.ExpireStartupWindowForTest(t, inst.tmuxSession)
+
 	// Fresh cache + flag on: the foreground process promotes idle→running.
 	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
 		inst.tmuxSession.Name: {CurrentCommand: "node"},

--- a/internal/tmux/seed_test_helper.go
+++ b/internal/tmux/seed_test_helper.go
@@ -26,6 +26,30 @@ func SeedPaneInfoCacheForTest(t testing.TB, info map[string]PaneInfo) {
 	})
 }
 
+// ExpireStartupWindowForTest ends the session's startup window (see
+// inStartupWindowLocked) so GetStatus classifies the pane from live evidence
+// instead of reporting "starting".
+//
+// Why tests need this (issue #1720): a session leaves the startup window early
+// only when a poll finds a busy indicator or a PROMPT indicator, and the shell
+// prompt patterns are the literal strings "$ ", "# " and "% ". A pane running
+// the developer's own login shell prints whatever prompt that shell is
+// configured to print — fish, starship, powerlevel10k and friends end in "❯",
+// and a dotfiles-managed zsh prompt need not contain any of the three. Those
+// panes stay "starting" for the full startupStateWindow, so any test that
+// asserts a tmux-derived waiting/idle/running verdict on a real shell session
+// would pass or fail according to the machine's shell configuration. Ending the
+// window explicitly makes the assertion about the code under test.
+func ExpireStartupWindowForTest(t testing.TB, s *Session) {
+	t.Helper()
+	if s == nil {
+		t.Fatal("ExpireStartupWindowForTest: nil session")
+	}
+	s.mu.Lock()
+	s.startupAt = time.Time{}
+	s.mu.Unlock()
+}
+
 // ExpirePaneInfoCacheForTest leaves the cache contents intact but rewinds the
 // timestamp past the freshness threshold so GetCachedPaneInfo treats it as
 // stale. Used to model the case where backgroundStatusUpdate hasn't run for a

--- a/internal/tmux/seed_test_helper.go
+++ b/internal/tmux/seed_test_helper.go
@@ -43,7 +43,10 @@ func SeedPaneInfoCacheForTest(t testing.TB, info map[string]PaneInfo) {
 func ExpireStartupWindowForTest(t testing.TB, s *Session) {
 	t.Helper()
 	if s == nil {
+		// Explicit return: t.Fatal is not a terminating call to static analysis,
+		// so without it the writes below read as a possible nil dereference.
 		t.Fatal("ExpireStartupWindowForTest: nil session")
+		return
 	}
 	s.mu.Lock()
 	s.startupAt = time.Time{}


### PR DESCRIPTION
Fixes the three baseline failures @jwiegley isolated in #1720. All three passed on the Linux CI runner and failed from a clean checkout on macOS arm64 because each one depended on something about the developer's machine rather than on the code under test. Root causes are unrelated, so each is fixed at its own layer.

## 1. `TestLaunchShell_ZshRCLoadedWhenEnabled` — inherited `ZDOTDIR`

zsh reads its startup files from `$ZDOTDIR` whenever that variable is **set**, and only falls back to `$HOME` when it is not. Dotfiles managers (nix home-manager, chezmoi, …) export `ZDOTDIR` from the login shell, so `go test` — and every child zsh it spawns — inherits it. Overriding `HOME` alone therefore left the fixture `~/.zshrc` unread and loaded the real user config instead, which is exactly the reported symptom (the fixture value never appears in the output). CI passes because `ZDOTDIR` is unset there.

Reproduced outside Go, with a fixture `.zshrc` in a sandbox HOME and a second one elsewhere:

```
$ env HOME=$SANDBOX ZDOTDIR=$ELSEWHERE /bin/zsh -il -c '...'
__AGENT_DECK__other-config__     # fixture ignored  → the #1720 failure
$ env HOME=$SANDBOX ZDOTDIR=$SANDBOX /bin/zsh -il -c '...'
__AGENT_DECK__zshrc__            # fixture loaded
```

`launchShellTestEnv` now pins `ZDOTDIR` to the sandbox HOME (restoring the previous value on cleanup), the child environment passes it explicitly, and the failure message names the startup directory zsh actually read so any future host divergence is self-diagnosing.

## 2. `TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision` — symlinked temp dir + glob cross-map

`writeTranscript1349` wrote the transcript under the **unresolved** project-path encoding, while `resolveClaudeTranscriptPath` looks up the **symlink-resolved** one — which is what Claude Code itself produces, since it names its `projects/` directory from `getcwd()` (always the physical path). On macOS every `t.TempDir()` diverges:

```
raw     : /var/folders/.../T/probe…
resolved: /private/var/folders/.../T/probe…
```

So the primary lookup missed for **both** instances and control fell through to the `projects/*/<sessionID>.jsonl` glob, which returns `matches[0]` — the same file for both projects. Hence "two different project paths resolve to the same transcript path".

Two changes:

* `writeTranscript1349` writes the resolved encoding, mirroring what Claude Code produces (this also makes the other tests in that file hit their primary path instead of the fallback on macOS).
* `resolveClaudeTranscriptPath` now tries the unresolved encoding as an **exact second candidate** before the glob. That keeps resolution deterministic and, more importantly, keeps the symlink case out of the glob — which cannot tell two projects apart when they share a session id, the cross-routing hazard #1349 exists to prevent.

New test `TestResolveClaudeTranscriptPath_UnresolvedEncodingStaysPerProject` pins that: two instances sharing a session id under symlinked project paths must resolve to distinct transcripts. It fails via the glob cross-map without the production change.

## 3. `TestUpdateStatus_ShellForegroundPromotion` — the assertion depended on the developer's shell prompt

A session leaves the tmux startup window early only when a poll finds a busy indicator or a **prompt** indicator, and the shell prompt patterns are the literal strings `"$ "`, `"# "` and `"% "`. A shell session's pane runs the developer's login shell, which prints whatever prompt it is configured to print. With the macOS default zsh prompt (`%n@%m %1~ %# `) the `"% "` pattern matches and the test passes; with a two-line or custom prompt it does not:

```
=== pane content ===
/tmp
❯ bash -c 'sleep 60'
=== prompt-pattern match ===
no match [$ ]   no match [# ]   no match [% ]
```

With no match the pane stays `"starting"` for the full `startupStateWindow` (2 min), so `UpdateStatus` maps every case to `StatusStarting` — the reported symptom. Note this is the only code path in `GetStatus` that yields `"starting"`, so the symptom pins the cause.

The test now ends the startup window explicitly via a new `tmux.ExpireStartupWindowForTest` helper (same file and shape as the existing `SeedPaneInfoCacheForTest` / `ExpirePaneInfoCacheForTest`). With the window ended, a quiet live pane settles on `"waiting"` deterministically on every host, so the four cases assert the promotion logic they cover — fresh non-interactive foreground command promotes, stale cache drops back to idle, an interactive program does not promote, and the flag off holds the historical default.

## Scope notes

* No production behavior change for status detection; the only non-test change is the extra exact candidate in `resolveClaudeTranscriptPath`, which is a no-op wherever the project path has no symlinks (the resolved and raw encodings are identical and the candidate list is de-duplicated).
* Follow-up worth filing separately (not changed here, to keep this scoped to #1720): a **real** shell session on a machine with a custom prompt shows `starting` for up to two minutes for the same reason as failure 3, and the `shell_running_indicator` promotion cannot fire during that window. `isPaneShellReady` in `pane_ready.go` shares the assumption. A prompt-string-independent signal (e.g. the pane's foreground command) would fix both.
* `sessionHasConversationData` / `sessionConversationByteSize` / `sessionConversationMtime` have their own resolve-then-fallback lookups with the same glob ambiguity; left untouched here since #1720 does not exercise them.

## Verification

* `go build ./...`, `go vet ./...`, `gofmt` clean.
* Each root cause reproduced outside the Go test binary with the standalone probes quoted above (inherited `ZDOTDIR` redirecting zsh; `EvalSymlinks` divergence for a macOS temp dir; a custom-prompt tmux pane matching none of the three prompt patterns).
* CI proves no Linux regression: the full suite runs on `ubuntu-latest` (`go-test.yml`).
* Worth noting for the record: the only macOS job in CI (`session-persistence.yml` → `unit-xplat`) runs `go test ./scripts/...`, so **no CI job exercises `internal/session` on macOS** — which is why these three could sit on main unnoticed. Adding `macos-latest` to the `go-test.yml` matrix would close that gap; happy to open it as a separate issue/PR rather than widen this one. @jwiegley, a re-run of your original command on this branch would be the direct confirmation.

Closes #1720


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript discovery for projects accessed through symlinked or alternate paths, ensuring the correct session transcript is found.
  * Improved shell startup handling in test environments to prevent host configuration from affecting shell behavior.

* **Tests**
  * Added regression coverage for transcript resolution across symlinked paths.
  * Strengthened shell startup and foreground-process status testing for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->