### PR TITLE
fix(cli): report wrapper in session show --json (#1924)

### DIFF
--- a/cmd/agent-deck/issue1924_show_wrapper_test.go
+++ b/cmd/agent-deck/issue1924_show_wrapper_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIssue1924_SessionShowJSONIncludesWrapper asserts that
+// `agent-deck session show --json <id>` reports the wrapper field.
+//
+// This is gh#615 again, one field over. Two separate JSON emitters: handleList
+// threads the value, handleSessionShow builds its own jsonData map and never
+// included wrapper. The data persists correctly — verified end to end through a
+// real storage round trip — so the only thing missing was the report.
+//
+// The cost of that gap is what makes it worth a test rather than a one-line
+// patch: `session show --json` is the natural way to verify `session set
+// wrapper`, and with the key absent `.wrapper` reads back as null. #1924 was
+// filed as "the write did not persist", which sent the investigation at the
+// mutator and the storage layer, neither of which was at fault.
+//
+// Emitted unconditionally, matching the channels field's stated reasoning:
+// omitting when empty makes absence-of-field ambiguous with absence-of-value.
+func TestIssue1924_SessionShowJSONIncludesWrapper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "-t", "wrap-show-test", "-c", "shell", "--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("add failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var addResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &addResp); err != nil {
+		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
+	}
+
+	// A session with no wrapper must still report the key, so "not set" is
+	// distinguishable from "not reported".
+	stdout, stderr, code = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var before map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &before); err != nil {
+		t.Fatalf("parse show response: %v\nstdout: %s", err, stdout)
+	}
+	if _, ok := before["wrapper"]; !ok {
+		t.Error("session show --json omits the wrapper key entirely; absent reads as null and is indistinguishable from an unpersisted write (#1924)")
+	}
+
+	const want = "env CODEX_HOME=/tmp/acct {command}"
+	stdout, stderr, code = runAgentDeck(t, home, "session", "set", addResp.ID, "wrapper", want)
+	if code != 0 {
+		t.Fatalf("session set wrapper failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+
+	stdout, stderr, code = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show after set failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var after map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &after); err != nil {
+		t.Fatalf("parse show response: %v\nstdout: %s", err, stdout)
+	}
+	got, ok := after["wrapper"]
+	if !ok {
+		t.Fatal("session show --json still omits wrapper after it was set (#1924)")
+	}
+	if got != want {
+		t.Errorf("wrapper = %v, want %q — the success line said it was set", got, want)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1663,6 +1663,15 @@ func handleSessionShow(profile string, args []string) {
 		jsonData["command"] = inst.Command
 	}
 
+	// #1924: always present, even when empty. `session set <id> wrapper …` is
+	// the natural thing to verify with `session show --json`, and this key was
+	// missing entirely — so `.wrapper` read back as null and a write that had
+	// in fact persisted looked like silent data loss. Same reasoning the
+	// channels field states below: omitting when empty makes absence-of-field
+	// ambiguous with absence-of-value, and here that ambiguity cost a user a
+	// bug report against the wrong component.
+	jsonData["wrapper"] = inst.Wrapper
+
 	if session.IsClaudeCompatible(inst.Tool) {
 		jsonData["claude_session_id"] = inst.ClaudeSessionID
 		jsonData["can_fork"] = inst.CanFork()


### PR DESCRIPTION
Addresses the first half of #1924.

## The write was never the problem

#1924 reports that `session set <id> wrapper …` prints success but does not persist, citing `session show --json` returning `wrapper: null`. I checked that before changing anything, because "reports success without persisting" points at the mutator and the storage layer.

The wrapper persists. Verified end to end against a real profile store — set the field, save, close, reopen, reload, and it comes back intact. The set path is also correctly ordered: it saves and checks the error before printing success, so a failed save cannot produce a success line.

## What is actually wrong

`session show --json` never emitted a `wrapper` key at all, so `.wrapper` read back as `null` — indistinguishable from a write that failed.

This is **gh#615 one field over**. There are two JSON emitters: `handleList` threads the value through, while `handleSessionShow` builds its own `jsonData` map, and the two drifted. #615 fixed exactly this for `channels`; `wrapper` was never brought along.

Emitted unconditionally rather than when non-empty, following the reasoning the channels field already states a few lines below:

> Always include channels for claude sessions — omitting when empty would make absence-of-field ambiguous with absence-of-value.

That ambiguity is the whole cost here. It sent a bug report at two components that were working correctly.

## Evidence

On `main`, the new test fails with the symptom from the issue:

```
issue1924_show_wrapper_test.go:60: session show --json omits the wrapper key entirely;
    absent reads as null and is indistinguishable from an unpersisted write (#1924)
issue1924_show_wrapper_test.go:79: session show --json still omits wrapper after it was set (#1924)
```

With the fix, it passes. The test drives the real CLI end to end and checks the key is present both before and after the wrapper is set, so "not set" stays distinguishable from "not reported".

`golangci-lint run cmd/agent-deck/...` reports `0 issues`.

## Not addressed here

#1924's second ask — populate `last_error` on every start failure, so an errored session always says why — is a separate concern and I have left the issue open for it. It is the more valuable half, and it stands on its own regardless of this fix: the reporter's session sat at `status=error` with `last_error=null` and no tmux session, which is zero diagnosable surface no matter what the wrapper did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `session show --json` now consistently includes the `wrapper` field, even when no wrapper is configured.
  * Wrapper values are preserved and displayed correctly after saving and reloading a session.

* **Tests**
  * Added coverage to verify JSON output and wrapper value persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->