### PR TITLE
fix Codex completion-only notify convergence

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -230,7 +230,11 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 	if err != nil {
 		return
 	}
-	defer lock.Close()
+	defer func() {
+		if err := lock.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "agent-deck: close Codex hook lock: %v\n", err)
+		}
+	}()
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
 		return
 	}
@@ -254,17 +258,28 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 	if len(turnIDs) > 0 {
 		turnID = strings.TrimSpace(turnIDs[0])
 	}
-	if started && evidenceSessionID != "" && turnID != "" {
-		prior.CodexStartedGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
-		prior.CodexStartedSessionID = evidenceSessionID
+	if started {
 		prior.CodexCompletedGeneration = ""
 		prior.CodexCompletedSessionID = ""
+		if evidenceSessionID != "" && turnID != "" {
+			prior.CodexStartedGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
+			prior.CodexStartedSessionID = evidenceSessionID
+		} else {
+			prior.CodexStartedGeneration = ""
+			prior.CodexStartedSessionID = ""
+		}
 	}
 	completionGeneration := ""
 	if evidenceSessionID != "" && turnID != "" {
 		completionGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
 	}
-	if completed && completionGeneration != "" && completionGeneration == prior.CodexStartedGeneration && evidenceSessionID == prior.CodexStartedSessionID {
+	// Codex's legacy notify contract emits only agent-turn-complete. A complete
+	// thread/turn identity therefore supplies both sides of the generation
+	// proof; waiting must not depend on a start notification that never occurs.
+	if completed && completionGeneration != "" &&
+		(prior.Status != "running" || prior.CodexStartedGeneration == "" || completionGeneration == prior.CodexStartedGeneration) {
+		prior.CodexStartedGeneration = completionGeneration
+		prior.CodexStartedSessionID = evidenceSessionID
 		prior.CodexCompletedGeneration = completionGeneration
 		prior.CodexCompletedSessionID = evidenceSessionID
 	}

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -254,6 +254,45 @@ func TestWriteCodexHookStatus_IdentityLessCompletionFailsClosed(t *testing.T) {
 	}
 }
 
+func TestWriteCodexHookStatus_LegacyCompletionConvergesWithoutStart(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTDECK_HOOKS_DIR", filepath.Join(t.TempDir(), "hooks"))
+	writeCodexHookStatus("legacy-complete", "waiting", "thread-1", "agent-turn-complete", "turn-1")
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), "legacy-complete.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got hookStatusFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CodexStartedGeneration == "" || got.CodexStartedGeneration != got.CodexCompletedGeneration {
+		t.Fatalf("completion-only notify did not converge: %#v", got)
+	}
+	if got.CodexStartedSessionID != "thread-1" || got.CodexCompletedSessionID != "thread-1" {
+		t.Fatalf("completion-only notify lost session identity: %#v", got)
+	}
+}
+
+func TestWriteCodexHookStatus_IdentityLessStartClearsPriorCompletion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTDECK_HOOKS_DIR", filepath.Join(t.TempDir(), "hooks"))
+	writeCodexHookStatus("stale-pair", "waiting", "thread-1", "agent-turn-complete", "turn-1")
+	writeCodexHookStatus("stale-pair", "running", "", "turn.started", "")
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), "stale-pair.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got hookStatusFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CodexStartedGeneration != "" || got.CodexCompletedGeneration != "" ||
+		got.CodexStartedSessionID != "" || got.CodexCompletedSessionID != "" {
+		t.Fatalf("identity-less start retained stale completion evidence: %#v", got)
+	}
+}
+
 func TestWriteCodexHookStatus_ConcurrentFleetPersistence(t *testing.T) {
 	for _, size := range []int{1, 20, 100} {
 		t.Run(fmt.Sprintf("fleet-%d", size), func(t *testing.T) {


### PR DESCRIPTION
## What problem does this solve?

Codex sessions could remain subject to first-sample running debounce after a completed turn because the notify integration waited for a start event that Codex never emits. This follows up on #1896.

## Why this change

Codex's legacy notify contract emits `agent-turn-complete` with both `thread-id` and `turn-id`. The completion payload now supplies the complete generation proof by itself. Start events remain supported for compatibility and always invalidate older completion evidence, even if their identity is incomplete.

The writable lock file's close error is also checked and reported.

## User impact

Codex session status converges to waiting immediately from valid completion-only notify payloads, including on a fresh CLI process, without allowing incomplete payloads to bypass the debounce.

## Evidence

- `go build ./...` passes with an isolated HOME/XDG environment.
- `go vet ./...` passes with an isolated HOME/XDG environment.
- Focused Codex hook and session convergence tests pass.
- The broader `cmd/agent-deck` and `internal/session` run passed `internal/session`; three unrelated environment-sensitive tests failed under host contention (two cold-start timing budgets and one stale-time boundary).

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol

**Prompt / session log (optional):** Not included.

## What actually bothered you

My human asked: "Verify and fix the P1 on merged PR #1896" because the convergence fix appeared inert against Codex's real completion-only notify contract.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5.6-sol intent=yes -->
