### PR TITLE
fix(ui): give the remote cost fetch its own timeout budget

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3304,7 +3304,12 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			for i := range sessions {
 				sessions[i].RemoteName = name
 			}
-			summary, costErr := runner.FetchCostSummary(ctx)
+			// #1912 follow-up: the session-list fetch may have consumed most
+			// of the shared budget on a slow remote, which silently dropped
+			// that remote's spend from the totals. Give costs their own bound.
+			costCtx, costCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+			summary, costErr := runner.FetchCostSummary(costCtx)
+			costCancel()
 
 			mu.Lock()
 			results[name] = sessions


### PR DESCRIPTION
FetchCostSummary reused the session-list fetch context, which on a slow remote is nearly expired by the time costs are requested — the cost call then times out and that remote's spend silently drops from the status-line totals. The cost fetch now gets its own context bounded by the same per-remote timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of remote cost-summary retrieval by giving it an independent timeout.
  * Session listing and cost-summary retrieval no longer interfere with each other’s timeout limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->