### PR TITLE
fix(opencode): preserve launch options on restart

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1799,7 +1799,7 @@ func (i *Instance) buildOpenCodeCommand(baseCommand string) string {
 	// injected, so clear any stale port from a prior launch — otherwise the
 	// SSE watcher could connect to a freed port later reused by an unrelated
 	// process (issue #1614). Status falls back to tmux content sniffing.
-	i.OpenCodePort = 0
+	i.setOpenCodePort(0)
 	return envPrefix + baseCommand
 }
 
@@ -1836,16 +1836,16 @@ func (i *Instance) buildOpenCodeExtraFlags() string {
 // be allocated — status detection then falls back to tmux polling.
 func (i *Instance) buildOpenCodeSSEPortFlag() string {
 	if config, err := LoadUserConfig(); err == nil && config != nil && config.OpenCode.DisableSSEStatus {
-		i.OpenCodePort = 0
+		i.setOpenCodePort(0)
 		return ""
 	}
 	port, err := allocateLocalPort()
 	if err != nil {
 		sessionLog.Warn("opencode_sse_port_alloc_failed", slog.String("error", err.Error()))
-		i.OpenCodePort = 0
+		i.setOpenCodePort(0)
 		return ""
 	}
-	i.OpenCodePort = port
+	i.setOpenCodePort(port)
 	return fmt.Sprintf(" --port %d", port)
 }
 
@@ -1868,6 +1868,12 @@ func (i *Instance) GetOpenCodePort() int {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.OpenCodePort
+}
+
+func (i *Instance) setOpenCodePort(port int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.OpenCodePort = port
 }
 
 // UpdateOpenCodeSSEStatus feeds an SSE-derived status ("running"/"waiting")
@@ -7617,15 +7623,12 @@ func (i *Instance) restart(env map[string]string) error {
 			}
 		}
 
-		var rawCmd string
-		if i.OpenCodeSessionID != "" {
-			// OPENCODE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
-			rawCmd = fmt.Sprintf("opencode -s %s", i.OpenCodeSessionID)
-		} else {
-			rawCmd = "opencode"
+		if i.OpenCodeSessionID == "" {
 			i.OpenCodeStartedAt = time.Now().UnixMilli()
 		}
-		rawCmd = i.buildRestartEnvPrefix() + rawCmd
+		// Reuse the canonical builder so live-pane respawns retain the same
+		// configured command, model, agent, and SSE flags as every other start.
+		rawCmd := i.buildOpenCodeCommand("opencode")
 		resumeCmd, containerName, err := i.prepareCommand(rawCmd)
 		if err != nil {
 			return err

--- a/internal/session/opencode_restart_model_test.go
+++ b/internal/session/opencode_restart_model_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// TestOpenCodeRestartLivePanePreservesLaunchOptions exercises the real
+// RestartWithEnv -> tmux respawn path while TestMain's isolated TMUX_TMPDIR
+// keeps the host's sessions untouched. It guards the live-pane branch, which
+// used to rebuild only "opencode -s <id>" and silently drop the persisted
+// model and the other flags owned by buildOpenCodeCommand.
+func TestOpenCodeRestartLivePanePreservesLaunchOptions(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	projectDir := t.TempDir()
+	stubDir := t.TempDir()
+	argvLog := filepath.Join(t.TempDir(), "opencode-argv.log")
+	stubPath := filepath.Join(stubDir, "opencode")
+	stub := `#!/bin/sh
+if [ "$1" = "session" ] && [ "$2" = "list" ]; then
+  printf '[]\n'
+  exit 0
+fi
+printf 'ARGS=%s\nMARKER=%s\n' "$*" "$OPENCODE_RESTART_MARKER" > "$OPENCODE_RESTART_LOG"
+sleep 30
+`
+	if err := os.WriteFile(stubPath, []byte(stub), 0o755); err != nil {
+		t.Fatalf("write opencode stub: %v", err)
+	}
+	stubPATH := stubDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	t.Setenv("PATH", stubPATH)
+
+	tmuxName := fmt.Sprintf("agentdeck-opencode-model-restart-%d", time.Now().UnixNano())
+	start := exec.Command("tmux", "new-session", "-d", "-s", tmuxName, "-c", projectDir, "sleep 30")
+	if output, err := start.CombinedOutput(); err != nil {
+		t.Fatalf("start isolated tmux session: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "kill-session", "-t", tmuxName).Run()
+	})
+
+	inst := NewInstanceWithTool("opencode-model-restart", projectDir, "opencode")
+	inst.ID = "opencode-model-restart-instance"
+	inst.OpenCodeSessionID = "ses_MODEL_RESTART"
+	if _, _, err := SetField(inst, FieldModel, "freemodel/gpt-5.3-codex", nil); err != nil {
+		t.Fatalf("persist model intent: %v", err)
+	}
+	opts := inst.GetOpenCodeOptions()
+	if opts == nil {
+		t.Fatal("persisted OpenCode options are nil")
+	}
+	opts.Agent = "build"
+	if err := inst.SetOpenCodeOptions(opts); err != nil {
+		t.Fatalf("persist OpenCode agent: %v", err)
+	}
+
+	// Round-trip the instance before binding the live pane, matching a fresh
+	// CLI process loading the model intent from the registry.
+	encoded, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("marshal instance: %v", err)
+	}
+	revived := &Instance{}
+	if err := json.Unmarshal(encoded, revived); err != nil {
+		t.Fatalf("unmarshal instance: %v", err)
+	}
+	revived.tmuxSession = tmux.ReconnectSessionLazy(tmuxName, tmuxName, projectDir, "opencode", "waiting")
+
+	if err := revived.RestartWithEnv(map[string]string{
+		"OPENCODE_RESTART_LOG":    argvLog,
+		"OPENCODE_RESTART_MARKER": "once",
+		"PATH":                    stubPATH,
+	}); err != nil {
+		t.Fatalf("RestartWithEnv: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	var argv []byte
+	for time.Now().Before(deadline) {
+		argv, err = os.ReadFile(argvLog)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("opencode stub did not capture restart argv: %v", err)
+	}
+	got := string(argv)
+	for _, want := range []string{
+		"-s ses_MODEL_RESTART",
+		"-m freemodel/gpt-5.3-codex",
+		"--agent build",
+		"--port ",
+		"MARKER=once",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("restart argv missing %q:\n%s", want, got)
+		}
+	}
+	if port := revived.GetOpenCodePort(); port <= 0 {
+		t.Errorf("canonical restart did not record an SSE port: %d", port)
+	}
+
+	paneCmd, err := exec.Command("tmux", "display-message", "-p", "-t", tmuxName+":", "#{pane_start_command}").Output()
+	if err != nil {
+		t.Fatalf("read respawned pane command: %v", err)
+	}
+	if count := strings.Count(string(paneCmd), "OPENCODE_RESTART_MARKER"); count != 1 {
+		t.Errorf("one-shot restart environment prefix count = %d, want 1:\n%s", count, paneCmd)
+	}
+}
+
+// TestOpenCodePortConcurrentBuildAndRead covers the live restart's interaction
+// with the status loop: restart rebuilds the OpenCode command (and its SSE
+// port) while the UI can concurrently snapshot that port for watcher targets.
+func TestOpenCodePortConcurrentBuildAndRead(t *testing.T) {
+	inst := NewInstanceWithTool("opencode-port-race", t.TempDir(), "opencode")
+	inst.OpenCodeSessionID = "ses_PORT_RACE"
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for n := 0; n < 128; n++ {
+			_ = inst.buildOpenCodeCommand("opencode")
+			runtime.Gosched()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for n := 0; n < 4096; n++ {
+			_ = inst.GetOpenCodePort()
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	wg.Wait()
+
+	if port := inst.GetOpenCodePort(); port <= 0 {
+		t.Fatalf("canonical builder did not retain its final SSE port: %d", port)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Restarting a live OpenCode session through AgentDeck resumes the conversation but
can silently drop the model and agent saved on the session. The registry still
shows the selected model even though the restarted OpenCode process was launched
without it.

## Why this change

The live-pane restart branch manually rebuilt only `opencode -s <session-id>`.
Every other normal OpenCode launch/restart path already uses
`buildOpenCodeCommand`, which owns the resume ID, persisted model and agent, SSE
port, configured executable, and one-shot environment prefix. This change routes
the live-pane branch through that existing builder instead of maintaining a
second, incomplete command path.

Provider catalog availability and whether a provider accepts a requested model
remain OpenCode concerns; AgentDeck's contract here is to preserve launch intent.

## User impact

After `session set <name> model <provider/model>`, restarting an already-running
OpenCode session keeps passing that model to OpenCode. The same restart also
retains the configured agent and SSE status port. Other tools, dead-session
fallback, and custom-command behavior are unchanged.

## Evidence

The new regression uses a task-isolated real tmux server, round-trips the
instance through JSON as a fresh CLI process would, respawns the live pane, and
records the actual OpenCode argv.

On parent `4630080726ddf99885e1d3d190ffcd2e25d18683`, it failed with:

    ARGS=-s ses_MODEL_RESTART
    MARKER=once
    restart argv missing "-m freemodel/gpt-5.3-codex"
    restart argv missing "--agent build"
    restart argv missing "--port "

On this branch:

    go test -p 1 ./internal/session -run '^TestOpenCodeRestartLivePanePreservesLaunchOptions$' -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/session  0.113s

Independent review of the first implementation found that canonical command
construction writes the SSE port while the UI may read it concurrently. The
new bounded regression reproduced that review finding before correction:

    WARNING: DATA RACE
    Write: (*Instance).buildOpenCodeSSEPortFlag (instance.go:1848)
    Previous read: (*Instance).GetOpenCodePort (instance.go:1870)

After routing every production `OpenCodePort` write through the instance mutex:

    go test -race -p 1 ./internal/session -run '^(TestOpenCodePortConcurrentBuildAndRead|TestOpenCodeRestartLivePanePreservesLaunchOptions)$' -count=5
    ok  github.com/asheshgoplani/agent-deck/internal/session  2.657s

    go test -p 1 ./internal/session -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/session  100.775s

Repository contributor self-check: 16 PASS, 0 FAIL, 0 WARN, including
sandboxed package tests, all-repository vet/build, and revert-check. Independent
read-only re-review of exact commit `14cc9bfaf44623fc9738da3ded1f3280733c4778`
returned PASS with no findings.

The real-tmux focused test remains about 0.12 seconds. This changes only the
explicit restart path; it adds no work to list, status, session output, or other
steady-state hot paths.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol

**Prompt / session log (optional):** —

## What actually bothered you

My human reported: "the resumed process command was only `opencode -s <session>`
with no model argument and the live OpenCode TUI still showed GLM-5.2."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

The package owning the change passes in the repository's isolated test harness;
the deliberately unchecked broad-suite box avoids claiming a suite wider than
this focused PR ran locally.

<!-- gate:ai=authored model=gpt-5.6-sol intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode restart behavior to preserve configured commands, models, agents, and SSE port settings.
  * Ensured updated port information remains reliable during concurrent operations.

* **Tests**
  * Added coverage validating restart behavior, launch option preservation, environment propagation, and concurrent port handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
