### PR TITLE
fix(release): publish releases only after assets are verified (closes #1759)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,26 @@ file an issue and fix it, don't merge through it.
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `release.yml` | push tag `v*` | Validates the tag matches `cmd/agent-deck/main.go`'s `Version`, runs `go test -race ./...`, runs `goreleaser --clean` to build Darwin/Linux × amd64/arm64 tarballs, publishes the GitHub Release, and asserts the expected five assets + `checksums.txt` landed. Replaces the pre-#332 manual `make release-local` step. |
+| `release.yml` | push tag `v*` | Validates the tag matches `cmd/agent-deck/main.go`'s `Version`, runs `go test -race ./...`, runs `goreleaser --clean` to build Darwin/Linux × amd64/arm64 tarballs into a **draft** release, asserts the four tarballs + `checksums.txt` landed, verifies every tarball against its published SHA-256 — and only then publishes the release. Replaces the pre-#332 manual `make release-local` step. |
+| `homebrew-verify.yml` | `workflow_run` after `release.yml` completes successfully (plus weekly cron, `workflow_dispatch`, and PRs touching install docs) | Probes the live tap: formula exists, its version matches `/releases/latest`, and every URL in it resolves. Moved off the tag-push trigger in #1759 because it used to race the release it was verifying. |
+
+### The release is published last, and only once (#1759)
+
+Assets are attached to a **draft** (`release.draft: true` in `.goreleaser.yml`) and
+`release.yml`'s `Publish release` step is the only thing that ever makes a
+release visible — after asset presence and checksum verification pass. If any
+step fails, the draft is never published, so `agent-deck update`, `brew`, and
+`agent-deck remote update` keep resolving the previous good release instead of
+an empty one. A leftover draft is adopted by the next run of the workflow for
+that tag (`release.use_existing_draft: true`).
+
+**Cutting a release therefore means pushing the tag — nothing else.** Never
+create the GitHub release yourself, and never with `gh release create` without
+`--draft`: GoReleaser copies the draft flag of a release that already exists, so
+a pre-published release stays public and asset-less for the whole ~11-minute
+build (exactly what broke v1.10.10 and v1.10.11). `release.yml` now forces such
+a release back to draft before building, but that safety net exists to catch
+mistakes, not to be relied on.
 | `pages.yml` | push to `main` touching `site/**`, or `workflow_dispatch` | Deploys the static landing site under `site/` to GitHub Pages. |
 
 ## Notification-only (no gate, no build)

--- a/.github/workflows/homebrew-verify.yml
+++ b/.github/workflows/homebrew-verify.yml
@@ -12,9 +12,15 @@ on:
       - '.goreleaser.yml'
       - 'scripts/verify-homebrew-install.sh'
       - '.github/workflows/homebrew-verify.yml'
-  push:
-    tags:
-      - 'v*'
+  # Runs after the Release workflow finishes, NOT on the tag push (#1759).
+  # On the tag push the release is mid-flight: the tap formula still holds the
+  # previous version while the API may already advertise the new tag, so the
+  # version-match check below failed on a race rather than on a real break —
+  # and it was verifying the previous release, not the one being cut.
+  workflow_run:
+    workflows: ['Release']
+    types:
+      - completed
   schedule:
     # Weekly probe so a broken tap is detected even without commits.
     - cron: '0 9 * * 1'
@@ -23,6 +29,10 @@ on:
 jobs:
   verify-formula:
     runs-on: ubuntu-latest
+    # A failed release deliberately leaves the previous version published and
+    # the tap untouched, which is a consistent state — nothing to verify, and
+    # verifying it would just add a second red check to an already-red release.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v7
       - name: Verify homebrew tap publishes a working formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,87 @@ jobs:
           ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
 
+      # #1759: the empty-release window. If a release already exists for this
+      # tag and is already published (an out-of-band `gh release create`, or a
+      # previous run of this workflow), GoReleaser will NOT re-draft it —
+      # createOrUpdateRelease copies the existing release's draft flag — so it
+      # would stay public and asset-less for the ~11 minutes of tests + build
+      # that follow. `agent-deck update` then errors with "no release binary
+      # available" and homebrew-verify red-fails on the mismatch.
+      #
+      # Force the invariant this pipeline depends on: when GoReleaser starts,
+      # the release for this tag either does not exist or is an unpublished
+      # draft. Publishing happens in exactly one place — the "Publish release"
+      # step below, after assets are verified. This runs before Go setup so the
+      # exposure window is seconds, not minutes.
+      #
+      # Re-drafting is non-destructive: the tag and any already-uploaded assets
+      # survive, and /releases/latest falls back to the previous good release,
+      # which is precisely the behaviour we want while a release is in flight.
+      - name: Force incomplete pre-existing release back to draft
+        timeout-minutes: 5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+
+          # `gh release view` resolves drafts too — it falls back to a draft
+          # lookup when the by-tag endpoint 404s — so "no release", "draft" and
+          # "published" are all distinguishable here.
+          if ! payload=$(gh release view "${REF_NAME}" --repo "${REPO}" --json isDraft,assets 2>/dev/null); then
+            echo "No release exists yet for ${REF_NAME} — GoReleaser will create it as a draft."
+            exit 0
+          fi
+          if [[ "$(jq -r '.isDraft' <<<"${payload}")" == "true" ]]; then
+            echo "Release ${REF_NAME} already exists as a draft — GoReleaser will adopt it."
+            exit 0
+          fi
+
+          # Keep this list in lockstep with "Validate release assets" below and
+          # with .goreleaser.yml's archive matrix.
+          EXPECTED=(
+            "agent-deck_${VERSION}_darwin_amd64.tar.gz"
+            "agent-deck_${VERSION}_darwin_arm64.tar.gz"
+            "agent-deck_${VERSION}_linux_amd64.tar.gz"
+            "agent-deck_${VERSION}_linux_arm64.tar.gz"
+            "checksums.txt"
+          )
+          ASSETS=$(jq -r '.assets[].name' <<<"${payload}")
+          MISSING=()
+          for asset in "${EXPECTED[@]}"; do
+            if ! grep -qx -- "${asset}" <<<"${ASSETS}"; then
+              MISSING+=("${asset}")
+            fi
+          done
+
+          if [[ ${#MISSING[@]} -eq 0 ]]; then
+            # A published release that already carries every asset is a finished
+            # release. Rebuilding it would delete and re-upload live assets,
+            # re-opening the very window this workflow exists to close, so stop
+            # instead. This is the mis-dispatch guard: re-running against an old
+            # complete tag must never disturb it.
+            echo "ERROR: release ${REF_NAME} is already published with all ${#EXPECTED[@]} assets."
+            echo "Nothing to do — refusing to rebuild and re-upload assets of a live release."
+            echo "To genuinely redo this release, delete the GitHub release first (the tag can stay),"
+            echo "then re-run this workflow."
+            exit 1
+          fi
+
+          echo "WARNING: release ${REF_NAME} is PUBLISHED but incomplete — missing:"
+          for m in "${MISSING[@]}"; do echo "  - ${m}"; done
+          echo "Reverting it to a draft so nobody observes an asset-less release (#1759)."
+          echo "Release cuts must push the tag only; never create the release published."
+          # The title is normalised to the tag on purpose: GoReleaser's
+          # use_existing_draft lookup matches a draft by release NAME (its
+          # findDraftRelease compares GetName(), while the caller passes the tag),
+          # so a release someone created with a custom title would be invisible to
+          # it and the run would collide on the tag instead of adopting the draft.
+          # .goreleaser.yml's name_template is "v{{.Version}}", i.e. exactly the tag.
+          gh release edit "${REF_NAME}" --repo "${REPO}" --draft=true --title "${REF_NAME}"
+          echo "Release ${REF_NAME} is now an unpublished draft titled ${REF_NAME}."
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
         with:
@@ -123,11 +204,16 @@ jobs:
         timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           VERSION="${REF_NAME#v}"
           echo "Validating assets for release ${REF_NAME} (version ${VERSION})..."
 
-          ASSETS=$(gh api "repos/${{ github.repository }}/releases/tags/${REF_NAME}" --jq '.assets[].name')
+          # The release is still a draft at this point (#1759), and
+          # /releases/tags/{tag} only resolves PUBLISHED releases — it would
+          # 404 here. `gh release view` falls back to a draft lookup, so it
+          # works for both.
+          ASSETS=$(gh release view "${REF_NAME}" --repo "${REPO}" --json assets --jq '.assets[].name')
 
           EXPECTED=(
             "agent-deck_${VERSION}_darwin_amd64.tar.gz"
@@ -238,6 +324,44 @@ jobs:
           fi
           echo "Verified ${#ARTIFACTS[@]} tarballs against checksums.txt; ready to attest."
 
+      # The single place a release becomes visible (#1759). Everything above has
+      # to have passed: GoReleaser succeeded, the four tarballs and
+      # checksums.txt are attached, and every tarball's SHA-256 matches the
+      # published checksum. Only then does the release leave draft.
+      #
+      # If any earlier step fails the draft is simply never published:
+      # /releases/latest keeps pointing at the last good release, so
+      # `agent-deck update` and Homebrew never observe an asset-less release.
+      # The leftover draft is picked up and reused by the next run of this
+      # workflow for the same tag (release.use_existing_draft).
+      - name: Publish release
+        timeout-minutes: 5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Publishing verified release ${REF_NAME}..."
+
+          # prerelease: auto in .goreleaser.yml keys off a pre-release suffix in
+          # the tag; mirror that here so an rc/beta tag is not promoted to
+          # "latest" on the releases page or the /releases/latest endpoint.
+          if [[ "${REF_NAME}" == *-* ]]; then
+            echo "Tag ${REF_NAME} carries a pre-release suffix — publishing as a pre-release, not latest."
+            gh release edit "${REF_NAME}" --repo "${REPO}" --draft=false --prerelease
+          else
+            gh release edit "${REF_NAME}" --repo "${REPO}" --draft=false --latest
+          fi
+
+          # Confirm the state we intended actually landed, so a silent no-op
+          # cannot masquerade as a successful publish.
+          IS_DRAFT=$(gh release view "${REF_NAME}" --repo "${REPO}" --json isDraft --jq '.isDraft')
+          if [[ "${IS_DRAFT}" != "false" ]]; then
+            echo "ERROR: release ${REF_NAME} is still a draft after publish — failing closed"
+            exit 1
+          fi
+          echo "Release ${REF_NAME} is published with all assets attached."
+
       - name: Attest build provenance
         timeout-minutes: 10
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
@@ -258,5 +382,5 @@ jobs:
             -H "Title: Release ${REF_NAME} failed" \
             -H "Priority: high" \
             -H "Tags: github,release,failure" \
-            -d "Release workflow failed for ${REF_NAME}. Check logs: ${RUN_URL}" \
+            -d "Release workflow failed for ${REF_NAME}. The release stays an unpublished draft, so updaters and Homebrew still see the previous good release; re-run this workflow to retry. Check logs: ${RUN_URL}" \
             "https://ntfy.sh/${NTFY_TOPIC}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,9 +63,26 @@ release:
   github:
     owner: asheshgoplani
     name: agent-deck
-  draft: false
+  # Assets are attached to a DRAFT and the release workflow publishes it only
+  # after every expected tarball + checksums.txt is present and checksum-verified
+  # (see .github/workflows/release.yml, "Publish release"). Never set this back
+  # to false: with draft: false the release becomes visible the moment it is
+  # created, and GoReleaser's own undraft-after-upload protection is defeated
+  # entirely when a release already exists for the tag — createOrUpdateRelease
+  # copies the existing release's draft flag, so a pre-published (e.g.
+  # `gh release create`) release stays public and empty for the whole build.
+  # That was the ~11-minute "no release binary available" window in v1.10.10 and
+  # v1.10.11 (#1759).
+  draft: true
+  # findRelease() only resolves published releases by tag unless this is set, so
+  # draft mode without it makes any workflow re-run collide on the existing tag
+  # instead of adopting the draft it created.
+  use_existing_draft: true
   prerelease: auto
   mode: append
+  # Must stay equal to the tag: use_existing_draft looks a draft up by release
+  # NAME, so a name_template that diverges from the tag would make an existing
+  # draft undiscoverable and the run would collide on the tag instead.
   name_template: "v{{.Version}}"
   header: |
     ## Agent Deck v{{.Version}}

--- a/Makefile
+++ b/Makefile
@@ -191,8 +191,11 @@ release-local:
 	go test -race ./...
 	@echo "=== Running GoReleaser ==="
 	goreleaser release --clean
-	@echo "=== Release complete ==="
-	@echo "Verify: gh release view $$(git describe --tags --exact-match) --repo asheshgoplani/agent-deck"
+	@echo "=== Draft release built ==="
+	@echo "Assets are attached to a DRAFT (.goreleaser.yml release.draft, #1759)."
+	@echo "Verify the assets, then publish it yourself — CI's publish step does not run for a local release:"
+	@echo "  gh release view $$(git describe --tags --exact-match) --repo asheshgoplani/agent-deck"
+	@echo "  gh release edit $$(git describe --tags --exact-match) --repo asheshgoplani/agent-deck --draft=false --latest"
 
 # Web UI test targets
 # Vitest (unit) + Playwright (e2e + screenshot regression). Both run against

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2881,6 +2881,15 @@ func handleUpdate(args []string) {
 		os.Exit(1)
 	}
 
+	// #1759: a release is visible on GitHub before its binaries finish
+	// uploading. CheckForUpdate degrades to the newest installable release and
+	// reports the in-flight one here, so say that plainly instead of either
+	// erroring out or implying the user is already current.
+	if info.PublishingVersion != "" {
+		fmt.Printf("\nℹ v%s was just released but its binaries are not attached yet.\n", info.PublishingVersion)
+		fmt.Println("  Re-run `agent-deck update` in a few minutes to get it.")
+	}
+
 	if !info.Available {
 		fmt.Println("✓ You're running the latest version!")
 		return

--- a/internal/update/checksum.go
+++ b/internal/update/checksum.go
@@ -114,7 +114,12 @@ func DownloadVerifiedBinary(release *Release, goos, goarch string) ([]byte, erro
 	}
 	assetURL := GetAssetURLForPlatform(release, goos, goarch)
 	if assetURL == "" {
-		return nil, fmt.Errorf("no release binary available for %s/%s", goos, goarch)
+		// A release with no asset for a supported platform is almost always a
+		// release that is still uploading, not a missing build (#1759). Say so:
+		// the bare form of this error read as a broken install and sent people
+		// looking for a fault that did not exist.
+		return nil, fmt.Errorf("release %s has no binary for %s/%s yet — %s",
+			release.TagName, goos, goarch, StillPublishingHint)
 	}
 	checksumsURL := GetChecksumsURL(release)
 	if checksumsURL == "" {

--- a/internal/update/publishwindow.go
+++ b/internal/update/publishwindow.go
@@ -1,0 +1,105 @@
+package update
+
+// Publish-window tolerance (#1759).
+//
+// A GitHub release exists before its assets do. GoReleaser creates the release,
+// then uploads the platform tarballs and checksums.txt, and only then publishes
+// it — but that ordering has been defeated twice (v1.10.10, v1.10.11) by a
+// release that was already public at tag time, leaving `/releases/latest`
+// advertising a tag with zero downloadable assets for ~11 minutes. Every
+// updater path then failed with "no release binary available for <os>/<arch>",
+// which reads like a broken install rather than "wait a moment".
+//
+// The pipeline side of that is fixed in .goreleaser.yml + release.yml (assets
+// land on a draft; publishing happens only after they are verified). This file
+// is the client-side belt: even against a repo mid-publish, or one released by
+// some future path that regresses the invariant, the updater degrades to the
+// newest release it can actually install and says so.
+//
+// The logic here is deliberately pure — no network, no clock, no filesystem —
+// so the fallback is unit-testable.
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrNoInstallableRelease reports that no release in the candidate set carries a
+// usable binary for the requested platform. Callers should surface
+// StillPublishingHint rather than a bare failure: the overwhelmingly likely
+// cause is a release that is still uploading its assets.
+var ErrNoInstallableRelease = errors.New("no release carries an installable binary for this platform")
+
+// StillPublishingHint is the user-facing explanation for the publish window. It
+// is phrased as an instruction ("try again shortly") because that is the correct
+// and sufficient user action — the window closes on its own in minutes.
+const StillPublishingHint = "the newest release is still publishing (its binaries are not attached yet) — try again shortly"
+
+// HasPlatformAsset reports whether release is actually installable for
+// goos/goarch: it must carry both the platform tarball and the checksums.txt
+// that the tarball is verified against. Requiring both matters — a release whose
+// tarballs have uploaded but whose checksums.txt has not would otherwise be
+// chosen and then rejected by DownloadVerifiedBinary's integrity gate, turning a
+// transient window into a hard failure.
+func HasPlatformAsset(release *Release, goos, goarch string) bool {
+	if release == nil {
+		return false
+	}
+	return GetAssetURLForPlatform(release, goos, goarch) != "" && GetChecksumsURL(release) != ""
+}
+
+// SelectInstallableRelease picks the newest release in releases that can be
+// installed on goos/goarch.
+//
+// Drafts and pre-releases are ignored, matching the semantics of GitHub's
+// /releases/latest endpoint: a draft is by definition not yet offered to users,
+// and falling back onto a pre-release would silently move a user off the stable
+// channel.
+//
+// installable is the newest release with a usable binary. publishing is the
+// newest eligible release that is NOT installable and is strictly newer than
+// installable — i.e. the release the user would have gotten had its assets been
+// attached — and is nil when the newest release is already installable. Callers
+// use it to explain why they are offering an older version.
+//
+// When nothing is installable, installable is nil and the error is
+// ErrNoInstallableRelease; publishing is still populated when a newer
+// asset-less release was seen, so the caller can name it.
+//
+// The input need not be sorted; ordering is decided by CompareVersions.
+func SelectInstallableRelease(releases []Release, goos, goarch string) (installable *Release, publishing *Release, err error) {
+	var newestEligible *Release
+
+	for i := range releases {
+		candidate := &releases[i]
+		if candidate.Draft || candidate.Prerelease {
+			continue
+		}
+		if strings.TrimSpace(candidate.TagName) == "" {
+			continue
+		}
+		if newestEligible == nil || CompareVersions(candidate.TagName, newestEligible.TagName) > 0 {
+			newestEligible = candidate
+		}
+		if !HasPlatformAsset(candidate, goos, goarch) {
+			continue
+		}
+		if installable == nil || CompareVersions(candidate.TagName, installable.TagName) > 0 {
+			installable = candidate
+		}
+	}
+
+	// Only report a publish window when the release we are skipping is newer
+	// than what we settled on. An older asset-less release (e.g. a long-deleted
+	// upload) is not something the user is waiting for.
+	if newestEligible != nil && !HasPlatformAsset(newestEligible, goos, goarch) {
+		if installable == nil || CompareVersions(newestEligible.TagName, installable.TagName) > 0 {
+			publishing = newestEligible
+		}
+	}
+
+	if installable == nil {
+		return nil, publishing, ErrNoInstallableRelease
+	}
+	return installable, publishing, nil
+}

--- a/internal/update/publishwindow_test.go
+++ b/internal/update/publishwindow_test.go
@@ -1,0 +1,263 @@
+package update
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// releaseWithAssets builds a release carrying the full goreleaser asset set for
+// one platform (tarball + checksums.txt), i.e. an installable release.
+func releaseWithAssets(tag, goos, goarch string) Release {
+	version := tag
+	if len(version) > 0 && version[0] == 'v' {
+		version = version[1:]
+	}
+	return Release{
+		TagName: tag,
+		HTMLURL: "https://example/releases/" + tag,
+		Assets: []Asset{
+			{
+				Name:               "agent-deck_" + version + "_" + goos + "_" + goarch + ".tar.gz",
+				BrowserDownloadURL: "https://example/d/" + version + "/" + goos + "-" + goarch + ".tar.gz",
+			},
+			{
+				Name:               ChecksumsAssetName,
+				BrowserDownloadURL: "https://example/d/" + version + "/checksums.txt",
+			},
+		},
+	}
+}
+
+// emptyRelease is the shape that caused #1759: a real, published release whose
+// assets have not been uploaded yet.
+func emptyRelease(tag string) Release {
+	return Release{TagName: tag, HTMLURL: "https://example/releases/" + tag}
+}
+
+func TestHasPlatformAsset(t *testing.T) {
+	t.Run("tarball and checksums present", func(t *testing.T) {
+		r := releaseWithAssets("v1.10.11", "darwin", "arm64")
+		assert.True(t, HasPlatformAsset(&r, "darwin", "arm64"))
+	})
+
+	t.Run("no assets at all is the publish window", func(t *testing.T) {
+		r := emptyRelease("v1.10.11")
+		assert.False(t, HasPlatformAsset(&r, "darwin", "arm64"))
+	})
+
+	t.Run("other platform only", func(t *testing.T) {
+		r := releaseWithAssets("v1.10.11", "linux", "amd64")
+		assert.False(t, HasPlatformAsset(&r, "darwin", "arm64"))
+	})
+
+	t.Run("tarball uploaded but checksums.txt not yet", func(t *testing.T) {
+		// Mid-upload: goreleaser writes checksums.txt last. Treating this as
+		// installable would pick a release that DownloadVerifiedBinary then
+		// refuses, converting a transient window into a hard failure.
+		r := releaseWithAssets("v1.10.11", "darwin", "arm64")
+		r.Assets = r.Assets[:1]
+		assert.False(t, HasPlatformAsset(&r, "darwin", "arm64"))
+	})
+
+	t.Run("nil release", func(t *testing.T) {
+		assert.False(t, HasPlatformAsset(nil, "darwin", "arm64"))
+	})
+}
+
+func TestSelectInstallableRelease(t *testing.T) {
+	t.Run("newest is installable", func(t *testing.T) {
+		releases := []Release{
+			releaseWithAssets("v1.10.11", "darwin", "arm64"),
+			releaseWithAssets("v1.10.10", "darwin", "arm64"),
+		}
+		got, publishing, err := SelectInstallableRelease(releases, "darwin", "arm64")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "v1.10.11", got.TagName)
+		assert.Nil(t, publishing, "nothing is mid-publish when the newest is installable")
+	})
+
+	t.Run("falls back past the mid-publish release", func(t *testing.T) {
+		// The exact v1.10.11 situation: latest is published and empty.
+		releases := []Release{
+			emptyRelease("v1.10.11"),
+			releaseWithAssets("v1.10.10", "darwin", "arm64"),
+			releaseWithAssets("v1.10.9", "darwin", "arm64"),
+		}
+		got, publishing, err := SelectInstallableRelease(releases, "darwin", "arm64")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "v1.10.10", got.TagName, "newest release that actually has a binary")
+		require.NotNil(t, publishing)
+		assert.Equal(t, "v1.10.11", publishing.TagName)
+	})
+
+	t.Run("unsorted input is ordered by version not position", func(t *testing.T) {
+		releases := []Release{
+			releaseWithAssets("v1.9.9", "linux", "amd64"),
+			emptyRelease("v1.10.11"),
+			releaseWithAssets("v1.10.10", "linux", "amd64"),
+			releaseWithAssets("v1.10.2", "linux", "amd64"),
+		}
+		got, publishing, err := SelectInstallableRelease(releases, "linux", "amd64")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.10.10", got.TagName)
+		require.NotNil(t, publishing)
+		assert.Equal(t, "v1.10.11", publishing.TagName)
+	})
+
+	t.Run("drafts are never offered", func(t *testing.T) {
+		draft := releaseWithAssets("v1.11.0", "darwin", "arm64")
+		draft.Draft = true
+		releases := []Release{draft, releaseWithAssets("v1.10.10", "darwin", "arm64")}
+		got, publishing, err := SelectInstallableRelease(releases, "darwin", "arm64")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.10.10", got.TagName)
+		assert.Nil(t, publishing, "a draft is not a release the user is waiting for")
+	})
+
+	t.Run("pre-releases are never offered", func(t *testing.T) {
+		pre := releaseWithAssets("v1.11.0", "darwin", "arm64")
+		pre.Prerelease = true
+		releases := []Release{pre, releaseWithAssets("v1.10.10", "darwin", "arm64")}
+		got, _, err := SelectInstallableRelease(releases, "darwin", "arm64")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.10.10", got.TagName, "must not move a user onto the pre-release channel")
+	})
+
+	t.Run("nothing installable", func(t *testing.T) {
+		releases := []Release{emptyRelease("v1.10.11"), emptyRelease("v1.10.10")}
+		got, publishing, err := SelectInstallableRelease(releases, "darwin", "arm64")
+		require.ErrorIs(t, err, ErrNoInstallableRelease)
+		assert.Nil(t, got)
+		require.NotNil(t, publishing, "caller can still name the newest release it skipped")
+		assert.Equal(t, "v1.10.11", publishing.TagName)
+	})
+
+	t.Run("no release built for this platform", func(t *testing.T) {
+		// Unsupported GOOS/GOARCH — not a publish window, and must not be
+		// reported as one.
+		releases := []Release{
+			releaseWithAssets("v1.10.11", "linux", "amd64"),
+			releaseWithAssets("v1.10.10", "linux", "amd64"),
+		}
+		got, publishing, err := SelectInstallableRelease(releases, "windows", "arm64")
+		require.ErrorIs(t, err, ErrNoInstallableRelease)
+		assert.Nil(t, got)
+		require.NotNil(t, publishing)
+		assert.Equal(t, "v1.10.11", publishing.TagName)
+	})
+
+	t.Run("empty and untagged input", func(t *testing.T) {
+		_, publishing, err := SelectInstallableRelease(nil, "darwin", "arm64")
+		require.ErrorIs(t, err, ErrNoInstallableRelease)
+		assert.Nil(t, publishing)
+
+		_, _, err = SelectInstallableRelease([]Release{{TagName: "  "}}, "darwin", "arm64")
+		require.ErrorIs(t, err, ErrNoInstallableRelease)
+	})
+
+	t.Run("an older asset-less release is not a publish window", func(t *testing.T) {
+		releases := []Release{
+			releaseWithAssets("v1.10.11", "darwin", "arm64"),
+			emptyRelease("v1.9.0"),
+		}
+		got, publishing, err := SelectInstallableRelease(releases, "darwin", "arm64")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.10.11", got.TagName)
+		assert.Nil(t, publishing)
+	})
+}
+
+// TestCheckForUpdate_PublishWindowFallsBack drives the whole path over a stub
+// GitHub API: /releases/latest reports a tag with no assets (the #1759 window)
+// and the listing carries an installable predecessor.
+func TestCheckForUpdate_PublishWindowFallsBack(t *testing.T) {
+	goos, goarch := runtime.GOOS, runtime.GOARCH
+
+	latest := emptyRelease("v1.10.11")
+	recent := []Release{
+		latest,
+		releaseWithAssets("v1.10.10", goos, goarch),
+		releaseWithAssets("v1.10.9", goos, goarch),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/"+GitHubRepo+"/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(latest)
+	})
+	mux.HandleFunc("/repos/"+GitHubRepo+"/releases", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(recent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	origURL := apiBaseURL
+	apiBaseURL = srv.URL
+	t.Cleanup(func() { apiBaseURL = origURL })
+
+	isolateUpdatePaths(t)
+
+	info, err := CheckForUpdate("1.10.9", true)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	// The user is offered the newest release that can actually be installed,
+	// with a working download URL instead of an empty one.
+	assert.Equal(t, "1.10.10", info.LatestVersion)
+	assert.NotEmpty(t, info.DownloadURL, "must not hand callers an empty download URL")
+	assert.True(t, info.Available)
+	// ...and is told which version is still landing.
+	assert.Equal(t, "1.10.11", info.PublishingVersion)
+
+	// A mid-publish answer must not be cached, or the user stays pinned to the
+	// older release for a full check interval after the real one goes live.
+	cached, err := CachedUpdateInfo("1.10.9")
+	require.NoError(t, err)
+	assert.Nil(t, cached, "publish-window results must not be persisted")
+}
+
+// TestCheckForUpdate_NoFallbackKeepsLatest pins the unsupported-platform case:
+// when NO release has a binary for this platform, behaviour is unchanged — the
+// newest release is still reported, and the result is cached as usual.
+func TestCheckForUpdate_NoFallbackKeepsLatest(t *testing.T) {
+	latest := releaseWithAssets("v1.10.11", "plan9", "mips")
+	recent := []Release{latest, releaseWithAssets("v1.10.10", "plan9", "mips")}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/"+GitHubRepo+"/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(latest)
+	})
+	mux.HandleFunc("/repos/"+GitHubRepo+"/releases", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(recent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	origURL := apiBaseURL
+	apiBaseURL = srv.URL
+	t.Cleanup(func() { apiBaseURL = origURL })
+
+	isolateUpdatePaths(t)
+
+	info, err := CheckForUpdate("1.10.9", true)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "1.10.11", info.LatestVersion)
+	assert.Empty(t, info.PublishingVersion, "an unsupported platform is not a publish window")
+
+	cached, err := CachedUpdateInfo("1.10.9")
+	require.NoError(t, err)
+	require.NotNil(t, cached, "normal results are still cached")
+	assert.Equal(t, "1.10.11", cached.LatestVersion)
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -76,6 +76,12 @@ type Release struct {
 	PublishedAt time.Time `json:"published_at"`
 	HTMLURL     string    `json:"html_url"`
 	Assets      []Asset   `json:"assets"`
+	// Draft and Prerelease let the publish-window fallback mirror GitHub's
+	// /releases/latest semantics when it walks the full release listing, which
+	// (unlike /releases/latest) includes drafts and pre-releases. See
+	// SelectInstallableRelease.
+	Draft      bool `json:"draft"`
+	Prerelease bool `json:"prerelease"`
 }
 
 // Asset represents a release asset (binary download)
@@ -106,6 +112,13 @@ type UpdateInfo struct {
 	// current version, capped at recentReleasesLimit. Populated when the
 	// full /releases listing is fetched alongside /releases/latest.
 	ReleasesBehind int
+	// PublishingVersion is set when the newest release on GitHub has no
+	// installable binary for this platform yet — i.e. the release is mid-publish
+	// (#1759). LatestVersion/DownloadURL then point at the newest release that
+	// IS installable, so an update still works; callers should mention
+	// StillPublishingHint so the user knows a newer version is imminent.
+	// Empty in the normal case.
+	PublishingVersion string
 }
 
 // NudgeThreshold is the minimum "releases behind" count that triggers the
@@ -473,15 +486,52 @@ func CheckForUpdate(currentVersion string, forceCheck bool) (*UpdateInfo, error)
 		return info, err
 	}
 
+	// Count how many releases the user is behind. A failure here is
+	// non-fatal — we fall back to 0 behind (no nudge) but still report
+	// Available so the standard banner renders. The same listing backs the
+	// publish-window fallback below.
+	releasesBehind := 0
+	recent, recentErr := fetchRecentReleases(recentReleasesLimit)
+	if recentErr == nil {
+		releasesBehind = CountReleasesBehind(currentVersion, recent)
+	}
+
+	// Publish-window tolerance (#1759): GitHub reports the new tag as latest
+	// before its assets finish uploading. Offering that release would hand every
+	// downstream path an empty DownloadURL and a "no release binary available"
+	// error, so instead fall back to the newest release we can actually install
+	// and remember which version is still publishing.
+	//
+	// The fallback is only taken when a usable older release actually exists.
+	// If nothing in the listing is installable we leave the result exactly as it
+	// was before this change: that is not a publish window but an unsupported
+	// platform (no goreleaser target for this GOOS/GOARCH), and flagging it on
+	// every check would suppress caching forever and burn the anonymous API
+	// rate limit.
+	publishingVersion := ""
+	if recentErr == nil && !HasPlatformAsset(release, runtime.GOOS, runtime.GOARCH) {
+		if installable, _, selErr := SelectInstallableRelease(recent, runtime.GOOS, runtime.GOARCH); selErr == nil {
+			publishingVersion = strings.TrimPrefix(release.TagName, "v")
+			release = installable
+		}
+	}
+
 	latestVersion := strings.TrimPrefix(release.TagName, "v")
 	downloadURL := getAssetURL(release)
 
-	// Count how many releases the user is behind. A failure here is
-	// non-fatal — we fall back to 0 behind (no nudge) but still report
-	// Available so the standard banner renders.
-	releasesBehind := 0
-	if recent, err := fetchRecentReleases(recentReleasesLimit); err == nil {
-		releasesBehind = CountReleasesBehind(currentVersion, recent)
+	info.LatestVersion = latestVersion
+	info.DownloadURL = downloadURL
+	info.ReleaseURL = release.HTMLURL
+	info.ReleasesBehind = releasesBehind
+	info.PublishingVersion = publishingVersion
+	info.Available = CompareVersions(currentVersion, latestVersion) < 0
+
+	// Don't persist a mid-publish answer. Caching it would pin the user to the
+	// older release for a full checkInterval (an hour by default) after the real
+	// release finished publishing minutes later; re-checking on the next
+	// invocation costs one API call and self-heals as soon as the assets land.
+	if publishingVersion != "" {
+		return info, nil
 	}
 
 	// Update cache
@@ -494,12 +544,6 @@ func CheckForUpdate(currentVersion string, forceCheck bool) (*UpdateInfo, error)
 		ReleasesBehind: releasesBehind,
 	}
 	_ = saveCache(cache) // Ignore cache save errors
-
-	info.LatestVersion = latestVersion
-	info.DownloadURL = downloadURL
-	info.ReleaseURL = release.HTMLURL
-	info.ReleasesBehind = releasesBehind
-	info.Available = CompareVersions(currentVersion, latestVersion) < 0
 
 	return info, nil
 }

--- a/scripts/verify-homebrew-install.sh
+++ b/scripts/verify-homebrew-install.sh
@@ -34,21 +34,42 @@ if ! curl -sf -o /dev/null "https://github.com/${OWNER}/${TAP_REPO}"; then
 fi
 pass "tap repo reachable"
 
-# 2. Formula exists
+# 2 + 3. Formula exists and its version matches the latest release.
+#
+# Retried, because raw.githubusercontent.com serves the formula through a CDN
+# with a cache lifetime of a few minutes: right after a release the tap commit
+# can be pushed while raw still returns the previous formula. A single attempt
+# turned that CDN lag into a red gate (#1759). A real break (tap push failed,
+# formula never updated) still fails — it just takes ATTEMPTS tries first.
+ATTEMPTS="${HOMEBREW_VERIFY_ATTEMPTS:-6}"
+RETRY_DELAY="${HOMEBREW_VERIFY_RETRY_DELAY:-30}"
+
 formula_url="${RAW_BASE}/${FORMULA_PATH}"
-formula=$(curl -sf "${formula_url}") || fail "formula not found at ${formula_url}"
+formula=""
+formula_version=""
+latest_tag=""
+
+for attempt in $(seq 1 "${ATTEMPTS}"); do
+  # Cache-bust so a retry can actually observe a newer formula.
+  formula=$(curl -sf "${formula_url}?nocache=$(date +%s)") ||
+    fail "formula not found at ${formula_url}"
+  formula_version=$(printf '%s\n' "${formula}" | sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p' | head -1)
+  [ -n "${formula_version}" ] || fail "could not parse formula version"
+
+  latest_tag=$(curl -sf "${RELEASES_API}" | sed -nE 's/.*"tag_name":[[:space:]]*"v?([^"]+)".*/\1/p' | head -1)
+  [ -n "${latest_tag}" ] || fail "could not fetch latest release tag"
+
+  if [ "${formula_version}" = "${latest_tag}" ]; then
+    break
+  fi
+
+  if [ "${attempt}" -eq "${ATTEMPTS}" ]; then
+    fail "formula version ${formula_version} != latest release ${latest_tag} after ${ATTEMPTS} attempts (goreleaser publish step likely failed)"
+  fi
+  echo "formula version ${formula_version} != latest release ${latest_tag}; retrying in ${RETRY_DELAY}s (attempt ${attempt}/${ATTEMPTS})"
+  sleep "${RETRY_DELAY}"
+done
 pass "formula exists at ${FORMULA_PATH}"
-
-# 3. Version matches latest release
-formula_version=$(printf '%s\n' "${formula}" | sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p' | head -1)
-[ -n "${formula_version}" ] || fail "could not parse formula version"
-
-latest_tag=$(curl -sf "${RELEASES_API}" | sed -nE 's/.*"tag_name":[[:space:]]*"v?([^"]+)".*/\1/p' | head -1)
-[ -n "${latest_tag}" ] || fail "could not fetch latest release tag"
-
-if [ "${formula_version}" != "${latest_tag}" ]; then
-  fail "formula version ${formula_version} != latest release ${latest_tag} (goreleaser publish step likely failed)"
-fi
 pass "formula version ${formula_version} matches latest release"
 
 # 4. All URLs in formula resolve


### PR DESCRIPTION
Closes #1759

## The bug

For roughly the first 11 minutes of a release, the GitHub Release for the new tag was **published but empty**. `/releases/latest` advertised the new tag with zero assets attached, so:

- `agent-deck update` (and the startup update prompt, and `agent-deck remote update`) failed with `no release binary available for <os>/<arch>`.
- `homebrew-verify` red-failed: it runs on the tag push and compares the tap formula version against `/releases/latest`, so the API said the new version while the tap still held the old one.

Measured from the GitHub API (`published_at` vs. first asset `created_at`):

| Tag | published_at | first asset | empty-and-published |
|---|---|---|---|
| v1.10.9 | 09:24:21Z | 09:24:19Z | none — published 2s *after* assets |
| v1.10.10 | 18:33:49Z | 18:44:36Z | **10m 47s** |
| v1.10.11 | 19:21:27Z | 19:32:53Z | **11m 26s** |

## Root cause

The release was already public *before CI started*: the `Release` workflow run for v1.10.10 was created at `18:33:51Z`, two seconds after `published_at`. So the release is created already-published at tag time, outside the workflow — and then CI spends ~11 minutes on tests and builds before the first asset lands.

GoReleaser's own protection ("always start as a draft while uploading artifacts, undraft after") does **not** save us here, because it only applies on the create path. In `internal/client/github.go`, `createOrUpdateRelease` finds the existing release and does:

```go
data.Draft = new(release.Draft)
```

It copies the existing release's draft flag. A pre-published release therefore stays public and asset-less for the entire build, and `PublishRelease`'s undraft at the end is a no-op. v1.10.9, cut by pushing the tag only, shows no window — which is exactly why this looked intermittent.

## The fix — three layers

**1. `.goreleaser.yml` — assets land on a draft.**
`release.draft: true`, so GoReleaser attaches assets and never publishes. Plus `release.use_existing_draft: true`: `findRelease()` only resolves *published* releases by tag unless that is set, so draft mode without it would make any workflow re-run collide on the existing tag instead of adopting the draft it created.

**2. `.github/workflows/release.yml` — one publish point, after verification.**

- New pre-flight step (runs immediately after checkout, before Go setup, so exposure is seconds): if a release already exists for the tag, is published, and is missing any expected asset, force it back to a draft. Non-destructive — tag and uploaded assets survive, and `/releases/latest` falls back to the last good release, which is the behaviour we want mid-flight. It also normalises the draft's title to the tag, because `use_existing_draft` matches a draft by release **name**, so a release created with a custom title would be invisible to GoReleaser.
- The same step **refuses to rebuild a published release that already has all its assets** and fails with an explanatory message. That is the mis-dispatch guard: re-running the workflow against an old, complete tag must never un-publish or re-upload over a live release.
- New final `Publish release` step — the only thing in the repo that makes a release visible. It runs after GoReleaser succeeded, after the four tarballs + `checksums.txt` are confirmed present, and after every tarball has been verified against its published SHA-256. It re-reads `isDraft` afterwards so a silent no-op cannot pass as a successful publish, and it honours `prerelease: auto` (a pre-release-suffixed tag is not promoted to `latest`).
- `Validate release assets` switched from `gh api /releases/tags/{tag}` to `gh release view`, because the by-tag endpoint only resolves published releases and would now 404 on the draft.
- The failure notification now states that the release stays an unpublished draft and that re-running the workflow retries it.

If anything fails, the draft is simply never published. Updaters and Homebrew continue to resolve the previous good release; the leftover draft is adopted by the next run for that tag.

**3. `internal/update` — client-side tolerance.**
New `internal/update/publishwindow.go`:

- `HasPlatformAsset` — a release is installable only if it carries *both* the platform tarball and `checksums.txt`. Requiring both matters: GoReleaser writes `checksums.txt` last, and picking a release without it would hand `DownloadVerifiedBinary`'s integrity gate a release it must reject, turning a transient window into a hard failure.
- `SelectInstallableRelease` — newest installable release, ignoring drafts and pre-releases (mirroring `/releases/latest` semantics, since the full listing includes both), and reporting which newer release is still publishing.
- `CheckForUpdate` now degrades to that release and sets `UpdateInfo.PublishingVersion`; `agent-deck update` prints "vX was just released but its binaries are not attached yet — re-run in a few minutes". Mid-publish answers are deliberately **not** cached, so the real release is picked up as soon as it lands instead of being pinned for a full check interval.
- The fallback is only taken when a usable older release exists. If nothing is installable this is an unsupported platform, not a publish window, and behaviour is unchanged — otherwise caching would be suppressed forever and the anonymous API rate limit would be burned.
- `DownloadVerifiedBinary`'s error now reads `release vX has no binary for os/arch yet — the newest release is still publishing …` instead of the bare `no release binary available`, which read like a broken install.

**Bonus: `homebrew-verify` no longer races the release it verifies.** It triggered on `push: tags`, i.e. concurrently with the release, so it was checking the *previous* state and failing on a race. It now triggers on `workflow_run` after `Release` completes successfully. Its formula lookup also retries (6 × 30s, cache-busted), because `raw.githubusercontent.com` serves the tap through a CDN that can lag the tap push by minutes; a genuine break still fails, it just takes the retries first.

## Tests

`internal/update/publishwindow_test.go` (pure logic, runs in CI):

- `HasPlatformAsset`: both assets present; no assets at all (the #1759 shape); other-platform-only; tarball uploaded but `checksums.txt` not yet; nil release.
- `SelectInstallableRelease`: newest installable; falls back past the mid-publish release (the exact v1.10.11 fixture); unsorted input ordered by version not position; drafts never offered; pre-releases never offered; nothing installable → `ErrNoInstallableRelease` while still naming the skipped release; unsupported platform; empty/untagged input; an *older* asset-less release is not reported as a publish window.
- `TestCheckForUpdate_PublishWindowFallsBack`: end-to-end over a stub GitHub API — asset-less latest plus installable predecessor gives a working `DownloadURL`, `PublishingVersion` set, and nothing written to the cache.
- `TestCheckForUpdate_NoFallbackKeepsLatest`: pins the unsupported-platform case as unchanged, including that it still caches.

Per the repo's hard rule, the Go test suite was not run against this host's real `~/.agent-deck`. Local verification was `go build ./...` and `go vet ./internal/update/... ./cmd/agent-deck/...` (both clean, and vet type-checks the new test file), `gofmt -l` clean, plus YAML parse checks on all three changed workflow/config files and `bash -n` on the changed script. CI runs the tests.

## Release runbook — what changes for future releases

**Cutting a release now means pushing the tag, and nothing else.**

- Do **not** create the GitHub release by hand, and never with `gh release create` without `--draft`. GoReleaser copies the draft flag of a release that already exists, so a pre-published release stays public and asset-less for the whole build — precisely what broke v1.10.10 and v1.10.11. The pre-flight step catches this now, but it exists to catch a mistake, not to be relied on.
- Tags and releases are created as **drafts**; publishing happens only after asset verification, and only inside `release.yml`.
- A red release run now leaves an **unpublished draft** rather than a broken public release. That is the intended outcome: `/releases/latest`, `agent-deck update`, and `brew` all stay on the previous good version. Fix the cause and re-run the workflow for the same tag — the draft is adopted and completed, no new tag needed.
- To genuinely redo an already-complete published release, delete the GitHub release first (the tag can stay), then re-run the workflow. The workflow now refuses to re-upload over a live, complete release.
- `make release-local` also produces a draft now; it prints the `gh release edit --draft=false --latest` command to finish the job, since CI's publish step does not run for a local release.
- `homebrew-verify` runs *after* the release completes, so a green release should be followed by a green brew check. A red brew check after a green release is now a real signal about the tap.

This is scoped to future releases and deliberately does not touch anything about the in-flight v1.10.11 run.
