### PR TITLE
fix(tmux): re-check a pid's identity before signalling it

### DIFF
--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -907,7 +907,11 @@ func readProcessExe(pid int) (string, error) {
 // the same PID cannot share it in practice: reuse requires wrapping the whole
 // pid_max range, which takes far longer than the field's 10ms resolution.
 // macOS (or a Linux host without /proc) falls back to `ps -o lstart=`, the same
-// fact at second resolution.
+// fact at second resolution — which is the fallback's one real weakness: a pid
+// reused inside the same second reads as the same incarnation there, and the
+// guard passes it through. That is still strictly better than the bare pid it
+// replaces, and Linux, where this sweep's worst incident happened, gets the
+// 10ms field.
 //
 // Read errors are returned rather than swallowed: an unreadable identity is
 // the caller's signal that the guard cannot be armed, which is a different
@@ -1016,6 +1020,13 @@ func stillSameIncarnation(pid int, identity string) bool {
 //     one you signalled" — so without this check a well-behaved client that
 //     obeyed SIGTERM promptly is indistinguishable from one that ignored it,
 //     and the escalation lands on the new occupant.
+//
+// What this does NOT do is close the window — it narrows it. A pid can still
+// change hands between the check returning and the kill(2) landing; the race is
+// simply one syscall wide now instead of the ~500ms the escalation used to hold
+// it open. Closing it outright needs a handle the kernel resolves atomically —
+// pidfd_send_signal(2) on Linux 5.1+, which the host this surfaced on has —
+// and that is a bigger change than the sweep is worth today.
 //
 // signalled reports whether anything was sent at all. Callers count kills and
 // log one line per victim, and a pid the guard refused to touch is not a

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -681,10 +681,14 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		// 500ms fallback for clients that ignore TERM.
 		usedSIGKILL, signalled := softKillProcessChecked(pid, identity, controlClientKillGrace)
 		if !signalled {
-			// The pid changed hands between the snapshot and now. Nothing was
-			// signalled, so nothing is counted — the burst metric below exists
-			// to observe real kill cascades.
-			pipeLog.Debug("skipped_recycled_control_client_pid",
+			// Nothing was sent, so nothing is counted — the burst metric below
+			// exists to observe real kill cascades. Two causes share this
+			// branch and the event name stays neutral between them: the pid's
+			// identity no longer matches (it changed hands since the snapshot),
+			// or it was already gone by the time we signalled (ESRCH). Only
+			// the first is a recycled pid, and from here they are not
+			// distinguishable.
+			pipeLog.Debug("skipped_control_client_not_signalled",
 				slog.String("session", sessionLabel),
 				slog.Int("pid", pid))
 			continue
@@ -925,8 +929,15 @@ func readProcessIdentity(pid int) (string, error) {
 		}
 		return fields[startTimeIndex], nil
 	}
+	// Bounded, unlike the sibling ps probes: this one runs once per candidate
+	// pid on the boot path, where SweepStaleControlClients already refuses to
+	// let a hung query stall startup (staleControlSweepTimeout). A deadline
+	// miss surfaces as an error, which leaves the guard unarmed — the sweep
+	// keeps working, it just stops being able to detect reuse.
+	ctx, cancel := context.WithTimeout(context.Background(), processProbeTimeout)
+	defer cancel()
 	// #nosec G204 -- "ps" is a fixed binary; only arg is strconv.Itoa(int).
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
 	if err != nil {
 		return "", err
 	}
@@ -941,6 +952,12 @@ func readProcessIdentity(pid int) (string, error) {
 // to change hands mid-grace. Forcing a real reuse would take a full pid_max
 // wrap inside a 100ms window.
 var processIdentityOf = readProcessIdentity
+
+// processProbeTimeout bounds the `ps` fallback in readProcessIdentity so a
+// wedged probe cannot stall the boot-path sweep that calls it. Matches
+// staleControlSweepTimeout, which bounds the list-clients query feeding the
+// same sweep.
+var processProbeTimeout = 2 * time.Second
 
 // controlClientKillGrace is how long softKillProcess waits after SIGTERM
 // before escalating to SIGKILL. 500ms matches empirical clean-shutdown

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -651,6 +651,18 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		if pid == myPID {
 			continue // don't kill our own process
 		}
+		// Capture the identity now, while the decision is being made. Every
+		// check below reads /proc for this pid, and the kill can land up to
+		// grace-per-earlier-victim later; the identity is what ties the two
+		// ends together. An unreadable identity leaves the guard unarmed
+		// rather than skipping the kill, so a host that cannot report start
+		// times keeps the cleanup it had before (see softKillProcessChecked);
+		// a pid that is simply gone still falls out of the SIGTERM's ESRCH
+		// path as it always did.
+		identity, err := processIdentityOf(pid)
+		if err != nil {
+			identity = ""
+		}
 		if !isControlClientOrphan(pid) {
 			// Live sibling TUI — leave its pipe alone. Without this guard
 			// two concurrent agent-deck TUIs (allow_multiple=true) would
@@ -667,7 +679,16 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		// the entire tmux server, wiping every agent-deck session. A SIGTERM
 		// lets the client drain and exit cleanly; SIGKILL is retained as a
 		// 500ms fallback for clients that ignore TERM.
-		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
+		usedSIGKILL, signalled := softKillProcessChecked(pid, identity, controlClientKillGrace)
+		if !signalled {
+			// The pid changed hands between the snapshot and now. Nothing was
+			// signalled, so nothing is counted — the burst metric below exists
+			// to observe real kill cascades.
+			pipeLog.Debug("skipped_recycled_control_client_pid",
+				slog.String("session", sessionLabel),
+				slog.Int("pid", pid))
+			continue
+		}
 		killCount++
 		pipeLog.Debug("killed_stale_control_client",
 			slog.String("session", sessionLabel),
@@ -872,6 +893,55 @@ func readProcessExe(pid int) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// readProcessIdentity returns a token that distinguishes one incarnation of a
+// PID from the next. A PID alone does not identify a process: the kernel
+// reissues it once the number wraps, so a PID read out of a `list-clients`
+// snapshot can belong to something else by the time it is signalled.
+//
+// Linux uses starttime (field 22 of /proc/<pid>/stat) — the boot-relative tick
+// the process started on, which the kernel never rewrites. Two incarnations of
+// the same PID cannot share it in practice: reuse requires wrapping the whole
+// pid_max range, which takes far longer than the field's 10ms resolution.
+// macOS (or a Linux host without /proc) falls back to `ps -o lstart=`, the same
+// fact at second resolution.
+//
+// Read errors are returned rather than swallowed: an unreadable identity is
+// the caller's signal that the guard cannot be armed, which is a different
+// state from "the identity changed" and is handled differently — see
+// softKillProcessChecked.
+func readProcessIdentity(pid int) (string, error) {
+	if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+		// Same parse as readParentPID: the comm field can contain ')', so
+		// split after the LAST one. Fields then start at state (field 3), so
+		// starttime (field 22) sits at index 19.
+		idx := strings.LastIndex(string(data), ")")
+		if idx < 0 {
+			return "", fmt.Errorf("malformed /proc/%d/stat", pid)
+		}
+		fields := strings.Fields(string(data[idx+1:]))
+		const startTimeIndex = 19
+		if len(fields) <= startTimeIndex {
+			return "", fmt.Errorf("/proc/%d/stat: too few fields", pid)
+		}
+		return fields[startTimeIndex], nil
+	}
+	// #nosec G204 -- "ps" is a fixed binary; only arg is strconv.Itoa(int).
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	if err != nil {
+		return "", err
+	}
+	identity := strings.TrimSpace(string(out))
+	if identity == "" {
+		return "", fmt.Errorf("no start time for pid %d", pid)
+	}
+	return identity, nil
+}
+
+// processIdentityOf is the seam the PID-reuse tests swap to make a pid appear
+// to change hands mid-grace. Forcing a real reuse would take a full pid_max
+// wrap inside a 100ms window.
+var processIdentityOf = readProcessIdentity
+
 // controlClientKillGrace is how long softKillProcess waits after SIGTERM
 // before escalating to SIGKILL. 500ms matches empirical clean-shutdown
 // times for `tmux -C attach-session` on macOS + Linux.
@@ -882,14 +952,71 @@ const controlClientKillGrace = 500 * time.Millisecond
 // SIGKILL was ultimately used. A non-existent pid (ESRCH) is treated as
 // already-dead and returns false without escalation.
 func softKillProcess(pid int, grace time.Duration) bool {
+	identity, err := processIdentityOf(pid)
+	if err != nil {
+		// Unreadable, or already gone. Either way there is nothing to compare
+		// against; softKillProcessChecked treats "" as an unarmed guard and
+		// behaves exactly as this function did before the guard existed.
+		identity = ""
+	}
+	usedSIGKILL, _ := softKillProcessChecked(pid, identity, grace)
+	return usedSIGKILL
+}
+
+// stillSameIncarnation reports whether pid still refers to the process that
+// identity was taken from, i.e. whether it is still the process the caller
+// decided to kill.
+//
+// An empty identity means the caller could not establish one, so the guard is
+// unarmed and the signal proceeds — the pre-guard behaviour. A read that fails
+// now means the process is gone (or has become unreadable), and there is
+// nothing worth signalling either way.
+func stillSameIncarnation(pid int, identity string) bool {
+	if identity == "" {
+		return true
+	}
+	current, err := processIdentityOf(pid)
+	if err != nil {
+		return false
+	}
+	return current == identity
+}
+
+// softKillProcessChecked is softKillProcess for a caller that decided to kill
+// pid at some earlier point and captured its identity then. It re-checks that
+// identity immediately before each signal, so a PID that changed hands between
+// the decision and the signal is left alone.
+//
+// Both checks are load-bearing, and they close different windows:
+//
+//   - Before the SIGTERM, because the caller's decision can be arbitrarily
+//     old. reapStaleControlClients works through a `list-clients` snapshot
+//     sequentially and blocks up to grace per victim, so the last PID in a
+//     burst is acted on N × grace after it was observed.
+//   - Before the SIGKILL, because the victim may have exited cleanly inside
+//     the grace period and had its number reissued. The poll below uses
+//     kill(pid, 0), which answers "some process holds this number", not "the
+//     one you signalled" — so without this check a well-behaved client that
+//     obeyed SIGTERM promptly is indistinguishable from one that ignored it,
+//     and the escalation lands on the new occupant.
+//
+// signalled reports whether anything was sent at all. Callers count kills and
+// log one line per victim, and a pid the guard refused to touch is not a
+// victim — reporting it as one would make the sweep's burst metric, which
+// exists to observe the kill cascade, count kills that never happened.
+func softKillProcessChecked(pid int, identity string, grace time.Duration) (usedSIGKILL, signalled bool) {
+	if !stillSameIncarnation(pid, identity) {
+		return false, false
+	}
+
 	// Initial SIGTERM. If the process is already gone, we're done.
 	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return false
+			return false, false
 		}
 		// Permission or other error — try SIGKILL as last resort.
 		_ = syscall.Kill(pid, syscall.SIGKILL)
-		return true
+		return true, true
 	}
 
 	// Poll for exit. syscall.Kill(pid, 0) returns ESRCH once the process
@@ -903,13 +1030,17 @@ func softKillProcess(pid int, grace time.Duration) bool {
 	for time.Now().Before(deadline) {
 		time.Sleep(pollInterval)
 		if err := syscall.Kill(pid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
-			return false
+			return false, true
 		}
 	}
 
-	// Still alive after grace — escalate.
+	// Something still holds the number after grace. Escalate only if it is
+	// still the process we signalled.
+	if !stillSameIncarnation(pid, identity) {
+		return false, true
+	}
 	_ = syscall.Kill(pid, syscall.SIGKILL)
-	return true
+	return true, true
 }
 
 // softKillProcessGroup is the process-group analogue of softKillProcess.

--- a/internal/tmux/softkill_pid_reuse_test.go
+++ b/internal/tmux/softkill_pid_reuse_test.go
@@ -190,6 +190,13 @@ func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T)
 	usedSIGKILL := softKillProcess(pid, 100*time.Millisecond)
 
 	assert.False(t, usedSIGKILL, "escalation must not fire once the pid changed hands")
+	// Without this, the test passes just as happily when the SIGTERM never went
+	// out at all — a pre-signal check that started failing would skip straight
+	// past the escalation this test exists to cover, and usedSIGKILL would be
+	// false for the wrong reason. The third read IS the escalation check, so
+	// reaching it proves the guarded path ran end to end.
+	assert.GreaterOrEqual(t, calls, 3,
+		"the escalation check must have been reached (capture, pre-signal check, then escalation)")
 	select {
 	case <-exited:
 		t.Fatal("the new occupant of the pid was SIGKILL'd by the escalation")

--- a/internal/tmux/softkill_pid_reuse_test.go
+++ b/internal/tmux/softkill_pid_reuse_test.go
@@ -1,0 +1,212 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A PID is not a stable name for a process. The sweeps in this file signal PIDs
+// they read out of a `list-clients` snapshot, and between that read and the
+// signal the client can exit and the kernel can hand its number to something
+// else. Two windows exist:
+//
+//   - Snapshot → SIGTERM. reapStaleControlClients kills sequentially and
+//     softKillProcess blocks up to controlClientKillGrace per victim, so with N
+//     stale clients the last line of the snapshot is up to N × 500ms old by the
+//     time it is acted on.
+//   - SIGTERM → SIGKILL. The escalation fires grace later, and the poll that
+//     decides it uses kill(pid, 0) — which cannot tell "still alive" from
+//     "died and the number was reissued".
+//
+// The guard is an identity captured with the decision and re-checked against
+// the live process immediately before each signal. These tests pin that the
+// guard blocks a signal when the identity no longer matches, and — just as
+// important — that it does not otherwise change who gets killed.
+
+// TestReadProcessIdentity_StableForOneIncarnation pins the property the guard
+// rests on: reading the same live process twice yields the same identity, so a
+// mismatch means the PID changed hands rather than that the read is noisy.
+func TestReadProcessIdentity_StableForOneIncarnation(t *testing.T) {
+	first, err := readProcessIdentity(os.Getpid())
+	require.NoError(t, err, "own identity must be readable")
+	require.NotEmpty(t, first, "identity must not be empty for a live process")
+
+	time.Sleep(20 * time.Millisecond)
+
+	second, err := readProcessIdentity(os.Getpid())
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "identity must not drift while the process lives")
+}
+
+// TestReadProcessIdentity_FailsForDeadProcess pins that a reaped PID has no
+// identity to compare against, which is what makes the guard fail closed for a
+// victim that is already gone.
+func TestReadProcessIdentity_FailsForDeadProcess(t *testing.T) {
+	cmd := spawnHelper(t, "clean")
+	pid := cmd.Process.Pid
+	require.NoError(t, cmd.Process.Kill())
+	_, _ = cmd.Process.Wait()
+
+	_, err := readProcessIdentity(pid)
+	assert.Error(t, err, "a reaped pid must not report an identity")
+}
+
+// TestSoftKillProcessChecked_SignalsWhenIdentityMatches is the no-regression
+// half: the guard must not turn the sweep inert. The child's SIGTERM handler
+// writes a marker, and SIGKILL cannot be trapped, so the marker is proof the
+// TERM path ran.
+func TestSoftKillProcessChecked_SignalsWhenIdentityMatches(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+	pid := cmd.Process.Pid
+
+	// Reap concurrently so the kill(pid, 0) poll sees ESRCH rather than a
+	// zombie — production has tmux reaping its own clients.
+	waitDone := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-waitDone
+	})
+
+	identity, err := readProcessIdentity(pid)
+	require.NoError(t, err)
+
+	_, signalled := softKillProcessChecked(pid, identity, 500*time.Millisecond)
+
+	assert.True(t, signalled, "a matching identity must report the kill as delivered")
+	assert.NoError(t, waitForFile(marker, 5*time.Second),
+		"a matching identity must not block the SIGTERM")
+}
+
+// TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged is the guard doing
+// its job on the snapshot→SIGTERM window. A stale identity stands in for the
+// real hazard — the PID we validated died and its number now belongs to an
+// unrelated process — because forcing a genuine PID wrap inside a test would
+// take pid_max allocations and prove no more than this does.
+//
+// Both assertions matter: the process outliving the call proves no signal of
+// either kind landed, and the marker's absence identifies which one would have
+// (the "clean" helper writes it from its SIGTERM handler).
+func TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+	pid := cmd.Process.Pid
+
+	// Survival is asserted by waiting on the process rather than by
+	// kill(pid, 0): between a signal landing and the parent's wait() the pid
+	// is a zombie that still answers signal 0, so a bare liveness probe would
+	// pass against the unguarded code and prove nothing.
+	exited := waitForExit(cmd)
+
+	usedSIGKILL, signalled := softKillProcessChecked(pid, "not-the-identity-we-validated", 100*time.Millisecond)
+
+	assert.False(t, usedSIGKILL, "a process we refused to signal cannot have been SIGKILL'd")
+	// The caller counts kills and logs one line per victim from this flag, so a
+	// skipped signal must not be reported as a kill.
+	assert.False(t, signalled, "a skipped signal must not be reported as delivered")
+
+	select {
+	case <-exited:
+		t.Fatal("a pid whose identity changed was signalled anyway")
+	case <-time.After(300 * time.Millisecond):
+	}
+	_, statErr := os.Stat(marker)
+	assert.Error(t, statErr, "no SIGTERM may reach a pid whose identity changed")
+}
+
+// TestSoftKillProcessChecked_SignalsWhenIdentityUnknown pins the deliberate
+// fail-open: on a host where identity cannot be established the guard is
+// disabled rather than the kill being skipped. Skipping would regress the
+// stale-client cleanup (#595) on exactly the hosts that cannot self-diagnose,
+// whereas a disabled guard is only as bad as the behaviour that shipped before
+// it existed.
+func TestSoftKillProcessChecked_SignalsWhenIdentityUnknown(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+
+	waitDone := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-waitDone
+	})
+
+	_, signalled := softKillProcessChecked(cmd.Process.Pid, "", 500*time.Millisecond)
+
+	assert.True(t, signalled, "an unarmed guard must still report a delivered kill")
+	assert.NoError(t, waitForFile(marker, 5*time.Second),
+		"an unreadable identity must disable the guard, not the kill")
+}
+
+// TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace covers the
+// second window, which no caller can close for itself: the victim accepted the
+// SIGTERM, exited inside the grace period, and its number was reissued before
+// the escalation. kill(pid, 0) still succeeds, so the unguarded code reads that
+// as "ignored my SIGTERM" and SIGKILLs whoever holds the number now.
+//
+// The seam supplies the real identity for the pre-SIGTERM check and a different
+// one afterwards, which is what a PID handed to a new process looks like from
+// here. The "ignore" helper drains SIGTERM and blocks forever, so it survives
+// to the escalation and its death would be unambiguous evidence of a SIGKILL.
+func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T) {
+	cmd := spawnHelper(t, "ignore")
+	pid := cmd.Process.Pid
+
+	live, err := readProcessIdentity(pid)
+	require.NoError(t, err)
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+
+	// Two reads happen before the SIGTERM — softKillProcess captures the
+	// identity, then the pre-signal check confirms it — and both must agree or
+	// the SIGTERM never goes out and the escalation is never reached. Every
+	// read after that is the escalation check, which must see a stranger.
+	calls := 0
+	processIdentityOf = func(p int) (string, error) {
+		calls++
+		if calls <= 2 {
+			return live, nil
+		}
+		return "recycled-during-grace", nil
+	}
+
+	exited := waitForExit(cmd)
+
+	usedSIGKILL := softKillProcess(pid, 100*time.Millisecond)
+
+	assert.False(t, usedSIGKILL, "escalation must not fire once the pid changed hands")
+	select {
+	case <-exited:
+		t.Fatal("the new occupant of the pid was SIGKILL'd by the escalation")
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// waitForExit reaps cmd in the background and returns a channel closed when it
+// exits. Waiting is the only conclusive way to assert a process was NOT
+// signalled: a killed-but-unwaited child stays a zombie that answers
+// kill(pid, 0) with nil, so a liveness probe passes whether or not the signal
+// was sent (see the bash/zombie notes in CLAUDE.md).
+func waitForExit(cmd *exec.Cmd) <-chan struct{} {
+	exited := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(exited)
+	}()
+	return exited
+}


### PR DESCRIPTION
## What problem does this solve?

The two sweeps in `internal/tmux/pipemanager.go` signal PIDs they decided about earlier, and a PID is not a stable name for a process. If the pid changes hands in between, the signal lands on whatever holds that number now — for a user, an unrelated process on their machine gets a SIGTERM (or a SIGKILL) from agent-deck's startup sweep.

Follow-up to a non-blocking review note on #1832: *"`softKillProcess` signals by bare PID with no re-validation immediately before the signal (same pattern as `reapStaleControlClients`) — a PID-reuse window between the `/proc` reads and the kill, narrow but real."* This PR closes it. It stands alone and does not depend on #1832.

## Why this change

There are two windows, and they are not the same size:

- **Snapshot → SIGTERM.** `reapStaleControlClients` works through one `list-clients` snapshot sequentially, and `softKillProcess` blocks up to `controlClientKillGrace` (500ms) per victim. The last pid in a burst is signalled up to N × 500ms after tmux reported it. #595 saw 176 orphaned control clients on one host, so N is not hypothetical.
- **SIGTERM → SIGKILL.** The escalation fires `grace` later and decides on `kill(pid, 0)`, which answers *"some process holds this number"*, not *"the one you signalled"*. A client that obeyed SIGTERM promptly and exited is indistinguishable from one that ignored it. This half needs no pid_max wrap to be wrong about what it is looking at — only a reissue inside a 500ms window.

`readProcessIdentity` returns a token that separates one incarnation of a pid from the next: `starttime` (field 22 of `/proc/<pid>/stat`) on Linux, which the kernel never rewrites, and `ps -o lstart=` elsewhere. Two incarnations of one pid cannot share it in practice — reuse takes a full pid_max wrap, far longer than the field's 10ms resolution.

`softKillProcessChecked` takes an identity captured when the decision was made and re-checks it immediately before each signal. `softKillProcess` keeps its signature and captures its own, so **the escalation half applies to every existing caller with no call-site change** — including `reapOrphanedPollClients`, whether or not #1832 lands. `reapStaleControlClients` captures earlier, before `isControlClientOrphan`, so the guard covers all the `/proc` reads its decision rests on.

Two deliberate choices worth arguing with:

- **Fail-open.** An identity that cannot be read *at all* leaves the guard unarmed and the kill proceeds. Failing closed would turn the #595 cleanup inert on exactly the hosts that cannot report start times. A read that fails *later* means the process is gone, and there is nothing to signal either way.
- **`signalled` return.** A pid the guard refuses is no longer counted by `killCount` or logged as `killed_stale_control_client`; it logs `skipped_recycled_control_client_pid` instead. The burst metric exists to observe kill cascades, so counting kills that never happened would make it lie.

Considered and rejected: re-reading `comm` before the signal. It is cheaper but only catches reuse by a non-tmux process, and it cannot distinguish a recycled pid that happens to be another tmux client — which is the likely occupant on a host running many of them.

## User impact

An unrelated process that inherits a recycled pid no longer receives agent-deck's SIGTERM/SIGKILL. No user-visible change otherwise: the same stale control clients are swept, and hosts where start times cannot be read behave exactly as before.

## Evidence

**The guard is what makes the tests pass.** With `stillSameIncarnation` forced to `return true` (i.e. pre-guard behaviour), on this branch:

```
--- FAIL: TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged (0.10s)
        Error:      Should be false
        Messages:   a skipped signal must not be reported as delivered
    softkill_pid_reuse_test.go:121: a pid whose identity changed was signalled anyway
--- FAIL: TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace (0.15s)
        Error:      Should be false
        Messages:   escalation must not fire once the pid changed hands
    softkill_pid_reuse_test.go:195: the new occupant of the pid was SIGKILL'd by the escalation
FAIL
```

With the guard restored:

```
--- PASS: TestReadProcessIdentity_StableForOneIncarnation (0.02s)
--- PASS: TestReadProcessIdentity_FailsForDeadProcess (0.03s)
--- PASS: TestSoftKillProcessChecked_SignalsWhenIdentityMatches (0.01s)
--- PASS: TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged (0.31s)
--- PASS: TestSoftKillProcessChecked_SignalsWhenIdentityUnknown (0.01s)
--- PASS: TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace (0.41s)
ok      github.com/asheshgoplani/agent-deck/internal/tmux        0.834s
```

Survival is asserted by waiting on the child, not with `kill(pid, 0)`: a killed-but-unwaited child is a zombie that still answers signal 0, so a liveness probe passes against the unguarded code and proves nothing.

Noting the self-check's `revert-check` WARN honestly: these tests cannot be run against pristine `main` as-is, because they name symbols this PR introduces (`readProcessIdentity`, `softKillProcessChecked`, `processIdentityOf`). Disabling the guard in place, as above, is the equivalent demonstration — same tests, same binary, only the re-check removed. They were also written before the guard existed and watched fail against a scaffold that ignored the identity, which is the same failure output.

**Hot path (startup / tmux layer).** The guard adds one `/proc/<pid>/stat` read per candidate at decision time and one per signal. Measured on the affected host (Linux 5.4, NVMe):

```
20000 reads in 203.106664ms — 10.2 µs/read
worst realistic sweep (176 stale clients x 2 reads): 3.574677ms
```

176 is the #595 worst case; the sweep it sits inside already spends 500ms per victim, so the added cost is ~0.001% of it.

**Suites.** `go build ./...`, `go vet ./...`, `gofmt -l` clean; `golangci-lint run internal/tmux/...` → `0 issues`. `go test -race` on the softkill and control-sweep tests: ok.

Sandboxed, serialized (`-p 1`, the parallel form has tmux-contention flakes on pristine `main` too):

```
--- FAIL: TestPersistence_TmuxDiesWithoutUserScope   (internal/session)
--- FAIL: TestAggregateSize_ReportsLargestClient     (internal/testutil/multiclienttmux)
```

Both are environment-only on this box and reproduce identically on pristine `upstream/main` — cgroup v2 `cgroup.kill` on a cgroup v1 host, and a tmux 3.0a size report. Everything else passes. `internal/tmux` alone passes sandboxed on this branch (`ok 40.171s`); pristine `upstream/main` under the *parallel* `./internal/...` form fails a different, moving set including `TestSweepStaleControlClients_AcrossAllSessions`, which is what identifies those as contention rather than regression.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

This came out of your own review note on #1832, and my human's instruction was direct: *"do the reapStaleControlClients fix as a separate PR"* — i.e. don't smuggle it into the diff that is already blocked on something else. The concrete worry is the shape of the #595 host: 176 stale clients swept sequentially at 500ms each is a snapshot that is over a minute stale by the end, on a box busy enough to be churning pids. Nobody would ever attribute the resulting stray SIGTERM to agent-deck.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed — two documented environment-only failures remain (see Evidence); both reproduce on pristine `upstream/main`
- [x] If this touches a hot path: before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process cleanup safety by verifying that a process still matches its original identity before sending termination signals.
  * Prevented signals from reaching a different process when a process ID is recycled.
  * Prevented unintended force-termination escalation after process ID reuse.
  * Preserved cleanup behavior when process identity information is unavailable.

* **Tests**
  * Added coverage for stable and unavailable identities, guarded signaling, and process ID recycling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->