### PR TITLE
fix(session): leave a reason when a restart fails (#1924)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8068,8 +8068,11 @@ func (i *Instance) restart(env map[string]string) error {
 					slog.String("reason", "orphan_bak_restore_restart"))
 			}
 		}
-		resumeCmd, containerName, err := i.prepareCommand(i.buildClaudeResumeCommand())
+		prepInput := i.buildClaudeResumeCommand()
+		resumeCmd, containerName, err := i.prepareCommand(prepInput)
 		if err != nil {
+			// #1924: a restart that fails here left StatusError with no reason.
+			i.recordPrepareFailure(prepInput, err)
 			return err
 		}
 		if containerName != "" {
@@ -8121,8 +8124,11 @@ func (i *Instance) restart(env map[string]string) error {
 
 	// If Gemini session with known ID AND tmux session exists, use respawn-pane.
 	if i.Tool == "gemini" && i.GeminiSessionID != "" && i.tmuxSession != nil && i.tmuxSession.Exists() {
-		resumeCmd, containerName, err := i.prepareCommand(i.buildGeminiCommand("gemini"))
+		prepInput := i.buildGeminiCommand("gemini")
+		resumeCmd, containerName, err := i.prepareCommand(prepInput)
 		if err != nil {
+			// #1924: a restart that fails here left StatusError with no reason.
+			i.recordPrepareFailure(prepInput, err)
 			return err
 		}
 		if containerName != "" {
@@ -8177,8 +8183,11 @@ func (i *Instance) restart(env map[string]string) error {
 		// Reuse the canonical builder so live-pane respawns retain the same
 		// configured command, model, agent, and SSE flags as every other start.
 		rawCmd := i.buildOpenCodeCommand("opencode")
-		resumeCmd, containerName, err := i.prepareCommand(rawCmd)
+		prepInput := rawCmd
+		resumeCmd, containerName, err := i.prepareCommand(prepInput)
 		if err != nil {
+			// #1924: a restart that fails here left StatusError with no reason.
+			i.recordPrepareFailure(prepInput, err)
 			return err
 		}
 		if containerName != "" {
@@ -8248,8 +8257,11 @@ func (i *Instance) restart(env map[string]string) error {
 		if i.CodexSessionID == "" {
 			i.CodexStartedAt = time.Now().UnixMilli()
 		}
-		resumeCmd, containerName, err := i.prepareCommand(i.buildCodexCommand(i.Command))
+		prepInput := i.buildCodexCommand(i.Command)
+		resumeCmd, containerName, err := i.prepareCommand(prepInput)
 		if err != nil {
+			// #1924: a restart that fails here left StatusError with no reason.
+			i.recordPrepareFailure(prepInput, err)
 			return err
 		}
 		if containerName != "" {
@@ -8288,8 +8300,11 @@ func (i *Instance) restart(env map[string]string) error {
 
 	// If Cursor session AND tmux session exists, use respawn-pane.
 	if i.Tool == "cursor" && i.tmuxSession != nil && i.tmuxSession.Exists() {
-		resumeCmd, containerName, err := i.prepareCommand(i.buildCursorCommand(i.Command, true))
+		prepInput := i.buildCursorCommand(i.Command, true)
+		resumeCmd, containerName, err := i.prepareCommand(prepInput)
 		if err != nil {
+			// #1924: a restart that fails here left StatusError with no reason.
+			i.recordPrepareFailure(prepInput, err)
 			return err
 		}
 		if containerName != "" {
@@ -8329,8 +8344,11 @@ func (i *Instance) restart(env map[string]string) error {
 				i.Command, toolDef.ResumeFlag, sessionID)
 		}
 		rawCmd = i.buildRestartEnvPrefix() + rawCmd
-		resumeCmd, containerName, err := i.prepareCommand(rawCmd)
+		prepInput := rawCmd
+		resumeCmd, containerName, err := i.prepareCommand(prepInput)
 		if err != nil {
+			// #1924: a restart that fails here left StatusError with no reason.
+			i.recordPrepareFailure(prepInput, err)
 			return err
 		}
 		if containerName != "" {
@@ -8479,6 +8497,11 @@ func (i *Instance) restart(env map[string]string) error {
 
 	if err := i.tmuxSession.Start(command); err != nil {
 		mcpLog.Debug("restart_start_failed", slog.String("error", err.Error()))
+		// #1924: Start() and its sister path have recorded this since #1580,
+		// but restart() never did — so the one case where the user has just
+		// changed something and is most likely to ask "why?" was the one that
+		// set StatusError with nothing to show for it.
+		i.recordTmuxStartFailure(command, err)
 		i.Status = StatusError
 		return fmt.Errorf("failed to restart tmux session: %w", err)
 	}


### PR DESCRIPTION
Second instalment on #1924's "every start failure should say why". **Does not close the issue.**

## The audit

I walked every site that assigns `StatusError` and classified each one. `restart()` came back systematically uncovered: **seven** `prepareCommand` calls and **one** `tmuxSession.Start`, each returning a bare error or setting `StatusError` with nothing recorded.

That is the worst place to have the gap. #1580 gave `Start()` and its sister path a durable spawn-failure sidecar, and #1931 extended it to their `prepareCommand` failures — but `restart()` was never brought along. So the one moment a user is most likely to ask "why?", having just changed a setting and restarted, is the one that produced an error status with nothing attached to it. That is exactly the surface #1924 describes: `status=error`, no reason, no tmux session.

All eight sites now record, reusing the existing sidecar, so `session show --json`'s `spawn_failure` key and the preview pane pick them up with no new plumbing.

## What the audit says needs nothing

The remaining `StatusError` assignments are status **detection**, not start failures: a dead pane, an unreachable hermes gateway, an auth failure the user must clear, an unrecognised pane state. In each the observation *is* the reason, and they already carry it in their own surfaces.

I am flagging that judgement rather than burying it, because it is the line between "this closes the ask" and "this closes part of it". Whether a detection-derived error should also carry a durable reason is a real question, just a broader one than #1924 asked.

## Implementation note

The `prepareCommand` argument is now bound to a local before the call so the record can name the command that failed to prepare. Previously the only variable in scope was the result, which is assigned only on success — so a naive record would have logged an empty command exactly when the command was the thing at fault.

## Evidence

`internal/session` passes in full (81s). `golangci-lint run internal/session/...` reports `0 issues`. `gofmt` clean.

Deliberately no new test here: the recording helpers and their display arm are already covered by #1931's tests, and what changed is which call sites invoke them. A test per call site would pin the current shape of `restart()` rather than the behaviour, and `restart()` is long enough that I would rather not weld tests to its internals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart reliability across supported tools by preserving original command inputs.
  * Preparation failures are now reported consistently during restarts.
  * Restart failures caused by terminal session startup are now recorded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->