### PR TITLE
invalidate stale Codex completion evidence

### DIFF
--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -35,6 +35,55 @@ func readStatusFileNoFollow(path string) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(f, maxHookStatusFileSize))
 }
 
+// consumeCodexCompletionEvidence clears a completed generation from the
+// durable hook record only when it still matches the generation observed by
+// the caller. The Codex notify writer uses the same sibling lock, so a newer
+// completion cannot be overwritten by a concurrent tmux status sample.
+func consumeCodexCompletionEvidence(instanceID, generation string) (retErr error) {
+	if strings.TrimSpace(instanceID) == "" || strings.TrimSpace(generation) == "" {
+		return nil
+	}
+	statusPath := hookStatusFilePath(instanceID)
+	lockPath := filepath.Join(filepath.Dir(statusPath), filepath.Base(instanceID)+".codex.lock")
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := lock.Close(); retErr == nil && err != nil {
+			retErr = err
+		}
+	}()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+
+	data, err := readStatusFileNoFollow(statusPath)
+	if err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var started, completed string
+	_ = json.Unmarshal(raw["codex_started_generation"], &started)
+	_ = json.Unmarshal(raw["codex_completed_generation"], &completed)
+	if started != generation || completed != generation {
+		return nil
+	}
+	delete(raw, "codex_started_generation")
+	delete(raw, "codex_completed_generation")
+	delete(raw, "codex_started_session_id")
+	delete(raw, "codex_completed_session_id")
+	updated, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(statusPath, updated, 0o600)
+}
+
 // HookStatus holds the decoded status from a hook status file.
 type HookStatus struct {
 	Status                   string    // running, idle, waiting, dead

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -39,39 +39,45 @@ func readStatusFileNoFollow(path string) ([]byte, error) {
 // durable hook record only when it still matches the generation observed by
 // the caller. The Codex notify writer uses the same sibling lock, so a newer
 // completion cannot be overwritten by a concurrent tmux status sample.
-func consumeCodexCompletionEvidence(instanceID, generation string) (retErr error) {
+func consumeCodexCompletionEvidence(instanceID, generation string) (consumed bool, retErr error) {
 	if strings.TrimSpace(instanceID) == "" || strings.TrimSpace(generation) == "" {
-		return nil
+		return false, nil
 	}
 	statusPath := hookStatusFilePath(instanceID)
 	lockPath := filepath.Join(filepath.Dir(statusPath), filepath.Base(instanceID)+".codex.lock")
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() {
 		if err := lock.Close(); retErr == nil && err != nil {
 			retErr = err
 		}
 	}()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		return err
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return false, nil
+		}
+		return false, err
 	}
 	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
 
 	data, err := readStatusFileNoFollow(statusPath)
 	if err != nil {
-		return err
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+		return false, err
 	}
 	var started, completed string
 	_ = json.Unmarshal(raw["codex_started_generation"], &started)
 	_ = json.Unmarshal(raw["codex_completed_generation"], &completed)
 	if started != generation || completed != generation {
-		return nil
+		return true, nil
 	}
 	delete(raw, "codex_started_generation")
 	delete(raw, "codex_completed_generation")
@@ -79,9 +85,12 @@ func consumeCodexCompletionEvidence(instanceID, generation string) (retErr error
 	delete(raw, "codex_completed_session_id")
 	updated, err := json.Marshal(raw)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return atomicWriteFile(statusPath, updated, 0o600)
+	if err := atomicWriteFile(statusPath, updated, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // HookStatus holds the decoded status from a hook status file.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5084,13 +5084,17 @@ func (i *Instance) invalidateCodexCompletionOnRunning() {
 		return
 	}
 	generation := i.codexCompletedGeneration
-	i.codexStartedGeneration, i.codexCompletedGeneration = "", ""
-	i.codexStartedSessionID, i.codexCompletedSessionID = "", ""
-	if err := consumeCodexCompletionEvidence(i.ID, generation); err != nil && !os.IsNotExist(err) {
+	consumed, err := consumeCodexCompletionEvidence(i.ID, generation)
+	if err != nil {
 		sessionLog.Debug("consume_codex_completion_evidence_failed",
 			slog.String("instance", i.ID),
 			slog.String("error", err.Error()),
 		)
+		return
+	}
+	if consumed {
+		i.codexStartedGeneration, i.codexCompletedGeneration = "", ""
+		i.codexStartedSessionID, i.codexCompletedSessionID = "", ""
 	}
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5073,6 +5073,27 @@ func (i *Instance) shouldBypassCodexWaitingDebounce(derived Status) bool {
 	return derived == StatusWaiting && i.codexCompletionConverged()
 }
 
+// invalidateCodexCompletionOnRunning makes completion-only proof one-turn
+// evidence. Once tmux authoritatively observes newer running activity, turn
+// A's completion must not let a later transient waiting sample masquerade as
+// completion of turn B. Clear both the warm instance and the durable hook file
+// used by fresh CLI processes.
+func (i *Instance) invalidateCodexCompletionOnRunning() {
+	if !IsCodexCompatible(i.Tool) || i.codexStartedGeneration == "" ||
+		i.codexStartedGeneration != i.codexCompletedGeneration {
+		return
+	}
+	generation := i.codexCompletedGeneration
+	i.codexStartedGeneration, i.codexCompletedGeneration = "", ""
+	i.codexStartedSessionID, i.codexCompletedSessionID = "", ""
+	if err := consumeCodexCompletionEvidence(i.ID, generation); err != nil && !os.IsNotExist(err) {
+		sessionLog.Debug("consume_codex_completion_evidence_failed",
+			slog.String("instance", i.ID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
 // terminatedPaneStatus classifies a session whose tmux pane/session has
 // vanished (or gone dead under remain-on-exit) AFTER having been started.
 //
@@ -5495,6 +5516,9 @@ func (i *Instance) UpdateStatus() error {
 		i.applyTerminatedPaneStatus()
 	default:
 		i.Status = StatusError
+	}
+	if i.Status == StatusRunning {
+		i.invalidateCodexCompletionOnRunning()
 	}
 
 	// Reconcile the auth hold with this sample. Runs after the status mapping so

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -183,6 +184,28 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 	}
 
 	// Turn B has no start hook; tmux is the authoritative newer-running edge.
+	// If the notify writer currently owns the lock, invalidation must return
+	// without blocking and retain the generation so the next running sample can
+	// retry the durable consume.
+	lockPath := filepath.Join(GetHooksDir(), instanceID+".codex.lock")
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	i.invalidateCodexCompletionOnRunning()
+	if !i.codexCompletionConverged() {
+		t.Fatal("contended durable consume discarded the in-memory retry generation")
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatal(err)
+	}
+
 	i.invalidateCodexCompletionOnRunning()
 	if i.codexCompletionConverged() {
 		t.Fatal("stale turn A evidence converged after turn B started")

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -1,6 +1,12 @@
 package session
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestShouldDebounceTmuxFlipForTool(t *testing.T) {
 	tests := map[string]bool{
@@ -139,6 +145,55 @@ func TestSetCodexGenerationEvidence_EvidenceLessDoesNotErase(t *testing.T) {
 	if i.codexStartedGeneration != "g" || i.codexCompletedGeneration != "g" ||
 		i.codexStartedSessionID != "s" || i.codexCompletedSessionID != "s" {
 		t.Fatalf("evidence-less update erased valid evidence: %#v", i)
+	}
+}
+
+func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	instanceID := "codex-next-turn"
+	sessionID := "thread-1"
+	generation := sessionID + ":turn-a"
+	path := filepath.Join(GetHooksDir(), instanceID+".json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	record := map[string]any{
+		"status":                     "waiting",
+		"session_id":                 sessionID,
+		"event":                      "agent-turn-complete",
+		"ts":                         time.Now().Unix(),
+		"codex_started_generation":   generation,
+		"codex_completed_generation": generation,
+		"codex_started_session_id":   sessionID,
+		"codex_completed_session_id": sessionID,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	i := &Instance{ID: instanceID, Tool: "codex", CodexSessionID: sessionID,
+		codexStartedGeneration: generation, codexCompletedGeneration: generation,
+		codexStartedSessionID: sessionID, codexCompletedSessionID: sessionID}
+	if !i.codexCompletionConverged() {
+		t.Fatal("completed turn A must initially converge")
+	}
+
+	// Turn B has no start hook; tmux is the authoritative newer-running edge.
+	i.invalidateCodexCompletionOnRunning()
+	if i.codexCompletionConverged() {
+		t.Fatal("stale turn A evidence converged after turn B started")
+	}
+	got := readHookStatusFile(instanceID)
+	if got == nil {
+		t.Fatal("hook status record disappeared")
+	}
+	if got.CodexStartedGeneration != "" || got.CodexCompletedGeneration != "" ||
+		got.CodexStartedSessionID != "" || got.CodexCompletedSessionID != "" {
+		t.Fatalf("durable stale completion evidence was not consumed: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## What problem does this solve?

After a Codex turn completed, its completion-only generation proof remained durable while a later turn was running. A transient waiting sample during that later turn could therefore reuse the old proof and bypass the running-to-waiting debounce. This follows up on #1908.

## Why this change

Codex's legacy notify stream has no start event, so tmux's active status is the authoritative signal that a newer turn has begun. When that signal arrives, agent-deck now consumes the matching completion proof in memory and in the hook file. The update uses the notify writer's lock and compares the expected generation before rewriting, so it cannot erase a different concurrent completion.

## User impact

A completed turn can still converge immediately, but its evidence cannot falsely complete a later active Codex turn.

## Evidence

- `go build ./...` passes with an isolated HOME/XDG environment.
- `go vet ./...` passes with an isolated HOME/XDG environment.
- Full `go test ./internal/session` passes with an isolated HOME/XDG environment.
- Regression coverage verifies: complete turn A, converge, observe turn B running, then stale A evidence no longer converges in memory or from disk.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol

**Prompt / session log (optional):** Not included.

## What actually bothered you

My human asked: "completion-only evidence is not invalidated when a subsequent turn starts running" and requested a regression covering completed turn A followed by active turn B.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5.6-sol intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented completion evidence from a previous turn from affecting the classification of later session states.
  * Ensured persisted completion data is cleared when a new running turn begins.
  * Added validation and atomic updates when processing completion evidence.

* **Tests**
  * Added coverage verifying completion evidence is invalidated and removed after a subsequent running turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->