### PR TITLE
fix(session): durable last-activity record so timestamps agree and survive restarts (#1846)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -473,6 +473,14 @@ type Instance struct {
 	hookSessionID  string    // Session ID from hook payload
 	hookLastUpdate time.Time // When hook status was last received
 
+	// Durable last-activity record (issue #1846). Unlike hookLastUpdate this
+	// survives ClearHookStatus and, via tool_data.last_activity_at, TUI
+	// restarts. lastActivityPersisted tracks the last value flushed to the
+	// DB so the hook observation path can throttle its targeted UPDATEs.
+	// See last_activity_persist.go.
+	lastActivityAt        time.Time
+	lastActivityPersisted time.Time
+
 	// SSE-based status detection for OpenCode (set by OpenCodeSSEWatcher,
 	// issue #1614). Not persisted; rebuilt from the live event stream.
 	sseStatus     string    // "running" or "waiting" (empty = no SSE data)
@@ -870,9 +878,24 @@ func (inst *Instance) SetToolThreadSafe(t string) {
 	inst.mu.Unlock()
 }
 
-// MarkAccessed updates the LastAccessedAt timestamp to now
+// MarkAccessed updates the LastAccessedAt timestamp to now.
+//
+// #1846: also persists it via a targeted single-row UPDATE. The in-memory
+// value used to reach SQLite only on the next full save cycle, which may
+// never come before the TUI exits — leaving the preview's fallback hours
+// stale after a restart. A full saveInstances here would be too heavy for
+// the attach path (see attachSession's no-synchronous-save note); one
+// UPDATE is not.
 func (inst *Instance) MarkAccessed() {
 	inst.LastAccessedAt = time.Now()
+	if db := statedb.GetGlobal(); db != nil {
+		if err := db.WriteLastAccessed(inst.ID, inst.LastAccessedAt); err != nil {
+			sessionLog.Debug("last_accessed_persist_failed",
+				slog.String("instance", inst.ID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
 }
 
 // GetLastActivityTime returns when the session was last active (content changed)
@@ -896,13 +919,21 @@ func (inst *Instance) GetLastActivityTime() time.Time {
 // stopped panes) and also feeds OpenCode rotation windows, so its semantics
 // must not change.
 //
-// Here we consult only CONFIRMED activity (LastObservedActivity guards on
-// realActivityConfirmed). When none has been observed we fall back to the
-// persisted last-accessed time — matching what the web serves — and finally
-// to CreatedAt. This keeps the TUI "⏱ last active" line in agreement with
-// the web instead of resetting to the most recent TUI load.
+// Here we consult only real activity evidence: CONFIRMED tmux activity
+// (LastObservedActivity guards on realActivityConfirmed) and the durable
+// last-activity record (#1846), whichever is newer. When neither exists we
+// fall back to the persisted last-accessed time — matching what the web
+// serves — and finally to CreatedAt. This keeps the TUI "⏱ last active"
+// line in agreement with the web instead of resetting to the most recent
+// TUI load. A LastAccessedAt newer than recorded activity deliberately does
+// NOT win: attaching to look at a quiet session is a peek, not activity —
+// the same principle the row badge's pickBadgeTime documents.
 func (inst *Instance) DisplayLastActivityTime() time.Time {
-	if ts, ok := inst.LastObservedActivity(); ok {
+	ts, ok := inst.LastObservedActivity()
+	if la := inst.LastActivityAt(); la.After(ts) {
+		ts, ok = la, true
+	}
+	if ok {
 		return ts
 	}
 	if !inst.LastAccessedAt.IsZero() {
@@ -4949,6 +4980,8 @@ func (i *Instance) UpdateStatus() error {
 			i.hookEvent = hs.Event
 			i.hookLastUpdate = hs.UpdatedAt
 			i.hookSessionID = hs.SessionID
+			// #1846: a disk-read hook sample is activity evidence too.
+			i.noteAgentActivityLocked(hs.UpdatedAt, false)
 			// Reset stale acknowledged flag from ReconnectSessionLazy.
 			// Without this, sessions loaded from SQLite with previousStatus="idle"
 			// would report idle even when the hook file says waiting/running.
@@ -5409,6 +5442,12 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	// Issue #1846: whatever hookLastUpdate ends up COMMITTED when this call
+	// returns is agent-activity evidence — fold it into the durable record.
+	// Runs before the mutex defer releases the lock. The reject branches
+	// below restore the pre-event value first, so a foreign ephemeral's
+	// timestamp is never credited to this instance.
+	defer func() { i.noteAgentActivityLocked(i.hookLastUpdate, false) }()
 
 	// Snapshot the prior hook-status fields so a candidate that fails the
 	// ownership check below can RESTORE them rather than leaving its status
@@ -5745,6 +5784,11 @@ func (i *Instance) SetAutoNameDescription(desc string) {
 // after an Escape interrupt where the Stop hook didn't fire).
 func (i *Instance) ClearHookStatus() {
 	i.mu.Lock()
+	// #1846: the file removed below is the only durable record of this
+	// session's last real activity, and the in-memory copy is zeroed right
+	// after. Fold it into the durable last-activity record first, bypassing
+	// the write throttle — this evidence has no other way to survive.
+	i.noteAgentActivityLocked(i.hookLastUpdate, true)
 	i.hookStatus = ""
 	i.hookLastUpdate = time.Time{}
 	i.mu.Unlock()

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -476,10 +476,12 @@ type Instance struct {
 	// Durable last-activity record (issue #1846). Unlike hookLastUpdate this
 	// survives ClearHookStatus and, via tool_data.last_activity_at, TUI
 	// restarts. lastActivityPersisted tracks the last value flushed to the
-	// DB so the hook observation path can throttle its targeted UPDATEs.
-	// See last_activity_persist.go.
+	// DB so the hook observation path can throttle its targeted UPDATEs;
+	// lastActivityPersistMu serializes those flushes WITHOUT holding i.mu
+	// across the DB write. See last_activity_persist.go.
 	lastActivityAt        time.Time
 	lastActivityPersisted time.Time
+	lastActivityPersistMu sync.Mutex
 
 	// SSE-based status detection for OpenCode (set by OpenCodeSSEWatcher,
 	// issue #1614). Not persisted; rebuilt from the live event stream.
@@ -4885,6 +4887,11 @@ func classifyTerminatedPane(exitCode int, haveExitCode bool, tool string) Status
 }
 
 func (i *Instance) UpdateStatus() error {
+	// #1846: flush any unpersisted last-activity evidence once the lock is
+	// released (declared before Lock so it runs after the Unlock defer).
+	// Cheap no-op unless the cold-load fold below (or an earlier
+	// UpdateHookStatus within the throttle window) left something behind.
+	defer i.persistLastActivity(false)
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -4981,7 +4988,8 @@ func (i *Instance) UpdateStatus() error {
 			i.hookLastUpdate = hs.UpdatedAt
 			i.hookSessionID = hs.SessionID
 			// #1846: a disk-read hook sample is activity evidence too.
-			i.noteAgentActivityLocked(hs.UpdatedAt, false)
+			// Flushed by this function's persistLastActivity defer.
+			i.noteAgentActivityLocked(hs.UpdatedAt)
 			// Reset stale acknowledged flag from ReconnectSessionLazy.
 			// Without this, sessions loaded from SQLite with previousStatus="idle"
 			// would report idle even when the hook file says waiting/running.
@@ -5441,13 +5449,16 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	}
 
 	i.mu.Lock()
-	defer i.mu.Unlock()
 	// Issue #1846: whatever hookLastUpdate ends up COMMITTED when this call
 	// returns is agent-activity evidence — fold it into the durable record.
-	// Runs before the mutex defer releases the lock. The reject branches
-	// below restore the pre-event value first, so a foreign ephemeral's
-	// timestamp is never credited to this instance.
-	defer func() { i.noteAgentActivityLocked(i.hookLastUpdate, false) }()
+	// The reject branches below restore the pre-event value first, so a
+	// foreign ephemeral's timestamp is never credited to this instance.
+	// Defer order (LIFO): the fold runs under the lock, then the lock is
+	// released, then the throttled SQLite flush runs OUTSIDE it — the DB
+	// write can stall on SQLITE_BUSY and must not hold up i.mu readers.
+	defer i.persistLastActivity(false)
+	defer i.mu.Unlock()
+	defer func() { i.noteAgentActivityLocked(i.hookLastUpdate) }()
 
 	// Snapshot the prior hook-status fields so a candidate that fails the
 	// ownership check below can RESTORE them rather than leaving its status
@@ -5786,12 +5797,15 @@ func (i *Instance) ClearHookStatus() {
 	i.mu.Lock()
 	// #1846: the file removed below is the only durable record of this
 	// session's last real activity, and the in-memory copy is zeroed right
-	// after. Fold it into the durable last-activity record first, bypassing
-	// the write throttle — this evidence has no other way to survive.
-	i.noteAgentActivityLocked(i.hookLastUpdate, true)
+	// after. Fold it into the durable last-activity record first.
+	i.noteAgentActivityLocked(i.hookLastUpdate)
 	i.hookStatus = ""
 	i.hookLastUpdate = time.Time{}
 	i.mu.Unlock()
+	// Flush BEFORE removing the file below, bypassing the write throttle —
+	// this evidence has no other way to survive. Outside i.mu: the SQLite
+	// write can stall on SQLITE_BUSY (see persistLastActivity).
+	i.persistLastActivity(true)
 
 	// Remove the persisted status file. Sandbox sessions bridge a PER-INSTANCE
 	// scoped subdir (…/hooks/sandbox/<id>/<id>.json) from the container, and the

--- a/internal/session/last_activity_persist.go
+++ b/internal/session/last_activity_persist.go
@@ -78,31 +78,60 @@ func (i *Instance) LastActivityAt() time.Time {
 	return i.lastActivityAt
 }
 
-// noteAgentActivityLocked folds t into the durable last-activity record
-// (monotonic: an older timestamp never rewinds it) and persists via a
-// targeted UPDATE. Caller must hold i.mu. force bypasses the write
-// throttle — pass true when the evidence backing the in-memory value is
-// about to be destroyed (ClearHookStatus deleting the hook file).
-func (i *Instance) noteAgentActivityLocked(t time.Time, force bool) {
+// noteAgentActivityLocked folds t into the in-memory last-activity record
+// (monotonic: an older timestamp never rewinds it). Caller must hold i.mu.
+//
+// Deliberately memory-only: the SQLite flush lives in persistLastActivity,
+// which callers invoke AFTER releasing i.mu. WriteLastActivityAt goes
+// through withBusyRetry on connections with busy_timeout=5000, so under
+// contention a single write can stall for seconds — and i.mu gates the TUI
+// render path, so holding it across the write would freeze the UI
+// (CodeRabbit finding on #1847).
+func (i *Instance) noteAgentActivityLocked(t time.Time) {
 	if !t.IsZero() && t.After(i.lastActivityAt) {
 		i.lastActivityAt = t
 	}
-	if i.lastActivityAt.IsZero() || !i.lastActivityAt.After(i.lastActivityPersisted) {
+}
+
+// persistLastActivity flushes the in-memory last-activity record to SQLite.
+// Caller must NOT hold i.mu — the lock is taken only briefly to snapshot
+// state on either side of the (potentially slow) DB write. force bypasses
+// the write throttle; pass true when the evidence backing the in-memory
+// value is about to be destroyed (ClearHookStatus deleting the hook file).
+//
+// lastActivityPersistMu serializes persists per instance so two concurrent
+// callers cannot write out of order (an older snapshot landing after a
+// newer one would leave the DB behind the throttle marker forever); each
+// caller re-snapshots the latest value once it holds the persist lock, so
+// writes are strictly monotonic.
+func (i *Instance) persistLastActivity(force bool) {
+	i.lastActivityPersistMu.Lock()
+	defer i.lastActivityPersistMu.Unlock()
+
+	i.mu.RLock()
+	to := i.lastActivityAt
+	skip := to.IsZero() || !to.After(i.lastActivityPersisted) ||
+		(!force && to.Sub(i.lastActivityPersisted) < lastActivityPersistInterval)
+	i.mu.RUnlock()
+	if skip {
 		return
 	}
-	if !force && i.lastActivityAt.Sub(i.lastActivityPersisted) < lastActivityPersistInterval {
-		return
-	}
+
 	db := statedb.GetGlobal()
 	if db == nil {
 		return
 	}
-	if err := db.WriteLastActivityAt(i.ID, i.lastActivityAt); err != nil {
+	if err := db.WriteLastActivityAt(i.ID, to); err != nil {
 		sessionLog.Debug("last_activity_persist_failed",
 			slog.String("instance", i.ID),
 			slog.String("error", err.Error()),
 		)
 		return
 	}
-	i.lastActivityPersisted = i.lastActivityAt
+
+	i.mu.Lock()
+	if to.After(i.lastActivityPersisted) {
+		i.lastActivityPersisted = to
+	}
+	i.mu.Unlock()
 }

--- a/internal/session/last_activity_persist.go
+++ b/internal/session/last_activity_persist.go
@@ -1,0 +1,108 @@
+// Issue #1846: the TUI's "ago" surfaces went stale because every trace of
+// real agent activity was ephemeral — the hook status file is deleted on
+// attach-return (deliberately, so a fresh-looking "waiting" file cannot mask
+// a pane killed by /q), the tmux tracker's confirmed activity is process-
+// local, and MarkAccessed only reached SQLite on the next full save cycle.
+// After a TUI restart the row badge collapsed to CreatedAt while the preview
+// fell back to a stale LastAccessedAt — two different wrong ages for the
+// same session.
+//
+// tool_data.last_activity_at is the durable record that closes the gap,
+// using the same extras-zone mechanism as #1704's last_started_at: merged
+// into the tool_data JSON blob outside the positional MarshalToolData
+// signature, so legacy binaries preserve it via MergeToolDataExtras and
+// legacy rows read as zero ("unknown").
+package session
+
+import (
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+const toolDataLastActivityAtKey = "last_activity_at"
+
+// lastActivityPersistInterval throttles the targeted DB write on the hook
+// observation path: a busy agent fires several hook events per turn, and
+// each observation would otherwise cost an UPDATE. Evidence-destroying
+// paths (ClearHookStatus) bypass the throttle with force=true, so at most
+// one interval of precision is ever at risk — and only if the process dies
+// without passing through ClearHookStatus.
+const lastActivityPersistInterval = 60 * time.Second
+
+// WriteLastActivityAtToToolData merges last_activity_at into the given
+// tool_data JSON blob as a Unix-seconds integer. A zero time removes the
+// key, keeping never-active sessions indistinguishable from rows saved by
+// an older binary.
+func WriteLastActivityAtToToolData(td json.RawMessage, t time.Time) json.RawMessage {
+	m := map[string]json.RawMessage{}
+	if len(td) > 0 {
+		_ = json.Unmarshal(td, &m)
+	}
+	if !t.IsZero() {
+		raw, _ := json.Marshal(t.Unix())
+		m[toolDataLastActivityAtKey] = raw
+	} else {
+		delete(m, toolDataLastActivityAtKey)
+	}
+	out, _ := json.Marshal(m)
+	return out
+}
+
+// ReadLastActivityAtFromToolData extracts last_activity_at from the blob.
+// Returns the zero time for missing/malformed/legacy rows — callers must
+// treat that as "unknown", never as "active at epoch".
+func ReadLastActivityAtFromToolData(td json.RawMessage) time.Time {
+	if len(td) == 0 {
+		return time.Time{}
+	}
+	var blob struct {
+		LastActivityAt int64 `json:"last_activity_at"`
+	}
+	_ = json.Unmarshal(td, &blob)
+	if blob.LastActivityAt == 0 {
+		return time.Time{}
+	}
+	return time.Unix(blob.LastActivityAt, 0).UTC()
+}
+
+// LastActivityAt returns the durable last-activity timestamp: the most
+// recent hook-evidenced agent activity this or any previous process
+// recorded. Zero means no activity has ever been recorded (legacy row or
+// genuinely never active). Thread-safe.
+func (i *Instance) LastActivityAt() time.Time {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.lastActivityAt
+}
+
+// noteAgentActivityLocked folds t into the durable last-activity record
+// (monotonic: an older timestamp never rewinds it) and persists via a
+// targeted UPDATE. Caller must hold i.mu. force bypasses the write
+// throttle — pass true when the evidence backing the in-memory value is
+// about to be destroyed (ClearHookStatus deleting the hook file).
+func (i *Instance) noteAgentActivityLocked(t time.Time, force bool) {
+	if !t.IsZero() && t.After(i.lastActivityAt) {
+		i.lastActivityAt = t
+	}
+	if i.lastActivityAt.IsZero() || !i.lastActivityAt.After(i.lastActivityPersisted) {
+		return
+	}
+	if !force && i.lastActivityAt.Sub(i.lastActivityPersisted) < lastActivityPersistInterval {
+		return
+	}
+	db := statedb.GetGlobal()
+	if db == nil {
+		return
+	}
+	if err := db.WriteLastActivityAt(i.ID, i.lastActivityAt); err != nil {
+		sessionLog.Debug("last_activity_persist_failed",
+			slog.String("instance", i.ID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	i.lastActivityPersisted = i.lastActivityAt
+}

--- a/internal/session/last_activity_persist_test.go
+++ b/internal/session/last_activity_persist_test.go
@@ -1,0 +1,344 @@
+// Issue #1846: the TUI's two "ago" surfaces (row badge, preview ⏱ line)
+// disagreed and both went stale because every trace of real agent activity
+// is ephemeral — the hook status file is deleted on attach-return, the tmux
+// tracker's confirmed activity is process-local, and MarkAccessed only
+// reaches SQLite on the next full save cycle (which may never come).
+//
+// These tests pin the durable last-activity record that closes the gap:
+// tool_data.last_activity_at (same extras-zone mechanism as #1704's
+// last_started_at), advanced whenever hook evidence is observed, flushed
+// before ClearHookStatus destroys that evidence, and never rewound.
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// readLastActivityAtFromDB returns tool_data.last_activity_at for the given
+// instance via a fresh LoadInstances query — what a restarted TUI or a
+// DB-direct consumer would observe.
+func readLastActivityAtFromDB(t *testing.T, db *statedb.StateDB, id string) time.Time {
+	t.Helper()
+	rows, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	for _, row := range rows {
+		if row.ID != id {
+			continue
+		}
+		return ReadLastActivityAtFromToolData(row.ToolData)
+	}
+	t.Fatalf("instance %q not found in DB", id)
+	return time.Time{}
+}
+
+func seedInstanceRow(t *testing.T, db *statedb.StateDB, inst *Instance, toolData string) {
+	t.Helper()
+	row := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        inst.Tool,
+		Status:      "idle",
+		CreatedAt:   time.Now(),
+		ToolData:    json.RawMessage(toolData),
+	}
+	if err := db.SaveInstance(row); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+}
+
+// TestLastActivityAt_ToolDataPersistenceRoundTrip mirrors
+// TestLastStartedAt_ToolDataPersistenceRoundTrip: the extras-zone helpers
+// round-trip, preserve unrelated keys, and a zero time clears the key so
+// legacy rows stay indistinguishable from never-active ones.
+func TestLastActivityAt_ToolDataPersistenceRoundTrip(t *testing.T) {
+	at := time.Date(2026, 8, 2, 21, 55, 0, 0, time.UTC)
+
+	td := WriteLastActivityAtToToolData(nil, at)
+	if got := ReadLastActivityAtFromToolData(td); !got.Equal(at) {
+		t.Fatalf("ReadLastActivityAtFromToolData after Write = %v, want %v", got, at)
+	}
+
+	cleared := WriteLastActivityAtToToolData(td, time.Time{})
+	if got := ReadLastActivityAtFromToolData(cleared); !got.IsZero() {
+		t.Fatalf("Write(td, zero) should clear, got %v", got)
+	}
+
+	mixed := []byte(`{"color":"#ff00aa","claude_session_id":"abc"}`)
+	out := WriteLastActivityAtToToolData(mixed, at)
+	if got := ReadLastActivityAtFromToolData(out); !got.Equal(at) {
+		t.Fatalf("round-trip with extras lost last_activity_at: got %v, want %v", got, at)
+	}
+	if !strings.Contains(string(out), `"color":"#ff00aa"`) {
+		t.Fatalf("round-trip dropped color: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"claude_session_id":"abc"`) {
+		t.Fatalf("round-trip dropped claude_session_id: %s", string(out))
+	}
+}
+
+// TestLastActivityAt_SQLiteRoundTrip proves the value survives a real
+// SaveWithGroups -> LoadWithGroups cycle — the boundary a TUI restart
+// crosses, which is exactly where the pre-fix badge collapsed back to
+// CreatedAt.
+func TestLastActivityAt_SQLiteRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	storage := newTestStorage(t)
+
+	inst := NewInstance("last-activity-roundtrip", "/tmp")
+	inst.Tool = "shell"
+	at := time.Now().Add(-90 * time.Minute).Truncate(time.Second)
+	inst.lastActivityAt = at
+
+	groupTree := NewGroupTreeWithGroups([]*Instance{inst}, nil)
+	if err := storage.SaveWithGroups([]*Instance{inst}, groupTree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	loaded, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(loaded))
+	}
+	if got := loaded[0].LastActivityAt(); !got.Equal(at) {
+		t.Fatalf("LastActivityAt not preserved across SQLite round-trip: got %v, want %v", got, at)
+	}
+
+	// Never-active sessions must keep reading as zero.
+	fresh := NewInstance("never-active-roundtrip", "/tmp")
+	fresh.Tool = "shell"
+	groupTree2 := NewGroupTreeWithGroups([]*Instance{fresh}, nil)
+	if err := storage.SaveWithGroups([]*Instance{fresh}, groupTree2); err != nil {
+		t.Fatalf("SaveWithGroups (never-active): %v", err)
+	}
+	loaded2, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups (never-active): %v", err)
+	}
+	for _, i := range loaded2 {
+		if i.ID == fresh.ID && !i.LastActivityAt().IsZero() {
+			t.Fatalf("never-active instance got non-zero LastActivityAt after round-trip: %v", i.LastActivityAt())
+		}
+	}
+}
+
+// TestUpdateHookStatus_AdvancesLastActivityAt: an accepted hook event (the
+// instance's own bound session id reporting from its own cwd) must advance
+// the durable record — both in memory and in the DB row, so a later TUI
+// restart still sees it.
+func TestUpdateHookStatus_AdvancesLastActivityAt(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-activity-advance", projectPath, "claude")
+	sessionID := "5ea244ce-0000-0000-0000-0000000000aa"
+	inst.ClaudeSessionID = sessionID
+	seedInstanceRow(t, db, inst, `{"claude_session_id":"`+sessionID+`"}`)
+
+	eventAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "waiting",
+		Event:     "Stop",
+		SessionID: sessionID,
+		UpdatedAt: eventAt,
+		Cwd:       projectPath,
+	})
+
+	if got := inst.LastActivityAt(); !got.Equal(eventAt) {
+		t.Fatalf("LastActivityAt after accepted hook event = %v, want %v", got, eventAt)
+	}
+	if got := readLastActivityAtFromDB(t, db, inst.ID); !got.Equal(eventAt) {
+		t.Fatalf("DB last_activity_at after accepted hook event = %v, want %v", got, eventAt)
+	}
+}
+
+// TestUpdateHookStatus_StaleReplayDoesNotRewind: the watcher re-applies the
+// same on-disk file on rescans; an event older than what we already know
+// must never pull the durable record backwards.
+func TestUpdateHookStatus_StaleReplayDoesNotRewind(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-activity-rewind", projectPath, "claude")
+	sessionID := "5ea244ce-0000-0000-0000-0000000000ab"
+	inst.ClaudeSessionID = sessionID
+
+	newer := time.Now().Add(-1 * time.Minute).Truncate(time.Second)
+	older := newer.Add(-30 * time.Minute)
+
+	inst.UpdateHookStatus(&HookStatus{Status: "waiting", Event: "Stop", SessionID: sessionID, UpdatedAt: newer, Cwd: projectPath})
+	inst.UpdateHookStatus(&HookStatus{Status: "waiting", Event: "Stop", SessionID: sessionID, UpdatedAt: older, Cwd: projectPath})
+
+	if got := inst.LastActivityAt(); !got.Equal(newer) {
+		t.Fatalf("stale replay rewound LastActivityAt to %v, want %v", got, newer)
+	}
+}
+
+// TestUpdateHookStatus_ForeignRejectDoesNotAdvanceLastActivityAt: a foreign
+// ephemeral (a `claude -p` child that inherited AGENTDECK_INSTANCE_ID, cwd
+// provably outside the instance's paths) is restored to a no-op by the
+// #1729 guard — its activity must not be credited to this instance either.
+func TestUpdateHookStatus_ForeignRejectDoesNotAdvanceLastActivityAt(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	foreignCwd := filepath.Join(tmpHome, "elsewhere")
+	for _, d := range []string{projectPath, foreignCwd} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	inst := NewInstanceWithTool("hook-activity-foreign", projectPath, "claude")
+	inst.ClaudeSessionID = "5ea244ce-0000-0000-0000-0000000000ac"
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		Event:     "UserPromptSubmit",
+		SessionID: "99999999-0000-0000-0000-0000000000ff", // foreign candidate
+		UpdatedAt: time.Now(),
+		Cwd:       foreignCwd,
+	})
+
+	if got := inst.LastActivityAt(); !got.IsZero() {
+		t.Fatalf("rejected foreign hook event advanced LastActivityAt to %v, want zero", got)
+	}
+}
+
+// TestClearHookStatus_PreservesActivityEvidence is the heart of #1846's
+// repro: attach-return calls ClearHookStatus to force live status polling
+// (a fresh-looking "waiting" file would mask a pane killed by /q), and
+// pre-fix that also destroyed the only durable record of real activity —
+// the badge collapsed to CreatedAt ("2d 9h ago") while the preview showed
+// LastAccessedAt ("7h 43m ago"). Clearing the hook STATUS must flush the
+// activity timestamp to the DB before the evidence is gone, even when the
+// throttled write in UpdateHookStatus skipped it.
+func TestClearHookStatus_PreservesActivityEvidence(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-activity-clear", projectPath, "claude")
+	sessionID := "5ea244ce-0000-0000-0000-0000000000ad"
+	inst.ClaudeSessionID = sessionID
+	seedInstanceRow(t, db, inst, `{"claude_session_id":"`+sessionID+`"}`)
+
+	// Two events inside the persist-throttle window: the first persists,
+	// the second stays memory-only — the exact state attach-return hits.
+	first := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	second := first.Add(10 * time.Second)
+	inst.UpdateHookStatus(&HookStatus{Status: "running", Event: "UserPromptSubmit", SessionID: sessionID, UpdatedAt: first, Cwd: projectPath})
+	inst.UpdateHookStatus(&HookStatus{Status: "waiting", Event: "Stop", SessionID: sessionID, UpdatedAt: second, Cwd: projectPath})
+
+	inst.ClearHookStatus()
+
+	if got := inst.LastActivityAt(); !got.Equal(second) {
+		t.Fatalf("ClearHookStatus lost in-memory activity evidence: got %v, want %v", got, second)
+	}
+	if got := readLastActivityAtFromDB(t, db, inst.ID); !got.Equal(second) {
+		t.Fatalf("ClearHookStatus did not flush activity evidence to DB: got %v, want %v", got, second)
+	}
+	// The status itself must still be cleared — that is ClearHookStatus's job.
+	if status, _ := inst.GetHookStatus(); status != "" {
+		t.Fatalf("ClearHookStatus left hook status %q, want empty", status)
+	}
+}
+
+// TestMarkAccessed_PersistsLastAccessedDurably: pre-fix, MarkAccessed only
+// mutated memory and reached SQLite on the next full save cycle — which may
+// never come before the TUI exits, leaving the preview's fallback hours
+// stale (the "7h 43m ago" half of #1846). The targeted write makes each
+// attach/detach durable on its own.
+func TestMarkAccessed_PersistsLastAccessedDurably(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	db := withTempGlobalStateDB(t)
+
+	inst := NewInstance("mark-accessed-durable", "/tmp")
+	inst.Tool = "shell"
+	seedInstanceRow(t, db, inst, `{}`)
+
+	before := time.Now().Add(-time.Second)
+	inst.MarkAccessed()
+
+	rows, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	for _, row := range rows {
+		if row.ID != inst.ID {
+			continue
+		}
+		if row.LastAccessed.Before(before) {
+			t.Fatalf("MarkAccessed not persisted: DB last_accessed = %v, want >= %v", row.LastAccessed, before)
+		}
+		return
+	}
+	t.Fatalf("instance %q not found in DB", inst.ID)
+}
+
+// TestDisplayLastActivityTime_PrefersPersistedActivity: the preview (and
+// staleActivityEvidence in status --stale) must see durable activity that
+// outlived the hook file, instead of falling through to the older
+// LastAccessedAt.
+func TestDisplayLastActivityTime_PrefersPersistedActivity(t *testing.T) {
+	inst := NewInstance("display-persisted-activity", "/tmp")
+	inst.Tool = "shell"
+	inst.LastAccessedAt = time.Now().Add(-8 * time.Hour)
+	activity := time.Now().Add(-90 * time.Minute).Truncate(time.Second)
+	inst.lastActivityAt = activity
+
+	if got := inst.DisplayLastActivityTime(); !got.Equal(activity) {
+		t.Fatalf("DisplayLastActivityTime = %v, want persisted activity %v", got, activity)
+	}
+
+	// An attach NEWER than the last real activity is a peek, not activity —
+	// the persisted evidence still wins (matches the badge's semantics).
+	inst.LastAccessedAt = time.Now()
+	if got := inst.DisplayLastActivityTime(); !got.Equal(activity) {
+		t.Fatalf("newer LastAccessedAt overrode real activity: got %v, want %v", got, activity)
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -64,8 +64,13 @@ type InstanceData struct {
 	// not a typed SQL column. Zero means unknown (old record or never
 	// started).
 	LastStartedAt time.Time `json:"last_started_at,omitempty"`
-	ArchivedAt    time.Time `json:"archived_at,omitempty"`
-	TmuxSession   string    `json:"tmux_session"`
+	// LastActivityAt mirrors Instance.lastActivityAt (issue #1846): durable
+	// hook-evidenced activity, persisted via the tool_data extras zone (see
+	// last_activity_persist.go). Zero means unknown (old record or never
+	// active).
+	LastActivityAt time.Time `json:"last_activity_at,omitempty"`
+	ArchivedAt     time.Time `json:"archived_at,omitempty"`
+	TmuxSession    string    `json:"tmux_session"`
 	// TmuxSocketName is the tmux -L selector captured at Instance creation
 	// (issue #687, v1.7.50). Empty for pre-v1.7.50 rows — those keep hitting
 	// the default server after upgrade.
@@ -968,6 +973,10 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	// `status --stale` (and ShouldSkipRestart's freshness guard) see a real
 	// value from a fresh CLI process instead of always-zero.
 	toolData = WriteLastStartedAtToToolData(toolData, inst.LastStartedAt)
+	// #1846: same treatment for the durable last-activity record, so the
+	// timestamp badge and preview survive a TUI restart instead of
+	// collapsing back to CreatedAt/LastAccessedAt.
+	toolData = WriteLastActivityAtToToolData(toolData, inst.LastActivityAt())
 
 	return &statedb.InstanceRow{
 		ID:                  inst.ID,
@@ -1142,6 +1151,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			SubcommandPassthrough:     ReadSubcommandPassthroughFromToolData(r.ToolData),
 			ClaudeSessionIDUnverified: ReadClaudeSessionUnverifiedFromToolData(r.ToolData),
 			LastStartedAt:             ReadLastStartedAtFromToolData(r.ToolData),
+			LastActivityAt:            ReadLastActivityAtFromToolData(r.ToolData),
 		}
 	}
 
@@ -1264,6 +1274,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			SubcommandPassthrough:     ReadSubcommandPassthroughFromToolData(r.ToolData),
 			ClaudeSessionIDUnverified: ReadClaudeSessionUnverifiedFromToolData(r.ToolData),
 			LastStartedAt:             ReadLastStartedAtFromToolData(r.ToolData),
+			LastActivityAt:            ReadLastActivityAtFromToolData(r.ToolData),
 		}
 	}
 
@@ -1513,14 +1524,19 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			IdleTimeoutSecs:              instData.IdleTimeoutSecs,
 			SubcommandPassthrough:        instData.SubcommandPassthrough,
 			LastStartedAt:                instData.LastStartedAt,
-			Sandbox:                      instData.Sandbox,
-			SandboxContainer:             instData.SandboxContainer,
-			SSHHost:                      instData.SSHHost,
-			SSHRemotePath:                instData.SSHRemotePath,
-			MultiRepoEnabled:             instData.MultiRepoEnabled,
-			AdditionalPaths:              instData.AdditionalPaths,
-			MultiRepoTempDir:             instData.MultiRepoTempDir,
-			tmuxSession:                  tmuxSess,
+			// #1846: the loaded value came from the DB, so it is by
+			// definition already persisted — seed both fields so the write
+			// throttle has an accurate baseline.
+			lastActivityAt:        instData.LastActivityAt,
+			lastActivityPersisted: instData.LastActivityAt,
+			Sandbox:               instData.Sandbox,
+			SandboxContainer:      instData.SandboxContainer,
+			SSHHost:               instData.SSHHost,
+			SSHRemotePath:         instData.SSHRemotePath,
+			MultiRepoEnabled:      instData.MultiRepoEnabled,
+			AdditionalPaths:       instData.AdditionalPaths,
+			MultiRepoTempDir:      instData.MultiRepoTempDir,
+			tmuxSession:           tmuxSess,
 		}
 		// Convert multi-repo worktree data
 		for _, wt := range instData.MultiRepoWorktrees {

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1442,6 +1442,40 @@ func (s *StateDB) WriteGeminiSessionBinding(id, sessionID string, detectedAt tim
 	})
 }
 
+// WriteLastActivityAt atomically rewrites tool_data.last_activity_at
+// (issue #1846's durable activity record) without touching any unrelated
+// keys — same json_set/withBusyRetry shape as WriteClaudeSessionBinding,
+// and for the same reason: the observing process (TUI hook watcher,
+// attach-return) has no save cycle it can rely on to flush the in-memory
+// value before the evidence behind it is gone.
+func (s *StateDB) WriteLastActivityAt(id string, at time.Time) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances
+			   SET tool_data = json_set(
+			         COALESCE(tool_data, '{}'),
+			         '$.last_activity_at', ?)
+			 WHERE id = ?`,
+			at.Unix(), id,
+		)
+		return err
+	})
+}
+
+// WriteLastAccessed atomically updates the last_accessed column for one
+// instance. MarkAccessed (#1846) uses this so each attach/detach is durable
+// on its own instead of waiting for a full saveInstances that may never run
+// before the TUI exits.
+func (s *StateDB) WriteLastAccessed(id string, at time.Time) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances SET last_accessed = ? WHERE id = ?`,
+			at.Unix(), id,
+		)
+		return err
+	})
+}
+
 // ReadAllStatuses returns status + acknowledged flag for every instance.
 func (s *StateDB) ReadAllStatuses() (map[string]StatusRow, error) {
 	rows, err := s.db.Query("SELECT id, status, tool, acknowledged FROM instances")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -16551,7 +16551,7 @@ func (h *Home) renderSessionItem(
 			hookStatus = h.hookWatcher.GetHookStatus(inst.ID)
 		}
 		confirmedTs, confirmedObserved := inst.LastObservedActivity()
-		ts := pickBadgeTime(inst.CreatedAt, inst.LastStartedAt, hookStatus, confirmedTs, confirmedObserved)
+		ts := sessionActivityTime(inst.CreatedAt, inst.LastStartedAt, inst.LastActivityAt(), inst.LastAccessedAt, confirmedTs, confirmedObserved, hookStatus)
 		timestampBadge = tsStyle.Render(" " + formatRelativeTime(ts))
 	}
 
@@ -17499,11 +17499,17 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	b.WriteString(infoStyle.Render("📁 " + pathStr))
 	b.WriteString("\n")
 
-	// Activity time - shows when session was last active. Uses the display-
-	// oriented accessor so sessions with no confirmed activity (error/idle/
-	// stopped) fall back to the persisted last-accessed time — matching the
-	// web — instead of leaking the tmux tracker's ~load-time seed.
-	activityTime := selected.DisplayLastActivityTime()
+	// Activity time - shows when session was last active. Composed with
+	// sessionActivityTime — the SAME formula as the row badge (issue #1846:
+	// the preview used to read DisplayLastActivityTime while the badge used
+	// pickBadgeTime, so the two surfaces showed different ages for the same
+	// session; both were stale once the underlying evidence was destroyed).
+	var previewHookStatus *session.HookStatus
+	if h.hookWatcher != nil {
+		previewHookStatus = h.hookWatcher.GetHookStatus(selected.ID)
+	}
+	confirmedTs, confirmedObserved := selected.LastObservedActivity()
+	activityTime := sessionActivityTime(selected.CreatedAt, selected.LastStartedAt, selected.LastActivityAt(), selected.LastAccessedAt, confirmedTs, confirmedObserved, previewHookStatus)
 	activityStr := formatRelativeTime(activityTime)
 	if selectedStatus == session.StatusRunning {
 		activityStr = "active now"
@@ -18762,14 +18768,19 @@ func truncatePath(path string, maxLen int) string {
 	return string(runes[:startLen]) + "..." + string(runes[len(runes)-endLen:])
 }
 
-// pickBadgeTime returns the most recent of the four signals the session-row
+// pickBadgeTime returns the most recent of the five signals the session-row
 // timestamp badge layers over, ignoring any signal that is unset / not
-// observed. Pure function — kept out of renderSessionItem so the 4-layer
+// observed. Pure function — kept out of renderSessionItem so the 5-layer
 // composition can be unit-tested without faking renderer dependencies.
 //
+// lastActivityAt is the durable record from tool_data.last_activity_at
+// (issue #1846): hook-evidenced activity that survives attach-return
+// deleting the hook file and TUI restarts losing the tmux tracker.
+//
 // LastAccessedAt is deliberately not a parameter: peeking at a quiet
-// session isn't an "update".
-func pickBadgeTime(createdAt, lastStartedAt time.Time, hookEvent *session.HookStatus, confirmedActivity time.Time, confirmedObserved bool) time.Time {
+// session isn't an "update". (sessionActivityTime layers it in as a
+// fallback when no activity evidence exists at all.)
+func pickBadgeTime(createdAt, lastStartedAt time.Time, hookEvent *session.HookStatus, lastActivityAt time.Time, confirmedActivity time.Time, confirmedObserved bool) time.Time {
 	ts := createdAt
 	if lastStartedAt.After(ts) {
 		ts = lastStartedAt
@@ -18777,8 +18788,28 @@ func pickBadgeTime(createdAt, lastStartedAt time.Time, hookEvent *session.HookSt
 	if hookEvent != nil && hookEvent.UpdatedAt.After(ts) {
 		ts = hookEvent.UpdatedAt
 	}
+	if lastActivityAt.After(ts) {
+		ts = lastActivityAt
+	}
 	if confirmedObserved && confirmedActivity.After(ts) {
 		ts = confirmedActivity
+	}
+	return ts
+}
+
+// sessionActivityTime is the single "last activity" composition BOTH the
+// session-row badge and the preview's "⏱" line render from (issue #1846:
+// the two surfaces used different formulas over different stale fallbacks
+// and showed two different wrong ages for the same session).
+//
+// Layering: pickBadgeTime's activity evidence wins outright; LastAccessedAt
+// participates only as a fallback when no evidence beyond CreatedAt exists —
+// a TUI attach is a better floor than creation time, but a peek at a quiet
+// session must never override recorded activity.
+func sessionActivityTime(createdAt, lastStartedAt, lastActivityAt, lastAccessedAt, confirmedActivity time.Time, confirmedObserved bool, hookEvent *session.HookStatus) time.Time {
+	ts := pickBadgeTime(createdAt, lastStartedAt, hookEvent, lastActivityAt, confirmedActivity, confirmedObserved)
+	if ts.Equal(createdAt) && lastAccessedAt.After(ts) {
+		return lastAccessedAt
 	}
 	return ts
 }

--- a/internal/ui/pick_badge_time_test.go
+++ b/internal/ui/pick_badge_time_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// pickBadgeTime composes the 4-layer "most recent" formula that drives the
+// pickBadgeTime composes the 5-layer "most recent" formula that drives the
 // session-row timestamp badge. Extracting it from renderSessionItem lets
 // us pin the composition without faking unexported Home/Instance fields.
 // Layers, in newest-wins order:
@@ -15,11 +15,12 @@ import (
 //	1. CreatedAt              (always set)
 //	2. LastStartedAt          (zero if never started)
 //	3. hookEvent.UpdatedAt    (nil if no hooks installed)
-//	4. confirmedActivity      (bool gates use — false means "ignore")
+//	4. lastActivityAt         (persisted durable activity, zero for legacy rows)
+//	5. confirmedActivity      (bool gates use — false means "ignore")
 
 func TestPickBadgeTime_PicksCreatedAtFloor(t *testing.T) {
 	created := time.Now().Add(-2 * time.Hour)
-	got := pickBadgeTime(created, time.Time{}, nil, time.Time{}, false)
+	got := pickBadgeTime(created, time.Time{}, nil, time.Time{}, time.Time{}, false)
 	if !got.Equal(created) {
 		t.Errorf("with only CreatedAt set, expected %v, got %v", created, got)
 	}
@@ -28,7 +29,7 @@ func TestPickBadgeTime_PicksCreatedAtFloor(t *testing.T) {
 func TestPickBadgeTime_LastStartedBeatsCreatedAt(t *testing.T) {
 	created := time.Now().Add(-5 * 24 * time.Hour)
 	started := time.Now().Add(-10 * time.Minute)
-	got := pickBadgeTime(created, started, nil, time.Time{}, false)
+	got := pickBadgeTime(created, started, nil, time.Time{}, time.Time{}, false)
 	if !got.Equal(started) {
 		t.Errorf("LastStartedAt should beat older CreatedAt, expected %v, got %v", started, got)
 	}
@@ -40,7 +41,7 @@ func TestPickBadgeTime_HookEventBeatsLifecycle(t *testing.T) {
 	hookAt := time.Now().Add(-30 * time.Second)
 	hook := &session.HookStatus{UpdatedAt: hookAt}
 
-	got := pickBadgeTime(created, started, hook, time.Time{}, false)
+	got := pickBadgeTime(created, started, hook, time.Time{}, time.Time{}, false)
 	if !got.Equal(hookAt) {
 		t.Errorf("newer hook event should beat lifecycle floor, expected %v, got %v", hookAt, got)
 	}
@@ -49,7 +50,7 @@ func TestPickBadgeTime_HookEventBeatsLifecycle(t *testing.T) {
 func TestPickBadgeTime_NilHookIgnored(t *testing.T) {
 	created := time.Now().Add(-2 * time.Hour)
 	started := time.Now().Add(-1 * time.Hour)
-	got := pickBadgeTime(created, started, nil, time.Time{}, false)
+	got := pickBadgeTime(created, started, nil, time.Time{}, time.Time{}, false)
 	if !got.Equal(started) {
 		t.Errorf("nil hookEvent must be ignored, expected %v, got %v", started, got)
 	}
@@ -63,7 +64,7 @@ func TestPickBadgeTime_StaleHookIgnored(t *testing.T) {
 	started := time.Now().Add(-5 * time.Minute)
 	staleHook := &session.HookStatus{UpdatedAt: time.Now().Add(-3 * time.Hour)}
 
-	got := pickBadgeTime(created, started, staleHook, time.Time{}, false)
+	got := pickBadgeTime(created, started, staleHook, time.Time{}, time.Time{}, false)
 	if !got.Equal(started) {
 		t.Errorf("stale hook older than LastStartedAt must not win, expected %v, got %v", started, got)
 	}
@@ -75,7 +76,7 @@ func TestPickBadgeTime_ConfirmedActivityBeatsHook(t *testing.T) {
 	hook := &session.HookStatus{UpdatedAt: time.Now().Add(-1 * time.Minute)}
 	confirmed := time.Now().Add(-3 * time.Second)
 
-	got := pickBadgeTime(created, started, hook, confirmed, true)
+	got := pickBadgeTime(created, started, hook, time.Time{}, confirmed, true)
 	if !got.Equal(confirmed) {
 		t.Errorf("newer tmux-confirmed activity should beat hook event, expected %v, got %v", confirmed, got)
 	}
@@ -91,7 +92,7 @@ func TestPickBadgeTime_ConfirmedActivityBeatsLifecycleWithoutHooks(t *testing.T)
 	started := time.Now().Add(-2 * time.Hour)
 	confirmed := time.Now().Add(-15 * time.Second)
 
-	got := pickBadgeTime(created, started, nil, confirmed, true)
+	got := pickBadgeTime(created, started, nil, time.Time{}, confirmed, true)
 	if !got.Equal(confirmed) {
 		t.Errorf("with no hook installed, tmux confirmed activity should beat LastStartedAt, "+
 			"expected %v, got %v", confirmed, got)
@@ -107,7 +108,7 @@ func TestPickBadgeTime_UnobservedConfirmedIgnored(t *testing.T) {
 	started := time.Now().Add(-1 * time.Hour)
 	confirmedButUnobserved := time.Now() // would dominate if not gated
 
-	got := pickBadgeTime(created, started, nil, confirmedButUnobserved, false)
+	got := pickBadgeTime(created, started, nil, time.Time{}, confirmedButUnobserved, false)
 	if !got.Equal(started) {
 		t.Fatalf("confirmedObserved=false must cause the timestamp to be ignored, "+
 			"expected %v (LastStartedAt), got %v", started, got)
@@ -115,8 +116,36 @@ func TestPickBadgeTime_UnobservedConfirmedIgnored(t *testing.T) {
 }
 
 func TestPickBadgeTime_AllLayersZero(t *testing.T) {
-	got := pickBadgeTime(time.Time{}, time.Time{}, nil, time.Time{}, false)
+	got := pickBadgeTime(time.Time{}, time.Time{}, nil, time.Time{}, time.Time{}, false)
 	if !got.IsZero() {
 		t.Errorf("with no signals at all, the function must return the zero time, got %v", got)
+	}
+}
+
+func TestPickBadgeTime_PersistedActivityBeatsLifecycle(t *testing.T) {
+	// Issue #1846: the durable last_activity_at record is what survives a
+	// TUI restart after attach-return deleted the hook file. It must move
+	// the badge past the lifecycle floor exactly like a live hook event
+	// would have.
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	started := time.Now().Add(-2 * time.Hour)
+	persisted := time.Now().Add(-90 * time.Minute)
+
+	got := pickBadgeTime(created, started, nil, persisted, time.Time{}, false)
+	if !got.Equal(persisted) {
+		t.Errorf("persisted activity should beat older lifecycle floor, expected %v, got %v", persisted, got)
+	}
+}
+
+func TestPickBadgeTime_StalePersistedActivityIgnored(t *testing.T) {
+	// A restart after the last recorded activity must win — the persisted
+	// record can only move the badge forward, never backward.
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	persisted := time.Now().Add(-3 * time.Hour)
+	started := time.Now().Add(-5 * time.Minute)
+
+	got := pickBadgeTime(created, started, nil, persisted, time.Time{}, false)
+	if !got.Equal(started) {
+		t.Errorf("persisted activity older than LastStartedAt must not win, expected %v, got %v", started, got)
 	}
 }

--- a/internal/ui/session_activity_time_test.go
+++ b/internal/ui/session_activity_time_test.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #1846: the session-row badge and the preview's "⏱" line computed
+// "last activity" with two different formulas (pickBadgeTime vs
+// DisplayLastActivityTime), so the same session showed two different — and
+// both stale — ages. sessionActivityTime is the single composition both
+// surfaces now render from: pickBadgeTime's evidence layers, falling back
+// to LastAccessedAt only when no activity evidence beyond creation exists
+// (a TUI attach is a better floor than CreatedAt, but a peek must never
+// override real recorded activity).
+
+func TestSessionActivityTime_FallsBackToLastAccessed(t *testing.T) {
+	created := time.Now().Add(-3 * 24 * time.Hour)
+	accessed := time.Now().Add(-7 * time.Hour)
+
+	got := sessionActivityTime(created, time.Time{}, time.Time{}, accessed, time.Time{}, false, nil)
+	if !got.Equal(accessed) {
+		t.Errorf("with no activity evidence, LastAccessedAt should beat CreatedAt, expected %v, got %v", accessed, got)
+	}
+}
+
+func TestSessionActivityTime_EvidenceBeatsNewerAccess(t *testing.T) {
+	// Attaching to look at a quiet session is a peek, not activity: real
+	// recorded evidence wins even when the attach is newer.
+	created := time.Now().Add(-3 * 24 * time.Hour)
+	persisted := time.Now().Add(-2 * time.Hour)
+	accessed := time.Now().Add(-5 * time.Minute)
+
+	got := sessionActivityTime(created, time.Time{}, persisted, accessed, time.Time{}, false, nil)
+	if !got.Equal(persisted) {
+		t.Errorf("recorded activity must beat a newer attach, expected %v, got %v", persisted, got)
+	}
+}
+
+func TestSessionActivityTime_NoAccessNoEvidenceIsCreatedAt(t *testing.T) {
+	created := time.Now().Add(-2 * time.Hour)
+	got := sessionActivityTime(created, time.Time{}, time.Time{}, time.Time{}, time.Time{}, false, nil)
+	if !got.Equal(created) {
+		t.Errorf("with nothing but CreatedAt, expected %v, got %v", created, got)
+	}
+}
+
+func TestSessionActivityTime_LifecycleEvidenceSuppressesAccessFallback(t *testing.T) {
+	// A restart IS activity evidence: once present, LastAccessedAt no
+	// longer participates, even when the attach is newer than the restart.
+	created := time.Now().Add(-3 * 24 * time.Hour)
+	started := time.Now().Add(-2 * time.Hour)
+	accessed := time.Now().Add(-5 * time.Minute)
+
+	got := sessionActivityTime(created, started, time.Time{}, accessed, time.Time{}, false, nil)
+	if !got.Equal(started) {
+		t.Errorf("lifecycle evidence must suppress the access fallback, expected %v, got %v", started, got)
+	}
+}
+
+// TestPreviewActivityLine_UsesUnifiedActivitySource pins the preview's "⏱"
+// line to the shared composition. Pre-#1846 the preview ignored
+// LastStartedAt entirely (DisplayLastActivityTime fell straight to
+// LastAccessedAt/CreatedAt), so a session restarted 30 minutes ago showed a
+// days-old age while the row badge showed "30m ago".
+func TestPreviewActivityLine_UsesUnifiedActivitySource(t *testing.T) {
+	forceTrueColorProfile()
+
+	h := NewHome()
+	h.width = 120
+	h.height = 40
+	h.initialLoading = false
+
+	inst := session.NewInstance("preview-activity-unified", t.TempDir())
+	inst.Tool = "bash"
+	inst.Status = session.StatusIdle
+	inst.CreatedAt = time.Now().Add(-3 * 24 * time.Hour)
+	inst.LastAccessedAt = time.Now().Add(-8 * time.Hour)
+	inst.LastStartedAt = time.Now().Add(-30 * time.Minute)
+
+	h.instancesMu.Lock()
+	h.instances = []*session.Instance{inst}
+	h.instanceByID[inst.ID] = inst
+	h.instancesMu.Unlock()
+
+	h.flatItems = []session.Item{{Type: session.ItemTypeSession, Session: inst}}
+	h.cursor = 0
+	h.setHotkeys(resolveHotkeys(nil))
+
+	out := h.renderPreviewPane(60, 30)
+	if !strings.Contains(out, "30m ago") {
+		t.Fatalf("preview ⏱ line should show the 30m-old restart via the unified activity source, got:\n%s", out)
+	}
+}
+
+// TestSessionTimestamp_BadgeFallsBackToLastAccessed is the row-badge half
+// of the same agreement: with no activity evidence at all, the badge must
+// show the last attach instead of collapsing to CreatedAt ("2d 9h ago" in
+// the #1846 report).
+func TestSessionTimestamp_BadgeFallsBackToLastAccessed(t *testing.T) {
+	inst := &session.Instance{
+		ID:             "sess-ts-accessed-fallback",
+		Title:          "accessed-fallback",
+		CreatedAt:      time.Now().Add(-3 * 24 * time.Hour),
+		LastAccessedAt: time.Now().Add(-30 * time.Minute),
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if !strings.Contains(row, "30m ago") {
+		t.Fatalf("badge should fall back to LastAccessedAt when no activity evidence exists, got: %q", row)
+	}
+}

--- a/internal/ui/session_timestamps_test.go
+++ b/internal/ui/session_timestamps_test.go
@@ -160,26 +160,35 @@ func TestSessionTimestamp_HandlesNilTmuxSessionWithoutCrash(t *testing.T) {
 	}
 }
 
-// Regression pin: LastAccessedAt must NOT influence the badge. A session
-// created 5 days ago that the user just attached to is still "5d ago" by
-// the badge's definition of update — opening the session isn't itself
-// an update event.
-func TestSessionTimestamp_LastAccessedAtIgnored(t *testing.T) {
+// Regression pin: a peek must not override activity evidence. Opening a
+// session isn't itself an update event, so once ANY real evidence exists
+// (here: a restart 2h ago), a 30-second-old attach must not reset the
+// badge to "just now".
+//
+// #1846 note: this pin used to be stronger — LastAccessedAt was excluded
+// from the badge entirely, so a session with NO evidence beyond CreatedAt
+// showed the creation age while the preview showed the attach age: two
+// different answers for the same session, both wrong. sessionActivityTime
+// now uses LastAccessedAt as the no-evidence fallback (pinned by
+// TestSessionTimestamp_BadgeFallsBackToLastAccessed); this test keeps the
+// original principle for every case where evidence exists.
+func TestSessionTimestamp_PeekDoesNotOverrideEvidence(t *testing.T) {
 	now := time.Now()
 	inst := &session.Instance{
 		ID:             "sess-ts-attached",
 		Title:          "just-peeked",
 		CreatedAt:      now.Add(-5 * 24 * time.Hour),
-		LastAccessedAt: now.Add(-30 * time.Second), // would say "just now" if included
+		LastStartedAt:  now.Add(-2 * time.Hour),
+		LastAccessedAt: now.Add(-30 * time.Second), // would say "just now" if it won
 	}
 
 	row := renderRowWithTimestamps(t, inst, true)
 
 	if strings.Contains(row, "just now") {
 		t.Fatalf("attaching to a stale session must not reset the badge to 'just now'. "+
-			"LastAccessedAt was deliberately removed from the formula. Got: %q", row)
+			"A peek never overrides activity evidence. Got: %q", row)
 	}
-	if !strings.Contains(row, "5d ago") {
-		t.Fatalf("expected 5d ago (CreatedAt floor). Got: %q", row)
+	if !strings.Contains(row, "2h ago") {
+		t.Fatalf("expected 2h ago (LastStartedAt evidence). Got: %q", row)
 	}
 }


### PR DESCRIPTION
## What problem does this solve?

With "Show session timestamps" enabled, the row badge and the preview's "⏱" line can show two different — and both wildly wrong — ages for the same session. In the live capture behind #1846, a session whose agent was active ~1.5h earlier showed **"2d 9h ago"** in the list and **"7h 43m ago"** in the preview. Fixes #1846.

## Why this change

Two compounding causes (full forensics in the issue):

1. **Different formulas per surface.** The badge used `pickBadgeTime` (CreatedAt / LastStartedAt / hook event / confirmed tmux activity, no LastAccessedAt); the preview used `DisplayLastActivityTime` (confirmed activity → LastAccessedAt → CreatedAt, no hook evidence). Each degraded to a different stale fallback.
2. **All real-activity evidence was ephemeral.** Attach-return deletes the hook status file (deliberately — a fresh-looking "waiting" file would mask a pane killed by `/q`), tmux-confirmed activity is process-local, and `MarkAccessed` only reached SQLite on the next full save cycle.

The fix makes the evidence durable and the composition shared, following existing house patterns rather than inventing new ones:

- **`tool_data.last_activity_at`** — durable activity record using #1704's `last_started_at` extras-zone mechanism (no schema migration; legacy binaries preserve the key via `MergeToolDataExtras`, legacy rows read as zero). Folded from every *committed* hook observation (`UpdateHookStatus`, `UpdateStatus` cold load) — monotonic, so stale watcher replays never rewind it, and #1729's foreign-ephemeral rejects restore the pre-event value so a `claude -p` child is never credited. Persisted with the `WriteClaudeSessionBinding` targeted-`json_set` shape, throttled to one UPDATE per minute per session; `ClearHookStatus` force-flushes before deleting the hook file it summarizes.
- **`MarkAccessed` persists via a targeted single-row UPDATE**, so attach/detach survive a TUI exit that never runs a save cycle (a full `saveInstances` on the attach path was ruled out back in #1753; one indexed UPDATE is ~7.6µs, see Evidence).
- **`sessionActivityTime`** — one composition rendered by BOTH surfaces: `pickBadgeTime`'s evidence layers plus the new durable record, with `LastAccessedAt` participating only as the no-evidence fallback. The old "peeking isn't an update" pin is preserved wherever any evidence exists (`TestSessionTimestamp_PeekDoesNotOverrideEvidence`); the one deliberate flip is the evidence-free case, where showing the last attach beats claiming days-old CreatedAt — that asymmetry was exactly the badge/preview disagreement.
- **`DisplayLastActivityTime`** folds the durable record in, so `status --stale`'s `staleActivityEvidence` (#1704) keeps working after attach-return has deleted the hook file it previously depended on.

Web parity (the sidebar serves raw `lastAccessedAt`) is intentionally left as a follow-up to keep this diff targeted; it benefits indirectly because `last_accessed` is now durably updated.

## User impact

Both timestamp surfaces show the same age for a session, and that age reflects the last real agent activity — surviving attach/detach cycles and TUI restarts. Sessions with no recorded activity (legacy rows, hookless tools) now show the last attach instead of the creation age.

## Evidence

Live repro (before), observed at 01:21 local on a real deck — one session, three answers:

    row badge:  "2d 9h ago"    <- CreatedAt          Jul 31 15:57
    preview ⏱:  "7h 43m ago"   <- LastAccessedAt     Aug  2 17:38
    real activity (hook .sid mtime + tool_data.claude_detected_at):
                                                     Aug  2 23:55 (~1.5h before)
    hooks dir:  <id>.sid present, <id>.json DELETED by attach-return

After — the repro shape is pinned by tests that fail on main:

    $ go test ./internal/session/ -run 'LastActivityAt|ClearHookStatus_Preserves|UpdateHookStatus_|MarkAccessed_Persists|DisplayLastActivityTime_Prefers' -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/session 0.996s
    $ go test ./internal/ui/ -run 'PickBadgeTime|SessionActivityTime|PreviewActivityLine|SessionTimestamp' -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/ui 0.684s

`TestClearHookStatus_PreservesActivityEvidence` was mutation-checked: weakening the force-flush to the throttled path makes it fail with the DB stuck on the older timestamp.

Hot-path timing (this touches the list render and attach path):

    BenchmarkPickBadgeTimeOld-12          71795652   33.02 ns/op   (badge composition, before)
    BenchmarkSessionActivityTimeNew-12    70608135   34.41 ns/op   (badge composition, after)
    BenchmarkWriteLastAccessed-12           156468    7577 ns/op   (attach-path targeted UPDATE)

Sandboxed suite: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — all packages ok except pre-existing environment flakes (`TestIssue1421_CleanStaleSSHSockets`, `TestPerf_*` budget tests), verified identical on a clean `upstream/main` worktree on the same machine.

Self-check notes: revert-check reports the new tests don't compile on base — expected, they exercise new symbols (`WriteLastActivityAtToToolData`, `sessionActivityTime`, the extended `pickBadgeTime`). Diff size is +778/−47, of which ~570 lines are tests (`last_activity_persist_test.go`, `session_activity_time_test.go`, extended pins); the production diff is ~210 lines across the four layers the bug spans (persist helpers, instance fold points, two statedb helpers, two render sites) and doesn't split without leaving one of the two surfaces lying.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):**

## What actually bothered you

Active agent-deck user; noticed the session list and preview showing two contradictory "ago" times, both far off from when they had last used the session, and asked for the root cause to be found and fixed upstream.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session activity timestamps are now retained across restarts.
  * Activity indicators and previews more accurately reflect recorded session activity.
  * Recent access times no longer incorrectly override stronger activity evidence.
  * Hook activity is preserved when hook status is cleared.
  * Stale or rejected activity updates no longer overwrite newer activity records.
* **Tests**
  * Added coverage for activity persistence, timestamp precedence, stale events, hook handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
