### PR TITLE
fix(opencode): avoid leaking CLI session polls

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -44,8 +44,13 @@ var (
 	uuidPatternRE               = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	geminiPromptRE              = regexp.MustCompile(`^(>|>>>|\$|❯|➜|gemini>|✦)\s*$`)
 	shellPromptRE               = regexp.MustCompile(`^[\s]*(>|>>>|\$|❯|➜|#|%)\s*$`)
-	openCodeCLIQueryGroup       singleflight.Group
-	openCodeCLIQueryCache       = struct {
+	openCodeSessionHTTPClient   = &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	openCodeCLIQueryGroup singleflight.Group
+	openCodeCLIQueryCache = struct {
 		sync.Mutex
 		entries map[string]openCodeCLIQueryCacheEntry
 	}{entries: make(map[string]openCodeCLIQueryCacheEntry)}
@@ -2580,13 +2585,13 @@ func (i *Instance) queryOpenCodeSessionsHTTP(port int) ([]openCodeSessionMetadat
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := openCodeSessionHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("OpenCode session endpoint returned %s", resp.Status)
+		return nil, fmt.Errorf("opencode session endpoint returned %s", resp.Status)
 	}
 
 	var payload []openCodeHTTPSessionMetadata

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -110,6 +110,9 @@ const (
 	opencodeRotationScanInterval   = 15 * time.Second
 	opencodeRotationActivityWindow = 30 * time.Second
 	opencodeStartupTimeSkew        = 5 * time.Second
+	// openCodeSessionResponseLimit bounds allocation if a persisted OpenCode
+	// port is later occupied by an unrelated loopback listener.
+	openCodeSessionResponseLimit = 8 << 20
 	// opencodeSSEFreshnessWindow bounds how long an SSE-derived status stays
 	// authoritative without stream traffic (issue #1614). OpenCode heartbeats
 	// its /event stream roughly every 10s, and the watcher refreshes the
@@ -2388,7 +2391,10 @@ func (i *Instance) watchForOpenCodeSession() {
 		time.Sleep(pollInterval)
 		attempt++
 
-		if i.OpenCodeSessionID != "" {
+		i.mu.RLock()
+		alreadyDetected := i.OpenCodeSessionID != ""
+		i.mu.RUnlock()
+		if alreadyDetected {
 			sessionLog.Debug("opencode_watcher_already_set")
 			return
 		}
@@ -2411,12 +2417,24 @@ func (i *Instance) watchForOpenCodeSession() {
 
 // setOpenCodeSession sets the session ID and stores it in tmux environment.
 func (i *Instance) setOpenCodeSession(sessionID string) {
+	i.mu.Lock()
+	i.setOpenCodeSessionLocked(sessionID)
+	tmuxSession := i.tmuxSession
+	i.mu.Unlock()
+	i.syncOpenCodeSessionEnvironment(tmuxSession, sessionID)
+}
+
+// setOpenCodeSessionLocked updates in-memory binding state. The caller must
+// hold i.mu for writing.
+func (i *Instance) setOpenCodeSessionLocked(sessionID string) {
 	i.OpenCodeSessionID = sessionID
 	i.OpenCodeDetectedAt = time.Now()
 	i.OpenCodeStartedAt = 0
+}
 
-	if i.tmuxSession != nil {
-		if err := i.tmuxSession.SetEnvironment("OPENCODE_SESSION_ID", sessionID); err != nil {
+func (i *Instance) syncOpenCodeSessionEnvironment(tmuxSession *tmux.Session, sessionID string) {
+	if tmuxSession != nil {
+		if err := tmuxSession.SetEnvironment("OPENCODE_SESSION_ID", sessionID); err != nil {
 			sessionLog.Warn("opencode_set_env_failed", slog.String("error", err.Error()))
 		}
 	}
@@ -2434,7 +2452,10 @@ type openCodeHTTPSessionMetadata struct {
 	ID        string `json:"id"`
 	Directory string `json:"directory"`
 	Path      string `json:"path"`
-	Time      struct {
+	Location  struct {
+		Directory string `json:"directory"`
+	} `json:"location"`
+	Time struct {
 		Created int64 `json:"created"`
 		Updated int64 `json:"updated"`
 	} `json:"time"`
@@ -2533,42 +2554,49 @@ func findBestOpenCodeSession(sessions []openCodeSessionMetadata, projectPath, cu
 // machines this still usually succeeds, and on genuine hangs the cache and
 // lastOpenCodeScanAt schedule a later retry instead of spawning a poll storm.
 func (i *Instance) queryOpenCodeSession() string {
+	i.mu.RLock()
+	port := i.OpenCodePort
+	projectPath := i.ProjectPath
+	currentID := i.OpenCodeSessionID
+	startedAt := i.OpenCodeStartedAt
+	i.mu.RUnlock()
+
 	var sessions []openCodeSessionMetadata
-	if port := i.GetOpenCodePort(); port > 0 {
+	if port > 0 {
 		var err error
-		sessions, err = i.queryOpenCodeSessionsHTTP(port)
+		sessions, err = i.queryOpenCodeSessionsHTTP(port, projectPath)
 		if err != nil {
 			sessionLog.Debug("opencode_http_query_failed",
-				slog.String("dir", i.ProjectPath),
+				slog.String("dir", projectPath),
 				slog.Int("port", port),
 				slog.String("error", err.Error()),
 			)
 			return ""
 		}
 	} else {
-		sessions = i.queryOpenCodeSessionsCLI()
+		sessions = i.queryOpenCodeSessionsCLI(projectPath)
 	}
 
 	sessionLog.Debug("opencode_parsed_sessions", slog.Int("count", len(sessions)))
 
 	var activityAt int64
-	if currentID := i.OpenCodeSessionID; currentID != "" {
+	if currentID != "" {
 		lastActivity := i.GetLastActivityTime()
 		if !lastActivity.IsZero() && time.Since(lastActivity) <= opencodeRotationActivityWindow {
 			activityAt = lastActivity.UnixMilli()
 		}
 	}
 
-	bestMatch := findBestOpenCodeSession(sessions, i.ProjectPath, i.OpenCodeSessionID, i.OpenCodeStartedAt, activityAt)
+	bestMatch := findBestOpenCodeSession(sessions, projectPath, currentID, startedAt, activityAt)
 	sessionLog.Debug(
 		"opencode_best_match",
 		slog.String("session_id", bestMatch),
-		slog.String("current_id", i.OpenCodeSessionID),
+		slog.String("current_id", currentID),
 	)
 	return bestMatch
 }
 
-func (i *Instance) queryOpenCodeSessionsHTTP(port int) ([]openCodeSessionMetadata, error) {
+func (i *Instance) queryOpenCodeSessionsHTTP(port int, projectPath string) ([]openCodeSessionMetadata, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
@@ -2578,7 +2606,7 @@ func (i *Instance) queryOpenCodeSessionsHTTP(port int) ([]openCodeSessionMetadat
 		Path:   "/session",
 	}
 	query := endpoint.Query()
-	query.Set("directory", i.ProjectPath)
+	query.Set("directory", projectPath)
 	endpoint.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
@@ -2595,15 +2623,19 @@ func (i *Instance) queryOpenCodeSessionsHTTP(port int) ([]openCodeSessionMetadat
 	}
 
 	var payload []openCodeHTTPSessionMetadata
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, openCodeSessionResponseLimit)).Decode(&payload); err != nil {
 		return nil, err
 	}
 
 	sessions := make([]openCodeSessionMetadata, 0, len(payload))
 	for _, session := range payload {
+		directory := session.Directory
+		if directory == "" {
+			directory = session.Location.Directory
+		}
 		sessions = append(sessions, openCodeSessionMetadata{
 			ID:        session.ID,
-			Directory: session.Directory,
+			Directory: directory,
 			Path:      session.Path,
 			Created:   session.Time.Created,
 			Updated:   session.Time.Updated,
@@ -2612,8 +2644,8 @@ func (i *Instance) queryOpenCodeSessionsHTTP(port int) ([]openCodeSessionMetadat
 	return sessions, nil
 }
 
-func (i *Instance) queryOpenCodeSessionsCLI() []openCodeSessionMetadata {
-	cacheKey := normalizePath(i.ProjectPath)
+func (i *Instance) queryOpenCodeSessionsCLI(projectPath string) []openCodeSessionMetadata {
+	cacheKey := normalizePath(projectPath)
 	if sessions, ok := cachedOpenCodeCLISessions(cacheKey); ok {
 		return sessions
 	}
@@ -2622,11 +2654,15 @@ func (i *Instance) queryOpenCodeSessionsCLI() []openCodeSessionMetadata {
 		if sessions, ok := cachedOpenCodeCLISessions(cacheKey); ok {
 			return sessions, nil
 		}
-		sessions := i.runOpenCodeSessionsCLI()
+		sessions := i.runOpenCodeSessionsCLI(projectPath)
 		cacheOpenCodeCLISessions(cacheKey, sessions)
 		return sessions, nil
 	})
-	return append([]openCodeSessionMetadata(nil), result.([]openCodeSessionMetadata)...)
+	sessions, ok := result.([]openCodeSessionMetadata)
+	if !ok {
+		return nil
+	}
+	return append([]openCodeSessionMetadata(nil), sessions...)
 }
 
 func cachedOpenCodeCLISessions(cacheKey string) ([]openCodeSessionMetadata, bool) {
@@ -2654,22 +2690,22 @@ func cacheOpenCodeCLISessions(cacheKey string, sessions []openCodeSessionMetadat
 	}
 }
 
-func (i *Instance) runOpenCodeSessionsCLI() []openCodeSessionMetadata {
+func (i *Instance) runOpenCodeSessionsCLI(projectPath string) []openCodeSessionMetadata {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	// Run: opencode session list --format json
 	cmd := exec.CommandContext(ctx, "opencode", "session", "list", "--format", "json")
-	cmd.Dir = i.ProjectPath
+	cmd.Dir = projectPath
 	cmd.WaitDelay = 500 * time.Millisecond
 
-	sessionLog.Debug("opencode_query_sessions", slog.String("dir", i.ProjectPath))
+	sessionLog.Debug("opencode_query_sessions", slog.String("dir", projectPath))
 
 	output, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			sessionLog.Warn("opencode_query_timeout",
-				slog.String("dir", i.ProjectPath),
+				slog.String("dir", projectPath),
 				slog.String("instance_id", i.ID),
 			)
 		} else {
@@ -5975,10 +6011,7 @@ func (i *Instance) updateOpenCodeSession(force bool) {
 	i.mu.Unlock()
 
 	candidate := i.queryOpenCodeSession()
-
-	i.mu.Lock()
 	i.applyOpenCodeSessionCandidate(candidate)
-	i.mu.Unlock()
 }
 
 func (i *Instance) applyOpenCodeSessionCandidate(candidate string) bool {
@@ -5986,10 +6019,12 @@ func (i *Instance) applyOpenCodeSessionCandidate(candidate string) bool {
 		return false
 	}
 
+	i.mu.Lock()
 	if candidate == i.OpenCodeSessionID {
 		if i.OpenCodeDetectedAt.IsZero() {
 			i.OpenCodeDetectedAt = time.Now()
 		}
+		i.mu.Unlock()
 		return false
 	}
 
@@ -6011,7 +6046,10 @@ func (i *Instance) applyOpenCodeSessionCandidate(candidate string) bool {
 		slog.String("new_id", candidate),
 	)
 
-	i.setOpenCodeSession(candidate)
+	i.setOpenCodeSessionLocked(candidate)
+	tmuxSession := i.tmuxSession
+	i.mu.Unlock()
+	i.syncOpenCodeSessionEnvironment(tmuxSession, candidate)
 	return true
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -13,6 +13,8 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +28,7 @@ import (
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/asheshgoplani/agent-deck/internal/docker"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
@@ -41,6 +44,11 @@ var (
 	uuidPatternRE               = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	geminiPromptRE              = regexp.MustCompile(`^(>|>>>|\$|❯|➜|gemini>|✦)\s*$`)
 	shellPromptRE               = regexp.MustCompile(`^[\s]*(>|>>>|\$|❯|➜|#|%)\s*$`)
+	openCodeCLIQueryGroup       singleflight.Group
+	openCodeCLIQueryCache       = struct {
+		sync.Mutex
+		entries map[string]openCodeCLIQueryCacheEntry
+	}{entries: make(map[string]openCodeCLIQueryCacheEntry)}
 )
 
 // Status represents the current state of a session
@@ -255,7 +263,7 @@ type Instance struct {
 	OpenCodeDetectedAt time.Time `json:"opencode_detected_at,omitempty"`
 	OpenCodeStartedAt  int64     `json:"-"`                       // Unix millis when we started OpenCode (for session matching, not persisted)
 	OpenCodePort       int       `json:"opencode_port,omitempty"` // Localhost port of OpenCode's event server (issue #1614); 0 = none
-	lastOpenCodeScanAt time.Time // Rate-limits expensive `opencode session list` scans
+	lastOpenCodeScanAt time.Time // Rate-limits OpenCode session-discovery scans
 
 	// Codex CLI integration
 	CodexSessionID  string    `json:"codex_session_id,omitempty"`
@@ -2323,8 +2331,9 @@ func codexRolloutExistsInHome(sessionID, codexHome string) bool {
 
 // detectOpenCodeSessionAsync detects the OpenCode session ID after startup
 // OpenCode generates session IDs internally (format: ses_XXXXX)
-// We query "opencode session list --format json" and match by project directory,
-// picking the most recently updated session (since OpenCode auto-resumes the last session)
+// We query the managed OpenCode HTTP server (or the bounded compatibility CLI
+// fallback) and match by project directory, picking the most recently updated
+// session since OpenCode auto-resumes the last session.
 func (i *Instance) detectOpenCodeSessionAsync() {
 	time.Sleep(1 * time.Second)
 
@@ -2416,6 +2425,21 @@ type openCodeSessionMetadata struct {
 	Updated   int64  `json:"updated"`
 }
 
+type openCodeHTTPSessionMetadata struct {
+	ID        string `json:"id"`
+	Directory string `json:"directory"`
+	Path      string `json:"path"`
+	Time      struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+	} `json:"time"`
+}
+
+type openCodeCLIQueryCacheEntry struct {
+	queriedAt time.Time
+	sessions  []openCodeSessionMetadata
+}
+
 // findBestOpenCodeSession keeps an existing binding if that session still exists
 // for the project. Fresh launches stay unbound until OpenCode persists a session
 // created during the current startup, which prevents adopting older same-project
@@ -2489,19 +2513,143 @@ func findBestOpenCodeSession(sessions []openCodeSessionMetadata, projectPath, cu
 	return bestMatch
 }
 
-// queryOpenCodeSession queries OpenCode CLI for sessions matching our project
-// directory. Unbound instances adopt the most recently updated session, while
-// already-bound instances keep their current ID as long as it still exists.
+// queryOpenCodeSession queries the managed OpenCode HTTP server for sessions
+// matching our project directory. Unbound instances adopt the most recently
+// updated session, while already-bound instances keep their current ID as long
+// as it still exists. Instances without a managed port retain a coalesced,
+// rate-limited CLI compatibility path.
 //
-// Bounded wall-clock cost:
+// CLI fallback wall-clock bounds:
 //   - 5s context deadline for the subprocess itself.
 //   - WaitDelay=500ms so cmd.Output() returns after the context fires even if
 //     an opencode grandchild keeps stdout pipes open (Go 1.20+).
 //
 // 5s is the ceiling for cold opencode CLI on large session stores; on slower
-// machines this still usually succeeds, and on genuine hangs we log a Warn
-// and lastOpenCodeScanAt schedules the next retry 15s later.
+// machines this still usually succeeds, and on genuine hangs the cache and
+// lastOpenCodeScanAt schedule a later retry instead of spawning a poll storm.
 func (i *Instance) queryOpenCodeSession() string {
+	var sessions []openCodeSessionMetadata
+	if port := i.GetOpenCodePort(); port > 0 {
+		var err error
+		sessions, err = i.queryOpenCodeSessionsHTTP(port)
+		if err != nil {
+			sessionLog.Debug("opencode_http_query_failed",
+				slog.String("dir", i.ProjectPath),
+				slog.Int("port", port),
+				slog.String("error", err.Error()),
+			)
+			return ""
+		}
+	} else {
+		sessions = i.queryOpenCodeSessionsCLI()
+	}
+
+	sessionLog.Debug("opencode_parsed_sessions", slog.Int("count", len(sessions)))
+
+	var activityAt int64
+	if currentID := i.OpenCodeSessionID; currentID != "" {
+		lastActivity := i.GetLastActivityTime()
+		if !lastActivity.IsZero() && time.Since(lastActivity) <= opencodeRotationActivityWindow {
+			activityAt = lastActivity.UnixMilli()
+		}
+	}
+
+	bestMatch := findBestOpenCodeSession(sessions, i.ProjectPath, i.OpenCodeSessionID, i.OpenCodeStartedAt, activityAt)
+	sessionLog.Debug(
+		"opencode_best_match",
+		slog.String("session_id", bestMatch),
+		slog.String("current_id", i.OpenCodeSessionID),
+	)
+	return bestMatch
+}
+
+func (i *Instance) queryOpenCodeSessionsHTTP(port int) ([]openCodeSessionMetadata, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	endpoint := url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(port)),
+		Path:   "/session",
+	}
+	query := endpoint.Query()
+	query.Set("directory", i.ProjectPath)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OpenCode session endpoint returned %s", resp.Status)
+	}
+
+	var payload []openCodeHTTPSessionMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	sessions := make([]openCodeSessionMetadata, 0, len(payload))
+	for _, session := range payload {
+		sessions = append(sessions, openCodeSessionMetadata{
+			ID:        session.ID,
+			Directory: session.Directory,
+			Path:      session.Path,
+			Created:   session.Time.Created,
+			Updated:   session.Time.Updated,
+		})
+	}
+	return sessions, nil
+}
+
+func (i *Instance) queryOpenCodeSessionsCLI() []openCodeSessionMetadata {
+	cacheKey := normalizePath(i.ProjectPath)
+	if sessions, ok := cachedOpenCodeCLISessions(cacheKey); ok {
+		return sessions
+	}
+
+	result, _, _ := openCodeCLIQueryGroup.Do(cacheKey, func() (any, error) {
+		if sessions, ok := cachedOpenCodeCLISessions(cacheKey); ok {
+			return sessions, nil
+		}
+		sessions := i.runOpenCodeSessionsCLI()
+		cacheOpenCodeCLISessions(cacheKey, sessions)
+		return sessions, nil
+	})
+	return append([]openCodeSessionMetadata(nil), result.([]openCodeSessionMetadata)...)
+}
+
+func cachedOpenCodeCLISessions(cacheKey string) ([]openCodeSessionMetadata, bool) {
+	now := time.Now()
+	openCodeCLIQueryCache.Lock()
+	defer openCodeCLIQueryCache.Unlock()
+	if cached, ok := openCodeCLIQueryCache.entries[cacheKey]; ok && now.Sub(cached.queriedAt) < opencodeRotationScanInterval {
+		return append([]openCodeSessionMetadata(nil), cached.sessions...), true
+	}
+	return nil, false
+}
+
+func cacheOpenCodeCLISessions(cacheKey string, sessions []openCodeSessionMetadata) {
+	now := time.Now()
+	openCodeCLIQueryCache.Lock()
+	defer openCodeCLIQueryCache.Unlock()
+	for key, cached := range openCodeCLIQueryCache.entries {
+		if now.Sub(cached.queriedAt) >= opencodeRotationScanInterval {
+			delete(openCodeCLIQueryCache.entries, key)
+		}
+	}
+	openCodeCLIQueryCache.entries[cacheKey] = openCodeCLIQueryCacheEntry{
+		queriedAt: now,
+		sessions:  append([]openCodeSessionMetadata(nil), sessions...),
+	}
+}
+
+func (i *Instance) runOpenCodeSessionsCLI() []openCodeSessionMetadata {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -2522,7 +2670,7 @@ func (i *Instance) queryOpenCodeSession() string {
 		} else {
 			sessionLog.Debug("opencode_query_failed", slog.String("error", err.Error()))
 		}
-		return ""
+		return nil
 	}
 
 	sessionLog.Debug("opencode_session_data_size", slog.Int("bytes", len(output)))
@@ -2533,26 +2681,9 @@ func (i *Instance) queryOpenCodeSession() string {
 
 	if err := json.Unmarshal(output, &sessions); err != nil {
 		sessionLog.Debug("opencode_parse_failed", slog.String("error", err.Error()))
-		return ""
+		return nil
 	}
-
-	sessionLog.Debug("opencode_parsed_sessions", slog.Int("count", len(sessions)))
-
-	var activityAt int64
-	if currentID := i.OpenCodeSessionID; currentID != "" {
-		lastActivity := i.GetLastActivityTime()
-		if !lastActivity.IsZero() && time.Since(lastActivity) <= opencodeRotationActivityWindow {
-			activityAt = lastActivity.UnixMilli()
-		}
-	}
-
-	bestMatch := findBestOpenCodeSession(sessions, i.ProjectPath, i.OpenCodeSessionID, i.OpenCodeStartedAt, activityAt)
-	sessionLog.Debug(
-		"opencode_best_match",
-		slog.String("session_id", bestMatch),
-		slog.String("current_id", i.OpenCodeSessionID),
-	)
-	return bestMatch
+	return sessions
 }
 
 // normalizePath normalizes a file path for comparison
@@ -5813,15 +5944,15 @@ func (i *Instance) UpdateGeminiSession(excludeIDs map[string]bool) {
 	i.updateGeminiLatestPrompt()
 }
 
-// UpdateOpenCodeSession refreshes the OpenCode session ID from OpenCode CLI
-// state without stealing a different tab's session from the same project.
+// UpdateOpenCodeSession refreshes the OpenCode session ID from OpenCode state
+// without stealing a different tab's session from the same project.
 func (i *Instance) UpdateOpenCodeSession() {
 	i.updateOpenCodeSession(false)
 }
 
 // updateOpenCodeSession self-manages i.mu: state reads/writes happen under the
-// lock but the queryOpenCodeSession subprocess runs outside it, so a slow
-// opencode CLI cannot starve render-path RLocks on this instance.
+// lock but queryOpenCodeSession I/O runs outside it, so a slow OpenCode server
+// or compatibility CLI cannot starve render-path RLocks on this instance.
 //
 // Contract: callers MUST NOT hold i.mu when invoking this function.
 func (i *Instance) updateOpenCodeSession(force bool) {

--- a/internal/session/opencode_session_discovery_test.go
+++ b/internal/session/opencode_session_discovery_test.go
@@ -7,9 +7,24 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
+
+func setFakeOpenCodePath(t *testing.T, script string, includeSystemPath bool) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeBin, "opencode"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	pathValue := fakeBin
+	if includeSystemPath && os.Getenv("PATH") != "" {
+		pathValue += string(os.PathListSeparator) + os.Getenv("PATH")
+	}
+	t.Setenv("PATH", pathValue)
+}
 
 func TestUpdateOpenCodeSession_ManagedPortUsesHTTPNestedTimes(t *testing.T) {
 	projectPath := t.TempDir()
@@ -22,19 +37,14 @@ func TestUpdateOpenCodeSession_ManagedPortUsesHTTPNestedTimes(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `[
 			{"id":"ses_OLD","directory":%q,"time":{"created":1000,"updated":2000}},
-			{"id":"ses_NEW","directory":%q,"time":{"created":3000,"updated":4000}},
+			{"id":"ses_NEW","location":{"directory":%q},"time":{"created":3000,"updated":4000}},
 			{"id":"ses_OTHER","directory":"/another/project","time":{"created":5000,"updated":6000}}
 		]`, projectPath, projectPath)
 	})
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
-	fakeBin := t.TempDir()
-	fakeOpenCode := filepath.Join(fakeBin, "opencode")
-	if err := os.WriteFile(fakeOpenCode, []byte("#!/bin/sh\nprintf '[]'\n"), 0o755); err != nil {
-		t.Fatalf("write fake opencode: %v", err)
-	}
-	t.Setenv("PATH", fakeBin)
+	setFakeOpenCodePath(t, "#!/bin/sh\nprintf '[]'\n", false)
 
 	inst := &Instance{
 		Tool:         "opencode",
@@ -62,13 +72,8 @@ func TestQueryOpenCodeSession_ManagedPortRetriesHTTPAfterFailure(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	marker := filepath.Join(t.TempDir(), "cli-invoked")
-	fakeBin := t.TempDir()
-	fakeOpenCode := filepath.Join(fakeBin, "opencode")
-	script := fmt.Sprintf("#!/bin/sh\ntouch %q\nprintf '[]'\n", marker)
-	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake opencode: %v", err)
-	}
-	t.Setenv("PATH", fakeBin)
+	script := fmt.Sprintf("#!/bin/sh\nprintf x > %q\nprintf '[]'\n", marker)
+	setFakeOpenCodePath(t, script, false)
 
 	inst := &Instance{
 		Tool:         "opencode",
@@ -100,6 +105,8 @@ func TestQueryOpenCodeSession_ManagedPortRefusesRedirect(t *testing.T) {
 
 	redirect := httptest.NewServer(http.RedirectHandler(target.URL, http.StatusTemporaryRedirect))
 	t.Cleanup(redirect.Close)
+	cliMarker := filepath.Join(t.TempDir(), "cli-invoked")
+	setFakeOpenCodePath(t, fmt.Sprintf("#!/bin/sh\nprintf x > %q\nprintf '[]'\n", cliMarker), false)
 	inst := &Instance{
 		Tool:         "opencode",
 		ProjectPath:  projectPath,
@@ -112,6 +119,59 @@ func TestQueryOpenCodeSession_ManagedPortRefusesRedirect(t *testing.T) {
 	if got := redirectedRequests.Load(); got != 0 {
 		t.Fatalf("redirect target request count = %d, want 0", got)
 	}
+	if _, err := os.Stat(cliMarker); !os.IsNotExist(err) {
+		t.Fatalf("redirect invoked CLI; marker stat error = %v", err)
+	}
+}
+
+func TestQueryOpenCodeSession_SnapshotsBindingWhileHTTPIsInFlight(t *testing.T) {
+	projectPath := t.TempDir()
+	requestStarted := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseResponse
+		fmt.Fprintf(w, `[
+			{"id":"ses_OLD","directory":%q,"time":{"created":1000,"updated":2000}},
+			{"id":"ses_NEW","directory":%q,"time":{"created":3000,"updated":4000}}
+		]`, projectPath, projectPath)
+	}))
+	t.Cleanup(server.Close)
+
+	inst := &Instance{
+		Tool:              "opencode",
+		ProjectPath:       projectPath,
+		OpenCodePort:      server.Listener.Addr().(*net.TCPAddr).Port,
+		OpenCodeSessionID: "ses_OLD",
+	}
+	result := make(chan string, 1)
+	go func() { result <- inst.queryOpenCodeSession() }()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("HTTP query did not start")
+	}
+	inst.setOpenCodeSession("ses_NEW")
+	close(releaseResponse)
+
+	if got := <-result; got != "ses_OLD" {
+		t.Fatalf("query result = %q, want snapshotted binding ses_OLD", got)
+	}
+}
+
+func TestQueryOpenCodeSessionsHTTP_RejectsOversizedResponse(t *testing.T) {
+	const oversizedPayload = (8 << 20) + 1024
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `[{"id":%q,"directory":"/project","time":{"created":1000,"updated":2000}}]`, strings.Repeat("x", oversizedPayload))
+	}))
+	t.Cleanup(server.Close)
+
+	inst := &Instance{Tool: "opencode", ProjectPath: "/project"}
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+	if _, err := inst.queryOpenCodeSessionsHTTP(port, inst.ProjectPath); err == nil {
+		t.Fatal("oversized OpenCode session response unexpectedly succeeded")
+	}
 }
 
 func TestQueryOpenCodeSession_NoManagedPortRateLimitsCLIFallback(t *testing.T) {
@@ -119,13 +179,8 @@ func TestQueryOpenCodeSession_NoManagedPortRateLimitsCLIFallback(t *testing.T) {
 	payload := fmt.Sprintf(`[{"id":"ses_COMPAT","directory":%q,"created":1000,"updated":2000}]`, projectPath)
 
 	marker := filepath.Join(t.TempDir(), "cli-invocations")
-	fakeBin := t.TempDir()
-	fakeOpenCode := filepath.Join(fakeBin, "opencode")
 	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\nprintf '%%s\\n' %q\n", marker, payload)
-	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake opencode: %v", err)
-	}
-	t.Setenv("PATH", fakeBin)
+	setFakeOpenCodePath(t, script, false)
 
 	inst := &Instance{Tool: "opencode", ProjectPath: projectPath}
 	for attempt := 0; attempt < 2; attempt++ {
@@ -148,13 +203,8 @@ func TestQueryOpenCodeSession_NoManagedPortCoalescesConcurrentCLIFallback(t *tes
 	payload := fmt.Sprintf(`[{"id":"ses_COALESCED","directory":%q,"created":1000,"updated":2000}]`, projectPath)
 
 	marker := filepath.Join(t.TempDir(), "cli-invocations")
-	fakeBin := t.TempDir()
-	fakeOpenCode := filepath.Join(fakeBin, "opencode")
-	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\n/bin/sleep 1\nprintf '%%s\\n' %q\n", marker, payload)
-	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake opencode: %v", err)
-	}
-	t.Setenv("PATH", fakeBin)
+	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\nsleep 1\nprintf '%%s\\n' %q\n", marker, payload)
+	setFakeOpenCodePath(t, script, true)
 
 	inst := &Instance{Tool: "opencode", ProjectPath: projectPath}
 	const callers = 8

--- a/internal/session/opencode_session_discovery_test.go
+++ b/internal/session/opencode_session_discovery_test.go
@@ -1,0 +1,178 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func TestUpdateOpenCodeSession_ManagedPortUsesHTTPNestedTimes(t *testing.T) {
+	projectPath := t.TempDir()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("directory"); got != projectPath {
+			t.Errorf("directory query = %q, want %q", got, projectPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[
+			{"id":"ses_OLD","directory":%q,"time":{"created":1000,"updated":2000}},
+			{"id":"ses_NEW","directory":%q,"time":{"created":3000,"updated":4000}},
+			{"id":"ses_OTHER","directory":"/another/project","time":{"created":5000,"updated":6000}}
+		]`, projectPath, projectPath)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	// The pre-fix implementation invokes the CLI even with a managed port.
+	// Keep that RED path hermetic: it must never reach the installed OpenCode.
+	fakeBin := t.TempDir()
+	fakeOpenCode := filepath.Join(fakeBin, "opencode")
+	if err := os.WriteFile(fakeOpenCode, []byte("#!/bin/sh\nprintf '[]'\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	inst := &Instance{
+		Tool:         "opencode",
+		ProjectPath:  projectPath,
+		OpenCodePort: server.Listener.Addr().(*net.TCPAddr).Port,
+	}
+	inst.UpdateOpenCodeSession()
+
+	if got := inst.OpenCodeSessionID; got != "ses_NEW" {
+		t.Fatalf("OpenCodeSessionID = %q, want %q", got, "ses_NEW")
+	}
+}
+
+func TestQueryOpenCodeSession_ManagedPortRetriesHTTPAfterFailure(t *testing.T) {
+	projectPath := t.TempDir()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			http.Error(w, "warming up", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[{"id":"ses_READY","directory":%q,"time":{"created":1000,"updated":2000}}]`, projectPath)
+	}))
+	t.Cleanup(server.Close)
+
+	marker := filepath.Join(t.TempDir(), "cli-invoked")
+	fakeBin := t.TempDir()
+	fakeOpenCode := filepath.Join(fakeBin, "opencode")
+	script := fmt.Sprintf("#!/bin/sh\ntouch %q\nprintf '[]'\n", marker)
+	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	inst := &Instance{
+		Tool:         "opencode",
+		ProjectPath:  projectPath,
+		OpenCodePort: server.Listener.Addr().(*net.TCPAddr).Port,
+	}
+	if got := inst.queryOpenCodeSession(); got != "" {
+		t.Fatalf("first query session ID = %q after HTTP failure, want empty", got)
+	}
+	if got := inst.queryOpenCodeSession(); got != "ses_READY" {
+		t.Fatalf("retry session ID = %q, want ses_READY", got)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("HTTP request count = %d, want 2", got)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("managed-port retry invoked CLI; marker stat error = %v", err)
+	}
+}
+
+func TestQueryOpenCodeSession_NoManagedPortRateLimitsCLIFallback(t *testing.T) {
+	projectPath := t.TempDir()
+	payload, err := json.Marshal([]openCodeSessionMetadata{{
+		ID:        "ses_COMPAT",
+		Directory: projectPath,
+		Created:   1000,
+		Updated:   2000,
+	}})
+	if err != nil {
+		t.Fatalf("marshal fake CLI response: %v", err)
+	}
+
+	marker := filepath.Join(t.TempDir(), "cli-invocations")
+	fakeBin := t.TempDir()
+	fakeOpenCode := filepath.Join(fakeBin, "opencode")
+	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\nprintf '%%s\\n' %q\n", marker, string(payload))
+	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	inst := &Instance{Tool: "opencode", ProjectPath: projectPath}
+	for attempt := 0; attempt < 2; attempt++ {
+		if got := inst.queryOpenCodeSession(); got != "ses_COMPAT" {
+			t.Fatalf("attempt %d session ID = %q, want ses_COMPAT", attempt+1, got)
+		}
+	}
+
+	invocations, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read CLI invocation marker: %v", err)
+	}
+	if got := len(invocations); got != 1 {
+		t.Fatalf("CLI invocation count = %d, want 1 within scan interval", got)
+	}
+}
+
+func TestQueryOpenCodeSession_NoManagedPortCoalescesConcurrentCLIFallback(t *testing.T) {
+	projectPath := t.TempDir()
+	payload, err := json.Marshal([]openCodeSessionMetadata{{
+		ID:        "ses_COALESCED",
+		Directory: projectPath,
+		Created:   1000,
+		Updated:   2000,
+	}})
+	if err != nil {
+		t.Fatalf("marshal fake CLI response: %v", err)
+	}
+
+	marker := filepath.Join(t.TempDir(), "cli-invocations")
+	fakeBin := t.TempDir()
+	fakeOpenCode := filepath.Join(fakeBin, "opencode")
+	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\n/bin/sleep 1\nprintf '%%s\\n' %q\n", marker, string(payload))
+	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	inst := &Instance{Tool: "opencode", ProjectPath: projectPath}
+	const callers = 8
+	start := make(chan struct{})
+	results := make(chan string, callers)
+	for range callers {
+		go func() {
+			<-start
+			results <- inst.queryOpenCodeSession()
+		}()
+	}
+	close(start)
+
+	for range callers {
+		if got := <-results; got != "ses_COALESCED" {
+			t.Fatalf("session ID = %q, want ses_COALESCED", got)
+		}
+	}
+
+	invocations, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("read CLI invocation marker: %v", err)
+	}
+	if got := len(invocations); got != 1 {
+		t.Fatalf("concurrent CLI invocation count = %d, want 1", got)
+	}
+}

--- a/internal/session/opencode_session_discovery_test.go
+++ b/internal/session/opencode_session_discovery_test.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -30,8 +29,6 @@ func TestUpdateOpenCodeSession_ManagedPortUsesHTTPNestedTimes(t *testing.T) {
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
-	// The pre-fix implementation invokes the CLI even with a managed port.
-	// Keep that RED path hermetic: it must never reach the installed OpenCode.
 	fakeBin := t.TempDir()
 	fakeOpenCode := filepath.Join(fakeBin, "opencode")
 	if err := os.WriteFile(fakeOpenCode, []byte("#!/bin/sh\nprintf '[]'\n"), 0o755); err != nil {
@@ -92,22 +89,39 @@ func TestQueryOpenCodeSession_ManagedPortRetriesHTTPAfterFailure(t *testing.T) {
 	}
 }
 
+func TestQueryOpenCodeSession_ManagedPortRefusesRedirect(t *testing.T) {
+	projectPath := t.TempDir()
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		fmt.Fprintf(w, `[{"id":"ses_REDIRECTED","directory":%q,"time":{"created":1000,"updated":2000}}]`, projectPath)
+	}))
+	t.Cleanup(target.Close)
+
+	redirect := httptest.NewServer(http.RedirectHandler(target.URL, http.StatusTemporaryRedirect))
+	t.Cleanup(redirect.Close)
+	inst := &Instance{
+		Tool:         "opencode",
+		ProjectPath:  projectPath,
+		OpenCodePort: redirect.Listener.Addr().(*net.TCPAddr).Port,
+	}
+
+	if got := inst.queryOpenCodeSession(); got != "" {
+		t.Fatalf("redirected query session ID = %q, want empty", got)
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target request count = %d, want 0", got)
+	}
+}
+
 func TestQueryOpenCodeSession_NoManagedPortRateLimitsCLIFallback(t *testing.T) {
 	projectPath := t.TempDir()
-	payload, err := json.Marshal([]openCodeSessionMetadata{{
-		ID:        "ses_COMPAT",
-		Directory: projectPath,
-		Created:   1000,
-		Updated:   2000,
-	}})
-	if err != nil {
-		t.Fatalf("marshal fake CLI response: %v", err)
-	}
+	payload := fmt.Sprintf(`[{"id":"ses_COMPAT","directory":%q,"created":1000,"updated":2000}]`, projectPath)
 
 	marker := filepath.Join(t.TempDir(), "cli-invocations")
 	fakeBin := t.TempDir()
 	fakeOpenCode := filepath.Join(fakeBin, "opencode")
-	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\nprintf '%%s\\n' %q\n", marker, string(payload))
+	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\nprintf '%%s\\n' %q\n", marker, payload)
 	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake opencode: %v", err)
 	}
@@ -131,20 +145,12 @@ func TestQueryOpenCodeSession_NoManagedPortRateLimitsCLIFallback(t *testing.T) {
 
 func TestQueryOpenCodeSession_NoManagedPortCoalescesConcurrentCLIFallback(t *testing.T) {
 	projectPath := t.TempDir()
-	payload, err := json.Marshal([]openCodeSessionMetadata{{
-		ID:        "ses_COALESCED",
-		Directory: projectPath,
-		Created:   1000,
-		Updated:   2000,
-	}})
-	if err != nil {
-		t.Fatalf("marshal fake CLI response: %v", err)
-	}
+	payload := fmt.Sprintf(`[{"id":"ses_COALESCED","directory":%q,"created":1000,"updated":2000}]`, projectPath)
 
 	marker := filepath.Join(t.TempDir(), "cli-invocations")
 	fakeBin := t.TempDir()
 	fakeOpenCode := filepath.Join(fakeBin, "opencode")
-	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\n/bin/sleep 1\nprintf '%%s\\n' %q\n", marker, string(payload))
+	script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\n/bin/sleep 1\nprintf '%%s\\n' %q\n", marker, payload)
 	if err := os.WriteFile(fakeOpenCode, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake opencode: %v", err)
 	}


### PR DESCRIPTION
## What problem does this solve?

AgentDeck repeatedly starts `opencode session list --format json` while polling
OpenCode sessions. OpenCode/OpenTUI/Bun can leave a unique native library in
`/tmp` for every headless process, so ordinary AgentDeck status polling can
amplify the upstream cleanup defect into several GiB of disk growth per hour.
Fixes #1848.

Related upstream cleanup reports:
[OpenCode #37671](https://github.com/anomalyco/opencode/issues/37671),
[Bun #29585](https://github.com/oven-sh/bun/issues/29585),
[Bun #30962](https://github.com/oven-sh/bun/issues/30962), and
[Bun PR #29587](https://github.com/oven-sh/bun/pull/29587).

## Why this change

AgentDeck already launches normal OpenCode sessions with a managed localhost
port for SSE status. The same server exposes `GET /session?directory=...`, so
session discovery can reuse it without creating another OpenCode process.

The HTTP response's nested `time.created` and `time.updated` fields are adapted
to the existing metadata shape before calling the unchanged
`findBestOpenCodeSession`, preserving startup, current-binding, and `/new`
rotation behavior. A warming or unreachable managed server returns no candidate
and is retried later; it never falls back immediately to the leaking CLI.
Redirects are refused so the project-directory query stays on loopback.

Custom/compatibility configurations without a managed port retain the CLI, but
raw session-list results (including failures) are cached for 15 seconds per
normalized project path and concurrent callers are coalesced with the existing
`x/sync/singleflight` dependency.

## User impact

Managed OpenCode sessions no longer launch a headless OpenCode process during
session discovery, removing AgentDeck's steady amplification of the native
`/tmp` leak. Configurations that intentionally disable the managed OpenCode
server continue to work through a bounded CLI compatibility path. No migration,
configuration change, session restart, or new dependency is required.

## Evidence

Live reproduction on AgentDeck v1.11.0 before this patch:

```text
window_seconds=62 exact_execs_observed=8 exact_files_created=6
execs_per_minute=7.74 files_per_minute=5.80
artifact_size=13745312 type="ELF 64-bit shared object" embedded_name="libopentui.so"
```

With two eligible sessions, the measured process rate could leave roughly
5.9 GiB/hour when every invocation produced a complete library. This patch's
managed-port tests enforce zero CLI invocations, including after an HTTP 503.

TDD RED evidence:

```text
TestUpdateOpenCodeSession_ManagedPortUsesHTTPNestedTimes:
OpenCodeSessionID = "", want "ses_NEW"

TestQueryOpenCodeSession_NoManagedPortRateLimitsCLIFallback:
CLI invocation count = 2, want 1 within scan interval

TestQueryOpenCodeSession_NoManagedPortCoalescesConcurrentCLIFallback:
concurrent CLI invocation count = 8, want 1

TestQueryOpenCodeSession_ManagedPortRefusesRedirect:
redirected query session ID = "ses_REDIRECTED", want empty
```

The first RED was captured before implementation on `580e772c`; the original
`queryOpenCodeSession` function has the same SHA-256 on current base
`46300807`, so the revert condition is unchanged on the PR base.

Focused GREEN gates on `1a7f9471`:

```text
go test ./internal/session -run '<six exact discovery/matching tests>' -count=3
ok github.com/asheshgoplani/agent-deck/internal/session 3.073s

go test -race ./internal/session -run '<six exact discovery/matching tests>' -count=1
ok github.com/asheshgoplani/agent-deck/internal/session 2.082s

go vet ./internal/session
PASS

go build ./cmd/agent-deck
PASS

git diff --check
PASS
```

All test commands ran serially with an owned `/var/tmp` `TMPDIR`. The full suite
was intentionally not run because the incident controller prohibited broad or
parallel suites while another test/model lane was active. The PR is scoped to
the focused session-discovery tests; CI can supply the sandboxed full-suite gate.

Review-correction gates on ab30c7ef67af84daf218ee29ba3921536d42f1a9:

- Expanded focused race: PASS; internal/session, 3.196s.
- gofmt on both changed files: PASS.
- go vet ./internal/session: PASS.
- go build ./cmd/agent-deck: PASS; candidate SHA-256 bec60b793f7f8980bc2af60ef8e07e4befb8ea7179e8bd3eac4848dbdf78a5b7.
- git diff --check and diff-scoped security scan: PASS.
- Review regressions cover both stable top-level directory and newer location.directory responses, an in-flight binding snapshot, oversized response rejection, redirect/CLI isolation, portable coalescing, and defensive singleflight handling.

The mandatory pre-race gate reported 15,803,058 KiB available, memory pressure avg10 0.00, and I/O some/full avg10 9.45/7.02. No competing Go or Bun test process was present. The focused commands ran serially; the controller prohibition on a broad suite remains in force.

Security self-scan: the only new production network operation is an HTTP GET to
`127.0.0.1` using AgentDeck's positive integer managed port. The directory is
encoded with `net/url`, redirects are refused, CLI arguments remain fixed argv,
and `go.mod`/`go.sum` are unchanged.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "Implement the smallest HTTP-first OpenCode session-discovery
seam: when OpenCodePort is managed and positive, query GET
/session?directory=... on that localhost port, adapt nested
time.created/time.updated while preserving current best-session matching, and
on managed-port failure retry HTTP later without immediate CLI fallback."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (deferred to CI under the controller's no-broad-suite constraint)
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after process-rate evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OpenCode session discovery now uses the managed local connection when available.
  * Added a more reliable fallback for environments without a managed connection, including rate limiting and request deduplication.
  * Improved handling of connection failures, redirects, oversized, and malformed responses.
  * Session timestamps are now captured more accurately from nested session data.
  * Improved session binding consistency during in-progress updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->
