### PR TITLE
fix(release): brew tap out of the release critical path so SLSA provenance ships (closes #1763, #1760)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,7 +22,7 @@ file an issue and fix it, don't merge through it.
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `release.yml` | push tag `v*` | Validates the tag matches `cmd/agent-deck/main.go`'s `Version`, runs `go test -race ./...`, runs `goreleaser --clean` to build Darwin/Linux × amd64/arm64 tarballs into a **draft** release, asserts the four tarballs + `checksums.txt` landed, verifies every tarball against its published SHA-256 — and only then publishes the release. Replaces the pre-#332 manual `make release-local` step. |
+| `release.yml` | push tag `v*` | Validates the tag matches `cmd/agent-deck/main.go`'s `Version`, runs `go test -race ./...`, runs `goreleaser --clean` to build Darwin/Linux × amd64/arm64 tarballs into a **draft** release, asserts the four tarballs + `checksums.txt` landed, verifies every tarball against its published SHA-256, signs SLSA build provenance — and only then publishes the release. Finally it pushes the Homebrew formula, best-effort. Replaces the pre-#332 manual `make release-local` step. |
 | `homebrew-verify.yml` | `workflow_run` after `release.yml` completes successfully (plus weekly cron, `workflow_dispatch`, and PRs touching install docs) | Probes the live tap: formula exists, its version matches `/releases/latest`, and every URL in it resolves. Moved off the tag-push trigger in #1759 because it used to race the release it was verifying. |
 
 ### The release is published last, and only once (#1759)
@@ -42,6 +42,37 @@ a pre-published release stays public and asset-less for the whole ~11-minute
 build (exactly what broke v1.10.10 and v1.10.11). `release.yml` now forces such
 a release back to draft before building, but that safety net exists to catch
 mistakes, not to be relied on.
+
+### Provenance is signed before publishing; the tap is pushed after (#1760, #1763)
+
+The tail of `release.yml` is ordered deliberately:
+
+1. **Attest build provenance** — signs the verified artifacts. It runs *before*
+   publishing so provenance is a precondition of a release being visible. If
+   signing fails, the draft is never published and nobody is handed an
+   artifact that `gh attestation verify` cannot check (SECURITY.md advertises
+   exactly that command).
+2. **Publish release** — the one place a release becomes visible.
+3. **Update Homebrew tap formula** — `continue-on-error: true`. Best effort, and
+   after publishing because the formula's download URLs only resolve once the
+   release is public.
+
+GoReleaser used to push the tap itself, in the middle of `goreleaser release`.
+That put a third-party package manager in the release's critical path: when
+`HOMEBREW_TAP_GITHUB_TOKEN` started returning `401 Bad credentials`, the
+GoReleaser step failed and **every step after it was skipped**, so v1.10.9,
+v1.10.10 and v1.10.11 shipped with no SLSA provenance at all (#1760). Now
+`brews.skip_upload: true` in `.goreleaser.yml` makes GoReleaser stop at
+generating `dist/homebrew/Formula/agent-deck.rb`, and the workflow owns the push.
+
+The tap step cannot fail a release, but it is not silent either: it emits a
+`::warning::` annotation plus a job summary with recovery commands, and it
+refuses to push unless the generated formula's version matches the tag and all
+four of its `sha256` values match the release's verified `checksums.txt` — a
+formula with a stale checksum breaks `brew install` for everyone. A red-but-
+ignored tap step on a green release means the tap needs attention (usually the
+token), not that the release is bad.
+
 | `pages.yml` | push to `main` touching `site/**`, or `workflow_dispatch` | Deploys the static landing site under `site/` to GitHub Pages. |
 
 ## Notification-only (no gate, no build)

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -47,12 +47,11 @@ jobs:
           version: '~> v2'
           args: release --snapshot --skip=publish --clean
         env:
-          # Snapshot mode does not call GitHub or the tap, but goreleaser
-          # still resolves env-var templates in .goreleaser.yml. Provide
-          # placeholders so {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }} in the
-          # brews block does not fail template evaluation.
+          # No HOMEBREW_TAP_GITHUB_TOKEN placeholder needed any more: the brews
+          # block no longer carries a `{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}`
+          # token template to resolve, because with brews.skip_upload GoReleaser
+          # never talks to the tap (the push moved into release.yml, #1763).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: snapshot-placeholder
 
       - name: Verify expected archives produced
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,10 +324,29 @@ jobs:
           fi
           echo "Verified ${#ARTIFACTS[@]} tarballs against checksums.txt; ready to attest."
 
+      # Signed BEFORE the release is published, so provenance is a precondition
+      # of visibility rather than an afterthought (#1760). SECURITY.md tells
+      # users to run `gh attestation verify` on release artifacts; if signing
+      # fails, the release stays an unpublished draft and nobody is handed an
+      # unverifiable artifact. This attests the local dist-attest/ files and
+      # does not touch the release itself, so nothing here needs the release to
+      # be public.
+      #
+      # If Sigstore/Fulcio is genuinely down and a release must go out anyway,
+      # publish the verified draft by hand — the assets are already attached and
+      # checksum-verified at this point:
+      #   gh release edit <tag> --repo asheshgoplani/agent-deck --draft=false --latest
+      - name: Attest build provenance
+        timeout-minutes: 10
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        with:
+          subject-path: 'dist-attest/*'
+
       # The single place a release becomes visible (#1759). Everything above has
       # to have passed: GoReleaser succeeded, the four tarballs and
-      # checksums.txt are attached, and every tarball's SHA-256 matches the
-      # published checksum. Only then does the release leave draft.
+      # checksums.txt are attached, every tarball's SHA-256 matches the
+      # published checksum, and build provenance is signed. Only then does the
+      # release leave draft.
       #
       # If any earlier step fails the draft is simply never published:
       # /releases/latest keeps pointing at the last good release, so
@@ -362,11 +381,171 @@ jobs:
           fi
           echo "Release ${REF_NAME} is published with all assets attached."
 
-      - name: Attest build provenance
-        timeout-minutes: 10
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
-        with:
-          subject-path: 'dist-attest/*'
+      # The Homebrew tap, deliberately last and deliberately unable to fail the
+      # job (#1763, #1760).
+      #
+      # GoReleaser used to push the formula itself, from inside
+      # `goreleaser release`. A tap failure therefore failed the GoReleaser step
+      # and skipped every step after it — which is how a 401 on the tap token
+      # cost v1.10.9/10/11 their build provenance. `brews.skip_upload: true` in
+      # .goreleaser.yml now stops at generating dist/homebrew/Formula/agent-deck.rb
+      # and this step owns the push.
+      #
+      # `continue-on-error: true` is the entire point: a dead tap token, a rate
+      # limit or a tap-side conflict must never turn a verified, published,
+      # attested release red. Brew users simply keep the previous formula until
+      # the next release or a manual push. The failure is still loud — a
+      # ::warning:: annotation plus recovery commands in the job summary — so
+      # "best effort" cannot decay into "silently broken forever".
+      #
+      # Running after "Publish release" is also required for correctness: the
+      # formula's download URLs only resolve once the release is public, and
+      # homebrew-verify.yml compares the tap against /releases/latest.
+      - name: Update Homebrew tap formula (best effort)
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          # The tap lives in a different repo, so this needs its own token with
+          # Contents: read/write on asheshgoplani/homebrew-tap. It is the only
+          # consumer of the secret now.
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          TAP_REPO: asheshgoplani/homebrew-tap
+          TAP_FORMULA_PATH: Formula/agent-deck.rb
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+
+          # Every exit path other than success goes through here: a warning
+          # annotation, an actionable job summary, and a non-zero exit so the
+          # step is visibly red-but-ignored instead of quietly green.
+          soft_fail() {
+            echo "::warning title=Homebrew tap not updated::$1"
+            {
+              echo "### Homebrew tap NOT updated for ${REF_NAME}"
+              echo
+              echo "$1"
+              echo
+              echo "The release itself is published, verified and attested — only the tap"
+              echo "lagged, so \`brew install ${TAP_REPO%/*}/tap/agent-deck\` keeps serving the"
+              echo "previous version until this is fixed."
+              echo
+              echo "Recovery:"
+              echo
+              echo "1. If the token is the problem, rotate \`HOMEBREW_TAP_GITHUB_TOKEN\`"
+              echo "   (fine-grained PAT, Contents: read/write on \`${TAP_REPO}\`) and re-run"
+              echo "   this workflow, or push the formula by hand."
+              echo "2. To push by hand, copy the generated formula from this run's GoReleaser"
+              echo "   output into \`${TAP_FORMULA_PATH}\` in \`${TAP_REPO}\` — the checksums must"
+              echo "   match \`checksums.txt\` on the ${REF_NAME} release."
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            exit 1
+          }
+
+          if [[ -z "${GH_TOKEN}" ]]; then
+            soft_fail "HOMEBREW_TAP_GITHUB_TOKEN is not set on this repository, so the tap push was skipped."
+          fi
+
+          # GoReleaser writes dist/homebrew/<directory>/<name>.rb; the find is a
+          # fallback so a future layout change degrades to a warning instead of
+          # pushing nothing silently.
+          FORMULA_FILE="dist/homebrew/Formula/agent-deck.rb"
+          if [[ ! -f "${FORMULA_FILE}" ]]; then
+            FORMULA_FILE=$(find dist -type f -name 'agent-deck.rb' -print -quit 2>/dev/null || true)
+          fi
+          if [[ -z "${FORMULA_FILE}" || ! -s "${FORMULA_FILE}" ]]; then
+            soft_fail "GoReleaser did not produce a Homebrew formula under dist/ — nothing to push."
+          fi
+          echo "Using generated formula: ${FORMULA_FILE}"
+
+          # Same parse as scripts/verify-homebrew-install.sh, so the gate that
+          # checks the tap later reads the version the same way we wrote it.
+          # `|| true` because `sed | head -1` can SIGPIPE under pipefail; the
+          # value is validated on the next line either way.
+          FORMULA_VERSION=$(sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p' "${FORMULA_FILE}" | head -1 || true)
+          if [[ "${FORMULA_VERSION}" != "${VERSION}" ]]; then
+            soft_fail "Generated formula is for version ${FORMULA_VERSION:-<unparseable>}, not ${VERSION} — refusing to push a mismatched formula."
+          fi
+
+          # Cross-check the formula against the checksums of the artifacts that
+          # were just verified and attested. A formula whose sha256 does not
+          # match the published tarball breaks `brew install` for every user
+          # with a checksum error, so it must never reach the tap. dist-attest/
+          # was populated and checksum-verified by the attestation step above.
+          echo "Cross-checking formula checksums against the published checksums.txt..."
+          if [[ ! -s dist-attest/checksums.txt ]]; then
+            soft_fail "dist-attest/checksums.txt is missing — cannot verify the formula's checksums, refusing to push."
+          fi
+          # Pair each url with the sha256 that follows it, and emit
+          # "<sha256>  <basename>" — byte-identical to a checksums.txt line.
+          # Written outside the checkout so the release job leaves no stray file
+          # in the working tree.
+          PAIRS_FILE="${RUNNER_TEMP:-.}/formula-checksums.txt"
+          awk_pair() {
+            awk '
+              /^[[:space:]]*url "/ {
+                match($0, /"[^"]+"/); u = substr($0, RSTART + 1, RLENGTH - 2); next
+              }
+              /^[[:space:]]*sha256 "/ {
+                match($0, /"[^"]+"/); s = substr($0, RSTART + 1, RLENGTH - 2)
+                if (u == "") { print "UNPAIRED"; exit 1 }
+                n = split(u, p, "/"); print s "  " p[n]; u = ""
+              }
+            ' "$1"
+          }
+          awk_pair "${FORMULA_FILE}" > "${PAIRS_FILE}" || \
+            soft_fail "Could not pair urls with sha256 entries in the generated formula."
+
+          PAIRS=$(grep -c . "${PAIRS_FILE}" || true)
+          if [[ "${PAIRS}" -ne 4 ]]; then
+            soft_fail "Expected 4 url/sha256 pairs in the formula (darwin+linux × amd64+arm64), found ${PAIRS}."
+          fi
+          while IFS= read -r line; do
+            if ! grep -qxF -- "${line}" dist-attest/checksums.txt; then
+              soft_fail "Formula entry '${line}' does not match the published checksums.txt — refusing to push a formula that would fail \`brew install\`."
+            fi
+          done < "${PAIRS_FILE}"
+          echo "All 4 formula checksums match the published release artifacts."
+
+          if ! BRANCH=$(gh api "repos/${TAP_REPO}" --jq '.default_branch'); then
+            soft_fail "Cannot read ${TAP_REPO} — HOMEBREW_TAP_GITHUB_TOKEN is missing, expired or lacks access (this is the #1760 401)."
+          fi
+
+          # Blob sha of the file being replaced. Absent on the first push, and
+          # the API requires it for an update, so tolerate the 404.
+          CURRENT_SHA=$(gh api "repos/${TAP_REPO}/contents/${TAP_FORMULA_PATH}?ref=${BRANCH}" --jq '.sha' 2>/dev/null || true)
+
+          # Encoded separately and checked: an empty `content` would replace the
+          # tap's formula with an empty file, which is worse than not pushing.
+          # `base64 -w0` is GNU coreutils, which ubuntu-latest has; this step
+          # never runs outside CI (`make release-local` does not push the tap).
+          CONTENT_B64=$(base64 -w0 "${FORMULA_FILE}" || true)
+          if [[ -z "${CONTENT_B64}" ]]; then
+            soft_fail "Could not base64-encode ${FORMULA_FILE} — refusing to push an empty formula."
+          fi
+
+          PUT_ARGS=(
+            -X PUT "repos/${TAP_REPO}/contents/${TAP_FORMULA_PATH}"
+            -f "message=agent-deck ${REF_NAME}"
+            -f "content=${CONTENT_B64}"
+            -f "branch=${BRANCH}"
+          )
+          if [[ -n "${CURRENT_SHA}" ]]; then
+            PUT_ARGS+=(-f "sha=${CURRENT_SHA}")
+          fi
+          if ! gh api "${PUT_ARGS[@]}" --jq '.commit.html_url // "(no new commit — formula already current)"'; then
+            soft_fail "Pushing ${TAP_FORMULA_PATH} to ${TAP_REPO}@${BRANCH} failed."
+          fi
+
+          # Read the tap back through the API (not raw.githubusercontent.com,
+          # which is CDN-cached for minutes) so a silent no-op cannot pass as a
+          # successful push — the same paranoia as "Publish release" above.
+          PUSHED_VERSION=$(gh api "repos/${TAP_REPO}/contents/${TAP_FORMULA_PATH}?ref=${BRANCH}" --jq '.content' \
+            | base64 -d \
+            | sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p' | head -1 || true)
+          if [[ "${PUSHED_VERSION}" != "${VERSION}" ]]; then
+            soft_fail "After the push, ${TAP_REPO}/${TAP_FORMULA_PATH} still reports version ${PUSHED_VERSION:-<unparseable>}, not ${VERSION}."
+          fi
+          echo "Homebrew tap updated: ${TAP_REPO}/${TAP_FORMULA_PATH} is now ${VERSION}."
 
       - name: Notify on failure
         if: failure()

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,12 +110,58 @@ release:
 
     **Full Changelog**: https://github.com/asheshgoplani/agent-deck/compare/{{ .PreviousTag }}...{{ .Tag }}
 
+# Homebrew tap. GoReleaser only GENERATES the formula here — it never pushes it.
+# The push lives in .github/workflows/release.yml ("Update Homebrew tap formula"),
+# after the release is published and provenance is signed, and it cannot fail the
+# release job. See the skip_upload comment below for why (#1760, #1763).
+#
+# Why this is still `brews` and not `homebrew_casks` (#1761):
+# GoReleaser soft-deprecated `brews` in v2.10 and hard-deprecated it in v2.16, in
+# favour of `homebrew_casks`. We are deliberately not migrating yet:
+#   1. Casks are macOS-only. agent-deck ships linux/amd64 + linux/arm64, and
+#      README.md, install.sh and homebrew-verify.yml all advertise
+#      `brew install asheshgoplani/tap/agent-deck` to Mac AND Linux/WSL users
+#      (#873). A cask silently drops every Linuxbrew user.
+#   2. It is a user-visible, cross-repository migration: a `tap_migrations.json`
+#      plus deleting Formula/agent-deck.rb in asheshgoplani/homebrew-tap, so
+#      existing installs transition instead of breaking. None of that can be
+#      reviewed or reverted from this repo.
+#   3. It cannot be exercised right now: HOMEBREW_TAP_GITHUB_TOKEN is returning
+#      401 Bad credentials, so no tap write of any shape can be validated until
+#      it is rotated.
+#   4. Landing it here would make the first release after this change exercise
+#      two unproven things at once — the new push path and a new tap layout.
+#      The point of #1763 is to get the tap out of the release critical path;
+#      prove that first, migrate second.
+# The deadline risk is bounded: GoReleaser removes deprecated options "only on
+# major versions" (goreleaser.com/deprecations), and .github/workflows/release.yml
+# constrains the action to `~> v2`, so `brews` cannot turn into a hard error
+# without an explicit major bump here. Until then the deprecated block does
+# nothing but render a file locally, which is the least exposed way to use it.
 brews:
   - name: agent-deck
+    # Generate the formula into dist/homebrew/Formula/agent-deck.rb and stop.
+    #
+    # GoReleaser pushes the tap from inside `goreleaser release`, and a tap
+    # failure fails the whole invocation. With the dead tap token that aborted
+    # the GoReleaser step, so every step after it was SKIPPED — including
+    # "Attest build provenance". v1.10.9, v1.10.10 and v1.10.11 shipped with no
+    # SLSA provenance while SECURITY.md tells users to run
+    # `gh attestation verify` (#1760). A best-effort package manager must not be
+    # able to cancel build provenance, or delete a verified release's assets on
+    # a retry.
+    #
+    # Never set this back to false: that puts the tap back in the release's
+    # critical path and re-opens #1760.
+    skip_upload: true
     repository:
       owner: asheshgoplani
       name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      # No `token` on purpose. With skip_upload: true GoReleaser never talks to
+      # the tap, so it needs no tap credentials — which also means
+      # `make release-local` no longer requires HOMEBREW_TAP_GITHUB_TOKEN, and a
+      # template referencing an unset .Env key can no longer fail the config.
+      # The secret is used only by release.yml's post-publish push step.
     directory: Formula
     homepage: "https://github.com/asheshgoplani/agent-deck"
     description: "Terminal session manager for AI coding agents"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Releases carry SLSA build provenance again, and the Homebrew tap can no longer fail a release.** GoReleaser pushed the brew formula from inside `goreleaser release`, so when the tap token started returning `401 Bad credentials` the whole GoReleaser step failed and every step after it was skipped — including artifact attestation. v1.10.9, v1.10.10 and v1.10.11 therefore shipped with no provenance while `SECURITY.md` told users to run `gh attestation verify`. GoReleaser now only generates the formula (`brews.skip_upload`), provenance is signed *before* the release is published (so an unsigned release is never made visible), and the tap push is a separate best-effort step that runs afterwards and cannot fail the job. The tap push refuses to publish a formula whose version or SHA-256s do not match the verified release assets, and reports failures as a warning annotation plus a job summary instead of silently skipping. ([#1760](https://github.com/asheshgoplani/agent-deck/issues/1760), [#1763](https://github.com/asheshgoplani/agent-deck/issues/1763))
+
 ## [1.10.11] - 2026-07-26
 
 Reliability release. Session identity is now immutable after creation, the tmux

--- a/Makefile
+++ b/Makefile
@@ -173,12 +173,15 @@ ci:
 
 # Local release using GoReleaser
 # Prerequisites: brew install goreleaser
-# Required env: GITHUB_TOKEN, HOMEBREW_TAP_GITHUB_TOKEN
+# Required env: GITHUB_TOKEN
+# HOMEBREW_TAP_GITHUB_TOKEN is NOT needed: with brews.skip_upload GoReleaser only
+# generates dist/homebrew/Formula/agent-deck.rb and never touches the tap. CI's
+# post-publish step owns the push (#1763), so a local release does not update the
+# tap at all.
 release-local:
 	@echo "=== Pre-flight checks ==="
 	@which goreleaser > /dev/null || (echo "ERROR: goreleaser not found. Run: brew install goreleaser" && exit 1)
 	@test -n "$$GITHUB_TOKEN" || (echo "ERROR: GITHUB_TOKEN not set" && exit 1)
-	@test -n "$$HOMEBREW_TAP_GITHUB_TOKEN" || (echo "ERROR: HOMEBREW_TAP_GITHUB_TOKEN not set" && exit 1)
 	@TAG=$$(git describe --tags --exact-match 2>/dev/null) || (echo "ERROR: HEAD is not tagged. Run: git tag vX.Y.Z" && exit 1); \
 	CODE_VERSION=$$(grep 'var Version' cmd/agent-deck/main.go | sed 's/.*"\(.*\)".*/\1/'); \
 	TAG_VERSION=$${TAG#v}; \
@@ -196,6 +199,8 @@ release-local:
 	@echo "Verify the assets, then publish it yourself — CI's publish step does not run for a local release:"
 	@echo "  gh release view $$(git describe --tags --exact-match) --repo asheshgoplani/agent-deck"
 	@echo "  gh release edit $$(git describe --tags --exact-match) --repo asheshgoplani/agent-deck --draft=false --latest"
+	@echo "Note: no SLSA provenance and no Homebrew tap update happen for a local release —"
+	@echo "both live in .github/workflows/release.yml. Prefer pushing the tag and letting CI do it."
 
 # Web UI test targets
 # Vitest (unit) + Playwright (e2e + screenshot regression). Both run against

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,3 +27,11 @@ Out of scope: third-party Claude / agent CLI tools agent-deck wraps, third-party
   ```bash
   gh attestation verify agent-deck_*_linux_amd64.tar.gz --repo asheshgoplani/agent-deck
   ```
+  **Known gap: v1.10.9, v1.10.10 and v1.10.11 have no attestation.** A failure
+  publishing the Homebrew tap aborted the release job before the signing step, so
+  `gh attestation verify` reports "no attestations found" for those three tags —
+  a broken pipeline, not a tampered artifact. Their assets were checked by hand
+  against `checksums.txt`; a hand check is not a signature, so treat those three
+  tags as unattested. Fixed in [#1760](https://github.com/asheshgoplani/agent-deck/issues/1760):
+  provenance is now signed *before* a release is published, and the tap can no
+  longer fail the release job. Releases after v1.10.11 are attested again.


### PR DESCRIPTION
Closes #1763
Closes #1760
Refs #1761 (documented decision — see "The deprecated `brews` config" below; needs a human call before that issue is closed)

Completes the draft-first release work from #1762: the Homebrew tap comes out of the release's critical path, and SLSA build provenance ships again.

## The bug, precisely

`goreleaser release` pushes the brew formula **from inside the release run**, and a tap failure fails the whole invocation. The tap token has been returning `401 Bad credentials`, so every release died at the GoReleaser step — and everything after it was skipped:

From the v1.10.11 run (`30216679269`):

```
      • release published    url=https://github.com/asheshgoplani/agent-deck/releases/tag/v1.10.11
    • homebrew formula
      • error checking for default branch  projectID=asheshgoplani/homebrew-tap statusCode=401 error=GET https://api.github.com/repos/asheshgoplani/homebrew-tap: 401 Bad credentials []
  ⨯ release failed after 2m22s
    error= * homebrew formula: could not get default branch: ... 401 Bad credentials
```

Step outcomes for that same run:

| Step | Outcome |
|---|---|
| Run GoReleaser | **failure** |
| Validate release assets | skipped |
| Download and verify release artifacts for attestation | skipped |
| **Attest build provenance** | **skipped** |

So the attestation steps were never disabled — they were unreachable. A best-effort package manager was able to cancel build provenance for three consecutive releases (v1.10.9, v1.10.10, v1.10.11) while `SECURITY.md` tells users to run `gh attestation verify`.

## The fix

**1. `.goreleaser.yml` — `brews.skip_upload: true`.** GoReleaser now only *generates* `dist/homebrew/Formula/agent-deck.rb` and never talks to the tap, so a dead tap token cannot fail `goreleaser release`. The `repository.token` template is removed too: with `skip_upload` there is nothing to authenticate, which also means `make release-local` no longer requires the tap secret and `release-snapshot.yml` no longer needs its `HOMEBREW_TAP_GITHUB_TOKEN: snapshot-placeholder` workaround (that placeholder existed *only* to keep `{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}` resolvable).

**2. `release.yml` — provenance is signed BEFORE publishing.** `Attest build provenance` moved above `Publish release`. Beyond un-skipping it, this makes provenance a *precondition of visibility*: if signing fails, the draft is simply never published and no user is handed an artifact that `gh attestation verify` cannot check. The attest step only reads local `dist-attest/` files, so it does not need the release to be public. If Sigstore is genuinely down and a release must go out anyway, the verified draft can be published by hand (documented in the step comment).

**3. `release.yml` — new final `Update Homebrew tap formula (best effort)` step**, `continue-on-error: true`, running after `Publish release` (required for correctness: the formula's download URLs only resolve once the release is public, and `homebrew-verify.yml` compares the tap against `/releases/latest`).

It cannot fail the job, but it is not silent either. Every non-success path emits a `::warning::` annotation **and** an actionable job summary (how to rotate the token, how to push by hand). And it refuses to push a bad formula:

- the generated formula's `version` must equal the tag;
- all four of its `sha256` values must match the release's already-verified `checksums.txt`, paired url-by-url — a formula with a stale checksum breaks `brew install` for *every* user with a checksum error, which is worse than a stale formula;
- the `content` is base64-encoded into a variable and checked non-empty first, so a broken encode can never overwrite the tap's formula with an empty file;
- after the push it re-reads the formula **through the API** (not `raw.githubusercontent.com`, which is CDN-cached for minutes) and fails if the version did not change — the same "a silent no-op must not pass as success" paranoia as `Publish release`.

**4. Docs.** `.github/workflows/README.md` gains a section on the new tail ordering. `SECURITY.md` states the known gap honestly: v1.10.9/10/11 have no attestation, that is a broken pipeline rather than a tampered artifact, and a hand checksum check is not a signature. `Makefile` drops the now-unnecessary `HOMEBREW_TAP_GITHUB_TOKEN` pre-flight and says plainly that a local release does not attest and does not touch the tap.

## The deprecated `brews` config (#1761) — decision, not an oversight

GoReleaser soft-deprecated `brews` in v2.10 and hard-deprecated it in v2.16 in favour of `homebrew_casks`. **This PR deliberately stays on `brews`**, for four reasons:

1. **Casks are macOS-only.** agent-deck ships `linux/amd64` + `linux/arm64`, and `README.md`, `install.sh` and `homebrew-verify.yml` all advertise `brew install asheshgoplani/tap/agent-deck` to Mac **and** Linux/WSL users (#873). A cask silently drops every Linuxbrew user.
2. **It is a user-visible, cross-repository migration.** Per the GoReleaser docs the correct path needs a `tap_migrations.json` plus deleting `Formula/agent-deck.rb` in `asheshgoplani/homebrew-tap`, so existing installs transition instead of breaking. None of that can be reviewed or reverted from this repo, and `scripts/verify-homebrew-install.sh` is hard-wired to `Formula/agent-deck.rb`.
3. **It cannot be exercised right now.** The tap token returns 401, so no tap write of any shape can be validated until it is rotated.
4. **It would make the next release exercise two unproven things at once** — the new push path *and* a new tap layout. The point of #1763 is to get the tap out of the release critical path; prove that first, migrate second.

The deadline risk is bounded and stated in the GoReleaser docs: *"Deprecated options are only removed on major versions of GoReleaser"*, and `release.yml` constrains the action to `~> v2`. Confirmed empirically: the v1.10.11 run used goreleaser **2.17.1** and `brews` still only warns. So `brews` cannot turn into a hard error without an explicit major bump in this repo. Until then the deprecated block does nothing but render a file locally — the least exposed way to use it. The full rationale and a migration checklist are recorded as a comment above the `brews` block so the next person does not have to rediscover it.

**#1761 therefore needs a human call.** If you accept the reasoning, close it as decided; if you want the cask migration, it should be its own PR after the tap token is rotated and this pipeline change has survived one real release.

## Maintainer action still required

`HOMEBREW_TAP_GITHUB_TOKEN` is still dead. After this PR the tap step will show as **red-but-ignored** on every release until it is rotated — visible, non-blocking, and no longer able to cost the release its provenance. To fix at the root: create a fine-grained PAT with **Contents: read/write** on `asheshgoplani/homebrew-tap` and set it as the `HOMEBREW_TAP_GITHUB_TOKEN` repo secret. (The tap formula is currently at 1.10.11 and correct — it was pushed by hand.)

## Verification

No Go code changed. The true test is the next real release; everything testable ahead of that was tested.

- `actionlint` clean on `release.yml`, `release-snapshot.yml`, `homebrew-verify.yml`.
- `goreleaser check` validates `.goreleaser.yml` (only the expected `brews` deprecation notice).
- **`goreleaser release --snapshot --clean` end-to-end locally: exit 0**, all four targets cross-compiled, and with `skip_upload` the formula is still written — `writing formula=dist/homebrew/Formula/agent-deck.rb`. This is what confirms the path the new step reads, and that no tap credentials are needed any more.
- The formula-vs-checksums cross-check was run against **real** GoReleaser output: the locally generated formula against its own `dist/checksums.txt` (4/4 match), and the **live v1.10.11 tap formula** (goreleaser 2.17.1 output) against the **published v1.10.11 `checksums.txt`** (4/4 match, version parsed as `1.10.11`).
- The tap step's script was extracted from the workflow and driven through 9 scenarios with stubbed `gh`: happy path (exit 0, tap updated) plus missing token, no formula in `dist/`, formula/tag version mismatch, checksum mismatch, missing `checksums.txt`, tap 401, only 3 url/sha256 pairs, and a "push returned success but the tap still shows the old version" no-op. All eight failure paths exit non-zero with the right message and a job summary; none of them can fail the job.
- `bash -n` on the step script; `make -n release-local` parses.

## Coordination

Touches no Go files and nothing under `internal/ui`, so there is no overlap with the in-flight TUI perf work (#1764, #1765). One adjacency: #1687 also edits `release-snapshot.yml`, but in the `on.push.paths` list (~line 21) while this PR edits the goreleaser step's `env:` (~line 49) — different hunks, no conflict expected.
