### PR TITLE
fix(tmux): refuse a start whose pane cannot reach its working directory (#1713)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -826,6 +826,11 @@ func (i *Instance) applyLaunchSettingsFromConfig() {
 	settings := GetTmuxSettings()
 	i.tmuxSession.LaunchInUserScope = settings.GetLaunchInUserScope()
 	i.tmuxSession.LaunchAs = settings.GetLaunchAs()
+	// #1713: an SSH session's ProjectPath is only a local placeholder — the
+	// project lives on the remote host and the pane just runs an ssh client —
+	// so the tmux working-directory guards must not refuse its start over a
+	// local directory nothing reads. Every local session keeps the guards.
+	i.tmuxSession.WorkDirIsPlaceholder = i.IsSSH()
 	i.applyVimModeFromConfig()
 }
 
@@ -8799,11 +8804,19 @@ func (i *Instance) OpenContainerShell() (string, error) {
 	cols, rows := tmux.InitialWindowSize()
 	newCtx, newCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer newCancel()
-	out, err := tmux.ExecContext(newCtx, i.TmuxSocketName,
+	newCmd := tmux.ExecContext(newCtx, i.TmuxSocketName,
 		"new-session", "-d", "-s", tmuxName,
 		"-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows),
 		"docker", "exec", "-it", i.SandboxContainer, "/bin/sh",
-	).CombinedOutput()
+	)
+	// #1713: if this new-session is what starts the tmux server, the server
+	// inherits this process's cwd — and agent-deck is frequently run from a
+	// worktree that later gets deleted, after which tmux ignores every -c and
+	// births all panes in that dead directory. Spawn from a directory that
+	// cannot be unlinked. The pane's own cwd is irrelevant here: it runs
+	// `docker exec`, whose working directory was fixed at container create.
+	newCmd.Dir = tmux.SpawnBaseDir
+	out, err := newCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating terminal session: %s: %w", strings.TrimSpace(string(out)), err)
 	}

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -770,7 +770,10 @@ func TestInstance_UpdateClaudeSession_RejectZombie(t *testing.T) {
 		}
 	}()
 
-	projectPath := "/tmp/claude-zombie-reject"
+	// A real directory: this test calls Start(), and a session whose project
+	// directory does not exist is now refused rather than silently started in
+	// $HOME (#1713). The path only needs to be stable within the test.
+	projectPath := t.TempDir()
 	projectDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(projectPath))
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("mkdir project dir: %v", err)

--- a/internal/session/issue1713_placeholder_workdir_test.go
+++ b/internal/session/issue1713_placeholder_workdir_test.go
@@ -1,0 +1,38 @@
+// Wiring pin for issue #1713 — the tmux working-directory guards.
+//
+// tmux does not fail a spawn over a bad start directory: it silently substitutes
+// $HOME (missing directory), and a server whose own cwd was unlinked ignores the
+// requested -c entirely and births every pane in that dead directory. Both
+// produced sessions that agent-deck reported as started while the agent had
+// never run, so internal/tmux now refuses such a start.
+//
+// One session kind must keep starting: an SSH session, whose ProjectPath is only
+// a local placeholder — the project lives on the remote host and the pane just
+// runs an ssh client. applyLaunchSettingsFromConfig is the single chokepoint the
+// three Start() paths share, so the opt-out is pinned here.
+package session
+
+import "testing"
+
+func TestApplyLaunchSettings_MarksSSHWorkDirAsPlaceholder(t *testing.T) {
+	inst := NewInstance("issue1713-ssh", t.TempDir())
+	inst.SSHHost = "build-box"
+
+	inst.applyLaunchSettingsFromConfig()
+
+	if !inst.tmuxSession.WorkDirIsPlaceholder {
+		t.Fatal("#1713: an SSH session's local path is a placeholder — the working-directory " +
+			"guards must not be able to refuse its start over a local directory nothing reads")
+	}
+}
+
+func TestApplyLaunchSettings_LocalSessionKeepsWorkDirGuards(t *testing.T) {
+	inst := NewInstance("issue1713-local", t.TempDir())
+
+	inst.applyLaunchSettingsFromConfig()
+
+	if inst.tmuxSession.WorkDirIsPlaceholder {
+		t.Fatal("#1713: a local session's working directory is load-bearing — running the agent " +
+			"in $HOME instead must stay a hard failure, not a silent success")
+	}
+}

--- a/internal/tmux/issue1713_workdir_guard_test.go
+++ b/internal/tmux/issue1713_workdir_guard_test.go
@@ -103,25 +103,22 @@ func TestResolveStartWorkDir_RejectsEmpty(t *testing.T) {
 // resolves a relative -c against the SPAWNING client's cwd, which is now
 // SpawnBaseDir ("/") — so leaving it relative would silently retarget the pane
 // to /<relative-path>.
+// Resolved against this process's cwd, not tmux's — deliberately without
+// chdir()ing the test process, which would leak into anything else running.
 func TestResolveStartWorkDir_AbsolutisesRelativePaths(t *testing.T) {
-	parent := t.TempDir()
-	child := filepath.Join(parent, "nested")
-	require.NoError(t, os.Mkdir(child, 0o755))
-
-	prev, err := os.Getwd()
+	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	require.NoError(t, os.Chdir(parent))
-	t.Cleanup(func() { _ = os.Chdir(prev) })
 
-	got, err := resolveStartWorkDir("nested")
+	got, err := resolveStartWorkDir(".")
 	require.NoError(t, err)
 	assert.True(t, filepath.IsAbs(got), "resolved path must be absolute, got %q", got)
 
 	gotInfo, err := os.Stat(got)
 	require.NoError(t, err)
-	wantInfo, err := os.Stat(child)
+	wantInfo, err := os.Stat(cwd)
 	require.NoError(t, err)
-	assert.True(t, os.SameFile(gotInfo, wantInfo), "resolved %q should be %q", got, child)
+	assert.True(t, os.SameFile(gotInfo, wantInfo),
+		"%q must resolve against agent-deck's cwd (%q), not tmux's", got, cwd)
 }
 
 // --- classifyPaneCwd --------------------------------------------------------

--- a/internal/tmux/issue1713_workdir_guard_test.go
+++ b/internal/tmux/issue1713_workdir_guard_test.go
@@ -1,0 +1,461 @@
+package tmux
+
+// Regression tests for #1713: `add -w` (worktree creation) produced a session
+// whose pane held only a broken shell —
+//
+//	shell-init: error retrieving current directory: getcwd: cannot access
+//	parent directories: No such file or directory
+//
+// — while agent-deck reported the session as created, started and alive. The
+// agent process never ran, and nothing short of `tmux capture-pane` revealed it.
+//
+// Root cause (verified against a bare tmux 3.7b, no agent-deck involved):
+//
+//	mkdir -p /tmp/x/srv /tmp/x/good
+//	( cd /tmp/x/srv && tmux -L probe new-session -d -s seed )   # server cwd = /tmp/x/srv
+//	rm -rf /tmp/x/srv                                           # unlink the server's cwd
+//	tmux -L probe new-session -d -s t -c /tmp/x/good bash -c pwd
+//	# -> pane_current_path is /tmp/x/srv (NOT the requested -c), and the pane
+//	#    prints the shell-init getcwd error above.
+//
+// Once a tmux server's own working directory is unlinked, tmux stops honouring
+// the requested -c start directory and every new pane inherits the server's dead
+// cwd. That accounts for each observation in the report: the worktree really was
+// fine, a restart hit the same server, three different worktree paths behaved
+// identically, plain `add <existing good path>` without -w failed the same way,
+// and host shells were unaffected. A worktree is a prime candidate for the
+// unlinked directory, since worktrees get removed routinely.
+//
+// The sibling defect on the same code path: with a HEALTHY server,
+// `new-session -c <missing dir>` does not fail either — tmux silently starts the
+// pane in $HOME, so a session whose project directory was deleted came up
+// "successfully" with the agent pointed at the user's home directory.
+//
+// Guards under test (workdir_guard.go):
+//   - SpawnBaseDir/newSpawnCommand — servers agent-deck starts run from "/",
+//     which can never be unlinked (prevention).
+//   - resolveStartWorkDir — refuse to start on a missing directory instead of
+//     silently landing in $HOME.
+//   - verifyPaneWorkDir — after creation, detect a pane born in an unlinked
+//     directory and fail loudly rather than recording it as alive.
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- resolveStartWorkDir -----------------------------------------------------
+
+func TestResolveStartWorkDir_AcceptsExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := resolveStartWorkDir(dir)
+	require.NoError(t, err)
+	assert.Equal(t, dir, got)
+}
+
+func TestResolveStartWorkDir_RejectsDeletedDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.RemoveAll(dir))
+
+	_, err := resolveStartWorkDir(dir)
+
+	require.Error(t, err, "a deleted project directory must refuse the start; tmux would "+
+		"otherwise silently run the agent in $HOME (#1713)")
+	assert.True(t, errors.Is(err, ErrWorkDirUnavailable))
+	assert.Contains(t, err.Error(), dir, "the message must name the directory the user has to fix")
+	assert.Contains(t, err.Error(), "$HOME", "the message must explain what tmux would have done instead")
+}
+
+func TestResolveStartWorkDir_RejectsFile(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+
+	_, err := resolveStartWorkDir(file)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrWorkDirUnavailable))
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestResolveStartWorkDir_RejectsEmpty(t *testing.T) {
+	for _, in := range []string{"", "   ", "\t"} {
+		_, err := resolveStartWorkDir(in)
+		require.Error(t, err, "input %q", in)
+		assert.True(t, errors.Is(err, ErrWorkDirUnavailable), "input %q", in)
+	}
+}
+
+// A relative path must be absolutised against agent-deck's own cwd. tmux
+// resolves a relative -c against the SPAWNING client's cwd, which is now
+// SpawnBaseDir ("/") — so leaving it relative would silently retarget the pane
+// to /<relative-path>.
+func TestResolveStartWorkDir_AbsolutisesRelativePaths(t *testing.T) {
+	parent := t.TempDir()
+	child := filepath.Join(parent, "nested")
+	require.NoError(t, os.Mkdir(child, 0o755))
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(parent))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	got, err := resolveStartWorkDir("nested")
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(got), "resolved path must be absolute, got %q", got)
+
+	gotInfo, err := os.Stat(got)
+	require.NoError(t, err)
+	wantInfo, err := os.Stat(child)
+	require.NoError(t, err)
+	assert.True(t, os.SameFile(gotInfo, wantInfo), "resolved %q should be %q", got, child)
+}
+
+// --- classifyPaneCwd --------------------------------------------------------
+
+func TestClassifyPaneCwd_Verdicts(t *testing.T) {
+	live := t.TempDir()
+	other := t.TempDir()
+
+	deleted := filepath.Join(t.TempDir(), "gone")
+	require.NoError(t, os.Mkdir(deleted, 0o755))
+	require.NoError(t, os.RemoveAll(deleted))
+
+	assert.Equal(t, paneCwdOK, classifyPaneCwd(live, live))
+	assert.Equal(t, paneCwdOK, classifyPaneCwd(live, live+string(filepath.Separator)),
+		"a trailing separator names the same directory")
+	assert.Equal(t, paneCwdElsewhere, classifyPaneCwd(live, other))
+	assert.Equal(t, paneCwdDeleted, classifyPaneCwd(live, deleted))
+	assert.Equal(t, paneCwdUnknown, classifyPaneCwd(live, ""),
+		"an empty reading is indeterminate and must never fail a start")
+	assert.Equal(t, paneCwdUnknown, classifyPaneCwd(live, "   "))
+}
+
+// macOS reports /private/tmp/x for a session started in /tmp/x. A symlinked
+// prefix is the same directory and must not be reported as a mismatch.
+func TestClassifyPaneCwd_ToleratesSymlinkedPrefix(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(real, link))
+
+	assert.Equal(t, paneCwdOK, classifyPaneCwd(link, real))
+	assert.Equal(t, paneCwdOK, classifyPaneCwd(real, link))
+}
+
+// --- verifyPaneWorkDir ------------------------------------------------------
+
+// stubPanePathProbe replaces the pane-cwd probe with a scripted sequence of
+// answers (the last one repeats) and shortens the re-check delay.
+func stubPanePathProbe(t *testing.T, answers ...string) *int {
+	t.Helper()
+	calls := 0
+	prevProbe := panePathProbe
+	prevDelay := paneCwdRecheckDelay
+	panePathProbe = func(*Session) (string, error) {
+		idx := calls
+		calls++
+		if idx >= len(answers) {
+			idx = len(answers) - 1
+		}
+		return answers[idx], nil
+	}
+	paneCwdRecheckDelay = time.Millisecond
+	t.Cleanup(func() {
+		panePathProbe = prevProbe
+		paneCwdRecheckDelay = prevDelay
+	})
+	return &calls
+}
+
+func TestVerifyPaneWorkDir_FailsLoudlyOnDeletedPaneCwd(t *testing.T) {
+	workDir := t.TempDir()
+	deleted := filepath.Join(t.TempDir(), "poisoned-server-cwd")
+	require.NoError(t, os.Mkdir(deleted, 0o755))
+	require.NoError(t, os.RemoveAll(deleted))
+
+	stubPanePathProbe(t, deleted)
+	s := &Session{Name: "agentdeck_wt", SocketName: "ad1713"}
+
+	err := s.verifyPaneWorkDir(workDir)
+
+	require.Error(t, err, "a pane born in an unlinked directory holds only a broken shell; "+
+		"reporting it as started is the #1713 failure")
+	assert.True(t, errors.Is(err, ErrPaneCwdDeleted))
+	assert.Contains(t, err.Error(), deleted, "must name the dead directory the pane landed in")
+	assert.Contains(t, err.Error(), workDir, "must name the directory that was requested")
+	assert.Contains(t, err.Error(), "ad1713", "must name the tmux server that needs restarting")
+	assert.Contains(t, err.Error(), "shell-init", "must connect to the symptom the user sees in the pane")
+}
+
+func TestVerifyPaneWorkDir_AcceptsRequestedDirectory(t *testing.T) {
+	workDir := t.TempDir()
+	stubPanePathProbe(t, workDir)
+
+	s := &Session{Name: "agentdeck_ok"}
+	assert.NoError(t, s.verifyPaneWorkDir(workDir))
+}
+
+// A pane command may legitimately change directory (the fork / multi-repo paths
+// build `cd <dir> && …`), so a real-but-different directory is a warning, never
+// a failed start.
+func TestVerifyPaneWorkDir_ToleratesDifferentLiveDirectory(t *testing.T) {
+	workDir := t.TempDir()
+	elsewhere := t.TempDir()
+	stubPanePathProbe(t, elsewhere)
+
+	s := &Session{Name: "agentdeck_cd"}
+	assert.NoError(t, s.verifyPaneWorkDir(workDir))
+}
+
+// tmux creates the pane process before it has chdir()ed, so the first reading
+// can still show the server's cwd. A transient "deleted" reading must be
+// re-confirmed rather than failing a healthy start.
+func TestVerifyPaneWorkDir_RetriesTransientDeletedReading(t *testing.T) {
+	workDir := t.TempDir()
+	stale := filepath.Join(t.TempDir(), "stale")
+	require.NoError(t, os.Mkdir(stale, 0o755))
+	require.NoError(t, os.RemoveAll(stale))
+
+	calls := stubPanePathProbe(t, stale, workDir)
+
+	s := &Session{Name: "agentdeck_race"}
+	require.NoError(t, s.verifyPaneWorkDir(workDir))
+	assert.Equal(t, 2, *calls, "a deleted reading must be re-probed before it is believed")
+}
+
+func TestVerifyPaneWorkDir_ProbeFailureIsNotAFailedStart(t *testing.T) {
+	prev := panePathProbe
+	panePathProbe = func(*Session) (string, error) { return "", fmt.Errorf("server busy") }
+	t.Cleanup(func() { panePathProbe = prev })
+
+	s := &Session{Name: "agentdeck_probe_err"}
+	assert.NoError(t, s.verifyPaneWorkDir(t.TempDir()),
+		"an unreadable probe is indeterminate and must never fail a start")
+}
+
+// --- Start() integration ----------------------------------------------------
+
+// A deleted working directory must be refused before anything is spawned, so no
+// half-alive session is left behind for the status layer to call healthy.
+func TestStart_RefusesDeletedWorkDirWithoutSpawning(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.RemoveAll(dir))
+
+	spawns := 0
+	prev := execCommand
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		spawns++
+		return prev("true")
+	}
+	t.Cleanup(func() { execCommand = prev })
+
+	s := &Session{Name: "agentdeck_missing_wt", SocketName: "ad1713-none", WorkDir: dir}
+	err := s.Start("claude")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrWorkDirUnavailable))
+	assert.Zero(t, spawns, "nothing may be spawned once the working directory is known to be gone")
+}
+
+// An SSH session's local path is only a placeholder — the pane runs an ssh
+// client and the project lives on the remote host — so a missing local
+// directory must not make the session unstartable. It keeps tmux's historical
+// $HOME landing, and the pane check is skipped for the same reason.
+func TestStart_PlaceholderWorkDirIsNotRefused(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "local-placeholder")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.RemoveAll(dir))
+
+	socket := privateSocketName1713(t)
+	s := &Session{
+		Name:                 "agentdeck_1713_ssh",
+		DisplayName:          "ssh-placeholder",
+		SocketName:           socket,
+		WorkDir:              dir,
+		WorkDirIsPlaceholder: true,
+	}
+
+	require.NoError(t, s.Start(""),
+		"a remote session must not be blocked by a local placeholder directory")
+	t.Cleanup(func() { _ = s.Kill() })
+	assert.True(t, s.Exists())
+}
+
+func TestVerifyPaneWorkDir_SkippedForPlaceholderWorkDir(t *testing.T) {
+	deleted := filepath.Join(t.TempDir(), "gone")
+	require.NoError(t, os.Mkdir(deleted, 0o755))
+	require.NoError(t, os.RemoveAll(deleted))
+	stubPanePathProbe(t, deleted)
+
+	placeholder := &Session{Name: "agentdeck_ssh", WorkDirIsPlaceholder: true}
+	assert.NoError(t, placeholder.verifyPaneWorkDirUnlessPlaceholder(t.TempDir()))
+
+	local := &Session{Name: "agentdeck_local"}
+	assert.Error(t, local.verifyPaneWorkDirUnlessPlaceholder(t.TempDir()),
+		"a local session must still be checked")
+}
+
+// End-to-end on a real tmux server: when the pane is not in a usable directory,
+// Start must report the failure AND leave no session behind. The poisoned-server
+// condition itself is simulated through the probe seam so the test does not
+// depend on tmux internals, but everything else — session creation, the guard,
+// the teardown — is real.
+func TestStart_KillsSessionBornInDeletedCwd(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	socket := privateSocketName1713(t)
+	workDir := t.TempDir()
+
+	deleted := filepath.Join(t.TempDir(), "server-cwd")
+	require.NoError(t, os.Mkdir(deleted, 0o755))
+	require.NoError(t, os.RemoveAll(deleted))
+	stubPanePathProbe(t, deleted)
+
+	s := &Session{
+		Name:        "agentdeck_1713_dead",
+		DisplayName: "dead-cwd",
+		SocketName:  socket,
+		WorkDir:     workDir,
+	}
+
+	err := s.Start("")
+
+	require.Error(t, err, "Start must not report success for a pane that cannot run the agent")
+	assert.True(t, errors.Is(err, ErrPaneCwdDeleted))
+	assert.False(t, s.Exists(),
+		"the broken session must be torn down, not left registered as alive (#1713)")
+}
+
+// The real probe against a real tmux session: a pane whose directory is deleted
+// after birth is classified as paneCwdDeleted. macOS keeps reporting the stale
+// path and Linux tmux strips the " (deleted)" suffix from /proc/<pid>/cwd, so
+// both platforms hand us a path that no longer exists.
+func TestVerifyPaneWorkDir_RealTmuxPaneWithDeletedDirectory(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	socket := privateSocketName1713(t)
+	workDir := filepath.Join(t.TempDir(), "worktree")
+	require.NoError(t, os.Mkdir(workDir, 0o755))
+
+	s := &Session{
+		Name:        "agentdeck_1713_real",
+		DisplayName: "real-probe",
+		SocketName:  socket,
+		WorkDir:     workDir,
+	}
+	require.NoError(t, s.Start(""), "session must start while the directory still exists")
+
+	// tmux creates the pane process before it has chdir()ed, so wait for the
+	// pane to actually settle in the requested directory before deleting it —
+	// otherwise this test could delete a directory the pane never entered.
+	requirePaneSettledIn(t, s, workDir)
+	require.NoError(t, s.verifyPaneWorkDir(workDir),
+		"sanity: the pane must be in the requested directory to begin with")
+
+	require.NoError(t, os.RemoveAll(workDir))
+
+	err := s.verifyPaneWorkDir(workDir)
+	require.Error(t, err, "a pane sitting in a deleted directory must be reported, not ignored")
+	assert.True(t, errors.Is(err, ErrPaneCwdDeleted))
+}
+
+// --- prevention: spawns run from a directory that cannot be deleted ---------
+
+func TestNewSpawnCommand_RunsFromSpawnBaseDir(t *testing.T) {
+	cmd := newSpawnCommand("tmux", "-V")
+	assert.Equal(t, SpawnBaseDir, cmd.Dir,
+		"a tmux server inherits its cwd from the process that starts it; spawning from %q "+
+			"is what keeps a deleted directory from poisoning the server (#1713)", SpawnBaseDir)
+
+	info, err := os.Stat(SpawnBaseDir)
+	require.NoError(t, err, "SpawnBaseDir must exist on every supported platform")
+	assert.True(t, info.IsDir())
+}
+
+// Lint: every subprocess spawn inside Session.Start must go through
+// newSpawnCommand. A bare execCommand there re-introduces the poisoning — the
+// tmux server would inherit agent-deck's own cwd, which is frequently a
+// worktree that later gets removed.
+func TestStartSpawnsGoThroughNewSpawnCommand(t *testing.T) {
+	root := moduleRoot(t)
+	path := filepath.Join(root, "internal", "tmux", "tmux.go")
+
+	src, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, 0)
+	require.NoError(t, err)
+
+	var body string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "Start" || fn.Recv == nil || fn.Body == nil {
+			continue
+		}
+		body = string(src[fset.Position(fn.Body.Pos()).Offset:fset.Position(fn.Body.End()).Offset])
+		break
+	}
+	require.NotEmpty(t, body, "Session.Start not found in %s", path)
+
+	assert.NotContains(t, body, "execCommand(",
+		"Session.Start must spawn via newSpawnCommand so the spawn (and any tmux server it "+
+			"starts) runs from %q — see workdir_guard.go (#1713)", SpawnBaseDir)
+	assert.Contains(t, body, "newSpawnCommand(")
+	assert.Contains(t, body, "verifyPaneWorkDirUnlessPlaceholder(",
+		"Start must verify where the pane actually landed before reporting success (#1713)")
+	assert.Contains(t, body, "resolveStartWorkDir(",
+		"Start must validate the working directory before spawning (#1713)")
+}
+
+// requirePaneSettledIn blocks until tmux reports the pane's cwd as the given
+// directory, so tests that depend on the pane really being there are not racing
+// the child's chdir().
+func requirePaneSettledIn(t *testing.T, s *Session, dir string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		reported, err := panePathProbe(s)
+		if err == nil {
+			last = reported
+			if classifyPaneCwd(dir, reported) == paneCwdOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("pane never settled in %q (last reading: %q)", dir, last)
+}
+
+// privateSocketName1713 returns a deterministic -L socket name for this test and
+// registers teardown that kills the server on the SAME socket. An env mismatch
+// between spawn and cleanup makes kill-server a silent no-op and leaks a server
+// plus its ptys (the 2026-07-18 pty-exhaustion incident).
+func privateSocketName1713(t *testing.T) string {
+	t.Helper()
+	socket := "ad1713-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+	kill := func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() }
+	kill() // clear anything a previously aborted run stranded
+	t.Cleanup(kill)
+	return socket
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -973,6 +973,14 @@ type Session struct {
 	InstanceID  string // Agent-deck instance ID for hook callbacks
 	startupAt   time.Time
 
+	// WorkDirIsPlaceholder marks a session whose local WorkDir is not where the
+	// work happens — today that means an SSH session, whose pane only runs an
+	// `ssh` client while the project lives on the remote host. Such a session
+	// keeps working even if the local directory disappears, so it opts out of
+	// the #1713 working-directory guards (see workdir_guard.go) rather than
+	// being refused a start over a path nothing reads.
+	WorkDirIsPlaceholder bool
+
 	// SocketName is the tmux `-L <name>` socket selector for this session.
 	// When empty (pre-v1.7.50 default), every tmux call targets the user's
 	// default server at $TMUX_TMPDIR/tmux-<uid>/default, preserving the
@@ -2112,6 +2120,40 @@ func (s *Session) Start(command string) error {
 	// See assertTestTmuxIsolation for the full rationale.
 	assertTestTmuxIsolation()
 
+	// #1713: resolve and validate the working directory BEFORE mutating session
+	// state or spawning anything. tmux does NOT fail when -c points at a missing
+	// directory — it silently starts the pane in $HOME — so without this check a
+	// session whose project directory (or worktree) was deleted starts "fine"
+	// and runs the agent against the user's home directory instead. Failing here
+	// keeps the session untouched and surfaces the real reason at the CLI.
+	workDir := s.WorkDir
+	if workDir == "" {
+		workDir = os.Getenv("HOME")
+	}
+	resolvedWorkDir, workDirErr := resolveStartWorkDir(workDir)
+	if workDirErr != nil {
+		if !s.WorkDirIsPlaceholder {
+			statusLog.Warn("tmux_start_refused_bad_workdir",
+				slog.String("session", s.Name),
+				slog.String("requested_workdir", s.WorkDir),
+				slog.String("error", workDirErr.Error()))
+			return workDirErr
+		}
+		// An SSH session's local path is a placeholder: the pane only runs an
+		// ssh client, so a missing local directory must not block the start.
+		// Keep tmux's historical $HOME landing, but say so instead of hiding it.
+		statusLog.Warn("tmux_start_placeholder_workdir_fallback",
+			slog.String("session", s.Name),
+			slog.String("requested_workdir", workDir),
+			slog.String("error", workDirErr.Error()))
+		home, homeErr := resolveStartWorkDir(os.Getenv("HOME"))
+		if homeErr != nil {
+			return workDirErr
+		}
+		resolvedWorkDir = home
+	}
+	workDir = resolvedWorkDir
+
 	s.Command = command
 	s.invalidateCache()
 	s.Created = time.Now()
@@ -2130,17 +2172,16 @@ func (s *Session) Start(command string) error {
 		s.Name = SessionPrefix + sanitized + "_" + generateShortID()
 	}
 
-	// Ensure working directory exists
-	workDir := s.WorkDir
-	if workDir == "" {
-		workDir = os.Getenv("HOME")
-	}
-
 	// Create new tmux session in detached mode with the command as the initial
 	// process. This avoids the slow shell-wait-sendkeys path (~2s pane ready poll).
 	// Commands containing bash-specific syntax are wrapped for fish compatibility.
+	//
+	// workDir was resolved and validated at the top of Start (#1713).
 	launcher, args := s.startCommandSpec(workDir, command)
-	cmd := execCommand(launcher, args...)
+	// newSpawnCommand (not bare execCommand) so the spawn — and any tmux server
+	// it starts — runs from SpawnBaseDir and can never inherit a directory that
+	// is later deleted. See workdir_guard.go.
+	cmd := newSpawnCommand(launcher, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if launcher == "tmux" {
@@ -2153,7 +2194,7 @@ func (s *Session) Start(command string) error {
 				statusLog.Warn("tmux_start_retry_after_socket_recovery",
 					slog.String("session", s.Name),
 				)
-				output, err = execCommand(launcher, args...).CombinedOutput()
+				output, err = newSpawnCommand(launcher, args...).CombinedOutput()
 			}
 		}
 	}
@@ -2197,7 +2238,7 @@ func (s *Session) Start(command string) error {
 		triedScope := false
 		if wasServiceModeArgs(args) {
 			scopeRetryArgs := buildScopeArgsFromTmuxArgs(s.Name, tmuxArgs)
-			scopeOutput, scopeErr = execCommand("systemd-run", scopeRetryArgs...).CombinedOutput()
+			scopeOutput, scopeErr = newSpawnCommand("systemd-run", scopeRetryArgs...).CombinedOutput()
 			triedScope = true
 			if scopeErr == nil {
 				output = scopeOutput
@@ -2215,7 +2256,7 @@ func (s *Session) Start(command string) error {
 		// initial attempt was scope-mode, in which case it's the next
 		// tier down).
 		if err != nil {
-			retryOutput, retryErr := execCommand("tmux", tmuxArgs...).CombinedOutput()
+			retryOutput, retryErr := newSpawnCommand("tmux", tmuxArgs...).CombinedOutput()
 			if retryErr == nil {
 				output = retryOutput
 				err = nil
@@ -2242,6 +2283,22 @@ func (s *Session) Start(command string) error {
 	// Register session in cache immediately to prevent race condition
 	// where Exists() returns false because cache was refreshed before session creation
 	registerSessionInCache(s.Name)
+
+	// #1713: a tmux server whose OWN cwd was unlinked stops honouring -c and
+	// births every pane in that dead directory, where the pane's shell cannot
+	// getcwd() and the agent never execs. SpawnBaseDir prevents that for servers
+	// agent-deck starts, but a server started earlier (or by another tool) can
+	// already be poisoned, so confirm where the pane actually landed. Reporting
+	// such a session as started is the exact "looked created, never ran the
+	// agent" failure from the report — tear it down and say why instead.
+	if cwdErr := s.verifyPaneWorkDirUnlessPlaceholder(workDir); cwdErr != nil {
+		if killErr := s.Kill(); killErr != nil {
+			statusLog.Warn("deleted_cwd_session_cleanup_failed",
+				slog.String("session", s.Name),
+				slog.String("error", killErr.Error()))
+		}
+		return cwdErr
+	}
 
 	// PERFORMANCE: Batch all session options into a single subprocess call.
 	// Before: 7 separate exec.Command calls = 7 subprocess spawns (~50-70ms)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2134,8 +2134,8 @@ func (s *Session) Start(command string) error {
 	if workDirErr != nil {
 		if !s.WorkDirIsPlaceholder {
 			statusLog.Warn("tmux_start_refused_bad_workdir",
-				slog.String("session", s.Name),
-				slog.String("requested_workdir", s.WorkDir),
+				slog.String("session", logging.SanitizeValue(s.Name)),
+				slog.String("requested_workdir", logging.SanitizeValue(s.WorkDir)),
 				slog.String("error", workDirErr.Error()))
 			return workDirErr
 		}
@@ -2143,8 +2143,8 @@ func (s *Session) Start(command string) error {
 		// ssh client, so a missing local directory must not block the start.
 		// Keep tmux's historical $HOME landing, but say so instead of hiding it.
 		statusLog.Warn("tmux_start_placeholder_workdir_fallback",
-			slog.String("session", s.Name),
-			slog.String("requested_workdir", workDir),
+			slog.String("session", logging.SanitizeValue(s.Name)),
+			slog.String("requested_workdir", logging.SanitizeValue(workDir)),
 			slog.String("error", workDirErr.Error()))
 		home, homeErr := resolveStartWorkDir(os.Getenv("HOME"))
 		if homeErr != nil {
@@ -2294,7 +2294,7 @@ func (s *Session) Start(command string) error {
 	if cwdErr := s.verifyPaneWorkDirUnlessPlaceholder(workDir); cwdErr != nil {
 		if killErr := s.Kill(); killErr != nil {
 			statusLog.Warn("deleted_cwd_session_cleanup_failed",
-				slog.String("session", s.Name),
+				slog.String("session", logging.SanitizeValue(s.Name)),
 				slog.String("error", killErr.Error()))
 		}
 		return cwdErr

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -181,14 +181,14 @@ const (
 // an unlinked cwd as "/path (deleted)" and macOS reports the stale path
 // verbatim; both fail the stat, so both are caught.
 func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
-	// Strip only the newline tmux's display-message output is terminated
-	// with, never plain spaces — a real directory name may legitimately have
-	// them, and stripping would compare requested (space-preserving) against
-	// a shortened panePath, producing a false paneCwdDeleted/paneCwdElsewhere
-	// verdict for a healthy pane. A result that is blank once spaces are also
-	// considered (empty, or all-whitespace) is treated as no real report at
-	// all — that judgment uses TrimSpace only to decide emptiness, the value
-	// actually stat()ed below keeps its interior/trailing spaces intact.
+	// Strip only newline/tab/control framing (never plain spaces) — a real
+	// directory name may legitimately have them, and stripping would compare
+	// requested (space-preserving) against a shortened panePath, producing a
+	// false paneCwdDeleted/paneCwdElsewhere verdict for a healthy pane. A
+	// result that is blank once spaces are also considered (empty, or
+	// all-whitespace) is treated as no real report at all — that judgment
+	// uses TrimSpace only to decide emptiness; the value actually stat()ed
+	// below keeps its interior/trailing spaces intact.
 	panePath = strings.Trim(panePath, "\n\r\t\v\f")
 	if strings.TrimSpace(panePath) == "" {
 		return paneCwdUnknown

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -120,16 +120,18 @@ func resolveStartWorkDir(workDir string) (string, error) {
 	// reachable from POST /api/sessions (CreateSessionRequest.ProjectPath in
 	// internal/web/handlers_sessions.go -> WebMutator.CreateSession ->
 	// tmux.NewSession) — not local-CLI-only as an earlier pass through this
-	// file claimed. Accepted, not a false positive: that endpoint requires
-	// WebMutations enabled (off by default), binds loopback-only unless the
-	// operator opts into a wider bind with --insecure-bind or a configured
-	// --token (internal/web/bind.go CheckBindSecurity; a token, when set, is
-	// then required on every request, but an empty token is NOT itself a
-	// requirement — it just means "authorize everything", which loopback-only
-	// binding is what actually contains). Either way, this endpoint already
-	// authorizes running an arbitrary agent process at the supplied path, a
-	// strictly greater capability than this existence-only Stat. There is
-	// also no "safe base directory" to contain dir within the
+	// file claimed. Accepted, not a false positive: WebMutations defaults to
+	// true (session.GetWebMutationsEnabled), so it is NOT what contains this
+	// endpoint, and an empty/unset token authorizes every request too (see
+	// authorizeRequest), so token presence isn't a requirement either. The
+	// actual containment is `agent-deck web`'s default bind: 127.0.0.1-only,
+	// and CheckBindSecurity (internal/web/bind.go) refuses to start on a
+	// non-loopback address unless the operator explicitly passes
+	// --insecure-bind or configures a --token for the wider bind. Whenever
+	// this endpoint IS reachable, it already authorizes running an arbitrary
+	// agent process at the supplied path, a strictly greater capability than
+	// this existence-only Stat. There is also no "safe base directory" to
+	// contain dir within the
 	// way #1771's fix does for skills_catalog.go's manifest-derived targets —
 	// a session's working directory is meant to be able to name any directory
 	// on disk, so a containment check would just be wrong here. This Stat
@@ -208,11 +210,12 @@ func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
 //
 // CodeQL go/path-injection: a is the already-validated requested workDir (see
 // resolveStartWorkDir's comment above — reachable from POST /api/sessions,
-// but gated by WebMutations + loopback-only-by-default bind, and strictly
-// weaker than that endpoint's own authorized capability; accepted, not
-// false-positive); b is panePath, tmux's own report of #{pane_current_path}
-// for a pane this process just created. Both Stat calls only check
-// existence/identity, never read or write file contents.
+// but contained by the web server's default loopback-only bind rather than
+// by WebMutations or a token, and strictly weaker than that endpoint's own
+// authorized capability; accepted, not false-positive); b is panePath,
+// tmux's own report of #{pane_current_path} for a pane this process just
+// created. Both Stat calls only check existence/identity, never read or
+// write file contents.
 func sameDirectory(a, b string) bool {
 	if a == b {
 		return true
@@ -235,7 +238,7 @@ var panePathProbe = func(s *Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// Strip only the trailing newline tmux's own output framing adds — not
+	// Strip only newline/tab/control framing from tmux's own output — not
 	// spaces, which may be a real part of the reported directory name. See
 	// classifyPaneCwd, which re-trims with the same restricted cutset.
 	return strings.Trim(string(out), "\n\r\t\v\f"), nil

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -92,7 +92,13 @@ var ErrPaneCwdDeleted = errors.New("tmux pane started in a deleted working direc
 // an absolute path is the only form the pane-cwd verification below can compare
 // against.
 func resolveStartWorkDir(workDir string) (string, error) {
-	dir := strings.TrimSpace(workDir)
+	// Trim only newline/tab/control whitespace picked up from config files or
+	// flag parsing — never plain spaces. POSIX directory names may legitimately
+	// contain leading/trailing spaces; stripping those would silently retarget
+	// the start to a different (possibly nonexistent-vs-existent) path than the
+	// one actually recorded for the session, which is exactly the class of
+	// wrong-directory failure this guard exists to catch.
+	dir := strings.Trim(workDir, "\n\r\t\v\f")
 	if dir == "" {
 		return "", fmt.Errorf(
 			"%w: no working directory is recorded for this session and $HOME is unset — "+
@@ -110,18 +116,22 @@ func resolveStartWorkDir(workDir string) (string, error) {
 		dir = abs
 	}
 
-	// CodeQL go/path-injection: dir traces back to Session.WorkDir, which is
-	// only ever set by local CLI/TUI flows on the operator's own machine
-	// (internal/ui/home.go, internal/tmux/tmux.go, internal/session/storage.go
-	// — grepped, none reachable from internal/web), never from an HTTP request
-	// or other remote-attacker-controlled input. There is also no "safe base
-	// directory" to contain dir within the way #1771's fix does for
-	// skills_catalog.go's manifest-derived targets — a session's working
-	// directory is meant to be able to name any directory on disk, so a
-	// containment check would just be wrong. This Stat only checks existence
-	// (see the os.IsNotExist branch below); it never reads, writes, or reveals
-	// file contents. Genuinely safe by construction.
-	info, err := os.Stat(dir) // lgtm[go/path-injection] -- local session-owner path, existence check only, see comment above
+	// CodeQL go/path-injection: dir traces back to Session.WorkDir, which IS
+	// reachable from POST /api/sessions (CreateSessionRequest.ProjectPath in
+	// internal/web/handlers_sessions.go -> WebMutator.CreateSession ->
+	// tmux.NewSession) — not local-CLI-only as an earlier pass through this
+	// file claimed. Accepted, not a false positive: that endpoint requires
+	// WebMutations enabled plus token auth, binds 127.0.0.1 by default, and
+	// refuses non-loopback requests without a token (internal/web/server.go);
+	// it already authorizes running an arbitrary agent process at the
+	// supplied path, a strictly greater capability than this existence-only
+	// Stat. There is also no "safe base directory" to contain dir within the
+	// way #1771's fix does for skills_catalog.go's manifest-derived targets —
+	// a session's working directory is meant to be able to name any directory
+	// on disk, so a containment check would just be wrong here. This Stat
+	// only checks existence (see the os.IsNotExist branch below); it never
+	// reads, writes, or reveals file contents.
+	info, err := os.Stat(dir) // lgtm[go/path-injection] -- accepted, existence check only, see comment above
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", fmt.Errorf(
@@ -185,7 +195,9 @@ func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
 // symlinked prefixes (macOS reports /private/tmp/x for /tmp/x).
 //
 // CodeQL go/path-injection: a is the already-validated requested workDir (see
-// resolveStartWorkDir's comment — local session-owner path, no remote input);
+// resolveStartWorkDir's comment above — reachable from POST /api/sessions,
+// but gated by WebMutations+token+loopback and strictly weaker than that
+// endpoint's own authorized capability, accepted not false-positive);
 // b is panePath, tmux's own report of #{pane_current_path} for a pane this
 // process just created. Both Stat calls only check existence/identity, never
 // read or write file contents.
@@ -193,7 +205,7 @@ func sameDirectory(a, b string) bool {
 	if a == b {
 		return true
 	}
-	ai, err := os.Stat(a) // lgtm[go/path-injection] -- local session-owner path, see doc above
+	ai, err := os.Stat(a) // lgtm[go/path-injection] -- accepted, see doc above
 	if err != nil {
 		return false
 	}
@@ -273,9 +285,16 @@ func (s *Session) verifyPaneWorkDir(workDir string) error {
 		return deletedPaneCwdError(s.SocketName, workDir, panePath)
 	case paneCwdElsewhere:
 		// Not a failure: a pane command may legitimately change directory
-		// (the fork/multi-repo paths build a `cd <dir> && …` command), and
-		// tmux's $HOME substitution is already prevented by
-		// resolveStartWorkDir. Logged so the mismatch is diagnosable.
+		// (the fork/multi-repo paths build a `cd <dir> && …` command).
+		// resolveStartWorkDir's pre-flight Stat rules out tmux's $HOME
+		// substitution for the common case, but not a TOCTOU race — if
+		// workDir is removed between that Stat and this pane actually
+		// spawning, tmux still substitutes $HOME and lands here as
+		// "elsewhere" rather than "deleted", so this warn-only path is a
+		// known gap, not a closed one. Kept warn-only deliberately (the
+		// legitimate cd-elsewhere case is far more common than the race),
+		// but a mismatch landing exactly on $HOME deserves scrutiny over one
+		// landing anywhere else. Logged either way so it is diagnosable.
 		statusLog.Warn("pane_cwd_differs_from_requested",
 			slog.String("session", logging.SanitizeValue(s.Name)),
 			slog.String("requested_workdir", logging.SanitizeValue(workDir)),

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -121,11 +121,15 @@ func resolveStartWorkDir(workDir string) (string, error) {
 	// internal/web/handlers_sessions.go -> WebMutator.CreateSession ->
 	// tmux.NewSession) — not local-CLI-only as an earlier pass through this
 	// file claimed. Accepted, not a false positive: that endpoint requires
-	// WebMutations enabled plus token auth, binds 127.0.0.1 by default, and
-	// refuses non-loopback requests without a token (internal/web/server.go);
-	// it already authorizes running an arbitrary agent process at the
-	// supplied path, a strictly greater capability than this existence-only
-	// Stat. There is also no "safe base directory" to contain dir within the
+	// WebMutations enabled (off by default), binds loopback-only unless the
+	// operator opts into a wider bind with --insecure-bind or a configured
+	// --token (internal/web/bind.go CheckBindSecurity; a token, when set, is
+	// then required on every request, but an empty token is NOT itself a
+	// requirement — it just means "authorize everything", which loopback-only
+	// binding is what actually contains). Either way, this endpoint already
+	// authorizes running an arbitrary agent process at the supplied path, a
+	// strictly greater capability than this existence-only Stat. There is
+	// also no "safe base directory" to contain dir within the
 	// way #1771's fix does for skills_catalog.go's manifest-derived targets —
 	// a session's working directory is meant to be able to name any directory
 	// on disk, so a containment check would just be wrong here. This Stat
@@ -175,8 +179,16 @@ const (
 // an unlinked cwd as "/path (deleted)" and macOS reports the stale path
 // verbatim; both fail the stat, so both are caught.
 func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
-	panePath = strings.TrimSpace(panePath)
-	if panePath == "" {
+	// Strip only the newline tmux's display-message output is terminated
+	// with, never plain spaces — a real directory name may legitimately have
+	// them, and stripping would compare requested (space-preserving) against
+	// a shortened panePath, producing a false paneCwdDeleted/paneCwdElsewhere
+	// verdict for a healthy pane. A result that is blank once spaces are also
+	// considered (empty, or all-whitespace) is treated as no real report at
+	// all — that judgment uses TrimSpace only to decide emptiness, the value
+	// actually stat()ed below keeps its interior/trailing spaces intact.
+	panePath = strings.Trim(panePath, "\n\r\t\v\f")
+	if strings.TrimSpace(panePath) == "" {
 		return paneCwdUnknown
 	}
 	if _, err := os.Stat(panePath); err != nil {
@@ -196,11 +208,11 @@ func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
 //
 // CodeQL go/path-injection: a is the already-validated requested workDir (see
 // resolveStartWorkDir's comment above — reachable from POST /api/sessions,
-// but gated by WebMutations+token+loopback and strictly weaker than that
-// endpoint's own authorized capability, accepted not false-positive);
-// b is panePath, tmux's own report of #{pane_current_path} for a pane this
-// process just created. Both Stat calls only check existence/identity, never
-// read or write file contents.
+// but gated by WebMutations + loopback-only-by-default bind, and strictly
+// weaker than that endpoint's own authorized capability; accepted, not
+// false-positive); b is panePath, tmux's own report of #{pane_current_path}
+// for a pane this process just created. Both Stat calls only check
+// existence/identity, never read or write file contents.
 func sameDirectory(a, b string) bool {
 	if a == b {
 		return true
@@ -223,7 +235,10 @@ var panePathProbe = func(s *Session) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	// Strip only the trailing newline tmux's own output framing adds — not
+	// spaces, which may be a real part of the reported directory name. See
+	// classifyPaneCwd, which re-trims with the same restricted cutset.
+	return strings.Trim(string(out), "\n\r\t\v\f"), nil
 }
 
 // paneCwdRecheckDelay spaces the re-probes below. tmux creates the pane process
@@ -287,14 +302,14 @@ func (s *Session) verifyPaneWorkDir(workDir string) error {
 		// Not a failure: a pane command may legitimately change directory
 		// (the fork/multi-repo paths build a `cd <dir> && …` command).
 		// resolveStartWorkDir's pre-flight Stat rules out tmux's $HOME
-		// substitution for the common case, but not a TOCTOU race — if
-		// workDir is removed between that Stat and this pane actually
-		// spawning, tmux still substitutes $HOME and lands here as
-		// "elsewhere" rather than "deleted", so this warn-only path is a
-		// known gap, not a closed one. Kept warn-only deliberately (the
-		// legitimate cd-elsewhere case is far more common than the race),
-		// but a mismatch landing exactly on $HOME deserves scrutiny over one
-		// landing anywhere else. Logged either way so it is diagnosable.
+		// substitution for the common case, but not a TOCTOU race: if workDir
+		// is removed between that Stat and this pane actually spawning, the
+		// outcome depends on exact timing. tmux may still substitute $HOME and
+		// land here as "elsewhere" — or the removal may instead be caught by
+		// classifyPaneCwd's own re-stat and surface as paneCwdDeleted above.
+		// Either way this is a known gap in the guard, not a closed one. Kept
+		// warn-only here deliberately (the legitimate cd-elsewhere case is far
+		// more common than the race). Logged either way so it is diagnosable.
 		statusLog.Warn("pane_cwd_differs_from_requested",
 			slog.String("session", logging.SanitizeValue(s.Name)),
 			slog.String("requested_workdir", logging.SanitizeValue(workDir)),

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
 
 // Issue #1713 — "add -w spawns a shell that dies with shell-init: error
@@ -108,7 +110,18 @@ func resolveStartWorkDir(workDir string) (string, error) {
 		dir = abs
 	}
 
-	info, err := os.Stat(dir)
+	// CodeQL go/path-injection: dir traces back to Session.WorkDir, which is
+	// only ever set by local CLI/TUI flows on the operator's own machine
+	// (internal/ui/home.go, internal/tmux/tmux.go, internal/session/storage.go
+	// — grepped, none reachable from internal/web), never from an HTTP request
+	// or other remote-attacker-controlled input. There is also no "safe base
+	// directory" to contain dir within the way #1771's fix does for
+	// skills_catalog.go's manifest-derived targets — a session's working
+	// directory is meant to be able to name any directory on disk, so a
+	// containment check would just be wrong. This Stat only checks existence
+	// (see the os.IsNotExist branch below); it never reads, writes, or reveals
+	// file contents. Genuinely safe by construction.
+	info, err := os.Stat(dir) // lgtm[go/path-injection] -- local session-owner path, existence check only, see comment above
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", fmt.Errorf(
@@ -170,15 +183,21 @@ func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
 
 // sameDirectory reports whether two paths name the same directory, tolerating
 // symlinked prefixes (macOS reports /private/tmp/x for /tmp/x).
+//
+// CodeQL go/path-injection: a is the already-validated requested workDir (see
+// resolveStartWorkDir's comment — local session-owner path, no remote input);
+// b is panePath, tmux's own report of #{pane_current_path} for a pane this
+// process just created. Both Stat calls only check existence/identity, never
+// read or write file contents.
 func sameDirectory(a, b string) bool {
 	if a == b {
 		return true
 	}
-	ai, err := os.Stat(a)
+	ai, err := os.Stat(a) // lgtm[go/path-injection] -- local session-owner path, see doc above
 	if err != nil {
 		return false
 	}
-	bi, err := os.Stat(b)
+	bi, err := os.Stat(b) // lgtm[go/path-injection] -- tmux-reported pane path, see doc above
 	if err != nil {
 		return false
 	}
@@ -228,7 +247,7 @@ func (s *Session) verifyPaneWorkDir(workDir string) error {
 		reported, err := panePathProbe(s)
 		if err != nil {
 			statusLog.Debug("pane_cwd_probe_failed",
-				slog.String("session", s.Name),
+				slog.String("session", logging.SanitizeValue(s.Name)),
 				slog.String("error", err.Error()))
 			return nil
 		}
@@ -246,9 +265,9 @@ func (s *Session) verifyPaneWorkDir(workDir string) error {
 	switch verdict {
 	case paneCwdDeleted:
 		statusLog.Error("pane_born_in_deleted_cwd",
-			slog.String("session", s.Name),
-			slog.String("requested_workdir", workDir),
-			slog.String("pane_cwd", panePath),
+			slog.String("session", logging.SanitizeValue(s.Name)),
+			slog.String("requested_workdir", logging.SanitizeValue(workDir)),
+			slog.String("pane_cwd", logging.SanitizeValue(panePath)),
 			slog.String("socket", socketLabel(s.SocketName)),
 			slog.String("issue", "1713"))
 		return deletedPaneCwdError(s.SocketName, workDir, panePath)
@@ -258,9 +277,9 @@ func (s *Session) verifyPaneWorkDir(workDir string) error {
 		// tmux's $HOME substitution is already prevented by
 		// resolveStartWorkDir. Logged so the mismatch is diagnosable.
 		statusLog.Warn("pane_cwd_differs_from_requested",
-			slog.String("session", s.Name),
-			slog.String("requested_workdir", workDir),
-			slog.String("pane_cwd", panePath))
+			slog.String("session", logging.SanitizeValue(s.Name)),
+			slog.String("requested_workdir", logging.SanitizeValue(workDir)),
+			slog.String("pane_cwd", logging.SanitizeValue(panePath)))
 	}
 	return nil
 }

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -1,0 +1,289 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Issue #1713 — "add -w spawns a shell that dies with shell-init: error
+// retrieving current directory".
+//
+// tmux never fails a spawn because of a bad working directory; it silently
+// substitutes one. Two observable behaviours (verified on tmux 3.7b, macOS,
+// and reproducible with a bare tmux) made agent-deck report a healthy session
+// that had never run the agent:
+//
+//  1. `new-session -c <missing dir>` → tmux starts the pane in $HOME instead.
+//     The agent boots, looks alive, and operates on the WRONG tree (the user's
+//     home directory) while agent-deck records success.
+//
+//  2. If the tmux SERVER's own working directory has been unlinked, tmux stops
+//     honouring `-c` altogether: every new pane inherits the server's dead cwd.
+//     The pane's first process then prints
+//
+//         shell-init: error retrieving current directory: getcwd: cannot
+//         access parent directories: No such file or directory
+//
+//     and the agent never runs. This is the reported failure, and it explains
+//     every observation in #1713: the worktree itself was fine (verified from
+//     another shell), the same error followed a restart, it reproduced across
+//     three different worktree paths, it reproduced WITHOUT -w when pointing at
+//     an already-good directory, and plain shells on the host worked fine —
+//     because none of those touch the poisoned tmux server.
+//
+//     A server picks up a deletable cwd by inheriting it from whatever process
+//     first started it. A worktree is exactly the kind of directory that later
+//     gets removed (`agent-deck rm`, `worktree cleanup`, a manual cleanup
+//     during resource pressure), which is why worktree users hit this first.
+//
+// The three guards below address that, in order of preference:
+//
+//   - SpawnBaseDir: every tmux spawn agent-deck issues runs from "/", so a
+//     server agent-deck starts can never inherit a directory that is later
+//     deleted. Prevention — no diagnosis needed.
+//   - resolveStartWorkDir: refuse to start at all when the session's directory
+//     is gone, instead of silently running the agent in $HOME.
+//   - verifyPaneWorkDir: after creation, notice a pane that was born in an
+//     unlinked directory (an already-poisoned server, which the prevention above
+//     cannot retro-fix) and fail loudly instead of recording it as alive.
+
+// SpawnBaseDir is the working directory agent-deck uses for the tmux
+// subprocesses it spawns. "/" is the one directory that cannot be deleted or
+// renamed, so a tmux server started by agent-deck can never end up holding an
+// unlinked cwd (behaviour 2 above).
+//
+// It is safe for the tmux argv agent-deck builds: start directories are passed
+// as absolute paths via -c (resolveStartWorkDir absolutises them first), so no
+// tmux argument is interpreted relative to the client's cwd.
+const SpawnBaseDir = "/"
+
+// newSpawnCommand builds a tmux (or systemd-run) spawn command that runs from
+// SpawnBaseDir. Every server-creating invocation must go through this — see
+// TestNewSpawnCommand_RunsFromSpawnBaseDir and the Start() lint in
+// issue1713_workdir_guard_test.go.
+func newSpawnCommand(launcher string, args ...string) *exec.Cmd {
+	cmd := execCommand(launcher, args...)
+	cmd.Dir = SpawnBaseDir
+	return cmd
+}
+
+// ErrWorkDirUnavailable marks a start refused because the session's working
+// directory could not be used. Callers can test for it with errors.Is.
+var ErrWorkDirUnavailable = errors.New("session working directory is unavailable")
+
+// ErrPaneCwdDeleted marks a session whose pane was born in a directory that no
+// longer exists — the pane holds only a broken shell and the agent never ran.
+var ErrPaneCwdDeleted = errors.New("tmux pane started in a deleted working directory")
+
+// resolveStartWorkDir absolutises and validates the directory a session is
+// about to start in. It returns the path to hand to `tmux new-session -c`, or
+// an error describing exactly what is wrong.
+//
+// Absolutising matters for two reasons: tmux resolves a relative -c against the
+// spawning client's cwd (which is SpawnBaseDir now, not agent-deck's cwd), and
+// an absolute path is the only form the pane-cwd verification below can compare
+// against.
+func resolveStartWorkDir(workDir string) (string, error) {
+	dir := strings.TrimSpace(workDir)
+	if dir == "" {
+		return "", fmt.Errorf(
+			"%w: no working directory is recorded for this session and $HOME is unset — "+
+				"set the session's path (agent-deck session show <id>) before starting it",
+			ErrWorkDirUnavailable)
+	}
+
+	if !filepath.IsAbs(dir) {
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return "", fmt.Errorf(
+				"%w: cannot resolve %q to an absolute path: %v",
+				ErrWorkDirUnavailable, dir, err)
+		}
+		dir = abs
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"%w: %s does not exist. The session's project directory (or worktree) was "+
+					"deleted or renamed. Starting anyway would not fail — tmux silently starts "+
+					"the pane in $HOME instead, so the agent would run against the wrong tree. "+
+					"Recreate the directory, or point the session at a new path, then start again",
+				ErrWorkDirUnavailable, dir)
+		}
+		return "", fmt.Errorf("%w: cannot access %s: %v", ErrWorkDirUnavailable, dir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%w: %s is not a directory", ErrWorkDirUnavailable, dir)
+	}
+	return dir, nil
+}
+
+// paneCwdVerdict classifies where a freshly created pane actually landed.
+type paneCwdVerdict int
+
+const (
+	// paneCwdOK — the pane is in the directory we asked for.
+	paneCwdOK paneCwdVerdict = iota
+	// paneCwdUnknown — we could not tell (empty/unreadable report). Never a
+	// reason to fail a start.
+	paneCwdUnknown
+	// paneCwdDeleted — the pane is sitting in a path that does not exist. Its
+	// shell cannot getcwd(); the agent did not run.
+	paneCwdDeleted
+	// paneCwdElsewhere — the pane is in a real but different directory (tmux
+	// substituted one, or the pane command changed directory itself).
+	paneCwdElsewhere
+)
+
+// classifyPaneCwd compares the requested start directory against the path tmux
+// reports for the pane. Pure apart from stat()ing the two paths, so it is
+// directly unit-testable.
+//
+// Only a path that provably does not exist yields paneCwdDeleted: an
+// unreadable or ambiguous reading must never fail a start. Linux tmux reports
+// an unlinked cwd as "/path (deleted)" and macOS reports the stale path
+// verbatim; both fail the stat, so both are caught.
+func classifyPaneCwd(requested, panePath string) paneCwdVerdict {
+	panePath = strings.TrimSpace(panePath)
+	if panePath == "" {
+		return paneCwdUnknown
+	}
+	if _, err := os.Stat(panePath); err != nil {
+		if os.IsNotExist(err) {
+			return paneCwdDeleted
+		}
+		return paneCwdUnknown
+	}
+	if sameDirectory(requested, panePath) {
+		return paneCwdOK
+	}
+	return paneCwdElsewhere
+}
+
+// sameDirectory reports whether two paths name the same directory, tolerating
+// symlinked prefixes (macOS reports /private/tmp/x for /tmp/x).
+func sameDirectory(a, b string) bool {
+	if a == b {
+		return true
+	}
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(ai, bi)
+}
+
+// panePathProbe reads the pane's live working directory. Swappable seam so the
+// verification logic can be tested without a tmux server.
+var panePathProbe = func(s *Session) (string, error) {
+	out, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{pane_current_path}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// paneCwdRecheckDelay spaces the re-probes below. tmux creates the pane process
+// before it has chdir()ed, so a single early read can legitimately still show
+// the server's cwd.
+var paneCwdRecheckDelay = 60 * time.Millisecond
+
+// paneCwdProbeAttempts is how many times a "deleted" reading is re-confirmed
+// before it is believed. Only the broken path pays this cost.
+const paneCwdProbeAttempts = 3
+
+// verifyPaneWorkDirUnlessPlaceholder is the Start() entry point: it skips the
+// check for sessions whose local directory is only a placeholder (SSH), whose
+// pane runs an ssh client that does not care where it started.
+func (s *Session) verifyPaneWorkDirUnlessPlaceholder(workDir string) error {
+	if s.WorkDirIsPlaceholder {
+		return nil
+	}
+	return s.verifyPaneWorkDir(workDir)
+}
+
+// verifyPaneWorkDir confirms a freshly created session's pane is not sitting in
+// an unlinked directory. It returns an error only when that is provable, so a
+// slow or unreadable probe can never fail an otherwise healthy start.
+func (s *Session) verifyPaneWorkDir(workDir string) error {
+	var panePath string
+	verdict := paneCwdUnknown
+
+	for attempt := 0; attempt < paneCwdProbeAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(paneCwdRecheckDelay)
+		}
+		reported, err := panePathProbe(s)
+		if err != nil {
+			statusLog.Debug("pane_cwd_probe_failed",
+				slog.String("session", s.Name),
+				slog.String("error", err.Error()))
+			return nil
+		}
+		panePath = reported
+		verdict = classifyPaneCwd(workDir, panePath)
+		// Only a "deleted" reading is worth re-confirming: it is the one
+		// verdict that fails the start, and the one a too-early read can
+		// manufacture (the pane process exists but has not chdir()ed yet, so
+		// it still shows the server's cwd).
+		if verdict != paneCwdDeleted {
+			break
+		}
+	}
+
+	switch verdict {
+	case paneCwdDeleted:
+		statusLog.Error("pane_born_in_deleted_cwd",
+			slog.String("session", s.Name),
+			slog.String("requested_workdir", workDir),
+			slog.String("pane_cwd", panePath),
+			slog.String("socket", socketLabel(s.SocketName)),
+			slog.String("issue", "1713"))
+		return deletedPaneCwdError(s.SocketName, workDir, panePath)
+	case paneCwdElsewhere:
+		// Not a failure: a pane command may legitimately change directory
+		// (the fork/multi-repo paths build a `cd <dir> && …` command), and
+		// tmux's $HOME substitution is already prevented by
+		// resolveStartWorkDir. Logged so the mismatch is diagnosable.
+		statusLog.Warn("pane_cwd_differs_from_requested",
+			slog.String("session", s.Name),
+			slog.String("requested_workdir", workDir),
+			slog.String("pane_cwd", panePath))
+	}
+	return nil
+}
+
+// socketLabel renders a socket name for human-facing messages.
+func socketLabel(socketName string) string {
+	name := strings.TrimSpace(socketName)
+	if name == "" {
+		return "default"
+	}
+	return name
+}
+
+// deletedPaneCwdError explains the poisoned-server failure and what to do about
+// it. Written for someone reading a CLI error, not a stack trace.
+func deletedPaneCwdError(socketName, workDir, panePath string) error {
+	return fmt.Errorf(
+		"%w: tmux placed the new pane in %s, which no longer exists, so the pane holds only a "+
+			"broken shell (\"shell-init: error retrieving current directory\") and the agent never "+
+			"started. The requested directory %s is fine — the tmux server on socket %q is itself "+
+			"running from a deleted directory, and tmux then ignores the -c start directory for every "+
+			"new pane. Restart that tmux server when its sessions can be recreated (all sessions on "+
+			"it are affected); servers agent-deck starts now run from %s, so this cannot recur for "+
+			"them (issue #1713)",
+		ErrPaneCwdDeleted, panePath, workDir, socketLabel(socketName), SpawnBaseDir)
+}


### PR DESCRIPTION
Fixes #1713.

## What was happening

`add -w` produced a session whose pane held only a broken shell:

```
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
```

agent-deck reported it created, started and `health_class: alive`. The agent never ran, and only a direct `tmux capture-pane` revealed it. Thank you @kewtyboi — the report ruled out so much up front that it pointed straight at the real culprit, which turned out not to be the worktree at all.

## Root cause

Reproduced with a bare tmux (3.7b, macOS), no agent-deck involved:

```sh
mkdir -p /tmp/x/srv /tmp/x/good
( cd /tmp/x/srv && tmux -L probe new-session -d -s seed )   # server cwd = /tmp/x/srv
rm -rf /tmp/x/srv                                           # unlink the SERVER's cwd
tmux -L probe new-session -d -s t -c /tmp/x/good bash -c pwd
# -> pane_current_path is /tmp/x/srv (NOT the requested -c), and the pane
#    prints exactly the shell-init getcwd error above
```

**Once a tmux server's own working directory has been unlinked, tmux stops honouring the requested `-c` start directory and every new pane inherits the server's dead cwd.** The pane's first process cannot `getcwd()`, so it prints that message and the agent never execs.

That accounts for every observation in the report:

| Report observation | Explanation |
| --- | --- |
| Worktree existed and was fully populated (verified from another shell) | The worktree was never the problem; the tmux **server** was |
| `session restart` hit the same error | Same server |
| Reproduced across 3 different worktree paths | Server-scoped, not path-scoped |
| Reproduced **without** `-w`, pointing at an already-good path | Confirms it is not worktree creation at all |
| `zsh -i -c pwd` / `bash -c pwd` fine on the host | Those never touch the tmux server |
| Not load-related | Correct — load was a red herring |

A tmux server inherits its cwd from whatever process starts it. agent-deck is frequently run from a worktree, and a worktree is exactly the kind of directory that later gets removed (`agent-deck rm`, `worktree cleanup`, a manual cleanup during resource pressure — which the report mentions). After that, every session created on that server is born broken. This also means the window stays broken until the server is restarted, matching "any dispatch attempt during this window".

### Sibling defect found on the same code path

With a *healthy* server, `new-session -c <missing dir>` does not fail either — tmux silently starts the pane in `$HOME`. So a session whose project directory or worktree was deleted came up "successfully" with the agent pointed at the user's home directory. `Start()` even carried the comment `// Ensure working directory exists` above code that never checked.

## The fix

Three guards, in order of preference (`internal/tmux/workdir_guard.go`):

1. **Prevention** — every tmux spawn agent-deck issues now runs from `/`, the one directory that cannot be unlinked, so a server agent-deck starts can never inherit a deletable cwd.
2. **Pre-flight** — `resolveStartWorkDir` absolutises and validates the working directory *before* anything is spawned, and refuses the start with a message naming the directory rather than silently landing the agent in `$HOME`.
3. **Post-flight** — after creation, verify where the pane actually landed. A pane sitting in a path that provably does not exist (an already-poisoned server, which prevention cannot retro-fix) fails loudly, and the half-alive session is torn down instead of being recorded as started.

Deliberately conservative: only a **provably missing** path fails a start. An unreadable probe, or a pane that changed directory itself (the fork / multi-repo paths build `cd <dir> && …` commands), is logged and tolerated. A "deleted" reading is re-confirmed before it is believed, because tmux creates the pane process before it has `chdir()`ed.

SSH sessions opt out through `WorkDirIsPlaceholder`: their local path is only a placeholder, the pane runs an `ssh` client, and the project lives on the remote host, so a missing local directory must not make them unstartable. They keep tmux's historical `$HOME` landing, logged rather than hidden.

## Verification

Behaviour checked against real tmux via a scratch binary built from this branch and from `main` (isolated `-L` socket + isolated `TMUX_TMPDIR`, servers killed with the same socket resolution):

**The reported scenario** — server started from a directory that is then deleted, then a session created with a perfectly good working directory:

```
PASS  poisoned server: Start reports failure instead of success
PASS  poisoned server: error is ErrPaneCwdDeleted
PASS  poisoned server: no half-alive session left behind
```

with the error text:

> tmux placed the new pane in /private/tmp/…/doomed, which no longer exists, so the pane holds only a broken shell ("shell-init: error retrieving current directory") and the agent never started. The requested directory /tmp/…/good is fine — the tmux server on socket "…" is itself running from a deleted directory, and tmux then ignores the -c start directory for every new pane. Restart that tmux server when its sessions can be recreated (all sessions on it are affected); servers agent-deck starts now run from /, so this cannot recur for them (issue #1713)

Unrelated sessions on that server were untouched — the teardown is session-scoped, never `kill-server`.

**Prevention, before vs after** — agent-deck launched from a directory deleted out from under it, creating the first session on a fresh socket:

| | tmux server cwd | pane cwd | reported |
| --- | --- | --- | --- |
| `main` | `/private/tmp/…/launchdir` (deleted) | the deleted dir | success + alive |
| this branch | `/` | the requested directory | success + alive |

On `main` that server is poisoned from birth for every later session; on this branch it cannot be.

Also verified: a missing working directory is refused with no tmux spawn at all; a placeholder (SSH) session with a missing local directory still starts; healthy starts are unchanged.

## Tests

- `internal/tmux/issue1713_workdir_guard_test.go` — the verdict classifier (ok / unknown / deleted / elsewhere, symlinked-prefix tolerance), `resolveStartWorkDir` (missing, file, empty, relative-absolutised), the re-confirm-before-failing retry, probe-failure tolerance, `Start()` refusing a deleted directory without spawning, `Start()` tearing down a session born in a deleted directory, the placeholder opt-out, and the real-tmux probe against a pane whose directory is deleted after birth. Plus a lint pinning that every spawn in `Session.Start` goes through `newSpawnCommand` and that both guards stay wired.
- `internal/session/issue1713_placeholder_workdir_test.go` — pins the SSH opt-out at the single chokepoint the three `Start()` paths share.
- `internal/session/instance_test.go` — one pre-existing test started a session in `/tmp/claude-zombie-reject`, which does not exist; it now uses a real temp dir. It was passing only because tmux silently redirected it to `$HOME`.

Every test in the repo that starts a session was audited for non-existent paths; that was the only one.

## Notes for review

- `Session.Start` now returns before mutating session state when the directory is unusable, so a refused start leaves the session untouched. Errors already surface at the CLI (`session start` exits 1) and are persisted by `recordTmuxStartFailure`, so `session show` explains it too.
- The sandbox terminal helper's `new-session` (`internal/session/instance.go`) also spawns from `/` now: it is the only other call that could create a server. Its pane runs `docker exec`, whose working directory is fixed at container create, so nothing else changes.
- No `internal/ui` refresh paths are touched, so there is no overlap with the TUI performance work in flight.
- Untouched on purpose: `respawn-pane` does not pass `-c`, so a restart re-uses the pane's recorded directory and falls back to `$HOME` if that directory is gone. Worth a separate look; re-anchoring restarts to the session's project directory is a behaviour change that deserves its own discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH and sandbox terminal startup when the original working directory is remote, deleted, or otherwise unavailable.
  * Added safeguards to prevent sessions from launching in invalid or unexpected directories.
  * Sessions now safely fall back to a reliable default directory when their configured directory cannot be used.
  * Improved cleanup of sessions whose terminal directory becomes invalid after startup.
  * Reduced startup failures caused by stale, missing, relative, or inaccessible working-directory paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->