### PR TITLE
test(session): stop TestCanRestartCursor failing without the cursor CLI (#1804)

### DIFF
--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1783,6 +1783,7 @@ func TestBuildCodexCommand_InlineCodexHomeDropsStaleID(t *testing.T) {
 
 func TestCanRestartCursor(t *testing.T) {
 	skipIfNoTmuxBinary(t)
+	skipIfNoCursorBinary(t)
 
 	inst := NewInstanceWithTool("cursor-restart-test", "/tmp", "cursor")
 	inst.Command = "sleep 60"
@@ -1804,8 +1805,11 @@ func TestCanRestartCursor(t *testing.T) {
 	if err := inst.Restart(); err != nil {
 		t.Fatalf("Restart failed: %v", err)
 	}
-	time.Sleep(100 * time.Millisecond)
-	if inst.tmuxSession == nil || !inst.tmuxSession.Exists() {
+	// Poll instead of sampling once. respawn-pane replaces the pane process, so
+	// how long the new leader takes to be observable varies with host load —
+	// exactly the flakiness skipIfClaudePaneUnreliable already documents for the
+	// Claude path ("a single 400ms sample was flaky under the full test suite").
+	if !waitForLivePane(inst, 2*time.Second) {
 		t.Fatal("tmux session should exist after Restart")
 	}
 	if inst.Status == StatusError {

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1783,7 +1783,6 @@ func TestBuildCodexCommand_InlineCodexHomeDropsStaleID(t *testing.T) {
 
 func TestCanRestartCursor(t *testing.T) {
 	skipIfNoTmuxBinary(t)
-	skipIfNoCursorBinary(t)
 
 	inst := NewInstanceWithTool("cursor-restart-test", "/tmp", "cursor")
 	inst.Command = "sleep 60"
@@ -1799,21 +1798,51 @@ func TestCanRestartCursor(t *testing.T) {
 		t.Fatal("CanRestart() should return true for a running Cursor session with live tmux pane")
 	}
 
-	// Simulate persisted command from a real Cursor session before restart.
-	inst.Command = "cursor agent"
+	// Stand in for the persisted Cursor command. A real `cursor agent` cannot be
+	// assumed: required CI installs tmux and zoxide only, and without the binary
+	// the respawned login shell exits at once and tmux drops the session — which
+	// is what made this test fail on every such host. The stand-in keeps the
+	// Cursor respawn path executing for real instead of being skipped.
+	inst.Command = fakeCursorExecutable(t, "exec sleep 60")
 
 	if err := inst.Restart(); err != nil {
 		t.Fatalf("Restart failed: %v", err)
 	}
-	// Poll instead of sampling once. respawn-pane replaces the pane process, so
-	// how long the new leader takes to be observable varies with host load —
-	// exactly the flakiness skipIfClaudePaneUnreliable already documents for the
-	// Claude path ("a single 400ms sample was flaky under the full test suite").
-	if !waitForLivePane(inst, 2*time.Second) {
-		t.Fatal("tmux session should exist after Restart")
-	}
+	// Require STABLE liveness rather than one sample. respawn-pane swaps the pane
+	// leader, so a single check can catch a pane that is about to exit — and the
+	// fixed 100ms sleep this replaces is the flakiness skipIfClaudePaneUnreliable
+	// already documents for the Claude path ("a single 400ms sample was flaky
+	// under the full test suite").
+	requireStableLivePane(t, inst, time.Second)
 	if inst.Status == StatusError {
 		t.Fatalf("after Restart, Status = %s; want != error", inst.Status)
+	}
+}
+
+// Pins the liveness probe itself. A Cursor binary that exists but quits
+// immediately must be reported as not-live — Session.Exists can still say
+// otherwise from a positive cache hit or the PipeManager connection RespawnPane
+// re-establishes, and Session.IsPaneDead reads a list-panes error as "not dead".
+// Without this, requireStableLivePane could pass on a dead session and the
+// regression above would be decorative.
+func TestCanRestartCursor_ProbeNoticesImmediateExit(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstanceWithTool("cursor-restart-probe-test", "/tmp", "cursor")
+	inst.Command = "sleep 60"
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+	defer func() { _ = inst.Kill() }()
+	inst.Status = StatusRunning
+
+	inst.Command = fakeCursorExecutable(t, "exit 0")
+	// Restart may itself report failure here; the point under test is that the
+	// probe does not claim the pane is live afterwards.
+	_ = inst.Restart()
+
+	if !paneGoneWithin(inst, 3*time.Second) {
+		t.Fatal("probe still reported a live pane after the stand-in exited immediately")
 	}
 }
 

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -125,6 +125,77 @@ func skipIfNoClaudeBinary(t *testing.T) {
 	skipIfClaudePaneUnreliable(t)
 }
 
+// skipIfNoCursorBinary skips when the `cursor` CLI is absent. Restart() on a
+// cursor session respawns the pane with `cursor agent --continue`; with no such
+// binary the login shell exits immediately, tmux tears down the pane, and with
+// it the session — so a test asserting the session survives Restart cannot pass
+// here for reasons that have nothing to do with the code under test.
+//
+// Mirrors skipIfNoClaudeBinary / skipIfNoOpenCode for the cursor path.
+func skipIfNoCursorBinary(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("cursor"); err != nil {
+		t.Skip("cursor binary not available (Restart respawns `cursor agent --continue`; without it the pane exits and tmux drops the session)")
+	}
+}
+
+// waitForLivePane polls until the instance's tmux pane is observably alive, or
+// the deadline passes. Returns whether it came up.
+//
+// A single fixed sleep cannot express this: respawn-pane swaps the pane leader,
+// and how quickly that is observable moves with host load. The same lesson is
+// already recorded in skipIfClaudePaneUnreliable, where one 400ms sample was
+// flaky under the full suite.
+func waitForLivePane(inst *Instance, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for {
+		if s := inst.GetTmuxSession(); s != nil && s.Exists() && !s.IsPaneDead() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitForLivePane is the load-tolerant replacement for a fixed sleep, so cover
+// both verdicts directly rather than only through its caller (which skips on
+// hosts without the cursor CLI).
+func TestWaitForLivePane(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	t.Run("returns true for a live pane", func(t *testing.T) {
+		inst := NewInstanceWithTool("wait-live-pane-alive", t.TempDir(), "claude")
+		inst.Command = "sleep 60"
+		if err := inst.Start(); err != nil {
+			t.Fatalf("Start failed: %v", err)
+		}
+		defer func() { _ = inst.Kill() }()
+
+		if !waitForLivePane(inst, 2*time.Second) {
+			t.Fatal("waitForLivePane = false for a live pane, want true")
+		}
+	})
+
+	t.Run("returns false once the pane is gone", func(t *testing.T) {
+		inst := NewInstanceWithTool("wait-live-pane-dead", t.TempDir(), "claude")
+		inst.Command = "sleep 60"
+		if err := inst.Start(); err != nil {
+			t.Fatalf("Start failed: %v", err)
+		}
+		if err := inst.Kill(); err != nil {
+			t.Fatalf("Kill failed: %v", err)
+		}
+
+		// Short window: the point is that it reports the absence rather than
+		// hanging for the full budget.
+		if waitForLivePane(inst, 300*time.Millisecond) {
+			t.Fatal("waitForLivePane = true after Kill, want false")
+		}
+	})
+}
+
 func TestMain(m *testing.M) {
 	os.Exit(runTestMain(m))
 }

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -1,14 +1,17 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/testutil"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // bootstrapSessionName is the idle tmux session kept alive for the lifetime
@@ -125,75 +128,78 @@ func skipIfNoClaudeBinary(t *testing.T) {
 	skipIfClaudePaneUnreliable(t)
 }
 
-// skipIfNoCursorBinary skips when the `cursor` CLI is absent. Restart() on a
-// cursor session respawns the pane with `cursor agent --continue`; with no such
-// binary the login shell exits immediately, tmux tears down the pane, and with
-// it the session — so a test asserting the session survives Restart cannot pass
-// here for reasons that have nothing to do with the code under test.
+// fakeCursorExecutable writes an executable stand-in for the `cursor` CLI and
+// returns its absolute path.
 //
-// Mirrors skipIfNoClaudeBinary / skipIfNoOpenCode for the cursor path.
-func skipIfNoCursorBinary(t *testing.T) {
+// buildCursorCommand appends `--continue` to whatever Instance.Command holds, so
+// the script must tolerate arbitrary args. Using a stand-in rather than skipping
+// when `cursor` is missing is what keeps the Cursor restart path in required CI:
+// go-test.yml installs tmux and zoxide only, so a binary-presence skip would
+// mean the regression never runs there at all.
+func fakeCursorExecutable(t *testing.T, body string) string {
 	t.Helper()
-	if _, err := exec.LookPath("cursor"); err != nil {
-		t.Skip("cursor binary not available (Restart respawns `cursor agent --continue`; without it the pane exits and tmux drops the session)")
+	path := filepath.Join(t.TempDir(), "cursor-stand-in")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write cursor stand-in: %v", err)
+	}
+	return path
+}
+
+// paneAliveNow probes the pane directly, bypassing every cache, and treats a
+// query error as NOT live.
+//
+// That is deliberately the opposite of Session.IsPaneDead, which reports "not
+// dead" when list-panes errors so a briefly-wedged server cannot flip live
+// sessions into an error state. That stance is right in production and wrong
+// here: a test asserting a pane survived must notice a pane that has gone, and
+// after the session vanishes list-panes errors. Session.Exists is unusable for
+// the same class of reason — it trusts a positive cache hit and a live
+// PipeManager connection, and RespawnPane reconnects that pipe itself.
+func paneAliveNow(sess *tmux.Session) bool {
+	if sess == nil {
+		return false
+	}
+	args := []string{}
+	if sock := strings.TrimSpace(sess.SocketName); sock != "" {
+		args = append(args, "-L", sock)
+	}
+	args = append(args, "list-panes", "-t", sess.Name+":0.0", "-F", "#{pane_dead}")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", args...).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "0"
+}
+
+// requireStableLivePane fails unless the pane is alive on EVERY sample across a
+// settle window. One sample cannot tell a pane that survived the respawn from
+// one that is about to exit, which is exactly the case a stand-in that quits
+// immediately produces.
+func requireStableLivePane(t *testing.T, inst *Instance, window time.Duration) {
+	t.Helper()
+	const samples = 5
+	for n := 1; n <= samples; n++ {
+		time.Sleep(window / samples)
+		if !paneAliveNow(inst.GetTmuxSession()) {
+			t.Fatalf("pane not live on sample %d/%d within %s of Restart", n, samples, window)
+		}
 	}
 }
 
-// waitForLivePane polls until the instance's tmux pane is observably alive, or
-// the deadline passes. Returns whether it came up.
-//
-// A single fixed sleep cannot express this: respawn-pane swaps the pane leader,
-// and how quickly that is observable moves with host load. The same lesson is
-// already recorded in skipIfClaudePaneUnreliable, where one 400ms sample was
-// flaky under the full suite.
-func waitForLivePane(inst *Instance, within time.Duration) bool {
-	deadline := time.Now().Add(within)
-	for {
-		if s := inst.GetTmuxSession(); s != nil && s.Exists() && !s.IsPaneDead() {
+// paneGoneWithin reports whether the pane is observed not-live before the
+// deadline. Used to pin the probe itself against a stand-in that exits at once.
+func paneGoneWithin(inst *Instance, window time.Duration) bool {
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		if !paneAliveNow(inst.GetTmuxSession()) {
 			return true
-		}
-		if time.Now().After(deadline) {
-			return false
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-}
-
-// waitForLivePane is the load-tolerant replacement for a fixed sleep, so cover
-// both verdicts directly rather than only through its caller (which skips on
-// hosts without the cursor CLI).
-func TestWaitForLivePane(t *testing.T) {
-	skipIfNoTmuxBinary(t)
-
-	t.Run("returns true for a live pane", func(t *testing.T) {
-		inst := NewInstanceWithTool("wait-live-pane-alive", t.TempDir(), "claude")
-		inst.Command = "sleep 60"
-		if err := inst.Start(); err != nil {
-			t.Fatalf("Start failed: %v", err)
-		}
-		defer func() { _ = inst.Kill() }()
-
-		if !waitForLivePane(inst, 2*time.Second) {
-			t.Fatal("waitForLivePane = false for a live pane, want true")
-		}
-	})
-
-	t.Run("returns false once the pane is gone", func(t *testing.T) {
-		inst := NewInstanceWithTool("wait-live-pane-dead", t.TempDir(), "claude")
-		inst.Command = "sleep 60"
-		if err := inst.Start(); err != nil {
-			t.Fatalf("Start failed: %v", err)
-		}
-		if err := inst.Kill(); err != nil {
-			t.Fatalf("Kill failed: %v", err)
-		}
-
-		// Short window: the point is that it reports the absence rather than
-		// hanging for the full budget.
-		if waitForLivePane(inst, 300*time.Millisecond) {
-			t.Fatal("waitForLivePane = true after Kill, want false")
-		}
-	})
+	return false
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## What problem does this solve?

Fixes #1804. `TestCanRestartCursor` fails on any host without the `cursor` CLI — including
your own `Full test suite (PR gate)` runner — and reds the gate on unrelated PRs. It has
already done so twice on `feat/claude-code-worktree-hooks`
([30356055817](https://github.com/asheshgoplani/agent-deck/actions/runs/30356055817),
[30355494370](https://github.com/asheshgoplani/agent-deck/actions/runs/30355494370)) and once
on mine (#1803).

## Why this change

Two defects, and the second is the one that matters:

**It cannot pass without the binary.** `Restart()` on a cursor session goes through
`RespawnPane` → `respawn-pane -k -t <session>: bash -lc "cursor agent --continue"`. With no
`cursor` the login shell fails `command not found` and exits; the pane is the session's only
pane and `remain-on-exit` is set for sandbox sessions only, so tmux drops the session. Measured
on a clean socket: the command returns in 0.00–0.01 s and the session is gone after 8–11 ms,
while the assertion fires at a fixed `time.Sleep(100 * time.Millisecond)`.

**Its passes were not evidence of a live session.** Standalone it fails deterministically (4/4),
which an 8–11 ms teardown against a 100 ms window would not do if this were only a race. It
passes solely inside the full `./internal/session/` package run, same commit and host. `Exists()`
has two paths that answer `true` without probing — a positive hit in the global session cache
(`internal/tmux/tmux.go:2407`) and a live `PipeManager` connection (`tmux.go:2413`) — and
`RespawnPane` re-establishes the control pipe immediately after the respawn it just performed.
So the green outcome tracked process-global state, not the thing being asserted.

**The fix, after review.** My first attempt skipped when the `cursor` binary was absent.
Cross-agent review rejected that with two P1s and was right on both:

1. **The skip removed the regression from required CI.** `go-test.yml` installs tmux and
   zoxide but not `cursor`, so a binary-presence skip means this test *never* executes in
   the gate — and the helper test I added covered only the helper, never `Restart()`. That
   trades a red gate for silent zero coverage of the path #968d9c01 added the test for.
2. **My liveness check was not a liveness check.** I built it on
   `Session.Exists() && !Session.IsPaneDead()` — while #1804, which I filed, says in as many
   words that `Exists()` can answer `true` from a positive cache hit or from the
   `PipeManager` connection `RespawnPane` itself re-establishes. `IsPaneDead()` compounds it:
   a `list-panes` error reads as "not dead", deliberately, so a briefly-wedged server cannot
   flip live sessions into error. Correct in production, wrong for a test that must notice a
   pane that has gone — a stand-in that exists and exits at once satisfied both predicates.

So the test is now **self-contained** rather than skipped: `Command` is set to an absolute
stand-in executable that ignores its args (`buildCursorCommand` appends `--continue`) and
stays alive, so `CanRestart` and the Cursor respawn path execute for real with no Cursor
installation. And the probe is honest: `paneAliveNow` queries tmux directly on the session's
own socket and treats a **query error as not-live**, while `requireStableLivePane` requires
liveness on every sample across a settle window instead of returning on the first live one.

The settle-window shape is still your own convention — `skipIfClaudePaneUnreliable` polls
for exactly this reason, and its comment records it: *"a single 400ms sample was flaky under
the full test suite (2/5 false-positives observed)"*. The original
`time.Sleep(100 * time.Millisecond)` was the pattern that comment warns against.

## User impact

None at runtime — test-only change, no production code touched. For contributors: the suite
stops going red on machines without the `cursor` CLI, which is most of them and all of CI —
and it does so by **running** the Cursor restart path against a stand-in rather than skipping
it, so the coverage exists on those machines instead of merely not failing there.

## Evidence

**Before, on this host (no `cursor` on `PATH`):**

```
standalone run1: FAIL    standalone run2: FAIL
standalone run3: FAIL    standalone run4: FAIL
    instance_test.go:1809: tmux session should exist after Restart
```

**Teardown timing that makes the 100 ms sample unwinnable** (clean tmux socket):

```
bash -lc 'cursor agent --continue'   => 0.00 s, 0.01 s, 0.00 s
session gone after respawn-pane      => 8 ms, 11 ms, 11 ms
```

**After — the test now RUNS rather than skipping, on this host which has no `cursor`:**

```
run1: --- PASS: TestCanRestartCursor (1.23s)  --- PASS: TestCanRestartCursor_ProbeNoticesImmediateExit (0.12s)  ok
run2: --- PASS: TestCanRestartCursor (1.17s)  --- PASS: TestCanRestartCursor_ProbeNoticesImmediateExit (0.12s)  ok
run3: --- PASS: TestCanRestartCursor (1.16s)  --- PASS: TestCanRestartCursor_ProbeNoticesImmediateExit (0.10s)  ok
```

That is the point of the rework: coverage that survives on a host without Cursor instead of
a skip that quietly removes it.

**The probe is pinned against a false positive.**
`TestCanRestartCursor_ProbeNoticesImmediateExit` drives the same respawn path with a stand-in
that exits immediately and asserts the probe reports not-live. Without it
`requireStableLivePane` could pass on a dead session and the regression above would be
decorative.

`gofmt` clean, `go vet ./internal/session/` clean. `./internal/session/` passes in full.

I left the "suite passes sandboxed" box unchecked rather than quietly checking it: on this host
the full `./...` also trips 10 pre-existing `internal/git` sparse-checkout failures
(`Cone = false for a cone-mode worktree`, `--cone`/`--sparse-index` landing as literal patterns)
because it runs git 2.34.1 on Ubuntu 22.04. They reproduce identically on unmodified `main` and
have nothing to do with this change, but the box as written is not true here, so I am not
checking it.

**Note on the revert-check:** this is a test-only change, so the usual "revert the non-test hunks
and watch the tests fail" does not apply — there are no non-test hunks. The before/after captures
above are the equivalent evidence, and `self-check.sh` was run with `SKIP_REVERT_CHECK=1` for
that reason.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):** not published; happy to share the investigation notes.

## What actually bothered you

My human's unrelated PR (#1803) went red on this test, and he asked for it to be dealt with
properly rather than worked around:

> «Покопай ещё в этот тест. С падающим CI наш PR точно не примут. Почему этот тест существует и
> как он проходил раньше, если мы его не добавляли?»
>
> ("Dig into this test some more. With CI red our PR definitely won't be accepted. Why does this
> test exist and how was it passing before, if we didn't add it?")

then, once the mechanism was clear:

> «Давай починим тест отдельным PR» — ("Let's fix the test in a separate PR.")

The second question is the one that produced the real finding. "How was it passing before" turned
out to have an uncomfortable answer: it was passing because `Exists()` can be satisfied by a
cache entry or a reconnected control pipe, so the green result never meant what it appeared to.
That is why this is a fix rather than a retry.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved restart validation by confirming the session remains active for a sustained period.
  * Added coverage for detecting sessions that terminate immediately after restarting.
  * Enhanced test stability using simulated command-line behavior and graceful handling when required tools are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->