### PR TITLE
fix(ui): anchor a relative New Session path to an absolute path (#1706)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7312,6 +7312,13 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// Get values including worktree settings.
 		name, path, command, branchName, worktreeEnabled := h.newDialog.GetValuesWithWorktree()
+		// #1706: a relative entry must be anchored to this process's cwd here,
+		// before it reaches the directory-exists check, os.MkdirAll, the
+		// worktree/VCS probe or the instance itself — tmux would otherwise
+		// resolve it against the tmux server's cwd and put the session
+		// somewhere other than the folder we created. Runs after the remote
+		// branch above returns, so remote paths are never touched.
+		path = absLocalProjectPath(path)
 
 		// Remember the submitted tool so the next new-session dialog preselects
 		// it (UX top-3 #2). Best-effort: persisted in the profile StateDB, never
@@ -7387,9 +7394,15 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		multiRepoPaths, multiRepoEnabled := h.newDialog.GetMultiRepoPaths()
 		var additionalPaths []string
 		if multiRepoEnabled && len(multiRepoPaths) > 1 {
-			// First path stays as ProjectPath, rest are additional
-			path = multiRepoPaths[0]
-			additionalPaths = multiRepoPaths[1:]
+			// First path stays as ProjectPath, rest are additional.
+			// #1706: same anchoring as the single-path field above — a relative
+			// entry here would be stored as a declared path and could never
+			// match a hook-reported cwd (#1731).
+			path = absLocalProjectPath(multiRepoPaths[0])
+			additionalPaths = make([]string, 0, len(multiRepoPaths)-1)
+			for _, p := range multiRepoPaths[1:] {
+				additionalPaths = append(additionalPaths, absLocalProjectPath(p))
+			}
 		}
 
 		// Show immediate placeholder in UI while worktree + session is created async

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7318,7 +7318,27 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// resolve it against the tmux server's cwd and put the session
 		// somewhere other than the folder we created. Runs after the remote
 		// branch above returns, so remote paths are never touched.
-		path = absLocalProjectPath(path)
+		//
+		// Multi-repo paths are resolved here too (not at their use site further
+		// down) so the single "cannot resolve" refusal happens while the dialog
+		// is still open and can show the error. A declared path that stayed
+		// relative could also never match a hook-reported cwd (#1731).
+		multiRepoPaths, multiRepoEnabled := h.newDialog.GetMultiRepoPaths()
+		absPath, absErr := absLocalProjectPath(path)
+		if absErr == nil {
+			path = absPath
+			for i, p := range multiRepoPaths {
+				if multiRepoPaths[i], absErr = absLocalProjectPath(p); absErr != nil {
+					break
+				}
+			}
+		}
+		if absErr != nil {
+			// filepath.Abs only fails when this process has no usable cwd, so
+			// there is nothing to anchor a relative path to.
+			h.newDialog.SetError("Cannot resolve a relative path here — enter an absolute path")
+			return h, nil
+		}
 
 		// Remember the submitted tool so the next new-session dialog preselects
 		// it (UX top-3 #2). Best-effort: persisted in the profile StateDB, never
@@ -7391,18 +7411,12 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		geminiYoloMode := h.newDialog.IsGeminiYoloMode()
 		sandboxMode := h.newDialog.IsSandboxEnabled()
-		multiRepoPaths, multiRepoEnabled := h.newDialog.GetMultiRepoPaths()
 		var additionalPaths []string
 		if multiRepoEnabled && len(multiRepoPaths) > 1 {
 			// First path stays as ProjectPath, rest are additional.
-			// #1706: same anchoring as the single-path field above — a relative
-			// entry here would be stored as a declared path and could never
-			// match a hook-reported cwd (#1731).
-			path = absLocalProjectPath(multiRepoPaths[0])
-			additionalPaths = make([]string, 0, len(multiRepoPaths)-1)
-			for _, p := range multiRepoPaths[1:] {
-				additionalPaths = append(additionalPaths, absLocalProjectPath(p))
-			}
+			// Already absolutized above (#1706).
+			path = multiRepoPaths[0]
+			additionalPaths = multiRepoPaths[1:]
 		}
 
 		// Show immediate placeholder in UI while worktree + session is created async

--- a/internal/ui/issue1706_relative_path_test.go
+++ b/internal/ui/issue1706_relative_path_test.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -32,7 +34,12 @@ func TestIssue1706_SubmitAnchorsRelativePathToAbsolute(t *testing.T) {
 		t.Fatalf("getwd: %v", err)
 	}
 
-	const relPath = "issue1706-relative-target-does-not-exist"
+	// Relative on purpose (that is the bug), but unique so the test can never
+	// collide with a directory that happens to exist in the package dir.
+	relPath := fmt.Sprintf("issue1706-relative-target-%d", time.Now().UnixNano())
+	if _, err := os.Stat(relPath); !os.IsNotExist(err) {
+		t.Fatalf("test precondition: %q must not exist (stat err = %v)", relPath, err)
+	}
 	want := filepath.Join(cwd, relPath)
 
 	h := NewHome()
@@ -96,8 +103,15 @@ func TestIssue1706_AbsLocalProjectPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := absLocalProjectPath(tt.input); got != tt.want {
+			got, err := absLocalProjectPath(tt.input)
+			if err != nil {
+				t.Fatalf("absLocalProjectPath(%q) returned error: %v", tt.input, err)
+			}
+			if got != tt.want {
 				t.Fatalf("absLocalProjectPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if tt.want != "" && !filepath.IsAbs(got) {
+				t.Fatalf("absLocalProjectPath(%q) = %q, which is not absolute", tt.input, got)
 			}
 		})
 	}

--- a/internal/ui/issue1706_relative_path_test.go
+++ b/internal/ui/issue1706_relative_path_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Issue #1706 — "Wrong path generated session": the New Session dialog accepted
+// a relative project path and passed it through verbatim. The TUI then resolved
+// it against its own process cwd (directory-exists check + os.MkdirAll), while
+// tmux resolved `new-session -c <relative>` against the tmux SERVER's cwd. The
+// session therefore did not land in the directory the user named, and a folder
+// could be created in a third, unrelated place.
+//
+// Contract: by the time a submitted local path reaches the create flow it is
+// absolute. The CLI already did this (cmd/agent-deck/cli_utils.go); these tests
+// pin it for the TUI.
+//
+// The submit is driven through the real key handler (handleNewDialogKey) and
+// stops at the "Directory Not Found" confirmation, so no session and no
+// directory are created — the assertion reads the pending path the confirmation
+// captured.
+
+func TestIssue1706_SubmitAnchorsRelativePathToAbsolute(t *testing.T) {
+	setXDGTestHome(t)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	const relPath = "issue1706-relative-target-does-not-exist"
+	want := filepath.Join(cwd, relPath)
+
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show()
+	h.newDialog.nameInput.SetValue("issue1706")
+	h.newDialog.pathInput.SetValue(relPath)
+
+	model, _ := h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyCtrlS})
+	home, ok := model.(*Home)
+	if !ok {
+		t.Fatal("handleNewDialogKey should return *Home")
+	}
+
+	if !home.confirmDialog.IsVisible() {
+		t.Fatalf("submitting a non-existent path must open the create-directory confirmation (validation error: %q)", home.newDialog.validationErr)
+	}
+	if got := home.confirmDialog.confirmType; got != ConfirmCreateDirectory {
+		t.Fatalf("confirmType = %v, want ConfirmCreateDirectory", got)
+	}
+
+	_, pendingPath, _, _, _, _, _, _, _, _ := home.confirmDialog.GetPendingSession()
+	if !filepath.IsAbs(pendingPath) {
+		t.Fatalf("pending session path = %q, want an absolute path (#1706: a relative path is created next to the TUI's cwd but tmux resolves it against the tmux server's cwd)", pendingPath)
+	}
+	if pendingPath != want {
+		t.Fatalf("pending session path = %q, want %q (relative entry anchored to the process cwd)", pendingPath, want)
+	}
+	// The confirmation also displays the path; it must show the resolved one so
+	// the user can see where the directory would actually be created.
+	if got := home.confirmDialog.targetName; got != want {
+		t.Fatalf("confirmation displays %q, want %q", got, want)
+	}
+
+	// Guard: the submit path must not have created anything on its own.
+	if _, err := os.Stat(relPath); !os.IsNotExist(err) {
+		t.Fatalf("submit must not create the directory before confirmation (stat err = %v)", err)
+	}
+}
+
+func TestIssue1706_AbsLocalProjectPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "absolute path is unchanged", input: "/Users/dev/work/app", want: "/Users/dev/work/app"},
+		{name: "bare relative name anchors to cwd", input: "app", want: filepath.Join(cwd, "app")},
+		{name: "nested relative path anchors to cwd", input: "dev/app", want: filepath.Join(cwd, "dev", "app")},
+		{name: "dot resolves to cwd", input: ".", want: cwd},
+		{name: "dot-slash prefix is cleaned", input: "./app", want: filepath.Join(cwd, "app")},
+		{name: "parent traversal is cleaned", input: "/Users/dev/work/../app", want: "/Users/dev/app"},
+		{name: "empty stays empty", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := absLocalProjectPath(tt.input); got != tt.want {
+				t.Fatalf("absLocalProjectPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/issue1706_relative_path_test.go
+++ b/internal/ui/issue1706_relative_path_test.go
@@ -116,3 +116,18 @@ func TestIssue1706_AbsLocalProjectPath(t *testing.T) {
 		})
 	}
 }
+
+// The submit resolves every declared multi-repo path to an absolute one, so
+// Validate's duplicate check has to compare resolved paths — otherwise "repo"
+// and "./repo" pass validation and then collapse into the same project path
+// plus a duplicate additional_paths entry.
+func TestIssue1706_ValidateRejectsRelativeDuplicateSpellings(t *testing.T) {
+	d := NewNewDialog()
+	d.nameInput.SetValue("issue1706")
+	d.multiRepoEnabled = true
+	d.multiRepoPaths = []string{"repo-alpha", "./repo-alpha"}
+
+	if got := d.Validate(); got != "Duplicate paths in multi-repo mode" {
+		t.Fatalf("Validate() = %q, want the duplicate-path rejection (both spellings resolve to the same directory)", got)
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1367,6 +1367,13 @@ func (d *NewDialog) Validate() string {
 				continue
 			}
 			expanded := session.ExpandPath(strings.Trim(p, "'\""))
+			// #1706: submit resolves every declared path to an absolute one, so
+			// the duplicate key must be resolved too — otherwise "repo" and
+			// "./repo" pass this check and then collapse into the same path.
+			// Dedupe key only; the entered values are left untouched.
+			if abs, err := filepath.Abs(expanded); err == nil {
+				expanded = abs
+			}
 			if seen[expanded] {
 				return "Duplicate paths in multi-repo mode"
 			}

--- a/internal/ui/newsession_path.go
+++ b/internal/ui/newsession_path.go
@@ -1,0 +1,43 @@
+package ui
+
+import "path/filepath"
+
+// absLocalProjectPath resolves a user-entered LOCAL project path to an
+// absolute, cleaned path.
+//
+// #1706: the New Session dialog accepts whatever the user types and, until
+// this normalization, handed it to session creation verbatim. A relative entry
+// ("dev/app", "app", ".", "../app") then meant two different directories at
+// once:
+//
+//   - the TUI resolved it against its OWN process cwd for the
+//     "Directory Not Found" check and the os.MkdirAll that follows, so the
+//     folder was created next to wherever agent-deck happened to be started;
+//   - tmux resolved `new-session -c <relative>` against the tmux SERVER's cwd,
+//     which is inherited from whichever client first started that server and is
+//     usually somewhere else entirely (and may no longer exist).
+//
+// So the session did not land in the directory the user named, and a folder
+// appeared in a third, unrelated place. A relative path stored as
+// instances.project_path also breaks everything that treats it as identity:
+// group derivation, the Claude project slug, and the #1731 hook-cwd ownership
+// comparison (which resolves symlinks on both sides and can never match a
+// relative string).
+//
+// The CLI has always absolutized here (cmd/agent-deck/cli_utils.go
+// resolveProjectPathArg); this brings the TUI in line. Remote paths must NEVER
+// pass through this function — they belong to the remote host's filesystem and
+// travel via NewDialog.GetRemoteValues instead.
+func absLocalProjectPath(path string) string {
+	if path == "" {
+		return path
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		// filepath.Abs only fails when the process cwd is unavailable. Keep the
+		// user's input (cleaned) rather than dropping it; the create flow will
+		// surface a normal filesystem error.
+		return filepath.Clean(path)
+	}
+	return abs
+}

--- a/internal/ui/newsession_path.go
+++ b/internal/ui/newsession_path.go
@@ -1,6 +1,9 @@
 package ui
 
-import "path/filepath"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 // absLocalProjectPath resolves a user-entered LOCAL project path to an
 // absolute, cleaned path.
@@ -28,16 +31,22 @@ import "path/filepath"
 // resolveProjectPathArg); this brings the TUI in line. Remote paths must NEVER
 // pass through this function — they belong to the remote host's filesystem and
 // travel via NewDialog.GetRemoteValues instead.
-func absLocalProjectPath(path string) string {
+//
+// An empty path is returned unchanged: multi-repo mode legitimately submits an
+// empty single-path field, and the emptiness check belongs to Validate.
+// Otherwise the returned path is guaranteed absolute, or an error is returned
+// and the caller must refuse the submission — falling back to the relative
+// string would reintroduce exactly the split-directory bug above.
+func absLocalProjectPath(path string) (string, error) {
 	if path == "" {
-		return path
+		return path, nil
 	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		// filepath.Abs only fails when the process cwd is unavailable. Keep the
-		// user's input (cleaned) rather than dropping it; the create flow will
-		// surface a normal filesystem error.
-		return filepath.Clean(path)
+		// filepath.Abs only fails when the process cwd is unavailable (e.g. the
+		// directory agent-deck was started in has been deleted), so there is no
+		// anchor to resolve a relative path against.
+		return "", fmt.Errorf("resolve %q: %w", path, err)
 	}
-	return abs
+	return abs, nil
 }


### PR DESCRIPTION
## Summary

Related to #1706 (report by @gamrom). This does not claim to be *the* fix for that report — the reporter has not been able to share the exact path yet — but it closes a real, reproducible way the TUI can put a session somewhere other than the path that was typed, and it is the one remaining local path-resolution hole after #1731 and #1737.

The New Session dialog handed whatever the user typed straight into session creation. A **relative** entry (`app`, `dev/app`, `./app`) then meant two different directories at once:

- the TUI resolved it against its **own process cwd** for the "Directory Not Found" check and the `os.MkdirAll` that follows, so the folder was created next to wherever agent-deck happened to be started;
- tmux resolved `new-session -c <relative>` against the **tmux server's** cwd, which is inherited from whichever client first started that server and is usually somewhere else entirely (and may no longer exist).

So the session did not land in the directory the user named, and a folder could appear in a third, unrelated place.

A relative string stored as `instances.project_path` also breaks everything that treats the path as identity: group derivation (`extractGroupPath`), the Claude project slug used for resume, and the hook-cwd ownership comparison added in #1731 — that one resolves symlinks on both sides, so a relative string can never match and every hook event is refused.

## Fix

`absLocalProjectPath` (new `internal/ui/newsession_path.go`) resolves a user-entered local path with `filepath.Abs`, which also cleans `.` / `..`. It is applied at the local submit site in `handleNewDialogKey`, **after** the `#1353` remote branch returns — remote paths belong to the remote host's filesystem and travel via `GetRemoteValues`, so they must never be absolutized locally. The multi-repo primary and additional paths get the same treatment, for the `#1731` reason above.

Deliberately placed at the submit site rather than inside `NewDialog.GetValues()`: the remote dialog's path default is `.` (meaning the remote home), pinned by `TestIssue1353_RemoteDialogDefaults`, and that must stay relative.

`filepath.Abs` only fails when this process has no usable cwd (the directory agent-deck was started in was deleted), and there is then nothing to anchor a relative path to. The helper returns an error rather than falling back to the relative string — that fallback would reintroduce the very split-directory bug it exists to prevent — and the submit shows an inline error with the dialog still open. Multi-repo paths are resolved at the same point so there is a single refusal site while the dialog can still display it (multi-repo mode permits an empty single-path field, so it can reach `Abs` first).

The CLI has always absolutized (`resolveProjectPathArg` in `cmd/agent-deck/cli_utils.go`), so this only brings the TUI in line — no new behaviour, no config.

## Tests

`internal/ui/issue1706_relative_path_test.go`:

- `TestIssue1706_SubmitAnchorsRelativePathToAbsolute` drives a real `Ctrl+S` submit through `handleNewDialogKey` with a relative, non-existent path. The submit stops at the "Directory Not Found" confirmation, so no session and no directory are created; the test asserts the path the confirmation captured (and displays) is the cwd-anchored absolute path. It fails on the pre-fix code, where the pending path is the bare relative string.
- `TestIssue1706_AbsLocalProjectPath` is a table test for the helper: absolute unchanged, bare/nested relative anchored, `.`, `./app`, `..` cleaning, empty stays empty.
- `TestIssue1706_ValidateRejectsRelativeDuplicateSpellings` pins the resolved duplicate key (`repo` vs `./repo`).

`go build ./...`, `go vet ./internal/ui/` and `gofmt` are clean locally; the package suite is left to CI per this repo's test-safety rules.

## Not in scope

No `internal/ui` refresh/tick paths are touched, so this does not overlap the in-flight TUI performance work on #1753.

## Review notes

Two rounds of Codex review on the diff. Landed: refuse the submit (inline error, dialog stays open) instead of falling back to the relative path when `filepath.Abs` fails, unique relative dir name in the regression test, and the resolved duplicate-path key above.

Two findings were checked and not acted on:

- *"Committing a secondary multi-repo entry leaves it in `pathInput`, so the pre-create checks probe the wrong repo."* Already handled — `CommitMultiRepoEdit` resets `pathInput` to the primary path for exactly this reason, as does `CommitInFlightMultiRepoEdit` on `Ctrl+S`.
- *"A multi-repo submit whose path is missing becomes a single-repo session."* Real, but pre-existing and unrelated to this diff: `ShowCreateDirectory` has never carried multi-repo state and `confirmCreateDirectory` passes `false, nil` explicitly. Moving the `GetMultiRepoPaths` read earlier does not change that outcome either way. Worth its own issue rather than a scope-widening ride along a path-resolution fix.
