### PR TITLE
fix(tmux): route multi-line sends through bracketed paste (#1855)

### DIFF
--- a/internal/tmux/issue1855_bracket_paste_test.go
+++ b/internal/tmux/issue1855_bracket_paste_test.go
@@ -1,0 +1,119 @@
+// Regression tests for issue #1855: `session send --message-file` (and any
+// other multi-line SendKeysAndEnter/SendKeysChunked call) glued adjacent
+// lines together with no separator once it reached an Ink-style composer
+// (Claude Code, confirmed manually against a real `claude` process).
+//
+// The transport itself never lost the bytes — a real pane driven with plain
+// `send-keys -l` receives every embedded LF byte-for-byte. The problem is
+// semantic: without a bracketed-paste envelope telling the composer "this is
+// pasted text, take it literally", an Ink text input has no way to
+// distinguish a bare LF from an unrecognized keystroke and drops it, which is
+// what glues the lines together.
+//
+// These tests drive a real tmux pane (same style as issue1793) and assert
+// what actually arrives at the other end, rather than the shape of the argv
+// agent-deck emits.
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// awaitBracketPasteFlag polls tmux's tracked bracket-paste state for the pane
+// until it matches want. A pane only reaches 1 after its own process has
+// written the DECSET 2004 enable sequence to stdout and tmux's terminal
+// emulation has observed it — both async relative to pane startup.
+func awaitBracketPasteFlag(t *testing.T, name string, want string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("tmux", "display-message", "-t", name, "-p", "#{bracket_paste_flag}").Output()
+		if err == nil {
+			last = strings.TrimSpace(string(out))
+			if last == want {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("pane bracket_paste_flag never reached %q (last observed: %q)", want, last)
+}
+
+// TestIssue1855_MultilinePayload_BracketedWhenPaneRequestsIt is the fix's
+// core claim: a short multi-line payload (well under canonicalSafeBytes, so
+// pre-fix this went out as a bare `send-keys -l`) against a pane that has
+// itself enabled bracketed-paste mode must arrive wrapped in \e[200~...\e[201~
+// with the embedded newlines preserved as LF. That envelope is what tells an
+// Ink composer the body is pasted text rather than a keystroke stream.
+func TestIssue1855_MultilinePayload_BracketedWhenPaneRequestsIt(t *testing.T) {
+	payload := "line1\nline2\nline3"
+	// \e[200~ + payload + \e[201~ + the trailing Enter (raw mode: \r).
+	want := "\x1b[200~" + payload + "\x1b[201~" + "\r"
+
+	sess, out := paneReader(t, "ad1855-bracketed",
+		fmt.Sprintf("stty raw -echo; printf '\\033[?2004h'; head -c %d", len(want)))
+	awaitDiscipline(t, sess, false)
+	awaitBracketPasteFlag(t, sess.Name, "1")
+
+	if err := sess.SendKeysAndEnter(payload); err != nil {
+		t.Fatalf("SendKeysAndEnter(%q) to a bracket-paste-aware pane must succeed: %v", payload, err)
+	}
+
+	got := string(awaitBytes(out, len(want), 15*time.Second))
+	if got != want {
+		t.Fatalf("bracket-paste-aware pane received %q, want %q (payload glued together with no bracket "+
+			"envelope is exactly issue #1855)", got, want)
+	}
+}
+
+// TestIssue1855_MultilinePayload_PlainWhenPaneDoesNotRequestIt guards the
+// no-op side of -p: a pane that never enabled bracketed-paste mode (every
+// non-Ink reader, and any Ink reader that hasn't gotten there yet) must still
+// receive the literal bytes with embedded LF preserved — no bracket markers
+// bolted on, no LF-to-CR substitution from tmux's other paste-buffer default.
+func TestIssue1855_MultilinePayload_PlainWhenPaneDoesNotRequestIt(t *testing.T) {
+	payload := "line1\nline2\nline3"
+	want := payload + "\r"
+
+	sess, out := paneReader(t, "ad1855-plain", fmt.Sprintf("stty raw -echo; head -c %d", len(want)))
+	awaitDiscipline(t, sess, false)
+	awaitBracketPasteFlag(t, sess.Name, "0")
+
+	if err := sess.SendKeysAndEnter(payload); err != nil {
+		t.Fatalf("SendKeysAndEnter(%q) to a plain pane must succeed: %v", payload, err)
+	}
+
+	got := string(awaitBytes(out, len(want), 15*time.Second))
+	if got != want {
+		t.Fatalf("plain pane received %q, want %q (unwrapped, LF preserved)", got, want)
+	}
+}
+
+// TestIssue1855_SingleLinePayload_UnaffectedByBracketPasteMode pins that the
+// fix is scoped to multi-line content: a single-line payload must stay on the
+// fast `send-keys -l` path even against a pane that has enabled bracketed
+// paste, since there is no embedded newline for a composer to mishandle.
+func TestIssue1855_SingleLinePayload_UnaffectedByBracketPasteMode(t *testing.T) {
+	payload := "no newlines here"
+	want := payload + "\r"
+
+	sess, out := paneReader(t, "ad1855-singleline",
+		fmt.Sprintf("stty raw -echo; printf '\\033[?2004h'; head -c %d", len(want)))
+	awaitDiscipline(t, sess, false)
+	awaitBracketPasteFlag(t, sess.Name, "1")
+
+	if err := sess.SendKeysAndEnter(payload); err != nil {
+		t.Fatalf("SendKeysAndEnter(%q) must succeed: %v", payload, err)
+	}
+
+	got := string(awaitBytes(out, len(want), 15*time.Second))
+	if got != want {
+		t.Fatalf("single-line payload against a bracket-paste-aware pane got %q, want %q unwrapped "+
+			"(no newline means nothing for a composer to mishandle, so no envelope is needed)", got, want)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5152,10 +5152,11 @@ func (s *Session) SendNamedKey(key string) error {
 }
 
 // SendKeysAndEnter sends literal text followed by Enter as two separate tmux
-// calls with a short delay between them. The delay is necessary because tmux
-// 3.2+ wraps send-keys -l in bracketed paste sequences (\e[200~...\e[201~).
-// Without the delay, Enter arrives in the same PTY buffer as the paste-end
-// marker and gets swallowed by async TUI frameworks (Ink/Node.js, curses).
+// calls with a short delay between them. sendKeysChunkedToTarget wraps
+// multi-line content in bracketed paste (\e[200~...\e[201~) via `paste-buffer
+// -p` (see issue #1855); the delay gives async TUI frameworks (Ink/Node.js,
+// curses) time to finish processing the paste-end marker before Enter
+// arrives, so it isn't swallowed alongside it.
 func (s *Session) SendKeysAndEnter(keys string) error {
 	return s.sendKeysAndEnterToTarget(s.Name, keys)
 }
@@ -5205,39 +5206,48 @@ func (s *Session) sendKeysAndEnterToTarget(target, keys string) error {
 }
 
 // SendKeysChunked delivers content to the tmux session's active window.
-// Payloads at or below canonicalSafeBytes go out as a single `send-keys -l`,
-// exactly as before. Larger payloads take the paste transport (load-buffer
-// from stdin + paste-buffer) after the pane's line discipline has been
-// checked; see sendKeysChunkedToTarget and canonical_line.go.
+// Single-line payloads at or below canonicalSafeBytes go out as a single
+// `send-keys -l`, exactly as before. Multi-line payloads, and anything larger,
+// take the paste transport (load-buffer from stdin + paste-buffer) after the
+// pane's line discipline has been checked; see sendKeysChunkedToTarget and
+// canonical_line.go.
 func (s *Session) SendKeysChunked(content string) error {
 	return s.sendKeysChunkedToTarget(s.Name, content)
 }
 
 // sendKeysChunkedToTarget is SendKeysChunked against an explicit tmux target.
 //
-// Three sizes of payload, three behaviors (issue #1793):
+//   - single-line, ≤ canonicalSafeBytes: one `send-keys -l`. Guaranteed to fit
+//     any line discipline, so nothing is inspected and nothing costs extra.
+//     This is the overwhelming majority of sends and is byte-for-byte
+//     unchanged.
 //
-//   - ≤ canonicalSafeBytes: one `send-keys -l`. Guaranteed to fit any line
-//     discipline, so nothing is inspected and nothing costs extra. This is
-//     the overwhelming majority of sends and is byte-for-byte unchanged.
+//   - multi-line, of any size: deliver via load-buffer + paste-buffer -p -r
+//     (see pasteToTarget). `send-keys -l` puts the embedded line breaks on
+//     the wire byte-for-byte — that was verified directly against a real
+//     pane, they are not lost in transit — but an Ink-style composer
+//     (Claude Code, and likely Codex/Copilot/OpenCode, since they're built on
+//     the same class of framework) has no way to tell a bare LF apart from a
+//     paste it wasn't told about, and silently drops it rather than inserting
+//     a line break, gluing the two lines together with no separator (issue
+//     #1855). Bracketed paste is the signal that tells the composer "this is
+//     pasted text, take it literally"; only paste-buffer's -p flag can add
+//     that wrapping, and only tmux send-keys -l cannot. -p is a no-op against
+//     a pane that never requested bracketed-paste mode, so this is free for
+//     every other kind of pane.
 //
-//   - larger, pane readable and canonical: refuse with
-//     *CanonicalOverflowError when the longest line does not fit the pane's
-//     canonical buffer. The kernel would discard the overflow AND the
-//     submitting Enter, so typing it would leave a half-line in the composer
-//     and report a success that never happened. Refusing types nothing.
-//
-//   - larger, otherwise: deliver via load-buffer + paste-buffer. tmux reads
-//     the body from our stdin instead of argv, which removes the ARG_MAX
-//     exposure and replaces N paced `send-keys` subprocesses with two calls.
-//     If the paste transport is unavailable the chunked send-keys path is
-//     still there as a fallback.
+//   - larger (including now any multi-line payload), pane readable and
+//     canonical: refuse with *CanonicalOverflowError when the longest line
+//     does not fit the pane's canonical buffer. The kernel would discard the
+//     overflow AND the submitting Enter, so typing it would leave a half-line
+//     in the composer and report a success that never happened. Refusing
+//     types nothing.
 //
 // The paste transport is NOT what fixes canonical overflow — it was measured
 // to fall off the identical cliff (canonical_line.go). Only the refusal, and
 // the caller's post-send verification, make the outcome honest.
 func (s *Session) sendKeysChunkedToTarget(target, content string) error {
-	if len(content) <= canonicalSafeBytes {
+	if len(content) <= canonicalSafeBytes && !strings.ContainsAny(content, "\r\n") {
 		return s.sendKeysToTarget(target, content)
 	}
 
@@ -5306,7 +5316,21 @@ func pasteBufferName() string {
 
 // pasteToTarget delivers content through tmux's paste path: `load-buffer -`
 // reads the body from this process's stdin (no argv size limit, no shell
-// quoting), then `paste-buffer -d` writes it to the pane and drops the buffer.
+// quoting), then `paste-buffer -d -p -r` writes it to the pane and drops the
+// buffer.
+//
+// -r stops tmux replacing embedded LF with CR, which is its documented
+// default; without it a multi-line payload is at the mercy of whatever a
+// given tmux build actually does with linefeeds, on top of everything -p
+// already needs LF preserved for (see below).
+//
+// -p wraps the buffer in bracketed-paste markers (\e[200~...\e[201~) — but
+// ONLY if the destination pane has itself requested bracketed-paste mode
+// (tmux tracks this per pane; it's a no-op otherwise, so this costs nothing
+// against panes that never asked). That wrapping is what tells an Ink-style
+// composer "this is pasted text, insert it literally" instead of trying to
+// interpret each embedded LF as a keystroke and dropping the ones it doesn't
+// recognize — see the sendKeysChunkedToTarget doc comment and issue #1855.
 func (s *Session) pasteToTarget(target, content string) error {
 	s.invalidateCache()
 
@@ -5323,7 +5347,7 @@ func (s *Session) pasteToTarget(target, content string) error {
 		return fmt.Errorf("load-buffer: %v: %w", err, errPasteNotStaged)
 	}
 
-	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-b", buf, "-t", target)
+	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-p", "-r", "-b", buf, "-t", target)
 	if err := runSendKeysBounded(paste); err != nil {
 		// -d never ran, so the staged buffer would linger. Drop it before
 		// falling back, otherwise the fallback's content and this stale copy


### PR DESCRIPTION
## What problem does this solve?

`session send --message-file` (and any other multi-line send) glues adjacent lines together with no separator once the message reaches an Ink-style composer like Claude Code. Fixes #1855.

## Why this change

I first assumed the transport was losing bytes and tried to reproduce it with `tmux send-keys -l` against a synthetic reader (`od -c`) — the raw LF arrived intact, byte-for-byte, disproving that theory. I then reproduced the exact bug against a real `claude` process in an isolated tmux socket: `❯ /superpowers:writing-skillsWrite a skill that writes cupcake flavors.` — same glued signature as the issue. So the bytes are fine in transit; the composer just has no way to distinguish a bare LF from an unrecognized keystroke and drops it.

Bracketed paste (`\e[200~...\e[201~`) is the signal that tells a composer "this is pasted text, take it literally." tmux's `paste-buffer -p` can add that wrapping (only against panes that have themselves requested bracketed-paste mode; it's a no-op otherwise), but plain `send-keys -l` never adds it. So the fix routes any content with an embedded newline through `paste-buffer -p -r` instead of `send-keys -l`, regardless of size — the existing `canonicalSafeBytes` size gate was about ARG_MAX/line-discipline safety, not composer semantics, and doesn't need to change. `-r` additionally stops tmux's documented default of replacing LF with CR, which the existing large-message path was silently relying on tmux's build-specific default to avoid.

I also found and corrected an inaccurate comment claiming "tmux 3.2+ wraps send-keys -l in bracketed paste sequences" — I disproved this directly (tmux 3.7b, `bracket_paste_flag=1`, plain LF on the wire, no markers). That comment was the stated rationale for the existing 100ms pre-Enter delay; the delay itself is still needed (now correctly attributed to the paste-buffer -p wrapping this fix adds), so no other change was needed there.

## User impact

Any multi-line prompt sent via `session send --message-file`/`--message`/`-m`, or any other code path that calls `SendKeysAndEnter`/`SendKeysChunked` with embedded newlines, now arrives at Claude Code (and other Ink-style tools) with its line breaks intact instead of glued together. No change for single-line messages or for panes that don't negotiate bracketed paste.

## Evidence

Reproduced against a real `claude` process on an isolated tmux socket (`/tmp/adtest.sock`), before and after:

```
# before (plain send-keys -l, matches the issue exactly):
❯ /superpowers:writing-skillsWrite a skill that writes cupcake flavors.

# after (load-buffer + paste-buffer -d -p -r):
❯ /superpowers:writing-skills
  Write a skill that writes cupcake flavors.
```

New regression tests drive a real tmux pane (no mocking of argv) and assert the literal bytes received:
- `TestIssue1855_MultilinePayload_BracketedWhenPaneRequestsIt` — fails without the fix (received `""`, i.e. the pane's `head -c` never got the expected byte count under the old `send-keys -l` path since it isn't bracket-wrapped), passes with it.
- `TestIssue1855_MultilinePayload_PlainWhenPaneDoesNotRequestIt` — confirms panes that never request bracketed-paste mode are unaffected (still literal LF, no CR substitution).
- `TestIssue1855_SingleLinePayload_UnaffectedByBracketPasteMode` — confirms single-line content stays on the fast `send-keys -l` path.

Sandboxed suite: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — all packages pass (one flaky, pre-existing, unrelated tmpdir-cleanup failure in `cmd/agent-deck` reproduces identically on `main` and passes on retry/isolation; not touched by this diff).

Timing: 20x `send-keys -l` averaged ~7.7ms/call; 20x `load-buffer`+`paste-buffer` averaged ~13.6ms/call (two tmux subprocess invocations instead of one). This only affects `session send` calls whose message contains a newline — a user-initiated, once-per-message action, not a per-tick path like `list`/`status`/startup — so I did not check the hot-path timing box below.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-5

**Prompt / session log (optional):** N/A

## What actually bothered you

My human (the issue reporter and repo maintainer) asked: "I created a fork in my personal account, bsaltz/agent-deck. Let's see if we can do anything with issue 1855" — issue 1855 being their own bug report that `session send --message-file` strips newlines, first noticed while trying to send a multi-line slash-command prompt to a Claude Code session.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — timing measured (see Evidence) but this is a once-per-message, user-initiated action, not a per-tick hot path, so leaving unchecked rather than overclaiming
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-sonnet-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux handling for multiline and large pasted content.
  * Preserved line breaks and correctly signaled pasted input to compatible terminal applications.
  * Retained consistent behavior for single-line input and panes without bracketed-paste support.
* **Tests**
  * Added regression coverage for bracketed and unbracketed paste scenarios, including byte-level validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->