### PR TITLE
fix(tmux): preserve Unicode output for locale-free clients

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmuxutf8"
 )
 
 // tmuxProbeTimeout bounds the plain-argv tmux probes the CLI fires to identify
@@ -25,13 +26,22 @@ import (
 // cadence pollers in internal/tmux did.
 const tmuxProbeTimeout = 3 * time.Second
 
-// tmuxProbeBounded runs `tmux <args…>` under tmuxProbeTimeout and returns
+// tmuxProbeBounded runs `tmux -u <args…>` under tmuxProbeTimeout and returns
 // stdout. exec.CommandContext SIGKILLs a wedged client at the deadline; the
 // WaitDelay bounds the post-kill stdio drain.
+//
+// The global `-u` is the #1867 fix, applied here for the same reason as in
+// internal/tmux's tmuxArgs: every caller of this helper PARSES the bytes it
+// returns. `#{pane_current_path}` in particular is arbitrary user text — a
+// working directory with a non-ASCII component comes back with each such byte
+// rewritten to "_" when the CLI's own locale is not UTF-8, which is the normal
+// state for a conductor-invoked `agent-deck` under systemd/launchd. Prepending
+// keeps the deliberate omission of -L (these probes auto-route via $TMUX; see
+// tmuxProbeTimeout above) intact.
 func tmuxProbeBounded(args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxProbeTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "tmux", args...)
+	cmd := exec.CommandContext(ctx, "tmux", tmuxutf8.Prepend(args)...)
 	cmd.WaitDelay = 2 * time.Second
 	return cmd.Output()
 }

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -41,6 +41,8 @@ const tmuxProbeTimeout = 3 * time.Second
 func tmuxProbeBounded(args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxProbeTimeout)
 	defer cancel()
+	// #nosec G204 -- "tmux" is a fixed binary and args are passed as an argv
+	// slice, never through a shell; callers supply only internal tmux probes.
 	cmd := exec.CommandContext(ctx, "tmux", tmuxutf8.Prepend(args)...)
 	cmd.WaitDelay = 2 * time.Second
 	return cmd.Output()

--- a/cmd/agent-deck/cli_utils_tmuxutf8_test.go
+++ b/cmd/agent-deck/cli_utils_tmuxutf8_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestTmuxProbeBounded_EmitsExactlyOneLeadingUTF8Flag pins the separate CLI
+// probe builder from #1867. These display-message probes deliberately bypass
+// internal/tmux's socket-aware factory so they can auto-route through $TMUX;
+// consequently this test must fail if tmuxutf8.Prepend is removed here even
+// while every internal/tmux factory test remains green.
+func TestTmuxProbeBounded_EmitsExactlyOneLeadingUTF8Flag(t *testing.T) {
+	fakeBin := t.TempDir()
+	fakeTmux := filepath.Join(fakeBin, "tmux")
+	if err := os.WriteFile(fakeTmux, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\"\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	out, err := tmuxProbeBounded("display-message", "-p", "#{session_name}|#{pane_current_path}")
+	if err != nil {
+		t.Fatalf("tmuxProbeBounded: %v", err)
+	}
+
+	got := strings.Fields(string(out))
+	want := []string{"-u", "display-message", "-p", "#{session_name}|#{pane_current_path}"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tmuxProbeBounded argv\n got:  %q\n want: %q", got, want)
+	}
+
+	utf8Flags := 0
+	for _, arg := range got {
+		if arg == "-u" {
+			utf8Flags++
+		}
+	}
+	if utf8Flags != 1 {
+		t.Fatalf("tmuxProbeBounded must emit exactly one -u, got %d in %q", utf8Flags, got)
+	}
+}

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -112,7 +112,7 @@ func NewControlPipe(sessionName, socketName string) (*ControlPipe, error) {
 }
 
 func newControlPipeOnce(sessionName, socketName string) (*ControlPipe, error) {
-	cmd := tmuxExec(socketName, "-C", "-u", "attach-session", "-t", sessionName)
+	cmd := tmuxExec(socketName, "-u", "-C", "attach-session", "-t", sessionName)
 	// Put in own process group so we can kill the entire group on shutdown
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 

--- a/internal/tmux/keysender.go
+++ b/internal/tmux/keysender.go
@@ -100,7 +100,7 @@ func OpenKeySender(socket, target string) (KeySender, error) {
 	// <socket>` selector, and the lint test in tmux_exec_lint_test.go
 	// enforces this. Plain `exec.Command("tmux", ...)` would silently
 	// defeat socket isolation when the user has opted in (#687).
-	cmd := tmuxExec(socket, "-C", "-u", "attach-session", "-t", target)
+	cmd := tmuxExec(socket, "-u", "-C", "attach-session", "-t", target)
 	// Own process group so Close can take down the whole subtree, matching
 	// ControlPipe. Without it a wedged child's descendants outlive Close.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/internal/tmux/keysender_no_implicit_session_test.go
+++ b/internal/tmux/keysender_no_implicit_session_test.go
@@ -111,11 +111,18 @@ func TestOpenKeySender_CreatesNoImplicitSession(t *testing.T) {
 }
 
 // bareControlArgv matches an argv that is nothing but a control-mode tmux
-// invocation, with or without a socket selector: "tmux -C",
-// "tmux -L foo -C", "tmux -S /path -C". This is the shape the 2026-07-26
-// reaper matched with `pgrep -fx "tmux -C"` — on macOS a server auto-started
-// by such a client inherits the argv and becomes indistinguishable from it.
-var bareControlArgv = regexp.MustCompile(`^(\S*/)?tmux( -[LS] \S+)? -C$`)
+// invocation, with or without the global UTF-8 flag and a socket selector:
+// "tmux -C", "tmux -u -C", "tmux -u -L foo -C", "tmux -S /path -C". This is
+// the shape the 2026-07-26 reaper matched with `pgrep -fx "tmux -C"` — on
+// macOS a server auto-started by such a client inherits the argv and becomes
+// indistinguishable from it.
+//
+// The optional `-u` group is load-bearing, not cosmetic: since #1867 the
+// factory emits it on every parsed client, so a regression back to a bare
+// control invocation would produce "tmux -u -L foo -C". Without the group this
+// pattern would silently stop matching that and the guard would go green while
+// guarding nothing.
+var bareControlArgv = regexp.MustCompile(`^(\S*/)?tmux( -u)?( -[LS] \S+)? -C$`)
 
 // TestOpenKeySender_ArgvIsNeverBareControlMode is the 2026-07-26 regression.
 // The client this package spawns must carry its command in argv so no

--- a/internal/tmux/pty_socket_test.go
+++ b/internal/tmux/pty_socket_test.go
@@ -26,14 +26,15 @@ import (
 func TestSession_AttachCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_iso_abc", SocketName: "agentdeck"}
 	cmd := s.attachCmd(context.Background())
-	wantArgs := []string{"tmux", "-L", "agentdeck", "-u", "attach-session", "-t", s.Name}
+	wantArgs := []string{"tmux", "-u", "-L", "agentdeck", "attach-session", "-t", s.Name}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("attach must route through tmuxCmdContext so -L lands before subcommand\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
 }
 
-// TestSession_AttachCmd_EmptySocket_NoDashL: opt-in contract. No config means
-// no -L; the required UTF-8 flag is independent of socket isolation.
+// TestSession_AttachCmd_EmptySocket_NoDashL: opt-in contract. No config =
+// no -L. The global -u is independent of socket selection and preserves the
+// shipped #1789 attach contract when agent-deck itself has no UTF-8 locale.
 func TestSession_AttachCmd_EmptySocket_NoDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_default_abc"}
 	cmd := s.attachCmd(context.Background())
@@ -50,7 +51,7 @@ func TestSession_AttachCmd_EmptySocket_NoDashL(t *testing.T) {
 func TestSession_AttachReadOnlyCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_ro_abc", SocketName: "agentdeck"}
 	cmd := s.attachReadOnlyCmd(context.Background())
-	wantArgs := []string{"tmux", "-L", "agentdeck", "-u", "attach-session", "-r", "-t", s.Name}
+	wantArgs := []string{"tmux", "-u", "-L", "agentdeck", "attach-session", "-r", "-t", s.Name}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("read-only attach must include -L <socket>\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -62,7 +63,7 @@ func TestSession_AttachReadOnlyCmd_WithSocket_PrependsDashL(t *testing.T) {
 func TestSession_ResizeCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_rsz_abc", SocketName: "agentdeck"}
 	cmd := s.resizeCmd(80, 24)
-	wantArgs := []string{"tmux", "-L", "agentdeck", "resize-window", "-t", s.Name, "-x", "80", "-y", "24"}
+	wantArgs := []string{"tmux", "-u", "-L", "agentdeck", "resize-window", "-t", s.Name, "-x", "80", "-y", "24"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("resize must carry -L <socket>\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -75,7 +76,7 @@ func TestSession_ResizeCmd_WithSocket_PrependsDashL(t *testing.T) {
 func TestSession_AttachWindowSelectCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_win_abc", SocketName: "agentdeck"}
 	cmd := s.selectWindowCmd(2)
-	wantArgs := []string{"tmux", "-L", "agentdeck", "select-window", "-t", "agentdeck_win_abc:2"}
+	wantArgs := []string{"tmux", "-u", "-L", "agentdeck", "select-window", "-t", "agentdeck_win_abc:2"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("select-window must carry -L <socket>\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -87,7 +88,7 @@ func TestSession_AttachWindowSelectCmd_WithSocket_PrependsDashL(t *testing.T) {
 func TestSession_StreamOutputCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_stream_abc", SocketName: "agentdeck"}
 	cmd := s.pipePaneStartCmd(context.Background())
-	wantArgs := []string{"tmux", "-L", "agentdeck", "pipe-pane", "-t", s.Name, "-o", "cat"}
+	wantArgs := []string{"tmux", "-u", "-L", "agentdeck", "pipe-pane", "-t", s.Name, "-o", "cat"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("pipe-pane start must carry -L <socket>\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -98,7 +99,7 @@ func TestSession_StreamOutputCmd_WithSocket_PrependsDashL(t *testing.T) {
 func TestSession_StreamOutputStopCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck_stream_abc", SocketName: "agentdeck"}
 	cmd := s.pipePaneStopCmd()
-	wantArgs := []string{"tmux", "-L", "agentdeck", "pipe-pane", "-t", s.Name}
+	wantArgs := []string{"tmux", "-u", "-L", "agentdeck", "pipe-pane", "-t", s.Name}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("pipe-pane stop must carry -L <socket>\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}

--- a/internal/tmux/socket.go
+++ b/internal/tmux/socket.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmuxutf8"
 )
 
 // tmuxSubprocessWaitDelay is the deadline cmd.Wait() waits for stdio I/O
@@ -137,27 +139,44 @@ func tmuxFmt(fields ...string) string {
 	return strings.Join(fields, tmuxFieldSep)
 }
 
-// tmuxArgs builds the full `tmux …` argv for a command, inserting the
-// `-L <name>` socket selector at the front when socketName is non-empty
-// and non-whitespace. An empty socket name is the pre-v1.7.50 default and
-// produces an unmodified argv — zero behavior change for users who do not
-// opt in to socket isolation (scope decision 1: empty default).
+// tmuxArgs builds the full `tmux …` argv for a command: tmux's global `-u`
+// (UTF-8) flag, then the `-L <name>` socket selector when socketName is
+// non-empty and non-whitespace, then the caller's subcommand. An empty socket
+// name is the pre-v1.7.50 default and produces no `-L` — zero behavior change
+// for users who do not opt in to socket isolation (scope decision 1: empty
+// default).
+//
+// The `-u` is the #1867 fix and is why this function, not the call sites, is
+// where the argv is assembled: a tmux client with no UTF-8 locale (systemd,
+// launchd, a bare container, CI) receives every non-ASCII byte rewritten to
+// "_", which destroys the braille spinner that the status fast path reads out
+// of `#{pane_title}`. Adding it here means a future call site is safe for
+// free. See internal/tmuxutf8 for the full rationale and for why forcing a
+// locale into the child environment was rejected instead.
 //
 // The returned slice is always freshly allocated; the caller's args slice
 // is never mutated or aliased.
 //
 // See CHANGELOG v1.7.50 and docs/README socket-isolation section.
 func tmuxArgs(socketName string, args ...string) []string {
-	name := strings.TrimSpace(socketName)
-	if name == "" {
-		out := make([]string, len(args))
-		copy(out, args)
-		return out
+	// Some attach call sites retain a literal leading -u because the repo-wide
+	// AST lint guards the shipped #1789 contract at each spawn. Remove it before
+	// inserting the socket selector; Prepend below restores exactly one global
+	// flag in the correct position.
+	if len(args) > 0 && args[0] == tmuxutf8.Flag {
+		args = args[1:]
 	}
-	out := make([]string, 0, len(args)+2)
-	out = append(out, "-L", name)
-	out = append(out, args...)
-	return out
+	name := strings.TrimSpace(socketName)
+	var out []string
+	if name == "" {
+		out = make([]string, len(args))
+		copy(out, args)
+	} else {
+		out = make([]string, 0, len(args)+2)
+		out = append(out, "-L", name)
+		out = append(out, args...)
+	}
+	return tmuxutf8.Prepend(out)
 }
 
 // tmuxExec constructs an *exec.Cmd that invokes `tmux` with the given
@@ -410,12 +429,12 @@ func ExecContext(ctx context.Context, socketName string, args ...string) *exec.C
 // session is launched via `systemd-run --user tmux <args…>`, the socket
 // selector has to live INSIDE the inner tmux argv — after the literal
 // "tmux" that systemd-run execs, before the subcommand. This helper
-// returns just the inner `[-L <name>] <args…>` slice; callers splice it
+// returns just the inner `-u [-L <name>] <args…>` slice; callers splice it
 // after "tmux" in their systemd-run argv (or use it directly when launcher
 // is "tmux").
 //
-// Empty / whitespace-only socket name returns the input args unchanged, so
-// pre-v1.7.50 call sites see byte-identical argv.
+// Empty / whitespace-only socket name omits only `-L`; `-u` remains because it
+// controls client encoding rather than server selection.
 func buildInnerTmuxArgs(socketName string, args ...string) []string {
 	// This argv is always spawned (directly, or spliced into a systemd-run
 	// argv), so it needs the same refusal as the exec factories — the layer of

--- a/internal/tmux/socket_test.go
+++ b/internal/tmux/socket_test.go
@@ -6,13 +6,18 @@ import (
 )
 
 // TestTmuxArgs_EmptySocketName_LeavesArgsUntouched is the default-socket
-// contract (scope decision 1): socket_name="" means zero behavior change
-// for existing users. The factory must NOT inject -L in that case.
+// contract (scope decision 1): socket_name="" means the factory must NOT
+// inject -L, so users who never opted into socket isolation keep reaching
+// their default server.
+//
+// The leading -u is unconditional and orthogonal (#1867): it forces UTF-8 on
+// the CLIENT and says nothing about which server the client talks to. See
+// tmuxArgs / internal/tmuxutf8.
 func TestTmuxArgs_EmptySocketName_LeavesArgsUntouched(t *testing.T) {
 	got := tmuxArgs("", "list-sessions", "-F", "#{session_name}")
-	want := []string{"list-sessions", "-F", "#{session_name}"}
+	want := []string{"-u", "list-sessions", "-F", "#{session_name}"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("empty socket must pass args through unchanged\n got:  %v\n want: %v", got, want)
+		t.Fatalf("empty socket must pass args through with no -L\n got:  %v\n want: %v", got, want)
 	}
 }
 
@@ -21,7 +26,7 @@ func TestTmuxArgs_EmptySocketName_LeavesArgsUntouched(t *testing.T) {
 // socket via the tmux `-L <name>` flag placed before the subcommand.
 func TestTmuxArgs_WithSocketName_PrependsDashL(t *testing.T) {
 	got := tmuxArgs("agent-deck", "has-session", "-t", "foo")
-	want := []string{"-L", "agent-deck", "has-session", "-t", "foo"}
+	want := []string{"-u", "-L", "agent-deck", "has-session", "-t", "foo"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("socket name must be injected as leading -L <name>\n got:  %v\n want: %v", got, want)
 	}
@@ -40,13 +45,13 @@ func TestTmuxArgs_WithSocketName_DoesNotMutateCallerSlice(t *testing.T) {
 }
 
 // TestTmuxArgs_WithSocketName_EmptyArgs handles the degenerate case. A
-// bare `tmux -L agent-deck` would print help/exit non-zero; still, the
-// factory must not crash or drop the -L flag.
+// bare `tmux -u -L agent-deck` would print help/exit non-zero; still, the
+// factory must not crash or drop either global flag.
 func TestTmuxArgs_WithSocketName_EmptyArgs(t *testing.T) {
 	got := tmuxArgs("agent-deck")
-	want := []string{"-L", "agent-deck"}
+	want := []string{"-u", "-L", "agent-deck"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("zero-arg call must still inject -L\n got:  %v\n want: %v", got, want)
+		t.Fatalf("zero-arg call must still inject -u and -L\n got:  %v\n want: %v", got, want)
 	}
 }
 
@@ -56,21 +61,23 @@ func TestTmuxArgs_WithSocketName_EmptyArgs(t *testing.T) {
 // create an unreachable server).
 func TestTmuxArgs_WhitespaceOnlySocketName_TreatedAsEmpty(t *testing.T) {
 	got := tmuxArgs("   ", "list-sessions")
-	want := []string{"list-sessions"}
+	want := []string{"-u", "list-sessions"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("whitespace-only socket must be treated as empty\n got:  %v\n want: %v", got, want)
 	}
 }
 
 // TestSession_TmuxCmd_EmptySocket_NoDashL: on an un-configured session
-// (new install, no config, no CLI flag), tmuxCmd must produce a plain
-// `tmux …` invocation — preserving pre-v1.7.50 behavior byte-for-byte.
+// (new install, no config, no CLI flag), tmuxCmd must emit no -L at all, so
+// the call still lands on the user's default server exactly as it did
+// pre-v1.7.50. The global -u is present regardless (#1867) — it selects the
+// client's charset, not the server.
 func TestSession_TmuxCmd_EmptySocket_NoDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck-x"}
 	cmd := s.tmuxCmd("has-session", "-t", s.Name)
-	wantArgs := []string{"tmux", "has-session", "-t", s.Name}
+	wantArgs := []string{"tmux", "-u", "has-session", "-t", s.Name}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
-		t.Fatalf("empty SocketName must produce plain tmux invocation\n got:  %v\n want: %v", cmd.Args, wantArgs)
+		t.Fatalf("empty SocketName must produce a tmux invocation with no -L\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
 }
 
@@ -80,7 +87,7 @@ func TestSession_TmuxCmd_EmptySocket_NoDashL(t *testing.T) {
 func TestSession_TmuxCmd_WithSocket_PrependsDashL(t *testing.T) {
 	s := &Session{Name: "agentdeck-x", SocketName: "agent-deck"}
 	cmd := s.tmuxCmd("has-session", "-t", s.Name)
-	wantArgs := []string{"tmux", "-L", "agent-deck", "has-session", "-t", s.Name}
+	wantArgs := []string{"tmux", "-u", "-L", "agent-deck", "has-session", "-t", s.Name}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("non-empty SocketName must inject -L in front of subcommand\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1276,8 +1276,8 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	// target the same isolated server. Without this, the session would be
 	// minted on the default server while later Session.tmuxCmd calls —
 	// which DO carry -L — would probe the isolated server and find
-	// nothing. Empty SocketName preserves pre-v1.7.50 behavior exactly
-	// (buildInnerTmuxArgs returns the args unchanged).
+	// nothing. Empty SocketName emits no -L at all, so the spawn still lands
+	// on the user's default server exactly as it did pre-v1.7.50.
 	//
 	// #1694: -x/-y birth the window at the terminal agent-deck runs on
 	// (generous fallback when there is no TTY) so the tool's FIRST paint is
@@ -1285,6 +1285,12 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	// that fixes its layout on frame one stays clipped forever — see
 	// InitialWindowSize. Appended AFTER -c so the argv prefix that callers and
 	// fallback helpers key on is unchanged.
+	// buildInnerTmuxArgs also prepends tmux's global -u (#1867). That is
+	// unconditional and independent of the socket: it forces the CLIENT to
+	// UTF-8 so nothing agent-deck later reads back is "_"-mangled. It is
+	// spliced INSIDE the inner tmux argv here, after the literal "tmux" that
+	// systemd-run execs — a global flag placed before "tmux" would be
+	// systemd-run's, not tmux's.
 	cols, rows := InitialWindowSize()
 	tmuxArgs := buildInnerTmuxArgs(s.SocketName, "new-session", "-d", "-s", s.Name, "-c", workDir,
 		"-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows))

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -57,7 +57,7 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 	// The tmux args shape after the systemd-run prefix must match the scope
 	// form's tmux args shape exactly. We use stripSystemdRunPrefix to verify.
 	tmuxArgs := stripSystemdRunPrefix(args)
-	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-service_1234abcd", "-c", "/tmp/project",
+	assert.Equal(t, []string{"-u", "new-session", "-d", "-s", "agentdeck_test-service_1234abcd", "-c", "/tmp/project",
 		"-x", "173", "-y", "41"}, tmuxArgs)
 }
 
@@ -101,7 +101,7 @@ func TestStartCommandSpec_LaunchAs_Direct_UsesDirectTmux(t *testing.T) {
 
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	assert.Equal(t, "tmux", launcher, "LaunchAs=direct must override LaunchInUserScope=true")
-	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-direct_1234abcd", "-c", "/tmp/project",
+	assert.Equal(t, []string{"-u", "new-session", "-d", "-s", "agentdeck_test-direct_1234abcd", "-c", "/tmp/project",
 		"-x", "173", "-y", "41"}, args)
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3032,7 +3032,7 @@ func TestStartCommandSpec_Default(t *testing.T) {
 
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	assert.Equal(t, "tmux", launcher)
-	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
+	assert.Equal(t, []string{"-u", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
 		"-x", "173", "-y", "41"}, args)
 }
 
@@ -3050,7 +3050,7 @@ func TestStartCommandSpec_UserScope(t *testing.T) {
 	require.GreaterOrEqual(t, len(args), 8)
 	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
 	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[5])
-	assert.Equal(t, []string{"tmux", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
+	assert.Equal(t, []string{"tmux", "-u", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
 		"-x", "173", "-y", "41"}, args[6:])
 }
 
@@ -3107,10 +3107,10 @@ func TestStartCommandSpec_InitialProcess_WrapsBashRegardlessOfContent(t *testing
 			// #1567/#1580: the command is delivered as SEPARATE argv tokens
 			// (bash, -c, COMMAND) so tmux execvp()s bash directly instead of
 			// wrapping the string through the server default-shell. With the
-			// #1694 birth size that is 13 args total:
-			// new-session -d -s NAME -c DIR -x COLS -y ROWS bash -c COMMAND.
-			require.Equal(t, 13, len(args),
-				"expected 13 args (new-session -d -s NAME -c DIR -x COLS -y ROWS bash -c COMMAND)")
+			// #1694 birth size and #1867 global -u that is 14 args total:
+			// -u new-session -d -s NAME -c DIR -x COLS -y ROWS bash -c COMMAND.
+			require.Equal(t, 14, len(args),
+				"expected 14 args (-u new-session -d -s NAME -c DIR -x COLS -y ROWS bash -c COMMAND)")
 
 			require.Equal(t, "bash", args[len(args)-3],
 				"command must be exec'd under bash for fish/zsh/bash compatibility")

--- a/internal/tmuxutf8/issue1867_nonutf8_client_test.go
+++ b/internal/tmuxutf8/issue1867_nonutf8_client_test.go
@@ -1,0 +1,212 @@
+package tmuxutf8_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// spinnerGlyph is U+280B BRAILLE PATTERN DOTS-1-2-4 (bytes e2 a0 8b), one of
+// the frames Claude Code writes into the pane title while a tool call is in
+// flight. AnalyzePaneTitle treats any U+2800–U+28FF rune as TitleStateWorking,
+// and that is the ONLY reliable mid-tool-call "running" signal there is — the
+// activity timestamp cannot distinguish real work from a status-bar repaint.
+const spinnerGlyph = "⠋"
+
+const spinnerTitle = spinnerGlyph + " Working on refactor"
+
+// nonUTF8Locale blanks the three variables tmux consults to decide whether a
+// client can be sent UTF-8 (LC_ALL, then LC_CTYPE, then LANG). tmux treats an
+// empty value exactly like an unset one, so this reproduces what systemd,
+// launchd and a bare container hand every service they start — verified
+// byte-for-byte against the `env -u LANG -u LC_ALL -u LC_CTYPE` form in the
+// issue.
+//
+// t.Setenv is used rather than os.Unsetenv so the restore is automatic and the
+// runtime refuses the test if it ever gains t.Parallel.
+func nonUTF8Locale(t *testing.T) {
+	t.Helper()
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_CTYPE", "")
+	t.Setenv("LANG", "")
+}
+
+// utf8Locale is the control condition: a client whose locale plainly announces
+// UTF-8, i.e. an ordinary interactive shell.
+func utf8Locale(t *testing.T) {
+	t.Helper()
+	t.Setenv("LC_ALL", "C.UTF-8")
+	t.Setenv("LC_CTYPE", "")
+	t.Setenv("LANG", "C.UTF-8")
+}
+
+// startSpinnerSession boots a private tmux server, creates one detached
+// session running `sleep`, and stamps the braille spinner into its pane title.
+// It returns the socket name and the tmux session name.
+//
+// Setup deliberately uses raw exec.Command with an explicit `-L` rather than
+// the tmux factory: the factory is the code under test, and the setup path must
+// behave identically at the merge-base and at HEAD or the test would not be
+// measuring anything. It is safe because TestMain has already repointed
+// TMUX_TMPDIR and cleared $TMUX, and because every command here names its
+// socket — there is no bare kill-server anywhere in this file.
+func startSpinnerSession(t *testing.T) (socket, session string) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux binary not available")
+	}
+
+	socket = fmt.Sprintf("ad1867-%d-%s", os.Getpid(), strings.ToLower(strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())))
+	session = "agentdeck_i1867"
+
+	run := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-L", socket}, args...)
+		if out, err := exec.Command("tmux", full...).CombinedOutput(); err != nil {
+			t.Fatalf("tmux %s: %v\n%s", strings.Join(full, " "), err, out)
+		}
+	}
+
+	t.Cleanup(func() {
+		// Socket-scoped. NEVER a bare kill-server: on the default socket that
+		// ends every tmux session on the machine.
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	})
+
+	run("new-session", "-d", "-s", session, "sleep", "300")
+	run("select-pane", "-t", session, "-T", spinnerTitle)
+
+	// select-pane is synchronous against the server, but the pane's program
+	// still has to exist before list-panes reports it; poll briefly rather than
+	// sleeping a fixed amount.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if exec.Command("tmux", "-L", socket, "has-session", "-t", session).Run() == nil {
+			return socket, session
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("tmux session %q never became visible on socket %q", session, socket)
+	return "", ""
+}
+
+// rawPaneTitle reads the pane title with a hand-built argv that does NOT carry
+// `-u`, i.e. exactly what agent-deck used to send. It is the test's probe for
+// whether this platform actually downgrades.
+func rawPaneTitle(t *testing.T, socket, session string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", "-L", socket, "list-panes", "-t", session, "-F", "#{pane_title}").Output()
+	if err != nil {
+		t.Fatalf("raw list-panes: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// readPaneTitleThroughAgentDeck drives the real production read path:
+// RefreshPaneInfoCache issues the `list-panes -a -F …` that feeds every status
+// decision, and GetCachedPaneInfo is what (*Session).GetStatus consults.
+func readPaneTitleThroughAgentDeck(t *testing.T, socket, session string) tmux.PaneInfo {
+	t.Helper()
+	tmux.SetDefaultSocketName(socket)
+	t.Cleanup(func() { tmux.SetDefaultSocketName("") })
+
+	tmux.RefreshPaneInfoCache()
+	info, ok := tmux.GetCachedPaneInfo(session)
+	if !ok {
+		t.Fatalf("RefreshPaneInfoCache did not cache session %q", session)
+	}
+	return info
+}
+
+// TestIssue1867_NonUTF8Client_StatusStillReadsSpinner is the regression test
+// for #1867.
+//
+// With no UTF-8 locale, tmux does not set CLIENT_UTF8 on the client and runs
+// every message it prints to it through utf8_sanitize(), which rewrites each
+// non-ASCII byte to "_". The server's copy of the title is untouched, so the
+// corruption is invisible to everything except the parser: agent-deck reads
+// "_ Working on refactor", AnalyzePaneTitle finds no braille rune, the title
+// fast path in GetStatus never fires, and a session that is plainly running is
+// reported idle.
+//
+// This test fails at the merge-base with a "_"-mangled title and passes once
+// the argv factory emits tmux's global `-u`.
+func TestIssue1867_NonUTF8Client_StatusStillReadsSpinner(t *testing.T) {
+	nonUTF8Locale(t)
+	socket, session := startSpinnerSession(t)
+
+	// Precondition: prove THIS platform+tmux actually downgrades under this
+	// environment. macOS does not reproduce (per the issue's measured matrix),
+	// and a box whose locale leaked back in would make every assertion below
+	// pass vacuously. Skipping here is honest; asserting would be a lie on
+	// darwin.
+	raw := rawPaneTitle(t, socket, session)
+	if strings.Contains(raw, spinnerGlyph) {
+		t.Skipf("tmux on this platform does not downgrade non-ASCII for a non-UTF-8 client "+
+			"(raw title without -u came back as %q / % x) — #1867 cannot manifest here", raw, raw)
+	}
+	if !strings.HasPrefix(raw, "_") {
+		t.Fatalf("unexpected raw title %q (% x): expected either the glyph or the '_' downgrade", raw, raw)
+	}
+	t.Logf("confirmed downgrade without -u: %q (% x)", raw, raw)
+
+	info := readPaneTitleThroughAgentDeck(t, socket, session)
+
+	if !strings.Contains(info.Title, spinnerGlyph) {
+		t.Errorf("agent-deck read a mangled pane title from a non-UTF-8 client\n"+
+			" got:  %q (% x)\n want to contain U+280B (e2 a0 8b)\n"+
+			"tmux downgraded every non-ASCII byte to '_' because the client carried no UTF-8 locale (#1867).",
+			info.Title, info.Title)
+	}
+
+	if state := tmux.AnalyzePaneTitle(info.Title, info.CurrentCommand); state != tmux.TitleStateWorking {
+		t.Errorf("AnalyzePaneTitle(%q) = %v, want TitleStateWorking — the session is running and the "+
+			"spinner is the only signal that says so", info.Title, state)
+	}
+
+	s := &tmux.Session{Name: session, SocketName: socket}
+	status, err := s.GetStatus()
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if status != "active" {
+		t.Errorf("GetStatus() = %q, want \"active\" — a session mid-tool-call reported as %q is exactly "+
+			"the user-visible symptom of #1867", status, status)
+	}
+}
+
+// TestIssue1867_UTF8Client_StatusUnchanged is the no-regression half: in an
+// ordinary UTF-8 environment — where the bug never existed — the read path must
+// still return the glyph and still report the session running. `-u` is a no-op
+// for a client whose locale already announces UTF-8, and this pins that.
+func TestIssue1867_UTF8Client_StatusUnchanged(t *testing.T) {
+	utf8Locale(t)
+	socket, session := startSpinnerSession(t)
+
+	if raw := rawPaneTitle(t, socket, session); !strings.Contains(raw, spinnerGlyph) {
+		t.Fatalf("a UTF-8 client should never see a downgrade; raw title was %q (% x)", raw, raw)
+	}
+
+	info := readPaneTitleThroughAgentDeck(t, socket, session)
+	if info.Title != spinnerTitle {
+		t.Errorf("pane title round-trip broken in a UTF-8 environment\n got:  %q (% x)\n want: %q",
+			info.Title, info.Title, spinnerTitle)
+	}
+	if state := tmux.AnalyzePaneTitle(info.Title, info.CurrentCommand); state != tmux.TitleStateWorking {
+		t.Errorf("AnalyzePaneTitle(%q) = %v, want TitleStateWorking", info.Title, state)
+	}
+
+	s := &tmux.Session{Name: session, SocketName: socket}
+	status, err := s.GetStatus()
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if status != "active" {
+		t.Errorf("GetStatus() = %q, want \"active\"", status)
+	}
+}

--- a/internal/tmuxutf8/testmain_test.go
+++ b/internal/tmuxutf8/testmain_test.go
@@ -1,0 +1,45 @@
+package tmuxutf8_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// TestMain isolates HOME and the tmux socket for this package.
+//
+// The integration test in this package spawns a REAL tmux server (that is the
+// only way to observe the #1867 downgrade — it happens inside tmux, not in Go),
+// so the isolation is load-bearing, not ceremonial:
+//
+//   - testutil.IsolateHome keeps agent-deck path resolution off the real
+//     ~/.agent-deck (2026-06-04 data-loss incident).
+//   - testutil.IsolateTmuxSocket unsets TMUX/TMUX_PANE — a tmux client locates
+//     its server from $TMUX FIRST, so an inherited $TMUX reaches the host's
+//     live server no matter what TMUX_TMPDIR says — and repoints TMUX_TMPDIR at
+//     a private dir (2026-04-17 / 2026-07-26 fleet-death incidents).
+//
+// On top of that every server this package starts is named with an explicit
+// `-L`, and is torn down with a `-L`-scoped kill-server. There is no bare
+// `tmux kill-server` anywhere in this package: an unqualified kill-server on
+// the default socket ends every tmux session on the machine.
+//
+// The setup+defer body lives in runTestMain rather than TestMain because
+// os.Exit does not run deferred functions — see
+// internal/testutil.TestNoTestMainLeaksCleanupBehindOsExit.
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+func runTestMain(m *testing.M) int {
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+
+	os.Setenv("AGENTDECK_PROFILE", "_test")
+
+	return m.Run()
+}

--- a/internal/tmuxutf8/tmuxutf8.go
+++ b/internal/tmuxutf8/tmuxutf8.go
@@ -1,0 +1,87 @@
+// Package tmuxutf8 owns one decision: whether a tmux command line agent-deck
+// builds carries tmux's global `-u` flag.
+//
+// # Why this exists (issue #1867)
+//
+// tmux decides a CLIENT's charset from that client's own LC_ALL / LC_CTYPE /
+// LANG. When none of them contain "UTF-8"/"UTF8", the client is not marked
+// CLIENT_UTF8 and the server runs every message it prints to that client
+// through utf8_sanitize(), which rewrites each non-ASCII byte to "_". The
+// server's own buffers stay correct — only the bytes handed to the non-UTF-8
+// client are rewritten — so the damage is invisible until something parses
+// them.
+//
+// agent-deck parses them constantly. `list-panes -F '#{pane_title}'` is how
+// RefreshPaneInfoCache learns that Claude is mid-tool-call: the braille
+// spinner (U+2800–U+28FF) in the pane title is the only reliable "running"
+// signal there is. Downgraded to "_", AnalyzePaneTitle returns
+// TitleStateUnknown, the title fast path in (*Session).GetStatus never fires,
+// and a plainly-running session is reported idle. `capture-pane -p` loses the
+// box-drawing and "⏵⏵" indicators the content scan looks for in the same way.
+//
+// This is not an exotic configuration. systemd (--user included) and launchd
+// start services with no LANG/LC_* at all, and so does a bare container — so
+// the notify-daemon, the conductor heartbeat, the web daemon and CI are all in
+// the affected state without anyone having configured anything. Measured on
+// tmux 3.2a / 3.4 / 3.5a / 3.6b / 3.7b across five Linux distros.
+//
+// # Why -u and not a locale in the child environment
+//
+// The obvious alternative is to hand the tmux client `LC_ALL=C.UTF-8` via
+// cmd.Env. It is rejected:
+//
+//   - `tmux new-session` copies the CLIENT's environment wholesale into the new
+//     session's environment, which tmux then hands to every process it spawns
+//     in that session. A forced LC_ALL would therefore silently relocalise the
+//     agent itself (message catalogues, collation, date formatting) — a much
+//     wider blast radius than the parsing bug being fixed.
+//   - It would fight internal/childenv, which is the sanctioned single filter
+//     for the environment of processes agent-deck spawns. childenv deliberately
+//     subtracts variables (TELEGRAM_*, an inherited CLAUDE_CONFIG_DIR); adding a
+//     locale there would push a value into the agent's env from a package whose
+//     whole contract is "never let the parent's pollution through".
+//   - `-u` is exactly scoped: it sets CLIENT_UTF8 on this one client and changes
+//     nothing else, including nothing the server keeps.
+//
+// # Version floor
+//
+// `-u` is one of tmux's oldest global flags — it is in the `usage: tmux
+// [-2CDlNuVv] …` line of every tmux from 1.0 through 3.7b, well below the
+// tmux 3.2+ floor install.sh's shipped tmux.conf already assumes. A tmux that
+// did not accept it would reject the flag with a usage error on stderr and a
+// non-zero exit, i.e. fail loudly and uniformly on the very first invocation
+// rather than corrupt anything.
+package tmuxutf8
+
+// Flag is tmux's global "assume the terminal supports UTF-8" option. It must
+// appear before the subcommand, alongside -L/-S, not after it.
+const Flag = "-u"
+
+// Prepend returns a fresh argv with Flag in front of args. It is the only
+// sanctioned way to add the flag, so `grep -r tmuxutf8` enumerates every tmux
+// command line in the codebase that is UTF-8 safe.
+//
+// The caller's slice is never mutated or aliased: agent-deck's tmux argv
+// builders run on hot status-poll paths and share their input slices.
+//
+// Prepend is idempotent for an argv that already leads with Flag, so wrapping a
+// pre-built command line twice cannot produce `tmux -u -u …`.
+func Prepend(args []string) []string {
+	if len(args) > 0 && args[0] == Flag {
+		out := make([]string, len(args))
+		copy(out, args)
+		return out
+	}
+	out := make([]string, 0, len(args)+1)
+	out = append(out, Flag)
+	return append(out, args...)
+}
+
+// HasFlag reports whether argv carries Flag in its GLOBAL flag position, i.e.
+// as the leading token. It deliberately does not scan the whole slice: `-u` is
+// also a per-subcommand option with an unrelated meaning ("unset") on
+// set-option and set-environment, and matching those would report UTF-8 safety
+// that is not there.
+func HasFlag(args []string) bool {
+	return len(args) > 0 && args[0] == Flag
+}

--- a/internal/tmuxutf8/tmuxutf8_test.go
+++ b/internal/tmuxutf8/tmuxutf8_test.go
@@ -1,0 +1,130 @@
+package tmuxutf8_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"github.com/asheshgoplani/agent-deck/internal/tmuxutf8"
+)
+
+// TestPrepend_AddsFlagInGlobalPosition: `-u` is a GLOBAL tmux option. Placed
+// after the subcommand it is either rejected or silently reinterpreted as that
+// subcommand's own `-u` (which means "unset" on set-option/set-environment), so
+// position is part of the contract, not a formatting detail.
+func TestPrepend_AddsFlagInGlobalPosition(t *testing.T) {
+	got := tmuxutf8.Prepend([]string{"-L", "agent-deck", "list-panes", "-a", "-F", "#{pane_title}"})
+	want := []string{"-u", "-L", "agent-deck", "list-panes", "-a", "-F", "#{pane_title}"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("-u must lead the argv\n got:  %v\n want: %v", got, want)
+	}
+}
+
+// TestPrepend_EmptyArgs: degenerate input must still yield a usable argv rather
+// than panicking or dropping the flag.
+func TestPrepend_EmptyArgs(t *testing.T) {
+	got := tmuxutf8.Prepend(nil)
+	want := []string{"-u"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("nil args\n got:  %v\n want: %v", got, want)
+	}
+}
+
+// TestPrepend_Idempotent: two builders can legitimately compose (the web bridge
+// prepends onto an argv it assembled itself). `tmux -u -u list-panes` is
+// accepted by tmux, but the duplicate would leak into every argv-shape
+// assertion in the repo, so the flag is applied at most once.
+func TestPrepend_Idempotent(t *testing.T) {
+	once := tmuxutf8.Prepend([]string{"has-session", "-t", "x"})
+	twice := tmuxutf8.Prepend(once)
+	if !reflect.DeepEqual(once, twice) {
+		t.Fatalf("Prepend must be idempotent\n once:  %v\n twice: %v", once, twice)
+	}
+}
+
+// TestPrepend_DoesNotMutateOrAliasCallerSlice: the tmux argv builders sit on
+// the status-poll hot path and pass slices they did not allocate. An
+// append-aliasing bug here would rewrite a caller's argv from under it.
+func TestPrepend_DoesNotMutateOrAliasCallerSlice(t *testing.T) {
+	// Extra capacity is what makes append() alias rather than copy.
+	original := make([]string, 3, 8)
+	copy(original, []string{"kill-session", "-t", "x"})
+	snapshot := append([]string(nil), original...)
+
+	out := tmuxutf8.Prepend(original)
+	out[len(out)-1] = "CLOBBERED"
+
+	if !reflect.DeepEqual(original, snapshot) {
+		t.Fatalf("Prepend must not alias the caller slice\n after: %v\n want:  %v", original, snapshot)
+	}
+}
+
+// TestHasFlag_OnlyMatchesGlobalPosition: `-u` after the subcommand is a
+// different option with a different meaning ("unset" for set-option /
+// set-environment — see internal/tmux/tmux.go's `set-option -u status-left`).
+// Reporting those as UTF-8 safe would hide exactly the bug this package exists
+// to prevent.
+func TestHasFlag_OnlyMatchesGlobalPosition(t *testing.T) {
+	if !tmuxutf8.HasFlag([]string{"-u", "-L", "s", "list-panes"}) {
+		t.Error("leading -u must be reported as present")
+	}
+	if tmuxutf8.HasFlag([]string{"-L", "s", "set-option", "-t", "x", "-u", "status-left"}) {
+		t.Error("a subcommand's own -u must NOT be reported as the global UTF-8 flag")
+	}
+	if tmuxutf8.HasFlag(nil) {
+		t.Error("nil argv must not report the flag")
+	}
+}
+
+// TestTmuxFactory_EmitsUTF8Flag is the choke-point contract (#1867): the
+// exported argv factory in internal/tmux — the one every call site outside the
+// package is required to funnel through by
+// TestNoRawTmuxExec_OutsideAllowlist — must emit `-u`, so a call site added
+// tomorrow is UTF-8 safe without its author knowing this bug exists.
+//
+// It lives here rather than in internal/tmux so that it can be run without
+// starting that package's test binary; the flag's presence is observable
+// through the public API because Exec returns the *exec.Cmd unstarted.
+func TestTmuxFactory_EmitsUTF8Flag(t *testing.T) {
+	cases := []struct {
+		name   string
+		socket string
+		args   []string
+		want   []string
+	}{
+		{
+			name:   "default socket",
+			socket: "",
+			args:   []string{"list-panes", "-a", "-F", "#{pane_title}"},
+			want:   []string{"tmux", "-u", "list-panes", "-a", "-F", "#{pane_title}"},
+		},
+		{
+			name:   "isolated socket",
+			socket: "agent-deck",
+			args:   []string{"list-panes", "-a", "-F", "#{pane_title}"},
+			want:   []string{"tmux", "-u", "-L", "agent-deck", "list-panes", "-a", "-F", "#{pane_title}"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tmux.Exec(tc.socket, tc.args...); !reflect.DeepEqual(got.Args, tc.want) {
+				t.Errorf("tmux.Exec\n got:  %v\n want: %v", got.Args, tc.want)
+			}
+			if got := tmux.ExecContext(context.Background(), tc.socket, tc.args...); !reflect.DeepEqual(got.Args, tc.want) {
+				t.Errorf("tmux.ExecContext\n got:  %v\n want: %v", got.Args, tc.want)
+			}
+		})
+	}
+}
+
+// TestTmuxFactory_UTF8FlagPrecedesSocketSelector pins the ordering explicitly.
+// `tmux -L name -u …` also works, but `tmux -L -u name …` (a flag landing
+// between -L and its value) does not, and an argv builder that appends rather
+// than prepends is one refactor away from that. Assert the exact shape.
+func TestTmuxFactory_UTF8FlagPrecedesSocketSelector(t *testing.T) {
+	args := tmux.Exec("agent-deck", "has-session", "-t", "x").Args
+	if len(args) < 4 || args[0] != "tmux" || args[1] != "-u" || args[2] != "-L" || args[3] != "agent-deck" {
+		t.Fatalf("want argv to start with [tmux -u -L agent-deck]; got %v", args)
+	}
+}

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmuxutf8"
 )
 
 var ErrTmuxSessionNotFound = errors.New("tmux session not found")
@@ -269,10 +271,20 @@ func tmuxCommand(socketName string, args ...string) *exec.Cmd {
 // tmuxCommandContext is the deadline-carrying variant of tmuxCommand. A context
 // with a timeout lets exec.CommandContext SIGKILL a tmux client that has wedged
 // on its own leaked fd table rather than blocking the caller forever.
+//
+// Every argv it builds carries tmux's global `-u` (#1867). This wrapper is the
+// web daemon's counterpart to internal/tmux's tmuxArgs, and the daemon is the
+// worst-affected process in the codebase: run under systemd or launchd it has
+// no LANG/LC_* at all, so without `-u` tmux rewrites every non-ASCII byte it
+// returns to "_". Unlike internal/tmux there is no interactive carve-out here,
+// because the web attach's terminal is not the user's — it is xterm.js in a
+// browser, which is unconditionally UTF-8. That is the same reasoning that
+// already pins TERM=xterm-256color in tmuxAttachCommand below.
 func tmuxCommandContext(ctx context.Context, socketName string, args ...string) *exec.Cmd {
+	utf8Args := tmuxutf8.Prepend(args)
 	// Explicit per-session socket name wins — this is the v1.7.50 path.
 	if trimmed := strings.TrimSpace(socketName); trimmed != "" {
-		finalArgs := append([]string{"-L", trimmed}, args...)
+		finalArgs := append([]string{tmuxutf8.Flag, "-L", trimmed}, utf8Args[1:]...)
 		cmd := exec.CommandContext(ctx, "tmux", finalArgs...)
 		// Unset TMUX so tmux-in-tmux guards don't trip: we are explicitly
 		// directing this to a different server than the one we're in.
@@ -282,9 +294,9 @@ func tmuxCommandContext(ctx context.Context, socketName string, args ...string) 
 
 	socketPath, hasSocket := tmuxSocketFromEnv()
 
-	finalArgs := args
+	finalArgs := utf8Args
 	if hasSocket {
-		finalArgs = append([]string{"-S", socketPath}, args...)
+		finalArgs = append([]string{tmuxutf8.Flag, "-S", socketPath}, utf8Args[1:]...)
 	}
 
 	cmd := exec.CommandContext(ctx, "tmux", finalArgs...)

--- a/internal/web/terminal_bridge_test.go
+++ b/internal/web/terminal_bridge_test.go
@@ -31,7 +31,7 @@ func TestTmuxAttachCommandUsesSocketFromTMUXEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-2", "")
 
-	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "-u", "attach-session", "-t", "sess-2"}
+	wantArgs := []string{"tmux", "-u", "-S", "/tmp/tmux-test.sock", "attach-session", "-t", "sess-2"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("unexpected args with TMUX env: got %v want %v", cmd.Args, wantArgs)
 	}
@@ -56,7 +56,7 @@ func TestTmuxAttachCommand_SocketNameOverridesEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("agentdeck-foo", "agent-deck")
 
-	wantArgs := []string{"tmux", "-L", "agent-deck", "-u", "attach-session", "-t", "agentdeck-foo"}
+	wantArgs := []string{"tmux", "-u", "-L", "agent-deck", "attach-session", "-t", "agentdeck-foo"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("socket name must take precedence over $TMUX env\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -235,7 +235,7 @@ func TestTmuxAttachCommand_WhitespaceSocketNameFallsBackToEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-3", "   \t")
 
-	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "-u", "attach-session", "-t", "sess-3"}
+	wantArgs := []string{"tmux", "-u", "-S", "/tmp/tmux-test.sock", "attach-session", "-t", "sess-3"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("whitespace-only socket name must fall through to legacy TMUX env\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}


### PR DESCRIPTION
Force UTF-8 mode on non-interactive tmux clients so pane titles and captured output preserve Unicode status glyphs even when the caller has no UTF-8 locale.

This keeps running-state detection accurate for daemon, service, web, and other locale-free callers while preserving interactive attach behavior.

Interactive attaches retain their existing command behavior.

Fixes #1867
