### PR TITLE
fix(tmux): close the orphan-sweep alias/abbreviation bypass in #1832, credit @drmzperx

### DIFF
--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -10,37 +10,28 @@ func nulArgv(fields ...string) string {
 	return strings.Join(fields, "\x00") + "\x00"
 }
 
-// TestIsReapableOneShotArgv pins WHICH tmux clients the orphan sweep may kill.
+// TestIsKnownCadenceArgv pins the SCOPE this sweep targets: the one-shot
+// poll/query/status commands agent-deck fires on a cadence. It is
+// deliberately NOT a safety test — isKnownCadenceArgv is an allowlist that
+// only ever narrows the sweep, never a denylist that could be trusted to keep
+// something out. See TestIsLiveTmuxClientOrServer_ChainedAliasRepro for the
+// actual safety guarantee and why it cannot live in this function.
 //
-// Matching on comm alone (a tmux client) plus SessionPrefix (argv mentions an
-// agent-deck session) is too broad in two directions, both of which SIGKILL
-// something the user cares about:
-//
-//   - An INTERACTIVE client. A user who runs `tmux attach-session -t
-//     agentdeck_foo` by hand gets a client whose parent is their shell, not
-//     agent-deck — and isControlClientOrphan treats any non-agent-deck parent
-//     as an orphan even while that parent is alive. Verified on a live host:
-//     such a client is selected for the kill. The session survives on the
-//     server, but the user is detached mid-interaction. Control-mode clients
-//     are already covered by reapStaleControlClients, which filters on
-//     client_control_mode and does not have this blind spot, so attach clients
-//     of either kind have no business in this sweep.
-//
-//   - A NASCENT SERVER. tmux renames the client to "tmux: client" before it
-//     forks the server (client.c calls proc_start("client") ahead of
-//     client_connect), and the forked server inherits that comm until its own
-//     proc_start("server") runs after daemon(). In that window a starting
-//     server presents comm "tmux: client" AND the creating client's argv
-//     (servers keep it — confirmed live: a running server shows
-//     `new-session -d -s agentdeck_…`) AND a parent that is either tmux or
-//     init. All three kill conditions hold. The window is sub-millisecond, but
-//     agent-deck starts one server per session during restore, concurrently
-//     with the first Connect that fires the sweep.
-//
-// Constraining the sweep to the one-shot cadence verbs it documents as its
-// target set closes both: neither attach-session nor new-session is a cadence
-// query, so neither is reapable regardless of comm or parentage.
-func TestIsReapableOneShotArgv(t *testing.T) {
+// History: this file used to pin isReapableOneShotArgv, which paired this
+// same allowlist with a denylist (neverReapVerbs) matching only the literal
+// strings "attach-session" / "new-session" and trusted that pairing as the
+// safety boundary. It was wrong to: tmux resolves command names by
+// unambiguous prefix, so "attach" (a real tmux alias), "attac", "att", "at",
+// even bare "a" all invoke attach-session unmodified (verified live on tmux
+// 3.7b — `tmux -C a -t sess` attaches). A chained
+// `tmux attach -t agentdeck_x \; set-option status on` cleared the old
+// denylist (wrong spelling) while "set-option" satisfied this allowlist, so
+// isReapableOneShotArgv ruled the whole line reapable with a live client
+// behind it. isKnownCadenceArgv keeps only the allowlist half — a miss here
+// means "skip", a hit means only "maybe, ask the server" — and
+// isLiveTmuxClientOrServer supplies the actual guarantee by asking the tmux
+// server itself, which cannot be abbreviated around.
+func TestIsKnownCadenceArgv(t *testing.T) {
 	tests := []struct {
 		name string
 		argv []string
@@ -58,19 +49,15 @@ func TestIsReapableOneShotArgv(t *testing.T) {
 		{"has-session", []string{"tmux", "has-session", "-t", "agentdeck_x"}, true},
 		{"kill-session mutation", []string{"tmux", "kill-session", "-t", "agentdeck_x"}, true},
 
-		// Interactive and control-mode attaches: never this sweep's business.
-		{"interactive attach", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
-		{"control-mode attach", []string{"tmux", "-C", "attach-session", "-t", "agentdeck_npm_a0e435da"}, false},
-
-		// A server being born carries the creating client's argv.
-		{"new-session", []string{"tmux", "-L", "ad-sock", "new-session", "-d", "-s", "agentdeck_x", "-c", "/home/u"}, false},
-
-		// A chained command that both attaches and sets an option must lose:
-		// the deny side is fail-safe, the allow side is an optimisation.
-		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+		// A cadence verb chained after an attach still matches the allowlist —
+		// that is expected and fine, because this function no longer decides
+		// whether the process is safe to kill. isLiveTmuxClientOrServer does.
+		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, true},
+		{"alias attach chained with set-option", []string{"tmux", "attach", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, true},
 
 		// Verbs outside the cadence set are not reapable even though they are
 		// legitimate tmux commands against an agent-deck session.
+		{"bare attach-session, no cadence verb", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
 		{"pipe-pane", []string{"tmux", "pipe-pane", "-t", "agentdeck_x", "cat > /tmp/log"}, false},
 		{"send-keys", []string{"tmux", "send-keys", "-t", "agentdeck_x", "hello", "Enter"}, false},
 		{"no verb at all", []string{"tmux"}, false},
@@ -79,9 +66,9 @@ func TestIsReapableOneShotArgv(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isReapableOneShotArgv(nulArgv(tc.argv...))
+			got := isKnownCadenceArgv(nulArgv(tc.argv...))
 			if got != tc.want {
-				t.Errorf("isReapableOneShotArgv(%q) = %v, want %v", tc.argv, got, tc.want)
+				t.Errorf("isKnownCadenceArgv(%q) = %v, want %v", tc.argv, got, tc.want)
 			}
 		})
 	}

--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -1,0 +1,88 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// nulArgv builds a /proc/<pid>/cmdline payload: NUL-separated, NUL-terminated.
+func nulArgv(fields ...string) string {
+	return strings.Join(fields, "\x00") + "\x00"
+}
+
+// TestIsReapableOneShotArgv pins WHICH tmux clients the orphan sweep may kill.
+//
+// Matching on comm alone (a tmux client) plus SessionPrefix (argv mentions an
+// agent-deck session) is too broad in two directions, both of which SIGKILL
+// something the user cares about:
+//
+//   - An INTERACTIVE client. A user who runs `tmux attach-session -t
+//     agentdeck_foo` by hand gets a client whose parent is their shell, not
+//     agent-deck — and isControlClientOrphan treats any non-agent-deck parent
+//     as an orphan even while that parent is alive. Verified on a live host:
+//     such a client is selected for the kill. The session survives on the
+//     server, but the user is detached mid-interaction. Control-mode clients
+//     are already covered by reapStaleControlClients, which filters on
+//     client_control_mode and does not have this blind spot, so attach clients
+//     of either kind have no business in this sweep.
+//
+//   - A NASCENT SERVER. tmux renames the client to "tmux: client" before it
+//     forks the server (client.c calls proc_start("client") ahead of
+//     client_connect), and the forked server inherits that comm until its own
+//     proc_start("server") runs after daemon(). In that window a starting
+//     server presents comm "tmux: client" AND the creating client's argv
+//     (servers keep it — confirmed live: a running server shows
+//     `new-session -d -s agentdeck_…`) AND a parent that is either tmux or
+//     init. All three kill conditions hold. The window is sub-millisecond, but
+//     agent-deck starts one server per session during restore, concurrently
+//     with the first Connect that fires the sweep.
+//
+// Constraining the sweep to the one-shot cadence verbs it documents as its
+// target set closes both: neither attach-session nor new-session is a cadence
+// query, so neither is reapable regardless of comm or parentage.
+func TestIsReapableOneShotArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		// The 2026-08-01 orphan: a chained status-bar set-option batch.
+		{
+			"chained set-option batch",
+			[]string{"tmux", "set-option", "-t", "agentdeck_npm_a0e435da", "@agentdeck_project_name", "workspace", ";", "set-option", "-t", "agentdeck_npm_a0e435da", "set-titles", "on"},
+			true,
+		},
+		{"list-clients", []string{"tmux", "list-clients", "-F", "#{session_name}"}, true},
+		{"display-message", []string{"tmux", "display-message", "-p", "-t", "agentdeck_x", "#{pane_pid}"}, true},
+		{"list-panes with socket flag", []string{"tmux", "-L", "ad-sock", "list-panes", "-t", "agentdeck_x"}, true},
+		{"has-session", []string{"tmux", "has-session", "-t", "agentdeck_x"}, true},
+		{"kill-session mutation", []string{"tmux", "kill-session", "-t", "agentdeck_x"}, true},
+
+		// Interactive and control-mode attaches: never this sweep's business.
+		{"interactive attach", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
+		{"control-mode attach", []string{"tmux", "-C", "attach-session", "-t", "agentdeck_npm_a0e435da"}, false},
+
+		// A server being born carries the creating client's argv.
+		{"new-session", []string{"tmux", "-L", "ad-sock", "new-session", "-d", "-s", "agentdeck_x", "-c", "/home/u"}, false},
+
+		// A chained command that both attaches and sets an option must lose:
+		// the deny side is fail-safe, the allow side is an optimisation.
+		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+
+		// Verbs outside the cadence set are not reapable even though they are
+		// legitimate tmux commands against an agent-deck session.
+		{"pipe-pane", []string{"tmux", "pipe-pane", "-t", "agentdeck_x", "cat > /tmp/log"}, false},
+		{"send-keys", []string{"tmux", "send-keys", "-t", "agentdeck_x", "hello", "Enter"}, false},
+		{"no verb at all", []string{"tmux"}, false},
+		{"empty", []string{}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isReapableOneShotArgv(nulArgv(tc.argv...))
+			if got != tc.want {
+				t.Errorf("isReapableOneShotArgv(%q) = %v, want %v", tc.argv, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/orphan_reap_comm_test.go
+++ b/internal/tmux/orphan_reap_comm_test.go
@@ -1,0 +1,63 @@
+package tmux
+
+import "testing"
+
+// TestIsReapableTmuxClientComm pins the /proc/<pid>/comm values that the
+// orphaned-poll-client sweep must recognise as a tmux CLIENT.
+//
+// The 2026-08-01 incident: two orphaned clients — `tmux list-clients` and
+// `tmux set-option -t agentdeck_npm_a0e435da …` — spun at ~98% CPU for 14
+// hours (13h47m and 13h43m of CPU time, 1023/1022 open fds, nearly all
+// anon_inode:[eventpoll]) while a healthy agent-deck TUI ran alongside them
+// for 12.5 of those hours and never reaped either one.
+//
+// reapOrphanedPollClients filtered on `comm == "tmux"`, documented as "the
+// server is 'tmux: server' and never matches". Half of that is right: the
+// server does rename itself. What the filter missed is that tmux renames the
+// CLIENT too — comm is "tmux: client", not "tmux". Measured on tmux 3.0a /
+// Linux 5.4, where `pgrep -x tmux` matches zero processes on a host running
+// twenty of them:
+//
+//	comm=[tmux: client]  argv=[tmux -C attach-session -t agentdeck_mvn_672de607]
+//	comm=[tmux: server]  argv=[/usr/bin/tmux -L ad1031-2044680 new-session -d …]
+//
+// So the equality test never held for any process, the sweep was inert on
+// every Linux host, and the orphans it exists to mop up survived indefinitely.
+//
+// Rejecting "tmux: server" is the load-bearing safety property here, not a
+// nicety: the sweep SIGKILLs what it matches, and killing a server would
+// destroy every session it hosts — the user's work, not a leaked query client.
+func TestIsReapableTmuxClientComm(t *testing.T) {
+	tests := []struct {
+		name string
+		comm string
+		want bool
+	}{
+		// The value actually observed for one-shot query/option clients on
+		// Linux. This is the case the original filter missed.
+		{"renamed client", "tmux: client", true},
+		// Trailing newline: /proc/<pid>/comm always ends in one.
+		{"renamed client with newline", "tmux: client\n", true},
+		// Kept for platforms/versions that do not rename the client.
+		{"bare tmux", "tmux", true},
+		{"bare tmux with newline", "tmux\n", true},
+
+		// Never reapable — killing a server destroys live user sessions.
+		{"server", "tmux: server", false},
+		{"server with newline", "tmux: server\n", false},
+
+		// Unrelated binaries whose names merely start with "tmux".
+		{"tmuxinator", "tmuxinator", false},
+		{"tmuxp", "tmuxp", false},
+		{"empty", "", false},
+		{"unrelated", "bash", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReapableTmuxClientComm(tc.comm); got != tc.want {
+				t.Errorf("isReapableTmuxClientComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/orphan_reap_comm_test.go
+++ b/internal/tmux/orphan_reap_comm_test.go
@@ -51,12 +51,77 @@ func TestIsReapableTmuxClientComm(t *testing.T) {
 		{"tmuxp", "tmuxp", false},
 		{"empty", "", false},
 		{"unrelated", "bash", false},
+
+		// A tmux invoked under a longer argv[0] still names its role as long
+		// as "<progname>: <role>" survives the 15-char comm limit. The role
+		// token is what authorises the kill, not the program name, so these
+		// are reapable — see tmuxCommRole.
+		{"five-char progname keeps role", "tmuxx: client", true},
+		{"five-char progname server", "tmuxx: server", false},
+
+		// Measured, not assumed: invoking /usr/bin/tmux through a symlink
+		// named "tmux-3.5a" yields exactly this comm — the role token is gone
+		// entirely, not truncated to a prefix. tmux formats "<progname>:
+		// <role> (<socket>)", the kernel caps comm at 15 chars, and tmux then
+		// cuts the result back to its last space, which for a 9-char progname
+		// lands immediately after the colon.
+		//
+		// A SERVER under the same binary produces the identical string, so
+		// nothing here can tell the two apart. Refusing to match is the only
+		// safe answer: a false positive SIGKILLs a server and takes every
+		// session it hosts with it. agent-deck never spawns tmux this way
+		// (every call site is exec.Command("tmux", …), so argv[0] is the
+		// literal "tmux"), so no orphan of its own can land in this state.
+		{"renamed binary loses role", "tmux-3.5a:", false},
+		{"renamed binary loses role, newline", "tmux-3.5a:\n", false},
+		{"colon with no role", "tmux:", false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isReapableTmuxClientComm(tc.comm); got != tc.want {
 				t.Errorf("isReapableTmuxClientComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsTruncatedTmuxComm pins which comm values the sweep must REPORT rather
+// than silently pass over.
+//
+// The original defect was not that the sweep killed the wrong thing — it was
+// that it killed nothing at all and said nothing about it, so two orphans burned
+// a core each for 14 hours with a healthy TUI running beside them. A comm whose
+// role token was lost to truncation puts the sweep back in exactly that state
+// for the affected process: it cannot be classified, so it cannot be reaped.
+// That is the right call, but it must be visible, not silent.
+func TestIsTruncatedTmuxComm(t *testing.T) {
+	tests := []struct {
+		name string
+		comm string
+		want bool
+	}{
+		// Role lost to truncation — unclassifiable, so worth reporting.
+		{"renamed binary", "tmux-3.5a:", true},
+		{"renamed binary with newline", "tmux-3.5a:\n", true},
+		{"bare colon", "tmux:", true},
+
+		// Classifiable: handled normally, nothing to report.
+		{"client", "tmux: client", false},
+		{"server", "tmux: server", false},
+		{"bare tmux", "tmux", false},
+		{"long progname keeping role", "tmuxx: client", false},
+
+		// Not tmux at all — the sweep skips these silently and always did.
+		{"bash", "bash", false},
+		{"empty", "", false},
+		{"unrelated with colon", "systemd:", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTruncatedTmuxComm(tc.comm); got != tc.want {
+				t.Errorf("isTruncatedTmuxComm(%q) = %v, want %v", tc.comm, got, tc.want)
 			}
 		})
 	}

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -1,0 +1,350 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// --- candidateSocketName: pure parsing, no tmux server needed -------------
+
+func TestCandidateSocketName(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmdlineFields []string
+		wantName      string
+		wantOK        bool
+	}{
+		{"no socket flag at all, default server", []string{"tmux", "list-clients", "-t", "agentdeck_x"}, "", true},
+		{"-L name", []string{"tmux", "-L", "ad1031-xxx", "list-clients", "-t", "agentdeck_x"}, "ad1031-xxx", true},
+		{"-C before -L", []string{"tmux", "-C", "-L", "ad1031-xxx", "attach-session", "-t", "agentdeck_x"}, "ad1031-xxx", true},
+		{"-S path is unresolvable via the -L-only factory", []string{"tmux", "-S", "/tmp/some/sock", "list-clients"}, "", false},
+		{"-S wins over -L per tmux's own precedence, still unresolvable", []string{"tmux", "-S", "/tmp/some/sock", "-L", "name", "list-clients"}, "", false},
+		{"empty argv", []string{}, "", true},
+		{"argv0 only", []string{"tmux"}, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, ok := candidateSocketName(tc.cmdlineFields)
+			if name != tc.wantName || ok != tc.wantOK {
+				t.Errorf("candidateSocketName(%q) = (%q, %v), want (%q, %v)",
+					tc.cmdlineFields, name, ok, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+// --- isLiveTmuxClientOrServer: real tmux server, real processes -----------
+//
+// These tests spawn an actual tmux server on an isolated socket (per-test -L
+// name, under the package TestMain's IsolateTmuxSocket-scoped TMUX_TMPDIR) and
+// exercise isLiveTmuxClientOrServer against real pids, not synthetic argv
+// strings — the whole point of this function is that it does not trust argv
+// text, so a test that only feeds it strings would not prove anything.
+
+// orphanLiveTestSocket returns a deterministic -L socket name for this test
+// and registers teardown that kills the server on the SAME socket — an env
+// mismatch between spawn and cleanup makes kill-server a silent no-op and
+// leaks a server plus its ptys (the 2026-07-18 incident class).
+func orphanLiveTestSocket(t *testing.T) string {
+	t.Helper()
+	socket := "ad-orphlive-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+	kill := func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() }
+	kill() // clear anything a previously aborted run stranded
+	t.Cleanup(kill)
+	return socket
+}
+
+// startOrphanLiveSession creates a long-lived session on socket and disables
+// exit-empty so the server outlives the session's own command for the
+// duration of the test (default tmux exits the server once its last session
+// closes, which would race every assertion below).
+func startOrphanLiveSession(t *testing.T, socket, session string) {
+	t.Helper()
+	if out, err := exec.Command("tmux", "-L", socket, "new-session", "-d", "-s", session, "sleep 6000").CombinedOutput(); err != nil {
+		t.Fatalf("new-session: %v: %s", err, out)
+	}
+	if out, err := exec.Command("tmux", "-L", socket, "set-option", "-g", "exit-empty", "off").CombinedOutput(); err != nil {
+		t.Fatalf("set-option exit-empty off: %v: %s", err, out)
+	}
+}
+
+// shQuote single-quotes s for safe embedding in a `sh -c` string, escaping any
+// literal single quotes. Used so a verb argument that is itself a shell
+// metacharacter to sh (the literal ";" tmux uses for command chaining) is
+// passed through as one opaque argv element rather than parsed by sh.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// reparentedControlClient spawns `tmux -S <socket> -C <verbArgs...>` — control
+// mode, so no real tty is required — via an intermediate `sh -c "... & echo
+// $!; exit 0"` wrapper that backgrounds the tmux invocation and exits
+// immediately. When sh exits, the kernel reparents the still-running tmux
+// client to init/launchd, exactly the shape a crashed or detached shell
+// leaves behind in production (and exactly what isControlClientOrphan's PPID
+// check is watching for).
+//
+// This matters for what the test proves: a pid that is merely a DIRECT child
+// of the test binary would itself satisfy looksLikeAgentDeckBinary (the test
+// binary's own exe path) and get preserved by isControlClientOrphan for the
+// wrong reason — parentage, not liveness — which would make the test pass
+// even with isLiveTmuxClientOrServer stubbed out entirely. Forcing a genuine
+// parentage orphan here means the ONLY thing standing between this pid and
+// SIGKILL, in the real reapOrphanedPollClients pipeline, is
+// isLiveTmuxClientOrServer.
+//
+// Returns the reparented client's pid and a cleanup that force-kills it
+// directly (bypassing tmux, since the whole point of the test is not to rely
+// on tmux protocol niceties for teardown either).
+func reparentedControlClient(t *testing.T, socket, session string, verbArgs ...string) int {
+	t.Helper()
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "stdin.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	// O_RDWR on a FIFO never blocks (unlike O_RDONLY/O_WRONLY, which each wait
+	// for a peer to open the other end). Holding this fd open for the test's
+	// duration keeps the client's stdin from seeing EOF without needing a
+	// separate background writer process.
+	keepOpen, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open fifo O_RDWR: %v", err)
+	}
+	t.Cleanup(func() { _ = keepOpen.Close() })
+
+	pidPath := filepath.Join(dir, "pid")
+	logPath := filepath.Join(dir, "out.log")
+
+	argv := append([]string{"tmux", "-S", socket, "-C"}, verbArgs...)
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shQuote(a)
+	}
+	script := strings.Join(quoted, " ") +
+		" < " + shQuote(fifoPath) + " > " + shQuote(logPath) + " 2>&1 & echo $! > " + shQuote(pidPath) + "; exit 0"
+
+	if out, err := exec.Command("sh", "-c", script).CombinedOutput(); err != nil {
+		t.Fatalf("sh wrapper: %v: %s", err, out)
+	}
+
+	var pidBytes []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err = os.ReadFile(pidPath)
+		if err == nil && strings.TrimSpace(string(pidBytes)) != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		logContents, _ := os.ReadFile(logPath)
+		t.Fatalf("read pid file: %v (log: %s)", err, logContents)
+	}
+
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	// Confirm the reparent actually happened before handing the pid back —
+	// otherwise a slow kernel scheduler could let a test proceed against a
+	// pid that is still parented to the wrapper's own shell, silently
+	// weakening the guarantee the test exists to establish.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ppid, err := readParentPID(pid)
+		if err == nil && ppid <= 1 {
+			return pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("pid %d never reparented to init within the deadline — cannot prove this is a genuine orphan", pid)
+	return 0
+}
+
+// TestIsLiveTmuxClientOrServer_ChainedAliasRepro is the direct regression test
+// for the #1832-supersede vulnerability: reapOrphanedPollClients' previous
+// safety gate (neverReapVerbs, matching only the literal strings
+// "attach-session" / "new-session") missed tmux's built-in alias "attach" and
+// every unambiguous abbreviation of it, so
+//
+//	tmux attach -t agentdeck_x \; set-option status on
+//
+// walked straight through: "attach" cleared the denylist (wrong spelling) and
+// "set-option" satisfied the cadence allowlist, so the whole chained command
+// was ruled reapable — while the attach half means a real interactive/control
+// client sits behind it. isLiveTmuxClientOrServer replaces that argv-text
+// check with a live query to the tmux server itself, which cannot be
+// abbreviated around: registration happens on connect, not by re-parsing argv.
+//
+// The client here is spawned via a genuine parentage orphan (see
+// reparentedControlClient) so this test cannot pass merely because
+// isControlClientOrphan happens to protect a same-parent test process — only
+// isLiveTmuxClientOrServer stands between this pid and a kill verdict.
+func TestIsLiveTmuxClientOrServer_ChainedAliasRepro(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_repro"
+	startOrphanLiveSession(t, socket, session)
+
+	pid := reparentedControlClient(t, socket, session,
+		"attach", "-t", session, ";", "set-option", "status", "on")
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{
+		"tmux", "-S", socket, "-C", "attach", "-t", session, ";", "set-option", "status", "on",
+	})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d — the query itself must succeed against a live server", pid)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false — VULNERABLE: a live client attached via the "+
+			"chained alias verb 'attach ; set-option' was not recognised as live and would be reaped", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_AbbreviatedAttach pins the same guarantee for
+// an even shorter abbreviation than the alias: tmux resolves command names by
+// unambiguous prefix, and "attach-session" is the only tmux command starting
+// with "a", so bare "a" alone resolves to it (verified live on tmux 3.7b —
+// `tmux -C a -t sess` attaches). No finite denylist of spelled-out verbs can
+// anticipate every such prefix across tmux versions; the server-identity
+// query does not need to.
+func TestIsLiveTmuxClientOrServer_AbbreviatedAttach(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_abbrev"
+	startOrphanLiveSession(t, socket, session)
+
+	pid := reparentedControlClient(t, socket, session, "a", "-t", session)
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-S", socket, "-C", "a", "-t", session})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false — a live client attached via the single-letter "+
+			"abbreviation 'a' was not recognised as live and would be reaped", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_FullVerbAttach is the control case: the
+// long-form "attach-session" verb the original (superseded) denylist did
+// catch, kept so a future edit cannot silently regress the common case while
+// fixing the alias/abbreviation gap.
+func TestIsLiveTmuxClientOrServer_FullVerbAttach(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_fullverb"
+	startOrphanLiveSession(t, socket, session)
+
+	pid := reparentedControlClient(t, socket, session, "attach-session", "-t", session)
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-S", socket, "-C", "attach-session", "-t", session})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false for a full-verb attach-session client", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_ServerItself pins the other half of the
+// guarantee: the server's own pid must never be classified as reapable, which
+// protects the nascent-server race (a server mid-startup still carries its
+// creating client's comm and argv — see reapOrphanedPollClients' doc comment)
+// by asking the server for its own identity rather than inferring role from
+// argv at all.
+func TestIsLiveTmuxClientOrServer_ServerItself(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_serverpid"
+	startOrphanLiveSession(t, socket, session)
+
+	out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{pid}").Output()
+	if err != nil {
+		t.Fatalf("display-message #{pid}: %v", err)
+	}
+	serverPID, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse server pid: %v", err)
+	}
+
+	live, ok := isLiveTmuxClientOrServer(serverPID, []string{"tmux", "-L", socket, "new-session", "-d", "-s", session})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify the server pid %d", serverPID)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false for the SERVER's own pid — "+
+			"this is the nascent-server kill class the sweep must never reach", serverPID)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_OneShotClient_NotLive confirms the sweep's
+// actual target class — a genuinely leaked one-shot query client — still
+// classifies as reapable (live=false, ok=true). Without this, an
+// overcautious implementation could satisfy every "never reap a live attach"
+// test by simply always returning live=true, which would silently restore
+// the original 2026-08-01 bug (the sweep reaps nothing).
+//
+// The client is frozen with SIGSTOP immediately after starting, mid-flight,
+// to stand in for the tmux-3.0a fd leak this sweep exists to mop up: verified
+// live that a SIGSTOPped one-shot list-clients client does not appear in the
+// server's own list-clients output even while its process is still alive —
+// one-shot cadence commands never register as persistent clients the way an
+// attach does, whether or not they are hung.
+func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_oneshot"
+	startOrphanLiveSession(t, socket, session)
+
+	cmd := exec.Command("tmux", "-S", socket, "list-clients", "-F", "#{client_pid}")
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	cmd.Stdin = devnull
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start one-shot client: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGCONT)
+		_, _ = cmd.Process.Wait()
+	})
+	if err := cmd.Process.Signal(syscall.SIGSTOP); err != nil {
+		t.Fatalf("SIGSTOP one-shot client: %v", err)
+	}
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-S", socket, "list-clients", "-F", "#{client_pid}"})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify the frozen one-shot client %d", pid)
+	}
+	if live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=true for a one-shot query client — "+
+			"this would make the sweep unable to reap the exact orphan class it exists for", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_NoServerAtSocket pins the fail-closed rule: no
+// server reachable at the resolved socket must return ok=false (unclassifiable,
+// refuse to kill), never live=false (safe to kill). A candidate whose target
+// server already exited is exactly the ambiguous case
+// isKnownCadenceArgv/isLiveTmuxClientOrServer's doc comments require refusing
+// rather than guessing about.
+func TestIsLiveTmuxClientOrServer_NoServerAtSocket(t *testing.T) {
+	socket := "ad-orphlive-no-such-server-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+
+	live, ok := isLiveTmuxClientOrServer(999999, []string{"tmux", "-L", socket, "list-clients"})
+	if ok {
+		t.Fatalf("isLiveTmuxClientOrServer against a nonexistent server returned ok=true (live=%v) — "+
+			"want ok=false (unclassifiable)", live)
+	}
+}

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -125,7 +125,14 @@ func reparentedControlClient(t *testing.T, socket, session string, verbArgs ...s
 	pidPath := filepath.Join(dir, "pid")
 	logPath := filepath.Join(dir, "out.log")
 
-	argv := append([]string{"tmux", "-S", socket, "-C"}, verbArgs...)
+	// -L, not -S: candidateSocketName only resolves -L (or no socket flag at
+	// all) because that is the only shape agent-deck's own tmuxExecContext
+	// factory ever produces (see candidateSocketName's doc comment) — a -S
+	// candidate is deliberately refused as unresolvable. Using -S here would
+	// also point this client at a different, nonexistent socket path than the
+	// one startOrphanLiveSession created with -L, so it would never actually
+	// reach the real server at all.
+	argv := append([]string{"tmux", "-L", socket, "-C"}, verbArgs...)
 	quoted := make([]string, len(argv))
 	for i, a := range argv {
 		quoted[i] = shQuote(a)
@@ -198,7 +205,7 @@ func TestIsLiveTmuxClientOrServer_ChainedAliasRepro(t *testing.T) {
 		"attach", "-t", session, ";", "set-option", "status", "on")
 
 	live, ok := isLiveTmuxClientOrServer(pid, []string{
-		"tmux", "-S", socket, "-C", "attach", "-t", session, ";", "set-option", "status", "on",
+		"tmux", "-L", socket, "-C", "attach", "-t", session, ";", "set-option", "status", "on",
 	})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d — the query itself must succeed against a live server", pid)
@@ -223,7 +230,7 @@ func TestIsLiveTmuxClientOrServer_AbbreviatedAttach(t *testing.T) {
 
 	pid := reparentedControlClient(t, socket, session, "a", "-t", session)
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-S", socket, "-C", "a", "-t", session})
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "-C", "a", "-t", session})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
 	}
@@ -244,7 +251,7 @@ func TestIsLiveTmuxClientOrServer_FullVerbAttach(t *testing.T) {
 
 	pid := reparentedControlClient(t, socket, session, "attach-session", "-t", session)
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-S", socket, "-C", "attach-session", "-t", session})
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "-C", "attach-session", "-t", session})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
 	}
@@ -301,7 +308,7 @@ func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
 	const session = "agentdeck_1832_oneshot"
 	startOrphanLiveSession(t, socket, session)
 
-	cmd := exec.Command("tmux", "-S", socket, "list-clients", "-F", "#{client_pid}")
+	cmd := exec.Command("tmux", "-L", socket, "list-clients", "-F", "#{client_pid}")
 	devnull, err := os.Open(os.DevNull)
 	if err != nil {
 		t.Fatalf("open devnull: %v", err)
@@ -320,7 +327,7 @@ func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
 		t.Fatalf("SIGSTOP one-shot client: %v", err)
 	}
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-S", socket, "list-clients", "-F", "#{client_pid}"})
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "list-clients", "-F", "#{client_pid}"})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify the frozen one-shot client %d", pid)
 	}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -800,43 +800,132 @@ var reapableOneShotVerbs = map[string]struct{}{
 	"unbind-key":       {},
 }
 
-// neverReapVerbs are the subcommands that disqualify a process outright, even
-// if the same argv also carries a reapable verb (tmux accepts `;`-chained
-// commands, so both can appear). Each names a process whose death costs the
-// user something this sweep has no standing to spend:
+// isKnownCadenceArgv reports whether a /proc/<pid>/cmdline names at least one
+// of the one-shot cadence verbs this sweep exists to reap (reapableOneShotVerbs).
+// cmdline fields are NUL-separated and NUL-terminated, so each argv element is
+// compared whole — a session name or path that merely contains a verb as a
+// substring cannot match.
 //
-//   - attach-session — an interactive client is the user's live view of a
-//     session, and a control-mode one belongs to a TUI. Orphaned control
-//     clients are reapStaleControlClients' job; it filters on
-//     client_control_mode and so cannot mistake a hand-run `tmux attach` for
-//     a leak. This sweep, matching only on comm + argv + parentage, can:
-//     isControlClientOrphan calls ANY non-agent-deck parent an orphan, so a
-//     client attached from the user's own shell qualifies while that shell is
-//     still alive.
-//   - new-session — a server inherits the creating client's comm ("tmux:
-//     client", set by proc_start before the fork) and argv until its own
-//     proc_start("server") runs after daemon(). A server killed in that window
-//     takes the session it was starting with it.
-var neverReapVerbs = map[string]struct{}{
-	"attach-session": {},
-	"new-session":    {},
-}
-
-// isReapableOneShotArgv reports whether a /proc/<pid>/cmdline names a one-shot
-// cadence command and nothing more dangerous. cmdline fields are NUL-separated
-// and NUL-terminated, so each argv element is compared whole — a session name
-// or path that merely contains a verb as a substring cannot match.
-func isReapableOneShotArgv(cmdline string) bool {
-	reapable := false
+// This is a SCOPE ALLOWLIST, not a safety boundary. A miss here only ever
+// narrows the sweep (skip, don't reap) — it must never be read as "argv proves
+// this is safe to kill". See isLiveTmuxClientOrServer for why: this function
+// used to be paired with a denylist (neverReapVerbs, matching only the literal
+// strings "attach-session" / "new-session") that WAS treated as a safety
+// boundary, and it was wrong to. tmux resolves command names by unambiguous
+// prefix — "attach-session" itself is the only tmux command starting with "a",
+// so "attach", "attac", "att", "at", even bare "a" all invoke it unmodified
+// (verified live: `tmux -C a -t sess` attaches on tmux 3.7b/darwin). A denylist
+// of literal verb strings cannot keep up with that; a chained
+// `tmux attach -t agentdeck_x \; set-option status on` cleared the old denylist
+// (wrong spelling) while "set-option" satisfied this allowlist, so the whole
+// line was ruled reapable with a live interactive client sitting behind it.
+// isLiveTmuxClientOrServer is the replacement: it asks the tmux server itself
+// whether the pid is attached, which cannot be abbreviated around.
+func isKnownCadenceArgv(cmdline string) bool {
 	for _, field := range strings.Split(strings.TrimRight(cmdline, "\x00"), "\x00") {
-		if _, denied := neverReapVerbs[field]; denied {
-			return false
-		}
 		if _, ok := reapableOneShotVerbs[field]; ok {
-			reapable = true
+			return true
 		}
 	}
-	return reapable
+	return false
+}
+
+// tmuxLiveQueryTimeout bounds each server-identity query
+// isLiveTmuxClientOrServer issues while classifying an orphan-sweep
+// candidate. Short and per-call, not shared: a wedged server on one socket
+// must not delay the verdict for candidates on any other socket, and the
+// sweep already treats a timeout as "cannot classify, refuse to kill" so
+// there is no correctness reason to wait longer.
+var tmuxLiveQueryTimeout = 2 * time.Second
+
+// candidateSocketName extracts the -L <name> (or default) socket selector
+// from a poll-sweep candidate's OWN argv — cmdlineFields[0] is the program
+// name (e.g. "tmux"); a leading `-L <name>` may follow it, mirroring exactly
+// what tmuxArgs would have inserted to produce this argv in the first place.
+//
+// A leading `-S <path>` returns ok=false. agent-deck itself never spawns tmux
+// that way (tmuxArgs only ever emits -L; grep the package), so a candidate
+// carrying -S was not spawned by agent-deck's own factory — meaning the
+// isLiveTmuxClientOrServer caller cannot safely resolve it through the
+// package's -L-only tmuxExecContext funnel, and per the "refuse anything
+// ambiguous" rule, unresolvable is not reapable rather than a case worth
+// widening the tmux-exec factory for.
+func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
+	if len(cmdlineFields) == 0 {
+		return "", true
+	}
+	rest := cmdlineFields[1:]
+	if socketPathFlag(rest) != "" {
+		return "", false
+	}
+	return socketNameFlag(rest), true
+}
+
+// isLiveTmuxClientOrServer authoritatively asks the tmux server that the
+// candidate's OWN argv targets whether pid IS that server, or is one of its
+// currently-connected clients — the two process classes reapOrphanedPollClients
+// must never kill. It replaces argv-verb pattern matching (isKnownCadenceArgv's
+// former denylist partner, neverReapVerbs) with the server's own live
+// bookkeeping, which cannot be abbreviated or aliased around: see
+// isKnownCadenceArgv's doc comment for the concrete bypass that motivated this.
+//
+// Two independent facts are checked against the server's own state:
+//
+//  1. pid == the server's own pid (queried as `#{pid}`). A server mid-startup
+//     still carries its creating client's comm and argv — tmux renames the
+//     client to "tmux: client" before forking, and the child keeps that comm
+//     and argv until its own post-daemon() rename — so comm+argv alone cannot
+//     rule out "this pid IS the server, not a client of it". Asking the server
+//     for its own pid can.
+//  2. pid appears in the server's `list-clients` output. A registered client is
+//     attached right now — interactively or in control mode — no matter what
+//     verb, alias, or abbreviation its argv spells the attach with, because
+//     registration happens on connect, not by re-parsing argv. A one-shot
+//     cadence command (list-clients, set-option, …) never registers as a
+//     persistent client even while its process is alive and spinning —
+//     verified live by SIGSTOPping one mid-flight and observing list-clients
+//     on the same server come back empty — so absence here rules out an
+//     attach specifically, not just "any client-shaped process".
+//
+// ok=false means neither fact could be established (no server at the resolved
+// socket, a -S-path candidate the package's -L-only exec funnel cannot resolve,
+// connection refused, or the query ran past tmuxLiveQueryTimeout). The caller
+// MUST treat ok=false as unclassifiable and refuse to kill — the same
+// fail-closed rule isTruncatedTmuxComm already established for an unreadable
+// comm value.
+func isLiveTmuxClientOrServer(pid int, cmdlineFields []string) (live bool, ok bool) {
+	socketName, resolvable := candidateSocketName(cmdlineFields)
+	if !resolvable {
+		return false, false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxLiveQueryTimeout)
+	defer cancel()
+	serverPIDOut, err := tmuxExecContext(ctx, socketName, "display-message", "-p", "#{pid}").Output()
+	if err != nil {
+		return false, false
+	}
+	serverPID, err := strconv.Atoi(strings.TrimSpace(string(serverPIDOut)))
+	if err != nil {
+		return false, false
+	}
+	if serverPID == pid {
+		return true, true // pid IS the server
+	}
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxLiveQueryTimeout)
+	defer cancel2()
+	clientsOut, err := tmuxExecContext(ctx2, socketName, "list-clients", "-F", "#{client_pid}").Output()
+	if err != nil {
+		return false, false
+	}
+	target := strconv.Itoa(pid)
+	for _, line := range strings.Split(strings.TrimSpace(string(clientsOut)), "\n") {
+		if strings.TrimSpace(line) == target {
+			return true, true // pid is a currently-registered client
+		}
+	}
+	return false, true
 }
 
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
@@ -857,13 +946,25 @@ func isReapableOneShotArgv(cmdline string) bool {
 //     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
 //     user's unrelated tmux is never touched,
-//   - its argv names a one-shot cadence verb and no attach/new-session verb
-//     (isReapableOneShotArgv), so neither a live interactive client nor a
-//     server still inside its startup rename window can be hit, and
+//   - its argv names a one-shot cadence verb (isKnownCadenceArgv) — a scope
+//     narrowing, not the safety check; see its doc comment for why an argv
+//     denylist cannot be the safety check,
+//   - the tmux server itself confirms, right now, that this pid is neither
+//     itself nor one of its connected clients (isLiveTmuxClientOrServer) —
+//     this is the actual guarantee that a live interactive/control attach or
+//     a server still inside its startup rename window is never hit, and it
+//     cannot be defeated by an abbreviated or aliased attach verb because it
+//     never inspects argv verbs at all, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
 //     (isControlClientOrphan — its parentage check is client-type-agnostic
 //     despite the name). A live TUI's own in-flight poll has PPID == our PID,
 //     so isControlClientOrphan returns false and it is preserved.
+//
+// Any of the two checks that query external state (comm-role classification,
+// tmux-server identity) failing to produce a definite answer is treated as
+// "cannot classify, refuse to kill" — never "assume safe". That fail-closed
+// rule is why isTruncatedTmuxComm and isLiveTmuxClientOrServer both return an
+// explicit ok/unclassifiable signal instead of collapsing into a bool.
 //
 // Linux-only: relies on procfs. On darwin/BSD it is a no-op (a `ps`-based
 // enumeration would be the port); the tmuxPollTimeout guard still applies
@@ -904,10 +1005,29 @@ func reapOrphanedPollClients() {
 		if err != nil || !strings.Contains(string(raw), SessionPrefix) {
 			continue
 		}
-		// Narrow comm+prefix down to the cadence commands this sweep exists
-		// for: an interactive attach and a server mid-startup both clear the
-		// checks above, and killing either costs the user real work.
-		if !isReapableOneShotArgv(string(raw)) {
+		// Scope narrowing only — see isKnownCadenceArgv's doc comment for why
+		// this must never be read as the safety check.
+		if !isKnownCadenceArgv(string(raw)) {
+			continue
+		}
+		// THE safety check: ask the tmux server itself, not argv text, whether
+		// this pid is live. live==true or ok==false both mean "do not kill".
+		cmdlineFields := strings.Split(strings.TrimRight(string(raw), "\x00"), "\x00")
+		live, ok := isLiveTmuxClientOrServer(pid, cmdlineFields)
+		if !ok {
+			skipped++
+			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.String("reason", "could not confirm via the tmux server itself whether this "+
+					"pid is live (no server at the resolved socket, an unresolvable -S candidate, "+
+					"or the query timed out); refusing to kill rather than guess"))
+			continue
+		}
+		if live {
+			pipeLog.Debug("preserved_live_tmux_client_or_server",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))))
 			continue
 		}
 		if !isControlClientOrphan(pid) {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -700,20 +700,80 @@ var orphanReapOnce sync.Once
 // the sweep inert — orphaned query clients spun at 100% CPU for as long as the
 // host stayed up.
 //
-// The bare "tmux" case is kept because the rename is a tmux implementation
-// detail, not a guarantee: a client that has not yet renamed itself, or a
-// version that never does, must still be reapable.
+// The bare "tmux" case is kept for the window between exec and the client's own
+// proc_start: a process that has not renamed itself yet is a client that has not
+// connected yet, never a server (the server is forked from an already-renamed
+// client, so it never presents a bare name).
 //
-// "tmux: server" MUST NOT match. The sweep SIGKILLs whatever it matches, and a
-// server holds every session it hosts, so a false positive there destroys the
-// user's running work rather than a leaked one-shot query.
+// It is the ROLE token that authorises the kill, not the program name — see
+// tmuxCommRole for why a longer argv[0] is still safe to reap when its role
+// survives, and isTruncatedTmuxComm for what happens when it does not.
+//
+// A server MUST NOT match. The sweep SIGKILLs whatever it matches, and a server
+// holds every session it hosts, so a false positive there destroys the user's
+// running work rather than a leaked one-shot query.
 func isReapableTmuxClientComm(comm string) bool {
-	switch strings.TrimSpace(comm) {
-	case "tmux", "tmux: client":
+	trimmed := strings.TrimSpace(comm)
+	if trimmed == "tmux" {
 		return true
-	default:
+	}
+	role, ok := tmuxCommRole(trimmed)
+	return ok && role == "client"
+}
+
+// tmuxCommRole splits tmux's setproctitle-style comm into its role token.
+// tmux formats "<progname>: <role> (<socket path>)", so the role is whatever
+// follows the first ": ".
+//
+// Keying on the role rather than on the literal "tmux: client" keeps the sweep
+// working for an installation whose binary is invoked under a longer name: a
+// 5-char progname still yields "tmuxx: client", which names its role
+// unambiguously and is as safe to reap as the canonical form.
+//
+// The role either survives whole or vanishes whole — it is never truncated to a
+// prefix. The kernel caps comm at 15 bytes and tmux then cuts the result back to
+// its last space, which is the one separating the role from the socket path. So
+// a partial "clie"/"serve" cannot reach this function, and matching role ==
+// "client" can never be satisfied by a server.
+func tmuxCommRole(comm string) (string, bool) {
+	idx := strings.Index(comm, ": ")
+	if idx <= 0 {
+		return "", false
+	}
+	role := comm[idx+2:]
+	if role == "" {
+		return "", false
+	}
+	return role, true
+}
+
+// isTruncatedTmuxComm reports whether comm looks like tmux's setproctitle output
+// whose role token was lost entirely to the 15-byte comm limit.
+//
+// Measured, not inferred: invoking /usr/bin/tmux through a symlink named
+// "tmux-3.5a" produces the comm "tmux-3.5a:" — cut back to the space right after
+// the colon, taking "client"/"server" with it. A server under that binary
+// produces the identical string, so such a process cannot be classified at all
+// and must not be killed.
+//
+// agent-deck cannot produce one of these itself: every spawn is
+// exec.Command("tmux", …), so argv[0] is the literal "tmux" whatever the binary
+// is called on disk. The case therefore belongs to a user's own tmux, which the
+// sweep has no business killing regardless.
+//
+// It is still worth reporting. The bug this whole sweep exists to prevent was
+// invisible — an inert filter that killed nothing and logged nothing while two
+// orphans burned a core each for 14 hours. Anything that silently narrows the
+// sweep back toward inert should say so.
+func isTruncatedTmuxComm(comm string) bool {
+	trimmed := strings.TrimSpace(comm)
+	if trimmed == "tmux" {
 		return false
 	}
+	if _, ok := tmuxCommRole(trimmed); ok {
+		return false
+	}
+	return strings.Contains(trimmed, "tmux") && strings.HasSuffix(trimmed, ":")
 }
 
 // reapableOneShotVerbs are the tmux subcommands reapOrphanedPollClients may
@@ -818,6 +878,7 @@ func reapOrphanedPollClients() {
 	}
 	myPID := os.Getpid()
 	killed := 0
+	skipped := 0
 	start := time.Now()
 	for _, e := range entries {
 		pid, err := strconv.Atoi(e.Name())
@@ -825,7 +886,16 @@ func reapOrphanedPollClients() {
 			continue
 		}
 		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil || !isReapableTmuxClientComm(string(comm)) {
+		if err != nil {
+			continue
+		}
+		reapable := isReapableTmuxClientComm(string(comm))
+		// A comm whose role token was truncated away cannot be classified as
+		// client or server. It is not killed; it is carried to the end of the
+		// gauntlet so that a process which is otherwise indistinguishable from
+		// a leak gets reported instead of vanishing from the sweep in silence.
+		unclassifiable := !reapable && isTruncatedTmuxComm(string(comm))
+		if !reapable && !unclassifiable {
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the
@@ -843,15 +913,25 @@ func reapOrphanedPollClients() {
 		if !isControlClientOrphan(pid) {
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
 		}
+		if unclassifiable {
+			skipped++
+			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.String("reason", "comm lost its role token to truncation; "+
+					"cannot prove this is a client rather than a server, so it is left alone"))
+			continue
+		}
 		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
 		killed++
 		pipeLog.Debug("reaped_orphaned_poll_client",
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	if killed > 0 {
+	if killed > 0 || skipped > 0 {
 		pipeLog.Info("orphaned_poll_clients_reaped",
 			slog.Int("kill_count", killed),
+			slog.Int("skipped_unclassifiable", skipped),
 			slog.Duration("duration", time.Since(start)))
 	}
 }

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -716,6 +716,69 @@ func isReapableTmuxClientComm(comm string) bool {
 	}
 }
 
+// reapableOneShotVerbs are the tmux subcommands reapOrphanedPollClients may
+// kill: the short-lived cadence queries and option writes agent-deck fires on a
+// timer, every one of which is safe to lose because its caller re-issues it on
+// the next tick. The set mirrors the poll/mutation lists that
+// TestPollCommandsAreBounded enforces deadlines for — same commands, same
+// reason: they run on a cadence, so they are the ones that leak.
+var reapableOneShotVerbs = map[string]struct{}{
+	"bind-key":         {},
+	"capture-pane":     {},
+	"detach-client":    {},
+	"display-message":  {},
+	"has-session":      {},
+	"kill-session":     {},
+	"list-clients":     {},
+	"list-panes":       {},
+	"list-sessions":    {},
+	"refresh-client":   {},
+	"set-option":       {},
+	"show-environment": {},
+	"show-option":      {},
+	"switch-client":    {},
+	"unbind-key":       {},
+}
+
+// neverReapVerbs are the subcommands that disqualify a process outright, even
+// if the same argv also carries a reapable verb (tmux accepts `;`-chained
+// commands, so both can appear). Each names a process whose death costs the
+// user something this sweep has no standing to spend:
+//
+//   - attach-session — an interactive client is the user's live view of a
+//     session, and a control-mode one belongs to a TUI. Orphaned control
+//     clients are reapStaleControlClients' job; it filters on
+//     client_control_mode and so cannot mistake a hand-run `tmux attach` for
+//     a leak. This sweep, matching only on comm + argv + parentage, can:
+//     isControlClientOrphan calls ANY non-agent-deck parent an orphan, so a
+//     client attached from the user's own shell qualifies while that shell is
+//     still alive.
+//   - new-session — a server inherits the creating client's comm ("tmux:
+//     client", set by proc_start before the fork) and argv until its own
+//     proc_start("server") runs after daemon(). A server killed in that window
+//     takes the session it was starting with it.
+var neverReapVerbs = map[string]struct{}{
+	"attach-session": {},
+	"new-session":    {},
+}
+
+// isReapableOneShotArgv reports whether a /proc/<pid>/cmdline names a one-shot
+// cadence command and nothing more dangerous. cmdline fields are NUL-separated
+// and NUL-terminated, so each argv element is compared whole — a session name
+// or path that merely contains a verb as a substring cannot match.
+func isReapableOneShotArgv(cmdline string) bool {
+	reapable := false
+	for _, field := range strings.Split(strings.TrimRight(cmdline, "\x00"), "\x00") {
+		if _, denied := neverReapVerbs[field]; denied {
+			return false
+		}
+		if _, ok := reapableOneShotVerbs[field]; ok {
+			reapable = true
+		}
+	}
+	return reapable
+}
+
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
 // `list-clients` / `display-message` / `list-panes` / status `set-option`
 // invocations agent-deck fires on a cadence — that a previous run spawned and
@@ -733,7 +796,10 @@ func isReapableTmuxClientComm(comm string) bool {
 //   - it is a tmux CLIENT process (isReapableTmuxClientComm; the server
 //     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
-//     user's unrelated tmux is never touched, and
+//     user's unrelated tmux is never touched,
+//   - its argv names a one-shot cadence verb and no attach/new-session verb
+//     (isReapableOneShotArgv), so neither a live interactive client nor a
+//     server still inside its startup rename window can be hit, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
 //     (isControlClientOrphan — its parentage check is client-type-agnostic
 //     despite the name). A live TUI's own in-flight poll has PPID == our PID,
@@ -766,6 +832,12 @@ func reapOrphanedPollClients() {
 		// "agentdeck_" target token regardless of separators.
 		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 		if err != nil || !strings.Contains(string(raw), SessionPrefix) {
+			continue
+		}
+		// Narrow comm+prefix down to the cadence commands this sweep exists
+		// for: an interactive attach and a server mid-startup both clear the
+		// checks above, and killing either costs the user real work.
+		if !isReapableOneShotArgv(string(raw)) {
 			continue
 		}
 		if !isControlClientOrphan(pid) {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -689,6 +689,33 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 // instead of re-scanning all of /proc on every Connect.
 var orphanReapOnce sync.Once
 
+// isReapableTmuxClientComm reports whether a /proc/<pid>/comm value identifies
+// a tmux CLIENT — the only process class reapOrphanedPollClients may kill.
+//
+// tmux renames both of its process roles after startup, so comm is "tmux:
+// client" / "tmux: server" rather than the bare "tmux" of the argv[0] the
+// process was exec'd with. (Verified on tmux 3.0a / Linux 5.4: `pgrep -x tmux`
+// matches nothing on a host running twenty tmux processes.) An earlier
+// equality test against "tmux" therefore matched no process at all and left
+// the sweep inert — orphaned query clients spun at 100% CPU for as long as the
+// host stayed up.
+//
+// The bare "tmux" case is kept because the rename is a tmux implementation
+// detail, not a guarantee: a client that has not yet renamed itself, or a
+// version that never does, must still be reapable.
+//
+// "tmux: server" MUST NOT match. The sweep SIGKILLs whatever it matches, and a
+// server holds every session it hosts, so a false positive there destroys the
+// user's running work rather than a leaked one-shot query.
+func isReapableTmuxClientComm(comm string) bool {
+	switch strings.TrimSpace(comm) {
+	case "tmux", "tmux: client":
+		return true
+	default:
+		return false
+	}
+}
+
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
 // `list-clients` / `display-message` / `list-panes` / status `set-option`
 // invocations agent-deck fires on a cadence — that a previous run spawned and
@@ -703,8 +730,8 @@ var orphanReapOnce sync.Once
 // timeout because the TUI was SIGKILL'd / OOM-killed mid-command.
 //
 // Safety — a process is killed only when ALL hold:
-//   - it is the `tmux` client binary (comm == "tmux"; the server is
-//     "tmux: server" and never matches),
+//   - it is a tmux CLIENT process (isReapableTmuxClientComm; the server
+//     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
 //     user's unrelated tmux is never touched, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
@@ -732,7 +759,7 @@ func reapOrphanedPollClients() {
 			continue
 		}
 		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil || strings.TrimSpace(string(comm)) != "tmux" {
+		if err != nil || !isReapableTmuxClientComm(string(comm)) {
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the


### PR DESCRIPTION
## Credit

This lands the fix from #1832, authored by **@drmzperx**. Their diagnosis of the dead orphan-sweep filter is exact and the write-up (the 14-hour spinner evidence, the `/proc` selection matrix, the truncated-comm proof) is some of the best incident forensics I've seen on this repo — thank you for tracking it down and documenting it so thoroughly. Their three commits are cherry-picked here unchanged, with authorship preserved. #1832 is being closed as superseded by this PR because its safety layer needed one more iteration before it could ship (see below); the actual bug diagnosis is 100% theirs.

## What problem does this solve?

Same root cause as #1832: `reapOrphanedPollClients` never reaped anything on Linux because it filtered on `comm == "tmux"`, and tmux renames both roles after startup (`tmux: client` / `tmux: server`), so the equality test matched no process at all. Two orphaned one-shot query clients spun at ~98% CPU for 14 hours as a result. drmzperx's fix (commits 1–3, unchanged here) corrects the comm match and adds the missing safety net for what starts matching once the filter actually works: an interactive/control-mode attach, and a server mid-startup that still carries its creating client's comm and argv.

## What changed on top of #1832

#1832's safety net for those two classes was an argv denylist (`neverReapVerbs`), refusing to reap a candidate whose argv contained the literal strings `"attach-session"` or `"new-session"`. That denylist is bypassable: tmux resolves command names by unambiguous prefix, and `attach-session` is the only tmux command starting with `a`, so `attach` (a real built-in alias), `attac`, `att`, `at`, even bare `a` all invoke it unmodified. Verified live on tmux 3.7b:

```
$ tmux -C a -t sess    # attaches — resolves to attach-session
$ tmux -C attac -t sess
command attach-session: unknown flag -C   # resolved the verb before failing on flag order
```

So a chained `tmux attach -t agentdeck_x \; set-option status on` clears the denylist (wrong spelling) while `set-option` satisfies the cadence allowlist, and the whole line was ruled reapable with a live interactive/control client sitting behind it — the exact class of bug that destroyed the live fleet on 2026-07-26.

This PR replaces the denylist with `isLiveTmuxClientOrServer`, which asks the tmux server the candidate's own argv targets — not argv text — two things:

1. **Is the candidate the server itself** (`#{pid}`)? Covers the nascent-server startup-rename race independently of any argv inspection.
2. **Is the candidate a currently-registered client** (`list-clients`)? Registration happens on connect, not by re-parsing argv, so it can't be abbreviated or aliased around. Verified live that a one-shot cadence command (`list-clients`, `set-option`, …) never registers as a persistent client even while wedged (SIGSTOPped mid-flight and checked), so this doesn't regress the sweep's actual target class.

Either query failing to produce a definite answer (no server at the resolved socket, a `-S`-path candidate the package's `-L`-only exec funnel can't resolve, connection refused, timeout) is treated as unclassifiable and refused — never assumed safe. Same fail-closed rule #1832 already established for a truncated/unclassifiable `comm` value.

The old allowlist half (`isKnownCadenceArgv`, renamed from `isReapableOneShotArgv`) is kept as pure scope narrowing — a miss only ever skips a candidate, it is not read as a safety signal anymore.

## Tests

- `TestIsLiveTmuxClientOrServer_ChainedAliasRepro` — the exact chained-alias repro (`attach -t sess ; set-option status on`) against a real tmux server, with the client spawned via a genuine parentage orphan (double-forked and reparented to init) so the test can't pass merely because the parentage check happens to protect a same-parent test process for the wrong reason.
- `TestIsLiveTmuxClientOrServer_AbbreviatedAttach` — same, with the single-letter abbreviation `a`.
- `TestIsLiveTmuxClientOrServer_FullVerbAttach` — control case for the long-form verb.
- `TestIsLiveTmuxClientOrServer_ServerItself` — the server's own pid must never classify as reapable.
- `TestIsLiveTmuxClientOrServer_OneShotClient_NotLive` — a frozen (SIGSTOPped) one-shot query client still classifies as reapable, so the sweep doesn't regress back to reaping nothing.
- `TestIsLiveTmuxClientOrServer_NoServerAtSocket` — no server at the socket returns unclassifiable, not "safe to kill".
- `TestCandidateSocketName` — pure parsing of `-L`/`-S`/default socket selection from a candidate's own argv.
- `TestIsKnownCadenceArgv` (renamed) — updated to reflect that this function is scope-only now, not a safety boundary.

## Verification

Sandboxed build and vet pass clean:

```
HOME=$SANDBOX XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go build ./...   # clean
HOME=$SANDBOX XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go vet ./...     # clean
gofmt -l <changed files>                                                       # clean
```

`go test` was intentionally not run against this host per repo policy (`internal/tmux` tests are not proven isolated from a real `$HOME`/tmux server on every path); CI is the test gate for this PR.

## AI disclosure

AI-authored (Claude), directed and reviewed by the repo maintainer. The replacement safety mechanism and its tests were written and manually verified against a real tmux 3.7b server (alias/abbreviation resolution, one-shot-client non-registration, server-pid identity) before being committed.

## Checklist

- [x] Targeted diff on top of #1832's unchanged commits: one additional problem (the denylist bypass), no unrelated changes
- [x] Tests added for the new behavior
- [x] Sandboxed `go build` / `go vet` clean; `gofmt` clean
- [x] `go test` not run locally (repo policy); CI is the gate
- [x] CHANGELOG.md untouched (entry added at landing, per repo convention)
- [x] Does not merge itself — open for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of orphaned tmux processes by recognizing valid client commands and aliases.
  * Protects active tmux clients and servers from accidental cleanup.
  * Skips unclassifiable or truncated processes and records them in cleanup statistics.
  * Added safer handling for missing or unreachable tmux servers.

* **Tests**
  * Added comprehensive coverage for command recognition, process classification, aliases, chained commands, live identities, and fail-safe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->