### PR TITLE
docs(skill): cross-reference the fleet skill and surface session children

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -114,6 +114,7 @@ The table above is what *agent-deck* does. This one is what the *CLI inside a se
 | `agent-deck session send <name> "message"` | Send message |
 | `agent-deck session send <name> --message-file <file>` | Send message from file (`-` = stdin); no shell quoting. Also on `launch`/`session start` |
 | `agent-deck session output <name>` | Get last response |
+| `agent-deck session children --json` | Child sessions' live status + asserted completions (non-blocking, read-only) |
 | `agent-deck session current [-q\|--json]` | Auto-detect current session |
 | `agent-deck session fork <name>` | Fork Claude/Pi conversation |
 | `agent-deck session switch-account <name> <account>` | Switch Claude account, conversation follows |
@@ -144,6 +145,10 @@ The script auto-detects current session/profile and creates a child session.
 | **Fire & forget** | (no --wait) | Default. Tell user: "Ask me to check when ready" |
 | **On-demand** | `agent-deck session output "Title"` | User asks to check |
 | **Blocking** | `--wait` flag | Need immediate result |
+
+### Fanning out several children?
+
+This section covers **one** child (launch + one of the three retrieval modes). For a *fleet* — several children in parallel, supervised non-blockingly from the parent — load the sibling [fleet skill](../fleet/SKILL.md) instead. It covers parented fan-out, polling live status and asserted completions via `agent-deck session children --json` (plus the push variant `--follow --until-done`), answering children stuck in `waiting`, and the grouping/`--parent` pitfalls.
 
 ### Recommended MCPs
 
@@ -967,3 +972,4 @@ See the [Self-Improvement](#self-improvement) section for how these were discove
 - [self-improvement.md](references/self-improvement.md) - Deep dive into the transcript-mining pipeline: architecture, privacy layers, output schemas, lessons learned
 - [goal.md](references/goal.md) - Deep dive into goal-driven worker autonomy: three-entity design, done-condition shell commands, manager loop, nudge generator, escalation bundle, implementation phases
 - [session-share skill](../session-share/SKILL.md) - Export/import sessions for collaboration
+- [fleet skill](../fleet/SKILL.md) - Fan out parallel child sessions and supervise them non-blockingly (`session children`)


### PR DESCRIPTION
## What problem does this solve?

The main `agent-deck` skill never mentions the sibling `fleet` skill or the `session children` command. An agent that loads only the main skill (the common case — it's the one the plugin triggers on "agent-deck", "session", "sub-agent") has no idea non-blocking child supervision exists, so it re-invents it every time: ad-hoc polling loops over `session show` / `session output`, or blocking `--wait` calls where a fleet peek was the right tool.

## Why this change

Docs-only, 6 added lines in `skills/agent-deck/SKILL.md`:

1. Add `agent-deck session children --json` to the Essential Commands table (it's the primary supervision read for any parent session, and the only Essential-Commands-tier command that was missing).
2. Add a "Fanning out several children?" pointer in the Sub-Agent Launch section directing the multi-child case to the fleet skill.
3. List the fleet skill in References alongside session-share (which was already cross-referenced).

The alternative — duplicating fleet content into the main skill — would create two copies to keep in sync; a pointer is enough for the agent to load the right skill.

## User impact

Agents driving agent-deck stop rediscovering child supervision from `--help`. No behavior change; no code touched.

## Evidence

On `main`, the gap is verifiable directly:

    $ grep -c "fleet\|session children" skills/agent-deck/SKILL.md
    0

while the sibling skill and the command both exist (`skills/fleet/SKILL.md`; `cmd/agent-deck/session_children_follow.go`).

Real-usage provenance: mining my own Claude Code transcripts (sessions from 2026-07-22, where a conductor-style session supervised agent-deck children) showed the agent working out `session children --json` from scratch mid-session rather than knowing it from the loaded skill.

Docs-only diff — no test changes; revert-check not applicable.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "I'm surprised how much is being rediscovered every time agent-deck gets invoked by an agent."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior — docs-only change, no behavior to test
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — not run: docs-only diff, no Go changes (self-check: go-checks skipped)
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->
