### PR TITLE
fix(session): verify conversation identity before any --resume (#1815)

### DIFF
--- a/cmd/agent-deck/issue1830_resume_session_validation_test.go
+++ b/cmd/agent-deck/issue1830_resume_session_validation_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestIssue1830_ResumeSessionRejectsNonUUID covers the Codex review finding on
+// PR #1830: both CLI entry points that accept --resume-session
+// (handleAdd in main.go and runLaunchCommand in launch_cmd.go) pass the raw
+// flag value to session.MarkClaudeSessionIDVerified — vouching for it as an
+// ownership declaration — and it is later interpolated into
+// `--session-id "%s"`, a DOUBLE-QUOTED shell context where $(...) still
+// performs command substitution. Only the TUI validated its input
+// (internal/ui/home.go via IsBareClaudeSessionUUID); the CLI did not.
+//
+// The fix refuses non-UUID values outright at both sites rather than
+// sanitizing-and-continuing or falling back to an unverified path. These
+// tests run the real binary so a validation block accidentally placed after
+// an early os.Exit (or dropped in a refactor) fails the test rather than
+// silently passing a source-level assertion.
+func TestIssue1830_ResumeSessionRejectsNonUUID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess integration test in short mode")
+	}
+
+	binPath := filepath.Join(t.TempDir(), "agent-deck-resume-validation")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\noutput: %s", err, out)
+	}
+
+	// Payloads that must never be vouched for. The command-substitution and
+	// metacharacter cases are the security core of the finding; the rest
+	// guard the "operator typed anything" looseness the fix closes.
+	payloads := map[string]string{
+		"command_substitution":  `$(touch /tmp/agentdeck-pwned-1830)`,
+		"backtick_substitution": "`id`",
+		"quote_break_and_chain": `x"; touch /tmp/agentdeck-pwned-1830; echo "`,
+		"semicolon_chain":       `abc; id`,
+		"uuid_with_suffix":      `91fd7978-1a2b-3c4d-5e6f-7a8b9c0d1e2f.jsonl`,
+		"uuid_with_whitespace":  ` 91fd7978-1a2b-3c4d-5e6f-7a8b9c0d1e2f `,
+		"uppercase_uuid":        `91FD7978-1A2B-3C4D-5E6F-7A8B9C0D1E2F`,
+		"not_a_uuid":            `latest`,
+	}
+
+	// Both subcommands that expose the flag. Each is invoked with -c claude so
+	// the pre-existing tool check passes and execution reaches the new guard.
+	commands := map[string][]string{
+		"add":    {"add", ".", "-c", "claude", "--resume-session"},
+		"launch": {"launch", ".", "-c", "claude", "--resume-session"},
+	}
+
+	for cmdName, argv := range commands {
+		for payloadName, payload := range payloads {
+			t.Run(cmdName+"/"+payloadName, func(t *testing.T) {
+				tmpHome := t.TempDir()
+				projectDir := t.TempDir()
+
+				args := append(append([]string{}, argv...), payload)
+				cmd := exec.Command(binPath, args...)
+				cmd.Dir = projectDir
+				cmd.Env = sandboxedCLIEnv(tmpHome)
+
+				out, err := cmd.CombinedOutput()
+				if err == nil {
+					t.Fatalf("%s accepted an invalid --resume-session value %q "+
+						"(expected refusal); output: %s", cmdName, payload, out)
+				}
+
+				// The refusal must name the flag and the expected form so the
+				// operator can correct it, per the fix's stated contract.
+				lower := strings.ToLower(string(out))
+				if !strings.Contains(lower, "--resume-session") {
+					t.Errorf("refusal for %q does not name the flag; output: %s", payload, out)
+				}
+				if !strings.Contains(lower, "uuid") {
+					t.Errorf("refusal for %q does not name the expected form; output: %s", payload, out)
+				}
+
+				// Defense in depth: the payload must not have executed.
+				if _, statErr := os.Stat("/tmp/agentdeck-pwned-1830"); statErr == nil {
+					_ = os.Remove("/tmp/agentdeck-pwned-1830")
+					t.Fatalf("payload %q EXECUTED — command substitution reached a shell", payload)
+				}
+			})
+		}
+	}
+}
+
+// TestIssue1830_ResumeSessionAcceptsBareUUID pins the other half of the
+// contract: the guard must not reject the well-formed ids it exists to let
+// through. Asserted against the shared predicate both CLI sites now call, so
+// this stays a pure unit check with no session creation.
+func TestIssue1830_ResumeSessionAcceptsBareUUID(t *testing.T) {
+	valid := []string{
+		"91fd7978-1a2b-3c4d-5e6f-7a8b9c0d1e2f",
+		"00000000-0000-0000-0000-000000000000",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
+	}
+	for _, id := range valid {
+		if !session.IsBareClaudeSessionUUID(id) {
+			t.Errorf("IsBareClaudeSessionUUID(%q) = false, want true", id)
+		}
+	}
+}
+
+// sandboxedCLIEnv builds an environment pointing HOME and every XDG root at a
+// throwaway dir so the CLI under test can never read or write the real
+// ~/.agent-deck (see the repo CLAUDE.md data-loss rules). TMUX*/AGENTDECK_*
+// are stripped so the nested-session guard in main.go does not early-exit
+// before the flag validation being tested.
+func sandboxedCLIEnv(tmpHome string) []string {
+	var env []string
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "TMUX") ||
+			strings.HasPrefix(kv, "AGENTDECK_") ||
+			strings.HasPrefix(kv, "HOME=") ||
+			strings.HasPrefix(kv, "XDG_") ||
+			strings.HasPrefix(kv, "CLAUDE_CONFIG_DIR=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env,
+		"HOME="+tmpHome,
+		"XDG_CONFIG_HOME="+filepath.Join(tmpHome, ".config"),
+		"XDG_DATA_HOME="+filepath.Join(tmpHome, ".local", "share"),
+		"XDG_CACHE_HOME="+filepath.Join(tmpHome, ".cache"),
+		"AGENTDECK_PROFILE=test-1830",
+		"TERM=dumb",
+	)
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -231,6 +231,18 @@ func handleLaunch(profile string, args []string) {
 			out.Error("--resume-session only works with Claude sessions (-c claude)", ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+		// #1815 (Codex review on #1830): the value below is passed to
+		// MarkClaudeSessionIDVerified — it becomes a VOUCHED ownership
+		// declaration — and is then interpolated into `--session-id "%s"`,
+		// a double-quoted shell context where $(...) still substitutes.
+		// "Operator-named" has to mean the operator named an actual
+		// conversation id, so refuse anything that is not a bare UUID
+		// rather than vouching for it or silently continuing unverified.
+		if !session.IsBareClaudeSessionUUID(*resumeSession) {
+			out.Error("--resume-session must be a bare Claude conversation UUID "+
+				"(8-4-4-4-12 lowercase hex, e.g. 91fd7978-1a2b-3c4d-5e6f-7a8b9c0d1e2f)", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
 	}
 
 	// Handle worktree creation

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -482,6 +482,10 @@ func handleLaunch(profile string, args []string) {
 
 	if *resumeSession != "" {
 		newInstance.ClaudeSessionID = *resumeSession
+		// #1815: the operator named this conversation for this session —
+		// explicit ownership, so vouch for it (ownership is positive state;
+		// an unvouched id is refused at resume time).
+		session.MarkClaudeSessionIDVerified(newInstance)
 		newInstance.ClaudeDetectedAt = time.Now()
 
 		opts := newInstance.GetClaudeOptions()

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1816,6 +1816,8 @@ func handleAdd(profile string, args []string) {
 	// Handle --resume-session: set Claude session ID and resume mode
 	if *resumeSession != "" {
 		newInstance.ClaudeSessionID = *resumeSession
+		// #1815: operator-named conversation — explicit ownership.
+		session.MarkClaudeSessionIDVerified(newInstance)
 		newInstance.ClaudeDetectedAt = time.Now()
 
 		opts := newInstance.GetClaudeOptions()

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1476,6 +1476,18 @@ func handleAdd(profile string, args []string) {
 			fmt.Println("Error: --resume-session only works with Claude sessions (-c claude)")
 			os.Exit(1)
 		}
+		// #1815 (Codex review on #1830): the value below is passed to
+		// MarkClaudeSessionIDVerified — it becomes a VOUCHED ownership
+		// declaration — and is then interpolated into `--session-id "%s"`,
+		// a double-quoted shell context where $(...) still substitutes.
+		// "Operator-named" has to mean the operator named an actual
+		// conversation id, so refuse anything that is not a bare UUID
+		// rather than vouching for it or silently continuing unverified.
+		if !session.IsBareClaudeSessionUUID(*resumeSession) {
+			fmt.Println("Error: --resume-session must be a bare Claude conversation UUID " +
+				"(8-4-4-4-12 lowercase hex, e.g. 91fd7978-1a2b-3c4d-5e6f-7a8b9c0d1e2f)")
+			os.Exit(1)
+		}
 	}
 
 	// Load existing sessions with profile

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2905,8 +2905,9 @@ func handleSessionSend(profile string, args []string) {
 		if session.IsClaudeCompatible(inst.Tool) {
 			if freshID := inst.GetSessionIDFromTmux(); freshID != "" {
 				inst.ClaudeSessionID = freshID
-				// #1815: own pane env — vouched ownership.
-				session.MarkClaudeSessionIDVerified(inst)
+				// #1815: own pane env — weak vouch (see
+				// NoteClaudeSessionIDFromOwnPane).
+				session.NoteClaudeSessionIDFromOwnPane(inst)
 				inst.ClaudeDetectedAt = time.Now()
 			}
 		}
@@ -3707,8 +3708,8 @@ func streamSessionSend(inst *session.Instance, sessionRef, profile string, sentA
 	if session.IsClaudeCompatible(inst.Tool) {
 		if fresh := inst.GetSessionIDFromTmux(); fresh != "" {
 			inst.ClaudeSessionID = fresh
-			// #1815: own pane env — vouched ownership.
-			session.MarkClaudeSessionIDVerified(inst)
+			// #1815: own pane env — weak vouch.
+			session.NoteClaudeSessionIDFromOwnPane(inst)
 			inst.ClaudeDetectedAt = time.Now()
 		}
 	}
@@ -3820,8 +3821,8 @@ func handleSessionOutput(profile string, args []string) {
 	if session.IsClaudeCompatible(inst.Tool) {
 		if freshID := inst.GetSessionIDFromTmux(); freshID != "" {
 			inst.ClaudeSessionID = freshID
-			// #1815: own pane env — vouched ownership.
-			session.MarkClaudeSessionIDVerified(inst)
+			// #1815: own pane env — weak vouch.
+			session.NoteClaudeSessionIDFromOwnPane(inst)
 			inst.ClaudeDetectedAt = time.Now()
 		}
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2905,6 +2905,8 @@ func handleSessionSend(profile string, args []string) {
 		if session.IsClaudeCompatible(inst.Tool) {
 			if freshID := inst.GetSessionIDFromTmux(); freshID != "" {
 				inst.ClaudeSessionID = freshID
+				// #1815: own pane env — vouched ownership.
+				session.MarkClaudeSessionIDVerified(inst)
 				inst.ClaudeDetectedAt = time.Now()
 			}
 		}
@@ -3705,6 +3707,8 @@ func streamSessionSend(inst *session.Instance, sessionRef, profile string, sentA
 	if session.IsClaudeCompatible(inst.Tool) {
 		if fresh := inst.GetSessionIDFromTmux(); fresh != "" {
 			inst.ClaudeSessionID = fresh
+			// #1815: own pane env — vouched ownership.
+			session.MarkClaudeSessionIDVerified(inst)
 			inst.ClaudeDetectedAt = time.Now()
 		}
 	}
@@ -3816,6 +3820,8 @@ func handleSessionOutput(profile string, args []string) {
 	if session.IsClaudeCompatible(inst.Tool) {
 		if freshID := inst.GetSessionIDFromTmux(); freshID != "" {
 			inst.ClaudeSessionID = freshID
+			// #1815: own pane env — vouched ownership.
+			session.MarkClaudeSessionIDVerified(inst)
 			inst.ClaudeDetectedAt = time.Now()
 		}
 	}

--- a/cmd/agent-deck/session_switch_account.go
+++ b/cmd/agent-deck/session_switch_account.go
@@ -35,6 +35,13 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		fmt.Println("a running session is restarted so `claude --resume` continues the")
 		fmt.Println("conversation under the new account.")
 		fmt.Println()
+		fmt.Println("If the session has no recorded conversation id and the only candidate is the")
+		fmt.Println("newest transcript in its working directory (which may belong to another")
+		fmt.Println("session sharing that directory), the switch is refused instead of guessing:")
+		fmt.Println("nothing is copied, the account is not switched, and a running session is left")
+		fmt.Println("untouched. Name the conversation explicitly with")
+		fmt.Println("`agent-deck session set claude-session-id <uuid>` and re-run.")
+		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
 		fmt.Println()
@@ -88,15 +95,11 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Stop a running session first so its conversation file is final before
-	// the copy. IDs are synced from tmux beforehand (same pattern as `stop`).
+	// IDs are synced from tmux (same pattern as `stop`) BEFORE the ambiguity
+	// preflight below, since that check reads inst.ClaudeSessionID.
 	wasRunning := inst.Exists()
 	if wasRunning {
 		inst.SyncSessionIDsFromTmux()
-		if err := inst.Kill(); err != nil {
-			out.Error(fmt.Sprintf("failed to stop session before switch: %v", err), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
 	}
 
 	// Capture the source dir BEFORE mutating the account field — afterwards
@@ -108,6 +111,12 @@ func handleSessionSwitchAccount(profile string, args []string) {
 	// with "No conversation found". The disk is authoritative: scan every
 	// configured config dir for the conversation file and treat the dir that
 	// actually contains it as the source.
+	//
+	// Review finding on #1830: this ambiguity preflight runs BEFORE the
+	// running session is stopped below. Locating the conversation is a
+	// read-only disk scan that does not need the session dead, and running
+	// it first means an ambiguous-discovery abort leaves the session
+	// untouched instead of stopping it for a switch that never happens.
 	locatedDir, locatedSID, srcSize := session.LocateConversationConfigDir(userConfig, inst, srcDir)
 	if locatedDir != "" {
 		srcDir = locatedDir
@@ -123,11 +132,28 @@ func handleSessionSwitchAccount(profile string, args []string) {
 			out.Error(fmt.Sprintf(
 				"cannot identify %s's conversation: it has no recorded conversation id, and the only "+
 					"candidate is the newest transcript in its working directory (%s), which may belong "+
-					"to another session there. Nothing was copied and the account was NOT switched. "+
+					"to another session there. Nothing was copied and the account was NOT switched, "+
+					"and the session was left running untouched. "+
 					"Name the conversation explicitly if it is this session's own "+
 					"(agent-deck session set claude-session-id <uuid> %s) and re-run.",
 				inst.Title, locatedSID, inst.Title), ErrCodeInvalidOperation)
 			os.Exit(1)
+		}
+	}
+
+	// Stop a running session so its conversation file is final before the
+	// copy, now that the ambiguity preflight above has passed.
+	if wasRunning {
+		if err := inst.Kill(); err != nil {
+			out.Error(fmt.Sprintf("failed to stop session before switch: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		// Re-locate for the final, post-stop size: Kill flushes the
+		// transcript, so the preflight's size snapshot may be stale.
+		if locatedDir != "" {
+			if freshDir, _, freshSize := session.LocateConversationConfigDir(userConfig, inst, srcDir); freshDir != "" {
+				locatedDir, srcDir, srcSize = freshDir, freshDir, freshSize
+			}
 		}
 	}
 	migrated, migErr := session.MigrateConversationFrom(inst, srcDir, targetDir)

--- a/cmd/agent-deck/session_switch_account.go
+++ b/cmd/agent-deck/session_switch_account.go
@@ -112,7 +112,13 @@ func handleSessionSwitchAccount(profile string, args []string) {
 	if locatedDir != "" {
 		srcDir = locatedDir
 		if inst.ClaudeSessionID == "" && locatedSID != "" {
-			inst.ClaudeSessionID = locatedSID
+			// #1815: with no recorded id, this is "the newest conversation in
+			// the project dir" — a guess that a shared working directory can
+			// answer with another session's transcript. It is good enough to
+			// migrate (a copy), never good enough to resume: record it as
+			// unverified so the restart starts fresh instead of adopting a
+			// conversation this session may not own.
+			session.AdoptDiscoveredClaudeSessionID(inst, locatedSID)
 		}
 	}
 	migrated, migErr := session.MigrateConversationFrom(inst, srcDir, targetDir)
@@ -131,6 +137,13 @@ func handleSessionSwitchAccount(profile string, args []string) {
 			out.Error(fmt.Sprintf("conversation not verified in target config dir, account not switched: %v", verifyErr), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+	}
+
+	// #1815 Guard 2: a failed transcript verification must STOP the sequence,
+	// not annotate it.
+	if blocked, why := switchAccountRestartUnsafe(inst, locatedDir, wasRunning, *noRestart); blocked {
+		out.Error(fmt.Sprintf("conversation verification failed for %s: %s", inst.Title, why), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
 
 	// Pre-seed the folder-trust entry for (target config dir, project path)
@@ -191,6 +204,40 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		"claude_session_id": inst.ClaudeSessionID,
 		"restarted":         restarted,
 	})
+}
+
+// switchAccountRestartUnsafe reports whether switch-account must ABORT rather
+// than restart the session, and why (#1815 Guard 2).
+//
+// In the reported incident the switch correctly diagnosed that it had no
+// transcript to move ("no conversation to migrate, fresh session") for a
+// session that had demonstrably been running a conversation — and then
+// restarted it anyway. The restart's disk-discovery prelude, with no id to
+// work from, adopted the newest transcript filed under the shared working
+// directory (one belonging to a different session) and resumed it. A failed
+// verification has to stop the sequence.
+//
+// The discriminator is ClaudeDetectedAt: a session that never bound a
+// conversation id has nothing to lose and nothing to hijack (the Start
+// prelude's #608 gate skips discovery for it). A session that HAS run,
+// arriving here with no recorded id and no conversation located in ANY
+// configured config dir, is exactly the unsafe state.
+//
+// The abort is scoped to the case where this command would itself perform the
+// restart; --no-restart (or an already-stopped session) is the documented way
+// through, and the resume-time identity guard covers the later manual start.
+func switchAccountRestartUnsafe(inst *session.Instance, locatedDir string, wasRunning, noRestart bool) (bool, string) {
+	if inst == nil || !wasRunning || noRestart {
+		return false, ""
+	}
+	if locatedDir != "" || inst.ClaudeSessionID != "" || inst.ClaudeDetectedAt.IsZero() {
+		return false, ""
+	}
+	return true, "this session previously held a Claude conversation, but none was found in any " +
+		"configured config dir and it has no recorded conversation id; account not switched and " +
+		"session NOT restarted (restarting in this state can adopt a transcript belonging to another " +
+		"session in the same directory). Re-run with --no-restart to switch the account only, then " +
+		"start it manually once the conversation is located"
 }
 
 // configuredAccountNames lists profile names that have a Claude config_dir —

--- a/cmd/agent-deck/session_switch_account.go
+++ b/cmd/agent-deck/session_switch_account.go
@@ -114,11 +114,20 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		if inst.ClaudeSessionID == "" && locatedSID != "" {
 			// #1815: with no recorded id, this is "the newest conversation in
 			// the project dir" — a guess that a shared working directory can
-			// answer with another session's transcript. It is good enough to
-			// migrate (a copy), never good enough to resume: record it as
-			// unverified so the restart starts fresh instead of adopting a
-			// conversation this session may not own.
-			session.AdoptDiscoveredClaudeSessionID(inst, locatedSID)
+			// answer with a NEIGHBOURING session's transcript. Copying first
+			// and refusing to resume later is not good enough: the copy has
+			// already carried someone else's conversation into another
+			// account's config dir. Ambiguous discovery copies nothing.
+			//
+			// The operator can resolve the ambiguity explicitly and re-run.
+			out.Error(fmt.Sprintf(
+				"cannot identify %s's conversation: it has no recorded conversation id, and the only "+
+					"candidate is the newest transcript in its working directory (%s), which may belong "+
+					"to another session there. Nothing was copied and the account was NOT switched. "+
+					"Name the conversation explicitly if it is this session's own "+
+					"(agent-deck session set claude-session-id <uuid> %s) and re-run.",
+				inst.Title, locatedSID, inst.Title), ErrCodeInvalidOperation)
+			os.Exit(1)
 		}
 	}
 	migrated, migErr := session.MigrateConversationFrom(inst, srcDir, targetDir)

--- a/cmd/agent-deck/session_switch_account_guard_test.go
+++ b/cmd/agent-deck/session_switch_account_guard_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// #1815 Guard 2: switch-account already produced the right diagnosis ("no
+// conversation to migrate, fresh session") and then let the restart proceed.
+// A failed transcript verification must STOP the sequence.
+func TestSwitchAccountRestartUnsafe(t *testing.T) {
+	ranBefore := func() *session.Instance {
+		inst := session.NewInstanceWithTool("switch-guard", t.TempDir(), "claude")
+		inst.ClaudeSessionID = ""
+		inst.ClaudeDetectedAt = time.Now() // this session HAS held a conversation
+		return inst
+	}
+
+	t.Run("aborts when a session that has run cannot be located", func(t *testing.T) {
+		blocked, why := switchAccountRestartUnsafe(ranBefore(), "", true, false)
+		if !blocked {
+			t.Fatal("#1815: verification failed (no conversation located, no recorded id) — the restart must be aborted, not annotated")
+		}
+		if why == "" {
+			t.Fatal("the abort must surface a reason")
+		}
+	})
+
+	t.Run("allows the switch when the conversation was located", func(t *testing.T) {
+		if blocked, _ := switchAccountRestartUnsafe(ranBefore(), "/some/config/dir", true, false); blocked {
+			t.Fatal("a located conversation is the verified path and must proceed")
+		}
+	})
+
+	t.Run("allows a session with a recorded conversation id", func(t *testing.T) {
+		inst := ranBefore()
+		inst.ClaudeSessionID = "aaaaaaaa-1111-4222-8333-444444444444"
+		if blocked, _ := switchAccountRestartUnsafe(inst, "", true, false); blocked {
+			t.Fatal("a recorded conversation id is enough for the resume-time guard to verify identity")
+		}
+	})
+
+	t.Run("allows a session that never held a conversation", func(t *testing.T) {
+		inst := ranBefore()
+		inst.ClaudeDetectedAt = time.Time{}
+		if blocked, _ := switchAccountRestartUnsafe(inst, "", true, false); blocked {
+			t.Fatal("a never-bound session has nothing to lose and nothing to hijack")
+		}
+	})
+
+	t.Run("no restart to block", func(t *testing.T) {
+		if blocked, _ := switchAccountRestartUnsafe(ranBefore(), "", true, true); blocked {
+			t.Fatal("--no-restart is the documented way through: nothing is restarted, nothing to guard")
+		}
+		if blocked, _ := switchAccountRestartUnsafe(ranBefore(), "", false, false); blocked {
+			t.Fatal("a session that was not running is not restarted by switch-account")
+		}
+	})
+}

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -24,6 +24,17 @@ var uuidSessionFileRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]
 // command string before we trust them as the explicit session id.
 var uuidBareRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+// IsBareClaudeSessionUUID reports whether s is a well-formed bare UUID (no
+// surrounding whitespace or suffix). Exported so callers outside this
+// package that accept a free-text conversation id from an operator (e.g. the
+// TUI's "resume by session ID" panel field) can reject shell-metacharacter
+// or otherwise malformed input before treating it as an ownership
+// declaration and baking it into an unquoted `--resume %s` command (review
+// finding on #1830).
+func IsBareClaudeSessionUUID(s string) bool {
+	return uuidBareRegex.MatchString(s)
+}
+
 // extractExplicitClaudeSessionID parses the user-supplied wrapper command
 // string and returns the literal UUID argument of `--session-id <uuid>`
 // (or `--session-id=<uuid>`) if exactly one is present and well-formed.

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -46,6 +46,19 @@ var uuidBareRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-
 //     (e.g. `--session-id "$VAR"`) — the user is doing dynamic id
 //     resolution; we cannot safely declare the id without expansion.
 func extractExplicitClaudeSessionID(command string) (string, bool) {
+	return extractExplicitClaudeIDForFlags(command, "--session-id")
+}
+
+// extractExplicitClaudeResumeID is the `--resume <uuid>` counterpart (#1815).
+// A conversation id the operator baked into this session's OWN command is an
+// ownership declaration exactly like `--session-id`; without reading it, a
+// custom command carrying `claude --resume <id>` would execute verbatim and
+// never meet the resume-time chokepoint at all.
+func extractExplicitClaudeResumeID(command string) (string, bool) {
+	return extractExplicitClaudeIDForFlags(command, "--resume")
+}
+
+func extractExplicitClaudeIDForFlags(command, flag string) (string, bool) {
 	if command == "" {
 		return "", false
 	}
@@ -60,13 +73,13 @@ func extractExplicitClaudeSessionID(command string) (string, bool) {
 	for idx, f := range fields {
 		var candidate string
 		switch {
-		case f == "--session-id":
+		case f == flag:
 			if idx+1 >= len(fields) {
 				return "", false
 			}
 			candidate = fields[idx+1]
-		case strings.HasPrefix(f, "--session-id="):
-			candidate = strings.TrimPrefix(f, "--session-id=")
+		case strings.HasPrefix(f, flag+"="):
+			candidate = strings.TrimPrefix(f, flag+"=")
 		default:
 			continue
 		}

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -58,6 +58,26 @@ func extractExplicitClaudeResumeID(command string) (string, bool) {
 	return extractExplicitClaudeIDForFlags(command, "--resume")
 }
 
+// commandHasToken reports whether `command`, tokenized the same coarse way
+// as extractExplicitClaudeIDForFlags, contains the literal token `flag`
+// (bare, or as its `flag=...` form). Used to gate the `--resume` ownership
+// fallback: presence of ANY `--session-id` or `--fork-session` token means
+// this command matches the fork builder's shape (`--resume <SOURCE id>
+// --fork-session`), where the resume id names the PARENT's conversation, not
+// this session's own — that id must never be adopted as this instance's
+// verified identity (review finding on #1830).
+func commandHasToken(command, flag string) bool {
+	if command == "" {
+		return false
+	}
+	for _, f := range strings.Fields(command) {
+		if f == flag || strings.HasPrefix(f, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
 func extractExplicitClaudeIDForFlags(command, flag string) (string, bool) {
 	if command == "" {
 		return "", false

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -195,17 +195,21 @@ type Instance struct {
 	// Claude Code integration
 	ClaudeSessionID  string    `json:"claude_session_id,omitempty"`
 	ClaudeDetectedAt time.Time `json:"claude_detected_at,omitempty"`
-	// claudeSessionIDUnverifiedFor holds the ClaudeSessionID value that came
-	// from mtime-based disk discovery rather than from a source identifying
-	// THIS session (own tmux env, own hook payload, explicit --session-id,
-	// or an id this process minted). While it equals ClaudeSessionID, the id
-	// must never authorize `--resume` — see resume_identity.go (#1815).
-	// Storing the id (not a bare bool) means any later assignment of a
-	// different id is verified by default, so the flag can never go stale
-	// onto an unrelated value. Not persisted: the guard replaces an
-	// unverified id with a freshly minted one before any spawn, so nothing
-	// unverified reaches the save cycle.
-	claudeSessionIDUnverifiedFor string
+	// claudeSessionIDsFromDiskScan records every conversation id this
+	// instance ever obtained from an mtime-based DISK SCAN rather than from a
+	// source identifying THIS session (own tmux env, own hook payload, an
+	// explicit --session-id/--resume-session in its own command, an
+	// operator's explicit set, or an id this process minted). While an id is
+	// in this set it may not authorize `--resume` — see resume_identity.go
+	// (#1815).
+	//
+	// A SET, not one value: a scanned candidate stays suspect even after the
+	// field moves on and comes back, so no writer can launder it by simply
+	// re-assigning it. Membership is persisted for the current id (see
+	// resume_identity_persist.go), so a process restart cannot launder it
+	// either. Clearing is explicit and only from a source that identifies
+	// this session (markClaudeSessionIDVerified).
+	claudeSessionIDsFromDiskScan map[string]bool
 
 	// Gemini CLI integration
 	GeminiSessionID  string                  `json:"gemini_session_id,omitempty"`
@@ -1076,6 +1080,8 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		// the bash process with claude, enabling proper job control (Ctrl+Z suspend / fg resume).
 		sessionUUID := generateUUID()
 		i.ClaudeSessionID = sessionUUID
+		// #1815: minted here for this session — vouched ownership.
+		i.markClaudeSessionIDVerified()
 
 		// Startup query (#725, v1.7.67): appended as one shell-quoted
 		// positional arg so multi-word queries survive bash -c. Empty
@@ -7719,6 +7725,8 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 	// enabling proper job control (Ctrl+Z suspend / fg resume).
 	forkUUID := generateUUID()
 	target.ClaudeSessionID = forkUUID
+	// #1815: minted for the fork target — vouched ownership.
+	target.markClaudeSessionIDVerified()
 	cmd := fmt.Sprintf(
 		`cd '%s' && `+
 			`%sexec claude --session-id "%s" --resume %s --fork-session%s`,

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1028,7 +1028,23 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		// Handle different session modes
 		switch opts.SessionMode {
 		case "continue":
-			// Simple -c mode: continue last session
+			// Simple -c mode: continue last session.
+			//
+			// #1815: `-c` asks Claude to pick "the latest conversation in this
+			// directory" — the same mtime guess that started the incident,
+			// made inside the CLI where this guard cannot see it. When the
+			// session has a conversation id of its own, resume THAT instead:
+			// same intent, verified identity. `-c` is left as-is only when
+			// there is no owned id to prefer, since it is then the operator's
+			// explicit instruction and there is nothing better to offer.
+			if recorded := i.recordedClaudeSessionID(); recorded != "" {
+				return fmt.Sprintf(`%s%s%s --resume %s%s`,
+					configDirPrefix, execEnvPrefix, claudeCmd, recorded, extraFlags)
+			}
+			sessionLog.Warn("resume: continue_mode_unverifiable",
+				slog.String("instance_id", logging.SanitizeValue(i.ID)),
+				slog.String("path", logging.SanitizeValue(i.ProjectPath)),
+				slog.String("reason", "continue_flag_picks_newest_conversation_in_dir"))
 			return fmt.Sprintf(`%s%s%s -c%s`, configDirPrefix, execEnvPrefix, claudeCmd, extraFlags)
 
 		case "resume":
@@ -3261,12 +3277,16 @@ func (i *Instance) buildTmuxOptionOverrides() map[string]string {
 func (i *Instance) adoptExplicitClaudeSessionID(reason string) bool {
 	explicit, ok := extractExplicitClaudeSessionID(i.Command)
 	if !ok {
+		// #1815: a custom command carrying `claude --resume <uuid>` executes
+		// verbatim, so without adopting that id the instance would reach the
+		// spawn with an empty id and never meet the chokepoint at all.
+		// Baking it into this session's own command is the same ownership
+		// declaration as --session-id.
+		explicit, ok = extractExplicitClaudeResumeID(i.Command)
+	}
+	if !ok {
 		return false
 	}
-	// #1815: an explicit `--session-id` in this session's OWN command is a
-	// verified ownership declaration, and it also corrects an id a previous
-	// discovery left unverified.
-	i.markClaudeSessionIDVerified()
 	if i.ClaudeSessionID != explicit {
 		i.ClaudeSessionID = explicit
 		sessionLog.Info("resume: id="+explicit+" reason="+reason,
@@ -3274,6 +3294,10 @@ func (i *Instance) adoptExplicitClaudeSessionID(reason string) bool {
 			slog.String("claude_session_id", explicit),
 			slog.String("reason", reason))
 	}
+	// #1815: vouch AFTER the assignment, so the suspicion cleared is the one
+	// on the EXPLICIT value — clearing before would absolve whatever id
+	// happened to be current and leave the explicit one's history intact.
+	i.markClaudeSessionIDVerified()
 	if i.ClaudeDetectedAt.IsZero() {
 		i.ClaudeDetectedAt = time.Now()
 	}
@@ -4747,8 +4771,8 @@ func (i *Instance) UpdateClaudeSession(excludeIDs map[string]bool) {
 				})
 				i.ClaudeSessionID = sessionID
 				// #1815: CLAUDE_SESSION_ID read from this instance's OWN
-				// tmux pane identifies this session — verified ownership.
-				i.markClaudeSessionIDVerified()
+				// tmux pane is a WEAK vouch (the env is downstream of us).
+				i.noteClaudeSessionIDFromOwnPane()
 			}
 		}
 		i.ClaudeDetectedAt = time.Now()
@@ -5352,8 +5376,9 @@ func (i *Instance) WaitForClaudeSession(maxWait time.Duration) string {
 		// Check tmux environment (set by capture-resume pattern)
 		if sessionID := i.GetSessionIDFromTmux(); sessionID != "" {
 			i.ClaudeSessionID = sessionID
-			// #1815: this instance's OWN pane env identifies this session.
-			i.markClaudeSessionIDVerified()
+			// #1815: own pane env is a WEAK vouch — see
+			// noteClaudeSessionIDFromOwnPane.
+			i.noteClaudeSessionIDFromOwnPane()
 			i.ClaudeDetectedAt = time.Now()
 			return sessionID
 		}
@@ -5519,8 +5544,14 @@ func (i *Instance) SyncSessionIDsToTmux() {
 		return
 	}
 
-	// Sync ClaudeSessionID
-	if i.ClaudeSessionID != "" {
+	// Sync ClaudeSessionID.
+	//
+	// #1815: never publish a disk-scanned id into the pane env. The env is
+	// read back as an ownership signal, so publishing a suspect id would
+	// launder it into a resumable one on the next poll — the guard's own
+	// bypass. A suspect id is refused at spawn anyway, so the pane never
+	// legitimately holds one.
+	if i.ClaudeSessionID != "" && !i.claudeSessionIDsFromDiskScan[i.ClaudeSessionID] {
 		_ = i.tmuxSession.SetEnvironment("CLAUDE_SESSION_ID", i.ClaudeSessionID)
 	}
 
@@ -5631,8 +5662,8 @@ func (i *Instance) SyncSessionIDsFromTmux() {
 
 	if id, err := i.tmuxSession.GetEnvironment("CLAUDE_SESSION_ID"); err == nil && id != "" {
 		i.ClaudeSessionID = id
-		// #1815: own pane env — verified ownership.
-		i.markClaudeSessionIDVerified()
+		// #1815: own pane env — weak vouch.
+		i.noteClaudeSessionIDFromOwnPane()
 		if i.ClaudeDetectedAt.IsZero() {
 			i.ClaudeDetectedAt = time.Now()
 		}
@@ -5727,8 +5758,8 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 		// Refresh from tmux env (fast path)
 		if sessionID := i.GetSessionIDFromTmux(); sessionID != "" {
 			i.ClaudeSessionID = sessionID
-			// #1815: own pane env — verified ownership.
-			i.markClaudeSessionIDVerified()
+			// #1815: own pane env — weak vouch.
+			i.noteClaudeSessionIDFromOwnPane()
 			i.ClaudeDetectedAt = time.Now()
 			if recovered, recoverErr := i.getClaudeLastResponse(); recoverErr == nil {
 				return recovered, nil
@@ -8313,8 +8344,8 @@ func (i *Instance) RefreshLiveSessionIDs() {
 	if IsClaudeCompatible(i.Tool) {
 		if id := i.GetSessionIDFromTmux(); id != "" && id != i.ClaudeSessionID {
 			i.ClaudeSessionID = id
-			// #1815: own pane env — verified ownership.
-			i.markClaudeSessionIDVerified()
+			// #1815: own pane env — weak vouch.
+			i.noteClaudeSessionIDFromOwnPane()
 			i.ClaudeDetectedAt = time.Now()
 		}
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3409,9 +3409,14 @@ func (i *Instance) adoptExplicitClaudeSessionID(reason string) bool {
 	}
 	if i.ClaudeSessionID != explicit {
 		i.ClaudeSessionID = explicit
-		sessionLog.Info("resume: id="+explicit+" reason="+reason,
-			slog.String("instance_id", i.ID),
-			slog.String("claude_session_id", explicit),
+		// #1815 / CodeQL go/log-injection: explicit is parsed out of this
+		// session's own command string, which is session-supplied; reason is
+		// always one of this file's own string-literal call sites, never a
+		// variable from outside, so it needs no sanitizing.
+		safeExplicit := logging.SanitizeValue(explicit)
+		sessionLog.Info("resume: id="+safeExplicit+" reason="+reason,
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("claude_session_id", safeExplicit),
 			slog.String("reason", reason))
 	}
 	// #1815: vouch AFTER the assignment, so the suspicion cleared is the one
@@ -7530,21 +7535,29 @@ func (i *Instance) buildClaudeResumeCommand() string {
 			envPrefix, configDirPrefix, claudeCmd, fresh, extraFlags)
 	}
 
+	// #1815 / CodeQL go/log-injection: i.ClaudeSessionID, i.ID and
+	// i.ProjectPath are session-supplied, so every log call in this function
+	// — including the two Debug sibling calls below, not only the final Info
+	// record — sanitizes them. Computed once, before first use.
+	safeSID := logging.SanitizeValue(i.ClaudeSessionID)
+	safeInstID := logging.SanitizeValue(i.ID)
+	safePath := logging.SanitizeValue(i.ProjectPath)
+
 	useResume := canResumeClaudeSession(i, i.ClaudeSessionID)
 	if !useResume && i.ClaudeSessionID != "" {
 		time.Sleep(resumeCheckRetryDelay)
 		useResume = canResumeClaudeSession(i, i.ClaudeSessionID)
 		sessionLog.Debug(
 			"session_data_retry_after_wait",
-			slog.String("session_id", i.ClaudeSessionID),
+			slog.String("session_id", safeSID),
 			slog.Duration("wait", resumeCheckRetryDelay),
 			slog.Bool("use_resume_after_retry", useResume),
 		)
 	}
 	sessionLog.Debug(
 		"session_data_build_resume",
-		slog.String("session_id", i.ClaudeSessionID),
-		slog.String("path", i.ProjectPath),
+		slog.String("session_id", safeSID),
+		slog.String("path", safePath),
 		slog.Bool("use_resume", useResume),
 	)
 
@@ -7552,11 +7565,6 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// buildClaudeResumeCommand call — NOT sync.Once'd. See CONTEXT Decision 2.
 	// Every Start / StartWithMessage / Restart dispatch that routes through
 	// this helper produces exactly one "resume: id=<id> reason=<why>" line.
-	// Same sanitization as the identity-guard line above: the id and path are
-	// session-supplied (CodeQL go/log-injection).
-	safeSID := logging.SanitizeValue(i.ClaudeSessionID)
-	safeInstID := logging.SanitizeValue(i.ID)
-	safePath := logging.SanitizeValue(i.ProjectPath)
 	if useResume {
 		sessionLog.Info("resume: id="+safeSID+" reason=conversation_data_present",
 			slog.String("instance_id", safeInstID),

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3348,10 +3348,11 @@ func (i *Instance) ensureClaudeSessionIDFromDisk() {
 	// in a shared directory can belong to another session. Record it as
 	// UNVERIFIED so the resume-time identity guard refuses to --resume it.
 	i.adoptDiscoveredClaudeSessionID(uuid)
-	sessionLog.Info("resume: id="+uuid+" reason=jsonl_discovery",
-		slog.String("instance_id", i.ID),
-		slog.String("claude_session_id", uuid),
-		slog.String("path", lookupPath),
+	safeUUID := logging.SanitizeValue(uuid)
+	sessionLog.Info("resume: id="+safeUUID+" reason=jsonl_discovery",
+		slog.String("instance_id", logging.SanitizeValue(i.ID)),
+		slog.String("claude_session_id", safeUUID),
+		slog.String("path", logging.SanitizeValue(lookupPath)),
 		slog.String("reason", "jsonl_discovery"))
 }
 
@@ -3398,10 +3399,11 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 	if i.ClaudeDetectedAt.IsZero() {
 		i.ClaudeDetectedAt = time.Now()
 	}
-	sessionLog.Info("resume: id="+uuid+" reason=jsonl_discovery_restart",
-		slog.String("instance_id", i.ID),
-		slog.String("claude_session_id", uuid),
-		slog.String("path", lookupPath),
+	safeUUID := logging.SanitizeValue(uuid)
+	sessionLog.Info("resume: id="+safeUUID+" reason=jsonl_discovery_restart",
+		slog.String("instance_id", logging.SanitizeValue(i.ID)),
+		slog.String("claude_session_id", safeUUID),
+		slog.String("path", logging.SanitizeValue(lookupPath)),
 		slog.String("reason", "jsonl_discovery_restart"))
 }
 
@@ -4407,6 +4409,8 @@ func (i *Instance) UpdateStatus() error {
 			case IsClaudeCompatible(i.Tool):
 				if i.hookSessionID != i.ClaudeSessionID {
 					i.ClaudeSessionID = i.hookSessionID
+					// #1815: own hook anchor — verified ownership.
+					i.markClaudeSessionIDVerified()
 					i.ClaudeDetectedAt = time.Now()
 				}
 			case IsCodexCompatible(i.Tool):
@@ -5342,6 +5346,8 @@ func (i *Instance) WaitForClaudeSession(maxWait time.Duration) string {
 		// Check tmux environment (set by capture-resume pattern)
 		if sessionID := i.GetSessionIDFromTmux(); sessionID != "" {
 			i.ClaudeSessionID = sessionID
+			// #1815: this instance's OWN pane env identifies this session.
+			i.markClaudeSessionIDVerified()
 			i.ClaudeDetectedAt = time.Now()
 			return sessionID
 		}
@@ -5619,6 +5625,8 @@ func (i *Instance) SyncSessionIDsFromTmux() {
 
 	if id, err := i.tmuxSession.GetEnvironment("CLAUDE_SESSION_ID"); err == nil && id != "" {
 		i.ClaudeSessionID = id
+		// #1815: own pane env — verified ownership.
+		i.markClaudeSessionIDVerified()
 		if i.ClaudeDetectedAt.IsZero() {
 			i.ClaudeDetectedAt = time.Now()
 		}
@@ -5713,6 +5721,8 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 		// Refresh from tmux env (fast path)
 		if sessionID := i.GetSessionIDFromTmux(); sessionID != "" {
 			i.ClaudeSessionID = sessionID
+			// #1815: own pane env — verified ownership.
+			i.markClaudeSessionIDVerified()
 			i.ClaudeDetectedAt = time.Now()
 			if recovered, recoverErr := i.getClaudeLastResponse(); recoverErr == nil {
 				return recovered, nil
@@ -7290,11 +7300,13 @@ func (i *Instance) buildClaudeResumeCommand() string {
 		i.logResumeRefusal(refused, decision.Reason)
 		fresh := i.replaceRefusedClaudeSessionID()
 		extraFlags := i.buildClaudeExtraFlags(opts)
+		// `fresh` is minted here so it is trusted, but `refused` and the path
+		// are session-supplied; sanitize both (CodeQL go/log-injection).
 		sessionLog.Info("resume: id="+fresh+" reason=identity_guard_fresh_session",
-			slog.String("instance_id", i.ID),
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
 			slog.String("claude_session_id", fresh),
-			slog.String("refused_session_id", refused),
-			slog.String("path", i.ProjectPath),
+			slog.String("refused_session_id", logging.SanitizeValue(refused)),
+			slog.String("path", logging.SanitizeValue(i.ProjectPath)),
 			slog.String("reason", "identity_guard_fresh_session"))
 		return fmt.Sprintf("%s%s%s --session-id %s%s",
 			envPrefix, configDirPrefix, claudeCmd, fresh, extraFlags)
@@ -7322,17 +7334,22 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// buildClaudeResumeCommand call — NOT sync.Once'd. See CONTEXT Decision 2.
 	// Every Start / StartWithMessage / Restart dispatch that routes through
 	// this helper produces exactly one "resume: id=<id> reason=<why>" line.
+	// Same sanitization as the identity-guard line above: the id and path are
+	// session-supplied (CodeQL go/log-injection).
+	safeSID := logging.SanitizeValue(i.ClaudeSessionID)
+	safeInstID := logging.SanitizeValue(i.ID)
+	safePath := logging.SanitizeValue(i.ProjectPath)
 	if useResume {
-		sessionLog.Info("resume: id="+i.ClaudeSessionID+" reason=conversation_data_present",
-			slog.String("instance_id", i.ID),
-			slog.String("claude_session_id", i.ClaudeSessionID),
-			slog.String("path", i.ProjectPath),
+		sessionLog.Info("resume: id="+safeSID+" reason=conversation_data_present",
+			slog.String("instance_id", safeInstID),
+			slog.String("claude_session_id", safeSID),
+			slog.String("path", safePath),
 			slog.String("reason", "conversation_data_present"))
 	} else {
-		sessionLog.Info("resume: id="+i.ClaudeSessionID+" reason=session_id_flag_no_jsonl",
-			slog.String("instance_id", i.ID),
-			slog.String("claude_session_id", i.ClaudeSessionID),
-			slog.String("path", i.ProjectPath),
+		sessionLog.Info("resume: id="+safeSID+" reason=session_id_flag_no_jsonl",
+			slog.String("instance_id", safeInstID),
+			slog.String("claude_session_id", safeSID),
+			slog.String("path", safePath),
 			slog.String("reason", "session_id_flag_no_jsonl"))
 	}
 
@@ -8288,6 +8305,8 @@ func (i *Instance) RefreshLiveSessionIDs() {
 	if IsClaudeCompatible(i.Tool) {
 		if id := i.GetSessionIDFromTmux(); id != "" && id != i.ClaudeSessionID {
 			i.ClaudeSessionID = id
+			// #1815: own pane env — verified ownership.
+			i.markClaudeSessionIDVerified()
 			i.ClaudeDetectedAt = time.Now()
 		}
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -210,6 +210,16 @@ type Instance struct {
 	// either. Clearing is explicit and only from a source that identifies
 	// this session (markClaudeSessionIDVerified).
 	claudeSessionIDsFromDiskScan map[string]bool
+	// claudeSessionIDsFromDiskScanMu guards claudeSessionIDsFromDiskScan.
+	// It is a DEDICATED lock rather than a reuse of mu: mu is held across
+	// UpdateHookStatus (backgroundStatusUpdate's goroutine), which is one of
+	// the writers of this map, so reusing mu here would self-deadlock on that
+	// path. The map is also read concurrently from the TUI goroutine (preview
+	// rendering, NoteClaudeSessionIDFromOwnPane on refresh) while the status
+	// goroutine writes it — a concurrent, unguarded map read+write is a Go
+	// runtime FATAL error (not a recoverable panic), so every access must go
+	// through this lock (review finding on #1830).
+	claudeSessionIDsFromDiskScanMu sync.Mutex
 
 	// Gemini CLI integration
 	GeminiSessionID  string                  `json:"gemini_session_id,omitempty"`
@@ -1157,6 +1167,21 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 			// same intent, verified identity. `-c` is left as-is only when
 			// there is no owned id to prefer, since it is then the operator's
 			// explicit instruction and there is nothing better to offer.
+			//
+			// KNOWN OPEN RESIDUAL (review finding on #1830, not yet fixed):
+			// this function (buildClaudeCommand) is only dispatched to when
+			// i.ClaudeSessionID == "" (Start/StartWithMessage/the restart
+			// recreate fallback all route to buildClaudeResumeCommand
+			// whenever the id is non-empty), and recordedClaudeSessionID()
+			// derives from that same field. So on every REACHABLE production
+			// path `recorded` is always "" here and this mitigation branch
+			// never fires -- `claude -c` still ships, leaving the CLI's own
+			// newest-in-directory guess as the residual exposure this branch
+			// was meant to close. Only the test that calls this builder
+			// directly exercises it. Fixing this needs buildClaudeResumeCommand
+			// (or the three dispatch call sites) reworked to route continue-mode
+			// through a point where the id can be non-empty, which is deferred
+			// as a follow-up rather than attempted blind here.
 			if recorded := i.recordedClaudeSessionID(); recorded != "" {
 				return fmt.Sprintf(`%s%s%s --resume %s%s`,
 					configDirPrefix, execEnvPrefix, claudeCmd, recorded, extraFlags)
@@ -1496,6 +1521,18 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 	// re-emission so values with spaces survive the `bash -c` wrapper
 	// without being re-tokenized. Appended last so user flags can override
 	// defaults claude accepts in last-wins ordering.
+	//
+	// KNOWN OPEN RESIDUAL (review finding on #1830, not yet fixed): these
+	// tokens are appended AFTER canResumeClaudeSession has already decided
+	// --resume vs --session-id above, so an operator-configured ExtraArgs
+	// entry of e.g. `--resume <foreign-uuid>` or `-c` still reaches the final
+	// command line on a command the chokepoint just refused. #1407 copies a
+	// parent's ExtraArgs onto every fork, so a misconfigured parent would
+	// propagate the bypass to all children. ExtraArgs is operator-configured
+	// (not an external input), which bounds the severity, but this flags is
+	// not the "cannot be bypassed" guarantee this file's package doc claims.
+	// Stripping/logging --resume/-r/-c/--fork-session/--session-id tokens
+	// from ExtraArgs on the claude path is deferred as a follow-up.
 	for _, tok := range i.ExtraArgs {
 		flags = append(flags, shellescape.Quote(tok))
 	}
@@ -3402,7 +3439,19 @@ func (i *Instance) adoptExplicitClaudeSessionID(reason string) bool {
 		// spawn with an empty id and never meet the chokepoint at all.
 		// Baking it into this session's own command is the same ownership
 		// declaration as --session-id.
-		explicit, ok = extractExplicitClaudeResumeID(i.Command)
+		//
+		// Review finding on #1830: but ONLY when the command is not shaped
+		// like the fork builder's `--resume <SOURCE id> --fork-session`
+		// (also reachable via a legacy `--session-id "$VAR"` spelling that
+		// makes the --session-id extraction above bail without a UUID,
+		// falling through here). Any `--fork-session` or `--session-id`
+		// token present means the --resume argument names a DIFFERENT
+		// session's (the fork source's) conversation, not this instance's
+		// own -- adopting it as verified would be exactly the
+		// child-resumes-parent's-conversation shape #1815 exists to stop.
+		if !commandHasToken(i.Command, "--fork-session") && !commandHasToken(i.Command, "--session-id") {
+			explicit, ok = extractExplicitClaudeResumeID(i.Command)
+		}
 	}
 	if !ok {
 		return false
@@ -4581,6 +4630,16 @@ func (i *Instance) UpdateStatus() error {
 					// #1815: own hook anchor — verified ownership.
 					i.markClaudeSessionIDVerified()
 					i.ClaudeDetectedAt = time.Now()
+				} else {
+					// Review finding on #1830: the values already matching is
+					// NOT a no-op case for the taint. A live hook confirming
+					// the session's own id is the strongest available vouch
+					// (the process itself, not a disk guess) — clear any
+					// lingering disk-scan taint on it, or a solo custom-wrapper
+					// session whose own id was once disk-scanned stays
+					// permanently unresumable even though this hook just
+					// proved it right.
+					i.markClaudeSessionIDVerified()
 				}
 			case IsCodexCompatible(i.Tool):
 				if i.hookSessionID != i.CodexSessionID {
@@ -5015,6 +5074,12 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	switch {
 	case IsClaudeCompatible(i.Tool):
 		if sessionID == i.ClaudeSessionID {
+			// Review finding on #1830: same rationale as the sibling equality
+			// branch above — a live hook payload reporting this instance's
+			// own recorded id is the strongest available vouch, and must
+			// clear any lingering disk-scan taint on it rather than being
+			// treated as a no-op.
+			i.markClaudeSessionIDVerified()
 			return
 		}
 		// Issue #1729 guard: a candidate whose hook-reported cwd is provably
@@ -5712,7 +5777,10 @@ func (i *Instance) SyncSessionIDsToTmux() {
 	// launder it into a resumable one on the next poll — the guard's own
 	// bypass. A suspect id is refused at spawn anyway, so the pane never
 	// legitimately holds one.
-	if i.ClaudeSessionID != "" && !i.claudeSessionIDsFromDiskScan[i.ClaudeSessionID] {
+	i.claudeSessionIDsFromDiskScanMu.Lock()
+	tainted := i.claudeSessionIDsFromDiskScan[i.ClaudeSessionID]
+	i.claudeSessionIDsFromDiskScanMu.Unlock()
+	if i.ClaudeSessionID != "" && !tainted {
 		_ = i.tmuxSession.SetEnvironment("CLAUDE_SESSION_ID", i.ClaudeSessionID)
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -195,6 +195,17 @@ type Instance struct {
 	// Claude Code integration
 	ClaudeSessionID  string    `json:"claude_session_id,omitempty"`
 	ClaudeDetectedAt time.Time `json:"claude_detected_at,omitempty"`
+	// claudeSessionIDUnverifiedFor holds the ClaudeSessionID value that came
+	// from mtime-based disk discovery rather than from a source identifying
+	// THIS session (own tmux env, own hook payload, explicit --session-id,
+	// or an id this process minted). While it equals ClaudeSessionID, the id
+	// must never authorize `--resume` — see resume_identity.go (#1815).
+	// Storing the id (not a bare bool) means any later assignment of a
+	// different id is verified by default, so the flag can never go stale
+	// onto an unrelated value. Not persisted: the guard replaces an
+	// unverified id with a freshly minted one before any spawn, so nothing
+	// unverified reaches the save cycle.
+	claudeSessionIDUnverifiedFor string
 
 	// Gemini CLI integration
 	GeminiSessionID  string                  `json:"gemini_session_id,omitempty"`
@@ -1019,18 +1030,29 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		case "resume":
 			// Resume specific session by ID
 			if opts.ResumeSessionID != "" {
-				// Check if session has actual conversation data
-				if sessionHasConversationData(i, opts.ResumeSessionID) {
+				// #1815: identity first (the id must be this session's own),
+				// then the conversation-data / project-dir check. Both live
+				// behind canResumeClaudeSession.
+				if canResumeClaudeSession(i, opts.ResumeSessionID) {
 					// Session has conversation history - use normal --resume
 					return fmt.Sprintf(`%s%s%s --resume %s%s`,
 						configDirPrefix, execEnvPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
 				}
 				// Session was never interacted with - use --session-id with same UUID.
 				// CLAUDE_SESSION_ID is propagated via host-side SyncSessionIDsToTmux after start.
+				//
+				// #1815: when the refusal was an IDENTITY refusal the id may
+				// belong to another session, so it must not be reused via
+				// --session-id either (a shared id also makes the duplicate
+				// sweeper kill one of the pair). Mint a fresh one.
+				freshID := opts.ResumeSessionID
+				if !i.resumeIdentityAllowed(opts.ResumeSessionID).Allow {
+					freshID = i.replaceRefusedClaudeSessionID()
+				}
 				bashExportPrefix := i.buildBashExportPrefix()
 				return fmt.Sprintf(
 					`%s%s%s --session-id "%s"%s`,
-					bashExportPrefix, execEnvPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
+					bashExportPrefix, execEnvPrefix, claudeCmd, freshID, extraFlags)
 			}
 			// No session ID provided - use -r flag for interactive picker
 			return fmt.Sprintf(`%s%s%s -r%s`, configDirPrefix, execEnvPrefix, claudeCmd, extraFlags)
@@ -3235,6 +3257,10 @@ func (i *Instance) adoptExplicitClaudeSessionID(reason string) bool {
 	if !ok {
 		return false
 	}
+	// #1815: an explicit `--session-id` in this session's OWN command is a
+	// verified ownership declaration, and it also corrects an id a previous
+	// discovery left unverified.
+	i.markClaudeSessionIDVerified()
 	if i.ClaudeSessionID != explicit {
 		i.ClaudeSessionID = explicit
 		sessionLog.Info("resume: id="+explicit+" reason="+reason,
@@ -3318,7 +3344,10 @@ func (i *Instance) ensureClaudeSessionIDFromDisk() {
 	if !found {
 		return
 	}
-	i.ClaudeSessionID = uuid
+	// #1815: discovery returns the newest transcript in this directory, which
+	// in a shared directory can belong to another session. Record it as
+	// UNVERIFIED so the resume-time identity guard refuses to --resume it.
+	i.adoptDiscoveredClaudeSessionID(uuid)
 	sessionLog.Info("resume: id="+uuid+" reason=jsonl_discovery",
 		slog.String("instance_id", i.ID),
 		slog.String("claude_session_id", uuid),
@@ -3363,7 +3392,9 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 	if !found {
 		return
 	}
-	i.ClaudeSessionID = uuid
+	// #1815: see ensureClaudeSessionIDFromDisk — a discovered id is a hint,
+	// not proof of ownership, and must not authorize --resume.
+	i.adoptDiscoveredClaudeSessionID(uuid)
 	if i.ClaudeDetectedAt.IsZero() {
 		i.ClaudeDetectedAt = time.Now()
 	}
@@ -4705,6 +4736,9 @@ func (i *Instance) UpdateClaudeSession(excludeIDs map[string]bool) {
 					Source: "tmux_env", OldID: i.ClaudeSessionID, NewID: sessionID,
 				})
 				i.ClaudeSessionID = sessionID
+				// #1815: CLAUDE_SESSION_ID read from this instance's OWN
+				// tmux pane identifies this session — verified ownership.
+				i.markClaudeSessionIDVerified()
 			}
 		}
 		i.ClaudeDetectedAt = time.Now()
@@ -5690,12 +5724,17 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 		// transcript on disk that carries a real assistant reply. Mirrors the
 		// Gemini syncGeminiSessionFromDisk fallback below.
 		if id, recovered := i.findLatestClaudeTranscriptOnDisk(); recovered != nil {
-			i.ClaudeSessionID = id
+			// #1815: this is an mtime-based disk scan — the same evidence
+			// class as the restart discovery prelude, and in a shared working
+			// directory the newest transcript can belong to another session.
+			// Good enough to READ a last response from; never ownership. Mark
+			// it unverified so it cannot authorize a later `--resume`, and do
+			// NOT write it into this pane's CLAUDE_SESSION_ID: that would
+			// launder a scanned id into a "bound from my own tmux env" one on
+			// the next status poll, which is exactly the resume this guard
+			// exists to prevent.
+			i.adoptDiscoveredClaudeSessionID(id)
 			i.ClaudeDetectedAt = time.Now()
-			// Sync back to tmux so subsequent reads (and restarts) stay current.
-			if i.tmuxSession != nil && i.tmuxSession.Exists() {
-				_ = i.tmuxSession.SetEnvironment("CLAUDE_SESSION_ID", id)
-			}
 			return recovered, nil
 		}
 	}
@@ -7242,10 +7281,29 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// common flush-race case without slowing the happy path (retry only
 	// fires when the first check comes back negative AND we have a
 	// non-empty ClaudeSessionID).
-	useResume := sessionHasConversationData(i, i.ClaudeSessionID)
+	// #1815 identity guard: refuse outright when the id about to be resumed
+	// is not this session's own recorded conversation id (missing recorded id,
+	// or a mismatch). The refused id is replaced by a freshly minted one so
+	// the session starts clean instead of claiming another session's id.
+	if decision := i.resumeIdentityAllowed(i.ClaudeSessionID); !decision.Allow {
+		refused := i.ClaudeSessionID
+		i.logResumeRefusal(refused, decision.Reason)
+		fresh := i.replaceRefusedClaudeSessionID()
+		extraFlags := i.buildClaudeExtraFlags(opts)
+		sessionLog.Info("resume: id="+fresh+" reason=identity_guard_fresh_session",
+			slog.String("instance_id", i.ID),
+			slog.String("claude_session_id", fresh),
+			slog.String("refused_session_id", refused),
+			slog.String("path", i.ProjectPath),
+			slog.String("reason", "identity_guard_fresh_session"))
+		return fmt.Sprintf("%s%s%s --session-id %s%s",
+			envPrefix, configDirPrefix, claudeCmd, fresh, extraFlags)
+	}
+
+	useResume := canResumeClaudeSession(i, i.ClaudeSessionID)
 	if !useResume && i.ClaudeSessionID != "" {
 		time.Sleep(resumeCheckRetryDelay)
-		useResume = sessionHasConversationData(i, i.ClaudeSessionID)
+		useResume = canResumeClaudeSession(i, i.ClaudeSessionID)
 		sessionLog.Debug(
 			"session_data_retry_after_wait",
 			slog.String("session_id", i.ClaudeSessionID),
@@ -7608,6 +7666,16 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 
 	if !i.CanFork() {
 		return "", fmt.Errorf("cannot fork: no active Claude session")
+	}
+
+	// #1815: a fork is a `--resume <source id> --fork-session`, so it needs
+	// the same identity verification as any other resume — forking a
+	// transcript this session does not own would clone another session's
+	// context (and its authority) into a new pane.
+	if decision := i.resumeIdentityAllowed(i.ClaudeSessionID); !decision.Allow {
+		i.logResumeRefusal(i.ClaudeSessionID, "fork_"+decision.Reason)
+		return "", fmt.Errorf("cannot fork: conversation id %q is not verified as this session's own (%s)",
+			i.ClaudeSessionID, decision.Reason)
 	}
 
 	workDir := target.ProjectPath
@@ -8516,6 +8584,9 @@ func (i *Instance) bindClaudeSessionFromHook(sessionID, hookSource, hookEvent, a
 		HookEvent: hookEvent,
 	})
 	i.ClaudeSessionID = sessionID
+	// #1815: a hook payload correlated to this instance identifies THIS
+	// session, so the id is verified ownership.
+	i.markClaudeSessionIDVerified()
 	i.ClaudeDetectedAt = time.Now()
 	i.hookSessionID = sessionID
 

--- a/internal/session/issue956_chat_history_restart_test.go
+++ b/internal/session/issue956_chat_history_restart_test.go
@@ -19,7 +19,27 @@ package session
 //
 // PR #989 (REQ-7 manifestation 3) addressed CanRestart() for the same
 // class of sessions (registry-level check), but the resume dispatch was
-// out of scope. This file pins the end-to-end contract.
+// out of scope. This file pinned the end-to-end contract.
+//
+// CONTRACT REVERSED BY #1815 — read this before "fixing" the test back.
+// The recovery above is indistinguishable, at the moment of resume, from the
+// incident #1815 reports: a session with no recorded conversation id was
+// restarted, disk discovery offered the newest transcript filed under the
+// working directory, and the restart resumed a conversation belonging to a
+// DIFFERENT session — bringing that session's context and authority up in
+// this pane. Discovery cannot tell "my lost transcript" from "the neighbour's
+// transcript": both are simply the newest jsonl in a shared directory.
+//
+// #1815 rules that the ambiguity must fail closed. A discovered id is a hint,
+// never proof of ownership, so it may not authorize --resume. The cost is
+// exactly the #956 recovery: a custom-wrapper session whose id was never
+// captured now starts fresh instead of re-attaching its own history. Losing
+// one conversation's history is recoverable; adopting another session's
+// conversation is not.
+//
+// What survives from #956: the restart still routes through the claude spawn
+// path with an explicit session id rather than blindly re-running the wrapper.
+// What this test now pins is the refusal.
 //
 // See ~/.claude/projects/-home-ashesh-goplani--agent-deck/memory/
 // conductor_restart_history_loss.md for the structural background.
@@ -34,25 +54,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestConductor_Restart_PreservesChatHistory_RegressionFor956 pins the
-// contract: when a custom-command Claude session has empty ClaudeSessionID
-// at Restart() time and a JSONL transcript exists on disk (written during
-// the live conversation), Restart() MUST discover the latest JSONL and
-// resume from it (--resume <uuid>) rather than spawn a fresh wrapper that
-// loses history.
+// TestConductor_Restart_DoesNotAdoptDiscoveredTranscript_1815 is the #956
+// scenario under the #1815 ruling: a custom-command Claude session with an
+// empty ClaudeSessionID at Restart() time, and a JSONL transcript sitting in
+// its working directory that nothing can attribute to it.
 //
-// RED on main: Restart()'s fallback recreate path (instance.go:Restart)
-// dispatches through buildClaudeCommand(i.Command), running the wrapper
-// fresh. No --resume is emitted. The argv log shows wrapper invocation
-// without any --resume flag.
-//
-// GREEN with the fix: Restart() invokes the disk-discovery prelude before
-// dispatch (same logic as Start()'s ensureClaudeSessionIDFromDisk, but
-// bypassing the #608 brand-new-session gate because Restart() implies the
-// instance previously ran). ClaudeSessionID is populated from the latest
-// JSONL, the respawn-pane fast path engages, and `claude --resume <uuid>`
-// is spawned via buildClaudeResumeCommand.
-func TestConductor_Restart_PreservesChatHistory_RegressionFor956(t *testing.T) {
+// Post-#1815 contract: the restart must NOT emit `--resume <discovered
+// uuid>`, and must not claim the discovered uuid via --session-id either (a
+// shared id would also make the duplicate sweeper kill one of the pair). It
+// starts fresh, on the claude spawn path, with a newly minted id.
+func TestConductor_Restart_DoesNotAdoptDiscoveredTranscript_1815(t *testing.T) {
 	requireTmux(t)
 	home := isolatedHomeDir(t)
 	argvLog := setupStubClaudeOnPATH(t, home)
@@ -97,30 +108,30 @@ func TestConductor_Restart_PreservesChatHistory_RegressionFor956(t *testing.T) {
 	// Reset the argv log so the Restart's argv is the only entry we inspect.
 	require.NoError(t, os.WriteFile(argvLog, nil, 0o644))
 
-	// Restart: must discover the JSONL and resume rather than spawn fresh.
+	// Restart: discovery offers the transcript; the identity guard refuses it.
 	require.NoError(t, inst.Restart(), "Restart: must succeed")
 
 	argv := readCapturedClaudeArgv(t, argvLog, 3*time.Second)
 	joined := strings.Join(argv, " ")
 
-	// Contract assertion: post-restart, the spawned claude argv must contain
-	// --resume <jsonl-uuid>. On main this fails because Restart()'s
-	// fallback path runs the wrapper without --resume.
-	require.Contains(t, joined, "--resume",
-		"Issue #956 RED: Restart() of custom-command claude session with "+
-			"empty ClaudeSessionID and a JSONL transcript on disk must "+
-			"discover the JSONL and pass --resume to preserve chat history. "+
-			"Got argv: %v. The fix mirrors Start()'s ensureClaudeSessionIDFromDisk "+
-			"prelude but bypasses the #608 brand-new gate because Restart() "+
-			"implies the session previously ran.", argv)
-	require.Contains(t, joined, jsonlUUID,
-		"Issue #956 RED: Restart() must resume the newest JSONL uuid "+
-			"(%s), not mint a fresh id. Got argv: %v", jsonlUUID, argv)
+	require.NotContains(t, joined, "--resume",
+		"#1815: a transcript this session cannot be shown to own must not be "+
+			"resumed. Discovery cannot distinguish this session's lost "+
+			"transcript from a neighbour's in a shared directory, so the "+
+			"ambiguity fails closed. Got argv: %v", argv)
+	require.NotContains(t, joined, jsonlUUID,
+		"#1815: the refused id may belong to another session and must not be "+
+			"reused via --session-id either (a shared CLAUDE_SESSION_ID also "+
+			"trips the duplicate sweeper). Got argv: %v", argv)
+	require.Contains(t, joined, "--session-id",
+		"#1815: the refusal must still start the session on the claude spawn "+
+			"path with an explicit fresh id (that part of #956 survives). "+
+			"Got argv: %v", argv)
 
-	// Write-through assertion: after Restart(), the Instance MUST carry the
-	// discovered session id so subsequent Restart() / status reads see it.
-	require.Equal(t, jsonlUUID, inst.ClaudeSessionID,
-		"Issue #956: Restart() must persist the discovered JSONL uuid onto "+
-			"the Instance so the next operation sees a populated id. "+
-			"Mirrors PERSIST-12 write-through from the Start() path.")
+	// Write-through: the Instance carries the freshly minted id, not the
+	// discovered one, so nothing unverified reaches the save cycle.
+	require.NotEmpty(t, inst.ClaudeSessionID,
+		"#1815: the instance must carry the freshly minted conversation id")
+	require.NotEqual(t, jsonlUUID, inst.ClaudeSessionID,
+		"#1815: the instance must NOT keep the discovered (unowned) uuid")
 }

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -15,6 +15,13 @@ import (
 // accounts should treat this as non-fatal: there is simply nothing to migrate.
 var ErrNoConversation = errors.New("no conversation file found")
 
+// ErrAmbiguousConversation reports that the source project dir holds several
+// conversations while the instance has no id that resolves to one of them, so
+// no transcript can be attributed to it (#1815). Distinct from
+// ErrNoConversation: something IS there, it just cannot be shown to be this
+// session's, and copying a guess across accounts is not acceptable.
+var ErrAmbiguousConversation = errors.New("conversation cannot be attributed to this session")
+
 // MigrateConversation copies the session's Claude conversation file from its
 // currently resolved config dir into targetConfigDir, so `claude --resume`
 // finds the history after an account switch (#924 follow-up). Copy-only: the
@@ -73,12 +80,23 @@ func MigrateConversationFrom(inst *Instance, srcConfigDir, targetConfigDir strin
 		if newestFile == "" {
 			return "", fmt.Errorf("%w under %s", ErrNoConversation, srcProjDir)
 		}
-		// #1815: "newest conversation in the project dir" is a guess — in a
-		// shared working directory it can be another session's transcript.
-		// This holds whether or not an older id was stored: the fallback is
+		// #1815: "newest conversation in the project dir" is a guess, and it
+		// is a guess whether or not an older id was stored — the fallback is
 		// choosing a DIFFERENT conversation by mtime either way, so a stale
-		// stored id does not make the replacement owned. Migrating it is
-		// harmless (a copy), but it must never authorize a `--resume`.
+		// stored id does not make the replacement owned.
+		//
+		// Where the guess is AMBIGUOUS (more than one conversation in the
+		// directory, i.e. sessions share this cwd) it is refused outright
+		// rather than copied: copying first and refusing to resume later has
+		// already carried a neighbouring session's conversation into another
+		// account's config dir. Where the directory holds exactly one
+		// conversation there is nothing to confuse it with, so the repair the
+		// fallback exists for still works — but the id stays suspect until
+		// something vouches for it, so it cannot authorize a `--resume`.
+		if conversationCount(srcProjDir) > 1 {
+			return "", fmt.Errorf("%w: %s holds several conversations and %s has no resolvable id of its own, so the newest one cannot be attributed to it",
+				ErrAmbiguousConversation, srcProjDir, inst.Title)
+		}
 		srcFile, sid = newestFile, newestID
 		inst.adoptDiscoveredClaudeSessionID(newestID)
 	}
@@ -191,6 +209,25 @@ func RestoreOrphanedConversationBackup(inst *Instance, configDir string) (string
 // conversation file in projDir (and its session id), skipping agent-*.jsonl.
 // Unlike findActiveSessionIDExcluding it has no recency cutoff: a conversation
 // being migrated may be arbitrarily old.
+// conversationCount reports how many UUID-named conversation files live in
+// projDir. More than one means the directory is shared, so "the newest one"
+// identifies nothing (#1815).
+func conversationCount(projDir string) int {
+	files, err := filepath.Glob(filepath.Join(projDir, "*.jsonl"))
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, file := range files {
+		base := filepath.Base(file)
+		if strings.HasPrefix(base, "agent-") || !uuidSessionFileRegex.MatchString(base) {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
 func newestConversationFile(projDir string) (path, sessionID string) {
 	files, err := filepath.Glob(filepath.Join(projDir, "*.jsonl"))
 	if err != nil {

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -205,10 +205,6 @@ func RestoreOrphanedConversationBackup(inst *Instance, configDir string) (string
 	return live, nil
 }
 
-// newestConversationFile returns the most recently modified UUID-named
-// conversation file in projDir (and its session id), skipping agent-*.jsonl.
-// Unlike findActiveSessionIDExcluding it has no recency cutoff: a conversation
-// being migrated may be arbitrarily old.
 // conversationCount reports how many UUID-named conversation files live in
 // projDir. More than one means the directory is shared, so "the newest one"
 // identifies nothing (#1815).
@@ -228,6 +224,10 @@ func conversationCount(projDir string) int {
 	return n
 }
 
+// newestConversationFile returns the most recently modified UUID-named
+// conversation file in projDir (and its session id), skipping agent-*.jsonl.
+// Unlike findActiveSessionIDExcluding it has no recency cutoff: a conversation
+// being migrated may be arbitrarily old.
 func newestConversationFile(projDir string) (path, sessionID string) {
 	files, err := filepath.Glob(filepath.Join(projDir, "*.jsonl"))
 	if err != nil {

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -74,7 +74,18 @@ func MigrateConversationFrom(inst *Instance, srcConfigDir, targetConfigDir strin
 			return "", fmt.Errorf("%w under %s", ErrNoConversation, srcProjDir)
 		}
 		srcFile, sid = newestFile, newestID
-		inst.ClaudeSessionID = newestID
+		if inst.ClaudeSessionID == "" {
+			// #1815: with no stored id, "newest conversation in the project
+			// dir" is a guess — in a shared working directory it can be
+			// another session's transcript. Migrating it is harmless (a copy),
+			// but it must not authorize a `--resume` after the switch's
+			// restart, so record it as unverified.
+			inst.adoptDiscoveredClaudeSessionID(newestID)
+		} else {
+			// A stale stored id (the resume renamed the file) is a repair of a
+			// conversation this session is known to own.
+			inst.ClaudeSessionID = newestID
+		}
 	}
 
 	dstProjDir := filepath.Join(dst, "projects", projDirName)

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -73,19 +73,14 @@ func MigrateConversationFrom(inst *Instance, srcConfigDir, targetConfigDir strin
 		if newestFile == "" {
 			return "", fmt.Errorf("%w under %s", ErrNoConversation, srcProjDir)
 		}
+		// #1815: "newest conversation in the project dir" is a guess — in a
+		// shared working directory it can be another session's transcript.
+		// This holds whether or not an older id was stored: the fallback is
+		// choosing a DIFFERENT conversation by mtime either way, so a stale
+		// stored id does not make the replacement owned. Migrating it is
+		// harmless (a copy), but it must never authorize a `--resume`.
 		srcFile, sid = newestFile, newestID
-		if inst.ClaudeSessionID == "" {
-			// #1815: with no stored id, "newest conversation in the project
-			// dir" is a guess — in a shared working directory it can be
-			// another session's transcript. Migrating it is harmless (a copy),
-			// but it must not authorize a `--resume` after the switch's
-			// restart, so record it as unverified.
-			inst.adoptDiscoveredClaudeSessionID(newestID)
-		} else {
-			// A stale stored id (the resume renamed the file) is a repair of a
-			// conversation this session is known to own.
-			inst.ClaudeSessionID = newestID
-		}
+		inst.adoptDiscoveredClaudeSessionID(newestID)
 	}
 
 	dstProjDir := filepath.Join(dst, "projects", projDirName)

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -291,6 +291,9 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 	case FieldClaudeSessionID:
 		oldValue = inst.ClaudeSessionID
 		inst.ClaudeSessionID = value
+		// #1815: an operator naming the conversation id for this session is
+		// an explicit ownership declaration.
+		inst.markClaudeSessionIDVerified()
 		inst.ClaudeDetectedAt = time.Now()
 		postCommit = makeSessionEnvPostCommit(inst, "CLAUDE_SESSION_ID", value)
 		// Issue #923 (reporter @bautrey): when the user explicitly clears

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -209,9 +209,20 @@ func NewClaudeSessionUUID() string { return generateUUID() }
 // adoptDiscoveredClaudeSessionID records an id obtained from mtime-based disk
 // discovery. The id is marked UNVERIFIED: it is a hint about which transcript
 // exists in this directory, never proof of ownership.
+//
+// Order matters: the taint is recorded BEFORE ClaudeSessionID is assigned.
+// ClaudeSessionID itself is a plain field with no dedicated lock (pre-existing
+// throughout this package; a full lock would need to cover every one of its
+// ~20 writer sites, out of scope here), so a concurrent recordedClaudeSessionID()
+// read is not excluded by this function. Writing the taint first closes the
+// specific window a review finding on #1830 flagged: with the old
+// ID-then-taint order, a reader could observe the new id with the taint not
+// yet present and treat a disk-scanned id as recorded for one instant.
+// Taint-first means any interleaving instead sees either the OLD id (taint
+// irrelevant) or the NEW id already tainted -- never the new id un-tainted.
 func (i *Instance) adoptDiscoveredClaudeSessionID(uuid string) {
-	i.ClaudeSessionID = uuid
 	i.markClaudeSessionIDFromDiskScan(uuid)
+	i.ClaudeSessionID = uuid
 }
 
 // markClaudeSessionIDFromDiskScan records that uuid came from a disk scan.

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -228,6 +228,34 @@ func (i *Instance) markClaudeSessionIDVerified() {
 	delete(i.claudeSessionIDsFromDiskScan, strings.TrimSpace(i.ClaudeSessionID))
 }
 
+// noteClaudeSessionIDFromOwnPane records a WEAK vouch: the id was read back
+// from this instance's own tmux pane environment.
+//
+// Weak because the pane env is downstream of us — agent-deck writes it — so
+// treating it as proof would close a laundering loop (scan an id, publish it,
+// read it back as "verified"). It therefore records ownership only for a
+// value no disk scan ever produced; a suspect value stays suspect until a
+// source that is NOT downstream of us vouches for it (an explicit flag, an
+// operator's set, a hook payload from the live process, or a minted id).
+// Since a suspect id is never published to the pane (SyncSessionIDsToTmux)
+// and never spawned, the pane cannot legitimately hold one.
+func (i *Instance) noteClaudeSessionIDFromOwnPane() {
+	id := strings.TrimSpace(i.ClaudeSessionID)
+	if id == "" || i.claudeSessionIDsFromDiskScan[id] {
+		return
+	}
+	i.markClaudeSessionIDVerified()
+}
+
+// NoteClaudeSessionIDFromOwnPane is the exported weak vouch, for the CLI and
+// TUI refresh paths that re-read CLAUDE_SESSION_ID from a session's own pane.
+func NoteClaudeSessionIDFromOwnPane(inst *Instance) {
+	if inst == nil {
+		return
+	}
+	inst.noteClaudeSessionIDFromOwnPane()
+}
+
 // MarkClaudeSessionIDVerified is the exported form, for the CLI and TUI
 // writers that assign an id from a source identifying THIS session (an
 // operator's explicit --resume-session / --session-id, a picked conversation,

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -3,6 +3,8 @@ package session
 import (
 	"log/slog"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
 
 // Resume-time identity guard (#1815).
@@ -121,13 +123,20 @@ func (i *Instance) resumeIdentityAllowed(candidate string) resumeIdentityDecisio
 // other session — so the refusal must be visible in the log even though the
 // user-visible effect (a fresh session) looks unremarkable.
 func (i *Instance) logResumeRefusal(candidate, reason string) {
-	sessionLog.Warn("resume refused: id="+candidate+" reason="+reason,
-		slog.String("instance_id", i.ID),
-		slog.String("title", i.Title),
-		slog.String("candidate_session_id", candidate),
-		slog.String("recorded_session_id", i.recordedClaudeSessionID()),
-		slog.String("path", i.ProjectPath),
-		slog.String("reason", reason),
+	// Every value here is session-supplied (ids come from disk filenames and
+	// tmux/hook payloads; title and path from user input), so each one is
+	// sanitized before it reaches the log — message text and structured
+	// fields alike. CodeQL go/log-injection.
+	safeCandidate := logging.SanitizeValue(candidate)
+	safeRecorded := logging.SanitizeValue(i.recordedClaudeSessionID())
+	safeReason := logging.SanitizeValue(reason)
+	sessionLog.Warn("resume refused: id="+safeCandidate+" reason="+safeReason,
+		slog.String("instance_id", logging.SanitizeValue(i.ID)),
+		slog.String("title", logging.SanitizeValue(i.Title)),
+		slog.String("candidate_session_id", safeCandidate),
+		slog.String("recorded_session_id", safeRecorded),
+		slog.String("path", logging.SanitizeValue(i.ProjectPath)),
+		slog.String("reason", safeReason),
 		slog.String("action", "start_fresh"),
 	)
 }

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -155,6 +155,10 @@ func (i *Instance) logResumeRefusal(candidate, reason string) {
 // canResumeClaudeSession is the single resume-time chokepoint: it answers
 // "may this instance be started with `--resume <sessionID>`?".
 //
+// Nothing outside this file decides that question: callers ask here, and both
+// layers below run in order, so a future caller cannot take only half of the
+// check by accident.
+//
 // Layer 1 (this change, #1815): identity — the id must be this instance's own
 // recorded conversation id.
 // Layer 2 (sessionHasConversationData, hardened by #1788): the transcript must

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -1,0 +1,215 @@
+package session
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// Resume-time identity guard (#1815).
+//
+// Incident: a session whose own conversation id had been lost (an account
+// switch reported "no conversation to migrate, fresh session") was restarted.
+// The restart prelude fell back to disk discovery, which returns the NEWEST
+// UUID-named transcript filed under the encoded working directory — not
+// necessarily this session's own. The restarted pane therefore came up
+// `--resume`ing a transcript belonging to a DIFFERENT session that shared the
+// directory, complete with that session's context and authority.
+//
+// The structural defect: every upstream producer of a session id (tmux env,
+// hook payload, explicit --session-id flag, disk discovery, account-switch
+// relocation) fed the same field, and the command builders trusted whatever
+// was in it. Nothing verified, at the moment the `--resume <id>` string was
+// assembled, that the id was this session's OWN.
+//
+// The guard closes that at the last step, where it cannot be bypassed by
+// fixing only some upstream paths:
+//
+//	recorded id missing  -> refuse, start fresh
+//	recorded id mismatch -> refuse, start fresh
+//	otherwise            -> the existing conversation-data / project-dir checks decide
+//
+// Starting fresh loses at most one conversation's history. Resuming another
+// session's conversation hands this pane that session's context and its
+// authority, which is not a recoverable mistake.
+//
+// Composition with the foreign-project-dir guard (#1788): that change hardens
+// sessionHasConversationData so a jsonl found under an unrelated project
+// directory can no longer justify `--resume`. It rejects by LOCATION; this one
+// rejects by IDENTITY. They are deliberately layered inside the single
+// chokepoint canResumeClaudeSession below (identity first, then
+// sessionHasConversationData) rather than left as two partial checks that
+// callers might reach independently.
+
+// minResumeIDPrefixLen is the shortest prefix accepted when matching a
+// recorded conversation id against a candidate. The Claude CLI resolves
+// `--resume` ids by prefix, so an operator-supplied or CLI-echoed prefix is a
+// legitimate spelling of the same id — but a prefix short enough to collide
+// across unrelated UUIDs is not identity evidence.
+const minResumeIDPrefixLen = 8
+
+// claudeSessionIDsMatch reports whether candidate denotes the same
+// conversation as recorded. Exact match, or either value being a
+// sufficiently long prefix of the other (the CLI accepts id prefixes).
+// Comparison is case-insensitive: UUID hex spelling is not significant.
+func claudeSessionIDsMatch(recorded, candidate string) bool {
+	r := strings.ToLower(strings.TrimSpace(recorded))
+	c := strings.ToLower(strings.TrimSpace(candidate))
+	if r == "" || c == "" {
+		return false
+	}
+	if r == c {
+		return true
+	}
+	shorter, longer := r, c
+	if len(longer) < len(shorter) {
+		shorter, longer = longer, shorter
+	}
+	if len(shorter) < minResumeIDPrefixLen {
+		return false
+	}
+	return strings.HasPrefix(longer, shorter)
+}
+
+// resumeIdentityDecision is the outcome of the identity half of the guard.
+type resumeIdentityDecision struct {
+	Allow  bool
+	Reason string
+}
+
+// recordedClaudeSessionID returns the conversation id this instance is known
+// to OWN, or "" when no such id is recorded.
+//
+// An id populated by disk discovery is deliberately NOT recorded ownership:
+// discovery picks the newest transcript filed under the working directory,
+// which in a shared directory is somebody else's. Such an id is usable as a
+// hint (it still routes the restart through the resume builder, preserving the
+// existing dispatch shape) but must never authorize `--resume`.
+func (i *Instance) recordedClaudeSessionID() string {
+	if i == nil {
+		return ""
+	}
+	id := strings.TrimSpace(i.ClaudeSessionID)
+	if id != "" && id == i.claudeSessionIDUnverifiedFor {
+		return ""
+	}
+	return id
+}
+
+// resumeIdentityAllowed is THE identity check. Every path that assembles a
+// `--resume` for a Claude conversation routes through it (directly, or via
+// canResumeClaudeSession): restart, start, revive/adopt preludes, fork,
+// account switch and the TUI session picker.
+//
+// candidate is the id that is about to be handed to `--resume`.
+func (i *Instance) resumeIdentityAllowed(candidate string) resumeIdentityDecision {
+	c := strings.TrimSpace(candidate)
+	if c == "" {
+		return resumeIdentityDecision{Reason: "empty_candidate_id"}
+	}
+	recorded := i.recordedClaudeSessionID()
+	if recorded == "" {
+		return resumeIdentityDecision{Reason: "no_recorded_session_id"}
+	}
+	if !claudeSessionIDsMatch(recorded, c) {
+		return resumeIdentityDecision{Reason: "identity_mismatch"}
+	}
+	return resumeIdentityDecision{Allow: true, Reason: "identity_verified"}
+}
+
+// logResumeRefusal emits the loud, grep-stable refusal record. Resuming the
+// wrong conversation is silent by nature — the pane simply comes up as some
+// other session — so the refusal must be visible in the log even though the
+// user-visible effect (a fresh session) looks unremarkable.
+func (i *Instance) logResumeRefusal(candidate, reason string) {
+	sessionLog.Warn("resume refused: id="+candidate+" reason="+reason,
+		slog.String("instance_id", i.ID),
+		slog.String("title", i.Title),
+		slog.String("candidate_session_id", candidate),
+		slog.String("recorded_session_id", i.recordedClaudeSessionID()),
+		slog.String("path", i.ProjectPath),
+		slog.String("reason", reason),
+		slog.String("action", "start_fresh"),
+	)
+}
+
+// canResumeClaudeSession is the single resume-time chokepoint: it answers
+// "may this instance be started with `--resume <sessionID>`?".
+//
+// Layer 1 (this change, #1815): identity — the id must be this instance's own
+// recorded conversation id.
+// Layer 2 (sessionHasConversationData, hardened by #1788): the transcript must
+// exist AND live in a project directory `claude --resume` can actually reach
+// from this instance's working dir.
+//
+// Callers must not skip straight to sessionHasConversationData when deciding
+// between --resume and --session-id; that function also serves bind-quality
+// gates (hook/tmux rebinding) where the question is "does this id have any
+// conversation data", not "may we resume it".
+func canResumeClaudeSession(inst *Instance, sessionID string) bool {
+	if inst == nil {
+		return false
+	}
+	if decision := inst.resumeIdentityAllowed(sessionID); !decision.Allow {
+		inst.logResumeRefusal(sessionID, decision.Reason)
+		return false
+	}
+	return sessionHasConversationData(inst, sessionID)
+}
+
+// ResumeIdentityAllowed exposes the identity half of the chokepoint to
+// callers outside this package (the TUI session picker) that must not apply
+// the conversation-data heuristics. It logs its own refusals, so a caller
+// only needs to act on the boolean; the reason is returned for messaging.
+func ResumeIdentityAllowed(inst *Instance, sessionID string) (bool, string) {
+	if inst == nil {
+		return false, "nil_instance"
+	}
+	decision := inst.resumeIdentityAllowed(sessionID)
+	if !decision.Allow {
+		inst.logResumeRefusal(sessionID, decision.Reason)
+	}
+	return decision.Allow, decision.Reason
+}
+
+// NewClaudeSessionUUID mints a fresh conversation id. Used when the guard
+// refuses a resume: the refused id belongs to (or may belong to) another
+// session, so it must not be reused via `--session-id` either.
+func NewClaudeSessionUUID() string { return generateUUID() }
+
+// adoptDiscoveredClaudeSessionID records an id obtained from mtime-based disk
+// discovery. The id is marked UNVERIFIED: it is a hint about which transcript
+// exists in this directory, never proof of ownership.
+func (i *Instance) adoptDiscoveredClaudeSessionID(uuid string) {
+	i.ClaudeSessionID = uuid
+	i.claudeSessionIDUnverifiedFor = strings.TrimSpace(uuid)
+}
+
+// AdoptDiscoveredClaudeSessionID is the exported form for callers outside
+// this package that resolve a conversation id by scanning disk (the
+// account-switch command, which locates "the newest conversation in this
+// project dir" when the session carries no recorded id).
+func AdoptDiscoveredClaudeSessionID(inst *Instance, uuid string) {
+	if inst == nil {
+		return
+	}
+	inst.adoptDiscoveredClaudeSessionID(uuid)
+}
+
+// markClaudeSessionIDVerified records that the current ClaudeSessionID came
+// from a source that identifies THIS session: the tmux environment of its own
+// pane, a hook payload it owns, an explicit `--session-id` in its own command,
+// or an id this process minted for it.
+func (i *Instance) markClaudeSessionIDVerified() {
+	i.claudeSessionIDUnverifiedFor = ""
+}
+
+// replaceRefusedClaudeSessionID mints and records a fresh conversation id
+// after the guard refused a resume, so the session starts clean instead of
+// claiming an id that may belong to another session (a shared id also makes
+// the duplicate sweeper kill one of the pair).
+func (i *Instance) replaceRefusedClaudeSessionID() string {
+	fresh := NewClaudeSessionUUID()
+	i.ClaudeSessionID = fresh
+	i.markClaudeSessionIDVerified()
+	return fresh
+}

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -102,7 +102,13 @@ func (i *Instance) recordedClaudeSessionID() string {
 		return ""
 	}
 	id := strings.TrimSpace(i.ClaudeSessionID)
-	if id == "" || i.claudeSessionIDsFromDiskScan[id] {
+	if id == "" {
+		return ""
+	}
+	i.claudeSessionIDsFromDiskScanMu.Lock()
+	tainted := i.claudeSessionIDsFromDiskScan[id]
+	i.claudeSessionIDsFromDiskScanMu.Unlock()
+	if tainted {
 		return ""
 	}
 	return id
@@ -214,6 +220,8 @@ func (i *Instance) markClaudeSessionIDFromDiskScan(uuid string) {
 	if id == "" {
 		return
 	}
+	i.claudeSessionIDsFromDiskScanMu.Lock()
+	defer i.claudeSessionIDsFromDiskScanMu.Unlock()
 	if i.claudeSessionIDsFromDiskScan == nil {
 		i.claudeSessionIDsFromDiskScan = map[string]bool{}
 	}
@@ -225,7 +233,10 @@ func (i *Instance) markClaudeSessionIDFromDiskScan(uuid string) {
 // pane, a hook payload it owns, an explicit `--session-id` in its own command,
 // or an id this process minted for it.
 func (i *Instance) markClaudeSessionIDVerified() {
-	delete(i.claudeSessionIDsFromDiskScan, strings.TrimSpace(i.ClaudeSessionID))
+	id := strings.TrimSpace(i.ClaudeSessionID)
+	i.claudeSessionIDsFromDiskScanMu.Lock()
+	delete(i.claudeSessionIDsFromDiskScan, id)
+	i.claudeSessionIDsFromDiskScanMu.Unlock()
 }
 
 // noteClaudeSessionIDFromOwnPane records a WEAK vouch: the id was read back
@@ -241,7 +252,13 @@ func (i *Instance) markClaudeSessionIDVerified() {
 // and never spawned, the pane cannot legitimately hold one.
 func (i *Instance) noteClaudeSessionIDFromOwnPane() {
 	id := strings.TrimSpace(i.ClaudeSessionID)
-	if id == "" || i.claudeSessionIDsFromDiskScan[id] {
+	if id == "" {
+		return
+	}
+	i.claudeSessionIDsFromDiskScanMu.Lock()
+	tainted := i.claudeSessionIDsFromDiskScan[id]
+	i.claudeSessionIDsFromDiskScanMu.Unlock()
+	if tainted {
 		return
 	}
 	i.markClaudeSessionIDVerified()

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -47,7 +47,13 @@ import (
 // `--resume` ids by prefix, so an operator-supplied or CLI-echoed prefix is a
 // legitimate spelling of the same id — but a prefix short enough to collide
 // across unrelated UUIDs is not identity evidence.
-const minResumeIDPrefixLen = 8
+//
+// 16 hex characters (the UUID's first two groups, ~64 bits) is the floor. The
+// obvious 8 is only 32 bits: a neighbouring transcript sharing eight leading
+// hex characters would pass, and the whole point of this guard is that a
+// neighbouring transcript must not pass. Nothing legitimate abbreviates a
+// conversation id below two groups.
+const minResumeIDPrefixLen = 16
 
 // claudeSessionIDsMatch reports whether candidate denotes the same
 // conversation as recorded. Exact match, or either value being a
@@ -81,6 +87,11 @@ type resumeIdentityDecision struct {
 // recordedClaudeSessionID returns the conversation id this instance is known
 // to OWN, or "" when no such id is recorded.
 //
+// The suspicion is keyed to the VALUE and never expires on its own: once an id
+// has been produced by a disk scan, no later writer can launder it into
+// ownership by re-assigning it; only an explicit vouch from a source that
+// identifies this session clears it.
+//
 // An id populated by disk discovery is deliberately NOT recorded ownership:
 // discovery picks the newest transcript filed under the working directory,
 // which in a shared directory is somebody else's. Such an id is usable as a
@@ -91,7 +102,7 @@ func (i *Instance) recordedClaudeSessionID() string {
 		return ""
 	}
 	id := strings.TrimSpace(i.ClaudeSessionID)
-	if id != "" && id == i.claudeSessionIDUnverifiedFor {
+	if id == "" || i.claudeSessionIDsFromDiskScan[id] {
 		return ""
 	}
 	return id
@@ -190,18 +201,19 @@ func NewClaudeSessionUUID() string { return generateUUID() }
 // exists in this directory, never proof of ownership.
 func (i *Instance) adoptDiscoveredClaudeSessionID(uuid string) {
 	i.ClaudeSessionID = uuid
-	i.claudeSessionIDUnverifiedFor = strings.TrimSpace(uuid)
+	i.markClaudeSessionIDFromDiskScan(uuid)
 }
 
-// AdoptDiscoveredClaudeSessionID is the exported form for callers outside
-// this package that resolve a conversation id by scanning disk (the
-// account-switch command, which locates "the newest conversation in this
-// project dir" when the session carries no recorded id).
-func AdoptDiscoveredClaudeSessionID(inst *Instance, uuid string) {
-	if inst == nil {
+// markClaudeSessionIDFromDiskScan records that uuid came from a disk scan.
+func (i *Instance) markClaudeSessionIDFromDiskScan(uuid string) {
+	id := strings.TrimSpace(uuid)
+	if id == "" {
 		return
 	}
-	inst.adoptDiscoveredClaudeSessionID(uuid)
+	if i.claudeSessionIDsFromDiskScan == nil {
+		i.claudeSessionIDsFromDiskScan = map[string]bool{}
+	}
+	i.claudeSessionIDsFromDiskScan[id] = true
 }
 
 // markClaudeSessionIDVerified records that the current ClaudeSessionID came
@@ -209,7 +221,19 @@ func AdoptDiscoveredClaudeSessionID(inst *Instance, uuid string) {
 // pane, a hook payload it owns, an explicit `--session-id` in its own command,
 // or an id this process minted for it.
 func (i *Instance) markClaudeSessionIDVerified() {
-	i.claudeSessionIDUnverifiedFor = ""
+	delete(i.claudeSessionIDsFromDiskScan, strings.TrimSpace(i.ClaudeSessionID))
+}
+
+// MarkClaudeSessionIDVerified is the exported form, for the CLI and TUI
+// writers that assign an id from a source identifying THIS session (an
+// operator's explicit --resume-session / --session-id, a picked conversation,
+// an id the command just minted). Calling it is what clears an earlier
+// disk-scan suspicion on that value.
+func MarkClaudeSessionIDVerified(inst *Instance) {
+	if inst == nil {
+		return
+	}
+	inst.markClaudeSessionIDVerified()
 }
 
 // replaceRefusedClaudeSessionID mints and records a fresh conversation id

--- a/internal/session/resume_identity_persist.go
+++ b/internal/session/resume_identity_persist.go
@@ -21,12 +21,20 @@ import "encoding/json"
 const toolDataClaudeSessionUnverifiedKey = "claude_session_id_unverified"
 
 // WriteClaudeSessionUnverifiedToToolData merges the taint flag into a
-// tool_data blob. false removes the key, keeping the blob byte-identical to a
-// pre-#1815 row so downgrades stay clean.
+// tool_data blob. false writes the key explicitly rather than deleting it,
+// keeping the write idempotent (see the comment below); a legacy row with no
+// key at all still reads as "not tainted" via ReadClaudeSessionUnverifiedFromToolData.
 func WriteClaudeSessionUnverifiedToToolData(td json.RawMessage, unverified bool) json.RawMessage {
 	m := map[string]json.RawMessage{}
 	if len(td) > 0 {
-		_ = json.Unmarshal(td, &m)
+		if err := json.Unmarshal(td, &m); err != nil {
+			// Malformed or non-object blob: leave it untouched rather than
+			// silently replacing every other persisted tool_data key
+			// (claude_session_id, sandbox, extra_args, plugins, ...) with a
+			// blob containing only the taint marker (CodeRabbit finding on
+			// #1830).
+			return td
+		}
 	}
 	// The key is written EXPLICITLY in both directions, never deleted.
 	// MergeToolDataExtras preserves keys absent from the replacement blob, so
@@ -37,7 +45,10 @@ func WriteClaudeSessionUnverifiedToToolData(td json.RawMessage, unverified bool)
 	} else {
 		m[toolDataClaudeSessionUnverifiedKey] = json.RawMessage("false")
 	}
-	out, _ := json.Marshal(m)
+	out, err := json.Marshal(m)
+	if err != nil {
+		return td
+	}
 	return out
 }
 

--- a/internal/session/resume_identity_persist.go
+++ b/internal/session/resume_identity_persist.go
@@ -62,6 +62,8 @@ func (i *Instance) claudeSessionIDIsUnverified() bool {
 	if i == nil || i.ClaudeSessionID == "" {
 		return false
 	}
+	i.claudeSessionIDsFromDiskScanMu.Lock()
+	defer i.claudeSessionIDsFromDiskScanMu.Unlock()
 	return i.claudeSessionIDsFromDiskScan[i.ClaudeSessionID]
 }
 

--- a/internal/session/resume_identity_persist.go
+++ b/internal/session/resume_identity_persist.go
@@ -1,0 +1,71 @@
+package session
+
+import "encoding/json"
+
+// Persistence of the resume-identity taint (#1815).
+//
+// The in-memory taint alone was bypassable: a writer that saves a discovered
+// conversation id WITHOUT going through the resume builder (`switch-account
+// --no-restart` is the plain example) puts an unverified id on disk, and the
+// next process to load it sees a plain recorded id and happily resumes it.
+// That is the incident's own shape — one step diagnoses a problem, a later
+// step acts as if it had not.
+//
+// So the taint travels with the id. It rides the tool_data extras zone,
+// outside the positional MarshalToolData signature, exactly like #1143's
+// idle_timeout_secs: MergeToolDataExtras preserves unknown keys across
+// INSERT OR REPLACE, so a row written by a new binary survives a round-trip
+// through an old one and vice versa. A legacy row simply has no key, which
+// reads as "not tainted" — the pre-#1815 status quo for ids that were already
+// on disk.
+const toolDataClaudeSessionUnverifiedKey = "claude_session_id_unverified"
+
+// WriteClaudeSessionUnverifiedToToolData merges the taint flag into a
+// tool_data blob. false removes the key, keeping the blob byte-identical to a
+// pre-#1815 row so downgrades stay clean.
+func WriteClaudeSessionUnverifiedToToolData(td json.RawMessage, unverified bool) json.RawMessage {
+	m := map[string]json.RawMessage{}
+	if len(td) > 0 {
+		_ = json.Unmarshal(td, &m)
+	}
+	if unverified {
+		m[toolDataClaudeSessionUnverifiedKey] = json.RawMessage("true")
+	} else {
+		delete(m, toolDataClaudeSessionUnverifiedKey)
+	}
+	out, _ := json.Marshal(m)
+	return out
+}
+
+// ReadClaudeSessionUnverifiedFromToolData extracts the taint flag. Missing,
+// malformed or legacy rows read as false.
+func ReadClaudeSessionUnverifiedFromToolData(td json.RawMessage) bool {
+	if len(td) == 0 {
+		return false
+	}
+	var blob struct {
+		Unverified bool `json:"claude_session_id_unverified"`
+	}
+	_ = json.Unmarshal(td, &blob)
+	return blob.Unverified
+}
+
+// claudeSessionIDIsUnverified reports whether the instance's CURRENT
+// conversation id is the tainted one. This is the value that gets persisted;
+// keeping it a derived predicate (rather than a second stored bool) means the
+// flag can never disagree with the id it describes.
+func (i *Instance) claudeSessionIDIsUnverified() bool {
+	if i == nil || i.ClaudeSessionID == "" {
+		return false
+	}
+	return i.ClaudeSessionID == i.claudeSessionIDUnverifiedFor
+}
+
+// restoreClaudeSessionTaint re-applies a persisted taint at load time, so a
+// process restart cannot launder an unverified id into a recorded one.
+func restoreClaudeSessionTaint(claudeSessionID string, unverified bool) string {
+	if !unverified {
+		return ""
+	}
+	return claudeSessionID
+}

--- a/internal/session/resume_identity_persist.go
+++ b/internal/session/resume_identity_persist.go
@@ -58,14 +58,19 @@ func (i *Instance) claudeSessionIDIsUnverified() bool {
 	if i == nil || i.ClaudeSessionID == "" {
 		return false
 	}
-	return i.ClaudeSessionID == i.claudeSessionIDUnverifiedFor
+	return i.claudeSessionIDsFromDiskScan[i.ClaudeSessionID]
 }
 
-// restoreClaudeSessionTaint re-applies a persisted taint at load time, so a
-// process restart cannot launder an unverified id into a recorded one.
-func restoreClaudeSessionTaint(claudeSessionID string, unverified bool) string {
-	if !unverified {
-		return ""
+// restoreClaudeSessionVerification maps the persisted NEGATIVE marker back
+// onto the in-memory POSITIVE state at load time, so a process restart cannot
+// launder an unverified id into a recorded one.
+//
+// The marker is negative on purpose: a row written before #1815 carries no
+// key and must keep resuming exactly as it did — a positive-on-disk model
+// would refuse every pre-existing session once, on upgrade, for nothing.
+func restoreClaudeSessionVerification(claudeSessionID string, unverified bool) map[string]bool {
+	if !unverified || claudeSessionID == "" {
+		return nil
 	}
-	return claudeSessionID
+	return map[string]bool{claudeSessionID: true}
 }

--- a/internal/session/resume_identity_persist.go
+++ b/internal/session/resume_identity_persist.go
@@ -28,10 +28,14 @@ func WriteClaudeSessionUnverifiedToToolData(td json.RawMessage, unverified bool)
 	if len(td) > 0 {
 		_ = json.Unmarshal(td, &m)
 	}
+	// The key is written EXPLICITLY in both directions, never deleted.
+	// MergeToolDataExtras preserves keys absent from the replacement blob, so
+	// a delete would let a stale `true` merge itself back on the next save and
+	// strand a since-verified session as permanently unresumable.
 	if unverified {
 		m[toolDataClaudeSessionUnverifiedKey] = json.RawMessage("true")
 	} else {
-		delete(m, toolDataClaudeSessionUnverifiedKey)
+		m[toolDataClaudeSessionUnverifiedKey] = json.RawMessage("false")
 	}
 	out, _ := json.Marshal(m)
 	return out

--- a/internal/session/resume_identity_test.go
+++ b/internal/session/resume_identity_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
 
 // Resume-identity guard suite (#1815).
@@ -401,5 +403,132 @@ func TestResumeGuard_ContinueModePrefersOwnConversation(t *testing.T) {
 	}
 	if !strings.Contains(cmd, "--resume "+ownID) {
 		t.Fatalf("#1815: continue mode must resume this session's own conversation.\ncommand: %s", cmd)
+	}
+}
+
+// TestResumeGuard_TaintSurvivesClearedIDSave pins a review finding on #1830:
+// the persisted taint was silently stripped while the tainted id itself
+// survived, defeating the PR's own persistence guarantee.
+//
+// Failure shape: an instance holds a disk-scanned (tainted) id A on disk.
+// Something clears the in-memory ClaudeSessionID to "" and saves (e.g.
+// RestartFresh's clearSessionBindingForFreshStart, or the stale-snapshot
+// race the sticky merge rule exists for). claude_session_id is a STICKY
+// extras key, so the OLD row's id A is carried forward across that save
+// even though the new blob omits it. But if the taint marker were written
+// explicitly as `false` whenever the in-memory id is empty (as it read
+// unverified() == false for id==""), that explicit false would win over the
+// old row's `true` in the extras merge -- id A survives, taint erased. A's
+// resume would then be silently authorized on the next load.
+//
+// The fix: instanceToRow must OMIT the taint marker (not write explicit
+// false) when inst.ClaudeSessionID is empty, so it rides along with the
+// same sticky-preserved old id instead of being overwritten.
+func TestResumeGuard_TaintSurvivesClearedIDSave(t *testing.T) {
+	const id = "b2b2b2b2-3333-4444-8555-666666666666"
+
+	// Step 1: instance has a tainted id and is saved -- old row on disk has
+	// claude_session_id=A and claude_session_id_unverified=true.
+	tainted := &Instance{ID: "taint-survive", Tool: "claude"}
+	tainted.adoptDiscoveredClaudeSessionID(id)
+	oldRow, err := instanceToRow(tainted)
+	if err != nil {
+		t.Fatalf("instanceToRow (tainted): %v", err)
+	}
+	if !ReadClaudeSessionUnverifiedFromToolData(oldRow.ToolData) {
+		t.Fatal("setup: the first save must persist the taint")
+	}
+
+	// Step 2: the in-memory id is cleared (e.g. a fresh-start reset) and the
+	// instance is saved again -- the new blob must OMIT the marker.
+	cleared := &Instance{ID: "taint-survive", Tool: "claude"}
+	cleared.ClaudeSessionID = ""
+	newRow, err := instanceToRow(cleared)
+	if err != nil {
+		t.Fatalf("instanceToRow (cleared): %v", err)
+	}
+	if strings.Contains(string(newRow.ToolData), toolDataClaudeSessionUnverifiedKey) {
+		t.Fatalf("a save with an empty ClaudeSessionID must OMIT the taint marker, not write it explicitly: %s", newRow.ToolData)
+	}
+
+	// Step 3: simulate the statedb extras merge that runs on every SaveInstance.
+	merged := statedb.MergeToolDataExtras(oldRow.ToolData, newRow.ToolData)
+	if !ReadClaudeSessionUnverifiedFromToolData(merged) {
+		t.Fatalf("the taint must survive a save whose in-memory id was cleared, or the sticky-preserved id %q would read back as verified: merged=%s", id, merged)
+	}
+}
+
+// TestResumeGuard_LiveHookConfirmationClearsTaint pins a review finding on
+// #1830: when a live hook payload reports an id that EQUALS this instance's
+// already-recorded (but disk-scan-tainted) id, that equality branch was
+// treated as a no-op and skipped the vouch. That is backwards -- a live
+// process's own hook confirming its own id is the STRONGEST available
+// evidence, and failing to clear the taint on it meant a correctly-recovered
+// solo session (its own transcript was the only one in its cwd) stayed
+// permanently unresumable.
+func TestResumeGuard_LiveHookConfirmationClearsTaint(t *testing.T) {
+	const id = "c3c3c3c3-4444-4555-8666-777777777777"
+
+	inst := &Instance{ID: "hook-confirms-taint", Tool: "claude"}
+	inst.adoptDiscoveredClaudeSessionID(id)
+	if !inst.claudeSessionIDIsUnverified() {
+		t.Fatal("setup: id must start tainted")
+	}
+
+	// A hook payload whose session id equals the already-recorded (tainted)
+	// id must clear the taint, not leave it in place.
+	inst.hookSessionID = id
+	if inst.hookSessionID != inst.ClaudeSessionID {
+		t.Fatal("setup: hookSessionID must equal ClaudeSessionID to hit the equality branch")
+	}
+	inst.markClaudeSessionIDVerified() // what the equality branch must call
+
+	if inst.claudeSessionIDIsUnverified() {
+		t.Fatal("a live hook payload confirming this instance's own recorded id must clear the disk-scan taint")
+	}
+	if decision := inst.resumeIdentityAllowed(id); !decision.Allow {
+		t.Fatalf("after hook confirmation the id must be resumable, got refused: %s", decision.Reason)
+	}
+}
+
+// TestResumeGuard_ForkResumeIDNeverAdoptedAsOwnIdentity pins a review
+// finding on #1830: adoptExplicitClaudeSessionID's `--resume` ownership
+// fallback (added so a custom command carrying `claude --resume <uuid>`
+// still meets the chokepoint) could adopt a FOREIGN conversation id and mark
+// it verified when the command matched the fork builder's shape --
+// `claude --session-id "$SESSION_ID" --resume <parent-uuid> --fork-session`
+// -- because the `--session-id` extraction bails on the first
+// non-bare-UUID argument (here, an unexpanded shell variable) without
+// scanning further, and the code fell through to treating the fork's
+// `--resume <parent-uuid>` as this session's own declared identity. That is
+// precisely the child-adopts-parent's-conversation shape #1815 exists to
+// stop.
+func TestResumeGuard_ForkResumeIDNeverAdoptedAsOwnIdentity(t *testing.T) {
+	const parentID = "d4d4d4d4-5555-4666-8777-888888888888"
+
+	inst := &Instance{
+		ID:      "fork-resume-guard",
+		Tool:    "claude",
+		Command: `claude --session-id "$SESSION_ID" --resume ` + parentID + ` --fork-session`,
+	}
+	if inst.adoptExplicitClaudeSessionID("test") {
+		t.Fatalf("a command shaped like the fork builder must not be treated as an explicit ownership declaration; adopted id=%q", inst.ClaudeSessionID)
+	}
+	if inst.ClaudeSessionID == parentID {
+		t.Fatal("the fork source's (parent's) conversation id must never be adopted as this instance's own identity")
+	}
+
+	// Sanity: a genuine standalone `claude --resume <uuid>` (no fork
+	// markers) must still be honored -- this guard must not regress that.
+	standalone := &Instance{
+		ID:      "standalone-resume",
+		Tool:    "claude",
+		Command: `claude --resume ` + parentID,
+	}
+	if !standalone.adoptExplicitClaudeSessionID("test") {
+		t.Fatal("a standalone --resume <uuid> command (no --session-id/--fork-session) must still be adopted")
+	}
+	if standalone.ClaudeSessionID != parentID {
+		t.Fatalf("standalone ClaudeSessionID = %q, want %q", standalone.ClaudeSessionID, parentID)
 	}
 }

--- a/internal/session/resume_identity_test.go
+++ b/internal/session/resume_identity_test.go
@@ -145,7 +145,7 @@ func TestResumeGuard_MatchingIDStillResumes(t *testing.T) {
 	if !canResumeClaudeSession(inst, ownID) {
 		t.Fatal("exact id match must resume")
 	}
-	if decision := inst.resumeIdentityAllowed(ownID[:8]); !decision.Allow {
+	if decision := inst.resumeIdentityAllowed(ownID[:16]); !decision.Allow {
 		t.Fatalf("id PREFIX form must be accepted (the CLI resolves --resume by prefix); reason=%s", decision.Reason)
 	}
 
@@ -167,9 +167,9 @@ func TestClaudeSessionIDsMatch(t *testing.T) {
 		{"exact", full, full, true},
 		{"case insensitive", full, strings.ToUpper(full), true},
 		{"whitespace trimmed", full, "  " + full + "\n", true},
-		{"candidate is prefix", full, full[:8], true},
-		{"recorded is prefix", full[:12], full, true},
-		{"prefix too short", full, full[:4], false},
+		{"candidate is prefix", full, full[:16], true},
+		{"recorded is prefix", full[:20], full, true},
+		{"prefix too short", full, full[:8], false},
 		{"different ids", full, "99999999-9999-4999-8999-999999999999", false},
 		{"empty recorded", "", full, false},
 		{"empty candidate", full, "", false},
@@ -202,14 +202,22 @@ func TestResumeGuard_VerifiedSourcesClearDiscoveryTaint(t *testing.T) {
 		t.Fatalf("a verified id must be recorded; got %q", inst.recordedClaudeSessionID())
 	}
 
-	// A LATER assignment of a different id is verified by default — the taint
-	// is bound to the discovered value, so it can never go stale onto an
-	// unrelated id and refuse a legitimate resume.
+	// Suspicion is keyed to the VALUE and does not expire: a writer cannot
+	// launder a scanned id by moving the field away and back again. This is
+	// the property that makes the guard unbypassable by re-assignment.
 	inst.adoptDiscoveredClaudeSessionID(id)
-	const boundByHook = "eeeeeeee-5555-4666-8777-888888888888"
-	inst.ClaudeSessionID = boundByHook
-	if inst.recordedClaudeSessionID() != boundByHook {
-		t.Fatalf("id replaced after a discovery must not inherit the taint; got %q", inst.recordedClaudeSessionID())
+	const boundElsewhere = "eeeeeeee-5555-4666-8777-888888888888"
+	inst.ClaudeSessionID = boundElsewhere
+	if inst.recordedClaudeSessionID() != boundElsewhere {
+		t.Fatalf("an id that never came from a disk scan is ownable; got %q", inst.recordedClaudeSessionID())
+	}
+	inst.ClaudeSessionID = id // back to the scanned value
+	if got := inst.recordedClaudeSessionID(); got != "" {
+		t.Fatalf("re-assigning a previously scanned id must NOT launder it into ownership; got %q", got)
+	}
+	inst.markClaudeSessionIDVerified()
+	if inst.recordedClaudeSessionID() != id {
+		t.Fatalf("an explicit vouch must clear the suspicion; got %q", inst.recordedClaudeSessionID())
 	}
 }
 
@@ -259,7 +267,7 @@ func TestResumeGuard_TaintIsPersisted(t *testing.T) {
 		ID:                           "persist-taint",
 		Tool:                         "claude",
 		ClaudeSessionID:              id,
-		claudeSessionIDUnverifiedFor: restoreClaudeSessionTaint(id, true),
+		claudeSessionIDsFromDiskScan: restoreClaudeSessionVerification(id, true),
 	}
 	if got := reloaded.recordedClaudeSessionID(); got != "" {
 		t.Fatalf("a reloaded tainted id must not count as recorded; got %q", got)
@@ -267,7 +275,47 @@ func TestResumeGuard_TaintIsPersisted(t *testing.T) {
 	if decision := reloaded.resumeIdentityAllowed(id); decision.Allow {
 		t.Fatal("a reloaded tainted id must still be refused for --resume")
 	}
-	if restoreClaudeSessionTaint(id, false) != "" {
-		t.Fatal("an untainted row must load clean")
+	if restoreClaudeSessionVerification(id, false) != nil {
+		t.Fatal("a pre-#1815 / untainted row must load clean so it keeps resuming")
+	}
+}
+
+// TestResumeGuard_MigrateFallbackNeverLaunders pins the adversarial-review
+// finding: MigrateConversationFrom's "newest conversation in the project dir"
+// fallback picks a DIFFERENT conversation by mtime, and that is equally a
+// guess whether or not a stale id was stored. Marking it only in the
+// empty-id case let a stale-id session adopt (and resume) a neighbour's
+// transcript.
+func TestResumeGuard_MigrateFallbackNeverLaunders(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+	inst.Tool = "claude"
+
+	src, dst := filepath.Join(home, "src-cfg"), filepath.Join(home, "dst-cfg")
+	projDir := filepath.Join(src, "projects", ConvertToClaudeDirName(inst.ProjectPath))
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir src project dir: %v", err)
+	}
+	const neighbourID = "a1a1a1a1-7777-4888-8999-aaaaaaaaaaaa"
+	body := `{"type":"user","sessionId":"` + neighbourID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(filepath.Join(projDir, neighbourID+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write neighbour transcript: %v", err)
+	}
+
+	// A STALE stored id: its file is gone, so the fallback fires.
+	inst.ClaudeSessionID = "deadbeef-0000-4000-8000-000000000000"
+	inst.markClaudeSessionIDVerified()
+
+	if _, err := MigrateConversationFrom(inst, src, dst); err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	if inst.ClaudeSessionID != neighbourID {
+		t.Fatalf("precondition: the fallback should have adopted the newest transcript; got %q", inst.ClaudeSessionID)
+	}
+	if got := inst.recordedClaudeSessionID(); got != "" {
+		t.Fatalf("a mtime-chosen replacement is not owned just because an older id existed; recorded = %q", got)
+	}
+	if decision := inst.resumeIdentityAllowed(neighbourID); decision.Allow {
+		t.Fatal("the migrated-by-guess conversation must not authorize --resume")
 	}
 }

--- a/internal/session/resume_identity_test.go
+++ b/internal/session/resume_identity_test.go
@@ -234,14 +234,16 @@ func TestResumeGuard_TaintIsPersisted(t *testing.T) {
 	if !ReadClaudeSessionUnverifiedFromToolData(blob) {
 		t.Fatal("an unverified id must round-trip as unverified")
 	}
-	// Clearing removes the key, so a verified row is byte-shape-identical to a
-	// pre-#1815 row (clean downgrades).
+	// Clearing writes an explicit false rather than deleting the key: the
+	// extras merge preserves keys missing from the replacement blob, so a
+	// delete would let a stale `true` merge back and strand a since-verified
+	// session as permanently unresumable.
 	cleared := WriteClaudeSessionUnverifiedToToolData(blob, false)
 	if ReadClaudeSessionUnverifiedFromToolData(cleared) {
-		t.Fatal("clearing the taint must remove it from the blob")
+		t.Fatal("clearing the taint must read back as verified")
 	}
-	if strings.Contains(string(cleared), toolDataClaudeSessionUnverifiedKey) {
-		t.Fatalf("cleared blob must not carry the key: %s", cleared)
+	if !strings.Contains(string(cleared), toolDataClaudeSessionUnverifiedKey) {
+		t.Fatalf("the cleared verdict must be written explicitly, not deleted: %s", cleared)
 	}
 	// A legacy row has no key at all and reads as verified — the pre-#1815
 	// status quo for ids already on disk.
@@ -317,5 +319,87 @@ func TestResumeGuard_MigrateFallbackNeverLaunders(t *testing.T) {
 	}
 	if decision := inst.resumeIdentityAllowed(neighbourID); decision.Allow {
 		t.Fatal("the migrated-by-guess conversation must not authorize --resume")
+	}
+}
+
+// TestResumeGuard_TmuxCannotLaunderAScannedID pins the laundering loop the
+// adversarial pass found: agent-deck writes CLAUDE_SESSION_ID into the pane
+// and reads it back as an ownership signal, so publishing a disk-scanned id
+// would let it return as "verified" on the next poll.
+func TestResumeGuard_TmuxCannotLaunderAScannedID(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const scanned = "b2b2b2b2-8888-4999-8aaa-bbbbbbbbbbbb"
+	inst.adoptDiscoveredClaudeSessionID(scanned)
+
+	// A pane read must NOT absolve a scanned id...
+	inst.noteClaudeSessionIDFromOwnPane()
+	if got := inst.recordedClaudeSessionID(); got != "" {
+		t.Fatalf("reading our own published value back must not verify it; got %q", got)
+	}
+	// ...while a value no scan produced is ownable through the same path.
+	const minted = "c3c3c3c3-9999-4aaa-8bbb-cccccccccccc"
+	inst.ClaudeSessionID = minted
+	inst.noteClaudeSessionIDFromOwnPane()
+	if inst.recordedClaudeSessionID() != minted {
+		t.Fatalf("a never-scanned id from our own pane is ownable; got %q", inst.recordedClaudeSessionID())
+	}
+	// A source that is not downstream of us still clears the suspicion.
+	inst.ClaudeSessionID = scanned
+	inst.markClaudeSessionIDVerified()
+	if inst.recordedClaudeSessionID() != scanned {
+		t.Fatal("an explicit vouch must still clear a scan suspicion")
+	}
+}
+
+// TestResumeGuard_ExplicitResumeInCommandIsAdopted covers the custom-command
+// bypass: `claude --resume <id>` baked into the session's own command executes
+// verbatim, so the id must be adopted (and owned) rather than left invisible
+// to the chokepoint.
+func TestResumeGuard_ExplicitResumeInCommandIsAdopted(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const explicit = "d4d4d4d4-aaaa-4bbb-8ccc-dddddddddddd"
+	// Pre-existing suspicion on the very value the operator names must clear.
+	inst.adoptDiscoveredClaudeSessionID(explicit)
+	inst.ClaudeSessionID = ""
+	inst.Command = "claude --resume " + explicit + " --model opus"
+
+	if !inst.adoptExplicitClaudeSessionID("test") {
+		t.Fatal("an embedded --resume <uuid> must be adopted as an explicit ownership declaration")
+	}
+	if inst.ClaudeSessionID != explicit {
+		t.Fatalf("adopted id = %q, want %q", inst.ClaudeSessionID, explicit)
+	}
+	if inst.recordedClaudeSessionID() != explicit {
+		t.Fatal("the vouch must apply to the EXPLICIT value, not to whatever id was current before it")
+	}
+}
+
+// TestResumeGuard_ContinueModePrefersOwnConversation pins the `-c` hole:
+// `claude -c` picks the newest conversation in the directory inside the CLI,
+// where this guard cannot see it. With an owned id, resume that instead.
+func TestResumeGuard_ContinueModePrefersOwnConversation(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const ownID = "e5e5e5e5-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	inst.ClaudeSessionID = ownID
+	inst.markClaudeSessionIDVerified()
+
+	opts := NewClaudeOptions(nil)
+	opts.SessionMode = "continue"
+	if err := inst.SetClaudeOptions(opts); err != nil {
+		t.Fatalf("SetClaudeOptions: %v", err)
+	}
+
+	cmd := inst.buildClaudeCommand("claude")
+	if strings.Contains(cmd, " -c") {
+		t.Fatalf("#1815: with an owned conversation id, continue mode must not defer to the CLI's newest-in-dir pick.\ncommand: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--resume "+ownID) {
+		t.Fatalf("#1815: continue mode must resume this session's own conversation.\ncommand: %s", cmd)
 	}
 }

--- a/internal/session/resume_identity_test.go
+++ b/internal/session/resume_identity_test.go
@@ -1,0 +1,214 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Resume-identity guard suite (#1815).
+//
+// Incident shape being pinned: a session whose own conversation id had been
+// lost (an account switch reported "no conversation to migrate, fresh
+// session") was restarted. The restart's disk-discovery prelude returned the
+// newest transcript filed under the working directory — one belonging to a
+// DIFFERENT session — and the restart resumed it. The restarted pane came up
+// as a live second instance of that other session, carrying its context and
+// its authority.
+//
+// Contract: at the moment a `--resume` is assembled, the id must match the
+// session's OWN recorded conversation id. No recorded id, or a mismatch,
+// means start fresh — and the refused id is not reused via --session-id
+// either, since it may belong to another session.
+
+// stageConversation writes a conversation jsonl for sessionID under home's
+// Claude projects dir for projectPath and returns its path.
+func stageConversation(t *testing.T, home, projectPath, sessionID string) string {
+	t.Helper()
+	dir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), projectPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	path := filepath.Join(dir, sessionID+".jsonl")
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hello"}` + "\n" +
+		`{"type":"assistant","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	return path
+}
+
+func newGuardInstance(t *testing.T, home string) *Instance {
+	t.Helper()
+	projectPath := filepath.Join(home, "shared-project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("guard-test", projectPath, "claude")
+	inst.ClaudeSessionID = ""
+	return inst
+}
+
+// TestResumeGuard_DiscoveredForeignTranscriptIsNotResumed is the incident
+// itself: session A has NO recorded conversation id, and disk discovery offers
+// session B's transcript from the shared working directory. The restart must
+// NOT resume B — and must not claim B's id via --session-id either.
+func TestResumeGuard_DiscoveredForeignTranscriptIsNotResumed(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const foreignID = "bbbbbbbb-2222-4333-8444-555555555555"
+	stageConversation(t, home, inst.ProjectPath, foreignID)
+
+	// Restart() implies the session previously ran.
+	inst.ClaudeDetectedAt = time.Now()
+	inst.ensureClaudeSessionIDFromDiskForRestart()
+
+	if inst.ClaudeSessionID != foreignID {
+		t.Fatalf("precondition: discovery should surface the only transcript on disk; got %q", inst.ClaudeSessionID)
+	}
+	if got := inst.recordedClaudeSessionID(); got != "" {
+		t.Fatalf("a discovered id must not count as a RECORDED (owned) id; recordedClaudeSessionID = %q", got)
+	}
+
+	cmd := inst.buildClaudeResumeCommand()
+
+	if strings.Contains(cmd, "--resume") {
+		t.Fatalf("#1815: restart must NOT --resume a transcript this session does not own.\ncommand: %s", cmd)
+	}
+	if strings.Contains(cmd, foreignID) {
+		t.Fatalf("#1815: the refused id belongs to another session and must not be reused via --session-id either.\ncommand: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--session-id ") {
+		t.Fatalf("refusal must start a fresh session via --session-id.\ncommand: %s", cmd)
+	}
+	if inst.ClaudeSessionID == foreignID || inst.ClaudeSessionID == "" {
+		t.Fatalf("instance must carry a freshly minted id after refusal; got %q", inst.ClaudeSessionID)
+	}
+	if inst.recordedClaudeSessionID() != inst.ClaudeSessionID {
+		t.Fatalf("the freshly minted id is this session's own and must be recorded as verified")
+	}
+}
+
+// TestResumeGuard_MissingRecordedUUIDRefuses pins the rule directly: with no
+// recorded conversation id, no candidate may be resumed.
+func TestResumeGuard_MissingRecordedUUIDRefuses(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const candidate = "cccccccc-3333-4444-8555-666666666666"
+	stageConversation(t, home, inst.ProjectPath, candidate)
+	inst.adoptDiscoveredClaudeSessionID(candidate)
+
+	if decision := inst.resumeIdentityAllowed(candidate); decision.Allow {
+		t.Fatalf("resume must be refused when no recorded conversation id exists (reason=%s)", decision.Reason)
+	} else if decision.Reason != "no_recorded_session_id" {
+		t.Fatalf("reason = %q, want no_recorded_session_id", decision.Reason)
+	}
+	if canResumeClaudeSession(inst, candidate) {
+		t.Fatal("chokepoint must refuse even though the transcript exists and has conversation data")
+	}
+}
+
+// TestResumeGuard_IdentityMismatchRefuses covers the other refusal: a recorded
+// id exists, but the candidate about to be resumed is a different conversation.
+func TestResumeGuard_IdentityMismatchRefuses(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const ownID = "11111111-1111-4111-8111-111111111111"
+	const otherID = "99999999-9999-4999-8999-999999999999"
+	stageConversation(t, home, inst.ProjectPath, ownID)
+	stageConversation(t, home, inst.ProjectPath, otherID)
+	inst.ClaudeSessionID = ownID
+
+	if canResumeClaudeSession(inst, otherID) {
+		t.Fatal("#1815: a candidate that is not this session's recorded conversation must be refused")
+	}
+	if !canResumeClaudeSession(inst, ownID) {
+		t.Fatal("the session's own conversation must still resume normally")
+	}
+}
+
+// TestResumeGuard_MatchingIDStillResumes is the no-regression case, including
+// the prefix spelling the Claude CLI accepts.
+func TestResumeGuard_MatchingIDStillResumes(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const ownID = "abcdef01-2345-4678-8abc-def012345678"
+	stageConversation(t, home, inst.ProjectPath, ownID)
+	inst.ClaudeSessionID = ownID
+
+	if !canResumeClaudeSession(inst, ownID) {
+		t.Fatal("exact id match must resume")
+	}
+	if decision := inst.resumeIdentityAllowed(ownID[:8]); !decision.Allow {
+		t.Fatalf("id PREFIX form must be accepted (the CLI resolves --resume by prefix); reason=%s", decision.Reason)
+	}
+
+	cmd := inst.buildClaudeResumeCommand()
+	if !strings.Contains(cmd, "--resume "+ownID) {
+		t.Fatalf("a verified, present conversation must still produce --resume <own id>.\ncommand: %s", cmd)
+	}
+}
+
+// TestClaudeSessionIDsMatch tables the matching rule, including the short
+// prefix that carries too little entropy to be identity evidence.
+func TestClaudeSessionIDsMatch(t *testing.T) {
+	const full = "abcdef01-2345-4678-8abc-def012345678"
+	cases := []struct {
+		name           string
+		recorded, cand string
+		want           bool
+	}{
+		{"exact", full, full, true},
+		{"case insensitive", full, strings.ToUpper(full), true},
+		{"whitespace trimmed", full, "  " + full + "\n", true},
+		{"candidate is prefix", full, full[:8], true},
+		{"recorded is prefix", full[:12], full, true},
+		{"prefix too short", full, full[:4], false},
+		{"different ids", full, "99999999-9999-4999-8999-999999999999", false},
+		{"empty recorded", "", full, false},
+		{"empty candidate", full, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeSessionIDsMatch(tc.recorded, tc.cand); got != tc.want {
+				t.Fatalf("claudeSessionIDsMatch(%q, %q) = %v, want %v", tc.recorded, tc.cand, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResumeGuard_VerifiedSourcesClearDiscoveryTaint: once a source that
+// identifies THIS session confirms the id (own tmux env, own hook payload,
+// explicit --session-id in its own command), the id becomes recorded and
+// resumable again.
+func TestResumeGuard_VerifiedSourcesClearDiscoveryTaint(t *testing.T) {
+	home := isolatedHomeDir(t)
+	inst := newGuardInstance(t, home)
+
+	const id = "dddddddd-4444-4555-8666-777777777777"
+	inst.adoptDiscoveredClaudeSessionID(id)
+	if inst.recordedClaudeSessionID() != "" {
+		t.Fatal("precondition: a discovered id is not recorded ownership")
+	}
+
+	inst.markClaudeSessionIDVerified()
+	if inst.recordedClaudeSessionID() != id {
+		t.Fatalf("a verified id must be recorded; got %q", inst.recordedClaudeSessionID())
+	}
+
+	// A LATER assignment of a different id is verified by default — the taint
+	// is bound to the discovered value, so it can never go stale onto an
+	// unrelated id and refuse a legitimate resume.
+	inst.adoptDiscoveredClaudeSessionID(id)
+	const boundByHook = "eeeeeeee-5555-4666-8777-888888888888"
+	inst.ClaudeSessionID = boundByHook
+	if inst.recordedClaudeSessionID() != boundByHook {
+		t.Fatalf("id replaced after a discovery must not inherit the taint; got %q", inst.recordedClaudeSessionID())
+	}
+}

--- a/internal/session/resume_identity_test.go
+++ b/internal/session/resume_identity_test.go
@@ -212,3 +212,62 @@ func TestResumeGuard_VerifiedSourcesClearDiscoveryTaint(t *testing.T) {
 		t.Fatalf("id replaced after a discovery must not inherit the taint; got %q", inst.recordedClaudeSessionID())
 	}
 }
+
+// TestResumeGuard_TaintIsPersisted covers the bypass that the in-memory-only
+// taint left open: a writer that SAVES a discovered conversation id without
+// ever going through the resume builder (`switch-account --no-restart` is the
+// plain case) would put an unverified id on disk, and the next process to load
+// it would see a plain recorded id and resume it. The taint therefore rides
+// the tool_data blob alongside the id.
+func TestResumeGuard_TaintIsPersisted(t *testing.T) {
+	const id = "f0f0f0f0-6666-4777-8888-999999999999"
+
+	blob := WriteClaudeSessionUnverifiedToToolData(nil, true)
+	if !ReadClaudeSessionUnverifiedFromToolData(blob) {
+		t.Fatal("an unverified id must round-trip as unverified")
+	}
+	// Clearing removes the key, so a verified row is byte-shape-identical to a
+	// pre-#1815 row (clean downgrades).
+	cleared := WriteClaudeSessionUnverifiedToToolData(blob, false)
+	if ReadClaudeSessionUnverifiedFromToolData(cleared) {
+		t.Fatal("clearing the taint must remove it from the blob")
+	}
+	if strings.Contains(string(cleared), toolDataClaudeSessionUnverifiedKey) {
+		t.Fatalf("cleared blob must not carry the key: %s", cleared)
+	}
+	// A legacy row has no key at all and reads as verified — the pre-#1815
+	// status quo for ids already on disk.
+	if ReadClaudeSessionUnverifiedFromToolData([]byte(`{"claude_session_id":"x"}`)) {
+		t.Fatal("a legacy row must not read as tainted")
+	}
+
+	// Write side: the flag is derived from the instance, so it can never
+	// disagree with the id it describes.
+	inst := &Instance{ID: "persist-taint", Tool: "claude"}
+	inst.adoptDiscoveredClaudeSessionID(id)
+	if !inst.claudeSessionIDIsUnverified() {
+		t.Fatal("a discovered id must be persisted as unverified")
+	}
+	inst.markClaudeSessionIDVerified()
+	if inst.claudeSessionIDIsUnverified() {
+		t.Fatal("a verified id must be persisted as verified")
+	}
+
+	// Load side: a persisted taint is re-applied, so a process restart cannot
+	// launder an unverified id into a resumable one.
+	reloaded := &Instance{
+		ID:                           "persist-taint",
+		Tool:                         "claude",
+		ClaudeSessionID:              id,
+		claudeSessionIDUnverifiedFor: restoreClaudeSessionTaint(id, true),
+	}
+	if got := reloaded.recordedClaudeSessionID(); got != "" {
+		t.Fatalf("a reloaded tainted id must not count as recorded; got %q", got)
+	}
+	if decision := reloaded.resumeIdentityAllowed(id); decision.Allow {
+		t.Fatal("a reloaded tainted id must still be refused for --resume")
+	}
+	if restoreClaudeSessionTaint(id, false) != "" {
+		t.Fatal("an untainted row must load clean")
+	}
+}

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -1255,6 +1255,17 @@ func writeCustomWrapperScript(t *testing.T, home string) string {
 	return wrapperPath
 }
 
+// TestPersistence_CustomCommandResumesFromLatestJSONL pinned REQ-7's
+// discovery-resume: a custom-wrapper session that lost its conversation id
+// resumed the newest transcript in its working directory.
+//
+// CONTRACT NARROWED BY #1815. Mtime order does not establish ownership: the
+// newest transcript in a shared working directory is just as likely to belong
+// to a neighbouring session, and resuming it brings that session's context
+// and authority up in this pane (the incident #1815 reports). Discovery still
+// runs and still write-throughs a candidate id — what changed is that the
+// candidate no longer AUTHORIZES --resume. The Start dispatch keeps its shape
+// (claude spawn path, explicit session id) and starts fresh.
 func TestPersistence_CustomCommandResumesFromLatestJSONL(t *testing.T) {
 	requireTmux(t)
 	home := isolatedHomeDir(t)
@@ -1299,20 +1310,25 @@ func TestPersistence_CustomCommandResumesFromLatestJSONL(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	// PERSIST-12 write-through check fires FIRST so the RED diagnostic is
-	// unambiguous even when the pre-fix dispatch never invokes the stub.
-	if inst.ClaudeSessionID != newerUUID {
-		t.Fatalf("TEST-09 PERSIST-12 RED: after Start() with Command=%q, empty ClaudeSessionID, and TWO JSONLs (%s older, %s newer) under %s, inst.ClaudeSessionID=%q, want %q (newer JSONL UUID). The Phase 5 helper must mutate i.ClaudeSessionID before spawn so subsequent Restart() takes the Phase 3 fast path. This is the 2026-04-15 incident REQ-7 root cause: Start()'s empty-ID branch at instance.go:1895-1901 dispatches through buildClaudeCommand (fresh UUID) instead of discovering the newest JSONL on disk.", inst.Command, olderUUID, newerUUID, projectDir, inst.ClaudeSessionID, newerUUID)
+	// PERSIST-12 write-through, post-#1815: the instance must carry a
+	// conversation id after Start (so the next Restart takes the Phase 3 fast
+	// path), but it must NOT be the discovered uuid — that transcript is not
+	// verifiably this session's own, so the guard replaced it with a freshly
+	// minted id.
+	if inst.ClaudeSessionID == "" || inst.ClaudeSessionID == newerUUID || inst.ClaudeSessionID == olderUUID {
+		t.Fatalf("#1815: after Start() the instance must carry a freshly minted conversation id, not a discovered one; got %q (discovered candidates: %s, %s)", inst.ClaudeSessionID, newerUUID, olderUUID)
 	}
-
 	argv := readCapturedClaudeArgv(t, argvLog, 3*time.Second)
 	joined := strings.Join(argv, " ")
 
-	if !strings.Contains(joined, "--resume") || !strings.Contains(joined, newerUUID) {
-		t.Fatalf("TEST-09 RED: after inst.Start() captured claude argv MUST contain '--resume %s'. Got argv: %v. Phase 5 plan 05-02 must route empty-ID Claude-compatible Starts through buildClaudeResumeCommand (via discoverLatestClaudeJSONL write-through).", newerUUID, argv)
+	if strings.Contains(joined, "--resume") {
+		t.Fatalf("#1815: an unowned discovered transcript must not be resumed. Got argv: %v", argv)
 	}
-	if strings.Contains(joined, olderUUID) {
-		t.Fatalf("TEST-09 RED: claude argv contains the OLDER JSONL uuid %s; newer %s must win on mtime. Argv: %v", olderUUID, newerUUID, argv)
+	if !strings.Contains(joined, "--session-id") {
+		t.Fatalf("#1815: the refusal must still spawn claude with an explicit fresh session id (REQ-7 dispatch shape survives). Got argv: %v", argv)
+	}
+	if strings.Contains(joined, newerUUID) || strings.Contains(joined, olderUUID) {
+		t.Fatalf("#1815: neither discovered uuid may be claimed via --session-id — they may belong to other sessions. Argv: %v", argv)
 	}
 
 	// PERSIST-13 fresh-fallback: no JSONL → no --resume, no error. This sub-case

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -937,7 +937,19 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	// writer that saves a discovered conversation id without ever passing
 	// through the resume builder (e.g. `switch-account --no-restart`) cannot
 	// leave an unverified id on disk that the next process treats as recorded.
-	toolData = WriteClaudeSessionUnverifiedToToolData(toolData, inst.claudeSessionIDIsUnverified())
+	//
+	// Only write the marker when there is a current id to describe it. When
+	// inst.ClaudeSessionID is empty, claude_session_id is OMITTED from this
+	// blob (MarshalToolData's omitempty) and MergeToolDataExtras carries the
+	// prior sticky-preserved id forward unchanged; the taint marker must be
+	// omitted too so it rides along with that same carried-forward id instead
+	// of being overwritten with an explicit `false`. Writing an explicit
+	// false here would erase a persisted taint while the tainted id itself
+	// survives via the sticky merge -- reopening #1815 through this exact
+	// persistence layer (review finding on #1830).
+	if inst.ClaudeSessionID != "" {
+		toolData = WriteClaudeSessionUnverifiedToToolData(toolData, inst.claudeSessionIDIsUnverified())
+	}
 	// #1704 blocker fix: same extras-zone treatment for last_started_at, so
 	// `status --stale` (and ShouldSkipRestart's freshness guard) see a real
 	// value from a fresh CLI process instead of always-zero.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -77,6 +77,11 @@ type InstanceData struct {
 	// Claude session (persisted for resume after app restart)
 	ClaudeSessionID  string    `json:"claude_session_id,omitempty"`
 	ClaudeDetectedAt time.Time `json:"claude_detected_at,omitempty"`
+	// #1815: true when ClaudeSessionID came from a disk scan and was never
+	// verified as this session's own. Persisted so the taint survives a
+	// process restart and the id can never launder itself into a resumable
+	// one just by being written and read back.
+	ClaudeSessionIDUnverified bool `json:"claude_session_id_unverified,omitempty"`
 
 	// Gemini session (persisted for resume after app restart)
 	GeminiSessionID  string    `json:"gemini_session_id,omitempty"`
@@ -923,6 +928,11 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	// the positional MarshalToolData signature so legacy binaries that don't
 	// know the key preserve it via MergeToolDataExtras.
 	toolData = WriteIdleTimeoutSecsToToolData(toolData, inst.IdleTimeoutSecs)
+	// #1815: the resume-identity taint travels with the id it describes, so a
+	// writer that saves a discovered conversation id without ever passing
+	// through the resume builder (e.g. `switch-account --no-restart`) cannot
+	// leave an unverified id on disk that the next process treats as recorded.
+	toolData = WriteClaudeSessionUnverifiedToToolData(toolData, inst.claudeSessionIDIsUnverified())
 
 	return &statedb.InstanceRow{
 		ID:                  inst.ID,
@@ -1094,6 +1104,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			AutoLinkedChannels:        autoLinkedChannels2,
 			Color:                     color2,
 			IdleTimeoutSecs:           ReadIdleTimeoutSecsFromToolData(r.ToolData),
+			ClaudeSessionIDUnverified: ReadClaudeSessionUnverifiedFromToolData(r.ToolData),
 		}
 	}
 
@@ -1213,6 +1224,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			AutoLinkedChannels:        autoLinkedChannels,
 			Color:                     color,
 			IdleTimeoutSecs:           ReadIdleTimeoutSecsFromToolData(r.ToolData),
+			ClaudeSessionIDUnverified: ReadClaudeSessionUnverifiedFromToolData(r.ToolData),
 		}
 	}
 
@@ -1414,59 +1426,60 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 		projectPath := ExpandPath(fixMalformedTildePath(instData.ProjectPath))
 
 		inst := &Instance{
-			ID:                        instData.ID,
-			Title:                     instData.Title,
-			ProjectPath:               projectPath,
-			GroupPath:                 groupPath,
-			Order:                     instData.Order,
-			ParentSessionID:           instData.ParentSessionID,
-			IsConductor:               instData.IsConductor,
-			NoTransitionNotify:        instData.NoTransitionNotify,
-			TitleLocked:               instData.TitleLocked,
-			AutoName:                  instData.AutoName,
-			autoNameDescription:       instData.AutoNameDescription,
-			Command:                   instData.Command,
-			Wrapper:                   instData.Wrapper,
-			Tool:                      instData.Tool,
-			Status:                    instData.Status,
-			CreatedAt:                 instData.CreatedAt,
-			LastAccessedAt:            instData.LastAccessedAt,
-			ArchivedAt:                instData.ArchivedAt,
-			WorktreePath:              instData.WorktreePath,
-			WorktreeRepoRoot:          instData.WorktreeRepoRoot,
-			WorktreeBranch:            instData.WorktreeBranch,
-			Account:                   instData.Account,
-			Pin:                       instData.Pin,
-			TmuxSocketName:            instData.TmuxSocketName,
-			ClaudeSessionID:           instData.ClaudeSessionID,
-			ClaudeDetectedAt:          instData.ClaudeDetectedAt,
-			GeminiSessionID:           instData.GeminiSessionID,
-			GeminiDetectedAt:          instData.GeminiDetectedAt,
-			GeminiYoloMode:            instData.GeminiYoloMode,
-			GeminiModel:               instData.GeminiModel,
-			OpenCodeSessionID:         instData.OpenCodeSessionID,
-			OpenCodeDetectedAt:        instData.OpenCodeDetectedAt,
-			CodexSessionID:            instData.CodexSessionID,
-			CodexDetectedAt:           instData.CodexDetectedAt,
-			ToolOptionsJSON:           instData.ToolOptionsJSON,
-			LatestPrompt:              instData.LatestPrompt,
-			Notes:                     instData.Notes,
-			LoadedMCPNames:            instData.LoadedMCPNames,
-			Channels:                  instData.Channels,
-			ExtraArgs:                 instData.ExtraArgs,
-			Plugins:                   instData.Plugins,
-			PluginChannelLinkDisabled: instData.PluginChannelLinkDisabled,
-			AutoLinkedChannels:        instData.AutoLinkedChannels,
-			Color:                     instData.Color,
-			IdleTimeoutSecs:           instData.IdleTimeoutSecs,
-			Sandbox:                   instData.Sandbox,
-			SandboxContainer:          instData.SandboxContainer,
-			SSHHost:                   instData.SSHHost,
-			SSHRemotePath:             instData.SSHRemotePath,
-			MultiRepoEnabled:          instData.MultiRepoEnabled,
-			AdditionalPaths:           instData.AdditionalPaths,
-			MultiRepoTempDir:          instData.MultiRepoTempDir,
-			tmuxSession:               tmuxSess,
+			ID:                           instData.ID,
+			Title:                        instData.Title,
+			ProjectPath:                  projectPath,
+			GroupPath:                    groupPath,
+			Order:                        instData.Order,
+			ParentSessionID:              instData.ParentSessionID,
+			IsConductor:                  instData.IsConductor,
+			NoTransitionNotify:           instData.NoTransitionNotify,
+			TitleLocked:                  instData.TitleLocked,
+			AutoName:                     instData.AutoName,
+			autoNameDescription:          instData.AutoNameDescription,
+			Command:                      instData.Command,
+			Wrapper:                      instData.Wrapper,
+			Tool:                         instData.Tool,
+			Status:                       instData.Status,
+			CreatedAt:                    instData.CreatedAt,
+			LastAccessedAt:               instData.LastAccessedAt,
+			ArchivedAt:                   instData.ArchivedAt,
+			WorktreePath:                 instData.WorktreePath,
+			WorktreeRepoRoot:             instData.WorktreeRepoRoot,
+			WorktreeBranch:               instData.WorktreeBranch,
+			Account:                      instData.Account,
+			Pin:                          instData.Pin,
+			TmuxSocketName:               instData.TmuxSocketName,
+			ClaudeSessionID:              instData.ClaudeSessionID,
+			ClaudeDetectedAt:             instData.ClaudeDetectedAt,
+			claudeSessionIDUnverifiedFor: restoreClaudeSessionTaint(instData.ClaudeSessionID, instData.ClaudeSessionIDUnverified),
+			GeminiSessionID:              instData.GeminiSessionID,
+			GeminiDetectedAt:             instData.GeminiDetectedAt,
+			GeminiYoloMode:               instData.GeminiYoloMode,
+			GeminiModel:                  instData.GeminiModel,
+			OpenCodeSessionID:            instData.OpenCodeSessionID,
+			OpenCodeDetectedAt:           instData.OpenCodeDetectedAt,
+			CodexSessionID:               instData.CodexSessionID,
+			CodexDetectedAt:              instData.CodexDetectedAt,
+			ToolOptionsJSON:              instData.ToolOptionsJSON,
+			LatestPrompt:                 instData.LatestPrompt,
+			Notes:                        instData.Notes,
+			LoadedMCPNames:               instData.LoadedMCPNames,
+			Channels:                     instData.Channels,
+			ExtraArgs:                    instData.ExtraArgs,
+			Plugins:                      instData.Plugins,
+			PluginChannelLinkDisabled:    instData.PluginChannelLinkDisabled,
+			AutoLinkedChannels:           instData.AutoLinkedChannels,
+			Color:                        instData.Color,
+			IdleTimeoutSecs:              instData.IdleTimeoutSecs,
+			Sandbox:                      instData.Sandbox,
+			SandboxContainer:             instData.SandboxContainer,
+			SSHHost:                      instData.SSHHost,
+			SSHRemotePath:                instData.SSHRemotePath,
+			MultiRepoEnabled:             instData.MultiRepoEnabled,
+			AdditionalPaths:              instData.AdditionalPaths,
+			MultiRepoTempDir:             instData.MultiRepoTempDir,
+			tmuxSession:                  tmuxSess,
 		}
 		// Convert multi-repo worktree data
 		for _, wt := range instData.MultiRepoWorktrees {

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -1452,7 +1452,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			TmuxSocketName:               instData.TmuxSocketName,
 			ClaudeSessionID:              instData.ClaudeSessionID,
 			ClaudeDetectedAt:             instData.ClaudeDetectedAt,
-			claudeSessionIDUnverifiedFor: restoreClaudeSessionTaint(instData.ClaudeSessionID, instData.ClaudeSessionIDUnverified),
+			claudeSessionIDsFromDiskScan: restoreClaudeSessionVerification(instData.ClaudeSessionID, instData.ClaudeSessionIDUnverified),
 			GeminiSessionID:              instData.GeminiSessionID,
 			GeminiDetectedAt:             instData.GeminiDetectedAt,
 			GeminiYoloMode:               instData.GeminiYoloMode,

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11311,12 +11311,22 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		// ToolOptionsJSON, which canResumeClaudeSession never reads) and
 		// silently mints a fresh id instead of resuming the one the operator
 		// picked (review finding on #1830).
+		//
+		// The field is free-text (internal/ui/claudeoptions.go's resumeIDInput
+		// applies no validation), so a well-formed-UUID check is required
+		// before trusting it as an ownership declaration: without it, a value
+		// containing shell metacharacters would still be vouched as verified
+		// here and later reach the unquoted `--resume %s` command build
+		// (review finding on #1830). A malformed value is left unassigned and
+		// falls through to the normal fresh-id path instead.
 		if tool == "claude" && len(toolOptionsJSON) > 0 {
 			if opts, err := session.UnmarshalClaudeOptions(toolOptionsJSON); err == nil && opts != nil &&
-				opts.SessionMode == "resume" && strings.TrimSpace(opts.ResumeSessionID) != "" {
-				inst.ClaudeSessionID = strings.TrimSpace(opts.ResumeSessionID)
-				session.MarkClaudeSessionIDVerified(inst)
-				inst.ClaudeDetectedAt = time.Now()
+				opts.SessionMode == "resume" {
+				if candidate := strings.TrimSpace(opts.ResumeSessionID); candidate != "" && session.IsBareClaudeSessionUUID(candidate) {
+					inst.ClaudeSessionID = candidate
+					session.MarkClaudeSessionIDVerified(inst)
+					inst.ClaudeDetectedAt = time.Now()
+				}
 			}
 		}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7266,8 +7266,24 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 			configDir := session.GetClaudeConfigDirForGroup(inst.GroupPath)
 			cmdBuilder.WriteString(fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir))
 		}
-		cmdBuilder.WriteString("claude --resume ")
-		cmdBuilder.WriteString(result.SessionID)
+		// #1815: the TUI picker builds a resume command too, so it routes
+		// through the same resume-time identity guard as restart / start /
+		// fork. The id was just recorded onto inst above (the user picked
+		// this conversation FOR this session), so the check passes by
+		// construction today — it is here so a future change that reuses an
+		// existing instance here cannot resume a conversation that instance
+		// does not own. Only the identity half applies: the user's explicit
+		// pick must not be downgraded to a fresh session by the
+		// conversation-data heuristics.
+		if allowed, _ := session.ResumeIdentityAllowed(inst, result.SessionID); allowed {
+			cmdBuilder.WriteString("claude --resume ")
+			cmdBuilder.WriteString(result.SessionID)
+		} else {
+			freshID := session.NewClaudeSessionUUID()
+			inst.ClaudeSessionID = freshID
+			cmdBuilder.WriteString("claude --session-id ")
+			cmdBuilder.WriteString(freshID)
+		}
 		if opts.SkipPermissions {
 			cmdBuilder.WriteString(" --dangerously-skip-permissions")
 		} else if opts.AllowSkipPermissions {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -19255,6 +19255,8 @@ func getSessionContent(inst *session.Instance) (string, error) {
 func getSessionContentWithLive(inst *session.Instance, liveClaudeID string) (string, error) {
 	if session.IsClaudeCompatible(inst.Tool) && liveClaudeID != "" && liveClaudeID != inst.ClaudeSessionID {
 		inst.ClaudeSessionID = liveClaudeID
+		// #1815: read from this session's OWN pane env — vouched ownership.
+		session.MarkClaudeSessionIDVerified(inst)
 	}
 
 	// Use best-effort: richer recovery than GetLastResponse if the refreshed

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7252,6 +7252,12 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		// would otherwise override the extractGroupPath default with "".
 		inst := session.NewInstanceWithGroupAndTool(title, projectPath, h.resolveNewSessionGroup(), "claude")
 		inst.ClaudeSessionID = result.SessionID
+		// #1815: the user picked this exact conversation for this brand-new
+		// instance — an explicit ownership declaration, not a disk-scan
+		// guess. Route it through the chokepoint like every other explicit
+		// writer (launch_cmd.go, mutators.go) instead of relying on a fresh
+		// instance's taint map being empty by construction.
+		session.MarkClaudeSessionIDVerified(inst)
 
 		// Build resume command with config dir and permission flags
 		userConfig, _ := session.LoadUserConfig()
@@ -7281,6 +7287,10 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		} else {
 			freshID := session.NewClaudeSessionUUID()
 			inst.ClaudeSessionID = freshID
+			// #1815: a freshly minted id is vouched ownership, same as every
+			// other minted-id writer (Instance.replaceRefusedClaudeSessionID,
+			// buildClaudeCommandWithMessage's own mint path).
+			session.MarkClaudeSessionIDVerified(inst)
 			cmdBuilder.WriteString("claude --session-id ")
 			cmdBuilder.WriteString(freshID)
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -19255,8 +19255,8 @@ func getSessionContent(inst *session.Instance) (string, error) {
 func getSessionContentWithLive(inst *session.Instance, liveClaudeID string) (string, error) {
 	if session.IsClaudeCompatible(inst.Tool) && liveClaudeID != "" && liveClaudeID != inst.ClaudeSessionID {
 		inst.ClaudeSessionID = liveClaudeID
-		// #1815: read from this session's OWN pane env — vouched ownership.
-		session.MarkClaudeSessionIDVerified(inst)
+		// #1815: read from this session's OWN pane env — weak vouch.
+		session.NoteClaudeSessionIDFromOwnPane(inst)
 	}
 
 	// Use best-effort: richer recovery than GetLastResponse if the refreshed

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11303,6 +11303,23 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			inst.ToolOptionsJSON = toolOptionsJSON
 		}
 
+		// #1815: an operator who typed a conversation UUID into the "resume by
+		// session ID" panel field made an explicit ownership declaration for
+		// THIS session, exactly like --resume-session on the CLI (see
+		// launch_cmd.go / main.go). Vouch for it here too, or the chokepoint
+		// sees no recorded ClaudeSessionID (only opts.ResumeSessionID inside
+		// ToolOptionsJSON, which canResumeClaudeSession never reads) and
+		// silently mints a fresh id instead of resuming the one the operator
+		// picked (review finding on #1830).
+		if tool == "claude" && len(toolOptionsJSON) > 0 {
+			if opts, err := session.UnmarshalClaudeOptions(toolOptionsJSON); err == nil && opts != nil &&
+				opts.SessionMode == "resume" && strings.TrimSpace(opts.ResumeSessionID) != "" {
+				inst.ClaudeSessionID = strings.TrimSpace(opts.ResumeSessionID)
+				session.MarkClaudeSessionIDVerified(inst)
+				inst.ClaudeDetectedAt = time.Now()
+			}
+		}
+
 		if launchModelID != "" {
 			if err := inst.ApplyLaunchModel(launchModelID); err != nil {
 				return sessionCreatedMsg{err: fmt.Errorf("failed to apply model override: %w", err), tempID: tempID}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -21,6 +21,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/BurntSushi/toml"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
@@ -7401,7 +7402,12 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		var cmdBuilder strings.Builder
 		if session.IsClaudeConfigDirExplicitForGroup(inst.GroupPath) {
 			configDir := session.GetClaudeConfigDirForGroup(inst.GroupPath)
-			cmdBuilder.WriteString(fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir))
+			// #1815 (Codex review on #1830): quote exactly as
+			// Instance.buildBashExportPrefix does (instance.go, audit F2) —
+			// this string is baked into inst.Command and ends up in a
+			// `bash -c` payload, so an unquoted config_dir containing
+			// whitespace, ;, or $(...) breaks the command or injects.
+			cmdBuilder.WriteString(fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", shellescape.Quote(configDir)))
 		}
 		// #1815: the TUI picker builds a resume command too, so it routes
 		// through the same resume-time identity guard as restart / start /

--- a/internal/ui/issue1830_configdir_quoting_test.go
+++ b/internal/ui/issue1830_configdir_quoting_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+// TestIssue1830_GlobalSearchConfigDirIsQuoted covers the Codex review Medium on
+// PR #1830: createSessionFromGlobalSearch built its resume command with
+// `CLAUDE_CONFIG_DIR=%s ` from a raw config dir, bypassing the quoting that
+// Instance.buildBashExportPrefix applies (instance.go, audit F2). The string it
+// builds is stored as inst.Command and ends up inside a `bash -c` payload, so a
+// config_dir containing whitespace silently breaks the command and one
+// containing ; or $(...) injects.
+//
+// This pins the technique: the emitted assignment must survive a real shell
+// with the value intact, for paths a user can legitimately have (spaces) and
+// for hostile ones.
+func TestIssue1830_GlobalSearchConfigDirIsQuoted(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	marker := "/tmp/agentdeck-pwned-1830-ui"
+	_ = os.Remove(marker)
+	t.Cleanup(func() { _ = os.Remove(marker) })
+
+	dirs := map[string]string{
+		"plain":                "/home/u/.claude",
+		"with_spaces":          "/home/u/My Claude Dir/.claude",
+		"semicolon_chain":      "/home/u/.claude; touch " + marker,
+		"command_substitution": "/home/u/$(touch " + marker + ")claude",
+		"single_quote":         "/home/u/it's/.claude",
+	}
+
+	for name, dir := range dirs {
+		t.Run(name, func(t *testing.T) {
+			// Exactly the construction the fixed call site uses.
+			assignment := fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", shellescape.Quote(dir))
+
+			// Run it the way it is ultimately run: as a bash -c payload.
+			out, err := exec.Command("bash", "-c", assignment+`printf '%s' "$CLAUDE_CONFIG_DIR"`).Output()
+			if err != nil {
+				t.Fatalf("bash rejected the assignment for %q: %v", dir, err)
+			}
+			if got := string(out); got != dir {
+				t.Errorf("config dir mangled by the shell:\n got: %q\nwant: %q", got, dir)
+			}
+			if _, statErr := os.Stat(marker); statErr == nil {
+				t.Fatalf("payload in %q EXECUTED — value reached the shell unquoted", dir)
+			}
+		})
+	}
+}
+
+// TestIssue1830_NoRawConfigDirInterpolation guards the specific line the fix
+// changed. The round-trip test above pins the technique but would still pass if
+// the call site regressed to the raw form, so assert the raw form is absent
+// from the source.
+func TestIssue1830_NoRawConfigDirInterpolation(t *testing.T) {
+	src, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+
+	// Matches `CLAUDE_CONFIG_DIR=%s` interpolated directly from a bare
+	// identifier (the pre-fix form) rather than through shellescape.Quote.
+	raw := regexp.MustCompile(`CLAUDE_CONFIG_DIR=%s[^"]*",\s*[A-Za-z_][A-Za-z0-9_.]*\)`)
+	for _, line := range strings.Split(string(src), "\n") {
+		if raw.MatchString(line) && !strings.Contains(line, "shellescape.Quote") {
+			t.Errorf("home.go interpolates CLAUDE_CONFIG_DIR without shellescape.Quote:\n  %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/internal/ui/issue1830_configdir_quoting_test.go
+++ b/internal/ui/issue1830_configdir_quoting_test.go
@@ -23,8 +23,10 @@ import (
 // with the value intact, for paths a user can legitimately have (spaces) and
 // for hostile ones.
 func TestIssue1830_GlobalSearchConfigDirIsQuoted(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not available")
+	for _, bin := range []string{"bash", "printenv"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available", bin)
+		}
 	}
 
 	marker := "/tmp/agentdeck-pwned-1830-ui"
@@ -44,12 +46,21 @@ func TestIssue1830_GlobalSearchConfigDirIsQuoted(t *testing.T) {
 			// Exactly the construction the fixed call site uses.
 			assignment := fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", shellescape.Quote(dir))
 
-			// Run it the way it is ultimately run: as a bash -c payload.
-			out, err := exec.Command("bash", "-c", assignment+`printf '%s' "$CLAUDE_CONFIG_DIR"`).Output()
+			// Run it the way it is ultimately run: as a bash -c payload where
+			// the assignment prefixes the command.
+			//
+			// Read the value back with printenv (an EXTERNAL command) rather
+			// than expanding "$CLAUDE_CONFIG_DIR" in the same command line: a
+			// var-assignment prefix is applied when the command is executed,
+			// but parameter expansion on that same line happens BEFORE it, so
+			// an in-line expansion reads empty and would fail every case
+			// including the benign one. printenv also matches how the real
+			// claude process receives the variable -- from its environment.
+			out, err := exec.Command("bash", "-c", assignment+"printenv CLAUDE_CONFIG_DIR").Output()
 			if err != nil {
 				t.Fatalf("bash rejected the assignment for %q: %v", dir, err)
 			}
-			if got := string(out); got != dir {
+			if got := strings.TrimSuffix(string(out), "\n"); got != dir {
 				t.Errorf("config dir mangled by the shell:\n got: %q\nwant: %q", got, dir)
 			}
 			if _, statErr := os.Stat(marker); statErr == nil {

--- a/internal/ui/issue1830_tui_resume_by_id_test.go
+++ b/internal/ui/issue1830_tui_resume_by_id_test.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestIssue1830_TUICreateResumeByIDVouchesOwnership pins a review finding on
+// #1830: the TUI options panel lets the operator type a conversation UUID
+// into the "resume by session ID" field (ClaudeOptions.SessionMode ==
+// "resume" / ResumeSessionID). That landed ONLY inside ToolOptionsJSON --
+// the create path never assigned it to inst.ClaudeSessionID or vouched for
+// it. The resume-time chokepoint (canResumeClaudeSession) never looks
+// inside ToolOptionsJSON, so recordedClaudeSessionID() was always empty and
+// the operator's explicit choice was silently discarded for a freshly
+// minted id.
+//
+// The fix mirrors the CLI's --resume-session handling (launch_cmd.go /
+// main.go): a non-empty operator-supplied ResumeSessionID is an ownership
+// declaration, so it must land on ClaudeSessionID AND be vouched via
+// session.MarkClaudeSessionIDVerified before the session ever reaches the
+// resume chokepoint.
+func TestIssue1830_TUICreateResumeByIDVouchesOwnership(t *testing.T) {
+	const wantID = "a1a1a1a1-2222-4333-8444-555555555555"
+
+	opts := session.NewClaudeOptions(nil)
+	opts.SessionMode = "resume"
+	opts.ResumeSessionID = wantID
+	toolOptionsJSON, err := session.MarshalToolOptions(opts)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	h := &Home{}
+	msg := h.createSessionInGroupWithWorktreeAndOptions(
+		"resume-by-id-test",
+		t.TempDir(),
+		"claude",
+		"test",
+		"", "", "",
+		false,
+		false,
+		toolOptionsJSON,
+		nil,
+		"",
+		"",
+		false,
+		nil,
+		"", "",
+		"",
+		false,
+	)().(sessionCreatedMsg)
+	if msg.err != nil {
+		t.Fatalf("create session: %v", msg.err)
+	}
+	inst := msg.instance
+	t.Cleanup(func() {
+		if err := inst.KillAndWait(); err != nil {
+			t.Errorf("cleanup session: %v", err)
+		}
+	})
+
+	if inst.ClaudeSessionID != wantID {
+		t.Fatalf("ClaudeSessionID = %q, want the operator-typed id %q -- the resume-by-id panel entry was discarded",
+			inst.ClaudeSessionID, wantID)
+	}
+	allow, reason := session.ResumeIdentityAllowed(inst, wantID)
+	if !allow {
+		t.Fatalf("ResumeIdentityAllowed(%q) = false (reason=%q), want true: an operator-typed resume id must be vouched, not left tainted/unrecorded", wantID, reason)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

A restarted session came back **resuming a conversation that was not its own**. Its recorded conversation id had been lost, the restart's disk-discovery prelude offered the newest transcript filed under its working directory, and the resume attached to that. The pane came up as a second live instance of a different session, carrying that session's context and its authority. Reported as #1815.

The sequence: session held in `auth-401` → account switch to another profile, whose migration reported "no conversation to migrate (fresh session)" and failed its own verification checks → `session restart` → resume attached to the wrong transcript.

The structural defect: every producer of a conversation id fed one field (tmux env, hook payload, explicit `--session-id`, disk discovery, account-switch relocation), and the command builders trusted whatever was in it. Nothing verified, at the moment the `--resume <id>` string was assembled, that the id belonged to this session.

## Why this change

The bug is not in any one upstream producer of a conversation id — it is that nothing checked at the last step. Fixing only discovery (or only the account switch) leaves the next producer free to hand a foreign id to `--resume`. A single resume-time chokepoint fails closed no matter which upstream path is wrong, and the failure mode it chooses (start fresh) is strictly recoverable while the one it prevents is not.

Guard 2 exists because the switch path had already reached the right conclusion and then discarded it: a diagnosis that does not stop the sequence is not a guard.

## Guard 1 (load-bearing): identity is verified at resume time

New chokepoint in `internal/session/resume_identity.go`. An id may authorize `--resume` only when it matches the session's OWN recorded conversation id — exact match, or the id-prefix spelling the CLI accepts (prefixes shorter than 8 chars are not identity evidence). Otherwise the resume is refused with a loud, grep-stable `resume refused: id=<id> reason=<why>` log line and the session starts fresh.

- **No recorded id → refuse.** This is the incident: nothing to verify against means nothing may be resumed.
- **Mismatch → refuse.**
- **The refused id is not reused via `--session-id` either.** It may belong to another session, and a shared `CLAUDE_SESSION_ID` also trips the duplicate sweeper. A fresh id is minted instead.

Every path that builds a Claude resume command routes through it: `buildClaudeResumeCommand` (restart / start / start-with-message), the `SessionMode == "resume"` dispatch, the fork builder (a fork is a `--resume <source> --fork-session`), and the TUI session picker. Copilot / Gemini / Hermes resumes use their own tool ids and are out of scope here.

Ids obtained by **scanning disk** are now recorded as hints, never as ownership:

- the restart and start discovery preludes (`ensureClaudeSessionIDFromDisk[ForRestart]`),
- the last-response recovery scan in `GetLastResponseBestEffort` — which additionally no longer writes its scanned id into the pane's `CLAUDE_SESSION_ID`, because that would launder a scanned id into a "bound from my own tmux env" one on the next poll,
- the account-switch "newest conversation in this project dir" lookup, when the session carries no recorded id.

Mtime order is not identity evidence: the newest transcript in a shared working directory is just as likely to be a neighbour's. The taint is stored as the tainted id itself rather than a bare flag, so a later assignment of a different id is verified by default and the marker can never go stale onto an unrelated value. Sources that genuinely identify this session (own tmux env, own hook payload, explicit `--session-id` in its own command, an id this process minted) clear it.

## Guard 2: a failed verification stops the sequence

`session switch-account` aborts instead of restarting when the session demonstrably held a conversation (`ClaudeDetectedAt` set) but arrives with no recorded id and no conversation located in any configured config dir. That is precisely the state whose restart lets discovery adopt a neighbour's transcript. `--no-restart` (or an already-stopped session) is the documented way through, and Guard 1 covers the later manual start. Extracted as `switchAccountRestartUnsafe` so the predicate is unit-tested.

## How this composes with #1788

#1788 (`fix/resume-cross-project-guard`) refuses to `--resume` a jsonl found under a **foreign project directory** — rejection by *location*, implemented by hardening `sessionHasConversationData`. This PR rejects by *identity*.

They are deliberately **layered inside one chokepoint**, not left as two partial checks:

```
canResumeClaudeSession(inst, id)
  ├─ layer 1  identity        (this PR)
  └─ layer 2  sessionHasConversationData  (hardened by #1788: transcript exists AND lives in a reachable project dir)
```

Callers that decide between `--resume` and `--session-id` now call `canResumeClaudeSession`, never `sessionHasConversationData` directly. `sessionHasConversationData` keeps its other job — bind-quality gating for hook/tmux rebinds, where the question is "does this id have any conversation data", not "may we resume it" — and this PR does not touch its body, so #1788 merges into it without conflict. Whichever lands second inherits the other layer for free.

## Behaviour this deliberately reverses

Two existing tests pinned discovery-based resume (#956 / REQ-7): a custom-wrapper session whose id was never captured re-attached to the newest transcript in its directory. At the moment of resume that is **indistinguishable** from the incident — discovery cannot tell "my lost transcript" from "the neighbour's". #1815 rules the ambiguity must fail closed, so both tests are rewritten to the new contract with the reasoning inline rather than quietly deleted:

- `TestConductor_Restart_PreservesChatHistory_RegressionFor956` → `TestConductor_Restart_DoesNotAdoptDiscoveredTranscript_1815`
- `TestPersistence_CustomCommandResumesFromLatestJSONL` — narrowed: discovery still write-throughs a candidate id and the spawn keeps its shape (claude spawn path with an explicit session id), but the candidate no longer authorizes `--resume`.

The cost is one conversation's history for that class of session; the alternative is adopting another session's conversation, which is not recoverable. If reviewers want the #956 recovery preserved behind an explicit opt-in, that is worth settling here.

## Tests

New `internal/session/resume_identity_test.go`:

- the exact incident shape — no recorded id, discovery offers another session's transcript → no `--resume`, the foreign uuid appears nowhere in the command, a fresh id is minted and recorded as verified;
- missing recorded id refuses (`reason=no_recorded_session_id`) even though the transcript exists and has conversation data;
- identity mismatch refuses while the session's own id still resumes;
- matching id resumes normally, including the prefix spelling;
- match table (case, whitespace, either-side prefix, too-short prefix, distinct ids, empties);
- the taint is bound to the discovered value and is cleared by verified sources.

New `cmd/agent-deck/session_switch_account_guard_test.go` covers Guard 2: aborts when a session that has run cannot be located; proceeds when the conversation was located, when a conversation id is recorded, when the session never held one, and when no restart would happen.

`gofmt`, `go build ./...` and `go vet ./...` clean in a sandboxed HOME.

Closes #1815

## User impact

- Sessions resume exactly as before whenever their conversation id is their own — the overwhelmingly common case.
- A session whose conversation id was never captured (custom-wrapper sessions relying on disk discovery) now starts fresh on restart instead of re-attaching to the newest transcript in its directory. That recovery is what could silently attach the wrong conversation.
- `session switch-account` refuses to restart a session it cannot account for, and says so; `--no-restart` still switches the account.
- Refusals are visible: `resume refused: id=<id> reason=<why>` in the session log.

## Evidence

New tests reproduce the incident shape directly (no recorded id + a foreign transcript offered by discovery → no `--resume`, foreign uuid absent from the spawned command, fresh id minted). Full CI green on this branch, including the complete test suite and the persistence suite under `-race`, which exercise the two rewritten contracts end-to-end through real spawns.

Local: `gofmt -l` clean, `go build ./...` and `go vet ./...` clean in a sandboxed HOME. Test runs on this host are prohibited by repo policy; CI is the authority.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-x

## What actually bothered you

My human's words: "a restarted child session resumed its PARENT CONDUCTOR's conversation ... a child became a second live instance of its own supervisor (rogue duplicate conductor with the parent's authority)." The ask was two guards: never `--resume` a transcript whose id does not match the session's own recorded id, and make the account-switch path hard-abort the restart when its own verification fails.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed locally — not run: this repo forbids `go test` on the maintainer host (it has wiped live profile data); CI ran the full suite green instead
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-x intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sessions from resuming or adopting conversations when ownership cannot be verified.
  * Account switching now stops safely without restarting sessions when transcript ownership is uncertain.
  * Rejected resume attempts now start a fresh conversation automatically.
  * Preserved session verification status across application restarts.
* **Reliability**
  * Improved matching for conversation IDs, including exact, partial, and case-insensitive matches.
  * Prevented ambiguous or foreign conversation histories from being opened accidentally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->