### PR TITLE
docs(README): document session naming — title-lock, sync_title, groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,32 @@ Closes [issue #602](https://github.com/asheshgoplani/agent-deck/issues/602).
 
 `agent-deck session switch-account <session> <account>` moves an existing session to another Claude account — **conversation included**. The session stops, its conversation file is migrated into the target account's config dir (copy-only, with a destination backup and size verification), the account is set, and the session restarts with `--resume`. `session set <session> account <name>` auto-migrates too.
 
+### Session naming
+
+Titles and groups answer different questions — "what is this, at a glance?" versus "why do these sessions belong together?" — and each has its own controls.
+
+#### Stable titles
+
+By default, agent-deck syncs a session's displayed title from the tool's own session name (Claude's `/rename`, `claude --name`, etc.), which is useful for watching a list of live agents but means a title you set can later be overwritten. Pick the control that matches how stable you need the title to be:
+
+| You want | Do this |
+| --- | --- |
+| This one session keeps the title I gave it | `--title-lock` (alias `--no-title-sync`) on `agent-deck add` / `agent-deck launch`, or `agent-deck session set-title-lock <id> on` at runtime |
+| No session in this installation ever gets renamed by its agent | `sync_title = false` in `config.toml` |
+| A throwaway session where the live task description matters more than a fixed name | `agent-deck add --quick` (`-Q` in the TUI) — the list shows the session's current Claude task in place of the generated handle |
+
+An explicit `-t/--title` implies a lock is unnecessary until the agent renames the session; pass `--title-lock` alongside it if the title must never move. A locked title is never silently overwritten by the sync path — it only changes via an explicit rename or `session set-title-lock <id> off`.
+
+#### Groups vs. parent linkage
+
+Groups carry real policy — `max_concurrent` (serial vs. bounded parallelism), `default_path`, and per-group Claude account/config (see [Declarative groups](#declarative-groups) and [Per-group Claude config](#per-group-claude-config) above). Treat that policy as the test for whether a new group is warranted:
+
+- **Don't encode dispatch relationships in a group name.** A conductor fanning out workers doesn't need `work`, `work-infra`, `work-hygiene` siblings to say "these came from the same orchestrator" — that's what parent linkage is for. Launch with `--parent <id>` (or let `agent-deck launch` auto-parent), and read the fleet back with `agent-deck session children`.
+- **Create a new group when something policy-shaped differs** from the parent group — a different concurrency cap, working directory, or Claude account. If nothing enforced differs, the thing you have is a topic, not a group; carry it in the title and parent linkage instead.
+- **Don't rely on titles or group names as machine keys.** Both are user-editable; a script or agent matching on either is relying on something that can change under it.
+
+There's no automated warning or enforcement for group sprawl yet — this is a documented convention, not a gate. See [`docs/design/2026-07-26-session-identity-and-group-purpose.md`](docs/design/2026-07-26-session-identity-and-group-purpose.md) for the fuller design writeup (task-identity field, group `--purpose`, advisory sprawl warning) if you hit a concrete gap this section doesn't cover.
+
 ### MCP Socket Pool
 
 Running many sessions? Socket pooling shares MCP processes across all sessions via Unix sockets, reducing MCP memory usage by 85-90%. Connections auto-recover from MCP crashes in ~3 seconds via a reconnecting proxy. Enable with `pool_all = true` in [config.toml](skills/agent-deck/references/config-reference.md).


### PR DESCRIPTION
## Summary

Docs-only pass for #1703. Adds a "Session naming" section to the README, right after the existing group-related feature sections, covering:

- **Stable titles** — a decision table for `--title-lock` / `--no-title-sync` (on `add`/`launch`), `session set-title-lock <id> on|off` at runtime, and `sync_title = false` in `config.toml` for installation-wide opt-out. These already cover the "titles get silently renamed" half of the ask; the gap was discoverability, not capability.
- **Groups vs. parent linkage** — advisory guidance (don't encode dispatch relationships in group names, use `--parent` / `session children` instead; only create a new group when concurrency/path/account policy actually differs) matching the maintainer's comment on the issue.
- A link to `docs/design/2026-07-26-session-identity-and-group-purpose.md` for the still-open proposal (task-id field, group `--purpose`, advisory sprawl warning) in case a concrete gap remains after this.

No code changes. No new flags, no enforcement — matches the maintainer's guidance that a first iteration should stay advisory and that the title-stability surface should be documented rather than duplicated with a new convention.

## Test plan

- [x] `go build ./...` (sandboxed HOME) — passes
- [x] Manual read-through of the new section for accuracy against current flag definitions (`cmd/agent-deck/main.go`, `cmd/agent-deck/launch_cmd.go`, `cmd/agent-deck/session_cmd.go`, `internal/session/userconfig.go`)
- [x] Anchors (`#declarative-groups`, `#per-group-claude-config`) verified against existing README headers
