### PR TITLE
fix(session): never persist env credential values in spawn-failure sidecars

### DIFF
--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -1,12 +1,12 @@
 package session
 
 import (
-	"regexp"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -55,13 +55,8 @@ func writeSpawnFailureRecord(rec SpawnFailureRecord) error {
 	return writeSpawnFailureRecordTo(rec, spawnFailureDir())
 }
 
-// writeSpawnFailureRecordTo is the path-explicit variant, used by
-// watchForFastDeath. dir is resolved once by the caller at goroutine-spawn
-// time (see the comment on watchForFastDeath) rather than re-resolved here
-// from the live $HOME, which could have moved on by the time the watcher's
-// goroutine — never joined — actually gets to write.
 // envExportPattern matches shell export statements with single-quoted values
-// (including the '\'' escape produced by buildEnvExports) so persisted
+// (including the quote escape produced by buildEnvExports) so persisted
 // commands never carry credential values. Only the value is redacted; the key
 // stays visible for diagnosis.
 var envExportPattern = regexp.MustCompile(`export ([A-Za-z_][A-Za-z0-9_]*)='(?:[^']*(?:'\\''[^']*)*)'`)
@@ -73,6 +68,107 @@ func redactEnvValues(s string) string {
 	return envExportPattern.ReplaceAllString(s, "export $1='[redacted]'")
 }
 
+// redactSidecarBytes redacts every string field of an already-persisted sidecar,
+// returning (redacted, true) only when something actually changed.
+//
+// It works on the decoded fields rather than the raw JSON text on purpose: a
+// value containing a quote carries the shell quote escape, which JSON in turn
+// escapes the backslash of, and envExportPattern would only half-match that —
+// a regex sweep over the raw bytes would leave part of such a secret on disk.
+// Decoding into
+// json.RawMessage (not into SpawnFailureRecord) keeps numbers byte-exact and
+// preserves fields written by a newer or older version of the struct, so a
+// rewrite never silently drops a record's contents.
+func redactSidecarBytes(data []byte) ([]byte, bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, false
+	}
+	changed := false
+	for key, raw := range fields {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			continue // not a string: numbers and nested shapes stay verbatim
+		}
+		redacted := redactEnvValues(s)
+		if redacted == s {
+			continue
+		}
+		encoded, err := json.Marshal(redacted)
+		if err != nil {
+			continue
+		}
+		fields[key] = encoded
+		changed = true
+	}
+	if !changed {
+		return nil, false
+	}
+	out, err := json.MarshalIndent(fields, "", "  ")
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// ensureSpawnFailureDirSecure hardens a spawn-failure directory that already
+// exists. os.MkdirAll leaves an EXISTING directory's mode untouched, so an
+// install upgraded from a version that created the dir 0755 keeps it — and every
+// 0644 sidecar already in it, written before redaction existed — readable by
+// every other local user. Without this, the redaction above only ever protects
+// fresh installs, and the credentials that actually leaked stay leaked.
+//
+// So: tighten the directory, then sweep the sidecars already in it — chmod 0600
+// AND rewrite them through the redactor, so a stored credential is removed from
+// disk rather than merely hidden behind directory permissions.
+//
+// Best-effort by construction: every step ignores its error and moves on. This
+// runs on the spawn-failure path only (a handful of files, and only when a
+// session has already failed to start), and it must never be the reason a
+// failure record fails to be written.
+func ensureSpawnFailureDirSecure(dir string) {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	if info.Mode().Perm() != 0o700 {
+		_ = os.Chmod(dir, 0o700)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		fi, err := entry.Info()
+		// Lstat semantics: a symlink is never a regular file here, so we can
+		// neither chmod nor rewrite through one into an unrelated target.
+		if err != nil || !fi.Mode().IsRegular() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if fi.Mode().Perm() != 0o600 {
+			_ = os.Chmod(path, 0o600)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		redacted, changed := redactSidecarBytes(data)
+		if !changed {
+			continue
+		}
+		_ = safeio.SafeOverwrite(path, redacted, safeio.Options{Perm: 0o600, SkipBackup: true})
+	}
+}
+
+// writeSpawnFailureRecordTo is the path-explicit variant, used by
+// watchForFastDeath. dir is resolved once by the caller at goroutine-spawn
+// time (see the comment on watchForFastDeath) rather than re-resolved here
+// from the live $HOME, which could have moved on by the time the watcher's
+// goroutine — never joined — actually gets to write.
 func writeSpawnFailureRecordTo(rec SpawnFailureRecord, dir string) error {
 	if rec.Timestamp == 0 {
 		rec.Timestamp = time.Now().Unix()
@@ -85,6 +181,9 @@ func writeSpawnFailureRecordTo(rec SpawnFailureRecord, dir string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("create spawn-failure dir: %w", err)
 	}
+	// MkdirAll above only sets the mode on a directory it creates; upgraded
+	// installs come with a 0755 one full of world-readable pre-fix sidecars.
+	ensureSpawnFailureDirSecure(filepath.Dir(path))
 	data, err := json.MarshalIndent(rec, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal spawn-failure record: %w", err)

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"regexp"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -59,12 +60,29 @@ func writeSpawnFailureRecord(rec SpawnFailureRecord) error {
 // time (see the comment on watchForFastDeath) rather than re-resolved here
 // from the live $HOME, which could have moved on by the time the watcher's
 // goroutine — never joined — actually gets to write.
+// envExportPattern matches shell export statements with single-quoted values
+// (including the '\'' escape produced by buildEnvExports) so persisted
+// commands never carry credential values. Only the value is redacted; the key
+// stays visible for diagnosis.
+var envExportPattern = regexp.MustCompile(`export ([A-Za-z_][A-Za-z0-9_]*)='(?:[^']*(?:'\\''[^']*)*)'`)
+
+// redactEnvValues strips env values from a persisted command or error string.
+// A restart --env API_KEY=... that fails during prepare would otherwise write
+// the literal secret into a sidecar that session show exposes.
+func redactEnvValues(s string) string {
+	return envExportPattern.ReplaceAllString(s, "export $1='[redacted]'")
+}
+
 func writeSpawnFailureRecordTo(rec SpawnFailureRecord, dir string) error {
 	if rec.Timestamp == 0 {
 		rec.Timestamp = time.Now().Unix()
 	}
+	// Single choke point: every writer funnels through here, so redaction and
+	// tight permissions cannot be forgotten at a call site.
+	rec.Command = redactEnvValues(rec.Command)
+	rec.DyingOutput = redactEnvValues(rec.DyingOutput)
 	path := filepath.Join(dir, rec.InstanceID+".json")
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("create spawn-failure dir: %w", err)
 	}
 	data, err := json.MarshalIndent(rec, "", "  ")
@@ -73,7 +91,7 @@ func writeSpawnFailureRecordTo(rec SpawnFailureRecord, dir string) error {
 	}
 	// SkipBackup: these sidecars are transient and self-clearing; a .bak would
 	// just be noise. RefuseEmpty is irrelevant (data is never empty).
-	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o644, SkipBackup: true})
+	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o600, SkipBackup: true})
 }
 
 // readSpawnFailureRecord loads the sidecar for an instance, or (nil, nil) when

--- a/internal/session/spawn_failure_redaction_test.go
+++ b/internal/session/spawn_failure_redaction_test.go
@@ -12,12 +12,14 @@ import (
 // persist the literal `export API_KEY='secret'` into a 0644 sidecar exposed
 // by session show. The record writer must redact values and write 0600.
 func TestSpawnFailureRecord_RedactsEnvValuesAndTightensPerms(t *testing.T) {
-	dir := t.TempDir()
+	// A child the writer has to create itself, so the 0700 directory mode is
+	// exercised rather than inherited from t.TempDir().
+	dir := filepath.Join(t.TempDir(), "runtime", "spawn-failure")
 	rec := SpawnFailureRecord{
-		InstanceID: "leaktest",
-		Tool:       "generic",
-		Command:    `export API_KEY='sk-live-SECRET' && export NOTE='it'\''s quoted' && mytool run`,
-		Reason:     "prepare_failed",
+		InstanceID:  "leaktest",
+		Tool:        "generic",
+		Command:     `export API_KEY='sk-live-SECRET' && export NOTE='it'\''s quoted' && mytool run`,
+		Reason:      "prepare_failed",
 		DyingOutput: `prepare failed running: export API_KEY='sk-live-SECRET' && mytool`,
 	}
 	if err := writeSpawnFailureRecordTo(rec, dir); err != nil {
@@ -47,5 +49,85 @@ func TestSpawnFailureRecord_RedactsEnvValuesAndTightensPerms(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("sidecar perms = %o, want 600", info.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("spawn-failure dir perms = %o, want 700", dirInfo.Mode().Perm())
+	}
+}
+
+// Upgrade path (#1934 review): the directory and the sidecars in it already
+// exist from a version that wrote them 0755/0644 with unredacted credentials.
+// os.MkdirAll leaves an existing directory's mode alone, so without an explicit
+// sweep the fix above would only protect fresh installs while the credentials
+// that actually leaked stayed world-readable on disk.
+func TestSpawnFailureRecord_TightensExistingDirAndSweepsOldSidecars(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "spawn-failure")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil { // defeat any umask narrowing
+		t.Fatalf("chmod dir: %v", err)
+	}
+	old := filepath.Join(dir, "old-session.json")
+	oldBody := `{
+  "instance_id": "old-session",
+  "tool": "generic",
+  "command": "export API_KEY='sk-live-OLDSECRET' && mytool run",
+  "reason": "prepare_failed",
+  "dying_output": "prepare failed running: export API_KEY='sk-live-OLDSECRET'",
+  "elapsed_ms": 0,
+  "ts": 1765400000
+}
+`
+	if err := os.WriteFile(old, []byte(oldBody), 0o644); err != nil {
+		t.Fatalf("write old sidecar: %v", err)
+	}
+	if err := os.Chmod(old, 0o644); err != nil {
+		t.Fatalf("chmod old sidecar: %v", err)
+	}
+
+	if err := writeSpawnFailureRecordTo(SpawnFailureRecord{
+		InstanceID: "new-session",
+		Tool:       "generic",
+		Reason:     "prepare_failed",
+	}, dir); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Fatalf("existing dir perms = %o, want 700", dirInfo.Mode().Perm())
+	}
+	oldInfo, err := os.Stat(old)
+	if err != nil {
+		t.Fatalf("stat old sidecar: %v", err)
+	}
+	if oldInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("old sidecar perms = %o, want 600", oldInfo.Mode().Perm())
+	}
+	data, err := os.ReadFile(old)
+	if err != nil {
+		t.Fatalf("read old sidecar: %v", err)
+	}
+	// Tight perms alone would only hide the credential; it must be gone.
+	if strings.Contains(string(data), "sk-live-OLDSECRET") {
+		t.Fatalf("pre-existing credential still on disk: %s", data)
+	}
+	var got SpawnFailureRecord
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("rewritten sidecar is not valid JSON: %v (%s)", err, data)
+	}
+	if !strings.Contains(got.Command, "export API_KEY='[redacted]'") || !strings.Contains(got.Command, "mytool run") {
+		t.Fatalf("rewrite must redact the value and keep the rest, got: %s", got.Command)
+	}
+	if got.InstanceID != "old-session" || got.Reason != "prepare_failed" || got.Timestamp != 1765400000 {
+		t.Fatalf("rewrite lost non-secret fields: %+v", got)
 	}
 }

--- a/internal/session/spawn_failure_redaction_test.go
+++ b/internal/session/spawn_failure_redaction_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Reproduction of the credential leak: a failed restart with --env used to
+// persist the literal `export API_KEY='secret'` into a 0644 sidecar exposed
+// by session show. The record writer must redact values and write 0600.
+func TestSpawnFailureRecord_RedactsEnvValuesAndTightensPerms(t *testing.T) {
+	dir := t.TempDir()
+	rec := SpawnFailureRecord{
+		InstanceID: "leaktest",
+		Tool:       "generic",
+		Command:    `export API_KEY='sk-live-SECRET' && export NOTE='it'\''s quoted' && mytool run`,
+		Reason:     "prepare_failed",
+		DyingOutput: `prepare failed running: export API_KEY='sk-live-SECRET' && mytool`,
+	}
+	if err := writeSpawnFailureRecordTo(rec, dir); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	path := filepath.Join(dir, "leaktest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(data), "sk-live-SECRET") || strings.Contains(string(data), "quoted") {
+		t.Fatalf("credential value leaked into sidecar: %s", data)
+	}
+	var got SpawnFailureRecord
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(got.Command, "export API_KEY='[redacted]'") {
+		t.Fatalf("key name must stay visible with redacted value, got: %s", got.Command)
+	}
+	if !strings.Contains(got.Command, "mytool run") {
+		t.Fatalf("non-secret command tail must survive, got: %s", got.Command)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("sidecar perms = %o, want 600", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
A failed `session restart --env KEY=...` on a resumable generic tool persisted the literal `export KEY=` string built for the restart into the spawn-failure sidecar — written 0644 (with a shared /tmp fallback) and exposed through `session show --json`. A transient credential became readable by other local users.

Fix at the single choke point every writer funnels through: env export values are redacted (key names stay visible for diagnosis, values become `[redacted]`, including inside DyingOutput error strings), and sidecars are now written 0600 in a 0700 directory.

Reproduce-fix-reprove: the new test writes a record carrying `export API_KEY=(secret)` including the quote-escape form, and asserts the secret is absent from the file, the key survives redacted, the command tail survives, and permissions are 0600. It fails on the previous writer and passes now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive environment-variable values are now redacted from persisted shell commands, captured output, and spawn-failure records.
  * Existing spawn-failure records are securely updated while preserving safe content and non-string fields.
  * Spawn-failure directories and records now use restrictive permissions to help prevent unauthorized access.
  * Symlink targets are protected from unintended modification during cleanup.

* **Tests**
  * Added coverage for secret redaction, safe content preservation, secure permissions, and cleanup of previously insecure records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->