### PR TITLE
fix: refresh Hermes restart memory baseline

### DIFF
--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -127,7 +127,8 @@ func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string
 	opposite := hermesHookScope(i.ID, !i.IsSandboxed())
 	defer func() { locks.release(); pruneHermesAbandonedScope(i.ID, opposite) }()
 	clearHermesHookScope(i.ID, opposite, false)
-	seed := hermesHookSeed{Status: status, Event: "agentdeck_spawn_seed", Timestamp: time.Now().Unix(), HookGeneration: generation, InitialMessagePending: pending}
+	now := time.Now()
+	seed := hermesHookSeed{Status: status, Event: "agentdeck_spawn_seed", Timestamp: now.Unix(), HookGeneration: generation, InitialMessagePending: pending}
 	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".json"), seed); err != nil {
 		return "", err
 	}
@@ -136,7 +137,16 @@ func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string
 	if err := atomicHermesJSON(filepath.Join(scope, i.ID+".generation.json"), hermesHookControl{Generation: generation, InitialMessagePending: pending}); err != nil {
 		return "", err
 	}
+	// Keep the synchronous status path aligned with the committed seed. The
+	// watcher will observe the same file later, but UpdateStatus may run first;
+	// leaving the previous process's fresh running/dead sample in memory would
+	// temporarily override the restart baseline until fsnotify catches up.
+	i.mu.Lock()
 	i.HermesHookGeneration = generation
+	i.hookStatus = status
+	i.hookEvent = seed.Event
+	i.hookLastUpdate = now
+	i.mu.Unlock()
 	return generation, nil
 }
 

--- a/internal/session/hermes_generation_test.go
+++ b/internal/session/hermes_generation_test.go
@@ -134,6 +134,35 @@ func TestHermesRestartWaitingSeedCarriesCurrentGeneration(t *testing.T) {
 	}
 }
 
+func TestHermesGenerationSeedRefreshesInMemoryBaseline(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	staleAt := time.Now().Add(-time.Minute)
+	inst := &Instance{
+		ID:             "hermes-memory-baseline",
+		Tool:           "hermes",
+		hookStatus:     "dead",
+		hookEvent:      "on_session_finalize",
+		hookLastUpdate: staleAt,
+	}
+	started := time.Now()
+	if _, err := inst.seedHermesHookGeneration("waiting", false); err != nil {
+		t.Fatal(err)
+	}
+	status, fresh := inst.GetHookStatus()
+	if status != "waiting" || !fresh {
+		t.Fatalf("immediate hook status = %q fresh=%v, want waiting/true", status, fresh)
+	}
+	inst.mu.RLock()
+	event, updated := inst.hookEvent, inst.hookLastUpdate
+	inst.mu.RUnlock()
+	if event != "agentdeck_spawn_seed" {
+		t.Fatalf("hook event = %q, want spawn seed", event)
+	}
+	if updated.Before(started) || !updated.After(staleAt) {
+		t.Fatalf("hook timestamp was not refreshed: got %v, started %v, stale %v", updated, started, staleAt)
+	}
+}
+
 func TestHermesSeedClearsOppositeLayout(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	inst := &Instance{ID: "hermes-mode-change", Tool: "hermes"}


### PR DESCRIPTION
## What problem does this solve?

A restarted Hermes session could briefly retain the previous processs fresh in-memory running or dead hook state even after the generation-aware waiting baseline was committed to disk.

## Why this change

The seed publisher now updates the in-memory hook baseline only after both atomic disk writes succeed, keeping synchronous UpdateStatus reads aligned with the committed generation.

## User impact

Hermes restart status changes to waiting immediately instead of depending on fsnotify delivery.

## Evidence

- Sandboxed focused Hermes generation test
- Sandboxed `go build ./...`
- Sandboxed `go vet ./...`

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** GPT-5

## What actually bothered you

The restart fix still allowed stale error or running state to remain visible until the asynchronous file watcher caught up.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included (not applicable; no added I/O or polling)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5 intent=yes -->
