### PR TITLE
fix(tmux): scope Ctrl+Q detach binding per session, not per socket

### DIFF
--- a/internal/tmux/ctrlq_detach_test.go
+++ b/internal/tmux/ctrlq_detach_test.go
@@ -5,41 +5,76 @@ import (
 	"testing"
 )
 
-// TestCtrlQDetachScript_ScopedToSessionPrefixNotOneSessionName is a
-// regression test for #1808.
+// TestCtrlQDetachIfShellFormat_ScopedToSessionPrefixNotOneSessionName is a
+// regression test for #1808 (and its #1820 shell-injection fix).
 //
 // tmux key bindings live on the SERVER, one per socket, not on the session.
 // The Ctrl+Q detach binding installed by Session.Start used to guard itself
 // with `if-shell [ "#{session_name}" = "<one hardcoded session name>" ]`,
-// re-installed by every Start() call. That only ever matched whichever
-// session started most recently on the socket — every OTHER session sharing
-// that socket hit the empty else-branch, tmux consumed nothing, and Ctrl+Q
-// fell through to the running app (killing Claude Code instead of
-// detaching) as soon as a socket hosted more than one session.
+// re-installed by every Start() call. Because the binding is "-n -T root",
+// tmux's root key table consumes Ctrl+Q on every client on the socket before
+// it reaches the pane — so that guard only ever matched whichever session
+// started most recently; every OTHER session sharing the socket hit the
+// empty else-branch and Ctrl+Q was silently swallowed instead of detaching.
 //
-// The fix (ctrlQDetachScript) must not bake any single session's name into
-// the script; it must re-check the CURRENT client's session via
-// #{session_name} at keypress time and match on the shared SessionPrefix,
-// so it stays correct for every agentdeck session sharing the socket
-// regardless of Start() order.
-func TestCtrlQDetachScript_ScopedToSessionPrefixNotOneSessionName(t *testing.T) {
-	script := ctrlQDetachScript()
+// The fix must not bake any single session's name into the guard, and the
+// guard itself must be a pure tmux FORMAT (never a shell script — see
+// TestCtrlQDetachBindArgs_UsesIfShellDetachClientDirectly): re-checked
+// against the CURRENT client's session at keypress time and matched on the
+// shared SessionPrefix, so (a) it stays correct for every agentdeck session
+// sharing the socket regardless of Start() order, and (b) a session name can
+// never reach a shell, so it can't be used to inject commands (#1820).
+func TestCtrlQDetachIfShellFormat_ScopedToSessionPrefixNotOneSessionName(t *testing.T) {
+	format := ctrlQDetachIfShellFormat()
 
-	if !strings.Contains(script, SessionPrefix) {
-		t.Fatalf("script does not reference SessionPrefix, so it can't recognize any agentdeck session sharing the socket: %q", script)
+	if !strings.Contains(format, SessionPrefix) {
+		t.Fatalf("format does not reference SessionPrefix, so it can't recognize any agentdeck session sharing the socket: %q", format)
 	}
-	if !strings.Contains(script, "#{session_name}") {
-		t.Fatalf("script must re-check the CURRENT client's session via #{session_name} at keypress time, not a name baked in once at bind time: %q", script)
+	if !strings.Contains(format, "#{session_name}") {
+		t.Fatalf("format must re-check the CURRENT client's session via #{session_name} at keypress time, not a name baked in once at bind time: %q", format)
 	}
-	if !strings.Contains(script, "detach-client") {
-		t.Fatalf("script must actually detach the invoking client: %q", script)
+	if strings.ContainsAny(format, `'"`) {
+		t.Fatalf("format must never quote the session name for a shell — it is a tmux FORMAT evaluated by the tmux server, not shell input; quoting here is exactly the #1820 injection shape: %q", format)
 	}
 
-	// The script must be identical no matter how many times it is generated
-	// (Start() re-installs it for every session on the socket) — if a caller
-	// ever starts interpolating a per-call session name again, the
+	// The format must be identical no matter how many times it is generated
+	// (Start() re-installs the binding for every session on the socket) — if
+	// a caller ever starts interpolating a per-call session name again, the
 	// socket-wide, single-session-guard bug (#1808) is back.
-	if again := ctrlQDetachScript(); again != script {
-		t.Fatalf("script must be stable across calls, not vary per session: first=%q second=%q", script, again)
+	if again := ctrlQDetachIfShellFormat(); again != format {
+		t.Fatalf("format must be stable across calls, not vary per session: first=%q second=%q", format, again)
+	}
+}
+
+// TestCtrlQDetachBindArgs_UsesIfShellDetachClientDirectly locks in that the
+// binding is installed as a plain `if-shell -F ... detach-client` command —
+// never routed through run-shell / an embedded shell script.
+//
+// A shell script re-introduces the #1820 injection surface: tmux expands
+// FORMATS into the script text before /bin/sh ever parses it, so a session
+// name containing shell metacharacters can break out of the substitution.
+// Routing detach-client through a run-shell subprocess also makes tmux
+// resolve "the client to detach" via a most-recently-active-client
+// heuristic instead of the client that actually pressed the key — this
+// asserts on the real args Session.Start feeds to bind-key so a regression
+// back to run-shell can't slip past review unnoticed.
+func TestCtrlQDetachBindArgs_UsesIfShellDetachClientDirectly(t *testing.T) {
+	args := ctrlQDetachBindArgs()
+	joined := strings.Join(args, " ")
+
+	if strings.Contains(joined, "run-shell") {
+		t.Fatalf("binding must not use run-shell (reintroduces the #1820 shell-injection surface): %v", args)
+	}
+	if len(args) == 0 || args[0] != "if-shell" {
+		t.Fatalf("binding must use if-shell as its first arg: %v", args)
+	}
+	if !strings.Contains(joined, "-F") {
+		t.Fatalf("binding must use if-shell -F so the guard is a tmux FORMAT, not a shell command: %v", args)
+	}
+	if !strings.Contains(joined, "detach-client") {
+		t.Fatalf("binding must detach-client directly, not via a subprocess: %v", args)
+	}
+	if !strings.Contains(joined, ctrlQDetachIfShellFormat()) {
+		t.Fatalf("binding must guard with ctrlQDetachIfShellFormat(): %v", args)
 	}
 }

--- a/internal/tmux/ctrlq_detach_test.go
+++ b/internal/tmux/ctrlq_detach_test.go
@@ -1,0 +1,45 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCtrlQDetachScript_ScopedToSessionPrefixNotOneSessionName is a
+// regression test for #1808.
+//
+// tmux key bindings live on the SERVER, one per socket, not on the session.
+// The Ctrl+Q detach binding installed by Session.Start used to guard itself
+// with `if-shell [ "#{session_name}" = "<one hardcoded session name>" ]`,
+// re-installed by every Start() call. That only ever matched whichever
+// session started most recently on the socket — every OTHER session sharing
+// that socket hit the empty else-branch, tmux consumed nothing, and Ctrl+Q
+// fell through to the running app (killing Claude Code instead of
+// detaching) as soon as a socket hosted more than one session.
+//
+// The fix (ctrlQDetachScript) must not bake any single session's name into
+// the script; it must re-check the CURRENT client's session via
+// #{session_name} at keypress time and match on the shared SessionPrefix,
+// so it stays correct for every agentdeck session sharing the socket
+// regardless of Start() order.
+func TestCtrlQDetachScript_ScopedToSessionPrefixNotOneSessionName(t *testing.T) {
+	script := ctrlQDetachScript()
+
+	if !strings.Contains(script, SessionPrefix) {
+		t.Fatalf("script does not reference SessionPrefix, so it can't recognize any agentdeck session sharing the socket: %q", script)
+	}
+	if !strings.Contains(script, "#{session_name}") {
+		t.Fatalf("script must re-check the CURRENT client's session via #{session_name} at keypress time, not a name baked in once at bind time: %q", script)
+	}
+	if !strings.Contains(script, "detach-client") {
+		t.Fatalf("script must actually detach the invoking client: %q", script)
+	}
+
+	// The script must be identical no matter how many times it is generated
+	// (Start() re-installs it for every session on the socket) — if a caller
+	// ever starts interpolating a per-call session name again, the
+	// socket-wide, single-session-guard bug (#1808) is back.
+	if again := ctrlQDetachScript(); again != script {
+		t.Fatalf("script must be stable across calls, not vary per session: first=%q second=%q", script, again)
+	}
+}

--- a/internal/tmux/ctrlq_detach_test.go
+++ b/internal/tmux/ctrlq_detach_test.go
@@ -60,21 +60,24 @@ func TestCtrlQDetachIfShellFormat_ScopedToSessionPrefixNotOneSessionName(t *test
 // back to run-shell can't slip past review unnoticed.
 func TestCtrlQDetachBindArgs_UsesIfShellDetachClientDirectly(t *testing.T) {
 	args := ctrlQDetachBindArgs()
-	joined := strings.Join(args, " ")
 
-	if strings.Contains(joined, "run-shell") {
-		t.Fatalf("binding must not use run-shell (reintroduces the #1820 shell-injection surface): %v", args)
+	// Exact argv, in order — not just substring presence — so a reordered or
+	// malformed arg list (e.g. -F landing after the format, or a stray extra
+	// element) fails the test instead of slipping through on a loose
+	// strings.Contains check.
+	want := []string{"if-shell", "-F", ctrlQDetachIfShellFormat(), "detach-client", ""}
+	if len(args) != len(want) {
+		t.Fatalf("bind-key args have wrong shape: got %v, want %v", args, want)
 	}
-	if len(args) == 0 || args[0] != "if-shell" {
-		t.Fatalf("binding must use if-shell as its first arg: %v", args)
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("bind-key args[%d] = %q, want %q (full: got %v, want %v)", i, args[i], want[i], args, want)
+		}
 	}
-	if !strings.Contains(joined, "-F") {
-		t.Fatalf("binding must use if-shell -F so the guard is a tmux FORMAT, not a shell command: %v", args)
-	}
-	if !strings.Contains(joined, "detach-client") {
-		t.Fatalf("binding must detach-client directly, not via a subprocess: %v", args)
-	}
-	if !strings.Contains(joined, ctrlQDetachIfShellFormat()) {
-		t.Fatalf("binding must guard with ctrlQDetachIfShellFormat(): %v", args)
+
+	for _, a := range args {
+		if strings.Contains(a, "run-shell") {
+			t.Fatalf("binding must not use run-shell (reintroduces the #1820 shell-injection surface): %v", args)
+		}
 	}
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2312,8 +2312,8 @@ func (s *Session) Start(command string) error {
 	// attached to the socket before it ever reaches the pane — so in every
 	// other session sharing the socket, the guard's empty else-branch did NOT
 	// let the key fall through to the running app; it silently swallowed the
-	// keypress instead (and, for a client nested inside another tmux, could
-	// drop the operator to the login shell rather than detaching). Use
+	// keypress instead, so Ctrl+Q simply did nothing until a client attached
+	// to the one session Start() most recently ran on the socket. Use
 	// if-shell -F to re-evaluate a tmux FORMAT against the CURRENT client's
 	// session at keypress time instead of baking in one session name — this
 	// scopes the detach to "whichever agentdeck session this client is

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2305,23 +2305,39 @@ func (s *Session) Start(command string) error {
 	// reader (e.g. iTerm2 on macOS). Only binds on agentdeck-managed sessions.
 	//
 	// #1808: tmux key bindings live on the SERVER (one per socket), not on the
-	// session — an `if-shell [ "#{session_name}" = "<s.Name>" ]` guard is
-	// re-installed by every Start(), so it only ever matches whichever
-	// session started most recently on this socket. In every other session
-	// sharing the socket the else-branch is empty, tmux consumes nothing, and
-	// Ctrl+Q falls through to the running app (killing Claude Code instead of
-	// detaching). Use run-shell to re-check the CURRENT client's session at
-	// keypress time instead of baking in one session name — this scopes the
-	// detach to "whichever agentdeck session this client is attached to"
-	// rather than "the one session that happened to Start() last", and
-	// matches the same prefix-check pattern BindMouseStatusRightDetach
-	// already uses for its detach binding. The inner `tmux` invocations run
-	// as a child of the server that owns this socket, so they stay on the
-	// right socket automatically (see BindMouseStatusRightDetach).
+	// session — a baked-in `if-shell [ "#{session_name}" = "<s.Name>" ]`
+	// guard, re-installed by every Start(), only ever matched whichever
+	// session started most recently on this socket. Because the binding is
+	// "-n -T root", tmux's root key table consumes Ctrl+Q on every client
+	// attached to the socket before it ever reaches the pane — so in every
+	// other session sharing the socket, the guard's empty else-branch did NOT
+	// let the key fall through to the running app; it silently swallowed the
+	// keypress instead (and, for a client nested inside another tmux, could
+	// drop the operator to the login shell rather than detaching). Use
+	// if-shell -F to re-evaluate a tmux FORMAT against the CURRENT client's
+	// session at keypress time instead of baking in one session name — this
+	// scopes the detach to "whichever agentdeck session this client is
+	// attached to" rather than "the one session that happened to Start()
+	// last", and matches the same prefix-match pattern
+	// BindMouseStatusRightDetach already uses for its detach binding.
+	//
+	// #1820: the guard used to be a `run-shell` shell script with the
+	// session name substituted into a single-quoted shell word by tmux's
+	// FORMATS expansion BEFORE the string reached /bin/sh — a session name
+	// containing a single quote (tmux permits quotes in names; only "."
+	// and ":" are forbidden) could break out of the quoting and have the
+	// remainder executed as shell commands on whichever socket owns the
+	// pane, including the user's own default tmux server. `if-shell -F`
+	// evaluates its pattern (#{m:pattern,string}) entirely inside tmux's own
+	// format engine — nothing is ever handed to a shell, so no session name
+	// can break out of anything — and "detach-client" runs directly on the
+	// invoking client's own command queue (no run-shell subprocess), so it
+	// detaches exactly the client that pressed the key even when the session
+	// has more than one client attached (e.g. a web `tmux -C` control client
+	// alongside a native terminal client; see controlpipe.go).
 	// Bounded — see tmuxMutationTimeout. Best-effort already, and it runs on
 	// the session-create path where a wedged client would stall the create.
-	_ = s.runBoundedMutation("bind-key", "-n", "-T", "root", "C-q",
-		"run-shell", ctrlQDetachScript())
+	_ = s.runBoundedMutation(append([]string{"bind-key", "-n", "-T", "root", "C-q"}, ctrlQDetachBindArgs()...)...)
 
 	// Apply user-specified tmux option overrides from config (after defaults).
 	// These are batched into a single call when multiple overrides are present.
@@ -6060,36 +6076,38 @@ func UnbindKey(key string) error {
 	return nil
 }
 
-// ctrlQDetachScript returns the run-shell script installed on the socket-wide
-// (server-wide) "-n -T root C-q" binding in Session.Start.
+// ctrlQDetachIfShellFormat returns the tmux FORMAT used to guard the
+// socket-wide (server-wide) "-n -T root C-q" binding in Session.Start: true
+// (non-"0", non-empty) exactly when the invoking client's current session
+// name starts with SessionPrefix.
 //
-// #1808: tmux key bindings live on the SERVER, one per socket, not on the
-// session. The binding used to be guarded by a baked-in `if-shell [
-// "#{session_name}" = "<one session's name>" ]`, re-installed by every
-// Start() call — so it only ever matched whichever session started most
-// recently on the socket. Every OTHER session sharing that socket hit the
-// empty else-branch, tmux consumed nothing, and Ctrl+Q fell through to the
-// running app (killing Claude Code instead of detaching) whenever more than
-// one agentdeck session shared a socket.
-//
-// This script is re-evaluated by tmux at KEYPRESS time against whichever
-// session the invoking client is currently attached to, rather than a name
-// captured once at bind time — so it stays correct for every session on the
-// socket regardless of Start() order. Same prefix-check pattern as
-// BindMouseStatusRightDetach below.
-func ctrlQDetachScript() string {
-	return fmt.Sprintf(`S=$(tmux display-message -p '#{session_name}'); case "$S" in %s*) tmux detach-client ;; esac`, SessionPrefix)
+// #{m:pattern,string} is evaluated entirely inside the tmux server's own
+// format engine at keypress time, against whichever session the invoking
+// client is currently attached to — never handed to a shell, so a session
+// name can never break out of any quoting (see the #1820 doc comment on the
+// call site in Session.Start for the injection this replaced). Same
+// prefix-match pattern as BindMouseStatusRightDetach below.
+func ctrlQDetachIfShellFormat() string {
+	return fmt.Sprintf("#{m:%s*,#{session_name}}", SessionPrefix)
+}
+
+// ctrlQDetachBindArgs returns the bind-key arguments (after "C-q") that
+// install the Ctrl+Q detach guard: a pure `if-shell -F ... detach-client`
+// command, never a run-shell/embedded-shell-script form. Kept as its own
+// function so tests can assert on the exact args Session.Start installs.
+func ctrlQDetachBindArgs() []string {
+	return []string{"if-shell", "-F", ctrlQDetachIfShellFormat(), "detach-client", ""}
 }
 
 // BindMouseStatusRightDetach binds a mouse click on the status-right area to detach.
 // Only fires inside agentdeck sessions (guards against detaching the user's outer tmux).
 func BindMouseStatusRightDetach() error {
-	// Guard: only detach if current session is an agentdeck-managed session
-	// The inner `tmux display-message` / `tmux detach-client` invocations run
-	// inside the tmux server that fired run-shell, so they stay on the right
-	// socket automatically.
-	script := `S=$(tmux display-message -p '#{session_name}'); case "$S" in agentdeck_*) tmux detach-client ;; esac`
-	return tmuxExec(DefaultSocketName(), "bind", "-n", "MouseDown1StatusRight", "run-shell", script).Run()
+	// Guard: only detach if current session is an agentdeck-managed session.
+	// #{m:pattern,string} is evaluated entirely inside tmux's format engine
+	// (see ctrlQDetachIfShellFormat) — never handed to a shell, so a session
+	// name containing shell metacharacters can't break out of anything.
+	return tmuxExec(DefaultSocketName(), "bind", "-n", "MouseDown1StatusRight",
+		"if-shell", "-F", ctrlQDetachIfShellFormat(), "detach-client", "").Run()
 }
 
 // UnbindMouseStatusClicks removes mouse click bindings from the status bar.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2303,11 +2303,25 @@ func (s *Session) Start(command string) error {
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where
 	// XON/XOFF flow control intercepts the key before it reaches the PTY stdin
 	// reader (e.g. iTerm2 on macOS). Only binds on agentdeck-managed sessions.
+	//
+	// #1808: tmux key bindings live on the SERVER (one per socket), not on the
+	// session — an `if-shell [ "#{session_name}" = "<s.Name>" ]` guard is
+	// re-installed by every Start(), so it only ever matches whichever
+	// session started most recently on this socket. In every other session
+	// sharing the socket the else-branch is empty, tmux consumes nothing, and
+	// Ctrl+Q falls through to the running app (killing Claude Code instead of
+	// detaching). Use run-shell to re-check the CURRENT client's session at
+	// keypress time instead of baking in one session name — this scopes the
+	// detach to "whichever agentdeck session this client is attached to"
+	// rather than "the one session that happened to Start() last", and
+	// matches the same prefix-check pattern BindMouseStatusRightDetach
+	// already uses for its detach binding. The inner `tmux` invocations run
+	// as a child of the server that owns this socket, so they stay on the
+	// right socket automatically (see BindMouseStatusRightDetach).
 	// Bounded — see tmuxMutationTimeout. Best-effort already, and it runs on
 	// the session-create path where a wedged client would stall the create.
 	_ = s.runBoundedMutation("bind-key", "-n", "-T", "root", "C-q",
-		"if-shell", fmt.Sprintf("[ \"#{session_name}\" = \"%s\" ]", s.Name),
-		"detach-client", "")
+		"run-shell", ctrlQDetachScript())
 
 	// Apply user-specified tmux option overrides from config (after defaults).
 	// These are batched into a single call when multiple overrides are present.
@@ -6044,6 +6058,27 @@ func UnbindKey(key string) error {
 	// bind-key 1 select-window -t :1
 	_ = runBoundedMutation(socket, "bind-key", key, "select-window", "-t", ":"+key)
 	return nil
+}
+
+// ctrlQDetachScript returns the run-shell script installed on the socket-wide
+// (server-wide) "-n -T root C-q" binding in Session.Start.
+//
+// #1808: tmux key bindings live on the SERVER, one per socket, not on the
+// session. The binding used to be guarded by a baked-in `if-shell [
+// "#{session_name}" = "<one session's name>" ]`, re-installed by every
+// Start() call — so it only ever matched whichever session started most
+// recently on the socket. Every OTHER session sharing that socket hit the
+// empty else-branch, tmux consumed nothing, and Ctrl+Q fell through to the
+// running app (killing Claude Code instead of detaching) whenever more than
+// one agentdeck session shared a socket.
+//
+// This script is re-evaluated by tmux at KEYPRESS time against whichever
+// session the invoking client is currently attached to, rather than a name
+// captured once at bind time — so it stays correct for every session on the
+// socket regardless of Start() order. Same prefix-check pattern as
+// BindMouseStatusRightDetach below.
+func ctrlQDetachScript() string {
+	return fmt.Sprintf(`S=$(tmux display-message -p '#{session_name}'); case "$S" in %s*) tmux detach-client ;; esac`, SessionPrefix)
 }
 
 // BindMouseStatusRightDetach binds a mouse click on the status-right area to detach.


### PR DESCRIPTION
## Summary

`Ctrl+Q` is meant to detach the tmux client as a fallback for terminals where XON/XOFF flow control eats the key before it reaches the PTY stdin reader (e.g. iTerm2 on macOS). The binding that implements this fallback is installed on the tmux **server**, one per socket — but it was guarded by a hardcoded single session name (`if-shell [ "#{session_name}" = "<one session>" ]`), re-installed by every `Session.Start()` call.

Since key bindings are server-wide and not per-session, that guard only ever matched whichever session started most recently on a given socket. Every other session sharing that socket hit the empty else-branch, tmux consumed nothing, and `Ctrl+Q` fell through to the running app — exiting Claude Code instead of detaching.

## Fix

Replace the baked-in session-name guard with a `run-shell` script that re-checks the **current client's** session at keypress time (`#{session_name}`) and matches it against the shared `SessionPrefix`, rather than one name captured once at bind time. This is the same prefix-check pattern `BindMouseStatusRightDetach` already uses for its own status-bar detach binding, so the two detach entry points are now consistent.

Because the check is re-evaluated dynamically per keypress against whichever session the client is actually attached to, it stays correct for any number of sessions sharing a socket, regardless of `Session.Start()` order — no per-attach rebind is needed.

Extracted the script into `ctrlQDetachScript()` and added a unit test asserting it references the current session dynamically and never bakes in one session's name.

## Testing

- Sandboxed `go build ./...` and `go vet ./...` — both clean.
- `gofmt -l internal/ cmd/` — no output.
- New unit test `TestCtrlQDetachScript_ScopedToSessionPrefixNotOneSessionName` in `internal/tmux/ctrlq_detach_test.go`.

Closes #1808
