### PR TITLE
fix(codex): resolve the resume gate against the account's codex home (#1929)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2081,13 +2081,6 @@ func nextShellWord(s string) (word string, remainder string, ok bool) {
 	return b.String(), "", true
 }
 
-func getCodexHomeDirForCommand(command string) string {
-	if codexHome := codexHomeFromCommand(command); codexHome != "" {
-		return codexHome
-	}
-	return getCodexHomeDir()
-}
-
 // accountCodexHomeDir returns the CODEX_HOME mapped to this session's account
 // slot via [profiles.<account>.codex].config_dir, or "" when the session has no
 // account or the account names no codex block.
@@ -2125,19 +2118,37 @@ func (i *Instance) codexHomeToExport() string {
 	return ""
 }
 
+// codexHomeForCommand returns the CODEX_HOME the launched process will actually
+// read and write under, for an already-resolved codex command line.
+//
+// This is the read-side mirror of codexHomeToExport and must stay in step with
+// it: whatever that exports, this resolves to. codexHomeToExport returns "" when
+// nothing needs exporting, in which case the process inherits the ambient
+// CODEX_HOME or falls back to ~/.codex — exactly what getCodexHomeDir resolves
+// to in that case.
+//
+// A resolver that disagrees with the launch is #1929: buildCodexCommand's
+// resume gate looked for the rollout in the DEFAULT home while the launch wrote
+// it under the ACCOUNT home, so the gate always missed, dropped the session id,
+// and every restart silently opened a fresh conversation.
+func (i *Instance) codexHomeForCommand(command string) string {
+	// A CODEX_HOME= embedded in the command is the user typing it by hand for
+	// this session, so it stays the most explicit signal of all — and the shell
+	// agrees, since it is emitted after any exported CODEX_HOME.
+	if codexHome := codexHomeFromCommand(command); codexHome != "" {
+		return codexHome
+	}
+	if accountHome := strings.TrimSpace(i.accountCodexHomeDir()); accountHome != "" {
+		return accountHome
+	}
+	return getCodexHomeDir()
+}
+
 func (i *Instance) getCodexHomeDir() string {
 	if i == nil {
 		return getCodexHomeDir()
 	}
-	// A CODEX_HOME= embedded in the session's own command is the user typing it
-	// by hand for this session, so it stays the most explicit signal of all.
-	if codexHome := codexHomeFromCommand(i.resolveCodexCommand(i.Command)); codexHome != "" {
-		return codexHome
-	}
-	if accountHome := i.accountCodexHomeDir(); accountHome != "" {
-		return accountHome
-	}
-	return getCodexHomeDir()
+	return i.codexHomeForCommand(i.resolveCodexCommand(i.Command))
 }
 
 // Codex stores sessions in ~/.codex/sessions/YYYY/MM/DD/*.jsonl
@@ -2180,7 +2191,10 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	modelFlag := i.resolveCodexModelFlag()
 	reasoningFlag := i.resolveCodexReasoningEffortFlag()
 	command := i.resolveCodexCommand(baseCommand)
-	codexHome := getCodexHomeDirForCommand(command)
+	// Must be the home this launch exports (above), not the process-wide one:
+	// the gates below decide whether a rollout exists, and looking in the wrong
+	// home destroys a live binding (#1929).
+	codexHome := i.codexHomeForCommand(command)
 
 	// Issue #756: Gate `codex resume <sid>` on rollout-file existence.
 	// If Codex died before flushing its rollout JSONL (tmux crash, kill -9
@@ -9408,6 +9422,12 @@ func (i *Instance) CreateForkedCodexInstanceWithOptions(
 	}
 	forked.Tool = i.Tool
 	forked.Wrapper = i.Wrapper
+	// #1929: a fork runs against the parent's thread, so it must run under the
+	// parent's account. Without this the fork resolves its own codex home
+	// through the default chain and `codex fork <parent-sid>` cannot find the
+	// rollout, which lives under the account's home — the fork starts empty and
+	// the account selection is lost from the record too.
+	forked.Account = i.Account
 
 	baseCommand := strings.TrimSpace(i.Command)
 	if baseCommand == "" {

--- a/internal/session/issue1922_codex_account_home_test.go
+++ b/internal/session/issue1922_codex_account_home_test.go
@@ -13,6 +13,10 @@ import (
 func codexAccountHome(t *testing.T) (workHome string) {
 	t.Helper()
 	tmp := withTempHome(t)
+	// withTempHome isolates HOME/XDG but not CODEX_HOME, which outranks the
+	// config on the no-account fallback path — a developer with CODEX_HOME set
+	// would see this suite fail on their own environment.
+	t.Setenv("CODEX_HOME", "")
 	if err := os.MkdirAll(filepath.Join(tmp, ".agent-deck"), 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}

--- a/internal/session/issue1929_codex_account_resume_test.go
+++ b/internal/session/issue1929_codex_account_resume_test.go
@@ -1,0 +1,164 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+// writeCodexRollout drops a minimal user-thread rollout JSONL for sessionID
+// under codexHome, matching the layout codexRolloutPathInHome globs for
+// (codexHome/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl).
+func writeCodexRollout(t *testing.T, codexHome, sessionID string) string {
+	t.Helper()
+	dir := filepath.Join(codexHome, "sessions", "2026", "08", "15")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll rollout dir: %v", err)
+	}
+	path := filepath.Join(dir, "rollout-2026-08-15T10-00-00-"+sessionID+".jsonl")
+	head := `{"type":"session_meta","payload":{"thread_source":"cli","source":"cli"}}` + "\n"
+	if err := os.WriteFile(path, []byte(head), 0o644); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+	return path
+}
+
+// #1929: the #756 resume-existence gate resolved the codex home with the
+// instance-blind getCodexHomeDirForCommand while the launch exported the
+// account-aware codexHomeToExport(). For a session whose account maps to
+// [profiles.<account>.codex].config_dir the rollout lives under the ACCOUNT
+// home but was looked for in the DEFAULT one, so the gate always missed and
+// silently dropped the binding — every restart started a fresh conversation.
+func TestIssue1929_AccountRolloutSurvivesTheResumeGate(t *testing.T) {
+	workHome := codexAccountHome(t)
+	sid := "a1111111-2222-4333-8444-555555555551"
+	writeCodexRollout(t, workHome, sid)
+
+	detectedAt := time.Now().Add(-time.Minute)
+	inst := &Instance{
+		ID: "i1929a", Title: "t", Tool: "codex", Command: "codex",
+		Account:         "work",
+		CodexSessionID:  sid,
+		CodexDetectedAt: detectedAt,
+	}
+
+	cmd := inst.buildCodexCommand("codex")
+
+	if inst.CodexSessionID != sid {
+		t.Fatalf("resume gate cleared the session id: CodexSessionID = %q, want %q — the rollout exists under the account home", inst.CodexSessionID, sid)
+	}
+	if inst.CodexDetectedAt.IsZero() {
+		t.Errorf("resume gate cleared CodexDetectedAt for a session with a live rollout")
+	}
+	if !strings.Contains(cmd, "resume "+sid) {
+		t.Errorf("launch command does not resume the bound session.\ngot: %s", cmd)
+	}
+}
+
+// The subagent-fork safety net reads the same home. With the instance-blind
+// lookup it could never see an account session's rollout, so a poisoned
+// subagent binding launched as `resume` and died on the first typed message.
+func TestIssue1929_SubagentGateSeesTheAccountHome(t *testing.T) {
+	workHome := codexAccountHome(t)
+	sid := "a1111111-2222-4333-8444-555555555552"
+	path := writeCodexRollout(t, workHome, sid)
+	head := `{"type":"session_meta","payload":{"thread_source":"subagent","parent_thread_id":"p"}}` + "\n"
+	if err := os.WriteFile(path, []byte(head), 0o644); err != nil {
+		t.Fatalf("rewrite rollout head: %v", err)
+	}
+
+	inst := &Instance{
+		ID: "i1929b", Title: "t", Tool: "codex", Command: "codex",
+		Account:        "work",
+		CodexSessionID: sid,
+	}
+
+	cmd := inst.buildCodexCommand("codex")
+	if !strings.Contains(cmd, "fork "+sid) {
+		t.Errorf("subagent binding was not forked — the gate looked in the wrong codex home.\ngot: %s", cmd)
+	}
+}
+
+// A session with no account keeps resolving through the env/profile/global
+// chain, so the gate must still find rollouts in the default home.
+func TestIssue1929_NoAccountResumeGateUnchanged(t *testing.T) {
+	tmp := withTempHome(t)
+	t.Setenv("CODEX_HOME", "")
+	globalHome := filepath.Join(tmp, "codex-global")
+	if err := os.MkdirAll(filepath.Join(tmp, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := &UserConfig{}
+	cfg.Codex.ConfigDir = globalHome
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	sid := "a1111111-2222-4333-8444-555555555553"
+	writeCodexRollout(t, globalHome, sid)
+
+	inst := &Instance{
+		ID: "i1929c", Title: "t", Tool: "codex", Command: "codex",
+		CodexSessionID: sid,
+	}
+	cmd := inst.buildCodexCommand("codex")
+	if inst.CodexSessionID != sid {
+		t.Fatalf("resume gate cleared a valid binding in the global codex home")
+	}
+	if !strings.Contains(cmd, "resume "+sid) {
+		t.Errorf("launch command does not resume the bound session.\ngot: %s", cmd)
+	}
+}
+
+// A genuinely stale binding (no rollout anywhere) must still be dropped — the
+// #756 gate's whole purpose. Guards against "fix" by disabling the gate.
+func TestIssue1929_StaleBindingStillDropped(t *testing.T) {
+	codexAccountHome(t)
+	sid := "a1111111-2222-4333-8444-555555555554"
+
+	inst := &Instance{
+		ID: "i1929d", Title: "t", Tool: "codex", Command: "codex",
+		Account:         "work",
+		CodexSessionID:  sid,
+		CodexDetectedAt: time.Now(),
+	}
+	cmd := inst.buildCodexCommand("codex")
+	if inst.CodexSessionID != "" {
+		t.Errorf("stale binding survived the resume gate: %q", inst.CodexSessionID)
+	}
+	if strings.Contains(cmd, "resume ") {
+		t.Errorf("launch command resumes an unresumable session.\ngot: %s", cmd)
+	}
+}
+
+// #1929: CreateForkedCodexInstanceWithOptions never copied Account onto the
+// fork target, so the fork lost the selected account: its launch exported the
+// default codex home and could not find the parent rollout it was forking.
+func TestIssue1929_ForkCarriesTheAccount(t *testing.T) {
+	workHome := codexAccountHome(t)
+	sid := "a1111111-2222-4333-8444-555555555555"
+	writeCodexRollout(t, workHome, sid)
+
+	parent := &Instance{
+		ID: "i1929e", Title: "parent", Tool: "codex", Command: "codex",
+		ProjectPath:    t.TempDir(),
+		Account:        "work",
+		CodexSessionID: sid,
+	}
+
+	forked, cmd, err := parent.CreateForkedCodexInstanceWithOptions("fork", "", nil)
+	if err != nil {
+		t.Fatalf("CreateForkedCodexInstanceWithOptions: %v", err)
+	}
+	if forked.Account != "work" {
+		t.Errorf("fork lost the account: Account = %q, want %q", forked.Account, "work")
+	}
+	want := "CODEX_HOME=" + shellescape.Quote(workHome) + " "
+	if !strings.Contains(cmd, want) {
+		t.Errorf("fork command does not export the account's codex home.\nwant substring: %s\ngot: %s", want, cmd)
+	}
+}


### PR DESCRIPTION
Follow-up to #1929 (merged as c4cbff63). Review found the account-aware codex home was applied to the launch but not to the code that reads it back, and that forks never carried the account at all.

## P1a — the resume gate looked in the wrong home and silently destroyed the binding

`buildCodexCommand` exported `i.codexHomeToExport()` (account-aware) and then resolved the home for its own gates with `getCodexHomeDirForCommand(command)` (instance-blind, ignores `Instance.Account`).

For a session whose account maps to `[profiles.<account>.codex].config_dir`, codex writes its rollout under the **account** home while the gate looked under the **default** one. `codexRolloutExistsInHome` therefore always missed, and the #756 stale-binding branch then cleared `CodexSessionID`, cleared `CodexDetectedAt` and called `ClearHookSessionAnchor(i.ID)`. **Every restart of an account session silently started a fresh conversation and destroyed the thread binding** — no error, nothing the user would read as data loss.

Every other in-function use of that variable had the same mismatch: the subagent-fork safety net (`codexSessionNeedsFork`) reads it too, so a poisoned subagent binding on an account session also slipped past the gate and died on the first typed message.

Fix: one instance method, `codexHomeForCommand`, the read-side mirror of `codexHomeToExport` — command-embedded `CODEX_HOME`, then the account, then the env/profile/global chain. `getCodexHomeDir()` now delegates to it and the instance-blind `getCodexHomeDirForCommand` is gone, so there is a single answer to "which home does this session use" rather than two that drift.

## P1b — forks lost the account

`CreateForkedCodexInstanceWithOptions` copied `Tool`, `Wrapper`, `Command` and the reasoning effort but never `Account`. The fork's own `codexHomeToExport()` then fell back to the default chain, so it exported the wrong home while `codex fork <parent-sid>` needed the rollout that lives under the parent's account home — the fork started empty, and the account selection was lost from the record too. Now copied from the parent.

## P2 — ambient `CODEX_HOME` leaked into the #1922 suite

`codexAccountHome` used `withTempHome`, which isolates HOME/XDG but not `CODEX_HOME` — and the no-account fallback case consults it first. The suite failed on any developer machine with `CODEX_HOME` set. Isolated in the helper, so all four #1922 cases are covered.

---

## Reproduce → fix → re-prove

All runs sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME=`.

### BEFORE — new tests against unmodified `origin/main` (52b407b8)

```
$ go test ./internal/session/ -count=1 -run 'TestIssue1929' -v
=== RUN   TestIssue1929_AccountRolloutSurvivesTheResumeGate
    issue1929_codex_account_resume_test.go:52: resume gate cleared the session id: CodexSessionID = "", want "a1111111-2222-4333-8444-555555555551" — the rollout exists under the account home
--- FAIL: TestIssue1929_AccountRolloutSurvivesTheResumeGate (0.03s)
=== RUN   TestIssue1929_SubagentGateSeesTheAccountHome
    issue1929_codex_account_resume_test.go:82: subagent binding was not forked — the gate looked in the wrong codex home.
        got: ... CODEX_HOME=/tmp/TestIssue1929_SubagentGateSeesTheAccountHome2497401564/001/codex-work codex
--- FAIL: TestIssue1929_SubagentGateSeesTheAccountHome (0.02s)
=== RUN   TestIssue1929_NoAccountResumeGateUnchanged
--- PASS: TestIssue1929_NoAccountResumeGateUnchanged (0.02s)
=== RUN   TestIssue1929_StaleBindingStillDropped
--- PASS: TestIssue1929_StaleBindingStillDropped (0.02s)
=== RUN   TestIssue1929_ForkCarriesTheAccount
    issue1929_codex_account_resume_test.go:158: fork lost the account: Account = "", want "work"
    issue1929_codex_account_resume_test.go:162: fork command does not export the account's codex home.
        want substring: CODEX_HOME=/tmp/TestIssue1929_ForkCarriesTheAccount1819322885/001/codex-work
        got: ... CODEX_HOME=/tmp/TestIssue1929_ForkCarriesTheAccount1819322885/001/codex-global codex fork a1111111-2222-4333-8444-555555555555
--- FAIL: TestIssue1929_ForkCarriesTheAccount (0.02s)
FAIL	github.com/asheshgoplani/agent-deck/internal/session	0.148s
```

Note the fork line: it exports `codex-global` while forking a sid whose rollout exists only in `codex-work`.

P2, same tree, with a developer's `CODEX_HOME` set:

```
$ CODEX_HOME=/home/dev/my-real-codex go test ./internal/session/ -count=1 -run 'TestIssue1922' -v
--- PASS: TestIssue1922_CodexAccountHomeIsExported (0.03s)
--- PASS: TestIssue1922_UnknownAccountFallsThrough (0.02s)
--- PASS: TestIssue1922_CommandEmbeddedHomeBeatsAccount (0.01s)
=== RUN   TestIssue1922_NoAccountUnchanged
    issue1922_codex_account_home_test.go:97: codexHomeToExport() = "/home/dev/my-real-codex", want the configured global codex home
--- FAIL: TestIssue1922_NoAccountUnchanged (0.02s)
FAIL	github.com/asheshgoplani/agent-deck/internal/session	0.126s
```

### AFTER — this branch

```
$ go test ./internal/session/ -count=1 -run 'TestIssue1929|TestIssue1922' -v
--- PASS: TestIssue1922_CodexAccountHomeIsExported (0.03s)
--- PASS: TestIssue1922_UnknownAccountFallsThrough (0.02s)
--- PASS: TestIssue1922_CommandEmbeddedHomeBeatsAccount (0.02s)
--- PASS: TestIssue1922_NoAccountUnchanged (0.01s)
--- PASS: TestIssue1929_AccountRolloutSurvivesTheResumeGate (0.02s)
--- PASS: TestIssue1929_SubagentGateSeesTheAccountHome (0.02s)
--- PASS: TestIssue1929_NoAccountResumeGateUnchanged (0.02s)
--- PASS: TestIssue1929_StaleBindingStillDropped (0.02s)
--- PASS: TestIssue1929_ForkCarriesTheAccount (0.02s)
ok  	github.com/asheshgoplani/agent-deck/internal/session	0.240s

$ CODEX_HOME=/home/dev/my-real-codex go test ./internal/session/ -count=1 -run 'TestIssue1922' -v
... all 4 PASS
ok  	github.com/asheshgoplani/agent-deck/internal/session	0.123s
```

### Gates

```
$ go test ./internal/session/ -count=1
ok  	github.com/asheshgoplani/agent-deck/internal/session	79.408s

$ gofmt -l internal/session/      # no output
$ golangci-lint run internal/session/...
0 issues.
```

## On the tests

Three of the five new cases are genuine regression tests — verified failing on unmodified main above, passing here. The other two are guardrails that pass on both sides on purpose:

- `TestIssue1929_NoAccountResumeGateUnchanged` — a session with no account still resolves through env/profile/global, so the gate must keep finding rollouts in the default home.
- `TestIssue1929_StaleBindingStillDropped` — a binding with no rollout anywhere must still be dropped. That is the whole point of the #756 gate, and it is the obvious wrong way to make P1a's symptom go away.

## Out of scope, worth a look separately

`CreateForkedInstanceWithOptions` (the Claude fork path) does not copy `Account` either. Claude's account level (#924) predates this and resolves through a different chain, so it is not obviously the same bug — flagging rather than changing it here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session resume and fork behavior for account-specific Codex configurations.
  * Ensured resumed sessions use the same account home as when they were launched.
  * Forked sessions now retain the parent session’s account settings.
  * Improved handling of default configurations and stale account bindings.

* **Tests**
  * Added regression coverage for account-aware resume, forking, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->