### PR TITLE
fix(cursor): prefer standalone agent CLI over cursor agent

### DIFF
--- a/cmd/agent-deck/copilot_detect_test.go
+++ b/cmd/agent-deck/copilot_detect_test.go
@@ -34,6 +34,8 @@ func TestDetectTool_Cursor(t *testing.T) {
 	}{
 		{"agent subcommand", "cursor agent", "cursor"},
 		{"bare binary", "cursor", "cursor"},
+		{"standalone agent", "agent", "cursor"},
+		{"standalone agent flags", "agent --continue", "cursor"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -62,7 +62,9 @@ func builtinTools() []builtinTool {
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
-		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}},
+		// detectTokens includes bare "agent" (standalone Cursor Agent CLI).
+		// Token match only: substring "agent" would false-match "agent-deck".
+		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}, detectTokens: []string{"agent"}},
 		{Name: "hermes", Icon: "☤", detectSubstrings: []string{"hermes"}},
 		{Name: "aider", Icon: "🐚"},
 		{Name: "shell", Icon: "🐚"},

--- a/internal/session/cursor_command.go
+++ b/internal/session/cursor_command.go
@@ -29,3 +29,15 @@ func isDefaultCursorInvocation(cmd string) bool {
 		return false
 	}
 }
+
+// cursorCommandInstalled reports whether a resolved Cursor launch command is
+// available for show_only_installed_tools. Stock defaults probe both
+// entrypoints; custom [cursor].command values probe that command directly.
+// (env_file does not affect install presence.)
+func cursorCommandInstalled(resolved string) bool {
+	cmd := strings.TrimSpace(resolved)
+	if isDefaultCursorInvocation(cmd) {
+		return probeInstalled("agent") || probeInstalled("cursor")
+	}
+	return probeInstalled(cmd)
+}

--- a/internal/session/cursor_command.go
+++ b/internal/session/cursor_command.go
@@ -1,0 +1,31 @@
+package session
+
+import "strings"
+
+// DefaultCursorCommand returns the host's preferred Cursor Agent CLI invocation.
+//
+// Cursor ships two entrypoints for the same agent TUI:
+//   - standalone `agent` (cursor-agent install under ~/.local/bin)
+//   - IDE shim `cursor agent` (Cursor.app's `cursor` binary on PATH)
+//
+// Prefer the standalone binary when present: many CLI-only installs never put
+// the IDE shim on PATH, and launching the hardcoded `cursor agent` then exits
+// immediately with "command not found: cursor".
+func DefaultCursorCommand() string {
+	if _, err := lookPathFn("agent"); err == nil {
+		return "agent"
+	}
+	return "cursor agent"
+}
+
+// isDefaultCursorInvocation reports whether cmd is one of the known default
+// Cursor launch forms (empty, tool id, or either stock entrypoint). Custom
+// invocations with extra flags stay untouched.
+func isDefaultCursorInvocation(cmd string) bool {
+	switch strings.ToLower(strings.TrimSpace(cmd)) {
+	case "", "cursor", "cursor agent", "agent":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/session/cursor_command.go
+++ b/internal/session/cursor_command.go
@@ -30,14 +30,36 @@ func isDefaultCursorInvocation(cmd string) bool {
 	}
 }
 
-// cursorCommandInstalled reports whether a resolved Cursor launch command is
-// available for show_only_installed_tools. Stock defaults probe both
-// entrypoints; custom [cursor].command values probe that command directly.
+// cursorCommandInstalled reports whether Cursor is available for
+// show_only_installed_tools.
+//
+// When [cursor].command is unset, either stock entrypoint (`agent` or `cursor`)
+// counts. When the user set an explicit override, only that command is probed
+// so a stock-looking override like command = "agent" cannot be marked installed
+// just because the other entrypoint exists.
 // (env_file does not affect install presence.)
-func cursorCommandInstalled(resolved string) bool {
-	cmd := strings.TrimSpace(resolved)
-	if isDefaultCursorInvocation(cmd) {
+func cursorCommandInstalled() bool {
+	config, _ := LoadUserConfig()
+	override := ""
+	if config != nil {
+		override = strings.TrimSpace(config.Cursor.Command)
+	}
+	if override == "" {
 		return probeInstalled("agent") || probeInstalled("cursor")
+	}
+	return probeCursorOverride(override)
+}
+
+// probeCursorOverride probes an explicit [cursor].command. Multi-word values
+// probe the first token so "cursor agent" does not inherit probeInstalled's
+// whitespace-wrapper "always installed" heuristic.
+func probeCursorOverride(cmd string) bool {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return false
+	}
+	if len(fields) > 1 {
+		return probeInstalled(fields[0])
 	}
 	return probeInstalled(cmd)
 }

--- a/internal/session/cursor_command_test.go
+++ b/internal/session/cursor_command_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDefaultCursorCommand_PrefersAgent(t *testing.T) {
+	orig := lookPathFn
+	t.Cleanup(func() { lookPathFn = orig })
+
+	lookPathFn = func(file string) (string, error) {
+		if file == "agent" {
+			return "/usr/local/bin/agent", nil
+		}
+		return "", errors.New("not found")
+	}
+	if got := DefaultCursorCommand(); got != "agent" {
+		t.Fatalf("DefaultCursorCommand() = %q, want %q", got, "agent")
+	}
+}
+
+func TestDefaultCursorCommand_FallsBackToCursorAgent(t *testing.T) {
+	orig := lookPathFn
+	t.Cleanup(func() { lookPathFn = orig })
+
+	lookPathFn = func(string) (string, error) {
+		return "", errors.New("not found")
+	}
+	if got := DefaultCursorCommand(); got != "cursor agent" {
+		t.Fatalf("DefaultCursorCommand() = %q, want %q", got, "cursor agent")
+	}
+}
+
+func TestIsDefaultCursorInvocation(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"", true},
+		{"cursor", true},
+		{"CURSOR", true},
+		{"cursor agent", true},
+		{"Cursor Agent", true},
+		{"agent", true},
+		{"agent --continue", false},
+		{"cursor agent --model x", false},
+		{"echo hi", false},
+	}
+	for _, tt := range tests {
+		if got := isDefaultCursorInvocation(tt.cmd); got != tt.want {
+			t.Errorf("isDefaultCursorInvocation(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}
+
+func TestGetToolCommand_CursorDefaultAndOverride(t *testing.T) {
+	orig := lookPathFn
+	t.Cleanup(func() { lookPathFn = orig })
+	lookPathFn = func(file string) (string, error) {
+		if file == "agent" {
+			return "/bin/agent", nil
+		}
+		return "", errors.New("not found")
+	}
+
+	cfg := &UserConfig{}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+	if got := GetToolCommand("cursor"); got != "agent" {
+		t.Fatalf("GetToolCommand(cursor) default = %q, want %q", got, "agent")
+	}
+
+	cfg2 := &UserConfig{Cursor: CursorSettings{Command: "cursor agent --force"}}
+	restore2 := resetUserConfigCache(t, cfg2)
+	defer restore2()
+	if got := GetToolCommand("cursor"); got != "cursor agent --force" {
+		t.Fatalf("GetToolCommand(cursor) override = %q, want %q", got, "cursor agent --force")
+	}
+}
+
+func TestBuildCursorCommand_ResolvesDefaultEntrypoint(t *testing.T) {
+	orig := lookPathFn
+	t.Cleanup(func() { lookPathFn = orig })
+	lookPathFn = func(file string) (string, error) {
+		if file == "agent" {
+			return "/bin/agent", nil
+		}
+		return "", errors.New("not found")
+	}
+	restore := resetUserConfigCache(t, &UserConfig{})
+	defer restore()
+
+	inst := NewInstanceWithTool("c1", "/tmp/c1", "cursor")
+	for _, base := range []string{"", "cursor", "cursor agent", "agent"} {
+		got := inst.buildCursorCommand(base, false)
+		if !strings.Contains(got, "agent") || strings.Contains(got, "cursor agent") {
+			t.Fatalf("buildCursorCommand(%q) = %q, want resolved agent entrypoint", base, got)
+		}
+		if strings.Contains(strings.ToLower(got), "--continue") {
+			t.Fatalf("buildCursorCommand(%q) unexpectedly includes --continue: %q", base, got)
+		}
+	}
+
+	got := inst.buildCursorCommand("cursor agent", true)
+	if !strings.Contains(got, "agent --continue") {
+		t.Fatalf("restart command = %q, want agent --continue", got)
+	}
+
+	got = inst.buildCursorCommand("agent --model x", true)
+	if !strings.Contains(got, "agent --model x --continue") {
+		t.Fatalf("custom command = %q, want agent --model x --continue", got)
+	}
+}

--- a/internal/session/cursor_command_test.go
+++ b/internal/session/cursor_command_test.go
@@ -6,6 +6,36 @@ import (
 	"testing"
 )
 
+func TestCursorCommandInstalled_OverrideProvenance(t *testing.T) {
+	withStubbedProbe(t, []string{"cursor"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{
+			Cursor: CursorSettings{Command: "agent"},
+		})
+		defer restore()
+		if cursorCommandInstalled() {
+			t.Fatal(`command="agent" with only cursor installed should be hidden`)
+		}
+	})
+
+	withStubbedProbe(t, []string{"agent"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{
+			Cursor: CursorSettings{Command: "cursor agent"},
+		})
+		defer restore()
+		if cursorCommandInstalled() {
+			t.Fatal(`command="cursor agent" with only agent installed should be hidden`)
+		}
+	})
+
+	withStubbedProbe(t, []string{"cursor"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{})
+		defer restore()
+		if !cursorCommandInstalled() {
+			t.Fatal("stock default with cursor on PATH should be visible")
+		}
+	})
+}
+
 func TestDefaultCursorCommand_PrefersAgent(t *testing.T) {
 	orig := lookPathFn
 	t.Cleanup(func() { lookPathFn = orig })

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -609,6 +609,8 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Copilot.EnvFile
 	case "crush":
 		return config.Crush.EnvFile
+	case "cursor":
+		return config.Cursor.EnvFile
 	case "hermes":
 		if name := conductorNameFromInstance(i); name != "" {
 			if conductorEnv := config.GetConductorHermesEnvFile(name); conductorEnv != "" {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2274,9 +2274,12 @@ func (i *Instance) preAcceptCursorWorkspaceTrust() {
 	}
 }
 
-// buildCursorCommand builds the command for the Cursor CLI (`cursor agent`).
+// buildCursorCommand builds the command for the Cursor Agent CLI.
 // continuePrev adds --continue so Restart resumes the previous chat in the workspace.
 // Env files from [shell].env_files are applied via buildEnvSourceCommand.
+//
+// Default entrypoint resolution prefers the standalone `agent` binary when it is
+// on PATH, falling back to `cursor agent`. See DefaultCursorCommand.
 func (i *Instance) buildCursorCommand(baseCommand string, continuePrev bool) string {
 	if i.Tool != "cursor" {
 		return baseCommand
@@ -2284,8 +2287,8 @@ func (i *Instance) buildCursorCommand(baseCommand string, continuePrev bool) str
 
 	envPrefix := i.buildEnvSourceCommand()
 	cmd := strings.TrimSpace(baseCommand)
-	if cmd == "" || strings.EqualFold(cmd, "cursor") {
-		cmd = "cursor agent"
+	if isDefaultCursorInvocation(cmd) {
+		cmd = GetToolCommand("cursor")
 	}
 
 	out := envPrefix + cmd

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1862,11 +1863,22 @@ func TestCanRestartCursor_ProbeNoticesImmediateExit(t *testing.T) {
 }
 
 func TestBuildCursorCommand(t *testing.T) {
+	orig := lookPathFn
+	t.Cleanup(func() { lookPathFn = orig })
+	lookPathFn = func(file string) (string, error) {
+		if file == "agent" {
+			return "/bin/agent", nil
+		}
+		return "", errors.New("not found")
+	}
+	restore := resetUserConfigCache(t, &UserConfig{})
+	defer restore()
+
 	inst := NewInstanceWithTool("c1", "/tmp/c1", "cursor")
 	inst.Command = ""
 	got := inst.buildCursorCommand(inst.Command, false)
-	if !strings.Contains(got, "cursor agent") {
-		t.Fatalf("fresh session: want cursor agent in command, got %q", got)
+	if !strings.Contains(got, "agent") {
+		t.Fatalf("fresh session: want agent in command, got %q", got)
 	}
 	if strings.Contains(strings.ToLower(got), "--continue") {
 		t.Fatalf("fresh session: should not add --continue, got %q", got)
@@ -1876,8 +1888,11 @@ func TestBuildCursorCommand(t *testing.T) {
 	if !strings.Contains(strings.ToLower(got), "--continue") {
 		t.Fatalf("restart: want --continue, got %q", got)
 	}
+	if !strings.Contains(got, "agent") || strings.Contains(got, "cursor agent") {
+		t.Fatalf("restart: want default rewritten to agent, got %q", got)
+	}
 
-	inst.Command = "cursor agent --continue"
+	inst.Command = "agent --continue"
 	got = inst.buildCursorCommand(inst.Command, true)
 	if strings.Count(strings.ToLower(got), "--continue") != 1 {
 		t.Fatalf("duplicate --continue: got %q", got)

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -151,13 +151,12 @@ func (r *Registry) runInstalledProbe() {
 			r.installed[name] = true // shell is always shown
 			continue
 		}
-		// Built-in probe uses the bare tool name, except Cursor: prefer the
-		// resolved [cursor].command. Stock defaults (`agent` / `cursor agent`)
-		// probe either entrypoint so a whitespace default does not spuriously
-		// count as installed via probeInstalled's wrapper heuristic.
+		// Built-in probe uses the bare tool name, except Cursor: honor an
+		// explicit [cursor].command override, otherwise accept either stock
+		// entrypoint (`agent` or `cursor`).
 		ok := false
 		if name == "cursor" {
-			ok = cursorCommandInstalled(GetToolCommand("cursor"))
+			ok = cursorCommandInstalled()
 		} else {
 			ok = probeInstalled(name)
 		}

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -151,14 +151,15 @@ func (r *Registry) runInstalledProbe() {
 			r.installed[name] = true // shell is always shown
 			continue
 		}
-		// Built-in probe uses the bare tool name, except Cursor: the CLI may be
-		// installed as standalone `agent` or as the IDE shim `cursor`.
-		probeName := name
+		// Built-in probe uses the bare tool name, except Cursor: prefer the
+		// resolved [cursor].command. Stock defaults (`agent` / `cursor agent`)
+		// probe either entrypoint so a whitespace default does not spuriously
+		// count as installed via probeInstalled's wrapper heuristic.
 		ok := false
 		if name == "cursor" {
-			ok = probeInstalled("agent") || probeInstalled("cursor")
+			ok = cursorCommandInstalled(GetToolCommand("cursor"))
 		} else {
-			ok = probeInstalled(probeName)
+			ok = probeInstalled(name)
 		}
 		r.installed[name] = ok
 		if ok {

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -151,8 +151,15 @@ func (r *Registry) runInstalledProbe() {
 			r.installed[name] = true // shell is always shown
 			continue
 		}
-		// A built-in's command is its bare name (matches Registry.All / detectTool).
-		ok := probeInstalled(name)
+		// Built-in probe uses the bare tool name, except Cursor: the CLI may be
+		// installed as standalone `agent` or as the IDE shim `cursor`.
+		probeName := name
+		ok := false
+		if name == "cursor" {
+			ok = probeInstalled("agent") || probeInstalled("cursor")
+		} else {
+			ok = probeInstalled(probeName)
+		}
 		r.installed[name] = ok
 		if ok {
 			nonShellInstalled++

--- a/internal/session/toolregistry_installed_test.go
+++ b/internal/session/toolregistry_installed_test.go
@@ -50,6 +50,48 @@ func commands(defs []ToolDef) []string {
 // TestInstalled_FilterOffNoProbe pins the core guardrail: with the flag off the
 // probe never runs and All() is unchanged. We make EVERY LookPath/Stat fail; if
 // the probe leaked into the default path, All() would drop entries.
+func TestInstalled_CursorResolvedCommandOverride(t *testing.T) {
+	// Neither stock entrypoint on PATH, but [cursor].command points at a real binary.
+	withStubbedProbe(t, []string{"/opt/bin/custom-cursor-agent"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{
+			Cursor: CursorSettings{Command: "/opt/bin/custom-cursor-agent"},
+		})
+		defer restore()
+
+		r := InitFiltered(nil, true, nil)
+		if !r.IsVisible("cursor") {
+			t.Fatal("IsVisible(cursor) = false, want true when [cursor].command resolves")
+		}
+	})
+
+	// Override to a missing binary: cursor should stay hidden (unless empty-fallback).
+	withStubbedProbe(t, []string{"claude"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{
+			Cursor: CursorSettings{Command: "/opt/bin/missing-cursor-agent"},
+		})
+		defer restore()
+
+		r := InitFiltered(nil, true, nil)
+		if r.FilterFallback() {
+			t.Fatal("precondition: non-shell tools resolved, fallback should be off")
+		}
+		if r.IsVisible("cursor") {
+			t.Fatal("IsVisible(cursor) = true, want false when override binary is missing")
+		}
+	})
+
+	// Stock defaults: agent alone is enough.
+	withStubbedProbe(t, []string{"agent", "claude"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{})
+		defer restore()
+
+		r := InitFiltered(nil, true, nil)
+		if !r.IsVisible("cursor") {
+			t.Fatal("IsVisible(cursor) = false, want true when agent is on PATH")
+		}
+	})
+}
+
 func TestInstalled_FilterOffNoProbe(t *testing.T) {
 	probeCalls := 0
 	origLookPath, origStat := lookPathFn, statFn

--- a/internal/session/toolregistry_installed_test.go
+++ b/internal/session/toolregistry_installed_test.go
@@ -90,6 +90,38 @@ func TestInstalled_CursorResolvedCommandOverride(t *testing.T) {
 			t.Fatal("IsVisible(cursor) = false, want true when agent is on PATH")
 		}
 	})
+
+	// Explicit command = "agent" must not borrow visibility from cursor alone.
+	withStubbedProbe(t, []string{"cursor", "claude"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{
+			Cursor: CursorSettings{Command: "agent"},
+		})
+		defer restore()
+
+		r := InitFiltered(nil, true, nil)
+		if r.FilterFallback() {
+			t.Fatal("precondition: non-shell tools resolved, fallback should be off")
+		}
+		if r.IsVisible("cursor") {
+			t.Fatal(`IsVisible(cursor) = true with command="agent" and only cursor on PATH; want false`)
+		}
+	})
+
+	// Explicit command = "cursor agent" must not borrow visibility from agent alone.
+	withStubbedProbe(t, []string{"agent", "claude"}, func() {
+		restore := resetUserConfigCache(t, &UserConfig{
+			Cursor: CursorSettings{Command: "cursor agent"},
+		})
+		defer restore()
+
+		r := InitFiltered(nil, true, nil)
+		if r.FilterFallback() {
+			t.Fatal("precondition: non-shell tools resolved, fallback should be off")
+		}
+		if r.IsVisible("cursor") {
+			t.Fatal(`IsVisible(cursor) = true with command="cursor agent" and only agent on PATH; want false`)
+		}
+	})
 }
 
 func TestInstalled_FilterOffNoProbe(t *testing.T) {

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -58,6 +58,8 @@ func TestRegistry_MatchAllBranches(t *testing.T) {
 		{"crush bare", "crush", "crush"},
 		// cursor
 		{"cursor agent subcommand", "cursor agent", "cursor"},
+		{"standalone agent binary", "agent", "cursor"},
+		{"standalone agent with flags", "agent --continue", "cursor"},
 		// hermes
 		{"hermes bare", "hermes", "hermes"},
 		// aider has NO detect arm — commands containing "aider" map to shell

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1856,6 +1856,16 @@ func (c *UserConfig) GetProfileCodexConfigDir(profile string) string {
 
 // CursorSettings defines Cursor Agent CLI integration configuration (Issue #1672).
 type CursorSettings struct {
+	// Command overrides the default binary/invocation for Cursor sessions.
+	// Supports flags (e.g., "agent --force", "cursor agent"). When empty,
+	// DefaultCursorCommand() prefers `agent` when present on PATH, else
+	// `cursor agent`.
+	Command string `toml:"command,omitempty"`
+
+	// EnvFile is a .env file specific to Cursor sessions (sourced before
+	// the agent command runs, like [gemini].env_file). Optional.
+	EnvFile string `toml:"env_file,omitempty"`
+
 	// HooksEnabled enables Cursor Agent CLI hooks for real-time status detection.
 	// When enabled, agent-deck silently injects lifecycle hooks into
 	// ~/.cursor/hooks.json on TUI startup whenever the cursor binary is on PATH.
@@ -3402,6 +3412,9 @@ func GetCustomToolNames() []string {
 func GetToolCommand(toolName string) string {
 	config, _ := LoadUserConfig()
 	if config == nil {
+		if toolName == "cursor" {
+			return DefaultCursorCommand()
+		}
 		return toolName
 	}
 	switch toolName {
@@ -3429,6 +3442,11 @@ func GetToolCommand(toolName string) string {
 		if config.Hermes.Command != "" {
 			return config.Hermes.Command
 		}
+	case "cursor":
+		if config.Cursor.Command != "" {
+			return config.Cursor.Command
+		}
+		return DefaultCursorCommand()
 	}
 	return toolName
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -821,6 +821,9 @@ func detectToolFromCommand(command string) string {
 			return "crush"
 		case "cursor":
 			return "cursor"
+		case "agent":
+			// Standalone Cursor Agent CLI binary (~/.local/bin/agent).
+			return "cursor"
 		case "hermes":
 			return "hermes"
 		case "pi":

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -639,6 +639,8 @@ func TestDetectToolFromCommand(t *testing.T) {
 		{name: "codex", command: "codex --dangerously-bypass-approvals-and-sandbox", want: "codex"},
 		{name: "pi", command: "pi --model fast", want: "pi"},
 		{name: "cursor", command: "cursor agent", want: "cursor"},
+		{name: "standalone agent", command: "agent", want: "cursor"},
+		{name: "standalone agent flags", command: "agent --continue", want: "cursor"},
 		{name: "shell command", command: "npm run dev", want: ""},
 		{name: "empty", command: "", want: ""},
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1676,11 +1676,11 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		}
 	}
 
-	// Cursor Agent CLI hooks: auto-inject silently when the cursor binary is
-	// available, unless the user opted out via [cursor] hooks_enabled = false
-	// (set durably by `agent-deck cursor-hooks uninstall`, issue #1672).
-	// The opt-out gates the watcher too, matching the [claude] hooks_enabled
-	// gate above.
+	// Cursor Agent CLI hooks: auto-inject silently when the resolved Cursor CLI
+	// binary (`agent` or `cursor`) is available, unless the user opted out via
+	// [cursor] hooks_enabled = false (set durably by `agent-deck cursor-hooks
+	// uninstall`, issue #1672). The opt-out gates the watcher too, matching the
+	// [claude] hooks_enabled gate above.
 	cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor"))
 	if shouldAutoInstallCursorHooks(userConfig, cursorCmd) {
 		if cursorFields := strings.Fields(cursorCmd); len(cursorFields) > 0 {
@@ -11682,7 +11682,7 @@ func createSessionTool(command string) (string, string) {
 		tool = "crush"
 	case "cursor":
 		tool = "cursor"
-		command = "cursor agent"
+		command = session.GetToolCommand("cursor")
 	case "hermes":
 		tool = "hermes"
 	default:
@@ -11936,7 +11936,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 	}
 	if command == "" && tool != "shell" {
 		if tool == "cursor" {
-			command = "cursor agent"
+			command = session.GetToolCommand("cursor")
 		} else {
 			command = tool
 		}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -248,10 +248,10 @@ type dialogSnapshot struct {
 
 // displayCommandPreset returns the visible label for a built-in preset slot.
 // The stored preset for Cursor remains "cursor" (tool id); the pill shows the
-// actual CLI users run ("cursor agent").
+// host-resolved CLI entrypoint (`agent` or `cursor agent`).
 func displayCommandPreset(cmd string) string {
 	if cmd == "cursor" {
-		return "cursor agent"
+		return session.DefaultCursorCommand()
 	}
 	return cmd
 }

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -406,8 +406,15 @@ func TestRenderLaunchModelInfoLines_ShowsModelAndVersion(t *testing.T) {
 }
 
 func TestDisplayCommandPreset(t *testing.T) {
-	if got := displayCommandPreset("cursor"); got != session.DefaultCursorCommand() {
-		t.Errorf("cursor → %q, want %q", got, session.DefaultCursorCommand())
+	// Both DefaultCursorCommand PATH outcomes are covered in
+	// session.TestDefaultCursorCommand_*; here we pin the UI wrapper and the
+	// two legal labels explicitly.
+	want := session.DefaultCursorCommand()
+	if want != "agent" && want != "cursor agent" {
+		t.Fatalf("DefaultCursorCommand() = %q, want agent or cursor agent", want)
+	}
+	if got := displayCommandPreset("cursor"); got != want {
+		t.Errorf("cursor → %q, want %q", got, want)
 	}
 	if got := displayCommandPreset("claude"); got != "claude" {
 		t.Errorf("claude passthrough: got %q", got)

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -406,8 +406,8 @@ func TestRenderLaunchModelInfoLines_ShowsModelAndVersion(t *testing.T) {
 }
 
 func TestDisplayCommandPreset(t *testing.T) {
-	if got := displayCommandPreset("cursor"); got != "cursor agent" {
-		t.Errorf("cursor → %q, want cursor agent", got)
+	if got := displayCommandPreset("cursor"); got != session.DefaultCursorCommand() {
+		t.Errorf("cursor → %q, want %q", got, session.DefaultCursorCommand())
 	}
 	if got := displayCommandPreset("claude"); got != "claude" {
 		t.Errorf("claude passthrough: got %q", got)

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -393,7 +393,7 @@ func (w *SetupWizard) View() string {
 			"pi":       "Pi CLI - lightweight coding assistant",
 			"crush":    "Crush - Charm's terminal-first AI coding assistant",
 			"shell":    "Shell - No AI tool (plain terminal)",
-			"cursor":   "Cursor Agent - Cursor CLI (cursor agent)",
+			"cursor":   "Cursor Agent - Cursor CLI (agent / cursor agent)",
 		}
 
 		for i, tool := range w.toolOptions {

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -288,12 +288,16 @@ Cursor Agent CLI integration settings.
 
 ```toml
 [cursor]
-hooks_enabled = false  # Disable automatic Cursor hook injection on TUI startup
+command = "agent"          # Override launch command (default: prefer `agent`, else `cursor agent`)
+env_file = "~/.cursor.env"
+hooks_enabled = false      # Disable automatic Cursor hook injection on TUI startup
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `hooks_enabled` | bool | `true` | When `true`, TUI startup silently injects agent-deck lifecycle hooks into `~/.cursor/hooks.json` whenever the `cursor` binary is on `PATH` (real-time status detection). Set `false` to durably opt out; `agent-deck cursor-hooks uninstall` writes this automatically so the uninstall survives TUI restarts (issue #1672). Re-enable with `agent-deck cursor-hooks install` or by removing the key. Mirrors `[claude] hooks_enabled`. |
+| `command` | string | host-resolved | Override the binary/invocation. When unset, prefers standalone `agent` when on `PATH`, otherwise `cursor agent`. |
+| `env_file` | string | `""` | A .env file sourced for Cursor sessions only. See [Path Resolution](#path-resolution). |
+| `hooks_enabled` | bool | `true` | When `true`, TUI startup silently injects agent-deck lifecycle hooks into `~/.cursor/hooks.json` whenever the resolved Cursor CLI binary is on `PATH` (real-time status detection). Set `false` to durably opt out; `agent-deck cursor-hooks uninstall` writes this automatically so the uninstall survives TUI restarts (issue #1672). Re-enable with `agent-deck cursor-hooks install` or by removing the key. Mirrors `[claude] hooks_enabled`. |
 
 ## [hermes] Section
 


### PR DESCRIPTION
## What problem does this solve?

Selecting the Cursor Agent provider in agent-deck launches `cursor agent`. On CLI-only Cursor Agent installs, only the standalone `agent` binary is on PATH (the IDE `cursor` shim is missing), so the pane exits immediately with `command not found: cursor`. A shell session with command `agent` works; the Cursor provider does not.

## Why this change

Prefer the standalone `agent` entrypoint when it resolves on PATH, fall back to `cursor agent`, and honor `[cursor].command` for explicit overrides. Rewrite only the stock default forms (`""`, `cursor`, `cursor agent`, `agent`) so custom flagged invocations stay untouched. Also detect bare `agent` as the Cursor tool and treat either binary as installed for `show_only_installed_tools`.

## User impact

Cursor sessions start correctly on hosts that only have the standalone Cursor Agent CLI (`agent`). Hosts that already have `cursor` on PATH keep working via fallback. Optional config: `[cursor] command = "..."` and `[cursor] env_file = "..."`.

## Evidence

Host before fix (no `cursor` on PATH, `agent` present):

```text
$ command -v agent
/Users/.../.local/bin/agent
$ command -v cursor
# empty
$ bash -lc 'cursor agent'
bash: cursor: command not found
```

With Cursor.app's bin prepended, the same CLI works:

```text
$ PATH="/Applications/Cursor.app/Contents/Resources/app/bin:$PATH" cursor agent -p --output-format text "say hi in 3 words"
Hi there, friend.
```

Unit coverage for the new resolver and rewiring:

```text
$ go test ./internal/session/ -run 'Cursor|DefaultCursor|BuildCursor|GetToolCommand_Cursor|Registry_Match'
ok
$ go test ./internal/tmux/ -run 'DetectToolFromCommand|cursor'
ok
$ go test ./internal/ui/ -run 'CommandPreset|displayCommand'
ok
$ go test ./cmd/agent-deck/ -run 'DetectTool_Cursor'
ok
```

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** cursor-composer

**Prompt / session log (optional):** local Cursor agent session investigating Cursor provider crashes, then patching and opening this PR

## What actually bothered you

Human asked: "There are issues with using agent deck with cursor. I can run a shell with agent as command. but when selecting cursor agent in the provider selector the session crashes." Follow-up: "wouldn't it be better if agent-deck changes what command it launches? patch this, and open a PR request"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=cursor-composer intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for launching Cursor through the standalone `agent` CLI.
  - Automatically falls back to `cursor agent` when the standalone CLI is unavailable.
  - Added optional Cursor session command and environment-file configuration.
  - Cursor setup, detection, and session creation now recognize both supported command formats.

- **Bug Fixes**
  - Prevented unrelated commands containing `agent` as a substring from being identified as Cursor.
  - Preserved custom Cursor commands and restart behavior.
  - Improved detection for Cursor commands with flags and configured overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->