### PR TITLE
fix: address publication review follow-ups

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1408,6 +1408,9 @@ func handleAdd(profile string, args []string) {
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
 	}
+	if *sshHost != "" && len(pluginFlags) > 0 {
+		fmt.Fprintln(os.Stderr, "Warning: --plugin is persisted but cannot be installed or enabled automatically over SSH; configure the selected plugins in the remote Claude profile.")
+	}
 
 	// Path argument is optional; if omitted with -g/--group, we'll try group default_path.
 	// Fix: sanitize input to remove surrounding quotes that cause issues.

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3491,7 +3491,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		paneNow := send.CaptureOutcome(captured, captureErr)
 		if paneNow.OK {
 			content := tmux.StripANSI(captured)
-			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
+			unsentPromptDetected = send.ComposerHoldsPasteMarker(captured, tmux.StripANSI) || send.HasUnsentComposerPrompt(content, message)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
 				sawDeliveryEvidence = true
 			}
@@ -3601,7 +3601,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	if opts.verifyDelivery {
 		if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
 			content := tmux.StripANSI(rawContent)
-			if send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message) {
+			if send.ComposerHoldsPasteMarker(rawContent, tmux.StripANSI) || send.HasUnsentComposerPrompt(content, message) {
 				return deliveryTypedNotSubmitted, fmt.Errorf(
 					"message typed but not submitted after %d verification checks (issue #1413): "+
 						"the composer still holds the message despite bounded Enter retries. "+

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -500,6 +500,27 @@ func TestSendWithRetryTarget_RetriesOnUnsentPasteMarker(t *testing.T) {
 	}
 }
 
+func TestSendWithRetryTarget_TranscriptPasteMarkerDoesNotBecomeTypedNotSubmitted(t *testing.T) {
+	// `paste-buffer -p` leaves this marker in transcript scrollback after the
+	// agent accepts the message. The live composer below it is empty. Whole-pane
+	// matching used to keep nudging Enter and classify the accepted send as
+	// typed_not_submitted.
+	pane := "assistant response\n[Pasted text #1 +89 lines]\n────────────\n❯ \n────────────\n"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active", "active"},
+		panes:    []string{pane, pane},
+	}
+	delivery, err := sendWithRetryTarget(mock, "first line\nsecond line", false, sendRetryOptions{
+		maxRetries: 2, checkDelay: 0, verifyDelivery: true, composerPasteFreeBeforeSend: true,
+	})
+	if err != nil || delivery != deliverySubmitted {
+		t.Fatalf("accepted multiline send misclassified: delivery=%q err=%v", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("transcript marker caused %d spurious Enter nudges", got)
+	}
+}
+
 // TestSendWithRetryTarget_DetectsPasteMarkerAfterInitialWaiting locks in the
 // post-#876 contract: an active-status transition (and a paste marker en
 // route) IS positive evidence, so verifyDelivery returns nil. State-machine

--- a/conductor/setup.sh
+++ b/conductor/setup.sh
@@ -45,8 +45,8 @@ register_session() {
     local profile="$1" dir="$2" title="$3"
     local out rc code
 
-    out="$(agent-deck -p "${profile}" add "${dir}" -t "${title}" -c claude -g "infra" --json 2>&1)"
-    rc=$?
+    rc=0
+    out="$(agent-deck -p "${profile}" add "${dir}" -t "${title}" -c claude -g "infra" --json 2>&1)" || rc=$?
 
     if [[ ${rc} -eq 0 ]]; then
         ok "  Session ${title} registered in ${profile}"

--- a/conductor/setup_register_test.go
+++ b/conductor/setup_register_test.go
@@ -66,7 +66,7 @@ func runRegisterSession(t *testing.T, exitCode int, stdoutText string) string {
 
 	body := extractShellFunc(t, "setup.sh", "register_session")
 	script := `#!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 GREEN=''; YELLOW=''; NC=''
 ok()   { echo "[ok] $*"; }
 warn() { echo "[warn] $*"; }

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -16,8 +16,6 @@ import (
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
-
-	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 type hermesHookControl struct {
@@ -416,41 +414,6 @@ func (i *Instance) buildHermesCommand(baseCommand string) string {
 	}
 
 	return envPrefix + cmd
-}
-
-// seedHermesHookBaseline records a synthetic "waiting" hook status, in memory
-// and in the persisted hook file, for a freshly (re)spawned hermes process
-// sitting at its prompt. Needed because hermes emits no lifecycle event at
-// process launch — on_session_start fires only at the first turn of a
-// brand-new session — so without this seed a restarted session has no hook
-// state at all until the user types. The first real hook event overwrites it.
-func (i *Instance) seedHermesHookBaseline() {
-	now := time.Now()
-	i.mu.Lock()
-	i.hookStatus = "waiting"
-	i.hookEvent = "agentdeck_restart_baseline"
-	i.hookLastUpdate = now
-	i.mu.Unlock()
-
-	payload, err := json.Marshal(map[string]interface{}{
-		"status": "waiting",
-		"event":  "agentdeck_restart_baseline",
-		"ts":     now.Unix(),
-		"cwd":    i.EffectiveWorkingDir(),
-	})
-	if err != nil {
-		return
-	}
-	hooksDir := GetHooksDir()
-	if err := os.MkdirAll(hooksDir, 0700); err != nil {
-		return
-	}
-	if err := atomicfile.WriteFile(filepath.Join(hooksDir, i.ID+".json"), payload, 0600); err != nil {
-		sessionLog.Debug("hermes_hook_baseline_write_failed",
-			slog.String("instance", i.ID),
-			slog.String("error", err.Error()),
-		)
-	}
 }
 
 // IsHermesGatewayReachable performs a basic reachable check against the

--- a/internal/session/hermes_generation_test.go
+++ b/internal/session/hermes_generation_test.go
@@ -109,6 +109,31 @@ func TestHermesClearStatusPreservesLiveGeneration(t *testing.T) {
 	}
 }
 
+func TestHermesRestartWaitingSeedCarriesCurrentGeneration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := &Instance{ID: "hermes-restart", Tool: "hermes"}
+	if _, err := inst.seedHermesHookGeneration("starting", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inst.seedHermesHookGeneration("waiting", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(GetHooksDir(), inst.ID+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seed hermesHookSeed
+	if err := json.Unmarshal(b, &seed); err != nil {
+		t.Fatal(err)
+	}
+	if seed.Status != "waiting" || seed.HookGeneration == "" || seed.HookGeneration != inst.HermesHookGeneration {
+		t.Fatalf("restart baseline is not generation-aware: %+v current=%q", seed, inst.HermesHookGeneration)
+	}
+	if command := inst.buildHermesCommand("hermes"); !strings.Contains(command, "AGENTDECK_HOOK_GENERATION="+seed.HookGeneration) {
+		t.Fatalf("replacement command does not export baseline generation: %s", command)
+	}
+}
+
 func TestHermesSeedClearsOppositeLayout(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	inst := &Instance{ID: "hermes-mode-change", Tool: "hermes"}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4868,7 +4868,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 		paneNow := send.CaptureOutcome(captured, captureErr)
 		if paneNow.OK {
 			content := tmux.StripANSI(captured)
-			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
+			unsentPromptDetected = send.ComposerHoldsPasteMarker(captured, tmux.StripANSI) || send.HasUnsentComposerPrompt(content, message)
 		}
 		verifiedStatus, statusErr := i.tmuxSession.GetStatus()
 
@@ -8305,8 +8305,9 @@ func (i *Instance) restart(env map[string]string) error {
 		// error ✕ for the whole freshness window, and without the seed the
 		// session shows no state at all. The freshly respawned process sits at
 		// its prompt, which is exactly "waiting".
-		i.ClearHookStatus()
-		i.seedHermesHookBaseline()
+		if _, err := i.seedHermesHookGeneration("waiting", false); err != nil {
+			return fmt.Errorf("seed hermes restart baseline: %w", err)
+		}
 		command = i.buildHermesCommand(i.Command)
 	} else {
 		// Route to appropriate command builder based on tool

--- a/internal/session/issue1858_remote_config_dir_test.go
+++ b/internal/session/issue1858_remote_config_dir_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"al.essio.dev/pkg/shellescape"

--- a/internal/session/issue1858_remote_config_dir_test.go
+++ b/internal/session/issue1858_remote_config_dir_test.go
@@ -79,6 +79,21 @@ func TestNeedsWorkerScratchConfigDir_NeverForRemoteSessions(t *testing.T) {
 	}
 }
 
+func TestRemotePluginSetupWarningIsExplicit(t *testing.T) {
+	remote := NewInstanceWithTool("remote", t.TempDir(), "claude")
+	remote.SSHHost = "cloudlydr@remote-host"
+	remote.Plugins = []string{"telegram"}
+	warning := remote.remotePluginSetupWarning()
+	if !strings.Contains(warning, "unavailable over SSH") || !strings.Contains(warning, "remote Claude profile") {
+		t.Fatalf("warning is not actionable: %q", warning)
+	}
+	local := NewInstanceWithTool("local", t.TempDir(), "claude")
+	local.Plugins = []string{"telegram"}
+	if got := local.remotePluginSetupWarning(); got != "" {
+		t.Fatalf("local plugin setup warned: %q", got)
+	}
+}
+
 // TestApplyWorkerScratchOverride_RemoteKeepsResolvedDir is defense in depth: even
 // if WorkerScratchConfigDir is somehow already set (an older state.db row, a
 // profile migration), the swap must not happen for a remote session.

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -808,6 +808,14 @@ func (i *Instance) prepareWorkerScratchConfigDirForSpawn() {
 	// re-arm needsScratchForTelegramChannelOwner on this very spawn
 	// (telegram_reliability.go, telegram-channel-restore).
 	reconcileConductorTelegramChannel(i)
+	if warning := i.remotePluginSetupWarning(); warning != "" {
+		sessionLog.Warn("ssh_plugin_setup_skipped",
+			slog.String("instance_id", i.ID),
+			slog.String("ssh_host", i.SSHHost),
+			slog.Any("plugins", i.Plugins),
+			slog.String("guidance", warning),
+		)
+	}
 	if !i.NeedsWorkerScratchConfigDir() {
 		return
 	}
@@ -866,6 +874,13 @@ func (i *Instance) prepareWorkerScratchConfigDirForSpawn() {
 	if result := VerifyTelegramChannelEnabled(effectiveDir, i.Channels); !result.OK {
 		EmitTelegramChannelDriftWarning(i.Title, i.ID, effectiveDir, i.Channels, result)
 	}
+}
+
+func (i *Instance) remotePluginSetupWarning() string {
+	if i == nil || !i.IsSSH() || len(i.Plugins) == 0 {
+		return ""
+	}
+	return "per-session plugin installation and enablement are unavailable over SSH; configure these plugins in the remote Claude profile"
 }
 
 // macOSScratchWarningEmitter is the package-level seam that lets tests

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -13818,6 +13818,16 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	}
 	h.remoteSessionsMu.RUnlock()
 
+	// Empty IDs cannot be represented in the persisted order overlay. A swap
+	// across one would be discarded by applyRemoteSessionOrder on the immediate
+	// rebuild, making a successful-looking move a silent no-op.
+	for _, id := range natural {
+		if id == "" {
+			h.setError(fmt.Errorf("cannot move '%s' %s: %s lists a session without an id in this group, so its order cannot be tracked", moved.Title, direction, item.RemoteName))
+			return
+		}
+	}
+
 	// A bucket whose IDs are not unique cannot be reordered at all:
 	// orderRemoteBucket refuses to permute it, because the slot mapping is no
 	// longer 1:1 and a row could be dropped or doubled. Storing an order for it

--- a/internal/ui/issue1875_remote_order_test.go
+++ b/internal/ui/issue1875_remote_order_test.go
@@ -499,3 +499,34 @@ agent_deck_path = "/usr/local/bin/agent-deck"
 		t.Fatal("silent no-op: moving a uniquely-named row in a duplicate-id bucket said nothing")
 	}
 }
+
+func TestRemoteReorderRejectsBucketWithMissingID(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.dev]
+host = "user@dev.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+`)
+	h := NewHome()
+	h.width, h.height = 160, 40
+	h.initialLoading = false
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "s-a", Title: "first", Status: "idle", Tool: "claude", Group: "work"},
+			{ID: "", Title: "legacy", Status: "idle", Tool: "claude", Group: "work"},
+			{ID: "s-b", Title: "third", Status: "idle", Tool: "claude", Group: "work"},
+		},
+	}
+	h.rebuildFlatItems()
+	before := visibleRemoteSessionIDs(h, "dev")
+	putCursorOnRemoteSession(t, h, "s-b")
+	h.handleMainKey(tea.KeyMsg{Type: tea.KeyShiftUp})
+	if got := visibleRemoteSessionIDs(h, "dev"); strings.Join(got, ",") != strings.Join(before, ",") {
+		t.Fatalf("rows moved across an ID-less row: %v -> %v", before, got)
+	}
+	if h.err == nil || !strings.Contains(strings.ToLower(h.err.Error()), "without an id") {
+		t.Fatalf("missing explicit ID-less-row error: %v", h.err)
+	}
+	if got := h.remoteSessionOrder.forRemote("dev")["work"]; got != nil {
+		t.Fatalf("stored unrepresentable order: %v", got)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Several post-merge review findings left send verification, remote ordering, conductor setup, SSH plugin handling, and Hermes restart status in misleading or broken states.

## Why this change

This fix-forward scopes paste detection to the active composer, rejects unrepresentable remote ordering, makes shell failure capture safe under errexit, warns when SSH plugin setup cannot be applied locally, and preserves generation-aware Hermes restart state.

## User impact

Multiline Claude sends no longer false-fail after acceptance; remote reorder failures and unsupported SSH plugin setup are explicit; conductor setup continues after registration races; restarted Hermes sessions immediately show waiting status.

## Evidence

- `go build ./...`
- `go vet ./...`
- `bash -n conductor/setup.sh`
- Focused regression tests across `./conductor`, `./internal/ui`, `./internal/session`, and `./cmd/agent-deck`, all with isolated HOME/XDG paths

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** GPT-5

## What actually bothered you

The merged fixes still left real review findings that could misreport accepted sends, silently ignore user actions, abort setup, or lose restart status.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included (not applicable; no polling cadence or added hot-path I/O)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5 intent=yes -->
