### PR TITLE
fix(codeql): sanitize logs and check file closes

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -230,7 +230,7 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 	if err != nil {
 		return
 	}
-	defer lock.Close()
+	defer closeChecked(lock)
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
 		return
 	}

--- a/cmd/agent-deck/file_close.go
+++ b/cmd/agent-deck/file_close.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// closeChecked closes a writable file and records failures that would
+// otherwise be silently lost from deferred Close calls.
+func closeChecked(file *os.File) {
+	if err := file.Close(); err != nil {
+		hookHandlerLog.Warn("writable_file_close_failed",
+			slog.String("error", logging.SanitizeValue(err.Error())))
+	}
+}

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -387,7 +387,7 @@ func writeHookStatusFile(instanceID string, statusFile hookStatusFile, mutateAnc
 		if err != nil {
 			return false
 		}
-		defer lock.Close()
+		defer closeChecked(lock)
 		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
 			return false
 		}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2622,7 +2622,7 @@ func (i *Instance) queryOpenCodeSession() string {
 		sessions, err = i.queryOpenCodeSessionsHTTP(port, projectPath)
 		if err != nil {
 			sessionLog.Debug("opencode_http_query_failed",
-				slog.String("dir", projectPath),
+				slog.String("dir", logging.SanitizeValue(projectPath)),
 				slog.Int("port", port),
 				slog.String("error", err.Error()),
 			)
@@ -2754,13 +2754,13 @@ func (i *Instance) runOpenCodeSessionsCLI(projectPath string) []openCodeSessionM
 	cmd.Dir = projectPath
 	cmd.WaitDelay = 500 * time.Millisecond
 
-	sessionLog.Debug("opencode_query_sessions", slog.String("dir", projectPath))
+	sessionLog.Debug("opencode_query_sessions", slog.String("dir", logging.SanitizeValue(projectPath)))
 
 	output, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			sessionLog.Warn("opencode_query_timeout",
-				slog.String("dir", projectPath),
+				slog.String("dir", logging.SanitizeValue(projectPath)),
 				slog.String("instance_id", i.ID),
 			)
 		} else {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
 
 // PipeManager manages ControlPipes for all active tmux sessions.
@@ -143,7 +145,7 @@ func (pm *PipeManager) Disconnect(sessionName string) {
 	if pipe != nil {
 		pipe.Close()
 	}
-	pipeLog.Debug("pipe_disconnected", slog.String("session", sessionName))
+	pipeLog.Debug("pipe_disconnected", slog.String("session", logging.SanitizeValue(sessionName)))
 }
 
 // GetPipe returns the ControlPipe for a session, or nil if not connected.

--- a/internal/tmux/socket.go
+++ b/internal/tmux/socket.go
@@ -172,6 +172,9 @@ func tmuxArgs(socketName string, args ...string) []string {
 		out = make([]string, len(args))
 		copy(out, args)
 	} else {
+		if len(args) > int(^uint(0)>>1)-2 {
+			panic("tmux argument list too large")
+		}
 		out = make([]string, 0, len(args)+2)
 		out = append(out, "-L", name)
 		out = append(out, args...)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2222,7 +2222,7 @@ func (s *Session) Start(command string) error {
 		if launcher == "tmux" {
 			if recovered, recoverErr := recoverFromStaleDefaultSocketIfNeeded(string(output)); recoverErr != nil {
 				statusLog.Warn("tmux_stale_socket_recovery_failed",
-					slog.String("session", s.Name),
+					slog.String("session", logging.SanitizeValue(s.Name)),
 					slog.String("error", recoverErr.Error()),
 				)
 			} else if recovered {
@@ -3067,7 +3067,7 @@ func (s *Session) Kill() error {
 	// Capture process tree BEFORE killing so we can verify they die
 	_, oldPIDs := s.getPaneProcessTree()
 	if len(oldPIDs) > 0 {
-		respawnLog.Info("pre_kill_process_tree", slog.String("session", s.Name), slog.Any("pids", oldPIDs))
+		respawnLog.Info("pre_kill_process_tree", slog.String("session", logging.SanitizeValue(s.Name)), slog.Any("pids", oldPIDs))
 	}
 
 	// Kill the tmux session. Bounded — see tmuxMutationTimeout. A client
@@ -3110,7 +3110,7 @@ func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 		// must not be silent: on a loaded box this is how a SIGHUP-immune agent
 		// survives a Kill() as an orphan.
 		statusLog.Warn("pane_process_tree_probe_failed",
-			slog.String("session", s.Name),
+			slog.String("session", logging.SanitizeValue(s.Name)),
 			slog.String("error", err.Error()))
 		return 0, nil
 	}
@@ -5535,7 +5535,7 @@ func (s *Session) sendKeysChunkedToTarget(target, content string) error {
 		// so a recurrence of #1855 behind a green exit is attributable to this
 		// path instead of looking like the fix regressed.
 		statusLog.Warn("paste_transport_unavailable_degraded_to_send_keys",
-			slog.String("session", s.Name),
+			slog.String("session", logging.SanitizeValue(s.Name)),
 			slog.Bool("multiline", strings.Contains(content, "\n")),
 			slog.Int("payload_bytes", len(content)),
 			slog.String("error", err.Error()))

--- a/internal/tmuxutf8/tmuxutf8.go
+++ b/internal/tmuxutf8/tmuxutf8.go
@@ -72,6 +72,9 @@ func Prepend(args []string) []string {
 		copy(out, args)
 		return out
 	}
+	if len(args) == int(^uint(0)>>1) {
+		panic("tmux argument list too large")
+	}
 	out := make([]string, 0, len(args)+1)
 	out = append(out, Flag)
 	return append(out, args...)


### PR DESCRIPTION
## Summary

- sanitize user-controlled session names and project paths at the newly reported structured-log sinks (CodeQL alerts #265-#268 and #275-#277, #280)
- check deferred writable lockfile close errors through one shared helper for both the Codex status writer and Hermes generation lock path (alerts #279 and #283)
- reject impossible argument-slice sizes before the two flagged capacity calculations can overflow (alerts #281 and #282)

## Validation

- `go test ./internal/tmux/... ./internal/tmuxutf8 ./internal/session/...` (pass)
- focused `cmd/agent-deck` hook tests (pass)
- `go build ./...` (pass)
- `go vet ./...` (pass)

The full `cmd/agent-deck` package test run also exercised the changed hook code, but its unrelated environment-sensitive performance, tmux cleanup, and stale-status tests failed. The focused hook suite passes.

## Left open

The path-injection reports are not changed here. The MCP paths already pass through `filepath.Clean`, `filepath.Abs`, and a relative containment check, while the tmux log deletion depends on the existing session-name/log-directory design. Further changes need a broader path-policy decision rather than a behavior-changing CodeQL-only patch.
