### PR TITLE
fix(send): preserve multiline message structure

### DIFF
--- a/cmd/agent-deck/issue1855_arrival_marker_scope_test.go
+++ b/cmd/agent-deck/issue1855_arrival_marker_scope_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Round-3 regression tests for issue #1855. The round-2 arrival signal was a
+// whole-pane BOOLEAN ("a [Pasted text …] marker is visible somewhere in the
+// pane") compared against a boolean baseline, while the body signal beside it
+// in the same block was a COUNT compared as `n > baseline.occurrences`. Two
+// distinct defects followed from that, and neither of the round-2 fixtures
+// could see either one, because they park the stale marker IN the composer —
+// the one place where a whole-pane look and a composer-scoped look agree.
+//
+// The distinction both tests below turn on: a collapsed paste marker in the
+// TRANSCRIPT is the ordinary on-screen trace of a multi-line send that
+// SUCCEEDED, and it stays there. A marker in the COMPOSER is payload that has
+// not been submitted. Only the second is evidence about the send in flight.
+
+// paneTranscriptMarkerEmptyComposer renders the pane AFTER a successful framed
+// multi-line send: the composer collapsed the payload to a marker, Enter was
+// accepted, and the marker now sits in the scrollback above an empty composer.
+func paneTranscriptMarkerEmptyComposer() string {
+	div := strings.Repeat("─", 25)
+	return "some prior output\n" +
+		"> [Pasted text #1 +2 lines]\n" +
+		"  working on it…\n" +
+		div + "\n❯ \n" + div + "\n"
+}
+
+// paneTranscriptMarkerPlusComposerMarker renders a SECOND framed multi-line
+// send to the same pane whose Enter was swallowed: the first send's marker is
+// still in the transcript, and the new payload sits collapsed and unsubmitted
+// in the composer.
+func paneTranscriptMarkerPlusComposerMarker() string {
+	div := strings.Repeat("─", 25)
+	return "some prior output\n" +
+		"> [Pasted text #1 +2 lines]\n" +
+		"  working on it…\n" +
+		div + "\n❯ [Pasted text #2 +2 lines]\n" + div + "\n"
+}
+
+// TestIssue1855_TranscriptMarkerWithEmptyComposerIsNotArrivalEvidence pins the
+// false FAILURE. The recipient was already busy at baseline (the common fleet
+// case — a worker mid-turn), which disables the status signal and leaves the
+// content signal as the whole delivery check. The send lands AND is submitted:
+// the composer collapses it, accepts Enter, and the marker ends up in the
+// transcript with the composer empty.
+//
+// Read whole-pane, that transcript marker is "a marker that was not there
+// before" and the send is reported as deliveryTyped with
+// "submission was never confirmed … Treat this as NOT delivered" — exit 1 for a
+// send that worked. A false "not delivered" is the input to the
+// double-delivery class (#876), so this is the more dangerous of the two
+// directions.
+//
+// The honest answer for a pane that shows neither the body nor an unsubmitted
+// composer is deliveryUnverified with no error: the historical best-effort
+// contract for a body whose lines are all below arrivalSafeLineBytes
+// (see TestIssue1793_SmallPayloadKeepsTheBestEffortContract).
+func TestIssue1855_TranscriptMarkerWithEmptyComposerIsNotArrivalEvidence(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		// Busy before the send and busy after it: no attributable transition,
+		// so the status signal proves nothing and is switched off.
+		statuses: []string{"active"},
+		// panes[0] is the pre-send baseline (clean, no marker anywhere);
+		// afterwards the payload has been submitted and its marker sits in
+		// the transcript above an EMPTY composer.
+		panes: []string{"❯ \n", paneTranscriptMarkerEmptyComposer()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, pasteCollapseMessage, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if delivery == deliveryTyped {
+		t.Fatal("issue #1855: a marker in the TRANSCRIPT above an empty composer is a submitted send, not unsent bytes; reporting it as typed fails a delivery that worked and invites a double send (#876)")
+	}
+	if err != nil {
+		t.Fatalf("small unmatched sends must stay best-effort, got error: %v", err)
+	}
+	if delivery != deliveryUnverified {
+		t.Fatalf("delivery: want %q, got %q", deliveryUnverified, delivery)
+	}
+}
+
+// TestIssue1855_SecondSendWithStaleTranscriptMarkerIsStillTyped pins the false
+// SUCCESS on the other side of the same defect. This is the SECOND multi-line
+// send to a pane: the first one's marker is permanently on screen in the
+// transcript, so a boolean baseline is armed before this send even starts and
+// "marker && !baseline.pasteMarker" can never fire again. This send's Enter is
+// swallowed and its payload sits collapsed in the composer — the #1793/#876
+// phantom, which round 2 closed only for the first multi-line send per pane.
+func TestIssue1855_SecondSendWithStaleTranscriptMarkerIsStillTyped(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		// Idle throughout: the agent never takes the message up.
+		statuses: []string{"waiting"},
+		// Baseline already carries the earlier send's transcript marker; the
+		// composer is empty. After the send the composer holds a NEW marker.
+		panes: []string{paneTranscriptMarkerEmptyComposer(), paneTranscriptMarkerPlusComposerMarker()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, pasteCollapseMessage, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if err == nil {
+		t.Fatal("issue #1855: the second multi-line send to a pane must still be verifiable — a marker left in the transcript by an earlier send must not disarm the signal")
+	}
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q, got %q", deliveryTyped, delivery)
+	}
+}
+
+// TestIssue1855_StaleMarkerCountsWhereNoComposerCanBeScoped is why the signal
+// is a COUNT and not merely composer-scoped. On a pane offering no
+// introspectable composer at all (codex, cursor, a plain shell) the scoping
+// falls back to the whole pane, where an earlier send's marker never goes
+// away. Comparing counts keeps the signal alive there; a boolean would be dead
+// from the first multi-line send onwards, exactly as in the test above.
+func TestIssue1855_StaleMarkerCountsWhereNoComposerCanBeScoped(t *testing.T) {
+	before := "session log\n[Pasted text #1 +2 lines]\nwork finished\n"
+	after := before + "[Pasted text #2 +2 lines]\n"
+
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{before, after},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, pasteCollapseMessage, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if err == nil {
+		t.Fatal("issue #1855: on a pane with no introspectable composer, one MORE paste marker than before is still this send's payload arriving")
+	}
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q, got %q", deliveryTyped, delivery)
+	}
+}

--- a/cmd/agent-deck/issue1855_arrival_paste_marker_test.go
+++ b/cmd/agent-deck/issue1855_arrival_paste_marker_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Round-2 regression tests for issue #1855: the arrival check must recognize
+// agent-deck's OWN bracketed-paste collapse as evidence that the body reached
+// the pane.
+//
+// The round-1 fix routed every multi-line body through `paste-buffer -p -r`.
+// The `-p` frame is what makes the body survive into a TUI composer — but it
+// also makes the composer render the payload as a "[Pasted text …]" marker
+// instead of the verbatim text, for the first time. verifyContentArrival is
+// the WHOLE delivery check for every non-Claude tool
+// (skipClaudeDeliveryVerify), and its only content signal was
+// "the message's distinctive token is visible in the pane". Against a
+// paste-collapsing composer that token can never appear, so a send whose Enter
+// was swallowed produced:
+//
+//	sawBody = false, riskyLine = false  ->  deliveryUnverified, nil  ->  exit 0
+//
+// i.e. `"success": true` for a message sitting unsent in the composer — the
+// exact phantom success issues #1793 and #876 were written to close, reopened
+// for the payload class the #1855 transport change retargets. Before the
+// transport change the same send left the (fused) body verbatim in the pane
+// and correctly reported deliveryTyped with a non-zero exit.
+//
+// The marker is measured as a TRANSITION from the pre-send baseline, exactly
+// like the body-occurrence signal it joins: a marker already parked in the
+// pane before the send says nothing about this send.
+
+// crlfFreeMultiLineMessage is a small multi-line body — the #1855 shape —
+// whose token cannot accidentally appear in any composer fixture below.
+const pasteCollapseMessage = "/superpowers:writing-skills\n" +
+	"Write a skill that writes cupcake flavors for seeded data instead of Lorem Ipsum."
+
+// composerHoldingPasteMarker renders a composer whose input line holds Claude's
+// (and codex's) collapsed-paste marker rather than the body: the on-screen
+// shape of a framed multi-line delivery whose Enter was swallowed.
+func composerHoldingPasteMarker() string {
+	div := strings.Repeat("─", 25)
+	return "some prior output\n" + div + "\n❯ [Pasted text #1 +2 lines]\n" + div + "\n"
+}
+
+// TestIssue1855_CollapsedPasteMarkerIsArrivalEvidence_NotAnUnverifiedSuccess is
+// the regression proper: a non-Claude tool, a multi-line body delivered as a
+// framed paste, the composer showing only the collapse marker, and an agent
+// that never goes active. The body token is unobservable by construction, so
+// without the marker signal this exits 0 claiming success.
+func TestIssue1855_CollapsedPasteMarkerIsArrivalEvidence_NotAnUnverifiedSuccess(t *testing.T) {
+	// panes[0] is the pre-send baseline (clean composer, no marker); every
+	// capture after the send shows our own collapsed paste.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"❯ \n", composerHoldingPasteMarker()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, pasteCollapseMessage, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if err == nil {
+		t.Fatal("issue #1855: a framed multi-line send whose collapse marker sits unsubmitted in the composer must not report success")
+	}
+	if delivery != deliveryTyped {
+		t.Fatalf("delivery: want %q, got %q", deliveryTyped, delivery)
+	}
+	if delivery == deliveryUnverified {
+		t.Fatal("issue #1855: deliveryUnverified here is the #1793 phantom success, reopened by the -p frame")
+	}
+	if fields := (sendDeliveryResult{delivery: delivery}).jsonFields(); fields["submitted"] != false {
+		t.Fatalf("typed must report submitted=false in --json, got %v", fields["submitted"])
+	}
+}
+
+// TestIssue1855_PreExistingPasteMarkerIsNotArrivalEvidence guards the signal
+// against the trap every other signal in this file already has to survive: a
+// marker that was ALREADY on screen before the send is a foreign paste (or the
+// scrollback of an earlier one), not proof that this send arrived. Only a
+// marker that was not there before counts.
+//
+// This body's lines are all below arrivalSafeLineBytes, so the historical
+// best-effort contract applies and the correct outcome is deliveryUnverified
+// with no error (see TestIssue1793_SmallPayloadKeepsTheBestEffortContract).
+// The assertion that matters is the one against deliveryTyped: reaching that
+// would mean the stale marker had been counted as this send's arrival.
+func TestIssue1855_PreExistingPasteMarkerIsNotArrivalEvidence(t *testing.T) {
+	// The marker is present in the baseline capture and never changes.
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{composerHoldingPasteMarker()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, pasteCollapseMessage, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if delivery == deliveryTyped {
+		t.Fatal("a paste marker that predates the send must not be counted as this send's arrival")
+	}
+	if err != nil {
+		t.Fatalf("small unmatched sends must stay best-effort, got error: %v", err)
+	}
+	if delivery != deliveryUnverified {
+		t.Fatalf("delivery: want %q, got %q", deliveryUnverified, delivery)
+	}
+}
+
+// TestIssue1855_PreExistingPasteMarkerOnALongLineIsStillAFailure is the same
+// trap at the size where "we could not tell" stops being an acceptable answer:
+// a line long enough to be eaten outright by a canonical reader, a marker that
+// was already parked in the composer, and nothing else changing. If the stale
+// marker were accepted as evidence this would report typed instead of the
+// honest no-evidence failure.
+func TestIssue1855_PreExistingPasteMarkerOnALongLineIsStillAFailure(t *testing.T) {
+	msg := bigMessage(4095)
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{composerHoldingPasteMarker()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+
+	if err == nil {
+		t.Fatal("a paste marker that predates the send must not certify a send that vanished")
+	}
+	if delivery != deliveryNoEvidence {
+		t.Fatalf("delivery: want %q, got %q", deliveryNoEvidence, delivery)
+	}
+}
+
+// TestIssue1855_CollapsedPasteMarkerDoesNotDowngradeARealSubmission: the marker
+// signal is arrival evidence only. An idle agent going active is still the
+// stronger signal and must still win, so a genuinely submitted framed paste is
+// not demoted to the typed-but-not-submitted failure above.
+func TestIssue1855_CollapsedPasteMarkerDoesNotDowngradeARealSubmission(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		// Idle before the send, working after it: a transition attributable
+		// to this delivery.
+		statuses: []string{"waiting", "active"},
+		panes:    []string{"❯ \n", composerHoldingPasteMarker()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, pasteCollapseMessage, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if delivery != deliverySubmitted {
+		t.Fatalf("delivery: want %q, got %q", deliverySubmitted, delivery)
+	}
+}

--- a/cmd/agent-deck/issue1855_launch_attribution_test.go
+++ b/cmd/agent-deck/issue1855_launch_attribution_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Round-2 regression tests for issue #1855 on the launch recovery path.
+//
+// verifyPromptConsumedAfterLaunch is the v1.7.64 safety net for the
+// welcome-screen race where claude eats the initial Enter of
+// `agent-deck launch -m "…" --no-wait`. It exists because the first-layer
+// budget on the launch path is only 8×150ms — far too short to observe that
+// race on a cold start with MCPs.
+//
+// The #1855 transport change frames every multi-line body as a bracketed
+// paste, so claude collapses the launch prompt behind a "[Pasted text …]"
+// marker as its NORMAL delivered form. The recovery pass built its #1777
+// attribution gate with no provenance:
+//
+//	attrib := send.EnterAttribution{Message: message}   // OwnPasteMarker false
+//
+// so the gate read agent-deck's own collapse as a foreign draft and withheld
+// the one retry this function exists to make — permanently, for the common
+// multi-line prompt shape. The caller had the provenance all along
+// (composerPasteFree, launch_cmd.go) and simply did not pass it.
+//
+// Second half of the fix: when the composer holds our own marker the body has
+// already arrived and only the Enter was lost, so the recovery must be a BARE
+// Enter. Retyping the message would append a second copy of the prompt behind
+// the marker and submit both.
+
+// paneMarkerComposer renders a composer whose input line holds claude's
+// collapsed-paste marker — the delivered-but-unsubmitted shape of a framed
+// multi-line launch prompt.
+func paneMarkerComposer() string {
+	div := strings.Repeat("─", 25)
+	return "welcome to claude\n" + div + "\n❯ [Pasted text #1 +3 lines]\n" + div + "\n"
+}
+
+// multiLineLaunchPrompt is the shape of every real `launch -m` prompt once the
+// completion-sentinel instruction is appended.
+const multiLineLaunchPrompt = "/superpowers:writing-skills\n" +
+	"Write a skill for seeded data.\n\n## Final step\nPrint the sentinel when done."
+
+// TestIssue1855_LaunchRecoveryNudgesItsOwnPasteMarker: with the pre-send
+// provenance passed through, our own collapse marker is attributable, so the
+// recovery fires — as a bare Enter, not a retype.
+func TestIssue1855_LaunchRecoveryNudgesItsOwnPasteMarker(t *testing.T) {
+	mock := &mockSendRetryTarget{panes: []string{paneMarkerComposer()}}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunchAttributed(
+		mock, multiLineLaunchPrompt, true,
+		5*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 1 {
+		t.Fatalf("issue #1855: an attributable paste marker must be recovered with exactly one bare Enter, got %d", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 0 {
+		t.Fatalf("issue #1855: the body already arrived behind the marker — retyping it would submit two copies of the prompt; got %d retypes", got)
+	}
+	if strings.Contains(warn.String(), "unattributable") {
+		t.Fatalf("our own paste marker must not be reported as unattributable content: %q", warn.String())
+	}
+}
+
+// TestIssue1855_LaunchRecoveryWithholdsForeignPasteMarker is the other
+// direction, and the reason the provenance is a parameter rather than an
+// assumption: with no pre-send evidence, a marker in the composer may be a
+// foreign paste, and #1777 requires the retry to be withheld rather than
+// submit text nobody authored.
+func TestIssue1855_LaunchRecoveryWithholdsForeignPasteMarker(t *testing.T) {
+	mock := &mockSendRetryTarget{panes: []string{paneMarkerComposer()}}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunchAttributed(
+		mock, multiLineLaunchPrompt, false,
+		5*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("#1777: an unattributable paste marker must never be nudged, got %d Enter presses", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 0 {
+		t.Fatalf("#1777: an unattributable composer must not be retyped into, got %d retypes", got)
+	}
+	if !strings.Contains(warn.String(), "unattributable") {
+		t.Fatalf("withholding the retry must be surfaced to the operator, got %q", warn.String())
+	}
+}
+
+// TestIssue1855_LaunchRecoveryStillRetypesAnUnsentPlainPrompt pins that the
+// bare-Enter branch is scoped to the marker case only: when the composer holds
+// the prompt as plain text (a single-line prompt, which still takes the
+// unframed send-keys path), the historical retype-and-submit recovery is
+// unchanged.
+func TestIssue1855_LaunchRecoveryStillRetypesAnUnsentPlainPrompt(t *testing.T) {
+	const prompt = "explain the transport fork in detail"
+	mock := &mockSendRetryTarget{panes: []string{paneUnsent(prompt)}}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunchAttributed(
+		mock, prompt, true,
+		5*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("a plainly-visible unsent prompt must still be recovered by one retype, got %d", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("the bare-Enter branch must be scoped to the paste-marker case, got %d bare Enters", got)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -653,21 +653,26 @@ func handleLaunch(profile string, args []string) {
 	if initialMessage != "" && *noWait {
 		tmuxSess := newInstance.GetTmuxSession()
 		if tmuxSess != nil {
+			// #1777 provenance probe: a freshly launched session has an
+			// empty composer, so a "[Pasted text …]" marker appearing
+			// during verification is this prompt's own collapse and the
+			// Enter nudge stays attributable. If the probe cannot confirm
+			// that, the gate withholds the nudge. Captured once, before the
+			// send, and shared with the v1.7.64 recovery pass below — a
+			// multi-line prompt collapses behind that marker as its normal
+			// delivered form (#1855), so the recovery retry needs the same
+			// provenance or its attribution gate withholds it forever.
+			pasteFreeBeforeSend := composerPasteFree(tmuxSess)
 			if _, err := sendWithRetryTarget(tmuxSess, initialMessage, skipClaudeDeliveryVerify(newInstance.Tool), sendRetryOptions{
-				maxRetries: 8,
-				checkDelay: 150 * time.Millisecond,
-				// #1777 provenance probe: a freshly launched session has an
-				// empty composer, so a "[Pasted text …]" marker appearing
-				// during verification is this prompt's own collapse and the
-				// Enter nudge stays attributable. If the probe cannot confirm
-				// that, the gate withholds the nudge.
-				composerPasteFreeBeforeSend: composerPasteFree(tmuxSess),
+				maxRetries:                  8,
+				checkDelay:                  150 * time.Millisecond,
+				composerPasteFreeBeforeSend: pasteFreeBeforeSend,
 			}); err != nil {
 				out.Error(fmt.Sprintf("failed to send initial message: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
 			}
-			verifyPromptConsumedAfterLaunch(
-				tmuxSess, initialMessage,
+			verifyPromptConsumedAfterLaunchAttributed(
+				tmuxSess, initialMessage, pasteFreeBeforeSend,
 				10*time.Second, 250*time.Millisecond,
 				os.Stderr,
 			)

--- a/cmd/agent-deck/launch_verify_prompt.go
+++ b/cmd/agent-deck/launch_verify_prompt.go
@@ -34,6 +34,29 @@ func verifyPromptConsumedAfterLaunch(
 	maxWait, pollInterval time.Duration,
 	warn io.Writer,
 ) {
+	verifyPromptConsumedAfterLaunchAttributed(target, message, false, maxWait, pollInterval, warn)
+}
+
+// verifyPromptConsumedAfterLaunchAttributed is verifyPromptConsumedAfterLaunch
+// with the #1777 provenance made explicit. ownPasteMarker carries the caller's
+// pre-send observation that the composer held no "[Pasted text …]" marker
+// (composerPasteFree, captured before the initial send): a marker seen now can
+// then only be the collapsed rendering of our own prompt.
+//
+// This matters because the transport frames every multi-line body as a
+// bracketed paste (issue #1855), so Claude collapsing the launch prompt behind
+// a paste marker is the NORMAL outcome for a multi-line `launch -m`, not a
+// rare foreign-paste event. Without the provenance, the attribution gate reads
+// our own marker as a foreign draft and permanently withholds the one recovery
+// retry this function exists to make — the v1.7.64 swallowed-Enter race would
+// leave every multi-line prompt sitting unsubmitted.
+func verifyPromptConsumedAfterLaunchAttributed(
+	target sendRetryTarget,
+	message string,
+	ownPasteMarker bool,
+	maxWait, pollInterval time.Duration,
+	warn io.Writer,
+) {
 	if pollPromptConsumed(target, message, maxWait, pollInterval) {
 		return
 	}
@@ -42,14 +65,23 @@ func verifyPromptConsumedAfterLaunch(
 	// attribute — a materialized autosuggestion, an operator draft — the
 	// retry would submit it with our prompt appended (#1777). Withhold it and
 	// let the warning below surface the unconsumed prompt instead.
-	attrib := send.EnterAttribution{Message: message}
-	if attrib.EnterWouldSubmitForeignDraft(send.CaptureOutcome(target.CapturePaneFresh()), tmux.StripANSI) {
+	attrib := send.EnterAttribution{Message: message, OwnPasteMarker: ownPasteMarker}
+	capture := send.CaptureOutcome(target.CapturePaneFresh())
+	if attrib.EnterWouldSubmitForeignDraft(capture, tmux.StripANSI) {
 		if warn != nil {
 			fmt.Fprintln(warn, "warning: launch prompt not consumed and the composer holds unattributable content; skipping the retry so nothing unauthored is submitted")
 		}
 		return
 	}
-	_ = target.SendKeysAndEnter(message)
+	if ownPasteMarker && capture.OK && send.ComposerHoldsPasteMarker(capture.Raw, tmux.StripANSI) {
+		// The composer holds our own collapsed paste marker: the body already
+		// arrived and only the Enter was lost. A bare Enter is the whole
+		// recovery — retyping the message would append a second copy of the
+		// prompt behind the marker and submit both.
+		_ = target.SendEnter()
+	} else {
+		_ = target.SendKeysAndEnter(message)
+	}
 	if pollPromptConsumed(target, message, maxWait, pollInterval) {
 		return
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3648,14 +3648,18 @@ type sendArrivalBaseline struct {
 	// off rather than defaulted to zero: a failed look would otherwise make
 	// a pre-existing copy of a repeated message read as a new arrival.
 	paneOK bool
-	// pasteMarker reports whether a "[Pasted text …]" collapse marker was
-	// already visible before the send. Only meaningful when paneOK is true —
-	// it comes from the same capture. Needed because the transport frames
-	// multi-line bodies as bracketed pastes (issue #1855), which a composer
-	// renders as that marker instead of the verbatim body: a marker that was
-	// NOT there before the send is this send's own payload arriving, and
-	// without the baseline a stale marker in scrollback would read as one.
-	pasteMarker bool
+	// pasteMarkers is how many "[Pasted text …]" collapse markers the
+	// composer already held before the send. Only meaningful when paneOK is
+	// true — it comes from the same capture. Needed because the transport
+	// frames multi-line bodies as bracketed pastes (issue #1855), which a
+	// composer renders as that marker instead of the verbatim body.
+	//
+	// A COUNT, exactly like occurrences above, and for the same reason: a
+	// submitted paste leaves its marker on screen permanently, so a boolean
+	// "a marker was already there" is armed forever after the first
+	// multi-line send to a pane and kills the signal for every later one.
+	// Only "one more than before" is attributable to THIS send.
+	pasteMarkers int
 	// wasActive reports whether the agent was already working before the
 	// send, in which case "it is active now" proves nothing.
 	wasActive bool
@@ -3670,8 +3674,8 @@ type sendArrivalBaseline struct {
 // baseline is disabled, never guessed.
 func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
 	base := sendArrivalBaseline{}
-	if n, marker, ok := paneArrivalObservation(target, message); ok {
-		base.occurrences, base.pasteMarker, base.paneOK = n, marker, true
+	if n, markers, ok := paneArrivalObservation(target, message); ok {
+		base.occurrences, base.pasteMarkers, base.paneOK = n, markers, true
 	}
 	if status, err := target.GetStatus(); err == nil {
 		base.wasActive, base.statusOK = status == "active", true
@@ -3757,20 +3761,29 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 			}
 		}
 		if baseline.paneOK {
-			if n, marker, ok := paneArrivalObservation(target, message); ok {
+			if n, markers, ok := paneArrivalObservation(target, message); ok {
 				if n > baseline.occurrences {
 					// Keep polling: the body is in, but the turn may still
 					// start within the budget and upgrade this to submitted.
 					sawBody = true
 				}
-				// A paste marker that was not there before the send is the
-				// collapsed rendering of this send's own framed body (issue
-				// #1855) — codex-style composers render agent-deck's
+				// A paste marker the COMPOSER did not hold before the send is
+				// the collapsed rendering of this send's own framed body
+				// (issue #1855) — codex-style composers render agent-deck's
 				// multi-line paste as "[Pasted text …]" too, so the verbatim
 				// token may never become visible. Same evidentiary strength
-				// as the body itself: bytes reached the composer, and
-				// nothing about the agent accepting them.
-				if marker && !baseline.pasteMarker {
+				// as the body itself: bytes reached the composer, and nothing
+				// about the agent accepting them.
+				//
+				// Measured as `markers > baseline.pasteMarkers`, the same
+				// delta idiom as the body count above and for the same
+				// reason. A boolean here would be wrong twice over: a
+				// submitted paste leaves its marker on screen, so the
+				// baseline arms permanently after the first multi-line send
+				// to the pane, and a marker sitting in the TRANSCRIPT (the
+				// shape of a send that SUCCEEDED) is not a composer holding
+				// unsent bytes.
+				if markers > baseline.pasteMarkers {
 					sawBody = true
 				}
 			}
@@ -3850,24 +3863,38 @@ func maxDeliverableLineBytes(target sendRetryTarget) int {
 
 // paneArrivalObservation reads the pane ONCE and reports both arrival signals
 // the check compares against its baseline: how many times the message's
-// distinctive token is visible, and whether a "[Pasted text …]" collapse
-// marker is visible. One capture serving both signals is deliberate — they
-// must describe the same instant, and the scripted-capture test fakes index
-// captures by call count. The final bool reports whether the pane was
-// actually read: a failed look is not "zero occurrences", it is no
+// distinctive token is visible in the pane, and how many "[Pasted text …]"
+// collapse markers the COMPOSER holds. One capture serving both signals is
+// deliberate — they must describe the same instant, and the scripted-capture
+// test fakes index captures by call count. The final bool reports whether the
+// pane was actually read: a failed look is not "zero occurrences", it is no
 // observation at all, and callers must not treat the two the same. A message
 // too short to yield a token reports false without reading the pane.
-func paneArrivalObservation(target sendRetryTarget, message string) (int, bool, bool) {
+//
+// The two signals are scoped differently on purpose. The body token is looked
+// for across the WHOLE pane, because a body that scrolled out of the composer
+// into the transcript still arrived. The marker is scoped to the COMPOSER
+// (send.ComposerPasteMarkerCount, the counting form of the helper the sibling
+// paths at launch_verify_prompt.go:76 and internal/ui/home.go:10308 already
+// use), because a marker in the TRANSCRIPT is the ordinary trace of a
+// SUCCESSFUL multi-line send: reading it as this send's unsent bytes turns a
+// delivered message into a "submission was never confirmed" failure, and a
+// false negative is the input to the double-delivery class (#876). Only a
+// composer holding one more marker than before is unsubmitted payload.
+//
+// Both counts are raw observations; the caller compares them to its baseline.
+func paneArrivalObservation(target sendRetryTarget, message string) (int, int, bool) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
-		return 0, false, false
+		return 0, 0, false
 	}
 	raw, err := target.CapturePaneFresh()
 	if err != nil {
-		return 0, false, false
+		return 0, 0, false
 	}
 	content := tmux.StripANSI(raw)
-	return strings.Count(collapseWhitespace(content), token), send.HasUnsentPastedPrompt(content), true
+	return strings.Count(collapseWhitespace(content), token),
+		send.ComposerPasteMarkerCount(raw, tmux.StripANSI), true
 }
 
 // collapseWhitespace removes every whitespace byte, so a comparison survives

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3648,6 +3648,14 @@ type sendArrivalBaseline struct {
 	// off rather than defaulted to zero: a failed look would otherwise make
 	// a pre-existing copy of a repeated message read as a new arrival.
 	paneOK bool
+	// pasteMarker reports whether a "[Pasted text …]" collapse marker was
+	// already visible before the send. Only meaningful when paneOK is true —
+	// it comes from the same capture. Needed because the transport frames
+	// multi-line bodies as bracketed pastes (issue #1855), which a composer
+	// renders as that marker instead of the verbatim body: a marker that was
+	// NOT there before the send is this send's own payload arriving, and
+	// without the baseline a stale marker in scrollback would read as one.
+	pasteMarker bool
 	// wasActive reports whether the agent was already working before the
 	// send, in which case "it is active now" proves nothing.
 	wasActive bool
@@ -3662,8 +3670,8 @@ type sendArrivalBaseline struct {
 // baseline is disabled, never guessed.
 func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
 	base := sendArrivalBaseline{}
-	if n, ok := countMessageInPane(target, message); ok {
-		base.occurrences, base.paneOK = n, true
+	if n, marker, ok := paneArrivalObservation(target, message); ok {
+		base.occurrences, base.pasteMarker, base.paneOK = n, marker, true
 	}
 	if status, err := target.GetStatus(); err == nil {
 		base.wasActive, base.statusOK = status == "active", true
@@ -3749,10 +3757,22 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 			}
 		}
 		if baseline.paneOK {
-			if n, ok := countMessageInPane(target, message); ok && n > baseline.occurrences {
-				// Keep polling: the body is in, but the turn may still start
-				// within the budget and upgrade this to submitted.
-				sawBody = true
+			if n, marker, ok := paneArrivalObservation(target, message); ok {
+				if n > baseline.occurrences {
+					// Keep polling: the body is in, but the turn may still
+					// start within the budget and upgrade this to submitted.
+					sawBody = true
+				}
+				// A paste marker that was not there before the send is the
+				// collapsed rendering of this send's own framed body (issue
+				// #1855) — codex-style composers render agent-deck's
+				// multi-line paste as "[Pasted text …]" too, so the verbatim
+				// token may never become visible. Same evidentiary strength
+				// as the body itself: bytes reached the composer, and
+				// nothing about the agent accepting them.
+				if marker && !baseline.pasteMarker {
+					sawBody = true
+				}
 			}
 		}
 		if i < checks-1 {
@@ -3828,20 +3848,26 @@ func maxDeliverableLineBytes(target sendRetryTarget) int {
 	return arrivalSafeLineBytes
 }
 
-// countMessageInPane reports how many times the message's distinctive token
-// appears in the pane right now. The bool reports whether the pane was
+// paneArrivalObservation reads the pane ONCE and reports both arrival signals
+// the check compares against its baseline: how many times the message's
+// distinctive token is visible, and whether a "[Pasted text …]" collapse
+// marker is visible. One capture serving both signals is deliberate — they
+// must describe the same instant, and the scripted-capture test fakes index
+// captures by call count. The final bool reports whether the pane was
 // actually read: a failed look is not "zero occurrences", it is no
-// observation at all, and callers must not treat the two the same.
-func countMessageInPane(target sendRetryTarget, message string) (int, bool) {
+// observation at all, and callers must not treat the two the same. A message
+// too short to yield a token reports false without reading the pane.
+func paneArrivalObservation(target sendRetryTarget, message string) (int, bool, bool) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
-		return 0, false
+		return 0, false, false
 	}
 	raw, err := target.CapturePaneFresh()
 	if err != nil {
-		return 0, false
+		return 0, false, false
 	}
-	return strings.Count(collapseWhitespace(tmux.StripANSI(raw)), token), true
+	content := tmux.StripANSI(raw)
+	return strings.Count(collapseWhitespace(content), token), send.HasUnsentPastedPrompt(content), true
 }
 
 // collapseWhitespace removes every whitespace byte, so a comparison survives

--- a/internal/send/attribution.go
+++ b/internal/send/attribution.go
@@ -141,12 +141,32 @@ func (a EnterAttribution) EnterWouldSubmitForeignDraft(c PaneCapture, strip func
 // composer to scope it to, yields no usable provenance and must not be
 // reported as clear.
 func ComposerHoldsPasteMarker(raw string, strip func(string) string) bool {
+	return ComposerPasteMarkerCount(raw, strip) > 0
+}
+
+// ComposerPasteMarkerCount is ComposerHoldsPasteMarker's count: how many
+// "[Pasted text …]" markers the VISIBLE COMPOSER holds, with the identical
+// scoping rule (and the identical whole-pane fallback when no composer can be
+// introspected at all, where the scrollback is the only thing there is to
+// look at).
+//
+// Both scopings matter to a caller measuring a delta across a send, and they
+// fix different halves of the same problem (issue #1855):
+//
+//   - COMPOSER scope separates "our paste collapsed in the composer, unsent"
+//     from "our paste collapsed in the transcript, submitted" — the latter
+//     being the normal shape of a SUCCESSFUL multi-line send, which a
+//     whole-pane look reports as unsubmitted text.
+//   - COUNTING keeps the signal alive on the panes where no composer can be
+//     scoped to and the fallback sees the whole pane, whose earlier markers
+//     never go away: one more than before is still this send's.
+func ComposerPasteMarkerCount(raw string, strip func(string) string) int {
 	strip = orIdentity(strip)
 	draft, visible := ComposerDraft(raw, strip)
 	if !visible {
-		return HasUnsentPastedPrompt(strip(raw))
+		return CountPasteMarkers(strip(raw))
 	}
-	return HasUnsentPastedPrompt(draft)
+	return CountPasteMarkers(draft)
 }
 
 func orIdentity(strip func(string) string) func(string) string {

--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -10,7 +10,22 @@ import (
 // HasUnsentPastedPrompt detects Claude's composer marker for a pasted-but-unsent prompt.
 // Example: "[Pasted text #1 +89 lines]".
 func HasUnsentPastedPrompt(content string) bool {
-	return strings.Contains(strings.ToLower(content), "[pasted text")
+	return CountPasteMarkers(content) > 0
+}
+
+// CountPasteMarkers reports HOW MANY "[Pasted text …]" markers content holds.
+// It is the same match HasUnsentPastedPrompt makes, kept as one implementation
+// so the boolean and the count can never drift apart.
+//
+// The count exists because presence alone is not a signal for a caller that
+// must attribute a marker to ONE send: a submitted paste leaves its collapsed
+// marker on screen for good, so "a marker is visible" is permanently true
+// after the first multi-line delivery to a pane, while "one more marker than
+// before" stays true of each subsequent send (issue #1855). Callers measuring
+// a delta must count; callers asking a yes/no question about the pane right
+// now (the #1777 attribution gate) must not.
+func CountPasteMarkers(content string) int {
+	return strings.Count(strings.ToLower(content), "[pasted text")
 }
 
 // firstNonEmptyLine returns the first physical line of s that is non-empty

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5365,10 +5365,14 @@ func (s *Session) SendNamedKey(key string) error {
 }
 
 // SendKeysAndEnter sends literal text followed by Enter as two separate tmux
-// calls with a short delay between them. The delay is necessary because tmux
-// 3.2+ wraps send-keys -l in bracketed paste sequences (\e[200~...\e[201~).
-// Without the delay, Enter arrives in the same PTY buffer as the paste-end
-// marker and gets swallowed by async TUI frameworks (Ink/Node.js, curses).
+// calls with a short delay between them. The delay gives async TUI frameworks
+// (Ink/Node.js, curses) time to finish processing the body — in particular a
+// bracketed-paste end marker (\e[201~), which `paste-buffer -p` emits for
+// multi-line and large payloads — before the Enter arrives in the PTY buffer;
+// without it the Enter lands in the same read as the paste-end marker and is
+// swallowed. (Measured on tmux 3.7b: `send-keys -l` is NOT wrapped in
+// bracketed paste, contrary to what this comment previously claimed — only
+// `paste-buffer -p` frames, and only when the pane app has enabled it.)
 func (s *Session) SendKeysAndEnter(keys string) error {
 	return s.sendKeysAndEnterToTarget(s.Name, keys)
 }
@@ -5418,23 +5422,38 @@ func (s *Session) sendKeysAndEnterToTarget(target, keys string) error {
 }
 
 // SendKeysChunked delivers content to the tmux session's active window.
-// Payloads at or below canonicalSafeBytes go out as a single `send-keys -l`,
-// exactly as before. Larger payloads take the paste transport (load-buffer
-// from stdin + paste-buffer) after the pane's line discipline has been
-// checked; see sendKeysChunkedToTarget and canonical_line.go.
+// Single-line payloads at or below canonicalSafeBytes go out as one
+// `send-keys -l`, exactly as before. Multi-line payloads of any size, and
+// larger single-line payloads, take the paste transport (load-buffer from
+// stdin + paste-buffer -p -r) — the only transport that preserves line
+// structure into a TUI composer; see sendKeysChunkedToTarget, pasteToTarget
+// and canonical_line.go.
 func (s *Session) SendKeysChunked(content string) error {
 	return s.sendKeysChunkedToTarget(s.Name, content)
 }
 
 // sendKeysChunkedToTarget is SendKeysChunked against an explicit tmux target.
 //
-// Three sizes of payload, three behaviors (issue #1793):
+// The transport fork (issues #1793 + #1855):
 //
-//   - ≤ canonicalSafeBytes: one `send-keys -l`. Guaranteed to fit any line
-//     discipline, so nothing is inspected and nothing costs extra. This is
-//     the overwhelming majority of sends and is byte-for-byte unchanged.
+//   - single-line, ≤ canonicalSafeBytes: one `send-keys -l`. Guaranteed to
+//     fit any line discipline, so nothing is inspected and nothing costs
+//     extra. This is the overwhelming majority of sends and is byte-for-byte
+//     unchanged.
 //
-//   - larger, pane readable and canonical: refuse with
+//   - multi-line, any size: the paste transport (issue #1855). A body with
+//     embedded LFs cannot go out as `send-keys -l`: the bytes arrive intact
+//     but UNFRAMED, and to a bracketed-paste TUI composer (Claude Code's
+//     Ink prompt) an unframed bare LF is a keystroke, not text — the
+//     composer drops it and the lines fuse. Only `paste-buffer -p -r`
+//     delivers both properties a multi-line body needs: literal LF (-r,
+//     without which tmux rewrites LF to CR, and CR is a submit key) and a
+//     bracketed-paste frame (-p) so the composer inserts the newlines as
+//     text. Short multi-line bodies skip the line-discipline probe below —
+//     every line of a ≤canonicalSafeBytes payload fits any canonical
+//     buffer, so there is nothing to refuse.
+//
+//   - single-line, larger, pane readable and canonical: refuse with
 //     *CanonicalOverflowError when the longest line does not fit the pane's
 //     canonical buffer. The kernel would discard the overflow AND the
 //     submitting Enter, so typing it would leave a half-line in the composer
@@ -5450,19 +5469,24 @@ func (s *Session) SendKeysChunked(content string) error {
 // to fall off the identical cliff (canonical_line.go). Only the refusal, and
 // the caller's post-send verification, make the outcome honest.
 func (s *Session) sendKeysChunkedToTarget(target, content string) error {
-	if len(content) <= canonicalSafeBytes {
+	if len(content) <= canonicalSafeBytes && !strings.Contains(content, "\n") {
 		return s.sendKeysToTarget(target, content)
 	}
 
 	// Above the always-safe size the pane itself decides. An unreadable
 	// discipline is "unknown", not "unsafe": deliver and let the caller
-	// verify rather than refusing a send that would have worked.
-	if ld, err := s.paneLineDiscipline(target); err == nil && ld.Canonical && ld.MaxLine > 0 {
-		if longest := longestLineBytes(content); longest > ld.MaxLine-1 {
-			return &CanonicalOverflowError{
-				LineBytes:  longest,
-				LimitBytes: ld.MaxLine,
-				TTY:        ld.TTY,
+	// verify rather than refusing a send that would have worked. Payloads at
+	// or below canonicalSafeBytes (multi-line ones reaching here for the
+	// paste framing) are safe per line by construction and are never probed
+	// nor refused.
+	if len(content) > canonicalSafeBytes {
+		if ld, err := s.paneLineDiscipline(target); err == nil && ld.Canonical && ld.MaxLine > 0 {
+			if longest := longestLineBytes(content); longest > ld.MaxLine-1 {
+				return &CanonicalOverflowError{
+					LineBytes:  longest,
+					LimitBytes: ld.MaxLine,
+					TTY:        ld.TTY,
+				}
 			}
 		}
 	}
@@ -5519,7 +5543,21 @@ func pasteBufferName() string {
 
 // pasteToTarget delivers content through tmux's paste path: `load-buffer -`
 // reads the body from this process's stdin (no argv size limit, no shell
-// quoting), then `paste-buffer -d` writes it to the pane and drops the buffer.
+// quoting), then `paste-buffer -p -r -d` writes it to the pane and drops the
+// buffer.
+//
+// The two paste flags are load-bearing for multi-line bodies (issue #1855),
+// measured on tmux 3.7b against a raw-mode pane with bracketed paste enabled:
+//
+//	-r  keeps embedded LFs as LF. Without it tmux rewrites every LF to CR,
+//	    and CR is a submit key — a multi-line message gets chopped into N
+//	    premature submissions.
+//	-p  frames the body in bracketed-paste markers (\e[200~…\e[201~) IF the
+//	    pane's application has requested bracketed paste. A TUI composer
+//	    only inserts an LF as text inside a paste frame; unframed it is a
+//	    keystroke and the lines fuse. Apps that never requested bracketed
+//	    paste (a cooked-mode shell) receive the bare body unchanged, so the
+//	    flag is safe for every consumer.
 func (s *Session) pasteToTarget(target, content string) error {
 	s.invalidateCache()
 
@@ -5536,7 +5574,7 @@ func (s *Session) pasteToTarget(target, content string) error {
 		return fmt.Errorf("load-buffer: %v: %w", err, errPasteNotStaged)
 	}
 
-	paste := keySenderExec(s.SocketName, "paste-buffer", "-d", "-b", buf, "-t", target)
+	paste := keySenderExec(s.SocketName, "paste-buffer", "-p", "-r", "-d", "-b", buf, "-t", target)
 	if err := runSendKeysBounded(paste); err != nil {
 		// -d never ran, so the staged buffer would linger. Drop it before
 		// falling back, otherwise the fallback's content and this stale copy

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5434,6 +5434,10 @@ func (s *Session) SendKeysChunked(content string) error {
 
 // sendKeysChunkedToTarget is SendKeysChunked against an explicit tmux target.
 //
+// CR handling: CRLF and bare-CR line breaks are normalized to LF before the
+// fork (see the comment in the body), so "multi-line" below means "contains
+// any line break", not "contains LF".
+//
 // The transport fork (issues #1793 + #1855):
 //
 //   - single-line, ≤ canonicalSafeBytes: one `send-keys -l`. Guaranteed to
@@ -5469,6 +5473,20 @@ func (s *Session) SendKeysChunked(content string) error {
 // to fall off the identical cliff (canonical_line.go). Only the refusal, and
 // the caller's post-send verification, make the outcome honest.
 func (s *Session) sendKeysChunkedToTarget(target, content string) error {
+	// A CR is a line break to everything downstream of this transport — the
+	// tty's ICRNL default turns an incoming CR into NL before the line
+	// discipline sees it (the same reason longestMessageLineBytes counts \r
+	// as a line terminator) — and to a bracketed-paste composer a CR inside
+	// the frame is a submit key. paste-buffer's -r flag only stops tmux's
+	// own LF→CR rewrite; it never removes CRs the payload already carries.
+	// So normalize here, before the transport fork: a CRLF body (a
+	// Windows-authored --message-file) and a bare-CR body both become LF
+	// line breaks, which routes them through the framed paste below and
+	// keeps the delivered frame CR-free.
+	if strings.Contains(content, "\r") {
+		content = strings.ReplaceAll(content, "\r\n", "\n")
+		content = strings.ReplaceAll(content, "\r", "\n")
+	}
 	if len(content) <= canonicalSafeBytes && !strings.Contains(content, "\n") {
 		return s.sendKeysToTarget(target, content)
 	}
@@ -5502,6 +5520,19 @@ func (s *Session) sendKeysChunkedToTarget(target, content string) error {
 	// concatenate it in the composer. An ambiguous transport failure is
 	// reported, never retried.
 	if errors.Is(err, errPasteNotStaged) {
+		// Degrading is deliberate — a tmux build whose paste path is down has
+		// no framing transport at all, and refusing would fail sends that a
+		// cooked-mode consumer would have taken fine. But the degradation must
+		// not be silent: for a multi-line body the fallback is the unframed
+		// `send-keys -l` transport issue #1855 is about, so the lines can fuse
+		// in a bracketed-paste composer exactly as originally reported. Log it
+		// so a recurrence of #1855 behind a green exit is attributable to this
+		// path instead of looking like the fix regressed.
+		statusLog.Warn("paste_transport_unavailable_degraded_to_send_keys",
+			slog.String("session", s.Name),
+			slog.Bool("multiline", strings.Contains(content, "\n")),
+			slog.Int("payload_bytes", len(content)),
+			slog.String("error", err.Error()))
 		return s.sendKeysChunkedFallback(target, content)
 	}
 	return err

--- a/internal/tmux/tmux_multiline_send_cr_test.go
+++ b/internal/tmux/tmux_multiline_send_cr_test.go
@@ -1,0 +1,96 @@
+// Round-2 regression tests for issue #1855: carriage returns are line breaks
+// too, and none of them may survive into the delivered byte stream.
+//
+// The round-1 fix defined "multi-line" as "contains LF" and leaned on
+// `paste-buffer -r`, which only stops tmux's own LF→CR rewrite — it never
+// removes CRs the payload already carries. That left two input classes broken:
+//
+//  1. a CRLF body (any Windows-authored --message-file) delivered literal \r
+//     bytes inside the bracketed-paste frame, and a CR is a submit key — the
+//     exact byte the round-1 tests declare fatal, just out of their fixtures'
+//     reach because those are LF-only; and
+//  2. a bare-CR body (no LF at all) failed the `strings.Contains(content,
+//     "\n")` gate entirely and went out as one UNFRAMED `send-keys -l`,
+//     leaving issue #1855 wholly unfixed for that input.
+//
+// The repo already defines \r as a line terminator — longestMessageLineBytes
+// (cmd/agent-deck/session_cmd.go) splits on both \n and \r because ICRNL (the
+// tty default) turns an incoming CR into NL before the line discipline sees
+// it. The transport now normalizes CRLF and bare CR to LF before its fork, so
+// both classes take the framed paste and the frame is CR-free.
+//
+// These tests reuse the round-1 harness (recordTransport / deliveredBytes /
+// assertMultiLineSurvived) and assert the delivered byte stream, not the
+// incantation.
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSendKeysAndEnter_CRLFMultiLine_NormalizedAndFramed: a small CRLF body —
+// the shape of every Windows-authored --message-file — must arrive framed,
+// LF-separated, with no CR anywhere in the stream.
+func TestSendKeysAndEnter_CRLFMultiLine_NormalizedAndFramed(t *testing.T) {
+	const crlfMessage = "/superpowers:writing-skills\r\n" +
+		"Write a skill that writes cupcake flavors and recipes for seeded data instead of Lorem Ipsum."
+	const normalized = "/superpowers:writing-skills\n" +
+		"Write a skill that writes cupcake flavors and recipes for seeded data instead of Lorem Ipsum."
+	if len(crlfMessage) > canonicalSafeBytes {
+		t.Fatalf("fixture no longer exercises the small-payload branch: %d bytes > %d",
+			len(crlfMessage), canonicalSafeBytes)
+	}
+
+	calls := recordTransport(t)
+	s := &Session{Name: "ml-crlf"}
+	if err := s.SendKeysAndEnter(crlfMessage); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	assertMultiLineSurvived(t, deliveredBytes(*calls), normalized)
+}
+
+// TestSendKeysAndEnter_BareCRMultiLine_TakesFramedPaste: a CR-delimited body
+// with no LF is still a multi-line message — pre-fix it slipped through the
+// LF-only gate and went out as one unframed send-keys -l.
+func TestSendKeysAndEnter_BareCRMultiLine_TakesFramedPaste(t *testing.T) {
+	const crMessage = "line one alpha\rline two bravo\rline three charlie"
+	const normalized = "line one alpha\nline two bravo\nline three charlie"
+	if len(crMessage) > canonicalSafeBytes || strings.Contains(crMessage, "\n") {
+		t.Fatal("fixture must be a small, LF-free, CR-delimited body")
+	}
+
+	calls := recordTransport(t)
+	s := &Session{Name: "ml-cr"}
+	if err := s.SendKeysAndEnter(crMessage); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	assertMultiLineSurvived(t, deliveredBytes(*calls), normalized)
+}
+
+// TestSendKeysAndEnter_LargeCRLFMultiLine_NormalizedAndFramed covers the same
+// normalization on the >canonicalSafeBytes branch, where the payload was
+// always going through paste-buffer and -r alone would have let the payload's
+// own CRs straight into the frame.
+func TestSendKeysAndEnter_LargeCRLFMultiLine_NormalizedAndFramed(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("/superpowers:writing-skills\r\n")
+	for b.Len() <= canonicalSafeBytes {
+		b.WriteString("Write a skill that writes cupcake flavors for seeded data.\r\n")
+	}
+	crlfMessage := strings.TrimRight(b.String(), "\r\n")
+	if len(crlfMessage) <= canonicalSafeBytes {
+		t.Fatalf("fixture does not exercise the large-payload branch: %d bytes", len(crlfMessage))
+	}
+	normalized := strings.ReplaceAll(crlfMessage, "\r\n", "\n")
+
+	calls := recordTransport(t)
+	s := &Session{Name: "ml-crlf-large"}
+	if err := s.SendKeysAndEnter(crlfMessage); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	assertMultiLineSurvived(t, deliveredBytes(*calls), normalized)
+}

--- a/internal/tmux/tmux_multiline_send_test.go
+++ b/internal/tmux/tmux_multiline_send_test.go
@@ -1,0 +1,257 @@
+// Regression tests for issue #1855: `session send --message-file` (and every
+// other multi-line send) delivers the body with its line structure destroyed.
+//
+// Reported symptom: a two-line prompt file
+//
+//	/superpowers:writing-skills
+//	Write a skill that writes cupcake flavors and recipes for seeded data instead of Lorem Ipsum.
+//
+// arrives in Claude Code's composer fused into one line, and the agent answers
+// `Unknown command: /superpowers:writing-skillsWrite`.
+//
+// The newlines are NOT lost in the CLI layer — resolveMessageInput preserves
+// interior LFs. They are lost in the tmux transport, and the exact mechanism
+// was measured against tmux 3.7b on macOS with a pane running
+// `sh -c 'stty raw -echo; printf "\033[?2004h"; cat -vet'`, i.e. a raw-mode app
+// that advertises bracketed paste exactly like Claude Code's Ink composer does,
+// and which prints `$` for LF, `^M` for CR and `^[` for ESC:
+//
+//	send-keys -l -- "a\nb"          -> a$ b$          (literal LF, NO paste frame)
+//	load-buffer + paste-buffer -d    -> a^Mb^M         (LF rewritten to CR)
+//	load-buffer + paste-buffer -p -d -> ^[[200~a^Mb^[[201~   (framed, still CR)
+//	load-buffer + paste-buffer -r -d -> a$ b$          (literal LF, NO paste frame)
+//	load-buffer + paste-buffer -p -r -d -> ^[[200~a$ b$^[[201~  (framed AND literal LF)
+//
+// So a multi-line body needs BOTH properties to survive into a TUI composer:
+//
+//  1. the LF bytes must reach the pane as LF, not CR — a CR is a submit key, so
+//     `paste-buffer -d` turns one message into N premature submissions; and
+//  2. the body must be framed as a bracketed paste — an unframed bare LF is a
+//     keystroke, not text, so the composer drops it (the reporter's fusion) or
+//     submits on it, rather than inserting a newline into the buffer.
+//
+// Today neither transport does both: payloads <= canonicalSafeBytes go out as a
+// bare `send-keys -l` (property 2 missing) and larger ones take
+// `paste-buffer -d` with neither `-p` nor `-r` (property 1 missing).
+//
+// These tests assert the delivered BYTE STREAM, not a particular tmux
+// incantation, so any transport that gets the bytes right passes.
+package tmux
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// tmuxCall is one recorded invocation of the keySenderExec seam: the argv after
+// the socket name, plus whatever the caller streamed in on stdin (load-buffer
+// reads the payload from stdin rather than argv).
+type tmuxCall struct {
+	argv  []string
+	stdin *bytes.Buffer
+}
+
+// recordTransport swaps keySenderExec for a recorder that captures the full
+// argv of every tmux invocation and, for `load-buffer`, the bytes streamed to
+// it. `load-buffer` is backed by a real `cat` so the payload the production
+// code writes to cmd.Stdin is copied into our buffer; everything else is backed
+// by `true`, which exits 0 without needing a tmux server.
+func recordTransport(t *testing.T) *[]*tmuxCall {
+	t.Helper()
+	original := keySenderExec
+	var mu sync.Mutex
+	var calls []*tmuxCall
+	keySenderExec = func(socketName string, args ...string) *exec.Cmd {
+		call := &tmuxCall{argv: append([]string(nil), args...), stdin: &bytes.Buffer{}}
+		mu.Lock()
+		calls = append(calls, call)
+		mu.Unlock()
+		if len(args) > 0 && args[0] == "load-buffer" {
+			// cat copies the staged payload from stdin (set by pasteToTarget
+			// after we return) into our buffer. cmd.Wait waits for that copy,
+			// so the buffer is complete once runSendKeysBounded returns.
+			cmd := exec.Command("cat")
+			cmd.Stdout = call.stdin
+			return cmd
+		}
+		return exec.Command("true")
+	}
+	t.Cleanup(func() { keySenderExec = original })
+	return &calls
+}
+
+func hasFlag(argv []string, flag string) bool {
+	for _, a := range argv {
+		if a == flag {
+			return true
+		}
+		if a == "--" {
+			return false
+		}
+	}
+	return false
+}
+
+// flagValue returns the argument following flag, e.g. flagValue(argv, "-b").
+func flagValue(argv []string, flag string) string {
+	for i, a := range argv {
+		if a == flag && i+1 < len(argv) {
+			return argv[i+1]
+		}
+	}
+	return ""
+}
+
+const (
+	pasteStart = "\x1b[200~"
+	pasteEnd   = "\x1b[201~"
+)
+
+// deliveredBytes replays the recorded tmux invocations through tmux's own
+// documented (and, in the header comment above, empirically measured) delivery
+// semantics and returns the byte stream the pane's application actually sees.
+//
+// This models tmux, not agent-deck: it is what lets the tests assert the
+// property that matters (the composer receives a framed, LF-preserving paste)
+// without pinning the fix to one particular tmux command.
+func deliveredBytes(calls []*tmuxCall) string {
+	buffers := map[string]string{}
+	var out strings.Builder
+	for _, c := range calls {
+		if len(c.argv) == 0 {
+			continue
+		}
+		switch c.argv[0] {
+		case "load-buffer":
+			buffers[flagValue(c.argv, "-b")] = c.stdin.String()
+		case "send-keys":
+			if !hasFlag(c.argv, "-l") {
+				// A named key (Escape, i, Enter) — not part of the body.
+				continue
+			}
+			// `send-keys -l ... -- <body>`: the body is emitted verbatim, with
+			// no bracketed-paste framing, even when the pane app has DECSET
+			// 2004 enabled.
+			out.WriteString(c.argv[len(c.argv)-1])
+		case "paste-buffer":
+			body := buffers[flagValue(c.argv, "-b")]
+			if !hasFlag(c.argv, "-r") {
+				// Without -r tmux replaces every LF with CR.
+				body = strings.ReplaceAll(body, "\n", "\r")
+			}
+			if hasFlag(c.argv, "-p") {
+				body = pasteStart + body + pasteEnd
+			}
+			out.WriteString(body)
+		}
+	}
+	return out.String()
+}
+
+// assertMultiLineSurvived is the shared assertion: the body reached the pane
+// with its LFs intact and framed as a bracketed paste.
+func assertMultiLineSurvived(t *testing.T, delivered, message string) {
+	t.Helper()
+
+	if strings.Contains(delivered, "\r") {
+		t.Errorf("multi-line body reached the pane with CR (\\r) in it — tmux rewrote the "+
+			"newlines, and a CR is a submit key, so the message is chopped into premature "+
+			"submissions.\ndelivered: %q", delivered)
+	}
+	if !strings.Contains(delivered, message) {
+		t.Errorf("multi-line body did not reach the pane intact.\n want (substring): %q\n got:             %q",
+			message, delivered)
+	}
+	if !strings.Contains(delivered, pasteStart) || !strings.Contains(delivered, pasteEnd) {
+		t.Errorf("multi-line body was NOT framed as a bracketed paste (missing ESC[200~ / ESC[201~). "+
+			"An unframed bare LF is a keystroke, not text: the composer drops it and the lines "+
+			"fuse (issue #1855).\ndelivered: %q", delivered)
+	}
+}
+
+// reporterMessage is the exact payload from issue #1855 — 132 bytes, i.e. well
+// under canonicalSafeBytes, so it takes the small-payload `send-keys -l` branch
+// that the reporter hit.
+const reporterMessage = "/superpowers:writing-skills\n" +
+	"Write a skill that writes cupcake flavors and recipes for seeded data instead of Lorem Ipsum."
+
+// TestSendKeysAndEnter_SmallMultiLine_PreservesLineStructure is the issue #1855
+// regression proper: the reporter's two-line prompt file, sent through the same
+// entry point `session send` uses.
+//
+// Pre-fix: the body goes out as one `send-keys -l`, so it reaches the pane as an
+// unframed bare LF → test FAILS on the missing bracketed-paste frame.
+func TestSendKeysAndEnter_SmallMultiLine_PreservesLineStructure(t *testing.T) {
+	if len(reporterMessage) > canonicalSafeBytes {
+		t.Fatalf("fixture no longer exercises the small-payload branch: %d bytes > %d",
+			len(reporterMessage), canonicalSafeBytes)
+	}
+
+	calls := recordTransport(t)
+	s := &Session{Name: "ml-small"}
+	if err := s.SendKeysAndEnter(reporterMessage); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	assertMultiLineSurvived(t, deliveredBytes(*calls), reporterMessage)
+}
+
+// TestSendKeysAndEnter_LargeMultiLine_PreservesLineStructure covers the other
+// half of the same defect: payloads above canonicalSafeBytes take the paste
+// transport, which runs `paste-buffer -d` with neither -p nor -r.
+//
+// Pre-fix: every LF is rewritten to CR → test FAILS on the CR check.
+func TestSendKeysAndEnter_LargeMultiLine_PreservesLineStructure(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("/superpowers:writing-skills\n")
+	for b.Len() <= canonicalSafeBytes {
+		b.WriteString("Write a skill that writes cupcake flavors for seeded data.\n")
+	}
+	message := strings.TrimRight(b.String(), "\n")
+	if len(message) <= canonicalSafeBytes {
+		t.Fatalf("fixture does not exercise the large-payload branch: %d bytes", len(message))
+	}
+
+	calls := recordTransport(t)
+	s := &Session{Name: "ml-large"}
+	if err := s.SendKeysAndEnter(message); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	assertMultiLineSurvived(t, deliveredBytes(*calls), message)
+}
+
+// TestSendKeysAndEnter_SingleLine_KeepsCheapSendKeysPath guards the fix against
+// overreach: single-line sends are the overwhelming majority, they have no line
+// structure to protect, and they must keep going out as one plain `send-keys -l`
+// rather than paying for a buffer round-trip.
+//
+// This test PASSES before the fix and must still pass after it.
+func TestSendKeysAndEnter_SingleLine_KeepsCheapSendKeysPath(t *testing.T) {
+	const message = "just one line, nothing to preserve"
+
+	calls := recordTransport(t)
+	s := &Session{Name: "ml-single"}
+	if err := s.SendKeysAndEnter(message); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	var bodyCalls int
+	for _, c := range *calls {
+		if len(c.argv) > 0 && c.argv[0] == "load-buffer" {
+			t.Errorf("single-line send used the paste transport: %v", c.argv)
+		}
+		if len(c.argv) > 0 && c.argv[0] == "send-keys" && hasFlag(c.argv, "-l") {
+			bodyCalls++
+			if got := c.argv[len(c.argv)-1]; got != message {
+				t.Errorf("single-line body altered: got %q, want %q", got, message)
+			}
+		}
+	}
+	if bodyCalls != 1 {
+		t.Errorf("single-line send emitted %d literal send-keys calls, want exactly 1", bodyCalls)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10313,7 +10313,11 @@ func conductorComposerGuardOptions() send.ComposerGuardOptions {
 // to prevent; the saved draft is logged instead.
 func deliverToConductorPaneGuarded(p guardableConductorPane, msg string, guardOpts send.ComposerGuardOptions, maxChecks int, checkDelay time.Duration) error {
 	guard := send.GuardComposerDraft(p, guardOpts)
-	err := deliverToConductorPaneTuned(p, msg, maxChecks, checkDelay)
+	// guard.ComposerPasteMarkerFree is the #1777 provenance the verify loop
+	// needs: the guard's pre-send capture saw a composer with no
+	// "[Pasted text …]" marker, so a marker seen during verification is the
+	// collapsed rendering of OUR framed multi-line payload (issue #1855).
+	err := deliverToConductorPaneAttributed(p, msg, guard.ComposerPasteMarkerFree, maxChecks, checkDelay)
 	if guard.SavedDraft != "" {
 		if err == nil {
 			// Delivery confirmed: type the operator draft back. If the
@@ -10356,12 +10360,26 @@ type guardableConductorPane interface {
 // has since gone idle) is not spammed with empty submissions.
 const blindEnterCap = 3
 
-// deliverToConductorPaneTuned is deliverToConductorPane with the verify budget
-// exposed for tests; production callers use the default budget (~10s).
+// deliverToConductorPaneTuned is deliverToConductorPaneAttributed without
+// pre-send provenance: a paste marker in the composer counts as foreign —
+// never nudged, never read as submitted. Kept for callers with no guard
+// capture to attribute against.
 func deliverToConductorPaneTuned(p conductorPane, msg string, maxChecks int, checkDelay time.Duration) error {
+	return deliverToConductorPaneAttributed(p, msg, false, maxChecks, checkDelay)
+}
+
+// deliverToConductorPaneAttributed is deliverToConductorPane with the verify
+// budget exposed for tests and the #1777 paste-marker provenance explicit;
+// production callers use the default budget (~10s). ownPasteMarker carries
+// the caller's pre-send observation that the composer held no "[Pasted text …]"
+// marker, which is what makes a marker seen during verification attributable
+// to this delivery's own bracketed-paste collapse (issue #1855) rather than
+// to a foreign paste parked in the composer.
+func deliverToConductorPaneAttributed(p conductorPane, msg string, ownPasteMarker bool, maxChecks int, checkDelay time.Duration) error {
 	if err := p.SendKeysAndEnter(msg); err != nil {
 		return err
 	}
+	attrib := send.EnterAttribution{Message: msg, OwnPasteMarker: ownPasteMarker}
 	sawUnsent := false
 	blindEnters := 0
 	for i := 0; i < maxChecks; i++ {
@@ -10390,6 +10408,21 @@ func deliverToConductorPaneTuned(p conductorPane, msg string, maxChecks int, che
 			sawUnsent = true
 			if err := p.SendEnter(); err != nil {
 				return fmt.Errorf("retry enter: %w", err)
+			}
+		case send.ComposerHoldsPasteMarker(raw, tmux.StripANSI):
+			// The composer holds a "[Pasted text …]" marker instead of the
+			// message body. Since the transport frames every multi-line
+			// payload as a bracketed paste (issue #1855), this is the NORMAL
+			// delivered-but-unsubmitted shape of our own send — but only
+			// provenance can say so, because the marker hides the content.
+			// NudgeEnter presses Enter only when the collapse is attributable
+			// (ownPasteMarker, or a pane with no composer introspection);
+			// otherwise it withholds, this case confirms nothing, and the
+			// loop times out honestly instead of the old behavior of falling
+			// through to "a composer is rendered without our message" and
+			// reporting an unsent message as submitted.
+			if attrib.NudgeEnter(p, send.Captured(raw), tmux.StripANSI) {
+				sawUnsent = true
 			}
 		case sawUnsent || send.HasCurrentComposerPrompt(content):
 			// The composer previously held the message and is now clear, or a

--- a/internal/ui/issue1855_conductor_paste_marker_test.go
+++ b/internal/ui/issue1855_conductor_paste_marker_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"testing"
+)
+
+// Round-2 regression tests for issue #1855 on the conductor/watcher dispatch
+// path.
+//
+// deliverToConductorPaneTuned was the only one of agent-deck's four post-send
+// verify loops with no "[Pasted text …]" arm — compare sendWithRetryTarget
+// (session_cmd.go) and Instance.sendMessageWhenReady (instance.go), which both
+// check send.HasUnsentPastedPrompt. Its switch read:
+//
+//	case send.HasUnsentComposerPrompt(content, msg):        // marker != msg -> false
+//	case sawUnsent || send.HasCurrentComposerPrompt(content):
+//	    return nil                                          // "submitted"
+//
+// so a composer holding agent-deck's OWN collapse marker matched the second
+// arm — "a composer is rendered without our message" — and the function
+// returned success on the FIRST check, with zero recovery Enters, for a
+// message still sitting unsent.
+//
+// The #1855 transport change is what put our own marker into that composer:
+// `paste-buffer -p` frames every multi-line body, and every payload above
+// canonicalSafeBytes, which is well within reach of both callers here (the
+// #1410 prompt dialog accepts 2000 bytes; formatWatcherDispatchMsg inlines a
+// full watcher event Body).
+
+// markerComposer renders a composer whose input line holds the collapsed-paste
+// marker instead of the body.
+func markerComposer() string {
+	return composerWith("[Pasted text #1 +4 lines]")
+}
+
+// conductorDispatchMessage is a multi-line body of the shape the transport now
+// frames.
+const conductorDispatchMessage = "[slack] alice: please re-check the delivery path\nand report back with the transcript"
+
+// TestIssue1855_ConductorDispatch_OwnPasteMarkerIsNotSubmitted is the
+// regression proper: an unattributable paste marker in the composer must never
+// be reported as delivered. Before the fix this returned nil immediately.
+func TestIssue1855_ConductorDispatch_OwnPasteMarkerIsNotSubmitted(t *testing.T) {
+	// No status ever goes active and the marker never clears.
+	p := &fakeConductorPane{captures: []string{markerComposer()}}
+
+	err := deliverToConductorPaneTuned(p, conductorDispatchMessage, 5, 0)
+
+	if err == nil {
+		t.Fatal("issue #1855: a composer holding an unattributable paste marker must not be reported as submitted")
+	}
+	if p.enterCalls != 0 {
+		t.Fatalf("#1777: an unattributable marker must not be nudged, got %d Enter presses", p.enterCalls)
+	}
+}
+
+// TestIssue1855_ConductorDispatch_AttributedPasteMarkerIsRecovered: with the
+// guard's pre-send provenance, the collapse is ours, so the loop nudges Enter
+// and confirms submission once the composer clears — the recovery the missing
+// arm was silently skipping.
+func TestIssue1855_ConductorDispatch_AttributedPasteMarkerIsRecovered(t *testing.T) {
+	p := &fakeConductorPane{captures: []string{
+		markerComposer(), // our collapsed body, Enter swallowed -> nudge
+		markerComposer(), // still unsent -> nudge again
+		emptyComposer(),  // accepted
+	}}
+
+	err := deliverToConductorPaneAttributed(p, conductorDispatchMessage, true, 40, 0)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.enterCalls != 2 {
+		t.Fatalf("recovery Enter presses: want 2, got %d", p.enterCalls)
+	}
+}
+
+// TestIssue1855_ConductorDispatch_AttributedMarkerNeverClearing_StillFails:
+// attribution buys a recovery attempt, not a success. If the marker never
+// leaves the composer the drop is still reported, so the caller logs it.
+func TestIssue1855_ConductorDispatch_AttributedMarkerNeverClearing_StillFails(t *testing.T) {
+	p := &fakeConductorPane{captures: []string{markerComposer()}}
+
+	err := deliverToConductorPaneAttributed(p, conductorDispatchMessage, true, 5, 0)
+
+	if err == nil {
+		t.Fatal("a message whose marker never leaves the composer must be reported as not confirmed")
+	}
+	if p.enterCalls != 5 {
+		t.Fatalf("want one recovery Enter per check (5), got %d", p.enterCalls)
+	}
+}
+
+// TestIssue1855_ConductorDispatch_PlainComposerBehaviorUnchanged guards the
+// new arm against overreach: a composer with no paste marker must behave
+// exactly as before — the ordinary "rendered composer, not our message"
+// reading still means submitted.
+func TestIssue1855_ConductorDispatch_PlainComposerBehaviorUnchanged(t *testing.T) {
+	p := &fakeConductorPane{captures: []string{emptyComposer()}}
+
+	if err := deliverToConductorPaneAttributed(p, conductorDispatchMessage, true, 40, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.enterCalls != 0 {
+		t.Fatalf("no retry Enter expected when the composer is clear, got %d", p.enterCalls)
+	}
+}


### PR DESCRIPTION
Preserves line boundaries when sending multiline messages and verifies delivery using scoped paste-marker evidence.

Fixes #1855