### PR TITLE
fix(watcher): stop health-checking adapters whose Setup failed (#1886)

### DIFF
--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -74,8 +74,13 @@ type adapterEntry struct {
 	// their *http.Client after validating the topic — so probing it can panic
 	// (#1886). It also decides who owns cleanup: a failed attempt is torn down
 	// immediately by setupAdapter, so Stop only tears down entries that are
-	// still holding a successful Setup. Only Start writes this field, before
-	// healthLoop is launched, so the later reads are race-free.
+	// still holding a successful Setup.
+	//
+	// setupAdapter is the only writer, and Start calls it before healthLoop is
+	// launched, so the later reads are race-free. Stop must keep it that way:
+	// its teardown pass runs after cancel() but before wg.Wait() returns, so
+	// healthLoop may still be reading this field, and stopOnce — not clearing
+	// the flag — is what makes that pass run at most once.
 	setupOK bool
 }
 
@@ -676,13 +681,13 @@ func (e *Engine) Stop() {
 		// Entries whose Setup failed were already torn down by setupAdapter at
 		// the moment they failed, so skipping them here is what makes cleanup
 		// exactly-once rather than twice (#1886). stopOnce keeps a second Stop
-		// from repeating this pass.
+		// from repeating this pass — this loop only reads setupOK, because
+		// healthLoop may still be reading it until wg.Wait() below returns.
 		for i := range e.adapters {
 			entry := &e.adapters[i]
 			if !entry.setupOK {
 				continue
 			}
-			entry.setupOK = false
 			e.teardownAdapter(entry, "stop")
 		}
 

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -68,6 +68,13 @@ type adapterEntry struct {
 	watcherID string
 	tracker   *HealthTracker
 	cancel    context.CancelFunc
+
+	// setupOK is true once Setup returned nil. An adapter whose Setup failed is
+	// half-constructed — NtfyAdapter and SlackAdapter, for instance, only build
+	// their *http.Client after validating the topic — so calling any other
+	// method on it can panic (#1886). Only Start writes this field, before
+	// healthLoop is launched, so the later reads are race-free.
+	setupOK bool
 }
 
 // Engine orchestrates the watcher event pipeline: adapter goroutines produce Events,
@@ -211,8 +218,13 @@ func (e *Engine) Start() error {
 				slog.String("type", entry.config.Type),
 				slog.String("error", err.Error()),
 			)
+			// The entry stays registered so the TUI still sees the watcher, but
+			// it is marked unhealthy and left with setupOK=false: healthLoop and
+			// Stop must not call into an adapter that never finished Setup.
+			entry.tracker.SetAdapterHealth(false)
 			continue
 		}
+		entry.setupOK = true
 
 		// #nosec G118 -- adapterCancel is preserved on entry.cancel; the parent
 		// context e.ctx is canceled by Stop() (see line 594), which propagates
@@ -570,11 +582,17 @@ func (e *Engine) healthLoop() {
 			for i := range e.adapters {
 				entry := &e.adapters[i]
 
-				if err := entry.adapter.HealthCheck(); err != nil {
-					entry.tracker.SetAdapterHealth(false)
-					entry.tracker.RecordError()
-				} else {
-					entry.tracker.SetAdapterHealth(true)
+				// Adapters whose Setup failed are already marked unhealthy in
+				// Start; probing them would call into a half-constructed adapter
+				// and take the whole process down (#1886). Still emit their state
+				// so the TUI keeps reporting the watcher as errored.
+				if entry.setupOK {
+					if err := entry.adapter.HealthCheck(); err != nil {
+						entry.tracker.SetAdapterHealth(false)
+						entry.tracker.RecordError()
+					} else {
+						entry.tracker.SetAdapterHealth(true)
+					}
 				}
 
 				state := entry.tracker.Check()
@@ -605,9 +623,14 @@ func (e *Engine) Stop() {
 		// Cancel root context, which propagates to all derived adapter contexts.
 		e.cancel()
 
-		// Best-effort teardown of all adapters.
+		// Best-effort teardown of every adapter that was actually set up.
+		// Teardown releases what Setup allocated, so an entry that never got
+		// past Setup has nothing to release and must not be called into (#1886).
 		for i := range e.adapters {
 			entry := &e.adapters[i]
+			if !entry.setupOK {
+				continue
+			}
 			if err := entry.adapter.Teardown(); err != nil {
 				e.log.Warn("adapter_teardown_error",
 					slog.String("watcher", entry.config.Name),

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -71,8 +71,10 @@ type adapterEntry struct {
 
 	// setupOK is true once Setup returned nil. An adapter whose Setup failed is
 	// half-constructed — NtfyAdapter and SlackAdapter, for instance, only build
-	// their *http.Client after validating the topic — so calling any other
-	// method on it can panic (#1886). Only Start writes this field, before
+	// their *http.Client after validating the topic — so probing it can panic
+	// (#1886). It also decides who owns cleanup: a failed attempt is torn down
+	// immediately by setupAdapter, so Stop only tears down entries that are
+	// still holding a successful Setup. Only Start writes this field, before
 	// healthLoop is launched, so the later reads are race-free.
 	setupOK bool
 }
@@ -212,19 +214,9 @@ func (e *Engine) Start() error {
 	for i := range e.adapters {
 		entry := &e.adapters[i]
 
-		if err := entry.adapter.Setup(e.ctx, entry.config); err != nil {
-			e.log.Warn("adapter_setup_failed",
-				slog.String("watcher", entry.config.Name),
-				slog.String("type", entry.config.Type),
-				slog.String("error", err.Error()),
-			)
-			// The entry stays registered so the TUI still sees the watcher, but
-			// it is marked unhealthy and left with setupOK=false: healthLoop and
-			// Stop must not call into an adapter that never finished Setup.
-			entry.tracker.SetAdapterHealth(false)
+		if !e.setupAdapter(entry) {
 			continue
 		}
-		entry.setupOK = true
 
 		// #nosec G118 -- adapterCancel is preserved on entry.cancel; the parent
 		// context e.ctx is canceled by Stop() (see line 594), which propagates
@@ -262,6 +254,63 @@ func (e *Engine) Start() error {
 	go e.reaper.loop()
 
 	return nil
+}
+
+// setupAdapter runs Setup for one entry and reports whether it succeeded.
+//
+// A failed Setup is cleaned up here, immediately and exactly once for that
+// attempt: Setup is not transactional, so an adapter can bind a listener, open
+// a client, or start a goroutine and then fail a later step, and skipping
+// Teardown would leak whatever it had already taken. The entry stays registered
+// (so the TUI still lists the watcher) but is marked unhealthy and left with
+// setupOK=false, which keeps healthLoop from probing a half-constructed adapter
+// and tells Stop that this entry's cleanup is already done.
+//
+// Calling setupAdapter again on the same entry is a retry: each failed attempt
+// gets its own cleanup, and a later success leaves exactly one live Setup for
+// Stop to release.
+func (e *Engine) setupAdapter(entry *adapterEntry) bool {
+	entry.setupOK = false
+
+	if err := entry.adapter.Setup(e.ctx, entry.config); err != nil {
+		e.log.Warn("adapter_setup_failed",
+			slog.String("watcher", entry.config.Name),
+			slog.String("type", entry.config.Type),
+			slog.String("error", err.Error()),
+		)
+		entry.tracker.SetAdapterHealth(false)
+		e.teardownAdapter(entry, "setup_failed")
+		return false
+	}
+
+	entry.setupOK = true
+	return true
+}
+
+// teardownAdapter calls Teardown once and contains anything it throws. A
+// half-constructed adapter is precisely the thing that panicked in #1886, and
+// cleanup runs on the failed-Setup path where that state is expected, so a
+// panicking Teardown must be logged and swallowed rather than allowed to take
+// the process down with it.
+func (e *Engine) teardownAdapter(entry *adapterEntry, reason string) {
+	defer func() {
+		if r := recover(); r != nil {
+			e.log.Error("adapter_teardown_panic",
+				slog.String("watcher", entry.config.Name),
+				slog.String("type", entry.config.Type),
+				slog.String("reason", reason),
+				slog.Any("panic", r),
+			)
+		}
+	}()
+
+	if err := entry.adapter.Teardown(); err != nil {
+		e.log.Warn("adapter_teardown_error",
+			slog.String("watcher", entry.config.Name),
+			slog.String("reason", reason),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 // runAdapter runs a single adapter's Listen loop in its own goroutine.
@@ -623,20 +672,18 @@ func (e *Engine) Stop() {
 		// Cancel root context, which propagates to all derived adapter contexts.
 		e.cancel()
 
-		// Best-effort teardown of every adapter that was actually set up.
-		// Teardown releases what Setup allocated, so an entry that never got
-		// past Setup has nothing to release and must not be called into (#1886).
+		// Best-effort teardown of every adapter still holding a successful Setup.
+		// Entries whose Setup failed were already torn down by setupAdapter at
+		// the moment they failed, so skipping them here is what makes cleanup
+		// exactly-once rather than twice (#1886). stopOnce keeps a second Stop
+		// from repeating this pass.
 		for i := range e.adapters {
 			entry := &e.adapters[i]
 			if !entry.setupOK {
 				continue
 			}
-			if err := entry.adapter.Teardown(); err != nil {
-				e.log.Warn("adapter_teardown_error",
-					slog.String("watcher", entry.config.Name),
-					slog.String("error", err.Error()),
-				)
-			}
+			entry.setupOK = false
+			e.teardownAdapter(entry, "stop")
 		}
 
 		// Wait for all goroutines (adapters + writer + health + triage) to exit.

--- a/internal/watcher/issue1886_failed_setup_test.go
+++ b/internal/watcher/issue1886_failed_setup_test.go
@@ -1,8 +1,10 @@
 package watcher
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -30,15 +32,84 @@ func newHealthLoopEngine(t *testing.T, interval time.Duration) *Engine {
 	return NewEngine(cfg)
 }
 
-// TestEngine_HealthLoop_SkipsAdapterWithFailedSetup reproduces #1886: an ntfy
-// watcher registered without a topic fails Setup, and the next health tick used
-// to panic with a nil-pointer dereference inside net/http.(*Client).do. The
-// engine must report the watcher as unhealthy instead of probing it.
+// failedSetupAdapter fails Setup and counts every call the engine makes into it
+// afterwards. The counters are what tell "healthLoop skipped this adapter" apart
+// from "healthLoop called it and got an error back" — a status assertion alone
+// cannot, because the adapter-level nil-client guard also yields an error.
+// HealthCheck returns nil on purpose: a call that did happen would flip the
+// tracker to healthy, so it would fail the status assertion as well.
+type failedSetupAdapter struct {
+	healthChecks atomic.Int64
+	teardowns    atomic.Int64
+}
+
+func (a *failedSetupAdapter) Setup(context.Context, AdapterConfig) error {
+	return errors.New("setup failed")
+}
+
+func (a *failedSetupAdapter) Listen(ctx context.Context, _ chan<- Event) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (a *failedSetupAdapter) Teardown() error {
+	a.teardowns.Add(1)
+	return nil
+}
+
+func (a *failedSetupAdapter) HealthCheck() error {
+	a.healthChecks.Add(1)
+	return nil
+}
+
+// TestEngine_HealthLoop_SkipsAdapterWithFailedSetup asserts the actual contract:
+// the health loop must not call into an adapter whose Setup failed, and must
+// still report that watcher as unhealthy.
 func TestEngine_HealthLoop_SkipsAdapterWithFailedSetup(t *testing.T) {
 	engine := newHealthLoopEngine(t, 20*time.Millisecond)
 
-	// No "topic" setting: NtfyAdapter.Setup returns an error before it assigns
-	// a.client, which is exactly the state the panicking watcher was left in.
+	adapter := &failedSetupAdapter{}
+	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "broken"}, 60)
+
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for a state, then let several more ticks pass so a health loop that
+	// probes unconditionally has every chance to call the adapter.
+	select {
+	case state := <-engine.HealthCh():
+		if state.WatcherName != "broken" {
+			t.Errorf("health state for %q, want %q", state.WatcherName, "broken")
+		}
+		if state.Status != HealthStatusError {
+			t.Errorf("status = %q, want %q (setup failed)", state.Status, HealthStatusError)
+		}
+	case <-time.After(2 * time.Second):
+		engine.Stop()
+		t.Fatal("no health state emitted for the watcher whose Setup failed")
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if n := adapter.healthChecks.Load(); n != 0 {
+		t.Errorf("HealthCheck called %d times on an adapter whose Setup failed, want 0", n)
+	}
+
+	engine.Stop()
+
+	if n := adapter.teardowns.Load(); n != 0 {
+		t.Errorf("Teardown called %d times on an adapter whose Setup failed, want 0", n)
+	}
+}
+
+// TestEngine_HealthLoop_NtfyWithFailedSetupDoesNotPanic is the #1886 regression
+// case itself: an ntfy watcher registered without a topic fails Setup before it
+// assigns a.client, and the next health tick used to panic with a nil-pointer
+// dereference inside net/http.(*Client).do, killing the process. Kept alongside
+// the skip test above because only this one exercises the real adapter.
+func TestEngine_HealthLoop_NtfyWithFailedSetupDoesNotPanic(t *testing.T) {
+	engine := newHealthLoopEngine(t, 20*time.Millisecond)
+
 	engine.RegisterAdapter("w1", &NtfyAdapter{}, AdapterConfig{
 		Type:     "ntfy",
 		Name:     "test-ntfy",

--- a/internal/watcher/issue1886_failed_setup_test.go
+++ b/internal/watcher/issue1886_failed_setup_test.go
@@ -1,0 +1,104 @@
+package watcher
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Issue #1886: a watcher whose Setup failed stayed registered on the engine, and
+// the health loop kept calling HealthCheck on it every tick. For the ntfy and
+// slack adapters that means dereferencing an *http.Client that Setup never got
+// far enough to build, which panicked and took the whole agent-deck process down
+// on a timer.
+
+// newHealthLoopEngine builds an engine with the health loop enabled; the shared
+// newTestEngine helper sets HealthCheckInterval to 0, which disables it.
+func newHealthLoopEngine(t *testing.T, interval time.Duration) *Engine {
+	t.Helper()
+	cfg := EngineConfig{
+		DB:                  newTestDB(t),
+		Router:              NewRouter(nil),
+		MaxEventsPerWatcher: 500,
+		HealthCheckInterval: interval,
+		// Use fakeSpawner so tests never exec real agent-deck subprocesses.
+		TriageSpawner: &fakeSpawner{},
+		TriageDir:     t.TempDir(),
+		ClientsPath:   filepath.Join(t.TempDir(), "clients.json"),
+	}
+	return NewEngine(cfg)
+}
+
+// TestEngine_HealthLoop_SkipsAdapterWithFailedSetup reproduces #1886: an ntfy
+// watcher registered without a topic fails Setup, and the next health tick used
+// to panic with a nil-pointer dereference inside net/http.(*Client).do. The
+// engine must report the watcher as unhealthy instead of probing it.
+func TestEngine_HealthLoop_SkipsAdapterWithFailedSetup(t *testing.T) {
+	engine := newHealthLoopEngine(t, 20*time.Millisecond)
+
+	// No "topic" setting: NtfyAdapter.Setup returns an error before it assigns
+	// a.client, which is exactly the state the panicking watcher was left in.
+	engine.RegisterAdapter("w1", &NtfyAdapter{}, AdapterConfig{
+		Type:     "ntfy",
+		Name:     "test-ntfy",
+		Settings: map[string]string{},
+	}, 60)
+
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	// Before the fix the health loop panicked on the first tick and the test
+	// binary died here rather than reporting a state.
+	select {
+	case state := <-engine.HealthCh():
+		if state.WatcherName != "test-ntfy" {
+			t.Errorf("health state for %q, want %q", state.WatcherName, "test-ntfy")
+		}
+		if state.Status != HealthStatusError {
+			t.Errorf("status = %q, want %q (setup failed)", state.Status, HealthStatusError)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no health state emitted for the watcher whose Setup failed")
+	}
+}
+
+// TestEngine_Stop_SkipsTeardownForFailedSetup verifies the symmetric case:
+// Teardown releases what Setup allocated, so an adapter that never completed
+// Setup must not be torn down either.
+func TestEngine_Stop_SkipsTeardownForFailedSetup(t *testing.T) {
+	engine, _ := newTestEngine(t, nil)
+
+	adapter := &MockAdapter{setupErr: errors.New("setup failed")}
+	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "broken"}, 60)
+
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	engine.Stop()
+
+	if !adapter.setupCalled {
+		t.Fatal("Setup was never called")
+	}
+	if adapter.teardownCalled {
+		t.Error("Teardown called on an adapter whose Setup failed")
+	}
+}
+
+// TestNtfy_HealthCheck_WithoutSetup pins the adapter-level guard: HealthCheck on
+// an un-set-up adapter reports an error rather than panicking.
+func TestNtfy_HealthCheck_WithoutSetup(t *testing.T) {
+	if err := (&NtfyAdapter{}).HealthCheck(); err == nil {
+		t.Error("HealthCheck() = nil, want an error when Setup never ran")
+	}
+}
+
+// TestSlack_HealthCheck_WithoutSetup covers the same latent nil client in the
+// slack adapter, which builds its client in Setup exactly like ntfy does.
+func TestSlack_HealthCheck_WithoutSetup(t *testing.T) {
+	if err := (&SlackAdapter{}).HealthCheck(); err == nil {
+		t.Error("HealthCheck() = nil, want an error when Setup never ran")
+	}
+}

--- a/internal/watcher/issue1886_failed_setup_test.go
+++ b/internal/watcher/issue1886_failed_setup_test.go
@@ -38,13 +38,25 @@ func newHealthLoopEngine(t *testing.T, interval time.Duration) *Engine {
 // cannot, because the adapter-level nil-client guard also yields an error.
 // HealthCheck returns nil on purpose: a call that did happen would flip the
 // tracker to healthy, so it would fail the status assertion as well.
+//
+// failSetups bounds how many Setup attempts fail, so one adapter can model a
+// retry that eventually succeeds. panicOnTeardown makes Teardown panic, which
+// is the half-constructed behaviour cleanup has to survive.
 type failedSetupAdapter struct {
+	failSetups      int64 // negative means: fail every attempt
+	panicOnTeardown bool
+
+	setups       atomic.Int64
 	healthChecks atomic.Int64
 	teardowns    atomic.Int64
 }
 
 func (a *failedSetupAdapter) Setup(context.Context, AdapterConfig) error {
-	return errors.New("setup failed")
+	n := a.setups.Add(1)
+	if a.failSetups < 0 || n <= a.failSetups {
+		return errors.New("setup failed")
+	}
+	return nil
 }
 
 func (a *failedSetupAdapter) Listen(ctx context.Context, _ chan<- Event) error {
@@ -54,6 +66,9 @@ func (a *failedSetupAdapter) Listen(ctx context.Context, _ chan<- Event) error {
 
 func (a *failedSetupAdapter) Teardown() error {
 	a.teardowns.Add(1)
+	if a.panicOnTeardown {
+		panic("teardown on a half-constructed adapter")
+	}
 	return nil
 }
 
@@ -68,7 +83,7 @@ func (a *failedSetupAdapter) HealthCheck() error {
 func TestEngine_HealthLoop_SkipsAdapterWithFailedSetup(t *testing.T) {
 	engine := newHealthLoopEngine(t, 20*time.Millisecond)
 
-	adapter := &failedSetupAdapter{}
+	adapter := &failedSetupAdapter{failSetups: -1}
 	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "broken"}, 60)
 
 	if err := engine.Start(); err != nil {
@@ -94,11 +109,17 @@ func TestEngine_HealthLoop_SkipsAdapterWithFailedSetup(t *testing.T) {
 	if n := adapter.healthChecks.Load(); n != 0 {
 		t.Errorf("HealthCheck called %d times on an adapter whose Setup failed, want 0", n)
 	}
+	// The failed attempt is cleaned up at the moment it fails, not deferred to
+	// Stop: Setup is not transactional, so it may already hold resources.
+	if n := adapter.teardowns.Load(); n != 1 {
+		t.Errorf("Teardown called %d times after the failed Setup, want exactly 1", n)
+	}
 
 	engine.Stop()
 
-	if n := adapter.teardowns.Load(); n != 0 {
-		t.Errorf("Teardown called %d times on an adapter whose Setup failed, want 0", n)
+	// Stop must not tear the same failed attempt down a second time.
+	if n := adapter.teardowns.Load(); n != 1 {
+		t.Errorf("Teardown called %d times after Stop, want it to stay at 1 (exactly-once)", n)
 	}
 }
 
@@ -136,25 +157,105 @@ func TestEngine_HealthLoop_NtfyWithFailedSetupDoesNotPanic(t *testing.T) {
 	}
 }
 
-// TestEngine_Stop_SkipsTeardownForFailedSetup verifies the symmetric case:
-// Teardown releases what Setup allocated, so an adapter that never completed
-// Setup must not be torn down either.
-func TestEngine_Stop_SkipsTeardownForFailedSetup(t *testing.T) {
+// TestEngine_Stop_TearsDownSuccessfulSetupExactlyOnce covers the other side:
+// an adapter that did complete Setup is holding resources, so Stop must release
+// them — once, even if Stop is called again.
+func TestEngine_Stop_TearsDownSuccessfulSetupExactlyOnce(t *testing.T) {
 	engine, _ := newTestEngine(t, nil)
 
-	adapter := &MockAdapter{setupErr: errors.New("setup failed")}
-	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "broken"}, 60)
+	adapter := &failedSetupAdapter{} // failSetups == 0: every Setup succeeds
+	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "healthy"}, 60)
 
 	if err := engine.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
+	if n := adapter.teardowns.Load(); n != 0 {
+		t.Fatalf("Teardown called %d times while the adapter was live, want 0", n)
+	}
+
+	engine.Stop()
+	if n := adapter.teardowns.Load(); n != 1 {
+		t.Errorf("Teardown called %d times after Stop, want exactly 1", n)
+	}
+
+	engine.Stop()
+	if n := adapter.teardowns.Load(); n != 1 {
+		t.Errorf("Teardown called %d times after a second Stop, want it to stay at 1", n)
+	}
+}
+
+// TestEngine_SetupRetry_CleansUpEveryFailedAttempt is the retry case the review
+// asked for: Setup is not transactional, so every failed attempt has to release
+// what that attempt took, and a later success must leave exactly one live Setup
+// for Stop to release. Two failures then a success means three Teardowns in
+// total — one per failed attempt, one final.
+func TestEngine_SetupRetry_CleansUpEveryFailedAttempt(t *testing.T) {
+	engine, _ := newTestEngine(t, nil)
+
+	adapter := &failedSetupAdapter{failSetups: 2}
+	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "flaky"}, 60)
+	entry := &engine.adapters[0]
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		if ok := engine.setupAdapter(entry); ok {
+			t.Fatalf("attempt %d: Setup unexpectedly succeeded", attempt)
+		}
+		if entry.setupOK {
+			t.Errorf("attempt %d: setupOK is true after a failed Setup", attempt)
+		}
+		if n := adapter.teardowns.Load(); n != int64(attempt) {
+			t.Errorf("attempt %d: Teardown called %d times, want %d (one per failed attempt)",
+				attempt, n, attempt)
+		}
+	}
+
+	if ok := engine.setupAdapter(entry); !ok {
+		t.Fatal("third attempt: Setup should have succeeded")
+	}
+	if !entry.setupOK {
+		t.Error("setupOK is false after a successful Setup")
+	}
+	if n := adapter.teardowns.Load(); n != 2 {
+		t.Errorf("Teardown called %d times after the successful attempt, want it to stay at 2", n)
+	}
+
 	engine.Stop()
 
-	if !adapter.setupCalled {
-		t.Fatal("Setup was never called")
+	if n := adapter.teardowns.Load(); n != 3 {
+		t.Errorf("Teardown called %d times after Stop, want 3 (2 failed attempts + 1 final cleanup)", n)
 	}
-	if adapter.teardownCalled {
-		t.Error("Teardown called on an adapter whose Setup failed")
+}
+
+// TestEngine_TeardownPanic_IsContained pins the "panic-contained" half. Cleanup
+// runs on the failed-Setup path, where the adapter is half-constructed — the
+// exact state that panicked in #1886 — so a panicking Teardown must be
+// swallowed rather than take the process down, and must not stop the engine
+// from setting up the adapters that follow it.
+func TestEngine_TeardownPanic_IsContained(t *testing.T) {
+	engine, _ := newTestEngine(t, nil)
+
+	panicky := &failedSetupAdapter{failSetups: -1, panicOnTeardown: true}
+	healthy := &MockAdapter{}
+	engine.RegisterAdapter("w1", panicky, AdapterConfig{Type: "mock", Name: "panicky"}, 60)
+	engine.RegisterAdapter("w2", healthy, AdapterConfig{Type: "mock", Name: "healthy"}, 60)
+
+	// Start must survive the panicking cleanup of the first adapter.
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if n := panicky.teardowns.Load(); n != 1 {
+		t.Errorf("Teardown called %d times on the failed adapter, want 1", n)
+	}
+	if !healthy.setupCalled {
+		t.Error("the adapter after the panicking one was never set up")
+	}
+
+	// And Stop must still run to completion, tearing down the live adapter.
+	engine.Stop()
+
+	if !healthy.teardownCalled {
+		t.Error("Teardown was not called on the live adapter during Stop")
 	}
 }
 

--- a/internal/watcher/issue1886_failed_setup_test.go
+++ b/internal/watcher/issue1886_failed_setup_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -41,10 +42,12 @@ func newHealthLoopEngine(t *testing.T, interval time.Duration) *Engine {
 //
 // failSetups bounds how many Setup attempts fail, so one adapter can model a
 // retry that eventually succeeds. panicOnTeardown makes Teardown panic, which
-// is the half-constructed behaviour cleanup has to survive.
+// is the half-constructed behaviour cleanup has to survive. healthDelay slows
+// HealthCheck down so a test can keep healthLoop inside its per-entry loop.
 type failedSetupAdapter struct {
 	failSetups      int64 // negative means: fail every attempt
 	panicOnTeardown bool
+	healthDelay     time.Duration
 
 	setups       atomic.Int64
 	healthChecks atomic.Int64
@@ -74,6 +77,9 @@ func (a *failedSetupAdapter) Teardown() error {
 
 func (a *failedSetupAdapter) HealthCheck() error {
 	a.healthChecks.Add(1)
+	if a.healthDelay > 0 {
+		time.Sleep(a.healthDelay)
+	}
 	return nil
 }
 
@@ -257,6 +263,39 @@ func TestEngine_TeardownPanic_IsContained(t *testing.T) {
 	if !healthy.teardownCalled {
 		t.Error("Teardown was not called on the live adapter during Stop")
 	}
+}
+
+// TestEngine_Stop_DoesNotRaceWithHealthLoopOverSetupOK pins the shutdown half of
+// the setupOK invariant. Stop's teardown pass runs after e.cancel() but before
+// e.wg.Wait() returns, so healthLoop can still be mid-iteration reading setupOK
+// while Stop walks the same entries: Stop must only read the field, never write
+// it. stopOnce is what makes the pass run at most once, not clearing the flag.
+//
+// Deliberately shaped to make the window wide instead of hoping to hit it: each
+// adapter's HealthCheck blocks for a millisecond, so with a 1ms tick healthLoop
+// is inside its per-entry loop for tens of milliseconds while Stop's loop runs
+// to completion in microseconds. Fails under -race if Stop writes setupOK.
+func TestEngine_Stop_DoesNotRaceWithHealthLoopOverSetupOK(t *testing.T) {
+	engine := newHealthLoopEngine(t, time.Millisecond)
+
+	const adapters = 32
+	for i := 0; i < adapters; i++ {
+		engine.RegisterAdapter(
+			fmt.Sprintf("w%d", i),
+			&failedSetupAdapter{healthDelay: time.Millisecond}, // failSetups == 0: Setup succeeds
+			AdapterConfig{Type: "mock", Name: fmt.Sprintf("live-%d", i)},
+			60,
+		)
+	}
+
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Let healthLoop get into an iteration before shutdown starts.
+	time.Sleep(5 * time.Millisecond)
+
+	engine.Stop()
 }
 
 // TestNtfy_HealthCheck_WithoutSetup pins the adapter-level guard: HealthCheck on

--- a/internal/watcher/ntfy.go
+++ b/internal/watcher/ntfy.go
@@ -179,8 +179,13 @@ func (a *NtfyAdapter) Teardown() error {
 }
 
 // HealthCheck verifies the ntfy server is reachable by sending an HTTP HEAD request
-// with a 5-second timeout (per D-10).
+// with a 5-second timeout (per D-10). It reports an error instead of dereferencing
+// a nil client when Setup never completed (#1886).
 func (a *NtfyAdapter) HealthCheck() error {
+	if a.client == nil {
+		return errors.New("ntfy adapter is not set up")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/internal/watcher/slack.go
+++ b/internal/watcher/slack.go
@@ -223,8 +223,13 @@ func (a *SlackAdapter) Teardown() error {
 }
 
 // HealthCheck verifies the ntfy server is reachable by sending an HTTP HEAD request
-// with a 5-second timeout.
+// with a 5-second timeout. It reports an error instead of dereferencing a nil
+// client when Setup never completed (#1886).
 func (a *SlackAdapter) HealthCheck() error {
+	if a.client == nil {
+		return errors.New("slack adapter is not set up")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
## What problem does this solve?

An ntfy watcher that is created and started (`agent-deck watcher create ntfy --name X --topic Y`, then `agent-deck watcher start X`) takes the whole `agent-deck` process down with a SIGSEGV on the next watcher health-check tick, and keeps doing it after every relaunch — the watcher is still configured and started, so the crash recurs on a timer until it is stopped by hand. Fixes #1886.

## Why this change

`Engine.Start` logs and skips an adapter whose `Setup` fails, but the entry stays in `e.adapters`, and `healthLoop` iterates that same slice — calling `HealthCheck()` on every entry, including the ones that were skipped. `NtfyAdapter.Setup` returns early when `Settings["topic"]` is empty, *before* it assigns `a.client`, so the health tick dereferences a nil `*http.Client` inside `net/http.(*Client).do`. A panic on the health goroutine is not recoverable from the TUI, so the process dies.

The fix records whether `Setup` actually succeeded (`adapterEntry.setupOK`) so `healthLoop` never probes an adapter that never finished `Setup`.

Cleanup is handled separately, and deliberately not by skipping it. `Setup` is not transactional — an adapter can bind a listener, open a client, or start a goroutine and then fail a later step — so `setupAdapter` tears a failed attempt down at the moment it fails, exactly once for that attempt, and `Stop` then releases only the entries still holding a successful `Setup`. Retrying cleans up each failed attempt in turn and leaves one live `Setup` for `Stop`. That cleanup is panic-contained: it runs on the half-constructed adapter that panicked in #1886 in the first place, so `teardownAdapter` recovers, logs `adapter_teardown_panic`, and lets the engine carry on with the adapters after it.

A failed-setup watcher is marked unhealthy once at `Start`, so `healthLoop` still emits its state every tick and the TUI reports it as errored. That state was previously unreachable, because the process died before anyone could see it.

I fixed this in the engine rather than lazily building the client inside `HealthCheck` (the direction the issue guessed at): an adapter whose `Setup` failed is half-constructed by definition, so a per-adapter rescue only patches the one field that happened to be nil this time. The nil-client guards added to `NtfyAdapter.HealthCheck` and `SlackAdapter.HealthCheck` are a second layer, not the fix — they turn any future call from a segfault into an error. `SlackAdapter` builds its client in `Setup` exactly like ntfy does and had the identical latent panic.

Scope note: the reason `Setup` fails in the first place is a separate defect — `agent-deck watcher create ntfy|slack --topic` validates `--topic` but never persists it to `watcher.toml`, so `Settings["topic"]` is always empty at runtime. That is a different bug in a different package, and it is fixed in a separate PR to keep this diff to one problem. The two are independent: this PR stops the crash for *any* adapter whose `Setup` fails, whatever the reason.

## User impact

A watcher whose adapter fails to initialise no longer crashes agent-deck. It is shown in the TUI with health status `error` ("adapter health check failed") instead of taking the process down on the health-check interval. Watchers that start normally are unaffected — one bool assignment per adapter at startup, no behaviour change on the healthy path.

## Evidence

**On the automated revert-check.** `self-check.sh` now reports it as a WARN rather than a PASS: reverting *all* non-test hunks removes `setupAdapter`, which the new tests call directly to drive a retry, so the package no longer compiles on base. Stating it rather than leaving it silent — I ran targeted reverts instead, each removing one behaviour and leaving the code compiling, shown below and in the follow-up notes.

**Review follow-up (237925a).** The maintainer caught a lifecycle bug in the first version: `Stop` skipped `Teardown` whenever `Setup` had returned an error, which assumes `Setup` is all-or-nothing. It is not, so the skip leaked whatever a partially-completed `Setup` had already taken, and the test asserting zero cleanup pinned that wrong behaviour. Cleanup now happens per failed attempt, exactly once, panic-contained, as described above. Removing the cleanup call fails the attempt/retry assertions:

```
Teardown called 0 times after the failed Setup, want exactly 1
attempt 1: Teardown called 0 times, want 1 (one per failed attempt)
attempt 2: Teardown called 0 times, want 2 (one per failed attempt)
Teardown called 1 times after Stop, want 3 (2 failed attempts + 1 final cleanup)
```

and removing the `recover` crashes the binary outright:

```
--- FAIL: TestEngine_TeardownPanic_IsContained
panic: teardown on a half-constructed adapter [recovered, repanicked]
```

**Review follow-up (9b5684e).** The first version of the skip test asserted only `HealthStatusError`, which held whether the loop skipped the adapter or called it and got an error back from the nil guard — it could not tell those apart. It now uses a `failedSetupAdapter` that counts the calls the engine makes into it, and whose `HealthCheck` returns `nil`, so a call that did happen also flips the tracker to healthy. The ntfy case is kept as a separate test: it is the real-adapter panic reproducer.

**Revert-check** — with the test file kept and the three non-test files reverted to `main`, both tests fail, each for its own reason. The skip test fails on the call counts (this is the assertion added after review — the status line alone would not have distinguished a skip from a guarded call), and the ntfy case still reproduces the reported panic:

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= \
    go test ./internal/watcher/ -run 'FailedSetup|WithoutSetup|DoesNotPanic' -v
=== RUN   TestEngine_HealthLoop_SkipsAdapterWithFailedSetup
    issue1886_failed_setup_test.go:86: status = "healthy", want "error" (setup failed)
    issue1886_failed_setup_test.go:95: HealthCheck called 6 times on an adapter whose Setup failed, want 0
    issue1886_failed_setup_test.go:101: Teardown called 1 times on an adapter whose Setup failed, want 0
--- FAIL: TestEngine_HealthLoop_SkipsAdapterWithFailedSetup (0.13s)
=== RUN   TestEngine_HealthLoop_NtfyWithFailedSetupDoesNotPanic
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1044ddfe4]

goroutine 31 [running]:
net/http.(*Client).do(0x0, 0x4562a41a0000)
	/opt/homebrew/Cellar/go/1.26.5/libexec/src/net/http/client.go:608 +0x154
net/http.(*Client).Do(...)
	/opt/homebrew/Cellar/go/1.26.5/libexec/src/net/http/client.go:592
github.com/asheshgoplani/agent-deck/internal/watcher.(*NtfyAdapter).HealthCheck(0x4562a3dde190)
	.../internal/watcher/ntfy.go:192 +0x90
github.com/asheshgoplani/agent-deck/internal/watcher.(*Engine).healthLoop(0x4562a42e2240)
	.../internal/watcher/engine.go:573 +0x124
created by github.com/asheshgoplani/agent-deck/internal/watcher.(*Engine).Start in goroutine 26
	.../internal/watcher/engine.go:235 +0x444
FAIL	github.com/asheshgoplani/agent-deck/internal/watcher	0.959s
```

Compare the issue's trace from the Homebrew build: same three agent-deck frames (`ntfy.go:192`, `engine.go:573`, `engine.go:235`), same nil `*http.Client` receiver.

**With the fix applied:**

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= \
    go test ./internal/watcher/ -run 'FailedSetup|WithoutSetup|DoesNotPanic' -v
--- PASS: TestEngine_HealthLoop_SkipsAdapterWithFailedSetup (0.13s)
--- PASS: TestEngine_HealthLoop_NtfyWithFailedSetupDoesNotPanic (0.03s)
--- PASS: TestEngine_Stop_SkipsTeardownForFailedSetup (0.01s)
--- PASS: TestNtfy_HealthCheck_WithoutSetup (0.00s)
--- PASS: TestSlack_HealthCheck_WithoutSetup (0.00s)
ok  	github.com/asheshgoplani/agent-deck/internal/watcher	1.563s
```

**Race detector** (the new `setupOK` field is written in `Start` and read from the health goroutine; `healthLoop` is launched after the setup loop completes, so the writes happen-before the reads):

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= \
    go test -race ./internal/watcher/
ok  	github.com/asheshgoplani/agent-deck/internal/watcher	17.082s
```

**Sandboxed suite** — `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` on this branch: every package passes except three that fail identically on unmodified `main` in this environment (macOS/Apple Silicon, Go 1.26.5), none of which my change touches. Stated rather than hidden:

| Package | On this branch | On clean `main` |
|---|---|---|
| `internal/watcher` | ok (14.6s) | ok |
| `internal/ui`, `cmd/agent-deck` | ok | ok |
| `internal/session` | FAIL `TestIssue1421_CleanStaleSSHSockets` | same failure |
| `internal/testutil`, `internal/tmux` | FAIL under full `./...` only | same — pass when run as their own packages |

`TestIssue1421_CleanStaleSSHSockets` fails with `bind: invalid argument` on a `stale@host:22` socket path under macOS's long `/var/folders/...` `TMPDIR` — a sandbox-path-length issue, reproducible on `main` before my commit. The `testutil`/`tmux` failures are tmux bootstrap contention that only appears when the whole tree runs in parallel; both packages pass in isolation, on this branch and on `main`. Re-running the exact same package set with and without my commit produced identical results.

**gofmt / vet:**

```
$ gofmt -l ./cmd ./internal     # prints nothing
$ go vet ./internal/watcher/    # exit 0
```

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):**

## What actually bothered you

My human hit this on their own machine — an ntfy watcher they had just set up was killing the whole TUI on a timer, and the only way to stop it was `watcher stop` plus deleting the config directory, which gave up on the watcher entirely. The issue (#1886) was filed by an agent on that same host from the live panic trace; the human's ask for this PR was: *"another agent on this local host created this issue: [#1886] — investigate the source and read the contributing guidelines on the project. then propose a patch that meets all the guidelines."*

So: same human, real crash, on a Homebrew install of agent-deck on macOS/Apple Silicon. The trace in the issue is from that machine, not from a test.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- Hot-path box left unchecked: the watcher engine starts during TUI startup, but the change adds one bool assignment per registered adapter in Start and one bool test per adapter per health tick. No measurable startup cost, so there is nothing meaningful to time. -->

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watcher startup handling when an adapter fails to initialize.
  * Failed adapters are cleaned up safely, marked unhealthy, and skipped during health checks.
  * Prevented crashes from health checks run before setup.
  * Teardown errors and panics are contained so shutdown can continue.
  * Ensured successful adapters are cleaned up exactly once.
* **Tests**
  * Added regression coverage for failed setup, retries, health checks, cleanup, and teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->