### PR TITLE
fix: converge Codex completion across CLI polls

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -31,6 +31,8 @@ type codexNotifyPayload struct {
 	SessionID    string `json:"session_id"`
 	ThreadID     string `json:"thread_id"`
 	ThreadIDDash string `json:"thread-id"`
+	TurnID       string `json:"turn_id"`
+	TurnIDDash   string `json:"turn-id"`
 	Params       map[string]json.RawMessage
 	Payload      map[string]json.RawMessage
 }
@@ -93,10 +95,10 @@ func decodeStringField(raw map[string]json.RawMessage, keys ...string) string {
 	return ""
 }
 
-func parseCodexNotifyPayload(data []byte) (event, sessionID string) {
+func parseCodexNotifyPayload(data []byte) (event, sessionID, turnID string) {
 	var payload codexNotifyPayload
 	if err := json.Unmarshal(data, &payload); err != nil {
-		return "", ""
+		return "", "", ""
 	}
 
 	event = strings.TrimSpace(payload.Type)
@@ -126,8 +128,18 @@ func parseCodexNotifyPayload(data []byte) (event, sessionID string) {
 	if sessionID == "" {
 		sessionID = decodeStringField(payload.Payload, "session_id", "thread_id", "thread-id", "id")
 	}
+	turnID = strings.TrimSpace(payload.TurnID)
+	if turnID == "" {
+		turnID = strings.TrimSpace(payload.TurnIDDash)
+	}
+	if turnID == "" {
+		turnID = decodeStringField(payload.Params, "turn_id", "turn-id")
+	}
+	if turnID == "" {
+		turnID = decodeStringField(payload.Payload, "turn_id", "turn-id")
+	}
 
-	return event, sessionID
+	return event, sessionID, turnID
 }
 
 // handleCodexNotify processes Codex notify payloads.
@@ -168,8 +180,9 @@ func handleCodexNotify() {
 
 	event := ""
 	sessionID := ""
+	turnID := ""
 	if len(data) > 0 {
-		event, sessionID = parseCodexNotifyPayload(data)
+		event, sessionID, turnID = parseCodexNotifyPayload(data)
 		if event == "" {
 			trimmed := strings.TrimSpace(string(data))
 			if !strings.HasPrefix(trimmed, "{") {
@@ -189,7 +202,7 @@ func handleCodexNotify() {
 		sessionID = strings.TrimSpace(os.Getenv("CODEX_SESSION_ID"))
 	}
 
-	writeCodexHookStatus(instanceID, status, sessionID, event)
+	writeCodexHookStatus(instanceID, status, sessionID, event, turnID)
 }
 
 func codexTurnEdge(event string) (started, completed bool) {
@@ -204,7 +217,7 @@ func codexTurnEdge(event string) (started, completed bool) {
 // writeCodexHookStatus retains both edges of the current turn under a file
 // lock. Notify invocations are separate processes and can overlap; serializing
 // the read/modify/write makes the generation proof deterministic.
-func writeCodexHookStatus(instanceID, status, sessionID, event string) {
+func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs ...string) {
 	if instanceID == "" || status == "" {
 		return
 	}
@@ -237,12 +250,22 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string) {
 		evidenceSessionID = session.ReadHookSessionAnchor(instanceID)
 	}
 	started, completed := codexTurnEdge(event)
-	if started {
-		prior.CodexStartedGeneration = fmt.Sprintf("%s:%d", evidenceSessionID, time.Now().UnixNano())
-		prior.CodexStartedSessionID = evidenceSessionID
+	turnID := ""
+	if len(turnIDs) > 0 {
+		turnID = strings.TrimSpace(turnIDs[0])
 	}
-	if completed && prior.CodexStartedGeneration != "" && evidenceSessionID != "" && evidenceSessionID == prior.CodexStartedSessionID {
-		prior.CodexCompletedGeneration = prior.CodexStartedGeneration
+	if started && evidenceSessionID != "" && turnID != "" {
+		prior.CodexStartedGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
+		prior.CodexStartedSessionID = evidenceSessionID
+		prior.CodexCompletedGeneration = ""
+		prior.CodexCompletedSessionID = ""
+	}
+	completionGeneration := ""
+	if evidenceSessionID != "" && turnID != "" {
+		completionGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
+	}
+	if completed && completionGeneration != "" && completionGeneration == prior.CodexStartedGeneration && evidenceSessionID == prior.CodexStartedSessionID {
+		prior.CodexCompletedGeneration = completionGeneration
 		prior.CodexCompletedSessionID = evidenceSessionID
 	}
 	prior.Status, prior.SessionID, prior.Event = status, sessionID, event

--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 const codexNotifyMarkerBegin = "# BEGIN AGENTDECK CODEX NOTIFY"

--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
+	"time"
 )
 
 const codexNotifyMarkerBegin = "# BEGIN AGENTDECK CODEX NOTIFY"
@@ -185,7 +187,66 @@ func handleCodexNotify() {
 		sessionID = strings.TrimSpace(os.Getenv("CODEX_SESSION_ID"))
 	}
 
-	writeHookStatus(instanceID, status, sessionID, event, "")
+	writeCodexHookStatus(instanceID, status, sessionID, event)
+}
+
+func codexTurnEdge(event string) (started, completed bool) {
+	canon := strings.NewReplacer(".", "/", "-", "/", "_", "/").Replace(strings.ToLower(strings.TrimSpace(event)))
+	if !strings.Contains(canon, "turn") {
+		return false, false
+	}
+	return strings.Contains(canon, "start"), strings.Contains(canon, "complete") ||
+		strings.Contains(canon, "fail") || strings.Contains(canon, "abort") || strings.Contains(canon, "cancel")
+}
+
+// writeCodexHookStatus retains both edges of the current turn under a file
+// lock. Notify invocations are separate processes and can overlap; serializing
+// the read/modify/write makes the generation proof deterministic.
+func writeCodexHookStatus(instanceID, status, sessionID, event string) {
+	if instanceID == "" || status == "" {
+		return
+	}
+	hooksDir := getHooksDir()
+	if err := os.MkdirAll(hooksDir, 0700); err != nil {
+		return
+	}
+	base := filepath.Base(instanceID)
+	lock, err := os.OpenFile(filepath.Join(hooksDir, base+".codex.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return
+	}
+	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) //nolint:errcheck
+
+	path := filepath.Join(hooksDir, base+".json")
+	var prior hookStatusFile
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &prior)
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID != "" {
+		session.WriteHookSessionAnchor(instanceID, sessionID)
+	}
+	evidenceSessionID := sessionID
+	if evidenceSessionID == "" {
+		evidenceSessionID = session.ReadHookSessionAnchor(instanceID)
+	}
+	started, completed := codexTurnEdge(event)
+	if started {
+		prior.CodexStartedGeneration = fmt.Sprintf("%s:%d", evidenceSessionID, time.Now().UnixNano())
+		prior.CodexStartedSessionID = evidenceSessionID
+	}
+	if completed && prior.CodexStartedGeneration != "" && evidenceSessionID != "" && evidenceSessionID == prior.CodexStartedSessionID {
+		prior.CodexCompletedGeneration = prior.CodexStartedGeneration
+		prior.CodexCompletedSessionID = evidenceSessionID
+	}
+	prior.Status, prior.SessionID, prior.Event = status, sessionID, event
+	prior.Timestamp = time.Now().Unix()
+	prior.DoneStatus, prior.DoneSummary, prior.TranscriptPath, prior.Cwd = "", "", "", ""
+	writeHookStatusFile(instanceID, prior)
 }
 
 func handleCodexHooks(args []string) {

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -146,7 +148,7 @@ func TestHandleCodexNotify_EmptyTailEventKeepsJSONEmptyAndPersistsAnchor(t *test
 	defer func() { os.Args = origArgs }()
 
 	// Seed sticky mapping with a thread_id-bearing event.
-	os.Args = []string{"agent-deck", "codex-notify", `{"event":"turn/started","thread_id":"thr-sticky"}`}
+	os.Args = []string{"agent-deck", "codex-notify", `{"event":"turn/started","thread_id":"thr-sticky","turn_id":"turn-main"}`}
 	handleCodexNotify()
 
 	// Tail event has no session_id/thread_id; should backfill from sticky store.
@@ -168,15 +170,15 @@ func TestHandleCodexNotify_EmptyTailEventKeepsJSONEmptyAndPersistsAnchor(t *test
 	if got := session.ReadHookSessionAnchor("inst-sticky"); got != "thr-sticky" {
 		t.Fatalf("session anchor = %q, want thr-sticky", got)
 	}
-	if hook.CodexStartedGeneration == "" || hook.CodexCompletedGeneration != hook.CodexStartedGeneration {
-		t.Fatalf("start/completion evidence did not converge: %#v", hook)
+	if hook.CodexStartedGeneration == "" || hook.CodexCompletedGeneration != "" {
+		t.Fatalf("identity-less completion must fail closed: %#v", hook)
 	}
 }
 
 func TestWriteCodexHookStatus_NewerStartSupersedesCompletedGeneration(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	writeCodexHookStatus("inst-generation", "running", "thread-1", "turn.started")
-	writeCodexHookStatus("inst-generation", "waiting", "thread-1", "turn.completed")
+	writeCodexHookStatus("inst-generation", "running", "thread-1", "turn.started", "turn-1")
+	writeCodexHookStatus("inst-generation", "waiting", "thread-1", "turn.completed", "turn-1")
 	path := filepath.Join(getHooksDir(), "inst-generation.json")
 	var completed hookStatusFile
 	data, err := os.ReadFile(path)
@@ -189,7 +191,7 @@ func TestWriteCodexHookStatus_NewerStartSupersedesCompletedGeneration(t *testing
 	if completed.CodexStartedGeneration != completed.CodexCompletedGeneration {
 		t.Fatal("matching completion was not retained")
 	}
-	writeCodexHookStatus("inst-generation", "running", "thread-1", "turn.started")
+	writeCodexHookStatus("inst-generation", "running", "thread-1", "turn.started", "turn-2")
 	var superseded hookStatusFile
 	data, err = os.ReadFile(path)
 	if err != nil {
@@ -200,6 +202,94 @@ func TestWriteCodexHookStatus_NewerStartSupersedesCompletedGeneration(t *testing
 	}
 	if superseded.CodexStartedGeneration == superseded.CodexCompletedGeneration {
 		t.Fatal("new start must supersede old completion evidence")
+	}
+}
+
+func TestWriteCodexHookStatus_CompletionMustMatchTurnIdentity(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTDECK_HOOKS_DIR", filepath.Join(t.TempDir(), "hooks"))
+
+	writeCodexHookStatus("turn-match", "running", "thread-1", "turn.started", "turn-2")
+	writeCodexHookStatus("turn-match", "waiting", "thread-1", "turn.completed", "turn-1")
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), "turn-match.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got hookStatusFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CodexCompletedGeneration != "" {
+		t.Fatalf("out-of-order completion converged live turn: %#v", got)
+	}
+
+	writeCodexHookStatus("turn-match", "waiting", "thread-1", "turn.completed", "turn-2")
+	data, err = os.ReadFile(filepath.Join(getHooksDir(), "turn-match.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CodexCompletedGeneration == "" || got.CodexCompletedGeneration != got.CodexStartedGeneration {
+		t.Fatalf("matching completion did not converge: %#v", got)
+	}
+}
+
+func TestWriteCodexHookStatus_IdentityLessCompletionFailsClosed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTDECK_HOOKS_DIR", filepath.Join(t.TempDir(), "hooks"))
+	writeCodexHookStatus("no-turn", "running", "thread-1", "turn.started", "turn-1")
+	writeCodexHookStatus("no-turn", "waiting", "thread-1", "agent-turn-complete", "")
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), "no-turn.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got hookStatusFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CodexCompletedGeneration != "" {
+		t.Fatalf("identity-less completion converged: %#v", got)
+	}
+}
+
+func TestWriteCodexHookStatus_ConcurrentFleetPersistence(t *testing.T) {
+	for _, size := range []int{1, 20, 100} {
+		t.Run(fmt.Sprintf("fleet-%d", size), func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("AGENTDECK_HOOKS_DIR", filepath.Join(t.TempDir(), "hooks"))
+			for n := 0; n < size; n++ {
+				id := fmt.Sprintf("instance-%03d", n)
+				turn := fmt.Sprintf("turn-%03d", n)
+				writeCodexHookStatus(id, "running", id, "turn.started", turn)
+			}
+			var wg sync.WaitGroup
+			wg.Add(size)
+			for n := 0; n < size; n++ {
+				n := n
+				go func() {
+					defer wg.Done()
+					id := fmt.Sprintf("instance-%03d", n)
+					writeCodexHookStatus(id, "waiting", id, "turn.completed", fmt.Sprintf("turn-%03d", n))
+				}()
+			}
+			wg.Wait()
+			for n := 0; n < size; n++ {
+				id := fmt.Sprintf("instance-%03d", n)
+				data, err := os.ReadFile(filepath.Join(getHooksDir(), id+".json"))
+				if err != nil {
+					t.Fatalf("read %s: %v", id, err)
+				}
+				var got hookStatusFile
+				if err := json.Unmarshal(data, &got); err != nil {
+					t.Fatalf("decode %s: %v", id, err)
+				}
+				if got.CodexStartedGeneration == "" || got.CodexStartedGeneration != got.CodexCompletedGeneration {
+					t.Fatalf("%s did not converge: %#v", id, got)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -168,6 +168,39 @@ func TestHandleCodexNotify_EmptyTailEventKeepsJSONEmptyAndPersistsAnchor(t *test
 	if got := session.ReadHookSessionAnchor("inst-sticky"); got != "thr-sticky" {
 		t.Fatalf("session anchor = %q, want thr-sticky", got)
 	}
+	if hook.CodexStartedGeneration == "" || hook.CodexCompletedGeneration != hook.CodexStartedGeneration {
+		t.Fatalf("start/completion evidence did not converge: %#v", hook)
+	}
+}
+
+func TestWriteCodexHookStatus_NewerStartSupersedesCompletedGeneration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeCodexHookStatus("inst-generation", "running", "thread-1", "turn.started")
+	writeCodexHookStatus("inst-generation", "waiting", "thread-1", "turn.completed")
+	path := filepath.Join(getHooksDir(), "inst-generation.json")
+	var completed hookStatusFile
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &completed); err != nil {
+		t.Fatal(err)
+	}
+	if completed.CodexStartedGeneration != completed.CodexCompletedGeneration {
+		t.Fatal("matching completion was not retained")
+	}
+	writeCodexHookStatus("inst-generation", "running", "thread-1", "turn.started")
+	var superseded hookStatusFile
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &superseded); err != nil {
+		t.Fatal(err)
+	}
+	if superseded.CodexStartedGeneration == superseded.CodexCompletedGeneration {
+		t.Fatal("new start must supersede old completion evidence")
+	}
 }
 
 func TestCodexHooksInstallUninstall(t *testing.T) {

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -63,10 +63,14 @@ func resolveStopHookActive(p hookPayload) bool {
 
 // hookStatusFile is the JSON written to ~/.agent-deck/hooks/{instance_id}.json
 type hookStatusFile struct {
-	Status    string `json:"status"`
-	SessionID string `json:"session_id,omitempty"`
-	Event     string `json:"event"`
-	Timestamp int64  `json:"ts"`
+	Status                   string `json:"status"`
+	SessionID                string `json:"session_id,omitempty"`
+	Event                    string `json:"event"`
+	Timestamp                int64  `json:"ts"`
+	CodexStartedGeneration   string `json:"codex_started_generation,omitempty"`
+	CodexCompletedGeneration string `json:"codex_completed_generation,omitempty"`
+	CodexStartedSessionID    string `json:"codex_started_session_id,omitempty"`
+	CodexCompletedSessionID  string `json:"codex_completed_session_id,omitempty"`
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). omitempty so ordinary Stops
 	// (no sentinel) leave the fields absent, which the daemon reads as
@@ -366,6 +370,16 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 		statusFile.DoneSummary = scan.signal.Summary
 	}
 	statusFile.TranscriptPath = scan.pendingTranscript
+	writeHookStatusFile(instanceID, statusFile)
+
+	// Clear sticky session mapping when the upstream session is explicitly ended.
+	if isTerminalHookEvent(event) {
+		session.ClearHookSessionAnchor(instanceID)
+	}
+}
+
+func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
+	hooksDir := getHooksDir()
 
 	jsonData, err := json.Marshal(statusFile)
 	if err != nil {
@@ -398,10 +412,6 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 		return
 	}
 
-	// Clear sticky session mapping when the upstream session is explicitly ended.
-	if isTerminalHookEvent(event) {
-		session.ClearHookSessionAnchor(instanceID)
-	}
 }
 
 func isTerminalHookEvent(event string) bool {

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -488,7 +488,7 @@ func cleanStaleHookFiles() {
 	cutoff := time.Now().Add(-24 * time.Hour)
 	for _, entry := range entries {
 		ext := filepath.Ext(entry.Name())
-		if entry.IsDir() || (ext != ".json" && ext != ".sid") {
+		if entry.IsDir() || (ext != ".json" && ext != ".sid" && !strings.HasSuffix(entry.Name(), ".codex.lock")) {
 			continue
 		}
 		info, err := entry.Info()

--- a/internal/session/cli_status_refresh.go
+++ b/internal/session/cli_status_refresh.go
@@ -31,7 +31,7 @@ func RefreshInstancesForCLIStatus(instances []*Instance) {
 		if inst == nil {
 			continue
 		}
-		if !IsClaudeCompatible(inst.Tool) && inst.Tool != "codex" && inst.Tool != "gemini" {
+		if !IsClaudeCompatible(inst.Tool) && !IsCodexCompatible(inst.Tool) && inst.Tool != "gemini" {
 			continue
 		}
 		if hs := readHookStatusFile(inst.ID); hs != nil {

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -327,27 +327,35 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			continue
 		}
 		var raw struct {
-			Status         string `json:"status"`
-			SessionID      string `json:"session_id"`
-			Event          string `json:"event"`
-			Timestamp      int64  `json:"ts"`
-			DoneStatus     string `json:"done_status"`
-			DoneSummary    string `json:"done_summary"`
-			TranscriptPath string `json:"transcript_path"`
-			Cwd            string `json:"cwd"`
+			Status                   string `json:"status"`
+			SessionID                string `json:"session_id"`
+			Event                    string `json:"event"`
+			Timestamp                int64  `json:"ts"`
+			DoneStatus               string `json:"done_status"`
+			DoneSummary              string `json:"done_summary"`
+			TranscriptPath           string `json:"transcript_path"`
+			Cwd                      string `json:"cwd"`
+			CodexStartedGeneration   string `json:"codex_started_generation"`
+			CodexCompletedGeneration string `json:"codex_completed_generation"`
+			CodexStartedSessionID    string `json:"codex_started_session_id"`
+			CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 		}
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
 		out[instanceID] = &HookStatus{
-			Status:         raw.Status,
-			SessionID:      raw.SessionID,
-			Event:          raw.Event,
-			UpdatedAt:      time.Unix(raw.Timestamp, 0),
-			DoneStatus:     raw.DoneStatus,
-			DoneSummary:    raw.DoneSummary,
-			TranscriptPath: raw.TranscriptPath,
-			Cwd:            raw.Cwd,
+			Status:                   raw.Status,
+			SessionID:                raw.SessionID,
+			Event:                    raw.Event,
+			UpdatedAt:                time.Unix(raw.Timestamp, 0),
+			DoneStatus:               raw.DoneStatus,
+			DoneSummary:              raw.DoneSummary,
+			TranscriptPath:           raw.TranscriptPath,
+			Cwd:                      raw.Cwd,
+			CodexStartedGeneration:   raw.CodexStartedGeneration,
+			CodexCompletedGeneration: raw.CodexCompletedGeneration,
+			CodexStartedSessionID:    raw.CodexStartedSessionID,
+			CodexCompletedSessionID:  raw.CodexCompletedSessionID,
 		}
 	}
 }
@@ -469,14 +477,18 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	}
 
 	var status struct {
-		Status         string `json:"status"`
-		SessionID      string `json:"session_id"`
-		Event          string `json:"event"`
-		Timestamp      int64  `json:"ts"`
-		DoneStatus     string `json:"done_status"`
-		DoneSummary    string `json:"done_summary"`
-		TranscriptPath string `json:"transcript_path"`
-		Cwd            string `json:"cwd"`
+		Status                   string `json:"status"`
+		SessionID                string `json:"session_id"`
+		Event                    string `json:"event"`
+		Timestamp                int64  `json:"ts"`
+		DoneStatus               string `json:"done_status"`
+		DoneSummary              string `json:"done_summary"`
+		TranscriptPath           string `json:"transcript_path"`
+		Cwd                      string `json:"cwd"`
+		CodexStartedGeneration   string `json:"codex_started_generation"`
+		CodexCompletedGeneration string `json:"codex_completed_generation"`
+		CodexStartedSessionID    string `json:"codex_started_session_id"`
+		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 	}
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
@@ -489,14 +501,18 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	}
 
 	hookStatus := &HookStatus{
-		Status:         status.Status,
-		SessionID:      status.SessionID,
-		Event:          status.Event,
-		UpdatedAt:      time.Unix(status.Timestamp, 0),
-		DoneStatus:     status.DoneStatus,
-		DoneSummary:    status.DoneSummary,
-		TranscriptPath: status.TranscriptPath,
-		Cwd:            status.Cwd,
+		Status:                   status.Status,
+		SessionID:                status.SessionID,
+		Event:                    status.Event,
+		UpdatedAt:                time.Unix(status.Timestamp, 0),
+		DoneStatus:               status.DoneStatus,
+		DoneSummary:              status.DoneSummary,
+		TranscriptPath:           status.TranscriptPath,
+		Cwd:                      status.Cwd,
+		CodexStartedGeneration:   status.CodexStartedGeneration,
+		CodexCompletedGeneration: status.CodexCompletedGeneration,
+		CodexStartedSessionID:    status.CodexStartedSessionID,
+		CodexCompletedSessionID:  status.CodexCompletedSessionID,
 	}
 
 	w.mu.Lock()

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -37,10 +37,14 @@ func readStatusFileNoFollow(path string) ([]byte, error) {
 
 // HookStatus holds the decoded status from a hook status file.
 type HookStatus struct {
-	Status    string    // running, idle, waiting, dead
-	SessionID string    // Claude session ID
-	Event     string    // Hook event name
-	UpdatedAt time.Time // When this status was received
+	Status                   string    // running, idle, waiting, dead
+	SessionID                string    // Claude session ID
+	Event                    string    // Hook event name
+	UpdatedAt                time.Time // When this status was received
+	CodexStartedGeneration   string
+	CodexCompletedGeneration string
+	CodexStartedSessionID    string
+	CodexCompletedSessionID  string
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
 	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen

--- a/internal/session/hook_watcher_test.go
+++ b/internal/session/hook_watcher_test.go
@@ -21,15 +21,23 @@ func TestStatusFileWatcher_ProcessFile(t *testing.T) {
 
 	// Write a status file
 	status := struct {
-		Status    string `json:"status"`
-		SessionID string `json:"session_id"`
-		Event     string `json:"event"`
-		Timestamp int64  `json:"ts"`
+		Status                   string `json:"status"`
+		SessionID                string `json:"session_id"`
+		Event                    string `json:"event"`
+		Timestamp                int64  `json:"ts"`
+		CodexStartedGeneration   string `json:"codex_started_generation"`
+		CodexCompletedGeneration string `json:"codex_completed_generation"`
+		CodexStartedSessionID    string `json:"codex_started_session_id"`
+		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 	}{
-		Status:    "running",
-		SessionID: "abc-123",
-		Event:     "UserPromptSubmit",
-		Timestamp: time.Now().Unix(),
+		Status:                   "running",
+		SessionID:                "abc-123",
+		Event:                    "UserPromptSubmit",
+		Timestamp:                time.Now().Unix(),
+		CodexStartedGeneration:   "thread:turn",
+		CodexCompletedGeneration: "thread:turn",
+		CodexStartedSessionID:    "thread",
+		CodexCompletedSessionID:  "thread",
 	}
 	data, _ := json.Marshal(status)
 	filePath := filepath.Join(hooksDir, "instance-001.json")
@@ -51,6 +59,10 @@ func TestStatusFileWatcher_ProcessFile(t *testing.T) {
 	}
 	if hs.Event != "UserPromptSubmit" {
 		t.Errorf("Event = %q, want UserPromptSubmit", hs.Event)
+	}
+	if hs.CodexStartedGeneration != "thread:turn" || hs.CodexCompletedGeneration != "thread:turn" ||
+		hs.CodexStartedSessionID != "thread" || hs.CodexCompletedSessionID != "thread" {
+		t.Fatalf("Codex evidence not propagated: %#v", hs)
 	}
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4994,6 +4994,10 @@ func (i *Instance) setCodexGenerationEvidence(status *HookStatus) {
 	if status == nil || !IsCodexCompatible(i.Tool) {
 		return
 	}
+	if status.CodexStartedGeneration == "" && status.CodexCompletedGeneration == "" &&
+		status.CodexStartedSessionID == "" && status.CodexCompletedSessionID == "" {
+		return
+	}
 	i.codexStartedGeneration = strings.TrimSpace(status.CodexStartedGeneration)
 	i.codexCompletedGeneration = strings.TrimSpace(status.CodexCompletedGeneration)
 	i.codexStartedSessionID = strings.TrimSpace(status.CodexStartedSessionID)
@@ -5012,6 +5016,10 @@ func (i *Instance) codexCompletionConverged() bool {
 		return false
 	}
 	return i.CodexSessionID != "" && i.codexStartedSessionID == i.CodexSessionID
+}
+
+func (i *Instance) shouldBypassCodexWaitingDebounce(derived Status) bool {
+	return derived == StatusWaiting && i.codexCompletionConverged()
 }
 
 // terminatedPaneStatus classifies a session whose tmux pane/session has
@@ -5190,7 +5198,7 @@ func (i *Instance) UpdateStatus() error {
 
 	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
 	// Read the hook file from disk once to give CLI the same fast path as the TUI.
-	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
 			i.hookEvent = hs.Event
@@ -5454,7 +5462,8 @@ func (i *Instance) UpdateStatus() error {
 	// this skip, each fresh CLI invocation (e.g. `agent-deck list --json`) sees
 	// tmuxFlipFromRunningPending = false and holds the status at running on the
 	// first sample, then exits before the second confirming sample can fire.
-	if shouldDebounceTmuxFlipForTool(i.Tool) && !i.codexCompletionConverged() {
+	bypassWaitingDebounce := i.shouldBypassCodexWaitingDebounce(i.Status)
+	if shouldDebounceTmuxFlipForTool(i.Tool) && !bypassWaitingDebounce {
 		if apply, nextPending, held := debounceFlipFromRunning(prevStatus, i.Status, status, i.hookStatus, i.tmuxFlipFromRunningPending); held {
 			i.tmuxFlipFromRunningPending = nextPending
 			i.Status = apply
@@ -5679,6 +5688,13 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	// it carried had already been written here and stuck, flipping this
 	// instance's status. See the candidate_has_no_conversation_data branch.
 	prevHookStatus, prevHookEvent, prevHookLastUpdate := i.hookStatus, i.hookEvent, i.hookLastUpdate
+	prevStartedGen, prevCompletedGen := i.codexStartedGeneration, i.codexCompletedGeneration
+	prevStartedSID, prevCompletedSID := i.codexStartedSessionID, i.codexCompletedSessionID
+	restoreHook := func() {
+		i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
+		i.codexStartedGeneration, i.codexCompletedGeneration = prevStartedGen, prevCompletedGen
+		i.codexStartedSessionID, i.codexCompletedSessionID = prevStartedSID, prevCompletedSID
+	}
 
 	// Detect whether this is genuinely new data (newer timestamp than last seen).
 	// Only reset acknowledgment on new events — not on re-application of the same
@@ -5750,7 +5766,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		// cwd (legacy hook files, agents that send none) is not evidence and
 		// never blocks.
 		if i.hookCwdIsForeign(status.Cwd) {
-			i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
+			restoreHook()
 			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
 				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
 				Source: hookSource, OldID: i.ClaudeSessionID, Candidate: sessionID,
@@ -5772,7 +5788,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 			// status must not stick either. Restore the pre-event status so the
 			// foreign hook is a no-op, not a flip. (A real /clear or fork carries
 			// conversation data and never reaches this branch.)
-			i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
+			restoreHook()
 			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
 				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
 				Source: hookSource, OldID: i.ClaudeSessionID, Candidate: sessionID,

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -484,10 +484,14 @@ type Instance struct {
 	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
-	hookStatus     string    // running, idle, waiting, dead (empty = no hook data)
-	hookEvent      string    // Hook event name that caused the last status (e.g. "PermissionRequest")
-	hookSessionID  string    // Session ID from hook payload
-	hookLastUpdate time.Time // When hook status was last received
+	hookStatus               string    // running, idle, waiting, dead (empty = no hook data)
+	hookEvent                string    // Hook event name that caused the last status (e.g. "PermissionRequest")
+	hookSessionID            string    // Session ID from hook payload
+	hookLastUpdate           time.Time // When hook status was last received
+	codexStartedGeneration   string
+	codexCompletedGeneration string
+	codexStartedSessionID    string
+	codexCompletedSessionID  string
 
 	// Durable last-activity record (issue #1846). Unlike hookLastUpdate this
 	// survives ClearHookStatus and, via tool_data.last_activity_at, TUI
@@ -4983,6 +4987,33 @@ func shouldDebounceTmuxFlipForTool(tool string) bool {
 		tool == "gemini" || tool == "hermes" || tool == "cursor"
 }
 
+// setCodexGenerationEvidence copies the durable notify edge pair into the
+// instance. Unlike tmuxFlipFromRunningPending, these fields survive a fresh
+// CLI process because they are retained in the hook status file.
+func (i *Instance) setCodexGenerationEvidence(status *HookStatus) {
+	if status == nil || !IsCodexCompatible(i.Tool) {
+		return
+	}
+	i.codexStartedGeneration = strings.TrimSpace(status.CodexStartedGeneration)
+	i.codexCompletedGeneration = strings.TrimSpace(status.CodexCompletedGeneration)
+	i.codexStartedSessionID = strings.TrimSpace(status.CodexStartedSessionID)
+	i.codexCompletedSessionID = strings.TrimSpace(status.CodexCompletedSessionID)
+}
+
+// codexCompletionConverged is deliberately fail-closed. Only the same retained
+// generation, for the same non-empty session bound to this instance, proves a
+// completed turn. Missing, mismatched, and superseded evidence stays subject
+// to the conservative running debounce.
+func (i *Instance) codexCompletionConverged() bool {
+	if !IsCodexCompatible(i.Tool) || i.codexStartedGeneration == "" ||
+		i.codexStartedGeneration != i.codexCompletedGeneration ||
+		i.codexStartedSessionID == "" ||
+		i.codexStartedSessionID != i.codexCompletedSessionID {
+		return false
+	}
+	return i.CodexSessionID != "" && i.codexStartedSessionID == i.CodexSessionID
+}
+
 // terminatedPaneStatus classifies a session whose tmux pane/session has
 // vanished (or gone dead under remain-on-exit) AFTER having been started.
 //
@@ -5168,6 +5199,7 @@ func (i *Instance) UpdateStatus() error {
 			// #1846: a disk-read hook sample is activity evidence too.
 			// Flushed by this function's persistLastActivity defer.
 			i.noteAgentActivityLocked(hs.UpdatedAt)
+			i.setCodexGenerationEvidence(hs)
 			// Reset stale acknowledged flag from ReconnectSessionLazy.
 			// Without this, sessions loaded from SQLite with previousStatus="idle"
 			// would report idle even when the hook file says waiting/running.
@@ -5422,7 +5454,7 @@ func (i *Instance) UpdateStatus() error {
 	// this skip, each fresh CLI invocation (e.g. `agent-deck list --json`) sees
 	// tmuxFlipFromRunningPending = false and holds the status at running on the
 	// first sample, then exits before the second confirming sample can fire.
-	if shouldDebounceTmuxFlipForTool(i.Tool) {
+	if shouldDebounceTmuxFlipForTool(i.Tool) && !i.codexCompletionConverged() {
 		if apply, nextPending, held := debounceFlipFromRunning(prevStatus, i.Status, status, i.hookStatus, i.tmuxFlipFromRunningPending); held {
 			i.tmuxFlipFromRunningPending = nextPending
 			i.Status = apply
@@ -5656,6 +5688,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	i.hookStatus = status.Status
 	i.hookEvent = status.Event
 	i.hookLastUpdate = status.UpdatedAt
+	i.setCodexGenerationEvidence(status)
 
 	// Permission-type events are always attention-needed, even if the user
 	// previously acknowledged this session. A mid-task permission block is new

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -97,6 +97,45 @@ func TestDebounceFlipFromRunning(t *testing.T) {
 	}
 }
 
+func TestCodexCompletionConvergenceRequiresMatchingGenerationAndSession(t *testing.T) {
+	tests := []struct {
+		name, started, completed, startedSession, completedSession, bound string
+		want                                                              bool
+	}{
+		{"matching", "g1", "g1", "s1", "s1", "s1", true},
+		{"missing completion", "g1", "", "s1", "", "s1", false},
+		{"mismatched completion", "g2", "g1", "s1", "s1", "s1", false},
+		{"newer start supersedes completion", "g2", "g1", "s1", "s1", "s1", false},
+		{"foreign session", "g1", "g1", "s1", "s1", "s2", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			i := &Instance{Tool: "codex", CodexSessionID: tc.bound,
+				codexStartedGeneration: tc.started, codexCompletedGeneration: tc.completed,
+				codexStartedSessionID: tc.startedSession, codexCompletedSessionID: tc.completedSession}
+			if got := i.codexCompletionConverged(); got != tc.want {
+				t.Fatalf("codexCompletionConverged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexCompletionConvergenceFleetSizes(t *testing.T) {
+	for _, size := range []int{1, 20, 100} {
+		instances := make([]*Instance, size)
+		for n := range instances {
+			instances[n] = &Instance{Tool: "codex", CodexSessionID: "s",
+				codexStartedGeneration: "g", codexCompletedGeneration: "g",
+				codexStartedSessionID: "s", codexCompletedSessionID: "s"}
+		}
+		for n, inst := range instances {
+			if !inst.codexCompletionConverged() {
+				t.Fatalf("size %d instance %d did not converge", size, n)
+			}
+		}
+	}
+}
+
 // The canonical long-bash sequence: running, then two consecutive tmux "waiting"
 // reads. The first is held at running (no false completion), the second flips.
 func TestDebounceFlipFromRunning_LongBashSequence(t *testing.T) {

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -120,19 +120,25 @@ func TestCodexCompletionConvergenceRequiresMatchingGenerationAndSession(t *testi
 	}
 }
 
-func TestCodexCompletionConvergenceFleetSizes(t *testing.T) {
-	for _, size := range []int{1, 20, 100} {
-		instances := make([]*Instance, size)
-		for n := range instances {
-			instances[n] = &Instance{Tool: "codex", CodexSessionID: "s",
-				codexStartedGeneration: "g", codexCompletedGeneration: "g",
-				codexStartedSessionID: "s", codexCompletedSessionID: "s"}
-		}
-		for n, inst := range instances {
-			if !inst.codexCompletionConverged() {
-				t.Fatalf("size %d instance %d did not converge", size, n)
-			}
-		}
+func TestCodexCompletionBypassesWaitingOnly(t *testing.T) {
+	i := &Instance{Tool: "codex", CodexSessionID: "s",
+		codexStartedGeneration: "g", codexCompletedGeneration: "g",
+		codexStartedSessionID: "s", codexCompletedSessionID: "s"}
+	if !i.shouldBypassCodexWaitingDebounce(StatusWaiting) {
+		t.Fatal("converged completion must bypass waiting debounce")
+	}
+	if i.shouldBypassCodexWaitingDebounce(StatusError) {
+		t.Fatal("completion evidence must not bypass error debounce")
+	}
+}
+
+func TestSetCodexGenerationEvidence_EvidenceLessDoesNotErase(t *testing.T) {
+	i := &Instance{Tool: "codex", codexStartedGeneration: "g", codexCompletedGeneration: "g",
+		codexStartedSessionID: "s", codexCompletedSessionID: "s"}
+	i.setCodexGenerationEvidence(&HookStatus{Status: "waiting"})
+	if i.codexStartedGeneration != "g" || i.codexCompletedGeneration != "g" ||
+		i.codexStartedSessionID != "s" || i.codexCompletedSessionID != "s" {
+		t.Fatalf("evidence-less update erased valid evidence: %#v", i)
 	}
 }
 

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -740,14 +740,18 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		return nil
 	}
 	var raw struct {
-		Status         string `json:"status"`
-		SessionID      string `json:"session_id"`
-		Event          string `json:"event"`
-		Timestamp      int64  `json:"ts"`
-		DoneStatus     string `json:"done_status"`
-		DoneSummary    string `json:"done_summary"`
-		TranscriptPath string `json:"transcript_path"`
-		Cwd            string `json:"cwd"`
+		Status                   string `json:"status"`
+		SessionID                string `json:"session_id"`
+		Event                    string `json:"event"`
+		Timestamp                int64  `json:"ts"`
+		DoneStatus               string `json:"done_status"`
+		DoneSummary              string `json:"done_summary"`
+		TranscriptPath           string `json:"transcript_path"`
+		Cwd                      string `json:"cwd"`
+		CodexStartedGeneration   string `json:"codex_started_generation"`
+		CodexCompletedGeneration string `json:"codex_completed_generation"`
+		CodexStartedSessionID    string `json:"codex_started_session_id"`
+		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
@@ -760,14 +764,18 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
 	return &HookStatus{
-		Status:         raw.Status,
-		SessionID:      raw.SessionID,
-		Event:          raw.Event,
-		UpdatedAt:      updatedAt,
-		DoneStatus:     raw.DoneStatus,
-		DoneSummary:    raw.DoneSummary,
-		TranscriptPath: raw.TranscriptPath,
-		Cwd:            raw.Cwd,
+		Status:                   raw.Status,
+		SessionID:                raw.SessionID,
+		Event:                    raw.Event,
+		UpdatedAt:                updatedAt,
+		DoneStatus:               raw.DoneStatus,
+		DoneSummary:              raw.DoneSummary,
+		TranscriptPath:           raw.TranscriptPath,
+		Cwd:                      raw.Cwd,
+		CodexStartedGeneration:   raw.CodexStartedGeneration,
+		CodexCompletedGeneration: raw.CodexCompletedGeneration,
+		CodexStartedSessionID:    raw.CodexStartedSessionID,
+		CodexCompletedSessionID:  raw.CodexCompletedSessionID,
 	}
 }
 

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -345,10 +345,14 @@ func toMenuSession(inst *session.Instance) *MenuSession {
 }
 
 type rawHookStatus struct {
-	Status    string `json:"status"`
-	SessionID string `json:"session_id"`
-	Event     string `json:"event"`
-	Timestamp int64  `json:"ts"`
+	Status                   string `json:"status"`
+	SessionID                string `json:"session_id"`
+	Event                    string `json:"event"`
+	Timestamp                int64  `json:"ts"`
+	CodexStartedGeneration   string `json:"codex_started_generation"`
+	CodexCompletedGeneration string `json:"codex_completed_generation"`
+	CodexStartedSessionID    string `json:"codex_started_session_id"`
+	CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 }
 
 func defaultLoadHookStatuses() map[string]*session.HookStatus {
@@ -410,10 +414,14 @@ func defaultLoadHookStatuses() map[string]*session.HookStatus {
 		}
 
 		hooksByInstance[instanceID] = &session.HookStatus{
-			Status:    parsed.Status,
-			SessionID: parsed.SessionID,
-			Event:     parsed.Event,
-			UpdatedAt: updatedAt,
+			Status:                   parsed.Status,
+			SessionID:                parsed.SessionID,
+			Event:                    parsed.Event,
+			UpdatedAt:                updatedAt,
+			CodexStartedGeneration:   parsed.CodexStartedGeneration,
+			CodexCompletedGeneration: parsed.CodexCompletedGeneration,
+			CodexStartedSessionID:    parsed.CodexStartedSessionID,
+			CodexCompletedSessionID:  parsed.CodexCompletedSessionID,
 		}
 	}
 

--- a/internal/web/session_data_service_hooks_test.go
+++ b/internal/web/session_data_service_hooks_test.go
@@ -18,7 +18,7 @@ func TestDefaultLoadHookStatuses(t *testing.T) {
 		t.Fatalf("mkdir hooks dir: %v", err)
 	}
 
-	valid := `{"status":"running","session_id":"claude-1","event":"UserPromptSubmit","ts":1735689600}`
+	valid := `{"status":"running","session_id":"claude-1","event":"UserPromptSubmit","ts":1735689600,"codex_started_generation":"s:t","codex_completed_generation":"s:t","codex_started_session_id":"s","codex_completed_session_id":"s"}`
 	if err := os.WriteFile(filepath.Join(hooksDir, "inst-1.json"), []byte(valid), 0o644); err != nil {
 		t.Fatalf("write valid hook file: %v", err)
 	}
@@ -43,6 +43,10 @@ func TestDefaultLoadHookStatuses(t *testing.T) {
 	}
 	if got.UpdatedAt.Unix() != 1735689600 {
 		t.Fatalf("expected timestamp 1735689600, got %d", got.UpdatedAt.Unix())
+	}
+	if got.CodexStartedGeneration != "s:t" || got.CodexCompletedGeneration != "s:t" ||
+		got.CodexStartedSessionID != "s" || got.CodexCompletedSessionID != "s" {
+		t.Fatalf("expected Codex evidence parity, got %#v", got)
 	}
 
 	if _, ok := statuses["broken"]; ok {


### PR DESCRIPTION
Persists Codex turn-generation evidence so fresh CLI polls can converge completed sessions without weakening fail-closed handling for missing, mismatched, or newer activity. Keeps CLI, TUI, and web status reads aligned.

Tests: `go build ./...`; `go vet ./...`; focused tests for `cmd/agent-deck`, `internal/session`, and `internal/web`.

Fixes #1792