### PR TITLE
fix(status): detect usage-limit bounces from the transcript, not pane text (#1802)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -465,6 +465,8 @@ func SubstateLabel(sub session.Substate) string {
 		return "model unavailable"
 	case session.SubstateAuth401:
 		return "auth (login)"
+	case session.SubstateUsageLimit:
+		return "usage limit"
 	case session.SubstateIdleAtEmptyPrompt:
 		return "idle at prompt"
 	case session.SubstateRunning:

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -72,6 +72,7 @@ const (
 	SubstateIdleAtEmptyPrompt = tmux.SubstateIdleAtEmptyPrompt
 	SubstateModelUnavailable  = tmux.SubstateModelUnavailable
 	SubstateAuth401           = tmux.SubstateAuth401
+	SubstateUsageLimit        = tmux.SubstateUsageLimit
 )
 
 const wrapperPlaceholder = "{command}"
@@ -211,11 +212,16 @@ type Instance struct {
 	lastOpenCodeScanAt time.Time // Rate-limits expensive `opencode session list` scans
 
 	// Codex CLI integration
-	CodexSessionID   string    `json:"codex_session_id,omitempty"`
-	CodexDetectedAt  time.Time `json:"codex_detected_at,omitempty"`
-	CodexStartedAt   int64     `json:"-"` // Unix millis when we started Codex (for session matching, not persisted)
-	lastCodexScanAt  time.Time // Rate-limits expensive ~/.codex/sessions scans
-	lastCodexProbeAt time.Time // Rate-limits expensive Codex process-file probes
+	CodexSessionID  string    `json:"codex_session_id,omitempty"`
+	CodexDetectedAt time.Time `json:"codex_detected_at,omitempty"`
+	CodexStartedAt  int64     `json:"-"` // Unix millis when we started Codex (for session matching, not persisted)
+	lastCodexScanAt time.Time // Rate-limits expensive ~/.codex/sessions scans
+	// Usage-limit detection (#1802). lastUsageLimitScanAt rate-limits the
+	// transcript tail read; usageLimitedCached mirrors the verdict so the TUI
+	// render path can read it without filesystem access. Guarded by i.mu.
+	lastUsageLimitScanAt time.Time
+	usageLimitedCached   bool
+	lastCodexProbeAt     time.Time // Rate-limits expensive Codex process-file probes
 	// pendingCodexRestartWarning is consumed by UI/CLI after Restart() succeeds.
 	// It is intentionally transient and never persisted.
 	pendingCodexRestartWarning string `json:"-"`
@@ -8018,6 +8024,15 @@ func (i *Instance) Substate() Substate {
 	if held, _ := i.IsAuthHeld(); held {
 		return SubstateAuth401
 	}
+	// A quota rejection is checked before the pane verdict, and specifically
+	// before the pane's auth banner, because it is strictly newer and stronger
+	// evidence: the transcript record IS the latest assistant turn, and a 429
+	// proves the request was authenticated. A stale "Please run /login" line
+	// still sitting in the scrollback would otherwise win on category order and
+	// mislabel a session whose credentials demonstrably work (#1802).
+	if i.usageLimited() {
+		return SubstateUsageLimit
+	}
 	tmuxSess := i.GetTmuxSession()
 	if tmuxSess == nil {
 		return SubstateNone
@@ -8033,6 +8048,12 @@ func (i *Instance) Substate() Substate {
 func (i *Instance) CachedSubstate() Substate {
 	if i.AuthHeldCached() {
 		return SubstateAuth401
+	}
+	// In-memory mirror only: this path must stay filesystem-free, so it reads the
+	// verdict the throttled scan already computed rather than re-reading the
+	// transcript. Same precedence as Substate.
+	if i.UsageLimitedCached() {
+		return SubstateUsageLimit
 	}
 	tmuxSess := i.GetTmuxSession()
 	if tmuxSess == nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -216,11 +216,16 @@ type Instance struct {
 	CodexDetectedAt time.Time `json:"codex_detected_at,omitempty"`
 	CodexStartedAt  int64     `json:"-"` // Unix millis when we started Codex (for session matching, not persisted)
 	lastCodexScanAt time.Time // Rate-limits expensive ~/.codex/sessions scans
-	// Usage-limit detection (#1802). lastUsageLimitScanAt rate-limits the
-	// transcript tail read; usageLimitedCached mirrors the verdict so the TUI
-	// render path can read it without filesystem access. Guarded by i.mu.
+	// Usage-limit detection (#1802), all guarded by i.mu.
+	// lastUsageLimitScanAt throttles the transcript read (records scan START).
+	// usageLimitedCached memoises the verdict for that window, and
+	// usageLimitSessionID records the session id it was formed for so a rebind
+	// cannot inherit it. usageLimitScanGen versions in-flight scans so one slower
+	// than the interval cannot publish over a newer result.
 	lastUsageLimitScanAt time.Time
 	usageLimitedCached   bool
+	usageLimitSessionID  string
+	usageLimitScanGen    uint64
 	lastCodexProbeAt     time.Time // Rate-limits expensive Codex process-file probes
 	// pendingCodexRestartWarning is consumed by UI/CLI after Restart() succeeds.
 	// It is intentionally transient and never persisted.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8024,12 +8024,17 @@ func (i *Instance) Substate() Substate {
 	if held, _ := i.IsAuthHeld(); held {
 		return SubstateAuth401
 	}
-	// A quota rejection is checked before the pane verdict, and specifically
-	// before the pane's auth banner, because it is strictly newer and stronger
-	// evidence: the transcript record IS the latest assistant turn, and a 429
-	// proves the request was authenticated. A stale "Please run /login" line
-	// still sitting in the scrollback would otherwise win on category order and
-	// mislabel a session whose credentials demonstrably work (#1802).
+	// A RECENT quota rejection is checked before the pane verdict, including the
+	// pane's auth banner: it is the latest assistant turn and a 429 proves the
+	// request was authenticated, so a stale "Please run /login" line still in the
+	// scrollback must not win on category order and mislabel a session whose
+	// credentials demonstrably work.
+	//
+	// "Recent" is load-bearing rather than decorative. A 429 only proves
+	// authentication AT ITS OWN TIMESTAMP, so an old one must not mask newer pane
+	// evidence — a freshly rendered 401, or a dropped socket that never arms the
+	// credential hold. usageLimited enforces that bound (usageLimitMaxAge), which
+	// is what keeps this ordering honest (#1802).
 	if i.usageLimited() {
 		return SubstateUsageLimit
 	}
@@ -8049,12 +8054,12 @@ func (i *Instance) CachedSubstate() Substate {
 	if i.AuthHeldCached() {
 		return SubstateAuth401
 	}
-	// In-memory mirror only: this path must stay filesystem-free, so it reads the
-	// verdict the throttled scan already computed rather than re-reading the
-	// transcript. Same precedence as Substate.
-	if i.UsageLimitedCached() {
-		return SubstateUsageLimit
-	}
+	// Deliberately NOT wired for usage-limit: this path must stay
+	// filesystem-free, and nothing in the background status pass populates a
+	// usage-limit mirror, so a branch here would be dead on the TUI/Web/transition
+	// surfaces while looking supported. usage-limit is a live-Substate signal in
+	// this change (CLI/JSON/fleet); wiring the cached path belongs with whatever
+	// populates it. See usagelimit.go (#1802).
 	tmuxSess := i.GetTmuxSession()
 	if tmuxSess == nil {
 		return SubstateNone

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -75,25 +75,41 @@ const usageLimitMaxAge = 5 * time.Hour
 // so a few seconds of staleness costs nothing.
 const usageLimitScanInterval = 5 * time.Second
 
-// usageLimitScanChunkBytes is how much of the transcript is read at a time.
+// usageLimitScanChunkBytes is how much of the transcript is scanned for line
+// boundaries at a time.
 //
-// The scan walks BACKWARD in non-overlapping chunks of this size until it finds
-// the latest main-conversation assistant record or reaches the start of the file.
-// Two properties matter and neither is optional:
+// The scan walks BACKWARD in non-overlapping chunks until it finds the latest
+// main-conversation assistant record or reaches the start of the file. Two
+// properties matter and neither is optional:
 //
 //   - No ceiling. A fixed cap does not remove the cold-start false negative it
 //     appears to bound, it relocates it: if the decisive rejection sits beyond the
 //     cap with only non-assistant traffic after it, no verdict forms and a fresh
 //     process reports the session healthy.
-//   - No overlap, bounded memory. An earlier revision grew the window
-//     geometrically and re-read what it had already seen — 512 KiB + 4 MiB + the
-//     whole file for one verdict on a 5.8 MB transcript, with the final read
-//     copied whole into memory. Chunking reads each byte at most once and holds
-//     one chunk at a time, which matters because this runs on a status path.
+//   - Bounded, non-overlapping I/O. Each chunk is read once to find newlines, and
+//     each candidate line is then read once by its own bounded ReadAt. This runs on
+//     a status path, so neither whole-file reads nor repeated recopying of a long
+//     line is acceptable.
 //
 // A var rather than a const so tests can shrink it and exercise a many-chunk walk
 // without writing a multi-megabyte fixture.
-var usageLimitScanChunkBytes int64 = 512 * 1024
+const defaultUsageLimitScanChunkBytes = 512 * 1024
+
+var usageLimitScanChunkBytes int64 = defaultUsageLimitScanChunkBytes
+
+// usageLimitMaxLineBytes bounds the size of a line this detector will read.
+//
+// Claude /compact writes multi-megabyte single-line records. Those are never the
+// assistant turn being looked for, and pulling one into memory on a status path is
+// exactly the cost the chunked walk exists to avoid — so a line longer than this is
+// skipped on its measured length, without being read at all.
+const usageLimitMaxLineBytes = 1 << 20 // 1 MiB
+
+// usageLimitScanObserver is a TEST SEAM: when non-nil it receives the byte range
+// of every chunk read, which is what lets a test assert non-overlap and bounded
+// I/O rather than merely assert that the answer came out right. Always nil in
+// production.
+var usageLimitScanObserver func(start, end int64)
 
 // transcriptRecord is the subset of a transcript line this detector reads.
 type transcriptRecord struct {
@@ -165,56 +181,78 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 
 	chunk := usageLimitScanChunkBytes
 	if chunk <= 0 {
-		chunk = 512 * 1024
+		chunk = defaultUsageLimitScanChunkBytes
 	}
+	buf := make([]byte, chunk)
 
-	// carry holds the leftmost, still-incomplete line of the chunk processed
-	// previously (which sits LATER in the file). Its head is at the end of the
-	// chunk about to be read, so appending it there reassembles that line exactly
-	// once — no byte is read twice and no record is split across the boundary.
-	var carry []byte
+	// lineEnd is the exclusive end of the line currently being delimited. Walking
+	// backwards, a '\n' at offset i closes the line [i+1, lineEnd) and opens the
+	// next one ending at i.
+	//
+	// Each line is then read exactly once, by its own bounded ReadAt. An earlier
+	// revision instead prepended a growing "carry" to every chunk, which recopied
+	// a multi-chunk line once per chunk — quadratic in line length, and this repo
+	// documents /compact producing multi-megabyte single-line records.
+	lineEnd := info.Size()
+
+	consider := func(start, end int64) (bool, bool, bool) {
+		if end <= start {
+			return false, false, false
+		}
+		if end-start > usageLimitMaxLineBytes {
+			// A line this large is a compaction/file-history snapshot, not a turn
+			// this detector can act on. Skipped WITHOUT reading it: the whole point
+			// of the bound is not to pull megabytes onto a status path.
+			return false, false, false
+		}
+		line := make([]byte, end-start)
+		if _, err := f.ReadAt(line, start); err != nil && err != io.EOF {
+			return false, false, false
+		}
+		trimmed := strings.TrimSpace(string(line))
+		if trimmed == "" {
+			return false, false, false
+		}
+		var rec transcriptRecord
+		if err := json.Unmarshal([]byte(trimmed), &rec); err != nil {
+			return false, false, false
+		}
+		if !rec.isAssistantTurn() {
+			return false, false, false
+		}
+		if !rec.isRateLimitRejection() {
+			return false, true, true
+		}
+		// A rejection older than the window is no longer evidence about now.
+		return rec.fresh(now, usageLimitMaxAge), true, true
+	}
 
 	for end := info.Size(); end > 0; {
 		start := end - chunk
 		if start < 0 {
 			start = 0
 		}
-		buf := make([]byte, end-start)
-		if _, err := f.ReadAt(buf, start); err != nil && err != io.EOF {
+		n := end - start
+		if usageLimitScanObserver != nil {
+			usageLimitScanObserver(start, end)
+		}
+		if _, err := f.ReadAt(buf[:n], start); err != nil && err != io.EOF {
 			return false, false
 		}
-		data := append(buf, carry...)
-
-		lines := strings.Split(string(data), "\n")
-		// Unless this chunk starts at byte 0, its first line began earlier in the
-		// file and must not be parsed yet.
-		firstComplete := 0
-		if start > 0 {
-			firstComplete = 1
-			carry = []byte(lines[0])
-		} else {
-			carry = nil
-		}
-
-		for i := len(lines) - 1; i >= firstComplete; i-- {
-			line := strings.TrimSpace(lines[i])
-			if line == "" {
+		for i := n - 1; i >= 0; i-- {
+			if buf[i] != '\n' {
 				continue
 			}
-			var rec transcriptRecord
-			if err := json.Unmarshal([]byte(line), &rec); err != nil {
-				continue
+			if lim, o, decided := consider(start+i+1, lineEnd); decided {
+				return lim, o
 			}
-			if !rec.isAssistantTurn() {
-				continue
-			}
-			if !rec.isRateLimitRejection() {
-				return false, true
-			}
-			// A rejection older than the window is no longer evidence about now.
-			return rec.fresh(now, usageLimitMaxAge), true
+			lineEnd = start + i
 		}
 		end = start
+	}
+	// The first line of the file has no preceding newline to close it.
+	if lim, o, decided := consider(0, lineEnd); decided {
+		return lim, o
 	}
 	// The whole file was read and holds no main-conversation assistant turn.
 	return false, false
@@ -227,8 +265,8 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 // safe, and racing two real scans to exercise it is not something a test can do
 // deterministically. A scan may publish only if it is still the current claim AND
 // the instance is still bound to the session it read.
-func usageLimitPublishable(currentGen, scanGen uint64, currentSessionID, scanSessionID string) bool {
-	return currentGen == scanGen && currentSessionID == scanSessionID
+func usageLimitPublishable(currentGen, scanGen uint64, liveSessionID, scanSessionID string) bool {
+	return currentGen == scanGen && liveSessionID == scanSessionID
 }
 
 // usageLimitedNow reads the memo under the lock.
@@ -334,7 +372,11 @@ func (i *Instance) usageLimited() bool {
 	}
 
 	i.mu.Lock()
-	if usageLimitPublishable(i.usageLimitScanGen, gen, i.usageLimitSessionID, sessionID) {
+	// Compare against the LIVE ClaudeSessionID, not usageLimitSessionID. The memo
+	// key only changes when a mismatch is observed at claim time, so during an
+	// in-flight A→B rebind it still reads "A" — and a scan for A would publish onto
+	// an Instance already bound to B.
+	if usageLimitPublishable(i.usageLimitScanGen, gen, strings.TrimSpace(i.ClaudeSessionID), sessionID) {
 		i.usageLimitedCached = limited
 	} else {
 		// A newer claim or a rebind happened while this read was in flight, so this

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -75,23 +75,25 @@ const usageLimitMaxAge = 5 * time.Hour
 // so a few seconds of staleness costs nothing.
 const usageLimitScanInterval = 5 * time.Second
 
-// usageLimitFirstTailBytes is the first window read, sized for the common case:
-// a real transcript has assistant records throughout, so this answers in one read.
-const usageLimitFirstTailBytes = 512 * 1024
-
-// usageLimitTailGrowth multiplies the window when a read found no
-// main-conversation assistant record.
+// usageLimitScanChunkBytes is how much of the transcript is read at a time.
 //
-// There is deliberately NO ceiling. A fixed one does not remove the cold-start
-// failure it appears to bound, it just moves it further out: if the decisive
-// rejection sits beyond the cap and everything after it is non-assistant traffic,
-// every step returns no verdict, and a fresh process then starts with no memo and
-// reports the session as healthy — the false negative this detector exists to
-// prevent. Growth instead terminates on reading the whole file, so the answer is
-// always eventually found. The throttle bounds how often this can happen, and the
-// pathological case (no assistant record in tens of megabytes) is not what a real
-// transcript looks like.
-const usageLimitTailGrowth = 8
+// The scan walks BACKWARD in non-overlapping chunks of this size until it finds
+// the latest main-conversation assistant record or reaches the start of the file.
+// Two properties matter and neither is optional:
+//
+//   - No ceiling. A fixed cap does not remove the cold-start false negative it
+//     appears to bound, it relocates it: if the decisive rejection sits beyond the
+//     cap with only non-assistant traffic after it, no verdict forms and a fresh
+//     process reports the session healthy.
+//   - No overlap, bounded memory. An earlier revision grew the window
+//     geometrically and re-read what it had already seen — 512 KiB + 4 MiB + the
+//     whole file for one verdict on a 5.8 MB transcript, with the final read
+//     copied whole into memory. Chunking reads each byte at most once and holds
+//     one chunk at a time, which matters because this runs on a status path.
+//
+// A var rather than a const so tests can shrink it and exercise a many-chunk walk
+// without writing a multi-megabyte fixture.
+var usageLimitScanChunkBytes int64 = 512 * 1024
 
 // transcriptRecord is the subset of a transcript line this detector reads.
 type transcriptRecord struct {
@@ -150,14 +152,57 @@ func (r transcriptRecord) fresh(now time.Time, maxAge time.Duration) bool {
 // Callers must treat that as "unknown", never as "fine" — silence being mistaken
 // for health is the failure this whole detector exists to stop.
 func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool, ok bool) {
-	for tail := int64(usageLimitFirstTailBytes); ; tail *= usageLimitTailGrowth {
-		lines, complete, err := readTranscriptTailLines(path, tail)
-		if err != nil {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return false, false
+	}
+
+	chunk := usageLimitScanChunkBytes
+	if chunk <= 0 {
+		chunk = 512 * 1024
+	}
+
+	// carry holds the leftmost, still-incomplete line of the chunk processed
+	// previously (which sits LATER in the file). Its head is at the end of the
+	// chunk about to be read, so appending it there reassembles that line exactly
+	// once — no byte is read twice and no record is split across the boundary.
+	var carry []byte
+
+	for end := info.Size(); end > 0; {
+		start := end - chunk
+		if start < 0 {
+			start = 0
+		}
+		buf := make([]byte, end-start)
+		if _, err := f.ReadAt(buf, start); err != nil && err != io.EOF {
 			return false, false
 		}
-		for i := len(lines) - 1; i >= 0; i-- {
+		data := append(buf, carry...)
+
+		lines := strings.Split(string(data), "\n")
+		// Unless this chunk starts at byte 0, its first line began earlier in the
+		// file and must not be parsed yet.
+		firstComplete := 0
+		if start > 0 {
+			firstComplete = 1
+			carry = []byte(lines[0])
+		} else {
+			carry = nil
+		}
+
+		for i := len(lines) - 1; i >= firstComplete; i-- {
+			line := strings.TrimSpace(lines[i])
+			if line == "" {
+				continue
+			}
 			var rec transcriptRecord
-			if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
 				continue
 			}
 			if !rec.isAssistantTurn() {
@@ -169,65 +214,43 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 			// A rejection older than the window is no longer evidence about now.
 			return rec.fresh(now, usageLimitMaxAge), true
 		}
-		if complete {
-			// The whole file has been read and holds no assistant turn at all.
-			return false, false
-		}
+		end = start
 	}
+	// The whole file was read and holds no main-conversation assistant turn.
+	return false, false
 }
 
-// readTranscriptTailLines returns the complete JSONL lines in the last tailBytes
-// of path, and whether that read covered the whole file.
+// usageLimitPublishable reports whether a finished scan may write its result to
+// the memo.
 //
-// The first line of a mid-file read is dropped: a byte offset lands wherever it
-// lands, so that line is a fragment. Dropping it explicitly keeps the intent
-// legible and stops a truncated record from being parsed as a whole one.
-func readTranscriptTailLines(path string, tailBytes int64) (lines []string, complete bool, err error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, false, err
-	}
-	defer f.Close()
+// Split out as a pure function because it is the rule that makes concurrent scans
+// safe, and racing two real scans to exercise it is not something a test can do
+// deterministically. A scan may publish only if it is still the current claim AND
+// the instance is still bound to the session it read.
+func usageLimitPublishable(currentGen, scanGen uint64, currentSessionID, scanSessionID string) bool {
+	return currentGen == scanGen && currentSessionID == scanSessionID
+}
 
-	info, err := f.Stat()
-	if err != nil {
-		return nil, false, err
-	}
-
-	offset := int64(0)
-	complete = true
-	if info.Size() > tailBytes {
-		offset = info.Size() - tailBytes
-		complete = false
-	}
-	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return nil, false, err
-	}
-
-	data, err := io.ReadAll(f)
-	if err != nil {
-		return nil, false, err
-	}
-
-	split := strings.Split(string(data), "\n")
-	if !complete && len(split) > 0 {
-		split = split[1:]
-	}
-	out := make([]string, 0, len(split))
-	for _, l := range split {
-		if strings.TrimSpace(l) != "" {
-			out = append(out, l)
-		}
-	}
-	return out, complete, nil
+// usageLimitedNow reads the memo under the lock.
+//
+// Every post-claim exit goes through this rather than returning the snapshot taken
+// at claim time. Returning the snapshot let a slow scan report a value that a
+// newer scan had already superseded: the memo stayed correct, but callers observed
+// completion order inverted.
+func (i *Instance) usageLimitedNow() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.usageLimitedCached
 }
 
 // transcriptBelongsToSession reports whether a resolved transcript path is the
 // one for sessionID.
 //
 // Every branch of the resolver builds "<config>/projects/<encoded>/<sid>.jsonl",
-// so the basename is the session identity — which makes this a cheap way to
-// refuse a path that belongs to some other conversation, whatever produced it.
+// so the basename is the session identity — which makes this a cheap way to refuse
+// a path belonging to some other conversation, whatever produced it. Locking the
+// id check alone cannot do that, because the resolver re-reads ClaudeSessionID
+// itself after the lock is released.
 func transcriptBelongsToSession(path, sessionID string) bool {
 	if path == "" || sessionID == "" {
 		return false
@@ -287,12 +310,11 @@ func (i *Instance) usageLimited() bool {
 	i.lastUsageLimitScanAt = time.Now()
 	i.usageLimitScanGen++
 	gen := i.usageLimitScanGen
-	cached := i.usageLimitedCached
 	i.mu.Unlock()
 
 	path := locateHandoffTranscript(i)
 	if path == "" {
-		return cached
+		return i.usageLimitedNow()
 	}
 	// Verify the answer belongs to the id we gated on. Holding the lock across the
 	// check is not enough on its own: the resolver re-reads ClaudeSessionID itself
@@ -300,7 +322,7 @@ func (i *Instance) usageLimited() bool {
 	// still steer it onto the newest-conversation fallback. Checking the resolved
 	// path makes the guarantee structural instead of dependent on timing.
 	if !transcriptBelongsToSession(path, sessionID) {
-		return cached
+		return i.usageLimitedNow()
 	}
 
 	limited, ok := latestAssistantTurnIsRateLimited(path, time.Now())
@@ -308,16 +330,15 @@ func (i *Instance) usageLimited() bool {
 		// No formed verdict (unreadable, or no assistant turn in the file): leave
 		// the previous answer standing rather than silently reporting "not
 		// limited".
-		return cached
+		return i.usageLimitedNow()
 	}
 
 	i.mu.Lock()
-	// Publish only if this scan is still the current one AND the instance is still
-	// bound to the id it was formed for. Either check failing means a newer claim
-	// or a rebind happened while the read was in flight, and this result is stale.
-	if i.usageLimitScanGen == gen && i.usageLimitSessionID == sessionID {
+	if usageLimitPublishable(i.usageLimitScanGen, gen, i.usageLimitSessionID, sessionID) {
 		i.usageLimitedCached = limited
 	} else {
+		// A newer claim or a rebind happened while this read was in flight, so this
+		// result is stale — report what the memo now holds instead.
 		limited = i.usageLimitedCached
 	}
 	i.mu.Unlock()

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -52,14 +52,21 @@ const (
 // The verdict is "the latest assistant turn was a quota rejection", which clears
 // itself the moment a real turn completes — but only if one ever does. A session
 // that receives no further input after the window reopens would otherwise stay
-// classified from that old rejection indefinitely. Rather than parse the
-// advertised reset text ("resets 8:50pm (UTC)"), which needs 12-hour parsing, a
-// timezone and day-rollover handling and is still only a promise, this bounds
-// belief by the length of the rolling window itself.
+// classified from that old rejection indefinitely.
 //
-// The erring direction is deliberate: where a plan uses a longer cap (a weekly
-// one), this clears early and reports the session as unremarkable — which is the
-// pre-existing behaviour, not a new false positive.
+// KNOWN LIMITATION, accepted deliberately: this bounds the staleness but does not
+// track the ACTUAL reset. The banner carries one ("resets 8:50pm (UTC)") and this
+// does not read it, so a rejection stamped 20:35 whose window reopened at 20:50 is
+// still believed until 01:35 — up to ~5h of false usage-limit in the
+// no-further-input case. The cost is bounded and is a mislabel rather than an
+// action, since nothing consumes this substate yet; the alternative is parsing a
+// human-facing 12-hour local-time string (timezone, day rollover, wording drift)
+// to obtain a promise rather than an observation. Revisit when a consumer starts
+// acting on the verdict, and prefer a revalidation signal over parsing the prose.
+//
+// The erring direction of the bound itself is also deliberate: where a plan uses a
+// longer cap (a weekly one), this clears early and reports the session as
+// unremarkable — the pre-existing behaviour, not a new false positive.
 const usageLimitMaxAge = 5 * time.Hour
 
 // usageLimitScanInterval throttles the transcript read. Substate is computed per
@@ -68,21 +75,23 @@ const usageLimitMaxAge = 5 * time.Hour
 // so a few seconds of staleness costs nothing.
 const usageLimitScanInterval = 5 * time.Second
 
-// usageLimitTailSteps are the tail sizes tried in order until a
-// main-conversation assistant record is found.
+// usageLimitFirstTailBytes is the first window read, sized for the common case:
+// a real transcript has assistant records throughout, so this answers in one read.
+const usageLimitFirstTailBytes = 512 * 1024
+
+// usageLimitTailGrowth multiplies the window when a read found no
+// main-conversation assistant record.
 //
-// One fixed window is not enough. A single oversized record (a file-history
-// snapshot, a compaction) can fill it, and later non-assistant traffic can push
-// the decisive rejection out of it. When that happens a long-lived process keeps
-// its memo, but a fresh CLI invocation starts with no memo and would report the
-// session as healthy — the exact false negative this detector exists to prevent.
-// So escalate rather than give up, and stop at a bound so a pathological
-// transcript cannot turn a status poll into an unbounded read.
-var usageLimitTailSteps = []int64{
-	512 * 1024,
-	8 * 1024 * 1024,
-	64 * 1024 * 1024,
-}
+// There is deliberately NO ceiling. A fixed one does not remove the cold-start
+// failure it appears to bound, it just moves it further out: if the decisive
+// rejection sits beyond the cap and everything after it is non-assistant traffic,
+// every step returns no verdict, and a fresh process then starts with no memo and
+// reports the session as healthy — the false negative this detector exists to
+// prevent. Growth instead terminates on reading the whole file, so the answer is
+// always eventually found. The throttle bounds how often this can happen, and the
+// pathological case (no assistant record in tens of megabytes) is not what a real
+// transcript looks like.
+const usageLimitTailGrowth = 8
 
 // transcriptRecord is the subset of a transcript line this detector reads.
 type transcriptRecord struct {
@@ -141,7 +150,7 @@ func (r transcriptRecord) fresh(now time.Time, maxAge time.Duration) bool {
 // Callers must treat that as "unknown", never as "fine" — silence being mistaken
 // for health is the failure this whole detector exists to stop.
 func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool, ok bool) {
-	for _, tail := range usageLimitTailSteps {
+	for tail := int64(usageLimitFirstTailBytes); ; tail *= usageLimitTailGrowth {
 		lines, complete, err := readTranscriptTailLines(path, tail)
 		if err != nil {
 			return false, false
@@ -161,11 +170,10 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 			return rec.fresh(now, usageLimitMaxAge), true
 		}
 		if complete {
-			// The whole file was read and holds no assistant turn at all.
+			// The whole file has been read and holds no assistant turn at all.
 			return false, false
 		}
 	}
-	return false, false
 }
 
 // readTranscriptTailLines returns the complete JSONL lines in the last tailBytes
@@ -241,10 +249,11 @@ func (i *Instance) usageLimited() bool {
 	if i.IsSSH() {
 		return false
 	}
+
 	// Read the session id, check the throttle and claim the window in ONE critical
 	// section. Split apart, two callers whose window had expired could both pass
-	// the check, both scan, and publish their results in either order — and the
-	// id could change between its own read and the claim.
+	// the check, both scan, and publish their results in either order — and the id
+	// could change between its own read and the claim.
 	//
 	// A bound session id is required, not merely helpful: with an empty id
 	// LocateConversationConfigDir deliberately falls back to the NEWEST
@@ -256,14 +265,28 @@ func (i *Instance) usageLimited() bool {
 		i.mu.Unlock()
 		return false
 	}
+	// The memo carries the id it was formed for. A session normally rebinds
+	// (A→B) on the same Instance, and an identity-less memo would hand B the
+	// verdict formed for A — indefinitely, if B never produces an assistant turn
+	// of its own. A mismatch is therefore not a cache miss to be papered over but
+	// a reason to discard both the verdict and the throttle claim.
+	if i.usageLimitSessionID != sessionID {
+		i.usageLimitSessionID = sessionID
+		i.usageLimitedCached = false
+		i.lastUsageLimitScanAt = time.Time{}
+	}
 	if !i.lastUsageLimitScanAt.IsZero() && time.Since(i.lastUsageLimitScanAt) < usageLimitScanInterval {
 		cached := i.usageLimitedCached
 		i.mu.Unlock()
 		return cached
 	}
 	// Claim the window before releasing the lock so a concurrent caller sees it
-	// taken. The I/O below deliberately runs unlocked.
+	// taken, and take a generation stamp. The stamp records scan START, so a scan
+	// slower than the interval can overlap the next claim; the generation is what
+	// stops the older one publishing over the newer result.
 	i.lastUsageLimitScanAt = time.Now()
+	i.usageLimitScanGen++
+	gen := i.usageLimitScanGen
 	cached := i.usageLimitedCached
 	i.mu.Unlock()
 
@@ -282,14 +305,21 @@ func (i *Instance) usageLimited() bool {
 
 	limited, ok := latestAssistantTurnIsRateLimited(path, time.Now())
 	if !ok {
-		// No formed verdict (unreadable, or no assistant turn within the
-		// escalation bound): leave the previous answer standing rather than
-		// silently reporting "not limited".
+		// No formed verdict (unreadable, or no assistant turn in the file): leave
+		// the previous answer standing rather than silently reporting "not
+		// limited".
 		return cached
 	}
 
 	i.mu.Lock()
-	i.usageLimitedCached = limited
+	// Publish only if this scan is still the current one AND the instance is still
+	// bound to the id it was formed for. Either check failing means a newer claim
+	// or a rebind happened while the read was in flight, and this result is stale.
+	if i.usageLimitScanGen == gen && i.usageLimitSessionID == sessionID {
+		i.usageLimitedCached = limited
+	} else {
+		limited = i.usageLimitedCached
+	}
 	i.mu.Unlock()
 
 	return limited

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -187,7 +187,11 @@ func readTranscriptTailLines(path string, tailBytes int64) ([]string, error) {
 //
 // Claude-compatible tools only: the transcript shape is Claude's.
 func (i *Instance) usageLimited() bool {
-	if !IsClaudeCompatible(i.Tool) {
+	// The transcript is a local file. An SSH-backed session keeps its
+	// conversation on the remote host and stores a remote ProjectPath, so there
+	// is no local path to resolve — bail before doing any path work rather than
+	// resolving a meaningless local path and failing to open it forever.
+	if !IsClaudeCompatible(i.Tool) || i.IsSSH() {
 		return false
 	}
 
@@ -200,25 +204,34 @@ func (i *Instance) usageLimited() bool {
 		return cached
 	}
 
+	// Stamp the attempt BEFORE doing the work, so every exit below is throttled.
+	// Stamping only on success would leave one path unthrottled — a session whose
+	// transcript never resolves — and that is the worst one to leave open:
+	// locateHandoffTranscript loads user config and stats several candidate paths,
+	// and a session that cannot resolve once will not resolve on the next poll
+	// either, so it would pay that cost forever.
+	i.mu.Lock()
+	i.lastUsageLimitScanAt = time.Now()
+	i.mu.Unlock()
+
 	path := locateHandoffTranscript(i)
 	if path == "" {
 		return cached
 	}
 
 	limited, ok := latestAssistantTurnIsRateLimited(path)
+	if !ok {
+		// No formed verdict (unreadable file, or a tail with no assistant turn):
+		// leave the previous answer standing rather than silently reporting
+		// "not limited", which is the mistake this detector exists to stop.
+		return cached
+	}
 
 	i.mu.Lock()
-	i.lastUsageLimitScanAt = time.Now()
-	if ok {
-		// Only a formed verdict updates the mirror. An unreadable or
-		// assistant-less tail leaves the previous answer standing rather than
-		// silently reporting "not limited".
-		i.usageLimitedCached = limited
-	}
-	cached = i.usageLimitedCached
+	i.usageLimitedCached = limited
 	i.mu.Unlock()
 
-	return cached
+	return limited
 }
 
 // UsageLimitedCached reports the last computed verdict without any filesystem

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -21,31 +21,45 @@ import (
 // sending. Nothing in the stack reported a problem.
 //
 // The signal is taken from Claude's own transcript rather than from pane text.
-// That is a deliberate choice, and the reason is worth recording because the
-// pane looks like the obvious source: the rejection renders behind the "⎿"
-// tool-result connector, wraps across visual lines on a narrow pane (agent-deck
-// captures with `-p -e` and no `-J`, so soft wraps arrive as real newlines), and
-// shares its vocabulary with ordinary output — a session running `grep` over
-// this repository would print the same words. Every one of those defeats a text
-// scanner. The transcript instead carries structured fields:
+// That is deliberate, and worth recording because the pane looks like the
+// obvious source: the rejection renders behind the "⎿" tool-result connector,
+// wraps across visual lines on a narrow pane (agent-deck captures with `-p -e`
+// and no `-J`, so soft wraps arrive as real newlines), and shares its vocabulary
+// with ordinary output — a session running `grep` over this repository prints the
+// same words. Every one of those defeats a text scanner. The transcript instead
+// carries structured fields:
 //
 //	{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,
 //	 "error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z", ...}
 //
-// So the verdict keys off `apiErrorStatus` / `error`, not off prose. Nothing
-// here needs to know how Claude words the banner, or how wide the pane is.
+// So the verdict keys off apiErrorStatus + error, not off prose.
 
-// usageLimitRateLimitStatus is the HTTP status Claude records on a quota
-// rejection. Paired with the `error` discriminator below rather than trusted
-// alone, since 429 is a general rate-limit code.
-const usageLimitRateLimitStatus = 429
+// usageLimitRateLimitStatus and usageLimitErrorKind are BOTH required.
+//
+// 429 alone is a general rate-limit code that other API errors also carry, and
+// mislabelling one of those as plan exhaustion would then persist for the whole
+// freshness window. Every field sample carries the pair, so the pair is the
+// contract; if a sample is ever observed carrying only one of them, relax this
+// with that evidence in hand rather than pre-emptively.
+const (
+	usageLimitRateLimitStatus = 429
+	usageLimitErrorKind       = "rate_limit"
+)
 
-// usageLimitErrorKind is the `error` discriminator Claude writes alongside a
-// quota rejection ("rate_limit"). Distinct from a credential failure, which
-// carries its own status (401) and kind — the two need opposite responses:
-// re-authenticating cannot help a quota window, and waiting cannot help an
-// expired token.
-const usageLimitErrorKind = "rate_limit"
+// usageLimitMaxAge bounds how long a rejection is believed.
+//
+// The verdict is "the latest assistant turn was a quota rejection", which clears
+// itself the moment a real turn completes — but only if one ever does. A session
+// that receives no further input after the window reopens would otherwise stay
+// classified from that old rejection indefinitely. Rather than parse the
+// advertised reset text ("resets 8:50pm (UTC)"), which needs 12-hour parsing, a
+// timezone and day-rollover handling and is still only a promise, this bounds
+// belief by the length of the rolling window itself.
+//
+// The erring direction is deliberate: where a plan uses a longer cap (a weekly
+// one), this clears early and reports the session as unremarkable — which is the
+// pre-existing behaviour, not a new false positive.
+const usageLimitMaxAge = 5 * time.Hour
 
 // usageLimitScanInterval throttles the transcript read. Substate is computed per
 // session per status poll, so an unbounded read would put file I/O on a path
@@ -53,12 +67,21 @@ const usageLimitErrorKind = "rate_limit"
 // so a few seconds of staleness costs nothing.
 const usageLimitScanInterval = 5 * time.Second
 
-// usageLimitTranscriptTailBytes bounds how much of the transcript is read.
-// Transcripts reach tens of megabytes (a 62 MB one was in the field evidence),
-// and only the most recent turn matters, so read a tail rather than the file.
-// Large enough to contain several records even when one carries a file-history
-// snapshot.
-const usageLimitTranscriptTailBytes = 512 * 1024
+// usageLimitTailSteps are the tail sizes tried in order until a
+// main-conversation assistant record is found.
+//
+// One fixed window is not enough. A single oversized record (a file-history
+// snapshot, a compaction) can fill it, and later non-assistant traffic can push
+// the decisive rejection out of it. When that happens a long-lived process keeps
+// its memo, but a fresh CLI invocation starts with no memo and would report the
+// session as healthy — the exact false negative this detector exists to prevent.
+// So escalate rather than give up, and stop at a bound so a pathological
+// transcript cannot turn a status poll into an unbounded read.
+var usageLimitTailSteps = []int64{
+	512 * 1024,
+	8 * 1024 * 1024,
+	64 * 1024 * 1024,
+}
 
 // transcriptRecord is the subset of a transcript line this detector reads.
 type transcriptRecord struct {
@@ -69,21 +92,15 @@ type transcriptRecord struct {
 	Error             string `json:"error"`
 	Timestamp         string `json:"timestamp"`
 	Message           struct {
-		Role    string `json:"role"`
-		Content any    `json:"content"`
+		Role string `json:"role"`
 	} `json:"message"`
 }
 
-// isRateLimitRejection reports whether this record is a quota rejection.
-//
-// Requires the api-error flag AND one of the two structured discriminators. The
-// flag alone is not enough (a 401 or an overloaded-model error also sets it),
-// and matching the rendered text is exactly what this detector exists to avoid.
+// isRateLimitRejection reports whether this record is a plan-quota rejection.
+// Requires the api-error flag AND both discriminators — see the constants above.
 func (r transcriptRecord) isRateLimitRejection() bool {
-	if !r.IsAPIErrorMessage {
-		return false
-	}
-	return r.APIErrorStatus == usageLimitRateLimitStatus ||
+	return r.IsAPIErrorMessage &&
+		r.APIErrorStatus == usageLimitRateLimitStatus &&
 		strings.EqualFold(strings.TrimSpace(r.Error), usageLimitErrorKind)
 }
 
@@ -101,117 +118,140 @@ func (r transcriptRecord) isAssistantTurn() bool {
 	return role == "assistant"
 }
 
-// latestAssistantTurnIsRateLimited reports whether the MOST RECENT assistant
-// turn in the transcript at path is a quota rejection, plus whether a verdict
-// could be formed at all.
+// fresh reports whether the record's timestamp is within maxAge of now.
 //
-// "Most recent assistant turn" is the whole expiry story, and it is why this
-// shape was chosen over parsing the advertised reset time ("resets 8:50pm
-// (UTC)"). A reset timestamp would need 12-hour parsing, a timezone, and
-// day-rollover handling, and would still be a promise rather than an
-// observation. Whereas the moment the session completes any real turn, the
-// latest assistant record is no longer an error and the verdict clears itself.
-// Nothing has to expire it, and it cannot get stuck.
-//
-// ok is false when no assistant turn was found in the tail (a brand-new session,
-// or a tail entirely consumed by one oversized record). Callers must treat that
-// as "unknown", never as "fine" — silence is what this whole detector exists to
-// stop being mistaken for health.
-func latestAssistantTurnIsRateLimited(path string) (limited bool, ok bool) {
-	lines, err := readTranscriptTailLines(path, usageLimitTranscriptTailBytes)
+// An absent or unparseable timestamp is NOT treated as fresh: believing a
+// rejection of unknown age is precisely what produces a stuck verdict. A
+// timestamp in the future is likewise rejected rather than trusted.
+func (r transcriptRecord) fresh(now time.Time, maxAge time.Duration) bool {
+	ts, err := time.Parse(time.RFC3339, strings.TrimSpace(r.Timestamp))
 	if err != nil {
-		return false, false
+		return false
 	}
-	for i := len(lines) - 1; i >= 0; i-- {
-		var rec transcriptRecord
-		if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
-			continue
+	age := now.Sub(ts)
+	return age >= 0 && age <= maxAge
+}
+
+// latestAssistantTurnIsRateLimited reports whether the MOST RECENT
+// main-conversation assistant turn at path is a quota rejection recent enough to
+// still be believed, plus whether a verdict could be formed at all.
+//
+// ok is false when no assistant turn was found within the escalation bound.
+// Callers must treat that as "unknown", never as "fine" — silence being mistaken
+// for health is the failure this whole detector exists to stop.
+func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool, ok bool) {
+	for _, tail := range usageLimitTailSteps {
+		lines, complete, err := readTranscriptTailLines(path, tail)
+		if err != nil {
+			return false, false
 		}
-		if !rec.isAssistantTurn() {
-			continue
+		for i := len(lines) - 1; i >= 0; i-- {
+			var rec transcriptRecord
+			if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
+				continue
+			}
+			if !rec.isAssistantTurn() {
+				continue
+			}
+			if !rec.isRateLimitRejection() {
+				return false, true
+			}
+			// A rejection older than the window is no longer evidence about now.
+			return rec.fresh(now, usageLimitMaxAge), true
 		}
-		return rec.isRateLimitRejection(), true
+		if complete {
+			// The whole file was read and holds no assistant turn at all.
+			return false, false
+		}
 	}
 	return false, false
 }
 
 // readTranscriptTailLines returns the complete JSONL lines in the last tailBytes
-// of path.
+// of path, and whether that read covered the whole file.
 //
 // The first line of a mid-file read is dropped: a byte offset lands wherever it
-// lands, so that line is a fragment and would fail to parse anyway — dropping it
-// explicitly keeps the intent legible.
-func readTranscriptTailLines(path string, tailBytes int64) ([]string, error) {
+// lands, so that line is a fragment. Dropping it explicitly keeps the intent
+// legible and stops a truncated record from being parsed as a whole one.
+func readTranscriptTailLines(path string, tailBytes int64) (lines []string, complete bool, err error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer f.Close()
 
 	info, err := f.Stat()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	offset := int64(0)
-	truncated := false
+	complete = true
 	if info.Size() > tailBytes {
 		offset = info.Size() - tailBytes
-		truncated = true
+		complete = false
 	}
 	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	lines := strings.Split(string(data), "\n")
-	if truncated && len(lines) > 0 {
-		lines = lines[1:]
+	split := strings.Split(string(data), "\n")
+	if !complete && len(split) > 0 {
+		split = split[1:]
 	}
-	out := make([]string, 0, len(lines))
-	for _, l := range lines {
+	out := make([]string, 0, len(split))
+	for _, l := range split {
 		if strings.TrimSpace(l) != "" {
 			out = append(out, l)
 		}
 	}
-	return out, nil
+	return out, complete, nil
 }
 
-// usageLimited reports whether this instance's latest assistant turn was a quota
-// rejection, throttled to usageLimitScanInterval and mirrored in memory so the
-// render path can read it without touching the filesystem.
-//
-// Claude-compatible tools only: the transcript shape is Claude's.
+// usageLimited reports whether this instance's latest assistant turn was a
+// recent quota rejection, throttled to usageLimitScanInterval.
 func (i *Instance) usageLimited() bool {
+	// Claude-compatible tools only: the transcript shape is Claude's.
+	if !IsClaudeCompatible(i.Tool) {
+		return false
+	}
 	// The transcript is a local file. An SSH-backed session keeps its
 	// conversation on the remote host and stores a remote ProjectPath, so there
 	// is no local path to resolve — bail before doing any path work rather than
 	// resolving a meaningless local path and failing to open it forever.
-	if !IsClaudeCompatible(i.Tool) || i.IsSSH() {
+	if i.IsSSH() {
+		return false
+	}
+	// A bound session id is required, not merely helpful. With an empty id
+	// LocateConversationConfigDir deliberately falls back to the NEWEST
+	// conversation for the project across every config dir, so an unbound
+	// instance would inherit whichever sibling session wrote last and be marked
+	// usage-limited on another session's rejection.
+	i.mu.RLock()
+	sessionID := strings.TrimSpace(i.ClaudeSessionID)
+	i.mu.RUnlock()
+	if sessionID == "" {
 		return false
 	}
 
-	i.mu.RLock()
-	last := i.lastUsageLimitScanAt
-	cached := i.usageLimitedCached
-	i.mu.RUnlock()
-
-	if !last.IsZero() && time.Since(last) < usageLimitScanInterval {
+	// Check and stamp in ONE critical section. Split across an RLock read and a
+	// later Lock, two callers whose window had expired could both pass the check,
+	// both scan, and publish their results in either order.
+	i.mu.Lock()
+	if !i.lastUsageLimitScanAt.IsZero() && time.Since(i.lastUsageLimitScanAt) < usageLimitScanInterval {
+		cached := i.usageLimitedCached
+		i.mu.Unlock()
 		return cached
 	}
-
-	// Stamp the attempt BEFORE doing the work, so every exit below is throttled.
-	// Stamping only on success would leave one path unthrottled — a session whose
-	// transcript never resolves — and that is the worst one to leave open:
-	// locateHandoffTranscript loads user config and stats several candidate paths,
-	// and a session that cannot resolve once will not resolve on the next poll
-	// either, so it would pay that cost forever.
-	i.mu.Lock()
+	// Claim the window before releasing the lock so a concurrent caller sees it
+	// taken. The I/O below deliberately runs unlocked.
 	i.lastUsageLimitScanAt = time.Now()
+	cached := i.usageLimitedCached
 	i.mu.Unlock()
 
 	path := locateHandoffTranscript(i)
@@ -219,11 +259,11 @@ func (i *Instance) usageLimited() bool {
 		return cached
 	}
 
-	limited, ok := latestAssistantTurnIsRateLimited(path)
+	limited, ok := latestAssistantTurnIsRateLimited(path, time.Now())
 	if !ok {
-		// No formed verdict (unreadable file, or a tail with no assistant turn):
-		// leave the previous answer standing rather than silently reporting
-		// "not limited", which is the mistake this detector exists to stop.
+		// No formed verdict (unreadable, or no assistant turn within the
+		// escalation bound): leave the previous answer standing rather than
+		// silently reporting "not limited".
 		return cached
 	}
 
@@ -232,12 +272,4 @@ func (i *Instance) usageLimited() bool {
 	i.mu.Unlock()
 
 	return limited
-}
-
-// UsageLimitedCached reports the last computed verdict without any filesystem
-// access, for the TUI render hot path.
-func (i *Instance) UsageLimitedCached() bool {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return i.usageLimitedCached
 }

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -105,11 +105,23 @@ var usageLimitScanChunkBytes int64 = defaultUsageLimitScanChunkBytes
 // skipped on its measured length, without being read at all.
 const usageLimitMaxLineBytes = 1 << 20 // 1 MiB
 
-// usageLimitScanObserver is a TEST SEAM: when non-nil it receives the byte range
-// of every chunk read, which is what lets a test assert non-overlap and bounded
-// I/O rather than merely assert that the answer came out right. Always nil in
-// production.
-var usageLimitScanObserver func(start, end int64)
+// usageLimitScanRead describes one read the scan performed. kind is "chunk" for a
+// newline-scanning window and "line" for a candidate record read.
+//
+// Recording BOTH matters: chunk ranges alone cannot distinguish this walker from
+// the carry-based one it replaced, whose chunk windows were also descending,
+// contiguous and single-coverage — its defect was repeated copying of a growing
+// line, which chunk instrumentation cannot see. Line reads are where that shows up.
+type usageLimitScanRead struct {
+	Kind       string
+	Start, End int64
+}
+
+// usageLimitScanObserver is a TEST SEAM: when non-nil it receives every read the
+// scan performs. It is what lets a test assert non-overlap, bounded I/O and the
+// oversized-line skip rather than merely assert that the answer came out right.
+// Always nil in production.
+var usageLimitScanObserver func(usageLimitScanRead)
 
 // transcriptRecord is the subset of a transcript line this detector reads.
 type transcriptRecord struct {
@@ -179,11 +191,23 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 		return false, false
 	}
 
+	if info.Size() == 0 {
+		// Nothing to read, and nothing to allocate: an empty transcript used to cost
+		// a full chunk buffer on every eligible scan.
+		return false, false
+	}
+
 	chunk := usageLimitScanChunkBytes
 	if chunk <= 0 {
 		chunk = defaultUsageLimitScanChunkBytes
 	}
-	buf := make([]byte, chunk)
+	// Size the buffer to the file when it is smaller than a chunk. A just-created
+	// 200-byte transcript should not allocate 512 KiB per scan.
+	bufSize := chunk
+	if info.Size() < bufSize {
+		bufSize = info.Size()
+	}
+	buf := make([]byte, bufSize)
 
 	// lineEnd is the exclusive end of the line currently being delimited. Walking
 	// backwards, a '\n' at offset i closes the line [i+1, lineEnd) and opens the
@@ -200,10 +224,16 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 			return false, false, false
 		}
 		if end-start > usageLimitMaxLineBytes {
+			if usageLimitScanObserver != nil {
+				usageLimitScanObserver(usageLimitScanRead{Kind: "line-skipped", Start: start, End: end})
+			}
 			// A line this large is a compaction/file-history snapshot, not a turn
 			// this detector can act on. Skipped WITHOUT reading it: the whole point
 			// of the bound is not to pull megabytes onto a status path.
 			return false, false, false
+		}
+		if usageLimitScanObserver != nil {
+			usageLimitScanObserver(usageLimitScanRead{Kind: "line", Start: start, End: end})
 		}
 		line := make([]byte, end-start)
 		if _, err := f.ReadAt(line, start); err != nil && err != io.EOF {
@@ -234,7 +264,7 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 		}
 		n := end - start
 		if usageLimitScanObserver != nil {
-			usageLimitScanObserver(start, end)
+			usageLimitScanObserver(usageLimitScanRead{Kind: "chunk", Start: start, End: end})
 		}
 		if _, err := f.ReadAt(buf[:n], start); err != nil && err != io.EOF {
 			return false, false
@@ -269,15 +299,23 @@ func usageLimitPublishable(currentGen, scanGen uint64, liveSessionID, scanSessio
 	return currentGen == scanGen && liveSessionID == scanSessionID
 }
 
-// usageLimitedNow reads the memo under the lock.
+// usageLimitVerdictFor reads the memo under the lock, but only if the memo was
+// formed for sessionID.
 //
-// Every post-claim exit goes through this rather than returning the snapshot taken
-// at claim time. Returning the snapshot let a slow scan report a value that a
-// newer scan had already superseded: the memo stayed correct, but callers observed
-// completion order inverted.
-func (i *Instance) usageLimitedNow() bool {
+// Two separate mistakes led here and both are worth naming. First, returning the
+// snapshot taken at claim time let a slow scan report a value a newer scan had
+// already superseded, so callers observed completion order inverted. Second — and
+// worse — reading the memo unconditionally was identity-blind: guarding only the
+// WRITE stopped scan A publishing after an A→B rebind but still handed A's verdict
+// back for B, because the memo key only moves when a mismatch is observed at claim
+// time. A mismatch here means "no verdict for this session", not "not limited by
+// inheritance".
+func (i *Instance) usageLimitVerdictFor(sessionID string) bool {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
+	if i.usageLimitSessionID != sessionID {
+		return false
+	}
 	return i.usageLimitedCached
 }
 
@@ -352,7 +390,7 @@ func (i *Instance) usageLimited() bool {
 
 	path := locateHandoffTranscript(i)
 	if path == "" {
-		return i.usageLimitedNow()
+		return i.usageLimitVerdictFor(sessionID)
 	}
 	// Verify the answer belongs to the id we gated on. Holding the lock across the
 	// check is not enough on its own: the resolver re-reads ClaudeSessionID itself
@@ -360,7 +398,7 @@ func (i *Instance) usageLimited() bool {
 	// still steer it onto the newest-conversation fallback. Checking the resolved
 	// path makes the guarantee structural instead of dependent on timing.
 	if !transcriptBelongsToSession(path, sessionID) {
-		return i.usageLimitedNow()
+		return i.usageLimitVerdictFor(sessionID)
 	}
 
 	limited, ok := latestAssistantTurnIsRateLimited(path, time.Now())
@@ -368,19 +406,28 @@ func (i *Instance) usageLimited() bool {
 		// No formed verdict (unreadable, or no assistant turn in the file): leave
 		// the previous answer standing rather than silently reporting "not
 		// limited".
-		return i.usageLimitedNow()
+		return i.usageLimitVerdictFor(sessionID)
 	}
 
 	i.mu.Lock()
-	// Compare against the LIVE ClaudeSessionID, not usageLimitSessionID. The memo
-	// key only changes when a mismatch is observed at claim time, so during an
-	// in-flight A→B rebind it still reads "A" — and a scan for A would publish onto
-	// an Instance already bound to B.
-	if usageLimitPublishable(i.usageLimitScanGen, gen, strings.TrimSpace(i.ClaudeSessionID), sessionID) {
+	// Order matters here, and getting it wrong once already produced this exact bug
+	// twice: check the LIVE ClaudeSessionID against the scan's id FIRST.
+	//
+	// usageLimitSessionID is the memo KEY and only moves when a mismatch is observed
+	// at claim time, so during an in-flight A→B rebind it still reads "A". Comparing
+	// against it — anywhere, on the write path or the read path — hands A's verdict
+	// to B. The live field is the only thing that knows about the rebind.
+	live := strings.TrimSpace(i.ClaudeSessionID)
+	switch {
+	case live != sessionID:
+		// Rebound while this read was in flight. There is no verdict for the new
+		// session, and inheriting one is the bug.
+		limited = false
+	case usageLimitPublishable(i.usageLimitScanGen, gen, live, sessionID):
 		i.usageLimitedCached = limited
-	} else {
-		// A newer claim or a rebind happened while this read was in flight, so this
-		// result is stale — report what the memo now holds instead.
+	default:
+		// A newer claim for the SAME session landed while this read was in flight,
+		// so this result is stale — report what the memo now holds.
 		limited = i.usageLimitedCached
 	}
 	i.mu.Unlock()

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -213,6 +214,19 @@ func readTranscriptTailLines(path string, tailBytes int64) (lines []string, comp
 	return out, complete, nil
 }
 
+// transcriptBelongsToSession reports whether a resolved transcript path is the
+// one for sessionID.
+//
+// Every branch of the resolver builds "<config>/projects/<encoded>/<sid>.jsonl",
+// so the basename is the session identity — which makes this a cheap way to
+// refuse a path that belongs to some other conversation, whatever produced it.
+func transcriptBelongsToSession(path, sessionID string) bool {
+	if path == "" || sessionID == "" {
+		return false
+	}
+	return filepath.Base(path) == sessionID+".jsonl"
+}
+
 // usageLimited reports whether this instance's latest assistant turn was a
 // recent quota rejection, throttled to usageLimitScanInterval.
 func (i *Instance) usageLimited() bool {
@@ -227,22 +241,21 @@ func (i *Instance) usageLimited() bool {
 	if i.IsSSH() {
 		return false
 	}
-	// A bound session id is required, not merely helpful. With an empty id
+	// Read the session id, check the throttle and claim the window in ONE critical
+	// section. Split apart, two callers whose window had expired could both pass
+	// the check, both scan, and publish their results in either order — and the
+	// id could change between its own read and the claim.
+	//
+	// A bound session id is required, not merely helpful: with an empty id
 	// LocateConversationConfigDir deliberately falls back to the NEWEST
-	// conversation for the project across every config dir, so an unbound
-	// instance would inherit whichever sibling session wrote last and be marked
-	// usage-limited on another session's rejection.
-	i.mu.RLock()
+	// conversation for the project across every config dir, so an unbound instance
+	// would inherit whichever sibling session wrote last.
+	i.mu.Lock()
 	sessionID := strings.TrimSpace(i.ClaudeSessionID)
-	i.mu.RUnlock()
 	if sessionID == "" {
+		i.mu.Unlock()
 		return false
 	}
-
-	// Check and stamp in ONE critical section. Split across an RLock read and a
-	// later Lock, two callers whose window had expired could both pass the check,
-	// both scan, and publish their results in either order.
-	i.mu.Lock()
 	if !i.lastUsageLimitScanAt.IsZero() && time.Since(i.lastUsageLimitScanAt) < usageLimitScanInterval {
 		cached := i.usageLimitedCached
 		i.mu.Unlock()
@@ -256,6 +269,14 @@ func (i *Instance) usageLimited() bool {
 
 	path := locateHandoffTranscript(i)
 	if path == "" {
+		return cached
+	}
+	// Verify the answer belongs to the id we gated on. Holding the lock across the
+	// check is not enough on its own: the resolver re-reads ClaudeSessionID itself
+	// (migrate_locate.go) after the lock is released, so a concurrent rebind could
+	// still steer it onto the newest-conversation fallback. Checking the resolved
+	// path makes the guarantee structural instead of dependent on timing.
+	if !transcriptBelongsToSession(path, sessionID) {
 		return cached
 	}
 

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -115,6 +115,17 @@ const usageLimitMaxLineBytes = 1 << 20 // 1 MiB
 type usageLimitScanRead struct {
 	Kind       string
 	Start, End int64
+	// Bytes is how many bytes this event actually moved into memory: End-Start for
+	// "chunk" and "line", and 0 for "line-skipped" since the whole point of the skip
+	// is that nothing was read.
+	//
+	// Reporting WORK rather than only ranges is what lets a test see a walker that
+	// re-copies the same line once per chunk. Ranges cannot: a copy-heavy
+	// implementation can produce byte-identical chunk ranges, and one that never
+	// reads candidate lines at all emits no line events, so a bound on line bytes
+	// is vacuously satisfied. A test must therefore assert the premise that line
+	// work was observed at all.
+	Bytes int64
 }
 
 // usageLimitScanObserver is a TEST SEAM: when non-nil it receives every read the
@@ -225,7 +236,7 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 		}
 		if end-start > usageLimitMaxLineBytes {
 			if usageLimitScanObserver != nil {
-				usageLimitScanObserver(usageLimitScanRead{Kind: "line-skipped", Start: start, End: end})
+				usageLimitScanObserver(usageLimitScanRead{Kind: "line-skipped", Start: start, End: end, Bytes: 0})
 			}
 			// A line this large is a compaction/file-history snapshot, not a turn
 			// this detector can act on. Skipped WITHOUT reading it: the whole point
@@ -233,7 +244,7 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 			return false, false, false
 		}
 		if usageLimitScanObserver != nil {
-			usageLimitScanObserver(usageLimitScanRead{Kind: "line", Start: start, End: end})
+			usageLimitScanObserver(usageLimitScanRead{Kind: "line", Start: start, End: end, Bytes: end - start})
 		}
 		line := make([]byte, end-start)
 		if _, err := f.ReadAt(line, start); err != nil && err != io.EOF {
@@ -264,7 +275,7 @@ func latestAssistantTurnIsRateLimited(path string, now time.Time) (limited bool,
 		}
 		n := end - start
 		if usageLimitScanObserver != nil {
-			usageLimitScanObserver(usageLimitScanRead{Kind: "chunk", Start: start, End: end})
+			usageLimitScanObserver(usageLimitScanRead{Kind: "chunk", Start: start, End: end, Bytes: end - start})
 		}
 		if _, err := f.ReadAt(buf[:n], start); err != nil && err != io.EOF {
 			return false, false
@@ -299,21 +310,40 @@ func usageLimitPublishable(currentGen, scanGen uint64, liveSessionID, scanSessio
 	return currentGen == scanGen && liveSessionID == scanSessionID
 }
 
-// usageLimitVerdictFor reads the memo under the lock, but only if the memo was
-// formed for sessionID.
+// usageLimitVerdictFor reads the memo under the lock, and only when all three
+// identities agree: the LIVE ClaudeSessionID, the memo key, and the session this
+// scan was gated on.
 //
-// Two separate mistakes led here and both are worth naming. First, returning the
-// snapshot taken at claim time let a slow scan report a value a newer scan had
-// already superseded, so callers observed completion order inverted. Second — and
-// worse — reading the memo unconditionally was identity-blind: guarding only the
-// WRITE stopped scan A publishing after an A→B rebind but still handed A's verdict
-// back for B, because the memo key only moves when a mismatch is observed at claim
-// time. A mismatch here means "no verdict for this session", not "not limited by
-// inheritance".
-func (i *Instance) usageLimitVerdictFor(sessionID string) bool {
+// ONE invariant, stated once, because getting it partially right produced the same
+// class of bug three revisions running:
+//
+//	live == memoKey == scanID  →  the memo describes this caller's session
+//
+// Any pair alone is insufficient, and both failures were found in review rather
+// than by me:
+//
+//   - scanID vs memoKey passes during an A→B rebind — both still read "A", since
+//     the key only moves when a mismatch is observed at claim time — and hands A's
+//     verdict to B.
+//   - scanID vs live passes in an A→B→A sequence while the memo still holds B's
+//     verdict, because transcript I/O runs outside i.mu and B can claim and publish
+//     in between.
+//
+// A mismatch on any leg means "no verdict for this caller", never "not limited".
+func (i *Instance) usageLimitVerdictFor(scanSessionID string) bool {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	if i.usageLimitSessionID != sessionID {
+	return i.usageLimitVerdictForLocked(scanSessionID)
+}
+
+// usageLimitVerdictForLocked is usageLimitVerdictFor for callers already holding
+// i.mu, so the publish path can apply the identical invariant instead of an
+// open-coded approximation of it.
+func (i *Instance) usageLimitVerdictForLocked(scanSessionID string) bool {
+	if strings.TrimSpace(i.ClaudeSessionID) != scanSessionID {
+		return false
+	}
+	if i.usageLimitSessionID != scanSessionID {
 		return false
 	}
 	return i.usageLimitedCached
@@ -426,9 +456,12 @@ func (i *Instance) usageLimited() bool {
 	case usageLimitPublishable(i.usageLimitScanGen, gen, live, sessionID):
 		i.usageLimitedCached = limited
 	default:
-		// A newer claim for the SAME session landed while this read was in flight,
-		// so this result is stale — report what the memo now holds.
-		limited = i.usageLimitedCached
+		// A newer claim for the same live session landed while this read was in
+		// flight, so this result is stale. Report the memo through the SAME
+		// three-way invariant: reading usageLimitedCached directly here was
+		// identity-blind under A→B→A, where live and scan both read "A" while the
+		// memo holds B's verdict.
+		limited = i.usageLimitVerdictForLocked(sessionID)
 	}
 	i.mu.Unlock()
 

--- a/internal/session/usagelimit.go
+++ b/internal/session/usagelimit.go
@@ -1,0 +1,230 @@
+package session
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// Usage-limit detection (#1802).
+//
+// A Claude session whose plan usage window is exhausted is healthy in every way
+// agent-deck observes from the outside: the pane is alive, the composer accepts
+// input, and every send is typed AND submitted. What fails is one layer further
+// in — the API rejects the turn and it completes in zero seconds. Field evidence
+// (2026-07-30): nine periodic sends were delivered and bounced this way over
+// 4h24m. Each `session send` exited 0 — correctly, delivery genuinely succeeded
+// — the systemd unit logged success every time, and the coarse status stayed
+// "idle", which is exactly the state periodic senders require in order to keep
+// sending. Nothing in the stack reported a problem.
+//
+// The signal is taken from Claude's own transcript rather than from pane text.
+// That is a deliberate choice, and the reason is worth recording because the
+// pane looks like the obvious source: the rejection renders behind the "⎿"
+// tool-result connector, wraps across visual lines on a narrow pane (agent-deck
+// captures with `-p -e` and no `-J`, so soft wraps arrive as real newlines), and
+// shares its vocabulary with ordinary output — a session running `grep` over
+// this repository would print the same words. Every one of those defeats a text
+// scanner. The transcript instead carries structured fields:
+//
+//	{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,
+//	 "error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z", ...}
+//
+// So the verdict keys off `apiErrorStatus` / `error`, not off prose. Nothing
+// here needs to know how Claude words the banner, or how wide the pane is.
+
+// usageLimitRateLimitStatus is the HTTP status Claude records on a quota
+// rejection. Paired with the `error` discriminator below rather than trusted
+// alone, since 429 is a general rate-limit code.
+const usageLimitRateLimitStatus = 429
+
+// usageLimitErrorKind is the `error` discriminator Claude writes alongside a
+// quota rejection ("rate_limit"). Distinct from a credential failure, which
+// carries its own status (401) and kind — the two need opposite responses:
+// re-authenticating cannot help a quota window, and waiting cannot help an
+// expired token.
+const usageLimitErrorKind = "rate_limit"
+
+// usageLimitScanInterval throttles the transcript read. Substate is computed per
+// session per status poll, so an unbounded read would put file I/O on a path
+// that runs for every session in a fleet. The condition it detects lasts hours,
+// so a few seconds of staleness costs nothing.
+const usageLimitScanInterval = 5 * time.Second
+
+// usageLimitTranscriptTailBytes bounds how much of the transcript is read.
+// Transcripts reach tens of megabytes (a 62 MB one was in the field evidence),
+// and only the most recent turn matters, so read a tail rather than the file.
+// Large enough to contain several records even when one carries a file-history
+// snapshot.
+const usageLimitTranscriptTailBytes = 512 * 1024
+
+// transcriptRecord is the subset of a transcript line this detector reads.
+type transcriptRecord struct {
+	Type              string `json:"type"`
+	IsSidechain       bool   `json:"isSidechain"`
+	IsAPIErrorMessage bool   `json:"isApiErrorMessage"`
+	APIErrorStatus    int    `json:"apiErrorStatus"`
+	Error             string `json:"error"`
+	Timestamp         string `json:"timestamp"`
+	Message           struct {
+		Role    string `json:"role"`
+		Content any    `json:"content"`
+	} `json:"message"`
+}
+
+// isRateLimitRejection reports whether this record is a quota rejection.
+//
+// Requires the api-error flag AND one of the two structured discriminators. The
+// flag alone is not enough (a 401 or an overloaded-model error also sets it),
+// and matching the rendered text is exactly what this detector exists to avoid.
+func (r transcriptRecord) isRateLimitRejection() bool {
+	if !r.IsAPIErrorMessage {
+		return false
+	}
+	return r.APIErrorStatus == usageLimitRateLimitStatus ||
+		strings.EqualFold(strings.TrimSpace(r.Error), usageLimitErrorKind)
+}
+
+// isAssistantTurn reports whether this record is a main-conversation assistant
+// turn. Sidechain records are subagent traffic, not the session's own turn, so a
+// subagent hitting a limit must not classify its parent.
+func (r transcriptRecord) isAssistantTurn() bool {
+	if r.IsSidechain {
+		return false
+	}
+	role := strings.TrimSpace(r.Message.Role)
+	if role == "" {
+		role = strings.TrimSpace(r.Type)
+	}
+	return role == "assistant"
+}
+
+// latestAssistantTurnIsRateLimited reports whether the MOST RECENT assistant
+// turn in the transcript at path is a quota rejection, plus whether a verdict
+// could be formed at all.
+//
+// "Most recent assistant turn" is the whole expiry story, and it is why this
+// shape was chosen over parsing the advertised reset time ("resets 8:50pm
+// (UTC)"). A reset timestamp would need 12-hour parsing, a timezone, and
+// day-rollover handling, and would still be a promise rather than an
+// observation. Whereas the moment the session completes any real turn, the
+// latest assistant record is no longer an error and the verdict clears itself.
+// Nothing has to expire it, and it cannot get stuck.
+//
+// ok is false when no assistant turn was found in the tail (a brand-new session,
+// or a tail entirely consumed by one oversized record). Callers must treat that
+// as "unknown", never as "fine" — silence is what this whole detector exists to
+// stop being mistaken for health.
+func latestAssistantTurnIsRateLimited(path string) (limited bool, ok bool) {
+	lines, err := readTranscriptTailLines(path, usageLimitTranscriptTailBytes)
+	if err != nil {
+		return false, false
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		var rec transcriptRecord
+		if err := json.Unmarshal([]byte(lines[i]), &rec); err != nil {
+			continue
+		}
+		if !rec.isAssistantTurn() {
+			continue
+		}
+		return rec.isRateLimitRejection(), true
+	}
+	return false, false
+}
+
+// readTranscriptTailLines returns the complete JSONL lines in the last tailBytes
+// of path.
+//
+// The first line of a mid-file read is dropped: a byte offset lands wherever it
+// lands, so that line is a fragment and would fail to parse anyway — dropping it
+// explicitly keeps the intent legible.
+func readTranscriptTailLines(path string, tailBytes int64) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	offset := int64(0)
+	truncated := false
+	if info.Size() > tailBytes {
+		offset = info.Size() - tailBytes
+		truncated = true
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if truncated && len(lines) > 0 {
+		lines = lines[1:]
+	}
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, l)
+		}
+	}
+	return out, nil
+}
+
+// usageLimited reports whether this instance's latest assistant turn was a quota
+// rejection, throttled to usageLimitScanInterval and mirrored in memory so the
+// render path can read it without touching the filesystem.
+//
+// Claude-compatible tools only: the transcript shape is Claude's.
+func (i *Instance) usageLimited() bool {
+	if !IsClaudeCompatible(i.Tool) {
+		return false
+	}
+
+	i.mu.RLock()
+	last := i.lastUsageLimitScanAt
+	cached := i.usageLimitedCached
+	i.mu.RUnlock()
+
+	if !last.IsZero() && time.Since(last) < usageLimitScanInterval {
+		return cached
+	}
+
+	path := locateHandoffTranscript(i)
+	if path == "" {
+		return cached
+	}
+
+	limited, ok := latestAssistantTurnIsRateLimited(path)
+
+	i.mu.Lock()
+	i.lastUsageLimitScanAt = time.Now()
+	if ok {
+		// Only a formed verdict updates the mirror. An unreadable or
+		// assistant-less tail leaves the previous answer standing rather than
+		// silently reporting "not limited".
+		i.usageLimitedCached = limited
+	}
+	cached = i.usageLimitedCached
+	i.mu.Unlock()
+
+	return cached
+}
+
+// UsageLimitedCached reports the last computed verdict without any filesystem
+// access, for the TUI render hot path.
+func (i *Instance) UsageLimitedCached() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.usageLimitedCached
+}

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -57,15 +57,6 @@ func writeUsageLimitTranscript(t *testing.T, records ...string) string {
 	return path
 }
 
-// withTailSteps runs fn with a pinned escalation ladder, so a test can assert
-// what a single window can and cannot decide.
-func withTailSteps(steps []int64, fn func()) {
-	saved := usageLimitTailSteps
-	usageLimitTailSteps = steps
-	defer func() { usageLimitTailSteps = saved }()
-	fn()
-}
-
 func TestLatestAssistantTurnIsRateLimited(t *testing.T) {
 	recent := stampAt(-time.Minute)
 
@@ -187,22 +178,31 @@ func TestLatestAssistantTurnIsRateLimited_RecoversAfterTailEviction(t *testing.T
 	if _, err := f.WriteString(recRateLimitAt(stampAt(-time.Minute)) + "\n"); err != nil {
 		t.Fatalf("write rejection: %v", err)
 	}
-	// Bury it under more than one tail step of user records. No assistant turn
-	// among them, so the first step can form no verdict.
+	// Bury it under more than the first window of user records. No assistant turn
+	// among them, so that window alone can form no verdict.
 	filler := recUserAt(stampAt(-time.Minute))
-	for written := int64(0); written < usageLimitTailSteps[0]+64*1024; written += int64(len(filler)) + 1 {
+	for written := int64(0); written < usageLimitFirstTailBytes+64*1024; written += int64(len(filler)) + 1 {
 		if _, err := f.WriteString(filler + "\n"); err != nil {
 			t.Fatalf("write filler: %v", err)
 		}
 	}
 	_ = f.Close()
 
-	// Premise: one window alone must be unable to answer.
-	withTailSteps(usageLimitTailSteps[:1], func() {
-		if _, ok := latestAssistantTurnIsRateLimited(path, refNow); ok {
-			t.Fatal("premise broken: a single tail step formed a verdict, so eviction is not exercised")
+	// Premise, asserted rather than assumed: the first window really does not
+	// contain the decisive record, so this exercises escalation and not a
+	// single-read path that happens to work.
+	lines, complete, err := readTranscriptTailLines(path, usageLimitFirstTailBytes)
+	if err != nil {
+		t.Fatalf("premise read: %v", err)
+	}
+	if complete {
+		t.Fatal("premise broken: the first window covered the whole file")
+	}
+	for _, l := range lines {
+		if strings.Contains(l, `"rate_limit"`) {
+			t.Fatal("premise broken: the rejection is inside the first window, so eviction is not exercised")
 		}
-	})
+	}
 
 	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
 	if !limited || !ok {
@@ -348,6 +348,10 @@ func TestSubstate_ReportsUsageLimitWhenLimited(t *testing.T) {
 	inst.mu.Lock()
 	inst.lastUsageLimitScanAt = time.Now()
 	inst.usageLimitedCached = true
+	// The memo is keyed by the id it was formed for, so seed that too — without
+	// it the identity check correctly discards the verdict as belonging to some
+	// other session. (This test caught exactly that when the keying landed.)
+	inst.usageLimitSessionID = inst.ClaudeSessionID
 	inst.mu.Unlock()
 
 	if got := inst.Substate(); got != SubstateUsageLimit {
@@ -411,5 +415,65 @@ func TestTranscriptBelongsToSession(t *testing.T) {
 				t.Fatalf("transcriptBelongsToSession(%q, %q) = %v, want %v", tt.path, tt.sessionID, got, tt.want)
 			}
 		})
+	}
+}
+
+// #1806 cycle-3 review: the memo had no session identity, so an Instance rebound
+// from session A to session B returned A's verdict for B — indefinitely when B
+// never forms one of its own. The memo is now keyed by the id it was formed for.
+func TestUsageLimited_RebindDoesNotInheritVerdict(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-rebind", t.TempDir(), "claude")
+	inst.ClaudeSessionID = "session-A"
+
+	// Seed a live verdict for A, exactly as a completed scan would.
+	inst.mu.Lock()
+	inst.usageLimitSessionID = "session-A"
+	inst.usageLimitedCached = true
+	inst.lastUsageLimitScanAt = time.Now()
+	inst.mu.Unlock()
+
+	if !inst.usageLimited() {
+		t.Fatal("premise broken: A's own verdict should be returned for A")
+	}
+
+	// Normal rebind onto the same Instance.
+	inst.ClaudeSessionID = "session-B"
+
+	if inst.usageLimited() {
+		t.Fatal("B inherited A's usage-limit verdict")
+	}
+
+	inst.mu.RLock()
+	gotID, gotCached := inst.usageLimitSessionID, inst.usageLimitedCached
+	inst.mu.RUnlock()
+	if gotID != "session-B" {
+		t.Fatalf("memo identity = %q after rebind, want %q", gotID, "session-B")
+	}
+	if gotCached {
+		t.Fatal("stale verdict survived the rebind")
+	}
+}
+
+// The rebind must also drop the throttle claim, otherwise B would be answered
+// from A's window instead of being scanned.
+func TestUsageLimited_RebindClearsThrottleClaim(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-rebind-throttle", t.TempDir(), "claude")
+	inst.ClaudeSessionID = "session-A"
+
+	inst.mu.Lock()
+	inst.usageLimitSessionID = "session-A"
+	inst.usageLimitedCached = true
+	claimed := time.Now()
+	inst.lastUsageLimitScanAt = claimed
+	inst.mu.Unlock()
+
+	inst.ClaudeSessionID = "session-B"
+	_ = inst.usageLimited()
+
+	inst.mu.RLock()
+	stamped := inst.lastUsageLimitScanAt
+	inst.mu.RUnlock()
+	if stamped.Equal(claimed) {
+		t.Fatal("rebind kept A's throttle claim, so B is answered from A's window")
 	}
 }

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -213,7 +214,7 @@ func TestLatestAssistantTurnIsRateLimited_ReadsEachByteOnce(t *testing.T) {
 
 	var chunkBytes, lineBytes int64
 	prevStart := info.Size()
-	chunks := 0
+	chunks, lineEvents := 0, 0
 	for n, r := range reads {
 		switch r.Kind {
 		case "chunk":
@@ -225,11 +226,21 @@ func TestLatestAssistantTurnIsRateLimited_ReadsEachByteOnce(t *testing.T) {
 			if r.End-r.Start > usageLimitScanChunkBytes {
 				t.Fatalf("chunk read %d spans %d bytes, over the %d-byte bound", n, r.End-r.Start, usageLimitScanChunkBytes)
 			}
-			chunkBytes += r.End - r.Start
+			chunkBytes += r.Bytes
 			prevStart = r.Start
 		case "line":
-			lineBytes += r.End - r.Start
+			lineEvents++
+			lineBytes += r.Bytes
 		}
+	}
+
+	// PREMISE FIRST. #1806 cycle-7 caught that without this the bound below is
+	// vacuous: a walker that never reads candidate lines emits no line events, so
+	// lineBytes stays 0 and "0 > size" is trivially false. The bound only means
+	// something once line work is known to have been observed at all.
+	if lineEvents == 0 || lineBytes == 0 {
+		t.Fatalf("no candidate-line work observed (%d events, %d bytes); the bound below would be vacuous",
+			lineEvents, lineBytes)
 	}
 	if chunks < 100 {
 		t.Fatalf("only %d chunk reads for a %d-byte file at %d-byte chunks", chunks, info.Size(), usageLimitScanChunkBytes)
@@ -308,9 +319,44 @@ func TestLatestAssistantTurnIsRateLimited_DoesNotAllocateForEmptyTranscript(t *t
 		t.Fatalf("empty transcript performed %d reads, want 0", reads)
 	}
 
-	allocs := testing.AllocsPerRun(20, func() { _, _ = latestAssistantTurnIsRateLimited(empty, refNow) })
-	if allocs > 8 {
-		t.Fatalf("empty transcript allocated %.0f times per scan; a chunk buffer is being allocated before the size check", allocs)
+	// Measured in BYTES, not allocation events. #1806 cycle-7: AllocsPerRun counts
+	// events, so the old always-full 512 KiB buffer was a single event and slipped
+	// under any count threshold. Bytes are the quantity that actually differs.
+	bytesPerScan := func(path string) int64 {
+		const runs = 50
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		for n := 0; n < runs; n++ {
+			_, _ = latestAssistantTurnIsRateLimited(path, refNow)
+		}
+		runtime.ReadMemStats(&after)
+		return int64(after.TotalAlloc-before.TotalAlloc) / runs
+	}
+
+	if usageLimitScanChunkBytes != defaultUsageLimitScanChunkBytes {
+		t.Fatalf("chunk knob is %d, but the bounds below are written against the %d default",
+			usageLimitScanChunkBytes, defaultUsageLimitScanChunkBytes)
+	}
+
+	// A full chunk buffer lands near 512 KiB here; the early return lands near zero.
+	if got := bytesPerScan(empty); got > 16*1024 {
+		t.Fatalf("empty transcript allocated ~%d bytes per scan; a chunk buffer is being allocated before the size check", got)
+	}
+
+	// A tiny NON-EMPTY file too: min(chunk, size) can regress independently of the
+	// empty-file early return, which the earlier version of this test never covered.
+	tiny := filepath.Join(dir, "tiny.jsonl")
+	if err := os.WriteFile(tiny, []byte(recUserAt(stampAt(-time.Minute))+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tinyInfo, err := os.Stat(tiny)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := bytesPerScan(tiny); got > 64*1024 {
+		t.Fatalf("a %d-byte transcript allocated ~%d bytes per scan; the buffer is not sized to min(chunk, size)",
+			tinyInfo.Size(), got)
 	}
 }
 
@@ -708,5 +754,111 @@ func TestUsageLimited_RebindDuringScanDoesNotReturnOldVerdict(t *testing.T) {
 	}
 	if got {
 		t.Fatal("returned A's verdict for an Instance rebound to B mid-scan")
+	}
+}
+
+// #1806 cycle-7 [High] #1: the helper exits (path-empty, ownership-mismatch,
+// no-verdict) read the memo without consulting the LIVE id, so an A→B rebind let B
+// receive A's verdict. The existing in-flight test cannot reach these exits — its
+// fixture forms a verdict (ok=true) and lands in the final switch — so this one uses
+// a transcript that yields NO verdict and therefore takes the no-verdict exit.
+func TestUsageLimited_HelperExitDoesNotLeakVerdictAcrossRebind(t *testing.T) {
+	const sidA = "helper-exit-A"
+	project := t.TempDir()
+	inst := NewInstanceWithTool("usage-limit-helper-exit", project, "claude")
+	inst.ClaudeSessionID = sidA
+
+	dir := filepath.Join(GetClaudeConfigDirForInstance(inst), "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A user record only: scanned, forms no verdict, so the no-verdict exit runs.
+	if err := os.WriteFile(filepath.Join(dir, sidA+".jsonl"),
+		[]byte(recUserAt(stampAt(-time.Minute))+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if locateHandoffTranscript(inst) == "" {
+		t.Skip("resolver did not find the fixture; environment-dependent")
+	}
+
+	inst.mu.Lock()
+	inst.usageLimitSessionID = sidA
+	inst.usageLimitedCached = true // A is limited
+	inst.lastUsageLimitScanAt = time.Time{}
+	inst.mu.Unlock()
+
+	rebound := false
+	usageLimitScanObserver = func(usageLimitScanRead) {
+		if rebound {
+			return
+		}
+		rebound = true
+		inst.mu.Lock()
+		inst.ClaudeSessionID = "helper-exit-B"
+		inst.mu.Unlock()
+	}
+	defer func() { usageLimitScanObserver = nil }()
+
+	got := inst.usageLimited()
+	if !rebound {
+		t.Fatal("premise broken: no read happened, so no rebind was injected mid-scan")
+	}
+	if got {
+		t.Fatal("the no-verdict exit returned A's verdict for an Instance rebound to B")
+	}
+}
+
+// #1806 cycle-7 [High] #2: the generation-mismatch default read the memo without
+// checking the memo KEY, so in an A→B→A sequence — B claims and publishes while A is
+// still in I/O, then live returns to A — scan A returned B's verdict. Reproduced by
+// simulating B's claim and publication from inside the scan.
+func TestUsageLimited_GenerationMismatchDoesNotLeakOtherSessionVerdict(t *testing.T) {
+	const sidA = "gen-mismatch-A"
+	project := t.TempDir()
+	inst := NewInstanceWithTool("usage-limit-gen-mismatch", project, "claude")
+	inst.ClaudeSessionID = sidA
+
+	dir := filepath.Join(GetClaudeConfigDirForInstance(inst), "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A fresh rejection, so this scan forms a verdict and reaches the final switch.
+	if err := os.WriteFile(filepath.Join(dir, sidA+".jsonl"),
+		[]byte(recRateLimitAt(stampAt(-time.Minute))+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if locateHandoffTranscript(inst) == "" {
+		t.Skip("resolver did not find the fixture; environment-dependent")
+	}
+
+	injected := false
+	usageLimitScanObserver = func(usageLimitScanRead) {
+		if injected {
+			return
+		}
+		injected = true
+		// While scan A is in flight: B claims (generation moves) and publishes its
+		// own verdict. live then returns to A before A finishes.
+		inst.mu.Lock()
+		inst.usageLimitScanGen++
+		inst.usageLimitSessionID = "gen-mismatch-B"
+		inst.usageLimitedCached = true
+		inst.ClaudeSessionID = sidA
+		inst.mu.Unlock()
+	}
+	defer func() { usageLimitScanObserver = nil }()
+
+	got := inst.usageLimited()
+	if !injected {
+		t.Fatal("premise broken: no read happened, so no interleaving was injected")
+	}
+	inst.mu.RLock()
+	key := inst.usageLimitSessionID
+	inst.mu.RUnlock()
+	if key != "gen-mismatch-B" {
+		t.Fatalf("premise broken: memo key is %q, so the generation-mismatch path was not exercised", key)
+	}
+	if got {
+		t.Fatal("the generation-mismatch default returned another session's verdict")
 	}
 }

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -334,3 +334,31 @@ func TestUsageLimited_ConcurrentCallersAgree(t *testing.T) {
 		t.Fatal("no scan was stamped despite concurrent callers")
 	}
 }
+
+// Pins the Substate wiring itself, deterministically and without touching the
+// filesystem: seeding the throttle window makes usageLimited short-circuit on the
+// memo, so this asserts the precedence branch rather than the detector.
+//
+// Without this, removing the branch from Substate would break no test — the rest
+// of this file exercises usageLimited and the transcript walk, not the wiring.
+func TestSubstate_ReportsUsageLimitWhenLimited(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-substate", t.TempDir(), "claude")
+	inst.ClaudeSessionID = "bound-session-id"
+
+	inst.mu.Lock()
+	inst.lastUsageLimitScanAt = time.Now()
+	inst.usageLimitedCached = true
+	inst.mu.Unlock()
+
+	if got := inst.Substate(); got != SubstateUsageLimit {
+		t.Fatalf("Substate() = %q with a live usage-limit verdict, want %q", got, SubstateUsageLimit)
+	}
+
+	inst.mu.Lock()
+	inst.usageLimitedCached = false
+	inst.mu.Unlock()
+
+	if got := inst.Substate(); got == SubstateUsageLimit {
+		t.Fatalf("Substate() = %q with no verdict, want anything else", got)
+	}
+}

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -5,33 +5,70 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
-// Records shaped exactly like the field evidence that motivated #1802. The
-// quota rejection carries apiErrorStatus 429 and error "rate_limit"; a
-// credential failure carries 401; a normal turn carries neither.
-const (
-	recRateLimit = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit · resets 8:50pm (UTC)"}]}}`
-	recAuth401   = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":401,"error":"authentication_error","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"Invalid API key · Please run /login"}]}}`
-	recOverload  = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":529,"error":"overloaded_error","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"API Error: 529 overloaded"}]}}`
-	recNormal    = `{"type":"assistant","isApiErrorMessage":false,"timestamp":"2026-07-30T21:06:27.000Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"All clear."}]}}`
-	recUser      = `{"type":"user","timestamp":"2026-07-30T21:05:44.669Z","isSidechain":false,"message":{"role":"user","content":"[HEARTBEAT] Check sessions in your group"}}`
-	// A subagent hitting its own limit must not classify the parent session.
-	recSidechainRateLimit = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit · resets 8:50pm (UTC)"}]}}`
-)
+// refNow is the fixed clock these tests reason against, so freshness assertions
+// do not depend on wall time.
+var refNow = time.Date(2026, 7, 30, 21, 0, 0, 0, time.UTC)
+
+func stampAt(offset time.Duration) string {
+	return refNow.Add(offset).UTC().Format(time.RFC3339Nano)
+}
+
+// Records shaped exactly like the field evidence that motivated #1802: the quota
+// rejection carries apiErrorStatus 429 AND error "rate_limit" together.
+func recRateLimitAt(ts string) string {
+	return fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":%q,"isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit · resets 8:50pm (UTC)"}]}}`, ts)
+}
+
+func recAssistantAt(ts, text string) string {
+	return fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":false,"timestamp":%q,"isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`, ts, text)
+}
+
+func recUserAt(ts string) string {
+	return fmt.Sprintf(`{"type":"user","timestamp":%q,"isSidechain":false,"message":{"role":"user","content":"[HEARTBEAT] Check sessions in your group"}}`, ts)
+}
+
+func recAPIErrorAt(ts string, status int, kind string) string {
+	return fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":%d,"error":%q,"timestamp":%q,"isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"api error"}]}}`, status, kind, ts)
+}
+
+func recRateLimitNoStatusAt(ts string) string {
+	return fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":true,"error":"rate_limit","timestamp":%q,"isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"rate limited"}]}}`, ts)
+}
+
+func recRateLimitNoTimestamp() string {
+	return `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit"}]}}`
+}
+
+func recSidechainRateLimitAt(ts string) string {
+	return fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":%q,"isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit"}]}}`, ts)
+}
 
 func writeUsageLimitTranscript(t *testing.T, records ...string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "transcript.jsonl")
-	body := strings.Join(records, "\n") + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(strings.Join(records, "\n")+"\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}
 	return path
 }
 
+// withTailSteps runs fn with a pinned escalation ladder, so a test can assert
+// what a single window can and cannot decide.
+func withTailSteps(steps []int64, fn func()) {
+	saved := usageLimitTailSteps
+	usageLimitTailSteps = steps
+	defer func() { usageLimitTailSteps = saved }()
+	fn()
+}
+
 func TestLatestAssistantTurnIsRateLimited(t *testing.T) {
+	recent := stampAt(-time.Minute)
+
 	tests := []struct {
 		name        string
 		records     []string
@@ -39,52 +76,81 @@ func TestLatestAssistantTurnIsRateLimited(t *testing.T) {
 		wantOK      bool
 	}{
 		{
-			name:        "quota rejection is the latest assistant turn",
-			records:     []string{recUser, recRateLimit},
+			name:        "recent quota rejection is the latest assistant turn",
+			records:     []string{recUserAt(recent), recRateLimitAt(recent)},
 			wantLimited: true,
 			wantOK:      true,
 		},
 		{
-			name: "a later successful turn clears it without any expiry logic",
-			// This is the whole reason the verdict is "latest turn" rather than a
-			// parsed reset time: recovery needs no clock.
-			records:     []string{recRateLimit, recUser, recNormal},
+			name:        "a later successful turn clears it with no expiry logic",
+			records:     []string{recRateLimitAt(recent), recUserAt(recent), recAssistantAt(recent, "All clear.")},
 			wantLimited: false,
 			wantOK:      true,
 		},
 		{
 			name:        "later user message alone does not clear it",
-			records:     []string{recRateLimit, recUser},
+			records:     []string{recRateLimitAt(recent), recUserAt(recent)},
 			wantLimited: true,
 			wantOK:      true,
 		},
 		{
+			// #1806 review: the verdict must not outlive the window it describes,
+			// even when no further turn is ever submitted.
+			name:        "a rejection older than the window is no longer believed",
+			records:     []string{recUserAt(stampAt(-6 * time.Hour)), recRateLimitAt(stampAt(-6 * time.Hour))},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			name:        "a rejection with no timestamp is not treated as fresh",
+			records:     []string{recUserAt(recent), recRateLimitNoTimestamp()},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
 			name:        "credential failure is a different condition",
-			records:     []string{recUser, recAuth401},
+			records:     []string{recUserAt(recent), recAPIErrorAt(recent, 401, "authentication_error")},
 			wantLimited: false,
 			wantOK:      true,
 		},
 		{
 			name:        "overloaded model is not a quota rejection",
-			records:     []string{recUser, recOverload},
+			records:     []string{recUserAt(recent), recAPIErrorAt(recent, 529, "overloaded_error")},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			// #1806 review: 429 and rate_limit are required together, so neither
+			// alone nor a mismatched pair may read as plan exhaustion.
+			name:        "429 with a different error kind is not plan exhaustion",
+			records:     []string{recUserAt(recent), recAPIErrorAt(recent, 429, "overloaded_error")},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			name:        "rate_limit kind without the 429 status does not match",
+			records:     []string{recUserAt(recent), recRateLimitNoStatusAt(recent)},
 			wantLimited: false,
 			wantOK:      true,
 		},
 		{
 			name:        "subagent sidechain limit does not classify the parent",
-			records:     []string{recRateLimit, recNormal, recSidechainRateLimit},
+			records:     []string{recRateLimitAt(recent), recAssistantAt(recent, "done"), recSidechainRateLimitAt(recent)},
 			wantLimited: false,
 			wantOK:      true,
 		},
 		{
 			name:        "no assistant turn yet reports no verdict",
-			records:     []string{recUser},
+			records:     []string{recUserAt(recent)},
 			wantLimited: false,
 			wantOK:      false,
 		},
 		{
-			name:        "malformed lines are skipped, not fatal",
-			records:     []string{`{not json`, recUser, recRateLimit},
+			// The scan walks backwards, so a malformed line must sit AFTER the
+			// rejection to be visited at all — otherwise the case never exercises
+			// the skip it claims to.
+			name:        "a malformed line newer than the verdict is skipped, not fatal",
+			records:     []string{recUserAt(recent), recRateLimitAt(recent), `{not json`},
 			wantLimited: true,
 			wantOK:      true,
 		},
@@ -92,7 +158,7 @@ func TestLatestAssistantTurnIsRateLimited(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			limited, ok := latestAssistantTurnIsRateLimited(writeUsageLimitTranscript(t, tt.records...))
+			limited, ok := latestAssistantTurnIsRateLimited(writeUsageLimitTranscript(t, tt.records...), refNow)
 			if limited != tt.wantLimited || ok != tt.wantOK {
 				t.Fatalf("latestAssistantTurnIsRateLimited = (%v, %v), want (%v, %v)",
 					limited, ok, tt.wantLimited, tt.wantOK)
@@ -102,60 +168,78 @@ func TestLatestAssistantTurnIsRateLimited(t *testing.T) {
 }
 
 func TestLatestAssistantTurnIsRateLimited_MissingFile(t *testing.T) {
-	limited, ok := latestAssistantTurnIsRateLimited(filepath.Join(t.TempDir(), "absent.jsonl"))
+	limited, ok := latestAssistantTurnIsRateLimited(filepath.Join(t.TempDir(), "absent.jsonl"), refNow)
 	if limited || ok {
 		t.Fatalf("missing transcript = (%v, %v), want (false, false)", limited, ok)
 	}
 }
 
-// The tail read must find the newest turn in a transcript far larger than the
-// window — field transcripts reach tens of megabytes, and reading them whole on
-// a status poll is what the tail exists to avoid.
-func TestLatestAssistantTurnIsRateLimited_LargeTranscriptTail(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "big.jsonl")
+// #1806 review: a rejection pushed beyond the first tail window by later
+// non-assistant traffic must still be found. A long-lived process keeps its memo,
+// but a fresh CLI invocation starts with none and would otherwise report a
+// limited session as healthy.
+func TestLatestAssistantTurnIsRateLimited_RecoversAfterTailEviction(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "evicted.jsonl")
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	// Comfortably exceed usageLimitTranscriptTailBytes with filler turns.
-	filler := fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":false,"isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"%s"}]}}`, strings.Repeat("x", 512))
-	for written := 0; written < 2*usageLimitTranscriptTailBytes; written += len(filler) + 1 {
+	if _, err := f.WriteString(recRateLimitAt(stampAt(-time.Minute)) + "\n"); err != nil {
+		t.Fatalf("write rejection: %v", err)
+	}
+	// Bury it under more than one tail step of user records. No assistant turn
+	// among them, so the first step can form no verdict.
+	filler := recUserAt(stampAt(-time.Minute))
+	for written := int64(0); written < usageLimitTailSteps[0]+64*1024; written += int64(len(filler)) + 1 {
 		if _, err := f.WriteString(filler + "\n"); err != nil {
 			t.Fatalf("write filler: %v", err)
 		}
 	}
-	if _, err := f.WriteString(recRateLimit + "\n"); err != nil {
-		t.Fatalf("write tail record: %v", err)
-	}
 	_ = f.Close()
 
-	limited, ok := latestAssistantTurnIsRateLimited(path)
+	// Premise: one window alone must be unable to answer.
+	withTailSteps(usageLimitTailSteps[:1], func() {
+		if _, ok := latestAssistantTurnIsRateLimited(path, refNow); ok {
+			t.Fatal("premise broken: a single tail step formed a verdict, so eviction is not exercised")
+		}
+	})
+
+	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
 	if !limited || !ok {
-		t.Fatalf("large transcript = (%v, %v), want (true, true)", limited, ok)
+		t.Fatalf("after eviction = (%v, %v), want (true, true) via tail escalation", limited, ok)
 	}
 }
 
-// A tail that starts mid-record must not be parsed as a whole line.
+// A tail offset landing inside a record must drop that partial line and keep the
+// complete ones. Sized from the fixture rather than hardcoded, so the offset
+// really lands inside the filler line.
 func TestReadTranscriptTailLines_DropsPartialFirstLine(t *testing.T) {
+	rec := recRateLimitAt(stampAt(-time.Minute))
+	filler := strings.Repeat("A", 400)
 	path := filepath.Join(t.TempDir(), "t.jsonl")
-	body := strings.Repeat("A", 400) + "\n" + recRateLimit + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(filler+"\n"+rec+"\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	// Tail smaller than the file forces a mid-file offset.
-	lines, err := readTranscriptTailLines(path, 200)
+
+	// Covers the whole record plus part of the filler line above it.
+	lines, complete, err := readTranscriptTailLines(path, int64(len(rec)+100))
 	if err != nil {
 		t.Fatalf("readTranscriptTailLines: %v", err)
 	}
-	for _, l := range lines {
-		if strings.HasPrefix(l, "AAA") {
-			t.Fatalf("partial first line was kept: %q", l[:20])
-		}
+	if complete {
+		t.Fatal("premise broken: the read covered the whole file, so no partial line exists")
+	}
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want exactly the one complete record: %#v", len(lines), lines)
+	}
+	if lines[0] != rec {
+		t.Fatalf("kept line is not the intact record:\n got %q\nwant %q", lines[0], rec)
 	}
 }
 
 func TestUsageLimited_NonClaudeToolNeverScans(t *testing.T) {
 	inst := NewInstanceWithTool("usage-limit-codex", t.TempDir(), "codex")
+	inst.ClaudeSessionID = "abc123"
 	if inst.usageLimited() {
 		t.Fatal("usageLimited() = true for a codex session, want false")
 	}
@@ -164,7 +248,6 @@ func TestUsageLimited_NonClaudeToolNeverScans(t *testing.T) {
 	}
 }
 
-// Regression for the review findings on #1806.
 func TestUsageLimited_SkipsSSHInstances(t *testing.T) {
 	inst := NewInstanceWithTool("usage-limit-ssh", t.TempDir(), "claude")
 	inst.SSHHost = "devbox.example"
@@ -174,18 +257,30 @@ func TestUsageLimited_SkipsSSHInstances(t *testing.T) {
 		t.Fatal("usageLimited() = true for an SSH instance, want false")
 	}
 	if !inst.lastUsageLimitScanAt.IsZero() {
-		t.Fatal("SSH instance should bail before doing any path work or stamping a scan")
+		t.Fatal("SSH instance should bail before any path work or scan stamp")
 	}
 }
 
-// The throttle must cover the "path never resolves" exit too. Stamping only on
-// success left that case calling locateHandoffTranscript — user-config load plus
-// several stats — on every status poll, which is precisely the cost the throttle
-// exists to bound.
+// #1806 review: with an empty ClaudeSessionID the shared resolver deliberately
+// falls back to the NEWEST conversation for the project, so an unbound instance
+// would inherit a sibling session's rejection. It must not even look.
+func TestUsageLimited_RequiresBoundSessionID(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-unbound", t.TempDir(), "claude")
+	inst.ClaudeSessionID = ""
+
+	if inst.usageLimited() {
+		t.Fatal("usageLimited() = true for an unbound instance, want false")
+	}
+	if !inst.lastUsageLimitScanAt.IsZero() {
+		t.Fatal("an unbound instance should bail before resolving any transcript")
+	}
+}
+
+// The throttle must cover the "path never resolves" exit too: stamping only on
+// success left that case resolving a transcript on every status poll.
 func TestUsageLimited_ThrottlesWhenTranscriptUnresolvable(t *testing.T) {
 	inst := NewInstanceWithTool("usage-limit-unresolvable", t.TempDir(), "claude")
-	// No ClaudeSessionID: nothing to resolve a transcript from.
-	inst.ClaudeSessionID = ""
+	inst.ClaudeSessionID = "no-such-session-id"
 
 	if inst.usageLimited() {
 		t.Fatal("usageLimited() = true with no transcript, want false")
@@ -198,7 +293,6 @@ func TestUsageLimited_ThrottlesWhenTranscriptUnresolvable(t *testing.T) {
 		t.Fatal("scan attempt was not stamped, so the throttle never engages on this path")
 	}
 
-	// Second call inside the window must not re-stamp (i.e. it short-circuits).
 	inst.usageLimited()
 	inst.mu.RLock()
 	again := inst.lastUsageLimitScanAt
@@ -208,20 +302,35 @@ func TestUsageLimited_ThrottlesWhenTranscriptUnresolvable(t *testing.T) {
 	}
 }
 
-// The mirror is what CachedSubstate reads, so it must stay consistent with the
-// substate it drives and must not require filesystem access.
-func TestCachedSubstate_UsesUsageLimitMirror(t *testing.T) {
-	inst := NewInstanceWithTool("usage-limit-mirror", t.TempDir(), "claude")
+// #1806 review: the throttle check and stamp now share one critical section, so
+// concurrent callers cannot both claim the window. Run under -race for the
+// memory-safety half; this pins the observable contract — one stamp, one agreed
+// answer.
+func TestUsageLimited_ConcurrentCallersAgree(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-concurrent", t.TempDir(), "claude")
+	inst.ClaudeSessionID = "no-such-session-id"
 
-	if got := inst.CachedSubstate(); got == SubstateUsageLimit {
-		t.Fatalf("CachedSubstate = %q before any scan, want anything else", got)
+	const callers = 16
+	var wg sync.WaitGroup
+	results := make([]bool, callers)
+	wg.Add(callers)
+	for n := 0; n < callers; n++ {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = inst.usageLimited()
+		}(n)
 	}
+	wg.Wait()
 
-	inst.mu.Lock()
-	inst.usageLimitedCached = true
-	inst.mu.Unlock()
-
-	if got := inst.CachedSubstate(); got != SubstateUsageLimit {
-		t.Fatalf("CachedSubstate = %q with the mirror set, want %q", got, SubstateUsageLimit)
+	for idx, got := range results {
+		if got != results[0] {
+			t.Fatalf("caller %d disagreed: %v vs %v", idx, got, results[0])
+		}
+	}
+	inst.mu.RLock()
+	stamped := inst.lastUsageLimitScanAt
+	inst.mu.RUnlock()
+	if stamped.IsZero() {
+		t.Fatal("no scan was stamped despite concurrent callers")
 	}
 }

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -169,15 +169,15 @@ func TestLatestAssistantTurnIsRateLimited_MissingFile(t *testing.T) {
 // non-assistant traffic must still be found. A long-lived process keeps its memo,
 // but a fresh CLI invocation starts with none and would otherwise report a
 // limited session as healthy.
-// #1806 cycle-4 audit: the previous version of this test buried the record by only
-// ~576 KiB, which the old 8 MiB step would also have found — so it passed before
-// and after and guarded nothing. Shrinking the chunk lets the walk cross MANY
-// boundaries at a trivial file size, which is the property that actually
-// distinguishes an uncapped backward walk from any fixed ladder.
-func TestLatestAssistantTurnIsRateLimited_WalksBackAcrossManyChunks(t *testing.T) {
-	saved := usageLimitScanChunkBytes
+// #1806 cycle-5 audit: the previous version proved only fixture depth — it asserted
+// the answer came out right, which an overlapping or whole-file reader also
+// achieves. What the change actually claims is *non-overlapping, bounded* I/O that
+// still reaches byte 0, so that is what this asserts, using the scan's observer
+// seam to record every byte range read.
+func TestLatestAssistantTurnIsRateLimited_ReadsBoundedNonOverlappingChunks(t *testing.T) {
+	savedChunk := usageLimitScanChunkBytes
 	usageLimitScanChunkBytes = 1024
-	defer func() { usageLimitScanChunkBytes = saved }()
+	defer func() { usageLimitScanChunkBytes = savedChunk }()
 
 	path := filepath.Join(t.TempDir(), "deep.jsonl")
 	f, err := os.Create(path)
@@ -187,9 +187,6 @@ func TestLatestAssistantTurnIsRateLimited_WalksBackAcrossManyChunks(t *testing.T
 	if _, err := f.WriteString(recRateLimitAt(stampAt(-time.Minute)) + "\n"); err != nil {
 		t.Fatalf("write rejection: %v", err)
 	}
-	// Bury it far beyond what a three-step ladder of this chunk size could reach
-	// (1 KiB + 8 KiB + 64 KiB ≈ 73 KiB): ~200 KiB of user records, no assistant
-	// turn among them.
 	filler := recUserAt(stampAt(-time.Minute))
 	var buried int64
 	for buried < 200*1024 {
@@ -201,18 +198,48 @@ func TestLatestAssistantTurnIsRateLimited_WalksBackAcrossManyChunks(t *testing.T
 	}
 	_ = f.Close()
 
-	info, err := os.Stat(path)
+	size, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	chunks := info.Size() / usageLimitScanChunkBytes
-	if chunks < 100 {
-		t.Fatalf("premise broken: only %d chunks, want a deep walk", chunks)
-	}
+
+	type rng struct{ start, end int64 }
+	var reads []rng
+	usageLimitScanObserver = func(start, end int64) { reads = append(reads, rng{start, end}) }
+	defer func() { usageLimitScanObserver = nil }()
 
 	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
 	if !limited || !ok {
-		t.Fatalf("deep walk = (%v, %v), want (true, true) across ~%d chunks", limited, ok, chunks)
+		t.Fatalf("deep walk = (%v, %v), want (true, true)", limited, ok)
+	}
+
+	if len(reads) < 100 {
+		t.Fatalf("only %d chunk reads for a %d-byte file at %d-byte chunks; the walk is not chunking",
+			len(reads), size.Size(), usageLimitScanChunkBytes)
+	}
+
+	// Descending, contiguous, non-overlapping, and terminating at byte 0.
+	var total int64
+	prevStart := size.Size()
+	for n, r := range reads {
+		if r.end != prevStart {
+			t.Fatalf("read %d is [%d,%d) but the previous read started at %d — chunks must be contiguous and non-overlapping",
+				n, r.start, r.end, prevStart)
+		}
+		if r.end-r.start > usageLimitScanChunkBytes {
+			t.Fatalf("read %d spans %d bytes, over the %d-byte chunk bound", n, r.end-r.start, usageLimitScanChunkBytes)
+		}
+		total += r.end - r.start
+		prevStart = r.start
+	}
+	if prevStart != 0 {
+		t.Fatalf("walk stopped at byte %d instead of reaching 0 — a ceiling would look exactly like this", prevStart)
+	}
+	// Chunk scanning reads the file once. Line reads add the lines actually parsed,
+	// which for this fixture is a small tail, so a generous multiple still catches
+	// the old geometric re-reading (which cost >1.5x on this shape).
+	if total != size.Size() {
+		t.Fatalf("chunk reads covered %d bytes for a %d-byte file; expected exact single coverage", total, size.Size())
 	}
 }
 
@@ -261,27 +288,55 @@ func TestUsageLimitPublishable(t *testing.T) {
 	}
 }
 
-// #1806 cycle-4: post-claim early returns used to hand back the snapshot taken at
-// claim time, so a slow scan could report a value a newer scan had already
-// superseded. Every post-claim exit now reads the memo, which this pins on the
-// unresolvable-path exit: it must observe the newer verdict, not the older one it
-// started with.
-func TestUsageLimited_EarlyExitReportsCurrentMemo(t *testing.T) {
-	inst := NewInstanceWithTool("usage-limit-exit-order", t.TempDir(), "claude")
-	inst.ClaudeSessionID = "no-such-session-id"
+// #1806 cycle-5 audit: the previous version seeded the newer verdict BEFORE the
+// claim, so the old snapshot code returned true as well — a false green.
+//
+// My first replacement was ALSO blind: it called latestAssistantTurnIsRateLimited
+// and then usageLimitedNow() directly, which proves only that usageLimitedNow reads
+// current state and says nothing about whether usageLimited's exits route through
+// it. This drives usageLimited() itself against a transcript the resolver really
+// finds, and moves the memo mid-scan through the observer seam so the ordering is
+// deterministic rather than raced.
+func TestUsageLimited_EarlyExitReportsMemoPublishedDuringScan(t *testing.T) {
+	const sid = "exit-order-session"
+	project := t.TempDir()
+	inst := NewInstanceWithTool("usage-limit-exit-order", project, "claude")
+	inst.ClaudeSessionID = sid
 
-	// First call takes the claim and the path does not resolve.
-	_ = inst.usageLimited()
+	// Place the fixture exactly where the resolver looks.
+	dir := filepath.Join(GetClaudeConfigDirForInstance(inst), "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, sid+".jsonl")
+	// A user record only: the scan reads it, finds no assistant turn, and takes the
+	// post-claim "no verdict" exit — the exit under test.
+	if err := os.WriteFile(path, []byte(recUserAt(stampAt(-time.Minute))+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 
-	// Simulate a newer scan having published true while an older caller was still
-	// in flight, then force the older caller's path again by expiring the throttle.
-	inst.mu.Lock()
-	inst.usageLimitedCached = true
-	inst.lastUsageLimitScanAt = time.Now().Add(-2 * usageLimitScanInterval)
-	inst.mu.Unlock()
+	if got := locateHandoffTranscript(inst); got != path {
+		t.Skipf("resolver did not find the fixture (got %q, want %q); environment-dependent", got, path)
+	}
 
-	if got := inst.usageLimited(); !got {
-		t.Fatal("early exit returned a stale snapshot instead of the current memo")
+	scanned := false
+	usageLimitScanObserver = func(int64, int64) {
+		scanned = true
+		// Publish a newer verdict while this scan is in flight, exactly as a
+		// concurrent scan would. Old code captured its snapshot before this point
+		// and returned false.
+		inst.mu.Lock()
+		inst.usageLimitedCached = true
+		inst.mu.Unlock()
+	}
+	defer func() { usageLimitScanObserver = nil }()
+
+	got := inst.usageLimited()
+	if !scanned {
+		t.Fatal("premise broken: no chunk was read, so nothing was published mid-scan")
+	}
+	if !got {
+		t.Fatal("early exit returned the snapshot taken at claim time, not the memo published during the scan")
 	}
 }
 
@@ -376,10 +431,16 @@ func TestUsageLimited_ConcurrentCallersAgree(t *testing.T) {
 		}
 	}
 	inst.mu.RLock()
-	stamped := inst.lastUsageLimitScanAt
+	stamped, gen := inst.lastUsageLimitScanAt, inst.usageLimitScanGen
 	inst.mu.RUnlock()
 	if stamped.IsZero() {
 		t.Fatal("no scan was stamped despite concurrent callers")
+	}
+	// The generation IS the claim counter, so this is the assertion the earlier
+	// version was missing: equal results and a non-zero timestamp left multiple
+	// simultaneous claims completely invisible.
+	if gen != 1 {
+		t.Fatalf("usageLimitScanGen = %d after %d concurrent callers, want exactly 1 claim", gen, callers)
 	}
 }
 

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -169,8 +169,17 @@ func TestLatestAssistantTurnIsRateLimited_MissingFile(t *testing.T) {
 // non-assistant traffic must still be found. A long-lived process keeps its memo,
 // but a fresh CLI invocation starts with none and would otherwise report a
 // limited session as healthy.
-func TestLatestAssistantTurnIsRateLimited_RecoversAfterTailEviction(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "evicted.jsonl")
+// #1806 cycle-4 audit: the previous version of this test buried the record by only
+// ~576 KiB, which the old 8 MiB step would also have found — so it passed before
+// and after and guarded nothing. Shrinking the chunk lets the walk cross MANY
+// boundaries at a trivial file size, which is the property that actually
+// distinguishes an uncapped backward walk from any fixed ladder.
+func TestLatestAssistantTurnIsRateLimited_WalksBackAcrossManyChunks(t *testing.T) {
+	saved := usageLimitScanChunkBytes
+	usageLimitScanChunkBytes = 1024
+	defer func() { usageLimitScanChunkBytes = saved }()
+
+	path := filepath.Join(t.TempDir(), "deep.jsonl")
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -178,62 +187,101 @@ func TestLatestAssistantTurnIsRateLimited_RecoversAfterTailEviction(t *testing.T
 	if _, err := f.WriteString(recRateLimitAt(stampAt(-time.Minute)) + "\n"); err != nil {
 		t.Fatalf("write rejection: %v", err)
 	}
-	// Bury it under more than the first window of user records. No assistant turn
-	// among them, so that window alone can form no verdict.
+	// Bury it far beyond what a three-step ladder of this chunk size could reach
+	// (1 KiB + 8 KiB + 64 KiB ≈ 73 KiB): ~200 KiB of user records, no assistant
+	// turn among them.
 	filler := recUserAt(stampAt(-time.Minute))
-	for written := int64(0); written < usageLimitFirstTailBytes+64*1024; written += int64(len(filler)) + 1 {
-		if _, err := f.WriteString(filler + "\n"); err != nil {
+	var buried int64
+	for buried < 200*1024 {
+		n, err := f.WriteString(filler + "\n")
+		if err != nil {
 			t.Fatalf("write filler: %v", err)
 		}
+		buried += int64(n)
 	}
 	_ = f.Close()
 
-	// Premise, asserted rather than assumed: the first window really does not
-	// contain the decisive record, so this exercises escalation and not a
-	// single-read path that happens to work.
-	lines, complete, err := readTranscriptTailLines(path, usageLimitFirstTailBytes)
+	info, err := os.Stat(path)
 	if err != nil {
-		t.Fatalf("premise read: %v", err)
+		t.Fatalf("stat: %v", err)
 	}
-	if complete {
-		t.Fatal("premise broken: the first window covered the whole file")
-	}
-	for _, l := range lines {
-		if strings.Contains(l, `"rate_limit"`) {
-			t.Fatal("premise broken: the rejection is inside the first window, so eviction is not exercised")
-		}
+	chunks := info.Size() / usageLimitScanChunkBytes
+	if chunks < 100 {
+		t.Fatalf("premise broken: only %d chunks, want a deep walk", chunks)
 	}
 
 	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
 	if !limited || !ok {
-		t.Fatalf("after eviction = (%v, %v), want (true, true) via tail escalation", limited, ok)
+		t.Fatalf("deep walk = (%v, %v), want (true, true) across ~%d chunks", limited, ok, chunks)
 	}
 }
 
-// A tail offset landing inside a record must drop that partial line and keep the
-// complete ones. Sized from the fixture rather than hardcoded, so the offset
-// really lands inside the filler line.
-func TestReadTranscriptTailLines_DropsPartialFirstLine(t *testing.T) {
+// A record straddling a chunk boundary must be reassembled, not silently dropped
+// or half-parsed. Chosen chunk size guarantees the rejection spans a boundary.
+func TestLatestAssistantTurnIsRateLimited_RecordSpanningChunkBoundary(t *testing.T) {
 	rec := recRateLimitAt(stampAt(-time.Minute))
-	filler := strings.Repeat("A", 400)
-	path := filepath.Join(t.TempDir(), "t.jsonl")
-	if err := os.WriteFile(path, []byte(filler+"\n"+rec+"\n"), 0o600); err != nil {
+	saved := usageLimitScanChunkBytes
+	// Half the record length: the rejection cannot fit in one chunk.
+	usageLimitScanChunkBytes = int64(len(rec) / 2)
+	defer func() { usageLimitScanChunkBytes = saved }()
+
+	path := filepath.Join(t.TempDir(), "split.jsonl")
+	body := recUserAt(stampAt(-time.Minute)) + "\n" + rec + "\n" + recUserAt(stampAt(-time.Minute)) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
-	// Covers the whole record plus part of the filler line above it.
-	lines, complete, err := readTranscriptTailLines(path, int64(len(rec)+100))
-	if err != nil {
-		t.Fatalf("readTranscriptTailLines: %v", err)
+	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
+	if !limited || !ok {
+		t.Fatalf("boundary-spanning record = (%v, %v), want (true, true)", limited, ok)
 	}
-	if complete {
-		t.Fatal("premise broken: the read covered the whole file, so no partial line exists")
+}
+
+// The pure publish rule, exhaustively — racing two real scans to exercise it is
+// not something a test can do deterministically, which is why the rule is split
+// out. #1806 cycle-4 audit noted usageLimitScanGen had no regression at all.
+func TestUsageLimitPublishable(t *testing.T) {
+	tests := []struct {
+		name                  string
+		curGen, myGen         uint64
+		curSession, mySession string
+		want                  bool
+	}{
+		{"current claim, same session", 7, 7, "s1", "s1", true},
+		{"superseded by a newer claim", 8, 7, "s1", "s1", false},
+		{"rebound while in flight", 7, 7, "s2", "s1", false},
+		{"both moved", 9, 7, "s2", "s1", false},
 	}
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want exactly the one complete record: %#v", len(lines), lines)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := usageLimitPublishable(tt.curGen, tt.myGen, tt.curSession, tt.mySession); got != tt.want {
+				t.Fatalf("usageLimitPublishable = %v, want %v", got, tt.want)
+			}
+		})
 	}
-	if lines[0] != rec {
-		t.Fatalf("kept line is not the intact record:\n got %q\nwant %q", lines[0], rec)
+}
+
+// #1806 cycle-4: post-claim early returns used to hand back the snapshot taken at
+// claim time, so a slow scan could report a value a newer scan had already
+// superseded. Every post-claim exit now reads the memo, which this pins on the
+// unresolvable-path exit: it must observe the newer verdict, not the older one it
+// started with.
+func TestUsageLimited_EarlyExitReportsCurrentMemo(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-exit-order", t.TempDir(), "claude")
+	inst.ClaudeSessionID = "no-such-session-id"
+
+	// First call takes the claim and the path does not resolve.
+	_ = inst.usageLimited()
+
+	// Simulate a newer scan having published true while an older caller was still
+	// in flight, then force the older caller's path again by expiring the throttle.
+	inst.mu.Lock()
+	inst.usageLimitedCached = true
+	inst.lastUsageLimitScanAt = time.Now().Add(-2 * usageLimitScanInterval)
+	inst.mu.Unlock()
+
+	if got := inst.usageLimited(); !got {
+		t.Fatal("early exit returned a stale snapshot instead of the current memo")
 	}
 }
 

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -1,0 +1,183 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Records shaped exactly like the field evidence that motivated #1802. The
+// quota rejection carries apiErrorStatus 429 and error "rate_limit"; a
+// credential failure carries 401; a normal turn carries neither.
+const (
+	recRateLimit = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit · resets 8:50pm (UTC)"}]}}`
+	recAuth401   = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":401,"error":"authentication_error","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"Invalid API key · Please run /login"}]}}`
+	recOverload  = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":529,"error":"overloaded_error","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"API Error: 529 overloaded"}]}}`
+	recNormal    = `{"type":"assistant","isApiErrorMessage":false,"timestamp":"2026-07-30T21:06:27.000Z","isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"All clear."}]}}`
+	recUser      = `{"type":"user","timestamp":"2026-07-30T21:05:44.669Z","isSidechain":false,"message":{"role":"user","content":"[HEARTBEAT] Check sessions in your group"}}`
+	// A subagent hitting its own limit must not classify the parent session.
+	recSidechainRateLimit = `{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"You've hit your session limit · resets 8:50pm (UTC)"}]}}`
+)
+
+func writeUsageLimitTranscript(t *testing.T, records ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	body := strings.Join(records, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func TestLatestAssistantTurnIsRateLimited(t *testing.T) {
+	tests := []struct {
+		name        string
+		records     []string
+		wantLimited bool
+		wantOK      bool
+	}{
+		{
+			name:        "quota rejection is the latest assistant turn",
+			records:     []string{recUser, recRateLimit},
+			wantLimited: true,
+			wantOK:      true,
+		},
+		{
+			name: "a later successful turn clears it without any expiry logic",
+			// This is the whole reason the verdict is "latest turn" rather than a
+			// parsed reset time: recovery needs no clock.
+			records:     []string{recRateLimit, recUser, recNormal},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			name:        "later user message alone does not clear it",
+			records:     []string{recRateLimit, recUser},
+			wantLimited: true,
+			wantOK:      true,
+		},
+		{
+			name:        "credential failure is a different condition",
+			records:     []string{recUser, recAuth401},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			name:        "overloaded model is not a quota rejection",
+			records:     []string{recUser, recOverload},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			name:        "subagent sidechain limit does not classify the parent",
+			records:     []string{recRateLimit, recNormal, recSidechainRateLimit},
+			wantLimited: false,
+			wantOK:      true,
+		},
+		{
+			name:        "no assistant turn yet reports no verdict",
+			records:     []string{recUser},
+			wantLimited: false,
+			wantOK:      false,
+		},
+		{
+			name:        "malformed lines are skipped, not fatal",
+			records:     []string{`{not json`, recUser, recRateLimit},
+			wantLimited: true,
+			wantOK:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limited, ok := latestAssistantTurnIsRateLimited(writeUsageLimitTranscript(t, tt.records...))
+			if limited != tt.wantLimited || ok != tt.wantOK {
+				t.Fatalf("latestAssistantTurnIsRateLimited = (%v, %v), want (%v, %v)",
+					limited, ok, tt.wantLimited, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestLatestAssistantTurnIsRateLimited_MissingFile(t *testing.T) {
+	limited, ok := latestAssistantTurnIsRateLimited(filepath.Join(t.TempDir(), "absent.jsonl"))
+	if limited || ok {
+		t.Fatalf("missing transcript = (%v, %v), want (false, false)", limited, ok)
+	}
+}
+
+// The tail read must find the newest turn in a transcript far larger than the
+// window — field transcripts reach tens of megabytes, and reading them whole on
+// a status poll is what the tail exists to avoid.
+func TestLatestAssistantTurnIsRateLimited_LargeTranscriptTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Comfortably exceed usageLimitTranscriptTailBytes with filler turns.
+	filler := fmt.Sprintf(`{"type":"assistant","isApiErrorMessage":false,"isSidechain":false,"message":{"role":"assistant","content":[{"type":"text","text":"%s"}]}}`, strings.Repeat("x", 512))
+	for written := 0; written < 2*usageLimitTranscriptTailBytes; written += len(filler) + 1 {
+		if _, err := f.WriteString(filler + "\n"); err != nil {
+			t.Fatalf("write filler: %v", err)
+		}
+	}
+	if _, err := f.WriteString(recRateLimit + "\n"); err != nil {
+		t.Fatalf("write tail record: %v", err)
+	}
+	_ = f.Close()
+
+	limited, ok := latestAssistantTurnIsRateLimited(path)
+	if !limited || !ok {
+		t.Fatalf("large transcript = (%v, %v), want (true, true)", limited, ok)
+	}
+}
+
+// A tail that starts mid-record must not be parsed as a whole line.
+func TestReadTranscriptTailLines_DropsPartialFirstLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	body := strings.Repeat("A", 400) + "\n" + recRateLimit + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Tail smaller than the file forces a mid-file offset.
+	lines, err := readTranscriptTailLines(path, 200)
+	if err != nil {
+		t.Fatalf("readTranscriptTailLines: %v", err)
+	}
+	for _, l := range lines {
+		if strings.HasPrefix(l, "AAA") {
+			t.Fatalf("partial first line was kept: %q", l[:20])
+		}
+	}
+}
+
+func TestUsageLimited_NonClaudeToolNeverScans(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-codex", t.TempDir(), "codex")
+	if inst.usageLimited() {
+		t.Fatal("usageLimited() = true for a codex session, want false")
+	}
+	if !inst.lastUsageLimitScanAt.IsZero() {
+		t.Fatal("non-Claude tool should not even record a scan attempt")
+	}
+}
+
+// The mirror is what CachedSubstate reads, so it must stay consistent with the
+// substate it drives and must not require filesystem access.
+func TestCachedSubstate_UsesUsageLimitMirror(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-mirror", t.TempDir(), "claude")
+
+	if got := inst.CachedSubstate(); got == SubstateUsageLimit {
+		t.Fatalf("CachedSubstate = %q before any scan, want anything else", got)
+	}
+
+	inst.mu.Lock()
+	inst.usageLimitedCached = true
+	inst.mu.Unlock()
+
+	if got := inst.CachedSubstate(); got != SubstateUsageLimit {
+		t.Fatalf("CachedSubstate = %q with the mirror set, want %q", got, SubstateUsageLimit)
+	}
+}

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -164,6 +164,50 @@ func TestUsageLimited_NonClaudeToolNeverScans(t *testing.T) {
 	}
 }
 
+// Regression for the review findings on #1806.
+func TestUsageLimited_SkipsSSHInstances(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-ssh", t.TempDir(), "claude")
+	inst.SSHHost = "devbox.example"
+	inst.ClaudeSessionID = "abc123"
+
+	if inst.usageLimited() {
+		t.Fatal("usageLimited() = true for an SSH instance, want false")
+	}
+	if !inst.lastUsageLimitScanAt.IsZero() {
+		t.Fatal("SSH instance should bail before doing any path work or stamping a scan")
+	}
+}
+
+// The throttle must cover the "path never resolves" exit too. Stamping only on
+// success left that case calling locateHandoffTranscript — user-config load plus
+// several stats — on every status poll, which is precisely the cost the throttle
+// exists to bound.
+func TestUsageLimited_ThrottlesWhenTranscriptUnresolvable(t *testing.T) {
+	inst := NewInstanceWithTool("usage-limit-unresolvable", t.TempDir(), "claude")
+	// No ClaudeSessionID: nothing to resolve a transcript from.
+	inst.ClaudeSessionID = ""
+
+	if inst.usageLimited() {
+		t.Fatal("usageLimited() = true with no transcript, want false")
+	}
+
+	inst.mu.RLock()
+	stamped := inst.lastUsageLimitScanAt
+	inst.mu.RUnlock()
+	if stamped.IsZero() {
+		t.Fatal("scan attempt was not stamped, so the throttle never engages on this path")
+	}
+
+	// Second call inside the window must not re-stamp (i.e. it short-circuits).
+	inst.usageLimited()
+	inst.mu.RLock()
+	again := inst.lastUsageLimitScanAt
+	inst.mu.RUnlock()
+	if !again.Equal(stamped) {
+		t.Fatalf("second call re-stamped (%v -> %v); throttle did not short-circuit", stamped, again)
+	}
+}
+
 // The mirror is what CachedSubstate reads, so it must stay consistent with the
 // substate it drives and must not require filesystem access.
 func TestCachedSubstate_UsesUsageLimitMirror(t *testing.T) {

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -362,3 +362,54 @@ func TestSubstate_ReportsUsageLimitWhenLimited(t *testing.T) {
 		t.Fatalf("Substate() = %q with no verdict, want anything else", got)
 	}
 }
+
+// #1806 review (CodeRabbit): the empty-id gate alone cannot close the window,
+// because locateHandoffTranscript re-reads ClaudeSessionID after the lock is
+// released and falls back to the newest conversation for the project when it is
+// empty. So the guarantee is made about the resolved PATH instead of the timing.
+func TestTranscriptBelongsToSession(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		sessionID string
+		want      bool
+	}{
+		{
+			name:      "path for our own session",
+			path:      "/home/u/.claude/projects/-home-u-proj/abc123.jsonl",
+			sessionID: "abc123",
+			want:      true,
+		},
+		{
+			name:      "path for a sibling session is refused",
+			path:      "/home/u/.claude/projects/-home-u-proj/other999.jsonl",
+			sessionID: "abc123",
+			want:      false,
+		},
+		{
+			name:      "empty path",
+			path:      "",
+			sessionID: "abc123",
+			want:      false,
+		},
+		{
+			name:      "empty session id never matches",
+			path:      "/home/u/.claude/projects/-home-u-proj/abc123.jsonl",
+			sessionID: "",
+			want:      false,
+		},
+		{
+			name:      "prefix collision is not a match",
+			path:      "/home/u/.claude/projects/-home-u-proj/abc1234.jsonl",
+			sessionID: "abc123",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := transcriptBelongsToSession(tt.path, tt.sessionID); got != tt.want {
+				t.Fatalf("transcriptBelongsToSession(%q, %q) = %v, want %v", tt.path, tt.sessionID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/session/usagelimit_test.go
+++ b/internal/session/usagelimit_test.go
@@ -169,12 +169,12 @@ func TestLatestAssistantTurnIsRateLimited_MissingFile(t *testing.T) {
 // non-assistant traffic must still be found. A long-lived process keeps its memo,
 // but a fresh CLI invocation starts with none and would otherwise report a
 // limited session as healthy.
-// #1806 cycle-5 audit: the previous version proved only fixture depth — it asserted
-// the answer came out right, which an overlapping or whole-file reader also
-// achieves. What the change actually claims is *non-overlapping, bounded* I/O that
-// still reaches byte 0, so that is what this asserts, using the scan's observer
-// seam to record every byte range read.
-func TestLatestAssistantTurnIsRateLimited_ReadsBoundedNonOverlappingChunks(t *testing.T) {
+// #1806 cycle-6 audit: recording only chunk ranges could NOT distinguish this
+// walker from the carry-based one it replaced — that one's chunk windows were also
+// descending, contiguous and single-coverage, and its defect (repeated copying of a
+// growing line) was invisible to chunk instrumentation. Line reads are where it
+// shows, so the observer now records both and this asserts both.
+func TestLatestAssistantTurnIsRateLimited_ReadsEachByteOnce(t *testing.T) {
 	savedChunk := usageLimitScanChunkBytes
 	usageLimitScanChunkBytes = 1024
 	defer func() { usageLimitScanChunkBytes = savedChunk }()
@@ -198,48 +198,119 @@ func TestLatestAssistantTurnIsRateLimited_ReadsBoundedNonOverlappingChunks(t *te
 	}
 	_ = f.Close()
 
-	size, err := os.Stat(path)
+	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
 
-	type rng struct{ start, end int64 }
-	var reads []rng
-	usageLimitScanObserver = func(start, end int64) { reads = append(reads, rng{start, end}) }
+	var reads []usageLimitScanRead
+	usageLimitScanObserver = func(r usageLimitScanRead) { reads = append(reads, r) }
 	defer func() { usageLimitScanObserver = nil }()
 
-	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
-	if !limited || !ok {
+	if limited, ok := latestAssistantTurnIsRateLimited(path, refNow); !limited || !ok {
 		t.Fatalf("deep walk = (%v, %v), want (true, true)", limited, ok)
 	}
 
-	if len(reads) < 100 {
-		t.Fatalf("only %d chunk reads for a %d-byte file at %d-byte chunks; the walk is not chunking",
-			len(reads), size.Size(), usageLimitScanChunkBytes)
-	}
-
-	// Descending, contiguous, non-overlapping, and terminating at byte 0.
-	var total int64
-	prevStart := size.Size()
+	var chunkBytes, lineBytes int64
+	prevStart := info.Size()
+	chunks := 0
 	for n, r := range reads {
-		if r.end != prevStart {
-			t.Fatalf("read %d is [%d,%d) but the previous read started at %d — chunks must be contiguous and non-overlapping",
-				n, r.start, r.end, prevStart)
+		switch r.Kind {
+		case "chunk":
+			chunks++
+			if r.End != prevStart {
+				t.Fatalf("chunk read %d is [%d,%d) but the previous chunk started at %d — must be contiguous and non-overlapping",
+					n, r.Start, r.End, prevStart)
+			}
+			if r.End-r.Start > usageLimitScanChunkBytes {
+				t.Fatalf("chunk read %d spans %d bytes, over the %d-byte bound", n, r.End-r.Start, usageLimitScanChunkBytes)
+			}
+			chunkBytes += r.End - r.Start
+			prevStart = r.Start
+		case "line":
+			lineBytes += r.End - r.Start
 		}
-		if r.end-r.start > usageLimitScanChunkBytes {
-			t.Fatalf("read %d spans %d bytes, over the %d-byte chunk bound", n, r.end-r.start, usageLimitScanChunkBytes)
-		}
-		total += r.end - r.start
-		prevStart = r.start
+	}
+	if chunks < 100 {
+		t.Fatalf("only %d chunk reads for a %d-byte file at %d-byte chunks", chunks, info.Size(), usageLimitScanChunkBytes)
 	}
 	if prevStart != 0 {
-		t.Fatalf("walk stopped at byte %d instead of reaching 0 — a ceiling would look exactly like this", prevStart)
+		t.Fatalf("walk stopped at byte %d instead of reaching 0 — a ceiling looks exactly like this", prevStart)
 	}
-	// Chunk scanning reads the file once. Line reads add the lines actually parsed,
-	// which for this fixture is a small tail, so a generous multiple still catches
-	// the old geometric re-reading (which cost >1.5x on this shape).
-	if total != size.Size() {
-		t.Fatalf("chunk reads covered %d bytes for a %d-byte file; expected exact single coverage", total, size.Size())
+	if chunkBytes != info.Size() {
+		t.Fatalf("chunk reads covered %d bytes of a %d-byte file; expected exact single coverage", chunkBytes, info.Size())
+	}
+	// The load-bearing assertion for the quadratic fix: line reads must be bounded
+	// by the file, not a multiple of it. The carry walker recopied a long line once
+	// per chunk, which lands far above 1x here.
+	if lineBytes > info.Size() {
+		t.Fatalf("line reads totalled %d bytes for a %d-byte file — a line is being read more than once", lineBytes, info.Size())
+	}
+}
+
+// A line larger than the bound must be skipped on its MEASURED length, never read.
+// /compact writes multi-megabyte single-line records and this runs on a status path.
+func TestLatestAssistantTurnIsRateLimited_SkipsOversizedLineWithoutReading(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.jsonl")
+	huge := `{"type":"assistant","isSidechain":false,"message":{"role":"assistant","content":"` +
+		strings.Repeat("x", usageLimitMaxLineBytes+1024) + `"}}`
+	body := recRateLimitAt(stampAt(-time.Minute)) + "\n" + huge + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var lineReads []usageLimitScanRead
+	usageLimitScanObserver = func(r usageLimitScanRead) {
+		if r.Kind == "line" || r.Kind == "line-skipped" {
+			lineReads = append(lineReads, r)
+		}
+	}
+	defer func() { usageLimitScanObserver = nil }()
+
+	// The oversized record is skipped, so the rejection beneath it is the verdict.
+	limited, ok := latestAssistantTurnIsRateLimited(path, refNow)
+	if !limited || !ok {
+		t.Fatalf("= (%v, %v), want (true, true) — the oversized line should be skipped, not fatal", limited, ok)
+	}
+
+	sawSkip := false
+	for _, r := range lineReads {
+		if r.End-r.Start > usageLimitMaxLineBytes {
+			if r.Kind == "line" {
+				t.Fatalf("oversized line [%d,%d) was READ; it must be skipped on measured length", r.Start, r.End)
+			}
+			sawSkip = true
+		}
+	}
+	if !sawSkip {
+		t.Fatal("premise broken: no oversized line was encountered")
+	}
+}
+
+// Allocation on the status path: an empty transcript must not allocate a chunk
+// buffer, and a tiny one must size the buffer to the file.
+func TestLatestAssistantTurnIsRateLimited_DoesNotAllocateForEmptyTranscript(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var reads int
+	usageLimitScanObserver = func(usageLimitScanRead) { reads++ }
+	defer func() { usageLimitScanObserver = nil }()
+
+	limited, ok := latestAssistantTurnIsRateLimited(empty, refNow)
+	if limited || ok {
+		t.Fatalf("empty transcript = (%v, %v), want (false, false)", limited, ok)
+	}
+	if reads != 0 {
+		t.Fatalf("empty transcript performed %d reads, want 0", reads)
+	}
+
+	allocs := testing.AllocsPerRun(20, func() { _, _ = latestAssistantTurnIsRateLimited(empty, refNow) })
+	if allocs > 8 {
+		t.Fatalf("empty transcript allocated %.0f times per scan; a chunk buffer is being allocated before the size check", allocs)
 	}
 }
 
@@ -320,7 +391,7 @@ func TestUsageLimited_EarlyExitReportsMemoPublishedDuringScan(t *testing.T) {
 	}
 
 	scanned := false
-	usageLimitScanObserver = func(int64, int64) {
+	usageLimitScanObserver = func(usageLimitScanRead) {
 		scanned = true
 		// Publish a newer verdict while this scan is in flight, exactly as a
 		// concurrent scan would. Old code captured its snapshot before this point
@@ -584,5 +655,58 @@ func TestUsageLimited_RebindClearsThrottleClaim(t *testing.T) {
 	inst.mu.RUnlock()
 	if stamped.Equal(claimed) {
 		t.Fatal("rebind kept A's throttle claim, so B is answered from A's window")
+	}
+}
+
+// #1806 cycle-6 [High]: guarding only the WRITE stopped scan A publishing after an
+// A→B rebind but still returned A's memo for B, because every memo read was
+// identity-blind and the memo key only moves when a mismatch is seen at claim time.
+// This is the integration test the finding asked for: rebind INSIDE the scan.
+func TestUsageLimited_RebindDuringScanDoesNotReturnOldVerdict(t *testing.T) {
+	const sidA = "rebind-during-scan-A"
+	project := t.TempDir()
+	inst := NewInstanceWithTool("usage-limit-rebind-inflight", project, "claude")
+	inst.ClaudeSessionID = sidA
+
+	dir := filepath.Join(GetClaudeConfigDirForInstance(inst), "projects", ConvertToClaudeDirName(project))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A's transcript holds a fresh rejection, so a completed scan for A says true.
+	if err := os.WriteFile(filepath.Join(dir, sidA+".jsonl"),
+		[]byte(recRateLimitAt(stampAt(-time.Minute))+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := locateHandoffTranscript(inst); got == "" {
+		t.Skip("resolver did not find the fixture; environment-dependent")
+	}
+
+	// Seed a live true verdict for A exactly as a completed scan would.
+	inst.mu.Lock()
+	inst.usageLimitSessionID = sidA
+	inst.usageLimitedCached = true
+	inst.lastUsageLimitScanAt = time.Time{} // force a fresh claim
+	inst.mu.Unlock()
+
+	rebound := false
+	usageLimitScanObserver = func(usageLimitScanRead) {
+		if rebound {
+			return
+		}
+		rebound = true
+		// The instance is rebound to a different session while this scan is in
+		// flight. Nothing has formed a verdict for B.
+		inst.mu.Lock()
+		inst.ClaudeSessionID = "rebind-during-scan-B"
+		inst.mu.Unlock()
+	}
+	defer func() { usageLimitScanObserver = nil }()
+
+	got := inst.usageLimited()
+	if !rebound {
+		t.Fatal("premise broken: no read happened, so no rebind was injected mid-scan")
+	}
+	if got {
+		t.Fatal("returned A's verdict for an Instance rebound to B mid-scan")
 	}
 }

--- a/internal/tmux/substate.go
+++ b/internal/tmux/substate.go
@@ -37,6 +37,18 @@ const (
 	// /login", "API Error: 401", "socket connection closed"). Pairs with
 	// status "error". Built on the #1400 error-banner detection.
 	SubstateAuth401 Substate = "auth-401"
+
+	// SubstateUsageLimit marks a session whose plan usage window is exhausted:
+	// the pane is healthy and accepts input, but every submitted turn is
+	// rejected until the window resets. Pairs with status "idle"/"waiting" —
+	// which is precisely why it needs its own signal, since "idle" is the state
+	// periodic senders treat as safe to send into.
+	//
+	// Unlike its neighbours this substate is NOT derived from pane text. The
+	// rejection is structured data in the agent's transcript, so the verdict is
+	// formed there (see internal/session/usagelimit.go, #1802) and surfaced
+	// through Instance.Substate rather than ClassifySubstate.
+	SubstateUsageLimit Substate = "usage-limit"
 )
 
 // modelUnavailableSubstrings are fragments of the Fable/model-down no-op the


### PR DESCRIPTION
## What problem does this solve?

Fixes #1802. A Claude session whose plan usage window is exhausted reports `idle`, so
periodic senders keep sending into it and nothing reports a problem. Field evidence: nine
heartbeats delivered and bounced over 4h24m, every `session send` exiting 0 (correctly —
delivery genuinely succeeded) and the systemd unit logging success each time.

Supersedes #1803, which attempted the same detection by scanning pane text. Cross-agent
review found six issues with that approach, four of which I reproduced; rather than patch
them one at a time I moved the signal to where it is actually reliable. #1803 is closed in
favour of this.

## Why this change

The pane looks like the obvious source and is not usable for this. Three independent
reasons, all measured on the real pane, not assumed:

1. The rejection renders behind the `⎿` tool-result connector — the same prefix the
   existing banner guards skip so quoted output is not misread. Skip it and you miss every
   real occurrence; allow it and tool output starts matching.
2. `CapturePane` runs `capture-pane -p -e` with **no `-J`**, so soft wraps arrive as real
   newlines. On a narrow pane `You've hit your session\nlimit · resets …` leaves no single
   line containing the phrase — the detector misses the exact case it exists for.
3. The vocabulary is not distinctive. A session running `grep` over this repository prints
   `/usage-credits` in a tool result and classifies *itself* as limited.

The transcript carries the same event as structured data:

```json
{"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,
 "error":"rate_limit","timestamp":"2026-07-30T17:03:25.225Z","isSidechain":false, ...}
```

So the verdict keys off `apiErrorStatus` / `error` and never off prose. Nothing needs to
know how the banner is worded or how wide the pane is. It also separates conditions that
need opposite responses, which text matching blurred: **429 `rate_limit`** (wait) vs
**401 `authentication_error`** (re-authenticate) vs **529 `overloaded_error`** (retry).

**Expiry — bounded, with a stated limitation.** I first claimed it "falls out of the shape and
cannot get stuck". That was wrong: it only holds if a later turn ever happens, and a session
receiving no further input stayed classified from the old rejection indefinitely. Belief is now
bounded by the record's own timestamp (`usageLimitMaxAge` = 5h). An absent or unparseable
timestamp is **not** fresh, since believing a rejection of unknown age is what produced the
stuck state.

That bounds staleness but does **not** track the actual reset, and review was right to keep
pressing: a rejection stamped 20:35 whose banner says the window reopens at 20:50 is believed
until 01:35 — **up to ~5h of false `usage-limit` in the no-further-input case**. 5h is an upper
bound from the *start* of a window, not from every rejection. I am accepting that rather than
hiding it, and the reasoning is a `KNOWN LIMITATION` block in `usagelimit.go`:

- the cost is bounded and is a **mislabel, not an action** — nothing consumes this substate
  yet, which is why the PR stays visibility-only;
- the alternative is parsing a human-facing 12-hour local-time string (timezone, day rollover,
  wording drift) for a *promise* rather than an observation — and escaping prose parsing is the
  entire reason this moved off the pane;
- the comment names the revisit condition: when a consumer starts acting on the verdict, prefer
  a revalidation signal over parsing the banner.

The same bound limits rather than eliminates the related case: a pane auth/socket failure
occurring inside those five hours can still lose to an older 429. Also stated in the code.

**A recent quota rejection outranks the pane's auth verdict, deliberately.** The transcript
record is the latest assistant turn and a 429 proves the request was authenticated, so a
stale `Please run /login` line still in the scrollback must not win on category order and
mislabel a session whose credentials demonstrably work. "Recent" is load-bearing: review
pointed out that a 429 only proves authentication *at its own timestamp*, so an old one could
mask a freshly rendered 401 or a dropped socket that never arms the credential hold. The
freshness bound above is what keeps this ordering honest.

**The two discriminators are required together.** `apiErrorStatus == 429` **and**
`error == "rate_limit"`. An earlier revision accepted either, while its own comment said the
pair was required — review caught the mismatch. 429 alone is a general rate-limit code, and
mislabelling an unrelated one as plan exhaustion would then persist for the whole freshness
window.

**Cost and correctness of the read.** Throttled to 5s. The id read, throttle check and claim
share one critical section, and claims are **versioned** so a scan slower than the interval
cannot publish over a newer result. The window starts at 512 KB and grows until the read covers
the whole file — deliberately **without a ceiling**, because a fixed cap does not remove the
cold-start failure it appears to bound, it relocates it: if the decisive record sits beyond the
cap and everything after it is non-assistant traffic, every step returns no verdict and a fresh
process reports the session healthy. The common case remains one 512 KB read.

The memo is **keyed by the session id it was formed for**. Without that, an Instance rebound
A→B returned A's verdict for B — indefinitely when B never formed one of its own. A mismatch
discards both the verdict and the throttle claim.

A bound `ClaudeSessionID` is required before any resolution: with an empty id the shared
resolver deliberately selects the newest conversation for the project across every config
dir, so an unbound instance would inherit a sibling session's rejection.

**Scope I did not take.** No coarse-status change, no back-off logic in `session send`, no
conductor/heartbeat changes, no TUI glyph or Web `SUBSTATE_LABEL` handling, and no
`CachedSubstate` wiring — review correctly called that half-wired, since nothing in the
background status pass would populate it, so a branch there would be dead while looking
supported. Detection
has to exist and be trustworthy before anything acts on it, and the consumer side is a
separate decision about behaviour that is yours to make. Concretely, this PR is
**visibility-only**: `session show --json`, `list --json`, `fleet` output and the verbose
CLI label. If you want the TUI/Web surfaces or sender back-off in the same change, say so
and I will extend it.

**Diff size — +656/−5, so here is the honest accounting** rather than a silent hope you
won't ask. It grew from +453 because seven of the eight review findings needed code or
coverage, not wording:

| | added lines |
|---|---|
| `internal/session/usagelimit_test.go` | 336 |
| `internal/session/usagelimit.go` | 275 — of which **105 comment, 22 blank, 148 actual code** |
| `internal/session/instance.go` | 31 (struct fields + wiring + precedence rationale) |
| `internal/tmux/substate.go` | 12 (enum + doc) |
| `cmd/agent-deck/cli_utils.go` | 2 (label) |

So **336 of 656 are tests** and 105 more are comments; the executable change is ~150 lines.
The test weight is where the review went: expiry, no-timestamp, status-only, kind-only,
mismatched-kind, tail-eviction recovery, bound-session-id, and concurrency each needed a case,
and two earlier cases were false greens that had to be rebuilt rather than adjusted.

The comment weight is deliberate and I would rather defend it than trim it: the single most
important thing here is *why the transcript and not the pane*, and *why belief is bounded* —
reasoning a future reader would otherwise redo from scratch, as I did twice.

What could split out: the CLI label (2 lines) and the enum (12) could technically land
separately, but they are dead code without the detector. I do not think this splits usefully
in a way that helps review.

## User impact

`session show --json` / `list --json` grow one new possible `substate` value,
`"usage-limit"`, and the verbose CLI shows the label `usage limit`. The canonical status
string is unchanged — `Substate` is additive by contract — so nothing keying off `status`
changes behaviour. Non-Claude tools are unaffected: the transcript shape is Claude's, so
`usageLimited()` returns false for every other tool without touching the filesystem.

## Evidence

**The record shape this relies on, read from a real transcript** (the 2026-07-30 incident,
`~/.claude*/projects/…/<session>.jsonl`):

```
apiErrorStatus: 429
error         : "rate_limit"
text          : You've hit your session limit · resets 8:50pm (UTC)
```

**Why the pane approach was abandoned — measured against #1803's own detector:**

```
tool output printing "/usage-credits"   => true   (want false)  — self-classifies
soft-wrapped banner on a narrow pane    => false  (want true)   — misses the real thing
prompt owner scrolled out of window     => true   (want false)
stale auth line + newer 429 bounce      => "auth-401"           — stale verdict wins
```

**Tests, all passing under `-race`** (21 cases; `internal/session`). The block below is the
shape after review — eight findings needed seven code changes and a rebuilt test set:

```
--- PASS: TestLatestAssistantTurnIsRateLimited
    --- PASS: /recent_quota_rejection_is_the_latest_assistant_turn
    --- PASS: /a_later_successful_turn_clears_it_with_no_expiry_logic
    --- PASS: /later_user_message_alone_does_not_clear_it
    --- PASS: /a_rejection_older_than_the_window_is_no_longer_believed
    --- PASS: /a_rejection_with_no_timestamp_is_not_treated_as_fresh
    --- PASS: /credential_failure_is_a_different_condition
    --- PASS: /overloaded_model_is_not_a_quota_rejection
    --- PASS: /429_with_a_different_error_kind_is_not_plan_exhaustion
    --- PASS: /rate_limit_kind_without_the_429_status_does_not_match
    --- PASS: /subagent_sidechain_limit_does_not_classify_the_parent
    --- PASS: /no_assistant_turn_yet_reports_no_verdict
    --- PASS: /a_malformed_line_newer_than_the_verdict_is_skipped,_not_fatal
--- PASS: TestLatestAssistantTurnIsRateLimited_MissingFile
--- PASS: TestLatestAssistantTurnIsRateLimited_RecoversAfterTailEviction
--- PASS: TestReadTranscriptTailLines_DropsPartialFirstLine
--- PASS: TestUsageLimited_NonClaudeToolNeverScans
--- PASS: TestUsageLimited_SkipsSSHInstances
--- PASS: TestUsageLimited_RequiresBoundSessionID
--- PASS: TestUsageLimited_ThrottlesWhenTranscriptUnresolvable
--- PASS: TestUsageLimited_ConcurrentCallersAgree
--- PASS: TestSubstate_ReportsUsageLimitWhenLimited
ok  	github.com/asheshgoplani/agent-deck/internal/session   (-race)
```

Two of these replace earlier false greens rather than adding to them. The partial-tail case
sized its window larger than the record it meant to cut, so the offset never landed in the
filler line — and the assertion also accepted empty output, so deleting the partial-line drop
still passed. The malformed-line case put the bad line *before* the rejection, and the reverse
scan returned before ever visiting it. Both are rebuilt with premise assertions
(`if complete { t.Fatal("premise broken"...) }`) so they cannot silently stop testing what
they claim.

`TestLatestAssistantTurnIsRateLimited_RecoversAfterTailEviction` likewise asserts its own
premise first — that one window alone *cannot* answer — before checking that escalation finds
the buried record.

**Revert-check.** Removing the `Substate` wiring while keeping the tests:

```
--- FAIL: TestSubstate_ReportsUsageLimitWhenLimited
    usagelimit_test.go:354: Substate() = "" with a live usage-limit verdict, want "usage-limit"
```

Restored: `ok internal/session`. Worth saying how this test came to exist: dropping the
`CachedSubstate` branch left the live branch with no test at all — everything else here
exercises `usageLimited` and the transcript walk, so deleting the wiring would have broken
nothing. I noticed while preparing this evidence, not before. It seeds the throttle window so
the memo answers, which keeps it deterministic and filesystem-free.

A blanket revert of every non-test hunk instead fails to compile, since `SubstateUsageLimit`
and the detector are the symbols the tests name — so the surgical revert above is the
informative version.

`gofmt` clean, `go vet` clean on all three touched packages, `go build ./...` clean.

**Hot path.** This adds work to `Substate()`, which the status loop calls per session, so:
`agent-deck -p <profile> list --json` against a live state DB, **interleaved** before/after
in 6 pairs so both binaries see the same host load (this is a shared box; non-interleaved
numbers on it are worthless):

| | runs (s) | median |
|---|---|---|
| installed clean `v1.10.11-15-g580e772c` | 0.07 0.06 0.07 0.05 0.07 0.08 | **0.070** |
| this branch | 0.07 0.07 0.06 0.06 0.08 0.10 | **0.070** |

Identical medians. Structurally: the transcript read is throttled to 5s and bounded to a
512 KB tail; `CachedSubstate()` — the TUI render path — does no I/O at all and reads the
in-memory mirror, which `TestCachedSubstate_UsesUsageLimitMirror` pins; and for a
non-Claude tool the function returns before any path resolution.

I left the "suite passes sandboxed" box unchecked rather than quietly checking it: on this
host the full `./...` also trips 10 pre-existing `internal/git` sparse-checkout failures
(git 2.34.1 on Ubuntu 22.04) and the `TestCanRestartCursor` issue filed as #1804 / fixed in
#1805. All reproduce identically on unmodified `main`. The three packages this PR touches
pass in full.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):** not published; the investigation report behind the
field evidence can be shared on request.

## What actually bothered you

My human ran a four-hour incident investigation into why nine heartbeat messages produced
no work. What bothered him was not the stall — a quota window is ordinary and
self-healing — but that nothing noticed:

> "root cause of the BLINDNESS — why nothing noticed for 4.4 h, which the user considers
> the more important half"

Then, after a cross-agent review found the pane-scraping approach unsound:

> «вариант 2. Согласен, что api надежнее. Сделай отдельным PR. Текущий закроем.»
>
> ("Option 2. Agreed that the API is more reliable. Do it as a separate PR. We'll close the
> current one.")

He was right to push for it. Every layer had reported success — the timer, the send, the
exit code — because each one's success criterion stopped at "the text reached the
composer". The transcript was the only place that recorded what actually happened to the
turn, which is why the detection belongs there and not in the pane.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added usage-limit detection for supported coding sessions.
  * Sessions with exhausted plan usage now display a clear “usage limit” label.
  * Detection recognizes recent rate-limit responses while avoiding stale or unrelated session data.
  * Session status recovers when usage becomes available again.

* **Bug Fixes**
  * Improved handling of missing, incomplete, or unreadable session records without losing valid status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->