### PR TITLE
fix(watcher): contain adapter recovery failures

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           check-latest: false
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -182,7 +182,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 func (e *Engine) RegisterAdapter(watcherID string, adapter WatcherAdapter, config AdapterConfig, maxSilenceMinutes int) {
 	tracker := NewHealthTracker(config.Name, maxSilenceMinutes)
 	e.adapters = append(e.adapters, adapterEntry{
-		adapter:   adapter,
+		adapter:   newRecoveredAdapter(adapter, config, e.log),
 		config:    config,
 		watcherID: watcherID,
 		tracker:   tracker,

--- a/internal/watcher/github.go
+++ b/internal/watcher/github.go
@@ -385,6 +385,9 @@ func (a *GitHubAdapter) HealthCheck() error {
 	a.mu.RLock()
 	addr := a.addr
 	a.mu.RUnlock()
+	if addr == "" {
+		return fmt.Errorf("github: adapter is not initialized")
+	}
 
 	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 	if err != nil {

--- a/internal/watcher/gmail.go
+++ b/internal/watcher/gmail.go
@@ -386,24 +386,29 @@ func (a *GmailAdapter) HealthCheck() error {
 	if lastErr != nil {
 		return lastErr
 	}
-	if a.tokenSrc != nil {
-		if _, err := a.tokenSrc.Token(); err != nil {
-			return fmt.Errorf("gmail: token source: %w", err)
-		}
+	if a.tokenSrc == nil {
+		return fmt.Errorf("gmail: adapter is not initialized: token source is unavailable")
 	}
-	if a.subscription != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		exists, err := a.subscription.Exists(ctx)
-		if err != nil {
-			return fmt.Errorf("gmail: subscription check: %w", err)
-		}
-		if !exists {
-			return fmt.Errorf("gmail: subscription %s does not exist", a.subscr)
-		}
+	if _, err := a.tokenSrc.Token(); err != nil {
+		return fmt.Errorf("gmail: token source: %w", err)
 	}
-	if !expiry.IsZero() && expiry.Before(time.Now()) {
+	if expiry.IsZero() {
+		return fmt.Errorf("gmail: adapter is not initialized: watch expiry is unavailable")
+	}
+	if expiry.Before(time.Now()) {
 		return fmt.Errorf("gmail: watch expiry has lapsed at %s", expiry.Format(time.RFC3339))
+	}
+	if a.pubsubClient == nil || a.subscription == nil {
+		return fmt.Errorf("gmail: adapter is not initialized: subscription is unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	exists, err := a.subscription.Exists(ctx)
+	if err != nil {
+		return fmt.Errorf("gmail: subscription check: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("gmail: subscription %s does not exist", a.subscr)
 	}
 	return nil
 }

--- a/internal/watcher/health_recovery_test.go
+++ b/internal/watcher/health_recovery_test.go
@@ -1,0 +1,145 @@
+package watcher
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type healthPanicAdapter struct {
+	panics atomic.Bool
+	checks atomic.Int32
+	passes atomic.Int32
+}
+
+func (*healthPanicAdapter) Setup(context.Context, AdapterConfig) error { return nil }
+func (*healthPanicAdapter) Listen(context.Context, chan<- Event) error { return nil }
+func (*healthPanicAdapter) Teardown() error                            { return nil }
+func (a *healthPanicAdapter) HealthCheck() error {
+	a.checks.Add(1)
+	if a.panics.Load() {
+		panic("secret-health-panic-value")
+	}
+	a.passes.Add(1)
+	return nil
+}
+
+type healthCountingAdapter struct{ checks atomic.Int32 }
+
+func (*healthCountingAdapter) Setup(context.Context, AdapterConfig) error { return nil }
+func (*healthCountingAdapter) Listen(context.Context, chan<- Event) error { return nil }
+func (*healthCountingAdapter) Teardown() error                            { return nil }
+func (a *healthCountingAdapter) HealthCheck() error {
+	a.checks.Add(1)
+	return nil
+}
+
+func TestRecoveredAdapterContainsHealthPanicAndSanitizesLog(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	engine := NewEngine(EngineConfig{Logger: logger, HealthCheckInterval: time.Millisecond})
+	panicking := &healthPanicAdapter{}
+	panicking.panics.Store(true)
+	sibling := &healthCountingAdapter{}
+	engine.RegisterAdapter("panic-id", panicking, AdapterConfig{Name: "panic-watch", Type: "test"}, 0)
+	engine.RegisterAdapter("sibling-id", sibling, AdapterConfig{Name: "sibling-watch", Type: "test"}, 0)
+
+	for i := range engine.adapters {
+		if err := engine.adapters[i].adapter.Setup(context.Background(), engine.adapters[i].config); err != nil {
+			t.Fatalf("Setup adapter %d: %v", i, err)
+		}
+	}
+	engine.wg.Add(1)
+	go engine.healthLoop()
+	t.Cleanup(func() {
+		engine.cancel()
+		engine.wg.Wait()
+	})
+
+	wantStates(t, engine.HealthCh(), map[string]HealthStatus{
+		"panic-watch":   HealthStatusError,
+		"sibling-watch": HealthStatusHealthy,
+	})
+	if sibling.checks.Load() == 0 {
+		t.Fatal("healthy sibling was not checked by the engine health loop")
+	}
+	panicState := engine.adapters[0].tracker.Check()
+	if panicState.Status != HealthStatusError || panicState.ConsecutiveErrors == 0 {
+		t.Fatalf("panic tracker state = %+v, want unhealthy with a recorded error", panicState)
+	}
+
+	// Repeated panics remain unhealthy without emitting a full stack every tick.
+	deadline := time.Now().Add(time.Second)
+	for panicking.checks.Load() < 3 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	// A successful check ends the episode, so a later panic transition is logged once.
+	panicking.panics.Store(false)
+	deadline = time.Now().Add(time.Second)
+	for panicking.passes.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if panicking.passes.Load() == 0 {
+		t.Fatal("successful health check did not end the panic episode")
+	}
+	panicking.panics.Store(true)
+	checksBeforeSecondEpisode := panicking.checks.Load()
+	deadline = time.Now().Add(time.Second)
+	for panicking.checks.Load() == checksBeforeSecondEpisode && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if panicking.checks.Load() == checksBeforeSecondEpisode {
+		t.Fatal("later panic did not start a new panic episode")
+	}
+	engine.cancel()
+	engine.wg.Wait()
+
+	out := logs.String()
+	for _, want := range []string{"adapter_health_panic", "panic-watch", "test", "panic_type", "stack"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log missing %q: %s", want, out)
+		}
+	}
+	if strings.Contains(out, "secret-health-panic-value") {
+		t.Fatalf("panic value leaked to log: %s", out)
+	}
+	if got := strings.Count(out, `"stack"`); got != 2 {
+		t.Fatalf("stack log count across two panic episodes = %d, want 2: %s", got, out)
+	}
+}
+
+func wantStates(t *testing.T, states <-chan HealthState, want map[string]HealthStatus) {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for len(want) > 0 {
+		select {
+		case state := <-states:
+			if status, ok := want[state.WatcherName]; ok && state.Status == status {
+				delete(want, state.WatcherName)
+			}
+		case <-timer.C:
+			t.Fatalf("missing health states: %v", want)
+		}
+	}
+}
+
+func wantState(t *testing.T, states <-chan HealthState, name string, status HealthStatus) {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case state := <-states:
+			if state.WatcherName == name && state.Status == status {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("no %s state for %s", status, name)
+		}
+	}
+}

--- a/internal/watcher/health_recovery_test.go
+++ b/internal/watcher/health_recovery_test.go
@@ -48,17 +48,10 @@ func TestRecoveredAdapterContainsHealthPanicAndSanitizesLog(t *testing.T) {
 	engine.RegisterAdapter("panic-id", panicking, AdapterConfig{Name: "panic-watch", Type: "test"}, 0)
 	engine.RegisterAdapter("sibling-id", sibling, AdapterConfig{Name: "sibling-watch", Type: "test"}, 0)
 
-	for i := range engine.adapters {
-		if err := engine.adapters[i].adapter.Setup(context.Background(), engine.adapters[i].config); err != nil {
-			t.Fatalf("Setup adapter %d: %v", i, err)
-		}
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
-	engine.wg.Add(1)
-	go engine.healthLoop()
-	t.Cleanup(func() {
-		engine.cancel()
-		engine.wg.Wait()
-	})
+	t.Cleanup(engine.Stop)
 
 	wantStates(t, engine.HealthCh(), map[string]HealthStatus{
 		"panic-watch":   HealthStatusError,
@@ -95,8 +88,7 @@ func TestRecoveredAdapterContainsHealthPanicAndSanitizesLog(t *testing.T) {
 	if panicking.checks.Load() == checksBeforeSecondEpisode {
 		t.Fatal("later panic did not start a new panic episode")
 	}
-	engine.cancel()
-	engine.wg.Wait()
+	engine.Stop()
 
 	out := logs.String()
 	for _, want := range []string{"adapter_health_panic", "panic-watch", "test", "panic_type", "stack"} {

--- a/internal/watcher/health_recovery_test.go
+++ b/internal/watcher/health_recovery_test.go
@@ -70,7 +70,8 @@ func TestRecoveredAdapterContainsHealthPanicAndSanitizesLog(t *testing.T) {
 	for panicking.checks.Load() < 3 && time.Now().Before(deadline) {
 		time.Sleep(time.Millisecond)
 	}
-	// A successful check ends the episode, so a later panic transition is logged once.
+	// A successful check ends the episode, but a quick later transition remains
+	// inside the stack-log rate cap.
 	panicking.panics.Store(false)
 	deadline = time.Now().Add(time.Second)
 	for panicking.passes.Load() == 0 && time.Now().Before(deadline) {
@@ -99,8 +100,49 @@ func TestRecoveredAdapterContainsHealthPanicAndSanitizesLog(t *testing.T) {
 	if strings.Contains(out, "secret-health-panic-value") {
 		t.Fatalf("panic value leaked to log: %s", out)
 	}
-	if got := strings.Count(out, `"stack"`); got != 2 {
-		t.Fatalf("stack log count across two panic episodes = %d, want 2: %s", got, out)
+	if got := strings.Count(out, `"stack"`); got != 1 {
+		t.Fatalf("stack log count across two quick panic episodes = %d, want 1: %s", got, out)
+	}
+}
+
+func TestRecoveredAdapterRateLimitsFlappingHealthPanicStacks(t *testing.T) {
+	var logs bytes.Buffer
+	adapter := &healthPanicAdapter{}
+	adapter.panics.Store(true)
+	now := time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+	wrapped := newRecoveredAdapter(adapter, AdapterConfig{Name: "flapping", Type: "test"}, slog.New(slog.NewJSONHandler(&logs, nil))).(*recoveredAdapter)
+	wrapped.now = func() time.Time { return now }
+
+	checkPanic := func() {
+		t.Helper()
+		if err := wrapped.HealthCheck(); err == nil {
+			t.Fatal("HealthCheck unexpectedly succeeded")
+		}
+	}
+	checkSuccess := func() {
+		t.Helper()
+		adapter.panics.Store(false)
+		if err := wrapped.HealthCheck(); err != nil {
+			t.Fatalf("HealthCheck: %v", err)
+		}
+		adapter.panics.Store(true)
+	}
+
+	checkPanic() // The first transition logs immediately.
+	checkSuccess()
+	checkPanic() // A quick flap is suppressed.
+	if got := strings.Count(logs.String(), `"stack"`); got != 1 {
+		t.Fatalf("stack log count inside rate window = %d, want 1", got)
+	}
+
+	now = now.Add(healthPanicStackLogInterval)
+	checkSuccess()
+	checkPanic()
+	if got := strings.Count(logs.String(), `"stack"`); got != 2 {
+		t.Fatalf("stack log count after rate window = %d, want 2", got)
+	}
+	if strings.Contains(logs.String(), "secret-health-panic-value") {
+		t.Fatalf("panic value leaked to log: %s", logs.String())
 	}
 }
 
@@ -116,22 +158,6 @@ func wantStates(t *testing.T, states <-chan HealthState, want map[string]HealthS
 			}
 		case <-timer.C:
 			t.Fatalf("missing health states: %v", want)
-		}
-	}
-}
-
-func wantState(t *testing.T, states <-chan HealthState, name string, status HealthStatus) {
-	t.Helper()
-	timer := time.NewTimer(2 * time.Second)
-	defer timer.Stop()
-	for {
-		select {
-		case state := <-states:
-			if state.WatcherName == name && state.Status == status {
-				return
-			}
-		case <-timer.C:
-			t.Fatalf("no %s state for %s", status, name)
 		}
 	}
 }

--- a/internal/watcher/health_uninitialized_test.go
+++ b/internal/watcher/health_uninitialized_test.go
@@ -1,0 +1,35 @@
+package watcher
+
+import (
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestAdapterHealthCheckRejectsUninitializedState(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		check func() error
+		want  string
+	}{
+		{name: "gmail zero", check: (&GmailAdapter{}).HealthCheck, want: "gmail: adapter is not initialized: token source is unavailable"},
+		{name: "github zero", check: (&GitHubAdapter{}).HealthCheck, want: "github: adapter is not initialized"},
+		{name: "webhook zero", check: (&WebhookAdapter{}).HealthCheck, want: "webhook: adapter is not initialized"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.check(); err == nil || err.Error() != tc.want {
+				t.Fatalf("HealthCheck() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestGmailHealthCheckRejectsPartialState(t *testing.T) {
+	partial := &GmailAdapter{
+		name:     "partial",
+		tokenSrc: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test"}),
+	}
+	if err := partial.HealthCheck(); err == nil {
+		t.Fatal("partially initialized Gmail adapter reported healthy")
+	}
+}

--- a/internal/watcher/partial_setup_cleanup_test.go
+++ b/internal/watcher/partial_setup_cleanup_test.go
@@ -1,0 +1,86 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+)
+
+type partialSetupAdapter struct {
+	setups    atomic.Int32
+	teardowns atomic.Int32
+}
+
+func (a *partialSetupAdapter) Setup(context.Context, AdapterConfig) error {
+	a.setups.Add(1)
+	return errors.New("setup failed after allocation")
+}
+
+type retrySetupAdapter struct {
+	setups    atomic.Int32
+	teardowns atomic.Int32
+}
+
+func (a *retrySetupAdapter) Setup(context.Context, AdapterConfig) error {
+	if a.setups.Add(1) == 1 {
+		return errors.New("first setup failed after allocation")
+	}
+	return nil
+}
+func (*retrySetupAdapter) Listen(context.Context, chan<- Event) error { return nil }
+func (a *retrySetupAdapter) Teardown() error {
+	a.teardowns.Add(1)
+	return nil
+}
+func (*retrySetupAdapter) HealthCheck() error { return nil }
+
+func TestRecoveredAdapterRetryRetainsFinalCleanup(t *testing.T) {
+	raw := &retrySetupAdapter{}
+	engine := NewEngine(EngineConfig{Logger: slog.Default()})
+	engine.RegisterAdapter("retry-id", raw, AdapterConfig{Name: "retry", Type: "test"}, 0)
+	wrapped := engine.adapters[0].adapter
+
+	if err := wrapped.Setup(context.Background(), AdapterConfig{}); err == nil {
+		t.Fatal("first Setup unexpectedly succeeded")
+	}
+	if got := raw.teardowns.Load(); got != 1 {
+		t.Fatalf("Teardown calls after failed Setup = %d, want 1", got)
+	}
+	if err := wrapped.Setup(context.Background(), AdapterConfig{}); err != nil {
+		t.Fatalf("retry Setup: %v", err)
+	}
+	if err := wrapped.Teardown(); err != nil {
+		t.Fatalf("final Teardown: %v", err)
+	}
+	if got := raw.teardowns.Load(); got != 2 {
+		t.Fatalf("Teardown calls after successful retry = %d, want 2", got)
+	}
+}
+func (*partialSetupAdapter) Listen(context.Context, chan<- Event) error { return nil }
+func (a *partialSetupAdapter) Teardown() error {
+	a.teardowns.Add(1)
+	return nil
+}
+func (*partialSetupAdapter) HealthCheck() error { return nil }
+
+func TestRecoveredAdapterCleansPartialSetupExactlyOnce(t *testing.T) {
+	raw := &partialSetupAdapter{}
+	engine := NewEngine(EngineConfig{Logger: slog.Default()})
+	engine.RegisterAdapter("partial-id", raw, AdapterConfig{Name: "partial", Type: "test"}, 0)
+	wrapped := engine.adapters[0].adapter
+
+	if err := wrapped.Setup(context.Background(), AdapterConfig{}); err == nil {
+		t.Fatal("Setup unexpectedly succeeded")
+	}
+	if got := raw.teardowns.Load(); got != 1 {
+		t.Fatalf("Teardown calls after failed Setup = %d, want 1", got)
+	}
+	if err := wrapped.Teardown(); err != nil {
+		t.Fatalf("later Teardown: %v", err)
+	}
+	if got := raw.teardowns.Load(); got != 1 {
+		t.Fatalf("Teardown calls after later Stop-style cleanup = %d, want 1", got)
+	}
+}

--- a/internal/watcher/partial_setup_cleanup_test.go
+++ b/internal/watcher/partial_setup_cleanup_test.go
@@ -67,20 +67,17 @@ func (*partialSetupAdapter) HealthCheck() error { return nil }
 
 func TestRecoveredAdapterCleansPartialSetupExactlyOnce(t *testing.T) {
 	raw := &partialSetupAdapter{}
-	engine := NewEngine(EngineConfig{Logger: slog.Default()})
+	engine, _ := newTestEngine(t, nil)
 	engine.RegisterAdapter("partial-id", raw, AdapterConfig{Name: "partial", Type: "test"}, 0)
-	wrapped := engine.adapters[0].adapter
 
-	if err := wrapped.Setup(context.Background(), AdapterConfig{}); err == nil {
-		t.Fatal("Setup unexpectedly succeeded")
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
 	if got := raw.teardowns.Load(); got != 1 {
 		t.Fatalf("Teardown calls after failed Setup = %d, want 1", got)
 	}
-	if err := wrapped.Teardown(); err != nil {
-		t.Fatalf("later Teardown: %v", err)
-	}
+	engine.Stop()
 	if got := raw.teardowns.Load(); got != 1 {
-		t.Fatalf("Teardown calls after later Stop-style cleanup = %d, want 1", got)
+		t.Fatalf("Teardown calls after Stop = %d, want 1", got)
 	}
 }

--- a/internal/watcher/recovered_adapter.go
+++ b/internal/watcher/recovered_adapter.go
@@ -7,7 +7,10 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 )
+
+const healthPanicStackLogInterval = 5 * time.Minute
 
 // recoveredAdapter contains HealthCheck and Teardown panics for every registered
 // adapter and gives each Setup attempt one rollback opportunity. Setup and Listen
@@ -17,14 +20,17 @@ type recoveredAdapter struct {
 	config AdapterConfig
 	log    *slog.Logger
 
-	teardownMu   sync.Mutex
-	teardownDone bool
-	teardownErr  error
-	healthPanic  atomic.Bool
+	teardownMu         sync.Mutex
+	teardownDone       bool
+	teardownErr        error
+	healthPanic        atomic.Bool
+	healthLogMu        sync.Mutex
+	lastHealthPanicLog time.Time
+	now                func() time.Time
 }
 
 func newRecoveredAdapter(raw WatcherAdapter, config AdapterConfig, logger *slog.Logger) WatcherAdapter {
-	return &recoveredAdapter{raw: raw, config: config, log: logger}
+	return &recoveredAdapter{raw: raw, config: config, log: logger, now: time.Now}
 }
 
 func (a *recoveredAdapter) Setup(ctx context.Context, config AdapterConfig) error {
@@ -77,7 +83,7 @@ func (a *recoveredAdapter) Teardown() (err error) {
 func (a *recoveredAdapter) HealthCheck() (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			if a.healthPanic.CompareAndSwap(false, true) {
+			if a.healthPanic.CompareAndSwap(false, true) && a.shouldLogHealthPanic() {
 				a.logPanic("adapter_health_panic", recovered)
 			}
 			err = fmt.Errorf("watcher adapter health check panic (%T)", recovered)
@@ -88,6 +94,17 @@ func (a *recoveredAdapter) HealthCheck() (err error) {
 		a.healthPanic.Store(false)
 	}
 	return err
+}
+
+func (a *recoveredAdapter) shouldLogHealthPanic() bool {
+	a.healthLogMu.Lock()
+	defer a.healthLogMu.Unlock()
+	now := a.now()
+	if !a.lastHealthPanicLog.IsZero() && now.Before(a.lastHealthPanicLog.Add(healthPanicStackLogInterval)) {
+		return false
+	}
+	a.lastHealthPanicLog = now
+	return true
 }
 
 // logPanic intentionally records only the dynamic type. runtime.Stack captures

--- a/internal/watcher/recovered_adapter.go
+++ b/internal/watcher/recovered_adapter.go
@@ -1,0 +1,105 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+// recoveredAdapter contains HealthCheck and Teardown panics for every registered
+// adapter and gives each Setup attempt one rollback opportunity. Setup and Listen
+// retain their existing engine-level behavior and are not panic recovery boundaries.
+type recoveredAdapter struct {
+	raw    WatcherAdapter
+	config AdapterConfig
+	log    *slog.Logger
+
+	teardownMu   sync.Mutex
+	teardownDone bool
+	teardownErr  error
+	healthPanic  atomic.Bool
+}
+
+func newRecoveredAdapter(raw WatcherAdapter, config AdapterConfig, logger *slog.Logger) WatcherAdapter {
+	return &recoveredAdapter{raw: raw, config: config, log: logger}
+}
+
+func (a *recoveredAdapter) Setup(ctx context.Context, config AdapterConfig) error {
+	// A registration is normally set up once. Resetting the teardown generation
+	// here also keeps a future explicit retry from consuming its final cleanup on
+	// an earlier failed attempt.
+	a.teardownMu.Lock()
+	a.teardownDone = false
+	a.teardownErr = nil
+	a.teardownMu.Unlock()
+
+	err := a.raw.Setup(ctx, config)
+	if err != nil {
+		// Setup is not transactional. Roll back partial resources here; engines
+		// that skip failed entries and engines that teardown every entry both
+		// compose with the decorator's exactly-once Teardown.
+		if cleanupErr := a.Teardown(); cleanupErr != nil {
+			a.log.Warn("adapter_failed_setup_cleanup_error",
+				slog.String("watcher", a.config.Name),
+				slog.String("type", a.config.Type),
+				slog.String("error", cleanupErr.Error()),
+			)
+		}
+	}
+	return err
+}
+
+func (a *recoveredAdapter) Listen(ctx context.Context, events chan<- Event) error {
+	return a.raw.Listen(ctx, events)
+}
+
+func (a *recoveredAdapter) Teardown() (err error) {
+	a.teardownMu.Lock()
+	defer a.teardownMu.Unlock()
+	if a.teardownDone {
+		return a.teardownErr
+	}
+	a.teardownDone = true
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			a.logPanic("adapter_teardown_panic", recovered)
+			a.teardownErr = fmt.Errorf("watcher adapter teardown panic (%T)", recovered)
+			err = a.teardownErr
+		}
+	}()
+	a.teardownErr = a.raw.Teardown()
+	return a.teardownErr
+}
+
+func (a *recoveredAdapter) HealthCheck() (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if a.healthPanic.CompareAndSwap(false, true) {
+				a.logPanic("adapter_health_panic", recovered)
+			}
+			err = fmt.Errorf("watcher adapter health check panic (%T)", recovered)
+		}
+	}()
+	err = a.raw.HealthCheck()
+	if err == nil {
+		a.healthPanic.Store(false)
+	}
+	return err
+}
+
+// logPanic intentionally records only the dynamic type. runtime.Stack captures
+// the current goroutine without serializing the recovered value, which may
+// contain credentials.
+func (a *recoveredAdapter) logPanic(event string, recovered any) {
+	stack := make([]byte, 64<<10)
+	n := runtime.Stack(stack, false)
+	a.log.Error(event,
+		slog.String("watcher", a.config.Name),
+		slog.String("type", a.config.Type),
+		slog.String("panic_type", fmt.Sprintf("%T", recovered)),
+		slog.String("stack", string(stack[:n])),
+	)
+}

--- a/internal/watcher/webhook.go
+++ b/internal/watcher/webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -173,6 +174,9 @@ func (a *WebhookAdapter) HealthCheck() error {
 	a.mu.RLock()
 	addr := a.addr
 	a.mu.RUnlock()
+	if addr == "" {
+		return fmt.Errorf("webhook: adapter is not initialized")
+	}
 
 	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 	if err != nil {


### PR DESCRIPTION
Contains watcher adapter recovery failures so health-check and teardown panics cannot stop sibling adapters. Cleans up partial setup attempts exactly once, fails closed for uninitialized adapters, sanitizes panic reporting, and rate-limits repeated recovery diagnostics.  

Fixes #1886


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health checks for GitHub, Gmail, and webhook integrations by detecting incomplete or invalid setup earlier.
  * Prevented adapter health-check and cleanup failures from interrupting other monitoring operations.
  * Improved recovery and retry handling after partial setup failures.
  * Added safeguards against repeated error logging during recurring failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

