### PR TITLE
fix(ui,web): stop archived sessions leaking into the web sidebar

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1990,11 +1990,6 @@ func (h *Home) publishWebMenuSnapshot() {
 		return
 	}
 
-	h.instancesMu.RLock()
-	instancesCopy := make([]*session.Instance, len(h.instances))
-	copy(instancesCopy, h.instances)
-	h.instancesMu.RUnlock()
-
 	// Archived sessions live in h.instances — the TUI drops them at render time
 	// in rebuildFlatItems, not at load time. The web snapshot is built from
 	// h.instances instead of h.flatItems, so it must apply the archive filter
@@ -2002,7 +1997,14 @@ func (h *Home) publishWebMenuSnapshot() {
 	// SessionDataService.LoadMenuSnapshot, the storage-backed loader that serves
 	// headless mode. The archived view is fed separately by
 	// LoadArchivedMenuSnapshot, so nothing here needs to preserve them.
-	instancesCopy = session.FilterInstancesByArchive(instancesCopy, false)
+	//
+	// FilterInstancesByArchive allocates the copy this function needs anyway, so
+	// it replaces the previous make+copy rather than adding to it — same one
+	// allocation per publish, and the archive read happens under the same lock
+	// that guards the slice.
+	h.instancesMu.RLock()
+	instancesCopy := session.FilterInstancesByArchive(h.instances, false)
+	h.instancesMu.RUnlock()
 
 	groupTreeCopy := h.groupTree.ShallowCopyForSave()
 	groupsData := make([]*session.GroupData, 0, len(groupTreeCopy.GroupList))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1995,6 +1995,15 @@ func (h *Home) publishWebMenuSnapshot() {
 	copy(instancesCopy, h.instances)
 	h.instancesMu.RUnlock()
 
+	// Archived sessions live in h.instances — the TUI drops them at render time
+	// in rebuildFlatItems, not at load time. The web snapshot is built from
+	// h.instances instead of h.flatItems, so it must apply the archive filter
+	// itself or archived sessions surface as ordinary sidebar rows. This mirrors
+	// SessionDataService.LoadMenuSnapshot, the storage-backed loader that serves
+	// headless mode. The archived view is fed separately by
+	// LoadArchivedMenuSnapshot, so nothing here needs to preserve them.
+	instancesCopy = session.FilterInstancesByArchive(instancesCopy, false)
+
 	groupTreeCopy := h.groupTree.ShallowCopyForSave()
 	groupsData := make([]*session.GroupData, 0, len(groupTreeCopy.GroupList))
 	for _, g := range groupTreeCopy.GroupList {

--- a/internal/ui/publish_web_snapshot_archived_test.go
+++ b/internal/ui/publish_web_snapshot_archived_test.go
@@ -1,0 +1,92 @@
+// The TUI hides archived sessions at RENDER time (rebuildFlatItems partitions
+// them out of h.flatItems), but publishWebMenuSnapshot builds the web snapshot
+// from h.instances — the unfiltered slice. With the web server embedded in the
+// TUI (`agent-deck web` without --no-tui), MemoryMenuData serves that published
+// snapshot in preference to the storage-backed fallback, so archived sessions
+// appeared as ordinary rows in the web sidebar while staying hidden in the TUI.
+//
+// The storage-backed path has always filtered (session_data_service.go:
+// FilterInstancesByArchive(instances, false)); the TUI publish path never did.
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/web"
+)
+
+// menuSnapshotTitles returns the session titles present in a published snapshot.
+func menuSnapshotTitles(snap *web.MenuSnapshot) []string {
+	var titles []string
+	for _, item := range snap.Items {
+		if item.Type == web.MenuItemTypeSession && item.Session != nil {
+			titles = append(titles, item.Session.Title)
+		}
+	}
+	return titles
+}
+
+func TestPublishWebMenuSnapshotExcludesArchivedSessions(t *testing.T) {
+	home := NewHome()
+	home.width, home.height = 120, 40
+	home.initialLoading = false
+
+	active := session.NewInstanceWithTool("active", "/tmp/a", "claude")
+	archived := session.NewInstanceWithTool("archived", "/tmp/b", "claude")
+	active.Status = session.StatusIdle
+	// An archived session keeps a stale, display-frozen status — `error` is the
+	// common case (classifyTerminatedPane returns it for a vanished pane with no
+	// recoverable exit code), and it is what paints a red dot in the web UI.
+	archived.Status = session.StatusError
+	archived.ArchivedAt = time.Now().UTC()
+
+	instances := []*session.Instance{active, archived}
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(instances)
+
+	// nil fallback: the snapshot under test must come from the TUI publish path,
+	// never from the storage-backed loader that already filters correctly.
+	menuData := web.NewMemoryMenuData(nil)
+	home.SetWebMenuData(menuData)
+	home.rebuildFlatItems()
+
+	snap, err := menuData.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("LoadMenuSnapshot: %v", err)
+	}
+
+	titles := menuSnapshotTitles(snap)
+	for _, title := range titles {
+		if title == "archived" {
+			t.Errorf("archived session leaked into the published web menu snapshot: %v "+
+				"(TUI hides it, web sidebar would render it — with a red dot for status=error)", titles)
+		}
+	}
+	if len(titles) != 1 || titles[0] != "active" {
+		t.Errorf("published snapshot sessions = %v, want [active]", titles)
+	}
+	if snap.TotalSessions != 1 {
+		t.Errorf("snapshot.TotalSessions = %d, want 1", snap.TotalSessions)
+	}
+}
+
+// The archived view is served by a separate endpoint backed by
+// LoadArchivedMenuSnapshot, which feeds BuildMenuSnapshot an archived-only
+// slice. BuildMenuSnapshot must therefore stay archive-agnostic — filtering
+// inside the builder would empty the Archived pane instead of fixing the leak.
+func TestBuildMenuSnapshotStaysArchiveAgnostic(t *testing.T) {
+	archived := session.NewInstanceWithTool("archived", "/tmp/b", "claude")
+	archived.ArchivedAt = time.Now().UTC()
+
+	snap := web.BuildMenuSnapshot("default", []*session.Instance{archived}, nil, time.Now())
+
+	if snap.TotalSessions != 1 {
+		t.Fatalf("BuildMenuSnapshot dropped an archived instance (TotalSessions=%d, want 1); "+
+			"the archived pane feeds it archived-only input and needs them preserved", snap.TotalSessions)
+	}
+}

--- a/internal/ui/publish_web_snapshot_archived_test.go
+++ b/internal/ui/publish_web_snapshot_archived_test.go
@@ -29,6 +29,9 @@ func menuSnapshotTitles(snap *web.MenuSnapshot) []string {
 	return titles
 }
 
+// TestPublishWebMenuSnapshotExcludesArchivedSessions pins the archive filter on
+// the TUI-to-web publish path: an archived instance in h.instances must not
+// reach the published menu snapshot.
 func TestPublishWebMenuSnapshotExcludesArchivedSessions(t *testing.T) {
 	home := NewHome()
 	home.width, home.height = 120, 40
@@ -75,6 +78,81 @@ func TestPublishWebMenuSnapshotExcludesArchivedSessions(t *testing.T) {
 	}
 }
 
+// TestPublishWebMenuSnapshotOmitsRemoteSessions documents the RemoteSession
+// surface for this change (.coderabbit.yaml remote_parity).
+//
+// Remote sessions cannot reach the web menu snapshot, so the archive filter
+// cannot affect them. They are session.RemoteSessionInfo — a different type
+// from *session.Instance — held in h.remoteSessions under a separate mutex, and
+// rebuildFlatItems appends them straight to h.flatItems via buildRemoteFlatItems
+// (home.go). publishWebMenuSnapshot reads only h.instances, which a
+// RemoteSessionInfo can never enter. RemoteSessionInfo has no archive field at
+// all, so "archived remote session" is not a representable state.
+//
+// Asserted rather than skipped: this fails if a future change starts folding
+// remotes into the published snapshot without carrying the filter along.
+func TestPublishWebMenuSnapshotOmitsRemoteSessions(t *testing.T) {
+	home := NewHome()
+	home.width, home.height = 120, 40
+	home.initialLoading = false
+
+	active := session.NewInstanceWithTool("local-active", "/tmp/a", "claude")
+	archived := session.NewInstanceWithTool("local-archived", "/tmp/b", "claude")
+	active.Status = session.StatusIdle
+	archived.Status = session.StatusError
+	archived.ArchivedAt = time.Now().UTC()
+
+	instances := []*session.Instance{active, archived}
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(instances)
+
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "remote-1", Title: "remote-session", RemoteName: "dev", Status: string(session.StatusRunning)},
+			{ID: "remote-2", Title: "remote-stopped", RemoteName: "dev", Status: string(session.StatusStopped)},
+		},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	menuData := web.NewMemoryMenuData(nil)
+	home.SetWebMenuData(menuData)
+	home.rebuildFlatItems()
+
+	// The TUI list does render the remote rows — proving they were live for this
+	// rebuild and the snapshot's omission is not just an empty fixture.
+	sawRemoteRow := false
+	for _, item := range home.flatItems {
+		if item.Type == session.ItemTypeRemoteSession {
+			sawRemoteRow = true
+			break
+		}
+	}
+	if !sawRemoteRow {
+		t.Fatalf("fixture never produced a remote row in flatItems; the snapshot assertion below would be vacuous")
+	}
+
+	snap, err := menuData.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("LoadMenuSnapshot: %v", err)
+	}
+
+	titles := menuSnapshotTitles(snap)
+	for _, title := range titles {
+		if title == "remote-session" || title == "remote-stopped" {
+			t.Errorf("remote session leaked into the published web menu snapshot: %v", titles)
+		}
+	}
+	if len(titles) != 1 || titles[0] != "local-active" {
+		t.Errorf("published snapshot sessions = %v, want [local-active]", titles)
+	}
+}
+
+// TestBuildMenuSnapshotStaysArchiveAgnostic pins that the builder itself does no
+// archive filtering.
+//
 // The archived view is served by a separate endpoint backed by
 // LoadArchivedMenuSnapshot, which feeds BuildMenuSnapshot an archived-only
 // slice. BuildMenuSnapshot must therefore stay archive-agnostic — filtering

--- a/internal/ui/publish_web_snapshot_bench_test.go
+++ b/internal/ui/publish_web_snapshot_bench_test.go
@@ -9,15 +9,17 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-// publishWebMenuSnapshot runs at the end of rebuildFlatItems, which is on the
-// TUI list hot path. Benchmarks the two candidate shapes for the archive filter
-// so the cost of the fix is measured rather than assumed.
+// benchInstances builds n sessions with roughly a third archived, matching a
+// well-used deck. Shared fixture for the benchmarks below.
+//
+// These exist because publishWebMenuSnapshot runs at the end of
+// rebuildFlatItems, which is on the TUI list hot path, so the cost of the
+// archive filter is measured rather than assumed.
 func benchInstances(n int) []*session.Instance {
 	out := make([]*session.Instance, 0, n)
 	for i := range n {
 		inst := session.NewInstanceWithTool(fmt.Sprintf("s%d", i), "/tmp/x", "claude")
 		inst.Status = session.StatusIdle
-		// Roughly a third archived, matching a well-used deck.
 		if i%3 == 0 {
 			inst.ArchivedAt = time.Now().UTC()
 		}
@@ -26,7 +28,8 @@ func benchInstances(n int) []*session.Instance {
 	return out
 }
 
-// The shape that shipped: filter allocates the copy directly.
+// BenchmarkPublishFilterOnly measures the shape that shipped: the filter
+// allocates the copy directly, replacing the previous make+copy.
 func BenchmarkPublishFilterOnly(b *testing.B) {
 	for _, n := range []int{10, 100, 1000} {
 		instances := benchInstances(n)
@@ -39,7 +42,8 @@ func BenchmarkPublishFilterOnly(b *testing.B) {
 	}
 }
 
-// The pre-fix shape (make+copy, no filter) — the baseline this replaced.
+// BenchmarkPublishCopyOnly measures the pre-fix shape (make+copy, no filter) —
+// the baseline the archive filter replaced.
 func BenchmarkPublishCopyOnly(b *testing.B) {
 	for _, n := range []int{10, 100, 1000} {
 		instances := benchInstances(n)
@@ -54,7 +58,8 @@ func BenchmarkPublishCopyOnly(b *testing.B) {
 	}
 }
 
-// End-to-end publish cost, the number that actually matters.
+// BenchmarkPublishWebMenuSnapshot measures end-to-end publish cost, the number
+// the filter's overhead should be judged against.
 func BenchmarkPublishWebMenuSnapshot(b *testing.B) {
 	for _, n := range []int{10, 100, 1000} {
 		instances := benchInstances(n)

--- a/internal/ui/publish_web_snapshot_bench_test.go
+++ b/internal/ui/publish_web_snapshot_bench_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/web"
+)
+
+// publishWebMenuSnapshot runs at the end of rebuildFlatItems, which is on the
+// TUI list hot path. Benchmarks the two candidate shapes for the archive filter
+// so the cost of the fix is measured rather than assumed.
+func benchInstances(n int) []*session.Instance {
+	out := make([]*session.Instance, 0, n)
+	for i := range n {
+		inst := session.NewInstanceWithTool(fmt.Sprintf("s%d", i), "/tmp/x", "claude")
+		inst.Status = session.StatusIdle
+		// Roughly a third archived, matching a well-used deck.
+		if i%3 == 0 {
+			inst.ArchivedAt = time.Now().UTC()
+		}
+		out = append(out, inst)
+	}
+	return out
+}
+
+// The shape that shipped: filter allocates the copy directly.
+func BenchmarkPublishFilterOnly(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		instances := benchInstances(n)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = session.FilterInstancesByArchive(instances, false)
+			}
+		})
+	}
+}
+
+// The pre-fix shape (make+copy, no filter) — the baseline this replaced.
+func BenchmarkPublishCopyOnly(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		instances := benchInstances(n)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				cp := make([]*session.Instance, len(instances))
+				copy(cp, instances)
+				_ = cp
+			}
+		})
+	}
+}
+
+// End-to-end publish cost, the number that actually matters.
+func BenchmarkPublishWebMenuSnapshot(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		instances := benchInstances(n)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			home := NewHome()
+			home.initialLoading = false
+			home.instancesMu.Lock()
+			home.instances = instances
+			home.instancesMu.Unlock()
+			home.groupTree = session.NewGroupTree(instances)
+			home.SetWebMenuData(web.NewMemoryMenuData(nil))
+
+			b.ReportAllocs()
+			for b.Loop() {
+				home.publishWebMenuSnapshot()
+			}
+		})
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -162,7 +162,7 @@ func TestServiceWorkerServed(t *testing.T) {
 	if !strings.Contains(rr.Body.String(), "CACHE_VERSION") {
 		t.Fatalf("expected service worker payload, got: %s", rr.Body.String())
 	}
-	if !strings.Contains(rr.Body.String(), `agentdeck-shell-v6`) {
+	if !strings.Contains(rr.Body.String(), `agentdeck-shell-v7`) {
 		t.Fatalf("expected bumped service worker cache version, got: %s", rr.Body.String())
 	}
 }

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -214,11 +214,21 @@ body[data-rail="hidden"] .rightrail { display: none; }
   display: flex; align-items: center; gap: 6px; min-width: 0;
 }
 .sess .tt { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12.5px; }
-.sess .dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
-.sess .dot.running { background: var(--status-running); box-shadow: 0 0 6px rgba(115,218,202,0.7); animation: pulse 2s ease-in-out infinite; }
-.sess .dot.waiting { background: var(--status-waiting); box-shadow: 0 0 6px rgba(224,175,104,0.7); animation: pulse 1.2s ease-in-out infinite; }
-.sess .dot.error   { background: var(--status-error);   box-shadow: 0 0 6px rgba(247,118,142,0.7); }
-.sess .dot.idle    { background: var(--status-idle); }
+/* Status dots. Scoped to both the sidebar (.sess) and the archived pane (.sr):
+   .sr rows previously matched no .dot rule at all, so their dot rendered as an
+   unstyled square-less span. Every session.Status value needs a rule here — an
+   unmatched status silently renders an invisible dot. */
+.sess .dot,
+.sr .dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
+.sess .dot.running, .sr .dot.running { background: var(--status-running); box-shadow: 0 0 6px rgba(115,218,202,0.7); animation: pulse 2s ease-in-out infinite; }
+.sess .dot.waiting, .sr .dot.waiting { background: var(--status-waiting); box-shadow: 0 0 6px rgba(224,175,104,0.7); animation: pulse 1.2s ease-in-out infinite; }
+.sess .dot.error,   .sr .dot.error   { background: var(--status-error);   box-shadow: 0 0 6px rgba(247,118,142,0.7); }
+.sess .dot.idle,    .sr .dot.idle    { background: var(--status-idle); }
+/* stopped/starting/queued had no rule and rendered invisible. The TUI paints a
+   dim ■ for stopped (and archived rows are forced to it), so match that. */
+.sess .dot.stopped, .sr .dot.stopped { background: var(--status-stopped); }
+.sess .dot.starting, .sr .dot.starting { background: var(--status-start); animation: pulse 1.2s ease-in-out infinite; }
+.sess .dot.queued,  .sr .dot.queued  { background: var(--status-idle); opacity: 0.6; }
 
 .sess .meta { display: flex; align-items: center; gap: 6px; }
 .sess .tag {

--- a/internal/web/static/app/design-tokens.css
+++ b/internal/web/static/app/design-tokens.css
@@ -63,6 +63,9 @@
   --status-waiting: var(--tn-yellow);
   --status-error:   var(--tn-red);
   --status-idle:    var(--tn-muted-2);
+  /* Mirrors the TUI's SessionStatusStopped (ColorTextDim, styles.go) — the
+     glyph an archived or deliberately-stopped row gets there. */
+  --status-stopped: var(--tn-muted);
   --status-start:   var(--tn-purple);
   --phosphor:       var(--tn-green);
   --amber:          var(--tn-yellow);

--- a/internal/web/static/app/panes/ArchivedPane.js
+++ b/internal/web/static/app/panes/ArchivedPane.js
@@ -9,13 +9,18 @@ import { archivedSessionsSignal, loadArchivedSessions } from '../state.js'
 import { apiFetch } from '../api.js'
 import { addToast } from '../Toast.js'
 
-function projectArchived(raw) {
+export function projectArchived(raw) {
   const s = raw || {}
   return {
     id: s.id || '',
     title: s.title || s.id,
     tool: s.tool || '',
-    status: s.status || 'idle',
+    // Archiving tears down the tmux pane but never resets Status, so the wire
+    // value is a stale last-known state — commonly 'error' (a vanished pane
+    // with no recoverable exit code classifies that way), which would paint a
+    // red dot on a row that is merely archived. The TUI masks this the same
+    // way in connection_status.go: `if archived { icon = "■", stopped }`.
+    status: 'stopped',
     group: s.groupPath || '',
     path: s.projectPath || '',
     archivedAt: s.archivedAt || null,

--- a/internal/web/static/sw.js
+++ b/internal/web/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "agentdeck-shell-v6"
+const CACHE_VERSION = "agentdeck-shell-v7"
 const SHELL_CACHE = CACHE_VERSION
 const APP_SHELL_URLS = [
   "/",

--- a/tests/web/unit/archivedPane.test.js
+++ b/tests/web/unit/archivedPane.test.js
@@ -1,0 +1,49 @@
+// Archiving tears down the tmux pane but never resets Status, so the wire value
+// for an archived session is a stale last-known state — commonly 'error' (a
+// vanished pane with no recoverable exit code classifies that way), which the
+// status-dot CSS paints red. That made merely-archived sessions read as
+// failures. The TUI masks this in connection_status.go
+// (`if archived { icon, style = "■", SessionStatusStopped }`); projectArchived
+// is the web-side equivalent.
+//
+// Tests projectArchived directly rather than rendering ArchivedPane: the vitest
+// alias map cannot currently resolve preact/hooks for component sources, so no
+// unit test renders a hooks-using component.
+import { describe, expect, it } from 'vitest'
+
+const archivedPaneModulePath = '../../../internal/web/static/app/panes/ArchivedPane.js'
+
+describe('projectArchived status normalization', () => {
+  it('rewrites a stale error status to stopped', async () => {
+    const { projectArchived } = await import(archivedPaneModulePath)
+
+    const row = projectArchived({
+      id: 'a1',
+      title: 'disk space',
+      tool: 'claude',
+      status: 'error',
+      archivedAt: '2026-08-01T10:00:00Z',
+    })
+
+    expect(row.status).toBe('stopped')
+    expect(row.title).toBe('disk space')
+    expect(row.archivedAt).toBe('2026-08-01T10:00:00Z')
+  })
+
+  it('normalizes every stale status, not just error', async () => {
+    const { projectArchived } = await import(archivedPaneModulePath)
+
+    // A stale 'running' would otherwise render a pulsing green dot on a session
+    // whose pane no longer exists.
+    for (const status of ['running', 'waiting', 'idle', 'starting', 'queued', 'stopped', '']) {
+      expect(projectArchived({ id: 'x', status }).status).toBe('stopped')
+    }
+  })
+
+  it('tolerates a missing/undefined payload', async () => {
+    const { projectArchived } = await import(archivedPaneModulePath)
+
+    expect(projectArchived(undefined).status).toBe('stopped')
+    expect(projectArchived({}).status).toBe('stopped')
+  })
+})

--- a/tests/web/unit/archivedPane.test.js
+++ b/tests/web/unit/archivedPane.test.js
@@ -6,9 +6,15 @@
 // (`if archived { icon, style = "■", SessionStatusStopped }`); projectArchived
 // is the web-side equivalent.
 //
-// Tests projectArchived directly rather than rendering ArchivedPane: the vitest
-// alias map cannot currently resolve preact/hooks for component sources, so no
-// unit test renders a hooks-using component.
+// Tests projectArchived directly rather than rendering ArchivedPane. Importing
+// the component works (the vitest alias order was fixed alongside this test),
+// but rendering it still throws "Cannot read properties of undefined (reading
+// '__$f')" from @preact/signals — the signals hook integration and the preact
+// instance doing the rendering are not the same copy under this alias map.
+// Fixing that is test-infra work beyond this bug; projectArchived is the whole
+// of the behaviour under test, so assert it directly. If the render harness is
+// repaired later, a render-level test asserting the .dot class would be a
+// strictly better pin, since it would cover the Dot wiring too.
 import { describe, expect, it } from 'vitest'
 
 const archivedPaneModulePath = '../../../internal/web/static/app/panes/ArchivedPane.js'

--- a/tests/web/vitest.config.js
+++ b/tests/web/vitest.config.js
@@ -45,10 +45,17 @@ export default defineConfig({
     // straight to the installed file. Sub-imports inside those files
     // (e.g. signals.module.js → preact/hooks) re-resolve via the same
     // alias map, so transitive resolution works without breakage.
+    //
+    // ORDER MATTERS. Vite keeps object aliases in insertion order and matches a
+    // string `find` by prefix (`importee === find || importee.startsWith(find +
+    // '/')`), so a bare 'preact' listed first also swallows 'preact/hooks' and
+    // rewrites it to <abs>/preact.mjs/hooks — a path that does not exist. Every
+    // subpath entry must precede its bare parent. This stayed latent until the
+    // first test imported a module that pulls in preact/hooks.
     alias: {
-      'preact': aliasFor('preact'),
       'preact/hooks': aliasFor('preact/hooks'),
       'preact/jsx-runtime': aliasFor('preact/jsx-runtime'),
+      'preact': aliasFor('preact'),
       'htm/preact': aliasFor('htm/preact'),
       '@preact/signals': aliasFor('@preact/signals'),
       '@preact/signals-core': aliasFor('@preact/signals-core'),


### PR DESCRIPTION
## What problem does this solve?

Archived sessions stay hidden in the TUI but show up as ordinary rows in the web sidebar, several of them with a red (error) status dot. The two interfaces disagree about what "archived" means, so the web deck is cluttered with sessions the user deliberately put away — and some of them look like failures.

No existing issue; found and reproduced locally.

## Why this change

The TUI hides archived sessions at **render** time, not at load time. `h.instances` genuinely holds them — the load query has no archive predicate — and `rebuildFlatItems` partitions them out of `h.flatItems` (`internal/ui/home.go:2315`). But the last statement of that same function, `publishWebMenuSnapshot`, built the web snapshot from the unfiltered `h.instances`. So the function that hides archived rows from the terminal republished them to the browser.

`MemoryMenuData.LoadMenuSnapshot` prefers that published snapshot over the storage-backed loader, and the storage-backed loader is the only path that filtered (`SessionDataService.LoadMenuSnapshot`, `session_data_service.go:258`). Hence `agent-deck web` leaked while `--no-tui` headless was always correct. Archive filtering was never in this path: `publishWebMenuSnapshot` predates the archive feature (PR #174, Feb) by four months (PR #1325, Jun).

**The filter goes in the caller, not in `BuildMenuSnapshot`.** That was the tempting fix and it is wrong: `LoadArchivedMenuSnapshot` feeds the same builder an archived-**only** slice and needs those rows preserved — filtering inside the builder would empty the Archived pane instead of fixing the leak. `TestBuildMenuSnapshotStaysArchiveAgnostic` pins that so a later "helpful" refactor can't quietly break it.

The red dot is a second, independent defect. Archiving tears down the tmux pane but never resets `Status`, so an archived row carries a stale last-known value — commonly `error`, since `classifyTerminatedPane` returns that for a vanished pane with no recoverable exit code. The TUI masks this (`connection_status.go:73-75` forces `■`/stopped for archived rows); the web painted the raw status. Fixed by mirroring the TUI mask in the archived pane.

While in the dot code: `stopped`, `starting` and `queued` had no CSS rule at all and rendered as invisible transparent circles, and the archived pane matched no `.dot` rule whatsoever. Note `tests/web/e2e/session-actions-ui.spec.js:85` already asserted `.dot.stopped` exists while nothing gave it a background — so this was a real pre-existing gap, not new scope.

## User impact

- Archived sessions no longer appear in the web sidebar. They remain fully available (and actionable — unarchive/delete) in the Archived pane, which is fed by a separate endpoint and is unaffected.
- Archived rows in the Archived pane now show a dim "stopped" dot instead of a stale red/green/amber one.
- Sessions in `stopped` / `starting` / `queued` state now have a visible status dot in the sidebar where they previously had an invisible one.
- Requires a service-worker cache refresh; `CACHE_VERSION` is bumped accordingly.

## Evidence

**Reproduced against a real deck.** Aggregate over the local state DB (titles withheld — private projects):

```
$ sqlite3 -readonly state.db \
    "select status, count(*), sum(archived_at != 0) as archived from instances group by status;"
status  |count|archived
error   |  4  |  4
running |  1  |  0
stopped |  3  |  3
waiting |  2  |  0
```

7 archived sessions, 4 of them persisted with `status='error'` — exactly the 4 red circles visible in the sidebar and absent from the TUI. After the fix all 7 are gone from the sidebar and present in the Archived pane.

**The Go regression test fails without the production change** (assertion text from the pre-fix run):

```
--- FAIL: TestPublishWebMenuSnapshotExcludesArchivedSessions
    archived session leaked into the published web menu snapshot: [active archived]
    published snapshot sessions = [active archived], want [active]
    snapshot.TotalSessions = 2, want 1
```

**The JS test fails without its fix:** all three cases fail with `expected 'error' to be 'stopped'`, `expected 'running' to be 'stopped'`, `expected 'idle' to be 'stopped'`.

**Hot path.** `publishWebMenuSnapshot` runs at the end of `rebuildFlatItems`, so the filter is folded into the copy that function already made rather than added after it — no allocation delta versus the pre-fix code (`BenchmarkPublish*`, included):

```
filter vs the make+copy it replaced — identical allocs and bytes
  n=10     105 ns/op    80 B/op   1 allocs/op   (copy:   68 ns,   80 B, 1)
  n=100    449 ns/op   896 B/op   1 allocs/op   (copy:  192 ns,  896 B, 1)
  n=1000  5684 ns/op  8192 B/op   1 allocs/op   (copy: 1033 ns, 8192 B, 1)

whole publish, for scale
  n=10     419 us/op    n=100  1.96 ms/op    n=1000  20.1 ms/op
```

The filter is ~0.02% of a publish at every size.

**Suites:** `go build ./...`, `go vet`, `gofmt` clean. `internal/ui` and `internal/web` pass sandboxed, including under `-race`. All 131 web unit tests pass.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

The model did the investigation and wrote all of the code. I directed it, chose the fix scope, and verified the result by hand on my own deck before it was committed. The change was then put through a multi-agent review in which each finding was independently refutation-tested; one surviving finding (a stale comment in a new test) was fixed, and one reviewer claim — that the component render harness works — was checked and rejected as false before being acted on.

## What actually bothered you

My exact words when I hit this:

> "By default when I'm on the TUI I do not see any of the archived session I have but when I log in on the Web Interface they all appear with a red circle next to them."

I keep a fairly busy deck and archive sessions to get them out of the way. They stay out of the way in the terminal, but every time I open the web UI on my phone the sidebar is full of them again, several looking like they crashed. So the archive is only half a feature depending on which interface you're in.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

**On the sandboxed suite box — left unticked deliberately.** It does not pass cleanly on my machine, but it does not pass on unmodified `main` either. I ran the same sandboxed command against a clean `main` worktree and got the same failures: `TestPerf_ColdStart_Help`, `TestPerf_ColdStart_Version`, `TestIssue1421_CleanStaleSSHSockets`, `TestTestMainDoesNotLeakBootstrapServer`, `TestTmuxBootstrap_ServerIsRunning`. They are tmux/socket/timing tests in `cmd/agent-deck`, `internal/session`, `internal/testutil` and `internal/tmux` — none in a package this diff touches — and they shift between runs (`TestSweepStaleControlClients_PreservesLiveSibling` failed on the branch run and not the baseline; `TestTmuxBootstrap_ServerIsRunning` did the reverse). `internal/ui` and `internal/web`, the two packages this change touches, pass sandboxed. Flagging rather than ticking so CI is the arbiter.

**Not run:** the Playwright e2e suite (needs browsers and a live server). Analysis says the committed screenshot baselines are safe — every fixture seeds only `running`/`waiting`/`idle`/`error`, and the four pre-existing dot rules kept byte-identical declarations when split onto `.sess`/`.sr` — but that is reasoning, not a green run.

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archived sessions no longer appear in active web menu views.
  * Archived sessions consistently display a stopped status, including when status data is missing or outdated.
  * Added status indicators and animations for archived, queued, starting, and stopped sessions.
  * Updated service worker caching to ensure the latest interface assets are loaded.

* **Tests**
  * Added coverage for archive filtering, status normalization, and menu snapshot behavior.
  * Added performance benchmarks for menu publishing across different session counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->