### PR TITLE
fix(watchdog): confirm a session is really stuck before restarting it (closes #1705)

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -3,18 +3,24 @@ name: python-compat
 # Regression gate for #864 - bridge.py must import on the Python version
 # shipped by default with WSL Ubuntu 20.04 (3.8). Runs on every PR that
 # touches the conductor bridge or its tests.
+#
+# The watchdog job (added for #1705) guards the other shipped Python daemon:
+# its unit suite had no gate at all, which is how a false-positive restart of a
+# live conductor could regress unnoticed.
 
 on:
   pull_request:
     paths:
       - 'internal/session/conductor_bridge.py'
       - 'conductor/tests/**'
+      - 'scripts/watchdog/**'
       - '.github/workflows/python-compat.yml'
   push:
     branches: [main]
     paths:
       - 'internal/session/conductor_bridge.py'
       - 'conductor/tests/**'
+      - 'scripts/watchdog/**'
       - '.github/workflows/python-compat.yml'
 
 jobs:
@@ -39,3 +45,22 @@ jobs:
         run: python -c "import sys; sys.path.insert(0, 'internal/session'); import conductor_bridge"
       - name: Compatibility test suite
         run: python -m pytest conductor/tests/test_python_compat.py -v
+
+  watchdog-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.12']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Compile-check
+        run: python -m py_compile scripts/watchdog/watchdog.py
+      # The suite isolates itself (temp log dirs, a binary path that cannot
+      # exist, no sleeps) and needs no third-party packages.
+      - name: Watchdog unit suite
+        working-directory: scripts/watchdog
+        run: python -m unittest test_watchdog -v

--- a/internal/session/reviver.go
+++ b/internal/session/reviver.go
@@ -118,13 +118,55 @@ func NewReviver() *Reviver {
 // is fixed via Storage.PersistRevivedInstances.
 func (r *Reviver) Classify(inst *Instance) RevivalClass {
 	name := instanceTmuxName(inst)
-	if !r.TmuxExists(name, inst.TmuxSocketName) {
-		return ClassDead
+	tmuxAlive := r.TmuxExists(name, inst.TmuxSocketName)
+	// Read the pipe whenever the server is up, even when the stored status alone
+	// already settles the verdict: the READING is the evidence #1705 asked for, and
+	// a log line that omits it cannot answer "was the session actually dead?" after
+	// the fact. IsConnected is an in-memory map lookup, so this costs nothing.
+	pipeAlive := false
+	if tmuxAlive && r.PipeAlive != nil {
+		pipeAlive = r.PipeAlive(name)
 	}
-	if inst.Status == StatusError || !r.PipeAlive(name) {
-		return ClassErrored
+
+	class := ClassAlive
+	switch {
+	case !tmuxAlive:
+		class = ClassDead
+	case inst.Status == StatusError || !pipeAlive:
+		class = ClassErrored
 	}
-	return ClassAlive
+	r.logClassify(inst, name, tmuxAlive, pipeAlive, class)
+	return class
+}
+
+// logClassify records the readings behind a classification, not just its outcome.
+//
+// Issue #1705 was a live conductor restarted as if it were dead, and the
+// investigation stalled because only the OUTCOME was recoverable afterwards — the
+// readings that produced it were never written down anywhere an operator could
+// retrieve. So every non-alive verdict states its evidence: tmux liveness, the
+// control-pipe reading, the stored status it was judged against, and when. Alive
+// verdicts stay at debug level; they are the overwhelming majority and carry no
+// diagnostic value.
+func (r *Reviver) logClassify(inst *Instance, name string, tmuxAlive, pipeAlive bool, class RevivalClass) {
+	if r.Log == nil {
+		return
+	}
+	attrs := []any{
+		slog.String("title", inst.Title),
+		slog.String("instance_id", inst.ID),
+		slog.String("tmux_session", name),
+		slog.Bool("tmux_alive", tmuxAlive),
+		slog.Bool("pipe_alive", pipeAlive),
+		slog.String("stored_status", string(inst.Status)),
+		slog.String("class", class.String()),
+		slog.Time("sampled_at", time.Now()),
+	}
+	if class == ClassAlive {
+		r.Log.Debug("reviver_classify", attrs...)
+		return
+	}
+	r.Log.Info("reviver_classify", attrs...)
 }
 
 // ReviveAll walks instances, classifies each, and triggers ReviveAction for

--- a/internal/session/reviver_classify_evidence_test.go
+++ b/internal/session/reviver_classify_evidence_test.go
@@ -1,0 +1,144 @@
+package session
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// Issue #1705: a live conductor was restarted as if it were dead, and the
+// investigation could not get past "the restart fired" because the READINGS
+// behind that verdict were never written down. Classify now states its evidence
+// for every non-alive verdict.
+
+// classifyAttrs returns the attributes of the last reviver_classify record.
+func classifyAttrs(t *testing.T, h *recordingHandler) map[string]string {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := len(h.recs) - 1; i >= 0; i-- {
+		if h.recs[i].Message != "reviver_classify" {
+			continue
+		}
+		attrs := map[string]string{}
+		h.recs[i].Attrs(func(a slog.Attr) bool {
+			attrs[a.Key] = a.Value.String()
+			return true
+		})
+		attrs["__level"] = h.recs[i].Level.String()
+		return attrs
+	}
+	t.Fatalf("no reviver_classify record emitted")
+	return nil
+}
+
+func TestReviver_Classify_LogsEvidenceForErroredSession(t *testing.T) {
+	inst := newReviverTestInstance("evidence-errored", StatusError)
+	h := &recordingHandler{}
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		PipeAlive:    func(string) bool { return false },
+		ReviveAction: func(*Instance) error { return nil },
+		Log:          slog.New(h),
+	}
+
+	if got := r.Classify(inst); got != ClassErrored {
+		t.Fatalf("expected ClassErrored, got %v", got)
+	}
+
+	attrs := classifyAttrs(t, h)
+	for key, want := range map[string]string{
+		"tmux_alive":    "true",
+		"pipe_alive":    "false",
+		"stored_status": string(StatusError),
+		"class":         "errored",
+		"title":         "evidence-errored",
+	} {
+		if attrs[key] != want {
+			t.Errorf("attr %q = %q, want %q", key, attrs[key], want)
+		}
+	}
+	if attrs["sampled_at"] == "" {
+		t.Error("evidence must be timestamped (sampled_at missing)")
+	}
+	if attrs["__level"] != slog.LevelInfo.String() {
+		t.Errorf("a non-alive verdict must be retrievable without debug logging; level=%s", attrs["__level"])
+	}
+}
+
+// The pipe reading must be recorded even when the stored status alone already
+// settles the verdict — it is the reading that says whether the session was
+// reachable, which is the whole question #1705 could not answer afterwards.
+func TestReviver_Classify_RecordsPipeReadingEvenWhenStatusDecides(t *testing.T) {
+	inst := newReviverTestInstance("evidence-live-pipe", StatusError)
+	h := &recordingHandler{}
+	probed := 0
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		PipeAlive:    func(string) bool { probed++; return true },
+		ReviveAction: func(*Instance) error { return nil },
+		Log:          slog.New(h),
+	}
+
+	if got := r.Classify(inst); got != ClassErrored {
+		t.Fatalf("a StatusError session on a live server stays ClassErrored, got %v", got)
+	}
+	if probed != 1 {
+		t.Fatalf("expected the pipe to be probed once for the record, got %d probes", probed)
+	}
+	if attrs := classifyAttrs(t, h); attrs["pipe_alive"] != "true" {
+		t.Errorf("pipe_alive = %q, want true (a live pipe under a StatusError reading is exactly the false-positive signal)", attrs["pipe_alive"])
+	}
+}
+
+func TestReviver_Classify_DeadServerEvidence(t *testing.T) {
+	inst := newReviverTestInstance("evidence-dead", StatusRunning)
+	h := &recordingHandler{}
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return false },
+		PipeAlive:    func(string) bool { t.Fatal("pipe must not be probed when the server is gone"); return false },
+		ReviveAction: func(*Instance) error { return nil },
+		Log:          slog.New(h),
+	}
+
+	if got := r.Classify(inst); got != ClassDead {
+		t.Fatalf("expected ClassDead, got %v", got)
+	}
+	attrs := classifyAttrs(t, h)
+	if attrs["tmux_alive"] != "false" || attrs["class"] != "dead" {
+		t.Errorf("dead-server evidence wrong: tmux_alive=%q class=%q", attrs["tmux_alive"], attrs["class"])
+	}
+}
+
+// An alive session is the overwhelming majority of every sweep: its verdict stays
+// at debug level so the fleet does not drown the useful records.
+func TestReviver_Classify_AliveVerdictStaysDebug(t *testing.T) {
+	inst := newReviverTestInstance("evidence-alive", StatusRunning)
+	h := &recordingHandler{}
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		PipeAlive:    func(string) bool { return true },
+		ReviveAction: func(*Instance) error { return nil },
+		Log:          slog.New(h),
+	}
+
+	if got := r.Classify(inst); got != ClassAlive {
+		t.Fatalf("expected ClassAlive, got %v", got)
+	}
+	if attrs := classifyAttrs(t, h); attrs["__level"] != slog.LevelDebug.String() {
+		t.Errorf("alive verdict level = %s, want DEBUG", attrs["__level"])
+	}
+}
+
+// A Reviver built by hand without a PipeAlive func must not panic: Classify used
+// to call it unconditionally on the non-error path only, and the evidence read
+// widened when that call site moved.
+func TestReviver_Classify_NilPipeAliveDoesNotPanic(t *testing.T) {
+	inst := newReviverTestInstance("evidence-nilpipe", StatusRunning)
+	r := &Reviver{
+		TmuxExists:   func(string, string) bool { return true },
+		ReviveAction: func(*Instance) error { return nil },
+	}
+	if got := r.Classify(inst); got != ClassErrored {
+		t.Fatalf("no pipe reading available → not provably alive; got %v", got)
+	}
+}

--- a/scripts/watchdog/DESIGN.md
+++ b/scripts/watchdog/DESIGN.md
@@ -72,7 +72,29 @@ A session is excluded if `status` == `"stopped"` (user deliberately stopped it).
 
 Call `agent-deck session restart <id>` — this preserves ClaudeSessionID via `respawn-pane -k`, env_file, config_dir, channels. Exactly what conductors need. No new restart logic in the watchdog; we reuse the battle-tested path.
 
+When agent-deck answers that call with `skipped: true`, a guard inside agent-deck declined on purpose (an auth hold, or the freshness guard from #30). The watchdog stops there: it does **not** escalate to `session start`, which would defeat the guard that just fired.
+
 ## Guardrails
+
+### Liveness confirmation immediately before the restart (#1705)
+
+A restart tears a live pane down, so the decision to fire one must be about the session **now** — not about whenever the triggering sample was taken. Two ways the authorizing `status == error` reading goes wrong:
+
+- **Stale.** Restarts are globally serialized (`MIN_GLOBAL_RESTART_INTERVAL_S`) and a cascade revives serially, so a queued decision can execute minutes after its sample. The session may have recovered in between.
+- **False.** `error` is partly derived from pane *content*, so a banner-shaped line sitting in scrollback keeps the verdict standing while the agent works on happily. Re-reading the status cannot see this: the content does not move, so every read agrees.
+
+So, as the last step inside `_do_restart` (after the serialization wait, not before it), the watchdog re-reads the status and samples the pane twice `LIVENESS_CONFIRM_GAP_S` apart via `session output --pane`. It skips the restart when:
+
+| Reason | Why |
+|---|---|
+| `recovered_before_restart` | the status is no longer `error` — the stale case |
+| `pane_active` | the pane is still producing output; an agent emitting output is not dead |
+| `status_unreadable` | we cannot see the session, so we cannot claim it is dead |
+| `auth_hold` | a restart cannot fix a credential, and each doomed boot races the shared rotating refresh token |
+
+A skip returns the rate-limit slot the caller reserved (a restart that never happened is not an attempt), so a live session the watchdog declined to touch cannot escalate as "keeps crashing". `LIVENESS_SKIP_ESCALATE_AFTER` consecutive `pane_active` skips escalate as `liveness-mismatch` — that is a status-classification problem to investigate, not a dead session.
+
+Every decision, skip or restart, is appended to `~/.agent-deck/watchdog/liveness.log`: both status reads with timestamps and substates, both pane digests, whether the pane moved, the auth-hold reason, and the verdict. Digests, never pane text — the log is meant to be readable and pasteable into a bug report.
 
 ### Per-session rate limit
 
@@ -129,6 +151,8 @@ No external store — state lives in-memory, resets on daemon restart. Acceptabl
 - `~/.agent-deck/watchdog/watchdog.py` — the daemon
 - `~/.agent-deck/watchdog/escalate.sh` — escalation stub (template)
 - `~/.agent-deck/watchdog/escalations.log` — written by daemon
+- `~/.agent-deck/watchdog/restart.log` — one record per restart, skip or refusal
+- `~/.agent-deck/watchdog/liveness.log` — one record per liveness decision, with the readings behind it (#1705)
 - `~/.agent-deck/watchdog/autorestart/<id>` — marker files for explicit opt-in (dir created by daemon)
 - `~/.config/systemd/user/agent-deck-watchdog.service` — user-level systemd unit (disabled until user approves)
 

--- a/scripts/watchdog/DESIGN.md
+++ b/scripts/watchdog/DESIGN.md
@@ -90,9 +90,10 @@ So, as the last step inside `_do_restart` (after the serialization wait, not bef
 | `recovered_before_restart` | the status is no longer `error` — the stale case |
 | `pane_active` | the pane is still producing output; an agent emitting output is not dead |
 | `status_unreadable` | we cannot see the session, so we cannot claim it is dead |
+| `shutting_down` | the daemon is exiting mid-sample; there is no second reading, and exit time is the worst time to be wrong |
 | `auth_hold` | a restart cannot fix a credential, and each doomed boot races the shared rotating refresh token |
 
-A skip returns the rate-limit slot the caller reserved (a restart that never happened is not an attempt), so a live session the watchdog declined to touch cannot escalate as "keeps crashing". `LIVENESS_SKIP_ESCALATE_AFTER` consecutive `pane_active` skips escalate as `liveness-mismatch` — that is a status-classification problem to investigate, not a dead session.
+A skip returns the rate-limit slot the caller reserved (a restart that never happened is not an attempt), so a live session the watchdog declined to touch cannot escalate as "keeps crashing". `LIVENESS_SKIP_ESCALATE_AFTER` consecutive `pane_active` skips escalate as `liveness-mismatch` — that is a status-classification problem to investigate, not a dead session. That alert and the auth-hold one fire once per error episode rather than once per poll (both conditions are observed on every poll until a human clears them); the skip counter resets when the session is next seen healthy.
 
 Every decision, skip or restart, is appended to `~/.agent-deck/watchdog/liveness.log`: both status reads with timestamps and substates, both pane digests, whether the pane moved, the auth-hold reason, and the verdict. Digests, never pane text — the log is meant to be readable and pasteable into a bug report.
 

--- a/scripts/watchdog/README.md
+++ b/scripts/watchdog/README.md
@@ -20,6 +20,25 @@ See `DESIGN.md` for architecture.
    (`parent_session_id` set) stuck in `status=waiting` with an unchanged tmux
    pane for >10 min, inject `report status?` via `agent-deck session send`
    (max one nudge per hour per session).
+4. **Liveness confirmation before every restart (#1705)** — the last thing before
+   a pane is torn down. A restart is destructive and the `status == error`
+   reading that authorizes one can be *stale* (restarts are serialized, and a
+   cascade revives serially, so a queued decision can execute minutes after its
+   sample) or *false* (`error` is partly derived from pane content, so a
+   banner-shaped line in scrollback keeps the verdict standing while the agent
+   works on). At the moment of the restart the watchdog therefore re-reads the
+   status, samples the pane twice, and skips the restart when the session
+   recovered, when the pane is still producing output, when the status cannot be
+   read, or when the session is held for an auth failure — a restart cannot fix
+   a credential. Every decision, skip or restart, is recorded in `liveness.log`
+   with its readings (statuses, substates, timestamps, pane digests). Digests
+   only: the log never carries pane text.
+
+   A skipped restart does not consume the per-session rate-limit budget, so a
+   session the watchdog correctly declined to touch cannot escalate as "keeps
+   crashing". Three consecutive skips on a moving pane escalate as
+   `liveness-mismatch` instead — that is a status-classification problem, not a
+   dead session.
 
 ## Install
 
@@ -69,17 +88,12 @@ python3 -m unittest test_watchdog -v
 pytest test_watchdog.py
 ```
 
-The full suite takes ~9 minutes because several tests exercise the global
-restart serialization (`MIN_GLOBAL_RESTART_INTERVAL_S=60`). For iterating on
-the v1.7.63 additions specifically:
-
-```bash
-python3 -m unittest \
-  test_watchdog.TestPollerExistence \
-  test_watchdog.TestBunTelegramStateDirs \
-  test_watchdog.TestWaitingTooLong
-# Runs in <1s.
-```
+The whole suite runs in well under a second. `setUpModule` redirects every log
+path to a temp dir, points `AGENT_DECK_BIN` at a path that cannot exist, and
+zeroes the two sleeps (`MIN_GLOBAL_RESTART_INTERVAL_S`, `LIVENESS_CONFIRM_GAP_S`).
+That isolation is not optional: the defaults resolve under `~/.agent-deck`, which
+on a maintainer machine is the live data directory, and the real CLI would be
+invoked against real sessions. Keep any new test inside it.
 
 ## Operational notes
 
@@ -87,4 +101,7 @@ python3 -m unittest \
   send / Telegram. Safe to leave running.
 - **One-shot** (`--once`) executes a single safety-poll pass and exits. Useful
   from shell scripts or cron alongside the systemd service.
-- Logs land in `$AGENT_DECK_ROOT/watchdog/{watchdog.log,restart.log,escalations.log}`.
+- Logs land in `$AGENT_DECK_ROOT/watchdog/{watchdog.log,restart.log,escalations.log,liveness.log}`.
+- `liveness.log` is the first thing to read after an unexpected restart (or an
+  expected one that never came): one JSON record per decision, carrying the
+  readings behind it rather than only its outcome.

--- a/scripts/watchdog/README.md
+++ b/scripts/watchdog/README.md
@@ -38,7 +38,9 @@ See `DESIGN.md` for architecture.
    session the watchdog correctly declined to touch cannot escalate as "keeps
    crashing". Three consecutive skips on a moving pane escalate as
    `liveness-mismatch` instead — that is a status-classification problem, not a
-   dead session.
+   dead session. Both that alert and the auth-hold one fire once per error
+   episode, not once per poll; the counter resets when the session is next seen
+   healthy.
 
 ## Install
 

--- a/scripts/watchdog/test_watchdog.py
+++ b/scripts/watchdog/test_watchdog.py
@@ -12,6 +12,51 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).parent))
 import watchdog as wd_mod
 
+_ISOLATION = {}
+
+# Every module-level name this suite overrides, so tearDownModule can put the
+# real ones back and nothing leaks between test runs in the same interpreter.
+_ISOLATED_NAMES = (
+    "AGENT_DECK_BIN", "WATCHDOG_DIR", "AUTORESTART_DIR", "ESCALATIONS_LOG",
+    "RESTART_LOG", "LIVENESS_LOG", "ESCALATE_SCRIPT",
+    "MIN_GLOBAL_RESTART_INTERVAL_S", "LIVENESS_CONFIRM_GAP_S",
+)
+
+
+def setUpModule():
+    """Keep the suite off the live agent-deck install, and make it fast.
+
+    watchdog.py resolves its log paths under AGENT_DECK_ROOT (default
+    ~/.agent-deck, which on a maintainer machine is the LIVE data directory) and
+    shells out to AGENT_DECK_BIN. Unguarded, a test run appends to the real
+    watchdog logs and can invoke the real CLI against real sessions. Redirect
+    both, point the binary at a path that cannot exist, and drop the two sleeps
+    (inter-restart spacing, liveness sample gap) so the suite finishes in seconds
+    instead of minutes — which is what lets it run in CI at all.
+    """
+    _ISOLATION["tmp"] = tempfile.TemporaryDirectory()
+    root = Path(_ISOLATION["tmp"].name)
+    (root / "watchdog" / "autorestart").mkdir(parents=True, exist_ok=True)
+    _ISOLATION["saved"] = {name: getattr(wd_mod, name) for name in _ISOLATED_NAMES}
+
+    wd_mod.AGENT_DECK_BIN = str(root / "no-such-agent-deck-binary")
+    wd_mod.WATCHDOG_DIR = root / "watchdog"
+    wd_mod.AUTORESTART_DIR = root / "watchdog" / "autorestart"
+    wd_mod.ESCALATIONS_LOG = root / "watchdog" / "escalations.log"
+    wd_mod.RESTART_LOG = root / "watchdog" / "restart.log"
+    wd_mod.LIVENESS_LOG = root / "watchdog" / "liveness.log"
+    wd_mod.ESCALATE_SCRIPT = root / "watchdog" / "escalate.sh"  # deliberately absent
+    wd_mod.MIN_GLOBAL_RESTART_INTERVAL_S = 0
+    wd_mod.LIVENESS_CONFIRM_GAP_S = 0.0
+
+
+def tearDownModule():
+    for name, value in _ISOLATION.get("saved", {}).items():
+        setattr(wd_mod, name, value)
+    tmp = _ISOLATION.pop("tmp", None)
+    if tmp is not None:
+        tmp.cleanup()
+
 
 def make_sess(sid="c-1", title="conductor-travel", group="", profile="personal",
               status="error", is_conductor=False):
@@ -689,6 +734,233 @@ class TestWaitingTooLong(unittest.TestCase):
             for args in call_args
         )
         self.assertTrue(found_send, f"expected session send call, got: {call_args}")
+
+
+class TestLivenessConfirmation(unittest.TestCase):
+    """Issue #1705: a conductor was restarted mid-turn while its agent was alive
+    and working. A restart tears the pane down, so the last thing the watchdog does
+    before firing one is confirm — right then — that the session really is stuck."""
+
+    def setUp(self):
+        self.wd = wd_mod.Watchdog(dry_run=True)
+        self.sess = make_sess(sid="cond-live", title="conductor-bruce")
+
+    def _liveness_records(self):
+        path = Path(wd_mod.LIVENESS_LOG)
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+    def _restart_records(self):
+        path = Path(wd_mod.RESTART_LOG)
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+    def test_moving_pane_vetoes_the_restart(self):
+        """The #1705 case: status says error, but the pane keeps producing output.
+        An agent that is still emitting output is not dead, whatever the status
+        reading says — and re-reading the status cannot see this, because a
+        content-derived verdict does not move while the agent works."""
+        with mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot",
+                               side_effect=["…curl running", "…curl finished, next tool"]):
+            proceed, record = self.wd._confirm_restart_needed("cond-live", "conductor-bruce", "personal")
+
+        self.assertFalse(proceed, "a pane that is still moving must not be restarted")
+        self.assertEqual(record["reason"], "pane_active")
+        self.assertTrue(record["pane"]["changed"])
+
+    def test_recovery_during_the_serialization_wait_vetoes_the_restart(self):
+        """Restarts are serialized (and cascades revive serially), so the decision
+        can execute long after the sample that justified it. By then the session may
+        have recovered on its own — the stale half of #1705."""
+        recovered = make_sess(sid="cond-live", title="conductor-bruce", status="running")
+        with mock.patch.object(wd_mod, "show_session", return_value=recovered), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", return_value="frozen"):
+            proceed, record = self.wd._confirm_restart_needed("cond-live", "conductor-bruce", "personal")
+
+        self.assertFalse(proceed)
+        self.assertEqual(record["reason"], "recovered_before_restart")
+
+    def test_frozen_pane_and_two_agreeing_reads_confirm_the_restart(self):
+        """The genuine death this watchdog exists for still restarts."""
+        with mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", return_value=""):
+            proceed, record = self.wd._confirm_restart_needed("cond-live", "conductor-bruce", "personal")
+
+        self.assertTrue(proceed)
+        self.assertEqual(record["reason"], "confirmed_dead")
+        self.assertEqual(len(record["reads"]), 2, "the decision must rest on two status reads")
+
+    def test_unreadable_status_is_not_treated_as_death(self):
+        with mock.patch.object(wd_mod, "show_session", return_value=None), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", return_value="x"):
+            proceed, record = self.wd._confirm_restart_needed("cond-live", "conductor-bruce", "personal")
+
+        self.assertFalse(proceed, "if we cannot see the session we cannot claim it is dead")
+        self.assertEqual(record["reason"], "status_unreadable")
+
+    def test_shutdown_mid_sample_leaves_the_session_alone(self):
+        self.wd.stop_event.set()
+        try:
+            with mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+                 mock.patch.object(wd_mod, "fetch_pane_snapshot", return_value="frozen"):
+                proceed, record = self.wd._confirm_restart_needed(
+                    "cond-live", "conductor-bruce", "personal")
+        finally:
+            self.wd.stop_event.clear()
+
+        self.assertFalse(proceed, "shutting down is the worst time to be wrong about a pane")
+        self.assertEqual(record["reason"], "shutting_down")
+
+    def test_auth_held_session_is_left_alone_and_escalated(self):
+        """Merged auth-hold policy: a restart cannot fix a credential, and each
+        doomed boot races the shared rotating refresh token."""
+        held = dict(self.sess)
+        held["substate"] = "auth-401"
+        held["auth_hold"] = {
+            "reason": "auth_death",
+            "remedy": "run /login, then restart it explicitly",
+            "evidence": "API Error: 401 <pane tail>",
+        }
+        with mock.patch.object(wd_mod, "show_session", return_value=held), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", return_value="") as pane, \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            proceed, record = self.wd._confirm_restart_needed(
+                "cond-live", "conductor-bruce", "personal", escalate_critical=True)
+
+        self.assertFalse(proceed)
+        self.assertEqual(record["reason"], "auth_hold")
+        self.assertEqual(record["auth_hold_reason"], "auth_death")
+        pane.assert_not_called()
+        tg.assert_called_once()
+        self.assertIn("auth-hold", Path(wd_mod.ESCALATIONS_LOG).read_text())
+
+    def test_record_carries_digests_not_pane_text(self):
+        """The record is written to be read by humans and pasted into bug reports,
+        so it must never carry pane content, prompts or secrets."""
+        private = "DO-NOT-LOG-THIS-PANE-TEXT and this conversation content"
+        with mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", side_effect=[private, private + "!"]):
+            _, record = self.wd._confirm_restart_needed("cond-live", "conductor-bruce", "personal")
+
+        serialized = json.dumps(record)
+        self.assertNotIn("DO-NOT-LOG-THIS-PANE-TEXT", serialized)
+        self.assertNotIn("conversation content", serialized)
+        self.assertEqual(len(record["pane"]["first"]), 16)
+        self.assertNotEqual(record["pane"]["first"], record["pane"]["second"])
+
+        persisted = self._liveness_records()[-1]
+        self.assertEqual(persisted["reason"], "pane_active", "every decision is recorded")
+        self.assertEqual(persisted["pane"], record["pane"])
+        self.assertNotIn("DO-NOT-LOG-THIS-PANE-TEXT", json.dumps(persisted))
+
+    def test_skipped_restart_does_not_burn_the_rate_limit_budget(self):
+        """A restart that never happened is not an attempt: otherwise a live
+        session the watchdog correctly declined to touch would exhaust its
+        3-per-10-min budget and escalate as "keeps crashing"."""
+        moving = ["frame-%d" % i for i in range(40)]
+        with mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", side_effect=moving), \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True):
+            for _ in range(wd_mod.RATE_LIMIT_MAX + 1):
+                self.wd.cooldown_until.pop("cond-live", None)
+                self.wd.maybe_restart(self.sess)
+
+        self.assertEqual(len(self.wd.restart_history.get("cond-live", [])), 0)
+        skipped = [r for r in self._restart_records() if r.get("action") == "skipped-alive"]
+        self.assertTrue(skipped, "the skip is auditable from the restart log too")
+        self.assertNotIn("keeps crashing", Path(wd_mod.ESCALATIONS_LOG).read_text())
+
+    def test_repeated_alive_skips_escalate_as_a_classification_problem(self):
+        moving = ["frame-%d" % i for i in range(40)]
+        with mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", side_effect=moving), \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            for _ in range(wd_mod.LIVENESS_SKIP_ESCALATE_AFTER):
+                self.wd._confirm_restart_needed(
+                    "cond-live", "conductor-bruce", "personal", escalate_critical=True)
+
+        tg.assert_called_once()
+        self.assertIn("liveness-mismatch", Path(wd_mod.ESCALATIONS_LOG).read_text())
+
+    def test_confirmation_runs_after_the_serialization_wait(self):
+        """Ordering is the whole point: confirming before the wait would confirm a
+        session that has been sitting in a restart queue ever since."""
+        events = []
+        wd = wd_mod.Watchdog(dry_run=True)
+
+        def _tracking_wait(timeout=None):
+            events.append(("wait", timeout))
+            return False  # never "stopped"; return immediately instead of sleeping
+
+        def _tracking_sample(sid, profile):
+            events.append(("sample", None))
+            return "frozen"
+
+        saved_interval = wd_mod.MIN_GLOBAL_RESTART_INTERVAL_S
+        wd_mod.MIN_GLOBAL_RESTART_INTERVAL_S = 30
+        try:
+            wd.last_global_restart_at = time.time()
+            with mock.patch.object(wd.stop_event, "wait", side_effect=_tracking_wait), \
+                 mock.patch.object(wd_mod, "show_session", return_value=self.sess), \
+                 mock.patch.object(wd_mod, "fetch_pane_snapshot", side_effect=_tracking_sample):
+                wd._do_restart("cond-live", "conductor-bruce", "personal")
+        finally:
+            wd_mod.MIN_GLOBAL_RESTART_INTERVAL_S = saved_interval
+
+        self.assertTrue(events, "expected the restart path to both wait and sample")
+        kind, timeout = events[0]
+        self.assertEqual(kind, "wait")
+        self.assertGreater(timeout, 1.0, "the first wait must be the serialization wait")
+        self.assertIn(
+            "sample", [k for k, _ in events],
+            "the liveness sample must be taken after the serialization wait, not before",
+        )
+
+
+class TestCliRefusedRestart(unittest.TestCase):
+    """A guard inside agent-deck (auth hold, or the #30 freshness guard) answers
+    `session restart` with success + skipped=true. Falling through to
+    `session start` would defeat exactly the guard that just fired."""
+
+    def test_refusal_does_not_fall_back_to_session_start(self):
+        wd = wd_mod.Watchdog(dry_run=False)
+        sess = make_sess(sid="cond-refused", title="conductor-bruce")
+        refusal = json.dumps({
+            "success": True, "skipped": True,
+            "reason": "the agent exited because it could not authenticate — "
+                      "automatic restarts are held (use --force to restart anyway)",
+            "id": "cond-refused", "title": "conductor-bruce",
+        })
+
+        calls = []
+
+        def _run_cmd(args, timeout=None):
+            calls.append(list(args))
+            if "restart" in args:
+                return 0, refusal, ""
+            return 0, "", ""
+
+        with mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             mock.patch.object(wd_mod, "fetch_pane_snapshot", return_value=""), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value=""), \
+             mock.patch.object(wd_mod, "run_cmd", side_effect=_run_cmd), \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True):
+            ok = wd._do_restart("cond-refused", "conductor-bruce", "personal")
+
+        self.assertFalse(ok)
+        self.assertFalse(
+            any("start" in args for args in calls),
+            f"a deliberate refusal must not be escalated to `session start`: {calls}",
+        )
+        self.assertFalse(
+            any("send" in args for args in calls),
+            "no continuity message for a session that was never restarted",
+        )
+        self.assertEqual(wd.consecutive_failures.get("cond-refused", 0), 0,
+                         "someone else's guard firing is not our restart failing")
 
 
 if __name__ == "__main__":

--- a/scripts/watchdog/test_watchdog.py
+++ b/scripts/watchdog/test_watchdog.py
@@ -885,6 +885,33 @@ class TestLivenessConfirmation(unittest.TestCase):
         tg.assert_called_once()
         self.assertIn("liveness-mismatch", Path(wd_mod.ESCALATIONS_LOG).read_text())
 
+    def test_auth_hold_is_reported_once_per_episode_not_once_per_poll(self):
+        """A hold only a human can clear is observed on every poll for as long as it
+        lasts. Repeating the alert every few minutes is how a channel stops being
+        read — so it fires once, and again only after the session is seen healthy."""
+        held = dict(self.sess)
+        held["auth_hold"] = {"reason": "auth_death", "remedy": "run /login"}
+        healthy = make_sess(sid="cond-live", title="conductor-bruce", status="running")
+
+        with mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            with mock.patch.object(wd_mod, "show_session", return_value=held):
+                for _ in range(4):
+                    self.wd._confirm_restart_needed(
+                        "cond-live", "conductor-bruce", "personal", escalate_critical=True)
+            self.assertEqual(tg.call_count, 1, "one alert per episode")
+
+            # Seen healthy → episode over, counter cleared.
+            with mock.patch.object(wd_mod, "show_session", return_value=healthy):
+                self.wd.maybe_restart(healthy)
+            self.assertNotIn("cond-live", self.wd.liveness_skips)
+
+            # It comes back: that is a new episode and does speak up again.
+            self.wd.last_escalation_at.clear()  # past the 5-min escalation dedup
+            with mock.patch.object(wd_mod, "show_session", return_value=held):
+                self.wd._confirm_restart_needed(
+                    "cond-live", "conductor-bruce", "personal", escalate_critical=True)
+            self.assertEqual(tg.call_count, 2)
+
     def test_confirmation_runs_after_the_serialization_wait(self):
         """Ordering is the whole point: confirming before the wait would confirm a
         session that has been sitting in a restart queue ever since."""

--- a/scripts/watchdog/watchdog.py
+++ b/scripts/watchdog/watchdog.py
@@ -85,6 +85,28 @@ CIRCUIT_BREAKER_429_WINDOW_S = 600            # counted over last 10 min
 CIRCUIT_BREAKER_PAUSE_S = 600                 # breaker pauses restarts for 10 min
 PROMPT_RESUME_TIMEOUT_S = 120                 # one-shot `claude --resume -p` timeout
 
+# --- liveness confirmation before a restart (issue #1705) ---
+# A restart is destructive: it tears the pane down and interrupts whatever the
+# agent was doing. The `status == error` reading that authorizes one can be wrong
+# in two different ways, and #1705 was a conductor restarted mid-turn:
+#
+#   STALE  — the reading and the restart are not the same moment. Restarts are
+#            globally serialized MIN_GLOBAL_RESTART_INTERVAL_S apart and a cascade
+#            revives serially, so a queued decision can execute minutes after the
+#            sample that justified it, long after the session recovered by itself.
+#   FALSE  — `error` is partly derived from pane CONTENT, so a banner-shaped line
+#            sitting in scrollback keeps the verdict standing while the agent works
+#            on happily. Re-reading the status does not help here: the content does
+#            not move, so every read agrees.
+#
+# So confirm at the moment of the restart, and let observed pane ACTIVITY veto it:
+# an agent that is still producing output is not dead, whatever the status says.
+# Every decision (restart or skip) is recorded with its readings, so a future
+# false positive can be diagnosed from the log instead of reconstructed.
+LIVENESS_CONFIRM_GAP_S = 2.0        # spacing between the two pane samples
+LIVENESS_LOG = WATCHDOG_DIR / "liveness.log"
+LIVENESS_SKIP_ESCALATE_AFTER = 3    # consecutive skips on one session → tell a human
+
 # Patterns we grep against tmux pane output / subprocess stderr.
 RATE_LIMIT_PATTERNS = (
     re.compile(r"\brate[- ]?limit", re.IGNORECASE),
@@ -173,6 +195,45 @@ def fetch_session_output(instance_id, profile):
     if rc != 0:
         return ""
     return out or ""
+
+
+def fetch_pane_snapshot(instance_id, profile):
+    """Raw tmux pane capture (`session output --pane`) — the liveness probe's sample.
+
+    Deliberately NOT the parsed transcript output `fetch_session_output` returns:
+    that only changes when a turn ends, so a session in the middle of a long tool
+    call looks frozen. The pane capture moves with every spinner frame and every
+    line a tool prints, which is exactly the "is this agent still producing
+    output?" signal a restart decision needs.
+
+    Returns the pane text, or None when the pane could not be sampled at all
+    (which is different from "" — an empty but readable pane)."""
+    args = [AGENT_DECK_BIN]
+    if profile:
+        args += ["-p", profile]
+    args += ["session", "output", instance_id, "--pane", "-q"]
+    rc, out, _ = run_cmd(args, timeout=15)
+    if rc != 0:
+        return None
+    return out or ""
+
+
+def digest_pane(text):
+    """Short content digest of a pane sample. The liveness record stores this and
+    never the text itself: panes carry prompts, transcripts and secrets, and this
+    log exists to be read by humans and pasted into bug reports."""
+    if text is None:
+        return ""
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def parse_cli_json(text):
+    """Parse an `agent-deck ... --json` payload, tolerating anything unexpected."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def detect_rate_limit(text):
@@ -429,6 +490,10 @@ class Watchdog:
         self.last_poller_restart_at = {}          # sid -> ts
         # v1.7.63 capability B: per-waiting-child {first_seen_at, pane_hash, last_nudge_at}
         self.waiting_tracker = {}
+        # #1705: consecutive liveness-confirmation skips per session. A session that
+        # keeps reporting error while its pane keeps moving is a status-classifier
+        # bug, not a dead session — after a few skips a human should hear about it.
+        self.liveness_skips = {}
 
     # ---- logging helpers ----
 
@@ -530,6 +595,133 @@ class Watchdog:
         """Must be called with self.lock held."""
         return now < self.rate_limited_until.get(sid, 0)
 
+    # ---- liveness confirmation (issue #1705) ----
+
+    def _forget_restart_attempt(self, sid):
+        """Give back the rate-limit slot a caller reserved for a restart that never
+        happened. A skipped restart is not an attempt: without this, a live session
+        the watchdog correctly declined to touch would still burn its
+        RATE_LIMIT_MAX budget and escalate as "keeps crashing"."""
+        with self.lock:
+            hist = self.restart_history.get(sid)
+            if hist:
+                hist.pop()
+
+    def _liveness_verdict(self, record, proceed, reason, escalate_critical):
+        """Finish a liveness record, persist it, and apply the bookkeeping the
+        verdict implies. Returns proceed unchanged so callers can `return`
+        straight through it."""
+        sid = record["id"]
+        record["decision"] = "restart" if proceed else "skip"
+        record["reason"] = reason
+        if proceed:
+            with self.lock:
+                self.liveness_skips.pop(sid, None)
+            log.info("liveness: %s confirmed not making progress (%s) — restarting", sid, reason)
+            self._audit(LIVENESS_LOG, record)
+            return proceed, record
+
+        self._forget_restart_attempt(sid)
+        with self.lock:
+            skips = self.liveness_skips.get(sid, 0) + 1
+            self.liveness_skips[sid] = skips
+        record["consecutive_skips"] = skips
+        log.warning("liveness: SKIPPING restart of %s — %s (skip #%d)", sid, reason, skips)
+        # Audited only once the record is complete, so the persisted evidence
+        # carries the skip count a reader needs to judge a recurring mismatch.
+        self._audit(LIVENESS_LOG, record)
+
+        if reason == "auth_hold":
+            # The merged auth-hold policy (2026-07-26 fleet death) exists because a
+            # restart cannot fix a credential and each doomed boot races the shared
+            # rotating refresh token. Tell a human; do not retry.
+            self.escalate(
+                "auth-hold",
+                f"{sid} is held for an auth failure ({record.get('auth_hold_reason', 'unknown')}) — "
+                f"a restart cannot fix a credential. Repair the login, then restart it explicitly.",
+                telegram=escalate_critical,
+                sid=sid,
+            )
+        elif skips >= LIVENESS_SKIP_ESCALATE_AFTER and reason == "pane_active":
+            self.escalate(
+                "liveness-mismatch",
+                f"{sid} has reported status=error {skips}x while its pane kept producing "
+                f"output — the session is alive and the restart was skipped each time. "
+                f"This is a status-classification problem, not a dead session.",
+                telegram=escalate_critical,
+                sid=sid,
+            )
+        return proceed, record
+
+    def _confirm_restart_needed(self, sid, title, profile, escalate_critical=False):
+        """Final liveness confirmation, run at the moment of the restart.
+
+        Returns (proceed, record). See the LIVENESS_* constants for why a single
+        `status == error` reading is not enough to authorize tearing a pane down.
+
+        The record is the post-hoc evidence #1705 asked for: both status reads with
+        their timestamps and substates, both pane digests, whether the pane moved,
+        the auth-hold reason if any, and the final decision. Digests only — never
+        pane text, prompts or environment."""
+        record = {
+            "ts": time.time(), "id": sid, "title": title, "profile": profile,
+            "gap_s": LIVENESS_CONFIRM_GAP_S, "reads": [],
+        }
+
+        def _read():
+            detail = show_session(sid, profile=profile)
+            status = (detail.get("status") or "").lower() if detail else ""
+            entry = {"ts": time.time(), "status": status or "unreadable"}
+            if detail and detail.get("substate"):
+                entry["substate"] = detail.get("substate")
+            record["reads"].append(entry)
+            return detail, entry["status"]
+
+        detail, status = _read()
+        if status == "unreadable":
+            # We cannot see the session, so we cannot claim it is dead. Restarting
+            # blind is how a CLI hiccup turns into a torn-down healthy pane.
+            return self._liveness_verdict(record, False, "status_unreadable", escalate_critical)
+        if status != "error":
+            # The stale-decision case: it recovered between the trigger and here.
+            return self._liveness_verdict(record, False, "recovered_before_restart", escalate_critical)
+
+        auth_hold = detail.get("auth_hold")
+        if isinstance(auth_hold, dict) and auth_hold:
+            # Reason only — auth_hold.evidence is retained pane text.
+            record["auth_hold_reason"] = auth_hold.get("reason") or "unknown"
+            return self._liveness_verdict(record, False, "auth_hold", escalate_critical)
+
+        first = fetch_pane_snapshot(sid, profile)
+        if self.stop_event.wait(LIVENESS_CONFIRM_GAP_S):
+            # Daemon is shutting down mid-sample: we have no second reading, and
+            # tearing a pane down on the way out is the worst possible time to be
+            # wrong. Leave it for the next run.
+            return self._liveness_verdict(record, False, "shutting_down", escalate_critical)
+        second = fetch_pane_snapshot(sid, profile)
+        sampled = first is not None and second is not None
+        record["pane"] = {
+            "first": digest_pane(first),
+            "second": digest_pane(second),
+            "sampled": sampled,
+            "changed": bool(sampled and first != second),
+            "empty": bool(sampled and not first and not second),
+        }
+        if record["pane"]["changed"]:
+            # Output is still flowing: the agent is alive and working. This is the
+            # #1705 false positive — a content-derived `error` verdict standing over
+            # a busy pane — and the one signal that re-reading the status cannot give.
+            return self._liveness_verdict(record, False, "pane_active", escalate_critical)
+
+        _, status2 = _read()
+        if status2 == "unreadable":
+            return self._liveness_verdict(record, False, "status_unreadable", escalate_critical)
+        if status2 != "error":
+            return self._liveness_verdict(record, False, "recovered_before_restart", escalate_critical)
+
+        # Two agreeing error reads, and nothing moved in the pane between them.
+        return self._liveness_verdict(record, True, "confirmed_dead", escalate_critical)
+
     # ---- single-session restart path ----
 
     def _poll_status(self, sid, profile, timeout_s, want_not="error"):
@@ -547,26 +739,34 @@ class Watchdog:
 
     def _restart_or_start(self, sid, profile):
         """Call `session restart`, verify status recovered; if not, fall back to `session start`.
-        Returns (ok, final_status, err_msg)."""
+        Returns (ok, final_status, err_msg, refused)."""
         base = [AGENT_DECK_BIN]
         if profile:
             base += ["-p", profile]
-        rc, _, err = run_cmd(base + ["session", "restart", sid], timeout=60)
+        rc, out_text, err = run_cmd(base + ["session", "restart", sid, "--json"], timeout=60)
         if rc != 0:
-            return False, None, f"restart rc={rc}: {err.strip()[:200]}"
+            return False, None, f"restart rc={rc}: {err.strip()[:200]}", False
+        payload = parse_cli_json(out_text)
+        if payload.get("skipped"):
+            # agent-deck refused ON PURPOSE — the auth hold, or the #30 freshness
+            # guard. Falling through to `session start` would defeat exactly the
+            # guard that just fired, and for an auth hold that means one more doomed
+            # boot racing the shared rotating refresh token (2026-07-26 fleet death).
+            reason = str(payload.get("reason") or "no reason given")[:200]
+            return False, None, f"agent-deck refused the restart: {reason}", True
         # Restart can silently no-op when tmux was fully dead. Poll up to 4s first.
         status = self._poll_status(sid, profile, timeout_s=4)
         if status.lower() != "error":
-            return True, status, None
+            return True, status, None, False
         log.warning("%s still in error after restart; falling back to session start", sid)
         rc2, _, err2 = run_cmd(base + ["session", "start", sid], timeout=60)
         if rc2 != 0:
-            return False, status, f"fallback start rc={rc2}: {err2.strip()[:200]}"
+            return False, status, f"fallback start rc={rc2}: {err2.strip()[:200]}", False
         # `start` can take longer — tmux bootstrap + claude cold start.
         status2 = self._poll_status(sid, profile, timeout_s=15)
         if status2.lower() == "error":
-            return False, status2, "fallback start returned success but status still error after 15s"
-        return True, status2, None
+            return False, status2, "fallback start returned success but status still error after 15s", False
+        return True, status2, None, False
 
     def _prompt_resume_personal(self, sid, profile):
         """One-shot `claude --resume <claude_sid> -p "continue..."` to burn a
@@ -640,6 +840,22 @@ class Watchdog:
                     log.info("%s still rate-limited, aborting restart", sid)
                     return False
 
+            # FINAL LIVENESS CONFIRMATION (#1705). Deliberately here and not in the
+            # callers: this is the last instruction before the pane is torn down, and
+            # the only point at which "is it actually stuck?" is being asked about
+            # NOW rather than about whenever the triggering sample was taken — which
+            # can be a minute or more ago after the serialization wait above.
+            proceed, liveness = self._confirm_restart_needed(
+                sid, title, profile, escalate_critical=escalate_critical,
+            )
+            if not proceed:
+                self._audit(RESTART_LOG, {
+                    "ts": time.time(), "id": sid, "title": title, "profile": profile,
+                    "action": "skipped-alive", "reason": liveness.get("reason"),
+                    "dry_run": self.dry_run,
+                })
+                return False
+
             log.info("RESTART %s (%s) profile=%s dry_run=%s", sid, title, profile, self.dry_run)
             self._audit(RESTART_LOG, {
                 "ts": time.time(), "id": sid, "title": title, "profile": profile,
@@ -648,8 +864,18 @@ class Watchdog:
             if self.dry_run:
                 self.last_global_restart_at = time.time()
                 return True
-            ok, final_status, err_msg = self._restart_or_start(sid, profile)
+            ok, final_status, err_msg, refused = self._restart_or_start(sid, profile)
             self.last_global_restart_at = time.time()
+
+            if refused:
+                # Not a failure of ours — a guard inside agent-deck declined. Log it
+                # and stop: retrying and counting crashes would fight the guard.
+                log.warning("restart of %s refused by agent-deck: %s", sid, err_msg)
+                self._audit(RESTART_LOG, {
+                    "ts": time.time(), "id": sid, "title": title, "profile": profile,
+                    "action": "cli-refused", "reason": err_msg,
+                })
+                return False
 
             # Inspect pane output if we failed — distinguish 429 from real crash
             # from deferred-tool-marker (where the -p fallback can help).

--- a/scripts/watchdog/watchdog.py
+++ b/scripts/watchdog/watchdog.py
@@ -631,7 +631,12 @@ class Watchdog:
         # carries the skip count a reader needs to judge a recurring mismatch.
         self._audit(LIVENESS_LOG, record)
 
-        if reason == "auth_hold":
+        # Both escalations fire ONCE per episode, not once per skip: a held or
+        # misreported session is observed every poll for as long as it lasts, and
+        # nagging every few minutes about a condition only a human can clear is how
+        # an alert channel stops being read. The counter resets when the session is
+        # next seen healthy (see maybe_restart), so a recurrence does speak up again.
+        if reason == "auth_hold" and skips == 1:
             # The merged auth-hold policy (2026-07-26 fleet death) exists because a
             # restart cannot fix a credential and each doomed boot races the shared
             # rotating refresh token. Tell a human; do not retry.
@@ -642,7 +647,7 @@ class Watchdog:
                 telegram=escalate_critical,
                 sid=sid,
             )
-        elif skips >= LIVENESS_SKIP_ESCALATE_AFTER and reason == "pane_active":
+        elif reason == "pane_active" and skips == LIVENESS_SKIP_ESCALATE_AFTER:
             self.escalate(
                 "liveness-mismatch",
                 f"{sid} has reported status=error {skips}x while its pane kept producing "
@@ -962,6 +967,9 @@ class Watchdog:
             log.debug("session %s status=%s (not error), skip", sid, status)
             with self.lock:
                 self.first_error_seen_at.pop(sid, None)
+                # Seen healthy: this error episode is over, so a later one starts
+                # counting liveness skips (and escalating) from scratch.
+                self.liveness_skips.pop(sid, None)
             return
 
         # Escalation-critical is a stricter classification than restart-critical.


### PR DESCRIPTION
## What problem does this solve?

Closes #1705 — a conductor session got a `[SESSION AUTO-RESTARTED]` continuity message while its agent was alive and had just finished a turn cleanly. The reporter ruled out an OS kill, ptmx exhaustion, a hook block and a tmux respawn with log evidence, and what remained was the watchdog restarting a session that was never dead. A restart of a live conductor interrupts whatever it was doing, so this is high impact even though it is rare.

The merged work from this week narrows the ways a session can *wrongly read* as error (#1725 clean one-shot exits, #1743 auth-hold, #1736 keysender servers, #1723 protocol mismatch), but none of it closes the actual hole: nothing re-confirms liveness at the moment the restart fires. That hole survives, so this fixes it rather than closing the issue as already-fixed.

## Why this change

`scripts/watchdog/watchdog.py` fires on `status == error`. That reading can be wrong in two ways, and the existing guards cover neither:

- **STALE.** The reading and the restart are not the same moment. `_do_restart` waits up to `MIN_GLOBAL_RESTART_INTERVAL_S` (60s) for the global restart serialization, and a cascade revives serially, so a queued decision can execute minutes after the sample that justified it. After that wait the code re-checked the circuit breaker and the 429 backoff — but never the status. A session that recovered on its own in the meantime was restarted anyway.
- **FALSE.** `error` is partly derived from pane *content* (`hasErrorBannerIndicator`, the model-unavailable no-op), so a banner-shaped line sitting in scrollback keeps the verdict standing while the agent works on happily. Re-reading the status does not catch this: the content does not move, so every read agrees. That is why the fix cannot be "two confirming status reads".

So the last thing before a pane is torn down is now a liveness confirmation, placed deliberately **after** the serialization wait: re-read the status, then sample the pane twice `LIVENESS_CONFIRM_GAP_S` apart via `session output --pane`. The pane capture is the right probe precisely because it moves with every spinner frame and every line of tool output, unlike the parsed transcript output, which only changes when a turn ends and so makes a session in a long tool call look frozen.

The restart is skipped when:

| Reason | Why |
|---|---|
| `recovered_before_restart` | status is no longer `error` — the stale case |
| `pane_active` | the pane is still producing output; an agent emitting output is not dead |
| `status_unreadable` | we cannot see the session, so we cannot claim it is dead |
| `shutting_down` | no second reading, and exit time is the worst time to be wrong |
| `auth_hold` | a restart cannot fix a credential, and each doomed boot races the shared rotating refresh token |

Two things fall out of the same failure and are fixed here because they are the same bug wearing different hats:

- **`session restart` answered with `skipped: true` was escalated to `session start`.** That is a guard inside agent-deck declining on purpose (the auth hold, or the #30 freshness guard) — the fallback defeated exactly the guard that just fired, and for an auth hold it meant one more doomed boot racing the shared token. It now stops there, and does not count as a restart failure of ours.
- **A skipped restart is no longer an attempt.** It gives back the rate-limit slot the caller reserved, so a live session the watchdog correctly declined to touch cannot exhaust its 3-per-10-min budget and escalate as "keeps crashing". Three consecutive skips on a moving pane escalate as `liveness-mismatch` instead, which names the real problem (status classification) rather than blaming the session.

Per the maintainer's request on the issue, the readings are now recorded, not just the outcome:

- `watchdog/liveness.log` — one JSON record per decision: both status reads with timestamps and substates, both pane digests, whether the pane moved, the auth-hold reason, the verdict, the consecutive-skip count. **Digests only, never pane text** — the log is meant to be readable and pasteable into a bug report, and panes carry prompts and secrets. There is a test asserting exactly that.
- `Reviver.Classify` states its evidence too — tmux liveness, the control-pipe reading, the stored status it was judged against, and when — at info level for non-alive verdicts and debug for alive ones. The pipe is now read whenever the server is up even when the stored status alone settles the verdict, because that reading (a *live* pipe under a `StatusError` reading) is the false-positive signal, and the original investigation stalled precisely because only the outcome was recoverable afterwards.

## User impact

The watchdog no longer restarts a session that is demonstrably alive, and never restarts an auth-held one. Genuine deaths are unaffected: a gone or frozen pane still yields two agreeing error reads with nothing moving, and restarts as before — with roughly 2s of extra confirmation latency, on a path that is already serialized at 60s intervals.

Operators get `liveness.log` to answer "why did that restart fire?" (or "why didn't it?") from the record rather than from reconstruction.

No behavior change for anyone not running `scripts/watchdog/watchdog.py`. The Go side adds log lines only.

## Evidence

Watchdog suite, run the way CI runs it (no env overrides, clean HOME):

```
$ cd scripts/watchdog && HOME=$(mktemp -d) python3 -m unittest test_watchdog
Ran 74 tests in 0.071s

OK
```

12 of those are new, covering: a moving pane vetoing the restart (the #1705 case); recovery during the serialization wait; a frozen pane plus two agreeing reads still restarting; unreadable status not being treated as death; shutdown mid-sample; an auth-held session left alone and escalated, with the pane never sampled; the record carrying digests and not pane text; a skip not burning the rate-limit budget; three skips escalating as `liveness-mismatch`; a hold being reported once per episode rather than once per poll, and speaking up again after the session is seen healthy; the confirmation running *after* the serialization wait, not before; and a deliberate CLI refusal not falling through to `session start` or sending a continuity message.

Go side: `go build ./...` clean, `go vet ./...` clean, `gofmt -l ./cmd ./internal` prints nothing. Four new tests in `internal/session/reviver_classify_evidence_test.go` assert the recorded evidence and levels, plus a nil-`PipeAlive` regression for the widened read. Per the repo's own hard rule I did not run the Go suite against this host's real `~/.agent-deck` — the touched package's tests use injected fakes and no tmux, and CI is the authority.

**Test isolation, worth flagging:** the watchdog suite resolved its log paths under the real `~/.agent-deck` (which on a maintainer machine is the live data directory) and shelled out to the real `agent-deck` binary, and it took ~9 minutes because of the serialization sleeps — which is presumably why it had no CI gate. `setUpModule` now redirects the paths to a temp dir, points the binary at a path that cannot exist, and zeroes both sleeps. That is what makes the suite runnable in CI at all, so it is wired into `python-compat.yml` (3.8 + 3.12), which previously covered only the conductor bridge.

Hot path: untouched. The liveness probe runs only on the restart path. `Reviver.Classify` adds one in-memory map lookup (`PipeManager.IsConnected`) per errored instance per sweep and no new tmux invocation or syscall.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

The maintainer asked for this stream directly: check whether the merged #1723/#1736/#1743 work already changed #1705, and if the root cause survives, fix it so the liveness probe cannot treat a slow or busy conductor as dead — coordinating with the auth-hold and protocol-mismatch policies rather than fighting them. It does survive: all that work narrows how a session comes to *read* as error, and none of it re-confirms liveness at the moment a restart fires. Reading #1705's own timeline, the thing that stings is that the conductor's Stop hooks had all completed cleanly less than a second before the continuity message landed — the session was as healthy as a session gets, and got interrupted anyway.

Credit to the reporter (@kewtyboi): the incident write-up ruled out jetsam, ptmx exhaustion, hook blocks and tmux respawn with cited log evidence, and correctly identified that `defaultReviveAction`'s own comment ("tmux is alive, so a `StatusError` reading is stale") admits these readings go stale. That framing is what this fix is built on. Their suggested hardening — structured reason logging, and a confirmation delay before restarting a critical conductor — is what landed here.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [~] Test suite passes sandboxed: watchdog suite green (74 tests, 0.07s, isolated HOME); the Go suite was NOT run locally — this repo's `CLAUDE.md` forbids `go test` against a real `~/.agent-deck`, and the host is a live data directory. Build, vet and gofmt are clean; CI is the authority. Not claiming a green suite I did not run.
- [x] If this touches a hot path: not a hot path — restart path only, plus one in-memory lookup per errored instance per revive sweep
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
