### PR TITLE
fix: honor inject_status_line=false on the watcher/reconnect path

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2541,7 +2541,17 @@ func parsePaneDeadStatus(raw string) (int, bool) {
 // Skips any option key that exists in s.OptionOverrides — user-defined options take precedence.
 func (s *Session) buildStatusBarArgs() []string {
 	if !s.injectStatusLine {
-		return nil
+		// Disabling injection must actively turn the bar OFF, not merely skip
+		// setting ours. tmux's own default is `status on`, so a bar — from that
+		// default, the user's tmux config, or an earlier run that had injection
+		// enabled — persists on the session unless we emit `status off`.
+		// Returning nil here is why `inject_status_line = false` silently did
+		// nothing on any session that already showed a bar (#687). Respect an
+		// explicit user `status` entry in [tmux].options.
+		if _, overridden := s.OptionOverrides["status"]; overridden {
+			return nil
+		}
+		return []string{"set-option", "-t", s.Name, "status", "off"}
 	}
 	themeStyle := currentTmuxThemeStyle()
 	rightStatus := s.themedStatusRight(themeStyle)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2851,6 +2851,10 @@ func TestBuildStatusBarArgs(t *testing.T) {
 }
 
 func TestBuildStatusBarArgs_InjectDisabled(t *testing.T) {
+	// Disabling injection must emit `status off` — not nil — so a bar already on
+	// the server (tmux's `status on` default, user config, or a prior enabled
+	// run) is actually removed. The real-tmux guard for this is
+	// tests/eval/session TestEval_Session_BarOff_RealTmux (#687).
 	s := &Session{
 		Name:             "test-sess",
 		DisplayName:      "proj",
@@ -2858,7 +2862,22 @@ func TestBuildStatusBarArgs_InjectDisabled(t *testing.T) {
 		injectStatusLine: false,
 	}
 	args := s.buildStatusBarArgs()
-	assert.Nil(t, args, "args should be nil when injectStatusLine is false")
+	assert.Equal(t, []string{"set-option", "-t", "test-sess", "status", "off"}, args,
+		"disabling injection must turn the status bar off")
+}
+
+func TestBuildStatusBarArgs_InjectDisabled_UserStatusOverride(t *testing.T) {
+	// An explicit user `status` in [tmux].options wins: agent-deck must not
+	// force it off.
+	s := &Session{
+		Name:             "test-sess",
+		DisplayName:      "proj",
+		WorkDir:          "/tmp",
+		injectStatusLine: false,
+		OptionOverrides:  map[string]string{"status": "on"},
+	}
+	assert.Nil(t, s.buildStatusBarArgs(),
+		"user status override must not be overridden when injection is disabled")
 }
 
 func TestBuildTerminalTitleArgs(t *testing.T) {

--- a/tests/eval/session/inject_status_off_test.go
+++ b/tests/eval/session/inject_status_off_test.go
@@ -1,0 +1,96 @@
+//go:build eval_smoke
+
+// Package session holds behavioral eval cases for agent-deck's session
+// lifecycle. This file owns the `inject_status_line = false` turn-OFF case:
+// disabling injection must actively remove the tmux status bar, not just skip
+// setting agent-deck's own. A unit test that asserts on the struct field or the
+// argv it just built cannot see this — only real tmux can (#687, and the reason
+// the eval lane exists per tests/eval/README.md).
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/tests/eval/harness"
+)
+
+// TestEval_Session_BarOff_RealTmux is revert-sensitive: it fails
+// without the `status off` emission in buildStatusBarArgs.
+//
+// The scenario mirrors what the user actually hits — a bar is already on the
+// tmux server (tmux's own default `status on`, the user's config, or a prior run
+// that had injection enabled), the user sets inject_status_line=false, and
+// expects it to go away. tmux defaults every new session to `status on`, so a
+// session started with injection disabled still starts from "on"; the test
+// asserts real tmux reports it as "off", which only holds if agent-deck actively
+// emits `status off` rather than merely skipping its own bar.
+func TestEval_Session_BarOff_RealTmux(t *testing.T) {
+	sb := harness.NewSandbox(t)
+	sb.InstallTmuxShim(t) // force the binary's tmux calls onto the sandbox socket
+
+	// 1. Config disables status-bar injection.
+	cfgDir := filepath.Join(sb.Home, ".config", "agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"),
+		[]byte("[tmux]\ninject_status_line = false\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	workDir := filepath.Join(sb.Home, "project")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	// 2. Register + start the agent-deck session (display name "inj"). tmux's
+	//    built-in default is `status on`, so the freshly created session starts
+	//    with a bar — agent-deck must turn it off for the config to take effect.
+	runBin(t, sb, "add", "-c", "bash", "-t", "inj", "-g", "evalgrp", workDir)
+	runBin(t, sb, "session", "start", "inj")
+
+	// 4. Find the agentdeck_* session tmux created.
+	deadline := time.Now().Add(5 * time.Second)
+	var sessName string
+	for time.Now().Before(deadline) {
+		out, err := sb.TmuxTry("list-sessions", "-F", "#{session_name}")
+		if err == nil {
+			for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+				if strings.HasPrefix(line, "agentdeck_") {
+					sessName = line
+					break
+				}
+			}
+		}
+		if sessName != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if sessName == "" {
+		out, _ := sb.TmuxTry("list-sessions")
+		t.Fatalf("no agentdeck_* session appeared within 5s.\ntmux list-sessions: %s", out)
+	}
+
+	// 5. Ask REAL tmux what the session's status option resolves to. With
+	//    injection disabled, agent-deck must have emitted `status off`; the
+	//    seeded global `status on` must not win.
+	status := strings.TrimSpace(
+		sb.Tmux("display-message", "-p", "-t", sessName, "#{status}"))
+
+	if status != "off" {
+		t.Fatalf("inject_status_line=false did not turn the status bar off.\n"+
+			"session=%q\n#{status}=%q (want \"off\")\n"+
+			"tmux defaults new sessions to `status on`; if agent-deck only skips "+
+			"setting its bar (returns nil from buildStatusBarArgs) instead of "+
+			"emitting `status off`, that default bar survives — exactly the "+
+			"#687 symptom.", sessName, status)
+	}
+
+	// Clean teardown; non-fatal (Sandbox.teardown kill-servers as a fallback).
+	_, _ = runBinTry(sb, "session", "stop", "inj")
+}


### PR DESCRIPTION
## What problem does this solve?

`[tmux].inject_status_line = false` doesn't actually remove the status bar. `buildStatusBarArgs` returns `nil` when injection is disabled, so `ConfigureStatusBar` becomes a no-op and agent-deck never emits `status off`. But tmux defaults every session to `status on`, so a bar — from that default, the user's own tmux config, or an earlier run that had injection enabled — survives untouched. Turning the option off stops us *setting* a bar but never *removes* one, so the opt-out silently does nothing on any session that already shows a bar (#687).

## Why this change

When injection is disabled, emit `set-option -t <session> status off` instead of returning `nil`, so disabling the option actually turns the bar off. An explicit user `status` entry in `[tmux].options` still wins (returns `nil`, we don't override it), so a user who wants to manage the bar themselves can.

This supersedes my earlier approach on this PR (seeding a process-wide `injectStatusLine` default for the reconnect constructors). That was a no-op: all four production construction sites already call `SetInjectStatusLine(GetTmuxSettings()...)` explicitly right after building the session, and `tmux.ReconnectSession` has no non-test callers — so the constructor default never changed observable behavior. The real gap was the missing turn-off, not the constructor default.

## User impact

`inject_status_line = false` now removes the agent-deck status bar on every session — fresh or reconnected — rather than silently leaving a pre-existing one on. No change for the default (`inject_status_line = true`). A user who sets `status` explicitly under `[tmux].options` keeps control of it.

## Evidence

The bug is invisible to a unit test that asserts on the struct field or the argv it just built — which is exactly how #687 shipped (see `tests/eval/README.md`). So the guard is a real-tmux eval.

`TestEval_Session_BarOff_RealTmux` (`tests/eval/session`) writes `inject_status_line = false`, starts a session under a real tmux server (which defaults to `status on`), and asks tmux itself:

    $ tmux display-message -p -t <session> '#{status}'
    off

Revert-sensitive: with the `tmux.go` hunk reverted (back to `return nil`), the same eval fails because the default bar survives —

    inject_status_off_test.go:86: inject_status_line=false did not turn the status bar off.
        session="agentdeck_inj_e76f8143"
        #{status}="on" (want "off")

Unit coverage of the arg builder both ways (`internal/tmux`): `TestBuildStatusBarArgs_InjectDisabled` asserts `set-option ... status off` is emitted; `TestBuildStatusBarArgs_InjectDisabled_UserStatusOverride` asserts an explicit user `status` override is left alone.

Sandboxed (production package):

    $ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/tmux/
    ok  github.com/asheshgoplani/agent-deck/internal/tmux

The eval runs under its build tag, matching the existing `TestEval_Session_InjectStatusLine_RealTmux`:

    $ go test -tags eval_smoke -run TestEval_Session_BarOff_RealTmux ./tests/eval/session/
    ok  github.com/asheshgoplani/agent-deck/tests/eval/session

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

**Prompt / session log (optional):** —

## What actually bothered you

My human, running agent-deck with the status bar disabled, asked, verbatim: "there is a bottom ribbon (maybe from TMUX) that can be removed so it doesn't take place (both TUI and iOS)". They had set `inject_status_line = false`, but the bar kept showing because disabling the option never actually turned tmux's status off.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): `buildStatusBarArgs` runs from `ConfigureStatusBar` on configure/reconnect, not per status poll — the change adds one `set-option` in the already-existing bounded batch, no measurable cost
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabling the injected status line now reliably turns off the tmux status bar.
  * Existing user-defined status settings are preserved when explicitly configured.

* **Tests**
  * Added coverage verifying status bar removal and user override behavior in real tmux sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->