### PR TITLE
fix(session): don't --resume a jsonl from a foreign project dir

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8822,19 +8822,46 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 		if err != nil {
 			primaryStatErr = err.Error()
 		}
-		// File doesn't exist at expected location - try cross-project search
-		// This handles path hash mismatches (e.g., session created from different directory)
+		// File doesn't exist at expected location - try cross-project search.
+		// This handles ENCODING mismatches that still denote the same real
+		// directory (symlinked project paths: the primary lookup encodes the
+		// resolved path, while Claude may have filed under the unresolved
+		// spelling, or vice versa).
+		//
+		// It must NOT accept a jsonl belonging to a genuinely different
+		// project. `claude --resume` only consults the project dir derived
+		// from its own cwd, so a foreign-directory hit is not evidence that
+		// --resume will succeed — it guarantees the opposite: Claude prints
+		// "No conversation found with session ID: <id>" and exits within a
+		// second, flapping the session to `error` on every restart forever.
+		// Returning false instead routes to --session-id, which starts
+		// cleanly in the correct project dir.
 		fallbackTried = true
-		if fallbackPath := findSessionFileInAllProjects(inst, sessionID); fallbackPath != "" {
+		fallbackPath := findSessionFileInAllProjects(inst, sessionID)
+		foreignHit := fallbackPath != "" &&
+			!encodesSameWorkingDir(filepath.Base(filepath.Dir(fallbackPath)), projectPath, resolvedPath)
+		if fallbackPath != "" {
 			fallbackPathFound = fallbackPath
-			sessionLog.Debug("session_data_cross_project_found", slog.String("path", fallbackPath))
-			sessionFile = fallbackPath
-		} else {
+		}
+		switch {
+		case foreignHit:
+			sessionLog.Debug(
+				"session_data_cross_project_rejected",
+				slog.String("found_path", fallbackPath),
+				slog.String("instance_working_dir", projectPath),
+				slog.String("result", "use_session_id"),
+			)
+			emitDecision(false, "foreign_project_dir_resume_would_fail")
+			return false
+		case fallbackPath == "":
 			// File doesn't exist anywhere - use --session-id to create fresh session
 			// (there's nothing to resume if the file doesn't exist)
 			sessionLog.Debug("session_data_file_not_found", slog.String("result", "use_session_id"))
 			emitDecision(false, "file_not_found")
 			return false
+		default:
+			sessionLog.Debug("session_data_cross_project_found", slog.String("path", fallbackPath))
+			sessionFile = fallbackPath
 		}
 	}
 
@@ -8887,10 +8914,44 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 	return false
 }
 
+// encodesSameWorkingDir reports whether encodedDir — a directory name found
+// under {config_dir}/projects — is a plausible Claude encoding of this
+// instance's own working directory, given both its literal and
+// symlink-resolved spellings.
+//
+// This gates the cross-project fallback in sessionHasConversationData. The
+// fallback globs every project dir, so it happily returns a jsonl belonging to
+// an unrelated session. That is worse than not finding one: `claude --resume`
+// derives its project dir from its own cwd, so acting on a foreign hit makes
+// Claude exit immediately with "No conversation found with session ID: <id>".
+// Only an encoding that denotes the SAME real directory (the symlinked-path
+// case the fallback exists for) is safe to accept.
+func encodesSameWorkingDir(encodedDir, projectPath, resolvedPath string) bool {
+	if encodedDir == "" {
+		return false
+	}
+	for _, candidate := range []string{projectPath, resolvedPath} {
+		if candidate == "" {
+			continue
+		}
+		if encodedDir == ConvertToClaudeDirName(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
 // findSessionFileInAllProjects searches all Claude project directories for a session file
 // This handles path hash mismatches when agent-deck runs from a different directory
 // than where the Claude session was originally created.
 // Returns the full path to the session file, or empty string if not found.
+//
+// CAUTION: a hit here means "this jsonl exists somewhere", NOT "Claude can
+// resume it". `claude --resume` only consults the project dir derived from its
+// own cwd. Callers deciding between --resume and --session-id must therefore
+// gate this result through encodesSameWorkingDir; callers that merely need the
+// file's size or mtime (sessionConversationByteSize, sessionConversationMtime)
+// can use it unguarded.
 // Uses the PER-INSTANCE config dir (via GetClaudeConfigDirForInstance) when
 // inst is non-nil so sessions with conductor/group config_dir overrides find
 // their own JSONLs. Passing inst == nil degrades to the global lookup.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8847,8 +8847,8 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 		case foreignHit:
 			sessionLog.Debug(
 				"session_data_cross_project_rejected",
-				slog.String("found_path", fallbackPath),
-				slog.String("instance_working_dir", projectPath),
+				slog.String("found_path", logging.SanitizeValue(fallbackPath)),
+				slog.String("instance_working_dir", logging.SanitizeValue(projectPath)),
 				slog.String("result", "use_session_id"),
 			)
 			emitDecision(false, "foreign_project_dir_resume_would_fail")
@@ -8860,7 +8860,7 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 			emitDecision(false, "file_not_found")
 			return false
 		default:
-			sessionLog.Debug("session_data_cross_project_found", slog.String("path", fallbackPath))
+			sessionLog.Debug("session_data_cross_project_found", slog.String("path", logging.SanitizeValue(fallbackPath)))
 			sessionFile = fallbackPath
 		}
 	}

--- a/internal/session/issue662_session_data_diag_test.go
+++ b/internal/session/issue662_session_data_diag_test.go
@@ -59,11 +59,23 @@ func TestIssue662_HiddenDirInPath_EncodesToDoubleDash(t *testing.T) {
 }
 
 // TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses pins hypothesis (3):
-// when the primary encoded path has no matching jsonl but ANOTHER project dir
+// when the primary encoded path has no matching jsonl but another project dir
 // under the same configDir does have <sessionID>.jsonl, the fallback must
-// surface it. This mirrors real-world path-hash drift where Claude was
-// originally invoked from a slightly different cwd than the Instance records
-// today.
+// surface it.
+//
+// CORRECTED SETUP: this test originally used two unrelated directories
+// (/tmp/instance-cwd-A vs an -tmp-instance-cwd-B jsonl) to stand in for
+// "path-hash drift". That premise was invalid and actively harmful — see
+// TestCrossProjectJSONL_DoesNotJustifyResume in resume_cross_project_test.go.
+// `claude --resume` resolves its project dir from its OWN cwd, so a jsonl
+// belonging to a genuinely different directory can never be resumed; treating
+// it as resumable made real sessions exit instantly with "No conversation
+// found" and flap to `error` on every restart.
+//
+// The drift the fallback legitimately rescues is an ENCODING mismatch over the
+// SAME real directory — a symlinked project path, where the primary lookup
+// encodes the resolved spelling but Claude filed under the unresolved one.
+// That is what this test now exercises, preserving hypothesis (3) coverage.
 func TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -79,8 +91,26 @@ func TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses(t *testing.T) {
 	})
 	ClearUserConfigCache()
 
-	instPath := "/tmp/instance-cwd-A"
-	actualEncoded := "-tmp-instance-cwd-B"
+	realPath := filepath.Join(tmpDir, "instance-cwd-real")
+	if err := os.MkdirAll(realPath, 0o755); err != nil {
+		t.Fatalf("mkdir real instance dir: %v", err)
+	}
+	instPath := filepath.Join(tmpDir, "instance-cwd-link")
+	if err := os.Symlink(realPath, instPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(instPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", instPath, err)
+	}
+	// The primary lookup encodes the resolved spelling; file the jsonl under
+	// the unresolved one so the primary stat misses and the fallback must run.
+	actualEncoded := ConvertToClaudeDirName(instPath)
+	if actualEncoded == ConvertToClaudeDirName(resolved) {
+		t.Skip("symlink did not produce a distinct encoding on this platform")
+	}
+
 	sessionID := "11111111-2222-3333-4444-555555555555"
 
 	actualDir := filepath.Join(tmpDir, "projects", actualEncoded)

--- a/internal/session/resume_cross_project_test.go
+++ b/internal/session/resume_cross_project_test.go
@@ -1,0 +1,155 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Cross-project --resume regression suite.
+//
+// Symptom (reported against v1.10.11): a session whose ProjectPath is
+// /Users/<u>/projects/devops/ansible carried a ClaudeSessionID whose jsonl
+// actually lived under the encoding of the PARENT dir
+// (~/.claude/projects/-Users-<u>-projects-devops/<id>.jsonl), because the
+// conversation had originally been started from the parent. Every restart
+// emitted `claude --resume <id>` from the ansible cwd, Claude answered
+//
+//	No conversation found with session ID: <id>
+//
+// and exited within ~1s — the session flapped straight to `error` and no
+// amount of retrying could recover it.
+//
+// Root cause: sessionHasConversationData falls back to
+// findSessionFileInAllProjects, which globs EVERY project dir under the
+// config dir. Finding the jsonl *somewhere* was treated as proof that
+// `--resume` would work. It is not: `claude --resume` only consults the
+// project dir derived from its own cwd. The fallback therefore promised a
+// resume Claude could not honor.
+//
+// The fallback still has a legitimate job — rescuing an encoding mismatch
+// that denotes the SAME real directory (symlinked project paths, where the
+// primary lookup encodes the resolved path but Claude filed under the
+// unresolved one). So the fix is not to delete the fallback but to accept it
+// only when the directory it found is a plausible encoding of this
+// instance's own working dir.
+//
+// Test 1 (RED before the fix) pins the bug.
+// Test 2 guards the symlink case the fallback exists for.
+
+// TestCrossProjectJSONL_DoesNotJustifyResume is the RED test. A jsonl filed
+// under a genuinely different project directory must NOT route the restart to
+// --resume, because Claude will not find it and will exit immediately.
+// Returning false routes to --session-id, which starts cleanly in the correct
+// project dir (verified against the real Claude CLI: reusing a session id
+// whose jsonl lives only under another project dir is NOT rejected).
+func TestCrossProjectJSONL_DoesNotJustifyResume(t *testing.T) {
+	tmpDir := t.TempDir()
+	withIsolatedClaudeConfigDir(t, tmpDir)
+
+	// Real, existing dirs so EvalSymlinks behaves deterministically.
+	parentDir := filepath.Join(tmpDir, "work", "devops")
+	childDir := filepath.Join(parentDir, "ansible")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("mkdir child dir: %v", err)
+	}
+
+	sessionID := "d046b632-3294-4c9c-accf-249386e68e61"
+
+	// File the transcript under the PARENT's encoding — a different project
+	// dir than the instance's own, exactly as in the field report.
+	resolvedParent := mustEvalSymlinks(t, parentDir)
+	foreignDir := filepath.Join(tmpDir, "projects", ConvertToClaudeDirName(resolvedParent))
+	if err := os.MkdirAll(foreignDir, 0o755); err != nil {
+		t.Fatalf("mkdir foreign projects dir: %v", err)
+	}
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(filepath.Join(foreignDir, sessionID+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	inst := NewInstance("cross-project", childDir)
+	inst.Tool = "claude"
+
+	if sessionHasConversationData(inst, sessionID) {
+		t.Fatalf("jsonl for %s lives only under %q, but the instance works in %q; "+
+			"`claude --resume` would fail with \"No conversation found\" and exit. "+
+			"sessionHasConversationData must return false so the restart uses --session-id.",
+			sessionID, foreignDir, childDir)
+	}
+}
+
+// TestSymlinkedProjectPath_StillResumesViaFallback guards the case the
+// cross-project fallback was actually added for: the SAME real directory
+// reachable under two spellings. The primary lookup encodes the resolved
+// path; if Claude filed the transcript under the unresolved (symlinked)
+// spelling, the fallback must still rescue it — Claude, running with that
+// cwd, does find its own file.
+func TestSymlinkedProjectPath_StillResumesViaFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	withIsolatedClaudeConfigDir(t, tmpDir)
+
+	realDir := filepath.Join(tmpDir, "real-project")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real dir: %v", err)
+	}
+	linkDir := filepath.Join(tmpDir, "linked-project")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	sessionID := "22222222-3333-4444-5555-666666666666"
+
+	// Claude filed under the UNRESOLVED spelling; the primary lookup will
+	// encode the RESOLVED one and miss.
+	unresolvedEncoded := ConvertToClaudeDirName(linkDir)
+	resolvedEncoded := ConvertToClaudeDirName(mustEvalSymlinks(t, linkDir))
+	if unresolvedEncoded == resolvedEncoded {
+		t.Skip("symlink did not produce a distinct encoding on this platform")
+	}
+
+	dir := filepath.Join(tmpDir, "projects", unresolvedEncoded)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	inst := NewInstance("symlinked", linkDir)
+	inst.Tool = "claude"
+
+	if !sessionHasConversationData(inst, sessionID) {
+		t.Fatalf("jsonl at %q denotes the same real dir as the instance path %q; "+
+			"the fallback must still accept it so restart uses --resume", dir, linkDir)
+	}
+}
+
+// withIsolatedClaudeConfigDir points CLAUDE_CONFIG_DIR at dir for the test and
+// restores the previous value (and the config cache) afterwards.
+func withIsolatedClaudeConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	orig, had := os.LookupEnv("CLAUDE_CONFIG_DIR")
+	if err := os.Setenv("CLAUDE_CONFIG_DIR", dir); err != nil {
+		t.Fatalf("set CLAUDE_CONFIG_DIR: %v", err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", orig)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+}
+
+func mustEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", path, err)
+	}
+	return resolved
+}


### PR DESCRIPTION
## What problem does this solve?

A session can get permanently stuck in `error`, restarting forever with no way to recover, when its `claude_session_id` was bound while Claude was running from a *different* directory than the session's current `project_path`. Every restart emits `claude --resume <id>`, Claude answers `No conversation found with session ID: <id>` and exits in about a second, and the session flaps straight back to `error`. Pressing restart again just replays it.

The trigger in the field: a session at `~/projects/devops/ansible` whose conversation had originally been started from the parent `~/projects/devops`, so the jsonl was filed under `~/.claude/projects/-Users-<u>-projects-devops/`, not under the `-ansible` encoding.

## Why this change

`sessionHasConversationData` exists to predict whether `--resume` will work, and falls back to `findSessionFileInAllProjects` when the primary encoded path misses. That fallback globs **every** project dir under the config dir, and finding the jsonl *somewhere* was treated as proof that `--resume` would succeed.

It is not. `claude --resume` resolves its project dir from its own cwd, so a foreign-directory hit guarantees the opposite outcome. The fallback was promising a resume Claude could not honor.

Deleting the fallback was the wrong fix — it does have a legitimate job: rescuing an *encoding* mismatch that still denotes the **same real directory** (symlinked project paths, where the primary lookup encodes the resolved spelling but Claude filed under the unresolved one). So the fallback is now gated through a small `encodesSameWorkingDir` helper that accepts it only when the found directory is a plausible Claude encoding of this instance's own working dir, in either spelling.

Two things I checked before picking `--session-id` as the fallback route:

- Reusing a session id whose jsonl lives only under *another* project dir is **not** rejected by the real Claude CLI — it starts cleanly and files a fresh transcript in the correct dir. So `--session-id` is a safe landing, and strictly better than a guaranteed instant exit.
- The two other `findSessionFileInAllProjects` callers (`sessionConversationByteSize`, `sessionConversationMtime`) only want the file's size/mtime, where locating it anywhere is correct. They stay unguarded, and the constraint is now documented on the helper so the gate isn't accidentally bypassed later.

One existing test needed correcting, and I want to flag it explicitly rather than bury it. `TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses` used `/tmp/instance-cwd-A` with a jsonl under `-tmp-instance-cwd-B` — two genuinely unrelated directories — and asserted that justifies a resume. That pinned the exact behavior causing this bug. Its setup is rewritten to a symlinked same-real-directory mismatch, which is the drift its comment actually describes, so hypothesis-(3) coverage survives. If you'd rather keep the original assertion, that's a design call worth settling here.

## User impact

Sessions whose Claude session id was bound from a different cwd now start instead of flapping in `error`. They start fresh (via `--session-id`) rather than resuming history that Claude cannot reach — the history was never actually reachable from that cwd, so nothing is lost that previously worked.

Users who *want* the old conversation back can point the session's project path at the directory the transcript belongs to, and `--resume` then resolves normally. That is how the reported session was recovered.

No change for sessions whose jsonl is where Claude expects it, and no change for the symlinked-path case.

## Evidence

**The failure, reproduced directly** — the exact command agent-deck logged, run from the session's cwd:

```
$ cd /Users/compass/projects/devops/ansible
$ claude --resume d0464432-3294-4c9c-xxxx-24938sdfe623e61 --model claude-opus-4-8 --permission-mode auto -p "say hi"
No conversation found with session ID: d0464432-3294-4c9c-xxxx-24938sdfe623e61
```

**agent-deck's own decision log admitting the mismatch** (`~/.cache/agent-deck/debug.log`, v1.10.11):

```json
{"msg":"session_data_decision","session_id":"d0464432-...",
 "resolved_project_path":"/Users/compass/projects/devops/ansible",
 "encoded_path":"-Users-compass-projects-devops-ansible",
 "primary_path_stat_err":"stat /Users/compass/.claude/projects/-Users-compass-projects-devops-ansible/d0464432-....jsonl: no such file or directory",
 "fallback_lookup_tried":true,
 "fallback_path_found":"/Users/compass/.claude/projects/-Users-compass-projects-devops/d0464432-....jsonl",
 "final_result":true,"reason":"session_id_line_present"}
```

Note `final_result: true` off a `fallback_path_found` in a different project dir — that is the bug in one line.

**The resulting flap** — start, then Claude exits ~1s later, repeatedly:

```json
{"time":"10:49:40.60","msg":"pipe_connected","session":"agentdeck_appcloud-ops_d28daea9"}
{"time":"10:49:41.47","msg":"hook_status_updated","instance":"b911b2fd-...","status":"dead","event":"SessionEnd"}
{"time":"10:49:41.81","msg":"pipe_reader_exited","session":"agentdeck_appcloud-ops_d28daea9"}
```

**After recovery** (project path pointed at the directory owning the transcript) — `SessionStart` instead of `SessionEnd`/`dead`, and the session went on to serve a real prompt:

```json
{"time":"10:59:55.06","msg":"hook_status_updated","instance":"b911b2fd-...","status":"waiting","event":"SessionStart"}
{"time":"11:00:40.13","msg":"hook_status_updated","instance":"b911b2fd-...","status":"running","event":"UserPromptSubmit"}
{"time":"11:03:58.75","msg":"hook_status_updated","instance":"b911b2fd-...","status":"waiting","event":"Stop"}
```

**Claude CLI probe backing the `--session-id` choice** — reusing an id whose jsonl exists only under another project dir is accepted, not rejected:

```
$ cd /tmp/scratch/projA && claude --session-id $UUID -p "reply OK"
OK
$ find ~/.claude/projects -name "$UUID.jsonl"
/Users/compass/.claude/projects/-private-tmp-scratch-projA/<uuid>.jsonl
$ cd /tmp/scratch/projB && claude --session-id $UUID -p "reply OK"
OK          # no "already in use" error; fresh transcript filed under projB
```

**Test, RED before the fix:**

```
$ go test ./internal/session/ -run TestCrossProjectJSONL_DoesNotJustifyResume -v
=== RUN   TestCrossProjectJSONL_DoesNotJustifyResume
    resume_cross_project_test.go:75: jsonl for d0464432-... lives only under
    ".../projects/-private-var-...-work-devops", but the instance works in
    ".../work/devops/ansible"; `claude --resume` would fail with "No conversation
    found" and exit. sessionHasConversationData must return false so the restart
    uses --session-id.
--- FAIL: TestCrossProjectJSONL_DoesNotJustifyResume (0.00s)
```

GREEN after, with the symlink guard passing alongside:

```
=== RUN   TestCrossProjectJSONL_DoesNotJustifyResume
--- PASS: TestCrossProjectJSONL_DoesNotJustifyResume (0.00s)
=== RUN   TestSymlinkedProjectPath_StillResumesViaFallback
--- PASS: TestSymlinkedProjectPath_StillResumesViaFallback (0.00s)
```

**Suite status.** `gofmt -l ./cmd ./internal` prints nothing; `go vet ./...` clean; `go test -race ./internal/session/ -run 'CrossProject|Symlinked|Issue662|Resume|SessionData|Persistence'` passes.

The sandboxed `go test ./...` run is **not** green on this machine, so to be straight about it: I compared it against a clean `origin/main` worktree run under identical conditions. Both fail 9 tests. Seven are identical and environmental (`TestEmbeddedBridge*`, `TestBridgeTemplate_UserIDResolutionBehavior` — Python exec returning 126; `TestIssue1421_CleanStaleSSHSockets` — invalid unix socket name; `TestPerf_ColdStart_*`, `TestTmuxBootstrap_ServerIsRunning`, `TestTestMainDoesNotLeakBootstrapServer`). The two that differ are flaky under full-suite parallelism, not caused by this change: baseline additionally failed `TestKillStaleControlClients_PreservesLiveSibling`, my run additionally failed `TestConductorTitledChild_DeliverCompletion_ParentedIsCommitted`, and that one passes 3/3 in isolation on **both** trees.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you

My human's ask, verbatim:

> check why my ops session in agent deck is unable to start

Then, after seeing the root cause and being offered the options:

> yes, open the PR

The session had been dead for a while and restarting it did nothing — it just bounced back to `error` every time, with no error surfaced in the UI explaining why. From the outside it looked like agent-deck simply couldn't launch the session; the actual message (`No conversation found with session ID`) was only visible by replaying the logged command by hand.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — not green on this machine; baselined against clean `origin/main` under identical conditions, see Evidence
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session resumption from using transcripts belonging to unrelated project directories.
  * Preserved resume behavior for projects accessed through equivalent symlinked paths.
  * Correctly falls back to session ID mode when conversation ownership cannot be verified.

* **Tests**
  * Added regression coverage for cross-project and symlink-based session resumption scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->