### PR TITLE
fix: force UTF-8 on the terminal-bridge tmux attach (-u)

### DIFF
--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -303,7 +303,13 @@ func tmuxAttachCommand(sessionName, socketName string) *exec.Cmd {
 	// for ALL attached clients (Ghostty, iTerm) — the dots-in-window symptom.
 	// With largest in effect, every client sees content sized to the biggest
 	// viewer; smaller clients see a clipped portion rather than dot-filled void.
-	cmd := tmuxCommand(socketName, "attach-session", "-t", sessionName)
+	// `-u` forces UTF-8 output regardless of the daemon's locale. Same class of
+	// bug as the TERM handling below: when the web daemon runs under launchd/
+	// systemd its environment carries no LANG/LC_*, so tmux treats this client as
+	// non-UTF-8 and downgrades every non-ASCII glyph (⏵, box-drawing, spinners)
+	// to '_' on the wire — the browser/mobile terminal then shows '_' where the
+	// agent drew Unicode, while tmux's own buffer (capture-pane) stays correct.
+	cmd := tmuxCommand(socketName, "-u", "attach-session", "-t", sessionName)
 	// Guarantee a usable TERM for the attach client. When the web daemon runs
 	// under launchd/systemd its environment carries no TERM, and a tmux attach
 	// client with an empty/unset TERM aborts with "open terminal failed:

--- a/internal/web/terminal_bridge_test.go
+++ b/internal/web/terminal_bridge_test.go
@@ -20,7 +20,7 @@ func TestTmuxAttachCommand_NoIgnoreSize(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-1", "")
 
-	wantArgs := []string{"tmux", "attach-session", "-t", "sess-1"}
+	wantArgs := []string{"tmux", "-u", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("unexpected args: got %v want %v", cmd.Args, wantArgs)
 	}
@@ -31,7 +31,7 @@ func TestTmuxAttachCommandUsesSocketFromTMUXEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-2", "")
 
-	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "attach-session", "-t", "sess-2"}
+	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "-u", "attach-session", "-t", "sess-2"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("unexpected args with TMUX env: got %v want %v", cmd.Args, wantArgs)
 	}
@@ -56,7 +56,7 @@ func TestTmuxAttachCommand_SocketNameOverridesEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("agentdeck-foo", "agent-deck")
 
-	wantArgs := []string{"tmux", "-L", "agent-deck", "attach-session", "-t", "agentdeck-foo"}
+	wantArgs := []string{"tmux", "-L", "agent-deck", "-u", "attach-session", "-t", "agentdeck-foo"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("socket name must take precedence over $TMUX env\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -235,7 +235,7 @@ func TestTmuxAttachCommand_WhitespaceSocketNameFallsBackToEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-3", "   \t")
 
-	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "attach-session", "-t", "sess-3"}
+	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "-u", "attach-session", "-t", "sess-3"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("whitespace-only socket name must fall through to legacy TMUX env\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}

--- a/internal/web/terminal_bridge_utf8_test.go
+++ b/internal/web/terminal_bridge_utf8_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package web
+
+import "testing"
+
+// TestTmuxAttachCommandForcesUTF8 guards the fix for tmux downgrading non-ASCII
+// glyphs to '_' when the daemon runs without a UTF-8 locale (e.g. under launchd):
+// the attach command must pass the global `-u` flag before the subcommand.
+func TestTmuxAttachCommandForcesUTF8(t *testing.T) {
+	cmd := tmuxAttachCommand("my-session", "my-socket")
+	args := cmd.Args
+
+	uIdx, attachIdx := -1, -1
+	for i, a := range args {
+		switch a {
+		case "-u":
+			uIdx = i
+		case "attach-session":
+			attachIdx = i
+		}
+	}
+
+	if uIdx == -1 {
+		t.Fatalf("expected global -u flag in attach command, got %v", args)
+	}
+	if attachIdx == -1 {
+		t.Fatalf("expected attach-session subcommand, got %v", args)
+	}
+	// -u is a server/client flag and must precede the subcommand.
+	if uIdx > attachIdx {
+		t.Fatalf("-u must come before attach-session, got %v", args)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

When the web daemon runs without a UTF-8 locale (e.g. under launchd/systemd, which start with no `LANG`/`LC_*`), tmux treats the terminal bridge's attach client as non-UTF-8 and downgrades every non-ASCII glyph — Claude Code's `⏵⏵` indicator, box-drawing, spinners — to `_` on the wire. The browser/mobile terminal shows `_` where the agent drew Unicode, while tmux's own buffer stays correct, so it looks like a client rendering bug when it's really the attach client's charset.

## Why this change

The bridge attaches with a plain `tmux attach-session`, so UTF-8 output depends entirely on the daemon's locale. This passes the global `-u` flag, which forces UTF-8 output regardless of the environment — mirroring the existing `ensureTERM` handling in the same function, which injects a `TERM` for the identical launchd-has-no-environment reason.

## User impact

Web/mobile terminal clients render the agent's Unicode correctly even when the daemon has no UTF-8 locale. No change when a UTF-8 locale is already present.

## Evidence

Raw bytes on the WebSocket for the `⏵⏵ bypass permissions` footer.

Before (no `-u`, daemon without `LANG`) — literal underscores, the UTF-8 for `⏵` (`e2 8f b5`) never appears:

    hex around 'bypass': 31 31 6d 5f 5f 20 62 79 70 61 73 73    ("__ bypass")

After (`-u`):

    hex around 'bypass': 31 31 6d e2 8f b5 e2 8f b5 20 62 79 70 61 73 73    ("⏵⏵ bypass")

Isolated `tmux attach` with the locale cleared confirms `-u` is the lever, not the locale: `⏵` UTF-8 count = 0 without `-u`, `> 0` with `-u`.

Sandboxed (touched package):

    $ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/web/
    ok  github.com/asheshgoplani/agent-deck/internal/web

Revert-check: reverting the `-u` in `terminal_bridge.go` makes the attach-command tests fail (the test is the assertion, not just a compile dependency):

    terminal_bridge_test.go:25: unexpected args: got [tmux attach-session -t sess-1] want [tmux -u attach-session -t sess-1]
    --- FAIL: TestTmuxAttachCommandForcesUTF8

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

**Prompt / session log (optional):** —

## What actually bothered you

My human, using the agent-deck iPhone terminal, said, verbatim: "there are some unexpected characters \"__\" in the Terminal instead of Claudes characters". Capturing the raw WebSocket bytes showed tmux was sending `_` in place of `⏵` because the launchd-started daemon had no UTF-8 locale.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — one-time flag on attach, no per-output overhead
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web terminal compatibility by forcing UTF-8 output when attaching to tmux sessions, including environments with missing locale settings.

* **Tests**
  * Added coverage to verify UTF-8 output is consistently enabled during terminal attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->