### PR TITLE
docs(skill): known gotcha — claude subcommands in -c are rewritten by flag injection

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -849,6 +849,24 @@ rm "$TARGET.old"
 
 Kernel tracks inodes, not names. Running processes keep a reference to the renamed inode; new invocations resolve through the original name to the new inode.
 
+### `-c "claude <subcommand> ..."` silently rewritten — injected flags demote the subcommand (#1800)
+
+Passing a claude **subcommand** as the session command — e.g. `-c "claude remote-control --name X"` or `-c "claude mcp serve"` — does not run the command you gave. Tool detection splits it into `claude` + extra args and re-appends the extras *after* agent-deck's injected flags, so the pane runs:
+
+```
+claude --session-id <uuid> --dangerously-skip-permissions remote-control --name X
+```
+
+The subcommand becomes a positional argument of plain interactive claude; no Remote Control server (or MCP server, etc.) ever starts. This affects any claude subcommand. See [#1800](https://github.com/asheshgoplani/agent-deck/issues/1800).
+
+**Workaround — wrap in a shell so tool detection treats the command as opaque:**
+
+```bash
+agent-deck add -t rc-server -c "bash -c 'exec claude remote-control --name X'" /path
+```
+
+The wrapped form injects nothing and runs the command verbatim. Trade-off: the session is opaque to claude session-id tracking / resume-on-restart — fine for server-style subcommands, which have no conversation to resume. Extra *flags* (e.g. `-c "claude --model opus"`) are unaffected — the wrapper-suffix path handles those correctly.
+
 ### Cross-machine config drift (macOS ↔ Linux)
 
 If `~/.agent-deck/skills/sources.toml` (or other config files) were copied verbatim from a macOS machine, paths like `/Users/<name>/` won't exist on Linux (should be `/home/<user>/`). The symptom: `agent-deck skill list` returns "No skills found" while the pool directory is clearly populated.


### PR DESCRIPTION
## What problem does this solve?

An agent (or human) that creates a session with `-c "claude remote-control --name X"` — or any claude **subcommand** — gets a silently different program: tool detection splits the command and re-appends the subcommand tokens after agent-deck's injected `--session-id`/permission flags, so the pane runs plain interactive claude with `remote-control` as a positional arg. No server starts, and nothing tells you why. Filed with a sandboxed reproduction as #1800; this PR adds the corresponding Known Gotchas entry so skill-driven agents route around it today, on every released version, independent of when/how the code fix lands.

## Why this change

Docs-only, one new entry in the Known Gotchas section of `skills/agent-deck/SKILL.md`, in the same symptom → workaround → issue format as the existing entries (#957, #966, etc.): what the rewrite looks like, the `bash -c 'exec …'` workaround, its trade-off (opaque to session-id tracking — fine for server-style subcommands with no conversation to resume), and the explicit note that extra *flags* (`-c "claude --model opus"`) are unaffected so nobody over-applies the workaround.

## User impact

Agents loading the skill warn/work around instead of shipping a session that silently runs the wrong program. No behavior change; no code touched.

## Evidence

Reproduced in a fully sandboxed environment (fresh `HOME`, own `TMUX_TMPDIR`, argv-logging `claude` shim) on v1.10.10 — full transcript in #1800. Key capture:

    # session created with: -c "claude remote-control --name rc-test"
    ARGV: --session-id 80c0ebf9-… --dangerously-skip-permissions remote-control --name rc-test

    # workaround: -c "bash -c 'exec claude remote-control --name rc-test'"
    ARGV: remote-control --name rc-test

Mechanism verified on current `main` (`cmd/agent-deck/cli_utils.go` `resolveSessionCommand` wrapper-suffix path + `internal/session/instance.go` flag injection) — details in #1800.

Docs-only diff — no test changes; revert-check not applicable.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "I'm surprised how much is being rediscovered every time agent-deck gets invoked by an agent." This gotcha was the sharpest case: an agent burned a debugging cycle discovering the rewrite and inventing the `bash -c` workaround, and that knowledge lived nowhere but one transcript until #1800.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior — docs-only change, no behavior to test
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — not run: docs-only diff, no Go changes (self-check: go-checks skipped)
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->
