### PR TITLE
feat(cli): separate internal profiles in profile list (#1926)

### DIFF
--- a/cmd/agent-deck/issue1926_profile_list_test.go
+++ b/cmd/agent-deck/issue1926_profile_list_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #1926: seven `_`-prefixed test-fixture profiles were listed inline with the
+// user's real ones, burying them. They are separated, not hidden — a profile
+// someone deliberately named with a leading underscore must still appear.
+func TestIssue1926_ProfileListSeparatesInternal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+
+	for _, name := range []string{"work", "_test-1926", "_scratch"} {
+		if _, stderr, code := runAgentDeck(t, home, "profile", "create", name); code != 0 {
+			t.Fatalf("profile create %s failed (exit %d): %s", name, code, stderr)
+		}
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "profile", "list")
+	if code != 0 {
+		t.Fatalf("profile list failed (exit %d): %s", code, stderr)
+	}
+
+	// Nothing may disappear: hiding by default would make an unexpected
+	// underscore profile invisible, which is worse than the clutter.
+	for _, name := range []string{"work", "_test-1926", "_scratch"} {
+		if !strings.Contains(stdout, name) {
+			t.Errorf("profile %q missing from listing:\n%s", name, stdout)
+		}
+	}
+	if !strings.Contains(stdout, "Internal") {
+		t.Errorf("listing does not separate internal profiles:\n%s", stdout)
+	}
+
+	// The real profile must come before the internal section, which is the
+	// entire point — otherwise it is still buried.
+	realIdx := strings.Index(stdout, "work")
+	sectionIdx := strings.Index(stdout, "Internal")
+	if realIdx < 0 || sectionIdx < 0 || realIdx > sectionIdx {
+		t.Errorf("real profiles should be listed before the internal section:\n%s", stdout)
+	}
+}
+
+// The JSON payload gains an `internal` flag so tooling can filter without
+// re-deriving the convention. Additive: existing keys are untouched.
+func TestIssue1926_ProfileListJSONMarksInternal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	for _, name := range []string{"work", "_test-1926"} {
+		if _, stderr, code := runAgentDeck(t, home, "profile", "create", name); code != 0 {
+			t.Fatalf("profile create %s failed (exit %d): %s", name, code, stderr)
+		}
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "profile", "list", "--json")
+	if code != 0 {
+		t.Fatalf("profile list --json failed (exit %d): %s", code, stderr)
+	}
+	var resp struct {
+		Profiles []struct {
+			Name      string `json:"name"`
+			IsDefault bool   `json:"is_default"`
+			Internal  bool   `json:"internal"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("parse: %v\n%s", err, stdout)
+	}
+
+	seen := map[string]bool{}
+	for _, p := range resp.Profiles {
+		seen[p.Name] = true
+		want := strings.HasPrefix(p.Name, "_")
+		if p.Internal != want {
+			t.Errorf("profile %q: internal = %v, want %v", p.Name, p.Internal, want)
+		}
+	}
+	for _, name := range []string{"work", "_test-1926"} {
+		if !seen[name] {
+			t.Errorf("profile %q missing from JSON payload:\n%s", name, stdout)
+		}
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3006,6 +3006,10 @@ func handleProfileList(out *CLIOutput, jsonMode bool) {
 			profileList = append(profileList, map[string]interface{}{
 				"name":       p,
 				"is_default": p == defaultProfile,
+				// #1926: let tooling filter the underscore-prefixed profiles
+				// (test fixtures, scratch) without re-deriving the convention.
+				// Additive — nothing is removed from the payload.
+				"internal": isInternalProfileName(p),
 			})
 		}
 		out.Success("", map[string]interface{}{
@@ -3023,15 +3027,53 @@ func handleProfileList(out *CLIOutput, jsonMode bool) {
 		return
 	}
 
-	fmt.Println("Profiles:")
+	// #1926: underscore-prefixed profiles are test fixtures and scratch state.
+	// Listed flat they bury the real ones — the report had seven of them ahead
+	// of the profiles the user actually cared about. Separated, not hidden:
+	// hiding by default would make a profile someone deliberately named with a
+	// leading underscore vanish with no way to notice.
+	var normal, internal []string
 	for _, p := range profiles {
+		if isInternalProfileName(p) {
+			internal = append(internal, p)
+			continue
+		}
+		normal = append(normal, p)
+	}
+
+	printProfile := func(p string) {
 		if p == defaultProfile {
 			fmt.Printf("  * %s (default)\n", p)
-		} else {
-			fmt.Printf("    %s\n", p)
+			return
+		}
+		fmt.Printf("    %s\n", p)
+	}
+
+	fmt.Println("Profiles:")
+	for _, p := range normal {
+		printProfile(p)
+	}
+	if len(normal) == 0 {
+		fmt.Println("    (none)")
+	}
+
+	if len(internal) > 0 {
+		fmt.Printf("\nInternal (test fixtures and scratch, '_' prefix): %d\n", len(internal))
+		for _, p := range internal {
+			printProfile(p)
 		}
 	}
+
 	fmt.Printf("\nTotal: %d profiles\n", len(profiles))
+}
+
+// isInternalProfileName reports whether a profile name follows the project's
+// underscore convention for test fixtures and scratch state (_test, _baseline,
+// …). Purely a display concern: nothing about the profile behaves differently,
+// and the listing separates rather than hides so an unexpected one is still
+// visible (#1926).
+func isInternalProfileName(name string) bool {
+	return strings.HasPrefix(name, "_")
 }
 
 func handleProfileCreate(out *CLIOutput, name string) {


### PR DESCRIPTION
The listing half of #1926. **Does not close the issue** — see below.

## What this changes

`profile list` put seven `_`-prefixed test-fixture profiles inline with the user's real ones, burying what they actually keep there. They now get their own section:

```
Profiles:
    work

Internal (test fixtures and scratch, '_' prefix): 1
    _test-x

Total: 2 profiles
```

`--json` gains an `internal` flag per profile so tooling can filter without re-deriving the convention. Additive — every existing key is untouched.

## Separated, not hidden

The issue offered either "visually separate" or "hide behind `--all`". I went with separation deliberately: hiding by default would make a profile someone named with a leading underscore on purpose disappear with no way to notice it was ever there. That trades a clutter problem for an invisibility problem, and invisibility is what made #1926 worth filing. The total stays whole for the same reason.

## What is still open

The other half — how test profiles reached a real profile store at all — is unresolved and I have asked a question on the issue rather than guessing.

Short version of what I found: the mechanism is real (`GetProfilesDir` resolves through `XDG_DATA_HOME`, which wins over `HOME`, and several test helpers set only `HOME`), but every package that touches profile paths has a `TestMain` calling `testutil.IsolateHome()`, which clears HOME *and* all XDG vars first. So those helpers are covered by design. I counted 103 of 129 HOME-setting test files as "missing XDG" before noticing that, and the number means nothing.

My current guess is that the debris predates the June isolation fixes and nothing prunes it — but that needs the reporter's directory mtimes to confirm, so the issue stays open.

## Evidence

```
--- PASS: TestIssue1926_ProfileListSeparatesInternal   (real profile listed before the internal section; nothing missing)
--- PASS: TestIssue1926_ProfileListJSONMarksInternal
```

`golangci-lint run cmd/agent-deck/...` reports `0 issues`. Full `cmd/agent-deck` package matches `main`: the only failures are `TestPerf_ColdStart_Help`/`_Version`, which fail identically on unmodified `main` on this host (load-sensitive; CI applies a budget multiplier).

One unrelated observation while verifying: `TestStatusStale_CLI_CandidateViewAndMutatesNothing` failed once in a full-package run and did not reproduce on a re-run or on clean `main`. Recording it as a possible flake rather than a finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile listings now distinguish internal profiles by marking names beginning with an underscore.
  * Human-readable listings separate regular profiles from internal profiles while keeping both visible.
  * JSON profile listings now include an `internal` indicator for each profile.
* **Bug Fixes**
  * Ensured regular and internal profiles remain present and correctly classified across listing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->