### PR TITLE
feat(status): read-only status --stale candidate view (#1704)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2594,6 +2594,10 @@ func handleStatus(profile string, args []string) {
 			fmt.Printf("Error: invalid --threshold %q: %v\n", *staleThreshold, err)
 			os.Exit(1)
 		}
+		if threshold < 0 {
+			fmt.Printf("Error: --threshold must not be negative, got %q\n", *staleThreshold)
+			os.Exit(1)
+		}
 		runStatusStale(profile, threshold, *jsonOutput)
 		return
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2550,6 +2550,12 @@ func handleStatus(profile string, args []string) {
 	quiet := fs.Bool("quiet", false, "Only output waiting count (for scripts)")
 	quietShort := fs.Bool("q", false, "Only output waiting count (short)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	// --stale (#1704): read-only lifecycle candidate view. See status_stale.go
+	// for the heuristics (never-started / bash-idle / last-activity) and the
+	// hard suggest-only constraint — this flag branches out before any of the
+	// counting/printing logic below and never mutates a session.
+	stale := fs.Bool("stale", false, "Show read-only stale-session candidates (never stops or removes anything)")
+	staleThreshold := fs.String("threshold", defaultStaleThreshold.String(), "Staleness age threshold for --stale, e.g. 24h, 48h, 168h (Go duration syntax)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck status [options]")
@@ -2564,10 +2570,32 @@ func handleStatus(profile string, args []string) {
 		fmt.Println("  agent-deck status -v           # Detailed list")
 		fmt.Println("  agent-deck status -q           # Just waiting count")
 		fmt.Println("  agent-deck -p work status      # Status for 'work' profile")
+		fmt.Println("  agent-deck status --stale                  # Read-only stale-candidate view (never-started/bash-idle/last-activity)")
+		fmt.Println("  agent-deck status --stale --threshold 48h  # Widen the staleness window")
+		fmt.Println("  agent-deck status --stale --json           # Machine-readable candidates, for agents")
+		fmt.Println()
+		fmt.Println("--stale --json shape:")
+		fmt.Println(`  {"threshold_seconds":86400,"total":5,"stale_count":2,"note":"...",`)
+		fmt.Println(`   "candidates":[{"id":"...","title":"...","tool":"...","status":"idle",`)
+		fmt.Println(`     "substate":"...","path":"...","group_path":"...","parent_session_id":"...",`)
+		fmt.Println(`     "reasons":["never-started"],"never_started":true,"created_at":"...",`)
+		fmt.Println(`     "last_started_at":"...","last_activity_at":"...","last_activity_age_seconds":90000}]}`)
+		fmt.Println("  --stale is READ-ONLY: it never stops or removes a session. Review candidates,")
+		fmt.Println("  then act yourself via `session stop`/`session remove`.")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
+	}
+
+	if *stale {
+		threshold, err := time.ParseDuration(*staleThreshold)
+		if err != nil {
+			fmt.Printf("Error: invalid --threshold %q: %v\n", *staleThreshold, err)
+			os.Exit(1)
+		}
+		runStatusStale(profile, threshold, *jsonOutput)
+		return
 	}
 
 	// Load sessions

--- a/cmd/agent-deck/status_stale.go
+++ b/cmd/agent-deck/status_stale.go
@@ -19,9 +19,13 @@ import (
 //
 // HARD CONSTRAINT (per the issue's accepted design + the standing
 // never-auto-stop/never-auto-delete rule): this view is suggest-only. It
-// never stops, removes, or otherwise mutates a session — it only reads
-// already-loaded Instance state and prints it. There is no code path from
-// this file that calls Stop/Remove/Save.
+// never stops or removes a session, and never writes session state back to
+// storage — there is no code path from this file that calls Stop/Remove/
+// Save. It does call the same status-refresh (RefreshInstancesForCLIStatus +
+// UpdateStatus) that plain `status`/`status -v` already run, which can
+// create/update/clear an auth-hold sidecar file exactly as those commands
+// do today; this file introduces no new mutation surface, but "read-only"
+// above refers specifically to the session record, not every byte on disk.
 
 // defaultStaleThreshold is the default staleness window applied when
 // --threshold is not given. 24h matches "sat around overnight with nobody
@@ -39,8 +43,8 @@ type staleReason string
 
 const (
 	reasonNeverStarted staleReason = "never-started" // added but Start() was never called
-	reasonBashIdle     staleReason = "bash-idle"     // started, now idle (user-acknowledged, per status table)
-	reasonLastActivity staleReason = "last-activity" // waiting/stopped with no observed activity past the threshold
+	reasonBashIdle     staleReason = "bash-idle"     // tool=="shell" session sitting at an idle prompt
+	reasonLastActivity staleReason = "last-activity" // waiting/idle/stopped with no observed activity past the threshold
 )
 
 // staleCandidate is one session flagged by the heuristic view, carrying the
@@ -86,6 +90,13 @@ func classifyStale(inst *session.Instance, now time.Time, threshold time.Duratio
 		return nil
 	}
 
+	// LastStartedAt is persisted via the tool_data extras zone (see
+	// internal/session/last_started_persist.go, added alongside this
+	// heuristic) so this reads a real cross-process value, not an
+	// always-zero in-memory-only field. Zero still means "unknown" for a
+	// record saved by a binary that predates that fix — those keep reading
+	// as never-started until the session is started again, matching
+	// Instance.LastStartedAt's documented zero-value contract.
 	neverStarted := inst.LastStartedAt.IsZero()
 	if neverStarted {
 		if now.Sub(inst.CreatedAt) >= threshold {
@@ -98,7 +109,13 @@ func classifyStale(inst *session.Instance, now time.Time, threshold time.Duratio
 	if activityAge < threshold {
 		return nil
 	}
-	if inst.Status == session.StatusIdle {
+	// StatusIdle is overloaded: for tool=="shell" it means a genuine bash
+	// prompt sitting idle (see UpdateStatus's "idle"/"waiting" tmux-status
+	// handling for shell), but for Claude/Codex/Gemini/etc it means
+	// "waiting, user-acknowledged" (Instance.UpdateStatus's IsAcknowledged
+	// branch) — a different situation that belongs under last-activity, not
+	// under a reason literally named bash-idle.
+	if inst.Status == session.StatusIdle && inst.Tool == "shell" {
 		return []staleReason{reasonBashIdle}
 	}
 	return []staleReason{reasonLastActivity}
@@ -214,5 +231,5 @@ func runStatusStale(profile string, threshold time.Duration, jsonOutput bool) {
 			truncate(c.Title, 16), c.Tool, c.Status, strings.Join(c.Reasons, ","), age.Round(time.Minute), c.Path)
 	}
 	fmt.Println()
-	fmt.Println("Suggest-only: review each candidate, then use `session stop`/`session remove` yourself. Nothing here was mutated.")
+	fmt.Println("Suggest-only: review each candidate, then use `session stop`/`session remove` yourself. This command never stops or removes a session.")
 }

--- a/cmd/agent-deck/status_stale.go
+++ b/cmd/agent-deck/status_stale.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// This file implements the read-only `agent-deck status --stale` candidate
+// view (issue #1704). It is the accepted first slice of proactive session
+// lifecycle management: a heuristic-driven list of sessions that LOOK
+// abandoned, shown with the evidence behind each classification, so a human
+// or a conductor agent can decide what to do about them.
+//
+// HARD CONSTRAINT (per the issue's accepted design + the standing
+// never-auto-stop/never-auto-delete rule): this view is suggest-only. It
+// never stops, removes, or otherwise mutates a session — it only reads
+// already-loaded Instance state and prints it. There is no code path from
+// this file that calls Stop/Remove/Save.
+
+// defaultStaleThreshold is the default staleness window applied when
+// --threshold is not given. 24h matches "sat around overnight with nobody
+// looking at it" — long enough that a lunch break doesn't false-positive,
+// short enough to catch the "forgot about this worker for a day" case the
+// issue was filed over.
+const defaultStaleThreshold = 24 * time.Hour
+
+// staleReason is a single named heuristic that fired for a candidate.
+// Multiple heuristics are evaluated but only one applies per session (see
+// classifyStale) so each candidate has exactly one primary reason — the
+// three named in the accepted scope: never-started, bash-idle, and
+// last-activity age for everything else sitting waiting/stopped.
+type staleReason string
+
+const (
+	reasonNeverStarted staleReason = "never-started" // added but Start() was never called
+	reasonBashIdle     staleReason = "bash-idle"     // started, now idle (user-acknowledged, per status table)
+	reasonLastActivity staleReason = "last-activity" // waiting/stopped with no observed activity past the threshold
+)
+
+// staleCandidate is one session flagged by the heuristic view, carrying the
+// evidence behind the classification so nobody has to trust the verdict
+// blindly (per Ashesh's #1704 review comment: "no single heuristic proves
+// that work is safely landed").
+type staleCandidate struct {
+	ID                  string   `json:"id"`
+	Title               string   `json:"title"`
+	Tool                string   `json:"tool"`
+	Status              string   `json:"status"`
+	Substate            string   `json:"substate,omitempty"`
+	Path                string   `json:"path"`
+	GroupPath           string   `json:"group_path,omitempty"`
+	ParentSessionID     string   `json:"parent_session_id,omitempty"`
+	Reasons             []string `json:"reasons"`
+	NeverStarted        bool     `json:"never_started"`
+	CreatedAt           string   `json:"created_at"`
+	LastStartedAt       string   `json:"last_started_at,omitempty"`
+	LastActivityAt      string   `json:"last_activity_at"`
+	LastActivityAgeSecs int64    `json:"last_activity_age_seconds"`
+}
+
+// staleEligibleStatus reports whether a status is even considered for
+// staleness. Running (active work) and error (needs attention, not cleanup)
+// are never candidates. Starting/queued are transient launch states, not
+// idle abandonment. Only waiting, idle, and stopped sessions can be stale.
+func staleEligibleStatus(status session.Status) bool {
+	switch status {
+	case session.StatusWaiting, session.StatusIdle, session.StatusStopped:
+		return true
+	default:
+		return false
+	}
+}
+
+// classifyStale evaluates the three in-scope heuristics against one instance
+// and returns the candidate reasons (empty when the session is not stale).
+// now and threshold are passed in explicitly so tests can exercise the pure
+// logic without depending on wall-clock time.
+func classifyStale(inst *session.Instance, now time.Time, threshold time.Duration) []staleReason {
+	if !staleEligibleStatus(inst.Status) {
+		return nil
+	}
+
+	neverStarted := inst.LastStartedAt.IsZero()
+	if neverStarted {
+		if now.Sub(inst.CreatedAt) >= threshold {
+			return []staleReason{reasonNeverStarted}
+		}
+		return nil
+	}
+
+	activityAge := now.Sub(inst.DisplayLastActivityTime())
+	if activityAge < threshold {
+		return nil
+	}
+	if inst.Status == session.StatusIdle {
+		return []staleReason{reasonBashIdle}
+	}
+	return []staleReason{reasonLastActivity}
+}
+
+// computeStaleCandidates scans instances (already status-refreshed by the
+// caller) and returns the stale subset, sorted oldest-last-activity-first so
+// the most obviously-abandoned sessions surface at the top.
+func computeStaleCandidates(instances []*session.Instance, now time.Time, threshold time.Duration) []staleCandidate {
+	var candidates []staleCandidate
+	for _, inst := range instances {
+		reasons := classifyStale(inst, now, threshold)
+		if len(reasons) == 0 {
+			continue
+		}
+		reasonStrs := make([]string, 0, len(reasons))
+		for _, r := range reasons {
+			reasonStrs = append(reasonStrs, string(r))
+		}
+		lastActivity := inst.DisplayLastActivityTime()
+		c := staleCandidate{
+			ID:                  inst.ID,
+			Title:               inst.Title,
+			Tool:                inst.Tool,
+			Status:              StatusString(inst.Status),
+			Substate:            string(inst.Substate()),
+			Path:                inst.ProjectPath,
+			GroupPath:           inst.GroupPath,
+			ParentSessionID:     inst.ParentSessionID,
+			Reasons:             reasonStrs,
+			NeverStarted:        inst.LastStartedAt.IsZero(),
+			CreatedAt:           inst.CreatedAt.Format(time.RFC3339),
+			LastActivityAt:      lastActivity.Format(time.RFC3339),
+			LastActivityAgeSecs: int64(now.Sub(lastActivity).Seconds()),
+		}
+		if !inst.LastStartedAt.IsZero() {
+			c.LastStartedAt = inst.LastStartedAt.Format(time.RFC3339)
+		}
+		candidates = append(candidates, c)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].LastActivityAgeSecs > candidates[j].LastActivityAgeSecs
+	})
+	return candidates
+}
+
+// staleCandidatesJSON is the top-level --stale --json envelope.
+type staleCandidatesJSON struct {
+	ThresholdSeconds int64            `json:"threshold_seconds"`
+	Total            int              `json:"total"`
+	StaleCount       int              `json:"stale_count"`
+	Candidates       []staleCandidate `json:"candidates"`
+	Note             string           `json:"note"`
+}
+
+// runStatusStale is the entry point invoked from handleStatus when --stale is
+// set. It is READ-ONLY: it loads, classifies, and prints — nothing here calls
+// Stop, Remove, or Save. profile/threshold/jsonOutput come from the parsed
+// flags in handleStatus.
+func runStatusStale(profile string, threshold time.Duration, jsonOutput bool) {
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		fmt.Printf("Error: failed to initialize storage: %v\n", err)
+		os.Exit(1)
+	}
+
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		fmt.Printf("Error: failed to load sessions: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Refresh status the same way `status`/`status -v` does (issue #610 parity)
+	// so staleness is judged against live state, not a stale on-disk snapshot.
+	// This only reads tmux/hook state into the in-memory Instance objects; it
+	// does not write anything back to storage (no SaveWithGroups call below).
+	session.RefreshInstancesForCLIStatus(instances)
+	for _, inst := range instances {
+		_ = inst.UpdateStatus()
+	}
+
+	now := time.Now()
+	candidates := computeStaleCandidates(instances, now, threshold)
+
+	if jsonOutput {
+		resp := staleCandidatesJSON{
+			ThresholdSeconds: int64(threshold.Seconds()),
+			Total:            len(instances),
+			StaleCount:       len(candidates),
+			Candidates:       candidates,
+			Note:             "read-only candidate view; nothing was stopped or removed",
+		}
+		if resp.Candidates == nil {
+			resp.Candidates = []staleCandidate{}
+		}
+		out, _ := json.Marshal(resp)
+		fmt.Println(string(out))
+		return
+	}
+
+	if len(candidates) == 0 {
+		fmt.Printf("No stale candidates in profile '%s' (threshold %s). %d session(s) checked.\n",
+			storage.Profile(), threshold, len(instances))
+		return
+	}
+
+	fmt.Printf("STALE CANDIDATES (%d of %d sessions, threshold %s) — read-only, nothing stopped or removed:\n\n",
+		len(candidates), len(instances), threshold)
+	for _, c := range candidates {
+		age := time.Duration(c.LastActivityAgeSecs) * time.Second
+		fmt.Printf("  %-16s %-10s %-8s %-16s last-active %s ago  %s\n",
+			truncate(c.Title, 16), c.Tool, c.Status, strings.Join(c.Reasons, ","), age.Round(time.Minute), c.Path)
+	}
+	fmt.Println()
+	fmt.Println("Suggest-only: review each candidate, then use `session stop`/`session remove` yourself. Nothing here was mutated.")
+}

--- a/cmd/agent-deck/status_stale.go
+++ b/cmd/agent-deck/status_stale.go
@@ -105,7 +105,7 @@ func classifyStale(inst *session.Instance, now time.Time, threshold time.Duratio
 		return nil
 	}
 
-	activityAge := now.Sub(inst.DisplayLastActivityTime())
+	activityAge := now.Sub(staleActivityEvidence(inst))
 	if activityAge < threshold {
 		return nil
 	}
@@ -119,6 +119,26 @@ func classifyStale(inst *session.Instance, now time.Time, threshold time.Duratio
 		return []staleReason{reasonBashIdle}
 	}
 	return []staleReason{reasonLastActivity}
+}
+
+// staleActivityEvidence returns the most credible "last active" timestamp
+// available for classification. DisplayLastActivityTime() alone is not
+// enough here: it only counts LastObservedActivity, a process-local tmux
+// tracker that a short-lived `status --stale` CLI invocation never runs
+// long enough to populate, so it falls straight through to the persisted
+// LastAccessedAt/CreatedAt fallback. That fallback can be stale for a
+// worker that just finished real work but was never attached in the TUI.
+// UpdateStatus's cold-load path (called by runStatusStale before this runs)
+// reads the on-disk hook status sidecar regardless of process age, so
+// LastHookActivityTime is durable, real evidence of recent activity — take
+// whichever timestamp is more recent (never the reverse: this can only
+// shrink the reported age, never inflate it into a false negative).
+func staleActivityEvidence(inst *session.Instance) time.Time {
+	activity := inst.DisplayLastActivityTime()
+	if hookTime, ok := inst.LastHookActivityTime(); ok && hookTime.After(activity) {
+		return hookTime
+	}
+	return activity
 }
 
 // computeStaleCandidates scans instances (already status-refreshed by the
@@ -135,7 +155,7 @@ func computeStaleCandidates(instances []*session.Instance, now time.Time, thresh
 		for _, r := range reasons {
 			reasonStrs = append(reasonStrs, string(r))
 		}
-		lastActivity := inst.DisplayLastActivityTime()
+		lastActivity := staleActivityEvidence(inst)
 		c := staleCandidate{
 			ID:                  inst.ID,
 			Title:               inst.Title,

--- a/cmd/agent-deck/status_stale.go
+++ b/cmd/agent-deck/status_stale.go
@@ -93,19 +93,30 @@ func classifyStale(inst *session.Instance, now time.Time, threshold time.Duratio
 	// LastStartedAt is persisted via the tool_data extras zone (see
 	// internal/session/last_started_persist.go, added alongside this
 	// heuristic) so this reads a real cross-process value, not an
-	// always-zero in-memory-only field. Zero still means "unknown" for a
-	// record saved by a binary that predates that fix — those keep reading
-	// as never-started until the session is started again, matching
-	// Instance.LastStartedAt's documented zero-value contract.
-	neverStarted := inst.LastStartedAt.IsZero()
-	if neverStarted {
+	// always-zero in-memory-only field. But zero is still ambiguous: it
+	// means either "genuinely never started" or "started before this
+	// field's persistence landed" (last_started_at is a brand-new tool_data
+	// key — every row saved before this fix shipped reads back as zero even
+	// though the session ran fine, and that describes literally every
+	// pre-existing session in the fleet on first deploy). Reporting the
+	// stronger "never-started" claim on an unproven zero is exactly the
+	// false-positive class this view exists to avoid (see the maintainer's
+	// PR #1826 review comment: "make the unknown case render as unknown
+	// rather than collapsing into a definite claim"). Corroborate with
+	// independent evidence collected by staleActivityEvidence — confirmed
+	// tmux activity, a TUI attach, or a durable hook-status sample — before
+	// asserting never-started: if any of those fired after CreatedAt,
+	// something DID happen, so fall through to the activity-based
+	// classification below instead.
+	evidence := staleActivityEvidence(inst)
+	if inst.LastStartedAt.IsZero() && evidence.Equal(inst.CreatedAt) {
 		if now.Sub(inst.CreatedAt) >= threshold {
 			return []staleReason{reasonNeverStarted}
 		}
 		return nil
 	}
 
-	activityAge := now.Sub(staleActivityEvidence(inst))
+	activityAge := now.Sub(evidence)
 	if activityAge < threshold {
 		return nil
 	}
@@ -152,21 +163,31 @@ func computeStaleCandidates(instances []*session.Instance, now time.Time, thresh
 			continue
 		}
 		reasonStrs := make([]string, 0, len(reasons))
+		neverStartedConfirmed := false
 		for _, r := range reasons {
 			reasonStrs = append(reasonStrs, string(r))
+			if r == reasonNeverStarted {
+				neverStartedConfirmed = true
+			}
 		}
 		lastActivity := staleActivityEvidence(inst)
 		c := staleCandidate{
-			ID:                  inst.ID,
-			Title:               inst.Title,
-			Tool:                inst.Tool,
-			Status:              StatusString(inst.Status),
-			Substate:            string(inst.Substate()),
-			Path:                inst.ProjectPath,
-			GroupPath:           inst.GroupPath,
-			ParentSessionID:     inst.ParentSessionID,
-			Reasons:             reasonStrs,
-			NeverStarted:        inst.LastStartedAt.IsZero(),
+			ID:              inst.ID,
+			Title:           inst.Title,
+			Tool:            inst.Tool,
+			Status:          StatusString(inst.Status),
+			Substate:        string(inst.Substate()),
+			Path:            inst.ProjectPath,
+			GroupPath:       inst.GroupPath,
+			ParentSessionID: inst.ParentSessionID,
+			Reasons:         reasonStrs,
+			// NeverStarted mirrors the actual classification reason (not a
+			// raw LastStartedAt.IsZero() check) so this boolean can never
+			// contradict Reasons — a zero LastStartedAt that was
+			// corroborated by other activity evidence and classified under
+			// last-activity/bash-idle instead must not also claim
+			// never-started here.
+			NeverStarted:        neverStartedConfirmed,
 			CreatedAt:           inst.CreatedAt.Format(time.RFC3339),
 			LastActivityAt:      lastActivity.Format(time.RFC3339),
 			LastActivityAgeSecs: int64(now.Sub(lastActivity).Seconds()),

--- a/cmd/agent-deck/status_stale_test.go
+++ b/cmd/agent-deck/status_stale_test.go
@@ -146,6 +146,50 @@ func TestClassifyStale_Heuristics(t *testing.T) {
 	}
 }
 
+// TestStaleActivityEvidence_PrefersDurableHookTimestamp is a regression
+// guard for the #1826 review's second P1 (chatgpt-codex-connector,
+// status_stale.go:110): DisplayLastActivityTime() alone only counts
+// process-local LastObservedActivity, which a short-lived `status --stale`
+// CLI invocation never runs long enough to populate, so it silently falls
+// back to the (possibly very old) CreatedAt/LastAccessedAt. A session that
+// just finished real work — proven by a fresh on-disk hook status sample —
+// must not be misclassified as stale against its creation time.
+func TestStaleActivityEvidence_PrefersDurableHookTimestamp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	old := time.Now().Add(-72 * time.Hour)
+	recent := time.Now().Add(-30 * time.Second)
+
+	inst := &session.Instance{
+		ID:            "stale-evidence-test",
+		Status:        session.StatusWaiting,
+		Tool:          "claude",
+		CreatedAt:     old,
+		LastStartedAt: old, // started, so classifyStale takes the activity-age branch
+		// No LastAccessedAt: never attached in the TUI, so
+		// DisplayLastActivityTime() would otherwise fall all the way back
+		// to the 72h-old CreatedAt.
+	}
+
+	// A hook sample with no SessionID/Event is a no-op past setting the
+	// hookStatus/hookLastUpdate fields themselves (see UpdateHookStatus:
+	// empty SessionID + no session-anchor file on this fresh HOME resolves
+	// to an early return before any session-id binding logic runs).
+	inst.UpdateHookStatus(&session.HookStatus{Status: "waiting", UpdatedAt: recent})
+
+	got := staleActivityEvidence(inst)
+	if !got.Equal(recent) {
+		t.Fatalf("staleActivityEvidence() = %v, want the durable hook timestamp %v (got CreatedAt-derived instead)", got, recent)
+	}
+
+	// End-to-end: with a 1h threshold, this session must NOT be flagged
+	// stale, even though CreatedAt is 72h old — the hook proves it was
+	// active 30s ago.
+	if got := classifyStale(inst, time.Now(), time.Hour); len(got) != 0 {
+		t.Fatalf("classifyStale() = %v, want nil: durable hook activity 30s ago must not read as stale under a 1h threshold", got)
+	}
+}
+
 // TestStatusStale_CLI_CandidateViewAndMutatesNothing is the end-to-end gate:
 // builds the real binary, adds a never-started session (nothing else could
 // legitimately reach candidate status without tmux in a test sandbox), and

--- a/cmd/agent-deck/status_stale_test.go
+++ b/cmd/agent-deck/status_stale_test.go
@@ -115,6 +115,23 @@ func TestClassifyStale_Heuristics(t *testing.T) {
 			want: []staleReason{reasonBashIdle},
 		},
 		{
+			// Regression guard (#1826 re-review BLOCKING finding): a zero
+			// LastStartedAt is ambiguous — it also describes every row
+			// persisted before last_started_at existed as a tool_data key,
+			// i.e. every live session in the fleet on first deploy of this
+			// fix. LastAccessedAt here proves the session WAS used after
+			// creation, so classifyStale must not assert the stronger,
+			// unproven never-started claim; it must fall through to the
+			// ordinary activity-based classification instead.
+			name: "zero_last_started_at_with_corroborating_activity_is_not_never_started",
+			inst: &session.Instance{
+				Status:         session.StatusWaiting,
+				CreatedAt:      now.Add(-72 * time.Hour),
+				LastAccessedAt: now.Add(-48 * time.Hour), // proves activity after creation; LastStartedAt left zero
+			},
+			want: []staleReason{reasonLastActivity},
+		},
+		{
 			// Regression guard (#1826 review finding #3): StatusIdle on a
 			// non-shell tool means "waiting, user-acknowledged" (see
 			// UpdateStatus's IsAcknowledged branch), not a bash prompt sitting

--- a/cmd/agent-deck/status_stale_test.go
+++ b/cmd/agent-deck/status_stale_test.go
@@ -104,14 +104,30 @@ func TestClassifyStale_Heuristics(t *testing.T) {
 			want: []staleReason{reasonLastActivity},
 		},
 		{
-			name: "started_then_idle_past_threshold_is_bash_idle",
+			name: "started_then_idle_shell_past_threshold_is_bash_idle",
 			inst: &session.Instance{
 				Status:         session.StatusIdle,
+				Tool:           "shell", // reasonBashIdle only applies to genuine bash-idle tools
 				CreatedAt:      now.Add(-72 * time.Hour),
 				LastStartedAt:  now.Add(-72 * time.Hour), // was started, so NOT never-started
 				LastAccessedAt: now.Add(-48 * time.Hour),
 			},
 			want: []staleReason{reasonBashIdle},
+		},
+		{
+			// Regression guard (#1826 review finding #3): StatusIdle on a
+			// non-shell tool means "waiting, user-acknowledged" (see
+			// UpdateStatus's IsAcknowledged branch), not a bash prompt sitting
+			// idle. It must classify as last-activity, never bash-idle.
+			name: "started_then_idle_claude_past_threshold_is_last_activity_not_bash_idle",
+			inst: &session.Instance{
+				Status:         session.StatusIdle,
+				Tool:           "claude",
+				CreatedAt:      now.Add(-72 * time.Hour),
+				LastStartedAt:  now.Add(-72 * time.Hour),
+				LastAccessedAt: now.Add(-48 * time.Hour),
+			},
+			want: []staleReason{reasonLastActivity},
 		},
 	}
 
@@ -271,5 +287,162 @@ func TestStatusStale_CLI_CandidateViewAndMutatesNothing(t *testing.T) {
 	}
 	if !strings.Contains(textOut, "read-only") {
 		t.Fatalf("text --stale output should reassert read-only/suggest-only framing: %s", textOut)
+	}
+}
+
+// TestStatusStale_CLI_StartedSessionIsNotNeverStarted closes the #1826
+// review's blind spot: the original CLI test only ever exercised a session
+// that was genuinely never started, so a heuristic that (bug) classified
+// EVERYTHING as never-started would still pass it. This test actually starts
+// a real session, lets tmux settle it to idle, and asserts through the
+// SQLite-backed CLI subprocess (a real process boundary, not an in-memory
+// Instance literal) that:
+//   - never_started is false and last_started_at is populated
+//   - the reason is bash-idle (tool=="shell"), not never-started
+//   - the candidate's status field is asserted, not just its reasons
+func TestStatusStale_CLI_StartedSessionIsNotNeverStarted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess integration test in short mode")
+	}
+
+	tmpHome := t.TempDir()
+	xdgConfigHome := filepath.Join(tmpHome, ".config")
+	xdgDataHome := filepath.Join(tmpHome, ".local", "share")
+	xdgCacheHome := filepath.Join(tmpHome, ".cache")
+	projectDir := filepath.Join(tmpHome, "project")
+	for _, dir := range []string{xdgConfigHome, xdgDataHome, xdgCacheHome, projectDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	binPath := filepath.Join(t.TempDir(), "agent-deck-stale-started-test")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\noutput: %s", err, out)
+	}
+
+	var env []string
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "TMUX") ||
+			strings.HasPrefix(kv, "AGENTDECK_") ||
+			strings.HasPrefix(kv, "HOME=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env,
+		"HOME="+tmpHome,
+		"XDG_CONFIG_HOME="+xdgConfigHome,
+		"XDG_DATA_HOME="+xdgDataHome,
+		"XDG_CACHE_HOME="+xdgCacheHome,
+		"AGENTDECK_PROFILE=test-1704-stale-started",
+		"TERM=dumb",
+	)
+
+	run := func(args ...string) (string, string, error) {
+		cmd := exec.Command(binPath, args...)
+		cmd.Env = env
+		cmd.Dir = projectDir
+		var stdout, stderr strings.Builder
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		return stdout.String(), stderr.String(), err
+	}
+
+	addOut, addErr, err := run("add", projectDir, "-t", "started-probe", "-c", "shell", "--no-parent", "--json")
+	if err != nil {
+		t.Fatalf("add failed: %v\nstdout=%s\nstderr=%s", err, addOut, addErr)
+	}
+	var added struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(addOut), &added); err != nil || added.ID == "" {
+		t.Fatalf("unmarshal add --json: %v\nraw=%s", err, addOut)
+	}
+	// Stop the tmux pane at the end regardless of outcome — this test spawns
+	// a real tmux session on the isolated per-test profile/socket.
+	t.Cleanup(func() {
+		_, _, _ = run("session", "stop", added.ID)
+	})
+
+	startOut, startErr, err := run("session", "start", added.ID, "--json")
+	if err != nil {
+		t.Fatalf("session start failed: %v\nstdout=%s\nstderr=%s", err, startOut, startErr)
+	}
+
+	// Poll list --json until tmux settles the shell to a terminal status
+	// (idle, given no foreground process) or the deadline expires.
+	type listRow struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	var lastStatus string
+	for time.Now().Before(deadline) {
+		listOut, listErrOut, err := run("list", "--json")
+		if err != nil {
+			t.Fatalf("list --json failed: %v\nstdout=%s\nstderr=%s", err, listOut, listErrOut)
+		}
+		var rows []listRow
+		if err := json.Unmarshal([]byte(listOut), &rows); err != nil {
+			t.Fatalf("unmarshal list --json: %v\nraw=%s", err, listOut)
+		}
+		for _, r := range rows {
+			if r.ID == added.ID {
+				lastStatus = r.Status
+			}
+		}
+		if lastStatus == "idle" || lastStatus == "waiting" {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if lastStatus != "idle" && lastStatus != "waiting" {
+		t.Fatalf("started shell session never settled to idle/waiting (last seen %q) — cannot exercise the started-then-idle path", lastStatus)
+	}
+
+	staleOut, staleErrOut, err := run("status", "--stale", "--threshold", "0s", "--json")
+	if err != nil {
+		t.Fatalf("status --stale --threshold 0s failed: %v\nstdout=%s\nstderr=%s", err, staleOut, staleErrOut)
+	}
+	var resp staleCandidatesJSON
+	if err := json.Unmarshal([]byte(staleOut), &resp); err != nil {
+		t.Fatalf("unmarshal --stale --json: %v\nraw=%s", err, staleOut)
+	}
+	var cand *staleCandidate
+	for i := range resp.Candidates {
+		if resp.Candidates[i].ID == added.ID {
+			cand = &resp.Candidates[i]
+		}
+	}
+	if cand == nil {
+		t.Fatalf("started session missing from --stale candidates: %+v", resp)
+	}
+	if cand.NeverStarted {
+		t.Fatalf("started session reported NeverStarted=true (the #1826 blocker regressed): %+v", cand)
+	}
+	if cand.LastStartedAt == "" {
+		t.Fatalf("started session missing last_started_at: %+v", cand)
+	}
+	if cand.Status != lastStatus {
+		t.Fatalf("candidate.Status = %q, want %q (the observed list --json status)", cand.Status, lastStatus)
+	}
+	if len(cand.Reasons) != 1 {
+		t.Fatalf("expected exactly one reason, got %v", cand.Reasons)
+	}
+	switch lastStatus {
+	case "idle":
+		if cand.Reasons[0] != string(reasonBashIdle) {
+			t.Fatalf("idle shell session reason = %q, want %q", cand.Reasons[0], reasonBashIdle)
+		}
+	case "waiting":
+		if cand.Reasons[0] != string(reasonLastActivity) {
+			t.Fatalf("waiting session reason = %q, want %q", cand.Reasons[0], reasonLastActivity)
+		}
+	}
+	if cand.Reasons[0] == string(reasonNeverStarted) {
+		t.Fatalf("started session classified as never-started: %+v", cand)
 	}
 }

--- a/cmd/agent-deck/status_stale_test.go
+++ b/cmd/agent-deck/status_stale_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestClassifyStale_Heuristics is a pure unit test over the three in-scope
+// #1704 heuristics (never-started, bash-idle, last-activity) plus the
+// exclusion rules (running/error/starting/queued are never candidates). No
+// subprocess, no tmux, no wall clock — now/threshold are injected.
+func TestClassifyStale_Heuristics(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	const threshold = 24 * time.Hour
+
+	tests := []struct {
+		name string
+		inst *session.Instance
+		want []staleReason
+	}{
+		{
+			name: "never_started_past_threshold",
+			inst: &session.Instance{
+				Status:    session.StatusIdle,
+				CreatedAt: now.Add(-25 * time.Hour), // LastStartedAt zero, CreatedAt old
+			},
+			want: []staleReason{reasonNeverStarted},
+		},
+		{
+			name: "never_started_within_threshold_not_stale",
+			inst: &session.Instance{
+				Status:    session.StatusIdle,
+				CreatedAt: now.Add(-1 * time.Hour), // just added, not stale yet
+			},
+			want: nil,
+		},
+		{
+			name: "running_never_a_candidate_even_if_old",
+			inst: &session.Instance{
+				Status:    session.StatusRunning,
+				CreatedAt: now.Add(-72 * time.Hour),
+			},
+			want: nil,
+		},
+		{
+			name: "error_never_a_candidate",
+			inst: &session.Instance{
+				Status:    session.StatusError,
+				CreatedAt: now.Add(-72 * time.Hour),
+			},
+			want: nil,
+		},
+		{
+			name: "starting_never_a_candidate",
+			inst: &session.Instance{
+				Status:    session.StatusStarting,
+				CreatedAt: now.Add(-72 * time.Hour),
+			},
+			want: nil,
+		},
+		{
+			name: "queued_never_a_candidate",
+			inst: &session.Instance{
+				Status:    session.StatusQueued,
+				CreatedAt: now.Add(-72 * time.Hour),
+			},
+			want: nil,
+		},
+		{
+			name: "waiting_within_threshold_not_stale",
+			inst: &session.Instance{
+				Status:         session.StatusWaiting,
+				CreatedAt:      now.Add(-72 * time.Hour),
+				LastStartedAt:  now.Add(-72 * time.Hour),
+				LastAccessedAt: now.Add(-1 * time.Hour), // recent activity via DisplayLastActivityTime fallback
+			},
+			want: nil,
+		},
+		{
+			name: "waiting_past_threshold_is_last_activity",
+			inst: &session.Instance{
+				Status:         session.StatusWaiting,
+				CreatedAt:      now.Add(-72 * time.Hour),
+				LastStartedAt:  now.Add(-72 * time.Hour),
+				LastAccessedAt: now.Add(-48 * time.Hour),
+			},
+			want: []staleReason{reasonLastActivity},
+		},
+		{
+			name: "stopped_past_threshold_is_last_activity",
+			inst: &session.Instance{
+				Status:         session.StatusStopped,
+				CreatedAt:      now.Add(-72 * time.Hour),
+				LastStartedAt:  now.Add(-72 * time.Hour),
+				LastAccessedAt: now.Add(-48 * time.Hour),
+			},
+			want: []staleReason{reasonLastActivity},
+		},
+		{
+			name: "started_then_idle_past_threshold_is_bash_idle",
+			inst: &session.Instance{
+				Status:         session.StatusIdle,
+				CreatedAt:      now.Add(-72 * time.Hour),
+				LastStartedAt:  now.Add(-72 * time.Hour), // was started, so NOT never-started
+				LastAccessedAt: now.Add(-48 * time.Hour),
+			},
+			want: []staleReason{reasonBashIdle},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyStale(tc.inst, now, threshold)
+			if len(got) != len(tc.want) {
+				t.Fatalf("classifyStale() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("classifyStale() = %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestStatusStale_CLI_CandidateViewAndMutatesNothing is the end-to-end gate:
+// builds the real binary, adds a never-started session (nothing else could
+// legitimately reach candidate status without tmux in a test sandbox), and
+// asserts:
+//   - status --stale --json with a 0s threshold flags it as a candidate with
+//     reason "never-started" and correct counts.
+//   - status --stale --json with the (long) default threshold reports ZERO
+//     candidates for the same fresh session — no false positives.
+//   - `list --json` before and after --stale is byte-identical on the fields
+//     that matter (status/count unchanged) — proving the read-only view
+//     mutated nothing.
+func TestStatusStale_CLI_CandidateViewAndMutatesNothing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess integration test in short mode")
+	}
+
+	tmpHome := t.TempDir()
+	xdgConfigHome := filepath.Join(tmpHome, ".config")
+	xdgDataHome := filepath.Join(tmpHome, ".local", "share")
+	xdgCacheHome := filepath.Join(tmpHome, ".cache")
+	projectDir := filepath.Join(tmpHome, "project")
+	for _, dir := range []string{xdgConfigHome, xdgDataHome, xdgCacheHome, projectDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	binPath := filepath.Join(t.TempDir(), "agent-deck-stale-test")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\noutput: %s", err, out)
+	}
+
+	var env []string
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "TMUX") ||
+			strings.HasPrefix(kv, "AGENTDECK_") ||
+			strings.HasPrefix(kv, "HOME=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env,
+		"HOME="+tmpHome,
+		"XDG_CONFIG_HOME="+xdgConfigHome,
+		"XDG_DATA_HOME="+xdgDataHome,
+		"XDG_CACHE_HOME="+xdgCacheHome,
+		"AGENTDECK_PROFILE=test-1704-stale",
+		"TERM=dumb",
+	)
+
+	run := func(args ...string) (string, string, error) {
+		cmd := exec.Command(binPath, args...)
+		cmd.Env = env
+		cmd.Dir = projectDir
+		var stdout, stderr strings.Builder
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		return stdout.String(), stderr.String(), err
+	}
+
+	// Add a session but never start it — the one candidate type reachable
+	// without a live tmux server in a test sandbox.
+	addOut, addErr, err := run("add", projectDir, "-t", "stale-probe", "-c", "shell", "--no-parent", "--json")
+	if err != nil {
+		t.Fatalf("add failed: %v\nstdout=%s\nstderr=%s", err, addOut, addErr)
+	}
+
+	// Baseline: with the (long) default threshold, a session added moments
+	// ago must NOT be a candidate. Guards against a threshold-comparison bug
+	// that would flag everything unconditionally.
+	baselineOut, baselineErr, err := run("status", "--stale", "--json")
+	if err != nil {
+		t.Fatalf("status --stale (default threshold) failed: %v\nstdout=%s\nstderr=%s", err, baselineOut, baselineErr)
+	}
+	var baseline staleCandidatesJSON
+	if err := json.Unmarshal([]byte(baselineOut), &baseline); err != nil {
+		t.Fatalf("unmarshal baseline --stale --json: %v\nraw=%s", err, baselineOut)
+	}
+	if baseline.StaleCount != 0 {
+		t.Fatalf("fresh session flagged stale under default threshold (false positive): %+v", baseline)
+	}
+	if baseline.Total != 1 {
+		t.Fatalf("expected total=1, got %d", baseline.Total)
+	}
+
+	// Snapshot list --json before forcing candidacy, to prove --stale never
+	// mutates session state.
+	listBefore, _, err := run("list", "--json")
+	if err != nil {
+		t.Fatalf("list --json (before) failed: %v", err)
+	}
+
+	// Force candidacy with a zero threshold and assert the shape + reason.
+	staleOut, staleErrOut, err := run("status", "--stale", "--threshold", "0s", "--json")
+	if err != nil {
+		t.Fatalf("status --stale --threshold 0s failed: %v\nstdout=%s\nstderr=%s", err, staleOut, staleErrOut)
+	}
+	var resp staleCandidatesJSON
+	if err := json.Unmarshal([]byte(staleOut), &resp); err != nil {
+		t.Fatalf("unmarshal --stale --json: %v\nraw=%s", err, staleOut)
+	}
+	if resp.StaleCount != 1 || len(resp.Candidates) != 1 {
+		t.Fatalf("expected exactly 1 stale candidate, got %+v", resp)
+	}
+	cand := resp.Candidates[0]
+	if cand.Title != "stale-probe" {
+		t.Fatalf("candidate title = %q, want %q", cand.Title, "stale-probe")
+	}
+	if !cand.NeverStarted {
+		t.Fatalf("candidate NeverStarted = false, want true: %+v", cand)
+	}
+	if len(cand.Reasons) != 1 || cand.Reasons[0] != string(reasonNeverStarted) {
+		t.Fatalf("candidate Reasons = %v, want [%s]", cand.Reasons, reasonNeverStarted)
+	}
+	if cand.LastStartedAt != "" {
+		t.Fatalf("never-started candidate must not carry LastStartedAt, got %q", cand.LastStartedAt)
+	}
+
+	// The critical mutation check: list --json after --stale must match
+	// list --json before it, byte for byte. If --stale silently stopped,
+	// removed, or otherwise rewrote the session this diverges.
+	listAfter, _, err := run("list", "--json")
+	if err != nil {
+		t.Fatalf("list --json (after) failed: %v", err)
+	}
+	if listBefore != listAfter {
+		t.Fatalf("status --stale mutated session state!\nbefore=%s\nafter=%s", listBefore, listAfter)
+	}
+
+	// Also confirm plain-text mode doesn't crash and mentions the candidate.
+	textOut, textErr, err := run("status", "--stale", "--threshold", "0s")
+	if err != nil {
+		t.Fatalf("status --stale (text) failed: %v\nstdout=%s\nstderr=%s", err, textOut, textErr)
+	}
+	if !strings.Contains(textOut, "stale-probe") || !strings.Contains(textOut, "never-started") {
+		t.Fatalf("text --stale output missing expected candidate info: %s", textOut)
+	}
+	if !strings.Contains(textOut, "read-only") {
+		t.Fatalf("text --stale output should reassert read-only/suggest-only framing: %s", textOut)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5005,6 +5005,28 @@ func (i *Instance) GetHookStatus() (string, bool) {
 	return i.hookStatus, fresh
 }
 
+// LastHookActivityTime returns the on-disk hook status file's UpdatedAt
+// timestamp for this instance, and true when a hook sample has been
+// recorded. Unlike LastObservedActivity's process-local tmux tracker, this
+// is populated even by a cold, short-lived CLI process: UpdateStatus's
+// "COLD LOAD" branch reads the sidecar hook file straight off disk before
+// this can be called. That makes it durable cross-process evidence of real
+// activity, which status --stale needs (issue #1704 dual-review finding):
+// a fresh CLI invocation never gets to observe LastObservedActivity, so
+// without this a session that just finished real work and has no
+// LastAccessedAt (never attached in the TUI) would misreport its
+// last-activity age against CreatedAt instead of the moment it actually
+// went idle/waiting.
+func (i *Instance) LastHookActivityTime() (time.Time, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	if i.hookStatus == "" || i.hookLastUpdate.IsZero() {
+		return time.Time{}, false
+	}
+	return i.hookLastUpdate, true
+}
+
 // GetAutoNameDescription returns the last captured Claude task description for
 // an AutoName session (empty if none captured yet). Thread-safe.
 func (i *Instance) GetAutoNameDescription() string {

--- a/internal/session/last_started_persist.go
+++ b/internal/session/last_started_persist.go
@@ -1,0 +1,59 @@
+// Issue #1704 follow-up (dual-review blocker): Instance.LastStartedAt was
+// declared as a "persisted stamp" (see the field's doc comment in
+// instance.go) but was never actually wired into InstanceData or SQLite —
+// it only ever lived in the in-process struct. Every out-of-process reader
+// (status --stale, ShouldSkipRestart's freshness guard via a fresh CLI
+// invocation) saw it as permanently zero.
+//
+// These helpers close that gap the same way #1143 added idle_timeout_secs:
+// merge/extract a key on the tool_data JSON blob without touching the
+// positional MarshalToolData/UnmarshalToolData signature or the SQL schema.
+// The MergeToolDataExtras layer in statedb preserves the key across
+// INSERT OR REPLACE, so a row written by a binary that predates this key
+// round-trips cleanly (old binary just never sees/writes it).
+package session
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const toolDataLastStartedAtKey = "last_started_at"
+
+// WriteLastStartedAtToToolData merges last_started_at into the given
+// tool_data JSON blob as a Unix-seconds integer. A zero time removes the key
+// (keeps the blob shape identical to a pre-fix row, so a session that was
+// added but genuinely never started stays indistinguishable from one saved
+// by an older binary).
+func WriteLastStartedAtToToolData(td json.RawMessage, t time.Time) json.RawMessage {
+	m := map[string]json.RawMessage{}
+	if len(td) > 0 {
+		_ = json.Unmarshal(td, &m)
+	}
+	if !t.IsZero() {
+		raw, _ := json.Marshal(t.Unix())
+		m[toolDataLastStartedAtKey] = raw
+	} else {
+		delete(m, toolDataLastStartedAtKey)
+	}
+	out, _ := json.Marshal(m)
+	return out
+}
+
+// ReadLastStartedAtFromToolData extracts last_started_at from the blob.
+// Returns the zero time.Time for missing/malformed/legacy rows — callers
+// must treat that as "unknown" (old record or genuinely never started), the
+// same contract Instance.LastStartedAt's doc comment already establishes.
+func ReadLastStartedAtFromToolData(td json.RawMessage) time.Time {
+	if len(td) == 0 {
+		return time.Time{}
+	}
+	var blob struct {
+		LastStartedAt int64 `json:"last_started_at"`
+	}
+	_ = json.Unmarshal(td, &blob)
+	if blob.LastStartedAt == 0 {
+		return time.Time{}
+	}
+	return time.Unix(blob.LastStartedAt, 0).UTC()
+}

--- a/internal/session/last_started_persist_test.go
+++ b/internal/session/last_started_persist_test.go
@@ -1,0 +1,103 @@
+// Issue #1704 dual-review blocker: Instance.LastStartedAt claimed to be a
+// "persisted stamp" but was never wired into InstanceData/SQLite, so every
+// out-of-process reader (status --stale) saw it as always-zero. These tests
+// guard the fix (last_started_persist.go) at the layer the original PR's
+// tests never touched: round-tripping through the actual save/load path,
+// not constructing Instance literals by hand.
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLastStartedAt_ToolDataPersistenceRoundTrip mirrors
+// TestIssue1143_IdleTimeout_PersistenceRoundTrip: exercises the extras-zone
+// helpers directly, including the "unrelated fields survive" and "zero
+// clears the key" cases.
+func TestLastStartedAt_ToolDataPersistenceRoundTrip(t *testing.T) {
+	started := time.Date(2026, 7, 1, 9, 30, 0, 0, time.UTC)
+
+	td := WriteLastStartedAtToToolData(nil, started)
+	got := ReadLastStartedAtFromToolData(td)
+	if !got.Equal(started) {
+		t.Fatalf("ReadLastStartedAtFromToolData after Write = %v, want %v", got, started)
+	}
+
+	// Zero time removes the key (old-record/never-started stay indistinguishable).
+	cleared := WriteLastStartedAtToToolData(td, time.Time{})
+	if got := ReadLastStartedAtFromToolData(cleared); !got.IsZero() {
+		t.Fatalf("Write(td, zero) should clear, got %v", got)
+	}
+
+	// Round-trip preserves unrelated fields.
+	mixed := []byte(`{"color":"#ff00aa","claude_session_id":"abc"}`)
+	out := WriteLastStartedAtToToolData(mixed, started)
+	if got := ReadLastStartedAtFromToolData(out); !got.Equal(started) {
+		t.Fatalf("round-trip with extras lost last_started_at: got %v, want %v", got, started)
+	}
+	if !strings.Contains(string(out), `"color":"#ff00aa"`) {
+		t.Fatalf("round-trip dropped color: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"claude_session_id":"abc"`) {
+		t.Fatalf("round-trip dropped claude_session_id: %s", string(out))
+	}
+}
+
+// TestLastStartedAt_SQLiteRoundTrip is the boundary test finding #1/#2 of
+// the #1704 review demanded: prove LastStartedAt survives an actual
+// SaveWithGroups -> LoadWithGroups cycle through SQLite — the exact process
+// boundary status_stale.go crosses — rather than being set directly on an
+// in-memory Instance literal the way the original heuristic tests did.
+func TestLastStartedAt_SQLiteRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	storage := newTestStorage(t)
+
+	inst := NewInstance("last-started-roundtrip", "/tmp")
+	inst.Tool = "shell"
+	started := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	inst.LastStartedAt = started
+
+	groupTree := NewGroupTreeWithGroups([]*Instance{inst}, nil)
+	if err := storage.SaveWithGroups([]*Instance{inst}, groupTree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	loaded, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(loaded))
+	}
+	if !loaded[0].LastStartedAt.Equal(started) {
+		t.Fatalf("LastStartedAt not preserved across SQLite round-trip: got %v, want %v", loaded[0].LastStartedAt, started)
+	}
+
+	// A session that was never started must keep reading as zero — the
+	// heuristic in status_stale.go depends on this staying a reliable
+	// "unknown/never" signal, not silently defaulting to "just started".
+	fresh := NewInstance("never-started-roundtrip", "/tmp")
+	fresh.Tool = "shell"
+	groupTree2 := NewGroupTreeWithGroups([]*Instance{fresh}, nil)
+	if err := storage.SaveWithGroups([]*Instance{fresh}, groupTree2); err != nil {
+		t.Fatalf("SaveWithGroups (never-started): %v", err)
+	}
+	loaded2, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups (never-started): %v", err)
+	}
+	var freshLoaded *Instance
+	for _, i := range loaded2 {
+		if i.ID == fresh.ID {
+			freshLoaded = i
+		}
+	}
+	if freshLoaded == nil {
+		t.Fatalf("never-started instance missing after reload")
+	}
+	if !freshLoaded.LastStartedAt.IsZero() {
+		t.Fatalf("never-started instance got a non-zero LastStartedAt after round-trip: %v", freshLoaded.LastStartedAt)
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -54,8 +54,13 @@ type InstanceData struct {
 	Status              Status    `json:"status"`
 	CreatedAt           time.Time `json:"created_at"`
 	LastAccessedAt      time.Time `json:"last_accessed_at,omitempty"`
-	ArchivedAt          time.Time `json:"archived_at,omitempty"`
-	TmuxSession         string    `json:"tmux_session"`
+	// LastStartedAt mirrors Instance.LastStartedAt (issue #30 / #1704 fix).
+	// Persisted via the tool_data extras zone (see last_started_persist.go),
+	// not a typed SQL column. Zero means unknown (old record or never
+	// started).
+	LastStartedAt time.Time `json:"last_started_at,omitempty"`
+	ArchivedAt    time.Time `json:"archived_at,omitempty"`
+	TmuxSession   string    `json:"tmux_session"`
 	// TmuxSocketName is the tmux -L selector captured at Instance creation
 	// (issue #687, v1.7.50). Empty for pre-v1.7.50 rows — those keep hitting
 	// the default server after upgrade.
@@ -923,6 +928,10 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	// the positional MarshalToolData signature so legacy binaries that don't
 	// know the key preserve it via MergeToolDataExtras.
 	toolData = WriteIdleTimeoutSecsToToolData(toolData, inst.IdleTimeoutSecs)
+	// #1704 blocker fix: same extras-zone treatment for last_started_at, so
+	// `status --stale` (and ShouldSkipRestart's freshness guard) see a real
+	// value from a fresh CLI process instead of always-zero.
+	toolData = WriteLastStartedAtToToolData(toolData, inst.LastStartedAt)
 
 	return &statedb.InstanceRow{
 		ID:                  inst.ID,
@@ -1094,6 +1103,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			AutoLinkedChannels:        autoLinkedChannels2,
 			Color:                     color2,
 			IdleTimeoutSecs:           ReadIdleTimeoutSecsFromToolData(r.ToolData),
+			LastStartedAt:             ReadLastStartedAtFromToolData(r.ToolData),
 		}
 	}
 
@@ -1213,6 +1223,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			AutoLinkedChannels:        autoLinkedChannels,
 			Color:                     color,
 			IdleTimeoutSecs:           ReadIdleTimeoutSecsFromToolData(r.ToolData),
+			LastStartedAt:             ReadLastStartedAtFromToolData(r.ToolData),
 		}
 	}
 
@@ -1459,6 +1470,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			AutoLinkedChannels:        instData.AutoLinkedChannels,
 			Color:                     instData.Color,
 			IdleTimeoutSecs:           instData.IdleTimeoutSecs,
+			LastStartedAt:             instData.LastStartedAt,
 			Sandbox:                   instData.Sandbox,
 			SandboxContainer:          instData.SandboxContainer,
 			SSHHost:                   instData.SSHHost,


### PR DESCRIPTION
## Summary

Implements the accepted first slice of proactive session lifecycle management from #1704: a **read-only** `agent-deck status --stale` candidate view.

Per the issue's accepted design comment, this stays deliberately narrow:

- Heuristics: **never-started**, **bash-idle**, and **last-activity age** past a configurable threshold (default 24h, via `--threshold`).
- Every candidate carries the evidence behind its classification (`created_at`, `last_started_at`, `last_activity_at`, `reasons`) rather than a bare verdict — "no single heuristic proves that work is safely landed."
- `--json` output for agents (CLI/TUI parity), documented in `--help`.
- **Hard constraint, enforced by construction:** this view never stops, removes, or otherwise mutates a session. It only loads instances, classifies them, and prints. There is no code path in `status_stale.go` that calls `Stop`/`Remove`/`Save`.

Excluded from candidacy: `running` (active work) and `error` (needs attention, not cleanup) statuses, plus the transient `starting`/`queued` states. Only `waiting`, `idle`, and `stopped` sessions are eligible.

TTL-based automated cleanup, the completion-sentinel/clean-working-tree/PR-state signals, and the review-prompt-before-removal flow are explicitly **out of scope** for this slice — this PR only ships the candidate view the issue's accepted comment called "the safest first slice."

## Test plan

- [x] Sandboxed `go build ./...` and `go vet ./...` clean.
- [x] New CLI test `TestStatusStale_CLI_CandidateViewAndMutatesNothing` (subprocess, builds the real binary): adds a never-started session, confirms it is **not** flagged under the default 24h threshold (no false positive), confirms it **is** flagged with `reasons: ["never-started"]` under `--threshold 0s`, and diffs `list --json` before/after to prove the view mutates nothing.
- [x] New pure unit test `TestClassifyStale_Heuristics` covering all three heuristics plus the running/error/starting/queued exclusions.
- [x] Manually smoke-tested the built binary end-to-end against an isolated `$HOME` (default threshold → 0 candidates; `--threshold 0s` → 1 candidate with correct evidence, in both `--json` and text modes; `list --json` unchanged afterward).
- [x] `--stale --json` shape documented in `agent-deck status --help`.
