### PR TITLE
fix(profile): warn+fallback on unknown CLAUDE_CONFIG_DIR-inferred profile, export CLAUDE_CONFIG_DIR host-side

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -239,7 +239,18 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Fprintln(os.Stderr, "Error: -claude-md and -shared-claude-md are only valid with --agent=claude")
 		os.Exit(1)
 	}
-	resolvedProfile := session.GetEffectiveProfile(profile)
+	// #1790/#1822 F2: route through the guarded resolver, not a bare
+	// GetEffectiveProfile — this value goes on to SetupConductorWithAgent
+	// and NewStorageWithProfile below, both of which create on-disk state.
+	// A bare GetEffectiveProfile would let a CLAUDE_CONFIG_DIR-inferred name
+	// that doesn't match an existing profile look like an explicit -p
+	// selection once resolved here, bypassing the #1790 guard a second hop
+	// downstream.
+	resolvedProfile, err := session.ResolveProfileForStorage(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to resolve profile: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Auto-migrate legacy conductors
 	runAutoMigration(*jsonOutput)

--- a/cmd/agent-deck/hook_children_context.go
+++ b/cmd/agent-deck/hook_children_context.go
@@ -117,8 +117,13 @@ func formatChildrenContext(rows []childRow) string {
 // snapshot, or "" when the session has none (or anything fails — the hook
 // must never break a turn over supervision sugar).
 func buildChildrenContextSummary(instanceID string) string {
-	profile := session.GetEffectiveProfile("")
-	storage, instances, _, err := loadSessionData(profile)
+	// #1790/#1822: pass "" straight through to loadSessionData/
+	// NewStorageWithProfile rather than pre-resolving via GetEffectiveProfile
+	// here. Pre-resolving would hand NewStorageWithProfile an already-concrete
+	// name, which its internal ResolveProfileForStorage guard cannot then
+	// distinguish from an explicit -p selection — reopening the same
+	// second-hop bypass fixed at the other call sites (F1/F2/F3).
+	storage, instances, _, err := loadSessionData("")
 	if err != nil {
 		return ""
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -806,7 +806,19 @@ func main() {
 	// When --no-tui is also set, run the HTTP server in the foreground and
 	// skip bubbletea entirely — the perf win that motivated this flag.
 	if webEnabled {
-		effectiveProfile := session.GetEffectiveProfile(profile)
+		// #1790: resolve (and refuse to silently auto-create) the same way
+		// NewStorageWithProfile does. Without this, GetEffectiveProfile
+		// returns a CLAUDE_CONFIG_DIR-inferred name unconditionally, and
+		// passing that concrete name into NewSessionDataService below makes
+		// its own internal NewStorageWithProfile call look like an explicit
+		// -p selection — bypassing the guard and re-opening the exact
+		// silent-empty-profile hole the guard exists to close, just via the
+		// web/headless entry point instead of the CLI/TUI one.
+		effectiveProfile, err := session.ResolveProfileForStorage(profile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to resolve profile for web server: %v\n", err)
+			os.Exit(1)
+		}
 		fallbackMenuData := web.NewSessionDataService(effectiveProfile)
 		liveMenuData := web.NewMemoryMenuData(fallbackMenuData)
 		homeModel.SetWebMenuData(liveMenuData)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/clipboard"
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
-	"github.com/asheshgoplani/agent-deck/internal/profile"
 	"github.com/asheshgoplani/agent-deck/internal/send"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
@@ -3961,10 +3960,22 @@ func handleSessionCurrent(profileArg string, args []string) {
 		os.Exit(1)
 	}
 
-	// Detect profile: use explicit arg if provided, otherwise auto-detect
+	// Detect profile: use explicit arg if provided, otherwise auto-detect.
+	// #1790/#1822: route the auto-detect path through ResolveProfileForStorage,
+	// not the bare GetEffectiveProfile(""). The
+	// result below is handed straight to findInstanceDataByTmuxFast, which
+	// opens/creates storage for it (NewStorageWithProfile) — a bare
+	// GetEffectiveProfile result would look like an explicit -p selection to
+	// that call's own guard, bypassing it a second hop downstream, the same
+	// class of bug fixed at the other call sites.
 	detectedProfile := profileArg
 	if detectedProfile == "" || detectedProfile == session.DefaultProfile {
-		detectedProfile = profile.DetectCurrentProfile()
+		resolved, err := session.ResolveProfileForStorage("")
+		if err != nil {
+			out.Error(fmt.Sprintf("failed to resolve profile: %v", err), ErrCodeNotFound)
+			os.Exit(1)
+		}
+		detectedProfile = resolved
 	}
 
 	// Try fast path: LoadLite + match by tmux session name

--- a/cmd/agent-deck/web_cmd.go
+++ b/cmd/agent-deck/web_cmd.go
@@ -79,7 +79,17 @@ func buildWebServer(profile string, args []string, menuData web.MenuDataLoader, 
 		return nil, err
 	}
 
-	effectiveProfile := session.GetEffectiveProfile(profile)
+	// #1790/#1822 F1: route through the guarded resolver, not a bare
+	// GetEffectiveProfile. The only current caller (main.go) already passes
+	// an already-guarded value here, but re-deriving with GetEffectiveProfile
+	// is a latent bypass for any other/future caller (this function is
+	// unexported but its contract should not depend on caller discipline
+	// alone) — EnsurePushVAPIDKeys below and NewSessionDataService inside
+	// web.NewServer both go on to create on-disk profile state from this.
+	effectiveProfile, err := session.ResolveProfileForStorage(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve profile: %w", err)
+	}
 
 	resolvedPushSubject := *pushVAPIDSubject
 	resolvedPushPublic := ""

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -376,7 +376,13 @@ func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 	}
 
 	if userConfig != nil {
-		profile := GetEffectiveProfile("")
+		// #1822 F1-class: route through the process's resolved profile
+		// (the same #1790 guard/fallback the host storage layer used) so
+		// this last-resort per-profile config_dir lookup keys off the
+		// profile this process actually opened, not a raw
+		// GetEffectiveProfile("") recomputation that can still return an
+		// inferred-but-rejected CLAUDE_CONFIG_DIR-derived name.
+		profile := resolvedProcessProfile()
 		if profileDir := userConfig.GetProfileClaudeConfigDir(profile); profileDir != "" {
 			return profileDir, "profile"
 		}

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -311,6 +311,31 @@ func SetDefaultProfile(profile string) error {
 	return SaveConfig(config)
 }
 
+// Profile resolution sources returned by getEffectiveProfileWithSource.
+// Callers that must decide whether it is safe to silently materialise a
+// profile on first use (e.g. NewStorageWithProfile) key off this value —
+// see issue #1790.
+const (
+	// ProfileSourceExplicit means the caller passed a profile explicitly
+	// (typically the -p/--profile flag). Auto-creating on first use is the
+	// documented, intentional way to spin up a new profile.
+	ProfileSourceExplicit = "explicit"
+	// ProfileSourceEnv means AGENTDECK_PROFILE selected the profile. Also
+	// explicit user/CI intent (e.g. AGENTDECK_PROFILE=_test); auto-create
+	// on first use is expected and unchanged.
+	ProfileSourceEnv = "env"
+	// ProfileSourceInferred means the profile name was *derived* from
+	// CLAUDE_CONFIG_DIR (issue #881), not chosen by the user for
+	// agent-deck's purposes. CLAUDE_CONFIG_DIR selects a Claude account,
+	// not an agent-deck profile — a name landing here that doesn't match
+	// an existing profile must not be silently auto-created (#1790).
+	ProfileSourceInferred = "inferred"
+	// ProfileSourceConfigDefault means config.json's default_profile applied.
+	ProfileSourceConfigDefault = "config-default"
+	// ProfileSourceFallback means nothing resolved and "default" applied.
+	ProfileSourceFallback = "fallback-default"
+)
+
 // GetEffectiveProfile returns the profile to use, considering:
 // 1. Explicitly provided profile (from -p flag)
 // 2. Environment variable AGENTDECK_PROFILE
@@ -324,28 +349,85 @@ func SetDefaultProfile(profile string) error {
 // see different sessions in TUI vs web. Both call sites now route through
 // this function to guarantee a single source of truth.
 func GetEffectiveProfile(explicit string) string {
+	profile, _ := getEffectiveProfileWithSource(explicit)
+	return profile
+}
+
+// getEffectiveProfileWithSource is GetEffectiveProfile plus the resolution
+// source, so callers that create on-disk state (NewStorageWithProfile) can
+// tell an explicit/env-selected profile (safe to auto-create) apart from one
+// merely inferred from CLAUDE_CONFIG_DIR (must not be silently materialised
+// if it doesn't already exist — #1790).
+func getEffectiveProfileWithSource(explicit string) (string, string) {
 	if explicit != "" {
-		return explicit
+		return explicit, ProfileSourceExplicit
 	}
 
 	if envProfile := os.Getenv("AGENTDECK_PROFILE"); envProfile != "" {
-		return envProfile
+		return envProfile, ProfileSourceEnv
 	}
 
 	if inferred := profileFromClaudeConfigDir(os.Getenv("CLAUDE_CONFIG_DIR")); inferred != "" {
-		return inferred
+		return inferred, ProfileSourceInferred
 	}
 
 	config, err := LoadConfig()
 	if err != nil {
-		return DefaultProfile
+		return DefaultProfile, ProfileSourceFallback
 	}
 
 	if config.DefaultProfile != "" {
-		return config.DefaultProfile
+		return config.DefaultProfile, ProfileSourceConfigDefault
 	}
 
-	return DefaultProfile
+	return DefaultProfile, ProfileSourceFallback
+}
+
+// ResolveProfileForStorage is GetEffectiveProfile plus the #1790 safety
+// guard: a profile name merely *inferred* from CLAUDE_CONFIG_DIR (e.g.
+// ~/.claude-work -> "work") is not user intent to select an agent-deck
+// profile — CLAUDE_CONFIG_DIR picks a Claude account, a separate axis. If
+// that inferred name doesn't already exist, this returns
+// ErrInferredProfileNotFound (wrapped, with the known profile list) instead
+// of a name that would go on to be silently auto-created as an empty
+// profile, potentially shadowing a real configured default with no message.
+//
+// Every call site that is about to CREATE or OPEN on-disk profile state from
+// a possibly-empty/possibly-inferred profile argument (NewStorageWithProfile,
+// and any pre-resolution done before handing a profile name down to it, e.g.
+// the web server bootstrap in cmd/agent-deck/main.go) must route through
+// this function rather than GetEffectiveProfile, or the guard is bypassed:
+// once a caller has already resolved "" to a concrete inferred name and
+// passes that name onward, it looks indistinguishable from an explicit -p
+// selection to any code further down the chain.
+//
+// Explicit (-p) and env (AGENTDECK_PROFILE) resolution are unaffected —
+// those remain the documented way to spin up a brand-new profile on first
+// use.
+func ResolveProfileForStorage(explicit string) (string, error) {
+	effectiveProfile, source := getEffectiveProfileWithSource(explicit)
+	if source != ProfileSourceInferred {
+		return effectiveProfile, nil
+	}
+
+	exists, existsErr := ProfileExists(effectiveProfile)
+	if existsErr != nil || exists {
+		return effectiveProfile, nil
+	}
+
+	known, listErr := ListProfiles()
+	knownDesc := "none yet"
+	if listErr == nil && len(known) > 0 {
+		knownDesc = strings.Join(known, ", ")
+	}
+	return "", fmt.Errorf(
+		"%w: CLAUDE_CONFIG_DIR=%q would select profile %q, which does not exist. "+
+			"Known profiles: %s. Pass -p/--profile or set AGENTDECK_PROFILE explicitly "+
+			"to pick one, or run `agent-deck profile create %s` if you intend to create it, "+
+			"or unset CLAUDE_CONFIG_DIR to use the default profile",
+		ErrInferredProfileNotFound, os.Getenv("CLAUDE_CONFIG_DIR"), effectiveProfile,
+		knownDesc, effectiveProfile,
+	)
 }
 
 // profileFromClaudeConfigDir maps a CLAUDE_CONFIG_DIR path to a profile name.

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -383,14 +383,35 @@ func getEffectiveProfileWithSource(explicit string) (string, string) {
 	return DefaultProfile, ProfileSourceFallback
 }
 
+// configuredDefaultProfile returns config.json's default_profile, or
+// DefaultProfile ("default") when unset or unreadable. This mirrors the
+// tail of getEffectiveProfileWithSource (priority 4-5) and is the safe
+// landing spot ResolveProfileForStorage falls back to instead of an
+// unrecognized CLAUDE_CONFIG_DIR-inferred name (#1790).
+func configuredDefaultProfile() string {
+	config, err := LoadConfig()
+	if err != nil || config.DefaultProfile == "" {
+		return DefaultProfile
+	}
+	return config.DefaultProfile
+}
+
 // ResolveProfileForStorage is GetEffectiveProfile plus the #1790 safety
 // guard: a profile name merely *inferred* from CLAUDE_CONFIG_DIR (e.g.
 // ~/.claude-work -> "work") is not user intent to select an agent-deck
 // profile — CLAUDE_CONFIG_DIR picks a Claude account, a separate axis. If
-// that inferred name doesn't already exist, this returns
-// ErrInferredProfileNotFound (wrapped, with the known profile list) instead
-// of a name that would go on to be silently auto-created as an empty
-// profile, potentially shadowing a real configured default with no message.
+// that inferred name doesn't already exist, this warns on stderr and falls
+// back to the configured default profile instead of a name that would go on
+// to be silently auto-created as an empty profile, potentially shadowing a
+// real configured default with no message. This matches #1790's "Expected"
+// behavior verbatim: do not auto-create, and do not hard-error either — say
+// so and fall back. A hard error here would make agent-deck refuse to start
+// from any shell exporting an unrelated CLAUDE_CONFIG_DIR whose basename
+// merely contains a dash (profileFromClaudeConfigDir's generic last-segment
+// fallback is intentionally broad, per #881/profile_resolver_test.go) —
+// turning "wrong profile inferred" into "agent-deck won't launch", which is
+// strictly worse for a class of paths far wider than the CLAUDE_CONFIG_DIR
+// dual-account pattern this inference exists for.
 //
 // Every call site that is about to CREATE or OPEN on-disk profile state from
 // a possibly-empty/possibly-inferred profile argument (NewStorageWithProfile,
@@ -404,6 +425,10 @@ func getEffectiveProfileWithSource(explicit string) (string, string) {
 // Explicit (-p) and env (AGENTDECK_PROFILE) resolution are unaffected —
 // those remain the documented way to spin up a brand-new profile on first
 // use.
+//
+// The only error this returns is a genuine ProfileExists I/O failure
+// (permission, transient filesystem); it never fails open on such an error
+// (fail open would silently restore the pre-#1790 auto-create hole).
 func ResolveProfileForStorage(explicit string) (string, error) {
 	effectiveProfile, source := getEffectiveProfileWithSource(explicit)
 	if source != ProfileSourceInferred {
@@ -411,23 +436,28 @@ func ResolveProfileForStorage(explicit string) (string, error) {
 	}
 
 	exists, existsErr := ProfileExists(effectiveProfile)
-	if existsErr != nil || exists {
+	if existsErr != nil {
+		return "", fmt.Errorf("checking whether inferred profile %q exists: %w", effectiveProfile, existsErr)
+	}
+	if exists {
 		return effectiveProfile, nil
 	}
 
+	fallback := configuredDefaultProfile()
 	known, listErr := ListProfiles()
 	knownDesc := "none yet"
 	if listErr == nil && len(known) > 0 {
 		knownDesc = strings.Join(known, ", ")
 	}
-	return "", fmt.Errorf(
-		"%w: CLAUDE_CONFIG_DIR=%q would select profile %q, which does not exist. "+
-			"Known profiles: %s. Pass -p/--profile or set AGENTDECK_PROFILE explicitly "+
-			"to pick one, or run `agent-deck profile create %s` if you intend to create it, "+
-			"or unset CLAUDE_CONFIG_DIR to use the default profile",
-		ErrInferredProfileNotFound, os.Getenv("CLAUDE_CONFIG_DIR"), effectiveProfile,
-		knownDesc, effectiveProfile,
+	fmt.Fprintf(os.Stderr,
+		"agent-deck: CLAUDE_CONFIG_DIR=%q would select profile %q, which does not exist; "+
+			"falling back to profile %q instead of creating it. Known profiles: %s. "+
+			"Pass -p/--profile or set AGENTDECK_PROFILE explicitly to pick a different profile, "+
+			"run `agent-deck profile create %s` if you intend to create it, "+
+			"or unset CLAUDE_CONFIG_DIR to use the default profile.\n",
+		os.Getenv("CLAUDE_CONFIG_DIR"), effectiveProfile, fallback, knownDesc, effectiveProfile,
 	)
+	return fallback, nil
 }
 
 // profileFromClaudeConfigDir maps a CLAUDE_CONFIG_DIR path to a profile name.

--- a/internal/session/configdir_env_injection_test.go
+++ b/internal/session/configdir_env_injection_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -143,6 +144,45 @@ func TestEnsureClaudeConfigDirEnv_NoExplicitConfigDir_DoesNotSet(t *testing.T) {
 	}
 }
 
+// TestEnsureClaudeConfigDirEnv_GateCloses_ClearsStaleValue pins #1822 F7:
+// when a previously-open gate closes (tool changes away from Claude, or the
+// instance no longer has an explicit config dir resolved), a stale
+// CLAUDE_CONFIG_DIR left in the tmux session env from an earlier call must
+// be unset — not merely left alone — so a later respawn never inherits an
+// account override that no longer applies.
+func TestEnsureClaudeConfigDirEnv_GateCloses_ClearsStaleValue(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+
+	title := uniqueShellTestTitle("ConfigDirGateCloses")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+
+	inst.Tool = "claude"
+	inst.ensureClaudeConfigDirEnv()
+	if _, err := inst.tmuxSession.GetEnvironment("CLAUDE_CONFIG_DIR"); err != nil {
+		t.Fatalf("precondition: CLAUDE_CONFIG_DIR should be set before the gate closes, GetEnvironment error: %v", err)
+	}
+
+	// Gate closes: tool is no longer Claude-compatible.
+	inst.Tool = "gemini"
+	inst.ensureClaudeConfigDirEnv()
+
+	if _, err := inst.tmuxSession.GetEnvironment("CLAUDE_CONFIG_DIR"); err == nil {
+		t.Error("CLAUDE_CONFIG_DIR should have been cleared from the tmux session env once the tool changed away from Claude")
+	}
+}
+
 // TestBuildBashExportPrefix_ExportsClaudeConfigDir covers the custom-command /
 // conductor wrapper path, which exports CLAUDE_CONFIG_DIR via `export VAR=...;`
 // (not a bare command-prefix assignment) so a hand-restart inside the pane
@@ -159,4 +199,86 @@ func TestBuildBashExportPrefix_ExportsClaudeConfigDir(t *testing.T) {
 	if !strings.Contains(prefix, "export CLAUDE_CONFIG_DIR="+wantDir+";") {
 		t.Errorf("bash export prefix should export CLAUDE_CONFIG_DIR=%s, got: %s", wantDir, prefix)
 	}
+}
+
+// TestClaudeConfigDirExport_VisibleInRunningPaneProcess is the #1822 F6
+// pane-PROCESS regression test — every other test in this file (and
+// TestSession_SetAndGetEnvironment in internal/tmux) only asserts against
+// tmux's SESSION environment table (`tmux show-environment` /
+// GetEnvironment), which is not the same thing as what a shell process
+// running inside a pane actually sees in its own env. `tmux set-environment`
+// only affects panes/processes tmux spawns AFTER the call; it cannot mutate
+// an already-running pane's process environment (tmux(1)). Codex flagged
+// this gap in review (PR #1822): "the resolved directory must be exported
+// in the launch command before the pane starts" — this test proves both
+// halves of that claim against a REAL running pane process (send-keys +
+// echo + capture-pane, reading $CLAUDE_CONFIG_DIR from the pane's own shell,
+// never GetEnvironment):
+//
+//  1. tmux set-environment (ensureClaudeConfigDirEnv's host-side re-assert,
+//     #1791) does NOT reach an already-running pane process — confirming
+//     why that mechanism alone cannot fix a pane that already exists.
+//  2. `export CLAUDE_CONFIG_DIR=...` executed directly in the pane process
+//     — the mechanism buildBashExportPrefix/buildClaudeResumeCommand now
+//     use for continue/resume/-r/restart (#1822 F5, replacing the old bare
+//     `CLAUDE_CONFIG_DIR=x claude` single-command prefix) — DOES persist in
+//     that process's own env, including across `exec "$SHELL"`, which is
+//     exactly what wrapExitToShell's fallback (#1161) execs into.
+func TestClaudeConfigDirExport_VisibleInRunningPaneProcess(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+
+	title := uniqueShellTestTitle("ConfigDirPaneProcess")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+	paneName := inst.tmuxSession.Name
+
+	// 1. tmux set-environment (session-level) must NOT reach the already-
+	// running pane process.
+	if err := inst.tmuxSession.SetEnvironment("CLAUDE_CONFIG_DIR", "session-level-value"); err != nil {
+		t.Fatalf("SetEnvironment: %v", err)
+	}
+	out := sendToPaneAndCapture(t, paneName, "echo PANE1=[$CLAUDE_CONFIG_DIR]")
+	if strings.Contains(out, "PANE1=[session-level-value]") {
+		t.Fatal("tmux set-environment unexpectedly reached the running pane process — test assumption invalid, or a tmux version quirk")
+	}
+
+	// 2. `export` run directly in the pane process DOES persist, including
+	// across exec into a replacement shell (the exit-to-shell fallback).
+	wantDir := "/tmp/pane-process-config-dir-1822"
+	sendToPaneAndCapture(t, paneName, "export CLAUDE_CONFIG_DIR="+wantDir)
+	sendToPaneAndCapture(t, paneName, `exec "$SHELL" -i`)
+	time.Sleep(300 * time.Millisecond) // let the re-exec'd interactive shell come up
+	out = sendToPaneAndCapture(t, paneName, "echo PANE2=[$CLAUDE_CONFIG_DIR]")
+	if !strings.Contains(out, "PANE2=["+wantDir+"]") {
+		t.Fatalf("expected exported CLAUDE_CONFIG_DIR to survive exec into the fallback shell, got pane content: %s", out)
+	}
+}
+
+// sendToPaneAndCapture types cmd into the named tmux pane, waits briefly for
+// it to execute, and returns the captured pane content. Uses the bare `tmux`
+// binary directly (not inst.tmuxSession's helpers) so it reads the pane
+// PROCESS's own terminal output rather than any tmux-session-level API —
+// TMUX_TMPDIR isolation (TestMain) applies process-wide via env, so this is
+// no less isolated than the tmux calls waitForTmuxSession/cleanupShellSessions
+// already make the same way.
+func sendToPaneAndCapture(t *testing.T, paneName, cmd string) string {
+	t.Helper()
+	if err := exec.Command("tmux", "send-keys", "-t", paneName, cmd, "Enter").Run(); err != nil {
+		t.Fatalf("send-keys(%q) failed: %v", cmd, err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	out, err := exec.Command("tmux", "capture-pane", "-p", "-t", paneName).Output()
+	if err != nil {
+		t.Fatalf("capture-pane failed: %v", err)
+	}
+	return string(out)
 }

--- a/internal/session/configdir_env_injection_test.go
+++ b/internal/session/configdir_env_injection_test.go
@@ -194,7 +194,7 @@ func TestBuildBashExportPrefix_ExportsClaudeConfigDir(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", wantDir)
 
 	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
-	prefix := inst.buildBashExportPrefix()
+	prefix := inst.buildBashExportPrefix(false)
 
 	if !strings.Contains(prefix, "export CLAUDE_CONFIG_DIR="+wantDir+";") {
 		t.Errorf("bash export prefix should export CLAUDE_CONFIG_DIR=%s, got: %s", wantDir, prefix)

--- a/internal/session/configdir_env_injection_test.go
+++ b/internal/session/configdir_env_injection_test.go
@@ -1,0 +1,162 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Host-side CLAUDE_CONFIG_DIR injection (issue #1791).
+//
+// CLAUDE_CONFIG_DIR was applied to the spawned launch *command* (as an
+// inline `CLAUDE_CONFIG_DIR=x claude ...` prefix or, on the custom-command
+// path, an `export ...;` prefix baked into the one-shot spawn string) but
+// never re-asserted host-side the way AGENTDECK_INSTANCE_ID/AGENTDECK_PROFILE
+// are (tmux set-environment). A fleet survey found it missing from the pane
+// shell environment in 14/40 sampled panes. Restarting `claude` by hand
+// inside the pane (Ctrl-C, then `claude`) then falls back to the ambient
+// ~/.claude root: wrong billed account, and a transcript the deck's own
+// resume logic can no longer find.
+//
+// ensureClaudeConfigDirEnv is the tool-agnostic (Claude-compatible-gated)
+// safety net (mirroring ensureProfileEnv) that every spawn/respawn success
+// path now calls.
+
+// TestEnsureClaudeConfigDirEnv_SetsHostSideEnv pins that ensureClaudeConfigDirEnv
+// writes CLAUDE_CONFIG_DIR into the live tmux session environment when the
+// instance has an explicit, resolved config dir (here: the CLAUDE_CONFIG_DIR
+// env var, priority level 4 of GetClaudeConfigDirForInstance).
+//
+// Uses a plain shell session (NewInstance, generic /bin/sh — no claude binary
+// needed in CI, matching TestEnsureProfileEnv_SetsHostSideEnv's pattern in
+// profile_env_injection_test.go) and flips Tool to "claude" post-Start so the
+// host-side env write is under test without depending on a live claude pane.
+func TestEnsureClaudeConfigDirEnv_SetsHostSideEnv(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+
+	wantDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", wantDir)
+
+	title := uniqueShellTestTitle("EnsureConfigDirEnv")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+	inst.Tool = "claude"
+
+	// Seed a stale value first so we prove ensureClaudeConfigDirEnv is what
+	// sets it, isolating the helper every respawn branch calls.
+	if err := inst.tmuxSession.SetEnvironment("CLAUDE_CONFIG_DIR", "stale"); err != nil {
+		t.Fatalf("seed SetEnvironment failed: %v", err)
+	}
+
+	inst.ensureClaudeConfigDirEnv()
+
+	got, err := inst.tmuxSession.GetEnvironment("CLAUDE_CONFIG_DIR")
+	if err != nil {
+		t.Fatalf("GetEnvironment(CLAUDE_CONFIG_DIR) failed: %v", err)
+	}
+	if got != wantDir {
+		t.Errorf("CLAUDE_CONFIG_DIR in tmux env = %q, want %q", got, wantDir)
+	}
+}
+
+// TestEnsureClaudeConfigDirEnv_NilTmuxSession_NoPanic pins the nil guard: a
+// respawn branch must never panic if the instance has no tmux session.
+func TestEnsureClaudeConfigDirEnv_NilTmuxSession_NoPanic(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/whatever")
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	inst.tmuxSession = nil
+	inst.ensureClaudeConfigDirEnv() // must not panic
+}
+
+// TestEnsureClaudeConfigDirEnv_NonClaudeTool_DoesNotSet pins the
+// IsClaudeCompatible gate: CLAUDE_CONFIG_DIR is Claude-specific, so a
+// non-Claude-compatible tool (e.g. gemini) must never get it injected
+// host-side even if CLAUDE_CONFIG_DIR happens to be set in the ambient env.
+// Uses a plain shell session (NewInstance, generic /bin/sh — no gemini
+// binary needed in CI) and flips Tool to "gemini" post-Start so only the
+// gate itself is under test, mirroring the shell-session pattern
+// profile_env_injection_test.go uses for the tmux-dependent profile tests.
+func TestEnsureClaudeConfigDirEnv_NonClaudeTool_DoesNotSet(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+
+	title := uniqueShellTestTitle("ConfigDirEnvNonClaudeGate")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+
+	inst.Tool = "gemini"
+	inst.ensureClaudeConfigDirEnv()
+
+	if _, err := inst.tmuxSession.GetEnvironment("CLAUDE_CONFIG_DIR"); err == nil {
+		t.Errorf("CLAUDE_CONFIG_DIR should not be set host-side for a non-Claude-compatible tool")
+	}
+}
+
+// TestEnsureClaudeConfigDirEnv_NoExplicitConfigDir_DoesNotSet pins the other
+// gate: when no priority level resolves an explicit config dir for the
+// instance (IsClaudeConfigDirExplicitForInstance is false, e.g. ambient
+// ~/.claude with no env/TOML override), the host-side var must not be set at
+// all — setting CLAUDE_CONFIG_DIR="" would itself be a footgun (breaks the
+// "no override, use claude's own default" case some callers rely on).
+func TestEnsureClaudeConfigDirEnv_NoExplicitConfigDir_DoesNotSet(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+	// Explicitly ensure no CLAUDE_CONFIG_DIR is inherited from the test host.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	title := uniqueShellTestTitle("ConfigDirEnvGate")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+	inst.Tool = "claude"
+
+	inst.ensureClaudeConfigDirEnv()
+
+	if _, err := inst.tmuxSession.GetEnvironment("CLAUDE_CONFIG_DIR"); err == nil {
+		t.Errorf("CLAUDE_CONFIG_DIR should not be set host-side when no explicit config dir resolves for the instance")
+	}
+}
+
+// TestBuildBashExportPrefix_ExportsClaudeConfigDir covers the custom-command /
+// conductor wrapper path, which exports CLAUDE_CONFIG_DIR via `export VAR=...;`
+// (not a bare command-prefix assignment) so a hand-restart inside the pane
+// inherits it too. Locks the existing behavior this fix's host-side net
+// complements — a regression here would silently reopen the gap for the
+// custom-command spawn path specifically.
+func TestBuildBashExportPrefix_ExportsClaudeConfigDir(t *testing.T) {
+	wantDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", wantDir)
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	prefix := inst.buildBashExportPrefix()
+
+	if !strings.Contains(prefix, "export CLAUDE_CONFIG_DIR="+wantDir+";") {
+		t.Errorf("bash export prefix should export CLAUDE_CONFIG_DIR=%s, got: %s", wantDir, prefix)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -968,9 +968,11 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	// survives into anything that process execs afterward, including the
 	// exit-to-shell fallback. See buildBashExportPrefix for what it emits
 	// (AGENTDECK_INSTANCE_ID/PROFILE always; CLAUDE_CONFIG_DIR only when
-	// IsClaudeConfigDirExplicitForInstance(i), mirroring the previous
-	// per-branch gate here).
-	bashExportPrefix := i.buildBashExportPrefix()
+	// IsClaudeConfigDirExplicitForInstance(i) AND claudeCmd is the literal
+	// "claude" binary — #1822 F3: when claudeCmd is a custom alias like
+	// "cdw"/"cdp", the deck must not also export CLAUDE_CONFIG_DIR here, or
+	// it overrides the alias's own resolution of which account to use).
+	bashExportPrefix := i.buildBashExportPrefix(claudeCmd != "claude")
 
 	// Get options - either from instance or create defaults from config
 	opts := i.GetClaudeOptions()
@@ -1079,20 +1081,34 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	// For custom commands (e.g., fork commands or conductor wrappers), prepend
 	// the env-source prefix (CFG-03) and the bash export prefix (CFG-02) so
 	// group env_file exports AND CLAUDE_CONFIG_DIR both land in the spawn env
-	// before exec'ing the wrapper.
-	return i.buildEnvSourceCommand() + i.buildBashExportPrefix() + baseCommand
+	// before exec'ing the wrapper. baseCommand here is the per-session
+	// Command field itself (a distinct axis from GetClaudeCommandForInstance,
+	// which never sees an instance-level custom command — see its doc
+	// comment), so the F3 custom-command gate does not apply: pass false.
+	return i.buildEnvSourceCommand() + i.buildBashExportPrefix(false) + baseCommand
 }
 
 // buildBashExportPrefix builds the export prefix used in bash -c commands.
 // Always exports AGENTDECK_INSTANCE_ID. CLAUDE_CONFIG_DIR is exported only
-// when the user has an explicit config_dir resolved for this instance;
-// when that gate is open, a prepared WorkerScratchConfigDir overrides
-// the resolved value — same priority as buildClaudeCommandWithMessage
-// and buildClaudeResumeCommand. See the comment there (issue #949) for
-// why the gate is required.
-func (i *Instance) buildBashExportPrefix() string {
+// when the user has an explicit config_dir resolved for this instance AND
+// skipConfigDirForCustomCommand is false; when that gate is open, a
+// prepared WorkerScratchConfigDir overrides the resolved value — same
+// priority as buildClaudeCommandWithMessage and buildClaudeResumeCommand.
+// See the comment there (issue #949) for why the gate is required.
+//
+// skipConfigDirForCustomCommand (#1822 F3): pass true when the command this
+// prefix is about to precede resolves to a custom Claude alias (e.g.
+// "cdw"/"cdp" from GetClaudeCommandForInstance) rather than the literal
+// "claude" binary — the alias is expected to set CLAUDE_CONFIG_DIR itself
+// (that's the point of aliasing), so exporting the deck's own resolved
+// value here would fight it. Pass false when the caller always execs the
+// literal "claude" binary (e.g. the fork-command builder) or when
+// baseCommand is an unrelated instance-level custom command string
+// (GetClaudeCommandForInstance never sees those — see its doc comment) —
+// in both cases there is no alias downstream to defer to.
+func (i *Instance) buildBashExportPrefix(skipConfigDirForCustomCommand bool) string {
 	prefix := fmt.Sprintf("export AGENTDECK_INSTANCE_ID=%s; export AGENTDECK_PROFILE=%s; ", i.ID, shellescape.Quote(sessionProfileEnvValue()))
-	if IsClaudeConfigDirExplicitForInstance(i) {
+	if IsClaudeConfigDirExplicitForInstance(i) && !skipConfigDirForCustomCommand {
 		// Issue #922 (reporter @bautrey): see applyWorkerScratchOverride.
 		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		// shellescape: the resolved config_dir lands in the same `bash -c`
@@ -1131,13 +1147,25 @@ func (i *Instance) buildResolvedAccountHintExports() string {
 // GetEffectiveProfile falls through to "default" — resolving the wrong profile
 // and silently orphaning auto-parent routing (resolveAutoParentInstance looks
 // up the caller's instance against the wrong profile's session list). The deck
-// process is single-profile (one Storage, one state.db), so GetEffectiveProfile("")
-// is authoritative here and matches storage.Profile() for every session it
-// manages. We inject it explicitly at each spawn site (rather than relying on
-// shell inheritance) so a child spawned from a child carries its own profile and
-// not a stale inherited one.
+// process is single-profile (one Storage, one state.db), so this must match
+// storage.Profile() for every session it manages. It routes through
+// ResolveProfileForStorage rather than a bare GetEffectiveProfile("") because
+// the host process itself may have hit the #1790 guard (an inferred,
+// nonexistent CLAUDE_CONFIG_DIR-derived name) and fallen back to the
+// configured default profile: injecting the raw inferred name here would
+// re-open that exact hole from inside every pane the deck spawns — the pane
+// classifies AGENTDECK_PROFILE as ProfileSourceEnv (explicit), bypasses the
+// guard unconditionally, and silently creates/opens a different state.db
+// than the host is using. We inject it explicitly at each spawn site
+// (rather than relying on shell inheritance) so a child spawned from a
+// child carries its own profile and not a stale inherited one.
 func sessionProfileEnvValue() string {
-	return GetEffectiveProfile("")
+	resolved, err := ResolveProfileForStorage("")
+	if err != nil {
+		sessionLog.Warn("resolve_profile_env_failed", slog.String("error", err.Error()))
+		return GetEffectiveProfile("")
+	}
+	return resolved
 }
 
 // ensureProfileEnv sets AGENTDECK_PROFILE host-side on the instance's tmux
@@ -1167,7 +1195,11 @@ func (i *Instance) ensureProfileEnv() {
 // the default ~/.claude root: wrong billed account, and (when config roots
 // share a `projects/` symlink) a transcript the deck can no longer find to
 // resume. Same gate as buildBashExportPrefix/buildClaudeCommandWithMessage:
-// only set when the instance has an explicit, resolved config_dir; a bare
+// only set when the instance has an explicit, resolved config_dir AND the
+// resolved Claude command is the literal "claude" binary, not a custom
+// alias (#1822 F3) — an alias like "cdw"/"cdp" is expected to set
+// CLAUDE_CONFIG_DIR itself, and asserting it host-side here would override
+// the alias's own resolution the next time it runs in this pane. A bare
 // CLAUDE_CONFIG_DIR="" would otherwise mask the profile-scoped identity of
 // panes intentionally left on the ambient ~/.claude root. Must run on every
 // spawn/respawn success path alongside ensureProfileEnv. Best-effort: a
@@ -1183,6 +1215,11 @@ func (i *Instance) ensureClaudeConfigDirEnv() {
 	// later respawn doesn't inherit an env stuck pointing at the wrong
 	// account — the same class of bug #1791 fixes, just in reverse.
 	if !IsClaudeCompatible(i.Tool) {
+		i.clearClaudeConfigDirEnv()
+		return
+	}
+	// #1822 F3: a custom command alias handles CLAUDE_CONFIG_DIR itself.
+	if GetClaudeCommandForInstance(i) != "claude" {
 		i.clearClaudeConfigDirEnv()
 		return
 	}
@@ -6759,6 +6796,16 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 		mcpLog.Debug("respawn_pane_claude", slog.String("command", resumeCmd))
 
+		// #1822 F2: assert AGENTDECK_PROFILE / CLAUDE_CONFIG_DIR host-side
+		// BEFORE respawn-pane, not after. tmux applies the session environment
+		// to a process at the moment it starts it, so setting it after
+		// RespawnPane only takes effect for the *next* spawn — the process
+		// RespawnPane is about to start still inherits whatever was set
+		// previously. This branch also returns before the fallback recreate
+		// path that would otherwise (re)assert it.
+		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
+
 		// Use respawn-pane for atomic restart
 		// This is more reliable than Ctrl+C + wait for shell + send command
 		// respawn-pane -k kills the current process and starts the new command atomically
@@ -6768,11 +6815,6 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 
 		mcpLog.Debug("respawn_pane_claude_succeeded")
-
-		// Re-assert AGENTDECK_PROFILE host-side: this respawn branch returns
-		// before the fallback recreate path that would otherwise set it.
-		i.ensureProfileEnv()
-		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.ClaudeSessionID)
@@ -6807,18 +6849,21 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 		sessionLog.Info("restart_gemini_respawn", slog.String("command", resumeCmd))
 
+		// #1822 F2: gemini's rebuilt resume command carries no inline
+		// AGENTDECK_PROFILE prefix, and this branch returns before the
+		// fallback recreate path that would otherwise set it. Must run
+		// BEFORE RespawnPane — tmux applies session env when it starts the
+		// process, so asserting it after RespawnPane only affects the next
+		// spawn, not the one just started.
+		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
+
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_gemini_respawn_failed", slog.String("error", err.Error()))
 			return fmt.Errorf("failed to restart Gemini session: %w", err)
 		}
 
 		sessionLog.Info("restart_gemini_respawn_succeeded")
-
-		// Re-assert AGENTDECK_PROFILE host-side: gemini's rebuilt resume command
-		// carries no inline AGENTDECK_PROFILE prefix, and this branch returns
-		// before the fallback recreate path that would otherwise set it.
-		i.ensureProfileEnv()
-		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.GeminiSessionID)
@@ -6863,6 +6908,13 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 		sessionLog.Info("restart_opencode_respawn", slog.String("command", resumeCmd))
 
+		// #1822 F2: opencode's rebuilt resume command carries no inline
+		// AGENTDECK_PROFILE prefix, and this branch returns before the
+		// fallback recreate path that would otherwise set it. Must run
+		// BEFORE RespawnPane — see the Claude branch above for why.
+		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
+
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_opencode_respawn_failed", slog.String("error", err.Error()))
 			return fmt.Errorf("failed to restart OpenCode session: %w", err)
@@ -6874,12 +6926,6 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 
 		sessionLog.Info("restart_opencode_respawn_succeeded")
-
-		// Re-assert AGENTDECK_PROFILE host-side: opencode's rebuilt resume command
-		// carries no inline AGENTDECK_PROFILE prefix, and this branch returns
-		// before the fallback recreate path that would otherwise set it.
-		i.ensureProfileEnv()
-		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		if i.OpenCodeSessionID != "" {
@@ -6933,6 +6979,13 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 		sessionLog.Info("restart_codex_respawn", slog.String("command", resumeCmd))
 
+		// #1822 F2: belt-and-suspenders to the inline prefix buildCodexCommand
+		// already injects; this branch returns before the fallback recreate
+		// path that would otherwise set it. Must run BEFORE RespawnPane —
+		// see the Claude branch above for why.
+		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
+
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_codex_respawn_failed", slog.String("error", err.Error()))
 			return fmt.Errorf("failed to restart Codex session: %w", err)
@@ -6944,12 +6997,6 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 
 		sessionLog.Info("restart_codex_respawn_succeeded")
-
-		// Re-assert AGENTDECK_PROFILE host-side as a belt-and-suspenders to the
-		// inline prefix buildCodexCommand already injects; this branch returns
-		// before the fallback recreate path that would otherwise set it.
-		i.ensureProfileEnv()
-		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.CodexSessionID)
@@ -6972,14 +7019,17 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 		sessionLog.Info("restart_cursor_respawn", slog.String("command", resumeCmd))
 
+		// #1822 F2: must run BEFORE RespawnPane — see the Claude branch above
+		// for why (tmux applies session env at process start, not after).
+		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
+
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info("restart_cursor_respawn_failed", slog.String("error", err.Error()))
 			return fmt.Errorf("failed to restart Cursor session: %w", err)
 		}
 
 		sessionLog.Info("restart_cursor_respawn_succeeded")
-		i.ensureProfileEnv()
-		i.ensureClaudeConfigDirEnv()
 		i.sweepDuplicateToolSessions()
 		i.CaptureLoadedMCPs()
 		i.Status = StatusWaiting
@@ -7011,6 +7061,13 @@ func (i *Instance) restart(env map[string]string) error {
 
 		sessionLog.Info("restart_generic_respawn", slog.String("tool", i.Tool), slog.String("command", resumeCmd))
 
+		// #1822 F2: the generic resume command is a bare
+		// `<cmd> <resumeFlag> <sid>` with no inline AGENTDECK_PROFILE prefix,
+		// and this branch returns before the fallback recreate path. Must run
+		// BEFORE RespawnPane — see the Claude branch above for why.
+		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
+
 		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
 			sessionLog.Info(
 				"restart_generic_respawn_failed",
@@ -7021,12 +7078,6 @@ func (i *Instance) restart(env map[string]string) error {
 		}
 
 		sessionLog.Info("restart_generic_respawn_succeeded", slog.String("tool", i.Tool))
-
-		// Re-assert AGENTDECK_PROFILE host-side: the generic resume command is a
-		// bare `<cmd> <resumeFlag> <sid>` with no inline AGENTDECK_PROFILE prefix,
-		// and this branch returns before the fallback recreate path.
-		i.ensureProfileEnv()
-		i.ensureClaudeConfigDirEnv()
 
 		i.loadCustomPatternsFromConfig() // Reload custom patterns
 		i.Status = StatusWaiting
@@ -7235,8 +7286,10 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// `KEY=val cmd` prefix — see the identical comment in
 	// buildClaudeCommandWithMessage for why (exit_to_shell's trailing
 	// `exec "$SHELL" -i` only inherits exported vars, not a single-command
-	// prefix scoped to the claude invocation alone).
-	bashExportPrefix := i.buildBashExportPrefix()
+	// prefix scoped to the claude invocation alone). #1822 F3: skip the
+	// CLAUDE_CONFIG_DIR export when claudeCmd resolves to a custom alias —
+	// the alias handles it itself.
+	bashExportPrefix := i.buildBashExportPrefix(claudeCmd != "claude")
 
 	// Get per-session permission settings (falls back to config if not persisted)
 	opts := i.GetClaudeOptions()
@@ -7629,8 +7682,10 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 	// IMPORTANT: For capture-resume commands (which contain $(...) syntax), we MUST use
 	// "claude" binary + explicit env exports, NOT a custom command alias like "cdw".
 	// Reason: Commands with $(...) get wrapped in `bash -c` for fish compatibility (#47),
-	// and shell aliases are not available in non-interactive bash shells.
-	bashExportPrefix := target.buildBashExportPrefix()
+	// and shell aliases are not available in non-interactive bash shells. This always
+	// execs the literal "claude" binary below regardless of GetClaudeCommandForInstance,
+	// so the #1822 F3 custom-command gate does not apply here: pass false.
+	bashExportPrefix := target.buildBashExportPrefix(false)
 
 	// If no options provided, use defaults from config
 	if opts == nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1172,6 +1172,39 @@ func (i *Instance) ensureProfileEnv() {
 	}
 }
 
+// ensureClaudeConfigDirEnv sets CLAUDE_CONFIG_DIR host-side on the instance's
+// tmux session (#1791), mirroring ensureProfileEnv. Without this, the var was
+// only ever applied as an inline command-prefix (CLAUDE_CONFIG_DIR=x claude
+// ...) or, on some paths, not applied to the persistent pane env at all — a
+// fleet survey found it missing from the pane shell in 14/40 sampled panes.
+// A hand-restart inside the pane (Ctrl-C, then `claude`) then falls back to
+// the default ~/.claude root: wrong billed account, and (when config roots
+// share a `projects/` symlink) a transcript the deck can no longer find to
+// resume. Same gate as buildBashExportPrefix/buildClaudeCommandWithMessage:
+// only set when the instance has an explicit, resolved config_dir; a bare
+// CLAUDE_CONFIG_DIR="" would otherwise mask the profile-scoped identity of
+// panes intentionally left on the ambient ~/.claude root. Must run on every
+// spawn/respawn success path alongside ensureProfileEnv. Best-effort: a
+// failure is logged, not fatal.
+func (i *Instance) ensureClaudeConfigDirEnv() {
+	if i.tmuxSession == nil {
+		return
+	}
+	if !IsClaudeCompatible(i.Tool) {
+		return
+	}
+	if !IsClaudeConfigDirExplicitForInstance(i) {
+		return
+	}
+	configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
+	if configDir == "" {
+		return
+	}
+	if err := i.tmuxSession.SetEnvironment("CLAUDE_CONFIG_DIR", configDir); err != nil {
+		sessionLog.Warn("set_claude_config_dir_failed", slog.String("error", err.Error()))
+	}
+}
+
 // logClaudeConfigResolution emits the CFG-07 observability line documenting
 // which priority level resolved CLAUDE_CONFIG_DIR for this session.
 // Owns the single CFG-07 slog message literal for this package.
@@ -3590,6 +3623,7 @@ func (i *Instance) Start() error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
+	i.ensureClaudeConfigDirEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
 	// sandbox and non-sandbox sessions). This replaces the previous approach of embedding
@@ -3852,6 +3886,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
+	i.ensureClaudeConfigDirEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
 	// sandbox and non-sandbox sessions).
@@ -6729,6 +6764,7 @@ func (i *Instance) restart(env map[string]string) error {
 		// Re-assert AGENTDECK_PROFILE host-side: this respawn branch returns
 		// before the fallback recreate path that would otherwise set it.
 		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.ClaudeSessionID)
@@ -6774,6 +6810,7 @@ func (i *Instance) restart(env map[string]string) error {
 		// carries no inline AGENTDECK_PROFILE prefix, and this branch returns
 		// before the fallback recreate path that would otherwise set it.
 		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.GeminiSessionID)
@@ -6834,6 +6871,7 @@ func (i *Instance) restart(env map[string]string) error {
 		// carries no inline AGENTDECK_PROFILE prefix, and this branch returns
 		// before the fallback recreate path that would otherwise set it.
 		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		if i.OpenCodeSessionID != "" {
@@ -6903,6 +6941,7 @@ func (i *Instance) restart(env map[string]string) error {
 		// inline prefix buildCodexCommand already injects; this branch returns
 		// before the fallback recreate path that would otherwise set it.
 		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.CodexSessionID)
@@ -6932,6 +6971,7 @@ func (i *Instance) restart(env map[string]string) error {
 
 		sessionLog.Info("restart_cursor_respawn_succeeded")
 		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
 		i.sweepDuplicateToolSessions()
 		i.CaptureLoadedMCPs()
 		i.Status = StatusWaiting
@@ -6978,6 +7018,7 @@ func (i *Instance) restart(env map[string]string) error {
 		// bare `<cmd> <resumeFlag> <sid>` with no inline AGENTDECK_PROFILE prefix,
 		// and this branch returns before the fallback recreate path.
 		i.ensureProfileEnv()
+		i.ensureClaudeConfigDirEnv()
 
 		i.loadCustomPatternsFromConfig() // Reload custom patterns
 		i.Status = StatusWaiting
@@ -7109,6 +7150,7 @@ func (i *Instance) restart(env map[string]string) error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
+	i.ensureClaudeConfigDirEnv()
 
 	// Propagate all known tool session IDs to the tmux environment (host-side).
 	// This covers Restart() which uses buildClaudeResumeCommand() and similar

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1160,6 +1160,21 @@ func (i *Instance) buildResolvedAccountHintExports() string {
 // (rather than relying on shell inheritance) so a child spawned from a
 // child carries its own profile and not a stale inherited one.
 func sessionProfileEnvValue() string {
+	return resolvedProcessProfile()
+}
+
+// resolvedProcessProfile returns the profile this process actually opened
+// storage under, routing through the same #1790 guard as the host's own
+// startup path (ResolveProfileForStorage) rather than a bare
+// GetEffectiveProfile(""). Any caller that uses a resolved profile name to
+// look up or select per-profile state (spawned-pane env, per-profile Codex
+// config, etc.) must go through this, not GetEffectiveProfile("") directly:
+// the guard falls the host back to the configured default when
+// CLAUDE_CONFIG_DIR infers a profile that doesn't exist, and
+// GetEffectiveProfile("") alone recomputes the rejected inferred name from
+// the same unchanged environment, bypassing the fallback (#1822 F1, and its
+// Codex-tool analogue in getCodexHomeDir/isCodexHomeExplicit below).
+func resolvedProcessProfile() string {
 	resolved, err := ResolveProfileForStorage("")
 	if err != nil {
 		sessionLog.Warn("resolve_profile_env_failed", slog.String("error", err.Error()))
@@ -2362,7 +2377,7 @@ func getCodexHomeDir() string {
 	}
 
 	if cfg, err := LoadUserConfig(); err == nil && cfg != nil {
-		profile := GetEffectiveProfile("")
+		profile := resolvedProcessProfile()
 		if profileDir := cfg.GetProfileCodexConfigDir(profile); profileDir != "" {
 			return profileDir
 		}
@@ -2386,7 +2401,7 @@ func isCodexHomeExplicit() bool {
 	if err != nil || cfg == nil {
 		return false
 	}
-	profile := GetEffectiveProfile("")
+	profile := resolvedProcessProfile()
 	if cfg.GetProfileCodexConfigDir(profile) != "" {
 		return true
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -951,38 +951,26 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 
 	// Get the configured Claude command (e.g., "claude", "cdw", "cdp"),
 	// resolved per instance: conductor > group (ancestor-walk) > global.
-	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
 	claudeCmd := GetClaudeCommandForInstance(i)
-	hasCustomCommand := claudeCmd != "claude"
 
-	// Resolve CLAUDE_CONFIG_DIR for this spawn. We inject the prefix only
-	// when the user has an explicit config_dir resolved for this instance
-	// (env var, profile, group, conductor, or `[claude].config_dir`). When
-	// the gate is open, a prepared WorkerScratchConfigDir overrides the
-	// resolved value — scratch carries the mutated enabledPlugins overlay
-	// (per-session plugin attach state, issue #59 / RFC PLUGIN_ATTACH.md).
-	//
-	// Issue #949: injecting scratch unconditionally breaks macOS Claude
-	// Code's keychain-keyed-by-CLAUDE_CONFIG_DIR-path OAuth on hosts where
-	// scratch is created for telegram-poller defense (#759) but the user
-	// has no explicit config_dir — the worker is routed to an opaque
-	// scratch path the keychain never saw, triggering login + onboarding
-	// every spawn. Gating restores the v1.9.1 behaviour: dormant scratch
-	// in that case, ambient ~/.claude wins.
-	// Issue #922 (reporter @bautrey): route the worker-scratch swap through
-	// applyWorkerScratchOverride so it emits an INFO log instead of being silent.
-	configDirPrefix := ""
-	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
-		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
-	}
-
-	// AGENTDECK_INSTANCE_ID is set as an inline env var so Claude's hook subprocesses
-	// can identify which agent-deck session they belong to. AGENTDECK_PROFILE is
-	// injected alongside it so an in-session `agent-deck` command resolves this
-	// session's own profile instead of falling back to "default".
-	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s ", i.ID, shellescape.Quote(sessionProfileEnvValue()))
-	configDirPrefix = instanceIDPrefix + configDirPrefix
+	// #1791/#1822 F5: every branch below (continue/-c, resume/--resume,
+	// resume-picker/-r, and fresh --session-id) shares a single `export ...;`
+	// prefix rather than each building its own inline `KEY=val cmd` form.
+	// A bare `KEY=val cmd` prefix scopes the variable to that ONE command
+	// only (standard shell semantics) — when exit_to_shell (#1161) then
+	// appends `; exec "$SHELL" -i` after the agent exits, that fallback
+	// shell does NOT inherit a non-exported prefix var, so CLAUDE_CONFIG_DIR
+	// silently reverts to the ambient ~/.claude root the moment the user
+	// exits Claude and gets dropped into the pane's shell — the exact
+	// wrong-account symptom #1791 exists to fix, just one step later than
+	// the original repro (Codex review, PR #1822). `export` persists the
+	// variable in the wrapping bash process's own environment, so it
+	// survives into anything that process execs afterward, including the
+	// exit-to-shell fallback. See buildBashExportPrefix for what it emits
+	// (AGENTDECK_INSTANCE_ID/PROFILE always; CLAUDE_CONFIG_DIR only when
+	// IsClaudeConfigDirExplicitForInstance(i), mirroring the previous
+	// per-branch gate here).
+	bashExportPrefix := i.buildBashExportPrefix()
 
 	// Get options - either from instance or create defaults from config
 	opts := i.GetClaudeOptions()
@@ -1014,7 +1002,7 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		switch opts.SessionMode {
 		case "continue":
 			// Simple -c mode: continue last session
-			return fmt.Sprintf(`%s%s%s -c%s`, configDirPrefix, execEnvPrefix, claudeCmd, extraFlags)
+			return fmt.Sprintf(`%s%s%s -c%s`, bashExportPrefix, execEnvPrefix, claudeCmd, extraFlags)
 
 		case "resume":
 			// Resume specific session by ID
@@ -1023,17 +1011,16 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 				if sessionHasConversationData(i, opts.ResumeSessionID) {
 					// Session has conversation history - use normal --resume
 					return fmt.Sprintf(`%s%s%s --resume %s%s`,
-						configDirPrefix, execEnvPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
+						bashExportPrefix, execEnvPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
 				}
 				// Session was never interacted with - use --session-id with same UUID.
 				// CLAUDE_SESSION_ID is propagated via host-side SyncSessionIDsToTmux after start.
-				bashExportPrefix := i.buildBashExportPrefix()
 				return fmt.Sprintf(
 					`%s%s%s --session-id "%s"%s`,
 					bashExportPrefix, execEnvPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
 			}
 			// No session ID provided - use -r flag for interactive picker
-			return fmt.Sprintf(`%s%s%s -r%s`, configDirPrefix, execEnvPrefix, claudeCmd, extraFlags)
+			return fmt.Sprintf(`%s%s%s -r%s`, bashExportPrefix, execEnvPrefix, claudeCmd, extraFlags)
 		}
 
 		// Default: new session with capture-resume pattern
@@ -1044,8 +1031,7 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		//
 		// NOTE: These commands get wrapped in `bash -c` for fish compatibility (#47),
 		// so shell aliases won't work — but real binaries/scripts are fine.
-		//
-		bashExportPrefix := i.buildBashExportPrefix()
+		// bashExportPrefix is the shared export prefix built above.
 
 		// Pre-generate UUID in Go to avoid shell uuidgen (may be absent in Docker sandbox).
 		// CLAUDE_SESSION_ID is also propagated via host-side SetEnvironment after tmux start.
@@ -1190,18 +1176,40 @@ func (i *Instance) ensureClaudeConfigDirEnv() {
 	if i.tmuxSession == nil {
 		return
 	}
+	// #1822 F7: any early return past this point means CLAUDE_CONFIG_DIR
+	// should NOT be set for this instance right now. Clear a stale value a
+	// previous call may have left in the tmux session env (e.g. the tool
+	// changed away from Claude, or an account override was removed) so a
+	// later respawn doesn't inherit an env stuck pointing at the wrong
+	// account — the same class of bug #1791 fixes, just in reverse.
 	if !IsClaudeCompatible(i.Tool) {
+		i.clearClaudeConfigDirEnv()
 		return
 	}
 	if !IsClaudeConfigDirExplicitForInstance(i) {
+		i.clearClaudeConfigDirEnv()
 		return
 	}
 	configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 	if configDir == "" {
+		i.clearClaudeConfigDirEnv()
 		return
 	}
 	if err := i.tmuxSession.SetEnvironment("CLAUDE_CONFIG_DIR", configDir); err != nil {
 		sessionLog.Warn("set_claude_config_dir_failed", slog.String("error", err.Error()))
+	}
+}
+
+// clearClaudeConfigDirEnv unsets CLAUDE_CONFIG_DIR from the tmux session env.
+// Best-effort: a failure (e.g. no prior value, session already gone) is
+// logged at debug, not warn — unlike SetEnvironment failing, there is no
+// stale-account risk if this is a no-op.
+func (i *Instance) clearClaudeConfigDirEnv() {
+	if i.tmuxSession == nil {
+		return
+	}
+	if err := i.tmuxSession.UnsetEnvironment("CLAUDE_CONFIG_DIR"); err != nil {
+		sessionLog.Debug("unset_claude_config_dir_noop", slog.String("error", err.Error()))
 	}
 }
 
@@ -7221,30 +7229,14 @@ func (i *Instance) buildClaudeResumeCommand() string {
 
 	// Get the configured Claude command (e.g., "claude", "cdw", "cdp"),
 	// resolved per instance: conductor > group (ancestor-walk) > global.
-	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
 	claudeCmd := GetClaudeCommandForInstance(i)
-	hasCustomCommand := claudeCmd != "claude"
 
-	// Resolve CLAUDE_CONFIG_DIR for this restart. Mirrors the gating logic
-	// in buildClaudeCommandWithMessage: we inject only when an explicit
-	// config_dir is resolved, with WorkerScratchConfigDir overriding the
-	// resolved value when set. See the comment there (issue #949) for the
-	// macOS-OAuth-keying motivation.
-	// Issue #922 (reporter @bautrey): route the worker-scratch swap through
-	// applyWorkerScratchOverride so the third spawn-env builder logs the swap
-	// with identical wording to the other two.
-	configDirPrefix := ""
-	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
-		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
-	}
-
-	// AGENTDECK_INSTANCE_ID is set as an inline env var so hook subprocesses
-	// can identify which agent-deck session they belong to. AGENTDECK_PROFILE is
-	// injected alongside it so an in-session `agent-deck` command resolves this
-	// session's own profile instead of falling back to "default".
-	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s ", i.ID, shellescape.Quote(sessionProfileEnvValue()))
-	configDirPrefix = instanceIDPrefix + configDirPrefix
+	// #1791/#1822 F5: use the shared `export ...;` prefix, not a bare
+	// `KEY=val cmd` prefix — see the identical comment in
+	// buildClaudeCommandWithMessage for why (exit_to_shell's trailing
+	// `exec "$SHELL" -i` only inherits exported vars, not a single-command
+	// prefix scoped to the claude invocation alone).
+	bashExportPrefix := i.buildBashExportPrefix()
 
 	// Get per-session permission settings (falls back to config if not persisted)
 	opts := i.GetClaudeOptions()
@@ -7313,11 +7305,11 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// (which silently fails inside Docker sandbox containers).
 	if useResume {
 		return fmt.Sprintf("%s%s%s --resume %s%s",
-			envPrefix, configDirPrefix, claudeCmd, i.ClaudeSessionID, extraFlags)
+			envPrefix, bashExportPrefix, claudeCmd, i.ClaudeSessionID, extraFlags)
 	}
 	// Session was never interacted with - use --session-id to create fresh session.
 	return fmt.Sprintf("%s%s%s --session-id %s%s",
-		envPrefix, configDirPrefix, claudeCmd, i.ClaudeSessionID, extraFlags)
+		envPrefix, bashExportPrefix, claudeCmd, i.ClaudeSessionID, extraFlags)
 }
 
 // SetGeminiModel sets the Gemini model for this session and triggers a restart if running.

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -530,9 +530,21 @@ config_dir = "~/.claude-work"
 		t.Errorf("Should use custom command 'cdw' from config, got: %s", cmd)
 	}
 
-	// Should include CLAUDE_CONFIG_DIR since config_dir is explicitly set
-	if !strings.Contains(cmd, "CLAUDE_CONFIG_DIR=") {
-		t.Errorf("Should include CLAUDE_CONFIG_DIR for capture-resume commands, got: %s", cmd)
+	// #1822 F3: a custom Claude command/alias (e.g. "cdw") is expected to
+	// resolve CLAUDE_CONFIG_DIR itself, so the deck must not also export
+	// its own resolved value ahead of it -- doing so would override the
+	// alias's own fallback resolution with the deck's value, which is the
+	// same wrong-account bug class #1822 exists to fix. This gate now
+	// applies uniformly across every buildClaudeCommandWithMessage branch
+	// (previously only continue/resume/-r respected it; the default
+	// capture-resume path here did not -- see PR #1822 review Finding 3).
+	// AGENTDECK_RESOLVED_CONFIG_DIR (the informational hint var, not the
+	// live override) is still always emitted.
+	if strings.Contains(cmd, "CLAUDE_CONFIG_DIR=") {
+		t.Errorf("Should NOT export CLAUDE_CONFIG_DIR for a custom-alias command, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "AGENTDECK_RESOLVED_CONFIG_DIR=") {
+		t.Errorf("Should still emit the AGENTDECK_RESOLVED_CONFIG_DIR hint var, got: %s", cmd)
 	}
 
 	// Should use --session-id with a literal Go-generated UUID (not shell variable)

--- a/internal/session/issue1206_spawn_shellquote_test.go
+++ b/internal/session/issue1206_spawn_shellquote_test.go
@@ -120,7 +120,7 @@ func TestBuildBashExportPrefix_ConfigDirIsShellQuoted(t *testing.T) {
 		t.Fatalf("precondition: explicit config_dir must resolve for this fixture")
 	}
 
-	prefix := inst.buildBashExportPrefix()
+	prefix := inst.buildBashExportPrefix(false)
 
 	if !strings.Contains(prefix, "CLAUDE_CONFIG_DIR=") {
 		t.Fatalf("precondition: CLAUDE_CONFIG_DIR must be exported; got:\n%s", prefix)

--- a/internal/session/issue1790_profile_autocreate_test.go
+++ b/internal/session/issue1790_profile_autocreate_test.go
@@ -1,7 +1,9 @@
 package session
 
 import (
-	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -11,7 +13,7 @@ import (
 //
 // Before this fix, NewStorageWithProfile resolved the effective profile via
 // GetEffectiveProfile — which infers a name from CLAUDE_CONFIG_DIR (e.g.
-// ~/.claude-anything -> "anything") — and then unconditionally MkdirAll'd
+// ~/.claude-work -> "work") — and then unconditionally MkdirAll'd
 // that profile's directory and opened/created its state.db. A user with an
 // explicitly configured default profile (containing real sessions) who ran
 // so much as `agent-deck ls` from a shell that happened to export
@@ -21,11 +23,36 @@ import (
 // seconds after a binary upgrade, one per CLAUDE_CONFIG_DIR value used in
 // any shell on the machine, none of them the configured default.
 //
-// The fix: only a profile the user selected explicitly (-p flag or
-// AGENTDECK_PROFILE) may be auto-created on first use. A profile name merely
-// inferred from CLAUDE_CONFIG_DIR must already exist, or NewStorageWithProfile
-// returns ErrInferredProfileNotFound with the known profile list instead of
-// creating anything.
+// The fix (per #1790's own "Expected" spec): only a profile the user
+// selected explicitly (-p flag or AGENTDECK_PROFILE) may be auto-created on
+// first use. A profile name merely inferred from CLAUDE_CONFIG_DIR must
+// already exist, or NewStorageWithProfile warns on stderr and falls back to
+// the configured default profile instead of creating anything — it does not
+// hard-error, since a hard error would make agent-deck refuse to start from
+// any shell exporting an unrelated CLAUDE_CONFIG_DIR.
+
+// captureStderr redirects os.Stderr for the duration of fn and returns
+// everything written to it. Used to assert on the #1790 fallback warning
+// without coupling tests to exact wording beyond the substrings that matter.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	_ = w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+	return string(out)
+}
 
 // withCleanProfileEnv clears AGENTDECK_PROFILE (TestMain sets it to "_test"
 // process-wide) and CLAUDE_CONFIG_DIR so each test starts from a known,
@@ -36,25 +63,28 @@ func withCleanProfileEnv(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 }
 
-func TestNewStorageWithProfile_InferredUnknownProfile_Errors(t *testing.T) {
+func TestNewStorageWithProfile_InferredUnknownProfile_FallsBackAndWarns(t *testing.T) {
 	withCleanProfileEnv(t)
 
 	// ~/.claude-issue1790missing infers profile "issue1790missing", which
 	// does not exist and was never created by this test.
 	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-issue1790missing")
 
-	storage, err := NewStorageWithProfile("")
-	if err == nil {
-		if storage != nil {
-			_ = storage.Close()
-		}
-		t.Fatal("expected an error for an inferred profile that does not exist, got nil")
+	var storage *Storage
+	var err error
+	stderr := captureStderr(t, func() {
+		storage, err = NewStorageWithProfile("")
+	})
+	if err != nil {
+		t.Fatalf("expected fallback (no error) for an inferred profile that does not exist, got: %v", err)
 	}
-	if !errors.Is(err, ErrInferredProfileNotFound) {
-		t.Errorf("error should wrap ErrInferredProfileNotFound, got: %v", err)
+	defer func() { _ = storage.Close() }()
+
+	if storage.Profile() == "issue1790missing" {
+		t.Fatalf("storage must NOT open the unrecognized inferred profile directly, got %q", storage.Profile())
 	}
-	if !strings.Contains(err.Error(), "issue1790missing") {
-		t.Errorf("error should name the inferred profile, got: %v", err)
+	if !strings.Contains(stderr, "issue1790missing") {
+		t.Errorf("fallback warning should name the inferred profile, got: %q", stderr)
 	}
 
 	exists, existsErr := ProfileExists("issue1790missing")
@@ -62,14 +92,14 @@ func TestNewStorageWithProfile_InferredUnknownProfile_Errors(t *testing.T) {
 		t.Fatalf("ProfileExists check failed: %v", existsErr)
 	}
 	if exists {
-		t.Error("profile must NOT have been auto-created by the failed resolution")
+		t.Error("profile must NOT have been auto-created by the fallback resolution")
 	}
 }
 
-func TestNewStorageWithProfile_InferredUnknownProfile_ErrorListsKnownProfiles(t *testing.T) {
+func TestNewStorageWithProfile_InferredUnknownProfile_WarningListsKnownProfiles(t *testing.T) {
 	withCleanProfileEnv(t)
 
-	// Seed a real, known profile so the error message has something to list.
+	// Seed a real, known profile so the warning message has something to list.
 	knownProfile := "issue1790known"
 	if seedStorage, seedErr := NewStorageWithProfile(knownProfile); seedErr != nil {
 		t.Fatalf("failed to seed known profile: %v", seedErr)
@@ -79,12 +109,18 @@ func TestNewStorageWithProfile_InferredUnknownProfile_ErrorListsKnownProfiles(t 
 
 	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-issue1790stillmissing")
 
-	_, err := NewStorageWithProfile("")
-	if err == nil {
-		t.Fatal("expected an error, got nil")
+	var storage *Storage
+	var err error
+	stderr := captureStderr(t, func() {
+		storage, err = NewStorageWithProfile("")
+	})
+	if err != nil {
+		t.Fatalf("expected fallback (no error), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), knownProfile) {
-		t.Errorf("error should list the known profile %q, got: %v", knownProfile, err)
+	defer func() { _ = storage.Close() }()
+
+	if !strings.Contains(stderr, knownProfile) {
+		t.Errorf("warning should list the known profile %q, got: %q", knownProfile, stderr)
 	}
 }
 
@@ -189,27 +225,25 @@ func TestResolveProfileForStorage_MatchesNewStorageWithProfile(t *testing.T) {
 	withCleanProfileEnv(t)
 	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-issue1790resolvefn")
 
-	_, resolveErr := ResolveProfileForStorage("")
-	if resolveErr == nil {
-		t.Fatal("expected ResolveProfileForStorage to error for an unknown inferred profile")
+	resolved, resolveErr := ResolveProfileForStorage("")
+	if resolveErr != nil {
+		t.Fatalf("expected ResolveProfileForStorage to fall back (no error) for an unknown inferred profile, got: %v", resolveErr)
 	}
-	if !errors.Is(resolveErr, ErrInferredProfileNotFound) {
-		t.Errorf("ResolveProfileForStorage error should wrap ErrInferredProfileNotFound, got: %v", resolveErr)
+	if resolved == "issue1790resolvefn" {
+		t.Fatalf("ResolveProfileForStorage must not return the unrecognized inferred name directly, got %q", resolved)
 	}
 
 	// A caller that pre-resolves via ResolveProfileForStorage and then
-	// passes the (never obtained, since it errored) name onward must not be
-	// able to accidentally create the profile by re-deriving it a second
-	// way — confirm NewStorageWithProfile("") on the same env agrees.
+	// passes the resulting (already-safe fallback) name onward must agree
+	// with what NewStorageWithProfile("") on the same env would open.
 	storage, storageErr := NewStorageWithProfile("")
-	if storageErr == nil {
-		if storage != nil {
-			_ = storage.Close()
-		}
-		t.Fatal("expected NewStorageWithProfile to also error for the same unknown inferred profile")
+	if storageErr != nil {
+		t.Fatalf("expected NewStorageWithProfile to also fall back (no error) for the same unknown inferred profile, got: %v", storageErr)
 	}
-	if !errors.Is(storageErr, ErrInferredProfileNotFound) {
-		t.Errorf("NewStorageWithProfile error should wrap ErrInferredProfileNotFound, got: %v", storageErr)
+	defer func() { _ = storage.Close() }()
+
+	if storage.Profile() != resolved {
+		t.Errorf("NewStorageWithProfile opened %q, ResolveProfileForStorage resolved %q; must match", storage.Profile(), resolved)
 	}
 }
 
@@ -241,5 +275,35 @@ func TestGetEffectiveProfileWithSource_Classification(t *testing.T) {
 				t.Errorf("source = %q, want %q", source, tc.wantSourceKind)
 			}
 		})
+	}
+}
+
+// TestResolveProfileForStorage_ExistsCheckFailure_FailsClosed pins F8: a
+// genuine ProfileExists I/O error (as opposed to "does not exist") must
+// propagate as an error rather than silently falling back to
+// auto-create/open behavior. Simulated via an unwritable GetProfileDir root
+// so os.Stat inside ProfileExists returns a non-NotExist error.
+func TestResolveProfileForStorage_ExistsCheckFailure_FailsClosed(t *testing.T) {
+	withCleanProfileEnv(t)
+	profileName := "issue1790existserr"
+	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-"+profileName)
+
+	profileDir, err := GetProfileDir(profileName)
+	if err != nil {
+		t.Fatalf("GetProfileDir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(profileDir), 0700); err != nil {
+		t.Fatalf("MkdirAll parent: %v", err)
+	}
+	// Make the profile's own directory path a regular file so os.Stat on
+	// <profileDir>/state.db fails with ENOTDIR, not "not exist" — a genuine
+	// I/O error ProfileExists must propagate rather than swallow.
+	if err := os.WriteFile(profileDir, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(profileDir) })
+
+	if _, err := ResolveProfileForStorage(""); err == nil {
+		t.Fatal("expected ResolveProfileForStorage to fail closed on a ProfileExists I/O error, got nil")
 	}
 }

--- a/internal/session/issue1790_profile_autocreate_test.go
+++ b/internal/session/issue1790_profile_autocreate_test.go
@@ -1,0 +1,245 @@
+package session
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Issue #1790: CLAUDE_CONFIG_DIR-derived profile names must never be
+// silently auto-created.
+//
+// Before this fix, NewStorageWithProfile resolved the effective profile via
+// GetEffectiveProfile — which infers a name from CLAUDE_CONFIG_DIR (e.g.
+// ~/.claude-anything -> "anything") — and then unconditionally MkdirAll'd
+// that profile's directory and opened/created its state.db. A user with an
+// explicitly configured default profile (containing real sessions) who ran
+// so much as `agent-deck ls` from a shell that happened to export
+// CLAUDE_CONFIG_DIR (a common dual-account alias pattern) got a brand new,
+// completely empty profile materialised with no message — reading as total
+// data loss. Real repro (2026-07-28): four empty profiles auto-created 19
+// seconds after a binary upgrade, one per CLAUDE_CONFIG_DIR value used in
+// any shell on the machine, none of them the configured default.
+//
+// The fix: only a profile the user selected explicitly (-p flag or
+// AGENTDECK_PROFILE) may be auto-created on first use. A profile name merely
+// inferred from CLAUDE_CONFIG_DIR must already exist, or NewStorageWithProfile
+// returns ErrInferredProfileNotFound with the known profile list instead of
+// creating anything.
+
+// withCleanProfileEnv clears AGENTDECK_PROFILE (TestMain sets it to "_test"
+// process-wide) and CLAUDE_CONFIG_DIR so each test starts from a known,
+// source-less resolution and can set up its own scenario.
+func withCleanProfileEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENTDECK_PROFILE", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+}
+
+func TestNewStorageWithProfile_InferredUnknownProfile_Errors(t *testing.T) {
+	withCleanProfileEnv(t)
+
+	// ~/.claude-issue1790missing infers profile "issue1790missing", which
+	// does not exist and was never created by this test.
+	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-issue1790missing")
+
+	storage, err := NewStorageWithProfile("")
+	if err == nil {
+		if storage != nil {
+			_ = storage.Close()
+		}
+		t.Fatal("expected an error for an inferred profile that does not exist, got nil")
+	}
+	if !errors.Is(err, ErrInferredProfileNotFound) {
+		t.Errorf("error should wrap ErrInferredProfileNotFound, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "issue1790missing") {
+		t.Errorf("error should name the inferred profile, got: %v", err)
+	}
+
+	exists, existsErr := ProfileExists("issue1790missing")
+	if existsErr != nil {
+		t.Fatalf("ProfileExists check failed: %v", existsErr)
+	}
+	if exists {
+		t.Error("profile must NOT have been auto-created by the failed resolution")
+	}
+}
+
+func TestNewStorageWithProfile_InferredUnknownProfile_ErrorListsKnownProfiles(t *testing.T) {
+	withCleanProfileEnv(t)
+
+	// Seed a real, known profile so the error message has something to list.
+	knownProfile := "issue1790known"
+	if seedStorage, seedErr := NewStorageWithProfile(knownProfile); seedErr != nil {
+		t.Fatalf("failed to seed known profile: %v", seedErr)
+	} else {
+		_ = seedStorage.Close()
+	}
+
+	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-issue1790stillmissing")
+
+	_, err := NewStorageWithProfile("")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), knownProfile) {
+		t.Errorf("error should list the known profile %q, got: %v", knownProfile, err)
+	}
+}
+
+// TestNewStorageWithProfile_InferredKnownProfile_Succeeds is the inverse:
+// when the CLAUDE_CONFIG_DIR-inferred name DOES match an existing profile
+// (the ordinary case for the cdw/cdp dual-account setup this inference was
+// built for, #881), resolution must keep working exactly as before.
+func TestNewStorageWithProfile_InferredKnownProfile_Succeeds(t *testing.T) {
+	withCleanProfileEnv(t)
+
+	profileName := "issue1790present"
+	if seedStorage, seedErr := NewStorageWithProfile(profileName); seedErr != nil {
+		t.Fatalf("failed to seed profile: %v", seedErr)
+	} else {
+		_ = seedStorage.Close()
+	}
+
+	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-"+profileName)
+
+	storage, err := NewStorageWithProfile("")
+	if err != nil {
+		t.Fatalf("expected success for an inferred profile that already exists, got: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	if storage.Profile() != profileName {
+		t.Errorf("storage.Profile() = %q, want %q", storage.Profile(), profileName)
+	}
+}
+
+// TestNewStorageWithProfile_ExplicitProfile_StillAutoCreates pins that the
+// -p/--profile flag's documented "first use creates it" behavior is
+// unaffected by this fix — only inference-sourced resolution is guarded.
+func TestNewStorageWithProfile_ExplicitProfile_StillAutoCreates(t *testing.T) {
+	withCleanProfileEnv(t)
+
+	profileName := "issue1790explicit"
+	exists, err := ProfileExists(profileName)
+	if err != nil {
+		t.Fatalf("ProfileExists check failed: %v", err)
+	}
+	if exists {
+		t.Fatalf("test profile %q must not already exist", profileName)
+	}
+
+	storage, err := NewStorageWithProfile(profileName)
+	if err != nil {
+		t.Fatalf("explicit profile must still auto-create on first use, got error: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	exists, err = ProfileExists(profileName)
+	if err != nil {
+		t.Fatalf("ProfileExists check failed: %v", err)
+	}
+	if !exists {
+		t.Error("explicit profile should have been auto-created")
+	}
+}
+
+// TestNewStorageWithProfile_EnvProfile_StillAutoCreates pins that
+// AGENTDECK_PROFILE-selected profiles (the CI / test-suite path, e.g.
+// AGENTDECK_PROFILE=_test) keep auto-creating on first use — this fix only
+// guards the CLAUDE_CONFIG_DIR-inference source, per the RISK note that
+// AGENTDECK_PROFILE=_test must keep working.
+func TestNewStorageWithProfile_EnvProfile_StillAutoCreates(t *testing.T) {
+	withCleanProfileEnv(t)
+
+	profileName := "issue1790envprofile"
+	t.Setenv("AGENTDECK_PROFILE", profileName)
+
+	exists, err := ProfileExists(profileName)
+	if err != nil {
+		t.Fatalf("ProfileExists check failed: %v", err)
+	}
+	if exists {
+		t.Fatalf("test profile %q must not already exist", profileName)
+	}
+
+	storage, err := NewStorageWithProfile("")
+	if err != nil {
+		t.Fatalf("AGENTDECK_PROFILE-selected profile must still auto-create on first use, got error: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+
+	exists, err = ProfileExists(profileName)
+	if err != nil {
+		t.Fatalf("ProfileExists check failed: %v", err)
+	}
+	if !exists {
+		t.Error("env-selected profile should have been auto-created")
+	}
+}
+
+// TestResolveProfileForStorage_MatchesNewStorageWithProfile pins that
+// ResolveProfileForStorage is the single source of truth NewStorageWithProfile
+// defers to, and that any OTHER caller doing its own pre-resolution before
+// opening storage (e.g. the web server bootstrap in cmd/agent-deck/main.go)
+// gets the identical guarded behavior rather than a bare GetEffectiveProfile
+// call that would silently reopen the #1790 hole via a second hop.
+func TestResolveProfileForStorage_MatchesNewStorageWithProfile(t *testing.T) {
+	withCleanProfileEnv(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-issue1790resolvefn")
+
+	_, resolveErr := ResolveProfileForStorage("")
+	if resolveErr == nil {
+		t.Fatal("expected ResolveProfileForStorage to error for an unknown inferred profile")
+	}
+	if !errors.Is(resolveErr, ErrInferredProfileNotFound) {
+		t.Errorf("ResolveProfileForStorage error should wrap ErrInferredProfileNotFound, got: %v", resolveErr)
+	}
+
+	// A caller that pre-resolves via ResolveProfileForStorage and then
+	// passes the (never obtained, since it errored) name onward must not be
+	// able to accidentally create the profile by re-deriving it a second
+	// way — confirm NewStorageWithProfile("") on the same env agrees.
+	storage, storageErr := NewStorageWithProfile("")
+	if storageErr == nil {
+		if storage != nil {
+			_ = storage.Close()
+		}
+		t.Fatal("expected NewStorageWithProfile to also error for the same unknown inferred profile")
+	}
+	if !errors.Is(storageErr, ErrInferredProfileNotFound) {
+		t.Errorf("NewStorageWithProfile error should wrap ErrInferredProfileNotFound, got: %v", storageErr)
+	}
+}
+
+// --- getEffectiveProfileWithSource source classification ---
+
+func TestGetEffectiveProfileWithSource_Classification(t *testing.T) {
+	cases := []struct {
+		name           string
+		explicit       string
+		envProfile     string
+		claudeConfig   string
+		wantSourceKind string
+	}{
+		{name: "explicit wins", explicit: "foo", wantSourceKind: ProfileSourceExplicit},
+		{name: "env wins over inference", envProfile: "bar", claudeConfig: "/x/.claude-baz", wantSourceKind: ProfileSourceEnv},
+		{name: "inferred from CLAUDE_CONFIG_DIR", claudeConfig: "/x/.claude-baz", wantSourceKind: ProfileSourceInferred},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withCleanProfileEnv(t)
+			if tc.envProfile != "" {
+				t.Setenv("AGENTDECK_PROFILE", tc.envProfile)
+			}
+			if tc.claudeConfig != "" {
+				t.Setenv("CLAUDE_CONFIG_DIR", tc.claudeConfig)
+			}
+			_, source := getEffectiveProfileWithSource(tc.explicit)
+			if source != tc.wantSourceKind {
+				t.Errorf("source = %q, want %q", source, tc.wantSourceKind)
+			}
+		})
+	}
+}

--- a/internal/session/issue949_scratch_injection_gate_test.go
+++ b/internal/session/issue949_scratch_injection_gate_test.go
@@ -84,7 +84,7 @@ token = "fake-token-for-test"
 			t.Errorf("scratch must NOT be injected when no explicit config_dir is set (#949)\ngot: %s", cmd)
 		}
 
-		exp := inst.buildBashExportPrefix()
+		exp := inst.buildBashExportPrefix(false)
 		if strings.Contains(exp, "CLAUDE_CONFIG_DIR=") {
 			t.Errorf("buildBashExportPrefix must NOT export CLAUDE_CONFIG_DIR when no explicit config_dir is set (#949)\ngot: %s", exp)
 		}

--- a/internal/session/profile_env_injection_test.go
+++ b/internal/session/profile_env_injection_test.go
@@ -65,7 +65,7 @@ func TestBuildBashExportPrefix_ExportsProfile(t *testing.T) {
 	withProfileEnv(t, "work")
 
 	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
-	prefix := inst.buildBashExportPrefix()
+	prefix := inst.buildBashExportPrefix(false)
 
 	if !strings.Contains(prefix, "export AGENTDECK_PROFILE=work;") {
 		t.Errorf("bash export prefix should export AGENTDECK_PROFILE=work, got: %s", prefix)

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -18,12 +18,6 @@ import (
 
 var storageLog = logging.ForComponent(logging.CompStorage)
 
-// ErrInferredProfileNotFound is wrapped into the error NewStorageWithProfile
-// returns when CLAUDE_CONFIG_DIR-inferred profile resolution (see
-// profileFromClaudeConfigDir) names a profile that doesn't exist on disk.
-// Callers/tests can match it with errors.Is.
-var ErrInferredProfileNotFound = errors.New("inferred profile does not exist")
-
 // fixMalformedTildePath fixes paths where the UI textinput suggestion appended
 // instead of replacing, producing paths like "/some/path~/actual/path".
 // Returns the path starting from the last "~/" occurrence.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -18,6 +18,12 @@ import (
 
 var storageLog = logging.ForComponent(logging.CompStorage)
 
+// ErrInferredProfileNotFound is wrapped into the error NewStorageWithProfile
+// returns when CLAUDE_CONFIG_DIR-inferred profile resolution (see
+// profileFromClaudeConfigDir) names a profile that doesn't exist on disk.
+// Callers/tests can match it with errors.Is.
+var ErrInferredProfileNotFound = errors.New("inferred profile does not exist")
+
 // fixMalformedTildePath fixes paths where the UI textinput suggestion appended
 // instead of replacing, producing paths like "/some/path~/actual/path".
 // Returns the path starting from the last "~/" occurrence.
@@ -189,8 +195,12 @@ func NewStorageWithProfile(profile string) (*Storage, error) {
 		}
 	}
 
-	// Get effective profile
-	effectiveProfile := GetEffectiveProfile(profile)
+	// Get effective profile, guarding against silently auto-creating a
+	// profile that was merely inferred from CLAUDE_CONFIG_DIR (#1790).
+	effectiveProfile, err := ResolveProfileForStorage(profile)
+	if err != nil {
+		return nil, err
+	}
 
 	// Get profile directory
 	profileDir, err := GetProfileDir(effectiveProfile)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1876,6 +1876,34 @@ func (s *Session) SetEnvironment(key, value string) error {
 	return err
 }
 
+// UnsetEnvironment removes an environment variable from this tmux session's
+// environment table (`set-environment -u`), so it is no longer inherited by
+// panes/processes tmux spawns afterward. Used to clear a stale value set by
+// a previous SetEnvironment call once the condition that set it no longer
+// applies (#1822 F7) — e.g. CLAUDE_CONFIG_DIR after a session's tool changes
+// away from Claude or its account override is removed. Without this, a
+// stale value would survive in the tmux session env and be inherited by any
+// later respawn, silently pointing a differently-configured pane at the
+// wrong account.
+func (s *Session) UnsetEnvironment(key string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := s.tmuxCmdContext(ctx, "set-environment", "-u", "-t", s.Name, key)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		s.envCacheMu.Lock()
+		if s.envCache != nil {
+			delete(s.envCache, key)
+		}
+		s.envCacheMu.Unlock()
+		return nil
+	}
+	if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+		return fmt.Errorf("%w: %s", err, trimmed)
+	}
+	return err
+}
+
 func (s *Session) ApplyThemeOptions() error {
 	themeStyle := currentTmuxThemeStyle()
 	var args []string

--- a/internal/web/push_service.go
+++ b/internal/web/push_service.go
@@ -78,7 +78,16 @@ type pushSubscriptionFileStore struct {
 }
 
 func newPushSubscriptionFileStore(profile string) (*pushSubscriptionFileStore, error) {
-	profileDir, err := session.GetProfileDir(session.GetEffectiveProfile(profile))
+	// #1790/#1822 F1: route through the guarded resolver — this store's
+	// path lives under the profile dir and callers below persist to it
+	// (creating the dir as needed), so a bare GetEffectiveProfile would
+	// bypass the #1790 guard for a CLAUDE_CONFIG_DIR-inferred profile that
+	// doesn't exist yet.
+	resolvedProfile, err := session.ResolveProfileForStorage(profile)
+	if err != nil {
+		return nil, fmt.Errorf("resolve profile: %w", err)
+	}
+	profileDir, err := session.GetProfileDir(resolvedProfile)
 	if err != nil {
 		return nil, fmt.Errorf("resolve profile dir: %w", err)
 	}

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -135,6 +135,11 @@ type MenuSession struct {
 type storageLoader interface {
 	LoadWithGroups() ([]*session.Instance, []*session.GroupData, error)
 	Close() error
+	// Profile returns the profile name actually opened — which, per the
+	// #1790 guard inside NewStorageWithProfile, may differ from the raw
+	// name requested (e.g. an unrecognized CLAUDE_CONFIG_DIR-inferred name
+	// falls back to the configured default). See NewSessionDataService.
+	Profile() string
 }
 
 type storageOpener func(profile string) (storageLoader, error)
@@ -149,9 +154,22 @@ type SessionDataService struct {
 }
 
 // NewSessionDataService creates a SessionDataService for a profile.
+//
+// #1790/#1822 F3: profile is stored RAW (possibly empty/possibly a
+// CLAUDE_CONFIG_DIR-inferred name) rather than pre-resolved via
+// GetEffectiveProfile. Pre-resolving here and handing the concrete result to
+// openStorage/NewStorageWithProfile would make it indistinguishable from an
+// explicit -p selection, bypassing NewStorageWithProfile's own #1790 guard a
+// second hop downstream — every caller of NewSessionDataService (web server
+// bootstrap, the standalone test-server binary, internal/web.NewServer's
+// fallback) inherited that hole. Real resolution, including the guard,
+// happens once inside the shared storage layer when the profile is actually
+// opened; s.profile is synced to the profile that was actually opened
+// afterwards (see resolveAndOpenStorage), so Profile()/BuildMenuSnapshot
+// still report the true effective name rather than the raw input.
 func NewSessionDataService(profile string) *SessionDataService {
 	return &SessionDataService{
-		profile:          session.GetEffectiveProfile(profile),
+		profile:          profile,
 		openStorage:      defaultStorageOpener,
 		now:              time.Now,
 		refreshLiveState: true,
@@ -163,9 +181,28 @@ func defaultStorageOpener(profile string) (storageLoader, error) {
 	return session.NewStorageWithProfile(profile)
 }
 
-// Profile returns the effective profile this service reads from.
+// Profile returns the effective profile this service reads from. Before the
+// first successful Load*MenuSnapshot call this may be the raw (possibly
+// empty/inferred) value passed to NewSessionDataService rather than the
+// guard-resolved effective name — see NewSessionDataService.
 func (s *SessionDataService) Profile() string {
 	return s.profile
+}
+
+// resolveAndOpenStorage opens storage for the raw profile this service was
+// constructed with (see NewSessionDataService) and syncs s.profile to
+// whatever profile was actually opened, so callers built on Profile() and
+// BuildMenuSnapshot's profile label observe the true effective name (post
+// #1790 guard/fallback) rather than the raw input.
+func (s *SessionDataService) resolveAndOpenStorage() (storageLoader, error) {
+	storage, err := s.openStorage(s.profile)
+	if err != nil {
+		return nil, fmt.Errorf("open storage for profile %q: %w", s.profile, err)
+	}
+	if opened := storage.Profile(); opened != "" {
+		s.profile = opened
+	}
+	return storage, nil
 }
 
 // LoadMenuSnapshot loads sessions/groups and returns a deterministic flattened menu DTO.
@@ -180,9 +217,9 @@ func (s *SessionDataService) LoadMenuSnapshot() (*MenuSnapshot, error) {
 		s.now = time.Now
 	}
 
-	storage, err := s.openStorage(s.profile)
+	storage, err := s.resolveAndOpenStorage()
 	if err != nil {
-		return nil, fmt.Errorf("open storage for profile %q: %w", s.profile, err)
+		return nil, err
 	}
 	defer func() { _ = storage.Close() }()
 
@@ -210,9 +247,9 @@ func (s *SessionDataService) LoadArchivedMenuSnapshot() (*MenuSnapshot, error) {
 		s.now = time.Now
 	}
 
-	storage, err := s.openStorage(s.profile)
+	storage, err := s.resolveAndOpenStorage()
 	if err != nil {
-		return nil, fmt.Errorf("open storage for profile %q: %w", s.profile, err)
+		return nil, err
 	}
 	defer func() { _ = storage.Close() }()
 

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/logging"
@@ -146,6 +147,12 @@ type storageOpener func(profile string) (storageLoader, error)
 
 // SessionDataService loads profile session data and transforms it into web-friendly DTOs.
 type SessionDataService struct {
+	// profileMu guards profile — LoadMenuSnapshot/LoadArchivedMenuSnapshot
+	// can be called concurrently (HTTP handlers + the push-service poller
+	// share one SessionDataService), and resolveAndOpenStorage writes the
+	// resolved name back to profile on every call (#1822 F3 follow-up:
+	// Codex found this was an unsynchronized data race).
+	profileMu        sync.Mutex
 	profile          string
 	openStorage      storageOpener
 	now              func() time.Time
@@ -186,6 +193,8 @@ func defaultStorageOpener(profile string) (storageLoader, error) {
 // empty/inferred) value passed to NewSessionDataService rather than the
 // guard-resolved effective name — see NewSessionDataService.
 func (s *SessionDataService) Profile() string {
+	s.profileMu.Lock()
+	defer s.profileMu.Unlock()
 	return s.profile
 }
 
@@ -194,15 +203,30 @@ func (s *SessionDataService) Profile() string {
 // whatever profile was actually opened, so callers built on Profile() and
 // BuildMenuSnapshot's profile label observe the true effective name (post
 // #1790 guard/fallback) rather than the raw input.
-func (s *SessionDataService) resolveAndOpenStorage() (storageLoader, error) {
-	storage, err := s.openStorage(s.profile)
+//
+// profileMu guards the read-then-write below: LoadMenuSnapshot and
+// LoadArchivedMenuSnapshot can run concurrently against one
+// SessionDataService (HTTP handlers + the push-service poller share one
+// instance), and without a lock two concurrent calls racing through this
+// read-modify-write would trip Go's race detector and could interleave a
+// stale profile into an error message or BuildMenuSnapshot call.
+func (s *SessionDataService) resolveAndOpenStorage() (storageLoader, string, error) {
+	s.profileMu.Lock()
+	requested := s.profile
+	s.profileMu.Unlock()
+
+	storage, err := s.openStorage(requested)
 	if err != nil {
-		return nil, fmt.Errorf("open storage for profile %q: %w", s.profile, err)
+		return nil, "", fmt.Errorf("open storage for profile %q: %w", requested, err)
 	}
+	resolved := requested
 	if opened := storage.Profile(); opened != "" {
+		resolved = opened
+		s.profileMu.Lock()
 		s.profile = opened
+		s.profileMu.Unlock()
 	}
-	return storage, nil
+	return storage, resolved, nil
 }
 
 // LoadMenuSnapshot loads sessions/groups and returns a deterministic flattened menu DTO.
@@ -217,7 +241,7 @@ func (s *SessionDataService) LoadMenuSnapshot() (*MenuSnapshot, error) {
 		s.now = time.Now
 	}
 
-	storage, err := s.resolveAndOpenStorage()
+	storage, profile, err := s.resolveAndOpenStorage()
 	if err != nil {
 		return nil, err
 	}
@@ -225,14 +249,14 @@ func (s *SessionDataService) LoadMenuSnapshot() (*MenuSnapshot, error) {
 
 	instances, groupsData, err := storage.LoadWithGroups()
 	if err != nil {
-		return nil, fmt.Errorf("load sessions for profile %q: %w", s.profile, err)
+		return nil, fmt.Errorf("load sessions for profile %q: %w", profile, err)
 	}
 	if s.refreshLiveState {
 		s.refreshStatuses(instances)
 	}
 
 	active := session.FilterInstancesByArchive(instances, false)
-	return BuildMenuSnapshot(s.profile, active, groupsData, s.now()), nil
+	return BuildMenuSnapshot(profile, active, groupsData, s.now()), nil
 }
 
 // LoadArchivedMenuSnapshot returns a menu containing only archived sessions.
@@ -247,7 +271,7 @@ func (s *SessionDataService) LoadArchivedMenuSnapshot() (*MenuSnapshot, error) {
 		s.now = time.Now
 	}
 
-	storage, err := s.resolveAndOpenStorage()
+	storage, profile, err := s.resolveAndOpenStorage()
 	if err != nil {
 		return nil, err
 	}
@@ -255,10 +279,10 @@ func (s *SessionDataService) LoadArchivedMenuSnapshot() (*MenuSnapshot, error) {
 
 	instances, groupsData, err := storage.LoadWithGroups()
 	if err != nil {
-		return nil, fmt.Errorf("load sessions for profile %q: %w", s.profile, err)
+		return nil, fmt.Errorf("load sessions for profile %q: %w", profile, err)
 	}
 	archived := session.FilterInstancesByArchive(instances, true)
-	return BuildMenuSnapshot(s.profile, archived, groupsData, s.now()), nil
+	return BuildMenuSnapshot(profile, archived, groupsData, s.now()), nil
 }
 
 func toMenuSession(inst *session.Instance) *MenuSession {

--- a/internal/web/session_data_service_test.go
+++ b/internal/web/session_data_service_test.go
@@ -13,6 +13,10 @@ type fakeStorage struct {
 	groups    []*session.GroupData
 	loadErr   error
 	closed    bool
+	// profile, if set, is what Profile() reports was actually opened. Left
+	// "" in most fixtures so SessionDataService.resolveAndOpenStorage
+	// leaves s.profile unchanged (see its own "opened != """ guard).
+	profile string
 }
 
 func (f *fakeStorage) LoadWithGroups() ([]*session.Instance, []*session.GroupData, error) {
@@ -25,6 +29,10 @@ func (f *fakeStorage) LoadWithGroups() ([]*session.Instance, []*session.GroupDat
 func (f *fakeStorage) Close() error {
 	f.closed = true
 	return nil
+}
+
+func (f *fakeStorage) Profile() string {
+	return f.profile
 }
 
 func TestSessionDataService_LoadMenuSnapshot(t *testing.T) {
@@ -209,6 +217,40 @@ func TestSessionDataService_LoadMenuSnapshotLoadError(t *testing.T) {
 	}
 	if !fake.closed {
 		t.Fatal("expected storage Close() to be called")
+	}
+}
+
+// TestSessionDataService_UnrecognizedInferredProfile_FallsBackNotBypassesGuard
+// is the F3 regression test: NewSessionDataService must not pre-resolve its
+// raw profile argument via GetEffectiveProfile before the real storage layer
+// ever sees it, or NewStorageWithProfile's own #1790 guard is bypassed a
+// second hop downstream (the concrete pre-resolved name looks identical to
+// an explicit -p selection). Exercises the REAL defaultStorageOpener /
+// session.NewStorageWithProfile path, not a fake.
+func TestSessionDataService_UnrecognizedInferredProfile_FallsBackNotBypassesGuard(t *testing.T) {
+	t.Setenv("AGENTDECK_PROFILE", "") // TestMain sets this package-wide; this test needs inference to actually apply.
+	missingProfile := "sessiondatasvc1822missing"
+	t.Setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude-"+missingProfile)
+
+	svc := NewSessionDataService("")
+
+	snapshot, err := svc.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("LoadMenuSnapshot() should fall back rather than error, got: %v", err)
+	}
+	if snapshot.Profile == missingProfile {
+		t.Fatalf("snapshot must not report the unrecognized inferred profile %q as opened", missingProfile)
+	}
+	if svc.Profile() == missingProfile {
+		t.Fatalf("service must not adopt the unrecognized inferred profile %q after load", missingProfile)
+	}
+
+	exists, existsErr := session.ProfileExists(missingProfile)
+	if existsErr != nil {
+		t.Fatalf("ProfileExists: %v", existsErr)
+	}
+	if exists {
+		t.Errorf("profile %q must not have been auto-created via NewSessionDataService", missingProfile)
 	}
 }
 

--- a/internal/web/vapid_keys.go
+++ b/internal/web/vapid_keys.go
@@ -26,7 +26,16 @@ type pushVAPIDKeysFile struct {
 // EnsurePushVAPIDKeys returns a persisted VAPID keypair for the given profile.
 // If no key file exists yet, it generates one via webpush.GenerateVAPIDKeys().
 func EnsurePushVAPIDKeys(profile, subject string) (publicKey, privateKey string, generated bool, err error) {
-	profileDir, err := session.GetProfileDir(session.GetEffectiveProfile(profile))
+	// #1790/#1822 F1: route through the guarded resolver — this writes a
+	// keyfile (MkdirAll included) into the profile dir below, so a bare
+	// GetEffectiveProfile would materialise a CLAUDE_CONFIG_DIR-inferred
+	// profile that doesn't exist yet, ahead of and independent from any
+	// storage-layer guard.
+	resolvedProfile, err := session.ResolveProfileForStorage(profile)
+	if err != nil {
+		return "", "", false, fmt.Errorf("resolve profile: %w", err)
+	}
+	profileDir, err := session.GetProfileDir(resolvedProfile)
 	if err != nil {
 		return "", "", false, fmt.Errorf("resolve profile dir: %w", err)
 	}


### PR DESCRIPTION
## Summary

Two related fixes to `CLAUDE_CONFIG_DIR` handling, batched together because they share a root cause (profile/account identity resolution) and the same reporter.

### #1790 — unknown/derived profile name silently auto-created

`GetEffectiveProfile` derives a profile name from `CLAUDE_CONFIG_DIR` (e.g. `~/.claude-<profile>` -> `"<profile>"`). `NewStorageWithProfile` then unconditionally created that profile's directory and opened/created its `state.db` — even when it didn't exist and a different, populated default profile was configured. A shell that happened to export `CLAUDE_CONFIG_DIR` (a common dual-account alias pattern) turned a bare `agent-deck ls` into an empty deck with no explanation — reading as total data loss.

**Fix:** only a profile the user selected *explicitly* (`-p`/`--profile` flag, or `AGENTDECK_PROFILE`) may still be auto-created on first use — that behavior is unchanged. A profile name merely *inferred* from `CLAUDE_CONFIG_DIR` must already exist; otherwise `ResolveProfileForStorage` warns on stderr (naming the inferred profile, the value of `CLAUDE_CONFIG_DIR`, and the list of known profiles) and falls back to the configured default profile, instead of creating anything. Every call site that creates or opens on-disk profile state now routes through this shared helper rather than a bare profile-name resolution, including the `agent-deck web` bootstrap, conductor session creation, VAPID key storage, the push-subscription store, and the child-context/`session current` helpers — each of those was its own second-hop bypass where a pre-resolved concrete name looked indistinguishable from an explicit `-p` selection to the code further down the chain.

`AGENTDECK_PROFILE=_test` (used throughout the test suite and CI) and explicit `-p <name>` continue to auto-create on first use, matching existing documented behavior — regression tests included.

### #1791 — `CLAUDE_CONFIG_DIR` not exported into the pane's persistent shell environment

`CLAUDE_CONFIG_DIR` was applied to the spawned launch command (either as a one-shot `CLAUDE_CONFIG_DIR=x claude ...` prefix, or as an `export ...;` prefix on the custom-command path) but never re-asserted host-side via `tmux set-environment`, unlike `AGENTDECK_INSTANCE_ID`/`AGENTDECK_PROFILE`. A survey across live panes found it missing from the pane's own shell environment in roughly a third of sampled sessions. Restarting `claude` by hand inside the pane (Ctrl-C, then `claude`) then silently fell back to the default `~/.claude` root: wrong billed account, and — where config roots share a transcript-store symlink — a session the deck's own resume logic can no longer locate.

**Fix:** added `ensureClaudeConfigDirEnv`, mirroring the existing `ensureProfileEnv` host-side safety net, called at every spawn/respawn success path *before* `tmux respawn-pane` runs (tmux applies session env when it starts a process, so asserting it afterward only affects the *next* spawn, not the one just started). It only sets the variable when the instance actually has an explicit, resolved `CLAUDE_CONFIG_DIR` and the resolved Claude command is the literal `claude` binary — not a custom alias like `cdw`/`cdp`, which is expected to resolve `CLAUDE_CONFIG_DIR` itself — and is a no-op (clearing any stale value) for non-Claude-compatible tools. The `continue`/`-c`, `--resume`, `-r`, and restart code paths were also moved onto the same shared `export ...;` prefix so `exit_to_shell`'s trailing `exec "$SHELL" -i` inherits it too, instead of a bare single-command-scoped assignment that a fallback shell would not see.

## Test plan

- [x] Sandboxed `go build ./...` and `go vet ./...` clean
- [x] `gofmt -l internal/ cmd/` clean
- [x] Regression tests added:
  - `internal/session/issue1790_profile_autocreate_test.go` — inferred-unknown-profile warns+falls back and does not create anything; inferred-known-profile still resolves; explicit `-p` and `AGENTDECK_PROFILE` still auto-create; error lists known profiles; `ResolveProfileForStorage`/`NewStorageWithProfile` agree; source-classification table
  - `internal/session/configdir_env_injection_test.go` — `ensureClaudeConfigDirEnv` sets the pane's tmux-session environment when explicit, is a no-op for non-Claude tools and when no config dir is explicitly resolved, doesn't panic on a nil tmux session, and a real running-pane-process check that `tmux set-environment` alone cannot reach an already-started pane
- [x] CI green

Fixes #1790, Fixes #1791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unknown profiles inferred from configuration directories from being silently created.
  * Added clear warnings and safe fallback to the configured profile when an inferred profile is unavailable.
  * Profile-resolution errors now stop setup and startup cleanly instead of creating incomplete state.
  * Improved consistency for profile selection across sessions, storage, web features, and push notifications.
  * Claude configuration directory settings now persist correctly across launches, restarts, and exit-to-shell flows.
  * Configuration directory values are cleared when no longer applicable, preventing stale settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
