### PR TITLE
ci: make the two required gates always able to report

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -20,12 +20,11 @@
 name: Go tests
 
 on:
+  # No paths filter on pull_request: `Full test suite (PR gate)` is a REQUIRED
+  # check, and a path-filtered required check simply never reports on (e.g.)
+  # docs-only PRs, blocking their merge forever. The job instead short-circuits
+  # cheaply when the diff touches nothing Go-related.
   pull_request:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/go-test.yml'
   push:
     branches:
       - main
@@ -52,8 +51,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # Docs-only PRs still need this required check to REPORT, but running the
+      # full race suite for a README tweak is waste. Detect whether anything
+      # Go-related changed; later steps skip (and the job passes) when not.
+      - name: Detect Go-relevant changes
+        id: gochanges
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$)'; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "No Go-relevant changes; passing the gate without running the suite."
+          fi
 
       - name: Set up Go
+        if: steps.gochanges.outputs.go == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
         with:
           go-version-file: go.mod
@@ -63,6 +82,7 @@ jobs:
       # release gate relies on that); install both explicitly here so this gate
       # is never weaker than the release gate it mirrors.
       - name: Install tmux and zoxide
+        if: steps.gochanges.outputs.go == 'true'
         timeout-minutes: 5
         run: |
           sudo apt-get update -qq
@@ -73,6 +93,7 @@ jobs:
       # Mirrors release.yml "Run tests" exactly — same gotestsum flags, same
       # -race, same 20m per-package timeout, same PERF_BUDGET_MULTIPLIER.
       - name: Run tests
+        if: steps.gochanges.outputs.go == 'true'
         timeout-minutes: 30
         env:
           PERF_BUDGET_MULTIPLIER: '2.0'

--- a/.github/workflows/pr-intake.yml
+++ b/.github/workflows/pr-intake.yml
@@ -13,7 +13,10 @@ name: PR Intake Gate (observe-only)
 
 on:
   pull_request_target:
-    types: [opened, edited, ready_for_review]
+    # synchronize/reopened matter because the ruleset requires `intake` on the
+    # CURRENT tip: without them, any PR whose last event was a push could never
+    # satisfy the merge gate (observed on real PRs blocked indefinitely).
+    types: [opened, edited, ready_for_review, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
Two config gaps let the ruleset-required checks permanently block PRs:

1. pr-intake triggered only on opened/edited/ready_for_review, but the ruleset requires the intake check on the CURRENT tip - any PR whose last event was a push could never satisfy the gate (a body edit was the only workaround). Now also fires on synchronize and reopened.

2. go-test was path-filtered to Go files while "Full test suite (PR gate)" is required unconditionally - docs-only PRs waited forever on a check that would never report. The filter is gone; the job instead detects Go-relevant changes and passes cheaply without running the suite when there are none.

Both observed blocking real PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull request validation now reports a required status for every pull request, including those without Go-related changes.
  * Go setup, dependency installation, and tests run only when relevant files are modified, while unrelated changes can pass the required check without unnecessary processing.
  * Pull request intake checks now rerun when changes are synchronized or a pull request is reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->