### PR TITLE
fix(ssh): make remote session identity location-aware

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -554,11 +554,58 @@ func ResolveSession(identifier string, instances []*session.Instance) (*session.
 
 	var matches []*session.Instance
 
-	// Try exact title match first
+	// An identifier written in the explicit [user@]host:/path form is answered
+	// by where sessions RUN, ahead of every other rule.
+	//
+	// That form is what the ambiguity messages below print and tell the user to
+	// retype. A title is free text, so a session titled "bob@host-b:/opt/app-b"
+	// could shadow the session actually running at that location — the
+	// supposedly unambiguous answer selecting the wrong session. A session
+	// cannot occupy a location by accident, so the location is the stronger
+	// claim on this syntax.
+	//
+	// It yields when nothing runs at the named location: the identifier can then
+	// only have meant a title or an ID, so no existing session becomes
+	// unaddressable because of the precedence.
+	if want, explicit := session.ParseLocation(identifier); explicit {
+		var locationMatches []*session.Instance
+		for _, inst := range instances {
+			if session.LocationOf(inst) == want {
+				locationMatches = append(locationMatches, inst)
+			}
+		}
+		if len(locationMatches) == 1 {
+			return locationMatches[0], "", ""
+		}
+		if len(locationMatches) > 1 {
+			return nil, fmt.Sprintf("location '%s' has multiple sessions:\n  - %s\nUse title or ID to specify.",
+				identifier, strings.Join(describeLocations(locationMatches), "\n  - ")), ErrCodeAmbiguous
+		}
+	}
+
+	// Try exact title match.
+	//
+	// Every match is collected rather than returning the first: duplicate
+	// detection is location-aware, so one title at two DIFFERENT locations is a
+	// state the CLI creates by design (two `add --ssh` runs from one controller
+	// directory without -t keep the same directory-derived title). Returning the
+	// first holder made `session <title> stop` act on an arbitrary one of two
+	// sessions on two different hosts, silently. A title is what every
+	// documented workflow types, so it gets the same ambiguity report the
+	// location branch gives — naming each location, which is how the user
+	// addresses the one they meant.
+	var titleMatches []*session.Instance
 	for _, inst := range instances {
 		if inst.Title == identifier {
-			return inst, "", ""
+			titleMatches = append(titleMatches, inst)
 		}
+	}
+	if len(titleMatches) == 1 {
+		return titleMatches[0], "", ""
+	}
+	if len(titleMatches) > 1 {
+		return nil, fmt.Sprintf("title '%s' is held by multiple sessions:\n  - %s\nUse the session ID, or rename one of them.",
+			identifier, strings.Join(describeLocations(titleMatches), "\n  - ")), ErrCodeAmbiguous
 	}
 
 	// Try ID prefix match (minimum 6 chars for prefix to avoid too many matches)
@@ -583,12 +630,30 @@ func ResolveSession(identifier string, instances []*session.Instance) (*session.
 			identifier, strings.Join(names, "\n  - ")), ErrCodeAmbiguous
 	}
 
-	// Try path match - collect all sessions at this path
-	var pathMatches []*session.Instance
+	// Try location match - collect all sessions that RUN at this location.
+	// Location, not ProjectPath: an --ssh session stores a local placeholder in
+	// ProjectPath, so the remote path it really runs at was unaddressable while
+	// the placeholder matched every remote session at once (#1852 site 1).
+	var pathMatches, localPathMatches []*session.Instance
 	for _, inst := range instances {
-		if inst.ProjectPath == identifier {
+		if instanceAtLocationIdentifier(inst, identifier) {
 			pathMatches = append(pathMatches, inst)
+			if session.LocationOf(inst).IsLocal() {
+				localPathMatches = append(localPathMatches, inst)
+			}
 		}
+	}
+
+	// A BARE path resolves against local sessions first. Making a bare path
+	// match SSHRemotePath is what lets `agent-deck session /srv/app-a` reach the
+	// remote session running there (#1852 site 1), but remote paths routinely
+	// mirror local ones — and `agent-deck <path>` is the documented way to
+	// address the session in the current directory, so registering an unrelated
+	// remote session at the same absolute path must not take that away. A path
+	// typed on THIS machine means this machine; the remote session at it stays
+	// addressable through the explicit [user@]host:/path form handled above.
+	if len(localPathMatches) > 0 {
+		pathMatches = localPathMatches
 	}
 
 	if len(pathMatches) == 1 {
@@ -596,12 +661,8 @@ func ResolveSession(identifier string, instances []*session.Instance) (*session.
 	}
 
 	if len(pathMatches) > 1 {
-		var names []string
-		for _, m := range pathMatches {
-			names = append(names, fmt.Sprintf("%s (%s)", m.Title, m.ID[:12]))
-		}
 		return nil, fmt.Sprintf("path '%s' has multiple sessions:\n  - %s\nUse title or ID to specify.",
-			identifier, strings.Join(names, "\n  - ")), ErrCodeAmbiguous
+			identifier, strings.Join(describeLocations(pathMatches), "\n  - ")), ErrCodeAmbiguous
 	}
 
 	return nil, fmt.Sprintf("session '%s' not found", identifier), ErrCodeNotFound

--- a/cmd/agent-deck/issue1850_add_duplicate_test.go
+++ b/cmd/agent-deck/issue1850_add_duplicate_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for https://github.com/asheshgoplani/agent-deck/issues/1850.
+//
+//  1. An exact duplicate registration was reported as success (exit 0, --json
+//     ignored entirely), so a script could not tell "created" from "already
+//     existed". `launch` already reported ALREADY_EXISTS and exited 1.
+//  2. A same-location registration without -t renamed silently, leaving a
+//     mystery "project (2)" with no trace of where it came from.
+//  3. --ssh sessions collided with each other even when genuinely different,
+//     and the rename message named the local placeholder directory.
+
+// --- 1. Exact duplicate ------------------------------------------------------
+
+// TestDecideAddTitle_ExactDuplicateIsRefused pins that an exact duplicate is a
+// refusal carrying the existing session, not a silent success.
+func TestDecideAddTitle_ExactDuplicateIsRefused(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "existing-1", Title: "dup", ProjectPath: "/path/to/project"},
+	}
+
+	d := decideAddTitle(instances, "dup", localLocation("/path/to/project"), true)
+
+	if d.Duplicate == nil {
+		t.Fatal("exact duplicate (same title, same location) was not refused")
+	}
+	if d.Duplicate.ID != "existing-1" {
+		t.Fatalf("duplicate names session %s, want existing-1", d.Duplicate.ID)
+	}
+	if d.RenamedFrom != "" {
+		t.Errorf("an explicit -t must never be auto-renamed; got RenamedFrom=%q", d.RenamedFrom)
+	}
+}
+
+// TestDecideAddTitle_DuplicateUsesAlreadyExistsCode pins the CLI contract the
+// issue asks for: the same ALREADY_EXISTS code `launch` uses, with a message
+// naming the existing session so a caller can act on it.
+func TestDecideAddTitle_DuplicateUsesAlreadyExistsCode(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "existing-1", Title: "dup", ProjectPath: "/path/to/project"},
+	}
+	d := decideAddTitle(instances, "dup", localLocation("/path/to/project"), true)
+
+	msg, code := d.DuplicateError()
+	if code != ErrCodeAlreadyExists {
+		t.Errorf("duplicate error code = %q, want %q", code, ErrCodeAlreadyExists)
+	}
+	for _, want := range []string{"dup", "existing-1", "/path/to/project"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("duplicate message does not name %q: %s", want, msg)
+		}
+	}
+}
+
+// TestDecideAddTitle_DuplicateJSONPayload pins that --json gets a structured
+// signal rather than being ignored on this path.
+func TestDecideAddTitle_DuplicateJSONPayload(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "existing-1", Title: "dup", ProjectPath: "/path/to/project"},
+	}
+	d := decideAddTitle(instances, "dup", localLocation("/path/to/project"), true)
+
+	out := NewCLIOutput(true, false)
+	raw := captureStdout(t, func() {
+		msg, code := d.DuplicateError()
+		out.ErrorWithData(msg, code, d.DuplicateJSONFields())
+	})
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("--json duplicate output is not JSON (%v): %s", err, raw)
+	}
+	if payload["success"] != false {
+		t.Errorf("payload success = %v, want false", payload["success"])
+	}
+	if payload["code"] != ErrCodeAlreadyExists {
+		t.Errorf("payload code = %v, want %s", payload["code"], ErrCodeAlreadyExists)
+	}
+	if payload["existing_id"] != "existing-1" {
+		t.Errorf("payload existing_id = %v, want existing-1", payload["existing_id"])
+	}
+	if payload["location"] != "/path/to/project" {
+		t.Errorf("payload location = %v, want /path/to/project", payload["location"])
+	}
+}
+
+// TestDecideAddTitle_RemoteDuplicateJSONNamesTheRemote: a machine consumer of a
+// remote duplicate needs the host and remote dir, not the placeholder.
+func TestDecideAddTitle_RemoteDuplicateJSONNamesTheRemote(t *testing.T) {
+	instances := []*session.Instance{sshInstance("existing-1", "shared", "alice@host-a", "/srv/app-a")}
+	d := decideAddTitle(instances, "shared", remoteLocation("alice@host-a", "/srv/app-a"), true)
+
+	fields := d.DuplicateJSONFields()
+	if fields["ssh_host"] != "alice@host-a" {
+		t.Errorf("ssh_host = %v, want alice@host-a", fields["ssh_host"])
+	}
+	if fields["ssh_remote_path"] != "/srv/app-a" {
+		t.Errorf("ssh_remote_path = %v, want /srv/app-a", fields["ssh_remote_path"])
+	}
+	if fields["location"] != "alice@host-a:/srv/app-a" {
+		t.Errorf("location = %v, want alice@host-a:/srv/app-a", fields["location"])
+	}
+}
+
+// --- 2. Visible auto-rename --------------------------------------------------
+
+// TestDecideAddTitle_SameLocationWithoutTitleIsRenamedVisibly keeps two agents
+// on one checkout working while leaving a trace.
+func TestDecideAddTitle_SameLocationWithoutTitleIsRenamedVisibly(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "existing-1", Title: "project", ProjectPath: "/path/to/project"},
+	}
+
+	d := decideAddTitle(instances, "project", localLocation("/path/to/project"), false)
+
+	if d.Duplicate != nil {
+		t.Fatal("a second session at the same location without -t must still be created")
+	}
+	if d.Title != "project (2)" {
+		t.Fatalf("title = %q, want %q", d.Title, "project (2)")
+	}
+	if d.RenamedFrom != "project" {
+		t.Fatalf("RenamedFrom = %q, want %q — the rename must leave a trace", d.RenamedFrom, "project")
+	}
+
+	warning := d.RenameWarning()
+	for _, want := range []string{"project", "project (2)", "/path/to/project"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("rename warning does not name %q: %s", want, warning)
+		}
+	}
+}
+
+// TestDecideAddTitle_NoRenameWhenLocationIsFree guards the silent common case.
+func TestDecideAddTitle_NoRenameWhenLocationIsFree(t *testing.T) {
+	d := decideAddTitle(nil, "project", localLocation("/path/to/project"), false)
+
+	if d.Title != "project" || d.RenamedFrom != "" || d.Duplicate != nil {
+		t.Fatalf("a first registration must be silent: %+v", d)
+	}
+	if d.RenameWarning() != "" {
+		t.Errorf("RenameWarning() must be empty when nothing was renamed, got %q", d.RenameWarning())
+	}
+}
+
+// --- 3. --ssh sessions -------------------------------------------------------
+
+// TestDecideAddTitle_RemoteSessionsOnDifferentHostsAreNotDuplicates is the exact
+// scenario from the report: same title, different host, different remote
+// directory, both registered from one local directory.
+func TestDecideAddTitle_RemoteSessionsOnDifferentHostsAreNotDuplicates(t *testing.T) {
+	instances := []*session.Instance{sshInstance("existing-1", "shared", "alice@host-a", "/srv/app-a")}
+
+	d := decideAddTitle(instances, "shared", remoteLocation("bob@host-b", "/opt/app-b"), true)
+
+	if d.Duplicate != nil {
+		t.Fatalf("bob@host-b:/opt/app-b refused as a duplicate of %s — different host, different remote dir", d.Duplicate.ID)
+	}
+	if d.RenamedFrom != "" {
+		t.Errorf("no rename should fire either; got RenamedFrom=%q", d.RenamedFrom)
+	}
+}
+
+// TestDecideAddTitle_SameHostDifferentRemotePathsAreNotDuplicates covers the
+// other half of requirement 3.
+func TestDecideAddTitle_SameHostDifferentRemotePathsAreNotDuplicates(t *testing.T) {
+	instances := []*session.Instance{sshInstance("existing-1", "shared", "alice@host-a", "/srv/app-a")}
+
+	d := decideAddTitle(instances, "shared", remoteLocation("alice@host-a", "/srv/app-b"), true)
+	if d.Duplicate != nil {
+		t.Fatalf("same host but a different remote path was refused as a duplicate of %s", d.Duplicate.ID)
+	}
+}
+
+// TestDecideAddTitle_LocalAndRemoteAtOnePathAreNeverDuplicates: a local session
+// at the placeholder path and a remote session registered from it are in
+// different places.
+func TestDecideAddTitle_LocalAndRemoteAtOnePathAreNeverDuplicates(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "local-1", Title: "shared", ProjectPath: controllerCWD},
+	}
+
+	d := decideAddTitle(instances, "shared", remoteLocation("alice@host-a", controllerCWD), true)
+	if d.Duplicate != nil {
+		t.Fatalf("a remote session was refused as a duplicate of the LOCAL session %s at the same path string", d.Duplicate.ID)
+	}
+}
+
+// TestDecideAddTitle_RemoteDuplicateNamesHostAndRemoteDir pins the message
+// content: naming the local placeholder tells the user nothing about the
+// collision.
+func TestDecideAddTitle_RemoteDuplicateNamesHostAndRemoteDir(t *testing.T) {
+	instances := []*session.Instance{sshInstance("existing-1", "shared", "alice@host-a", "/srv/app-a")}
+
+	d := decideAddTitle(instances, "shared", remoteLocation("alice@host-a", "/srv/app-a"), true)
+	if d.Duplicate == nil {
+		t.Fatal("same title at the same host and remote path must still be a duplicate")
+	}
+
+	msg, _ := d.DuplicateError()
+	if !strings.Contains(msg, "alice@host-a:/srv/app-a") {
+		t.Errorf("duplicate message does not name the remote location: %s", msg)
+	}
+	if strings.Contains(msg, controllerCWD) {
+		t.Errorf("duplicate message names the local placeholder %s, which has nothing to do with the collision: %s", controllerCWD, msg)
+	}
+}
+
+// TestDecideAddTitle_RemoteRenameWarningNamesRemoteLocation covers the same for
+// the auto-rename path (required behaviour 2).
+func TestDecideAddTitle_RemoteRenameWarningNamesRemoteLocation(t *testing.T) {
+	instances := []*session.Instance{sshInstance("existing-1", "app", "alice@host-a", "/srv/app-a")}
+
+	d := decideAddTitle(instances, "app", remoteLocation("alice@host-a", "/srv/app-a"), false)
+	if d.RenamedFrom != "app" || d.Title != "app (2)" {
+		t.Fatalf("expected a visible rename at the same remote location, got %+v", d)
+	}
+	warning := d.RenameWarning()
+	if !strings.Contains(warning, "alice@host-a:/srv/app-a") {
+		t.Errorf("rename warning does not name the remote location: %s", warning)
+	}
+	if strings.Contains(warning, controllerCWD) {
+		t.Errorf("rename warning names the local placeholder %s: %s", controllerCWD, warning)
+	}
+}
+
+// TestDecideAddTitle_RemoteHomeSpellingsAreOneLocation ties the CLI decision to
+// the canonical-path rule: `--remote-path ~` and no --remote-path at all name
+// the same directory, so they must collide with each other.
+func TestDecideAddTitle_RemoteHomeSpellingsAreOneLocation(t *testing.T) {
+	instances := []*session.Instance{sshInstance("existing-1", "home", "alice@host-a", "")}
+
+	d := decideAddTitle(instances, "home", remoteLocation("alice@host-a", "~"), true)
+	if d.Duplicate == nil {
+		t.Fatal(`--remote-path "~" was not recognised as the same location as no --remote-path, but both run in the remote home`)
+	}
+
+	// ...while a directory UNDER the remote home is its own place.
+	d = decideAddTitle(instances, "home", remoteLocation("alice@host-a", "~/work"), true)
+	if d.Duplicate != nil {
+		t.Fatalf("~/work was folded onto the remote home itself (conflict with %s)", d.Duplicate.ID)
+	}
+}

--- a/cmd/agent-deck/issue1852_projectpath_sites_test.go
+++ b/cmd/agent-deck/issue1852_projectpath_sites_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for https://github.com/asheshgoplani/agent-deck/issues/1852.
+//
+// Five sites identified a session by comparing Instance.ProjectPath, which for
+// an --ssh session is only a local placeholder defaulting to the controller's
+// working directory. Each of them could match the wrong session or refuse a
+// right one.
+
+// --- Sites 2 and 3: worktree occupancy ---------------------------------------
+
+// TestLocalSessionPaths_ExcludesRemotePlaceholder pins the harmful direction
+// called out in the issue: in the cleanup path a genuinely orphaned worktree was
+// skipped as in-use because a remote session's placeholder equalled it.
+func TestLocalSessionPaths_ExcludesRemotePlaceholder(t *testing.T) {
+	orphan := "/home/dev/repo-worktrees/feature-x"
+
+	remote := sshInstance("aaaaaaaaaaaaaaaa", "remote", "alice@host-a", "/srv/app-a")
+	remote.ProjectPath = orphan // registered from inside the orphaned worktree dir
+
+	paths := localSessionPaths([]*session.Instance{remote})
+	if paths[orphan] {
+		t.Fatalf("orphaned worktree %s counted as occupied by a remote session's placeholder — cleanup would never report it", orphan)
+	}
+}
+
+// TestLocalSessionPaths_KeepsLocalAndWorktreePaths guards the useful half.
+func TestLocalSessionPaths_KeepsLocalAndWorktreePaths(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "a", Title: "local", ProjectPath: "/home/dev/repo"},
+		{ID: "b", Title: "wt", ProjectPath: "/home/dev/repo", WorktreePath: "/home/dev/repo-worktrees/feature-y"},
+	}
+
+	paths := localSessionPaths(instances)
+	for _, want := range []string{"/home/dev/repo", "/home/dev/repo-worktrees/feature-y"} {
+		if !paths[want] {
+			t.Errorf("localSessionPaths dropped occupied path %s", want)
+		}
+	}
+}
+
+// TestLocalSessionPaths_RemoteWorktreePathStillCounts: WorktreePath is a real
+// local checkout even when the session that owns it runs remotely, so it must
+// keep counting as occupied.
+func TestLocalSessionPaths_RemoteWorktreePathStillCounts(t *testing.T) {
+	remote := sshInstance("a", "remote", "alice@host-a", "/srv/app-a")
+	remote.WorktreePath = "/home/dev/repo-worktrees/feature-z"
+
+	paths := localSessionPaths([]*session.Instance{remote})
+	if !paths[remote.WorktreePath] {
+		t.Error("a real local worktree stopped counting as occupied because its session runs remotely")
+	}
+}
+
+// --- Site 4: findSessionByTmux path fallback ---------------------------------
+
+// TestLocalSessionsAtPath_TmuxFallbackIgnoresRemote pins the fallback used for
+// non-agentdeck tmux sessions: a pane's cwd is a local path, so a remote session
+// must never be attributed to it.
+func TestLocalSessionsAtPath_TmuxFallbackIgnoresRemote(t *testing.T) {
+	instances := []*session.Instance{
+		sshInstance("aaaaaaaaaaaaaaaa", "remote", "alice@host-a", "/srv/app-a"),
+	}
+
+	if got := localSessionsAtPath(instances, controllerCWD); len(got) != 0 {
+		t.Fatalf("a pane at %s was attributed to remote session %s", controllerCWD, got[0].ID)
+	}
+	if got := localSessionForPaneCwd(instances, controllerCWD); got != nil {
+		t.Fatalf("localSessionForPaneCwd attributed the pane to remote session %s", got.ID)
+	}
+}
+
+// TestLocalSessionForPaneCwd_TwoLocalSessionsStillSelfDetect is review finding
+// F7. Excluding remote sessions is the fix; refusing when two LOCAL sessions
+// share a cwd is a separate decision that would take self-detection away from
+// the very workflow #1850's auto-rename exists to support.
+func TestLocalSessionForPaneCwd_TwoLocalSessionsStillSelfDetect(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "a", Title: "one", ProjectPath: "/home/dev/repo"},
+		{ID: "b", Title: "two", ProjectPath: "/home/dev/repo"},
+		sshInstance("c", "remote", "alice@host-a", "/srv/app-a"),
+	}
+
+	got := localSessionForPaneCwd(instances, "/home/dev/repo")
+	if got == nil {
+		t.Fatal("two LOCAL sessions in one directory now resolve to NOTHING — a pane there can no longer detect the session it sits in (F7)")
+	}
+	if got.ID != "a" {
+		t.Fatalf("pane cwd resolved to %s, want the first registered local session 'a'", got.ID)
+	}
+}
+
+// --- Site 5: `try` occupancy check -------------------------------------------
+
+// TestLocalSessionsAtPath_TryIgnoresRemote pins site 5: `try` has no --ssh
+// support, so a remote session whose placeholder equals the experiment path must
+// not be adopted and started.
+func TestLocalSessionsAtPath_TryIgnoresRemote(t *testing.T) {
+	expPath := "/home/dev/experiments/spike"
+
+	remote := sshInstance("aaaaaaaaaaaaaaaa", "remote", "alice@host-a", "/srv/app-a")
+	remote.ProjectPath = expPath
+
+	if got := localSessionsAtPath([]*session.Instance{remote}, expPath); len(got) != 0 {
+		t.Fatalf("`try %s` would have started remote session %s", expPath, got[0].ID)
+	}
+
+	local := &session.Instance{ID: "bbbbbbbbbbbbbbbb", Title: "spike", ProjectPath: expPath}
+	got := localSessionsAtPath([]*session.Instance{remote, local}, expPath)
+	if len(got) != 1 || got[0].ID != local.ID {
+		t.Fatalf("`try %s` did not pick the local session; got %v", expPath, got)
+	}
+}
+
+// --- The identifier parser ---------------------------------------------------
+
+func TestParseLocation(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantOK   bool
+		wantHost string
+		wantPath string
+	}{
+		{"alice@host-a:/srv/app", true, "alice@host-a", "/srv/app"},
+		{"host-a:/srv/app/", true, "host-a", "/srv/app"},
+		{"host-a:~/app", true, "host-a", "~/app"},
+		{"host-a:~", true, "host-a", ""},    // the remote home, canonical form
+		{"/srv/app", false, "", ""},         // bare path
+		{"C:\\src\\project", false, "", ""}, // windows drive letter
+		{"foo:bar", false, "", ""},          // relative remote path — not a location
+		{":/srv/app", false, "", ""},        // no host
+		{"/home/a:/srv/app", false, "", ""}, // host part contains a slash
+		{"my session", false, "", ""},       // title-ish
+	}
+	for _, c := range cases {
+		got, ok := session.ParseLocation(c.in)
+		if ok != c.wantOK {
+			t.Errorf("ParseLocation(%q) ok = %v, want %v", c.in, ok, c.wantOK)
+			continue
+		}
+		if ok && got != session.RemoteLocation(c.wantHost, c.wantPath) {
+			t.Errorf("ParseLocation(%q) = %+v, want host %q path %q", c.in, got, c.wantHost, c.wantPath)
+		}
+	}
+}

--- a/cmd/agent-deck/issue1853_set_title_duplicate_test.go
+++ b/cmd/agent-deck/issue1853_set_title_duplicate_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for https://github.com/asheshgoplani/agent-deck/issues/1853.
+//
+// `session set <id> title <new>` had no collision check on either side of its
+// SetField call, so it could rename a session onto a title another session
+// already holds at the same location — the exact state `add` and `launch`
+// refuse. Title plus location is what the CLI treats as a session's identity, so
+// the result is two sessions neither of which is addressable by title:
+// ResolveSession reports ErrCodeAmbiguous for both (pinned in
+// TestResolveSession_TitleHeldTwiceIsAmbiguous).
+//
+//	agent-deck add -t alpha /tmp/proj
+//	agent-deck add -t beta  /tmp/proj
+//	agent-deck session set <beta-id> title alpha    # used to succeed
+//	agent-deck add -t alpha /tmp/proj               # refused, exit 1
+
+// TestTitleConflictAt_RejectsTitleHeldAtSameLocation is the reported case.
+func TestTitleConflictAt_RejectsTitleHeldAtSameLocation(t *testing.T) {
+	alpha := &session.Instance{ID: "alpha-id", Title: "alpha", ProjectPath: "/tmp/proj"}
+	beta := &session.Instance{ID: "beta-id", Title: "beta", ProjectPath: "/tmp/proj"}
+	instances := []*session.Instance{alpha, beta}
+
+	conflict := titleConflictAt(instances, beta, "alpha")
+	if conflict == nil {
+		t.Fatal("renaming beta onto alpha at the same location was allowed; add and launch both refuse it")
+	}
+	if conflict.ID != "alpha-id" {
+		t.Fatalf("conflict names %s, want alpha-id — the message must name the existing session so the user can act on it", conflict.ID)
+	}
+}
+
+// TestTitleConflictAt_AllowsSameTitleAtDifferentLocation keeps the useful case:
+// one title per location, not one title globally.
+func TestTitleConflictAt_AllowsSameTitleAtDifferentLocation(t *testing.T) {
+	alpha := &session.Instance{ID: "alpha-id", Title: "alpha", ProjectPath: "/tmp/proj-a"}
+	beta := &session.Instance{ID: "beta-id", Title: "beta", ProjectPath: "/tmp/proj-b"}
+	instances := []*session.Instance{alpha, beta}
+
+	if conflict := titleConflictAt(instances, beta, "alpha"); conflict != nil {
+		t.Fatalf("renaming to a title held at a DIFFERENT location was refused (conflict=%s)", conflict.ID)
+	}
+}
+
+// TestCheckTitleConflict_AllowsRenameToOwnTitle: a no-op rename must not report
+// the session as its own conflict.
+func TestCheckTitleConflict_AllowsRenameToOwnTitle(t *testing.T) {
+	alpha := &session.Instance{ID: "alpha-id", Title: "alpha", ProjectPath: "/tmp/proj"}
+	instances := []*session.Instance{alpha}
+
+	if msg, _ := checkTitleConflict(instances, alpha, "alpha"); msg != "" {
+		t.Fatalf("a session was reported as a conflict with itself: %s", msg)
+	}
+}
+
+// TestTitleConflictAt_RemoteSessionsOnDifferentHostsDoNotConflict: the same
+// location rule the rest of the epic uses — a remote session's ProjectPath is a
+// placeholder, so two remote sessions sharing one must not block each other.
+func TestTitleConflictAt_RemoteSessionsOnDifferentHostsDoNotConflict(t *testing.T) {
+	a := sshInstance("a-id", "alpha", "alice@host-a", "/srv/app-a")
+	b := sshInstance("b-id", "beta", "bob@host-b", "/opt/app-b")
+	instances := []*session.Instance{a, b}
+
+	if conflict := titleConflictAt(instances, b, "alpha"); conflict != nil {
+		t.Fatalf("two remote sessions on different hosts blocked each other's title (conflict=%s)", conflict.ID)
+	}
+}
+
+// TestTitleConflictAt_SameRemoteLocationConflicts is the remote half of the
+// refusal.
+func TestTitleConflictAt_SameRemoteLocationConflicts(t *testing.T) {
+	a := &session.Instance{
+		ID: "a-id", Title: "alpha", ProjectPath: "/home/dev/cwd-one",
+		SSHHost: "alice@host-a", SSHRemotePath: "/srv/app",
+	}
+	b := &session.Instance{
+		ID: "b-id", Title: "beta", ProjectPath: "/home/dev/cwd-two",
+		SSHHost: "alice@host-a", SSHRemotePath: "/srv/app",
+	}
+	instances := []*session.Instance{a, b}
+
+	conflict := titleConflictAt(instances, b, "alpha")
+	if conflict == nil {
+		t.Fatal("two sessions at the same host and remote path were allowed to share a title")
+	}
+	if conflict.ID != "a-id" {
+		t.Fatalf("conflict names %s, want a-id", conflict.ID)
+	}
+}
+
+// TestCheckTitleConflict_UsesAlreadyExistsCode pins the CLI contract shared by
+// all three commands that can refuse this (review finding F8): `add`, `rename`
+// and `session set <id> title` must answer with one code, or a --json consumer
+// has to special-case whichever is different. `rename` used to answer
+// INVALID_OPERATION.
+func TestCheckTitleConflict_UsesAlreadyExistsCode(t *testing.T) {
+	alpha := &session.Instance{ID: "alpha-id", Title: "alpha", ProjectPath: "/tmp/proj"}
+	beta := &session.Instance{ID: "beta-id", Title: "beta", ProjectPath: "/tmp/proj"}
+	instances := []*session.Instance{alpha, beta}
+
+	msg, code := checkTitleConflict(instances, beta, "alpha")
+	if code != ErrCodeAlreadyExists {
+		t.Errorf("code = %q, want %q", code, ErrCodeAlreadyExists)
+	}
+	for _, want := range []string{"alpha", "alpha-id", "/tmp/proj"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message does not name %q: %s", want, msg)
+		}
+	}
+
+	// The `add` path must answer with the same code for the same condition.
+	d := decideAddTitle(instances, "alpha", localLocation("/tmp/proj"), true)
+	_, addCode := d.DuplicateError()
+	if addCode != code {
+		t.Errorf("add answers %q where rename/session-set answer %q for the identical collision", addCode, code)
+	}
+}
+
+// TestCheckTitleConflict_RemoteMessageNamesTheRemoteLocation: the refusal has to
+// tell the user WHERE the collision is, and for a remote session that is the
+// host and remote dir.
+func TestCheckTitleConflict_RemoteMessageNamesTheRemoteLocation(t *testing.T) {
+	a := sshInstance("a-id", "alpha", "alice@host-a", "/srv/app")
+	b := sshInstance("b-id", "beta", "alice@host-a", "/srv/app")
+
+	msg, _ := checkTitleConflict([]*session.Instance{a, b}, b, "alpha")
+	if !strings.Contains(msg, "alice@host-a:/srv/app") {
+		t.Errorf("refusal does not name the remote location: %s", msg)
+	}
+	if strings.Contains(msg, controllerCWD) {
+		t.Errorf("refusal names the local placeholder %s: %s", controllerCWD, msg)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -321,7 +321,7 @@ func handleLaunch(profile string, args []string) {
 	}
 
 	// Load sessions
-	storage, instances, groups, err := loadSessionData(profile)
+	storage, instances, _, err := loadSessionData(profile)
 	if err != nil {
 		out.Error(err.Error(), ErrCodeNotFound)
 		os.Exit(1)
@@ -398,7 +398,8 @@ func handleLaunch(profile string, args []string) {
 		out.Error(reloadErr.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
-	instances, groups = freshInstances, freshGroups
+	instances = freshInstances
+	groups := freshGroups
 
 	launchDecision := decideAddTitle(instances, sessionTitle, localLocation(path), userProvidedTitle)
 	if launchDecision.Duplicate != nil {

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -393,9 +393,12 @@ func handleLaunch(profile string, args []string) {
 		}
 	}
 	defer releaseLaunchRegistration()
-	if freshInstances, freshGroups, loadErr := storage.LoadWithGroups(); loadErr == nil {
-		instances, groups = freshInstances, freshGroups
+	freshInstances, freshGroups, reloadErr := reloadForRegistration(storage)
+	if reloadErr != nil {
+		out.Error(reloadErr.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
+	instances, groups = freshInstances, freshGroups
 
 	launchDecision := decideAddTitle(instances, sessionTitle, localLocation(path), userProvidedTitle)
 	if launchDecision.Duplicate != nil {

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -371,18 +371,41 @@ func handleLaunch(profile string, args []string) {
 		sessionTitle = filepath.Base(path)
 	}
 
-	// Check for duplicate and generate unique title
+	// Check for duplicate and generate unique title.
+	//
+	// Same read-decide-write window `add` has (see handleAdd): the list loaded
+	// above answers "is this (title, location) taken?" and the insert happens
+	// much later, so a concurrent registration can take the pair in between.
+	// The lock covers goroutines and separate processes; the re-read inside it
+	// is what makes the answer current. `launch` has no --ssh flag, so its
+	// location is always local — but it shares the predicate with `add` so the
+	// two can never disagree about what a duplicate is.
 	userProvidedTitle := (mergeFlags(*title, *titleShort) != "")
-	if !userProvidedTitle {
-		sessionTitle = generateUniqueTitle(instances, sessionTitle, path)
-	} else {
-		if isDupe, existingInst := isDuplicateSession(instances, sessionTitle, path); isDupe {
-			out.Error(
-				fmt.Sprintf("session already exists: %s (%s)", existingInst.Title, existingInst.ID),
-				ErrCodeAlreadyExists,
-			)
-			os.Exit(1)
+	launchRegLock, launchRegLockErr := session.AcquireRegistrationLock(profile)
+	if launchRegLockErr != nil {
+		out.Error(fmt.Sprintf("failed to acquire session registration lock: %v", launchRegLockErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	releaseLaunchRegistration := func() {
+		if launchRegLock != nil {
+			launchRegLock.Release()
+			launchRegLock = nil
 		}
+	}
+	defer releaseLaunchRegistration()
+	if freshInstances, freshGroups, loadErr := storage.LoadWithGroups(); loadErr == nil {
+		instances, groups = freshInstances, freshGroups
+	}
+
+	launchDecision := decideAddTitle(instances, sessionTitle, localLocation(path), userProvidedTitle)
+	if launchDecision.Duplicate != nil {
+		msg, code := launchDecision.DuplicateError()
+		out.ErrorWithData(msg, code, launchDecision.DuplicateJSONFields())
+		os.Exit(1)
+	}
+	sessionTitle = launchDecision.Title
+	if warning := launchDecision.RenameWarning(); warning != "" && !*jsonOutput && !quietMode {
+		fmt.Fprintln(os.Stderr, warning)
 	}
 
 	// Create new instance
@@ -543,6 +566,9 @@ func handleLaunch(profile string, args []string) {
 		out.Error(fmt.Sprintf("failed to save session: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
+	// The (title, location) pair is now taken in the state db; the start and
+	// attach below must not hold the lock for other registrations.
+	releaseLaunchRegistration()
 
 	// Attach MCPs if specified
 	if len(mcpFlags) > 0 {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1727,9 +1727,15 @@ func handleAdd(profile string, args []string) {
 		}
 	}
 	defer releaseRegistration()
-	if freshInstances, freshGroups, loadErr := storage.LoadWithGroups(); loadErr == nil {
-		instances, groups = freshInstances, freshGroups
+	freshInstances, freshGroups, reloadErr := reloadForRegistration(storage)
+	if reloadErr != nil {
+		// Never fall back to the pre-lock snapshot: that is the stale list the
+		// lock exists to invalidate, and `add` would then rewrite the whole
+		// instances table from it, erasing any row registered in between.
+		out.Error(reloadErr.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
+	instances, groups = freshInstances, freshGroups
 
 	// Where the session will ACTUALLY run. For an --ssh session `path` is only a
 	// local placeholder (it defaults to the controller's working directory), so
@@ -2559,7 +2565,7 @@ func handleRename(profile string, args []string) {
 		os.Exit(1)
 	}
 	defer regLock.Release()
-	instances, groups, err := storage.LoadWithGroups()
+	instances, groups, err := reloadForRegistration(storage)
 	if err != nil {
 		out.Error(err.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1184,58 +1184,11 @@ func reorderArgsForFlagParsing(args []string) []string {
 	return append(flags, positional...)
 }
 
-// isDuplicateSession checks if a session with the same title AND path already exists.
-// Returns (isDuplicate, existingInstance)
-// Paths are normalized by removing trailing slashes for comparison.
-func isDuplicateSession(instances []*session.Instance, title, path string) (bool, *session.Instance) {
-	// Normalize path by removing trailing slash (except for root "/")
-	normalizedPath := strings.TrimSuffix(path, "/")
-	if normalizedPath == "" {
-		normalizedPath = "/"
-	}
-
-	for _, inst := range instances {
-		// Normalize existing path for comparison
-		existingPath := strings.TrimSuffix(inst.ProjectPath, "/")
-		if existingPath == "" {
-			existingPath = "/"
-		}
-
-		if existingPath == normalizedPath && inst.Title == title {
-			return true, inst
-		}
-	}
-	return false, nil
-}
-
-// generateUniqueTitle generates a unique title for sessions at the same path.
-// If "project" exists at path, returns "project (2)", then "project (3)", etc.
-func generateUniqueTitle(instances []*session.Instance, baseTitle, path string) string {
-	// Check if base title is available at this path
-	titleExists := func(title string) bool {
-		for _, inst := range instances {
-			if inst.ProjectPath == path && inst.Title == title {
-				return true
-			}
-		}
-		return false
-	}
-
-	if !titleExists(baseTitle) {
-		return baseTitle
-	}
-
-	// Find next available number
-	for i := 2; i <= 100; i++ { // Cap at 100 to prevent infinite loop
-		candidate := fmt.Sprintf("%s (%d)", baseTitle, i)
-		if !titleExists(candidate) {
-			return candidate
-		}
-	}
-
-	// Fallback: use timestamp
-	return fmt.Sprintf("%s (%d)", baseTitle, time.Now().Unix())
-}
+// isDuplicateSession and generateUniqueTitle moved to session_location.go, where
+// they compare WHERE A SESSION RUNS instead of its ProjectPath string. For an
+// --ssh session ProjectPath is only a local placeholder, so the old string
+// comparison reported every remote session registered from one directory as
+// co-located with every other one (#1850, #1852).
 
 // isWorktreeAlreadyExistsError detects whether git worktree creation failed because
 // the destination path already exists. This preserves friendly UX while avoiding
@@ -1747,17 +1700,67 @@ func handleAdd(profile string, args []string) {
 	userProvidedTitle := (mergeFlags(*title, *titleShort) != "")
 	isQuick := *quickCreate || *quickCreateShort
 
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	// Registration is a read-decide-write window: the instance list loaded at
+	// the top of this function answers "is this (title, location) taken?", and
+	// the INSERT happens hundreds of lines later. A concurrent `add`/`launch`
+	// can take the pair in between, so two racing `add -t dup <path>` runs would
+	// both see "free" and both create — the exact state #1850 makes `add`
+	// refuse — and two racing bumps would pick the same "(2)".
+	//
+	// The lock closes that window for goroutines AND for separate processes; the
+	// re-read below is the half that matters, because a list loaded before the
+	// lock is the stale snapshot the lock exists to invalidate. Released
+	// explicitly right after the save so an interactive `--attach` does not hold
+	// it for the length of the attach.
+	regLock, regLockErr := session.AcquireRegistrationLock(profile)
+	if regLockErr != nil {
+		out.Error(fmt.Sprintf("failed to acquire session registration lock: %v", regLockErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	releaseRegistration := func() {
+		if regLock != nil {
+			regLock.Release()
+			regLock = nil
+		}
+	}
+	defer releaseRegistration()
+	if freshInstances, freshGroups, loadErr := storage.LoadWithGroups(); loadErr == nil {
+		instances, groups = freshInstances, freshGroups
+	}
+
+	// Where the session will ACTUALLY run. For an --ssh session `path` is only a
+	// local placeholder (it defaults to the controller's working directory), so
+	// deciding identity from it makes every remote session registered from one
+	// directory look co-located with every other one (#1850 case 3). These are
+	// the same two flag values assigned verbatim to the instance below, so the
+	// decision and what gets stored cannot skew.
+	addLocation := localLocation(path)
+	if *sshHost != "" {
+		addLocation = remoteLocation(*sshHost, *sshRemotePath)
+	}
+
 	if isQuick && !userProvidedTitle {
 		// Quick mode: use auto-generated adjective-noun name
 		sessionTitle = session.GenerateUniqueSessionName(instances, sessionGroup)
-	} else if !userProvidedTitle {
-		// User didn't provide title - auto-generate unique title for this path
-		sessionTitle = generateUniqueTitle(instances, sessionTitle, path)
 	} else {
-		// User provided explicit title - check for exact duplicate (same title AND path)
-		if isDupe, existingInst := isDuplicateSession(instances, sessionTitle, path); isDupe {
-			fmt.Printf("Session already exists with same title and path: %s (%s)\n", existingInst.Title, existingInst.ID)
-			os.Exit(0)
+		decision := decideAddTitle(instances, sessionTitle, addLocation, userProvidedTitle)
+		if decision.Duplicate != nil {
+			// #1850 case 1: this used to print a line and exit 0, with --json
+			// ignored entirely, so a script could not tell "created" from
+			// "already existed". Same ALREADY_EXISTS contract as `launch`.
+			msg, code := decision.DuplicateError()
+			out.ErrorWithData(msg, code, decision.DuplicateJSONFields())
+			os.Exit(1)
+		}
+		sessionTitle = decision.Title
+		// #1850 case 2: the rename stays (two agents on one checkout is a real
+		// workflow) but it leaves a trace. stderr keeps stdout and the exit code
+		// unchanged; --json and -q suppress it.
+		if warning := decision.RenameWarning(); warning != "" && !*jsonOutput && !quietMode {
+			fmt.Fprintln(os.Stderr, warning)
 		}
 	}
 
@@ -1943,6 +1946,9 @@ func handleAdd(profile string, args []string) {
 		fmt.Printf("Error: failed to save session: %v\n", err)
 		os.Exit(1)
 	}
+	// The (title, location) pair is now taken in the state db; everything below
+	// is per-session setup that no other registration can race with.
+	releaseRegistration()
 
 	// Attach MCPs if specified
 	if len(mcpFlags) > 0 {
@@ -1966,8 +1972,8 @@ func handleAdd(profile string, args []string) {
 		}
 	}
 
-	quietMode := *quiet || *quietShort
-	out := NewCLIOutput(*jsonOutput, quietMode)
+	// quietMode / out are established before the registration decision above,
+	// which is the first place `add` can refuse.
 
 	// --attach: create → start → attach, so `add --attach` "instantly opens"
 	// the new session in one step. Refused loudly (never silently) under
@@ -2538,7 +2544,22 @@ func handleRename(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	storage, instances, groups, err := loadSessionData(profile)
+	storage, _, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// A rename takes a (title, location) pair, exactly as `add` does, so it runs
+	// under the same lock and reads the instance list INSIDE it — otherwise two
+	// concurrent renames onto one title both see it free.
+	regLock, regLockErr := session.AcquireRegistrationLock(profile)
+	if regLockErr != nil {
+		out.Error(fmt.Sprintf("failed to acquire session registration lock: %v", regLockErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	defer regLock.Release()
+	instances, groups, err := storage.LoadWithGroups()
 	if err != nil {
 		out.Error(err.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
@@ -2555,15 +2576,14 @@ func handleRename(profile string, args []string) {
 
 	oldTitle := inst.Title
 
-	// Check for duplicate title at the same path (but allow renaming to same title)
-	if newTitle != oldTitle {
-		if isDup, existing := isDuplicateSession(instances, newTitle, inst.ProjectPath); isDup {
-			out.Error(
-				fmt.Sprintf("session with title %q already exists at path %q (id: %s)", newTitle, inst.ProjectPath, existing.ID),
-				ErrCodeInvalidOperation,
-			)
-			os.Exit(1)
-		}
+	// Refuse a title another session already holds at the SAME LOCATION (but
+	// allow renaming to the title this session already has). checkTitleConflict
+	// is shared with `add` and `session set <id> title` so all three answer
+	// ALREADY_EXISTS; this call site used to answer INVALID_OPERATION for the
+	// identical condition, forcing --json consumers to special-case `rename`.
+	if msg, code := checkTitleConflict(instances, inst, newTitle); msg != "" {
+		out.Error(msg, code)
+		os.Exit(1)
 	}
 
 	// Route through SetField so the rename also sets TitleLocked — a direct

--- a/cmd/agent-deck/registration_race_test.go
+++ b/cmd/agent-deck/registration_race_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -382,4 +383,137 @@ func TestRegistrationLock_SerializesAndIsPerProfile(t *testing.T) {
 	// Release must be safe on a nil lock (the error paths return one).
 	var nilLock *session.RegistrationLock
 	nilLock.Release()
+}
+
+// --- Review round 1, finding F2: a failed re-read must abort ------------------
+//
+// The reload inside the lock used to be `if fresh, g, err := ...; err == nil`,
+// so a transient failure (SQLITE_BUSY) silently left the caller running on the
+// PRE-LOCK snapshot — the exact stale list the lock exists to invalidate. That
+// gives up the atomicity the lock was taken for, and in `add` the subsequent
+// whole-list SaveWithGroups rewrites the table from that stale slice, erasing
+// any row registered in between.
+
+// TestReloadForRegistration_PropagatesFailure pins the seam itself: a broken
+// storage handle must produce an error, never an empty-but-usable list that a
+// caller would mistake for "no sessions registered".
+func TestReloadForRegistration_PropagatesFailure(t *testing.T) {
+	profile := sandboxProfile(t)
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	// Closing the handle makes LoadWithGroups fail the way a transient
+	// SQLITE_BUSY would, without having to provoke real contention.
+	if err := storage.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	instances, groups, err := reloadForRegistration(storage)
+	if err == nil {
+		t.Fatalf("a failed re-read returned no error (instances=%v groups=%v); the caller would proceed on the stale pre-lock snapshot", instances, groups)
+	}
+	if instances != nil || groups != nil {
+		t.Errorf("a failed re-read must return no list at all, got instances=%v groups=%v", instances, groups)
+	}
+}
+
+// TestConcurrentAdd_FailedReloadNeverCreatesADuplicate is the racing test.
+//
+// Half the racers' in-lock re-reads fail. The invariant is not "every racer
+// succeeds" — it is that a racer which cannot see current state never
+// REGISTERS. So exactly one session may exist at the end, never two, and the
+// title must never be taken twice.
+func TestConcurrentAdd_FailedReloadNeverCreatesADuplicate(t *testing.T) {
+	profile := sandboxProfile(t)
+	loc := session.LocalLocation(t.TempDir())
+
+	var mu sync.Mutex
+	var reloadCalls int
+	orig := reloadForRegistrationFn
+	reloadForRegistrationFn = func(s *session.Storage) ([]*session.Instance, []*session.GroupData, error) {
+		mu.Lock()
+		reloadCalls++
+		fail := reloadCalls%2 == 0
+		mu.Unlock()
+		if fail {
+			return nil, nil, errors.New("statedb: wal mode: database is locked (5) (SQLITE_BUSY)")
+		}
+		return orig(s)
+	}
+	t.Cleanup(func() { reloadForRegistrationFn = orig })
+
+	const racers = 8
+	var created, aborted int
+	var start, done sync.WaitGroup
+	start.Add(1)
+
+	for i := 0; i < racers; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+
+			lock, err := session.AcquireRegistrationLock(profile)
+			if err != nil {
+				t.Errorf("lock: %v", err)
+				return
+			}
+			defer lock.Release()
+
+			storage, err := session.NewStorageWithProfile(profile)
+			if err != nil {
+				t.Errorf("storage: %v", err)
+				return
+			}
+			defer func() { _ = storage.Close() }()
+
+			// This is the shape every registration path now has: abort on a
+			// failed re-read rather than fall back to a pre-lock snapshot.
+			instances, groups, err := reloadForRegistration(storage)
+			if err != nil {
+				mu.Lock()
+				aborted++
+				mu.Unlock()
+				return
+			}
+
+			d := decideAddTitle(instances, "dup", loc, true)
+			if d.Duplicate != nil {
+				return
+			}
+			instances = append(instances, session.NewInstance(d.Title, loc.Path))
+			if err := storage.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, groups)); err != nil {
+				t.Errorf("save: %v", err)
+				return
+			}
+			mu.Lock()
+			created++
+			mu.Unlock()
+		}()
+	}
+
+	start.Done()
+	done.Wait()
+
+	if aborted == 0 {
+		t.Fatal("no racer hit the injected reload failure; this test is not exercising the path it claims to")
+	}
+	if created > 1 {
+		t.Fatalf("%d sessions were created for one (title, location); a racer registered on a stale snapshot after its re-read failed", created)
+	}
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(instances) > 1 {
+		t.Fatalf("state db holds %d sessions, want at most 1", len(instances))
+	}
 }

--- a/cmd/agent-deck/registration_race_test.go
+++ b/cmd/agent-deck/registration_race_test.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Required behaviour 8: registration, rename and identity decisions must be safe
+// under concurrent add/launch.
+//
+// The hazard is a read-decide-write window, not a data race on a variable:
+// `add` LOADS the instance list, asks "is this (title, location) taken?", and
+// INSERTs much later. Between the question and the answer another process can
+// take the pair, so two racing `add -t dup <path>` runs both see "free" and both
+// create — the exact state #1850 makes `add` refuse — and two racing bumps pick
+// the same "(2)".
+//
+// What makes each decision safe: session.AcquireRegistrationLock(profile), held
+// across [load → decide → insert], with the instance list re-read INSIDE the
+// lock. The in-process sync.Mutex covers goroutines (the TUI, tests) and the
+// advisory flock on a per-profile lockfile covers separate agent-deck processes.
+//
+// These tests run the racing sequence the CLI runs. Run them with -race.
+
+// registerConcurrently performs the same [lock → reload → decide → insert →
+// release] sequence handleAdd performs, from n goroutines at once.
+func registerConcurrently(t *testing.T, profile string, n int, title string, loc session.Location, userProvidedTitle bool) (created []string, refused int) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+
+	for i := 0; i < n; i++ {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+
+			// The lock comes first, then the storage handle. Opening N
+			// connections at once makes SQLite's WAL-mode setup itself contend
+			// (SQLITE_BUSY at open), which is a property of the storage layer
+			// and not what this test is about — the window under test is
+			// [load -> decide -> insert].
+			lock, err := session.AcquireRegistrationLock(profile)
+			if err != nil {
+				t.Errorf("acquire registration lock: %v", err)
+				return
+			}
+			defer lock.Release()
+
+			storage, err := session.NewStorageWithProfile(profile)
+			if err != nil {
+				t.Errorf("storage: %v", err)
+				return
+			}
+			defer func() { _ = storage.Close() }()
+
+			instances, groups, err := storage.LoadWithGroups()
+			if err != nil {
+				t.Errorf("load: %v", err)
+				return
+			}
+
+			d := decideAddTitle(instances, title, loc, userProvidedTitle)
+			if d.Duplicate != nil {
+				mu.Lock()
+				refused++
+				mu.Unlock()
+				return
+			}
+
+			inst := session.NewInstance(d.Title, loc.Path)
+			if !loc.IsLocal() {
+				inst.SSHHost = loc.Host
+				inst.SSHRemotePath = loc.Path
+				inst.ProjectPath = controllerCWD
+			}
+			instances = append(instances, inst)
+			if err := storage.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, groups)); err != nil {
+				t.Errorf("save: %v", err)
+				return
+			}
+
+			mu.Lock()
+			created = append(created, d.Title)
+			mu.Unlock()
+		}(i)
+	}
+
+	start.Done()
+	done.Wait()
+	return created, refused
+}
+
+func sandboxProfile(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	return "race_test_profile"
+}
+
+// TestConcurrentAdd_ExplicitTitleRegistersExactlyOnce is the #1850 refusal under
+// contention: N concurrent `add -t dup <path>` must produce exactly one session,
+// with every other attempt refused. Without the lock, several would see "free"
+// and create, which is the state `add` exists to prevent.
+func TestConcurrentAdd_ExplicitTitleRegistersExactlyOnce(t *testing.T) {
+	profile := sandboxProfile(t)
+	loc := session.LocalLocation(t.TempDir())
+
+	const racers = 8
+	created, refused := registerConcurrently(t, profile, racers, "dup", loc, true)
+
+	if len(created) != 1 {
+		t.Fatalf("concurrent `add -t dup` created %d sessions (%v); exactly one must win and the rest must be refused", len(created), created)
+	}
+	if refused != racers-1 {
+		t.Fatalf("refused %d of %d racers, want %d", refused, racers, racers-1)
+	}
+
+	// And the persisted state agrees.
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer func() { _ = storage.Close() }()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("state db holds %d sessions after the race, want 1", len(instances))
+	}
+}
+
+// TestConcurrentAdd_AutoRenameNeverCollides is the #1850 rename path under
+// contention: without -t every racer is created, but each must get a DISTINCT
+// title. Two racers both reading "project is taken, project (2) is free" would
+// otherwise both register "project (2)".
+func TestConcurrentAdd_AutoRenameNeverCollides(t *testing.T) {
+	profile := sandboxProfile(t)
+	loc := session.LocalLocation(t.TempDir())
+
+	const racers = 8
+	created, refused := registerConcurrently(t, profile, racers, "project", loc, false)
+
+	if refused != 0 {
+		t.Fatalf("the auto-rename path must never refuse; %d racers were refused", refused)
+	}
+	if len(created) != racers {
+		t.Fatalf("created %d sessions, want %d", len(created), racers)
+	}
+
+	seen := map[string]bool{}
+	for _, title := range created {
+		if seen[title] {
+			t.Fatalf("two concurrent registrations both took the title %q at one location", title)
+		}
+		seen[title] = true
+	}
+	if !seen["project"] {
+		t.Errorf("no racer got the unbumped base title; created=%v", created)
+	}
+}
+
+// TestConcurrentAdd_DifferentRemoteLocationsDoNotBlockEachOther: the lock must
+// serialize the DECISION without turning genuinely independent registrations
+// into duplicates. Same title, different hosts — all must be created.
+func TestConcurrentAdd_DifferentRemoteLocationsDoNotBlockEachOther(t *testing.T) {
+	profile := sandboxProfile(t)
+
+	const racers = 6
+	var mu sync.Mutex
+	var created, refusedTitles []string
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+
+	for i := 0; i < racers; i++ {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+
+			loc := session.RemoteLocation(fmt.Sprintf("user@host-%d", i), "/srv/app")
+
+			lock, err := session.AcquireRegistrationLock(profile)
+			if err != nil {
+				t.Errorf("lock: %v", err)
+				return
+			}
+			defer lock.Release()
+
+			storage, err := session.NewStorageWithProfile(profile)
+			if err != nil {
+				t.Errorf("storage: %v", err)
+				return
+			}
+			defer func() { _ = storage.Close() }()
+
+			instances, groups, err := storage.LoadWithGroups()
+			if err != nil {
+				t.Errorf("load: %v", err)
+				return
+			}
+
+			d := decideAddTitle(instances, "shared", loc, true)
+			mu.Lock()
+			if d.Duplicate != nil {
+				refusedTitles = append(refusedTitles, loc.String())
+				mu.Unlock()
+				return
+			}
+			mu.Unlock()
+
+			inst := session.NewInstance(d.Title, controllerCWD)
+			inst.SSHHost = loc.Host
+			inst.SSHRemotePath = loc.Path
+			instances = append(instances, inst)
+			if err := storage.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, groups)); err != nil {
+				t.Errorf("save: %v", err)
+				return
+			}
+			mu.Lock()
+			created = append(created, loc.String())
+			mu.Unlock()
+		}(i)
+	}
+
+	start.Done()
+	done.Wait()
+
+	if len(refusedTitles) != 0 {
+		t.Fatalf("remote sessions on different hosts were refused as duplicates of each other: %v", refusedTitles)
+	}
+	if len(created) != racers {
+		t.Fatalf("created %d remote sessions, want %d", len(created), racers)
+	}
+}
+
+// TestConcurrentTitleRename_OnlyOneWins is required behaviour 8 for the rename
+// side (#1853): two sessions at one location racing to take the same title.
+func TestConcurrentTitleRename_OnlyOneWins(t *testing.T) {
+	profile := sandboxProfile(t)
+	dir := t.TempDir()
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	seed := []*session.Instance{
+		session.NewInstance("alpha", dir),
+		session.NewInstance("beta", dir),
+		session.NewInstance("gamma", dir),
+	}
+	if err := storage.SaveWithGroups(seed, session.NewGroupTreeWithGroups(seed, nil)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	renameTargets := []string{seed[1].ID, seed[2].ID}
+	_ = storage.Close()
+
+	var mu sync.Mutex
+	var applied int
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+
+	for _, id := range renameTargets {
+		done.Add(1)
+		go func(id string) {
+			defer done.Done()
+			start.Wait()
+
+			lock, err := session.AcquireRegistrationLock(profile)
+			if err != nil {
+				t.Errorf("lock: %v", err)
+				return
+			}
+			defer lock.Release()
+
+			s, err := session.NewStorageWithProfile(profile)
+			if err != nil {
+				t.Errorf("storage: %v", err)
+				return
+			}
+			defer func() { _ = s.Close() }()
+
+			instances, groups, err := s.LoadWithGroups()
+			if err != nil {
+				t.Errorf("load: %v", err)
+				return
+			}
+			var target *session.Instance
+			for _, inst := range instances {
+				if inst.ID == id {
+					target = inst
+				}
+			}
+			if target == nil {
+				t.Errorf("seeded session %s vanished", id)
+				return
+			}
+			if msg, _ := checkTitleConflict(instances, target, "alpha"); msg != "" {
+				return // correctly refused
+			}
+			if _, _, err := session.SetField(target, session.FieldTitle, "alpha", nil); err != nil {
+				t.Errorf("SetField: %v", err)
+				return
+			}
+			if err := s.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, groups)); err != nil {
+				t.Errorf("save: %v", err)
+				return
+			}
+			mu.Lock()
+			applied++
+			mu.Unlock()
+		}(id)
+	}
+
+	start.Done()
+	done.Wait()
+
+	if applied != 0 {
+		t.Fatalf("%d concurrent renames onto a title already held at that location were applied; every one must be refused", applied)
+	}
+
+	s, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	instances, _, err := s.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	count := 0
+	for _, inst := range instances {
+		if inst.Title == "alpha" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("%d sessions hold the title \"alpha\" at one location after the race, want 1", count)
+	}
+}
+
+// TestRegistrationLock_SerializesAndIsPerProfile pins the two properties the
+// decisions above rely on.
+func TestRegistrationLock_SerializesAndIsPerProfile(t *testing.T) {
+	sandboxProfile(t)
+
+	// Mutual exclusion: a counter incremented non-atomically under the lock must
+	// come out exact under -race.
+	var counter int
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lock, err := session.AcquireRegistrationLock("p1")
+			if err != nil {
+				t.Errorf("acquire: %v", err)
+				return
+			}
+			counter++
+			lock.Release()
+		}()
+	}
+	wg.Wait()
+	if counter != 24 {
+		t.Fatalf("counter = %d, want 24 — the registration lock did not serialize", counter)
+	}
+
+	// Release must be safe on a nil lock (the error paths return one).
+	var nilLock *session.RegistrationLock
+	nilLock.Release()
+}

--- a/cmd/agent-deck/remote_fixtures_test.go
+++ b/cmd/agent-deck/remote_fixtures_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/asheshgoplani/agent-deck/internal/session"
+
+// Shared fixtures for the --ssh identity tests. Deliberately free of any symbol
+// this epic introduces, so the test files that only use pre-existing API still
+// compile — and fail — against the unfixed merge base.
+
+// controllerCWD is what `add --ssh` actually stores in ProjectPath: the
+// controller's working directory, which has nothing to do with where the
+// session runs.
+const controllerCWD = "/home/dev/controller-cwd"
+
+func sshInstance(id, title, host, remotePath string) *session.Instance {
+	return &session.Instance{
+		ID:            id,
+		Title:         title,
+		ProjectPath:   controllerCWD, // local placeholder, not where it runs
+		SSHHost:       host,
+		SSHRemotePath: remotePath,
+	}
+}

--- a/cmd/agent-deck/resolve_session_location_test.go
+++ b/cmd/agent-deck/resolve_session_location_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// ResolveSession is the CLI's identity lookup, and it exists at the merge base —
+// so every test in this file compiles against the unfixed tree and fails there
+// for the reason the issue describes.
+//
+// It covers #1852 site 1 (a remote session addressed by the path it runs at, and
+// a local placeholder no longer matching every remote session at once) plus the
+// two addressing regressions the previous attempt at this epic shipped:
+// F3 (a title held twice silently returning the first holder) and F4 (a bare
+// local path ceasing to resolve because a remote session mirrors its path).
+
+// --- Site 1: ResolveSession path match ---------------------------------------
+
+// TestResolveSession_RemotePathIsAddressable pins the first effect: a remote
+// session could not be addressed by the path it actually runs at, because that
+// string is never stored in ProjectPath.
+func TestResolveSession_RemotePathIsAddressable(t *testing.T) {
+	instances := []*session.Instance{
+		sshInstance("aaaaaaaaaaaaaaaa", "app-a", "alice@host-a", "/srv/app-a"),
+		{ID: "bbbbbbbbbbbbbbbb", Title: "local", ProjectPath: "/home/dev/local"},
+	}
+
+	inst, errMsg, _ := ResolveSession("/srv/app-a", instances)
+	if inst == nil {
+		t.Fatalf("ResolveSession(/srv/app-a) did not find the remote session running there: %s", errMsg)
+	}
+	if inst.ID != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("ResolveSession(/srv/app-a) = %s, want the remote session", inst.ID)
+	}
+}
+
+// TestResolveSession_ExplicitHostPathForm addresses a remote session
+// unambiguously when two hosts export the same remote directory.
+func TestResolveSession_ExplicitHostPathForm(t *testing.T) {
+	instances := []*session.Instance{
+		sshInstance("aaaaaaaaaaaaaaaa", "app-a", "alice@host-a", "/srv/app"),
+		sshInstance("bbbbbbbbbbbbbbbb", "app-b", "bob@host-b", "/srv/app"),
+	}
+
+	// The bare path is genuinely ambiguous across two hosts...
+	if _, _, code := ResolveSession("/srv/app", instances); code != ErrCodeAmbiguous {
+		t.Fatalf("bare /srv/app should be AMBIGUOUS across two hosts, got code %q", code)
+	}
+
+	// ...and host:path disambiguates it.
+	inst, errMsg, _ := ResolveSession("bob@host-b:/srv/app", instances)
+	if inst == nil {
+		t.Fatalf("ResolveSession(bob@host-b:/srv/app) failed: %s", errMsg)
+	}
+	if inst.ID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("ResolveSession(bob@host-b:/srv/app) = %s, want bbbbbbbbbbbbbbbb", inst.ID)
+	}
+}
+
+// TestResolveSession_PlaceholderDoesNotMatchRemoteSessions pins the second
+// effect: several remote sessions sharing one placeholder all matched when the
+// local placeholder path was passed, producing a spurious "path has multiple
+// sessions" error for sessions that are not in the same place.
+func TestResolveSession_PlaceholderDoesNotMatchRemoteSessions(t *testing.T) {
+	instances := []*session.Instance{
+		sshInstance("aaaaaaaaaaaaaaaa", "app-a", "alice@host-a", "/srv/app-a"),
+		sshInstance("bbbbbbbbbbbbbbbb", "app-b", "bob@host-b", "/opt/app-b"),
+		{ID: "cccccccccccccccc", Title: "here", ProjectPath: controllerCWD},
+	}
+
+	inst, errMsg, code := ResolveSession(controllerCWD, instances)
+	if code == ErrCodeAmbiguous {
+		t.Fatalf("the controller's own directory was reported ambiguous because remote placeholders matched: %s", errMsg)
+	}
+	if inst == nil {
+		t.Fatalf("ResolveSession(%s) = nil (%s); the one local session there should resolve", controllerCWD, errMsg)
+	}
+	if inst.ID != "cccccccccccccccc" {
+		t.Fatalf("ResolveSession(%s) = %s, want the local session cccccccccccccccc", controllerCWD, inst.ID)
+	}
+}
+
+// TestResolveSession_AmbiguityMessageNamesLocations keeps the error actionable
+// for remote sessions: naming the local placeholder tells the user nothing.
+func TestResolveSession_AmbiguityMessageNamesLocations(t *testing.T) {
+	instances := []*session.Instance{
+		sshInstance("aaaaaaaaaaaaaaaa", "app", "alice@host-a", "/srv/app"),
+		sshInstance("bbbbbbbbbbbbbbbb", "app-two", "bob@host-b", "/srv/app"),
+	}
+
+	_, errMsg, code := ResolveSession("/srv/app", instances)
+	if code != ErrCodeAmbiguous {
+		t.Fatalf("expected AMBIGUOUS, got %q", code)
+	}
+	for _, want := range []string{"alice@host-a:/srv/app", "bob@host-b:/srv/app"} {
+		if !strings.Contains(errMsg, want) {
+			t.Errorf("ambiguity message does not name %q:\n%s", want, errMsg)
+		}
+	}
+}
+
+// TestResolveSession_LocalPathStillResolves guards the common case.
+func TestResolveSession_LocalPathStillResolves(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "aaaaaaaaaaaaaaaa", Title: "local", ProjectPath: "/home/dev/local"},
+	}
+	inst, errMsg, _ := ResolveSession("/home/dev/local", instances)
+	if inst == nil || inst.ID != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("local path lookup regressed: inst=%v err=%s", inst, errMsg)
+	}
+}
+
+// TestResolveSession_TitleHeldTwiceIsAmbiguous is review finding F3.
+//
+// Location-aware duplicate detection deliberately allows one title at two
+// DIFFERENT locations — two `add --ssh` runs from one controller directory
+// without -t keep the same directory-derived title. The previous attempt made
+// that state reachable while ResolveSession's title branch still returned the
+// FIRST exact match, so `agent-deck session <title> stop` acted on an arbitrary
+// one of two sessions on two different hosts, silently. Ambiguity must be an
+// error, not a coin flip.
+func TestResolveSession_TitleHeldTwiceIsAmbiguous(t *testing.T) {
+	instances := []*session.Instance{
+		sshInstance("aaaaaaaaaaaaaaaa", "proj", "alice@host-a", "/srv/app-a"),
+		sshInstance("bbbbbbbbbbbbbbbb", "proj", "bob@host-b", "/opt/app-b"),
+	}
+
+	inst, errMsg, code := ResolveSession("proj", instances)
+	if inst != nil {
+		t.Fatalf("ResolveSession returned session %s for a title held by two sessions on two hosts — a stop/send/output would hit an arbitrary one", inst.ID)
+	}
+	if code != ErrCodeAmbiguous {
+		t.Fatalf("code = %q, want %q", code, ErrCodeAmbiguous)
+	}
+	for _, want := range []string{"alice@host-a:/srv/app-a", "bob@host-b:/opt/app-b"} {
+		if !strings.Contains(errMsg, want) {
+			t.Errorf("ambiguity message does not name %q, so the user cannot pick one:\n%s", want, errMsg)
+		}
+	}
+}
+
+// TestResolveSession_UniqueTitleStillResolves guards the overwhelmingly common
+// case against the fix above.
+func TestResolveSession_UniqueTitleStillResolves(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "aaaaaaaaaaaaaaaa", Title: "alpha", ProjectPath: "/tmp/a"},
+		{ID: "bbbbbbbbbbbbbbbb", Title: "beta", ProjectPath: "/tmp/b"},
+	}
+	inst, errMsg, _ := ResolveSession("alpha", instances)
+	if inst == nil || inst.ID != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("unique title lookup regressed: inst=%v err=%s", inst, errMsg)
+	}
+}
+
+// TestResolveSession_BareLocalPathPrefersLocalSession is review finding F4.
+//
+// Making a bare path match SSHRemotePath is what lets `agent-deck session
+// /srv/app-a` reach the remote session running there (#1852 site 1). The cost,
+// if unmanaged, is that `agent-deck <path>` — the documented way to address the
+// session in the current directory — starts reporting AMBIGUOUS as soon as an
+// unrelated remote session runs at the same absolute path, and remote paths
+// routinely mirror local ones.
+//
+// A path typed on THIS machine means this machine.
+func TestResolveSession_BareLocalPathPrefersLocalSession(t *testing.T) {
+	local := &session.Instance{ID: "aaaaaaaaaaaaaaaa", Title: "local-app", ProjectPath: "/home/dev/app"}
+	remote := sshInstance("bbbbbbbbbbbbbbbb", "remote-app", "alice@host-a", "/home/dev/app")
+
+	inst, errMsg, code := ResolveSession("/home/dev/app", []*session.Instance{local, remote})
+	if inst == nil {
+		t.Fatalf("a bare local path stopped resolving because a remote session runs at the same absolute path: code=%q %s", code, errMsg)
+	}
+	if inst.ID != local.ID {
+		t.Fatalf("bare path resolved to %s, want the LOCAL session %s", inst.ID, local.ID)
+	}
+
+	// The remote session at that path stays addressable through the explicit form.
+	inst, errMsg, _ = ResolveSession("alice@host-a:/home/dev/app", []*session.Instance{local, remote})
+	if inst == nil || inst.ID != remote.ID {
+		t.Fatalf("the remote session at a mirrored path is not addressable explicitly: inst=%v err=%s", inst, errMsg)
+	}
+}
+
+// TestResolveSession_BareRemotePathStillResolvesWhenNoLocalSessionIsThere keeps
+// the #1852 site-1 feature working: preferring local matches must not mean
+// "ignore remote matches".
+func TestResolveSession_BareRemotePathStillResolvesWhenNoLocalSessionIsThere(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "aaaaaaaaaaaaaaaa", Title: "local", ProjectPath: "/home/dev/other"},
+		sshInstance("bbbbbbbbbbbbbbbb", "remote", "alice@host-a", "/srv/app-a"),
+	}
+	inst, errMsg, _ := ResolveSession("/srv/app-a", instances)
+	if inst == nil || inst.ID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("a bare remote path with no local session at it should resolve to the remote session: inst=%v err=%s", inst, errMsg)
+	}
+}
+
+// TestResolveSession_ExplicitLocationBeatsAFreeTextTitle closes the hole the
+// round-2 cross-model review found: the ambiguity messages advertise the
+// [user@]host:/path form as the way to pick one session, but a TITLE is free
+// text, so a session titled "bob@host-b:/opt/app-b" could shadow the session
+// actually running there — the supposedly unambiguous answer selecting the wrong
+// session. A session cannot occupy a location by accident.
+func TestResolveSession_ExplicitLocationBeatsAFreeTextTitle(t *testing.T) {
+	decoy := &session.Instance{ID: "dddddddddddddddd", Title: "bob@host-b:/opt/app-b", ProjectPath: "/tmp/decoy"}
+	real := sshInstance("bbbbbbbbbbbbbbbb", "app-b", "bob@host-b", "/opt/app-b")
+
+	inst, errMsg, _ := ResolveSession("bob@host-b:/opt/app-b", []*session.Instance{decoy, real})
+	if inst == nil {
+		t.Fatalf("explicit location form did not resolve: %s", errMsg)
+	}
+	if inst.ID != real.ID {
+		t.Fatalf("a session TITLED like a location shadowed the session actually running there (got %s, want %s)", inst.ID, real.ID)
+	}
+}
+
+// TestResolveSession_ExplicitLocationYieldsToTitleWhenNothingRunsThere: the
+// precedence must not make an existing session unaddressable. When no session
+// runs at the named location, the identifier can only have meant a title or ID.
+func TestResolveSession_ExplicitLocationYieldsToTitleWhenNothingRunsThere(t *testing.T) {
+	oddTitle := &session.Instance{ID: "dddddddddddddddd", Title: "bob@host-b:/opt/app-b", ProjectPath: "/tmp/decoy"}
+
+	inst, errMsg, _ := ResolveSession("bob@host-b:/opt/app-b", []*session.Instance{oddTitle})
+	if inst == nil || inst.ID != oddTitle.ID {
+		t.Fatalf("a session whose title looks like a location became unaddressable: inst=%v err=%s", inst, errMsg)
+	}
+}
+
+// TestResolveSession_RemoteHomeIsAddressableByTheStringWePrint ties the
+// addressing surface to the canonical-path rule. `add --ssh alice@host-a` with
+// no --remote-path stores "", and every message prints that as "alice@host-a:~".
+// If "~" did not fold back to "", the ambiguity messages would hand the user an
+// identifier that answers NOT_FOUND.
+func TestResolveSession_RemoteHomeIsAddressableByTheStringWePrint(t *testing.T) {
+	remote := sshInstance("aaaaaaaaaaaaaaaa", "home-session", "alice@host-a", "")
+
+	// "alice@host-a:~" is the literal string every duplicate, rename and
+	// ambiguity message prints for a session registered with no --remote-path.
+	// (That rendering is pinned separately by TestLocationString_RoundTrips… in
+	// internal/session.)
+	const rendered = "alice@host-a:~"
+
+	inst, errMsg, _ := ResolveSession(rendered, []*session.Instance{remote})
+	if inst == nil || inst.ID != remote.ID {
+		t.Fatalf("the identifier the CLI prints does not resolve back to the session: inst=%v err=%s", inst, errMsg)
+	}
+}
+
+// TestResolveSession_IDPrefixStillWins guards the branch order: an ID prefix
+// must keep working, and it is checked after titles as before.
+func TestResolveSession_IDPrefixStillWins(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "abcdef123456789", Title: "one", ProjectPath: "/tmp/a"},
+	}
+	inst, errMsg, _ := ResolveSession("abcdef", instances)
+	if inst == nil || inst.ID != "abcdef123456789" {
+		t.Fatalf("ID prefix lookup regressed: inst=%v err=%s", inst, errMsg)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1927,9 +1927,12 @@ func handleSessionSet(profile string, args []string) {
 			os.Exit(1)
 		}
 		defer regLock.Release()
-		if freshInstances, freshGroups, loadErr := storage.LoadWithGroups(); loadErr == nil {
-			instances, groupsData = freshInstances, freshGroups
+		freshInstances, freshGroups, reloadErr := reloadForRegistration(storage)
+		if reloadErr != nil {
+			out.Error(reloadErr.Error(), ErrCodeInvalidOperation)
+			os.Exit(1)
 		}
+		instances, groupsData = freshInstances, freshGroups
 	}
 
 	// Resolve session

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1915,6 +1915,23 @@ func handleSessionSet(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	// A title change takes a (title, location) pair exactly as `add` does, so it
+	// runs under the same profile registration lock and re-reads the instance
+	// list INSIDE it. Without that, two concurrent renames onto one title both
+	// see it free and both apply. Only the title field needs it; every other
+	// field is per-session state that cannot collide.
+	if field == session.FieldTitle {
+		regLock, regLockErr := session.AcquireRegistrationLock(profile)
+		if regLockErr != nil {
+			out.Error(fmt.Sprintf("failed to acquire session registration lock: %v", regLockErr), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		defer regLock.Release()
+		if freshInstances, freshGroups, loadErr := storage.LoadWithGroups(); loadErr == nil {
+			instances, groupsData = freshInstances, freshGroups
+		}
+	}
+
 	// Resolve session
 	inst, errMsg, errCode := ResolveSession(identifier, instances)
 	if inst == nil {
@@ -1924,6 +1941,20 @@ func handleSessionSet(profile string, args []string) {
 		}
 		os.Exit(1)
 		return // unreachable, satisfies staticcheck SA5011
+	}
+
+	// #1853: `session set <id> title` had no collision check on either side of
+	// the SetField call, so it could rename a session onto a title another
+	// session already holds at the same location — the exact state `add` and
+	// `launch` refuse. Two sessions sharing a title at one location are then
+	// both unaddressable by title, because ResolveSession can only report
+	// ErrCodeAmbiguous. Same predicate and same ALREADY_EXISTS code as `add` and
+	// `rename`, naming the existing session's ID so the user can act on it.
+	if field == session.FieldTitle {
+		if msg, code := checkTitleConflict(instances, inst, value); msg != "" {
+			out.Error(msg, code)
+			os.Exit(1)
+		}
 	}
 
 	// #924 follow-up: the conversation follows the account. Capture the old
@@ -2093,14 +2124,11 @@ func findSessionByTmux(instances []*session.Instance) *session.Instance {
 		}
 	}
 
-	// Try to find by path (only for non-agentdeck tmux sessions)
-	for _, inst := range instances {
-		if inst.ProjectPath == currentPath {
-			return inst
-		}
-	}
-
-	return nil
+	// Try to find by path (only for non-agentdeck tmux sessions). The pane's cwd
+	// is a LOCAL path, so only a local session can own it — a remote session's
+	// ProjectPath is a placeholder that frequently equals the controller's
+	// working directory (#1852 site 4).
+	return localSessionForPaneCwd(instances, currentPath)
 }
 
 // showTmuxSessionInfo shows information about the current tmux session (unregistered)
@@ -4102,6 +4130,21 @@ func streamSessionSend(inst *session.Instance, sessionRef, profile string, sentA
 			session.NoteClaudeSessionIDFromOwnPane(inst)
 			inst.ClaudeDetectedAt = time.Now()
 		}
+	}
+
+	// A remote session's transcript is on the remote host, so the poll below can
+	// only ever time out. Say why now instead of after the full timeout with
+	// "transcript not found", which reads as "not written yet" and sends the
+	// user looking on the wrong machine (#1851).
+	if !resolvedInst.TranscriptIsResolvableLocally() {
+		errEv := map[string]interface{}{
+			"type":    "error",
+			"message": fmt.Sprintf("session runs on %s; its Claude transcript is not on this machine, so there is nothing to stream", resolvedInst.SSHHost),
+			"ts":      time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		b, _ := json.Marshal(errEv)
+		fmt.Println(string(b))
+		return fmt.Errorf("session runs on %s; its Claude transcript is not on this machine", resolvedInst.SSHHost)
 	}
 
 	var jsonlPath string

--- a/cmd/agent-deck/session_location.go
+++ b/cmd/agent-deck/session_location.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// This file is the CLI half of "a session's identity is WHERE IT RUNS".
+//
+// The location primitive itself lives in internal/session (session.Location,
+// session.CanonicalRemotePath, session.RemoteCDPrefix) because identity and
+// EXECUTION have to agree: the canonical spelling of a remote path is the same
+// rule that decides which directory the remote command actually `cd`s into. The
+// helpers below are the CLI-facing decisions built on top of it — duplicate
+// detection, the visible auto-rename, title-conflict refusal, and the
+// local-only path queries.
+
+// locationOf returns where inst actually runs.
+func locationOf(inst *session.Instance) session.Location { return session.LocationOf(inst) }
+
+// localLocation builds the location of a session that runs on this machine.
+func localLocation(path string) session.Location { return session.LocalLocation(path) }
+
+// remoteLocation builds the location of an --ssh session.
+func remoteLocation(host, remotePath string) session.Location {
+	return session.RemoteLocation(host, remotePath)
+}
+
+// isDuplicateSessionAt reports whether an existing session holds this title at
+// this location. Title plus location is what the CLI treats as a session's
+// identity (see ResolveSession), so this is the single predicate every
+// identity-collision check uses.
+func isDuplicateSessionAt(instances []*session.Instance, title string, loc session.Location) (bool, *session.Instance) {
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if inst.Title == title && locationOf(inst) == loc {
+			return true, inst
+		}
+	}
+	return false, nil
+}
+
+// isDuplicateSession is the local-session form of isDuplicateSessionAt, kept for
+// the callers that can only ever register on this machine. Note that a local
+// path no longer matches a remote session's placeholder.
+func isDuplicateSession(instances []*session.Instance, title, path string) (bool, *session.Instance) {
+	return isDuplicateSessionAt(instances, title, localLocation(path))
+}
+
+// generateUniqueTitleAt generates a unique title for sessions at one location.
+// If "project" already exists there, returns "project (2)", then "project (3)".
+// Comparing by location keeps the bump from firing against a remote session that
+// merely stores the same local placeholder.
+func generateUniqueTitleAt(instances []*session.Instance, baseTitle string, loc session.Location) string {
+	titleExists := func(title string) bool {
+		exists, _ := isDuplicateSessionAt(instances, title, loc)
+		return exists
+	}
+
+	if !titleExists(baseTitle) {
+		return baseTitle
+	}
+
+	for i := 2; i <= 100; i++ { // Cap at 100 to prevent infinite loop
+		candidate := fmt.Sprintf("%s (%d)", baseTitle, i)
+		if !titleExists(candidate) {
+			return candidate
+		}
+	}
+
+	// Fallback: use timestamp
+	return fmt.Sprintf("%s (%d)", baseTitle, time.Now().Unix())
+}
+
+// generateUniqueTitle is the local-session form of generateUniqueTitleAt.
+func generateUniqueTitle(instances []*session.Instance, baseTitle, path string) string {
+	return generateUniqueTitleAt(instances, baseTitle, localLocation(path))
+}
+
+// addTitleDecision is what `add` decided about the requested title at the
+// location the session will actually run in. It exists so the three outcomes the
+// CLI must distinguish — created, created-under-a-different-name, refused — are
+// one value the caller renders, rather than three scattered branches with three
+// different exit codes (issue #1850).
+type addTitleDecision struct {
+	// Title is the title to register. Equals the requested title unless
+	// RenamedFrom is set.
+	Title string
+	// Duplicate is the existing session holding the requested title at this
+	// location. Non-nil means "refuse": the caller reports ALREADY_EXISTS and
+	// exits non-zero, matching `launch`.
+	Duplicate *session.Instance
+	// RenamedFrom is the requested title when it was auto-bumped, empty
+	// otherwise. Two agents on one checkout is a legitimate workflow, so the
+	// bump stays — but it must leave a trace.
+	RenamedFrom string
+	// Location is where the session runs, used for messages.
+	Location session.Location
+}
+
+// decideAddTitle resolves the requested title against the sessions already
+// registered at loc. An explicit -t is never renamed behind the user's back: it
+// is either accepted or refused as a duplicate. Without -t the title is a
+// derived default, so bumping it is reasonable.
+//
+// Concurrency: the caller must hold the profile registration lock
+// (session.AcquireRegistrationLock) and must have re-read `instances` while
+// holding it. This function is pure; the atomicity lives at the call site.
+func decideAddTitle(instances []*session.Instance, requested string, loc session.Location, userProvidedTitle bool) addTitleDecision {
+	d := addTitleDecision{Title: requested, Location: loc}
+
+	if userProvidedTitle {
+		if isDupe, existing := isDuplicateSessionAt(instances, requested, loc); isDupe {
+			d.Duplicate = existing
+		}
+		return d
+	}
+
+	if unique := generateUniqueTitleAt(instances, requested, loc); unique != requested {
+		d.Title = unique
+		d.RenamedFrom = requested
+	}
+	return d
+}
+
+// DuplicateError renders the refusal. The ALREADY_EXISTS code matches `launch`
+// and the convention used elsewhere in the CLI, and the message names the
+// existing session's id so the user can act on it, plus the location that
+// actually collided (host and remote directory for a remote session).
+func (d addTitleDecision) DuplicateError() (string, string) {
+	if d.Duplicate == nil {
+		return "", ""
+	}
+	return fmt.Sprintf("session already exists: %q at %s (id: %s)",
+		d.Duplicate.Title, d.Location.String(), d.Duplicate.ID), ErrCodeAlreadyExists
+}
+
+// DuplicateJSONFields are the machine-checkable fields merged into the --json
+// error payload. Before #1850 this path ignored --json entirely, so a machine
+// consumer got no structured signal at all.
+func (d addTitleDecision) DuplicateJSONFields() map[string]interface{} {
+	if d.Duplicate == nil {
+		return nil
+	}
+	fields := map[string]interface{}{
+		"existing_id":    d.Duplicate.ID,
+		"existing_title": d.Duplicate.Title,
+		"location":       d.Location.String(),
+	}
+	if !d.Location.IsLocal() {
+		fields["ssh_host"] = d.Location.Host
+		fields["ssh_remote_path"] = d.Location.Path
+	}
+	return fields
+}
+
+// RenameWarning renders the trace the silent rename used to lack. Empty when
+// nothing was renamed. The caller writes it to stderr and suppresses it under
+// --json and -q, so the exit code and stdout contract are unchanged.
+func (d addTitleDecision) RenameWarning() string {
+	if d.RenamedFrom == "" {
+		return ""
+	}
+	return fmt.Sprintf("Warning: a session titled %q already exists at %s; registering this one as %q instead. Pass -t to choose a title.",
+		d.RenamedFrom, d.Location.String(), d.Title)
+}
+
+// titleConflictAt returns the OTHER session holding newTitle at inst's location,
+// or nil when the rename is free. It is the guard `session set <id> title` was
+// missing (#1853): `add` and `launch` both refuse that state, so without it the
+// state `add` will not let you create was reachable in one command — and two
+// sessions sharing a title at one location are then both unaddressable by title,
+// because ResolveSession reports them as ErrCodeAmbiguous.
+//
+// The check lives at the CLI callers rather than in session.SetField because
+// SetField takes a single *Instance with no access to the instance list, and the
+// TUI edit dialog has no collision check of its own to inherit from.
+func titleConflictAt(instances []*session.Instance, inst *session.Instance, newTitle string) *session.Instance {
+	if inst == nil {
+		return nil
+	}
+	loc := locationOf(inst)
+	for _, other := range instances {
+		if other == nil || other.ID == inst.ID {
+			continue
+		}
+		if other.Title == newTitle && locationOf(other) == loc {
+			return other
+		}
+	}
+	return nil
+}
+
+// titleConflictError renders the refusal for titleConflictAt, using the same
+// ALREADY_EXISTS code `add` and `launch` use and naming the existing session's
+// ID so the user can act on it.
+func titleConflictError(inst *session.Instance, newTitle string, conflict *session.Instance) (string, string) {
+	return fmt.Sprintf("session with title %q already exists at %s (id: %s)",
+		newTitle, locationOf(inst).String(), conflict.ID), ErrCodeAlreadyExists
+}
+
+// checkTitleConflict is the one decision every rename path makes: it returns the
+// (message, code) pair to report when newTitle is already held by ANOTHER
+// session at inst's location, and ("", "") when the rename is free.
+//
+// `add`, `rename` and `session set <id> title` all refuse the same condition, so
+// they must report it with the same code — `rename` used to answer
+// INVALID_OPERATION where the other two answer ALREADY_EXISTS, forcing a --json
+// consumer to special-case one of the three (review finding F8). Renaming a
+// session to the title it already holds stays a no-op.
+func checkTitleConflict(instances []*session.Instance, inst *session.Instance, newTitle string) (string, string) {
+	if inst == nil || newTitle == inst.Title {
+		return "", ""
+	}
+	conflict := titleConflictAt(instances, inst, newTitle)
+	if conflict == nil {
+		return "", ""
+	}
+	return titleConflictError(inst, newTitle, conflict)
+}
+
+// instanceAtLocationIdentifier reports whether inst runs at the location the
+// user named. Matching the location's path (SSHRemotePath for a remote session,
+// ProjectPath for a local one) means `agent-deck session /srv/app-a` addresses a
+// remote session by the path it actually runs at, and the controller's local
+// placeholder no longer matches every remote session at once (#1852 site 1).
+func instanceAtLocationIdentifier(inst *session.Instance, identifier string) bool {
+	loc := locationOf(inst)
+	if want, ok := session.ParseLocation(identifier); ok {
+		return loc == want
+	}
+	return loc.Path == session.LocalLocation(identifier).Path
+}
+
+// describeLocations renders one "title (id) at <location>" line per session for
+// an ambiguity message. Naming the location — host and remote directory for a
+// remote session, not its local placeholder — is what makes the message
+// actionable: it is the identifier the user retypes to pick one.
+func describeLocations(matches []*session.Instance) []string {
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		id := m.ID
+		if len(id) > 12 {
+			id = id[:12]
+		}
+		names = append(names, fmt.Sprintf("%s (%s) at %s", m.Title, id, locationOf(m).String()))
+	}
+	return names
+}
+
+// localSessionPaths returns the set of LOCAL filesystem paths that sessions
+// occupy — project paths and worktree paths. A remote session contributes
+// nothing: its ProjectPath is a placeholder, not a checkout, so inserting it
+// makes a local worktree at that path look occupied and hides a genuinely
+// orphaned worktree from cleanup (#1852 sites 2 and 3).
+func localSessionPaths(instances []*session.Instance) map[string]bool {
+	paths := make(map[string]bool, len(instances))
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if loc := locationOf(inst); loc.IsLocal() && loc.Path != "" {
+			paths[loc.Path] = true
+		}
+		if inst.WorktreePath != "" {
+			paths[inst.WorktreePath] = true
+		}
+	}
+	return paths
+}
+
+// localSessionsAtPath returns every session that runs locally at path. Callers
+// that can only mean a local session (worktree occupancy, `try`, the tmux-cwd
+// fallback) must use this rather than comparing ProjectPath, so a remote session
+// whose placeholder happens to equal path is never picked up (#1852 sites 4
+// and 5).
+func localSessionsAtPath(instances []*session.Instance, path string) []*session.Instance {
+	want := localLocation(path)
+	var matches []*session.Instance
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if locationOf(inst) == want {
+			matches = append(matches, inst)
+		}
+	}
+	return matches
+}
+
+// localSessionForPaneCwd picks the session that owns a non-agentdeck tmux pane
+// whose cwd is path, or nil when the pane belongs to no registered session.
+//
+// A pane's cwd is a LOCAL path, so only a local session can own it: a remote
+// session's ProjectPath is a placeholder that frequently equals the controller's
+// working directory, and matching it would attribute this pane to a session
+// running on another host (#1852 site 4). That exclusion is the whole fix.
+//
+// Several LOCAL sessions at one cwd is a different question, and the answer
+// stays what it has always been — the first registered one (review finding F7).
+// Two agents on one checkout is the workflow #1850's auto-rename exists to
+// support, and refusing to self-detect there would take a feature away to buy
+// nothing: the caller only reports which session the pane sits in.
+func localSessionForPaneCwd(instances []*session.Instance, path string) *session.Instance {
+	if matches := localSessionsAtPath(instances, path); len(matches) > 0 {
+		return matches[0]
+	}
+	return nil
+}

--- a/cmd/agent-deck/session_location.go
+++ b/cmd/agent-deck/session_location.go
@@ -17,6 +17,38 @@ import (
 // detection, the visible auto-rename, title-conflict refusal, and the
 // local-only path queries.
 
+// reloadForRegistrationFn is the seam the registration paths read the instance
+// list through, indirected so tests can inject the transient failure this
+// function exists to handle.
+var reloadForRegistrationFn = defaultReloadForRegistration
+
+// reloadForRegistration re-reads the instance list while the caller holds the
+// profile registration lock.
+//
+// It returns an error rather than a stale list, and every caller must abort on
+// it. That is the whole point: the list loaded BEFORE the lock is the snapshot
+// the lock exists to invalidate, so continuing with it after a failed re-read
+// gives up exactly the atomicity the lock was taken for. Concretely (review
+// round 1, finding F2): process A loads the list, process B registers
+// (title, location), A takes the lock, A's re-read fails transiently with
+// SQLITE_BUSY — and if A proceeds on the pre-lock snapshot it accepts the same
+// (title, location) B just took. Worse, `add`'s whole-list SaveWithGroups then
+// rewrites the table from that stale slice and erases B's row.
+//
+// Failing the command is the right outcome: `add`/`launch`/`rename` are cheap to
+// retry, and a duplicate registration or a deleted sibling session is not.
+func reloadForRegistration(storage *session.Storage) ([]*session.Instance, []*session.GroupData, error) {
+	return reloadForRegistrationFn(storage)
+}
+
+func defaultReloadForRegistration(storage *session.Storage) ([]*session.Instance, []*session.GroupData, error) {
+	instances, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		return nil, nil, fmt.Errorf("re-reading sessions under the registration lock: %w", err)
+	}
+	return instances, groups, nil
+}
+
 // locationOf returns where inst actually runs.
 func locationOf(inst *session.Instance) session.Location { return session.LocationOf(inst) }
 

--- a/cmd/agent-deck/try_cmd.go
+++ b/cmd/agent-deck/try_cmd.go
@@ -116,9 +116,12 @@ func handleTry(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Check if session already exists for this path
-	for _, inst := range instances {
-		if inst.ProjectPath == exp.Path {
+	// Check if a session already exists for this path. localSessionsAtPath, not
+	// a ProjectPath comparison: `try` has no --ssh support, so it can only ever
+	// mean a LOCAL session, and a remote session whose placeholder happens to
+	// equal exp.Path would otherwise be adopted and started (#1852 site 5).
+	for _, inst := range localSessionsAtPath(instances, exp.Path) {
+		{
 			// Session exists - just start it if not running
 			if !inst.Exists() {
 				if err := inst.Start(); err != nil {

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -234,10 +234,15 @@ func handleWorktreeList(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Build session map: path -> session title
+	// Build session map: LOCAL path -> session. A remote session contributes
+	// nothing: its ProjectPath is a placeholder, not a checkout, so listing it
+	// here labels a local worktree with a session running on another host
+	// (#1852 site 2).
 	sessionByPath := make(map[string]*session.Instance)
 	for _, inst := range instances {
-		sessionByPath[inst.ProjectPath] = inst
+		if loc := locationOf(inst); loc.IsLocal() && loc.Path != "" {
+			sessionByPath[loc.Path] = inst
+		}
 		if inst.WorktreePath != "" {
 			sessionByPath[inst.WorktreePath] = inst
 		}
@@ -451,14 +456,11 @@ func handleWorktreeCleanup(profile string, args []string) {
 		cleanupBackend = backend
 		worktrees, wErr := cleanupBackend.ListWorktrees()
 		if wErr == nil {
-			// Build set of paths that sessions use
-			sessionPaths := make(map[string]bool)
-			for _, inst := range instances {
-				sessionPaths[inst.ProjectPath] = true
-				if inst.WorktreePath != "" {
-					sessionPaths[inst.WorktreePath] = true
-				}
-			}
+			// Build the set of LOCAL paths that sessions occupy. This is the
+			// harmful direction of #1852 site 3: a remote session's placeholder
+			// inserted here makes a genuinely orphaned worktree look in-use, so
+			// cleanup silently skips it forever.
+			sessionPaths := localSessionPaths(instances)
 
 			// Check each worktree (skip the first one which is usually the main repo)
 			for i, wt := range worktrees {

--- a/conductor/setup.sh
+++ b/conductor/setup.sh
@@ -24,6 +24,53 @@ ok()    { echo -e "${GREEN}[ok]${NC}    $*"; }
 warn()  { echo -e "${YELLOW}[warn]${NC}  $*"; }
 fail()  { echo -e "${RED}[fail]${NC}  $*"; exit 1; }
 
+# register_session <profile> <dir> <title>
+#
+# Issue #1854: this used to be
+#
+#   agent-deck add … 2>/dev/null && ok "registered" || warn "Could not register"
+#
+# and the warn branch told the user to do something that would fail. The python
+# existence check above it exits non-zero both when the session genuinely does
+# not exist AND when the probe itself could not run, so `add` is reached in two
+# very different situations. Since #1850 an exact duplicate exits non-zero with
+# an ALREADY_EXISTS payload, which took the warn branch; `2>/dev/null` then
+# discarded the message that said so, leaving no way to tell the outcomes apart.
+#
+# --json carries the distinction directly, so branch on the code. stderr is kept
+# on the failure path — discarding it on the one branch whose job is reporting a
+# failure is how the original message got lost. Like the original, this never
+# fails the script.
+register_session() {
+    local profile="$1" dir="$2" title="$3"
+    local out rc code
+
+    out="$(agent-deck -p "${profile}" add "${dir}" -t "${title}" -c claude -g "infra" --json 2>&1)"
+    rc=$?
+
+    if [[ ${rc} -eq 0 ]]; then
+        ok "  Session ${title} registered in ${profile}"
+        return 0
+    fi
+
+    code="$(printf '%s' "${out}" | python3 -c "
+import sys, json
+try:
+    print(json.loads(sys.stdin.read()).get('code', ''))
+except Exception:
+    print('')
+" 2>/dev/null)"
+
+    if [[ "${code}" == "ALREADY_EXISTS" ]]; then
+        ok "  Session ${title} already registered in ${profile}"
+        return 0
+    fi
+
+    warn "  Could not register ${title} (add manually from TUI)"
+    warn "    ${out}"
+    return 0
+}
+
 # --------------------------------------------------------------------------
 # Preflight checks
 # --------------------------------------------------------------------------
@@ -159,9 +206,7 @@ sys.exit(0 if found else 1)
 " 2>/dev/null; then
         ok "  Session ${SESSION_TITLE} already registered in ${PROFILE}"
     else
-        agent-deck -p "${PROFILE}" add "${PROFILE_DIR}" -t "${SESSION_TITLE}" -c claude -g "infra" 2>/dev/null && \
-            ok "  Session ${SESSION_TITLE} registered in ${PROFILE}" || \
-            warn "  Could not register ${SESSION_TITLE} (add manually from TUI)"
+        register_session "${PROFILE}" "${PROFILE_DIR}" "${SESSION_TITLE}"
     fi
 done
 

--- a/conductor/setup_register_test.go
+++ b/conductor/setup_register_test.go
@@ -1,0 +1,151 @@
+package conductor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression test for https://github.com/asheshgoplani/agent-deck/issues/1854.
+//
+// conductor/setup.sh reported "Could not register <title> (add manually from
+// TUI)" for a session that was already registered and needed nothing done — an
+// instruction that would itself fail.
+//
+// The python existence check above the `add` exits non-zero both when the
+// session genuinely does not exist AND when the probe itself could not run, so
+// `add` is reached in two very different situations. Before #1850 a duplicate
+// exited 0 and printed the ok line (wrong but harmless); #1850 made it exit
+// non-zero with an ALREADY_EXISTS payload, which took the warn branch, and
+// `2>/dev/null` discarded the message that would have said so.
+//
+// These tests drive the real register_session function out of setup.sh with a
+// fake `agent-deck` on PATH.
+
+// extractShellFunc pulls one top-level function out of a shell script so the
+// test can source it without executing the whole setup.
+func extractShellFunc(t *testing.T, script, name string) string {
+	t.Helper()
+	raw, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("read %s: %v", script, err)
+	}
+	lines := strings.Split(string(raw), "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, name+"() {") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("%s does not define %s()", script, name)
+	}
+	for i := start; i < len(lines); i++ {
+		if lines[i] == "}" {
+			return strings.Join(lines[start:i+1], "\n")
+		}
+	}
+	t.Fatalf("unterminated %s() in %s", name, script)
+	return ""
+}
+
+// runRegisterSession sources register_session with a fake `agent-deck` that
+// exits with exitCode after printing stdoutText, and returns the combined
+// output.
+func runRegisterSession(t *testing.T, exitCode int, stdoutText string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	fake := "#!/usr/bin/env bash\ncat <<'JSON'\n" + stdoutText + "\nJSON\nexit " + itoa(exitCode) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "agent-deck"), []byte(fake), 0o755); err != nil {
+		t.Fatalf("write fake agent-deck: %v", err)
+	}
+
+	body := extractShellFunc(t, "setup.sh", "register_session")
+	script := `#!/usr/bin/env bash
+set -uo pipefail
+GREEN=''; YELLOW=''; NC=''
+ok()   { echo "[ok] $*"; }
+warn() { echo "[warn] $*"; }
+` + body + `
+register_session "testprofile" "/tmp/profile-dir" "conductor-title"
+`
+	path := filepath.Join(binDir, "drive.sh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write driver: %v", err)
+	}
+
+	cmd := exec.Command("bash", path)
+	cmd.Env = append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("register_session driver failed (it must never fail the script): %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+// TestRegisterSession_AlreadyRegisteredIsNotAFailure is the reported bug.
+func TestRegisterSession_AlreadyRegisteredIsNotAFailure(t *testing.T) {
+	out := runRegisterSession(t, 1, `{"success":false,"error":"session already exists: \"conductor-title\" at /tmp/profile-dir (id: abc123)","code":"ALREADY_EXISTS"}`)
+
+	if strings.Contains(out, "Could not register") {
+		t.Fatalf("an already-registered session was reported as a registration failure, telling the user to do something that would fail:\n%s", out)
+	}
+	if !strings.Contains(out, "[ok]") {
+		t.Fatalf("an already-registered session should report ok:\n%s", out)
+	}
+	if !strings.Contains(out, "already registered") {
+		t.Errorf("the ok line should distinguish 'already registered' from 'registered':\n%s", out)
+	}
+}
+
+// TestRegisterSession_FreshRegistrationReportsOk guards the success path.
+func TestRegisterSession_FreshRegistrationReportsOk(t *testing.T) {
+	out := runRegisterSession(t, 0, `{"success":true,"id":"abc123"}`)
+
+	if !strings.Contains(out, "[ok]") || strings.Contains(out, "Could not register") {
+		t.Fatalf("a fresh registration was not reported as success:\n%s", out)
+	}
+	if strings.Contains(out, "already registered") {
+		t.Errorf("a fresh registration was reported as already registered:\n%s", out)
+	}
+}
+
+// TestRegisterSession_RealFailureStillWarnsAndShowsTheError keeps the branch
+// honest for genuine failures, and surfaces the error text that `2>/dev/null`
+// used to discard on the one path whose whole job is reporting a failure.
+func TestRegisterSession_RealFailureStillWarnsAndShowsTheError(t *testing.T) {
+	out := runRegisterSession(t, 1, `{"success":false,"error":"path does not exist: /tmp/profile-dir","code":"INVALID_OPERATION"}`)
+
+	if !strings.Contains(out, "Could not register") {
+		t.Fatalf("a genuine failure was reported as success:\n%s", out)
+	}
+	if !strings.Contains(out, "path does not exist") {
+		t.Errorf("the real error text was discarded, leaving the user nothing to act on:\n%s", out)
+	}
+}
+
+// TestRegisterSession_NonJSONFailureStillWarns: a crash that prints no JSON at
+// all must not be mistaken for ALREADY_EXISTS.
+func TestRegisterSession_NonJSONFailureStillWarns(t *testing.T) {
+	out := runRegisterSession(t, 2, `panic: something went very wrong`)
+
+	if !strings.Contains(out, "Could not register") {
+		t.Fatalf("a non-JSON crash was not reported as a failure:\n%s", out)
+	}
+}

--- a/internal/session/handoff.go
+++ b/internal/session/handoff.go
@@ -41,6 +41,14 @@ func BuildClaudeToCodexHandoffPrompt(inst *Instance, maxChars int) (string, Hand
 	if inst.ClaudeSessionID == "" {
 		return "", HandoffInfo{}, fmt.Errorf("session %q has no Claude session ID", inst.Title)
 	}
+	// `session handoff` is a conversation read, and an --ssh session's
+	// conversation is on the remote host (#1851). Resolving it here would not
+	// miss — it would hit, on whatever LOCAL session sits at the placeholder
+	// ProjectPath — and hand that session's entire transcript to another tool.
+	if !inst.TranscriptIsResolvableLocally() {
+		return "", HandoffInfo{}, fmt.Errorf("session %q runs on %s; its Claude transcript is not on this machine, so there is nothing here to hand off",
+			inst.Title, inst.SSHHost)
+	}
 
 	transcriptPath := locateHandoffTranscript(inst)
 	messages, err := readClaudeTranscriptMessages(transcriptPath)
@@ -100,6 +108,13 @@ func ClaudeTranscriptPathForInstance(inst *Instance) string {
 }
 
 func claudeTranscriptPathIn(configDir string, inst *Instance, sessionID string) string {
+	// The seam, not just the callers: this function ends with a CONSTRUCTED path
+	// when nothing is found, so for a remote session it never returns "not here"
+	// — it returns a controller path under the placeholder, which is a LOCAL
+	// session's transcript directory (#1851).
+	if !inst.TranscriptIsResolvableLocally() {
+		return ""
+	}
 	projectPath := inst.EffectiveWorkingDir()
 	if transcript := resolveClaudeTranscriptPath(configDir, projectPath, sessionID); transcript != "" {
 		return transcript

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6765,6 +6765,37 @@ func (i *Instance) ClaudeSessionIDCollidesWith(peers []*Instance) bool {
 	return false
 }
 
+// conversationIsResumable answers the question the spawn builders actually ask:
+// should this session be started with `--resume <id>` (continue the existing
+// conversation) or `--session-id <id>` (create a fresh one under that id)?
+//
+// For a LOCAL session that is the same question as "is there conversation data
+// on disk", so it delegates unchanged.
+//
+// For an --ssh session it is NOT. The transcript lives on the remote host, so
+// the controller cannot see it — and answering the local-disk question with a
+// hard false (which is the correct answer to *that* question, see
+// sessionHasConversationData) would make every remote restart emit
+// `--session-id <already-used-uuid>`, asking claude to CREATE a session that
+// already exists. That loses the conversation, or claude rejects the id
+// outright. Review round 1, finding F1.
+//
+// The controller's evidence for a remote session is the id it recorded when the
+// session last ran. A non-empty ClaudeSessionID means "this session previously
+// had this conversation", so `--resume` is the right instruction and the remote
+// claude resolves it against the remote disk — the only disk that can answer.
+// If the remote transcript is genuinely gone, claude reports that on the remote,
+// which is a far better failure than silently starting fresh over a live id.
+func conversationIsResumable(inst *Instance, sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	if inst != nil && !inst.TranscriptIsResolvableLocally() {
+		return true
+	}
+	return sessionHasConversationData(inst, sessionID)
+}
+
 // TranscriptIsResolvableLocally reports whether this instance's conversation
 // transcript can be looked up in the CONTROLLER's filesystem.
 //
@@ -8433,7 +8464,7 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	safePath := logging.SanitizeValue(i.ProjectPath)
 
 	useResume := canResumeClaudeSession(i, i.ClaudeSessionID)
-	if !useResume && i.ClaudeSessionID != "" {
+	if !useResume && i.ClaudeSessionID != "" && i.TranscriptIsResolvableLocally() {
 		time.Sleep(resumeCheckRetryDelay)
 		useResume = canResumeClaudeSession(i, i.ClaudeSessionID)
 		sessionLog.Debug(
@@ -9812,6 +9843,9 @@ func (i *Instance) bindClaudeSessionFromHook(sessionID, hookSource, hookEvent, a
 // Returns false if:
 // - File doesn't exist (nothing to resume, use --session-id)
 // - File exists but has zero "sessionId" occurrences (never interacted)
+// It answers a LOCAL-DISK question. Callers deciding "start fresh or resume?"
+// must use conversationIsResumable instead — see its doc comment for why a hard
+// false is the wrong answer for a remote session.
 func sessionHasConversationData(inst *Instance, sessionID string) bool {
 	// #1851: for an --ssh session every path below is a directory on THIS
 	// machine, keyed on the local placeholder ProjectPath — so "yes, that id has

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1403,10 +1403,13 @@ func (i *Instance) buildBashExportPrefix(skipConfigDirForCustomCommand bool) str
 	if IsClaudeConfigDirExplicitForInstance(i) && !skipConfigDirForCustomCommand {
 		// Issue #922 (reporter @bautrey): see applyWorkerScratchOverride.
 		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
-		// shellescape: the resolved config_dir lands in the same `bash -c`
-		// payload as the quoted AGENTDECK_RESOLVED_* exports below; a config_dir
-		// containing ;/$() would otherwise inject. Audit F2.
-		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", shellescape.Quote(configDir))
+		// configDirShellExpr quotes the resolved config_dir — it lands in the
+		// same `bash -c` payload as the quoted AGENTDECK_RESOLVED_* exports
+		// below, and a config_dir containing ;/$() would otherwise inject
+		// (audit F2) — and, for an --ssh session, expresses a local-home path
+		// relative to $HOME so it resolves against the REMOTE user's home
+		// instead of a local path that does not exist there (#1858).
+		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", i.configDirShellExpr(configDir))
 	}
 	prefix += i.buildResolvedAccountHintExports()
 	return prefix
@@ -1422,11 +1425,19 @@ func (i *Instance) buildBashExportPrefix(skipConfigDirForCustomCommand bool) str
 // per-session scratch path. Always emitted for claude-compatible
 // instances (including when source resolves to "default") so consumers
 // can rely on the vars being present.
+//
+// AGENTDECK_RESOLVED_CONFIG_DIR goes through configDirShellExpr for the same
+// reason CLAUDE_CONFIG_DIR does (#1858, review finding F6): the consumers are
+// hooks and statusline scripts running on the host the session runs on, so for
+// an --ssh session a literal local-home path names a directory that does not
+// exist there — and shipping two config-dir vars that disagree, with the
+// readable one wrong, is worse than shipping one. The $HOME indirection is
+// resolved by the shell that reads it, so a local session is byte-identical.
 func (i *Instance) buildResolvedAccountHintExports() string {
 	resolved, source := GetClaudeConfigDirSourceForInstance(i)
 	return fmt.Sprintf(
 		"export AGENTDECK_RESOLVED_CONFIG_DIR=%s; export AGENTDECK_RESOLVED_GROUP=%s; export AGENTDECK_RESOLVED_SOURCE=%s; ",
-		shellescape.Quote(resolved),
+		i.configDirShellExpr(resolved),
 		shellescape.Quote(i.GroupPath),
 		shellescape.Quote(source),
 	)
@@ -4092,6 +4103,22 @@ func (i *Instance) ensureClaudeSessionIDFromDisk() {
 	// transcripts (e.g. a removed-then-recreated review session) cannot hijack
 	// a sibling's conversation. The Restart prelude already does this for
 	// #1147; this closes the same gap on the Start path.
+	// Issue #1851: the same bail-out the Restart variant needs, placed before
+	// every disk touch below. The #608 gate further down makes the Start path
+	// only ACCIDENTALLY safe for remote sessions — it is re-opened by
+	// `session set <id> claude-session-id X` (mutators.go), which stamps
+	// ClaudeDetectedAt, after which a later clear leaves a remote session
+	// eligible for the local mtime walk. The rule is unconditional: a local
+	// ~/.claude/projects lookup is never right for a conversation that lives on
+	// another host.
+	if !i.TranscriptIsResolvableLocally() {
+		sessionLog.Info("resume: skipped reason=remote_session",
+			slog.String("instance_id", i.ID),
+			slog.String("ssh_host", i.SSHHost),
+			slog.String("ssh_remote_path", i.SSHRemotePath),
+			slog.String("reason", "jsonl_discovery_remote_skip"))
+		return
+	}
 	explicitSessionID := i.adoptExplicitClaudeSessionID("session_id_flag_explicit")
 	if i.Tool == "claude" && i.ClaudeSessionID != "" {
 		if restored, err := RestoreOrphanedConversationBackup(i, GetClaudeConfigDirForInstance(i)); err == nil && restored != "" {
@@ -4166,6 +4193,25 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 	// sharing a CLAUDE_SESSION_ID. Adopting the explicit id BEFORE the
 	// non-empty short-circuit ensures it also corrects a previously-
 	// hijacked id from an earlier buggy run.
+	// Issue #1851: a remote session's conversation lives on the remote host, so
+	// a local ~/.claude/projects lookup can never be right for it. Without this
+	// bail-out the walk below scans the CONTROLLER's projects dir — keyed on
+	// ProjectPath, which for an --ssh session is only a local placeholder
+	// defaulting to the controller's cwd — and adopts whichever LOCAL session
+	// wrote last. restart() then calls sweepDuplicateToolSessions(), which kills
+	// the local tmux session that legitimately owns that conversation.
+	//
+	// A remote session's local ClaudeSessionID is essentially always empty
+	// (SyncSessionIDsToTmux only writes the tmux var when the id is already
+	// non-empty), so every remote restart reaches this point.
+	if !i.TranscriptIsResolvableLocally() {
+		sessionLog.Info("resume: skipped reason=remote_session",
+			slog.String("instance_id", i.ID),
+			slog.String("ssh_host", i.SSHHost),
+			slog.String("ssh_remote_path", i.SSHRemotePath),
+			slog.String("reason", "jsonl_discovery_restart_remote_skip"))
+		return
+	}
 	if i.adoptExplicitClaudeSessionID("session_id_flag_explicit_restart") {
 		return
 	}
@@ -6719,13 +6765,53 @@ func (i *Instance) ClaudeSessionIDCollidesWith(peers []*Instance) bool {
 	return false
 }
 
-// claudeTranscriptDir returns the directory that GetJSONLPath would place this
-// instance's transcript in (config dir + encoded project path), used to decide
-// whether two instances would collide on the same transcript file. It mirrors
-// GetJSONLPath's resolution (GetClaudeConfigDir + i.ProjectPath) exactly, so the
+// TranscriptIsResolvableLocally reports whether this instance's conversation
+// transcript can be looked up in the CONTROLLER's filesystem.
+//
+// It is false for an --ssh session, unconditionally (#1851). That session's
+// harness runs on another host and writes its transcript into THAT host's config
+// dir. All the controller holds is ProjectPath — a local placeholder defaulting
+// to the directory `add --ssh` was run from — so a lookup through it does not
+// merely miss: it HITS, on whatever local session happens to sit at that
+// directory. Every local-disk transcript lookup must ask this first; the harm is
+// symmetrical (a remote session reads a local conversation, and by adopting its
+// id sends the next restart's duplicate sweeper after the local session that
+// owns it).
+//
+// The complete list of entry points this gates is in the package doc for
+// remote_transcript_boundary.go.
+func (i *Instance) TranscriptIsResolvableLocally() bool {
+	return i != nil && !i.IsSSH()
+}
+
+// claudeTranscriptDir returns the key used to decide whether two instances would
+// collide on one transcript file (issue #1349 defense-in-depth #2, via
+// ClaudeSessionIDCollidesWith). For a local instance it mirrors GetJSONLPath's
+// resolution — GetClaudeConfigDir + encoded ProjectPath — exactly, so the
 // collision verdict matches the path the guard protects.
+//
+// Issue #1851: a remote session's transcript is not in this filesystem at all,
+// and its ProjectPath is only a local placeholder, so two remote sessions
+// sharing a placeholder were judged to share a transcript directory and
+// GetJSONLPathChecked refused reads that were never in conflict. Remote sessions
+// are therefore keyed on where they actually run (host + canonical remote path).
+//
+// Changing this key is only safe because it is changed together with every path
+// that derives a file location from it: TranscriptIsResolvableLocally gates
+// GetJSONLPath, getClaudeLastResponse and findLatestClaudeTranscriptOnDisk (see
+// remote_transcript_boundary.go), so no remote instance resolves a local
+// transcript path at all and a local/remote pair sharing one claude_session_id
+// can no longer land on one file for the guard to have to catch. Without those
+// gates this key would DISABLE the #1349/#1352 guard for exactly the pair this
+// epic exists to separate. The result is a collision KEY that is never opened as
+// a path, and the "remote-transcripts" segment keeps it from ever aliasing a
+// real local projects/ directory.
 func (i *Instance) claudeTranscriptDir() string {
 	configDir := GetClaudeConfigDir()
+	if i.IsSSH() {
+		loc := LocationOf(i)
+		return filepath.Join(configDir, "remote-transcripts", ConvertToClaudeDirName(loc.String()))
+	}
 	resolvedPath := i.ProjectPath
 	if resolved, err := filepath.EvalSymlinks(i.ProjectPath); err == nil {
 		resolvedPath = resolved
@@ -6814,8 +6900,17 @@ func resolveClaudeTranscriptPath(configDir, projectPath, sessionID string) strin
 
 // GetJSONLPath returns the path to the Claude session JSONL file for analytics.
 // Returns empty string if this is not a Claude session or the transcript is absent.
+//
+// A remote session's transcript is never absent-or-here: it is on the remote
+// host, so "" is the only truthful answer (see TranscriptIsResolvableLocally).
+// Resolving it through the local placeholder ProjectPath would hand a LOCAL
+// session's conversation to every caller of this function — analytics, the
+// transition notifier, the TUI, and GetJSONLPathChecked.
 func (i *Instance) GetJSONLPath() string {
 	if !IsClaudeCompatible(i.Tool) || i.ClaudeSessionID == "" {
+		return ""
+	}
+	if !i.TranscriptIsResolvableLocally() {
 		return ""
 	}
 	return resolveClaudeTranscriptPath(GetClaudeConfigDir(), i.ProjectPath, i.ClaudeSessionID)
@@ -6826,6 +6921,12 @@ func (i *Instance) getClaudeLastResponse() (*ResponseOutput, error) {
 	// Require stored session ID - no fallback to file scanning
 	if i.ClaudeSessionID == "" {
 		return nil, fmt.Errorf("no Claude session ID available for this instance")
+	}
+
+	// The conversation of an --ssh session is on the remote host; reading the
+	// controller's disk for it returns a LOCAL session's reply (#1851).
+	if !i.TranscriptIsResolvableLocally() {
+		return nil, fmt.Errorf("instance %s runs on %s; its Claude transcript is not on this machine", i.ID, i.SSHHost)
 	}
 
 	sessionFile := resolveClaudeTranscriptPath(GetClaudeConfigDir(), i.ProjectPath, i.ClaudeSessionID)
@@ -6854,7 +6955,20 @@ func (i *Instance) getClaudeLastResponse() (*ResponseOutput, error) {
 // syncGeminiSessionFromDisk fallback.
 //
 // Returns ("", nil) when no suitable transcript is found.
+//
+// It is the third door into "resolve a conversation against local disk", and the
+// most dangerous one: its caller WRITES the recovered id back onto the instance
+// and into the tmux pane's environment. For an --ssh session that would adopt a
+// LOCAL conversation durably, so the next restart reaches
+// sweepDuplicateToolSessions holding a local session's CLAUDE_SESSION_ID and
+// kills it — #1851's data loss, reached past the restart bail-out (which returns
+// early once ClaudeSessionID is non-empty). Hence the same unconditional gate the
+// other two doors have.
 func (i *Instance) findLatestClaudeTranscriptOnDisk() (string, *ResponseOutput) {
+	if !i.TranscriptIsResolvableLocally() {
+		return "", nil
+	}
+
 	configDir := GetClaudeConfigDir()
 
 	resolvedPath := i.ProjectPath
@@ -9532,6 +9646,11 @@ func geminiSessionHasConversationData(sessionID, projectPath string) bool {
 // primary gate, so a missing file degrades gracefully to "candidate
 // doesn't appear larger, reject" rather than false-accepting.
 func sessionConversationByteSize(inst *Instance, sessionID string) int64 {
+	// #1851: see sessionHasConversationData — a remote session's transcript is
+	// not in this filesystem, so any size found here belongs to someone else.
+	if inst != nil && !inst.TranscriptIsResolvableLocally() {
+		return 0
+	}
 	var configDir string
 	if inst != nil {
 		configDir = GetClaudeConfigDirForInstance(inst)
@@ -9577,6 +9696,10 @@ func sessionConversationByteSize(inst *Instance, sessionID string) int64 {
 // like /clear (rich session is dormant, candidate is the new active jsonl).
 // Path resolution mirrors sessionConversationByteSize.
 func sessionConversationMtime(inst *Instance, sessionID string) time.Time {
+	// #1851: see sessionHasConversationData.
+	if inst != nil && !inst.TranscriptIsResolvableLocally() {
+		return time.Time{}
+	}
 	var configDir string
 	if inst != nil {
 		configDir = GetClaudeConfigDirForInstance(inst)
@@ -9690,6 +9813,14 @@ func (i *Instance) bindClaudeSessionFromHook(sessionID, hookSource, hookEvent, a
 // - File doesn't exist (nothing to resume, use --session-id)
 // - File exists but has zero "sessionId" occurrences (never interacted)
 func sessionHasConversationData(inst *Instance, sessionID string) bool {
+	// #1851: for an --ssh session every path below is a directory on THIS
+	// machine, keyed on the local placeholder ProjectPath — so "yes, that id has
+	// conversation data" would be a statement about a LOCAL session's transcript.
+	// The honest answer for a conversation that lives on another host is "not
+	// here"; the remote harness makes its own resume decision on its own disk.
+	if inst != nil && !inst.TranscriptIsResolvableLocally() {
+		return false
+	}
 	// Build the session file path
 	// Format: {config_dir}/projects/{encoded_path}/{sessionID}.jsonl
 	var configDir string
@@ -9832,6 +9963,12 @@ func findSessionFileInAllProjects(inst *Instance, sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
+	// #1851: this scans EVERY local project dir for <sessionID>.jsonl, so for a
+	// remote session it is the widest door of all — it does not even need the
+	// placeholder path to collide.
+	if inst != nil && !inst.TranscriptIsResolvableLocally() {
+		return ""
+	}
 
 	var configDir string
 	if inst != nil {
@@ -9944,13 +10081,24 @@ func (i *Instance) wrapForSSH(command string) string {
 	sshDir := "/tmp/agent-deck-ssh"
 	_ = os.MkdirAll(sshDir, 0700)
 
-	remoteCmd := command
-	if i.SSHRemotePath != "" {
-		// Escape single quotes in the remote path and command
-		escapedPath := strings.ReplaceAll(i.SSHRemotePath, "'", "'\\''")
-		escapedCmd := strings.ReplaceAll(command, "'", "'\\''")
-		remoteCmd = fmt.Sprintf("cd '%s' && %s", escapedPath, escapedCmd)
-	}
+	// remoteCmd is the shell program the REMOTE shell will run. It is quoted
+	// exactly once, by shellQuote below, when it becomes ssh's final argument.
+	//
+	// The command is spliced in verbatim: it is already a shell program (the
+	// export prefix plus the harness invocation), not a literal to embed. It
+	// used to be escaped here as well and then again by shellQuote, so every
+	// single quote in the payload reached the remote shell malformed. That broke
+	// EVERY ungrouped --ssh claude session with a --remote-path, because the
+	// spawn prefix always emits `export AGENTDECK_RESOLVED_GROUP='';` — the
+	// remote shell answered `unexpected EOF while looking for matching '` and
+	// the session died in ~250ms, which is the symptom #1858 reports.
+	//
+	// RemoteCDPrefix (not a hand-rolled `cd '%s'`) is what makes the directory
+	// the session RUNS in the same directory its identity says it is in: it
+	// leaves a ~ prefix unquoted so the remote shell expands it against the
+	// REMOTE user's home, and emits nothing at all for the spellings that
+	// CanonicalRemotePath folds together ("", "~", "~/").
+	remoteCmd := RemoteCDPrefix(i.SSHRemotePath) + command
 
 	return fmt.Sprintf(
 		"ssh -t -o ControlMaster=auto -o ControlPath=/tmp/agent-deck-ssh/%%r@%%h:%%p -o ControlPersist=600 %s %s",

--- a/internal/session/issue1851_remote_transcript_boundary_test.go
+++ b/internal/session/issue1851_remote_transcript_boundary_test.go
@@ -1,0 +1,359 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for https://github.com/asheshgoplani/agent-deck/issues/1851.
+//
+// An --ssh session's conversation lives on the remote host, but everything that
+// resolves a transcript on the controller is keyed on Instance.ProjectPath —
+// which for a remote session is only a LOCAL placeholder, defaulting to the
+// directory `add --ssh` was run in. So a lookup does not miss; it HITS, on
+// whatever local session sits at that directory. The reported consequence is
+// data loss: the remote adopts the local session's conversation UUID, and
+// restart()'s sweepDuplicateToolSessions then kills the local tmux session that
+// legitimately owns it.
+//
+// The fixture below is deliberately the WORST case — a local session and a
+// remote session at the same placeholder path, with a real transcript on local
+// disk. Each test asserts the remote refuses AND that the identical local
+// lookup still succeeds, so a guard that simply broke the feature would fail.
+
+const localReplyText = "LOCAL SESSION SECRET REPLY"
+
+// remoteBoundaryFixture seeds a local Claude transcript under projectPath and
+// returns a local instance that owns it plus a remote instance that merely
+// stores the same path as its placeholder.
+func remoteBoundaryFixture(t *testing.T) (local, remote *Instance, sessionID, projectPath string) {
+	t.Helper()
+
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".claude")
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	projectPath = t.TempDir()
+	sessionID = "11111111-2222-3333-4444-555555555555"
+
+	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(projectPath))
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	// The "sessionId" field is what sessionHasConversationData looks for to
+	// decide the conversation was actually interacted with.
+	line := `{"sessionId":"` + sessionID + `","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"` + localReplyText + `"}]}}`
+	if err := os.WriteFile(filepath.Join(projDir, sessionID+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	local = NewInstanceWithTool("local-owner", projectPath, "claude")
+	local.ClaudeSessionID = sessionID
+	local.ClaudeDetectedAt = time.Now()
+
+	remote = NewInstanceWithTool("remote-session", projectPath, "claude")
+	remote.SSHHost = "alice@host-a"
+	remote.SSHRemotePath = "/srv/app-a"
+
+	return local, remote, sessionID, projectPath
+}
+
+// --- Door 1 and 2: session-id adoption from disk ------------------------------
+
+// TestEnsureClaudeSessionIDFromDiskForRestart_RemoteNeverAdoptsLocalUUID is the
+// reported bug. Every remote restart reaches this function (a remote session's
+// local ClaudeSessionID is essentially always empty), and the mtime walk it does
+// scans the CONTROLLER's projects dir.
+func TestEnsureClaudeSessionIDFromDiskForRestart_RemoteNeverAdoptsLocalUUID(t *testing.T) {
+	local, remote, sessionID, _ := remoteBoundaryFixture(t)
+
+	remote.ensureClaudeSessionIDFromDiskForRestart()
+	if remote.ClaudeSessionID != "" {
+		t.Fatalf("remote session adopted a LOCAL conversation UUID %q on restart; the dup sweeper would then kill the local session that owns it", remote.ClaudeSessionID)
+	}
+
+	// The same walk must still work for a local session, or the guard has just
+	// broken restart-resume rather than scoped it.
+	local.ClaudeSessionID = ""
+	local.ensureClaudeSessionIDFromDiskForRestart()
+	if local.ClaudeSessionID != sessionID {
+		t.Fatalf("local restart discovery regressed: got %q, want %q", local.ClaudeSessionID, sessionID)
+	}
+}
+
+// TestEnsureClaudeSessionIDFromDisk_RemoteNeverAdoptsLocalUUID covers the Start
+// path. It is only ACCIDENTALLY safe today via the #608 ClaudeDetectedAt gate,
+// and that gate is re-openable through `session set <id> claude-session-id X`.
+func TestEnsureClaudeSessionIDFromDisk_RemoteNeverAdoptsLocalUUID(t *testing.T) {
+	_, remote, _, _ := remoteBoundaryFixture(t)
+
+	// Stamp ClaudeDetectedAt then clear the id: exactly the state
+	// `session set claude-session-id` leaves behind, which opens the #608 gate.
+	remote.ClaudeDetectedAt = time.Now()
+	remote.ClaudeSessionID = ""
+
+	remote.ensureClaudeSessionIDFromDisk()
+	if remote.ClaudeSessionID != "" {
+		t.Fatalf("remote session adopted LOCAL conversation UUID %q on the Start path", remote.ClaudeSessionID)
+	}
+}
+
+// TestSweepDuplicateToolSessions_RemoteHasNoLocalIDToSweepWith is required
+// behaviour 5: the sweeper must never kill a session because a remote session
+// picked up its conversation id. With adoption blocked the remote reaches the
+// sweep holding no tool session id at all, so the CLAUDE_SESSION_ID sweep cannot
+// name anyone else's conversation.
+func TestSweepDuplicateToolSessions_RemoteHasNoLocalIDToSweepWith(t *testing.T) {
+	_, remote, sessionID, _ := remoteBoundaryFixture(t)
+
+	var sweptVars, sweptValues []string
+	orig := killDuplicateSessionsFn
+	killDuplicateSessionsFn = func(envKey, envValue, excludeName string) {
+		sweptVars = append(sweptVars, envKey)
+		sweptValues = append(sweptValues, envValue)
+	}
+	t.Cleanup(func() { killDuplicateSessionsFn = orig })
+
+	remote.ensureClaudeSessionIDFromDiskForRestart()
+	remote.tmuxSession = remote.GetTmuxSession()
+	remote.sweepDuplicateToolSessions()
+
+	for i, v := range sweptValues {
+		if sweptVars[i] == "CLAUDE_SESSION_ID" && v == sessionID {
+			t.Fatalf("the sweeper was handed the LOCAL session's conversation id %q — it would kill the local tmux session that owns it", v)
+		}
+	}
+}
+
+// --- Door 3: the disk scan that WRITES its result back ------------------------
+
+// TestFindLatestClaudeTranscriptOnDisk_RemoteRefuses covers review finding F2:
+// the third door, and the most dangerous one, because GetLastResponseBestEffort
+// stores what it finds onto the instance and into the pane's tmux env — which
+// then reaches the sweeper past the restart bail-out.
+func TestFindLatestClaudeTranscriptOnDisk_RemoteRefuses(t *testing.T) {
+	local, remote, _, _ := remoteBoundaryFixture(t)
+
+	if id, resp := remote.findLatestClaudeTranscriptOnDisk(); id != "" || resp != nil {
+		t.Fatalf("remote session found a LOCAL transcript on disk: id=%q resp=%+v", id, resp)
+	}
+	if id, resp := local.findLatestClaudeTranscriptOnDisk(); id == "" || resp == nil {
+		t.Fatalf("local disk scan regressed: id=%q resp=%+v", id, resp)
+	}
+}
+
+// TestGetLastResponseBestEffort_RemoteNeverReturnsLocalConversation is the same
+// door seen from its caller: the observable harm is that `session output` on a
+// remote session returns a local session's reply.
+func TestGetLastResponseBestEffort_RemoteNeverReturnsLocalConversation(t *testing.T) {
+	_, remote, _, _ := remoteBoundaryFixture(t)
+
+	resp, err := remote.GetLastResponseBestEffort()
+	if err == nil && resp != nil && strings.Contains(resp.Content, localReplyText) {
+		t.Fatalf("remote session returned the LOCAL session's conversation: %q", resp.Content)
+	}
+	if remote.ClaudeSessionID != "" {
+		t.Fatalf("remote session durably adopted local conversation id %q via the read path", remote.ClaudeSessionID)
+	}
+}
+
+// --- Doors 4 and 5: path resolution and the structured read -------------------
+
+// TestGetJSONLPath_RemoteResolvesToNothing pins the rule that makes the
+// claudeTranscriptDir key change safe (review finding F1): no remote instance
+// resolves a local transcript path at all.
+func TestGetJSONLPath_RemoteResolvesToNothing(t *testing.T) {
+	local, remote, sessionID, _ := remoteBoundaryFixture(t)
+	remote.ClaudeSessionID = sessionID // as if set by `session set claude-session-id`
+
+	if got := remote.GetJSONLPath(); got != "" {
+		t.Fatalf("remote session resolved a LOCAL transcript path %q", got)
+	}
+	if got := local.GetJSONLPath(); got == "" {
+		t.Fatal("local transcript resolution regressed")
+	}
+}
+
+// TestGetClaudeLastResponse_RemoteRefuses covers `session output`'s structured
+// read.
+func TestGetClaudeLastResponse_RemoteRefuses(t *testing.T) {
+	local, remote, sessionID, _ := remoteBoundaryFixture(t)
+	remote.ClaudeSessionID = sessionID
+
+	if resp, err := remote.getClaudeLastResponse(); err == nil {
+		t.Fatalf("remote session read a LOCAL transcript: %+v", resp)
+	}
+	if _, err := local.getClaudeLastResponse(); err != nil {
+		t.Fatalf("local structured read regressed: %v", err)
+	}
+}
+
+// --- Review finding F1: the collision guard must NOT be disabled ---------------
+
+// TestClaudeSessionIDCollision_LocalAndRemoteCannotShareOneTranscriptFile is the
+// regression the previous attempt shipped and pinned as correct.
+//
+// claudeTranscriptDir keys remote sessions on where they RUN, so a local and a
+// remote session sharing the placeholder path and a claude_session_id no longer
+// "collide". That is only safe because the remote resolves to NO file at all —
+// which is what this test checks, rather than checking the collision verdict in
+// isolation. The property that matters is the one #1349/#1352 protect: two live
+// instances must never be handed the same transcript path.
+func TestClaudeSessionIDCollision_LocalAndRemoteCannotShareOneTranscriptFile(t *testing.T) {
+	local, remote, sessionID, _ := remoteBoundaryFixture(t)
+	remote.ClaudeSessionID = sessionID
+	local.Status = StatusRunning
+	remote.Status = StatusRunning
+
+	peers := []*Instance{local, remote}
+
+	localPath, localErr := local.GetJSONLPathChecked(peers)
+	remotePath, remoteErr := remote.GetJSONLPathChecked(peers)
+
+	if remotePath != "" {
+		t.Fatalf("remote session was handed a local transcript path %q (err=%v)", remotePath, remoteErr)
+	}
+	if localPath != "" && localPath == remotePath {
+		t.Fatalf("a local and a remote session resolved to the SAME transcript file %q — the #1349 guard is off", localPath)
+	}
+	if localErr != nil {
+		t.Fatalf("the local session lost access to its own transcript: %v", localErr)
+	}
+}
+
+// TestClaudeSessionIDCollision_TwoLocalSessionsStillRefused is the other half of
+// F1: narrowing the key must not weaken the guard for the pair it was written
+// for. Two LOCAL live instances sharing a project dir and a session id still
+// resolve to one file, and must still be refused.
+func TestClaudeSessionIDCollision_TwoLocalSessionsStillRefused(t *testing.T) {
+	local, _, sessionID, projectPath := remoteBoundaryFixture(t)
+	local.Status = StatusRunning
+
+	sibling := NewInstanceWithTool("local-sibling", projectPath, "claude")
+	sibling.ClaudeSessionID = sessionID
+	sibling.ClaudeDetectedAt = time.Now()
+	sibling.Status = StatusRunning
+
+	peers := []*Instance{local, sibling}
+	if !local.ClaudeSessionIDCollidesWith(peers) {
+		t.Fatal("two LOCAL live instances sharing a project dir and a claude_session_id are no longer detected as colliding — the #1349/#1352 guard was weakened")
+	}
+	if _, err := local.GetJSONLPathChecked(peers); err == nil {
+		t.Fatal("GetJSONLPathChecked stopped refusing a genuine local collision")
+	}
+}
+
+// TestClaudeTranscriptDir_RemoteSessionsAreKeyedByWhereTheyRun is the #1851
+// half of the key change: two remote sessions that merely share a local
+// placeholder are not in the same place and must not be judged to share a
+// transcript directory.
+func TestClaudeTranscriptDir_RemoteSessionsAreKeyedByWhereTheyRun(t *testing.T) {
+	_, remoteA, _, projectPath := remoteBoundaryFixture(t)
+
+	remoteB := NewInstanceWithTool("remote-b", projectPath, "claude") // same placeholder
+	remoteB.SSHHost = "bob@host-b"
+	remoteB.SSHRemotePath = "/opt/app-b"
+
+	if remoteA.claudeTranscriptDir() == remoteB.claudeTranscriptDir() {
+		t.Fatal("two remote sessions on different hosts share a transcript key because their local placeholders match")
+	}
+
+	// Same host, same remote dir, different placeholders: genuinely co-located.
+	remoteC := NewInstanceWithTool("remote-c", t.TempDir(), "claude")
+	remoteC.SSHHost = remoteA.SSHHost
+	remoteC.SSHRemotePath = remoteA.SSHRemotePath
+	if remoteA.claudeTranscriptDir() != remoteC.claudeTranscriptDir() {
+		t.Fatal("two sessions at the same host and remote path do not share a transcript key")
+	}
+
+	// The two spellings of the remote home are one place here too.
+	remoteHomeA := NewInstanceWithTool("h1", t.TempDir(), "claude")
+	remoteHomeA.SSHHost = "alice@host-a"
+	remoteHomeA.SSHRemotePath = ""
+	remoteHomeB := NewInstanceWithTool("h2", t.TempDir(), "claude")
+	remoteHomeB.SSHHost = "alice@host-a"
+	remoteHomeB.SSHRemotePath = "~"
+	if remoteHomeA.claudeTranscriptDir() != remoteHomeB.claudeTranscriptDir() {
+		t.Fatal(`remote paths "" and "~" produced different transcript keys, but they run in the same directory`)
+	}
+
+	// The key must never alias a real local projects/ directory.
+	if strings.Contains(remoteA.claudeTranscriptDir(), filepath.Join("projects", ConvertToClaudeDirName(projectPath))) {
+		t.Fatalf("remote transcript key aliases a local project dir: %s", remoteA.claudeTranscriptDir())
+	}
+}
+
+// --- Doors 6 to 9: the conversation-data probes -------------------------------
+
+func TestConversationDataProbes_RemoteRefuses(t *testing.T) {
+	local, remote, sessionID, _ := remoteBoundaryFixture(t)
+
+	if sessionHasConversationData(remote, sessionID) {
+		t.Error("sessionHasConversationData said a LOCAL transcript belongs to the remote session")
+	}
+	if !sessionHasConversationData(local, sessionID) {
+		t.Error("sessionHasConversationData regressed for a local session")
+	}
+
+	if got := sessionConversationByteSize(remote, sessionID); got != 0 {
+		t.Errorf("sessionConversationByteSize measured a local transcript for a remote session: %d", got)
+	}
+	if got := sessionConversationByteSize(local, sessionID); got == 0 {
+		t.Error("sessionConversationByteSize regressed for a local session")
+	}
+
+	if got := sessionConversationMtime(remote, sessionID); !got.IsZero() {
+		t.Errorf("sessionConversationMtime read a local transcript for a remote session: %v", got)
+	}
+
+	if got := findSessionFileInAllProjects(remote, sessionID); got != "" {
+		t.Errorf("findSessionFileInAllProjects found %q for a remote session — this door does not even need the placeholder to collide", got)
+	}
+	if got := findSessionFileInAllProjects(local, sessionID); got == "" {
+		t.Error("findSessionFileInAllProjects regressed for a local session")
+	}
+}
+
+// --- Doors 10 to 14: handoff and migration ------------------------------------
+
+func TestHandoffAndMigration_RemoteRefuses(t *testing.T) {
+	local, remote, sessionID, _ := remoteBoundaryFixture(t)
+	remote.ClaudeSessionID = sessionID
+
+	if got := ClaudeTranscriptPathForInstance(remote); got != "" {
+		t.Errorf("ClaudeTranscriptPathForInstance CONSTRUCTED a local path for a remote session: %q", got)
+	}
+	if got := ClaudeTranscriptPathForInstance(local); got == "" {
+		t.Error("ClaudeTranscriptPathForInstance regressed for a local session")
+	}
+
+	if _, _, err := BuildClaudeToCodexHandoffPrompt(remote, 1000); err == nil {
+		t.Error("session handoff read a LOCAL session's whole transcript for a remote session")
+	}
+
+	cfg, cfgErr := LoadUserConfig()
+	if cfgErr == nil {
+		if dir, _, _ := LocateConversationConfigDir(cfg, remote, GetClaudeConfigDir()); dir != "" {
+			t.Errorf("LocateConversationConfigDir named %q for a remote session; switch-account then MIGRATES that file", dir)
+		}
+		if dir, _, _ := LocateConversationConfigDir(cfg, local, GetClaudeConfigDir()); dir == "" {
+			t.Error("LocateConversationConfigDir regressed for a local session")
+		}
+	}
+
+	if moved, err := MigrateConversationFrom(remote, GetClaudeConfigDir(), t.TempDir()); err != nil || moved != "" {
+		t.Errorf("MigrateConversationFrom moved %q for a remote session (err=%v)", moved, err)
+	}
+
+	// The live transcript exists, so RestoreOrphanedConversationBackup is a
+	// no-op for both; the point is that the remote never reaches the scan.
+	if restored, err := RestoreOrphanedConversationBackup(remote, GetClaudeConfigDir()); err != nil || restored != "" {
+		t.Errorf("RestoreOrphanedConversationBackup restored %q for a remote session (err=%v)", restored, err)
+	}
+}

--- a/internal/session/issue1858_remote_config_dir_test.go
+++ b/internal/session/issue1858_remote_config_dir_test.go
@@ -1,0 +1,106 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+// shellQuoteForTest mirrors what a LOCAL session's config dir goes through, so
+// the "unchanged for local sessions" assertion compares against the real thing.
+func shellQuoteForTest(s string) string { return shellescape.Quote(s) }
+
+// evalShellValue evaluates a shell VALUE EXPRESSION the way the spawn payload
+// does, under the given HOME, and discards the result. It exists to prove the
+// expression cannot execute anything.
+func evalShellValue(t *testing.T, expr, home string) error {
+	t.Helper()
+	cmd := exec.Command("bash", "-c", "V="+expr+"; printf '%s' \"$V\" >/dev/null")
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return &shellEvalError{expr: expr, out: string(out), err: err}
+	}
+	return nil
+}
+
+type shellEvalError struct {
+	expr string
+	out  string
+	err  error
+}
+
+func (e *shellEvalError) Error() string {
+	return e.expr + ": " + e.err.Error() + ": " + e.out
+}
+
+// Regression tests for https://github.com/asheshgoplani/agent-deck/issues/1858.
+//
+// Reporter @yuvalsc: an `add --ssh` session crashes after ~250ms when the remote
+// user differs from the local one, because CLAUDE_CONFIG_DIR is built from the
+// LOCAL home and passed verbatim into the remote command:
+//
+//	export CLAUDE_CONFIG_DIR=/Users/yuvals/.local/share/agent-deck/worker-scratch/<id>
+//
+// Local user `yuvals`, remote user `cloudlydr`: /Users/yuvals does not exist on
+// the remote host and is not creatable there, so claude cannot make its config
+// dir and exits immediately.
+//
+// The end-to-end proof (the payload actually running under a different HOME
+// through a fake ssh) lives in location_identity_execution_test.go. These tests
+// pin the two mechanisms underneath it.
+
+// TestNeedsWorkerScratchConfigDir_NeverForRemoteSessions closes the root cause.
+// The worker scratch is a LOCAL tree — a settings.json plus plugin symlinks
+// under this machine's data dir — so there is nothing for the remote host to
+// use even if the path did exist there.
+func TestNeedsWorkerScratchConfigDir_NeverForRemoteSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	// A session with explicit plugins is the plainest scratch trigger.
+	local := NewInstanceWithTool("local", t.TempDir(), "claude")
+	local.Plugins = []string{"telegram"}
+	if !local.NeedsWorkerScratchConfigDir() {
+		t.Skip("no scratch trigger fires in this environment; the remote assertion below would be vacuous")
+	}
+
+	remote := NewInstanceWithTool("remote", t.TempDir(), "claude")
+	remote.Plugins = []string{"telegram"}
+	remote.SSHHost = "cloudlydr@remote-host"
+	if remote.NeedsWorkerScratchConfigDir() {
+		t.Fatal("a remote session was given a LOCAL worker-scratch config dir; the remote host cannot create a path under the local home (#1858)")
+	}
+}
+
+// TestApplyWorkerScratchOverride_RemoteKeepsResolvedDir is defense in depth: even
+// if WorkerScratchConfigDir is somehow already set (an older state.db row, a
+// profile migration), the swap must not happen for a remote session.
+func TestApplyWorkerScratchOverride_RemoteKeepsResolvedDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	scratch := filepath.Join(home, ".local", "share", "agent-deck", "worker-scratch", "abc")
+	resolved := "/Users/cloudlydr/.claude"
+
+	local := NewInstanceWithTool("local", t.TempDir(), "claude")
+	local.WorkerScratchConfigDir = scratch
+	if got := local.applyWorkerScratchOverride(resolved); got != scratch {
+		t.Fatalf("local scratch override regressed: got %q, want %q", got, scratch)
+	}
+
+	remote := NewInstanceWithTool("remote", t.TempDir(), "claude")
+	remote.WorkerScratchConfigDir = scratch
+	remote.SSHHost = "cloudlydr@remote-host"
+	if got := remote.applyWorkerScratchOverride(resolved); got != resolved {
+		t.Fatalf("a remote session's CLAUDE_CONFIG_DIR was swapped to the LOCAL scratch path %q; want the resolved dir %q", got, resolved)
+	}
+}

--- a/internal/session/issue1858_wrapforssh_e2e_test.go
+++ b/internal/session/issue1858_wrapforssh_e2e_test.go
@@ -1,0 +1,187 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// End-to-end proof for issues #1858 and review findings F5/F6, plus the round-3
+// "~" objection, driven through a fake `ssh` on PATH that reproduces ssh's own
+// semantics: the remote command starts in the REMOTE user's home, and the final
+// argument is handed to a shell to re-parse.
+//
+// Every symbol used here exists at the merge base, so these tests run — and
+// fail — against the unfixed tree.
+
+// fakeSSHDir installs an `ssh` shim that behaves like the real thing for the two
+// properties under test: the remote command starts in the REMOTE user's home,
+// and the final argument is handed to a shell to parse. It records the exact
+// argv it was invoked with so a test can assert on the command line the remote
+// host receives.
+func fakeSSHDir(t *testing.T, remoteHome string) (binDir, argvLog string) {
+	t.Helper()
+	binDir = t.TempDir()
+	argvLog = filepath.Join(binDir, "argv.log")
+
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+# Fake ssh. Records argv, then reproduces the two behaviours under test:
+#  * the remote command runs as the REMOTE user, in the REMOTE home
+#  * ssh passes the command to the remote login shell, which re-parses it
+{ printf '%%s\n' "$*"; } >> %q
+cmd=""
+for a in "$@"; do cmd=$a; done
+export HOME=%q
+cd "$HOME" || exit 97
+exec bash -c "$cmd"
+`, argvLog, remoteHome)
+
+	if err := os.WriteFile(filepath.Join(binDir, "ssh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ssh: %v", err)
+	}
+	return binDir, argvLog
+}
+
+// runRemote composes inst's spawn payload the way a real spawn does, sends it
+// through wrapForSSH, and executes the result with the fake ssh first on PATH.
+// It returns the remote side's stdout+stderr and the recorded command line.
+func runRemote(t *testing.T, inst *Instance, remoteHome, probe string) (output, argv string) {
+	t.Helper()
+
+	binDir, argvLog := fakeSSHDir(t, remoteHome)
+	payload := inst.buildBashExportPrefix() + probe
+	composed := inst.wrapForSSH(payload)
+
+	cmd := exec.Command("bash", "-c", composed)
+	cmd.Env = append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, _ := cmd.CombinedOutput()
+
+	recorded, _ := os.ReadFile(argvLog)
+	return string(out), strings.TrimSpace(string(recorded))
+}
+
+// remoteClaudeInstance builds an --ssh claude instance with an explicit config
+// dir under the LOCAL home — the shape #1858 reports — and NO group, which is
+// the reporter's exact repro and the case that used to break the remote parse.
+func remoteClaudeInstance(t *testing.T, remotePath string) *Instance {
+	t.Helper()
+	localHome := t.TempDir()
+	t.Setenv("HOME", localHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(localHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	inst := NewInstanceWithTool("remote-host", t.TempDir(), "claude")
+	inst.SSHHost = "cloudlydr@remote-host"
+	inst.SSHRemotePath = remotePath
+	inst.GroupPath = "" // ungrouped: emits AGENTDECK_RESOLVED_GROUP='' (review F5)
+	return inst
+}
+
+// --- End to end through a fake ssh -------------------------------------------
+
+// TestWrapForSSH_UngroupedRemoteSessionParsesOnTheRemoteShell is review finding
+// F5. wrapForSSH escaped single quotes TWICE when SSHRemotePath was set: once
+// into the payload and again over the whole thing in shellQuote. The spawn
+// prefix always emits `export AGENTDECK_RESOLVED_GROUP=”;` for a claude
+// session, so EVERY ungrouped --ssh session with a --remote-path produced a
+// remote command the remote shell could not parse — `unexpected EOF while
+// looking for matching '`, i.e. the ~250ms exit #1858 reports.
+//
+// The previous attempt's test evaluated the config-dir expression alone with
+// printf and never composed it through wrapForSSH, so it passed green over a
+// payload that could not run. This one runs the composed command line.
+func TestWrapForSSH_UngroupedRemoteSessionParsesOnTheRemoteShell(t *testing.T) {
+	remoteHome := t.TempDir()
+	remoteDir := filepath.Join(remoteHome, "app")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	inst := remoteClaudeInstance(t, remoteDir)
+	out, argv := runRemote(t, inst, remoteHome, `printf 'REMOTE_OK\n'`)
+
+	if strings.Contains(out, "unexpected EOF") || strings.Contains(out, "syntax error") {
+		t.Fatalf("the remote shell could not parse the spawn payload — this is the ~250ms crash:\n%s\n\ncommand line was:\n%s", out, argv)
+	}
+	if !strings.Contains(out, "REMOTE_OK") {
+		t.Fatalf("remote command did not run:\n%s\n\ncommand line was:\n%s", out, argv)
+	}
+	if !strings.Contains(argv, "AGENTDECK_RESOLVED_GROUP") {
+		t.Fatalf("this test is not exercising the ungrouped payload it claims to; argv:\n%s", argv)
+	}
+}
+
+// TestWrapForSSH_ConfigDirResolvesAgainstTheRemoteHome is #1858 itself, plus
+// review finding F6 for the second variable. Both config-dir vars must name a
+// directory that exists on the REMOTE host; a literal local-home path does not,
+// and two vars naming the config dir while disagreeing is worse than one.
+func TestWrapForSSH_ConfigDirResolvesAgainstTheRemoteHome(t *testing.T) {
+	remoteHome := t.TempDir()
+	inst := remoteClaudeInstance(t, "")
+	localHome := os.Getenv("HOME")
+
+	out, argv := runRemote(t, inst, remoteHome,
+		`printf 'CFG=[%s]\nRESOLVED=[%s]\n' "$CLAUDE_CONFIG_DIR" "$AGENTDECK_RESOLVED_CONFIG_DIR"`)
+
+	wantCfg := "CFG=[" + filepath.Join(remoteHome, ".claude") + "]"
+	if !strings.Contains(out, wantCfg) {
+		t.Errorf("CLAUDE_CONFIG_DIR did not resolve against the REMOTE user's home.\nwant %s\ngot:\n%s\n\ncommand line:\n%s", wantCfg, out, argv)
+	}
+	wantResolved := "RESOLVED=[" + filepath.Join(remoteHome, ".claude") + "]"
+	if !strings.Contains(out, wantResolved) {
+		t.Errorf("AGENTDECK_RESOLVED_CONFIG_DIR (what hooks and statusline scripts read) did not resolve against the REMOTE home.\nwant %s\ngot:\n%s", wantResolved, out)
+	}
+	if strings.Contains(argv, localHome) {
+		t.Errorf("the literal LOCAL home path %q was shipped to the remote host:\n%s", localHome, argv)
+	}
+}
+
+// TestWrapForSSH_RemoteWorkingDirectoryMatchesIdentity is the ~ rule proven end
+// to end, through the real composed command line rather than through
+// RemoteCDPrefix alone.
+func TestWrapForSSH_RemoteWorkingDirectoryMatchesIdentity(t *testing.T) {
+	remoteHome := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(remoteHome, "work"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	for _, c := range []struct{ remotePath, wantDir string }{
+		{"", remoteHome},
+		{"~", remoteHome},
+		{"~/work", filepath.Join(remoteHome, "work")},
+	} {
+		inst := remoteClaudeInstance(t, c.remotePath)
+		out, argv := runRemote(t, inst, remoteHome, `printf 'PWD=[%s]\n' "$PWD"`)
+
+		want := "PWD=[" + c.wantDir + "]"
+		if !strings.Contains(out, want) {
+			t.Errorf("--remote-path %q ran in the wrong directory.\nwant %s\ngot:\n%s\n\ncommand line:\n%s", c.remotePath, want, out, argv)
+		}
+	}
+}
+
+// TestWrapForSSH_QuotesTheRemotePathExactlyOnce guards the shape of the fix
+// directly: the payload must appear in the composed command with its quotes
+// escaped once (by shellQuote) and not twice.
+func TestWrapForSSH_QuotesTheRemotePathExactlyOnce(t *testing.T) {
+	inst := NewInstanceWithTool("q", t.TempDir(), "claude")
+	inst.SSHHost = "alice@host-a"
+	inst.SSHRemotePath = "/srv/app"
+
+	composed := inst.wrapForSSH(`export X=''; run`)
+
+	// Double-escaping shows up as the four-character sequence '\'' having been
+	// applied twice, i.e. a backslash before a backslash-quote.
+	if regexp.MustCompile(`\\'\\\\''`).MatchString(composed) {
+		t.Fatalf("payload appears to be escaped twice:\n%s", composed)
+	}
+	// One round of shellQuote turns each ' into '\''.
+	if !strings.Contains(composed, `export X='\'''\''; run`) {
+		t.Fatalf("payload is not escaped exactly once by shellQuote:\n%s", composed)
+	}
+}

--- a/internal/session/issue1858_wrapforssh_e2e_test.go
+++ b/internal/session/issue1858_wrapforssh_e2e_test.go
@@ -53,7 +53,7 @@ func runRemote(t *testing.T, inst *Instance, remoteHome, probe string) (output, 
 	t.Helper()
 
 	binDir, argvLog := fakeSSHDir(t, remoteHome)
-	payload := inst.buildBashExportPrefix() + probe
+	payload := inst.buildBashExportPrefix(false) + probe
 	composed := inst.wrapForSSH(payload)
 
 	cmd := exec.Command("bash", "-c", composed)

--- a/internal/session/issue1858_wrapforssh_e2e_test.go
+++ b/internal/session/issue1858_wrapforssh_e2e_test.go
@@ -61,7 +61,12 @@ func runRemote(t *testing.T, inst *Instance, remoteHome, probe string) (output, 
 	out, _ := cmd.CombinedOutput()
 
 	recorded, _ := os.ReadFile(argvLog)
-	return string(out), strings.TrimSpace(string(recorded))
+	argv = strings.TrimSpace(string(recorded))
+	// Logged unconditionally, not just on failure: "the exact command line the
+	// remote host receives" is the artifact a reviewer wants to read for #1858,
+	// and `go test -v` is the cheapest way to hand it to them.
+	t.Logf("remote host received:\n  argv:   %s\n  output: %s", argv, strings.TrimSpace(string(out)))
+	return string(out), argv
 }
 
 // remoteClaudeInstance builds an --ssh claude instance with an explicit config

--- a/internal/session/location.go
+++ b/internal/session/location.go
@@ -1,0 +1,221 @@
+package session
+
+import (
+	"strings"
+)
+
+// Location answers "where does this session actually run?".
+//
+// It exists because Instance.ProjectPath is NOT that answer for an --ssh
+// session: `add --ssh` stores a LOCAL placeholder there (defaulting to the
+// controller's working directory) while the real location lives in SSHHost
+// plus SSHRemotePath. Comparing ProjectPath strings therefore reports every
+// remote session registered from one local directory as co-located with every
+// other one — and with any local session sitting at that directory. That single
+// mistake is the root cause behind issues #1850, #1851, #1852 and #1853.
+//
+// The rule this type encodes: a local location and a remote location are never
+// equal, and two remote locations are equal only when BOTH the host and the
+// canonical remote path match.
+//
+// It lives in package session, not in cmd/agent-deck, because identity and
+// EXECUTION have to agree. The previous attempt at this epic put the type in
+// the CLI, folded "~" into "" for identity, and left wrapForSSH emitting
+// `cd '~'` — which does not expand to $HOME — so two spellings that compared
+// equal ran in different directories. CanonicalRemotePath and RemoteCDPrefix
+// below are the single rule both sides use.
+type Location struct {
+	// Host is the SSH destination ("user@host"), empty for a local session.
+	Host string
+	// Path is the canonical remote path for a remote session and the project
+	// path for a local one (see CanonicalRemotePath / normalizeLocalPath).
+	Path string
+}
+
+// normalizeLocalPath strips trailing slashes so "/srv/app", "/srv/app/" and
+// "/srv/app//" compare equal, preserving root and the empty (unspecified) path.
+//
+// Every trailing slash goes, not just one: Location is compared with ==, so any
+// spelling this function leaves behind is a location of its own. A path that
+// kept one would silently pass the duplicate-title check and then fail to
+// resolve depending on how the user typed it.
+func normalizeLocalPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	trimmed := strings.TrimRight(p, "/")
+	if trimmed == "" {
+		return "/"
+	}
+	return trimmed
+}
+
+// CanonicalRemotePath is the ONE spelling of a remote directory that identity
+// comparison and command execution both use.
+//
+// The remote default directory has three spellings that all name the same
+// place, because `ssh host <cmd>` runs <cmd> from the remote user's home:
+//
+//	""    — `add --ssh alice@host` with no --remote-path; no `cd` is emitted
+//	"~"   — what Location.String() prints, so it is what a user types back
+//	"~/"  — the same with a trailing slash
+//
+// All three canonicalize to "". Everything else keeps its ~-rooted or absolute
+// form with trailing slashes stripped: "~/work" is a real place under the
+// remote home and stays distinct from "" and from any local path.
+//
+// This is the identity half of the rule. RemoteCDPrefix is the execution half,
+// and they are tested against each other (see TestRemotePathIdentityAndExecutionAgree).
+func CanonicalRemotePath(p string) string {
+	p = normalizeLocalPath(p)
+	if p == "~" {
+		return ""
+	}
+	return p
+}
+
+// LocalLocation builds the location of a session that runs on this machine.
+func LocalLocation(path string) Location {
+	return Location{Path: normalizeLocalPath(path)}
+}
+
+// RemoteLocation builds the location of an --ssh session. An empty (canonical)
+// remote path means "the remote user's home directory" — still a distinct place
+// from any local path, so it never collapses onto the local form.
+func RemoteLocation(host, remotePath string) Location {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return LocalLocation(remotePath)
+	}
+	return Location{Host: host, Path: CanonicalRemotePath(remotePath)}
+}
+
+// LocationOf returns where inst actually runs, consulting SSHHost/SSHRemotePath
+// instead of trusting ProjectPath.
+func LocationOf(inst *Instance) Location {
+	if inst == nil {
+		return Location{}
+	}
+	if inst.IsSSH() {
+		return RemoteLocation(inst.SSHHost, inst.SSHRemotePath)
+	}
+	return LocalLocation(inst.ProjectPath)
+}
+
+// IsLocal reports whether this location is on the controller machine — i.e.
+// whether its path is a real path in this filesystem.
+func (l Location) IsLocal() bool { return l.Host == "" }
+
+// String renders the location for humans. A message about a remote session must
+// name the host and remote directory; naming the local placeholder (as the
+// pre-fix duplicate/rename messages did) points the user at a directory that has
+// nothing to do with the collision.
+//
+// The rendered form round-trips: ParseLocation(l.String()) == l for every remote
+// location, so an ambiguity message hands the user an identifier that resolves.
+// That is why the empty remote path prints as "~" — and why CanonicalRemotePath
+// folds "~" back to "".
+func (l Location) String() string {
+	if l.IsLocal() {
+		return l.Path
+	}
+	if l.Path == "" {
+		return l.Host + ":~"
+	}
+	return l.Host + ":" + l.Path
+}
+
+// ParseLocation interprets a user-typed location. `[user@]host:/path` and
+// `[user@]host:~[/path]` address a remote session explicitly; anything else is
+// not a location identifier (callers treat it as a bare path).
+//
+// A Windows-style drive letter ("C:\src") is not a host:path form, and neither
+// is a relative "foo:bar" — the remote form requires an absolute or ~-rooted
+// remote path.
+func ParseLocation(identifier string) (Location, bool) {
+	idx := strings.Index(identifier, ":")
+	if idx <= 0 {
+		return Location{}, false
+	}
+	host, remotePath := identifier[:idx], identifier[idx+1:]
+	if host == "" || strings.ContainsAny(host, "/\\ ") {
+		return Location{}, false
+	}
+	if !strings.HasPrefix(remotePath, "/") && !strings.HasPrefix(remotePath, "~") {
+		return Location{}, false
+	}
+	return RemoteLocation(host, remotePath), true
+}
+
+// RemoteCDPrefix renders the `cd <dir> && ` prefix that puts the remote command
+// in remotePath, or "" when no `cd` is needed.
+//
+// This is the EXECUTION half of the rule CanonicalRemotePath states for
+// identity, and the two must agree or a session runs somewhere other than where
+// its identity says it does:
+//
+//   - canonical "" (i.e. "", "~", "~/") emits nothing. `ssh host <cmd>` already
+//     starts <cmd> in the remote user's home, so "no cd" and "cd $HOME" are the
+//     same directory — which is exactly why the three spellings are ONE location.
+//   - a ~-rooted path keeps its tilde UNQUOTED so the remote shell expands it
+//     against the REMOTE user's home. `cd '~/work'` (the old form) is a literal
+//     directory named "~" — the round-3 review's blocking finding.
+//   - anything else is a literal path and is single-quoted in full.
+//
+// The result is spliced into the payload that wrapForSSH hands to ssh, which
+// quotes the whole program exactly once. Every character except a deliberate
+// tilde prefix is inside single quotes, so a remote path containing ;/$() cannot
+// inject.
+func RemoteCDPrefix(remotePath string) string {
+	p := CanonicalRemotePath(remotePath)
+	if p == "" {
+		return ""
+	}
+	return "cd " + remoteDirShellExpr(p) + " && "
+}
+
+// remoteDirShellExpr quotes a canonical remote path for the remote shell,
+// leaving a tilde prefix unquoted so it expands. It is only ever called with a
+// non-empty canonical path.
+func remoteDirShellExpr(p string) string {
+	if !strings.HasPrefix(p, "~") {
+		return shellQuote(p)
+	}
+	// Split "~" or "~user" off the first segment; bash only expands a tilde
+	// prefix that is unquoted and at the start of the word.
+	prefix, rest := p, ""
+	if idx := strings.Index(p, "/"); idx >= 0 {
+		prefix, rest = p[:idx], p[idx+1:]
+	}
+	if !tildePrefixIsShellSafe(prefix) {
+		// A username we cannot vouch for: quote the whole thing rather than
+		// splice unquoted text into the remote shell. The cd then fails
+		// loudly on the remote instead of executing something we did not mean.
+		return shellQuote(p)
+	}
+	if rest == "" {
+		return prefix
+	}
+	return prefix + "/" + shellQuote(rest)
+}
+
+// tildePrefixIsShellSafe reports whether prefix is "~" or "~<username>" with a
+// username made only of characters that cannot mean anything to a shell.
+func tildePrefixIsShellSafe(prefix string) bool {
+	if prefix == "~" {
+		return true
+	}
+	if !strings.HasPrefix(prefix, "~") {
+		return false
+	}
+	for _, r := range prefix[1:] {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '_', r == '-', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/session/location.go
+++ b/internal/session/location.go
@@ -61,18 +61,43 @@ func normalizeLocalPath(p string) string {
 //	"~"   — what Location.String() prints, so it is what a user types back
 //	"~/"  — the same with a trailing slash
 //
-// All three canonicalize to "". Everything else keeps its ~-rooted or absolute
-// form with trailing slashes stripped: "~/work" is a real place under the
-// remote home and stays distinct from "" and from any local path.
+// All three canonicalize to "".
+//
+// A RELATIVE remote path is resolved the same way, for the same reason: `ssh
+// host <cmd>` starts in the remote home, so `--remote-path work` runs in
+// $HOME/work — the identical directory `--remote-path ~/work` names. They are
+// therefore ONE location and canonicalize to the ~-rooted form.
+//
+// Folding relative paths here rather than teaching ParseLocation to accept them
+// is what keeps Location.String() parseable (review round 1, finding F3):
+// String() used to render a relative path as "host:work", which ParseLocation
+// rejected, so an ambiguity message printed an identifier that then resolved to
+// NOT_FOUND. ParseLocation stays strict — accepting "host:relative" there would
+// let the explicit-location syntax shadow ordinary titles, which is the hazard
+// the strictness exists to prevent.
+//
+// Everything else keeps its absolute form with trailing slashes stripped.
 //
 // This is the identity half of the rule. RemoteCDPrefix is the execution half,
-// and they are tested against each other (see TestRemotePathIdentityAndExecutionAgree).
+// and they are tested against each other (see
+// TestRemoteCDPrefix_IdentityAndExecutionAgree).
 func CanonicalRemotePath(p string) string {
 	p = normalizeLocalPath(p)
-	if p == "~" {
+	if p == "~" || p == "" {
 		return ""
 	}
-	return p
+	if strings.HasPrefix(p, "/") || strings.HasPrefix(p, "~") {
+		return p
+	}
+	// Relative to the remote home. Strip a leading "./" so "./work", "work" and
+	// "~/work" are one location, and fold a bare "." onto the home itself.
+	for strings.HasPrefix(p, "./") {
+		p = strings.TrimPrefix(p, "./")
+	}
+	if p == "" || p == "." {
+		return ""
+	}
+	return "~/" + p
 }
 
 // LocalLocation builds the location of a session that runs on this machine.
@@ -114,8 +139,13 @@ func (l Location) IsLocal() bool { return l.Host == "" }
 //
 // The rendered form round-trips: ParseLocation(l.String()) == l for every remote
 // location, so an ambiguity message hands the user an identifier that resolves.
-// That is why the empty remote path prints as "~" — and why CanonicalRemotePath
-// folds "~" back to "".
+// That is why the empty remote path prints as "~" (and why CanonicalRemotePath
+// folds "~" back to ""), and why a relative remote path is canonicalized to its
+// ~-rooted form before it ever reaches String(). The property is pinned by
+// TestLocationString_RoundTripsThroughParseLocation over every path shape.
+//
+// A LOCAL location renders as the bare path, which ParseLocation deliberately
+// does not accept — bare paths are answered by ResolveSession's path branch.
 func (l Location) String() string {
 	if l.IsLocal() {
 		return l.Path

--- a/internal/session/location_identity_execution_test.go
+++ b/internal/session/location_identity_execution_test.go
@@ -56,21 +56,89 @@ func TestCanonicalRemotePath_FoldsTheSpellingsOfTheRemoteHome(t *testing.T) {
 // TestLocationString_RoundTripsThroughParseLocation is the property the
 // ambiguity messages depend on: they print a location and tell the user to
 // retype it, so what they print has to resolve back to the same location.
+//
+// Review round 1, finding F3: this held for absolute and ~-rooted paths but not
+// for a RELATIVE one. `add --ssh host --remote-path work` was accepted and
+// String() rendered it as "host:work", which ParseLocation rejected — so the CLI
+// printed an identifier that answered NOT_FOUND. The table below covers every
+// shape a --remote-path can take, which is what stops the class recurring.
 func TestLocationString_RoundTripsThroughParseLocation(t *testing.T) {
-	for _, loc := range []Location{
-		RemoteLocation("alice@host-a", ""),
-		RemoteLocation("alice@host-a", "~"),
-		RemoteLocation("alice@host-a", "~/work"),
-		RemoteLocation("host-b", "/srv/app"),
-	} {
+	// Every spelling a user can give --remote-path, including the ones that
+	// canonicalize onto each other.
+	remotePaths := []string{
+		"",           // no --remote-path
+		"~",          // the remote home, as String() prints it
+		"~/",         //
+		"~/work",     // under the remote home
+		"~/work/",    //
+		"work",       // RELATIVE — F3
+		"./work",     //
+		"work/",      //
+		"deep/sub",   // relative, multi-segment
+		".",          // the remote home again
+		"/srv/app",   // absolute
+		"/srv/app/",  //
+		"/srv/app//", //
+		"/",          // remote root
+	}
+
+	for _, rp := range remotePaths {
+		loc := RemoteLocation("alice@host-a", rp)
 		rendered := loc.String()
+
 		parsed, ok := ParseLocation(rendered)
 		if !ok {
-			t.Errorf("ParseLocation(%q) refused a string Location.String() produced", rendered)
+			t.Errorf("--remote-path %q renders as %q, which ParseLocation REFUSES — the CLI would print an identifier that does not resolve", rp, rendered)
 			continue
 		}
 		if parsed != loc {
-			t.Errorf("round trip of %+v via %q produced %+v", loc, rendered, parsed)
+			t.Errorf("--remote-path %q: round trip via %q produced %+v, want %+v", rp, rendered, parsed, loc)
+		}
+	}
+
+	// The equivalences the canonical form asserts, spelled out.
+	home := RemoteLocation("alice@host-a", "")
+	for _, sameAsHome := range []string{"~", "~/", ".", "./"} {
+		if got := RemoteLocation("alice@host-a", sameAsHome); got != home {
+			t.Errorf("--remote-path %q = %+v, want the remote home %+v", sameAsHome, got, home)
+		}
+	}
+	underHome := RemoteLocation("alice@host-a", "~/work")
+	for _, sameAsUnderHome := range []string{"work", "./work", "work/", "~/work/"} {
+		if got := RemoteLocation("alice@host-a", sameAsUnderHome); got != underHome {
+			t.Errorf("--remote-path %q = %+v, want %+v — ssh starts in the remote home, so these are one directory", sameAsUnderHome, got, underHome)
+		}
+	}
+	// ...and an absolute path is emphatically NOT the same place.
+	if RemoteLocation("alice@host-a", "/work") == underHome {
+		t.Error("/work was folded onto ~/work")
+	}
+}
+
+// TestRelativeRemotePath_IdentityAndExecutionAgree is the F3 fix held to the
+// same standard as the `~` rule: folding "work" onto "~/work" for identity is
+// only correct if they also RUN in the same directory.
+func TestRelativeRemotePath_IdentityAndExecutionAgree(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "work"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	want := filepath.Join(home, "work")
+	for _, spelling := range []string{"work", "./work", "~/work", "work/"} {
+		script := RemoteCDPrefix(spelling) + `printf '%s' "$PWD"`
+		cmd := exec.Command("bash", "-c", script)
+		// The shell starts in $HOME, exactly as `ssh host <cmd>` does — which is
+		// why a relative remote path means "under the remote home" at all.
+		cmd.Dir = home
+		cmd.Env = append(os.Environ(), "HOME="+home)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("--remote-path %q: prefix %q failed: %v (%s)", spelling, RemoteCDPrefix(spelling), err, out)
+			continue
+		}
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Errorf("--remote-path %q ran in %q, want %q (prefix %q)", spelling, got, want, RemoteCDPrefix(spelling))
 		}
 	}
 }

--- a/internal/session/location_identity_execution_test.go
+++ b/internal/session/location_identity_execution_test.go
@@ -1,0 +1,246 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The round-3 review of the previous attempt at this epic failed on exactly one
+// thing: SSHRemotePath "~" was folded into "" for location IDENTITY while
+// EXECUTION single-quoted it into `cd '~'`, which is a literal directory named
+// "~", not $HOME. Two spellings that compared equal ran in different places, and
+// the same quoting made an accepted "~/work" mean a literal "~" directory.
+//
+// These tests hold identity and execution against each other. CanonicalRemotePath
+// is the identity half and RemoteCDPrefix is the execution half; both live in
+// location.go so there is one rule, and the end-to-end test below runs the real
+// composed ssh command line through a fake `ssh` that reproduces ssh's own
+// semantics (start in the remote user's home, hand the last argument to a shell).
+
+// --- The rule, stated on both sides ------------------------------------------
+
+// TestCanonicalRemotePath_FoldsTheSpellingsOfTheRemoteHome pins the identity
+// half.
+func TestCanonicalRemotePath_FoldsTheSpellingsOfTheRemoteHome(t *testing.T) {
+	same := []string{"", "~", "~/", "  ~  "}
+	for _, spelling := range same {
+		if got := CanonicalRemotePath(spelling); got != "" {
+			t.Errorf("CanonicalRemotePath(%q) = %q, want \"\" — every spelling of the remote home is ONE location", spelling, got)
+		}
+	}
+
+	distinct := map[string]string{
+		"~/work":     "~/work",
+		"~/work/":    "~/work",
+		"/srv/app":   "/srv/app",
+		"/srv/app//": "/srv/app",
+		"/":          "/",
+	}
+	for in, want := range distinct {
+		if got := CanonicalRemotePath(in); got != want {
+			t.Errorf("CanonicalRemotePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	if RemoteLocation("h", "~/work") == RemoteLocation("h", "") {
+		t.Error("a path UNDER the remote home collapsed onto the remote home itself")
+	}
+	if RemoteLocation("h", "") != RemoteLocation("h", "~") {
+		t.Error(`remote paths "" and "~" must be the SAME location — they run in the same directory`)
+	}
+}
+
+// TestLocationString_RoundTripsThroughParseLocation is the property the
+// ambiguity messages depend on: they print a location and tell the user to
+// retype it, so what they print has to resolve back to the same location.
+func TestLocationString_RoundTripsThroughParseLocation(t *testing.T) {
+	for _, loc := range []Location{
+		RemoteLocation("alice@host-a", ""),
+		RemoteLocation("alice@host-a", "~"),
+		RemoteLocation("alice@host-a", "~/work"),
+		RemoteLocation("host-b", "/srv/app"),
+	} {
+		rendered := loc.String()
+		parsed, ok := ParseLocation(rendered)
+		if !ok {
+			t.Errorf("ParseLocation(%q) refused a string Location.String() produced", rendered)
+			continue
+		}
+		if parsed != loc {
+			t.Errorf("round trip of %+v via %q produced %+v", loc, rendered, parsed)
+		}
+	}
+}
+
+// TestRemoteCDPrefix_IdentityAndExecutionAgree is the core of the round-3
+// objection: for every remote path, the directory the command RUNS in must be
+// the directory the identity rule says it is. It executes the emitted prefix in
+// a real shell rather than asserting on its text, because `cd '~'` looks
+// perfectly reasonable as text and is wrong.
+func TestRemoteCDPrefix_IdentityAndExecutionAgree(t *testing.T) {
+	home := t.TempDir()
+	for _, sub := range []string{"work", "my dir", "quote'dir"} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	elsewhere := t.TempDir()
+
+	cases := []struct {
+		remotePath string
+		wantDir    string
+	}{
+		{"", home},                                  // no --remote-path: ssh lands in the remote home
+		{"~", home},                                 // the spelling String() prints
+		{"~/", home},                                //
+		{"~/work", filepath.Join(home, "work")},     // under the remote home
+		{"~/work/", filepath.Join(home, "work")},    //
+		{"~/my dir", filepath.Join(home, "my dir")}, // needs quoting AND tilde expansion
+		{"~/quote'dir", filepath.Join(home, "quote'dir")},
+		{elsewhere, elsewhere}, // absolute
+	}
+
+	for _, c := range cases {
+		// The shell starts in $HOME, exactly as `ssh host <cmd>` does, so "no
+		// prefix" must mean "the remote home".
+		script := RemoteCDPrefix(c.remotePath) + `printf '%s' "$PWD"`
+		cmd := exec.Command("bash", "-c", script)
+		cmd.Dir = home
+		cmd.Env = append(os.Environ(), "HOME="+home)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Errorf("remote path %q: prefix %q failed to execute: %v (%s)", c.remotePath, RemoteCDPrefix(c.remotePath), err, out)
+			continue
+		}
+		got := strings.TrimSpace(string(out))
+		if got != c.wantDir {
+			t.Errorf("remote path %q ran in %q, want %q (prefix was %q)", c.remotePath, got, c.wantDir, RemoteCDPrefix(c.remotePath))
+		}
+
+		// ...and the identity rule must agree with where it actually ran.
+		canonical := CanonicalRemotePath(c.remotePath)
+		if canonical == "" && got != home {
+			t.Errorf("remote path %q canonicalises to the remote home but ran in %q", c.remotePath, got)
+		}
+	}
+}
+
+// TestRemoteCDPrefix_DoesNotInject: a remote path is attacker-influenced state
+// (it comes off disk), so the emitted prefix must not execute anything.
+func TestRemoteCDPrefix_DoesNotInject(t *testing.T) {
+	home := t.TempDir()
+	marker := filepath.Join(home, "pwned")
+
+	for _, evil := range []string{
+		"/tmp/x; touch " + marker,
+		"/tmp/x$(touch " + marker + ")",
+		"~/$(touch " + marker + ")",
+		"~/`touch " + marker + "`",
+	} {
+		script := RemoteCDPrefix(evil) + `printf ok`
+		cmd := exec.Command("bash", "-c", script)
+		cmd.Env = append(os.Environ(), "HOME="+home)
+		_, _ = cmd.CombinedOutput() // the cd is expected to FAIL; that is fine
+		if _, err := os.Stat(marker); err == nil {
+			t.Fatalf("remote path %q executed: prefix was %q", evil, RemoteCDPrefix(evil))
+		}
+	}
+}
+
+// --- The predicate the transcript boundary rests on ---------------------------
+
+// TestTranscriptIsResolvableLocally_IsTheOneRule keeps the predicate itself
+// honest: the whole enumeration in remote_transcript_boundary.go depends on it.
+func TestTranscriptIsResolvableLocally_IsTheOneRule(t *testing.T) {
+	local := NewInstanceWithTool("l", t.TempDir(), "claude")
+	if !local.TranscriptIsResolvableLocally() {
+		t.Error("a local session's transcript must be resolvable locally")
+	}
+
+	remote := NewInstanceWithTool("r", t.TempDir(), "claude")
+	remote.SSHHost = "alice@host-a"
+	if remote.TranscriptIsResolvableLocally() {
+		t.Error("a remote session's transcript must never be resolvable locally")
+	}
+
+	// True regardless of whether --remote-path was given: SSHHost alone makes
+	// the conversation live on another machine.
+	remote.SSHRemotePath = ""
+	if remote.TranscriptIsResolvableLocally() {
+		t.Error("a remote session with no --remote-path is still remote")
+	}
+
+	var nilInst *Instance
+	if nilInst.TranscriptIsResolvableLocally() {
+		t.Error("nil must not claim a locally resolvable transcript")
+	}
+}
+
+// --- #1858: the config-dir expression -----------------------------------------
+
+// TestConfigDirShellExpr_RemoteHomeRelative pins the expression itself: a path
+// under the LOCAL home is only meaningful relative to A home, so it is emitted
+// relative to $HOME for the remote shell to expand. A path OUTSIDE the local
+// home is the user's own absolute declaration — the reporter's working
+// `[profiles.<account>.claude].config_dir = /Users/cloudlydr/.claude` case — and
+// passes through unchanged.
+func TestConfigDirShellExpr_RemoteHomeRelative(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	remote := NewInstanceWithTool("remote", t.TempDir(), "claude")
+	remote.SSHHost = "cloudlydr@remote-host"
+	local := NewInstanceWithTool("local", t.TempDir(), "claude")
+
+	underHome := filepath.Join(home, ".claude")
+	outsideHome := "/Users/cloudlydr/.claude"
+
+	if got := remote.configDirShellExpr(underHome); !strings.Contains(got, `"$HOME"`) {
+		t.Errorf("a local-home config dir was shipped literally to the remote host: %s", got)
+	}
+	if got := remote.configDirShellExpr(underHome); strings.Contains(got, home) {
+		t.Errorf("the literal local home %q leaked into the remote expression: %s", home, got)
+	}
+	if got := remote.configDirShellExpr(home); got != `"$HOME"` {
+		t.Errorf("the local home itself should render as \"$HOME\", got %s", got)
+	}
+	if got := remote.configDirShellExpr(outsideHome); strings.Contains(got, "$HOME") {
+		t.Errorf("an absolute config dir outside the local home must pass through unchanged, got %s", got)
+	}
+
+	// A local session is byte-identical to before the change.
+	for _, dir := range []string{underHome, outsideHome, home} {
+		if got, want := local.configDirShellExpr(dir), shellQuoteForTest(dir); got != want {
+			t.Errorf("local session config dir changed shape: got %s, want %s", got, want)
+		}
+	}
+}
+
+// TestConfigDirShellExpr_IsInjectionSafe: the expression lands in a `bash -c`
+// payload, so everything except the deliberate "$HOME" must be quoted.
+func TestConfigDirShellExpr_IsInjectionSafe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	marker := filepath.Join(home, "pwned")
+
+	remote := NewInstanceWithTool("remote", t.TempDir(), "claude")
+	remote.SSHHost = "cloudlydr@remote-host"
+
+	for _, evil := range []string{
+		filepath.Join(home, "a$(touch "+marker+")"),
+		filepath.Join(home, "b`touch "+marker+"`"),
+		filepath.Join(home, "c;touch "+marker),
+		"/outside/$(touch " + marker + ")",
+	} {
+		expr := remote.configDirShellExpr(evil)
+		if err := evalShellValue(t, expr, home); err != nil {
+			t.Fatalf("expression %q failed to evaluate: %v", expr, err)
+		}
+		if _, err := os.Stat(marker); err == nil {
+			t.Fatalf("config dir %q injected; expression was %s", evil, expr)
+		}
+	}
+}

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -54,6 +54,12 @@ func MigrateConversationFrom(inst *Instance, srcConfigDir, targetConfigDir strin
 	if inst.Tool != "claude" {
 		return "", fmt.Errorf("conversation migration is only supported for claude sessions (tool: %s)", inst.Tool)
 	}
+	// #1851: the file this would move is located through the local placeholder
+	// ProjectPath, so for an --ssh session it belongs to a LOCAL session. Moving
+	// it takes a conversation away from the session that owns it.
+	if !inst.TranscriptIsResolvableLocally() {
+		return "", nil
+	}
 	src := ExpandPath(strings.TrimSpace(srcConfigDir))
 	dst := ExpandPath(strings.TrimSpace(targetConfigDir))
 	if src == "" || dst == "" {
@@ -170,6 +176,12 @@ func copyDirVerified(src, dst string) error {
 // restored path (or "" for no-op) and any error.
 func RestoreOrphanedConversationBackup(inst *Instance, configDir string) (string, error) {
 	if inst == nil || inst.Tool != "claude" || inst.ClaudeSessionID == "" || strings.TrimSpace(configDir) == "" {
+		return "", nil
+	}
+	// #1851: the .bak- orphan this would restore lives in a LOCAL project dir
+	// keyed on the placeholder ProjectPath; for an --ssh session it is another
+	// session's residue, not this one's.
+	if !inst.TranscriptIsResolvableLocally() {
 		return "", nil
 	}
 

--- a/internal/session/migrate_locate.go
+++ b/internal/session/migrate_locate.go
@@ -36,6 +36,15 @@ func LocateConversationConfigDir(cfg *UserConfig, inst *Instance, extraCandidate
 	if inst == nil || inst.Tool != "claude" || inst.ProjectPath == "" {
 		return "", "", 0
 	}
+	// Every candidate below is a directory on THIS machine, keyed on
+	// ConvertToClaudeDirName(inst.ProjectPath). For an --ssh session ProjectPath
+	// is a local placeholder, so the scan would name a LOCAL session's
+	// conversation — and this function's caller (switch-account) then MIGRATES
+	// the file it names, moving a transcript out from under the session that
+	// owns it (#1851).
+	if !inst.TranscriptIsResolvableLocally() {
+		return "", "", 0
+	}
 	candidates := conversationConfigDirCandidates(cfg, extraCandidates...)
 	projDirName := ConvertToClaudeDirName(inst.ProjectPath)
 

--- a/internal/session/registration_lock.go
+++ b/internal/session/registration_lock.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+// registrationMu serializes session-registration decisions WITHIN this process;
+// the sibling advisory flock serializes them ACROSS processes. One global mutex
+// is enough: registration is rare, and the resource being protected — "which
+// (title, location) pairs are taken in this profile" — is one shared thing.
+var registrationMu sync.Mutex
+
+// RegistrationLock holds both lock layers; Release unwinds them in reverse.
+type RegistrationLock struct {
+	file *os.File
+}
+
+// Release drops the advisory flock and the in-process mutex. Safe on nil.
+func (l *RegistrationLock) Release() {
+	if l == nil {
+		return
+	}
+	if l.file != nil {
+		// Best-effort: LOCK_UN errors are non-actionable; Close drops the fd,
+		// which also releases the advisory lock.
+		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+		_ = l.file.Close()
+	}
+	registrationMu.Unlock()
+}
+
+// AcquireRegistrationLock serializes the read-decide-write window that turns a
+// requested title into a registered session.
+//
+// Why it exists: `add` and `launch` both LOAD the instance list, ask "is this
+// (title, location) taken?", and only then INSERT. Between the question and the
+// answer another process can register the same pair, so two concurrent
+// `add -t dup <path>` runs could both see "free" and both create — the exact
+// state #1850 makes `add` refuse. The same window makes the auto-rename pick
+// the same "(2)" suffix twice, and makes `rename` / `session set <id> title`
+// able to move a session onto a title another process is simultaneously taking.
+//
+// Holding this across [load → decide → insert] makes each of those decisions
+// atomic with respect to every other registration in the same profile:
+//
+//   - the in-process mutex covers goroutines (the TUI, tests with t.Parallel);
+//   - the advisory flock covers separate `agent-deck` processes;
+//   - callers MUST re-read the instance list INSIDE the lock, because a list
+//     loaded before acquiring it is exactly the stale snapshot the lock exists
+//     to invalidate.
+//
+// The lockfile is per profile: two profiles are separate namespaces with
+// separate state.db files, so serializing them together would only add
+// contention. It lives in the locks dir next to the spawn and conductor locks,
+// outside any directory a migration might relocate.
+//
+// Not reentrant. No entry point that takes it calls another that does.
+func AcquireRegistrationLock(profile string) (*RegistrationLock, error) {
+	registrationMu.Lock()
+	path, err := registrationLockPath(profile)
+	if err != nil {
+		registrationMu.Unlock()
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		registrationMu.Unlock()
+		return nil, fmt.Errorf("open registration lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		registrationMu.Unlock()
+		return nil, fmt.Errorf("flock registration lock: %w", err)
+	}
+	return &RegistrationLock{file: f}, nil
+}
+
+func registrationLockPath(profile string) (string, error) {
+	locks, err := resolveLocksDirForSpawnLock()
+	if err != nil {
+		return "", fmt.Errorf("resolve locks dir for registration lock: %w", err)
+	}
+	if err := os.MkdirAll(locks, 0o700); err != nil {
+		return "", fmt.Errorf("create locks dir for registration lock: %w", err)
+	}
+	return filepath.Join(locks, fmt.Sprintf("session-registration-%s.lock", spawnLockSafeID(profile))), nil
+}

--- a/internal/session/remote_transcript_boundary.go
+++ b/internal/session/remote_transcript_boundary.go
@@ -1,0 +1,53 @@
+package session
+
+// This file is documentation, not code: it is the enumeration the "a remote
+// session never resolves its conversation against local disk" rule (#1851) is
+// only as good as.
+//
+// A rule described as unconditional has to be enforced at EVERY entry point,
+// and the previous attempt at this epic was faulted for closing two of three
+// doors while the commit message called the rule unconditional. So the doors
+// are listed here, each one gated on Instance.TranscriptIsResolvableLocally(),
+// and TestRemoteTranscriptBoundary_EveryEntryPointRefuses in
+// issue1851_remote_transcript_boundary_test.go exercises the list.
+//
+// Why a hit is worse than a miss: an --ssh session stores a LOCAL placeholder
+// in ProjectPath (defaulting to the directory `add --ssh` ran in). Every lookup
+// below is keyed on that placeholder or scans all local project dirs, so for a
+// remote session it does not fail to find a transcript — it finds a LOCAL
+// session's transcript.
+//
+// The doors, in package session:
+//
+//  1. ensureClaudeSessionIDFromDisk        (instance.go) — Start-path adoption
+//  2. ensureClaudeSessionIDFromDiskForRestart (instance.go) — the #1851 report
+//  3. findLatestClaudeTranscriptOnDisk     (instance.go) — writes the adopted id
+//     back onto the instance AND into the pane's tmux env (GetLastResponseBestEffort)
+//  4. GetJSONLPath                         (instance.go) — analytics, transition
+//     notifier, TUI, and GetJSONLPathChecked all funnel through it
+//  5. getClaudeLastResponse                (instance.go) — `session output`
+//  6. sessionHasConversationData           (instance.go) — resume/bind decisions
+//  7. sessionConversationByteSize          (instance.go) — bind tiebreaker
+//  8. sessionConversationMtime             (instance.go) — bind tiebreaker
+//  9. findSessionFileInAllProjects         (instance.go) — scans every project dir
+// 10. claudeTranscriptPathIn               (handoff.go) — CONSTRUCTS a path when
+//     nothing is found, so it never returns "not here" on its own
+// 11. BuildClaudeToCodexHandoffPrompt      (handoff.go) — hands a whole transcript
+//     to another tool
+// 12. LocateConversationConfigDir          (migrate_locate.go) — its caller
+//     (switch-account) MIGRATES the file it names
+// 13. MigrateConversation                  (migrate.go) — same, directly
+// 14. RestoreOrphanedConversationBackup    (migrate.go) — restores a .bak over a
+//     local project dir
+//
+// Outside package session:
+//
+// 15. internal/ctxinspect/sessionhost.BuildRequest — its retry ladder re-resolves
+//     against per-instance config dirs
+// 16. cmd/agent-deck streamSessionSend — polls for a local transcript that can
+//     never appear
+//
+// claudeTranscriptDir (instance.go) is deliberately NOT gated: it is a collision
+// KEY, never opened as a path, and it is keyed on the remote location precisely
+// so two remote sessions sharing a placeholder stop being judged co-located. See
+// its doc comment for why changing that key is only safe alongside gates 3-5.

--- a/internal/session/resume_identity.go
+++ b/internal/session/resume_identity.go
@@ -183,7 +183,7 @@ func canResumeClaudeSession(inst *Instance, sessionID string) bool {
 		inst.logResumeRefusal(sessionID, decision.Reason)
 		return false
 	}
-	return sessionHasConversationData(inst, sessionID)
+	return conversationIsResumable(inst, sessionID)
 }
 
 // ResumeIdentityAllowed exposes the identity half of the chokepoint to

--- a/internal/session/review_r1_ssh_resume_test.go
+++ b/internal/session/review_r1_ssh_resume_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Review round 1, finding F1: SSH Claude sessions could no longer resume a
+// remote conversation.
+//
+// The #1851 transcript boundary makes sessionHasConversationData return false
+// for an --ssh session, which is the correct answer to the question it asks
+// ("is there conversation data on THIS machine?"). But buildClaudeResumeCommand
+// used that answer to choose between `--resume <id>` and `--session-id <id>`,
+// so every remote restart asked claude to CREATE a session under an
+// already-used UUID: the conversation is lost, or claude rejects the id.
+//
+// conversationIsResumable separates the two questions. For a remote session the
+// controller's evidence is the id it recorded; the remote claude resolves it
+// against the only disk that can answer.
+
+// remoteClaudeSessionForResume builds an --ssh claude instance that previously
+// ran and carries a conversation id, with no local transcript anywhere.
+func remoteClaudeSessionForResume(t *testing.T, sessionID string) *Instance {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", home+"/.claude")
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	inst := NewInstanceWithTool("remote-resume", t.TempDir(), "claude")
+	inst.SSHHost = "cloudlydr@remote-host"
+	inst.SSHRemotePath = "/srv/app"
+	inst.ClaudeSessionID = sessionID
+	inst.ClaudeDetectedAt = time.Now()
+	return inst
+}
+
+// TestBuildClaudeResumeCommand_RemoteSessionResumesItsConversation is the F1
+// regression itself.
+func TestBuildClaudeResumeCommand_RemoteSessionResumesItsConversation(t *testing.T) {
+	const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	inst := remoteClaudeSessionForResume(t, sessionID)
+
+	cmd := inst.buildClaudeResumeCommand()
+
+	if !strings.Contains(cmd, "--resume "+sessionID) {
+		t.Fatalf("a remote session with a recorded conversation id must resume it, not create a fresh session under an already-used UUID.\ngot: %s", cmd)
+	}
+	if strings.Contains(cmd, "--session-id "+sessionID) {
+		t.Fatalf("remote restart emitted --session-id for an id that is already in use:\n%s", cmd)
+	}
+}
+
+// TestBuildClaudeResumeCommand_RemoteWithNoConversationIDStartsFresh: the
+// evidence is the recorded id, so with no id there is nothing to resume.
+func TestBuildClaudeResumeCommand_RemoteWithNoConversationIDStartsFresh(t *testing.T) {
+	inst := remoteClaudeSessionForResume(t, "")
+
+	cmd := inst.buildClaudeResumeCommand()
+	if strings.Contains(cmd, "--resume") {
+		t.Fatalf("a remote session with no recorded conversation id has nothing to resume:\n%s", cmd)
+	}
+}
+
+// TestBuildClaudeResumeCommand_LocalBehaviourUnchanged guards the local half:
+// the fix must not turn "no conversation on disk" into a resume for a local
+// session, which is the #662 / v1.7.6 behaviour the original check protects.
+func TestBuildClaudeResumeCommand_LocalBehaviourUnchanged(t *testing.T) {
+	const sessionID = "11111111-2222-3333-4444-555555555555"
+
+	// A local session whose transcript does NOT exist must still start fresh.
+	local, _, _, _ := remoteBoundaryFixture(t)
+	local.ClaudeSessionID = "99999999-8888-7777-6666-555555555555" // no file for this id
+	if conversationIsResumable(local, local.ClaudeSessionID) {
+		t.Error("a LOCAL session with no conversation data on disk must not resume")
+	}
+
+	// ...and one whose transcript DOES exist must resume.
+	local.ClaudeSessionID = sessionID
+	if !conversationIsResumable(local, sessionID) {
+		t.Error("a LOCAL session with conversation data on disk must resume")
+	}
+}
+
+// TestConversationIsResumable_SeparatesTheTwoQuestions pins the distinction the
+// fix rests on: the local-disk predicate stays honest (false for remote — the
+// #1851 boundary) while the resume decision gets the SSH-aware answer.
+func TestConversationIsResumable_SeparatesTheTwoQuestions(t *testing.T) {
+	const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	remote := remoteClaudeSessionForResume(t, sessionID)
+
+	if sessionHasConversationData(remote, sessionID) {
+		t.Error("sessionHasConversationData must stay false for a remote session: it answers a LOCAL-disk question (#1851)")
+	}
+	if !conversationIsResumable(remote, sessionID) {
+		t.Error("conversationIsResumable must be true for a remote session with a recorded id (F1)")
+	}
+	if conversationIsResumable(remote, "") {
+		t.Error("no recorded id means nothing to resume, remote or not")
+	}
+	if conversationIsResumable(nil, "") {
+		t.Error("nil instance with no id must not be resumable")
+	}
+}
+
+// TestBuildClaudeCommandWithMessage_RemoteResumeModeResumes covers the sibling
+// call site: `SessionMode == "resume"` had the identical bug.
+func TestBuildClaudeCommandWithMessage_RemoteResumeModeResumes(t *testing.T) {
+	const sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	inst := remoteClaudeSessionForResume(t, sessionID)
+
+	opts := inst.GetClaudeOptions()
+	if opts == nil {
+		userConfig, _ := LoadUserConfig()
+		opts = NewClaudeOptions(userConfig)
+	}
+	opts.SessionMode = "resume"
+	opts.ResumeSessionID = sessionID
+	if err := inst.SetClaudeOptions(opts); err != nil {
+		t.Fatalf("SetClaudeOptions: %v", err)
+	}
+
+	cmd := inst.buildClaudeCommandWithMessage("claude", "")
+	if !strings.Contains(cmd, "--resume "+sessionID) {
+		t.Fatalf("resume-mode spawn for a remote session did not resume its conversation:\n%s", cmd)
+	}
+}
+
+// TestSessionHasConversationData_HookGuardsStayConservative: the OTHER callers
+// of sessionHasConversationData are "is this candidate id trustworthy?" guards
+// protecting an established instance from a foreign ephemeral. A local-disk
+// "no" is the correct conservative answer there and must NOT become "yes"
+// through the resume-side fix.
+func TestSessionHasConversationData_HookGuardsStayConservative(t *testing.T) {
+	remote := remoteClaudeSessionForResume(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	if sessionHasConversationData(remote, "ffffffff-ffff-ffff-ffff-ffffffffffff") {
+		t.Error("an unknown candidate id must not be credited with conversation data for a remote session")
+	}
+	if got := sessionConversationByteSize(remote, "ffffffff-ffff-ffff-ffff-ffffffffffff"); got != 0 {
+		t.Errorf("sessionConversationByteSize = %d for a remote session, want 0", got)
+	}
+}

--- a/internal/session/ssh_config_dir.go
+++ b/internal/session/ssh_config_dir.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+// configDirShellExpr renders a resolved CLAUDE_CONFIG_DIR as a shell VALUE
+// EXPRESSION for the payload this instance's spawn command becomes.
+//
+// Issue #1858 (reporter @yuvalsc): for an --ssh session that payload runs on
+// the REMOTE host, as the remote user, but the path was built from the LOCAL
+// machine's home and passed verbatim:
+//
+//	export CLAUDE_CONFIG_DIR=/Users/yuvals/.local/share/agent-deck/worker-scratch/<id>
+//
+// With local user `yuvals` and remote user `cloudlydr`, /Users/yuvals does not
+// exist on the remote host, claude cannot create its config dir, and the
+// session exits after ~250ms.
+//
+// The rule: a path under the LOCAL home is only meaningful relative to a home
+// directory, so it is emitted relative to $HOME and left for the remote shell
+// to expand against the remote user's home. A path OUTSIDE the local home is
+// the user's own absolute declaration — that is the reporter's working
+// `[profiles.<account>.claude].config_dir = /Users/cloudlydr/.claude` case —
+// and passes through unchanged. Local sessions are unaffected and keep the
+// exact literal path they always had.
+//
+// The result is shell-safe: everything except the deliberate `"$HOME"` is
+// single-quoted, so a config dir containing ;/$() cannot inject into the
+// `bash -c` payload (which wrapForSSH then quotes exactly once into
+// `ssh -t <cmd>` — see the escaping note there).
+func (i *Instance) configDirShellExpr(dir string) string {
+	if i == nil || !i.IsSSH() {
+		return shellescape.Quote(dir)
+	}
+	rel, ok := pathRelativeToLocalHome(dir)
+	if !ok {
+		return shellescape.Quote(dir)
+	}
+	if rel == "" {
+		return `"$HOME"`
+	}
+	return `"$HOME"` + shellescape.Quote("/"+rel)
+}
+
+// pathRelativeToLocalHome reports whether dir lives under this machine's home
+// directory and, if so, its path relative to it ("" when dir IS the home dir).
+func pathRelativeToLocalHome(dir string) (string, bool) {
+	home := strings.TrimSpace(os.Getenv("HOME"))
+	if home == "" {
+		var err error
+		if home, err = os.UserHomeDir(); err != nil || home == "" {
+			return "", false
+		}
+	}
+	home = filepath.Clean(home)
+	dir = filepath.Clean(dir)
+	if dir == home {
+		return "", true
+	}
+	if !strings.HasPrefix(dir, home+string(os.PathSeparator)) {
+		return "", false
+	}
+	rel, err := filepath.Rel(home, dir)
+	if err != nil || rel == "" || strings.HasPrefix(rel, "..") {
+		return "", false
+	}
+	return rel, true
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -106,7 +106,16 @@ func configDeclaresTelegram(cfg *UserConfig) bool {
 //
 // When multiple reasons fire, EnsureWorkerScratchConfigDir combines the
 // deny+allow lists.
+// Never true for an --ssh session (issue #1858): the scratch is a LOCAL tree —
+// a settings.json plus plugin symlinks under this machine's data dir — and the
+// remote spawn would be handed a path built from the LOCAL home. When the remote
+// user differs from the local one that path does not exist and is not creatable
+// there, so claude exits immediately (~250ms, the reported symptom). A remote
+// session runs under the remote host's own config dir.
 func (i *Instance) NeedsWorkerScratchConfigDir() bool {
+	if i != nil && i.IsSSH() {
+		return false
+	}
 	return needsScratchForTelegram(i) ||
 		needsScratchForExplicitPlugins(i) ||
 		needsScratchForGlobalChannelConflict(i) ||
@@ -752,6 +761,20 @@ func (i *Instance) CleanupWorkerScratchConfigDir() {
 // this the only place the swap can happen.
 func (i *Instance) applyWorkerScratchOverride(resolvedConfigDir string) string {
 	if i.WorkerScratchConfigDir == "" {
+		return resolvedConfigDir
+	}
+	// Issue #1858, defense in depth: the scratch path is built from the LOCAL
+	// home and the remote host cannot use it. NeedsWorkerScratchConfigDir
+	// already refuses to prepare one for a remote session; this makes the swap
+	// itself impossible even if the field was set some other way (an older
+	// state.db row, a profile migration).
+	if i.IsSSH() {
+		sessionLog.Info("worker_scratch_override_skipped_remote",
+			slog.String("instance_id", i.ID),
+			slog.String("ssh_host", i.SSHHost),
+			slog.String("resolved_config_dir", resolvedConfigDir),
+			slog.String("worker_scratch_config_dir", i.WorkerScratchConfigDir),
+		)
 		return resolvedConfigDir
 	}
 	sessionLog.Info("worker_scratch_override",

--- a/skills/agent-deck/scripts/goal/goal.sh
+++ b/skills/agent-deck/scripts/goal/goal.sh
@@ -73,9 +73,30 @@ PROMPT="${PROMPT//\{MAX_CYCLES\}/$MAX_CYCLES}"
 # capture the session id reliably (launch -m sometimes races with prompts).
 echo "[goal] spawning worker: $WORKER_TITLE in $WORKDIR" >&2
 
-# Create the session
-if ! agent-deck -p "$PROFILE" add "$WORKDIR" -t "$WORKER_TITLE" -c claude -g goal 2>&1 | grep -E "(Created|exists)" >&2; then
-    :  # add may exit non-zero on "already exists"; we tolerate that
+# Create the session.
+#
+# Since #1850 an exact duplicate exits non-zero with an ALREADY_EXISTS payload,
+# which is a fine outcome here — the worker session simply already exists. This
+# used to be `… 2>&1 | grep -E "(Created|exists)"`, which only appeared to work
+# because the new stderr text happens to contain the word "exists"; one wording
+# change would have turned a real failure into a silent success. Branch on the
+# structured code instead, and let anything else fail loudly.
+ADD_OUT="$(agent-deck -p "$PROFILE" add "$WORKDIR" -t "$WORKER_TITLE" -c claude -g goal --json 2>&1)"
+ADD_RC=$?
+if [[ $ADD_RC -ne 0 ]]; then
+    ADD_CODE="$(printf '%s' "$ADD_OUT" | python3 -c "
+import sys, json
+try:
+    print(json.loads(sys.stdin.read()).get('code', ''))
+except Exception:
+    print('')
+" 2>/dev/null)"
+    if [[ "$ADD_CODE" == "ALREADY_EXISTS" ]]; then
+        echo "[goal] worker session already exists: $WORKER_TITLE" >&2
+    else
+        echo "[goal] could not create worker session '$WORKER_TITLE': $ADD_OUT" >&2
+        exit 1
+    fi
 fi
 
 agent-deck -p "$PROFILE" session start "$WORKER_TITLE" >&2 || true


### PR DESCRIPTION
Make SSH session identity reflect where the session actually runs: remote host and remote path, rather than the controller's local placeholder path.

This makes duplicate handling, title resolution, transcript isolation, concurrent registration, remote config paths, and SSH command construction agree on the same location model. Remote conversations resume without consulting local transcript storage, and registration failures now produce consistent structured errors.

Local and remote sessions remain independently addressable when their paths overlap.

Fixes #1850
Fixes #1851
Fixes #1852
Fixes #1853
Fixes #1854
Fixes #1858
