### PR TITLE
fix(security): resolve symlinks in skills-dir containment check

### DIFF
--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -668,12 +668,22 @@ func TestTargetExists_DanglingPoolLinkCountsAbsent(t *testing.T) {
 	defer p.Close()
 
 	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint")
-	exists, err := p.targetExists(targetRel)
+	exists, err := p.targetExists(targetRel, filepath.Join(poolRoot, "gone"))
 	if err != nil {
 		t.Fatalf("targetExists failed: %v", err)
 	}
 	if exists {
-		t.Fatalf("dangling pool link should count as absent")
+		t.Fatalf("dangling link to this attachment's own source should count as absent")
+	}
+
+	// A dangling link into an UNRELATED pool entry is a foreign replacement:
+	// present, so the loadout layer reports it instead of overwriting it.
+	exists, err = p.targetExists(targetRel, filepath.Join(poolRoot, "lint"))
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatalf("dangling link to an unrelated pool entry must count as present")
 	}
 
 	// A live pool link counts as present.
@@ -683,7 +693,7 @@ func TestTargetExists_DanglingPoolLinkCountsAbsent(t *testing.T) {
 	if err := os.Symlink(filepath.Join(poolRoot, "lint"), filepath.Join(skillsDir, "lint")); err != nil {
 		t.Fatalf("symlink live pool entry: %v", err)
 	}
-	exists, err = p.targetExists(targetRel)
+	exists, err = p.targetExists(targetRel, filepath.Join(poolRoot, "lint"))
 	if err != nil {
 		t.Fatalf("targetExists failed: %v", err)
 	}
@@ -713,7 +723,7 @@ func TestTargetExists_ForeignResolvableLinkCountsPresent(t *testing.T) {
 	}
 	defer p.Close()
 
-	exists, err := p.targetExists(buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint"))
+	exists, err := p.targetExists(buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint"), "")
 	if err != nil {
 		t.Fatalf("targetExists failed: %v", err)
 	}
@@ -757,5 +767,82 @@ func TestMaterialize_RefusesPoolLinkPointingOutsideRegisteredRoots(t *testing.T)
 	}
 	if _, err := os.Stat(filepath.Join(projectPath, ".agents", "skills", "lint")); !os.IsNotExist(err) {
 		t.Fatalf("nothing should have been materialized, stat err = %v", err)
+	}
+}
+
+// TestCopyIntoRoot_RefusesToTruncateSquattedDestination proves the copy path
+// creates its leaves exclusively: a name squatted at the destination (in the
+// real attack, a hard link to a victim file, which os.Root cannot constrain)
+// is refused rather than truncated.
+func TestCopyIntoRoot_RefusesToTruncateSquattedDestination(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("new"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	victim := filepath.Join(dstDir, "SKILL.md")
+	if err := os.WriteFile(victim, []byte("victim"), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	srcRoot, err := os.OpenRoot(srcDir)
+	if err != nil {
+		t.Fatalf("open source root: %v", err)
+	}
+	defer srcRoot.Close()
+	dstRoot, err := os.OpenRoot(dstDir)
+	if err != nil {
+		t.Fatalf("open dest root: %v", err)
+	}
+	defer dstRoot.Close()
+
+	if err := copyFileIntoRoot(dstRoot, srcRoot, "SKILL.md", "SKILL.md"); err == nil {
+		t.Fatalf("expected refusal to write over an existing destination entry")
+	}
+	content, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("victim disappeared: %v", err)
+	}
+	if string(content) != "victim" {
+		t.Fatalf("victim was truncated/overwritten: %q", string(content))
+	}
+}
+
+// TestRemovePinned_RemovesTreeWithoutFollowingLinks proves the replacement for
+// Root.RemoveAll deletes a real managed subtree, unlinks symlinks instead of
+// following them, and leaves link destinations untouched.
+func TestRemovePinned_RemovesTreeWithoutFollowingLinks(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+	keep := filepath.Join(outside, "keep.txt")
+	if err := os.WriteFile(keep, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("seed outside file: %v", err)
+	}
+
+	entry := filepath.Join(projectPath, ".claude", "skills", "lint")
+	if err := os.MkdirAll(filepath.Join(entry, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir entry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entry, "nested", "SKILL.md"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed skill file: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(entry, "linked")); err != nil {
+		t.Fatalf("symlink into entry: %v", err)
+	}
+
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	if err := p.removeManagedTarget(buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint")); err != nil {
+		t.Fatalf("removeManagedTarget failed: %v", err)
+	}
+	if _, err := os.Lstat(entry); !os.IsNotExist(err) {
+		t.Fatalf("managed entry should be gone, stat err = %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("removal followed a symlink out of the project: %v", err)
 	}
 }

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -185,6 +185,51 @@ func TestResolveContainedTargetPath_AllowsFinalComponentSymlink(t *testing.T) {
 	}
 }
 
+// TestIsContainedIn_RootBase proves containment works when the base is the
+// filesystem root: the old base+PathSeparator string-prefix compare produced
+// "//" as the required prefix, which no cleaned path carries, so every
+// legitimate target under a root-based project was rejected. The
+// filepath.Rel-based check accepts root-based targets and still refuses
+// escapes.
+func TestIsContainedIn_RootBase(t *testing.T) {
+	root := string(os.PathSeparator)
+	cases := []struct {
+		base, target string
+		want         bool
+	}{
+		{root, filepath.Join(root, ".claude", "skills"), true},
+		{root, root, true},
+		{filepath.Join(root, ".claude", "skills"), filepath.Join(root, ".claude", "skills", "my-skill"), true},
+		{filepath.Join(root, ".claude", "skills"), filepath.Join(root, ".claude"), false},
+		{filepath.Join(root, ".claude", "skills"), filepath.Join(root, "elsewhere"), false},
+		{filepath.Join(root, "a"), filepath.Join(root, "ab"), false},
+	}
+	for _, c := range cases {
+		if got := isContainedIn(c.base, c.target); got != c.want {
+			t.Errorf("isContainedIn(%q, %q) = %v, want %v", c.base, c.target, got, c.want)
+		}
+	}
+}
+
+// TestResolveContainedTargetPath_RootProjectPath proves the full containment
+// pipeline accepts a managed target for a project rooted at "/" (read-only:
+// nothing is created; resolution walks up to the deepest existing ancestor).
+func TestResolveContainedTargetPath_RootProjectPath(t *testing.T) {
+	projectPath := string(os.PathSeparator)
+	if _, err := os.Lstat(filepath.Join(projectPath, ".claude")); err == nil {
+		t.Skip("/.claude exists on this host; skipping literal-root check")
+	}
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "my-skill")
+	got, err := resolveContainedTargetPath(projectPath, targetRel)
+	if err != nil {
+		t.Fatalf("expected root-based managed target to be allowed, got: %v", err)
+	}
+	want := resolveTargetPath(projectPath, targetRel)
+	if got != want {
+		t.Fatalf("resolveContainedTargetPath = %q, want %q", got, want)
+	}
+}
+
 // TestResolveContainedTargetPath_AllowsNonExistingTargetUnderRealDir proves
 // the creation path still works when neither the target nor the managed dir
 // exists yet (first attach creates them).

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -721,3 +721,41 @@ func TestTargetExists_ForeignResolvableLinkCountsPresent(t *testing.T) {
 		t.Fatalf("foreign but resolvable link must count as present")
 	}
 }
+
+// TestMaterialize_RefusesPoolLinkPointingOutsideRegisteredRoots proves the
+// other direction of the source-symlink hop: a managed entry whose link
+// escapes every registered source root is refused as a materialization source
+// (no filesystem call touches the destination), while the legitimate pool link
+// keeps migrating (TestMaterialize_MigratesFromPoolSymlinkWhenSourceGone).
+func TestMaterialize_RefusesPoolLinkPointingOutsideRegisteredRoots(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	poolRoot := t.TempDir()
+	writeSkillDir(t, poolRoot, "lint", "lint", "Linting best practices")
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: poolRoot, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+	writeSkillDir(t, outside, "lint", "lint", "Planted outside every registered root")
+
+	skillsDir := filepath.Join(projectPath, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skills dir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "lint"), filepath.Join(skillsDir, "lint")); err != nil {
+		t.Fatalf("symlink outside dir: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectAgentsSkillsDir, "lint")
+	if _, err := materializeSkillCopyOnly(projectPath, filepath.Join(skillsDir, "lint"), targetRel); err == nil {
+		t.Fatalf("expected refusal for a managed link escaping every registered source root")
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, ".agents", "skills", "lint")); !os.IsNotExist(err) {
+		t.Fatalf("nothing should have been materialized, stat err = %v", err)
+	}
+}

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -526,3 +526,165 @@ func TestMaterialize_RefusesSymlinkedProjectSourceDir(t *testing.T) {
 		t.Fatalf("expected refusal for source under a symlinked project skills dir")
 	}
 }
+
+// --- Round-5 hardening: pinned directory descriptors ---
+
+// TestOpenPinnedDir_RefusesSymlinkedComponentInsideProject proves the pinning
+// walk refuses a managed-dir component that is a symlink even when it stays
+// INSIDE the project (".claude/skills -> .."), which os.Root alone permits
+// because it never leaves the root. Removal and materialization must not be
+// able to reach the project root that way.
+func TestOpenPinnedDir_RefusesSymlinkedComponentInsideProject(t *testing.T) {
+	projectPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.Symlink("..", filepath.Join(projectPath, ".claude", "skills")); err != nil {
+		t.Fatalf("symlink skills dir: %v", err)
+	}
+
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	if _, err := p.openPinnedDir(filepath.FromSlash(projectClaudeSkillsDir), false); err == nil {
+		t.Fatalf("expected pinned open to refuse a symlinked component")
+	}
+	if _, err := p.openPinnedDir(filepath.FromSlash(projectClaudeSkillsDir), true); err == nil {
+		t.Fatalf("expected pinned open (create) to refuse a symlinked component")
+	}
+}
+
+// TestOpenTargetParent_AllowsRealManagedDirAndPoolLink proves the pinned path
+// still serves the legitimate flows: a real managed dir is pinned and created
+// on demand, and a final-component pool symlink inside it is addressed by name.
+func TestOpenTargetParent_AllowsRealManagedDirAndPoolLink(t *testing.T) {
+	projectPath := t.TempDir()
+	pool := t.TempDir()
+	poolSkill := filepath.Join(pool, "my-skill")
+	if err := os.MkdirAll(poolSkill, 0o755); err != nil {
+		t.Fatalf("mkdir pool skill: %v", err)
+	}
+
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "my-skill")
+	parent, name, err := p.openTargetParent(targetRel, true)
+	if err != nil {
+		t.Fatalf("expected managed dir to be created and pinned, got: %v", err)
+	}
+	if name != "my-skill" {
+		t.Fatalf("entry name = %q, want my-skill", name)
+	}
+	if err := parent.Symlink(poolSkill, name); err != nil {
+		t.Fatalf("pool symlink creation failed: %v", err)
+	}
+	parent.Close()
+
+	if err := p.removeManagedTarget(targetRel); err != nil {
+		t.Fatalf("removal of pool symlink failed: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(projectPath, ".claude", "skills", "my-skill")); !os.IsNotExist(err) {
+		t.Fatalf("expected the link to be removed, got: %v", err)
+	}
+	if _, err := os.Stat(poolSkill); err != nil {
+		t.Fatalf("pool destination was deleted through the link: %v", err)
+	}
+}
+
+// TestSaveManifest_UsesExclusiveRandomTempFile proves the manifest save no
+// longer truncates a predictable temp path (which could be pre-created as a
+// hard link to a victim file) and leaves no temp file behind.
+func TestSaveManifest_UsesExclusiveRandomTempFile(t *testing.T) {
+	projectPath := t.TempDir()
+	dir := filepath.Join(projectPath, projectSkillsDirName)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	squatted := filepath.Join(dir, projectSkillsManifest+".tmp")
+	if err := os.WriteFile(squatted, []byte("victim"), 0o600); err != nil {
+		t.Fatalf("seed squatted temp file: %v", err)
+	}
+
+	if err := SaveProjectSkillsManifest(projectPath, &ProjectSkillsManifest{}); err != nil {
+		t.Fatalf("SaveProjectSkillsManifest failed: %v", err)
+	}
+
+	content, err := os.ReadFile(squatted)
+	if err != nil {
+		t.Fatalf("squatted temp file disappeared: %v", err)
+	}
+	if string(content) != "victim" {
+		t.Fatalf("squatted temp file was overwritten: %q", string(content))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read manifest dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != projectSkillsManifest && e.Name() != projectSkillsManifest+".tmp" {
+			t.Fatalf("save left a stray temp file behind: %s", e.Name())
+		}
+	}
+}
+
+// TestTargetExists_DanglingPoolLinkCountsAbsent proves a leftover link into a
+// pool entry that no longer exists is treated as ABSENT (so attach
+// rematerializes) rather than as an attached skill.
+func TestTargetExists_DanglingPoolLinkCountsAbsent(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	poolRoot := t.TempDir()
+	writeSkillDir(t, poolRoot, "lint", "lint", "Linting best practices")
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: poolRoot, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+	skillsDir := filepath.Join(projectPath, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skills dir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(poolRoot, "gone"), filepath.Join(skillsDir, "lint")); err != nil {
+		t.Fatalf("symlink dangling pool entry: %v", err)
+	}
+
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint")
+	exists, err := p.targetExists(targetRel)
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if exists {
+		t.Fatalf("dangling pool link should count as absent")
+	}
+
+	// A live pool link counts as present.
+	if err := os.Remove(filepath.Join(skillsDir, "lint")); err != nil {
+		t.Fatalf("remove dangling link: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(poolRoot, "lint"), filepath.Join(skillsDir, "lint")); err != nil {
+		t.Fatalf("symlink live pool entry: %v", err)
+	}
+	exists, err = p.targetExists(targetRel)
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatalf("live pool link should count as present")
+	}
+}

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -636,7 +636,10 @@ func TestSaveManifest_UsesExclusiveRandomTempFile(t *testing.T) {
 
 // TestTargetExists_DanglingPoolLinkCountsAbsent proves a leftover link into a
 // pool entry that no longer exists is treated as ABSENT (so attach
-// rematerializes) rather than as an attached skill.
+// rematerializes) rather than as an attached skill, while a live pool link
+// still counts as present. A FOREIGN but resolvable replacement also stays
+// "present" on purpose: the loadout layer reports those instead of silently
+// overwriting them (TestLoadout_RefusesForeignReplacementOfManagedSymlink).
 func TestTargetExists_DanglingPoolLinkCountsAbsent(t *testing.T) {
 	_, cleanup := setupSkillTestEnv(t)
 	defer cleanup()
@@ -686,5 +689,35 @@ func TestTargetExists_DanglingPoolLinkCountsAbsent(t *testing.T) {
 	}
 	if !exists {
 		t.Fatalf("live pool link should count as present")
+	}
+}
+
+// TestTargetExists_ForeignResolvableLinkCountsPresent pins the policy the
+// loadout layer depends on: a managed entry replaced by a link to an unrelated
+// but existing directory is PRESENT (reported as already attached, then
+// refused as unhealthy upstream), never silently rematerialized over.
+func TestTargetExists_ForeignResolvableLinkCountsPresent(t *testing.T) {
+	projectPath := t.TempDir()
+	foreign := t.TempDir()
+	skillsDir := filepath.Join(projectPath, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skills dir: %v", err)
+	}
+	if err := os.Symlink(foreign, filepath.Join(skillsDir, "lint")); err != nil {
+		t.Fatalf("symlink foreign dir: %v", err)
+	}
+
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	exists, err := p.targetExists(buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint"))
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatalf("foreign but resolvable link must count as present")
 	}
 }

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -1,0 +1,212 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Security: symlink-aware containment for skills-catalog targets (Codex P1 on
+// PR #1809). resolveContainedTargetPath used filepath.Clean + string prefix
+// only, so a repo shipping .claude/skills (or any ancestor component) as a
+// symlink pointing outside the project string-passed containment while the
+// target physically lived at the symlink destination — letting
+// safeRemoveManagedTarget's os.RemoveAll delete files there and letting
+// materialization create files there. Containment now compares
+// symlink-RESOLVED ancestors; the final target component is deliberately left
+// unresolved so pool-attached skills (symlinks inside the managed dir) keep
+// working.
+
+// TestResolveContainedTargetPath_RefusesSymlinkedSkillsDirEscape proves a
+// managed skills dir that is itself a symlink out of the project is refused.
+func TestResolveContainedTargetPath_RefusesSymlinkedSkillsDirEscape(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(projectPath, ".claude", "skills")); err != nil {
+		t.Fatalf("symlink skills dir: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "victim")
+	if _, err := resolveContainedTargetPath(projectPath, targetRel); err == nil {
+		t.Fatalf("expected refusal for symlinked skills dir escaping the project, got nil error")
+	}
+}
+
+// TestResolveContainedTargetPath_RefusesSymlinkedAncestorEscape proves an
+// intermediate ancestor symlink (.claude -> outside) is refused too.
+func TestResolveContainedTargetPath_RefusesSymlinkedAncestorEscape(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(outside, "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir outside skills: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(projectPath, ".claude")); err != nil {
+		t.Fatalf("symlink .claude: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "victim")
+	if _, err := resolveContainedTargetPath(projectPath, targetRel); err == nil {
+		t.Fatalf("expected refusal for symlinked ancestor escaping the project, got nil error")
+	}
+}
+
+// TestSafeRemoveManagedTarget_DoesNotFollowSymlinkedSkillsDir proves the
+// physical outcome: with .claude/skills symlinked outside the project, remove
+// is refused and the file at the symlink destination survives.
+func TestSafeRemoveManagedTarget_DoesNotFollowSymlinkedSkillsDir(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+
+	victimDir := filepath.Join(outside, "victim")
+	if err := os.MkdirAll(victimDir, 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	victimFile := filepath.Join(victimDir, "precious.txt")
+	if err := os.WriteFile(victimFile, []byte("do not delete"), 0o600); err != nil {
+		t.Fatalf("write victim file: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(projectPath, ".claude", "skills")); err != nil {
+		t.Fatalf("symlink skills dir: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "victim")
+	if err := safeRemoveManagedTarget(projectPath, targetRel); err == nil {
+		t.Fatalf("expected safeRemoveManagedTarget to refuse a symlinked skills dir")
+	}
+	if _, err := os.Stat(victimFile); err != nil {
+		t.Fatalf("victim file outside the project was touched: %v", err)
+	}
+}
+
+// TestAttachSkillCandidate_RefusesSymlinkedSkillsDirOnMaterialize proves the
+// materialization path refuses to create anything through a skills dir that
+// symlinks out of the project.
+func TestAttachSkillCandidate_RefusesSymlinkedSkillsDirOnMaterialize(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	sourcePath, err := os.MkdirTemp("", "agentdeck-1809-source-*")
+	if err != nil {
+		t.Fatalf("failed to create source path: %v", err)
+	}
+	defer os.RemoveAll(sourcePath)
+	writeSkillDir(t, sourcePath, "lint", "lint", "Linting best practices")
+
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"local": {Path: sourcePath, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath, err := os.MkdirTemp("", "agentdeck-1809-project-*")
+	if err != nil {
+		t.Fatalf("failed to create project path: %v", err)
+	}
+	defer os.RemoveAll(projectPath)
+
+	outside, err := os.MkdirTemp("", "agentdeck-1809-outside-*")
+	if err != nil {
+		t.Fatalf("failed to create outside path: %v", err)
+	}
+	defer os.RemoveAll(outside)
+
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(projectPath, ".claude", "skills")); err != nil {
+		t.Fatalf("symlink skills dir: %v", err)
+	}
+
+	if _, err := AttachSkillToProject(projectPath, "claude", "lint", "local"); err == nil {
+		t.Fatalf("expected AttachSkillToProject to refuse a symlinked skills dir")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read outside dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("materialization escaped into %s: %v", outside, entries)
+	}
+}
+
+// TestResolveContainedTargetPath_AllowsFinalComponentSymlink proves the
+// pool-attach pattern keeps working: the target ITSELF being a symlink inside
+// a real managed dir is fine (RemoveAll removes the link, not the
+// destination).
+func TestResolveContainedTargetPath_AllowsFinalComponentSymlink(t *testing.T) {
+	projectPath := t.TempDir()
+	pool := t.TempDir()
+
+	poolSkill := filepath.Join(pool, "my-skill")
+	if err := os.MkdirAll(poolSkill, 0o755); err != nil {
+		t.Fatalf("mkdir pool skill: %v", err)
+	}
+	keepFile := filepath.Join(poolSkill, "SKILL.md")
+	if err := os.WriteFile(keepFile, []byte("# my-skill"), 0o600); err != nil {
+		t.Fatalf("write pool SKILL.md: %v", err)
+	}
+
+	skillsDir := filepath.Join(projectPath, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skills dir: %v", err)
+	}
+	if err := os.Symlink(poolSkill, filepath.Join(skillsDir, "my-skill")); err != nil {
+		t.Fatalf("symlink pool skill: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "my-skill")
+	got, err := resolveContainedTargetPath(projectPath, targetRel)
+	if err != nil {
+		t.Fatalf("expected final-component symlink to be allowed, got: %v", err)
+	}
+	want := resolveTargetPath(projectPath, targetRel)
+	if got != want {
+		t.Fatalf("resolveContainedTargetPath = %q, want %q", got, want)
+	}
+
+	// Detach-style removal removes the LINK, never the pool destination.
+	if err := safeRemoveManagedTarget(projectPath, targetRel); err != nil {
+		t.Fatalf("safeRemoveManagedTarget on pool symlink failed: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(skillsDir, "my-skill")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink to be removed, got: %v", err)
+	}
+	if _, err := os.Stat(keepFile); err != nil {
+		t.Fatalf("pool skill content was deleted through the symlink: %v", err)
+	}
+}
+
+// TestResolveContainedTargetPath_AllowsNonExistingTargetUnderRealDir proves
+// the creation path still works when neither the target nor the managed dir
+// exists yet (first attach creates them).
+func TestResolveContainedTargetPath_AllowsNonExistingTargetUnderRealDir(t *testing.T) {
+	projectPath := t.TempDir()
+
+	// Managed dir does not exist at all yet.
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "brand-new")
+	got, err := resolveContainedTargetPath(projectPath, targetRel)
+	if err != nil {
+		t.Fatalf("expected non-existing target under non-existing managed dir to be allowed, got: %v", err)
+	}
+	want := resolveTargetPath(projectPath, targetRel)
+	if got != want {
+		t.Fatalf("resolveContainedTargetPath = %q, want %q", got, want)
+	}
+
+	// Managed dir exists, target does not.
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude", "skills"), 0o755); err != nil {
+		t.Fatalf("mkdir skills dir: %v", err)
+	}
+	if _, err := resolveContainedTargetPath(projectPath, targetRel); err != nil {
+		t.Fatalf("expected non-existing target under existing managed dir to be allowed, got: %v", err)
+	}
+}

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -549,10 +549,10 @@ func TestOpenPinnedDir_RefusesSymlinkedComponentInsideProject(t *testing.T) {
 	}
 	defer p.Close()
 
-	if _, err := p.openPinnedDir(filepath.FromSlash(projectClaudeSkillsDir), false); err == nil {
+	if _, _, err := p.openPinnedDir(filepath.FromSlash(projectClaudeSkillsDir), false); err == nil {
 		t.Fatalf("expected pinned open to refuse a symlinked component")
 	}
-	if _, err := p.openPinnedDir(filepath.FromSlash(projectClaudeSkillsDir), true); err == nil {
+	if _, _, err := p.openPinnedDir(filepath.FromSlash(projectClaudeSkillsDir), true); err == nil {
 		t.Fatalf("expected pinned open (create) to refuse a symlinked component")
 	}
 }
@@ -575,7 +575,7 @@ func TestOpenTargetParent_AllowsRealManagedDirAndPoolLink(t *testing.T) {
 	defer p.Close()
 
 	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "my-skill")
-	parent, name, err := p.openTargetParent(targetRel, true)
+	parent, name, _, err := p.openTargetParent(targetRel, true)
 	if err != nil {
 		t.Fatalf("expected managed dir to be created and pinned, got: %v", err)
 	}
@@ -844,5 +844,95 @@ func TestRemovePinned_RemovesTreeWithoutFollowingLinks(t *testing.T) {
 	}
 	if _, err := os.Stat(keep); err != nil {
 		t.Fatalf("removal followed a symlink out of the project: %v", err)
+	}
+}
+
+// TestAliasRegisteredSourceRoot_AttachMigrateAndHeal is the regression test for
+// sources registered through a symlink alias (/alias/pool -> /real/pool), which
+// is a normal local setup. Physical link destinations never match a lexical
+// registered root, so attach worked but migration from the managed link and
+// healing of a dangling attachment silently failed. All three paths are pinned
+// here.
+func TestAliasRegisteredSourceRoot_AttachMigrateAndHeal(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	root := t.TempDir()
+	realPool := filepath.Join(root, "real-pool")
+	writeSkillDir(t, realPool, "lint", "lint", "Linting best practices")
+	aliasPool := filepath.Join(root, "alias-pool")
+	if err := os.Symlink(realPool, aliasPool); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	// Registered through the ALIAS, while the filesystem answers physically.
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: aliasPool, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+
+	// 1. Attach.
+	if _, err := AttachSkillToProject(projectPath, "claude", "lint", "pool"); err != nil {
+		t.Fatalf("attach from alias-registered source failed: %v", err)
+	}
+	claudeEntry := filepath.Join(projectPath, ".claude", "skills", "lint")
+	if _, err := os.Stat(filepath.Join(claudeEntry, "SKILL.md")); err != nil {
+		t.Fatalf("expected attached skill content: %v", err)
+	}
+
+	// 2. Migrate from the managed link (recorded source unavailable).
+	stale := SkillCandidate{
+		ID:         buildSkillID("pool", "lint"),
+		Name:       "lint",
+		Source:     "pool",
+		SourcePath: filepath.Join(aliasPool, "gone-away"),
+		EntryName:  "lint",
+		Kind:       "dir",
+	}
+	if err := ApplyProjectSkills(projectPath, "codex", []SkillCandidate{stale}); err != nil {
+		t.Fatalf("migration from alias-registered managed link failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, ".agents", "skills", "lint", "SKILL.md")); err != nil {
+		t.Fatalf("expected migrated skill content: %v", err)
+	}
+
+	// 3. Heal a dangling attachment whose link points at the alias-registered
+	//    source: it must count as ABSENT so attach rematerializes it.
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	agentsEntry := filepath.Join(projectPath, ".agents", "skills", "lint")
+	if err := os.RemoveAll(agentsEntry); err != nil {
+		t.Fatalf("clear migrated entry: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(aliasPool, "lint"), agentsEntry); err != nil {
+		t.Fatalf("install alias pool link: %v", err)
+	}
+	exists, err := p.targetExists(buildProjectSkillTargetPath(projectAgentsSkillsDir, "lint"), filepath.Join(aliasPool, "lint"))
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatalf("live alias-registered pool link must count as present")
+	}
+
+	if err := os.Remove(agentsEntry); err != nil {
+		t.Fatalf("remove link: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(aliasPool, "vanished"), agentsEntry); err != nil {
+		t.Fatalf("install dangling alias link: %v", err)
+	}
+	exists, err = p.targetExists(buildProjectSkillTargetPath(projectAgentsSkillsDir, "lint"), filepath.Join(aliasPool, "vanished"))
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if exists {
+		t.Fatalf("dangling alias-registered link must count as absent so it can heal")
 	}
 }

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -277,6 +277,38 @@ func TestResolveContainedTargetPath_RefusesManagedDirItself(t *testing.T) {
 	}
 }
 
+// TestMaterializeSkill_RefusesUnregisteredSource proves the SOURCE side of
+// materialization is gated too (CodeQL go/path-injection alert 237): the
+// destination is Root-confined, but the source path arrives from manifest or
+// candidate data and is opened by path. A source outside every registered
+// skill source root and outside the project's managed skills dirs is refused
+// before any read.
+func TestMaterializeSkill_RefusesUnregisteredSource(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	projectPath, err := os.MkdirTemp("", "agentdeck-1809-src-project-*")
+	if err != nil {
+		t.Fatalf("failed to create project path: %v", err)
+	}
+	defer os.RemoveAll(projectPath)
+
+	outside, err := os.MkdirTemp("", "agentdeck-1809-src-outside-*")
+	if err != nil {
+		t.Fatalf("failed to create outside path: %v", err)
+	}
+	defer os.RemoveAll(outside)
+	writeSkillDir(t, outside, "evil", "evil", "Not from a registered source")
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "evil")
+	if _, err := materializeSkill(projectPath, filepath.Join(outside, "evil"), targetRel); err == nil {
+		t.Fatalf("expected materializeSkill to refuse a source outside registered skill sources")
+	}
+	if _, err := materializeSkillCopyOnly(projectPath, filepath.Join(outside, "evil"), targetRel); err == nil {
+		t.Fatalf("expected materializeSkillCopyOnly to refuse a source outside registered skill sources")
+	}
+}
+
 // TestIsContainedIn_RootBase proves containment works when the base is the
 // filesystem root: the old base+PathSeparator string-prefix compare produced
 // "//" as the required prefix, which no cleaned path carries, so every

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -185,6 +185,98 @@ func TestResolveContainedTargetPath_AllowsFinalComponentSymlink(t *testing.T) {
 	}
 }
 
+// TestResolveContainedTargetPath_RefusesSkillsDirSymlinkedInsideProject
+// proves the adversarial variant where the symlink points back INSIDE the
+// project: .claude/skills -> .. makes ".claude/skills/.git" physically the
+// project's .git dir while still resolving inside the project root, so a
+// resolved-prefix compare against the project alone would pass. The
+// no-symlinked-ancestor-components rule refuses it and the .git content
+// survives.
+func TestResolveContainedTargetPath_RefusesSkillsDirSymlinkedInsideProject(t *testing.T) {
+	projectPath := t.TempDir()
+
+	gitDir := filepath.Join(projectPath, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	gitFile := filepath.Join(gitDir, "HEAD")
+	if err := os.WriteFile(gitFile, []byte("ref: refs/heads/main"), 0o600); err != nil {
+		t.Fatalf("write .git/HEAD: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.Symlink("..", filepath.Join(projectPath, ".claude", "skills")); err != nil {
+		t.Fatalf("symlink skills dir: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, ".git")
+	if _, err := resolveContainedTargetPath(projectPath, targetRel); err == nil {
+		t.Fatalf("expected refusal for skills dir symlinked back into the project, got nil error")
+	}
+	if err := safeRemoveManagedTarget(projectPath, targetRel); err == nil {
+		t.Fatalf("expected safeRemoveManagedTarget to refuse, got nil error")
+	}
+	if _, err := os.Stat(gitFile); err != nil {
+		t.Fatalf(".git content was deleted through the symlinked skills dir: %v", err)
+	}
+}
+
+// TestResolveContainedTargetPath_RefusesDanglingSymlinkedAncestor proves a
+// DANGLING skills-dir symlink is refused rather than treated as an absent
+// component: .claude/skills -> /outside/not-yet-created ENOENTs under
+// EvalSymlinks, which an existence-based walk would misread as "nothing
+// there yet" and pass lexically — but materializing through it would create
+// the outside tree once the destination becomes creatable.
+func TestResolveContainedTargetPath_RefusesDanglingSymlinkedAncestor(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(projectPath, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	dangling := filepath.Join(outside, "not-yet-created")
+	if err := os.Symlink(dangling, filepath.Join(projectPath, ".claude", "skills")); err != nil {
+		t.Fatalf("symlink skills dir: %v", err)
+	}
+
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "victim")
+	if _, err := resolveContainedTargetPath(projectPath, targetRel); err == nil {
+		t.Fatalf("expected refusal for dangling symlinked skills dir, got nil error")
+	}
+}
+
+// TestResolveContainedTargetPath_RefusesManagedDirItself proves the target
+// must be a STRICT descendant: a tampered ".claude/skills/." cleans to the
+// managed dir itself, and RemoveAll there would wipe the whole catalog.
+func TestResolveContainedTargetPath_RefusesManagedDirItself(t *testing.T) {
+	projectPath := t.TempDir()
+
+	skillsDir := filepath.Join(projectPath, ".claude", "skills")
+	if err := os.MkdirAll(filepath.Join(skillsDir, "my-skill"), 0o755); err != nil {
+		t.Fatalf("mkdir skills content: %v", err)
+	}
+	keepFile := filepath.Join(skillsDir, "my-skill", "SKILL.md")
+	if err := os.WriteFile(keepFile, []byte("# my-skill"), 0o600); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	for _, rel := range []string{
+		projectClaudeSkillsDir,
+		projectClaudeSkillsDir + "/.",
+	} {
+		if _, err := resolveContainedTargetPath(projectPath, rel); err == nil {
+			t.Fatalf("expected refusal for managed-dir-itself target %q, got nil error", rel)
+		}
+		if err := safeRemoveManagedTarget(projectPath, rel); err == nil {
+			t.Fatalf("expected safeRemoveManagedTarget to refuse %q, got nil error", rel)
+		}
+	}
+	if _, err := os.Stat(keepFile); err != nil {
+		t.Fatalf("skills catalog content was wiped: %v", err)
+	}
+}
+
 // TestIsContainedIn_RootBase proves containment works when the base is the
 // filesystem root: the old base+PathSeparator string-prefix compare produced
 // "//" as the required prefix, which no cleaned path carries, so every

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -936,3 +936,92 @@ func TestAliasRegisteredSourceRoot_AttachMigrateAndHeal(t *testing.T) {
 		t.Fatalf("dangling alias-registered link must count as absent so it can heal")
 	}
 }
+
+// --- Final round: source-side pinning and dangling-link classification ---
+
+// TestMaterialize_LinkTargetComesFromPinnedSourceRoot pins the invariant behind
+// the source-side no-reopen-after-pinning rule: the created managed link names
+// the entry INSIDE the registered source root (root physical path + validated
+// remainder), never a path re-resolved from the source after validation. That
+// is what stops a source entry swapped for an external symlink between
+// validation and link creation from becoming a managed attachment pointing
+// outside the source root.
+func TestMaterialize_LinkTargetComesFromPinnedSourceRoot(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	root := t.TempDir()
+	realPool := filepath.Join(root, "real-pool")
+	writeSkillDir(t, realPool, "lint", "lint", "Linting best practices")
+	aliasPool := filepath.Join(root, "alias-pool")
+	if err := os.Symlink(realPool, aliasPool); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: aliasPool, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+	attached, err := AttachSkillToProject(projectPath, "claude", "lint", "pool")
+	if err != nil {
+		t.Fatalf("attach failed: %v", err)
+	}
+	entry := filepath.Join(projectPath, ".claude", "skills", "lint")
+	info, err := os.Lstat(entry)
+	if err != nil {
+		t.Fatalf("lstat attached entry: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Skipf("attach fell back to copy mode (%s)", attached.Mode)
+	}
+
+	linkText, err := os.Readlink(entry)
+	if err != nil {
+		t.Fatalf("readlink attached entry: %v", err)
+	}
+	if !filepath.IsAbs(linkText) {
+		linkText = filepath.Join(filepath.Dir(entry), linkText)
+	}
+	poolPhysical := physicalPath(aliasPool)
+	if _, inside := relUnderBase(poolPhysical, filepath.Clean(linkText)); !inside {
+		t.Fatalf("managed link %q must name an entry inside the registered source root %q", linkText, poolPhysical)
+	}
+	if _, err := os.Stat(filepath.Join(entry, "SKILL.md")); err != nil {
+		t.Fatalf("expected the link to resolve to the skill: %v", err)
+	}
+}
+
+// TestTargetExists_DanglingLinkOutsideManagedDirsCountsPresent covers the
+// classification-ordering fix: a Stat failure is no longer treated as proof of
+// absence. A RELATIVE dangling link that stays inside the managed os.Root but
+// resolves outside the managed skills dirs is a foreign entry and must be
+// reported (present), not deleted and replaced.
+func TestTargetExists_DanglingLinkOutsideManagedDirsCountsPresent(t *testing.T) {
+	projectPath := t.TempDir()
+	skillsDir := filepath.Join(projectPath, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skills dir: %v", err)
+	}
+	// Resolves to <project>/.claude/evil-missing: inside the project, outside
+	// every managed skills dir, and dangling.
+	if err := os.Symlink(filepath.Join("..", "evil-missing"), filepath.Join(skillsDir, "lint")); err != nil {
+		t.Fatalf("install dangling foreign link: %v", err)
+	}
+
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		t.Fatalf("openProjectRoot: %v", err)
+	}
+	defer p.Close()
+
+	exists, err := p.targetExists(buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint"),
+		filepath.Join(t.TempDir(), "lint"))
+	if err != nil {
+		t.Fatalf("targetExists failed: %v", err)
+	}
+	if !exists {
+		t.Fatalf("a dangling foreign link must count as present, not be overwritten")
+	}
+}

--- a/internal/session/issue1809_symlink_containment_test.go
+++ b/internal/session/issue1809_symlink_containment_test.go
@@ -379,3 +379,150 @@ func TestResolveContainedTargetPath_AllowsNonExistingTargetUnderRealDir(t *testi
 		t.Fatalf("expected non-existing target under existing managed dir to be allowed, got: %v", err)
 	}
 }
+
+// --- Round-4 hardening: one pinned project descriptor, no reopen-by-name ---
+
+// TestMaterialize_MigratesFromPoolSymlinkWhenSourceGone is the regression test
+// for the migration path: the source being copied is the CURRENT managed
+// entry, which for a pool-attached skill is a symlink whose destination lives
+// outside the project. Reading it strictly inside the project skills root
+// refused that escape and broke migration. The source resolver now follows a
+// final-component symlink one hop and re-validates the DESTINATION as a
+// registered source, so migration works while non-source destinations stay
+// refused.
+func TestMaterialize_MigratesFromPoolSymlinkWhenSourceGone(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	poolRoot := t.TempDir()
+	writeSkillDir(t, poolRoot, "lint", "lint", "Linting best practices")
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: poolRoot, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+	attached, err := AttachSkillToProject(projectPath, "claude", "lint", "pool")
+	if err != nil {
+		t.Fatalf("attach failed: %v", err)
+	}
+	claudeEntry := filepath.Join(projectPath, ".claude", "skills", "lint")
+	info, err := os.Lstat(claudeEntry)
+	if err != nil {
+		t.Fatalf("lstat attached entry: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Skipf("attach fell back to copy mode (%s); symlink migration path not exercised", attached.Mode)
+	}
+
+	// Migrate to the .agents/skills dir by copying FROM the pool symlink,
+	// exactly as the migration branch does when the recorded source is gone.
+	targetRel := buildProjectSkillTargetPath(projectAgentsSkillsDir, "lint")
+	if _, err := materializeSkillCopyOnly(projectPath, claudeEntry, targetRel); err != nil {
+		t.Fatalf("migration from pool symlink failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, ".agents", "skills", "lint", "SKILL.md")); err != nil {
+		t.Fatalf("expected migrated skill content, got: %v", err)
+	}
+}
+
+// TestApplyProjectSkills_MigratesPoolSymlinkWithStaleSourcePath drives the same
+// regression end to end: a desired candidate whose recorded SourcePath no
+// longer exists, migrating a pool-symlinked entry from .claude/skills to
+// .agents/skills.
+func TestApplyProjectSkills_MigratesPoolSymlinkWithStaleSourcePath(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	poolRoot := t.TempDir()
+	writeSkillDir(t, poolRoot, "lint", "lint", "Linting best practices")
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: poolRoot, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+	if _, err := AttachSkillToProject(projectPath, "claude", "lint", "pool"); err != nil {
+		t.Fatalf("attach failed: %v", err)
+	}
+
+	stale := SkillCandidate{
+		ID:         buildSkillID("pool", "lint"),
+		Name:       "lint",
+		Source:     "pool",
+		SourcePath: filepath.Join(poolRoot, "gone-away"),
+		EntryName:  "lint",
+		Kind:       "dir",
+	}
+	if err := ApplyProjectSkills(projectPath, "codex", []SkillCandidate{stale}); err != nil {
+		t.Fatalf("apply with stale source path failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, ".agents", "skills", "lint", "SKILL.md")); err != nil {
+		t.Fatalf("expected migrated skill content, got: %v", err)
+	}
+}
+
+// TestManifestWrites_RefuseSymlinkedAgentDeckDir proves manifest I/O goes
+// through the pinned project descriptor: a repo shipping ".agent-deck" as a
+// symlink out of the project must not redirect the manifest write.
+func TestManifestWrites_RefuseSymlinkedAgentDeckDir(t *testing.T) {
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.Symlink(outside, filepath.Join(projectPath, projectSkillsDirName)); err != nil {
+		t.Fatalf("symlink .agent-deck: %v", err)
+	}
+
+	manifest := &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{{
+		ID: "pool/lint", Name: "lint", Source: "pool", EntryName: "lint",
+		TargetPath: buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint"),
+	}}}
+	if err := SaveProjectSkillsManifest(projectPath, manifest); err == nil {
+		t.Fatalf("expected manifest save to refuse a symlinked .agent-deck dir")
+	}
+	if _, err := LoadProjectSkillsManifest(projectPath); err == nil {
+		t.Fatalf("expected manifest load to refuse a symlinked .agent-deck dir")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read outside dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("manifest write escaped into %s: %v", outside, entries)
+	}
+}
+
+// TestMaterialize_RefusesSymlinkedProjectSourceDir proves project-local source
+// dirs are validated BEFORE being opened: ".agents/skills -> /outside" must be
+// refused as a materialization source, not anchored and read through.
+func TestMaterialize_RefusesSymlinkedProjectSourceDir(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	poolRoot := t.TempDir()
+	writeSkillDir(t, poolRoot, "lint", "lint", "Linting best practices")
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"pool": {Path: poolRoot, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
+
+	projectPath := t.TempDir()
+	outside := t.TempDir()
+	writeSkillDir(t, outside, "evil", "evil", "Planted outside the project")
+
+	if err := os.MkdirAll(filepath.Join(projectPath, ".agents"), 0o755); err != nil {
+		t.Fatalf("mkdir .agents: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(projectPath, ".agents", "skills")); err != nil {
+		t.Fatalf("symlink .agents/skills: %v", err)
+	}
+
+	source := filepath.Join(projectPath, ".agents", "skills", "evil")
+	targetRel := buildProjectSkillTargetPath(projectClaudeSkillsDir, "evil")
+	if _, err := materializeSkillCopyOnly(projectPath, source, targetRel); err == nil {
+		t.Fatalf("expected refusal for source under a symlinked project skills dir")
+	}
+}

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -1185,10 +1185,13 @@ func (p *projectRoot) targetExists(targetRel string) (bool, error) {
 
 	// Root.Stat reports the escape before it reports whether the destination
 	// exists, so an out-of-root link lands here whether it is a live pool
-	// attachment or a dangling leftover. Read the link and check the
-	// destination through a registered source root: a live pool skill counts
-	// as present, a dangling or non-source destination counts as ABSENT so the
-	// attach flow rematerializes over it instead of reporting it attached.
+	// attachment or a dangling leftover. Resolve the link explicitly and let
+	// the DESTINATION decide: a link that resolves (pool attachment, or a
+	// foreign replacement the loadout layer must report rather than silently
+	// overwrite) counts as present; a dangling link counts as ABSENT so the
+	// attach flow rematerializes over it. This is a read-only metadata check
+	// on the link's own destination — the same thing the previous os.Stat on
+	// the target did — while every mutation stays descriptor-relative.
 	info, lerr := parent.Lstat(name)
 	if lerr != nil {
 		if os.IsNotExist(lerr) {
@@ -1201,18 +1204,16 @@ func (p *projectRoot) targetExists(targetRel string) (bool, error) {
 	}
 	dest, rerr := parent.Readlink(name)
 	if rerr != nil {
-		return false, nil
+		return true, nil
 	}
 	if !filepath.IsAbs(dest) {
 		dest = filepath.Join(p.physicalDirOf(targetRel), dest)
 	}
-	srcRoot, srcRel, _, err := p.openContainedSource(dest)
-	if err != nil {
-		return false, nil
-	}
-	defer srcRoot.Close()
-	if _, err := srcRoot.Stat(srcRel); err != nil {
-		return false, nil
+	if _, err := os.Stat(filepath.Clean(dest)); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return true, nil
 	}
 	return true, nil
 }

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -733,7 +733,7 @@ func sortAttachments(skills []ProjectSkillAttachment) {
 // but a repo can still ship .agent-deck as a symlink; requireNoSymlinkAncestors
 // refuses that instead of reading (or later writing) through it.
 func (p *projectRoot) loadManifest() (*ProjectSkillsManifest, error) {
-	dir, err := p.openPinnedDir(projectSkillsDirName, false)
+	dir, _, err := p.openPinnedDir(projectSkillsDirName, false)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{}}, nil
@@ -779,7 +779,7 @@ func (p *projectRoot) saveManifest(manifest *ProjectSkillsManifest) error {
 	}
 	sortAttachments(manifest.Skills)
 
-	dir, err := p.openPinnedDir(projectSkillsDirName, true)
+	dir, _, err := p.openPinnedDir(projectSkillsDirName, true)
 	if err != nil {
 		return fmt.Errorf("failed to open manifest directory: %w", err)
 	}
@@ -957,8 +957,23 @@ func copyDir(src, dst string) error {
 // "operate on a path" leaves a window (and a fresh traversal) every time.
 type projectRoot struct {
 	path string
+	phys string      // physical (symlink-resolved) project path, resolved ONCE
 	root *os.Root
 	info os.FileInfo // the pinned project dir itself, for device identity
+}
+
+// physicalPath resolves path through symlinks, falling back to the cleaned
+// lexical form when it cannot be resolved (it may not exist yet). Registered
+// source roots and link destinations must be compared in the SAME form: a
+// source registered through an alias (/alias/pool -> /real/pool) yields
+// physical destinations from Readlink/EvalSymlinks that never match the
+// lexical root, which silently broke migration and dangling-link healing for
+// alias-registered pools.
+func physicalPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 func openProjectRoot(projectPath string) (*projectRoot, error) {
@@ -971,7 +986,8 @@ func openProjectRoot(projectPath string) (*projectRoot, error) {
 		_ = root.Close()
 		return nil, err
 	}
-	return &projectRoot{path: filepath.Clean(projectPath), root: root, info: info}, nil
+	cleaned := filepath.Clean(projectPath)
+	return &projectRoot{path: cleaned, phys: physicalPath(cleaned), root: root, info: info}, nil
 }
 
 // openPinnedChildDir opens ONE component below parent as a pinned child root.
@@ -1032,9 +1048,15 @@ func (p *projectRoot) openPinnedChildDir(parent *os.Root, name string, create bo
 // openPinnedDir walks rel component by component, pinning each directory by
 // descriptor identity. The returned root is the deepest directory; the caller
 // operates on entries inside it by NAME ONLY, never by reassembled path.
-func (p *projectRoot) openPinnedDir(rel string, create bool) (*os.Root, error) {
+// The physical path of the pinned directory is accumulated FROM THE WALK: the
+// project's physical path plus each component, every one of which was just
+// proven to be a real (non-symlink) directory. That is why it is safe — and it
+// is the only way to name the pinned directory without reopening it by
+// pathname, which would reintroduce the swap window the pinning closes.
+func (p *projectRoot) openPinnedDir(rel string, create bool) (*os.Root, string, error) {
 	current := p.root
 	owned := false
+	phys := p.phys
 	for _, component := range strings.Split(filepath.Clean(rel), string(os.PathSeparator)) {
 		if component == "" || component == "." {
 			continue
@@ -1044,18 +1066,19 @@ func (p *projectRoot) openPinnedDir(rel string, create bool) (*os.Root, error) {
 			if owned {
 				_ = current.Close()
 			}
-			return nil, err
+			return nil, "", err
 		}
 		if owned {
 			_ = current.Close()
 		}
 		current = next
 		owned = true
+		phys = filepath.Join(phys, component)
 	}
 	if !owned {
-		return nil, fmt.Errorf("refusing to pin the project root itself")
+		return nil, "", fmt.Errorf("refusing to pin the project root itself")
 	}
-	return current, nil
+	return current, phys, nil
 }
 
 // removePinned deletes name inside the PINNED parent without ever crossing a
@@ -1106,21 +1129,21 @@ func (p *projectRoot) removePinned(parent *os.Root, name string) error {
 // that contains it plus the final entry name. Every managed-target operation
 // (exists checks, RemoveAll, Symlink, copy) runs through this pair, so nothing
 // downstream ever re-resolves a path.
-func (p *projectRoot) openTargetParent(targetRel string, create bool) (*os.Root, string, error) {
+func (p *projectRoot) openTargetParent(targetRel string, create bool) (*os.Root, string, string, error) {
 	rel, err := p.validateManagedTarget(targetRel)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	dir, name := filepath.Split(rel)
 	dir = filepath.Clean(dir)
 	if name == "" {
-		return nil, "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", p.abs(rel))
+		return nil, "", "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", p.abs(rel))
 	}
-	parent, err := p.openPinnedDir(dir, create)
+	parent, parentPhys, err := p.openPinnedDir(dir, create)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	return parent, name, nil
+	return parent, name, parentPhys, nil
 }
 
 func (p *projectRoot) Close() {
@@ -1217,7 +1240,7 @@ func (p *projectRoot) validateManagedTarget(targetRel string) (string, error) {
 // project is "present" (Root refuses to traverse the escape, which is itself
 // proof the entry exists as an escaping link).
 func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, error) {
-	parent, name, err := p.openTargetParent(targetRel, false)
+	parent, name, parentPhys, err := p.openTargetParent(targetRel, false)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -1256,7 +1279,9 @@ func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, erro
 		return true, nil
 	}
 	if !filepath.IsAbs(dest) {
-		dest = filepath.Join(p.physicalDirOf(targetRel), dest)
+		// Joined against the PINNED parent's physical path (from the pin walk),
+		// never a fresh pathname lookup.
+		dest = filepath.Join(parentPhys, dest)
 	}
 
 	// Only THIS attachment's own link may be treated as healable. A link is
@@ -1269,14 +1294,20 @@ func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, erro
 	dest = filepath.Clean(dest)
 	ours := false
 	if expectedSource != "" {
-		if resolvedExpected, eerr := resolveSkillSourcePath(expectedSource); eerr == nil && resolvedExpected == dest {
+		if resolvedExpected, eerr := resolveSkillSourcePath(expectedSource); eerr == nil &&
+			(resolvedExpected == dest || physicalPath(resolvedExpected) == physicalPath(dest)) {
 			ours = true
 		}
 	}
 	if !ours {
+		destPhys := physicalPath(dest)
 		for _, dir := range knownProjectSkillsDirs() {
-			base := filepath.Clean(filepath.Join(p.path, filepath.FromSlash(dir)))
-			if dest != base && isContainedIn(base, dest) {
+			suffix := filepath.FromSlash(dir)
+			if _, matched := relUnderBase(filepath.Join(p.path, suffix), dest); matched {
+				ours = true
+				break
+			}
+			if _, matched := relUnderBase(filepath.Join(p.phys, suffix), destPhys); matched {
 				ours = true
 				break
 			}
@@ -1310,23 +1341,11 @@ func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, erro
 	return true, nil
 }
 
-// physicalDirOf returns the canonical, symlink-resolved directory that holds
-// targetRel. Relative link text must be joined against the PHYSICAL directory
-// (that is what the kernel does, and what materialize used when it computed
-// the link text); joining against a lexical alias would resolve pool links to
-// the wrong path on alias-accessed projects.
-func (p *projectRoot) physicalDirOf(targetRel string) string {
-	dir := filepath.Dir(resolveTargetPath(p.path, targetRel))
-	if physical, err := filepath.EvalSymlinks(dir); err == nil {
-		return physical
-	}
-	return dir
-}
 
 // targetEntryExists reports whether the entry itself exists (Lstat semantics:
 // a symlink counts even when it dangles).
 func (p *projectRoot) targetEntryExists(targetRel string) (bool, error) {
-	parent, name, err := p.openTargetParent(targetRel, false)
+	parent, name, _, err := p.openTargetParent(targetRel, false)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -1394,6 +1413,21 @@ func (p *projectRoot) openContainedSource(sourcePath string) (*os.Root, string, 
 	return nil, "", "", fmt.Errorf("refusing to materialize from source with more than %d symlink levels: %s", maxSourceSymlinkHops, resolved)
 }
 
+// relUnderBase reports whether target is a STRICT descendant of base and, if
+// so, its path relative to base.
+func relUnderBase(base, target string) (string, bool) {
+	base = filepath.Clean(base)
+	target = filepath.Clean(target)
+	if target == base || !isContainedIn(base, target) {
+		return "", false
+	}
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", false
+	}
+	return rel, true
+}
+
 // openSourceRootFor picks the root a resolved source belongs to. Project-local
 // candidates are validated through the pinned project descriptor BEFORE being
 // opened — a shipped ".agents/skills -> /outside" is refused rather than
@@ -1404,48 +1438,53 @@ func (p *projectRoot) openSourceRootFor(resolved string) (*os.Root, string, stri
 	if err != nil {
 		return nil, "", "", err
 	}
+	resolvedPhys := physicalPath(resolved)
 	for _, def := range sources {
 		rootPath := expandSkillPath(def.Path)
 		if rootPath == "" || !filepath.IsAbs(rootPath) {
 			continue
 		}
 		rootPath = filepath.Clean(rootPath)
-		if resolved == rootPath || !isContainedIn(rootPath, resolved) {
+		// Compare lexically AND physically: a root registered through a symlink
+		// alias (/alias/pool -> /real/pool) never matches a physical
+		// destination lexically, which broke migration from managed links and
+		// dangling-link healing for alias-registered pools. The Root is always
+		// opened at the REGISTERED path; rel is taken against whichever form
+		// matched, and both name the same directory.
+		rel, matched := relUnderBase(rootPath, resolved)
+		if !matched {
+			rel, matched = relUnderBase(physicalPath(rootPath), resolvedPhys)
+		}
+		if !matched {
 			continue
 		}
 		root, err := os.OpenRoot(rootPath)
 		if err != nil {
 			return nil, "", "", err
 		}
-		rel, err := filepath.Rel(rootPath, resolved)
-		if err != nil {
-			root.Close()
-			return nil, "", "", err
-		}
 		return root, rel, resolved, nil
 	}
 
 	for _, dir := range knownProjectSkillsDirs() {
-		base := filepath.Clean(filepath.Join(p.path, filepath.FromSlash(dir)))
-		if resolved == base || !isContainedIn(base, resolved) {
+		suffix := filepath.FromSlash(dir)
+		innerRel, matched := relUnderBase(filepath.Join(p.path, suffix), resolved)
+		if !matched {
+			innerRel, matched = relUnderBase(filepath.Join(p.phys, suffix), resolvedPhys)
+		}
+		if !matched {
 			continue
 		}
-		rel, err := p.projectRel(resolved)
-		if err != nil {
-			return nil, "", "", err
-		}
-		if err := p.requireNoSymlinkAncestors(rel, true); err != nil {
+		// The project-relative path is rebuilt from the CONSTANT managed-dir
+		// component plus the matched remainder, so an alias-accessed project
+		// resolves identically whether the caller handed us a lexical or a
+		// physical path.
+		if err := p.requireNoSymlinkAncestors(filepath.Join(suffix, innerRel), true); err != nil {
 			return nil, "", "", err
 		}
 		// Pinned by descriptor identity, same as the target side: a source dir
 		// swapped for a symlink after validation cannot be opened.
-		root, err := p.openPinnedDir(filepath.FromSlash(dir), false)
+		root, _, err := p.openPinnedDir(suffix, false)
 		if err != nil {
-			return nil, "", "", err
-		}
-		innerRel, err := filepath.Rel(base, resolved)
-		if err != nil {
-			root.Close()
 			return nil, "", "", err
 		}
 		return root, innerRel, resolved, nil
@@ -1564,7 +1603,7 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 	}
 	defer srcRoot.Close()
 
-	parent, name, err := p.openTargetParent(targetRel, true)
+	parent, name, parentPhys, err := p.openTargetParent(targetRel, true)
 	if err != nil {
 		return "", err
 	}
@@ -1584,11 +1623,13 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 		// path: the source exists (its root Stat'ed it below) and the link text
 		// is verified to rejoin exactly to the source.
 		if _, serr := srcRoot.Stat(srcRel); serr == nil {
-			linkBase := p.physicalDirOf(targetRel)
-			sourceTarget := srcAbs
-			if resolvedSource, rerr := filepath.EvalSymlinks(srcAbs); rerr == nil {
-				sourceTarget = resolvedSource
-			}
+			// parentPhys came out of the pin walk (project physical path plus
+			// components already proven to be real directories). Re-deriving it
+			// with a pathname lookup here would let a rename between pinning
+			// and link creation compute the link against a replacement
+			// directory while creating it in the pinned original.
+			linkBase := parentPhys
+			sourceTarget := physicalPath(srcAbs)
 			if linkText, rerr := filepath.Rel(linkBase, sourceTarget); rerr == nil &&
 				filepath.Clean(filepath.Join(linkBase, linkText)) == filepath.Clean(sourceTarget) {
 				if err := parent.Symlink(linkText, name); err == nil {
@@ -1606,7 +1647,7 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 // root, so there is no revalidated-by-name window between them. A non-managed,
 // absolute, or "../"-escaping target is REFUSED and never removed (Audit M3).
 func (p *projectRoot) removeManagedTarget(targetRel string) error {
-	parent, name, err := p.openTargetParent(targetRel, false)
+	parent, name, _, err := p.openTargetParent(targetRel, false)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -1695,7 +1736,12 @@ func buildAttachment(tool string, candidate SkillCandidate, mode string) Project
 	})
 }
 
-func validateAttachableSkillCandidate(candidate SkillCandidate) error {
+// validateAttachableSkillCandidate checks the candidate's own source. Every
+// metadata read goes through openContainedSource FIRST and is then performed
+// descriptor-relative inside the validated root: stat'ing the raw SourcePath
+// beforehand was an arbitrary-path existence oracle that contradicted the
+// source-side containment guarantee.
+func (p *projectRoot) validateAttachableSkillCandidate(candidate SkillCandidate) error {
 	// Project-managed skills must be directory skills carrying SKILL.md or
 	// a Claude Code plugin manifest (.claude-plugin/plugin.json) — the same
 	// markers candidate discovery accepts.
@@ -1703,7 +1749,13 @@ func validateAttachableSkillCandidate(candidate SkillCandidate) error {
 		return fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
 	}
 
-	info, err := os.Stat(candidate.SourcePath)
+	srcRoot, srcRel, _, err := p.openContainedSource(candidate.SourcePath)
+	if err != nil {
+		return err
+	}
+	defer srcRoot.Close()
+
+	info, err := srcRoot.Stat(srcRel)
 	if err != nil {
 		return err
 	}
@@ -1711,10 +1763,9 @@ func validateAttachableSkillCandidate(candidate SkillCandidate) error {
 		return fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
 	}
 
-	skillMD := filepath.Join(candidate.SourcePath, "SKILL.md")
-	if _, err := os.Stat(skillMD); err != nil {
+	if _, err := srcRoot.Stat(filepath.Join(srcRel, "SKILL.md")); err != nil {
 		if os.IsNotExist(err) {
-			if hasPluginManifest(candidate.SourcePath) {
+			if pluginInfo, perr := srcRoot.Stat(filepath.Join(srcRel, ".claude-plugin", "plugin.json")); perr == nil && !pluginInfo.IsDir() {
 				return nil
 			}
 			return fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
@@ -1739,10 +1790,16 @@ func hasPluginManifest(dir string) bool {
 // the existing target's own content rather than a fresh source.
 func (p *projectRoot) resolveMaterializationSource(sourcePath, fallbackRel string) (source string, usedFallback bool, err error) {
 	if strings.TrimSpace(sourcePath) != "" {
-		if _, err := os.Stat(sourcePath); err == nil {
-			return sourcePath, false, nil
-		} else if !os.IsNotExist(err) {
-			return "", false, err
+		// Same rule as validateAttachableSkillCandidate: containment first, then
+		// the existence check descriptor-relative inside the validated root. A
+		// source that is unreachable OR outside every registered root simply
+		// falls through to the current-target fallback below.
+		if srcRoot, srcRel, _, err := p.openContainedSource(sourcePath); err == nil {
+			_, statErr := srcRoot.Stat(srcRel)
+			srcRoot.Close()
+			if statErr == nil {
+				return sourcePath, false, nil
+			}
 		}
 	}
 	if strings.TrimSpace(fallbackRel) != "" {
@@ -1824,7 +1881,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 			if usedCurrentTarget {
 				mode, err = p.materialize(sourceToUse, desiredTargetRel, true)
 			} else {
-				if err := validateAttachableSkillCandidate(candidate); err != nil {
+				if err := p.validateAttachableSkillCandidate(candidate); err != nil {
 					return nil, err
 				}
 				mode, err = p.materialize(sourceToUse, desiredTargetRel, false)
@@ -1854,7 +1911,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 				}
 				return nil, err
 			}
-			if err := validateAttachableSkillCandidate(candidate); err != nil {
+			if err := p.validateAttachableSkillCandidate(candidate); err != nil {
 				return nil, err
 			}
 			mode, err := p.materialize(sourceToUse, existing.TargetPath, false)
@@ -1875,7 +1932,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		return &updated, nil
 	}
 
-	if err := validateAttachableSkillCandidate(candidate); err != nil {
+	if err := p.validateAttachableSkillCandidate(candidate); err != nil {
 		return nil, err
 	}
 
@@ -2121,7 +2178,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 					if usedCurrentTarget {
 						mode, err = p.materialize(sourceToUse, desiredTargetRel, true)
 					} else {
-						if err := validateAttachableSkillCandidate(candidate); err != nil {
+						if err := p.validateAttachableSkillCandidate(candidate); err != nil {
 							return err
 						}
 						mode, err = p.materialize(sourceToUse, desiredTargetRel, false)
@@ -2148,7 +2205,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 					}
 					return err
 				} else {
-					if err := validateAttachableSkillCandidate(candidate); err != nil {
+					if err := p.validateAttachableSkillCandidate(candidate); err != nil {
 						return err
 					}
 					mode, err := p.materialize(sourceToUse, desiredTargetRel, false)
@@ -2173,7 +2230,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		if err != nil {
 			return err
 		}
-		if err := validateAttachableSkillCandidate(candidate); err != nil {
+		if err := p.validateAttachableSkillCandidate(candidate); err != nil {
 			return err
 		}
 		mode, err := p.materialize(sourceToUse, attachment.TargetPath, false)

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -884,36 +884,152 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-func materializeSkillCopyOnly(sourcePath, targetPath string) (string, error) {
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-		return "", err
+// copyFileIntoRoot copies src (read with plain os APIs — the source is a
+// trusted skill pool/config dir) to dstRel inside root, creating the file
+// descriptor-relative so a hostile path swap under the managed dir cannot
+// redirect the write outside it.
+func copyFileIntoRoot(root *os.Root, src, dstRel string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
 	}
-	if err := os.RemoveAll(targetPath); err != nil {
-		return "", err
+	defer srcFile.Close()
+
+	info, err := srcFile.Stat()
+	if err != nil {
+		return err
 	}
 
+	if dir := filepath.Dir(dstRel); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	dstFile, err := root.OpenFile(dstRel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+// copyDirIntoRoot mirrors copyDir but writes descriptor-relative inside root.
+// Symlinked SOURCE entries are resolved and copied as content, same as before.
+func copyDirIntoRoot(root *os.Root, src, dstRel string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := root.MkdirAll(dstRel, 0o755); err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		entryRel := filepath.Join(dstRel, entry.Name())
+
+		info, err := os.Lstat(srcPath)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			realPath, err := filepath.EvalSymlinks(srcPath)
+			if err != nil {
+				return err
+			}
+			info, err = os.Stat(realPath)
+			if err != nil {
+				return err
+			}
+			srcPath = realPath
+		}
+
+		if info.IsDir() {
+			if err := copyDirIntoRoot(root, srcPath, entryRel); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFileIntoRoot(root, srcPath, entryRel); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func copySkillIntoRoot(root *os.Root, sourcePath, targetRel string) (string, error) {
 	info, err := os.Stat(sourcePath)
 	if err != nil {
 		return "", err
 	}
 	if info.IsDir() {
-		if err := copyDir(sourcePath, targetPath); err != nil {
+		if err := copyDirIntoRoot(root, sourcePath, targetRel); err != nil {
 			return "", err
 		}
 	} else {
-		if err := copyFile(sourcePath, targetPath); err != nil {
+		if err := copyFileIntoRoot(root, sourcePath, targetRel); err != nil {
 			return "", err
 		}
 	}
 	return "copy", nil
 }
 
-func materializeSkill(sourcePath, targetPath string) (string, error) {
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+// openManagedTargetRoot validates targetRel via managedTargetBaseAndRel,
+// ensures the managed skills dir exists, and opens it as an os.Root so all
+// mutations happen descriptor-relative (no path re-traversal, no TOCTOU
+// escape). Returns the root, the target's root-relative path, and the
+// validated absolute target path (for read-only checks and messages).
+func openManagedTargetRoot(projectPath, targetRel string) (*os.Root, string, string, error) {
+	base, rel, err := managedTargetBaseAndRel(projectPath, targetRel)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return nil, "", "", err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return root, rel, filepath.Join(base, rel), nil
+}
+
+func materializeSkillCopyOnly(projectPath, sourcePath, targetRel string) (string, error) {
+	root, rel, _, err := openManagedTargetRoot(projectPath, targetRel)
+	if err != nil {
 		return "", err
 	}
+	defer root.Close()
 
-	if err := os.RemoveAll(targetPath); err != nil {
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
+	}
+	if err := root.RemoveAll(rel); err != nil {
+		return "", err
+	}
+	return copySkillIntoRoot(root, sourcePath, rel)
+}
+
+func materializeSkill(projectPath, sourcePath, targetRel string) (string, error) {
+	root, rel, targetPath, err := openManagedTargetRoot(projectPath, targetRel)
+	if err != nil {
+		return "", err
+	}
+	defer root.Close()
+
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
+	}
+	if err := root.RemoveAll(rel); err != nil {
 		return "", err
 	}
 
@@ -932,17 +1048,22 @@ func materializeSkill(sourcePath, targetPath string) (string, error) {
 
 	relTarget, relErr := filepath.Rel(relBase, resolvedSourcePath)
 	if relErr == nil {
-		if err := os.Symlink(relTarget, targetPath); err == nil {
-			// Validate that the symlink resolves to a real target.
-			// If it does not, fall back to copy mode below.
+		// Root.Symlink creates the link descriptor-relative; the link CONTENT
+		// may point at the pool outside the root — creating it is fine, Root
+		// only forbids traversing through escapes.
+		if err := root.Symlink(relTarget, rel); err == nil {
+			// Validate that the symlink resolves to a real target. Use plain
+			// os.Stat on the absolute path: Root.Stat refuses symlinks that
+			// resolve outside the root, and legitimate pool links do exactly
+			// that. If the link dangles, fall back to copy mode below.
 			if _, err := os.Stat(targetPath); err == nil {
 				return "symlink", nil
 			}
-			_ = os.Remove(targetPath)
+			_ = root.Remove(rel)
 		}
 	}
 
-	return materializeSkillCopyOnly(sourcePath, targetPath)
+	return copySkillIntoRoot(root, sourcePath, rel)
 }
 
 func resolveTargetPath(projectPath, targetPath string) string {
@@ -950,35 +1071,6 @@ func resolveTargetPath(projectPath, targetPath string) string {
 		return filepath.Clean(targetPath)
 	}
 	return filepath.Clean(filepath.Join(projectPath, filepath.FromSlash(targetPath)))
-}
-
-// resolveSymlinkedAncestors resolves every EXISTING component of path through
-// symlinks. When path (or a suffix of it) does not exist yet — the normal case
-// on the materialization path, where the target is created by the caller — the
-// deepest existing ancestor is resolved via filepath.EvalSymlinks and the
-// non-existing remainder is re-appended verbatim. Any filesystem error other
-// than "does not exist" is returned so callers refuse rather than guess.
-func resolveSymlinkedAncestors(path string) (string, error) {
-	existing := filepath.Clean(path)
-	var suffix []string
-	for {
-		resolved, err := filepath.EvalSymlinks(existing)
-		if err == nil {
-			for i := len(suffix) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, suffix[i])
-			}
-			return resolved, nil
-		}
-		if !os.IsNotExist(err) {
-			return "", err
-		}
-		parent := filepath.Dir(existing)
-		if parent == existing {
-			return "", err
-		}
-		suffix = append(suffix, filepath.Base(existing))
-		existing = parent
-	}
 }
 
 // resolveContainedTargetPath resolves targetRel against projectPath and REFUSES
@@ -992,15 +1084,25 @@ func resolveSymlinkedAncestors(path string) (string, error) {
 // knownProjectSkillsDirs(). Callers must check the error and must not fall
 // back to the raw, unchecked resolveTargetPath for the same operation.
 //
-// Containment is checked on SYMLINK-RESOLVED paths, not just cleaned strings:
-// a repo that ships .claude/skills (or any ancestor component) as a symlink
-// pointing outside the project would otherwise string-pass the prefix check
-// while the target physically lives — and gets removed or materialized — at
-// the symlink destination. Only ancestor components are resolved; the FINAL
-// target component is deliberately left unresolved because pool-attached
-// skills are themselves symlinks inside the managed dir (os.RemoveAll on a
-// symlink removes the link, never the destination), and containment is about
+// Containment is symlink-aware, not just string-based: the project root is
+// resolved via EvalSymlinks (its OWN ancestry may legitimately contain
+// symlinks, e.g. macOS /tmp -> /private/tmp), then every component from the
+// project root down to the target is Lstat-walked. Any EXISTING non-final
+// component that is itself a symlink is refused outright — whether it points
+// outside the project, back INSIDE it (a repo shipping .claude/skills -> ..
+// would otherwise expose the project root, .git included, to RemoveAll), or
+// DANGLES (an EvalSymlinks-based check reads a dangling link's ENOENT as
+// "component absent" and passes it lexically). The managed skills dir is
+// therefore required to sit at its canonical physical location with no
+// symlinked components. Missing components are fine: the creation path
+// materializes them as real directories. The FINAL target component may be a
+// symlink — pool-attached skills are symlinks inside the managed dir, and
+// removal deletes the link, never its destination; containment is about
 // where the target path lives, not what a final-component link points to.
+//
+// The target must also be a STRICT descendant of the managed dir: a tampered
+// ".claude/skills/." cleans to the managed dir itself, and RemoveAll there
+// would wipe the whole catalog.
 func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
 	targetPath := resolveTargetPath(projectPath, targetRel)
 	skillDir, ok := managedProjectSkillsDirForTarget(targetRel)
@@ -1011,38 +1113,55 @@ func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
 	if !isContainedIn(base, targetPath) {
 		return "", fmt.Errorf("refusing to use path outside project skills dir: %s", targetPath)
 	}
+	if targetPath == filepath.Clean(base) {
+		return "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", targetPath)
+	}
 
-	// Symlink-aware containment. Resolve the project root, the managed base,
-	// and the target's PARENT through any existing symlinked ancestors (the
-	// base and target often do not exist yet on the creation path — the
-	// deepest existing ancestor is resolved and the rest re-appended).
-	resolvedProject, err := resolveSymlinkedAncestors(projectPath)
+	resolvedProject, err := filepath.EvalSymlinks(projectPath)
 	if err != nil {
 		return "", fmt.Errorf("refusing to use unresolvable project path %s: %w", projectPath, err)
 	}
-	resolvedBase, err := resolveSymlinkedAncestors(base)
-	if err != nil {
-		return "", fmt.Errorf("refusing to use unresolvable project skills dir %s: %w", base, err)
+	relFromProject, err := filepath.Rel(filepath.Clean(projectPath), targetPath)
+	if err != nil || relFromProject == "." || relFromProject == ".." ||
+		strings.HasPrefix(relFromProject, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("refusing to use path outside the project: %s", targetPath)
 	}
-	// A managed skills dir whose components symlink outside the project (e.g.
-	// a repo shipping .claude/skills -> /elsewhere) must not be treated as a
-	// managed dir at all: RemoveAll/materialize through it acts outside the
-	// project.
-	if !isContainedIn(resolvedProject, resolvedBase) {
-		return "", fmt.Errorf("refusing to use project skills dir that resolves outside the project: %s -> %s", base, resolvedBase)
-	}
-	resolvedParent, err := resolveSymlinkedAncestors(filepath.Dir(targetPath))
-	if err != nil {
-		return "", fmt.Errorf("refusing to use unresolvable target path %s: %w", targetPath, err)
-	}
-	resolvedTarget := resolvedParent
-	if targetPath != filepath.Dir(targetPath) {
-		resolvedTarget = filepath.Join(resolvedParent, filepath.Base(targetPath))
-	}
-	if !isContainedIn(resolvedBase, resolvedTarget) {
-		return "", fmt.Errorf("refusing to use target path that resolves outside the project skills dir: %s -> %s", targetPath, resolvedTarget)
+	current := resolvedProject
+	components := strings.Split(relFromProject, string(os.PathSeparator))
+	for i, component := range components {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// This component (and everything below it) does not exist yet;
+				// the creation path will materialize real directories here.
+				break
+			}
+			return "", fmt.Errorf("refusing to use unresolvable target path %s: %w", targetPath, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 && i < len(components)-1 {
+			return "", fmt.Errorf("refusing to use target path with a symlinked ancestor component: %s", current)
+		}
 	}
 	return targetPath, nil
+}
+
+// managedTargetBaseAndRel returns the canonical managed skills dir for
+// targetRel plus the target's path relative to it, after full containment
+// validation. It is the shared setup for the descriptor-relative (os.Root)
+// mutation sinks below.
+func managedTargetBaseAndRel(projectPath, targetRel string) (string, string, error) {
+	targetPath, err := resolveContainedTargetPath(projectPath, targetRel)
+	if err != nil {
+		return "", "", err
+	}
+	skillDir, _ := managedProjectSkillsDirForTarget(targetRel)
+	base := filepath.Join(projectPath, filepath.FromSlash(skillDir))
+	rel, err := filepath.Rel(filepath.Clean(base), targetPath)
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Clean(base), rel, nil
 }
 
 func removeAttachmentTarget(projectPath string, attachment ProjectSkillAttachment) error {
@@ -1050,18 +1169,31 @@ func removeAttachmentTarget(projectPath string, attachment ProjectSkillAttachmen
 }
 
 // safeRemoveManagedTarget removes targetRel (resolved against projectPath) only
-// when it is contained in a managed project-skills dir, then RemoveAll's it.
-// A non-managed, absolute, or "../"-escaping target is REFUSED and never removed.
-// Every os.RemoveAll that operates on a manifest-derived TargetPath (attach
-// detach + the migration branches in attachSkillCandidate / reconcileProjectSkills)
-// must route through here so a tampered manifest can't trigger deletion outside
-// the project skills dir. Audit M3.
+// when it is contained in a managed project-skills dir. A non-managed,
+// absolute, or "../"-escaping target is REFUSED and never removed. Every
+// removal that operates on a manifest-derived TargetPath (attach, detach + the
+// migration branches in attachSkillCandidate / reconcileProjectSkills) must
+// route through here so a tampered manifest can't trigger deletion outside the
+// project skills dir. Audit M3.
+//
+// The removal itself is descriptor-relative: the managed skills dir is opened
+// with os.Root and the target removed via Root.RemoveAll, so even a path swap
+// between validation and mutation (TOCTOU) cannot escape the managed dir —
+// the kernel enforces no-traversal semantics on every operation inside Root.
 func safeRemoveManagedTarget(projectPath, targetRel string) error {
-	targetPath, err := resolveContainedTargetPath(projectPath, targetRel)
+	base, rel, err := managedTargetBaseAndRel(projectPath, targetRel)
 	if err != nil {
 		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %w", err)
 	}
-	return os.RemoveAll(targetPath)
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer root.Close()
+	return root.RemoveAll(rel)
 }
 
 func buildAttachment(tool string, candidate SkillCandidate, mode string) ProjectSkillAttachment {
@@ -1193,12 +1325,12 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 			}
 			mode := ""
 			if sourceToUse == currentTargetPath {
-				mode, err = materializeSkillCopyOnly(sourceToUse, desiredTargetPath)
+				mode, err = materializeSkillCopyOnly(projectPath, sourceToUse, desiredTargetRel)
 			} else {
 				if err := validateAttachableSkillCandidate(candidate); err != nil {
 					return nil, err
 				}
-				mode, err = materializeSkill(sourceToUse, desiredTargetPath)
+				mode, err = materializeSkill(projectPath, sourceToUse, desiredTargetRel)
 			}
 			if err != nil {
 				return nil, err
@@ -1228,7 +1360,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 			if err := validateAttachableSkillCandidate(candidate); err != nil {
 				return nil, err
 			}
-			mode, err := materializeSkill(sourceToUse, currentTargetPath)
+			mode, err := materializeSkill(projectPath, sourceToUse, existing.TargetPath)
 			if err != nil {
 				return nil, err
 			}
@@ -1268,7 +1400,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		return nil, err
 	}
 
-	mode, err := materializeSkill(candidate.SourcePath, targetPath)
+	mode, err := materializeSkill(projectPath, candidate.SourcePath, attachment.TargetPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1476,12 +1608,12 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 				} else {
 					mode := ""
 					if sourceToUse == currentTargetPath {
-						mode, err = materializeSkillCopyOnly(sourceToUse, desiredTargetPath)
+						mode, err = materializeSkillCopyOnly(projectPath, sourceToUse, desiredTargetRel)
 					} else {
 						if err := validateAttachableSkillCandidate(candidate); err != nil {
 							return err
 						}
-						mode, err = materializeSkill(sourceToUse, desiredTargetPath)
+						mode, err = materializeSkill(projectPath, sourceToUse, desiredTargetRel)
 					}
 					if err != nil {
 						return err
@@ -1509,7 +1641,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 					if err := validateAttachableSkillCandidate(candidate); err != nil {
 						return err
 					}
-					mode, err := materializeSkill(sourceToUse, desiredTargetPath)
+					mode, err := materializeSkill(projectPath, sourceToUse, desiredTargetRel)
 					if err != nil {
 						return err
 					}
@@ -1524,8 +1656,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		}
 
 		attachment := buildAttachment(tool, candidate, "")
-		targetPath, err := resolveContainedTargetPath(projectPath, attachment.TargetPath)
-		if err != nil {
+		if _, err := resolveContainedTargetPath(projectPath, attachment.TargetPath); err != nil {
 			return err
 		}
 		sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, "")
@@ -1535,7 +1666,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		if err := validateAttachableSkillCandidate(candidate); err != nil {
 			return err
 		}
-		mode, err := materializeSkill(sourceToUse, targetPath)
+		mode, err := materializeSkill(projectPath, sourceToUse, attachment.TargetPath)
 		if err != nil {
 			return err
 		}

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -1209,7 +1209,27 @@ func (p *projectRoot) targetExists(targetRel string) (bool, error) {
 	if !filepath.IsAbs(dest) {
 		dest = filepath.Join(p.physicalDirOf(targetRel), dest)
 	}
-	if _, err := os.Stat(filepath.Clean(dest)); err != nil {
+
+	// The link destination is attacker-influenced, so NO filesystem call may
+	// touch it as a bare path (CodeQL go/path-injection). It is routed through
+	// the same containment gate every other source takes: openContainedSource
+	// requires it to sit strictly inside a registered sources.toml root or a
+	// managed project skills dir, follows further hops under that same rule
+	// with a capped hop count, and hands back a Root anchored at the validated
+	// root — the existence check is then descriptor-relative inside it.
+	//
+	// A destination that resolves OUTSIDE every registered root is not probed
+	// at all: it is a foreign replacement, reported as PRESENT so the loadout
+	// layer refuses it rather than silently overwriting it.
+	srcRoot, srcRel, _, err := p.openContainedSource(dest)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return true, nil
+	}
+	defer srcRoot.Close()
+	if _, err := srcRoot.Stat(srcRel); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -727,12 +728,16 @@ func sortAttachments(skills []ProjectSkillAttachment) {
 // but a repo can still ship .agent-deck as a symlink; requireNoSymlinkAncestors
 // refuses that instead of reading (or later writing) through it.
 func (p *projectRoot) loadManifest() (*ProjectSkillsManifest, error) {
-	rel := filepath.Join(projectSkillsDirName, projectSkillsManifest)
-	if err := p.requireNoSymlinkAncestors(rel, false); err != nil {
+	dir, err := p.openPinnedDir(projectSkillsDirName, false)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{}}, nil
+		}
 		return nil, err
 	}
+	defer dir.Close()
 
-	data, err := p.root.ReadFile(rel)
+	data, err := dir.ReadFile(projectSkillsManifest)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{}}, nil
@@ -769,13 +774,11 @@ func (p *projectRoot) saveManifest(manifest *ProjectSkillsManifest) error {
 	}
 	sortAttachments(manifest.Skills)
 
-	rel := filepath.Join(projectSkillsDirName, projectSkillsManifest)
-	if err := p.requireNoSymlinkAncestors(rel, false); err != nil {
-		return err
+	dir, err := p.openPinnedDir(projectSkillsDirName, true)
+	if err != nil {
+		return fmt.Errorf("failed to open manifest directory: %w", err)
 	}
-	if err := p.root.MkdirAll(projectSkillsDirName, 0o700); err != nil {
-		return fmt.Errorf("failed to create manifest directory: %w", err)
-	}
+	defer dir.Close()
 
 	var buf bytes.Buffer
 	encoder := toml.NewEncoder(&buf)
@@ -783,12 +786,29 @@ func (p *projectRoot) saveManifest(manifest *ProjectSkillsManifest) error {
 		return fmt.Errorf("failed to encode skills manifest: %w", err)
 	}
 
-	tmpRel := rel + ".tmp"
-	if err := p.root.WriteFile(tmpRel, buf.Bytes(), 0o600); err != nil {
+	// Randomized name + O_CREATE|O_EXCL: a predictable, truncating temp path
+	// can be pre-created as a hard link to a victim file, which the save would
+	// then truncate. O_EXCL refuses to reuse any existing entry.
+	var nonce [8]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
 		return fmt.Errorf("failed to write skills manifest: %w", err)
 	}
-	if err := p.root.Rename(tmpRel, rel); err != nil {
-		_ = p.root.Remove(tmpRel)
+	tmpName := fmt.Sprintf("%s.%x.tmp", projectSkillsManifest, nonce)
+	tmpFile, err := dir.OpenFile(tmpName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to write skills manifest: %w", err)
+	}
+	if _, err := tmpFile.Write(buf.Bytes()); err != nil {
+		_ = tmpFile.Close()
+		_ = dir.Remove(tmpName)
+		return fmt.Errorf("failed to write skills manifest: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = dir.Remove(tmpName)
+		return fmt.Errorf("failed to write skills manifest: %w", err)
+	}
+	if err := dir.Rename(tmpName, projectSkillsManifest); err != nil {
+		_ = dir.Remove(tmpName)
 		return fmt.Errorf("failed to save skills manifest: %w", err)
 	}
 	return nil
@@ -933,6 +953,7 @@ func copyDir(src, dst string) error {
 type projectRoot struct {
 	path string
 	root *os.Root
+	info os.FileInfo // the pinned project dir itself, for device identity
 }
 
 func openProjectRoot(projectPath string) (*projectRoot, error) {
@@ -940,7 +961,117 @@ func openProjectRoot(projectPath string) (*projectRoot, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &projectRoot{path: filepath.Clean(projectPath), root: root}, nil
+	info, err := root.Stat(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	return &projectRoot{path: filepath.Clean(projectPath), root: root, info: info}, nil
+}
+
+// openPinnedChildDir opens ONE component below parent as a pinned child root.
+//
+// This is what makes validation and mutation inseparable. Checking a name and
+// then operating on that name again leaves a window in which the entry can be
+// swapped for a symlink that still resolves INSIDE the project (".claude/skills
+// -> ..", which os.Root permits because it never leaves the root) — the check
+// passes and the mutation lands on the project root. Here the entry is
+// inspected with Lstat, opened, and the OPENED DESCRIPTOR is then verified to
+// be the very inode that was inspected (os.SameFile). A swap in between
+// changes the identity and is refused; everything afterwards runs against the
+// descriptor, which no rename can redirect.
+//
+// The component must be a real directory (never a symlink) on the same
+// filesystem as the project, so a mount planted at a managed dir cannot
+// redirect removal or materialization onto foreign content either.
+func (p *projectRoot) openPinnedChildDir(parent *os.Root, name string, create bool) (*os.Root, error) {
+	info, err := parent.Lstat(name)
+	if err != nil {
+		if !os.IsNotExist(err) || !create {
+			return nil, err
+		}
+		if err := parent.Mkdir(name, 0o755); err != nil && !os.IsExist(err) {
+			return nil, err
+		}
+		info, err = parent.Lstat(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to use symlinked directory component: %s", name)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("refusing to use non-directory component: %s", name)
+	}
+	child, err := parent.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	pinned, err := child.Stat(".")
+	if err != nil {
+		_ = child.Close()
+		return nil, err
+	}
+	if !os.SameFile(info, pinned) {
+		_ = child.Close()
+		return nil, fmt.Errorf("refusing to use directory component that changed identity during validation: %s", name)
+	}
+	if !sameFilesystem(p.info, pinned) {
+		_ = child.Close()
+		return nil, fmt.Errorf("refusing to use directory component on a different filesystem: %s", name)
+	}
+	return child, nil
+}
+
+// openPinnedDir walks rel component by component, pinning each directory by
+// descriptor identity. The returned root is the deepest directory; the caller
+// operates on entries inside it by NAME ONLY, never by reassembled path.
+func (p *projectRoot) openPinnedDir(rel string, create bool) (*os.Root, error) {
+	current := p.root
+	owned := false
+	for _, component := range strings.Split(filepath.Clean(rel), string(os.PathSeparator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		next, err := p.openPinnedChildDir(current, component, create)
+		if err != nil {
+			if owned {
+				_ = current.Close()
+			}
+			return nil, err
+		}
+		if owned {
+			_ = current.Close()
+		}
+		current = next
+		owned = true
+	}
+	if !owned {
+		return nil, fmt.Errorf("refusing to pin the project root itself")
+	}
+	return current, nil
+}
+
+// openTargetParent validates a managed target and returns the PINNED directory
+// that contains it plus the final entry name. Every managed-target operation
+// (exists checks, RemoveAll, Symlink, copy) runs through this pair, so nothing
+// downstream ever re-resolves a path.
+func (p *projectRoot) openTargetParent(targetRel string, create bool) (*os.Root, string, error) {
+	rel, err := p.validateManagedTarget(targetRel)
+	if err != nil {
+		return nil, "", err
+	}
+	dir, name := filepath.Split(rel)
+	dir = filepath.Clean(dir)
+	if name == "" {
+		return nil, "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", p.abs(rel))
+	}
+	parent, err := p.openPinnedDir(dir, create)
+	if err != nil {
+		return nil, "", err
+	}
+	return parent, name, nil
 }
 
 func (p *projectRoot) Close() {
@@ -1036,23 +1167,82 @@ func (p *projectRoot) validateManagedTarget(targetRel string) (string, error) {
 // while a pool symlink whose destination legitimately lives outside the
 // project is "present" (Root refuses to traverse the escape, which is itself
 // proof the entry exists as an escaping link).
-func (p *projectRoot) targetExists(rel string) (bool, error) {
-	if _, err := p.root.Stat(rel); err == nil {
-		return true, nil
-	} else if !os.IsNotExist(err) {
-		if _, lerr := p.root.Lstat(rel); lerr == nil {
-			return true, nil
-		} else if !os.IsNotExist(lerr) {
-			return false, err
+func (p *projectRoot) targetExists(targetRel string) (bool, error) {
+	parent, name, err := p.openTargetParent(targetRel, false)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
 		}
+		return false, err
 	}
-	return false, nil
+	defer parent.Close()
+
+	if _, err := parent.Stat(name); err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	// Root.Stat reports the escape before it reports whether the destination
+	// exists, so an out-of-root link lands here whether it is a live pool
+	// attachment or a dangling leftover. Read the link and check the
+	// destination through a registered source root: a live pool skill counts
+	// as present, a dangling or non-source destination counts as ABSENT so the
+	// attach flow rematerializes over it instead of reporting it attached.
+	info, lerr := parent.Lstat(name)
+	if lerr != nil {
+		if os.IsNotExist(lerr) {
+			return false, nil
+		}
+		return false, lerr
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return true, nil
+	}
+	dest, rerr := parent.Readlink(name)
+	if rerr != nil {
+		return false, nil
+	}
+	if !filepath.IsAbs(dest) {
+		dest = filepath.Join(p.physicalDirOf(targetRel), dest)
+	}
+	srcRoot, srcRel, _, err := p.openContainedSource(dest)
+	if err != nil {
+		return false, nil
+	}
+	defer srcRoot.Close()
+	if _, err := srcRoot.Stat(srcRel); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// physicalDirOf returns the canonical, symlink-resolved directory that holds
+// targetRel. Relative link text must be joined against the PHYSICAL directory
+// (that is what the kernel does, and what materialize used when it computed
+// the link text); joining against a lexical alias would resolve pool links to
+// the wrong path on alias-accessed projects.
+func (p *projectRoot) physicalDirOf(targetRel string) string {
+	dir := filepath.Dir(resolveTargetPath(p.path, targetRel))
+	if physical, err := filepath.EvalSymlinks(dir); err == nil {
+		return physical
+	}
+	return dir
 }
 
 // targetEntryExists reports whether the entry itself exists (Lstat semantics:
 // a symlink counts even when it dangles).
-func (p *projectRoot) targetEntryExists(rel string) (bool, error) {
-	if _, err := p.root.Lstat(rel); err == nil {
+func (p *projectRoot) targetEntryExists(targetRel string) (bool, error) {
+	parent, name, err := p.openTargetParent(targetRel, false)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer parent.Close()
+
+	if _, err := parent.Lstat(name); err == nil {
 		return true, nil
 	} else if !os.IsNotExist(err) {
 		return false, err
@@ -1098,7 +1288,11 @@ func (p *projectRoot) openContainedSource(sourcePath string) (*os.Root, string, 
 			return nil, "", "", rerr
 		}
 		if !filepath.IsAbs(dest) {
-			dest = filepath.Join(filepath.Dir(abs), dest)
+			baseDir := filepath.Dir(abs)
+			if physical, perr := filepath.EvalSymlinks(baseDir); perr == nil {
+				baseDir = physical
+			}
+			dest = filepath.Join(baseDir, dest)
 		}
 		resolved = filepath.Clean(dest)
 	}
@@ -1148,7 +1342,9 @@ func (p *projectRoot) openSourceRootFor(resolved string) (*os.Root, string, stri
 		if err := p.requireNoSymlinkAncestors(rel, true); err != nil {
 			return nil, "", "", err
 		}
-		root, err := p.root.OpenRoot(filepath.FromSlash(dir))
+		// Pinned by descriptor identity, same as the target side: a source dir
+		// swapped for a symlink after validation cannot be opened.
+		root, err := p.openPinnedDir(filepath.FromSlash(dir), false)
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -1269,16 +1465,13 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 	}
 	defer srcRoot.Close()
 
-	rel, err := p.validateManagedTarget(targetRel)
+	parent, name, err := p.openTargetParent(targetRel, true)
 	if err != nil {
 		return "", err
 	}
-	if dir := filepath.Dir(rel); dir != "." {
-		if err := p.root.MkdirAll(dir, 0o755); err != nil {
-			return "", err
-		}
-	}
-	if err := p.root.RemoveAll(rel); err != nil {
+	defer parent.Close()
+
+	if err := parent.RemoveAll(name); err != nil {
 		return "", err
 	}
 
@@ -1292,24 +1485,21 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 		// path: the source exists (its root Stat'ed it below) and the link text
 		// is verified to rejoin exactly to the source.
 		if _, serr := srcRoot.Stat(srcRel); serr == nil {
-			linkBase := p.abs(filepath.Dir(rel))
-			if resolvedBase, rerr := filepath.EvalSymlinks(linkBase); rerr == nil {
-				linkBase = resolvedBase
-			}
+			linkBase := p.physicalDirOf(targetRel)
 			sourceTarget := srcAbs
 			if resolvedSource, rerr := filepath.EvalSymlinks(srcAbs); rerr == nil {
 				sourceTarget = resolvedSource
 			}
 			if linkText, rerr := filepath.Rel(linkBase, sourceTarget); rerr == nil &&
 				filepath.Clean(filepath.Join(linkBase, linkText)) == filepath.Clean(sourceTarget) {
-				if err := p.root.Symlink(linkText, rel); err == nil {
+				if err := parent.Symlink(linkText, name); err == nil {
 					return "symlink", nil
 				}
 			}
 		}
 	}
 
-	return copySkillIntoRoot(p.root, srcRoot, srcRel, rel)
+	return copySkillIntoRoot(parent, srcRoot, srcRel, name)
 }
 
 // removeManagedTarget validates and removes in one descriptor-relative step:
@@ -1317,11 +1507,15 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 // root, so there is no revalidated-by-name window between them. A non-managed,
 // absolute, or "../"-escaping target is REFUSED and never removed (Audit M3).
 func (p *projectRoot) removeManagedTarget(targetRel string) error {
-	rel, err := p.validateManagedTarget(targetRel)
+	parent, name, err := p.openTargetParent(targetRel, false)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %w", err)
 	}
-	return p.root.RemoveAll(rel)
+	defer parent.Close()
+	return parent.RemoveAll(name)
 }
 
 // materializeSkill / materializeSkillCopyOnly / safeRemoveManagedTarget are the

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -884,52 +884,68 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-// resolveContainedSourcePath validates a materialization SOURCE path the way
+// openContainedSourceRoot validates a materialization SOURCE path the way
 // targets are validated (CodeQL go/path-injection, alert 237): the destination
 // side is Root-confined, but the source still arrives from manifest- or
-// candidate-derived data and is opened by path. A source is accepted only when
-// it sits strictly inside a registered skill source root (sources.toml: the
-// managed pool, claude-global, and operator-registered dirs) or strictly
-// inside one of the project's own managed skills dirs (the migration fallback
-// that copies from the current, already containment-checked target). Anything
-// else — absolute paths into arbitrary trees, "../" escapes — is refused
-// before any filesystem read.
-func resolveContainedSourcePath(projectPath, sourcePath string) (string, error) {
+// candidate-derived data. A source is accepted only when it sits strictly
+// inside a registered skill source root (sources.toml: the managed pool,
+// claude-global, and operator-registered dirs) or strictly inside one of the
+// project's own managed skills dirs (the migration fallback that copies from
+// the current, already containment-checked target). The accepted root is
+// returned as an os.Root opened at the REGISTERED root path, so every
+// subsequent source read is descriptor-relative and cannot traverse outside
+// it. Anything else — absolute paths into arbitrary trees, "../" escapes —
+// is refused before any filesystem read.
+func openContainedSourceRoot(projectPath, sourcePath string) (*os.Root, string, string, error) {
 	resolved, err := resolveSkillSourcePath(sourcePath)
 	if err != nil {
-		return "", err
+		return nil, "", "", err
+	}
+
+	openAt := func(rootPath string) (*os.Root, string, string, error) {
+		root, err := os.OpenRoot(rootPath)
+		if err != nil {
+			return nil, "", "", err
+		}
+		rel, err := filepath.Rel(rootPath, resolved)
+		if err != nil {
+			root.Close()
+			return nil, "", "", err
+		}
+		return root, rel, resolved, nil
 	}
 
 	sources, err := LoadSkillSources()
 	if err != nil {
-		return "", err
+		return nil, "", "", err
 	}
 	for _, def := range sources {
 		rootPath := expandSkillPath(def.Path)
 		if rootPath == "" || !filepath.IsAbs(rootPath) {
 			continue
 		}
-		if resolved != filepath.Clean(rootPath) && isContainedIn(rootPath, resolved) {
-			return resolved, nil
+		rootPath = filepath.Clean(rootPath)
+		if resolved != rootPath && isContainedIn(rootPath, resolved) {
+			return openAt(rootPath)
 		}
 	}
 
 	for _, dir := range knownProjectSkillsDirs() {
-		base := filepath.Join(projectPath, filepath.FromSlash(dir))
-		if resolved != filepath.Clean(base) && isContainedIn(base, resolved) {
-			return resolved, nil
+		base := filepath.Clean(filepath.Join(projectPath, filepath.FromSlash(dir)))
+		if resolved != base && isContainedIn(base, resolved) {
+			return openAt(base)
 		}
 	}
 
-	return "", fmt.Errorf("refusing to materialize from source outside registered skill sources: %s", resolved)
+	return nil, "", "", fmt.Errorf("refusing to materialize from source outside registered skill sources: %s", resolved)
 }
 
-// copyFileIntoRoot copies src (read with plain os APIs — src has passed
-// resolveContainedSourcePath at the materialize entry points) to dstRel inside
-// root, creating the file descriptor-relative so a hostile path swap under
-// the managed dir cannot redirect the write outside it.
-func copyFileIntoRoot(root *os.Root, src, dstRel string) error {
-	srcFile, err := os.Open(src)
+// copyFileIntoRoot copies srcRel (read descriptor-relative inside srcRoot, a
+// registered skill source root) to dstRel inside dstRoot, so neither side of
+// the copy can be redirected outside its root by a hostile path swap. A
+// symlinked source file is followed only within srcRoot; escapes error.
+func copyFileIntoRoot(dstRoot, srcRoot *os.Root, srcRel, dstRel string) error {
+	srcFile, err := srcRoot.Open(srcRel)
 	if err != nil {
 		return err
 	}
@@ -941,12 +957,12 @@ func copyFileIntoRoot(root *os.Root, src, dstRel string) error {
 	}
 
 	if dir := filepath.Dir(dstRel); dir != "." {
-		if err := root.MkdirAll(dir, 0o755); err != nil {
+		if err := dstRoot.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}
 	}
 
-	dstFile, err := root.OpenFile(dstRel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	dstFile, err := dstRoot.OpenFile(dstRel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
 	if err != nil {
 		return err
 	}
@@ -958,43 +974,41 @@ func copyFileIntoRoot(root *os.Root, src, dstRel string) error {
 	return nil
 }
 
-// copyDirIntoRoot mirrors copyDir but writes descriptor-relative inside root.
-// Symlinked SOURCE entries are resolved and copied as content, same as before.
-func copyDirIntoRoot(root *os.Root, src, dstRel string) error {
-	entries, err := os.ReadDir(src)
+// copyDirIntoRoot mirrors copyDir but reads and writes descriptor-relative.
+// Symlinked SOURCE entries are followed and copied as content like before,
+// with one deliberate tightening: a source symlink may only resolve within
+// the registered source root — an escape errors instead of being followed.
+func copyDirIntoRoot(dstRoot, srcRoot *os.Root, srcRel, dstRel string) error {
+	srcDir, err := srcRoot.Open(srcRel)
 	if err != nil {
 		return err
 	}
-	if err := root.MkdirAll(dstRel, 0o755); err != nil {
+	entries, err := srcDir.ReadDir(-1)
+	srcDir.Close()
+	if err != nil {
+		return err
+	}
+	if err := dstRoot.MkdirAll(dstRel, 0o755); err != nil {
 		return err
 	}
 
 	for _, entry := range entries {
-		srcPath := filepath.Join(src, entry.Name())
-		entryRel := filepath.Join(dstRel, entry.Name())
+		entrySrcRel := filepath.Join(srcRel, entry.Name())
+		entryDstRel := filepath.Join(dstRel, entry.Name())
 
-		info, err := os.Lstat(srcPath)
+		// Stat (not Lstat): follows in-root symlinked source entries so their
+		// CONTENT is copied, matching the previous EvalSymlinks behavior.
+		info, err := srcRoot.Stat(entrySrcRel)
 		if err != nil {
 			return err
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			realPath, err := filepath.EvalSymlinks(srcPath)
-			if err != nil {
-				return err
-			}
-			info, err = os.Stat(realPath)
-			if err != nil {
-				return err
-			}
-			srcPath = realPath
-		}
 
 		if info.IsDir() {
-			if err := copyDirIntoRoot(root, srcPath, entryRel); err != nil {
+			if err := copyDirIntoRoot(dstRoot, srcRoot, entrySrcRel, entryDstRel); err != nil {
 				return err
 			}
 		} else {
-			if err := copyFileIntoRoot(root, srcPath, entryRel); err != nil {
+			if err := copyFileIntoRoot(dstRoot, srcRoot, entrySrcRel, entryDstRel); err != nil {
 				return err
 			}
 		}
@@ -1002,17 +1016,17 @@ func copyDirIntoRoot(root *os.Root, src, dstRel string) error {
 	return nil
 }
 
-func copySkillIntoRoot(root *os.Root, sourcePath, targetRel string) (string, error) {
-	info, err := os.Stat(sourcePath)
+func copySkillIntoRoot(dstRoot, srcRoot *os.Root, srcRel, dstRel string) (string, error) {
+	info, err := srcRoot.Stat(srcRel)
 	if err != nil {
 		return "", err
 	}
 	if info.IsDir() {
-		if err := copyDirIntoRoot(root, sourcePath, targetRel); err != nil {
+		if err := copyDirIntoRoot(dstRoot, srcRoot, srcRel, dstRel); err != nil {
 			return "", err
 		}
 	} else {
-		if err := copyFileIntoRoot(root, sourcePath, targetRel); err != nil {
+		if err := copyFileIntoRoot(dstRoot, srcRoot, srcRel, dstRel); err != nil {
 			return "", err
 		}
 	}
@@ -1029,10 +1043,21 @@ func openManagedTargetRoot(projectPath, targetRel string) (*os.Root, string, str
 	if err != nil {
 		return nil, "", "", err
 	}
-	if err := os.MkdirAll(base, 0o755); err != nil {
+	skillDir, _ := managedProjectSkillsDirForTarget(targetRel)
+	// Create and open the managed dir descriptor-relative to the project root:
+	// skillDir is one of the knownProjectSkillsDirs constants, so nothing
+	// manifest-derived reaches MkdirAll, and the sub-Root open cannot traverse
+	// a component swapped in after validation.
+	projRoot, err := os.OpenRoot(projectPath)
+	if err != nil {
 		return nil, "", "", err
 	}
-	root, err := os.OpenRoot(base)
+	defer projRoot.Close()
+	skillDirRel := filepath.FromSlash(skillDir)
+	if err := projRoot.MkdirAll(skillDirRel, 0o755); err != nil {
+		return nil, "", "", err
+	}
+	root, err := projRoot.OpenRoot(skillDirRel)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -1040,10 +1065,11 @@ func openManagedTargetRoot(projectPath, targetRel string) (*os.Root, string, str
 }
 
 func materializeSkillCopyOnly(projectPath, sourcePath, targetRel string) (string, error) {
-	sourcePath, err := resolveContainedSourcePath(projectPath, sourcePath)
+	srcRoot, srcRel, _, err := openContainedSourceRoot(projectPath, sourcePath)
 	if err != nil {
 		return "", err
 	}
+	defer srcRoot.Close()
 	root, rel, _, err := openManagedTargetRoot(projectPath, targetRel)
 	if err != nil {
 		return "", err
@@ -1058,14 +1084,15 @@ func materializeSkillCopyOnly(projectPath, sourcePath, targetRel string) (string
 	if err := root.RemoveAll(rel); err != nil {
 		return "", err
 	}
-	return copySkillIntoRoot(root, sourcePath, rel)
+	return copySkillIntoRoot(root, srcRoot, srcRel, rel)
 }
 
 func materializeSkill(projectPath, sourcePath, targetRel string) (string, error) {
-	sourcePath, err := resolveContainedSourcePath(projectPath, sourcePath)
+	srcRoot, srcRel, resolvedSource, err := openContainedSourceRoot(projectPath, sourcePath)
 	if err != nil {
 		return "", err
 	}
+	defer srcRoot.Close()
 	root, rel, targetPath, err := openManagedTargetRoot(projectPath, targetRel)
 	if err != nil {
 		return "", err
@@ -1084,8 +1111,8 @@ func materializeSkill(projectPath, sourcePath, targetRel string) (string, error)
 	// Resolve symlinks before computing relative paths.
 	// This avoids broken relative links when target lives under a symlinked path
 	// (for example macOS /tmp -> /private/tmp).
-	resolvedSourcePath := sourcePath
-	if resolved, err := filepath.EvalSymlinks(sourcePath); err == nil {
+	resolvedSourcePath := resolvedSource
+	if resolved, err := filepath.EvalSymlinks(resolvedSource); err == nil {
 		resolvedSourcePath = resolved
 	}
 
@@ -1111,7 +1138,7 @@ func materializeSkill(projectPath, sourcePath, targetRel string) (string, error)
 		}
 	}
 
-	return copySkillIntoRoot(root, sourcePath, rel)
+	return copySkillIntoRoot(root, srcRoot, srcRel, rel)
 }
 
 func resolveTargetPath(projectPath, targetPath string) string {
@@ -1165,20 +1192,27 @@ func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
 		return "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", targetPath)
 	}
 
-	resolvedProject, err := filepath.EvalSymlinks(projectPath)
+	// Walk descriptor-relative from the project root: os.Root pins the
+	// directory once, so the per-component Lstat can neither be redirected by
+	// a concurrent path swap above the project nor traverse an escape (Root
+	// errors instead). The project's OWN ancestry may contain legitimate
+	// symlinks (macOS /tmp -> /private/tmp); opening the Root traverses those
+	// once and the checks below only see components INSIDE the project.
+	projRoot, err := os.OpenRoot(projectPath)
 	if err != nil {
 		return "", fmt.Errorf("refusing to use unresolvable project path %s: %w", projectPath, err)
 	}
+	defer projRoot.Close()
 	relFromProject, err := filepath.Rel(filepath.Clean(projectPath), targetPath)
 	if err != nil || relFromProject == "." || relFromProject == ".." ||
 		strings.HasPrefix(relFromProject, ".."+string(os.PathSeparator)) {
 		return "", fmt.Errorf("refusing to use path outside the project: %s", targetPath)
 	}
-	current := resolvedProject
+	relSoFar := ""
 	components := strings.Split(relFromProject, string(os.PathSeparator))
 	for i, component := range components {
-		current = filepath.Join(current, component)
-		info, err := os.Lstat(current)
+		relSoFar = filepath.Join(relSoFar, component)
+		info, err := projRoot.Lstat(relSoFar)
 		if err != nil {
 			if os.IsNotExist(err) {
 				// This component (and everything below it) does not exist yet;
@@ -1188,7 +1222,7 @@ func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
 			return "", fmt.Errorf("refusing to use unresolvable target path %s: %w", targetPath, err)
 		}
 		if info.Mode()&os.ModeSymlink != 0 && i < len(components)-1 {
-			return "", fmt.Errorf("refusing to use target path with a symlinked ancestor component: %s", current)
+			return "", fmt.Errorf("refusing to use target path with a symlinked ancestor component: %s", filepath.Join(projectPath, relSoFar))
 		}
 	}
 	return targetPath, nil

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -957,7 +957,7 @@ func copyDir(src, dst string) error {
 // "operate on a path" leaves a window (and a fresh traversal) every time.
 type projectRoot struct {
 	path string
-	phys string      // physical (symlink-resolved) project path, resolved ONCE
+	phys string // physical (symlink-resolved) project path, resolved ONCE
 	root *os.Root
 	info os.FileInfo // the pinned project dir itself, for device identity
 }
@@ -1340,7 +1340,6 @@ func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, erro
 	}
 	return true, nil
 }
-
 
 // targetEntryExists reports whether the entry itself exists (Lstat semantics:
 // a symlink counts even when it dangles).

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -1251,29 +1251,31 @@ func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, erro
 
 	if _, err := parent.Stat(name); err == nil {
 		return true, nil
-	} else if os.IsNotExist(err) {
-		return false, nil
 	}
 
-	// Root.Stat reports the escape before it reports whether the destination
-	// exists, so an out-of-root link lands here whether it is a live pool
-	// attachment or a dangling leftover. Resolve the link explicitly and let
-	// the DESTINATION decide: a link that resolves (pool attachment, or a
-	// foreign replacement the loadout layer must report rather than silently
-	// overwrite) counts as present; a dangling link counts as ABSENT so the
-	// attach flow rematerializes over it. This is a read-only metadata check
-	// on the link's own destination — the same thing the previous os.Stat on
-	// the target did — while every mutation stays descriptor-relative.
+	// Stat failing is NOT proof of absence, and concluding absence from it was
+	// a bug: a dangling link whose destination stays inside the managed root
+	// (say "lint -> unrelated-missing") ENOENTs here, and returning early made
+	// attach delete and replace a foreign entry instead of reporting it. Lstat
+	// the ENTRY first, then let ownership classification decide.
 	info, lerr := parent.Lstat(name)
 	if lerr != nil {
 		if os.IsNotExist(lerr) {
+			// Genuinely missing: nothing is there to report or overwrite.
 			return false, nil
 		}
 		return false, lerr
 	}
 	if info.Mode()&os.ModeSymlink == 0 {
+		// A real entry that Stat could not resolve still EXISTS.
 		return true, nil
 	}
+
+	// From here the entry is a symlink. Its destination decides: only a link
+	// proven to be THIS attachment's own (below) may count as absent so the
+	// attach flow can heal it. Everything else — live pool attachments and
+	// foreign replacements alike — counts as present, leaving the call to the
+	// loadout layer rather than silently overwriting it.
 	dest, rerr := parent.Readlink(name)
 	if rerr != nil {
 		return true, nil
@@ -1324,15 +1326,15 @@ func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, erro
 	// managed project skills dir, follows further hops under that same rule
 	// with a capped hop count, and hands back a Root anchored at the validated
 	// root — the existence check is then descriptor-relative inside it.
-	srcRoot, srcRel, _, err := p.openContainedSource(dest)
+	src, err := p.openContainedSource(dest)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return true, nil
 	}
-	defer srcRoot.Close()
-	if _, err := srcRoot.Stat(srcRel); err != nil {
+	defer src.Close()
+	if _, err := src.root.Stat(src.rel); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
@@ -1374,42 +1376,67 @@ func (p *projectRoot) targetEntryExists(targetRel string) (bool, error) {
 // from an existing pool-attached symlink work when the recorded source path is
 // gone: the managed entry is a link into the pool, so reading it as a source
 // means validating the POOL destination, not refusing the escape.
-func (p *projectRoot) openContainedSource(sourcePath string) (*os.Root, string, string, error) {
+// containedSource is a validated materialization source: a pinned root, the
+// entry's path relative to that root, the lexical absolute path (for messages
+// and link-text interpretation), and the root's PHYSICAL path captured when
+// the root was opened. rootPhys is what makes it possible to name the source
+// after pinning WITHOUT a fresh pathname lookup — resolving srcAbs again post
+// validation would follow a component swapped in afterwards and could point a
+// managed attachment straight out of the source root.
+type containedSource struct {
+	root     *os.Root
+	rel      string
+	abs      string
+	rootPhys string
+}
+
+// target is the absolute path the source occupies, derived purely from pinned
+// state: the root's captured physical path plus the validated remainder.
+func (c *containedSource) target() string {
+	return filepath.Join(c.rootPhys, c.rel)
+}
+
+func (c *containedSource) Close() {
+	if c != nil && c.root != nil {
+		_ = c.root.Close()
+	}
+}
+
+func (p *projectRoot) openContainedSource(sourcePath string) (*containedSource, error) {
 	resolved, err := resolveSkillSourcePath(sourcePath)
 	if err != nil {
-		return nil, "", "", err
+		return nil, err
 	}
 
 	// The budget counts LINKS FOLLOWED; the terminal path is always validated
 	// because each iteration returns as soon as the entry is not a symlink.
 	for hop := 0; hop <= maxSourceSymlinkHops; hop++ {
-		root, rel, abs, err := p.openSourceRootFor(resolved)
+		src, err := p.openSourceRootFor(resolved)
 		if err != nil {
-			return nil, "", "", err
+			return nil, err
 		}
-		info, lerr := root.Lstat(rel)
+		info, lerr := src.root.Lstat(src.rel)
 		if lerr != nil {
-			root.Close()
-			return nil, "", "", lerr
+			src.Close()
+			return nil, lerr
 		}
 		if info.Mode()&os.ModeSymlink == 0 {
-			return root, rel, abs, nil
+			return src, nil
 		}
-		dest, rerr := root.Readlink(rel)
-		root.Close()
+		dest, rerr := src.root.Readlink(src.rel)
+		linkDir := filepath.Dir(src.target())
+		src.Close()
 		if rerr != nil {
-			return nil, "", "", rerr
+			return nil, rerr
 		}
 		if !filepath.IsAbs(dest) {
-			baseDir := filepath.Dir(abs)
-			if physical, perr := filepath.EvalSymlinks(baseDir); perr == nil {
-				baseDir = physical
-			}
-			dest = filepath.Join(baseDir, dest)
+			// Joined against the pinned root's captured physical path, not a
+			// fresh EvalSymlinks of the link's own directory.
+			dest = filepath.Join(linkDir, dest)
 		}
 		resolved = filepath.Clean(dest)
 	}
-	return nil, "", "", fmt.Errorf("refusing to materialize from source with more than %d symlink levels: %s", maxSourceSymlinkHops, resolved)
+	return nil, fmt.Errorf("refusing to materialize from source with more than %d symlink levels: %s", maxSourceSymlinkHops, resolved)
 }
 
 // relUnderBase reports whether target is a STRICT descendant of base and, if
@@ -1432,10 +1459,10 @@ func relUnderBase(base, target string) (string, bool) {
 // opened — a shipped ".agents/skills -> /outside" is refused rather than
 // anchored — and are then opened RELATIVE to the project root using the
 // constant managed-dir component, never by reassembled absolute path.
-func (p *projectRoot) openSourceRootFor(resolved string) (*os.Root, string, string, error) {
+func (p *projectRoot) openSourceRootFor(resolved string) (*containedSource, error) {
 	sources, err := LoadSkillSources()
 	if err != nil {
-		return nil, "", "", err
+		return nil, err
 	}
 	resolvedPhys := physicalPath(resolved)
 	for _, def := range sources {
@@ -1459,9 +1486,12 @@ func (p *projectRoot) openSourceRootFor(resolved string) (*os.Root, string, stri
 		}
 		root, err := os.OpenRoot(rootPath)
 		if err != nil {
-			return nil, "", "", err
+			return nil, err
 		}
-		return root, rel, resolved, nil
+		// physicalPath is evaluated HERE, at open time, and never again for
+		// this source: everything downstream names the entry as
+		// rootPhys + rel.
+		return &containedSource{root: root, rel: rel, abs: resolved, rootPhys: physicalPath(rootPath)}, nil
 	}
 
 	for _, dir := range knownProjectSkillsDirs() {
@@ -1478,18 +1508,19 @@ func (p *projectRoot) openSourceRootFor(resolved string) (*os.Root, string, stri
 		// resolves identically whether the caller handed us a lexical or a
 		// physical path.
 		if err := p.requireNoSymlinkAncestors(filepath.Join(suffix, innerRel), true); err != nil {
-			return nil, "", "", err
+			return nil, err
 		}
 		// Pinned by descriptor identity, same as the target side: a source dir
-		// swapped for a symlink after validation cannot be opened.
-		root, _, err := p.openPinnedDir(suffix, false)
+		// swapped for a symlink after validation cannot be opened. rootPhys
+		// comes out of that same pin walk.
+		root, rootPhys, err := p.openPinnedDir(suffix, false)
 		if err != nil {
-			return nil, "", "", err
+			return nil, err
 		}
-		return root, innerRel, resolved, nil
+		return &containedSource{root: root, rel: innerRel, abs: resolved, rootPhys: rootPhys}, nil
 	}
 
-	return nil, "", "", fmt.Errorf("refusing to materialize from source outside registered skill sources: %s", resolved)
+	return nil, fmt.Errorf("refusing to materialize from source outside registered skill sources: %s", resolved)
 }
 
 // copyFileIntoRoot copies srcRel (read descriptor-relative inside srcRoot, a
@@ -1596,13 +1627,13 @@ func copySkillIntoRoot(dstRoot, srcRoot *os.Root, srcRel, dstRel string) (string
 // mode is skipped (the migration case, where the source IS the current
 // target's content).
 func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (string, error) {
-	srcRoot, srcRel, srcAbs, err := p.openContainedSource(sourcePath)
+	src, err := p.openContainedSource(sourcePath)
 	if err != nil {
 		return "", err
 	}
-	defer srcRoot.Close()
+	defer src.Close()
 
-	parent, name, parentPhys, err := p.openTargetParent(targetRel, true)
+	parent, name, _, err := p.openTargetParent(targetRel, true)
 	if err != nil {
 		return "", err
 	}
@@ -1613,32 +1644,26 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 	}
 
 	if !copyOnly {
-		// Link text is computed from the validated Root-relative target and the
-		// source's own root; the link is CREATED descriptor-relative. The link
-		// content may point at the pool outside the project — creating such a
-		// link is fine, os.Root only forbids traversing through escapes.
+		// The link TARGET is derived purely from pinned state: the source
+		// root's physical path captured when that root was opened, plus the
+		// remainder validated inside it. It is never re-resolved from a
+		// pathname after pinning — doing so would follow a source entry
+		// swapped for an external symlink in the meantime and point the
+		// managed attachment straight out of the source root.
 		//
-		// Correctness of the link is proven without re-Stat'ing the target by
-		// path: the source exists (its root Stat'ed it below) and the link text
-		// is verified to rejoin exactly to the source.
-		if _, serr := srcRoot.Stat(srcRel); serr == nil {
-			// parentPhys came out of the pin walk (project physical path plus
-			// components already proven to be real directories). Re-deriving it
-			// with a pathname lookup here would let a rename between pinning
-			// and link creation compute the link against a replacement
-			// directory while creating it in the pinned original.
-			linkBase := parentPhys
-			sourceTarget := physicalPath(srcAbs)
-			if linkText, rerr := filepath.Rel(linkBase, sourceTarget); rerr == nil &&
-				filepath.Clean(filepath.Join(linkBase, linkText)) == filepath.Clean(sourceTarget) {
-				if err := parent.Symlink(linkText, name); err == nil {
-					return "symlink", nil
-				}
+		// The ABSOLUTE form is used deliberately: a relative link would have to
+		// be measured against the target parent's path, which cannot be
+		// re-derived after pinning without the same class of lookup. The link
+		// is still CREATED descriptor-relative; link CONTENT pointing outside
+		// the project is fine, os.Root only forbids traversing escapes.
+		if _, serr := src.root.Stat(src.rel); serr == nil {
+			if err := parent.Symlink(src.target(), name); err == nil {
+				return "symlink", nil
 			}
 		}
 	}
 
-	return copySkillIntoRoot(parent, srcRoot, srcRel, name)
+	return copySkillIntoRoot(parent, src.root, src.rel, name)
 }
 
 // removeManagedTarget validates and removes in one descriptor-relative step:
@@ -1748,13 +1773,13 @@ func (p *projectRoot) validateAttachableSkillCandidate(candidate SkillCandidate)
 		return fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
 	}
 
-	srcRoot, srcRel, _, err := p.openContainedSource(candidate.SourcePath)
+	src, err := p.openContainedSource(candidate.SourcePath)
 	if err != nil {
 		return err
 	}
-	defer srcRoot.Close()
+	defer src.Close()
 
-	info, err := srcRoot.Stat(srcRel)
+	info, err := src.root.Stat(src.rel)
 	if err != nil {
 		return err
 	}
@@ -1762,9 +1787,9 @@ func (p *projectRoot) validateAttachableSkillCandidate(candidate SkillCandidate)
 		return fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
 	}
 
-	if _, err := srcRoot.Stat(filepath.Join(srcRel, "SKILL.md")); err != nil {
+	if _, err := src.root.Stat(filepath.Join(src.rel, "SKILL.md")); err != nil {
 		if os.IsNotExist(err) {
-			if pluginInfo, perr := srcRoot.Stat(filepath.Join(srcRel, ".claude-plugin", "plugin.json")); perr == nil && !pluginInfo.IsDir() {
+			if pluginInfo, perr := src.root.Stat(filepath.Join(src.rel, ".claude-plugin", "plugin.json")); perr == nil && !pluginInfo.IsDir() {
 				return nil
 			}
 			return fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
@@ -1793,9 +1818,9 @@ func (p *projectRoot) resolveMaterializationSource(sourcePath, fallbackRel strin
 		// the existence check descriptor-relative inside the validated root. A
 		// source that is unreachable OR outside every registered root simply
 		// falls through to the current-target fallback below.
-		if srcRoot, srcRel, _, err := p.openContainedSource(sourcePath); err == nil {
-			_, statErr := srcRoot.Stat(srcRel)
-			srcRoot.Close()
+		if src, err := p.openContainedSource(sourcePath); err == nil {
+			_, statErr := src.root.Stat(src.rel)
+			src.Close()
 			if statErr == nil {
 				return sourcePath, false, nil
 			}

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -232,12 +232,20 @@ func resolveSkillSourcePath(path string) (string, error) {
 }
 
 func isContainedIn(basePath, targetPath string) bool {
-	normalizedBase := filepath.Clean(basePath)
-	normalizedTarget := filepath.Clean(targetPath)
-	if normalizedBase == normalizedTarget {
+	// filepath.Rel-based containment instead of a string-prefix compare: with
+	// base "/" the old base+PathSeparator prefix became "//", which no cleaned
+	// path carries, so every legitimate target under a root-based project was
+	// rejected (attach/detach/apply all failed). Rel handles the root base and
+	// any trailing-separator quirks uniformly; "." means equal-to-base, which
+	// was previously accepted and stays accepted.
+	rel, err := filepath.Rel(filepath.Clean(basePath), filepath.Clean(targetPath))
+	if err != nil {
+		return false
+	}
+	if rel == "." {
 		return true
 	}
-	return strings.HasPrefix(normalizedTarget, normalizedBase+string(os.PathSeparator))
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 // GetSkillsRootPath returns the Agent Deck skills config directory, falling back

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -17,6 +17,11 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 )
 
+// maxSourceSymlinkHops bounds how many symlink levels a materialization source
+// may traverse, mirroring the kernel's own ELOOP budget rather than a tighter
+// limit that would reject chains the OS (and skill discovery) accept.
+const maxSourceSymlinkHops = 32
+
 const (
 	skillsDirName            = "skills"
 	skillSourcesFileName     = "sources.toml"
@@ -1053,6 +1058,50 @@ func (p *projectRoot) openPinnedDir(rel string, create bool) (*os.Root, error) {
 	return current, nil
 }
 
+// removePinned deletes name inside the PINNED parent without ever crossing a
+// filesystem boundary. os.Root.RemoveAll happily descends through mount points
+// (root confinement stops traversal escapes, not mounts), so a mount planted
+// at or below a managed entry could be recursively deleted. This walks the
+// tree itself: symlinks and non-directories are unlinked (never followed), and
+// every directory it descends into is re-pinned through openPinnedChildDir,
+// which enforces both non-symlink identity and same-filesystem residency.
+func (p *projectRoot) removePinned(parent *os.Root, name string) error {
+	info, err := parent.Lstat(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return parent.Remove(name)
+	}
+
+	child, err := p.openPinnedChildDir(parent, name, false)
+	if err != nil {
+		return err
+	}
+	dir, err := child.Open(".")
+	if err != nil {
+		_ = child.Close()
+		return err
+	}
+	entries, err := dir.ReadDir(-1)
+	_ = dir.Close()
+	if err != nil {
+		_ = child.Close()
+		return err
+	}
+	for _, entry := range entries {
+		if err := p.removePinned(child, entry.Name()); err != nil {
+			_ = child.Close()
+			return err
+		}
+	}
+	_ = child.Close()
+	return parent.Remove(name)
+}
+
 // openTargetParent validates a managed target and returns the PINNED directory
 // that contains it plus the final entry name. Every managed-target operation
 // (exists checks, RemoveAll, Symlink, copy) runs through this pair, so nothing
@@ -1167,7 +1216,7 @@ func (p *projectRoot) validateManagedTarget(targetRel string) (string, error) {
 // while a pool symlink whose destination legitimately lives outside the
 // project is "present" (Root refuses to traverse the escape, which is itself
 // proof the entry exists as an escaping link).
-func (p *projectRoot) targetExists(targetRel string) (bool, error) {
+func (p *projectRoot) targetExists(targetRel, expectedSource string) (bool, error) {
 	parent, name, err := p.openTargetParent(targetRel, false)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1210,6 +1259,33 @@ func (p *projectRoot) targetExists(targetRel string) (bool, error) {
 		dest = filepath.Join(p.physicalDirOf(targetRel), dest)
 	}
 
+	// Only THIS attachment's own link may be treated as healable. A link is
+	// ours when it points at the recorded source, or when it points back into
+	// the project's own managed skills dirs (the "lint -> missing-target"
+	// leftover a previous run wrote). Anything else — including a link into an
+	// UNRELATED entry under a registered pool root — is a foreign replacement
+	// and counts as PRESENT, so the loadout layer reports it instead of
+	// silently overwriting it.
+	dest = filepath.Clean(dest)
+	ours := false
+	if expectedSource != "" {
+		if resolvedExpected, eerr := resolveSkillSourcePath(expectedSource); eerr == nil && resolvedExpected == dest {
+			ours = true
+		}
+	}
+	if !ours {
+		for _, dir := range knownProjectSkillsDirs() {
+			base := filepath.Clean(filepath.Join(p.path, filepath.FromSlash(dir)))
+			if dest != base && isContainedIn(base, dest) {
+				ours = true
+				break
+			}
+		}
+	}
+	if !ours {
+		return true, nil
+	}
+
 	// The link destination is attacker-influenced, so NO filesystem call may
 	// touch it as a bare path (CodeQL go/path-injection). It is routed through
 	// the same containment gate every other source takes: openContainedSource
@@ -1217,10 +1293,6 @@ func (p *projectRoot) targetExists(targetRel string) (bool, error) {
 	// managed project skills dir, follows further hops under that same rule
 	// with a capped hop count, and hands back a Root anchored at the validated
 	// root — the existence check is then descriptor-relative inside it.
-	//
-	// A destination that resolves OUTSIDE every registered root is not probed
-	// at all: it is a foreign replacement, reported as PRESENT so the loadout
-	// layer refuses it rather than silently overwriting it.
 	srcRoot, srcRel, _, err := p.openContainedSource(dest)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1290,7 +1362,9 @@ func (p *projectRoot) openContainedSource(sourcePath string) (*os.Root, string, 
 		return nil, "", "", err
 	}
 
-	for hop := 0; hop < 8; hop++ {
+	// The budget counts LINKS FOLLOWED; the terminal path is always validated
+	// because each iteration returns as soon as the entry is not a symlink.
+	for hop := 0; hop <= maxSourceSymlinkHops; hop++ {
 		root, rel, abs, err := p.openSourceRootFor(resolved)
 		if err != nil {
 			return nil, "", "", err
@@ -1317,7 +1391,7 @@ func (p *projectRoot) openContainedSource(sourcePath string) (*os.Root, string, 
 		}
 		resolved = filepath.Clean(dest)
 	}
-	return nil, "", "", fmt.Errorf("refusing to materialize from source with too many symlink levels: %s", resolved)
+	return nil, "", "", fmt.Errorf("refusing to materialize from source with more than %d symlink levels: %s", maxSourceSymlinkHops, resolved)
 }
 
 // openSourceRootFor picks the root a resolved source belongs to. Project-local
@@ -1402,7 +1476,11 @@ func copyFileIntoRoot(dstRoot, srcRoot *os.Root, srcRel, dstRel string) error {
 		}
 	}
 
-	dstFile, err := dstRoot.OpenFile(dstRel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	// O_EXCL, never O_TRUNC: the destination was just removed, so a name that
+	// exists here appeared in a race — possibly a hard link to a victim file,
+	// which os.Root cannot constrain (root confinement is about traversal, not
+	// about which inode a link points to). Refuse instead of truncating it.
+	dstFile, err := dstRoot.OpenFile(dstRel, os.O_CREATE|os.O_EXCL|os.O_WRONLY, info.Mode())
 	if err != nil {
 		return err
 	}
@@ -1492,7 +1570,7 @@ func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (
 	}
 	defer parent.Close()
 
-	if err := parent.RemoveAll(name); err != nil {
+	if err := p.removePinned(parent, name); err != nil {
 		return "", err
 	}
 
@@ -1536,7 +1614,7 @@ func (p *projectRoot) removeManagedTarget(targetRel string) error {
 		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %w", err)
 	}
 	defer parent.Close()
-	return parent.RemoveAll(name)
+	return p.removePinned(parent, name)
 }
 
 // materializeSkill / materializeSkillCopyOnly / safeRemoveManagedTarget are the
@@ -1668,7 +1746,7 @@ func (p *projectRoot) resolveMaterializationSource(sourcePath, fallbackRel strin
 		}
 	}
 	if strings.TrimSpace(fallbackRel) != "" {
-		exists, err := p.targetExists(fallbackRel)
+		exists, err := p.targetExists(fallbackRel, sourcePath)
 		if err != nil {
 			return "", false, err
 		}
@@ -1764,7 +1842,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 			existing.Mode = mode
 			existing.AttachedAt = time.Now().Format(time.RFC3339)
 		} else {
-			if exists, err := p.targetExists(currentTargetRelPath); err != nil {
+			if exists, err := p.targetExists(currentTargetRelPath, candidate.SourcePath); err != nil {
 				return nil, err
 			} else if exists {
 				return nil, fmt.Errorf("%w: %s", ErrSkillAlreadyAttached, candidate.Name)
@@ -2060,7 +2138,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 					current.Mode = mode
 					current.AttachedAt = time.Now().Format(time.RFC3339)
 				}
-			} else if exists, err := p.targetExists(desiredTargetRelPath); err != nil {
+			} else if exists, err := p.targetExists(desiredTargetRelPath, candidate.SourcePath); err != nil {
 				return err
 			} else if !exists {
 				sourceToUse, _, err := p.resolveMaterializationSource(candidate.SourcePath, "")

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -722,15 +722,26 @@ func sortAttachments(skills []ProjectSkillAttachment) {
 	})
 }
 
-// LoadProjectSkillsManifest reads project attachment state.
-func LoadProjectSkillsManifest(projectPath string) (*ProjectSkillsManifest, error) {
-	manifestPath := GetProjectSkillsManifestPath(projectPath)
-	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
-		return &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{}}, nil
+// loadManifest reads project attachment state through the pinned project
+// descriptor. The manifest lives at the constant path .agent-deck/skills.toml,
+// but a repo can still ship .agent-deck as a symlink; requireNoSymlinkAncestors
+// refuses that instead of reading (or later writing) through it.
+func (p *projectRoot) loadManifest() (*ProjectSkillsManifest, error) {
+	rel := filepath.Join(projectSkillsDirName, projectSkillsManifest)
+	if err := p.requireNoSymlinkAncestors(rel, false); err != nil {
+		return nil, err
+	}
+
+	data, err := p.root.ReadFile(rel)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{}}, nil
+		}
+		return nil, fmt.Errorf("failed to read skills manifest: %w", err)
 	}
 
 	var manifest ProjectSkillsManifest
-	if _, err := toml.DecodeFile(manifestPath, &manifest); err != nil {
+	if err := toml.Unmarshal(data, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse skills manifest: %w", err)
 	}
 	if manifest.Skills == nil {
@@ -743,8 +754,10 @@ func LoadProjectSkillsManifest(projectPath string) (*ProjectSkillsManifest, erro
 	return &manifest, nil
 }
 
-// SaveProjectSkillsManifest writes project attachment state atomically.
-func SaveProjectSkillsManifest(projectPath string, manifest *ProjectSkillsManifest) error {
+// saveManifest writes project attachment state atomically through the pinned
+// project descriptor (MkdirAll + WriteFile + Rename all Root-relative), so a
+// shipped ".agent-deck -> /outside" cannot redirect the write.
+func (p *projectRoot) saveManifest(manifest *ProjectSkillsManifest) error {
 	if manifest == nil {
 		manifest = &ProjectSkillsManifest{}
 	}
@@ -756,8 +769,11 @@ func SaveProjectSkillsManifest(projectPath string, manifest *ProjectSkillsManife
 	}
 	sortAttachments(manifest.Skills)
 
-	manifestPath := GetProjectSkillsManifestPath(projectPath)
-	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o700); err != nil {
+	rel := filepath.Join(projectSkillsDirName, projectSkillsManifest)
+	if err := p.requireNoSymlinkAncestors(rel, false); err != nil {
+		return err
+	}
+	if err := p.root.MkdirAll(projectSkillsDirName, 0o700); err != nil {
 		return fmt.Errorf("failed to create manifest directory: %w", err)
 	}
 
@@ -767,15 +783,38 @@ func SaveProjectSkillsManifest(projectPath string, manifest *ProjectSkillsManife
 		return fmt.Errorf("failed to encode skills manifest: %w", err)
 	}
 
-	tmpPath := manifestPath + ".tmp"
-	if err := os.WriteFile(tmpPath, buf.Bytes(), 0o600); err != nil {
+	tmpRel := rel + ".tmp"
+	if err := p.root.WriteFile(tmpRel, buf.Bytes(), 0o600); err != nil {
 		return fmt.Errorf("failed to write skills manifest: %w", err)
 	}
-	if err := os.Rename(tmpPath, manifestPath); err != nil {
-		_ = os.Remove(tmpPath)
+	if err := p.root.Rename(tmpRel, rel); err != nil {
+		_ = p.root.Remove(tmpRel)
 		return fmt.Errorf("failed to save skills manifest: %w", err)
 	}
 	return nil
+}
+
+// LoadProjectSkillsManifest reads project attachment state.
+func LoadProjectSkillsManifest(projectPath string) (*ProjectSkillsManifest, error) {
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ProjectSkillsManifest{Skills: []ProjectSkillAttachment{}}, nil
+		}
+		return nil, err
+	}
+	defer p.Close()
+	return p.loadManifest()
+}
+
+// SaveProjectSkillsManifest writes project attachment state atomically.
+func SaveProjectSkillsManifest(projectPath string, manifest *ProjectSkillsManifest) error {
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		return err
+	}
+	defer p.Close()
+	return p.saveManifest(manifest)
 }
 
 // GetAttachedProjectSkills returns manifest-backed attached skills.
@@ -884,25 +923,207 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-// openContainedSourceRoot validates a materialization SOURCE path the way
-// targets are validated (CodeQL go/path-injection, alert 237): the destination
-// side is Root-confined, but the source still arrives from manifest- or
-// candidate-derived data. A source is accepted only when it sits strictly
-// inside a registered skill source root (sources.toml: the managed pool,
-// claude-global, and operator-registered dirs) or strictly inside one of the
-// project's own managed skills dirs (the migration fallback that copies from
-// the current, already containment-checked target). The accepted root is
-// returned as an os.Root opened at the REGISTERED root path, so every
-// subsequent source read is descriptor-relative and cannot traverse outside
-// it. Anything else — absolute paths into arbitrary trees, "../" escapes —
-// is refused before any filesystem read.
-func openContainedSourceRoot(projectPath, sourcePath string) (*os.Root, string, string, error) {
+// projectRoot is a single live descriptor pinned on the project directory.
+// Every containment check AND every mutation in the attach / detach / apply /
+// materialize / manifest paths runs through this one Root, so validation and
+// mutation observe the same pinned directory and no already-validated path is
+// ever reopened by name. That is the structural fix for the class of findings
+// that kept moving between call sites: separating "validate a string" from
+// "operate on a path" leaves a window (and a fresh traversal) every time.
+type projectRoot struct {
+	path string
+	root *os.Root
+}
+
+func openProjectRoot(projectPath string) (*projectRoot, error) {
+	root, err := os.OpenRoot(projectPath)
+	if err != nil {
+		return nil, err
+	}
+	return &projectRoot{path: filepath.Clean(projectPath), root: root}, nil
+}
+
+func (p *projectRoot) Close() {
+	_ = p.root.Close()
+}
+
+// abs renders a Root-relative path for error messages and for computing
+// symlink link text. It is never fed back to a path-based filesystem API.
+func (p *projectRoot) abs(rel string) string {
+	return filepath.Join(p.path, rel)
+}
+
+// projectRel converts an absolute or project-relative path into a path
+// relative to the pinned project root, refusing anything that escapes it or
+// designates the project root itself.
+func (p *projectRoot) projectRel(path string) (string, error) {
+	abs := resolveTargetPath(p.path, path)
+	rel, err := filepath.Rel(p.path, abs)
+	if err != nil || rel == "." || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("refusing to use path outside the project: %s", abs)
+	}
+	return rel, nil
+}
+
+// requireNoSymlinkAncestors walks rel component by component through the
+// pinned project descriptor and refuses any EXISTING component that is a
+// symlink — whether it points outside the project, back INSIDE it (a repo
+// shipping ".claude/skills -> .." would otherwise expose the project root,
+// .git included), or DANGLES (a dangling link ENOENTs under EvalSymlinks and
+// an existence-based check would read that as "component absent"). Missing
+// components are fine: the creation path materializes them as real
+// directories. When allowFinalSymlink is set, the LAST component may be a
+// symlink — pool-attached skills are symlinks inside the managed dir, and
+// removal deletes the link, never its destination.
+func (p *projectRoot) requireNoSymlinkAncestors(rel string, allowFinalSymlink bool) error {
+	components := strings.Split(rel, string(os.PathSeparator))
+	relSoFar := ""
+	for i, component := range components {
+		relSoFar = filepath.Join(relSoFar, component)
+		info, err := p.root.Lstat(relSoFar)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("refusing to use unresolvable path %s: %w", p.abs(rel), err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			if allowFinalSymlink && i == len(components)-1 {
+				return nil
+			}
+			return fmt.Errorf("refusing to use path with a symlinked ancestor component: %s", p.abs(relSoFar))
+		}
+	}
+	return nil
+}
+
+// validateManagedTarget is the single containment gate for every managed-skill
+// path. It returns the target's PROJECT-RELATIVE path, which is what all
+// mutations use against the pinned descriptor — callers never receive an
+// absolute path to re-traverse.
+//
+// The target must name a managed project-skills dir, must be a STRICT
+// descendant of it (a tampered ".claude/skills/." cleans to the managed dir
+// itself, and RemoveAll there would wipe the whole catalog), must not escape
+// the project, and must have no symlinked ancestor component.
+func (p *projectRoot) validateManagedTarget(targetRel string) (string, error) {
+	targetPath := resolveTargetPath(p.path, targetRel)
+	skillDir, ok := managedProjectSkillsDirForTarget(targetRel)
+	if !ok {
+		return "", fmt.Errorf("refusing to use path outside managed project skills dirs: %s", targetPath)
+	}
+	base := filepath.Clean(filepath.Join(p.path, filepath.FromSlash(skillDir)))
+	if !isContainedIn(base, targetPath) {
+		return "", fmt.Errorf("refusing to use path outside project skills dir: %s", targetPath)
+	}
+	if targetPath == base {
+		return "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", targetPath)
+	}
+	rel, err := p.projectRel(targetPath)
+	if err != nil {
+		return "", err
+	}
+	if err := p.requireNoSymlinkAncestors(rel, true); err != nil {
+		return "", err
+	}
+	return rel, nil
+}
+
+// targetExists reports whether a validated managed target currently resolves
+// to something, with the follow-the-link semantics the attach flow relies on:
+// a broken link inside the project is "absent" (so reattach rematerializes),
+// while a pool symlink whose destination legitimately lives outside the
+// project is "present" (Root refuses to traverse the escape, which is itself
+// proof the entry exists as an escaping link).
+func (p *projectRoot) targetExists(rel string) (bool, error) {
+	if _, err := p.root.Stat(rel); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		if _, lerr := p.root.Lstat(rel); lerr == nil {
+			return true, nil
+		} else if !os.IsNotExist(lerr) {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+// targetEntryExists reports whether the entry itself exists (Lstat semantics:
+// a symlink counts even when it dangles).
+func (p *projectRoot) targetEntryExists(rel string) (bool, error) {
+	if _, err := p.root.Lstat(rel); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	return false, nil
+}
+
+// openContainedSource validates a materialization SOURCE and returns it as an
+// os.Root plus a root-relative path, so every source read is descriptor-
+// relative too. A source is accepted only when it lives strictly inside a
+// registered skill source root (sources.toml: the managed pool, claude-global,
+// operator-registered dirs) or strictly inside one of the project's own
+// managed skills dirs — the migration fallback that copies from the current,
+// already containment-checked target.
+//
+// A FINAL-component symlink is followed one hop at a time and the destination
+// is re-validated as a source in its own right. That is what makes migration
+// from an existing pool-attached symlink work when the recorded source path is
+// gone: the managed entry is a link into the pool, so reading it as a source
+// means validating the POOL destination, not refusing the escape.
+func (p *projectRoot) openContainedSource(sourcePath string) (*os.Root, string, string, error) {
 	resolved, err := resolveSkillSourcePath(sourcePath)
 	if err != nil {
 		return nil, "", "", err
 	}
 
-	openAt := func(rootPath string) (*os.Root, string, string, error) {
+	for hop := 0; hop < 8; hop++ {
+		root, rel, abs, err := p.openSourceRootFor(resolved)
+		if err != nil {
+			return nil, "", "", err
+		}
+		info, lerr := root.Lstat(rel)
+		if lerr != nil {
+			root.Close()
+			return nil, "", "", lerr
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return root, rel, abs, nil
+		}
+		dest, rerr := root.Readlink(rel)
+		root.Close()
+		if rerr != nil {
+			return nil, "", "", rerr
+		}
+		if !filepath.IsAbs(dest) {
+			dest = filepath.Join(filepath.Dir(abs), dest)
+		}
+		resolved = filepath.Clean(dest)
+	}
+	return nil, "", "", fmt.Errorf("refusing to materialize from source with too many symlink levels: %s", resolved)
+}
+
+// openSourceRootFor picks the root a resolved source belongs to. Project-local
+// candidates are validated through the pinned project descriptor BEFORE being
+// opened — a shipped ".agents/skills -> /outside" is refused rather than
+// anchored — and are then opened RELATIVE to the project root using the
+// constant managed-dir component, never by reassembled absolute path.
+func (p *projectRoot) openSourceRootFor(resolved string) (*os.Root, string, string, error) {
+	sources, err := LoadSkillSources()
+	if err != nil {
+		return nil, "", "", err
+	}
+	for _, def := range sources {
+		rootPath := expandSkillPath(def.Path)
+		if rootPath == "" || !filepath.IsAbs(rootPath) {
+			continue
+		}
+		rootPath = filepath.Clean(rootPath)
+		if resolved == rootPath || !isContainedIn(rootPath, resolved) {
+			continue
+		}
 		root, err := os.OpenRoot(rootPath)
 		if err != nil {
 			return nil, "", "", err
@@ -915,26 +1136,28 @@ func openContainedSourceRoot(projectPath, sourcePath string) (*os.Root, string, 
 		return root, rel, resolved, nil
 	}
 
-	sources, err := LoadSkillSources()
-	if err != nil {
-		return nil, "", "", err
-	}
-	for _, def := range sources {
-		rootPath := expandSkillPath(def.Path)
-		if rootPath == "" || !filepath.IsAbs(rootPath) {
+	for _, dir := range knownProjectSkillsDirs() {
+		base := filepath.Clean(filepath.Join(p.path, filepath.FromSlash(dir)))
+		if resolved == base || !isContainedIn(base, resolved) {
 			continue
 		}
-		rootPath = filepath.Clean(rootPath)
-		if resolved != rootPath && isContainedIn(rootPath, resolved) {
-			return openAt(rootPath)
+		rel, err := p.projectRel(resolved)
+		if err != nil {
+			return nil, "", "", err
 		}
-	}
-
-	for _, dir := range knownProjectSkillsDirs() {
-		base := filepath.Clean(filepath.Join(projectPath, filepath.FromSlash(dir)))
-		if resolved != base && isContainedIn(base, resolved) {
-			return openAt(base)
+		if err := p.requireNoSymlinkAncestors(rel, true); err != nil {
+			return nil, "", "", err
 		}
+		root, err := p.root.OpenRoot(filepath.FromSlash(dir))
+		if err != nil {
+			return nil, "", "", err
+		}
+		innerRel, err := filepath.Rel(base, resolved)
+		if err != nil {
+			root.Close()
+			return nil, "", "", err
+		}
+		return root, innerRel, resolved, nil
 	}
 
 	return nil, "", "", fmt.Errorf("refusing to materialize from source outside registered skill sources: %s", resolved)
@@ -1033,112 +1256,106 @@ func copySkillIntoRoot(dstRoot, srcRoot *os.Root, srcRel, dstRel string) (string
 	return "copy", nil
 }
 
-// openManagedTargetRoot validates targetRel via managedTargetBaseAndRel,
-// ensures the managed skills dir exists, and opens it as an os.Root so all
-// mutations happen descriptor-relative (no path re-traversal, no TOCTOU
-// escape). Returns the root, the target's root-relative path, and the
-// validated absolute target path (for read-only checks and messages).
-func openManagedTargetRoot(projectPath, targetRel string) (*os.Root, string, string, error) {
-	base, rel, err := managedTargetBaseAndRel(projectPath, targetRel)
+// materialize places sourcePath at the validated managed target, entirely
+// through the pinned project descriptor: MkdirAll, RemoveAll, Symlink and the
+// copy fallback are all Root-relative, so a component swapped in after
+// validation cannot redirect any of them. When copyOnly is set the symlink
+// mode is skipped (the migration case, where the source IS the current
+// target's content).
+func (p *projectRoot) materialize(sourcePath, targetRel string, copyOnly bool) (string, error) {
+	srcRoot, srcRel, srcAbs, err := p.openContainedSource(sourcePath)
 	if err != nil {
-		return nil, "", "", err
+		return "", err
 	}
-	skillDir, _ := managedProjectSkillsDirForTarget(targetRel)
-	// Create and open the managed dir descriptor-relative to the project root:
-	// skillDir is one of the knownProjectSkillsDirs constants, so nothing
-	// manifest-derived reaches MkdirAll, and the sub-Root open cannot traverse
-	// a component swapped in after validation.
-	projRoot, err := os.OpenRoot(projectPath)
+	defer srcRoot.Close()
+
+	rel, err := p.validateManagedTarget(targetRel)
 	if err != nil {
-		return nil, "", "", err
+		return "", err
 	}
-	defer projRoot.Close()
-	skillDirRel := filepath.FromSlash(skillDir)
-	if err := projRoot.MkdirAll(skillDirRel, 0o755); err != nil {
-		return nil, "", "", err
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := p.root.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
 	}
-	root, err := projRoot.OpenRoot(skillDirRel)
+	if err := p.root.RemoveAll(rel); err != nil {
+		return "", err
+	}
+
+	if !copyOnly {
+		// Link text is computed from the validated Root-relative target and the
+		// source's own root; the link is CREATED descriptor-relative. The link
+		// content may point at the pool outside the project — creating such a
+		// link is fine, os.Root only forbids traversing through escapes.
+		//
+		// Correctness of the link is proven without re-Stat'ing the target by
+		// path: the source exists (its root Stat'ed it below) and the link text
+		// is verified to rejoin exactly to the source.
+		if _, serr := srcRoot.Stat(srcRel); serr == nil {
+			linkBase := p.abs(filepath.Dir(rel))
+			if resolvedBase, rerr := filepath.EvalSymlinks(linkBase); rerr == nil {
+				linkBase = resolvedBase
+			}
+			sourceTarget := srcAbs
+			if resolvedSource, rerr := filepath.EvalSymlinks(srcAbs); rerr == nil {
+				sourceTarget = resolvedSource
+			}
+			if linkText, rerr := filepath.Rel(linkBase, sourceTarget); rerr == nil &&
+				filepath.Clean(filepath.Join(linkBase, linkText)) == filepath.Clean(sourceTarget) {
+				if err := p.root.Symlink(linkText, rel); err == nil {
+					return "symlink", nil
+				}
+			}
+		}
+	}
+
+	return copySkillIntoRoot(p.root, srcRoot, srcRel, rel)
+}
+
+// removeManagedTarget validates and removes in one descriptor-relative step:
+// the containment walk and the RemoveAll run against the SAME pinned project
+// root, so there is no revalidated-by-name window between them. A non-managed,
+// absolute, or "../"-escaping target is REFUSED and never removed (Audit M3).
+func (p *projectRoot) removeManagedTarget(targetRel string) error {
+	rel, err := p.validateManagedTarget(targetRel)
 	if err != nil {
-		return nil, "", "", err
+		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %w", err)
 	}
-	return root, rel, filepath.Join(base, rel), nil
+	return p.root.RemoveAll(rel)
+}
+
+// materializeSkill / materializeSkillCopyOnly / safeRemoveManagedTarget are the
+// path-based entry points kept for callers (and tests) that only have a project
+// path. They open the project root once and delegate; nothing else in this file
+// reopens a root per operation.
+func materializeSkill(projectPath, sourcePath, targetRel string) (string, error) {
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		return "", err
+	}
+	defer p.Close()
+	return p.materialize(sourcePath, targetRel, false)
 }
 
 func materializeSkillCopyOnly(projectPath, sourcePath, targetRel string) (string, error) {
-	srcRoot, srcRel, _, err := openContainedSourceRoot(projectPath, sourcePath)
+	p, err := openProjectRoot(projectPath)
 	if err != nil {
 		return "", err
 	}
-	defer srcRoot.Close()
-	root, rel, _, err := openManagedTargetRoot(projectPath, targetRel)
-	if err != nil {
-		return "", err
-	}
-	defer root.Close()
-
-	if dir := filepath.Dir(rel); dir != "." {
-		if err := root.MkdirAll(dir, 0o755); err != nil {
-			return "", err
-		}
-	}
-	if err := root.RemoveAll(rel); err != nil {
-		return "", err
-	}
-	return copySkillIntoRoot(root, srcRoot, srcRel, rel)
+	defer p.Close()
+	return p.materialize(sourcePath, targetRel, true)
 }
 
-func materializeSkill(projectPath, sourcePath, targetRel string) (string, error) {
-	srcRoot, srcRel, resolvedSource, err := openContainedSourceRoot(projectPath, sourcePath)
+func safeRemoveManagedTarget(projectPath, targetRel string) error {
+	p, err := openProjectRoot(projectPath)
 	if err != nil {
-		return "", err
-	}
-	defer srcRoot.Close()
-	root, rel, targetPath, err := openManagedTargetRoot(projectPath, targetRel)
-	if err != nil {
-		return "", err
-	}
-	defer root.Close()
-
-	if dir := filepath.Dir(rel); dir != "." {
-		if err := root.MkdirAll(dir, 0o755); err != nil {
-			return "", err
+		if os.IsNotExist(err) {
+			return nil
 		}
+		return err
 	}
-	if err := root.RemoveAll(rel); err != nil {
-		return "", err
-	}
-
-	// Resolve symlinks before computing relative paths.
-	// This avoids broken relative links when target lives under a symlinked path
-	// (for example macOS /tmp -> /private/tmp).
-	resolvedSourcePath := resolvedSource
-	if resolved, err := filepath.EvalSymlinks(resolvedSource); err == nil {
-		resolvedSourcePath = resolved
-	}
-
-	relBase := filepath.Dir(targetPath)
-	if resolvedBase, err := filepath.EvalSymlinks(relBase); err == nil {
-		relBase = resolvedBase
-	}
-
-	relTarget, relErr := filepath.Rel(relBase, resolvedSourcePath)
-	if relErr == nil {
-		// Root.Symlink creates the link descriptor-relative; the link CONTENT
-		// may point at the pool outside the root — creating it is fine, Root
-		// only forbids traversing through escapes.
-		if err := root.Symlink(relTarget, rel); err == nil {
-			// Validate that the symlink resolves to a real target. Use plain
-			// os.Stat on the absolute path: Root.Stat refuses symlinks that
-			// resolve outside the root, and legitimate pool links do exactly
-			// that. If the link dangles, fall back to copy mode below.
-			if _, err := os.Stat(targetPath); err == nil {
-				return "symlink", nil
-			}
-			_ = root.Remove(rel)
-		}
-	}
-
-	return copySkillIntoRoot(root, srcRoot, srcRel, rel)
+	defer p.Close()
+	return p.removeManagedTarget(targetRel)
 }
 
 func resolveTargetPath(projectPath, targetPath string) string {
@@ -1148,134 +1365,26 @@ func resolveTargetPath(projectPath, targetPath string) string {
 	return filepath.Clean(filepath.Join(projectPath, filepath.FromSlash(targetPath)))
 }
 
-// resolveContainedTargetPath resolves targetRel against projectPath and REFUSES
-// any result that is not contained in a managed project-skills dir — the same
-// containment guard #1200 added for worktree deletion (Audit M3), applied here
-// to every filesystem sink (Stat/Lstat/symlink/copy) that consumes a
-// manifest- or candidate-derived path, not just os.RemoveAll. A non-managed,
-// absolute, or "../"-escaping target returns an error instead of a path, so
-// CodeQL's go/path-injection sinks in attachSkillCandidate and
-// ApplyProjectSkills only ever see a path proven to sit inside one of
-// knownProjectSkillsDirs(). Callers must check the error and must not fall
-// back to the raw, unchecked resolveTargetPath for the same operation.
-//
-// Containment is symlink-aware, not just string-based: the project root is
-// resolved via EvalSymlinks (its OWN ancestry may legitimately contain
-// symlinks, e.g. macOS /tmp -> /private/tmp), then every component from the
-// project root down to the target is Lstat-walked. Any EXISTING non-final
-// component that is itself a symlink is refused outright — whether it points
-// outside the project, back INSIDE it (a repo shipping .claude/skills -> ..
-// would otherwise expose the project root, .git included, to RemoveAll), or
-// DANGLES (an EvalSymlinks-based check reads a dangling link's ENOENT as
-// "component absent" and passes it lexically). The managed skills dir is
-// therefore required to sit at its canonical physical location with no
-// symlinked components. Missing components are fine: the creation path
-// materializes them as real directories. The FINAL target component may be a
-// symlink — pool-attached skills are symlinks inside the managed dir, and
-// removal deletes the link, never its destination; containment is about
-// where the target path lives, not what a final-component link points to.
-//
-// The target must also be a STRICT descendant of the managed dir: a tampered
-// ".claude/skills/." cleans to the managed dir itself, and RemoveAll there
-// would wipe the whole catalog.
+// resolveContainedTargetPath is the read-only façade over
+// projectRoot.validateManagedTarget for callers that only need to know whether
+// a manifest- or candidate-derived target is acceptable. It returns the
+// absolute path for comparison and messages ONLY — every mutation goes through
+// the pinned descriptor via projectRoot, never through this path.
 func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
-	targetPath := resolveTargetPath(projectPath, targetRel)
-	skillDir, ok := managedProjectSkillsDirForTarget(targetRel)
-	if !ok {
-		return "", fmt.Errorf("refusing to use path outside managed project skills dirs: %s", targetPath)
-	}
-	base := filepath.Join(projectPath, filepath.FromSlash(skillDir))
-	if !isContainedIn(base, targetPath) {
-		return "", fmt.Errorf("refusing to use path outside project skills dir: %s", targetPath)
-	}
-	if targetPath == filepath.Clean(base) {
-		return "", fmt.Errorf("refusing to operate on the managed project skills dir itself: %s", targetPath)
-	}
-
-	// Walk descriptor-relative from the project root: os.Root pins the
-	// directory once, so the per-component Lstat can neither be redirected by
-	// a concurrent path swap above the project nor traverse an escape (Root
-	// errors instead). The project's OWN ancestry may contain legitimate
-	// symlinks (macOS /tmp -> /private/tmp); opening the Root traverses those
-	// once and the checks below only see components INSIDE the project.
-	projRoot, err := os.OpenRoot(projectPath)
+	p, err := openProjectRoot(projectPath)
 	if err != nil {
 		return "", fmt.Errorf("refusing to use unresolvable project path %s: %w", projectPath, err)
 	}
-	defer projRoot.Close()
-	relFromProject, err := filepath.Rel(filepath.Clean(projectPath), targetPath)
-	if err != nil || relFromProject == "." || relFromProject == ".." ||
-		strings.HasPrefix(relFromProject, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("refusing to use path outside the project: %s", targetPath)
+	defer p.Close()
+	rel, err := p.validateManagedTarget(targetRel)
+	if err != nil {
+		return "", err
 	}
-	relSoFar := ""
-	components := strings.Split(relFromProject, string(os.PathSeparator))
-	for i, component := range components {
-		relSoFar = filepath.Join(relSoFar, component)
-		info, err := projRoot.Lstat(relSoFar)
-		if err != nil {
-			if os.IsNotExist(err) {
-				// This component (and everything below it) does not exist yet;
-				// the creation path will materialize real directories here.
-				break
-			}
-			return "", fmt.Errorf("refusing to use unresolvable target path %s: %w", targetPath, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 && i < len(components)-1 {
-			return "", fmt.Errorf("refusing to use target path with a symlinked ancestor component: %s", filepath.Join(projectPath, relSoFar))
-		}
-	}
-	return targetPath, nil
+	return p.abs(rel), nil
 }
 
-// managedTargetBaseAndRel returns the canonical managed skills dir for
-// targetRel plus the target's path relative to it, after full containment
-// validation. It is the shared setup for the descriptor-relative (os.Root)
-// mutation sinks below.
-func managedTargetBaseAndRel(projectPath, targetRel string) (string, string, error) {
-	targetPath, err := resolveContainedTargetPath(projectPath, targetRel)
-	if err != nil {
-		return "", "", err
-	}
-	skillDir, _ := managedProjectSkillsDirForTarget(targetRel)
-	base := filepath.Join(projectPath, filepath.FromSlash(skillDir))
-	rel, err := filepath.Rel(filepath.Clean(base), targetPath)
-	if err != nil {
-		return "", "", err
-	}
-	return filepath.Clean(base), rel, nil
-}
-
-func removeAttachmentTarget(projectPath string, attachment ProjectSkillAttachment) error {
-	return safeRemoveManagedTarget(projectPath, attachment.TargetPath)
-}
-
-// safeRemoveManagedTarget removes targetRel (resolved against projectPath) only
-// when it is contained in a managed project-skills dir. A non-managed,
-// absolute, or "../"-escaping target is REFUSED and never removed. Every
-// removal that operates on a manifest-derived TargetPath (attach, detach + the
-// migration branches in attachSkillCandidate / reconcileProjectSkills) must
-// route through here so a tampered manifest can't trigger deletion outside the
-// project skills dir. Audit M3.
-//
-// The removal itself is descriptor-relative: the managed skills dir is opened
-// with os.Root and the target removed via Root.RemoveAll, so even a path swap
-// between validation and mutation (TOCTOU) cannot escape the managed dir —
-// the kernel enforces no-traversal semantics on every operation inside Root.
-func safeRemoveManagedTarget(projectPath, targetRel string) error {
-	base, rel, err := managedTargetBaseAndRel(projectPath, targetRel)
-	if err != nil {
-		return fmt.Errorf("refusing to remove path outside managed project skills dirs: %w", err)
-	}
-	root, err := os.OpenRoot(base)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	defer root.Close()
-	return root.RemoveAll(rel)
+func removeAttachmentTarget(p *projectRoot, attachment ProjectSkillAttachment) error {
+	return p.removeManagedTarget(attachment.TargetPath)
 }
 
 func buildAttachment(tool string, candidate SkillCandidate, mode string) ProjectSkillAttachment {
@@ -1330,22 +1439,29 @@ func hasPluginManifest(dir string) bool {
 	return err == nil && !info.IsDir()
 }
 
-func resolveMaterializationSource(sourcePath, fallbackPath string) (string, error) {
+// resolveMaterializationSource picks the source to materialize from: the
+// recorded source path when it still exists, otherwise the CURRENT managed
+// target (fallbackRel, project-relative), which is checked through the pinned
+// descriptor rather than by path. usedFallback tells the caller it is copying
+// the existing target's own content rather than a fresh source.
+func (p *projectRoot) resolveMaterializationSource(sourcePath, fallbackRel string) (source string, usedFallback bool, err error) {
 	if strings.TrimSpace(sourcePath) != "" {
 		if _, err := os.Stat(sourcePath); err == nil {
-			return sourcePath, nil
+			return sourcePath, false, nil
 		} else if !os.IsNotExist(err) {
-			return "", err
+			return "", false, err
 		}
 	}
-	if strings.TrimSpace(fallbackPath) != "" {
-		if _, err := os.Stat(fallbackPath); err == nil {
-			return fallbackPath, nil
-		} else if !os.IsNotExist(err) {
-			return "", err
+	if strings.TrimSpace(fallbackRel) != "" {
+		exists, err := p.targetExists(fallbackRel)
+		if err != nil {
+			return "", false, err
+		}
+		if exists {
+			return p.abs(fallbackRel), true, nil
 		}
 	}
-	return "", os.ErrNotExist
+	return "", false, os.ErrNotExist
 }
 
 func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*ProjectSkillAttachment, error) {
@@ -1356,7 +1472,13 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		return nil, fmt.Errorf("%w: %s", ErrSkillUnsupportedKind, candidate.Name)
 	}
 
-	manifest, err := LoadProjectSkillsManifest(projectPath)
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		return nil, err
+	}
+	defer p.Close()
+
+	manifest, err := p.loadManifest()
 	if err != nil {
 		return nil, err
 	}
@@ -1374,11 +1496,11 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		if !targetPathUsesSkillDir(existing.TargetPath, expectedDir) {
 			desiredTargetRel = expectedTargetRel
 		}
-		desiredTargetPath, err := resolveContainedTargetPath(projectPath, desiredTargetRel)
+		desiredTargetRelPath, err := p.validateManagedTarget(desiredTargetRel)
 		if err != nil {
 			return nil, err
 		}
-		currentTargetPath, err := resolveContainedTargetPath(projectPath, existing.TargetPath)
+		currentTargetRelPath, err := p.validateManagedTarget(existing.TargetPath)
 		if err != nil {
 			return nil, err
 		}
@@ -1391,14 +1513,14 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 				return nil, fmt.Errorf("target already managed by %s", other.Name)
 			}
 		}
-		if currentTargetPath != desiredTargetPath {
-			if _, err := os.Lstat(desiredTargetPath); err == nil {
-				return nil, fmt.Errorf("target already exists and is not managed: %s", desiredTargetPath)
-			} else if !os.IsNotExist(err) {
+		if currentTargetRelPath != desiredTargetRelPath {
+			if exists, err := p.targetEntryExists(desiredTargetRelPath); err != nil {
 				return nil, err
+			} else if exists {
+				return nil, fmt.Errorf("target already exists and is not managed: %s", p.abs(desiredTargetRelPath))
 			}
 
-			sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, currentTargetPath)
+			sourceToUse, usedCurrentTarget, err := p.resolveMaterializationSource(candidate.SourcePath, currentTargetRelPath)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					return nil, fmt.Errorf("cannot migrate attached skill %s: source and current target are unavailable", existing.Name)
@@ -1406,33 +1528,33 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 				return nil, err
 			}
 			mode := ""
-			if sourceToUse == currentTargetPath {
-				mode, err = materializeSkillCopyOnly(projectPath, sourceToUse, desiredTargetRel)
+			if usedCurrentTarget {
+				mode, err = p.materialize(sourceToUse, desiredTargetRel, true)
 			} else {
 				if err := validateAttachableSkillCandidate(candidate); err != nil {
 					return nil, err
 				}
-				mode, err = materializeSkill(projectPath, sourceToUse, desiredTargetRel)
+				mode, err = p.materialize(sourceToUse, desiredTargetRel, false)
 			}
 			if err != nil {
 				return nil, err
 			}
-			// Audit M3: guard the manifest-derived currentTargetPath removal so a
+			// Audit M3: guard the manifest-derived current-target removal so a
 			// tampered TargetPath can't delete outside the project skills dir.
-			if err := safeRemoveManagedTarget(projectPath, existing.TargetPath); err != nil {
-				_ = safeRemoveManagedTarget(projectPath, desiredTargetRel)
+			if err := p.removeManagedTarget(existing.TargetPath); err != nil {
+				_ = p.removeManagedTarget(desiredTargetRel)
 				return nil, err
 			}
 			existing.TargetPath = desiredTargetRel
 			existing.Mode = mode
 			existing.AttachedAt = time.Now().Format(time.RFC3339)
 		} else {
-			if _, err := os.Stat(currentTargetPath); err == nil {
-				return nil, fmt.Errorf("%w: %s", ErrSkillAlreadyAttached, candidate.Name)
-			} else if !os.IsNotExist(err) {
+			if exists, err := p.targetExists(currentTargetRelPath); err != nil {
 				return nil, err
+			} else if exists {
+				return nil, fmt.Errorf("%w: %s", ErrSkillAlreadyAttached, candidate.Name)
 			}
-			sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, "")
+			sourceToUse, _, err := p.resolveMaterializationSource(candidate.SourcePath, "")
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					return nil, fmt.Errorf("cannot rematerialize attached skill %s: source path is unavailable", existing.Name)
@@ -1442,7 +1564,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 			if err := validateAttachableSkillCandidate(candidate); err != nil {
 				return nil, err
 			}
-			mode, err := materializeSkill(projectPath, sourceToUse, existing.TargetPath)
+			mode, err := p.materialize(sourceToUse, existing.TargetPath, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1453,7 +1575,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		existing.SourcePath = candidate.SourcePath
 		existing.EntryName = candidate.EntryName
 		manifest.Skills[i] = normalizeAttachment(existing)
-		if err := SaveProjectSkillsManifest(projectPath, manifest); err != nil {
+		if err := p.saveManifest(manifest); err != nil {
 			return nil, err
 		}
 		updated := manifest.Skills[i]
@@ -1465,7 +1587,7 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 	}
 
 	attachment := buildAttachment(tool, candidate, "")
-	targetPath, err := resolveContainedTargetPath(projectPath, attachment.TargetPath)
+	targetRelPath, err := p.validateManagedTarget(attachment.TargetPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1476,13 +1598,13 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 		}
 	}
 
-	if _, err := os.Lstat(targetPath); err == nil {
-		return nil, fmt.Errorf("target already exists and is not managed: %s", targetPath)
-	} else if !os.IsNotExist(err) {
+	if exists, err := p.targetEntryExists(targetRelPath); err != nil {
 		return nil, err
+	} else if exists {
+		return nil, fmt.Errorf("target already exists and is not managed: %s", p.abs(targetRelPath))
 	}
 
-	mode, err := materializeSkill(projectPath, candidate.SourcePath, attachment.TargetPath)
+	mode, err := p.materialize(candidate.SourcePath, attachment.TargetPath, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1490,8 +1612,8 @@ func attachSkillCandidate(projectPath, tool string, candidate SkillCandidate) (*
 	attachment = normalizeAttachment(attachment)
 
 	manifest.Skills = append(manifest.Skills, attachment)
-	if err := SaveProjectSkillsManifest(projectPath, manifest); err != nil {
-		_ = removeAttachmentTarget(projectPath, attachment)
+	if err := p.saveManifest(manifest); err != nil {
+		_ = removeAttachmentTarget(p, attachment)
 		return nil, err
 	}
 
@@ -1534,7 +1656,13 @@ func matchesAttachmentReference(a ProjectSkillAttachment, skillRef, sourceName s
 
 // DetachSkillFromProject detaches one managed skill and removes its manifest entry.
 func DetachSkillFromProject(projectPath, skillRef, sourceName string) (*ProjectSkillAttachment, error) {
-	manifest, err := LoadProjectSkillsManifest(projectPath)
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		return nil, err
+	}
+	defer p.Close()
+
+	manifest, err := p.loadManifest()
 	if err != nil {
 		return nil, err
 	}
@@ -1556,12 +1684,12 @@ func DetachSkillFromProject(projectPath, skillRef, sourceName string) (*ProjectS
 	}
 
 	removed := manifest.Skills[matchedIdx]
-	if err := removeAttachmentTarget(projectPath, removed); err != nil {
+	if err := removeAttachmentTarget(p, removed); err != nil {
 		return nil, err
 	}
 
 	manifest.Skills = append(manifest.Skills[:matchedIdx], manifest.Skills[matchedIdx+1:]...)
-	if err := SaveProjectSkillsManifest(projectPath, manifest); err != nil {
+	if err := p.saveManifest(manifest); err != nil {
 		return nil, err
 	}
 
@@ -1575,7 +1703,13 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		return fmt.Errorf("project skills are not supported for %s sessions", tool)
 	}
 
-	manifest, err := LoadProjectSkillsManifest(projectPath)
+	p, err := openProjectRoot(projectPath)
+	if err != nil {
+		return err
+	}
+	defer p.Close()
+
+	manifest, err := p.loadManifest()
 	if err != nil {
 		return err
 	}
@@ -1623,14 +1757,14 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 	for _, id := range orderedIDs {
 		targetRel := desiredTargetByID[id]
 		targetKey := normalizeSkillToken(targetRel)
-		targetPath, err := resolveContainedTargetPath(projectPath, targetRel)
+		targetRelPath, err := p.validateManagedTarget(targetRel)
 		if err != nil {
 			return err
 		}
 
-		currentTargetPath := ""
+		currentTargetRelPath := ""
 		if current, exists := currentByID[id]; exists {
-			currentTargetPath, err = resolveContainedTargetPath(projectPath, current.TargetPath)
+			currentTargetRelPath, err = p.validateManagedTarget(current.TargetPath)
 			if err != nil {
 				return err
 			}
@@ -1642,18 +1776,20 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 			}
 		}
 
-		if _, err := os.Lstat(targetPath); err == nil {
-			if currentTargetPath == targetPath {
+		exists, err := p.targetEntryExists(targetRelPath)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if currentTargetRelPath == targetRelPath {
 				continue
 			}
-			if existingOwner, exists := managedTargetOwner[targetKey]; exists && existingOwner != id {
+			if existingOwner, owned := managedTargetOwner[targetKey]; owned && existingOwner != id {
 				if _, keep := desiredByID[existingOwner]; !keep {
 					continue
 				}
 			}
-			return fmt.Errorf("target already exists and is not managed: %s", targetPath)
-		} else if !os.IsNotExist(err) {
-			return err
+			return fmt.Errorf("target already exists and is not managed: %s", p.abs(targetRelPath))
 		}
 	}
 
@@ -1662,7 +1798,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		if _, keep := desiredByID[id]; keep {
 			continue
 		}
-		if err := removeAttachmentTarget(projectPath, attachment); err != nil {
+		if err := removeAttachmentTarget(p, attachment); err != nil {
 			return err
 		}
 	}
@@ -1672,16 +1808,16 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		candidate := desiredByID[id]
 		desiredTargetRel := desiredTargetByID[id]
 		if current, exists := currentByID[id]; exists {
-			currentTargetPath, err := resolveContainedTargetPath(projectPath, current.TargetPath)
+			currentTargetRelPath, err := p.validateManagedTarget(current.TargetPath)
 			if err != nil {
 				return err
 			}
-			desiredTargetPath, err := resolveContainedTargetPath(projectPath, desiredTargetRel)
+			desiredTargetRelPath, err := p.validateManagedTarget(desiredTargetRel)
 			if err != nil {
 				return err
 			}
-			if currentTargetPath != desiredTargetPath {
-				sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, currentTargetPath)
+			if currentTargetRelPath != desiredTargetRelPath {
+				sourceToUse, usedCurrentTarget, err := p.resolveMaterializationSource(candidate.SourcePath, currentTargetRelPath)
 				if err != nil {
 					if errors.Is(err, os.ErrNotExist) {
 						return fmt.Errorf("cannot migrate attached skill %s: source and current target are unavailable", current.Name)
@@ -1689,31 +1825,30 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 					return err
 				} else {
 					mode := ""
-					if sourceToUse == currentTargetPath {
-						mode, err = materializeSkillCopyOnly(projectPath, sourceToUse, desiredTargetRel)
+					if usedCurrentTarget {
+						mode, err = p.materialize(sourceToUse, desiredTargetRel, true)
 					} else {
 						if err := validateAttachableSkillCandidate(candidate); err != nil {
 							return err
 						}
-						mode, err = materializeSkill(projectPath, sourceToUse, desiredTargetRel)
+						mode, err = p.materialize(sourceToUse, desiredTargetRel, false)
 					}
 					if err != nil {
 						return err
 					}
-					// Audit M3: guard the manifest-derived currentTargetPath removal.
-					if err := safeRemoveManagedTarget(projectPath, current.TargetPath); err != nil {
-						_ = safeRemoveManagedTarget(projectPath, desiredTargetRel)
+					// Audit M3: guard the manifest-derived current-target removal.
+					if err := p.removeManagedTarget(current.TargetPath); err != nil {
+						_ = p.removeManagedTarget(desiredTargetRel)
 						return err
 					}
 					current.TargetPath = desiredTargetRel
 					current.Mode = mode
 					current.AttachedAt = time.Now().Format(time.RFC3339)
 				}
-			} else if _, err := os.Stat(desiredTargetPath); err != nil {
-				if !os.IsNotExist(err) {
-					return err
-				}
-				sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, "")
+			} else if exists, err := p.targetExists(desiredTargetRelPath); err != nil {
+				return err
+			} else if !exists {
+				sourceToUse, _, err := p.resolveMaterializationSource(candidate.SourcePath, "")
 				if err != nil {
 					if errors.Is(err, os.ErrNotExist) {
 						return fmt.Errorf("cannot rematerialize attached skill %s: source path is unavailable", current.Name)
@@ -1723,7 +1858,7 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 					if err := validateAttachableSkillCandidate(candidate); err != nil {
 						return err
 					}
-					mode, err := materializeSkill(projectPath, sourceToUse, desiredTargetRel)
+					mode, err := p.materialize(sourceToUse, desiredTargetRel, false)
 					if err != nil {
 						return err
 					}
@@ -1738,17 +1873,17 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 		}
 
 		attachment := buildAttachment(tool, candidate, "")
-		if _, err := resolveContainedTargetPath(projectPath, attachment.TargetPath); err != nil {
+		if _, err := p.validateManagedTarget(attachment.TargetPath); err != nil {
 			return err
 		}
-		sourceToUse, err := resolveMaterializationSource(candidate.SourcePath, "")
+		sourceToUse, _, err := p.resolveMaterializationSource(candidate.SourcePath, "")
 		if err != nil {
 			return err
 		}
 		if err := validateAttachableSkillCandidate(candidate); err != nil {
 			return err
 		}
-		mode, err := materializeSkill(projectPath, sourceToUse, attachment.TargetPath)
+		mode, err := p.materialize(sourceToUse, attachment.TargetPath, false)
 		if err != nil {
 			return err
 		}
@@ -1757,5 +1892,5 @@ func ApplyProjectSkills(projectPath, tool string, desired []SkillCandidate) erro
 	}
 
 	manifest.Skills = newManifest
-	return SaveProjectSkillsManifest(projectPath, manifest)
+	return p.saveManifest(manifest)
 }

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -884,10 +884,50 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-// copyFileIntoRoot copies src (read with plain os APIs — the source is a
-// trusted skill pool/config dir) to dstRel inside root, creating the file
-// descriptor-relative so a hostile path swap under the managed dir cannot
-// redirect the write outside it.
+// resolveContainedSourcePath validates a materialization SOURCE path the way
+// targets are validated (CodeQL go/path-injection, alert 237): the destination
+// side is Root-confined, but the source still arrives from manifest- or
+// candidate-derived data and is opened by path. A source is accepted only when
+// it sits strictly inside a registered skill source root (sources.toml: the
+// managed pool, claude-global, and operator-registered dirs) or strictly
+// inside one of the project's own managed skills dirs (the migration fallback
+// that copies from the current, already containment-checked target). Anything
+// else — absolute paths into arbitrary trees, "../" escapes — is refused
+// before any filesystem read.
+func resolveContainedSourcePath(projectPath, sourcePath string) (string, error) {
+	resolved, err := resolveSkillSourcePath(sourcePath)
+	if err != nil {
+		return "", err
+	}
+
+	sources, err := LoadSkillSources()
+	if err != nil {
+		return "", err
+	}
+	for _, def := range sources {
+		rootPath := expandSkillPath(def.Path)
+		if rootPath == "" || !filepath.IsAbs(rootPath) {
+			continue
+		}
+		if resolved != filepath.Clean(rootPath) && isContainedIn(rootPath, resolved) {
+			return resolved, nil
+		}
+	}
+
+	for _, dir := range knownProjectSkillsDirs() {
+		base := filepath.Join(projectPath, filepath.FromSlash(dir))
+		if resolved != filepath.Clean(base) && isContainedIn(base, resolved) {
+			return resolved, nil
+		}
+	}
+
+	return "", fmt.Errorf("refusing to materialize from source outside registered skill sources: %s", resolved)
+}
+
+// copyFileIntoRoot copies src (read with plain os APIs — src has passed
+// resolveContainedSourcePath at the materialize entry points) to dstRel inside
+// root, creating the file descriptor-relative so a hostile path swap under
+// the managed dir cannot redirect the write outside it.
 func copyFileIntoRoot(root *os.Root, src, dstRel string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
@@ -1000,6 +1040,10 @@ func openManagedTargetRoot(projectPath, targetRel string) (*os.Root, string, str
 }
 
 func materializeSkillCopyOnly(projectPath, sourcePath, targetRel string) (string, error) {
+	sourcePath, err := resolveContainedSourcePath(projectPath, sourcePath)
+	if err != nil {
+		return "", err
+	}
 	root, rel, _, err := openManagedTargetRoot(projectPath, targetRel)
 	if err != nil {
 		return "", err
@@ -1018,6 +1062,10 @@ func materializeSkillCopyOnly(projectPath, sourcePath, targetRel string) (string
 }
 
 func materializeSkill(projectPath, sourcePath, targetRel string) (string, error) {
+	sourcePath, err := resolveContainedSourcePath(projectPath, sourcePath)
+	if err != nil {
+		return "", err
+	}
 	root, rel, targetPath, err := openManagedTargetRoot(projectPath, targetRel)
 	if err != nil {
 		return "", err

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -944,6 +944,35 @@ func resolveTargetPath(projectPath, targetPath string) string {
 	return filepath.Clean(filepath.Join(projectPath, filepath.FromSlash(targetPath)))
 }
 
+// resolveSymlinkedAncestors resolves every EXISTING component of path through
+// symlinks. When path (or a suffix of it) does not exist yet — the normal case
+// on the materialization path, where the target is created by the caller — the
+// deepest existing ancestor is resolved via filepath.EvalSymlinks and the
+// non-existing remainder is re-appended verbatim. Any filesystem error other
+// than "does not exist" is returned so callers refuse rather than guess.
+func resolveSymlinkedAncestors(path string) (string, error) {
+	existing := filepath.Clean(path)
+	var suffix []string
+	for {
+		resolved, err := filepath.EvalSymlinks(existing)
+		if err == nil {
+			for i := len(suffix) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, suffix[i])
+			}
+			return resolved, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return "", err
+		}
+		suffix = append(suffix, filepath.Base(existing))
+		existing = parent
+	}
+}
+
 // resolveContainedTargetPath resolves targetRel against projectPath and REFUSES
 // any result that is not contained in a managed project-skills dir — the same
 // containment guard #1200 added for worktree deletion (Audit M3), applied here
@@ -954,6 +983,16 @@ func resolveTargetPath(projectPath, targetPath string) string {
 // ApplyProjectSkills only ever see a path proven to sit inside one of
 // knownProjectSkillsDirs(). Callers must check the error and must not fall
 // back to the raw, unchecked resolveTargetPath for the same operation.
+//
+// Containment is checked on SYMLINK-RESOLVED paths, not just cleaned strings:
+// a repo that ships .claude/skills (or any ancestor component) as a symlink
+// pointing outside the project would otherwise string-pass the prefix check
+// while the target physically lives — and gets removed or materialized — at
+// the symlink destination. Only ancestor components are resolved; the FINAL
+// target component is deliberately left unresolved because pool-attached
+// skills are themselves symlinks inside the managed dir (os.RemoveAll on a
+// symlink removes the link, never the destination), and containment is about
+// where the target path lives, not what a final-component link points to.
 func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
 	targetPath := resolveTargetPath(projectPath, targetRel)
 	skillDir, ok := managedProjectSkillsDirForTarget(targetRel)
@@ -963,6 +1002,37 @@ func resolveContainedTargetPath(projectPath, targetRel string) (string, error) {
 	base := filepath.Join(projectPath, filepath.FromSlash(skillDir))
 	if !isContainedIn(base, targetPath) {
 		return "", fmt.Errorf("refusing to use path outside project skills dir: %s", targetPath)
+	}
+
+	// Symlink-aware containment. Resolve the project root, the managed base,
+	// and the target's PARENT through any existing symlinked ancestors (the
+	// base and target often do not exist yet on the creation path — the
+	// deepest existing ancestor is resolved and the rest re-appended).
+	resolvedProject, err := resolveSymlinkedAncestors(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("refusing to use unresolvable project path %s: %w", projectPath, err)
+	}
+	resolvedBase, err := resolveSymlinkedAncestors(base)
+	if err != nil {
+		return "", fmt.Errorf("refusing to use unresolvable project skills dir %s: %w", base, err)
+	}
+	// A managed skills dir whose components symlink outside the project (e.g.
+	// a repo shipping .claude/skills -> /elsewhere) must not be treated as a
+	// managed dir at all: RemoveAll/materialize through it acts outside the
+	// project.
+	if !isContainedIn(resolvedProject, resolvedBase) {
+		return "", fmt.Errorf("refusing to use project skills dir that resolves outside the project: %s -> %s", base, resolvedBase)
+	}
+	resolvedParent, err := resolveSymlinkedAncestors(filepath.Dir(targetPath))
+	if err != nil {
+		return "", fmt.Errorf("refusing to use unresolvable target path %s: %w", targetPath, err)
+	}
+	resolvedTarget := resolvedParent
+	if targetPath != filepath.Dir(targetPath) {
+		resolvedTarget = filepath.Join(resolvedParent, filepath.Base(targetPath))
+	}
+	if !isContainedIn(resolvedBase, resolvedTarget) {
+		return "", fmt.Errorf("refusing to use target path that resolves outside the project skills dir: %s -> %s", targetPath, resolvedTarget)
 	}
 	return targetPath, nil
 }

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -598,10 +598,18 @@ func TestAttachSkillToProject_RematerializesBrokenSymlink(t *testing.T) {
 }
 
 func TestMaterializeSkill_SymlinkedTargetPathCreatesReadableTarget(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
 	root := t.TempDir()
 
 	sourceRoot := filepath.Join(root, "source")
 	sourcePath := writeSkillDir(t, sourceRoot, "lint", "lint", "Linting best practices")
+	if err := SaveSkillSources(map[string]SkillSourceDef{
+		"local": {Path: sourceRoot, Enabled: boolPtr(true)},
+	}); err != nil {
+		t.Fatalf("SaveSkillSources failed: %v", err)
+	}
 
 	realBase := filepath.Join(root, "real", "nested", "path")
 	if err := os.MkdirAll(realBase, 0o755); err != nil {

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -613,8 +613,12 @@ func TestMaterializeSkill_SymlinkedTargetPathCreatesReadableTarget(t *testing.T)
 		t.Skipf("symlink not supported in this environment: %v", err)
 	}
 
-	targetPath := filepath.Join(aliasBase, "project", ".claude", "skills", "lint")
-	mode, err := materializeSkill(sourcePath, targetPath)
+	projectPath := filepath.Join(aliasBase, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("failed to create project path: %v", err)
+	}
+	targetPath := filepath.Join(projectPath, ".claude", "skills", "lint")
+	mode, err := materializeSkill(projectPath, sourcePath, buildProjectSkillTargetPath(projectClaudeSkillsDir, "lint"))
 	if err != nil {
 		t.Fatalf("materializeSkill failed: %v", err)
 	}

--- a/internal/session/skills_devcheck_other.go
+++ b/internal/session/skills_devcheck_other.go
@@ -1,0 +1,8 @@
+//go:build !unix
+
+package session
+
+import "os"
+
+// sameFilesystem is a no-op on platforms without a portable device identifier.
+func sameFilesystem(a, b os.FileInfo) bool { return true }

--- a/internal/session/skills_devcheck_unix.go
+++ b/internal/session/skills_devcheck_unix.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package session
+
+import (
+	"os"
+	"syscall"
+)
+
+// sameFilesystem reports whether two entries live on the same device.
+//
+// os.Root deliberately traverses filesystem boundaries, so the
+// no-symlinked-component rule alone does not stop a mount planted at a managed
+// skills dir (or at .agent-deck) from redirecting removal and materialization
+// onto foreign content. Comparing device numbers rejects the cross-device case
+// (FUSE, a separate filesystem, an external volume). Same-device bind mounts
+// are NOT detectable this way — that needs Linux statx mount IDs — and are out
+// of scope: planting one inside the user's project requires privileges far
+// beyond the hostile-repo threat model this guard is for.
+func sameFilesystem(a, b os.FileInfo) bool {
+	sa, aok := a.Sys().(*syscall.Stat_t)
+	sb, bok := b.Sys().(*syscall.Stat_t)
+	if !aok || !bok {
+		return true
+	}
+	return sa.Dev == sb.Dev
+}


### PR DESCRIPTION
## What problem does this solve?

Follow-up to #1809. The Codex security review on that PR flagged a P1 in the new containment guard: `isContainedIn` (and therefore `resolveContainedTargetPath`) compares only `filepath.Clean`-ed path strings, with no symlink resolution.

The bypass: a repo ships `.claude/skills` — or any ancestor component of a managed skills dir — as a symlink pointing outside the project. A tampered `.agent-deck/skills.toml` `TargetPath` then string-passes the containment check while the resolved path physically lives outside the project. From there, `safeRemoveManagedTarget`'s `os.RemoveAll` deletes files at the symlink destination, and skill materialization can create files there.

## Why this change

Containment must be decided on symlink-resolved paths, not path strings. `resolveContainedTargetPath` now:

- resolves the project root, the managed skills dir (`base`), and the target's **parent** through their symlinked ancestors via a new `resolveSymlinkedAncestors` helper — it `EvalSymlinks` the deepest EXISTING ancestor and re-appends the non-existing suffix, so the creation path (target, or even the skills dir itself, not existing yet on first attach) keeps working;
- refuses a managed skills dir that resolves outside the resolved project root (the shipped-symlink attack);
- refuses a target that resolves outside the resolved managed dir (intermediate-symlink escape).

The **final target component is deliberately left unresolved**: pool-attached skills are themselves symlinks inside the managed dir pointing at the pool, and that is legitimate — `os.RemoveAll` on a symlink removes the link, never its destination. Containment is about where the target path lives, not what a final-component link points to, so attach/detach of pool-symlinked skills is unchanged.

Any filesystem error other than "does not exist" during resolution refuses the path instead of guessing.

## User impact

None for normal use. Attach, detach, apply, and pool-symlink skills behave exactly as before. Only repos deliberately shipping a managed skills dir (or an ancestor of one) as a symlink out of the project tree are now refused — which is the attack, not a supported layout.

## Evidence

New tests in `internal/session/issue1809_symlink_containment_test.go`:

- `TestResolveContainedTargetPath_RefusesSymlinkedSkillsDirEscape` / `..._RefusesSymlinkedAncestorEscape` — `.claude/skills` or `.claude` symlinked outside the project is refused.
- `TestSafeRemoveManagedTarget_DoesNotFollowSymlinkedSkillsDir` — physical proof: remove is refused and the file at the symlink destination survives.
- `TestAttachSkillCandidate_RefusesSymlinkedSkillsDirOnMaterialize` — materialization refuses too; nothing is created outside the project.
- `TestResolveContainedTargetPath_AllowsFinalComponentSymlink` — pool-attach pattern regression test: final-component symlink accepted, and removal deletes the link while the pool content survives.
- `TestResolveContainedTargetPath_AllowsNonExistingTargetUnderRealDir` — creation path with a not-yet-existing target and a not-yet-existing managed dir stays accepted.

Sandboxed `go build ./...` and `go vet ./...` are clean (isolated `HOME`/XDG); the test suite runs in CI.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude (Anthropic)

## What actually bothered you

The Codex review on #1809 pointed out that the brand-new containment guard could be walked around with a shipped symlink — a repo you merely open a session in could delete or plant files anywhere the symlink points. That turns a hardening PR into a false sense of safety, so it needed an immediate follow-up.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (build+vet sandboxed locally; full suite via CI)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill management safeguards against symlinked paths escaping the project directory.
  * Blocked invalid, dangling, ancestor, self-referencing, and unregistered skill paths.
  * Protected manifest files and files outside the project during skill operations.
  * Preserved support for valid final-path symlinks and skill migration scenarios.

* **Tests**
  * Added comprehensive coverage for symlink containment, root paths, missing targets, migration, removal, manifest handling, and materialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->