### PR TITLE
fix(ui): reorder remote sessions with shift+up/down

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           check-latest: false
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -13785,6 +13785,17 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	}
 	h.remoteSessionsMu.RUnlock()
 
+	// A bucket whose IDs are not unique cannot be reordered at all:
+	// orderRemoteBucket refuses to permute it, because the slot mapping is no
+	// longer 1:1 and a row could be dropped or doubled. Storing an order for it
+	// would change nothing on screen — a no-op dressed as success, which is the
+	// bug this issue is about. It also makes the row itself ambiguous: two rows
+	// answering to the same ID cannot be told apart. Report it instead.
+	if dup, ok := firstDuplicateID(natural); ok {
+		h.setError(fmt.Errorf("cannot move '%s' %s: %s lists more than one session with id %q in this group, so their order cannot be tracked", moved.Title, direction, item.RemoteName, dup))
+		return
+	}
+
 	// Start from what is actually on screen — the fetched list with the
 	// current overlay already applied — so a move is always relative to what
 	// the user sees, whatever has drifted since the overlay was written.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -377,6 +377,13 @@ type Home struct {
 	// store rather than groupTree's expanded flags.
 	remoteGroupsCollapsed map[string]bool
 
+	// Manual order of remote session rows (#1875), keyed by
+	// remoteOrderKey(remote, groupPath) -> session IDs. Remote rows are not
+	// Instances in groupTree, so shift+up/down cannot move them there; this
+	// local overlay carries the order instead and is persisted in ui_state
+	// (see applyRemoteSessionOrder for the drift rules).
+	remoteSessionOrder map[string][]string
+
 	// Worktree dirty status cache (lazy, 10s TTL)
 	worktreeDirtyCache   map[string]bool      // sessionID -> isDirty
 	worktreeDirtyCacheTs map[string]time.Time // sessionID -> cache timestamp
@@ -732,6 +739,12 @@ type uiState struct {
 	// groupTree, which is persisted separately by saveGroupState; remote groups
 	// are synthetic UI rows and have no home there.
 	RemoteGroupsCollapsed []string `json:"remote_groups_collapsed,omitempty"`
+
+	// RemoteSessionOrder is the manual order of remote session rows (#1875),
+	// keyed by remoteOrderKey(remote, groupPath). It rides in ui_state
+	// because it is a view preference of this machine, exactly like the
+	// preview mode and status filter above.
+	RemoteSessionOrder map[string][]string `json:"remote_session_order,omitempty"`
 }
 
 type selectedItemIdentity struct {
@@ -1441,6 +1454,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		lastLogActivity:           make(map[string]time.Time),
 		windowsCollapsed:          make(map[string]bool),
 		remoteGroupsCollapsed:     make(map[string]bool),
+		remoteSessionOrder:        make(map[string][]string),
 		worktreeDirtyCache:        make(map[string]bool),
 		worktreeDirtyCacheTs:      make(map[string]time.Time),
 		statusTrigger:             make(chan statusUpdateRequest, 1), // Buffered to avoid blocking
@@ -2570,7 +2584,8 @@ func (h *Home) rebuildFlatItems() {
 		for _, remoteName := range remoteNames {
 			// #1553: nest each remote's sessions under their Group paths
 			// instead of dumping them flat at Level 1.
-			h.flatItems = append(h.flatItems, buildRemoteFlatItems(remoteName, remotes[remoteName], h.remoteGroupsCollapsed)...)
+			// #1875: apply the user's manual row order for this remote.
+			h.flatItems = append(h.flatItems, buildRemoteFlatItemsOrdered(remoteName, remotes[remoteName], h.remoteGroupsCollapsed, h.remoteSessionOrder)...)
 		}
 	}
 
@@ -8695,6 +8710,13 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			switch item.Type {
+			case session.ItemTypeRemoteSession, session.ItemTypeRemoteGroup:
+				// #1875: remote rows are not Instances in groupTree, so they
+				// carry a local order overlay instead. Returning here also
+				// skips the forceSaveInstances below, which has nothing to do
+				// with a remote reorder.
+				h.moveRemoteItem(item, -1)
+				return h, nil
 			case session.ItemTypeGroup:
 				h.groupTree.MoveGroupUp(item.Path)
 				h.rebuildFlatItems()
@@ -8728,6 +8750,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			switch item.Type {
+			case session.ItemTypeRemoteSession, session.ItemTypeRemoteGroup:
+				// #1875 — see the shift+up twin above.
+				h.moveRemoteItem(item, 1)
+				return h, nil
 			case session.ItemTypeGroup:
 				h.groupTree.MoveGroupDown(item.Path)
 				h.rebuildFlatItems()
@@ -11394,9 +11420,10 @@ func (h *Home) saveUIState() {
 	}
 
 	state := uiState{
-		PreviewMode:   int(h.previewMode),
-		StatusFilter:  string(h.statusFilter),
-		GroupViewMode: int(h.groupViewMode),
+		PreviewMode:        int(h.previewMode),
+		StatusFilter:       string(h.statusFilter),
+		GroupViewMode:      int(h.groupViewMode),
+		RemoteSessionOrder: h.remoteSessionOrder,
 	}
 
 	// Sorted so an unchanged fold state marshals byte-identically and doesn't
@@ -11475,6 +11502,16 @@ func (h *Home) loadUIState() {
 	h.groupViewMode = session.GroupViewMode(state.GroupViewMode)
 	if h.groupViewMode < session.GroupViewNormal || h.groupViewMode >= session.GroupViewModeCount {
 		h.groupViewMode = session.GroupViewNormal
+	}
+
+	// #1875: restore the manual remote row order. Entries for remotes that no
+	// longer exist are harmless — a bucket key nobody builds is never read —
+	// and stale session IDs inside a live bucket are skipped when applied.
+	h.remoteSessionOrder = make(map[string][]string, len(state.RemoteSessionOrder))
+	for key, ids := range state.RemoteSessionOrder {
+		if len(ids) > 0 {
+			h.remoteSessionOrder[key] = ids
+		}
 	}
 
 	// Defer cursor restoration until flatItems are populated
@@ -13675,6 +13712,95 @@ func (a attachWindowCmd) Run() error {
 func (a attachWindowCmd) SetStdin(r io.Reader)  {}
 func (a attachWindowCmd) SetStdout(w io.Writer) {}
 func (a attachWindowCmd) SetStderr(w io.Writer) {}
+
+// moveRemoteItem handles shift+up/down (and the +/-/K/J aliases) on a remote
+// row (#1875). delta is -1 for up and +1 for down.
+//
+// The move rewrites this bucket's entry in the local order overlay and saves
+// it; nothing is sent to the remote. Every path through here either changes
+// the order or reports why it could not, because a silent no-op is the bug
+// being fixed — a remote row that swallows the keystroke is indistinguishable
+// from a stuck key.
+//
+// Remote GROUP headers deliberately do not reorder. buildRemoteFlatItems emits
+// them by walking the bucket paths in lexicographic order, which is what makes
+// a parent header land immediately before its descendants and lets the
+// intermediate headers of "a/b/c" be synthesized on the fly; a manual group
+// order would have to replace that walk with a real tree. Remote groups also
+// have no identity of their own — they exist only as the Group strings of the
+// sessions inside them, so a group with no sessions cannot even be addressed.
+// The header therefore says so instead of going quiet.
+func (h *Home) moveRemoteItem(item session.Item, delta int) {
+	direction := "up"
+	edge := "first"
+	if delta > 0 {
+		direction = "down"
+		edge = "last"
+	}
+
+	if item.Type == session.ItemTypeRemoteGroup {
+		h.setError(fmt.Errorf("cannot move %s: remote group rows are ordered by name — reorder the sessions inside instead", direction))
+		return
+	}
+	if item.RemoteSession == nil || item.RemoteName == "" {
+		h.setError(fmt.Errorf("cannot move %s: this remote session row is malformed", direction))
+		return
+	}
+	moved := item.RemoteSession
+	if moved.ID == "" {
+		h.setError(fmt.Errorf("cannot move '%s' %s: %s did not report an id for it", moved.Title, direction, item.RemoteName))
+		return
+	}
+
+	// The bucket is the one buildRemoteFlatItems put this row in: same remote,
+	// same normalized group path.
+	groupPath := normalizeRemoteGroupPath(moved.Group)
+	key := remoteOrderKey(item.RemoteName, groupPath)
+
+	h.remoteSessionsMu.RLock()
+	fetched := h.remoteSessions[item.RemoteName]
+	natural := make([]string, 0, len(fetched))
+	for i := range fetched {
+		if normalizeRemoteGroupPath(fetched[i].Group) == groupPath {
+			natural = append(natural, fetched[i].ID)
+		}
+	}
+	h.remoteSessionsMu.RUnlock()
+
+	// Start from what is actually on screen — the fetched list with the
+	// current overlay already applied — so a move is always relative to what
+	// the user sees, whatever has drifted since the overlay was written.
+	current := applyRemoteSessionOrder(natural, h.remoteSessionOrder[key])
+	pos := -1
+	for i, id := range current {
+		if id == moved.ID {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		h.setError(fmt.Errorf("cannot move '%s' %s: it is no longer listed on %s", moved.Title, direction, item.RemoteName))
+		return
+	}
+
+	target := pos + delta
+	if target < 0 || target >= len(current) {
+		h.setError(fmt.Errorf("'%s' is already %s in its group on %s", moved.Title, edge, item.RemoteName))
+		return
+	}
+	current[pos], current[target] = current[target], current[pos]
+
+	// current lists exactly the sessions present in this bucket right now, so
+	// storing it whole keeps the overlay complete and the next move stable.
+	if h.remoteSessionOrder == nil {
+		h.remoteSessionOrder = make(map[string][]string)
+	}
+	h.remoteSessionOrder[key] = current
+
+	h.clearError()
+	h.rebuildFlatItemsPreservingSelection(h.captureSelectedItemIdentity())
+	h.saveUIState()
+}
 
 // attachRemoteSession attaches to a remote session via SSH, suspending the TUI.
 func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -377,12 +377,12 @@ type Home struct {
 	// store rather than groupTree's expanded flags.
 	remoteGroupsCollapsed map[string]bool
 
-	// Manual order of remote session rows (#1875), keyed by
-	// remoteOrderKey(remote, groupPath) -> session IDs. Remote rows are not
-	// Instances in groupTree, so shift+up/down cannot move them there; this
-	// local overlay carries the order instead and is persisted in ui_state
-	// (see applyRemoteSessionOrder for the drift rules).
-	remoteSessionOrder map[string][]string
+	// Manual order of remote session rows (#1875): remote -> group path ->
+	// session IDs. Remote rows are not Instances in groupTree, so shift+up/down
+	// cannot move them there; this local overlay carries the order instead and
+	// is persisted in ui_state (see applyRemoteSessionOrder for the drift
+	// rules and remoteOrder for why the scoping is nested).
+	remoteSessionOrder remoteOrder
 
 	// Worktree dirty status cache (lazy, 10s TTL)
 	worktreeDirtyCache   map[string]bool      // sessionID -> isDirty
@@ -740,11 +740,12 @@ type uiState struct {
 	// are synthetic UI rows and have no home there.
 	RemoteGroupsCollapsed []string `json:"remote_groups_collapsed,omitempty"`
 
-	// RemoteSessionOrder is the manual order of remote session rows (#1875),
-	// keyed by remoteOrderKey(remote, groupPath). It rides in ui_state
-	// because it is a view preference of this machine, exactly like the
-	// preview mode and status filter above.
-	RemoteSessionOrder map[string][]string `json:"remote_session_order,omitempty"`
+	// RemoteSessionOrder is the manual order of remote session rows (#1875):
+	// remote -> group path -> session IDs. It rides in ui_state because it is
+	// a view preference of this machine, exactly like the preview mode and
+	// status filter above. Nested rather than flat-keyed so a remote name or
+	// group path containing "/" cannot alias another bucket (see remoteOrder).
+	RemoteSessionOrder map[string]map[string][]string `json:"remote_session_order,omitempty"`
 }
 
 type selectedItemIdentity struct {
@@ -1454,7 +1455,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		lastLogActivity:           make(map[string]time.Time),
 		windowsCollapsed:          make(map[string]bool),
 		remoteGroupsCollapsed:     make(map[string]bool),
-		remoteSessionOrder:        make(map[string][]string),
+		remoteSessionOrder:        make(remoteOrder),
 		worktreeDirtyCache:        make(map[string]bool),
 		worktreeDirtyCacheTs:      make(map[string]time.Time),
 		statusTrigger:             make(chan statusUpdateRequest, 1), // Buffered to avoid blocking
@@ -2585,7 +2586,7 @@ func (h *Home) rebuildFlatItems() {
 			// #1553: nest each remote's sessions under their Group paths
 			// instead of dumping them flat at Level 1.
 			// #1875: apply the user's manual row order for this remote.
-			h.flatItems = append(h.flatItems, buildRemoteFlatItemsOrdered(remoteName, remotes[remoteName], h.remoteGroupsCollapsed, h.remoteSessionOrder)...)
+			h.flatItems = append(h.flatItems, buildRemoteFlatItemsOrdered(remoteName, remotes[remoteName], h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName))...)
 		}
 	}
 
@@ -11410,13 +11411,27 @@ func (h *Home) saveGroupState() {
 }
 
 // saveUIState persists cursor position, preview mode, and status filter to SQLite metadata.
+// Failures are logged only; use saveUIStateErr when the caller has to tell the
+// user that their action did not stick.
 func (h *Home) saveUIState() {
+	_ = h.saveUIStateErr()
+}
+
+// saveUIStateErr is saveUIState with the write outcome returned.
+//
+// The periodic and incidental callers do not care — a dropped autosave is
+// recoverable on the next tick. An explicit user action does care: #1875 exists
+// because a remote row silently swallowed a keystroke, and "the rows moved but
+// the order was never written" is the same lie one layer down. A nil storage or
+// DB is not a failure: that is the headless/no-persistence configuration, not a
+// write that went wrong.
+func (h *Home) saveUIStateErr() error {
 	if h.storage == nil {
-		return
+		return nil
 	}
 	db := h.storage.GetDB()
 	if db == nil {
-		return
+		return nil
 	}
 
 	state := uiState{
@@ -11457,11 +11472,13 @@ func (h *Home) saveUIState() {
 	data, err := json.Marshal(state)
 	if err != nil {
 		uiLog.Warn("save_ui_state_marshal_failed", slog.String("error", err.Error()))
-		return
+		return err
 	}
 	if err := db.SetMeta("ui_state", string(data)); err != nil {
 		uiLog.Warn("save_ui_state_failed", slog.String("error", err.Error()))
+		return err
 	}
+	return nil
 }
 
 // loadUIState reads persisted UI state from SQLite metadata.
@@ -11507,10 +11524,12 @@ func (h *Home) loadUIState() {
 	// #1875: restore the manual remote row order. Entries for remotes that no
 	// longer exist are harmless — a bucket key nobody builds is never read —
 	// and stale session IDs inside a live bucket are skipped when applied.
-	h.remoteSessionOrder = make(map[string][]string, len(state.RemoteSessionOrder))
-	for key, ids := range state.RemoteSessionOrder {
-		if len(ids) > 0 {
-			h.remoteSessionOrder[key] = ids
+	h.remoteSessionOrder = make(remoteOrder, len(state.RemoteSessionOrder))
+	for remoteName, groups := range state.RemoteSessionOrder {
+		for groupPath, ids := range groups {
+			if len(ids) > 0 {
+				h.remoteSessionOrder.set(remoteName, groupPath, ids)
+			}
 		}
 	}
 
@@ -13755,7 +13774,6 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	// The bucket is the one buildRemoteFlatItems put this row in: same remote,
 	// same normalized group path.
 	groupPath := normalizeRemoteGroupPath(moved.Group)
-	key := remoteOrderKey(item.RemoteName, groupPath)
 
 	h.remoteSessionsMu.RLock()
 	fetched := h.remoteSessions[item.RemoteName]
@@ -13770,7 +13788,7 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	// Start from what is actually on screen — the fetched list with the
 	// current overlay already applied — so a move is always relative to what
 	// the user sees, whatever has drifted since the overlay was written.
-	current := applyRemoteSessionOrder(natural, h.remoteSessionOrder[key])
+	current := applyRemoteSessionOrder(natural, h.remoteSessionOrder.forRemote(item.RemoteName)[groupPath])
 	pos := -1
 	for i, id := range current {
 		if id == moved.ID {
@@ -13793,13 +13811,19 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	// current lists exactly the sessions present in this bucket right now, so
 	// storing it whole keeps the overlay complete and the next move stable.
 	if h.remoteSessionOrder == nil {
-		h.remoteSessionOrder = make(map[string][]string)
+		h.remoteSessionOrder = make(remoteOrder)
 	}
-	h.remoteSessionOrder[key] = current
+	h.remoteSessionOrder.set(item.RemoteName, groupPath, current)
 
 	h.clearError()
 	h.rebuildFlatItemsPreservingSelection(h.captureSelectedItemIdentity())
-	h.saveUIState()
+
+	// A move that cannot be written is a move that will be gone at the next
+	// launch. Say so: the rows visibly moved, so staying quiet here would be
+	// the same silent lie this issue is about, one layer down.
+	if err := h.saveUIStateErr(); err != nil {
+		h.setError(fmt.Errorf("moved '%s' %s, but the order could not be saved and will not survive a restart: %w", moved.Title, direction, err))
+	}
 }
 
 // attachRemoteSession attaches to a remote session via SSH, suspending the TUI.

--- a/internal/ui/issue1875_remote_order_test.go
+++ b/internal/ui/issue1875_remote_order_test.go
@@ -136,30 +136,28 @@ func TestRemoteOrderScoping_Issue1875(t *testing.T) {
 	}
 
 	// Only dev's "work" bucket is reordered.
-	order := map[string][]string{
-		remoteOrderKey("dev", "work"): {"dev-2", "dev-1"},
-	}
+	order := remoteOrder{"dev": {"work": {"dev-2", "dev-1"}}}
 
 	// Group buckets are emitted in lexicographic path order ("other" before
 	// "work"), which the session overlay must not disturb; inside "work" the
 	// overlay applies, and "other" keeps the fetched order.
-	devIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order))
+	devIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order.forRemote("dev")))
 	if strings.Join(devIDs, ",") != "dev-3,dev-4,dev-2,dev-1" {
 		t.Fatalf("dev order = %v, want [dev-3 dev-4 dev-2 dev-1]", devIDs)
 	}
 
-	prodIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order))
+	prodIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order.forRemote("prod")))
 	if strings.Join(prodIDs, ",") != "prod-1,prod-2" {
 		t.Fatalf("dev's overlay leaked onto prod: order = %v, want [prod-1 prod-2]", prodIDs)
 	}
 
 	// An overlay written against prod's same-named group must not move dev.
-	order[remoteOrderKey("prod", "work")] = []string{"prod-2", "prod-1"}
-	devIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order))
+	order.set("prod", "work", []string{"prod-2", "prod-1"})
+	devIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order.forRemote("dev")))
 	if strings.Join(devIDs, ",") != "dev-3,dev-4,dev-2,dev-1" {
 		t.Fatalf("prod's overlay leaked onto dev: order = %v", devIDs)
 	}
-	prodIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order))
+	prodIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order.forRemote("prod")))
 	if strings.Join(prodIDs, ",") != "prod-2,prod-1" {
 		t.Fatalf("prod order = %v, want [prod-2 prod-1]", prodIDs)
 	}
@@ -170,7 +168,7 @@ func TestRemoteOrderScoping_Issue1875(t *testing.T) {
 		t.Fatalf("emitted %d rows for %d sessions", len(devIDs), len(devSessions))
 	}
 	var headers []string
-	for _, it := range buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order) {
+	for _, it := range buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order.forRemote("dev")) {
 		if it.Type == session.ItemTypeRemoteGroup {
 			headers = append(headers, it.Path)
 		}
@@ -210,14 +208,14 @@ func TestRemoteOrderSurvivesRestart_Issue1875(t *testing.T) {
 		{ID: "s-beta", Title: "beta", Group: "work"},
 		{ID: "s-gamma", Title: "gamma", Group: "work"},
 	}
-	key := remoteOrderKey("dev", "work")
-
 	before := NewHome()
 	before.storage = storage
 	before.profile = "_i1875order"
 	before.storageWatcher = nil
-	before.remoteSessionOrder[key] = []string{"s-gamma", "s-alpha", "s-beta"}
-	before.saveUIState()
+	before.remoteSessionOrder.set("dev", "work", []string{"s-gamma", "s-alpha", "s-beta"})
+	if err := before.saveUIStateErr(); err != nil {
+		t.Fatalf("saveUIStateErr: %v", err)
+	}
 
 	// A fresh process: new Home, same on-disk state.
 	after := NewHome()
@@ -226,13 +224,13 @@ func TestRemoteOrderSurvivesRestart_Issue1875(t *testing.T) {
 	after.storageWatcher = nil
 	after.loadUIState()
 
-	got := after.remoteSessionOrder[key]
+	got := after.remoteSessionOrder.forRemote("dev")["work"]
 	if strings.Join(got, ",") != "s-gamma,s-alpha,s-beta" {
 		t.Fatalf("order did not survive the restart: %v, want [s-gamma s-alpha s-beta]", got)
 	}
 
 	// And it must still produce that order on screen.
-	ids := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", sessions, remoteHealth{}, after.remoteSessionOrder))
+	ids := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", sessions, remoteHealth{}, after.remoteSessionOrder.forRemote("dev")))
 	if strings.Join(ids, ",") != "s-gamma,s-alpha,s-beta" {
 		t.Fatalf("restored overlay did not reorder the rows: %v", ids)
 	}
@@ -270,8 +268,149 @@ func TestShiftUpOnRemoteSessionPersists_Issue1875(t *testing.T) {
 	reloaded.storageWatcher = nil
 	reloaded.loadUIState()
 
-	got := reloaded.remoteSessionOrder[remoteOrderKey("dev", "work")]
+	got := reloaded.remoteSessionOrder.forRemote("dev")["work"]
 	if strings.Join(got, ",") != "s-alpha,s-gamma,s-beta" {
 		t.Fatalf("the reorder was not persisted: %v, want [s-alpha s-gamma s-beta]", got)
+	}
+}
+
+// Review round 1, F1: the overlay was keyed by concatenating
+// "remotes/<remote>/<group>". Remote names are unrestricted TOML map keys and
+// group paths legitimately contain "/", so remote "dev/work" + group "x" and
+// remote "dev" + group "work/x" produced the same key and shared an ordering.
+// The nested map cannot alias whatever the names contain.
+func TestRemoteOrderKeysCannotAlias_Issue1875(t *testing.T) {
+	// Bucket A: a remote whose NAME contains a slash, group "x".
+	aSessions := []session.RemoteSessionInfo{
+		{ID: "a-1", Title: "one", Group: "x"},
+		{ID: "a-2", Title: "two", Group: "x"},
+	}
+	// Bucket B: a remote named "dev", group path "work/x". Under the old
+	// concatenated key both of these were "remotes/dev/work/x".
+	bSessions := []session.RemoteSessionInfo{
+		{ID: "b-1", Title: "one", Group: "work/x"},
+		{ID: "b-2", Title: "two", Group: "work/x"},
+	}
+
+	order := remoteOrder{}
+	order.set("dev/work", "x", []string{"a-2", "a-1"})
+
+	aIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev/work", aSessions, remoteHealth{}, order.forRemote("dev/work")))
+	if strings.Join(aIDs, ",") != "a-2,a-1" {
+		t.Fatalf("remote 'dev/work' group 'x' order = %v, want [a-2 a-1]", aIDs)
+	}
+
+	bIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", bSessions, remoteHealth{}, order.forRemote("dev")))
+	if strings.Join(bIDs, ",") != "b-1,b-2" {
+		t.Fatalf("the 'dev/work'+'x' ordering aliased onto 'dev'+'work/x': order = %v, want [b-1 b-2]", bIDs)
+	}
+
+	// And the reverse: an ordering on dev/work/x must not reach dev/work + x.
+	order.set("dev", "work/x", []string{"b-2", "b-1"})
+	aIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev/work", aSessions, remoteHealth{}, order.forRemote("dev/work")))
+	if strings.Join(aIDs, ",") != "a-2,a-1" {
+		t.Fatalf("the 'dev'+'work/x' ordering aliased onto 'dev/work'+'x': order = %v, want [a-2 a-1]", aIDs)
+	}
+	bIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", bSessions, remoteHealth{}, order.forRemote("dev")))
+	if strings.Join(bIDs, ",") != "b-2,b-1" {
+		t.Fatalf("remote 'dev' group 'work/x' order = %v, want [b-2 b-1]", bIDs)
+	}
+}
+
+// F1, persistence half: the separator-bearing names must also survive the
+// ui_state round trip as distinct buckets.
+func TestRemoteOrderSlashKeysRoundTrip_Issue1875(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(func() { os.Setenv("HOME", origHome); session.ClearUserConfigCache() })
+
+	storage, err := session.NewStorageWithProfile("_i1875slash")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	before := NewHome()
+	before.storage = storage
+	before.profile = "_i1875slash"
+	before.storageWatcher = nil
+	before.remoteSessionOrder.set("dev/work", "x", []string{"a-2", "a-1"})
+	before.remoteSessionOrder.set("dev", "work/x", []string{"b-2", "b-1"})
+	if err := before.saveUIStateErr(); err != nil {
+		t.Fatalf("saveUIStateErr: %v", err)
+	}
+
+	after := NewHome()
+	after.storage = storage
+	after.profile = "_i1875slash"
+	after.storageWatcher = nil
+	after.loadUIState()
+
+	if got := after.remoteSessionOrder.forRemote("dev/work")["x"]; strings.Join(got, ",") != "a-2,a-1" {
+		t.Fatalf("remote 'dev/work' group 'x' = %v, want [a-2 a-1]", got)
+	}
+	if got := after.remoteSessionOrder.forRemote("dev")["work/x"]; strings.Join(got, ",") != "b-2,b-1" {
+		t.Fatalf("remote 'dev' group 'work/x' = %v, want [b-2 b-1]", got)
+	}
+	if got := after.remoteSessionOrder.forRemote("dev")["x"]; got != nil {
+		t.Fatalf("buckets merged across the round trip: dev/x = %v, want nothing", got)
+	}
+}
+
+// Review round 1, F2: saveUIState only logged SetMeta failures, so a reorder on
+// a locked, read-only or full database moved the rows on screen, said nothing,
+// and reverted at the next launch. The failure is injected by closing the
+// storage out from under the handler, which is what a dead DB handle looks like
+// to SetMeta.
+func TestRemoteReorderReportsSaveFailure_Issue1875(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(func() { os.Setenv("HOME", origHome); session.ClearUserConfigCache() })
+
+	storage, err := session.NewStorageWithProfile("_i1875savefail")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+
+	h := armHomeForRemoteReorder(t)
+	h.storage = storage
+	h.profile = "_i1875savefail"
+	h.storageWatcher = nil
+
+	// Sanity: the same move succeeds quietly while the DB is alive.
+	putCursorOnRemoteSession(t, h, "s-beta")
+	h.moveRemoteItem(h.flatItems[h.cursor], -1)
+	if h.err != nil {
+		t.Fatalf("a healthy save reported an error: %v", h.err)
+	}
+
+	if err := storage.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := h.saveUIStateErr(); got == nil {
+		t.Fatal("precondition: saveUIStateErr returned nil against a closed database")
+	}
+
+	h.clearError()
+	putCursorOnRemoteSession(t, h, "s-gamma")
+	h.moveRemoteItem(h.flatItems[h.cursor], -1)
+
+	if h.err == nil {
+		t.Fatal("a reorder that could not be persisted reported success")
+	}
+	msg := strings.ToLower(h.err.Error())
+	if !strings.Contains(msg, "saved") && !strings.Contains(msg, "save") {
+		t.Fatalf("message does not say the order was not saved: %q", h.err.Error())
+	}
+	if !strings.Contains(msg, "restart") {
+		t.Fatalf("message does not warn that the order will not survive a restart: %q", h.err.Error())
+	}
+
+	// The move itself still happened on screen — the message explains that it
+	// is not durable, it does not pretend the keystroke was refused.
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-beta,s-gamma,s-alpha" {
+		t.Fatalf("in-memory order = %v, want [s-beta s-gamma s-alpha]", got)
 	}
 }

--- a/internal/ui/issue1875_remote_order_test.go
+++ b/internal/ui/issue1875_remote_order_test.go
@@ -143,23 +143,23 @@ func TestRemoteOrderScoping_Issue1875(t *testing.T) {
 	// Group buckets are emitted in lexicographic path order ("other" before
 	// "work"), which the session overlay must not disturb; inside "work" the
 	// overlay applies, and "other" keeps the fetched order.
-	devIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order.forRemote("dev")))
+	devIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, nil, order.forRemote("dev")))
 	if strings.Join(devIDs, ",") != "dev-3,dev-4,dev-2,dev-1" {
 		t.Fatalf("dev order = %v, want [dev-3 dev-4 dev-2 dev-1]", devIDs)
 	}
 
-	prodIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order.forRemote("prod")))
+	prodIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, nil, order.forRemote("prod")))
 	if strings.Join(prodIDs, ",") != "prod-1,prod-2" {
 		t.Fatalf("dev's overlay leaked onto prod: order = %v, want [prod-1 prod-2]", prodIDs)
 	}
 
 	// An overlay written against prod's same-named group must not move dev.
 	order.set("prod", "work", []string{"prod-2", "prod-1"})
-	devIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order.forRemote("dev")))
+	devIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, nil, order.forRemote("dev")))
 	if strings.Join(devIDs, ",") != "dev-3,dev-4,dev-2,dev-1" {
 		t.Fatalf("prod's overlay leaked onto dev: order = %v", devIDs)
 	}
-	prodIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order.forRemote("prod")))
+	prodIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, nil, order.forRemote("prod")))
 	if strings.Join(prodIDs, ",") != "prod-2,prod-1" {
 		t.Fatalf("prod order = %v, want [prod-2 prod-1]", prodIDs)
 	}
@@ -170,7 +170,7 @@ func TestRemoteOrderScoping_Issue1875(t *testing.T) {
 		t.Fatalf("emitted %d rows for %d sessions", len(devIDs), len(devSessions))
 	}
 	var headers []string
-	for _, it := range buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order.forRemote("dev")) {
+	for _, it := range buildRemoteFlatItemsOrdered("dev", devSessions, nil, order.forRemote("dev")) {
 		if it.Type == session.ItemTypeRemoteGroup {
 			headers = append(headers, it.Path)
 		}
@@ -232,7 +232,7 @@ func TestRemoteOrderSurvivesRestart_Issue1875(t *testing.T) {
 	}
 
 	// And it must still produce that order on screen.
-	ids := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", sessions, remoteHealth{}, after.remoteSessionOrder.forRemote("dev")))
+	ids := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", sessions, nil, after.remoteSessionOrder.forRemote("dev")))
 	if strings.Join(ids, ",") != "s-gamma,s-alpha,s-beta" {
 		t.Fatalf("restored overlay did not reorder the rows: %v", ids)
 	}
@@ -297,23 +297,23 @@ func TestRemoteOrderKeysCannotAlias_Issue1875(t *testing.T) {
 	order := remoteOrder{}
 	order.set("dev/work", "x", []string{"a-2", "a-1"})
 
-	aIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev/work", aSessions, remoteHealth{}, order.forRemote("dev/work")))
+	aIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev/work", aSessions, nil, order.forRemote("dev/work")))
 	if strings.Join(aIDs, ",") != "a-2,a-1" {
 		t.Fatalf("remote 'dev/work' group 'x' order = %v, want [a-2 a-1]", aIDs)
 	}
 
-	bIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", bSessions, remoteHealth{}, order.forRemote("dev")))
+	bIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", bSessions, nil, order.forRemote("dev")))
 	if strings.Join(bIDs, ",") != "b-1,b-2" {
 		t.Fatalf("the 'dev/work'+'x' ordering aliased onto 'dev'+'work/x': order = %v, want [b-1 b-2]", bIDs)
 	}
 
 	// And the reverse: an ordering on dev/work/x must not reach dev/work + x.
 	order.set("dev", "work/x", []string{"b-2", "b-1"})
-	aIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev/work", aSessions, remoteHealth{}, order.forRemote("dev/work")))
+	aIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev/work", aSessions, nil, order.forRemote("dev/work")))
 	if strings.Join(aIDs, ",") != "a-2,a-1" {
 		t.Fatalf("the 'dev'+'work/x' ordering aliased onto 'dev/work'+'x': order = %v, want [a-2 a-1]", aIDs)
 	}
-	bIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", bSessions, remoteHealth{}, order.forRemote("dev")))
+	bIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", bSessions, nil, order.forRemote("dev")))
 	if strings.Join(bIDs, ",") != "b-2,b-1" {
 		t.Fatalf("remote 'dev' group 'work/x' order = %v, want [b-2 b-1]", bIDs)
 	}

--- a/internal/ui/issue1875_remote_order_test.go
+++ b/internal/ui/issue1875_remote_order_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
@@ -412,5 +414,88 @@ func TestRemoteReorderReportsSaveFailure_Issue1875(t *testing.T) {
 	// is not durable, it does not pretend the keystroke was refused.
 	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-beta,s-gamma,s-alpha" {
 		t.Fatalf("in-memory order = %v, want [s-beta s-gamma s-alpha]", got)
+	}
+}
+
+// Review round 2, F1: orderRemoteBucket deliberately refuses to permute a
+// bucket whose IDs are not unique, so a move there could never change the
+// screen. moveRemoteItem used to swap and save anyway — nothing moved, no
+// message, which is the same silent no-op this issue exists to fix, reached by
+// a different door. The bail-out is correct; treating it as success was not.
+//
+// This drives the key handler, not just the overlay function.
+func TestRemoteReorderReportsDuplicateIDs_Issue1875(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.dev]
+host = "user@dev.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+`)
+
+	newHome := func() *Home {
+		h := NewHome()
+		h.width, h.height = 160, 40
+		h.initialLoading = false
+		h.remoteSessions = map[string][]session.RemoteSessionInfo{
+			"dev": {
+				{ID: "dup", Title: "first", Status: "idle", Tool: "claude", Group: "work"},
+				{ID: "dup", Title: "second", Status: "idle", Tool: "claude", Group: "work"},
+				{ID: "s-b", Title: "third", Status: "idle", Tool: "claude", Group: "work"},
+			},
+		}
+		h.rebuildFlatItems()
+		return h
+	}
+
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "shift+down", key: tea.KeyMsg{Type: tea.KeyShiftDown}},
+		{name: "shift+up", key: tea.KeyMsg{Type: tea.KeyShiftUp}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHome()
+			h.clearError()
+
+			before := visibleRemoteSessionIDs(h, "dev")
+			putCursorOnRemoteSession(t, h, "dup")
+			h.handleMainKey(tc.key)
+
+			// The overlay cannot express this bucket, so the rows must not move.
+			after := visibleRemoteSessionIDs(h, "dev")
+			if strings.Join(after, ",") != strings.Join(before, ",") {
+				t.Fatalf("rows moved in an unaddressable bucket: %v -> %v", before, after)
+			}
+			// ...and the user must be told why, rather than see a dead key.
+			if h.err == nil {
+				t.Fatal("silent no-op: a duplicate-id bucket produced no footer message")
+			}
+			msg := h.err.Error()
+			if !strings.Contains(msg, "dup") {
+				t.Fatalf("message does not name the duplicated id: %q", msg)
+			}
+			if !strings.Contains(strings.ToLower(msg), "more than one") {
+				t.Fatalf("message does not explain the duplication: %q", msg)
+			}
+			// Nothing may be written for a bucket that cannot be ordered.
+			if got := h.remoteSessionOrder.forRemote("dev")["work"]; got != nil {
+				t.Fatalf("an order was stored for an unaddressable bucket: %v", got)
+			}
+		})
+	}
+
+	// The third session in that group is equally stuck: any order stored for
+	// the bucket would be ignored by the builder, so it must report too rather
+	// than appear to work.
+	h := newHome()
+	h.clearError()
+	before := visibleRemoteSessionIDs(h, "dev")
+	putCursorOnRemoteSession(t, h, "s-b")
+	h.handleMainKey(tea.KeyMsg{Type: tea.KeyShiftUp})
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != strings.Join(before, ",") {
+		t.Fatalf("rows moved in an unaddressable bucket: %v -> %v", before, got)
+	}
+	if h.err == nil {
+		t.Fatal("silent no-op: moving a uniquely-named row in a duplicate-id bucket said nothing")
 	}
 }

--- a/internal/ui/issue1875_remote_order_test.go
+++ b/internal/ui/issue1875_remote_order_test.go
@@ -1,0 +1,277 @@
+// Issue #1875, part 2: the overlay itself.
+//
+// The reorder overlay is local, so it drifts against a remote that adds and
+// removes sessions without asking. These tests pin the three drift rules —
+// skip stale IDs, keep unseen sessions in their natural position, emit every
+// fetched session exactly once — plus their interleaving, the per-remote and
+// per-group scoping, and the ui_state round trip across a restart.
+package ui
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestApplyRemoteSessionOrder_Drift_Issue1875(t *testing.T) {
+	cases := []struct {
+		name    string
+		natural []string
+		order   []string
+		want    []string
+	}{
+		{
+			name:    "empty overlay keeps the fetched order",
+			natural: []string{"a", "b", "c"},
+			order:   nil,
+			want:    []string{"a", "b", "c"},
+		},
+		{
+			name:    "empty remote yields nothing",
+			natural: nil,
+			order:   []string{"a", "b"},
+			want:    nil,
+		},
+		{
+			name:    "single session cannot move",
+			natural: []string{"a"},
+			order:   []string{"b", "a"},
+			want:    []string{"a"},
+		},
+		{
+			name:    "full overlay is honored exactly",
+			natural: []string{"a", "b", "c"},
+			order:   []string{"c", "a", "b"},
+			want:    []string{"c", "a", "b"},
+		},
+		{
+			name:    "stale ids are skipped",
+			natural: []string{"a", "b", "c"},
+			order:   []string{"c", "deleted-on-the-remote", "a", "b"},
+			want:    []string{"c", "a", "b"},
+		},
+		{
+			name:    "an entirely stale overlay is inert",
+			natural: []string{"a", "b"},
+			order:   []string{"x", "y"},
+			want:    []string{"a", "b"},
+		},
+		{
+			name: "unseen sessions keep their natural position",
+			// "c" is new on the remote and sits last there; it must stay last
+			// rather than be dragged along by the overlay, and "d" must stay
+			// between the two overlay-known rows.
+			natural: []string{"a", "d", "b", "c"},
+			order:   []string{"b", "a"},
+			want:    []string{"b", "d", "a", "c"},
+		},
+		{
+			name:    "stale and unseen interleaved",
+			natural: []string{"a", "new1", "b", "new2", "c"},
+			order:   []string{"c", "gone1", "a", "gone2", "b"},
+			want:    []string{"c", "new1", "a", "new2", "b"},
+		},
+		{
+			name:    "an overlay repeat is used once",
+			natural: []string{"a", "b", "c"},
+			order:   []string{"b", "b", "a"},
+			want:    []string{"b", "a", "c"},
+		},
+		{
+			name: "duplicate ids on the remote leave the fetched order alone",
+			// Cannot map slots 1:1, and dropping or doubling a row is worse
+			// than not reordering.
+			natural: []string{"a", "a", "b"},
+			order:   []string{"b", "a"},
+			want:    []string{"a", "a", "b"},
+		},
+		{
+			name:    "an id-less row is never addressable but is still emitted",
+			natural: []string{"a", "", "b"},
+			order:   []string{"b", "a"},
+			want:    []string{"b", "", "a"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			natural := append([]string(nil), tc.natural...)
+			got := applyRemoteSessionOrder(natural, tc.order)
+
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("order = %v, want %v", got, tc.want)
+			}
+			// The result must always be a permutation of the input: no row
+			// dropped, none doubled.
+			gotSorted, wantSorted := append([]string(nil), got...), append([]string(nil), tc.natural...)
+			sort.Strings(gotSorted)
+			sort.Strings(wantSorted)
+			if strings.Join(gotSorted, ",") != strings.Join(wantSorted, ",") {
+				t.Fatalf("not a permutation of the fetched list: %v vs %v", gotSorted, wantSorted)
+			}
+			// The caller's slice must survive untouched.
+			if strings.Join(natural, ",") != strings.Join(tc.natural, ",") {
+				t.Fatalf("input slice was mutated: %v", natural)
+			}
+		})
+	}
+}
+
+// The overlay is keyed per remote AND per group path, and its values are
+// session IDs, so a same-named group on another host and an identically titled
+// session on another host both stay out of each other's way.
+func TestRemoteOrderScoping_Issue1875(t *testing.T) {
+	devSessions := []session.RemoteSessionInfo{
+		{ID: "dev-1", Title: "build", Group: "work"},
+		{ID: "dev-2", Title: "test", Group: "work"},
+		{ID: "dev-3", Title: "build", Group: "other"},
+		{ID: "dev-4", Title: "test", Group: "other"},
+	}
+	prodSessions := []session.RemoteSessionInfo{
+		{ID: "prod-1", Title: "build", Group: "work"},
+		{ID: "prod-2", Title: "test", Group: "work"},
+	}
+
+	// Only dev's "work" bucket is reordered.
+	order := map[string][]string{
+		remoteOrderKey("dev", "work"): {"dev-2", "dev-1"},
+	}
+
+	// Group buckets are emitted in lexicographic path order ("other" before
+	// "work"), which the session overlay must not disturb; inside "work" the
+	// overlay applies, and "other" keeps the fetched order.
+	devIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order))
+	if strings.Join(devIDs, ",") != "dev-3,dev-4,dev-2,dev-1" {
+		t.Fatalf("dev order = %v, want [dev-3 dev-4 dev-2 dev-1]", devIDs)
+	}
+
+	prodIDs := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order))
+	if strings.Join(prodIDs, ",") != "prod-1,prod-2" {
+		t.Fatalf("dev's overlay leaked onto prod: order = %v, want [prod-1 prod-2]", prodIDs)
+	}
+
+	// An overlay written against prod's same-named group must not move dev.
+	order[remoteOrderKey("prod", "work")] = []string{"prod-2", "prod-1"}
+	devIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order))
+	if strings.Join(devIDs, ",") != "dev-3,dev-4,dev-2,dev-1" {
+		t.Fatalf("prod's overlay leaked onto dev: order = %v", devIDs)
+	}
+	prodIDs = remoteItemSessionIDs(buildRemoteFlatItemsOrdered("prod", prodSessions, remoteHealth{}, order))
+	if strings.Join(prodIDs, ",") != "prod-2,prod-1" {
+		t.Fatalf("prod order = %v, want [prod-2 prod-1]", prodIDs)
+	}
+
+	// Every fetched session is still emitted exactly once, and no group header
+	// was disturbed by the session reorder.
+	if len(devIDs) != len(devSessions) {
+		t.Fatalf("emitted %d rows for %d sessions", len(devIDs), len(devSessions))
+	}
+	var headers []string
+	for _, it := range buildRemoteFlatItemsOrdered("dev", devSessions, remoteHealth{}, order) {
+		if it.Type == session.ItemTypeRemoteGroup {
+			headers = append(headers, it.Path)
+		}
+	}
+	if strings.Join(headers, ",") != "remotes/dev,remotes/dev/other,remotes/dev/work" {
+		t.Fatalf("group headers moved: %v", headers)
+	}
+}
+
+func remoteItemSessionIDs(items []session.Item) []string {
+	var ids []string
+	for _, it := range items {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession != nil {
+			ids = append(ids, it.RemoteSession.ID)
+		}
+	}
+	return ids
+}
+
+// The order is a view preference, so it must survive a TUI restart the same
+// way the preview mode and status filter do: written to ui_state, read back on
+// the next launch.
+func TestRemoteOrderSurvivesRestart_Issue1875(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(func() { os.Setenv("HOME", origHome); session.ClearUserConfigCache() })
+
+	storage, err := session.NewStorageWithProfile("_i1875order")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	sessions := []session.RemoteSessionInfo{
+		{ID: "s-alpha", Title: "alpha", Group: "work"},
+		{ID: "s-beta", Title: "beta", Group: "work"},
+		{ID: "s-gamma", Title: "gamma", Group: "work"},
+	}
+	key := remoteOrderKey("dev", "work")
+
+	before := NewHome()
+	before.storage = storage
+	before.profile = "_i1875order"
+	before.storageWatcher = nil
+	before.remoteSessionOrder[key] = []string{"s-gamma", "s-alpha", "s-beta"}
+	before.saveUIState()
+
+	// A fresh process: new Home, same on-disk state.
+	after := NewHome()
+	after.storage = storage
+	after.profile = "_i1875order"
+	after.storageWatcher = nil
+	after.loadUIState()
+
+	got := after.remoteSessionOrder[key]
+	if strings.Join(got, ",") != "s-gamma,s-alpha,s-beta" {
+		t.Fatalf("order did not survive the restart: %v, want [s-gamma s-alpha s-beta]", got)
+	}
+
+	// And it must still produce that order on screen.
+	ids := remoteItemSessionIDs(buildRemoteFlatItemsOrdered("dev", sessions, remoteHealth{}, after.remoteSessionOrder))
+	if strings.Join(ids, ",") != "s-gamma,s-alpha,s-beta" {
+		t.Fatalf("restored overlay did not reorder the rows: %v", ids)
+	}
+}
+
+// End to end through the key handler: a shift+up must be persisted, so the
+// order the user set is the order the next launch shows.
+func TestShiftUpOnRemoteSessionPersists_Issue1875(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(func() { os.Setenv("HOME", origHome); session.ClearUserConfigCache() })
+
+	storage, err := session.NewStorageWithProfile("_i1875key")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	h := armHomeForRemoteReorder(t)
+	h.storage = storage
+	h.profile = "_i1875key"
+	h.storageWatcher = nil
+
+	putCursorOnRemoteSession(t, h, "s-gamma")
+	h.moveRemoteItem(h.flatItems[h.cursor], -1)
+
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-alpha,s-gamma,s-beta" {
+		t.Fatalf("in-memory order = %v, want [s-alpha s-gamma s-beta]", got)
+	}
+
+	reloaded := NewHome()
+	reloaded.storage = storage
+	reloaded.profile = "_i1875key"
+	reloaded.storageWatcher = nil
+	reloaded.loadUIState()
+
+	got := reloaded.remoteSessionOrder[remoteOrderKey("dev", "work")]
+	if strings.Join(got, ",") != "s-alpha,s-gamma,s-beta" {
+		t.Fatalf("the reorder was not persisted: %v, want [s-alpha s-gamma s-beta]", got)
+	}
+}

--- a/internal/ui/issue1875_remote_reorder_test.go
+++ b/internal/ui/issue1875_remote_reorder_test.go
@@ -1,0 +1,168 @@
+// Issue #1875: shift+up/down (and the +/-/K/J aliases) do nothing on a remote
+// session row.
+//
+// The move handlers in home.go switch on ItemTypeGroup and ItemTypeSession
+// only; ItemTypeRemoteSession and ItemTypeRemoteGroup fall off the end of the
+// switch, so the keypress produces no repaint, no error and no state change.
+// Because the same keys work on the local rows immediately above, it reads as
+// a stuck key rather than an unimplemented path.
+//
+// These two tests drive the real handler through handleMainKey. They are
+// written against the pre-fix API surface only, so they compile and FAIL at
+// the merge base:
+//
+//   - the reorder test fails because the row order never changes;
+//   - the never-silent test fails because h.err stays nil.
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// armHomeForRemoteReorder builds a Home with one remote holding three sessions
+// in a single group, in fetch order alpha, beta, gamma.
+func armHomeForRemoteReorder(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.dev]
+host = "user@dev.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+`)
+
+	h := NewHome()
+	h.width, h.height = 160, 40
+	h.initialLoading = false
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "s-alpha", Title: "alpha", Status: "idle", Tool: "claude", Group: "work"},
+			{ID: "s-beta", Title: "beta", Status: "idle", Tool: "claude", Group: "work"},
+			{ID: "s-gamma", Title: "gamma", Status: "idle", Tool: "claude", Group: "work"},
+		},
+	}
+	h.rebuildFlatItems()
+	return h
+}
+
+// visibleRemoteSessionIDs reads the on-screen order of one remote's session
+// rows straight out of the flat item list.
+func visibleRemoteSessionIDs(h *Home, remoteName string) []string {
+	var ids []string
+	for _, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession != nil && it.RemoteName == remoteName {
+			ids = append(ids, it.RemoteSession.ID)
+		}
+	}
+	return ids
+}
+
+// putCursorOnRemoteSession parks the cursor on a remote session row by ID.
+func putCursorOnRemoteSession(t *testing.T, h *Home, id string) {
+	t.Helper()
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession != nil && it.RemoteSession.ID == id {
+			h.cursor = i
+			return
+		}
+	}
+	t.Fatalf("no remote session row with id %q; rows=%v", id, visibleRemoteSessionIDs(h, "dev"))
+}
+
+func TestShiftUpDownReordersRemoteSession_Issue1875(t *testing.T) {
+	h := armHomeForRemoteReorder(t)
+
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-alpha,s-beta,s-gamma" {
+		t.Fatalf("precondition: fetched order = %v, want [s-alpha s-beta s-gamma]", got)
+	}
+
+	// shift+up on beta must swap it above alpha.
+	putCursorOnRemoteSession(t, h, "s-beta")
+	h.handleMainKey(tea.KeyMsg{Type: tea.KeyShiftUp})
+
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-beta,s-alpha,s-gamma" {
+		t.Fatalf("shift+up on a remote session did not reorder: order = %v, want [s-beta s-alpha s-gamma]", got)
+	}
+
+	// The cursor must follow the row the user moved, or a second press moves
+	// whatever slid into its place instead.
+	if it := h.flatItems[h.cursor]; it.Type != session.ItemTypeRemoteSession || it.RemoteSession == nil || it.RemoteSession.ID != "s-beta" {
+		t.Fatalf("cursor did not follow the moved row: cursor is on %+v", it)
+	}
+
+	// shift+down puts it back.
+	h.handleMainKey(tea.KeyMsg{Type: tea.KeyShiftDown})
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-alpha,s-beta,s-gamma" {
+		t.Fatalf("shift+down on a remote session did not reorder: order = %v, want [s-alpha s-beta s-gamma]", got)
+	}
+
+	// The "J" alias must reach the same path as shift+down.
+	putCursorOnRemoteSession(t, h, "s-alpha")
+	h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("J")})
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != "s-beta,s-alpha,s-gamma" {
+		t.Fatalf("J alias did not reorder a remote session: order = %v, want [s-beta s-alpha s-gamma]", got)
+	}
+}
+
+// A move that cannot be performed must say so. A silent no-op is the bug this
+// issue is about, so every unsupported remote case has to leave a message in
+// the footer.
+func TestRemoteReorderIsNeverSilent_Issue1875(t *testing.T) {
+	cases := []struct {
+		name string
+		arm  func(t *testing.T, h *Home)
+		key  tea.KeyMsg
+		want string
+	}{
+		{
+			name: "remote group header",
+			arm: func(t *testing.T, h *Home) {
+				for i, it := range h.flatItems {
+					if it.Type == session.ItemTypeRemoteGroup && it.Path == "remotes/dev/work" {
+						h.cursor = i
+						return
+					}
+				}
+				t.Fatalf("no remote sub-group header row")
+			},
+			key:  tea.KeyMsg{Type: tea.KeyShiftUp},
+			want: "group",
+		},
+		{
+			name: "already first in group",
+			arm: func(t *testing.T, h *Home) {
+				putCursorOnRemoteSession(t, h, "s-alpha")
+			},
+			key:  tea.KeyMsg{Type: tea.KeyShiftUp},
+			want: "first",
+		},
+		{
+			name: "already last in group",
+			arm: func(t *testing.T, h *Home) {
+				putCursorOnRemoteSession(t, h, "s-gamma")
+			},
+			key:  tea.KeyMsg{Type: tea.KeyShiftDown},
+			want: "last",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := armHomeForRemoteReorder(t)
+			h.clearError()
+			tc.arm(t, h)
+			h.handleMainKey(tc.key)
+
+			if h.err == nil {
+				t.Fatalf("silent no-op: %s produced no footer message", tc.name)
+			}
+			if !strings.Contains(strings.ToLower(h.err.Error()), tc.want) {
+				t.Fatalf("message %q does not mention %q", h.err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/remote_order.go
+++ b/internal/ui/remote_order.go
@@ -109,6 +109,22 @@ func applyRemoteSessionOrder(natural, order []string) []string {
 	return out
 }
 
+// firstDuplicateID reports the first session ID that appears more than once,
+// which is the exact condition under which orderRemoteBucket refuses to
+// reorder a bucket. A caller reordering on behalf of the user must ask this
+// before it changes anything, so an unaddressable bucket produces a message
+// rather than a move that silently does nothing.
+func firstDuplicateID(ids []string) (string, bool) {
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			return id, true
+		}
+		seen[id] = true
+	}
+	return "", false
+}
+
 // orderRemoteBucket permutes one group bucket's indices into sessions by the
 // overlay, leaving the caller's slice untouched.
 func orderRemoteBucket(sessions []session.RemoteSessionInfo, idxs []int, order []string) []int {
@@ -123,7 +139,10 @@ func orderRemoteBucket(sessions []session.RemoteSessionInfo, idxs []int, order [
 		byID[sessions[idx].ID] = idx
 	}
 	if len(byID) != len(idxs) {
-		return idxs // duplicate (or empty) IDs: not addressable, leave as fetched
+		// Duplicate IDs: not addressable, leave as fetched. Callers acting on a
+		// user keystroke must check firstDuplicateID first, or this bail-out
+		// looks to the user exactly like a move that did nothing.
+		return idxs
 	}
 
 	want := applyRemoteSessionOrder(natural, order)

--- a/internal/ui/remote_order.go
+++ b/internal/ui/remote_order.go
@@ -6,9 +6,9 @@ import "github.com/asheshgoplani/agent-deck/internal/session"
 //
 // Remote rows are RemoteSessionInfo values fetched over SSH, not Instances
 // living in groupTree, so groupTree.MoveSessionUp/Down has nothing to move.
-// The order is therefore kept as a purely local overlay: a
-// map[bucketKey][]sessionID on Home, applied when the flat item list is built
-// and persisted in ui_state next to the other view preferences. Nothing is
+// The order is therefore kept as a purely local overlay: a remoteOrder on
+// Home, applied when the flat item list is built and persisted in ui_state
+// next to the other view preferences. Nothing is
 // sent to the remote — ordering is a viewing preference of the machine doing
 // the viewing, and a remote-authoritative reorder would need a new subcommand
 // plus a wire protocol that silently breaks against older remote binaries.
@@ -24,13 +24,33 @@ import "github.com/asheshgoplani/agent-deck/internal/session"
 // The last rule is the important one: getting it wrong either duplicates a row
 // or makes one vanish, both worse than the no-op this fixes.
 
-// remoteOrderKey is the overlay bucket key: one ordering per remote per group
-// path. It matches the Path that buildRemoteFlatItems stamps on the rows of
-// that bucket ("remotes/<remote>/<group>"), so two remotes owning a same-named
-// group never share an ordering, and IDs — never titles — are the values, so
-// two identically titled sessions on different hosts cannot collide either.
-func remoteOrderKey(remoteName, groupPath string) string {
-	return "remotes/" + remoteName + "/" + groupPath
+// remoteOrder is the whole overlay: remote name -> group path -> session IDs.
+//
+// The nesting is the scoping, and it is nested rather than keyed by a joined
+// string on purpose. A flat "remotes/<remote>/<group>" key is ambiguous,
+// because neither half is free of separators: remote names are unrestricted
+// TOML map keys and group paths legitimately contain "/", so remote "dev/work"
+// + group "x" and remote "dev" + group "work/x" would produce the same key and
+// silently share an ordering. Two map levels cannot collide whatever the
+// names contain, and JSON object keys need no escaping either, so the
+// ui_state round trip is exact.
+//
+// Values are session IDs, never titles, so two identically titled sessions on
+// different hosts — or in different groups — stay independent.
+type remoteOrder map[string]map[string][]string
+
+// forRemote returns one remote's group -> session ID orderings. The nil map
+// reads fine, so callers need no nil check.
+func (o remoteOrder) forRemote(remoteName string) map[string][]string {
+	return o[remoteName]
+}
+
+// set records the order of one bucket, creating the remote's level on demand.
+func (o remoteOrder) set(remoteName, groupPath string, ids []string) {
+	if o[remoteName] == nil {
+		o[remoteName] = make(map[string][]string, 1)
+	}
+	o[remoteName][groupPath] = ids
 }
 
 // applyRemoteSessionOrder returns natural (session IDs in the order the remote

--- a/internal/ui/remote_order.go
+++ b/internal/ui/remote_order.go
@@ -1,0 +1,115 @@
+package ui
+
+import "github.com/asheshgoplani/agent-deck/internal/session"
+
+// Manual ordering of remote session rows (#1875).
+//
+// Remote rows are RemoteSessionInfo values fetched over SSH, not Instances
+// living in groupTree, so groupTree.MoveSessionUp/Down has nothing to move.
+// The order is therefore kept as a purely local overlay: a
+// map[bucketKey][]sessionID on Home, applied when the flat item list is built
+// and persisted in ui_state next to the other view preferences. Nothing is
+// sent to the remote — ordering is a viewing preference of the machine doing
+// the viewing, and a remote-authoritative reorder would need a new subcommand
+// plus a wire protocol that silently breaks against older remote binaries.
+//
+// The overlay drifts by design: sessions come and go on the other machine
+// without asking us. The rules, in one place, are
+//
+//   - stale IDs (in the overlay, gone from the remote) are skipped;
+//   - unseen sessions (on the remote, absent from the overlay) keep their
+//     natural position, i.e. the index the remote's own listing gave them;
+//   - every fetched session is emitted exactly once.
+//
+// The last rule is the important one: getting it wrong either duplicates a row
+// or makes one vanish, both worse than the no-op this fixes.
+
+// remoteOrderKey is the overlay bucket key: one ordering per remote per group
+// path. It matches the Path that buildRemoteFlatItems stamps on the rows of
+// that bucket ("remotes/<remote>/<group>"), so two remotes owning a same-named
+// group never share an ordering, and IDs — never titles — are the values, so
+// two identically titled sessions on different hosts cannot collide either.
+func remoteOrderKey(remoteName, groupPath string) string {
+	return "remotes/" + remoteName + "/" + groupPath
+}
+
+// applyRemoteSessionOrder returns natural (session IDs in the order the remote
+// listed them) permuted by the overlay order.
+//
+// The permutation is positional: the natural indices held by sessions the
+// overlay knows about are the movable slots, and they are refilled in overlay
+// order. A session the overlay has never seen is not a slot, so it stays at
+// the exact index the remote gave it rather than being flushed to the end.
+//
+// The result is always a permutation of natural — same length, same multiset
+// of IDs — so no row can be dropped or doubled. If natural somehow contains a
+// duplicate ID the slot mapping is no longer 1:1, and the fetched order is
+// returned untouched rather than risking that invariant.
+func applyRemoteSessionOrder(natural, order []string) []string {
+	out := make([]string, len(natural))
+	copy(out, natural)
+	if len(order) == 0 || len(natural) < 2 {
+		return out
+	}
+
+	present := make(map[string]bool, len(natural))
+	for _, id := range natural {
+		if id == "" {
+			continue // an ID-less row can never be addressed by the overlay
+		}
+		present[id] = true
+	}
+
+	// Overlay entries that still exist on the remote, overlay order, deduped.
+	ordered := make([]string, 0, len(order))
+	known := make(map[string]bool, len(order))
+	for _, id := range order {
+		if !present[id] || known[id] {
+			continue // stale overlay entry, or a repeat within the overlay
+		}
+		known[id] = true
+		ordered = append(ordered, id)
+	}
+	if len(ordered) == 0 {
+		return out
+	}
+
+	slots := make([]int, 0, len(ordered))
+	for i, id := range natural {
+		if known[id] {
+			slots = append(slots, i)
+		}
+	}
+	if len(slots) != len(ordered) {
+		return out // duplicate IDs on the remote: bail rather than lose a row
+	}
+	for k, i := range slots {
+		out[i] = ordered[k]
+	}
+	return out
+}
+
+// orderRemoteBucket permutes one group bucket's indices into sessions by the
+// overlay, leaving the caller's slice untouched.
+func orderRemoteBucket(sessions []session.RemoteSessionInfo, idxs []int, order []string) []int {
+	if len(order) == 0 || len(idxs) < 2 {
+		return idxs
+	}
+
+	natural := make([]string, len(idxs))
+	byID := make(map[string]int, len(idxs))
+	for k, idx := range idxs {
+		natural[k] = sessions[idx].ID
+		byID[sessions[idx].ID] = idx
+	}
+	if len(byID) != len(idxs) {
+		return idxs // duplicate (or empty) IDs: not addressable, leave as fetched
+	}
+
+	want := applyRemoteSessionOrder(natural, order)
+	out := make([]int, 0, len(idxs))
+	for _, id := range want {
+		out = append(out, byID[id])
+	}
+	return out
+}

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -28,6 +28,13 @@ import (
 // withheld — so the row stays on screen and can be reopened. Passing nil emits
 // the full tree, which is what every caller did before collapsing existed.
 func buildRemoteFlatItems(remoteName string, sessions []session.RemoteSessionInfo, collapsed map[string]bool) []session.Item {
+	return buildRemoteFlatItemsOrdered(remoteName, sessions, collapsed, nil)
+}
+
+// buildRemoteFlatItemsOrdered is buildRemoteFlatItems with the manual
+// row-order overlay (#1875) applied. order is keyed by remoteOrderKey and may
+// be nil, in which case each bucket keeps the order the remote listed.
+func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSessionInfo, collapsed map[string]bool, order map[string][]string) []session.Item {
 	items := make([]session.Item, 0, len(sessions)+2)
 
 	remoteRoot := "remotes/" + remoteName
@@ -103,7 +110,9 @@ func buildRemoteFlatItems(remoteName string, sessions []session.RemoteSessionInf
 
 		// Sessions sit one level below their owning group header.
 		sessionLevel := len(segments) + 1
-		idxs := buckets[gp]
+		// #1875: the user's manual order for this bucket, if any. Group
+		// headers keep their lexicographic order; only sessions move.
+		idxs := orderRemoteBucket(sessions, buckets[gp], order[remoteOrderKey(remoteName, gp)])
 		for j, idx := range idxs {
 			items = append(items, session.Item{
 				Type:          session.ItemTypeRemoteSession,

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -32,8 +32,9 @@ func buildRemoteFlatItems(remoteName string, sessions []session.RemoteSessionInf
 }
 
 // buildRemoteFlatItemsOrdered is buildRemoteFlatItems with the manual
-// row-order overlay (#1875) applied. order is keyed by remoteOrderKey and may
-// be nil, in which case each bucket keeps the order the remote listed.
+// row-order overlay (#1875) applied. order holds THIS remote's group path ->
+// session IDs (i.e. remoteOrder.forRemote(remoteName)) and may be nil, in
+// which case each bucket keeps the order the remote listed.
 func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSessionInfo, collapsed map[string]bool, order map[string][]string) []session.Item {
 	items := make([]session.Item, 0, len(sessions)+2)
 
@@ -112,7 +113,7 @@ func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSes
 		sessionLevel := len(segments) + 1
 		// #1875: the user's manual order for this bucket, if any. Group
 		// headers keep their lexicographic order; only sessions move.
-		idxs := orderRemoteBucket(sessions, buckets[gp], order[remoteOrderKey(remoteName, gp)])
+		idxs := orderRemoteBucket(sessions, buckets[gp], order[gp])
 		for j, idx := range idxs {
 			items = append(items, session.Item{
 				Type:          session.ItemTypeRemoteSession,


### PR DESCRIPTION
Adds a persisted, per-remote ordering overlay so Shift+Up and Shift+Down reorder remote session rows without mutating the remote host. Preserves remote-group collapsing, handles changing session lists, and reports persistence or duplicate-ID failures instead of silently ignoring the action.  

Fixes #1875


