### PR TITLE
fix(send): never submit composer content not attributable to the operator (#1777)

### DIFF
--- a/cmd/agent-deck/issue1777_foreign_draft_test.go
+++ b/cmd/agent-deck/issue1777_foreign_draft_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -68,5 +69,61 @@ func TestSendWithRetryTarget_GhostSuggestionDoesNotBlockNudges(t *testing.T) {
 	})
 	if got := atomic.LoadInt32(&mock.sendEnterCalls); got == 0 {
 		t.Fatal("a dim ghost holds no buffer content; Enter nudges must remain allowed")
+	}
+}
+
+// Issue #1777 follow-up: the pasted-text branch used to escape the gate.
+// `HasUnsentPastedPrompt` matches "[pasted text" anywhere in the pane and its
+// hit short-circuited the attribution check to false, so that branch pressed
+// Enter unconditionally — submitting a paste the operator never authored.
+// Every branch now routes through send.EnterAttribution.NudgeEnter.
+
+func TestSendWithRetryTarget_ForeignPasteMarkerBlocksEnterNudges(t *testing.T) {
+	// A "[Pasted text …]" marker is parked in the composer and agent-deck has
+	// no evidence it created it (no pre-send provenance): no Enter may fire.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{claudeComposerANSI("[Pasted text #1 +89 lines]")},
+	}
+	_, _ = sendWithRetryTarget(mock, "status update please", false, sendRetryOptions{
+		maxRetries: 6, checkDelay: 0, maxFullResends: -1,
+	})
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("issue #1777: the pasted-text branch must not bypass the attribution gate, got %d Enter presses", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+		t.Fatalf("full resends are disabled; nothing may clear the pane, got %d Ctrl+C calls", got)
+	}
+}
+
+func TestSendWithRetryTarget_OwnPasteMarkerStillNudged(t *testing.T) {
+	// Delivery regression guard: with the pre-send probe confirming an
+	// unmarked composer, the marker is our own bulk payload collapsed by
+	// Claude, and the swallowed-Enter recovery must still work.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{claudeComposerANSI("[Pasted text #1 +89 lines]")},
+	}
+	_, _ = sendWithRetryTarget(mock, "a long automated payload", false, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, maxFullResends: -1,
+		composerPasteFreeBeforeSend: true,
+	})
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got == 0 {
+		t.Fatal("our own collapsed paste must still receive recovery Enters")
+	}
+}
+
+func TestComposerPasteFree_ProbeIsFailSafe(t *testing.T) {
+	clear := &mockSendRetryTarget{panes: []string{claudeComposerANSI("")}}
+	if !composerPasteFree(clear) {
+		t.Fatal("an unmarked composer must report paste-free")
+	}
+	parked := &mockSendRetryTarget{panes: []string{claudeComposerANSI("[Pasted text #1 +89 lines]")}}
+	if composerPasteFree(parked) {
+		t.Fatal("a parked composer paste marker must not report paste-free")
+	}
+	broken := &mockSendRetryTarget{panes: []string{""}, paneErrs: []error{errors.New("pane gone")}}
+	if composerPasteFree(broken) {
+		t.Fatal("a capture failure must fail safe (no provenance evidence)")
 	}
 }

--- a/cmd/agent-deck/issue1777_foreign_draft_test.go
+++ b/cmd/agent-deck/issue1777_foreign_draft_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Issue #1777: a Claude autosuggestion can materialize in the composer as
+// REAL, normal-coloured (\e[39m) unsubmitted input. The send-verify loop's
+// fallback Enter nudges must never fire into that state — a bare Enter would
+// submit an instruction no operator wrote.
+
+// claudeComposerANSI renders a composer block with ANSI attributes intact,
+// mirroring `tmux capture-pane -e` output (claudeComposer in
+// issue1409_1413_send_guard_test.go is the stripped equivalent).
+func claudeComposerANSI(body string) string {
+	div := strings.Repeat("─", 40)
+	return "some prior output\n" + div + "\n\x1b[39m❯ " + body + "\n" + div + "\n  auto mode on\n"
+}
+
+func TestSendWithRetryTarget_ForeignComposerContentBlocksEnterNudges(t *testing.T) {
+	// A materialized suggestion (one of the reporter's live specimens) is
+	// parked in the composer; the target never goes active. Every waiting
+	// and ambiguous check would previously nudge a bare Enter — submitting
+	// the foreign text. With the attribution gate no Enter may fire.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{claudeComposerANSI("upgrade agent-deck on carrollton and archive the five error sessions")},
+	}
+	_, _ = sendWithRetryTarget(mock, "status update please", false, sendRetryOptions{
+		maxRetries: 6, checkDelay: 0, maxFullResends: -1,
+	})
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("issue #1777: bare Enter nudges must not fire while foreign content is parked in the composer, got %d", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+		t.Fatalf("full resends are disabled; nothing may clear the pane, got %d Ctrl+C calls", got)
+	}
+}
+
+func TestSendWithRetryTarget_OwnParkedMessageStillNudged(t *testing.T) {
+	// Recovery regression guard: the composer holding OUR message is exactly
+	// the state the retry Enter exists for — the gate must not block it.
+	const msg = "instruct the worker to re-run CI now"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{claudeComposerANSI(msg)},
+	}
+	_, _ = sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, maxFullResends: -1,
+	})
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got == 0 {
+		t.Fatal("agent-deck's own parked message must still receive recovery Enters")
+	}
+}
+
+func TestSendWithRetryTarget_GhostSuggestionDoesNotBlockNudges(t *testing.T) {
+	// A still-dim ghost (\e[2m) means the composer buffer is empty: nudges
+	// stay allowed (they submit nothing), so delivery recovery for panes
+	// showing only a suggestion is unchanged.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{claudeComposerANSI("\x1b[2mConfirm the audit row after the next heartbeat\x1b[0m")},
+	}
+	_, _ = sendWithRetryTarget(mock, "status update please", false, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, maxFullResends: -1,
+	})
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got == 0 {
+		t.Fatal("a dim ghost holds no buffer content; Enter nudges must remain allowed")
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -651,6 +651,12 @@ func handleLaunch(profile string, args []string) {
 			if _, err := sendWithRetryTarget(tmuxSess, initialMessage, skipClaudeDeliveryVerify(newInstance.Tool), sendRetryOptions{
 				maxRetries: 8,
 				checkDelay: 150 * time.Millisecond,
+				// #1777 provenance probe: a freshly launched session has an
+				// empty composer, so a "[Pasted text …]" marker appearing
+				// during verification is this prompt's own collapse and the
+				// Enter nudge stays attributable. If the probe cannot confirm
+				// that, the gate withholds the nudge.
+				composerPasteFreeBeforeSend: composerPasteFree(tmuxSess),
 			}); err != nil {
 				out.Error(fmt.Sprintf("failed to send initial message: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)

--- a/cmd/agent-deck/launch_verify_prompt.go
+++ b/cmd/agent-deck/launch_verify_prompt.go
@@ -37,6 +37,18 @@ func verifyPromptConsumedAfterLaunch(
 	if pollPromptConsumed(target, message, maxWait, pollInterval) {
 		return
 	}
+	// The retry types the message and presses Enter, so it submits whatever
+	// the composer holds at that moment. If that is content agent-deck cannot
+	// attribute — a materialized autosuggestion, an operator draft — the
+	// retry would submit it with our prompt appended (#1777). Withhold it and
+	// let the warning below surface the unconsumed prompt instead.
+	attrib := send.EnterAttribution{Message: message}
+	if attrib.EnterWouldSubmitForeignDraft(send.CaptureOutcome(target.CapturePaneFresh()), tmux.StripANSI) {
+		if warn != nil {
+			fmt.Fprintln(warn, "warning: launch prompt not consumed and the composer holds unattributable content; skipping the retry so nothing unauthored is submitted")
+		}
+		return
+	}
 	_ = target.SendKeysAndEnter(message)
 	if pollPromptConsumed(target, message, maxWait, pollInterval) {
 		return

--- a/cmd/agent-deck/launch_verify_prompt.go
+++ b/cmd/agent-deck/launch_verify_prompt.go
@@ -59,9 +59,19 @@ func verifyPromptConsumedAfterLaunch(
 }
 
 // pollPromptConsumed returns true once the pane shows a rendered composer
-// whose input line no longer contains the message — i.e., Enter was
-// accepted. Returns false on timeout. Capture errors are treated as "not
-// yet consumed" so we keep polling until the budget expires.
+// that is genuinely empty — i.e., Enter was accepted and nothing (ours or
+// foreign) is sitting in the input line. Returns false on timeout. Capture
+// errors are treated as "not yet consumed" so we keep polling until the
+// budget expires.
+//
+// Consumed must NOT be inferred merely from "our message isn't in the
+// composer" (#1777): a materialized autosuggestion or an unrelated draft
+// parked in the composer instead of our message would satisfy that weaker
+// check and short-circuit this poll as a false success, skipping the
+// attribution gate below entirely — the retry-withhold-and-warn path could
+// then never fire because the caller believes delivery already succeeded.
+// ComposerHasDraft reports true for ANY visible draft, ours or foreign, so
+// only a truly empty (or suggestion/placeholder) composer counts as consumed.
 func pollPromptConsumed(target sendRetryTarget, message string, maxWait, pollInterval time.Duration) bool {
 	if pollInterval <= 0 {
 		pollInterval = 100 * time.Millisecond
@@ -70,7 +80,7 @@ func pollPromptConsumed(target sendRetryTarget, message string, maxWait, pollInt
 	for {
 		if raw, err := target.CapturePaneFresh(); err == nil {
 			content := tmux.StripANSI(raw)
-			if send.HasCurrentComposerPrompt(content) && !send.HasUnsentComposerPrompt(content, message) {
+			if send.HasCurrentComposerPrompt(content) && !send.ComposerHasDraft(raw, tmux.StripANSI) {
 				return true
 			}
 		}

--- a/cmd/agent-deck/launch_verify_prompt_test.go
+++ b/cmd/agent-deck/launch_verify_prompt_test.go
@@ -160,3 +160,25 @@ func TestVerifyPromptConsumedAfterLaunch_RespectsWallTimeBudget(t *testing.T) {
 		t.Fatalf("verify took %v, expected <500ms with 30ms budgets (unbounded poll bug)", elapsed)
 	}
 }
+
+// Issue #1777: the retry types the prompt and presses Enter, so it submits
+// whatever the composer holds at that moment. Foreign content parked there —
+// a materialized Claude autosuggestion, an operator draft — must never be
+// submitted with our prompt appended.
+func TestVerifyPromptConsumedAfterLaunch_ForeignComposerContent_NoRetry_WarningEmitted(t *testing.T) {
+	foreign := "some output above\n" +
+		"─────────────────────────\n" +
+		"\x1b[39m❯ archive every error session and upgrade the fleet\n" +
+		"─────────────────────────\n"
+	mock := &mockSendRetryTarget{panes: []string{foreign}}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunch(mock, "explain this code", 10*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 0 {
+		t.Fatalf("retry must be withheld while unattributable content sits in the composer, got %d sends", got)
+	}
+	if warn.Len() == 0 {
+		t.Fatal("the withheld retry must be surfaced as a warning")
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3164,6 +3164,11 @@ func executeSend(target sendRetryTarget, tool, message string, noWait bool, tun 
 		res.held = guard.Held
 		res.draftSaved = guard.SavedDraft
 		res.draftCleared = guard.DraftCleared
+		// Provenance for the #1777 attribution gate, taken from the capture
+		// the guard already made just before we type: with no paste marker
+		// parked in the composer then, a marker seen during verification is
+		// the collapsed form of our own payload and may be nudged.
+		tun.retry.composerPasteFreeBeforeSend = guard.ComposerPasteMarkerFree
 	}
 
 	delivery, err := sendWithRetryTarget(target, message, skipClaudeDeliveryVerify(tool), tun.retry)
@@ -3307,6 +3312,27 @@ type sendRetryOptions struct {
 	// error instead of the prior best-effort `nil`. Closes the silent-drop
 	// path reported in issue #876.
 	verifyDelivery bool
+
+	// composerPasteFreeBeforeSend is the pre-send provenance evidence for the
+	// #1777 attribution gate: the caller positively observed, immediately
+	// before this send, a composer holding no "[Pasted text …]" marker. Only
+	// then can a marker seen during the verify loop be attributed to the
+	// collapse of our own payload and receive an Enter nudge. Left false, a
+	// composer paste marker counts as foreign content and no nudge fires —
+	// the fail-safe default for callers that cannot establish provenance.
+	composerPasteFreeBeforeSend bool
+}
+
+// composerPasteFree captures the pane and reports whether the composer is
+// currently free of a "[Pasted text …]" marker — the pre-send provenance
+// probe for sendRetryOptions.composerPasteFreeBeforeSend (issue #1777). A
+// capture failure returns false (fail safe: no evidence, no attribution).
+func composerPasteFree(target sendRetryTarget) bool {
+	raw, err := target.CapturePaneFresh()
+	if err != nil {
+		return false
+	}
+	return !send.ComposerHoldsPasteMarker(raw, tmux.StripANSI)
 }
 
 // sendWithRetryTarget sends the message and runs the bounded submit
@@ -3415,21 +3441,26 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	// Take the first run of non-whitespace content, capped, to avoid false
 	// positives from matching common short strings.
 	deliveryToken := messageDeliveryToken(message)
+	// attrib is the #1777 attribution gate. EVERY bare Enter in this loop —
+	// including the unsent-prompt branch, which used to press unconditionally
+	// whenever a "[Pasted text …]" marker appeared anywhere in the pane —
+	// goes through attrib.NudgeEnter, so no branch can submit composer
+	// content agent-deck cannot attribute to its own delivery.
+	attrib := send.EnterAttribution{
+		Message:        message,
+		OwnPasteMarker: opts.composerPasteFreeBeforeSend,
+	}
 	for retry := 0; retry < opts.maxRetries; retry++ {
 		time.Sleep(opts.checkDelay)
 
 		unsentPromptDetected := false
-		// foreignDraftParked (issue #1777): the composer visibly holds content
-		// that is neither our message nor a suggestion/placeholder — e.g. a
-		// Claude autosuggestion materialized as real normal-coloured input.
-		// The fallback Enter nudges below must not fire then: a bare Enter
-		// would submit an instruction no operator wrote. Skipping the nudge
-		// is the safe failure (the verify then classifies the delivery).
-		foreignDraftParked := false
-		if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
-			content := tmux.StripANSI(rawContent)
+		// rawContent is this iteration's ANSI-bearing capture ("" when the
+		// capture failed), and is what the attribution gate reads.
+		rawContent := ""
+		if captured, captureErr := target.CapturePaneFresh(); captureErr == nil {
+			rawContent = captured
+			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
-			foreignDraftParked = !unsentPromptDetected && send.EnterWouldSubmitForeignDraft(rawContent, tmux.StripANSI, message)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
 				sawDeliveryEvidence = true
 			}
@@ -3442,7 +3473,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 			waitingNoMarkerChecks = 0
 			waitingNoActivityChecks = 0
 			activeChecks = 0
-			_ = target.SendEnter()
+			attrib.NudgeEnter(target, rawContent, tmux.StripANSI)
 			continue
 		}
 
@@ -3492,8 +3523,8 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// aggressively in the early window (every iteration for first 5
 				// retries) then every 2nd iteration. This addresses bracketed
 				// paste timing failures that are most likely early on.
-				if (retry < 5 || retry%2 == 0) && !foreignDraftParked {
-					_ = target.SendEnter()
+				if retry < 5 || retry%2 == 0 {
+					attrib.NudgeEnter(target, rawContent, tmux.StripANSI)
 				}
 			}
 			continue
@@ -3504,8 +3535,8 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		// Ambiguous state: keep a best-effort Enter retry budget.
 		// Increased from 2 to 4 because some TUI frameworks take longer
 		// to process and reflect state.
-		if retry < 4 && !foreignDraftParked {
-			_ = target.SendEnter()
+		if retry < 4 {
+			attrib.NudgeEnter(target, rawContent, tmux.StripANSI)
 		}
 	}
 

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3505,8 +3505,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// visible but the input handler wasn't ready, so sent keys were
 				// discarded. Clear stale input and re-send the full message.
 				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends {
-					fullResendCount++
-					waitingNoActivityChecks = 0
 					// The resend types the message and presses Enter, so it
 					// submits whatever the composer still holds. Ctrl+C is
 					// meant to empty it first — but a failed Ctrl+C, or one
@@ -3514,6 +3512,16 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 					// submitted with our payload appended (#1777). Re-read
 					// the pane and skip the resend unless the composer is
 					// verifiably clear of content we cannot attribute.
+					//
+					// fullResendCount and waitingNoActivityChecks are consumed
+					// below, ONLY once a resend is actually about to fire —
+					// not here. Either abort path (Ctrl+C error, or a pane
+					// that still reads as foreign after it) sends nothing, so
+					// charging the finite resend budget or resetting the
+					// waiting-check counter here would burn a scarce slot for
+					// no send and force a fresh fullResendThreshold wait
+					// before the next attempt, right after Ctrl+C may have
+					// already wiped the composer (#1778 review finding 3).
 					if ctrlCErr := target.SendCtrlC(); ctrlCErr != nil {
 						continue
 					}
@@ -3522,6 +3530,8 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 						send.CaptureOutcome(target.CapturePaneFresh()), tmux.StripANSI) {
 						continue
 					}
+					fullResendCount++
+					waitingNoActivityChecks = 0
 					// A successful resend is not yet evidence of receipt — the
 					// next iteration must still observe a positive signal — so
 					// we intentionally do NOT set sawDeliveryEvidence here, even

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3419,9 +3419,17 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		time.Sleep(opts.checkDelay)
 
 		unsentPromptDetected := false
+		// foreignDraftParked (issue #1777): the composer visibly holds content
+		// that is neither our message nor a suggestion/placeholder — e.g. a
+		// Claude autosuggestion materialized as real normal-coloured input.
+		// The fallback Enter nudges below must not fire then: a bare Enter
+		// would submit an instruction no operator wrote. Skipping the nudge
+		// is the safe failure (the verify then classifies the delivery).
+		foreignDraftParked := false
 		if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
 			content := tmux.StripANSI(rawContent)
 			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
+			foreignDraftParked = !unsentPromptDetected && send.EnterWouldSubmitForeignDraft(rawContent, tmux.StripANSI, message)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
 				sawDeliveryEvidence = true
 			}
@@ -3484,7 +3492,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// aggressively in the early window (every iteration for first 5
 				// retries) then every 2nd iteration. This addresses bracketed
 				// paste timing failures that are most likely early on.
-				if retry < 5 || retry%2 == 0 {
+				if (retry < 5 || retry%2 == 0) && !foreignDraftParked {
 					_ = target.SendEnter()
 				}
 			}
@@ -3496,7 +3504,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		// Ambiguous state: keep a best-effort Enter retry budget.
 		// Increased from 2 to 4 because some TUI frameworks take longer
 		// to process and reflect state.
-		if retry < 4 {
+		if retry < 4 && !foreignDraftParked {
 			_ = target.SendEnter()
 		}
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3454,11 +3454,11 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		time.Sleep(opts.checkDelay)
 
 		unsentPromptDetected := false
-		// rawContent is this iteration's ANSI-bearing capture ("" when the
-		// capture failed), and is what the attribution gate reads.
-		rawContent := ""
-		if captured, captureErr := target.CapturePaneFresh(); captureErr == nil {
-			rawContent = captured
+		// paneNow is this iteration's observation (raw ANSI + whether the
+		// capture succeeded at all), and is what the attribution gate reads.
+		captured, captureErr := target.CapturePaneFresh()
+		paneNow := send.CaptureOutcome(captured, captureErr)
+		if paneNow.OK {
 			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
@@ -3473,7 +3473,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 			waitingNoMarkerChecks = 0
 			waitingNoActivityChecks = 0
 			activeChecks = 0
-			attrib.NudgeEnter(target, rawContent, tmux.StripANSI)
+			attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
 			continue
 		}
 
@@ -3507,8 +3507,21 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends {
 					fullResendCount++
 					waitingNoActivityChecks = 0
-					_ = target.SendCtrlC()
+					// The resend types the message and presses Enter, so it
+					// submits whatever the composer still holds. Ctrl+C is
+					// meant to empty it first — but a failed Ctrl+C, or one
+					// the agent ignored, would leave foreign content to be
+					// submitted with our payload appended (#1777). Re-read
+					// the pane and skip the resend unless the composer is
+					// verifiably clear of content we cannot attribute.
+					if ctrlCErr := target.SendCtrlC(); ctrlCErr != nil {
+						continue
+					}
 					time.Sleep(200 * time.Millisecond)
+					if attrib.EnterWouldSubmitForeignDraft(
+						send.CaptureOutcome(target.CapturePaneFresh()), tmux.StripANSI) {
+						continue
+					}
 					// A successful resend is not yet evidence of receipt — the
 					// next iteration must still observe a positive signal — so
 					// we intentionally do NOT set sawDeliveryEvidence here, even
@@ -3524,7 +3537,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// retries) then every 2nd iteration. This addresses bracketed
 				// paste timing failures that are most likely early on.
 				if retry < 5 || retry%2 == 0 {
-					attrib.NudgeEnter(target, rawContent, tmux.StripANSI)
+					attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
 				}
 			}
 			continue
@@ -3536,7 +3549,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		// Increased from 2 to 4 because some TUI frameworks take longer
 		// to process and reflect state.
 		if retry < 4 {
-			attrib.NudgeEnter(target, rawContent, tmux.StripANSI)
+			attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
 		}
 	}
 

--- a/internal/send/attribution.go
+++ b/internal/send/attribution.go
@@ -1,5 +1,7 @@
 package send
 
+import "strings"
+
 // EnterAttribution is the single chokepoint every automated bare-Enter press
 // must route through (issue #1777).
 //
@@ -116,7 +118,7 @@ func (a EnterAttribution) EnterWouldSubmitForeignDraft(c PaneCapture, strip func
 		// Empty composer, suggestion, or placeholder: Enter submits nothing.
 		return false
 	}
-	if a.Message != "" && HasUnsentComposerPrompt(strip(raw), a.Message) {
+	if a.Message != "" && composerBodyIsOurMessage(strip(raw), a.Message) {
 		// The composer holds agent-deck's own payload verbatim: attributable.
 		return false
 	}
@@ -152,4 +154,53 @@ func orIdentity(strip func(string) string) func(string) string {
 		return func(s string) string { return s }
 	}
 	return strip
+}
+
+// composerBodyIsOurMessage reports whether the composer body currently
+// visible in content is agent-deck's own message — not merely a FOREIGN
+// draft that happens to contain it.
+//
+// send.go's HasUnsentComposerPrompt is intentionally loose for its own
+// callers (the send-verify retry loop, deciding whether a resend is still
+// needed): it matches on bare `strings.Contains(promptBody, msg)` and, as a
+// last resort, on any 32-char prefix of msg appearing anywhere in the
+// prompt body. A false positive there just skips a resend — recoverable.
+// This function backs the attribution gate instead, where a false positive
+// presses Enter on text nobody authored — unrecoverable. It therefore keeps
+// only the prefix-anchored matches (composer holds our message verbatim, or
+// the wrapped first visual line is a genuine prefix of it) and drops the
+// bare-containment and 32-char-substring branches entirely: e.g. a foreign
+// autosuggestion "continue the refactor and delete the stale worktrees"
+// must not be classified as attributable just because it contains the short
+// message "continue" (#1778 review finding 1).
+func composerBodyIsOurMessage(content, message string) bool {
+	msg := NormalizePromptText(message)
+	if msg == "" {
+		return false
+	}
+	promptBody, hasPrompt := CurrentComposerPrompt(content)
+	if !hasPrompt {
+		return false
+	}
+	promptBody = NormalizePromptText(promptBody)
+	if promptBody == "" {
+		return false
+	}
+
+	// Composer holds our message verbatim (or our message plus trailing
+	// characters the terminal echoed, e.g. a cursor glyph).
+	if promptBody == msg || strings.HasPrefix(promptBody, msg) {
+		return true
+	}
+
+	// Wrapped prompts: Claude often shows only the first visual line of the
+	// current composer input. A substantial prefix match is safe because it
+	// can only agree with OUR message, not an unrelated foreign one, absent
+	// a coincidence over minWrappedPrefixLen characters.
+	const minWrappedPrefixLen = 16
+	if len(promptBody) >= minWrappedPrefixLen && strings.HasPrefix(msg, promptBody) {
+		return true
+	}
+
+	return false
 }

--- a/internal/send/attribution.go
+++ b/internal/send/attribution.go
@@ -187,9 +187,20 @@ func composerBodyIsOurMessage(content, message string) bool {
 		return false
 	}
 
-	// Composer holds our message verbatim (or our message plus trailing
-	// characters the terminal echoed, e.g. a cursor glyph).
-	if promptBody == msg || strings.HasPrefix(promptBody, msg) {
+	// Composer holds our message verbatim, or our message plus a SHORT
+	// trailing addition the terminal echoed (e.g. a cursor glyph, a stray
+	// space). This bound is load-bearing, not cosmetic: an unbounded
+	// promptBody-has-prefix-msg check would itself be the #1778 finding-1
+	// bug it claims to fix above — "continue" is a prefix of the foreign
+	// autosuggestion "continue the refactor and delete the stale
+	// worktrees", so the two-line comment's promise only holds if the
+	// extra bytes beyond msg are capped to what a terminal actually adds,
+	// not left open to arbitrary foreign continuation text.
+	const maxTrailingEcho = 4
+	if promptBody == msg {
+		return true
+	}
+	if strings.HasPrefix(promptBody, msg) && len(promptBody)-len(msg) <= maxTrailingEcho {
 		return true
 	}
 

--- a/internal/send/attribution.go
+++ b/internal/send/attribution.go
@@ -43,17 +43,46 @@ type EnterPresser interface {
 	SendEnter() error
 }
 
+// PaneCapture is one pane observation handed to the gate. OK distinguishes
+// the two states a nil-ish capture can mean, which the gate must treat in
+// OPPOSITE directions:
+//
+//	OK=true, no composer found  — positively observed a pane that offers no
+//	                              composer introspection (codex, cursor, a
+//	                              plain shell). Nothing attributable to
+//	                              protect: nudges stay allowed, which is the
+//	                              only reason those agents recover at all.
+//	OK=false                    — the pane could not be read. Zero evidence
+//	                              about what an Enter would submit, so the
+//	                              nudge is withheld.
+type PaneCapture struct {
+	// Raw is the capture with ANSI attributes INTACT (tmux capture-pane -e).
+	Raw string
+	// OK is true when the capture call itself succeeded.
+	OK bool
+}
+
+// Captured wraps a successful pane capture.
+func Captured(raw string) PaneCapture { return PaneCapture{Raw: raw, OK: true} }
+
+// CaptureOutcome wraps a capture attempt and its error in one step.
+func CaptureOutcome(raw string, err error) PaneCapture {
+	if err != nil {
+		return PaneCapture{}
+	}
+	return Captured(raw)
+}
+
 // NudgeEnter presses Enter only when the pane's current composer content is
 // attributable to agent-deck's own in-flight delivery. It reports whether the
 // press was made.
 //
 // This is the chokepoint: automated recovery paths must call NudgeEnter
 // instead of SendEnter directly, so no future branch can reintroduce an
-// ungated press. raw is this iteration's pane capture with ANSI attributes
-// INTACT ("" when the capture failed); strip removes ANSI for text extraction
-// (pass tmux.StripANSI; nil means identity).
-func (a EnterAttribution) NudgeEnter(p EnterPresser, raw string, strip func(string) string) bool {
-	if p == nil || a.EnterWouldSubmitForeignDraft(raw, strip) {
+// ungated press. c is this iteration's pane observation; strip removes ANSI
+// for text extraction (pass tmux.StripANSI; nil means identity).
+func (a EnterAttribution) NudgeEnter(p EnterPresser, c PaneCapture, strip func(string) string) bool {
+	if p == nil || a.EnterWouldSubmitForeignDraft(c, strip) {
 		return false
 	}
 	return p.SendEnter() == nil
@@ -63,18 +92,25 @@ func (a EnterAttribution) NudgeEnter(p EnterPresser, raw string, strip func(stri
 // pane right now could submit composer content that agent-deck cannot
 // positively attribute to its own in-flight delivery.
 //
-// raw must be the pane capture with ANSI attributes INTACT (tmux capture-pane
-// -e — CapturePaneFresh already requests it); a plain capture strips the
-// dim/grey attribute and makes ghost text look typed, so colour classification
-// must happen pre-strip. The gate additionally treats even normal-coloured
-// foreign content as unsubmittable, so colour is no longer load-bearing for
-// safety. strip removes ANSI for text extraction (nil means identity).
+// c.Raw must be the pane capture with ANSI attributes INTACT (tmux
+// capture-pane -e — CapturePaneFresh already requests it); a plain capture
+// strips the dim/grey attribute and makes ghost text look typed, so colour
+// classification must happen pre-strip. The gate additionally treats even
+// normal-coloured foreign content as unsubmittable, so colour is no longer
+// load-bearing for safety. strip removes ANSI for text extraction (nil means
+// identity).
 //
-// A pane with no introspectable composer returns false: there is nothing
-// attributable to protect and the nudge paths exist precisely for those
-// agents.
-func (a EnterAttribution) EnterWouldSubmitForeignDraft(raw string, strip func(string) string) bool {
+// A FAILED capture returns true: with no reading of the pane there is no
+// evidence about what Enter would submit. A SUCCESSFUL capture showing no
+// introspectable composer returns false — there is nothing attributable to
+// protect and the nudge paths exist precisely for those agents.
+func (a EnterAttribution) EnterWouldSubmitForeignDraft(c PaneCapture, strip func(string) string) bool {
+	if !c.OK {
+		// Unreadable pane: withhold the nudge rather than press blind.
+		return true
+	}
 	strip = orIdentity(strip)
+	raw := c.Raw
 	draft, visible := ComposerDraft(raw, strip)
 	if !visible || draft == "" {
 		// Empty composer, suggestion, or placeholder: Enter submits nothing.
@@ -92,23 +128,23 @@ func (a EnterAttribution) EnterWouldSubmitForeignDraft(raw string, strip func(st
 	return true
 }
 
-// EnterWouldSubmitForeignDraft is the provenance-free form of the gate: with
-// no evidence about who created a composer paste marker, the marker counts as
-// foreign. Callers that can supply provenance use EnterAttribution directly.
-func EnterWouldSubmitForeignDraft(raw string, strip func(string) string, message string) bool {
-	return EnterAttribution{Message: message}.EnterWouldSubmitForeignDraft(raw, strip)
-}
-
 // ComposerHoldsPasteMarker reports whether the VISIBLE COMPOSER — not the
 // pane's scrollback, which the whole-pane HasUnsentPastedPrompt would also
 // match — currently holds Claude's "[Pasted text #N +M lines]" marker.
 // Automated senders call it on a pre-send capture to establish
 // EnterAttribution.OwnPasteMarker: a composer with no marker before the send
 // means any marker afterwards is the collapsed form of their own payload.
+// When no composer is introspectable at all the check falls back to the
+// whole-pane match: a pane that already shows paste text somewhere, with no
+// composer to scope it to, yields no usable provenance and must not be
+// reported as clear.
 func ComposerHoldsPasteMarker(raw string, strip func(string) string) bool {
 	strip = orIdentity(strip)
 	draft, visible := ComposerDraft(raw, strip)
-	return visible && HasUnsentPastedPrompt(draft)
+	if !visible {
+		return HasUnsentPastedPrompt(strip(raw))
+	}
+	return HasUnsentPastedPrompt(draft)
 }
 
 func orIdentity(strip func(string) string) func(string) string {

--- a/internal/send/attribution.go
+++ b/internal/send/attribution.go
@@ -1,0 +1,43 @@
+package send
+
+// EnterWouldSubmitForeignDraft reports whether a bare Enter pressed into the
+// pane right now could submit composer content that agent-deck cannot
+// positively attribute to its own in-flight delivery (issue #1777).
+//
+// The invariant it enforces: agent-deck must never cause text it did not
+// receive from the operator to be submitted. A Claude autosuggestion can
+// materialize in the composer as REAL, normal-coloured (`\e[39m`) unsubmitted
+// input — indistinguishable from an operator draft by colour alone — and the
+// send-verify loops' fallback "nudge Enter" presses would submit it as an
+// instruction nobody authored. Before any bare Enter that is not a direct
+// response to seeing agent-deck's own message parked in the composer, callers
+// must consult this check and skip the press when it returns true.
+//
+// raw is the pane capture with ANSI attributes INTACT (tmux capture-pane -e —
+// CapturePaneFresh already requests it); a plain capture strips the dim/grey
+// attribute and makes ghost text look typed, so detection on stripped content
+// is unreliable by construction. strip removes ANSI for text extraction (pass
+// tmux.StripANSI; nil means identity). message is the payload agent-deck
+// itself just typed — content matching it is attributable and safe to nudge.
+//
+// Failure semantics are deliberately asymmetric: returning true only skips a
+// recovery nudge (the delivery verify then reports the send unconfirmed —
+// recoverable), while a wrong false submits foreign text (unrecoverable). A
+// pane with no introspectable composer returns false: there is nothing
+// attributable to protect and the nudge paths exist precisely for those
+// agents.
+func EnterWouldSubmitForeignDraft(raw string, strip func(string) string, message string) bool {
+	if strip == nil {
+		strip = func(s string) string { return s }
+	}
+	draft, visible := ComposerDraft(raw, strip)
+	if !visible || draft == "" {
+		// Empty composer, suggestion, or placeholder: Enter submits nothing.
+		return false
+	}
+	if message != "" && HasUnsentComposerPrompt(strip(raw), message) {
+		// The composer holds agent-deck's own payload: attributable.
+		return false
+	}
+	return true
+}

--- a/internal/send/attribution.go
+++ b/internal/send/attribution.go
@@ -1,43 +1,119 @@
 package send
 
-// EnterWouldSubmitForeignDraft reports whether a bare Enter pressed into the
-// pane right now could submit composer content that agent-deck cannot
-// positively attribute to its own in-flight delivery (issue #1777).
+// EnterAttribution is the single chokepoint every automated bare-Enter press
+// must route through (issue #1777).
 //
 // The invariant it enforces: agent-deck must never cause text it did not
 // receive from the operator to be submitted. A Claude autosuggestion can
 // materialize in the composer as REAL, normal-coloured (`\e[39m`) unsubmitted
 // input — indistinguishable from an operator draft by colour alone — and the
 // send-verify loops' fallback "nudge Enter" presses would submit it as an
-// instruction nobody authored. Before any bare Enter that is not a direct
-// response to seeing agent-deck's own message parked in the composer, callers
-// must consult this check and skip the press when it returns true.
+// instruction nobody authored. So the rule is inverted from "block what looks
+// like a ghost" to "press only what is positively attributable": an empty
+// composer, a suggestion/placeholder, the message agent-deck itself just
+// typed, or that message collapsed behind Claude's paste marker with
+// provenance evidence (OwnPasteMarker) that the collapse is ours.
 //
-// raw is the pane capture with ANSI attributes INTACT (tmux capture-pane -e —
-// CapturePaneFresh already requests it); a plain capture strips the dim/grey
-// attribute and makes ghost text look typed, so detection on stripped content
-// is unreliable by construction. strip removes ANSI for text extraction (pass
-// tmux.StripANSI; nil means identity). message is the payload agent-deck
-// itself just typed — content matching it is attributable and safe to nudge.
+// Failure semantics are deliberately asymmetric: withholding a nudge only
+// leaves a delivery unconfirmed (the verify then classifies it — #1413
+// semantics — recoverable), while a wrong press submits foreign text
+// (unrecoverable). Every field therefore fails safe at its zero value.
+type EnterAttribution struct {
+	// Message is the payload agent-deck itself typed into this pane. Composer
+	// content matching it is attributable and safe to nudge.
+	Message string
+
+	// OwnPasteMarker records that a "[Pasted text #N +M lines]" marker found
+	// in the composer AFTER the send is the collapsed rendering of Message.
+	// Claude hides a bulk paste behind that marker, so the composer body
+	// cannot be matched against Message by content and provenance is the only
+	// available evidence. Callers set it true only when they positively
+	// observed, immediately before typing, a composer holding no paste marker
+	// (see ComposerHoldsPasteMarker): a marker seen afterwards can then only
+	// be the one their own paste created.
+	//
+	// Left false (unknown provenance, capture failure, no plumbing) a
+	// composer paste marker counts as foreign and the Enter is withheld.
+	OwnPasteMarker bool
+}
+
+// EnterPresser is the minimal pane surface NudgeEnter needs. Both
+// *tmux.Session and the send-verify loops' targets satisfy it.
+type EnterPresser interface {
+	SendEnter() error
+}
+
+// NudgeEnter presses Enter only when the pane's current composer content is
+// attributable to agent-deck's own in-flight delivery. It reports whether the
+// press was made.
 //
-// Failure semantics are deliberately asymmetric: returning true only skips a
-// recovery nudge (the delivery verify then reports the send unconfirmed —
-// recoverable), while a wrong false submits foreign text (unrecoverable). A
-// pane with no introspectable composer returns false: there is nothing
+// This is the chokepoint: automated recovery paths must call NudgeEnter
+// instead of SendEnter directly, so no future branch can reintroduce an
+// ungated press. raw is this iteration's pane capture with ANSI attributes
+// INTACT ("" when the capture failed); strip removes ANSI for text extraction
+// (pass tmux.StripANSI; nil means identity).
+func (a EnterAttribution) NudgeEnter(p EnterPresser, raw string, strip func(string) string) bool {
+	if p == nil || a.EnterWouldSubmitForeignDraft(raw, strip) {
+		return false
+	}
+	return p.SendEnter() == nil
+}
+
+// EnterWouldSubmitForeignDraft reports whether a bare Enter pressed into the
+// pane right now could submit composer content that agent-deck cannot
+// positively attribute to its own in-flight delivery.
+//
+// raw must be the pane capture with ANSI attributes INTACT (tmux capture-pane
+// -e — CapturePaneFresh already requests it); a plain capture strips the
+// dim/grey attribute and makes ghost text look typed, so colour classification
+// must happen pre-strip. The gate additionally treats even normal-coloured
+// foreign content as unsubmittable, so colour is no longer load-bearing for
+// safety. strip removes ANSI for text extraction (nil means identity).
+//
+// A pane with no introspectable composer returns false: there is nothing
 // attributable to protect and the nudge paths exist precisely for those
 // agents.
-func EnterWouldSubmitForeignDraft(raw string, strip func(string) string, message string) bool {
-	if strip == nil {
-		strip = func(s string) string { return s }
-	}
+func (a EnterAttribution) EnterWouldSubmitForeignDraft(raw string, strip func(string) string) bool {
+	strip = orIdentity(strip)
 	draft, visible := ComposerDraft(raw, strip)
 	if !visible || draft == "" {
 		// Empty composer, suggestion, or placeholder: Enter submits nothing.
 		return false
 	}
-	if message != "" && HasUnsentComposerPrompt(strip(raw), message) {
-		// The composer holds agent-deck's own payload: attributable.
+	if a.Message != "" && HasUnsentComposerPrompt(strip(raw), a.Message) {
+		// The composer holds agent-deck's own payload verbatim: attributable.
+		return false
+	}
+	if a.OwnPasteMarker && HasUnsentPastedPrompt(draft) {
+		// The composer holds a paste marker and the caller established that
+		// no marker was parked there before it typed: the collapse is ours.
 		return false
 	}
 	return true
+}
+
+// EnterWouldSubmitForeignDraft is the provenance-free form of the gate: with
+// no evidence about who created a composer paste marker, the marker counts as
+// foreign. Callers that can supply provenance use EnterAttribution directly.
+func EnterWouldSubmitForeignDraft(raw string, strip func(string) string, message string) bool {
+	return EnterAttribution{Message: message}.EnterWouldSubmitForeignDraft(raw, strip)
+}
+
+// ComposerHoldsPasteMarker reports whether the VISIBLE COMPOSER — not the
+// pane's scrollback, which the whole-pane HasUnsentPastedPrompt would also
+// match — currently holds Claude's "[Pasted text #N +M lines]" marker.
+// Automated senders call it on a pre-send capture to establish
+// EnterAttribution.OwnPasteMarker: a composer with no marker before the send
+// means any marker afterwards is the collapsed form of their own payload.
+func ComposerHoldsPasteMarker(raw string, strip func(string) string) bool {
+	strip = orIdentity(strip)
+	draft, visible := ComposerDraft(raw, strip)
+	return visible && HasUnsentPastedPrompt(draft)
+}
+
+func orIdentity(strip func(string) string) func(string) string {
+	if strip == nil {
+		return func(s string) string { return s }
+	}
+	return strip
 }

--- a/internal/send/attribution_test.go
+++ b/internal/send/attribution_test.go
@@ -1,21 +1,30 @@
 package send
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
-// Issue #1777: EnterWouldSubmitForeignDraft is the attribution gate every bare
-// Enter nudge must consult. Fixtures shared with suggestion_test.go.
+// Issue #1777: EnterAttribution is the attribution gate every bare Enter nudge
+// must route through. Fixtures shared with suggestion_test.go.
+
+const attribMessage = "our automated message"
+
+var errPaneGone = errors.New("pane gone")
+
+func attrib() EnterAttribution { return EnterAttribution{Message: attribMessage} }
 
 func TestEnterWouldSubmitForeignDraft_MaterializedSuggestionBlocksEnter(t *testing.T) {
 	// The defect case: a suggestion materialized as real, normal-coloured
 	// (\e[39m) unsubmitted input. agent-deck did not place it there, so a
 	// bare Enter would submit an instruction nobody authored.
-	if !EnterWouldSubmitForeignDraft(pane(fixtureMaterializedComposer), stripANSI, "our automated message") {
+	if !attrib().EnterWouldSubmitForeignDraft(Captured(pane(fixtureMaterializedComposer)), stripANSI) {
 		t.Fatal("normal-coloured foreign composer content must block a bare Enter")
 	}
 }
 
 func TestEnterWouldSubmitForeignDraft_OperatorDraftBlocksEnter(t *testing.T) {
-	if !EnterWouldSubmitForeignDraft(pane(fixtureRealDraftComposer), stripANSI, "our automated message") {
+	if !attrib().EnterWouldSubmitForeignDraft(Captured(pane(fixtureRealDraftComposer)), stripANSI) {
 		t.Fatal("an operator draft must block a bare Enter")
 	}
 }
@@ -23,8 +32,8 @@ func TestEnterWouldSubmitForeignDraft_OperatorDraftBlocksEnter(t *testing.T) {
 func TestEnterWouldSubmitForeignDraft_OwnMessageIsAttributable(t *testing.T) {
 	// The composer holding the payload agent-deck itself typed is exactly the
 	// state the recovery Enter exists for.
-	line := "\x1b[39m❯ our automated message"
-	if EnterWouldSubmitForeignDraft(pane(line), stripANSI, "our automated message") {
+	line := "\x1b[39m❯ " + attribMessage
+	if attrib().EnterWouldSubmitForeignDraft(Captured(pane(line)), stripANSI) {
 		t.Fatal("agent-deck's own parked message must not block the recovery Enter")
 	}
 }
@@ -36,7 +45,7 @@ func TestEnterWouldSubmitForeignDraft_EmptyAndGhostComposersAreSafe(t *testing.T
 		"grey 90":   fixtureGreyBrightBlackComposer,
 		"grey 256":  fixtureGrey256Composer,
 	} {
-		if EnterWouldSubmitForeignDraft(pane(fixture), stripANSI, "our automated message") {
+		if attrib().EnterWouldSubmitForeignDraft(Captured(pane(fixture)), stripANSI) {
 			t.Fatalf("%s composer must not block a nudge — Enter submits nothing", name)
 		}
 	}
@@ -45,26 +54,35 @@ func TestEnterWouldSubmitForeignDraft_EmptyAndGhostComposersAreSafe(t *testing.T
 func TestEnterWouldSubmitForeignDraft_NoComposerIsSafe(t *testing.T) {
 	// Panes without composer introspection (codex/cursor) keep their existing
 	// bounded blind-Enter behavior.
-	if EnterWouldSubmitForeignDraft("codex>\nplain output\n", stripANSI, "msg") {
+	if attrib().EnterWouldSubmitForeignDraft(Captured("codex>\nplain output\n"), stripANSI) {
 		t.Fatal("a pane without a composer must not block the nudge paths")
 	}
 }
 
-// Issue #1777 follow-up: the pasted-text branch of the send-verify loops used
-// to bypass the gate entirely — a whole-pane "[pasted text" match short-
-// circuited it to false and pressed Enter unconditionally. Claude collapses a
-// bulk paste behind that marker, so the composer body cannot be matched
-// against our payload by content; attribution is by provenance instead.
+func TestEnterWouldSubmitForeignDraft_FailedCaptureBlocksEnter(t *testing.T) {
+	// A pane that could not be read yields NO evidence about what an Enter
+	// would submit — the opposite of a pane positively observed to have no
+	// composer. Pressing blind is the unrecoverable direction.
+	if !attrib().EnterWouldSubmitForeignDraft(PaneCapture{}, stripANSI) {
+		t.Fatal("an unreadable pane must block the nudge")
+	}
+	if !attrib().EnterWouldSubmitForeignDraft(CaptureOutcome(pane(fixtureEmptyComposer), errPaneGone), stripANSI) {
+		t.Fatal("CaptureOutcome must discard content from a failed capture")
+	}
+}
+
+// The pasted-text branch of the send-verify loops used to bypass the gate
+// entirely: a whole-pane "[pasted text" match short-circuited it to false and
+// pressed Enter unconditionally. Claude collapses a bulk paste behind that
+// marker, so the composer body cannot be matched against our payload by
+// content; attribution is by provenance instead.
 
 func TestEnterWouldSubmitForeignDraft_ForeignPasteMarkerBlocksEnter(t *testing.T) {
 	// No pre-send evidence: the marker may be a paste the operator (or
 	// anything else) parked in the composer, so Enter must be withheld.
 	composer := "\x1b[39m❯ [Pasted text #1 +89 lines]"
-	if !EnterWouldSubmitForeignDraft(pane(composer), stripANSI, "our automated message") {
+	if !attrib().EnterWouldSubmitForeignDraft(Captured(pane(composer)), stripANSI) {
 		t.Fatal("a composer paste marker with no provenance evidence must block a bare Enter")
-	}
-	if !(EnterAttribution{Message: "our automated message"}).EnterWouldSubmitForeignDraft(pane(composer), stripANSI) {
-		t.Fatal("EnterAttribution zero value must fail safe on a composer paste marker")
 	}
 }
 
@@ -72,8 +90,8 @@ func TestEnterWouldSubmitForeignDraft_OwnPasteMarkerIsAttributable(t *testing.T)
 	// The sender observed an unmarked composer immediately before typing, so
 	// the marker is the collapsed form of its own payload: the recovery Enter
 	// for a swallowed submit must still fire.
-	attrib := EnterAttribution{Message: "a very long automated message", OwnPasteMarker: true}
-	if attrib.EnterWouldSubmitForeignDraft(pane("\x1b[39m❯ [Pasted text #1 +89 lines]"), stripANSI) {
+	a := EnterAttribution{Message: "a very long automated payload", OwnPasteMarker: true}
+	if a.EnterWouldSubmitForeignDraft(Captured(pane("\x1b[39m❯ [Pasted text #1 +89 lines]")), stripANSI) {
 		t.Fatal("a paste marker created by our own send must not block the recovery Enter")
 	}
 }
@@ -81,8 +99,8 @@ func TestEnterWouldSubmitForeignDraft_OwnPasteMarkerIsAttributable(t *testing.T)
 func TestEnterWouldSubmitForeignDraft_OwnPasteEvidenceDoesNotExcuseTypedForeignText(t *testing.T) {
 	// Provenance evidence is scoped to the paste marker only: a materialized
 	// suggestion sitting in the composer stays blocked.
-	attrib := EnterAttribution{Message: "our automated message", OwnPasteMarker: true}
-	if !attrib.EnterWouldSubmitForeignDraft(pane(fixtureMaterializedComposer), stripANSI) {
+	a := EnterAttribution{Message: attribMessage, OwnPasteMarker: true}
+	if !a.EnterWouldSubmitForeignDraft(Captured(pane(fixtureMaterializedComposer)), stripANSI) {
 		t.Fatal("paste provenance must not unblock non-paste foreign composer content")
 	}
 }
@@ -99,8 +117,10 @@ func TestComposerHoldsPasteMarker_IsComposerScopedNotWholePane(t *testing.T) {
 	if !ComposerHoldsPasteMarker(pane("\x1b[39m❯ [Pasted text #2 +12 lines]"), stripANSI) {
 		t.Fatal("a paste marker in the visible composer must be reported")
 	}
-	if !HasUnsentPastedPrompt(stripANSI(raw)) {
-		t.Fatal("fixture guard: the whole-pane check is expected to match here — that is the imprecision being avoided")
+	// With no composer to scope the check to, the whole-pane match is the
+	// fallback: an unscopable marker yields no usable provenance.
+	if !ComposerHoldsPasteMarker("plain output\n[Pasted text #3 +4 lines]\n", stripANSI) {
+		t.Fatal("without a composer, paste text anywhere must deny provenance")
 	}
 }
 
@@ -108,17 +128,19 @@ func TestNudgeEnter_PressesOnlyWhenAttributable(t *testing.T) {
 	presses := 0
 	presser := enterPresserFunc(func() error { presses++; return nil })
 
-	attrib := EnterAttribution{Message: "our automated message"}
-	if attrib.NudgeEnter(presser, pane(fixtureMaterializedComposer), stripANSI) {
+	if attrib().NudgeEnter(presser, Captured(pane(fixtureMaterializedComposer)), stripANSI) {
 		t.Fatal("NudgeEnter must not press into foreign composer content")
 	}
-	if attrib.NudgeEnter(presser, pane("\x1b[39m❯ [Pasted text #1 +89 lines]"), stripANSI) {
+	if attrib().NudgeEnter(presser, Captured(pane("\x1b[39m❯ [Pasted text #1 +89 lines]")), stripANSI) {
 		t.Fatal("NudgeEnter must not press into an unattributable paste marker")
+	}
+	if attrib().NudgeEnter(presser, PaneCapture{}, stripANSI) {
+		t.Fatal("NudgeEnter must not press on an unreadable pane")
 	}
 	if presses != 0 {
 		t.Fatalf("expected no Enter presses, got %d", presses)
 	}
-	if !attrib.NudgeEnter(presser, pane(fixtureEmptyComposer), stripANSI) || presses != 1 {
+	if !attrib().NudgeEnter(presser, Captured(pane(fixtureEmptyComposer)), stripANSI) || presses != 1 {
 		t.Fatalf("NudgeEnter must press when the composer is empty (presses=%d)", presses)
 	}
 }

--- a/internal/send/attribution_test.go
+++ b/internal/send/attribution_test.go
@@ -1,0 +1,51 @@
+package send
+
+import "testing"
+
+// Issue #1777: EnterWouldSubmitForeignDraft is the attribution gate every bare
+// Enter nudge must consult. Fixtures shared with suggestion_test.go.
+
+func TestEnterWouldSubmitForeignDraft_MaterializedSuggestionBlocksEnter(t *testing.T) {
+	// The defect case: a suggestion materialized as real, normal-coloured
+	// (\e[39m) unsubmitted input. agent-deck did not place it there, so a
+	// bare Enter would submit an instruction nobody authored.
+	if !EnterWouldSubmitForeignDraft(pane(fixtureMaterializedComposer), stripANSI, "our automated message") {
+		t.Fatal("normal-coloured foreign composer content must block a bare Enter")
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_OperatorDraftBlocksEnter(t *testing.T) {
+	if !EnterWouldSubmitForeignDraft(pane(fixtureRealDraftComposer), stripANSI, "our automated message") {
+		t.Fatal("an operator draft must block a bare Enter")
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_OwnMessageIsAttributable(t *testing.T) {
+	// The composer holding the payload agent-deck itself typed is exactly the
+	// state the recovery Enter exists for.
+	line := "\x1b[39m❯ our automated message"
+	if EnterWouldSubmitForeignDraft(pane(line), stripANSI, "our automated message") {
+		t.Fatal("agent-deck's own parked message must not block the recovery Enter")
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_EmptyAndGhostComposersAreSafe(t *testing.T) {
+	for name, fixture := range map[string]string{
+		"empty":     fixtureEmptyComposer,
+		"dim ghost": fixtureGhostComposer,
+		"grey 90":   fixtureGreyBrightBlackComposer,
+		"grey 256":  fixtureGrey256Composer,
+	} {
+		if EnterWouldSubmitForeignDraft(pane(fixture), stripANSI, "our automated message") {
+			t.Fatalf("%s composer must not block a nudge — Enter submits nothing", name)
+		}
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_NoComposerIsSafe(t *testing.T) {
+	// Panes without composer introspection (codex/cursor) keep their existing
+	// bounded blind-Enter behavior.
+	if EnterWouldSubmitForeignDraft("codex>\nplain output\n", stripANSI, "msg") {
+		t.Fatal("a pane without a composer must not block the nudge paths")
+	}
+}

--- a/internal/send/attribution_test.go
+++ b/internal/send/attribution_test.go
@@ -49,3 +49,80 @@ func TestEnterWouldSubmitForeignDraft_NoComposerIsSafe(t *testing.T) {
 		t.Fatal("a pane without a composer must not block the nudge paths")
 	}
 }
+
+// Issue #1777 follow-up: the pasted-text branch of the send-verify loops used
+// to bypass the gate entirely — a whole-pane "[pasted text" match short-
+// circuited it to false and pressed Enter unconditionally. Claude collapses a
+// bulk paste behind that marker, so the composer body cannot be matched
+// against our payload by content; attribution is by provenance instead.
+
+func TestEnterWouldSubmitForeignDraft_ForeignPasteMarkerBlocksEnter(t *testing.T) {
+	// No pre-send evidence: the marker may be a paste the operator (or
+	// anything else) parked in the composer, so Enter must be withheld.
+	composer := "\x1b[39m❯ [Pasted text #1 +89 lines]"
+	if !EnterWouldSubmitForeignDraft(pane(composer), stripANSI, "our automated message") {
+		t.Fatal("a composer paste marker with no provenance evidence must block a bare Enter")
+	}
+	if !(EnterAttribution{Message: "our automated message"}).EnterWouldSubmitForeignDraft(pane(composer), stripANSI) {
+		t.Fatal("EnterAttribution zero value must fail safe on a composer paste marker")
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_OwnPasteMarkerIsAttributable(t *testing.T) {
+	// The sender observed an unmarked composer immediately before typing, so
+	// the marker is the collapsed form of its own payload: the recovery Enter
+	// for a swallowed submit must still fire.
+	attrib := EnterAttribution{Message: "a very long automated message", OwnPasteMarker: true}
+	if attrib.EnterWouldSubmitForeignDraft(pane("\x1b[39m❯ [Pasted text #1 +89 lines]"), stripANSI) {
+		t.Fatal("a paste marker created by our own send must not block the recovery Enter")
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_OwnPasteEvidenceDoesNotExcuseTypedForeignText(t *testing.T) {
+	// Provenance evidence is scoped to the paste marker only: a materialized
+	// suggestion sitting in the composer stays blocked.
+	attrib := EnterAttribution{Message: "our automated message", OwnPasteMarker: true}
+	if !attrib.EnterWouldSubmitForeignDraft(pane(fixtureMaterializedComposer), stripANSI) {
+		t.Fatal("paste provenance must not unblock non-paste foreign composer content")
+	}
+}
+
+func TestComposerHoldsPasteMarker_IsComposerScopedNotWholePane(t *testing.T) {
+	// A marker in submitted scrollback is history, not a parked draft: it must
+	// not poison the pre-send provenance probe (that would permanently disable
+	// nudges for panes that ever received a large paste).
+	history := "\x1b[38;5;239m\x1b[48;5;237m❯ \x1b[38;5;231m[Pasted text #1 +89 lines]\x1b[39m"
+	raw := "some prior output\n" + history + "\n\x1b[39m❯ "
+	if ComposerHoldsPasteMarker(raw, stripANSI) {
+		t.Fatal("a paste marker in scrollback must not count as a parked composer marker")
+	}
+	if !ComposerHoldsPasteMarker(pane("\x1b[39m❯ [Pasted text #2 +12 lines]"), stripANSI) {
+		t.Fatal("a paste marker in the visible composer must be reported")
+	}
+	if !HasUnsentPastedPrompt(stripANSI(raw)) {
+		t.Fatal("fixture guard: the whole-pane check is expected to match here — that is the imprecision being avoided")
+	}
+}
+
+func TestNudgeEnter_PressesOnlyWhenAttributable(t *testing.T) {
+	presses := 0
+	presser := enterPresserFunc(func() error { presses++; return nil })
+
+	attrib := EnterAttribution{Message: "our automated message"}
+	if attrib.NudgeEnter(presser, pane(fixtureMaterializedComposer), stripANSI) {
+		t.Fatal("NudgeEnter must not press into foreign composer content")
+	}
+	if attrib.NudgeEnter(presser, pane("\x1b[39m❯ [Pasted text #1 +89 lines]"), stripANSI) {
+		t.Fatal("NudgeEnter must not press into an unattributable paste marker")
+	}
+	if presses != 0 {
+		t.Fatalf("expected no Enter presses, got %d", presses)
+	}
+	if !attrib.NudgeEnter(presser, pane(fixtureEmptyComposer), stripANSI) || presses != 1 {
+		t.Fatalf("NudgeEnter must press when the composer is empty (presses=%d)", presses)
+	}
+}
+
+type enterPresserFunc func() error
+
+func (f enterPresserFunc) SendEnter() error { return f() }

--- a/internal/send/attribution_test.go
+++ b/internal/send/attribution_test.go
@@ -38,6 +38,29 @@ func TestEnterWouldSubmitForeignDraft_OwnMessageIsAttributable(t *testing.T) {
 	}
 }
 
+// #1778 review finding 1 (codex, round 2): composerBodyIsOurMessage's own
+// doc comment claims a foreign autosuggestion "continue the refactor and
+// delete the stale worktrees" must not be classified as attributable just
+// because it contains the short message "continue" — but the unbounded
+// strings.HasPrefix(promptBody, msg) check made exactly that claim false.
+func TestEnterWouldSubmitForeignDraft_ShortMessagePrefixOfLongForeignDraftBlocksEnter(t *testing.T) {
+	a := EnterAttribution{Message: "continue"}
+	composer := "\x1b[39m❯ continue the refactor and delete the stale worktrees"
+	if !a.EnterWouldSubmitForeignDraft(Captured(pane(composer)), stripANSI) {
+		t.Fatal("a foreign draft that merely starts with our short message must block a bare Enter")
+	}
+}
+
+func TestEnterWouldSubmitForeignDraft_OwnMessagePlusShortTerminalEchoIsAttributable(t *testing.T) {
+	// A cursor glyph or a stray padding character the terminal appends after
+	// our own message verbatim must not defeat the recovery Enter.
+	a := EnterAttribution{Message: attribMessage}
+	composer := "\x1b[39m❯ " + attribMessage + " "
+	if a.EnterWouldSubmitForeignDraft(Captured(pane(composer)), stripANSI) {
+		t.Fatal("our own message plus a short terminal-echoed trailer must not block the recovery Enter")
+	}
+}
+
 func TestEnterWouldSubmitForeignDraft_EmptyAndGhostComposersAreSafe(t *testing.T) {
 	for name, fixture := range map[string]string{
 		"empty":     fixtureEmptyComposer,

--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -124,6 +124,29 @@ const maxComposerClearAttempts = 2
 // settle is enough for the attribute to land before re-classification.
 const saveReconfirmDelay = 50 * time.Millisecond
 
+// composerProvenanceFree reports whether raw is safe pre-send evidence that
+// no foreign paste marker is parked in the composer — the same guarantee
+// ComposerPasteMarkerFree promises callers (issue #1777 provenance).
+//
+// A VISIBLE, EMPTY composer proves it directly. An UNSCOPABLE pane
+// (!visible — codex/cursor, or a transiently unreadable Claude pane) must
+// NOT be folded into that case: ComposerHoldsPasteMarker makes the OPPOSITE
+// call on purpose for !visible, falling back to a whole-pane scan, because
+// "no composer to scope to" yields no usable provenance on its own. Before
+// this fix GuardComposerDraft (the producer for the highest-volume send
+// path) granted provenance on any !visible read regardless, disagreeing
+// with ComposerHoldsPasteMarker on the identical pane state and letting a
+// foreign marker that renders later be misattributed as ours (#1778 review
+// finding 2). Mirror ComposerHoldsPasteMarker's choice here so the two
+// producers of this evidence never disagree.
+func composerProvenanceFree(raw string, strip func(string) string) bool {
+	draft, visible := ComposerDraft(raw, strip)
+	if visible {
+		return draft == ""
+	}
+	return !ComposerHoldsPasteMarker(raw, strip)
+}
+
 // GuardComposerDraft implements the composer-collision guard for automated
 // sends (issue #1409): an automated SendKeysAndEnter against a composer that
 // already holds half-typed operator input would merge with it and submit the
@@ -158,10 +181,7 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 			// Pane not introspectable: never block delivery on it.
 			return ComposerGuardResult{Held: time.Since(start)}
 		}
-		draft, visible := ComposerDraft(raw, strip)
-		if !visible || draft == "" {
-			// Composer empty, suggestion or absent: no parked paste marker,
-			// so a marker seen after the send belongs to our own paste.
+		if composerProvenanceFree(raw, strip) {
 			return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
 		}
 		if !time.Now().Before(deadline) {
@@ -189,10 +209,10 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 	if err != nil {
 		return ComposerGuardResult{Held: time.Since(start)}
 	}
-	draft, visible := ComposerDraft(raw, strip)
-	if !visible || draft == "" {
+	if composerProvenanceFree(raw, strip) {
 		return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
 	}
+	draft, _ := ComposerDraft(raw, strip)
 
 	// Save the confirmed operator draft and clear the composer so the
 	// automated message cannot merge with it.

--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -212,7 +212,15 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 	if composerProvenanceFree(raw, strip) {
 		return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
 	}
-	draft, _ := ComposerDraft(raw, strip)
+	draft, visible := ComposerDraft(raw, strip)
+	if !visible {
+		// No introspectable composer, yet the pane still shows a foreign
+		// paste-marker pattern: provenance cannot be established and there
+		// is no composer to clear. Fail safe without a blind Ctrl+C (#1778
+		// review finding 1) rather than falling through into the save-clear
+		// flow with an empty draft.
+		return ComposerGuardResult{Held: time.Since(start)}
+	}
 
 	// Save the confirmed operator draft and clear the composer so the
 	// automated message cannot merge with it.
@@ -228,7 +236,15 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 		clearDeadline := time.Now().Add(opts.ClearWait)
 		for {
 			raw, err := t.CapturePaneFresh()
-			if err == nil && !ComposerHasDraft(raw, strip) {
+			// Require a POSITIVELY visible, empty composer before granting
+			// ComposerPasteMarkerFree: a capture that comes back !visible
+			// (transiently unreadable pane, dialog, etc.) is not evidence the
+			// clear succeeded, so it must not be folded into "cleared" (#1778
+			// review finding 2 — ComposerHasDraft is false for !visible too,
+			// which previously let this branch grant provenance it never
+			// established).
+			clearedDraft, clearedVisible := ComposerDraft(raw, strip)
+			if err == nil && clearedVisible && clearedDraft == "" {
 				res.DraftCleared = true
 				// The composer is confirmed empty right before the send, so
 				// any paste marker appearing afterwards is our own (#1777).

--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -141,7 +141,6 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 
 	start := time.Now()
 	deadline := start.Add(opts.HoldWait)
-	lastDraft := ""
 
 	for {
 		raw, err := t.CapturePaneFresh()
@@ -153,7 +152,6 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 		if !visible || draft == "" {
 			return ComposerGuardResult{Held: time.Since(start)}
 		}
-		lastDraft = draft
 		if !time.Now().Before(deadline) {
 			break
 		}
@@ -183,11 +181,10 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 	if !visible || draft == "" {
 		return ComposerGuardResult{Held: time.Since(start)}
 	}
-	lastDraft = draft
 
 	// Save the confirmed operator draft and clear the composer so the
 	// automated message cannot merge with it.
-	res := ComposerGuardResult{SavedDraft: lastDraft}
+	res := ComposerGuardResult{SavedDraft: draft}
 	clearPoll := poll
 	if clearPoll > 100*time.Millisecond {
 		clearPoll = 100 * time.Millisecond

--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -108,6 +108,12 @@ type ComposerGuardResult struct {
 // maxComposerClearAttempts bounds Ctrl+C attempts during save-clear.
 const maxComposerClearAttempts = 2
 
+// saveReconfirmDelay is the settle time before the save-step re-capture. A
+// suggestion sampled in the sub-frame where its text is painted but the dim
+// SGR has not landed reads as an operator draft (issue #1777); one frame of
+// settle is enough for the attribute to land before re-classification.
+const saveReconfirmDelay = 50 * time.Millisecond
+
 // GuardComposerDraft implements the composer-collision guard for automated
 // sends (issue #1409): an automated SendKeysAndEnter against a composer that
 // already holds half-typed operator input would merge with it and submit the
@@ -160,8 +166,27 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 		}
 	}
 
-	// Hold bound reached with the operator draft still present: save it and
-	// clear the composer so the automated message cannot merge with it.
+	// Hold bound reached with the operator draft still present. Before
+	// committing to save-clear-restore, re-capture and re-classify: a single
+	// mid-render sample can show suggestion text whose dim/grey SGR has not
+	// landed yet, and saving it would later RESTORE the suggestion as real,
+	// normal-coloured composer text that a bare Enter could submit (issue
+	// #1777). Only content that classifies as an operator draft on a second,
+	// settled capture is ever saved. On a capture failure nothing is saved —
+	// the guard must not attribute content it cannot re-read.
+	time.Sleep(saveReconfirmDelay)
+	raw, err := t.CapturePaneFresh()
+	if err != nil {
+		return ComposerGuardResult{Held: time.Since(start)}
+	}
+	draft, visible := ComposerDraft(raw, strip)
+	if !visible || draft == "" {
+		return ComposerGuardResult{Held: time.Since(start)}
+	}
+	lastDraft = draft
+
+	// Save the confirmed operator draft and clear the composer so the
+	// automated message cannot merge with it.
 	res := ComposerGuardResult{SavedDraft: lastDraft}
 	clearPoll := poll
 	if clearPoll > 100*time.Millisecond {

--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -103,6 +103,16 @@ type ComposerGuardResult struct {
 	// regardless (delivery must not be dropped), accepting the residual
 	// merge risk for this pathological case.
 	ClearFailed bool
+	// ComposerPasteMarkerFree is true when the guard's LAST successful
+	// capture showed a composer holding no "[Pasted text …]" marker. It is
+	// the pre-send provenance evidence the attribution gate needs to tell
+	// agent-deck's own collapsed paste apart from a foreign one parked in the
+	// composer (issue #1777): with no marker there before the send, a marker
+	// seen afterwards can only be the one our own paste created. False
+	// whenever the guard could not establish that (capture failure, or a
+	// marker still present), which fails safe — the gate then withholds the
+	// Enter nudge.
+	ComposerPasteMarkerFree bool
 }
 
 // maxComposerClearAttempts bounds Ctrl+C attempts during save-clear.
@@ -150,7 +160,9 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 		}
 		draft, visible := ComposerDraft(raw, strip)
 		if !visible || draft == "" {
-			return ComposerGuardResult{Held: time.Since(start)}
+			// Composer empty, suggestion or absent: no parked paste marker,
+			// so a marker seen after the send belongs to our own paste.
+			return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
 		}
 		if !time.Now().Before(deadline) {
 			break
@@ -179,7 +191,7 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 	}
 	draft, visible := ComposerDraft(raw, strip)
 	if !visible || draft == "" {
-		return ComposerGuardResult{Held: time.Since(start)}
+		return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
 	}
 
 	// Save the confirmed operator draft and clear the composer so the
@@ -198,6 +210,9 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 			raw, err := t.CapturePaneFresh()
 			if err == nil && !ComposerHasDraft(raw, strip) {
 				res.DraftCleared = true
+				// The composer is confirmed empty right before the send, so
+				// any paste marker appearing afterwards is our own (#1777).
+				res.ComposerPasteMarkerFree = true
 				res.Held = time.Since(start)
 				return res
 			}

--- a/internal/send/guard_test.go
+++ b/internal/send/guard_test.go
@@ -216,3 +216,32 @@ func TestGuardComposerDraft_StripIsApplied(t *testing.T) {
 		t.Fatalf("expected stripped empty composer to pass through, got %+v", res)
 	}
 }
+
+// Issue #1777: the guard's last pre-send observation is the provenance
+// evidence the attribution gate uses to tell agent-deck's own collapsed paste
+// from a foreign one parked in the composer.
+func TestGuardComposerDraft_ReportsComposerPasteMarkerFree(t *testing.T) {
+	empty := &fakeGuardTarget{captures: []string{renderComposer("")}}
+	if res := GuardComposerDraft(empty, ComposerGuardOptions{
+		HoldWait: time.Second, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+	}); !res.ComposerPasteMarkerFree {
+		t.Fatal("an empty composer before the send means a later paste marker is ours")
+	}
+
+	parked := &fakeGuardTarget{
+		captures: []string{renderComposer("[Pasted text #1 +89 lines]")},
+		ctrlCErr: errors.New("ctrl-c failed"),
+	}
+	if res := GuardComposerDraft(parked, ComposerGuardOptions{
+		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+	}); res.ComposerPasteMarkerFree {
+		t.Fatal("a paste marker still parked in the composer must not be reported as clear")
+	}
+
+	broken := &fakeGuardTarget{captureErr: errors.New("pane gone")}
+	if res := GuardComposerDraft(broken, ComposerGuardOptions{
+		HoldWait: time.Second, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+	}); res.ComposerPasteMarkerFree {
+		t.Fatal("a capture failure yields no provenance evidence; must fail safe")
+	}
+}

--- a/internal/send/guard_test.go
+++ b/internal/send/guard_test.go
@@ -245,3 +245,27 @@ func TestGuardComposerDraft_ReportsComposerPasteMarkerFree(t *testing.T) {
 		t.Fatal("a capture failure yields no provenance evidence; must fail safe")
 	}
 }
+
+// #1778 review findings 1+2: a non-introspectable pane (no ❯ composer to
+// scope to — codex/cursor, or a transiently unreadable Claude pane) that
+// still shows a foreign "[Pasted text ...]" marker anywhere in the whole-pane
+// scan must be held with NO Ctrl+C attempt and must NOT be reported as
+// ComposerPasteMarkerFree. Before the fix, the save-clear path discarded the
+// visible bit from ComposerDraft, sent a blind Ctrl+C into a pane it never
+// confirmed had a composer, and then granted ComposerPasteMarkerFree because
+// ComposerHasDraft is trivially false for !visible.
+func TestGuardComposerDraft_NonIntrospectablePaneWithForeignMarkerNeverClears(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{"codex>\n[Pasted text #1 +42 lines]\nplain output\n"}}
+	res := GuardComposerDraft(target, ComposerGuardOptions{
+		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+	})
+	if target.ctrlCCalls != 0 {
+		t.Fatalf("must not Ctrl+C a pane with no introspectable composer, got %d calls", target.ctrlCCalls)
+	}
+	if res.ComposerPasteMarkerFree {
+		t.Fatal("provenance cannot be established on a non-introspectable pane; must fail safe")
+	}
+	if res.DraftCleared || res.SavedDraft != "" {
+		t.Fatalf("nothing to save or clear on a non-introspectable pane, got %+v", res)
+	}
+}

--- a/internal/send/suggestion.go
+++ b/internal/send/suggestion.go
@@ -42,45 +42,85 @@ func composerMarkerBody(line string) (string, bool) {
 	return "", false
 }
 
-// applySGR folds one SGR parameter list into the running dim state.
+// sgrState is the running rendering state a suggestion can hide behind.
+// Claude (or a terminal profile) renders the ghost either with the SGR
+// dim/faint attribute or in bright-black/256-colour grey — issue #1777
+// documented fleets where the same suggestion arrived as `\e[90m` /
+// `\e[38;5;8m` instead of `\e[2m`, defeating a dim-only check.
+type sgrState struct {
+	dim  bool // SGR 2 (faint)
+	grey bool // bright-black foreground: SGR 90 or 38;5;8
+}
+
+// applySGR folds one SGR parameter list into the running suggestion-rendering
+// state.
 //
 // Extended-colour introducers (38/48/58) consume their own parameters —
 // `38;5;2` is colour index 2, NOT the dim attribute — so they are skipped
 // explicitly. Without that, the bright-white `38;5;231` Claude uses for
-// submitted messages would be misread.
-func applySGR(params string, dim *bool) {
+// submitted messages would be misread. A 38-introduced foreground REPLACES
+// the previous foreground, so it sets or clears grey; any direct foreground
+// parameter (30-37, 39, 91-97) likewise clears it.
+func applySGR(params string, st *sgrState) {
 	if params == "" {
 		// A bare CSI m is an implicit reset.
-		*dim = false
+		*st = sgrState{}
 		return
 	}
 	parts := strings.Split(params, ";")
 	for i := 0; i < len(parts); i++ {
-		switch strings.TrimSpace(parts[i]) {
+		p := strings.TrimSpace(parts[i])
+		switch p {
 		case "38", "48", "58":
 			if i+1 < len(parts) {
 				switch strings.TrimSpace(parts[i+1]) {
 				case "5":
+					if p == "38" {
+						st.grey = i+2 < len(parts) && strings.TrimSpace(parts[i+2]) == "8"
+					}
 					i += 2 // 5;n
 				case "2":
+					if p == "38" {
+						st.grey = false
+					}
 					i += 4 // 2;r;g;b
 				default:
 					i++
 				}
 			}
 		case "2":
-			*dim = true
-		case "0", "00", "22":
-			*dim = false
+			st.dim = true
+		case "0", "00":
+			*st = sgrState{}
+		case "22":
+			st.dim = false
+		case "90":
+			st.grey = true
+		default:
+			if isForegroundColourParam(p) {
+				st.grey = false
+			}
 		}
 	}
 }
 
+// isForegroundColourParam reports whether p sets the foreground colour
+// directly (classic 30-37, default 39, bright non-black 91-97).
+func isForegroundColourParam(p string) bool {
+	switch p {
+	case "30", "31", "32", "33", "34", "35", "36", "37", "39",
+		"91", "92", "93", "94", "95", "96", "97":
+		return true
+	}
+	return false
+}
+
 // bodyStartsDim reports whether the first visible (non-whitespace) character
-// in an ANSI-bearing composer body is rendered dim. Returns false when the
-// body holds no visible character at all (an empty composer).
+// in an ANSI-bearing composer body is rendered in a suggestion style — dim,
+// or bright-black grey (issue #1777). Returns false when the body holds no
+// visible character at all (an empty composer).
 func bodyStartsDim(s string) bool {
-	dim := false
+	var st sgrState
 	for i := 0; i < len(s); {
 		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
 			j := i + 2
@@ -89,7 +129,7 @@ func bodyStartsDim(s string) bool {
 			}
 			if j < len(s) {
 				if s[j] == 'm' {
-					applySGR(s[i+2:j], &dim)
+					applySGR(s[i+2:j], &st)
 				}
 				i = j + 1
 				continue
@@ -98,7 +138,7 @@ func bodyStartsDim(s string) bool {
 		}
 		r, size := utf8.DecodeRuneInString(s[i:])
 		if !isComposerSpace(r) {
-			return dim
+			return st.dim || st.grey
 		}
 		i += size
 	}
@@ -116,8 +156,8 @@ func isComposerSpace(r rune) bool {
 }
 
 // ComposerBodyIsSuggestion reports whether the composer in raw (ANSI-bearing)
-// pane content currently shows a dim-rendered Claude autosuggestion rather
-// than operator input. The composer is the LAST marker line in the pane;
+// pane content currently shows a dim- or grey-rendered Claude autosuggestion
+// rather than operator input. The composer is the LAST marker line in the pane;
 // earlier marker lines are submitted history.
 func ComposerBodyIsSuggestion(raw string) bool {
 	lines := strings.Split(raw, "\n")

--- a/internal/send/suggestion_test.go
+++ b/internal/send/suggestion_test.go
@@ -162,3 +162,127 @@ func TestGuardComposerDraft_StillGuardsRealDraftWithANSI(t *testing.T) {
 		t.Fatal("expected Ctrl+C for a real operator draft")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1777 — the inverse gap: suggestions that render normal-coloured, and
+// suggestions rendered grey instead of dim. Composer lines below mirror the
+// reporter's `tmux capture-pane -e -p` evidence.
+// ---------------------------------------------------------------------------
+
+const (
+	// Suggestion rendered bright-black (SGR 90) instead of dim — a Claude
+	// build / terminal profile rendering the ghost in grey defeats a
+	// dim-only check.
+	fixtureGreyBrightBlackComposer = "\x1b[39m❯ \x1b[90mupgrade agent-deck on carrollton and archive the five error sessions\x1b[0m"
+
+	// Same ghost via 256-colour grey (colour index 8, bright black).
+	fixtureGrey256Composer = "\x1b[39m❯ \x1b[38;5;8mprune the stale cluster\x1b[0m"
+
+	// A suggestion that MATERIALIZED as real, normal-coloured (\e[39m)
+	// unsubmitted input — the #1777 defect case. Colour alone cannot prove
+	// this is not an operator draft, so it must be treated as one for
+	// guard purposes but must NEVER be submitted by a bare Enter.
+	fixtureMaterializedComposer = "\x1b[39m❯ wrap up the session — anything left uncommitted?"
+)
+
+func TestComposerBodyIsSuggestion_GreyBrightBlackIsDetected(t *testing.T) {
+	if !ComposerBodyIsSuggestion(pane(fixtureGreyBrightBlackComposer)) {
+		t.Fatal("SGR 90 (bright-black) autosuggestion must be detected as a suggestion")
+	}
+}
+
+func TestComposerBodyIsSuggestion_Grey256IsDetected(t *testing.T) {
+	if !ComposerBodyIsSuggestion(pane(fixtureGrey256Composer)) {
+		t.Fatal("38;5;8 (256-colour grey) autosuggestion must be detected as a suggestion")
+	}
+}
+
+// Grey reset back to the default foreground before the body means the body is
+// real input, not a ghost.
+func TestComposerBodyIsSuggestion_GreyResetBeforeBodyIsNotASuggestion(t *testing.T) {
+	line := "\x1b[90m❯ \x1b[39mreal typed text after grey marker"
+	if ComposerBodyIsSuggestion(pane(line)) {
+		t.Fatal("SGR 39 resets the foreground; body must read as real input")
+	}
+}
+
+// A non-grey 256-colour foreground must not be classified as a ghost.
+func TestComposerBodyIsSuggestion_NonGrey256IsNotASuggestion(t *testing.T) {
+	line := "\x1b[39m❯ \x1b[38;5;231mbright white typed text"
+	if ComposerBodyIsSuggestion(pane(line)) {
+		t.Fatal("38;5;231 is bright white, not the suggestion grey")
+	}
+}
+
+func TestComposerDraft_GreyGhostsYieldNoDraft(t *testing.T) {
+	for _, fixture := range []string{fixtureGreyBrightBlackComposer, fixtureGrey256Composer} {
+		draft, visible := ComposerDraft(pane(fixture), stripANSI)
+		if !visible {
+			t.Fatal("expected the composer to be visible")
+		}
+		if draft != "" {
+			t.Fatalf("grey autosuggestion must yield an empty draft, got %q", draft)
+		}
+	}
+}
+
+// Grey ghosts must pass straight through the guard exactly like dim ones:
+// no SavedDraft (it would be retyped back as real committable text).
+func TestGuardComposerDraft_IgnoresGreyAutosuggestion(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{pane(fixtureGreyBrightBlackComposer)}}
+	res := GuardComposerDraft(target, ComposerGuardOptions{
+		HoldWait: time.Second, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+		Strip: stripANSI,
+	})
+	if res.SavedDraft != "" {
+		t.Fatalf("grey autosuggestion must never be saved as a draft, got %q", res.SavedDraft)
+	}
+	if target.ctrlCCalls != 0 {
+		t.Fatalf("must not Ctrl+C for a grey autosuggestion, got %d calls", target.ctrlCCalls)
+	}
+}
+
+// The #1777 capture race: the hold-bound sample catches the suggestion in the
+// sub-frame where its text is painted but the dim SGR has not landed, so it
+// reads as an operator draft. The guard must re-capture before saving; the
+// settled capture shows the dim attribute and nothing may be saved — a saved
+// "draft" here is what executeSend later types back as real, normal-coloured
+// stranded text that a bare Enter would submit.
+func TestGuardComposerDraft_MidRenderSuggestionIsNotSaved(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{
+		pane(fixtureMaterializedComposer), // mid-render: no dim SGR yet
+		pane("\x1b[39m❯ \x1b[2mwrap up the session — anything left uncommitted?\x1b[0m"),
+	}}
+	res := GuardComposerDraft(target, ComposerGuardOptions{
+		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
+		Strip: stripANSI,
+	})
+	if res.SavedDraft != "" {
+		t.Fatalf("mid-render suggestion must not be saved (it would be restored as real text), got %q", res.SavedDraft)
+	}
+	if target.ctrlCCalls != 0 {
+		t.Fatalf("must not Ctrl+C when the re-capture reclassifies the content, got %d calls", target.ctrlCCalls)
+	}
+	if target.captureCalls != 2 {
+		t.Fatalf("expected the save step to re-capture (2 captures), got %d", target.captureCalls)
+	}
+}
+
+// The save-step re-capture must not weaken #1409: a REAL draft that is still
+// present on the second capture is saved and cleared exactly as before.
+func TestGuardComposerDraft_ReconfirmStillSavesRealDraft(t *testing.T) {
+	target := &fakeGuardTarget{
+		captures:     []string{pane(fixtureRealDraftComposer)},
+		clearOnCtrlC: true,
+	}
+	res := GuardComposerDraft(target, ComposerGuardOptions{
+		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: 50 * time.Millisecond,
+		Strip: stripANSI,
+	})
+	if res.SavedDraft != "REALDRAFT typed by a human" {
+		t.Fatalf("confirmed operator draft must still be saved, got %q", res.SavedDraft)
+	}
+	if !res.DraftCleared {
+		t.Fatalf("confirmed operator draft must still be cleared, got %+v", res)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4306,6 +4306,18 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 		return fmt.Errorf("timeout waiting for agent to be ready")
 	}
 
+	// Pre-send provenance probe for the #1777 attribution gate: Claude
+	// collapses a bulk paste behind "[Pasted text #N +M lines]", so the
+	// composer body can no longer be matched against our payload. Observing
+	// an unmarked composer immediately before typing is the evidence that a
+	// marker seen afterwards is OUR collapse and not a foreign paste parked
+	// there. A capture failure leaves it false, and the gate then withholds
+	// the nudge.
+	composerPasteFreeBeforeSend := false
+	if raw, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
+		composerPasteFreeBeforeSend = !send.ComposerHoldsPasteMarker(raw, tmux.StripANSI)
+	}
+
 	if err := i.tmuxSession.SendKeysAndEnter(message); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
@@ -4327,29 +4339,34 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 	waitingNoMarkerChecks := 0
 	activeChecks := 0
 	sawActiveAfterSend := false
+	// attrib is the #1777 attribution gate. EVERY bare Enter below —
+	// including the unsent-prompt branch, which used to press unconditionally
+	// whenever a "[Pasted text …]" marker appeared anywhere in the pane —
+	// routes through attrib.NudgeEnter, so no branch can submit composer
+	// content agent-deck cannot attribute to its own delivery.
+	attrib := send.EnterAttribution{
+		Message:        message,
+		OwnPasteMarker: composerPasteFreeBeforeSend,
+	}
 
 	for retry := 0; retry < verifyRetries; retry++ {
 		time.Sleep(verifyDelay)
 
 		unsentPromptDetected := false
-		// foreignDraftParked (issue #1777): the composer visibly holds content
-		// that is neither our message nor a suggestion/placeholder — e.g. a
-		// Claude autosuggestion materialized as real normal-coloured input.
-		// The fallback Enter nudges below must not fire then: a bare Enter
-		// would submit an instruction no operator wrote. Skipping the nudge
-		// is the safe failure (worst case the delivery stays unconfirmed).
-		foreignDraftParked := false
-		if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
-			content := tmux.StripANSI(rawContent)
+		// rawContent is this iteration's ANSI-bearing capture ("" when the
+		// capture failed), and is what the attribution gate reads.
+		rawContent := ""
+		if captured, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
+			rawContent = captured
+			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
-			foreignDraftParked = !unsentPromptDetected && send.EnterWouldSubmitForeignDraft(rawContent, tmux.StripANSI, message)
 		}
 		verifiedStatus, statusErr := i.tmuxSession.GetStatus()
 
 		if unsentPromptDetected {
 			waitingNoMarkerChecks = 0
 			activeChecks = 0
-			_ = i.tmuxSession.SendEnter()
+			attrib.NudgeEnter(i.tmuxSession, rawContent, tmux.StripANSI)
 			continue
 		}
 
@@ -4372,16 +4389,16 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 				}
 			} else {
 				waitingNoMarkerChecks = 0
-				if (retry < 5 || retry%2 == 0) && !foreignDraftParked {
-					_ = i.tmuxSession.SendEnter()
+				if retry < 5 || retry%2 == 0 {
+					attrib.NudgeEnter(i.tmuxSession, rawContent, tmux.StripANSI)
 				}
 			}
 			continue
 		}
 
 		waitingNoMarkerChecks = 0
-		if retry < 4 && !foreignDraftParked {
-			_ = i.tmuxSession.SendEnter()
+		if retry < 4 {
+			attrib.NudgeEnter(i.tmuxSession, rawContent, tmux.StripANSI)
 		}
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4332,9 +4332,17 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 		time.Sleep(verifyDelay)
 
 		unsentPromptDetected := false
+		// foreignDraftParked (issue #1777): the composer visibly holds content
+		// that is neither our message nor a suggestion/placeholder — e.g. a
+		// Claude autosuggestion materialized as real normal-coloured input.
+		// The fallback Enter nudges below must not fire then: a bare Enter
+		// would submit an instruction no operator wrote. Skipping the nudge
+		// is the safe failure (worst case the delivery stays unconfirmed).
+		foreignDraftParked := false
 		if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
 			content := tmux.StripANSI(rawContent)
 			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
+			foreignDraftParked = !unsentPromptDetected && send.EnterWouldSubmitForeignDraft(rawContent, tmux.StripANSI, message)
 		}
 		verifiedStatus, statusErr := i.tmuxSession.GetStatus()
 
@@ -4364,7 +4372,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 				}
 			} else {
 				waitingNoMarkerChecks = 0
-				if retry < 5 || retry%2 == 0 {
+				if (retry < 5 || retry%2 == 0) && !foreignDraftParked {
 					_ = i.tmuxSession.SendEnter()
 				}
 			}
@@ -4372,7 +4380,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 		}
 
 		waitingNoMarkerChecks = 0
-		if retry < 4 {
+		if retry < 4 && !foreignDraftParked {
 			_ = i.tmuxSession.SendEnter()
 		}
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4353,11 +4353,11 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 		time.Sleep(verifyDelay)
 
 		unsentPromptDetected := false
-		// rawContent is this iteration's ANSI-bearing capture ("" when the
-		// capture failed), and is what the attribution gate reads.
-		rawContent := ""
-		if captured, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
-			rawContent = captured
+		// paneNow is this iteration's observation (raw ANSI + whether the
+		// capture succeeded at all), and is what the attribution gate reads.
+		captured, captureErr := i.tmuxSession.CapturePaneFresh()
+		paneNow := send.CaptureOutcome(captured, captureErr)
+		if paneNow.OK {
 			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
 		}
@@ -4366,7 +4366,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 		if unsentPromptDetected {
 			waitingNoMarkerChecks = 0
 			activeChecks = 0
-			attrib.NudgeEnter(i.tmuxSession, rawContent, tmux.StripANSI)
+			attrib.NudgeEnter(i.tmuxSession, paneNow, tmux.StripANSI)
 			continue
 		}
 
@@ -4390,7 +4390,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 			} else {
 				waitingNoMarkerChecks = 0
 				if retry < 5 || retry%2 == 0 {
-					attrib.NudgeEnter(i.tmuxSession, rawContent, tmux.StripANSI)
+					attrib.NudgeEnter(i.tmuxSession, paneNow, tmux.StripANSI)
 				}
 			}
 			continue
@@ -4398,7 +4398,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 
 		waitingNoMarkerChecks = 0
 		if retry < 4 {
-			attrib.NudgeEnter(i.tmuxSession, rawContent, tmux.StripANSI)
+			attrib.NudgeEnter(i.tmuxSession, paneNow, tmux.StripANSI)
 		}
 	}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10294,7 +10294,10 @@ func deliverToConductorPaneTuned(p conductorPane, msg string, maxChecks int, che
 		case blindEnters < blindEnterCap:
 			// No composer introspection (e.g. codex/cursor) and not yet active.
 			// Re-press Enter a bounded number of times in case the delayed Enter
-			// was dropped, then defer to the status signal above.
+			// was dropped, then defer to the status signal above. A visible
+			// composer holding foreign content never reaches this arm — the
+			// HasCurrentComposerPrompt case above returns first — so this blind
+			// Enter cannot submit text nobody authored (#1777 audit).
 			blindEnters++
 			if err := p.SendEnter(); err != nil {
 				return fmt.Errorf("retry enter: %w", err)

--- a/internal/ui/issue1777_grey_suggestion_test.go
+++ b/internal/ui/issue1777_grey_suggestion_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Issue #1777: a Claude autosuggestion rendered in bright-black grey (SGR 90
+// or 38;5;8) instead of dim defeats a dim-only check, so the watcher-dispatch
+// guard would save it as an "operator draft" and restore it after delivery —
+// stranding the suggestion in the composer as real, normal-coloured text that
+// a later bare Enter could submit. Grey ghosts must pass through the guard
+// exactly like dim ones: no Ctrl+C, no save, no restore.
+func TestDeliverToConductorPaneGuarded_IgnoresGreySuggestion(t *testing.T) {
+	div := strings.Repeat("─", 40)
+	greyPane := "some prior output\n" + div +
+		"\n\x1b[39m❯ \x1b[90mupgrade agent-deck on carrollton and archive the five error sessions\x1b[0m\n" +
+		div + "\n  auto mode on\n"
+	p := &guardedFakePane{
+		draftPane:        greyPane,
+		postSendCaptures: []string{emptyComposer()},
+	}
+	opts := testConductorGuardOpts()
+	opts.Strip = tmux.StripANSI
+	if err := deliverToConductorPaneGuarded(p, "[slack] u: hi", opts, 40, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.ctrlCCalls != 0 || p.chunkedCalls != 0 {
+		t.Fatalf("grey suggestion must not trigger save-clear-restore, got ctrlC=%d chunked=%d",
+			p.ctrlCCalls, p.chunkedCalls)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Fixes #1777 (reported by @jwr456): a Claude Code composer autosuggestion can materialize as **real, normal-coloured (`\e[39m`) unsubmitted input**. agent-deck cannot distinguish it from an operator draft by colour, and the send-verify loops' fallback "nudge Enter" presses would submit it as an instruction nobody authored. This is treated as security-class: **agent-deck must never cause text it did not receive from the operator to be submitted.**

v1.10.11 (#1677) covered the dim (`\e[2m`) ghost case; this closes the inverse gap, and closes a further chokepoint bypass found during review (the pasted-text branch below).

## Why this change

### Root cause

Two mechanisms, both identified from the reporter's `capture-pane -e` evidence:

1. **Capture race (agent-deck's own leg).** `GuardComposerDraft` can sample the pane in the sub-frame where the suggestion text is painted but its dim SGR has not landed. It then classifies the ghost as an operator draft, saves the stripped text, Ctrl+C-clears the composer, delivers the automated message, and **restores the suggestion via `SendKeysChunked` without Enter**, stranding it as real `\e[39m` composer text. This explains the specimens on sessions that received a `session send`.
2. **Grey renderings defeat detection.** `bodyStartsDim` treated only SGR `2` as a suggestion. A Claude build or terminal profile rendering the ghost in bright-black grey (`\e[90m` / `\e[38;5;8m`) was classified as an operator draft and took the same save-restore path.

At least one reporter specimen sat on an idle session with no send in the window; that materialization is upstream in Claude Code itself and agent-deck cannot prevent it, but with this PR agent-deck can no longer **submit** it.

### The invariant chosen (fail safe)

Anywhere agent-deck presses a bare Enter, the payload must be positively attributable: an empty composer, a suggestion/placeholder, the message agent-deck itself just typed, or that message collapsed behind Claude's paste marker with positive pre-send provenance. Anything else parks the pane — the nudge is skipped, delivery verification classifies the outcome (#1413 semantics), and a human decides. The asymmetry is deliberate: a skipped nudge at worst leaves a delivery unconfirmed (recoverable); a wrong Enter submits foreign text (unrecoverable).

### Closing the chokepoint bypass (this pass)

Review of the initial version of this PR found that the attribution gate landed one branch short: in both `sendWithRetryTarget` and `sendMessageWhenReady` the gate was computed as `foreignDraftParked = !unsentPromptDetected && EnterWouldSubmitForeignDraft(...)`, so a hit on `HasUnsentPastedPrompt` — a whole-pane `"[pasted text"` substring match — short-circuited the check to `false` and took the branch that presses Enter unconditionally. A pane holding pasted text the operator did not author could still be submitted through that one branch, even with the rest of the gate in place.

The paste case genuinely needs different handling rather than a plain block — Claude collapses a bulk paste behind `[Pasted text #N +M lines]`, so the composer body can no longer be matched against the payload by content, and blocking outright would strand every large automated prompt whose submitting Enter was swallowed. Rather than skip the gate for that branch, the distinction is now made explicit and evidence-based:

- `send.EnterAttribution` is the single chokepoint every automated bare-Enter press routes through (`NudgeEnter`). All Enter presses in both verify loops — including the pasted-text branch — now call it; no bare `SendEnter` remains in either loop.
- `OwnPasteMarker` excuses a composer paste marker only when the sender positively observed an unmarked composer immediately *before* typing (`ComposerHoldsPasteMarker` / `ComposerGuardResult.ComposerPasteMarkerFree`): a marker seen afterwards can then only be the one its own paste created. This evidence is scoped to the marker alone — a materialized suggestion stays blocked even with it present.
- Every unknown (capture failure, a marker still parked pre-send, callers with no plumbing) leaves provenance `false`, which withholds the nudge — fail-safe at the zero value.

Three more residual gaps surfaced in the same review and are fixed the same way (see individual commits): a loose `strings.Contains` match let a foreign draft that merely contained agent-deck's (often short) message pass as attributable; `GuardComposerDraft` and `ComposerHoldsPasteMarker` disagreed about what an unreadable/unscoped composer means for provenance; and the full-resend budget was being spent on aborted attempts that never actually sent anything.

A second read-only static review (of this PR's own diff) found one more instance of the same class: `composerBodyIsOurMessage`'s doc comment already claimed a foreign draft "continue the refactor and delete the stale worktrees" must not be attributed to a short message "continue" — but the code's `strings.HasPrefix(promptBody, msg)` branch had no bound on the trailing content, so it did exactly that for any short automated message. Fixed by bounding the trailing addition to what a terminal actually echoes (a cursor glyph / a few padding bytes), with a regression test pinning the doc comment's own example.

### Rebase onto #1831

#1831 (merged the same day) rewrote parts of the send path — the delivery-verdict / typed-vs-submitted reporting logic in `sendWithRetryTarget`. This branch is rebased onto current `main` so the two compose cleanly: the attribution gate here decides *whether* to press Enter; #1831's verdict logic decides *what to report* about the outcome. They read from and write to disjoint state (the gate never inspects or sets a delivery verdict; the verdict logic never presses Enter directly, only through `attrib.NudgeEnter`), so neither can override the other.

## User impact

None visible in the normal case. A materialized autosuggestion or a foreign paste sitting in the composer during a `session send` / launch-verify retry no longer gets submitted as if the operator typed it; the delivery is instead reported as unconfirmed (per #1413 semantics) so a human can look at the pane, instead of the composer's contents being pressed into the target agent.

## Evidence

`go build ./...` and `go vet ./...` clean (sandboxed). Full test suite green in CI (see checks on this PR): golangci, govulncheck, CodeQL, session-persistence, and the full Go test suite (PR gate) all pass. Targeted regression tests below fail on `main` without this fix and pass with it.

## Changes

- **`internal/send/suggestion.go`** — the suggestion classifier now recognises grey renderings (SGR `90`, `38;5;8`) alongside dim. Foreground resets (`39`, `30-37`, `91-97`, other `38`-introduced colours) clear the grey state so genuine input after a grey marker still reads as input. Existing extended-colour skip logic (so `38;5;2` is never misread as dim) is preserved.
- **`internal/send/guard.go`** — save-step reconfirm: at the hold bound the guard re-captures after a one-frame settle before committing to save-clear-restore. Content that reclassifies as a suggestion (the mid-render race) or fails to re-capture is never saved, so a ghost can never be restored as real text. Real drafts keep full #1409 protection. Provenance producers (`GuardComposerDraft`, `ComposerHoldsPasteMarker`) now agree on what an unreadable/unscoped composer means.
- **`internal/send/attribution.go`** (new) — `EnterAttribution` / `EnterWouldSubmitForeignDraft`: the shared attribution gate and single chokepoint for every automated bare-Enter press. Reads the RAW `-e` capture (per the reporter's caveat, a plain capture strips ANSI and makes ghost text look typed by construction, so colour classification must happen pre-strip; the gate additionally treats even normal-coloured foreign content as unsubmittable, so colour is no longer load-bearing for safety). A failed capture withholds the nudge (no evidence); a capture with no introspectable composer at all leaves nudges allowed (codex/cursor).
- **`cmd/agent-deck/session_cmd.go`** (`sendWithRetryTarget`) and **`internal/session/instance.go`** (`sendMessageWhenReady`) — every fallback Enter nudge, including the pasted-text branch, now routes through `attrib.NudgeEnter`; no bare `SendEnter` remains in either loop. The full-resend path aborts and re-checks attribution before retyping instead of pressing regardless.
- **`cmd/agent-deck/launch_cmd.go` / `launch_verify_prompt.go`** — the launch prompt verifier's retry consults the same gate.
- **`internal/ui/home.go`** — audit note only: the watcher-dispatch blind-Enter arm is unreachable while any composer is visible (the `HasCurrentComposerPrompt` arm returns first), so it cannot submit foreign text; documented at the call site.

### Bare-Enter audit (every place agent-deck presses Enter)

| Surface | Verdict |
|---|---|
| `sendWithRetryTarget` waiting/ambiguous/pasted-text nudges | **gated** (this PR) |
| `sendMessageWhenReady` waiting/ambiguous/pasted-text nudges | **gated** (this PR) |
| launch prompt verifier retry | **gated** (this PR) |
| unsent-own-message recovery Enters (all loops) | attributable by construction (composer holds our payload) |
| full-resend path | Ctrl+C-clears and re-checks attribution before retyping — never submits pre-existing content |
| `deliverToConductorPaneTuned` blind Enters | unreachable with a visible composer; documented |
| resume-picker auto-confirm | fires only when both picker markers are visible |
| restart paths (`Restart`/watchdog) | atomic `respawn-pane`; no Enter pressed at all |
| insert mode / quick-approve / `session send-keys` | direct operator actions |

### Trigger analysis (why intermittent)

A read-only scan of a 64-pane fleet on the maintainer's host the same night found **zero** stranded composer text, against the reporter's 10 of 16 — the materialization is conditional, not universal. Consistent with the root cause: the agent-deck leg requires a `session send` to sample the suggestion mid-render, so exposure scales with send traffic into panes that are idle long enough to be showing suggestions, and with render latency (the reporter is on WSL2, where slower paint pipelines widen the text-painted-but-SGR-not-landed window). The grey leg depends on Claude build/terminal profile. The reporter's idle-no-send specimen is the upstream materialization. All three legs are now either fixed (race, grey) or neutralized (attribution gate blocks submission regardless of how the text got there).

## Tests (each fails without the fix)

- Grey ghosts (`90`, `38;5;8`) classified as suggestions; yield no draft; ignored by `GuardComposerDraft` — and at the watcher-dispatch layer (`internal/ui`) trigger no save-clear-restore.
- Mid-render race: hold-bound sample shows the suggestion without its dim SGR, reconfirm capture shows it dim → nothing saved, no Ctrl+C.
- Reconfirm does not weaken #1409: a real draft still present on the second capture is saved and cleared exactly as before.
- Attribution gate: materialized `\e[39m` foreign content and operator drafts block Enter; empty/dim/grey/placeholder composers and agent-deck's own parked message do not.
- `TestSendWithRetryTarget_ForeignPasteMarkerBlocksEnterNudges` — a "[Pasted text …]" marker parked in the composer with no pre-send provenance receives **zero** Enter presses across the whole verify budget (this is the pasted-text chokepoint bypass this pass closes).
- `TestSendWithRetryTarget_OwnPasteMarkerStillNudged` — the same marker, with positive pre-send provenance, is still nudged (regression guard against over-blocking).
- `sendWithRetryTarget`: a parked foreign specimen (verbatim from the report) receives **zero** Enter presses across the whole verify budget; own-message recovery and dim-ghost nudge behavior unchanged.
- `TestEnterWouldSubmitForeignDraft_ShortMessagePrefixOfLongForeignDraftBlocksEnter` — a short message ("continue") no longer attributes an unrelated longer foreign draft that happens to start with it; `TestEnterWouldSubmitForeignDraft_OwnMessagePlusShortTerminalEchoIsAttributable` pins that a real short terminal-echoed trailer after our own message is unaffected.

`go build ./...` and `go vet` clean; full test suite runs in CI (green — see checks above).

Credit to @jwr456 — the ANSI captures, the `C-u` discriminator, and the `capture-pane -e` caveat made both gaps directly actionable.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-5

## What actually bothered you

The maintainer's own review of this PR (tracked as issue #1778) found that the attribution gate it introduced could itself be bypassed: `HasUnsentPastedPrompt`'s whole-pane match short-circuited the gate to `false` for one branch, so that branch pressed Enter unconditionally — the exact class of bug (an automated Enter submitting content the operator didn't author) the PR exists to prevent. The ask was explicit: route every `SendEnter` path through one chokepoint so no branch can bypass the check, and if the pasted-text case genuinely needs different handling, make that explicit and evidence-based in code rather than quietly skipping the gate. Also: #1831 merged into `main` the same day and touched the same send path, so this branch needed a real rebase (not just a merge) so the attribution gate and #1831's delivery-verdict logic compose instead of fighting each other.

## Checklist

- [x] Targeted diff: one problem (the attribution-gate chokepoint bypass and its adjacent residual gaps), no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `go build ./...` and `go vet ./...` clean locally; full suite green in CI
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-sonnet-5 intent=yes -->
