### PR TITLE
fix(security): path containment in skills catalog + log-injection sweep

### DIFF
--- a/internal/logging/sanitize.go
+++ b/internal/logging/sanitize.go
@@ -1,0 +1,39 @@
+package logging
+
+import "strings"
+
+// SanitizeValue strips characters that let an untrusted value forge fake log
+// lines or otherwise corrupt structured/text log output (CRLF-style log
+// injection, CodeQL go/log-injection). Newlines, carriage returns, and other
+// C0 control characters are replaced with a visible escape marker so the
+// original value stays legible without letting it inject new record
+// boundaries. Call this on any user- or session-supplied string (path,
+// title, session ID, env value, ...) before passing it to a log call.
+func SanitizeValue(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	dirty := false
+	for _, r := range s {
+		switch {
+		case r == '\n':
+			dirty = true
+			b.WriteString(`\n`)
+		case r == '\r':
+			dirty = true
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteByte('\t')
+		case r < 0x20 || r == 0x7f:
+			dirty = true
+			b.WriteRune(0xfffd)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if !dirty {
+		return s
+	}
+	return b.String()
+}

--- a/internal/logging/sanitize_test.go
+++ b/internal/logging/sanitize_test.go
@@ -1,0 +1,31 @@
+package logging
+
+import "testing"
+
+func TestSanitizeValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		want  string
+		dirty bool // sanity check: dirty input must not equal itself after sanitizing
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "clean", in: "my-session-42", want: "my-session-42"},
+		{name: "newline", in: "evil\nfake_log_line=1", want: `evil\nfake_log_line=1`, dirty: true},
+		{name: "carriage_return", in: "evil\r\ninjected", want: `evil\r\ninjected`, dirty: true},
+		{name: "tab_preserved", in: "col1\tcol2", want: "col1\tcol2"},
+		{name: "control_char", in: "bad\x00value", want: "bad�value", dirty: true},
+		{name: "unicode_preserved", in: "sess-éè", want: "sess-éè"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeValue(tc.in)
+			if got != tc.want {
+				t.Fatalf("SanitizeValue(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if tc.dirty && got == tc.in {
+				t.Fatalf("SanitizeValue(%q) left the injected control character untouched", tc.in)
+			}
+		})
+	}
+}

--- a/internal/session/issue1771_path_injection_test.go
+++ b/internal/session/issue1771_path_injection_test.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Security: skills-catalog read/write path containment (CodeQL go/path-injection,
+// issue #1771). safeRemoveManagedTarget already gated os.RemoveAll behind
+// managedProjectSkillsDirForTarget + isContainedIn (Audit M3); that guard was
+// missing on the os.Stat/os.Lstat/materializeSkill sinks in attachSkillCandidate
+// and ApplyProjectSkills, which resolved a manifest- or candidate-derived
+// TargetPath via the unchecked resolveTargetPath and used the result directly.
+// resolveContainedTargetPath closes that gap by applying the same containment
+// check to every sink, not just removal.
+
+func TestResolveContainedTargetPath_RefusesTraversalEscape(t *testing.T) {
+	base := t.TempDir()
+	projectPath := filepath.Join(base, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	if _, err := resolveContainedTargetPath(projectPath, filepath.Join("..", "evil")); err == nil {
+		t.Fatalf("expected refusal for traversal escape, got nil error")
+	}
+}
+
+func TestResolveContainedTargetPath_RefusesAbsoluteNonManagedPath(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+
+	if _, err := resolveContainedTargetPath(projectPath, outside); err == nil {
+		t.Fatalf("expected refusal for non-managed absolute path, got nil error")
+	}
+}
+
+func TestResolveContainedTargetPath_AllowsManagedPath(t *testing.T) {
+	projectPath := t.TempDir()
+	skillDir, ok := GetProjectSkillsDir("claude")
+	if !ok {
+		t.Fatalf("expected a managed skills dir for claude")
+	}
+	targetRel := buildProjectSkillTargetPath(skillDir, "my-skill")
+
+	got, err := resolveContainedTargetPath(projectPath, targetRel)
+	if err != nil {
+		t.Fatalf("expected managed path to be allowed, got: %v", err)
+	}
+	want := resolveTargetPath(projectPath, targetRel)
+	if got != want {
+		t.Fatalf("resolveContainedTargetPath = %q, want %q", got, want)
+	}
+}
+
+// TestAttachSkillCandidate_RefusesTamperedManifestTargetOnMigration proves the
+// migration codepath in attachSkillCandidate (an existing manifest entry whose
+// TargetPath no longer matches the tool's skill dir) refuses to Stat/Lstat/
+// materialize against a manifest TargetPath that escapes the project root,
+// instead of resolving it unchecked the way it did before #1771.
+func TestAttachSkillCandidate_RefusesTamperedManifestTargetOnMigration(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	sourcePath, err := os.MkdirTemp("", "agentdeck-1771-source-*")
+	if err != nil {
+		t.Fatalf("failed to create source path: %v", err)
+	}
+	defer os.RemoveAll(sourcePath)
+	writeSkillDir(t, sourcePath, "lint", "lint", "Linting best practices")
+
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"local": {Path: sourcePath, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath, err := os.MkdirTemp("", "agentdeck-1771-project-*")
+	if err != nil {
+		t.Fatalf("failed to create project path: %v", err)
+	}
+	defer os.RemoveAll(projectPath)
+
+	// Seed a manifest as if it had been tampered with (or corrupted) to point
+	// its TargetPath outside any managed project-skills dir.
+	tampered := ProjectSkillAttachment{
+		ID:         buildSkillID("local", "lint"),
+		Name:       "lint",
+		Source:     "local",
+		SourcePath: filepath.Join(sourcePath, "lint"),
+		EntryName:  "lint",
+		TargetPath: filepath.Join("..", "evil"),
+		Mode:       "copy",
+	}
+	if err := SaveProjectSkillsManifest(projectPath, &ProjectSkillsManifest{
+		Skills: []ProjectSkillAttachment{tampered},
+	}); err != nil {
+		t.Fatalf("SaveProjectSkillsManifest failed: %v", err)
+	}
+
+	if _, err := AttachSkillToProject(projectPath, "claude", "lint", "local"); err == nil {
+		t.Fatalf("expected AttachSkillToProject to refuse a tampered out-of-tree TargetPath")
+	}
+}

--- a/internal/session/opencode_mcp.go
+++ b/internal/session/opencode_mcp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
 
 // opencodeMCPServer represents one server entry in opencode.json under "mcp".
@@ -225,7 +226,7 @@ func buildOpenCodeMCPServers(enabledNames []string) map[string]opencodeMCPServer
 // OpenCode's local config uses {"mcp": {"name": {"type":"local","command":[...]}}} format.
 func WriteOpenCodeProjectMCP(projectPath string, enabledNames []string) error {
 	if !GetManageMCPJson() {
-		mcpCatLog.Debug("opencode_mcp_json_management_disabled", "path", projectPath)
+		mcpCatLog.Debug("opencode_mcp_json_management_disabled", "path", logging.SanitizeValue(projectPath))
 		return nil
 	}
 	if projectPath == "" {

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -944,27 +944,44 @@ func resolveTargetPath(projectPath, targetPath string) string {
 	return filepath.Clean(filepath.Join(projectPath, filepath.FromSlash(targetPath)))
 }
 
+// resolveContainedTargetPath resolves targetRel against projectPath and REFUSES
+// any result that is not contained in a managed project-skills dir — the same
+// containment guard #1200 added for worktree deletion (Audit M3), applied here
+// to every filesystem sink (Stat/Lstat/symlink/copy) that consumes a
+// manifest- or candidate-derived path, not just os.RemoveAll. A non-managed,
+// absolute, or "../"-escaping target returns an error instead of a path, so
+// CodeQL's go/path-injection sinks in attachSkillCandidate and
+// ApplyProjectSkills only ever see a path proven to sit inside one of
+// knownProjectSkillsDirs(). Callers must check the error and must not fall
+// back to the raw, unchecked resolveTargetPath for the same operation.
+func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
+	targetPath := resolveTargetPath(projectPath, targetRel)
+	skillDir, ok := managedProjectSkillsDirForTarget(targetRel)
+	if !ok {
+		return "", fmt.Errorf("refusing to use path outside managed project skills dirs: %s", targetPath)
+	}
+	base := filepath.Join(projectPath, filepath.FromSlash(skillDir))
+	if !isContainedIn(base, targetPath) {
+		return "", fmt.Errorf("refusing to use path outside project skills dir: %s", targetPath)
+	}
+	return targetPath, nil
+}
+
 func removeAttachmentTarget(projectPath string, attachment ProjectSkillAttachment) error {
 	return safeRemoveManagedTarget(projectPath, attachment.TargetPath)
 }
 
 // safeRemoveManagedTarget removes targetRel (resolved against projectPath) only
 // when it is contained in a managed project-skills dir, then RemoveAll's it.
-// A non-managed, absolute, or "../"-escaping target is REFUSED and never removed
-// — the same containment guard #1200 added for worktree deletion. Every
-// os.RemoveAll that operates on a manifest-derived TargetPath (attach detach +
-// the migration branches in attachSkillCandidate / reconcileProjectSkills) must
-// route through here so a tampered manifest can't trigger deletion outside the
-// project skills dir. Audit M3.
+// A non-managed, absolute, or "../"-escaping target is REFUSED and never removed.
+// Every os.RemoveAll that operates on a manifest-derived TargetPath (attach
+// detach + the migration branches in attachSkillCandidate / reconcileProjectSkills)
+// must route through here so a tampered manifest can't trigger deletion outside
+// the project skills dir. Audit M3.
 func safeRemoveManagedTarget(projectPath, targetRel string) error {
-	targetPath := resolveTargetPath(projectPath, targetRel)
-	skillDir, ok := managedProjectSkillsDirForTarget(targetRel)
-	if !ok {
-		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %s", targetPath)
-	}
-	base := filepath.Join(projectPath, filepath.FromSlash(skillDir))
-	if !isContainedIn(base, targetPath) {
-		return fmt.Errorf("refusing to remove path outside project skills dir: %s", targetPath)
+	targetPath, err := resolveContainedTargetPath(projectPath, targetRel)
+	if err != nil {
+		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %w", err)
 	}
 	return os.RemoveAll(targetPath)
 }
@@ -1065,8 +1082,14 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		if !targetPathUsesSkillDir(existing.TargetPath, expectedDir) {
 			desiredTargetRel = expectedTargetRel
 		}
-		desiredTargetPath := resolveTargetPath(projectPath, desiredTargetRel)
-		currentTargetPath := resolveTargetPath(projectPath, existing.TargetPath)
+		desiredTargetPath, err := resolveContainedTargetPath(projectPath, desiredTargetRel)
+		if err != nil {
+			return nil, err
+		}
+		currentTargetPath, err := resolveContainedTargetPath(projectPath, existing.TargetPath)
+		if err != nil {
+			return nil, err
+		}
 
 		for _, other := range manifest.Skills {
 			if normalizeSkillToken(skillIDForAttachment(other)) == normalizeSkillToken(candidateID) {
@@ -1150,7 +1173,10 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 	}
 
 	attachment := buildAttachment(tool, candidate, "")
-	targetPath := resolveTargetPath(projectPath, attachment.TargetPath)
+	targetPath, err := resolveContainedTargetPath(projectPath, attachment.TargetPath)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, existing := range manifest.Skills {
 		if normalizeSkillToken(existing.TargetPath) == normalizeSkillToken(attachment.TargetPath) {
@@ -1305,11 +1331,17 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 	for _, id := range orderedIDs {
 		targetRel := desiredTargetByID[id]
 		targetKey := normalizeSkillToken(targetRel)
-		targetPath := resolveTargetPath(projectPath, targetRel)
+		targetPath, err := resolveContainedTargetPath(projectPath, targetRel)
+		if err != nil {
+			return err
+		}
 
 		currentTargetPath := ""
 		if current, exists := currentByID[id]; exists {
-			currentTargetPath = resolveTargetPath(projectPath, current.TargetPath)
+			currentTargetPath, err = resolveContainedTargetPath(projectPath, current.TargetPath)
+			if err != nil {
+				return err
+			}
 		}
 
 		if existingOwner, exists := managedTargetOwner[targetKey]; exists && existingOwner != id {
@@ -1348,8 +1380,14 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		candidate := desiredByID[id]
 		desiredTargetRel := desiredTargetByID[id]
 		if current, exists := currentByID[id]; exists {
-			currentTargetPath := resolveTargetPath(projectPath, current.TargetPath)
-			desiredTargetPath := resolveTargetPath(projectPath, desiredTargetRel)
+			currentTargetPath, err := resolveContainedTargetPath(projectPath, current.TargetPath)
+			if err != nil {
+				return err
+			}
+			desiredTargetPath, err := resolveContainedTargetPath(projectPath, desiredTargetRel)
+			if err != nil {
+				return err
+			}
 			if currentTargetPath != desiredTargetPath {
 				sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, currentTargetPath)
 				if err != nil {
@@ -1408,7 +1446,10 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		}
 
 		attachment := buildAttachment(tool, candidate, "")
-		targetPath := resolveTargetPath(projectPath, attachment.TargetPath)
+		targetPath, err := resolveContainedTargetPath(projectPath, attachment.TargetPath)
+		if err != nil {
+			return err
+		}
 		sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, "")
 		if err != nil {
 			return err

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1829,10 +1829,10 @@ func KillSessionsWithEnvValue(envKey, envValue, excludeName string) {
 		if idx := strings.IndexByte(line, '='); idx >= 0 {
 			if line[idx+1:] == envValue {
 				statusLog.Warn("killing_duplicate_session",
-					slog.String("session", name),
-					slog.String("env_key", envKey),
-					slog.String("env_value", envValue),
-					slog.String("kept", excludeName))
+					slog.String("session", logging.SanitizeValue(name)),
+					slog.String("env_key", logging.SanitizeValue(envKey)),
+					slog.String("env_value", logging.SanitizeValue(envValue)),
+					slog.String("kept", logging.SanitizeValue(excludeName)))
 				// Bounded — see tmuxMutationTimeout. Best-effort already (error
 				// discarded), so a timeout changes nothing but the wait.
 				_ = runBoundedMutation(socket, "kill-session", "-t", name)

--- a/internal/web/handlers_ws.go
+++ b/internal/web/handlers_ws.go
@@ -204,16 +204,19 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				logging.ForComponent(logging.CompWeb).Warn("websocket_keepalive_timeout",
 					slog.String("session_id", logSessionID),
-					slog.String("error", err.Error()))
+					slog.String("error", logging.SanitizeValue(err.Error())))
 			} else if websocket.IsUnexpectedCloseError(
 				err,
 				websocket.CloseNormalClosure,
 				websocket.CloseGoingAway,
 				websocket.CloseNoStatusReceived,
 			) {
+				// err may be a *websocket.CloseError whose Text is the
+				// peer-supplied close reason (attacker-controlled) — sanitize
+				// it same as logSessionID above (go/log-injection).
 				logging.ForComponent(logging.CompWeb).Warn("websocket_closed_unexpectedly",
 					slog.String("session_id", logSessionID),
-					slog.String("error", err.Error()))
+					slog.String("error", logging.SanitizeValue(err.Error())))
 			}
 			return
 		}

--- a/internal/web/handlers_ws.go
+++ b/internal/web/handlers_ws.go
@@ -79,6 +79,10 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusBadRequest, "INVALID_REQUEST", "session id is required")
 		return
 	}
+	// sessionID is attacker-controlled (raw URL path segment); every log call
+	// below must use this sanitized copy, never sessionID itself, so a crafted
+	// CRLF/control-char id can't forge fake log lines (go/log-injection).
+	logSessionID := logging.SanitizeValue(sessionID)
 
 	snapshot, err := s.menuData.LoadMenuSnapshot()
 	if err != nil {
@@ -156,7 +160,7 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 		bridge, err = newTmuxPTYBridge(menuSession.TmuxSession, menuSession.TmuxSocketName, sessionID, writer)
 		if err != nil {
 			logging.ForComponent(logging.CompWeb).Error("terminal_attach_failed",
-				slog.String("session_id", sessionID),
+				slog.String("session_id", logSessionID),
 				slog.String("tmux_session", menuSession.TmuxSession),
 				slog.String("error", err.Error()))
 			code := "TERMINAL_ATTACH_FAILED"
@@ -199,7 +203,7 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				logging.ForComponent(logging.CompWeb).Warn("websocket_keepalive_timeout",
-					slog.String("session_id", sessionID),
+					slog.String("session_id", logSessionID),
 					slog.String("error", err.Error()))
 			} else if websocket.IsUnexpectedCloseError(
 				err,
@@ -208,7 +212,7 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 				websocket.CloseNoStatusReceived,
 			) {
 				logging.ForComponent(logging.CompWeb).Warn("websocket_closed_unexpectedly",
-					slog.String("session_id", sessionID),
+					slog.String("session_id", logSessionID),
 					slog.String("error", err.Error()))
 			}
 			return


### PR DESCRIPTION
## What

Fixes the three HIGH CodeQL `go/path-injection` alerts in `internal/session/skills_catalog.go` (reported around lines ~1080, ~1115, ~1161) and sweeps the four log-injection sites called out alongside them.

### Path containment (the HIGH alerts)

`resolveTargetPath()` resolved a manifest- or candidate-derived `TargetPath` with only `filepath.Clean`/`Join`, and that path then reached `os.Stat`/`os.Lstat` and `materializeSkill`'s symlink/copy sinks with no containment check. `safeRemoveManagedTarget` already confined `os.RemoveAll` to a managed project-skills dir (Audit M3, #1200) — that guard just wasn't applied anywhere else.

Added `resolveContainedTargetPath(projectPath, targetRel)`, which resolves the path and then requires it to sit inside one of the known managed project-skills dirs (the same `managedProjectSkillsDirForTarget` + `isContainedIn` check `safeRemoveManagedTarget` already used). Every read/write sink in `attachSkillCandidate` and `ApplyProjectSkills` that previously called the unchecked `resolveTargetPath` now goes through this instead and returns an error rather than touching the filesystem when a manifest entry is tampered or corrupted. `safeRemoveManagedTarget` itself was refactored to share the same helper.

### Log-injection sweep

Sanitized the four sites named in the issue (raw newline/control-char values could forge fake log lines):
- `internal/web/handlers_ws.go` — the WebSocket session ID comes straight off the URL path; now every log call in the handler uses a sanitized copy.
- `internal/tmux/tmux.go` — `killing_duplicate_session` logs env-derived session/env values.
- `internal/session/opencode_mcp.go` — the OpenCode project-path debug log.

Added `logging.SanitizeValue` (new `internal/logging/sanitize.go`) that escapes `\n`/`\r` and strips other C0 control characters, for reuse at future sites.

## Testing

- Sandboxed `go build ./...` and `go vet ./...` (isolated `HOME`/XDG, no writes to real config) — both clean.
- New tests: `internal/logging/sanitize_test.go` (sanitizer behavior) and `internal/session/issue1771_path_injection_test.go` (containment refuses traversal/absolute escapes, allows managed paths, and proves the previously-vulnerable migration codepath in `attachSkillCandidate` now refuses a tampered manifest `TargetPath`). Existing `issue1206_skills_migration_removeall_test.go` coverage for `safeRemoveManagedTarget` continues to pass through the refactor.

Closes #1771


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened protection against path traversal and unmanaged filesystem targets during skill operations and migration.
  * Sanitized potentially unsafe values before including them in application logs, including session identifiers, paths, and environment details.

* **Bug Fixes**
  * Prevented unsafe paths from being used during attachment, reconciliation, cleanup, and migration workflows.

* **Tests**
  * Added coverage for log sanitization and security regressions involving traversal, absolute paths, and tampered targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->