### PR TITLE
docs(skill): state the session-manager vs process-supervisor boundary

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -811,6 +811,16 @@ agent-deck session set <session> account <account>
 2. **Restart after MCP attach:** Always run `session restart` after `mcp attach`
 3. **Never poll from other agents** - can interfere with target session
 
+## What agent-deck is NOT: a process supervisor
+
+agent-deck manages **interactive agent sessions**. It is not a supervisor for always-on daemons or network listeners, and reaching for it as one leads to subtle failures. Before wrapping a long-lived service (a webhook listener, an SSE bridge, a `claude remote-control` server, any daemon) in a deck session, check this boundary:
+
+- **Sessions live in a user tmux server and die with it.** An SSH logout can take every session down ([#958](https://github.com/asheshgoplani/agent-deck/issues/958) — mitigate with `loginctl enable-linger` + `launch_in_user_scope=true`, but the failure mode remains).
+- **Nothing auto-restarts a crashed session** unless you run the optional watchdog daemon ([documentation/WATCHDOG.md](https://github.com/asheshgoplani/agent-deck/blob/main/documentation/WATCHDOG.md)) — and the watchdog restarts *sessions*, with session semantics.
+- **`session restart` has conversation semantics, not daemon semantics.** For a Claude session it rebuilds the pane command around `claude --resume <id>` — correct for resuming a chat, wrong for "bring my listener back exactly as it was". Custom-command sessions re-run their stored wrapper, but registry drift on custom commands is a known trap ([#956](https://github.com/asheshgoplani/agent-deck/issues/956), [#911](https://github.com/asheshgoplani/agent-deck/issues/911)).
+
+**Rule of thumb:** always-on listeners and daemons belong under the OS supervisor (launchd on macOS, systemd on Linux — the headless `web --no-tui` daemon itself is run that way, see [#1452](https://github.com/asheshgoplani/agent-deck/issues/1452)); agent-deck owns the interactive sessions and workers. When a session merely *talks to* a service, supervise the service outside the deck and keep the session disposable.
+
 ## Known Gotchas (v1.7.0+)
 
 Friction points discovered during real usage. Work around them per the patterns below.


### PR DESCRIPTION
## What problem does this solve?

The skill documents everything agent-deck *can* do but never says what it is *not* for, so agents keep trying to use deck sessions to supervise always-on daemons and network listeners — and re-derive the boundary from failures, one incident at a time: sessions dying with the tmux server on SSH logout (#958), `session restart` rebuilding a Claude pane around `claude --resume` when what the user wanted was "bring my listener back", and no crash-restart at all without the optional watchdog.

## Why this change

Docs-only, one new section in `skills/agent-deck/SKILL.md` ("What agent-deck is NOT: a process supervisor"), placed after Critical Rules where the skill's other guardrails live. It states the boundary in three verifiable bullets (tmux-server lifetime, no auto-restart without the watchdog, restart-has-conversation-semantics) and one rule of thumb: daemons → launchd/systemd; interactive sessions and workers → agent-deck. Each claim cites the existing issue or doc (#958, #956, #911, #1452, WATCHDOG.md) rather than asserting from scratch.

Framing note: this is not "agent-deck is bad at X" — it's the same boundary the project itself draws (the headless `web --no-tui` daemon is expected to run under launchd/systemd per #1452; WATCHDOG.md exists precisely because sessions don't self-restart). The section just makes the boundary legible to agents before they hit it.

## User impact

Agents stop burning user time wedging listeners into deck sessions and then debugging the resulting lifecycle surprises. No behavior change; no code touched.

## Evidence

Claims verified against code and tracker on `main`:

- Restart semantics: `internal/session/instance.go` (buildClaudeCommandWithMessage) — `SessionMode "resume"` rebuilds the pane command as `claude --resume <id>` when conversation data exists; custom commands fall through to re-running the stored wrapper (with the known custom-command registry traps: #956, #911).
- tmux-server lifetime: #958 (all sessions die on SSH logout; `enable-linger` + `launch_in_user_scope` as mitigation).
- No auto-restart: `documentation/WATCHDOG.md` (optional daemon, exists because sessions don't self-restart).
- Supervisor interplay is real and acknowledged upstream: #1452 (headless `web --no-tui` under launchd/systemd).

Real-usage provenance: in my own Claude Code transcripts (2026-07-22), an agent spent most of a day dry-running a deck-supervised `claude remote-control` listener before concluding exactly this boundary — "durability is a supervisor problem — use the OS supervisor, not a session manager pressed into the role" — knowledge that then existed nowhere except that one transcript.

Docs-only diff — no test changes; revert-check not applicable.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "I'm surprised how much is being rediscovered every time agent-deck gets invoked by an agent."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior — docs-only change, no behavior to test
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — not run: docs-only diff, no Go changes (self-check: go-checks skipped)
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->
