### PR TITLE
fix Codex completion invalidation lock safety follow-up

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -226,12 +226,23 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 		return
 	}
 	base := filepath.Base(instanceID)
-	lock, err := os.OpenFile(filepath.Join(hooksDir, base+".codex.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	// This lock serializes notify writers only. It is intentionally distinct
+	// from the host-owned consumption lock: a sandbox may control this scoped
+	// directory, so host lifecycle code must never wait on it.
+	lock, err := os.OpenFile(filepath.Join(hooksDir, base+".codex-writer.lock"), os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return
 	}
 	defer closeChecked(lock)
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+	locked := false
+	for attempt := 0; attempt < 20; attempt++ {
+		if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+			locked = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !locked {
 		return
 	}
 	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) //nolint:errcheck

--- a/cmd/agent-deck/codex_hooks_cmd_test.go
+++ b/cmd/agent-deck/codex_hooks_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -329,6 +330,33 @@ func TestWriteCodexHookStatus_ConcurrentFleetPersistence(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCleanStaleHookFilesPreservesCodexWriterLockForLiveStatus(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(getHooksDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	instanceID := "codex-live-writer"
+	statusPath := filepath.Join(getHooksDir(), instanceID+".json")
+	lockPath := filepath.Join(getHooksDir(), instanceID+".codex-writer.lock")
+	if err := os.WriteFile(statusPath, []byte(`{"status":"running"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeChecked(lock)
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(lockPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanStaleHookFiles()
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("writer lock for live status was reaped: %v", err)
 	}
 }
 

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -554,7 +554,7 @@ func cleanStaleHookFiles() {
 		if strings.HasSuffix(entry.Name(), ".generation.json") {
 			continue // generation controls are never age-reaped
 		}
-		if strings.HasSuffix(entry.Name(), ".lock") && !strings.HasSuffix(entry.Name(), ".codex.lock") {
+		if strings.HasSuffix(entry.Name(), ".lock") {
 			info, err := entry.Info()
 			if err != nil || !info.ModTime().Before(cutoff) {
 				continue
@@ -579,7 +579,7 @@ func cleanStaleHookFiles() {
 			continue
 		}
 		ext := filepath.Ext(entry.Name())
-		if entry.IsDir() || (ext != ".json" && ext != ".sid" && !strings.HasSuffix(entry.Name(), ".codex.lock")) {
+		if entry.IsDir() || (ext != ".json" && ext != ".sid") {
 			continue
 		}
 		info, err := entry.Info()

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -560,6 +560,9 @@ func cleanStaleHookFiles() {
 				continue
 			}
 			id := strings.TrimSuffix(entry.Name(), ".lock")
+			if strings.HasSuffix(entry.Name(), ".codex-writer.lock") {
+				id = strings.TrimSuffix(entry.Name(), ".codex-writer.lock")
+			}
 			if _, err := os.Stat(filepath.Join(hooksDir, id+".json")); err == nil {
 				continue
 			}

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -2,8 +2,10 @@ package session
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -89,17 +91,26 @@ func consumeCodexCompletionEvidence(instanceID, generation string) (consumed boo
 	if err != nil {
 		return false, err
 	}
-	if err := atomicWriteFile(filepath.Join(root, base+".json"), updated, 0o600); err != nil {
+	generationDir := filepath.Join(root, base)
+	if err := os.MkdirAll(generationDir, 0o700); err != nil {
+		return false, err
+	}
+	if err := atomicWriteFile(codexConsumedGenerationPath(instanceID, generation), updated, 0o600); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func codexConsumedGenerationPath(instanceID, generation string) string {
+	digest := sha256.Sum256([]byte(generation))
+	return filepath.Join(GetHooksDir(), ".codex-consumed", filepath.Base(instanceID), fmt.Sprintf("%x.json", digest))
 }
 
 func codexCompletionEvidenceConsumed(instanceID, generation string) bool {
 	if strings.TrimSpace(instanceID) == "" || strings.TrimSpace(generation) == "" {
 		return false
 	}
-	path := filepath.Join(GetHooksDir(), ".codex-consumed", filepath.Base(instanceID)+".json")
+	path := codexConsumedGenerationPath(instanceID, generation)
 	data, err := readStatusFileNoFollow(path)
 	if err != nil {
 		return false
@@ -532,8 +543,18 @@ func (w *StatusFileWatcher) Stop() {
 // GetHookStatus returns the hook status for an instance, or nil if not available.
 func (w *StatusFileWatcher) GetHookStatus(instanceID string) *HookStatus {
 	w.mu.RLock()
-	defer w.mu.RUnlock()
-	return w.statuses[instanceID]
+	status := w.statuses[instanceID]
+	if status == nil {
+		w.mu.RUnlock()
+		return nil
+	}
+	copy := *status
+	w.mu.RUnlock()
+	// Consumption writes do not touch the sandbox-owned hook JSON and therefore
+	// do not produce an fsnotify event. Re-mask a copy on every retrieval so a
+	// cached completed generation cannot be fed back into an Instance.
+	maskConsumedCodexCompletion(instanceID, &copy)
+	return &copy
 }
 
 // ClearHookStatus removes the cached hook status for an instance.

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -22,6 +22,11 @@ var hookLog = logging.ForComponent(logging.CompSession)
 
 const maxHookStatusFileSize = 64 << 10 // status files are a few hundred bytes
 
+const (
+	codexConsumeLockAttempts = 4
+	codexConsumeLockDelay    = 5 * time.Millisecond
+)
+
 // readStatusFileNoFollow reads a hook status file without following a
 // final-component symlink (O_NOFOLLOW) and bounded in size, so a compromised
 // sandbox cannot symlink <id>.json at a sibling/host/device file to exfiltrate
@@ -35,16 +40,22 @@ func readStatusFileNoFollow(path string) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(f, maxHookStatusFileSize))
 }
 
-// consumeCodexCompletionEvidence clears a completed generation from the
-// durable hook record only when it still matches the generation observed by
-// the caller. The Codex notify writer uses the same sibling lock, so a newer
-// completion cannot be overwritten by a concurrent tmux status sample.
+// consumeCodexCompletionEvidence durably records a completed generation as
+// consumed. Both this record and its lock live under the host-owned hooks root,
+// outside the per-instance directory mounted writable into a sandbox. Readers
+// mask a matching generation, leaving a concurrently-written newer generation
+// intact. Lock acquisition is bounded so status refresh can never be held
+// hostage by another process.
 func consumeCodexCompletionEvidence(instanceID, generation string) (consumed bool, retErr error) {
 	if strings.TrimSpace(instanceID) == "" || strings.TrimSpace(generation) == "" {
 		return false, nil
 	}
-	statusPath := hookStatusFilePath(instanceID)
-	lockPath := filepath.Join(filepath.Dir(statusPath), filepath.Base(instanceID)+".codex.lock")
+	root := filepath.Join(GetHooksDir(), ".codex-consumed")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return false, err
+	}
+	base := filepath.Base(instanceID)
+	lockPath := filepath.Join(root, base+".lock")
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return false, err
@@ -54,43 +65,60 @@ func consumeCodexCompletionEvidence(instanceID, generation string) (consumed boo
 			retErr = err
 		}
 	}()
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		if errors.Is(err, syscall.EWOULDBLOCK) {
-			return false, nil
+	locked := false
+	for attempt := 0; attempt < codexConsumeLockAttempts; attempt++ {
+		err = syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			locked = true
+			break
 		}
-		return false, err
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return false, err
+		}
+		if attempt+1 < codexConsumeLockAttempts {
+			time.Sleep(codexConsumeLockDelay)
+		}
+	}
+	if !locked {
+		return false, nil
 	}
 	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
-
-	data, err := readStatusFileNoFollow(statusPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return true, nil
-		}
-		return false, err
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return false, err
-	}
-	var started, completed string
-	_ = json.Unmarshal(raw["codex_started_generation"], &started)
-	_ = json.Unmarshal(raw["codex_completed_generation"], &completed)
-	if started != generation || completed != generation {
-		return true, nil
-	}
-	delete(raw, "codex_started_generation")
-	delete(raw, "codex_completed_generation")
-	delete(raw, "codex_started_session_id")
-	delete(raw, "codex_completed_session_id")
-	updated, err := json.Marshal(raw)
+	updated, err := json.Marshal(struct {
+		Generation string `json:"generation"`
+	}{Generation: generation})
 	if err != nil {
 		return false, err
 	}
-	if err := atomicWriteFile(statusPath, updated, 0o600); err != nil {
+	if err := atomicWriteFile(filepath.Join(root, base+".json"), updated, 0o600); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func codexCompletionEvidenceConsumed(instanceID, generation string) bool {
+	if strings.TrimSpace(instanceID) == "" || strings.TrimSpace(generation) == "" {
+		return false
+	}
+	path := filepath.Join(GetHooksDir(), ".codex-consumed", filepath.Base(instanceID)+".json")
+	data, err := readStatusFileNoFollow(path)
+	if err != nil {
+		return false
+	}
+	var record struct {
+		Generation string `json:"generation"`
+	}
+	return json.Unmarshal(data, &record) == nil && record.Generation == generation
+}
+
+func maskConsumedCodexCompletion(instanceID string, status *HookStatus) {
+	if status == nil || status.CodexStartedGeneration == "" ||
+		status.CodexStartedGeneration != status.CodexCompletedGeneration ||
+		!codexCompletionEvidenceConsumed(instanceID, status.CodexStartedGeneration) {
+		return
+	}
+	status.CodexStartedGeneration, status.CodexCompletedGeneration = "", ""
+	status.CodexStartedSessionID, status.CodexCompletedSessionID = "", ""
+	status.codexCompletionConsumed = true
 }
 
 // HookStatus holds the decoded status from a hook status file.
@@ -105,6 +133,7 @@ type HookStatus struct {
 	CodexCompletedSessionID  string
 	HookGeneration           string
 	Sequence                 uint64
+	codexCompletionConsumed  bool
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
 	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
@@ -466,7 +495,7 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 		if generation, authority := hookGenerationForInstance(instanceID); !hookGenerationRecordAccepted(raw.HookGeneration, generation, authority) {
 			continue
 		}
-		out[instanceID] = &HookStatus{
+		hookStatus := &HookStatus{
 			Status:                   raw.Status,
 			SessionID:                raw.SessionID,
 			Event:                    raw.Event,
@@ -482,6 +511,8 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			HookGeneration:           raw.HookGeneration,
 			Sequence:                 raw.Sequence,
 		}
+		maskConsumedCodexCompletion(instanceID, hookStatus)
+		out[instanceID] = hookStatus
 	}
 }
 
@@ -646,6 +677,7 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		HookGeneration:           status.HookGeneration,
 		Sequence:                 status.Sequence,
 	}
+	maskConsumedCodexCompletion(instanceID, hookStatus)
 
 	w.mu.Lock()
 	if prior := w.statuses[instanceID]; prior != nil && status.HookGeneration != "" && prior.HookGeneration == status.HookGeneration && status.Sequence <= prior.Sequence {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -485,14 +485,15 @@ type Instance struct {
 	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
-	hookStatus               string    // running, idle, waiting, dead (empty = no hook data)
-	hookEvent                string    // Hook event name that caused the last status (e.g. "PermissionRequest")
-	hookSessionID            string    // Session ID from hook payload
-	hookLastUpdate           time.Time // When hook status was last received
-	codexStartedGeneration   string
-	codexCompletedGeneration string
-	codexStartedSessionID    string
-	codexCompletedSessionID  string
+	hookStatus                  string    // running, idle, waiting, dead (empty = no hook data)
+	hookEvent                   string    // Hook event name that caused the last status (e.g. "PermissionRequest")
+	hookSessionID               string    // Session ID from hook payload
+	hookLastUpdate              time.Time // When hook status was last received
+	codexStartedGeneration      string
+	codexCompletedGeneration    string
+	codexStartedSessionID       string
+	codexCompletedSessionID     string
+	codexInvalidatingGeneration string
 
 	// Durable last-activity record (issue #1846). Unlike hookLastUpdate this
 	// survives ClearHookStatus and, via tool_data.last_activity_at, TUI
@@ -5045,6 +5046,11 @@ func (i *Instance) setCodexGenerationEvidence(status *HookStatus) {
 	if status == nil || !IsCodexCompatible(i.Tool) {
 		return
 	}
+	if status.codexCompletionConsumed {
+		i.codexStartedGeneration, i.codexCompletedGeneration = "", ""
+		i.codexStartedSessionID, i.codexCompletedSessionID = "", ""
+		return
+	}
 	if status.CodexStartedGeneration == "" && status.CodexCompletedGeneration == "" &&
 		status.CodexStartedSessionID == "" && status.CodexCompletedSessionID == "" {
 		return
@@ -5053,6 +5059,9 @@ func (i *Instance) setCodexGenerationEvidence(status *HookStatus) {
 	i.codexCompletedGeneration = strings.TrimSpace(status.CodexCompletedGeneration)
 	i.codexStartedSessionID = strings.TrimSpace(status.CodexStartedSessionID)
 	i.codexCompletedSessionID = strings.TrimSpace(status.CodexCompletedSessionID)
+	if i.codexInvalidatingGeneration != i.codexStartedGeneration {
+		i.codexInvalidatingGeneration = ""
+	}
 }
 
 // codexCompletionConverged is deliberately fail-closed. Only the same retained
@@ -5061,6 +5070,7 @@ func (i *Instance) setCodexGenerationEvidence(status *HookStatus) {
 // to the conservative running debounce.
 func (i *Instance) codexCompletionConverged() bool {
 	if !IsCodexCompatible(i.Tool) || i.codexStartedGeneration == "" ||
+		i.codexInvalidatingGeneration == i.codexStartedGeneration ||
 		i.codexStartedGeneration != i.codexCompletedGeneration ||
 		i.codexStartedSessionID == "" ||
 		i.codexStartedSessionID != i.codexCompletedSessionID {
@@ -5076,15 +5086,21 @@ func (i *Instance) shouldBypassCodexWaitingDebounce(derived Status) bool {
 // invalidateCodexCompletionOnRunning makes completion-only proof one-turn
 // evidence. Once tmux authoritatively observes newer running activity, turn
 // A's completion must not let a later transient waiting sample masquerade as
-// completion of turn B. Clear both the warm instance and the durable hook file
-// used by fresh CLI processes.
+// completion of turn B. Persist a host-owned consumption marker first, then
+// clear the warm instance only after that write succeeds.
+// Caller must hold i.mu. The method drops it around all durable coordination.
 func (i *Instance) invalidateCodexCompletionOnRunning() {
 	if !IsCodexCompatible(i.Tool) || i.codexStartedGeneration == "" ||
 		i.codexStartedGeneration != i.codexCompletedGeneration {
 		return
 	}
 	generation := i.codexCompletedGeneration
+	i.codexInvalidatingGeneration = generation
+	// The durable operation can briefly retry a non-blocking host lock and can
+	// perform filesystem I/O. Never expose Instance.mu across either operation.
+	i.mu.Unlock()
 	consumed, err := consumeCodexCompletionEvidence(i.ID, generation)
+	i.mu.Lock()
 	if err != nil {
 		sessionLog.Debug("consume_codex_completion_evidence_failed",
 			slog.String("instance", i.ID),
@@ -5093,8 +5109,13 @@ func (i *Instance) invalidateCodexCompletionOnRunning() {
 		return
 	}
 	if consumed {
-		i.codexStartedGeneration, i.codexCompletedGeneration = "", ""
-		i.codexStartedSessionID, i.codexCompletedSessionID = "", ""
+		if i.codexStartedGeneration == generation && i.codexCompletedGeneration == generation {
+			i.codexStartedGeneration, i.codexCompletedGeneration = "", ""
+			i.codexStartedSessionID, i.codexCompletedSessionID = "", ""
+		}
+		if i.codexInvalidatingGeneration == generation {
+			i.codexInvalidatingGeneration = ""
+		}
 	}
 }
 

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -184,10 +184,14 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 	}
 
 	// Turn B has no start hook; tmux is the authoritative newer-running edge.
-	// If the notify writer currently owns the lock, invalidation must return
-	// without blocking and retain the generation so the next running sample can
-	// retry the durable consume.
-	lockPath := filepath.Join(GetHooksDir(), instanceID+".codex.lock")
+	// Hold the host-only consumption lock and prove invalidation releases i.mu
+	// while its bounded retry runs. Contention suppresses convergence but keeps
+	// the generation in memory for the next running sample to retry.
+	consumedDir := filepath.Join(GetHooksDir(), ".codex-consumed")
+	if err := os.MkdirAll(consumedDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(consumedDir, instanceID+".lock")
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		t.Fatal(err)
@@ -195,9 +199,34 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
 		t.Fatal(err)
 	}
-	i.invalidateCodexCompletionOnRunning()
-	if !i.codexCompletionConverged() {
-		t.Fatal("contended durable consume discarded the in-memory retry generation")
+	i.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		i.invalidateCodexCompletionOnRunning()
+		i.mu.Unlock()
+		close(done)
+	}()
+	muLive := make(chan struct{})
+	go func() {
+		i.mu.Lock()
+		i.mu.Unlock()
+		close(muLive)
+	}()
+	select {
+	case <-muLive:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Instance.mu stayed blocked behind the held file lock")
+	}
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("bounded file-lock acquisition did not return")
+	}
+	if i.codexCompletionConverged() {
+		t.Fatal("contended consume must suppress stale completion convergence")
+	}
+	if i.codexStartedGeneration != generation || i.codexCompletedGeneration != generation {
+		t.Fatal("contended durable consume discarded the retry generation")
 	}
 	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
 		t.Fatal(err)
@@ -206,7 +235,9 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 		t.Fatal(err)
 	}
 
+	i.mu.Lock()
 	i.invalidateCodexCompletionOnRunning()
+	i.mu.Unlock()
 	if i.codexCompletionConverged() {
 		t.Fatal("stale turn A evidence converged after turn B started")
 	}
@@ -217,6 +248,37 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 	if got.CodexStartedGeneration != "" || got.CodexCompletedGeneration != "" ||
 		got.CodexStartedSessionID != "" || got.CodexCompletedSessionID != "" {
 		t.Fatalf("durable stale completion evidence was not consumed: %#v", got)
+	}
+}
+
+func TestCodexCompletionInvalidationRetriesAfterDurableWriteFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	instanceID, generation := "codex-retry", "thread-1:turn-a"
+	consumedPath := filepath.Join(GetHooksDir(), ".codex-consumed", instanceID+".json")
+	if err := os.MkdirAll(consumedPath, 0o700); err != nil { // force atomic rename failure
+		t.Fatal(err)
+	}
+	i := &Instance{ID: instanceID, Tool: "codex", CodexSessionID: "thread-1",
+		codexStartedGeneration: generation, codexCompletedGeneration: generation,
+		codexStartedSessionID: "thread-1", codexCompletedSessionID: "thread-1"}
+
+	i.mu.Lock()
+	i.invalidateCodexCompletionOnRunning()
+	i.mu.Unlock()
+	if i.codexStartedGeneration != generation || i.codexCompletedGeneration != generation {
+		t.Fatal("memory cleared before durable consume succeeded")
+	}
+	if i.codexCompletionConverged() {
+		t.Fatal("failed durable consume must remain in the safe, non-converged state")
+	}
+	if err := os.Remove(consumedPath); err != nil {
+		t.Fatal(err)
+	}
+	i.mu.Lock()
+	i.invalidateCodexCompletionOnRunning()
+	i.mu.Unlock()
+	if i.codexStartedGeneration != "" || i.codexCompletedGeneration != "" {
+		t.Fatal("retry did not clear memory after durable consume succeeded")
 	}
 }
 

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -250,12 +250,25 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 		got.CodexStartedSessionID != "" || got.CodexCompletedSessionID != "" {
 		t.Fatalf("durable stale completion evidence was not consumed: %#v", got)
 	}
+
+	// The watcher cached the unmasked hook record before consumption and sees
+	// no event when the host-only marker lands. Polling must re-mask that cached
+	// copy instead of rehydrating turn A into the warm Instance.
+	watcher := &StatusFileWatcher{statuses: map[string]*HookStatus{instanceID: {
+		Status: "waiting", SessionID: sessionID,
+		CodexStartedGeneration: generation, CodexCompletedGeneration: generation,
+		CodexStartedSessionID: sessionID, CodexCompletedSessionID: sessionID,
+	}}}
+	i.UpdateHookStatus(watcher.GetHookStatus(instanceID))
+	if i.codexCompletionConverged() {
+		t.Fatal("polling loop rehydrated consumed completion from watcher cache")
+	}
 }
 
 func TestCodexCompletionInvalidationRetriesAfterDurableWriteFailure(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	instanceID, generation := "codex-retry", "thread-1:turn-a"
-	consumedPath := filepath.Join(GetHooksDir(), ".codex-consumed", instanceID+".json")
+	consumedPath := codexConsumedGenerationPath(instanceID, generation)
 	if err := os.MkdirAll(consumedPath, 0o700); err != nil { // force atomic rename failure
 		t.Fatal(err)
 	}
@@ -280,6 +293,23 @@ func TestCodexCompletionInvalidationRetriesAfterDurableWriteFailure(t *testing.T
 	i.mu.Unlock()
 	if i.codexStartedGeneration != "" || i.codexCompletedGeneration != "" {
 		t.Fatal("retry did not clear memory after durable consume succeeded")
+	}
+}
+
+func TestCodexConsumedGenerationsCannotOverwriteEachOther(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	instanceID := "codex-ordered-consume"
+	newer := "thread-1:turn-b"
+	older := "thread-1:turn-a"
+	if consumed, err := consumeCodexCompletionEvidence(instanceID, newer); err != nil || !consumed {
+		t.Fatalf("consume newer generation: consumed=%v err=%v", consumed, err)
+	}
+	// Simulate a delayed process persisting stale A after B already landed.
+	if consumed, err := consumeCodexCompletionEvidence(instanceID, older); err != nil || !consumed {
+		t.Fatalf("consume older generation: consumed=%v err=%v", consumed, err)
+	}
+	if !codexCompletionEvidenceConsumed(instanceID, newer) || !codexCompletionEvidenceConsumed(instanceID, older) {
+		t.Fatal("delayed stale consume replaced another consumed generation")
 	}
 }
 

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -206,11 +206,12 @@ func TestCodexCompletionEvidenceInvalidatedBySubsequentRunningTurn(t *testing.T)
 		i.mu.Unlock()
 		close(done)
 	}()
-	muLive := make(chan struct{})
+	muLive := make(chan Status)
 	go func() {
 		i.mu.Lock()
+		status := i.Status
 		i.mu.Unlock()
-		close(muLive)
+		muLive <- status
 	}()
 	select {
 	case <-muLive:

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -769,7 +769,7 @@ func readHookStatusFile(instanceID string) *HookStatus {
 	if raw.Timestamp > 0 {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
-	return &HookStatus{
+	hookStatus := &HookStatus{
 		Status:                   raw.Status,
 		SessionID:                raw.SessionID,
 		Event:                    raw.Event,
@@ -785,6 +785,8 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		HookGeneration:           raw.HookGeneration,
 		Sequence:                 raw.Sequence,
 	}
+	maskConsumedCodexCompletion(instanceID, hookStatus)
+	return hookStatus
 }
 
 func (d *TransitionDaemon) emitHookTransitionCandidates(


### PR DESCRIPTION
## Summary

- move Codex completion consumption coordination into a host-owned directory outside sandbox-writable hook scopes
- use bounded non-blocking locking and release the instance mutex before durable filesystem work
- retain completion evidence for retry until durable consumption succeeds while suppressing stale convergence in memory
- mask consumed generations for fresh readers without overwriting concurrent newer hook generations

## Tests

- sandboxed focused Codex completion invalidation tests
- sandboxed `go build ./...`
- sandboxed `go vet ./...`
- sandboxed full suite: touched packages passed; unrelated existing timing tests failed under local load (cold-start performance, SQLite delete performance, websocket keepalive)
- regression tests fail on current main and pass with this change

Follow-up to #1919.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex completion status handling to prevent stale or already-consumed completions from appearing.
  * Added safer cleanup and bounded retry behavior when completion records are temporarily locked.
  * Preserved completion evidence when durable updates fail, enabling successful retry later.
  * Prevented status updates from blocking other session activity during lock contention.
* **Tests**
  * Expanded coverage for completion invalidation, lock contention, and retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->