### PR TITLE
fix(codex): retain completion evidence for fresh status polls

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -186,7 +186,7 @@ func handleCodexNotify() {
 	if sessionID == "" {
 		sessionID = strings.TrimSpace(os.Getenv("CODEX_SESSION_ID"))
 	}
-	if session.IsCodexSubagentThread(sessionID, filepath.Dir(getCodexConfigPath())) {
+	if session.IsCodexSubagentThread(sessionID, session.GetCodexConfigDir()) {
 		return
 	}
 

--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 const codexNotifyMarkerBegin = "# BEGIN AGENTDECK CODEX NOTIFY"
@@ -183,6 +185,9 @@ func handleCodexNotify() {
 
 	if sessionID == "" {
 		sessionID = strings.TrimSpace(os.Getenv("CODEX_SESSION_ID"))
+	}
+	if session.IsCodexSubagentThread(sessionID, filepath.Dir(getCodexConfigPath())) {
+		return
 	}
 
 	writeHookStatus(instanceID, status, sessionID, event, "")

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -179,11 +179,20 @@ func TestHandleCodexNotify_EmptyTailEventKeepsJSONEmptyAndPersistsAnchor(t *test
 
 func TestHandleCodexNotify_SubagentCannotOverwritePersistedMainThreadEvidence(t *testing.T) {
 	tmpHome := t.TempDir()
-	codexHome := filepath.Join(tmpHome, "codex")
+	codexHome := filepath.Join(tmpHome, "configured-codex")
 	t.Setenv("HOME", tmpHome)
-	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, "xdg-config"))
+	t.Setenv("CODEX_HOME", "")
 	t.Setenv("AGENTDECK_INSTANCE_ID", "inst-subagent-disk-gate")
 	t.Setenv("CODEX_SESSION_ID", "")
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Codex: session.CodexSettings{ConfigDir: codexHome},
+	}); err != nil {
+		t.Fatalf("save configured Codex home: %v", err)
+	}
+	session.ClearUserConfigCache()
 
 	origArgs := os.Args
 	defer func() { os.Args = origArgs }()

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -165,6 +165,13 @@ func TestHandleCodexNotify_EmptyTailEventKeepsJSONEmptyAndPersistsAnchor(t *test
 	if hook.SessionID != "" {
 		t.Fatalf("hook session_id = %q, want empty for compatibility", hook.SessionID)
 	}
+	if hook.StateSessionID != "thr-sticky" {
+		t.Fatalf("hook retained session_id = %q, want thr-sticky", hook.StateSessionID)
+	}
+	if hook.LastTurnStartedGeneration == 0 ||
+		hook.LastTurnCompletedGeneration <= hook.LastTurnStartedGeneration {
+		t.Fatalf("turn generations not retained: %#v", hook)
+	}
 	if got := session.ReadHookSessionAnchor("inst-sticky"); got != "thr-sticky" {
 		t.Fatalf("session anchor = %q, want thr-sticky", got)
 	}

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -177,6 +177,54 @@ func TestHandleCodexNotify_EmptyTailEventKeepsJSONEmptyAndPersistsAnchor(t *test
 	}
 }
 
+func TestHandleCodexNotify_SubagentCannotOverwritePersistedMainThreadEvidence(t *testing.T) {
+	tmpHome := t.TempDir()
+	codexHome := filepath.Join(tmpHome, "codex")
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("AGENTDECK_INSTANCE_ID", "inst-subagent-disk-gate")
+	t.Setenv("CODEX_SESSION_ID", "")
+
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	const mainSID = "thread-main-disk-gate"
+	const childSID = "thread-child-disk-gate"
+	os.Args = []string{"agent-deck", "codex-notify", `{"event":"turn/started","thread_id":"` + mainSID + `"}`}
+	handleCodexNotify()
+	os.Args = []string{"agent-deck", "codex-notify", `{"event":"turn/completed","thread_id":"` + mainSID + `"}`}
+	handleCodexNotify()
+
+	rolloutDir := filepath.Join(codexHome, "sessions", "2026", "08", "02")
+	if err := os.MkdirAll(rolloutDir, 0o700); err != nil {
+		t.Fatalf("mkdir rollout dir: %v", err)
+	}
+	childRollout := `{"type":"session_meta","payload":{"id":"` + childSID + `","thread_source":"subagent","parent_thread_id":"` + mainSID + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(rolloutDir, "rollout-2026-08-02T00-00-00-"+childSID+".jsonl"), []byte(childRollout), 0o600); err != nil {
+		t.Fatalf("write child rollout: %v", err)
+	}
+
+	os.Args = []string{"agent-deck", "codex-notify", `{"event":"turn/completed","thread_id":"` + childSID + `"}`}
+	handleCodexNotify()
+
+	hookPath := filepath.Join(getHooksDir(), "inst-subagent-disk-gate.json")
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	var hook hookStatusFile
+	if err := json.Unmarshal(data, &hook); err != nil {
+		t.Fatalf("unmarshal hook: %v", err)
+	}
+	if hook.StateSessionID != mainSID || hook.Generation != 2 ||
+		hook.LastTurnStartedGeneration != 1 || hook.LastTurnCompletedGeneration != 2 {
+		t.Fatalf("subagent overwrote main-thread evidence: %#v", hook)
+	}
+	if got := session.ReadHookSessionAnchor("inst-subagent-disk-gate"); got != mainSID {
+		t.Fatalf("subagent overwrote main-thread anchor: got %q, want %q", got, mainSID)
+	}
+}
+
 func TestCodexHooksInstallUninstall(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -61,31 +61,9 @@ func resolveStopHookActive(p hookPayload) bool {
 	return p.StopHookActive == nil || *p.StopHookActive
 }
 
-// hookStatusFile is the JSON written to ~/.agent-deck/hooks/{instance_id}.json
-type hookStatusFile struct {
-	Status    string `json:"status"`
-	SessionID string `json:"session_id,omitempty"`
-	Event     string `json:"event"`
-	Timestamp int64  `json:"ts"`
-	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
-	// detected on the Stop edge (issue #1186). omitempty so ordinary Stops
-	// (no sentinel) leave the fields absent, which the daemon reads as
-	// "no finished event to emit."
-	DoneStatus  string `json:"done_status,omitempty"`
-	DoneSummary string `json:"done_summary,omitempty"`
-	// TranscriptPath is persisted ONLY when the Stop-edge sentinel scan was
-	// inconclusive because the turn's assistant record had not flushed yet
-	// (issue #1186 flush race). The daemon re-scans this path on its poll
-	// loop; the synchronous Stop hook (#1225) must not wait out the flush.
-	TranscriptPath string `json:"transcript_path,omitempty"`
-	// Cwd is the working directory the hook payload reported for this event.
-	// Issue #1729: the session-binding path uses it as same-session evidence —
-	// a candidate session id whose cwd is provably outside the instance's
-	// declared paths (e.g. a headless `claude -p` worker at $TMPDIR that
-	// inherited AGENTDECK_INSTANCE_ID) must never bind. omitempty keeps legacy
-	// files byte-identical when the agent sends no cwd.
-	Cwd string `json:"cwd,omitempty"`
-}
+// Preserve the historical command-package name while the serialized schema is
+// owned by internal/session.
+type hookStatusFile = session.HookStateDocument
 
 // normalizeHookEventKey folds hook event names from Claude (PascalCase), Cursor
 // (camelCase), Hermes (snake_case), and Codex into a single lookup key.
@@ -96,6 +74,23 @@ func normalizeHookEventKey(event string) string {
 
 func isStopHookEvent(event string) bool {
 	return normalizeHookEventKey(event) == "stop"
+}
+
+func hookStateEventKind(event string) session.HookStateEventKind {
+	key := strings.ToLower(strings.TrimSpace(event))
+	key = strings.NewReplacer("_", "", "-", "", " ", "", ".", "", "/", "").Replace(key)
+	switch key {
+	case "userpromptsubmit", "beforesubmitprompt", "beforeagent",
+		"agentturnstart", "agentturnstarted", "turnstart", "turnstarted":
+		return session.HookTurnStarted
+	case "stop", "afteragent",
+		"agentturncomplete", "agentturncompleted",
+		"turncomplete", "turncompleted", "turnfailed", "turnaborted",
+		"turncancelled", "turncanceled":
+		return session.HookTurnCompleted
+	default:
+		return session.HookStatusOnly
+	}
 }
 
 // mapEventToStatus maps a hook event to an agent-deck status string.
@@ -354,47 +349,24 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 		session.WriteHookSessionAnchor(instanceID, sessionID)
 	}
 
-	statusFile := hookStatusFile{
+	stateEvent := session.HookStateEvent{
+		Kind:      hookStateEventKind(event),
 		Status:    status,
 		SessionID: sessionID,
 		Event:     event,
-		Timestamp: time.Now().Unix(),
+		At:        time.Now(),
 		Cwd:       strings.TrimSpace(cwd),
 	}
 	if scan.signal != nil {
-		statusFile.DoneStatus = scan.signal.Status
-		statusFile.DoneSummary = scan.signal.Summary
+		stateEvent.DoneStatus = scan.signal.Status
+		stateEvent.DoneSummary = scan.signal.Summary
 	}
-	statusFile.TranscriptPath = scan.pendingTranscript
-
-	jsonData, err := json.Marshal(statusFile)
-	if err != nil {
-		hookHandlerLog.Warn("hook_status_marshal_failed",
-			slog.String("instance", instanceID),
-			slog.String("error", err.Error()),
-		)
-		return
-	}
-
-	filePath := filepath.Join(hooksDir, filepath.Base(instanceID)+".json")
-	tmpPath := filePath + ".tmp"
-	if err := os.WriteFile(tmpPath, jsonData, 0600); err != nil {
+	stateEvent.TranscriptPath = scan.pendingTranscript
+	if err := session.WriteHookState(instanceID, stateEvent); err != nil {
 		hookHandlerLog.Warn("hook_status_write_failed",
-			slog.String("path", tmpPath),
 			slog.String("instance", instanceID),
 			slog.String("error", err.Error()),
 		)
-		return
-	}
-	if err := os.Rename(tmpPath, filePath); err != nil {
-		hookHandlerLog.Warn("hook_status_rename_failed",
-			slog.String("from", tmpPath),
-			slog.String("to", filePath),
-			slog.String("instance", instanceID),
-			slog.String("error", err.Error()),
-		)
-		// Best-effort cleanup of the orphaned temp file.
-		_ = os.Remove(tmpPath)
 		return
 	}
 

--- a/internal/session/codex_completion_evidence_test.go
+++ b/internal/session/codex_completion_evidence_test.go
@@ -12,25 +12,27 @@ func TestCodexCompletionMatchesBoundSession(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		stateID   string
-		boundID   string
-		started   uint64
-		completed uint64
-		want      bool
+		name       string
+		stateID    string
+		boundID    string
+		generation uint64
+		started    uint64
+		completed  uint64
+		want       bool
 	}{
-		{name: "matching completion", stateID: "thread-1", boundID: "thread-1", started: 4, completed: 5, want: true},
-		{name: "completion without observed start", stateID: "thread-1", boundID: "thread-1", completed: 1, want: true},
-		{name: "newer start", stateID: "thread-1", boundID: "thread-1", started: 6, completed: 5},
-		{name: "different session", stateID: "thread-2", boundID: "thread-1", started: 4, completed: 5},
-		{name: "missing retained identity", boundID: "thread-1", started: 4, completed: 5},
-		{name: "no completion", stateID: "thread-1", boundID: "thread-1", started: 4},
+		{name: "matching current completion", stateID: "thread-1", boundID: "thread-1", generation: 5, started: 4, completed: 5, want: true},
+		{name: "completion without observed start", stateID: "thread-1", boundID: "thread-1", generation: 1, completed: 1, want: true},
+		{name: "later event makes completion stale", stateID: "thread-1", boundID: "thread-1", generation: 6, started: 4, completed: 5},
+		{name: "newer start", stateID: "thread-1", boundID: "thread-1", generation: 6, started: 6, completed: 5},
+		{name: "different session", stateID: "thread-2", boundID: "thread-1", generation: 5, started: 4, completed: 5},
+		{name: "missing retained identity", boundID: "thread-1", generation: 5, started: 4, completed: 5},
+		{name: "no completion", stateID: "thread-1", boundID: "thread-1", generation: 4, started: 4},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := codexCompletionMatchesBoundSession(tc.stateID, tc.boundID, tc.started, tc.completed); got != tc.want {
-				t.Fatalf("codexCompletionMatchesBoundSession(%q, %q, %d, %d) = %v, want %v",
-					tc.stateID, tc.boundID, tc.started, tc.completed, got, tc.want)
+			if got := codexCompletionMatchesBoundSession(tc.stateID, tc.boundID, tc.generation, tc.started, tc.completed); got != tc.want {
+				t.Fatalf("codexCompletionMatchesBoundSession(%q, %q, %d, %d, %d) = %v, want %v",
+					tc.stateID, tc.boundID, tc.generation, tc.started, tc.completed, got, tc.want)
 			}
 		})
 	}

--- a/internal/session/codex_completion_evidence_test.go
+++ b/internal/session/codex_completion_evidence_test.go
@@ -125,12 +125,13 @@ func TestCodexSubagentCompletionCannotReplaceMainCompletionEvidence(t *testing.T
 	seedCodexRolloutWithMeta(t, codexHome, childSID, "subagent", mainSID, true)
 
 	inst.CodexSessionID = mainSID
+	mainCompletionAt := time.Now()
 	inst.UpdateHookStatus(&HookStatus{
 		Status:                      "waiting",
 		SessionID:                   mainSID,
 		StateSessionID:              mainSID,
-		Event:                       "agent-turn-complete",
-		UpdatedAt:                   time.Now(),
+		Event:                       "main-turn-complete",
+		UpdatedAt:                   mainCompletionAt,
 		Generation:                  5,
 		LastTurnStartedGeneration:   4,
 		LastTurnCompletedGeneration: 5,
@@ -150,5 +151,60 @@ func TestCodexSubagentCompletionCannotReplaceMainCompletionEvidence(t *testing.T
 	defer inst.mu.RUnlock()
 	if !inst.hasMatchingCodexCompletionLocked() {
 		t.Fatal("rejected subagent completion replaced the main thread's retained completion evidence")
+	}
+	if inst.hookStatus != "waiting" || inst.hookEvent != "main-turn-complete" ||
+		!inst.hookLastUpdate.Equal(mainCompletionAt) {
+		t.Fatalf("rejected subagent completion replaced main hook status: status=%q event=%q updated=%v",
+			inst.hookStatus, inst.hookEvent, inst.hookLastUpdate)
+	}
+}
+
+func TestCodexCompatibleToolColdLoadsRetainedCompletionEvidence(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, "xdg-config"))
+	t.Setenv("CODEX_HOME", filepath.Join(tmpHome, "codex"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+	if err := SaveUserConfig(&UserConfig{Tools: map[string]ToolDef{
+		"custom-codex": {Command: "codex", CompatibleWith: "codex"},
+	}}); err != nil {
+		t.Fatalf("save custom Codex tool: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstanceWithTool("custom-codex-cold-load", tmpHome, "custom-codex")
+	if err := inst.tmuxSession.Start("sleep 3600"); err != nil {
+		t.Fatalf("start tmux fixture: %v", err)
+	}
+	defer func() { _ = inst.tmuxSession.Kill() }()
+
+	const threadID = "thread-custom-cold-load"
+	inst.Status = StatusRunning
+	inst.CodexSessionID = threadID
+	if err := WriteHookState(inst.ID, HookStateEvent{
+		Kind: HookTurnStarted, Status: "running", SessionID: threadID,
+		Event: "turn.started", At: time.Now(),
+	}); err != nil {
+		t.Fatalf("write retained start: %v", err)
+	}
+	if err := WriteHookState(inst.ID, HookStateEvent{
+		Kind: HookTurnCompleted, Status: "waiting", SessionID: threadID,
+		Event: "turn.completed", At: time.Now(),
+	}); err != nil {
+		t.Fatalf("write retained completion: %v", err)
+	}
+
+	if err := inst.UpdateStatus(); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.hookStateSessionID != threadID || inst.hookGeneration != 2 ||
+		inst.hookLastTurnCompletedGeneration != 2 {
+		t.Fatalf("Codex-compatible cold load lost retained evidence: state=%q generation=%d completed=%d",
+			inst.hookStateSessionID, inst.hookGeneration, inst.hookLastTurnCompletedGeneration)
 	}
 }

--- a/internal/session/codex_completion_evidence_test.go
+++ b/internal/session/codex_completion_evidence_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCodexCompletionMatchesBoundSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		stateID   string
+		boundID   string
+		started   uint64
+		completed uint64
+		want      bool
+	}{
+		{name: "matching completion", stateID: "thread-1", boundID: "thread-1", started: 4, completed: 5, want: true},
+		{name: "completion without observed start", stateID: "thread-1", boundID: "thread-1", completed: 1, want: true},
+		{name: "newer start", stateID: "thread-1", boundID: "thread-1", started: 6, completed: 5},
+		{name: "different session", stateID: "thread-2", boundID: "thread-1", started: 4, completed: 5},
+		{name: "missing retained identity", boundID: "thread-1", started: 4, completed: 5},
+		{name: "no completion", stateID: "thread-1", boundID: "thread-1", started: 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexCompletionMatchesBoundSession(tc.stateID, tc.boundID, tc.started, tc.completed); got != tc.want {
+				t.Fatalf("codexCompletionMatchesBoundSession(%q, %q, %d, %d) = %v, want %v",
+					tc.stateID, tc.boundID, tc.started, tc.completed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDebounceFlipFromRunningWithCodexCompletionSettlesFirstSample(t *testing.T) {
+	t.Parallel()
+
+	apply, pending, held := debounceFlipFromRunningWithCompletion(
+		StatusRunning, StatusWaiting, "waiting", "waiting", false, true,
+	)
+	if held || pending || apply != StatusWaiting {
+		t.Fatalf("matching completion must settle first sample; got apply=%s pending=%v held=%v", apply, pending, held)
+	}
+
+	apply, pending, held = debounceFlipFromRunningWithCompletion(
+		StatusRunning, StatusWaiting, "waiting", "waiting", false, false,
+	)
+	if !held || !pending || apply != StatusRunning {
+		t.Fatalf("pane-only first sample must remain debounced; got apply=%s pending=%v held=%v", apply, pending, held)
+	}
+}
+
+func TestReadHookStatusFilePreservesRetainedGenerations(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	const instanceID = "instance-reader"
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o700); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	document := HookStateDocument{
+		SchemaVersion:               HookStateSchemaV1,
+		Status:                      "waiting",
+		StateSessionID:              "thread-1",
+		Event:                       "agent-turn-complete",
+		Timestamp:                   1722190000,
+		Generation:                  9,
+		LastTurnStartedGeneration:   8,
+		LastTurnCompletedGeneration: 9,
+	}
+	data, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, instanceID+".json"), data, 0o600); err != nil {
+		t.Fatalf("write hook state: %v", err)
+	}
+
+	status := readHookStatusFile(instanceID)
+	if status == nil {
+		t.Fatal("readHookStatusFile returned nil")
+	}
+	if status.StateSessionID != "thread-1" || status.Generation != 9 ||
+		status.LastTurnStartedGeneration != 8 || status.LastTurnCompletedGeneration != 9 {
+		t.Fatalf("retained evidence lost: %#v", status)
+	}
+}
+
+func TestInstanceRetainsMatchingCodexCompletionEvidence(t *testing.T) {
+	t.Parallel()
+
+	inst := &Instance{Tool: "codex", CodexSessionID: "thread-1"}
+	inst.UpdateHookStatus(&HookStatus{
+		Status:                      "waiting",
+		SessionID:                   "thread-1",
+		StateSessionID:              "thread-1",
+		Event:                       "agent-turn-complete",
+		UpdatedAt:                   time.Now(),
+		Generation:                  5,
+		LastTurnStartedGeneration:   4,
+		LastTurnCompletedGeneration: 5,
+	})
+
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if !inst.hasMatchingCodexCompletionLocked() {
+		t.Fatal("matching retained completion was not available to status debounce")
+	}
+}

--- a/internal/session/codex_completion_evidence_test.go
+++ b/internal/session/codex_completion_evidence_test.go
@@ -113,3 +113,40 @@ func TestInstanceRetainsMatchingCodexCompletionEvidence(t *testing.T) {
 		t.Fatal("matching retained completion was not available to status debounce")
 	}
 }
+
+func TestCodexSubagentCompletionCannotReplaceMainCompletionEvidence(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+
+	mainSID := uniqueSID(t)
+	childSID := uniqueSID(t)
+	seedCodexRolloutWithMeta(t, codexHome, mainSID, "user", "", false)
+	seedCodexRolloutWithMeta(t, codexHome, childSID, "subagent", mainSID, true)
+
+	inst.CodexSessionID = mainSID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:                      "waiting",
+		SessionID:                   mainSID,
+		StateSessionID:              mainSID,
+		Event:                       "agent-turn-complete",
+		UpdatedAt:                   time.Now(),
+		Generation:                  5,
+		LastTurnStartedGeneration:   4,
+		LastTurnCompletedGeneration: 5,
+	})
+	inst.UpdateHookStatus(&HookStatus{
+		Status:                      "waiting",
+		SessionID:                   childSID,
+		StateSessionID:              childSID,
+		Event:                       "agent-turn-complete",
+		UpdatedAt:                   time.Now().Add(time.Second),
+		Generation:                  6,
+		LastTurnStartedGeneration:   4,
+		LastTurnCompletedGeneration: 6,
+	})
+
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if !inst.hasMatchingCodexCompletionLocked() {
+		t.Fatal("rejected subagent completion replaced the main thread's retained completion evidence")
+	}
+}

--- a/internal/session/codex_subagent_gate.go
+++ b/internal/session/codex_subagent_gate.go
@@ -149,14 +149,21 @@ func codexThreadMetaForSession(sessionID, codexHome string) (codexThreadMeta, bo
 	return meta, true
 }
 
+// IsCodexSubagentThread reports whether a flushed rollout proves that the
+// session was spawned as a Codex subagent. Missing or unreadable rollouts are
+// not evidence and return false so newly-created user threads remain usable.
+func IsCodexSubagentThread(sessionID, codexHome string) bool {
+	meta, ok := codexThreadMetaForSession(sessionID, codexHome)
+	return ok && meta.ThreadSource == "subagent"
+}
+
 // shouldRejectCodexSubagentRebind reports whether a candidate session id from
 // any rotation source (notify hook, live-process FD probe, disk scan) must be
 // rejected because it names a subagent-spawned thread. Candidates without a
 // flushed rollout are allowed through (fail-open, matching the pre-gate
 // behavior for freshly created sessions).
 func (i *Instance) shouldRejectCodexSubagentRebind(candidateID string) bool {
-	meta, ok := codexThreadMetaForSession(candidateID, i.getCodexHomeDir())
-	return ok && meta.ThreadSource == "subagent"
+	return IsCodexSubagentThread(candidateID, i.getCodexHomeDir())
 }
 
 // codexSessionNeedsFork reports whether the bound session id names a

--- a/internal/session/hook_state.go
+++ b/internal/session/hook_state.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"fmt"
+	"time"
+)
+
+const HookStateSchemaV1 = "agent-deck.hook-state/v1"
+
+// HookStateDocument extends the latest hook event with retained, monotonic
+// turn generations. The legacy fields keep their existing JSON names so older
+// Agent Deck versions can continue reading files written by this version.
+type HookStateDocument struct {
+	SchemaVersion string `json:"hook_state_schema_version,omitempty"`
+
+	Status    string `json:"status"`
+	SessionID string `json:"session_id,omitempty"`
+	// StateSessionID binds retained generations to one upstream session while
+	// SessionID preserves the legacy latest-event field, which may be empty.
+	StateSessionID string `json:"hook_state_session_id,omitempty"`
+	Event          string `json:"event"`
+	Timestamp      int64  `json:"ts"`
+
+	DoneStatus     string `json:"done_status,omitempty"`
+	DoneSummary    string `json:"done_summary,omitempty"`
+	TranscriptPath string `json:"transcript_path,omitempty"`
+	Cwd            string `json:"cwd,omitempty"`
+
+	Generation                  uint64 `json:"generation,omitempty"`
+	LastTurnStartedGeneration   uint64 `json:"last_turn_started_generation,omitempty"`
+	LastTurnCompletedGeneration uint64 `json:"last_turn_completed_generation,omitempty"`
+	LastTurnStartedAt           int64  `json:"last_turn_started_at,omitempty"`
+	LastTurnCompletedAt         int64  `json:"last_turn_completed_at,omitempty"`
+}
+
+type HookStateEventKind string
+
+const (
+	HookStatusOnly    HookStateEventKind = "status"
+	HookTurnStarted   HookStateEventKind = "turn_started"
+	HookTurnCompleted HookStateEventKind = "turn_completed"
+)
+
+type HookStateEvent struct {
+	Kind           HookStateEventKind
+	Status         string
+	SessionID      string
+	Event          string
+	At             time.Time
+	DoneStatus     string
+	DoneSummary    string
+	TranscriptPath string
+	Cwd            string
+}
+
+// AdvanceHookState retains turn ordering even when start and completion share
+// one Unix second. A changed upstream session cannot inherit an old completion.
+func AdvanceHookState(previous HookStateDocument, event HookStateEvent) (HookStateDocument, error) {
+	switch event.Kind {
+	case HookStatusOnly, HookTurnStarted, HookTurnCompleted:
+	default:
+		return HookStateDocument{}, fmt.Errorf("unknown hook state event kind %q", event.Kind)
+	}
+	if event.Status == "" {
+		return HookStateDocument{}, fmt.Errorf("hook status is required")
+	}
+
+	next := previous
+	if next.SchemaVersion == "" {
+		next.SchemaVersion = HookStateSchemaV1
+	}
+	previousStateSessionID := previous.StateSessionID
+	if previousStateSessionID == "" {
+		previousStateSessionID = previous.SessionID
+	}
+	if previousStateSessionID != "" && event.SessionID != "" && previousStateSessionID != event.SessionID {
+		next.LastTurnStartedGeneration = 0
+		next.LastTurnCompletedGeneration = 0
+		next.LastTurnStartedAt = 0
+		next.LastTurnCompletedAt = 0
+	}
+
+	// Preserve the legacy latest-event shape: an event without a session ID
+	// keeps session_id empty. The retained identity remains available separately.
+	next.SessionID = event.SessionID
+	if event.SessionID != "" {
+		next.StateSessionID = event.SessionID
+	}
+	if event.Status == "dead" && event.SessionID == "" {
+		next.StateSessionID = ""
+		next.LastTurnStartedGeneration = 0
+		next.LastTurnCompletedGeneration = 0
+		next.LastTurnStartedAt = 0
+		next.LastTurnCompletedAt = 0
+	}
+
+	at := event.At
+	if at.IsZero() {
+		at = time.Now()
+	}
+	next.Generation++
+	next.Status = event.Status
+	next.Event = event.Event
+	next.Timestamp = at.Unix()
+	next.DoneStatus = event.DoneStatus
+	next.DoneSummary = event.DoneSummary
+	next.TranscriptPath = event.TranscriptPath
+	next.Cwd = event.Cwd
+
+	switch event.Kind {
+	case HookTurnStarted:
+		next.LastTurnStartedGeneration = next.Generation
+		next.LastTurnStartedAt = at.UnixNano()
+	case HookTurnCompleted:
+		next.LastTurnCompletedGeneration = next.Generation
+		next.LastTurnCompletedAt = at.UnixNano()
+	}
+	return next, nil
+}
+
+func validateHookInstanceID(instanceID string) error {
+	if len(instanceID) == 0 || len(instanceID) > 128 || instanceID == "." || instanceID == ".." {
+		return fmt.Errorf("invalid hook instance ID")
+	}
+	for _, r := range instanceID {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-', r == '_':
+		default:
+			return fmt.Errorf("invalid hook instance ID")
+		}
+	}
+	return nil
+}

--- a/internal/session/hook_state_store.go
+++ b/internal/session/hook_state_store.go
@@ -2,12 +2,15 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
+
+var errHookStateDecode = errors.New("decode hook state")
 
 // WriteHookState applies one event under a per-instance file lock and replaces
 // the status document atomically with a randomized same-directory temp file.
@@ -38,7 +41,10 @@ func writeHookStateAt(hooksDir, instanceID string, event HookStateEvent) error {
 	statePath := filepath.Join(hooksDir, instanceID+".json")
 	previous, err := readHookStateAt(statePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read hook state: %w", err)
+		if !errors.Is(err, errHookStateDecode) {
+			return fmt.Errorf("read hook state: %w", err)
+		}
+		previous = HookStateDocument{}
 	}
 	next, err := AdvanceHookState(previous, event)
 	if err != nil {
@@ -92,7 +98,7 @@ func readHookStateAt(path string) (HookStateDocument, error) {
 	}
 	var state HookStateDocument
 	if err := json.Unmarshal(data, &state); err != nil {
-		return HookStateDocument{}, fmt.Errorf("decode hook state: %w", err)
+		return HookStateDocument{}, fmt.Errorf("%w: %w", errHookStateDecode, err)
 	}
 	return state, nil
 }

--- a/internal/session/hook_state_store.go
+++ b/internal/session/hook_state_store.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// WriteHookState applies one event under a per-instance file lock and replaces
+// the status document atomically with a randomized same-directory temp file.
+func WriteHookState(instanceID string, event HookStateEvent) error {
+	return writeHookStateAt(GetHooksDir(), instanceID, event)
+}
+
+func writeHookStateAt(hooksDir, instanceID string, event HookStateEvent) error {
+	if err := validateHookInstanceID(instanceID); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(hooksDir, 0o700); err != nil {
+		return fmt.Errorf("create hooks directory: %w", err)
+	}
+
+	lockPath := filepath.Join(hooksDir, "."+instanceID+".lock")
+	lockFD, err := unix.Open(lockPath, unix.O_CREAT|unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return fmt.Errorf("open hook state lock: %w", err)
+	}
+	lockFile := os.NewFile(uintptr(lockFD), lockPath)
+	defer lockFile.Close()
+	if err := unix.Flock(lockFD, unix.LOCK_EX); err != nil {
+		return fmt.Errorf("lock hook state: %w", err)
+	}
+	defer unix.Flock(lockFD, unix.LOCK_UN) //nolint:errcheck
+
+	statePath := filepath.Join(hooksDir, instanceID+".json")
+	previous, err := readHookStateAt(statePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read hook state: %w", err)
+	}
+	next, err := AdvanceHookState(previous, event)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(next)
+	if err != nil {
+		return fmt.Errorf("marshal hook state: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(hooksDir, "."+instanceID+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create hook state temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		_ = tmp.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return fmt.Errorf("secure hook state temp: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write hook state temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync hook state temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close hook state temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, statePath); err != nil {
+		return fmt.Errorf("replace hook state: %w", err)
+	}
+	cleanup = false
+
+	if dir, err := os.Open(hooksDir); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
+}
+
+func readHookStateAt(path string) (HookStateDocument, error) {
+	data, err := readStatusFileNoFollow(path)
+	if err != nil {
+		return HookStateDocument{}, err
+	}
+	var state HookStateDocument
+	if err := json.Unmarshal(data, &state); err != nil {
+		return HookStateDocument{}, fmt.Errorf("decode hook state: %w", err)
+	}
+	return state, nil
+}

--- a/internal/session/hook_state_store_test.go
+++ b/internal/session/hook_state_store_test.go
@@ -101,3 +101,32 @@ func TestWriteHookStateAtRejectsSymlinkWithoutTouchingTarget(t *testing.T) {
 		t.Fatalf("symlink target changed: %q", data)
 	}
 }
+
+func TestWriteHookStateAtRecoversFromCorruptDocument(t *testing.T) {
+	t.Parallel()
+
+	hooksDir := filepath.Join(t.TempDir(), "hooks")
+	if err := os.Mkdir(hooksDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	statePath := filepath.Join(hooksDir, "instance-1.json")
+	if err := os.WriteFile(statePath, []byte(`{"status":`), 0o600); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+
+	err := writeHookStateAt(hooksDir, "instance-1", HookStateEvent{
+		Kind: HookTurnCompleted, Status: "waiting", SessionID: "thread-1", Event: "turn.completed",
+	})
+	if err != nil {
+		t.Fatalf("writeHookStateAt did not recover from corrupt state: %v", err)
+	}
+
+	state, err := readHookStateAt(statePath)
+	if err != nil {
+		t.Fatalf("read recovered state: %v", err)
+	}
+	if state.Generation != 1 || state.StateSessionID != "thread-1" ||
+		state.LastTurnCompletedGeneration != 1 {
+		t.Fatalf("recovered state = %#v, want fresh completed generation", state)
+	}
+}

--- a/internal/session/hook_state_store_test.go
+++ b/internal/session/hook_state_store_test.go
@@ -1,0 +1,103 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+func TestWriteHookStateAtSerializesConcurrentWriters(t *testing.T) {
+	t.Parallel()
+
+	hooksDir := filepath.Join(t.TempDir(), "hooks")
+	const writers = 24
+	errs := make(chan error, writers)
+	var wg sync.WaitGroup
+	for idx := 0; idx < writers; idx++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- writeHookStateAt(hooksDir, "instance-1", HookStateEvent{
+				Kind: HookStatusOnly, Status: "running", SessionID: "thread-1", Event: "status",
+			})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent writer: %v", err)
+		}
+	}
+
+	if err := writeHookStateAt(hooksDir, "instance-1", HookStateEvent{
+		Kind: HookTurnStarted, Status: "running", SessionID: "thread-1", Event: "turn.started",
+	}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := writeHookStateAt(hooksDir, "instance-1", HookStateEvent{
+		Kind: HookTurnCompleted, Status: "waiting", SessionID: "thread-1", Event: "turn.completed",
+	}); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	state, err := readHookStateAt(filepath.Join(hooksDir, "instance-1.json"))
+	if err != nil {
+		t.Fatalf("readHookStateAt: %v", err)
+	}
+	if state.Generation != writers+2 {
+		t.Fatalf("generation = %d, want %d", state.Generation, writers+2)
+	}
+	if state.LastTurnStartedGeneration != writers+1 || state.LastTurnCompletedGeneration != writers+2 {
+		t.Fatalf("start/completion generations not retained: %#v", state)
+	}
+
+	info, err := os.Stat(filepath.Join(hooksDir, "instance-1.json"))
+	if err != nil {
+		t.Fatalf("stat hook state: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("hook state mode = %o, want 600", got)
+	}
+	temps, err := filepath.Glob(filepath.Join(hooksDir, ".instance-1.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(temps) != 0 {
+		t.Fatalf("atomic temp files left behind: %v", temps)
+	}
+}
+
+func TestWriteHookStateAtRejectsSymlinkWithoutTouchingTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, "hooks")
+	if err := os.Mkdir(hooksDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	victim := filepath.Join(root, "victim")
+	if err := os.WriteFile(victim, []byte("do not touch"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+	if err := os.Symlink(victim, filepath.Join(hooksDir, "instance-1.json")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := writeHookStateAt(hooksDir, "instance-1", HookStateEvent{
+		Kind: HookTurnStarted, Status: "running", SessionID: "thread-1", Event: "turn.started",
+	})
+	if err == nil || !errors.Is(err, syscall.ELOOP) {
+		t.Fatalf("symlink write error = %v, want ELOOP", err)
+	}
+	data, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(data) != "do not touch" {
+		t.Fatalf("symlink target changed: %q", data)
+	}
+}

--- a/internal/session/hook_state_store_test.go
+++ b/internal/session/hook_state_store_test.go
@@ -130,3 +130,26 @@ func TestWriteHookStateAtRecoversFromCorruptDocument(t *testing.T) {
 		t.Fatalf("recovered state = %#v, want fresh completed generation", state)
 	}
 }
+
+func TestWriteHookStateAtPropagatesNonDecodeReadError(t *testing.T) {
+	t.Parallel()
+
+	hooksDir := filepath.Join(t.TempDir(), "hooks")
+	if err := os.Mkdir(hooksDir, 0o700); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	statePath := filepath.Join(hooksDir, "instance-1.json")
+	if err := os.Mkdir(statePath, 0o700); err != nil {
+		t.Fatalf("mkdir state-path obstruction: %v", err)
+	}
+
+	err := writeHookStateAt(hooksDir, "instance-1", HookStateEvent{
+		Kind: HookTurnCompleted, Status: "waiting", SessionID: "thread-1", Event: "turn.completed",
+	})
+	if err == nil {
+		t.Fatal("non-decode read error was silently recovered")
+	}
+	if info, statErr := os.Stat(statePath); statErr != nil || !info.IsDir() {
+		t.Fatalf("state-path obstruction changed: info=%v err=%v", info, statErr)
+	}
+}

--- a/internal/session/hook_state_test.go
+++ b/internal/session/hook_state_test.go
@@ -69,6 +69,32 @@ func TestAdvanceHookStateNewSessionCannotReusePriorCompletion(t *testing.T) {
 	}
 }
 
+func TestAdvanceHookStateDeadEventClearsRetainedEvidence(t *testing.T) {
+	t.Parallel()
+
+	state := HookStateDocument{
+		SchemaVersion:               HookStateSchemaV1,
+		Generation:                  5,
+		SessionID:                   "thread-1",
+		StateSessionID:              "thread-1",
+		LastTurnStartedGeneration:   4,
+		LastTurnCompletedGeneration: 5,
+		LastTurnStartedAt:           100,
+		LastTurnCompletedAt:         200,
+	}
+	next, err := AdvanceHookState(state, HookStateEvent{
+		Kind: HookStatusOnly, Status: "dead", Event: "session.dead",
+	})
+	if err != nil {
+		t.Fatalf("AdvanceHookState: %v", err)
+	}
+	if next.StateSessionID != "" || next.LastTurnStartedGeneration != 0 ||
+		next.LastTurnCompletedGeneration != 0 || next.LastTurnStartedAt != 0 ||
+		next.LastTurnCompletedAt != 0 {
+		t.Fatalf("dead event did not clear retained evidence: %#v", next)
+	}
+}
+
 func TestValidateHookInstanceIDRejectsUnsafePaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/hook_state_test.go
+++ b/internal/session/hook_state_test.go
@@ -1,0 +1,85 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestHookStateDocumentReadsLegacyStatusJSON(t *testing.T) {
+	t.Parallel()
+
+	legacy := []byte(`{"status":"waiting","session_id":"thread-1","event":"agent-turn-complete","ts":1722186000}`)
+	var state HookStateDocument
+	if err := json.Unmarshal(legacy, &state); err != nil {
+		t.Fatalf("Unmarshal legacy status: %v", err)
+	}
+	if state.Status != "waiting" || state.SessionID != "thread-1" || state.Event != "agent-turn-complete" {
+		t.Fatalf("legacy fields changed: %#v", state)
+	}
+	if state.Generation != 0 || state.LastTurnStartedGeneration != 0 || state.LastTurnCompletedGeneration != 0 {
+		t.Fatalf("legacy document must start without retained generations: %#v", state)
+	}
+}
+
+func TestAdvanceHookStateRetainsSameSecondStartAndCompletion(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 7, 28, 17, 50, 0, 0, time.UTC)
+	state, err := AdvanceHookState(HookStateDocument{}, HookStateEvent{
+		Kind: HookTurnStarted, Status: "running", SessionID: "thread-1", Event: "turn.started", At: at,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	state, err = AdvanceHookState(state, HookStateEvent{
+		Kind: HookTurnCompleted, Status: "waiting", SessionID: "thread-1", Event: "agent-turn-complete", At: at,
+	})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	if state.Generation != 2 || state.LastTurnStartedGeneration != 1 || state.LastTurnCompletedGeneration != 2 {
+		t.Fatalf("retained generation order lost: %#v", state)
+	}
+	if state.LastTurnStartedAt != at.UnixNano() || state.LastTurnCompletedAt != at.UnixNano() {
+		t.Fatalf("event times not retained: %#v", state)
+	}
+}
+
+func TestAdvanceHookStateNewSessionCannotReusePriorCompletion(t *testing.T) {
+	t.Parallel()
+
+	state := HookStateDocument{
+		SchemaVersion:               HookStateSchemaV1,
+		Generation:                  8,
+		SessionID:                   "thread-old",
+		StateSessionID:              "thread-old",
+		LastTurnStartedGeneration:   7,
+		LastTurnCompletedGeneration: 8,
+	}
+	next, err := AdvanceHookState(state, HookStateEvent{
+		Kind: HookTurnStarted, Status: "running", SessionID: "thread-new", Event: "turn.started",
+	})
+	if err != nil {
+		t.Fatalf("AdvanceHookState: %v", err)
+	}
+	if next.Generation != 9 || next.LastTurnStartedGeneration != 9 || next.LastTurnCompletedGeneration != 0 {
+		t.Fatalf("new session inherited prior completion: %#v", next)
+	}
+}
+
+func TestValidateHookInstanceIDRejectsUnsafePaths(t *testing.T) {
+	t.Parallel()
+
+	for _, valid := range []string{"instance-001", "550e8400-e29b-41d4-a716-446655440000", "abc_DEF"} {
+		if err := validateHookInstanceID(valid); err != nil {
+			t.Errorf("valid ID %q rejected: %v", valid, err)
+		}
+	}
+	for _, invalid := range []string{"", ".", "..", "../victim", "nested/victim", `nested\victim`, "has space", "💣"} {
+		if err := validateHookInstanceID(invalid); err == nil {
+			t.Errorf("unsafe ID %q accepted", invalid)
+		}
+	}
+}

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -64,7 +64,9 @@ type HookStatus struct {
 	Cwd string
 }
 
-func hookStatusFromDocument(state HookStateDocument, updatedAt time.Time) *HookStatus {
+// HookStatusFromDocument converts the shared persisted hook-state document to
+// the in-memory shape consumed by every status surface.
+func HookStatusFromDocument(state HookStateDocument, updatedAt time.Time) *HookStatus {
 	return &HookStatus{
 		Status:                      state.Status,
 		SessionID:                   state.SessionID,
@@ -353,7 +355,7 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
-		out[instanceID] = hookStatusFromDocument(raw, time.Unix(raw.Timestamp, 0))
+		out[instanceID] = HookStatusFromDocument(raw, time.Unix(raw.Timestamp, 0))
 	}
 }
 
@@ -484,7 +486,7 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		return
 	}
 
-	hookStatus := hookStatusFromDocument(status, time.Unix(status.Timestamp, 0))
+	hookStatus := HookStatusFromDocument(status, time.Unix(status.Timestamp, 0))
 
 	w.mu.Lock()
 	w.statuses[instanceID] = hookStatus

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -41,6 +41,14 @@ type HookStatus struct {
 	SessionID string    // Claude session ID
 	Event     string    // Hook event name
 	UpdatedAt time.Time // When this status was received
+	// Retained Codex turn evidence. StateSessionID remains populated when a
+	// completion payload omits the legacy latest-event session_id.
+	StateSessionID              string
+	Generation                  uint64
+	LastTurnStartedGeneration   uint64
+	LastTurnCompletedGeneration uint64
+	LastTurnStartedAt           int64
+	LastTurnCompletedAt         int64
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
 	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
@@ -54,6 +62,25 @@ type HookStatus struct {
 	// id may bind — empty (legacy files, agents that send no cwd) means "no
 	// evidence either way" and never blocks.
 	Cwd string
+}
+
+func hookStatusFromDocument(state HookStateDocument, updatedAt time.Time) *HookStatus {
+	return &HookStatus{
+		Status:                      state.Status,
+		SessionID:                   state.SessionID,
+		StateSessionID:              state.StateSessionID,
+		Event:                       state.Event,
+		UpdatedAt:                   updatedAt,
+		Generation:                  state.Generation,
+		LastTurnStartedGeneration:   state.LastTurnStartedGeneration,
+		LastTurnCompletedGeneration: state.LastTurnCompletedGeneration,
+		LastTurnStartedAt:           state.LastTurnStartedAt,
+		LastTurnCompletedAt:         state.LastTurnCompletedAt,
+		DoneStatus:                  state.DoneStatus,
+		DoneSummary:                 state.DoneSummary,
+		TranscriptPath:              state.TranscriptPath,
+		Cwd:                         state.Cwd,
+	}
 }
 
 // StatusFileWatcher watches ~/.agent-deck/hooks/ for status file changes
@@ -322,29 +349,11 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 		if rerr != nil {
 			continue
 		}
-		var raw struct {
-			Status         string `json:"status"`
-			SessionID      string `json:"session_id"`
-			Event          string `json:"event"`
-			Timestamp      int64  `json:"ts"`
-			DoneStatus     string `json:"done_status"`
-			DoneSummary    string `json:"done_summary"`
-			TranscriptPath string `json:"transcript_path"`
-			Cwd            string `json:"cwd"`
-		}
+		var raw HookStateDocument
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
-		out[instanceID] = &HookStatus{
-			Status:         raw.Status,
-			SessionID:      raw.SessionID,
-			Event:          raw.Event,
-			UpdatedAt:      time.Unix(raw.Timestamp, 0),
-			DoneStatus:     raw.DoneStatus,
-			DoneSummary:    raw.DoneSummary,
-			TranscriptPath: raw.TranscriptPath,
-			Cwd:            raw.Cwd,
-		}
+		out[instanceID] = hookStatusFromDocument(raw, time.Unix(raw.Timestamp, 0))
 	}
 }
 
@@ -464,16 +473,7 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		return
 	}
 
-	var status struct {
-		Status         string `json:"status"`
-		SessionID      string `json:"session_id"`
-		Event          string `json:"event"`
-		Timestamp      int64  `json:"ts"`
-		DoneStatus     string `json:"done_status"`
-		DoneSummary    string `json:"done_summary"`
-		TranscriptPath string `json:"transcript_path"`
-		Cwd            string `json:"cwd"`
-	}
+	var status HookStateDocument
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
 			slog.String("path", filePath),
@@ -484,16 +484,7 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		return
 	}
 
-	hookStatus := &HookStatus{
-		Status:         status.Status,
-		SessionID:      status.SessionID,
-		Event:          status.Event,
-		UpdatedAt:      time.Unix(status.Timestamp, 0),
-		DoneStatus:     status.DoneStatus,
-		DoneSummary:    status.DoneSummary,
-		TranscriptPath: status.TranscriptPath,
-		Cwd:            status.Cwd,
-	}
+	hookStatus := hookStatusFromDocument(status, time.Unix(status.Timestamp, 0))
 
 	w.mu.Lock()
 	w.statuses[instanceID] = hookStatus

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5637,6 +5637,10 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		// refuses turn/start and error-loops the session. See
 		// codex_subagent_gate.go.
 		if i.shouldRejectCodexSubagentRebind(sessionID) {
+			i.hookStateSessionID = prevHookStateSessionID
+			i.hookGeneration = prevHookGeneration
+			i.hookLastTurnStartedGeneration = prevHookStartedGeneration
+			i.hookLastTurnCompletedGeneration = prevHookCompletedGeneration
 			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
 				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
 				Source: hookSource, OldID: i.CodexSessionID, Candidate: sessionID,

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4981,7 +4981,7 @@ func (i *Instance) UpdateStatus() error {
 
 	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
 	// Read the hook file from disk once to give CLI the same fast path as the TUI.
-	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
 			i.hookEvent = hs.Event
@@ -5639,6 +5639,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		// refuses turn/start and error-loops the session. See
 		// codex_subagent_gate.go.
 		if i.shouldRejectCodexSubagentRebind(sessionID) {
+			i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
 			i.hookStateSessionID = prevHookStateSessionID
 			i.hookGeneration = prevHookGeneration
 			i.hookLastTurnStartedGeneration = prevHookStartedGeneration

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4785,11 +4785,12 @@ func debounceFlipFromRunningWithCompletion(prev, derived Status, tmuxRaw, hookSt
 	return debounceFlipFromRunning(prev, derived, tmuxRaw, hookStatus, pending)
 }
 
-func codexCompletionMatchesBoundSession(stateSessionID, boundSessionID string, started, completed uint64) bool {
+func codexCompletionMatchesBoundSession(stateSessionID, boundSessionID string, generation, started, completed uint64) bool {
 	return stateSessionID != "" &&
 		boundSessionID != "" &&
 		stateSessionID == boundSessionID &&
 		completed > 0 &&
+		completed == generation &&
 		completed >= started
 }
 
@@ -4798,6 +4799,7 @@ func (i *Instance) hasMatchingCodexCompletionLocked() bool {
 		codexCompletionMatchesBoundSession(
 			i.hookStateSessionID,
 			i.CodexSessionID,
+			i.hookGeneration,
 			i.hookLastTurnStartedGeneration,
 			i.hookLastTurnCompletedGeneration,
 		)

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -472,6 +472,13 @@ type Instance struct {
 	hookEvent      string    // Hook event name that caused the last status (e.g. "PermissionRequest")
 	hookSessionID  string    // Session ID from hook payload
 	hookLastUpdate time.Time // When hook status was last received
+	// Retained turn evidence is written atomically by hook processes. It lets a
+	// fresh CLI process distinguish an explicit Codex completion from a
+	// pane-only running→waiting sample that still needs debounce.
+	hookStateSessionID              string
+	hookGeneration                  uint64
+	hookLastTurnStartedGeneration   uint64
+	hookLastTurnCompletedGeneration uint64
 
 	// SSE-based status detection for OpenCode (set by OpenCodeSSEWatcher,
 	// issue #1614). Not persisted; rebuilt from the live event stream.
@@ -4767,6 +4774,35 @@ func debounceFlipFromRunning(prev, derived Status, tmuxRaw, hookStatus string, p
 	return derived, false, false
 }
 
+// debounceFlipFromRunningWithCompletion preserves the existing one-sample hold
+// unless an explicit matching-session Codex completion corroborates a waiting
+// pane. Errors remain debounceable because completion evidence does not explain
+// a failed pane capture or an error banner.
+func debounceFlipFromRunningWithCompletion(prev, derived Status, tmuxRaw, hookStatus string, pending, matchingCompletion bool) (apply Status, nextPending bool, held bool) {
+	if matchingCompletion && derived == StatusWaiting {
+		return derived, false, false
+	}
+	return debounceFlipFromRunning(prev, derived, tmuxRaw, hookStatus, pending)
+}
+
+func codexCompletionMatchesBoundSession(stateSessionID, boundSessionID string, started, completed uint64) bool {
+	return stateSessionID != "" &&
+		boundSessionID != "" &&
+		stateSessionID == boundSessionID &&
+		completed > 0 &&
+		completed >= started
+}
+
+func (i *Instance) hasMatchingCodexCompletionLocked() bool {
+	return IsCodexCompatible(i.Tool) &&
+		codexCompletionMatchesBoundSession(
+			i.hookStateSessionID,
+			i.CodexSessionID,
+			i.hookLastTurnStartedGeneration,
+			i.hookLastTurnCompletedGeneration,
+		)
+}
+
 func shouldDebounceTmuxFlipForTool(tool string) bool {
 	return tool == "" || IsClaudeCompatible(tool) || IsCodexCompatible(tool) ||
 		tool == "gemini" || tool == "hermes" || tool == "cursor"
@@ -4949,6 +4985,10 @@ func (i *Instance) UpdateStatus() error {
 			i.hookEvent = hs.Event
 			i.hookLastUpdate = hs.UpdatedAt
 			i.hookSessionID = hs.SessionID
+			i.hookStateSessionID = hs.StateSessionID
+			i.hookGeneration = hs.Generation
+			i.hookLastTurnStartedGeneration = hs.LastTurnStartedGeneration
+			i.hookLastTurnCompletedGeneration = hs.LastTurnCompletedGeneration
 			// Reset stale acknowledged flag from ReconnectSessionLazy.
 			// Without this, sessions loaded from SQLite with previousStatus="idle"
 			// would report idle even when the hook file says waiting/running.
@@ -5204,7 +5244,15 @@ func (i *Instance) UpdateStatus() error {
 	// tmuxFlipFromRunningPending = false and holds the status at running on the
 	// first sample, then exits before the second confirming sample can fire.
 	if shouldDebounceTmuxFlipForTool(i.Tool) {
-		if apply, nextPending, held := debounceFlipFromRunning(prevStatus, i.Status, status, i.hookStatus, i.tmuxFlipFromRunningPending); held {
+		matchingCompletion := i.hasMatchingCodexCompletionLocked()
+		if apply, nextPending, held := debounceFlipFromRunningWithCompletion(
+			prevStatus,
+			i.Status,
+			status,
+			i.hookStatus,
+			i.tmuxFlipFromRunningPending,
+			matchingCompletion,
+		); held {
 			i.tmuxFlipFromRunningPending = nextPending
 			i.Status = apply
 			return nil
@@ -5212,6 +5260,13 @@ func (i *Instance) UpdateStatus() error {
 		// Confirmed flip (second consecutive sample) or a non-debounceable outcome:
 		// clear the marker so a later genuine flip starts a fresh debounce.
 		i.tmuxFlipFromRunningPending = false
+		// A matching retained completion plus a waiting pane is already the
+		// complete status decision. The bound Codex session ID is part of that
+		// evidence, so a fresh CLI does not need the later DetectTool/session
+		// metadata probes that the ordinary tmux fallback performs.
+		if matchingCompletion && i.Status == StatusWaiting {
+			return nil
+		}
 	} else {
 		i.tmuxFlipFromRunningPending = false
 	}
@@ -5419,6 +5474,10 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	// it carried had already been written here and stuck, flipping this
 	// instance's status. See the candidate_has_no_conversation_data branch.
 	prevHookStatus, prevHookEvent, prevHookLastUpdate := i.hookStatus, i.hookEvent, i.hookLastUpdate
+	prevHookStateSessionID := i.hookStateSessionID
+	prevHookGeneration := i.hookGeneration
+	prevHookStartedGeneration := i.hookLastTurnStartedGeneration
+	prevHookCompletedGeneration := i.hookLastTurnCompletedGeneration
 
 	// Detect whether this is genuinely new data (newer timestamp than last seen).
 	// Only reset acknowledgment on new events — not on re-application of the same
@@ -5428,6 +5487,10 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	i.hookStatus = status.Status
 	i.hookEvent = status.Event
 	i.hookLastUpdate = status.UpdatedAt
+	i.hookStateSessionID = status.StateSessionID
+	i.hookGeneration = status.Generation
+	i.hookLastTurnStartedGeneration = status.LastTurnStartedGeneration
+	i.hookLastTurnCompletedGeneration = status.LastTurnCompletedGeneration
 
 	// Permission-type events are always attention-needed, even if the user
 	// previously acknowledged this session. A mid-task permission block is new
@@ -5490,6 +5553,10 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		// never blocks.
 		if i.hookCwdIsForeign(status.Cwd) {
 			i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
+			i.hookStateSessionID = prevHookStateSessionID
+			i.hookGeneration = prevHookGeneration
+			i.hookLastTurnStartedGeneration = prevHookStartedGeneration
+			i.hookLastTurnCompletedGeneration = prevHookCompletedGeneration
 			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
 				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
 				Source: hookSource, OldID: i.ClaudeSessionID, Candidate: sessionID,
@@ -5512,6 +5579,10 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 			// foreign hook is a no-op, not a flip. (A real /clear or fork carries
 			// conversation data and never reaches this branch.)
 			i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
+			i.hookStateSessionID = prevHookStateSessionID
+			i.hookGeneration = prevHookGeneration
+			i.hookLastTurnStartedGeneration = prevHookStartedGeneration
+			i.hookLastTurnCompletedGeneration = prevHookCompletedGeneration
 			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
 				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
 				Source: hookSource, OldID: i.ClaudeSessionID, Candidate: sessionID,
@@ -5746,7 +5817,13 @@ func (i *Instance) SetAutoNameDescription(desc string) {
 func (i *Instance) ClearHookStatus() {
 	i.mu.Lock()
 	i.hookStatus = ""
+	i.hookEvent = ""
+	i.hookSessionID = ""
 	i.hookLastUpdate = time.Time{}
+	i.hookStateSessionID = ""
+	i.hookGeneration = 0
+	i.hookLastTurnStartedGeneration = 0
+	i.hookLastTurnCompletedGeneration = 0
 	i.mu.Unlock()
 
 	// Remove the persisted status file. Sandbox sessions bridge a PER-INSTANCE

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -739,16 +739,7 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	if err != nil || len(data) == 0 {
 		return nil
 	}
-	var raw struct {
-		Status         string `json:"status"`
-		SessionID      string `json:"session_id"`
-		Event          string `json:"event"`
-		Timestamp      int64  `json:"ts"`
-		DoneStatus     string `json:"done_status"`
-		DoneSummary    string `json:"done_summary"`
-		TranscriptPath string `json:"transcript_path"`
-		Cwd            string `json:"cwd"`
-	}
+	var raw HookStateDocument
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
 	}
@@ -759,16 +750,7 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	if raw.Timestamp > 0 {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
-	return &HookStatus{
-		Status:         raw.Status,
-		SessionID:      raw.SessionID,
-		Event:          raw.Event,
-		UpdatedAt:      updatedAt,
-		DoneStatus:     raw.DoneStatus,
-		DoneSummary:    raw.DoneSummary,
-		TranscriptPath: raw.TranscriptPath,
-		Cwd:            raw.Cwd,
-	}
+	return hookStatusFromDocument(raw, updatedAt)
 }
 
 func (d *TransitionDaemon) emitHookTransitionCandidates(

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -750,7 +750,7 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	if raw.Timestamp > 0 {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
-	return hookStatusFromDocument(raw, updatedAt)
+	return HookStatusFromDocument(raw, updatedAt)
 }
 
 func (d *TransitionDaemon) emitHookTransitionCandidates(

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -344,13 +344,6 @@ func toMenuSession(inst *session.Instance) *MenuSession {
 	}
 }
 
-type rawHookStatus struct {
-	Status    string `json:"status"`
-	SessionID string `json:"session_id"`
-	Event     string `json:"event"`
-	Timestamp int64  `json:"ts"`
-}
-
 func defaultLoadHookStatuses() map[string]*session.HookStatus {
 	hooksByInstance := make(map[string]*session.HookStatus)
 	hooksDir := session.GetHooksDir()
@@ -389,7 +382,7 @@ func defaultLoadHookStatuses() map[string]*session.HookStatus {
 			continue
 		}
 
-		var parsed rawHookStatus
+		var parsed session.HookStateDocument
 		if err := json.Unmarshal(raw, &parsed); err != nil {
 			hookStatusLog.Warn("hook_status_unmarshal_failed",
 				slog.String("file", entry.Name()),
@@ -409,12 +402,7 @@ func defaultLoadHookStatuses() map[string]*session.HookStatus {
 			}
 		}
 
-		hooksByInstance[instanceID] = &session.HookStatus{
-			Status:    parsed.Status,
-			SessionID: parsed.SessionID,
-			Event:     parsed.Event,
-			UpdatedAt: updatedAt,
-		}
+		hooksByInstance[instanceID] = session.HookStatusFromDocument(parsed, updatedAt)
 	}
 
 	return hooksByInstance

--- a/internal/web/session_data_service_hooks_test.go
+++ b/internal/web/session_data_service_hooks_test.go
@@ -50,6 +50,44 @@ func TestDefaultLoadHookStatuses(t *testing.T) {
 	}
 }
 
+func TestDefaultLoadHookStatusesRetainsGenerationEvidence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	at := time.Date(2026, 7, 28, 18, 15, 0, 0, time.UTC)
+	if err := session.WriteHookState("web-hook-state", session.HookStateEvent{
+		Kind:      session.HookTurnStarted,
+		Status:    "running",
+		SessionID: "thread-web",
+		Event:     "turn.started",
+		At:        at,
+	}); err != nil {
+		t.Fatalf("write start state: %v", err)
+	}
+	if err := session.WriteHookState("web-hook-state", session.HookStateEvent{
+		Kind:      session.HookTurnCompleted,
+		Status:    "waiting",
+		SessionID: "thread-web",
+		Event:     "agent-turn-complete",
+		At:        at,
+	}); err != nil {
+		t.Fatalf("write completion state: %v", err)
+	}
+
+	hook := defaultLoadHookStatuses()["web-hook-state"]
+	if hook == nil {
+		t.Fatal("hook state not loaded")
+	}
+	if hook.StateSessionID != "thread-web" || hook.Generation != 2 ||
+		hook.LastTurnStartedGeneration != 1 || hook.LastTurnCompletedGeneration != 2 {
+		t.Fatalf("retained evidence = (%q,%d,%d,%d), want (thread-web,2,1,2)",
+			hook.StateSessionID,
+			hook.Generation,
+			hook.LastTurnStartedGeneration,
+			hook.LastTurnCompletedGeneration)
+	}
+}
+
 func TestSessionDataServiceRefreshStatusesAppliesHookData(t *testing.T) {
 	inst := &session.Instance{
 		ID: "sess-1",


### PR DESCRIPTION
## What problem does this solve?

Fresh `agent-deck list --json` processes can report a completed Codex session as
`running` forever because every process forgets the first half of the
running-to-waiting debounce. Fixes #1792.

## Why this change

Codex completion hooks are explicit evidence, but the current status file keeps
only the latest event and orders events with Unix-second timestamps. This
extends that file compatibly with a monotonic generation plus retained
last-started/last-completed generations bound to one Codex thread.

Hook writers now serialize read-modify-write with a per-instance `flock` and
randomized same-directory atomic replacement. A matching completion may bypass
only the first pane debounce sample when it is the current retained event and
the pane also reports waiting. Pane-only evidence, a different thread, or any
later retained event keeps the existing debounce behavior.

All status surfaces now decode the same persisted hook document. Proven Codex
subagent hooks are rejected in the standalone hook process before they can
overwrite the main-thread evidence; missing or unreadable rollout metadata
remains fail-open for compatibility with newly-created user threads.

This is the status-only first slice of the design discussed in #1794; it does
not change prompt delivery, queues, or hook installation.

The 1,024 changed lines stay together because they are one compatibility
contract across the hook writer, every persisted-state reader, the in-memory
debounce, and their regressions. Splitting a reader from the writer would
recreate the mixed-surface failure found during review.

## User impact

A Codex turn with matching current completion evidence settles from persisted
`running` to `waiting` on the first fresh status poll, including Web/headless
status loading. An idle-looking pane without that evidence still cannot
manufacture a completion.

Legacy hook JSON remains readable, and older Agent Deck versions ignore the
new additive fields.

## Evidence

Clean-main real-Codex reproduction and environment details are recorded in
#1792. For the initial tested branch head, I built commit `7885cfe7` as Agent
Deck v1.10.11:

    sha256 8b11c7743f9715a9dec64e7809765a6fdbbc00b5c6bb970a58cf11a5e39ffcce

One isolated real-tmux fixture used a scratch HOME/XDG/profile/socket, a fake
Codex prompt, a persisted `running` row, and a matching completion aged 300s.
The same fixture and same three fresh-process polls produced:

    base 580e772c: running, running, running
    PR   7885cfe7: waiting, waiting, waiting
    persisted DB status after polls: running

Hostile inverse: after retaining a newer start (`started_generation=9`,
`completed_generation=8`) while the fake pane still looked idle, three fresh PR
polls remained `running`.

Hot-path timing over 20 fresh polls on the matching-completion fixture:

    base: 0.850s, 0.818s, 0.938s
    PR:   0.918s, 0.909s, 1.003s

Durable hook-write stress on the current branch completed 100 repetitions of
the 26-write serialized/concurrent regression (2,600 fsync-backed writes) in
76.750s on the host filesystem, about 29.5 ms per write including lock
contention.

The branch is rebased onto upstream `a6626aba`; current head is `ba16ecb2`.
Maintainer-review follow-up added three RED-to-GREEN regressions:

    Web/headless retained evidence:
      before: retained evidence = ("",0,0,0), want (thread-web,2,1,2)
      after:  go test ./internal/web -run '^TestDefaultLoadHookStatusesRetainsGenerationEvidence$' -> ok

    Current-generation completion:
      before: compile failure from the newly-required generation contract
      after:  later events make an older completion ineligible

    Cold-process subagent gate:
      before: child completion overwrote main evidence (generation 3)
      after:  persisted main evidence remains generation 2 and its anchor is unchanged

The subsequent incremental review found three valid compatibility/rollback
edges, all corrected test-first in `ba16ecb2`:

    Configured Codex home:
      before: config_dir-only child rollout was missed and overwrote generation 3
      after:  standalone notify and session gates share GetCodexConfigDir

    compatible_with = "codex" cold load:
      before: retained state="", generation=0, completed=0
      after:  custom Codex tools restore the same generation evidence as built-in Codex

    rejected subagent rollback:
      before: event and UpdatedAt remained the child's fresh completion
      after:  status/event/update time and retained generations all remain the main thread's

The existing fail-closed non-decode I/O behavior also gained explicit coverage;
a directory obstruction at the state-file path is returned as an error and is
not replaced or treated as corrupt JSON.

Focused and package gates:

    go test -p 1 ./internal/session -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/session  92.885s

    go test -p 1 ./internal/web -skip '^(TestWSKeepaliveReapsDeadPeer|TestWSKeepaliveHealthyClientSurvives)$' -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/web  1.518s

    go test -p 1 ./cmd/agent-deck -skip '^TestPerf_ColdStart_(Help|Version)$' -count=1
    ok  github.com/asheshgoplani/agent-deck/cmd/agent-deck  96.765s

    focused -race runs for the new Web, completion, configured-home, compatible-tool,
    rollback, and non-decode I/O regressions: ok
    go vet ./internal/session ./internal/web ./cmd/agent-deck: ok
    go build ./cmd/agent-deck: ok
    git diff --check: ok

The unskipped Web package and CLI package failures reproduce on exact clean
upstream `a6626aba`: the two WebSocket keepalive tests fail there with the same
messages, and the Help/Version cold-start tests exceed the same 40 ms host
threshold (45.11 ms and 41.39 ms on clean main; 43.14 ms and 43.35 ms on this
branch). They are baseline/environment residue, not introduced by this PR.

Revert-check: the changed tests fail on the upstream base without the
production change (new shared hook-document and completion-generation contracts
are absent, and the new Web/cold-process assertions fail), so the tests prove
the fix.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: “Implement the approved plan test-first, beginning with the
contracts and schema lane specified by the plan.” The plan was triggered by
Codex sessions that had visibly completed but stayed `running` across every
fresh Agent Deck poll.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (four host-sensitive failures reproduce on exact clean upstream; details above)
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session and turn-status tracking across Codex hook events.
  * Prevented subagent completions from overwriting main-session completion evidence.
  * Improved recovery from malformed status data while preserving valid state.
  * Improved status reconciliation so completed turns are recognized more reliably.

* **Security & Reliability**
  * Added safer concurrent status updates, file validation, and atomic persistence.
  * Preserved session and generation evidence when loading status after restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->