### PR TITLE
feat(tui): show running/waiting status counts on remote group headers

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -17185,6 +17185,7 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 		sessions := h.remoteSessions[item.RemoteName]
 		groupPath := strings.TrimPrefix(item.Path, "remotes/"+item.RemoteName+"/")
 		count := remoteSubGroupCount(sessions, groupPath)
+		running, waiting := remoteStatusCounts(sessions, groupPath)
 		h.remoteSessionsMu.RUnlock()
 
 		segName := groupPath
@@ -17192,12 +17193,13 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 			segName = groupPath[idx+1:]
 		}
 
-		b.WriteString(fmt.Sprintf("%s%s%s %s%s\n",
+		b.WriteString(fmt.Sprintf("%s%s%s %s%s%s\n",
 			remoteRowGutter(selected),        // align with group hotkey gutter
 			strings.Repeat("  ", item.Level), // nest under the remote header
 			expandIcon,
 			nameStyle.Render(segName),
 			countStyle.Render(fmt.Sprintf(" (%d)", count)),
+			remoteStatusSuffix(running, waiting),
 		))
 		return
 	}
@@ -17205,18 +17207,34 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 	// Level 0: the remote host header. Count all sessions for this remote.
 	h.remoteSessionsMu.RLock()
 	count := 0
+	running, waiting := 0, 0
 	if sessions, ok := h.remoteSessions[item.RemoteName]; ok {
 		count = len(sessions)
+		running, waiting = remoteStatusCounts(sessions, "")
 	}
 	h.remoteSessionsMu.RUnlock()
 
-	b.WriteString(fmt.Sprintf("%s%s %s%s%s\n",
+	b.WriteString(fmt.Sprintf("%s%s %s%s%s%s\n",
 		remoteRowGutter(selected), // align with group hotkey gutter (flush with local root groups)
 		expandIcon,
 		nameStyle.Render("remotes/"+item.RemoteName),
 		countStyle.Render(fmt.Sprintf(" (%d)", count)),
+		remoteStatusSuffix(running, waiting),
 		h.renderRemoteLatencyMarker(item.RemoteName, selected),
 	))
+}
+
+// remoteStatusSuffix renders the same running/waiting glyph counts local
+// group headers show, for remote host and sub-group headers.
+func remoteStatusSuffix(running, waiting int) string {
+	out := ""
+	if running > 0 {
+		out += " " + GroupStatusRunning.Render(fmt.Sprintf("● %d", running))
+	}
+	if waiting > 0 {
+		out += " " + GroupStatusWaiting.Render(fmt.Sprintf("◐ %d", waiting))
+	}
+	return out
 }
 
 // renderRemoteLatencyMarker returns the colored ` — Xms` (or ` — offline`)

--- a/internal/ui/remote_status_counts_test.go
+++ b/internal/ui/remote_status_counts_test.go
@@ -1,0 +1,44 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Remote group headers must show the same running/waiting glyph counts as
+// local group headers (status parity, #1864 family).
+func TestRemoteStatusCounts_WholeRemote(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{Group: "a", Status: "running"},
+		{Group: "a/b", Status: "waiting"},
+		{Group: "c", Status: "waiting"},
+		{Group: "c", Status: "stopped"},
+	}
+	running, waiting := remoteStatusCounts(sessions, "")
+	if running != 1 || waiting != 2 {
+		t.Fatalf("whole-remote counts = %d/%d, want 1/2", running, waiting)
+	}
+}
+
+func TestRemoteStatusCounts_SubGroupScoped(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{Group: "a", Status: "running"},
+		{Group: "a/b", Status: "waiting"},
+		{Group: "ab", Status: "waiting"}, // prefix trap: "ab" is not under "a"
+		{Group: "c", Status: "running"},
+	}
+	running, waiting := remoteStatusCounts(sessions, "a")
+	if running != 1 || waiting != 1 {
+		t.Fatalf("sub-group counts = %d/%d, want 1/1", running, waiting)
+	}
+}
+
+func TestRemoteStatusSuffix_EmptyWhenIdle(t *testing.T) {
+	if got := remoteStatusSuffix(0, 0); got != "" {
+		t.Fatalf("idle suffix = %q, want empty", got)
+	}
+	if got := remoteStatusSuffix(2, 3); got == "" {
+		t.Fatalf("active suffix should not be empty")
+	}
+}

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -154,3 +154,24 @@ func remoteSubGroupCount(sessions []session.RemoteSessionInfo, groupPath string)
 	}
 	return count
 }
+
+// remoteStatusCounts aggregates running/waiting session counts for a remote
+// group header, mirroring the local group-header status glyphs (#1864 parity).
+// An empty groupPath aggregates the whole remote (the Level-0 host header).
+func remoteStatusCounts(sessions []session.RemoteSessionInfo, groupPath string) (running, waiting int) {
+	for i := range sessions {
+		if groupPath != "" {
+			g := normalizeRemoteGroupPath(sessions[i].Group)
+			if g != groupPath && !strings.HasPrefix(g, groupPath+"/") {
+				continue
+			}
+		}
+		switch sessions[i].Status {
+		case "running":
+			running++
+		case "waiting":
+			waiting++
+		}
+	}
+	return running, waiting
+}


### PR DESCRIPTION
Remote group headers (host level and nested sub-groups) now show the same running/waiting status glyph counts that local group headers show, so a remote fleet reads at a glance. Counts are scoped per sub-group with a prefix-trap guard and covered by unit tests; verified rendering in a live TUI.
