### PR TITLE
Refresh MiniMax pricing metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ Hide tools you don't use from the new-session picker with `[ui].hidden_tools` (a
 Track token usage and costs across all your AI agent sessions in real-time.
 
 - **Automatic collection** — Claude Code hook integration reads transcript files on each turn. Gemini/Codex/MiniMax support via output parsing (untested)
-- **14 models priced** — Claude Opus 4.6/4.7, Sonnet 4.6, Haiku 4.5, Gemini Pro/Flash, GPT-4o/4.1, o3, o4-mini, MiniMax M2.7/M2.7-highspeed/M2.5/M2.5-highspeed with daily price refresh
+- **15 models priced** — Claude Opus 4.6/4.7, Sonnet 4.6, Haiku 4.5, Gemini Pro/Flash, GPT-4o/4.1, o3, o4-mini, MiniMax M3/M2.7/M2.7-highspeed/M2.5/M2.5-highspeed with daily price refresh
 - **TUI dashboard** — press `$` to view today/week/month costs, top sessions, model breakdown
 - **Web dashboard** — `/costs` page with Chart.js charts, group drill-down, session detail views, SSE live updates
 - **Budget limits** — configurable daily/weekly/monthly/per-group/per-session limits with 80% warning and 100% hard stop (untested)

--- a/internal/costs/parser_minimax_integration_test.go
+++ b/internal/costs/parser_minimax_integration_test.go
@@ -10,6 +10,22 @@ import (
 // Integration tests verify the full cost pipeline for MiniMax models:
 // output parsing → token extraction → pricing lookup → cost computation.
 
+func TestMiniMaxEndToEnd_M3(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	collector := NewCollector(pricer)
+
+	input := "MiniMax usage: 1,000,000 input tokens, 500,000 output tokens (MiniMax-M3)"
+	events, err := collector.Collect("minimax", "integration-m3", input)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	ev := events[0]
+	assert.Equal(t, "integration-m3", ev.SessionID)
+	assert.Equal(t, "MiniMax-M3", ev.Model)
+	// 1M input at $0.60/Mtok plus 500K output at $2.40/Mtok totals $1.80.
+	assert.Equal(t, int64(1_800_000), ev.CostMicrodollars)
+}
+
 func TestMiniMaxEndToEnd_M27(t *testing.T) {
 	pricer := NewPricer(PricerConfig{})
 	collector := NewCollector(pricer)
@@ -24,10 +40,8 @@ func TestMiniMaxEndToEnd_M27(t *testing.T) {
 	assert.Equal(t, "MiniMax-M2.7", ev.Model)
 	assert.Equal(t, int64(500_000), ev.InputTokens)
 	assert.Equal(t, int64(100_000), ev.OutputTokens)
-	// 500K input at $0.70/Mtok = $0.35 = 350,000 microdollars
-	// 100K output at $2.80/Mtok = $0.28 = 280,000 microdollars
-	// Total = 630,000 microdollars
-	assert.Equal(t, int64(630_000), ev.CostMicrodollars)
+	// 500K input at $0.30/Mtok plus 100K output at $1.20/Mtok totals $0.27.
+	assert.Equal(t, int64(270_000), ev.CostMicrodollars)
 }
 
 func TestMiniMaxEndToEnd_M25Highspeed(t *testing.T) {

--- a/internal/costs/pricing.go
+++ b/internal/costs/pricing.go
@@ -81,7 +81,8 @@ func NewPricer(cfg PricerConfig) *Pricer {
 			"o3":                priceFromUSD(2.0, 8.0, 0, 0),
 			"o4-mini":           priceFromUSD(1.10, 4.40, 0, 0),
 			// MiniMax models (https://www.minimaxi.com/en/pricing)
-			"MiniMax-M2.7":           priceFromUSD(0.70, 2.80, 0, 0),
+			"MiniMax-M3":             priceFromUSD(0.60, 2.40, 0.12, 0),
+			"MiniMax-M2.7":           priceFromUSD(0.30, 1.20, 0.06, 0.375),
 			"MiniMax-M2.7-highspeed": priceFromUSD(0.35, 1.40, 0, 0),
 			"MiniMax-M2.5":           priceFromUSD(0.50, 2.00, 0, 0),
 			"MiniMax-M2.5-highspeed": priceFromUSD(0.15, 0.60, 0, 0),

--- a/internal/costs/pricing_test.go
+++ b/internal/costs/pricing_test.go
@@ -75,14 +75,17 @@ func TestMiniMaxPricing(t *testing.T) {
 	p := NewPricer(PricerConfig{})
 
 	tests := []struct {
-		model  string
-		input  int64
-		output int64
+		model      string
+		input      int64
+		output     int64
+		cacheRead  int64
+		cacheWrite int64
 	}{
-		{"MiniMax-M2.7", 700_000, 2_800_000},
-		{"MiniMax-M2.7-highspeed", 350_000, 1_400_000},
-		{"MiniMax-M2.5", 500_000, 2_000_000},
-		{"MiniMax-M2.5-highspeed", 150_000, 600_000},
+		{"MiniMax-M3", 600_000, 2_400_000, 120_000, 0},
+		{"MiniMax-M2.7", 300_000, 1_200_000, 60_000, 375_000},
+		{"MiniMax-M2.7-highspeed", 350_000, 1_400_000, 0, 0},
+		{"MiniMax-M2.5", 500_000, 2_000_000, 0, 0},
+		{"MiniMax-M2.5-highspeed", 150_000, 600_000, 0, 0},
 	}
 
 	for _, tt := range tests {
@@ -90,15 +93,16 @@ func TestMiniMaxPricing(t *testing.T) {
 		assert.True(t, ok, "model %s should have pricing", tt.model)
 		assert.Equal(t, tt.input, mp.InputPerMtokMicro, "model %s input pricing", tt.model)
 		assert.Equal(t, tt.output, mp.OutputPerMtokMicro, "model %s output pricing", tt.model)
+		assert.Equal(t, tt.cacheRead, mp.CacheReadPerMtokMicro, "model %s cache read pricing", tt.model)
+		assert.Equal(t, tt.cacheWrite, mp.CacheWritePerMtokMicro, "model %s cache write pricing", tt.model)
 	}
 }
 
 func TestMiniMaxComputeCost(t *testing.T) {
 	p := NewPricer(PricerConfig{})
-	// MiniMax-M2.7: input=$0.70/Mtok, output=$2.80/Mtok
-	// 1M input = $0.70, 1M output = $2.80 → total $3.50 = 3,500,000 microdollars
-	cost := p.ComputeCost("MiniMax-M2.7", 1_000_000, 1_000_000, 0, 0)
-	assert.Equal(t, int64(3_500_000), cost)
+	// MiniMax-M2.7: $0.30 input + $1.20 output + $0.06 cache read + $0.375 cache write.
+	cost := p.ComputeCost("MiniMax-M2.7", 1_000_000, 1_000_000, 1_000_000, 1_000_000)
+	assert.Equal(t, int64(1_935_000), cost)
 }
 
 func TestPricerModelNormalization(t *testing.T) {

--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -88,7 +88,8 @@ var modelContextWindowPrefixes = []struct {
 	{"claude-3-5", 200000},
 	{"claude-3-opus", 200000},
 	// MiniMax models
-	{"MiniMax-M2.7", 1000000},          // 1M context
+	{"MiniMax-M3", 1000000},            // 1M context
+	{"MiniMax-M2.7", 204800},           // 204.8K context
 	{"MiniMax-M2.5-highspeed", 204000}, // 204K context (must precede M2.5)
 	{"MiniMax-M2.5", 204000},           // 204K context
 }
@@ -130,7 +131,8 @@ var modelPricing = map[string]ModelPricing{
 	"claude-3-5-sonnet":        {Input: 3.0, Output: 15.0, CacheRead: 0.30, CacheWrite: 3.75},
 	"claude-3-5-haiku":         {Input: 0.80, Output: 4.0, CacheRead: 0.08, CacheWrite: 1.0},
 	// MiniMax models
-	"MiniMax-M2.7":           {Input: 0.70, Output: 2.80},
+	"MiniMax-M3":             {Input: 0.60, Output: 2.40, CacheRead: 0.12},
+	"MiniMax-M2.7":           {Input: 0.30, Output: 1.20, CacheRead: 0.06, CacheWrite: 0.375},
 	"MiniMax-M2.7-highspeed": {Input: 0.35, Output: 1.40},
 	"MiniMax-M2.5":           {Input: 0.50, Output: 2.00},
 	"MiniMax-M2.5-highspeed": {Input: 0.15, Output: 0.60},

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -72,6 +72,9 @@ func TestContextWindowForModel(t *testing.T) {
 	assert.Equal(t, 200000, contextWindowForModel("claude-haiku-4-5"))
 	// 3.x models: 200k
 	assert.Equal(t, 200000, contextWindowForModel("claude-3-5-sonnet"))
+	// MiniMax models
+	assert.Equal(t, 1000000, contextWindowForModel("MiniMax-M3"))
+	assert.Equal(t, 204800, contextWindowForModel("MiniMax-M2.7"))
 	// Unknown/empty: 200k fallback
 	assert.Equal(t, 200000, contextWindowForModel("unknown-model"))
 	assert.Equal(t, 200000, contextWindowForModel(""))
@@ -337,6 +340,18 @@ func TestCostCalculation_HaikuModel(t *testing.T) {
 	// Expected: (1M * 0.80 + 100K * 4 + 500K * 0.08 + 200K * 1.0) / 1M
 	// = (0.80 + 0.4 + 0.04 + 0.2) = $1.44
 	assert.InDelta(t, 1.44, cost, 0.01)
+}
+
+func TestCostCalculation_MiniMaxModels(t *testing.T) {
+	analytics := &SessionAnalytics{
+		InputTokens:      1000000,
+		OutputTokens:     1000000,
+		CacheReadTokens:  1000000,
+		CacheWriteTokens: 1000000,
+	}
+
+	assert.InDelta(t, 3.12, analytics.CalculateCost("MiniMax-M3"), 0.001)
+	assert.InDelta(t, 1.935, analytics.CalculateCost("MiniMax-M2.7"), 0.001)
 }
 
 func TestCostCalculation_DefaultFallback(t *testing.T) {


### PR DESCRIPTION
Reason: Refresh MiniMax executable model pricing and context metadata.

Changes:
- Add MiniMax-M3 pricing to the cost pricer and session analytics tables.
- Refresh MiniMax-M2.7 pricing, cache pricing, and context-window metadata.
- Update MiniMax cost and context tests plus the user-facing priced-model count.

Checks:
- git diff --check
- go test ./internal/costs
- go test ./internal/session -run "TestContextWindowForModel|TestCostCalculation_MiniMaxModels"

Note:
- go test ./internal/costs ./internal/session was also run; the session package has unrelated environment-sensitive failures in TestIssue1421_CleanStaleSSHSockets and TestPerf_OutboxDrain_Drain25 on this machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MiniMax M3 model identification, context limits, and cost calculation.
  * Added cache-read and cache-write pricing support for MiniMax models.
* **Bug Fixes**
  * Corrected MiniMax M2.7 pricing and updated its context window to 204.8K tokens.
* **Tests**
  * Expanded coverage for MiniMax M2.7 and M3 pricing, caching, context limits, and end-to-end cost calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->