### PR TITLE
fix(tmux): return an error when a live control pipe has no stdin

### DIFF
--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -294,7 +294,19 @@ func (cp *ControlPipe) SendCommand(command string) (string, error) {
 		cp.mu.RUnlock()
 		return "", fmt.Errorf("pipe not alive for session %s", cp.sessionName)
 	}
+	stdin := cp.stdin
 	cp.mu.RUnlock()
+
+	// alive and stdin are set together by the constructor, so a live pipe
+	// normally has one. Report it rather than trusting the pairing: writing to
+	// a nil stdin panics inside fmt, and every caller of this reaches it from
+	// backgroundStatusUpdate, whose deferred recover swallows the panic and
+	// abandons the whole status sweep — the TUI just stops updating, with one
+	// background_update_panic line as the only evidence. An error here is
+	// handled: RefreshAllActivities records it and moves to the next pipe.
+	if stdin == nil {
+		return "", fmt.Errorf("pipe has no stdin for session %s", cp.sessionName)
+	}
 
 	cp.cmdMu.Lock()
 	defer cp.cmdMu.Unlock()
@@ -306,7 +318,7 @@ func (cp *ControlPipe) SendCommand(command string) (string, error) {
 	}
 
 	// Send command through stdin
-	_, err := fmt.Fprintln(cp.stdin, command)
+	_, err := fmt.Fprintln(stdin, command)
 	if err != nil {
 		return "", fmt.Errorf("write to pipe: %w", err)
 	}

--- a/internal/tmux/controlpipe_test.go
+++ b/internal/tmux/controlpipe_test.go
@@ -523,3 +523,20 @@ func drainEvents(ch <-chan struct{}, duration time.Duration) {
 		}
 	}
 }
+
+// A ControlPipe can be marked alive without ever having been given a stdin —
+// the test seeder does exactly that, and a zero-value pipe would too. Writing
+// to that nil stdin used to panic inside fmt. Because every caller reaches
+// SendCommand from the TUI's background status sweep, whose deferred recover
+// swallows panics, the visible symptom was the sweep dying mid-flight and the
+// TUI quietly ceasing to update statuses. It must return an error instead, so
+// callers like RefreshAllActivities can skip the pipe and carry on.
+func TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking(t *testing.T) {
+	cp := &ControlPipe{sessionName: "no-stdin", alive: true}
+
+	out, err := cp.SendCommand("list-windows")
+
+	require.Error(t, err, "a live pipe with no stdin must report an error")
+	assert.Empty(t, out)
+	assert.Contains(t, err.Error(), "no-stdin", "the error should name the session")
+}


### PR DESCRIPTION
## What

`ControlPipe.SendCommand` checked `cp.alive` and then wrote straight to `cp.stdin`.
A pipe can be marked alive without ever having been given a stdin, and
`fmt.Fprintln` panics on a nil writer.

This reads `stdin` into a local under the existing read lock and returns
`pipe has no stdin for session %s` when it is nil. The later `fmt.Fprintln` uses
that local rather than re-reading the field, so the nil check and the write
cannot disagree if the field changes in between.

## Why it matters

Every caller reaches `SendCommand` from the TUI's background status sweep, whose
deferred `recover` swallows the panic and abandons the rest of the sweep. The
visible symptom is not a crash — the TUI just silently stops updating session
statuses, with one `background_update_panic` line as the only evidence. An error
return is handled: `RefreshAllActivities` records it and moves to the next pipe.

## Provenance

The guard and its test are extracted verbatim from **#1765**
("perf(tui): refresh architecture v2"), which is +2618/-139 and parked on an
unreviewed architecture decision. The panic fix should not wait on that call.
**#1765 can drop this hunk on rebase.** None of the refresh work is included here.

## Reproduce → fix → reprove

Branched from `origin/main` @ `52b407b8` in a fresh worktree. The test was written
and run *first*, against unmodified `origin/main`, with the guard not yet applied.

### BEFORE — `origin/main` + the test, guard NOT applied

```
### label=BEFORE  HEAD=52b407b8  2026-08-16T10:21:06Z
### pkg=./internal/tmux/  run=^TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking$  (-p 1, no -race)
=== RUN   TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking
--- FAIL: TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5031ee]

goroutine 9 [running]:
testing.tRunner.func1.2({0x8e9ca0, 0xdb7610})
	/usr/local/go/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1977 +0x349
panic({0x8e9ca0?, 0xdb7610?})
	/usr/local/go/src/runtime/panic.go:860 +0x13a
fmt.Fprintln({0x0, 0x0}, {0x1f761e5f7ea8, 0x1, 0x1})
	/usr/local/go/src/fmt/print.go:306 +0x4e
github.com/asheshgoplani/agent-deck/internal/tmux.(*ControlPipe).SendCommand(0x1f761e712690, {0x97925a, 0xc})
	/home/ashesh/projects/agent-deck-g14/w-1765-pipe-guard/internal/tmux/controlpipe.go:309 +0x2a5
github.com/asheshgoplani/agent-deck/internal/tmux.TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking(0x1f761e670b48)
	/home/ashesh/projects/agent-deck-g14/w-1765-pipe-guard/internal/tmux/controlpipe_test.go:537 +0x50
testing.tRunner(0x1f761e670b48, 0x9c02e0)
	/usr/local/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:2101 +0x4c5
FAIL	github.com/asheshgoplani/agent-deck/internal/tmux	0.043s
FAIL
### exit=1
```

### AFTER — same commit, same test, guard applied

```
### label=AFTER  HEAD=52b407b8  2026-08-16T10:22:13Z
### pkg=./internal/tmux/  run=^TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking$  (-p 1, no -race)
=== RUN   TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking
--- PASS: TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking (0.00s)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/tmux	0.044s
### exit=0
```

### Does the test fail on pre-fix code?

**Yes.** The BEFORE run above *is* the pre-fix run: same worktree, same test, same
command, at `52b407b8` — the exact parent of this PR's only commit — with the
`controlpipe.go` change absent. It fails with a nil-pointer SIGSEGV inside
`fmt.Fprintln`, raised at `controlpipe.go:309`, which is the
`fmt.Fprintln(cp.stdin, command)` line this PR changes. The test does not pass
before and after; it goes FAIL (panic) → PASS.

## How it was run

Single package, `-run`-filtered to the new test, `-p 1`, no `-race`, in a
sandboxed `HOME` with `XDG_*` cleared:

```
go test ./internal/tmux/ -run '^TestSendCommand_NilStdinReturnsErrorInsteadOfPanicking$' -count=1 -p 1 -v
```

`internal/tmux`'s `TestMain` already calls `testutil.IsolateTmuxSocket()` before
spawning anything, so the run never touches the default tmux socket. Verified: the
box's 4 real sessions on the default socket were unchanged before and after every
run. The new test needs no tmux server at all — it constructs a `ControlPipe`
directly.

Also clean on this package: `gofmt -l` (no output), `go vet`, `golangci-lint run`
(0 issues).

### Tests that could not be isolated, and were skipped

`TestControlPipe_SendCommand` and `TestSession_SendCommand` exercise the live-tmux
`SendCommand` path, but both call `skipIfNoTmuxServer`, which requires a real
pre-existing session beyond `TestMain`'s bootstrap. Under an isolated socket no
such session exists, so both **skip**:

```
--- SKIP: TestControlPipe_SendCommand (0.01s)
    tmux server has only the bootstrap session; legacy test requires a real live session
--- SKIP: TestSession_SendCommand (0.01s)
    tmux server has only the bootstrap session; legacy test requires a real live session
```

Making them run would mean pointing the suite at the default socket, which is not
acceptable on this box. They are unaffected by this change in any case: on every
path where a live pipe has a stdin, the new local is that same stdin and behaviour
is identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented a crash when sending commands through a live session without an available input stream.
  - The operation now returns a clear error while preserving the session name and returning no output.

- **Tests**
  - Added coverage to verify the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->