### PR TITLE
fix(cli): stop the #1923 flag guard rejecting valid commands (#1928)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -48,6 +48,18 @@ func tmuxProbeBounded(args ...string) ([]byte, error) {
 	return cmd.Output()
 }
 
+// guardedValueFlags are the flags checkFlagValueNotFlag will police: those whose
+// value is a plain name and can never legitimately look like a flag.
+//
+// It is an ALLOWLIST on purpose. The first version of this check policed every
+// value-taking flag, which broke the documented `--extra-arg --model
+// --extra-arg opus` pass-through — for --extra-arg a flag-shaped value is the
+// entire point, not a mistake (#1928). Only add a flag here when a leading dash
+// in its value is always a user error.
+var guardedValueFlags = map[string]bool{
+	"account": true,
+}
+
 // checkFlagValueNotFlag reports a value-taking flag whose value was omitted and
 // which therefore swallows the NEXT flag as its value (issue #1923).
 //
@@ -86,6 +98,9 @@ func checkFlagValueNotFlag(fs *flag.FlagSet, args []string) error {
 		}
 		name := strings.TrimLeft(arg, "-")
 		if strings.Contains(name, "=") || boolFlags[name] || !known[name] {
+			continue
+		}
+		if !guardedValueFlags[name] {
 			continue
 		}
 		// Read the following token, if there is one. Assigned inside the bounds

--- a/cmd/agent-deck/issue1923_flag_value_test.go
+++ b/cmd/agent-deck/issue1923_flag_value_test.go
@@ -13,6 +13,11 @@ func issue1923FlagSet() *flag.FlagSet {
 	fs.String("account", "", "")
 	fs.String("t", "", "")
 	fs.String("wrapper", "", "")
+	// #1928: extra-arg and model must be registered for the pass-through case
+	// to be exercised at all — an unregistered flag is skipped by the guard, so
+	// without these the P2 regression test would pass vacuously.
+	fs.String("extra-arg", "", "")
+	fs.String("model", "", "")
 	fs.Bool("q", false, "")
 	fs.Bool("sandbox", false, "")
 	return fs
@@ -69,5 +74,84 @@ func TestIssue1923_GuardAcceptsValidUsage(t *testing.T) {
 				t.Errorf("rejected valid args %v: %v", tc.args, err)
 			}
 		})
+	}
+}
+
+// #1928: the first version of this guard policed EVERY value-taking flag and
+// ran after reorderArgsForFlagParsing. Both choices produced false rejections of
+// valid commands. These pin the two reported shapes and the original #1923 case
+// together, because the fix has to keep all three true at once.
+func TestIssue1928_ValidCommandsAreNotRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			// P1. reorderArgsForFlagParsing did not know --account takes a
+			// value, so it moved "work" away as a positional and left
+			// --account sitting next to -q — a pair the user never wrote.
+			"account with its value, followed by a bool flag",
+			[]string{"add", ".", "-t", "title", "--account", "work", "-q"},
+		},
+		{
+			// P2. --extra-arg's whole purpose is passing flags through, so a
+			// flag-shaped value is correct usage, not an omitted value.
+			"documented --extra-arg pass-through of a registered flag name",
+			[]string{"add", ".", "-t", "t2", "--extra-arg", "--model", "--extra-arg", "opus"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := checkFlagValueNotFlag(issue1923FlagSet(), tc.args); err != nil {
+				t.Errorf("valid command rejected (#1928): %v\nargs: %v", err, tc.args)
+			}
+		})
+	}
+}
+
+// Pins WHY the guard runs before reordering rather than after. Reordering the
+// P1 command separates --account from "work"; a guard reading that output sees
+// two adjacent flags and reports a mistake the user never made. Checking the
+// original argv is what makes the guard honest.
+func TestIssue1928_GuardMustRunBeforeReorder(t *testing.T) {
+	original := []string{".", "-t", "title", "--account", "work", "-q"}
+
+	if err := checkFlagValueNotFlag(issue1923FlagSet(), original); err != nil {
+		t.Fatalf("guard rejected the original argv: %v", err)
+	}
+
+	// Simulate the pre-fix call order on a reorderer that does not know
+	// --account takes a value, which is the state main was in.
+	naive := []string{"-t", "title", "--account", "-q", ".", "work"}
+	if err := checkFlagValueNotFlag(issue1923FlagSet(), naive); err == nil {
+		t.Fatal("expected the reordered form to trip the guard — if it does not, " +
+			"this test no longer demonstrates why order matters")
+	}
+}
+
+// The #1923 protection must survive the #1928 narrowing: --account with its
+// value omitted still swallows the next flag, and that is still reported.
+func TestIssue1928_OriginalCaseStillRejected(t *testing.T) {
+	err := checkFlagValueNotFlag(issue1923FlagSet(), []string{"add", ".", "--account", "-q"})
+	if err == nil {
+		t.Fatal("#1923 regression: --account with no value no longer reports swallowing -q")
+	}
+	if !strings.Contains(err.Error(), "-q") {
+		t.Errorf("error should still name the swallowed flag: %v", err)
+	}
+}
+
+// The root cause of P1: reorderArgsForFlagParsing keeps a flag and its value
+// together only for flags it knows take one. --account was missing from that
+// map, which separated them before any guard ran — a mis-parse that predates
+// the guard and would have mangled --account on its own.
+func TestIssue1928_ReorderKeepsAccountValue(t *testing.T) {
+	got := reorderArgsForFlagParsing([]string{".", "-t", "title", "--account", "work", "-q"})
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "--account work") {
+		t.Errorf("reorder separated --account from its value: %v", got)
+	}
+	if got[len(got)-1] != "." {
+		t.Errorf("positional path should be last, got %v", got)
 	}
 }

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1151,6 +1151,10 @@ func reorderArgsForFlagParsing(args []string) []string {
 		"ssh":            true,
 		"remote-path":    true,
 		"tmux-socket":    true,
+		// #928 follow-up: account was missing here, so `--account work` had its
+		// value stripped off as a positional and reordered away from the flag.
+		// That mis-parse predates the #1923 guard; the guard only made it loud.
+		"account": true,
 	}
 
 	var flags []string
@@ -1404,17 +1408,21 @@ func handleAdd(profile string, args []string) {
 	// Reorder args: move path to end so flags are parsed correctly
 	// Go's flag package stops parsing at first non-flag argument
 	// This allows: "add . -c claude" to work same as "add -c claude ."
-	args = reorderArgsForFlagParsing(args)
-
-	// #1923: catch a value-taking flag that swallowed the next flag because its
-	// own value was omitted. Checked before Parse so the report names the real
-	// mistake — `add` stores --account verbatim and never rejects an unknown
-	// name, so without this the session is created against a bogus account and
-	// only surfaces later as a quota error the user cannot trace back to here.
+	// #1923: catch --account swallowing the next flag because its own value was
+	// omitted. `add` stores the account verbatim and never rejects an unknown
+	// name, so otherwise the session is created against a bogus account and only
+	// surfaces later as a quota error the user cannot trace back to here.
+	//
+	// Runs on the ORIGINAL argv, before reordering. reorderArgsForFlagParsing
+	// moves a flag's value when it does not recognise the flag as value-taking,
+	// which can leave two flags adjacent that the user never wrote that way —
+	// so checking after it reports a mistake the user did not make (#1928).
 	if err := checkFlagValueNotFlag(fs, args); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	args = reorderArgsForFlagParsing(args)
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Fixes the P1 and P2 false rejections introduced by my own #1928. Both were reproduced against a build of current `main` before anything was changed, and re-run against the fixed build as proof.

## Reproduction — current `main` (`e80e2c25`), sandboxed HOME

**P1 — a valid command, refused:**

```
$ agent-deck add . -t title --account work -q
Error: -account needs a value, but the next argument is the flag -q.
  Either give -account its value, or move -q elsewhere.
  (If "-q" really is the value you want, pass -account=-q.)
exit=1        # no session created
```

**P2 — the documented `--extra-arg` pass-through, refused:**

```
$ agent-deck add . -c claude -t t2 --extra-arg --model --extra-arg opus
Error: -extra-arg needs a value, but the next argument is the flag --model.
  Either give -extra-arg its value, or move --model elsewhere.
exit=1
```

## After the fix — same commands, same sandbox

```
$ agent-deck add . -t title --account work -q
exit=0        # session created

$ agent-deck add . -c claude -t t2 --extra-arg --model --extra-arg opus
✓ Added session: t2
  Profile: default
exit=0
```

**#1923 still rejected, unchanged:**

```
$ agent-deck add . --account -q
Error: -account needs a value, but the next argument is the flag -q.
exit=1        # before AND after
```

## Cause

**P1 is a pre-existing mis-parse my guard turned fatal.** `reorderArgsForFlagParsing` keeps a flag and its value together only for flags listed in its own `valueFlagNames` map, and `account` was never added there. Proven directly:

```
reorderArgsForFlagParsing([". -t title --account work -q"])
  → [-t title --account -q . work]        # on main
```

`work` is stripped off as a positional, leaving `--account` adjacent to `-q` — a pair the user never wrote. The guard then read that output and reported it. Fixed by adding `account` to the map **and** running the guard on the original argv, before reordering can separate a flag from its value.

**P2 is the guard being too broad.** `--model` is a registered flag name, so a flag-shaped value tripped it — but for `--extra-arg` a flag-shaped value is the entire documented purpose. argv shape alone cannot distinguish "value omitted" from "value legitimately looks like a flag", so that judgement has to be per-flag. The guard now polices an explicit allowlist, `guardedValueFlags`, currently containing only `account` — the flag #1923 was actually about. Adding to it requires that a leading dash in that flag's value is *always* a user error.

## Tests

Three shapes pinned together, because the fix has to keep all three true at once, plus one pinning why the guard runs before reordering rather than after.

Verified against `main` — the new tests fail there with exactly the reported symptoms:

```
--- FAIL: TestIssue1928_ValidCommandsAreNotRejected/documented_--extra-arg_pass-through_of_a_registered_flag_name
    valid command rejected (#1928): -extra-arg needs a value, but the next argument is the flag --model.
--- FAIL: TestIssue1928_ReorderKeepsAccountValue
    reorder separated --account from its value: [-t title --account -q . work]
```

One test-quality note: the P2 case needed `extra-arg` and `model` registered on the test `FlagSet`. Without them the guard skips unregistered flags and the test passed vacuously on main — it was checked and corrected before this was pushed.

`golangci-lint run cmd/agent-deck/...` reports `0 issues`; `gofmt` clean.

## Unrelated flaky test, evidence attached

`TestStatusStale_CLI_CandidateViewAndMutatesNothing` failed in the full-package run here. It is **not** caused by this change — on pristine `main`, isolated, it fails intermittently:

```
pristine-main run 1: ok      run 2: FAIL     run 3: FAIL
pristine-main run 4: ok      run 5: ok       run 6: FAIL
```

3 failures in 6 runs at ~50%. Raising it separately rather than folding it in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line parsing for account values during argument reordering.
  * Prevented missing account values from being incorrectly accepted as another flag’s value.
  * Preserved flag-shaped pass-through values, such as `--extra-arg --model`.
  * Continued rejecting commands where the account value is omitted.

* **Tests**
  * Added regression coverage for valid and invalid flag combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->