### PR TITLE
fix(web): close remote scanner lifecycle gaps

### DIFF
--- a/internal/session/remote_fleet.go
+++ b/internal/session/remote_fleet.go
@@ -239,6 +239,10 @@ func (s *RemoteFleetScanner) scanRemote(ctx context.Context, name string, config
 		if backoff > maxBackoff {
 			backoff = maxBackoff
 		}
+		completedAt := time.Now().UTC()
+		if s.now != nil {
+			completedAt = s.now().UTC()
+		}
 		remote := RemoteFleetRemote{Name: name, Issue: "unavailable", Sessions: make([]RemoteSessionInfo, 0), ObservedAt: observedAt}
 		if hadPrior {
 			remote = prior.remote
@@ -246,7 +250,7 @@ func (s *RemoteFleetScanner) scanRemote(ctx context.Context, name string, config
 			remote.Issue = "unavailable"
 			remote.Stale = true
 		}
-		return remoteFleetState{remote: remote, backoff: backoff, nextAttempt: observedAt.Add(backoff)}
+		return remoteFleetState{remote: remote, backoff: backoff, nextAttempt: completedAt.Add(backoff)}
 	}
 	for i := range sessions {
 		sessions[i].RemoteName = name

--- a/internal/session/remote_fleet_test.go
+++ b/internal/session/remote_fleet_test.go
@@ -160,11 +160,15 @@ func TestRemoteFleetScannerBoundsConcurrencyAndHonorsLifecycleCancellation(t *te
 }
 
 type sequenceFleetRunner struct {
-	mu    *sync.Mutex
-	calls *int
+	mu      *sync.Mutex
+	calls   *int
+	onFetch func()
 }
 
 func (f sequenceFleetRunner) FetchSessions(context.Context) ([]RemoteSessionInfo, error) {
+	if f.onFetch != nil {
+		f.onFetch()
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	*f.calls++
@@ -172,6 +176,33 @@ func (f sequenceFleetRunner) FetchSessions(context.Context) ([]RemoteSessionInfo
 		return nil, errors.New("offline")
 	}
 	return []RemoteSessionInfo{{ID: "kept", Status: "waiting"}}, nil
+}
+
+func TestRemoteFleetScannerStartsFailureBackoffAfterScanCompletes(t *testing.T) {
+	scanner := NewRemoteFleetScanner()
+	startedAt := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	current := startedAt
+	scanner.now = func() time.Time { return current }
+	scanner.loadConfig = func() (*UserConfig, error) {
+		return &UserConfig{Remotes: map[string]RemoteConfig{"slow": {Host: "slow"}}}, nil
+	}
+	var mu sync.Mutex
+	calls := 1 // sequence runner fails when calls advances above one
+	scanner.newRunner = func(string, RemoteConfig) remoteFleetRunner {
+		return sequenceFleetRunner{
+			mu: &mu, calls: &calls,
+			onFetch: func() { current = current.Add(10 * time.Second) },
+		}
+	}
+
+	scanner.refreshOnce(context.Background())
+	scanner.mu.RLock()
+	state := scanner.states["slow"]
+	scanner.mu.RUnlock()
+	want := startedAt.Add(10*time.Second + defaultRemoteFleetRefresh)
+	if !state.nextAttempt.Equal(want) {
+		t.Fatalf("next attempt = %v, want scan completion + backoff = %v", state.nextAttempt, want)
+	}
 }
 
 func (sequenceFleetRunner) MeasureLatency(context.Context) (time.Duration, error) { return 0, nil }

--- a/internal/web/handlers_remotes_test.go
+++ b/internal/web/handlers_remotes_test.go
@@ -3,9 +3,11 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -66,4 +68,30 @@ func TestRemotesAPIOnlyReadsSnapshot(t *testing.T) {
 	}
 	// The loader has no request-aware method: this test protects the security
 	// boundary that authenticated requests cannot initiate background work.
+}
+
+func TestServerStartCancelsRemoteFleetWhenListenFails(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer listener.Close()
+
+	started := make(chan context.Context, 1)
+	loader := &fakeRemoteFleetLoader{started: started}
+	srv := NewServer(Config{ListenAddr: listener.Addr().String(), RemoteFleet: loader})
+	if err := srv.Start(); err == nil {
+		t.Fatal("Start succeeded with occupied listen address")
+	}
+
+	select {
+	case scannerCtx := <-started:
+		select {
+		case <-scannerCtx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("remote fleet context was not canceled after listen failure")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("remote fleet did not start")
+	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -349,6 +349,9 @@ func (s *Server) Start() error {
 		s.hookWatcher = nil
 	}
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if s.cancelBase != nil {
+			s.cancelBase()
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
## What problem does this solve?

Two P2 follow-ups on #1915 remained after merge:

1. a slow failed SSH scan could consume its retry delay because `nextAttempt` was based on scan start time;
2. a web bind failure returned without canceling the already-started remote scanner context.

## Why this change

The retry deadline is now based on the scanner clock after `FetchSessions` returns, so every failed attempt receives the full backoff interval. The non-graceful `ListenAndServe` error path now cancels the server base context before returning, stopping background scanner work when no server is listening.

Each behavior has a focused regression test: one advances the injected clock during a failed scan, and one occupies the configured port and observes scanner-context cancellation.

## User impact

Unreachable remotes cannot be retried immediately after a slow timeout, and failed web startup no longer leaves orphaned SSH polling behind.

## Validation

Sandboxed with `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME=`:

- focused remote scanner tests passed
- focused remote web/server tests passed
- `go build ./...` passed
- `go vet ./...` passed
- web unit suite: 131 passed
- full Playwright suite: 595 passed, 107 expected viewport skips

## What actually bothered you

The maintainer asked to fix two concrete P2 lifecycle defects found after #1915 merged, without expanding into unrelated review cleanup.

## Checklist

- [x] Both reported P2s verified on current `main`
- [x] One regression test per defect
- [x] No unrelated review findings included
- [x] Sandboxed build, vet, focused tests, and web suites pass
