### PR TITLE
test(session): pin that the cursor "agent" token cannot match agent-deck

### DIFF
--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -60,6 +60,13 @@ func TestRegistry_MatchAllBranches(t *testing.T) {
 		{"cursor agent subcommand", "cursor agent", "cursor"},
 		{"standalone agent binary", "agent", "cursor"},
 		{"standalone agent with flags", "agent --continue", "cursor"},
+		// The "agent" arm is a whitespace-token match for exactly this reason:
+		// as a substring it would swallow agent-deck's own commands and label
+		// every one of them a Cursor session. builtinTools says so in a comment;
+		// these cases are what stop a later change from folding "agent" back
+		// into detectSubstrings with every test still green.
+		{"cursor no false match in agent-deck", "agent-deck", "shell"},
+		{"cursor no false match in agent-deck subcommand", "agent-deck session send x", "shell"},
 		// hermes
 		{"hermes bare", "hermes", "hermes"},
 		// aider has NO detect arm — commands containing "aider" map to shell


### PR DESCRIPTION
## What problem does this solve?

#1890 added bare `agent` as a Cursor detect pattern, for the standalone Cursor Agent CLI. It was deliberately made a whitespace-token match rather than a substring, because as a substring it would swallow agent-deck's own commands and label every one of them a Cursor session. `builtinTools` records that reasoning in a comment — but nothing enforced it. Folding `agent` back into `detectSubstrings` would have left the entire suite green.

## Why this change

Two table cases that fail if that ever happens, mirroring the existing `epic` / `tapioca` pair that guards the `pi` token for exactly the same reason.

## Evidence

Temporarily making `agent` a substring instead of a token:

```
--- FAIL: TestRegistry_MatchAllBranches/cursor_no_false_match_in_agent-deck
    toolregistry_test.go:81: Match("agent-deck") = "cursor", want "shell"
--- FAIL: TestRegistry_MatchAllBranches/cursor_no_false_match_in_agent-deck_subcommand
    toolregistry_test.go:81: Match("agent-deck session send x") = "cursor", want "shell"
```

Restored, `go test ./internal/session/` passes (82s, full package).

## Scope

Test-only; no production change. Follow-up to the review nit on #1890 — credit to @MauriceDHanisch, whose comment in that PR is the reasoning being pinned here. Raised as a nit there and offered to send it myself rather than ask for another branch spin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session detection for `agent-deck` commands.
  * Prevented these commands from being incorrectly identified as Cursor sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->