### PR TITLE
test(ui): strengthen attach return guards

### DIFF
--- a/internal/ui/issue1753_detach_return_test.go
+++ b/internal/ui/issue1753_detach_return_test.go
@@ -36,6 +36,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -299,6 +300,26 @@ func TestIssue1753_AttachCmdClearsAttachFlagBeforeReturning(t *testing.T) {
 	}
 }
 
+func TestIssue1753_AttachWindowCmdClearsAttachFlagBeforeReturning(t *testing.T) {
+	h := NewHome()
+	h.isAttaching.Store(true)
+
+	// A session name that cannot exist makes AttachWindow return after its
+	// existence probe, without selecting or attaching to a tmux window.
+	cmd := attachWindowCmd{
+		session:     &tmux.Session{Name: "agentdeck_issue1753_absent_window_session"},
+		windowIndex: 1,
+		detachByte:  17,
+		onExit:      func() { h.isAttaching.Store(false) },
+	}
+	_ = cmd.Run()
+
+	if h.isAttaching.Load() {
+		t.Fatal("attachWindowCmd.Run returned with isAttaching still set: View() will render " +
+			"\"\" on the first frame after Bubble Tea resumes")
+	}
+}
+
 // TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls is the source-level guard.
 // The behavioural tests above can only observe the snapshot; this one states the rule
 // directly, so a future edit that re-adds an inline tmux round-trip to any of the four
@@ -358,18 +379,53 @@ func TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls(t *testing.T) {
 		}
 	}
 
-	// attachSession must wire onExit, or the first repaint goes back to racing the
-	// ExecCallback goroutine.
-	body := funcBody(t, text, "func (h *Home) attachSession(")
-	if !strings.Contains(body, "onExit:") || !strings.Contains(body, "isAttaching.Store(false)") {
-		t.Error("attachSession no longer clears isAttaching via attachCmd.onExit: the first " +
-			"post-detach View can race the ExecCallback goroutine and render blank (#1753)")
+	// Every local attach path must wire onExit, or the first repaint goes back to
+	// racing the ExecCallback goroutine.
+	mainKeyBody := funcBody(t, text, "func (h *Home) handleMainKey(")
+	attachSites := []struct {
+		name string
+		body string
+		cmd  string
+	}{
+		{
+			name: "session",
+			body: funcBody(t, text, "func (h *Home) attachSession("),
+			cmd:  "attachCmd{",
+		},
+		{
+			name: "window",
+			body: handlerBlock(t, mainKeyBody, `case "enter":`),
+			cmd:  "attachWindowCmd{",
+		},
+		{
+			name: "sandbox terminal",
+			body: handlerBlock(t, mainKeyBody, `case "E":`),
+			cmd:  "attachCmd{",
+		},
 	}
+	for _, site := range attachSites {
+		if !strings.Contains(site.body, site.cmd) ||
+			!strings.Contains(site.body, "onExit:") ||
+			!strings.Contains(site.body, "isAttaching.Store(false)") {
+			t.Errorf("%s attach no longer clears isAttaching via onExit: the first "+
+				"post-detach View can race the ExecCallback goroutine and render blank (#1753)",
+				site.name)
+		}
+	}
+
 	// The pane-CWD probe (two tmux subprocess spawns) must stay behind the
 	// follow-cwd setting instead of running on every detach.
+	body := funcBody(t, text, "func (h *Home) attachSession(")
 	if strings.Contains(body, "GetWorkDir()") && !strings.Contains(body, "GetFollowCwdOnAttach()") {
 		t.Error("attachSession probes the pane CWD unconditionally again: GetWorkDir costs two " +
 			"tmux subprocess spawns on the detach path for a feature that defaults to off (#1753)")
+	}
+	followCwdGate := regexp.MustCompile(
+		`if\s+!followCwd\s*\|\|\s*ts\s*==\s*nil\s*\{\s*return\s+""\s*\}`,
+	)
+	if !followCwdGate.MatchString(body) {
+		t.Error("attachSession no longer returns before GetWorkDir when follow-CWD is disabled " +
+			"or the tmux session is nil (#1753)")
 	}
 }
 

--- a/internal/ui/issue1753_detach_return_test.go
+++ b/internal/ui/issue1753_detach_return_test.go
@@ -389,17 +389,17 @@ func TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls(t *testing.T) {
 	}{
 		{
 			name: "session",
-			body: funcBody(t, text, "func (h *Home) attachSession("),
+			body: braceBlock(t, funcBody(t, text, "func (h *Home) attachSession("), "attachCmd{"),
 			cmd:  "attachCmd{",
 		},
 		{
 			name: "window",
-			body: handlerBlock(t, mainKeyBody, `case "enter":`),
+			body: braceBlock(t, handlerBlock(t, mainKeyBody, `case "enter":`), "attachWindowCmd{"),
 			cmd:  "attachWindowCmd{",
 		},
 		{
 			name: "sandbox terminal",
-			body: handlerBlock(t, mainKeyBody, `case "E":`),
+			body: braceBlock(t, handlerBlock(t, mainKeyBody, `case "E":`), "attachCmd{"),
 			cmd:  "attachCmd{",
 		},
 	}
@@ -415,15 +415,13 @@ func TestIssue1753_AttachReturnHandlersHaveNoInlineTmuxCalls(t *testing.T) {
 
 	// The pane-CWD probe (two tmux subprocess spawns) must stay behind the
 	// follow-cwd setting instead of running on every detach.
-	body := funcBody(t, text, "func (h *Home) attachSession(")
-	if strings.Contains(body, "GetWorkDir()") && !strings.Contains(body, "GetFollowCwdOnAttach()") {
-		t.Error("attachSession probes the pane CWD unconditionally again: GetWorkDir costs two " +
-			"tmux subprocess spawns on the detach path for a feature that defaults to off (#1753)")
-	}
+	attachSessionBody := funcBody(t, text, "func (h *Home) attachSession(")
+	workDirHelper := braceBlock(t, attachSessionBody, "workDirIfFollowing := func(")
 	followCwdGate := regexp.MustCompile(
 		`if\s+!followCwd\s*\|\|\s*ts\s*==\s*nil\s*\{\s*return\s+""\s*\}`,
 	)
-	if !followCwdGate.MatchString(body) {
+	if !followCwdGate.MatchString(workDirHelper) ||
+		!strings.Contains(workDirHelper, "GetWorkDir()") {
 		t.Error("attachSession no longer returns before GetWorkDir when follow-CWD is disabled " +
 			"or the tmux session is nil (#1753)")
 	}
@@ -442,6 +440,34 @@ func funcBody(t *testing.T, text, signature string) string {
 		return rest[:end]
 	}
 	return rest
+}
+
+// braceBlock returns the brace-delimited block following marker.
+func braceBlock(t *testing.T, text, marker string) string {
+	t.Helper()
+	start := strings.Index(text, marker)
+	if start < 0 {
+		t.Fatalf("block marker %q not found in home.go", marker)
+	}
+	openOffset := strings.Index(text[start:], "{")
+	if openOffset < 0 {
+		t.Fatalf("block marker %q has no opening brace in home.go", marker)
+	}
+	open := start + openOffset
+	depth := 0
+	for i := open; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("block marker %q has no closing brace in home.go", marker)
+	return ""
 }
 
 // handlerBlock returns the source text of one `case <label>` arm: from the label up to


### PR DESCRIPTION
## What problem does this solve?

The attach-return regression coverage could miss two ways the blank-screen race might return: `attachWindowCmd` had no direct cleanup test, and the source guard neither covered every local attach site nor rejected an inverted follow-CWD gate. Closes #1772.

## Why this change

This stays tests-only. It exercises `attachWindowCmd.onExit` directly, checks all three local attach call sites, and requires the actual disabled-or-nil early-return condition before `GetWorkDir`.

The issue also noted that no test sets `isReloading`; current `main` already covers that in `TestShiftReorder_PersistsDuringReload_Issue1582`, so this PR does not duplicate it.

## User impact

None, internal regression coverage only. Future detach-path regressions should fail during review instead of reaching users.

## Evidence

- `GOOS=linux GOARCH=amd64 go test -c ./internal/ui` - passed
- `GOOS=linux GOARCH=amd64 go vet ./...` - passed
- `GOOS=linux GOARCH=amd64 go build ./...` - passed
- `gofmt -l internal/ui/issue1753_detach_return_test.go` - clean
- `git diff --check` - clean
- The full sandboxed runtime suite could not complete locally: the Windows host cannot compile the repository's Unix syscall paths, and the local Docker engine terminated during the Linux run. CI remains the runtime verification source.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** Not published.

## What actually bothered you

My human asked: "oss contribution of the day mate"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- Your PR will be validated (applied, built, tested) by the maintainer's AI pipeline within about a day. You'll get a structured comment with the result. Merges are always human. -->

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new regression test to ensure the attachment state flag is cleared before returning from an attachment command (preventing a blank frame/early exit issues).
  - Strengthened the existing source-level validation to confirm the same on-exit clearing behavior across session attach, window attach, and sandbox terminal attach paths.
  - Tightened follow-CWD gating validation using regex-based source checks, ensuring the early probe path is prevented when follow-CWD is disabled (or when no tmux session is available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->