### PR TITLE
docs(README): fix title-lock and -Q claims in Session naming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ By default, agent-deck syncs a session's displayed title from the tool's own ses
 | --- | --- |
 | This one session keeps the title I gave it | `--title-lock` (alias `--no-title-sync`) on `agent-deck add` / `agent-deck launch`, or `agent-deck session set-title-lock <id> on` at runtime |
 | No session in this installation ever gets renamed by its agent | `sync_title = false` in `config.toml` |
-| A throwaway session where the live task description matters more than a fixed name | `agent-deck add --quick` (`-Q` in the TUI) — the list shows the session's current Claude task in place of the generated handle |
+| A throwaway session where the live task description matters more than a fixed name | `agent-deck add --quick` (`-Q` short flag) — the list shows the session's current Claude task in place of the generated handle |
 
-An explicit `-t/--title` implies a lock is unnecessary until the agent renames the session; pass `--title-lock` alongside it if the title must never move. A locked title is never silently overwritten by the sync path — it only changes via an explicit rename or `session set-title-lock <id> off`.
+An explicit `-t/--title` locks the title automatically, the same as passing `--title-lock` — there's no separate opt-in needed. There's also no create-time opt-out: if you want a session with an explicit title to still pick up the agent's renames, unlock it afterward with `agent-deck session set-title-lock <id> off`. A locked title is never silently overwritten by the sync path — it only changes via an explicit rename or `session set-title-lock <id> off`.
 
 #### Groups vs. parent linkage
 


### PR DESCRIPTION
## Summary

Follow-up correction for the "Session naming" section added in #1823 (closes #1703). Post-merge review of that PR found two inaccuracies in `README.md`:

- The paragraph under the title-lock table said an explicit `-t/--title` "implies a lock is unnecessary until the agent renames the session; pass `--title-lock` alongside it if the title must never move." That's backwards: `shouldLockTitle` (`cmd/agent-deck/main.go`) locks the title as soon as a user title is provided, no separate `--title-lock` needed, and there's no create-time opt-out — unlocking after the fact requires `agent-deck session set-title-lock <id> off`. `launch`'s own flag help already documents this ("implied by an explicit -t/--title (#697)"), and issue #1715 is pinned by a regression test with the opposite contract.
- The quick-create row parenthetical said `-Q` is "in the TUI". `-Q` is the CLI short flag for `add --quick` (`cmd/agent-deck/main.go`); the TUI's quick-create key is `N`, not `-Q`.

## Changes

- Rewrote the title-lock paragraph to state the actual `-t/--title` → auto-lock contract and the unlock path.
- Reworded the quick-create row to say "short flag" instead of "in the TUI".

## Test plan

- [x] Sandboxed `go build ./...` — clean
- [x] Sandboxed `go vet ./...` — clean
- [x] `gofmt -l internal/ cmd/` — clean (docs-only diff, no Go files touched)
