### PR TITLE
fix(cli): reject an add flag whose value is the next flag (#1923)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -88,10 +88,17 @@ func checkFlagValueNotFlag(fs *flag.FlagSet, args []string) error {
 		if strings.Contains(name, "=") || boolFlags[name] || !known[name] {
 			continue
 		}
-		if i+1 >= len(args) {
-			continue // flag.Parse reports the missing value itself
+		// Read the following token, if there is one. Assigned inside the bounds
+		// check rather than after it so the indexing is locally provable — an
+		// `i+1 >= len(args)` guard followed by args[i+1] reads as an unchecked
+		// index to gosec (G602).
+		next := ""
+		if i+1 < len(args) {
+			next = args[i+1]
 		}
-		next := args[i+1]
+		if next == "" {
+			continue // nothing follows; flag.Parse reports the missing value
+		}
 		if !strings.HasPrefix(next, "-") || next == "-" {
 			i++ // ordinary value; skip it so it is not re-examined as a flag
 			continue

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -48,6 +48,65 @@ func tmuxProbeBounded(args ...string) ([]byte, error) {
 	return cmd.Output()
 }
 
+// checkFlagValueNotFlag reports a value-taking flag whose value was omitted and
+// which therefore swallows the NEXT flag as its value (issue #1923).
+//
+// Go's flag package takes the token after a non-boolean flag unconditionally —
+// it has no notion that the token is itself a flag — so `--account -q` binds
+// the string "-q" to --account and -q never takes effect. That is invisible
+// wherever the value is stored without validation: `add` records --account
+// "captured verbatim" and treats an unknown name as a silent fall-through, so
+// the session is created against the wrong account and only surfaces later as a
+// quota error on an account the user never chose.
+//
+// The check is deliberately narrow: it fires only when the consumed value
+// EXACTLY names a flag registered on this FlagSet. A value that merely starts
+// with "-" is left alone, because a legitimate value may (a path, a negative
+// number, a wrapper fragment); one that matches a real flag of this very
+// command effectively never is.
+//
+// Returns nil when args are fine, so callers can pass it straight through.
+func checkFlagValueNotFlag(fs *flag.FlagSet, args []string) error {
+	known := make(map[string]bool)
+	boolFlags := make(map[string]bool)
+	fs.VisitAll(func(f *flag.Flag) {
+		known[f.Name] = true
+		if bf, ok := f.Value.(interface{ IsBoolFlag() bool }); ok && bf.IsBoolFlag() {
+			boolFlags[f.Name] = true
+		}
+	})
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return nil // everything after this is positional
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			continue
+		}
+		name := strings.TrimLeft(arg, "-")
+		if strings.Contains(name, "=") || boolFlags[name] || !known[name] {
+			continue
+		}
+		if i+1 >= len(args) {
+			continue // flag.Parse reports the missing value itself
+		}
+		next := args[i+1]
+		if !strings.HasPrefix(next, "-") || next == "-" {
+			i++ // ordinary value; skip it so it is not re-examined as a flag
+			continue
+		}
+		if nextName := strings.TrimLeft(next, "-"); known[nextName] {
+			return fmt.Errorf(
+				"-%s needs a value, but the next argument is the flag %s.\n"+
+					"  Either give -%s its value, or move %s elsewhere.\n"+
+					"  (If %q really is the value you want, pass -%s=%s.)",
+				name, next, name, next, next, name, next)
+		}
+	}
+	return nil
+}
+
 // normalizeArgs reorders args so flags come before positional arguments.
 // Go's flag package stops parsing at the first non-flag argument, which means
 // "session show my-title --json" silently ignores --json. This function

--- a/cmd/agent-deck/issue1923_flag_value_test.go
+++ b/cmd/agent-deck/issue1923_flag_value_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// issue1923FlagSet mirrors the shape of `add`'s flags: a mix of value-taking
+// and boolean, including the short -q that the reported command used.
+func issue1923FlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("add", flag.ContinueOnError)
+	fs.String("account", "", "")
+	fs.String("t", "", "")
+	fs.String("wrapper", "", "")
+	fs.Bool("q", false, "")
+	fs.Bool("sandbox", false, "")
+	return fs
+}
+
+// The bug (#1923): with its value omitted, --account binds the FOLLOWING flag
+// as its value. Both effects are silent — the account is stored verbatim and
+// -q never takes effect.
+func TestIssue1923_FlagValueSwallowsNextFlag(t *testing.T) {
+	fs := issue1923FlagSet()
+	args := []string{"--account", "-q", "/path"}
+
+	// Establish that this is what the parser really does, so the guard below
+	// is pinned to observed behaviour rather than to an assumption about it.
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := fs.Lookup("account").Value.String(); got != "-q" {
+		t.Fatalf("precondition changed: account = %q, want %q", got, "-q")
+	}
+	if fs.Lookup("q").Value.String() != "false" {
+		t.Fatalf("precondition changed: -q should have been swallowed")
+	}
+
+	err := checkFlagValueNotFlag(issue1923FlagSet(), args)
+	if err == nil {
+		t.Fatal("checkFlagValueNotFlag accepted --account with the next flag as its value")
+	}
+	for _, want := range []string{"-account", "-q"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name %q so the user can see what to fix", err, want)
+		}
+	}
+}
+
+// The guard must not fire on correct usage, including the exact command from
+// the issue, which parses fine once --account has its value.
+func TestIssue1923_GuardAcceptsValidUsage(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"reported command with the value present", []string{"/p", "-t", "title", "--account", "work", "-q"}},
+		{"bool flags adjacent", []string{"-q", "--sandbox", "/p"}},
+		{"value that merely starts with a dash", []string{"--wrapper", "-custom-thing", "/p"}},
+		{"explicit = form is always the user's choice", []string{"--account=-q", "/p"}},
+		{"unknown flag is flag.Parse's business, not ours", []string{"--nope", "-q", "/p"}},
+		{"trailing flag with no next token", []string{"/p", "--account"}},
+		{"everything after -- is positional", []string{"--", "--account", "-q"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := checkFlagValueNotFlag(issue1923FlagSet(), tc.args); err != nil {
+				t.Errorf("rejected valid args %v: %v", tc.args, err)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1406,6 +1406,16 @@ func handleAdd(profile string, args []string) {
 	// This allows: "add . -c claude" to work same as "add -c claude ."
 	args = reorderArgsForFlagParsing(args)
 
+	// #1923: catch a value-taking flag that swallowed the next flag because its
+	// own value was omitted. Checked before Parse so the report names the real
+	// mistake — `add` stores --account verbatim and never rejects an unknown
+	// name, so without this the session is created against a bogus account and
+	// only surfaces later as a quota error the user cannot trace back to here.
+	if err := checkFlagValueNotFlag(fs, args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Closes #1923.

## What problem does this solve?

Go's `flag` package takes the token after a non-boolean flag unconditionally — it has no notion that the token is itself a flag. So `agent-deck add --account -q <path>` binds the string `-q` to `--account`, and `-q` never takes effect.

Both halves are silent. `add` stores `--account` verbatim and treats an unknown name as a fall-through rather than an error, so the session is created against an account the user never chose. It resurfaces later as a quota error against the wrong account, with nothing pointing back at the command that caused it.

## Why this shape

`checkFlagValueNotFlag` reports it before parsing, so the message names the real mistake rather than whatever downstream symptom appears first.

The check is deliberately narrow: it fires only when the consumed value **exactly names a flag registered on the same FlagSet**. A value that merely begins with `-` is left alone — a legitimate value may (a path, a negative number, a wrapper fragment) — while one that names a flag of this very command effectively never is. The error names both flags and points at `--flag=value` for anyone who genuinely wants a dash-leading value.

Scoped to `add`, which is where the report came from and where the failure is invisible. The helper is command-agnostic, but there are 83 `Parse` sites in this package and sweeping them all is a far larger blast radius than this fix warrants. Adopting it elsewhere is a separate change, and worth doing.

## A correction to the issue

The command as written in #1923 — with a value present after `--account` — parses correctly; I verified that before changing anything. The defect needs the value to be **omitted**. The test pins the real trigger, and also asserts the parser behaviour being guarded against, so the guard cannot drift from what it claims to prevent.

## Evidence

```
--- PASS: TestIssue1923_FlagValueSwallowsNextFlag
--- PASS: TestIssue1923_GuardAcceptsValidUsage/reported_command_with_the_value_present
--- PASS: TestIssue1923_GuardAcceptsValidUsage/value_that_merely_starts_with_a_dash
--- PASS: TestIssue1923_GuardAcceptsValidUsage/explicit_=_form_is_always_the_user's_choice
--- PASS: TestIssue1923_GuardAcceptsValidUsage/unknown_flag_is_flag.Parse's_business,_not_ours
--- PASS: TestIssue1923_GuardAcceptsValidUsage/trailing_flag_with_no_next_token
--- PASS: TestIssue1923_GuardAcceptsValidUsage/everything_after_--_is_positional
```

`go vet` and `go build ./...` clean. The full `cmd/agent-deck` package passes apart from `TestPerf_ColdStart_Help` / `_Version`, which fail identically on unmodified `main` on this host (75ms against a 40ms budget) — machine load, not this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line validation when a value-taking option is followed by another flag.
  - Added clear error messages identifying both the option missing a value and the unexpected flag.
  - Prevented malformed input from being used during session creation.
  - Preserved support for valid hyphen-prefixed values, inline assignments, boolean flags, positional arguments, and arguments after `--`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->