### PR TITLE
docs: clean up v1.12.0 documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-14
+
+### Added
+
+- **Federated remote TUI navigation now mirrors local groups.** Remote sessions are nested under their remote group paths; remote host and subgroup rows can be collapsed with the normal group keys. Sessions can be reordered within their remote group with the existing reorder keys. This order is a persisted preference on the viewing machine; it does not rewrite the remote host, and remote group headers remain name-sorted. Remote rows expose coarse status; local substates and the federated tree are not yet available in the Web UI.
+
+### Security
+
+- **Go toolchain updated to 1.25.13** for the latest standard-library security fixes.
+
 ## [1.11.0] - 2026-08-01
 
 Security and correctness release. Repo-supplied worktree scripts now require explicit consent, path handling around the skills catalog and logs is hardened, `session send` tells the truth about delivery, restarted sessions can no longer resume the wrong conversation, and Ctrl+Q detach works on every session sharing a tmux socket.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Tell us **which model** in the PR's AI-disclosure section (`claude-opus-4-x`, `g
 
 ### Prerequisites
 
-- Go 1.24 or later (or Go 1.21+ with automatic toolchain download)
+- Go 1.25.13
 - tmux
 - Make
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![GitHub Stars](https://img.shields.io/github/stars/asheshgoplani/agent-deck?style=for-the-badge&logo=github&color=yellow&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck/stargazers)
 [![Downloads](https://img.shields.io/github/downloads/asheshgoplani/agent-deck/total?style=for-the-badge&logo=github&color=bb9af7&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck/releases)
-[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=for-the-badge&logo=go&labelColor=1a1b26)](https://go.dev)
+[![Go Version](https://img.shields.io/badge/Go-1.25.13-00ADD8?style=for-the-badge&logo=go&labelColor=1a1b26)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-9ece6a?style=for-the-badge&labelColor=1a1b26)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20WSL-7aa2f7?style=for-the-badge&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck)
 [![Latest Release](https://img.shields.io/github/v/release/asheshgoplani/agent-deck?style=for-the-badge&color=e0af68&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck/releases)
@@ -85,6 +85,7 @@ See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#uninstalli
 agent-deck                        # Launch TUI
 agent-deck add . -c claude        # Add current dir with Claude
 agent-deck session fork my-proj   # Fork a supported session
+agent-deck session send my-proj --message-file task.md # Send a multiline prompt
 agent-deck session remove my-proj # Remove stopped/errored session from registry (transcripts preserved)
 agent-deck mcp attach my-proj exa # Attach MCP to session
 agent-deck skill attach my-proj docs --source pool --restart # Attach skill + restart
@@ -721,6 +722,15 @@ Agent Deck works with any terminal-based AI tool:
 | **Hermes Agent** | Organization, launch |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 
+Codex status detection uses Codex's notify hook. Install and verify it once for each Codex home:
+
+```bash
+agent-deck codex-hooks install
+agent-deck codex-hooks status
+```
+
+If you set `CODEX_HOME`, use the same environment here and when launching Codex. Without the hook, turn-level running/waiting status cannot converge reliably.
+
 Hide tools you don't use from the new-session picker with `[ui].hidden_tools` (applies to TUI and web; `shell` is always available).
 
 ### Cost Tracking Dashboard
@@ -835,13 +845,12 @@ Feedback posts to a public GitHub Discussion at [Feedback Hub](https://github.co
 - Or run `agent-deck feedback` from the CLI (rating 1-5)
 - **Nothing is sent until you explicitly type `y` at the confirmation prompt.** Before the prompt, the CLI shows (1) the public URL the comment will land on, (2) that it posts via the `gh` CLI using your account, (3) your GitHub username as it will appear, and (4) the exact body that will be posted. Default answer is **N** — pressing Enter declines.
 - If `gh` fails (auth required, not installed, network), the CLI prints an error and exits non-zero. No clipboard or browser fallback is triggered on the CLI path.
-- A private/anonymous feedback channel is being designed for a future release — track in [#679](https://github.com/asheshgoplani/agent-deck/issues/679).
 
 **Feedback prompt frequency** (v1.7.41+): the TUI's auto-prompt is paced so brand-new users aren't asked on their first few launches. The first prompt appears only after **7 launches or 3 days** of use, whichever comes later. If you dismiss it, agent-deck waits **14 days** before asking again. You'll see at most **3 prompts per version**, and pressing `n` at any step opts you out permanently — use `agent-deck feedback` or `Ctrl+E` to re-enable on demand. Opt-out always wins over every pacing gate.
 
 ### Remote Instances
 
-Manage agent-deck instances running on remote SSH servers from your local terminal. Remote sessions appear alongside local sessions in the TUI and all CLI commands.
+Manage agent-deck instances running on remote SSH servers from your local terminal. Remote sessions report coarse live status and use the same nested group layout as local sessions; remote groups can be collapsed, and `K`/`J` reorder sessions within a remote group. Session identity includes its location, so the same title can safely exist locally and on different remote host/path pairs.
 
 ```bash
 # Register a remote
@@ -865,25 +874,9 @@ agent-deck remote update          # all remotes
 agent-deck remote update dev      # specific remote
 ```
 
-Remote configuration is stored under `[remotes]` in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`). All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.
+Remote configuration is stored under `[remotes]` in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`). `remote list` and `remote sessions` support `--json` output for scripting. See the [Remote Commands reference](skills/agent-deck/references/cli-reference.md#remote-commands) for flags, security behavior, and examples.
 
 Pressing `n` on a remote group or session opens the full new-session dialog in **remote mode**: path suggestions come from the remote host, the remote session's group is pre-filled, and the create routes over SSH with your chosen tool — sessions are never accidentally created on localhost.
-
-#### Security
-
-- **SSH host-key stance.** agent-deck verifies remote host keys against your `~/.ssh/known_hosts` using OpenSSH's secure default — it never sets `StrictHostKeyChecking=no` and never points `UserKnownHostsFile` at `/dev/null`. Every connection (list, attach, deploy) runs with `BatchMode=yes`, so an **unknown or changed host key fails fast** with a clear `Host key verification failed` error instead of silently trusting the host or hanging on a prompt. Add each remote to `known_hosts` first (e.g. `ssh user@host` once interactively, or `ssh-keyscan`), and authenticate with keys/an agent (BatchMode disables interactive password prompts). A changed host key is treated as a potential MITM and refused until you resolve it.
-- **Verified binary deploys.** `agent-deck remote update` downloads the GitHub release archive and verifies its **SHA-256 against the release's published `checksums.txt`** before deploying. A missing `checksums.txt`, a missing entry, or a hash mismatch aborts the deploy — an unverified or tampered artifact is never piped to a remote.
-
-### Reaching services running inside remote sessions
-
-If you run a dev server, REPL, or web UI inside a remote session and want to reach it from your local browser, use **[Tailscale](https://tailscale.com)** rather than ad-hoc SSH port forwarding. Tailscale gives every machine on your tailnet a direct IP, so a service on `localhost:3000` of your remote box is reachable at `http://<remote-tailnet-ip>:3000` from your laptop with no `-L`/`-R` setup, no port collisions when multiple sessions share a remote, and no ControlMaster edge cases.
-
-Setup once:
-1. Install Tailscale on your local machine and on each remote: `curl -fsSL https://tailscale.com/install.sh | sh`
-2. `sudo tailscale up` on both ends, sign in with the same account
-3. Use the remote's tailnet IP (or MagicDNS name) in your browser
-
-This is why agent-deck does not ship native SSH `-L`/`-R` forwarding: Tailscale solves the same problem more robustly with no per-session configuration.
 
 ## Web Mode
 
@@ -912,6 +905,8 @@ agent-deck web --token my-secret
 # then open: http://127.0.0.1:8420/?token=my-secret
 ```
 
+The browser UI includes the live Command Center, session terminal, costs, archive, and settings views. See [Command Center](docs/COMMAND-CENTER.md) for the fleet view; use `--read-only` when browser clients should not mutate sessions.
+
 ## Documentation
 
 **Onboarding** — five-minute walkthroughs for new users:
@@ -925,7 +920,6 @@ agent-deck web --token my-secret
 
 | Guide | What's Inside |
 |-------|---------------|
-| [Conductor](docs/conductor/) | What a conductor is, channel pairing, state files, multi-conductor setups |
 | [Skills](documentation/SKILLS.md) | User-level vs pool skills, authoring, attach/detach, when to use which tier |
 | [Watchdog](documentation/WATCHDOG.md) | Optional Python daemon that auto-restarts critical sessions and nudges stuck children |
 | [Watchers](documentation/WATCHERS.md) | Event-forwarding framework: doorbell model, built-in adapters, custom watchers, gotchas |

--- a/docs/COMMAND-CENTER.md
+++ b/docs/COMMAND-CENTER.md
@@ -21,5 +21,5 @@ requires authentication; `--token` also protects API and WebSocket access on a
 loopback bind. Use `agent-deck web --read-only` to hide write controls and reject
 mutating requests. The [CLI reference](../skills/agent-deck/references/cli-reference.md#web-command) lists the current flags.
 
-For general web configuration, including `listen_addr`, `auth_token`, and
-`mutations_enabled`, see the [configuration reference](../skills/agent-deck/references/config-reference.md#web-configuration).
+For persisted `[web]` settings such as `mutations_enabled`, `trusted_domains`,
+and `confirm_link_open`, see the [configuration reference](../skills/agent-deck/references/config-reference.md#web-section).

--- a/docs/COMMAND-CENTER.md
+++ b/docs/COMMAND-CENTER.md
@@ -1,135 +1,25 @@
 # Command Center
 
-The Command Center is the embedded, live, two-way **fleet god-view** inside
-`agent-deck web`. It productizes the hand-made conductor status HTMLs into a real
-feature: a first-class tab that renders cross-project status live off an SSE feed,
-surfaces the decisions waiting on you, and routes typed instructions to Maestro or
-a chosen conductor through the supported `session send` path.
+Command Center is the fleet overview in `agent-deck web`. It shows conductors,
+their active child sessions, current work, waiting decisions, and recent
+completions in one live view. Status updates arrive automatically; the page does
+not need to be refreshed.
 
-It is private by construction — loopback by default, token-gated for any
-non-loopback bind, never public — inheriting the web server's existing security
-model (`auth.go`, `bind.go`, `csrf.go`, the mutation gate + rate limiter). It adds
-no new server, no new daemon, and no new auth surface.
+Start the web UI and open the **Command Center** tab:
 
-## v1 (shipped)
-
-A "Command Center" tab (positioned first) in the existing Preact SPA, backed by
-three additive endpoints registered on the existing mux behind the existing gates.
-
-### Endpoints (`internal/web/handlers_command_center.go`)
-
-| Endpoint | Method | Purpose |
-|---|---|---|
-| `/api/command-center/status` | GET | One-shot synthesized cross-project snapshot |
-| `/events/command-center` | GET (SSE) | Live push of the snapshot, fingerprint-diffed + heartbeat (same pattern as `/events/menu`) |
-| `/api/command-center/ask` | POST | Two-way input: route an instruction to Maestro / a conductor via `session send`; mutation-gated, CSRF fail-closed, target-allowlisted, argv-safe |
-
-### What it does
-
-- **Live, no polling.** `/events/command-center` subscribes to the same menu
-  change channel the menu SSE uses, so a session transition pushes a new snapshot
-  instantly. The page never polls; it re-renders off a Preact signal.
-- **Completion notifications.** The stream diffs each session's status between
-  consecutive snapshots server-side; a `running → done/waiting` transition is
-  emitted in `recentlyCompleted`, and the panel fires a "✅ X just finished"
-  toast (de-duplicated by completion id so reconnects don't re-fire).
-- **See-everything, noise filtered.** Per-conductor rows show each conductor's
-  health plus its active child sessions and what each is working on (from the
-  session's latest activity). **Error and stopped sessions are filtered out** by
-  construction. Honest-status v2 substates (`model-unavailable`, `auth-401`,
-  `idle-at-empty-prompt`) are surfaced distinctly rather than hidden as "running".
-- **Decisions waiting on you.** Parsed live from the agent-deck conductor's
-  `OPEN-ITEMS.md` §D, each with a 💬 comment affordance that prefills the input.
-- **Two-way input.** An input box (with a Maestro/conductor target picker) POSTs
-  to `/api/command-center/ask`, which delivers via `agent-deck -p <profile>
-  session send <target> "[command-center] <text>" --no-wait`. The text is passed
-  as a single argv element (never interpolated into a shell string), the target
-  is validated against a server-authoritative allowlist (Maestro + live
-  `conductor-*` sessions), and every ask is journaled (correlation id + target +
-  text-hash, never the raw text). Replies reflect back through the SSE feed as the
-  fleet moves.
-
-### Frontend (`internal/web/static/app/`)
-
-- `panes/CommandCenterPane.js` — the panel.
-- `Topbar.js` — the "Command Center" tab (first) with a decisions-waiting badge.
-- `main.js` — `startCommandCenterSSE()` subscribes to `/events/command-center`,
-  updates `commandCenterSignal`, and fires completion toasts.
-- `state.js` — `commandCenterSignal`.
-- `app.css` — the `.cc-*` styles (reuse the existing design tokens).
-
-### Snapshot shape
-
-```jsonc
-{
-  "profile": "personal",
-  "generatedAt": "2026-06-15T...",
-  "conductors": [
-    { "name": "agent-deck", "target": "conductor-agent-deck",
-      "status": "running", "substate": "",
-      "currentlyWorkingOn": "v1.9.67 release wave",
-      "sessions": [ { "id": "...", "title": "fix-1431", "status": "running",
-                      "substate": "", "workingOn": "investigating spawn race" } ],
-      "counts": { "running": 1, "waiting": 0, "idle": 0 } }
-  ],
-  "totals": { "running": 1, "waiting": 0, "idle": 0 },
-  "decisionsWaiting": [ { "id": "#1361", "question": "...", "route": "conductor-agent-deck" } ],
-  "recentlyCompleted": [ { "id": "...", "title": "X", "status": "waiting", "at": "..." } ],
-  "askTargets": [ "maestro", "conductor-agent-deck" ]
-}
+```bash
+agent-deck web
 ```
 
-No secret-shaped field (token/key/credential) is ever in the payload — only which
-account/conductor, never the credential. (Asserted in
-`handlers_command_center_test.go`.)
+Each conductor row includes its health, active-session counts, and current work.
+Waiting decisions have a comment action, and the instruction box can send a
+message to Maestro or a selected conductor. Instructions use the same supported
+delivery path as `agent-deck session send`.
 
-### Tests
+The web server listens on `127.0.0.1:8420` by default. A non-loopback bind
+requires authentication; `--token` also protects API and WebSocket access on a
+loopback bind. Use `agent-deck web --read-only` to hide write controls and reject
+mutating requests. The [CLI reference](../skills/agent-deck/references/cli-reference.md#web-command) lists the current flags.
 
-- `internal/web/handlers_command_center_test.go` — synthesis (grouping, noise
-  filtering, substate surfacing, completion diff), `OPEN-ITEMS.md` §D parsing, the
-  status endpoint, SSE initial+change, `/ask` target allowlist + mutation gate +
-  empty-text rejection, target resolution.
-- `tests/web/e2e/command-center.spec.js` — Playwright: live render, conductor
-  rows + input bar, **live SSE update without reload**, **error/stopped
-  filtering**, two-way input routing (the web-UI TDD gate).
-
-## v2 (planned — follow-on PR)
-
-v2 deepens interactivity and per-project depth. It is additive to the v1 surface
-and ships as its own review-gated PR.
-
-1. **Connected per-project detail pages.** Navigable, in-app explain/detail views
-   per project (the ryan/poster/opengraphdb-style pages from the prototype):
-   click a conductor row → a detail panel with its roadmap, recent releases, what
-   each session is doing in depth, and a back affordance. Rendered from the same
-   snapshot plus the conductor's richer status artifacts.
-2. **Comment-on-anything.** A 💬 on every entity (conductor, session, decision,
-   recently-completed) that prefills the input with that entity's context
-   (`re <id>: …`) and, on send, attaches a `context` object to `/ask` so the
-   receiving conductor knows exactly what is being commented on. (v1 already
-   prefills for decisions; v2 generalizes it to all rows and wires `context`.)
-3. **Correlated reply read-back.** `/ask` records the correlation id + target; a
-   follow-up SSE event reads the target's latest response via the existing
-   `session output` path and shows it inline under the input — the chat-style
-   "you asked X, conductor replied Y" (design §5.3 fidelity tier 2). v1 reflects
-   replies via the live fleet-state SSE (tier 1); v2 adds the explicit read-back.
-4. **Keyboard navigation.** Arrows move row focus, Enter opens/expands, Esc backs
-   out / blurs the input, digit-jump (1–9) to a row, `/` to focus the input —
-   matching the prototype's nav model.
-5. **Compact plain-language layout.** A density toggle + a one-paragraph
-   plain-language fleet summary (an optional, debounced, Maestro-routed LLM
-   synthesis — never on the hot path), for the "tell me what's going on" glance.
-6. **Structured per-conductor `status.json` contract.** v1 already reads an
-   optional `conductor/<name>/status.json` `{headline}` when present (falling back
-   to the live latest-prompt). v2 formalizes the full contract
-   (`{headline, inProgress[], recentlyDone[], decisionsWaiting[], updatedAt}`) and
-   has conductors write it on their heartbeat, replacing free-text parsing with
-   structured signal.
-
-## v3 (gated on OpenGraphDB — not in scope here)
-
-Swap the interim local synthesis for an OGDB operational-knowledge-graph backend
-behind a single `StatusSource` interface (the renderer is unchanged), adding a
-free-form "ask anything about everything" query. Gated on OGDB R5/R6/R7/R10 + an
-agreed operational-KG schema co-designed with conductor-opengraphdb. See the full
-design doc (`conductor/agent-deck/COMMAND-CENTER-DESIGN.md` §7) for the seam.
+For general web configuration, including `listen_addr`, `auth_token`, and
+`mutations_enabled`, see the [configuration reference](../skills/agent-deck/references/config-reference.md#web-configuration).

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -145,7 +145,7 @@ This script is invoked in CI AND is referenced from the CLAUDE.md section (REQ-4
 
 ## Architecture notes
 
-Agent-deck is a Go 1.22+ CLI + Bubble Tea TUI. Relevant packages for this spec:
+Agent-deck is a Go 1.25.13 CLI + Bubble Tea TUI. Relevant packages for this spec:
 
 - `internal/tmux/` — low-level tmux server/session spawn (`tmux.go` line 814-837 holds the systemd-run wrap).
 - `internal/session/` — `Instance` struct, lifecycle (`instance.go`), user config (`userconfig.go`), storage (JSON on disk under `~/.agent-deck/<profile>/`).

--- a/docs/plans/2026-06-13-fleet-fanout-cli-plan.md
+++ b/docs/plans/2026-06-13-fleet-fanout-cli-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Three changes in the existing Go CLI. (1) A new durable, non-destructive **completion ledger** file-store (mirroring the proven `CompletionRecord` pattern but in its own directory, so it does not collide with the task-worker claim-guard semantics) written at both the interactive done-signal emit site and the task-worker path. (2) A read-only `session children` subcommand that merges live status with ledger entries. (3) A `launch --assert-done` flag (default-on for Claude) that appends the completion-sentinel instruction to the child's initial message.
 
-**Tech Stack:** Go 1.24, standard library only. Tests via `go test`. Spec: `docs/superpowers/specs/2026-06-13-fleet-fanout-cli-design.md`.
+**Tech Stack at implementation:** Go, standard library only. Tests via `go test`. Spec: `docs/plans/2026-06-13-fleet-fanout-cli-design.md`.
 
 **Design refinement vs spec:** The spec said "persist completion on the session record." Implementation uses a dedicated ledger file-store instead of new `Instance` SQLite columns — lower risk (no schema migration) and avoids overloading the existing `completions/` claim store, whose presence makes the daemon stand down (`transition_daemon.go:311`). Same observable behavior: completion becomes a non-destructively queryable property.
 

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -1,8 +1,7 @@
 # Capability Verification
 
 This directory holds the **user-level capability verification** artifacts for agent-deck:
-the checklist that tracks whether each capability in the
-[v2 Capability Spec](../../) (229 stable `CAP-<AREA>-NNN` IDs) has been verified
+the checklist that tracks whether each of the 229 stable `CAP-<AREA>-NNN` capabilities has been verified
 **as a user would experience it** — by driving the real binary on each surface it
 supports and capturing visual evidence — not merely by unit tests.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17,7 +17,7 @@ This file contains complete documentation for AI/LLM consumption.
 **Your AI agent command center**
 
 [![GitHub Stars](https://img.shields.io/github/stars/asheshgoplani/agent-deck?style=for-the-badge&logo=github&color=yellow&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck/stargazers)
-[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=for-the-badge&logo=go&labelColor=1a1b26)](https://go.dev)
+[![Go Version](https://img.shields.io/badge/Go-1.25.13-00ADD8?style=for-the-badge&logo=go&labelColor=1a1b26)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-9ece6a?style=for-the-badge&labelColor=1a1b26)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20WSL-7aa2f7?style=for-the-badge&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck)
 [![Latest Release](https://img.shields.io/github/v/release/asheshgoplani/agent-deck?style=for-the-badge&color=e0af68&labelColor=1a1b26)](https://github.com/asheshgoplani/agent-deck/releases)

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -15,6 +15,7 @@ Complete reference for all agent-deck CLI commands.
 - [Group Commands](#group-commands)
 - [Profile Commands](#profile-commands)
 - [Remote Commands](#remote-commands)
+- [Codex Hook Commands](#codex-hook-commands)
 - [Conductor Commands](#conductor-commands)
 
 ## Global Options
@@ -43,6 +44,8 @@ agent-deck add [path] [options]
 | `--no-parent` | Disable automatic parent linking |
 | `--mcp` | Attach MCP (repeatable) |
 | `--attach` | Start and attach to the session immediately after creating it (requires an interactive terminal; not supported with `--ssh`/`--json`) |
+| `--ssh <user@host>` | Run the session over SSH; this is a destination, not a registered remote name |
+| `--remote-path <absolute-path>` | Working directory on the SSH host; an absolute positional path with `--ssh` is equivalent |
 
 ```bash
 agent-deck add -t "My Project" -c claude .
@@ -59,6 +62,7 @@ Notes:
 - `--parent` and `--no-parent` are mutually exclusive.
 - Explicit `-g/--group` overrides inherited parent group.
 - If `--cmd` contains extra args and no explicit `--wrapper` is provided, agent-deck auto-generates a wrapper to preserve those args.
+- SSH session identity is the SSH destination plus remote working directory. Configure key selection with `IdentityFile`/`Host` in `~/.ssh/config` or use `ssh-agent`; agent-deck has no private-key flag.
 
 ### launch - Create + start (+ optional message)
 
@@ -254,7 +258,15 @@ Setting `account` auto-migrates the Claude conversation into the target account'
 ### session send
 
 ```bash
-agent-deck session send <id|title> "message" [--no-wait] [-q] [--json]
+agent-deck session send <id|title> "message" [--wait|--stream|--no-wait] [-q] [--json]
+agent-deck session send <id|title> --message-file <file|-> [--wait|--stream|--no-wait] [-q] [--json]
+```
+
+Use `--message-file` for long or multiline messages, or `--message-file -` for stdin. Do not combine it with an inline message.
+
+```bash
+git diff | agent-deck session send my-project --message-file -
+agent-deck session send my-project --message-file task.md --wait
 ```
 
 Default behavior:
@@ -281,7 +293,7 @@ approval: that path sends composer text followed by Enter.
 agent-deck session output [id|title] [--json] [-q]
 ```
 
-Get last response from Claude/Gemini session.
+Get the last response from a session. Transcript-backed extraction is tool-dependent; use `--pane` for a raw tmux capture when structured output is unavailable.
 
 ### session set-parent / unset-parent
 
@@ -573,6 +585,8 @@ agent-deck conductor list [--profile <name>]
 
 Manage agent-deck instances running on remote SSH servers. Remote sessions appear alongside local sessions in the TUI and CLI.
 
+Registered remotes are named fleet endpoints. They are separate from the per-session SSH destination used by `agent-deck add --ssh`.
+
 Remote configuration is stored in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`) under the `[remotes]` map.
 
 ### remote add
@@ -612,7 +626,9 @@ Lists all configured remotes. Use `--json` for scripting.
 agent-deck remote sessions [name] [--json]
 ```
 
-Fetches active sessions from all remotes, or from a specific remote if `name` is provided. Displays title, tool, status, and session ID. Use `--json` for scripting.
+Fetches active sessions from all remotes, or from a specific remote if `name` is provided. Displays title, tool, live status, and session ID. Use `--json` for scripting.
+
+In the TUI, remote sessions use the same status indicators and nested group tree as local sessions. Remote headers and groups can be collapsed, and `K`/`J` preserve a manual order within each remote group. A session's location (local or SSH host plus remote path) is part of its identity, so identical titles at different locations do not collide.
 
 ### remote attach
 
@@ -650,6 +666,18 @@ agent-deck remote rename dev my-session new-name
 agent-deck remote update          # update all remotes
 agent-deck remote update dev      # update specific remote
 ```
+
+SSH uses OpenSSH host-key verification and `BatchMode=yes`; unknown or changed hosts fail instead of prompting. Authenticate with an SSH agent or configured key and establish trust in `known_hosts` before registering a remote. `remote update` verifies the downloaded archive against the release checksums before deployment.
+
+## Codex Hook Commands
+
+```bash
+agent-deck codex-hooks install
+agent-deck codex-hooks status
+agent-deck codex-hooks uninstall
+```
+
+Codex turn-level status uses its notify hook. Install it once per Codex home; if `CODEX_HOME` is set, use the same environment for installation and Codex sessions.
 
 ## Session Resolution
 

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -36,6 +36,8 @@ Complete reference for agent-deck Terminal UI features.
 | `f` | Quick fork (Claude/OpenCode/Pi/Codex) |
 | `F` | Fork with options (Claude/OpenCode/Pi/Codex) |
 
+For remote group headers, `Enter`/`Tab` toggles collapse and `h`/Left collapses or moves to the parent. Remote-session reorder keys move only within the current remote group; the order is saved on the viewing machine, while remote group headers remain name-sorted.
+
 ### Group Actions
 
 | Key | Action |
@@ -67,7 +69,7 @@ Complete reference for agent-deck Terminal UI features.
 | `Ctrl+Q` | Detach (keep tmux running) |
 | `q` / `Ctrl+C` | Quit |
 
-## Status Indicators
+## Local Status Indicators
 
 | Symbol | Status | Color | Meaning |
 |--------|--------|-------|---------|
@@ -76,6 +78,8 @@ Complete reference for agent-deck Terminal UI features.
 | `○` | Idle | Gray | Stopped, acknowledged |
 | `✕` | Error | Red | tmux session doesn't exist |
 | `⟳` | Starting | Yellow | Session launching |
+
+Federated remote rows currently carry coarse running/waiting/idle/error status; local Honest Status substates are not included in the remote payload.
 
 ## Dialogs
 


### PR DESCRIPTION
## Summary

- mark the shipped v1.12.0 changelog section and document its remote TUI behavior and Go 1.25.13 toolchain
- correct command claims for multiline messages, remote JSON/help support, SSH location identity, and Codex status hooks
- replace the implementation-heavy Command Center roadmap with a concise user guide
- consolidate remote security details into the CLI reference and remove duplicated README content
- remove a closed future-feature reference, a duplicate Conductor index entry, and a dead capability-spec link

## Why content was removed

- Command Center endpoint schemas, test inventories, and future implementation plans were internal and stale after the feature shipped.
- Remote security and service-access instructions duplicated the canonical CLI reference and had already drifted from the command surface.
- The duplicate Conductor row and closed future-work statement added no current user guidance.

## Validation

- `go build ./...`
- focused message-input tests in `cmd/agent-deck`
- focused remote collapse/order/status tests in `internal/ui`
- built-binary help checks for `session send`, `remote`, `remote add`, and `codex-hooks`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Go version badge to reflect Go 1.25.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->