### PR TITLE
feat(web): trusted_domains allowlist skips the terminal link-open confirm

### DIFF
--- a/cmd/agent-deck/web_cmd.go
+++ b/cmd/agent-deck/web_cmd.go
@@ -98,6 +98,7 @@ func buildWebServer(profile string, args []string, menuData web.MenuDataLoader, 
 		}
 	}
 
+	confirmLinkOpen := session.GetWebConfirmLinkOpen()
 	server := web.NewServer(web.Config{
 		ListenAddr:          *listenAddr,
 		Profile:             effectiveProfile,
@@ -105,6 +106,8 @@ func buildWebServer(profile string, args []string, menuData web.MenuDataLoader, 
 		WebMutations:        resolveMutationsEnabled(*readOnly),
 		Token:               *token,
 		InsecureBind:        *insecureBind,
+		TrustedDomains:      session.GetWebTrustedDomains(),
+		ConfirmLinkOpen:     &confirmLinkOpen,
 		MenuData:            menuData,
 		PushVAPIDPublicKey:  resolvedPushPublic,
 		PushVAPIDPrivateKey: resolvedPushPrivate,

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -664,6 +664,19 @@ type WebSettings struct {
 	// MutationsEnabled controls whether POST/PATCH/DELETE endpoints accept
 	// requests. nil (omitted) defaults to true. Forced off by --read-only.
 	MutationsEnabled *bool `toml:"mutations_enabled,omitempty"`
+
+	// TrustedDomains lists hosts whose links open from the web terminal
+	// without the "this link could potentially be dangerous" confirm
+	// (issue #1682). Entries are hosts, not URLs — a full URL is accepted
+	// and reduced to its host. A leading `*.` matches subdomains only
+	// (`*.corp.example` matches `git.corp.example`, not `corp.example`).
+	// Everything not on the list still confirms.
+	TrustedDomains []string `toml:"trusted_domains,omitempty"`
+
+	// ConfirmLinkOpen controls the web terminal's link-open confirm for
+	// hosts that are NOT on TrustedDomains. nil (omitted) defaults to true.
+	// Setting it false accepts the risk and opens every link directly.
+	ConfirmLinkOpen *bool `toml:"confirm_link_open,omitempty"`
 }
 
 // FeedbackSettings controls the in-product feedback prompts.
@@ -3487,6 +3500,104 @@ func GetWebMutationsEnabled() bool {
 		return true
 	}
 	return *config.Web.MutationsEnabled
+}
+
+// GetWebTrustedDomains returns the normalized `[web].trusted_domains` hosts.
+// Links whose host matches an entry skip the web terminal's link-open confirm
+// (issue #1682). Returns an empty slice when the key is absent, so the
+// confirm stays on for everything by default.
+func GetWebTrustedDomains() []string {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil {
+		return nil
+	}
+	return NormalizeTrustedDomains(config.Web.TrustedDomains)
+}
+
+// GetWebConfirmLinkOpen reports whether the web terminal confirms before
+// opening a link whose host is not on `[web].trusted_domains`. Defaults to
+// true when `[web].confirm_link_open` is omitted.
+func GetWebConfirmLinkOpen() bool {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil || config.Web.ConfirmLinkOpen == nil {
+		return true
+	}
+	return *config.Web.ConfirmLinkOpen
+}
+
+// NormalizeTrustedDomains reduces raw `[web].trusted_domains` entries to
+// lowercase hosts suitable for exact comparison against a URL host:
+//
+//   - "https://gitlab.corp.example/group/repo" -> "gitlab.corp.example"
+//   - "GitLab.Corp.Example:8443"               -> "gitlab.corp.example"
+//   - "*.corp.example"                         -> "*.corp.example" (subdomains)
+//
+// Blank entries, bare wildcards ("*", "*."), and entries that carry no host
+// are dropped. Duplicates are removed, input order is preserved.
+func NormalizeTrustedDomains(entries []string) []string {
+	out := make([]string, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, raw := range entries {
+		host := normalizeTrustedDomain(raw)
+		if host == "" {
+			continue
+		}
+		if _, dup := seen[host]; dup {
+			continue
+		}
+		seen[host] = struct{}{}
+		out = append(out, host)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// normalizeTrustedDomain normalizes one entry; "" means "unusable, drop it".
+func normalizeTrustedDomain(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" {
+		return ""
+	}
+	// Accept a pasted URL: strip scheme, then anything from the first
+	// path/query/fragment separator onward.
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+	// Strip userinfo ("user:pass@host") — the host is what we match on.
+	if i := strings.LastIndex(s, "@"); i >= 0 {
+		s = s[i+1:]
+	}
+	wildcard := strings.HasPrefix(s, "*.")
+	if wildcard {
+		s = s[2:]
+	}
+	// Strip the port. Bracketed IPv6 literals keep their brackets so the
+	// colons inside are not mistaken for a port separator.
+	if strings.HasPrefix(s, "[") {
+		if i := strings.Index(s, "]"); i >= 0 {
+			s = s[:i+1]
+		}
+	} else if i := strings.LastIndex(s, ":"); i >= 0 && !strings.Contains(s[i+1:], ":") {
+		s = s[:i]
+	}
+	s = strings.TrimSuffix(s, ".")
+	if s == "" || strings.ContainsAny(s, " \t*") {
+		return ""
+	}
+	if wildcard {
+		// A subdomain wildcard needs a registrable base with a dot, else
+		// "*.example" would silently allow every single-label host.
+		if !strings.Contains(s, ".") {
+			return ""
+		}
+		return "*." + s
+	}
+	return s
 }
 
 // GetHotkeyOverrides returns user-configured hotkey overrides from config.toml.

--- a/internal/session/userconfig_web_test.go
+++ b/internal/session/userconfig_web_test.go
@@ -74,3 +74,91 @@ mutations_enabled = false
 		t.Errorf("GetWebMutationsEnabled() = true, want false when explicitly disabled")
 	}
 }
+
+// --- [web] trusted_domains / confirm_link_open (issue #1682) ---------------
+
+func TestWebTrustedDomains_EmptyWhenAbsent(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+mutations_enabled = true
+`)
+	if got := GetWebTrustedDomains(); len(got) != 0 {
+		t.Errorf("GetWebTrustedDomains() = %v, want empty when the key is absent", got)
+	}
+}
+
+func TestWebTrustedDomains_ReadsAndNormalizes(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+trusted_domains = ["GitLab.Corp.Example", "https://gerrit.corp.example:8443/c/1", "  ", "*.ci.corp.example", "gitlab.corp.example"]
+`)
+	got := GetWebTrustedDomains()
+	want := []string{"gitlab.corp.example", "gerrit.corp.example", "*.ci.corp.example"}
+	if len(got) != len(want) {
+		t.Fatalf("GetWebTrustedDomains() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("GetWebTrustedDomains()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestWebConfirmLinkOpen_DefaultsTrue(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+trusted_domains = ["gitlab.corp.example"]
+`)
+	if !GetWebConfirmLinkOpen() {
+		t.Error("GetWebConfirmLinkOpen() = false, want true when the key is omitted")
+	}
+}
+
+func TestWebConfirmLinkOpen_ExplicitFalse(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+confirm_link_open = false
+`)
+	if GetWebConfirmLinkOpen() {
+		t.Error("GetWebConfirmLinkOpen() = true, want false when explicitly disabled")
+	}
+}
+
+func TestNormalizeTrustedDomains(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil stays nil", nil, nil},
+		{"plain host", []string{"gitlab.corp.example"}, []string{"gitlab.corp.example"}},
+		{"case folded", []string{"GitLab.CORP.example"}, []string{"gitlab.corp.example"}},
+		{"trims space", []string{"  gitlab.corp.example  "}, []string{"gitlab.corp.example"}},
+		{"strips scheme and path", []string{"https://gitlab.corp.example/group/repo/-/merge_requests/7"}, []string{"gitlab.corp.example"}},
+		{"strips port", []string{"gerrit.corp.example:8443"}, []string{"gerrit.corp.example"}},
+		{"strips userinfo", []string{"https://user:pw@gitlab.corp.example"}, []string{"gitlab.corp.example"}},
+		{"strips trailing dot", []string{"gitlab.corp.example."}, []string{"gitlab.corp.example"}},
+		{"keeps subdomain wildcard", []string{"*.corp.example"}, []string{"*.corp.example"}},
+		{"wildcard with port", []string{"*.corp.example:8443"}, []string{"*.corp.example"}},
+		{"ipv6 literal keeps brackets", []string{"[::1]:8443"}, []string{"[::1]"}},
+		{"drops blanks", []string{"", "   ", "\t"}, nil},
+		{"drops bare wildcard", []string{"*", "*.", "*.example"}, nil},
+		{"drops embedded wildcard", []string{"git.*.corp.example"}, nil},
+		{"drops scheme-only", []string{"https://"}, nil},
+		{"dedupes after normalizing", []string{"gitlab.corp.example", "GITLAB.corp.example:443"}, []string{"gitlab.corp.example"}},
+		{"preserves order", []string{"b.example", "a.example"}, []string{"b.example", "a.example"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeTrustedDomains(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("NormalizeTrustedDomains(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("NormalizeTrustedDomains(%v)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -113,6 +113,12 @@ type SettingsResponse struct {
 	// show_only_installed_tools ("" mapped to "shell" for web).
 	HiddenTools []string `json:"hiddenTools"`
 	PickerTools []string `json:"pickerTools"`
+
+	// Link-open policy for the web terminal (issue #1682). TrustedDomains
+	// are normalized hosts whose links open without a confirm;
+	// ConfirmLinkOpen reports whether every other host still confirms.
+	TrustedDomains  []string `json:"trustedDomains"`
+	ConfirmLinkOpen bool     `json:"confirmLinkOpen"`
 }
 
 // ProfilesResponse is returned by GET /api/profiles.

--- a/internal/web/handlers_settings.go
+++ b/internal/web/handlers_settings.go
@@ -17,6 +17,14 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The link-open allowlist (issue #1682) is always serialized as an array,
+	// never null, so the client's `Array.isArray` hydration guard cannot be
+	// tripped by an unconfigured server.
+	trustedDomains := s.cfg.TrustedDomains
+	if trustedDomains == nil {
+		trustedDomains = []string{}
+	}
+
 	// Tool-visibility filter (issue #1259) is read from the process registry at
 	// request time, so it reflects the current config (re-probed only when config
 	// changes — see currentRegistry). It is a display filter only.
@@ -30,6 +38,8 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		ToolFilterFallback: session.ToolFilterFallbackActive(),
 		HiddenTools:        session.ConfiguredHiddenToolNames(),
 		PickerTools:        session.PickerToolNames(),
+		TrustedDomains:     trustedDomains,
+		ConfirmLinkOpen:    s.cfg.confirmLinkOpen(),
 	})
 }
 

--- a/internal/web/handlers_settings_test.go
+++ b/internal/web/handlers_settings_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -157,5 +158,67 @@ func TestProfilesUnauthorized(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), ErrCodeUnauthorized) {
 		t.Errorf("expected UNAUTHORIZED error, got: %s", rr.Body.String())
+	}
+}
+
+// Issue #1682: GET /api/settings carries the terminal link-open policy so the
+// web UI can skip the confirm for trusted hosts. A Config that never set
+// ConfirmLinkOpen must still report the confirm ON — a false there would
+// silently disable the prompt for every host.
+func TestSettingsLinkPolicy_DefaultsToConfirmOn(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Profile: "default"})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	var got SettingsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	if !got.ConfirmLinkOpen {
+		t.Error("confirmLinkOpen = false with ConfirmLinkOpen unset, want true (confirm stays on)")
+	}
+	if len(got.TrustedDomains) != 0 {
+		t.Errorf("trustedDomains = %v, want empty when unconfigured", got.TrustedDomains)
+	}
+}
+
+func TestSettingsLinkPolicy_ServesConfiguredAllowlistAndToggle(t *testing.T) {
+	off := false
+	srv := NewServer(Config{
+		ListenAddr:      "127.0.0.1:0",
+		Profile:         "default",
+		TrustedDomains:  []string{"gitlab.corp.example", "*.ci.corp.example"},
+		ConfirmLinkOpen: &off,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	var got SettingsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode settings: %v", err)
+	}
+	if got.ConfirmLinkOpen {
+		t.Error("confirmLinkOpen = true, want false when ConfirmLinkOpen is explicitly false")
+	}
+	want := []string{"gitlab.corp.example", "*.ci.corp.example"}
+	if len(got.TrustedDomains) != len(want) {
+		t.Fatalf("trustedDomains = %v, want %v", got.TrustedDomains, want)
+	}
+	for i := range want {
+		if got.TrustedDomains[i] != want[i] {
+			t.Errorf("trustedDomains[%d] = %q, want %q", i, got.TrustedDomains[i], want[i])
+		}
 	}
 }

--- a/internal/web/issue1682_link_policy_test.go
+++ b/internal/web/issue1682_link_policy_test.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestTerminalLinkHandler_WiredIntoTerminal_RegressionFor1682 pins the one
+// line that makes `[web].trusted_domains` reachable at all.
+//
+// The trusted-domain policy lives in static/app/terminalLinks.js and is
+// covered behaviorally by tests/web/unit/terminalLinks.test.js (matching
+// rules) and tests/web/e2e/trusted-domains.spec.js (allowlisted vs not, in a
+// real browser against a real server). Neither can observe whether xterm is
+// actually handed the handler: an OSC-8 link only exists once a live tmux
+// pane emits one, and xterm exposes no back-reference from its DOM element to
+// the Terminal instance.
+//
+// So this is a source pin, in the same spirit as
+// TestWebBundle_ChartNotInInitialPayload_RegressionFor1022. Drop the
+// `linkHandler` option from TerminalPanel.js and every link silently falls
+// back to xterm's built-in "could potentially be dangerous" confirm — the
+// exact regression issue #1682 asks us to prevent.
+func TestTerminalLinkHandler_WiredIntoTerminal_RegressionFor1682(t *testing.T) {
+	panel := readEmbedded(t, "static/app/TerminalPanel.js")
+
+	if !strings.Contains(panel, `from './terminalLinks.js'`) {
+		t.Error("TerminalPanel.js does not import ./terminalLinks.js")
+	}
+	wired := regexp.MustCompile(`linkHandler\s*:\s*createTerminalLinkHandler\(\)`)
+	if !wired.MatchString(panel) {
+		t.Error("TerminalPanel.js does not pass linkHandler: createTerminalLinkHandler() to new Terminal(...) — " +
+			"without it xterm's built-in confirm fires on every link and [web].trusted_domains has no effect")
+	}
+
+	// The policy module must keep reading the hydrated signals rather than a
+	// snapshot captured at terminal-construction time.
+	links := readEmbedded(t, "static/app/terminalLinks.js")
+	for _, want := range []string{"trustedDomainsSignal", "confirmLinkOpenSignal"} {
+		if !strings.Contains(links, want) {
+			t.Errorf("terminalLinks.js no longer references %s — link policy would ignore /api/settings", want)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -27,12 +27,26 @@ type Config struct {
 	// InsecureBind explicitly acknowledges binding a non-loopback address
 	// with no auth token (an unauthenticated RCE surface). Without it the
 	// server refuses to start in that configuration. See bind.go / report #1.
-	InsecureBind        bool
+	InsecureBind bool
+	// TrustedDomains lists hosts (already normalized by
+	// session.NormalizeTrustedDomains) whose links open from the web
+	// terminal without a confirm. Issue #1682.
+	TrustedDomains []string
+	// ConfirmLinkOpen gates the web terminal's link-open confirm for hosts
+	// that are NOT trusted. nil means "confirm" — the safe default, so a
+	// Config built without this field never silently disables the prompt.
+	ConfirmLinkOpen     *bool
 	MenuData            MenuDataLoader
 	PushVAPIDPublicKey  string
 	PushVAPIDPrivateKey string
 	PushVAPIDSubject    string
 	PushTestInterval    time.Duration
+}
+
+// confirmLinkOpen resolves Config.ConfirmLinkOpen, defaulting to true so an
+// omitted field keeps the confirm prompt rather than removing it.
+func (c Config) confirmLinkOpen() bool {
+	return c.ConfirmLinkOpen == nil || *c.ConfirmLinkOpen
 }
 
 // DefaultUndoWindow is the default Chrome-style undo grace period for

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -32,6 +32,7 @@ import {
   profilesSignal, systemStatsSignal,
   toolFilterSignal, visibleToolsSignal, toolFilterFallbackSignal,
   hiddenToolsSignal, pickerToolsSignal,
+  trustedDomainsSignal, confirmLinkOpenSignal,
 } from './state.js'
 import {
   activeTabSignal, paletteOpenSignal, tweaksOpenSignal,
@@ -157,6 +158,13 @@ export function AppShell() {
         }
         if (Array.isArray(data.pickerTools) && data.pickerTools.length > 0) {
           pickerToolsSignal.value = data.pickerTools
+        }
+        // Terminal link-open policy (issue #1682).
+        if (Array.isArray(data.trustedDomains)) {
+          trustedDomainsSignal.value = data.trustedDomains
+        }
+        if (typeof data.confirmLinkOpen === 'boolean') {
+          confirmLinkOpenSignal.value = data.confirmLinkOpen
         }
       })
       .catch(() => {})

--- a/internal/web/static/app/SettingsPanel.js
+++ b/internal/web/static/app/SettingsPanel.js
@@ -30,8 +30,10 @@ export function SettingsPanel() {
       <div class="kv" data-testid="settings-web-mutations"><span class="k">web mutations</span><span class=${`v ${settings.webMutations ? 'ok' : 'warn'}`}>${settings.webMutations ? 'enabled' : 'disabled'}</span></div>
       <div class="kv" data-testid="settings-hidden-tools"><span class="k">hidden tools</span><span class="v">${(settings.hiddenTools || []).join(', ') || 'none'}</span></div>
       <div class="kv" data-testid="settings-picker-tools"><span class="k">picker tools</span><span class="v">${(settings.pickerTools || []).join(', ') || 'loading…'}</span></div>
+      <div class="kv" data-testid="settings-trusted-domains"><span class="k">trusted domains</span><span class="v">${(settings.trustedDomains || []).join(', ') || 'none'}</span></div>
+      <div class="kv" data-testid="settings-confirm-link-open"><span class="k">link confirm</span><span class=${`v ${settings.confirmLinkOpen === false ? 'warn' : 'ok'}`}>${settings.confirmLinkOpen === false ? 'off' : 'on'}</span></div>
       <div style="font-family: var(--mono); font-size: 11px; color: var(--muted); margin-top: 8px;">
-        Edit <code>~/.config/agent-deck/config.toml</code> (<code>[ui] hidden_tools</code>) or use TUI Settings → Visible tools…
+        Edit <code>~/.config/agent-deck/config.toml</code> (<code>[ui] hidden_tools</code>, <code>[web] trusted_domains</code>) or use TUI Settings → Visible tools…
       </div>
     </div>
   `

--- a/internal/web/static/app/TerminalPanel.js
+++ b/internal/web/static/app/TerminalPanel.js
@@ -9,6 +9,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { EmptyStateDashboard } from './EmptyStateDashboard.js'
 import { terminalKeymap } from './terminalKeys.js'
+import { createTerminalLinkHandler } from './terminalLinks.js'
 
 // Mobile detection: pointer:coarse for touch devices
 function isMobileDevice() {
@@ -139,6 +140,10 @@ export function TerminalPanel() {
       disableStdin: false,
       fontFamily: 'IBM Plex Mono, Menlo, Consolas, monospace',
       fontSize: 13,
+      // Issue #1682: replaces xterm's built-in OSC-8 activate handler, which
+      // confirms on every link. Ours skips the confirm for `[web]
+      // trusted_domains` hosts and honors `confirm_link_open`.
+      linkHandler: createTerminalLinkHandler(),
       scrollback: 10000,
       theme: {
         background: '#0a1220',

--- a/internal/web/static/app/state.js
+++ b/internal/web/static/app/state.js
@@ -155,6 +155,15 @@ export const toolFilterFallbackSignal = signal(false)
 export const hiddenToolsSignal = signal([])
 export const pickerToolsSignal = signal([])
 
+// Web terminal link-open policy (issue #1682), hydrated from /api/settings.
+// trustedDomainsSignal holds the `[web].trusted_domains` hosts whose links
+// open without the confirm; confirmLinkOpenSignal is `[web].confirm_link_open`
+// and gates the prompt for every other host. Defaults are the safe ones (no
+// trusted hosts, confirm on) so the prompt only relaxes once the real config
+// arrives.
+export const trustedDomainsSignal = signal([])
+export const confirmLinkOpenSignal = signal(true)
+
 // POL-1 (Phase 9, plan 01): sidebar load state for skeleton render gate.
 // Initialized false; flipped to true on the first /api/menu response OR the
 // first SSE `menu` snapshot in main.js. Never flips back — once the sidebar

--- a/internal/web/static/app/terminalLinks.js
+++ b/internal/web/static/app/terminalLinks.js
@@ -1,0 +1,118 @@
+// terminalLinks.js -- link-open policy for the web terminal (issue #1682).
+//
+// xterm's built-in OSC-8 handler confirms on EVERY link, which is pure
+// friction for anyone clicking self-hosted GitLab/Gerrit/CI links all day.
+// TerminalPanel installs this handler instead and consults `[web]` config
+// (served by GET /api/settings, hydrated into signals by AppShell):
+//
+//   trusted_domains   = ["gitlab.corp.example", "*.ci.corp.example"]
+//   confirm_link_open = true   # default; false accepts the risk globally
+//
+// Trusted host -> opens directly. Everything else keeps the confirm. The open
+// mirrors xterm's: blank window, `opener` cleared, then navigate.
+import { trustedDomainsSignal, confirmLinkOpenSignal } from './state.js'
+
+// Reduces one allowlist entry to a comparable lowercase host, mirroring
+// session.NormalizeTrustedDomains in Go. '' means "unusable, ignore it".
+export function normalizeTrustedDomain(entry) {
+  let s = String(entry == null ? '' : entry).trim().toLowerCase()
+  if (!s) return ''
+  const scheme = s.indexOf('://')
+  if (scheme >= 0) s = s.slice(scheme + 3)
+  const path = s.search(/[/?#]/)
+  if (path >= 0) s = s.slice(0, path)
+  const at = s.lastIndexOf('@')
+  if (at >= 0) s = s.slice(at + 1)
+  const wildcard = s.startsWith('*.')
+  if (wildcard) s = s.slice(2)
+  if (s.startsWith('[')) {
+    // IPv6 literal: keep the brackets, drop any :port after them.
+    const end = s.indexOf(']')
+    if (end >= 0) s = s.slice(0, end + 1)
+  } else {
+    const colon = s.lastIndexOf(':')
+    if (colon >= 0 && !s.slice(colon + 1).includes(':')) s = s.slice(0, colon)
+  }
+  if (s.endsWith('.')) s = s.slice(0, -1)
+  if (!s || /[\s*]/.test(s)) return ''
+  // A wildcard needs a base with a dot, else `*.example` would allow every
+  // single-label host on the network.
+  if (wildcard) return s.includes('.') ? '*.' + s : ''
+  return s
+}
+
+// Lowercase host of an http(s) URL; '' when unparseable or another scheme
+// (a non-http link never auto-opens, whatever its host claims to be).
+function hostOf(url) {
+  let parsed
+  try {
+    parsed = new URL(String(url))
+  } catch (_e) {
+    return ''
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return ''
+  return parsed.hostname.toLowerCase().replace(/\.$/, '')
+}
+
+// Host-only match: exact (case- and port-insensitive), or a `*.base` entry
+// matching strictly deeper subdomains of `base`.
+export function isTrustedLinkTarget(url, trustedDomains) {
+  const host = hostOf(url)
+  if (!host) return false
+  for (const raw of Array.isArray(trustedDomains) ? trustedDomains : []) {
+    const entry = normalizeTrustedDomain(raw)
+    if (!entry) continue
+    if (entry.startsWith('*.')) {
+      const base = entry.slice(2)
+      if (host.length > base.length + 1 && host.endsWith('.' + base)) return true
+    } else if (host === entry) {
+      return true
+    }
+  }
+  return false
+}
+
+// The whole policy: confirm unless the prompt is off or the host is trusted.
+export function shouldConfirmLinkOpen(url, options = {}) {
+  const { trustedDomains = [], confirmLinkOpen = true } = options
+  if (!confirmLinkOpen) return false
+  return !isTrustedLinkTarget(url, trustedDomains)
+}
+
+// Applies the policy, then opens the link the way xterm's built-in does.
+// `env` is injectable so tests can supply fakes instead of real dialogs.
+export function openTerminalLink(url, options = {}, env = {}) {
+  const win = env.win || (typeof window !== 'undefined' ? window : undefined)
+  if (!win) return false
+  if (shouldConfirmLinkOpen(url, options)) {
+    const ask = env.confirm || win.confirm.bind(win)
+    if (!ask(`Do you want to navigate to ${url}?\n\nWARNING: This link could potentially be dangerous`)) {
+      return false
+    }
+  }
+  const opened = win.open()
+  if (!opened) {
+    // Same as xterm: refuse to navigate rather than hand the target a live
+    // opener reference we could not clear.
+    console.warn('Opening link blocked as opener could not be cleared')
+    return false
+  }
+  try {
+    opened.opener = null
+  } catch (_e) { /* read-only in some browsers; window.open already noopener'd */ }
+  opened.location.href = url
+  return true
+}
+
+// The xterm `linkHandler` option. Reads the live signals at click time so a
+// settings refresh takes effect without rebuilding the terminal.
+export function createTerminalLinkHandler() {
+  return {
+    activate(_event, text) {
+      openTerminalLink(text, {
+        trustedDomains: trustedDomainsSignal.value,
+        confirmLinkOpen: confirmLinkOpenSignal.value,
+      })
+    },
+  }
+}

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -517,6 +517,29 @@ attach_on_create = true                       # Opt IN: instantly attach to a ne
 
 Filters compose: `hidden_tools` is applied first, then `show_only_installed_tools` (when enabled).
 
+## [web] Section
+
+`agent-deck web` HTTP server settings.
+
+```toml
+[web]
+mutations_enabled = true                      # Accept POST/PATCH/DELETE from the web UI
+trusted_domains = [                           # Links to these hosts open without a confirm
+  "gitlab.mycorp.example",
+  "gerrit.mycorp.example",
+  "*.ci.mycorp.example",                      # subdomains of ci.mycorp.example
+]
+confirm_link_open = true                      # Confirm before opening any OTHER host
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mutations_enabled` | bool | `true` | When `false`, mutating endpoints (POST/PATCH/DELETE) return HTTP 403 and the web UI hides its write affordances. `--read-only` forces this off regardless of the config value. |
+| `trusted_domains` | []string | `[]` | Hosts whose links open straight from the web terminal, skipping the "this link could potentially be dangerous" confirm. Everything not listed still confirms. Matching is on **host** only: case-insensitive, port- and path-independent. An entry may be a bare host (`gitlab.corp.example`), a pasted URL (reduced to its host), or `*.base.example` to match **subdomains** of `base.example` (not the bare base itself). Only `http`/`https` links are ever auto-opened. Unusable entries (`*`, `*.example`, blanks) are dropped. |
+| `confirm_link_open` | bool | `true` | Confirm before opening a web-terminal link whose host is **not** in `trusted_domains`. Set `false` to accept the risk and open every link directly — prefer `trusted_domains`, which keeps the safety net for arbitrary links. |
+
+Both link keys are read at server start and served to the browser by `GET /api/settings`; the web Settings drawer shows the active values.
+
 ## [global_search] Section
 
 Search across all Claude conversations.

--- a/tests/web/e2e/trusted-domains.spec.js
+++ b/tests/web/e2e/trusted-domains.spec.js
@@ -1,0 +1,273 @@
+// e2e/trusted-domains.spec.js -- `[web].trusted_domains` allowlist (#1682).
+//
+// xterm.js ships a default OSC-8 activate handler that always fires
+// `confirm("Do you want to navigate to <url>? WARNING: This link could
+// potentially be dangerous")`. Anyone clicking self-hosted GitLab / Gerrit /
+// CI links all day pays that prompt several times a minute. TerminalPanel.js
+// now installs the `linkHandler` from terminalLinks.js, which consults the
+// config served by GET /api/settings:
+//
+//   [web]
+//   trusted_domains   = ["gitlab.corp.example", "*.ci.corp.example"]
+//   confirm_link_open = true   # default; false accepts the risk globally
+//
+// What this spec pins, end to end through the real server:
+//   1. GET /api/settings carries `trustedDomains` + `confirmLinkOpen` from
+//      web.Config (internal/web/handlers_settings.go).
+//   2. AppShell.js hydrates trustedDomainsSignal / confirmLinkOpenSignal from
+//      that response, and the settings drawer renders both.
+//   3. Activating an ALLOWLISTED link opens it with NO confirm; activating a
+//      NON-allowlisted link still confirms — the core of the issue.
+//   4. `confirm_link_open = false` drops the prompt for every host.
+//
+// Why the handler is driven directly instead of clicking rendered link cells:
+// an OSC-8 hyperlink only exists in the terminal buffer once a live tmux pane
+// emits one, and the in-memory fixture has no pane (its /ws/session endpoint
+// has no tmux behind it). So the spec imports the SAME production module
+// instance the app loaded (`/static/app/terminalLinks.js` — identical URL, so
+// the browser reuses the module record and its hydrated signals) and calls the
+// `activate` callback xterm itself would call. The decision path under test is
+// the real one, in a real browser, against real hydrated config.
+//
+// The shared fixture (helpers/global-setup.js) runs with no trusted domains,
+// so each describe block boots its own web-fixture on an ephemeral port with
+// the flags it needs, exactly like read-only-mode.spec.js. Extra servers are
+// wasteful, so this spec runs on chromium-desktop only — the policy is
+// viewport-independent.
+
+import { test, expect } from '@playwright/test'
+import { spawn } from 'node:child_process'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const BIN_PATH = resolve(import.meta.dirname, '..', '.tmp', 'web-fixture')
+
+const TRUSTED_EXACT = 'gitlab.corp.example'
+const TRUSTED_WILDCARD = '*.ci.corp.example'
+
+// spawnFixture boots a web-fixture with `extraArgs` on an OS-allocated port
+// and returns { base, kill }. Mirrors read-only-mode.spec.js.
+async function spawnFixture(extraArgs) {
+  if (!existsSync(BIN_PATH)) {
+    throw new Error(
+      `trusted-domains: fixture binary missing at ${BIN_PATH}. ` +
+        'Run via `npm run test:e2e` so global-setup builds it first.',
+    )
+  }
+  const portFile = join(tmpdir(), `adweb-td-${randomBytes(6).toString('hex')}.port`)
+  const child = spawn(
+    BIN_PATH,
+    ['-listen', '127.0.0.1:0', '-port-file', portFile, ...extraArgs],
+    { stdio: ['ignore', 'ignore', 'inherit'] },
+  )
+  const kill = () => { child.kill('SIGTERM') }
+
+  try {
+    const deadline = Date.now() + 10_000
+    let port = null
+    while (Date.now() < deadline) {
+      if (child.exitCode !== null) {
+        throw new Error(`trusted-domains web-fixture exited early (code ${child.exitCode})`)
+      }
+      if (existsSync(portFile)) {
+        const txt = readFileSync(portFile, 'utf8').trim()
+        if (txt) {
+          port = Number(txt)
+          break
+        }
+      }
+      await sleep(100)
+    }
+    if (!port) throw new Error('trusted-domains web-fixture never wrote its port file')
+    const base = `http://127.0.0.1:${port}`
+
+    let healthy = false
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(`${base}/healthz`)
+        if (res.ok) {
+          healthy = true
+          break
+        }
+      } catch (_) { /* not up yet */ }
+      await sleep(100)
+    }
+    if (!healthy) throw new Error(`trusted-domains web-fixture never became healthy at ${base}`)
+    return { base, kill }
+  } catch (err) {
+    kill()
+    throw err
+  } finally {
+    rmSync(portFile, { force: true })
+  }
+}
+
+// Records confirm() calls and window.open() navigations instead of showing a
+// real dialog, so the assertion "was the user prompted?" is observable. The
+// stub keeps xterm's contract: open() returns a window whose `opener` is
+// cleared before `location.href` is assigned.
+async function stubLinkOpening(page) {
+  await page.addInitScript(() => {
+    window.__confirmCalls = []
+    window.__openedLinks = []
+    window.confirm = (message) => {
+      window.__confirmCalls.push(message)
+      return true
+    }
+    window.open = () => ({
+      opener: {},
+      location: {
+        set href(value) { window.__openedLinks.push(value) },
+        get href() { return window.__openedLinks[window.__openedLinks.length - 1] },
+      },
+    })
+  })
+}
+
+// Loads the app and blocks until AppShell's /api/settings hydration has
+// reached the link-policy signals. state.js starts at the safe defaults
+// (no trusted hosts, confirm on), so comparing the signals against the live
+// API response is a real barrier for both fixture configurations here: one
+// ships a non-empty allowlist, the other flips confirmLinkOpen to false.
+async function gotoHydratedApp(page, base) {
+  await stubLinkOpening(page)
+  await page.goto(`${base}/`)
+  await page.waitForSelector('.sess', { timeout: 5000 })
+  await page.waitForFunction(async () => {
+    const res = await fetch('/api/settings')
+    if (!res.ok) return false
+    const body = await res.json()
+    const state = await import('/static/app/state.js')
+    return state.confirmLinkOpenSignal.value === body.confirmLinkOpen &&
+      JSON.stringify(state.trustedDomainsSignal.value) === JSON.stringify(body.trustedDomains)
+  }, { timeout: 5000 })
+}
+
+// Invokes the production xterm linkHandler for `url` and reports what the
+// user saw: how many confirms fired and which URLs actually opened.
+async function activateLink(page, url) {
+  return page.evaluate(async (target) => {
+    const before = {
+      confirms: window.__confirmCalls.length,
+      opens: window.__openedLinks.length,
+    }
+    const { createTerminalLinkHandler } = await import('/static/app/terminalLinks.js')
+    createTerminalLinkHandler().activate(new MouseEvent('click'), target)
+    return {
+      confirms: window.__confirmCalls.slice(before.confirms),
+      opened: window.__openedLinks.slice(before.opens),
+    }
+  }, url)
+}
+
+test.describe('trusted_domains allowlist (confirm_link_open on)', () => {
+  test.skip(
+    ({ viewport }) => (viewport?.width || 1280) !== 1280,
+    'desktop project only: the link policy is viewport-independent; one extra server is enough',
+  )
+
+  let fixture = null
+
+  test.beforeAll(async ({}, testInfo) => {
+    if ((testInfo.project.use?.viewport?.width || 1280) !== 1280) return
+    fixture = await spawnFixture(['-trusted-domains', `${TRUSTED_EXACT},${TRUSTED_WILDCARD}`])
+  })
+
+  test.afterAll(() => {
+    if (fixture) fixture.kill()
+    fixture = null
+  })
+
+  test('GET /api/settings serves the allowlist and confirmLinkOpen:true', async ({ request }) => {
+    const res = await request.get(`${fixture.base}/api/settings`)
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.trustedDomains).toEqual([TRUSTED_EXACT, TRUSTED_WILDCARD])
+    expect(body.confirmLinkOpen).toBe(true)
+  })
+
+  test('the settings drawer shows the hydrated policy', async ({ page }) => {
+    await gotoHydratedApp(page, fixture.base)
+    await page.keyboard.press('Control+k')
+    await expect(page.locator('[data-testid="command-palette"]')).toBeVisible()
+    await page.locator('[data-testid="palette-cmd-row"]', { hasText: 'Settings drawer' }).click()
+    await expect(page.locator('[data-testid="settings-panel"]')).toBeVisible({ timeout: 5000 })
+
+    await expect(page.locator('[data-testid="settings-trusted-domains"] .v'))
+      .toHaveText(`${TRUSTED_EXACT}, ${TRUSTED_WILDCARD}`)
+    await expect(page.locator('[data-testid="settings-confirm-link-open"] .v')).toHaveText('on')
+  })
+
+  test('an ALLOWLISTED link opens with no confirmation', async ({ page }) => {
+    await gotoHydratedApp(page, fixture.base)
+    const url = `https://${TRUSTED_EXACT}/team/repo/-/merge_requests/42`
+    const result = await activateLink(page, url)
+    expect(result.confirms).toEqual([])
+    expect(result.opened).toEqual([url])
+  })
+
+  test('a subdomain under a *. entry opens with no confirmation', async ({ page }) => {
+    await gotoHydratedApp(page, fixture.base)
+    const url = 'https://build7.ci.corp.example/job/9/console'
+    const result = await activateLink(page, url)
+    expect(result.confirms).toEqual([])
+    expect(result.opened).toEqual([url])
+  })
+
+  test('a NON-allowlisted link still confirms before opening', async ({ page }) => {
+    await gotoHydratedApp(page, fixture.base)
+    const url = 'https://random-blog.example/post/1'
+    const result = await activateLink(page, url)
+    expect(result.confirms).toHaveLength(1)
+    expect(result.confirms[0]).toContain(url)
+    expect(result.confirms[0]).toContain('could potentially be dangerous')
+    // The stub accepts, so the navigation still happens — the point is that
+    // the user was asked.
+    expect(result.opened).toEqual([url])
+  })
+
+  test('a lookalike host that merely ends with a trusted name still confirms', async ({ page }) => {
+    await gotoHydratedApp(page, fixture.base)
+    const url = `https://${TRUSTED_EXACT}.evil.test/phish`
+    const result = await activateLink(page, url)
+    expect(result.confirms).toHaveLength(1)
+  })
+})
+
+test.describe('confirm_link_open = false (global opt-out)', () => {
+  test.skip(
+    ({ viewport }) => (viewport?.width || 1280) !== 1280,
+    'desktop project only: the link policy is viewport-independent; one extra server is enough',
+  )
+
+  let fixture = null
+
+  test.beforeAll(async ({}, testInfo) => {
+    if ((testInfo.project.use?.viewport?.width || 1280) !== 1280) return
+    fixture = await spawnFixture(['-confirm-link-open=false'])
+  })
+
+  test.afterAll(() => {
+    if (fixture) fixture.kill()
+    fixture = null
+  })
+
+  test('GET /api/settings reports confirmLinkOpen:false with an empty allowlist', async ({ request }) => {
+    const res = await request.get(`${fixture.base}/api/settings`)
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.confirmLinkOpen).toBe(false)
+    expect(body.trustedDomains).toEqual([])
+  })
+
+  test('every link opens without a confirmation, allowlist or not', async ({ page }) => {
+    await gotoHydratedApp(page, fixture.base)
+    const url = 'https://random-blog.example/post/1'
+    const result = await activateLink(page, url)
+    expect(result.confirms).toEqual([])
+    expect(result.opened).toEqual([url])
+  })
+})

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -33,6 +34,8 @@ func main() {
 	mutationsAllowed := flag.Bool("allow-mutations", true, "Allow POST/DELETE actions through the web API")
 	portFile := flag.String("port-file", "", "If set, write the bound TCP port to this file once listening (used with :0)")
 	startupToken := flag.String("startup-token", "", "Echoed at /__fixture/whoami so callers can verify they're talking to this exact process")
+	trustedDomains := flag.String("trusted-domains", "", "Comma-separated `[web].trusted_domains` hosts served by GET /api/settings (issue #1682)")
+	confirmLinkOpen := flag.Bool("confirm-link-open", true, "Value of `[web].confirm_link_open` served by GET /api/settings (issue #1682)")
 	flag.Parse()
 
 	store := newFixtureStore()
@@ -61,7 +64,12 @@ func main() {
 		Profile:      "fixture",
 		ReadOnly:     false,
 		WebMutations: *mutationsAllowed,
-		MenuData:     store,
+		// Link-open policy (issue #1682). Normalized through the same
+		// helper `agent-deck web` uses so the fixture cannot serve a shape
+		// the real server never would.
+		TrustedDomains:  session.NormalizeTrustedDomains(splitCSV(*trustedDomains)),
+		ConfirmLinkOpen: confirmLinkOpen,
+		MenuData:        store,
 	})
 	server.SetMutator(store)
 	// Hold the MCP manager on the store so /__fixture/reset clears its
@@ -638,6 +646,23 @@ func (s *fixtureStore) adminHandler() http.Handler {
 		}
 	})
 	return mux
+}
+
+// splitCSV splits a comma-separated flag value into non-empty trimmed parts.
+// Returns nil for an empty value so the fixture's default is "no trusted
+// domains" rather than one blank entry.
+func splitCSV(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func indexOf(s string, c byte) int {

--- a/tests/web/unit/terminalLinks.test.js
+++ b/tests/web/unit/terminalLinks.test.js
@@ -1,0 +1,232 @@
+// unit/terminalLinks.test.js -- link-open policy for the web terminal (#1682).
+//
+// xterm's built-in OSC-8 handler confirms on every link. terminalLinks.js
+// replaces it: hosts on `[web].trusted_domains` open straight away, everything
+// else still confirms, and `confirm_link_open = false` drops the prompt
+// entirely. The allowlist is a security control, so the bypass cases
+// (lookalike suffixes, wildcards, non-http schemes, credentials in the URL)
+// are pinned as hard as the happy path.
+
+import { describe, it, expect, vi } from 'vitest'
+
+const modulePath = '../../../internal/web/static/app/terminalLinks.js'
+
+const load = () => import(modulePath)
+
+describe('normalizeTrustedDomain', () => {
+  const cases = [
+    ['gitlab.corp.example', 'gitlab.corp.example'],
+    ['GitLab.CORP.Example', 'gitlab.corp.example'],
+    ['  gitlab.corp.example  ', 'gitlab.corp.example'],
+    ['https://gitlab.corp.example/group/repo/-/merge_requests/7', 'gitlab.corp.example'],
+    ['gerrit.corp.example:8443', 'gerrit.corp.example'],
+    ['https://user:pw@gitlab.corp.example', 'gitlab.corp.example'],
+    ['gitlab.corp.example.', 'gitlab.corp.example'],
+    ['*.corp.example', '*.corp.example'],
+    ['*.corp.example:8443', '*.corp.example'],
+    ['[::1]:8443', '[::1]'],
+    // Unusable entries are dropped rather than turned into something broad.
+    ['', ''],
+    ['   ', ''],
+    ['*', ''],
+    ['*.', ''],
+    ['*.example', ''],
+    ['git.*.corp.example', ''],
+    ['https://', ''],
+    [null, ''],
+    [undefined, ''],
+  ]
+  for (const [input, want] of cases) {
+    it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async () => {
+      const { normalizeTrustedDomain } = await load()
+      expect(normalizeTrustedDomain(input)).toBe(want)
+    })
+  }
+})
+
+describe('isTrustedLinkTarget', () => {
+  const list = ['gitlab.corp.example', '*.ci.corp.example']
+
+  it('matches an exact host', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://gitlab.corp.example/x/-/mr/1', list)).toBe(true)
+  })
+  it('ignores the port and the path', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://gitlab.corp.example:8443/a?b=c#d', list)).toBe(true)
+  })
+  it('is case-insensitive on the host', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://GitLab.Corp.Example/x', list)).toBe(true)
+  })
+  it('matches plain http as well as https', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('http://gitlab.corp.example/x', list)).toBe(true)
+  })
+  it('matches a subdomain under a *. entry', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://build7.ci.corp.example/job/9', list)).toBe(true)
+  })
+  it('does NOT let a *. entry match its own bare base', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://ci.corp.example/', list)).toBe(false)
+  })
+  it('does NOT match an unrelated host', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://evil.example/pwn', list)).toBe(false)
+  })
+  it('does NOT match a suffix lookalike of an exact entry', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://notgitlab.corp.example/x', list)).toBe(false)
+    expect(isTrustedLinkTarget('https://gitlab.corp.example.evil.test/x', list)).toBe(false)
+  })
+  it('does NOT match a suffix lookalike of a wildcard base', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://evilci.corp.example/x', list)).toBe(false)
+  })
+  it('does NOT trust a host smuggled into userinfo', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('https://gitlab.corp.example@evil.example/x', list)).toBe(false)
+  })
+  it('does NOT trust non-http schemes even when the host matches', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('file://gitlab.corp.example/etc/passwd', list)).toBe(false)
+    expect(isTrustedLinkTarget('javascript:alert(1)', list)).toBe(false)
+  })
+  it('returns false for unparseable input and for an empty/missing list', async () => {
+    const { isTrustedLinkTarget } = await load()
+    expect(isTrustedLinkTarget('not a url', list)).toBe(false)
+    expect(isTrustedLinkTarget('https://gitlab.corp.example/x', [])).toBe(false)
+    expect(isTrustedLinkTarget('https://gitlab.corp.example/x', undefined)).toBe(false)
+  })
+})
+
+describe('shouldConfirmLinkOpen', () => {
+  it('confirms by default (no options at all)', async () => {
+    const { shouldConfirmLinkOpen } = await load()
+    expect(shouldConfirmLinkOpen('https://gitlab.corp.example/x')).toBe(true)
+  })
+  it('skips the confirm for an allowlisted host', async () => {
+    const { shouldConfirmLinkOpen } = await load()
+    expect(shouldConfirmLinkOpen('https://gitlab.corp.example/x', {
+      trustedDomains: ['gitlab.corp.example'],
+    })).toBe(false)
+  })
+  it('still confirms for a host that is not allowlisted', async () => {
+    const { shouldConfirmLinkOpen } = await load()
+    expect(shouldConfirmLinkOpen('https://evil.example/x', {
+      trustedDomains: ['gitlab.corp.example'],
+    })).toBe(true)
+  })
+  it('confirm_link_open = false drops the prompt for every host', async () => {
+    const { shouldConfirmLinkOpen } = await load()
+    expect(shouldConfirmLinkOpen('https://evil.example/x', {
+      trustedDomains: [],
+      confirmLinkOpen: false,
+    })).toBe(false)
+  })
+})
+
+describe('openTerminalLink', () => {
+  // Fake window: records open() calls and hands back a stub child window.
+  const fakeWin = () => {
+    const child = { opener: {}, location: { href: '' } }
+    return {
+      child,
+      open: vi.fn(() => child),
+    }
+  }
+
+  it('opens an allowlisted link without asking', async () => {
+    const { openTerminalLink } = await load()
+    const win = fakeWin()
+    const ask = vi.fn(() => true)
+    const ok = openTerminalLink('https://gitlab.corp.example/x', {
+      trustedDomains: ['gitlab.corp.example'],
+    }, { win, confirm: ask })
+
+    expect(ok).toBe(true)
+    expect(ask).not.toHaveBeenCalled()
+    expect(win.open).toHaveBeenCalledTimes(1)
+    expect(win.child.location.href).toBe('https://gitlab.corp.example/x')
+    // The opener must be cleared before navigating, exactly as xterm does.
+    expect(win.child.opener).toBe(null)
+  })
+
+  it('asks before opening a link that is not allowlisted', async () => {
+    const { openTerminalLink } = await load()
+    const win = fakeWin()
+    const ask = vi.fn(() => true)
+    openTerminalLink('https://evil.example/x', {
+      trustedDomains: ['gitlab.corp.example'],
+    }, { win, confirm: ask })
+
+    expect(ask).toHaveBeenCalledTimes(1)
+    expect(ask.mock.calls[0][0]).toContain('https://evil.example/x')
+    expect(win.open).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens nothing when the confirm is declined', async () => {
+    const { openTerminalLink } = await load()
+    const win = fakeWin()
+    const ask = vi.fn(() => false)
+    const ok = openTerminalLink('https://evil.example/x', { trustedDomains: [] }, { win, confirm: ask })
+
+    expect(ok).toBe(false)
+    expect(win.open).not.toHaveBeenCalled()
+  })
+
+  it('refuses to navigate when the popup was blocked', async () => {
+    const { openTerminalLink } = await load()
+    const win = { open: vi.fn(() => null) }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const ok = openTerminalLink('https://gitlab.corp.example/x', {
+      trustedDomains: ['gitlab.corp.example'],
+    }, { win, confirm: () => true })
+
+    expect(ok).toBe(false)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('createTerminalLinkHandler', () => {
+  it('reads the live signals at click time', async () => {
+    const { createTerminalLinkHandler } = await load()
+    const { trustedDomainsSignal, confirmLinkOpenSignal } =
+      await import('../../../internal/web/static/app/state.js')
+
+    const handler = createTerminalLinkHandler()
+    const opened = []
+    const child = { opener: {}, location: {} }
+    Object.defineProperty(child.location, 'href', {
+      set(v) { opened.push(v) },
+      get() { return opened[opened.length - 1] },
+    })
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => child)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockImplementation(() => false)
+
+    // Not trusted yet -> confirm fires, declined, nothing opens.
+    handler.activate(new MouseEvent('click'), 'https://gitlab.corp.example/x')
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(opened).toEqual([])
+
+    // Hydrating the signal (what AppShell does from /api/settings) flips the
+    // decision without rebuilding the handler.
+    trustedDomainsSignal.value = ['gitlab.corp.example']
+    handler.activate(new MouseEvent('click'), 'https://gitlab.corp.example/x')
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(opened).toEqual(['https://gitlab.corp.example/x'])
+
+    // The global toggle suppresses the prompt for untrusted hosts too.
+    confirmLinkOpenSignal.value = false
+    handler.activate(new MouseEvent('click'), 'https://evil.example/x')
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(opened).toEqual(['https://gitlab.corp.example/x', 'https://evil.example/x'])
+
+    trustedDomainsSignal.value = []
+    confirmLinkOpenSignal.value = true
+    openSpy.mockRestore()
+    confirmSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## What problem does this solve?

Closes #1682. Clicking a link in the web terminal always fired xterm.js's built-in OSC-8 handler, which confirms unconditionally: *"Do you want to navigate to … WARNING: This link could potentially be dangerous"*. For anyone working against internal tooling (self-hosted GitLab, Gerrit, CI) every merge-request and build link pays that prompt, several times a minute during review work, for links they already trust.

This adds the `[web].trusted_domains` allowlist the issue asked for, plus the explicit `confirm_link_open` toggle:

```toml
[web]
trusted_domains = [
  "gitlab.mycorp.example",
  "gerrit.mycorp.example",
  "*.ci.mycorp.example",   # subdomains of ci.mycorp.example
]
confirm_link_open = true    # default; false accepts the risk globally
```

A link whose **host** matches an entry opens directly. Everything else still confirms, so the safety net stays in place for arbitrary links — the allowlist form the issue thread picked as the default recommendation.

## Why this change

The confirm is not agent-deck code: it lives in the vendored `static/vendor/xterm.mjs` `OscLinkProvider`, whose default `activate` callback is used whenever the terminal has no `linkHandler` option. So the single link-open call site is the `new Terminal({…})` in `static/app/TerminalPanel.js`: supplying `linkHandler` replaces the built-in handler outright, with no patching of the vendored bundle.

The policy itself lives in a new `static/app/terminalLinks.js` and is deliberately conservative, because an allowlist is a security control:

- **Host-only matching**, case-insensitive, port- and path-independent. Exact match by default; `*.base` matches strictly *deeper* subdomains of `base` and never the bare base itself.
- **Normalized once in Go** (`session.NormalizeTrustedDomains`) so a pasted URL, a `host:port`, userinfo, or a trailing dot all reduce to the same comparable host. Unusable entries (`*`, `*.`, `*.example`, `git.*.corp.example`, blanks) are **dropped**, never widened — `*.example` would otherwise allow every single-label host on the network. The JS mirrors the same normalizer so a hand-edited config and an API-served list behave identically.
- **Only `http`/`https` ever auto-open.** `file://gitlab.corp.example/…` and `javascript:` never match, whatever host they claim.
- The open still mirrors xterm exactly: blank window, `opener` cleared, then navigate; a blocked popup refuses to navigate rather than hand the target a live opener.

Config plumbing follows the existing `[web].mutations_enabled` path — config → `web.Config` → `GET /api/settings` → signals hydrated by `AppShell.js` → read at click time, so changing settings needs no terminal rebuild. One deliberate asymmetry: `web.Config.ConfirmLinkOpen` is a `*bool` where `nil` means *confirm*. A plain `bool` would let any `web.Config{…}` built without the field (tests, the e2e fixture, a future caller) silently disable the prompt for every host; the pointer makes the safe value the zero value. `GET /api/settings` always serializes `trustedDomains` as an array, never `null`.

## User impact

- Default behavior is **unchanged**: with no `[web]` config, every link still confirms.
- Opt in per host with `[web].trusted_domains`; those links now open on the first click.
- `[web].confirm_link_open = false` drops the prompt entirely for users who accept the risk (documented as the less-preferred option).
- The web Settings drawer gained two read-only rows (`trusted domains`, `link confirm`) so the active policy is visible without reading `config.toml`.
- New `[web]` section in `skills/agent-deck/references/config-reference.md` documenting all three keys (`mutations_enabled` was previously undocumented there too).

## Evidence

**Playwright e2e (the web gate), `tests/web/e2e/trusted-domains.spec.js`** — boots dedicated `web-fixture` instances on ephemeral ports (same pattern as `read-only-mode.spec.js`), one with `-trusted-domains gitlab.corp.example,*.ci.corp.example` and one with `-confirm-link-open=false`, then drives the production handler in a real browser against a real server after real `/api/settings` hydration:

```
Running 8 tests using 1 worker
  ✓ 1 … GET /api/settings serves the allowlist and confirmLinkOpen:true (19ms)
  ✓ 2 … the settings drawer shows the hydrated policy (841ms)
  ✓ 3 … an ALLOWLISTED link opens with no confirmation (369ms)
  ✓ 4 … a subdomain under a *. entry opens with no confirmation (367ms)
  ✓ 5 … a NON-allowlisted link still confirms before opening (368ms)
  ✓ 6 … a lookalike host that merely ends with a trusted name still confirms (366ms)
  ✓ 7 … GET /api/settings reports confirmLinkOpen:false with an empty allowlist (5ms)
  ✓ 8 … every link opens without a confirmation, allowlist or not (354ms)
  8 passed (34.1s)
```

The spec explains in-file why it invokes the `activate` callback xterm itself would call rather than clicking a rendered link cell: an OSC-8 hyperlink only exists in the terminal buffer once a live tmux pane emits one, and the in-memory fixture has no pane. It imports the *same* module instance the app loaded (identical `/static/app/terminalLinks.js` URL → same module record, same hydrated signals), so the decision path under test is the real one.

**Full `tests/web` suite** (`npm run test:unit` + `npm run test:e2e`), sandboxed HOME/XDG:

```
Test Files  9 passed (9)      Tests  128 passed (128)     # vitest, incl. 40 new
587 passed, 5 failed (4.4m)                              # playwright
```

The 5 failures are all `toHaveScreenshot` baseline mismatches (`visual-baselines` home light/dark, `keyboard-parity` shortcuts overlay). They reproduce identically on a pristine `origin/main` checkout on this machine (verified with the change stashed: same 4 visual-baseline failures, 5 passed) — the committed baselines are generated on Linux CI and this run was macOS. Nothing this PR touches is rendered on the home screen or the shortcuts overlay.

**Go**: `go build ./...` and `go vet ./...` clean. Go tests were **not** run on this host — this machine's `$HOME` *is* a live `~/.agent-deck` data directory and several packages are not isolated from the real home (the failure mode documented in the repo `CLAUDE.md`). The new Go coverage is left to CI's sandboxed runners:

- `internal/session/userconfig_web_test.go` — defaults when the keys are absent, reading + normalizing the list, `confirm_link_open` default/explicit, and a 17-case table over `NormalizeTrustedDomains` (case folding, scheme/path/port/userinfo/trailing-dot stripping, IPv6 literal, dedupe, order preservation, and every entry shape that must be dropped).
- `internal/web/handlers_settings_test.go` — the `/api/settings` contract, including that a `Config` with `ConfirmLinkOpen` unset still reports `confirmLinkOpen: true`.
- `internal/web/issue1682_link_policy_test.go` — source pin on the `TerminalPanel.js` wiring, in the same spirit as `TestWebBundle_ChartNotInInitialPayload_RegressionFor1022`. Neither behavioral suite can observe whether xterm is actually *handed* the handler (no OSC-8 link without a live pane; xterm exposes no back-reference from its DOM element to the Terminal instance), and deleting that one option would silently restore the confirm on every link.

**Bypass cases pinned in `tests/web/unit/terminalLinks.test.js`** (40 cases): `notgitlab.corp.example`, `gitlab.corp.example.evil.test`, `evilci.corp.example` vs `*.ci.corp.example`, `ci.corp.example` against its own `*.` entry, `https://gitlab.corp.example@evil.example/`, `file://` and `javascript:` with a trusted host, unparseable input, empty/missing list, declined confirm, blocked popup, and the live-signal re-read.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-x

## What actually bothered you

From the issue, and it matches the maintainer's own review workflow: every merge-request link in a self-hosted GitLab / Gerrit setup fires the same "this could be dangerous" dialog, so reviewing a stack of MRs from the agent-deck web terminal costs several extra clicks a minute on links that are known-safe internal tooling. The friction is bad enough that the realistic alternative is switching the confirm off wholesale, which is exactly the outcome an allowlist avoids.

Note for @amh1k, who offered to take this on: apologies for the overlap — this was picked up in the same sweep that reopened the issue and I did not want it to sit unlanded a second time. Genuinely happy to hand over follow-ups here (a TUI-side equivalent, or a web toggle that writes the config), and review comments on this diff are very welcome.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — **not run on this host** (its `$HOME` is a live agent-deck data dir; see Evidence). `go build` + `go vet` clean; Go tests verified by CI.
- [x] If this touches a hot path: n/a — click-time only, no change to list/status/session output/startup/tmux
- [x] CHANGELOG.md untouched
- [x] AI-assisted? Disclosed above, with validation evidence
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=claude-opus-4-x intent=yes -->
