### PR TITLE
fix(tui): first frame after detach is never empty and never O(visible rows) (#1753)

### DIFF
--- a/internal/session/claude_title_reconcile.go
+++ b/internal/session/claude_title_reconcile.go
@@ -150,7 +150,7 @@ func (i *Instance) ReconcileTitleFromClaude(sessionID string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	i.Title = name
+	i.SetTitleThreadSafe(name)
 	i.SyncTmuxDisplayName()
 	if tmuxSess := i.GetTmuxSession(); tmuxSess != nil && tmuxSess.Name != "" {
 		_ = tmux.WriteBadgeUpdate(tmuxSess.Name, name)

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -669,6 +669,28 @@ func (inst *Instance) GetToolThreadSafe() string {
 	return t
 }
 
+// GetTitleThreadSafe returns the session title with read-lock protection.
+// Use this when reading Title from a goroutine concurrent with title syncs
+// (SetField, ReconcileTitleFromClaude, pending-title reapplication) — those
+// writers go through SetTitleThreadSafe below, so this getter is the other
+// half of the pair readers on a different goroutine need.
+func (inst *Instance) GetTitleThreadSafe() string {
+	inst.mu.RLock()
+	t := inst.Title
+	inst.mu.RUnlock()
+	return t
+}
+
+// SetTitleThreadSafe sets the session title with write-lock protection. All
+// cross-goroutine writers (SetField, ReconcileTitleFromClaude, pending-title
+// reapplication) must go through this rather than assigning Title directly,
+// or GetTitleThreadSafe's read lock buys nothing.
+func (inst *Instance) SetTitleThreadSafe(t string) {
+	inst.mu.Lock()
+	inst.Title = t
+	inst.mu.Unlock()
+}
+
 // SetToolThreadSafe sets the tool name with write-lock protection.
 func (inst *Instance) SetToolThreadSafe(t string) {
 	inst.mu.Lock()

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -138,8 +138,8 @@ func normalizeToolSessionID(field, value string) (string, error) {
 func SetField(inst *Instance, field, value string, extraArgsTokens []string) (oldValue string, postCommit func(), err error) {
 	switch field {
 	case FieldTitle:
-		oldValue = inst.Title
-		inst.Title = value
+		oldValue = inst.GetTitleThreadSafe()
+		inst.SetTitleThreadSafe(value)
 		inst.SetAutoName(false) // a user/explicit name replaces the auto handle
 		// An explicit rename is user intent: lock the title so the #572
 		// Claude-name sync (plan titles, /rename) can't revert it on the

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -16555,8 +16555,8 @@ func (h *Home) renderSessionItem(
 	// internal/ui/cellwidth.go for the upstream disagreement.
 	if (selected || h.showPaneTitles) && paneSubtitle != "" {
 		// paneSubtitle is non-empty only for non-auto-named rows (auto-named rows
-		// promote the pane title to displayTitle), so the prior !inst.GetAutoName()
-		// guard is now folded into sessionDisplayLabels.
+		// promote the pane title to displayTitle), so the auto-name guard that
+		// used to sit here is folded into the snapshot-based label helper.
 		// Dual layout: sidebar is narrower than h.width (#937). Using full
 		// terminal width here overflows the SESSIONS pane, then lipgloss
 		// truncation disagrees from terminal cells — wrapped lines duplicate

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -296,6 +296,7 @@ type Home struct {
 	viewOffset          int                   // First visible item index (for scrolling)
 	previewScrollOffset int                   // Lines scrolled up from tail in the preview pane (#574). 0 = tail (default). Reset on cursor move.
 	isAttaching         atomic.Bool           // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
+	lastRenderedFrame   string                // Last non-empty frame View produced; re-served while isAttaching so no frame is ever black (#1753). Event-loop goroutine only.
 	statusFilter        session.Status        // Filter sessions by status ("" = all, or specific status)
 	groupScope          string                // Limit TUI to a specific group path ("" = all groups)
 	initialSelect       string                // Session ID or title to preselect on first load (#709). Does NOT scope groups.
@@ -326,6 +327,16 @@ type Home struct {
 	// Instead of updating ALL sessions every tick, we update batches of 5-10 sessions
 	// This reduces CPU usage by 90%+ while maintaining responsiveness
 	statusUpdateIndex atomic.Int32 // Current position in round-robin cycle (atomic for thread safety)
+	// Visible-row round-robin state (#1753): with a large group expanded the
+	// visible set approaches fleet size, so "always refresh every visible row"
+	// degenerates into the same per-row storm the off-screen batching exists to
+	// prevent. Visible rows get their own cursor and per-pass budget instead.
+	visibleStatusUpdateIndex atomic.Int32
+	// visibleRefreshFingerprint remembers, per session, the cached tmux window
+	// activity at the last visible-row refresh, so an unchanged idle row costs
+	// zero. Owned exclusively by the status worker goroutine (processStatusUpdate)
+	// — no lock needed.
+	visibleRefreshFingerprint map[string]int64
 
 	// Background status worker (Priority 1C optimization)
 	// Moves status updates to a separate goroutine, completely decoupling from UI
@@ -3859,6 +3870,18 @@ type sessionRenderState struct {
 	substate  session.Substate // Honest Status v2: additive refinement (model-unavailable, auth-401, ...)
 	tool      string
 	paneTitle string // Current task description from tmux pane title (stripped of spinner/done markers)
+	// Row-label fields (#1753): the per-row render path used to read these
+	// through Instance getters, each an Instance.mu RLock. A background
+	// UpdateStatus holds that mutex as a WRITER across tmux subprocess calls
+	// (Exists probe 2s cap, DetectTool capture 3s cap), and Go's RWMutex
+	// queues new readers behind a waiting writer — so one mid-sweep session
+	// could stall View() for seconds, scaling with visible row count. That is
+	// the residual "Ctrl+Q → black screen" on large decks with a big group
+	// expanded. Carrying the labels in the snapshot makes row rendering
+	// lock-free.
+	title        string // Instance.Title at snapshot time
+	autoName     bool   // session displays a captured/live task description
+	autoNameDesc string // last persisted auto-name description (fallback when paneTitle empty)
 }
 
 // displaySessionTitle returns the label to render for a session row. For an
@@ -3900,6 +3923,22 @@ func displaySessionTitle(inst *session.Instance, paneTitle string) string {
 	return inst.Title
 }
 
+// displaySessionTitleFromState is displaySessionTitle computed purely from a
+// sessionRenderState — no Instance.mu access, so it can never block behind a
+// background UpdateStatus writer (#1753; see the field comments on
+// sessionRenderState). The overview row renderer must use this form.
+func displaySessionTitleFromState(state sessionRenderState) string {
+	if state.autoName {
+		if state.paneTitle != "" {
+			return state.paneTitle
+		}
+		if state.autoNameDesc != "" {
+			return state.autoNameDesc
+		}
+	}
+	return state.title
+}
+
 // sessionDisplayLabels returns the primary title and the optional dim secondary
 // subtitle to render for a session row, given its live pane title (already
 // cleaned by cleanPaneTitle). Both render paths — the overview
@@ -3915,6 +3954,18 @@ func sessionDisplayLabels(inst *session.Instance, paneTitle string) (title, subt
 	title = displaySessionTitle(inst, paneTitle)
 	if !inst.GetAutoName() {
 		subtitle = paneTitle
+	}
+	return title, subtitle
+}
+
+// sessionDisplayLabelsFromState is the lock-free form of sessionDisplayLabels,
+// reading everything from the render snapshot (#1753). Same policy: an
+// auto-named session promotes the task description to the title and shows no
+// subtitle; everything else keeps its handle and shows the pane title dim.
+func sessionDisplayLabelsFromState(state sessionRenderState) (title, subtitle string) {
+	title = displaySessionTitleFromState(state)
+	if !state.autoName {
+		subtitle = state.paneTitle
 	}
 	return title, subtitle
 }
@@ -3965,6 +4016,11 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 			status:   inst.GetStatusThreadSafe(),
 			substate: inst.CachedSubstate(),
 			tool:     inst.GetToolThreadSafe(),
+			// Label fields: read here, on the refresher's goroutine, so the
+			// render path never takes Instance.mu per row (#1753).
+			title:        inst.Title,
+			autoName:     inst.GetAutoName(),
+			autoNameDesc: inst.GetAutoNameDescription(),
 		}
 		// Look up pane title from the already-refreshed tmux cache.
 		// Only RefreshPaneInfoCache (called from backgroundStatusUpdate) keeps
@@ -4002,10 +4058,15 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 			return state
 		}
 	}
-	// Fallback for newly-added sessions before snapshot refresh.
+	// Fallback for newly-added sessions before snapshot refresh. This path DOES
+	// take Instance.mu (briefly, as a reader); it is bounded to sessions that a
+	// snapshot refresh has not seen yet, never the steady-state whole list.
 	return sessionRenderState{
-		status: inst.GetStatusThreadSafe(),
-		tool:   inst.GetToolThreadSafe(),
+		status:       inst.GetStatusThreadSafe(),
+		tool:         inst.GetToolThreadSafe(),
+		title:        inst.Title,
+		autoName:     inst.GetAutoName(),
+		autoNameDesc: inst.GetAutoNameDescription(),
 	}
 }
 
@@ -4749,6 +4810,23 @@ func (h *Home) updateKeyBindings() {
 	h.boundKeysMu.Unlock()
 }
 
+// noteGroupToggled treats a group EXPAND as a first-class refresh trigger
+// (#1753). Expanding a large group makes many rows newly visible at once; they
+// render instantly from the render snapshot (rebuildFlatItems does no tmux
+// work), and this nudge asks the status worker to start filling them in through
+// the budgeted visible round-robin — amortized over passes, never as a
+// synchronous whole-group burst. The cursor reset makes the newly revealed
+// rows' refresh order start from the top of the visible set. Collapse needs no
+// nudge: it only removes rows.
+func (h *Home) noteGroupToggled(groupPath string) {
+	group, ok := h.groupTree.Groups[groupPath]
+	if !ok || !group.Expanded {
+		return
+	}
+	h.visibleStatusUpdateIndex.Store(0)
+	h.triggerStatusUpdate()
+}
+
 // triggerStatusUpdate sends a non-blocking request to the background worker
 // If the worker is busy, the request is dropped (next tick will retry)
 func (h *Home) triggerStatusUpdate() {
@@ -4881,6 +4959,10 @@ func (h *Home) publishCurrentSessionStates() {
 // With batching (3 visible + 2 non-visible per tick), we keep each tick under 100ms.
 func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 	const batchSize = 2 // Reduced from 5 to 2 - fewer CapturePane() calls per tick
+	// Visible rows are budgeted too (#1753): see Step 1 below. 4 rows per pass
+	// keeps a screenful fresh within a few passes while bounding the worst case
+	// (large group expanded => visible ≈ fleet) to a constant per pass.
+	const visibleStatusBatchSize = 4
 	if hotUntil := h.navigationHotUntil.Load(); hotUntil > 0 && time.Now().UnixNano() < hotUntil {
 		return
 	}
@@ -4919,11 +5001,35 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 	// Track if any status actually changed (for cache invalidation)
 	statusChanged := false
 
-	// Step 1: Always update visible sessions (Priority 1B - visible first)
+	// Step 1: Visible sessions — budgeted round-robin (#1753).
+	//
+	// This used to refresh EVERY visible row each pass. That is fine when the
+	// visible set is a screenful of a mostly-collapsed list, but with a large
+	// group expanded the visible set approaches fleet size and this became an
+	// unbudgeted burst of per-row UpdateStatus calls — each of which takes the
+	// Instance write lock, sometimes across tmux subprocess round-trips. On the
+	// reporter's ~57-session deck that burst is what stretched the first
+	// post-detach frames into a visible black screen and made group expansion
+	// lag. Visible rows now cycle through their own cursor with a fixed budget
+	// per pass, and an idle row whose cached tmux window activity has not moved
+	// since its last refresh is skipped outright (cost zero). The full
+	// background sweep (2-10s cadence) remains the freshness backstop for every
+	// row, visible or not, so the budget only bounds burst size, not eventual
+	// freshness.
+	if h.visibleRefreshFingerprint == nil {
+		h.visibleRefreshFingerprint = make(map[string]int64)
+	}
+	visibleInstances := make([]*session.Instance, 0, len(visibleIDs))
 	for _, inst := range instancesCopy {
-		if !visibleIDs[inst.ID] {
-			continue
+		if visibleIDs[inst.ID] {
+			visibleInstances = append(visibleInstances, inst)
 		}
+	}
+	visRemaining := visibleStatusBatchSize
+	visStart := int(h.visibleStatusUpdateIndex.Load())
+	for i := 0; i < len(visibleInstances) && visRemaining > 0; i++ {
+		idx := (visStart + i) % len(visibleInstances)
+		inst := visibleInstances[idx]
 		// Skip sessions this instance neither owns nor is orphan-polling this
 		// sweep: mirrors the background sweep's gate so the incremental poll
 		// path can't defeat the dedup claim polling promises (flag off or nil
@@ -4931,12 +5037,30 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 		if !h.isPolledByMe(inst.ID) {
 			continue
 		}
+		// Cheap-fingerprint skip: an idle visible row whose cached window
+		// activity is unchanged since its last refresh cannot have new status.
+		// Skipping here (before UpdateStatus) means it does not even pay the
+		// Instance write lock. Non-idle rows always go through — their status
+		// can change without a tmux activity bump (hook files, process exit).
+		if inst.GetStatusThreadSafe() == session.StatusIdle {
+			if ts := inst.GetTmuxSession(); ts != nil {
+				fp := ts.GetCachedWindowActivity()
+				if fp != 0 && fp == h.visibleRefreshFingerprint[inst.ID] {
+					continue
+				}
+			}
+		}
 		oldStatus := inst.GetStatusThreadSafe()
 		_ = inst.UpdateStatus() // Ignore errors in background worker
 		if inst.GetStatusThreadSafe() != oldStatus {
 			statusChanged = true
 		}
+		if ts := inst.GetTmuxSession(); ts != nil {
+			h.visibleRefreshFingerprint[inst.ID] = ts.GetCachedWindowActivity()
+		}
 		updated[inst.ID] = true
+		visRemaining--
+		h.visibleStatusUpdateIndex.Store(int32((idx + 1) % len(visibleInstances))) // #nosec G115 -- idx bounded by slice length
 	}
 
 	// Step 2: Round-robin through non-visible sessions (Priority 1A - batching)
@@ -4950,8 +5074,12 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 		idx := (startIdx + i) % instanceCount
 		inst := instancesCopy[idx]
 
-		// Skip if already updated (visible)
-		if updated[inst.ID] {
+		// Skip visible rows here: they are the visible round-robin's job (Step 1,
+		// budgeted). Before the visible budget existed, `updated` covered every
+		// visible row so this loop was implicitly off-screen-only; now that Step 1
+		// refreshes at most visibleStatusBatchSize of them per pass, the skip must
+		// be explicit or off-screen rows would compete with visible ones here.
+		if visibleIDs[inst.ID] || updated[inst.ID] {
 			continue
 		}
 
@@ -7935,7 +8063,12 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 					return h, nil
 				}
 				if item.Session.Exists() {
-					h.isAttaching.Store(true) // Prevent View() output during transition (atomic)
+					// No isAttaching pre-set here: attachSession sets the flag
+					// itself right before returning the tea.Exec Cmd, and can
+					// return nil (GetTmuxSession()==nil on a cross-socket race)
+					// — a premature set followed by a nil return left the flag
+					// stuck true and View() suppressed forever (#1753; same
+					// rationale as the handleWebAttach call site).
 					return h, h.attachSession(item.Session)
 				}
 			} else if item.Type == session.ItemTypeGroup {
@@ -7949,6 +8082,7 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 				h.saveGroupState()
+				h.noteGroupToggled(groupPath)
 			}
 			return h, nil
 		}
@@ -8325,6 +8459,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 				h.saveGroupState()
+				h.noteGroupToggled(groupPath)
 			} else if item.Type == session.ItemTypeWindow {
 				// Find parent session by WindowSessionID
 				var parentInst *session.Instance
@@ -8386,6 +8521,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 				h.saveGroupState()
+				h.noteGroupToggled(groupPath)
 			} else if item.Type == session.ItemTypeSession && h.sessionHasWindows(item) {
 				sid := item.Session.ID
 				h.windowsCollapsed[sid] = !h.windowsCollapsed[sid]
@@ -13229,6 +13365,10 @@ type remoteCreateAndAttachCmd struct {
 	path      string
 	group     string
 	createCtx context.Context
+	// onExit: same contract as attachCmd.onExit (#1753) — clear the attach flag
+	// while Bubble Tea's loop is still parked, so the first View() after resume
+	// never races the ExecCallback goroutine and renders blank.
+	onExit func()
 }
 
 type remoteAttachFailedError struct {
@@ -13244,6 +13384,9 @@ func (e remoteAttachFailedError) Unwrap() error {
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
+	if r.onExit != nil {
+		defer r.onExit()
+	}
 	baseCtx := r.createCtx
 	if baseCtx == nil {
 		baseCtx = context.Background()
@@ -13283,7 +13426,13 @@ func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, gro
 	}
 	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
-	return tea.Exec(remoteCreateAndAttachCmd{runner: runner, tool: tool, title: title, path: path, group: group, createCtx: h.ctx}, func(err error) tea.Msg {
+	return tea.Exec(remoteCreateAndAttachCmd{
+		runner: runner, tool: tool, title: title, path: path, group: group, createCtx: h.ctx,
+		// Clear the flag inside Run(), before Bubble Tea restores the terminal
+		// and resumes the loop (#1753); the callback below is only the belt for
+		// the path where Run() never executes.
+		onExit: func() { h.isAttaching.Store(false) },
+	}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
 		if err != nil {
 			var attachErr remoteAttachFailedError
@@ -13329,7 +13478,13 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 	}
 	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
-	return tea.Exec(remoteAttachCmd{runner: runner, sessionID: sessionID}, func(err error) tea.Msg {
+	return tea.Exec(remoteAttachCmd{
+		runner:    runner,
+		sessionID: sessionID,
+		// Clear the flag inside Run() (#1753) — see attachCmd.onExit. The
+		// callback clear below is only the belt for the never-ran path.
+		onExit: func() { h.isAttaching.Store(false) },
+	}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
 		return statusUpdateMsg{}
 	})
@@ -13339,9 +13494,14 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 type remoteAttachCmd struct {
 	runner    *session.SSHRunner
 	sessionID string
+	// onExit: same contract as attachCmd.onExit (#1753).
+	onExit func()
 }
 
 func (r remoteAttachCmd) Run() error {
+	if r.onExit != nil {
+		defer r.onExit()
+	}
 	return r.runner.Attach(r.sessionID)
 }
 
@@ -13618,12 +13778,37 @@ func (h *Home) updateSizes() {
 
 // View renders the UI
 func (h *Home) View() string {
-	// CRITICAL: Return empty during attach to prevent View() output leakage
-	// (Bubble Tea Issue #431 - View gets printed to stdout during tea.Exec)
+	// CRITICAL: Do not render fresh output during attach (Bubble Tea Issue #431
+	// - View gets printed to stdout during tea.Exec). Historically this
+	// returned "", which had two failure modes (#1753 black-screen family):
+	//   - the frame Bubble Tea renders between Update returning the tea.Exec
+	//     Cmd and the exec actually parking the loop cleared the screen to
+	//     black before tmux took over;
+	//   - any path that left the flag set when the loop resumed (an exec
+	//     ExecCallback racing the first View, a Store(true) with no attach)
+	//     kept the screen black until the next message — or forever.
+	// Returning the last rendered frame is safe in both directions: while the
+	// renderer is still running it diffs against the identical screen content
+	// and writes nothing, and if the flag is ever stale after resume the user
+	// sees the list (at worst a few frames old) instead of black. Only the
+	// very first frame of the process can still be empty here, and no attach
+	// can be triggered before the first render.
 	if h.isAttaching.Load() { // Atomic read for thread safety
-		return ""
+		return h.lastRenderedFrame
 	}
 
+	frame := h.renderFrame()
+	if frame != "" {
+		h.lastRenderedFrame = frame
+	}
+	return frame
+}
+
+// renderFrame is the real frame builder behind View. Split out so View can
+// cache the last rendered frame for the isAttaching fallback above without
+// threading a save through every return site. Runs only on the Bubble Tea
+// event-loop goroutine, as View always has.
+func (h *Home) renderFrame() string {
 	if h.width == 0 {
 		return "Loading..."
 	}
@@ -16306,7 +16491,10 @@ func (h *Home) renderSessionItem(
 	// paneTitle) falls back to the handle automatically. paneSubtitle is the dim
 	// trailing pane title for non-auto-named rows ("" when auto-named, since the
 	// pane title is already promoted to displayTitle) — see sessionDisplayLabels.
-	displayTitle, paneSubtitle := sessionDisplayLabels(inst, instState.paneTitle)
+	// Snapshot form only here: the per-row Instance.mu reads the inst-based
+	// form does can block behind a mid-sweep UpdateStatus writer for seconds,
+	// scaling with visible rows (#1753 black-screen).
+	displayTitle, paneSubtitle := sessionDisplayLabelsFromState(instState)
 	// Pin marker (pin-sessions): a 📌 prefix flags any pinned row. Position in
 	// the list conveys top vs bottom; the emoji conveys "this is pinned".
 	// Prepended before the AutoName truncation budget so width accounting below
@@ -16318,7 +16506,7 @@ func (h *Home) renderSessionItem(
 	if isMaestro {
 		displayTitle = "⬢ " + displayTitle
 	}
-	if inst.GetAutoName() && listWidth > 0 {
+	if instState.autoName && listWidth > 0 {
 		// Task descriptions can be long; truncate to the row's free width so the
 		// tool label and badges stay on-row. Keep the reserved terms below in
 		// sync with the row format that follows.
@@ -18881,6 +19069,15 @@ func (h *Home) openSessionSwitcher(fromID string, reattachOnCancel bool) {
 	if !h.sessionSwitcher.Show(fromID, instances, subtitles) {
 		return
 	}
+	// Snapshot the row labels at open time so the switcher's View renders
+	// lock-free (#1753) — see SessionSwitcher.labels.
+	labels := make(map[string]sessionRenderState, len(instances))
+	for _, inst := range instances {
+		if inst != nil {
+			labels[inst.ID] = h.getSessionRenderState(inst)
+		}
+	}
+	h.sessionSwitcher.labels = labels
 	h.sessionSwitcher.reattachOnCancel = reattachOnCancel
 	// Treat the opening Ctrl+S as the first advance so key-repeat that arrives
 	// right after the attach->TUI handoff is throttled instead of spinning.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4017,8 +4017,11 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 			substate: inst.CachedSubstate(),
 			tool:     inst.GetToolThreadSafe(),
 			// Label fields: read here, on the refresher's goroutine, so the
-			// render path never takes Instance.mu per row (#1753).
-			title:        inst.Title,
+			// render path never takes Instance.mu per row (#1753). Title goes
+			// through GetTitleThreadSafe because SetField/ReconcileTitleFromClaude/
+			// pending-title reapply can mutate it concurrently from the Bubble
+			// Tea event-loop goroutine.
+			title:        inst.GetTitleThreadSafe(),
 			autoName:     inst.GetAutoName(),
 			autoNameDesc: inst.GetAutoNameDescription(),
 		}
@@ -4064,7 +4067,7 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 	return sessionRenderState{
 		status:       inst.GetStatusThreadSafe(),
 		tool:         inst.GetToolThreadSafe(),
-		title:        inst.Title,
+		title:        inst.GetTitleThreadSafe(),
 		autoName:     inst.GetAutoName(),
 		autoNameDesc: inst.GetAutoNameDescription(),
 	}
@@ -5454,8 +5457,8 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				applied := false
 				for id, pt := range h.pendingTitleChanges {
 					if inst := h.getInstanceByID(id); inst != nil {
-						if inst.Title != pt.title {
-							inst.Title = pt.title
+						if inst.GetTitleThreadSafe() != pt.title {
+							inst.SetTitleThreadSafe(pt.title)
 							inst.SyncTmuxDisplayName()
 							applied = true
 							uiLog.Info("pending_rename_reapplied",

--- a/internal/ui/issue1753_blackscreen_test.go
+++ b/internal/ui/issue1753_blackscreen_test.go
@@ -1,0 +1,446 @@
+// Issue #1753 (black-screen follow-up to #1764) — on the reporter's live deck
+// (~57 agent sessions, two TUIs), Ctrl+Q still showed ~1s of black screen before
+// the list reappeared, reproducing when a large group was expanded and vanishing
+// when it was collapsed.
+//
+// Two families of cause, both pinned here:
+//
+//  1. EMPTY first frame: View() returned "" whenever isAttaching was set, and
+//     several attach flavors could reach the first post-resume View() with the
+//     flag still set (remote exec commands cleared it only in the ExecCallback,
+//     which Bubble Tea runs on its own goroutine after resuming the loop; the
+//     double-click site pre-set the flag before a call that can return nil,
+//     leaving it stuck forever). Fixes: every tea.ExecCommand clears the flag
+//     via onExit inside Run() — i.e. while the loop is still parked — and
+//     View() re-serves the last rendered frame instead of "" as the belt.
+//
+//  2. BLOCKED first frame: the per-row render path took Instance.mu (RLock) via
+//     GetAutoName/GetAutoNameDescription while background UpdateStatus holds
+//     that mutex as a WRITER across tmux subprocess calls (Exists probe 2s cap,
+//     DetectTool capture 3s cap). Go's RWMutex queues new readers behind a
+//     waiting writer, so the first frame stalled for seconds, scaling with the
+//     number of visible rows — which is why a big expanded group reproduced it.
+//     Additionally processStatusUpdate refreshed EVERY visible row per pass, an
+//     unbudgeted burst of write-lock acquisitions when visible ≈ fleet. Fixes:
+//     row labels come from the lock-free render snapshot, visible rows get a
+//     budgeted round-robin (with a cheap activity-fingerprint skip), and group
+//     expand becomes a trigger for that amortized path instead of a burst.
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// blackscreenTestHome builds a Home that has rendered once, so
+// lastRenderedFrame is populated the way it always is before any attach can be
+// triggered in a real session (an attach needs a rendered list to select from).
+func blackscreenTestHome(t *testing.T) *Home {
+	t.Helper()
+	inst := &session.Instance{ID: "s1", Title: "session-one", Tool: "shell", Status: session.StatusStopped}
+	h := newTestHomeWithItems(200, 50, []session.Item{
+		{Type: session.ItemTypeSession, Session: inst, Level: 0},
+	})
+	h.instances = []*session.Instance{inst}
+	h.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	h.groupTree = session.NewGroupTree(h.instances)
+	if v := h.View(); strings.TrimSpace(v) == "" {
+		t.Fatal("precondition: initial View() should render a non-empty frame")
+	}
+	return h
+}
+
+// --- Family 1: the first View() after every attach flavor must be non-empty ---
+
+// TestIssue1753_FirstViewNonEmptyAfterSessionAttach: the plain Enter-attach
+// flavor (attachCmd). onExit must clear the flag before Run returns, and the
+// first View() after that must render the list.
+func TestIssue1753_FirstViewNonEmptyAfterSessionAttach(t *testing.T) {
+	h := blackscreenTestHome(t)
+	h.isAttaching.Store(true)
+	cmd := attachCmd{
+		session: &tmux.Session{Name: "agentdeck_issue1753_absent"},
+		opts:    tmux.AttachOptions{DetachByte: 17},
+		onExit:  func() { h.isAttaching.Store(false) },
+	}
+	_ = cmd.Run()
+	if h.isAttaching.Load() {
+		t.Fatal("attachCmd.Run returned with isAttaching still set (#1753)")
+	}
+	if strings.TrimSpace(h.View()) == "" {
+		t.Fatal("first View() after session-attach return is empty: black screen (#1753)")
+	}
+}
+
+// TestIssue1753_FirstViewNonEmptyAfterWindowAttach: the window-attach flavor.
+// The #1764 review flagged that no test constructed attachWindowCmd at all, so
+// its onExit wiring was unverified safety-critical code.
+func TestIssue1753_FirstViewNonEmptyAfterWindowAttach(t *testing.T) {
+	h := blackscreenTestHome(t)
+	h.isAttaching.Store(true)
+	cmd := attachWindowCmd{
+		session:     &tmux.Session{Name: "agentdeck_issue1753_absent"},
+		windowIndex: 1,
+		detachByte:  17,
+		onExit:      func() { h.isAttaching.Store(false) },
+	}
+	_ = cmd.Run()
+	if h.isAttaching.Load() {
+		t.Fatal("attachWindowCmd.Run returned with isAttaching still set: first frame after " +
+			"a window detach renders blank (#1753)")
+	}
+	if strings.TrimSpace(h.View()) == "" {
+		t.Fatal("first View() after window-attach return is empty: black screen (#1753)")
+	}
+}
+
+// TestIssue1753_FirstViewNonEmptyAfterRemoteAttach: the remote SSH flavors.
+// Before the fix neither remoteAttachCmd nor remoteCreateAndAttachCmd had an
+// onExit at all — the flag was cleared only in the ExecCallback goroutine,
+// which races the first View() after Bubble Tea resumes.
+func TestIssue1753_FirstViewNonEmptyAfterRemoteAttach(t *testing.T) {
+	// Host "" fails ValidateSSHHost immediately: Run errors without spawning
+	// ssh, exactly the shape of a failed remote attach.
+	runner := session.NewSSHRunner("issue1753", session.RemoteConfig{Host: ""})
+
+	t.Run("attach", func(t *testing.T) {
+		h := blackscreenTestHome(t)
+		h.isAttaching.Store(true)
+		cmd := remoteAttachCmd{
+			runner:    runner,
+			sessionID: "absent",
+			onExit:    func() { h.isAttaching.Store(false) },
+		}
+		if err := cmd.Run(); err == nil {
+			t.Fatal("precondition: remote attach against an empty host should fail")
+		}
+		if h.isAttaching.Load() {
+			t.Fatal("remoteAttachCmd.Run returned with isAttaching still set (#1753)")
+		}
+		if strings.TrimSpace(h.View()) == "" {
+			t.Fatal("first View() after remote-attach return is empty: black screen (#1753)")
+		}
+	})
+
+	t.Run("create-and-attach", func(t *testing.T) {
+		h := blackscreenTestHome(t)
+		h.isAttaching.Store(true)
+		cmd := remoteCreateAndAttachCmd{
+			runner: runner,
+			tool:   "shell",
+			onExit: func() { h.isAttaching.Store(false) },
+		}
+		if err := cmd.Run(); err == nil {
+			t.Fatal("precondition: remote create against an empty host should fail")
+		}
+		if h.isAttaching.Load() {
+			t.Fatal("remoteCreateAndAttachCmd.Run returned with isAttaching still set (#1753)")
+		}
+		if strings.TrimSpace(h.View()) == "" {
+			t.Fatal("first View() after remote create-and-attach return is empty (#1753)")
+		}
+	})
+}
+
+// TestIssue1753_FirstViewNonEmptyOnReloadingReturn: the auto-reload branch of
+// the statusUpdateMsg handler (isReloading=true) returns early — before the fix
+// no test ever set isReloading, so nothing pinned that this branch still leaves
+// the first frame renderable.
+func TestIssue1753_FirstViewNonEmptyOnReloadingReturn(t *testing.T) {
+	h := blackscreenTestHome(t)
+	h.reloadMu.Lock()
+	h.isReloading = true
+	h.reloadMu.Unlock()
+	h.isAttaching.Store(true)
+
+	_, _ = h.Update(statusUpdateMsg{})
+
+	if h.isAttaching.Load() {
+		t.Fatal("statusUpdateMsg (reloading branch) left isAttaching set (#1753)")
+	}
+	if strings.TrimSpace(h.View()) == "" {
+		t.Fatal("first View() after reloading-branch attach return is empty (#1753)")
+	}
+}
+
+// TestIssue1753_ViewFallsBackToLastFrameWhileAttaching is the belt itself:
+// even when the flag is (wrongly) still set after the loop resumes, View()
+// serves the last rendered frame instead of clearing the screen to black.
+func TestIssue1753_ViewFallsBackToLastFrameWhileAttaching(t *testing.T) {
+	h := blackscreenTestHome(t)
+	want := h.View()
+
+	h.isAttaching.Store(true)
+	got := h.View()
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("View() returned an empty frame while isAttaching was set: any path that " +
+			"reaches the first post-resume View with the flag still set shows a black " +
+			"screen (#1753)")
+	}
+	if got != want {
+		t.Fatalf("View() while attaching should re-serve the last rendered frame, got a different frame")
+	}
+}
+
+// TestIssue1753_AttachSessionNilReturnLeavesFlagClear pins the stuck-flag
+// route: attachSession returns nil when the instance has no tmux session, and
+// the flag must not be left set by anyone in that case. Before the fix the
+// double-click handler pre-set isAttaching before calling attachSession, so a
+// nil return suppressed View() forever.
+func TestIssue1753_AttachSessionNilReturnLeavesFlagClear(t *testing.T) {
+	h := blackscreenTestHome(t)
+	inst := &session.Instance{ID: "no-tmux", Title: "no-tmux", Tool: "shell", Status: session.StatusStopped}
+
+	if cmd := h.attachSession(inst); cmd != nil {
+		t.Fatal("precondition: attachSession on an instance with no tmux session should return nil")
+	}
+	if h.isAttaching.Load() {
+		t.Fatal("attachSession(nil-tmux) left isAttaching set: View() would be suppressed forever (#1753)")
+	}
+
+	// Source-level guard for the double-click site specifically: the block that
+	// handles a double-click must not pre-set the flag.
+	src, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+	text := string(src)
+	start := strings.Index(text, "if isDoubleClick {")
+	if start < 0 {
+		t.Fatal("double-click block not found in home.go")
+	}
+	block := text[start:]
+	if end := strings.Index(block, "// Single click"); end >= 0 {
+		block = block[:end]
+	}
+	if strings.Contains(block, "isAttaching.Store(true)") {
+		t.Fatal("double-click handler pre-sets isAttaching before attachSession, which can " +
+			"return nil and leave the flag stuck true — permanent black screen (#1753)")
+	}
+}
+
+// TestIssue1753_AllExecCommandsClearFlagInRun is the source-level guard for the
+// wiring: every tea.Exec call site in home.go that sets isAttaching must hand
+// the clear to the command's onExit (run while the loop is parked), not only to
+// the ExecCallback (run on its own goroutine after the loop resumed).
+func TestIssue1753_AllExecCommandsClearFlagInRun(t *testing.T) {
+	src, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+	text := string(src)
+
+	for _, cmdType := range []string{
+		"tea.Exec(attachCmd{",
+		"tea.Exec(attachWindowCmd{",
+		"tea.Exec(remoteAttachCmd{",
+		"tea.Exec(remoteCreateAndAttachCmd{",
+	} {
+		idx := 0
+		found := false
+		for {
+			at := strings.Index(text[idx:], cmdType)
+			if at < 0 {
+				break
+			}
+			found = true
+			site := text[idx+at:]
+			if end := strings.Index(site, "func(err error) tea.Msg"); end >= 0 {
+				site = site[:end]
+			}
+			if !strings.Contains(site, "onExit:") {
+				t.Errorf("%s call site without onExit: the attach flag would only be cleared "+
+					"in the ExecCallback goroutine, racing the first post-resume View (#1753)", cmdType)
+			}
+			idx += at + len(cmdType)
+		}
+		if !found {
+			t.Errorf("no %s call site found — update this guard if the command was renamed (#1753)", cmdType)
+		}
+	}
+
+	// And each command type's Run must defer onExit.
+	for _, runSig := range []string{
+		"func (a attachCmd) Run() error {",
+		"func (a attachWindowCmd) Run() error {",
+		"func (r remoteAttachCmd) Run() error {",
+		"func (r remoteCreateAndAttachCmd) Run() error {",
+	} {
+		body := funcBody(t, text, runSig)
+		if !strings.Contains(body, "onExit") {
+			t.Errorf("%s does not run onExit: the flag clear would not happen while the "+
+				"loop is parked (#1753)", runSig)
+		}
+	}
+}
+
+// --- Family 2: the first frame must not block on or scale with visible rows ---
+
+// TestIssue1753_RowLabelsRenderLockFree is the source-level guard for the
+// blocked-first-frame fix: the overview row renderer must derive its labels
+// from the render snapshot (sessionDisplayLabelsFromState), never from the
+// Instance getters that take Instance.mu per row.
+func TestIssue1753_RowLabelsRenderLockFree(t *testing.T) {
+	src, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+	body := funcBody(t, string(src), "func (h *Home) renderSessionItem(")
+	for _, banned := range []string{
+		"sessionDisplayLabels(inst",
+		"inst.GetAutoName()",
+		"inst.GetAutoNameDescription()",
+		"inst.GetStatusThreadSafe()",
+	} {
+		if strings.Contains(body, banned) {
+			t.Errorf("renderSessionItem calls %s: that takes Instance.mu per visible row, and a "+
+				"background UpdateStatus holds that mutex as a writer across tmux subprocess "+
+				"calls — the first post-detach frame then blocks for seconds, scaling with "+
+				"visible row count (#1753). Read it from the render snapshot instead.", banned)
+		}
+	}
+
+	// The snapshot must actually carry the label fields, or the lock-free path
+	// would render blank titles.
+	inst := &session.Instance{ID: "snap", Title: "handle", Tool: "shell", Status: session.StatusStopped}
+	h := newTestHomeWithItems(120, 40, nil)
+	h.instances = []*session.Instance{inst}
+	h.refreshSessionRenderSnapshot(nil)
+	state, ok := h.getSessionRenderSnapshot()["snap"]
+	if !ok {
+		t.Fatal("render snapshot missing instance after refresh")
+	}
+	if state.title != "handle" {
+		t.Fatalf("render snapshot does not carry the row title (got %q): the lock-free label "+
+			"path would render empty rows (#1753)", state.title)
+	}
+	if title, _ := sessionDisplayLabelsFromState(state); title != "handle" {
+		t.Fatalf("sessionDisplayLabelsFromState = %q, want the instance handle", title)
+	}
+}
+
+// TestIssue1753_VisibleRowRefreshIsBudgeted: with a large group expanded the
+// visible set approaches fleet size, so "refresh every visible row per pass"
+// degenerates into the very burst the off-screen batching exists to prevent —
+// each UpdateStatus takes the Instance write lock, sometimes across tmux
+// subprocess calls. Visible rows must be budgeted round-robin instead.
+func TestIssue1753_VisibleRowRefreshIsBudgeted(t *testing.T) {
+	const fleet = 30
+	instances := make([]*session.Instance, 0, fleet)
+	ids := make([]string, 0, fleet)
+	for i := 0; i < fleet; i++ {
+		// StatusRunning with no tmux session: UpdateStatus flips it to a
+		// terminated status, so "status changed" counts UpdateStatus calls.
+		inst := &session.Instance{
+			ID:     fmt.Sprintf("v-%d", i),
+			Title:  fmt.Sprintf("v-%d", i),
+			Tool:   "shell",
+			Status: session.StatusRunning,
+		}
+		instances = append(instances, inst)
+		ids = append(ids, inst.ID)
+	}
+	h := newTestHomeWithItems(200, 50, nil)
+	h.instances = instances
+
+	req := statusUpdateRequest{viewOffset: 0, visibleHeight: fleet, flatItemIDs: ids}
+	h.processStatusUpdate(req)
+
+	changed := 0
+	for _, inst := range instances {
+		if inst.GetStatusThreadSafe() != session.StatusRunning {
+			changed++
+		}
+	}
+	// visibleStatusBatchSize(4) + the off-screen batch(2) is the absolute upper
+	// bound of UpdateStatus calls in one pass; all 30 rows are visible here so
+	// the off-screen batch has nothing to do.
+	if changed > 6 {
+		t.Fatalf("one processStatusUpdate pass refreshed %d of %d visible rows: the visible-row "+
+			"burst is back — with a large group expanded this is an unbudgeted storm of "+
+			"Instance write locks right when the user expects a frame (#1753)", changed, fleet)
+	}
+	if changed == 0 {
+		t.Fatal("processStatusUpdate refreshed no visible rows at all: the budget must " +
+			"amortize, not starve (#1753)")
+	}
+
+	// The round-robin must CYCLE: repeated passes eventually cover every row.
+	// 12 passes x 4-row budget > 30 rows even with slack for skips.
+	for pass := 0; pass < 12; pass++ {
+		h.processStatusUpdate(req)
+	}
+	for _, inst := range instances {
+		if inst.GetStatusThreadSafe() == session.StatusRunning {
+			t.Fatalf("row %s never refreshed across repeated passes: the visible round-robin "+
+				"does not cycle (#1753)", inst.ID)
+		}
+	}
+}
+
+// TestIssue1753_GroupExpandIsBudgetedTrigger: expanding a group must not run
+// any synchronous per-row work on the event loop; it renders from the snapshot
+// and nudges the budgeted status worker instead.
+func TestIssue1753_GroupExpandIsBudgetedTrigger(t *testing.T) {
+	const groupSize = 20
+	instances := make([]*session.Instance, 0, groupSize)
+	for i := 0; i < groupSize; i++ {
+		instances = append(instances, &session.Instance{
+			ID:        fmt.Sprintf("g-%d", i),
+			Title:     fmt.Sprintf("g-%d", i),
+			Tool:      "shell",
+			Status:    session.StatusStopped,
+			GroupPath: "biggroup",
+		})
+	}
+	h := newTestHomeWithItems(200, 50, nil)
+	h.instances = instances
+	h.groupTree = session.NewGroupTree(instances)
+	h.groupTree.CollapseGroup("biggroup")
+	h.rebuildFlatItems()
+	if len(h.flatItems) == 0 || h.flatItems[0].Type != session.ItemTypeGroup {
+		t.Fatal("precondition: collapsed group row expected at the top of flatItems")
+	}
+	h.cursor = 0
+
+	// Expand via the real key handler (tab toggles the group under the cursor).
+	statusBefore := make(map[string]session.Status, groupSize)
+	for _, inst := range instances {
+		statusBefore[inst.ID] = inst.GetStatusThreadSafe()
+	}
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// 1. No synchronous refresh burst: expanding changed no session status
+	//    inline (rebuildFlatItems is pure in-memory).
+	for _, inst := range instances {
+		if inst.GetStatusThreadSafe() != statusBefore[inst.ID] {
+			t.Fatalf("group expand refreshed session %s synchronously on the event loop (#1753)", inst.ID)
+		}
+	}
+
+	// 2. The expand queued a budgeted refresh request for the worker.
+	select {
+	case req := <-h.statusTrigger:
+		if len(req.flatItemIDs) == 0 {
+			t.Fatal("group-expand trigger carried no session IDs (#1753)")
+		}
+	default:
+		t.Fatal("group expand queued no status-update request: newly visible rows would " +
+			"wait for the next tick instead of filling in amortized (#1753)")
+	}
+
+	// 3. Collapse must NOT nudge the worker (nothing became visible).
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyTab})
+	select {
+	case <-h.statusTrigger:
+		t.Fatal("group collapse queued a status-update request: collapse reveals nothing (#1753)")
+	default:
+	}
+}

--- a/internal/ui/session_switcher.go
+++ b/internal/ui/session_switcher.go
@@ -30,13 +30,19 @@ const switcherRepeatGuard = 80 * time.Millisecond
 // cycle forward / backward, arrow keys browse, and the highlight is attached on
 // Enter or after a brief idle once you've cycled.
 type SessionSwitcher struct {
-	visible          bool
-	width, height    int
-	sessions         []*session.Instance // active sessions, MRU-ordered
-	cursor           int
-	fromID           string            // session the picker was opened from
-	subtitles        map[string]string // sessionID -> dim conversation/pane title (matches the overview)
-	reattachOnCancel bool              // Esc re-attaches to fromID (opened while attached) vs. just closing (opened from the overview)
+	visible       bool
+	width, height int
+	sessions      []*session.Instance // active sessions, MRU-ordered
+	cursor        int
+	fromID        string            // session the picker was opened from
+	subtitles     map[string]string // sessionID -> dim conversation/pane title (matches the overview)
+	// labels carries the render-snapshot state per session so View() can build
+	// rows lock-free (#1753): the switcher opens on the event loop right after
+	// a switch-return, and per-row Instance.mu reads could block behind a
+	// mid-sweep UpdateStatus writer for seconds. Nil (e.g. in direct Show
+	// callers/tests) falls back to the Instance getters.
+	labels           map[string]sessionRenderState
+	reattachOnCancel bool // Esc re-attaches to fromID (opened while attached) vs. just closing (opened from the overview)
 	// commitGen is bumped on every open/cycle/cancel so a stale idle-commit
 	// timer (scheduled before a later keypress) is ignored when it fires. It is
 	// intentionally monotonic — never reset — so a timer from a previous
@@ -143,6 +149,7 @@ func (s *SessionSwitcher) Hide() {
 	s.sessions = nil
 	s.fromID = ""
 	s.subtitles = nil
+	s.labels = nil
 	s.reattachOnCancel = false
 	s.lastCycleAt = time.Time{}
 }
@@ -227,12 +234,20 @@ func (s *SessionSwitcher) View() string {
 	// horizontal padding). The dialog grows to fit it, capped at the terminal.
 	natural := max(cellWidth(header), cellWidth(footerCycle), cellWidth(footerNav))
 	for i, inst := range s.sessions {
-		indicator := statusIndicator(inst.GetStatusThreadSafe())
+		var indicator, label, subtitle string
+		if state, ok := s.labels[inst.ID]; ok {
+			// Lock-free path (#1753): status and labels from the render
+			// snapshot captured at open time — no Instance.mu per row.
+			indicator = statusIndicator(state.status)
+			label, subtitle = sessionDisplayLabelsFromState(state)
+		} else {
+			indicator = statusIndicator(inst.GetStatusThreadSafe())
+			label, subtitle = sessionDisplayLabels(inst, s.subtitles[inst.ID])
+		}
 		tool := ""
 		if inst.Tool != "" {
 			tool = fmt.Sprintf(" (%s)", inst.Tool)
 		}
-		label, subtitle := sessionDisplayLabels(inst, s.subtitles[inst.ID])
 		title := label + tool
 
 		marker := "  "


### PR DESCRIPTION
## What problem does this solve?

On the maintainer's live fleet (~57 agent sessions, two TUIs), Ctrl+Q on main tip (post-#1764) still showed ~1s of black screen before the list reappeared. The key diagnostic on #1753: it reproduces when a large group is expanded and goes away when it is collapsed.

## Root causes (enumerated)

**A. Routes where the first View() after `tea.Exec` returns could be EMPTY** (`View()` returns `""` while `isAttaching` is set):

| route | before | after |
|---|---|---|
| session attach (`attachCmd`) | cleared in `Run()` via onExit (#1764) ✅ | unchanged, now belt-covered |
| window attach (`attachWindowCmd`) | wired but untested (flagged in the #1764 review) | pinned by test |
| container shell (`attachCmd` via E) | wired | pinned by source guard |
| remote attach (`remoteAttachCmd`) | ❌ cleared only in the ExecCallback — Bubble Tea runs it on its own goroutine after the loop resumes, so the first View() raced it and rendered `""` | onExit clears in `Run()` |
| remote create+attach (`remoteCreateAndAttachCmd`) | ❌ same race | onExit clears in `Run()` |
| double-click attach | ❌ pre-set `isAttaching` before `attachSession`, which can return nil → flag stuck true → **permanent** black screen | pre-set removed; `attachSession` owns the flag |
| reloading branch of `statusUpdateMsg` | cleared but never exercised by a test | pinned by test |
| any future stuck-flag path | black until next message (or forever) | **belt: `View()` re-serves the last rendered frame instead of `""`** — identical content while the renderer is live, so nothing is written and Bubble Tea #431 stays fixed |

**B. Routes where the first frame is BLOCKED** (the felt ~1s, scaling with visible rows):

1. `renderSessionItem` read `GetAutoName()` (twice) + `GetAutoNameDescription()` per visible row — each an `Instance.mu` RLock — while background `UpdateStatus` holds that mutex as a **writer across tmux subprocess calls** (`Exists` probe 2s cap at instance.go:4213/4246, `DetectTool`→capture 3s cap at :4574, `show-environment` at :4621). Go's RWMutex queues new readers behind a waiting writer, so one mid-sweep session stalls the whole frame; more visible rows ⇒ more chances to hit a locked one. **Exactly** why an expanded group reproduces it and two TUIs (double sweep pressure, slower tmux server) make it worse. Row labels now ride the lock-free render snapshot; the session switcher rows too.
2. `processStatusUpdate` refreshed **every** visible row per pass. With a large group expanded, visible ≈ fleet, so the visible-fast/offscreen-skip split degenerated into an unbudgeted storm of Instance write locks (the new requirement recorded on #1753). Visible rows now cycle a dedicated round-robin cursor with a fixed budget (4/pass), idle rows with an unchanged cached-activity fingerprint cost zero, and the off-screen batch is explicitly off-screen-only.
3. Group expand is a first-class trigger case: rows render instantly from the snapshot (rebuild is pure in-memory, unchanged) and a budgeted refresh request is queued for the worker — never a synchronous whole-group burst. Collapse queues nothing.

## Measurements (sandbox)

Isolated HOME/profile/tmux socket, 60 synthetic `--cmd sleep` sessions, TUI driven inside the isolated tmux at 220x50, frames sampled via `capture-pane` and classified ATTACHED/BLANK/TUI:

| flavor | detach→list (median) | blank window (median) |
|---|---|---|
| baseline (pre-fix), group expanded | 33ms | 8ms |
| baseline + saturated tmux server | 68ms | ~0–52ms |
| **fixed**, group expanded | 29ms | 10ms |
| **fixed**, group collapsed | 39ms | 9ms |
| **fixed**, window attach | 35ms | 11ms |

As with #1764, the sandbox's idle `sleep` panes cannot reproduce the live fleet's contention (their UpdateStatus never reaches the under-lock subprocess paths, so pre-fix blank is already small); the sandbox proves the fix regresses nothing and that blank stays bounded at ~1 renderer frame (~10ms — the alt-screen erase→first-flush gap, the floor of this architecture). The lock-contention leg is pinned by code-path tests and source guards instead: an empty first frame is now structurally unreachable, and no keypress→first-frame path scales with visible rows.

## Tests (all fail without their fix)

- first-View-non-empty per attach flavor: session, window, remote attach, remote create+attach, reloading branch
- the View last-frame fallback and the stuck-flag (`attachSession` nil-return) route
- source guards: every `tea.Exec` site wires `onExit`; `Run()` of all four command types defers it; `renderSessionItem` never touches `Instance.mu` getters
- `processStatusUpdate`: visible budget upper bound, round-robin cycling coverage, group-expand queues a budgeted request / collapse does not, no synchronous refresh on expand

## Coordination with #1765

Deliberately non-conflicting: this PR touches `processStatusUpdate` batching, the render snapshot fields, and attach-flag wiring — not the sweep architecture. The visible-row budget here is the incremental form of the per-tick budget the refresh-architecture-v2 design calls for; when #1765 lands, its event-driven sweep composes with (and can subsume) Step 1's budget, while the flag wiring and lock-free labels remain necessary regardless.

Refs #1753.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed black-screen and empty UI issues after attaching, including failed or unexpected attach attempts.
  * The UI now preserves the last complete frame during attachment transitions.
  * Group expansion and toggle actions recover correctly without leaving the UI stuck.

* **Performance**
  * Improved responsiveness when displaying session labels and refreshing status in expanded groups.

* **Tests**
  * Added regression coverage for attachment flows, first-frame rendering, fallback behavior, and performance safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->