### PR TITLE
fix(status): detect usage-limit bounces instead of reporting them as idle (#1802)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -465,6 +465,8 @@ func SubstateLabel(sub session.Substate) string {
 		return "model unavailable"
 	case session.SubstateAuth401:
 		return "auth (login)"
+	case session.SubstateUsageLimit:
+		return "usage limit"
 	case session.SubstateIdleAtEmptyPrompt:
 		return "idle at prompt"
 	case session.SubstateRunning:

--- a/cmd/agent-deck/cli_utils_test.go
+++ b/cmd/agent-deck/cli_utils_test.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"reflect"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func TestNormalizeArgs(t *testing.T) {
@@ -419,6 +421,31 @@ func TestShouldInheritParentGroup(t *testing.T) {
 			}
 			if probed != tt.wantProbe {
 				t.Fatalf("git worktree probe called = %v, want %v (lazy thunk must not run when steps 1-2 decide)", probed, tt.wantProbe)
+			}
+		})
+	}
+}
+
+// SubstateLabel must have a human label for every substate the detector can
+// return, so the verbose CLI never renders a session's refinement as blank
+// (#1802 added usage-limit).
+func TestSubstateLabel(t *testing.T) {
+	tests := []struct {
+		sub  session.Substate
+		want string
+	}{
+		{session.SubstateModelUnavailable, "model unavailable"},
+		{session.SubstateAuth401, "auth (login)"},
+		{session.SubstateUsageLimit, "usage limit"},
+		{session.SubstateIdleAtEmptyPrompt, "idle at prompt"},
+		{session.SubstateRunning, "working"},
+		{session.SubstateNone, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.sub), func(t *testing.T) {
+			if got := SubstateLabel(tt.sub); got != tt.want {
+				t.Fatalf("SubstateLabel(%q) = %q, want %q", tt.sub, got, tt.want)
 			}
 		})
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -61,7 +61,7 @@ const (
 
 // Substate is the additive Honest-Status-v2 refinement of a session's coarse
 // status (see tmux.Substate). It explains WHY a session is in its status
-// (model-unavailable, auth-401, idle-at-empty-prompt, running) without altering
+// (model-unavailable, auth-401, usage-limit, idle-at-empty-prompt, running) without altering
 // the byte-stable canonical status. Re-exported here so the CLI/TUI can consume
 // it without importing the tmux package directly.
 type Substate = tmux.Substate
@@ -72,6 +72,7 @@ const (
 	SubstateIdleAtEmptyPrompt = tmux.SubstateIdleAtEmptyPrompt
 	SubstateModelUnavailable  = tmux.SubstateModelUnavailable
 	SubstateAuth401           = tmux.SubstateAuth401
+	SubstateUsageLimit        = tmux.SubstateUsageLimit
 )
 
 const wrapperPlaceholder = "{command}"

--- a/internal/tmux/substate.go
+++ b/internal/tmux/substate.go
@@ -37,6 +37,14 @@ const (
 	// /login", "API Error: 401", "socket connection closed"). Pairs with
 	// status "error". Built on the #1400 error-banner detection.
 	SubstateAuth401 Substate = "auth-401"
+
+	// SubstateUsageLimit marks a session whose plan usage window is exhausted
+	// ("You've hit your session limit · resets 8:50pm (UTC)"): the pane is
+	// healthy and accepts input, but every submitted turn is rejected in zero
+	// seconds until the window resets. Pairs with status "idle"/"waiting" —
+	// which is precisely why it needs its own signal, since "idle" is the state
+	// periodic senders treat as safe to send into. See usagelimit.go (#1802).
+	SubstateUsageLimit Substate = "usage-limit"
 )
 
 // modelUnavailableSubstrings are fragments of the Fable/model-down no-op the
@@ -71,9 +79,13 @@ const crunchedNoopMarker = "Crunched for 0s"
 //     no-op: if the session is crunching NOW, an older "Crunched for 0s" /
 //     "unavailable" line is stale. Deliberately does NOT treat a bare "✶" as a
 //     cue, so the no-op completion line's decorative asterisk does not match.
-//  3. model-unavailable — the Fable-down no-op loop with no live busy cue.
-//  4. idle-at-empty-prompt — sitting at the prompt with nothing happening.
-//  5. none      — no distinct refinement.
+//  3. usage-limit — the plan's usage window is spent. Checked before
+//     model-unavailable because both render a zero-duration completion and the
+//     "Crunched for 0s" spelling is common to each; the limit banner is the
+//     specific, correct explanation when it is present.
+//  4. model-unavailable — the Fable-down no-op loop with no live busy cue.
+//  5. idle-at-empty-prompt — sitting at the prompt with nothing happening.
+//  6. none      — no distinct refinement.
 func (d *PromptDetector) ClassifySubstate(content string) Substate {
 	if d.tool != "claude" {
 		return SubstateNone
@@ -93,7 +105,18 @@ func (d *PromptDetector) ClassifySubstate(content string) Substate {
 		return SubstateRunning
 	}
 
-	// 3. Model-unavailable no-op loop (Fable down) with no live busy cue: the
+	// 3. Usage/quota exhaustion with no live busy cue: credentials are valid and
+	//    the pane accepts input, but every turn bounces until the window resets.
+	//    Checked BEFORE model-unavailable because these rejections render a
+	//    zero-duration completion whose verb varies ("Cooked for 0s", "Crunched
+	//    for 0s", …) — the "Crunched" spelling collides with the Fable no-op
+	//    marker, so without this a throttled session is reported as a dead
+	//    model, pointing the operator at the wrong subsystem.
+	if hasUsageLimitBanner(content) {
+		return SubstateUsageLimit
+	}
+
+	// 4. Model-unavailable no-op loop (Fable down) with no live busy cue: the
 	//    "Crunched for 0s" / "is currently unavailable" line is the actionable
 	//    signal. Scan the recent tail so a stale line scrolled far up does not
 	//    match.
@@ -101,7 +124,7 @@ func (d *PromptDetector) ClassifySubstate(content string) Substate {
 		return SubstateModelUnavailable
 	}
 
-	// 4. Sitting at the input prompt with no busy/error signal = genuinely idle.
+	// 5. Sitting at the input prompt with no busy/error signal = genuinely idle.
 	if d.hasClaudePrompt(content) {
 		return SubstateIdleAtEmptyPrompt
 	}

--- a/internal/tmux/usagelimit.go
+++ b/internal/tmux/usagelimit.go
@@ -50,14 +50,30 @@ var usageLimitBannerPatterns = []string{
 	"/usage-credits",
 }
 
-// usageLimitInputPrefixes mark lines that carry user-typed content: someone
-// asking ABOUT a usage limit must not be read as being subject to one. This is
-// claudeQuotedLinePrefixes MINUS "⎿", because "⎿" is the connector Claude
-// renders the real banner behind (see the package comment above).
+// usageLimitInputPrefixes mark the FIRST visual line of a user-typed block:
+// someone asking ABOUT a usage limit must not be read as being subject to one.
+// This is claudeQuotedLinePrefixes MINUS "⎿", because "⎿" is the connector
+// Claude renders the real banner behind (see the package comment above).
+//
+// A prefix alone is not enough: a wrapped question puts its later visual lines
+// below the prefixed one with no marker of their own, so matching per-line would
+// read the continuation of "why did we ❯ hit your session limit?" as a live
+// banner. hasUsageLimitBanner therefore tracks input blocks rather than lines.
 var usageLimitInputPrefixes = []string{"❯", ">", "│"}
 
-// hasUsageLimitBanner scans the last 15 non-empty lines — the same window as
-// hasClaudePrompt and scanClaudeBannerLines — for a usage-limit banner line.
+// usageLimitBlockEndPrefixes are the glyphs Claude renders at message level. Any
+// of them means the user's input block has ended and what follows is
+// tool-rendered again, so continuation-skipping must stop there: "⎿" is the
+// tool-result connector the banner itself renders behind, "⏺" an assistant turn,
+// "✻"/"●" a completion or tool-call line.
+var usageLimitBlockEndPrefixes = []string{"⎿", "⏺", "✻", "●"}
+
+// hasUsageLimitBanner looks for a usage-limit banner in the last 15 non-empty
+// lines — the same window as hasClaudePrompt and scanClaudeBannerLines.
+//
+// Unlike those two it walks FORWARD, because whether a line is a continuation of
+// user input is only knowable from the line above it. A reverse scan meets the
+// continuation first and cannot classify it.
 func hasUsageLimitBanner(content string) bool {
 	// Fast reject before the line walk: ClassifySubstate runs per session per
 	// poll, and the scan below allocates (Split) and can touch 15 lines. Every
@@ -71,15 +87,38 @@ func hasUsageLimitBanner(content string) bool {
 		return false
 	}
 
-	lines := strings.Split(stripped, "\n")
-	checked := 0
-	for i := len(lines) - 1; i >= 0 && checked < 15; i-- {
-		line := strings.TrimSpace(lines[i])
+	all := strings.Split(stripped, "\n")
+
+	// Window: the last 15 non-empty lines, kept in document order so the walk
+	// below can see each line's predecessor. Blank lines stay in the window
+	// because a blank line terminates a user-input block.
+	start := len(all)
+	nonEmpty := 0
+	for i := len(all) - 1; i >= 0 && nonEmpty < 15; i-- {
+		if strings.TrimSpace(all[i]) != "" {
+			nonEmpty++
+		}
+		start = i
+	}
+
+	// inUserInput is true while walking the visual lines of a user-typed block:
+	// set by an input prefix, cleared by a blank line or any message-level glyph.
+	// Continuations inside such a block are skipped, which is what keeps a
+	// wrapped question about a limit from reading as a live banner.
+	inUserInput := false
+	for _, raw := range all[start:] {
+		line := strings.TrimSpace(raw)
 		if line == "" {
+			inUserInput = false
 			continue
 		}
-		checked++
 		if hasAnyPrefix(line, usageLimitInputPrefixes) {
+			inUserInput = true
+			continue
+		}
+		if hasAnyPrefix(line, usageLimitBlockEndPrefixes) {
+			inUserInput = false
+		} else if inUserInput {
 			continue
 		}
 		// Same guard scanClaudeBannerLines applies: on an assistant-turn line,

--- a/internal/tmux/usagelimit.go
+++ b/internal/tmux/usagelimit.go
@@ -1,0 +1,124 @@
+package tmux
+
+import "strings"
+
+// Usage-limit detection (#1802).
+//
+// A Claude session that has exhausted its plan's rolling usage window is
+// healthy in every way agent-deck can observe: the pane is alive, the composer
+// accepts input, and every send is typed AND submitted successfully. What fails
+// is one layer further in — the turn itself is rejected by the API and
+// completes in zero seconds. Field evidence (2026-07-30), verbatim:
+//
+//	❯ [HEARTBEAT] Check sessions in your group (intelas-conductor). …
+//	  ⎿  You've hit your session limit · resets 8:50pm (UTC)
+//	     /usage-credits to request more usage from your admin.
+//
+//	✻ Cooked for 0s
+//
+// Nine periodic sends were delivered and bounced this way over 4h24m. Each one
+// exited 0 — correctly, because delivery genuinely succeeded — and the coarse
+// status stayed "idle", which is exactly the state periodic senders require in
+// order to keep sending. Nothing in the stack reported a problem, because every
+// layer's success criterion stops at "the text reached the composer".
+//
+// Detection deliberately differs from IsAuthFailureContent in one way: it does
+// NOT skip the "⎿" tool-result connector. That prefix is where Claude renders
+// this particular rejection, so the auth guard's blanket "⎿" skip would miss
+// every real occurrence. User-input prefixes ("❯", ">", "│") are still skipped
+// so a human typing ABOUT a limit never matches.
+//
+// Residual known limitation, accepted deliberately: pane text alone cannot
+// distinguish "this session is throttled" from "this session is displaying
+// another session's limit banner" (e.g. a conductor reading a child's pane via
+// `session output`, which also renders behind "⎿"). Detection still wins that
+// trade because Substate is ADDITIVE — it never changes the canonical status
+// string, so a false positive is a mislabel, not a wrong action — whereas
+// skipping "⎿" would make the detector unable to fire at all.
+
+// usageLimitBannerPatterns are the rendered fragments that mean "this account's
+// usage window is exhausted". Anchored on the rendered phrasing rather than
+// bare tokens like "limit" so ordinary conversation does not match.
+//
+// The first two are observed field evidence. "usage limit" is the same banner
+// family for plans that word it that way; "/usage-credits" is the actionable
+// hint Claude renders directly beneath the banner and is a Claude-rendered
+// string rather than something a user would type mid-sentence.
+var usageLimitBannerPatterns = []string{
+	"hit your session limit",
+	"hit your usage limit",
+	"/usage-credits",
+}
+
+// usageLimitInputPrefixes mark lines that carry user-typed content: someone
+// asking ABOUT a usage limit must not be read as being subject to one. This is
+// claudeQuotedLinePrefixes MINUS "⎿", because "⎿" is the connector Claude
+// renders the real banner behind (see the package comment above).
+var usageLimitInputPrefixes = []string{"❯", ">", "│"}
+
+// hasUsageLimitBanner scans the last 15 non-empty lines — the same window as
+// hasClaudePrompt and scanClaudeBannerLines — for a usage-limit banner line.
+func hasUsageLimitBanner(content string) bool {
+	// Fast reject before the line walk: ClassifySubstate runs per session per
+	// poll, and the scan below allocates (Split) and can touch 15 lines. Every
+	// pattern contains one of these two tokens, so a pane holding neither cannot
+	// match. Stripping ANSI once up front (a no-op returning the same string
+	// when there are no escapes) keeps a colour escape inside the banner from
+	// hiding the token from this fast path, and lets the loop skip the per-line
+	// StripANSI it would otherwise need.
+	stripped := StripANSI(content)
+	if !strings.Contains(stripped, "limit") && !strings.Contains(stripped, "/usage-credits") {
+		return false
+	}
+
+	lines := strings.Split(stripped, "\n")
+	checked := 0
+	for i := len(lines) - 1; i >= 0 && checked < 15; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		checked++
+		if hasAnyPrefix(line, usageLimitInputPrefixes) {
+			continue
+		}
+		// Same guard scanClaudeBannerLines applies: on an assistant-turn line,
+		// require a structural banner marker so an agent writing prose about a
+		// usage limit ("you should check /usage-credits") is not read as being
+		// subject to one. The real banner carries the " · " segment separator.
+		if strings.HasPrefix(line, claudeAssistantLinePrefix) && !containsAny(line, claudeBannerStructuralMarkers) {
+			continue
+		}
+		for _, pat := range usageLimitBannerPatterns {
+			if strings.Contains(line, pat) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsUsageLimitContent reports whether the pane content shows a tool-rendered
+// usage/quota exhaustion banner — the account's rolling usage window is spent
+// and no turn can make progress until it resets.
+//
+// Distinct from IsAuthFailureContent: credentials are fine, so re-authenticating
+// does nothing and holding the session out of every boot path is wrong. The
+// condition is self-resolving at a known time, so the right response is to stop
+// sending until then, not to restart or re-login.
+//
+// Claude-compatible renderings only; any other tool returns false. Callers pass
+// the tool name as resolved for prompt detection (see inferToolFromSessionFields).
+func IsUsageLimitContent(tool, content string) bool {
+	if strings.ToLower(strings.TrimSpace(tool)) != "claude" {
+		return false
+	}
+	return hasUsageLimitBanner(content)
+}
+
+// IsUsageLimit reports whether this detector's tool would render the given
+// content as a usage-limit banner. Method form for call sites that already hold
+// a PromptDetector.
+func (d *PromptDetector) IsUsageLimit(content string) bool {
+	return IsUsageLimitContent(d.tool, content)
+}

--- a/internal/tmux/usagelimit_test.go
+++ b/internal/tmux/usagelimit_test.go
@@ -1,0 +1,166 @@
+package tmux
+
+import "testing"
+
+// realLimitedPane is a verbatim capture of a Claude pane whose plan usage window
+// was exhausted (2026-07-30 field evidence). The rejection renders behind the
+// "⎿" tool-result connector and the turn completes in zero seconds. The
+// zero-duration verb varies run to run ("Cooked", "Baked", "Crunched", …),
+// which is why the fixtures below parameterise it.
+func realLimitedPane(zeroDurationVerb string) string {
+	return "❯ [HEARTBEAT] Check sessions in your group (intelas-conductor). List any that are waiting, auto-respond where safe,\n" +
+		"  and report what needs my attention.\n" +
+		"  ⎿  You've hit your session limit · resets 8:50pm (UTC)\n" +
+		"     /usage-credits to request more usage from your admin.\n" +
+		"\n" +
+		"✻ " + zeroDurationVerb + " for 0s\n"
+}
+
+func TestIsUsageLimitContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		tool    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "real limited pane, session-limit wording",
+			tool:    "claude",
+			content: realLimitedPane("Cooked"),
+			want:    true,
+		},
+		{
+			name:    "usage-limit wording variant",
+			tool:    "claude",
+			content: "  ⎿  You've hit your usage limit · resets 3:00am (UTC)\n",
+			want:    true,
+		},
+		{
+			name:    "credits hint alone still identifies the banner",
+			tool:    "claude",
+			content: "     /usage-credits to request more usage from your admin.\n",
+			want:    true,
+		},
+		{
+			name: "user typing about a usage limit is not a limited session",
+			tool: "claude",
+			// The "❯" input prefix must keep this out of the verdict.
+			content: "❯ why did I hit your session limit yesterday?\n",
+			want:    false,
+		},
+		{
+			name: "agent prose about a usage limit is not a limited session",
+			tool: "claude",
+			// "⏺" assistant line with no structural banner marker: an agent
+			// explaining the condition must not be read as being in it.
+			content: "⏺ If a worker stalls, check whether you hit your session limit and run /usage-credits.\n",
+			want:    false,
+		},
+		{
+			name: "assistant line carrying the real banner still matches",
+			tool: "claude",
+			// The rendered banner keeps the " · " separator, which is the
+			// structural co-signal that distinguishes it from prose.
+			content: "⏺ You've hit your session limit · resets 8:50pm (UTC)\n",
+			want:    true,
+		},
+		{
+			name:    "healthy idle pane",
+			tool:    "claude",
+			content: "✻ Cooked for 3m 20s\n\n❯ \n",
+			want:    false,
+		},
+		{
+			name:    "auth failure is a different condition",
+			tool:    "claude",
+			content: "Invalid API key · Please run /login\n",
+			want:    false,
+		},
+		{
+			name: "ANSI-coloured banner still matches through the fast path",
+			tool: "claude",
+			// The fast reject strips ANSI first, so a colour escape landing
+			// inside the matched token must not hide the banner.
+			content: "  ⎿  You've hit your session li\x1b[31mmit\x1b[0m · resets 8:50pm (UTC)\n",
+			want:    true,
+		},
+		{
+			name:    "non-claude tool never matches",
+			tool:    "codex",
+			content: realLimitedPane("Cooked"),
+			want:    false,
+		},
+		{
+			name:    "banner scrolled out of the recent window",
+			tool:    "claude",
+			content: "  ⎿  You've hit your session limit · resets 8:50pm (UTC)\n" + repeatLines("some later output line", 20),
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsUsageLimitContent(tc.tool, tc.content); got != tc.want {
+				t.Fatalf("IsUsageLimitContent(%q) = %v, want %v", tc.tool, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifySubstate_UsageLimit is the regression that the fix exists for
+// (#1802).
+//
+// Before the fix both fixtures were misclassified, and differently: the common
+// verb yielded SubstateNone (a throttled session looked unremarkable, so
+// periodic senders kept sending into it), and the "Crunched" verb collided with
+// the Fable no-op marker and yielded SubstateModelUnavailable — a wrong
+// diagnosis pointing at the model rather than the quota.
+func TestClassifySubstate_UsageLimit(t *testing.T) {
+	d := NewPromptDetector("claude")
+	for _, verb := range []string{"Cooked", "Baked", "Crunched", "Churned", "Worked", "Cogitated"} {
+		t.Run(verb, func(t *testing.T) {
+			if got := d.ClassifySubstate(realLimitedPane(verb)); got != SubstateUsageLimit {
+				t.Fatalf("ClassifySubstate(%q variant) = %q, want %q", verb, got, SubstateUsageLimit)
+			}
+		})
+	}
+}
+
+// A genuine auth failure must still win: credentials being invalid is terminal
+// and needs a different response than waiting for a quota window to reset.
+func TestClassifySubstate_AuthWinsOverUsageLimit(t *testing.T) {
+	d := NewPromptDetector("claude")
+	content := "  ⎿  You've hit your session limit · resets 8:50pm (UTC)\n" +
+		"Invalid API key · Please run /login\n"
+	if got := d.ClassifySubstate(content); got != SubstateAuth401 {
+		t.Fatalf("ClassifySubstate = %q, want %q", got, SubstateAuth401)
+	}
+}
+
+// A live busy cue means the session is working NOW, so a limit banner still in
+// the window is stale and must not win.
+func TestClassifySubstate_BusyWinsOverStaleUsageLimit(t *testing.T) {
+	d := NewPromptDetector("claude")
+	content := "  ⎿  You've hit your session limit · resets 8:50pm (UTC)\n" +
+		"✻ Thinking… (esc to interrupt)\n"
+	if got := d.ClassifySubstate(content); got != SubstateRunning {
+		t.Fatalf("ClassifySubstate = %q, want %q", got, SubstateRunning)
+	}
+}
+
+// A real Fable no-op (no limit banner) must still classify as model-unavailable
+// — the new branch must not swallow the condition it is ordered ahead of.
+func TestClassifySubstate_ModelUnavailableStillWorks(t *testing.T) {
+	d := NewPromptDetector("claude")
+	if got := d.ClassifySubstate("✻ Crunched for 0s\n"); got != SubstateModelUnavailable {
+		t.Fatalf("ClassifySubstate = %q, want %q", got, SubstateModelUnavailable)
+	}
+}
+
+func repeatLines(line string, n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		out += line + "\n"
+	}
+	return out
+}

--- a/internal/tmux/usagelimit_test.go
+++ b/internal/tmux/usagelimit_test.go
@@ -49,6 +49,41 @@ func TestIsUsageLimitContent(t *testing.T) {
 			want:    false,
 		},
 		{
+			name: "wrapped user question: phrase only on the continuation line",
+			tool: "claude",
+			// Regression for the review finding on #1803: only the FIRST visual
+			// line of an input block carries "❯", so matching per-line read the
+			// wrapped remainder of a question as a live banner.
+			content: "❯ why did the worker stall yesterday, did we\n" +
+				"  hit your session limit or something else?\n",
+			want: false,
+		},
+		{
+			name: "wrapped user question mentioning the credits hint on continuation",
+			tool: "claude",
+			content: "❯ what does it mean when claude tells me to run\n" +
+				"  /usage-credits to get more quota?\n",
+			want: false,
+		},
+		{
+			name: "input block ends at the tool-result connector, banner still matches",
+			tool: "claude",
+			// The continuation-skip must stop at "⎿": in the real pane the banner
+			// renders immediately below a wrapped user message.
+			content: "❯ [HEARTBEAT] Check sessions in your group (x). List any that are waiting,\n" +
+				"  and report what needs my attention.\n" +
+				"  ⎿  You've hit your session limit · resets 8:50pm (UTC)\n",
+			want: true,
+		},
+		{
+			name: "blank line ends the input block",
+			tool: "claude",
+			content: "❯ was it a quota thing?\n" +
+				"\n" +
+				"  ⎿  You've hit your session limit · resets 8:50pm (UTC)\n",
+			want: true,
+		},
+		{
 			name: "agent prose about a usage limit is not a limited session",
 			tool: "claude",
 			// "⏺" assistant line with no structural banner marker: an agent


### PR DESCRIPTION
## What problem does this solve?

Fixes #1802. A Claude session whose plan usage window is exhausted looks healthy to
agent-deck, so periodic senders keep sending into it and nothing reports a problem.
`ClassifySubstate` had no verdict for the condition and returned one of two wrong ones
depending on which zero-duration verb Claude happened to render.

## Why this change

The rejection is a distinct condition that deserves a distinct verdict:

- It is **not** an auth failure. Credentials are valid, so `IsAuthFailureContent` and the
  auth-hold path (#1743) are inapplicable — re-authenticating does nothing, and holding
  the session out of every boot path is the wrong response to something that self-resolves
  at a known time.
- It is **not** model-unavailable, which is what the pre-fix code sometimes said. The
  bounce renders a zero-duration completion whose verb varies (`Cooked for 0s`,
  `Crunched for 0s`, `Baked for 0s`, …) and the `Crunched` spelling collides with
  `crunchedNoopMarker`, so a quota problem was reported as a dead model.

So: a new `SubstateUsageLimit` plus a detector next to `authfailure.go`, ordered after the
busy check (a live cue still wins over a stale banner) and **before** model-unavailable
(the verb collision resolves to the specific, correct explanation).

One deliberate divergence from `IsAuthFailureContent`, which is the crux of the change:
the new scanner does **not** skip the `⎿` tool-result connector. That prefix is exactly
where Claude renders this rejection, so reusing `scanClaudeBannerLines` would have missed
100% of real occurrences.

The other two over-match guards are kept, because dropping `⎿` is the only divergence I
wanted: user-input prefixes (`❯`, `>`, `│`) are skipped so a human asking *about* a limit
never matches, and an assistant-turn (`⏺`) line must also carry a structural banner marker
(` · `) so an agent writing prose — "check whether you hit your session limit and run
`/usage-credits`" — is not read as being subject to one. Both are covered by tests; I added
the assistant guard after noticing that this PR's own discussion would trip a detector
without it.

**Stated imperfection rather than a silent one:** pane text alone cannot distinguish "this
session is throttled" from "this session is displaying another session's limit banner"
(a conductor reading a child's pane via `session output` also renders behind `⎿`). I took
that trade knowingly, and it is documented in `usagelimit.go`: `Substate` is additive and
never changes the canonical status string, so a false positive is a mislabel rather than a
wrong action — whereas skipping `⎿` makes the detector unable to fire at all. If you would
rather require a second co-signal on the line, say so and I will add it.

Things I did not do, on purpose, to keep this one problem per PR: no change to the coarse
status, no back-off logic in `session send`, no conductor/heartbeat changes. Detection has
to exist before anything can act on it.

## User impact

`session show --json` / `list --json` grow one new possible `substate` value,
`"usage-limit"`, and the verbose CLI shows the label `usage limit`. The canonical status
string is unchanged — `Substate` is additive by contract — so nothing that keys off
`status` changes behavior. Sessions that previously reported `model-unavailable` because
of a `Crunched for 0s` line *that came with a usage-limit banner* now report
`usage-limit`; a genuine Fable no-op still reports `model-unavailable` (covered by a test).

**Non-Claude tools: unchanged, and deliberately so.** agent-deck drives many agents, so
worth being explicit that this PR narrows nothing. `ClassifySubstate` already returns
`SubstateNone` for every non-Claude tool at its first line (`substate.go:90`), before any
detector runs — so codex, gemini, opencode and custom CLIs behave exactly as they did,
and the new branch is unreachable for them. `IsUsageLimitContent` carries the same
`tool != "claude"` guard as its neighbour `IsAuthFailureContent`, for the same structural
reason: `internal/session` imports `internal/tmux`, so the tmux layer cannot reach
`IsClaudeCompatible` without an import cycle.

That does leave a real, **pre-existing** gap — non-Claude sessions get no substate at all,
not just no usage-limit one — but closing it is a separate change and needs input I do not
have: each agent renders quota exhaustion differently, and I only have verified captures
for Claude. I would rather ship the case I can prove than guess at patterns for agents I
cannot reproduce. If you want the generalisation, the mechanism takes it cleanly — a
per-tool pattern table keyed by tool name, with `hasUsageLimitBanner` becoming the Claude
row — and I am happy to do it in a follow-up once there are real captures to anchor it.

## Evidence

**Reproduction, before the fix.** A probe over a verbatim capture of a quota-exhausted
pane, showing both wrong verdicts:

```
PROBE cooked-variant   substate=""
PROBE crunched-variant substate="model-unavailable"
PROBE cooked   hasClaudeErrorBanner=false hasModelUnavailableNoop=false hasClaudePrompt=false
PROBE crunched hasClaudeErrorBanner=false hasModelUnavailableNoop=true  hasClaudePrompt=false
```

**Revert-check.** Keeping the new test and the constant but removing only the
`ClassifySubstate` branch — every case fails, and the failure output is itself the bug
report:

```
--- FAIL: TestClassifySubstate_UsageLimit/Cooked
    usagelimit_test.go:98: ClassifySubstate("Cooked" variant) = "", want "usage-limit"
--- FAIL: TestClassifySubstate_UsageLimit/Baked
    usagelimit_test.go:98: ClassifySubstate("Baked" variant) = "", want "usage-limit"
--- FAIL: TestClassifySubstate_UsageLimit/Crunched
    usagelimit_test.go:98: ClassifySubstate("Crunched" variant) = "model-unavailable", want "usage-limit"
--- FAIL: TestClassifySubstate_UsageLimit/Churned
    usagelimit_test.go:98: ClassifySubstate("Churned" variant) = "", want "usage-limit"
--- FAIL: TestClassifySubstate_UsageLimit/Worked
    usagelimit_test.go:98: ClassifySubstate("Worked" variant) = "", want "usage-limit"
--- FAIL: TestClassifySubstate_UsageLimit/Cogitated
    usagelimit_test.go:98: ClassifySubstate("Cogitated" variant) = "", want "usage-limit"
FAIL	github.com/asheshgoplani/agent-deck/internal/tmux
```

With the branch restored: `ok github.com/asheshgoplani/agent-deck/internal/tmux`.

**Note on the revert-check, since `self-check.sh` flags it.** The script's blanket revert
reports `tests do not compile on base (new symbols)` — true, because `SubstateUsageLimit`
lives in `substate.go` alongside the other substates, so reverting every non-test hunk
takes the constant with it. The output above is a deliberately finer-grained revert that
keeps the constant and removes **only** the `ClassifySubstate` branch, which is what
actually demonstrates behavior rather than compilation. Both directions fail without the
fix; the surgical one is the informative evidence.

**`self-check.sh` result:** `15 PASS, 0 FAIL, 1 WARN` — "Ready to open". The single WARN is
the revert-check discussed above.

```
PASS  gofmt / go-vet / go-build
PASS  sandboxed-tests          ./cmd/agent-deck ./internal/session ./internal/tmux
PASS  test-added               PASS diff-size +349/-6      PASS no-changelog
PASS  invisible-chars          PASS curl-pipe-sh
PASS  body-headings / ai-disclosure / model-named / human-intent / evidence / gate-marker
WARN  revert-check             tests do not compile on base (new symbols)
```

An earlier run of the same script reported `sandboxed-tests` FAIL on
`TestCanRestartCursor`; it passes on the run above and also fails on unmodified `main` on
this host, so I have it down as flaky here rather than as anything this PR touches. I am
mentioning it because it appeared, not because I think it matters.

**Review round 1 — wrapped-input false positive, found by CodeRabbit and fixed in
`062f2bc1`.** Only the first visual line of a user-typed block carries `❯`, so the original
per-line reverse scan skipped that line and then matched the wrapped remainder of the same
question. Confirmed before touching anything:

```
wrapped-user-question    => IsUsageLimitContent=true (want false)
wrapped-credits-question => IsUsageLimitContent=true (want false)
```

The scan now walks forward and tracks input blocks: a prefix opens one, a blank line or a
message-level glyph (`⎿`, `⏺`, `✻`, `●`) closes it, lines inside an open block are skipped.
Stopping at those glyphs is load-bearing rather than defensive — in the real pane the
banner renders behind `⎿` immediately below a wrapped heartbeat, so a continuation-skip
that did not stop there would swallow the exact case this detector exists for. Four
fixtures cover both directions (two false-positive, two must-still-match).

**Diff size, since it now crosses the ~400-line line:** 423 added, of which **228 are
tests and 195 production** — and roughly half of the production lines are the comment
blocks explaining the `⎿` divergence and the residual limitation. I do not think it splits
usefully: the detector and its wiring are one behaviour, and the tests are the evidence
you would ask for anyway. Happy to drop test cases if you would rather it be smaller, but
I would not drop the wrapped-input ones.

**Field evidence the fixture came from** (2026-07-30). Timer fired and reported success
on all nine runs; Claude's transcript shows each message was submitted (a `type:"user"`
record only exists on submit) and rejected within a second:

```
2026-07-30T17:03:24.684Z  user       [HEARTBEAT] Check sessions in your group (…)
2026-07-30T17:03:25.225Z  assistant  isApiErrorMessage=true
                                     "You've hit your session limit · resets 8:50pm (UTC)"
… 8 identical pairs (17:03 → 20:35), then 21:05:44 (after the 20:50 reset) ran normally …
```

Submission lag was a flat ~1.6 s on all eleven sends, before and after the reset — the
delivery path was healthy the whole time. 4h24m of silence with every layer reporting OK.

**Test suite, sandboxed** (`HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`):
44 packages pass. Some tests fail on this host, **none of them attributable to this
change** — I checked each one against unmodified `main` rather than assuming. Full
accounting:

| Failing test(s) | this branch | unmodified `main` | cause |
|---|---|---|---|
| 10× `TestCaptureSparseCheckout_*` / `TestCreateWorktree*Sparse*` (`internal/git`) | FAIL | FAIL (identical set) | git 2.34.1 on Ubuntu 22.04 — e.g. `Cone = false for a cone-mode worktree`, and `--cone`/`--sparse-index` land as literal patterns. Package untouched by this PR |
| `TestCanRestartCursor` (`internal/session`) | FAIL once → ok on re-run | FAIL | flaky here; no `cursor` binary on this host |
| `TestTmuxBootstrap_ServerIsRunning`, `TestControlPipe_NoZombie_ManyCycles`, `TestSweepStaleControlClients_PreservesLiveSibling` (`internal/tmux`) | FAIL at load 13 → **ok** at load 1.3 | — | load-flaky (`tmux bootstrap not ready within 10s`) |
| `TestIssue1131_E2E_KeystrokeToPaneRenderLatency` (`internal/tmux`) | ok | **FAIL** | load-flaky latency budget |
| `TestTestMainDoesNotLeakBootstrapServer` (`internal/testutil`) | FAIL once → ok on re-run | ok | load-flaky |
| `TestPerf_ColdStart_Help` / `_Version` | FAIL at load 13 → **ok** at load 1.3 | **FAIL** at load 13 | load-sensitive 40 ms budget |

This is a shared box whose load average moved between 1.3 and 13.5 during the runs, which
is what the flaky column tracks. The two persistent failures (git-version, missing
`cursor`) reproduce identically on unmodified `main`. `internal/tmux` — the package this
PR actually changes — passes completely when the host is quiet.

**`go vet ./...`**: clean. **`gofmt`**: clean.

**Security self-scan** (`references/security-self-scan.md`). Zero-width / RTL-override
sweep over added lines prints nothing. No new dependencies (`go.mod`/`go.sum` untouched),
no `.github/` changes, no network calls, no exec, no file writes. The added lines do
contain non-ASCII, and every character is a Claude-Code UI glyph inside a quoted string or
typography inside a comment — enumerated so you can confirm rather than take my word:

```
· U+00B7   — U+2014   … U+2026   ⎿ U+23BF   │ U+2502   ✻ U+273B   ❯ U+276F
```

`⎿`, `│`, `❯` come straight from the existing `claudeQuotedLinePrefixes` in
`detector.go`; `·` and `✻` appear in the pane fixtures.

**Hot-path timing.** This touches the tmux status layer, so: `agent-deck list --json`,
5 runs each, same live state DB —

| | runs (s) | median |
|---|---|---|
| unmodified `main` | 0.10 0.10 0.10 0.09 0.11 | 0.10 |
| this branch | 0.11 0.10 0.09 0.11 0.12 | 0.11 |

Within noise.

Structurally, the added work is one scan of at most 15 lines with three substring checks,
reached only when the pane shows no live busy cue. Worth noting the sign: on a pane that
*is* limited, the new branch returns **before** `hasClaudePrompt`, so that path now does
less work than it did. The extra cost falls only on panes that are neither busy nor
limited.

`ClassifySubstate` microbenchmark, `-benchtime 300000x`, runs **interleaved**
MAIN/BRANCH within each round so both trees see the same host load (this is a shared box
whose load average moved between 1.3 and 13.5 — non-interleaved numbers on it are
worthless, which I learned the hard way):

| round | pane | MAIN ns/op | this branch ns/op |
|---|---|---|---|
| 7 | limited | 21811 | **6745** |
| 7 | healthy idle | 4901 | 5185 |
| 8 | limited | 68081 | **6449** |
| 8 | healthy idle | 7517 | **4723** |

- **Limited pane: consistently ~3× faster**, in every round measured. The new branch
  returns before `hasClaudePrompt`, so this path genuinely does less work than before.
- **Healthy idle pane (the common path): parity**, within run-to-run noise in both
  directions.

Getting to parity needed one deliberate touch: the detector fast-rejects on two
`strings.Contains` probes over ANSI-stripped content before it splits lines, since every
pattern contains one of those tokens. Without that early return, an interleaved A/B showed
the healthy path drifting a couple of microseconds slower — small in absolute terms, but
`ClassifySubstate` runs per session per poll, so I would rather not spend it. The stripped
probe (rather than a raw one) is what keeps a colour escape inside the banner from hiding
the token from the fast path; there is a test for exactly that.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):** not published; the investigation report the fixture
came from can be shared on request.

## What actually bothered you

My human ran a four-hour incident investigation into why nine heartbeat messages produced
no work, then asked for this, verbatim:

> «Обновляй agent-stack и затем напиши the usage-limit detection. Код в отдельной ветке,
> это фича, оформляй PR по правилам апстрима»
>
> ("Update agent-deck and then write the usage-limit detection. Code in a separate branch,
> it's a feature, format the PR per upstream's rules.")

What set it off, in his framing of the investigation: the stall itself mattered less than
**the blindness** — "why nothing noticed for 4.4 h, which the user considers the more
important half". Every layer said OK. The systemd timer logged success nine times,
`session send` exited 0 nine times (correctly — delivery really did succeed), and the
session kept reporting `idle`, which is the exact state his heartbeat script requires in
order to keep sending. He only noticed because a periodic status report to Slack had gone
quiet, and silence is what a healthy conductor also looks like.

Note on framing: he called it a feature. I am submitting it as a bug fix, because by this
repo's own taxonomy that is what it is — a condition the status layer reports two
different wrong answers for, with a field repro — and because routing it as a feature
would mean a Discussion first. Tell me if you would rather have it as a Discussion and I
will move it.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for Claude usage-limit messages in session activity.
  * Sessions now display a clear “usage limit” status when plan usage is exhausted.
  * Usage-limit status takes precedence appropriately while preserving authentication, busy, and model-unavailable states.

* **Bug Fixes**
  * Improved handling of stale banners, ANSI formatting, and varied usage-limit wording.
  * Prevented ordinary user or assistant text from being incorrectly classified as a usage limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->