### PR TITLE
fix(hermes): bind hook status to spawn generations

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -271,7 +271,7 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 	prior.Status, prior.SessionID, prior.Event = status, sessionID, event
 	prior.Timestamp = time.Now().Unix()
 	prior.DoneStatus, prior.DoneSummary, prior.TranscriptPath, prior.Cwd = "", "", "", ""
-	writeHookStatusFile(instanceID, prior)
+	writeHookStatusFile(instanceID, prior, false)
 }
 
 func handleCodexHooks(args []string) {

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -388,3 +388,15 @@ func TestGetCodexConfigPath_UsesCodexHome(t *testing.T) {
 		t.Fatalf("getCodexConfigPath() = %q, expected suffix codex-home/config.toml", got)
 	}
 }
+
+func TestCodexSharedStatusWriteNeverMutatesAnchor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "codex-anchor-owner"
+	session.WriteHookSessionAnchor(id, "thread-current")
+	if !writeHookStatusFile(id, hookStatusFile{Status: "dead", SessionID: "thread-stale", Event: "SessionEnd", Timestamp: 1}, false) {
+		t.Fatal("status write failed")
+	}
+	if got := session.ReadHookSessionAnchor(id); got != "thread-current" {
+		t.Fatalf("shared writer mutated Codex anchor: %q", got)
+	}
+}

--- a/cmd/agent-deck/hermes_generation_test.go
+++ b/cmd/agent-deck/hermes_generation_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func writeHermesControl(t *testing.T, id, generation string) {
@@ -17,6 +20,48 @@ func writeHermesControl(t *testing.T, id, generation string) {
 	b, _ := json.Marshal(map[string]any{"generation": generation, "next_sequence": 0})
 	if err := os.WriteFile(filepath.Join(getHooksDir(), id+".generation.json"), b, 0600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestHermesStaleGenerationCannotMutateAnchor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "hermes-anchor"
+	writeHermesControl(t, id, "g2")
+	session.WriteHookSessionAnchor(id, "current-session")
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "g1")
+	writeHookStatus(id, "dead", "old-session", "on_session_finalize", "")
+	if got := session.ReadHookSessionAnchor(id); got != "current-session" {
+		t.Fatalf("stale hook changed anchor to %q", got)
+	}
+}
+
+func TestCleanStaleHookFilesPreservesLiveGenerationControlAndLock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "hermes-long-lived"
+	writeHermesControl(t, id, "g")
+	status := filepath.Join(getHooksDir(), id+".json")
+	lock := filepath.Join(getHooksDir(), id+".lock")
+	control := filepath.Join(getHooksDir(), id+".generation.json")
+	if err := os.WriteFile(status, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lock, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	for _, path := range []string{status, lock, control} {
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cleanStaleHookFiles()
+	if _, err := os.Stat(status); !os.IsNotExist(err) {
+		t.Fatalf("old status survived: %v", err)
+	}
+	for _, path := range []string{lock, control} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("live generation artifact reaped: %s: %v", path, err)
+		}
 	}
 }
 

--- a/cmd/agent-deck/hermes_generation_test.go
+++ b/cmd/agent-deck/hermes_generation_test.go
@@ -65,6 +65,25 @@ func TestCleanStaleHookFilesPreservesLiveGenerationControlAndLock(t *testing.T) 
 	}
 }
 
+func TestCleanStaleHookFilesReapsOnlyUnlockedAbandonedHermesLock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(getHooksDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(getHooksDir(), "hermes-abandoned.lock")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	cleanStaleHookFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("abandoned lock survived: %v", err)
+	}
+}
+
 func TestHermesDelayedOldGenerationWriteRejected(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	id := "hermes-delayed"
@@ -110,5 +129,32 @@ func TestHermesConcurrentWritersUseMonotonicSequenceAndNoTemps(t *testing.T) {
 	}
 	if temps, _ := filepath.Glob(filepath.Join(getHooksDir(), "."+id+"*.tmp-*")); len(temps) != 0 {
 		t.Fatalf("orphan temps: %v", temps)
+	}
+}
+
+func TestHermesAttachClearPreservesInitialMessagePending(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "g")
+	id := "hermes-pending"
+	b, _ := json.Marshal(hookGenerationControl{Generation: "g", InitialMessagePending: true})
+	if err := os.MkdirAll(getHooksDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(getHooksDir(), id+".generation.json"), b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if writeHookStatusFile(id, hookStatusFile{Status: "waiting", Event: "on_session_start", Timestamp: 1}, true) {
+		t.Fatal("on_session_start downgraded pending initial message")
+	}
+	if !writeHookStatusFile(id, hookStatusFile{Status: "waiting", Event: "post_llm_call", Timestamp: 2}, true) {
+		t.Fatal("post_llm_call rejected")
+	}
+	controlData, err := os.ReadFile(filepath.Join(getHooksDir(), id+".generation.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var control hookGenerationControl
+	if json.Unmarshal(controlData, &control) != nil || control.InitialMessagePending {
+		t.Fatalf("completion did not clear pending: %+v", control)
 	}
 }

--- a/cmd/agent-deck/hermes_generation_test.go
+++ b/cmd/agent-deck/hermes_generation_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func writeHermesControl(t *testing.T, id, generation string) {
+	t.Helper()
+	if err := os.MkdirAll(getHooksDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(map[string]any{"generation": generation, "next_sequence": 0})
+	if err := os.WriteFile(filepath.Join(getHooksDir(), id+".generation.json"), b, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHermesDelayedOldGenerationWriteRejected(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "hermes-delayed"
+	writeHermesControl(t, id, "g2")
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "g1")
+	writeHookStatus(id, "dead", "", "on_session_finalize", "")
+	if _, err := os.Stat(filepath.Join(getHooksDir(), id+".json")); !os.IsNotExist(err) {
+		t.Fatalf("stale write accepted: %v", err)
+	}
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "g2")
+	writeHookStatus(id, "waiting", "", "post_llm_call", "")
+	var got hookStatusFile
+	b, err := os.ReadFile(filepath.Join(getHooksDir(), id+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if json.Unmarshal(b, &got) != nil || got.HookGeneration != "g2" || got.Sequence != 1 {
+		t.Fatalf("bad accepted write: %+v", got)
+	}
+}
+
+func TestHermesConcurrentWritersUseMonotonicSequenceAndNoTemps(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "g")
+	id := "hermes-concurrent"
+	writeHermesControl(t, id, "g")
+	var wg sync.WaitGroup
+	for n := 0; n < 24; n++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			writeHookStatus(id, "running", "", fmt.Sprintf("pre_tool_call_%d", n), "")
+		}(n)
+	}
+	wg.Wait()
+	var got hookStatusFile
+	b, err := os.ReadFile(filepath.Join(getHooksDir(), id+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if json.Unmarshal(b, &got) != nil || got.Sequence != 24 {
+		t.Fatalf("sequence=%d want 24", got.Sequence)
+	}
+	if temps, _ := filepath.Glob(filepath.Join(getHooksDir(), "."+id+"*.tmp-*")); len(temps) != 0 {
+		t.Fatalf("orphan temps: %v", temps)
+	}
+}

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -95,6 +95,12 @@ type hookStatusFile struct {
 	Cwd string `json:"cwd,omitempty"`
 }
 
+type hookGenerationControl struct {
+	Generation            string `json:"generation"`
+	NextSequence          uint64 `json:"next_sequence"`
+	InitialMessagePending bool   `json:"initial_message_pending,omitempty"`
+}
+
 // normalizeHookEventKey folds hook event names from Claude (PascalCase), Cursor
 // (camelCase), Hermes (snake_case), and Codex into a single lookup key.
 func normalizeHookEventKey(event string) string {
@@ -369,10 +375,10 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 		statusFile.DoneSummary = scan.signal.Summary
 	}
 	statusFile.TranscriptPath = scan.pendingTranscript
-	writeHookStatusFile(instanceID, statusFile)
+	writeHookStatusFile(instanceID, statusFile, true)
 }
 
-func writeHookStatusFile(instanceID string, statusFile hookStatusFile) bool {
+func writeHookStatusFile(instanceID string, statusFile hookStatusFile, mutateAnchor bool) bool {
 	hooksDir := getHooksDir()
 	generation := strings.TrimSpace(os.Getenv("AGENTDECK_HOOK_GENERATION"))
 	if generation != "" {
@@ -387,30 +393,22 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) bool {
 		}
 		defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
 		controlPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".generation.json")
-		var control struct {
-			Generation   string `json:"generation"`
-			NextSequence uint64 `json:"next_sequence"`
-		}
+		var control hookGenerationControl
 		data, err := readHookFileBounded(controlPath)
 		if err != nil || json.Unmarshal(data, &control) != nil || control.Generation != generation {
 			return false
 		}
 		// StartWithMessage stays running until the agent-level completion edge.
-		if normalizeHookEventKey(statusFile.Event) == "onsessionstart" {
-			var prior hookStatusFile
-			if b, err := readHookFileBounded(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation && prior.InitialMessagePending {
-				return false
-			}
+		if normalizeHookEventKey(statusFile.Event) == "onsessionstart" && control.InitialMessagePending {
+			return false
 		}
 		control.NextSequence++
 		statusFile.HookGeneration, statusFile.Sequence = generation, control.NextSequence
 		completionEvent := normalizeHookEventKey(statusFile.Event)
-		if completionEvent != "postllmcall" && completionEvent != "onsessionend" {
-			var prior hookStatusFile
-			if b, err := readHookFileBounded(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation {
-				statusFile.InitialMessagePending = prior.InitialMessagePending
-			}
+		if completionEvent == "postllmcall" || completionEvent == "onsessionend" {
+			control.InitialMessagePending = false
 		}
+		statusFile.InitialMessagePending = control.InitialMessagePending
 		b, err := json.Marshal(control)
 		if err != nil || atomicHookWrite(controlPath, b) != nil {
 			return false
@@ -438,26 +436,24 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) bool {
 	// Keep anchor mutation in the same generation-locked critical section as
 	// acceptance and status publication. Restart cannot rotate generations in
 	// between these operations.
-	if statusFile.SessionID != "" {
+	if mutateAnchor && statusFile.SessionID != "" {
 		session.WriteHookSessionAnchor(instanceID, statusFile.SessionID)
 	}
-	if isTerminalHookEvent(statusFile.Event) {
+	if mutateAnchor && isTerminalHookEvent(statusFile.Event) {
 		session.ClearHookSessionAnchor(instanceID)
 	}
 	return true
 }
 
 func readHookFileBounded(path string) ([]byte, error) {
-	info, err := os.Lstat(path)
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, errors.New("unsafe hook file: symlink")
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
+	f := os.NewFile(uintptr(fd), path)
+	if f == nil {
+		_ = syscall.Close(fd)
+		return nil, errors.New("open hook file")
 	}
 	defer f.Close()
 	return io.ReadAll(io.LimitReader(f, 64<<10))
@@ -555,8 +551,32 @@ func cleanStaleHookFiles() {
 
 	cutoff := time.Now().Add(-24 * time.Hour)
 	for _, entry := range entries {
-		if strings.HasSuffix(entry.Name(), ".generation.json") || (strings.HasSuffix(entry.Name(), ".lock") && !strings.HasSuffix(entry.Name(), ".codex.lock")) {
-			continue // live generation controls/locks are never age-reaped
+		if strings.HasSuffix(entry.Name(), ".generation.json") {
+			continue // generation controls are never age-reaped
+		}
+		if strings.HasSuffix(entry.Name(), ".lock") && !strings.HasSuffix(entry.Name(), ".codex.lock") {
+			info, err := entry.Info()
+			if err != nil || !info.ModTime().Before(cutoff) {
+				continue
+			}
+			id := strings.TrimSuffix(entry.Name(), ".lock")
+			if _, err := os.Stat(filepath.Join(hooksDir, id+".json")); err == nil {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(hooksDir, id+".generation.json")); err == nil {
+				continue
+			}
+			path := filepath.Join(hooksDir, entry.Name())
+			f, err := os.OpenFile(path, os.O_RDWR, 0600)
+			if err != nil {
+				continue
+			}
+			if syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) == nil {
+				_ = os.Remove(path)
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+			}
+			_ = f.Close()
+			continue
 		}
 		ext := filepath.Ext(entry.Name())
 		if entry.IsDir() || (ext != ".json" && ext != ".sid" && !strings.HasSuffix(entry.Name(), ".codex.lock")) {

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
@@ -71,6 +72,9 @@ type hookStatusFile struct {
 	CodexCompletedGeneration string `json:"codex_completed_generation,omitempty"`
 	CodexStartedSessionID    string `json:"codex_started_session_id,omitempty"`
 	CodexCompletedSessionID  string `json:"codex_completed_session_id,omitempty"`
+	HookGeneration           string `json:"hook_generation,omitempty"`
+	Sequence                 uint64 `json:"sequence,omitempty"`
+	InitialMessagePending    bool   `json:"initial_message_pending,omitempty"`
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). omitempty so ordinary Stops
 	// (no sentinel) leave the fields absent, which the daemon reads as
@@ -380,6 +384,48 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 
 func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
 	hooksDir := getHooksDir()
+	generation := strings.TrimSpace(os.Getenv("AGENTDECK_HOOK_GENERATION"))
+	if generation != "" {
+		lockPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".lock")
+		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			return
+		}
+		defer lock.Close()
+		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+			return
+		}
+		defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		controlPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".generation.json")
+		var control struct {
+			Generation   string `json:"generation"`
+			NextSequence uint64 `json:"next_sequence"`
+		}
+		data, err := os.ReadFile(controlPath)
+		if err != nil || json.Unmarshal(data, &control) != nil || control.Generation != generation {
+			return
+		}
+		// StartWithMessage stays running until the agent-level completion edge.
+		if normalizeHookEventKey(statusFile.Event) == "onsessionstart" {
+			var prior hookStatusFile
+			if b, err := os.ReadFile(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation && prior.InitialMessagePending {
+				return
+			}
+		}
+		control.NextSequence++
+		statusFile.HookGeneration, statusFile.Sequence = generation, control.NextSequence
+		completionEvent := normalizeHookEventKey(statusFile.Event)
+		if completionEvent != "postllmcall" && completionEvent != "onsessionend" {
+			var prior hookStatusFile
+			if b, err := os.ReadFile(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation {
+				statusFile.InitialMessagePending = prior.InitialMessagePending
+			}
+		}
+		b, err := json.Marshal(control)
+		if err != nil || atomicHookWrite(controlPath, b) != nil {
+			return
+		}
+	}
 
 	jsonData, err := json.Marshal(statusFile)
 	if err != nil {
@@ -391,27 +437,33 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
 	}
 
 	filePath := filepath.Join(hooksDir, filepath.Base(instanceID)+".json")
-	tmpPath := filePath + ".tmp"
-	if err := os.WriteFile(tmpPath, jsonData, 0600); err != nil {
+	if err := atomicHookWrite(filePath, jsonData); err != nil {
 		hookHandlerLog.Warn("hook_status_write_failed",
-			slog.String("path", tmpPath),
+			slog.String("path", filePath),
 			slog.String("instance", instanceID),
 			slog.String("error", err.Error()),
 		)
 		return
 	}
-	if err := os.Rename(tmpPath, filePath); err != nil {
-		hookHandlerLog.Warn("hook_status_rename_failed",
-			slog.String("from", tmpPath),
-			slog.String("to", filePath),
-			slog.String("instance", instanceID),
-			slog.String("error", err.Error()),
-		)
-		// Best-effort cleanup of the orphaned temp file.
-		_ = os.Remove(tmpPath)
-		return
-	}
+}
 
+func atomicHookWrite(path string, data []byte) error {
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp)
+	if err = f.Chmod(0600); err == nil {
+		_, err = f.Write(data)
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 func isTerminalHookEvent(event string) bool {
@@ -424,7 +476,7 @@ func isTerminalHookEvent(event string) bool {
 	// sidecar on ordinary non-terminal "Stop"/turn-complete style events.
 	switch norm {
 	case "sessionend", "sessionended", "sessionclose", "sessionclosed", "sessiondone", "sessionexit", "sessionexited",
-		"onsessionend", // Hermes: on_session_end normalized
+		"onsessionfinalize", // Hermes final process/session event
 		"threadend", "threadended", "threadterminate", "threadterminated", "threadclose", "threadclosed",
 		"threaddone", "threadexit", "threadexited":
 		return true

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -391,7 +391,7 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile, mutateAnc
 		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
 			return false
 		}
-		defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
 		controlPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".generation.json")
 		var control hookGenerationControl
 		data, err := readHookFileBounded(controlPath)
@@ -592,12 +592,19 @@ func cleanStaleHookFiles() {
 	}
 	// Crash-orphaned unique temp files are safe to reap by age. WalkDir does
 	// not follow symlinked directories, preserving sandbox scope boundaries.
+	root, rootErr := os.OpenRoot(hooksDir)
+	if rootErr != nil {
+		return
+	}
+	defer func() { _ = root.Close() }()
 	_ = filepath.WalkDir(hooksDir, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil || entry.IsDir() || !strings.Contains(entry.Name(), ".tmp-") {
 			return nil
 		}
 		if info, err := entry.Info(); err == nil && info.ModTime().Before(cutoff) {
-			_ = os.Remove(path)
+			if rel, err := filepath.Rel(hooksDir, path); err == nil {
+				_ = root.Remove(rel)
+			}
 		}
 		return nil
 	})

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -356,11 +356,6 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 	}
 
 	sessionID = strings.TrimSpace(sessionID)
-	// Preserve legacy hook JSON semantics: empty stays empty.
-	// Persist non-empty session IDs in a sidecar, to be used only when reading.
-	if sessionID != "" {
-		session.WriteHookSessionAnchor(instanceID, sessionID)
-	}
 
 	statusFile := hookStatusFile{
 		Status:    status,
@@ -375,25 +370,20 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 	}
 	statusFile.TranscriptPath = scan.pendingTranscript
 	writeHookStatusFile(instanceID, statusFile)
-
-	// Clear sticky session mapping when the upstream session is explicitly ended.
-	if isTerminalHookEvent(event) {
-		session.ClearHookSessionAnchor(instanceID)
-	}
 }
 
-func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
+func writeHookStatusFile(instanceID string, statusFile hookStatusFile) bool {
 	hooksDir := getHooksDir()
 	generation := strings.TrimSpace(os.Getenv("AGENTDECK_HOOK_GENERATION"))
 	if generation != "" {
 		lockPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".lock")
 		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
 		if err != nil {
-			return
+			return false
 		}
 		defer lock.Close()
 		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-			return
+			return false
 		}
 		defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
 		controlPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".generation.json")
@@ -401,15 +391,15 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
 			Generation   string `json:"generation"`
 			NextSequence uint64 `json:"next_sequence"`
 		}
-		data, err := os.ReadFile(controlPath)
+		data, err := readHookFileBounded(controlPath)
 		if err != nil || json.Unmarshal(data, &control) != nil || control.Generation != generation {
-			return
+			return false
 		}
 		// StartWithMessage stays running until the agent-level completion edge.
 		if normalizeHookEventKey(statusFile.Event) == "onsessionstart" {
 			var prior hookStatusFile
-			if b, err := os.ReadFile(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation && prior.InitialMessagePending {
-				return
+			if b, err := readHookFileBounded(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation && prior.InitialMessagePending {
+				return false
 			}
 		}
 		control.NextSequence++
@@ -417,13 +407,13 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
 		completionEvent := normalizeHookEventKey(statusFile.Event)
 		if completionEvent != "postllmcall" && completionEvent != "onsessionend" {
 			var prior hookStatusFile
-			if b, err := os.ReadFile(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation {
+			if b, err := readHookFileBounded(filepath.Join(hooksDir, filepath.Base(instanceID)+".json")); err == nil && json.Unmarshal(b, &prior) == nil && prior.HookGeneration == generation {
 				statusFile.InitialMessagePending = prior.InitialMessagePending
 			}
 		}
 		b, err := json.Marshal(control)
 		if err != nil || atomicHookWrite(controlPath, b) != nil {
-			return
+			return false
 		}
 	}
 
@@ -433,7 +423,7 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
 			slog.String("instance", instanceID),
 			slog.String("error", err.Error()),
 		)
-		return
+		return false
 	}
 
 	filePath := filepath.Join(hooksDir, filepath.Base(instanceID)+".json")
@@ -443,8 +433,34 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile) {
 			slog.String("instance", instanceID),
 			slog.String("error", err.Error()),
 		)
-		return
+		return false
 	}
+	// Keep anchor mutation in the same generation-locked critical section as
+	// acceptance and status publication. Restart cannot rotate generations in
+	// between these operations.
+	if statusFile.SessionID != "" {
+		session.WriteHookSessionAnchor(instanceID, statusFile.SessionID)
+	}
+	if isTerminalHookEvent(statusFile.Event) {
+		session.ClearHookSessionAnchor(instanceID)
+	}
+	return true
+}
+
+func readHookFileBounded(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("unsafe hook file: symlink")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(io.LimitReader(f, 64<<10))
 }
 
 func atomicHookWrite(path string, data []byte) error {
@@ -539,6 +555,9 @@ func cleanStaleHookFiles() {
 
 	cutoff := time.Now().Add(-24 * time.Hour)
 	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".generation.json") || (strings.HasSuffix(entry.Name(), ".lock") && !strings.HasSuffix(entry.Name(), ".codex.lock")) {
+			continue // live generation controls/locks are never age-reaped
+		}
 		ext := filepath.Ext(entry.Name())
 		if entry.IsDir() || (ext != ".json" && ext != ".sid" && !strings.HasSuffix(entry.Name(), ".codex.lock")) {
 			continue
@@ -551,6 +570,17 @@ func cleanStaleHookFiles() {
 			_ = os.Remove(filepath.Join(hooksDir, entry.Name()))
 		}
 	}
+	// Crash-orphaned unique temp files are safe to reap by age. WalkDir does
+	// not follow symlinked directories, preserving sandbox scope boundaries.
+	_ = filepath.WalkDir(hooksDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() || !strings.Contains(entry.Name(), ".tmp-") {
+			return nil
+		}
+		if info, err := entry.Info(); err == nil && info.ModTime().Before(cutoff) {
+			_ = os.Remove(path)
+		}
+		return nil
+	})
 }
 
 // handleHooks handles the "hooks" CLI subcommand for manual hook management.

--- a/cmd/agent-deck/hook_handler_test.go
+++ b/cmd/agent-deck/hook_handler_test.go
@@ -273,7 +273,8 @@ func TestIsTerminalHookEvent(t *testing.T) {
 	}{
 		{event: "SessionEnd", expect: true},
 		{event: "session_end", expect: true},
-		{event: "on_session_end", expect: true}, // Hermes shell hook terminal event
+		{event: "on_session_end", expect: false}, // Hermes per-turn event
+		{event: "on_session_finalize", expect: true},
 		{event: "session.closed", expect: true},
 		{event: "ThreadClosed", expect: true},
 		{event: "thread/terminated", expect: true},

--- a/internal/session/cli_status_refresh.go
+++ b/internal/session/cli_status_refresh.go
@@ -31,7 +31,7 @@ func RefreshInstancesForCLIStatus(instances []*Instance) {
 		if inst == nil {
 			continue
 		}
-		if !IsClaudeCompatible(inst.Tool) && !IsCodexCompatible(inst.Tool) && inst.Tool != "gemini" {
+		if !IsClaudeCompatible(inst.Tool) && !IsCodexCompatible(inst.Tool) && inst.Tool != "gemini" && inst.Tool != "cursor" && inst.Tool != "hermes" {
 			continue
 		}
 		if hs := readHookStatusFile(inst.ID); hs != nil {

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -21,8 +21,9 @@ import (
 )
 
 type hermesHookControl struct {
-	Generation   string `json:"generation"`
-	NextSequence uint64 `json:"next_sequence"`
+	Generation            string `json:"generation"`
+	NextSequence          uint64 `json:"next_sequence"`
+	InitialMessagePending bool   `json:"initial_message_pending,omitempty"`
 }
 type hermesHookSeed struct {
 	Status                string `json:"status"`
@@ -110,6 +111,9 @@ func atomicHermesJSON(path string, value any) error {
 }
 
 func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string, error) {
+	if !hermesHookInstanceIDPattern.MatchString(i.ID) || strings.Contains(i.ID, "..") {
+		return "", fmt.Errorf("invalid instance id %q", i.ID)
+	}
 	var raw [16]byte
 	if _, err := rand.Read(raw[:]); err != nil {
 		return "", err
@@ -123,8 +127,8 @@ func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string
 	if err != nil {
 		return "", err
 	}
-	defer locks.release()
 	opposite := hermesHookScope(i.ID, !i.IsSandboxed())
+	defer func() { locks.release(); pruneHermesAbandonedScope(i.ID, opposite) }()
 	clearHermesHookScope(i.ID, opposite, false)
 	seed := hermesHookSeed{Status: status, Event: "agentdeck_spawn_seed", Timestamp: time.Now().Unix(), HookGeneration: generation, InitialMessagePending: pending}
 	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".json"), seed); err != nil {
@@ -132,7 +136,7 @@ func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string
 	}
 	// The control rename is the invalidation boundary. The seed is already
 	// durable and both possible writer scopes are locked when it becomes live.
-	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".generation.json"), hermesHookControl{Generation: generation}); err != nil {
+	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".generation.json"), hermesHookControl{Generation: generation, InitialMessagePending: pending}); err != nil {
 		return "", err
 	}
 	i.HermesHookGeneration = generation
@@ -153,8 +157,40 @@ func clearHermesHookScope(instanceID, dir string, preserveControl bool) {
 // clearHermesHookStatuses is safe during attach-return: it removes stale
 // status snapshots but preserves the live process's control and lock inodes.
 func (i *Instance) clearHermesHookStatuses() {
+	if !hermesHookInstanceIDPattern.MatchString(i.ID) || strings.Contains(i.ID, "..") {
+		return
+	}
+	locks, err := acquireHermesHookLocks(i.ID)
+	if err != nil {
+		return
+	}
+	defer locks.release()
 	for _, dir := range []string{GetHooksDir(), filepath.Join(GetHooksDir(), "sandbox", i.ID)} {
 		clearHermesHookScope(i.ID, dir, true)
+	}
+}
+
+func pruneHermesAbandonedScope(instanceID, dir string) {
+	if _, err := os.Stat(filepath.Join(dir, instanceID+".json")); err == nil {
+		return
+	}
+	if _, err := os.Stat(filepath.Join(dir, instanceID+".generation.json")); err == nil {
+		return
+	}
+	lockPath := filepath.Join(dir, instanceID+".lock")
+	f, err := os.OpenFile(lockPath, os.O_RDWR, 0600)
+	if err != nil {
+		return
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return
+	}
+	_ = os.Remove(lockPath)
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = f.Close()
+	if dir != GetHooksDir() {
+		_ = os.Remove(dir)
 	}
 }
 

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
@@ -30,6 +31,49 @@ type hermesHookSeed struct {
 	HookGeneration        string `json:"hook_generation"`
 	Sequence              uint64 `json:"sequence"`
 	InitialMessagePending bool   `json:"initial_message_pending,omitempty"`
+}
+
+var hermesHookInstanceIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
+
+type hermesHookLocks struct{ files []*os.File }
+
+func (l *hermesHookLocks) release() {
+	for n := len(l.files) - 1; n >= 0; n-- {
+		_ = syscall.Flock(int(l.files[n].Fd()), syscall.LOCK_UN)
+		_ = l.files[n].Close()
+	}
+}
+
+func acquireHermesHookLocks(instanceID string) (*hermesHookLocks, error) {
+	if !hermesHookInstanceIDPattern.MatchString(instanceID) || strings.Contains(instanceID, "..") {
+		return nil, fmt.Errorf("invalid instance id %q", instanceID)
+	}
+	root := GetHooksDir()
+	dirs := []string{root, filepath.Join(root, "sandbox", instanceID)}
+	locks := &hermesHookLocks{}
+	for _, dir := range dirs {
+		if dir != root {
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				continue
+			}
+		}
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			locks.release()
+			return nil, err
+		}
+		f, err := os.OpenFile(filepath.Join(dir, instanceID+".lock"), os.O_CREATE|os.O_RDWR, 0600)
+		if err != nil {
+			locks.release()
+			return nil, err
+		}
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+			_ = f.Close()
+			locks.release()
+			return nil, err
+		}
+		locks.files = append(locks.files, f)
+	}
+	return locks, nil
 }
 
 func hermesHookScope(instanceID string, sandboxed bool) string {
@@ -72,35 +116,68 @@ func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string
 	}
 	generation := fmt.Sprintf("%x", raw[:])
 	scope := hermesHookScope(i.ID, i.IsSandboxed())
-	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".generation.json"), hermesHookControl{Generation: generation}); err != nil {
+	if err := os.MkdirAll(scope, 0700); err != nil {
 		return "", err
 	}
+	locks, err := acquireHermesHookLocks(i.ID)
+	if err != nil {
+		return "", err
+	}
+	defer locks.release()
+	opposite := hermesHookScope(i.ID, !i.IsSandboxed())
+	clearHermesHookScope(i.ID, opposite, false)
 	seed := hermesHookSeed{Status: status, Event: "agentdeck_spawn_seed", Timestamp: time.Now().Unix(), HookGeneration: generation, InitialMessagePending: pending}
 	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".json"), seed); err != nil {
+		return "", err
+	}
+	// The control rename is the invalidation boundary. The seed is already
+	// durable and both possible writer scopes are locked when it becomes live.
+	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".generation.json"), hermesHookControl{Generation: generation}); err != nil {
 		return "", err
 	}
 	i.HermesHookGeneration = generation
 	return generation, nil
 }
 
+func clearHermesHookScope(instanceID, dir string, preserveControl bool) {
+	_ = os.Remove(filepath.Join(dir, instanceID+".json"))
+	if !preserveControl {
+		_ = os.Remove(filepath.Join(dir, instanceID+".generation.json"))
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "."+instanceID+"*.tmp-*"))
+	for _, p := range matches {
+		_ = os.Remove(p)
+	}
+}
+
+// clearHermesHookStatuses is safe during attach-return: it removes stale
+// status snapshots but preserves the live process's control and lock inodes.
+func (i *Instance) clearHermesHookStatuses() {
+	for _, dir := range []string{GetHooksDir(), filepath.Join(GetHooksDir(), "sandbox", i.ID)} {
+		clearHermesHookScope(i.ID, dir, true)
+	}
+}
+
 func hermesHookArtifactPaths(instanceID string) []string {
 	root := GetHooksDir()
 	var out []string
 	for _, dir := range []string{root, filepath.Join(root, "sandbox", instanceID)} {
-		out = append(out, filepath.Join(dir, instanceID+".json"), filepath.Join(dir, instanceID+".generation.json"), filepath.Join(dir, instanceID+".lock"))
+		out = append(out, filepath.Join(dir, instanceID+".json"), filepath.Join(dir, instanceID+".generation.json"))
 	}
 	return out
 }
 
 func (i *Instance) clearHermesHookArtifacts() {
-	for _, p := range hermesHookArtifactPaths(i.ID) {
-		_ = os.Remove(p)
+	if !hermesHookInstanceIDPattern.MatchString(i.ID) || strings.Contains(i.ID, "..") {
+		return
 	}
+	locks, err := acquireHermesHookLocks(i.ID)
+	if err != nil {
+		return
+	}
+	defer locks.release()
 	for _, dir := range []string{GetHooksDir(), filepath.Join(GetHooksDir(), "sandbox", i.ID)} {
-		matches, _ := filepath.Glob(filepath.Join(dir, "."+i.ID+"*.tmp-*"))
-		for _, p := range matches {
-			_ = os.Remove(p)
-		}
+		clearHermesHookScope(i.ID, dir, false)
 	}
 }
 

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -17,6 +18,91 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
+
+type hermesHookControl struct {
+	Generation   string `json:"generation"`
+	NextSequence uint64 `json:"next_sequence"`
+}
+type hermesHookSeed struct {
+	Status                string `json:"status"`
+	Event                 string `json:"event"`
+	Timestamp             int64  `json:"ts"`
+	HookGeneration        string `json:"hook_generation"`
+	Sequence              uint64 `json:"sequence"`
+	InitialMessagePending bool   `json:"initial_message_pending,omitempty"`
+}
+
+func hermesHookScope(instanceID string, sandboxed bool) string {
+	if sandboxed {
+		return filepath.Join(GetHooksDir(), "sandbox", instanceID)
+	}
+	return GetHooksDir()
+}
+
+func atomicHermesJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp)
+	if err = f.Chmod(0600); err == nil {
+		_, err = f.Write(b)
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	generation := fmt.Sprintf("%x", raw[:])
+	scope := hermesHookScope(i.ID, i.IsSandboxed())
+	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".generation.json"), hermesHookControl{Generation: generation}); err != nil {
+		return "", err
+	}
+	seed := hermesHookSeed{Status: status, Event: "agentdeck_spawn_seed", Timestamp: time.Now().Unix(), HookGeneration: generation, InitialMessagePending: pending}
+	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".json"), seed); err != nil {
+		return "", err
+	}
+	i.HermesHookGeneration = generation
+	return generation, nil
+}
+
+func hermesHookArtifactPaths(instanceID string) []string {
+	root := GetHooksDir()
+	var out []string
+	for _, dir := range []string{root, filepath.Join(root, "sandbox", instanceID)} {
+		out = append(out, filepath.Join(dir, instanceID+".json"), filepath.Join(dir, instanceID+".generation.json"), filepath.Join(dir, instanceID+".lock"))
+	}
+	return out
+}
+
+func (i *Instance) clearHermesHookArtifacts() {
+	for _, p := range hermesHookArtifactPaths(i.ID) {
+		_ = os.Remove(p)
+	}
+	for _, dir := range []string{GetHooksDir(), filepath.Join(GetHooksDir(), "sandbox", i.ID)} {
+		matches, _ := filepath.Glob(filepath.Join(dir, "."+i.ID+"*.tmp-*"))
+		for _, p := range matches {
+			_ = os.Remove(p)
+		}
+	}
+}
 
 // hermesSessionIDPattern matches a hermes session ID (e.g. "20260720_143254_a3db50"):
 // {YYYYMMDD}_{HHMMSS}_{hex}. Used to pick the ID column out of `hermes sessions
@@ -166,6 +252,9 @@ func (i *Instance) buildHermesCommand(baseCommand string) string {
 	}
 
 	envPrefix := i.buildEnvSourceCommand()
+	if i.HermesHookGeneration != "" {
+		envPrefix += "export AGENTDECK_HOOK_GENERATION=" + shellescape.Quote(i.HermesHookGeneration) + "; "
+	}
 
 	// AGENTDECK_* env injection is required for the shell hooks Hermes spawns
 	// (pre_llm_call / pre_tool_call / … → `agent-deck hook-handler`) to identify

--- a/internal/session/hermes_daemon_feed_test.go
+++ b/internal/session/hermes_daemon_feed_test.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHermesDaemonFeedAdmitsOnlyCurrentAfterAgent(t *testing.T) {
+	for n, tc := range []struct {
+		name, event, generation, control string
+		want                             int
+	}{
+		{"post-llm-call", "post_llm_call", "", "", 1},
+		{"tool-activity", "post_tool_call", "", "", 0},
+		{"stale-generation", "post_llm_call", "old", "current", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := fmt.Sprintf("_test_hermes_feed_%d", n)
+			d, storage := bootstrapDaemonProfile(t, profile)
+			ResetInboxFingerprintCacheForTest()
+			t.Cleanup(ResetInboxFingerprintCacheForTest)
+			parentID := fmt.Sprintf("hermes-parent-%d", n)
+			childID := fmt.Sprintf("hermes-child-%d", n)
+			now := time.Now()
+			child := &Instance{ID: childID, Title: "hermes-worker", ProjectPath: "/tmp/" + childID, GroupPath: DefaultGroupPath, ParentSessionID: parentID, Tool: "hermes", Status: StatusRunning, CreatedAt: now}
+			parent := &Instance{ID: parentID, Title: "orchestrator", ProjectPath: "/tmp/" + parentID, GroupPath: DefaultGroupPath, Tool: "claude", Status: StatusRunning, CreatedAt: now}
+			if err := storage.SaveWithGroups([]*Instance{child, parent}, nil); err != nil {
+				t.Fatal(err)
+			}
+			db := storage.GetDB()
+			if err := db.RegisterInstance(false); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.WriteStatus(childID, "running", "hermes"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.WriteStatus(parentID, "running", "claude"); err != nil {
+				t.Fatal(err)
+			}
+			hooks := GetHooksDir()
+			if err := os.MkdirAll(hooks, 0700); err != nil {
+				t.Fatal(err)
+			}
+			if tc.control != "" {
+				b, _ := json.Marshal(hermesHookControl{Generation: tc.control})
+				if err := os.WriteFile(filepath.Join(hooks, childID+".generation.json"), b, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			status := map[string]any{"status": "waiting", "event": tc.event, "ts": time.Now().Unix()}
+			if tc.generation != "" {
+				status["hook_generation"] = tc.generation
+				status["sequence"] = 1
+			}
+			b, _ := json.Marshal(status)
+			if err := os.WriteFile(filepath.Join(hooks, childID+".json"), b, 0600); err != nil {
+				t.Fatal(err)
+			}
+			d.syncProfile(profile)
+			events, err := DrainInboxForParent(parentID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(events) != tc.want {
+				t.Fatalf("daemon feed delivered %d events, want %d: %+v", len(events), tc.want, events)
+			}
+		})
+	}
+}

--- a/internal/session/hermes_generation_test.go
+++ b/internal/session/hermes_generation_test.go
@@ -141,10 +141,49 @@ func TestHermesGenerationAuthorityRejectsOppositeLegacyStatus(t *testing.T) {
 	if err := os.MkdirAll(scoped, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(scoped, id+".json"), []byte(`{"status":"waiting","event":"after_agent","ts":1}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(scoped, id+".json"), []byte(`{"status":"waiting","event":"post_llm_call","ts":1}`), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if got := readHookStatusFile(id); got != nil {
 		t.Fatalf("opposite legacy status accepted: %+v", got)
+	}
+}
+
+func TestHermesGenerationAuthorityAmbiguityFailsClosed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "hermes-ambiguous"
+	root := GetHooksDir()
+	scoped := filepath.Join(root, "sandbox", id)
+	if err := os.MkdirAll(scoped, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicHermesJSON(filepath.Join(root, id+".generation.json"), hermesHookControl{Generation: "flat"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicHermesJSON(filepath.Join(scoped, id+".generation.json"), hermesHookControl{Generation: "scoped"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scoped, id+".json"), []byte(`{"status":"waiting","event":"post_llm_call","ts":1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readHookStatusFile(id); got != nil {
+		t.Fatalf("ambiguous authority accepted status: %+v", got)
+	}
+}
+
+func TestHermesGenerationAuthorityMalformedFailsClosed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "hermes-malformed"
+	if err := os.MkdirAll(GetHooksDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(GetHooksDir(), id+".generation.json"), []byte(`{"generation":`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(GetHooksDir(), id+".json"), []byte(`{"status":"waiting","event":"post_llm_call","ts":1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readHookStatusFile(id); got != nil {
+		t.Fatalf("malformed authority accepted status: %+v", got)
 	}
 }

--- a/internal/session/hermes_generation_test.go
+++ b/internal/session/hermes_generation_test.go
@@ -88,3 +88,63 @@ func TestHermesTerminalClassification(t *testing.T) {
 		t.Fatal("on_session_end is per-turn, not session-terminal")
 	}
 }
+
+func TestHermesClearStatusPreservesLiveGeneration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := &Instance{ID: "hermes-attached", Tool: "hermes"}
+	if _, err := inst.seedHermesHookGeneration("waiting", false); err != nil {
+		t.Fatal(err)
+	}
+	control := filepath.Join(GetHooksDir(), inst.ID+".generation.json")
+	lock := filepath.Join(GetHooksDir(), inst.ID+".lock")
+	inst.ClearHookStatus()
+	if _, err := os.Stat(control); err != nil {
+		t.Fatalf("live control removed: %v", err)
+	}
+	if _, err := os.Stat(lock); err != nil {
+		t.Fatalf("live lock removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(GetHooksDir(), inst.ID+".json")); !os.IsNotExist(err) {
+		t.Fatalf("status not cleared: %v", err)
+	}
+}
+
+func TestHermesSeedClearsOppositeLayout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := &Instance{ID: "hermes-mode-change", Tool: "hermes"}
+	scoped := filepath.Join(GetHooksDir(), "sandbox", inst.ID)
+	if err := os.MkdirAll(scoped, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{".json", ".generation.json"} {
+		if err := os.WriteFile(filepath.Join(scoped, inst.ID+suffix), []byte("{}"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := inst.seedHermesHookGeneration("waiting", false); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{".json", ".generation.json"} {
+		if _, err := os.Stat(filepath.Join(scoped, inst.ID+suffix)); !os.IsNotExist(err) {
+			t.Fatalf("opposite artifact survived: %s (%v)", suffix, err)
+		}
+	}
+}
+
+func TestHermesGenerationAuthorityRejectsOppositeLegacyStatus(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	id := "hermes-authority"
+	if err := atomicHermesJSON(filepath.Join(GetHooksDir(), id+".generation.json"), hermesHookControl{Generation: "current"}); err != nil {
+		t.Fatal(err)
+	}
+	scoped := filepath.Join(GetHooksDir(), "sandbox", id)
+	if err := os.MkdirAll(scoped, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scoped, id+".json"), []byte(`{"status":"waiting","event":"after_agent","ts":1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readHookStatusFile(id); got != nil {
+		t.Fatalf("opposite legacy status accepted: %+v", got)
+	}
+}

--- a/internal/session/hermes_generation_test.go
+++ b/internal/session/hermes_generation_test.go
@@ -1,0 +1,90 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHermesHookGenerationRejectsDelayedAndCleansBothScopes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := &Instance{ID: "hermes-gen", Tool: "hermes"}
+	g1, err := inst.seedHermesHookGeneration("waiting", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g2, err := inst.seedHermesHookGeneration("starting", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g1 == g2 || g1 == "" || g2 == "" {
+		t.Fatalf("non-unique generations: %q %q", g1, g2)
+	}
+	if got := inst.buildHermesCommand("hermes"); !strings.Contains(got, "AGENTDECK_HOOK_GENERATION=") {
+		t.Fatalf("generation missing from command: %s", got)
+	}
+	for _, p := range hermesHookArtifactPaths(inst.ID) {
+		if strings.HasSuffix(p, ".json") {
+			if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, []byte("{}"), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	inst.clearHermesHookArtifacts()
+	for _, p := range hermesHookArtifactPaths(inst.ID) {
+		if _, err := os.Lstat(p); !os.IsNotExist(err) {
+			t.Fatalf("artifact survived: %s (%v)", p, err)
+		}
+	}
+}
+
+func TestHermesOnlyAgentCompletionIsTransitionCandidate(t *testing.T) {
+	for _, tc := range []struct {
+		event string
+		want  bool
+	}{{"post_llm_call", true}, {"on_session_end", true}, {"post_tool_call", false}, {"on_session_start", false}} {
+		_, got := terminalHookTransitionCandidate("hermes", &HookStatus{Status: "waiting", Event: tc.event, UpdatedAt: time.Now()})
+		if got != tc.want {
+			t.Errorf("event %s candidate=%v want %v", tc.event, got, tc.want)
+		}
+	}
+}
+
+func TestHermesGenerationSeedUsesScopedPathAndPending(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := &Instance{ID: "hermes-sandbox", Tool: "hermes", Sandbox: &SandboxConfig{Enabled: true}}
+	g, err := inst.seedHermesHookGeneration("running", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(GetHooksDir(), "sandbox", inst.ID, inst.ID+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Generation string `json:"hook_generation"`
+		Pending    bool   `json:"initial_message_pending"`
+		Sequence   uint64 `json:"sequence"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Generation != g || !got.Pending || got.Sequence != 0 {
+		t.Fatalf("bad seed: %+v", got)
+	}
+}
+
+func TestHermesTerminalClassification(t *testing.T) {
+	if isTerminalHookEvent("on_session_finalize") != true {
+		t.Fatal("finalize must be terminal")
+	}
+	if isTerminalHookEvent("on_session_end") {
+		t.Fatal("on_session_end is per-turn, not session-terminal")
+	}
+}

--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -1,13 +1,18 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -112,6 +117,53 @@ var hermesHookEvents = []string{
 	"on_session_finalize",
 }
 
+var hermesLegacyHookEvents = []string{"pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"}
+var hermesCalendarVersion = regexp.MustCompile(`(?:v)?(20[0-9]{2})\.([0-9]{1,2})\.([0-9]{1,2})`)
+var hermesVocabularyCache sync.Map // configured command -> bool
+
+// hermesExtendedHookVocabularySupported fails closed for unknown/old Hermes
+// versions: those installs receive only the legacy four keys, avoiding a
+// strict-schema config break. v2026.8.3 is the pinned vocabulary floor.
+var hermesExtendedHookVocabularySupported = func() bool {
+	if override := strings.TrimSpace(os.Getenv("AGENTDECK_HERMES_HOOK_VOCABULARY")); override != "" {
+		return override == "v2026.8.3" || override == "extended"
+	}
+	fields := strings.Fields(GetToolCommand("hermes"))
+	if len(fields) == 0 {
+		return false
+	}
+	cacheKey := strings.Join(fields, "\x00")
+	if cached, ok := hermesVocabularyCache.Load(cacheKey); ok {
+		return cached.(bool)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, fields[0], append(fields[1:], "--version")...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		hermesVocabularyCache.Store(cacheKey, false)
+		return false
+	}
+	m := hermesCalendarVersion.FindStringSubmatch(string(out))
+	if len(m) != 4 {
+		hermesVocabularyCache.Store(cacheKey, false)
+		return false
+	}
+	year, _ := strconv.Atoi(m[1])
+	month, _ := strconv.Atoi(m[2])
+	day, _ := strconv.Atoi(m[3])
+	supported := year > 2026 || (year == 2026 && (month > 8 || (month == 8 && day >= 3)))
+	hermesVocabularyCache.Store(cacheKey, supported)
+	return supported
+}
+
+func hermesHookEventsForInstall() []string {
+	if hermesExtendedHookVocabularySupported() {
+		return hermesHookEvents
+	}
+	return hermesLegacyHookEvents
+}
+
 // GetHermesConfigDir returns the Hermes config directory (~/.hermes).
 func GetHermesConfigDir() string {
 	home, err := os.UserHomeDir()
@@ -156,11 +208,12 @@ func InjectHermesHooks(configDir string) (bool, error) {
 		}
 	}
 
-	if hermesHooksAlreadyInstalled(raw) {
+	events := hermesHookEventsForInstall()
+	if hermesHooksAlreadyInstalled(raw, events) {
 		return false, nil
 	}
 
-	mergeHermesHookEntries(raw)
+	mergeHermesHookEntries(raw, events)
 
 	out, err := yaml.Marshal(raw)
 	if err != nil {
@@ -289,17 +342,17 @@ func CheckHermesHooksInstalled(configDir string) bool {
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return false
 	}
-	return hermesHooksAlreadyInstalled(raw)
+	return hermesHooksAlreadyInstalled(raw, hermesHookEventsForInstall())
 }
 
 // hermesHooksAlreadyInstalled checks that every required event has an
 // agent-deck hook entry.
-func hermesHooksAlreadyInstalled(raw map[string]interface{}) bool {
+func hermesHooksAlreadyInstalled(raw map[string]interface{}, events []string) bool {
 	hooksSection, _ := raw["hooks"].(map[string]interface{})
 	if hooksSection == nil {
 		return false
 	}
-	for _, event := range hermesHookEvents {
+	for _, event := range events {
 		eventHooks, _ := hooksSection[event].([]interface{})
 		found := false
 		for _, h := range eventHooks {
@@ -321,13 +374,13 @@ func hermesHooksAlreadyInstalled(raw map[string]interface{}) bool {
 }
 
 // mergeHermesHookEntries appends agent-deck hook entries for any missing events.
-func mergeHermesHookEntries(raw map[string]interface{}) {
+func mergeHermesHookEntries(raw map[string]interface{}, events []string) {
 	hooksSection, _ := raw["hooks"].(map[string]interface{})
 	if hooksSection == nil {
 		hooksSection = make(map[string]interface{})
 	}
 
-	for _, event := range hermesHookEvents {
+	for _, event := range events {
 		eventHooks, _ := hooksSection[event].([]interface{})
 		alreadyPresent := false
 		for _, h := range eventHooks {

--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -138,6 +138,8 @@ var hermesExtendedHookVocabularySupported = func() bool {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+	// #nosec G204 -- the executable and argv come from the operator-configured
+	// Hermes tool command and are passed directly without shell evaluation.
 	cmd := exec.CommandContext(ctx, fields[0], append(fields[1:], "--version")...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/session/hermes_hooks_test.go
+++ b/internal/session/hermes_hooks_test.go
@@ -39,6 +39,7 @@ func TestInjectHermesHooks_Idempotent(t *testing.T) {
 }
 
 func TestInjectHermesHooks_AllEventsPresent(t *testing.T) {
+	t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "extended")
 	dir := t.TempDir()
 	if _, err := session.InjectHermesHooks(dir); err != nil {
 		t.Fatalf("install: %v", err)
@@ -81,6 +82,7 @@ func TestInjectHermesHooks_AllEventsPresent(t *testing.T) {
 // working even if InjectHermesHooks ever grows an "already installed"
 // fast path keyed on something weaker than the full event set.
 func TestInjectHermesHooks_UpgradesLegacyInstall(t *testing.T) {
+	t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "extended")
 	dir := t.TempDir()
 	legacy := []byte(`hooks:
   pre_tool_call:
@@ -134,6 +136,28 @@ func TestInjectHermesHooks_UpgradesLegacyInstall(t *testing.T) {
 
 	if !strings.Contains(string(data), "/usr/local/bin/my-hook.sh") {
 		t.Error("user hook was dropped during upgrade")
+	}
+}
+
+func TestInjectHermesHooks_OldVersionUsesLegacyVocabulary(t *testing.T) {
+	t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "legacy")
+	dir := t.TempDir()
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	hooks, _ := raw["hooks"].(map[string]interface{})
+	for _, event := range []string{"pre_llm_call", "post_llm_call", "pre_api_request", "post_api_request", "on_session_finalize"} {
+		if _, exists := hooks[event]; exists {
+			t.Fatalf("unsupported event %q injected", event)
+		}
 	}
 }
 

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -45,6 +45,9 @@ type HookStatus struct {
 	CodexCompletedGeneration string
 	CodexStartedSessionID    string
 	CodexCompletedSessionID  string
+	HookGeneration           string
+	Sequence                 uint64
+	InitialMessagePending    bool
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
 	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
@@ -287,6 +290,9 @@ func (w *StatusFileWatcher) instanceIDForStatusFile(filePath string) (string, bo
 	}
 	dir := filepath.Dir(filePath)
 	base := filepath.Base(filePath)
+	if strings.HasSuffix(base, ".generation.json") {
+		return "", false
+	}
 	// Per-instance scoped subdir: …/hooks/sandbox/<id>/…  (parent-of-dir is the
 	// sandbox root, so dir itself is the per-instance subdir named <id>).
 	if w.sandboxDir != "" && filepath.Dir(dir) == w.sandboxDir {
@@ -311,6 +317,9 @@ func (w *StatusFileWatcher) instanceIDForStatusFile(filePath string) (string, bo
 func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir string, entries []os.DirEntry) {
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".generation.json") {
 			continue
 		}
 		path := filepath.Join(dir, entry.Name())
@@ -339,9 +348,20 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			CodexCompletedGeneration string `json:"codex_completed_generation"`
 			CodexStartedSessionID    string `json:"codex_started_session_id"`
 			CodexCompletedSessionID  string `json:"codex_completed_session_id"`
+			HookGeneration           string `json:"hook_generation"`
+			Sequence                 uint64 `json:"sequence"`
+			InitialMessagePending    bool   `json:"initial_message_pending"`
 		}
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
+		}
+		if controlData, controlErr := readStatusFileNoFollow(filepath.Join(dir, instanceID+".generation.json")); controlErr == nil {
+			var control struct {
+				Generation string `json:"generation"`
+			}
+			if json.Unmarshal(controlData, &control) != nil || control.Generation == "" || raw.HookGeneration != control.Generation {
+				continue
+			}
 		}
 		out[instanceID] = &HookStatus{
 			Status:                   raw.Status,
@@ -356,6 +376,9 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			CodexCompletedGeneration: raw.CodexCompletedGeneration,
 			CodexStartedSessionID:    raw.CodexStartedSessionID,
 			CodexCompletedSessionID:  raw.CodexCompletedSessionID,
+			HookGeneration:           raw.HookGeneration,
+			Sequence:                 raw.Sequence,
+			InitialMessagePending:    raw.InitialMessagePending,
 		}
 	}
 }
@@ -489,6 +512,9 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		CodexCompletedGeneration string `json:"codex_completed_generation"`
 		CodexStartedSessionID    string `json:"codex_started_session_id"`
 		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
+		HookGeneration           string `json:"hook_generation"`
+		Sequence                 uint64 `json:"sequence"`
+		InitialMessagePending    bool   `json:"initial_message_pending"`
 	}
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
@@ -498,6 +524,15 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 			slog.Int("bytes_read", len(data)),
 		)
 		return
+	}
+	controlPath := filepath.Join(filepath.Dir(filePath), instanceID+".generation.json")
+	if controlData, controlErr := readStatusFileNoFollow(controlPath); controlErr == nil {
+		var control struct {
+			Generation string `json:"generation"`
+		}
+		if json.Unmarshal(controlData, &control) != nil || control.Generation == "" || status.HookGeneration != control.Generation {
+			return
+		}
 	}
 
 	hookStatus := &HookStatus{
@@ -513,9 +548,16 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		CodexCompletedGeneration: status.CodexCompletedGeneration,
 		CodexStartedSessionID:    status.CodexStartedSessionID,
 		CodexCompletedSessionID:  status.CodexCompletedSessionID,
+		HookGeneration:           status.HookGeneration,
+		Sequence:                 status.Sequence,
+		InitialMessagePending:    status.InitialMessagePending,
 	}
 
 	w.mu.Lock()
+	if prior := w.statuses[instanceID]; prior != nil && status.HookGeneration != "" && prior.HookGeneration == status.HookGeneration && status.Sequence <= prior.Sequence {
+		w.mu.Unlock()
+		return
+	}
 	w.statuses[instanceID] = hookStatus
 	w.mu.Unlock()
 

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -47,7 +47,6 @@ type HookStatus struct {
 	CodexCompletedSessionID  string
 	HookGeneration           string
 	Sequence                 uint64
-	InitialMessagePending    bool
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
 	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
@@ -61,6 +60,33 @@ type HookStatus struct {
 	// id may bind — empty (legacy files, agents that send no cwd) means "no
 	// evidence either way" and never blocks.
 	Cwd string
+}
+
+// hookGenerationForInstance resolves generation authority by instance, not by
+// whichever layout happened to contain a status file. A mode change leaves at
+// most one control (seed clears the opposite scope); conflicting controls fail
+// closed rather than selecting a stale layout.
+func hookGenerationForInstance(instanceID string) (string, bool) {
+	root := GetHooksDir()
+	paths := []string{filepath.Join(root, "sandbox", instanceID, instanceID+".generation.json"), filepath.Join(root, instanceID+".generation.json")}
+	found := ""
+	for _, path := range paths {
+		data, err := readStatusFileNoFollow(path)
+		if err != nil {
+			continue
+		}
+		var control struct {
+			Generation string `json:"generation"`
+		}
+		if json.Unmarshal(data, &control) != nil || control.Generation == "" {
+			return "", true
+		}
+		if found != "" && found != control.Generation {
+			return "", true
+		}
+		found = control.Generation
+	}
+	return found, found != ""
 }
 
 // StatusFileWatcher watches ~/.agent-deck/hooks/ for status file changes
@@ -350,18 +376,12 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 			HookGeneration           string `json:"hook_generation"`
 			Sequence                 uint64 `json:"sequence"`
-			InitialMessagePending    bool   `json:"initial_message_pending"`
 		}
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
-		if controlData, controlErr := readStatusFileNoFollow(filepath.Join(dir, instanceID+".generation.json")); controlErr == nil {
-			var control struct {
-				Generation string `json:"generation"`
-			}
-			if json.Unmarshal(controlData, &control) != nil || control.Generation == "" || raw.HookGeneration != control.Generation {
-				continue
-			}
+		if generation, controlled := hookGenerationForInstance(instanceID); controlled && raw.HookGeneration != generation {
+			continue
 		}
 		out[instanceID] = &HookStatus{
 			Status:                   raw.Status,
@@ -378,7 +398,6 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			CodexCompletedSessionID:  raw.CodexCompletedSessionID,
 			HookGeneration:           raw.HookGeneration,
 			Sequence:                 raw.Sequence,
-			InitialMessagePending:    raw.InitialMessagePending,
 		}
 	}
 }
@@ -514,7 +533,6 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 		HookGeneration           string `json:"hook_generation"`
 		Sequence                 uint64 `json:"sequence"`
-		InitialMessagePending    bool   `json:"initial_message_pending"`
 	}
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
@@ -525,14 +543,8 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		)
 		return
 	}
-	controlPath := filepath.Join(filepath.Dir(filePath), instanceID+".generation.json")
-	if controlData, controlErr := readStatusFileNoFollow(controlPath); controlErr == nil {
-		var control struct {
-			Generation string `json:"generation"`
-		}
-		if json.Unmarshal(controlData, &control) != nil || control.Generation == "" || status.HookGeneration != control.Generation {
-			return
-		}
+	if generation, controlled := hookGenerationForInstance(instanceID); controlled && status.HookGeneration != generation {
+		return
 	}
 
 	hookStatus := &HookStatus{
@@ -550,7 +562,6 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		CodexCompletedSessionID:  status.CodexCompletedSessionID,
 		HookGeneration:           status.HookGeneration,
 		Sequence:                 status.Sequence,
-		InitialMessagePending:    status.InitialMessagePending,
 	}
 
 	w.mu.Lock()

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -66,27 +66,52 @@ type HookStatus struct {
 // whichever layout happened to contain a status file. A mode change leaves at
 // most one control (seed clears the opposite scope); conflicting controls fail
 // closed rather than selecting a stale layout.
-func hookGenerationForInstance(instanceID string) (string, bool) {
+type hookGenerationAuthority uint8
+
+const (
+	hookGenerationAbsent hookGenerationAuthority = iota
+	hookGenerationValid
+	hookGenerationAmbiguous
+)
+
+func hookGenerationForInstance(instanceID string) (string, hookGenerationAuthority) {
 	root := GetHooksDir()
 	paths := []string{filepath.Join(root, "sandbox", instanceID, instanceID+".generation.json"), filepath.Join(root, instanceID+".generation.json")}
 	found := ""
 	for _, path := range paths {
 		data, err := readStatusFileNoFollow(path)
 		if err != nil {
+			if _, statErr := os.Lstat(path); statErr == nil {
+				return "", hookGenerationAmbiguous
+			}
 			continue
 		}
 		var control struct {
 			Generation string `json:"generation"`
 		}
 		if json.Unmarshal(data, &control) != nil || control.Generation == "" {
-			return "", true
+			return "", hookGenerationAmbiguous
 		}
 		if found != "" && found != control.Generation {
-			return "", true
+			return "", hookGenerationAmbiguous
 		}
 		found = control.Generation
 	}
-	return found, found != ""
+	if found == "" {
+		return "", hookGenerationAbsent
+	}
+	return found, hookGenerationValid
+}
+
+func hookGenerationRecordAccepted(recordGeneration string, generation string, authority hookGenerationAuthority) bool {
+	switch authority {
+	case hookGenerationAbsent:
+		return recordGeneration == ""
+	case hookGenerationValid:
+		return recordGeneration == generation
+	default:
+		return false
+	}
 }
 
 // StatusFileWatcher watches ~/.agent-deck/hooks/ for status file changes
@@ -380,7 +405,7 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
-		if generation, controlled := hookGenerationForInstance(instanceID); controlled && raw.HookGeneration != generation {
+		if generation, authority := hookGenerationForInstance(instanceID); !hookGenerationRecordAccepted(raw.HookGeneration, generation, authority) {
 			continue
 		}
 		out[instanceID] = &HookStatus{
@@ -543,7 +568,7 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		)
 		return
 	}
-	if generation, controlled := hookGenerationForInstance(instanceID); controlled && status.HookGeneration != generation {
+	if generation, authority := hookGenerationForInstance(instanceID); !hookGenerationRecordAccepted(status.HookGeneration, generation, authority) {
 		return
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -299,7 +299,8 @@ type Instance struct {
 	// persisted (json:"-"): it is re-captured on every restart, so it needs no
 	// lifetime beyond a single Restart() call — which also keeps it out of the
 	// JSON marshaling that could otherwise race the restart-time write.
-	HermesSessionID string `json:"-"`
+	HermesSessionID      string `json:"-"`
+	HermesHookGeneration string `json:"-"`
 	// restartEnv contains one-shot environment overrides while RestartWithEnv is
 	// building the replacement process. It is cleared before the call returns.
 	restartEnv map[string]string
@@ -4342,7 +4343,9 @@ func (i *Instance) Start() error {
 		// fires only at the first turn), so seed the "waiting" baseline the
 		// prompt represents — otherwise a fresh session has no status icon
 		// until the user types.
-		i.seedHermesHookBaseline()
+		if _, err := i.seedHermesHookGeneration("waiting", false); err != nil {
+			return err
+		}
 		command = i.buildHermesCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
@@ -4629,7 +4632,9 @@ func (i *Instance) StartWithMessage(message string) error {
 		// fires only at the first turn), so seed the "waiting" baseline the
 		// prompt represents — otherwise a fresh session has no status icon
 		// until the user types.
-		i.seedHermesHookBaseline()
+		if _, err := i.seedHermesHookGeneration("running", true); err != nil {
+			return err
+		}
 		command = i.buildHermesCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
@@ -6033,6 +6038,10 @@ func (i *Instance) ClearHookStatus() {
 	// this evidence has no other way to survive. Outside i.mu: the SQLite
 	// write can stall on SQLITE_BUSY (see persistLastActivity).
 	i.persistLastActivity(true)
+	if i.Tool == "hermes" {
+		i.clearHermesHookArtifacts()
+		return
+	}
 
 	// Remove the persisted status file. Sandbox sessions bridge a PER-INSTANCE
 	// scoped subdir (…/hooks/sandbox/<id>/<id>.json) from the container, and the
@@ -7631,6 +7640,9 @@ func (i *Instance) killInternal(sync bool) error {
 	i.mu.Unlock()
 	// (gen already bumped at the top of killInternal, before the tmux kill —
 	// see the comment there for why it must happen first, not here.)
+	if i.Tool == "hermes" {
+		i.clearHermesHookArtifacts()
+	}
 
 	// Clean up sandbox container (only if name matches our prefix convention).
 	// Runs regardless of tmux kill result to avoid orphaned containers.
@@ -7747,6 +7759,14 @@ func (i *Instance) restart(env map[string]string) error {
 			i.restartEnv[key] = value
 		}
 		defer func() { i.restartEnv = nil }()
+	}
+	// Generation publication is the restart invalidation boundary. Commit it
+	// before any signal/kill reaches the old Hermes process, so its delayed
+	// hooks cannot overwrite the replacement's starting seed.
+	if i.Tool == "hermes" {
+		if _, err := i.seedHermesHookGeneration("starting", false); err != nil {
+			return fmt.Errorf("seed hermes restart generation: %w", err)
+		}
 	}
 
 	mcpLog.Debug(

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6039,7 +6039,7 @@ func (i *Instance) ClearHookStatus() {
 	// write can stall on SQLITE_BUSY (see persistLastActivity).
 	i.persistLastActivity(true)
 	if i.Tool == "hermes" {
-		i.clearHermesHookArtifacts()
+		i.clearHermesHookStatuses()
 		return
 	}
 

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -334,7 +334,7 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 	hookStatuses := make(map[string]*HookStatus, len(instances))
 	for _, inst := range instances {
 		byID[inst.ID] = inst
-		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "cursor" {
+		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "cursor" || inst.Tool == "hermes" {
 			if hs := d.hookStatusForInstance(inst.ID); hs != nil {
 				// Issue #1349: only let a hook status rebind the session id when
 				// the instance is actually LIVE (running/waiting/idle with a real
@@ -762,7 +762,7 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	if strings.TrimSpace(raw.Status) == "" {
 		return nil
 	}
-	if generation, controlled := hookGenerationForInstance(instanceID); controlled && raw.HookGeneration != generation {
+	if generation, authority := hookGenerationForInstance(instanceID); !hookGenerationRecordAccepted(raw.HookGeneration, generation, authority) {
 		return nil
 	}
 	updatedAt := time.Now()

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -735,7 +735,8 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	// No-follow + size-bounded read for both the scoped (sandbox) and flat
 	// (non-sandbox) paths: a container could symlink or oversize its <id>.json
 	// to read a host file or OOM the shared notify-daemon that polls this.
-	data, err := readStatusFileNoFollow(hookStatusFilePath(instanceID))
+	statusPath := hookStatusFilePath(instanceID)
+	data, err := readStatusFileNoFollow(statusPath)
 	if err != nil || len(data) == 0 {
 		return nil
 	}
@@ -752,12 +753,24 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		CodexCompletedGeneration string `json:"codex_completed_generation"`
 		CodexStartedSessionID    string `json:"codex_started_session_id"`
 		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
+		HookGeneration           string `json:"hook_generation"`
+		Sequence                 uint64 `json:"sequence"`
+		InitialMessagePending    bool   `json:"initial_message_pending"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
 	}
 	if strings.TrimSpace(raw.Status) == "" {
 		return nil
+	}
+	controlPath := filepath.Join(filepath.Dir(statusPath), instanceID+".generation.json")
+	if controlData, controlErr := readStatusFileNoFollow(controlPath); controlErr == nil {
+		var control struct {
+			Generation string `json:"generation"`
+		}
+		if json.Unmarshal(controlData, &control) != nil || control.Generation == "" || raw.HookGeneration != control.Generation {
+			return nil
+		}
 	}
 	updatedAt := time.Now()
 	if raw.Timestamp > 0 {
@@ -776,6 +789,9 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		CodexCompletedGeneration: raw.CodexCompletedGeneration,
 		CodexStartedSessionID:    raw.CodexStartedSessionID,
 		CodexCompletedSessionID:  raw.CodexCompletedSessionID,
+		HookGeneration:           raw.HookGeneration,
+		Sequence:                 raw.Sequence,
+		InitialMessagePending:    raw.InitialMessagePending,
 	}
 }
 
@@ -875,6 +891,10 @@ func terminalHookTransitionCandidate(tool string, hs *HookStatus) (hookTransitio
 		if event == "stop" {
 			return hookTransitionCandidate{ToStatus: to, Timestamp: hs.UpdatedAt}, true
 		}
+	case "hermes":
+		if event == "post_llm_call" || event == "postllmcall" || event == "onsessionend" || event == "on_session_end" {
+			return hookTransitionCandidate{ToStatus: to, Timestamp: hs.UpdatedAt}, true
+		}
 	}
 	return hookTransitionCandidate{}, false
 }
@@ -894,7 +914,7 @@ func isTerminalHookEvent(event string) bool {
 	norm = strings.NewReplacer(".", "", "-", "", "_", "", "/", "", " ", "").Replace(norm)
 	switch norm {
 	case "sessionend", "sessionended", "sessionclose", "sessionclosed", "sessiondone", "sessionexit", "sessionexited",
-		"onsessionend",
+		"onsessionfinalize",
 		"threadend", "threadended", "threadterminate", "threadterminated", "threadclose", "threadclosed",
 		"threaddone", "threadexit", "threadexited":
 		return true

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -755,7 +755,6 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
 		HookGeneration           string `json:"hook_generation"`
 		Sequence                 uint64 `json:"sequence"`
-		InitialMessagePending    bool   `json:"initial_message_pending"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
@@ -763,14 +762,8 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	if strings.TrimSpace(raw.Status) == "" {
 		return nil
 	}
-	controlPath := filepath.Join(filepath.Dir(statusPath), instanceID+".generation.json")
-	if controlData, controlErr := readStatusFileNoFollow(controlPath); controlErr == nil {
-		var control struct {
-			Generation string `json:"generation"`
-		}
-		if json.Unmarshal(controlData, &control) != nil || control.Generation == "" || raw.HookGeneration != control.Generation {
-			return nil
-		}
+	if generation, controlled := hookGenerationForInstance(instanceID); controlled && raw.HookGeneration != generation {
+		return nil
 	}
 	updatedAt := time.Now()
 	if raw.Timestamp > 0 {
@@ -791,7 +784,6 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		CodexCompletedSessionID:  raw.CodexCompletedSessionID,
 		HookGeneration:           raw.HookGeneration,
 		Sequence:                 raw.Sequence,
-		InitialMessagePending:    raw.InitialMessagePending,
 	}
 }
 


### PR DESCRIPTION
Binds Hermes hook updates to the active spawn generation so delayed events from an earlier process cannot overwrite a restarted session. Preserves pending initial-message state, cleans up generation artifacts safely, and feeds generation-aware status into daemon transitions.

Tests: `go build ./...`; `go vet ./...`; focused Hermes and hook-status tests in `cmd/agent-deck` and `internal/session`.

Fixes #1825

