### PR TITLE
docs(skill): document agent-deck try (scratch sessions) in SKILL.md

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -121,6 +121,7 @@ The table above is what *agent-deck* does. This one is what the *CLI inside a se
 | `agent-deck mcp attach <name> <mcp>` | Attach MCP (then restart) |
 | `agent-deck status` | Quick status summary |
 | `agent-deck add --worktree <branch>` | Create session in git worktree |
+| `agent-deck try <name>` | Scratch session in a dated experiment folder |
 | `agent-deck worktree list` | List worktrees with sessions |
 | `agent-deck worktree cleanup` | Find orphaned worktrees/sessions |
 | `agent-deck feedback` | Submit feedback (opens rating prompt + optional comment) |
@@ -454,6 +455,33 @@ agent-deck worktree cleanup --force
 | **Feature isolation** | Keep main branch clean while agent experiments |
 | **Code review** | Agent reviews PR in worktree while main work continues |
 | **Hotfix work** | Quick branch off main without disrupting feature work |
+
+## Scratch Sessions (`agent-deck try`)
+
+**Use when:** the user wants a throwaway playground, a quick experiment, or a scratch repo to dry-run something — "spin up a scratch session", "try this out somewhere disposable", "make a playground".
+
+```bash
+# Find-or-create a dated experiment folder and start a session in it
+agent-deck try redis-cache            # → <experiments-dir>/2026-07-29-redis-cache/
+agent-deck try rds                    # Fuzzy-matches an existing experiment (e.g. redis-cache)
+agent-deck try myproject -c gemini    # Non-default tool
+agent-deck try myproject --no-session # Create/find the folder only
+agent-deck try scratch --sandbox      # Run the session in a Docker sandbox
+agent-deck try --list [query]         # List (or fuzzy-search) existing experiments
+```
+
+The argument is an **experiment name**, not a prompt. `try` finds or creates `<experiments-dir>/<YYYY-MM-DD>-<name>/`, reuses an existing session for that path if one exists, and otherwise creates one in the `experiments` group and starts it.
+
+**The base directory is configurable** — important when your machine only trusts certain roots for agent workspaces:
+
+```toml
+[experiments]
+directory = "~/code/tries"    # Default: ~/src/tries
+date_prefix = true            # YYYY-MM-DD- prefix on folder names
+default_tool = "claude"       # Tool when -c is omitted
+```
+
+Note: `try` creates a plain folder, not a git repo — run `git init` in it first if the experiment needs one.
 
 ## Watchers
 

--- a/skills/agent-deck/references/sandbox.md
+++ b/skills/agent-deck/references/sandbox.md
@@ -28,8 +28,9 @@ agent-deck add --sandbox .
 # Create sandboxed session with custom image
 agent-deck add --sandbox-image myregistry/custom:v1 .
 
-# One-shot sandboxed task
-agent-deck try "refactor the auth module"
+# Sandboxed scratch session in a dated experiment folder
+# (argument is an experiment NAME, not a prompt — see the Scratch Sessions section in SKILL.md)
+agent-deck try auth-refactor --sandbox
 
 # Remove session (auto-cleans container)
 agent-deck remove <session>


### PR DESCRIPTION
## What problem does this solve?

`agent-deck try` is absent from the main skill, so every time a user asks their agent for a scratch playground the agent rediscovers the command from `--help` — including the question that actually matters on locked-down machines: whether the experiments directory is configurable (it is: `[experiments] directory`). Worse, the one place the skill *does* show `try` — `references/sandbox.md` — shows it taking a prompt string (`agent-deck try "refactor the auth module"`), but the argument is an experiment **name** (`try_cmd.go`: fuzzy-matched against existing experiment folders), so the example teaches agents the wrong mental model.

## Why this change

Docs-only:

1. New "Scratch Sessions (`agent-deck try`)" section in `skills/agent-deck/SKILL.md`: find-or-create semantics, fuzzy matching, `--list` / `--no-session` / `-c` / `--sandbox`, the `[experiments]` config block (directory / date_prefix / default_tool), and the "plain folder, not a git repo" note.
2. One row in Essential Commands.
3. Fix the misleading `sandbox.md` example to use an experiment name and point at the new section.

All claims verified against `cmd/agent-deck/try_cmd.go` and `internal/experiments/experiments.go` on main (see Evidence).

## User impact

Agents answer "spin up a scratch session" correctly on the first try, including redirecting the experiments dir on machines that only trust specific workspace roots. No behavior change; no code touched.

## Evidence

Verified against the implementation on `main`:

- `cmd/agent-deck/try_cmd.go` — usage says "Experiment name (fuzzy matched against existing experiments)"; flags `--list/-l`, `--no-session`, `--sandbox`, `-c/--cmd`; config help prints the `[experiments]` block.
- `internal/session/userconfig.go` `GetExperimentsSettings()` — default directory `~/src/tries`, `[experiments].directory` honored with `ExpandPath`.
- `internal/experiments/experiments.go` — folder creation is `os.MkdirAll` only (no `git init`), supporting the "plain folder" note.
- The corrected sandbox example: `agent-deck try auth-refactor --sandbox` matches the real flag set (`--sandbox` is a `try` flag).

Real-usage provenance: in my own Claude Code transcripts (2026-07-22), an agent driving agent-deck was instructed to "skip `agent-deck try` if its path isn't configurable" — a question the skill couldn't answer, so the agent worked around the command instead of configuring it.

Docs-only diff — no test changes; revert-check not applicable.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "I'm surprised how much is being rediscovered every time agent-deck gets invoked by an agent."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior — docs-only change, no behavior to test
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — not run: docs-only diff, no Go changes (self-check: go-checks skipped)
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->
