### PR TITLE
fix(session): record a reason when a start fails before tmux (#1924)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4452,6 +4452,9 @@ func (i *Instance) Start() error {
 	var err error
 	command, containerName, err = i.prepareCommand(command)
 	if err != nil {
+		// #1924: leave a reason behind. Without this the session sits on
+		// StatusError with no tmux session and nothing to diagnose from.
+		i.recordPrepareFailure(command, err)
 		return err
 	}
 	if containerName != "" {
@@ -4741,6 +4744,9 @@ func (i *Instance) StartWithMessage(message string) error {
 	var err error
 	command, containerName, err = i.prepareCommand(command)
 	if err != nil {
+		// #1924: leave a reason behind. Without this the session sits on
+		// StatusError with no tmux session and nothing to diagnose from.
+		i.recordPrepareFailure(command, err)
 		return err
 	}
 	if containerName != "" {
@@ -8449,6 +8455,7 @@ func (i *Instance) restart(env map[string]string) error {
 	}
 	command, containerName, err := i.prepareCommand(command)
 	if err != nil {
+		i.recordPrepareFailure(command, err) // #1924, sister path
 		return err
 	}
 	if containerName != "" {

--- a/internal/session/issue1924_prepare_failure_test.go
+++ b/internal/session/issue1924_prepare_failure_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A start that fails before tmux is ever invoked must still leave a reason
+// behind. #1924: the session sat on StatusError with no tmux session, no
+// spawn-failure record, and nothing in `session show` — an error state with no
+// reason, which the issue rightly calls a guess rendered as fact.
+func TestIssue1924_PrepareFailureLeavesARecord(t *testing.T) {
+	withTempHome(t)
+
+	inst := &Instance{ID: "prep-1924", Title: "t", Tool: "codex", Command: "codex"}
+	t.Cleanup(func() { clearSpawnFailureRecord(inst.ID) })
+
+	if rec := inst.SpawnFailure(); rec != nil {
+		t.Fatalf("precondition: expected no record, got %+v", rec)
+	}
+
+	inst.recordPrepareFailure("env BROKEN {command}", errors.New("sandbox image pull failed"))
+
+	rec := inst.SpawnFailure()
+	if rec == nil {
+		t.Fatal("no spawn-failure record written for a pre-tmux start failure")
+	}
+	if rec.Reason != "prepare_failed" {
+		t.Errorf("Reason = %q, want %q", rec.Reason, "prepare_failed")
+	}
+	if !strings.Contains(rec.DyingOutput, "sandbox image pull failed") {
+		t.Errorf("record does not carry the error text: %q", rec.DyingOutput)
+	}
+	if rec.Command != "env BROKEN {command}" {
+		t.Errorf("Command = %q, want the command that failed to prepare", rec.Command)
+	}
+}
+
+// The rendered text must not claim something ran. The default arm says the
+// session "ended unexpectedly during startup", which is wrong when nothing was
+// ever launched — and a confidently wrong explanation is worse than a vague one
+// for someone trying to diagnose a failure.
+func TestIssue1924_PrepareFailureDisplayDoesNotClaimItRan(t *testing.T) {
+	rec := &SpawnFailureRecord{
+		InstanceID: "x", Tool: "codex",
+		Command: "env BROKEN {command}", Reason: "prepare_failed",
+		DyingOutput: "sandbox image pull failed",
+	}
+	out := rec.FormatForDisplay()
+
+	if !strings.Contains(out, "could not be prepared") {
+		t.Errorf("display text should say the command was never launched:\n%s", out)
+	}
+	if strings.Contains(out, "ended unexpectedly during startup") {
+		t.Errorf("display text claims the session ran, but nothing was launched:\n%s", out)
+	}
+	if !strings.Contains(out, "sandbox image pull failed") {
+		t.Errorf("display text drops the actual reason:\n%s", out)
+	}
+}
+
+// A nil error must not write a record — a start that did not fail has nothing
+// to explain, and a stray record would mask the next real one.
+func TestIssue1924_NoRecordWithoutAnError(t *testing.T) {
+	withTempHome(t)
+	inst := &Instance{ID: "prep-1924-nil", Title: "t", Tool: "codex"}
+	t.Cleanup(func() { clearSpawnFailureRecord(inst.ID) })
+
+	inst.recordPrepareFailure("cmd", nil)
+
+	if rec := inst.SpawnFailure(); rec != nil {
+		t.Errorf("record written for a nil error: %+v", rec)
+	}
+}

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -27,7 +27,7 @@ type SpawnFailureRecord struct {
 	InstanceID  string `json:"instance_id"`
 	Tool        string `json:"tool"`
 	Command     string `json:"command,omitempty"`
-	Reason      string `json:"reason"`                 // tmux_start_failed | spawn_died_fast
+	Reason      string `json:"reason"`                 // tmux_start_failed | spawn_died_fast | prepare_failed
 	DyingOutput string `json:"dying_output,omitempty"` // last pane snapshot captured while alive
 	ElapsedMs   int64  `json:"elapsed_ms"`             // ms from spawn to observed death (0 for tmux_start_failed)
 	Timestamp   int64  `json:"ts"`
@@ -125,6 +125,10 @@ func (r *SpawnFailureRecord) FormatForDisplay() string {
 		b.WriteString("The terminal session could not be created.\n")
 	case "spawn_died_fast":
 		fmt.Fprintf(&b, "The command exited almost immediately (after %dms).\n", r.ElapsedMs)
+	case "prepare_failed":
+		// Nothing was launched, so the default arm's "ended unexpectedly
+		// during startup" would be actively misleading here.
+		b.WriteString("The command could not be prepared, so nothing was launched.\n")
 	default:
 		b.WriteString("The session ended unexpectedly during startup.\n")
 	}
@@ -305,6 +309,43 @@ func (i *Instance) watchForFastDeath(command string, gen uint64, wake <-chan str
 			slog.String("dying_output", logging.SanitizeValue(lastSnapshot)))
 		return
 	}
+}
+
+// recordPrepareFailure persists a record for a start that failed BEFORE tmux
+// was ever asked to do anything — command/wrapper assembly, sandbox setup,
+// config regeneration (#1924).
+//
+// These paths returned a bare error, so the session landed on StatusError with
+// no tmux session, no spawn-failure record and nothing in `session show`: an
+// error state with no reason, which is a guess rendered as fact. They are also
+// the paths most likely to be hit right after a user edits a wrapper or command,
+// which is exactly when a reason is worth the most.
+func (i *Instance) recordPrepareFailure(command string, prepErr error) {
+	if prepErr == nil {
+		return
+	}
+	rec := SpawnFailureRecord{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Command:    command,
+		Reason:     "prepare_failed",
+		// Reusing DyingOutput for the error string, as recordTmuxStartFailure
+		// already does: there is no pane to snapshot, so the error IS the
+		// diagnostic.
+		DyingOutput: prepErr.Error(),
+	}
+	if err := writeSpawnFailureRecord(rec); err != nil {
+		sessionLog.Warn("spawn_failure_record_write_failed",
+			slog.String("instance_id", i.ID),
+			slog.String("error", err.Error()))
+	}
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "spawn_failed",
+		Source:     "prepare_command",
+		Reason:     prepErr.Error(),
+	})
 }
 
 // recordTmuxStartFailure persists a record for the case where tmux itself


### PR DESCRIPTION
Partial progress on #1924's second ask. **Does not close the issue** — see Scope.

## What this fixes

`prepareCommand`'s failure paths returned a bare error, so the session landed on `StatusError` with no tmux session, no spawn-failure record, and nothing for `session show` to report. That is the surface #1924 describes: `status=error`, `last_error=null`, `substate=null`, nothing to go on.

All three `prepareCommand` call sites now record a `SpawnFailureRecord` with reason `prepare_failed`, reusing the sidecar #1580 already built — so the existing `spawn_failure` key in `session show --json` and the preview pane surface it with no new plumbing.

`FormatForDisplay` gets its own arm. The default text says the session "ended unexpectedly during startup", which is actively misleading when nothing was ever launched; a confidently wrong explanation is worse than a vague one for someone mid-diagnosis.

## Scope — stated plainly, because it matters here

**I cannot claim this explains the failure in #1924.** `prepareCommand` has two error paths:

- `applyWrapper` — currently **cannot** return a non-nil error at all; every branch returns `nil`
- `wrapForSandbox` — reachable, but the reported session does not look sandboxed

So the reporter's start failed somewhere this patch does not cover. I went looking for the wrapper connection because they had just set a wrapper, and it is not there.

What the change is worth on its own: a reachable error path that leaves a session unexplained now leaves a reason, and it costs almost nothing because the sidecar already existed.

## What #1924 still needs

The second ask is broader than this: it wants **every** start failure to leave a reason. Answering it properly means auditing every path that can put a session on `StatusError` and confirming each one records something. That is worth doing — it is the "unknown as first-class state" direction the issue cites — but it is a bigger piece of work than one fix, and I would rather leave the issue open and honest than close it on a partial.

## Evidence

```
--- PASS: TestIssue1924_PrepareFailureLeavesARecord
--- PASS: TestIssue1924_PrepareFailureDisplayDoesNotClaimItRan
--- PASS: TestIssue1924_NoRecordWithoutAnError
```

Full `internal/session` package passes (82s); `golangci-lint run internal/session/...` reports `0 issues`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preparation failures are now recorded with the relevant error and command details.
  * Failure messages accurately indicate when a command was not launched.
  * Restart fallback failures now retain diagnostic information.
  * Preparation failures emit the appropriate lifecycle event for visibility.

* **Tests**
  * Added regression coverage for preparation failure records, display messages, and successful preparations without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->