### PR TITLE
fix: store project_path absolute on every local write path (#1706)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -206,6 +206,8 @@ func shouldInheritParentGroup(explicitGroupProvided, inheritGroupFlag bool, path
 }
 
 // resolveAddPath resolves the user-provided positional path arg for `agent-deck add`.
+// Also used by `agent-deck session move` (#1706): both take a user-supplied
+// positional project path and must resolve it the same way.
 // Handles ".", "~", "~/foo", "$VAR/foo", and relative/absolute paths uniformly.
 // session.ExpandPath runs first so a literal tilde from a non-expanding shell
 // (e.g. SSH-driven invocation) reaches a real home directory before Abs.

--- a/cmd/agent-deck/issue1706_move_relative_test.go
+++ b/cmd/agent-deck/issue1706_move_relative_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Related to #1706: `session move` stored its positional path argument verbatim,
+// so a relative argument became a relative project_path — resolved against the
+// tmux server's cwd when the session restarts, and against a different
+// directory again for the Claude history slug this command migrates. `add` has
+// always resolved the same argument; move now does too.
+//
+// The relative argument used here is "." (the CLI subprocess inherits this test
+// binary's cwd), so the test creates no directories anywhere.
+func TestIssue1706_SessionMoveResolvesRelativePathArg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	oldPath := home + "/old-proj"
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	id := sessionMoveAddSession(t, home, oldPath, "move-relative")
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"session", "move", id, ".",
+		"--no-restart",
+		"--json",
+	)
+	if code != 0 {
+		t.Fatalf("session move . failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+
+	listJSON := readSessionsJSON(t, home)
+	if !strings.Contains(listJSON, cwd) {
+		t.Errorf("project path was not resolved to the caller's cwd %q; list:\n%s", cwd, listJSON)
+	}
+	if strings.Contains(listJSON, `"path":"."`) || strings.Contains(listJSON, `"path": "."`) {
+		t.Errorf("project path was stored as the literal relative argument; list:\n%s", listJSON)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1943,6 +1943,11 @@ func handleSessionSet(profile string, args []string) {
 		os.Exit(1)
 		return // unreachable, satisfies staticcheck SA5011
 	}
+	// #1706: SetField canonicalizes a project path (expand + absolutize), so
+	// report what was actually stored rather than the raw argument.
+	if field == session.FieldPath {
+		value = inst.ProjectPath
+	}
 	// CLI holds no lock — run tmux side effects inline. TUI defers them
 	// until after instancesMu.Unlock.
 	if postCommit != nil {

--- a/cmd/agent-deck/session_move.go
+++ b/cmd/agent-deck/session_move.go
@@ -94,7 +94,15 @@ func handleSessionMove(profile string, args []string) {
 	}
 
 	identifier := fs.Arg(0)
-	newPath := fs.Arg(1)
+	// #1706: resolve the positional path exactly as `add` does. The stored
+	// project_path is identity — the Claude-history migration below derives its
+	// slug from it, and tmux would resolve a relative value against the tmux
+	// server's cwd rather than the caller's.
+	newPath, resErr := resolveAddPath(fs.Arg(1))
+	if resErr != nil {
+		out.Error(fmt.Sprintf("resolve new path: %v", resErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 
 	storage, instances, groups, err := loadSessionData(profile)
 	if err != nil {

--- a/cmd/agent-deck/session_move.go
+++ b/cmd/agent-deck/session_move.go
@@ -94,15 +94,7 @@ func handleSessionMove(profile string, args []string) {
 	}
 
 	identifier := fs.Arg(0)
-	// #1706: resolve the positional path exactly as `add` does. The stored
-	// project_path is identity — the Claude-history migration below derives its
-	// slug from it, and tmux would resolve a relative value against the tmux
-	// server's cwd rather than the caller's.
-	newPath, resErr := resolveAddPath(fs.Arg(1))
-	if resErr != nil {
-		out.Error(fmt.Sprintf("resolve new path: %v", resErr), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
+	newPath := fs.Arg(1)
 
 	storage, instances, groups, err := loadSessionData(profile)
 	if err != nil {
@@ -118,6 +110,21 @@ func handleSessionMove(profile string, args []string) {
 		}
 		os.Exit(1)
 		return
+	}
+
+	// #1706: resolve the positional path exactly as `add` does. The stored
+	// project_path is identity — the Claude-history migration below derives its
+	// slug from it, and tmux would resolve a relative value against the tmux
+	// server's cwd rather than the caller's. An SSH session's path names a
+	// directory on the remote host, so this machine's cwd is not a valid anchor
+	// for it; leave those verbatim.
+	if !inst.IsSSH() {
+		resolved, resErr := resolveAddPath(newPath)
+		if resErr != nil {
+			out.Error(fmt.Sprintf("resolve new path: %v", resErr), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		newPath = resolved
 	}
 
 	oldPath := inst.ProjectPath

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -149,6 +149,14 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 
 	case FieldPath:
 		oldValue = inst.ProjectPath
+		// #1706: store the canonical absolute path so tmux, the Claude project
+		// slug and the #1731 hook-cwd check all read the same directory. An SSH
+		// session's path names a directory on the remote host, so this machine's
+		// cwd is not a valid anchor for it — leave those verbatim.
+		if inst.IsSSH() {
+			inst.ProjectPath = value
+			break
+		}
 		resolved, resErr := ResolveProjectPath(value)
 		if resErr != nil {
 			return oldValue, nil, &MutationError{Field: field, Msg: resErr.Error()}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -149,7 +149,11 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 
 	case FieldPath:
 		oldValue = inst.ProjectPath
-		inst.ProjectPath = value
+		resolved, resErr := ResolveProjectPath(value)
+		if resErr != nil {
+			return oldValue, nil, &MutationError{Field: field, Msg: resErr.Error()}
+		}
+		inst.ProjectPath = resolved
 
 	case FieldCommand:
 		oldValue = inst.Command

--- a/internal/session/projectpath.go
+++ b/internal/session/projectpath.go
@@ -3,7 +3,6 @@ package session
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 )
 
 // ResolveProjectPath turns a user-supplied project path into the canonical form
@@ -31,12 +30,14 @@ import (
 // Callers are the machine-local writers (the CLI acting on its own profile, the
 // TUI, the web mutator). Paths that belong to a remote host must not pass
 // through here: they are resolved on that host by the CLI running there.
+// Whitespace is NOT trimmed: a directory name may legally begin or end with a
+// space, and `add` does not trim either. Callers that read a text field trim it
+// themselves before calling.
 func ResolveProjectPath(path string) (string, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	if path == "" {
 		return path, nil
 	}
-	abs, err := filepath.Abs(ExpandPath(trimmed))
+	abs, err := filepath.Abs(ExpandPath(path))
 	if err != nil {
 		// filepath.Abs only fails when the process has no usable cwd, so there
 		// is no anchor for a relative path. Refuse rather than store a value

--- a/internal/session/projectpath.go
+++ b/internal/session/projectpath.go
@@ -1,0 +1,47 @@
+package session
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveProjectPath turns a user-supplied project path into the canonical form
+// stored in instances.project_path: environment variables and `~` expanded, then
+// made absolute.
+//
+// Related to #1706. project_path is identity (#1731 made it immutable outside
+// the declared multi-repo set and this explicit mutation path), and a relative
+// value cannot serve as identity:
+//
+//   - tmux resolves `new-session -c <relative>` against the tmux SERVER's cwd,
+//     inherited from whichever client first started it, so the session lands
+//     somewhere other than the directory the user meant;
+//   - the Claude project slug derived from it points at a different transcript
+//     directory depending on who resolves it, which breaks resume;
+//   - the #1731 hook-cwd ownership check resolves symlinks on both sides, so a
+//     relative stored path can never match a hook-reported cwd and every event
+//     is refused.
+//
+// `agent-deck add` has always resolved its positional path argument this way
+// (cmd/agent-deck/cli_utils.go resolveAddPath); this is the same rule for every
+// later write. An empty value is returned unchanged — emptiness is the caller's
+// validation concern, not this function's.
+//
+// Callers are the machine-local writers (the CLI acting on its own profile, the
+// TUI, the web mutator). Paths that belong to a remote host must not pass
+// through here: they are resolved on that host by the CLI running there.
+func ResolveProjectPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return path, nil
+	}
+	abs, err := filepath.Abs(ExpandPath(trimmed))
+	if err != nil {
+		// filepath.Abs only fails when the process has no usable cwd, so there
+		// is no anchor for a relative path. Refuse rather than store a value
+		// that resolves differently for every reader.
+		return "", fmt.Errorf("cannot resolve project path %q: %w", path, err)
+	}
+	return abs, nil
+}

--- a/internal/session/projectpath_test.go
+++ b/internal/session/projectpath_test.go
@@ -1,0 +1,104 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Related to #1706. project_path is identity: tmux resolves a relative value
+// against the tmux server's cwd, the Claude project slug derived from it points
+// somewhere else again, and the #1731 hook-cwd ownership check (which resolves
+// symlinks on both sides) can never match a relative string. Every local writer
+// must therefore store an absolute path — `agent-deck add` always did, the
+// later mutation paths did not.
+
+func TestResolveProjectPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home dir: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "absolute path is unchanged", input: "/repos/app", want: "/repos/app"},
+		{name: "bare relative name anchors to cwd", input: "app", want: filepath.Join(cwd, "app")},
+		{name: "nested relative path anchors to cwd", input: "src/app", want: filepath.Join(cwd, "src", "app")},
+		{name: "dot-slash prefix is cleaned", input: "./app", want: filepath.Join(cwd, "app")},
+		{name: "parent traversal is cleaned", input: "/repos/app/../other", want: "/repos/other"},
+		{name: "trailing slash is cleaned", input: "/repos/app/", want: "/repos/app"},
+		{name: "surrounding whitespace is trimmed", input: "  /repos/app  ", want: "/repos/app"},
+		{name: "tilde is expanded", input: "~/repos/app", want: filepath.Join(home, "repos", "app")},
+		{name: "empty stays empty", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveProjectPath(tt.input)
+			if err != nil {
+				t.Fatalf("ResolveProjectPath(%q) returned error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveProjectPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// `agent-deck session set <id> path <p>` and the TUI's edit-session dialog share
+// SetField, so the resolution has to happen there rather than in each caller.
+func TestSetField_PathIsStoredAbsolute(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	inst := &Instance{ProjectPath: "/repos/original"}
+
+	oldValue, _, err := SetField(inst, FieldPath, "relative/target", nil)
+	if err != nil {
+		t.Fatalf("SetField(path) returned error: %v", err)
+	}
+	if oldValue != "/repos/original" {
+		t.Fatalf("old value = %q, want %q", oldValue, "/repos/original")
+	}
+
+	want := filepath.Join(cwd, "relative", "target")
+	if inst.ProjectPath != want {
+		t.Fatalf("ProjectPath = %q, want %q (a relative project_path resolves differently for tmux, the Claude slug and the #1731 hook-cwd check)", inst.ProjectPath, want)
+	}
+}
+
+func TestSetField_PathExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home dir: %v", err)
+	}
+
+	inst := &Instance{ProjectPath: "/repos/original"}
+	if _, _, err := SetField(inst, FieldPath, "~/repos/app", nil); err != nil {
+		t.Fatalf("SetField(path) returned error: %v", err)
+	}
+
+	want := filepath.Join(home, "repos", "app")
+	if inst.ProjectPath != want {
+		t.Fatalf("ProjectPath = %q, want %q (a quoted tilde from a non-expanding shell must still reach a real directory)", inst.ProjectPath, want)
+	}
+}
+
+func TestSetField_PathAbsoluteValueIsPreserved(t *testing.T) {
+	inst := &Instance{ProjectPath: "/repos/original"}
+	if _, _, err := SetField(inst, FieldPath, "/repos/moved", nil); err != nil {
+		t.Fatalf("SetField(path) returned error: %v", err)
+	}
+	if inst.ProjectPath != "/repos/moved" {
+		t.Fatalf("ProjectPath = %q, want %q (an absolute value must pass through untouched)", inst.ProjectPath, "/repos/moved")
+	}
+}

--- a/internal/session/projectpath_test.go
+++ b/internal/session/projectpath_test.go
@@ -34,7 +34,6 @@ func TestResolveProjectPath(t *testing.T) {
 		{name: "dot-slash prefix is cleaned", input: "./app", want: filepath.Join(cwd, "app")},
 		{name: "parent traversal is cleaned", input: "/repos/app/../other", want: "/repos/other"},
 		{name: "trailing slash is cleaned", input: "/repos/app/", want: "/repos/app"},
-		{name: "surrounding whitespace is trimmed", input: "  /repos/app  ", want: "/repos/app"},
 		{name: "tilde is expanded", input: "~/repos/app", want: filepath.Join(home, "repos", "app")},
 		{name: "empty stays empty", input: "", want: ""},
 	}
@@ -100,5 +99,30 @@ func TestSetField_PathAbsoluteValueIsPreserved(t *testing.T) {
 	}
 	if inst.ProjectPath != "/repos/moved" {
 		t.Fatalf("ProjectPath = %q, want %q (an absolute value must pass through untouched)", inst.ProjectPath, "/repos/moved")
+	}
+}
+
+// A directory name may legally begin or end with a space, and `add` does not
+// trim its argument either, so neither may this. Text fields are trimmed by the
+// caller that reads them.
+func TestResolveProjectPath_PreservesSignificantWhitespace(t *testing.T) {
+	got, err := ResolveProjectPath("/repos/app ")
+	if err != nil {
+		t.Fatalf("ResolveProjectPath returned error: %v", err)
+	}
+	if got != "/repos/app " {
+		t.Fatalf("ResolveProjectPath(%q) = %q, want the trailing space preserved", "/repos/app ", got)
+	}
+}
+
+// An SSH session's path names a directory on the remote host, so this machine's
+// cwd is not a valid anchor for it.
+func TestSetField_PathOnSSHInstanceIsNotResolvedLocally(t *testing.T) {
+	inst := &Instance{ProjectPath: "srv/app", SSHHost: "build-box"}
+	if _, _, err := SetField(inst, FieldPath, "srv/app-v2", nil); err != nil {
+		t.Fatalf("SetField(path) returned error: %v", err)
+	}
+	if inst.ProjectPath != "srv/app-v2" {
+		t.Fatalf("ProjectPath = %q, want %q (a remote path must not be anchored to the local cwd)", inst.ProjectPath, "srv/app-v2")
 	}
 }

--- a/internal/ui/editpaths_dialog.go
+++ b/internal/ui/editpaths_dialog.go
@@ -122,7 +122,20 @@ func (d *EditPathsDialog) cleanedPaths() []string {
 		if p == "" {
 			continue
 		}
-		expanded := session.ExpandPath(p)
+		// #1706: these paths are persisted as project_path / additional_paths,
+		// so they must be absolute — a relative entry is validated against the
+		// TUI's cwd here but read back by tmux, the Claude slug and the #1731
+		// hook-cwd check, which each resolve it differently. Resolving before
+		// the dedupe also stops "repo" and "./repo" from becoming two entries
+		// for one directory.
+		expanded, resErr := session.ResolveProjectPath(p)
+		if resErr != nil {
+			// Only reachable when this process has no usable cwd, so there is
+			// nothing to anchor a relative entry to. Dropping it here surfaces
+			// as Validate's "requires at least 2 paths" rather than persisting a
+			// path that resolves differently for every reader.
+			continue
+		}
 		if seen[expanded] {
 			continue
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7152,6 +7152,13 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		if projectPath == "" {
 			projectPath = "."
 		}
+		// #1706: "." (and any relative CWD a search result carries) must not be
+		// persisted as project_path — tmux resolves it against the tmux server's
+		// cwd, and the Claude project slug derived from it would point elsewhere
+		// again.
+		if resolved, resErr := session.ResolveProjectPath(projectPath); resErr == nil {
+			projectPath = resolved
+		}
 
 		// Create instance. Issue #666: resolveNewSessionGroup rescues empty
 		// cursor-group (Window / RemoteGroup / placeholder flatItems) so

--- a/internal/ui/issue1706_editpaths_abs_test.go
+++ b/internal/ui/issue1706_editpaths_abs_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Related to #1706: the edit-paths dialog persists its list straight into
+// project_path / additional_paths, so a relative entry would be validated
+// against the TUI's cwd and then read back by tmux, the Claude project slug and
+// the #1731 hook-cwd ownership check, each of which resolves it differently.
+func TestIssue1706_EditPathsDialogResolvesRelativeEntries(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	inst := newTestMultiRepoInstance([]string{"/tmp/repo-a", "/tmp/repo-b"})
+	d := NewEditPathsDialog()
+	d.Show(inst, nil)
+	d.paths = []string{"/tmp/repo-a", "repo-relative"}
+
+	got := d.GetPaths()
+	if len(got) != 2 {
+		t.Fatalf("GetPaths() returned %d paths, want 2: %v", len(got), got)
+	}
+	want := filepath.Join(cwd, "repo-relative")
+	if got[1] != want {
+		t.Fatalf("GetPaths()[1] = %q, want %q", got[1], want)
+	}
+	if got[0] != "/tmp/repo-a" {
+		t.Fatalf("GetPaths()[0] = %q, want the absolute entry untouched", got[0])
+	}
+}
+
+// Resolving before the dedupe also collapses two spellings of one directory,
+// which would otherwise be stored as two distinct additional_paths entries.
+func TestIssue1706_EditPathsDialogDedupesEquivalentSpellings(t *testing.T) {
+	inst := newTestMultiRepoInstance([]string{"/tmp/repo-a", "/tmp/repo-b"})
+	d := NewEditPathsDialog()
+	d.Show(inst, nil)
+	d.paths = []string{"/tmp/repo-a", "repo-relative", "./repo-relative"}
+
+	if got := d.GetPaths(); len(got) != 2 {
+		t.Fatalf("GetPaths() returned %d paths, want 2 (the two spellings are one directory): %v", len(got), got)
+	}
+}

--- a/internal/ui/issue1706_web_mutator_test.go
+++ b/internal/ui/issue1706_web_mutator_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Related to #1706. The web mutator's create path takes project_path straight
+// from an HTTP request, so it must go through the same resolution as every other
+// local writer: a relative value would be resolved against the tmux server's cwd
+// when the session starts, and against a different directory again for the
+// Claude project slug.
+//
+// Structural pin, following TestWebMutatorForkSessionUsesSharedToolDispatcher:
+// exercising CreateSession for real needs a live storage transaction, and the
+// resolution behaviour itself is covered by internal/session
+// (TestResolveProjectPath, TestSetField_PathIsStoredAbsolute).
+func TestIssue1706_WebMutatorResolvesProjectPathOnCreate(t *testing.T) {
+	src, err := os.ReadFile("web_mutator.go")
+	if err != nil {
+		t.Fatalf("read web_mutator.go: %v", err)
+	}
+	body := string(src)
+	if !strings.Contains(body, "session.ResolveProjectPath(projectPath)") {
+		t.Fatal("WebMutator.CreateSession must resolve projectPath via session.ResolveProjectPath (#1706)")
+	}
+	// SetField canonicalizes a path, so comparing the raw request value against
+	// the old one reports another spelling of the stored path as a real change
+	// (and as restart-required).
+	if !strings.Contains(body, "newValue = inst.ProjectPath") {
+		t.Fatal("WebMutator.UpdateSession must compare the stored path, not the raw request value (#1706)")
+	}
+}

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -98,6 +98,13 @@ func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID,
 		return "", err
 	}
 	defer unlock()
+	// #1706: project_path is identity and must be absolute — the request may
+	// carry a relative path, which tmux would resolve against the tmux server's
+	// cwd rather than this process's.
+	projectPath, err = session.ResolveProjectPath(projectPath)
+	if err != nil {
+		return "", err
+	}
 	var inst *session.Instance
 	if groupPath != "" {
 		inst = session.NewInstanceWithGroupAndTool(title, projectPath, groupPath, tool)
@@ -453,7 +460,15 @@ func (m *WebMutator) UpdateSession(id string, updates map[string]string) ([]stri
 			m.h.instancesMu.Unlock()
 			return nil, false, err
 		}
-		if oldValue == value {
+		// #1706: SetField canonicalizes a project path, so a request carrying
+		// another spelling of the stored path is a no-op — compare what was
+		// actually stored, not the raw request value, or it would be reported
+		// as changed and restart-required.
+		newValue := value
+		if field == session.FieldPath {
+			newValue = inst.ProjectPath
+		}
+		if oldValue == newValue {
 			continue
 		}
 		changed = append(changed, field)


### PR DESCRIPTION
## Summary

Follow-on to #1766 (both relate to #1706). #1766 fixes the New Session dialog; this fixes the same defect at every *other* place a local `project_path` gets written.

`agent-deck add` has always resolved its positional path argument — `resolveAddPath` expands env vars and `~`, then calls `filepath.Abs`. Nothing that writes the path afterwards did:

| Writer | Before |
| --- | --- |
| `session.SetField(FieldPath)` — shared by `agent-deck session set <id> path <p>`, the TUI edit-session dialog and the web mutator | assigned the raw value |
| `agent-deck session move <id> <new-path>` | assigned the positional argument, and derived the Claude-history migration slug from it |
| TUI edit-paths dialog (multi-repo) | expanded `~` and env vars, never absolutized |
| `WebMutator.CreateSession` | used the path from the request as-is |
| `createSessionFromGlobalSearch` | fell back to the literal `"."` |

## Why a relative `project_path` is broken, not just untidy

It is identity, and it resolves differently for every reader:

- tmux resolves `new-session -c <relative>` against the **tmux server's** cwd, inherited from whichever client first started that server;
- the Claude project slug derived from it points at a different transcript directory, so resume looks in the wrong place;
- the hook-cwd ownership check added in #1731 resolves symlinks on both sides, so a relative stored path can never match a hook-reported cwd — every hook event for that session is refused.

## Fix

New `session.ResolveProjectPath` is the single rule: expand env + `~`, then absolutize, refusing when the process has no cwd to anchor to (rather than storing a value that means different things to different readers). Whitespace is deliberately *not* trimmed — a directory name may legally begin or end with a space, and `add` does not trim either; the callers that read text fields already trim.

`SetField` uses it, so the CLI, the TUI edit dialog and the web mutator share one behaviour. The edit-paths dialog resolves before its dedupe, which also stops `repo` and `./repo` from becoming two entries for one directory. `session move` reuses `resolveAddPath` so it matches `add` exactly.

**Remote paths stay raw.** An SSH session's path names a directory on the remote host, so this machine's cwd is not a valid anchor: `SetField` and `session move` leave `inst.IsSSH()` instances verbatim, and remote-session creation never routes through here (it is resolved by the CLI running on that host).

Two reporting bugs that this canonicalization would otherwise introduce are fixed with it: `session set <id> path .` reported `"new_value":"."` while storing the resolved path, and the web mutator's change detection compared the raw request value against the old one, so another spelling of the stored path counted as changed and restart-required.

## Tests

`internal/session/projectpath_test.go` — `ResolveProjectPath` table (absolute unchanged, bare/nested relative anchored, `./`, `..`, trailing slash, `~`, empty, significant whitespace preserved); `SetField` stores an absolute path, expands a quoted `~`, passes an absolute value through untouched, and leaves an SSH instance's path alone.

`internal/ui/issue1706_editpaths_abs_test.go` — the edit-paths dialog resolves a relative entry and collapses two spellings of one directory.

`internal/ui/issue1706_web_mutator_test.go` — structural pin for the web mutator's create resolution and change detection, following the existing `web_mutator_fork_test.go` pattern (exercising `CreateSession` for real needs a live storage transaction; the resolution behaviour itself is covered in `internal/session`).

`cmd/agent-deck/issue1706_move_relative_test.go` — `session move <id> .` must persist the caller's cwd, not the literal `.`. Uses `.` deliberately so the test creates no directories anywhere.

`go build ./...`, `go vet` and `gofmt` clean locally; the suites are left to CI per this repo's test-safety rules.

## Review notes

Two rounds of Codex review. Everything above the "Fix" heading was the first round's scope; the second round found the SSH-path case, the two remaining creation sites, both reporting bugs and the whitespace trim, all of which are now in the diff. One finding was checked and rejected: the TUI new-session flow it flagged is fixed in #1766, which was not in this diff.

Merge order does not matter — the two PRs touch disjoint code (#1766: `handleNewDialogKey` + `NewDialog.Validate`; this one: `SetField`, `session move`, edit-paths, web mutator, global-search create).
