### PR TITLE
fix(ui): make detach/switch return instant at large fleet sizes

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1137,6 +1137,13 @@ type switcherCommitMsg struct {
 
 type attachReturnRefreshMsg struct{}
 
+// attachReturnSyncedMsg lands when the attach-return reconciliation that used to
+// run inline on the Bubble Tea event loop (tmux cache refresh + a forced status
+// check for the session we just left) has finished on its own goroutine. The
+// handler only re-derives the list rows from the already-updated snapshot, which
+// is pure in-memory work. See attachReturnSyncCmd for why the split exists.
+type attachReturnSyncedMsg struct{}
+
 // storageChangedMsg signals that state.db was modified externally
 type storageChangedMsg struct{}
 
@@ -4773,6 +4780,48 @@ func (h *Home) triggerStatusUpdate() {
 	}
 }
 
+// attachReturnSyncCmd reconciles the session the user just detached from, OFF the
+// Bubble Tea event loop.
+//
+// Issue #1753: refreshAttachedSessionStatus was called inline from the attach-return
+// message handler, so the first repaint of the list waited on two tmux control-mode
+// round-trips (list-windows -a, list-panes -a — both O(fleet)), a forced capture-pane
+// for the session we left, a hook-status file removal, a possible SQLite status write,
+// and a full render-snapshot rebuild. Until that chain finished the event loop could
+// not run Update/View, and View() returns "" while isAttaching is set, so the user
+// looked at a blank screen for the whole duration. At ~70 sessions that is exactly the
+// "Ctrl+Q takes noticeably long to come back" report.
+//
+// The split: the event loop repaints the list immediately from the last snapshot, this
+// Cmd does the tmux/disk work on its own goroutine, and attachReturnSyncedMsg triggers
+// one more cheap repaint with the reconciled row. Worst case a row shows its pre-attach
+// status for a few frames instead of the list being frozen. Every call in the body
+// already runs on the background status worker (backgroundStatusUpdate /
+// processStatusUpdate), so no new concurrency contract is introduced — see
+// refreshAttachedSessionStatus.
+func (h *Home) attachReturnSyncCmd(sessionID string) tea.Cmd {
+	if strings.TrimSpace(sessionID) == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		h.refreshAttachedSessionStatus(sessionID)
+		return attachReturnSyncedMsg{}
+	}
+}
+
+// attachReturnRefreshCmd is the fleet-wide half of the same split: the delayed
+// post-attach catch-up (attachReturnRefreshMsg) refreshed both tmux caches inline,
+// which is a second event-loop stall ~350ms after the list came back. Same contract
+// as attachReturnSyncCmd: tmux work here, row rebuild on the event loop.
+func (h *Home) attachReturnRefreshCmd() tea.Cmd {
+	return func() tea.Msg {
+		tmux.RefreshSessionCache()
+		tmux.RefreshPaneInfoCache()
+		h.refreshSessionRenderSnapshot(nil)
+		return attachReturnSyncedMsg{}
+	}
+}
+
 func (h *Home) refreshAttachedSessionStatus(sessionID string) {
 	if strings.TrimSpace(sessionID) == "" {
 		return
@@ -6091,9 +6140,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.isAttaching.Store(false) // Atomic store for thread safety
 		now := time.Now()
 		h.beginAttachReturnGrace(now)
-		// Reconcile the attached session synchronously before the normal delayed
-		// refresh so an exited pane does not render as still running for a tick.
-		h.refreshAttachedSessionStatus(msg.attachedSessionID)
+		// Reconcile the session we just left on its own goroutine (#1753). It used
+		// to run inline here, which held the event loop — and therefore the first
+		// repaint of the list — behind O(fleet) tmux round-trips. attachReturnSyncCmd
+		// carries the rationale; attachReturnSyncedMsg repaints when it lands.
+		syncCmd := h.attachReturnSyncCmd(msg.attachedSessionID)
 
 		selectedBefore := h.captureSelectedItemIdentity()
 		h.rebuildFlatItemsPreservingSelection(selectedBefore)
@@ -6139,7 +6190,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		reloading := h.isReloading
 		h.reloadMu.Unlock()
 		if reloading {
-			return h, tea.EnableMouseCellMotion
+			// syncCmd still has to run: the inline refresh it replaced happened
+			// before this early return, so dropping it here would leave the row we
+			// just detached from unreconciled.
+			return h, tea.Batch(tea.EnableMouseCellMotion, syncCmd)
 		}
 
 		h.followAttachReturnCwd(msg)
@@ -6163,6 +6217,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.EnableMouseCellMotion,
 			RestoreLegacyKeyboardCmd(os.Stdout),
 			tea.WindowSize(),
+			syncCmd,
 			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
 		)
 
@@ -6173,7 +6228,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// by handleSessionSwitcherKey.
 		h.isAttaching.Store(false)
 		h.beginAttachReturnGrace(time.Now())
-		h.refreshAttachedSessionStatus(msg.fromSessionID)
+		syncCmd := h.attachReturnSyncCmd(msg.fromSessionID)
 		selectedBefore := h.captureSelectedItemIdentity()
 		h.rebuildFlatItemsPreservingSelection(selectedBefore)
 		h.followAttachReturnCwd(statusUpdateMsg{
@@ -6185,6 +6240,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.EnableMouseCellMotion,
 			RestoreLegacyKeyboardCmd(os.Stdout),
 			tea.WindowSize(),
+			syncCmd,
 			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
 		)
 
@@ -6195,7 +6251,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// capture. Esc re-attaches; Ctrl+Q returns to the list.
 		h.isAttaching.Store(false)
 		h.beginAttachReturnGrace(time.Now())
-		h.refreshAttachedSessionStatus(msg.fromSessionID)
+		syncCmd := h.attachReturnSyncCmd(msg.fromSessionID)
 		selectedBefore := h.captureSelectedItemIdentity()
 		h.rebuildFlatItemsPreservingSelection(selectedBefore)
 		h.followAttachReturnCwd(statusUpdateMsg{
@@ -6207,6 +6263,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.EnableMouseCellMotion,
 			RestoreLegacyKeyboardCmd(os.Stdout),
 			tea.WindowSize(),
+			syncCmd,
 			captureCmd,
 		)
 
@@ -6226,11 +6283,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, h.handleSwitcherCommit(msg)
 
 	case attachReturnRefreshMsg:
+		// The tmux cache refresh moved to its own goroutine (#1753) — running it
+		// here stalled the event loop a second time, ~350ms after the list came
+		// back. The row rebuild happens in attachReturnSyncedMsg, on the loop,
+		// where h.flatItems/h.cursor are safe to touch.
+		return h, h.attachReturnRefreshCmd()
+
+	case attachReturnSyncedMsg:
+		// Async attach-return reconciliation finished: re-derive the rows from the
+		// snapshot it just published. Pure in-memory work, no tmux, no disk.
 		selectedBefore := h.captureSelectedItemIdentity()
-		tmux.RefreshSessionCache()
-		tmux.RefreshPaneInfoCache()
 		h.rebuildFlatItemsPreservingSelection(selectedBefore)
-		h.refreshSessionRenderSnapshot(nil)
 		return h, nil
 
 	case previewDebounceMsg:
@@ -8247,7 +8310,12 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						}
 
 						h.isAttaching.Store(true)
-						return h, tea.Exec(attachWindowCmd{session: tmuxSess, windowIndex: item.WindowIndex, detachByte: h.detachByte()}, func(err error) tea.Msg {
+						return h, tea.Exec(attachWindowCmd{
+							session:     tmuxSess,
+							windowIndex: item.WindowIndex,
+							detachByte:  h.detachByte(),
+							onExit:      func() { h.isAttaching.Store(false) },
+						}, func(err error) tea.Msg {
 							h.isAttaching.Store(false)
 							parentInst.MarkAccessed()
 							return statusUpdateMsg{}
@@ -8721,7 +8789,11 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			termSession := &tmux.Session{Name: tmuxName}
 			h.isAttaching.Store(true)
-			return h, tea.Exec(attachCmd{session: termSession, opts: tmux.AttachOptions{DetachByte: h.detachByte()}}, func(err error) tea.Msg {
+			return h, tea.Exec(attachCmd{
+				session: termSession,
+				opts:    tmux.AttachOptions{DetachByte: h.detachByte()},
+				onExit:  func() { h.isAttaching.Store(false) },
+			}, func(err error) tea.Msg {
 				h.isAttaching.Store(false)
 				return statusUpdateMsg{}
 			})
@@ -12904,11 +12976,22 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 	// which would lose the tmux session state)
 	h.isAttaching.Store(true) // Prevent View() output only during actual attach transition
 	res := &attachResult{}
-	return tea.Exec(attachCmd{session: tmuxSess, opts: h.attachOptions(tmuxSess), result: res}, func(err error) tea.Msg {
-		// CRITICAL: Set isAttaching to false BEFORE returning the message
-		// This prevents a race condition where View() could be called with
-		// isAttaching=true before Update() processes statusUpdateMsg,
-		// causing a blank screen on return from attached session
+	return tea.Exec(attachCmd{
+		session: tmuxSess,
+		opts:    h.attachOptions(tmuxSess),
+		result:  res,
+		// #1753: clear the flag inside Run(), i.e. BEFORE Bubble Tea restores the
+		// terminal and resumes the loop. The ExecCallback below runs on its own
+		// goroutine, so clearing it only there raced the first View() after resume:
+		// View() returns "" while isAttaching is set, so losing that race meant the
+		// list stayed blank until the NEXT message arrived. Clearing it here makes
+		// the first post-detach repaint deterministic. Nothing can call View() in
+		// between — the event loop is parked inside Program.exec for the whole
+		// attach.
+		onExit: func() { h.isAttaching.Store(false) },
+	}, func(err error) tea.Msg {
+		// Belt for the path where Bubble Tea fails to release the terminal and
+		// invokes this callback without ever running attachCmd.Run().
 		h.isAttaching.Store(false) // Atomic store for thread safety
 
 		// NOTE: No manual screen clear here. Bubble Tea's RestoreTerminal()
@@ -12923,7 +13006,22 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 		// This lets running sessions stay green through attach/detach cycles.
 
 		// Capture current pane CWD after attach returns for optional path follow.
-		currentWorkDir := strings.TrimSpace(tmuxSess.GetWorkDir())
+		//
+		// #1753: only when the feature is actually on. GetWorkDir costs two tmux
+		// subprocess spawns (Exists + display-message), and on macOS every fork
+		// briefly quiesces the whole process — measured at 5-13ms of dead time here,
+		// the single largest item between the detach key and the first repaint, paid
+		// on every detach for a feature that defaults to off. followAttachReturnCwd
+		// consults the same setting, so an empty value changes nothing when it is off.
+		instanceSettings := session.GetInstanceSettings()
+		followCwd := instanceSettings.GetFollowCwdOnAttach()
+		workDirIfFollowing := func(ts *tmux.Session) string {
+			if !followCwd || ts == nil {
+				return ""
+			}
+			return strings.TrimSpace(ts.GetWorkDir())
+		}
+		currentWorkDir := workDirIfFollowing(tmuxSess)
 
 		// The user pressed the session-switch key while attached: surface the
 		// in-attach switcher instead of just returning to the list.
@@ -12948,10 +13046,8 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 				h.instancesMu.RUnlock()
 				if switched != nil {
 					fromID = switched.ID
-					if ts := switched.GetTmuxSession(); ts != nil {
-						if wd := strings.TrimSpace(ts.GetWorkDir()); wd != "" {
-							fromWorkDir = wd
-						}
+					if wd := workDirIfFollowing(switched.GetTmuxSession()); wd != "" {
+						fromWorkDir = wd
 					}
 				}
 			}
@@ -13036,11 +13132,19 @@ type attachCmd struct {
 	session *tmux.Session
 	opts    tmux.AttachOptions
 	result  *attachResult
+	// onExit runs as Run returns, i.e. while Bubble Tea's event loop is still
+	// parked inside Program.exec and before it restores the terminal. It exists so
+	// the attach flag can be cleared without racing the first repaint (#1753); see
+	// the call site in attachSession.
+	onExit func()
 }
 
 func (a attachCmd) Run() error {
 	// NOTE: Screen clearing is ONLY done in the tea.Exec callback (after Attach returns)
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
+	if a.onExit != nil {
+		defer a.onExit()
+	}
 
 	ctx := context.Background()
 	intent, err := a.session.AttachWithOptions(ctx, a.opts)
@@ -13140,9 +13244,14 @@ type attachWindowCmd struct {
 	session     *tmux.Session
 	windowIndex int
 	detachByte  byte
+	// onExit: same contract as attachCmd.onExit (#1753).
+	onExit func()
 }
 
 func (a attachWindowCmd) Run() error {
+	if a.onExit != nil {
+		defer a.onExit()
+	}
 	ctx := context.Background()
 	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6235,6 +6235,14 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			attachedSessionID: msg.fromSessionID,
 			attachedWorkDir:   msg.attachedWorkDir,
 		})
+		// Deliberate consequence of the #1753 split: openSessionSwitcher reads the
+		// dim pane-title subtitles out of the render snapshot, which syncCmd now
+		// republishes a few ms AFTER this point instead of just before it. The
+		// picker therefore opens with subtitles from the last background sweep (at
+		// most one sweep interval old) rather than freshly captured ones. That is
+		// the trade the issue asks for: the picker appears at once instead of after
+		// an O(fleet) tmux stall, and the stale value is a secondary hint, never a
+		// status.
 		h.openSessionSwitcher(msg.fromSessionID, true)
 		return h, tea.Batch(
 			tea.EnableMouseCellMotion,

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3479,7 +3479,19 @@ func TestStatusUpdateMsg_PreservesSelectedSessionAcrossRebuild(t *testing.T) {
 	}
 }
 
-func TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender(t *testing.T) {
+// TestStatusUpdateMsg_ReconcilesAttachedSessionViaDeferredCmd was
+// ...BeforeRender until #1753: the reconciliation used to run inline in the
+// statusUpdateMsg handler, which held the Bubble Tea event loop — and therefore the
+// first repaint of the list after Ctrl+Q — behind O(fleet) tmux round-trips. It now
+// runs on the Cmd the handler returns.
+//
+// The protection this test encodes is unchanged and still enforced below: a stale
+// "running" hook file must not keep an exited pane green, the render snapshot must
+// agree, and the stale hook file must be gone. Only the timing moved — from "before
+// the first render" to "on the returned Cmd", i.e. one extra repaint later, which is
+// milliseconds. The pre-Cmd assertions make that ordering explicit so a future edit
+// cannot quietly put the blocking work back on the event loop.
+func TestStatusUpdateMsg_ReconcilesAttachedSessionViaDeferredCmd(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
@@ -3503,8 +3515,24 @@ func TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender(t *testing.T) {
 		t.Fatalf("write stale hook: %v", err)
 	}
 
-	model, _ := h.Update(statusUpdateMsg{attachedSessionID: inst.ID})
+	model, cmd := h.Update(statusUpdateMsg{attachedSessionID: inst.ID})
 	home := model.(*Home)
+
+	// #1753: nothing may have happened yet — the event loop has to be free to repaint
+	// the list from the last snapshot.
+	if got := inst.GetStatusThreadSafe(); got != session.StatusRunning {
+		t.Fatalf("status reconciled inline on the event loop: status = %q, want it still %q "+
+			"until the deferred Cmd runs (#1753)", got, session.StatusRunning)
+	}
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Fatalf("stale hook file removed inline on the event loop (#1753): %v", err)
+	}
+
+	// Now run the deferred reconciliation the handler scheduled.
+	if !yieldsMsg(cmd, "ui.attachReturnSyncedMsg") {
+		t.Fatal("statusUpdateMsg returned no deferred reconcile Cmd, so the exited pane " +
+			"would stay green forever (#1753)")
+	}
 
 	if got := inst.GetStatusThreadSafe(); got != session.StatusError {
 		t.Fatalf("attached session status = %q, want %q", got, session.StatusError)

--- a/internal/ui/issue1753_detach_return_test.go
+++ b/internal/ui/issue1753_detach_return_test.go
@@ -1,0 +1,333 @@
+// Issue #1753 — pressing Ctrl+Q inside an attached session took noticeably long
+// to come back to the list on a ~70-session deck, and so did switching sessions.
+//
+// Measured in a sandbox (isolated HOME/profile/tmux socket, 70 synthetic
+// `--cmd sleep` sessions, 220x50, 10 attach->Ctrl+Q cycles), instrumented at every
+// stage between the detach byte and the first repaint:
+//
+//	stage                                    before      after
+//	GetWorkDir (2 tmux subprocess spawns)    5-13 ms     not called
+//	RefreshSessionCache (list-windows -a)    1-2 ms      off the event loop
+//	RefreshPaneInfoCache (list-panes -a)     2-4 ms      off the event loop
+//	forced UpdateStatus (capture-pane)       included    off the event loop
+//	detach key -> first repaint (median)     11.0 ms     6.7 ms   (idle server)
+//	detach key -> first repaint (median)     17.1 ms     6.1 ms   (busy server)
+//
+// The absolute numbers are small in a sandbox of idle `sleep` panes; the point of
+// the fix is that NONE of that work is on the event loop any more, so the delay no
+// longer scales with fleet size or tmux-server load — on the reporter's deck of ~70
+// live agent sessions each of those round-trips costs an order of magnitude more.
+//
+// What these tests pin:
+//
+//  1. the attach-return message handlers hand the tmux/disk reconciliation to a
+//     tea.Cmd instead of running it inline (fails on the pre-fix code, which
+//     populated the render snapshot before Update returned),
+//  2. the reconciliation still HAPPENS — the deferred Cmd does the work and asks
+//     for a repaint, so no row can go stale forever,
+//  3. attachCmd clears the attach flag before Bubble Tea resumes, so the first
+//     post-detach View renders the list instead of the "" that View returns while
+//     isAttaching is set,
+//  4. a generous wall-clock budget on the handler at 70 sessions, to catch a future
+//     re-introduction of any O(fleet) blocking call on the event loop.
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// homeWithInstances builds a Home whose instance index and flat item list both
+// describe n sessions, which is what the attach-return path walks.
+func homeWithInstances(t *testing.T, n int) (*Home, []*session.Instance) {
+	t.Helper()
+
+	instances := make([]*session.Instance, 0, n)
+	items := make([]session.Item, 0, n)
+	byID := make(map[string]*session.Instance, n)
+	for i := 0; i < n; i++ {
+		inst := &session.Instance{
+			ID:    fmt.Sprintf("sess-%d", i),
+			Title: fmt.Sprintf("sess-%d", i),
+			Tool:  "shell",
+			// Stopped keeps the reconciliation a pure in-memory no-op: with no tmux
+			// session UpdateStatus leaves a stopped instance stopped, so nothing
+			// publishes web state or writes to SQLite and the only observable effect
+			// is the render snapshot these tests key on.
+			Status: session.StatusStopped,
+		}
+		instances = append(instances, inst)
+		byID[inst.ID] = inst
+		items = append(items, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 0})
+	}
+
+	h := newTestHomeWithItems(200, 50, items)
+	h.instances = instances
+	h.instanceByID = byID
+	// The attach-return handlers re-derive rows from the group tree, so it has to
+	// describe the same fleet or the rebuild is vacuous.
+	h.groupTree = session.NewGroupTree(instances)
+	return h, instances
+}
+
+// yieldsMsg executes cmd (walking tea.Batch trees) and reports whether any
+// resulting message has the given concrete type name.
+func yieldsMsg(cmd tea.Cmd, typeName string) bool {
+	if cmd == nil {
+		return false
+	}
+	return msgYields(cmd(), typeName)
+}
+
+func msgYields(msg tea.Msg, typeName string) bool {
+	if msg == nil {
+		return false
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if yieldsMsg(c, typeName) {
+				return true
+			}
+		}
+		return false
+	}
+	return fmt.Sprintf("%T", msg) == typeName
+}
+
+// TestIssue1753_StatusUpdateDefersReconcileOffTheEventLoop is the core regression
+// gate. refreshAttachedSessionStatus ends by publishing a fresh render snapshot, so
+// "snapshot still empty when Update returned" is a precise proxy for "the tmux/disk
+// reconciliation did not run on the event loop". Pre-fix the snapshot was populated
+// inline and this fails; post-fix it is published by the returned Cmd.
+func TestIssue1753_StatusUpdateDefersReconcileOffTheEventLoop(t *testing.T) {
+	h, instances := homeWithInstances(t, 8)
+	attached := instances[0]
+
+	if snap := h.getSessionRenderSnapshot(); len(snap) != 0 {
+		t.Fatalf("precondition: render snapshot should start empty, has %d entries", len(snap))
+	}
+
+	_, cmd := h.Update(statusUpdateMsg{attachedSessionID: attached.ID})
+
+	if snap := h.getSessionRenderSnapshot(); len(snap) != 0 {
+		t.Fatalf("attach-return reconciliation ran inline on the event loop: "+
+			"render snapshot already has %d entries when Update returned (#1753)", len(snap))
+	}
+	if !yieldsMsg(cmd, "ui.attachReturnSyncedMsg") {
+		t.Fatal("attach-return Update returned no async reconcile Cmd: the deferred " +
+			"work would never run, leaving rows stale (#1753)")
+	}
+	// ...and the deferred Cmd must actually do the reconciliation.
+	if snap := h.getSessionRenderSnapshot(); len(snap) == 0 {
+		t.Fatal("async reconcile Cmd ran but published no render snapshot (#1753)")
+	}
+}
+
+// TestIssue1753_SwitcherReturnDefersReconcileOffTheEventLoop covers the "switching
+// sessions is laggy too" half of the report: the in-attach switcher and scrollback
+// return paths ran the same inline reconciliation.
+func TestIssue1753_SwitcherReturnDefersReconcileOffTheEventLoop(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  func(id string) tea.Msg
+	}{
+		{"switcher", func(id string) tea.Msg { return openSwitcherMsg{fromSessionID: id} }},
+		{"scrollback", func(id string) tea.Msg { return openScrollbackMsg{fromSessionID: id} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, instances := homeWithInstances(t, 8)
+			from := instances[0]
+
+			_, cmd := h.Update(tc.msg(from.ID))
+
+			if snap := h.getSessionRenderSnapshot(); len(snap) != 0 {
+				t.Fatalf("%s return reconciled inline on the event loop: snapshot has %d entries (#1753)",
+					tc.name, len(snap))
+			}
+			if !yieldsMsg(cmd, "ui.attachReturnSyncedMsg") {
+				t.Fatalf("%s return returned no async reconcile Cmd (#1753)", tc.name)
+			}
+		})
+	}
+}
+
+// TestIssue1753_DelayedRefreshDefersTmuxWork pins the second stall: the delayed
+// post-attach catch-up (attachReturnRefreshMsg, ~350ms after the list came back)
+// refreshed both tmux caches inline.
+func TestIssue1753_DelayedRefreshDefersTmuxWork(t *testing.T) {
+	h, _ := homeWithInstances(t, 8)
+
+	_, cmd := h.Update(attachReturnRefreshMsg{})
+
+	if snap := h.getSessionRenderSnapshot(); len(snap) != 0 {
+		t.Fatalf("delayed attach-return refresh did tmux work on the event loop: "+
+			"snapshot has %d entries when Update returned (#1753)", len(snap))
+	}
+	if !yieldsMsg(cmd, "ui.attachReturnSyncedMsg") {
+		t.Fatal("delayed attach-return refresh returned no async Cmd (#1753)")
+	}
+	if snap := h.getSessionRenderSnapshot(); len(snap) == 0 {
+		t.Fatal("delayed refresh Cmd ran but published no render snapshot (#1753)")
+	}
+}
+
+// TestIssue1753_SyncedMsgRebuildsRowsWithoutTmux asserts the repaint half of the
+// split is cheap: handling attachReturnSyncedMsg only re-derives rows in memory.
+func TestIssue1753_SyncedMsgRebuildsRowsWithoutTmux(t *testing.T) {
+	h, _ := homeWithInstances(t, 70)
+
+	start := time.Now()
+	_, cmd := h.Update(attachReturnSyncedMsg{})
+	elapsed := time.Since(start)
+
+	if cmd != nil {
+		t.Fatalf("attachReturnSyncedMsg should not schedule further work, got %T", cmd)
+	}
+	// Pure in-memory rebuild of 70 rows. The budget is deliberately loose for slow
+	// CI runners; it only fails if a tmux/disk call sneaks back in.
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("attachReturnSyncedMsg took %s for 70 sessions: something blocking "+
+			"came back into the repaint path (#1753)", elapsed)
+	}
+}
+
+// TestIssue1753_AttachReturnUpdateStaysUnderBudget is the wall-clock budget guard
+// for the handler itself at the reporter's fleet size. Generous on purpose: this is
+// a floor against re-introducing an O(fleet) blocking call, not a benchmark.
+func TestIssue1753_AttachReturnUpdateStaysUnderBudget(t *testing.T) {
+	h, instances := homeWithInstances(t, 70)
+
+	start := time.Now()
+	_, _ = h.Update(statusUpdateMsg{attachedSessionID: instances[0].ID})
+	elapsed := time.Since(start)
+
+	const budget = 150 * time.Millisecond
+	if elapsed > budget {
+		t.Fatalf("attach-return Update took %s at 70 sessions (budget %s): the detach "+
+			"path is blocking the event loop again (#1753)", elapsed, budget)
+	}
+}
+
+// TestIssue1753_AttachCmdClearsAttachFlagBeforeReturning pins the ordering that makes
+// the first post-detach repaint deterministic. View() returns "" while isAttaching is
+// set; clearing it only in the ExecCallback (which Bubble Tea runs on its own
+// goroutine, after it has already resumed the loop) raced that first View, and losing
+// the race left the screen blank until the next message arrived.
+func TestIssue1753_AttachCmdClearsAttachFlagBeforeReturning(t *testing.T) {
+	h := NewHome()
+	h.isAttaching.Store(true)
+
+	// A session name that cannot exist: AttachWithOptions fails its Exists() probe
+	// and returns immediately, without attaching anything.
+	cmd := attachCmd{
+		session: &tmux.Session{Name: "agentdeck_issue1753_absent_session"},
+		opts:    tmux.AttachOptions{DetachByte: 17},
+		onExit:  func() { h.isAttaching.Store(false) },
+	}
+	_ = cmd.Run()
+
+	if h.isAttaching.Load() {
+		t.Fatal("attachCmd.Run returned with isAttaching still set: View() will render " +
+			"\"\" on the first frame after Bubble Tea resumes, so the list comes back " +
+			"blank until the next message (#1753)")
+	}
+}
+
+// TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls is the source-level guard.
+// The behavioural tests above can only observe the snapshot; this one states the rule
+// directly, so a future edit that re-adds an inline tmux round-trip to any of the four
+// attach-return handlers fails here with the reason attached.
+func TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls(t *testing.T) {
+	src, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+	text := string(src)
+
+	banned := []string{
+		"tmux.RefreshSessionCache()",
+		"tmux.RefreshPaneInfoCache()",
+		"h.refreshAttachedSessionStatus(",
+		".GetWorkDir()",
+	}
+	for _, handler := range []string{
+		"case statusUpdateMsg:",
+		"case openSwitcherMsg:",
+		"case openScrollbackMsg:",
+		"case attachReturnRefreshMsg:",
+		"case attachReturnSyncedMsg:",
+	} {
+		block := handlerBlock(t, text, handler)
+		for _, call := range banned {
+			if strings.Contains(block, call) {
+				t.Errorf("%s runs %s inline on the Bubble Tea event loop — that blocks the "+
+					"first repaint after detach. Hand it to attachReturnSyncCmd / "+
+					"attachReturnRefreshCmd instead (#1753)", handler, call)
+			}
+		}
+	}
+
+	// And the deferred path must still exist: an "optimisation" that just deletes the
+	// reconciliation would pass the bans above while leaving rows stale forever.
+	for _, required := range []string{
+		"func (h *Home) attachReturnSyncCmd(",
+		"func (h *Home) attachReturnRefreshCmd(",
+	} {
+		if !strings.Contains(text, required) {
+			t.Errorf("missing %s: the attach-return reconciliation has no deferred home (#1753)", required)
+		}
+	}
+
+	// attachSession must wire onExit, or the first repaint goes back to racing the
+	// ExecCallback goroutine.
+	body := funcBody(t, text, "func (h *Home) attachSession(")
+	if !strings.Contains(body, "onExit:") || !strings.Contains(body, "isAttaching.Store(false)") {
+		t.Error("attachSession no longer clears isAttaching via attachCmd.onExit: the first " +
+			"post-detach View can race the ExecCallback goroutine and render blank (#1753)")
+	}
+	// The pane-CWD probe (two tmux subprocess spawns) must stay behind the
+	// follow-cwd setting instead of running on every detach.
+	if strings.Contains(body, "GetWorkDir()") && !strings.Contains(body, "GetFollowCwdOnAttach()") {
+		t.Error("attachSession probes the pane CWD unconditionally again: GetWorkDir costs two " +
+			"tmux subprocess spawns on the detach path for a feature that defaults to off (#1753)")
+	}
+}
+
+// funcBody returns the source text of one top-level function, from its signature to
+// the start of the next one.
+func funcBody(t *testing.T, text, signature string) string {
+	t.Helper()
+	start := strings.Index(text, signature)
+	if start < 0 {
+		t.Fatalf("function %q not found in home.go", signature)
+	}
+	rest := text[start+len(signature):]
+	if end := strings.Index(rest, "\nfunc "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+// handlerBlock returns the source text of one `case <label>` arm: from the label up to
+// the next `\n\tcase ` at the same indentation, which is where the next arm starts.
+func handlerBlock(t *testing.T, text, label string) string {
+	t.Helper()
+	start := strings.Index(text, label)
+	if start < 0 {
+		t.Fatalf("handler %q not found in home.go", label)
+	}
+	rest := text[start+len(label):]
+	if end := strings.Index(rest, "\n\tcase "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}

--- a/internal/ui/issue1753_detach_return_test.go
+++ b/internal/ui/issue1753_detach_return_test.go
@@ -200,6 +200,63 @@ func TestIssue1753_SyncedMsgRebuildsRowsWithoutTmux(t *testing.T) {
 	}
 }
 
+// TestIssue1753_RemoteSessionsUnaffected covers the RemoteSession side of the
+// attach-return paths this PR touches.
+//
+//   - Remote attach (attachRemoteSession) returns statusUpdateMsg with an EMPTY
+//     attachedSessionID, so it schedules no reconcile — exactly as the inline
+//     refreshAttachedSessionStatus("") it replaced returned immediately. Pinning that
+//     keeps a future edit from firing a local-tmux reconcile for a remote session.
+//   - The extra rebuild introduced by attachReturnSyncedMsg must keep a selected
+//     remote row selected, since remote items are appended to flatItems from
+//     h.remoteSessions on every rebuild.
+func TestIssue1753_RemoteSessionsUnaffected(t *testing.T) {
+	h, _ := homeWithInstances(t, 4)
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"box": {
+			{ID: "r1", Title: "remote-one", Tool: "shell", Status: "running"},
+			{ID: "r2", Title: "remote-two", Tool: "shell", Status: "running"},
+		},
+	}
+	h.rebuildFlatItems()
+
+	target := -1
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession != nil && it.RemoteSession.ID == "r2" {
+			target = i
+			break
+		}
+	}
+	if target < 0 {
+		t.Fatal("precondition: remote session row r2 not present in flatItems")
+	}
+	h.cursor = target
+
+	// A remote attach return carries no session ID: no local reconcile may be scheduled.
+	if _, cmd := h.Update(statusUpdateMsg{}); yieldsMsg(cmd, "ui.attachReturnSyncedMsg") {
+		t.Error("remote attach return scheduled a local-tmux reconcile; statusUpdateMsg with " +
+			"no attachedSessionID must schedule none (#1753)")
+	}
+
+	// Re-select r2 (the handler above rebuilt the list) and check the new
+	// attachReturnSyncedMsg rebuild preserves a remote selection.
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession != nil && it.RemoteSession.ID == "r2" {
+			h.cursor = i
+			break
+		}
+	}
+	_, _ = h.Update(attachReturnSyncedMsg{})
+
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) {
+		t.Fatalf("cursor %d out of range after rebuild (%d items)", h.cursor, len(h.flatItems))
+	}
+	got := h.flatItems[h.cursor]
+	if got.Type != session.ItemTypeRemoteSession || got.RemoteSession == nil || got.RemoteSession.ID != "r2" {
+		t.Fatalf("attachReturnSyncedMsg rebuild lost the remote selection: cursor now on %v (#1753)", got.Type)
+	}
+}
+
 // TestIssue1753_AttachReturnUpdateStaysUnderBudget is the wall-clock budget guard
 // for the handler itself at the reporter's fleet size. Generous on purpose: this is
 // a floor against re-introducing an O(fleet) blocking call, not a benchmark.
@@ -258,6 +315,20 @@ func TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls(t *testing.T) {
 		"tmux.RefreshPaneInfoCache()",
 		"h.refreshAttachedSessionStatus(",
 		".GetWorkDir()",
+	}
+	// followAttachReturnCwd is called inline by those handlers, so a blocking call
+	// added inside it would restore the latency while every per-handler ban above
+	// still passed. It must take the pane CWD as a parameter and consult the setting,
+	// never probe tmux itself.
+	cwdHelper := funcBody(t, text, "func (h *Home) followAttachReturnCwd(")
+	if strings.Contains(cwdHelper, "GetWorkDir()") {
+		t.Error("followAttachReturnCwd probes tmux itself: it runs inline on the event loop " +
+			"from the attach-return handlers, so that puts a subprocess spawn back between " +
+			"the detach key and the first repaint (#1753)")
+	}
+	if !strings.Contains(cwdHelper, "GetFollowCwdOnAttach()") {
+		t.Error("followAttachReturnCwd no longer checks GetFollowCwdOnAttach() before doing " +
+			"work: the attach-return path pays for a feature that defaults to off (#1753)")
 	}
 	for _, handler := range []string{
 		"case statusUpdateMsg:",


### PR DESCRIPTION
## What problem does this solve?

On a deck of ~70 sessions, pressing Ctrl+Q inside an attached session takes noticeably
long to come back to the list, and returning from the in-attach session switcher feels
the same. Refs #1753 (raised there as a follow-up to the `View()` CPU work; #1756 fixes
the render side, this fixes the detach side).

## Why this change

I instrumented every stage between the detach byte and the first repaint in a sandbox
(isolated `HOME`, own profile, own tmux socket, 70 synthetic `--cmd sleep` sessions,
220x50, TUI driven inside the isolated tmux), 10 attach -> Ctrl+Q cycles per run.

The tmux/PTY teardown turned out to be cheap (~1ms total). Everything expensive sat
**after** `tea.Exec` returned, on the Bubble Tea event loop, while `View()` was still
returning `""` — so the user was staring at a blank screen for all of it:

| step, before | what it costs | measured (idle / saturated tmux server) |
|---|---|---|
| `tmuxSess.GetWorkDir()` in the ExecCallback | 2 tmux **subprocess** spawns (`Exists` + `display-message`); on macOS every `fork` briefly quiesces the whole process | 7.5 ms / 11.1 ms |
| `RefreshPaneInfoCache()` | control-mode `list-panes -a`, O(fleet) | 1.6 ms / 3.0 ms |
| `RefreshSessionCache()` | control-mode `list-windows -a`, O(fleet) | 0.9 ms / 1.3 ms |
| forced `UpdateStatus()` | `capture-pane` of the session just left, plus a hook-status file unlink and a possible SQLite write | 0.1 ms on a `sleep` pane |
| render-snapshot rebuild | 70 entries | <0.1 ms |
| the same two cache refreshes **again**, inline in `attachReturnRefreshMsg` | a second event-loop stall ~350ms later | 2.5-4.3 ms |

Two structural problems explain the "intermittently" in the report:

1. **`GetWorkDir` ran unconditionally**, for `[instances] follow_cwd_on_attach`, which
   defaults to **off**. Pure dead time on every single detach.
2. **`isAttaching` was cleared only in the ExecCallback**, which Bubble Tea runs on its
   own goroutine *after* it has already restored the terminal and resumed the loop. The
   first `View()` after resume therefore raced that store, and `View()` returns `""`
   while the flag is set — lose the race and the list stays blank until the *next*
   message arrives.

So the approach is: put nothing on the pre-first-frame path at all.

* The attach-return reconciliation moves off the event loop into a `tea.Cmd`
  (`attachReturnSyncCmd`). The loop repaints the list immediately from the last
  snapshot; the tmux/disk work runs on its own goroutine; `attachReturnSyncedMsg`
  triggers one more cheap in-memory repaint with the reconciled row. Applied to all
  three return paths: plain detach, in-attach switcher, scrollback.
* The delayed catch-up (`attachReturnRefreshMsg`) gets the same treatment via
  `attachReturnRefreshCmd`, so it no longer stalls the loop a second time.
* `GetWorkDir` is gated on `GetFollowCwdOnAttach()` — the same setting
  `followAttachReturnCwd` already consults, so nothing changes when the feature is on.
* `isAttaching` is cleared inside `attachCmd.Run()` / `attachWindowCmd.Run()`, while the
  loop is still parked in `Program.exec`, which makes the first repaint deterministic.
  The callback keeps its own store as a belt for the path where Bubble Tea never runs
  `Run()`.

Everything the deferred Cmd calls (`tmux.Refresh*`, `inst.UpdateStatus`,
`refreshSessionRenderSnapshot`, `publishWebSessionStates`, statedb writes) already runs
on the background status worker, so no new concurrency contract is introduced.

Considered and rejected: keeping the refresh inline but shrinking it (still O(fleet) on
the loop, and still scales with server load), and moving it to the 350ms follow-up tick
(fixes the first frame but just relocates the stall onto a later keystroke).

Left alone on purpose: the fleet-wide background sweep already runs off the event loop,
is already gated for ~1.2s after attach return by `attachReturnHotDuration`, and already
does visible-rows-first with round-robin batching. Throttling it further would trade
correctness for no additional first-frame win.

## User impact

Ctrl+Q back to the list, and returning from the in-attach switcher, repaint immediately
instead of waiting on tmux. Net effect: **zero tmux round-trips, zero subprocess spawns
and zero disk writes on the event loop between the detach key and the first repaint**
(was 5 round-trips + a hook-file unlink + up to one SQLite write).

One deliberate behaviour change: `openSessionSwitcher` reads its dim pane-title
subtitles out of the render snapshot, which the deferred Cmd now republishes a few ms
*after* the picker opens rather than just before it. The picker therefore opens with
subtitles from the last background sweep (at most one sweep interval old) instead of
freshly captured ones. That is the trade the issue asks for, and the possibly-stale
value is a secondary hint, never a status. Called out in a comment at the call site.

## Evidence

Same sandbox, same 10-cycle workload, instrumented build on both sides. `T_frame` =
detach key -> first repaint of the list completes. `T_settled` = detach key ->
post-detach `Update` returns (event loop free for keystrokes again).

| tmux server | metric | before (median / max) | after (median / max) |
|---|---|---|---|
| idle | `T_frame` | 11.0 / 19.1 ms | **6.7 / 8.0 ms** |
| idle | `T_settled` | 17.8 / 29.1 ms | **14.2 / 24.7 ms** |
| busy (4 concurrent sweepers) | `T_frame` | 10.6 / 15.2 ms | **3.9 / 5.6 ms** |
| busy (4 concurrent sweepers) | `T_settled` | 19.0 / 39.8 ms | **8.7 / 15.0 ms** |
| saturated (12 concurrent sweepers) | `T_frame` | 17.1 / 18.0 ms | **6.1 / 9.6 ms** |
| saturated (12 concurrent sweepers) | `T_settled` | 30.8 / 32.3 ms | **14.8 / 25.0 ms** |

The load rows are the important ones. Before, `T_frame` tracks tmux-server load
(11.0 -> 17.1 ms median) because the blocking calls are on the critical path. After, it
does not (6.7 -> 6.1 ms): nothing left on that path scales with fleet size or server
load. A sandbox of idle `sleep` panes makes those calls cheap in absolute terms — on a
deck of ~70 live agent sessions each of them costs an order of magnitude more, which is
where the user-visible delay came from.

Two honesty notes on the measurement:

* A black-box measure (detach key -> the list frame's bytes reaching the terminal, via
  `pipe-pane`) sat at ~19ms in *every* configuration, before and after. That number is
  floored by Bubble Tea's 60fps renderer flush plus the instrumentation pipe, so it
  cannot resolve the in-process differences — hence the in-process stage trace as the
  primary metric.
* `View()` itself still costs ~2.7-3.8ms per frame here and is now the largest single
  item left on the path. That is #1756's subject, not this PR's.

Correctness check, since the reason the refresh was inline was "an exited pane must not
render as still running for a tick": with the final build in the sandbox, attach, then
kill the attached session's tmux from outside — the deck comes back with that row
already flipped to `✕ error` and the header count updated (`○ 69 idle • ✕ 1 error`). The
deferred Cmd runs in ~5-20ms, so the worst case is a row showing its pre-attach status
for a frame or two instead of the whole list being frozen.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human asked: "pressing Ctrl+Q inside an attached session takes noticeably long to
return to the list, and switching sessions likewise — we need it to be snappy and fast."
His deck runs ~70 sessions on v1.10.11.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — **not run locally, on purpose.** On this machine `$HOME` *is* the live agent-deck data directory, and local suite runs there are what caused the profile-wipe and PTY-exhaustion incidents in `CLAUDE.md`. Verified locally with `go build`, `go vet` and `go test -c` (both with and without the `eval_smoke` tag); the suite itself is left to CI's `Go tests` + `Eval smoke` jobs, which run the same command sandboxed.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled (same-repo branch, so maintainers can push to it directly)

## Tests

New `internal/ui/issue1753_detach_return_test.go`:

* `TestIssue1753_StatusUpdateDefersReconcileOffTheEventLoop` — the render snapshot must
  still be empty when `Update` returns (pre-fix it was populated inline), and the
  returned Cmd must actually perform the reconciliation. This is the
  fails-without-the-fix discriminator.
* `TestIssue1753_SwitcherReturnDefersReconcileOffTheEventLoop` — same for the switcher
  and scrollback return paths.
* `TestIssue1753_DelayedRefreshDefersTmuxWork` — same for the 350ms catch-up.
* `TestIssue1753_SyncedMsgRebuildsRowsWithoutTmux` — the repaint half stays in-memory.
* `TestIssue1753_AttachReturnUpdateStaysUnderBudget` — wall-clock budget on the handler
  at 70 sessions, deliberately generous (150ms) for slow CI runners; it only fails if an
  O(fleet) blocking call comes back.
* `TestIssue1753_AttachCmdClearsAttachFlagBeforeReturning` — `Run()` must clear the
  attach flag before returning.
* `TestIssue1753_RemoteSessionsUnaffected` — remote attach returns `statusUpdateMsg` with
  an empty `attachedSessionID`, so it schedules no local-tmux reconcile (the same no-op
  the inline `refreshAttachedSessionStatus("")` was), and the extra rebuild introduced by
  `attachReturnSyncedMsg` keeps a selected remote row selected.
* `TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls` — source-level guard naming
  the rule for each of the five handlers, plus `followAttachReturnCwd` (which runs inline
  from those handlers, so a blocking call added there would pass every per-handler ban),
  plus that the deferred path and the follow-cwd gate still exist, so "delete the
  reconciliation" cannot pass the bans.

Both of the last two came from CodeRabbit's review on this PR; each was verified against
the code before being acted on.

One existing test changed, deliberately.
`TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender` pinned the exact inline
behaviour this PR removes — it asserted the attached session was already reconciled when
the handler returned — and CI caught it (`eval_smoke suite`). Renamed to
`...ViaDeferredCmd`, with every protection it encoded kept and re-asserted after running
the returned Cmd: a stale `running` hook must not keep an exited pane green, the render
snapshot must agree, and the stale hook file must be gone. The inverse assertions were
added before the Cmd runs, so the new ordering is pinned too and the blocking work
cannot quietly move back onto the event loop.

## Note on #1756

Overlaps #1753 by issue, not by code: that PR fixes `View()`'s full-frame `MaxWidth` pass
in `renderDualColumnLayout`, this one fixes the detach path. Different hunks of `home.go`
and separate test files. Verified rather than assumed: merging `refs/pull/1756/head` into
this branch locally produces **no conflicts** and the merged tree builds, so the two can
land in either order.

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
