### PR TITLE
fix(tmux): make the orphaned poll-client sweep actually reap

### DIFF
--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -40,6 +40,64 @@ func nulArgv(fields ...string) string {
 // Constraining the sweep to the one-shot cadence verbs it documents as its
 // target set closes both: neither attach-session nor new-session is a cadence
 // query, so neither is reapable regardless of comm or parentage.
+// TestNeverReapVerb pins the spelling rule the deny-list has to survive.
+//
+// tmux does not require the full verb. cmd_find() resolves a command name three
+// ways, and the deny-list is only safe if it recognises all of them:
+//
+//   - the full name — `attach-session`;
+//   - the alias, matched whole — `attach`, `new` (cmd-attach-session.c and
+//     cmd-new-session.c both carry a .alias field; they are entries in tmux's
+//     own command table, not documentation shorthand);
+//   - ANY unambiguous prefix of the full name — verified against tmux 3.0a:
+//     `attach-sess`, `att` and even `a` all reach attach-session, and
+//     `new-sess -d -s x` creates a session. A prefix of the *alias* does not
+//     resolve (`lscl` is rejected while `lsc` works), so an exact-match test is
+//     enough for the alias but not for the name.
+//
+// Prefixes are matched to the shortest form on purpose, including ones tmux
+// itself would reject as ambiguous (`n` could be new-session, new-window,
+// next-layout or next-window). Such a process dies on its own error rather than
+// attaching, so denying it costs one skipped reap — the direction this sweep is
+// required to fail in. `new-window`/`neww` are not denied: neither is a prefix
+// or alias of new-session, and this list names the verbs whose death costs the
+// user a live client or a session being born, not everything tmux can spell.
+func TestNeverReapVerb(t *testing.T) {
+	tests := []struct {
+		field string
+		want  bool
+	}{
+		{"attach-session", true},
+		{"attach", true},
+		{"attach-sess", true},
+		{"att", true},
+		{"a", true},
+		{"new-session", true},
+		{"new", true},
+		{"new-sess", true},
+		{"n", true},
+
+		{"", false},
+		{"attach-sessions", false},
+		{"attaché", false},
+		{"new-window", false},
+		{"neww", false},
+		{"next-window", false},
+		{"set-option", false},
+		{"list-clients", false},
+		{"agentdeck_npm_a0e435da", false},
+		{"-t", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			if got := isNeverReapVerb(tc.field); got != tc.want {
+				t.Errorf("isNeverReapVerb(%q) = %v, want %v", tc.field, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsReapableOneShotArgv(t *testing.T) {
 	tests := []struct {
 		name string
@@ -68,6 +126,15 @@ func TestIsReapableOneShotArgv(t *testing.T) {
 		// A chained command that both attaches and sets an option must lose:
 		// the deny side is fail-safe, the allow side is an optimisation.
 		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+
+		// Same chain, spelled the way tmux also accepts it. A deny-list keyed on
+		// the full verb alone lets every one of these through to the allow-list's
+		// set-option and reaps a live interactive client (see TestNeverReapVerb).
+		{"alias attach chained with set-option", []string{"tmux", "attach", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+		{"alias new chained with set-option", []string{"tmux", "new", "-d", "-s", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+		{"prefix attach-sess chained with set-option", []string{"tmux", "attach-sess", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+		{"prefix att chained with set-option", []string{"tmux", "att", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+		{"prefix new-sess chained with set-option", []string{"tmux", "new-sess", "-d", "-s", "agentdeck_x", ";", "set-option", "status", "on"}, false},
 
 		// Verbs outside the cadence set are not reapable even though they are
 		// legitimate tmux commands against an agent-deck session.

--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -43,7 +43,8 @@ func nulArgv(fields ...string) string {
 // TestNeverReapVerb pins the spelling rule the deny-list has to survive.
 //
 // tmux does not require the full verb. cmd_find() resolves a command name three
-// ways, and the deny-list is only safe if it recognises all of them:
+// ways, and the deny-list is only safe if it recognises all of them — plus a
+// fourth spelling that the parser produces before cmd_find() ever sees it:
 //
 //   - the full name — `attach-session`;
 //   - the alias, matched whole — `attach`, `new` (cmd-attach-session.c and
@@ -53,7 +54,11 @@ func nulArgv(fields ...string) string {
 //     `attach-sess`, `att` and even `a` all reach attach-session, and
 //     `new-sess -d -s x` creates a session. A prefix of the *alias* does not
 //     resolve (`lscl` is rejected while `lsc` works), so an exact-match test is
-//     enough for the alias but not for the name.
+//     enough for the alias but not for the name;
+//   - any of those with the command separator glued on. The separator does not
+//     have to stand alone as its own argv field: cmd_parse_from_arguments
+//     strips one unescaped trailing ";" from an argument, so `tmux attach\;
+//     set-option …` resolves attach-session out of the single field "attach;".
 //
 // Prefixes are matched to the shortest form on purpose, including ones tmux
 // itself would reject as ambiguous (`n` could be new-session, new-window,
@@ -76,6 +81,20 @@ func TestNeverReapVerb(t *testing.T) {
 		{"new", true},
 		{"new-sess", true},
 		{"n", true},
+
+		// A trailing separator glued to the verb. tmux strips one unescaped ";"
+		// off an argument before resolving it, so these are the same commands.
+		{"attach;", true},
+		{"att;", true},
+		{"new;", true},
+		{"new-sess;", true},
+
+		// Escaped, so the ";" survives into the command name and tmux rejects
+		// the whole thing ("unknown command: att;"). Only one separator is
+		// stripped, so "attach;;" is rejected the same way.
+		{`att\;`, false},
+		{"attach;;", false},
+		{";", false},
 
 		{"", false},
 		{"attach-sessions", false},
@@ -135,6 +154,13 @@ func TestIsReapableOneShotArgv(t *testing.T) {
 		{"prefix attach-sess chained with set-option", []string{"tmux", "attach-sess", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
 		{"prefix att chained with set-option", []string{"tmux", "att", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
 		{"prefix new-sess chained with set-option", []string{"tmux", "new-sess", "-d", "-s", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+
+		// `tmux attach\; set-option …` — the separator glues to the verb rather
+		// than standing alone, so the field is "attach;" and a deny keyed on the
+		// bare spellings misses it. tmux resolves it to attach-session all the
+		// same, which is a live client.
+		{"glued separator attach chained with set-option", []string{"tmux", "attach;", "set-option", "-t", "agentdeck_x", "status", "on"}, false},
+		{"glued separator new chained with set-option", []string{"tmux", "new;", "set-option", "-t", "agentdeck_x", "status", "on"}, false},
 
 		// Verbs outside the cadence set are not reapable even though they are
 		// legitimate tmux commands against an agent-deck session.

--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -1,0 +1,88 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// nulArgv builds a /proc/<pid>/cmdline payload: NUL-separated, NUL-terminated.
+func nulArgv(fields ...string) string {
+	return strings.Join(fields, "\x00") + "\x00"
+}
+
+// TestIsReapableOneShotArgv pins WHICH tmux clients the orphan sweep may kill.
+//
+// Matching on comm alone (a tmux client) plus SessionPrefix (argv mentions an
+// agent-deck session) is too broad in two directions, both of which SIGKILL
+// something the user cares about:
+//
+//   - An INTERACTIVE client. A user who runs `tmux attach-session -t
+//     agentdeck_foo` by hand gets a client whose parent is their shell, not
+//     agent-deck — and isControlClientOrphan treats any non-agent-deck parent
+//     as an orphan even while that parent is alive. Verified on a live host:
+//     such a client is selected for the kill. The session survives on the
+//     server, but the user is detached mid-interaction. Control-mode clients
+//     are already covered by reapStaleControlClients, which filters on
+//     client_control_mode and does not have this blind spot, so attach clients
+//     of either kind have no business in this sweep.
+//
+//   - A NASCENT SERVER. tmux renames the client to "tmux: client" before it
+//     forks the server (client.c calls proc_start("client") ahead of
+//     client_connect), and the forked server inherits that comm until its own
+//     proc_start("server") runs after daemon(). In that window a starting
+//     server presents comm "tmux: client" AND the creating client's argv
+//     (servers keep it — confirmed live: a running server shows
+//     `new-session -d -s agentdeck_…`) AND a parent that is either tmux or
+//     init. All three kill conditions hold. The window is sub-millisecond, but
+//     agent-deck starts one server per session during restore, concurrently
+//     with the first Connect that fires the sweep.
+//
+// Constraining the sweep to the one-shot cadence verbs it documents as its
+// target set closes both: neither attach-session nor new-session is a cadence
+// query, so neither is reapable regardless of comm or parentage.
+func TestIsReapableOneShotArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		// The 2026-08-01 orphan: a chained status-bar set-option batch.
+		{
+			"chained set-option batch",
+			[]string{"tmux", "set-option", "-t", "agentdeck_npm_a0e435da", "@agentdeck_project_name", "workspace", ";", "set-option", "-t", "agentdeck_npm_a0e435da", "set-titles", "on"},
+			true,
+		},
+		{"list-clients", []string{"tmux", "list-clients", "-F", "#{session_name}"}, true},
+		{"display-message", []string{"tmux", "display-message", "-p", "-t", "agentdeck_x", "#{pane_pid}"}, true},
+		{"list-panes with socket flag", []string{"tmux", "-L", "ad-sock", "list-panes", "-t", "agentdeck_x"}, true},
+		{"has-session", []string{"tmux", "has-session", "-t", "agentdeck_x"}, true},
+		{"kill-session mutation", []string{"tmux", "kill-session", "-t", "agentdeck_x"}, true},
+
+		// Interactive and control-mode attaches: never this sweep's business.
+		{"interactive attach", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
+		{"control-mode attach", []string{"tmux", "-C", "attach-session", "-t", "agentdeck_npm_a0e435da"}, false},
+
+		// A server being born carries the creating client's argv.
+		{"new-session", []string{"tmux", "-L", "ad-sock", "new-session", "-d", "-s", "agentdeck_x", "-c", "/home/u"}, false},
+
+		// A chained command that both attaches and sets an option must lose:
+		// the deny side is fail-safe, the allow side is an optimisation.
+		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+
+		// Verbs outside the cadence set are not reapable even though they are
+		// legitimate tmux commands against an agent-deck session.
+		{"pipe-pane", []string{"tmux", "pipe-pane", "-t", "agentdeck_x", "cat > /tmp/log"}, false},
+		{"send-keys", []string{"tmux", "send-keys", "-t", "agentdeck_x", "hello", "Enter"}, false},
+		{"no verb at all", []string{"tmux"}, false},
+		{"empty", []string{}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isReapableOneShotArgv(nulArgv(tc.argv...))
+			if got != tc.want {
+				t.Errorf("isReapableOneShotArgv(%q) = %v, want %v", tc.argv, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/orphan_reap_comm_test.go
+++ b/internal/tmux/orphan_reap_comm_test.go
@@ -1,0 +1,63 @@
+package tmux
+
+import "testing"
+
+// TestIsReapableTmuxClientComm pins the /proc/<pid>/comm values that the
+// orphaned-poll-client sweep must recognise as a tmux CLIENT.
+//
+// The 2026-08-01 incident: two orphaned clients — `tmux list-clients` and
+// `tmux set-option -t agentdeck_npm_a0e435da …` — spun at ~98% CPU for 14
+// hours (13h47m and 13h43m of CPU time, 1023/1022 open fds, nearly all
+// anon_inode:[eventpoll]) while a healthy agent-deck TUI ran alongside them
+// for 12.5 of those hours and never reaped either one.
+//
+// reapOrphanedPollClients filtered on `comm == "tmux"`, documented as "the
+// server is 'tmux: server' and never matches". Half of that is right: the
+// server does rename itself. What the filter missed is that tmux renames the
+// CLIENT too — comm is "tmux: client", not "tmux". Measured on tmux 3.0a /
+// Linux 5.4, where `pgrep -x tmux` matches zero processes on a host running
+// twenty of them:
+//
+//	comm=[tmux: client]  argv=[tmux -C attach-session -t agentdeck_mvn_672de607]
+//	comm=[tmux: server]  argv=[/usr/bin/tmux -L ad1031-2044680 new-session -d …]
+//
+// So the equality test never held for any process, the sweep was inert on
+// every Linux host, and the orphans it exists to mop up survived indefinitely.
+//
+// Rejecting "tmux: server" is the load-bearing safety property here, not a
+// nicety: the sweep SIGKILLs what it matches, and killing a server would
+// destroy every session it hosts — the user's work, not a leaked query client.
+func TestIsReapableTmuxClientComm(t *testing.T) {
+	tests := []struct {
+		name string
+		comm string
+		want bool
+	}{
+		// The value actually observed for one-shot query/option clients on
+		// Linux. This is the case the original filter missed.
+		{"renamed client", "tmux: client", true},
+		// Trailing newline: /proc/<pid>/comm always ends in one.
+		{"renamed client with newline", "tmux: client\n", true},
+		// Kept for platforms/versions that do not rename the client.
+		{"bare tmux", "tmux", true},
+		{"bare tmux with newline", "tmux\n", true},
+
+		// Never reapable — killing a server destroys live user sessions.
+		{"server", "tmux: server", false},
+		{"server with newline", "tmux: server\n", false},
+
+		// Unrelated binaries whose names merely start with "tmux".
+		{"tmuxinator", "tmuxinator", false},
+		{"tmuxp", "tmuxp", false},
+		{"empty", "", false},
+		{"unrelated", "bash", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReapableTmuxClientComm(tc.comm); got != tc.want {
+				t.Errorf("isReapableTmuxClientComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/orphan_reap_comm_test.go
+++ b/internal/tmux/orphan_reap_comm_test.go
@@ -51,12 +51,77 @@ func TestIsReapableTmuxClientComm(t *testing.T) {
 		{"tmuxp", "tmuxp", false},
 		{"empty", "", false},
 		{"unrelated", "bash", false},
+
+		// A tmux invoked under a longer argv[0] still names its role as long
+		// as "<progname>: <role>" survives the 15-char comm limit. The role
+		// token is what authorises the kill, not the program name, so these
+		// are reapable — see tmuxCommRole.
+		{"five-char progname keeps role", "tmuxx: client", true},
+		{"five-char progname server", "tmuxx: server", false},
+
+		// Measured, not assumed: invoking /usr/bin/tmux through a symlink
+		// named "tmux-3.5a" yields exactly this comm — the role token is gone
+		// entirely, not truncated to a prefix. tmux formats "<progname>:
+		// <role> (<socket>)", the kernel caps comm at 15 chars, and tmux then
+		// cuts the result back to its last space, which for a 9-char progname
+		// lands immediately after the colon.
+		//
+		// A SERVER under the same binary produces the identical string, so
+		// nothing here can tell the two apart. Refusing to match is the only
+		// safe answer: a false positive SIGKILLs a server and takes every
+		// session it hosts with it. agent-deck never spawns tmux this way
+		// (every call site is exec.Command("tmux", …), so argv[0] is the
+		// literal "tmux"), so no orphan of its own can land in this state.
+		{"renamed binary loses role", "tmux-3.5a:", false},
+		{"renamed binary loses role, newline", "tmux-3.5a:\n", false},
+		{"colon with no role", "tmux:", false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isReapableTmuxClientComm(tc.comm); got != tc.want {
 				t.Errorf("isReapableTmuxClientComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsTruncatedTmuxComm pins which comm values the sweep must REPORT rather
+// than silently pass over.
+//
+// The original defect was not that the sweep killed the wrong thing — it was
+// that it killed nothing at all and said nothing about it, so two orphans burned
+// a core each for 14 hours with a healthy TUI running beside them. A comm whose
+// role token was lost to truncation puts the sweep back in exactly that state
+// for the affected process: it cannot be classified, so it cannot be reaped.
+// That is the right call, but it must be visible, not silent.
+func TestIsTruncatedTmuxComm(t *testing.T) {
+	tests := []struct {
+		name string
+		comm string
+		want bool
+	}{
+		// Role lost to truncation — unclassifiable, so worth reporting.
+		{"renamed binary", "tmux-3.5a:", true},
+		{"renamed binary with newline", "tmux-3.5a:\n", true},
+		{"bare colon", "tmux:", true},
+
+		// Classifiable: handled normally, nothing to report.
+		{"client", "tmux: client", false},
+		{"server", "tmux: server", false},
+		{"bare tmux", "tmux", false},
+		{"long progname keeping role", "tmuxx: client", false},
+
+		// Not tmux at all — the sweep skips these silently and always did.
+		{"bash", "bash", false},
+		{"empty", "", false},
+		{"unrelated with colon", "systemd:", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTruncatedTmuxComm(tc.comm); got != tc.want {
+				t.Errorf("isTruncatedTmuxComm(%q) = %v, want %v", tc.comm, got, tc.want)
 			}
 		})
 	}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -817,9 +817,47 @@ var reapableOneShotVerbs = map[string]struct{}{
 //     client", set by proc_start before the fork) and argv until its own
 //     proc_start("server") runs after daemon(). A server killed in that window
 //     takes the session it was starting with it.
-var neverReapVerbs = map[string]struct{}{
-	"attach-session": {},
-	"new-session":    {},
+//
+// Each entry carries the alias tmux's own command table gives it, because the
+// deny-list has to recognise a verb in every spelling tmux will accept for it —
+// see isNeverReapVerb.
+var neverReapVerbs = []struct {
+	name  string
+	alias string
+}{
+	{name: "attach-session", alias: "attach"}, // cmd-attach-session.c
+	{name: "new-session", alias: "new"},       // cmd-new-session.c
+}
+
+// isNeverReapVerb reports whether an argv field names a denied verb in any
+// spelling tmux resolves. cmd_find() accepts three, and matching only the first
+// leaves the other two as a way through the deny-list into the allow-list:
+//
+//   - the full name;
+//   - the alias, matched whole ("attach", "new");
+//   - any prefix of the full name, if unambiguous. Verified against tmux 3.0a:
+//     `att -t x` reaches attach-session and `new-sess -d -s x` creates a
+//     session. A prefix of the ALIAS does not resolve ("lscl" is rejected while
+//     "lsc" works), so the alias needs equality and the name needs HasPrefix.
+//
+// Prefixes are honoured down to a single character, including ones tmux itself
+// rejects as ambiguous ("n" could be new-session, new-window, next-layout or
+// next-window; "a" is unambiguously attach-session). An ambiguous one dies on
+// tmux's own error instead of attaching, so denying it costs at most a skipped
+// reap — the direction this sweep is required to fail in.
+//
+// The allow-list stays exact-match: an unrecognised spelling of a cadence verb
+// leaves reapable false, which is the same fail-safe outcome.
+func isNeverReapVerb(field string) bool {
+	if field == "" {
+		return false
+	}
+	for _, verb := range neverReapVerbs {
+		if field == verb.alias || strings.HasPrefix(verb.name, field) {
+			return true
+		}
+	}
+	return false
 }
 
 // isReapableOneShotArgv reports whether a /proc/<pid>/cmdline names a one-shot
@@ -829,7 +867,7 @@ var neverReapVerbs = map[string]struct{}{
 func isReapableOneShotArgv(cmdline string) bool {
 	reapable := false
 	for _, field := range strings.Split(strings.TrimRight(cmdline, "\x00"), "\x00") {
-		if _, denied := neverReapVerbs[field]; denied {
+		if isNeverReapVerb(field) {
 			return false
 		}
 		if _, ok := reapableOneShotVerbs[field]; ok {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -700,20 +700,80 @@ var orphanReapOnce sync.Once
 // the sweep inert — orphaned query clients spun at 100% CPU for as long as the
 // host stayed up.
 //
-// The bare "tmux" case is kept because the rename is a tmux implementation
-// detail, not a guarantee: a client that has not yet renamed itself, or a
-// version that never does, must still be reapable.
+// The bare "tmux" case is kept for the window between exec and the client's own
+// proc_start: a process that has not renamed itself yet is a client that has not
+// connected yet, never a server (the server is forked from an already-renamed
+// client, so it never presents a bare name).
 //
-// "tmux: server" MUST NOT match. The sweep SIGKILLs whatever it matches, and a
-// server holds every session it hosts, so a false positive there destroys the
-// user's running work rather than a leaked one-shot query.
+// It is the ROLE token that authorises the kill, not the program name — see
+// tmuxCommRole for why a longer argv[0] is still safe to reap when its role
+// survives, and isTruncatedTmuxComm for what happens when it does not.
+//
+// A server MUST NOT match. The sweep SIGKILLs whatever it matches, and a server
+// holds every session it hosts, so a false positive there destroys the user's
+// running work rather than a leaked one-shot query.
 func isReapableTmuxClientComm(comm string) bool {
-	switch strings.TrimSpace(comm) {
-	case "tmux", "tmux: client":
+	trimmed := strings.TrimSpace(comm)
+	if trimmed == "tmux" {
 		return true
-	default:
+	}
+	role, ok := tmuxCommRole(trimmed)
+	return ok && role == "client"
+}
+
+// tmuxCommRole splits tmux's setproctitle-style comm into its role token.
+// tmux formats "<progname>: <role> (<socket path>)", so the role is whatever
+// follows the first ": ".
+//
+// Keying on the role rather than on the literal "tmux: client" keeps the sweep
+// working for an installation whose binary is invoked under a longer name: a
+// 5-char progname still yields "tmuxx: client", which names its role
+// unambiguously and is as safe to reap as the canonical form.
+//
+// The role either survives whole or vanishes whole — it is never truncated to a
+// prefix. The kernel caps comm at 15 bytes and tmux then cuts the result back to
+// its last space, which is the one separating the role from the socket path. So
+// a partial "clie"/"serve" cannot reach this function, and matching role ==
+// "client" can never be satisfied by a server.
+func tmuxCommRole(comm string) (string, bool) {
+	idx := strings.Index(comm, ": ")
+	if idx <= 0 {
+		return "", false
+	}
+	role := comm[idx+2:]
+	if role == "" {
+		return "", false
+	}
+	return role, true
+}
+
+// isTruncatedTmuxComm reports whether comm looks like tmux's setproctitle output
+// whose role token was lost entirely to the 15-byte comm limit.
+//
+// Measured, not inferred: invoking /usr/bin/tmux through a symlink named
+// "tmux-3.5a" produces the comm "tmux-3.5a:" — cut back to the space right after
+// the colon, taking "client"/"server" with it. A server under that binary
+// produces the identical string, so such a process cannot be classified at all
+// and must not be killed.
+//
+// agent-deck cannot produce one of these itself: every spawn is
+// exec.Command("tmux", …), so argv[0] is the literal "tmux" whatever the binary
+// is called on disk. The case therefore belongs to a user's own tmux, which the
+// sweep has no business killing regardless.
+//
+// It is still worth reporting. The bug this whole sweep exists to prevent was
+// invisible — an inert filter that killed nothing and logged nothing while two
+// orphans burned a core each for 14 hours. Anything that silently narrows the
+// sweep back toward inert should say so.
+func isTruncatedTmuxComm(comm string) bool {
+	trimmed := strings.TrimSpace(comm)
+	if trimmed == "tmux" {
 		return false
 	}
+	if _, ok := tmuxCommRole(trimmed); ok {
+		return false
+	}
+	return strings.Contains(trimmed, "tmux") && strings.HasSuffix(trimmed, ":")
 }
 
 // reapableOneShotVerbs are the tmux subcommands reapOrphanedPollClients may
@@ -818,6 +878,7 @@ func reapOrphanedPollClients() {
 	}
 	myPID := os.Getpid()
 	killed := 0
+	skipped := 0
 	start := time.Now()
 	for _, e := range entries {
 		pid, err := strconv.Atoi(e.Name())
@@ -825,7 +886,16 @@ func reapOrphanedPollClients() {
 			continue
 		}
 		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil || !isReapableTmuxClientComm(string(comm)) {
+		if err != nil {
+			continue
+		}
+		reapable := isReapableTmuxClientComm(string(comm))
+		// A comm whose role token was truncated away cannot be classified as
+		// client or server. It is not killed; it is carried to the end of the
+		// gauntlet so that a process which is otherwise indistinguishable from
+		// a leak gets reported instead of vanishing from the sweep in silence.
+		unclassifiable := !reapable && isTruncatedTmuxComm(string(comm))
+		if !reapable && !unclassifiable {
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the
@@ -843,15 +913,25 @@ func reapOrphanedPollClients() {
 		if !isControlClientOrphan(pid) {
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
 		}
+		if unclassifiable {
+			skipped++
+			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.String("reason", "comm lost its role token to truncation; "+
+					"cannot prove this is a client rather than a server, so it is left alone"))
+			continue
+		}
 		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
 		killed++
 		pipeLog.Debug("reaped_orphaned_poll_client",
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	if killed > 0 {
+	if killed > 0 || skipped > 0 {
 		pipeLog.Info("orphaned_poll_clients_reaped",
 			slog.Int("kill_count", killed),
+			slog.Int("skipped_unclassifiable", skipped),
 			slog.Duration("duration", time.Since(start)))
 	}
 }

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -716,6 +716,69 @@ func isReapableTmuxClientComm(comm string) bool {
 	}
 }
 
+// reapableOneShotVerbs are the tmux subcommands reapOrphanedPollClients may
+// kill: the short-lived cadence queries and option writes agent-deck fires on a
+// timer, every one of which is safe to lose because its caller re-issues it on
+// the next tick. The set mirrors the poll/mutation lists that
+// TestPollCommandsAreBounded enforces deadlines for — same commands, same
+// reason: they run on a cadence, so they are the ones that leak.
+var reapableOneShotVerbs = map[string]struct{}{
+	"bind-key":         {},
+	"capture-pane":     {},
+	"detach-client":    {},
+	"display-message":  {},
+	"has-session":      {},
+	"kill-session":     {},
+	"list-clients":     {},
+	"list-panes":       {},
+	"list-sessions":    {},
+	"refresh-client":   {},
+	"set-option":       {},
+	"show-environment": {},
+	"show-option":      {},
+	"switch-client":    {},
+	"unbind-key":       {},
+}
+
+// neverReapVerbs are the subcommands that disqualify a process outright, even
+// if the same argv also carries a reapable verb (tmux accepts `;`-chained
+// commands, so both can appear). Each names a process whose death costs the
+// user something this sweep has no standing to spend:
+//
+//   - attach-session — an interactive client is the user's live view of a
+//     session, and a control-mode one belongs to a TUI. Orphaned control
+//     clients are reapStaleControlClients' job; it filters on
+//     client_control_mode and so cannot mistake a hand-run `tmux attach` for
+//     a leak. This sweep, matching only on comm + argv + parentage, can:
+//     isControlClientOrphan calls ANY non-agent-deck parent an orphan, so a
+//     client attached from the user's own shell qualifies while that shell is
+//     still alive.
+//   - new-session — a server inherits the creating client's comm ("tmux:
+//     client", set by proc_start before the fork) and argv until its own
+//     proc_start("server") runs after daemon(). A server killed in that window
+//     takes the session it was starting with it.
+var neverReapVerbs = map[string]struct{}{
+	"attach-session": {},
+	"new-session":    {},
+}
+
+// isReapableOneShotArgv reports whether a /proc/<pid>/cmdline names a one-shot
+// cadence command and nothing more dangerous. cmdline fields are NUL-separated
+// and NUL-terminated, so each argv element is compared whole — a session name
+// or path that merely contains a verb as a substring cannot match.
+func isReapableOneShotArgv(cmdline string) bool {
+	reapable := false
+	for _, field := range strings.Split(strings.TrimRight(cmdline, "\x00"), "\x00") {
+		if _, denied := neverReapVerbs[field]; denied {
+			return false
+		}
+		if _, ok := reapableOneShotVerbs[field]; ok {
+			reapable = true
+		}
+	}
+	return reapable
+}
+
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
 // `list-clients` / `display-message` / `list-panes` / status `set-option`
 // invocations agent-deck fires on a cadence — that a previous run spawned and
@@ -733,7 +796,10 @@ func isReapableTmuxClientComm(comm string) bool {
 //   - it is a tmux CLIENT process (isReapableTmuxClientComm; the server
 //     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
-//     user's unrelated tmux is never touched, and
+//     user's unrelated tmux is never touched,
+//   - its argv names a one-shot cadence verb and no attach/new-session verb
+//     (isReapableOneShotArgv), so neither a live interactive client nor a
+//     server still inside its startup rename window can be hit, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
 //     (isControlClientOrphan — its parentage check is client-type-agnostic
 //     despite the name). A live TUI's own in-flight poll has PPID == our PID,
@@ -766,6 +832,12 @@ func reapOrphanedPollClients() {
 		// "agentdeck_" target token regardless of separators.
 		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 		if err != nil || !strings.Contains(string(raw), SessionPrefix) {
+			continue
+		}
+		// Narrow comm+prefix down to the cadence commands this sweep exists
+		// for: an interactive attach and a server mid-startup both clear the
+		// checks above, and killing either costs the user real work.
+		if !isReapableOneShotArgv(string(raw)) {
 			continue
 		}
 		if !isControlClientOrphan(pid) {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -829,9 +829,25 @@ var neverReapVerbs = []struct {
 	{name: "new-session", alias: "new"},       // cmd-new-session.c
 }
 
+// tmuxVerbToken strips the command separator tmux itself strips before it
+// resolves anything. cmd_parse_from_arguments (cmd-parse.y) takes ONE unescaped
+// trailing ";" off an argument and treats it as the boundary, so the separator
+// need not stand alone: `tmux attach\; set-option …` puts the single field
+// "attach;" in argv and still runs attach-session. Escaping it (`att\;` quoted
+// through to tmux) leaves the ";" in the command name, which tmux rejects with
+// "unknown command: att;" — verified on 3.0a, and the parser is unchanged on
+// master.
+func tmuxVerbToken(field string) string {
+	if strings.HasSuffix(field, ";") && !strings.HasSuffix(field, `\;`) {
+		return strings.TrimSuffix(field, ";")
+	}
+	return field
+}
+
 // isNeverReapVerb reports whether an argv field names a denied verb in any
-// spelling tmux resolves. cmd_find() accepts three, and matching only the first
-// leaves the other two as a way through the deny-list into the allow-list:
+// spelling tmux resolves. cmd_find() accepts three, and a fourth comes from the
+// parser that runs before it; matching only the full name leaves the rest as a
+// way through the deny-list into the allow-list:
 //
 //   - the full name;
 //   - the alias, matched whole ("attach", "new");
@@ -839,6 +855,7 @@ var neverReapVerbs = []struct {
 //     `att -t x` reaches attach-session and `new-sess -d -s x` creates a
 //     session. A prefix of the ALIAS does not resolve ("lscl" is rejected while
 //     "lsc" works), so the alias needs equality and the name needs HasPrefix.
+//   - any of the above with the separator glued on — see tmuxVerbToken.
 //
 // Prefixes are honoured down to a single character, including ones tmux itself
 // rejects as ambiguous ("n" could be new-session, new-window, next-layout or
@@ -849,6 +866,7 @@ var neverReapVerbs = []struct {
 // The allow-list stays exact-match: an unrecognised spelling of a cadence verb
 // leaves reapable false, which is the same fail-safe outcome.
 func isNeverReapVerb(field string) bool {
+	field = tmuxVerbToken(field)
 	if field == "" {
 		return false
 	}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -689,6 +689,33 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 // instead of re-scanning all of /proc on every Connect.
 var orphanReapOnce sync.Once
 
+// isReapableTmuxClientComm reports whether a /proc/<pid>/comm value identifies
+// a tmux CLIENT — the only process class reapOrphanedPollClients may kill.
+//
+// tmux renames both of its process roles after startup, so comm is "tmux:
+// client" / "tmux: server" rather than the bare "tmux" of the argv[0] the
+// process was exec'd with. (Verified on tmux 3.0a / Linux 5.4: `pgrep -x tmux`
+// matches nothing on a host running twenty tmux processes.) An earlier
+// equality test against "tmux" therefore matched no process at all and left
+// the sweep inert — orphaned query clients spun at 100% CPU for as long as the
+// host stayed up.
+//
+// The bare "tmux" case is kept because the rename is a tmux implementation
+// detail, not a guarantee: a client that has not yet renamed itself, or a
+// version that never does, must still be reapable.
+//
+// "tmux: server" MUST NOT match. The sweep SIGKILLs whatever it matches, and a
+// server holds every session it hosts, so a false positive there destroys the
+// user's running work rather than a leaked one-shot query.
+func isReapableTmuxClientComm(comm string) bool {
+	switch strings.TrimSpace(comm) {
+	case "tmux", "tmux: client":
+		return true
+	default:
+		return false
+	}
+}
+
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
 // `list-clients` / `display-message` / `list-panes` / status `set-option`
 // invocations agent-deck fires on a cadence — that a previous run spawned and
@@ -703,8 +730,8 @@ var orphanReapOnce sync.Once
 // timeout because the TUI was SIGKILL'd / OOM-killed mid-command.
 //
 // Safety — a process is killed only when ALL hold:
-//   - it is the `tmux` client binary (comm == "tmux"; the server is
-//     "tmux: server" and never matches),
+//   - it is a tmux CLIENT process (isReapableTmuxClientComm; the server
+//     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
 //     user's unrelated tmux is never touched, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
@@ -732,7 +759,7 @@ func reapOrphanedPollClients() {
 			continue
 		}
 		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil || strings.TrimSpace(string(comm)) != "tmux" {
+		if err != nil || !isReapableTmuxClientComm(string(comm)) {
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the


### PR DESCRIPTION
## What problem does this solve?

`reapOrphanedPollClients` has never reaped anything on Linux. It selects candidates with `comm == "tmux"`, but tmux renames its processes at startup, so `/proc/<pid>/comm` reads `tmux: client` or `tmux: server` — never the bare `tmux` of the argv[0] it was exec'd with. On the host where this surfaced, `pgrep -x tmux` matches **zero** of twenty live tmux processes.

The sweep exists to mop up orphaned one-shot query clients that escaped `tmuxPollTimeout` — the ones a tmux 3.0a fd leak leaves spinning at 100% CPU with no way to exit. Because the filter matched nothing, they were never mopped up.

Observed 2026-08-01: two orphans — `tmux list-clients` and `tmux set-option -t agentdeck_npm_… ; …` — each burning ~98% of a core for **14 hours** (13h47m and 13h43m of CPU time, 1023/1022 open fds, nearly all `anon_inode:[eventpoll]`). A healthy agent-deck TUI ran beside them for 12.5 of those hours and reaped neither. Load average 25 on 8 cores.

## Why this change

Three commits, smallest first.

**1 — match the renamed comm.** Replaces the equality test. The existing doc comment said *"the server is `tmux: server` and never matches"*; the server half is right, the client half is not — tmux renames both roles.

**2 — restrict the sweep to the verbs it documents.** Commit 1 alone is not safe to ship: once the predicate starts matching, `comm + SessionPrefix + parentage` selects two classes that must never be killed.

- *Interactive clients.* `isControlClientOrphan` treats **any** non-agent-deck parent as an orphan, including a live one. So `tmux attach-session -t agentdeck_foo` run by hand from a shell qualifies, and the user gets detached mid-interaction on the next startup. `reapStaleControlClients` cannot make this mistake — it filters on `client_control_mode` — so attach clients do not belong in this sweep at all.
- *Nascent servers.* tmux calls `proc_start("client")` before `client_connect()` forks the server, so a starting server inherits `tmux: client` until its own `proc_start("server")` after `daemon()`. In that window it presents a client's comm, the creating client's argv (servers keep it), and a parent of tmux-or-init — all three kill conditions. Sub-millisecond, but agent-deck starts one server per session during restore, racing the first `Connect()` that fires the sweep.

Requiring argv to name a cadence verb and no `attach-session`/`new-session` closes both.

**3 — key on the role token, and report what cannot be classified.** Matching the literal `tmux: client` ties the sweep to one argv[0]. Keying on the role instead widens it safely, and makes the one unclassifiable case explicit rather than silent:

| progname | comm | role |
|---|---|---|
| `tmux` | `tmux: client` | survives → reapable |
| `tmuxx` | `tmuxx: client` | survives → reapable (new) |
| `tmux-3.5a` | `tmux-3.5a:` | **lost** → not reapable, logged at WARN |

The role survives whole or vanishes whole: the kernel caps comm at 15 bytes and tmux cuts back to the last space, which is the one before the socket path. A partial `clie`/`serve` cannot occur, so `role == "client"` can never be satisfied by a server.

When the role is gone the process genuinely cannot be classified — verified by running a server and a one-shot client under the same 9-char name and getting the identical comm `tmux-3.5a:` for both. Killing on that would be a coin flip on destroying a server, so it is left alone and logged. agent-deck cannot produce one itself: every spawn is `exec.Command("tmux", …)`, so argv[0] is the literal `tmux` whatever the binary is named on disk.

## User impact

Orphaned tmux query clients that survived a TUI crash or restart are now actually reaped at startup instead of spinning at 100% CPU until reboot. On the affected host that was two full cores.

No change to normal operation: nothing is killed that was not already unowned and matching a cadence verb.

## Evidence

**The orphans, before the fix** (`ps`, 2026-08-01):

```
    PID    PPID USER     %CPU     ELAPSED STAT COMMAND
3908313    4069 ati      97.8    14:01:27 R    tmux list-clients -F #{session_name}|#{client_control_mode}
3897971    4069 ati      97.7    14:05:45 R    tmux set-option -t agentdeck_npm_a0e435da @agentdeck_project_name …
```

Both at 1023/1022 open fds, nearly all `anon_inode:[eventpoll]`; PPID 4069 is `systemd --user`. Load average 25.60 on 8 cores; 4.87 after killing them.

**comm is never bare `tmux`** — the whole defect, on tmux 3.0a / Linux 5.4:

```
comm=[tmux: client]  argv=[tmux -C attach-session -t agentdeck_mvn_672de607]
comm=[tmux: server]  argv=[/usr/bin/tmux -L ad1031-2044680 new-session -d -s agentdeck_…]
$ pgrep -x tmux | wc -l
0
```

**Live selection matrix.** Four real orphans on one throwaway socket, run against the old and new predicates side by side:

| pid | comm | actual role | old filter | comm-only (commit 1) | shipped (commits 1–3) |
|---|---|---|---|---|---|
| 2222660 | `tmux-3.5a:` | **server** | – | – | – spared |
| 2222748 | `tmux-3.5a:` | client | – | – | – spared, **reported** |
| 2222749 | `tmuxx: client` | client | – | reap | **reap** |
| 2222750 | `tmux: client` | client | – | reap | **reap** |
| (earlier) | `tmux: client` | shell-attached client | – | **reap — regression** | – spared |
| (earlier) | `tmux: server` | server, `agentdeck_` argv | – | – | – spared |

`servers killed: 0` in every configuration. Note rows 1 and 2: a server and a client with the *identical* comm — direct proof that refusing to classify is the only safe answer there.

**Hot path timing** (tmux layer). The sweep is a single `/proc` scan fired once per run from the first `Connect()`. Old vs shipped filter, interleaved rounds so cache state and drifting load hit both equally, on a host with 1063 processes:

```
old  mean /proc sweep: 22.980ms (n=40, interleaved)
new  mean /proc sweep: 23.819ms (n=40, interleaved)
```

**+0.84 ms (~3.7%), once per process lifetime.** The extra cost is the role split plus the argv verb scan on the handful of entries that clear the comm check. For contrast, the bug this fixes cost two full cores for 14 hours.

(A first, sequential measurement showed the new filter as *faster* — cold-cache ordering artifact, discarded in favour of the interleaved run above.)

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5 (investigation, fix, tests). An independent adversarial review pass was run with a second model (Fable 5), which caught the two regressions that became commit 2 and corrected a wrong assumption about the truncated-comm format that became commit 3.

**Prompt / session log (optional):** not published; the operator's verbatim asks are quoted below.

## What actually bothered you

My human's opening question, verbatim:

> what process ate my cpu?

Their machine had load average 25 on 8 cores. Two orphaned tmux clients had been spinning for 14 hours. After we tracked it down and killed them, the follow-up was:

> can you fix the agent-deck fd leak?

The name turned out to be half right — the fd leak itself is tmux 3.0a's, and `tmuxPollTimeout` already bounds new leaks correctly. What was broken was the safety net for the leaks that escape it: `reapOrphanedPollClients`, which had been silently matching nothing since it was written. That silence is the part worth fixing — the sweep reported `kill_count` only when it was greater than zero, so an inert sweep and a clean host looked identical in the logs.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed — with two host-limitation exceptions that also fail on unmodified `upstream/main`; see below
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

### Test suite state

Sandboxed, packages serialized (`-p 1`; running them concurrently makes several packages collide on the single sandbox `$HOME` and produces six spurious failures on branch *and* baseline alike, including the tmux bootstrap):

```
HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test -p 1 ./...
```

| | this branch | unmodified `upstream/main` |
|---|---|---|
| ok packages | **48** | 46 |
| failing tests | **2** | 5 |
| `internal/tmux` | **ok** (34.6s) | FAIL |
| `cmd/agent-deck` | **ok** (69.0s) | FAIL |

The branch's two failures are a strict subset of the baseline's five, and both are host limitations rather than code:

- `TestPersistence_TmuxDiesWithoutUserScope` — `write cgroup.kill …: no such file or directory`. `cgroup.kill` is cgroup-v2 (Linux ≥ 5.14); this host is kernel 5.4 on v1 hierarchies.
- `TestAggregateSize_ReportsLargestClient` — `WindowSize=80x23; expected at least 80x24`; no TTY in the harness.

Baseline additionally fails three timing-sensitive tests the branch passed on this run (`TestPerf_ColdStart_Help`, `TestPerf_ColdStart_Version`, `TestIssue1131_E2E_KeystrokeToPaneRenderLatency`) — noted for completeness, not claimed as an improvement.

Also clean: `gofmt`, `go vet ./...`, `go build ./cmd/agent-deck/`, `golangci-lint run` (0 issues), and the release-tests YAML guard. `make css-verify` fails identically on pristine `upstream/main` (a local Tailwind build differing from the committed artifact), so it is untouched by this diff.

### Known gap, deliberately not fixed here

An orphaned bare `tmux list-clients` (no `-t`, as spawned by `SweepStaleControlClients`) carries no session name in argv, so the `SessionPrefix` filter still skips it — one of the two 14-hour orphans was this shape. Widening that filter means reasoning about tmux clients agent-deck did not spawn, which is a different risk profile than this diff; it deserves its own change. The `-t`-carrying variant from `killStaleControlClients` **is** covered.

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of orphaned tmux processes by distinguishing client processes from servers and unrelated processes.
  * Prevented cleanup of interactive attaches, session creation commands, and unsupported command types.
  * Added reporting for processes that cannot be safely classified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->