### PR TITLE
feat(web): show configured remotes safely in Fleet

### DIFF
--- a/internal/session/remote_fleet.go
+++ b/internal/session/remote_fleet.go
@@ -1,0 +1,168 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+const defaultRemoteFleetTimeout = 15 * time.Second
+
+// RemoteFleetSnapshot is a read-only view of every configured remote. It is
+// deliberately separate from local storage: remote sessions remain owned by
+// their remote Agent Deck instance.
+type RemoteFleetSnapshot struct {
+	ObservedAt time.Time           `json:"observedAt"`
+	Remotes    []RemoteFleetRemote `json:"remotes"`
+	Counts     RemoteFleetCounts   `json:"counts"`
+}
+
+type RemoteFleetRemote struct {
+	Name      string              `json:"name"`
+	Online    bool                `json:"online"`
+	LatencyMS int                 `json:"latencyMs,omitempty"`
+	Issue     string              `json:"issue,omitempty"`
+	Sessions  []RemoteSessionInfo `json:"sessions"`
+}
+
+type RemoteFleetCounts struct {
+	RemotesOnline  int `json:"remotesOnline"`
+	RemotesOffline int `json:"remotesOffline"`
+	Sessions       int `json:"sessions"`
+	Running        int `json:"running"`
+	Waiting        int `json:"waiting"`
+	Idle           int `json:"idle"`
+	Error          int `json:"error"`
+	Stopped        int `json:"stopped"`
+}
+
+type remoteFleetRunner interface {
+	FetchSessions(context.Context) ([]RemoteSessionInfo, error)
+	MeasureLatency(context.Context) (time.Duration, error)
+}
+
+// RemoteFleetScanner projects the existing remote registry and SSH session
+// API into a web-safe snapshot. Dependencies are injectable so tests never
+// open SSH connections.
+type RemoteFleetScanner struct {
+	loadConfig func() (*UserConfig, error)
+	newRunner  func(string, RemoteConfig) remoteFleetRunner
+	now        func() time.Time
+	timeout    time.Duration
+}
+
+func NewRemoteFleetScanner() *RemoteFleetScanner {
+	return &RemoteFleetScanner{
+		loadConfig: LoadUserConfig,
+		newRunner: func(name string, config RemoteConfig) remoteFleetRunner {
+			return NewSSHRunner(name, config)
+		},
+		now:     time.Now,
+		timeout: defaultRemoteFleetTimeout,
+	}
+}
+
+func (s *RemoteFleetScanner) Scan(ctx context.Context) (RemoteFleetSnapshot, error) {
+	if s == nil || s.loadConfig == nil || s.newRunner == nil {
+		return RemoteFleetSnapshot{}, fmt.Errorf("remote fleet scanner is not configured")
+	}
+	config, err := s.loadConfig()
+	if err != nil {
+		return RemoteFleetSnapshot{}, fmt.Errorf("load remote config: %w", err)
+	}
+	if config == nil {
+		return RemoteFleetSnapshot{}, fmt.Errorf("remote config is unavailable")
+	}
+
+	timeout := s.timeout
+	if timeout <= 0 {
+		timeout = defaultRemoteFleetTimeout
+	}
+	now := s.now
+	if now == nil {
+		now = time.Now
+	}
+	snapshot := RemoteFleetSnapshot{
+		ObservedAt: now().UTC(),
+		Remotes:    make([]RemoteFleetRemote, 0, len(config.Remotes)),
+	}
+	if len(config.Remotes) == 0 {
+		return snapshot, nil
+	}
+
+	CleanStaleSSHSockets()
+	results := make(chan RemoteFleetRemote, len(config.Remotes))
+	var wg sync.WaitGroup
+	for name, remoteConfig := range config.Remotes {
+		wg.Add(1)
+		go func(name string, remoteConfig RemoteConfig) {
+			defer wg.Done()
+			remoteCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			remote := RemoteFleetRemote{
+				Name: name, Sessions: make([]RemoteSessionInfo, 0),
+			}
+			runner := s.newRunner(name, remoteConfig)
+			sessions, fetchErr := runner.FetchSessions(remoteCtx)
+			if fetchErr != nil {
+				// SSH errors can include command lines and private paths. The web
+				// API exposes only this stable classification.
+				remote.Issue = "unavailable"
+				results <- remote
+				return
+			}
+			remote.Online = true
+			for i := range sessions {
+				sessions[i].RemoteName = name
+			}
+			if sessions != nil {
+				remote.Sessions = sessions
+			}
+			if latency, latencyErr := runner.MeasureLatency(remoteCtx); latencyErr == nil {
+				remote.LatencyMS = int(latency.Round(time.Millisecond) / time.Millisecond)
+			}
+			results <- remote
+		}(name, remoteConfig)
+	}
+	wg.Wait()
+	close(results)
+
+	for remote := range results {
+		snapshot.Remotes = append(snapshot.Remotes, remote)
+	}
+	sort.Slice(snapshot.Remotes, func(i, j int) bool {
+		return snapshot.Remotes[i].Name < snapshot.Remotes[j].Name
+	})
+	snapshot.Counts = countRemoteFleet(snapshot.Remotes)
+	return snapshot, nil
+}
+
+func countRemoteFleet(remotes []RemoteFleetRemote) RemoteFleetCounts {
+	var counts RemoteFleetCounts
+	for _, remote := range remotes {
+		if remote.Online {
+			counts.RemotesOnline++
+		} else {
+			counts.RemotesOffline++
+		}
+		counts.Sessions += len(remote.Sessions)
+		for _, remoteSession := range remote.Sessions {
+			switch remoteSession.Status {
+			case "running", "starting":
+				counts.Running++
+			case "waiting":
+				counts.Waiting++
+			case "idle":
+				counts.Idle++
+			case "error":
+				counts.Error++
+			case "stopped":
+				counts.Stopped++
+			}
+		}
+	}
+	return counts
+}

--- a/internal/session/remote_fleet.go
+++ b/internal/session/remote_fleet.go
@@ -2,13 +2,17 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
 )
 
-const defaultRemoteFleetTimeout = 15 * time.Second
+const (
+	defaultRemoteFleetTimeout     = 15 * time.Second
+	defaultRemoteFleetRefresh     = 5 * time.Second
+	defaultRemoteFleetConcurrency = 4
+	defaultRemoteFleetMaxBackoff  = time.Minute
+)
 
 // RemoteFleetSnapshot is a read-only view of every configured remote. It is
 // deliberately separate from local storage: remote sessions remain owned by
@@ -19,14 +23,20 @@ type RemoteFleetSnapshot struct {
 	Counts     RemoteFleetCounts   `json:"counts"`
 }
 
+// RemoteFleetRemote is the last observation of one configured remote. Stale
+// records retain their last known sessions after a failed refresh.
 type RemoteFleetRemote struct {
-	Name      string              `json:"name"`
-	Online    bool                `json:"online"`
-	LatencyMS int                 `json:"latencyMs,omitempty"`
-	Issue     string              `json:"issue,omitempty"`
-	Sessions  []RemoteSessionInfo `json:"sessions"`
+	Name       string              `json:"name"`
+	Online     bool                `json:"online"`
+	LatencyMS  int                 `json:"latencyMs,omitempty"`
+	Issue      string              `json:"issue,omitempty"`
+	Sessions   []RemoteSessionInfo `json:"sessions"`
+	ObservedAt time.Time           `json:"observedAt"`
+	AgeSeconds int64               `json:"ageSeconds"`
+	Stale      bool                `json:"stale,omitempty"`
 }
 
+// RemoteFleetCounts contains aggregate remote and session status counts.
 type RemoteFleetCounts struct {
 	RemotesOnline  int `json:"remotesOnline"`
 	RemotesOffline int `json:"remotesOffline"`
@@ -43,101 +53,241 @@ type remoteFleetRunner interface {
 	MeasureLatency(context.Context) (time.Duration, error)
 }
 
-// RemoteFleetScanner projects the existing remote registry and SSH session
-// API into a web-safe snapshot. Dependencies are injectable so tests never
-// open SSH connections.
-type RemoteFleetScanner struct {
-	loadConfig func() (*UserConfig, error)
-	newRunner  func(string, RemoteConfig) remoteFleetRunner
-	now        func() time.Time
-	timeout    time.Duration
+type remoteFleetState struct {
+	remote      RemoteFleetRemote
+	nextAttempt time.Time
+	backoff     time.Duration
 }
 
+// RemoteFleetScanner owns the single background scan loop used by a web
+// server. HTTP requests only read Snapshot and can never initiate SSH work.
+type RemoteFleetScanner struct {
+	loadConfig  func() (*UserConfig, error)
+	newRunner   func(string, RemoteConfig) remoteFleetRunner
+	now         func() time.Time
+	timeout     time.Duration
+	refresh     time.Duration
+	maxBackoff  time.Duration
+	concurrency int
+
+	mu       sync.RWMutex
+	snapshot RemoteFleetSnapshot
+	states   map[string]remoteFleetState
+	start    sync.Once
+}
+
+// NewRemoteFleetScanner creates an idle scanner. Start ties its refresh loop
+// to the caller's lifecycle context.
 func NewRemoteFleetScanner() *RemoteFleetScanner {
 	return &RemoteFleetScanner{
 		loadConfig: LoadUserConfig,
 		newRunner: func(name string, config RemoteConfig) remoteFleetRunner {
 			return NewSSHRunner(name, config)
 		},
-		now:     time.Now,
-		timeout: defaultRemoteFleetTimeout,
+		now: time.Now, timeout: defaultRemoteFleetTimeout,
+		refresh: defaultRemoteFleetRefresh, maxBackoff: defaultRemoteFleetMaxBackoff,
+		concurrency: defaultRemoteFleetConcurrency, states: make(map[string]remoteFleetState),
+		snapshot: RemoteFleetSnapshot{Remotes: make([]RemoteFleetRemote, 0)},
 	}
 }
 
-func (s *RemoteFleetScanner) Scan(ctx context.Context) (RemoteFleetSnapshot, error) {
-	if s == nil || s.loadConfig == nil || s.newRunner == nil {
-		return RemoteFleetSnapshot{}, fmt.Errorf("remote fleet scanner is not configured")
+// Start begins the server-owned refresh loop. Repeated calls are harmless.
+func (s *RemoteFleetScanner) Start(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	s.start.Do(func() { go s.run(ctx) })
+}
+
+func (s *RemoteFleetScanner) run(ctx context.Context) {
+	s.refreshOnce(ctx)
+	refresh := s.refresh
+	if refresh <= 0 {
+		refresh = defaultRemoteFleetRefresh
+	}
+	ticker := time.NewTicker(refresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.refreshOnce(ctx)
+		}
+	}
+}
+
+// Snapshot returns a copy of the latest in-memory result without doing I/O.
+func (s *RemoteFleetScanner) Snapshot() RemoteFleetSnapshot {
+	if s == nil {
+		return RemoteFleetSnapshot{Remotes: make([]RemoteFleetRemote, 0)}
+	}
+	s.mu.RLock()
+	snapshot := cloneRemoteFleetSnapshot(s.snapshot)
+	s.mu.RUnlock()
+	now := time.Now().UTC()
+	if s.now != nil {
+		now = s.now().UTC()
+	}
+	for i := range snapshot.Remotes {
+		if !snapshot.Remotes[i].ObservedAt.IsZero() {
+			age := now.Sub(snapshot.Remotes[i].ObservedAt)
+			if age > 0 {
+				snapshot.Remotes[i].AgeSeconds = int64(age / time.Second)
+			}
+		}
+	}
+	return snapshot
+}
+
+func (s *RemoteFleetScanner) refreshOnce(ctx context.Context) {
+	if s.loadConfig == nil || s.newRunner == nil || ctx.Err() != nil {
+		return
 	}
 	config, err := s.loadConfig()
-	if err != nil {
-		return RemoteFleetSnapshot{}, fmt.Errorf("load remote config: %w", err)
-	}
-	if config == nil {
-		return RemoteFleetSnapshot{}, fmt.Errorf("remote config is unavailable")
-	}
-
-	timeout := s.timeout
-	if timeout <= 0 {
-		timeout = defaultRemoteFleetTimeout
+	if err != nil || config == nil {
+		return
 	}
 	now := s.now
 	if now == nil {
 		now = time.Now
 	}
-	snapshot := RemoteFleetSnapshot{
-		ObservedAt: now().UTC(),
-		Remotes:    make([]RemoteFleetRemote, 0, len(config.Remotes)),
-	}
-	if len(config.Remotes) == 0 {
-		return snapshot, nil
-	}
+	observedAt := now().UTC()
 
-	CleanStaleSSHSockets()
-	results := make(chan RemoteFleetRemote, len(config.Remotes))
-	var wg sync.WaitGroup
+	s.mu.Lock()
+	for name := range s.states {
+		if _, configured := config.Remotes[name]; !configured {
+			delete(s.states, name)
+		}
+	}
+	type job struct {
+		name   string
+		config RemoteConfig
+	}
+	jobs := make([]job, 0, len(config.Remotes))
 	for name, remoteConfig := range config.Remotes {
-		wg.Add(1)
-		go func(name string, remoteConfig RemoteConfig) {
-			defer wg.Done()
-			remoteCtx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-
-			remote := RemoteFleetRemote{
-				Name: name, Sessions: make([]RemoteSessionInfo, 0),
-			}
-			runner := s.newRunner(name, remoteConfig)
-			sessions, fetchErr := runner.FetchSessions(remoteCtx)
-			if fetchErr != nil {
-				// SSH errors can include command lines and private paths. The web
-				// API exposes only this stable classification.
-				remote.Issue = "unavailable"
-				results <- remote
-				return
-			}
-			remote.Online = true
-			for i := range sessions {
-				sessions[i].RemoteName = name
-			}
-			if sessions != nil {
-				remote.Sessions = sessions
-			}
-			if latency, latencyErr := runner.MeasureLatency(remoteCtx); latencyErr == nil {
-				remote.LatencyMS = int(latency.Round(time.Millisecond) / time.Millisecond)
-			}
-			results <- remote
-		}(name, remoteConfig)
+		state, ok := s.states[name]
+		if !ok || !observedAt.Before(state.nextAttempt) {
+			jobs = append(jobs, job{name, remoteConfig})
+		}
 	}
-	wg.Wait()
-	close(results)
+	s.mu.Unlock()
 
-	for remote := range results {
-		snapshot.Remotes = append(snapshot.Remotes, remote)
+	if len(jobs) > 0 {
+		CleanStaleSSHSockets()
+		limit := s.concurrency
+		if limit <= 0 {
+			limit = defaultRemoteFleetConcurrency
+		}
+		if limit > len(jobs) {
+			limit = len(jobs)
+		}
+		jobCh := make(chan job)
+		resultCh := make(chan remoteFleetState, len(jobs))
+		var workers sync.WaitGroup
+		for range limit {
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				for item := range jobCh {
+					resultCh <- s.scanRemote(ctx, item.name, item.config, observedAt)
+				}
+			}()
+		}
+		go func() {
+			defer close(jobCh)
+			for _, item := range jobs {
+				select {
+				case jobCh <- item:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+		workers.Wait()
+		close(resultCh)
+		s.mu.Lock()
+		for state := range resultCh {
+			s.states[state.remote.Name] = state
+		}
+		s.mu.Unlock()
 	}
-	sort.Slice(snapshot.Remotes, func(i, j int) bool {
-		return snapshot.Remotes[i].Name < snapshot.Remotes[j].Name
-	})
+	s.publishSnapshot(observedAt, config.Remotes)
+}
+
+func (s *RemoteFleetScanner) scanRemote(ctx context.Context, name string, config RemoteConfig, observedAt time.Time) remoteFleetState {
+	timeout := s.timeout
+	if timeout <= 0 {
+		timeout = defaultRemoteFleetTimeout
+	}
+	remoteCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	runner := s.newRunner(name, config)
+	sessions, err := runner.FetchSessions(remoteCtx)
+	if err != nil {
+		s.mu.RLock()
+		prior, hadPrior := s.states[name]
+		s.mu.RUnlock()
+		backoff := defaultRemoteFleetRefresh
+		if hadPrior && prior.backoff > 0 {
+			backoff = prior.backoff * 2
+		}
+		maxBackoff := s.maxBackoff
+		if maxBackoff <= 0 {
+			maxBackoff = defaultRemoteFleetMaxBackoff
+		}
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		remote := RemoteFleetRemote{Name: name, Issue: "unavailable", Sessions: make([]RemoteSessionInfo, 0), ObservedAt: observedAt}
+		if hadPrior {
+			remote = prior.remote
+			remote.Online = false
+			remote.Issue = "unavailable"
+			remote.Stale = true
+		}
+		return remoteFleetState{remote: remote, backoff: backoff, nextAttempt: observedAt.Add(backoff)}
+	}
+	for i := range sessions {
+		sessions[i].RemoteName = name
+	}
+	if sessions == nil {
+		sessions = make([]RemoteSessionInfo, 0)
+	}
+	remote := RemoteFleetRemote{Name: name, Online: true, Sessions: sessions, ObservedAt: observedAt}
+	if latency, latencyErr := runner.MeasureLatency(remoteCtx); latencyErr == nil {
+		remote.LatencyMS = int(latency.Round(time.Millisecond) / time.Millisecond)
+	}
+	return remoteFleetState{remote: remote, nextAttempt: observedAt.Add(s.refresh)}
+}
+
+func (s *RemoteFleetScanner) publishSnapshot(observedAt time.Time, configured map[string]RemoteConfig) {
+	s.mu.Lock()
+	snapshot := RemoteFleetSnapshot{ObservedAt: observedAt, Remotes: make([]RemoteFleetRemote, 0, len(configured))}
+	for name := range configured {
+		if state, ok := s.states[name]; ok {
+			snapshot.Remotes = append(snapshot.Remotes, state.remote)
+		}
+	}
+	sort.Slice(snapshot.Remotes, func(i, j int) bool { return snapshot.Remotes[i].Name < snapshot.Remotes[j].Name })
 	snapshot.Counts = countRemoteFleet(snapshot.Remotes)
-	return snapshot, nil
+	s.snapshot = snapshot
+	s.mu.Unlock()
+}
+
+func cloneRemoteFleetSnapshot(in RemoteFleetSnapshot) RemoteFleetSnapshot {
+	out := in
+	out.Remotes = append([]RemoteFleetRemote(nil), in.Remotes...)
+	for i := range out.Remotes {
+		out.Remotes[i].Sessions = append([]RemoteSessionInfo(nil), in.Remotes[i].Sessions...)
+		if out.Remotes[i].Sessions == nil && in.Remotes[i].Sessions != nil {
+			out.Remotes[i].Sessions = make([]RemoteSessionInfo, 0)
+		}
+	}
+	if out.Remotes == nil {
+		out.Remotes = make([]RemoteFleetRemote, 0)
+	}
+	return out
 }
 
 func countRemoteFleet(remotes []RemoteFleetRemote) RemoteFleetCounts {

--- a/internal/session/remote_fleet_test.go
+++ b/internal/session/remote_fleet_test.go
@@ -3,6 +3,8 @@ package session
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -12,6 +14,31 @@ type fakeFleetRemoteRunner struct {
 	latency  time.Duration
 	err      error
 }
+
+type trackingFleetRunner struct {
+	active  *atomic.Int32
+	peak    *atomic.Int32
+	release <-chan struct{}
+}
+
+func (f trackingFleetRunner) FetchSessions(ctx context.Context) ([]RemoteSessionInfo, error) {
+	active := f.active.Add(1)
+	defer f.active.Add(-1)
+	for {
+		peak := f.peak.Load()
+		if active <= peak || f.peak.CompareAndSwap(peak, active) {
+			break
+		}
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-f.release:
+		return []RemoteSessionInfo{}, nil
+	}
+}
+
+func (trackingFleetRunner) MeasureLatency(context.Context) (time.Duration, error) { return 0, nil }
 
 func (f fakeFleetRemoteRunner) FetchSessions(context.Context) ([]RemoteSessionInfo, error) {
 	if f.err != nil {
@@ -48,10 +75,8 @@ func TestRemoteFleetScannerReturnsSortedSnapshot(t *testing.T) {
 		return time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
 	}
 
-	snapshot, err := scanner.Scan(context.Background())
-	if err != nil {
-		t.Fatalf("Scan: %v", err)
-	}
+	scanner.refreshOnce(context.Background())
+	snapshot := scanner.Snapshot()
 	if len(snapshot.Remotes) != 2 || snapshot.Remotes[0].Name != "alpha" ||
 		snapshot.Remotes[1].Name != "zeta" {
 		t.Fatalf("remotes = %#v", snapshot.Remotes)
@@ -80,10 +105,8 @@ func TestRemoteFleetScannerKeepsOfflineRemoteWithoutLeakingError(t *testing.T) {
 		return fakeFleetRemoteRunner{err: errors.New("secret ssh command and path")}
 	}
 
-	snapshot, err := scanner.Scan(context.Background())
-	if err != nil {
-		t.Fatalf("Scan: %v", err)
-	}
+	scanner.refreshOnce(context.Background())
+	snapshot := scanner.Snapshot()
 	remote := snapshot.Remotes[0]
 	if remote.Online || remote.Issue != "unavailable" || remote.Sessions == nil {
 		t.Fatalf("offline remote = %#v", remote)
@@ -98,11 +121,85 @@ func TestRemoteFleetScannerReturnsEmptySnapshotWithoutRemotes(t *testing.T) {
 	scanner.loadConfig = func() (*UserConfig, error) {
 		return &UserConfig{}, nil
 	}
-	snapshot, err := scanner.Scan(context.Background())
-	if err != nil {
-		t.Fatalf("Scan: %v", err)
-	}
+	scanner.refreshOnce(context.Background())
+	snapshot := scanner.Snapshot()
 	if snapshot.Remotes == nil || len(snapshot.Remotes) != 0 {
 		t.Fatalf("remotes = %#v, want non-nil empty slice", snapshot.Remotes)
+	}
+}
+
+func TestRemoteFleetScannerBoundsConcurrencyAndHonorsLifecycleCancellation(t *testing.T) {
+	scanner := NewRemoteFleetScanner()
+	scanner.concurrency = 2
+	remotes := make(map[string]RemoteConfig)
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		remotes[name] = RemoteConfig{Host: name}
+	}
+	scanner.loadConfig = func() (*UserConfig, error) { return &UserConfig{Remotes: remotes}, nil }
+	var active, peak atomic.Int32
+	release := make(chan struct{})
+	scanner.newRunner = func(string, RemoteConfig) remoteFleetRunner {
+		return trackingFleetRunner{active: &active, peak: &peak, release: release}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { scanner.refreshOnce(ctx); close(done) }()
+	deadline := time.Now().Add(time.Second)
+	for peak.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := peak.Load(); got != 2 {
+		t.Fatalf("peak concurrency = %d, want 2", got)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("scan did not stop with lifecycle context")
+	}
+}
+
+type sequenceFleetRunner struct {
+	mu    *sync.Mutex
+	calls *int
+}
+
+func (f sequenceFleetRunner) FetchSessions(context.Context) ([]RemoteSessionInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	*f.calls++
+	if *f.calls > 1 {
+		return nil, errors.New("offline")
+	}
+	return []RemoteSessionInfo{{ID: "kept", Status: "waiting"}}, nil
+}
+
+func (sequenceFleetRunner) MeasureLatency(context.Context) (time.Duration, error) { return 0, nil }
+
+func TestRemoteFleetScannerRetainsStaleResultsAndBacksOffFailures(t *testing.T) {
+	scanner := NewRemoteFleetScanner()
+	current := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	scanner.now = func() time.Time { return current }
+	scanner.refresh = time.Second
+	scanner.loadConfig = func() (*UserConfig, error) {
+		return &UserConfig{Remotes: map[string]RemoteConfig{"build": {Host: "build"}}}, nil
+	}
+	var mu sync.Mutex
+	calls := 0
+	scanner.newRunner = func(string, RemoteConfig) remoteFleetRunner { return sequenceFleetRunner{mu: &mu, calls: &calls} }
+	scanner.refreshOnce(context.Background())
+	current = current.Add(time.Second)
+	scanner.refreshOnce(context.Background())
+	snapshot := scanner.Snapshot()
+	if len(snapshot.Remotes) != 1 || !snapshot.Remotes[0].Stale || snapshot.Remotes[0].Online || len(snapshot.Remotes[0].Sessions) != 1 {
+		t.Fatalf("stale snapshot = %#v", snapshot)
+	}
+	current = current.Add(time.Second)
+	scanner.refreshOnce(context.Background())
+	mu.Lock()
+	gotCalls := calls
+	mu.Unlock()
+	if gotCalls != 2 {
+		t.Fatalf("calls during failure backoff = %d, want 2", gotCalls)
 	}
 }

--- a/internal/session/remote_fleet_test.go
+++ b/internal/session/remote_fleet_test.go
@@ -1,0 +1,108 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeFleetRemoteRunner struct {
+	sessions []RemoteSessionInfo
+	latency  time.Duration
+	err      error
+}
+
+func (f fakeFleetRemoteRunner) FetchSessions(context.Context) ([]RemoteSessionInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]RemoteSessionInfo(nil), f.sessions...), nil
+}
+
+func (f fakeFleetRemoteRunner) MeasureLatency(context.Context) (time.Duration, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.latency, nil
+}
+
+func TestRemoteFleetScannerReturnsSortedSnapshot(t *testing.T) {
+	scanner := NewRemoteFleetScanner()
+	scanner.loadConfig = func() (*UserConfig, error) {
+		return &UserConfig{Remotes: map[string]RemoteConfig{
+			"zeta":  {Host: "zeta@example"},
+			"alpha": {Host: "alpha@example"},
+		}}, nil
+	}
+	scanner.newRunner = func(name string, _ RemoteConfig) remoteFleetRunner {
+		return fakeFleetRemoteRunner{
+			latency: 27 * time.Millisecond,
+			sessions: []RemoteSessionInfo{{
+				ID: "session-1", Title: "Build", Path: "/work/" + name,
+				Group: name, Tool: "codex", Status: "waiting",
+			}},
+		}
+	}
+	scanner.now = func() time.Time {
+		return time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	}
+
+	snapshot, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(snapshot.Remotes) != 2 || snapshot.Remotes[0].Name != "alpha" ||
+		snapshot.Remotes[1].Name != "zeta" {
+		t.Fatalf("remotes = %#v", snapshot.Remotes)
+	}
+	alpha := snapshot.Remotes[0]
+	if !alpha.Online || alpha.LatencyMS != 27 || len(alpha.Sessions) != 1 {
+		t.Fatalf("alpha = %#v", alpha)
+	}
+	if alpha.Sessions[0].RemoteName != "alpha" {
+		t.Fatalf("session remote = %q, want alpha", alpha.Sessions[0].RemoteName)
+	}
+	if snapshot.Counts.RemotesOnline != 2 || snapshot.Counts.Sessions != 2 ||
+		snapshot.Counts.Waiting != 2 {
+		t.Fatalf("counts = %#v", snapshot.Counts)
+	}
+}
+
+func TestRemoteFleetScannerKeepsOfflineRemoteWithoutLeakingError(t *testing.T) {
+	scanner := NewRemoteFleetScanner()
+	scanner.loadConfig = func() (*UserConfig, error) {
+		return &UserConfig{Remotes: map[string]RemoteConfig{
+			"offline": {Host: "offline@example"},
+		}}, nil
+	}
+	scanner.newRunner = func(string, RemoteConfig) remoteFleetRunner {
+		return fakeFleetRemoteRunner{err: errors.New("secret ssh command and path")}
+	}
+
+	snapshot, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	remote := snapshot.Remotes[0]
+	if remote.Online || remote.Issue != "unavailable" || remote.Sessions == nil {
+		t.Fatalf("offline remote = %#v", remote)
+	}
+	if snapshot.Counts.RemotesOffline != 1 {
+		t.Fatalf("counts = %#v", snapshot.Counts)
+	}
+}
+
+func TestRemoteFleetScannerReturnsEmptySnapshotWithoutRemotes(t *testing.T) {
+	scanner := NewRemoteFleetScanner()
+	scanner.loadConfig = func() (*UserConfig, error) {
+		return &UserConfig{}, nil
+	}
+	snapshot, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if snapshot.Remotes == nil || len(snapshot.Remotes) != 0 {
+		t.Fatalf("remotes = %#v, want non-nil empty slice", snapshot.Remotes)
+	}
+}

--- a/internal/web/handlers_remotes.go
+++ b/internal/web/handlers_remotes.go
@@ -1,0 +1,36 @@
+package web
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// RemoteFleetLoader provides a read-only snapshot of configured SSH remotes.
+// It is exported so embedders can supply a cached or otherwise customized
+// scanner without coupling the web package to its concrete implementation.
+type RemoteFleetLoader interface {
+	Scan(context.Context) (session.RemoteFleetSnapshot, error)
+}
+
+func (s *Server) handleRemotes(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "unauthorized")
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
+		return
+	}
+	if s.remoteFleet == nil {
+		writeAPIError(w, http.StatusServiceUnavailable, ErrCodeNotImplemented, "remote fleet is unavailable")
+		return
+	}
+	snapshot, err := s.remoteFleet.Scan(r.Context())
+	if err != nil {
+		writeAPIError(w, http.StatusServiceUnavailable, ErrCodeInternalError, "remote fleet scan failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
+}

--- a/internal/web/handlers_remotes.go
+++ b/internal/web/handlers_remotes.go
@@ -2,7 +2,10 @@ package web
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -12,6 +15,75 @@ import (
 // scanner without coupling the web package to its concrete implementation.
 type RemoteFleetLoader interface {
 	Scan(context.Context) (session.RemoteFleetSnapshot, error)
+}
+
+const remoteFleetCacheTTL = 5 * time.Second
+
+type remoteFleetFlight struct {
+	done     chan struct{}
+	snapshot session.RemoteFleetSnapshot
+	err      error
+	waiters  int
+}
+
+// remoteFleetCache prevents multiple web clients from multiplying SSH work.
+// A fresh successful snapshot is reused briefly; concurrent cache misses share
+// one scan and receive the same result.
+type remoteFleetCache struct {
+	loader RemoteFleetLoader
+	ttl    time.Duration
+	now    func() time.Time
+
+	mu       sync.Mutex
+	snapshot session.RemoteFleetSnapshot
+	expires  time.Time
+	inFlight *remoteFleetFlight
+}
+
+func newRemoteFleetCache(loader RemoteFleetLoader) *remoteFleetCache {
+	return &remoteFleetCache{loader: loader, ttl: remoteFleetCacheTTL, now: time.Now}
+}
+
+func (c *remoteFleetCache) Scan(ctx context.Context) (session.RemoteFleetSnapshot, error) {
+	if c == nil || c.loader == nil {
+		return session.RemoteFleetSnapshot{}, errors.New("remote fleet cache is not configured")
+	}
+	now := c.now
+	if now == nil {
+		now = time.Now
+	}
+
+	c.mu.Lock()
+	if !c.expires.IsZero() && now().Before(c.expires) {
+		snapshot := c.snapshot
+		c.mu.Unlock()
+		return snapshot, nil
+	}
+	if c.inFlight != nil {
+		flight := c.inFlight
+		flight.waiters++
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return session.RemoteFleetSnapshot{}, ctx.Err()
+		case <-flight.done:
+			return flight.snapshot, flight.err
+		}
+	}
+	flight := &remoteFleetFlight{done: make(chan struct{})}
+	c.inFlight = flight
+	c.mu.Unlock()
+
+	flight.snapshot, flight.err = c.loader.Scan(ctx)
+	c.mu.Lock()
+	if flight.err == nil {
+		c.snapshot = flight.snapshot
+		c.expires = now().Add(c.ttl)
+	}
+	c.inFlight = nil
+	close(flight.done)
+	c.mu.Unlock()
+	return flight.snapshot, flight.err
 }
 
 func (s *Server) handleRemotes(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/handlers_remotes.go
+++ b/internal/web/handlers_remotes.go
@@ -2,88 +2,16 @@ package web
 
 import (
 	"context"
-	"errors"
 	"net/http"
-	"sync"
-	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// RemoteFleetLoader provides a read-only snapshot of configured SSH remotes.
-// It is exported so embedders can supply a cached or otherwise customized
-// scanner without coupling the web package to its concrete implementation.
+// RemoteFleetLoader is a server-owned source of remote fleet snapshots.
+// Start may perform background I/O; Snapshot must only read memory.
 type RemoteFleetLoader interface {
-	Scan(context.Context) (session.RemoteFleetSnapshot, error)
-}
-
-const remoteFleetCacheTTL = 5 * time.Second
-
-type remoteFleetFlight struct {
-	done     chan struct{}
-	snapshot session.RemoteFleetSnapshot
-	err      error
-	waiters  int
-}
-
-// remoteFleetCache prevents multiple web clients from multiplying SSH work.
-// A fresh successful snapshot is reused briefly; concurrent cache misses share
-// one scan and receive the same result.
-type remoteFleetCache struct {
-	loader RemoteFleetLoader
-	ttl    time.Duration
-	now    func() time.Time
-
-	mu       sync.Mutex
-	snapshot session.RemoteFleetSnapshot
-	expires  time.Time
-	inFlight *remoteFleetFlight
-}
-
-func newRemoteFleetCache(loader RemoteFleetLoader) *remoteFleetCache {
-	return &remoteFleetCache{loader: loader, ttl: remoteFleetCacheTTL, now: time.Now}
-}
-
-func (c *remoteFleetCache) Scan(ctx context.Context) (session.RemoteFleetSnapshot, error) {
-	if c == nil || c.loader == nil {
-		return session.RemoteFleetSnapshot{}, errors.New("remote fleet cache is not configured")
-	}
-	now := c.now
-	if now == nil {
-		now = time.Now
-	}
-
-	c.mu.Lock()
-	if !c.expires.IsZero() && now().Before(c.expires) {
-		snapshot := c.snapshot
-		c.mu.Unlock()
-		return snapshot, nil
-	}
-	if c.inFlight != nil {
-		flight := c.inFlight
-		flight.waiters++
-		c.mu.Unlock()
-		select {
-		case <-ctx.Done():
-			return session.RemoteFleetSnapshot{}, ctx.Err()
-		case <-flight.done:
-			return flight.snapshot, flight.err
-		}
-	}
-	flight := &remoteFleetFlight{done: make(chan struct{})}
-	c.inFlight = flight
-	c.mu.Unlock()
-
-	flight.snapshot, flight.err = c.loader.Scan(ctx)
-	c.mu.Lock()
-	if flight.err == nil {
-		c.snapshot = flight.snapshot
-		c.expires = now().Add(c.ttl)
-	}
-	c.inFlight = nil
-	close(flight.done)
-	c.mu.Unlock()
-	return flight.snapshot, flight.err
+	Start(context.Context)
+	Snapshot() session.RemoteFleetSnapshot
 }
 
 func (s *Server) handleRemotes(w http.ResponseWriter, r *http.Request) {
@@ -99,10 +27,5 @@ func (s *Server) handleRemotes(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusServiceUnavailable, ErrCodeNotImplemented, "remote fleet is unavailable")
 		return
 	}
-	snapshot, err := s.remoteFleet.Scan(r.Context())
-	if err != nil {
-		writeAPIError(w, http.StatusServiceUnavailable, ErrCodeInternalError, "remote fleet scan failed")
-		return
-	}
-	writeJSON(w, http.StatusOK, snapshot)
+	writeJSON(w, http.StatusOK, s.remoteFleet.Snapshot())
 }

--- a/internal/web/handlers_remotes_test.go
+++ b/internal/web/handlers_remotes_test.go
@@ -1,0 +1,77 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+type fakeRemoteFleetLoader struct {
+	snapshot session.RemoteFleetSnapshot
+	err      error
+}
+
+func (f fakeRemoteFleetLoader) Scan(context.Context) (session.RemoteFleetSnapshot, error) {
+	return f.snapshot, f.err
+}
+
+func TestRemotesAPIListsConfiguredFleet(t *testing.T) {
+	srv := NewServer(Config{RemoteFleet: fakeRemoteFleetLoader{
+		snapshot: session.RemoteFleetSnapshot{
+			Remotes: []session.RemoteFleetRemote{{
+				Name: "build", Online: true,
+				Sessions: []session.RemoteSessionInfo{{ID: "session-1", Title: "Build"}},
+			}},
+			Counts: session.RemoteFleetCounts{RemotesOnline: 1, Sessions: 1},
+		},
+	}})
+	req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var snapshot session.RemoteFleetSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(snapshot.Remotes) != 1 || snapshot.Remotes[0].Name != "build" ||
+		snapshot.Counts.Sessions != 1 {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
+func TestRemotesAPIFailsClosed(t *testing.T) {
+	t.Run("authorization", func(t *testing.T) {
+		srv := NewServer(Config{
+			Token: "secret", RemoteFleet: fakeRemoteFleetLoader{},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("scanner error", func(t *testing.T) {
+		srv := NewServer(Config{RemoteFleet: fakeRemoteFleetLoader{
+			err: errors.New("raw ssh detail must not leak"),
+		}})
+		req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rec.Code)
+		}
+		if body := rec.Body.String(); body == "" || strings.Contains(body, "raw ssh detail") {
+			t.Fatalf("unsafe error response = %q", body)
+		}
+	})
+}

--- a/internal/web/handlers_remotes_test.go
+++ b/internal/web/handlers_remotes_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -74,4 +76,72 @@ func TestRemotesAPIFailsClosed(t *testing.T) {
 			t.Fatalf("unsafe error response = %q", body)
 		}
 	})
+}
+
+type blockingRemoteFleetLoader struct {
+	mu      sync.Mutex
+	calls   int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (f *blockingRemoteFleetLoader) Scan(context.Context) (session.RemoteFleetSnapshot, error) {
+	f.mu.Lock()
+	f.calls++
+	if f.calls == 1 {
+		close(f.started)
+	}
+	f.mu.Unlock()
+	<-f.release
+	return session.RemoteFleetSnapshot{Counts: session.RemoteFleetCounts{RemotesOnline: 1}}, nil
+}
+
+func TestRemoteFleetCacheCoalescesAndReusesScans(t *testing.T) {
+	loader := &blockingRemoteFleetLoader{
+		started: make(chan struct{}), release: make(chan struct{}),
+	}
+	cache := newRemoteFleetCache(loader)
+	cache.ttl = time.Minute
+
+	const callers = 12
+	results := make(chan error, callers)
+	go func() {
+		_, err := cache.Scan(context.Background())
+		results <- err
+	}()
+	<-loader.started
+	for range callers - 1 {
+		go func() {
+			_, err := cache.Scan(context.Background())
+			results <- err
+		}()
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		cache.mu.Lock()
+		waiters := cache.inFlight.waiters
+		cache.mu.Unlock()
+		if waiters == callers-1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("coalesced waiters = %d, want %d", waiters, callers-1)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(loader.release)
+	for range callers {
+		if err := <-results; err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+	}
+	if _, err := cache.Scan(context.Background()); err != nil {
+		t.Fatalf("cached Scan: %v", err)
+	}
+	loader.mu.Lock()
+	calls := loader.calls
+	loader.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("loader calls = %d, want 1", calls)
+	}
 }

--- a/internal/web/handlers_remotes_test.go
+++ b/internal/web/handlers_remotes_test.go
@@ -3,36 +3,31 @@ package web
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 type fakeRemoteFleetLoader struct {
 	snapshot session.RemoteFleetSnapshot
-	err      error
+	started  chan context.Context
 }
 
-func (f fakeRemoteFleetLoader) Scan(context.Context) (session.RemoteFleetSnapshot, error) {
-	return f.snapshot, f.err
+func (f *fakeRemoteFleetLoader) Start(ctx context.Context) {
+	if f.started != nil {
+		f.started <- ctx
+	}
 }
+
+func (f *fakeRemoteFleetLoader) Snapshot() session.RemoteFleetSnapshot { return f.snapshot }
 
 func TestRemotesAPIListsConfiguredFleet(t *testing.T) {
-	srv := NewServer(Config{RemoteFleet: fakeRemoteFleetLoader{
-		snapshot: session.RemoteFleetSnapshot{
-			Remotes: []session.RemoteFleetRemote{{
-				Name: "build", Online: true,
-				Sessions: []session.RemoteSessionInfo{{ID: "session-1", Title: "Build"}},
-			}},
-			Counts: session.RemoteFleetCounts{RemotesOnline: 1, Sessions: 1},
-		},
-	}})
+	srv := NewServer(Config{RemoteFleet: &fakeRemoteFleetLoader{snapshot: session.RemoteFleetSnapshot{
+		Remotes: []session.RemoteFleetRemote{{Name: "build", Online: true, Sessions: []session.RemoteSessionInfo{{ID: "session-1", Title: "Build"}}}},
+		Counts:  session.RemoteFleetCounts{RemotesOnline: 1, Sessions: 1},
+	}}})
 	req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)
@@ -43,105 +38,32 @@ func TestRemotesAPIListsConfiguredFleet(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if len(snapshot.Remotes) != 1 || snapshot.Remotes[0].Name != "build" ||
-		snapshot.Counts.Sessions != 1 {
+	if len(snapshot.Remotes) != 1 || snapshot.Remotes[0].Name != "build" || snapshot.Counts.Sessions != 1 {
 		t.Fatalf("snapshot = %#v", snapshot)
 	}
 }
 
-func TestRemotesAPIFailsClosed(t *testing.T) {
-	t.Run("authorization", func(t *testing.T) {
-		srv := NewServer(Config{
-			Token: "secret", RemoteFleet: fakeRemoteFleetLoader{},
-		})
+func TestRemotesAPIRequiresAuthorization(t *testing.T) {
+	srv := NewServer(Config{Token: "secret", RemoteFleet: &fakeRemoteFleetLoader{}})
+	req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRemotesAPIOnlyReadsSnapshot(t *testing.T) {
+	loader := &fakeRemoteFleetLoader{snapshot: session.RemoteFleetSnapshot{}}
+	srv := NewServer(Config{RemoteFleet: loader})
+	for range 12 {
 		req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
 		rec := httptest.NewRecorder()
 		srv.Handler().ServeHTTP(rec, req)
-		if rec.Code != http.StatusUnauthorized {
-			t.Fatalf("status = %d, want 401", rec.Code)
-		}
-	})
-
-	t.Run("scanner error", func(t *testing.T) {
-		srv := NewServer(Config{RemoteFleet: fakeRemoteFleetLoader{
-			err: errors.New("raw ssh detail must not leak"),
-		}})
-		req := httptest.NewRequest(http.MethodGet, "/api/remotes", nil)
-		rec := httptest.NewRecorder()
-		srv.Handler().ServeHTTP(rec, req)
-		if rec.Code != http.StatusServiceUnavailable {
-			t.Fatalf("status = %d, want 503", rec.Code)
-		}
-		if body := rec.Body.String(); body == "" || strings.Contains(body, "raw ssh detail") {
-			t.Fatalf("unsafe error response = %q", body)
-		}
-	})
-}
-
-type blockingRemoteFleetLoader struct {
-	mu      sync.Mutex
-	calls   int
-	started chan struct{}
-	release chan struct{}
-}
-
-func (f *blockingRemoteFleetLoader) Scan(context.Context) (session.RemoteFleetSnapshot, error) {
-	f.mu.Lock()
-	f.calls++
-	if f.calls == 1 {
-		close(f.started)
-	}
-	f.mu.Unlock()
-	<-f.release
-	return session.RemoteFleetSnapshot{Counts: session.RemoteFleetCounts{RemotesOnline: 1}}, nil
-}
-
-func TestRemoteFleetCacheCoalescesAndReusesScans(t *testing.T) {
-	loader := &blockingRemoteFleetLoader{
-		started: make(chan struct{}), release: make(chan struct{}),
-	}
-	cache := newRemoteFleetCache(loader)
-	cache.ttl = time.Minute
-
-	const callers = 12
-	results := make(chan error, callers)
-	go func() {
-		_, err := cache.Scan(context.Background())
-		results <- err
-	}()
-	<-loader.started
-	for range callers - 1 {
-		go func() {
-			_, err := cache.Scan(context.Background())
-			results <- err
-		}()
-	}
-	deadline := time.Now().Add(time.Second)
-	for {
-		cache.mu.Lock()
-		waiters := cache.inFlight.waiters
-		cache.mu.Unlock()
-		if waiters == callers-1 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("coalesced waiters = %d, want %d", waiters, callers-1)
-		}
-		time.Sleep(time.Millisecond)
-	}
-	close(loader.release)
-	for range callers {
-		if err := <-results; err != nil {
-			t.Fatalf("Scan: %v", err)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
 		}
 	}
-	if _, err := cache.Scan(context.Background()); err != nil {
-		t.Fatalf("cached Scan: %v", err)
-	}
-	loader.mu.Lock()
-	calls := loader.calls
-	loader.mu.Unlock()
-	if calls != 1 {
-		t.Fatalf("loader calls = %d, want 1", calls)
-	}
+	// The loader has no request-aware method: this test protects the security
+	// boundary that authenticated requests cannot initiate background work.
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -202,10 +202,11 @@ func NewServer(cfg Config) *Server {
 		mutationLimiter:  mutationLimiter,
 		hookStatusLoader: defaultLoadHookStatuses,
 	}
-	s.baseCtx, s.cancelBase = context.WithCancel(context.Background())
 	if s.remoteFleet == nil {
 		s.remoteFleet = session.NewRemoteFleetScanner()
 	}
+	s.remoteFleet = newRemoteFleetCache(s.remoteFleet)
+	s.baseCtx, s.cancelBase = context.WithCancel(context.Background())
 	webLog := logging.ForComponent(logging.CompWeb)
 	if pushSvc, err := newPushService(cfg, menuData); err != nil {
 		webLog.Warn("push_disabled", slog.String("error", err.Error()))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -41,6 +41,7 @@ type Config struct {
 	PushVAPIDPrivateKey string
 	PushVAPIDSubject    string
 	PushTestInterval    time.Duration
+	RemoteFleet         RemoteFleetLoader
 }
 
 // confirmLinkOpen resolves Config.ConfirmLinkOpen, defaulting to true so an
@@ -167,6 +168,7 @@ type Server struct {
 	mutator         SessionMutator
 	skills          SkillsService
 	mcpMgr          MCPManager
+	remoteFleet     RemoteFleetLoader
 	mutationLimiter *rate.Limiter
 
 	// hookStatusLoader returns the latest hook payload for every instance
@@ -195,11 +197,15 @@ func NewServer(cfg Config) *Server {
 	s := &Server{
 		cfg:              cfg,
 		menuData:         menuData,
+		remoteFleet:      cfg.RemoteFleet,
 		menuSubscribers:  make(map[chan struct{}]struct{}),
 		mutationLimiter:  mutationLimiter,
 		hookStatusLoader: defaultLoadHookStatuses,
 	}
 	s.baseCtx, s.cancelBase = context.WithCancel(context.Background())
+	if s.remoteFleet == nil {
+		s.remoteFleet = session.NewRemoteFleetScanner()
+	}
 	webLog := logging.ForComponent(logging.CompWeb)
 	if pushSvc, err := newPushService(cfg, menuData); err != nil {
 		webLog.Warn("push_disabled", slog.String("error", err.Error()))
@@ -238,6 +244,7 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("/api/menu", s.handleMenu)
 	mux.HandleFunc("/api/session/", s.handleSessionByID)
 	mux.HandleFunc("/api/sessions", s.handleSessionsCollection)
+	mux.HandleFunc("/api/remotes", s.handleRemotes)
 	// /api/sessions/undelete is a collection-level action (Chrome-style
 	// ctrl+z undo). Register before the subtree pattern so Go 1.22+
 	// ServeMux precedence routes it cleanly instead of treating

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -205,7 +205,6 @@ func NewServer(cfg Config) *Server {
 	if s.remoteFleet == nil {
 		s.remoteFleet = session.NewRemoteFleetScanner()
 	}
-	s.remoteFleet = newRemoteFleetCache(s.remoteFleet)
 	s.baseCtx, s.cancelBase = context.WithCancel(context.Background())
 	webLog := logging.ForComponent(logging.CompWeb)
 	if pushSvc, err := newPushService(cfg, menuData); err != nil {
@@ -323,6 +322,9 @@ func (s *Server) Start() error {
 	// address even if a caller bypassed the CLI flag check. See report #1.
 	if err := s.checkBindSecurity(); err != nil {
 		return err
+	}
+	if s.remoteFleet != nil {
+		s.remoteFleet.Start(s.baseCtx)
 	}
 
 	webLog := logging.ForComponent(logging.CompWeb)

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -772,6 +772,7 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .fleet-stats .stat .num.error   { color: var(--tn-red); }
 .fleet-stats .stat .num.idle    { color: var(--text-dim); }
 .fleet-stats .stat .num.cost    { color: var(--accent); }
+.fleet-remotes-summary { font-family: var(--mono); font-size: 10px; color: var(--tn-cyan); }
 
 .fleet-section { display: flex; flex-direction: column; gap: 12px; }
 .fleet-section-head {
@@ -814,6 +815,15 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .group-card.running::before { background: var(--tn-green); }
 .group-card.waiting::before { background: var(--tn-yellow); }
 .group-card.error::before   { background: var(--tn-red); }
+.fleet-remote-state { margin-left: auto; font-family: var(--mono); font-size: 10.5px; color: var(--tn-green); }
+.fleet-remote-state.offline { color: var(--tn-red); }
+.fleet-remote-empty, .fleet-remote-error {
+  padding: 10px; border: 1px dashed var(--border); border-radius: 4px;
+  font-family: var(--mono); font-size: 10.5px; color: var(--muted);
+}
+.fleet-remote-error { color: var(--tn-red); }
+.fleet-remote-session-tile { cursor: default; }
+.fleet-remote-session-tile:hover { border-color: var(--border); background: var(--card); }
 .gc-head { display: flex; align-items: center; gap: 10px; }
 .gc-head .t { font-family: var(--sans); font-weight: 600; color: var(--text-hi); font-size: 13px; letter-spacing: 0.02em; }
 .gc-head .health .d { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--muted); }

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -817,6 +817,7 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .group-card.error::before   { background: var(--tn-red); }
 .fleet-remote-state { margin-left: auto; font-family: var(--mono); font-size: 10.5px; color: var(--tn-green); }
 .fleet-remote-state.offline { color: var(--tn-red); }
+.fleet-remote-age { padding: 0 12px 10px; font-family: var(--mono); font-size: 9.5px; color: var(--tn-amber); }
 .fleet-remote-empty, .fleet-remote-error {
   padding: 10px; border: 1px dashed var(--border); border-radius: 4px;
   font-family: var(--mono); font-size: 10.5px; color: var(--muted);

--- a/internal/web/static/app/panes/FleetPane.js
+++ b/internal/web/static/app/panes/FleetPane.js
@@ -27,6 +27,13 @@ function remoteHealth(remote) {
   return 'idle'
 }
 
+function remoteAge(remote) {
+  const seconds = Math.max(0, Number(remote?.ageSeconds) || 0)
+  if (seconds < 60) return `${seconds}s ago`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+  return `${Math.floor(seconds / 3600)}h ago`
+}
+
 function RemoteCard({ remote }) {
   const sessions = remoteSessions(remote)
   const health = remoteHealth(remote)
@@ -40,10 +47,10 @@ function RemoteCard({ remote }) {
         <span class="t">${remote.name}</span>
         <span class="health"><span class=${`d ${health}`}/></span>
         <span class=${`fleet-remote-state ${remote.online ? 'online' : 'offline'}`}>
-          ${remote.online ? (remote.latencyMs ? `${remote.latencyMs}ms` : 'online') : 'offline'}
+          ${remote.stale ? 'stale' : remote.online ? (remote.latencyMs ? `${remote.latencyMs}ms` : 'online') : 'offline'}
         </span>
       </div>
-      ${!remote.online
+      ${!remote.online && sessions.length === 0
         ? html`<div class="fleet-remote-empty">Remote unavailable</div>`
         : sessions.length === 0
           ? html`<div class="fleet-remote-empty">Online · no sessions</div>`
@@ -66,6 +73,9 @@ function RemoteCard({ remote }) {
           ${sessions.length} session${sessions.length === 1 ? '' : 's'}
         </span>
       </div>
+      ${remote.stale && html`<div class="fleet-remote-age" data-testid="fleet-remote-age">
+        Last known state · ${remoteAge(remote)}
+      </div>`}
     </article>
   `
 }
@@ -189,7 +199,7 @@ export function FleetPane() {
       <div class="fleet-section">
         <div class="fleet-section-head">
           <span class="kicker">GROUPS</span>
-          <span class="sub-kicker">${groups.length} group${groups.length === 1 ? '' : 's'} · ${sessions.length} local session${sessions.length === 1 ? '' : 's'}</span>
+          <span class="sub-kicker">${groups.length} group${groups.length === 1 ? '' : 's'} · ${sessions.length} ${remoteTotal > 0 ? 'local ' : ''}session${sessions.length === 1 ? '' : 's'}</span>
         </div>
         ${groups.length === 0 || sessions.length === 0
           ? html`<div style="font-family: var(--mono); font-size: 11px; color: var(--muted); padding: 16px;">

--- a/internal/web/static/app/panes/FleetPane.js
+++ b/internal/web/static/app/panes/FleetPane.js
@@ -3,10 +3,72 @@
 // has additional sections (conductor graph, watcher strip) that depend on
 // fields the API does not expose; those render as informative empty hints.
 import { html } from 'htm/preact'
-import { useMemo } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { apiFetch } from '../api.js'
 import { menuModelSignal } from '../dataModel.js'
 import { selectedIdSignal } from '../state.js'
 import { activeTabSignal } from '../uiState.js'
+
+const EMPTY_REMOTE_COUNTS = {
+  remotesOnline: 0, remotesOffline: 0, sessions: 0,
+  running: 0, waiting: 0, idle: 0, error: 0, stopped: 0,
+}
+
+function remoteSessions(remote) {
+  return Array.isArray(remote?.sessions) ? remote.sessions : []
+}
+
+function remoteHealth(remote) {
+  if (!remote.online) return 'error'
+  const sessions = remoteSessions(remote)
+  if (sessions.some(s => s.status === 'error')) return 'error'
+  if (sessions.some(s => s.status === 'waiting')) return 'waiting'
+  if (sessions.some(s => s.status === 'running' || s.status === 'starting')) return 'running'
+  return 'idle'
+}
+
+function RemoteCard({ remote }) {
+  const sessions = remoteSessions(remote)
+  const health = remoteHealth(remote)
+  const running = sessions.filter(s => s.status === 'running' || s.status === 'starting').length
+  const waiting = sessions.filter(s => s.status === 'waiting').length
+  const errors = sessions.filter(s => s.status === 'error').length
+  return html`
+    <article class=${`group-card fleet-remote-card ${health}`}
+      data-testid="fleet-remote-card" data-remote-name=${remote.name}>
+      <div class="gc-head">
+        <span class="t">${remote.name}</span>
+        <span class="health"><span class=${`d ${health}`}/></span>
+        <span class=${`fleet-remote-state ${remote.online ? 'online' : 'offline'}`}>
+          ${remote.online ? (remote.latencyMs ? `${remote.latencyMs}ms` : 'online') : 'offline'}
+        </span>
+      </div>
+      ${!remote.online
+        ? html`<div class="fleet-remote-empty">Remote unavailable</div>`
+        : sessions.length === 0
+          ? html`<div class="fleet-remote-empty">Online · no sessions</div>`
+          : html`<div class="gc-tiles">
+              ${sessions.map(s => html`
+                <div key=${s.id} class="tile fleet-remote-session-tile"
+                  data-testid="fleet-remote-session-tile" data-session-id=${s.id}
+                  title=${s.path || s.id}>
+                  <span class=${`tdot ${s.status}`}/>
+                  <span class="tn">${s.title || s.id}</span>
+                  ${s.tool && html`<span class="ttool">${s.tool}</span>`}
+                </div>
+              `)}
+            </div>`}
+      <div class="gc-foot">
+        <span class="cn"><span class="d running"/>${running}</span>
+        <span class="cn"><span class="d waiting"/>${waiting}</span>
+        <span class="cn"><span class="d error"/>${errors}</span>
+        <span class="path" data-testid="fleet-remote-session-count">
+          ${sessions.length} session${sessions.length === 1 ? '' : 's'}
+        </span>
+      </div>
+    </article>
+  `
+}
 
 function GroupCard({ name, items, onSelect }) {
   const running = items.filter(s => s.status === 'running').length
@@ -41,12 +103,51 @@ function GroupCard({ name, items, onSelect }) {
 
 export function FleetPane() {
   const { groups, byGroup, sessions } = menuModelSignal.value
-  const counts = useMemo(() => ({
+  const [remoteFleet, setRemoteFleet] = useState(null)
+  const [remoteError, setRemoteError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    let requestRunning = false
+    const load = async () => {
+      if (requestRunning) return
+      requestRunning = true
+      try {
+        const value = await apiFetch('GET', '/api/remotes')
+        if (!cancelled) {
+          setRemoteFleet(value)
+          setRemoteError('')
+        }
+      } catch (err) {
+        if (!cancelled) setRemoteError(err.message || 'Could not scan configured remotes')
+      } finally {
+        requestRunning = false
+      }
+    }
+    load()
+    const interval = setInterval(load, 10000)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [])
+
+  const localCounts = useMemo(() => ({
     running: sessions.filter(s => s.status === 'running').length,
     waiting: sessions.filter(s => s.status === 'waiting').length,
     error:   sessions.filter(s => s.status === 'error').length,
     idle:    sessions.filter(s => s.status === 'idle').length,
   }), [sessions])
+  const remoteCounts = remoteFleet?.counts || EMPTY_REMOTE_COUNTS
+  const remotes = Array.isArray(remoteFleet?.remotes) ? remoteFleet.remotes : []
+  const remoteTotal = remoteCounts.remotesOnline + remoteCounts.remotesOffline
+  const counts = {
+    running: localCounts.running + remoteCounts.running,
+    waiting: localCounts.waiting + remoteCounts.waiting,
+    error: localCounts.error + remoteCounts.error,
+    idle: localCounts.idle + remoteCounts.idle,
+  }
+  const sessionTotal = sessions.length + remoteCounts.sessions
   const totalCost = sessions.reduce((n, s) => n + (s.cost || 0), 0)
 
   const onSelect = (id) => {
@@ -62,13 +163,33 @@ export function FleetPane() {
         <div class="stat" data-testid="fleet-stat-error"><div class="lbl">ERROR</div><div class="num error">${counts.error}</div></div>
         <div class="stat" data-testid="fleet-stat-idle"><div class="lbl">IDLE</div><div class="num idle">${counts.idle}</div></div>
         <div class="stat" data-testid="fleet-stat-cost"><div class="lbl">SPEND · TODAY</div><div class="num cost">$${totalCost.toFixed(2)}</div></div>
-        <div class="stat" data-testid="fleet-stat-sessions"><div class="lbl">SESSIONS</div><div class="num">${sessions.length}</div></div>
+        <div class="stat" data-testid="fleet-stat-sessions">
+          <div class="lbl">SESSIONS</div>
+          <div class="num">${sessionTotal}</div>
+          ${remoteTotal > 0 && html`<div class="fleet-remotes-summary" data-testid="fleet-stat-remotes">
+            ${remoteCounts.remotesOnline}/${remoteTotal} remotes online
+          </div>`}
+        </div>
       </div>
+
+      ${(remoteTotal > 0 || remoteError) && html`
+        <div class="fleet-section" data-testid="fleet-remotes-section">
+          <div class="fleet-section-head">
+            <span class="kicker">REMOTES</span>
+            <span class="sub-kicker">${remoteCounts.remotesOnline} online · ${remoteCounts.sessions} sessions</span>
+          </div>
+          ${remoteError
+            ? html`<div class="fleet-remote-error">${remoteError}</div>`
+            : html`<div class="fleet-grid">
+                ${remotes.map(remote => html`<${RemoteCard} key=${remote.name} remote=${remote}/>`)}
+              </div>`}
+        </div>
+      `}
 
       <div class="fleet-section">
         <div class="fleet-section-head">
           <span class="kicker">GROUPS</span>
-          <span class="sub-kicker">${groups.length} group${groups.length === 1 ? '' : 's'} · ${sessions.length} session${sessions.length === 1 ? '' : 's'}</span>
+          <span class="sub-kicker">${groups.length} group${groups.length === 1 ? '' : 's'} · ${sessions.length} local session${sessions.length === 1 ? '' : 's'}</span>
         </div>
         ${groups.length === 0 || sessions.length === 0
           ? html`<div style="font-family: var(--mono); font-size: 11px; color: var(--muted); padding: 16px;">

--- a/tests/web/e2e/fleet-pane.spec.js
+++ b/tests/web/e2e/fleet-pane.spec.js
@@ -113,4 +113,37 @@ test.describe('fleet pane', () => {
     await expect(page.locator('[data-testid="fleet-stat-running"] .num')).toHaveText('1')
     await expect(page.locator('[data-testid="fleet-stat-sessions"] .num')).toHaveText('4')
   })
+
+  test('configured remotes render alongside local groups', async ({ page }) => {
+    await page.route('**/api/remotes', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        observedAt: '2026-08-05T12:00:00Z',
+        counts: {
+          remotesOnline: 1, remotesOffline: 1, sessions: 2,
+          running: 1, waiting: 1, idle: 0, error: 0, stopped: 0,
+        },
+        remotes: [
+          {
+            name: 'build', online: true, latencyMs: 24,
+            sessions: [
+              { id: 'remote-1', title: 'release', path: '/srv/release', tool: 'codex', status: 'running' },
+              { id: 'remote-2', title: 'review', path: '/srv/review', tool: 'claude', status: 'waiting' },
+            ],
+          },
+          { name: 'offline', online: false, issue: 'unavailable', sessions: [] },
+        ],
+      }),
+    }))
+
+    await page.goto('/')
+    await expect(page.locator('[data-testid="fleet-remote-card"]')).toHaveCount(2)
+    await expect(page.locator('[data-testid="fleet-remote-card"][data-remote-name="build"]'))
+      .toContainText('24ms')
+    await expect(page.locator('[data-testid="fleet-remote-session-tile"]')).toHaveCount(2)
+    await expect(page.locator('[data-testid="fleet-stat-remotes"]')).toHaveText('1/2 remotes online')
+    await expect(page.locator('[data-testid="fleet-stat-sessions"] .num')).toHaveText('6')
+    await expect(page.locator('[data-testid="fleet-group-card"]')).toHaveCount(3)
+  })
 })

--- a/tests/web/e2e/fleet-pane.spec.js
+++ b/tests/web/e2e/fleet-pane.spec.js
@@ -114,36 +114,17 @@ test.describe('fleet pane', () => {
     await expect(page.locator('[data-testid="fleet-stat-sessions"] .num')).toHaveText('4')
   })
 
-  test('configured remotes render alongside local groups', async ({ page }) => {
-    await page.route('**/api/remotes', route => route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        observedAt: '2026-08-05T12:00:00Z',
-        counts: {
-          remotesOnline: 1, remotesOffline: 1, sessions: 2,
-          running: 1, waiting: 1, idle: 0, error: 0, stopped: 0,
-        },
-        remotes: [
-          {
-            name: 'build', online: true, latencyMs: 24,
-            sessions: [
-              { id: 'remote-1', title: 'release', path: '/srv/release', tool: 'codex', status: 'running' },
-              { id: 'remote-2', title: 'review', path: '/srv/review', tool: 'claude', status: 'waiting' },
-            ],
-          },
-          { name: 'offline', online: false, issue: 'unavailable', sessions: [] },
-        ],
-      }),
-    }))
-
+  test('configured remotes render through the production API alongside local groups', async ({ page, request }) => {
+    await request.post('/__fixture/remotes')
     await page.goto('/')
     await expect(page.locator('[data-testid="fleet-remote-card"]')).toHaveCount(2)
     await expect(page.locator('[data-testid="fleet-remote-card"][data-remote-name="build"]'))
       .toContainText('24ms')
-    await expect(page.locator('[data-testid="fleet-remote-session-tile"]')).toHaveCount(2)
+    await expect(page.locator('[data-testid="fleet-remote-session-tile"]')).toHaveCount(3)
+    await expect(page.locator('[data-testid="fleet-remote-card"][data-remote-name="offline"]')).toContainText('last-known')
+    await expect(page.locator('[data-testid="fleet-remote-age"]')).toHaveText('Last known state · 37s ago')
     await expect(page.locator('[data-testid="fleet-stat-remotes"]')).toHaveText('1/2 remotes online')
-    await expect(page.locator('[data-testid="fleet-stat-sessions"] .num')).toHaveText('6')
+    await expect(page.locator('[data-testid="fleet-stat-sessions"] .num')).toHaveText('7')
     await expect(page.locator('[data-testid="fleet-group-card"]')).toHaveCount(3)
   })
 })

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -70,6 +70,7 @@ func main() {
 		TrustedDomains:  session.NormalizeTrustedDomains(splitCSV(*trustedDomains)),
 		ConfirmLinkOpen: confirmLinkOpen,
 		MenuData:        store,
+		RemoteFleet:     store,
 	})
 	server.SetMutator(store)
 	// Hold the MCP manager on the store so /__fixture/reset clears its
@@ -125,20 +126,45 @@ func main() {
 	_ = server.Shutdown(ctx)
 }
 
+func (s *fixtureStore) Start(context.Context) {}
+
+func (s *fixtureStore) Snapshot() session.RemoteFleetSnapshot {
+	s.mu.Lock()
+	enabled := s.remotesEnabled
+	s.mu.Unlock()
+	if !enabled {
+		return session.RemoteFleetSnapshot{Remotes: []session.RemoteFleetRemote{}}
+	}
+	return session.RemoteFleetSnapshot{
+		ObservedAt: time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC),
+		Counts:     session.RemoteFleetCounts{RemotesOnline: 1, RemotesOffline: 1, Sessions: 3, Running: 1, Waiting: 1, Idle: 1},
+		Remotes: []session.RemoteFleetRemote{
+			{Name: "build", Online: true, LatencyMS: 24, Sessions: []session.RemoteSessionInfo{
+				{ID: "remote-1", Title: "release", Path: "/srv/release", Tool: "codex", Status: "running"},
+				{ID: "remote-2", Title: "review", Path: "/srv/review", Tool: "claude", Status: "waiting"},
+			}},
+			{Name: "offline", Issue: "unavailable", Stale: true, AgeSeconds: 37, Sessions: []session.RemoteSessionInfo{
+				{ID: "remote-stale", Title: "last-known", Tool: "codex", Status: "idle"},
+			}},
+		},
+	}
+}
+
 // fixtureStore implements both web.MenuDataLoader and web.SessionMutator
 // against in-memory state. All operations are concurrency-safe.
 type fixtureStore struct {
-	mu           sync.Mutex
-	now          func() time.Time
-	profile      string
-	groups       map[string]*web.MenuGroup // keyed by path
-	sessions     map[string]*web.MenuSession
-	order        []string // session id order
-	nextID       int
-	startupToken string // echoed at /__fixture/whoami for spawn verification
-	catalog      []session.SkillCandidate
-	attached     map[string][]session.ProjectSkillAttachment // by projectPath
-	mcpMgr       *fixtureMCPManager                          // reset alongside the store on /__fixture/reset
+	mu             sync.Mutex
+	now            func() time.Time
+	profile        string
+	groups         map[string]*web.MenuGroup // keyed by path
+	sessions       map[string]*web.MenuSession
+	order          []string // session id order
+	nextID         int
+	startupToken   string // echoed at /__fixture/whoami for spawn verification
+	catalog        []session.SkillCandidate
+	attached       map[string][]session.ProjectSkillAttachment // by projectPath
+	mcpMgr         *fixtureMCPManager                          // reset alongside the store on /__fixture/reset
+	remotesEnabled bool
 
 	// undoStack tracks recently-deleted sessions for ctrl+z undo. Capped
 	// at 10 entries (FIFO eviction) to match the TUI Home.undoStack.
@@ -167,6 +193,7 @@ func newFixtureStore() *fixtureStore {
 func (s *fixtureStore) seed() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.remotesEnabled = false
 	s.groups = map[string]*web.MenuGroup{
 		"work":           {Name: "work", Path: "work", Expanded: true, Order: 0, SessionCount: 2},
 		"work/innotrade": {Name: "innotrade", Path: "work/innotrade", Expanded: true, Order: 1, SessionCount: 1},
@@ -613,6 +640,16 @@ func (s *fixtureStore) adminHandler() http.Handler {
 		snap, _ := s.LoadMenuSnapshot()
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(snap)
+	})
+	mux.HandleFunc("/__fixture/remotes", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		s.mu.Lock()
+		s.remotesEnabled = true
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
 	})
 	mux.HandleFunc("/__fixture/session/", func(w http.ResponseWriter, r *http.Request) {
 		// /__fixture/session/{id}/status?to=active


### PR DESCRIPTION
## Summary

Builds on #1869 by @mdrzn and preserves the contributor's original commits and authorship while completing the maintainer security and browser gates.

## Hardened in this successor

- moves remote SSH refreshes out of authenticated request handling and into one server-lifecycle-owned background scanner
- bounds concurrent remote work to four workers
- isolates cancellation from individual HTTP requests and ties it to server shutdown
- applies independent exponential failure backoff per remote
- retains last-known sessions after refresh failures and shows their age in Fleet
- keeps `/api/remotes` behind the existing web authorization model and limits the handler to in-memory snapshot reads
- replaces the intercepted browser mock with production-route Playwright coverage
- preserves the no-remotes rendering so existing visual baselines and performance budgets do not regress

## Validation

Sandboxed with `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME=`:

- `go test ./internal/session -run TestRemoteFleet -count=1`
- `go test ./internal/web -run TestRemotesAPI -count=1`
- `go build ./...`
- `go vet ./...`
- web unit suite: 131 passed
- focused Fleet Playwright: 18 passed across desktop, tablet, and phone
- full Playwright suite: 595 passed, 107 expected viewport skips
- visual baselines: 9 passed
- Lighthouse: five collection runs; all absolute assertions passed

Fixes #1859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a remote fleet view showing configured remotes, availability, latency, session counts, and last-known state.
- Added the `/api/remotes` endpoint with authorization and snapshot-based responses.
- Combined local and remote session statistics in the fleet dashboard.
- Remote failures retain stale results while clearly indicating offline status.

## Bug Fixes
- Improved resilience with bounded concurrency, timeouts, retries, and failure backoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->