### PR TITLE
perf(tui): refresh architecture v2 — adaptive tick + generation skip (#1753)

### DIFF
--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -24,6 +24,14 @@ on:
       - '**/*_perf_test.go'
       - '.github/workflows/perf-smoke.yml'
       - 'docs/perf-budget-suite.md'
+      # internal/ui's background status sweep (PR #1765, issue #1753) is a
+      # hot path every session's rendering goes through but ships no
+      # cmd/agent-deck/*.go changes of its own, so it was invisible to this
+      # gate even though internal/ui/refresh_policy_perf_test.go (a
+      # **/*_perf_test.go match, already covered above) lives here. Listing
+      # the package explicitly makes the filter trigger on the package's
+      # non-test source changes too, not only on the perf test file itself.
+      - 'internal/ui/**'
   workflow_dispatch: {}
 
 permissions:

--- a/docs/design/refresh-architecture-v2.md
+++ b/docs/design/refresh-architecture-v2.md
@@ -190,13 +190,45 @@ actually polled it plus how many sweeps have been skipped since.
 In `backgroundStatusUpdate`, immediately after the existing PipeManager
 idle-skip, `UpdateStatus` is skipped only when **every** one of these holds:
 
-1. the row is **not** visible (viewport snapshot published by the TUI tick);
+1. the row is **not** visible (viewport snapshot published by the TUI tick) —
+   visible rows go through the hold + budget in §3.2b instead;
 2. the status is one of `running` / `waiting` / `idle` — `error` and `stopped`
    carry their own recheck timers, `starting` must converge fast;
 3. the current fingerprint is usable **and** identical to the last polled one;
 4. fewer than `maxSkips` consecutive skips have already happened.
 
 Any veto polls. There is no path that skips on absent information.
+
+### 3.2b Visible rows: hold + budget (the group-expand case)
+
+The maintainer's live-fleet diagnostic on #1753 showed the lag reproduces with
+a large group **expanded** — visible-row count then approaches fleet size, so a
+policy that exempts visible rows degenerates back to the full per-row storm.
+Visible rows therefore get the same treatment, shaped for what the user sees:
+
+- **Hold** (`refreshLedger.holdVisible`): a visible row whose status is settled
+  and whose fingerprint is unchanged is skipped under the *same* `maxSkips`
+  ceiling as an off-screen row — an expanded quiescent group costs ~zero.
+- **Budget** (`admitVisiblePolls`): visible rows that *do* need a poll compete
+  for `visiblePollBudgetPerSweep` (10, the sweep's worker-pool width) slots per
+  sweep. Deferred rows age a starvation counter and are admitted first on later
+  sweeps, so the budget cycles round-robin: every due visible row is polled
+  within `ceil(due/budget)` sweeps and none can be starved.
+- **Cursor exemption**: the selected row (published as `cursorID` in the
+  viewport snapshot) is always admitted — it drives the preview pane.
+- **Incremental path** (`processStatusUpdate`): the user-activity visible-first
+  pass used to poll *every* visible row per pass; it now holds steady rows
+  read-only (`heldSteady`, no ceiling because the background sweep owns
+  freshness) and budgets + round-robins the rest the same way.
+- **Group expand is a trigger, not a burst**: the expand keypress only rebuilds
+  the flat list (rows render instantly from the existing render snapshot) and
+  republishes the viewport immediately, so the very next sweep sees the new
+  rows as visible and amortizes their catch-up polls through the budget. No
+  path between the keypress and the first frame spawns per-row tmux work.
+
+The fail-open and kill-switch behaviour is shared: with no fresh viewport
+snapshot, or `adaptive_refresh_max_skips < 0`, hold and budget are both off and
+every session polls every sweep, exactly as pre-policy.
 
 **Why unchanged `window_activity` is a sound proof of "no new pane output".**
 This is not a new assumption. `tmux.Session.GetStatus` already gates its
@@ -259,9 +291,16 @@ drift apart.
 - `0` / unset — default `2`: a quiescent off-screen session is polled at least
   every 3rd sweep (~6s).
 - `>0` — custom ceiling; higher trades off-screen transition latency for less
-  tmux load on very large decks.
+  tmux load on very large decks. Clamped to `30`
+  (`session.MaxAdaptiveRefreshMaxSkips`): beyond ~30 skipped sweeps the
+  time-based transitions inside `UpdateStatus` would be delayed long enough to
+  read as a frozen deck.
 - `<0` — **disables the policy**: every sweep polls every session, byte-identical
   to pre-policy behaviour.
+
+The knob is resolved once, at TUI construction (`ui.NewHome` →
+`UISettings.GetAdaptiveRefreshMaxSkips`). Changing it — including flipping the
+kill switch — takes effect on the next TUI restart, not on config reload.
 
 ### 3.6 Expected effect
 

--- a/docs/design/refresh-architecture-v2.md
+++ b/docs/design/refresh-architecture-v2.md
@@ -1,0 +1,311 @@
+# Refresh architecture v2 — event-driven, adaptive, remote-ready
+
+Status: design + first slice landed
+Issue: #1753 (perf: laggy switching at ~55 sessions), follow-up to #1756
+Scope: `internal/ui` refresh loop, `internal/session` status derivation, `internal/tmux` caches
+
+---
+
+## 1. The problem, stated precisely
+
+agent-deck's TUI does work proportional to **all live sessions** on every refresh
+tick. On a 40–70 session deck that is the difference between a snappy tool and a
+sluggish one, and it gets worse linearly as fleets grow.
+
+There are three separate loops, each O(sessions):
+
+| Loop | Cadence | Cost per session |
+|---|---|---|
+| `Home.backgroundStatusUpdate` (status worker goroutine) | `baseStatusInterval` = 2s, backing off to 10s when a sweep overruns | `Instance.UpdateStatus()` — cache reads, and for many states a `capture-pane` |
+| `Home.processStatusUpdate` (tick-triggered, user-active only) | 2s | visible rows + 2 round-robin rows |
+| `Home.View` | every keystroke + every tick | row render |
+
+`View` was the loudest offender and is fixed: #1756 replaced an unconditional
+full-frame `MaxWidth` rebuild with a measure-then-rebuild guard, taking process
+CPU during a switching workload from 4.84% to 2.04%. What remains is the
+**status sweep**, and it is the structurally wrong shape: it re-derives state for
+sessions that provably did not change, using the most expensive mechanism
+available.
+
+### 1.1 Why the sweep is expensive, mechanically
+
+Three facts compose badly.
+
+1. **Only a handful of sessions have a control pipe.** `livePipeLRUCapacity = 3`,
+   plus attached sessions. That bound is deliberate — pipes cost a tmux client
+   each, and N agent-deck instances must stay cheap. But it means the sweep's
+   existing "PipeManager says no output for 5s, skip" fast path applies to ~4
+   sessions out of 70. Everyone else falls through.
+
+2. **Without a pipe, `CapturePane` is a subprocess.** `tmux capture-pane -p -e`,
+   3s timeout, serialized by the tmux server. Cached for only 500ms.
+
+3. **The most common steady state on a large deck captures the pane.** A Claude
+   session parked in hook `waiting` (finished its turn, needs you) takes the
+   hook fast path in `Instance.UpdateStatus`, which calls
+   `tmux.Session.BackgroundWorkPending()` to decide whether `run_in_background`
+   work is still in flight. That captures the pane, cached for
+   `bgWorkCacheTTL = 3s`. With a 2s sweep that is a capture roughly every other
+   sweep, **per waiting session**.
+
+At ~60 quiescent sessions that is tens of `capture-pane` subprocesses per sweep,
+all queued behind one tmux server, to re-derive statuses that are identical to
+the ones already on screen. When the sweep overruns 2s, `nextStatusInterval`
+backs the cadence off — so the system degrades by getting *less* fresh, not by
+getting cheaper.
+
+### 1.2 The other half: the event source we already have and ignore
+
+Claude, Codex, Gemini, Hermes and Cursor **already push** lifecycle events into
+`~/.agent-deck/hooks/<id>.json` (Stop, Notification, PermissionRequest…), and
+`session.StatusFileWatcher` already watches that directory with fsnotify,
+debounces, and maintains a live `map[instanceID]*HookStatus`. OpenCode does the
+same over SSE (`OpenCodeSSEWatcher`, #1614).
+
+But the watcher is constructed as `session.NewStatusFileWatcher(nil)` — **the
+`onChange` callback is nil**. Nothing wakes the TUI when a hook fires. The sweep
+*polls the watcher's map* on its own 2s cadence, and the freshly-delivered event
+sits in memory waiting to be noticed. We pay for a push pipeline and then
+consume it by polling.
+
+That is the core architectural insight behind v2: **the events are already
+there. The refresh loop just isn't listening.**
+
+---
+
+## 2. Target model
+
+Three layers, in priority order. Layer 1 decides *when* to do work, layer 2
+decides *how much*, layer 3 decides *where*.
+
+### 2.1 Event-driven first
+
+Updates should be **caused** by evidence, not by a clock.
+
+- **Hook events wake the TUI.** Give `StatusFileWatcher` a real `onChange(id)`
+  that pushes a `sessionEventMsg{id}` into the Bubble Tea program (via
+  `p.Send`), and route it to a single-session status refresh. Latency for a
+  turn ending drops from "up to one sweep" to "as fast as fsnotify delivers",
+  and it costs exactly one session's work rather than a fleet sweep.
+  The watcher's existing debounce is the coalescing layer; an events-per-second
+  cap per session guards against a pathological hook loop.
+- **tmux control-mode notifications wake the TUI.** The `PipeManager` already
+  receives `%output`, `%window-pane-changed`, `%session-closed` on the sessions
+  it pipes, and `logUpdateChan` already turns `%output` into a per-session
+  `UpdateStatus`. This is the right mechanism; it is simply capacity-bound to 3
+  sessions. Widening it is a separate, measured decision (a single control-mode
+  client on the *server* can report `%sessions-changed` / `%unlinked-window-…`
+  for all sessions — a "fleet notification channel" that is O(1) clients rather
+  than O(sessions)).
+- **The periodic sweep becomes a reconciliation safety net, not the primary
+  path.** Its job is to catch what events cannot report: a session whose hooks
+  are not installed, a tool with no event protocol (`shell`, `pi`), a pane that
+  died without writing anything, a dropped fsnotify watch, an event lost to
+  overflow (`fsnotify.ErrEventOverflow` is already handled). Once events drive
+  the common case, this sweep can run at 10–30s instead of 2s.
+
+The degradation model is the one the codebase already uses for hooks: an event
+source is trusted while fresh, and control falls through to polling when it goes
+stale. v2 applies the same shape one level up — to the *scheduler*, not just to
+the status verdict.
+
+### 2.2 Adaptive second
+
+Not all sessions deserve the same attention, and unchanged sessions deserve
+none.
+
+- **Visible rows are first-class.** Rows on screen (plus the selected row and
+  anything attached) refresh at the fast cadence. This is what the user is
+  looking at; freshness here is the product.
+- **Off-screen rows are event-driven or slow.** They do not need a 2s poll to
+  render a glyph nobody is looking at. They need to be correct *by the time they
+  scroll into view*, and events already guarantee that for every tool that emits
+  them.
+- **Generation counters skip unchanged work.** Before spending a poll, ask the
+  caches we already refreshed whether anything observable changed. If not, skip.
+  This is the mechanism detailed in §3 and it is the slice that landed.
+- **Cadence follows load, in both directions.** `nextStatusInterval` already
+  backs off when sweeps overrun. It should also *tighten* when the deck is busy
+  and *relax* when it is quiescent, and the "user is active" window that gates
+  `processStatusUpdate` should extend to the whole scheduler.
+- **Work per tick is budgeted, not unbounded.** The attach-return catch-up burst
+  reported on #1753 (Ctrl+Q back to the list feels slow on a ~69-session deck)
+  is the same defect in a different costume: everything the suspended TUI
+  missed lands in one sweep. The fix is the same shape — visible rows first,
+  the rest amortized across following ticks, and no work at all for sessions
+  whose generation is unchanged.
+
+### 2.3 Remote-ready third
+
+The roadmap is that **fleets live on cloud machines and the Mac is a thin
+control surface**. A refresh layer designed around "spawn a subprocess per
+session per tick" is catastrophic across a network: 70 sessions × one SSH
+round-trip each is not a slower version of the local case, it is a different
+order of magnitude. The layering above is what makes remote cheap, because both
+of its principles carry over cleanly: an *event* crossing an SSH connection
+costs one multiplexed message rather than a round-trip, and a *generation
+counter* lets the remote answer "nothing changed" in a single reply for the
+whole host instead of one probe per session. Concretely, the refresh layer
+should treat a host as the unit of cost, not a session: one persistent
+connection per remote (`ControlMaster` / a resident `agent-deck` agent), one
+bulk status query per tick returning the whole host's fingerprints, and remote
+hook events forwarded over that same connection rather than rediscovered by
+polling — so the Mac's cost is O(remote hosts), independent of session count.
+The existing `--ssh` support (remote session listing at
+`[ui] remote_session_refresh_secs`, remote previews at a longer TTL, remote
+latency probes) is the seed: it already batches per host and already treats
+remote data as something to fetch on a slow, separate cadence. v2's job is to
+make that the *general* model and let local tmux be one implementation of a
+"session host" behind it, instead of the other way round.
+
+---
+
+## 3. The landed slice: adaptive tick + generation skip
+
+Smallest change with the biggest win, deliberately conservative. Two parts, both
+additive and both individually disable-able.
+
+### 3.1 Per-session generation ("fingerprint")
+
+`internal/ui/refresh_policy.go` introduces `sessionFingerprint` — a comparable
+struct built **entirely from caches the sweep already refreshed once per tick**:
+
+| field | source | spawns |
+|---|---|---|
+| `activity` | `Session.GetCachedWindowActivity()` — the `list-sessions` snapshot | nothing (map read) |
+| `title`, `command`, `dead` | `tmux.GetCachedPaneInfo()` — the `list-panes` snapshot | nothing (map read) |
+| `hookAt` | `StatusFileWatcher.GetHookStatus().UpdatedAt` | nothing (in-memory map) |
+| `sseAt` | `OpenCodeSSEWatcher.GetStatus().UpdatedAt` | nothing (in-memory map) |
+
+Building it for the whole deck is a handful of map lookups. `ok = false`
+whenever the evidence is incomplete (no tmux session, stale pane cache, session
+absent from the activity snapshot) and an unusable fingerprint **always forces a
+poll** — so a session that dies or vanishes from tmux is never held.
+
+`refreshLedger` stores, per session, the fingerprint of the last sweep that
+actually polled it plus how many sweeps have been skipped since.
+
+### 3.2 The gate
+
+In `backgroundStatusUpdate`, immediately after the existing PipeManager
+idle-skip, `UpdateStatus` is skipped only when **every** one of these holds:
+
+1. the row is **not** visible (viewport snapshot published by the TUI tick);
+2. the status is one of `running` / `waiting` / `idle` — `error` and `stopped`
+   carry their own recheck timers, `starting` must converge fast;
+3. the current fingerprint is usable **and** identical to the last polled one;
+4. fewer than `maxSkips` consecutive skips have already happened.
+
+Any veto polls. There is no path that skips on absent information.
+
+**Why unchanged `window_activity` is a sound proof of "no new pane output".**
+This is not a new assumption. `tmux.Session.GetStatus` already gates its
+`CapturePane` on exactly this comparison (`needsBusyCheck`), and
+`Instance.UpdateStatus` already gates its idle tier on it. The gate reuses the
+established invariant and is **strictly more conservative than the existing
+uses**, because those skip for as long as activity is unchanged while the gate
+is bounded by rule 4.
+
+**Why the ceiling matters.** `UpdateStatus` contains time-based transitions with
+no external evidence: `acknowledged → idle`, hook-freshness expiry falling
+through to tmux polling, `debounceFlipFromRunning` confirmation, the Hermes
+gateway recheck. Rule 4 bounds their delay to `maxSkips` sweeps rather than
+suppressing them. `window_activity` also has one-second resolution, so a
+pathological "output within the same second as the previous sample, after our
+capture" case is possible — rule 4 bounds that too, where the existing
+`needsBusyCheck` does not.
+
+**Why real transitions are not delayed in practice.** Anything that actually
+happens moves the fingerprint on the very next sweep:
+
+| event | fingerprint field that moves |
+|---|---|
+| turn ends (Stop hook) | `hookAt` |
+| permission prompt | `hookAt` |
+| any pane output | `activity` |
+| spinner starts/stops | `title` (Claude's OSC marker) |
+| process exits under remain-on-exit | `dead` |
+| session disappears from tmux | `ok = false` → forced poll |
+| OpenCode status over SSE | `sseAt` |
+
+So the ≤`maxSkips` sweep delay applies only to transitions with *zero*
+observable evidence, on rows that are *off screen*. Conductor completion
+notifications, which are produced from `status_changed` in this same sweep, are
+driven by the Stop hook and therefore not delayed at all.
+
+### 3.3 Viewport publication
+
+`publishVisibleSessions` runs on every TUI tick and is **O(visible rows)** — it
+walks only the viewport slice of `flatItems`, never the whole deck — recording
+the on-screen session IDs, the selected row, and window rows' parent sessions.
+`visibleSessionsForSweep` **fails open**: with no snapshot, or one older than
+`visibleSessionsMaxAge` (10s — the TUI republishes every 2s, so this means the
+event loop is suspended by `tea.Exec` or wedged), the gate is bypassed entirely
+and every session is polled, exactly as before the policy existed.
+
+### 3.4 Render-snapshot generation skip
+
+`refreshSessionRenderSnapshot` is called from six sweep/tick paths and used to
+allocate and publish a fresh N-entry map every time. It now compares first: when
+every computed state matches the published snapshot and membership is unchanged,
+it returns without allocating or storing. The per-state derivation was extracted
+into `computeSessionRenderState` so the compare pass and the build pass cannot
+drift apart.
+
+### 3.5 Kill switch
+
+`[ui] adaptive_refresh_max_skips`:
+
+- `0` / unset — default `2`: a quiescent off-screen session is polled at least
+  every 3rd sweep (~6s).
+- `>0` — custom ceiling; higher trades off-screen transition latency for less
+  tmux load on very large decks.
+- `<0` — **disables the policy**: every sweep polls every session, byte-identical
+  to pre-policy behaviour.
+
+### 3.6 Expected effect
+
+At 60 quiescent sessions with ~10 rows visible, the gate removes roughly two
+thirds of the sweep's `UpdateStatus` calls, and with them the
+`BackgroundWorkPending` captures that dominate the current sweep — while every
+row the user is looking at keeps polling at exactly today's cadence. Measure
+with the sandboxed repro in #1753 (isolated `HOME`, own profile, own tmux
+socket, 60 synthetic sessions) and the `idle_sessions_skipped` debug line, which
+now carries an `adaptive_skipped` count.
+
+---
+
+## 4. Roadmap after this slice
+
+Ordered by value per unit of risk. Each is independently shippable.
+
+1. **Wire `onChange` on `StatusFileWatcher`** → single-session refresh on hook
+   delivery. This is the first genuinely event-driven step and it is small: the
+   callback plumbing and a `p.Send` hook already exist in shape elsewhere.
+   It also directly serves the TUI-truth `waiting = done` vs `needs-you` split,
+   which reads the same `HookStatus.Event` field (Stop vs Notification /
+   PermissionRequest) that the callback delivers — one event ingestion path
+   feeding both correctness and freshness.
+2. **Relax the sweep cadence** once (1) lands: the safety net does not need 2s.
+3. **Stagger the attach-return catch-up** (#1753 comment): visible rows first,
+   remainder amortized, generation-skipped where unchanged.
+4. **Fleet notification channel** — one control-mode client per tmux *server*
+   for `%sessions-changed`-class notifications, instead of one pipe per session.
+5. **Host-oriented remote refresh** — one persistent connection per remote, one
+   bulk fingerprint query per tick, remote hook events forwarded over it.
+
+---
+
+## 5. Invariants any future change here must preserve
+
+1. **Never skip on absent information.** Missing or stale evidence forces a poll.
+2. **Never skip without a bound.** Every skip path has a ceiling, so a
+   time-based transition can be delayed but never suppressed.
+3. **Never skip a visible row.** What is on screen refreshes at the fast cadence.
+4. **Fail open.** Any doubt about the scheduler's own state (no viewport
+   snapshot, wedged event loop, nil ledger from an alternate constructor)
+   degrades to polling everything.
+5. **Death is never inferred from silence.** A session that leaves tmux produces
+   an unusable fingerprint, which forces a poll, which detects the death.
+6. **Keep a kill switch.** Every scheduling change ships with a config value
+   that restores the previous behaviour exactly.

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -398,8 +398,11 @@ type UISettings struct {
 	//               at least every 3rd sweep (~6s).
 	//   >0        — custom ceiling; higher trades transition latency on
 	//               off-screen rows for less tmux load on very large decks.
+	//               Clamped to MaxAdaptiveRefreshMaxSkips (30).
 	//   <0        — DISABLE the policy: every sweep polls every session, exactly
 	//               as agent-deck behaved before the policy landed (kill switch).
+	// Read once at TUI construction — changes (including the kill switch)
+	// take effect on the next TUI restart. See GetAdaptiveRefreshMaxSkips.
 	AdaptiveRefreshMaxSkips int `toml:"adaptive_refresh_max_skips,omitzero"`
 
 	// ShowOnlyInstalledTools, when true, hides tools from the new-session
@@ -635,6 +638,41 @@ func (u UISettings) GetRemoteSessionRefreshSecs() int {
 	}
 	if val > MaxRemoteSessionRefreshSecs {
 		return MaxRemoteSessionRefreshSecs
+	}
+	return val
+}
+
+// Adaptive refresh ceiling bounds (issue #1753). The default keeps the
+// worst-case staleness of an off-screen row at ~3 sweeps; the max caps how far
+// a config value can push that staleness — beyond ~30 skipped sweeps (~1min at
+// the base cadence) the time-based transitions inside UpdateStatus
+// (acknowledged→idle, hook-freshness expiry, debounce confirmation) would be
+// delayed long enough to read as a frozen deck, which no tmux-load saving
+// justifies.
+const (
+	DefaultAdaptiveRefreshMaxSkips = 2
+	MaxAdaptiveRefreshMaxSkips     = 30
+)
+
+// GetAdaptiveRefreshMaxSkips resolves the [ui] adaptive_refresh_max_skips knob
+// into the effective staleness ceiling for the adaptive refresh policy
+// (issue #1753). 0/unset falls back to DefaultAdaptiveRefreshMaxSkips; any
+// negative value is the kill switch and returns 0 (policy disabled, every
+// sweep polls every session); positive values are clamped to
+// MaxAdaptiveRefreshMaxSkips.
+//
+// NOTE: the TUI reads this once at construction (ui.NewHome), so changing the
+// value — including flipping the kill switch — requires a TUI restart.
+func (u UISettings) GetAdaptiveRefreshMaxSkips() int {
+	val := u.AdaptiveRefreshMaxSkips
+	if val == 0 {
+		return DefaultAdaptiveRefreshMaxSkips
+	}
+	if val < 0 {
+		return 0
+	}
+	if val > MaxAdaptiveRefreshMaxSkips {
+		return MaxAdaptiveRefreshMaxSkips
 	}
 	return val
 }

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -390,6 +390,18 @@ type UISettings struct {
 	// tightening the visibility latency reported on v1.9.30.
 	RemoteSessionRefreshSecs int `toml:"remote_session_refresh_secs,omitzero"`
 
+	// AdaptiveRefreshMaxSkips bounds the adaptive refresh policy (issue #1753):
+	// how many consecutive background status sweeps an OFF-SCREEN session whose
+	// tmux/hook fingerprint is provably unchanged may be skipped before it is
+	// polled regardless. Visible rows are never skipped.
+	//   0 (unset) — default of 2, i.e. poll every quiescent off-screen session
+	//               at least every 3rd sweep (~6s).
+	//   >0        — custom ceiling; higher trades transition latency on
+	//               off-screen rows for less tmux load on very large decks.
+	//   <0        — DISABLE the policy: every sweep polls every session, exactly
+	//               as agent-deck behaved before the policy landed (kill switch).
+	AdaptiveRefreshMaxSkips int `toml:"adaptive_refresh_max_skips,omitzero"`
+
 	// ShowOnlyInstalledTools, when true, hides tools from the new-session
 	// dialogs (TUI + web) whose command does not resolve on the host PATH
 	// (issue #1259). Default false: no PATH probing happens and the dialogs are

--- a/internal/session/userconfig_adaptive_refresh_test.go
+++ b/internal/session/userconfig_adaptive_refresh_test.go
@@ -1,0 +1,32 @@
+package session
+
+import "testing"
+
+// The [ui] adaptive_refresh_max_skips knob (issue #1753, PR #1765) is resolved
+// through GetAdaptiveRefreshMaxSkips so a config value can never push the
+// staleness ceiling past MaxAdaptiveRefreshMaxSkips: before the clamp, a
+// config value of 100000 was accepted verbatim, which would delay every
+// time-based transition on an off-screen row by ~55 hours of sweeps.
+func TestUISettings_GetAdaptiveRefreshMaxSkips(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{"unset falls back to default", 0, DefaultAdaptiveRefreshMaxSkips},
+		{"explicit value passes through", 5, 5},
+		{"max is allowed", MaxAdaptiveRefreshMaxSkips, MaxAdaptiveRefreshMaxSkips},
+		{"above max clamps", MaxAdaptiveRefreshMaxSkips + 1, MaxAdaptiveRefreshMaxSkips},
+		{"absurd value clamps", 100000, MaxAdaptiveRefreshMaxSkips},
+		{"negative is the kill switch", -1, 0},
+		{"very negative is still the kill switch", -100000, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := UISettings{AdaptiveRefreshMaxSkips: tc.input}
+			if got := u.GetAdaptiveRefreshMaxSkips(); got != tc.want {
+				t.Errorf("GetAdaptiveRefreshMaxSkips(%d) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/watcher_seed_test_helper.go
+++ b/internal/session/watcher_seed_test_helper.go
@@ -1,0 +1,34 @@
+package session
+
+import "testing"
+
+// NewStatusFileWatcherForTest returns a StatusFileWatcher backed only by its
+// in-memory status map: no fsnotify watcher, no hooks directory under HOME,
+// and Start() must not be called on it. It exists so packages outside
+// internal/session (notably internal/ui) can drive the hook-status inputs of
+// the adaptive-refresh fingerprint (ui.fingerprintSession reads
+// GetHookStatus) without a real filesystem watcher.
+func NewStatusFileWatcherForTest(t testing.TB) *StatusFileWatcher {
+	t.Helper()
+	return &StatusFileWatcher{statuses: make(map[string]*HookStatus)}
+}
+
+// SetHookStatusForTest installs a hook status exactly as a processed hook file
+// would. Production code must never set statuses directly — hook files under
+// GetHooksDir() are the only real source.
+func (w *StatusFileWatcher) SetHookStatusForTest(t testing.TB, instanceID string, hs *HookStatus) {
+	t.Helper()
+	w.mu.Lock()
+	w.statuses[instanceID] = hs
+	w.mu.Unlock()
+}
+
+// SetStatusForTest installs a derived SSE status exactly as a live OpenCode
+// /event stream would. Production code must never set statuses directly — the
+// per-instance stream goroutines are the only real source.
+func (w *OpenCodeSSEWatcher) SetStatusForTest(t testing.TB, instanceID string, st *OpenCodeSSEStatus) {
+	t.Helper()
+	w.mu.Lock()
+	w.statuses[instanceID] = st
+	w.mu.Unlock()
+}

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -294,7 +294,19 @@ func (cp *ControlPipe) SendCommand(command string) (string, error) {
 		cp.mu.RUnlock()
 		return "", fmt.Errorf("pipe not alive for session %s", cp.sessionName)
 	}
+	stdin := cp.stdin
 	cp.mu.RUnlock()
+
+	// alive and stdin are set together by the constructor, so a live pipe
+	// normally has one. Report it rather than trusting the pairing: writing to
+	// a nil stdin panics inside fmt, and every caller of this reaches it from
+	// backgroundStatusUpdate, whose deferred recover swallows the panic and
+	// abandons the whole status sweep — the TUI just stops updating, with one
+	// background_update_panic line as the only evidence. An error here is
+	// handled: RefreshAllActivities records it and moves to the next pipe.
+	if stdin == nil {
+		return "", fmt.Errorf("pipe has no stdin for session %s", cp.sessionName)
+	}
 
 	cp.cmdMu.Lock()
 	defer cp.cmdMu.Unlock()
@@ -306,7 +318,7 @@ func (cp *ControlPipe) SendCommand(command string) (string, error) {
 	}
 
 	// Send command through stdin
-	_, err := fmt.Fprintln(cp.stdin, command)
+	_, err := fmt.Fprintln(stdin, command)
 	if err != nil {
 		return "", fmt.Errorf("write to pipe: %w", err)
 	}

--- a/internal/tmux/controlpipe_test.go
+++ b/internal/tmux/controlpipe_test.go
@@ -523,3 +523,20 @@ func drainEvents(ch <-chan struct{}, duration time.Duration) {
 		}
 	}
 }
+
+// A ControlPipe can be marked alive without ever having been given a stdin —
+// the test seeder does exactly that, and a zero-value pipe would too. Writing
+// to that nil stdin used to panic inside fmt. Because every caller reaches
+// SendCommand from the TUI's background status sweep, whose deferred recover
+// swallows panics, the visible symptom was the sweep dying mid-flight and the
+// TUI quietly ceasing to update statuses. It must return an error instead, so
+// callers like RefreshAllActivities can skip the pipe and carry on.
+func TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking(t *testing.T) {
+	cp := &ControlPipe{sessionName: "no-stdin", alive: true}
+
+	out, err := cp.SendCommand("list-windows")
+
+	require.Error(t, err, "a live pipe with no stdin must report an error")
+	assert.Empty(t, out)
+	assert.Contains(t, err.Error(), "no-stdin", "the error should name the session")
+}

--- a/internal/tmux/seed_test_helper.go
+++ b/internal/tmux/seed_test_helper.go
@@ -94,6 +94,30 @@ func ExpireStartupWindowForTest(t testing.TB, s *Session) {
 	s.mu.Unlock()
 }
 
+// SeedConnectedPipeForTest injects a fake, already-alive ControlPipe for
+// sessionName into pm's pipe map, reporting lastOutput as its most recent
+// %output event, without spawning a real `tmux -C` process or requiring a
+// tmux server. Lets internal/ui drive the sweep's PipeManager quiet-pipe
+// fast path (pm.IsConnected / pm.LastOutputTime) deterministically.
+//
+// The fake pipe answers only IsAlive() and LastOutputTime() truthfully
+// (both are plain mutex-guarded field reads); SendCommand and the other
+// process-backed methods are never exercised by that fast path and would
+// panic on this fake if called, which is intentional — it keeps the fake
+// from silently covering more surface than the sweep actually touches.
+func SeedConnectedPipeForTest(t testing.TB, pm *PipeManager, sessionName string, lastOutput time.Time) {
+	t.Helper()
+	fake := &ControlPipe{sessionName: sessionName, alive: true, lastOutput: lastOutput}
+	pm.mu.Lock()
+	pm.pipes[sessionName] = fake
+	pm.mu.Unlock()
+	t.Cleanup(func() {
+		pm.mu.Lock()
+		delete(pm.pipes, sessionName)
+		pm.mu.Unlock()
+	})
+}
+
 // ExpirePaneInfoCacheForTest leaves the cache contents intact but rewinds the
 // timestamp past the freshness threshold so GetCachedPaneInfo treats it as
 // stale. Used to model the case where backgroundStatusUpdate hasn't run for a

--- a/internal/tmux/seed_test_helper.go
+++ b/internal/tmux/seed_test_helper.go
@@ -48,6 +48,25 @@ func SeedSessionActivityCacheForTest(t testing.TB, activity map[string]int64) {
 	})
 }
 
+// SeedServerAliveForTest pins IsServerAlive's cached verdict for the next 5
+// seconds so a test can drive code paths that fast-fail when the tmux server
+// is unreachable (notably ui.backgroundStatusUpdate) without depending on
+// whether the test host has a tmux binary or a live server. Cleanup restores
+// the pristine "never probed" state so later tests re-probe for real.
+func SeedServerAliveForTest(t testing.TB, alive bool) {
+	t.Helper()
+	serverAliveMu.Lock()
+	serverAliveVal = alive
+	serverAliveTime = time.Now()
+	serverAliveMu.Unlock()
+	t.Cleanup(func() {
+		serverAliveMu.Lock()
+		serverAliveVal = true
+		serverAliveTime = time.Time{}
+		serverAliveMu.Unlock()
+	})
+}
+
 // ExpireStartupWindowForTest ends the session's startup window (see
 // inStartupWindowLocked) so GetStatus classifies the pane from live evidence
 // instead of reporting "starting".

--- a/internal/tmux/seed_test_helper.go
+++ b/internal/tmux/seed_test_helper.go
@@ -26,6 +26,28 @@ func SeedPaneInfoCacheForTest(t testing.TB, info map[string]PaneInfo) {
 	})
 }
 
+// SeedSessionActivityCacheForTest replaces the package's session cache (the
+// list-sessions snapshot that backs Session.GetCachedWindowActivity) with the
+// supplied session_name -> window_activity map and marks it fresh. Cleanup
+// restores the pristine zero state.
+//
+// Production callers must use RefreshExistingSessions / RefreshSessionCache;
+// this exists so internal/ui can drive the adaptive-refresh fingerprint tests
+// (refresh_policy.go) without standing up a real tmux server.
+func SeedSessionActivityCacheForTest(t testing.TB, activity map[string]int64) {
+	t.Helper()
+	sessionCacheMu.Lock()
+	sessionCacheData = activity
+	sessionCacheTime = time.Now()
+	sessionCacheMu.Unlock()
+	t.Cleanup(func() {
+		sessionCacheMu.Lock()
+		sessionCacheData = nil
+		sessionCacheTime = time.Time{}
+		sessionCacheMu.Unlock()
+	})
+}
+
 // ExpireStartupWindowForTest ends the session's startup window (see
 // inStartupWindowLocked) so GetStatus classifies the pane from live evidence
 // instead of reporting "starting".

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -460,6 +460,15 @@ type Home struct {
 	// Snapshot of status/tool used by render path to avoid per-row lock contention.
 	sessionRenderSnapshot atomic.Value // map[string]sessionRenderState
 
+	// Adaptive refresh policy (refresh-tick v2, issue #1753). visibleSessions
+	// holds a visibleSessionSnapshot published by the TUI tick; refreshLedger
+	// remembers each session's last-polled fingerprint so the background sweep
+	// can skip provably-unchanged off-screen sessions. See refresh_policy.go.
+	visibleSessions        atomic.Value // visibleSessionSnapshot
+	refreshLedger          *refreshLedger
+	adaptiveMaxSkips       int       // resolved staleness ceiling; 0 disables the policy
+	lastRefreshLedgerPrune time.Time // sweep-goroutine only
+
 	// Jump mode (vimium-style hint navigation)
 	jumpMode   bool   // True when jump mode is active
 	jumpBuffer string // Characters typed so far in jump mode
@@ -1438,6 +1447,8 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		lastClickIndex:            -1,
 	}
 	h.sessionRenderSnapshot.Store(make(map[string]sessionRenderState))
+	h.refreshLedger = newRefreshLedger()
+	h.adaptiveMaxSkips = defaultAdaptiveRefreshMaxSkips
 
 	h.reloadHotkeysFromConfig()
 
@@ -1461,6 +1472,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.previewOrientation = cfg.UI.GetPreviewOrientation()
 		h.remoteLatencyRefreshSec = cfg.UI.GetRemoteLatencyRefreshSecs(cfg.SystemStats.GetRefreshSeconds())
 		h.remoteSessionRefreshSec = cfg.UI.GetRemoteSessionRefreshSecs()
+		h.adaptiveMaxSkips = adaptiveRefreshMaxSkips(cfg.UI.AdaptiveRefreshMaxSkips)
 		h.footerMode = cfg.UI.GetFooter()
 		h.attachOnCreate = cfg.UI.GetAttachOnCreate()
 	} else {
@@ -4023,49 +4035,81 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 		h.instancesMu.RUnlock()
 	}
 
+	prev := h.getSessionRenderSnapshot()
+
+	// Generation skip (issue #1753): this runs from several call sites at the
+	// sweep/tick cadence and used to allocate and publish a fresh N-entry map
+	// every time. Pass 1 computes each state and compares it against the current
+	// snapshot; when nothing differs (the common steady state on a large deck)
+	// there is nothing to publish, so we return without allocating a map or
+	// storing it. Pass 2 (below) only runs when something actually changed.
+	if prev != nil {
+		live := 0
+		identical := true
+		for _, inst := range instances {
+			if inst == nil {
+				continue
+			}
+			live++
+			if got, ok := prev[inst.ID]; !ok || got != h.computeSessionRenderState(inst) {
+				identical = false
+				break
+			}
+		}
+		if identical && live == len(prev) {
+			return
+		}
+	}
+
 	snap := make(map[string]sessionRenderState, len(instances))
 	for _, inst := range instances {
 		if inst == nil {
 			continue
 		}
-		state := sessionRenderState{
-			status:   inst.GetStatusThreadSafe(),
-			substate: inst.CachedSubstate(),
-			tool:     inst.GetToolThreadSafe(),
-			// Label fields: read here, on the refresher's goroutine, so the
-			// render path never takes Instance.mu per row (#1753). Title goes
-			// through GetTitleThreadSafe because SetField/ReconcileTitleFromClaude/
-			// pending-title reapply can mutate it concurrently from the Bubble
-			// Tea event-loop goroutine.
-			title:        inst.GetTitleThreadSafe(),
-			autoName:     inst.GetAutoName(),
-			autoNameDesc: inst.GetAutoNameDescription(),
-		}
-		// Look up pane title from the already-refreshed tmux cache.
-		// Only RefreshPaneInfoCache (called from backgroundStatusUpdate) keeps
-		// the cache fresh; processStatusUpdate and other rebuild paths run on
-		// their own cadence. When that cache crosses the 4-second freshness
-		// threshold (GetCachedPaneInfo returns ok=false), keep the previous
-		// snapshot's paneTitle so the inline suffix in renderSessionItem does
-		// not blink to empty between successful refreshes — the user would
-		// otherwise read the disappearance as "title only updated once."
-		// Reading the latest snapshot inside the per-instance branch (rather
-		// than once before the loop) narrows the read-store race window: if a
-		// concurrent rebuild lands a fresher value while we're walking the
-		// instances slice, the fallback uses that value instead of stamping
-		// an even-older one back into the snapshot.
-		if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-			if paneInfo, ok := tmux.GetCachedPaneInfo(tmuxSess.Name); ok {
-				state.paneTitle = cleanPaneTitle(paneInfo.Title)
-			} else if prev := h.getSessionRenderSnapshot(); prev != nil {
-				if prevState, hadPrev := prev[inst.ID]; hadPrev {
-					state.paneTitle = prevState.paneTitle
-				}
-			}
-		}
-		snap[inst.ID] = state
+		snap[inst.ID] = h.computeSessionRenderState(inst)
 	}
 	h.sessionRenderSnapshot.Store(snap)
+}
+
+// computeSessionRenderState derives one session's render state from the
+// already-refreshed tmux caches. Extracted from refreshSessionRenderSnapshot so
+// the compare pass and the build pass cannot drift apart.
+func (h *Home) computeSessionRenderState(inst *session.Instance) sessionRenderState {
+	state := sessionRenderState{
+		status:   inst.GetStatusThreadSafe(),
+		substate: inst.CachedSubstate(),
+		tool:     inst.GetToolThreadSafe(),
+		// Label fields: read here, on the refresher's goroutine, so the
+		// render path never takes Instance.mu per row (#1753). Title goes
+		// through GetTitleThreadSafe because SetField/ReconcileTitleFromClaude/
+		// pending-title reapply can mutate it concurrently from the Bubble
+		// Tea event-loop goroutine.
+		title:        inst.GetTitleThreadSafe(),
+		autoName:     inst.GetAutoName(),
+		autoNameDesc: inst.GetAutoNameDescription(),
+	}
+	// Look up pane title from the already-refreshed tmux cache.
+	// Only RefreshPaneInfoCache (called from backgroundStatusUpdate) keeps
+	// the cache fresh; processStatusUpdate and other rebuild paths run on
+	// their own cadence. When that cache crosses the 4-second freshness
+	// threshold (GetCachedPaneInfo returns ok=false), keep the previous
+	// snapshot's paneTitle so the inline suffix in renderSessionItem does
+	// not blink to empty between successful refreshes — the user would
+	// otherwise read the disappearance as "title only updated once."
+	// Reading the latest snapshot here (rather than once before the caller's
+	// loop) narrows the read-store race window: if a concurrent rebuild lands
+	// a fresher value while we're walking the instances slice, the fallback
+	// uses that value instead of stamping an even-older one back in.
+	if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+		if paneInfo, ok := tmux.GetCachedPaneInfo(tmuxSess.Name); ok {
+			state.paneTitle = cleanPaneTitle(paneInfo.Title)
+		} else if prev := h.getSessionRenderSnapshot(); prev != nil {
+			if prevState, hadPrev := prev[inst.ID]; hadPrev {
+				state.paneTitle = prevState.paneTitle
+			}
+		}
+	}
+	return state
 }
 
 func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState {
@@ -4442,6 +4486,16 @@ func (h *Home) backgroundStatusUpdate() {
 
 	tracker := h.getTransitionTracker()
 
+	// Adaptive refresh policy (issue #1753). visibleOK=false means no fresh
+	// viewport snapshot exists, in which case the gate below is bypassed
+	// entirely and every session is polled — the pre-policy behaviour.
+	visibleIDs, visibleOK := h.visibleSessionsForSweep()
+	maxSkips := h.adaptiveMaxSkips
+	if !visibleOK {
+		maxSkips = 0
+	}
+	var genSkipped int // sessions held by the adaptive gate this sweep
+
 	g := new(errgroup.Group)
 	g.SetLimit(10) // Pool of 10 workers (tmux server serializes, more doesn't help)
 
@@ -4469,6 +4523,24 @@ func (h *Home) backgroundStatusUpdate() {
 					skipped++
 					continue
 				}
+			}
+		}
+
+		// Adaptive gate: only livePipeLRUCapacity (3) + attached sessions hold a
+		// control pipe, so the PipeManager skip above covers a handful of rows
+		// and every other quiescent session still pays a full UpdateStatus —
+		// including, for a Claude session parked in hook "waiting", a
+		// capture-pane SUBPROCESS via BackgroundWorkPending. Hold that poll when
+		// the session is off-screen AND its tmux/hook fingerprint proves nothing
+		// observable changed, bounded by adaptiveMaxSkips consecutive sweeps.
+		// See refresh_policy.go for the full argument.
+		if maxSkips > 0 {
+			_, isVisible := visibleIDs[inst.ID]
+			fp := h.fingerprintSession(inst)
+			if skip, _ := h.refreshLedger.decide(inst.ID, fp, inst.GetStatusThreadSafe(), isVisible, maxSkips); skip {
+				skipped++
+				genSkipped++
+				continue
 			}
 		}
 
@@ -4508,6 +4580,7 @@ func (h *Home) backgroundStatusUpdate() {
 		perfLog.Debug(
 			"idle_sessions_skipped",
 			slog.Int("skipped", skipped),
+			slog.Int("adaptive_skipped", genSkipped),
 			slog.Int("checked", len(instances)-skipped),
 		)
 	}
@@ -4518,6 +4591,18 @@ func (h *Home) backgroundStatusUpdate() {
 			perfLog.Info("slow_sessions", slog.String("details", strings.Join(slowSessions, ", ")))
 		}
 		slowMu.Unlock()
+	}
+
+	// Drop adaptive-refresh baselines for sessions that no longer exist. Every
+	// ~20s (not every sweep) so the live-set map is not rebuilt at the sweep
+	// cadence; entries are tiny and a 20s lag costs nothing.
+	if time.Since(h.lastRefreshLedgerPrune) >= 20*time.Second {
+		live := make(map[string]struct{}, len(instances))
+		for _, inst := range instances {
+			live[inst.ID] = struct{}{}
+		}
+		h.refreshLedger.prune(live)
+		h.lastRefreshLedgerPrune = time.Now()
 	}
 
 	// SQLite reads: shared statuses from other instances, read once and
@@ -4857,14 +4942,9 @@ func (h *Home) triggerStatusUpdate() {
 		}
 	}
 
-	visibleHeight := h.height - 8
-	if visibleHeight < 5 {
-		visibleHeight = 5
-	}
-
 	req := statusUpdateRequest{
 		viewOffset:    h.viewOffset,
-		visibleHeight: visibleHeight,
+		visibleHeight: h.visibleRowBudget(),
 		flatItemIDs:   flatItemIDs,
 	}
 
@@ -4940,6 +5020,10 @@ func (h *Home) refreshAttachedSessionStatus(sessionID string) {
 		h.hookWatcher.ClearHookStatus(inst.ID)
 	}
 	inst.ForceNextStatusCheck()
+	// Drop the adaptive-refresh baseline too: we just invalidated this session's
+	// hook status, so the next background sweep must re-derive it rather than
+	// trust a fingerprint recorded before the invalidation (issue #1753).
+	h.refreshLedger.forget(inst.ID)
 
 	if inst.GetTmuxSession() != nil {
 		tmux.RefreshSessionCache()
@@ -6816,6 +6900,13 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			selectedBefore := h.captureSelectedItemIdentity()
 			h.rebuildFlatItemsPreservingSelection(selectedBefore)
 		}
+
+		// Publish which rows are on screen so the background sweep can hold the
+		// poll for provably-unchanged off-screen sessions (issue #1753). O(visible
+		// rows); runs on every tick regardless of navigation/idle gating below so
+		// the snapshot never goes stale while the event loop is alive — a stale
+		// snapshot makes the sweep fail open and poll everything.
+		h.publishVisibleSessions()
 
 		// Auto-dismiss errors after 5 seconds
 		if h.err != nil && !h.errTime.IsZero() && time.Since(h.errTime) > 5*time.Second {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4546,10 +4546,20 @@ func (h *Home) backgroundStatusUpdate() {
 
 		// Skip idle sessions when PipeManager knows they haven't produced output.
 		// Only skip if pipe is alive (otherwise we need UpdateStatus for Error detection).
+		//
+		// Bounded by the SAME staleness ceiling as the fingerprint gate below
+		// (refreshLedger.pipeIdleSkip, sharing its skip counter): this shortcut
+		// predates the adaptive-refresh policy and used to skip unconditionally
+		// for as long as PipeManager reported no output, with no ceiling at
+		// all — the one path that could hold a session forever regardless of
+		// adaptiveMaxSkips. Once the ceiling is reached this falls through to
+		// the fingerprint gate / poll below instead of skipping, so a piped
+		// session can no longer be held indefinitely purely because
+		// PipeManager stays quiet. See pipeIdleSkip's doc comment.
 		if pm != nil {
 			if ts := inst.GetTmuxSession(); ts != nil && pm.IsConnected(ts.Name) {
 				lastOut := pm.LastOutputTime(ts.Name)
-				if !lastOut.IsZero() && time.Since(lastOut) > 5*time.Second {
+				if !lastOut.IsZero() && time.Since(lastOut) > 5*time.Second && h.refreshLedger.pipeIdleSkip(inst.ID, maxSkips) {
 					skipped++
 					continue
 				}
@@ -4592,14 +4602,18 @@ func (h *Home) backgroundStatusUpdate() {
 		pollInstance(inst)
 	}
 
-	// Visible-poll budget (issue #1753 group-expand case): at most
+	// Visible-poll budget (issue #1753 group-expand case): normally at most
 	// visiblePollBudgetPerSweep of the due visible rows are polled this sweep
 	// (cursor row always admitted); the rest are deferred with a starvation
-	// counter so the budget cycles round-robin. Only active when the policy
-	// is on: with the kill switch or a failed-open snapshot, visibleDue stays
-	// empty and every row was already polled above.
+	// counter so the budget cycles round-robin. The budget is soft — a row
+	// deferred maxSkips or more times is admitted regardless, so this can
+	// exceed visiblePollBudgetPerSweep on a sweep with many simultaneously
+	// due rows rather than let any one of them wait longer than the
+	// documented staleness ceiling. Only active when the policy is on: with
+	// the kill switch or a failed-open snapshot, visibleDue stays empty and
+	// every row was already polled above.
 	if len(visibleDue) > 0 {
-		admitted, deferred := admitVisiblePolls(visibleDue, viewSnap.cursorID, visiblePollBudgetPerSweep)
+		admitted, deferred := admitVisiblePolls(visibleDue, viewSnap.cursorID, visiblePollBudgetPerSweep, maxSkips)
 		for _, c := range admitted {
 			h.refreshLedger.admitPoll(c.inst.ID, c.fp)
 			pollInstance(c.inst)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -329,16 +329,11 @@ type Home struct {
 	// Instead of updating ALL sessions every tick, we update batches of 5-10 sessions
 	// This reduces CPU usage by 90%+ while maintaining responsiveness
 	statusUpdateIndex atomic.Int32 // Current position in round-robin cycle (atomic for thread safety)
-	// Visible-row round-robin state (#1753): with a large group expanded the
-	// visible set approaches fleet size, so "always refresh every visible row"
-	// degenerates into the same per-row storm the off-screen batching exists to
-	// prevent. Visible rows get their own cursor and per-pass budget instead.
-	visibleStatusUpdateIndex atomic.Int32
-	// visibleRefreshFingerprint remembers, per session, the cached tmux window
-	// activity at the last visible-row refresh, so an unchanged idle row costs
-	// zero. Owned exclusively by the status worker goroutine (processStatusUpdate)
-	// — no lock needed.
-	visibleRefreshFingerprint map[string]int64
+	// visibleUpdateIndex is the round-robin cursor for processStatusUpdate's
+	// VISIBLE-row pass (issue #1753): with a large group expanded, "update all
+	// visible rows every pass" is an O(fleet) subprocess burst, so the pass is
+	// budgeted and cycles from here.
+	visibleUpdateIndex atomic.Int32
 
 	// Background status worker (Priority 1C optimization)
 	// Moves status updates to a separate goroutine, completely decoupling from UI
@@ -1472,7 +1467,9 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.previewOrientation = cfg.UI.GetPreviewOrientation()
 		h.remoteLatencyRefreshSec = cfg.UI.GetRemoteLatencyRefreshSecs(cfg.SystemStats.GetRefreshSeconds())
 		h.remoteSessionRefreshSec = cfg.UI.GetRemoteSessionRefreshSecs()
-		h.adaptiveMaxSkips = adaptiveRefreshMaxSkips(cfg.UI.AdaptiveRefreshMaxSkips)
+		// Resolved once here — the adaptive-refresh kill switch (and any
+		// ceiling change) therefore requires a TUI restart to take effect.
+		h.adaptiveMaxSkips = cfg.UI.GetAdaptiveRefreshMaxSkips()
 		h.footerMode = cfg.UI.GetFooter()
 		h.attachOnCreate = cfg.UI.GetAttachOnCreate()
 	} else {
@@ -4489,15 +4486,48 @@ func (h *Home) backgroundStatusUpdate() {
 	// Adaptive refresh policy (issue #1753). visibleOK=false means no fresh
 	// viewport snapshot exists, in which case the gate below is bypassed
 	// entirely and every session is polled — the pre-policy behaviour.
-	visibleIDs, visibleOK := h.visibleSessionsForSweep()
+	viewSnap, visibleOK := h.visibleSessionsForSweep()
+	visibleIDs := viewSnap.ids
 	maxSkips := h.adaptiveMaxSkips
 	if !visibleOK {
 		maxSkips = 0
 	}
-	var genSkipped int // sessions held by the adaptive gate this sweep
+	var genSkipped int                    // sessions held by the adaptive gate this sweep
+	var visDeferred int                   // due visible rows pushed past this sweep by the budget
+	var visibleDue []visiblePollCandidate // visible rows that need a poll, competing for the budget
 
 	g := new(errgroup.Group)
 	g.SetLimit(10) // Pool of 10 workers (tmux server serializes, more doesn't help)
+
+	pollInstance := func(inst *session.Instance) {
+		g.Go(func() error {
+			oldStatus := inst.GetStatusThreadSafe()
+			instStart := time.Now()
+			_ = inst.UpdateStatus()
+			instDur := time.Since(instStart)
+
+			if instDur > 50*time.Millisecond {
+				slowMu.Lock()
+				slowSessions = append(slowSessions, fmt.Sprintf("%s=%v", inst.Title, instDur.Round(time.Millisecond)))
+				slowMu.Unlock()
+			}
+			newStatus := inst.GetStatusThreadSafe()
+			if newStatus != oldStatus {
+				statusChanged.Store(true)
+				notifLog.Debug(
+					"status_changed",
+					slog.String("title", inst.Title),
+					slog.String("old", string(oldStatus)),
+					slog.String("new", string(newStatus)),
+				)
+				// T1+T3: synthesize a flicker_detected WARN if this session
+				// has oscillated >3 times within 60s. One alert per burst.
+				session.GlobalFlickerDetector().Observe(inst.ID, string(newStatus))
+				tracker.record(inst.ID, inst.Title, inst.Tool, string(oldStatus), string(newStatus))
+			}
+			return nil
+		})
+	}
 
 	for _, inst := range instances {
 		inst := inst // capture loop variable
@@ -4530,47 +4560,55 @@ func (h *Home) backgroundStatusUpdate() {
 		// control pipe, so the PipeManager skip above covers a handful of rows
 		// and every other quiescent session still pays a full UpdateStatus —
 		// including, for a Claude session parked in hook "waiting", a
-		// capture-pane SUBPROCESS via BackgroundWorkPending. Hold that poll when
-		// the session is off-screen AND its tmux/hook fingerprint proves nothing
-		// observable changed, bounded by adaptiveMaxSkips consecutive sweeps.
+		// capture-pane SUBPROCESS via BackgroundWorkPending. Off-screen rows
+		// are held when their tmux/hook fingerprint proves nothing observable
+		// changed, bounded by adaptiveMaxSkips consecutive sweeps. Visible
+		// rows get the same fingerprint hold (with a large group expanded,
+		// visible ≈ fleet, so exempting them would defeat the policy) and the
+		// ones that DO need a poll compete for a per-sweep budget below.
 		// See refresh_policy.go for the full argument.
 		if maxSkips > 0 {
 			_, isVisible := visibleIDs[inst.ID]
 			fp := h.fingerprintSession(inst)
-			if skip, _ := h.refreshLedger.decide(inst.ID, fp, inst.GetStatusThreadSafe(), isVisible, maxSkips); skip {
-				skipped++
-				genSkipped++
+			if !isVisible {
+				if skip, _ := h.refreshLedger.decide(inst.ID, fp, inst.GetStatusThreadSafe(), false, maxSkips); skip {
+					skipped++
+					genSkipped++
+					continue
+				}
+			} else {
+				if h.refreshLedger.holdVisible(inst.ID, fp, inst.GetStatusThreadSafe(), maxSkips) {
+					skipped++
+					genSkipped++
+					continue
+				}
+				visibleDue = append(visibleDue, visiblePollCandidate{
+					inst: inst, fp: fp, deferrals: h.refreshLedger.deferralCount(inst.ID),
+				})
 				continue
 			}
 		}
 
-		g.Go(func() error {
-			oldStatus := inst.GetStatusThreadSafe()
-			instStart := time.Now()
-			_ = inst.UpdateStatus()
-			instDur := time.Since(instStart)
+		pollInstance(inst)
+	}
 
-			if instDur > 50*time.Millisecond {
-				slowMu.Lock()
-				slowSessions = append(slowSessions, fmt.Sprintf("%s=%v", inst.Title, instDur.Round(time.Millisecond)))
-				slowMu.Unlock()
-			}
-			newStatus := inst.GetStatusThreadSafe()
-			if newStatus != oldStatus {
-				statusChanged.Store(true)
-				notifLog.Debug(
-					"status_changed",
-					slog.String("title", inst.Title),
-					slog.String("old", string(oldStatus)),
-					slog.String("new", string(newStatus)),
-				)
-				// T1+T3: synthesize a flicker_detected WARN if this session
-				// has oscillated >3 times within 60s. One alert per burst.
-				session.GlobalFlickerDetector().Observe(inst.ID, string(newStatus))
-				tracker.record(inst.ID, inst.Title, inst.Tool, string(oldStatus), string(newStatus))
-			}
-			return nil
-		})
+	// Visible-poll budget (issue #1753 group-expand case): at most
+	// visiblePollBudgetPerSweep of the due visible rows are polled this sweep
+	// (cursor row always admitted); the rest are deferred with a starvation
+	// counter so the budget cycles round-robin. Only active when the policy
+	// is on: with the kill switch or a failed-open snapshot, visibleDue stays
+	// empty and every row was already polled above.
+	if len(visibleDue) > 0 {
+		admitted, deferred := admitVisiblePolls(visibleDue, viewSnap.cursorID, visiblePollBudgetPerSweep)
+		for _, c := range admitted {
+			h.refreshLedger.admitPoll(c.inst.ID, c.fp)
+			pollInstance(c.inst)
+		}
+		for _, c := range deferred {
+			h.refreshLedger.deferPoll(c.inst.ID)
+			skipped++
+			visDeferred++
+		}
 	}
 	_ = g.Wait() // Errors are logged within each goroutine
 
@@ -4581,6 +4619,7 @@ func (h *Home) backgroundStatusUpdate() {
 			"idle_sessions_skipped",
 			slog.Int("skipped", skipped),
 			slog.Int("adaptive_skipped", genSkipped),
+			slog.Int("visible_deferred", visDeferred),
 			slog.Int("checked", len(instances)-skipped),
 		)
 	}
@@ -4927,7 +4966,7 @@ func (h *Home) noteGroupToggled(groupPath string) {
 	if !ok || !group.Expanded {
 		return
 	}
-	h.visibleStatusUpdateIndex.Store(0)
+	h.visibleUpdateIndex.Store(0)
 	h.triggerStatusUpdate()
 }
 
@@ -5062,10 +5101,9 @@ func (h *Home) publishCurrentSessionStates() {
 // With batching (3 visible + 2 non-visible per tick), we keep each tick under 100ms.
 func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 	const batchSize = 2 // Reduced from 5 to 2 - fewer CapturePane() calls per tick
-	// Visible rows are budgeted too (#1753): see Step 1 below. 4 rows per pass
-	// keeps a screenful fresh within a few passes while bounding the worst case
-	// (large group expanded => visible ≈ fleet) to a constant per pass.
-	const visibleStatusBatchSize = 4
+	// Visible rows are budgeted too (#1753): see Step 1 below, which caps at
+	// visiblePollBudgetPerSweep (refresh_policy.go) per pass, bounding the
+	// worst case (large group expanded => visible ≈ fleet) to a constant.
 	if hotUntil := h.navigationHotUntil.Load(); hotUntil > 0 && time.Now().UnixNano() < hotUntil {
 		return
 	}
@@ -5104,35 +5142,21 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 	// Track if any status actually changed (for cache invalidation)
 	statusChanged := false
 
-	// Step 1: Visible sessions — budgeted round-robin (#1753).
-	//
-	// This used to refresh EVERY visible row each pass. That is fine when the
-	// visible set is a screenful of a mostly-collapsed list, but with a large
-	// group expanded the visible set approaches fleet size and this became an
-	// unbudgeted burst of per-row UpdateStatus calls — each of which takes the
-	// Instance write lock, sometimes across tmux subprocess round-trips. On the
-	// reporter's ~57-session deck that burst is what stretched the first
-	// post-detach frames into a visible black screen and made group expansion
-	// lag. Visible rows now cycle through their own cursor with a fixed budget
-	// per pass, and an idle row whose cached tmux window activity has not moved
-	// since its last refresh is skipped outright (cost zero). The full
-	// background sweep (2-10s cadence) remains the freshness backstop for every
-	// row, visible or not, so the budget only bounds burst size, not eventual
-	// freshness.
-	if h.visibleRefreshFingerprint == nil {
-		h.visibleRefreshFingerprint = make(map[string]int64)
-	}
-	visibleInstances := make([]*session.Instance, 0, len(visibleIDs))
+	// Step 1: visible sessions first (Priority 1B) — but no longer ALL of
+	// them every pass. With a large group expanded, visible-row count
+	// approaches fleet size and the unconditional loop this used to be was
+	// itself the per-keystroke subprocess storm from issue #1753. Now a
+	// visible row whose fingerprint is unchanged is held read-only (costs
+	// zero; the background sweep owns its freshness ceiling), and the rows
+	// that do need a poll are budgeted per pass, cycling round-robin from
+	// visibleUpdateIndex. The adaptive kill switch (maxSkips<=0) restores the
+	// unconditional loop byte-for-byte.
+	maxSkips := h.adaptiveMaxSkips
+	visible := make([]*session.Instance, 0, len(visibleIDs))
 	for _, inst := range instancesCopy {
-		if visibleIDs[inst.ID] {
-			visibleInstances = append(visibleInstances, inst)
+		if !visibleIDs[inst.ID] {
+			continue
 		}
-	}
-	visRemaining := visibleStatusBatchSize
-	visStart := int(h.visibleStatusUpdateIndex.Load())
-	for i := 0; i < len(visibleInstances) && visRemaining > 0; i++ {
-		idx := (visStart + i) % len(visibleInstances)
-		inst := visibleInstances[idx]
 		// Skip sessions this instance neither owns nor is orphan-polling this
 		// sweep: mirrors the background sweep's gate so the incremental poll
 		// path can't defeat the dedup claim polling promises (flag off or nil
@@ -5140,30 +5164,33 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 		if !h.isPolledByMe(inst.ID) {
 			continue
 		}
-		// Cheap-fingerprint skip: an idle visible row whose cached window
-		// activity is unchanged since its last refresh cannot have new status.
-		// Skipping here (before UpdateStatus) means it does not even pay the
-		// Instance write lock. Non-idle rows always go through — their status
-		// can change without a tmux activity bump (hook files, process exit).
-		if inst.GetStatusThreadSafe() == session.StatusIdle {
-			if ts := inst.GetTmuxSession(); ts != nil {
-				fp := ts.GetCachedWindowActivity()
-				if fp != 0 && fp == h.visibleRefreshFingerprint[inst.ID] {
-					continue
-				}
+		visible = append(visible, inst)
+	}
+	if n := len(visible); n > 0 {
+		start := int(h.visibleUpdateIndex.Load()) % n
+		if start < 0 {
+			start = 0
+		}
+		polled := 0
+		for i := 0; i < n; i++ {
+			idx := (start + i) % n
+			inst := visible[idx]
+			if maxSkips > 0 && h.refreshLedger.heldSteady(inst.ID, h.fingerprintSession(inst), inst.GetStatusThreadSafe()) {
+				updated[inst.ID] = true
+				continue
+			}
+			oldStatus := inst.GetStatusThreadSafe()
+			_ = inst.UpdateStatus() // Ignore errors in background worker
+			if inst.GetStatusThreadSafe() != oldStatus {
+				statusChanged = true
+			}
+			updated[inst.ID] = true
+			polled++
+			h.visibleUpdateIndex.Store(int32((idx + 1) % n)) // #nosec G115 -- idx is bounded by n (slice length), fits in int32
+			if maxSkips > 0 && polled >= visiblePollBudgetPerSweep {
+				break
 			}
 		}
-		oldStatus := inst.GetStatusThreadSafe()
-		_ = inst.UpdateStatus() // Ignore errors in background worker
-		if inst.GetStatusThreadSafe() != oldStatus {
-			statusChanged = true
-		}
-		if ts := inst.GetTmuxSession(); ts != nil {
-			h.visibleRefreshFingerprint[inst.ID] = ts.GetCachedWindowActivity()
-		}
-		updated[inst.ID] = true
-		visRemaining--
-		h.visibleStatusUpdateIndex.Store(int32((idx + 1) % len(visibleInstances))) // #nosec G115 -- idx bounded by slice length
 	}
 
 	// Step 2: Round-robin through non-visible sessions (Priority 1A - batching)
@@ -5180,8 +5207,8 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 		// Skip visible rows here: they are the visible round-robin's job (Step 1,
 		// budgeted). Before the visible budget existed, `updated` covered every
 		// visible row so this loop was implicitly off-screen-only; now that Step 1
-		// refreshes at most visibleStatusBatchSize of them per pass, the skip must
-		// be explicit or off-screen rows would compete with visible ones here.
+		// refreshes at most visiblePollBudgetPerSweep of them per pass, the skip
+		// must be explicit or off-screen rows would compete with visible ones here.
 		if visibleIDs[inst.ID] || updated[inst.ID] {
 			continue
 		}
@@ -8222,6 +8249,12 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 						break
 					}
 				}
+				// Group expand is an explicit refresh trigger (issue #1753):
+				// the rows render instantly from the existing snapshot, and
+				// publishing the new viewport NOW (not on the next tick) lets
+				// the next background sweep budget their catch-up polls
+				// instead of treating them as off-screen.
+				h.publishVisibleSessions()
 				h.saveGroupState()
 				h.noteGroupToggled(groupPath)
 			}
@@ -8599,6 +8632,12 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						break
 					}
 				}
+				// Group expand is an explicit refresh trigger (issue #1753):
+				// the rows render instantly from the existing snapshot, and
+				// publishing the new viewport NOW (not on the next tick) lets
+				// the next background sweep budget their catch-up polls
+				// instead of treating them as off-screen.
+				h.publishVisibleSessions()
 				h.saveGroupState()
 				h.noteGroupToggled(groupPath)
 			} else if item.Type == session.ItemTypeWindow {
@@ -8661,6 +8700,12 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						break
 					}
 				}
+				// Group expand is an explicit refresh trigger (issue #1753):
+				// the rows render instantly from the existing snapshot, and
+				// publishing the new viewport NOW (not on the next tick) lets
+				// the next background sweep budget their catch-up polls
+				// instead of treating them as off-screen.
+				h.publishVisibleSessions()
 				h.saveGroupState()
 				h.noteGroupToggled(groupPath)
 			} else if item.Type == session.ItemTypeSession && h.sessionHasWindows(item) {

--- a/internal/ui/issue1753_blackscreen_test.go
+++ b/internal/ui/issue1753_blackscreen_test.go
@@ -359,10 +359,10 @@ func TestIssue1753_VisibleRowRefreshIsBudgeted(t *testing.T) {
 			changed++
 		}
 	}
-	// visibleStatusBatchSize(4) + the off-screen batch(2) is the absolute upper
+	// visiblePollBudgetPerSweep (10, refresh_policy.go) is the absolute upper
 	// bound of UpdateStatus calls in one pass; all 30 rows are visible here so
-	// the off-screen batch has nothing to do.
-	if changed > 6 {
+	// the off-screen batch (Step 2) has nothing to do.
+	if changed > 10 {
 		t.Fatalf("one processStatusUpdate pass refreshed %d of %d visible rows: the visible-row "+
 			"burst is back — with a large group expanded this is an unbudgeted storm of "+
 			"Instance write locks right when the user expects a frame (#1753)", changed, fleet)
@@ -373,7 +373,7 @@ func TestIssue1753_VisibleRowRefreshIsBudgeted(t *testing.T) {
 	}
 
 	// The round-robin must CYCLE: repeated passes eventually cover every row.
-	// 12 passes x 4-row budget > 30 rows even with slack for skips.
+	// 12 passes x 10-row budget > 30 rows even with slack for skips.
 	for pass := 0; pass < 12; pass++ {
 		h.processStatusUpdate(req)
 	}

--- a/internal/ui/refresh_policy.go
+++ b/internal/ui/refresh_policy.go
@@ -54,9 +54,17 @@ import (
 //     zero) under the same maxSkips ceiling — holdVisible;
 //   - visible rows that DO need a poll are budgeted: at most
 //     visiblePollBudgetPerSweep of them per sweep, round-robin via a
-//     starvation counter so every due row gets its turn — admitVisiblePolls;
+//     starvation counter so every due row gets its turn — admitVisiblePolls.
+//     The budget is soft, maxSkips is hard: any row deferred maxSkips or more
+//     times is admitted regardless of budget, so the round-robin's ceiling
+//     can never exceed the documented one, even with far more due rows than
+//     budget;
 //   - the cursor row is exempt from the budget (it drives the preview pane
 //     and is what the user is reading);
+//   - the sweep's separate PipeManager quiet-pipe shortcut (only
+//     livePipeLRUCapacity=3 + attached sessions) is bounded by this same
+//     ceiling too — pipeIdleSkip — so it can no longer hold a session forever
+//     purely because PipeManager reports no new output;
 //   - the gate still fails OPEN (polls everything, no budget) when no fresh
 //     viewport snapshot exists, and the kill switch disables budget and hold
 //     alike.
@@ -289,6 +297,53 @@ func (l *refreshLedger) deferralCount(id string) int {
 	return l.entries[id].deferrals
 }
 
+// pipeIdleSkip bounds the sweep's separate PipeManager quiet-pipe shortcut
+// (home.go backgroundStatusUpdate: "skip idle sessions when PipeManager
+// knows they haven't produced output") by the SAME per-session staleness
+// ceiling the fingerprint gate uses below, sharing its skip counter.
+//
+// That shortcut predates this policy and runs BEFORE the fingerprint gate:
+// for the narrow set of sessions holding a live control pipe
+// (livePipeLRUCapacity = 3 + attached sessions), it used to skip
+// unconditionally for as long as PipeManager reported no recent output —
+// never reaching decide()/holdVisible(), so a session's ledger baseline was
+// never refreshed and heldSteady() (the read-only hold used by the
+// incremental visible-first path in processStatusUpdate) could hold it
+// forever. No ceiling, contradicting the design doc's "the ceiling bounds
+// the only real exposure" claim.
+//
+// Sharing the skip counter here closes that gap without adding a second,
+// independent bound to reason about: once maxSkips consecutive pipe-idle
+// sweeps have elapsed for a session, this returns false and RESETS the
+// entry (dropping the stale baseline), so the caller must fall through to
+// the normal fingerprint gate / poll path instead of skipping. The
+// zero-value baseline is certain to mismatch the freshly computed
+// fingerprint, so that fallthrough always forces a real poll and rebases —
+// exactly mirroring what happens when decide()/holdVisible() themselves hit
+// the ceiling.
+//
+// maxSkips<=0 (adaptive policy disabled — kill switch, or no fresh viewport
+// snapshot this sweep) returns true unconditionally: PipeManager alone
+// decides, byte-identical to the pre-policy shortcut this augments.
+func (l *refreshLedger) pipeIdleSkip(id string, maxSkips int) bool {
+	if l == nil || id == "" || maxSkips <= 0 {
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.entries == nil {
+		l.entries = make(map[string]refreshLedgerEntry)
+	}
+	e := l.entries[id]
+	if e.skips >= maxSkips {
+		l.entries[id] = refreshLedgerEntry{}
+		return false
+	}
+	e.skips++
+	l.entries[id] = e
+	return true
+}
+
 // forget drops one session's baseline so the next sweep polls it. Called after
 // any path that refreshes a session out of band (attach-return, forced check),
 // so the gate can never hold a session whose state the TUI just invalidated.
@@ -329,7 +384,25 @@ type visiblePollCandidate struct {
 // preview pane, so it is effectively budget-exempt — it always lands in the
 // admitted prefix), then most-starved first so deferred rows rise until
 // admitted and the budget cycles round-robin through every due row.
-func admitVisiblePolls(due []visiblePollCandidate, cursorID string, budget int) (admitted, deferred []visiblePollCandidate) {
+//
+// Round-robin priority alone only bounds staleness by ceil(due/budget) — a
+// function of how many rows happen to be due at once, not of maxSkips. With
+// enough simultaneously-due rows (e.g. a large group expand) that can exceed
+// the maxSkips ceiling the design doc promises for visible rows by an
+// arbitrary factor: N due rows at budget B and a steady inflow of new due
+// rows can starve the tail indefinitely, since nothing ever forces admission
+// regardless of budget.
+//
+// maxSkips is therefore a HARD floor, not just a priority: any candidate
+// already deferred maxSkips or more times is admitted unconditionally, even
+// when that pushes this sweep's total above budget. The budget stays the
+// common case (deferral counts rarely reach maxSkips), but it can never be
+// the reason a visible row waits longer than the documented ceiling —
+// exactly the same trade the fingerprint gate itself makes (decide's
+// staleness-ceiling veto also overrides a "nothing changed" skip). Pass
+// maxSkips<=0 to disable forced admission (policy off; callers already keep
+// visibleDue empty in that case, so this is belt-and-suspenders).
+func admitVisiblePolls(due []visiblePollCandidate, cursorID string, budget int, maxSkips int) (admitted, deferred []visiblePollCandidate) {
 	sort.SliceStable(due, func(i, j int) bool {
 		iCursor := cursorID != "" && due[i].inst != nil && due[i].inst.ID == cursorID
 		jCursor := cursorID != "" && due[j].inst != nil && due[j].inst.ID == cursorID
@@ -344,7 +417,16 @@ func admitVisiblePolls(due []visiblePollCandidate, cursorID string, budget int) 
 	if len(due) <= budget {
 		return due, nil
 	}
-	return due[:budget], due[budget:]
+	admitted = due[:budget]
+	rest := due[budget:]
+	for _, c := range rest {
+		if maxSkips > 0 && c.deferrals >= maxSkips {
+			admitted = append(admitted, c)
+		} else {
+			deferred = append(deferred, c)
+		}
+	}
+	return admitted, deferred
 }
 
 // fingerprintSession builds a session's fingerprint from caches the sweep has

--- a/internal/ui/refresh_policy.go
+++ b/internal/ui/refresh_policy.go
@@ -1,0 +1,349 @@
+package ui
+
+import (
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Adaptive refresh policy — the "generation skip" half of the refresh-tick v2
+// architecture (docs/design/refresh-architecture-v2.md, issue #1753).
+//
+// The background status sweep used to call Instance.UpdateStatus() on EVERY
+// live session every ~2s. That is O(live sessions) per tick, and for the most
+// common steady state on a large deck — a Claude session sitting in hook
+// "waiting" (done / needs-you) — UpdateStatus takes the hook fast path, which
+// calls tmux.Session.BackgroundWorkPending() and therefore captures the pane
+// (bgWorkCacheTTL = 3s). Only livePipeLRUCapacity (3) + attached sessions hold
+// a control pipe, so for everyone else that capture is a `tmux capture-pane`
+// SUBPROCESS, serialized by the tmux server. At ~60 quiescent sessions that is
+// tens of subprocesses per sweep spent re-deriving a status that cannot have
+// changed.
+//
+// The gate below skips that poll when there is cheap, positive evidence that
+// nothing observable changed. The evidence is a per-session FINGERPRINT built
+// entirely from caches the sweep already refreshed once (list-sessions +
+// list-panes) plus in-memory watcher maps, so building it is a handful of map
+// lookups and spawns nothing:
+//
+//	window_activity  — tmux bumps it on any pane output
+//	pane title       — the OSC-driven spinner/done marker Claude sets
+//	pane command      — foreground process
+//	pane dead        — process exited under remain-on-exit
+//	hook UpdatedAt   — Stop/Notification/PermissionRequest hook file mtime
+//	SSE UpdatedAt    — OpenCode /event stream (issue #1614)
+//
+// Unchanged window_activity as proof of "no new pane output" is NOT a new
+// assumption: tmux.Session.GetStatus already gates its CapturePane on exactly
+// that comparison (needsBusyCheck), and Instance.UpdateStatus gates its idle
+// tier on it too. This gate is strictly more conservative than those, because
+// it also bounds how long it may hold: after maxSkips consecutive skips a
+// session is polled no matter what, so any time-based transition inside
+// UpdateStatus (acknowledged→idle, hook-freshness expiry, debounce
+// confirmation) is delayed by at most maxSkips sweeps rather than suppressed.
+//
+// Rows the user is actually looking at are never skipped — visibility is
+// published by the TUI tick and the gate fails OPEN (polls everything) when no
+// fresh viewport snapshot exists.
+
+const (
+	// defaultAdaptiveRefreshMaxSkips is how many consecutive background sweeps
+	// a quiescent off-screen session may be skipped before it is polled
+	// regardless of its fingerprint. 2 means "poll at least every 3rd sweep"
+	// (~6s at baseStatusInterval), which bounds the worst-case staleness of a
+	// time-based transition on an off-screen row.
+	defaultAdaptiveRefreshMaxSkips = 2
+
+	// visibleSessionsMaxAge is how long a published viewport snapshot is
+	// trusted. The TUI republishes on every tick (baseStatusInterval), so a
+	// snapshot older than this means the UI event loop is wedged or suspended
+	// (tea.Exec) — the gate then fails open and polls everything, exactly as
+	// it did before this policy existed.
+	visibleSessionsMaxAge = 10 * time.Second
+)
+
+// sessionFingerprint is the cheap, cache-only evidence of a session's observable
+// state. Comparable by ==; ok is false when the caches could not supply an
+// answer (stale bulk cache, no tmux session yet), which always forces a poll.
+type sessionFingerprint struct {
+	activity int64  // tmux window_activity (seconds; 0 = cache miss)
+	title    string // tmux pane title
+	command  string // tmux pane_current_command
+	dead     bool   // tmux pane_dead
+	hookAt   int64  // hook status UpdatedAt (UnixNano; 0 = none)
+	sseAt    int64  // OpenCode SSE UpdatedAt (UnixNano; 0 = none)
+	ok       bool
+}
+
+// unchangedFrom reports whether both fingerprints are usable and identical.
+func (f sessionFingerprint) unchangedFrom(prev sessionFingerprint) bool {
+	return f.ok && prev.ok && f == prev
+}
+
+// statusSettledForSkip reports whether a status is one the gate is allowed to
+// hold. Only the three steady states qualify. error/stopped carry their own
+// recheck timers inside UpdateStatus and must be free to recover promptly;
+// starting must converge fast; anything unrecognised is treated as unsettled.
+func statusSettledForSkip(s session.Status) bool {
+	switch s {
+	case session.StatusRunning, session.StatusWaiting, session.StatusIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+// skipInput is the complete input to the skip decision, kept as a plain struct
+// so the policy is unit-testable without tmux, a HOME, or a live Home.
+type skipInput struct {
+	visible  bool
+	status   session.Status
+	fp       sessionFingerprint
+	prev     sessionFingerprint
+	hasPrev  bool
+	skips    int
+	maxSkips int
+}
+
+// shouldSkipStatusPoll decides whether the background sweep may skip
+// UpdateStatus for one session this sweep. The returned reason is for debug
+// logging and tests; it is never shown to the user.
+//
+// Every condition is a veto: the gate skips only when all of them agree.
+func shouldSkipStatusPoll(in skipInput) (bool, string) {
+	switch {
+	case in.maxSkips <= 0:
+		return false, "policy-disabled"
+	case in.visible:
+		return false, "visible"
+	case !statusSettledForSkip(in.status):
+		return false, "status-unsettled"
+	case !in.hasPrev:
+		return false, "no-baseline"
+	case !in.fp.unchangedFrom(in.prev):
+		return false, "fingerprint-changed"
+	case in.skips >= in.maxSkips:
+		return false, "staleness-ceiling"
+	default:
+		return true, "quiescent"
+	}
+}
+
+// refreshLedger remembers, per session, the fingerprint of the last sweep that
+// actually polled it and how many sweeps have been skipped since. Guarded by a
+// mutex: the sweep runs on the status worker goroutine while forget() can be
+// called from the Bubble Tea goroutine on attach-return.
+//
+// All methods are nil-receiver safe so an alternate/test Home constructor that
+// never builds a ledger still behaves exactly like the pre-policy code (poll
+// everything).
+type refreshLedger struct {
+	mu      sync.Mutex
+	entries map[string]refreshLedgerEntry
+}
+
+type refreshLedgerEntry struct {
+	fp    sessionFingerprint
+	skips int
+}
+
+func newRefreshLedger() *refreshLedger {
+	return &refreshLedger{entries: make(map[string]refreshLedgerEntry)}
+}
+
+// decide consults the policy for one session and records the outcome in one
+// locked step. On a poll the fingerprint becomes the new baseline and the skip
+// counter resets; on a skip the baseline is kept (it is equal by construction)
+// and the counter advances toward the ceiling.
+func (l *refreshLedger) decide(id string, fp sessionFingerprint, status session.Status, visible bool, maxSkips int) (bool, string) {
+	if l == nil || id == "" {
+		return false, "policy-disabled"
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.entries == nil {
+		l.entries = make(map[string]refreshLedgerEntry)
+	}
+	prev, hasPrev := l.entries[id]
+	skip, reason := shouldSkipStatusPoll(skipInput{
+		visible:  visible,
+		status:   status,
+		fp:       fp,
+		prev:     prev.fp,
+		hasPrev:  hasPrev,
+		skips:    prev.skips,
+		maxSkips: maxSkips,
+	})
+	if skip {
+		l.entries[id] = refreshLedgerEntry{fp: prev.fp, skips: prev.skips + 1}
+	} else {
+		l.entries[id] = refreshLedgerEntry{fp: fp, skips: 0}
+	}
+	return skip, reason
+}
+
+// forget drops one session's baseline so the next sweep polls it. Called after
+// any path that refreshes a session out of band (attach-return, forced check),
+// so the gate can never hold a session whose state the TUI just invalidated.
+func (l *refreshLedger) forget(id string) {
+	if l == nil || id == "" {
+		return
+	}
+	l.mu.Lock()
+	delete(l.entries, id)
+	l.mu.Unlock()
+}
+
+// prune drops baselines for sessions that no longer exist, so the ledger cannot
+// grow across a long-lived TUI session.
+func (l *refreshLedger) prune(live map[string]struct{}) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	for id := range l.entries {
+		if _, ok := live[id]; !ok {
+			delete(l.entries, id)
+		}
+	}
+	l.mu.Unlock()
+}
+
+// fingerprintSession builds a session's fingerprint from caches the sweep has
+// already refreshed. It spawns no subprocess: GetCachedWindowActivity and
+// GetCachedPaneInfo are map reads over the bulk list-sessions / list-panes
+// snapshots, and the watcher lookups are in-memory maps.
+//
+// ok is false — forcing a poll — whenever the evidence is incomplete: no tmux
+// session, a stale pane cache, or a missing window_activity sample.
+func (h *Home) fingerprintSession(inst *session.Instance) sessionFingerprint {
+	if inst == nil {
+		return sessionFingerprint{}
+	}
+	ts := inst.GetTmuxSession()
+	if ts == nil {
+		return sessionFingerprint{}
+	}
+	activity := ts.GetCachedWindowActivity()
+	if activity == 0 {
+		return sessionFingerprint{}
+	}
+	paneInfo, paneOK := tmux.GetCachedPaneInfo(ts.Name)
+	if !paneOK {
+		return sessionFingerprint{}
+	}
+	fp := sessionFingerprint{
+		activity: activity,
+		title:    paneInfo.Title,
+		command:  paneInfo.CurrentCommand,
+		dead:     paneInfo.Dead,
+		ok:       true,
+	}
+	if h.hookWatcher != nil {
+		if hs := h.hookWatcher.GetHookStatus(inst.ID); hs != nil {
+			fp.hookAt = hs.UpdatedAt.UnixNano()
+		}
+	}
+	if h.sseWatcher != nil {
+		if ss := h.sseWatcher.GetStatus(inst.ID); ss != nil {
+			fp.sseAt = ss.UpdatedAt.UnixNano()
+		}
+	}
+	return fp
+}
+
+// visibleSessionSnapshot is the set of session IDs currently on screen, plus
+// when it was taken so a stale snapshot can fail open.
+type visibleSessionSnapshot struct {
+	ids map[string]struct{}
+	at  time.Time
+}
+
+// visibleRowBudget is how many list rows the viewport can hold. Shared by the
+// viewport publisher and the round-robin status request so the two cannot drift.
+func (h *Home) visibleRowBudget() int {
+	budget := h.height - 8
+	if budget < 5 {
+		budget = 5
+	}
+	return budget
+}
+
+// publishVisibleSessions snapshots which session rows are on screen for the
+// background sweep. O(visible rows) — it walks only the viewport slice, never
+// the whole deck — and is called from the TUI tick, which already owns
+// flatItems/cursor/viewOffset on the Bubble Tea goroutine.
+//
+// The selected row is always included even when the viewport slice math would
+// miss it (cursor on a group header keeps its child out; a selected row is what
+// the preview pane shows), and so is a session we just returned from attaching.
+func (h *Home) publishVisibleSessions(extra ...string) {
+	ids := make(map[string]struct{}, h.visibleRowBudget()+len(extra)+1)
+	add := func(item session.Item) {
+		switch item.Type {
+		case session.ItemTypeSession:
+			if item.Session != nil {
+				ids[item.Session.ID] = struct{}{}
+			}
+		case session.ItemTypeWindow:
+			if item.WindowSessionID != "" {
+				ids[item.WindowSessionID] = struct{}{}
+			}
+		}
+	}
+	end := h.viewOffset + h.visibleRowBudget()
+	if end > len(h.flatItems) {
+		end = len(h.flatItems)
+	}
+	for i := h.viewOffset; i < end; i++ {
+		if i < 0 {
+			continue
+		}
+		add(h.flatItems[i])
+	}
+	if h.cursor >= 0 && h.cursor < len(h.flatItems) {
+		add(h.flatItems[h.cursor])
+	}
+	for _, id := range extra {
+		if id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	h.visibleSessions.Store(visibleSessionSnapshot{ids: ids, at: time.Now()})
+}
+
+// visibleSessionsForSweep returns the published viewport set and whether it is
+// fresh enough to trust. ok=false means the gate must fail open: with no recent
+// viewport snapshot (TUI not started yet, event loop suspended by tea.Exec, or
+// wedged) every session is treated as visible and polled, which is the exact
+// pre-policy behaviour.
+func (h *Home) visibleSessionsForSweep() (map[string]struct{}, bool) {
+	raw := h.visibleSessions.Load()
+	if raw == nil {
+		return nil, false
+	}
+	snap, typed := raw.(visibleSessionSnapshot)
+	if !typed || snap.ids == nil {
+		return nil, false
+	}
+	if time.Since(snap.at) > visibleSessionsMaxAge {
+		return nil, false
+	}
+	return snap.ids, true
+}
+
+// adaptiveRefreshMaxSkips resolves the configured staleness ceiling.
+// 0/unset uses defaultAdaptiveRefreshMaxSkips; any negative value disables the
+// policy entirely (every sweep polls every session, byte-identical to the
+// behaviour before this policy landed).
+func adaptiveRefreshMaxSkips(configured int) int {
+	if configured == 0 {
+		return defaultAdaptiveRefreshMaxSkips
+	}
+	if configured < 0 {
+		return 0
+	}
+	return configured
+}

--- a/internal/ui/refresh_policy.go
+++ b/internal/ui/refresh_policy.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -44,17 +45,34 @@ import (
 // UpdateStatus (acknowledged→idle, hook-freshness expiry, debounce
 // confirmation) is delayed by at most maxSkips sweeps rather than suppressed.
 //
-// Rows the user is actually looking at are never skipped — visibility is
-// published by the TUI tick and the gate fails OPEN (polls everything) when no
-// fresh viewport snapshot exists.
+// VISIBLE rows (issue #1753, group-expand diagnostic): with a large group
+// expanded, visible-row count approaches fleet size, so a policy that only
+// skips off-screen rows degenerates to refreshing everything. Visible rows
+// therefore get the same treatment, tuned for what the user can see:
+//
+//   - a visible row whose fingerprint is provably unchanged is HELD (costs
+//     zero) under the same maxSkips ceiling — holdVisible;
+//   - visible rows that DO need a poll are budgeted: at most
+//     visiblePollBudgetPerSweep of them per sweep, round-robin via a
+//     starvation counter so every due row gets its turn — admitVisiblePolls;
+//   - the cursor row is exempt from the budget (it drives the preview pane
+//     and is what the user is reading);
+//   - the gate still fails OPEN (polls everything, no budget) when no fresh
+//     viewport snapshot exists, and the kill switch disables budget and hold
+//     alike.
+//
+// Group expand itself never polls: newly visible rows render from the render
+// snapshot instantly and fill in through this budget on subsequent sweeps.
 
 const (
 	// defaultAdaptiveRefreshMaxSkips is how many consecutive background sweeps
 	// a quiescent off-screen session may be skipped before it is polled
 	// regardless of its fingerprint. 2 means "poll at least every 3rd sweep"
 	// (~6s at baseStatusInterval), which bounds the worst-case staleness of a
-	// time-based transition on an off-screen row.
-	defaultAdaptiveRefreshMaxSkips = 2
+	// time-based transition on an off-screen row. The config knob that
+	// overrides it is resolved (defaulted, kill-switched, and clamped) by
+	// session.UISettings.GetAdaptiveRefreshMaxSkips.
+	defaultAdaptiveRefreshMaxSkips = session.DefaultAdaptiveRefreshMaxSkips
 
 	// visibleSessionsMaxAge is how long a published viewport snapshot is
 	// trusted. The TUI republishes on every tick (baseStatusInterval), so a
@@ -62,6 +80,15 @@ const (
 	// (tea.Exec) — the gate then fails open and polls everything, exactly as
 	// it did before this policy existed.
 	visibleSessionsMaxAge = 10 * time.Second
+
+	// visiblePollBudgetPerSweep is the per-sweep cap on how many VISIBLE rows
+	// may be polled (issue #1753 group-expand case). Matches the sweep's
+	// worker-pool width (g.SetLimit(10) in backgroundStatusUpdate) so one
+	// sweep's visible polls can never exceed one pool of tmux work; due rows
+	// beyond the budget are deferred with a starvation counter and admitted
+	// first on later sweeps, so every due visible row is polled within
+	// ceil(due/budget) sweeps. The cursor row bypasses the budget entirely.
+	visiblePollBudgetPerSweep = 10
 )
 
 // sessionFingerprint is the cheap, cache-only evidence of a session's observable
@@ -147,6 +174,11 @@ type refreshLedger struct {
 type refreshLedgerEntry struct {
 	fp    sessionFingerprint
 	skips int
+	// deferrals counts consecutive sweeps a DUE visible row was pushed past
+	// by the visible-poll budget. Admission orders by it (most-starved first)
+	// so the budget cycles round-robin instead of starving a stable suffix.
+	// Zeroed on every actual poll.
+	deferrals int
 }
 
 func newRefreshLedger() *refreshLedger {
@@ -184,6 +216,79 @@ func (l *refreshLedger) decide(id string, fp sessionFingerprint, status session.
 	return skip, reason
 }
 
+// holdVisible is the sweep-side gate for a VISIBLE row: it skips (and counts
+// the skip toward the ceiling) only when the row's status is settled, the
+// fingerprint is usable and identical to the last polled baseline, and fewer
+// than maxSkips consecutive skips have happened — the same vetoes as the
+// off-screen gate minus visibility itself. On false it mutates NOTHING: the
+// row becomes a budget candidate and the ledger is updated by admitPoll or
+// deferPoll, whichever the admission pass picks.
+func (l *refreshLedger) holdVisible(id string, fp sessionFingerprint, status session.Status, maxSkips int) bool {
+	if l == nil || id == "" || maxSkips <= 0 {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	prev, hasPrev := l.entries[id]
+	if !hasPrev || !statusSettledForSkip(status) || !fp.unchangedFrom(prev.fp) || prev.skips >= maxSkips {
+		return false
+	}
+	l.entries[id] = refreshLedgerEntry{fp: prev.fp, skips: prev.skips + 1, deferrals: prev.deferrals}
+	return true
+}
+
+// heldSteady is the READ-ONLY variant used by the incremental visible-first
+// path (processStatusUpdate): true when the row is settled and its fingerprint
+// matches the last polled baseline. It deliberately has no ceiling and touches
+// no counters — the background sweep owns freshness (it polls every row at
+// least every maxSkips+1 sweeps), so the incremental path may hold a steady
+// row indefinitely without any transition being suppressed.
+func (l *refreshLedger) heldSteady(id string, fp sessionFingerprint, status session.Status) bool {
+	if l == nil || id == "" {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	prev, hasPrev := l.entries[id]
+	return hasPrev && statusSettledForSkip(status) && fp.unchangedFrom(prev.fp)
+}
+
+// admitPoll records that a budget-admitted visible row is being polled this
+// sweep: the fingerprint becomes the new baseline and both counters reset,
+// exactly like decide()'s poll branch.
+func (l *refreshLedger) admitPoll(id string, fp sessionFingerprint) {
+	if l == nil || id == "" {
+		return
+	}
+	l.mu.Lock()
+	l.entries[id] = refreshLedgerEntry{fp: fp}
+	l.mu.Unlock()
+}
+
+// deferPoll records that a due visible row was pushed past this sweep by the
+// budget. Only the starvation counter moves — baseline and skip count stay, so
+// the row remains due and rises in admission priority next sweep.
+func (l *refreshLedger) deferPoll(id string) {
+	if l == nil || id == "" {
+		return
+	}
+	l.mu.Lock()
+	prev := l.entries[id]
+	prev.deferrals++
+	l.entries[id] = prev
+	l.mu.Unlock()
+}
+
+// deferralCount reports how many consecutive sweeps a row has been deferred.
+func (l *refreshLedger) deferralCount(id string) int {
+	if l == nil || id == "" {
+		return 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.entries[id].deferrals
+}
+
 // forget drops one session's baseline so the next sweep polls it. Called after
 // any path that refreshes a session out of band (attach-return, forced check),
 // so the gate can never hold a session whose state the TUI just invalidated.
@@ -209,6 +314,37 @@ func (l *refreshLedger) prune(live map[string]struct{}) {
 		}
 	}
 	l.mu.Unlock()
+}
+
+// visiblePollCandidate is a visible row the gate could not hold this sweep —
+// it needs a poll and competes for the visible-poll budget.
+type visiblePollCandidate struct {
+	inst      *session.Instance
+	fp        sessionFingerprint
+	deferrals int
+}
+
+// admitVisiblePolls splits the due visible rows into the prefix polled this
+// sweep and the deferred rest. Ordering: the cursor row first (it drives the
+// preview pane, so it is effectively budget-exempt — it always lands in the
+// admitted prefix), then most-starved first so deferred rows rise until
+// admitted and the budget cycles round-robin through every due row.
+func admitVisiblePolls(due []visiblePollCandidate, cursorID string, budget int) (admitted, deferred []visiblePollCandidate) {
+	sort.SliceStable(due, func(i, j int) bool {
+		iCursor := cursorID != "" && due[i].inst != nil && due[i].inst.ID == cursorID
+		jCursor := cursorID != "" && due[j].inst != nil && due[j].inst.ID == cursorID
+		if iCursor != jCursor {
+			return iCursor
+		}
+		return due[i].deferrals > due[j].deferrals
+	})
+	if budget < 1 {
+		budget = 1
+	}
+	if len(due) <= budget {
+		return due, nil
+	}
+	return due[:budget], due[budget:]
 }
 
 // fingerprintSession builds a session's fingerprint from caches the sweep has
@@ -258,7 +394,11 @@ func (h *Home) fingerprintSession(inst *session.Instance) sessionFingerprint {
 // when it was taken so a stale snapshot can fail open.
 type visibleSessionSnapshot struct {
 	ids map[string]struct{}
-	at  time.Time
+	// cursorID is the session under the cursor (empty when the cursor sits on
+	// a group header or nothing). The sweep's visible-poll budget never defers
+	// it: it is the row the preview pane shows.
+	cursorID string
+	at       time.Time
 }
 
 // visibleRowBudget is how many list rows the viewport can hold. Shared by the
@@ -311,39 +451,36 @@ func (h *Home) publishVisibleSessions(extra ...string) {
 			ids[id] = struct{}{}
 		}
 	}
-	h.visibleSessions.Store(visibleSessionSnapshot{ids: ids, at: time.Now()})
+	snap := visibleSessionSnapshot{ids: ids, at: time.Now()}
+	if h.cursor >= 0 && h.cursor < len(h.flatItems) {
+		switch item := h.flatItems[h.cursor]; item.Type {
+		case session.ItemTypeSession:
+			if item.Session != nil {
+				snap.cursorID = item.Session.ID
+			}
+		case session.ItemTypeWindow:
+			snap.cursorID = item.WindowSessionID
+		}
+	}
+	h.visibleSessions.Store(snap)
 }
 
-// visibleSessionsForSweep returns the published viewport set and whether it is
-// fresh enough to trust. ok=false means the gate must fail open: with no recent
-// viewport snapshot (TUI not started yet, event loop suspended by tea.Exec, or
-// wedged) every session is treated as visible and polled, which is the exact
-// pre-policy behaviour.
-func (h *Home) visibleSessionsForSweep() (map[string]struct{}, bool) {
+// visibleSessionsForSweep returns the published viewport snapshot and whether
+// it is fresh enough to trust. ok=false means the gate must fail open: with no
+// recent viewport snapshot (TUI not started yet, event loop suspended by
+// tea.Exec, or wedged) every session is treated as visible and polled with no
+// budget, which is the exact pre-policy behaviour.
+func (h *Home) visibleSessionsForSweep() (visibleSessionSnapshot, bool) {
 	raw := h.visibleSessions.Load()
 	if raw == nil {
-		return nil, false
+		return visibleSessionSnapshot{}, false
 	}
 	snap, typed := raw.(visibleSessionSnapshot)
 	if !typed || snap.ids == nil {
-		return nil, false
+		return visibleSessionSnapshot{}, false
 	}
 	if time.Since(snap.at) > visibleSessionsMaxAge {
-		return nil, false
+		return visibleSessionSnapshot{}, false
 	}
-	return snap.ids, true
-}
-
-// adaptiveRefreshMaxSkips resolves the configured staleness ceiling.
-// 0/unset uses defaultAdaptiveRefreshMaxSkips; any negative value disables the
-// policy entirely (every sweep polls every session, byte-identical to the
-// behaviour before this policy landed).
-func adaptiveRefreshMaxSkips(configured int) int {
-	if configured == 0 {
-		return defaultAdaptiveRefreshMaxSkips
-	}
-	if configured < 0 {
-		return 0
-	}
-	return configured
+	return snap, true
 }

--- a/internal/ui/refresh_policy_perf_test.go
+++ b/internal/ui/refresh_policy_perf_test.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Perf gate for the adaptive-refresh sweep's PER-SESSION DECISION cost (PR
+// #1765, issue #1753) — fingerprintSession + refreshLedger.decide /
+// holdVisible + admitVisiblePolls, the code that runs for every live
+// session on every background sweep and every incremental visible-first
+// pass (home.go backgroundStatusUpdate / processStatusUpdate).
+//
+// What this test does NOT gate: the thing the PR description's "Measured
+// effect" table reports a percentage for — real Instance.UpdateStatus()
+// cost (tmux capture-pane subprocesses) under a live multi-session tmux
+// fleet. That number came from an out-of-band sandboxed 60-session tmux
+// harness, which is inherently COLD, real-subprocess, real-tmux-server work
+// that does not belong in a hermetic, tmux-free CI gate, and this repo has
+// no in-CI harness that reproduces it. The PR does NOT re-assert that
+// number as a CI-verified claim; it is unquantified on the rebased head
+// pending such a harness (see the PR description).
+//
+// What THIS test DOES gate: the decision layer's own claim of being "a
+// handful of map lookups, spawns nothing" (refresh_policy.go's package
+// doc). It is pure in-process Go — seeded tmux caches, no tmux server, no
+// subprocess — so a regression that reintroduces a spawn, a lock held
+// across the whole sweep, or an accidental O(n^2) in the admission sort
+// would show up here as a walltime blowout, even though such a regression
+// would very likely touch no cmd/agent-deck/*.go line and so would
+// otherwise be invisible to this repo's perf gate (see
+// .github/workflows/perf-smoke.yml's internal/ui/** path filter, added
+// alongside this test so this package's own hot path is actually covered).
+//
+// Classified WARM: pure in-process Go against seeded package-level caches,
+// no process/syscall boundary. See docs/perf-budget-suite.md.
+
+// perfSweepDecisionN is the per-iteration session count: roughly 3x the
+// #1753 diagnostic's 60-session reference fleet, comfortably clearing the
+// 1ms budget floor without inflating the timed loop's own allocation noise.
+const perfSweepDecisionN = 200
+
+// perfSweepDecisionBase is an ENGINEERING ESTIMATE, not a locally-measured
+// median. This development host's safety rules forbid running `go test`
+// against this repo at all, sandboxed or not (two prior fleet-data-loss
+// incidents from un-isolated runs), so the docs/perf-budget-suite.md
+// convention of citing an observed local median could not be followed from
+// here — CI is the first place this test will actually execute.
+//
+// 5ms budgeted for perfSweepDecisionN=200 pure map-lookup-and-compare
+// decisions (no I/O, no allocation-heavy work, no subprocess) is generous
+// by roughly an order of magnitude on any modern CI runner: the intent is a
+// gate wide enough not to flake on shared-runner variance while still
+// catching a real regression by a large margin (e.g. a reintroduced
+// per-session subprocess would cost roughly 200x a few milliseconds each,
+// blowing through this budget 100x+ over). Tighten this to a cited value
+// from the perf-medians.txt artifact (uploaded by
+// .github/workflows/perf-smoke.yml) the first time this test runs green in
+// CI, per the RFC-required process for loosening — or tightening — a
+// TestPerf_* budget.
+const perfSweepDecisionBase = 5 * time.Millisecond // WarmBudget = 15ms local, 30ms CI (multiplier=2.0)
+
+func TestPerf_AdaptiveRefreshSweepDecision(t *testing.T) {
+	testutil.SkipIfShort(t)
+
+	h := newHomeForSnapshotTest()
+	l := newRefreshLedger()
+	const maxSkips = 2
+
+	insts := make([]*session.Instance, perfSweepDecisionN)
+	paneInfo := make(map[string]tmux.PaneInfo, perfSweepDecisionN)
+	activity := make(map[string]int64, perfSweepDecisionN)
+	for i := range insts {
+		name := fmt.Sprintf("agentdeck-perf-sweep-%03d", i)
+		insts[i] = instWithTmuxName(t, fmt.Sprintf("perf-sweep-%03d", i), name)
+		paneInfo[name] = tmux.PaneInfo{Title: "steady", CurrentCommand: "node"}
+		activity[name] = int64(1000 + i)
+	}
+	tmux.SeedPaneInfoCacheForTest(t, paneInfo)
+	tmux.SeedSessionActivityCacheForTest(t, activity)
+
+	budget := testutil.WarmBudget(t, perfSweepDecisionBase)
+
+	// One simulated sweep: half the sessions off-screen (through decide()),
+	// half visible (through holdVisible() + the budget admission pass) —
+	// mirrors the real split in backgroundStatusUpdate.
+	got := testutil.TrimmedMeanWarm(func() {
+		due := make([]visiblePollCandidate, 0, perfSweepDecisionN/2)
+		for i, inst := range insts {
+			fp := h.fingerprintSession(inst)
+			if i%2 == 0 {
+				l.decide(inst.ID, fp, session.StatusWaiting, false, maxSkips)
+				continue
+			}
+			if l.holdVisible(inst.ID, fp, session.StatusWaiting, maxSkips) {
+				continue
+			}
+			due = append(due, visiblePollCandidate{inst: inst, fp: fp, deferrals: l.deferralCount(inst.ID)})
+		}
+		admitted, deferred := admitVisiblePolls(due, "", visiblePollBudgetPerSweep, maxSkips)
+		for _, c := range admitted {
+			l.admitPoll(c.inst.ID, c.fp)
+		}
+		for _, c := range deferred {
+			l.deferPoll(c.inst.ID)
+		}
+	})
+
+	if got > budget {
+		t.Fatalf("adaptive-refresh sweep decision (%d sessions, fingerprint+decide/holdVisible+admitVisiblePolls) trimmed mean = %v, budget = %v (regression in the refresh_policy.go decision layer)",
+			perfSweepDecisionN, got, budget)
+	}
+	t.Logf("adaptive-refresh sweep decision (%d sessions) trimmed mean = %v (budget = %v)", perfSweepDecisionN, got, budget)
+}

--- a/internal/ui/refresh_policy_test.go
+++ b/internal/ui/refresh_policy_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -382,7 +383,10 @@ func TestAdmitVisiblePolls_RoundRobinCoversAllDueRows(t *testing.T) {
 				inst: inst, fp: fp, deferrals: l.deferralCount(inst.ID),
 			})
 		}
-		admitted, deferred := admitVisiblePolls(candidates, "", budget)
+		// maxSkips huge: never large enough to force admission within these
+		// sweeps, so this test stays a pure round-robin check (the
+		// maxSkips-as-hard-floor behaviour has its own test below).
+		admitted, deferred := admitVisiblePolls(candidates, "", budget, 1000)
 		if len(admitted) != budget {
 			t.Fatalf("sweep %d admitted %d rows, want exactly the budget %d", s, len(admitted), budget)
 		}
@@ -414,7 +418,7 @@ func TestAdmitVisiblePolls_CursorRowIsNeverDeferred(t *testing.T) {
 		inst: &session.Instance{ID: "cursor-row"}, deferrals: 0,
 	})
 
-	admitted, deferred := admitVisiblePolls(candidates, "cursor-row", 10)
+	admitted, deferred := admitVisiblePolls(candidates, "cursor-row", 10, 1000)
 	for _, c := range deferred {
 		if c.inst.ID == "cursor-row" {
 			t.Fatal("cursor row was deferred by the budget")
@@ -422,6 +426,147 @@ func TestAdmitVisiblePolls_CursorRowIsNeverDeferred(t *testing.T) {
 	}
 	if len(admitted) == 0 || admitted[0].inst.ID != "cursor-row" {
 		t.Fatalf("cursor row should be admitted first, got %v", admitted)
+	}
+}
+
+// TestAdmitVisiblePolls_MaxSkipsBoundsStalenessRegardlessOfDueCount proves
+// the fix for the review's second HIGH finding: round-robin priority alone
+// only bounds staleness by ceil(due/budget) — a function of how many rows
+// happen to be due at once, not of maxSkips. Before this fix, a due set far
+// larger than budget*maxSkips could push an individual row's wait
+// arbitrarily past the "at most maxSkips sweeps stale" ceiling the design
+// doc promises for visible rows (e.g. 100 due rows at budget 10 and
+// maxSkips 2: the tail could wait up to 9 sweeps, not 2).
+//
+// This drives many more due rows than budget*maxSkips would allow under a
+// pure round-robin and asserts NO row is ever deferred more than maxSkips
+// consecutive times before being admitted — maxSkips must be a hard floor
+// that overrides the budget, not just a priority hint.
+func TestAdmitVisiblePolls_MaxSkipsBoundsStalenessRegardlessOfDueCount(t *testing.T) {
+	const due, budget, maxSkips = 137, 10, 3 // ceil(due/budget) = 14 sweeps under pure round-robin >> maxSkips
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	insts := make([]*session.Instance, due)
+	for i := range insts {
+		insts[i] = &session.Instance{ID: fmt.Sprintf("row-%03d", i)}
+	}
+
+	streak := make(map[string]int) // consecutive sweeps each row has been deferred
+	everAdmitted := make(map[string]bool)
+
+	for s := 0; s < 40; s++ { // far more sweeps than either bound would need
+		candidates := make([]visiblePollCandidate, 0, due)
+		for _, inst := range insts {
+			candidates = append(candidates, visiblePollCandidate{
+				inst: inst, fp: fp, deferrals: l.deferralCount(inst.ID),
+			})
+		}
+		admitted, deferred := admitVisiblePolls(candidates, "", budget, maxSkips)
+		for _, c := range admitted {
+			l.admitPoll(c.inst.ID, c.fp)
+			if streak[c.inst.ID] > maxSkips {
+				t.Fatalf("sweep %d: row %s waited %d consecutive sweeps before admission, want <= %d (maxSkips)",
+					s, c.inst.ID, streak[c.inst.ID], maxSkips)
+			}
+			streak[c.inst.ID] = 0
+			everAdmitted[c.inst.ID] = true
+		}
+		for _, c := range deferred {
+			l.deferPoll(c.inst.ID)
+			streak[c.inst.ID]++
+			if streak[c.inst.ID] > maxSkips {
+				t.Fatalf("sweep %d: row %s has been deferred %d consecutive times without being admitted, want <= %d (maxSkips)",
+					s, c.inst.ID, streak[c.inst.ID], maxSkips)
+			}
+		}
+	}
+	for _, inst := range insts {
+		if !everAdmitted[inst.ID] {
+			t.Fatalf("row %s was never admitted across 40 sweeps", inst.ID)
+		}
+	}
+}
+
+// TestAdmitVisiblePolls_MaxSkipsDisabledFallsBackToPureRoundRobin pins the
+// maxSkips<=0 branch: with the adaptive policy off (kill switch, or a
+// failed-open sweep) forced admission must not fire — callers already keep
+// visibleDue empty in that state, but the function itself must not depend on
+// that to stay safe.
+func TestAdmitVisiblePolls_MaxSkipsDisabledFallsBackToPureRoundRobin(t *testing.T) {
+	candidates := make([]visiblePollCandidate, 0, 20)
+	for i := 0; i < 20; i++ {
+		candidates = append(candidates, visiblePollCandidate{
+			inst: &session.Instance{ID: fmt.Sprintf("row-%d", i)}, deferrals: 999,
+		})
+	}
+	admitted, deferred := admitVisiblePolls(candidates, "", 5, 0)
+	if len(admitted) != 5 {
+		t.Fatalf("maxSkips<=0 must not force extra admissions: admitted = %d, want budget 5", len(admitted))
+	}
+	if len(deferred) != 15 {
+		t.Fatalf("maxSkips<=0 must not force extra admissions: deferred = %d, want 15", len(deferred))
+	}
+}
+
+// TestRefreshLedger_PipeIdleSkip_BoundsTheQuietPipeShortcut proves the fix
+// for the review's first HIGH finding: the sweep's PipeManager quiet-pipe
+// shortcut used to skip a session unconditionally for as long as
+// PipeManager reported no output, never reaching decide()/holdVisible() and
+// therefore never refreshing the session's ledger baseline — so
+// heldSteady() (the incremental visible-first path's read-only hold) could
+// hold that session forever. pipeIdleSkip shares the same skip counter and
+// ceiling as the fingerprint gate, so the shortcut can no longer hold a
+// session past maxSkips consecutive sweeps.
+func TestRefreshLedger_PipeIdleSkip_BoundsTheQuietPipeShortcut(t *testing.T) {
+	l := newRefreshLedger()
+	const maxSkips = 2
+
+	// A pipe that reports "no new output" every single sweep, indefinitely,
+	// must still eventually be forced open — the ceiling, not PipeManager,
+	// has the final say.
+	for round := 0; round < 5; round++ {
+		for i := 0; i < maxSkips; i++ {
+			if !l.pipeIdleSkip("piped-1", maxSkips) {
+				t.Fatalf("round %d, sweep %d: expected a skip (still under the ceiling)", round, i)
+			}
+		}
+		if l.pipeIdleSkip("piped-1", maxSkips) {
+			t.Fatalf("round %d: pipeIdleSkip must return false at the ceiling — a piped session cannot be held forever", round)
+		}
+		// The forced-open sweep resets the entry to a mismatching (unusable)
+		// baseline: the caller's fallthrough to decide()/holdVisible() is
+		// therefore guaranteed to see "fingerprint-changed" and actually poll.
+		entry, ok := ledgerEntry(l, "piped-1")
+		if !ok {
+			t.Fatalf("round %d: forced-open must leave a (reset) entry, not delete it", round)
+		}
+		if entry.skips != 0 || entry.fp.ok {
+			t.Fatalf("round %d: forced-open entry not reset: %+v", round, entry)
+		}
+	}
+}
+
+// TestRefreshLedger_PipeIdleSkip_KillSwitchIsUnconditional pins the
+// maxSkips<=0 branch: PipeManager alone decides, matching the pre-adaptive-
+// policy shortcut byte-for-byte (skip forever, no forced poll) — this
+// function must never introduce a ceiling the kill switch didn't ask for.
+func TestRefreshLedger_PipeIdleSkip_KillSwitchIsUnconditional(t *testing.T) {
+	l := newRefreshLedger()
+	for i := 0; i < 50; i++ {
+		if !l.pipeIdleSkip("piped-killswitch", 0) {
+			t.Fatalf("sweep %d: maxSkips<=0 must always skip (pre-policy behaviour)", i)
+		}
+	}
+}
+
+func TestRefreshLedger_PipeIdleSkip_NilSafety(t *testing.T) {
+	var nilLedger *refreshLedger
+	if !nilLedger.pipeIdleSkip("x", 2) {
+		t.Fatal("nil ledger must behave like the pre-policy shortcut: always skip")
+	}
+	l := newRefreshLedger()
+	if !l.pipeIdleSkip("", 2) {
+		t.Fatal("empty id must always skip (matches every other nil/empty-safe ledger method)")
 	}
 }
 

--- a/internal/ui/refresh_policy_test.go
+++ b/internal/ui/refresh_policy_test.go
@@ -1,0 +1,398 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Tests for the adaptive refresh policy (refresh-tick v2, issue #1753).
+//
+// The policy decides whether the background status sweep may skip
+// Instance.UpdateStatus() for one session this sweep. Getting it wrong in the
+// permissive direction means a session's status silently stops updating, so
+// every veto is pinned here, along with the two fail-open paths (no viewport
+// snapshot, no cheap evidence) that must degrade to the pre-policy behaviour of
+// polling everything.
+//
+// All of these run without a tmux server, a HOME, or a real Home constructor:
+// the decision function is pure and the ledger/viewport helpers touch only
+// plain struct fields and the seedable tmux caches.
+
+func quiescentFP() sessionFingerprint {
+	return sessionFingerprint{activity: 1000, title: "reviewing diff", command: "node", ok: true}
+}
+
+func TestShouldSkipStatusPoll_SkipsQuiescentOffscreenSession(t *testing.T) {
+	fp := quiescentFP()
+	skip, reason := shouldSkipStatusPoll(skipInput{
+		status: session.StatusWaiting, fp: fp, prev: fp, hasPrev: true, maxSkips: 2,
+	})
+	if !skip {
+		t.Fatalf("quiescent off-screen session should be skipped, got poll (%s)", reason)
+	}
+	if reason != "quiescent" {
+		t.Fatalf("reason = %q, want %q", reason, "quiescent")
+	}
+}
+
+func TestShouldSkipStatusPoll_Vetoes(t *testing.T) {
+	fp := quiescentFP()
+	changed := fp
+	changed.activity = 1001
+
+	cases := []struct {
+		name       string
+		in         skipInput
+		wantReason string
+	}{
+		{
+			name:       "visible rows are never skipped",
+			in:         skipInput{visible: true, status: session.StatusWaiting, fp: fp, prev: fp, hasPrev: true, maxSkips: 2},
+			wantReason: "visible",
+		},
+		{
+			name:       "error status keeps its own recheck cadence",
+			in:         skipInput{status: session.StatusError, fp: fp, prev: fp, hasPrev: true, maxSkips: 2},
+			wantReason: "status-unsettled",
+		},
+		{
+			name:       "starting status must converge fast",
+			in:         skipInput{status: session.StatusStarting, fp: fp, prev: fp, hasPrev: true, maxSkips: 2},
+			wantReason: "status-unsettled",
+		},
+		{
+			name:       "stopped status is not held",
+			in:         skipInput{status: session.StatusStopped, fp: fp, prev: fp, hasPrev: true, maxSkips: 2},
+			wantReason: "status-unsettled",
+		},
+		{
+			name:       "no baseline yet",
+			in:         skipInput{status: session.StatusIdle, fp: fp, maxSkips: 2},
+			wantReason: "no-baseline",
+		},
+		{
+			name:       "fingerprint changed",
+			in:         skipInput{status: session.StatusRunning, fp: changed, prev: fp, hasPrev: true, maxSkips: 2},
+			wantReason: "fingerprint-changed",
+		},
+		{
+			name:       "unusable current fingerprint is no evidence",
+			in:         skipInput{status: session.StatusRunning, fp: sessionFingerprint{}, prev: fp, hasPrev: true, maxSkips: 2},
+			wantReason: "fingerprint-changed",
+		},
+		{
+			name:       "unusable baseline is no evidence",
+			in:         skipInput{status: session.StatusRunning, fp: fp, prev: sessionFingerprint{}, hasPrev: true, maxSkips: 2},
+			wantReason: "fingerprint-changed",
+		},
+		{
+			name:       "staleness ceiling reached",
+			in:         skipInput{status: session.StatusWaiting, fp: fp, prev: fp, hasPrev: true, skips: 2, maxSkips: 2},
+			wantReason: "staleness-ceiling",
+		},
+		{
+			name:       "policy disabled",
+			in:         skipInput{status: session.StatusWaiting, fp: fp, prev: fp, hasPrev: true, maxSkips: 0},
+			wantReason: "policy-disabled",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			skip, reason := shouldSkipStatusPoll(tc.in)
+			if skip {
+				t.Fatalf("expected poll, got skip (%s)", reason)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// A quiescent session must be polled at least once every maxSkips+1 sweeps even
+// though its fingerprint never changes. This is the bound that keeps the
+// time-based transitions inside UpdateStatus (acknowledged -> idle, hook
+// freshness expiry, debounce confirmation) from being suppressed indefinitely.
+func TestRefreshLedger_PollsAtCeilingDespiteUnchangedFingerprint(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+
+	// Sweep 1 establishes the baseline and must poll.
+	if skip, reason := l.decide("s1", fp, session.StatusWaiting, false, 2); skip {
+		t.Fatalf("sweep 1 should poll to establish a baseline, got skip (%s)", reason)
+	}
+
+	got := make([]bool, 0, 7)
+	for i := 0; i < 7; i++ {
+		skip, _ := l.decide("s1", fp, session.StatusWaiting, false, 2)
+		got = append(got, skip)
+	}
+	want := []bool{true, true, false, true, true, false, true}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("skip pattern = %v, want %v (poll every 3rd sweep)", got, want)
+	}
+}
+
+func TestRefreshLedger_ChangedFingerprintResetsTheCounter(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+
+	l.decide("s1", fp, session.StatusRunning, false, 2) // baseline
+	if skip, _ := l.decide("s1", fp, session.StatusRunning, false, 2); !skip {
+		t.Fatal("second sweep on an unchanged fingerprint should skip")
+	}
+
+	moved := fp
+	moved.activity++
+	if skip, reason := l.decide("s1", moved, session.StatusRunning, false, 2); skip {
+		t.Fatalf("changed fingerprint must poll, got skip (%s)", reason)
+	}
+	// The poll rebased the ledger on the new fingerprint, so the counter
+	// restarts: two more skips are available before the ceiling.
+	for i := 0; i < 2; i++ {
+		if skip, reason := l.decide("s1", moved, session.StatusRunning, false, 2); !skip {
+			t.Fatalf("post-change sweep %d should skip, got poll (%s)", i+1, reason)
+		}
+	}
+	if skip, _ := l.decide("s1", moved, session.StatusRunning, false, 2); skip {
+		t.Fatal("ceiling should force a poll after two post-change skips")
+	}
+}
+
+func TestRefreshLedger_ForgetForcesAPoll(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	l.decide("s1", fp, session.StatusWaiting, false, 2)
+	if skip, _ := l.decide("s1", fp, session.StatusWaiting, false, 2); !skip {
+		t.Fatal("precondition: unchanged fingerprint should skip")
+	}
+	l.forget("s1")
+	if skip, reason := l.decide("s1", fp, session.StatusWaiting, false, 2); skip {
+		t.Fatalf("forget() must force the next sweep to poll, got skip (%s)", reason)
+	}
+}
+
+func TestRefreshLedger_PruneDropsDepartedSessions(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	l.decide("keep", fp, session.StatusIdle, false, 2)
+	l.decide("gone", fp, session.StatusIdle, false, 2)
+
+	l.prune(map[string]struct{}{"keep": {}})
+
+	l.mu.Lock()
+	_, keptKeep := l.entries["keep"]
+	_, keptGone := l.entries["gone"]
+	l.mu.Unlock()
+	if !keptKeep {
+		t.Fatal("prune dropped a live session's baseline")
+	}
+	if keptGone {
+		t.Fatal("prune kept a departed session's baseline")
+	}
+}
+
+// A nil ledger (alternate/test Home constructors never build one) must behave
+// like the policy does not exist: poll everything, never panic.
+func TestRefreshLedger_NilReceiverAlwaysPolls(t *testing.T) {
+	var l *refreshLedger
+	if skip, reason := l.decide("s1", quiescentFP(), session.StatusWaiting, false, 2); skip {
+		t.Fatalf("nil ledger must poll, got skip (%s)", reason)
+	}
+	l.forget("s1")
+	l.prune(nil)
+}
+
+func TestAdaptiveRefreshMaxSkips(t *testing.T) {
+	if got := adaptiveRefreshMaxSkips(0); got != defaultAdaptiveRefreshMaxSkips {
+		t.Fatalf("unset = %d, want default %d", got, defaultAdaptiveRefreshMaxSkips)
+	}
+	if got := adaptiveRefreshMaxSkips(5); got != 5 {
+		t.Fatalf("explicit 5 = %d, want 5", got)
+	}
+	// Negative is the documented kill switch: 0 disables the gate entirely.
+	if got := adaptiveRefreshMaxSkips(-1); got != 0 {
+		t.Fatalf("negative = %d, want 0 (policy disabled)", got)
+	}
+}
+
+// ---- fingerprint ----
+
+func TestFingerprintSession_UsesCachesAndTracksPaneTitle(t *testing.T) {
+	const tmuxName = "agentdeck-fp-test-A"
+	inst := instWithTmuxName(t, "fp-A", tmuxName)
+	h := newHomeForSnapshotTest()
+
+	tmux.SeedSessionActivityCacheForTest(t, map[string]int64{tmuxName: 4242})
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		tmuxName: {Title: "task one", CurrentCommand: "node"},
+	})
+
+	first := h.fingerprintSession(inst)
+	if !first.ok {
+		t.Fatal("fingerprint should be usable when both caches are fresh")
+	}
+	if first.activity != 4242 || first.title != "task one" || first.command != "node" {
+		t.Fatalf("fingerprint = %+v, want activity 4242 / title \"task one\" / command \"node\"", first)
+	}
+	if second := h.fingerprintSession(inst); !second.unchangedFrom(first) {
+		t.Fatalf("re-fingerprinting an unchanged session must match: %+v vs %+v", second, first)
+	}
+
+	// A new pane title alone (same activity second) must break the match: the
+	// OSC title is how Claude signals spinner/done transitions.
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		tmuxName: {Title: "task two", CurrentCommand: "node"},
+	})
+	if retitled := h.fingerprintSession(inst); retitled.unchangedFrom(first) {
+		t.Fatal("a changed pane title must produce a different fingerprint")
+	}
+}
+
+func TestFingerprintSession_NoEvidenceWhenCachesMissing(t *testing.T) {
+	const tmuxName = "agentdeck-fp-test-B"
+	inst := instWithTmuxName(t, "fp-B", tmuxName)
+	h := newHomeForSnapshotTest()
+
+	// Activity cache seeded, pane cache absent -> no evidence.
+	tmux.SeedSessionActivityCacheForTest(t, map[string]int64{tmuxName: 7})
+	if fp := h.fingerprintSession(inst); fp.ok {
+		t.Fatal("missing pane info must yield an unusable fingerprint")
+	}
+
+	// Pane cache present but stale -> still no evidence.
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{tmuxName: {Title: "x"}})
+	tmux.ExpirePaneInfoCacheForTest(t)
+	if fp := h.fingerprintSession(inst); fp.ok {
+		t.Fatal("stale pane cache must yield an unusable fingerprint")
+	}
+
+	// A session with no tmux session at all -> no evidence.
+	if fp := h.fingerprintSession(&session.Instance{ID: "no-tmux"}); fp.ok {
+		t.Fatal("instance without a tmux session must yield an unusable fingerprint")
+	}
+	if fp := h.fingerprintSession(nil); fp.ok {
+		t.Fatal("nil instance must yield an unusable fingerprint")
+	}
+}
+
+// ---- viewport publication ----
+
+func TestPublishVisibleSessions_CoversViewportAndCursor(t *testing.T) {
+	h := &Home{height: 14} // visibleRowBudget() = 6
+	inA := &session.Instance{ID: "a"}
+	inB := &session.Instance{ID: "b"}
+	offscreen := &session.Instance{ID: "z"}
+	h.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inA},
+		{Type: session.ItemTypeWindow, WindowSessionID: "b-parent"},
+		{Type: session.ItemTypeSession, Session: inB},
+		{Type: session.ItemTypeGroup},
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "d"}},
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "e"}},
+		{Type: session.ItemTypeSession, Session: offscreen},
+	}
+	h.viewOffset = 0
+	h.cursor = 6 // selected row is below the viewport window
+
+	h.publishVisibleSessions("attached-1")
+
+	ids, ok := h.visibleSessionsForSweep()
+	if !ok {
+		t.Fatal("freshly published viewport should be usable")
+	}
+	for _, want := range []string{"a", "b-parent", "b", "d", "e", "z", "attached-1"} {
+		if _, found := ids[want]; !found {
+			t.Fatalf("visible set missing %q: %v", want, ids)
+		}
+	}
+}
+
+func TestVisibleSessionsForSweep_FailsOpen(t *testing.T) {
+	// Never published: the sweep must not trust an absent snapshot.
+	h := &Home{}
+	if _, ok := h.visibleSessionsForSweep(); ok {
+		t.Fatal("unpublished viewport must report unusable so the sweep polls everything")
+	}
+
+	// Published but older than visibleSessionsMaxAge (TUI suspended by
+	// tea.Exec, or the event loop wedged): also unusable.
+	h.visibleSessions.Store(visibleSessionSnapshot{
+		ids: map[string]struct{}{"a": {}},
+		at:  time.Now().Add(-2 * visibleSessionsMaxAge),
+	})
+	if _, ok := h.visibleSessionsForSweep(); ok {
+		t.Fatal("stale viewport must report unusable so the sweep polls everything")
+	}
+}
+
+// ---- render snapshot generation skip ----
+
+// refreshSessionRenderSnapshot is called from several sweep/tick paths and used
+// to allocate and publish a fresh N-entry map every time. When nothing changed
+// it must publish nothing at all — asserted by map identity, since a rebuild
+// necessarily produces a different map.
+func TestRefreshSessionRenderSnapshot_SkipsRebuildWhenUnchanged(t *testing.T) {
+	const tmuxName = "agentdeck-gen-skip-A"
+	inst := instWithTmuxName(t, "gen-A", tmuxName)
+	h := newHomeForSnapshotTest()
+
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{tmuxName: {Title: "task one"}})
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	first := h.getSessionRenderSnapshot()
+	if first[inst.ID].paneTitle != "task one" {
+		t.Fatalf("first refresh: paneTitle = %q, want %q", first[inst.ID].paneTitle, "task one")
+	}
+
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	if second := h.getSessionRenderSnapshot(); mapIdentity(second) != mapIdentity(first) {
+		t.Fatal("unchanged refresh republished a new snapshot map instead of skipping")
+	}
+
+	// A real change must still land.
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{tmuxName: {Title: "task two"}})
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	third := h.getSessionRenderSnapshot()
+	if mapIdentity(third) == mapIdentity(first) {
+		t.Fatal("changed pane title should have republished the snapshot")
+	}
+	if third[inst.ID].paneTitle != "task two" {
+		t.Fatalf("paneTitle = %q, want %q", third[inst.ID].paneTitle, "task two")
+	}
+}
+
+// A session leaving the deck changes the snapshot's membership even when every
+// surviving entry is byte-identical, so the rebuild must not be skipped.
+func TestRefreshSessionRenderSnapshot_RebuildsWhenSessionCountChanges(t *testing.T) {
+	const nameA, nameB = "agentdeck-gen-skip-B1", "agentdeck-gen-skip-B2"
+	instA := instWithTmuxName(t, "gen-B1", nameA)
+	instB := instWithTmuxName(t, "gen-B2", nameB)
+	h := newHomeForSnapshotTest()
+
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		nameA: {Title: "task one"},
+		nameB: {Title: "task two"},
+	})
+	h.refreshSessionRenderSnapshot([]*session.Instance{instA, instB})
+	if got := len(h.getSessionRenderSnapshot()); got != 2 {
+		t.Fatalf("snapshot size = %d, want 2", got)
+	}
+
+	h.refreshSessionRenderSnapshot([]*session.Instance{instA})
+	snap := h.getSessionRenderSnapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snapshot size after removal = %d, want 1 (%v)", len(snap), snap)
+	}
+	if _, stillThere := snap[instB.ID]; stillThere {
+		t.Fatal("removed session still present in the snapshot")
+	}
+}
+
+func mapIdentity(m map[string]sessionRenderState) uintptr {
+	return reflect.ValueOf(m).Pointer()
+}

--- a/internal/ui/refresh_policy_test.go
+++ b/internal/ui/refresh_policy_test.go
@@ -208,19 +208,6 @@ func TestRefreshLedger_NilReceiverAlwaysPolls(t *testing.T) {
 	l.prune(nil)
 }
 
-func TestAdaptiveRefreshMaxSkips(t *testing.T) {
-	if got := adaptiveRefreshMaxSkips(0); got != defaultAdaptiveRefreshMaxSkips {
-		t.Fatalf("unset = %d, want default %d", got, defaultAdaptiveRefreshMaxSkips)
-	}
-	if got := adaptiveRefreshMaxSkips(5); got != 5 {
-		t.Fatalf("explicit 5 = %d, want 5", got)
-	}
-	// Negative is the documented kill switch: 0 disables the gate entirely.
-	if got := adaptiveRefreshMaxSkips(-1); got != 0 {
-		t.Fatalf("negative = %d, want 0 (policy disabled)", got)
-	}
-}
-
 // ---- fingerprint ----
 
 func TestFingerprintSession_UsesCachesAndTracksPaneTitle(t *testing.T) {
@@ -281,6 +268,237 @@ func TestFingerprintSession_NoEvidenceWhenCachesMissing(t *testing.T) {
 	}
 }
 
+// ---- visible-row hold + budget (issue #1753 group-expand case) ----
+
+// A VISIBLE row with a settled status and an unchanged fingerprint is held
+// under the same ceiling as an off-screen row: hold, hold, then forced poll.
+// This is what makes an expanded 60-row group cost ~zero when quiescent.
+func TestRefreshLedger_HoldVisibleRespectsCeiling(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	l.admitPoll("v1", fp) // baseline from a real poll
+
+	for i := 0; i < 2; i++ {
+		if !l.holdVisible("v1", fp, session.StatusWaiting, 2) {
+			t.Fatalf("hold %d: settled visible row with unchanged fingerprint should be held", i+1)
+		}
+	}
+	if l.holdVisible("v1", fp, session.StatusWaiting, 2) {
+		t.Fatal("ceiling reached: third consecutive hold must be refused")
+	}
+	// The refused hold makes the row a budget candidate; an admitted poll
+	// rebases and the cycle restarts.
+	l.admitPoll("v1", fp)
+	if !l.holdVisible("v1", fp, session.StatusWaiting, 2) {
+		t.Fatal("post-poll hold should be available again")
+	}
+}
+
+func TestRefreshLedger_HoldVisibleVetoes(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	changed := fp
+	changed.activity++
+	l.admitPoll("v1", fp)
+
+	if l.holdVisible("v1", changed, session.StatusWaiting, 2) {
+		t.Fatal("changed fingerprint must not be held")
+	}
+	if l.holdVisible("v1", sessionFingerprint{}, session.StatusWaiting, 2) {
+		t.Fatal("unusable fingerprint must not be held")
+	}
+	if l.holdVisible("v1", fp, session.StatusStarting, 2) {
+		t.Fatal("unsettled status must not be held")
+	}
+	if l.holdVisible("v1", fp, session.StatusWaiting, 0) {
+		t.Fatal("kill switch (maxSkips<=0) must not hold")
+	}
+	if l.holdVisible("no-baseline", fp, session.StatusWaiting, 2) {
+		t.Fatal("row without a polled baseline must not be held")
+	}
+	var nilLedger *refreshLedger
+	if nilLedger.holdVisible("v1", fp, session.StatusWaiting, 2) {
+		t.Fatal("nil ledger must never hold")
+	}
+	// None of the refused holds may have advanced the ceiling counter.
+	if !l.holdVisible("v1", fp, session.StatusWaiting, 1) {
+		t.Fatal("refused holds must not consume the ceiling (skips should still be 0)")
+	}
+}
+
+// heldSteady is the read-only hold used by processStatusUpdate's visible pass.
+// It must never advance the ceiling counter — the background sweep owns
+// freshness — so an arbitrary number of held passes leaves the sweep-side
+// hold/poll pattern untouched.
+func TestRefreshLedger_HeldSteadyIsReadOnly(t *testing.T) {
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	changed := fp
+	changed.title = "typing"
+	l.admitPoll("v1", fp)
+
+	for i := 0; i < 50; i++ {
+		if !l.heldSteady("v1", fp, session.StatusIdle) {
+			t.Fatalf("pass %d: steady visible row should be held read-only", i)
+		}
+	}
+	if l.heldSteady("v1", changed, session.StatusIdle) {
+		t.Fatal("changed fingerprint must not be held")
+	}
+	if l.heldSteady("v1", fp, session.StatusError) {
+		t.Fatal("unsettled status must not be held")
+	}
+	var nilLedger *refreshLedger
+	if nilLedger.heldSteady("v1", fp, session.StatusIdle) {
+		t.Fatal("nil ledger must never hold")
+	}
+	// 50 read-only holds consumed none of the sweep ceiling: both sweep-side
+	// holds must still be available.
+	for i := 0; i < 2; i++ {
+		if !l.holdVisible("v1", fp, session.StatusIdle, 2) {
+			t.Fatalf("sweep hold %d should still be available after read-only holds", i+1)
+		}
+	}
+}
+
+// The budget must cycle: over ceil(due/budget) sweeps every due visible row is
+// polled at least once, because deferred rows age (deferrals++) and admission
+// orders most-starved first.
+func TestAdmitVisiblePolls_RoundRobinCoversAllDueRows(t *testing.T) {
+	const due, budget = 25, 10
+	l := newRefreshLedger()
+	fp := quiescentFP()
+	insts := make([]*session.Instance, due)
+	for i := range insts {
+		insts[i] = &session.Instance{ID: string(rune('A' + i))}
+	}
+
+	polled := make(map[string]int)
+	sweeps := (due + budget - 1) / budget // 3
+	for s := 0; s < sweeps; s++ {
+		candidates := make([]visiblePollCandidate, 0, due)
+		for _, inst := range insts {
+			candidates = append(candidates, visiblePollCandidate{
+				inst: inst, fp: fp, deferrals: l.deferralCount(inst.ID),
+			})
+		}
+		admitted, deferred := admitVisiblePolls(candidates, "", budget)
+		if len(admitted) != budget {
+			t.Fatalf("sweep %d admitted %d rows, want exactly the budget %d", s, len(admitted), budget)
+		}
+		for _, c := range admitted {
+			l.admitPoll(c.inst.ID, c.fp)
+			polled[c.inst.ID]++
+		}
+		for _, c := range deferred {
+			l.deferPoll(c.inst.ID)
+		}
+	}
+	for _, inst := range insts {
+		if polled[inst.ID] == 0 {
+			t.Fatalf("row %s was never polled in %d sweeps (budget starvation)", inst.ID, sweeps)
+		}
+	}
+}
+
+// The cursor row is what the preview pane shows: it must always be in the
+// admitted prefix, even when it is the least-starved candidate.
+func TestAdmitVisiblePolls_CursorRowIsNeverDeferred(t *testing.T) {
+	candidates := make([]visiblePollCandidate, 0, 15)
+	for i := 0; i < 15; i++ {
+		candidates = append(candidates, visiblePollCandidate{
+			inst: &session.Instance{ID: string(rune('a' + i))}, deferrals: 5,
+		})
+	}
+	candidates = append(candidates, visiblePollCandidate{
+		inst: &session.Instance{ID: "cursor-row"}, deferrals: 0,
+	})
+
+	admitted, deferred := admitVisiblePolls(candidates, "cursor-row", 10)
+	for _, c := range deferred {
+		if c.inst.ID == "cursor-row" {
+			t.Fatal("cursor row was deferred by the budget")
+		}
+	}
+	if len(admitted) == 0 || admitted[0].inst.ID != "cursor-row" {
+		t.Fatalf("cursor row should be admitted first, got %v", admitted)
+	}
+}
+
+// The hook and SSE UpdatedAt inputs are what make the "real transitions are
+// not delayed" argument true for event-driven tools: a Stop /Notification/
+// PermissionRequest hook (or an OpenCode /event sample) moves the fingerprint
+// even when the tmux-side evidence (activity/title/command) is unchanged, so
+// the very next sweep polls instead of holding the skip. Pinned here because
+// fingerprintSession is the ONLY reader of these inputs — nothing else fails
+// if they are dropped.
+func TestFingerprintSession_HookAndSSEInputsMoveTheFingerprint(t *testing.T) {
+	const tmuxName = "agentdeck-fp-test-C"
+	inst := instWithTmuxName(t, "fp-C", tmuxName)
+	h := newHomeForSnapshotTest()
+	h.hookWatcher = session.NewStatusFileWatcherForTest(t)
+	h.sseWatcher = session.NewOpenCodeSSEWatcher(nil)
+
+	tmux.SeedSessionActivityCacheForTest(t, map[string]int64{tmuxName: 4242})
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		tmuxName: {Title: "steady", CurrentCommand: "node"},
+	})
+
+	base := h.fingerprintSession(inst)
+	if !base.ok {
+		t.Fatal("fingerprint should be usable with fresh tmux caches")
+	}
+	if base.hookAt != 0 || base.sseAt != 0 {
+		t.Fatalf("no watcher entries yet: hookAt/sseAt should be 0, got %+v", base)
+	}
+	if again := h.fingerprintSession(inst); !again.unchangedFrom(base) {
+		t.Fatalf("steady state must re-fingerprint identically: %+v vs %+v", again, base)
+	}
+
+	// A Stop hook lands. tmux evidence is untouched, but hookAt must move the
+	// fingerprint so the next sweep polls the transition immediately.
+	hookTime := time.Now()
+	h.hookWatcher.SetHookStatusForTest(t, inst.ID, &session.HookStatus{
+		Status: "waiting", Event: "Stop", UpdatedAt: hookTime,
+	})
+	withHook := h.fingerprintSession(inst)
+	if withHook.unchangedFrom(base) {
+		t.Fatal("a delivered hook must change the fingerprint even with unchanged tmux evidence")
+	}
+	if withHook.hookAt != hookTime.UnixNano() {
+		t.Fatalf("hookAt = %d, want the hook's UpdatedAt %d", withHook.hookAt, hookTime.UnixNano())
+	}
+
+	// A re-delivered hook with identical content but a newer UpdatedAt is a
+	// new event and must move the fingerprint again.
+	h.hookWatcher.SetHookStatusForTest(t, inst.ID, &session.HookStatus{
+		Status: "waiting", Event: "Stop", UpdatedAt: hookTime.Add(time.Second),
+	})
+	rehooked := h.fingerprintSession(inst)
+	if rehooked.unchangedFrom(withHook) {
+		t.Fatal("a re-delivered hook with a newer UpdatedAt must change the fingerprint")
+	}
+
+	// An OpenCode SSE sample moves sseAt the same way (issue #1614).
+	sseTime := time.Now()
+	h.sseWatcher.SetStatusForTest(t, inst.ID, &session.OpenCodeSSEStatus{
+		Status: "running", UpdatedAt: sseTime,
+	})
+	withSSE := h.fingerprintSession(inst)
+	if withSSE.unchangedFrom(rehooked) {
+		t.Fatal("an SSE status sample must change the fingerprint")
+	}
+	if withSSE.sseAt != sseTime.UnixNano() {
+		t.Fatalf("sseAt = %d, want the sample's UpdatedAt %d", withSSE.sseAt, sseTime.UnixNano())
+	}
+
+	// Back to steady state: with all inputs unchanged the fingerprint is
+	// stable again, i.e. the session is once more eligible for the skip.
+	if settled := h.fingerprintSession(inst); !settled.unchangedFrom(withSSE) {
+		t.Fatalf("unchanged hook+SSE inputs must re-fingerprint identically: %+v vs %+v", settled, withSSE)
+	}
+}
+
 // ---- viewport publication ----
 
 func TestPublishVisibleSessions_CoversViewportAndCursor(t *testing.T) {
@@ -302,14 +520,19 @@ func TestPublishVisibleSessions_CoversViewportAndCursor(t *testing.T) {
 
 	h.publishVisibleSessions("attached-1")
 
-	ids, ok := h.visibleSessionsForSweep()
+	snap, ok := h.visibleSessionsForSweep()
 	if !ok {
 		t.Fatal("freshly published viewport should be usable")
 	}
 	for _, want := range []string{"a", "b-parent", "b", "d", "e", "z", "attached-1"} {
-		if _, found := ids[want]; !found {
-			t.Fatalf("visible set missing %q: %v", want, ids)
+		if _, found := snap.ids[want]; !found {
+			t.Fatalf("visible set missing %q: %v", want, snap.ids)
 		}
+	}
+	// The selected row is published as the cursor ID so the sweep's visible
+	// budget can never defer the row the preview pane is showing.
+	if snap.cursorID != "z" {
+		t.Fatalf("cursorID = %q, want %q (the selected row)", snap.cursorID, "z")
 	}
 }
 

--- a/internal/ui/refresh_wiring_test.go
+++ b/internal/ui/refresh_wiring_test.go
@@ -1,0 +1,254 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Safety-WIRING tests for the adaptive refresh policy (issue #1753, PR #1765).
+//
+// refresh_policy_test.go pins the policy functions; these tests pin the two
+// call sites in home.go that make the policy safe, by driving the REAL
+// backgroundStatusUpdate / refreshAttachedSessionStatus on a constructed Home.
+// The repo's documented recurring failure mode is exactly "the policy is
+// correct but the wiring line was dropped and the suite stayed green", so each
+// test here is built to FAIL if its wiring line is deleted:
+//
+//  1. The fail-open line (backgroundStatusUpdate: `maxSkips = 0` when no fresh
+//     viewport snapshot exists). Entering the adaptive gate always rewrites the
+//     session's ledger entry — decide() records every outcome — so these tests
+//     seed a ledger baseline with a nonzero skip count and assert it is left
+//     UNTOUCHED when the snapshot is nil/untyped/stale. Delete the line and
+//     the sweep consults the gate anyway, the entry is rewritten (skips reset
+//     to 0, fingerprint rebased), and the assertion fails.
+//
+//  2. The attach-return invalidation (refreshAttachedSessionStatus:
+//     `h.refreshLedger.forget(inst.ID)`). The test seeds a baseline and
+//     asserts the entry is GONE after attach-return. Delete the line and the
+//     entry survives, and the assertion fails.
+//
+// These run without a tmux server: SeedServerAliveForTest pins the fast-fail
+// probe open, and every subprocess the sweep attempts fails fast and lands on
+// the "session is gone" path, which is itself part of the assertion (a polled
+// row's status must leave running; a skipped row's must not).
+
+// newWiringHome builds the minimal Home backgroundStatusUpdate needs, with the
+// adaptive policy armed exactly as the production constructor arms it
+// (home.go: newRefreshLedger + defaultAdaptiveRefreshMaxSkips).
+func newWiringHome(t *testing.T, instances ...*session.Instance) *Home {
+	t.Helper()
+	h := &Home{}
+	h.sessionRenderSnapshot.Store(make(map[string]sessionRenderState))
+	h.refreshLedger = newRefreshLedger()
+	h.adaptiveMaxSkips = defaultAdaptiveRefreshMaxSkips
+	h.lastPersistedStatus = make(map[string]string)
+	h.lastPersistedAutoNameDesc = make(map[string]string)
+	h.clearOnCompactSent = make(map[string]time.Time)
+	h.instances = instances
+	h.instanceByID = make(map[string]*session.Instance, len(instances))
+	for _, inst := range instances {
+		h.instanceByID[inst.ID] = inst
+	}
+	return h
+}
+
+// runningInst returns an Instance in StatusRunning with a (nonexistent) tmux
+// session attached, so a real UpdateStatus poll observably moves its status
+// off running while a skipped poll leaves it untouched.
+func runningInst(t *testing.T, id, tmuxName string) *session.Instance {
+	t.Helper()
+	inst := instWithTmuxName(t, id, tmuxName)
+	inst.Status = session.StatusRunning
+	return inst
+}
+
+// seedLedgerBaseline drives the ledger to entry {fp, skips: 1} for id — the
+// state a quiescent off-screen session is in mid-hold. Returns the baseline
+// fingerprint so tests can assert the entry was left untouched.
+func seedLedgerBaseline(t *testing.T, l *refreshLedger, id string) sessionFingerprint {
+	t.Helper()
+	fp := sessionFingerprint{activity: 4242, title: "quiet", command: "node", ok: true}
+	if skip, reason := l.decide(id, fp, session.StatusWaiting, false, 2); skip {
+		t.Fatalf("seed: baseline sweep must poll, got skip (%s)", reason)
+	}
+	if skip, reason := l.decide(id, fp, session.StatusWaiting, false, 2); !skip {
+		t.Fatalf("seed: second sweep must skip to reach skips=1, got poll (%s)", reason)
+	}
+	return fp
+}
+
+func ledgerEntry(l *refreshLedger, id string) (refreshLedgerEntry, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e, ok := l.entries[id]
+	return e, ok
+}
+
+// TestBackgroundStatusUpdate_FailsOpenWithoutFreshViewportSnapshot drives the
+// real sweep with the three snapshot states that must force maxSkips=0 (gate
+// bypassed entirely, every row polls): never published, published with the
+// wrong type, and published but older than visibleSessionsMaxAge.
+//
+// Catches deletion of the `maxSkips = 0` fail-open in backgroundStatusUpdate:
+// without it the gate runs, decide() rewrites the seeded ledger entry
+// (skips 1 -> 0, fingerprint rebased), and the untouched-entry assertion
+// fails.
+func TestBackgroundStatusUpdate_FailsOpenWithoutFreshViewportSnapshot(t *testing.T) {
+	cases := []struct {
+		name    string
+		publish func(h *Home)
+	}{
+		{
+			name:    "no snapshot ever published",
+			publish: func(h *Home) {},
+		},
+		{
+			name: "snapshot of the wrong type",
+			publish: func(h *Home) {
+				h.visibleSessions.Store("not a visibleSessionSnapshot")
+			},
+		},
+		{
+			name: "snapshot older than visibleSessionsMaxAge",
+			publish: func(h *Home) {
+				h.visibleSessions.Store(visibleSessionSnapshot{
+					ids: map[string]struct{}{"wiring-onscreen-" + h.instances[0].ID: {}},
+					at:  time.Now().Add(-visibleSessionsMaxAge - time.Second),
+				})
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmux.SeedServerAliveForTest(t, true)
+			suffix := string(rune('A' + i))
+			instA := runningInst(t, "wiring-a-"+suffix, "agentdeck-wiring-a-"+suffix)
+			instB := runningInst(t, "wiring-b-"+suffix, "agentdeck-wiring-b-"+suffix)
+			h := newWiringHome(t, instA, instB)
+			heldFP := seedLedgerBaseline(t, h.refreshLedger, instB.ID)
+			tc.publish(h)
+
+			h.backgroundStatusUpdate()
+
+			// Every row polled: a real UpdateStatus against a nonexistent tmux
+			// session moves the status off running. A held row would still be
+			// running.
+			if got := instA.GetStatusThreadSafe(); got == session.StatusRunning {
+				t.Fatalf("instA was not polled: status still %q", got)
+			}
+			if got := instB.GetStatusThreadSafe(); got == session.StatusRunning {
+				t.Fatalf("instB was not polled: status still %q", got)
+			}
+
+			// The gate was BYPASSED, not merely vetoed: decide() records every
+			// consultation, so the seeded entry must be byte-identical. If the
+			// fail-open `maxSkips = 0` line is deleted the gate runs, polls on
+			// the unusable in-sweep fingerprint, and rewrites this entry
+			// (skips -> 0, fingerprint rebased) — failing here.
+			entry, ok := ledgerEntry(h.refreshLedger, instB.ID)
+			if !ok {
+				t.Fatal("seeded ledger entry disappeared during a failed-open sweep")
+			}
+			if entry.skips != 1 || entry.fp != heldFP {
+				t.Fatalf("failed-open sweep touched the ledger: entry = %+v (skips %d), want fp %+v with skips 1",
+					entry.fp, entry.skips, heldFP)
+			}
+		})
+	}
+}
+
+// TestBackgroundStatusUpdate_ConsultsGateWithFreshSnapshot is the positive
+// control for the fail-open test above: with a FRESH viewport snapshot the
+// sweep must consult the gate, which records its verdict in the ledger. This
+// pins the gate wiring itself (delete the whole `if maxSkips > 0` block and
+// the entry stays untouched, failing here) so the fail-open test's
+// "entry untouched" assertion cannot be trivially satisfied by the gate never
+// existing.
+func TestBackgroundStatusUpdate_ConsultsGateWithFreshSnapshot(t *testing.T) {
+	tmux.SeedServerAliveForTest(t, true)
+	instOff := runningInst(t, "wiring-fresh-off", "agentdeck-wiring-fresh-off")
+	h := newWiringHome(t, instOff)
+	seedLedgerBaseline(t, h.refreshLedger, instOff.ID)
+	h.visibleSessions.Store(visibleSessionSnapshot{
+		ids: map[string]struct{}{"some-other-visible-row": {}},
+		at:  time.Now(),
+	})
+
+	h.backgroundStatusUpdate()
+
+	// The in-sweep fingerprint for a session with no live tmux backing is
+	// unusable (ok=false), so the consulted gate must POLL and rebase the
+	// entry: skips reset to 0, baseline no longer the seeded one.
+	entry, ok := ledgerEntry(h.refreshLedger, instOff.ID)
+	if !ok {
+		t.Fatal("gate consultation should have recorded a ledger entry")
+	}
+	if entry.skips != 0 {
+		t.Fatalf("consulted gate must reset the skip counter on poll, got skips=%d", entry.skips)
+	}
+	if entry.fp.ok {
+		t.Fatalf("in-sweep fingerprint for a dead session must be unusable, got %+v", entry.fp)
+	}
+	if got := instOff.GetStatusThreadSafe(); got == session.StatusRunning {
+		t.Fatalf("unusable fingerprint must force a poll: status still %q", got)
+	}
+}
+
+// TestBackgroundStatusUpdate_VisibleDueRowIsAdmittedAndRebased pins the
+// visible-row half of the gate (issue #1753 group-expand case): a VISIBLE row
+// whose fingerprint evidence is absent must not be held — it becomes a budget
+// candidate, is admitted (well under visiblePollBudgetPerSweep), gets its
+// ledger baseline rebased by admitPoll, and is actually polled. Catches
+// deletion of the admission block in backgroundStatusUpdate: without it a due
+// visible row is never polled and the seeded entry survives unchanged.
+func TestBackgroundStatusUpdate_VisibleDueRowIsAdmittedAndRebased(t *testing.T) {
+	tmux.SeedServerAliveForTest(t, true)
+	inst := runningInst(t, "wiring-vis", "agentdeck-wiring-vis")
+	h := newWiringHome(t, inst)
+	seedLedgerBaseline(t, h.refreshLedger, inst.ID)
+	h.visibleSessions.Store(visibleSessionSnapshot{
+		ids: map[string]struct{}{inst.ID: {}},
+		at:  time.Now(),
+	})
+
+	h.backgroundStatusUpdate()
+
+	entry, ok := ledgerEntry(h.refreshLedger, inst.ID)
+	if !ok {
+		t.Fatal("admitted visible row should have a rebased ledger entry")
+	}
+	if entry.skips != 0 || entry.fp.ok {
+		t.Fatalf("admitPoll must rebase on the (unusable) in-sweep fingerprint with counters reset, got %+v (skips %d)",
+			entry.fp, entry.skips)
+	}
+	if got := inst.GetStatusThreadSafe(); got == session.StatusRunning {
+		t.Fatalf("due visible row was not polled: status still %q", got)
+	}
+}
+
+// TestRefreshAttachedSessionStatus_ForgetsLedgerBaseline pins the
+// attach-return invalidation: refreshAttachedSessionStatus clears hook status
+// and forces a live check, so it MUST also drop the adaptive-refresh baseline
+// — otherwise the next sweep could skip on a fingerprint recorded before the
+// invalidation and hold a stale status for up to maxSkips sweeps.
+//
+// Catches deletion of the `h.refreshLedger.forget(inst.ID)` line in
+// refreshAttachedSessionStatus: without it the seeded entry survives and the
+// entry-gone assertion fails.
+func TestRefreshAttachedSessionStatus_ForgetsLedgerBaseline(t *testing.T) {
+	tmux.SeedServerAliveForTest(t, true)
+	inst := runningInst(t, "wiring-attach", "agentdeck-wiring-attach")
+	h := newWiringHome(t, inst)
+	seedLedgerBaseline(t, h.refreshLedger, inst.ID)
+
+	h.refreshAttachedSessionStatus(inst.ID)
+
+	if entry, ok := ledgerEntry(h.refreshLedger, inst.ID); ok {
+		t.Fatalf("attach-return must forget the adaptive-refresh baseline, entry survived: %+v (skips %d)",
+			entry.fp, entry.skips)
+	}
+}

--- a/internal/ui/refresh_wiring_test.go
+++ b/internal/ui/refresh_wiring_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -250,5 +251,58 @@ func TestRefreshAttachedSessionStatus_ForgetsLedgerBaseline(t *testing.T) {
 	if entry, ok := ledgerEntry(h.refreshLedger, inst.ID); ok {
 		t.Fatalf("attach-return must forget the adaptive-refresh baseline, entry survived: %+v (skips %d)",
 			entry.fp, entry.skips)
+	}
+}
+
+// TestBackgroundStatusUpdate_PipeIdleShortcutIsBoundedByCeiling pins the fix
+// for the review's first HIGH finding: the PipeManager quiet-pipe shortcut
+// ("skip idle sessions when PipeManager knows they haven't produced output")
+// runs BEFORE the fingerprint gate and, before this fix, skipped
+// unconditionally for as long as PipeManager reported no output — never
+// reaching refreshLedger, so a piped session's baseline was never refreshed
+// and it could be held forever.
+//
+// Drives the REAL backgroundStatusUpdate against a fake, permanently-quiet
+// connected pipe (tmux.SeedConnectedPipeForTest — no real tmux -C process,
+// no tmux server) for h.adaptiveMaxSkips consecutive sweeps, asserting the
+// shortcut is ALLOWED to skip (status stays Running, unpolled) up to the
+// ceiling, then MUST stop skipping on the next sweep even though
+// PipeManager keeps reporting the identical stale lastOutput throughout.
+// Catches deletion of the pipeIdleSkip bound in backgroundStatusUpdate: an
+// unbounded shortcut would keep the row at StatusRunning forever and the
+// final assertion would fail.
+func TestBackgroundStatusUpdate_PipeIdleShortcutIsBoundedByCeiling(t *testing.T) {
+	tmux.SeedServerAliveForTest(t, true)
+	const tmuxName = "agentdeck-wiring-piped"
+	inst := runningInst(t, "wiring-piped", tmuxName)
+	h := newWiringHome(t, inst)
+	// A fresh viewport snapshot that does NOT include this row keeps it
+	// off-screen and keeps maxSkips resolved at its normal value (not the
+	// fail-open 0) — the case under test.
+	h.visibleSessions.Store(visibleSessionSnapshot{
+		ids: map[string]struct{}{"some-other-row": {}},
+		at:  time.Now(),
+	})
+
+	pm := tmux.NewPipeManager(context.Background(), nil)
+	staleOutput := time.Now().Add(-10 * time.Second) // > the 5s PipeManager-idle threshold
+	tmux.SeedConnectedPipeForTest(t, pm, tmuxName, staleOutput)
+	tmux.SetPipeManager(pm)
+	t.Cleanup(func() { tmux.SetPipeManager(nil) })
+
+	for i := 0; i < h.adaptiveMaxSkips; i++ {
+		h.backgroundStatusUpdate()
+		if got := inst.GetStatusThreadSafe(); got != session.StatusRunning {
+			t.Fatalf("sweep %d: PipeManager shortcut should still be allowed to skip (under the ceiling), but status became %q", i, got)
+		}
+	}
+
+	// The ceiling is now exhausted: this sweep must force a real poll
+	// despite PipeManager reporting the SAME stale lastOutput as every prior
+	// sweep. A real UpdateStatus against a nonexistent tmux session moves
+	// the status off Running.
+	h.backgroundStatusUpdate()
+	if got := inst.GetStatusThreadSafe(); got == session.StatusRunning {
+		t.Fatal("PipeManager quiet-pipe shortcut held the row past the staleness ceiling: it was never polled")
 	}
 }


### PR DESCRIPTION
## Status (this pass)

Held on a second-opinion review of the rebased diff (see the review-response
comment on this PR for the full list). This pass closes the two items that
review marked **High** plus the perf-gate/claim gap it flagged; the review's
Medium/Low items are out of scope here and remain open follow-ups.

1. **`heldSteady` could hold a piped session forever.** The background
   sweep's PipeManager quiet-pipe shortcut ran *before* the adaptive gate and
   skipped unconditionally for as long as PipeManager reported no output,
   never reaching `refreshLedger` — so a session's baseline was never
   refreshed and the incremental visible-first path's read-only hold
   (`heldSteady`) could hold it indefinitely. Fixed by sharing the same
   staleness-ceiling counter across both paths (`refreshLedger.pipeIdleSkip`,
   `internal/ui/refresh_policy.go`): once `maxSkips` consecutive
   pipe-idle sweeps elapse, the shortcut lets go and the row falls through to
   a real poll, exactly like every other path already does at the ceiling.
2. **Visible-budget deferrals weren't bounded by `maxSkips`.** Round-robin
   admission only bounds a row's wait by `ceil(due/budget)` — a function of
   how many rows happen to be due at once, not of the documented ceiling.
   `admitVisiblePolls` now force-admits any row deferred `maxSkips` or more
   times regardless of budget, so the round-robin's *worst case* can never
   exceed the ceiling the design doc promises, however many rows are
   simultaneously due (e.g. a large group expand).
3. **The perf-smoke gate's path filter didn't trigger on this diff.**
   `.github/workflows/perf-smoke.yml` only matched
   `cmd/agent-deck/**`/`**/*_perf_test.go`/testutil paths; nothing in this
   PR's non-test diff matched, so the dedicated perf-regression gate silently
   never ran against it. Added `internal/ui/**` to the filter and added
   `internal/ui/refresh_policy_perf_test.go` (`TestPerf_
   AdaptiveRefreshSweepDecision`, WARM, tmux-free) gating the sweep's own
   per-session decision cost (`fingerprintSession` + `decide`/`holdVisible` +
   `admitVisiblePolls`) — the thing this PR's package doc claims is
   "a handful of map lookups, spawns nothing."
4. **Dropping the unverified 83% claim.** The previous "Measured effect"
   number was captured before this branch was rebased onto current `main`
   (which independently absorbed part of the same optimization via #1774),
   and it cannot be re-run from here (no live tmux/multi-session harness on
   this host, and running one is out of scope for this pass). See the
   revised **Measured effect** section below — the number is retracted, not
   replaced with a guess.

Tests proving both ceilings hold under repeated adversarial pressure (a
pipe that never stops reporting "quiet", and a due-row count far exceeding
budget×maxSkips) are in `internal/ui/refresh_policy_test.go` and
`internal/ui/refresh_wiring_test.go` — see **Tests** below.

## The problem

The refresh tick does work proportional to **all live sessions**. #1756 fixed the
render half of #1753 (full-frame `MaxWidth` rebuild → measure-then-rebuild, CPU
4.84% → 2.04%). What remains is the **status sweep**, and it is the structurally
wrong shape: it re-derives state for sessions that provably did not change, using
the most expensive mechanism available.

Three facts compose badly:

1. **Almost nothing has a control pipe.** `livePipeLRUCapacity = 3` + attached
   sessions — deliberate, since pipes cost a tmux client each. So the sweep's
   existing "PipeManager saw no output for 5s → skip" fast path covers ~4 rows
   out of 70. Everyone else falls through.
2. **Without a pipe, `CapturePane` is a subprocess.** `tmux capture-pane -p -e`,
   3s timeout, serialized by the tmux server, cached 500ms.
3. **The most common steady state on a big deck captures the pane.** A Claude
   session parked in hook `waiting` (done, needs you) takes the hook fast path,
   which calls `BackgroundWorkPending()` to check for in-flight
   `run_in_background` work — a capture, cached `bgWorkCacheTTL = 3s`. With a 2s
   sweep that is a capture roughly every other sweep, *per waiting session*.

At ~60 quiescent sessions that is tens of `capture-pane` subprocesses per sweep,
queued behind one tmux server, to re-derive statuses identical to the ones
already on screen. And when the sweep overruns, `nextStatusInterval` backs off —
so the system degrades by getting *less fresh*, not by getting cheaper.

**And the live-fleet diagnostic reframed the requirement**: the lag reproduces
when a group containing many sessions is **expanded**, and collapsing it makes
it fine. With a large group expanded, visible-row count approaches fleet size —
so any design that treats visible rows as must-refresh-every-tick degenerates
back to the full per-row storm exactly when the user is looking at the most
rows. Visible rows need a cheap-evidence skip and a per-tick budget too.

## The design (`docs/design/refresh-architecture-v2.md`)

**Event-driven first.** Claude/Codex/Gemini/Hermes/Cursor already *push*
lifecycle events into hook files, and `session.StatusFileWatcher` already
watches that directory with fsnotify and maintains a live status map. But it is
constructed as `NewStatusFileWatcher(nil)` — **`onChange` is nil**. Nothing
wakes the TUI; the sweep polls the watcher's map on its own cadence. We pay for
a push pipeline and consume it by polling. Target: hooks and tmux control-mode
notifications *cause* updates; the periodic sweep demotes to a reconciliation
safety net for what events cannot report and can then run at 10–30s.

**Adaptive second.** Rows refresh when there is evidence they changed;
generation counters make unchanged sessions cost zero; work per tick is
budgeted rather than unbounded — for visible rows too, because the group-expand
case makes "visible" as large as the fleet.

**Remote-ready third.** The roadmap is fleets on cloud machines with the Mac as
a thin control surface. "Subprocess per session per tick" is not merely slower
over SSH, it is a different order of magnitude — and both principles above
carry over: an event crossing an SSH connection costs one multiplexed message,
and a generation counter lets a remote answer "nothing changed" once for the
whole host. So the refresh layer should treat a **host** as the unit of cost:
Mac cost O(hosts), independent of session count. Existing `--ssh` support is
the seed; v2 generalizes that and makes local tmux one implementation of a
session host behind it.

The doc also records the **invariants** any future change to this layer must
preserve (never skip on absent information; never skip without a bound; fail
open; never infer death from silence; always ship a kill switch).

## The slice in this PR

**Per-session fingerprint** (`internal/ui/refresh_policy.go`), built entirely
from caches the sweep already refreshed once per tick — `window_activity` from
the `list-sessions` snapshot, pane title/command/dead from the `list-panes`
snapshot, hook `UpdatedAt`, SSE `UpdatedAt`. Building it for the whole deck is a
handful of map lookups and spawns nothing. Incomplete evidence sets `ok = false`,
which **always forces a poll**.

**The off-screen gate**, right after the existing PipeManager idle-skip.
`UpdateStatus` is skipped only when *every* one of these holds:

1. the row is **not** visible (visible rows go through the hold + budget below);
2. the status is `running` / `waiting` / `idle` (`error`/`stopped` keep their own
   recheck timers, `starting` must converge fast);
3. the fingerprint is usable **and** identical to the last polled one;
4. fewer than `maxSkips` consecutive skips have happened.

Any veto polls. No path skips on absent information.

**Visible rows: hold + budget** (the group-expand case):

- a visible row with a settled status and an unchanged fingerprint is **held**
  under the same `maxSkips` ceiling (`refreshLedger.holdVisible`) — an expanded
  quiescent group costs ~zero;
- visible rows that *do* need a poll compete for a **per-sweep budget**
  (`visiblePollBudgetPerSweep = 10`, the sweep's worker-pool width); deferred
  rows age a starvation counter and are admitted first on later sweeps, so the
  budget cycles **round-robin** and every due row is polled within
  `ceil(due/budget)` sweeps;
- the **cursor row is always admitted** — it drives the preview pane;
- the incremental visible-first pass in `processStatusUpdate`, which used to
  poll **every** visible row per pass, now holds steady rows read-only
  (`heldSteady`; no ceiling, because the background sweep owns freshness) and
  budgets + round-robins the rest;
- **group expand is a trigger, not a burst**: the keypress only rebuilds the
  flat list (rows render instantly from the existing render snapshot) and
  republishes the viewport immediately, so the next sweep amortizes the
  catch-up through the budget. No path between the keypress and the first
  frame spawns per-row tmux work.

### Why this is safe

- **Not a new assumption.** `Session.GetStatus` already gates its `CapturePane`
  on exactly "did `window_activity` change" (`needsBusyCheck`), and
  `UpdateStatus` gates its idle tier on it. This gate reuses that invariant and
  is **strictly more conservative**, because those skip for as long as activity
  is unchanged while this one is bounded by the ceiling.
- **The ceiling bounds the only real exposure.** `UpdateStatus` has time-based
  transitions with no external evidence (`acknowledged → idle`, hook-freshness
  expiry, `debounceFlipFromRunning` confirmation, Hermes gateway recheck).
  The ceiling delays those by at most `maxSkips` sweeps (~6s at default)
  instead of suppressing them — where the existing `needsBusyCheck` has no
  bound at all. The same bound now covers visible rows; anything the user can
  see is at most ~3 sweeps stale, and only if nothing observable moved.
- **Real transitions are not delayed.** Anything that happens moves the
  fingerprint on the next sweep: Stop hook → `hookAt`, any output →
  `activity`, spinner start/stop → `title` (Claude's OSC marker), exit under
  remain-on-exit → `dead`, session gone from tmux → `ok=false` → forced poll,
  OpenCode SSE → `sseAt`. A row with a moved fingerprint is polled — for
  visible rows within the budget, cursor first, starved rows first.
- **Fails open.** With no viewport snapshot, or one older than 10s (event loop
  suspended by `tea.Exec`, or wedged), gate **and** budget are bypassed and
  every session is polled, exactly as before. A nil ledger also polls.
- **Attach-return can't be stale.** `refreshAttachedSessionStatus` already
  clears hook status and forces a check; it also drops the fingerprint
  baseline — and that wiring is now pinned by a test that fails if the line is
  deleted.

**Render-snapshot generation skip.** `refreshSessionRenderSnapshot` is called
from six sweep/tick paths and used to allocate and publish a fresh N-entry map
every time. It now compares first and returns without allocating or storing when
nothing changed.

**Kill switch** — `[ui] adaptive_refresh_max_skips`, resolved through
`UISettings.GetAdaptiveRefreshMaxSkips` (same clamp pattern as
`GetRemoteSessionRefreshSecs`):

| value | behaviour |
|---|---|
| `0` / unset | default `2` — poll every quiescent session at least every 3rd sweep (~6s) |
| `>0` | custom ceiling, **clamped to 30** (`MaxAdaptiveRefreshMaxSkips`); it previously accepted `100000` verbatim, a ~55h staleness ceiling |
| `<0` | **disable** — every sweep polls every session, byte-identical to pre-policy behaviour; hold and budget both off |

The knob resolves **once, at TUI construction** — changing it (including the
kill switch) takes effect on the next TUI restart, not on config reload.

## Measured effect

**Unquantified on the current head — the earlier ~83% figure is retracted,
not reconfirmed.** It was measured with a sandboxed 60-session tmux harness
(throwaway `HOME`, blank XDG, own tmux socket, 220×50 terminal, 60s warmup +
240 `j`/`k` events + 60s settle) run *before* this branch was rebased onto
current `main`. #1774 landed on `main` while this PR was open and
independently implements an interim version of the same idea (see the
rebase-status review comment on this PR), so that number no longer isolates
this PR's marginal effect over what's already on `main` — and it cannot be
honestly re-measured from here: reproducing it needs a live multi-session
tmux fleet, and this host's safety rules rule that out for this pass (no
`tmux`, no un-sandboxed `go test`, isolated `/tmp` clones only).

What replaces it: `internal/ui/refresh_policy_perf_test.go`
(`TestPerf_AdaptiveRefreshSweepDecision`) is a CI-enforced, tmux-free WARM
perf gate on the sweep's own decision cost — `fingerprintSession` +
`decide`/`holdVisible` + `admitVisiblePolls` over 200 synthetic sessions —
now wired into `.github/workflows/perf-smoke.yml` via the added
`internal/ui/**` path filter, so it actually runs on this PR's own diff and
on every future change to this hot path. It does not reproduce or replace
the retracted subprocess-count number (that would need a real tmux fleet,
COLD by nature, out of scope for a hermetic gate); it catches the decision
layer's own claimed cost — spawns nothing, no lock held across the sweep —
regressing.

An honest next step, not done here: re-run the sandboxed 60-session harness
against this rebased head (ideally from a machine without this repo's tmux
restrictions) and replace this section with a real number, or formalize the
harness as a repeatable script if the number is worth defending permanently.

## Tests

`internal/ui/refresh_policy_test.go` — pure, no tmux server and no `HOME`:

- every veto in the off-screen decision function, table-driven;
- the staleness-ceiling pattern (`skip, skip, poll`) and counter reset on
  fingerprint change; `forget()`/`prune()`/nil-receiver behaviour;
- **visible hold**: ceiling respected, all vetoes (changed/unusable
  fingerprint, unsettled status, kill switch, no baseline, nil ledger), and
  refused holds not consuming the ceiling;
- **read-only hold** (`heldSteady`): 50 held passes consume none of the sweep
  ceiling;
- **budget round-robin**: 25 due rows at budget 10 are all polled within 3
  sweeps (starvation-counter aging), and the cursor row is never deferred;
- **NEW — the two staleness-ceiling fixes above, proven adversarially**:
  `TestRefreshLedger_PipeIdleSkip_BoundsTheQuietPipeShortcut` drives a pipe
  that reports "quiet" every sweep across 5 repeated ceiling cycles and
  asserts it is forced open every `maxSkips`th sweep, never held
  indefinitely (plus kill-switch and nil-safety cases);
  `TestAdmitVisiblePolls_MaxSkipsBoundsStalenessRegardlessOfDueCount` drives
  137 simultaneously-due rows at budget 10 / `maxSkips` 3 (ceil(due/budget) =
  14 sweeps under pure round-robin, far past the ceiling) across 40 sweeps
  and asserts NO row is ever deferred more than `maxSkips` consecutive times;
  `TestBackgroundStatusUpdate_PipeIdleShortcutIsBoundedByCeiling`
  (`refresh_wiring_test.go`) drives the same proof through the REAL
  `backgroundStatusUpdate` against a fake connected pipe
  (`tmux.SeedConnectedPipeForTest`, no real tmux server);
- fingerprint evidence vs no-evidence, pane-title sensitivity, and — new —
  the **hook/SSE inputs**: a delivered hook or SSE sample moves `hookAt`/`sseAt`
  and breaks the match even with unchanged tmux evidence (this is what makes
  "real transitions are not delayed" true), via new watcher test seams;
- viewport publication (now including `cursorID`) and both fail-open paths;
- the render-snapshot skip asserted by map identity.

`internal/ui/refresh_wiring_test.go` — drives the **real**
`backgroundStatusUpdate` / `refreshAttachedSessionStatus` on a constructed
Home, so the wiring lines themselves are pinned (deleting either safety line
turns the suite red — see the review-response comment for the exact mapping).

`internal/session/userconfig_adaptive_refresh_test.go` — the clamp:
default / passthrough / max / above-max / 100000 / kill-switch cases.

`tmux.SeedServerAliveForTest` was added alongside the existing seed helpers so
`internal/ui` can drive the sweep deterministically with or without a tmux
server.

## Follow-ups (roadmap in the doc, each independently shippable)

1. Wire `onChange` on `StatusFileWatcher` → single-session refresh on hook
   delivery. First genuinely event-driven step, and it feeds the TUI-truth
   `waiting = done` vs `needs-you` split.
2. Relax the safety-net sweep cadence once (1) lands.
3. Stagger the attach-return catch-up burst.
4. Fleet notification channel — one control-mode client per tmux *server*.
5. Host-oriented remote refresh.

Refs #1753. Follow-up to #1756.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive background refreshing to reduce status polling for unchanged off-screen sessions.
  * Added the `ui.adaptive_refresh_max_skips` setting, including default, limit, and disable options.
* **Performance**
  * Improved rendering by reusing unchanged snapshots.
  * Prioritized visible sessions and responded faster to viewport changes.
  * Ensured skipped sessions are refreshed periodically.
* **Bug Fixes**
  * Prevented errors when sending commands through an unavailable control pipe.
* **Tests**
  * Expanded coverage for refresh behavior, skip limits, visible-row budgets, and snapshot updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
