### PR TITLE
fix(tui): remote sessions use the same status indicators as local ones (#1864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Remote (SSH) sessions now use the same status indicators as local ones.** The remote row renderer carried its own copy of the status-glyph switch, and it had drifted: waiting showed ◉ instead of ◐, error showed ✗ (U+2717) instead of ✕ (U+2715), and the glyph was colored from the raw ANSI palette so it ignored the active theme. The remote preview pane was a third copy that disagreed with the row — one waiting remote session rendered ◉ in the list and ◐ in its own preview. All three now share `rowStatusGlyph`. Remote rows also gain the states the private copy had no case for: ■ for stopped and archived (an archived remote kept a live glyph, because archiving does not reset Status), and the ⚡ model-unavailable / 🔒 auth-401 substate glyphs. `list --json` on the remote already emitted `substate` and `archived`; `RemoteSessionInfo` was dropping them. A remote too old to send those fields degrades to the coarse-status glyph. Same class of bug as [#1091](https://github.com/asheshgoplani/agent-deck/issues/1091), in the same function. ([#1864](https://github.com/asheshgoplani/agent-deck/issues/1864))
+
 ## [1.11.0] - 2026-08-01
 
 Security and correctness release. Repo-supplied worktree scripts now require explicit consent, path handling around the skills catalog and logs is hardened, `session send` tells the truth about delivery, restarted sessions can no longer resume the wrong conversation, and Ctrl+Q detach works on every session sharing a tmux socket.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -960,6 +960,16 @@ type RemoteSessionInfo struct {
 	Status    string `json:"status"`
 	CreatedAt string `json:"created_at"`
 
+	// Substate and Archived are what the local row needs to pick the same
+	// status glyph a local session would get: the ⚡/🔒 substate refinements
+	// and the archived override (an archived session keeps a live Status, so
+	// without this flag it renders as still running). `list --json` on the
+	// remote has always emitted both; they were simply dropped here. A remote
+	// too old to send them omits the keys, which unmarshal to ""/false and
+	// degrade to the coarse-status glyph.
+	Substate string `json:"substate"`
+	Archived bool   `json:"archived"`
+
 	// Set locally, not from JSON
 	RemoteName string `json:"-"`
 }

--- a/internal/ui/connection_status.go
+++ b/internal/ui/connection_status.go
@@ -76,6 +76,25 @@ func rowStatusGlyph(status session.Status, substate session.Substate, archived b
 	return icon, style
 }
 
+// remoteRowStatusGlyph is the remote-session entry point to rowStatusGlyph.
+//
+// A remote row's state arrives as raw JSON strings from `agent-deck list --json`
+// on the far side (session.RemoteSessionInfo), never as typed values. Those
+// strings are emitted from the same session.Status / tmux.Substate constants
+// (see StatusString in cmd/agent-deck/cli_utils.go), so the conversion is a
+// direct cast; an unrecognized value — including the empty string an older
+// remote sends for a field it predates — falls through to rowStatusGlyph's
+// ○ idle default.
+//
+// Routing remotes through the same helper as local rows is what stops the two
+// from drifting. Before this, remote rows carried a private copy of the switch
+// that had diverged to ◉ for waiting and ✗ (U+2717, vs the local ✕ U+2715) for
+// error, colored from the raw ANSI palette so it ignored the active theme, and
+// with no case at all for stopped/queued/archived or the substate glyphs.
+func remoteRowStatusGlyph(status, substate string, archived bool) (icon string, style lipgloss.Style) {
+	return rowStatusGlyph(session.Status(status), session.Substate(substate), archived)
+}
+
 // authHoldHintLines is the preview-pane hint for a session held out of automatic
 // restarts because its agent cannot authenticate.
 //

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -16764,20 +16764,14 @@ func (h *Home) renderRemotePreview(item session.Item, width, height int) string 
 	b.WriteString(nameStyle.Render(rs.Title))
 	b.WriteString("  ")
 
-	statusColor := ColorTextDim
-	statusIcon := "○"
-	switch rs.Status {
-	case "running":
-		statusIcon = "●"
-		statusColor = ColorGreen
-	case "waiting":
-		statusIcon = "◐"
-		statusColor = ColorYellow
-	case "error":
-		statusIcon = "✗"
-		statusColor = ColorRed
+	statusIcon, statusStyle := remoteRowStatusGlyph(rs.Status, rs.Substate, rs.Archived)
+	// The archived override swaps the glyph to ■ regardless of the stale live
+	// Status, so the label has to follow it or the row reads "■ running".
+	statusLabel := rs.Status
+	if rs.Archived {
+		statusLabel = "archived"
 	}
-	b.WriteString(lipgloss.NewStyle().Foreground(statusColor).Render(statusIcon + " " + rs.Status))
+	b.WriteString(statusStyle.Render(statusIcon + " " + statusLabel))
 	b.WriteString("\n\n")
 
 	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
@@ -16935,24 +16929,7 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 		return
 	}
 
-	statusIcon := "○"
-	statusColor := lipgloss.Color("8") // gray
-	switch rs.Status {
-	case "running":
-		statusIcon = "●"
-		statusColor = lipgloss.Color("2") // green
-	case "waiting":
-		statusIcon = "◉"
-		statusColor = lipgloss.Color("3") // yellow
-	case "idle":
-		statusIcon = "○"
-		statusColor = lipgloss.Color("8")
-	case "error":
-		statusIcon = "✗"
-		statusColor = lipgloss.Color("1") // red
-	}
-
-	sStyle := lipgloss.NewStyle().Foreground(statusColor)
+	statusIcon, sStyle := remoteRowStatusGlyph(rs.Status, rs.Substate, rs.Archived)
 	titleStyle := lipgloss.NewStyle().Foreground(ColorText)
 	if selected {
 		sStyle = SessionStatusSelStyle

--- a/internal/ui/remote_status_glyph_parity_test.go
+++ b/internal/ui/remote_status_glyph_parity_test.go
@@ -1,0 +1,290 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Remote rows used to carry a private copy of the local status-glyph switch,
+// and the copy had drifted. renderRemoteSessionItem rendered waiting as ◉ and
+// error as ✗ (U+2717) where a local row renders ◐ and ✕ (U+2715), colored the
+// glyph from the raw ANSI palette (lipgloss.Color("2"/"3"/"1"/"8")) instead of
+// the theme's SessionStatus* styles, and had no case at all for stopped,
+// queued, archived, or the ⚡/🔒 substates. renderRemotePreview was a THIRD
+// copy that used ◐ but ✗ — so one waiting remote session showed ◉ in the list
+// and ◐ in its own preview.
+//
+// This is the same class of bug as #1091 (remote tool labels rendered gray
+// instead of the brand color), in the same function, fixed the same way: route
+// the remote path through the local helper instead of duplicating it.
+//
+// These tests pin the parity so a future edit to rowStatusGlyph cannot silently
+// leave the remote renderers behind again.
+
+// TestRemoteRowStatusGlyph_MatchesLocalRowGlyph is the load-bearing assertion:
+// for every status/substate/archived combination the wire can carry, the remote
+// helper must return exactly what a local session in the same state returns.
+func TestRemoteRowStatusGlyph_MatchesLocalRowGlyph(t *testing.T) {
+	forceTrueColorProfile()
+
+	cases := []struct {
+		name     string
+		status   string
+		substate string
+		archived bool
+	}{
+		{"running", "running", "", false},
+		{"waiting", "waiting", "", false},
+		{"idle", "idle", "", false},
+		{"error", "error", "", false},
+		{"stopped", "stopped", "", false},
+		{"queued", "queued", "", false},
+		{"archived overrides live status", "running", "", true},
+		{"error + model unavailable", "error", string(session.SubstateModelUnavailable), false},
+		{"error + auth 401", "error", string(session.SubstateAuth401), false},
+		{"stopped + auth 401", "stopped", string(session.SubstateAuth401), false},
+		// An older remote omits the substate/archived keys entirely; they
+		// unmarshal to ""/false and must degrade to the coarse-status glyph.
+		{"older remote, no substate", "waiting", "", false},
+		// A status string this build does not know must not render blank.
+		{"unknown status", "banana", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotIcon, gotStyle := remoteRowStatusGlyph(tc.status, tc.substate, tc.archived)
+			wantIcon, wantStyle := rowStatusGlyph(
+				session.Status(tc.status), session.Substate(tc.substate), tc.archived)
+
+			if gotIcon != wantIcon {
+				t.Errorf("glyph = %q, want %q — remote rows must use the local glyph set",
+					gotIcon, wantIcon)
+			}
+			if gotStyle.Render("x") != wantStyle.Render("x") {
+				t.Errorf("style = %q, want %q — remote rows must use the theme's SessionStatus* styles",
+					gotStyle.Render("x"), wantStyle.Render("x"))
+			}
+			if gotIcon == "" {
+				t.Errorf("glyph is empty for status %q — every state needs a visible indicator", tc.status)
+			}
+		})
+	}
+}
+
+// TestRemoteSessionRow_UsesLocalGlyphs renders the actual row and asserts the
+// two drifted glyphs are gone. ◉ and ✗ appearing anywhere in the output means
+// the private switch is back.
+func TestRemoteSessionRow_UsesLocalGlyphs(t *testing.T) {
+	forceTrueColorProfile()
+
+	cases := []struct {
+		status    string
+		wantGlyph string
+		bugGlyph  string // what the drifted copy rendered
+	}{
+		{"waiting", "◐", "◉"},
+		{"error", "✕", "✗"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+
+			remote := session.RemoteSessionInfo{
+				ID: "r1", Title: "sess", Tool: "claude",
+				Status: tc.status, RemoteName: "dev",
+			}
+			item := session.Item{
+				Type:          session.ItemTypeRemoteSession,
+				RemoteSession: &remote,
+				RemoteName:    "dev",
+			}
+
+			var b strings.Builder
+			home.renderRemoteSessionItem(&b, item, false)
+			rendered := b.String()
+
+			if !strings.Contains(rendered, tc.wantGlyph) {
+				t.Errorf("remote %s row missing local glyph %q; got %q",
+					tc.status, tc.wantGlyph, rendered)
+			}
+			if strings.Contains(rendered, tc.bugGlyph) {
+				t.Errorf("remote %s row still renders the drifted glyph %q — "+
+					"renderRemoteSessionItem must delegate to rowStatusGlyph; got %q",
+					tc.status, tc.bugGlyph, rendered)
+			}
+		})
+	}
+}
+
+// TestRemoteSessionRow_GlyphUsesThemeStyle guards the color half of the fix.
+// The old code hardcoded lipgloss.Color("3") for waiting, which does not track
+// a theme switch the way SessionStatusWaiting does.
+func TestRemoteSessionRow_GlyphUsesThemeStyle(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID: "r1", Title: "sess", Status: "waiting", RemoteName: "dev",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteSession: &remote,
+		RemoteName:    "dev",
+	}
+
+	var b strings.Builder
+	home.renderRemoteSessionItem(&b, item, false)
+	rendered := b.String()
+
+	want := SessionStatusWaiting.Render("◐")
+	if !strings.Contains(rendered, want) {
+		t.Errorf("remote waiting glyph must be styled with SessionStatusWaiting "+
+			"(theme-aware) rather than a raw ANSI palette index.\nwant substring: %q\ngot: %q",
+			want, rendered)
+	}
+}
+
+// TestRemoteSessionRow_ArchivedAndSubstateGlyphs covers the states the old
+// remote switch had no case for. Substate and Archived now come over the wire
+// in RemoteSessionInfo — `list --json` on the remote had always emitted them.
+func TestRemoteSessionRow_ArchivedAndSubstateGlyphs(t *testing.T) {
+	forceTrueColorProfile()
+
+	cases := []struct {
+		name      string
+		remote    session.RemoteSessionInfo
+		wantGlyph string
+	}{
+		{
+			// The old code fell through to ○ gray, so an archived remote
+			// looked like a live idle session.
+			name: "archived beats a stale running status",
+			remote: session.RemoteSessionInfo{
+				Status: "running", Archived: true,
+			},
+			wantGlyph: "■",
+		},
+		{
+			name: "stopped",
+			remote: session.RemoteSessionInfo{
+				Status: "stopped",
+			},
+			wantGlyph: "■",
+		},
+		{
+			name: "error + model unavailable",
+			remote: session.RemoteSessionInfo{
+				Status: "error", Substate: string(session.SubstateModelUnavailable),
+			},
+			wantGlyph: "⚡",
+		},
+		{
+			name: "error + auth 401",
+			remote: session.RemoteSessionInfo{
+				Status: "error", Substate: string(session.SubstateAuth401),
+			},
+			wantGlyph: "🔒",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+
+			rs := tc.remote
+			rs.ID, rs.Title, rs.RemoteName = "r1", "sess", "dev"
+			item := session.Item{
+				Type:          session.ItemTypeRemoteSession,
+				RemoteSession: &rs,
+				RemoteName:    "dev",
+			}
+
+			var b strings.Builder
+			home.renderRemoteSessionItem(&b, item, false)
+			rendered := b.String()
+
+			if !strings.Contains(rendered, tc.wantGlyph) {
+				t.Errorf("want glyph %q in remote row; got %q", tc.wantGlyph, rendered)
+			}
+		})
+	}
+}
+
+// TestRemoteSession_RowAndPreviewAgree closes the third-copy gap: the list row
+// and the preview pane for the SAME session must show the SAME glyph. Before
+// the fix a waiting remote was ◉ in the row and ◐ in the preview.
+func TestRemoteSession_RowAndPreviewAgree(t *testing.T) {
+	forceTrueColorProfile()
+
+	for _, status := range []string{"running", "waiting", "idle", "error", "stopped"} {
+		t.Run(status, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+
+			remote := session.RemoteSessionInfo{
+				ID: "r1", Title: "sess", Tool: "claude",
+				Status: status, Path: "/tmp/p", RemoteName: "dev",
+			}
+			item := session.Item{
+				Type:          session.ItemTypeRemoteSession,
+				RemoteSession: &remote,
+				RemoteName:    "dev",
+			}
+
+			wantGlyph, _ := rowStatusGlyph(session.Status(status), "", false)
+
+			var b strings.Builder
+			home.renderRemoteSessionItem(&b, item, false)
+			if !strings.Contains(b.String(), wantGlyph) {
+				t.Errorf("row for %q missing glyph %q; got %q", status, wantGlyph, b.String())
+			}
+
+			preview := home.renderRemotePreview(item, 60, 20)
+			if !strings.Contains(preview, wantGlyph) {
+				t.Errorf("preview for %q missing glyph %q — row and preview must agree; got %q",
+					status, wantGlyph, preview)
+			}
+		})
+	}
+}
+
+// TestRemoteSessionPreview_ArchivedLabelFollowsGlyph pins the label fix: the
+// archived override forces ■, so the text beside it must not still read
+// "running".
+func TestRemoteSessionPreview_ArchivedLabelFollowsGlyph(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID: "r1", Title: "sess", Status: "running", Archived: true,
+		Path: "/tmp/p", RemoteName: "dev",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteSession: &remote,
+		RemoteName:    "dev",
+	}
+
+	preview := home.renderRemotePreview(item, 60, 20)
+	if !strings.Contains(preview, "archived") {
+		t.Errorf("archived remote preview must label itself archived; got %q", preview)
+	}
+	if strings.Contains(preview, "■ running") {
+		t.Errorf("archived remote preview shows the ■ glyph next to a stale "+
+			"\"running\" label; got %q", preview)
+	}
+}


### PR DESCRIPTION
Closes #1864.

Remote rows had their own copy of the local status-glyph switch, and the copy had drifted. This routes all three renderers through `rowStatusGlyph`.

### What changes on screen

| | before | after |
|---|---|---|
| waiting | ◉ | ◐ |
| error | ✗ (U+2717) | ✕ (U+2715) |
| glyph color | raw ANSI palette indices | theme's `SessionStatus*` styles |
| stopped | ○ gray | ■ |
| archived | live glyph (looked still-running) | ■ |
| error + model-unavailable | ✗ | ⚡ |
| error + auth-401 | ✗ | 🔒 |

`renderRemotePreview` was a third copy that used ◐ for waiting but ✗ for error, so one waiting remote session rendered ◉ in the list and ◐ in its own preview. Both now agree by construction.

### How

- `remoteRowStatusGlyph(status, substate string, archived bool)` in `internal/ui/connection_status.go` casts the wire's strings to `session.Status` / `session.Substate` and delegates. The strings are emitted by `StatusString` on the remote from the same constants, so the cast is exact; anything unrecognized — including the empty string an older remote sends for a field it predates — falls through to the existing ○ idle default.
- `RemoteSessionInfo` gains `Substate` and `Archived`. **No wire-format change:** `list --json` has always emitted both keys, the struct was just dropping them on unmarshal.
- The preview's status label follows the archived override, so it no longer reads "■ running".

Net −32 lines of duplicated switch.

### Compatibility

A remote running a build too old to emit `substate`/`archived` omits the keys; they unmarshal to `""`/`false` and the row degrades to the coarse-status glyph — i.e. today's behavior, minus the drifted codepoints. Covered by the `older remote, no substate` case in the parity table.

### Tests

New `internal/ui/remote_status_glyph_parity_test.go`:

- `TestRemoteRowStatusGlyph_MatchesLocalRowGlyph` — the load-bearing one: table over every status/substate/archived combination the wire can carry, asserting the remote helper returns byte-identical glyph *and* rendered style to what a local session in the same state gets. This is what stops the two from drifting again.
- `TestRemoteSessionRow_UsesLocalGlyphs` — renders the real row; fails if ◉ or ✗ appear anywhere.
- `TestRemoteSessionRow_GlyphUsesThemeStyle` — pins the color half (`SessionStatusWaiting`, not a palette index).
- `TestRemoteSessionRow_ArchivedAndSubstateGlyphs` — the states the private switch had no case for.
- `TestRemoteSession_RowAndPreviewAgree` — row and preview, same session, same glyph.
- `TestRemoteSessionPreview_ArchivedLabelFollowsGlyph`.

`internal/ui` is fully green.

One pre-existing failure in `internal/session`, unrelated and not touched here: `TestIssue1421_CleanStaleSSHSockets` fails identically on clean `origin/main` on macOS — it binds a unix socket at a path containing `stale@host:22` and the `:` is rejected (`bind: invalid argument`). Verified by stashing this branch's changes and re-running.

### Note on prior art

This is the same class of bug as #1091, in the same function. That fix routed the remote *tool label* through `GetToolStyle` instead of a local copy, and left the status glyph three lines above it behind. #1846 is the timestamp version of the same row-vs-preview divergence, still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CZXWysD54cbgdA1NZBpjH
