### PR TITLE
fix(remote): make the per-command SSH timeout configurable

### DIFF
--- a/internal/session/remote_timeout_test.go
+++ b/internal/session/remote_timeout_test.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// The hardcoded 10s remote command timeout made any remote whose
+// `list --json` exceeds it look permanently unavailable. The timeout is
+// now per-remote configurable with a 30s default.
+func TestRemoteConfig_GetCommandTimeout_Default(t *testing.T) {
+	rc := RemoteConfig{Host: "user@host"}
+	if got := rc.GetCommandTimeout(); got != 30*time.Second {
+		t.Fatalf("default timeout = %v, want 30s", got)
+	}
+}
+
+func TestRemoteConfig_GetCommandTimeout_Configured(t *testing.T) {
+	rc := RemoteConfig{Host: "user@host", CommandTimeoutSeconds: 90}
+	if got := rc.GetCommandTimeout(); got != 90*time.Second {
+		t.Fatalf("configured timeout = %v, want 90s", got)
+	}
+}
+
+func TestRemoteConfig_GetCommandTimeout_RejectsNonPositive(t *testing.T) {
+	rc := RemoteConfig{Host: "user@host", CommandTimeoutSeconds: -5}
+	if got := rc.GetCommandTimeout(); got != 30*time.Second {
+		t.Fatalf("negative timeout = %v, want 30s fallback", got)
+	}
+}
+
+func TestNewSSHRunner_CarriesConfiguredTimeout(t *testing.T) {
+	r := NewSSHRunner("g14", RemoteConfig{Host: "user@host", CommandTimeoutSeconds: 90})
+	if r.commandTimeout != 90*time.Second {
+		t.Fatalf("runner timeout = %v, want 90s", r.commandTimeout)
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -147,6 +147,9 @@ type SSHRunner struct {
 	AgentDeckPath string // Remote agent-deck binary path
 	Profile       string // Remote profile name
 
+	// commandTimeout bounds each remote command; zero means the 30s default.
+	commandTimeout time.Duration
+
 	// configuredPath is the raw agent_deck_path from config ("" if unset). It
 	// lets ResolveRemotePath decide whether to honor an explicit user path or
 	// probe the remote's real binary location via $PATH (#1171).
@@ -172,12 +175,17 @@ func NewSSHRunner(name string, rc RemoteConfig) *SSHRunner {
 		AgentDeckPath:  rc.GetAgentDeckPath(),
 		configuredPath: rc.AgentDeckPath,
 		Profile:        rc.GetProfile(),
+		commandTimeout: rc.GetCommandTimeout(),
 	}
 }
 
 // Run executes an agent-deck command on the remote host and returns stdout.
 func (r *SSHRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	timeout := r.commandTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return r.run(timeoutCtx, args...)
 }

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -722,6 +722,12 @@ type RemoteConfig struct {
 
 	// Profile is the remote profile to use (default: "default")
 	Profile string `toml:"profile,omitempty"`
+
+	// CommandTimeoutSeconds bounds each remote agent-deck command (default 30).
+	// Raise it for remotes whose session fleets make `list --json` slow; the
+	// old hardcoded 10s silently killed fetches from hosts with many sessions,
+	// making the whole remote look unavailable (#1859 family).
+	CommandTimeoutSeconds int `toml:"command_timeout_seconds,omitempty"`
 }
 
 // GetAgentDeckPath returns the agent-deck binary path, defaulting to "agent-deck".
@@ -730,6 +736,15 @@ func (rc RemoteConfig) GetAgentDeckPath() string {
 		return rc.AgentDeckPath
 	}
 	return "agent-deck"
+}
+
+// GetCommandTimeout returns the per-command timeout for this remote,
+// defaulting to 30s and rejecting non-positive values.
+func (rc RemoteConfig) GetCommandTimeout() time.Duration {
+	if rc.CommandTimeoutSeconds > 0 {
+		return time.Duration(rc.CommandTimeoutSeconds) * time.Second
+	}
+	return 30 * time.Second
 }
 
 // GetProfile returns the remote profile, defaulting to "default".

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3288,7 +3288,9 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 		wg.Add(1)
 		go func(name string, rc session.RemoteConfig) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
+			// Honor the per-remote command_timeout_seconds: hosts with large
+			// session fleets legitimately need more than the old flat 15s.
+			ctx, cancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
 			defer cancel()
 
 			runner := session.NewSSHRunner(name, rc)
@@ -3797,7 +3799,7 @@ func (h *Home) fetchRemotePreview(remoteName, sessionID, key string) tea.Cmd {
 		}
 
 		runner := session.NewSSHRunner(remoteName, rc)
-		ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
+		ctx, cancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
 		defer cancel()
 
 		// #1101: use FetchSessionPane (raw capture-pane content with ANSI +


### PR DESCRIPTION
The hardcoded 10s timeout in SSHRunner.Run kills every remote fetch from hosts whose session fleets make list --json slower than 10s, making the remote look permanently unavailable in the TUI and CLI.

Adds a per-remote command_timeout_seconds setting (default 30s, non-positive values fall back) threaded through NewSSHRunner, with tests. The deeper fix — making list itself fast at fleet scale — is tracked separately.
