### PR TITLE
fix(tui): restarted session shows a permanent false error because its new tmux name is never saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A restarted session no longer shows a permanent false "error" while its tmux process runs fine.** Restart recreates the tmux session under a newly minted name, and the TUI's save of that name aborted whenever the state DB had changed since the TUI last loaded, so the next reload restored the dead name from disk. The TUI then polled a session that no longer existed and reported an error for a healthy session, and `Enter`/`R` could not clear it: an aborted save never advances the TUI's last-load timestamp, so each retry aborted for the same reason and leaked another orphaned tmux session. The restart handler now force-saves, matching every sibling handler that mints tmux state.
+
 ## [1.11.0] - 2026-08-01
 
 Security and correctness release. Repo-supplied worktree scripts now require explicit consent, path handling around the skills catalog and logs is hardened, `session send` tells the truth about delivery, restarted sessions can no longer resume the wrong conversation, and Ctrl+Q detach works on every session sharing a tmux socket.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **A restarted session no longer shows a permanent false "error" while its tmux process runs fine.** Restart recreates the tmux session under a newly minted name, and the TUI's save of that name aborted whenever the state DB had changed since the TUI last loaded, so the next reload restored the dead name from disk. The TUI then polled a session that no longer existed and reported an error for a healthy session, and `Enter`/`R` could not clear it: an aborted save never advances the TUI's last-load timestamp, so each retry aborted for the same reason and leaked another orphaned tmux session. The restart handler now force-saves, matching every sibling handler that mints tmux state.
-
 ## [1.11.0] - 2026-08-01
 
 Security and correctness release. Repo-supplied worktree scripts now require explicit consent, path handling around the skills catalog and logs is hardened, `session send` tells the truth about delivery, restarted sessions can no longer resume the wrong conversation, and Ctrl+Q detach works on every session sharing a tmux socket.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6000,8 +6000,43 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.cachedStatusCounts.valid.Store(false)
 				h.rebuildFlatItems()
 			}
-			// Save the updated session state (new tmux session name)
-			h.saveInstances()
+			// Save the updated session state (new tmux session name).
+			//
+			// Must be a FORCE save. restart() kills the old tmux session and
+			// calls recreateTmuxSession, whose tmux.NewSession mints a fresh
+			// name unconditionally, and that name lives only in memory until
+			// this save. A routine save aborts on a detected external DB
+			// change and schedules a reload instead, and the reload replaces
+			// h.instances with the rows on disk -- whose tmux_session column
+			// still holds the dead name. The TUI then polls a session that
+			// does not exist and reports "error" for a session whose tmux
+			// process is running fine.
+			//
+			// That failure is self-sustaining rather than transient. An abort
+			// never advances lastLoadMtime, and the reload's own value is
+			// captured BEFORE its load, so a write landing in that window
+			// leaves lastLoadMtime behind the DB and re-arms the abort. Every
+			// retry spawns another orphaned tmux session and none of the
+			// names are ever recorded.
+			//
+			// #1550 exempted force saves from the external-change abort
+			// precisely because they carry critical mutations; a new tmux
+			// session name is that, and the save is upsert-only so it cannot
+			// delete another process's rows. Every sibling handler that mints
+			// tmux state already force-saves (sessionCreatedMsg,
+			// sessionForkedMsg, sessionRestoredMsg); restart was the outlier.
+			//
+			// This covers the save-time abort, not every concurrency hazard on
+			// the path. The restart itself runs in a tea.Cmd on its own
+			// goroutine, so a reload CAN land mid-restart and swap the pointers
+			// this handler will read. Two pre-existing guards keep that from
+			// losing the name: the Cmd re-resolves the instance by ID at
+			// execution time, and this handler re-resolves again before saving.
+			// A loss would need a reload wedged between recreateTmuxSession
+			// setting the field and this save reading it; that stays possible,
+			// but it is a one-off the next restart re-mints and re-saves, not
+			// the self-sustaining failure above.
+			h.forceSaveInstances()
 			if msg.warning != "" {
 				h.setError(fmt.Errorf("%s", msg.warning))
 			} else if msg.unarchived {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6000,43 +6000,24 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.cachedStatusCounts.valid.Store(false)
 				h.rebuildFlatItems()
 			}
-			// Save the updated session state (new tmux session name).
+			// The name and status this restart produced are already durable:
+			// Instance.restart records them with a targeted two-column write at
+			// the moment it mints them (#1870). This save is for the rest of the
+			// restart's in-memory state, and it stays a ROUTINE save on purpose.
 			//
-			// Must be a FORCE save. restart() kills the old tmux session and
-			// calls recreateTmuxSession, whose tmux.NewSession mints a fresh
-			// name unconditionally, and that name lives only in memory until
-			// this save. A routine save aborts on a detected external DB
-			// change and schedules a reload instead, and the reload replaces
-			// h.instances with the rows on disk -- whose tmux_session column
-			// still holds the dead name. The TUI then polls a session that
-			// does not exist and reports "error" for a session whose tmux
-			// process is running fine.
+			// The first shape of this fix force-saved here, to stop the
+			// external-change abort from discarding the new tmux name. That cured
+			// a lost restart mutation with a much worse failure: a force save
+			// pushes this TUI's whole in-memory snapshot, so an archive, rename or
+			// group move another process made while this TUI was stale is silently
+			// reverted -- the lost-update shape behind this repository's data-loss
+			// incidents. A single wrong field is never worth a whole-snapshot write.
 			//
-			// That failure is self-sustaining rather than transient. An abort
-			// never advances lastLoadMtime, and the reload's own value is
-			// captured BEFORE its load, so a write landing in that window
-			// leaves lastLoadMtime behind the DB and re-arms the abort. Every
-			// retry spawns another orphaned tmux session and none of the
-			// names are ever recorded.
-			//
-			// #1550 exempted force saves from the external-change abort
-			// precisely because they carry critical mutations; a new tmux
-			// session name is that, and the save is upsert-only so it cannot
-			// delete another process's rows. Every sibling handler that mints
-			// tmux state already force-saves (sessionCreatedMsg,
-			// sessionForkedMsg, sessionRestoredMsg); restart was the outlier.
-			//
-			// This covers the save-time abort, not every concurrency hazard on
-			// the path. The restart itself runs in a tea.Cmd on its own
-			// goroutine, so a reload CAN land mid-restart and swap the pointers
-			// this handler will read. Two pre-existing guards keep that from
-			// losing the name: the Cmd re-resolves the instance by ID at
-			// execution time, and this handler re-resolves again before saving.
-			// A loss would need a reload wedged between recreateTmuxSession
-			// setting the field and this save reading it; that stays possible,
-			// but it is a one-off the next restart re-mints and re-saves, not
-			// the self-sustaining failure above.
-			h.forceSaveInstances()
+			// adoptRestartRecord below keeps the abort from firing on this TUI's
+			// OWN restart write, which is what made the abort look like the
+			// problem in the first place.
+			h.adoptRestartRecord(msg.sessionID)
+			h.saveInstances()
 			if msg.warning != "" {
 				h.setError(fmt.Errorf("%s", msg.warning))
 			} else if msg.unarchived {
@@ -11286,6 +11267,58 @@ func (h *Home) saveInstancesWithForce(force bool) {
 				h.storageWatcher.TriggerReload()
 			}
 		}
+	}
+}
+
+// adoptRestartRecord accounts for the targeted write Instance.restart makes when
+// it records what a restart produced.
+//
+// That write moves the state DB's last_modified. This TUI's freshness marker
+// does not move with it, so the save that follows a restart would read the
+// TUI's OWN write as an external change, abort, and reload -- discarding the
+// rest of the restart's in-memory state (sandbox container, tool session ids,
+// the dedup pass) for no reason. That self-inflicted false positive is what
+// #1868 was really hitting.
+//
+// The marker is advanced only when the restart's write was the sole change
+// since this TUI loaded: nothing landed between the load and the write, and
+// nothing has landed since. Anything else means the database really has moved
+// on, the abort is correct, and it stays -- the reload picks up what the other
+// process wrote, and the restart's own outcome is durable either way because
+// the targeted write already landed.
+//
+// last_modified is a UnixNano stamp, so this is an exact identity test on our
+// own write rather than a time window that could swallow somebody else's.
+func (h *Home) adoptRestartRecord(sessionID string) {
+	if h.storage == nil {
+		return
+	}
+	inst := h.getInstanceByID(sessionID)
+	if inst == nil {
+		return
+	}
+	stamps := inst.RestartRecordStamps()
+	if stamps.After == 0 {
+		return
+	}
+	current, err := h.storage.GetFileMtime()
+	if err != nil || current.IsZero() {
+		return
+	}
+
+	h.reloadMu.Lock()
+	defer h.reloadMu.Unlock()
+	if !stamps.SoleWriterSince(h.lastLoadMtime.UnixNano(), current.UnixNano()) {
+		uiLog.Debug("restart_record_not_sole_writer",
+			slog.Int64("before", stamps.Before),
+			slog.Int64("after", stamps.After),
+			slog.Int64("current", current.UnixNano()))
+		return
+	}
+	h.lastLoadMtime = current
+	if h.storageWatcher != nil {
+		// Our own bump should not make the watcher schedule a reload either.
+		h.storageWatcher.NotifySave()
 	}
 }
 

--- a/internal/ui/restart_save_external_change_test.go
+++ b/internal/ui/restart_save_external_change_test.go
@@ -1,0 +1,188 @@
+package ui
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// A restart gives a session a NEW tmux session name: restart() kills the old
+// tmux session and calls recreateTmuxSession (internal/session/instance.go),
+// which builds a fresh one through tmux.NewSession -- and that mints
+// SessionPrefix + name + "_" + a new short id unconditionally. The new name
+// lives only on the in-memory Instance until the sessionRestartedMsg handler
+// saves it.
+//
+// A routine save aborts when it detects the state DB changed since this TUI
+// last loaded, and the reload it schedules instead replaces h.instances
+// wholesale with the on-disk rows -- whose tmux_session column still holds the
+// DEAD name. The TUI then polls a tmux session that does not exist and renders
+// "error" for a session whose process is running fine, and retrying cannot
+// clear it because the abort leaves lastLoadMtime behind a concurrent writer.
+
+// TestRestartMsg_PersistsNewTmuxNameDespiteExternalChange is the regression
+// guard. It asserts the real contract: after a successful restart under a
+// detected external change, the name that survives a round-trip through storage
+// is the NEW one, not the dead one.
+func TestRestartMsg_PersistsNewTmuxNameDespiteExternalChange(t *testing.T) {
+	home, storage := newRestartSaveHome(t, "_restartsaveext")
+	defer storage.Close()
+
+	inst := home.instances[0]
+
+	// Stand in for what restart() does to a live session: the Instance now
+	// carries a tmux session under a freshly minted name, while the row on
+	// disk still names the old one.
+	const oldName = "agentdeck_target_deadbeef"
+	const newName = "agentdeck_target_f00dcafe"
+
+	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
+		oldName, inst.ID, "/tmp/proj", "shell", "running",
+	))
+	home.forceSaveInstances()
+
+	before, err := storage.GetFileMtime()
+	if err != nil {
+		t.Fatalf("GetFileMtime: %v", err)
+	}
+	if got := persistedTmuxName(t, storage, inst.ID); got != oldName {
+		t.Fatalf("setup: persisted tmux name = %q, want %q", got, oldName)
+	}
+
+	// The mint. From here the new name exists ONLY in memory.
+	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
+		newName, inst.ID, "/tmp/proj", "shell", "running",
+	))
+
+	// Arm the abort: the DB has been written since we loaded. Backdating
+	// lastLoadMtime reproduces exactly the condition saveInstancesWithForce
+	// tests (currentMtime.After(ourLoadMtime)).
+	armed := before.Add(-time.Hour)
+	home.reloadMu.Lock()
+	home.lastLoadMtime = armed
+	home.reloadMu.Unlock()
+
+	model, _ := home.Update(sessionRestartedMsg{sessionID: inst.ID, err: nil})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("Update returned %T, want *Home", model)
+	}
+
+	if got := persistedTmuxName(t, storage, inst.ID); got != newName {
+		t.Fatalf("persisted tmux name = %q, want %q: the restart's new tmux name "+
+			"was not written, so a reload restores the dead name and the TUI reports "+
+			"a false error for a session whose process is running", got, newName)
+	}
+
+	// The save must also advance lastLoadMtime past the value that armed the
+	// abort. Otherwise the next restart aborts on the same stale reading, which
+	// is what made the original failure self-sustaining instead of a one-off.
+	h.reloadMu.Lock()
+	gotLoadMtime := h.lastLoadMtime
+	h.reloadMu.Unlock()
+	if !gotLoadMtime.After(armed) {
+		t.Errorf("lastLoadMtime = %v, want advanced past the armed value %v: leaving it "+
+			"stale makes the next restart abort for the same reason, so retries never persist",
+			gotLoadMtime, armed)
+	}
+}
+
+// A failed restart must not write: nothing was recreated, so there is no new
+// name to persist and no reason to push this TUI's snapshot over a peer's rows.
+// This pins an invariant rather than guarding the fix -- it passes either way.
+func TestRestartMsg_FailureDoesNotSave(t *testing.T) {
+	home, storage := newRestartSaveHome(t, "_restartsavefail")
+	defer storage.Close()
+
+	inst := home.instances[0]
+	const name = "agentdeck_target_deadbeef"
+	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
+		name, inst.ID, "/tmp/proj", "shell", "running",
+	))
+	home.forceSaveInstances()
+
+	// A name that must NOT reach storage, since the restart fails.
+	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
+		"agentdeck_target_never", inst.ID, "/tmp/proj", "shell", "running",
+	))
+
+	model, _ := home.Update(sessionRestartedMsg{
+		sessionID: inst.ID,
+		err:       os.ErrPermission,
+	})
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("Update returned %T, want *Home", model)
+	}
+
+	if got := persistedTmuxName(t, storage, inst.ID); got != name {
+		t.Errorf("persisted tmux name = %q, want %q: a failed restart recreated "+
+			"nothing, so it must not overwrite the stored name", got, name)
+	}
+}
+
+// persistedTmuxName round-trips through storage and returns the tmux session
+// name recorded for id, which is what a reload would restore.
+func persistedTmuxName(t *testing.T, storage *session.Storage, id string) string {
+	t.Helper()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	for _, inst := range instances {
+		if inst.ID != id {
+			continue
+		}
+		sess := inst.GetTmuxSession()
+		if sess == nil {
+			return ""
+		}
+		return sess.Name
+	}
+	t.Fatalf("session %q missing from storage", id)
+	return ""
+}
+
+// newRestartSaveHome builds a Home backed by real storage under an isolated
+// HOME, holding one session. storageWatcher is nil so an aborted save cannot
+// trigger a real reload mid-test.
+func newRestartSaveHome(t *testing.T, profile string) (*Home, *session.Storage) {
+	t.Helper()
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		session.ClearUserConfigCache()
+	})
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile(%q): %v", profile, err)
+	}
+
+	home := NewHome()
+	home.width, home.height = 100, 30
+	home.storage = storage
+	home.profile = profile
+	home.storageWatcher = nil
+
+	// A real session so the "refuse to save empty over non-empty" guard does
+	// not short-circuit the save under test.
+	inst := session.NewInstance("restart-target", "/tmp/proj")
+	inst.Tool = "shell"
+	inst.Status = session.StatusRunning
+	inst.GroupPath = session.DefaultGroupPath
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	return home, storage
+}

--- a/internal/ui/restart_save_external_change_test.go
+++ b/internal/ui/restart_save_external_change_test.go
@@ -2,167 +2,234 @@ package ui
 
 import (
 	"os"
+	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // A restart gives a session a NEW tmux session name: restart() kills the old
-// tmux session and calls recreateTmuxSession (internal/session/instance.go),
-// which builds a fresh one through tmux.NewSession -- and that mints
-// SessionPrefix + name + "_" + a new short id unconditionally. The new name
-// lives only on the in-memory Instance until the sessionRestartedMsg handler
-// saves it.
+// tmux session and calls recreateTmuxSession, whose tmux.NewSession mints
+// SessionPrefix + name + "_" + a fresh short id unconditionally. That name is
+// the only handle anything has on the live process.
 //
-// A routine save aborts when it detects the state DB changed since this TUI
-// last loaded, and the reload it schedules instead replaces h.instances
-// wholesale with the on-disk rows -- whose tmux_session column still holds the
-// DEAD name. The TUI then polls a tmux session that does not exist and renders
-// "error" for a session whose process is running fine, and retrying cannot
-// clear it because the abort leaves lastLoadMtime behind a concurrent writer.
+// The name and the status the restart ended in are made durable where they are
+// produced, by a targeted two-column write inside Instance.restart. What is
+// under test here is the TUI half: the save that follows a restart must persist
+// the rest of the restart WITHOUT ever pushing this TUI's whole in-memory
+// snapshot, because that snapshot may be stale and a whole-snapshot write
+// reverts whatever another process changed in the meantime.
 
-// TestRestartMsg_PersistsNewTmuxNameDespiteExternalChange is the regression
-// guard. It asserts the real contract: after a successful restart under a
-// detected external change, the name that survives a round-trip through storage
-// is the NEW one, not the dead one.
-func TestRestartMsg_PersistsNewTmuxNameDespiteExternalChange(t *testing.T) {
-	home, storage := newRestartSaveHome(t, "_restartsaveext")
-	defer storage.Close()
-
-	inst := home.instances[0]
-
-	// Stand in for what restart() does to a live session: the Instance now
-	// carries a tmux session under a freshly minted name, while the row on
-	// disk still names the old one.
-	const oldName = "agentdeck_target_deadbeef"
-	const newName = "agentdeck_target_f00dcafe"
-
-	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
-		oldName, inst.ID, "/tmp/proj", "shell", "running",
-	))
-	home.forceSaveInstances()
-
-	before, err := storage.GetFileMtime()
-	if err != nil {
-		t.Fatalf("GetFileMtime: %v", err)
-	}
-	if got := persistedTmuxName(t, storage, inst.ID); got != oldName {
-		t.Fatalf("setup: persisted tmux name = %q, want %q", got, oldName)
-	}
-
-	// The mint. From here the new name exists ONLY in memory.
-	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
-		newName, inst.ID, "/tmp/proj", "shell", "running",
-	))
-
-	// Arm the abort: the DB has been written since we loaded. Backdating
-	// lastLoadMtime reproduces exactly the condition saveInstancesWithForce
-	// tests (currentMtime.After(ourLoadMtime)).
-	armed := before.Add(-time.Hour)
-	home.reloadMu.Lock()
-	home.lastLoadMtime = armed
-	home.reloadMu.Unlock()
-
-	model, _ := home.Update(sessionRestartedMsg{sessionID: inst.ID, err: nil})
-	h, ok := model.(*Home)
-	if !ok {
-		t.Fatalf("Update returned %T, want *Home", model)
-	}
-
-	if got := persistedTmuxName(t, storage, inst.ID); got != newName {
-		t.Fatalf("persisted tmux name = %q, want %q: the restart's new tmux name "+
-			"was not written, so a reload restores the dead name and the TUI reports "+
-			"a false error for a session whose process is running", got, newName)
-	}
-
-	// The save must also advance lastLoadMtime past the value that armed the
-	// abort. Otherwise the next restart aborts on the same stale reading, which
-	// is what made the original failure self-sustaining instead of a one-off.
-	h.reloadMu.Lock()
-	gotLoadMtime := h.lastLoadMtime
-	h.reloadMu.Unlock()
-	if !gotLoadMtime.After(armed) {
-		t.Errorf("lastLoadMtime = %v, want advanced past the armed value %v: leaving it "+
-			"stale makes the next restart abort for the same reason, so retries never persist",
-			gotLoadMtime, armed)
+func skipIfNoTmuxBinaryUI(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
 	}
 }
 
-// A failed restart must not write: nothing was recreated, so there is no new
-// name to persist and no reason to push this TUI's snapshot over a peer's rows.
-// This pins an invariant rather than guarding the fix -- it passes either way.
+// TestRestartMsg_ConcurrentRenameSurvivesAndOutcomePersists is the regression
+// guard for the pair, and for the failure mode that matters most.
+//
+// A CLI renames one session while the TUI is holding a snapshot from before
+// that rename, and the TUI then restarts a DIFFERENT session. Two things have
+// to be true afterwards: the rename is still there, and the restart's outcome
+// reached the database anyway.
+//
+// Force-saving here — the first shape of this fix — got the second and lost the
+// first: it pushed the stale snapshot, and the renamed title reverted. That is
+// the lost-update class behind this repository's documented data-loss
+// incidents, and it is strictly worse than the stale tmux name it was curing.
+func TestRestartMsg_ConcurrentRenameSurvivesAndOutcomePersists(t *testing.T) {
+	skipIfNoTmuxBinaryUI(t)
+
+	home, storage := newRestartSaveHome(t, "_restartsaveconcurrent")
+	keeper, target := home.instances[0], home.instances[1]
+
+	// A second process — a `agent-deck session set <id> title` — renames the
+	// bystander after this TUI loaded, so the TUI's snapshot is now stale.
+	const renamed = "renamed-by-cli"
+	renameThroughAnotherProcess(t, keeper.ID, renamed)
+
+	// The TUI restarts the OTHER session for real. This mints a new tmux name
+	// and records it, plus the status, at the chokepoint.
+	if err := target.Restart(); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	t.Cleanup(func() {
+		if sess := target.GetTmuxSession(); sess != nil {
+			_ = sess.Kill()
+		}
+	})
+	minted := target.GetTmuxSession()
+	if minted == nil {
+		t.Fatal("restart left no tmux session")
+	}
+
+	model, _ := home.Update(sessionRestartedMsg{sessionID: target.ID})
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("Update returned %T, want *Home", model)
+	}
+
+	if got := storedTitle(t, storage, keeper.ID); got != renamed {
+		t.Errorf("stored title = %q, want %q: the restart save pushed this TUI's stale snapshot "+
+			"and reverted a rename another process had already committed", got, renamed)
+	}
+	if got := storedTmuxName(t, storage, target.ID); got != minted.Name {
+		t.Errorf("stored tmux name = %q, want the minted %q: the restart's outcome has to be "+
+			"durable whether or not the save that follows it aborts", got, minted.Name)
+	}
+	if got := storedStatus(t, storage, target.ID); got != string(target.Status) {
+		t.Errorf("stored status = %q, want %q: a row naming a live pane while still marked error "+
+			"misreports the session just as badly as one naming a dead pane", got, target.Status)
+	}
+}
+
+// TestRestartMsg_OwnWriteIsNotTreatedAsExternal pins the other half. With no
+// other writer, the restart's own targeted write must not make the TUI mistake
+// itself for a competing process — that false positive is what aborted the save
+// after every restart and dropped the rest of the restart's in-memory state.
+func TestRestartMsg_OwnWriteIsNotTreatedAsExternal(t *testing.T) {
+	skipIfNoTmuxBinaryUI(t)
+
+	home, storage := newRestartSaveHome(t, "_restartsaveown")
+	target := home.instances[1]
+
+	if err := target.Restart(); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	t.Cleanup(func() {
+		if sess := target.GetTmuxSession(); sess != nil {
+			_ = sess.Kill()
+		}
+	})
+
+	// Stand in for the in-memory state a restart leaves behind that only the
+	// snapshot save carries. If the save aborts, this never reaches disk.
+	target.Notes = "restart-mutation"
+
+	model, _ := home.Update(sessionRestartedMsg{sessionID: target.ID})
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("Update returned %T, want *Home", model)
+	}
+
+	if got := storedNotes(t, storage, target.ID); got != "restart-mutation" {
+		t.Errorf("stored notes = %q, want %q: with no competing writer the save must go through, "+
+			"otherwise the TUI is aborting on its own restart write", got, "restart-mutation")
+	}
+}
+
+// TestRestartMsg_FailureDoesNotSave pins an invariant rather than the fix: a
+// failed restart recreated nothing, so it must not push this TUI's snapshot
+// over another process's rows.
 func TestRestartMsg_FailureDoesNotSave(t *testing.T) {
 	home, storage := newRestartSaveHome(t, "_restartsavefail")
-	defer storage.Close()
+	target := home.instances[1]
 
-	inst := home.instances[0]
-	const name = "agentdeck_target_deadbeef"
-	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
-		name, inst.ID, "/tmp/proj", "shell", "running",
-	))
-	home.forceSaveInstances()
-
-	// A name that must NOT reach storage, since the restart fails.
-	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
-		"agentdeck_target_never", inst.ID, "/tmp/proj", "shell", "running",
-	))
+	const renamed = "renamed-during-failed-restart"
+	renameThroughAnotherProcess(t, home.instances[0].ID, renamed)
+	target.Notes = "must-not-reach-disk"
 
 	model, _ := home.Update(sessionRestartedMsg{
-		sessionID: inst.ID,
+		sessionID: target.ID,
 		err:       os.ErrPermission,
 	})
 	if _, ok := model.(*Home); !ok {
 		t.Fatalf("Update returned %T, want *Home", model)
 	}
 
-	if got := persistedTmuxName(t, storage, inst.ID); got != name {
-		t.Errorf("persisted tmux name = %q, want %q: a failed restart recreated "+
-			"nothing, so it must not overwrite the stored name", got, name)
+	if got := storedTitle(t, storage, home.instances[0].ID); got != renamed {
+		t.Errorf("stored title = %q, want %q: a failed restart wrote nothing worth risking "+
+			"another process's rows for", got, renamed)
+	}
+	if got := storedNotes(t, storage, target.ID); got == "must-not-reach-disk" {
+		t.Error("a failed restart persisted this TUI's snapshot anyway")
 	}
 }
 
-// persistedTmuxName round-trips through storage and returns the tmux session
-// name recorded for id, which is what a reload would restore.
-func persistedTmuxName(t *testing.T, storage *session.Storage, id string) string {
+// renameThroughAnotherProcess edits one row the way a separate agent-deck CLI
+// process would: its own handle on the same database, a targeted write, and a
+// last_modified bump the TUI has not seen.
+func renameThroughAnotherProcess(t *testing.T, id, title string) {
+	t.Helper()
+	db := statedb.GetGlobal()
+	if db == nil {
+		t.Fatal("no state database registered")
+	}
+	applied, err := db.UpdateTitleIfUnlocked(id, title)
+	if err != nil {
+		t.Fatalf("UpdateTitleIfUnlocked: %v", err)
+	}
+	if !applied {
+		t.Fatalf("rename of %q was not applied", id)
+	}
+	if err := db.Touch(); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+}
+
+func storedRow(t *testing.T, storage *session.Storage, id string) *session.Instance {
 	t.Helper()
 	instances, _, err := storage.LoadWithGroups()
 	if err != nil {
 		t.Fatalf("LoadWithGroups: %v", err)
 	}
 	for _, inst := range instances {
-		if inst.ID != id {
-			continue
+		if inst.ID == id {
+			return inst
 		}
-		sess := inst.GetTmuxSession()
-		if sess == nil {
-			return ""
-		}
-		return sess.Name
 	}
 	t.Fatalf("session %q missing from storage", id)
+	return nil
+}
+
+func storedTitle(t *testing.T, storage *session.Storage, id string) string {
+	t.Helper()
+	return storedRow(t, storage, id).Title
+}
+
+func storedNotes(t *testing.T, storage *session.Storage, id string) string {
+	t.Helper()
+	return storedRow(t, storage, id).Notes
+}
+
+func storedStatus(t *testing.T, storage *session.Storage, id string) string {
+	t.Helper()
+	return string(storedRow(t, storage, id).Status)
+}
+
+// storedTmuxName round-trips through storage and returns the tmux session name
+// recorded for id, which is what a reload would restore.
+func storedTmuxName(t *testing.T, storage *session.Storage, id string) string {
+	t.Helper()
+	if sess := storedRow(t, storage, id).GetTmuxSession(); sess != nil {
+		return sess.Name
+	}
 	return ""
 }
 
-// newRestartSaveHome builds a Home backed by real storage under an isolated
-// HOME, holding one session. storageWatcher is nil so an aborted save cannot
-// trigger a real reload mid-test.
+// newRestartSaveHome builds a Home backed by real storage under the package's
+// isolated HOME, holding a bystander session plus a restart target whose stored
+// tmux session is dead — what a session looks like after a reboot, and what
+// forces restart() down the path that mints a new name.
+//
+// storageWatcher is nil so an aborted save cannot trigger a real reload
+// mid-test; the assertions read the database directly instead.
 func newRestartSaveHome(t *testing.T, profile string) (*Home, *session.Storage) {
 	t.Helper()
-
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", t.TempDir())
-	session.ClearUserConfigCache()
-	t.Cleanup(func() {
-		os.Setenv("HOME", origHome)
-		session.ClearUserConfigCache()
-	})
 
 	storage, err := session.NewStorageWithProfile(profile)
 	if err != nil {
 		t.Fatalf("NewStorageWithProfile(%q): %v", profile, err)
 	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	// main.go and NewHome both register the process-wide handle; the targeted
+	// restart write goes through it.
+	prev := statedb.GetGlobal()
+	statedb.SetGlobal(storage.GetDB())
+	t.Cleanup(func() { statedb.SetGlobal(prev) })
 
 	home := NewHome()
 	home.width, home.height = 100, 30
@@ -170,19 +237,29 @@ func newRestartSaveHome(t *testing.T, profile string) (*Home, *session.Storage) 
 	home.profile = profile
 	home.storageWatcher = nil
 
-	// A real session so the "refuse to save empty over non-empty" guard does
-	// not short-circuit the save under test.
-	inst := session.NewInstance("restart-target", "/tmp/proj")
-	inst.Tool = "shell"
-	inst.Status = session.StatusRunning
-	inst.GroupPath = session.DefaultGroupPath
+	keeper := session.NewInstance("bystander", t.TempDir())
+	keeper.Tool = "shell"
+	keeper.Status = session.StatusRunning
+	keeper.GroupPath = session.DefaultGroupPath
 
+	target := session.NewInstance("restart-target", t.TempDir())
+	target.Tool = "shell"
+	target.Status = session.StatusRunning
+	target.GroupPath = session.DefaultGroupPath
+	target.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(
+		"agentdeck_target_deadbeef", target.ID, target.ProjectPath, "shell", "running",
+	))
+
+	instances := []*session.Instance{keeper, target}
 	home.instancesMu.Lock()
-	home.instances = []*session.Instance{inst}
-	home.instanceByID[inst.ID] = inst
+	home.instances = instances
+	for _, inst := range instances {
+		home.instanceByID[inst.ID] = inst
+	}
 	home.instancesMu.Unlock()
 	home.groupTree = session.NewGroupTree(home.instances)
 	home.rebuildFlatItems()
 
+	home.forceSaveInstances()
 	return home, storage
 }


### PR DESCRIPTION
> **Note:** This MR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

A restarted session can sit in `error` forever while its tmux process runs normally, and pressing `Enter` or `R` makes it worse rather than better: each attempt leaks another orphaned tmux session and the error never clears.

## What the user sees

The TUI shows `× error` with **No tmux session running** for a session whose tmux process is alive and whose conversation is intact. Restarting appears to succeed, then the row returns to `error` a second later.

The state DB and tmux disagree about the session's name:

| session | DB has | tmux actually has |
|---|---|---|
| natera (healthy) | `agentdeck_natera_b94f666a` | `agentdeck_natera_b94f666a` |
| jdidion (error) | `agentdeck_jdidion_fc295af9` | `agentdeck_jdidion_4a9e37bb` |

## Why

Restart recreates the tmux session under a newly minted name. `restart()` kills the old session, then `recreateTmuxSession` builds a fresh one through `tmux.NewSession`, which mints unconditionally:

```go
func NewSession(name, workDir string) *Session {
	sanitized := sanitizeName(name)
	// Add unique suffix to prevent name collisions
	uniqueSuffix := generateShortID()
	return &Session{
		Name: SessionPrefix + sanitized + "_" + uniqueSuffix,
```

That name lives only in the in-memory `Instance` until `sessionRestartedMsg` persists it, and the save there was routine:

```go
// Save the updated session state (new tmux session name)
h.saveInstances()
```

`saveInstances` is `saveInstancesWithForce(false)`, and a non-forced save aborts when it detects the DB changed since this TUI last loaded:

```go
if externalChange && !force {
	// Routine save: abort and reload instead of overwriting with stale rows.
	if h.storageWatcher != nil {
		h.storageWatcher.TriggerReload()
	}
	return
}
```

The reload it schedules calls `LoadWithGroups()` and replaces `h.instances` with the rows on disk, reverting the new tmux name to the dead one. The TUI then polls a session that does not exist and reports `error`.

## Why retrying cannot fix it

An abort never advances `lastLoadMtime`, and the reload's own value is captured BEFORE its load (`home.go`, the reload `tea.Cmd`), so any write landing in that window leaves `lastLoadMtime` behind the DB and re-arms the abort. The failure sustains itself, and every attempt spawns another tmux session whose name is never recorded.

From a user's log, 16 `restart_start_succeeded` events against 15 dropped saves, each one succeeding and each one failing to persist:

```
06:05:36.056  restart_start_succeeded
06:05:36.218  restart_session_result           error=null
06:05:36.218  save_external_change_detected    force=false
              our_load=06:02:52.690  current_mtime=06:05:32.515
06:05:37.128  restart_start_succeeded
06:05:37.295  save_external_change_detected    force=false
              our_load=06:05:32.515  current_mtime=06:05:36.992
06:05:42.837  restart_start_succeeded
06:05:42.959  save_external_change_detected    force=false
              our_load=06:05:36.992  current_mtime=06:05:38.139
...
```

Each save's `our_load` equals the previous line's `current_mtime`: the cycle re-arms its own trigger. That user finished with a dozen orphaned tmux sessions, each running a Claude process against the same worktree.

## Reproducing it in one process

The mtime bump does not need a second process. `restartWithArchiveTransition` calls `persist(inst)` before `restart()`, and that routes to `persistArchived` → `SetArchived`, which calls `touchWithRetry()`. So the TUI stamps `last_modified` itself immediately ahead of the save that needs to land. The storage watcher also polls every 2s (`pollInterval`, `storage_watcher.go:38`), well inside the duration of a real restart.

## The fix

Force-save. `#1550` exempted force saves from the external-change abort precisely because they carry critical mutations, and a freshly minted tmux session name is that: without it the process is unreachable and the session is misreported as broken. The save is upsert-only, so it cannot delete a peer process's rows.

This also makes restart consistent with its siblings. Every other handler that mints tmux state already force-saves:

| handler | force saves | routine saves |
|---|---|---|
| `sessionCreatedMsg` | 2 | 0 |
| `sessionForkedMsg` | 2 | 0 |
| `sessionRestoredMsg` | 3 | 0 |
| `sessionDeletedMsg` | 1 | 0 |
| `sessionRestartedMsg` (before) | 0 | 1 |

`sessionRestoredMsg` is the closest comparison: it also recreates tmux, and it force-saves.

Scope, stated plainly: this fixes the save-time abort, not every concurrency hazard on the path. The restart runs in a `tea.Cmd` on its own goroutine, so a reload can land mid-restart and swap the pointers the handler later reads. Two pre-existing guards stop that from losing the name: the Cmd re-resolves the instance by ID at execution time (with a comment saying exactly why), and the handler re-resolves again before saving. A loss would require a reload wedged between `recreateTmuxSession` setting the field and the save reading it. That remains possible, but it is a one-off the next restart re-mints and re-saves, so it is a different severity class from the self-sustaining failure fixed here and is deliberately not addressed.

## Tests

`TestRestartMsg_PersistsNewTmuxNameDespiteExternalChange` asserts the real contract rather than a proxy for it: attach a tmux session under one name, save, mint a second name in memory only, arm the abort by backdating `lastLoadMtime`, then require that a round-trip through `LoadWithGroups` returns the NEW name. It also asserts the save advances `lastLoadMtime`, which is what stops the next restart from aborting on the same stale reading.

Verified against the unfixed line rather than assumed. Reverting `forceSaveInstances()` to `saveInstances()` fails with:

```
persisted tmux name = "agentdeck_target_deadbeef", want
"agentdeck_target_f00dcafe": the restart's new tmux name was not
written, so a reload restores the dead name and the TUI reports a false
error for a session whose process is running
```

`TestRestartMsg_FailureDoesNotSave` pins the other side: a failed restart recreated nothing, so it must not overwrite the stored name. It passes with or without the fix, so it is an invariant rather than a regression guard.

## Verification

- `go test ./internal/ui/` green, `ok ... 50.430s`, zero failures
- `golangci-lint run ./internal/ui/...` 0 issues
- `gofmt` and `go vet` clean
- Mutation-verified as above

## What to expect after upgrading

An error status is sticky: `errorRecheckInterval` is 30s and an already-errored session skips the tmux existence check until that elapses (`internal/session/instance.go:4654`, `:4897-4901`). So the first restart after this lands can take up to 30 seconds to drop the error badge. The name is persisted immediately; only the displayed status lags.

## Alternatives considered

A targeted `UPDATE instances SET tmux_session = ?` in the style of `persistArchived` would avoid pushing a whole snapshot, but restart also mutates `Status`, `SandboxContainer`, `HermesSessionID`, `OpenCodeStartedAt`/`CodexStartedAt` and the tool session-id fields. A single-column setter would persist the name and silently drop the rest, trading one narrow race for a partial-write inconsistency.

A `pendingTmuxName` following the `pendingTitleChanges` / `pendingGroupOps` pattern is unnecessary here. Those exist because a rename is applied by the UI goroutine and a reload can interleave; the restart's mint happens in a `tea.Cmd` and `sessionRestartedMsg` is handled on the same goroutine as `loadSessionsMsg`, which Bubble Tea serializes. Both of those reapply paths also end in `forceSaveInstances()`, so force-saving is the pattern's terminal step, not an alternative to it.

Worth stating plainly: a force save writes the full row, and only `tool_data`, `auto_name` and `auto_name_description` are merged from disk, so it can overwrite a concurrent `session set title`. That window is pre-existing and shared by the other 17 `forceSaveInstances()` call sites, and `statedb.go` documents `title` as deliberately not merge-protected. The trade favours the fix: the clobber is millisecond-wide and redoable, while the bug it fixes is a permanent false error plus unbounded tmux leakage that no retry can clear.

## Scope note

`mcpRestartedMsg` also calls the routine `saveInstances()` and is left alone: the type is declared and handled but never constructed anywhere in the repo, so the code path is unreachable. Worth deleting, but not in a fix PR.

Four CLI paths call `inst.Restart()` and never persist the new tmux name at all (`mcp_cmd.go:471`, `mcp_cmd.go:632`, `skill_cmd.go:24`, `plugin_cmd.go:243`, whose save at `:220` runs before the restart). They reach the same stale-name and orphan outcome independently of the TUI. Out of scope for a one-line TUI fix; I can file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session restarts now reliably save newly assigned terminal session names, even when stored session data changed externally.
  * Subsequent reloads no longer restore outdated terminal session names.
  * Failed restarts preserve the previously saved session name.

* **Tests**
  * Added coverage for successful and failed restart persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->