### PR TITLE
fix(codex): honour the account's codex home when launching (#1922)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2088,11 +2088,56 @@ func getCodexHomeDirForCommand(command string) string {
 	return getCodexHomeDir()
 }
 
+// accountCodexHomeDir returns the CODEX_HOME mapped to this session's account
+// slot via [profiles.<account>.codex].config_dir, or "" when the session has no
+// account or the account names no codex block.
+//
+// Mirrors the account level of resolveClaudeConfigDir (#924): the per-session
+// account is the most specific thing the user can say about which credentials a
+// session runs under, so it outranks the process-wide CODEX_HOME and the
+// profile/global config. An account with no matching block falls through
+// silently, matching the permissive style of the Claude chain.
+func (i *Instance) accountCodexHomeDir() string {
+	if i == nil || strings.TrimSpace(i.Account) == "" {
+		return ""
+	}
+	cfg, err := LoadUserConfig()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.GetProfileCodexConfigDir(i.Account)
+}
+
+// codexHomeToExport returns the CODEX_HOME this session must launch with, or ""
+// when nothing should be exported and codex may use its own default.
+//
+// Both codex launch paths (normal and fork) call this so they cannot drift: a
+// session that resolves its home one way and launches another is exactly the
+// #1922 failure — the account was recorded and reported, but the process ran
+// against ~/.codex.
+func (i *Instance) codexHomeToExport() string {
+	if accountHome := strings.TrimSpace(i.accountCodexHomeDir()); accountHome != "" {
+		return accountHome
+	}
+	if isCodexHomeExplicit() {
+		return strings.TrimSpace(getCodexHomeDir())
+	}
+	return ""
+}
+
 func (i *Instance) getCodexHomeDir() string {
 	if i == nil {
 		return getCodexHomeDir()
 	}
-	return getCodexHomeDirForCommand(i.resolveCodexCommand(i.Command))
+	// A CODEX_HOME= embedded in the session's own command is the user typing it
+	// by hand for this session, so it stays the most explicit signal of all.
+	if codexHome := codexHomeFromCommand(i.resolveCodexCommand(i.Command)); codexHome != "" {
+		return codexHome
+	}
+	if accountHome := i.accountCodexHomeDir(); accountHome != "" {
+		return accountHome
+	}
+	return getCodexHomeDir()
 }
 
 // Codex stores sessions in ~/.codex/sessions/YYYY/MM/DD/*.jsonl
@@ -2122,14 +2167,11 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	if i.Tool == "codex" && trimmed != "codex" && trimmed != "" {
 		return envPrefix + trimmed
 	}
-	if isCodexHomeExplicit() {
-		codexHome := strings.TrimSpace(getCodexHomeDir())
-		if codexHome != "" {
-			if err := os.MkdirAll(codexHome, 0o755); err != nil {
-				sessionLog.Warn("codex_home_mkdir_failed",
-					slog.String("path", codexHome),
-					slog.String("error", err.Error()))
-			}
+	if codexHome := i.codexHomeToExport(); codexHome != "" {
+		if err := os.MkdirAll(codexHome, 0o755); err != nil {
+			sessionLog.Warn("codex_home_mkdir_failed",
+				slog.String("path", codexHome),
+				slog.String("error", err.Error()))
 		}
 		envPrefix += "CODEX_HOME=" + codexHome + " "
 	}
@@ -9305,16 +9347,13 @@ func (i *Instance) buildCodexForkCommandForTarget(target *Instance, baseCommand 
 	modelFlag := target.resolveCodexModelFlag()
 	reasoningFlag := target.resolveCodexReasoningEffortFlag()
 	command := target.resolveCodexCommand(baseCommand)
-	if isCodexHomeExplicit() {
-		codexHome := strings.TrimSpace(getCodexHomeDir())
-		if codexHome != "" {
-			if err := os.MkdirAll(codexHome, 0o755); err != nil {
-				sessionLog.Warn("codex_home_mkdir_failed",
-					slog.String("path", codexHome),
-					slog.String("error", err.Error()))
-			}
-			envPrefix += "CODEX_HOME=" + shellescape.Quote(codexHome) + " "
+	if codexHome := target.codexHomeToExport(); codexHome != "" {
+		if err := os.MkdirAll(codexHome, 0o755); err != nil {
+			sessionLog.Warn("codex_home_mkdir_failed",
+				slog.String("path", codexHome),
+				slog.String("error", err.Error()))
 		}
+		envPrefix += "CODEX_HOME=" + shellescape.Quote(codexHome) + " "
 	}
 	return envPrefix + fmt.Sprintf("%s%s%s%s fork %s", command, yoloFlag, modelFlag, reasoningFlag, shellescape.Quote(i.CodexSessionID)), nil
 }

--- a/internal/session/issue1922_codex_account_home_test.go
+++ b/internal/session/issue1922_codex_account_home_test.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexAccountHome sets up an isolated HOME holding a config.toml that maps two
+// account slots to their own codex homes, plus a global [codex] config_dir to
+// prove the account outranks it.
+func codexAccountHome(t *testing.T) (workHome string) {
+	t.Helper()
+	tmp := withTempHome(t)
+	if err := os.MkdirAll(filepath.Join(tmp, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	workHome = filepath.Join(tmp, "codex-work")
+	cfg := &UserConfig{
+		Profiles: map[string]ProfileSettings{
+			"work": {Codex: ProfileCodexSettings{ConfigDir: workHome}},
+		},
+	}
+	cfg.Codex.ConfigDir = filepath.Join(tmp, "codex-global")
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	return workHome
+}
+
+// #1922: setting an account on a codex session recorded and reported the
+// account but never applied [profiles.<account>.codex].config_dir, so the
+// process launched against the default codex home. The mismatch surfaced only
+// as a quota error on an account the user never chose.
+func TestIssue1922_CodexAccountHomeIsExported(t *testing.T) {
+	workHome := codexAccountHome(t)
+
+	inst := &Instance{ID: "i1", Title: "t", Tool: "codex", Command: "codex", Account: "work"}
+
+	if got := inst.codexHomeToExport(); got != workHome {
+		t.Fatalf("codexHomeToExport() = %q, want the account's home %q", got, workHome)
+	}
+	if got := inst.getCodexHomeDir(); got != workHome {
+		t.Errorf("getCodexHomeDir() = %q, want %q — resolution and launch must agree", got, workHome)
+	}
+
+	cmd := inst.buildCodexCommand("codex")
+	if !strings.Contains(cmd, "CODEX_HOME="+workHome+" ") {
+		t.Errorf("launch command does not export the account's CODEX_HOME.\ngot: %s", cmd)
+	}
+}
+
+// An account naming no codex block must fall through silently rather than
+// exporting an empty CODEX_HOME, matching the permissive style of the Claude
+// account chain.
+func TestIssue1922_UnknownAccountFallsThrough(t *testing.T) {
+	codexAccountHome(t)
+
+	inst := &Instance{ID: "i2", Title: "t", Tool: "codex", Command: "codex", Account: "no-such-account"}
+
+	if got := inst.accountCodexHomeDir(); got != "" {
+		t.Errorf("accountCodexHomeDir() = %q, want \"\" for an account with no codex block", got)
+	}
+	cmd := inst.buildCodexCommand("codex")
+	if strings.Contains(cmd, "CODEX_HOME= ") {
+		t.Errorf("empty CODEX_HOME exported for an unmapped account.\ngot: %s", cmd)
+	}
+}
+
+// A CODEX_HOME the user embedded in this session's own command is the most
+// explicit statement there is and must still win over the account mapping.
+func TestIssue1922_CommandEmbeddedHomeBeatsAccount(t *testing.T) {
+	codexAccountHome(t)
+
+	explicit := "/tmp/explicit-codex-home"
+	inst := &Instance{
+		ID: "i3", Title: "t", Tool: "codex",
+		Command: "CODEX_HOME=" + explicit + " codex",
+		Account: "work",
+	}
+
+	if got := inst.getCodexHomeDir(); got != explicit {
+		t.Errorf("getCodexHomeDir() = %q, want the command-embedded %q", got, explicit)
+	}
+}
+
+// A session with no account keeps the pre-existing chain untouched.
+func TestIssue1922_NoAccountUnchanged(t *testing.T) {
+	codexAccountHome(t)
+
+	inst := &Instance{ID: "i4", Title: "t", Tool: "codex", Command: "codex"}
+	if got := inst.accountCodexHomeDir(); got != "" {
+		t.Errorf("accountCodexHomeDir() = %q, want \"\" when no account is set", got)
+	}
+	if got := inst.codexHomeToExport(); !strings.Contains(got, "codex-global") {
+		t.Errorf("codexHomeToExport() = %q, want the configured global codex home", got)
+	}
+}


### PR DESCRIPTION
Closes #1922.

## What problem does this solve?

Setting an account on a codex session recorded it, reported it, and wired Claude's `config_dir` — but never applied `[profiles.<account>.codex].config_dir`. The session launched against the default `~/.codex` while reporting the new account, so the mismatch surfaced later as a quota error on an account the user never chose. As the issue puts it, that reads as a limits problem rather than a wiring one, which is what makes it expensive.

## Cause

Both codex resolution paths were instance-blind. `getCodexHomeDir()` consults `CODEX_HOME`, then the active **profile**, then global — never the per-session `Account`. And `buildCodexCommand` exported `CODEX_HOME` only when `isCodexHomeExplicit()` agreed, which asks the same instance-blind question. `resolveClaudeConfigDir` has had an account level since #924; codex simply never grew one.

## Why this shape

The new account level mirrors Claude's precedence rather than inventing one:

1. a `CODEX_HOME=` embedded in the session's own command — the user typing it by hand for this session is the most explicit signal there is, and it is also the workaround the reporter used
2. the account's `[profiles.<account>.codex].config_dir`
3. the existing env → profile → global → default chain

An account naming no codex block falls through silently, matching the permissive style of the Claude chain (an unconfigured account name is a no-op, not an error).

Both launch paths — normal and fork — now route through `codexHomeToExport()` so they cannot drift apart. A session that resolves its home one way and launches another is exactly this bug.

## One change beyond the reported symptom

The non-fork path appended `CODEX_HOME=` even when the resolved value was empty, exporting an empty variable instead of leaving codex to its own default. The append now sits inside the non-empty check, as it already did on the fork path. Flagging it explicitly because it is a behaviour change outside the issue as written, and worth a second opinion.

Not changed, but noticed: the non-fork path interpolates the path unquoted while the fork path uses `shellescape.Quote`. A codex home containing a space would break the former. I left it alone to keep this diff to one concern, but it is worth its own fix.

## Evidence

```
--- PASS: TestIssue1922_CodexAccountHomeIsExported      (asserts the launch command, not just the resolver)
--- PASS: TestIssue1922_UnknownAccountFallsThrough      (no empty CODEX_HOME for an unmapped account)
--- PASS: TestIssue1922_CommandEmbeddedHomeBeatsAccount
--- PASS: TestIssue1922_NoAccountUnchanged
```

Removing the account level from `codexHomeToExport` fails the first test with `= ".../codex-global", want ".../codex-work"`, so the test pins the fix rather than describing it.

`golangci-lint run internal/session/...` reports `0 issues`; the full `internal/session` package passes (99s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for account-specific Codex home directories during session launches.
  * Embedded `CODEX_HOME` settings take precedence over account-specific and global settings.
  * Normal and forked sessions now consistently use and export the selected Codex home directory.
  * Sessions without account mappings continue to use existing global behavior.

* **Bug Fixes**
  * Prevented unmapped accounts from exporting an empty Codex home setting.

* **Tests**
  * Added coverage for account-specific resolution, precedence rules, fork launches, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->