### PR TITLE
fix: show Hermes starting state after restart

### DIFF
--- a/internal/session/hermes_generation_test.go
+++ b/internal/session/hermes_generation_test.go
@@ -163,6 +163,37 @@ func TestHermesGenerationSeedRefreshesInMemoryBaseline(t *testing.T) {
 	}
 }
 
+func TestHermesRestartStartingHookOverridesStaleError(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	t.Setenv("HOME", t.TempDir())
+
+	// Use a harmless shell command to provide the live tmux session that
+	// UpdateStatus requires, then model the Hermes restart capture window.
+	inst := NewInstanceWithTool("hermes-restart-starting", t.TempDir(), "shell")
+	inst.Command = "sleep 30"
+	if err := inst.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = inst.Kill() }()
+
+	inst.mu.Lock()
+	inst.Tool = "hermes"
+	inst.Status = StatusError
+	inst.hookStatus = "dead"
+	inst.hookLastUpdate = time.Now()
+	inst.mu.Unlock()
+
+	if _, err := inst.seedHermesHookGeneration("starting", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := inst.UpdateStatus(); err != nil {
+		t.Fatal(err)
+	}
+	if inst.Status != StatusStarting {
+		t.Fatalf("restart status = %q, want %q", inst.Status, StatusStarting)
+	}
+}
+
 func TestHermesSeedClearsOppositeLayout(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	inst := &Instance{ID: "hermes-mode-change", Tool: "hermes"}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5276,6 +5276,8 @@ func (i *Instance) UpdateStatus() error {
 		i.hookStatus != "" &&
 		time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus) {
 		switch i.hookStatus {
+		case "starting":
+			i.Status = StatusStarting
 		case "running":
 			i.Status = StatusRunning
 			// Reset acknowledged: new activity means output not yet seen.


### PR DESCRIPTION
## What problem does this solve?

After restarting Hermes, the fresh synthetic `starting` hook baseline could leave the instance showing a stale error until the new Hermes session ID arrived, because the hook fast path did not map `starting`.

## Why this change

Treat a fresh `starting` hook exactly as the committed lifecycle state in `UpdateStatus`. The regression seeds the real generation-aware restart baseline, starts from a stale error, and verifies the live status becomes `starting` immediately.

## User impact

A restarted Hermes session shows starting during session-ID capture instead of retaining an error from the previous process.

## Evidence

- `HOME=<temp> XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test -v ./internal/session -run 'TestHermes(RestartStartingHookOverridesStaleError|GenerationSeedRefreshesInMemoryBaseline)$' -count=1`
- `HOME=<temp> XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go build ./...`
- `HOME=<temp> XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go vet ./...`
- Hot-path impact: one additional constant-time switch case; no I/O or polling added.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** GPT-5

**Prompt / session log (optional):**

## What actually bothered you

“The restart fast path ignores the newly seeded starting state, so Hermes can keep showing the old process's error during the session-ID capture window.”

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status handling during Hermes restarts.
  * Instances now correctly transition to “Starting” when a restart is detected, including when a previous error status is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->