### PR TITLE
fix(send): stop reporting success for sends the pane never received (#1793)

### DIFF
--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -118,9 +118,11 @@ func TestIssue1793_IdenticalMessageAlreadyOnScreen_IsNotEvidence(t *testing.T) {
 // never echoes the body.
 func TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival(t *testing.T) {
 	msg := bigMessage(4095)
+	// Index 0 is the pre-send baseline: the agent was idle, so going active
+	// afterwards is a transition attributable to this send.
 	mock := &mockSendRetryTarget{
-		statuses: []string{"active"},
-		panes:    []string{"thinking…\n"},
+		statuses: []string{"waiting", "active"},
+		panes:    []string{"❯ \n", "thinking…\n"},
 	}
 
 	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
@@ -131,6 +133,32 @@ func TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival(t *testing.T) {
 	}
 	if delivery != deliveryArrived {
 		t.Fatalf("delivery: want %q, got %q", deliveryArrived, delivery)
+	}
+}
+
+// TestIssue1793_AlreadyActiveAgent_IsNotEvidenceOfArrival is the second half
+// of the same trap as the leftover-copy test, and the more dangerous one: a
+// pane that was ALREADY working is still working a moment later whether or not
+// it received anything. Accepting "it is active now" as proof would hand back
+// success for a message that vanished into a busy agent — the #1793 phantom,
+// reintroduced through the status signal instead of the pane signal. Only a
+// transition from not-active to active counts.
+func TestIssue1793_AlreadyActiveAgent_IsNotEvidenceOfArrival(t *testing.T) {
+	msg := bigMessage(4095)
+	// Busy before the send, busy throughout, and the body never appears.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes:    []string{"thinking…\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err == nil {
+		t.Fatal("an agent that was already busy before the send does not prove the send arrived")
+	}
+	if delivery != deliveryNoEvidence {
+		t.Fatalf("delivery: want %q, got %q", deliveryNoEvidence, delivery)
 	}
 }
 

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -80,16 +80,91 @@ func TestIssue1793_LargePayloadVisibleInPane_IsReportedTypedNotSubmitted(t *test
 	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
 		maxRetries: 4, checkDelay: 0,
 	})
-	if err != nil {
-		t.Fatalf("a message visible in the pane must not be reported as lost: %v", err)
+	// Seen in the pane, but the agent never took it up: typed, NOT submitted,
+	// and NOT a success. Text sitting unsent in a composer is the reported
+	// bug; returning nil here would give the caller exit 0 and
+	// "success": true right next to "submitted": false.
+	if err == nil {
+		t.Fatal("issue #1793: a message that reached the pane but was never submitted must not report success")
 	}
-	// Seen in the pane, but the agent never took it up: typed, NOT submitted.
-	// Calling this "submitted" would be the original bug wearing a new status.
 	if delivery != deliveryTyped {
 		t.Fatalf("delivery: want %q, got %q", deliveryTyped, delivery)
 	}
 	if fields := (sendDeliveryResult{delivery: delivery}).jsonFields(); fields["submitted"] != false {
 		t.Fatalf("typed must report submitted=false in --json, got %v", fields["submitted"])
+	}
+}
+
+// TestIssue1793_ClaudePath_TypedButNeverSubmitted_IsNotSuccess is the Claude
+// half of the same defect. The Claude verification loop treated "the body is
+// visible in the pane" as delivery evidence and, at the end of its budget,
+// returned deliverySubmitted on the strength of it — re-certifying the exact
+// state #1793 is about, on the path most sessions actually use.
+//
+// Body visible, composer never shows an unsent marker, agent never goes
+// active: that is arrival without submission and must fail.
+func TestIssue1793_ClaudePath_TypedButNeverSubmitted_IsNotSuccess(t *testing.T) {
+	const msg = "please re-run the integration suite against staging"
+	// The body is on screen, but no composer marker and the status never
+	// leaves "waiting" — nothing ever showed the agent taking it up.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"some prior output\n" + msg + "\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries: 5, checkDelay: 0, verifyDelivery: true,
+	})
+	if err == nil {
+		t.Fatal("issue #1793: body text alone is arrival, not submission, and must not report success")
+	}
+	if delivery == deliverySubmitted {
+		t.Fatal("issue #1793: the Claude path must not promote visible body text to submitted")
+	}
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q, got %q", deliveryTyped, delivery)
+	}
+}
+
+// TestIssue1793_ClaudePath_ActiveTransitionStillReportsSubmitted guards the
+// other direction: the fix above must not stop the Claude path recognising a
+// genuinely accepted turn.
+func TestIssue1793_ClaudePath_ActiveTransitionStillReportsSubmitted(t *testing.T) {
+	const msg = "please re-run the integration suite against staging"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active", "active"},
+		panes:    []string{""},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries: 5, checkDelay: 0, verifyDelivery: true,
+	})
+	if err != nil {
+		t.Fatalf("an agent that went active accepted the turn: %v", err)
+	}
+	if delivery != deliverySubmitted {
+		t.Fatalf("delivery: want %q, got %q", deliverySubmitted, delivery)
+	}
+}
+
+// TestIssue1793_TypedIsAFailingExitNotASuccessfulOne pins the contract the
+// CLI exposes: JSON, exit code and human text must agree. `typed` carries
+// submitted=false, so it must also carry success=false and a nonzero exit.
+func TestIssue1793_TypedIsAFailingExitNotASuccessfulOne(t *testing.T) {
+	fields := (sendDeliveryResult{delivery: deliveryTyped}).jsonFields()
+	if fields["submitted"] != false {
+		t.Fatalf("typed must report submitted=false, got %v", fields["submitted"])
+	}
+	// The command maps a non-nil sendErr to ErrorWithData + os.Exit(1); the
+	// statuses that must travel that path are pinned here so a future edit
+	// cannot quietly route `typed` into the success branch.
+	for _, failing := range []string{deliveryTyped, deliveryNoEvidence, deliveryLineTooLong, deliveryTypedNotSubmitted} {
+		if failing == deliverySubmitted {
+			t.Fatalf("%q must never be treated as a successful delivery", failing)
+		}
+		if got := (sendDeliveryResult{delivery: failing}).jsonFields()["submitted"]; got != false {
+			t.Errorf("%q must report submitted=false, got %v", failing, got)
+		}
 	}
 }
 

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -50,13 +51,13 @@ func TestIssue1793_LargePayloadNeverSeenInPane_IsAFailureNotAnUnverifiedSuccess(
 	}
 }
 
-// TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived pins the positive
-// direction, and pins it through terminal line wrapping: a pane wraps long
+// TestIssue1793_LargePayloadVisibleInPane_IsReportedTypedNotSubmitted pins the
+// positive direction, and pins it through terminal line wrapping: a pane wraps long
 // content at its width and capture-pane returns those wraps as newlines, so a
 // byte-exact search for the body fails on any real wide message. Verification
 // that cannot see a delivered message is worse than none — it turns working
 // sends into failures.
-func TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived(t *testing.T) {
+func TestIssue1793_LargePayloadVisibleInPane_IsReportedTypedNotSubmitted(t *testing.T) {
 	msg := bigMessage(4095)
 
 	// Render the message the way a 80-column pane would: hard-wrapped.
@@ -82,8 +83,13 @@ func TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a message visible in the pane must not be reported as lost: %v", err)
 	}
-	if delivery != deliveryArrived {
-		t.Fatalf("delivery: want %q, got %q", deliveryArrived, delivery)
+	// Seen in the pane, but the agent never took it up: typed, NOT submitted.
+	// Calling this "submitted" would be the original bug wearing a new status.
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q, got %q", deliveryTyped, delivery)
+	}
+	if fields := (sendDeliveryResult{delivery: delivery}).jsonFields(); fields["submitted"] != false {
+		t.Fatalf("typed must report submitted=false in --json, got %v", fields["submitted"])
 	}
 }
 
@@ -113,10 +119,11 @@ func TestIssue1793_IdenticalMessageAlreadyOnScreen_IsNotEvidence(t *testing.T) {
 	}
 }
 
-// TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival: an agent that
-// starts working necessarily received what it is working on, even if its TUI
-// never echoes the body.
-func TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival(t *testing.T) {
+// TestIssue1793_LargePayload_IdleAgentGoingActiveIsSubmitted: an agent that
+// was idle and starts working necessarily received what it is working on,
+// even if its TUI never echoes the body. That is the one signal here strong
+// enough to claim submission.
+func TestIssue1793_LargePayload_IdleAgentGoingActiveIsSubmitted(t *testing.T) {
 	msg := bigMessage(4095)
 	// Index 0 is the pre-send baseline: the agent was idle, so going active
 	// afterwards is a transition attributable to this send.
@@ -131,8 +138,8 @@ func TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if delivery != deliveryArrived {
-		t.Fatalf("delivery: want %q, got %q", deliveryArrived, delivery)
+	if delivery != deliverySubmitted {
+		t.Fatalf("delivery: want %q, got %q", deliverySubmitted, delivery)
 	}
 }
 
@@ -203,6 +210,80 @@ func TestIssue1793_UnverifiableMessageSaysSoInsteadOfGuessing(t *testing.T) {
 	}
 }
 
+// TestIssue1793_LargeMultilinePayloadIsNotFailedForItsTotalSize is the
+// regression for a contradiction in an earlier cut of this fix: the transport
+// refuses on the longest LINE (canonical buffering is per line), but the CLI
+// gated its hard failure on the TOTAL payload size. A 20 KB body of 80-byte
+// lines transports fine — the tmux suite proves it against a real pane — yet
+// would have been reported as lost whenever the agent's TUI does not echo it.
+func TestIssue1793_LargeMultilinePayloadIsNotFailedForItsTotalSize(t *testing.T) {
+	// 20 KB total, longest line 80 bytes: far above any total-size threshold,
+	// far below every canonical line buffer.
+	body := strings.Repeat(strings.Repeat("m", 79)+"\n", 250)
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"a pane that never echoes anything\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, body, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err != nil {
+		t.Fatalf("a %d-byte payload whose longest line is 79 bytes is deliverable and must not be "+
+			"reported as lost: %v", len(body), err)
+	}
+	if delivery != deliveryUnverified {
+		t.Fatalf("delivery: want %q, got %q", deliveryUnverified, delivery)
+	}
+}
+
+// TestIssue1793_TokenlessOverLongLineIsNotAFreePass closes the door a
+// verification check leaves open by construction: a payload with no content
+// distinctive enough to search for. If such a message also carries a line long
+// enough to be eaten whole, "we could not look" must not come back as exit 0 —
+// that is the reported bug reached through the token-less path.
+func TestIssue1793_TokenlessOverLongLineIsNotAFreePass(t *testing.T) {
+	// Whitespace only: messageDeliveryToken yields nothing to search for.
+	body := strings.Repeat(" ", 4095)
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, body, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err == nil {
+		t.Fatal("an unverifiable message with an over-long line must not report success")
+	}
+	if delivery != deliveryNoEvidence {
+		t.Fatalf("delivery: want %q, got %q", deliveryNoEvidence, delivery)
+	}
+}
+
+// TestIssue1793_FailedBaselineDisablesTheSignalItBelongsTo: a baseline that
+// could not be read is not a baseline of zero. If the pre-send capture fails
+// and the pane already holds a copy of a repeated message, treating the
+// missing baseline as 0 would read that stale copy as a fresh arrival.
+func TestIssue1793_FailedBaselineDisablesTheSignalItBelongsTo(t *testing.T) {
+	msg := bigMessage(4095)
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"}, // busy before and after: no transition
+		panes:    []string{"❯ " + msg + "\n"},
+		paneErrs: []error{errors.New("capture failed")}, // baseline unreadable
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err == nil {
+		t.Fatal("with no readable baseline, a pre-existing copy must not certify the send")
+	}
+	if delivery != deliveryNoEvidence {
+		t.Fatalf("delivery: want %q, got %q", deliveryNoEvidence, delivery)
+	}
+}
+
 // TestIssue1793_CanonicalOverflowIsItsOwnDeliveryStatus: when the transport
 // refuses because the pane's canonical buffer cannot hold the line, nothing
 // was typed. That is a distinct, non-retryable outcome and must not be
@@ -253,7 +334,7 @@ func TestIssue1793_CanonicalOverflowSurvivesTheClaudeVerifiedPath(t *testing.T) 
 // statuses are actually machine-readable by the callers that key off them
 // (watchers, conductors, bridges), rather than only existing in Go.
 func TestIssue1793_DeliveryStatusReachesTheJSONContract(t *testing.T) {
-	for _, status := range []string{deliveryLineTooLong, deliveryNoEvidence, deliveryArrived} {
+	for _, status := range []string{deliveryLineTooLong, deliveryNoEvidence, deliveryTyped} {
 		res := sendDeliveryResult{delivery: status}
 		fields := res.jsonFields()
 		if fields["delivery"] != status {

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #1793: `session send` returned {"success":true,"delivery":"unverified"}
+// for a 4095-byte payload that never reached the agent.
+//
+// The failure direction is the point of these tests: when delivery cannot be
+// confirmed, the command must NOT report success. A test suite that only
+// checks the happy path is how a fix that delivers nothing gets merged.
+// ---------------------------------------------------------------------------
+
+// bigMessage returns a payload at or above the size where an unconfirmed send
+// is treated as a failure rather than as "we could not tell".
+func bigMessage(n int) string {
+	const marker = "ISSUE1793-DISTINCTIVE-PAYLOAD-MARKER "
+	return marker + strings.Repeat("x", n-len(marker))
+}
+
+// TestIssue1793_LargePayloadNeverSeenInPane_IsAFailureNotAnUnverifiedSuccess
+// is the exact reported scenario: a boundary-sized prompt to a non-Claude tool
+// (Codex), the pane never shows it, the agent never goes active. The old code
+// returned deliveryUnverified with a nil error and the CLI exited 0.
+func TestIssue1793_LargePayloadNeverSeenInPane_IsAFailureNotAnUnverifiedSuccess(t *testing.T) {
+	msg := bigMessage(4095)
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"codex composer, empty, nothing of ours in it\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if err == nil {
+		t.Fatal("issue #1793: an unconfirmed large send must not report success")
+	}
+	if delivery != deliveryNoEvidence {
+		t.Fatalf("delivery: want %q, got %q", deliveryNoEvidence, delivery)
+	}
+	if delivery == deliveryUnverified {
+		t.Fatal("issue #1793: transport-only success is exactly the phantom this fixes")
+	}
+}
+
+// TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived pins the positive
+// direction, and pins it through terminal line wrapping: a pane wraps long
+// content at its width and capture-pane returns those wraps as newlines, so a
+// byte-exact search for the body fails on any real wide message. Verification
+// that cannot see a delivered message is worse than none — it turns working
+// sends into failures.
+func TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived(t *testing.T) {
+	msg := bigMessage(4095)
+
+	// Render the message the way a 80-column pane would: hard-wrapped.
+	var wrapped strings.Builder
+	for i := 0; i < len(msg); i += 80 {
+		end := i + 80
+		if end > len(msg) {
+			end = len(msg)
+		}
+		wrapped.WriteString(msg[i:end])
+		wrapped.WriteString("\n")
+	}
+
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"❯ " + wrapped.String()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err != nil {
+		t.Fatalf("a message visible in the pane must not be reported as lost: %v", err)
+	}
+	if delivery != deliveryArrived {
+		t.Fatalf("delivery: want %q, got %q", deliveryArrived, delivery)
+	}
+}
+
+// TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival: an agent that
+// starts working necessarily received what it is working on, even if its TUI
+// never echoes the body.
+func TestIssue1793_LargePayload_AgentGoingActiveCountsAsArrival(t *testing.T) {
+	msg := bigMessage(4095)
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes:    []string{"thinking…\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if delivery != deliveryArrived {
+		t.Fatalf("delivery: want %q, got %q", deliveryArrived, delivery)
+	}
+}
+
+// TestIssue1793_SmallPayloadKeepsTheBestEffortContract: below the size where
+// canonical-buffer loss can happen, an unmatched pane is far more likely to be
+// a rendering quirk than a lost message. Those keep reporting `unverified`
+// rather than becoming a wall of new failures — the honesty fix must not turn
+// into a false-alarm generator.
+func TestIssue1793_SmallPayloadKeepsTheBestEffortContract(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"nothing of ours here\n"},
+	}
+	delivery, err := sendWithRetryTarget(mock, "please re-run the integration suite", true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err != nil {
+		t.Fatalf("small unmatched sends must stay best-effort, got error: %v", err)
+	}
+	if delivery != deliveryUnverified {
+		t.Fatalf("delivery: want %q, got %q", deliveryUnverified, delivery)
+	}
+}
+
+// TestIssue1793_UnverifiableMessageSaysSoInsteadOfGuessing: a message with no
+// distinctive token cannot be looked for at all. That is "verification
+// impossible", which must be reported as unverified — not silently upgraded
+// to success-with-evidence and not downgraded to a fabricated failure.
+func TestIssue1793_UnverifiableMessageSaysSoInsteadOfGuessing(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"y\n"},
+	}
+	delivery, err := sendWithRetryTarget(mock, "y", true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if delivery != deliveryUnverified {
+		t.Fatalf("delivery: want %q, got %q", deliveryUnverified, delivery)
+	}
+}
+
+// TestIssue1793_CanonicalOverflowIsItsOwnDeliveryStatus: when the transport
+// refuses because the pane's canonical buffer cannot hold the line, nothing
+// was typed. That is a distinct, non-retryable outcome and must not be
+// flattened into the generic send_failed bucket, so callers can tell "the
+// composer is untouched, change the message" from "the pipe broke, try again".
+func TestIssue1793_CanonicalOverflowIsItsOwnDeliveryStatus(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		sendKeysErr: fmt.Errorf("send to pane: %w", &tmux.CanonicalOverflowError{
+			LineBytes:  4095,
+			LimitBytes: 4095,
+			TTY:        "/dev/pts/7",
+		}),
+	}
+
+	delivery, err := sendWithRetryTarget(mock, bigMessage(4095), true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err == nil {
+		t.Fatal("a refused over-long line must be an error")
+	}
+	if delivery != deliveryLineTooLong {
+		t.Fatalf("delivery: want %q, got %q", deliveryLineTooLong, delivery)
+	}
+	if !strings.Contains(err.Error(), "canonical") {
+		t.Errorf("error should explain the canonical-buffer cause, got: %v", err)
+	}
+}
+
+// TestIssue1793_CanonicalOverflowSurvivesTheClaudeVerifiedPath: the same
+// refusal must classify identically when the Claude verification loop is in
+// play, not just on the skip-verify path.
+func TestIssue1793_CanonicalOverflowSurvivesTheClaudeVerifiedPath(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		sendKeysErr: &tmux.CanonicalOverflowError{LineBytes: 2000, LimitBytes: 1024, TTY: "/dev/ttys001"},
+	}
+	delivery, err := sendWithRetryTarget(mock, bigMessage(2000), false, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, verifyDelivery: true,
+	})
+	if err == nil {
+		t.Fatal("a refused over-long line must be an error on the verified path too")
+	}
+	if delivery != deliveryLineTooLong {
+		t.Fatalf("delivery: want %q, got %q", deliveryLineTooLong, delivery)
+	}
+}
+
+// TestIssue1793_DeliveryStatusReachesTheJSONContract pins that the new
+// statuses are actually machine-readable by the callers that key off them
+// (watchers, conductors, bridges), rather than only existing in Go.
+func TestIssue1793_DeliveryStatusReachesTheJSONContract(t *testing.T) {
+	for _, status := range []string{deliveryLineTooLong, deliveryNoEvidence, deliveryArrived} {
+		res := sendDeliveryResult{delivery: status}
+		fields := res.jsonFields()
+		if fields["delivery"] != status {
+			t.Errorf("delivery %q missing from --json fields: %v", status, fields)
+		}
+	}
+}

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -70,9 +70,10 @@ func TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived(t *testing.T) {
 		wrapped.WriteString("\n")
 	}
 
+	// Index 0 is the pre-send baseline capture, the rest are post-send.
 	mock := &mockSendRetryTarget{
 		statuses: []string{"waiting"},
-		panes:    []string{"❯ " + wrapped.String()},
+		panes:    []string{"❯ \n", "❯ " + wrapped.String()},
 	}
 
 	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
@@ -83,6 +84,32 @@ func TestIssue1793_LargePayloadVisibleInPane_IsReportedArrived(t *testing.T) {
 	}
 	if delivery != deliveryArrived {
 		t.Fatalf("delivery: want %q, got %q", deliveryArrived, delivery)
+	}
+}
+
+// TestIssue1793_IdenticalMessageAlreadyOnScreen_IsNotEvidence guards the
+// nastiest false positive available to a "is the body in the pane?" check.
+// Automated senders repeat themselves — heartbeats, inbox nudges, retries of
+// the same body. If the previous copy is still on screen, a naive containment
+// check certifies the NEXT send even when that one vanished. Only an increase
+// in occurrences counts.
+func TestIssue1793_IdenticalMessageAlreadyOnScreen_IsNotEvidence(t *testing.T) {
+	msg := bigMessage(4095)
+	// The same body is already in the pane before the send, and the pane
+	// never changes afterwards: the new send went nowhere.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"❯ " + msg + "\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err == nil {
+		t.Fatal("a leftover copy of an identical message must not certify a send that vanished")
+	}
+	if delivery != deliveryNoEvidence {
+		t.Fatalf("delivery: want %q, got %q", deliveryNoEvidence, delivery)
 	}
 }
 

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3308,15 +3308,22 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		opts.checkDelay = 0
 	}
 
-	// Baseline for the arrival check below. Taken BEFORE the send, because
-	// "the body is on screen" is not evidence on its own: re-sending an
-	// identical message (a heartbeat, an inbox nudge, a retry) would match
-	// the previous copy still sitting in the pane and certify a send that
-	// vanished. Only an INCREASE in occurrences is evidence. Costs one pane
-	// capture, and only on the path that needs it.
-	arrivalBaseline := 0
+	// Baseline for the arrival check below, taken BEFORE the send. Neither
+	// signal the check uses means anything as a snapshot — only as a change:
+	//
+	//   - "the body is on screen": re-sending an identical message (a
+	//     heartbeat, an inbox nudge, a retry) would match the previous copy
+	//     still sitting in the pane and certify a send that vanished.
+	//   - "the agent is active": a pane that was ALREADY busy is still busy a
+	//     moment later whether or not it received anything.
+	//
+	// Both would hand back a success for a message that never arrived, which
+	// is the exact phantom this is here to kill. Only a transition away from
+	// this baseline counts. Costs one pane capture plus one status read, and
+	// only on the path that needs them.
+	var arrivalBaseline sendArrivalBaseline
 	if skipVerify {
-		arrivalBaseline = countMessageInPane(target, message)
+		arrivalBaseline = captureArrivalBaseline(target, message)
 	}
 
 	if err := target.SendKeysAndEnter(message); err != nil {
@@ -3517,19 +3524,47 @@ const arrivalVerifyChecks = 10
 // signature and must not be reported as success.
 const arrivalStrictBytes = 1023
 
+// sendArrivalBaseline is the pre-send state the arrival check measures change
+// against. Every field here is meaningless on its own and meaningful only as a
+// delta (see the comment at the capture site).
+type sendArrivalBaseline struct {
+	// occurrences is how many copies of the message body were already
+	// visible in the pane before the send.
+	occurrences int
+	// wasActive reports whether the agent was already working before the
+	// send, in which case "it is active now" proves nothing.
+	wasActive bool
+}
+
+// captureArrivalBaseline snapshots the pane and status before a send.
+func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
+	base := sendArrivalBaseline{occurrences: countMessageInPane(target, message)}
+	if status, err := target.GetStatus(); err == nil && status == "active" {
+		base.wasActive = true
+	}
+	return base
+}
+
 // verifyContentArrival confirms that message reached the target pane, for
 // tools whose TUI exposes no Claude-shaped submit signal (issue #1793).
 //
-// Evidence is either the message body appearing in the captured pane, or the
-// session going "active" right after the send — an agent that started working
-// necessarily received what it is working on.
+// Evidence is a TRANSITION from the pre-send baseline, never a snapshot:
+// either a new copy of the body appearing in the pane, or the agent going
+// active when it was not active before the send — an idle agent that starts
+// working necessarily received what it started working on. An agent that was
+// already busy stays busy regardless, so that case proves nothing and is not
+// accepted.
 //
 // The pane comparison is whitespace-insensitive because a pane wraps long
 // lines at its width and capture-pane returns those wraps as newlines, so a
 // byte-exact search for a 64-character token fails on any message wider than
 // the remaining columns. Stripping whitespace from both sides restores the
 // contiguity the terminal broke.
-func verifyContentArrival(target sendRetryTarget, message string, opts sendRetryOptions, baseline int) (string, error) {
+//
+// A failed pre-send capture yields a zero baseline, which degrades the check
+// to plain containment — what it would have been anyway — rather than to a
+// stricter verdict the evidence doesn't support.
+func verifyContentArrival(target sendRetryTarget, message string, opts sendRetryOptions, baseline sendArrivalBaseline) (string, error) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
 		// No distinctive token to look for (very short or all-whitespace
@@ -3547,11 +3582,13 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 	}
 
 	for i := 0; i < checks; i++ {
-		if countMessageInPane(target, message) > baseline {
+		if countMessageInPane(target, message) > baseline.occurrences {
 			return deliveryArrived, nil
 		}
-		if status, err := target.GetStatus(); err == nil && status == "active" {
-			return deliveryArrived, nil
+		if !baseline.wasActive {
+			if status, err := target.GetStatus(); err == nil && status == "active" {
+				return deliveryArrived, nil
+			}
 		}
 		if i < checks-1 {
 			time.Sleep(opts.checkDelay)
@@ -3560,9 +3597,10 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 
 	if len(message) >= arrivalStrictBytes {
 		return deliveryNoEvidence, fmt.Errorf(
-			"send not delivered: a %d-byte message never appeared in the pane and the agent never went active "+
-				"after %d checks (issue #1793). A payload this size is lost outright when the pane's reader "+
-				"buffers input per line, so this is reported as a failure rather than as an unverified success",
+			"send not delivered: a %d-byte message never appeared in the pane and the agent showed no new "+
+				"activity after %d checks (issue #1793). A payload this size is lost outright when the pane's "+
+				"reader buffers input per line, so this is reported as a failure rather than as an unverified "+
+				"success",
 			len(message), checks)
 	}
 	return deliveryUnverified, nil

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2997,11 +2997,14 @@ const (
 	// canonical-overflow failure mode cannot apply and it carries no token
 	// distinctive enough to look for in the pane.
 	deliveryUnverified = "unverified"
-	// deliveryArrived: the message body was observed in the target pane (or
-	// the agent went active right after the send), so it demonstrably
-	// arrived. Used for tools whose TUI exposes no Claude-shaped submit
-	// signal — arrival is proven, submission is inferred from it.
-	deliveryArrived = "arrived"
+	// deliveryTyped: the message body was observed reaching the target pane,
+	// but nothing proved the agent accepted it as a turn. Strictly better
+	// than the old blind "unverified" — the bytes demonstrably arrived — and
+	// strictly weaker than deliverySubmitted, which is the point: content
+	// sitting in a composer is not an accepted turn, and calling it one is
+	// how issue #1793 happened in the first place. Carries
+	// `"submitted": false` in --json so callers cannot mistake it.
+	deliveryTyped = "typed"
 	// deliveryLineTooLong: refused before typing anything because the pane's
 	// reader is in canonical mode and a payload line exceeds its line buffer
 	// (issue #1793). The kernel would discard the overflow and the
@@ -3046,6 +3049,11 @@ func (r sendDeliveryResult) jsonFields() map[string]interface{} {
 	fields := map[string]interface{}{}
 	if r.delivery != "" {
 		fields["delivery"] = r.delivery
+		// Explicit, machine-checkable: a caller must not have to know which
+		// delivery strings imply an accepted turn. Only deliverySubmitted
+		// does; `typed` in particular means the bytes arrived and nothing
+		// confirmed the agent took them up (issue #1793).
+		fields["submitted"] = r.delivery == deliverySubmitted
 	}
 	if ms := r.held.Milliseconds(); ms > 0 {
 		fields["held_for_composer_ms"] = ms
@@ -3514,15 +3522,19 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 // cover a redraw, not a reply: at the callers' 200ms checkDelay that is ~2s.
 const arrivalVerifyChecks = 10
 
-// arrivalStrictBytes is the payload size at or above which a failed arrival
-// check is a hard failure rather than an "unverified" shrug. It is the same
-// always-safe line size the tmux transport uses (internal/tmux
-// canonicalSafeBytes): below it the canonical-overflow loss mode of issue
-// #1793 cannot occur, so a missed pane match is far more likely to be a
-// rendering quirk than a lost message, and the historical best-effort
-// contract is kept. At or above it a missed match is the actual bug
-// signature and must not be reported as success.
-const arrivalStrictBytes = 1023
+// arrivalSafeLineBytes is the longest LINE that no line discipline can lose,
+// and therefore the threshold above which an unconfirmed send is a failure
+// rather than an "unverified" shrug. Same figure the tmux transport treats as
+// always-safe (internal/tmux canonicalSafeBytes): at or below it the
+// canonical-overflow loss mode of issue #1793 cannot occur, so a missed pane
+// match is far likelier to be a rendering quirk than a lost message and the
+// historical best-effort contract is kept. Above it a missed match is the
+// actual bug signature and must not be reported as success.
+//
+// Measured per LINE, deliberately. Gating on total payload size would fail a
+// 20 KB body of short lines that the transport in this same change delivers
+// without trouble.
+const arrivalSafeLineBytes = 1023
 
 // sendArrivalBaseline is the pre-send state the arrival check measures change
 // against. Every field here is meaningless on its own and meaningful only as a
@@ -3531,16 +3543,30 @@ type sendArrivalBaseline struct {
 	// occurrences is how many copies of the message body were already
 	// visible in the pane before the send.
 	occurrences int
+	// paneOK reports that the pre-send capture actually succeeded. When it
+	// did not there is NO baseline, and the content signal must be switched
+	// off rather than defaulted to zero: a failed look would otherwise make
+	// a pre-existing copy of a repeated message read as a new arrival.
+	paneOK bool
 	// wasActive reports whether the agent was already working before the
 	// send, in which case "it is active now" proves nothing.
 	wasActive bool
+	// statusOK reports that the pre-send status read succeeded. Same reason:
+	// a failed read defaulting to "was not active" would turn a
+	// continuously-busy agent into a fake not-active-to-active transition.
+	statusOK bool
 }
 
-// captureArrivalBaseline snapshots the pane and status before a send.
+// captureArrivalBaseline snapshots the pane and status before a send. Each
+// signal records whether it was actually observed; a signal without a valid
+// baseline is disabled, never guessed.
 func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
-	base := sendArrivalBaseline{occurrences: countMessageInPane(target, message)}
-	if status, err := target.GetStatus(); err == nil && status == "active" {
-		base.wasActive = true
+	base := sendArrivalBaseline{}
+	if n, ok := countMessageInPane(target, message); ok {
+		base.occurrences, base.paneOK = n, true
+	}
+	if status, err := target.GetStatus(); err == nil {
+		base.wasActive, base.statusOK = status == "active", true
 	}
 	return base
 }
@@ -3555,21 +3581,43 @@ func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalB
 // already busy stays busy regardless, so that case proves nothing and is not
 // accepted.
 //
+// The two signals are not equal in strength, and the result says which one
+// was found. An idle agent going active is attributable to this send, so that
+// is deliverySubmitted. The body appearing is only deliveryTyped: bytes in a
+// composer are not an accepted turn — Enter can still have been swallowed,
+// which is the failure #1413 and #1793 are both about.
+//
 // The pane comparison is whitespace-insensitive because a pane wraps long
 // lines at its width and capture-pane returns those wraps as newlines, so a
 // byte-exact search for a 64-character token fails on any message wider than
 // the remaining columns. Stripping whitespace from both sides restores the
 // contiguity the terminal broke.
 //
-// A failed pre-send capture yields a zero baseline, which degrades the check
-// to plain containment — what it would have been anyway — rather than to a
-// stricter verdict the evidence doesn't support.
+// A signal whose pre-send baseline could not be read is switched OFF, not
+// defaulted: without a baseline there is no transition to measure, and
+// guessing one is how a failed capture would quietly become fake evidence.
 func verifyContentArrival(target sendRetryTarget, message string, opts sendRetryOptions, baseline sendArrivalBaseline) (string, error) {
+	// Whether an unverified outcome is a failure depends on the longest LINE,
+	// not on the total payload. Canonical buffering is per line — that is the
+	// whole finding this fix rests on — so a 20 KB body of 80-byte lines is
+	// as deliverable as a one-liner, and failing it for its total size would
+	// contradict the transport in the same commit.
+	riskyLine := longestMessageLineBytes(message) > arrivalSafeLineBytes
+
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
-		// No distinctive token to look for (very short or all-whitespace
-		// message). Verification is impossible rather than failed: say so
-		// instead of inventing either verdict.
+		// Nothing distinctive enough to look for. Verification is impossible
+		// rather than failed — but "impossible" must not become an exit 0 for
+		// a payload with a line big enough to be silently eaten, which would
+		// leave the reported bug wide open through the token-less door.
+		if riskyLine {
+			return deliveryNoEvidence, fmt.Errorf(
+				"send could not be verified: this message has a %d-byte line, long enough that a "+
+					"canonical-mode reader can discard it along with the submitting Enter, and it carries no "+
+					"content distinctive enough to look for in the pane (issue #1793). Refusing to report "+
+					"success for a send nothing can confirm",
+				longestMessageLineBytes(message))
+		}
 		return deliveryUnverified, nil
 	}
 
@@ -3581,13 +3629,20 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		checks = 1
 	}
 
+	sawBody := false
 	for i := 0; i < checks; i++ {
-		if countMessageInPane(target, message) > baseline.occurrences {
-			return deliveryArrived, nil
-		}
-		if !baseline.wasActive {
+		// Strongest signal first: an idle agent that starts working received
+		// what it started working on, which is submission, not just arrival.
+		if baseline.statusOK && !baseline.wasActive {
 			if status, err := target.GetStatus(); err == nil && status == "active" {
-				return deliveryArrived, nil
+				return deliverySubmitted, nil
+			}
+		}
+		if baseline.paneOK {
+			if n, ok := countMessageInPane(target, message); ok && n > baseline.occurrences {
+				// Keep polling: the body is in, but the turn may still start
+				// within the budget and upgrade this to submitted.
+				sawBody = true
 			}
 		}
 		if i < checks-1 {
@@ -3595,30 +3650,51 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		}
 	}
 
-	if len(message) >= arrivalStrictBytes {
+	if sawBody {
+		// The bytes demonstrably reached the pane and nothing showed the
+		// agent taking them up. Reported honestly as typed, never as
+		// submitted.
+		return deliveryTyped, nil
+	}
+
+	if riskyLine {
 		return deliveryNoEvidence, fmt.Errorf(
-			"send not delivered: a %d-byte message never appeared in the pane and the agent showed no new "+
-				"activity after %d checks (issue #1793). A payload this size is lost outright when the pane's "+
-				"reader buffers input per line, so this is reported as a failure rather than as an unverified "+
-				"success",
-			len(message), checks)
+			"send could not be confirmed: a message with a %d-byte line never appeared in the pane and the "+
+				"agent showed no new activity after %d checks (issue #1793). A line that long is discarded "+
+				"outright — together with the submitting Enter — by a canonical-mode reader, so this is "+
+				"reported as a failure rather than as an unverified success",
+			longestMessageLineBytes(message), checks)
 	}
 	return deliveryUnverified, nil
 }
 
+// longestMessageLineBytes is the length of the longest \n-delimited line of
+// message. Mirrors the quantity the tmux transport measures, because the
+// terminal limit this whole fix is about is per line, not per payload.
+func longestMessageLineBytes(message string) int {
+	longest := 0
+	for _, line := range strings.Split(message, "\n") {
+		if len(line) > longest {
+			longest = len(line)
+		}
+	}
+	return longest
+}
+
 // countMessageInPane reports how many times the message's distinctive token
-// appears in the pane right now. Returns 0 when the pane cannot be captured
-// or the message has no usable token — a failed look is never evidence.
-func countMessageInPane(target sendRetryTarget, message string) int {
+// appears in the pane right now. The bool reports whether the pane was
+// actually read: a failed look is not "zero occurrences", it is no
+// observation at all, and callers must not treat the two the same.
+func countMessageInPane(target sendRetryTarget, message string) (int, bool) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
-		return 0
+		return 0, false
 	}
 	raw, err := target.CapturePaneFresh()
 	if err != nil {
-		return 0
+		return 0, false
 	}
-	return strings.Count(collapseWhitespace(tmux.StripANSI(raw)), token)
+	return strings.Count(collapseWhitespace(tmux.StripANSI(raw)), token), true
 }
 
 // collapseWhitespace removes every whitespace byte, so a comparison survives

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3308,6 +3308,17 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		opts.checkDelay = 0
 	}
 
+	// Baseline for the arrival check below. Taken BEFORE the send, because
+	// "the body is on screen" is not evidence on its own: re-sending an
+	// identical message (a heartbeat, an inbox nudge, a retry) would match
+	// the previous copy still sitting in the pane and certify a send that
+	// vanished. Only an INCREASE in occurrences is evidence. Costs one pane
+	// capture, and only on the path that needs it.
+	arrivalBaseline := 0
+	if skipVerify {
+		arrivalBaseline = countMessageInPane(target, message)
+	}
+
 	if err := target.SendKeysAndEnter(message); err != nil {
 		// A refused over-long line is a distinct, actionable outcome: the
 		// transport typed nothing, so the composer is untouched and the
@@ -3325,7 +3336,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		// how a 4095-byte payload that never reached the agent was reported
 		// as `{"success":true,"delivery":"unverified"}`. Confirm the body
 		// actually reached the pane before claiming anything.
-		return verifyContentArrival(target, message, opts)
+		return verifyContentArrival(target, message, opts, arrivalBaseline)
 	}
 
 	// Verify the agent accepted Enter and began processing.
@@ -3518,7 +3529,7 @@ const arrivalStrictBytes = 1023
 // byte-exact search for a 64-character token fails on any message wider than
 // the remaining columns. Stripping whitespace from both sides restores the
 // contiguity the terminal broke.
-func verifyContentArrival(target sendRetryTarget, message string, opts sendRetryOptions) (string, error) {
+func verifyContentArrival(target sendRetryTarget, message string, opts sendRetryOptions, baseline int) (string, error) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
 		// No distinctive token to look for (very short or all-whitespace
@@ -3536,10 +3547,8 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 	}
 
 	for i := 0; i < checks; i++ {
-		if raw, err := target.CapturePaneFresh(); err == nil {
-			if strings.Contains(collapseWhitespace(tmux.StripANSI(raw)), token) {
-				return deliveryArrived, nil
-			}
+		if countMessageInPane(target, message) > baseline {
+			return deliveryArrived, nil
 		}
 		if status, err := target.GetStatus(); err == nil && status == "active" {
 			return deliveryArrived, nil
@@ -3557,6 +3566,21 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 			len(message), checks)
 	}
 	return deliveryUnverified, nil
+}
+
+// countMessageInPane reports how many times the message's distinctive token
+// appears in the pane right now. Returns 0 when the pane cannot be captured
+// or the message has no usable token — a failed look is never evidence.
+func countMessageInPane(target sendRetryTarget, message string) int {
+	token := collapseWhitespace(messageDeliveryToken(message))
+	if token == "" {
+		return 0
+	}
+	raw, err := target.CapturePaneFresh()
+	if err != nil {
+		return 0
+	}
+	return strings.Count(collapseWhitespace(tmux.StripANSI(raw)), token)
 }
 
 // collapseWhitespace removes every whitespace byte, so a comparison survives

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2834,9 +2834,17 @@ func handleSessionSend(profile string, args []string) {
 		extra := sendRes.jsonFields()
 		extra["session_id"] = inst.ID
 		extra["session_title"] = inst.Title
-		if sendRes.delivery == deliveryTypedNotSubmitted {
+		switch sendRes.delivery {
+		case deliveryTypedNotSubmitted:
 			out.ErrorWithData(fmt.Sprintf("message typed but not submitted to '%s': %v", inst.Title, sendErr), ErrCodeDeliveryFailed, extra)
-		} else {
+		case deliveryLineTooLong:
+			// Nothing was typed, so the composer is exactly as the operator
+			// left it. Retrying the same body is pointless; the actionable
+			// advice is to break the line or send a file reference.
+			out.ErrorWithData(fmt.Sprintf("message too long for '%s' to receive as one line: %v", inst.Title, sendErr), ErrCodeDeliveryFailed, extra)
+		case deliveryNoEvidence:
+			out.ErrorWithData(fmt.Sprintf("message not delivered to '%s': %v", inst.Title, sendErr), ErrCodeDeliveryFailed, extra)
+		default:
 			out.ErrorWithData(fmt.Sprintf("failed to send message: %v", sendErr), ErrCodeInvalidOperation, extra)
 		}
 		os.Exit(1)
@@ -2981,10 +2989,24 @@ const (
 	// deliverySubmitted: positive evidence the agent accepted the message
 	// (an "active" transition, or the composer cleared after holding it).
 	deliverySubmitted = "submitted"
-	// deliveryUnverified: the message was sent but this tool's TUI exposes
-	// no Claude-shaped verification signals, so submission is unverified
-	// (non-Claude tools; legacy best-effort contract).
+	// deliveryUnverified: the message was sent but neither Claude-shaped
+	// submission signals nor a content-arrival check could reach a verdict,
+	// so submission is genuinely unknown. Since issue #1793 this is the
+	// narrow "we could not tell" bucket, not the catch-all it used to be:
+	// a send only lands here when the payload is small enough that the
+	// canonical-overflow failure mode cannot apply and it carries no token
+	// distinctive enough to look for in the pane.
 	deliveryUnverified = "unverified"
+	// deliveryArrived: the message body was observed in the target pane (or
+	// the agent went active right after the send), so it demonstrably
+	// arrived. Used for tools whose TUI exposes no Claude-shaped submit
+	// signal — arrival is proven, submission is inferred from it.
+	deliveryArrived = "arrived"
+	// deliveryLineTooLong: refused before typing anything because the pane's
+	// reader is in canonical mode and a payload line exceeds its line buffer
+	// (issue #1793). The kernel would discard the overflow and the
+	// submitting Enter with it, so this can never be reported as success.
+	deliveryLineTooLong = "line_too_long"
 	// deliveryTypedNotSubmitted: the message body is still sitting unsent in
 	// the composer after the bounded Enter-retry budget (issue #1413).
 	deliveryTypedNotSubmitted = "typed_not_submitted"
@@ -3287,11 +3309,23 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	}
 
 	if err := target.SendKeysAndEnter(message); err != nil {
+		// A refused over-long line is a distinct, actionable outcome: the
+		// transport typed nothing, so the composer is untouched and the
+		// caller must not retry the same body against the same pane
+		// (issue #1793).
+		if errors.Is(err, tmux.ErrCanonicalLineOverflow) {
+			return deliveryLineTooLong, fmt.Errorf("message not delivered: %w", err)
+		}
 		return deliverySendFailed, fmt.Errorf("failed to send message: %w", err)
 	}
 
 	if skipVerify {
-		return deliveryUnverified, nil
+		// Issue #1793: "the tmux command returned" is not delivery. This
+		// path used to return success on transport alone, which is exactly
+		// how a 4095-byte payload that never reached the agent was reported
+		// as `{"success":true,"delivery":"unverified"}`. Confirm the body
+		// actually reached the pane before claiming anything.
+		return verifyContentArrival(target, message, opts)
 	}
 
 	// Verify the agent accepted Enter and began processing.
@@ -3457,6 +3491,80 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 // suitable for "did this body appear in the pane?" verification. Returns "" if
 // the message contains no usefully-distinctive token (e.g. all whitespace, or
 // only short common words).
+// arrivalVerifyChecks bounds the post-send content-arrival poll. The body
+// echoes into the pane as fast as the agent redraws, so this only has to
+// cover a redraw, not a reply: at the callers' 200ms checkDelay that is ~2s.
+const arrivalVerifyChecks = 10
+
+// arrivalStrictBytes is the payload size at or above which a failed arrival
+// check is a hard failure rather than an "unverified" shrug. It is the same
+// always-safe line size the tmux transport uses (internal/tmux
+// canonicalSafeBytes): below it the canonical-overflow loss mode of issue
+// #1793 cannot occur, so a missed pane match is far more likely to be a
+// rendering quirk than a lost message, and the historical best-effort
+// contract is kept. At or above it a missed match is the actual bug
+// signature and must not be reported as success.
+const arrivalStrictBytes = 1023
+
+// verifyContentArrival confirms that message reached the target pane, for
+// tools whose TUI exposes no Claude-shaped submit signal (issue #1793).
+//
+// Evidence is either the message body appearing in the captured pane, or the
+// session going "active" right after the send — an agent that started working
+// necessarily received what it is working on.
+//
+// The pane comparison is whitespace-insensitive because a pane wraps long
+// lines at its width and capture-pane returns those wraps as newlines, so a
+// byte-exact search for a 64-character token fails on any message wider than
+// the remaining columns. Stripping whitespace from both sides restores the
+// contiguity the terminal broke.
+func verifyContentArrival(target sendRetryTarget, message string, opts sendRetryOptions) (string, error) {
+	token := collapseWhitespace(messageDeliveryToken(message))
+	if token == "" {
+		// No distinctive token to look for (very short or all-whitespace
+		// message). Verification is impossible rather than failed: say so
+		// instead of inventing either verdict.
+		return deliveryUnverified, nil
+	}
+
+	checks := opts.maxRetries
+	if checks > arrivalVerifyChecks {
+		checks = arrivalVerifyChecks
+	}
+	if checks < 1 {
+		checks = 1
+	}
+
+	for i := 0; i < checks; i++ {
+		if raw, err := target.CapturePaneFresh(); err == nil {
+			if strings.Contains(collapseWhitespace(tmux.StripANSI(raw)), token) {
+				return deliveryArrived, nil
+			}
+		}
+		if status, err := target.GetStatus(); err == nil && status == "active" {
+			return deliveryArrived, nil
+		}
+		if i < checks-1 {
+			time.Sleep(opts.checkDelay)
+		}
+	}
+
+	if len(message) >= arrivalStrictBytes {
+		return deliveryNoEvidence, fmt.Errorf(
+			"send not delivered: a %d-byte message never appeared in the pane and the agent never went active "+
+				"after %d checks (issue #1793). A payload this size is lost outright when the pane's reader "+
+				"buffers input per line, so this is reported as a failure rather than as an unverified success",
+			len(message), checks)
+	}
+	return deliveryUnverified, nil
+}
+
+// collapseWhitespace removes every whitespace byte, so a comparison survives
+// the line wrapping a terminal applies to long content.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), "")
+}
+
 func messageDeliveryToken(message string) string {
 	const minTokenLen = 12
 	const maxTokenLen = 64

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2842,6 +2842,8 @@ func handleSessionSend(profile string, args []string) {
 			// left it. Retrying the same body is pointless; the actionable
 			// advice is to break the line or send a file reference.
 			out.ErrorWithData(fmt.Sprintf("message too long for '%s' to receive as one line: %v", inst.Title, sendErr), ErrCodeDeliveryFailed, extra)
+		case deliveryTyped:
+			out.ErrorWithData(fmt.Sprintf("message reached '%s' but was never confirmed submitted: %v", inst.Title, sendErr), ErrCodeDeliveryFailed, extra)
 		case deliveryNoEvidence:
 			out.ErrorWithData(fmt.Sprintf("message not delivered to '%s': %v", inst.Title, sendErr), ErrCodeDeliveryFailed, extra)
 		default:
@@ -2998,12 +3000,13 @@ const (
 	// distinctive enough to look for in the pane.
 	deliveryUnverified = "unverified"
 	// deliveryTyped: the message body was observed reaching the target pane,
-	// but nothing proved the agent accepted it as a turn. Strictly better
-	// than the old blind "unverified" — the bytes demonstrably arrived — and
-	// strictly weaker than deliverySubmitted, which is the point: content
-	// sitting in a composer is not an accepted turn, and calling it one is
-	// how issue #1793 happened in the first place. Carries
-	// `"submitted": false` in --json so callers cannot mistake it.
+	// but nothing proved the agent accepted it as a turn. Content sitting in
+	// a composer is not an accepted turn, and calling it one is how issue
+	// #1793 happened in the first place — so this is a FAILURE: nonzero exit,
+	// `"success": false`, `"submitted": false`. It is distinct from
+	// deliveryTypedNotSubmitted, which is the stronger claim that the
+	// composer was still positively holding the message at the end of the
+	// bounded Enter retries.
 	deliveryTyped = "typed"
 	// deliveryLineTooLong: refused before typing anything because the pane's
 	// reader is in canonical mode and a payload line exceeds its line buffer
@@ -3384,11 +3387,26 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	fullResendCount := 0
 	// sawDeliveryEvidence flips true on any positive signal that the message
 	// reached the agent: an "active" status transition, an unsent-prompt
-	// composer marker, the message body appearing verbatim in the pane, or a
-	// successful full resend. When opts.verifyDelivery is set and this stays
-	// false for the entire budget, the function returns an error instead of
-	// silently succeeding (issue #876).
+	// composer marker, or the message body appearing verbatim in the pane.
+	// When opts.verifyDelivery is set and this stays false for the entire
+	// budget, the function returns an error instead of silently succeeding
+	// (issue #876).
+	//
+	// ARRIVAL IS NOT SUBMISSION. Two of those three signals — body text in the
+	// pane, and an unsent-prompt marker — say the bytes got there and say
+	// nothing about the agent accepting them. The unsent-prompt marker
+	// literally means the opposite. Only sawActiveAfterSend below is
+	// submission evidence, and conflating the two is what let this function
+	// return deliverySubmitted for a message still sitting in a composer:
+	// the exact phantom success of issue #1793, on the Claude path.
 	sawDeliveryEvidence := false
+	// sawUnsentMarker records that the composer was positively observed
+	// HOLDING this message at some point. Combined with the composer being
+	// clear at the end of the budget (checked below), held-then-cleared is
+	// genuine submission evidence: the agent took the message out of the
+	// composer. Body text merely being visible is not the same thing and must
+	// not be treated as if it were.
+	sawUnsentMarker := false
 	// Snippet of the message body to look for in captured pane content. Some
 	// TUI frameworks (and non-Claude tools) won't render a "[Pasted text …]"
 	// or "❯ <msg>" marker, so direct verbatim content is the only signal.
@@ -3410,6 +3428,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 
 		if unsentPromptDetected {
 			sawDeliveryEvidence = true
+			sawUnsentMarker = true
 			waitingNoMarkerChecks = 0
 			waitingNoActivityChecks = 0
 			activeChecks = 0
@@ -3504,9 +3523,26 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				"and the message body was not visible in the pane. Verify the inner agent is reading from "+
 				"its TTY before retrying", opts.maxRetries)
 		}
-		// Evidence was observed and the composer no longer holds the message:
-		// it was accepted at some point during the budget.
-		return deliverySubmitted, nil
+		if sawActiveAfterSend {
+			// The agent went active after the send: it took the message up.
+			return deliverySubmitted, nil
+		}
+		if sawUnsentMarker {
+			// The composer was observed holding this message and — per the
+			// typed_not_submitted check just above, which did not fire — is
+			// no longer holding it. Held-then-cleared means the agent took it
+			// out of the composer, which is submission.
+			return deliverySubmitted, nil
+		}
+		// The only thing ever observed was the body being visible somewhere in
+		// the pane. That proves the bytes arrived and proves nothing about the
+		// agent accepting them: the Enter can still have been swallowed. Do
+		// not promote arrival to submission — that promotion IS issue #1793.
+		return deliveryTyped, fmt.Errorf(
+			"message reached the pane but submission was never confirmed after %d checks (issue #1793): "+
+				"the body was visible but the agent never began processing it and the composer was never "+
+				"observed taking it. Treat this as NOT delivered — the submitting Enter may have been "+
+				"swallowed", opts.maxRetries)
 	}
 
 	// Legacy best-effort contract for paths that gate verification elsewhere.
@@ -3602,7 +3638,17 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 	// whole finding this fix rests on — so a 20 KB body of 80-byte lines is
 	// as deliverable as a one-liner, and failing it for its total size would
 	// contradict the transport in the same commit.
-	riskyLine := longestMessageLineBytes(message) > arrivalSafeLineBytes
+	//
+	// The comparison is against the pane's own capacity where that can be
+	// measured, and only against the universal floor when it cannot. The
+	// floor is what EVERY pane can take, not what THIS pane can take: a
+	// raw-mode pane has no line limit at all, so judging it by the floor
+	// would condemn perfectly deliverable sends.
+	longestLine := longestMessageLineBytes(message)
+	riskyLine := false
+	if longestLine > arrivalSafeLineBytes {
+		riskyLine = longestLine > maxDeliverableLineBytes(target)
+	}
 
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
@@ -3616,7 +3662,7 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 					"canonical-mode reader can discard it along with the submitting Enter, and it carries no "+
 					"content distinctive enough to look for in the pane (issue #1793). Refusing to report "+
 					"success for a send nothing can confirm",
-				longestMessageLineBytes(message))
+				longestLine)
 		}
 		return deliveryUnverified, nil
 	}
@@ -3652,9 +3698,15 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 
 	if sawBody {
 		// The bytes demonstrably reached the pane and nothing showed the
-		// agent taking them up. Reported honestly as typed, never as
-		// submitted.
-		return deliveryTyped, nil
+		// agent taking them up. This is NOT a success: text sitting unsent in
+		// a composer is precisely the state issue #1793 reported as a false
+		// success, and returning nil here would hand the caller exit 0 and
+		// `"success": true` next to `"submitted": false`. Fail, so scripts and
+		// agents cannot read it as delivered.
+		return deliveryTyped, fmt.Errorf(
+			"message reached the pane but submission was never confirmed after %d checks (issue #1793): "+
+				"the body is visible but the agent never began processing it. Treat this as NOT delivered — "+
+				"the submitting Enter may have been swallowed", checks)
 	}
 
 	if riskyLine {
@@ -3663,22 +3715,53 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 				"agent showed no new activity after %d checks (issue #1793). A line that long is discarded "+
 				"outright — together with the submitting Enter — by a canonical-mode reader, so this is "+
 				"reported as a failure rather than as an unverified success",
-			longestMessageLineBytes(message), checks)
+			longestLine, checks)
 	}
 	return deliveryUnverified, nil
 }
 
-// longestMessageLineBytes is the length of the longest \n-delimited line of
-// message. Mirrors the quantity the tmux transport measures, because the
-// terminal limit this whole fix is about is per line, not per payload.
+// longestMessageLineBytes is the length of the longest line of message.
+// Mirrors the quantity the tmux transport measures, because the terminal
+// limit this whole fix is about is per line, not per payload. Both \n and \r
+// end a line: with ICRNL set (the tty default) an incoming CR becomes NL
+// before the line discipline sees it, so counting only \n would read a
+// CR-delimited body as one enormous line.
 func longestMessageLineBytes(message string) int {
 	longest := 0
-	for _, line := range strings.Split(message, "\n") {
+	for _, line := range strings.FieldsFunc(message, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	}) {
 		if len(line) > longest {
 			longest = len(line)
 		}
 	}
 	return longest
+}
+
+// paneLineCapacityReporter is implemented by *tmux.Session. It is an optional
+// capability, discovered by type assertion, so the interface sendRetryTarget
+// stays small and existing fakes keep working: a target that cannot report a
+// capacity simply falls back to the universal floor.
+type paneLineCapacityReporter interface {
+	PaneLineCapacity() (int, bool)
+}
+
+// maxDeliverableLineBytes returns the longest single line this target can
+// accept. It prefers the pane's DETECTED capacity — a raw-mode pane has no
+// line limit and a Linux canonical pane holds four times what the floor
+// assumes — and only falls back to arrivalSafeLineBytes when the pane cannot
+// be probed. Without this, a 2000-byte line that delivers perfectly to any
+// raw-mode agent TUI would be reported as lost purely because 2000 > 1023.
+//
+// Only consulted when a line already exceeds the floor, so ordinary sends
+// never pay for the probe.
+func maxDeliverableLineBytes(target sendRetryTarget) int {
+	if reporter, ok := target.(paneLineCapacityReporter); ok {
+		if capacity, known := reporter.PaneLineCapacity(); known && capacity > 0 {
+			return capacity
+		}
+	}
+	return arrivalSafeLineBytes
 }
 
 // countMessageInPane reports how many times the message's distinctive token

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -1537,10 +1537,17 @@ func TestSendWithRetryTarget_VerifyDelivery_AcceptsUnsentMarker(t *testing.T) {
 	}
 }
 
-func TestSendWithRetryTarget_VerifyDelivery_AcceptsMessageInPane(t *testing.T) {
+func TestSendWithRetryTarget_VerifyDelivery_MessageInPaneIsReceiptNotSubmission(t *testing.T) {
 	// If the message body itself shows up in the captured pane (e.g. behind a
 	// non-Claude composer that doesn't render an "unsent paste" marker), that
-	// is direct evidence the keystrokes were received. Must not error.
+	// is direct evidence the keystrokes were RECEIVED — so this must never be
+	// reported as the #876 silent drop.
+	//
+	// Updated for issue #1793: it is not evidence the message was SUBMITTED.
+	// This test previously asserted err == nil, which meant a body sitting in
+	// a composer whose Enter was swallowed exited 0 as "delivered" — the
+	// phantom success #1793 was filed about. Receipt and submission are now
+	// separate verdicts.
 	statuses := make([]string, 6)
 	panes := make([]string, 6)
 	for i := range statuses {
@@ -1548,11 +1555,20 @@ func TestSendWithRetryTarget_VerifyDelivery_AcceptsMessageInPane(t *testing.T) {
 		panes[i] = "DELIVERY_TOKEN_876 — verbatim message body in pane"
 	}
 	mock := &mockSendRetryTarget{statuses: statuses, panes: panes}
-	_, err := sendWithRetryTarget(mock, "DELIVERY_TOKEN_876", false, sendRetryOptions{
+	delivery, err := sendWithRetryTarget(mock, "DELIVERY_TOKEN_876", false, sendRetryOptions{
 		maxRetries: 6, checkDelay: 0, verifyDelivery: true,
 	})
-	if err != nil {
-		t.Fatalf("verifyDelivery must accept message-in-pane as receipt evidence: %v", err)
+	if delivery == deliveryNoEvidence {
+		t.Fatal("#876: a verbatim body in the pane is receipt evidence and must not be a silent drop")
+	}
+	if err != nil && strings.Contains(err.Error(), "dropped silently") {
+		t.Fatalf("#876: must not report a silent drop when the body is visible: %v", err)
+	}
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q (received, submission unconfirmed), got %q", deliveryTyped, delivery)
+	}
+	if err == nil {
+		t.Fatal("issue #1793: received-but-not-submitted must not report success")
 	}
 }
 

--- a/cmd/agent-deck/session_send_token_test.go
+++ b/cmd/agent-deck/session_send_token_test.go
@@ -107,12 +107,32 @@ func TestSendWithRetryTarget_VerifyDelivery_LargePromptBodyMatch(t *testing.T) {
 	panes := []string{"", paneAfterPaste, paneAfterPaste, paneAfterPaste, paneAfterPaste}
 	mock := &mockSendRetryTarget{statuses: statuses, panes: panes}
 
-	_, err := sendWithRetryTarget(mock, body, false, sendRetryOptions{
+	delivery, err := sendWithRetryTarget(mock, body, false, sendRetryOptions{
 		maxRetries: 5, checkDelay: 0, verifyDelivery: true,
 	})
-	if err != nil {
-		t.Fatalf("verifyDelivery on large prompt must accept body-prefix match: got error %v "+
-			"(this is the S-CLI-4 / #876 conductor large-prompt silent-drop scenario)", err)
+	// #876's gap was the loop never NOTICING a large body, so it reported the
+	// message "dropped silently". The body-prefix match still closes that: the
+	// result must not be deliveryNoEvidence and must not be the silent-drop
+	// error.
+	if delivery == deliveryNoEvidence {
+		t.Fatalf("verifyDelivery on large prompt must accept body-prefix match as evidence the body "+
+			"arrived: got %q (this is the S-CLI-4 / #876 conductor large-prompt silent-drop scenario)", delivery)
+	}
+	if err != nil && strings.Contains(err.Error(), "dropped silently") {
+		t.Fatalf("#876: a visible body must not be reported as a silent drop: %v", err)
+	}
+	// Updated for issue #1793. This test used to assert err == nil, i.e. that
+	// a visible body means "delivered". It does not: here the status never
+	// leaves "waiting" and the composer is never seen taking the message, so
+	// the body arrived and nothing shows the agent accepted it. Reporting that
+	// as success is the phantom #1793 was filed about, so the honest outcome
+	// is `typed` with a non-nil error. #876's own guarantee — don't call a
+	// visible body a silent drop — is asserted above and still holds.
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q (arrived, submission unconfirmed), got %q", deliveryTyped, delivery)
+	}
+	if err == nil {
+		t.Fatal("issue #1793: body visible but never submitted must not report success")
 	}
 	// Sanity: the initial send fired exactly once. A regression that decided
 	// "large body → just retry harder" would inflate this and re-open #479.

--- a/internal/tmux/canonical_line.go
+++ b/internal/tmux/canonical_line.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -150,24 +151,54 @@ func (s *Session) paneLineDiscipline(target string) (lineDiscipline, error) {
 	return ld, nil
 }
 
-// longestLineBytes returns the length in bytes of the longest \n-delimited
-// line in content. Canonical buffering is per line, so this — not len(content)
-// — is the quantity that has to fit.
+// longestLineBytes returns the length in bytes of the longest line in content.
+// Canonical buffering is per line, so this — not len(content) — is the
+// quantity that has to fit.
+//
+// Both \n and \r end a line. A tty with ICRNL set (the default) turns an
+// incoming CR into NL before the line discipline sees it, so a CR-delimited or
+// CRLF payload is just as line-delimited as an LF one. Counting only \n would
+// measure a CR-delimited body as one enormous line and refuse a send that
+// would have delivered perfectly.
 func longestLineBytes(content string) int {
-	longest := 0
-	for {
-		i := strings.IndexByte(content, '\n')
-		if i < 0 {
-			if len(content) > longest {
-				longest = len(content)
+	longest, current := 0, 0
+	for i := 0; i < len(content); i++ {
+		if content[i] == '\n' || content[i] == '\r' {
+			if current > longest {
+				longest = current
 			}
-			return longest
+			current = 0
+			continue
 		}
-		if i > longest {
-			longest = i
-		}
-		content = content[i+1:]
+		current++
 	}
+	if current > longest {
+		longest = current
+	}
+	return longest
+}
+
+// PaneLineCapacity reports the largest single line, in bytes, that this
+// session's pane can currently accept, and whether that could be determined.
+//
+// A raw-mode reader has no line limit at all, so it reports math.MaxInt: the
+// caller's job is to distinguish "this pane cannot take a line that long" from
+// "this pane can take anything", and a raw pane is the second. A canonical
+// reader reports its buffer minus the byte the terminator needs. When the
+// discipline cannot be read at all the bool is false and the caller must fall
+// back to the universal floor rather than inventing a capacity.
+func (s *Session) PaneLineCapacity() (int, bool) {
+	ld, err := s.paneLineDiscipline(s.Name)
+	if err != nil {
+		return 0, false
+	}
+	if !ld.Canonical {
+		return math.MaxInt, true
+	}
+	if ld.MaxLine <= 0 {
+		return 0, false
+	}
+	return ld.MaxLine - 1, true
 }
 
 // runeSafeCut returns the largest cut point ≤ maxSize that does not land in

--- a/internal/tmux/canonical_line.go
+++ b/internal/tmux/canonical_line.go
@@ -1,0 +1,180 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Canonical-mode line buffering: why a big `session send` can vanish.
+//
+// A pane's tty has a line discipline. When the program reading the pane runs
+// in CANONICAL mode (ICANON set — a plain shell command like `cat`, a
+// `read` loop, any non-TUI reader), the kernel buffers input until a line
+// terminator arrives and only then hands the line to the reader. That buffer
+// is finite and it is PER LINE, not per write. Once a line exceeds the
+// buffer with no terminator in sight, the kernel throws input away — and the
+// Enter that would have submitted it is thrown away with it. The send
+// "succeeds" at every layer that can see it while nothing is delivered.
+//
+// Measured on the transports agent-deck can choose between (macOS 15.5,
+// tmux 3.7b, reader = `cat > file`, payload = N bytes of ASCII then Enter):
+//
+//	payload   send-keys -l   load-buffer+paste-buffer
+//	1000      1001 bytes     1001 bytes
+//	1023      1024 bytes     1024 bytes
+//	1024         0 bytes        0 bytes
+//	4095         0 bytes        0 bytes
+//
+// The cliff sits at 1024 bytes INCLUDING the terminator, and both transports
+// fall off it at exactly the same place. That is the finding that decides the
+// shape of this fix: the limit belongs to the READER's line discipline, so no
+// choice of writer — not chunked send-keys, not load-buffer/paste-buffer, not
+// bracketed paste — can move it. Issue #1793 assumed a 4096-byte boundary and
+// PR #1819 tried to fix it by shrinking send-keys chunks; neither matches what
+// the terminal actually does.
+//
+// Against the same panes with the reader in RAW mode (ICANON clear — every
+// TUI agent: Claude Code, Codex, a readline shell prompt) all three transports
+// delivered 8000 bytes intact. So the failure is not "big sends are broken",
+// it is "big sends into a canonical-mode reader are impossible", and the only
+// honest handling is to detect that state and refuse rather than to type half
+// a line into a buffer that will discard it.
+
+const (
+	// canonicalSafeBytes is the largest payload guaranteed to survive any
+	// pane's line discipline without inspecting it. 1023 = the smallest
+	// canonical line buffer agent-deck runs against (macOS MAX_CANON is
+	// 1024 and counts the line terminator; measured cliff above), minus the
+	// one byte the trailing Enter occupies.
+	//
+	// This is a "no questions asked" size, not the real limit: payloads
+	// above it are not assumed to fail, they are checked against the actual
+	// pane (see paneLineDiscipline).
+	canonicalSafeBytes = 1023
+
+	// canonMinDarwin is MAX_CANON on darwin (sys/syslimits.h: MAX_CANON 1024,
+	// enforced by the tty line discipline in bsd/kern/tty.c) and matches the
+	// measured cliff above.
+	canonMinDarwin = 1024
+
+	// canonMinLinux is the usable n_tty canonical buffer on Linux. The buffer
+	// is N_TTY_BUF_SIZE = 4096 (drivers/tty/n_tty.c) but n_tty_receive_char
+	// discards input once read_cnt reaches N_TTY_BUF_SIZE-1, so 4095 bytes
+	// including the terminator is what actually survives — which is why the
+	// 4095-byte payload in issue #1793 was lost on Linux while a 4094-byte
+	// one would not have been.
+	//
+	// This constant is deliberately used in preference to
+	// fpathconf(_PC_MAX_CANON), which reports the POSIX minimum of 255 on
+	// Linux while the kernel really buffers 4095; trusting fpathconf there
+	// would reject ordinary 300-byte sends.
+	canonMinLinux = 4095
+)
+
+// ErrCanonicalLineOverflow reports that a payload cannot be delivered to the
+// target pane because the pane's reader is in canonical mode and one of the
+// payload's lines is longer than that pane's canonical line buffer. Callers
+// must surface this as a delivery FAILURE: nothing was typed, so nothing was
+// corrupted, and retrying the same body against the same pane will fail the
+// same way.
+var ErrCanonicalLineOverflow = errors.New("payload line exceeds the pane's canonical-mode line buffer")
+
+// CanonicalOverflowError carries the measured numbers behind
+// ErrCanonicalLineOverflow so the CLI can report them instead of a guess.
+type CanonicalOverflowError struct {
+	// LineBytes is the length of the longest line in the payload.
+	LineBytes int
+	// LimitBytes is the pane's canonical line buffer, terminator included.
+	LimitBytes int
+	// TTY is the pane's tty path, as reported by tmux.
+	TTY string
+}
+
+func (e *CanonicalOverflowError) Error() string {
+	return fmt.Sprintf(
+		"%v: longest payload line is %d bytes but %s is in canonical mode with a %d-byte line buffer "+
+			"(terminator included), so the kernel would discard the overflow and the submitting Enter with it; "+
+			"nothing was typed",
+		ErrCanonicalLineOverflow, e.LineBytes, e.TTY, e.LimitBytes)
+}
+
+func (e *CanonicalOverflowError) Unwrap() error { return ErrCanonicalLineOverflow }
+
+// lineDiscipline is the observed input mode of a pane's tty.
+type lineDiscipline struct {
+	// Canonical is true when the reader has ICANON set, i.e. the kernel is
+	// buffering input per line instead of delivering it byte by byte.
+	Canonical bool
+	// MaxLine is the canonical line buffer in bytes, terminator included.
+	// Only meaningful when Canonical is true.
+	MaxLine int
+	// TTY is the pane's tty device path.
+	TTY string
+}
+
+// paneLineDiscipline reads the line discipline of target's tty. It costs one
+// `tmux display-message` plus one open+tcgetattr, so callers must only reach
+// for it when a payload is actually large enough to care (> canonicalSafeBytes).
+// An error means "could not tell" — never "safe" and never "unsafe"; callers
+// treat an unreadable discipline as unknown and fall through to delivery plus
+// verification rather than refusing.
+func (s *Session) paneLineDiscipline(target string) (lineDiscipline, error) {
+	out, err := s.runBoundedOutput("display-message", "-t", target, "-p", "#{pane_tty}")
+	if err != nil {
+		return lineDiscipline{}, fmt.Errorf("read pane tty: %w", err)
+	}
+	tty := strings.TrimSpace(string(out))
+	if tty == "" {
+		return lineDiscipline{}, errors.New("read pane tty: tmux reported no tty for the pane")
+	}
+	ld, err := ttyLineDiscipline(tty)
+	if err != nil {
+		return lineDiscipline{}, err
+	}
+	ld.TTY = tty
+	return ld, nil
+}
+
+// longestLineBytes returns the length in bytes of the longest \n-delimited
+// line in content. Canonical buffering is per line, so this — not len(content)
+// — is the quantity that has to fit.
+func longestLineBytes(content string) int {
+	longest := 0
+	for {
+		i := strings.IndexByte(content, '\n')
+		if i < 0 {
+			if len(content) > longest {
+				longest = len(content)
+			}
+			return longest
+		}
+		if i > longest {
+			longest = i
+		}
+		content = content[i+1:]
+	}
+}
+
+// runeSafeCut returns the largest cut point ≤ maxSize that does not land in
+// the middle of a UTF-8 sequence. A rune is at most 4 bytes, so backing off
+// past 4 continuation bytes is impossible; if it happens the input was not
+// valid UTF-8 to begin with and the raw maxSize cut is returned unchanged.
+func runeSafeCut(s string, maxSize int) int {
+	if maxSize >= len(s) {
+		return len(s)
+	}
+	cut := maxSize
+	for i := 0; i < 3 && cut > 0; i++ {
+		// 0b10xxxxxx marks a UTF-8 continuation byte: cutting here would
+		// split the rune that started earlier.
+		if s[cut]&0xC0 != 0x80 {
+			return cut
+		}
+		cut--
+	}
+	if cut > 0 && s[cut]&0xC0 != 0x80 {
+		return cut
+	}
+	return maxSize
+}

--- a/internal/tmux/canonical_line.go
+++ b/internal/tmux/canonical_line.go
@@ -40,6 +40,16 @@ import (
 // it is "big sends into a canonical-mode reader are impossible", and the only
 // honest handling is to detect that state and refuse rather than to type half
 // a line into a buffer that will discard it.
+//
+// Scope note, so this is not over-credited. The reporter of #1793 lost a
+// 4095-byte payload against Codex on Linux, and Linux's canonical buffer was
+// then measured (in CI, see canonMinLinux) to carry exactly that much. Codex
+// runs its pane in raw mode anyway. So THEIR loss was not canonical overflow;
+// what fixes their report is the CLI refusing to call an unconfirmed send a
+// success (cmd/agent-deck: verifyContentArrival). This file closes the
+// adjacent hole the investigation turned up — the one case where the terminal
+// itself guarantees the message cannot arrive — so it is caught before
+// anything is typed rather than after nothing was delivered.
 
 const (
 	// canonicalSafeBytes is the largest payload guaranteed to survive any
@@ -58,18 +68,22 @@ const (
 	// measured cliff above.
 	canonMinDarwin = 1024
 
-	// canonMinLinux is the usable n_tty canonical buffer on Linux. The buffer
-	// is N_TTY_BUF_SIZE = 4096 (drivers/tty/n_tty.c) but n_tty_receive_char
-	// discards input once read_cnt reaches N_TTY_BUF_SIZE-1, so 4095 bytes
-	// including the terminator is what actually survives — which is why the
-	// 4095-byte payload in issue #1793 was lost on Linux while a 4094-byte
-	// one would not have been.
+	// canonMinLinux is the n_tty canonical buffer on Linux: N_TTY_BUF_SIZE =
+	// 4096 (drivers/tty/n_tty.c), terminator included.
+	//
+	// Measured, not assumed. The first CI run of
+	// TestIssue1793_CanonicalPane_OverLimitLineIsMeasuredLostThenRefused had
+	// this constant at 4095 on the reasoning that n_tty stops at
+	// N_TTY_BUF_SIZE-1; ubuntu-latest answered with "4096 bytes arrived" and
+	// the test failed. 4095 bytes of body plus the terminator survives on
+	// Linux, so the buffer is the full 4096 and the largest deliverable line
+	// is 4095.
 	//
 	// This constant is deliberately used in preference to
 	// fpathconf(_PC_MAX_CANON), which reports the POSIX minimum of 255 on
-	// Linux while the kernel really buffers 4095; trusting fpathconf there
+	// Linux while the kernel really buffers 4096; trusting fpathconf there
 	// would reject ordinary 300-byte sends.
-	canonMinLinux = 4095
+	canonMinLinux = 4096
 )
 
 // ErrCanonicalLineOverflow reports that a payload cannot be delivered to the
@@ -157,24 +171,24 @@ func longestLineBytes(content string) int {
 }
 
 // runeSafeCut returns the largest cut point ≤ maxSize that does not land in
-// the middle of a UTF-8 sequence. A rune is at most 4 bytes, so backing off
-// past 4 continuation bytes is impossible; if it happens the input was not
-// valid UTF-8 to begin with and the raw maxSize cut is returned unchanged.
+// the middle of a UTF-8 sequence.
+//
+// A rune is at most 4 bytes, so at most 3 continuation bytes are ever backed
+// over. Two cases cannot be satisfied and fall back to the raw maxSize cut:
+// input that was not valid UTF-8 to begin with, and a maxSize smaller than
+// the rune it lands in (no safe cut point exists at all). Returning maxSize
+// rather than 0 there is load-bearing — the caller splits in a loop and a
+// zero-length cut would never terminate.
 func runeSafeCut(s string, maxSize int) int {
 	if maxSize >= len(s) {
 		return len(s)
 	}
-	cut := maxSize
-	for i := 0; i < 3 && cut > 0; i++ {
-		// 0b10xxxxxx marks a UTF-8 continuation byte: cutting here would
+	for cut := maxSize; cut > 0 && maxSize-cut < 4; cut-- {
+		// 0b10xxxxxx marks a UTF-8 continuation byte: cutting there would
 		// split the rune that started earlier.
 		if s[cut]&0xC0 != 0x80 {
 			return cut
 		}
-		cut--
-	}
-	if cut > 0 && s[cut]&0xC0 != 0x80 {
-		return cut
 	}
 	return maxSize
 }

--- a/internal/tmux/canonical_line_bsd.go
+++ b/internal/tmux/canonical_line_bsd.go
@@ -1,0 +1,10 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+package tmux
+
+import "golang.org/x/sys/unix"
+
+// getTermiosReq is the ioctl that reads a tty's termios on darwin and the
+// BSDs, where the Linux TCGETS request does not exist.
+const getTermiosReq = unix.TIOCGETA

--- a/internal/tmux/canonical_line_linux.go
+++ b/internal/tmux/canonical_line_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+// +build linux
+
+package tmux
+
+import "golang.org/x/sys/unix"
+
+// getTermiosReq is the ioctl that reads a tty's termios on Linux.
+const getTermiosReq = unix.TCGETS

--- a/internal/tmux/canonical_line_unix.go
+++ b/internal/tmux/canonical_line_unix.go
@@ -1,0 +1,52 @@
+//go:build !windows
+// +build !windows
+
+package tmux
+
+import (
+	"fmt"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// ttyLineDiscipline opens the pane's tty read-only and asks the kernel
+// whether its reader is in canonical mode, and how much it will buffer.
+//
+// O_NONBLOCK|O_NOCTTY is load-bearing: without O_NONBLOCK the open blocks
+// until a peer opens the other side, and without O_NOCTTY this process could
+// acquire the pane's tty as its controlling terminal. Neither the fd nor the
+// call disturbs the pane — tcgetattr is a pure read.
+func ttyLineDiscipline(tty string) (lineDiscipline, error) {
+	fd, err := unix.Open(tty, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOCTTY, 0)
+	if err != nil {
+		return lineDiscipline{}, fmt.Errorf("open pane tty %s: %w", tty, err)
+	}
+	defer func() { _ = unix.Close(fd) }()
+
+	termios, err := unix.IoctlGetTermios(fd, getTermiosReq)
+	if err != nil {
+		return lineDiscipline{}, fmt.Errorf("read termios of %s: %w", tty, err)
+	}
+	return lineDiscipline{
+		Canonical: termios.Lflag&unix.ICANON != 0,
+		MaxLine:   canonicalBufferBytes(),
+	}, nil
+}
+
+// canonicalBufferBytes returns the kernel's canonical line buffer for this
+// platform, terminator included. See canonMinLinux for why fpathconf's
+// _PC_MAX_CANON is not used: Linux reports the POSIX floor of 255 there while
+// n_tty really buffers 4096, and rejecting sends at 255 bytes would break
+// ordinary traffic. Unknown platforms fall back to the smallest figure we
+// have measured, which errs toward checking more payloads rather than fewer.
+func canonicalBufferBytes() int {
+	switch runtime.GOOS {
+	case "linux":
+		return canonMinLinux
+	case "darwin":
+		return canonMinDarwin
+	default:
+		return canonMinDarwin
+	}
+}

--- a/internal/tmux/canonical_line_windows.go
+++ b/internal/tmux/canonical_line_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package tmux
+
+import "errors"
+
+// ttyLineDiscipline has no meaning on Windows: there is no tty line
+// discipline to inspect. Returning an error keeps the caller on the
+// "unknown discipline" path — deliver, then verify — rather than
+// refusing sends outright.
+func ttyLineDiscipline(string) (lineDiscipline, error) {
+	return lineDiscipline{}, errors.New("tty line discipline is not inspectable on windows")
+}

--- a/internal/tmux/issue1793_send_delivery_test.go
+++ b/internal/tmux/issue1793_send_delivery_test.go
@@ -200,9 +200,18 @@ func TestIssue1793_CanonicalPane_OverLimitLineIsMeasuredLostThenRefused(t *testi
 	if err := lost.sendEnterRawToTarget(lost.Name); err != nil {
 		t.Fatalf("raw transport Enter: %v", err)
 	}
-	if got := awaitBytes(lostOut, 1, 3*time.Second); len(got) != 0 {
-		t.Fatalf("expected the canonical buffer to discard a %d-byte line, but %d bytes arrived; "+
-			"this platform's limit is not %d and the constant needs re-measuring", len(body), len(got), limit)
+	// The invariant is "this line does not arrive as a submitted line", not
+	// "nothing arrives" — kernels lose it differently and both losses are the
+	// #1793 phantom. macOS discards the whole overflowing line, so the reader
+	// sees 0 bytes. Linux hands over the 4096 bytes it buffered and eats the
+	// terminator, so the reader sees a truncated body and no Enter, and the
+	// turn never starts. Asserting the macOS shape specifically is what failed
+	// this test on ubuntu-latest.
+	if got := awaitBytes(lostOut, len(body)+1, 3*time.Second); len(got) == len(body)+1 {
+		t.Fatalf("expected a %d-byte line to be unsubmittable through a %d-byte canonical buffer, "+
+			"but the reader received the whole body AND the terminator (%d bytes); "+
+			"this platform's limit is not %d and the constant needs re-measuring",
+			len(body), limit, len(got), limit)
 	}
 
 	// --- the fix ---------------------------------------------------------

--- a/internal/tmux/issue1793_send_delivery_test.go
+++ b/internal/tmux/issue1793_send_delivery_test.go
@@ -1,0 +1,307 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #1793: `session send` reported success for a payload that was never
+// delivered.
+//
+// These tests drive a REAL tmux pane with a REAL reader and assert what the
+// reader actually received. That is the whole point: the previous regression
+// tests for this bug asserted the SHAPE OF THE ARGV agent-deck passes to
+// `tmux send-keys` (chunk sizes), which a fix that cannot possibly work still
+// satisfies — PR #1819 passed those tests while delivering nothing.
+//
+// Nothing here inspects argv. Every assertion is "what bytes came out of the
+// other end of the pty".
+// ---------------------------------------------------------------------------
+
+// paneReader starts a tmux session whose pane runs `shellCmd` and returns the
+// session, plus the path the reader writes to. The session is killed by socket
+// target (never by name-matching a process, never kill-server) on cleanup.
+func paneReader(t *testing.T, name, shellCmd string) (*Session, string) {
+	t.Helper()
+	skipIfNoTmuxBinary(t)
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "received.bin")
+	full := fmt.Sprintf("%s > '%s'", shellCmd, out)
+
+	cmd := exec.Command("tmux", "new-session", "-d", "-s", name, "-x", "200", "-y", "50", "sh", "-c", full)
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("cannot create tmux session for a real-pane test: %v (%s)", err, strings.TrimSpace(string(b)))
+	}
+	t.Cleanup(func() {
+		// Kill this one session on the socket this test binary already
+		// isolated (TestMain's IsolateTmuxSocket). Never kill-server, never
+		// match tmux by process name.
+		_ = exec.Command("tmux", "kill-session", "-t", name).Run()
+	})
+
+	return &Session{Name: name}, out
+}
+
+// awaitDiscipline polls the pane's line discipline until it matches want,
+// which doubles as the readiness gate for a pane that runs `stty` on startup.
+func awaitDiscipline(t *testing.T, s *Session, wantCanonical bool) lineDiscipline {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var last error
+	for time.Now().Before(deadline) {
+		ld, err := s.paneLineDiscipline(s.Name)
+		if err == nil && ld.Canonical == wantCanonical {
+			return ld
+		}
+		last = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("pane never reached canonical=%v (last probe error: %v)", wantCanonical, last)
+	return lineDiscipline{}
+}
+
+// awaitBytes polls the reader's output file until it holds want bytes,
+// returning what it holds when the deadline passes.
+func awaitBytes(path string, want int, timeout time.Duration) []byte {
+	deadline := time.Now().Add(timeout)
+	var last []byte
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(path)
+		if err == nil {
+			last = b
+			if len(b) >= want {
+				return b
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return last
+}
+
+// TestIssue1793_RawModePane_ReceivesWholeOverLimitPayloadAndTheEnter is the
+// test the maintainer asked for: drive a real pane with a payload far above
+// the canonical limit and assert the pane received THE WHOLE THING and that
+// it was submitted.
+//
+// The reader is in raw mode, which is what every real agent TUI (Claude Code,
+// Codex, a readline shell prompt) puts its tty in. `head -c` exits the instant
+// it has the expected byte count, so the file is flushed by process exit
+// rather than by luck of stdio buffering.
+func TestIssue1793_RawModePane_ReceivesWholeOverLimitPayloadAndTheEnter(t *testing.T) {
+	const payloadBytes = 8000
+	// +1 for the Enter: raw mode delivers it as a literal \r byte, so the
+	// reader seeing it is direct evidence the submit keystroke survived the
+	// body rather than being swallowed behind it.
+	want := payloadBytes + 1
+
+	sess, out := paneReader(t, "ad1793-raw", fmt.Sprintf("stty raw -echo; head -c %d", want))
+	awaitDiscipline(t, sess, false)
+
+	payload := strings.Repeat("A", payloadBytes-1) + "Z"
+	if err := sess.SendKeysAndEnter(payload); err != nil {
+		t.Fatalf("SendKeysAndEnter(%d bytes) to a raw-mode pane must succeed: %v", payloadBytes, err)
+	}
+
+	got := awaitBytes(out, want, 15*time.Second)
+	if len(got) != want {
+		t.Fatalf("raw-mode pane received %d bytes, want %d (body %d + Enter): the payload was truncated in transit",
+			len(got), want, payloadBytes)
+	}
+	if string(got[:payloadBytes]) != payload {
+		t.Fatal("raw-mode pane received the right number of bytes but not the right bytes")
+	}
+	if got[payloadBytes] != '\r' {
+		t.Fatalf("the submitting Enter never arrived after the body: trailing byte is %q", got[payloadBytes])
+	}
+}
+
+// TestIssue1793_RawModePane_PreservesMultibyteRunes pins that the transport
+// for over-limit payloads does not cut a UTF-8 rune in half. The old chunked
+// `send-keys` path split at a raw byte offset, which put invalid UTF-8 on the
+// wire whenever a multi-byte character straddled the boundary.
+func TestIssue1793_RawModePane_PreservesMultibyteRunes(t *testing.T) {
+	// Every rune is 3 bytes, so any split at a byte offset that is not a
+	// multiple of 3 corrupts a character.
+	payload := strings.Repeat("あ", 2000)
+	want := len(payload) + 1
+
+	sess, out := paneReader(t, "ad1793-utf8", fmt.Sprintf("stty raw -echo; head -c %d", want))
+	awaitDiscipline(t, sess, false)
+
+	if err := sess.SendKeysAndEnter(payload); err != nil {
+		t.Fatalf("SendKeysAndEnter(%d bytes of UTF-8): %v", len(payload), err)
+	}
+
+	got := awaitBytes(out, want, 15*time.Second)
+	if len(got) < len(payload) || string(got[:len(payload)]) != payload {
+		t.Fatalf("multibyte payload was corrupted in transit: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// TestIssue1793_CanonicalPane_DeliversUpToTheLimit pins the boundary from
+// below: the largest line the pane's canonical buffer can hold must still go
+// through untouched. Without this, "refuse over-long lines" could silently
+// become "refuse everything large".
+func TestIssue1793_CanonicalPane_DeliversUpToTheLimit(t *testing.T) {
+	limit := canonicalBufferBytes()
+	// limit includes the terminator, so the largest deliverable body is
+	// limit-1 and the reader should see exactly limit bytes with the newline.
+	body := strings.Repeat("A", limit-2) + "Z"
+
+	sess, out := paneReader(t, "ad1793-canon-ok", fmt.Sprintf("head -c %d", limit))
+	ld := awaitDiscipline(t, sess, true)
+	if ld.MaxLine != limit {
+		t.Fatalf("probe reported a %d-byte canonical buffer, this platform's is %d", ld.MaxLine, limit)
+	}
+
+	if err := sess.SendKeysAndEnter(body); err != nil {
+		t.Fatalf("a %d-byte line fits the %d-byte canonical buffer and must not be refused: %v", len(body), limit, err)
+	}
+
+	got := awaitBytes(out, limit, 15*time.Second)
+	if len(got) != limit || string(got[:len(body)]) != body {
+		t.Fatalf("canonical pane received %d bytes, want %d: the at-limit line did not survive", len(got), limit)
+	}
+}
+
+// TestIssue1793_CanonicalPane_OverLimitLineIsMeasuredLostThenRefused is the
+// core of the bug and its fix, in one test.
+//
+// First half: send one byte too many through the RAW transport, bypassing the
+// guard, and watch the kernel throw away the entire line AND the Enter. That
+// is the phantom send from issue #1793 — reproduced, not assumed, on this
+// machine's real line discipline.
+//
+// Second half: the same payload through the public send path must return
+// ErrCanonicalLineOverflow and type NOTHING, so the caller reports a failure
+// instead of a success and the composer is left uncorrupted.
+func TestIssue1793_CanonicalPane_OverLimitLineIsMeasuredLostThenRefused(t *testing.T) {
+	limit := canonicalBufferBytes()
+	// One byte past what fits: body + terminator = limit + 1.
+	body := strings.Repeat("A", limit)
+
+	// --- the measurement -------------------------------------------------
+	lost, lostOut := paneReader(t, "ad1793-canon-lost", fmt.Sprintf("head -c %d", limit+1))
+	awaitDiscipline(t, lost, true)
+
+	if err := lost.sendKeysToTarget(lost.Name, body); err != nil {
+		t.Fatalf("raw transport send-keys: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if err := lost.sendEnterRawToTarget(lost.Name); err != nil {
+		t.Fatalf("raw transport Enter: %v", err)
+	}
+	if got := awaitBytes(lostOut, 1, 3*time.Second); len(got) != 0 {
+		t.Fatalf("expected the canonical buffer to discard a %d-byte line, but %d bytes arrived; "+
+			"this platform's limit is not %d and the constant needs re-measuring", len(body), len(got), limit)
+	}
+
+	// --- the fix ---------------------------------------------------------
+	guarded, guardedOut := paneReader(t, "ad1793-canon-refused", fmt.Sprintf("head -c %d", limit+1))
+	awaitDiscipline(t, guarded, true)
+
+	err := guarded.SendKeysAndEnter(body)
+	if err == nil {
+		t.Fatal("issue #1793: a line that the pane's canonical buffer cannot hold must not report success")
+	}
+	if !errors.Is(err, ErrCanonicalLineOverflow) {
+		t.Fatalf("want ErrCanonicalLineOverflow, got %v", err)
+	}
+	var overflow *CanonicalOverflowError
+	if !errors.As(err, &overflow) {
+		t.Fatalf("the error must carry the measured numbers, got %T", err)
+	}
+	if overflow.LineBytes != len(body) || overflow.LimitBytes != limit {
+		t.Fatalf("overflow detail wrong: line=%d limit=%d, want line=%d limit=%d",
+			overflow.LineBytes, overflow.LimitBytes, len(body), limit)
+	}
+	if got := awaitBytes(guardedOut, 1, time.Second); len(got) != 0 {
+		t.Fatalf("a refused send must type nothing, but %d bytes reached the pane", len(got))
+	}
+}
+
+// TestIssue1793_CanonicalPane_ManyShortLinesAreNotRefused pins that the guard
+// measures the longest LINE, not the total payload. Canonical buffering is
+// per line, so a 20 KB body of short lines is perfectly deliverable and
+// refusing it would be a regression.
+func TestIssue1793_CanonicalPane_ManyShortLinesAreNotRefused(t *testing.T) {
+	line := strings.Repeat("B", 79) + "\n"
+	body := strings.Repeat(line, 250) // 20000 bytes, longest line 80
+	want := len(body) + 1             // trailing Enter closes the final (empty) line
+
+	sess, out := paneReader(t, "ad1793-canon-lines", fmt.Sprintf("head -c %d", want))
+	awaitDiscipline(t, sess, true)
+
+	if err := sess.SendKeysAndEnter(body); err != nil {
+		t.Fatalf("a %d-byte payload of 80-byte lines fits a canonical buffer line-by-line: %v", len(body), err)
+	}
+	if got := awaitBytes(out, want, 20*time.Second); len(got) < len(body) {
+		t.Fatalf("multi-line payload truncated: got %d bytes, want %d", len(got), want)
+	}
+}
+
+// TestLongestLineBytes pins the quantity the guard actually measures.
+func TestLongestLineBytes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"abc\n", 3},
+		{"ab\nabcd\nx", 4},
+		{"ab\nabcd\nxyzzyx", 6},
+		{strings.Repeat("a", 5000), 5000},
+	}
+	for _, c := range cases {
+		if got := longestLineBytes(c.in); got != c.want {
+			t.Errorf("longestLineBytes(%d bytes) = %d, want %d", len(c.in), got, c.want)
+		}
+	}
+}
+
+// TestRuneSafeCut pins that the chunked fallback never splits a rune.
+func TestRuneSafeCut(t *testing.T) {
+	s := strings.Repeat("あ", 10) // 3 bytes per rune
+	for size := 1; size < len(s); size++ {
+		cut := runeSafeCut(s, size)
+		if cut > size {
+			t.Fatalf("runeSafeCut(%d) = %d: must never cut beyond the requested size", size, cut)
+		}
+		if cut%3 != 0 {
+			t.Fatalf("runeSafeCut(%d) = %d: lands mid-rune", size, cut)
+		}
+	}
+	if got := runeSafeCut("abcdef", 100); got != 6 {
+		t.Fatalf("runeSafeCut past end = %d, want 6", got)
+	}
+}
+
+// TestSplitIntoChunksNeverSplitsARune is the reconstruction guarantee for the
+// chunked fallback path.
+func TestSplitIntoChunksNeverSplitsARune(t *testing.T) {
+	// 3-byte runes with no newline anywhere force the hard-split branch, and
+	// 4096 is not a multiple of 3 so a naive cut lands mid-rune.
+	original := strings.Repeat("あ", 4000)
+	chunks := splitIntoChunks(original, 4096)
+	if len(chunks) < 2 {
+		t.Fatalf("expected a hard split, got %d chunk(s)", len(chunks))
+	}
+	for i, c := range chunks {
+		if !utf8.ValidString(c) {
+			t.Fatalf("chunk %d is not valid UTF-8: a rune was cut in half", i)
+		}
+	}
+	if strings.Join(chunks, "") != original {
+		t.Fatal("chunks do not reassemble into the original content")
+	}
+}

--- a/internal/tmux/issue1793_send_delivery_test.go
+++ b/internal/tmux/issue1793_send_delivery_test.go
@@ -269,20 +269,41 @@ func TestLongestLineBytes(t *testing.T) {
 	}
 }
 
-// TestRuneSafeCut pins that the chunked fallback never splits a rune.
+// TestRuneSafeCut pins that the chunked fallback never splits a rune, and
+// that the one case where it cannot avoid doing so still makes progress.
 func TestRuneSafeCut(t *testing.T) {
-	s := strings.Repeat("あ", 10) // 3 bytes per rune
-	for size := 1; size < len(s); size++ {
+	const runeWidth = 3 // "あ" is 3 bytes
+	s := strings.Repeat("あ", 10)
+
+	// Any cut with at least one whole rune behind it must land on a
+	// boundary.
+	for size := runeWidth; size < len(s); size++ {
 		cut := runeSafeCut(s, size)
 		if cut > size {
 			t.Fatalf("runeSafeCut(%d) = %d: must never cut beyond the requested size", size, cut)
 		}
-		if cut%3 != 0 {
+		if cut%runeWidth != 0 {
 			t.Fatalf("runeSafeCut(%d) = %d: lands mid-rune", size, cut)
 		}
+		if cut == 0 {
+			t.Fatalf("runeSafeCut(%d) = 0: a zero-length cut would loop forever in splitIntoChunks", size)
+		}
 	}
+
+	// A cut smaller than the rune it lands in has no safe answer. It must
+	// still return something non-zero, or splitIntoChunks never terminates.
+	for size := 1; size < runeWidth; size++ {
+		if got := runeSafeCut(s, size); got != size {
+			t.Fatalf("runeSafeCut(%d) = %d: with no safe cut available it must fall back to the requested size", size, got)
+		}
+	}
+
 	if got := runeSafeCut("abcdef", 100); got != 6 {
 		t.Fatalf("runeSafeCut past end = %d, want 6", got)
+	}
+	// Invalid UTF-8 must not send the backoff searching indefinitely.
+	if got := runeSafeCut("\x80\x80\x80\x80\x80\x80", 4); got != 4 {
+		t.Fatalf("runeSafeCut on invalid UTF-8 = %d, want the raw cut 4", got)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5131,10 +5131,23 @@ func (s *Session) sendKeysChunkedToTarget(target, content string) error {
 	return s.sendKeysChunkedFallback(target, content)
 }
 
-// pasteBufferName is the tmux buffer agent-deck stages large payloads in. A
-// fixed name (rather than tmux's numbered stack) keeps the user's copy
-// buffers untouched, and `paste-buffer -d` deletes it immediately after.
-const pasteBufferName = "agent-deck-send"
+// pasteBufferSeq makes every staged buffer name unique within this process.
+var pasteBufferSeq atomic.Uint64
+
+// pasteBufferName returns the tmux buffer name to stage one payload in.
+//
+// The name MUST be unique per send. tmux buffers are per-SERVER, not per
+// session, so a fixed name would be a cross-session data race: two concurrent
+// large sends (a conductor fanning messages out to its children is the normal
+// case) would have the second `load-buffer` overwrite the first's content
+// between its load and its paste, and the first pane would receive the other
+// session's message. pid + counter keeps concurrent senders — in this process
+// or in a second agent-deck process on the same server — off each other's
+// buffers. Named rather than using tmux's numbered stack so the user's own
+// copy buffers stay untouched.
+func pasteBufferName() string {
+	return fmt.Sprintf("agent-deck-send-%d-%d", os.Getpid(), pasteBufferSeq.Add(1))
+}
 
 // pasteToTarget delivers content through tmux's paste path: `load-buffer -`
 // reads the body from this process's stdin (no argv size limit, no shell
@@ -5142,18 +5155,23 @@ const pasteBufferName = "agent-deck-send"
 func (s *Session) pasteToTarget(target, content string) error {
 	s.invalidateCache()
 
-	load := keySenderExec(s.SocketName, "load-buffer", "-b", pasteBufferName, "-")
+	buf := pasteBufferName()
+	load := keySenderExec(s.SocketName, "load-buffer", "-b", buf, "-")
 	load.Stdin = strings.NewReader(content)
 	if err := runSendKeysBounded(load); err != nil {
+		// load-buffer can fail after partially creating the buffer (e.g. the
+		// deadline fires mid-write), so drop it rather than leaving a
+		// half-written payload sitting on the server.
+		_ = runSendKeysBounded(keySenderExec(s.SocketName, "delete-buffer", "-b", buf))
 		return fmt.Errorf("load-buffer: %w", err)
 	}
 
-	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-b", pasteBufferName, "-t", target)
+	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-b", buf, "-t", target)
 	if err := runSendKeysBounded(paste); err != nil {
 		// -d never ran, so the staged buffer would linger. Drop it before
 		// falling back, otherwise the fallback's content and this stale copy
 		// both sit in the buffer stack.
-		_ = runSendKeysBounded(keySenderExec(s.SocketName, "delete-buffer", "-b", pasteBufferName))
+		_ = runSendKeysBounded(keySenderExec(s.SocketName, "delete-buffer", "-b", buf))
 		return fmt.Errorf("paste-buffer: %w", err)
 	}
 	return nil

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5057,6 +5057,20 @@ func (s *Session) SendKeysAndEnterToWindow(windowIndex int, keys string) error {
 // (active window) and SendKeysAndEnterToWindow (explicit window).
 func (s *Session) sendKeysAndEnterToTarget(target, keys string) error {
 	s.invalidateCache()
+	// Pin the pane before anything else touches it. A session-name target is
+	// re-resolved by tmux on EVERY command, so the probe, the body and the
+	// Enter are three independent lookups: if the active window or pane
+	// changes between them, agent-deck can inspect the line discipline of
+	// pane A, paste the body into pane B and submit it in pane C — a false
+	// refusal or an undetected loss, depending which way it drifts. `#{pane_id}`
+	// is immutable for the life of the pane, so resolving it once removes the
+	// drift for every step that follows. Only done for payloads big enough to
+	// need the probe, so ordinary sends pay nothing (issue #1793).
+	if len(keys) > canonicalSafeBytes {
+		if paneID, err := s.resolvePaneID(target); err == nil && paneID != "" {
+			target = paneID
+		}
+	}
 	// Guarantee the composer is in insert mode BEFORE the paste so a vim
 	// normal-mode prompt doesn't interpret the message body as motion/command
 	// keystrokes (issue #1264). No-op unless VimMode is set.
@@ -5125,11 +5139,37 @@ func (s *Session) sendKeysChunkedToTarget(target, content string) error {
 		}
 	}
 
-	if err := s.pasteToTarget(target, content); err == nil {
+	err := s.pasteToTarget(target, content)
+	if err == nil {
 		return nil
 	}
-	return s.sendKeysChunkedFallback(target, content)
+	// Fall back ONLY when the failure happened before any byte could reach the
+	// pane. Once `paste-buffer` has been invoked its failure is ambiguous — a
+	// timeout can fire after some or all of the body was already written — and
+	// re-sending the whole message through send-keys would duplicate or
+	// concatenate it in the composer. An ambiguous transport failure is
+	// reported, never retried.
+	if errors.Is(err, errPasteNotStaged) {
+		return s.sendKeysChunkedFallback(target, content)
+	}
+	return err
 }
+
+// resolvePaneID returns the immutable `#{pane_id}` (e.g. "%17") currently
+// backing target, so subsequent commands address that exact pane rather than
+// re-resolving a session name that may have moved.
+func (s *Session) resolvePaneID(target string) (string, error) {
+	out, err := s.runBoundedOutput("display-message", "-t", target, "-p", "#{pane_id}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// errPasteNotStaged marks a paste failure that happened BEFORE `paste-buffer`
+// ran, so no byte of the payload can have reached the pane and retrying
+// through another transport is safe.
+var errPasteNotStaged = errors.New("payload was never staged into the pane")
 
 // pasteBufferSeq makes every staged buffer name unique within this process.
 var pasteBufferSeq atomic.Uint64
@@ -5163,7 +5203,9 @@ func (s *Session) pasteToTarget(target, content string) error {
 		// deadline fires mid-write), so drop it rather than leaving a
 		// half-written payload sitting on the server.
 		_ = runSendKeysBounded(keySenderExec(s.SocketName, "delete-buffer", "-b", buf))
-		return fmt.Errorf("load-buffer: %w", err)
+		// Nothing was pasted: the payload only ever existed in a server-side
+		// buffer, so another transport may safely try again.
+		return fmt.Errorf("load-buffer: %v: %w", err, errPasteNotStaged)
 	}
 
 	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-b", buf, "-t", target)
@@ -5172,7 +5214,11 @@ func (s *Session) pasteToTarget(target, content string) error {
 		// falling back, otherwise the fallback's content and this stale copy
 		// both sit in the buffer stack.
 		_ = runSendKeysBounded(keySenderExec(s.SocketName, "delete-buffer", "-b", buf))
-		return fmt.Errorf("paste-buffer: %w", err)
+		// Deliberately NOT errPasteNotStaged: paste-buffer already ran, so an
+		// unknown amount of the body may be in the composer. Deleting the
+		// buffer does not un-write those bytes.
+		return fmt.Errorf("paste-buffer failed after writing to the pane, delivery is indeterminate "+
+			"and must not be retried: %w", err)
 	}
 	return nil
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5075,15 +5075,93 @@ func (s *Session) sendKeysAndEnterToTarget(target, keys string) error {
 	return s.sendEnterRawToTarget(target)
 }
 
-// SendKeysChunked sends large content to the tmux session in chunks to avoid
-// tmux/OS buffer limits. Content ≤4KB is sent directly via SendKeys.
-// Larger content is split at newline boundaries with a short delay between chunks.
+// SendKeysChunked delivers content to the tmux session's active window.
+// Payloads at or below canonicalSafeBytes go out as a single `send-keys -l`,
+// exactly as before. Larger payloads take the paste transport (load-buffer
+// from stdin + paste-buffer) after the pane's line discipline has been
+// checked; see sendKeysChunkedToTarget and canonical_line.go.
 func (s *Session) SendKeysChunked(content string) error {
 	return s.sendKeysChunkedToTarget(s.Name, content)
 }
 
 // sendKeysChunkedToTarget is SendKeysChunked against an explicit tmux target.
+//
+// Three sizes of payload, three behaviors (issue #1793):
+//
+//   - ≤ canonicalSafeBytes: one `send-keys -l`. Guaranteed to fit any line
+//     discipline, so nothing is inspected and nothing costs extra. This is
+//     the overwhelming majority of sends and is byte-for-byte unchanged.
+//
+//   - larger, pane readable and canonical: refuse with
+//     *CanonicalOverflowError when the longest line does not fit the pane's
+//     canonical buffer. The kernel would discard the overflow AND the
+//     submitting Enter, so typing it would leave a half-line in the composer
+//     and report a success that never happened. Refusing types nothing.
+//
+//   - larger, otherwise: deliver via load-buffer + paste-buffer. tmux reads
+//     the body from our stdin instead of argv, which removes the ARG_MAX
+//     exposure and replaces N paced `send-keys` subprocesses with two calls.
+//     If the paste transport is unavailable the chunked send-keys path is
+//     still there as a fallback.
+//
+// The paste transport is NOT what fixes canonical overflow — it was measured
+// to fall off the identical cliff (canonical_line.go). Only the refusal, and
+// the caller's post-send verification, make the outcome honest.
 func (s *Session) sendKeysChunkedToTarget(target, content string) error {
+	if len(content) <= canonicalSafeBytes {
+		return s.sendKeysToTarget(target, content)
+	}
+
+	// Above the always-safe size the pane itself decides. An unreadable
+	// discipline is "unknown", not "unsafe": deliver and let the caller
+	// verify rather than refusing a send that would have worked.
+	if ld, err := s.paneLineDiscipline(target); err == nil && ld.Canonical && ld.MaxLine > 0 {
+		if longest := longestLineBytes(content); longest > ld.MaxLine-1 {
+			return &CanonicalOverflowError{
+				LineBytes:  longest,
+				LimitBytes: ld.MaxLine,
+				TTY:        ld.TTY,
+			}
+		}
+	}
+
+	if err := s.pasteToTarget(target, content); err == nil {
+		return nil
+	}
+	return s.sendKeysChunkedFallback(target, content)
+}
+
+// pasteBufferName is the tmux buffer agent-deck stages large payloads in. A
+// fixed name (rather than tmux's numbered stack) keeps the user's copy
+// buffers untouched, and `paste-buffer -d` deletes it immediately after.
+const pasteBufferName = "agent-deck-send"
+
+// pasteToTarget delivers content through tmux's paste path: `load-buffer -`
+// reads the body from this process's stdin (no argv size limit, no shell
+// quoting), then `paste-buffer -d` writes it to the pane and drops the buffer.
+func (s *Session) pasteToTarget(target, content string) error {
+	s.invalidateCache()
+
+	load := keySenderExec(s.SocketName, "load-buffer", "-b", pasteBufferName, "-")
+	load.Stdin = strings.NewReader(content)
+	if err := runSendKeysBounded(load); err != nil {
+		return fmt.Errorf("load-buffer: %w", err)
+	}
+
+	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-b", pasteBufferName, "-t", target)
+	if err := runSendKeysBounded(paste); err != nil {
+		// -d never ran, so the staged buffer would linger. Drop it before
+		// falling back, otherwise the fallback's content and this stale copy
+		// both sit in the buffer stack.
+		_ = runSendKeysBounded(keySenderExec(s.SocketName, "delete-buffer", "-b", pasteBufferName))
+		return fmt.Errorf("paste-buffer: %w", err)
+	}
+	return nil
+}
+
+// sendKeysChunkedFallback is the historical paced `send-keys -l` transport,
+// kept as the fallback for tmux builds where the paste path fails.
+func (s *Session) sendKeysChunkedFallback(target, content string) error {
 	const chunkSize = 4096
 	const chunkDelay = 50 * time.Millisecond
 
@@ -5130,9 +5208,13 @@ func splitIntoChunks(content string, maxSize int) []string {
 			chunks = append(chunks, remaining[:cutPoint+1])
 			remaining = remaining[cutPoint+1:]
 		} else {
-			// No newline found: hard split at maxSize
-			chunks = append(chunks, remaining[:maxSize])
-			remaining = remaining[maxSize:]
+			// No newline found: hard split at maxSize, backed off to the
+			// nearest rune boundary so a multi-byte character is never cut in
+			// half across two `send-keys -l` calls (which would put invalid
+			// UTF-8 on the wire and corrupt the character in the pane).
+			cut := runeSafeCut(remaining, maxSize)
+			chunks = append(chunks, remaining[:cut])
+			remaining = remaining[cut:]
 		}
 	}
 


### PR DESCRIPTION
## What problem does this solve?

`agent-deck session send` could exit 0 with `{"success":true,"delivery":"unverified"}` for a boundary-sized payload that the receiving agent never got and never submitted (#1793). The caller has no way to tell a delivered message from a vanished one, so watchers and conductors happily move on from a turn that never started.

Closes #1793

## Why this change

This supersedes the chunk-size approach in #1819. That PR shrank `send-keys` chunks to 1023 bytes on the theory that each write had to fit the canonical buffer. The maintainer's note on #1819 is right that the limit is per **line**, not per **write**: every chunk lands in the same line buffer and accumulates there until Enter, so a 4095-byte message overflows exactly as before.

Rather than assume a boundary, I measured one (macOS 15.5, tmux 3.7b, reader `cat > file`, payload of N bytes then Enter):

| payload | `send-keys -l` | `load-buffer` + `paste-buffer` |
|--------:|---------------:|-------------------------------:|
| 1000    | 1001 bytes     | 1001 bytes                     |
| 1023    | 1024 bytes     | 1024 bytes                     |
| 1024    | **0 bytes**    | **0 bytes**                    |
| 4095    | **0 bytes**    | **0 bytes**                    |

Two findings decide the shape of the fix:

1. The cliff is at 1024 bytes including the terminator, not 4096.
2. **Both transports fall off it at exactly the same place.** The limit belongs to the reader's line discipline, not to the writer, so `load-buffer`/`paste-buffer` is not the cure either. I want to be explicit about that since the maintainer note suggested it as the delivery-path change — I implemented it and then measured that it does not move the boundary.

Repeating the same runs with the reader in **raw** mode (ICANON clear — what every agent TUI actually uses) delivered 8000 bytes intact on all transports. So the real statement is not "big sends are broken", it is "a line bigger than the reader's canonical buffer cannot be delivered by anyone", and the only honest handling is to detect it and refuse.

What landed:

**Transport (`internal/tmux`).** Payloads at or below 1023 bytes take the unchanged single `send-keys -l` — the overwhelming majority of sends are byte-for-byte identical and pay nothing new. Above that, the pane's termios is probed (`#{pane_tty}` + `tcgetattr`); if the reader is canonical and a payload line will not fit, the send is refused with `ErrCanonicalLineOverflow` and **nothing is typed**, so the composer is left uncorrupted instead of holding half a line whose Enter got eaten. Deliverable large payloads go out via `load-buffer -` + `paste-buffer`, which reads the body from stdin instead of argv: that removes the ARG_MAX exposure and replaces N paced subprocesses with two calls. It is an improvement, not the fix, and the comments say so plainly so the next reader does not mistake it for one.

The per-platform buffer figures are documented with their source: darwin `MAX_CANON` = 1024 (`sys/syslimits.h`, matches the measurement above); Linux = 4096 (`N_TTY_BUF_SIZE`, `drivers/tty/n_tty.c`). The Linux figure was corrected **by CI**: I first shipped 4095, reasoning from `n_tty` stopping at `N_TTY_BUF_SIZE - 1`, and ubuntu-latest answered "4096 bytes arrived" and failed the boundary test. That is the tests doing their job — see the Evidence section. `fpathconf(_PC_MAX_CANON)` is deliberately not used: Linux reports the POSIX floor of 255 there while the kernel really buffers 4096, and trusting it would reject ordinary 300-byte sends.

Large payloads stage into a **per-send** tmux buffer (pid + counter), not a fixed name. tmux buffers are per-server, not per session, so a fixed name would be a cross-session data race: a conductor fanning large messages out to several children concurrently could have the second `load-buffer` overwrite the first between its load and its paste, and deliver one child's message into another child's pane. The buffer is dropped on every path, including both error paths.

**Reporting (`cmd/agent-deck`).** For every non-Claude tool, verification was skipped and the result hardcoded to `unverified` with a nil error — that single line is what produced the reported output. Delivery is now confirmed against `capture-pane` before success is claimed, compared whitespace-insensitively so a body wrapped at the pane width still matches (a byte-exact search fails on any message wider than the remaining columns, which would turn working sends into failures).

Crucially, evidence is a **transition** from a pre-send baseline, never a snapshot. Both available signals are worthless as snapshots and it is easy to get this wrong in a way that quietly rebuilds the bug:

- "the body is on screen" — automated senders repeat themselves (heartbeats, inbox nudges, retries). A leftover copy of an identical message would certify the *next* send even when that one vanished.
- "the agent is active" — a pane that was **already** busy is still busy a moment later whether or not it received anything.

So the check captures the occurrence count and the busy state before the send, and accepts only an increase in copies, or a transition from not-active to active. A signal whose baseline could not be read is switched **off**, not defaulted — without a baseline there is no transition to measure, and guessing one turns a failed capture into fake evidence. Every trap here has a named regression test.

The signals are also not equal in strength, and the result says which one was found:

| observation | verdict | exit |
|---|---|---|
| idle agent goes active | `submitted` | 0 |
| composer seen **holding** the message, then clear | `submitted` | 0 |
| body merely appears in the pane | `typed` | **non-zero** |
| nothing, and a line exceeds the pane's capacity | `no_evidence` | non-zero |

That distinction is the point. Bytes sitting in a composer whose Enter was swallowed are exactly the #1413/#1793 failure, so a status that called them "delivered" would re-certify the thing it was added to catch. **`typed` is a failure**, not a softer success: JSON `success:false`, `submitted:false`, non-zero exit, and human text that says submission was never confirmed. `--json` carries the explicit `submitted` boolean so no caller has to know which delivery strings imply an accepted turn.

Held-then-cleared is kept as submission evidence deliberately — the composer positively took the message out, which is more than "the text is on screen somewhere".

Finally, the hard-failure gate measures the **longest line**, not the total payload — matching the transport. Gating on total size would contradict the central finding of this PR and fail a 20 KB body of short lines that the real-pane test here proves is deliverable. The line is compared against the pane's **detected** capacity where that can be probed, falling back to the universal 1023-byte floor only when it cannot: the floor is what *every* pane can take, not what *this* pane can take, and a raw-mode pane has no line limit at all. A line ends at `\n` **or** `\r` — with `ICRNL` set (the tty default) an incoming CR becomes NL before the line discipline sees it, so counting only `\n` would measure a CRLF payload as one enormous line and refuse a send that delivers fine.

The honesty cuts both ways, deliberately:

- over-long **line**, never seen in the pane and no new activity → `no_evidence`, nonzero exit. This is the reported bug.
- idle agent went active → `submitted`. Body visible but nothing took it up → `typed` (`submitted: false`).
- refused before typing → `line_too_long`, nonzero exit, and retrying the same body is pointless.
- payload whose longest line is ≤1023 bytes and cannot be matched → still `unverified`, exit 0. At that size the canonical loss mode cannot apply, so an unmatched pane is far more likely to be a rendering quirk than a lost message. Verification failed there, not delivery, and saying otherwise would make this fix a false-alarm generator.
- no token distinctive enough to search for → `unverified`, **unless** the payload also carries an over-long line, which would otherwise be a free pass straight back to the reported bug.

Also fixes a real independent bug surfaced by review of #1819: the chunked fallback's hard split could cut a UTF-8 rune in half.

## User impact

- A large `session send` that cannot be delivered now fails loudly (nonzero exit, `delivery` in `--json`) instead of exiting 0 on a message that vanished.
- `delivery` gains `arrived`, `line_too_long`, and a much narrower `unverified`. Existing values are unchanged; `unverified` now means "could not tell", not "did not look".
- Sends of 1023 bytes or less are unchanged in behavior and in cost.
- Large sends make two tmux calls instead of a paced chain of them.

## Evidence

Real panes, real readers, asserting the bytes that came out of the far end of the pty (macOS 15.5, tmux 3.7b):

```text
RAW8000:                canonical=false got=8001 want=8001 bodyOK=true enterOK=true
RAWUTF8:                got=6001 want=6001 exact=true
CANON1023:              canonical=true  got=1024 want=1024 exact=true
CANON1024-RAWTRANSPORT: got=0    want=0    phantomReproduced=true
CANON-MULTILINE:        got=20001 want=20001 ok=true
```

The same suite on ubuntu-latest then taught me two things I had wrong, which is the strongest evidence I can offer that these tests are load-bearing rather than decorative:

1. The Linux buffer is 4096, not the 4095 I had reasoned my way to. Corrected, with the measurement recorded next to the constant.
2. **Linux loses the line differently.** macOS discards the whole overflowing line, so the reader sees 0 bytes. Linux hands over the 4096 bytes it buffered and eats the terminator — the body arrives truncated, the Enter does not, and the turn never starts. Same phantom, different kernel. The test now asserts the invariant that holds everywhere ("this does not arrive as a *submitted* line") instead of the one platform it happened to be written on.

That second point also corrects something in this PR's own framing: since Linux carries a 4095-byte payload fine and Codex runs its pane in raw mode anyway, the reporter's specific loss was **not** canonical overflow. What fixes their report is the CLI refusing to call an unconfirmed send a success. The canonical guard closes the adjacent hole the investigation turned up — the one case where the terminal itself guarantees the message cannot arrive. The code says so rather than over-crediting the guard.

Read as: an 8000-byte payload arrives whole on a raw-mode pane **and the submitting Enter arrives behind it** (the trailing `\r`); multibyte content survives byte-exact; the largest line the canonical buffer can hold still goes through untouched; one byte more is silently discarded in full — the phantom send, reproduced rather than assumed; and a 20 KB payload of short lines is not refused, because the guard measures the longest line rather than the total size.

The same scenarios are the new test suite (`internal/tmux/issue1793_send_delivery_test.go`), which drives real tmux panes and asserts received bytes. Nothing in it inspects argv — the existing regression tests for this issue asserted the shape of the argv passed to `tmux send-keys`, which is precisely why a fix that could not work still passed them.

The failure direction is covered too (`cmd/agent-deck/issue1793_delivery_verify_test.go`): the exact reported scenario returns an error and `no_evidence` instead of an unverified success; a wrapped-in-pane body is still recognised as arrived; a refused over-long line reports `line_too_long` on both the verified and skip-verify paths; and short unmatched sends keep the best-effort contract.

Sandboxed `go build ./...`, `go vet ./cmd/... ./internal/tmux/...` and `gofmt -l` are clean. The full suite runs in CI, not on the authoring host — this repo's own `CLAUDE.md` bans un-sandboxed local test runs after three live-data wipes.

## Review

A Codex adversarial pass on the near-final diff returned **do not ship** with two CRITICAL findings, and it was right about both — they were my own inconsistencies, and both were this bug wearing different clothes:

1. Returning success as soon as the body appeared in the pane proved *typing*, not *submission* — re-certifying the exact state #1793 is about. Fixed by grading the signals and reporting `typed` vs `submitted`.
2. The hard-failure gate used total payload size while the transport used longest line, so a deliverable 20 KB multi-line body could be reported lost. Fixed by measuring the line.

Also fixed from that pass: the probe/paste/Enter trio re-resolving a session-name target and potentially addressing three different panes (pane id is now pinned once); a `paste-buffer` failure falling back to a full resend even though paste can fail *after* writing part of the body (fallback is now reachable only from a `load-buffer` failure, where nothing reached the pane); failed baselines silently becoming zero; and token-less payloads bypassing the gate. Four new regression tests, one per reintroduction path.

A second, clean Codex pass on the post-fix diff then found that round had only **half**-fixed the headline bug, and both findings were merge-blocking:

1. The **Claude** verification path — the one most sessions actually use — still promoted arrival to submission at the end of its budget on the strength of "the body was visible in the pane". I had fixed this for non-Claude tools and left the main path re-certifying the exact state #1793 reports. Fixed, while preserving *held-then-cleared* as genuine submission evidence (the first cut of the fix was too blunt to make that distinction).
2. `typed` returned a **nil** error, so the CLI printed `"success": true` directly next to `"submitted": false`. Text sitting unsubmitted in a composer reported success — the headline bug wearing the hat this PR invented for it. `typed` is now a non-zero exit on both paths.

Plus the capacity-vs-floor gate and CR/CRLF line counting described above.

Three existing tests asserted the behaviour identified as CRITICAL — that a visible body means delivered. They are **updated rather than deleted**, and each keeps its original #876 guarantee (a visible body is never reported as a silent drop) while dropping the success claim that guarantee never needed. Calling that out explicitly because "the fix made a test fail so the test changed" deserves scrutiny, and these are the exact assertions the review flagged.

Not addressed, and flagged deliberately rather than silently: the reviewer would also like an end-to-end CLI-level test against real panes (the current split is real panes for transport, mocks for the CLI verification path), whitespace-preserving wrap reconstruction using pane-width metadata instead of collapsing whitespace, and per-platform termios constants for non-Linux/non-Darwin targets. Those are worth doing and are better as follow-ups than as more surface on this diff — happy to take direction on whether any should block.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-x

## What actually bothered you

My human asked: "Fix issue #1793 properly. An existing PR #1819 took the wrong approach (shrinking send chunks to 1023 bytes) and I rejected it as maintainer." Their framing of the bug was the brief: the CLI reported delivered while nothing was submitted, chunking cannot fix a per-line limit, and — the part they said was the heart of it — "never report success on an unverified send". So the instruction was explicitly to measure the boundary rather than hardcode 4096, and to make the exit code and JSON honest. Measuring is also what showed that the suggested `load-buffer`/`paste-buffer` delivery path does not move the boundary either, which is reported above rather than quietly shipped as a fix.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — run in CI, not on the authoring host
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — sends of 1023 bytes or less take the same single `send-keys -l` as before, with no added probe; larger sends drop from a paced chain of subprocesses to two calls
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-x intent=yes -->
