### PR TITLE
fix(hermes): make session status reporting work — env injection, turn-level hooks, correct turn-end mapping

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -128,7 +128,19 @@ func mapEventToStatus(event string) string {
 	case "onsessionstart":
 		return "waiting" // Hermes session started, waiting for first prompt
 	case "onsessionend":
-		return "dead" // Hermes session ended
+		// Hermes fires on_session_end at the end of EVERY run_conversation
+		// call — once per user message — NOT at process exit. It is the
+		// turn-end edge, and the only one an interrupted turn gets
+		// (post_llm_call is skipped when interrupted). Mapping it to dead
+		// showed an error ✕ after every completed turn.
+		return "waiting"
+	case "onsessionfinalize":
+		return "dead" // Hermes process exit / session reset — the real session end
+	case "preapirequest", "postapirequest":
+		// Per-API-call heartbeat within a turn: refreshes "running" so a
+		// long multi-step turn doesn't outlive the hook freshness window
+		// and fade to idle mid-work.
+		return "running"
 	case "userpromptsubmit", "beforesubmitprompt":
 		return "running" // user sent prompt, agent is processing
 	case "stop":

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -111,9 +111,19 @@ func mapEventToStatus(event string) string {
 		return "running" // Gemini received user input and is processing
 	case "afteragent":
 		return "waiting" // Gemini completed response, back to waiting
+	case "prellmcall":
+		return "running" // Hermes: turn started (LLM/tool-calling loop), agent is working
+	case "postllmcall":
+		return "waiting" // Hermes: turn complete, final response produced, back at prompt
 	case "pretoolcall", "pretooluse":
 		return "running" // executing a tool call
-	case "posttoolcall", "posttooluse", "posttoolusefailure":
+	case "posttoolcall":
+		// Hermes only (other tools' post-tool events normalize to
+		// "posttooluse"). Mid-turn a finished tool call means the LLM is
+		// generating the next step, not that the agent is back at the prompt;
+		// post_llm_call owns the turn-end waiting edge.
+		return "running"
+	case "posttooluse", "posttoolusefailure":
 		return "waiting" // finished a tool call, back at prompt
 	case "onsessionstart":
 		return "waiting" // Hermes session started, waiting for first prompt

--- a/cmd/agent-deck/hook_handler_test.go
+++ b/cmd/agent-deck/hook_handler_test.go
@@ -35,7 +35,16 @@ func TestMapEventToStatus(t *testing.T) {
 		// Claude/Cursor post-tool events keep mapping to waiting.
 		{"PostToolUse", "waiting"},
 		{"on_session_start", "waiting"},
-		{"on_session_end", "dead"},
+		// Hermes fires on_session_end after EVERY run_conversation call (once
+		// per user message), not at process exit — it is the turn-end edge,
+		// and the only one an interrupted turn gets (post_llm_call is skipped
+		// on interrupt). The real process-exit event is on_session_finalize.
+		{"on_session_end", "waiting"},
+		{"on_session_finalize", "dead"},
+		// Per-API-call heartbeat: keeps "running" fresh through long
+		// multi-step turns that would outlive the hook freshness window.
+		{"pre_api_request", "running"},
+		{"post_api_request", "running"},
 		{"subagent_stop", ""},
 		// Cursor Agent CLI hook events (camelCase)
 		{"sessionStart", "waiting"},

--- a/cmd/agent-deck/hook_handler_test.go
+++ b/cmd/agent-deck/hook_handler_test.go
@@ -26,8 +26,14 @@ func TestMapEventToStatus(t *testing.T) {
 		{"PreCompact", ""},
 		{"UnknownEvent", ""},
 		// Hermes shell hook events
+		{"pre_llm_call", "running"},
+		{"post_llm_call", "waiting"},
 		{"pre_tool_call", "running"},
-		{"post_tool_call", "waiting"},
+		// Hermes-only key: mid-turn, a finished tool call means the LLM keeps
+		// working; the turn-end waiting edge belongs to post_llm_call.
+		{"post_tool_call", "running"},
+		// Claude/Cursor post-tool events keep mapping to waiting.
+		{"PostToolUse", "waiting"},
 		{"on_session_start", "waiting"},
 		{"on_session_end", "dead"},
 		{"subagent_stop", ""},

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -164,6 +164,20 @@ func (i *Instance) buildHermesCommand(baseCommand string) string {
 
 	envPrefix := i.buildEnvSourceCommand()
 
+	// AGENTDECK_* env injection is required for the shell hooks Hermes spawns
+	// (pre_llm_call / pre_tool_call / … → `agent-deck hook-handler`) to identify
+	// this session. hook-handler reads AGENTDECK_INSTANCE_ID and silently no-ops
+	// without it, so without this prefix Hermes hooks never write a status file
+	// and the state indicator never updates. Injected BEFORE the custom-command
+	// passthrough so those sessions get it too (mirrors buildCodexCommand).
+	// Title is user-editable and could contain shell metacharacters ($(...),
+	// backticks, $VAR — all of which stay live inside %q's double quotes), so
+	// it needs shellescape's single quotes. ID is regex-constrained and Tool
+	// is guaranteed "hermes" by the guard above.
+	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%s AGENTDECK_TOOL=%s AGENTDECK_PROFILE=%s ",
+		i.ID, shellescape.Quote(i.Title), i.Tool, shellescape.Quote(sessionProfileEnvValue()))
+	envPrefix += agentdeckEnvPrefix
+
 	// Passthrough: custom command from CLI (not the bare name)
 	if baseCommand != "hermes" && baseCommand != "" {
 		return envPrefix + baseCommand

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 // hermesSessionIDPattern matches a hermes session ID (e.g. "20260720_143254_a3db50"):
@@ -211,6 +214,41 @@ func (i *Instance) buildHermesCommand(baseCommand string) string {
 	}
 
 	return envPrefix + cmd
+}
+
+// seedHermesHookBaseline records a synthetic "waiting" hook status, in memory
+// and in the persisted hook file, for a freshly (re)spawned hermes process
+// sitting at its prompt. Needed because hermes emits no lifecycle event at
+// process launch — on_session_start fires only at the first turn of a
+// brand-new session — so without this seed a restarted session has no hook
+// state at all until the user types. The first real hook event overwrites it.
+func (i *Instance) seedHermesHookBaseline() {
+	now := time.Now()
+	i.mu.Lock()
+	i.hookStatus = "waiting"
+	i.hookEvent = "agentdeck_restart_baseline"
+	i.hookLastUpdate = now
+	i.mu.Unlock()
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"status": "waiting",
+		"event":  "agentdeck_restart_baseline",
+		"ts":     now.Unix(),
+		"cwd":    i.EffectiveWorkingDir(),
+	})
+	if err != nil {
+		return
+	}
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0700); err != nil {
+		return
+	}
+	if err := atomicfile.WriteFile(filepath.Join(hooksDir, i.ID+".json"), payload, 0600); err != nil {
+		sessionLog.Debug("hermes_hook_baseline_write_failed",
+			slog.String("instance", i.ID),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 // IsHermesGatewayReachable performs a basic reachable check against the

--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -91,15 +91,25 @@ func isAgentDeckOwnedHook(cmd string) bool {
 // pre_tool_call/post_tool_call fire around each tool call nested inside that
 // bracket; both map to "running", because after a tool returns the LLM is
 // still generating the next step — post_llm_call owns the waiting edge.
+// pre_api_request/post_api_request fire around every LLM API call and act as
+// a mid-turn "running" heartbeat, so long multi-step turns don't outlive the
+// hook freshness window and fade to idle.
 // on_session_start provides an initial waiting state.
-// on_session_end signals the session is dead.
+// on_session_end fires after EVERY run_conversation call (once per user
+// message), so it is a turn-end "waiting" edge — the only one an interrupted
+// turn gets, since post_llm_call is skipped on interrupt.
+// on_session_finalize is the real session end (CLI exit//reset, gateway
+// session eviction) and maps to "dead".
 var hermesHookEvents = []string{
 	"pre_llm_call",
 	"post_llm_call",
+	"pre_api_request",
+	"post_api_request",
 	"pre_tool_call",
 	"post_tool_call",
 	"on_session_start",
 	"on_session_end",
+	"on_session_finalize",
 }
 
 // GetHermesConfigDir returns the Hermes config directory (~/.hermes).

--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -82,10 +82,20 @@ func isAgentDeckOwnedHook(cmd string) bool {
 }
 
 // hermesHookEvents are the Hermes lifecycle events we subscribe to.
-// pre_tool_call/post_tool_call bracket each tool call (running/waiting).
+// pre_llm_call/post_llm_call bracket the WHOLE turn (running/waiting): per the
+// Hermes docs, pre_llm_call fires once per turn before the tool-calling loop
+// begins and post_llm_call fires once per turn after the final response is
+// produced. Without these, a turn that generates text without calling a tool
+// (the common case) never flips to "running" — the indicator was stuck on the
+// prior post_tool_call/on_session_start "waiting" state while Hermes was busy.
+// pre_tool_call/post_tool_call fire around each tool call nested inside that
+// bracket; both map to "running", because after a tool returns the LLM is
+// still generating the next step — post_llm_call owns the waiting edge.
 // on_session_start provides an initial waiting state.
 // on_session_end signals the session is dead.
 var hermesHookEvents = []string{
+	"pre_llm_call",
+	"post_llm_call",
 	"pre_tool_call",
 	"post_tool_call",
 	"on_session_start",

--- a/internal/session/hermes_hooks_test.go
+++ b/internal/session/hermes_hooks_test.go
@@ -59,7 +59,7 @@ func TestInjectHermesHooks_AllEventsPresent(t *testing.T) {
 		t.Fatal("no hooks section in config.yaml")
 	}
 
-	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"} {
+	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_api_request", "post_api_request", "pre_tool_call", "post_tool_call", "on_session_start", "on_session_end", "on_session_finalize"} {
 		entries, _ := hooksSection[event].([]interface{})
 		found := false
 		for _, e := range entries {
@@ -118,7 +118,7 @@ func TestInjectHermesHooks_UpgradesLegacyInstall(t *testing.T) {
 		t.Fatal("no hooks section in config.yaml")
 	}
 
-	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"} {
+	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_api_request", "post_api_request", "pre_tool_call", "post_tool_call", "on_session_start", "on_session_end", "on_session_finalize"} {
 		entries, _ := hooksSection[event].([]interface{})
 		count := 0
 		for _, e := range entries {

--- a/internal/session/hermes_hooks_test.go
+++ b/internal/session/hermes_hooks_test.go
@@ -59,7 +59,7 @@ func TestInjectHermesHooks_AllEventsPresent(t *testing.T) {
 		t.Fatal("no hooks section in config.yaml")
 	}
 
-	for _, event := range []string{"pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"} {
+	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"} {
 		entries, _ := hooksSection[event].([]interface{})
 		found := false
 		for _, e := range entries {
@@ -71,6 +71,69 @@ func TestInjectHermesHooks_AllEventsPresent(t *testing.T) {
 		if !found {
 			t.Errorf("event %q missing agent-deck hook-handler entry", event)
 		}
+	}
+}
+
+// TestInjectHermesHooks_UpgradesLegacyInstall pins the self-heal promise: an
+// install predating the pre/post_llm_call events (only the original four) must
+// gain exactly the two missing entries on the next inject, without duplicating
+// the existing agent-deck entries or dropping user hooks. This must keep
+// working even if InjectHermesHooks ever grows an "already installed"
+// fast path keyed on something weaker than the full event set.
+func TestInjectHermesHooks_UpgradesLegacyInstall(t *testing.T) {
+	dir := t.TempDir()
+	legacy := []byte(`hooks:
+  pre_tool_call:
+    - command: agent-deck hook-handler
+    - command: /usr/local/bin/my-hook.sh
+  post_tool_call:
+    - command: agent-deck hook-handler
+  on_session_start:
+    - command: agent-deck hook-handler
+  on_session_end:
+    - command: agent-deck hook-handler
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), legacy, 0644); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+
+	installed, err := session.InjectHermesHooks(dir)
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if !installed {
+		t.Fatal("InjectHermesHooks() = false, want true (legacy install lacks the llm_call events)")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse config.yaml: %v", err)
+	}
+	hooksSection, _ := raw["hooks"].(map[string]interface{})
+	if hooksSection == nil {
+		t.Fatal("no hooks section in config.yaml")
+	}
+
+	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"} {
+		entries, _ := hooksSection[event].([]interface{})
+		count := 0
+		for _, e := range entries {
+			em, _ := e.(map[string]interface{})
+			if cmd, _ := em["command"].(string); strings.Contains(cmd, "agent-deck hook-handler") {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("event %q has %d agent-deck entries, want exactly 1", event, count)
+		}
+	}
+
+	if !strings.Contains(string(data), "/usr/local/bin/my-hook.sh") {
+		t.Error("user hook was dropped during upgrade")
 	}
 }
 

--- a/internal/session/hermes_test.go
+++ b/internal/session/hermes_test.go
@@ -250,6 +250,46 @@ func TestBuildHermesCommand_Passthrough(t *testing.T) {
 	}
 }
 
+// TestBuildHermesCommand_InjectsInstanceIDEnv pins the fix for the state
+// indicator: the shell hooks Hermes spawns run `agent-deck hook-handler`, which
+// reads AGENTDECK_INSTANCE_ID and silently no-ops without it. Both the default
+// and custom-command (passthrough) launch paths must export it.
+func TestBuildHermesCommand_InjectsInstanceIDEnv(t *testing.T) {
+	restore := resetUserConfigCache(t, &UserConfig{})
+	defer restore()
+
+	inst := &Instance{ID: "abc-123", Title: "dev", Tool: "hermes"}
+
+	cmd := inst.buildHermesCommand("hermes")
+	if !strings.Contains(cmd, "AGENTDECK_INSTANCE_ID=abc-123") {
+		t.Errorf("buildHermesCommand() = %q, want it to export AGENTDECK_INSTANCE_ID", cmd)
+	}
+	// VAR=... assignments only apply to the command they precede, so the
+	// prefix must end up before the hermes command word, not after it.
+	if !strings.HasSuffix(cmd, " hermes") {
+		t.Errorf("buildHermesCommand() = %q, want env assignments to prefix the hermes command word", cmd)
+	}
+	if pass := inst.buildHermesCommand("hermes --special-flag"); !strings.Contains(pass, "AGENTDECK_INSTANCE_ID=abc-123") {
+		t.Errorf("buildHermesCommand passthrough = %q, want it to export AGENTDECK_INSTANCE_ID", pass)
+	}
+
+	// Title is user-editable text landing in an executed command string; $ and
+	// backticks stay live inside double quotes, so it must be single-quoted to
+	// reach the hook env byte-for-byte instead of being expanded or executed.
+	hostile := &Instance{ID: "abc-123", Title: "check `date` $(id) $HOME", Tool: "hermes"}
+	if cmd := hostile.buildHermesCommand("hermes"); !strings.Contains(cmd, "AGENTDECK_TITLE='check `date` $(id) $HOME'") {
+		t.Errorf("buildHermesCommand() = %q, want the title single-quoted verbatim", cmd)
+	}
+
+	// The env prefix must compose with --resume (both features prepend/append
+	// around the same base command).
+	resumed := &Instance{ID: "abc-123", Title: "dev", Tool: "hermes", HermesSessionID: "20260720_143254_a3db50"}
+	if cmd := resumed.buildHermesCommand("hermes"); !strings.Contains(cmd, "AGENTDECK_INSTANCE_ID=abc-123") ||
+		!strings.HasSuffix(cmd, "hermes --resume 20260720_143254_a3db50") {
+		t.Errorf("buildHermesCommand() = %q, want env prefix and trailing --resume together", cmd)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Gateway health check tests
 // ---------------------------------------------------------------------------

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3517,6 +3517,11 @@ func (i *Instance) Start() error {
 	case i.Tool == "cursor":
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
+		// Hermes emits no lifecycle event at process launch (on_session_start
+		// fires only at the first turn), so seed the "waiting" baseline the
+		// prompt represents — otherwise a fresh session has no status icon
+		// until the user types.
+		i.seedHermesHookBaseline()
 		command = i.buildHermesCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
@@ -3786,6 +3791,11 @@ func (i *Instance) StartWithMessage(message string) error {
 	case i.Tool == "cursor":
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
+		// Hermes emits no lifecycle event at process launch (on_session_start
+		// fires only at the first turn), so seed the "waiting" baseline the
+		// prompt represents — otherwise a fresh session has no status icon
+		// until the user types.
+		i.seedHermesHookBaseline()
 		command = i.buildHermesCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
@@ -7018,6 +7028,16 @@ func (i *Instance) restart(env map[string]string) error {
 		// buildHermesCommand starts fresh instead of resuming a dead ID forever.
 		// Scoped to the working dir to avoid picking up an unrelated session.
 		i.HermesSessionID = captureHermesSessionID(i.EffectiveWorkingDir())
+		// Drop any stale hook state from the previous process, then seed a
+		// synthetic "waiting" baseline. Hermes fires on_session_start only at
+		// the FIRST TURN of a brand-new session (not at process launch), so
+		// after a restart NOTHING writes a hook status until the user types:
+		// without the clear a pre-restart on_session_finalize "dead" shows an
+		// error ✕ for the whole freshness window, and without the seed the
+		// session shows no state at all. The freshly respawned process sits at
+		// its prompt, which is exactly "waiting".
+		i.ClearHookStatus()
+		i.seedHermesHookBaseline()
 		command = i.buildHermesCommand(i.Command)
 	} else {
 		// Route to appropriate command builder based on tool


### PR DESCRIPTION
## What problem does this solve?

The status indicator of a Hermes session never reflects what the agent is doing: it stays empty while the agent is generating a response, and flips to an error ✕ the moment a turn completes and the agent goes idle. In practice a Hermes session's icon is either blank or wrongly red almost all of the time.

Three stacked root causes, found by live-tracing the hook status file during real turns:

1. `buildHermesCommand` never injected the `AGENTDECK_*` env prefix that the Claude and Codex builders add, so the shell hooks Hermes spawns (`agent-deck hook-handler`) read an empty instance id and silently no-op'd — the hook set agent-deck itself installs into `~/.hermes/config.yaml` ran and did nothing.
2. The subscribed hook set had no turn-level events: a turn that generates text without calling a tool (the common case) never flipped to "running".
3. Hermes fires `on_session_end` at the end of **every** `run_conversation()` call — once per user message, not at process exit (`agent/turn_finalizer.py` invokes it unconditionally, milliseconds after `post_llm_call`, clobbering its "waiting" write). Mapping it to `dead` painted an error ✕ after every completed turn.

## Why this change

Three commits, one per root cause:

- **`fix(hermes): show running status during LLM generation`** — subscribe Hermes' turn-level `pre_llm_call`/`post_llm_call` events (per the Hermes docs they fire once per turn, bracketing the tool-calling loop) and map pre→running, post→waiting. With the turn-end edge owned by `post_llm_call`, Hermes' `post_tool_call` is remapped to running: mid-turn, a finished tool call means the LLM is generating the next step. (`post_tool_call` normalizes to a Hermes-only key; Claude/Cursor post-tool mappings are untouched.) Existing installs self-heal via the merge path, pinned by `TestInjectHermesHooks_UpgradesLegacyInstall`.
- **`fix(hermes): export AGENTDECK_INSTANCE_ID so Hermes hooks report status`** — inject the `AGENTDECK_INSTANCE_ID/TITLE/TOOL/PROFILE` prefix before the custom-command passthrough, mirroring `buildCodexCommand`. Title is user-editable text landing in an executed command string, so it is `shellescape`-single-quoted rather than `%q`'d (`$` and backticks stay live inside double quotes — the same hazard `buildCodexForkCommandForTarget` already guards against).
- **`fix(hermes): map turn-end events correctly; add per-API-call running heartbeat`** — `on_session_end` → waiting (it is the reliable turn-end edge, and the only one an interrupted turn gets, since `post_llm_call` fires only when a final response exists and the turn was not interrupted); subscribe `on_session_finalize` → dead (the real session end: CLI atexit and `/reset`, gateway session eviction); subscribe `pre/post_api_request` → running as a per-API-call heartbeat so multi-step turns longer than the 2-minute hook freshness window don't fade to idle mid-work. Because Hermes emits no lifecycle event at process launch (`on_session_start` fires only at the first turn of a brand-new session), launch/restart now clears stale hook state and seeds a synthetic "waiting" baseline — without it a restarted session either kept a stale pre-restart "dead" (✕) or had no status icon at all until the user typed.

The three new events are auto-injected into `~/.hermes/config.yaml` on next startup; Hermes asks its one-time consent per new (event, command) pair.

## User impact

Hermes sessions now show correct status transitions: running (green) while the agent works — LLM generation and tool calls alike — waiting at the prompt after each turn, and dead only when the Hermes process actually exits or the session is reset. Restarted sessions show "waiting" immediately instead of a stale ✕ or nothing.

## Evidence

Live capture of the hook status file (`~/.agent-deck/hooks/<instance>.json`) during a real tool-using turn, before → after.

Before (no-tool turn; `post_llm_call`'s waiting is clobbered milliseconds later, final state of every turn is dead → ✕):

    21:09:39 {"status":"running","event":"pre_llm_call",...}
    21:09:48 {"status":"dead","event":"on_session_end",...}   # process still alive, agent idle at prompt

After (tool-using turn):

    21:19:28 {"status":"running","event":"pre_api_request",...}
    21:19:34 {"status":"running","event":"post_api_request",...}
    21:19:34 {"status":"running","event":"pre_tool_call",...}
    21:19:35 {"status":"running","event":"post_tool_call",...}
    21:19:35 {"status":"running","event":"pre_api_request",...}   # heartbeat, 2nd API call
    21:19:42 {"status":"running","event":"post_api_request",...}
    21:19:43 {"status":"waiting","event":"on_session_end",...}    # turn end: waiting, not ✕

Real exit (`/exit`) now produces the dead state from the right event:

    21:20:11 {"status":"dead","event":"on_session_finalize",...}

Restart baseline (immediately after `agent-deck session restart`, before any user input):

    {"status":"waiting","event":"agentdeck_restart_baseline",...}
    $ agent-deck session show <id>   →   Status: ◐ waiting

The `on_session_end`-fires-per-turn semantics were verified in the Hermes source (`agent/turn_finalizer.py`: fired "at the very end of every run_conversation call"; its own comment notes `run_conversation()` is called once per user message), and `hermes sessions list`-based resume (#1693) still works — the env prefix composes with `--resume` (covered by test assertions).

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):**

## What actually bothered you

My human runs Hermes sessions inside agent-deck and asked (translated from Hungarian): "Unfortunately it's not right — while the Hermes agent is working the indicator stays empty, and at one point it switched to ✕ even though it had just gone idle. Analyze the bug." After the fix cycle: "I restarted the TUI, now it's good — open the PR."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added broader lifecycle tracking for Hermes sessions, including LLM calls, API requests, tool calls, and finalization.
  - Hermes processes now receive instance, title, tool, and profile context automatically.
  - Legacy Hermes configurations are upgraded with missing lifecycle hooks while preserving existing custom hooks.

- **Bug Fixes**
  - Session restarts now reset stale terminal states and correctly begin in a waiting state.
  - Improved handling of session completion and API activity status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->