### PR TITLE
fix(tmux): reap orphaned poll clients safely — composed chain superseding #1832, #1837, #1872

### DIFF
--- a/internal/tmux/control_client_sweep_budget_test.go
+++ b/internal/tmux/control_client_sweep_budget_test.go
@@ -1,0 +1,80 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reapStaleControlClients had no deadline of its own. staleControlSweepTimeout
+// bounded only the `list-clients` query feeding it, so the sweep that follows —
+// one identity read per pid, then a SIGTERM and up to controlClientKillGrace
+// per victim — ran unbounded, synchronously, on the boot path (main.go's
+// SweepStaleControlClients, immediately before the TUI starts). Over the
+// backlog this function documents (176 orphaned clients), that is a startup
+// stall measured in minutes.
+//
+// Commit 3a5af543 makes exactly this argument to get the ORPHAN sweep off the
+// Connect path and did not apply it here, which the maintainer's review called
+// out as a non-blocking finding.
+
+// TestReapStaleControlClients_StopsAndReportsWhenTheBudgetIsSpent is the
+// counterpart of TestSweepOrphanCandidates_StopsAndReportsWhenTheBudgetIsSpent:
+// a spent budget must stop the sweep before it signals anything, and the
+// candidates it never reached must be reported rather than silently dropped.
+func TestReapStaleControlClients_StopsAndReportsWhenTheBudgetIsSpent(t *testing.T) {
+	first := fakeTmuxCandidate(t, "ignore")
+	second := fakeTmuxCandidate(t, "ignore")
+
+	spent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	killed, unexamined := reapStaleControlClients(spent,
+		fmt.Sprintf("1 %d\n1 %d\n", first, second), "(test)")
+
+	assert.Equal(t, 0, killed, "a spent budget must stop the sweep before it signals anything")
+	assert.Equal(t, 2, unexamined, "every candidate the sweep never reached must be reported")
+
+	// Both helpers ignore SIGTERM, so had either been signalled the escalation
+	// would have SIGKILL'd it.
+	time.Sleep(300 * time.Millisecond)
+	assert.NoError(t, syscall.Kill(first, 0), "the first candidate was signalled despite a spent budget")
+	assert.NoError(t, syscall.Kill(second, 0), "the second candidate was signalled despite a spent budget")
+}
+
+// TestSweepStaleControlClients_BoundsTheWholeSweepNotJustTheQuery pins the
+// wiring at the boot-path entry point. Bounding `list-clients` and then handing
+// the sweep a context.Background() is the shape this fix exists to remove, and
+// it is invisible from inside reapStaleControlClients — only the caller can be
+// wrong about it.
+func TestSweepStaleControlClients_BoundsTheWholeSweepNotJustTheQuery(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_sweep_budget"
+	startOrphanLiveSession(t, socket, session)
+	reparentedControlClient(t, socket, session, "attach-session", "-t", session)
+
+	// Record the context the sweep hands its identity reads, and refuse the
+	// read so nothing is signalled: this test is about the deadline, not kills.
+	var gotDeadline bool
+	var sawRead bool
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+	processIdentityOf = func(ctx context.Context, _ int) (string, error) {
+		sawRead = true
+		_, gotDeadline = ctx.Deadline()
+		return "", fmt.Errorf("refused by the test")
+	}
+
+	SweepStaleControlClients(socket)
+
+	require.True(t, sawRead,
+		"the sweep never reached an identity read — the fixture is not exercising the path under test")
+	assert.True(t, gotDeadline,
+		"the sweep's identity reads ran under a context with no deadline: the whole sweep, "+
+			"not just its list-clients query, must be bounded on the boot path")
+}

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -468,9 +468,13 @@ func reapWithEOFGrace(reap func(), proc *os.Process, pgid int, eofGrace, killGra
 		return false
 	case <-time.After(eofGrace):
 	}
-	if proc != nil && proc.Signal(syscall.Signal(0)) == nil {
+	stillOurs := func() bool { return proc != nil && proc.Signal(syscall.Signal(0)) == nil }
+	if stillOurs() {
 		if pgid > 0 {
-			_ = softKillProcessGroup(pgid, killGrace)
+			// stillOurs is re-asked inside, immediately before the escalation:
+			// this check is only true of the instant it runs in, and the
+			// escalation is a whole grace later.
+			_ = softKillProcessGroup(pgid, killGrace, stillOurs)
 		} else {
 			// The child leads no group of its own, so there is nothing wider to
 			// kill than the child. Through its handle, not its pid.

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -42,8 +42,12 @@ type ControlPipe struct {
 	sessionName string
 	socketName  string // tmux -L value; "" means user's default server
 	cmd         *exec.Cmd
-	stdin       io.WriteCloser
-	stdout      io.ReadCloser
+	// pgid is the process group cmd was given at spawn, captured while it was
+	// certainly unreaped. 0 means it leads no group of its own. See
+	// ownProcessGroupID and reapWithEOFGrace.
+	pgid   int
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
 
 	// Event channel: fires when the session produces output
 	outputEvents chan struct{}
@@ -111,6 +115,25 @@ func NewControlPipe(sessionName, socketName string) (*ControlPipe, error) {
 	return nil, lastErr
 }
 
+// ownProcessGroupID returns the process-group id a just-started child leads, or
+// 0 when it leads none of its own.
+//
+// Read once, here, while the child is certainly unreaped: a child started with
+// Setpgid and no explicit Pgid becomes the leader of a group whose id is its own
+// pid, so the group id is known at spawn and never has to be looked up from a
+// pid later — which is the lookup that can answer for a stranger. A child that
+// joined an existing group (Pgid != 0) leads nothing, and killing the group it
+// merely belongs to would reach processes this pipe never started.
+func ownProcessGroupID(cmd *exec.Cmd) int {
+	if cmd.Process == nil || cmd.SysProcAttr == nil {
+		return 0
+	}
+	if !cmd.SysProcAttr.Setpgid || cmd.SysProcAttr.Pgid != 0 {
+		return 0
+	}
+	return cmd.Process.Pid
+}
+
 func newControlPipeOnce(sessionName, socketName string) (*ControlPipe, error) {
 	cmd := tmuxExec(socketName, "-u", "-C", "attach-session", "-t", sessionName)
 	// Put in own process group so we can kill the entire group on shutdown
@@ -135,6 +158,7 @@ func newControlPipeOnce(sessionName, socketName string) (*ControlPipe, error) {
 		sessionName:  sessionName,
 		socketName:   socketName,
 		cmd:          cmd,
+		pgid:         ownProcessGroupID(cmd),
 		stdin:        stdin,
 		stdout:       stdout,
 		outputEvents: make(chan struct{}, 64),
@@ -393,7 +417,7 @@ func (cp *ControlPipe) Close() {
 		// timeout, while still routing the underlying cmd.Wait() through
 		// the waitOnce gate that protects against a concurrent Wait from
 		// reader() (#677).
-		usedFallback := reapWithEOFGrace(cp.reap, cp.cmd.Process, controlPipeEOFExitGrace, controlClientKillGrace)
+		usedFallback := reapWithEOFGrace(cp.reap, cp.cmd.Process, cp.pgid, controlPipeEOFExitGrace, controlClientKillGrace)
 		if usedFallback {
 			pipeLog.Warn("eof_fallback_fired",
 				slog.String("session", cp.sessionName),
@@ -418,7 +442,22 @@ func (cp *ControlPipe) Close() {
 // underlying cmd.Wait through their own once-guard — the production
 // caller (ControlPipe.Close) needs this to coordinate with reader()'s
 // concurrent reap (#677); the test caller passes a plain wrapper.
-func reapWithEOFGrace(reap func(), proc *os.Process, eofGrace, killGrace time.Duration) (usedFallback bool) {
+//
+// pgid is the process group the child was given AT SPAWN (0 if it leads no
+// group of its own). It is not looked up here on purpose: a lookup keyed on
+// proc.Pid answers for whoever holds that number NOW, and once the child has
+// been waited on that is not necessarily the child. That is the same recycled-
+// pid hazard the single-pid arm below is guarded against, but resolved into a
+// whole process group and then SIGTERMed and SIGKILLed — a strictly wider blast
+// radius on what used to be the unguarded arm.
+//
+// Both arms are gated on the handle. os.Process.Signal reports ErrProcessDone
+// once the process has been waited on, and only while it has NOT been waited on
+// is its pid — and therefore the pgid it leads — guaranteed still to name the
+// child. Reaching the fallback with a reaped handle is not hypothetical: reap
+// shares a once-guard with reader(), so reader() can complete the Wait while
+// this call is still waiting for its own turn to return.
+func reapWithEOFGrace(reap func(), proc *os.Process, pgid int, eofGrace, killGrace time.Duration) (usedFallback bool) {
 	reapDone := make(chan struct{})
 	go func() {
 		reap()
@@ -429,15 +468,12 @@ func reapWithEOFGrace(reap func(), proc *os.Process, eofGrace, killGrace time.Du
 		return false
 	case <-time.After(eofGrace):
 	}
-	if proc != nil {
-		if pgid, err := syscall.Getpgid(proc.Pid); err == nil {
+	if proc != nil && proc.Signal(syscall.Signal(0)) == nil {
+		if pgid > 0 {
 			_ = softKillProcessGroup(pgid, killGrace)
 		} else {
-			// Pgid lookup failed (process already exited or not a group
-			// leader) — fall back to soft-killing the child itself. Through
-			// its handle, not its pid: this is our own child and Wait may
-			// already have reaped it, so a bare pid here could name whoever
-			// inherited the number.
+			// The child leads no group of its own, so there is nothing wider to
+			// kill than the child. Through its handle, not its pid.
 			_ = softKillProcessHandle(proc, killGrace)
 		}
 	}

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -434,8 +434,11 @@ func reapWithEOFGrace(reap func(), proc *os.Process, eofGrace, killGrace time.Du
 			_ = softKillProcessGroup(pgid, killGrace)
 		} else {
 			// Pgid lookup failed (process already exited or not a group
-			// leader) — fall back to single-pid soft-kill.
-			_ = softKillProcess(proc.Pid, killGrace)
+			// leader) — fall back to soft-killing the child itself. Through
+			// its handle, not its pid: this is our own child and Wait may
+			// already have reaped it, so a bare pid here could name whoever
+			// inherited the number.
+			_ = softKillProcessHandle(proc, killGrace)
 		}
 	}
 	<-reapDone

--- a/internal/tmux/default_socket_guard.go
+++ b/internal/tmux/default_socket_guard.go
@@ -162,44 +162,78 @@ func isExistingSocket(path string) bool {
 	return info.Mode()&os.ModeSocket != 0
 }
 
-// socketPathFlag returns the value of a leading global `-S <path>` flag.
-//
-// Scanning stops at the first argument that is not a flag, i.e. at the tmux
-// command itself. That boundary is load-bearing: `-S` means "socket path" only
-// as a server flag, and means "start line" to capture-pane
-// (`capture-pane -p -S -2000`) and "status line" to refresh-client. Treating a
-// command-level -S as a socket would mistake "-2000" for a socket path.
+// socketPathFlag returns the value of a leading global `-S <path>` flag, in any
+// of the spellings tmux's getopt accepts. See leadingFlagValue for those, and
+// for why the scan stops at the tmux command.
 func socketPathFlag(args []string) string {
-	return leadingFlagValue(args, "-S")
+	return leadingFlagValue(args, 'S')
 }
 
 // socketNameFlag returns the value of a leading global `-L <name>` flag. The
 // factory inserts -L from its socketName argument, but a call site may also
 // pass one through directly.
 func socketNameFlag(args []string) string {
-	return leadingFlagValue(args, "-L")
+	return leadingFlagValue(args, 'L')
 }
 
-// leadingFlagValue finds `flag <value>` within the run of global flags that
-// precedes the tmux command.
-func leadingFlagValue(args []string, flag string) string {
+// tmuxValueFlags are the global flags that consume a value: `-c shell-command`,
+// `-f file`, `-L socket-name`, `-S socket-path`, `-T features`. Every other
+// global tmux accepts (-2 -C -l -N -q -u -v) is a boolean.
+const tmuxValueFlags = "cfLST"
+
+// leadingFlagValue finds the value of a single-letter global flag within the
+// run of global flags that precedes the tmux command.
+//
+// tmux parses its globals with getopt(3), so one flag has three spellings that
+// all mean the same thing, and the socket flags reach this function in all of
+// them:
+//
+//	tmux -L work ls      separated
+//	tmux -Lwork ls       attached
+//	tmux -CLwork attach  bundled behind booleans, then attached
+//
+// Verified live on tmux 3.0a: all three report the same "error connecting to
+// /tmp/tmux-1000/work". Matching whole argv words (`arg == "-L"`) sees only the
+// first, and answers "no socket selector" for the other two — which resolves to
+// the DEFAULT socket. That is the wrong server for both callers: for
+// assertTmuxSpawnIsolated a spawn aimed at the user's real server reads as
+// isolated, and for the orphan sweep a client that is alive on its own server
+// reads as not-live. So the scan walks each word one flag character at a time.
+//
+// Scanning still stops at the first argument that is not a flag, i.e. at the
+// tmux command itself. That boundary is load-bearing: `-S` means "socket path"
+// only as a global, and means "start line" to capture-pane
+// (`capture-pane -p -S -2000`, or `-S-2000`) and "status line" to
+// refresh-client. Treating a command-level -S as a socket would mistake "-2000"
+// for a socket path.
+func leadingFlagValue(args []string, flag byte) string {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if !strings.HasPrefix(arg, "-") {
+		if len(arg) < 2 || arg[0] != '-' {
 			// The tmux command. Anything after this belongs to it.
 			return ""
 		}
-		if arg == flag {
-			if i+1 < len(args) {
-				return strings.TrimSpace(args[i+1])
+		for j := 1; j < len(arg); j++ {
+			c := arg[j]
+			if !strings.ContainsRune(tmuxValueFlags, rune(c)) {
+				continue // a boolean; keep reading the bundle
 			}
-			return ""
-		}
-		// Global flags that themselves take a value; skip the value so it is
-		// never mistaken for a flag or for the command.
-		switch arg {
-		case "-f", "-L", "-S", "-T", "-c":
-			i++
+			// Everything after the flag letter is its value; an empty
+			// remainder means the value is the next word.
+			value := arg[j+1:]
+			if value == "" {
+				if i+1 >= len(args) {
+					return ""
+				}
+				value = args[i+1]
+				i++
+			}
+			if c == flag {
+				return strings.TrimSpace(value)
+			}
+			// A different value flag. Its value is consumed either way, so it
+			// can never be mistaken for a flag or for the command.
+			break
 		}
 	}
 	return ""

--- a/internal/tmux/default_socket_guard.go
+++ b/internal/tmux/default_socket_guard.go
@@ -200,18 +200,39 @@ const tmuxValueFlags = "cfLST"
 // isolated, and for the orphan sweep a client that is alive on its own server
 // reads as not-live. So the scan walks each word one flag character at a time.
 //
-// Scanning still stops at the first argument that is not a flag, i.e. at the
-// tmux command itself. That boundary is load-bearing: `-S` means "socket path"
-// only as a global, and means "start line" to capture-pane
-// (`capture-pane -p -S -2000`, or `-S-2000`) and "status line" to
-// refresh-client. Treating a command-level -S as a socket would mistake "-2000"
-// for a socket path.
+// A repeated flag keeps its LAST value, because that is what getopt leaves
+// behind: tmux assigns as it parses, so the second `-L` overwrites the first.
+// Verified live on tmux 3.0a — `tmux -L zzza1 -L zzzb2 ls` reports "error
+// connecting to /tmp/tmux-1000/zzzb2", and `-S` behaves the same. Answering
+// with the FIRST value is not a harmless imprecision: it names a server tmux
+// will not talk to, so `-S <isolated> -S <the user's default>` reads as an
+// isolated spawn to assertTmuxSpawnIsolated while tmux kill-servers the user's
+// real fleet. It is also invisible to a socket comparison, since both sides of
+// that comparison would mis-read the same argv the same way and agree.
+//
+// Scanning stops at `--`, and at the first argument that is not a flag, i.e. at
+// the tmux command itself. Both boundaries are load-bearing:
+//
+//   - `--` ends the globals for getopt, so `tmux -- -Lfoo ls` treats -Lfoo as
+//     the COMMAND ("unknown command: -Lfoo" on 3.0a). Reading a selector out of
+//     it invents a server that was never named.
+//   - `-S` means "socket path" only as a global; it means "start line" to
+//     capture-pane (`capture-pane -p -S -2000`, or `-S-2000`) and "status line"
+//     to refresh-client. Treating a command-level -S as a socket would mistake
+//     "-2000" for a socket path.
+//
+// Values are returned verbatim. tmux does not trim them — `tmux -L ' name' ls`
+// really does resolve to a socket whose name begins with a space — and a parser
+// that trims names a different server than the one the argv asks for.
 func leadingFlagValue(args []string, flag byte) string {
+	value := ""
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if arg == "--" {
+			return value // getopt stops here; the rest is the command
+		}
 		if len(arg) < 2 || arg[0] != '-' {
-			// The tmux command. Anything after this belongs to it.
-			return ""
+			return value // the tmux command; anything after belongs to it
 		}
 		for j := 1; j < len(arg); j++ {
 			c := arg[j]
@@ -220,23 +241,23 @@ func leadingFlagValue(args []string, flag byte) string {
 			}
 			// Everything after the flag letter is its value; an empty
 			// remainder means the value is the next word.
-			value := arg[j+1:]
-			if value == "" {
+			v := arg[j+1:]
+			if v == "" {
 				if i+1 >= len(args) {
-					return ""
+					return value
 				}
-				value = args[i+1]
+				v = args[i+1]
 				i++
 			}
 			if c == flag {
-				return strings.TrimSpace(value)
+				value = v // last occurrence wins, as getopt's assignment does
 			}
 			// A different value flag. Its value is consumed either way, so it
 			// can never be mistaken for a flag or for the command.
 			break
 		}
 	}
-	return ""
+	return value
 }
 
 // socketPathFromTmuxEnv extracts the socket path from a $TMUX value, which tmux

--- a/internal/tmux/default_socket_guard_test.go
+++ b/internal/tmux/default_socket_guard_test.go
@@ -85,6 +85,46 @@ func TestResolveTmuxSocketPath(t *testing.T) {
 			args: []string{"-C", "attach-session", "-t", "sess"},
 			want: filepath.Join(isolated, "tmux-501", "default"),
 		},
+		// tmux parses its global flags with getopt(3), so every separated form
+		// below has an attached and/or bundled spelling that means exactly the
+		// same thing to tmux. Verified live on tmux 3.0a: `tmux -Lfoo ls`,
+		// `tmux -CLfoo ls` and `tmux -uLfoo ls` all report the same
+		// "error connecting to /tmp/tmux-1000/foo". A resolver that only
+		// understands `-L foo` reads all three as "no socket selector" and
+		// answers with the DEFAULT socket — the wrong server.
+		{
+			name: "attached -L value",
+			env:  nil,
+			args: []string{"-Lad1031-cafe", "list-sessions"},
+			want: filepath.Join("/tmp", "tmux-501", "ad1031-cafe"),
+		},
+		{
+			name: "attached -S value",
+			env:  map[string]string{"TMUX_TMPDIR": isolated},
+			args: []string{"-S/tmp/ad-sock-xyz/s", "list-sessions"},
+			want: "/tmp/ad-sock-xyz/s",
+		},
+		{
+			name: "boolean flags bundled ahead of an attached -L",
+			env:  nil,
+			args: []string{"-CLad1031-cafe", "attach-session", "-t", "sess"},
+			want: filepath.Join("/tmp", "tmux-501", "ad1031-cafe"),
+		},
+		{
+			name: "boolean flags bundled ahead of a separated -L",
+			env:  nil,
+			args: []string{"-uL", "ad1031-cafe", "list-sessions"},
+			want: filepath.Join("/tmp", "tmux-501", "ad1031-cafe"),
+		},
+		{
+			// The command boundary still rules: capture-pane's own -S means
+			// "start line". Its attached spelling must stay invisible here for
+			// the same reason the separated one is.
+			name: "an attached -S that belongs to the COMMAND is not a socket path",
+			env:  map[string]string{"TMUX_TMPDIR": isolated},
+			args: []string{"capture-pane", "-t", "sess", "-p", "-e", "-S-2000"},
+			want: filepath.Join(isolated, "tmux-501", "default"),
+		},
 	}
 
 	for _, tc := range cases {
@@ -133,6 +173,20 @@ func TestAssertTmuxSpawnIsolated_RefusesUserDefaultSocket(t *testing.T) {
 			name: "keysender-shaped control client on the default socket",
 			env:  nil,
 			args: []string{"-C", "attach-session", "-t", "agentdeck_x"},
+		},
+		{
+			// The guard exists to keep a test binary off the user's real
+			// server. An -S it cannot parse resolves to the isolated
+			// TMUX_TMPDIR instead and reads as safe, so the guard waves
+			// through the exact spawn it was written to refuse.
+			name: "explicit -S at the default socket, attached spelling",
+			env:  map[string]string{"TMUX_TMPDIR": "/tmp/ad-tmux-abc"},
+			args: []string{"-S/private/tmp/tmux-501/default", "kill-server"},
+		},
+		{
+			name: "control-mode flag bundled ahead of an attached -S at the default socket",
+			env:  map[string]string{"TMUX_TMPDIR": "/tmp/ad-tmux-abc"},
+			args: []string{"-CS/tmp/tmux-501/default", "attach-session", "-t", "agentdeck_x"},
 		},
 	}
 

--- a/internal/tmux/default_socket_guard_test.go
+++ b/internal/tmux/default_socket_guard_test.go
@@ -125,6 +125,39 @@ func TestResolveTmuxSocketPath(t *testing.T) {
 			args: []string{"capture-pane", "-t", "sess", "-p", "-e", "-S-2000"},
 			want: filepath.Join(isolated, "tmux-501", "default"),
 		},
+		// getopt assigns as it goes, so a repeated flag ends up holding its LAST
+		// value. Verified live on tmux 3.0a: `tmux -L zzza1 -L zzzb2 ls` reports
+		// "error connecting to /tmp/tmux-1000/zzzb2", and the same for -S.
+		// Answering with the first value names a server tmux will not talk to.
+		{
+			name: "the LAST of a repeated -L wins",
+			env:  nil,
+			args: []string{"-L", "first-name", "-L", "second-name", "list-sessions"},
+			want: filepath.Join("/tmp", "tmux-501", "second-name"),
+		},
+		{
+			name: "the LAST of a repeated -S wins",
+			env:  map[string]string{"TMUX_TMPDIR": isolated},
+			args: []string{"-S", "/tmp/first.sock", "-S", "/tmp/second.sock", "list-sessions"},
+			want: "/tmp/second.sock",
+		},
+		{
+			// `tmux -- -Lfoo ls` reports "unknown command: -Lfoo" on 3.0a: getopt
+			// stopped at --, so -Lfoo is the COMMAND and the socket is the
+			// default one. Reading a selector out of it invents a server.
+			name: "-- ends the global flags",
+			env:  map[string]string{"TMUX_TMPDIR": isolated},
+			args: []string{"--", "-Lfoo", "list-sessions"},
+			want: filepath.Join(isolated, "tmux-501", "default"),
+		},
+		{
+			// `tmux -L ' zzzspace' ls` reports "error connecting to
+			// /tmp/tmux-1000/ zzzspace" — the space is part of the name.
+			name: "whitespace in a socket name is significant",
+			env:  nil,
+			args: []string{"-L", " spaced", "list-sessions"},
+			want: filepath.Join("/tmp", "tmux-501", " spaced"),
+		},
 	}
 
 	for _, tc := range cases {
@@ -187,6 +220,19 @@ func TestAssertTmuxSpawnIsolated_RefusesUserDefaultSocket(t *testing.T) {
 			name: "control-mode flag bundled ahead of an attached -S at the default socket",
 			env:  map[string]string{"TMUX_TMPDIR": "/tmp/ad-tmux-abc"},
 			args: []string{"-CS/tmp/tmux-501/default", "attach-session", "-t", "agentdeck_x"},
+		},
+		{
+			// The isolated -S first, the user's real server second. tmux takes
+			// the LAST one, so this argv kill-servers the user's fleet while a
+			// first-match parser reads the isolated path and calls it safe.
+			name: "an isolated -S followed by the default socket",
+			env:  map[string]string{"TMUX_TMPDIR": "/tmp/ad-tmux-abc"},
+			args: []string{"-S", "/tmp/ad-sock-xyz/s", "-S", "/private/tmp/tmux-501/default", "kill-server"},
+		},
+		{
+			name: "a name-keyed -L followed by the default socket name",
+			env:  nil,
+			args: []string{"-L", "ad1031-cafe", "-L", "default", "kill-server"},
 		},
 	}
 

--- a/internal/tmux/keysender.go
+++ b/internal/tmux/keysender.go
@@ -51,7 +51,10 @@ type KeySender interface {
 type localKeySender struct {
 	target string
 	cmd    *exec.Cmd
-	stdin  io.WriteCloser
+	// pgid is the process group cmd was given at spawn, captured while it was
+	// certainly unreaped. See ownProcessGroupID and reapWithEOFGrace.
+	pgid  int
+	stdin io.WriteCloser
 
 	waitOnce sync.Once
 
@@ -118,7 +121,7 @@ func OpenKeySender(socket, target string) (KeySender, error) {
 		_ = stdout.Close()
 		return nil, fmt.Errorf("keysender: start tmux -C -u attach-session: %w", err)
 	}
-	k := &localKeySender{target: target, cmd: cmd, stdin: stdin}
+	k := &localKeySender{target: target, cmd: cmd, pgid: ownProcessGroupID(cmd), stdin: stdin}
 
 	// Drain stdout so the OS pipe buffer never fills and blocks Send writes,
 	// and settle the attach handshake on the way past. tmux answers the
@@ -233,7 +236,7 @@ func (k *localKeySender) Close() error {
 	// v1.5.x cascade incident). Killing the GROUP — not just the pid — is
 	// what guarantees Close tears down everything Open spawned.
 	if cmd != nil && cmd.Process != nil {
-		_ = reapWithEOFGrace(k.reap, cmd.Process, keySenderEOFExitGrace, controlClientKillGrace)
+		_ = reapWithEOFGrace(k.reap, cmd.Process, k.pgid, keySenderEOFExitGrace, controlClientKillGrace)
 	}
 	return nil
 }

--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -10,37 +10,28 @@ func nulArgv(fields ...string) string {
 	return strings.Join(fields, "\x00") + "\x00"
 }
 
-// TestIsReapableOneShotArgv pins WHICH tmux clients the orphan sweep may kill.
+// TestIsKnownCadenceArgv pins the SCOPE this sweep targets: the one-shot
+// poll/query/status commands agent-deck fires on a cadence. It is
+// deliberately NOT a safety test — isKnownCadenceArgv is an allowlist that
+// only ever narrows the sweep, never a denylist that could be trusted to keep
+// something out. See TestIsLiveTmuxClientOrServer_ChainedAliasRepro for the
+// actual safety guarantee and why it cannot live in this function.
 //
-// Matching on comm alone (a tmux client) plus SessionPrefix (argv mentions an
-// agent-deck session) is too broad in two directions, both of which SIGKILL
-// something the user cares about:
-//
-//   - An INTERACTIVE client. A user who runs `tmux attach-session -t
-//     agentdeck_foo` by hand gets a client whose parent is their shell, not
-//     agent-deck — and isControlClientOrphan treats any non-agent-deck parent
-//     as an orphan even while that parent is alive. Verified on a live host:
-//     such a client is selected for the kill. The session survives on the
-//     server, but the user is detached mid-interaction. Control-mode clients
-//     are already covered by reapStaleControlClients, which filters on
-//     client_control_mode and does not have this blind spot, so attach clients
-//     of either kind have no business in this sweep.
-//
-//   - A NASCENT SERVER. tmux renames the client to "tmux: client" before it
-//     forks the server (client.c calls proc_start("client") ahead of
-//     client_connect), and the forked server inherits that comm until its own
-//     proc_start("server") runs after daemon(). In that window a starting
-//     server presents comm "tmux: client" AND the creating client's argv
-//     (servers keep it — confirmed live: a running server shows
-//     `new-session -d -s agentdeck_…`) AND a parent that is either tmux or
-//     init. All three kill conditions hold. The window is sub-millisecond, but
-//     agent-deck starts one server per session during restore, concurrently
-//     with the first Connect that fires the sweep.
-//
-// Constraining the sweep to the one-shot cadence verbs it documents as its
-// target set closes both: neither attach-session nor new-session is a cadence
-// query, so neither is reapable regardless of comm or parentage.
-func TestIsReapableOneShotArgv(t *testing.T) {
+// History: this file used to pin isReapableOneShotArgv, which paired this
+// same allowlist with a denylist (neverReapVerbs) matching only the literal
+// strings "attach-session" / "new-session" and trusted that pairing as the
+// safety boundary. It was wrong to: tmux resolves command names by
+// unambiguous prefix, so "attach" (a real tmux alias), "attac", "att", "at",
+// even bare "a" all invoke attach-session unmodified (verified live on tmux
+// 3.7b — `tmux -C a -t sess` attaches). A chained
+// `tmux attach -t agentdeck_x \; set-option status on` cleared the old
+// denylist (wrong spelling) while "set-option" satisfied this allowlist, so
+// isReapableOneShotArgv ruled the whole line reapable with a live client
+// behind it. isKnownCadenceArgv keeps only the allowlist half — a miss here
+// means "skip", a hit means only "maybe, ask the server" — and
+// isLiveTmuxClientOrServer supplies the actual guarantee by asking the tmux
+// server itself, which cannot be abbreviated around.
+func TestIsKnownCadenceArgv(t *testing.T) {
 	tests := []struct {
 		name string
 		argv []string
@@ -58,19 +49,15 @@ func TestIsReapableOneShotArgv(t *testing.T) {
 		{"has-session", []string{"tmux", "has-session", "-t", "agentdeck_x"}, true},
 		{"kill-session mutation", []string{"tmux", "kill-session", "-t", "agentdeck_x"}, true},
 
-		// Interactive and control-mode attaches: never this sweep's business.
-		{"interactive attach", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
-		{"control-mode attach", []string{"tmux", "-C", "attach-session", "-t", "agentdeck_npm_a0e435da"}, false},
-
-		// A server being born carries the creating client's argv.
-		{"new-session", []string{"tmux", "-L", "ad-sock", "new-session", "-d", "-s", "agentdeck_x", "-c", "/home/u"}, false},
-
-		// A chained command that both attaches and sets an option must lose:
-		// the deny side is fail-safe, the allow side is an optimisation.
-		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+		// A cadence verb chained after an attach still matches the allowlist —
+		// that is expected and fine, because this function no longer decides
+		// whether the process is safe to kill. isLiveTmuxClientOrServer does.
+		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, true},
+		{"alias attach chained with set-option", []string{"tmux", "attach", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, true},
 
 		// Verbs outside the cadence set are not reapable even though they are
 		// legitimate tmux commands against an agent-deck session.
+		{"bare attach-session, no cadence verb", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
 		{"pipe-pane", []string{"tmux", "pipe-pane", "-t", "agentdeck_x", "cat > /tmp/log"}, false},
 		{"send-keys", []string{"tmux", "send-keys", "-t", "agentdeck_x", "hello", "Enter"}, false},
 		{"no verb at all", []string{"tmux"}, false},
@@ -79,9 +66,9 @@ func TestIsReapableOneShotArgv(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isReapableOneShotArgv(nulArgv(tc.argv...))
+			got := isKnownCadenceArgv(nulArgv(tc.argv...))
 			if got != tc.want {
-				t.Errorf("isReapableOneShotArgv(%q) = %v, want %v", tc.argv, got, tc.want)
+				t.Errorf("isKnownCadenceArgv(%q) = %v, want %v", tc.argv, got, tc.want)
 			}
 		})
 	}

--- a/internal/tmux/orphan_reap_argv_test.go
+++ b/internal/tmux/orphan_reap_argv_test.go
@@ -1,0 +1,88 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// nulArgv builds a /proc/<pid>/cmdline payload: NUL-separated, NUL-terminated.
+func nulArgv(fields ...string) string {
+	return strings.Join(fields, "\x00") + "\x00"
+}
+
+// TestIsReapableOneShotArgv pins WHICH tmux clients the orphan sweep may kill.
+//
+// Matching on comm alone (a tmux client) plus SessionPrefix (argv mentions an
+// agent-deck session) is too broad in two directions, both of which SIGKILL
+// something the user cares about:
+//
+//   - An INTERACTIVE client. A user who runs `tmux attach-session -t
+//     agentdeck_foo` by hand gets a client whose parent is their shell, not
+//     agent-deck — and isControlClientOrphan treats any non-agent-deck parent
+//     as an orphan even while that parent is alive. Verified on a live host:
+//     such a client is selected for the kill. The session survives on the
+//     server, but the user is detached mid-interaction. Control-mode clients
+//     are already covered by reapStaleControlClients, which filters on
+//     client_control_mode and does not have this blind spot, so attach clients
+//     of either kind have no business in this sweep.
+//
+//   - A NASCENT SERVER. tmux renames the client to "tmux: client" before it
+//     forks the server (client.c calls proc_start("client") ahead of
+//     client_connect), and the forked server inherits that comm until its own
+//     proc_start("server") runs after daemon(). In that window a starting
+//     server presents comm "tmux: client" AND the creating client's argv
+//     (servers keep it — confirmed live: a running server shows
+//     `new-session -d -s agentdeck_…`) AND a parent that is either tmux or
+//     init. All three kill conditions hold. The window is sub-millisecond, but
+//     agent-deck starts one server per session during restore, concurrently
+//     with the first Connect that fires the sweep.
+//
+// Constraining the sweep to the one-shot cadence verbs it documents as its
+// target set closes both: neither attach-session nor new-session is a cadence
+// query, so neither is reapable regardless of comm or parentage.
+func TestIsReapableOneShotArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		// The 2026-08-01 orphan: a chained status-bar set-option batch.
+		{
+			"chained set-option batch",
+			[]string{"tmux", "set-option", "-t", "agentdeck_npm_a0e435da", "@agentdeck_project_name", "workspace", ";", "set-option", "-t", "agentdeck_npm_a0e435da", "set-titles", "on"},
+			true,
+		},
+		{"list-clients", []string{"tmux", "list-clients", "-F", "#{session_name}"}, true},
+		{"display-message", []string{"tmux", "display-message", "-p", "-t", "agentdeck_x", "#{pane_pid}"}, true},
+		{"list-panes with socket flag", []string{"tmux", "-L", "ad-sock", "list-panes", "-t", "agentdeck_x"}, true},
+		{"has-session", []string{"tmux", "has-session", "-t", "agentdeck_x"}, true},
+		{"kill-session mutation", []string{"tmux", "kill-session", "-t", "agentdeck_x"}, true},
+
+		// Interactive and control-mode attaches: never this sweep's business.
+		{"interactive attach", []string{"tmux", "attach-session", "-t", "agentdeck_dev_d83a1787"}, false},
+		{"control-mode attach", []string{"tmux", "-C", "attach-session", "-t", "agentdeck_npm_a0e435da"}, false},
+
+		// A server being born carries the creating client's argv.
+		{"new-session", []string{"tmux", "-L", "ad-sock", "new-session", "-d", "-s", "agentdeck_x", "-c", "/home/u"}, false},
+
+		// A chained command that both attaches and sets an option must lose:
+		// the deny side is fail-safe, the allow side is an optimisation.
+		{"attach chained with set-option", []string{"tmux", "attach-session", "-t", "agentdeck_x", ";", "set-option", "status", "on"}, false},
+
+		// Verbs outside the cadence set are not reapable even though they are
+		// legitimate tmux commands against an agent-deck session.
+		{"pipe-pane", []string{"tmux", "pipe-pane", "-t", "agentdeck_x", "cat > /tmp/log"}, false},
+		{"send-keys", []string{"tmux", "send-keys", "-t", "agentdeck_x", "hello", "Enter"}, false},
+		{"no verb at all", []string{"tmux"}, false},
+		{"empty", []string{}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isReapableOneShotArgv(nulArgv(tc.argv...))
+			if got != tc.want {
+				t.Errorf("isReapableOneShotArgv(%q) = %v, want %v", tc.argv, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/orphan_reap_budget_test.go
+++ b/internal/tmux/orphan_reap_budget_test.go
@@ -1,0 +1,163 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The orphan sweep asks a tmux server about every candidate it cannot rule out
+// cheaply, and those queries are slowest on exactly the wedged host that
+// produced the orphans. Two properties keep that from becoming the problem it
+// is meant to solve: the whole sweep runs under ONE deadline, and it does not
+// run on the goroutine that opens sessions.
+
+// TestSweepOrphanCandidates_StopsAndReportsWhenTheBudgetIsSpent pins the first.
+// A sweep out of budget stops where it is and says how much it never looked at
+// — it does not keep querying, and it does not return counts that read like a
+// clean run. Silent truncation here would recreate the original failure of this
+// code: a sweep that did nothing looked exactly like one that found nothing.
+func TestSweepOrphanCandidates_StopsAndReportsWhenTheBudgetIsSpent(t *testing.T) {
+	spent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	queries := 0
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) {
+		queries++
+		return false, true
+	})
+
+	candidates := []orphanCandidate{
+		{pid: 1 << 30, comm: "tmux: client", cmdline: cadenceCmdline("a"), identity: "id-a"},
+		{pid: 1<<30 + 1, comm: "tmux: client", cmdline: cadenceCmdline("b"), identity: "id-b"},
+	}
+
+	killed, skipped, unexamined := sweepOrphanCandidates(spent, candidates)
+
+	assert.Equal(t, 0, killed)
+	assert.Equal(t, 0, skipped)
+	assert.Equal(t, len(candidates), unexamined, "every unjudged candidate must be reported")
+	assert.Equal(t, 0, queries, "a spent budget must stop the queries, not just the kills")
+}
+
+// TestSweepOrphanCandidates_BudgetIsAggregateNotPerCandidate pins that the
+// deadline covers the sweep as a whole. Before this, each candidate carried its
+// own two-second allowance, so total cost scaled with the number of candidates
+// — twenty orphans meant a sweep nobody had bounded.
+//
+// Each stubbed query burns a slice of a deliberately small budget, so the run
+// must stop partway through a candidate list that a per-candidate allowance
+// would have walked to the end.
+func TestSweepOrphanCandidates_BudgetIsAggregateNotPerCandidate(t *testing.T) {
+	budget, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	t.Cleanup(cancel)
+
+	stubLiveTmuxIdentity(t, func(ctx context.Context, _ int, _ []string) (bool, bool) {
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-ctx.Done():
+		}
+		return true, true // live: preserved, so nothing here is ever signalled
+	})
+
+	candidates := make([]orphanCandidate, 20)
+	for i := range candidates {
+		candidates[i] = orphanCandidate{
+			pid:      1<<30 + i,
+			comm:     "tmux: client",
+			cmdline:  cadenceCmdline("s"),
+			identity: "id",
+		}
+	}
+
+	killed, _, unexamined := sweepOrphanCandidates(budget, candidates)
+
+	assert.Equal(t, 0, killed)
+	assert.Positive(t, unexamined,
+		"the sweep must stop at its own deadline; a per-candidate allowance would have judged all %d",
+		len(candidates))
+}
+
+// TestIsLiveTmuxClientOrServer_RefusesOnceTheBudgetIsSpent pins the nesting
+// underneath: the per-probe cap is derived FROM the budget rather than being a
+// separate allowance, so a probe started after the budget is gone cannot run at
+// all — and a query that produced no answer is unclassifiable, which the sweep
+// treats as "refuse to kill". No tmux server is involved: there is nothing left
+// to ask with.
+func TestIsLiveTmuxClientOrServer_RefusesOnceTheBudgetIsSpent(t *testing.T) {
+	spent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	live, ok := isLiveTmuxClientOrServer(spent, 1<<30, []string{"tmux", "-L", "no-such-socket", "list-clients"})
+
+	assert.False(t, ok, "a query with no budget left cannot classify anything")
+	assert.False(t, live)
+}
+
+// TestStartOrphanReapOnce_RunsInTheBackgroundExactlyOnce pins the second
+// property. The sweep sits on Connect, which is the fleet-restore path, and it
+// now costs tmux subprocesses per candidate — so it must not be something a
+// session open waits for, and twenty sessions opening at once must still
+// produce exactly one sweep.
+func TestStartOrphanReapOnce_RunsInTheBackgroundExactlyOnce(t *testing.T) {
+	originalFn := orphanReapFn
+	originalStarted := orphanReapStarted.Load()
+	t.Cleanup(func() {
+		orphanReapFn = originalFn
+		// Restore whatever the suite had — TestMain marks the sweep started so
+		// no Connect launches a real one mid-suite.
+		orphanReapStarted.Store(originalStarted)
+	})
+	orphanReapStarted.Store(false)
+
+	release := make(chan struct{})
+	running := make(chan struct{})
+	runs := 0
+	orphanReapFn = func() {
+		runs++
+		close(running)
+		<-release
+	}
+
+	returned := make(chan struct{})
+	go func() {
+		startOrphanReapOnce()
+		startOrphanReapOnce() // a second Connect must not queue a second sweep
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startOrphanReapOnce blocked its caller: the sweep is back on the Connect path")
+	}
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the sweep never started")
+	}
+	close(release)
+
+	// Nothing else can start it now: the flag is set and the only in-flight run
+	// has been released.
+	require.Eventually(t, func() bool { return runs == 1 }, 2*time.Second, 10*time.Millisecond)
+	startOrphanReapOnce()
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, runs, "the sweep must run at most once per agent-deck run")
+}
+
+// cadenceCmdline builds the NUL-separated /proc cmdline of a one-shot cadence
+// client targeting an agent-deck session — the argv shape the sweep's scope
+// checks are looking for.
+func cadenceCmdline(session string) string {
+	fields := []string{"tmux", "-L", "sock", "list-clients", "-t", SessionPrefix + session}
+	out := ""
+	for _, f := range fields {
+		out += f + "\x00"
+	}
+	return out
+}

--- a/internal/tmux/orphan_reap_budget_test.go
+++ b/internal/tmux/orphan_reap_budget_test.go
@@ -35,11 +35,12 @@ func TestSweepOrphanCandidates_StopsAndReportsWhenTheBudgetIsSpent(t *testing.T)
 		{pid: 1<<30 + 1, comm: "tmux: client", cmdline: cadenceCmdline("b"), identity: "id-b"},
 	}
 
-	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(spent, candidates)
+	killed, unclassifiable, notSignalled, unknownParent, unexamined := sweepOrphanCandidates(spent, candidates)
 
 	assert.Equal(t, 0, killed)
 	assert.Equal(t, 0, unclassifiable)
 	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unknownParent)
 	assert.Equal(t, len(candidates), unexamined, "every unjudged candidate must be reported")
 	assert.Equal(t, 0, queries, "a spent budget must stop the queries, not just the kills")
 }
@@ -74,7 +75,7 @@ func TestSweepOrphanCandidates_BudgetIsAggregateNotPerCandidate(t *testing.T) {
 		}
 	}
 
-	killed, _, _, unexamined := sweepOrphanCandidates(budget, candidates)
+	killed, _, _, _, unexamined := sweepOrphanCandidates(budget, candidates)
 
 	assert.Equal(t, 0, killed)
 	assert.Positive(t, unexamined,

--- a/internal/tmux/orphan_reap_budget_test.go
+++ b/internal/tmux/orphan_reap_budget_test.go
@@ -35,10 +35,11 @@ func TestSweepOrphanCandidates_StopsAndReportsWhenTheBudgetIsSpent(t *testing.T)
 		{pid: 1<<30 + 1, comm: "tmux: client", cmdline: cadenceCmdline("b"), identity: "id-b"},
 	}
 
-	killed, skipped, unexamined := sweepOrphanCandidates(spent, candidates)
+	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(spent, candidates)
 
 	assert.Equal(t, 0, killed)
-	assert.Equal(t, 0, skipped)
+	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, notSignalled)
 	assert.Equal(t, len(candidates), unexamined, "every unjudged candidate must be reported")
 	assert.Equal(t, 0, queries, "a spent budget must stop the queries, not just the kills")
 }
@@ -73,7 +74,7 @@ func TestSweepOrphanCandidates_BudgetIsAggregateNotPerCandidate(t *testing.T) {
 		}
 	}
 
-	killed, _, unexamined := sweepOrphanCandidates(budget, candidates)
+	killed, _, _, unexamined := sweepOrphanCandidates(budget, candidates)
 
 	assert.Equal(t, 0, killed)
 	assert.Positive(t, unexamined,
@@ -160,4 +161,34 @@ func cadenceCmdline(session string) string {
 		out += f + "\x00"
 	}
 	return out
+}
+
+// TestKillStaleControlClients_LaunchesTheOrphanSweep pins the wiring itself.
+// The launcher is only reached from killStaleControlClients, and every test
+// above drives the sweep's internals directly, so without this one the call at
+// the top of killStaleControlClients could be deleted and the whole suite would
+// still pass — the sweep would simply never run in production again, which is
+// the exact shape of the bug this code was written to fix.
+func TestKillStaleControlClients_LaunchesTheOrphanSweep(t *testing.T) {
+	originalFn := orphanReapFn
+	originalStarted := orphanReapStarted.Load()
+	t.Cleanup(func() {
+		orphanReapFn = originalFn
+		orphanReapStarted.Store(originalStarted)
+	})
+
+	launched := make(chan struct{})
+	orphanReapFn = func() { close(launched) }
+	orphanReapStarted.Store(false)
+
+	// The tmux half of killStaleControlClients fails fast against a socket with
+	// no server and is not what this asserts; the launch must happen first and
+	// regardless.
+	killStaleControlClients("no-such-session", "no-such-socket-for-the-launch-test")
+
+	select {
+	case <-launched:
+	case <-time.After(5 * time.Second):
+		t.Fatal("killStaleControlClients no longer launches the orphan sweep")
+	}
 }

--- a/internal/tmux/orphan_reap_comm_test.go
+++ b/internal/tmux/orphan_reap_comm_test.go
@@ -1,0 +1,63 @@
+package tmux
+
+import "testing"
+
+// TestIsReapableTmuxClientComm pins the /proc/<pid>/comm values that the
+// orphaned-poll-client sweep must recognise as a tmux CLIENT.
+//
+// The 2026-08-01 incident: two orphaned clients — `tmux list-clients` and
+// `tmux set-option -t agentdeck_npm_a0e435da …` — spun at ~98% CPU for 14
+// hours (13h47m and 13h43m of CPU time, 1023/1022 open fds, nearly all
+// anon_inode:[eventpoll]) while a healthy agent-deck TUI ran alongside them
+// for 12.5 of those hours and never reaped either one.
+//
+// reapOrphanedPollClients filtered on `comm == "tmux"`, documented as "the
+// server is 'tmux: server' and never matches". Half of that is right: the
+// server does rename itself. What the filter missed is that tmux renames the
+// CLIENT too — comm is "tmux: client", not "tmux". Measured on tmux 3.0a /
+// Linux 5.4, where `pgrep -x tmux` matches zero processes on a host running
+// twenty of them:
+//
+//	comm=[tmux: client]  argv=[tmux -C attach-session -t agentdeck_mvn_672de607]
+//	comm=[tmux: server]  argv=[/usr/bin/tmux -L ad1031-2044680 new-session -d …]
+//
+// So the equality test never held for any process, the sweep was inert on
+// every Linux host, and the orphans it exists to mop up survived indefinitely.
+//
+// Rejecting "tmux: server" is the load-bearing safety property here, not a
+// nicety: the sweep SIGKILLs what it matches, and killing a server would
+// destroy every session it hosts — the user's work, not a leaked query client.
+func TestIsReapableTmuxClientComm(t *testing.T) {
+	tests := []struct {
+		name string
+		comm string
+		want bool
+	}{
+		// The value actually observed for one-shot query/option clients on
+		// Linux. This is the case the original filter missed.
+		{"renamed client", "tmux: client", true},
+		// Trailing newline: /proc/<pid>/comm always ends in one.
+		{"renamed client with newline", "tmux: client\n", true},
+		// Kept for platforms/versions that do not rename the client.
+		{"bare tmux", "tmux", true},
+		{"bare tmux with newline", "tmux\n", true},
+
+		// Never reapable — killing a server destroys live user sessions.
+		{"server", "tmux: server", false},
+		{"server with newline", "tmux: server\n", false},
+
+		// Unrelated binaries whose names merely start with "tmux".
+		{"tmuxinator", "tmuxinator", false},
+		{"tmuxp", "tmuxp", false},
+		{"empty", "", false},
+		{"unrelated", "bash", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReapableTmuxClientComm(tc.comm); got != tc.want {
+				t.Errorf("isReapableTmuxClientComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/orphan_reap_comm_test.go
+++ b/internal/tmux/orphan_reap_comm_test.go
@@ -51,12 +51,77 @@ func TestIsReapableTmuxClientComm(t *testing.T) {
 		{"tmuxp", "tmuxp", false},
 		{"empty", "", false},
 		{"unrelated", "bash", false},
+
+		// A tmux invoked under a longer argv[0] still names its role as long
+		// as "<progname>: <role>" survives the 15-char comm limit. The role
+		// token is what authorises the kill, not the program name, so these
+		// are reapable — see tmuxCommRole.
+		{"five-char progname keeps role", "tmuxx: client", true},
+		{"five-char progname server", "tmuxx: server", false},
+
+		// Measured, not assumed: invoking /usr/bin/tmux through a symlink
+		// named "tmux-3.5a" yields exactly this comm — the role token is gone
+		// entirely, not truncated to a prefix. tmux formats "<progname>:
+		// <role> (<socket>)", the kernel caps comm at 15 chars, and tmux then
+		// cuts the result back to its last space, which for a 9-char progname
+		// lands immediately after the colon.
+		//
+		// A SERVER under the same binary produces the identical string, so
+		// nothing here can tell the two apart. Refusing to match is the only
+		// safe answer: a false positive SIGKILLs a server and takes every
+		// session it hosts with it. agent-deck never spawns tmux this way
+		// (every call site is exec.Command("tmux", …), so argv[0] is the
+		// literal "tmux"), so no orphan of its own can land in this state.
+		{"renamed binary loses role", "tmux-3.5a:", false},
+		{"renamed binary loses role, newline", "tmux-3.5a:\n", false},
+		{"colon with no role", "tmux:", false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isReapableTmuxClientComm(tc.comm); got != tc.want {
 				t.Errorf("isReapableTmuxClientComm(%q) = %v, want %v", tc.comm, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsTruncatedTmuxComm pins which comm values the sweep must REPORT rather
+// than silently pass over.
+//
+// The original defect was not that the sweep killed the wrong thing — it was
+// that it killed nothing at all and said nothing about it, so two orphans burned
+// a core each for 14 hours with a healthy TUI running beside them. A comm whose
+// role token was lost to truncation puts the sweep back in exactly that state
+// for the affected process: it cannot be classified, so it cannot be reaped.
+// That is the right call, but it must be visible, not silent.
+func TestIsTruncatedTmuxComm(t *testing.T) {
+	tests := []struct {
+		name string
+		comm string
+		want bool
+	}{
+		// Role lost to truncation — unclassifiable, so worth reporting.
+		{"renamed binary", "tmux-3.5a:", true},
+		{"renamed binary with newline", "tmux-3.5a:\n", true},
+		{"bare colon", "tmux:", true},
+
+		// Classifiable: handled normally, nothing to report.
+		{"client", "tmux: client", false},
+		{"server", "tmux: server", false},
+		{"bare tmux", "tmux", false},
+		{"long progname keeping role", "tmuxx: client", false},
+
+		// Not tmux at all — the sweep skips these silently and always did.
+		{"bash", "bash", false},
+		{"empty", "", false},
+		{"unrelated with colon", "systemd:", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTruncatedTmuxComm(tc.comm); got != tc.want {
+				t.Errorf("isTruncatedTmuxComm(%q) = %v, want %v", tc.comm, got, tc.want)
 			}
 		})
 	}

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -1,0 +1,307 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The orphan sweep decides to kill a pid on the strength of facts it read out
+// of /proc, and only signals it after asking a tmux server about it — a query
+// that can take seconds on exactly the unhealthy host that produced the orphans
+// in the first place. A pid is not a stable name for a process across that gap.
+//
+// These tests cover the gap end to end: that the facts a verdict rests on all
+// belong to ONE incarnation of the pid (readOrphanCandidate), and that a pid
+// which changes hands after those facts are taken is refused rather than
+// killed (sweepOrphanCandidates). The unit-level guarantees either side of it —
+// the identity re-check immediately before each signal — live in
+// softkill_pid_reuse_test.go.
+//
+// Candidates here are real reparented processes with a real "tmux" comm, not
+// synthetic structs: the collector's pre-filter, the comm classification and
+// isControlClientOrphan's parentage check all read /proc for themselves, and a
+// test that fed them strings would prove nothing about the code that runs in
+// production.
+
+// fakeTmuxCandidate starts the test binary in helper mode through a symlink
+// named "tmux", with an argv shaped like the leaked one-shot cadence client the
+// sweep exists to reap, and returns its pid.
+//
+// Two properties are bought by the awkward spawn:
+//
+//   - comm. The kernel takes comm from the basename of the path handed to
+//     execve, so a symlink named "tmux" is enough to make a Go test binary
+//     present to the sweep exactly as a tmux client does (the same mechanism
+//     that produces the truncated "tmux-3.5a:" comm this package documents).
+//   - parentage. The helper is launched from an `sh -c '… & exit 0'` wrapper
+//     that exits immediately, so the kernel reparents it to init. A direct
+//     child of the test binary would be preserved by isControlClientOrphan for
+//     the wrong reason — its parent's exe IS the agent-deck-shaped binary — and
+//     every assertion below would pass without the code under test doing
+//     anything.
+//
+// The returned pid is not this process's child, so it cannot be reaped with
+// Wait; teardown SIGKILLs it and waits for the pid to disappear, which init
+// makes prompt.
+func fakeTmuxCandidate(t *testing.T, role string, extraEnv ...string) int {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("candidate collection reads procfs; linux-only by construction")
+	}
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	dir := t.TempDir()
+	link := filepath.Join(dir, "tmux")
+	require.NoError(t, os.Symlink(exe, link))
+
+	ready := filepath.Join(dir, "ready")
+	env := []string{
+		"SOFTKILL_TEST_HELPER=" + role,
+		softkillReadyEnv + "=" + ready,
+	}
+	env = append(env, extraEnv...)
+
+	// argv the sweep must recognise: an agent-deck session target
+	// (SessionPrefix) and a cadence verb from reapableOneShotVerbs. The
+	// -test.run guard keeps the child out of the test framework even if the
+	// TestMain helper dispatch is ever reordered.
+	argv := []string{link, "-test.run=^$", "-L", "orphan-identity-test",
+		"list-clients", "-t", SessionPrefix + "identity_probe"}
+
+	quoted := make([]string, 0, len(env)+len(argv))
+	for _, kv := range env {
+		key, value, _ := strings.Cut(kv, "=")
+		quoted = append(quoted, key+"="+shQuote(value))
+	}
+	for _, arg := range argv {
+		quoted = append(quoted, shQuote(arg))
+	}
+	// Background the helper and exit at once: when sh goes, the kernel
+	// reparents the helper to init.
+	//
+	// The pid travels through a file and the helper's own output goes to a
+	// log, rather than either riding sh's stdout: a backgrounded child
+	// inherits the stdout pipe, so an exec.Command().Output() here would not
+	// return until the helper itself exited — which for these roles is never.
+	pidPath := filepath.Join(dir, "pid")
+	logPath := filepath.Join(dir, "out.log")
+	script := strings.Join(quoted, " ") + " > " + shQuote(logPath) + " 2>&1 & echo $! > " + shQuote(pidPath) + "; exit 0"
+	wrapper := exec.Command("sh", "-c", script)
+	out, err := wrapper.CombinedOutput()
+	require.NoError(t, err, "spawning the reparented candidate: %s", out)
+	wrapperPID := wrapper.Process.Pid
+
+	var pidBytes []byte
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err = os.ReadFile(pidPath)
+		if err == nil && strings.TrimSpace(string(pidBytes)) != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		logContents, _ := os.ReadFile(logPath)
+		t.Fatalf("read pid file: %v (helper log: %s)", err, logContents)
+	}
+
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+		// init reaps it, so the pid genuinely disappears rather than
+		// lingering as a zombie that still answers signal 0.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if err := syscall.Kill(pid, 0); err != nil {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Errorf("reparented helper pid %d survived SIGKILL; a test child was leaked", pid)
+	})
+
+	waitForReady(t, ready, 10*time.Second)
+
+	// Confirm the reparent actually happened before handing the pid back. A
+	// pid still parented to the wrapper shell would satisfy isControlClientOrphan
+	// for the wrong reason on a slow scheduler, silently weakening every test
+	// that follows.
+	//
+	// "Reparented" is "no longer the wrapper's child", not "ppid == 1": the
+	// kernel hands an orphan to the nearest subreaper, which under a
+	// `systemd --user` session (or inside a container) is not init. Waiting for
+	// pid 1 specifically would spin out the deadline on such hosts and prove
+	// less than this does.
+	require.Eventually(t, func() bool {
+		ppid, err := readParentPID(pid)
+		return err == nil && ppid != wrapperPID
+	}, 5*time.Second, 10*time.Millisecond,
+		"pid %d never left the wrapper shell — cannot prove this is a genuine orphan", pid)
+
+	// Pin the two properties the spawn exists to buy, so a future change to
+	// either mechanism fails here rather than silently making every test below
+	// vacuous.
+	comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	require.NoError(t, err)
+	require.True(t, isReapableTmuxClientComm(string(comm)),
+		"the symlink must give the helper a tmux client's comm, got %q", strings.TrimSpace(string(comm)))
+	require.True(t, isControlClientOrphan(pid),
+		"the helper must be a genuine parentage orphan, or the sweep would preserve it for the wrong reason")
+
+	return pid
+}
+
+// stubLiveTmuxIdentity replaces the tmux-server query with a fixed verdict.
+// The real query needs a live server and is exercised against one in
+// orphan_reap_live_identity_test.go; what these tests are about is what the
+// gauntlet does with the answer, and what happens to the pid while it is being
+// fetched.
+func stubLiveTmuxIdentity(t *testing.T, fn func(pid int, cmdlineFields []string) (live, ok bool)) {
+	t.Helper()
+	original := liveTmuxIdentityOf
+	t.Cleanup(func() { liveTmuxIdentityOf = original })
+	liveTmuxIdentityOf = fn
+}
+
+// TestReadOrphanCandidate_AcceptsAStableCandidate is the no-regression half:
+// bracketing the classify reads with identity reads must not stop the collector
+// from collecting. Without this, every "refuses to kill" test below could pass
+// against a collector that simply never returns a candidate.
+func TestReadOrphanCandidate_AcceptsAStableCandidate(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+
+	c, identifiable, ok := readOrphanCandidate(pid)
+
+	require.True(t, ok, "a live tmux-shaped orphan must be collected as a candidate")
+	assert.True(t, identifiable)
+	assert.Equal(t, pid, c.pid)
+	assert.Contains(t, c.cmdline, SessionPrefix, "the candidate must carry the argv its verdict rests on")
+	identity, err := readProcessIdentity(pid)
+	require.NoError(t, err)
+	assert.Equal(t, identity, c.identity, "the candidate must carry this incarnation's identity")
+}
+
+// TestReadOrphanCandidate_DropsWhenIdentityChangesBetweenReads is the reason the
+// identity is read twice. If a pid changes hands while the collector is reading
+// it, the comm and cmdline describe the process that died and the identity
+// describes the one that took its number — a chimera that would then be judged,
+// and whose identity would still match at signal time because it belongs to the
+// live process. Facts from two processes must produce no candidate at all.
+func TestReadOrphanCandidate_DropsWhenIdentityChangesBetweenReads(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+	calls := 0
+	processIdentityOf = func(p int) (string, error) {
+		calls++
+		if calls == 1 {
+			return "identity-of-the-process-that-died", nil
+		}
+		return original(p)
+	}
+
+	_, identifiable, ok := readOrphanCandidate(pid)
+
+	assert.False(t, ok, "facts spanning two incarnations must not become a candidate")
+	assert.False(t, identifiable, "the drop must be reported, not silent")
+	assert.GreaterOrEqual(t, calls, 2, "the collector must re-read the identity after the classify reads")
+}
+
+// TestReadOrphanCandidate_DropsWhenIdentityUnreadable pins the fail-closed rule
+// at the collector: a pid whose identity cannot be read cannot be tied to any
+// later signal, so it never becomes a candidate — and is counted, so a sweep
+// that has gone inert on such a host says so.
+func TestReadOrphanCandidate_DropsWhenIdentityUnreadable(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+	processIdentityOf = func(int) (string, error) {
+		return "", errors.New("no /proc and no ps on this host")
+	}
+
+	_, identifiable, ok := readOrphanCandidate(pid)
+
+	assert.False(t, ok)
+	assert.False(t, identifiable, "an unidentifiable candidate must be reported, not silently skipped")
+}
+
+// TestSweepOrphanCandidates_KillsAnIdentifiedOrphan is the positive control for
+// the whole file. The guard is only interesting if the sweep still reaps what
+// it is supposed to reap: a real orphaned process with a tmux client's comm, an
+// agent-deck cadence argv, no live registration on the server, and an identity
+// that never changes must be killed.
+func TestSweepOrphanCandidates_KillsAnIdentifiedOrphan(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "term-handled")
+	pid := fakeTmuxCandidate(t, "clean", "MARKER="+marker)
+
+	c, _, ok := readOrphanCandidate(pid)
+	require.True(t, ok)
+	stubLiveTmuxIdentity(t, func(int, []string) (bool, bool) { return false, true })
+
+	killed, skipped := sweepOrphanCandidates([]orphanCandidate{c})
+
+	assert.Equal(t, 1, killed, "an identified orphan must still be reaped")
+	assert.Equal(t, 0, skipped)
+	assert.NoError(t, waitForFile(marker, 5*time.Second),
+		"the victim must have received the SIGTERM its handler writes the marker from")
+}
+
+// TestSweepOrphanCandidates_RefusesWhenPIDChangesHandsDuringTheLiveQuery is the
+// boundary this composed change exists for.
+//
+// The tmux-server query is the slowest step in the gauntlet — two subprocesses,
+// each bounded by tmuxLiveQueryTimeout, and slowest precisely on the unhealthy
+// host that produces orphans. A pid that exits during it and has its number
+// reissued must not be signalled on the strength of facts belonging to the
+// process that is gone.
+//
+// The stub makes the pid appear to change hands while the query runs, which is
+// what a reissue looks like from here; forcing a real one would take a full
+// pid_max wrap inside the window and prove no more. The helper ignores SIGTERM,
+// so had the sweep signalled it the escalation would have SIGKILL'd it and its
+// survival would be unambiguous.
+//
+// This is the assertion that fails if the identity is ever captured at kill
+// time again instead of before classification: a late capture reads the new
+// occupant's identity, matches it against itself, and kills.
+func TestSweepOrphanCandidates_RefusesWhenPIDChangesHandsDuringTheLiveQuery(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+
+	c, _, ok := readOrphanCandidate(pid)
+	require.True(t, ok)
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+	stubLiveTmuxIdentity(t, func(int, []string) (bool, bool) {
+		// The pid changes hands mid-query: every identity read from here on
+		// belongs to whoever holds the number now.
+		processIdentityOf = func(int) (string, error) { return "identity-of-the-new-occupant", nil }
+		return false, true
+	})
+
+	killed, skipped := sweepOrphanCandidates([]orphanCandidate{c})
+
+	assert.Equal(t, 0, killed, "a pid that changed hands during classification must not be killed")
+	assert.Equal(t, 1, skipped, "the refusal must be counted, not silent")
+
+	processIdentityOf = original
+	time.Sleep(300 * time.Millisecond)
+	assert.NoError(t, syscall.Kill(pid, 0),
+		"the new occupant of the pid was signalled; it is not this sweep's to kill")
+}

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -169,7 +170,7 @@ func fakeTmuxCandidate(t *testing.T, role string, extraEnv ...string) int {
 // orphan_reap_live_identity_test.go; what these tests are about is what the
 // gauntlet does with the answer, and what happens to the pid while it is being
 // fetched.
-func stubLiveTmuxIdentity(t *testing.T, fn func(pid int, cmdlineFields []string) (live, ok bool)) {
+func stubLiveTmuxIdentity(t *testing.T, fn func(budget context.Context, pid int, cmdlineFields []string) (live, ok bool)) {
 	t.Helper()
 	original := liveTmuxIdentityOf
 	t.Cleanup(func() { liveTmuxIdentityOf = original })
@@ -183,13 +184,13 @@ func stubLiveTmuxIdentity(t *testing.T, fn func(pid int, cmdlineFields []string)
 func TestReadOrphanCandidate_AcceptsAStableCandidate(t *testing.T) {
 	pid := fakeTmuxCandidate(t, "ignore")
 
-	c, identifiable, ok := readOrphanCandidate(pid)
+	c, identifiable, ok := readOrphanCandidate(context.Background(), pid)
 
 	require.True(t, ok, "a live tmux-shaped orphan must be collected as a candidate")
 	assert.True(t, identifiable)
 	assert.Equal(t, pid, c.pid)
 	assert.Contains(t, c.cmdline, SessionPrefix, "the candidate must carry the argv its verdict rests on")
-	identity, err := readProcessIdentity(pid)
+	identity, err := readProcessIdentity(context.Background(), pid)
 	require.NoError(t, err)
 	assert.Equal(t, identity, c.identity, "the candidate must carry this incarnation's identity")
 }
@@ -206,15 +207,15 @@ func TestReadOrphanCandidate_DropsWhenIdentityChangesBetweenReads(t *testing.T) 
 	original := processIdentityOf
 	t.Cleanup(func() { processIdentityOf = original })
 	calls := 0
-	processIdentityOf = func(p int) (string, error) {
+	processIdentityOf = func(ctx context.Context, p int) (string, error) {
 		calls++
 		if calls == 1 {
 			return "identity-of-the-process-that-died", nil
 		}
-		return original(p)
+		return original(ctx, p)
 	}
 
-	_, identifiable, ok := readOrphanCandidate(pid)
+	_, identifiable, ok := readOrphanCandidate(context.Background(), pid)
 
 	assert.False(t, ok, "facts spanning two incarnations must not become a candidate")
 	assert.False(t, identifiable, "the drop must be reported, not silent")
@@ -230,11 +231,11 @@ func TestReadOrphanCandidate_DropsWhenIdentityUnreadable(t *testing.T) {
 
 	original := processIdentityOf
 	t.Cleanup(func() { processIdentityOf = original })
-	processIdentityOf = func(int) (string, error) {
+	processIdentityOf = func(context.Context, int) (string, error) {
 		return "", errors.New("no /proc and no ps on this host")
 	}
 
-	_, identifiable, ok := readOrphanCandidate(pid)
+	_, identifiable, ok := readOrphanCandidate(context.Background(), pid)
 
 	assert.False(t, ok)
 	assert.False(t, identifiable, "an unidentifiable candidate must be reported, not silently skipped")
@@ -250,14 +251,15 @@ func TestSweepOrphanCandidates_KillsAnIdentifiedOrphan(t *testing.T) {
 	marker := filepath.Join(dir, "term-handled")
 	pid := fakeTmuxCandidate(t, "clean", "MARKER="+marker)
 
-	c, _, ok := readOrphanCandidate(pid)
+	c, _, ok := readOrphanCandidate(context.Background(), pid)
 	require.True(t, ok)
-	stubLiveTmuxIdentity(t, func(int, []string) (bool, bool) { return false, true })
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
 
-	killed, skipped := sweepOrphanCandidates([]orphanCandidate{c})
+	killed, skipped, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
 
 	assert.Equal(t, 1, killed, "an identified orphan must still be reaped")
 	assert.Equal(t, 0, skipped)
+	assert.Equal(t, 0, unexamined)
 	assert.NoError(t, waitForFile(marker, 5*time.Second),
 		"the victim must have received the SIGTERM its handler writes the marker from")
 }
@@ -283,22 +285,23 @@ func TestSweepOrphanCandidates_KillsAnIdentifiedOrphan(t *testing.T) {
 func TestSweepOrphanCandidates_RefusesWhenPIDChangesHandsDuringTheLiveQuery(t *testing.T) {
 	pid := fakeTmuxCandidate(t, "ignore")
 
-	c, _, ok := readOrphanCandidate(pid)
+	c, _, ok := readOrphanCandidate(context.Background(), pid)
 	require.True(t, ok)
 
 	original := processIdentityOf
 	t.Cleanup(func() { processIdentityOf = original })
-	stubLiveTmuxIdentity(t, func(int, []string) (bool, bool) {
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) {
 		// The pid changes hands mid-query: every identity read from here on
 		// belongs to whoever holds the number now.
-		processIdentityOf = func(int) (string, error) { return "identity-of-the-new-occupant", nil }
+		processIdentityOf = func(context.Context, int) (string, error) { return "identity-of-the-new-occupant", nil }
 		return false, true
 	})
 
-	killed, skipped := sweepOrphanCandidates([]orphanCandidate{c})
+	killed, skipped, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
 
 	assert.Equal(t, 0, killed, "a pid that changed hands during classification must not be killed")
 	assert.Equal(t, 1, skipped, "the refusal must be counted, not silent")
+	assert.Equal(t, 0, unexamined)
 
 	processIdentityOf = original
 	time.Sleep(300 * time.Millisecond)

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -159,7 +159,10 @@ func fakeTmuxCandidate(t *testing.T, role string, extraEnv ...string) int {
 	require.NoError(t, err)
 	require.True(t, isReapableTmuxClientComm(string(comm)),
 		"the symlink must give the helper a tmux client's comm, got %q", strings.TrimSpace(string(comm)))
-	require.True(t, isControlClientOrphan(pid),
+	orphan, known := isControlClientOrphan(pid)
+	require.True(t, known,
+		"the helper's parentage must be readable, or the sweep would refuse it for the wrong reason")
+	require.True(t, orphan,
 		"the helper must be a genuine parentage orphan, or the sweep would preserve it for the wrong reason")
 
 	return pid
@@ -255,11 +258,12 @@ func TestSweepOrphanCandidates_KillsAnIdentifiedOrphan(t *testing.T) {
 	require.True(t, ok)
 	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
 
-	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+	killed, unclassifiable, notSignalled, unknownParent, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
 
 	assert.Equal(t, 1, killed, "an identified orphan must still be reaped")
 	assert.Equal(t, 0, unclassifiable)
 	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unknownParent)
 	assert.Equal(t, 0, unexamined)
 	assert.NoError(t, waitForFile(marker, 5*time.Second),
 		"the victim must have received the SIGTERM its handler writes the marker from")
@@ -298,11 +302,12 @@ func TestSweepOrphanCandidates_RefusesWhenPIDChangesHandsDuringTheLiveQuery(t *t
 		return false, true
 	})
 
-	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+	killed, unclassifiable, notSignalled, unknownParent, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
 
 	assert.Equal(t, 0, killed, "a pid that changed hands during classification must not be killed")
 	assert.Equal(t, 1, notSignalled, "the refusal must be counted, not silent")
 	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, unknownParent)
 	assert.Equal(t, 0, unexamined)
 
 	processIdentityOf = original

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -378,7 +378,7 @@ func TestReapStaleControlClients_RefusesAPIDRecycledDuringAnEarlierVictimsGrace(
 	}
 
 	snapshot := fmt.Sprintf("1 %d\n1 %d\n", firstVictim, secondVictim)
-	killCount := reapStaleControlClients(snapshot, "(test)")
+	killCount, _ := reapStaleControlClients(context.Background(), snapshot, "(test)")
 
 	assert.Equal(t, 1, killCount, "only the victim whose identity held may be counted as killed")
 	assert.True(t, recycled, "the first victim's kill must have run, or this test proves nothing")

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -58,6 +58,23 @@ import (
 // makes prompt.
 func fakeTmuxCandidate(t *testing.T, role string, extraEnv ...string) int {
 	t.Helper()
+	// argv the sweep must recognise: an agent-deck session target
+	// (SessionPrefix) and a cadence verb from reapableOneShotVerbs.
+	return fakeTmuxCandidateArgv(t, role,
+		[]string{"-L", "orphan-identity-test", "list-clients", "-t", SessionPrefix + "identity_probe"},
+		extraEnv...)
+}
+
+// fakeTmuxCandidateArgv is fakeTmuxCandidate with the tmux argv left to the
+// caller, for the tests that need a candidate the sweep must NOT act on:
+// proving a scope guard holds needs a live process the guard is the only thing
+// protecting, and a guard is only pinned by an argv that fails it.
+//
+// tmuxArgs are the arguments after argv[0]; the "-test.run" guard is inserted
+// here and keeps the child out of the test framework even if the TestMain
+// helper dispatch is ever reordered.
+func fakeTmuxCandidateArgv(t *testing.T, role string, tmuxArgs []string, extraEnv ...string) int {
+	t.Helper()
 	if runtime.GOOS != "linux" {
 		t.Skip("candidate collection reads procfs; linux-only by construction")
 	}
@@ -75,12 +92,7 @@ func fakeTmuxCandidate(t *testing.T, role string, extraEnv ...string) int {
 	}
 	env = append(env, extraEnv...)
 
-	// argv the sweep must recognise: an agent-deck session target
-	// (SessionPrefix) and a cadence verb from reapableOneShotVerbs. The
-	// -test.run guard keeps the child out of the test framework even if the
-	// TestMain helper dispatch is ever reordered.
-	argv := []string{link, "-test.run=^$", "-L", "orphan-identity-test",
-		"list-clients", "-t", SessionPrefix + "identity_probe"}
+	argv := append([]string{link, "-test.run=^$"}, tmuxArgs...)
 
 	quoted := make([]string, 0, len(env)+len(argv))
 	for _, kv := range env {

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -171,11 +171,8 @@ func fakeTmuxCandidateArgv(t *testing.T, role string, tmuxArgs []string, extraEn
 	require.NoError(t, err)
 	require.True(t, isReapableTmuxClientComm(string(comm)),
 		"the symlink must give the helper a tmux client's comm, got %q", strings.TrimSpace(string(comm)))
-	orphan, known := isControlClientOrphan(pid)
-	require.True(t, known,
-		"the helper's parentage must be readable, or the sweep would refuse it for the wrong reason")
-	require.True(t, orphan,
-		"the helper must be a genuine parentage orphan, or the sweep would preserve it for the wrong reason")
+	require.Equal(t, parentageOrphaned, isControlClientOrphan(pid),
+		"the helper must be a genuine parentage orphan, or the sweep would spare it for the wrong reason")
 
 	return pid
 }

--- a/internal/tmux/orphan_reap_identity_test.go
+++ b/internal/tmux/orphan_reap_identity_test.go
@@ -255,10 +255,11 @@ func TestSweepOrphanCandidates_KillsAnIdentifiedOrphan(t *testing.T) {
 	require.True(t, ok)
 	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
 
-	killed, skipped, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
 
 	assert.Equal(t, 1, killed, "an identified orphan must still be reaped")
-	assert.Equal(t, 0, skipped)
+	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, notSignalled)
 	assert.Equal(t, 0, unexamined)
 	assert.NoError(t, waitForFile(marker, 5*time.Second),
 		"the victim must have received the SIGTERM its handler writes the marker from")
@@ -297,14 +298,81 @@ func TestSweepOrphanCandidates_RefusesWhenPIDChangesHandsDuringTheLiveQuery(t *t
 		return false, true
 	})
 
-	killed, skipped, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
 
 	assert.Equal(t, 0, killed, "a pid that changed hands during classification must not be killed")
-	assert.Equal(t, 1, skipped, "the refusal must be counted, not silent")
+	assert.Equal(t, 1, notSignalled, "the refusal must be counted, not silent")
+	assert.Equal(t, 0, unclassifiable)
 	assert.Equal(t, 0, unexamined)
 
 	processIdentityOf = original
 	time.Sleep(300 * time.Millisecond)
 	assert.NoError(t, syscall.Kill(pid, 0),
 		"the new occupant of the pid was signalled; it is not this sweep's to kill")
+}
+
+// TestReapStaleControlClients_RefusesAPIDRecycledDuringAnEarlierVictimsGrace
+// covers the other sweep's snapshot-to-signal window, which is the widest one
+// in this file: reapStaleControlClients kills sequentially and each victim can
+// hold the loop for a full controlClientKillGrace, so the last pid in a
+// `list-clients` snapshot is acted on N × grace after tmux reported it.
+//
+// That sweep has no comm check and no live-server query — the checks the orphan
+// sweep leans on — so if the identity were captured at each pid's turn rather
+// than up front, a pid recycled during an earlier victim's grace would be
+// identified as its NEW occupant, agree with itself at signal time, and be
+// killed on the strength of a `list-clients` line that described someone else.
+// isControlClientOrphan does not stop that: it says "orphan" for anything not
+// parented to an agent-deck binary, which a stranger process generally is not.
+//
+// The seam plays the recycle: the second victim's identity changes as soon as
+// the first victim's kill begins. With the capture up front the change lands
+// after the identity was taken, so the pre-signal check refuses; with the
+// capture inline it would land BEFORE, and the sweep would kill the stranger.
+func TestReapStaleControlClients_RefusesAPIDRecycledDuringAnEarlierVictimsGrace(t *testing.T) {
+	firstVictim := fakeTmuxCandidate(t, "ignore")  // ignores SIGTERM: holds the loop for a full grace
+	secondVictim := fakeTmuxCandidate(t, "ignore") // must survive
+
+	realFirst, err := readProcessIdentity(context.Background(), firstVictim)
+	require.NoError(t, err)
+	realSecond, err := readProcessIdentity(context.Background(), secondVictim)
+	require.NoError(t, err)
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+
+	// Keyed on which pid is being read and how far the sweep has got, not on a
+	// raw call count: the second read of the FIRST victim is its pre-signal
+	// check, which can only happen once the capture phase is over.
+	firstVictimReads := 0
+	recycled := false
+	processIdentityOf = func(_ context.Context, p int) (string, error) {
+		switch p {
+		case firstVictim:
+			firstVictimReads++
+			if firstVictimReads >= 2 {
+				recycled = true
+			}
+			return realFirst, nil
+		case secondVictim:
+			if recycled {
+				return "identity-of-the-new-occupant", nil
+			}
+			return realSecond, nil
+		}
+		return original(context.Background(), p)
+	}
+
+	snapshot := fmt.Sprintf("1 %d\n1 %d\n", firstVictim, secondVictim)
+	killCount := reapStaleControlClients(snapshot, "(test)")
+
+	assert.Equal(t, 1, killCount, "only the victim whose identity held may be counted as killed")
+	assert.True(t, recycled, "the first victim's kill must have run, or this test proves nothing")
+	// The first victim ignores SIGTERM, so it dies to the escalation's SIGKILL;
+	// its subreaper needs a moment to reap it before the pid stops answering.
+	require.Eventually(t, func() bool { return syscall.Kill(firstVictim, 0) != nil },
+		5*time.Second, 10*time.Millisecond,
+		"the first victim's identity never changed; it must have been killed")
+	assert.NoError(t, syscall.Kill(secondVictim, 0),
+		"a pid recycled during an earlier victim's grace must not be signalled")
 }

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -1,0 +1,357 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// --- candidateSocketName: pure parsing, no tmux server needed -------------
+
+func TestCandidateSocketName(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmdlineFields []string
+		wantName      string
+		wantOK        bool
+	}{
+		{"no socket flag at all, default server", []string{"tmux", "list-clients", "-t", "agentdeck_x"}, "", true},
+		{"-L name", []string{"tmux", "-L", "ad1031-xxx", "list-clients", "-t", "agentdeck_x"}, "ad1031-xxx", true},
+		{"-C before -L", []string{"tmux", "-C", "-L", "ad1031-xxx", "attach-session", "-t", "agentdeck_x"}, "ad1031-xxx", true},
+		{"-S path is unresolvable via the -L-only factory", []string{"tmux", "-S", "/tmp/some/sock", "list-clients"}, "", false},
+		{"-S wins over -L per tmux's own precedence, still unresolvable", []string{"tmux", "-S", "/tmp/some/sock", "-L", "name", "list-clients"}, "", false},
+		{"empty argv", []string{}, "", true},
+		{"argv0 only", []string{"tmux"}, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, ok := candidateSocketName(tc.cmdlineFields)
+			if name != tc.wantName || ok != tc.wantOK {
+				t.Errorf("candidateSocketName(%q) = (%q, %v), want (%q, %v)",
+					tc.cmdlineFields, name, ok, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+// --- isLiveTmuxClientOrServer: real tmux server, real processes -----------
+//
+// These tests spawn an actual tmux server on an isolated socket (per-test -L
+// name, under the package TestMain's IsolateTmuxSocket-scoped TMUX_TMPDIR) and
+// exercise isLiveTmuxClientOrServer against real pids, not synthetic argv
+// strings — the whole point of this function is that it does not trust argv
+// text, so a test that only feeds it strings would not prove anything.
+
+// orphanLiveTestSocket returns a deterministic -L socket name for this test
+// and registers teardown that kills the server on the SAME socket — an env
+// mismatch between spawn and cleanup makes kill-server a silent no-op and
+// leaks a server plus its ptys (the 2026-07-18 incident class).
+func orphanLiveTestSocket(t *testing.T) string {
+	t.Helper()
+	socket := "ad-orphlive-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+	kill := func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() }
+	kill() // clear anything a previously aborted run stranded
+	t.Cleanup(kill)
+	return socket
+}
+
+// startOrphanLiveSession creates a long-lived session on socket and disables
+// exit-empty so the server outlives the session's own command for the
+// duration of the test (default tmux exits the server once its last session
+// closes, which would race every assertion below).
+func startOrphanLiveSession(t *testing.T, socket, session string) {
+	t.Helper()
+	if out, err := exec.Command("tmux", "-L", socket, "new-session", "-d", "-s", session, "sleep 6000").CombinedOutput(); err != nil {
+		t.Fatalf("new-session: %v: %s", err, out)
+	}
+	if out, err := exec.Command("tmux", "-L", socket, "set-option", "-g", "exit-empty", "off").CombinedOutput(); err != nil {
+		t.Fatalf("set-option exit-empty off: %v: %s", err, out)
+	}
+}
+
+// shQuote single-quotes s for safe embedding in a `sh -c` string, escaping any
+// literal single quotes. Used so a verb argument that is itself a shell
+// metacharacter to sh (the literal ";" tmux uses for command chaining) is
+// passed through as one opaque argv element rather than parsed by sh.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// reparentedControlClient spawns `tmux -S <socket> -C <verbArgs...>` — control
+// mode, so no real tty is required — via an intermediate `sh -c "... & echo
+// $!; exit 0"` wrapper that backgrounds the tmux invocation and exits
+// immediately. When sh exits, the kernel reparents the still-running tmux
+// client to init/launchd, exactly the shape a crashed or detached shell
+// leaves behind in production (and exactly what isControlClientOrphan's PPID
+// check is watching for).
+//
+// This matters for what the test proves: a pid that is merely a DIRECT child
+// of the test binary would itself satisfy looksLikeAgentDeckBinary (the test
+// binary's own exe path) and get preserved by isControlClientOrphan for the
+// wrong reason — parentage, not liveness — which would make the test pass
+// even with isLiveTmuxClientOrServer stubbed out entirely. Forcing a genuine
+// parentage orphan here means the ONLY thing standing between this pid and
+// SIGKILL, in the real reapOrphanedPollClients pipeline, is
+// isLiveTmuxClientOrServer.
+//
+// Returns the reparented client's pid and a cleanup that force-kills it
+// directly (bypassing tmux, since the whole point of the test is not to rely
+// on tmux protocol niceties for teardown either).
+func reparentedControlClient(t *testing.T, socket, session string, verbArgs ...string) int {
+	t.Helper()
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "stdin.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	// O_RDWR on a FIFO never blocks (unlike O_RDONLY/O_WRONLY, which each wait
+	// for a peer to open the other end). Holding this fd open for the test's
+	// duration keeps the client's stdin from seeing EOF without needing a
+	// separate background writer process.
+	keepOpen, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open fifo O_RDWR: %v", err)
+	}
+	t.Cleanup(func() { _ = keepOpen.Close() })
+
+	pidPath := filepath.Join(dir, "pid")
+	logPath := filepath.Join(dir, "out.log")
+
+	// -L, not -S: candidateSocketName only resolves -L (or no socket flag at
+	// all) because that is the only shape agent-deck's own tmuxExecContext
+	// factory ever produces (see candidateSocketName's doc comment) — a -S
+	// candidate is deliberately refused as unresolvable. Using -S here would
+	// also point this client at a different, nonexistent socket path than the
+	// one startOrphanLiveSession created with -L, so it would never actually
+	// reach the real server at all.
+	argv := append([]string{"tmux", "-L", socket, "-C"}, verbArgs...)
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shQuote(a)
+	}
+	script := strings.Join(quoted, " ") +
+		" < " + shQuote(fifoPath) + " > " + shQuote(logPath) + " 2>&1 & echo $! > " + shQuote(pidPath) + "; exit 0"
+
+	if out, err := exec.Command("sh", "-c", script).CombinedOutput(); err != nil {
+		t.Fatalf("sh wrapper: %v: %s", err, out)
+	}
+
+	var pidBytes []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err = os.ReadFile(pidPath)
+		if err == nil && strings.TrimSpace(string(pidBytes)) != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		logContents, _ := os.ReadFile(logPath)
+		t.Fatalf("read pid file: %v (log: %s)", err, logContents)
+	}
+
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	// Confirm the reparent actually happened before handing the pid back —
+	// otherwise a slow kernel scheduler could let a test proceed against a
+	// pid that is still parented to the wrapper's own shell, silently
+	// weakening the guarantee the test exists to establish.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ppid, err := readParentPID(pid)
+		if err == nil && ppid <= 1 {
+			return pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("pid %d never reparented to init within the deadline — cannot prove this is a genuine orphan", pid)
+	return 0
+}
+
+// TestIsLiveTmuxClientOrServer_ChainedAliasRepro is the direct regression test
+// for the #1832-supersede vulnerability: reapOrphanedPollClients' previous
+// safety gate (neverReapVerbs, matching only the literal strings
+// "attach-session" / "new-session") missed tmux's built-in alias "attach" and
+// every unambiguous abbreviation of it, so
+//
+//	tmux attach -t agentdeck_x \; set-option status on
+//
+// walked straight through: "attach" cleared the denylist (wrong spelling) and
+// "set-option" satisfied the cadence allowlist, so the whole chained command
+// was ruled reapable — while the attach half means a real interactive/control
+// client sits behind it. isLiveTmuxClientOrServer replaces that argv-text
+// check with a live query to the tmux server itself, which cannot be
+// abbreviated around: registration happens on connect, not by re-parsing argv.
+//
+// The client here is spawned via a genuine parentage orphan (see
+// reparentedControlClient) so this test cannot pass merely because
+// isControlClientOrphan happens to protect a same-parent test process — only
+// isLiveTmuxClientOrServer stands between this pid and a kill verdict.
+func TestIsLiveTmuxClientOrServer_ChainedAliasRepro(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_repro"
+	startOrphanLiveSession(t, socket, session)
+
+	pid := reparentedControlClient(t, socket, session,
+		"attach", "-t", session, ";", "set-option", "status", "on")
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{
+		"tmux", "-L", socket, "-C", "attach", "-t", session, ";", "set-option", "status", "on",
+	})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d — the query itself must succeed against a live server", pid)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false — VULNERABLE: a live client attached via the "+
+			"chained alias verb 'attach ; set-option' was not recognised as live and would be reaped", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_AbbreviatedAttach pins the same guarantee for
+// an even shorter abbreviation than the alias: tmux resolves command names by
+// unambiguous prefix, and "attach-session" is the only tmux command starting
+// with "a", so bare "a" alone resolves to it (verified live on tmux 3.7b —
+// `tmux -C a -t sess` attaches). No finite denylist of spelled-out verbs can
+// anticipate every such prefix across tmux versions; the server-identity
+// query does not need to.
+func TestIsLiveTmuxClientOrServer_AbbreviatedAttach(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_abbrev"
+	startOrphanLiveSession(t, socket, session)
+
+	pid := reparentedControlClient(t, socket, session, "a", "-t", session)
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "-C", "a", "-t", session})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false — a live client attached via the single-letter "+
+			"abbreviation 'a' was not recognised as live and would be reaped", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_FullVerbAttach is the control case: the
+// long-form "attach-session" verb the original (superseded) denylist did
+// catch, kept so a future edit cannot silently regress the common case while
+// fixing the alias/abbreviation gap.
+func TestIsLiveTmuxClientOrServer_FullVerbAttach(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_fullverb"
+	startOrphanLiveSession(t, socket, session)
+
+	pid := reparentedControlClient(t, socket, session, "attach-session", "-t", session)
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "-C", "attach-session", "-t", session})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false for a full-verb attach-session client", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_ServerItself pins the other half of the
+// guarantee: the server's own pid must never be classified as reapable, which
+// protects the nascent-server race (a server mid-startup still carries its
+// creating client's comm and argv — see reapOrphanedPollClients' doc comment)
+// by asking the server for its own identity rather than inferring role from
+// argv at all.
+func TestIsLiveTmuxClientOrServer_ServerItself(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_serverpid"
+	startOrphanLiveSession(t, socket, session)
+
+	out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{pid}").Output()
+	if err != nil {
+		t.Fatalf("display-message #{pid}: %v", err)
+	}
+	serverPID, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse server pid: %v", err)
+	}
+
+	live, ok := isLiveTmuxClientOrServer(serverPID, []string{"tmux", "-L", socket, "new-session", "-d", "-s", session})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify the server pid %d", serverPID)
+	}
+	if !live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=false for the SERVER's own pid — "+
+			"this is the nascent-server kill class the sweep must never reach", serverPID)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_OneShotClient_NotLive confirms the sweep's
+// actual target class — a genuinely leaked one-shot query client — still
+// classifies as reapable (live=false, ok=true). Without this, an
+// overcautious implementation could satisfy every "never reap a live attach"
+// test by simply always returning live=true, which would silently restore
+// the original 2026-08-01 bug (the sweep reaps nothing).
+//
+// The client is frozen with SIGSTOP immediately after starting, mid-flight,
+// to stand in for the tmux-3.0a fd leak this sweep exists to mop up: verified
+// live that a SIGSTOPped one-shot list-clients client does not appear in the
+// server's own list-clients output even while its process is still alive —
+// one-shot cadence commands never register as persistent clients the way an
+// attach does, whether or not they are hung.
+func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
+	socket := orphanLiveTestSocket(t)
+	const session = "agentdeck_1832_oneshot"
+	startOrphanLiveSession(t, socket, session)
+
+	cmd := exec.Command("tmux", "-L", socket, "list-clients", "-F", "#{client_pid}")
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	cmd.Stdin = devnull
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start one-shot client: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGCONT)
+		_, _ = cmd.Process.Wait()
+	})
+	if err := cmd.Process.Signal(syscall.SIGSTOP); err != nil {
+		t.Fatalf("SIGSTOP one-shot client: %v", err)
+	}
+
+	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "list-clients", "-F", "#{client_pid}"})
+	if !ok {
+		t.Fatalf("isLiveTmuxClientOrServer could not classify the frozen one-shot client %d", pid)
+	}
+	if live {
+		t.Fatalf("isLiveTmuxClientOrServer(%d) = live=true for a one-shot query client — "+
+			"this would make the sweep unable to reap the exact orphan class it exists for", pid)
+	}
+}
+
+// TestIsLiveTmuxClientOrServer_NoServerAtSocket pins the fail-closed rule: no
+// server reachable at the resolved socket must return ok=false (unclassifiable,
+// refuse to kill), never live=false (safe to kill). A candidate whose target
+// server already exited is exactly the ambiguous case
+// isKnownCadenceArgv/isLiveTmuxClientOrServer's doc comments require refusing
+// rather than guessing about.
+func TestIsLiveTmuxClientOrServer_NoServerAtSocket(t *testing.T) {
+	socket := "ad-orphlive-no-such-server-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+
+	live, ok := isLiveTmuxClientOrServer(999999, []string{"tmux", "-L", socket, "list-clients"})
+	if ok {
+		t.Fatalf("isLiveTmuxClientOrServer against a nonexistent server returned ok=true (live=%v) — "+
+			"want ok=false (unclassifiable)", live)
+	}
+}

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -204,7 +205,7 @@ func TestIsLiveTmuxClientOrServer_ChainedAliasRepro(t *testing.T) {
 	pid := reparentedControlClient(t, socket, session,
 		"attach", "-t", session, ";", "set-option", "status", "on")
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, []string{
 		"tmux", "-L", socket, "-C", "attach", "-t", session, ";", "set-option", "status", "on",
 	})
 	if !ok {
@@ -230,7 +231,7 @@ func TestIsLiveTmuxClientOrServer_AbbreviatedAttach(t *testing.T) {
 
 	pid := reparentedControlClient(t, socket, session, "a", "-t", session)
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "-C", "a", "-t", session})
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, []string{"tmux", "-L", socket, "-C", "a", "-t", session})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
 	}
@@ -251,7 +252,7 @@ func TestIsLiveTmuxClientOrServer_FullVerbAttach(t *testing.T) {
 
 	pid := reparentedControlClient(t, socket, session, "attach-session", "-t", session)
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "-C", "attach-session", "-t", session})
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, []string{"tmux", "-L", socket, "-C", "attach-session", "-t", session})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify pid %d", pid)
 	}
@@ -280,7 +281,7 @@ func TestIsLiveTmuxClientOrServer_ServerItself(t *testing.T) {
 		t.Fatalf("parse server pid: %v", err)
 	}
 
-	live, ok := isLiveTmuxClientOrServer(serverPID, []string{"tmux", "-L", socket, "new-session", "-d", "-s", session})
+	live, ok := isLiveTmuxClientOrServer(context.Background(), serverPID, []string{"tmux", "-L", socket, "new-session", "-d", "-s", session})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify the server pid %d", serverPID)
 	}
@@ -327,7 +328,7 @@ func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
 		t.Fatalf("SIGSTOP one-shot client: %v", err)
 	}
 
-	live, ok := isLiveTmuxClientOrServer(pid, []string{"tmux", "-L", socket, "list-clients", "-F", "#{client_pid}"})
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, []string{"tmux", "-L", socket, "list-clients", "-F", "#{client_pid}"})
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify the frozen one-shot client %d", pid)
 	}
@@ -349,7 +350,7 @@ func TestIsLiveTmuxClientOrServer_NoServerAtSocket(t *testing.T) {
 		socket = socket[:40]
 	}
 
-	live, ok := isLiveTmuxClientOrServer(999999, []string{"tmux", "-L", socket, "list-clients"})
+	live, ok := isLiveTmuxClientOrServer(context.Background(), 999999, []string{"tmux", "-L", socket, "list-clients"})
 	if ok {
 		t.Fatalf("isLiveTmuxClientOrServer against a nonexistent server returned ok=true (live=%v) — "+
 			"want ok=false (unclassifiable)", live)

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -141,9 +141,11 @@ func reparentedControlClient(t *testing.T, socket, session string, verbArgs ...s
 	script := strings.Join(quoted, " ") +
 		" < " + shQuote(fifoPath) + " > " + shQuote(logPath) + " 2>&1 & echo $! > " + shQuote(pidPath) + "; exit 0"
 
-	if out, err := exec.Command("sh", "-c", script).CombinedOutput(); err != nil {
+	wrapper := exec.Command("sh", "-c", script)
+	if out, err := wrapper.CombinedOutput(); err != nil {
 		t.Fatalf("sh wrapper: %v: %s", err, out)
 	}
+	wrapperPID := wrapper.Process.Pid
 
 	var pidBytes []byte
 	deadline := time.Now().Add(2 * time.Second)
@@ -166,15 +168,51 @@ func reparentedControlClient(t *testing.T, socket, session string, verbArgs ...s
 	// otherwise a slow kernel scheduler could let a test proceed against a
 	// pid that is still parented to the wrapper's own shell, silently
 	// weakening the guarantee the test exists to establish.
+	//
+	// "Reparented" means "no longer the wrapper's child", not "ppid == 1": the
+	// kernel hands an orphan to the nearest SUBREAPER, and under a
+	// `systemd --user` session — the normal shape of a Linux desktop, and of
+	// this repo's own dev hosts — that is the user manager, not init. Requiring
+	// pid 1 makes this helper fail everywhere except a CI runner that happens
+	// not to have one, and it proves nothing extra: what the test needs is a
+	// parent that is not an agent-deck-shaped binary, which is exactly what
+	// isControlClientOrphan goes on to check.
 	deadline = time.Now().Add(2 * time.Second)
+	reparented := false
 	for time.Now().Before(deadline) {
 		ppid, err := readParentPID(pid)
-		if err == nil && ppid <= 1 {
-			return pid
+		if err == nil && ppid != wrapperPID {
+			reparented = true
+			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("pid %d never reparented to init within the deadline — cannot prove this is a genuine orphan", pid)
+	if !reparented {
+		t.Fatalf("pid %d never left the wrapper shell within the deadline — cannot prove this is a genuine orphan", pid)
+	}
+
+	// Wait for the server to actually register the client before handing the
+	// pid back. Registration happens asynchronously after exec — which is the
+	// whole reason isLiveTmuxClientOrServer asks the server instead of reading
+	// argv — so a caller that queried immediately could see a not-yet-registered
+	// client and read it as "not live", failing for a timing reason rather than
+	// a classification one. (Setup, not the assertion: what the tests check is
+	// that the aliased/abbreviated spellings resolve to a real attach at all.)
+	deadline = time.Now().Add(5 * time.Second)
+	target := strconv.Itoa(pid)
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("tmux", "-L", socket, "list-clients", "-F", "#{client_pid}").Output()
+		if err == nil {
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if strings.TrimSpace(line) == target {
+					return pid
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	logContents, _ := os.ReadFile(logPath)
+	t.Fatalf("client pid %d never registered with the server on socket %s (log: %s)", pid, socket, logContents)
 	return 0
 }
 

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -86,7 +86,7 @@ func shQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// reparentedControlClient spawns `tmux -S <socket> -C <verbArgs...>` — control
+// reparentedControlClient spawns `tmux -L <socket> -C <verbArgs...>` — control
 // mode, so no real tty is required — via an intermediate `sh -c "... & echo
 // $!; exit 0"` wrapper that backgrounds the tmux invocation and exits
 // immediately. When sh exits, the kernel reparents the still-running tmux

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -38,6 +38,13 @@ func TestCandidateSocketName(t *testing.T) {
 		{"bundled booleans before a separated -L", []string{"tmux", "-uL", "ad1031-xxx", "list-clients"}, "ad1031-xxx", true},
 		{"attached -S path is unresolvable via the -L-only factory", []string{"tmux", "-S/tmp/some/sock", "list-clients"}, "", false},
 		{"-C bundled with an attached -S", []string{"tmux", "-CS/tmp/some/sock", "attach-session"}, "", false},
+		// Repeated flags: tmux keeps the last. Reading the first names a server
+		// the candidate is not on — and since the query side would mis-read it
+		// the SAME way, the socket comparison in isLiveTmuxClientOrServer would
+		// agree with itself and prove nothing.
+		{"the LAST of a repeated -L wins", []string{"tmux", "-L", "first", "-L", "second", "list-clients"}, "second", true},
+		{"a -S anywhere in the run is still unresolvable", []string{"tmux", "-L", "name", "-S", "/tmp/s", "list-clients"}, "", false},
+		{"-- ends the global flags", []string{"tmux", "--", "-Lfoo", "list-clients"}, "", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -28,6 +28,16 @@ func TestCandidateSocketName(t *testing.T) {
 		{"-S wins over -L per tmux's own precedence, still unresolvable", []string{"tmux", "-S", "/tmp/some/sock", "-L", "name", "list-clients"}, "", false},
 		{"empty argv", []string{}, "", true},
 		{"argv0 only", []string{"tmux"}, "", true},
+		// getopt's attached and bundled spellings. A candidate that carries
+		// one of these is talking to a socket this parser cannot see: the
+		// separated-form-only reader answers "no selector", the live-identity
+		// query then goes to the DEFAULT server, and a client that is alive on
+		// its own server reads as not-live — the kill verdict.
+		{"attached -L name", []string{"tmux", "-Lad1031-xxx", "list-clients", "-t", "agentdeck_x"}, "ad1031-xxx", true},
+		{"-C bundled with an attached -L", []string{"tmux", "-CLad1031-xxx", "attach-session", "-t", "agentdeck_x"}, "ad1031-xxx", true},
+		{"bundled booleans before a separated -L", []string{"tmux", "-uL", "ad1031-xxx", "list-clients"}, "ad1031-xxx", true},
+		{"attached -S path is unresolvable via the -L-only factory", []string{"tmux", "-S/tmp/some/sock", "list-clients"}, "", false},
+		{"-C bundled with an attached -S", []string{"tmux", "-CS/tmp/some/sock", "attach-session"}, "", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tmux/orphan_reap_parentage_test.go
+++ b/internal/tmux/orphan_reap_parentage_test.go
@@ -186,7 +186,7 @@ func TestReapStaleControlClients_RefusesUnknownParentage(t *testing.T) {
 	pid := fakeTmuxCandidate(t, "ignore")
 	stubControlClientOrphan(t, alwaysUnknownParentage)
 
-	killed := reapStaleControlClients(fmt.Sprintf("1 %d\n", pid), "(test)")
+	killed, _ := reapStaleControlClients(context.Background(), fmt.Sprintf("1 %d\n", pid), "(test)")
 
 	assert.Equal(t, 0, killed)
 	time.Sleep(300 * time.Millisecond)

--- a/internal/tmux/orphan_reap_parentage_test.go
+++ b/internal/tmux/orphan_reap_parentage_test.go
@@ -1,0 +1,168 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The parentage check is the last gate in front of a signal in both sweeps, and
+// it used to answer "orphan, sweep it" whenever it could not read the facts it
+// judges on. That is fail-open in the one place both sweeps agree must fail
+// closed: an unreadable parent is indistinguishable from a live sibling TUI's
+// parent, and the tie was being broken toward killing.
+//
+// These tests pin the three unreadable cases as refusals, and — just as
+// important — pin the two cases that are genuine determinations rather than
+// read failures, so fail-closed does not quietly turn the sweeps inert.
+
+func TestIsControlClientOrphanFor_FailsClosedWhenParentageIsUnreadable(t *testing.T) {
+	const clientPID = 4242
+	const parentPID = 999
+
+	parentIs := func(ppid int) func(int) (int, error) {
+		return func(int) (int, error) { return ppid, nil }
+	}
+	alive := func(int) error { return nil }
+	agentDeckExe := func(int) (string, error) { return "/usr/local/bin/agent-deck", nil }
+	strangerExe := func(int) (string, error) { return "/usr/bin/tmux", nil }
+
+	cases := []struct {
+		name       string
+		parentPID  func(int) (int, error)
+		probeAlive func(int) error
+		processExe func(int) (string, error)
+		wantOrphan bool
+		wantKnown  bool
+	}{
+		{
+			name:      "parent pid unreadable",
+			parentPID: func(int) (int, error) { return 0, errors.New("no /proc, and ps failed too") },
+			// A host that cannot report parentage says nothing about whether a
+			// live TUI owns this client.
+			probeAlive: alive, processExe: agentDeckExe,
+			wantOrphan: false, wantKnown: false,
+		},
+		{
+			name:      "parent liveness probe refused",
+			parentPID: parentIs(parentPID),
+			// EPERM means the parent EXISTS and is someone else's. That is the
+			// opposite of "the parent died", which is what this branch used to
+			// conclude from any error at all.
+			probeAlive: func(int) error { return syscall.EPERM }, processExe: agentDeckExe,
+			wantOrphan: false, wantKnown: false,
+		},
+		{
+			name:       "parent exe unreadable",
+			parentPID:  parentIs(parentPID),
+			probeAlive: alive,
+			processExe: func(int) (string, error) { return "", errors.New("permission denied") },
+			wantOrphan: false, wantKnown: false,
+		},
+		{
+			// Determinations, not read failures. These must keep saying orphan,
+			// or #595 cleanup goes inert and the pty table fills up again.
+			name:      "reparented to init",
+			parentPID: parentIs(1), probeAlive: alive, processExe: agentDeckExe,
+			wantOrphan: true, wantKnown: true,
+		},
+		{
+			name:      "parent confirmed gone",
+			parentPID: parentIs(parentPID),
+			// ESRCH is the kernel confirming there is no such process. The
+			// client is being orphaned right now.
+			probeAlive: func(int) error { return syscall.ESRCH }, processExe: agentDeckExe,
+			wantOrphan: true, wantKnown: true,
+		},
+		{
+			name:      "live agent-deck parent",
+			parentPID: parentIs(parentPID), probeAlive: alive, processExe: agentDeckExe,
+			wantOrphan: false, wantKnown: true,
+		},
+		{
+			name:      "live parent that is not agent-deck",
+			parentPID: parentIs(parentPID), probeAlive: alive, processExe: strangerExe,
+			wantOrphan: true, wantKnown: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orphan, known := isControlClientOrphanFor(tc.parentPID, tc.probeAlive, tc.processExe, clientPID)
+			assert.Equal(t, tc.wantKnown, known, "known")
+			assert.Equal(t, tc.wantOrphan, orphan, "orphan")
+			if !known {
+				assert.False(t, orphan,
+					"an unknown verdict must never also read as orphan: every caller "+
+						"that ignores `known` would then signal on a guess")
+			}
+		})
+	}
+}
+
+// stubControlClientOrphan swaps the parentage seam for the duration of a test.
+func stubControlClientOrphan(t *testing.T, fn func(int) (bool, bool)) {
+	t.Helper()
+	original := controlClientOrphanOf
+	t.Cleanup(func() { controlClientOrphanOf = original })
+	controlClientOrphanOf = fn
+}
+
+// unknownParentage is the verdict the two call-site tests below stub in:
+// known=false, and orphan=true underneath it.
+//
+// isControlClientOrphanFor never produces that pair — the unit test above pins
+// that it cannot — and that is exactly why it is the right stub here. A caller
+// that reads `orphan` and ignores `known` sends the signal; a caller that checks
+// `known` first refuses. Stubbing known=false with orphan=false instead would
+// pass either way, since both gates end in "leave it alone", and would pin
+// nothing.
+func unknownParentage(int) (bool, bool) { return true, false }
+
+// TestSweepOrphanCandidates_RefusesUnknownParentage pins the orphan sweep's call
+// site: an indeterminate verdict must stop the gauntlet before the signal and be
+// counted, not fall through to the kill the way any non-false answer used to.
+func TestSweepOrphanCandidates_RefusesUnknownParentage(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+
+	c, _, ok := readOrphanCandidate(context.Background(), pid)
+	require.True(t, ok)
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
+	stubControlClientOrphan(t, unknownParentage)
+
+	killed, unclassifiable, notSignalled, unknownParent, unexamined :=
+		sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+
+	assert.Equal(t, 0, killed, "a candidate whose parentage could not be read must not be killed")
+	assert.Equal(t, 1, unknownParent, "the refusal must be counted, not silent")
+	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unexamined)
+
+	// The helper ignores SIGTERM, so had the sweep signalled it, the escalation
+	// would have SIGKILL'd it and this would fail.
+	time.Sleep(300 * time.Millisecond)
+	assert.NoError(t, syscall.Kill(pid, 0), "the candidate was signalled despite an unknown verdict")
+}
+
+// TestReapStaleControlClients_RefusesUnknownParentage pins the same gate in the
+// other sweep. This one has no comm filter and no live-server query, so the
+// parentage check is the ONLY thing standing between a `list-clients` line and a
+// SIGTERM — a fail-open answer here is signalled immediately.
+func TestReapStaleControlClients_RefusesUnknownParentage(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+	stubControlClientOrphan(t, unknownParentage)
+
+	killed := reapStaleControlClients(fmt.Sprintf("1 %d\n", pid), "(test)")
+
+	assert.Equal(t, 0, killed)
+	time.Sleep(300 * time.Millisecond)
+	assert.NoError(t, syscall.Kill(pid, 0),
+		"a control client whose parentage could not be read was signalled anyway")
+}

--- a/internal/tmux/orphan_reap_parentage_test.go
+++ b/internal/tmux/orphan_reap_parentage_test.go
@@ -34,20 +34,36 @@ func TestIsControlClientOrphanFor_FailsClosedWhenParentageIsUnreadable(t *testin
 	strangerExe := func(int) (string, error) { return "/usr/bin/tmux", nil }
 
 	cases := []struct {
-		name       string
-		parentPID  func(int) (int, error)
-		probeAlive func(int) error
-		processExe func(int) (string, error)
-		wantOrphan bool
-		wantKnown  bool
+		name        string
+		parentPID   func(int) (int, error)
+		probeAlive  func(int) error
+		processExe  func(int) (string, error)
+		wantVerdict parentageVerdict
 	}{
 		{
-			name:      "parent pid unreadable",
+			name:      "parent pid unreadable while the candidate is still there",
 			parentPID: func(int) (int, error) { return 0, errors.New("no /proc, and ps failed too") },
 			// A host that cannot report parentage says nothing about whether a
 			// live TUI owns this client.
 			probeAlive: alive, processExe: agentDeckExe,
-			wantOrphan: false, wantKnown: false,
+			wantVerdict: parentageUnknown,
+		},
+		{
+			// The ordinary churn case, and NOT a refusal: candidates die during
+			// the gauntlet all the time (an earlier victim's grace runs in
+			// between). Reporting it as "could not establish whether a live TUI
+			// owns this client" would put a Warn about a safety-relevant
+			// failure on every normal sweep, and bury the ones that matter.
+			name:      "the candidate itself is gone",
+			parentPID: func(int) (int, error) { return 0, errors.New("no such process") },
+			probeAlive: func(probed int) error {
+				if probed == clientPID {
+					return syscall.ESRCH
+				}
+				return nil
+			},
+			processExe:  agentDeckExe,
+			wantVerdict: parentageCandidateGone,
 		},
 		{
 			name:      "parent liveness probe refused",
@@ -56,21 +72,21 @@ func TestIsControlClientOrphanFor_FailsClosedWhenParentageIsUnreadable(t *testin
 			// opposite of "the parent died", which is what this branch used to
 			// conclude from any error at all.
 			probeAlive: func(int) error { return syscall.EPERM }, processExe: agentDeckExe,
-			wantOrphan: false, wantKnown: false,
+			wantVerdict: parentageUnknown,
 		},
 		{
-			name:       "parent exe unreadable",
-			parentPID:  parentIs(parentPID),
-			probeAlive: alive,
-			processExe: func(int) (string, error) { return "", errors.New("permission denied") },
-			wantOrphan: false, wantKnown: false,
+			name:        "parent exe unreadable",
+			parentPID:   parentIs(parentPID),
+			probeAlive:  alive,
+			processExe:  func(int) (string, error) { return "", errors.New("permission denied") },
+			wantVerdict: parentageUnknown,
 		},
 		{
 			// Determinations, not read failures. These must keep saying orphan,
 			// or #595 cleanup goes inert and the pty table fills up again.
 			name:      "reparented to init",
 			parentPID: parentIs(1), probeAlive: alive, processExe: agentDeckExe,
-			wantOrphan: true, wantKnown: true,
+			wantVerdict: parentageOrphaned,
 		},
 		{
 			name:      "parent confirmed gone",
@@ -78,52 +94,39 @@ func TestIsControlClientOrphanFor_FailsClosedWhenParentageIsUnreadable(t *testin
 			// ESRCH is the kernel confirming there is no such process. The
 			// client is being orphaned right now.
 			probeAlive: func(int) error { return syscall.ESRCH }, processExe: agentDeckExe,
-			wantOrphan: true, wantKnown: true,
+			wantVerdict: parentageOrphaned,
 		},
 		{
 			name:      "live agent-deck parent",
 			parentPID: parentIs(parentPID), probeAlive: alive, processExe: agentDeckExe,
-			wantOrphan: false, wantKnown: true,
+			wantVerdict: parentageOwned,
 		},
 		{
 			name:      "live parent that is not agent-deck",
 			parentPID: parentIs(parentPID), probeAlive: alive, processExe: strangerExe,
-			wantOrphan: true, wantKnown: true,
+			wantVerdict: parentageOrphaned,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			orphan, known := isControlClientOrphanFor(tc.parentPID, tc.probeAlive, tc.processExe, clientPID)
-			assert.Equal(t, tc.wantKnown, known, "known")
-			assert.Equal(t, tc.wantOrphan, orphan, "orphan")
-			if !known {
-				assert.False(t, orphan,
-					"an unknown verdict must never also read as orphan: every caller "+
-						"that ignores `known` would then signal on a guess")
-			}
+			got := isControlClientOrphanFor(tc.parentPID, tc.probeAlive, tc.processExe, clientPID)
+			assert.Equal(t, tc.wantVerdict, got)
+			assert.Equal(t, tc.wantVerdict == parentageOrphaned, got.reapable(),
+				"only a positive orphan determination may authorise a signal")
 		})
 	}
 }
 
 // stubControlClientOrphan swaps the parentage seam for the duration of a test.
-func stubControlClientOrphan(t *testing.T, fn func(int) (bool, bool)) {
+func stubControlClientOrphan(t *testing.T, fn func(int) parentageVerdict) {
 	t.Helper()
 	original := controlClientOrphanOf
 	t.Cleanup(func() { controlClientOrphanOf = original })
 	controlClientOrphanOf = fn
 }
 
-// unknownParentage is the verdict the two call-site tests below stub in:
-// known=false, and orphan=true underneath it.
-//
-// isControlClientOrphanFor never produces that pair — the unit test above pins
-// that it cannot — and that is exactly why it is the right stub here. A caller
-// that reads `orphan` and ignores `known` sends the signal; a caller that checks
-// `known` first refuses. Stubbing known=false with orphan=false instead would
-// pass either way, since both gates end in "leave it alone", and would pin
-// nothing.
-func unknownParentage(int) (bool, bool) { return true, false }
+func alwaysUnknownParentage(int) parentageVerdict { return parentageUnknown }
 
 // TestSweepOrphanCandidates_RefusesUnknownParentage pins the orphan sweep's call
 // site: an indeterminate verdict must stop the gauntlet before the signal and be
@@ -134,7 +137,7 @@ func TestSweepOrphanCandidates_RefusesUnknownParentage(t *testing.T) {
 	c, _, ok := readOrphanCandidate(context.Background(), pid)
 	require.True(t, ok)
 	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
-	stubControlClientOrphan(t, unknownParentage)
+	stubControlClientOrphan(t, alwaysUnknownParentage)
 
 	killed, unclassifiable, notSignalled, unknownParent, unexamined :=
 		sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
@@ -151,13 +154,37 @@ func TestSweepOrphanCandidates_RefusesUnknownParentage(t *testing.T) {
 	assert.NoError(t, syscall.Kill(pid, 0), "the candidate was signalled despite an unknown verdict")
 }
 
+// TestSweepOrphanCandidates_DoesNotReportAVanishedCandidateAsARefusal separates
+// the two things that used to share one answer. A candidate that exited during
+// the gauntlet is ordinary churn — earlier victims' grace periods run in between
+// — and counting it as "could not establish whether a live TUI owns this"
+// would put a safety-shaped Warn on routine sweeps and bury the real ones.
+func TestSweepOrphanCandidates_DoesNotReportAVanishedCandidateAsARefusal(t *testing.T) {
+	pid := fakeTmuxCandidate(t, "ignore")
+
+	c, _, ok := readOrphanCandidate(context.Background(), pid)
+	require.True(t, ok)
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
+	stubControlClientOrphan(t, func(int) parentageVerdict { return parentageCandidateGone })
+
+	killed, unclassifiable, notSignalled, unknownParent, unexamined :=
+		sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+
+	assert.Equal(t, 0, killed, "there is nothing left to kill")
+	assert.Equal(t, 0, unknownParent,
+		"a candidate that simply exited is not a refusal to establish its parentage")
+	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unexamined)
+}
+
 // TestReapStaleControlClients_RefusesUnknownParentage pins the same gate in the
 // other sweep. This one has no comm filter and no live-server query, so the
 // parentage check is the ONLY thing standing between a `list-clients` line and a
 // SIGTERM — a fail-open answer here is signalled immediately.
 func TestReapStaleControlClients_RefusesUnknownParentage(t *testing.T) {
 	pid := fakeTmuxCandidate(t, "ignore")
-	stubControlClientOrphan(t, unknownParentage)
+	stubControlClientOrphan(t, alwaysUnknownParentage)
 
 	killed := reapStaleControlClients(fmt.Sprintf("1 %d\n", pid), "(test)")
 

--- a/internal/tmux/orphan_reap_query_cost_test.go
+++ b/internal/tmux/orphan_reap_query_cost_test.go
@@ -1,0 +1,50 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSweepOrphanCandidates_DoesNotQueryForACandidateItHasAlreadyRefused pins
+// the ordering of the gauntlet, which is a budget property rather than a safety
+// one — but this sweep's budget IS a safety property second-hand: candidates it
+// never reaches are left leaking, and it only reaches them if the ones ahead do
+// not waste its allowance.
+//
+// A comm whose role token was truncated away can never be killed. Asking the
+// tmux server about it anyway costs up to 2 × tmuxLiveQueryTimeout of a shared
+// orphanSweepBudget — against exactly the wedged server that produced the
+// candidates — for an answer that is then thrown away.
+func TestSweepOrphanCandidates_DoesNotQueryForACandidateItHasAlreadyRefused(t *testing.T) {
+	queries := 0
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) {
+		queries++
+		return false, true
+	})
+
+	// Truncated comm ("tmux-3.5a:" is the shape measured in the wild), and an
+	// argv that passes both scope checks, so the ONLY thing left to decide it
+	// is the truncation — and that is decided before the query.
+	candidate := orphanCandidate{
+		pid:      1 << 30,
+		comm:     "tmux-3.5a:",
+		cmdline:  cadenceCmdline("truncated_probe"),
+		identity: "id",
+	}
+	require.True(t, isTruncatedTmuxComm(candidate.comm), "the fixture must be a truncated comm")
+	require.False(t, isReapableTmuxClientComm(candidate.comm), "and not classifiable as a client")
+
+	killed, unclassifiable, notSignalled, unknownParent, unexamined :=
+		sweepOrphanCandidates(context.Background(), []orphanCandidate{candidate})
+
+	assert.Equal(t, 0, queries,
+		"the sweep spent a tmux query on a candidate it had already decided it can never kill")
+	assert.Equal(t, 1, unclassifiable, "the refusal must still be reported")
+	assert.Equal(t, 0, killed)
+	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unknownParent)
+	assert.Equal(t, 0, unexamined)
+}

--- a/internal/tmux/orphan_reap_scope_test.go
+++ b/internal/tmux/orphan_reap_scope_test.go
@@ -1,0 +1,91 @@
+package tmux
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two guards in sweepOrphanCandidates narrow what it may kill, and a mutation
+// run found both of them unpinned: delete either and the package stayed green.
+// The SessionPrefix one is the one that matters — reapOrphanedPollClients'
+// own doc calls it the boundary that keeps the sweep off a tmux client that is
+// not agent-deck's — and "green with the boundary deleted" is exactly the shape
+// of the two incidents behind this file.
+//
+// Both tests below use a REAL live process that fails the guard under test and
+// passes everything else, so the guard is the only thing between it and a
+// SIGTERM/SIGKILL. The helper ignores SIGTERM, which makes its survival
+// unambiguous: had the sweep signalled it, the escalation would have killed it.
+
+// sweepWithNothingLive runs the gauntlet with the live-server query stubbed to
+// its most kill-permissive answer ("classifiable, and not live"), so nothing
+// downstream of the scope guards can be the reason a candidate survives.
+func sweepWithNothingLive(t *testing.T, c orphanCandidate) (killed, unclassifiable, notSignalled, unknownParent, unexamined int) {
+	t.Helper()
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return false, true })
+	return sweepOrphanCandidates(context.Background(), []orphanCandidate{c})
+}
+
+// assertSurvivedTheSweep waits out the SIGTERM grace and the SIGKILL behind it,
+// then checks the pid is still there. These helpers are reparented to init,
+// which reaps them promptly, so the pid genuinely disappears when killed rather
+// than lingering as a zombie that would answer signal 0 either way.
+func assertSurvivedTheSweep(t *testing.T, pid int, why string) {
+	t.Helper()
+	time.Sleep(controlClientKillGrace + 300*time.Millisecond)
+	assert.NoError(t, syscall.Kill(pid, 0), why)
+}
+
+// TestSweepOrphanCandidates_LeavesATmuxClientOutsideAgentDeckAlone pins the
+// SessionPrefix scope check. The candidate is a genuine orphaned tmux client
+// running a cadence verb — everything the sweep looks for — except that the
+// session it targets is not agent-deck's. Nothing else in the gauntlet
+// distinguishes it, so without this check the sweep reaps other software's
+// tmux clients.
+func TestSweepOrphanCandidates_LeavesATmuxClientOutsideAgentDeckAlone(t *testing.T) {
+	pid := fakeTmuxCandidateArgv(t, "ignore",
+		[]string{"-L", "orphan-scope-test", "list-clients", "-t", "someoneelses_session"})
+
+	c, _, ok := readOrphanCandidate(context.Background(), pid)
+	require.True(t, ok, "the candidate must reach the gauntlet, or this test proves nothing")
+	require.NotContains(t, c.cmdline, SessionPrefix, "the candidate must fail the guard under test")
+
+	killed, unclassifiable, notSignalled, unknownParent, unexamined := sweepWithNothingLive(t, c)
+
+	assert.Equal(t, 0, killed, "a tmux client targeting a session that is not agent-deck's must not be killed")
+	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unknownParent)
+	assert.Equal(t, 0, unexamined)
+	assertSurvivedTheSweep(t, pid, "a tmux client outside agent-deck's own sessions was signalled")
+}
+
+// TestSweepOrphanCandidates_LeavesANonCadenceVerbAlone pins the
+// isKnownCadenceArgv call site. The verb allowlist is scope, not safety — its
+// own doc says so — but scope is what keeps the sweep to the short-lived
+// commands whose loss costs nothing, and a candidate running something else is
+// not one the sweep may guess about.
+func TestSweepOrphanCandidates_LeavesANonCadenceVerbAlone(t *testing.T) {
+	pid := fakeTmuxCandidateArgv(t, "ignore",
+		[]string{"-L", "orphan-scope-test", "rename-window", "-t", SessionPrefix + "scope_probe", "newname"})
+
+	c, _, ok := readOrphanCandidate(context.Background(), pid)
+	require.True(t, ok)
+	require.Contains(t, c.cmdline, SessionPrefix,
+		"the candidate must pass the OTHER scope guard, so only the verb check is under test")
+	require.False(t, isKnownCadenceArgv(c.cmdline), "the candidate must fail the guard under test")
+
+	killed, unclassifiable, notSignalled, unknownParent, unexamined := sweepWithNothingLive(t, c)
+
+	assert.Equal(t, 0, killed, "a client running a verb outside the cadence allowlist must not be killed")
+	assert.Equal(t, 0, unclassifiable)
+	assert.Equal(t, 0, notSignalled)
+	assert.Equal(t, 0, unknownParent)
+	assert.Equal(t, 0, unexamined)
+	assertSurvivedTheSweep(t, pid, "a client running a non-cadence verb was signalled")
+}

--- a/internal/tmux/orphan_reap_socket_memo_test.go
+++ b/internal/tmux/orphan_reap_socket_memo_test.go
@@ -1,0 +1,101 @@
+package tmux
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isLiveTmuxClientOrServer spawns two tmux clients per candidate and memoizes
+// nothing. On the host this sweep exists for, that is up to two spawns per
+// wedged orphan — each one a fresh client against the same unresponsive server,
+// and so itself a candidate for the fd leak being cleaned up — with each pair
+// riding tmuxLiveQueryTimeout, so a handful of candidates can spend the whole
+// shared budget and the rest are reported unexamined.
+//
+// The obvious fix is to cache the answers, and the PR body rejects it for a
+// real reason: a cached client list goes stale inside one sweep, and a client
+// that connects mid-sweep would then be absent from the cache and eligible to
+// be killed. Freshness is the safety property.
+//
+// What IS cacheable is the refusal. "This socket could not be reached" only
+// ever produces more refusals, never a kill, so memoizing it is fail-closed by
+// construction — and it is precisely the expensive case, since an unreachable
+// or wedged server is what makes a query ride its full cap.
+
+func TestIsLiveTmuxClientOrServer_MemoizesAnUnreachableSocketForTheSweep(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resolving a candidate's own socket reads /proc/<pid>/environ; linux-only by construction")
+	}
+	socket := orphanLiveTestSocket(t)
+	resetUnreachableSockets()
+
+	// A live candidate whose argv points at a socket with no server on it.
+	pid := fakeTmuxCandidateArgv(t, "ignore",
+		[]string{"-L", socket, "list-clients", "-t", SessionPrefix + "memo_probe"})
+	cmdlineFields := []string{"tmux", "-L", socket, "list-clients", "-t", SessionPrefix + "memo_probe"}
+
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, cmdlineFields)
+	require.False(t, ok, "no server on that socket yet, so the candidate must be unclassifiable")
+	require.False(t, live)
+
+	// Now stand a real server up on that same socket, mid-sweep. Without the
+	// memo the next call reaches it, finds neither its server pid nor any of
+	// its clients matching, and answers live=false ok=true — a KILL verdict,
+	// produced by a server that was not even running when this sweep started
+	// judging the candidate.
+	startOrphanLiveSession(t, socket, "agentdeck_memo_probe")
+	out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{pid}").Output()
+	require.NoError(t, err, "the server must be answering, or this proves nothing")
+	require.NotEmpty(t, out)
+
+	live, ok = isLiveTmuxClientOrServer(context.Background(), pid, cmdlineFields)
+
+	assert.False(t, ok,
+		"a socket already found unreachable in this sweep must stay refused: re-querying it "+
+			"both spends the budget again and lets a server that appeared mid-sweep produce a "+
+			"kill verdict for a candidate judged against its absence")
+	assert.False(t, live)
+}
+
+// TestResetUnreachableSockets_ClearsBetweenSweeps pins the scope of the memo.
+// It is a within-one-sweep optimisation; carrying it across sweeps would make a
+// socket that was briefly unreachable permanently unreapable, which is the
+// inert-sweep failure this area started with.
+func TestResetUnreachableSockets_ClearsBetweenSweeps(t *testing.T) {
+	resetUnreachableSockets()
+	markSocketUnreachable("/tmp/some-socket")
+	require.True(t, socketKnownUnreachable("/tmp/some-socket"))
+
+	resetUnreachableSockets()
+
+	assert.False(t, socketKnownUnreachable("/tmp/some-socket"),
+		"the memo must not survive into the next sweep")
+}
+
+// TestReapOrphanedPollClients_ClearsTheMemoAtTheStartOfASweep pins the WIRING,
+// not just the helper. A reset function nothing calls is the same defect as no
+// reset at all: the memo would survive into the next sweep and a socket that
+// was briefly unreachable would be permanently unreapable.
+//
+// Every candidate reads as live here, so this exercises the real sweep over the
+// real /proc without a single signal being sent.
+func TestReapOrphanedPollClients_ClearsTheMemoAtTheStartOfASweep(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the sweep is linux-only by construction")
+	}
+	stubLiveTmuxIdentity(t, func(context.Context, int, []string) (bool, bool) { return true, true })
+
+	const stale = "/tmp/unreachable-in-the-previous-sweep"
+	markSocketUnreachable(stale)
+	require.True(t, socketKnownUnreachable(stale))
+
+	reapOrphanedPollClients()
+
+	assert.False(t, socketKnownUnreachable(stale),
+		"the sweep must clear the memo as it starts; a reset nobody calls is not a reset")
+}

--- a/internal/tmux/orphan_reap_socket_ownership_test.go
+++ b/internal/tmux/orphan_reap_socket_ownership_test.go
@@ -1,0 +1,216 @@
+package tmux
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The ownership boundary this file exists for.
+//
+// isLiveTmuxClientOrServer takes the candidate's socket SELECTOR from the
+// candidate's own argv (-L work), but the query it then issues resolves that
+// name through THIS process's TMUX_TMPDIR. Two tmux servers can carry the same
+// -L name under different bases, and they are different servers. When that
+// happens both queries succeed against the wrong one, neither its server pid
+// nor any of its client pids matches, and the function answers live=false,
+// ok=true — the kill verdict — against a client that is attached and alive on
+// its own server.
+//
+// Every pre-existing case in orphan_reap_live_identity_test.go creates the
+// server with `-L <socket>` and puts that same `-L <socket>` in the candidate
+// argv, so the candidate's socket always equals the resolved socket and this
+// case cannot arise. A case the suite never constructs cannot fail it, which is
+// why green CI never said anything about this.
+
+// tmuxUnder runs a raw tmux command under an explicit TMUX_TMPDIR, so a test can
+// stand up a server that this process does NOT resolve to.
+//
+// Deliberately not tmuxExec: the package factory resolves -L through the test
+// process's own env, which is the very coupling under test here.
+func tmuxUnder(t *testing.T, tmpdir string, args ...string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("tmux", args...)
+	cmd.Env = append(os.Environ(), "TMUX_TMPDIR="+tmpdir, "TMUX=")
+	return cmd
+}
+
+// foreignTmuxBase makes a TMUX_TMPDIR that is not this process's, and keeps it
+// short: the socket path lands in a sockaddr_un, which is capped near 104 bytes,
+// and t.TempDir() names itself after the test.
+func foreignTmuxBase(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "adfgn")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// startServerUnder creates a session on socketName under base, with exit-empty
+// off so the server outlives its own command, and registers teardown that kills
+// it through the SAME env — a mismatch there makes kill-server a silent no-op
+// and strands a server plus its ptys.
+func startServerUnder(t *testing.T, base, socketName, session string) {
+	t.Helper()
+	out, err := tmuxUnder(t, base, "-L", socketName, "new-session", "-d", "-s", session, "sleep 6000").CombinedOutput()
+	require.NoError(t, err, "new-session under %s: %s", base, out)
+	t.Cleanup(func() { _ = tmuxUnder(t, base, "-L", socketName, "kill-server").Run() })
+	out, err = tmuxUnder(t, base, "-L", socketName, "set-option", "-g", "exit-empty", "off").CombinedOutput()
+	require.NoError(t, err, "exit-empty off: %s", out)
+}
+
+// attachedClientUnder spawns a control-mode client attached to a session on
+// base's server, reparented away from the test binary, and returns its pid once
+// the server has registered it. It is a real, live, attached client — the class
+// isLiveTmuxClientOrServer must never report as reapable.
+func attachedClientUnder(t *testing.T, base, socketName, session string) int {
+	t.Helper()
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "stdin.fifo")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0o600))
+	keepOpen, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = keepOpen.Close() })
+
+	pidPath := filepath.Join(dir, "pid")
+	logPath := filepath.Join(dir, "out.log")
+	argv := []string{"tmux", "-L", socketName, "-C", "attach-session", "-t", session}
+	quoted := make([]string, len(argv))
+	for i, a := range argv {
+		quoted[i] = shQuote(a)
+	}
+	script := "TMUX= TMUX_TMPDIR=" + shQuote(base) + " " + strings.Join(quoted, " ") +
+		" < " + shQuote(fifoPath) + " > " + shQuote(logPath) + " 2>&1 & echo $! > " + shQuote(pidPath) + "; exit 0"
+
+	wrapper := exec.Command("sh", "-c", script)
+	out, err := wrapper.CombinedOutput()
+	require.NoError(t, err, "sh wrapper: %s", out)
+
+	var pidBytes []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pidBytes, err = os.ReadFile(pidPath)
+		if err == nil && strings.TrimSpace(string(pidBytes)) != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	require.NoError(t, err, "read pid file")
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	// Registration happens asynchronously after exec, so wait for the server to
+	// actually know about it — otherwise a refusal could be a timing artefact
+	// rather than the boundary under test.
+	deadline = time.Now().Add(5 * time.Second)
+	target := strconv.Itoa(pid)
+	for time.Now().Before(deadline) {
+		out, err := tmuxUnder(t, base, "-L", socketName, "list-clients", "-F", "#{client_pid}").Output()
+		if err == nil {
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if strings.TrimSpace(line) == target {
+					return pid
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	logContents, _ := os.ReadFile(logPath)
+	t.Fatalf("client pid %d never registered on %s/%s (log: %s)", pid, base, socketName, logContents)
+	return 0
+}
+
+// TestIsLiveTmuxClientOrServer_RefusesACandidateOnAnotherServer is the case the
+// suite could not construct. Two servers carry the same -L name under different
+// bases. The candidate is attached and alive on the foreign one; the query
+// resolves to ours, which is also running and answering — so nothing fails, and
+// the honest answer ("I asked the wrong server") is only available by comparing
+// sockets.
+func TestIsLiveTmuxClientOrServer_RefusesACandidateOnAnotherServer(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resolving a candidate's own socket reads /proc/<pid>/environ; linux-only by construction")
+	}
+	const socketName = "adwrongsrv"
+	const session = "agentdeck_wrong_server"
+
+	// Ours: a live server on the same -L name, under the package's isolated
+	// TMUX_TMPDIR. It must exist and answer, or the refusal would come from
+	// "no server there" and prove nothing about the boundary.
+	ourBase := os.Getenv("TMUX_TMPDIR")
+	require.NotEmpty(t, ourBase, "package TestMain must have isolated TMUX_TMPDIR")
+	startServerUnder(t, ourBase, socketName, "agentdeck_ours")
+
+	// Theirs: same name, different base, with a live attached client.
+	foreign := foreignTmuxBase(t)
+	startServerUnder(t, foreign, socketName, session)
+	pid := attachedClientUnder(t, foreign, socketName, session)
+
+	cmdlineFields := []string{"tmux", "-L", socketName, "-C", "attach-session", "-t", session}
+
+	// The premise: both servers are up, and they are different servers.
+	ourPID, err := tmuxUnder(t, ourBase, "-L", socketName, "display-message", "-p", "#{pid}").Output()
+	require.NoError(t, err, "our own server must be answering, or this test proves nothing")
+	theirPID, err := tmuxUnder(t, foreign, "-L", socketName, "display-message", "-p", "#{pid}").Output()
+	require.NoError(t, err)
+	require.NotEqual(t, strings.TrimSpace(string(ourPID)), strings.TrimSpace(string(theirPID)),
+		"the two bases must hold DIFFERENT servers, or there is no wrong server to reach")
+
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, cmdlineFields)
+
+	assert.False(t, ok,
+		"a candidate whose own socket is not the one the query reaches must be unclassifiable; "+
+			"ok=true here is a kill verdict against a client that is attached and alive")
+	assert.False(t, live)
+
+	// And the verdict must be reached without signalling anything.
+	time.Sleep(200 * time.Millisecond)
+	assert.NoError(t, syscall.Kill(pid, 0), "the live foreign client was signalled")
+}
+
+// TestIsLiveTmuxClientOrServer_AcceptsACandidateOnOurOwnSocket is the positive
+// control. Same-socket candidates are the whole population the sweep is for, so
+// a socket comparison that refuses them too would close the hole by making the
+// sweep inert — the failure mode this file's subject has twice already.
+func TestIsLiveTmuxClientOrServer_AcceptsACandidateOnOurOwnSocket(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("resolving a candidate's own socket reads /proc/<pid>/environ; linux-only by construction")
+	}
+	const socketName = "adsamesrv"
+	const session = "agentdeck_same_server"
+
+	ourBase := os.Getenv("TMUX_TMPDIR")
+	require.NotEmpty(t, ourBase)
+	startServerUnder(t, ourBase, socketName, session)
+	pid := attachedClientUnder(t, ourBase, socketName, session)
+
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid,
+		[]string{"tmux", "-L", socketName, "-C", "attach-session", "-t", session})
+
+	assert.True(t, ok, "a candidate on the socket we resolve to must still be classifiable")
+	assert.True(t, live, "an attached client on our own server must read as live")
+}
+
+// TestCandidateSocketPath_RefusesAnUnreadableEnvironment covers the other half
+// of "resolve the candidate's socket from the candidate": a pid whose
+// environment cannot be read cannot have its socket established either, and
+// unestablished is a refusal, not a default.
+func TestCandidateSocketPath_RefusesAnUnreadableEnvironment(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("reads /proc/<pid>/environ")
+	}
+	// A pid that does not exist: /proc/<pid>/environ is as unreadable as it
+	// gets, without needing a second uid.
+	_, ok := candidateSocketPath(1<<30, []string{"tmux", "-L", "whatever", "list-clients"})
+
+	assert.False(t, ok, "an unreadable environment must not resolve to a socket")
+}

--- a/internal/tmux/orphan_reap_socket_ownership_test.go
+++ b/internal/tmux/orphan_reap_socket_ownership_test.go
@@ -268,6 +268,16 @@ func TestCandidateSocketPath_RefusesACandidateInAnotherMountNamespace(t *testing
 	if _, err := exec.LookPath("unshare"); err != nil {
 		t.Skip("unshare(1) not available")
 	}
+	// Pre-flight, and not optional: a host can forbid unprivileged user
+	// namespaces outright — GitHub's Ubuntu runners do, via
+	// apparmor_restrict_unprivileged_userns=1 — and unshare reports that by
+	// failing AFTER exec. Start() therefore succeeds and the only symptom is
+	// the readiness wait below timing out, which would make an unavailable
+	// kernel feature look like a broken test.
+	if out, err := exec.Command("unshare", "-Umr", "true").CombinedOutput(); err != nil {
+		t.Skipf("unprivileged mount namespaces unavailable on this host (%v): %s",
+			err, strings.TrimSpace(string(out)))
+	}
 
 	dir := t.TempDir()
 	ready := filepath.Join(dir, "ready")

--- a/internal/tmux/orphan_reap_socket_ownership_test.go
+++ b/internal/tmux/orphan_reap_socket_ownership_test.go
@@ -214,3 +214,100 @@ func TestCandidateSocketPath_RefusesAnUnreadableEnvironment(t *testing.T) {
 
 	assert.False(t, ok, "an unreadable environment must not resolve to a socket")
 }
+
+// TestCandidateSocketPath_RefusesAnEmptyEnvironment pins the branch that
+// separates "no environment" from "an environment with nothing in it". A read
+// that succeeds with zero bytes leaves every lookup returning "", which
+// resolves confidently to the DEFAULT socket — and then judges the candidate
+// against a server it was never shown to be on.
+//
+// Measured on this kernel rather than assumed: a ZOMBIE's environ does not do
+// this, it fails outright (EPERM, or ENOENT once reaped) and is refused by the
+// error path above. What actually reads back empty-and-successful is a live
+// process exec'd with a genuinely empty environment, which is what this
+// constructs. agent-deck's own cadence clients inherit os.Environ(), so a
+// candidate with no environment at all is not one of ours to begin with.
+func TestCandidateSocketPath_RefusesAnEmptyEnvironment(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("reads /proc/<pid>/environ")
+	}
+	cmd := exec.Command("sleep", "300")
+	cmd.Env = []string{} // exec'd with no environment at all
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	// The premise. If this ever stops reading back empty-and-successful, the
+	// guard under test is dead code and this test must say so rather than keep
+	// passing for a different reason.
+	raw, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/environ")
+	require.NoError(t, err, "the read must SUCCEED, or this pins the error path instead")
+	require.Empty(t, raw, "the environment must read back EMPTY, or this test pins nothing")
+
+	_, ok := candidateSocketPath(pid, []string{"tmux", "-L", "work", "list-clients"})
+
+	assert.False(t, ok, "an empty environment must not resolve to the default socket")
+}
+
+// TestCandidateSocketPath_RefusesACandidateInAnotherMountNamespace covers the
+// false-match direction, which is the dangerous one: a refusal only costs a
+// leaked client, a false match costs a live one.
+//
+// Same uid, same socket name, same resolved path STRING — and a different mount
+// namespace, so that string names a different file. String equality says "our
+// server", the query goes to ours, the candidate is unknown there, and the
+// verdict is a kill against a client attached and alive on the server it can
+// actually see.
+func TestCandidateSocketPath_RefusesACandidateInAnotherMountNamespace(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mount namespaces are linux-only")
+	}
+	if _, err := exec.LookPath("unshare"); err != nil {
+		t.Skip("unshare(1) not available")
+	}
+
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	// -U -r: an unprivileged user namespace mapping us to root inside, which is
+	// what makes -m (a new mount namespace) available without real privilege.
+	cmd := exec.Command("unshare", "-Umr", "sh", "-c",
+		"echo ready > "+shQuote(ready)+"; exec sleep 300")
+	// The candidate's socket must resolve to the SAME STRING as ours, or this
+	// test would pass on a path mismatch and prove nothing about namespaces.
+	cmd.Env = append(os.Environ(), "TMUX_TMPDIR="+os.Getenv("TMUX_TMPDIR"), "TMUX=")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot create an unprivileged mount namespace here: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	require.NoError(t, waitForFile(ready, 5*time.Second), "namespaced child never started")
+
+	// Premises: a different mount namespace, and an identical path string.
+	ourNS, err := os.Readlink("/proc/self/ns/mnt")
+	require.NoError(t, err)
+	theirNS, err := os.Readlink("/proc/" + strconv.Itoa(pid) + "/ns/mnt")
+	if err != nil {
+		t.Skipf("cannot read the child's mount namespace: %v", err)
+	}
+	require.NotEqual(t, ourNS, theirNS, "the child did not get its own mount namespace")
+
+	args := []string{"tmux", "-L", "nsprobe", "list-clients"}
+	lookupEnv, err := readProcessEnviron(pid)
+	require.NoError(t, err)
+	require.Equal(t,
+		normalizeTmpPath(resolveTmuxSocketPath(os.Getenv, os.Getuid(), "nsprobe", nil)),
+		normalizeTmpPath(resolveTmuxSocketPath(lookupEnv, os.Getuid(), "", args[1:])),
+		"the two paths must be the same STRING, or this test proves nothing about namespaces")
+
+	_, ok := candidateSocketPath(pid, args)
+
+	assert.False(t, ok,
+		"a candidate in another mount namespace resolves to the same path string but a "+
+			"different file; treating that as our socket is a kill verdict on a live client")
+}

--- a/internal/tmux/orphan_reap_verb_parity_test.go
+++ b/internal/tmux/orphan_reap_verb_parity_test.go
@@ -1,0 +1,51 @@
+package tmux
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReapableVerbsMatchTheBoundedCommandLists pins the claim
+// reapableOneShotVerbs makes about itself: "the set mirrors the poll/mutation
+// lists that TestPollCommandsAreBounded enforces deadlines for — same commands,
+// same reason: they run on a cadence, so they are the ones that leak."
+//
+// It does mirror them today, and nothing made it stay that way. The lint's own
+// comments record its lists being widened twice ("the status-bar and key-binding
+// commands join them ... one round later"), and each widening teaches the lint
+// about a new cadence command while leaving the reaper unable to reap that
+// command's orphans — which is the sweep quietly going inert for one verb at a
+// time, the exact failure this whole area exists to prevent, and invisible
+// because a narrower sweep never fails a test.
+//
+// Deliberately an equality assertion rather than a subset one. A verb the
+// reaper may kill but the lint does not bound is just as wrong in the other
+// direction: it means agent-deck spawns that command unbounded, so the sweep is
+// authorised to kill a process class that this package never promised to stop
+// leaking.
+func TestReapableVerbsMatchTheBoundedCommandLists(t *testing.T) {
+	keys := func(m map[string]struct{}) []string {
+		out := make([]string, 0, len(m))
+		for k := range m {
+			out = append(out, k)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	bounded := map[string]struct{}{}
+	for verb := range pollSubcommands {
+		bounded[verb] = struct{}{}
+	}
+	for verb := range mutationSubcommands {
+		bounded[verb] = struct{}{}
+	}
+
+	assert.Equal(t, keys(bounded), keys(reapableOneShotVerbs),
+		"reapableOneShotVerbs must equal pollSubcommands ∪ mutationSubcommands. "+
+			"A verb bounded by the lint but missing here leaks orphans the sweep cannot reap; "+
+			"a verb here but not bounded there is one this package never promised to stop leaking. "+
+			"If you are adding a cadence command, add it to both.")
+}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -691,6 +691,33 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 // instead of re-scanning all of /proc on every Connect.
 var orphanReapOnce sync.Once
 
+// isReapableTmuxClientComm reports whether a /proc/<pid>/comm value identifies
+// a tmux CLIENT — the only process class reapOrphanedPollClients may kill.
+//
+// tmux renames both of its process roles after startup, so comm is "tmux:
+// client" / "tmux: server" rather than the bare "tmux" of the argv[0] the
+// process was exec'd with. (Verified on tmux 3.0a / Linux 5.4: `pgrep -x tmux`
+// matches nothing on a host running twenty tmux processes.) An earlier
+// equality test against "tmux" therefore matched no process at all and left
+// the sweep inert — orphaned query clients spun at 100% CPU for as long as the
+// host stayed up.
+//
+// The bare "tmux" case is kept because the rename is a tmux implementation
+// detail, not a guarantee: a client that has not yet renamed itself, or a
+// version that never does, must still be reapable.
+//
+// "tmux: server" MUST NOT match. The sweep SIGKILLs whatever it matches, and a
+// server holds every session it hosts, so a false positive there destroys the
+// user's running work rather than a leaked one-shot query.
+func isReapableTmuxClientComm(comm string) bool {
+	switch strings.TrimSpace(comm) {
+	case "tmux", "tmux: client":
+		return true
+	default:
+		return false
+	}
+}
+
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
 // `list-clients` / `display-message` / `list-panes` / status `set-option`
 // invocations agent-deck fires on a cadence — that a previous run spawned and
@@ -705,8 +732,8 @@ var orphanReapOnce sync.Once
 // timeout because the TUI was SIGKILL'd / OOM-killed mid-command.
 //
 // Safety — a process is killed only when ALL hold:
-//   - it is the `tmux` client binary (comm == "tmux"; the server is
-//     "tmux: server" and never matches),
+//   - it is a tmux CLIENT process (isReapableTmuxClientComm; the server
+//     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
 //     user's unrelated tmux is never touched, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
@@ -734,7 +761,7 @@ func reapOrphanedPollClients() {
 			continue
 		}
 		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil || strings.TrimSpace(string(comm)) != "tmux" {
+		if err != nil || !isReapableTmuxClientComm(string(comm)) {
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -1134,6 +1134,53 @@ func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 	return socketNameFlag(rest), true
 }
 
+// unreachableSockets memoizes, for the duration of ONE sweep, the sockets whose
+// tmux server could not be reached. It is reset at the start of every sweep.
+//
+// Caching the ANSWERS to the two identity queries is rejected on purpose (see
+// reapOrphanedPollClients' notes): a cached client list goes stale inside a
+// sweep, and a client that connects mid-sweep would be absent from it and
+// eligible to be killed. Freshness is the safety property there.
+//
+// Caching the REFUSAL is a different thing. "This socket could not be reached"
+// only ever produces more refusals, never a kill, so it is fail-closed by
+// construction — and it is the expensive case: an unreachable or wedged server
+// is exactly what makes a query ride its full tmuxLiveQueryTimeout, twice per
+// candidate. On the incident host that is the difference between judging every
+// candidate and spending the whole budget on the first handful, and it saves a
+// spawn per skipped query — each of which is another client against a server
+// that leaks an fd per client.
+//
+// It also closes a window rather than opening one: without it, a server that
+// appears mid-sweep can answer for a candidate whose absence was judged against
+// the socket being empty, and that answer is a kill verdict.
+var (
+	unreachableSocketsMu sync.Mutex
+	unreachableSockets   = map[string]struct{}{}
+)
+
+// resetUnreachableSockets clears the memo. Called at the start of each sweep:
+// carrying it across sweeps would make a socket that was briefly unreachable
+// permanently unreapable, which is the inert-sweep failure this area began with.
+func resetUnreachableSockets() {
+	unreachableSocketsMu.Lock()
+	defer unreachableSocketsMu.Unlock()
+	unreachableSockets = map[string]struct{}{}
+}
+
+func markSocketUnreachable(socket string) {
+	unreachableSocketsMu.Lock()
+	defer unreachableSocketsMu.Unlock()
+	unreachableSockets[socket] = struct{}{}
+}
+
+func socketKnownUnreachable(socket string) bool {
+	unreachableSocketsMu.Lock()
+	defer unreachableSocketsMu.Unlock()
+	_, ok := unreachableSockets[socket]
+	return ok
+}
+
 // isLiveTmuxClientOrServer authoritatively asks the tmux server that the
 // candidate's OWN argv targets whether pid IS that server, or is one of its
 // currently-connected clients — the two process classes reapOrphanedPollClients
@@ -1218,10 +1265,15 @@ func isLiveTmuxClientOrServer(budget context.Context, pid int, cmdlineFields []s
 		return false, false
 	}
 
+	if socketKnownUnreachable(querySocket) {
+		return false, false
+	}
+
 	ctx, cancel := context.WithTimeout(budget, tmuxLiveQueryTimeout)
 	defer cancel()
 	serverPIDOut, err := tmuxExecContext(ctx, socketName, "display-message", "-p", "#{pid}").Output()
 	if err != nil {
+		markSocketUnreachable(querySocket)
 		return false, false
 	}
 	serverPID, err := strconv.Atoi(strings.TrimSpace(string(serverPIDOut)))
@@ -1236,6 +1288,7 @@ func isLiveTmuxClientOrServer(budget context.Context, pid int, cmdlineFields []s
 	defer cancel2()
 	clientsOut, err := tmuxExecContext(ctx2, socketName, "list-clients", "-F", "#{client_pid}").Output()
 	if err != nil {
+		markSocketUnreachable(querySocket)
 		return false, false
 	}
 	target := strconv.Itoa(pid)
@@ -1300,6 +1353,7 @@ func reapOrphanedPollClients() {
 		return
 	}
 	start := time.Now()
+	resetUnreachableSockets()
 	budget, cancel := context.WithTimeout(context.Background(), orphanSweepBudget)
 	defer cancel()
 	candidates, unidentifiable := collectOrphanCandidates(budget)
@@ -1478,6 +1532,26 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 		if !isKnownCadenceArgv(c.cmdline) {
 			continue
 		}
+		if commUnclassifiable {
+			// Decided already, so decide it here rather than after the tmux
+			// query: this candidate can never be killed, and the query is the
+			// most expensive step in the gauntlet — up to 2 × tmuxLiveQueryTimeout
+			// against exactly the wedged server that produces these candidates.
+			// Spending a fifth of the sweep's whole budget on an answer that is
+			// then discarded starves the candidates that could still be judged,
+			// and on a host whose tmux is invoked under a longer name (the
+			// measured "tmux-3.5a:" case) there can be a handful of these.
+			//
+			// The reporting is unchanged, which is the point of refusing here
+			// rather than skipping silently.
+			unclassifiable++
+			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
+				slog.Int("pid", c.pid),
+				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))),
+				slog.String("reason", "comm lost its role token to truncation; "+
+					"cannot prove this is a client rather than a server, so it is left alone"))
+			continue
+		}
 		// THE safety check: ask the tmux server itself, not argv text, whether
 		// this pid is live. live==true or ok==false both mean "do not kill".
 		cmdlineFields := strings.Split(strings.TrimRight(c.cmdline, "\x00"), "\x00")
@@ -1526,15 +1600,6 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 			pipeLog.Warn("orphan_sweep_skipped_unhandled_parentage_verdict",
 				slog.Int("pid", c.pid),
 				slog.Int("verdict", int(verdict)))
-			continue
-		}
-		if commUnclassifiable {
-			unclassifiable++
-			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
-				slog.Int("pid", c.pid),
-				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))),
-				slog.String("reason", "comm lost its role token to truncation; "+
-					"cannot prove this is a client rather than a server, so it is left alone"))
 			continue
 		}
 		// The identity was captured before any of the above ran, and the tmux

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -702,20 +702,80 @@ var orphanReapOnce sync.Once
 // the sweep inert — orphaned query clients spun at 100% CPU for as long as the
 // host stayed up.
 //
-// The bare "tmux" case is kept because the rename is a tmux implementation
-// detail, not a guarantee: a client that has not yet renamed itself, or a
-// version that never does, must still be reapable.
+// The bare "tmux" case is kept for the window between exec and the client's own
+// proc_start: a process that has not renamed itself yet is a client that has not
+// connected yet, never a server (the server is forked from an already-renamed
+// client, so it never presents a bare name).
 //
-// "tmux: server" MUST NOT match. The sweep SIGKILLs whatever it matches, and a
-// server holds every session it hosts, so a false positive there destroys the
-// user's running work rather than a leaked one-shot query.
+// It is the ROLE token that authorises the kill, not the program name — see
+// tmuxCommRole for why a longer argv[0] is still safe to reap when its role
+// survives, and isTruncatedTmuxComm for what happens when it does not.
+//
+// A server MUST NOT match. The sweep SIGKILLs whatever it matches, and a server
+// holds every session it hosts, so a false positive there destroys the user's
+// running work rather than a leaked one-shot query.
 func isReapableTmuxClientComm(comm string) bool {
-	switch strings.TrimSpace(comm) {
-	case "tmux", "tmux: client":
+	trimmed := strings.TrimSpace(comm)
+	if trimmed == "tmux" {
 		return true
-	default:
+	}
+	role, ok := tmuxCommRole(trimmed)
+	return ok && role == "client"
+}
+
+// tmuxCommRole splits tmux's setproctitle-style comm into its role token.
+// tmux formats "<progname>: <role> (<socket path>)", so the role is whatever
+// follows the first ": ".
+//
+// Keying on the role rather than on the literal "tmux: client" keeps the sweep
+// working for an installation whose binary is invoked under a longer name: a
+// 5-char progname still yields "tmuxx: client", which names its role
+// unambiguously and is as safe to reap as the canonical form.
+//
+// The role either survives whole or vanishes whole — it is never truncated to a
+// prefix. The kernel caps comm at 15 bytes and tmux then cuts the result back to
+// its last space, which is the one separating the role from the socket path. So
+// a partial "clie"/"serve" cannot reach this function, and matching role ==
+// "client" can never be satisfied by a server.
+func tmuxCommRole(comm string) (string, bool) {
+	idx := strings.Index(comm, ": ")
+	if idx <= 0 {
+		return "", false
+	}
+	role := comm[idx+2:]
+	if role == "" {
+		return "", false
+	}
+	return role, true
+}
+
+// isTruncatedTmuxComm reports whether comm looks like tmux's setproctitle output
+// whose role token was lost entirely to the 15-byte comm limit.
+//
+// Measured, not inferred: invoking /usr/bin/tmux through a symlink named
+// "tmux-3.5a" produces the comm "tmux-3.5a:" — cut back to the space right after
+// the colon, taking "client"/"server" with it. A server under that binary
+// produces the identical string, so such a process cannot be classified at all
+// and must not be killed.
+//
+// agent-deck cannot produce one of these itself: every spawn is
+// exec.Command("tmux", …), so argv[0] is the literal "tmux" whatever the binary
+// is called on disk. The case therefore belongs to a user's own tmux, which the
+// sweep has no business killing regardless.
+//
+// It is still worth reporting. The bug this whole sweep exists to prevent was
+// invisible — an inert filter that killed nothing and logged nothing while two
+// orphans burned a core each for 14 hours. Anything that silently narrows the
+// sweep back toward inert should say so.
+func isTruncatedTmuxComm(comm string) bool {
+	trimmed := strings.TrimSpace(comm)
+	if trimmed == "tmux" {
 		return false
 	}
+	if _, ok := tmuxCommRole(trimmed); ok {
+		return false
+	}
+	return strings.Contains(trimmed, "tmux") && strings.HasSuffix(trimmed, ":")
 }
 
 // reapableOneShotVerbs are the tmux subcommands reapOrphanedPollClients may
@@ -820,6 +880,7 @@ func reapOrphanedPollClients() {
 	}
 	myPID := os.Getpid()
 	killed := 0
+	skipped := 0
 	start := time.Now()
 	for _, e := range entries {
 		pid, err := strconv.Atoi(e.Name())
@@ -827,7 +888,16 @@ func reapOrphanedPollClients() {
 			continue
 		}
 		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil || !isReapableTmuxClientComm(string(comm)) {
+		if err != nil {
+			continue
+		}
+		reapable := isReapableTmuxClientComm(string(comm))
+		// A comm whose role token was truncated away cannot be classified as
+		// client or server. It is not killed; it is carried to the end of the
+		// gauntlet so that a process which is otherwise indistinguishable from
+		// a leak gets reported instead of vanishing from the sweep in silence.
+		unclassifiable := !reapable && isTruncatedTmuxComm(string(comm))
+		if !reapable && !unclassifiable {
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the
@@ -845,15 +915,25 @@ func reapOrphanedPollClients() {
 		if !isControlClientOrphan(pid) {
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
 		}
+		if unclassifiable {
+			skipped++
+			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.String("reason", "comm lost its role token to truncation; "+
+					"cannot prove this is a client rather than a server, so it is left alone"))
+			continue
+		}
 		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
 		killed++
 		pipeLog.Debug("reaped_orphaned_poll_client",
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	if killed > 0 {
+	if killed > 0 || skipped > 0 {
 		pipeLog.Info("orphaned_poll_clients_reaped",
 			slog.Int("kill_count", killed),
+			slog.Int("skipped_unclassifiable", skipped),
 			slog.Duration("duration", time.Since(start)))
 	}
 }

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -582,7 +582,9 @@ func killStaleControlClients(sessionName, socketName string) {
 	if err != nil {
 		return // session may not exist or no clients attached
 	}
-	reapStaleControlClients(string(out), sessionName)
+	budget, cancel := context.WithTimeout(context.Background(), staleControlSweepBudget)
+	defer cancel()
+	reapStaleControlClients(budget, string(out), sessionName)
 }
 
 // SweepStaleControlClients reaps orphaned control-mode clients across EVERY
@@ -605,17 +607,45 @@ func killStaleControlClients(sessionName, socketName string) {
 // failed) list-clients is treated as best-effort and skipped — the next launch
 // sweeps again.
 func SweepStaleControlClients(socketName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), staleControlSweepTimeout)
+	budget, cancel := context.WithTimeout(context.Background(), staleControlSweepBudget)
 	defer cancel()
-	out, err := tmuxExecContext(ctx, socketName,
+
+	// The query gets its own, tighter cap nested inside the budget: an
+	// unresponsive server must not spend the whole allowance before a single
+	// client has been looked at.
+	queryCtx, cancelQuery := context.WithTimeout(budget, staleControlSweepTimeout)
+	defer cancelQuery()
+	out, err := tmuxExecContext(queryCtx, socketName,
 		"list-clients",
 		"-F", "#{client_control_mode} #{client_pid}",
 	).Output()
 	if err != nil {
 		return // no server running, no clients attached, or the probe timed out
 	}
-	reapStaleControlClients(string(out), "(all-sessions)")
+	reapStaleControlClients(budget, string(out), "(all-sessions)")
 }
+
+// staleControlSweepBudget is the aggregate deadline for one stale-control-client
+// sweep: the identity reads AND the SIGTERM/grace of every victim, not just the
+// enumeration. It is deliberately far larger than staleControlSweepTimeout,
+// because the two bound different risks — the query cap stops one wedged server
+// from stalling the sweep, while this one stops the sweep as a whole from
+// stalling the boot path.
+//
+// Sized to clear a real backlog rather than to be tight. The dominant cost is
+// controlClientKillGrace per victim, and only for a client that ignores
+// SIGTERM: softKillProcessChecked polls and returns as soon as the pid is gone,
+// so the 176-client case this sweep exists for normally costs milliseconds of
+// /proc reads plus prompt exits. Ten seconds leaves that untouched and caps the
+// pathological host, where the remainder is reported and swept again next
+// launch.
+//
+// Why this sweep stays synchronous, unlike its sibling: main.go runs it
+// immediately BEFORE the TUI starts connecting its own pipes, precisely because
+// the failure it cleans up is an exhausted pty table. Backgrounding it would
+// let this process start claiming ptys while the backlog is still there, which
+// is the ordering the boot-path call exists to guarantee.
+var staleControlSweepBudget = 10 * time.Second
 
 // staleControlSweepTimeout bounds the boot-path server-wide list-clients query
 // in SweepStaleControlClients so an unresponsive tmux server can't hang startup.
@@ -625,8 +655,23 @@ var staleControlSweepTimeout = 2 * time.Second
 // #{client_pid}"` output and soft-kills each orphaned control-mode client.
 // sessionLabel identifies the sweep scope in the observability logs ("(all-
 // sessions)" for the server-wide startup sweep, otherwise the session name).
-// Returns the number of clients killed.
-func reapStaleControlClients(listOutput, sessionLabel string) int {
+// Returns the number of clients killed, and the number never examined because
+// the budget ran out.
+//
+// budget bounds the WHOLE sweep, not one probe of it. Before this, the only
+// deadline in this area was staleControlSweepTimeout on the `list-clients`
+// query that feeds this function; everything after it — one identity read per
+// listed pid, then a SIGTERM and up to controlClientKillGrace per victim — ran
+// unbounded and synchronously on the boot path. Over the backlog this function
+// exists for (176 orphaned clients, see SweepStaleControlClients) that is a
+// startup stall measured in minutes, on a host already in trouble. Commit
+// 3a5af543 makes this argument to get the orphan sweep off the Connect path;
+// the same reasoning applies here and was not applied.
+//
+// Candidates left unexamined are counted and logged rather than dropped
+// quietly: the next launch sweeps again, and a sweep that quietly narrows
+// itself toward inert is the original failure of this whole area.
+func reapStaleControlClients(budget context.Context, listOutput, sessionLabel string) (killed, unexamined int) {
 	myPID := os.Getpid()
 
 	// Track burst stats so production logs surface how often this fires N>0
@@ -637,7 +682,6 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 	// killed_stale_control_client log emits per-PID; the Info line below
 	// surfaces the cascade as a single observable event.
 	burstStart := time.Now()
-	killCount := 0
 
 	// Pass 1: identify every pid in the snapshot BEFORE anything is killed.
 	//
@@ -672,7 +716,11 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		if pid == myPID {
 			continue // don't kill our own process
 		}
-		identity, err := processIdentityOf(context.Background(), pid)
+		if budget.Err() != nil {
+			unexamined++
+			continue
+		}
+		identity, err := processIdentityOf(budget, pid)
 		if err != nil {
 			// Fail closed: a pid we cannot identify is not signalled. See
 			// stillSameIncarnation.
@@ -693,6 +741,10 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 	// immediately before each signal, and a pid that changed hands is refused.
 	for _, c := range candidates {
 		pid, identity := c.pid, c.identity
+		if budget.Err() != nil {
+			unexamined++
+			continue
+		}
 		switch verdict := controlClientOrphanOf(pid); verdict {
 		case parentageUnknown:
 			// This sweep has no comm filter and no live-server query, so the
@@ -737,7 +789,7 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		// the entire tmux server, wiping every agent-deck session. A SIGTERM
 		// lets the client drain and exit cleanly; SIGKILL is retained as a
 		// 500ms fallback for clients that ignore TERM.
-		usedSIGKILL, signalled := softKillProcessChecked(context.Background(), pid, identity, controlClientKillGrace)
+		usedSIGKILL, signalled := softKillProcessChecked(budget, pid, identity, controlClientKillGrace)
 		if !signalled {
 			// Nothing was sent, so nothing is counted — the burst metric below
 			// exists to observe real kill cascades. Two causes share this
@@ -751,20 +803,21 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 				slog.Int("pid", pid))
 			continue
 		}
-		killCount++
+		killed++
 		pipeLog.Debug("killed_stale_control_client",
 			slog.String("session", logging.SanitizeValue(sessionLabel)),
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
 
-	if killCount > 0 {
+	if killed > 0 || unexamined > 0 {
 		pipeLog.Info("stale_control_clients_swept",
 			slog.String("session", logging.SanitizeValue(sessionLabel)),
-			slog.Int("kill_count", killCount),
+			slog.Int("kill_count", killed),
+			slog.Int("unexamined_out_of_budget", unexamined),
 			slog.Duration("duration", time.Since(burstStart)))
 	}
-	return killCount
+	return killed, unexamined
 }
 
 // orphanReapStarted ensures the process-wide orphaned-poll-client sweep is

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -1740,8 +1740,19 @@ func softKillProcessChecked(budget context.Context, pid int, identity string, gr
 // It sends SIGTERM to the entire group (-pgid), polls every 5ms up to grace
 // for the group to drain, and escalates to SIGKILL if any process in the
 // group is still alive at the deadline. Returns true iff SIGKILL was
-// ultimately used. An empty group (ESRCH on initial SIGTERM) is treated as
-// already-dead and returns false without escalation.
+// ultimately used.
+//
+// A SIGTERM the kernel refuses ends the attempt; nothing is escalated and
+// nothing is reported as killed:
+//
+//   - ESRCH — the group is empty, i.e. already dead.
+//   - EPERM — not one member of that group is ours. This is what a recycled
+//     pgid looks like from here. The old code read it as a reason to try
+//     harder and sent a group-wide SIGKILL, which is the one response that
+//     cannot help: kill(2)'s permission check is identical for both signals,
+//     so the escalation either fails the same way or lands on a group this
+//     process has no business signalling. It then returned true, reporting a
+//     kill that never happened.
 //
 // Used by ControlPipe.Close() to tear down the agent-deck-owned
 // `tmux -C attach-session` child without racing tmux's control-mode
@@ -1752,13 +1763,18 @@ func softKillProcessChecked(budget context.Context, pid int, identity string, gr
 // only covered killStaleControlClients (the post-restart cleanup path);
 // the active-pipe close path still SIGKILL'd. This helper closes that gap.
 func softKillProcessGroup(pgid int, grace time.Duration) bool {
-	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return false
-		}
-		// Permission or other error — fall back to SIGKILL on the group.
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
-		return true
+	return softKillProcessGroupWith(syscall.Kill, pgid, grace)
+}
+
+// softKillProcessGroupWith is the injectable core of softKillProcessGroup. kill
+// is syscall.Kill in production; a test passes its own so the errno branches can
+// be driven without a group this process genuinely may not signal (which needs a
+// second uid, i.e. a host the CI runners do not provide).
+func softKillProcessGroupWith(kill func(pid int, sig syscall.Signal) error, pgid int, grace time.Duration) bool {
+	if err := kill(-pgid, syscall.SIGTERM); err != nil {
+		// ESRCH (empty group) or EPERM (not ours) — either way there is
+		// nothing here this process both may and should kill.
+		return false
 	}
 
 	const pollInterval = 5 * time.Millisecond
@@ -1767,12 +1783,12 @@ func softKillProcessGroup(pgid int, grace time.Duration) bool {
 		time.Sleep(pollInterval)
 		// kill(-pgid, 0) returns ESRCH only when no process in the group
 		// remains; until then it returns nil (some member alive or zombie).
-		if err := syscall.Kill(-pgid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
+		if err := kill(-pgid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
 			return false
 		}
 	}
 
-	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	_ = kill(-pgid, syscall.SIGKILL)
 	return true
 }
 

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -677,7 +677,7 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 			// Fail closed: a pid we cannot identify is not signalled. See
 			// stillSameIncarnation.
 			pipeLog.Warn("skipped_unidentifiable_control_client_pid",
-				slog.String("session", sessionLabel),
+				slog.String("session", logging.SanitizeValue(sessionLabel)),
 				slog.Int("pid", pid),
 				slog.String("reason", "could not read a start-time identity for this pid; "+
 					"refusing to signal a pid that cannot be tied to the client tmux reported"))
@@ -698,7 +698,7 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 			// two concurrent agent-deck TUIs (allow_multiple=true) would
 			// SIGTERM each other's control clients on every reconnect (#927).
 			pipeLog.Debug("preserved_live_sibling_control_client",
-				slog.String("session", sessionLabel),
+				slog.String("session", logging.SanitizeValue(sessionLabel)),
 				slog.Int("pid", pid))
 			continue
 		}
@@ -719,20 +719,20 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 			// the first is a recycled pid, and from here they are not
 			// distinguishable.
 			pipeLog.Debug("skipped_control_client_not_signalled",
-				slog.String("session", sessionLabel),
+				slog.String("session", logging.SanitizeValue(sessionLabel)),
 				slog.Int("pid", pid))
 			continue
 		}
 		killCount++
 		pipeLog.Debug("killed_stale_control_client",
-			slog.String("session", sessionLabel),
+			slog.String("session", logging.SanitizeValue(sessionLabel)),
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
 
 	if killCount > 0 {
 		pipeLog.Info("stale_control_clients_swept",
-			slog.String("session", sessionLabel),
+			slog.String("session", logging.SanitizeValue(sessionLabel)),
 			slog.Int("kill_count", killCount),
 			slog.Duration("duration", time.Since(burstStart)))
 	}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -718,6 +718,69 @@ func isReapableTmuxClientComm(comm string) bool {
 	}
 }
 
+// reapableOneShotVerbs are the tmux subcommands reapOrphanedPollClients may
+// kill: the short-lived cadence queries and option writes agent-deck fires on a
+// timer, every one of which is safe to lose because its caller re-issues it on
+// the next tick. The set mirrors the poll/mutation lists that
+// TestPollCommandsAreBounded enforces deadlines for — same commands, same
+// reason: they run on a cadence, so they are the ones that leak.
+var reapableOneShotVerbs = map[string]struct{}{
+	"bind-key":         {},
+	"capture-pane":     {},
+	"detach-client":    {},
+	"display-message":  {},
+	"has-session":      {},
+	"kill-session":     {},
+	"list-clients":     {},
+	"list-panes":       {},
+	"list-sessions":    {},
+	"refresh-client":   {},
+	"set-option":       {},
+	"show-environment": {},
+	"show-option":      {},
+	"switch-client":    {},
+	"unbind-key":       {},
+}
+
+// neverReapVerbs are the subcommands that disqualify a process outright, even
+// if the same argv also carries a reapable verb (tmux accepts `;`-chained
+// commands, so both can appear). Each names a process whose death costs the
+// user something this sweep has no standing to spend:
+//
+//   - attach-session — an interactive client is the user's live view of a
+//     session, and a control-mode one belongs to a TUI. Orphaned control
+//     clients are reapStaleControlClients' job; it filters on
+//     client_control_mode and so cannot mistake a hand-run `tmux attach` for
+//     a leak. This sweep, matching only on comm + argv + parentage, can:
+//     isControlClientOrphan calls ANY non-agent-deck parent an orphan, so a
+//     client attached from the user's own shell qualifies while that shell is
+//     still alive.
+//   - new-session — a server inherits the creating client's comm ("tmux:
+//     client", set by proc_start before the fork) and argv until its own
+//     proc_start("server") runs after daemon(). A server killed in that window
+//     takes the session it was starting with it.
+var neverReapVerbs = map[string]struct{}{
+	"attach-session": {},
+	"new-session":    {},
+}
+
+// isReapableOneShotArgv reports whether a /proc/<pid>/cmdline names a one-shot
+// cadence command and nothing more dangerous. cmdline fields are NUL-separated
+// and NUL-terminated, so each argv element is compared whole — a session name
+// or path that merely contains a verb as a substring cannot match.
+func isReapableOneShotArgv(cmdline string) bool {
+	reapable := false
+	for _, field := range strings.Split(strings.TrimRight(cmdline, "\x00"), "\x00") {
+		if _, denied := neverReapVerbs[field]; denied {
+			return false
+		}
+		if _, ok := reapableOneShotVerbs[field]; ok {
+			reapable = true
+		}
+	}
+	return reapable
+}
+
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
 // `list-clients` / `display-message` / `list-panes` / status `set-option`
 // invocations agent-deck fires on a cadence — that a previous run spawned and
@@ -735,7 +798,10 @@ func isReapableTmuxClientComm(comm string) bool {
 //   - it is a tmux CLIENT process (isReapableTmuxClientComm; the server
 //     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
-//     user's unrelated tmux is never touched, and
+//     user's unrelated tmux is never touched,
+//   - its argv names a one-shot cadence verb and no attach/new-session verb
+//     (isReapableOneShotArgv), so neither a live interactive client nor a
+//     server still inside its startup rename window can be hit, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
 //     (isControlClientOrphan — its parentage check is client-type-agnostic
 //     despite the name). A live TUI's own in-flight poll has PPID == our PID,
@@ -768,6 +834,12 @@ func reapOrphanedPollClients() {
 		// "agentdeck_" target token regardless of separators.
 		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 		if err != nil || !strings.Contains(string(raw), SessionPrefix) {
+			continue
+		}
+		// Narrow comm+prefix down to the cadence commands this sweep exists
+		// for: an interactive attach and a server mid-startup both clear the
+		// checks above, and killing either costs the user real work.
+		if !isReapableOneShotArgv(string(raw)) {
 			continue
 		}
 		if !isControlClientOrphan(pid) {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -639,6 +639,24 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 	burstStart := time.Now()
 	killCount := 0
 
+	// Pass 1: identify every pid in the snapshot BEFORE anything is killed.
+	//
+	// The two passes are the point. Killing is sequential and each victim can
+	// hold the loop for a full grace period, so with the capture inline the Nth
+	// pid's identity would be read N × grace after tmux listed it — and a pid
+	// recycled during an earlier victim's grace would be identified as its NEW
+	// occupant, which then matches at signal time and is killed. This sweep has
+	// no comm check and no live-server query to catch that (unlike the orphan
+	// sweep); isControlClientOrphan alone would not, since it says "orphan" for
+	// any process not parented to an agent-deck binary. Capturing everything up
+	// front shrinks the snapshot-to-identity gap to the microseconds it takes to
+	// read /proc, and the re-check inside softKillProcessChecked covers the rest
+	// of the wait.
+	type staleControlClient struct {
+		pid      int
+		identity string
+	}
+	candidates := make([]staleControlClient, 0, 8)
 	for _, line := range strings.Split(strings.TrimSpace(listOutput), "\n") {
 		if line == "" {
 			continue
@@ -654,12 +672,6 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		if pid == myPID {
 			continue // don't kill our own process
 		}
-		// Capture the identity now, BEFORE the checks that justify the kill.
-		// Every one of them reads /proc for this pid, and the kill can land up
-		// to grace-per-earlier-victim later; the identity is what ties the two
-		// ends together. Capturing it afterwards would defeat the guard in the
-		// exact case it exists for — the reads would describe the old process
-		// and the identity the new one, and they would agree at signal time.
 		identity, err := processIdentityOf(context.Background(), pid)
 		if err != nil {
 			// Fail closed: a pid we cannot identify is not signalled. See
@@ -671,6 +683,16 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 					"refusing to signal a pid that cannot be tied to the client tmux reported"))
 			continue
 		}
+		candidates = append(candidates, staleControlClient{pid: pid, identity: identity})
+	}
+
+	// Pass 2: judge and kill. A verdict here can rest on /proc reads taken after
+	// an earlier victim's grace, so it can in principle describe a different
+	// process than the one listed — but nothing is signalled on the strength of
+	// it: softKillProcessChecked re-checks the identity captured in pass 1
+	// immediately before each signal, and a pid that changed hands is refused.
+	for _, c := range candidates {
+		pid, identity := c.pid, c.identity
 		if !isControlClientOrphan(pid) {
 			// Live sibling TUI — leave its pipe alone. Without this guard
 			// two concurrent agent-deck TUIs (allow_multiple=true) would
@@ -756,7 +778,9 @@ func startOrphanReapOnce() {
 // The per-probe caps (processProbeTimeout, tmuxLiveQueryTimeout) are nested
 // inside it rather than being separate budgets of their own: each probe expires
 // at whichever comes first, so one wedged probe cannot eat the whole budget and
-// starve every later candidate, and the sum still cannot exceed this.
+// starve every later candidate. The ceiling is this budget plus one candidate:
+// the loop checks the budget between candidates, so a candidate already in
+// flight when it expires runs to its own caps before the sweep stops.
 //
 // 20s buys roughly five fully-wedged candidates at the per-probe caps, or many
 // hundreds of healthy ones — a live server answers `#{pid}` in milliseconds.
@@ -970,6 +994,27 @@ func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 // MUST treat ok=false as unclassifiable and refuse to kill — the same
 // fail-closed rule isTruncatedTmuxComm already established for an unreadable
 // comm value.
+//
+// ⚠️ Accepted gap, measured on tmux 3.0a (the version the CPU-spin incident
+// happened on): a server that is RUNNING but holds ZERO sessions answers both
+// queries with "no current target", because each needs a target session to
+// resolve against. That is ok=false, so orphans left behind on a server whose
+// sessions have all closed are never reaped — precisely the incident-shaped
+// host. Refusing is still the right verdict, because from here "cannot reach a
+// server" is indistinguishable from "reached the wrong server": this package
+// resolves -L names through its own TMUX_TMPDIR, which need not be the
+// candidate's. Widening it means finding a query that identifies a server
+// without a session, and that is a change to make deliberately, not by relaxing
+// a kill guard.
+//
+// A second, narrower window is inherent to asking the server at all: a user's
+// own interactive client that has started but not yet registered reads as
+// not-live for the width of one query. Parentage does not protect it (its
+// parent is the user's shell, so isControlClientOrphan says orphan), so such a
+// client can be SIGTERMed if the sweep lands in that gap. It is one query wide,
+// happens at most once per agent-deck run, and costs an aborted attach rather
+// than a session — the alternative, caching or trusting argv text, is what this
+// function exists to replace.
 func isLiveTmuxClientOrServer(budget context.Context, pid int, cmdlineFields []string) (live bool, ok bool) {
 	socketName, resolvable := candidateSocketName(cmdlineFields)
 	if !resolvable {
@@ -1061,11 +1106,16 @@ func reapOrphanedPollClients() {
 	budget, cancel := context.WithTimeout(context.Background(), orphanSweepBudget)
 	defer cancel()
 	candidates, unidentifiable := collectOrphanCandidates(budget)
-	killed, skipped, unexamined := sweepOrphanCandidates(budget, candidates)
-	if killed > 0 || skipped > 0 || unidentifiable > 0 || unexamined > 0 {
-		pipeLog.Info("orphaned_poll_clients_reaped",
+	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(budget, candidates)
+	if killed > 0 || unclassifiable > 0 || notSignalled > 0 || unidentifiable > 0 || unexamined > 0 {
+		// One line per sweep that did anything at all, kills included or not:
+		// the counters are the only place a run that refused everything is
+		// visible at Info level, and "the sweep went inert and nobody noticed"
+		// is the failure this whole area exists to prevent.
+		pipeLog.Info("orphan_sweep_finished",
 			slog.Int("kill_count", killed),
-			slog.Int("skipped_unclassifiable", skipped),
+			slog.Int("skipped_unclassifiable", unclassifiable),
+			slog.Int("skipped_not_signalled", notSignalled),
 			slog.Int("skipped_unidentifiable", unidentifiable),
 			slog.Int("unexamined_out_of_budget", unexamined),
 			slog.Duration("duration", time.Since(start)))
@@ -1181,10 +1231,17 @@ func collectOrphanCandidates(budget context.Context) (candidates []orphanCandida
 // pid changing hands while that answer is being fetched.
 var liveTmuxIdentityOf = isLiveTmuxClientOrServer
 
-// sweepOrphanCandidates runs the kill gauntlet over already-read candidates and
-// returns how many were killed and how many were refused for want of a definite
-// classification. Every refusal is logged; none is silent.
-func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate) (killed, skipped, unexamined int) {
+// sweepOrphanCandidates runs the kill gauntlet over already-read candidates.
+//
+// The three refusal counts are kept apart because they mean different things to
+// whoever is reading the log: unclassifiable is "the tmux server or the comm
+// could not tell us what this is", notSignalled is "we decided to kill it and
+// then it stopped being the process we decided about", and unexamined is "we
+// ran out of budget". Each refusal also logs a line of its own — Debug for the
+// routine ones, Warn for the ones that mean the sweep is losing ground — and
+// every one of them reaches Info level through the caller's summary, so a run
+// that refused everything can never look like a run that found nothing.
+func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate) (killed, unclassifiable, notSignalled, unexamined int) {
 	for i, c := range candidates {
 		if err := budget.Err(); err != nil {
 			// Out of budget. Report what was left unexamined rather than
@@ -1204,8 +1261,8 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 		// client or server. It is not killed; it is carried to the end of the
 		// gauntlet so that a process which is otherwise indistinguishable from
 		// a leak gets reported instead of vanishing from the sweep in silence.
-		unclassifiable := !reapable && isTruncatedTmuxComm(c.comm)
-		if !reapable && !unclassifiable {
+		commUnclassifiable := !reapable && isTruncatedTmuxComm(c.comm)
+		if !reapable && !commUnclassifiable {
 			// Neither, despite passing the collector's pre-filter: tmux renames
 			// itself from the bare "tmux" it was exec'd as to "tmux: server"
 			// shortly after startup, so a candidate admitted on the bare name
@@ -1228,29 +1285,30 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 		cmdlineFields := strings.Split(strings.TrimRight(c.cmdline, "\x00"), "\x00")
 		live, ok := liveTmuxIdentityOf(budget, c.pid, cmdlineFields)
 		if !ok {
-			skipped++
+			unclassifiable++
 			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
 				slog.Int("pid", c.pid),
-				slog.String("comm", strings.TrimSpace(c.comm)),
+				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))),
 				slog.String("reason", "could not confirm via the tmux server itself whether this "+
-					"pid is live (no server at the resolved socket, an unresolvable -S candidate, "+
-					"or the query timed out); refusing to kill rather than guess"))
+					"pid is live (no server at the resolved socket, a running server holding no "+
+					"sessions — which cannot answer either query on tmux 3.0a — an unresolvable -S "+
+					"candidate, or the query timed out); refusing to kill rather than guess"))
 			continue
 		}
 		if live {
 			pipeLog.Debug("preserved_live_tmux_client_or_server",
 				slog.Int("pid", c.pid),
-				slog.String("comm", strings.TrimSpace(c.comm)))
+				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))))
 			continue
 		}
 		if !isControlClientOrphan(c.pid) {
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
 		}
-		if unclassifiable {
-			skipped++
+		if commUnclassifiable {
+			unclassifiable++
 			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
 				slog.Int("pid", c.pid),
-				slog.String("comm", strings.TrimSpace(c.comm)),
+				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))),
 				slog.String("reason", "comm lost its role token to truncation; "+
 					"cannot prove this is a client rather than a server, so it is left alone"))
 			continue
@@ -1262,7 +1320,7 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 		// strength of facts that belong to a process which no longer exists.
 		usedSIGKILL, signalled := softKillProcessChecked(budget, c.pid, c.identity, controlClientKillGrace)
 		if !signalled {
-			skipped++
+			notSignalled++
 			pipeLog.Debug("orphan_sweep_candidate_not_signalled",
 				slog.Int("pid", c.pid),
 				slog.String("reason", "the pid no longer holds the identity it was judged under, "+
@@ -1274,7 +1332,7 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 			slog.Int("pid", c.pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	return killed, skipped, unexamined
+	return killed, unclassifiable, notSignalled, unexamined
 }
 
 // isControlClientOrphan reports whether the control-mode client pid is a
@@ -1463,32 +1521,47 @@ var processProbeTimeout = 2 * time.Second
 // times for `tmux -C attach-session` on macOS + Linux.
 const controlClientKillGrace = 500 * time.Millisecond
 
-// softKillProcess sends SIGTERM to pid, polls every 25ms up to grace for the
-// process to exit, and escalates to SIGKILL if it doesn't. Returns true iff
-// SIGKILL was ultimately used. A non-existent pid (ESRCH) is treated as
-// already-dead and returns false without escalation.
+// softKillProcessHandle sends SIGTERM to proc, polls up to grace for it to
+// exit, and escalates to SIGKILL if it doesn't. Returns true iff SIGKILL was
+// ultimately used; an already-exited child is treated as done and returns false
+// without escalation.
 //
-// A pid whose identity cannot be established is not signalled at all: see
-// stillSameIncarnation for why this fails closed rather than proceeding with an
-// unarmed guard. In practice an unreadable identity for a live process means
-// neither /proc nor `ps` works on the host; a process that is simply gone reads
-// the same way, and refusing to signal it costs nothing.
+// It is for a process THIS program spawned and still holds an
+// *os.Process for, which is a stable OS-level name for that one child: the
+// handle carries the kernel's own reference (a pidfd where the runtime has one),
+// and once Wait has reaped the child every further signal through it fails with
+// ErrProcessDone instead of reaching whoever inherited the number. So it needs
+// no start-time identity guard — it cannot signal a recycled pid by
+// construction, which is strictly better than re-checking one.
 //
-// This is the entry point for callers with no budget of their own: its identity
-// probes get the plain per-probe cap (processProbeTimeout). The sweep does not
-// come through here — it captures the identity itself, long before the kill, and
-// calls softKillProcessChecked under its own budget.
-func softKillProcess(pid int, grace time.Duration) bool {
-	identity, err := processIdentityOf(context.Background(), pid)
-	if err != nil {
-		pipeLog.Warn("skipped_kill_unidentifiable_pid",
-			slog.Int("pid", pid),
-			slog.String("reason", "could not read a start-time identity for this pid, so it "+
-				"cannot be shown to still be the process the caller judged; refusing to signal it"))
+// The pid-based sweeps have no handle, having found their victims in /proc or in
+// tmux output; they capture an identity at decision time and go through
+// softKillProcessChecked instead.
+func softKillProcessHandle(proc *os.Process, grace time.Duration) bool {
+	if proc == nil {
 		return false
 	}
-	usedSIGKILL, _ := softKillProcessChecked(context.Background(), pid, identity, grace)
-	return usedSIGKILL
+	// Already reaped, or not ours to signal. Nothing was sent either way.
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return false
+	}
+
+	// Poll for exit. Signal(0) through the handle starts failing once the
+	// child has been waited on, which is the same edge kill(pid, 0)'s ESRCH
+	// marks for a pid — except it cannot be satisfied by a stranger holding
+	// the number. The concurrent reaper is what turns the exit into that edge;
+	// see reapWithEOFGrace.
+	const pollInterval = 5 * time.Millisecond
+	deadline := time.Now().Add(grace)
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			return false
+		}
+	}
+
+	// Still there after grace — escalate through the same handle.
+	return proc.Kill() == nil
 }
 
 // stillSameIncarnation reports whether pid still refers to the process that
@@ -1554,14 +1627,23 @@ func softKillProcessChecked(budget context.Context, pid int, identity string, gr
 		return false, false
 	}
 
-	// Initial SIGTERM. If the process is already gone, we're done.
+	// Initial SIGTERM. If the process is already gone, or is not ours to
+	// signal, we're done — and in neither case may this report a kill.
+	//
+	// EPERM is reachable: the orphan sweep walks all of /proc, so it can select
+	// another user's tmux client. Retrying with SIGKILL cannot succeed where
+	// SIGTERM was refused (the permission check is per-signal-send, not
+	// per-signal), and reporting the attempt as a kill would put a process that
+	// is still running into kill_count and log reaped_orphaned_poll_client for
+	// it — the burst metric exists to observe real cascades, so it must not
+	// count kills that never happened.
 	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return false, false
+		if !errors.Is(err, syscall.ESRCH) {
+			pipeLog.Warn("skipped_kill_signal_refused",
+				slog.Int("pid", pid),
+				slog.String("error", err.Error()))
 		}
-		// Permission or other error — try SIGKILL as last resort.
-		_ = syscall.Kill(pid, syscall.SIGKILL)
-		return true, true
+		return false, false
 	}
 
 	// Poll for exit. syscall.Kill(pid, 0) returns ESRCH once the process

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -653,6 +653,23 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		if pid == myPID {
 			continue // don't kill our own process
 		}
+		// Capture the identity now, BEFORE the checks that justify the kill.
+		// Every one of them reads /proc for this pid, and the kill can land up
+		// to grace-per-earlier-victim later; the identity is what ties the two
+		// ends together. Capturing it afterwards would defeat the guard in the
+		// exact case it exists for — the reads would describe the old process
+		// and the identity the new one, and they would agree at signal time.
+		identity, err := processIdentityOf(pid)
+		if err != nil {
+			// Fail closed: a pid we cannot identify is not signalled. See
+			// stillSameIncarnation.
+			pipeLog.Warn("skipped_unidentifiable_control_client_pid",
+				slog.String("session", sessionLabel),
+				slog.Int("pid", pid),
+				slog.String("reason", "could not read a start-time identity for this pid; "+
+					"refusing to signal a pid that cannot be tied to the client tmux reported"))
+			continue
+		}
 		if !isControlClientOrphan(pid) {
 			// Live sibling TUI — leave its pipe alone. Without this guard
 			// two concurrent agent-deck TUIs (allow_multiple=true) would
@@ -669,7 +686,20 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		// the entire tmux server, wiping every agent-deck session. A SIGTERM
 		// lets the client drain and exit cleanly; SIGKILL is retained as a
 		// 500ms fallback for clients that ignore TERM.
-		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
+		usedSIGKILL, signalled := softKillProcessChecked(pid, identity, controlClientKillGrace)
+		if !signalled {
+			// Nothing was sent, so nothing is counted — the burst metric below
+			// exists to observe real kill cascades. Two causes share this
+			// branch and the event name stays neutral between them: the pid's
+			// identity no longer matches (it changed hands since the snapshot),
+			// or it was already gone by the time we signalled (ESRCH). Only
+			// the first is a recycled pid, and from here they are not
+			// distinguishable.
+			pipeLog.Debug("skipped_control_client_not_signalled",
+				slog.String("session", sessionLabel),
+				slog.Int("pid", pid))
+			continue
+		}
 		killCount++
 		pipeLog.Debug("killed_stale_control_client",
 			slog.String("session", sessionLabel),
@@ -960,7 +990,14 @@ func isLiveTmuxClientOrServer(pid int, cmdlineFields []string) (live bool, ok bo
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
 //     (isControlClientOrphan — its parentage check is client-type-agnostic
 //     despite the name). A live TUI's own in-flight poll has PPID == our PID,
-//     so isControlClientOrphan returns false and it is preserved.
+//     so isControlClientOrphan returns false and it is preserved, and
+//   - it is still the same process all of the above was decided about. Every
+//     check reads /proc or a tmux server for a PID, and a PID is not a stable
+//     name for a process; the identity captured before the first of those reads
+//     is re-checked immediately before each signal (readOrphanCandidate,
+//     softKillProcessChecked). A PID that changes hands anywhere in the
+//     gauntlet is refused, not killed on the strength of a dead process's
+//     facts.
 //
 // Any of the two checks that query external state (comm-role classification,
 // tmux-server identity) failing to produce a definite answer is treated as
@@ -975,52 +1012,165 @@ func reapOrphanedPollClients() {
 	if runtime.GOOS != "linux" {
 		return
 	}
+	start := time.Now()
+	candidates, unidentifiable := collectOrphanCandidates()
+	killed, skipped := sweepOrphanCandidates(candidates)
+	if killed > 0 || skipped > 0 || unidentifiable > 0 {
+		pipeLog.Info("orphaned_poll_clients_reaped",
+			slog.Int("kill_count", killed),
+			slog.Int("skipped_unclassifiable", skipped),
+			slog.Int("skipped_unidentifiable", unidentifiable),
+			slog.Duration("duration", time.Since(start)))
+	}
+}
+
+// orphanCandidate is one process the sweep has read out of /proc and not yet
+// judged: the facts its verdict rests on, plus the identity that ties those
+// facts to a single incarnation of the pid.
+type orphanCandidate struct {
+	pid      int
+	comm     string
+	cmdline  string
+	identity string
+}
+
+// readOrphanCandidate reads the facts for one /proc entry, and returns them only
+// if they all describe the same incarnation of pid.
+//
+// The identity is captured BEFORE the reads that classify the process and read
+// again after them. That bracketing is the point. Capturing it later — at kill
+// time, as an earlier revision did — defeats the guard in exactly the case it
+// exists for: if the pid changes hands while the sweep is working, the classify
+// reads describe the process that died and the identity describes the one that
+// took its number, so the check at signal time compares the new process against
+// itself and agrees. Bracketing means either every fact belongs to one process
+// or the candidate is dropped.
+//
+// ok=false means "not a candidate, or not readable as one consistent process".
+// identifiable=false narrows that to the cases the caller must report rather
+// than pass over: no identity could be read, or the two reads disagreed. Both
+// mean a process that might be a leak was left alone, and a sweep quietly
+// narrowing itself back toward inert is the original failure of this code.
+func readOrphanCandidate(pid int) (c orphanCandidate, identifiable, ok bool) {
+	// Cheap pre-filter first. /proc holds every process on the host and only a
+	// handful can ever be tmux clients, so the two identity reads below are
+	// paid for only the few entries that get past this. This read carries no
+	// safety weight — the comm the verdict rests on is the bracketed one.
+	preComm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return c, true, false
+	}
+	if !isReapableTmuxClientComm(string(preComm)) && !isTruncatedTmuxComm(string(preComm)) {
+		return c, true, false
+	}
+
+	before, err := processIdentityOf(pid)
+	if err != nil {
+		return c, false, false
+	}
+	comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return c, true, false // exited mid-read; nothing to judge and nothing to kill
+	}
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return c, true, false
+	}
+	after, err := processIdentityOf(pid)
+	if err != nil || after != before {
+		return c, false, false
+	}
+
+	return orphanCandidate{
+		pid:      pid,
+		comm:     string(comm),
+		cmdline:  string(cmdline),
+		identity: before,
+	}, true, true
+}
+
+// collectOrphanCandidates walks /proc and returns every entry that could be a
+// leaked one-shot client, together with a count of the entries that looked like
+// one but could not be pinned to a single incarnation (see readOrphanCandidate).
+//
+// Enumerating first, judging second, keeps the /proc walk short: the judging
+// half queries a tmux server per candidate and can block for as long as the
+// sweep's budget allows, and holding a directory listing of every process on
+// the host open across that is pointless.
+func collectOrphanCandidates() (candidates []orphanCandidate, unidentifiable int) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
-		return
+		return nil, 0
 	}
 	myPID := os.Getpid()
-	killed := 0
-	skipped := 0
-	start := time.Now()
 	for _, e := range entries {
 		pid, err := strconv.Atoi(e.Name())
 		if err != nil || pid == myPID {
 			continue
 		}
-		comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil {
+		c, identifiable, ok := readOrphanCandidate(pid)
+		if !identifiable {
+			unidentifiable++
+			pipeLog.Warn("orphan_sweep_skipped_unidentifiable_pid",
+				slog.Int("pid", pid),
+				slog.String("reason", "a tmux-shaped process whose start-time identity could not be "+
+					"read, or changed between reads; its facts cannot be tied to one process, so it "+
+					"is left alone rather than judged as a chimera"))
 			continue
 		}
-		reapable := isReapableTmuxClientComm(string(comm))
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, c)
+	}
+	return candidates, unidentifiable
+}
+
+// liveTmuxIdentityOf is the seam the sweep tests swap for
+// isLiveTmuxClientOrServer. The real one needs a live tmux server to answer
+// (see orphan_reap_live_identity_test.go, which exercises it against one); the
+// sweep tests are about what the gauntlet does with the answer, and about the
+// pid changing hands while that answer is being fetched.
+var liveTmuxIdentityOf = isLiveTmuxClientOrServer
+
+// sweepOrphanCandidates runs the kill gauntlet over already-read candidates and
+// returns how many were killed and how many were refused for want of a definite
+// classification. Every refusal is logged; none is silent.
+func sweepOrphanCandidates(candidates []orphanCandidate) (killed, skipped int) {
+	for _, c := range candidates {
+		reapable := isReapableTmuxClientComm(c.comm)
 		// A comm whose role token was truncated away cannot be classified as
 		// client or server. It is not killed; it is carried to the end of the
 		// gauntlet so that a process which is otherwise indistinguishable from
 		// a leak gets reported instead of vanishing from the sweep in silence.
-		unclassifiable := !reapable && isTruncatedTmuxComm(string(comm))
+		unclassifiable := !reapable && isTruncatedTmuxComm(c.comm)
 		if !reapable && !unclassifiable {
+			// Neither, despite passing the collector's pre-filter: tmux renames
+			// itself from the bare "tmux" it was exec'd as to "tmux: server"
+			// shortly after startup, so a candidate admitted on the bare name
+			// can read as a server by the time its facts are taken. Same
+			// process, later name — and a server is never a kill candidate.
 			continue
 		}
 		// cmdline fields are NUL-separated; substring search still matches the
 		// "agentdeck_" target token regardless of separators.
-		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-		if err != nil || !strings.Contains(string(raw), SessionPrefix) {
+		if !strings.Contains(c.cmdline, SessionPrefix) {
 			continue
 		}
 		// Scope narrowing only — see isKnownCadenceArgv's doc comment for why
 		// this must never be read as the safety check.
-		if !isKnownCadenceArgv(string(raw)) {
+		if !isKnownCadenceArgv(c.cmdline) {
 			continue
 		}
 		// THE safety check: ask the tmux server itself, not argv text, whether
 		// this pid is live. live==true or ok==false both mean "do not kill".
-		cmdlineFields := strings.Split(strings.TrimRight(string(raw), "\x00"), "\x00")
-		live, ok := isLiveTmuxClientOrServer(pid, cmdlineFields)
+		cmdlineFields := strings.Split(strings.TrimRight(c.cmdline, "\x00"), "\x00")
+		live, ok := liveTmuxIdentityOf(c.pid, cmdlineFields)
 		if !ok {
 			skipped++
 			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
-				slog.Int("pid", pid),
-				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.Int("pid", c.pid),
+				slog.String("comm", strings.TrimSpace(c.comm)),
 				slog.String("reason", "could not confirm via the tmux server itself whether this "+
 					"pid is live (no server at the resolved socket, an unresolvable -S candidate, "+
 					"or the query timed out); refusing to kill rather than guess"))
@@ -1028,34 +1178,42 @@ func reapOrphanedPollClients() {
 		}
 		if live {
 			pipeLog.Debug("preserved_live_tmux_client_or_server",
-				slog.Int("pid", pid),
-				slog.String("comm", strings.TrimSpace(string(comm))))
+				slog.Int("pid", c.pid),
+				slog.String("comm", strings.TrimSpace(c.comm)))
 			continue
 		}
-		if !isControlClientOrphan(pid) {
+		if !isControlClientOrphan(c.pid) {
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
 		}
 		if unclassifiable {
 			skipped++
 			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
-				slog.Int("pid", pid),
-				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.Int("pid", c.pid),
+				slog.String("comm", strings.TrimSpace(c.comm)),
 				slog.String("reason", "comm lost its role token to truncation; "+
 					"cannot prove this is a client rather than a server, so it is left alone"))
 			continue
 		}
-		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
+		// The identity was captured before any of the above ran, and the tmux
+		// query in particular can take seconds. softKillProcessChecked re-checks
+		// it immediately before each signal, so a pid that changed hands while
+		// the gauntlet was running is refused here rather than killed on the
+		// strength of facts that belong to a process which no longer exists.
+		usedSIGKILL, signalled := softKillProcessChecked(c.pid, c.identity, controlClientKillGrace)
+		if !signalled {
+			skipped++
+			pipeLog.Debug("orphan_sweep_candidate_not_signalled",
+				slog.Int("pid", c.pid),
+				slog.String("reason", "the pid no longer holds the identity it was judged under, "+
+					"or was already gone"))
+			continue
+		}
 		killed++
 		pipeLog.Debug("reaped_orphaned_poll_client",
-			slog.Int("pid", pid),
+			slog.Int("pid", c.pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	if killed > 0 || skipped > 0 {
-		pipeLog.Info("orphaned_poll_clients_reaped",
-			slog.Int("kill_count", killed),
-			slog.Int("skipped_unclassifiable", skipped),
-			slog.Duration("duration", time.Since(start)))
-	}
+	return killed, skipped
 }
 
 // isControlClientOrphan reports whether the control-mode client pid is a
@@ -1173,6 +1331,72 @@ func readProcessExe(pid int) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// readProcessIdentity returns a token that distinguishes one incarnation of a
+// PID from the next. A PID alone does not identify a process: the kernel
+// reissues it once the number wraps, so a PID read out of a `list-clients`
+// snapshot can belong to something else by the time it is signalled.
+//
+// Linux uses starttime (field 22 of /proc/<pid>/stat) — the boot-relative tick
+// the process started on, which the kernel never rewrites. Two incarnations of
+// the same PID cannot share it in practice: reuse requires wrapping the whole
+// pid_max range, which takes far longer than the field's 10ms resolution.
+// macOS (or a Linux host without /proc) falls back to `ps -o lstart=`, the same
+// fact at second resolution — which is the fallback's one real weakness: a pid
+// reused inside the same second reads as the same incarnation there, and the
+// guard passes it through. That is still strictly better than the bare pid it
+// replaces, and Linux, where this sweep's worst incident happened, gets the
+// 10ms field.
+//
+// Read errors are returned rather than swallowed: an unreadable identity is
+// the caller's signal that the guard cannot be armed, which is a different
+// state from "the identity changed" and is handled differently — see
+// softKillProcessChecked.
+func readProcessIdentity(pid int) (string, error) {
+	if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+		// Same parse as readParentPID: the comm field can contain ')', so
+		// split after the LAST one. Fields then start at state (field 3), so
+		// starttime (field 22) sits at index 19.
+		idx := strings.LastIndex(string(data), ")")
+		if idx < 0 {
+			return "", fmt.Errorf("malformed /proc/%d/stat", pid)
+		}
+		fields := strings.Fields(string(data[idx+1:]))
+		const startTimeIndex = 19
+		if len(fields) <= startTimeIndex {
+			return "", fmt.Errorf("/proc/%d/stat: too few fields", pid)
+		}
+		return fields[startTimeIndex], nil
+	}
+	// Bounded, unlike the sibling ps probes: this one runs once per candidate
+	// pid on the boot path, where SweepStaleControlClients already refuses to
+	// let a hung query stall startup (staleControlSweepTimeout). A deadline
+	// miss surfaces as an error, which leaves the guard unarmed — the sweep
+	// keeps working, it just stops being able to detect reuse.
+	ctx, cancel := context.WithTimeout(context.Background(), processProbeTimeout)
+	defer cancel()
+	// #nosec G204 -- "ps" is a fixed binary; only arg is strconv.Itoa(int).
+	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	if err != nil {
+		return "", err
+	}
+	identity := strings.TrimSpace(string(out))
+	if identity == "" {
+		return "", fmt.Errorf("no start time for pid %d", pid)
+	}
+	return identity, nil
+}
+
+// processIdentityOf is the seam the PID-reuse tests swap to make a pid appear
+// to change hands mid-grace. Forcing a real reuse would take a full pid_max
+// wrap inside a 100ms window.
+var processIdentityOf = readProcessIdentity
+
+// processProbeTimeout bounds the `ps` fallback in readProcessIdentity so a
+// wedged probe cannot stall the boot-path sweep that calls it. Matches
+// staleControlSweepTimeout, which bounds the list-clients query feeding the
+// same sweep.
+var processProbeTimeout = 2 * time.Second
+
 // controlClientKillGrace is how long softKillProcess waits after SIGTERM
 // before escalating to SIGKILL. 500ms matches empirical clean-shutdown
 // times for `tmux -C attach-session` on macOS + Linux.
@@ -1182,15 +1406,95 @@ const controlClientKillGrace = 500 * time.Millisecond
 // process to exit, and escalates to SIGKILL if it doesn't. Returns true iff
 // SIGKILL was ultimately used. A non-existent pid (ESRCH) is treated as
 // already-dead and returns false without escalation.
+// A pid whose identity cannot be established is not signalled at all: see
+// stillSameIncarnation for why this fails closed rather than proceeding with an
+// unarmed guard. In practice an unreadable identity for a live process means
+// neither /proc nor `ps` works on the host; a process that is simply gone reads
+// the same way, and refusing to signal it costs nothing.
 func softKillProcess(pid int, grace time.Duration) bool {
+	identity, err := processIdentityOf(pid)
+	if err != nil {
+		pipeLog.Warn("skipped_kill_unidentifiable_pid",
+			slog.Int("pid", pid),
+			slog.String("reason", "could not read a start-time identity for this pid, so it "+
+				"cannot be shown to still be the process the caller judged; refusing to signal it"))
+		return false
+	}
+	usedSIGKILL, _ := softKillProcessChecked(pid, identity, grace)
+	return usedSIGKILL
+}
+
+// stillSameIncarnation reports whether pid still refers to the process that
+// identity was taken from, i.e. whether it is still the process the caller
+// decided to kill.
+//
+// Fail-closed in both directions:
+//
+//   - An empty identity means the caller never established one. There is then
+//     nothing tying this pid to the process the caller judged, so the signal is
+//     refused rather than sent to an unidentified pid. An earlier revision of
+//     this guard treated "" as "guard unarmed, proceed", on the argument that a
+//     host unable to report start times should keep the #595 cleanup it had
+//     before. That trade is the wrong way round for code whose failure mode is
+//     SIGKILLing a live process: the sweep going inert is recoverable and
+//     logged, a wrong kill is neither. Callers report the refusal (see
+//     orphan_sweep_skipped_unidentifiable_pid) so an inert sweep is visible
+//     rather than silent.
+//   - A read that fails now means the process is gone or has become
+//     unreadable, and there is nothing worth signalling either way.
+func stillSameIncarnation(pid int, identity string) bool {
+	if identity == "" {
+		return false
+	}
+	current, err := processIdentityOf(pid)
+	if err != nil {
+		return false
+	}
+	return current == identity
+}
+
+// softKillProcessChecked is softKillProcess for a caller that decided to kill
+// pid at some earlier point and captured its identity then. It re-checks that
+// identity immediately before each signal, so a PID that changed hands between
+// the decision and the signal is left alone.
+//
+// Both checks are load-bearing, and they close different windows:
+//
+//   - Before the SIGTERM, because the caller's decision can be arbitrarily
+//     old. reapStaleControlClients works through a `list-clients` snapshot
+//     sequentially and blocks up to grace per victim, so the last PID in a
+//     burst is acted on N × grace after it was observed.
+//   - Before the SIGKILL, because the victim may have exited cleanly inside
+//     the grace period and had its number reissued. The poll below uses
+//     kill(pid, 0), which answers "some process holds this number", not "the
+//     one you signalled" — so without this check a well-behaved client that
+//     obeyed SIGTERM promptly is indistinguishable from one that ignored it,
+//     and the escalation lands on the new occupant.
+//
+// What this does NOT do is close the window — it narrows it. A pid can still
+// change hands between the check returning and the kill(2) landing; the race is
+// simply one syscall wide now instead of the ~500ms the escalation used to hold
+// it open. Closing it outright needs a handle the kernel resolves atomically —
+// pidfd_send_signal(2) on Linux 5.1+, which the host this surfaced on has —
+// and that is a bigger change than the sweep is worth today.
+//
+// signalled reports whether anything was sent at all. Callers count kills and
+// log one line per victim, and a pid the guard refused to touch is not a
+// victim — reporting it as one would make the sweep's burst metric, which
+// exists to observe the kill cascade, count kills that never happened.
+func softKillProcessChecked(pid int, identity string, grace time.Duration) (usedSIGKILL, signalled bool) {
+	if !stillSameIncarnation(pid, identity) {
+		return false, false
+	}
+
 	// Initial SIGTERM. If the process is already gone, we're done.
 	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return false
+			return false, false
 		}
 		// Permission or other error — try SIGKILL as last resort.
 		_ = syscall.Kill(pid, syscall.SIGKILL)
-		return true
+		return true, true
 	}
 
 	// Poll for exit. syscall.Kill(pid, 0) returns ESRCH once the process
@@ -1204,13 +1508,17 @@ func softKillProcess(pid int, grace time.Duration) bool {
 	for time.Now().Before(deadline) {
 		time.Sleep(pollInterval)
 		if err := syscall.Kill(pid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
-			return false
+			return false, true
 		}
 	}
 
-	// Still alive after grace — escalate.
+	// Something still holds the number after grace. Escalate only if it is
+	// still the process we signalled.
+	if !stillSameIncarnation(pid, identity) {
+		return false, true
+	}
 	_ = syscall.Kill(pid, syscall.SIGKILL)
-	return true
+	return true, true
 }
 
 // softKillProcessGroup is the process-group analogue of softKillProcess.

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -965,6 +965,60 @@ var tmuxLiveQueryTimeout = 2 * time.Second
 // package's -L-only tmuxExecContext funnel, and per the "refuse anything
 // ambiguous" rule, unresolvable is not reapable rather than a case worth
 // widening the tmux-exec factory for.
+// candidateSocketPath resolves the socket the CANDIDATE is talking to, out of
+// the candidate's own environment and its own argv — the two inputs tmux itself
+// used when it picked a socket.
+//
+// This exists because a socket NAME is not a socket. `-L work` resolves to
+// $TMUX_TMPDIR/tmux-<uid>/work, so the same name under two bases is two
+// different servers, and the name alone cannot tell them apart. Reading the
+// candidate's TMUX/TMUX_TMPDIR is the only way to say which one it meant.
+//
+// ok=false means the environment could not be read, which includes a pid that
+// has exited, a zombie (whose environ reads back empty rather than failing), and
+// another user's process. All of them are refusals: a socket that cannot be
+// established is not a socket that can be compared.
+//
+// The uid is this process's, deliberately. A candidate belonging to another uid
+// resolves its own -L name under tmux-<theirs>, so the comparison this feeds
+// cannot match and the candidate is refused — which is the right answer for a
+// process this sweep has no business killing anyway.
+func candidateSocketPath(pid int, cmdlineFields []string) (path string, ok bool) {
+	lookupEnv, err := readProcessEnviron(pid)
+	if err != nil {
+		return "", false
+	}
+	var args []string
+	if len(cmdlineFields) > 1 {
+		args = cmdlineFields[1:]
+	}
+	return normalizeTmpPath(resolveTmuxSocketPath(lookupEnv, os.Getuid(), "", args)), true
+}
+
+// readProcessEnviron reads pid's environment out of procfs as a lookup function
+// shaped for resolveTmuxSocketPath.
+//
+// An empty read is an error, not an empty environment: /proc/<pid>/environ comes
+// back empty with no error for a zombie, and treating that as "this process has
+// no TMUX_TMPDIR" would resolve it to the default socket — a confident answer
+// about a process that no longer has an environment to have.
+func readProcessEnviron(pid int) (func(string) string, error) {
+	raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty environment for pid %d", pid)
+	}
+	env := make(map[string]string, 32)
+	for _, entry := range strings.Split(string(raw), "\x00") {
+		if key, value, found := strings.Cut(entry, "="); found {
+			env[key] = value
+		}
+	}
+	return func(key string) string { return env[key] }, nil
+}
+
 func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 	if len(cmdlineFields) == 0 {
 		return "", true
@@ -1002,7 +1056,19 @@ func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 //     on the same server come back empty — so absence here rules out an
 //     attach specifically, not just "any client-shaped process".
 //
-// ok=false means neither fact could be established (no server at the resolved
+// Before either query is issued, the candidate's OWN socket is resolved from
+// its own environment and argv (candidateSocketPath) and compared against the
+// socket the query will reach. A tmux socket NAME is not a server: `-L work`
+// means $TMUX_TMPDIR/tmux-<uid>/work, and this package resolves that name
+// through ITS environment, not the candidate's. Same name, different base,
+// different server — and asking the wrong server is not a failure that
+// announces itself. Both queries succeed, neither the server pid nor any client
+// pid matches, and the answer comes back "not live" with full confidence about
+// a client that is attached and alive on its own server. A socket that differs,
+// or that cannot be established at all, is ok=false.
+//
+// ok=false means the candidate's server could not be identified as ours, or
+// neither fact could be established against it (no server at the resolved
 // socket, a -S-path candidate the package's -L-only exec funnel cannot resolve,
 // connection refused, or the query ran past tmuxLiveQueryTimeout). The caller
 // MUST treat ok=false as unclassifiable and refuse to kill — the same
@@ -1014,12 +1080,9 @@ func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 // queries with "no current target", because each needs a target session to
 // resolve against. That is ok=false, so orphans left behind on a server whose
 // sessions have all closed are never reaped — precisely the incident-shaped
-// host. Refusing is still the right verdict, because from here "cannot reach a
-// server" is indistinguishable from "reached the wrong server": this package
-// resolves -L names through its own TMUX_TMPDIR, which need not be the
-// candidate's. Widening it means finding a query that identifies a server
-// without a session, and that is a change to make deliberately, not by relaxing
-// a kill guard.
+// host. Widening it means finding a query that identifies a server without a
+// session, and that is a change to make deliberately, not by relaxing a kill
+// guard.
 //
 // A second, narrower window is inherent to asking the server at all: a user's
 // own interactive client that has started but not yet registered reads as
@@ -1032,6 +1095,22 @@ func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 func isLiveTmuxClientOrServer(budget context.Context, pid int, cmdlineFields []string) (live bool, ok bool) {
 	socketName, resolvable := candidateSocketName(cmdlineFields)
 	if !resolvable {
+		return false, false
+	}
+
+	// Establish that the server about to be asked is the candidate's server.
+	// Without this the two are only assumed to be the same, and when they are
+	// not, both queries succeed against a stranger's server, neither pid
+	// matches, and the confident answer is "not live" — the kill verdict —
+	// about a client that is attached and alive on its own.
+	candidateSocket, resolved := candidateSocketPath(pid, cmdlineFields)
+	if !resolved {
+		return false, false
+	}
+	// What tmuxExecContext will actually reach: the same -L name, resolved
+	// through THIS process's environment, which is the whole asymmetry.
+	querySocket := normalizeTmpPath(resolveTmuxSocketPath(os.Getenv, os.Getuid(), socketName, nil))
+	if candidateSocket != querySocket {
 		return false, false
 	}
 

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -802,43 +802,132 @@ var reapableOneShotVerbs = map[string]struct{}{
 	"unbind-key":       {},
 }
 
-// neverReapVerbs are the subcommands that disqualify a process outright, even
-// if the same argv also carries a reapable verb (tmux accepts `;`-chained
-// commands, so both can appear). Each names a process whose death costs the
-// user something this sweep has no standing to spend:
+// isKnownCadenceArgv reports whether a /proc/<pid>/cmdline names at least one
+// of the one-shot cadence verbs this sweep exists to reap (reapableOneShotVerbs).
+// cmdline fields are NUL-separated and NUL-terminated, so each argv element is
+// compared whole — a session name or path that merely contains a verb as a
+// substring cannot match.
 //
-//   - attach-session — an interactive client is the user's live view of a
-//     session, and a control-mode one belongs to a TUI. Orphaned control
-//     clients are reapStaleControlClients' job; it filters on
-//     client_control_mode and so cannot mistake a hand-run `tmux attach` for
-//     a leak. This sweep, matching only on comm + argv + parentage, can:
-//     isControlClientOrphan calls ANY non-agent-deck parent an orphan, so a
-//     client attached from the user's own shell qualifies while that shell is
-//     still alive.
-//   - new-session — a server inherits the creating client's comm ("tmux:
-//     client", set by proc_start before the fork) and argv until its own
-//     proc_start("server") runs after daemon(). A server killed in that window
-//     takes the session it was starting with it.
-var neverReapVerbs = map[string]struct{}{
-	"attach-session": {},
-	"new-session":    {},
-}
-
-// isReapableOneShotArgv reports whether a /proc/<pid>/cmdline names a one-shot
-// cadence command and nothing more dangerous. cmdline fields are NUL-separated
-// and NUL-terminated, so each argv element is compared whole — a session name
-// or path that merely contains a verb as a substring cannot match.
-func isReapableOneShotArgv(cmdline string) bool {
-	reapable := false
+// This is a SCOPE ALLOWLIST, not a safety boundary. A miss here only ever
+// narrows the sweep (skip, don't reap) — it must never be read as "argv proves
+// this is safe to kill". See isLiveTmuxClientOrServer for why: this function
+// used to be paired with a denylist (neverReapVerbs, matching only the literal
+// strings "attach-session" / "new-session") that WAS treated as a safety
+// boundary, and it was wrong to. tmux resolves command names by unambiguous
+// prefix — "attach-session" itself is the only tmux command starting with "a",
+// so "attach", "attac", "att", "at", even bare "a" all invoke it unmodified
+// (verified live: `tmux -C a -t sess` attaches on tmux 3.7b/darwin). A denylist
+// of literal verb strings cannot keep up with that; a chained
+// `tmux attach -t agentdeck_x \; set-option status on` cleared the old denylist
+// (wrong spelling) while "set-option" satisfied this allowlist, so the whole
+// line was ruled reapable with a live interactive client sitting behind it.
+// isLiveTmuxClientOrServer is the replacement: it asks the tmux server itself
+// whether the pid is attached, which cannot be abbreviated around.
+func isKnownCadenceArgv(cmdline string) bool {
 	for _, field := range strings.Split(strings.TrimRight(cmdline, "\x00"), "\x00") {
-		if _, denied := neverReapVerbs[field]; denied {
-			return false
-		}
 		if _, ok := reapableOneShotVerbs[field]; ok {
-			reapable = true
+			return true
 		}
 	}
-	return reapable
+	return false
+}
+
+// tmuxLiveQueryTimeout bounds each server-identity query
+// isLiveTmuxClientOrServer issues while classifying an orphan-sweep
+// candidate. Short and per-call, not shared: a wedged server on one socket
+// must not delay the verdict for candidates on any other socket, and the
+// sweep already treats a timeout as "cannot classify, refuse to kill" so
+// there is no correctness reason to wait longer.
+var tmuxLiveQueryTimeout = 2 * time.Second
+
+// candidateSocketName extracts the -L <name> (or default) socket selector
+// from a poll-sweep candidate's OWN argv — cmdlineFields[0] is the program
+// name (e.g. "tmux"); a leading `-L <name>` may follow it, mirroring exactly
+// what tmuxArgs would have inserted to produce this argv in the first place.
+//
+// A leading `-S <path>` returns ok=false. agent-deck itself never spawns tmux
+// that way (tmuxArgs only ever emits -L; grep the package), so a candidate
+// carrying -S was not spawned by agent-deck's own factory — meaning the
+// isLiveTmuxClientOrServer caller cannot safely resolve it through the
+// package's -L-only tmuxExecContext funnel, and per the "refuse anything
+// ambiguous" rule, unresolvable is not reapable rather than a case worth
+// widening the tmux-exec factory for.
+func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
+	if len(cmdlineFields) == 0 {
+		return "", true
+	}
+	rest := cmdlineFields[1:]
+	if socketPathFlag(rest) != "" {
+		return "", false
+	}
+	return socketNameFlag(rest), true
+}
+
+// isLiveTmuxClientOrServer authoritatively asks the tmux server that the
+// candidate's OWN argv targets whether pid IS that server, or is one of its
+// currently-connected clients — the two process classes reapOrphanedPollClients
+// must never kill. It replaces argv-verb pattern matching (isKnownCadenceArgv's
+// former denylist partner, neverReapVerbs) with the server's own live
+// bookkeeping, which cannot be abbreviated or aliased around: see
+// isKnownCadenceArgv's doc comment for the concrete bypass that motivated this.
+//
+// Two independent facts are checked against the server's own state:
+//
+//  1. pid == the server's own pid (queried as `#{pid}`). A server mid-startup
+//     still carries its creating client's comm and argv — tmux renames the
+//     client to "tmux: client" before forking, and the child keeps that comm
+//     and argv until its own post-daemon() rename — so comm+argv alone cannot
+//     rule out "this pid IS the server, not a client of it". Asking the server
+//     for its own pid can.
+//  2. pid appears in the server's `list-clients` output. A registered client is
+//     attached right now — interactively or in control mode — no matter what
+//     verb, alias, or abbreviation its argv spells the attach with, because
+//     registration happens on connect, not by re-parsing argv. A one-shot
+//     cadence command (list-clients, set-option, …) never registers as a
+//     persistent client even while its process is alive and spinning —
+//     verified live by SIGSTOPping one mid-flight and observing list-clients
+//     on the same server come back empty — so absence here rules out an
+//     attach specifically, not just "any client-shaped process".
+//
+// ok=false means neither fact could be established (no server at the resolved
+// socket, a -S-path candidate the package's -L-only exec funnel cannot resolve,
+// connection refused, or the query ran past tmuxLiveQueryTimeout). The caller
+// MUST treat ok=false as unclassifiable and refuse to kill — the same
+// fail-closed rule isTruncatedTmuxComm already established for an unreadable
+// comm value.
+func isLiveTmuxClientOrServer(pid int, cmdlineFields []string) (live bool, ok bool) {
+	socketName, resolvable := candidateSocketName(cmdlineFields)
+	if !resolvable {
+		return false, false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxLiveQueryTimeout)
+	defer cancel()
+	serverPIDOut, err := tmuxExecContext(ctx, socketName, "display-message", "-p", "#{pid}").Output()
+	if err != nil {
+		return false, false
+	}
+	serverPID, err := strconv.Atoi(strings.TrimSpace(string(serverPIDOut)))
+	if err != nil {
+		return false, false
+	}
+	if serverPID == pid {
+		return true, true // pid IS the server
+	}
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxLiveQueryTimeout)
+	defer cancel2()
+	clientsOut, err := tmuxExecContext(ctx2, socketName, "list-clients", "-F", "#{client_pid}").Output()
+	if err != nil {
+		return false, false
+	}
+	target := strconv.Itoa(pid)
+	for _, line := range strings.Split(strings.TrimSpace(string(clientsOut)), "\n") {
+		if strings.TrimSpace(line) == target {
+			return true, true // pid is a currently-registered client
+		}
+	}
+	return false, true
 }
 
 // reapOrphanedPollClients kills leaked one-shot tmux *command* clients — the
@@ -859,13 +948,25 @@ func isReapableOneShotArgv(cmdline string) bool {
 //     renames itself to "tmux: server" and is never matched),
 //   - its argv targets an agent-deck session (contains SessionPrefix), so a
 //     user's unrelated tmux is never touched,
-//   - its argv names a one-shot cadence verb and no attach/new-session verb
-//     (isReapableOneShotArgv), so neither a live interactive client nor a
-//     server still inside its startup rename window can be hit, and
+//   - its argv names a one-shot cadence verb (isKnownCadenceArgv) — a scope
+//     narrowing, not the safety check; see its doc comment for why an argv
+//     denylist cannot be the safety check,
+//   - the tmux server itself confirms, right now, that this pid is neither
+//     itself nor one of its connected clients (isLiveTmuxClientOrServer) —
+//     this is the actual guarantee that a live interactive/control attach or
+//     a server still inside its startup rename window is never hit, and it
+//     cannot be defeated by an abbreviated or aliased attach verb because it
+//     never inspects argv verbs at all, and
 //   - it is a reparented orphan no longer owned by any live agent-deck TUI
 //     (isControlClientOrphan — its parentage check is client-type-agnostic
 //     despite the name). A live TUI's own in-flight poll has PPID == our PID,
 //     so isControlClientOrphan returns false and it is preserved.
+//
+// Any of the two checks that query external state (comm-role classification,
+// tmux-server identity) failing to produce a definite answer is treated as
+// "cannot classify, refuse to kill" — never "assume safe". That fail-closed
+// rule is why isTruncatedTmuxComm and isLiveTmuxClientOrServer both return an
+// explicit ok/unclassifiable signal instead of collapsing into a bool.
 //
 // Linux-only: relies on procfs. On darwin/BSD it is a no-op (a `ps`-based
 // enumeration would be the port); the tmuxPollTimeout guard still applies
@@ -906,10 +1007,29 @@ func reapOrphanedPollClients() {
 		if err != nil || !strings.Contains(string(raw), SessionPrefix) {
 			continue
 		}
-		// Narrow comm+prefix down to the cadence commands this sweep exists
-		// for: an interactive attach and a server mid-startup both clear the
-		// checks above, and killing either costs the user real work.
-		if !isReapableOneShotArgv(string(raw)) {
+		// Scope narrowing only — see isKnownCadenceArgv's doc comment for why
+		// this must never be read as the safety check.
+		if !isKnownCadenceArgv(string(raw)) {
+			continue
+		}
+		// THE safety check: ask the tmux server itself, not argv text, whether
+		// this pid is live. live==true or ok==false both mean "do not kill".
+		cmdlineFields := strings.Split(strings.TrimRight(string(raw), "\x00"), "\x00")
+		live, ok := isLiveTmuxClientOrServer(pid, cmdlineFields)
+		if !ok {
+			skipped++
+			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))),
+				slog.String("reason", "could not confirm via the tmux server itself whether this "+
+					"pid is live (no server at the resolved socket, an unresolvable -S candidate, "+
+					"or the query timed out); refusing to kill rather than guess"))
+			continue
+		}
+		if live {
+			pipeLog.Debug("preserved_live_tmux_client_or_server",
+				slog.Int("pid", pid),
+				slog.String("comm", strings.TrimSpace(string(comm))))
 			continue
 		}
 		if !isControlClientOrphan(pid) {

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -568,8 +569,8 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 func killStaleControlClients(sessionName, socketName string) {
 	// Once per run, also sweep orphaned one-shot *command* clients (poll/query/
 	// status set-option) that this function's control-mode-only filter can never
-	// reach. See reapOrphanedPollClients.
-	orphanReapOnce.Do(reapOrphanedPollClients)
+	// reach. Off this goroutine — see startOrphanReapOnce.
+	startOrphanReapOnce()
 
 	// Bounded — see tmuxPollTimeout. This is the sweep that reaps stale
 	// clients; if its own enumeration hangs on an fd-exhausted client, the
@@ -659,7 +660,7 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		// ends together. Capturing it afterwards would defeat the guard in the
 		// exact case it exists for — the reads would describe the old process
 		// and the identity the new one, and they would agree at signal time.
-		identity, err := processIdentityOf(pid)
+		identity, err := processIdentityOf(context.Background(), pid)
 		if err != nil {
 			// Fail closed: a pid we cannot identify is not signalled. See
 			// stillSameIncarnation.
@@ -686,7 +687,7 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 		// the entire tmux server, wiping every agent-deck session. A SIGTERM
 		// lets the client drain and exit cleanly; SIGKILL is retained as a
 		// 500ms fallback for clients that ignore TERM.
-		usedSIGKILL, signalled := softKillProcessChecked(pid, identity, controlClientKillGrace)
+		usedSIGKILL, signalled := softKillProcessChecked(context.Background(), pid, identity, controlClientKillGrace)
 		if !signalled {
 			// Nothing was sent, so nothing is counted — the burst metric below
 			// exists to observe real kill cascades. Two causes share this
@@ -716,10 +717,52 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 	return killCount
 }
 
-// orphanReapOnce ensures the process-wide orphaned-poll-client sweep runs at
-// most once per agent-deck run (on the first session Connect after startup),
-// instead of re-scanning all of /proc on every Connect.
-var orphanReapOnce sync.Once
+// orphanReapStarted ensures the process-wide orphaned-poll-client sweep is
+// launched at most once per agent-deck run (on the first session Connect after
+// startup), instead of re-scanning all of /proc on every Connect.
+var orphanReapStarted atomic.Bool
+
+// orphanReapFn is the seam the launcher tests swap. The sweep itself walks all
+// of /proc and signals processes; a test of "is it launched once, and off the
+// caller's goroutine" has no business doing either.
+var orphanReapFn = reapOrphanedPollClients
+
+// startOrphanReapOnce launches the orphan sweep in the background, at most once
+// per run.
+//
+// In the background because it sits on Connect, and Connect is the fleet-restore
+// path: every session opened at startup goes through it. The sweep used to be
+// pure /proc reads — microseconds — but it now asks a tmux server about each
+// surviving candidate, and those queries are slowest exactly when the host is
+// unhealthy, which is the same condition that produces the orphans. Run inline
+// behind a once-guard, every other session's Connect blocks on the slowest
+// candidate set: two orphans cost seconds, twenty cost a startup nobody would
+// describe as working. Nothing on the Connect path consumes the sweep's result,
+// so there is nothing to wait for.
+//
+// A run that exits before the sweep finishes simply leaves the remaining
+// orphans for the next launch, which is what a missed sweep has always meant.
+func startOrphanReapOnce() {
+	if orphanReapStarted.CompareAndSwap(false, true) {
+		go orphanReapFn()
+	}
+}
+
+// orphanSweepBudget is the ONE deadline the whole orphan sweep runs under:
+// every external probe it makes — each candidate's identity reads, each tmux
+// server query — derives from it, so the sweep's total cost is bounded no
+// matter how many candidates /proc offers or how wedged the host is.
+//
+// The per-probe caps (processProbeTimeout, tmuxLiveQueryTimeout) are nested
+// inside it rather than being separate budgets of their own: each probe expires
+// at whichever comes first, so one wedged probe cannot eat the whole budget and
+// starve every later candidate, and the sum still cannot exceed this.
+//
+// 20s buys roughly five fully-wedged candidates at the per-probe caps, or many
+// hundreds of healthy ones — a live server answers `#{pid}` in milliseconds.
+// Overrunning it is not a failure: the remaining candidates are logged as
+// unexamined and swept on the next run.
+var orphanSweepBudget = 20 * time.Second
 
 // isReapableTmuxClientComm reports whether a /proc/<pid>/comm value identifies
 // a tmux CLIENT — the only process class reapOrphanedPollClients may kill.
@@ -862,12 +905,14 @@ func isKnownCadenceArgv(cmdline string) bool {
 	return false
 }
 
-// tmuxLiveQueryTimeout bounds each server-identity query
-// isLiveTmuxClientOrServer issues while classifying an orphan-sweep
-// candidate. Short and per-call, not shared: a wedged server on one socket
-// must not delay the verdict for candidates on any other socket, and the
-// sweep already treats a timeout as "cannot classify, refuse to kill" so
-// there is no correctness reason to wait longer.
+// tmuxLiveQueryTimeout caps each server-identity query isLiveTmuxClientOrServer
+// issues while classifying an orphan-sweep candidate. It is a cap nested inside
+// the sweep's single budget (orphanSweepBudget), not an allowance of its own:
+// each query expires at whichever comes first, so a wedged server on one socket
+// cannot delay the verdict for candidates on other sockets, and the sweep's
+// total cost still cannot exceed the budget however many candidates there are.
+// A timeout is already treated as "cannot classify, refuse to kill", so there
+// is no correctness reason to wait longer.
 var tmuxLiveQueryTimeout = 2 * time.Second
 
 // candidateSocketName extracts the -L <name> (or default) socket selector
@@ -925,13 +970,13 @@ func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 // MUST treat ok=false as unclassifiable and refuse to kill — the same
 // fail-closed rule isTruncatedTmuxComm already established for an unreadable
 // comm value.
-func isLiveTmuxClientOrServer(pid int, cmdlineFields []string) (live bool, ok bool) {
+func isLiveTmuxClientOrServer(budget context.Context, pid int, cmdlineFields []string) (live bool, ok bool) {
 	socketName, resolvable := candidateSocketName(cmdlineFields)
 	if !resolvable {
 		return false, false
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), tmuxLiveQueryTimeout)
+	ctx, cancel := context.WithTimeout(budget, tmuxLiveQueryTimeout)
 	defer cancel()
 	serverPIDOut, err := tmuxExecContext(ctx, socketName, "display-message", "-p", "#{pid}").Output()
 	if err != nil {
@@ -945,7 +990,7 @@ func isLiveTmuxClientOrServer(pid int, cmdlineFields []string) (live bool, ok bo
 		return true, true // pid IS the server
 	}
 
-	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxLiveQueryTimeout)
+	ctx2, cancel2 := context.WithTimeout(budget, tmuxLiveQueryTimeout)
 	defer cancel2()
 	clientsOut, err := tmuxExecContext(ctx2, socketName, "list-clients", "-F", "#{client_pid}").Output()
 	if err != nil {
@@ -1013,13 +1058,16 @@ func reapOrphanedPollClients() {
 		return
 	}
 	start := time.Now()
-	candidates, unidentifiable := collectOrphanCandidates()
-	killed, skipped := sweepOrphanCandidates(candidates)
-	if killed > 0 || skipped > 0 || unidentifiable > 0 {
+	budget, cancel := context.WithTimeout(context.Background(), orphanSweepBudget)
+	defer cancel()
+	candidates, unidentifiable := collectOrphanCandidates(budget)
+	killed, skipped, unexamined := sweepOrphanCandidates(budget, candidates)
+	if killed > 0 || skipped > 0 || unidentifiable > 0 || unexamined > 0 {
 		pipeLog.Info("orphaned_poll_clients_reaped",
 			slog.Int("kill_count", killed),
 			slog.Int("skipped_unclassifiable", skipped),
 			slog.Int("skipped_unidentifiable", unidentifiable),
+			slog.Int("unexamined_out_of_budget", unexamined),
 			slog.Duration("duration", time.Since(start)))
 	}
 }
@@ -1051,7 +1099,7 @@ type orphanCandidate struct {
 // than pass over: no identity could be read, or the two reads disagreed. Both
 // mean a process that might be a leak was left alone, and a sweep quietly
 // narrowing itself back toward inert is the original failure of this code.
-func readOrphanCandidate(pid int) (c orphanCandidate, identifiable, ok bool) {
+func readOrphanCandidate(budget context.Context, pid int) (c orphanCandidate, identifiable, ok bool) {
 	// Cheap pre-filter first. /proc holds every process on the host and only a
 	// handful can ever be tmux clients, so the two identity reads below are
 	// paid for only the few entries that get past this. This read carries no
@@ -1064,7 +1112,7 @@ func readOrphanCandidate(pid int) (c orphanCandidate, identifiable, ok bool) {
 		return c, true, false
 	}
 
-	before, err := processIdentityOf(pid)
+	before, err := processIdentityOf(budget, pid)
 	if err != nil {
 		return c, false, false
 	}
@@ -1076,7 +1124,7 @@ func readOrphanCandidate(pid int) (c orphanCandidate, identifiable, ok bool) {
 	if err != nil {
 		return c, true, false
 	}
-	after, err := processIdentityOf(pid)
+	after, err := processIdentityOf(budget, pid)
 	if err != nil || after != before {
 		return c, false, false
 	}
@@ -1097,7 +1145,7 @@ func readOrphanCandidate(pid int) (c orphanCandidate, identifiable, ok bool) {
 // half queries a tmux server per candidate and can block for as long as the
 // sweep's budget allows, and holding a directory listing of every process on
 // the host open across that is pointless.
-func collectOrphanCandidates() (candidates []orphanCandidate, unidentifiable int) {
+func collectOrphanCandidates(budget context.Context) (candidates []orphanCandidate, unidentifiable int) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil, 0
@@ -1108,7 +1156,7 @@ func collectOrphanCandidates() (candidates []orphanCandidate, unidentifiable int
 		if err != nil || pid == myPID {
 			continue
 		}
-		c, identifiable, ok := readOrphanCandidate(pid)
+		c, identifiable, ok := readOrphanCandidate(budget, pid)
 		if !identifiable {
 			unidentifiable++
 			pipeLog.Warn("orphan_sweep_skipped_unidentifiable_pid",
@@ -1136,8 +1184,21 @@ var liveTmuxIdentityOf = isLiveTmuxClientOrServer
 // sweepOrphanCandidates runs the kill gauntlet over already-read candidates and
 // returns how many were killed and how many were refused for want of a definite
 // classification. Every refusal is logged; none is silent.
-func sweepOrphanCandidates(candidates []orphanCandidate) (killed, skipped int) {
-	for _, c := range candidates {
+func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate) (killed, skipped, unexamined int) {
+	for i, c := range candidates {
+		if err := budget.Err(); err != nil {
+			// Out of budget. Report what was left unexamined rather than
+			// returning counts that read like a clean sweep — this whole area
+			// exists because a sweep that quietly did nothing looked exactly
+			// like one that found nothing.
+			unexamined = len(candidates) - i
+			pipeLog.Warn("orphan_sweep_budget_exhausted",
+				slog.Int("unexamined", unexamined),
+				slog.Int("examined", i),
+				slog.String("reason", "the sweep's total deadline (orphanSweepBudget) passed before every "+
+					"candidate was judged; the remaining ones are left for the next run"))
+			break
+		}
 		reapable := isReapableTmuxClientComm(c.comm)
 		// A comm whose role token was truncated away cannot be classified as
 		// client or server. It is not killed; it is carried to the end of the
@@ -1165,7 +1226,7 @@ func sweepOrphanCandidates(candidates []orphanCandidate) (killed, skipped int) {
 		// THE safety check: ask the tmux server itself, not argv text, whether
 		// this pid is live. live==true or ok==false both mean "do not kill".
 		cmdlineFields := strings.Split(strings.TrimRight(c.cmdline, "\x00"), "\x00")
-		live, ok := liveTmuxIdentityOf(c.pid, cmdlineFields)
+		live, ok := liveTmuxIdentityOf(budget, c.pid, cmdlineFields)
 		if !ok {
 			skipped++
 			pipeLog.Warn("orphan_sweep_skipped_unclassifiable_tmux",
@@ -1199,7 +1260,7 @@ func sweepOrphanCandidates(candidates []orphanCandidate) (killed, skipped int) {
 		// it immediately before each signal, so a pid that changed hands while
 		// the gauntlet was running is refused here rather than killed on the
 		// strength of facts that belong to a process which no longer exists.
-		usedSIGKILL, signalled := softKillProcessChecked(c.pid, c.identity, controlClientKillGrace)
+		usedSIGKILL, signalled := softKillProcessChecked(budget, c.pid, c.identity, controlClientKillGrace)
 		if !signalled {
 			skipped++
 			pipeLog.Debug("orphan_sweep_candidate_not_signalled",
@@ -1213,7 +1274,7 @@ func sweepOrphanCandidates(candidates []orphanCandidate) (killed, skipped int) {
 			slog.Int("pid", c.pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	return killed, skipped
+	return killed, skipped, unexamined
 }
 
 // isControlClientOrphan reports whether the control-mode client pid is a
@@ -1351,7 +1412,7 @@ func readProcessExe(pid int) (string, error) {
 // the caller's signal that the guard cannot be armed, which is a different
 // state from "the identity changed" and is handled differently — see
 // softKillProcessChecked.
-func readProcessIdentity(pid int) (string, error) {
+func readProcessIdentity(budget context.Context, pid int) (string, error) {
 	if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
 		// Same parse as readParentPID: the comm field can contain ')', so
 		// split after the LAST one. Fields then start at state (field 3), so
@@ -1367,12 +1428,10 @@ func readProcessIdentity(pid int) (string, error) {
 		}
 		return fields[startTimeIndex], nil
 	}
-	// Bounded, unlike the sibling ps probes: this one runs once per candidate
-	// pid on the boot path, where SweepStaleControlClients already refuses to
-	// let a hung query stall startup (staleControlSweepTimeout). A deadline
-	// miss surfaces as an error, which leaves the guard unarmed — the sweep
-	// keeps working, it just stops being able to detect reuse.
-	ctx, cancel := context.WithTimeout(context.Background(), processProbeTimeout)
+	// Bounded, unlike the sibling ps probes, and bounded by the CALLER's budget
+	// as well as by its own cap. A deadline miss surfaces as an error, which
+	// fails closed: the pid is not signalled, and the caller reports it.
+	ctx, cancel := context.WithTimeout(budget, processProbeTimeout)
 	defer cancel()
 	// #nosec G204 -- "ps" is a fixed binary; only arg is strconv.Itoa(int).
 	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
@@ -1391,8 +1450,10 @@ func readProcessIdentity(pid int) (string, error) {
 // wrap inside a 100ms window.
 var processIdentityOf = readProcessIdentity
 
-// processProbeTimeout bounds the `ps` fallback in readProcessIdentity so a
-// wedged probe cannot stall the boot-path sweep that calls it. Matches
+// processProbeTimeout caps the `ps` fallback in readProcessIdentity. Like
+// tmuxLiveQueryTimeout it nests inside whatever budget the caller passes — the
+// sweep's single deadline, or a background context for callers that have none —
+// so one wedged probe can spend at most this much of it. Matches
 // staleControlSweepTimeout, which bounds the list-clients query feeding the
 // same sweep.
 var processProbeTimeout = 2 * time.Second
@@ -1406,13 +1467,19 @@ const controlClientKillGrace = 500 * time.Millisecond
 // process to exit, and escalates to SIGKILL if it doesn't. Returns true iff
 // SIGKILL was ultimately used. A non-existent pid (ESRCH) is treated as
 // already-dead and returns false without escalation.
+//
 // A pid whose identity cannot be established is not signalled at all: see
 // stillSameIncarnation for why this fails closed rather than proceeding with an
 // unarmed guard. In practice an unreadable identity for a live process means
 // neither /proc nor `ps` works on the host; a process that is simply gone reads
 // the same way, and refusing to signal it costs nothing.
+//
+// This is the entry point for callers with no budget of their own: its identity
+// probes get the plain per-probe cap (processProbeTimeout). The sweep does not
+// come through here — it captures the identity itself, long before the kill, and
+// calls softKillProcessChecked under its own budget.
 func softKillProcess(pid int, grace time.Duration) bool {
-	identity, err := processIdentityOf(pid)
+	identity, err := processIdentityOf(context.Background(), pid)
 	if err != nil {
 		pipeLog.Warn("skipped_kill_unidentifiable_pid",
 			slog.Int("pid", pid),
@@ -1420,7 +1487,7 @@ func softKillProcess(pid int, grace time.Duration) bool {
 				"cannot be shown to still be the process the caller judged; refusing to signal it"))
 		return false
 	}
-	usedSIGKILL, _ := softKillProcessChecked(pid, identity, grace)
+	usedSIGKILL, _ := softKillProcessChecked(context.Background(), pid, identity, grace)
 	return usedSIGKILL
 }
 
@@ -1442,11 +1509,11 @@ func softKillProcess(pid int, grace time.Duration) bool {
 //     rather than silent.
 //   - A read that fails now means the process is gone or has become
 //     unreadable, and there is nothing worth signalling either way.
-func stillSameIncarnation(pid int, identity string) bool {
+func stillSameIncarnation(budget context.Context, pid int, identity string) bool {
 	if identity == "" {
 		return false
 	}
-	current, err := processIdentityOf(pid)
+	current, err := processIdentityOf(budget, pid)
 	if err != nil {
 		return false
 	}
@@ -1482,8 +1549,8 @@ func stillSameIncarnation(pid int, identity string) bool {
 // log one line per victim, and a pid the guard refused to touch is not a
 // victim — reporting it as one would make the sweep's burst metric, which
 // exists to observe the kill cascade, count kills that never happened.
-func softKillProcessChecked(pid int, identity string, grace time.Duration) (usedSIGKILL, signalled bool) {
-	if !stillSameIncarnation(pid, identity) {
+func softKillProcessChecked(budget context.Context, pid int, identity string, grace time.Duration) (usedSIGKILL, signalled bool) {
+	if !stillSameIncarnation(budget, pid, identity) {
 		return false, false
 	}
 
@@ -1514,7 +1581,7 @@ func softKillProcessChecked(pid int, identity string, grace time.Duration) (used
 
 	// Something still holds the number after grace. Escalate only if it is
 	// still the process we signalled.
-	if !stillSameIncarnation(pid, identity) {
+	if !stillSameIncarnation(budget, pid, identity) {
 		return false, true
 	}
 	_ = syscall.Kill(pid, syscall.SIGKILL)

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -693,8 +693,8 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 	// immediately before each signal, and a pid that changed hands is refused.
 	for _, c := range candidates {
 		pid, identity := c.pid, c.identity
-		orphan, known := controlClientOrphanOf(pid)
-		if !known {
+		switch verdict := controlClientOrphanOf(pid); verdict {
+		case parentageUnknown:
 			// This sweep has no comm filter and no live-server query, so the
 			// parentage check is the only thing between a list-clients line and
 			// a SIGTERM. An indeterminate answer is not a licence to send one.
@@ -706,14 +706,28 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 					"parent's executable could not be read); refusing to signal rather than "+
 					"assume the owner is gone"))
 			continue
-		}
-		if !orphan {
+		case parentageCandidateGone:
+			pipeLog.Debug("skipped_control_client_already_gone",
+				slog.String("session", logging.SanitizeValue(sessionLabel)),
+				slog.Int("pid", pid))
+			continue
+		case parentageOwned:
 			// Live sibling TUI — leave its pipe alone. Without this guard
 			// two concurrent agent-deck TUIs (allow_multiple=true) would
 			// SIGTERM each other's control clients on every reconnect (#927).
 			pipeLog.Debug("preserved_live_sibling_control_client",
 				slog.String("session", logging.SanitizeValue(sessionLabel)),
 				slog.Int("pid", pid))
+			continue
+		case parentageOrphaned:
+			// The only verdict that reaches a signal. Fall through.
+		default:
+			// A verdict added later and not handled here must never reach the
+			// kill by default.
+			pipeLog.Warn("skipped_unhandled_parentage_verdict",
+				slog.String("session", logging.SanitizeValue(sessionLabel)),
+				slog.Int("pid", pid),
+				slog.Int("verdict", int(verdict)))
 			continue
 		}
 		// Soft-kill the stale control-mode client process.
@@ -953,18 +967,6 @@ func isKnownCadenceArgv(cmdline string) bool {
 // is no correctness reason to wait longer.
 var tmuxLiveQueryTimeout = 2 * time.Second
 
-// candidateSocketName extracts the -L <name> (or default) socket selector
-// from a poll-sweep candidate's OWN argv — cmdlineFields[0] is the program
-// name (e.g. "tmux"); a leading `-L <name>` may follow it, mirroring exactly
-// what tmuxArgs would have inserted to produce this argv in the first place.
-//
-// A leading `-S <path>` returns ok=false. agent-deck itself never spawns tmux
-// that way (tmuxArgs only ever emits -L; grep the package), so a candidate
-// carrying -S was not spawned by agent-deck's own factory — meaning the
-// isLiveTmuxClientOrServer caller cannot safely resolve it through the
-// package's -L-only tmuxExecContext funnel, and per the "refuse anything
-// ambiguous" rule, unresolvable is not reapable rather than a case worth
-// widening the tmux-exec factory for.
 // candidateSocketPath resolves the socket the CANDIDATE is talking to, out of
 // the candidate's own environment and its own argv — the two inputs tmux itself
 // used when it picked a socket.
@@ -974,9 +976,12 @@ var tmuxLiveQueryTimeout = 2 * time.Second
 // different servers, and the name alone cannot tell them apart. Reading the
 // candidate's TMUX/TMUX_TMPDIR is the only way to say which one it meant.
 //
-// ok=false means the environment could not be read, which includes a pid that
-// has exited, a zombie (whose environ reads back empty rather than failing), and
-// another user's process. All of them are refusals: a socket that cannot be
+// ok=false means the candidate's socket could not be established: a different
+// mount namespace, or an environment that could not be read — a pid that has
+// exited, a zombie (measured on this kernel: the read FAILS with EPERM, or
+// ENOENT once reaped), another user's process, or a live process exec'd with a
+// genuinely empty environment, which is the one case that reads back
+// successfully with nothing in it. All are refusals: a socket that cannot be
 // established is not a socket that can be compared.
 //
 // The uid is this process's, deliberately. A candidate belonging to another uid
@@ -984,6 +989,15 @@ var tmuxLiveQueryTimeout = 2 * time.Second
 // cannot match and the candidate is refused — which is the right answer for a
 // process this sweep has no business killing anyway.
 func candidateSocketPath(pid int, cmdlineFields []string) (path string, ok bool) {
+	// A path is only a name for a file within one mount namespace. A candidate
+	// in another one — a container on the same host, same uid — resolves its
+	// -L name to a path that is character-for-character ours and names a
+	// different socket on a different filesystem. String equality would then
+	// call it our server and judge it there, which is the false-match direction:
+	// a wrong refusal costs a leaked client, a wrong match costs a live one.
+	if !sameMountNamespace(pid) {
+		return "", false
+	}
 	lookupEnv, err := readProcessEnviron(pid)
 	if err != nil {
 		return "", false
@@ -995,13 +1009,38 @@ func candidateSocketPath(pid int, cmdlineFields []string) (path string, ok bool)
 	return normalizeTmpPath(resolveTmuxSocketPath(lookupEnv, os.Getuid(), "", args)), true
 }
 
+// sameMountNamespace reports whether pid resolves filesystem paths the same way
+// this process does. Anything else — including a namespace that cannot be read —
+// is a no.
+//
+// This costs no reach that candidateSocketPath does not already need:
+// /proc/<pid>/ns/mnt and /proc/<pid>/environ are gated by the same
+// PTRACE_MODE_READ check, so a candidate whose environment is readable has a
+// readable namespace link too (verified on this host under yama
+// ptrace_scope=1, for a same-uid process that is not a descendant).
+func sameMountNamespace(pid int) bool {
+	theirs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/mnt", pid))
+	if err != nil {
+		return false
+	}
+	ours, err := os.Readlink("/proc/self/ns/mnt")
+	if err != nil {
+		return false
+	}
+	return theirs == ours
+}
+
 // readProcessEnviron reads pid's environment out of procfs as a lookup function
 // shaped for resolveTmuxSocketPath.
 //
-// An empty read is an error, not an empty environment: /proc/<pid>/environ comes
-// back empty with no error for a zombie, and treating that as "this process has
-// no TMUX_TMPDIR" would resolve it to the default socket — a confident answer
-// about a process that no longer has an environment to have.
+// An empty read is an error, not an empty environment. Treating zero bytes as
+// "this process has no TMUX_TMPDIR" would leave every lookup returning "" and
+// resolve the candidate to the DEFAULT socket — a confident answer built from
+// nothing, which is then used to pick which server to judge it on. Measured
+// rather than assumed: a zombie does NOT reach here (its environ read fails),
+// and what does read back empty-and-successful is a live process exec'd with no
+// environment at all — never one of agent-deck's own clients, which inherit
+// os.Environ().
 func readProcessEnviron(pid int) (func(string) string, error) {
 	raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
 	if err != nil {
@@ -1019,6 +1058,18 @@ func readProcessEnviron(pid int) (func(string) string, error) {
 	return func(key string) string { return env[key] }, nil
 }
 
+// candidateSocketName extracts the -L <name> (or default) socket selector
+// from a poll-sweep candidate's OWN argv — cmdlineFields[0] is the program
+// name (e.g. "tmux"); a leading `-L <name>` may follow it, mirroring exactly
+// what tmuxArgs would have inserted to produce this argv in the first place.
+//
+// A leading `-S <path>` returns ok=false. agent-deck itself never spawns tmux
+// that way (tmuxArgs only ever emits -L; grep the package), so a candidate
+// carrying -S was not spawned by agent-deck's own factory — meaning the
+// isLiveTmuxClientOrServer caller cannot safely resolve it through the
+// package's -L-only tmuxExecContext funnel, and per the "refuse anything
+// ambiguous" rule, unresolvable is not reapable rather than a case worth
+// widening the tmux-exec factory for.
 func candidateSocketName(cmdlineFields []string) (name string, ok bool) {
 	if len(cmdlineFields) == 0 {
 		return "", true
@@ -1384,9 +1435,13 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 				slog.Int("pid", c.pid),
 				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))),
 				slog.String("reason", "could not confirm via the tmux server itself whether this "+
-					"pid is live (no server at the resolved socket, a running server holding no "+
-					"sessions — which cannot answer either query on tmux 3.0a — an unresolvable -S "+
-					"candidate, or the query timed out); refusing to kill rather than guess"))
+					"pid is live (the candidate's own socket is not the one this process "+
+					"resolves that name to — a changed TMUX_TMPDIR does this, and every orphan "+
+					"from the old base stays unreapable until it is restored; the candidate's "+
+					"environment or mount namespace could not be read; no server at the resolved "+
+					"socket; a running server holding no sessions, which cannot answer either "+
+					"query on tmux 3.0a; an unresolvable -S candidate; or the query timed out); "+
+					"refusing to kill rather than guess"))
 			continue
 		}
 		if live {
@@ -1395,8 +1450,8 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))))
 			continue
 		}
-		orphan, parentageKnown := controlClientOrphanOf(c.pid)
-		if !parentageKnown {
+		switch verdict := controlClientOrphanOf(c.pid); verdict {
+		case parentageUnknown:
 			unknownParent++
 			pipeLog.Warn("orphan_sweep_skipped_unknown_parentage",
 				slog.Int("pid", c.pid),
@@ -1405,9 +1460,20 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 					"this client (its parent pid, that parent's liveness, or that parent's "+
 					"executable could not be read); refusing to kill rather than guess"))
 			continue
-		}
-		if !orphan {
+		case parentageCandidateGone:
+			// Not a refusal: it exited while the gauntlet ran, which is routine.
+			pipeLog.Debug("orphan_sweep_candidate_already_gone", slog.Int("pid", c.pid))
+			continue
+		case parentageOwned:
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
+		case parentageOrphaned:
+			// The only verdict that reaches a signal. Fall through.
+		default:
+			unknownParent++
+			pipeLog.Warn("orphan_sweep_skipped_unhandled_parentage_verdict",
+				slog.Int("pid", c.pid),
+				slog.Int("verdict", int(verdict)))
+			continue
 		}
 		if commUnclassifiable {
 			unclassifiable++
@@ -1477,9 +1543,34 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 // Why not a heartbeat file: would need TUI-startup wiring + a refresh
 // goroutine + lifecycle cleanup. The PPID+exe check is zero-state and
 // agrees on the same answer.
-func isControlClientOrphan(pid int) (orphan bool, known bool) {
+func isControlClientOrphan(pid int) parentageVerdict {
 	return isControlClientOrphanFor(readParentPID, probeProcessAlive, readProcessExe, pid)
 }
+
+// parentageVerdict is what the parentage gate can conclude. Four answers rather
+// than a bool, because three of them mean "do not signal" for reasons an
+// operator must be able to tell apart: only one of them is a failure.
+type parentageVerdict int
+
+const (
+	// parentageUnknown: the facts could not be read. Refuse, and say so loudly —
+	// this is the one that means something is wrong with the host or with us.
+	parentageUnknown parentageVerdict = iota
+	// parentageOrphaned: the owning TUI is gone. The only verdict that
+	// authorises a signal.
+	parentageOrphaned
+	// parentageOwned: a live agent-deck TUI (possibly a sibling) owns it.
+	parentageOwned
+	// parentageCandidateGone: the candidate itself no longer exists. Ordinary
+	// churn — candidates die during the gauntlet all the time, because earlier
+	// victims' grace periods run in between — and NOT a failure to establish
+	// anything. Reporting it as unknown would put a safety-shaped Warn on
+	// routine sweeps and bury the ones that matter.
+	parentageCandidateGone
+)
+
+// reapable reports whether this verdict authorises a signal. Exactly one does.
+func (v parentageVerdict) reapable() bool { return v == parentageOrphaned }
 
 // controlClientOrphanOf is the seam both sweeps call through, so their handling
 // of an indeterminate verdict can be tested without a host on which /proc reads
@@ -1497,33 +1588,43 @@ func isControlClientOrphanFor(
 	probeAlive func(int) error,
 	processExe func(int) (string, error),
 	pid int,
-) (orphan bool, known bool) {
+) parentageVerdict {
 	ppid, err := parentPID(pid)
 	if err != nil {
-		return false, false
+		// Before calling this a failure, ask the cheaper question: is the
+		// CANDIDATE still there? A pid that exited has no parent to report, and
+		// that is a determination about a process with nothing left to kill —
+		// not a host that cannot answer.
+		if errors.Is(probeAlive(pid), syscall.ESRCH) {
+			return parentageCandidateGone
+		}
+		return parentageUnknown
 	}
 	if ppid <= 1 {
 		// PPID == 1 means the kernel has already reparented the client to
 		// init — definitively an orphan.
-		return true, true
+		return parentageOrphaned
 	}
 	// Liveness check on the parent. If the parent died between the list-clients
 	// call and now, the client is in the process of being orphaned right now.
 	if err := probeAlive(ppid); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return true, true
+			return parentageOrphaned
 		}
 		// The parent is there and we cannot look at it (EPERM), or the probe
 		// failed for a reason we cannot name. Neither says "orphan".
-		return false, false
+		return parentageUnknown
 	}
 	parentExe, err := processExe(ppid)
 	if err != nil {
 		// Linux without /proc-read permission, or macOS with `ps` failing. The
 		// parent is alive; we simply cannot tell whose it is.
-		return false, false
+		return parentageUnknown
 	}
-	return !looksLikeAgentDeckBinary(parentExe), true
+	if looksLikeAgentDeckBinary(parentExe) {
+		return parentageOwned
+	}
+	return parentageOrphaned
 }
 
 // looksLikeAgentDeckBinary returns true when exePath plausibly refers to an
@@ -1841,16 +1942,23 @@ func softKillProcessChecked(budget context.Context, pid int, identity string, gr
 // server — wiping every agent-deck session. The mitigation in #739
 // only covered killStaleControlClients (the post-restart cleanup path);
 // the active-pipe close path still SIGKILL'd. This helper closes that gap.
-func softKillProcessGroup(pgid int, grace time.Duration) bool {
-	return softKillProcessGroupWith(syscall.Kill, pgid, grace)
-}
+// groupKillSyscall is the seam softKillProcessGroup signals through. A test
+// swaps it to drive the errno branches, which otherwise need a second uid to
+// reach. It is deliberately a package var rather than a parameter of an
+// injectable core: a core-only test leaves the exported behaviour free to drift
+// away from it, and the escalation this function refuses to make is exactly the
+// kind of thing that gets pasted back in.
+var groupKillSyscall = syscall.Kill
 
-// softKillProcessGroupWith is the injectable core of softKillProcessGroup. kill
-// is syscall.Kill in production; a test passes its own so the errno branches can
-// be driven without a group this process genuinely may not signal (which needs a
-// second uid, i.e. a host the CI runners do not provide).
-func softKillProcessGroupWith(kill func(pid int, sig syscall.Signal) error, pgid int, grace time.Duration) bool {
-	if err := kill(-pgid, syscall.SIGTERM); err != nil {
+// stillOurs is re-asked immediately before the escalation. The pgid was
+// captured when the child was certainly unreaped, but that was a full grace ago
+// and the child can exit and be reaped inside it — by the concurrent reap this
+// path exists to outrun — which frees its pid, and the pgid is that same
+// number. softKillProcessChecked re-verifies incarnation before ITS escalation
+// for the same reason; without this the group arm was the last signal on this
+// path still resting on a name that may have changed hands.
+func softKillProcessGroup(pgid int, grace time.Duration, stillOurs func() bool) bool {
+	if err := groupKillSyscall(-pgid, syscall.SIGTERM); err != nil {
 		// ESRCH (empty group) or EPERM (not ours) — either way there is
 		// nothing here this process both may and should kill.
 		return false
@@ -1862,12 +1970,24 @@ func softKillProcessGroupWith(kill func(pid int, sig syscall.Signal) error, pgid
 		time.Sleep(pollInterval)
 		// kill(-pgid, 0) returns ESRCH only when no process in the group
 		// remains; until then it returns nil (some member alive or zombie).
-		if err := kill(-pgid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
+		if err := groupKillSyscall(-pgid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
+			return false
+		}
+		if !stillOurs() {
+			// The child was reaped while we waited. Whatever answers to this
+			// pgid now, we can no longer show it is ours. Its remaining members
+			// are left behind — a leak the next sweep can see — rather than
+			// SIGKILLing a group on the strength of a recycled number.
+			pipeLog.Warn("skipped_group_escalation_pgid_changed_hands",
+				slog.Int("pgid", pgid),
+				slog.String("reason", "the child was reaped during the kill grace, so its pid — "+
+					"and the process group id that is the same number — may name a stranger; "+
+					"refusing the group-wide SIGKILL rather than guess"))
 			return false
 		}
 	}
 
-	_ = kill(-pgid, syscall.SIGKILL)
+	_ = groupKillSyscall(-pgid, syscall.SIGKILL)
 	return true
 }
 

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -693,7 +693,21 @@ func reapStaleControlClients(listOutput, sessionLabel string) int {
 	// immediately before each signal, and a pid that changed hands is refused.
 	for _, c := range candidates {
 		pid, identity := c.pid, c.identity
-		if !isControlClientOrphan(pid) {
+		orphan, known := controlClientOrphanOf(pid)
+		if !known {
+			// This sweep has no comm filter and no live-server query, so the
+			// parentage check is the only thing between a list-clients line and
+			// a SIGTERM. An indeterminate answer is not a licence to send one.
+			pipeLog.Warn("skipped_unknown_parentage",
+				slog.String("session", logging.SanitizeValue(sessionLabel)),
+				slog.Int("pid", pid),
+				slog.String("reason", "could not establish whether a live agent-deck TUI owns "+
+					"this control client (its parent pid, that parent's liveness, or that "+
+					"parent's executable could not be read); refusing to signal rather than "+
+					"assume the owner is gone"))
+			continue
+		}
+		if !orphan {
 			// Live sibling TUI — leave its pipe alone. Without this guard
 			// two concurrent agent-deck TUIs (allow_multiple=true) would
 			// SIGTERM each other's control clients on every reconnect (#927).
@@ -1106,8 +1120,8 @@ func reapOrphanedPollClients() {
 	budget, cancel := context.WithTimeout(context.Background(), orphanSweepBudget)
 	defer cancel()
 	candidates, unidentifiable := collectOrphanCandidates(budget)
-	killed, unclassifiable, notSignalled, unexamined := sweepOrphanCandidates(budget, candidates)
-	if killed > 0 || unclassifiable > 0 || notSignalled > 0 || unidentifiable > 0 || unexamined > 0 {
+	killed, unclassifiable, notSignalled, unknownParent, unexamined := sweepOrphanCandidates(budget, candidates)
+	if killed > 0 || unclassifiable > 0 || notSignalled > 0 || unidentifiable > 0 || unknownParent > 0 || unexamined > 0 {
 		// One line per sweep that did anything at all, kills included or not:
 		// the counters are the only place a run that refused everything is
 		// visible at Info level, and "the sweep went inert and nobody noticed"
@@ -1117,6 +1131,7 @@ func reapOrphanedPollClients() {
 			slog.Int("skipped_unclassifiable", unclassifiable),
 			slog.Int("skipped_not_signalled", notSignalled),
 			slog.Int("skipped_unidentifiable", unidentifiable),
+			slog.Int("skipped_unknown_parentage", unknownParent),
 			slog.Int("unexamined_out_of_budget", unexamined),
 			slog.Duration("duration", time.Since(start)))
 	}
@@ -1241,7 +1256,7 @@ var liveTmuxIdentityOf = isLiveTmuxClientOrServer
 // routine ones, Warn for the ones that mean the sweep is losing ground — and
 // every one of them reaches Info level through the caller's summary, so a run
 // that refused everything can never look like a run that found nothing.
-func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate) (killed, unclassifiable, notSignalled, unexamined int) {
+func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate) (killed, unclassifiable, notSignalled, unknownParent, unexamined int) {
 	for i, c := range candidates {
 		if err := budget.Err(); err != nil {
 			// Out of budget. Report what was left unexamined rather than
@@ -1301,7 +1316,18 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))))
 			continue
 		}
-		if !isControlClientOrphan(c.pid) {
+		orphan, parentageKnown := controlClientOrphanOf(c.pid)
+		if !parentageKnown {
+			unknownParent++
+			pipeLog.Warn("orphan_sweep_skipped_unknown_parentage",
+				slog.Int("pid", c.pid),
+				slog.String("comm", logging.SanitizeValue(strings.TrimSpace(c.comm))),
+				slog.String("reason", "could not establish whether a live agent-deck TUI owns "+
+					"this client (its parent pid, that parent's liveness, or that parent's "+
+					"executable could not be read); refusing to kill rather than guess"))
+			continue
+		}
+		if !orphan {
 			continue // owned by a live agent-deck TUI (incl. a sibling) — keep
 		}
 		if commUnclassifiable {
@@ -1332,7 +1358,7 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 			slog.Int("pid", c.pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
 	}
-	return killed, unclassifiable, notSignalled, unexamined
+	return killed, unclassifiable, notSignalled, unknownParent, unexamined
 }
 
 // isControlClientOrphan reports whether the control-mode client pid is a
@@ -1348,37 +1374,77 @@ func sweepOrphanCandidates(budget context.Context, candidates []orphanCandidate)
 // subreaper such as `systemd --user` / `launchd` — none of which match
 // agent-deck.
 //
-// Conservative: any error reading parent metadata returns true (treat as
-// orphan, sweep it). The prior behaviour was "kill anything that isn't me",
-// so falling back to that on metadata-read failures preserves cleanup
-// behaviour for #595's stale-client class without regressing.
+// known=false means the parentage could not be established at all, and the
+// caller MUST refuse to signal. This gate used to answer "orphan, sweep it" for
+// every read failure, on the reasoning that the behaviour it replaced was "kill
+// anything that isn't me" so falling back to it regressed nothing. That reads
+// the failure the wrong way round: an unreadable parent is exactly as
+// consistent with a live sibling TUI as with a dead one, and the sweeps break
+// that tie by killing. It is also the same fail-closed rule the rest of this
+// gauntlet already follows — isTruncatedTmuxComm for an unreadable comm,
+// isLiveTmuxClientOrServer's ok=false for an unreachable server,
+// stillSameIncarnation for an unreadable identity. Refusing costs a leaked
+// client that the next sweep re-examines; guessing costs a live client.
+//
+// Two verdicts are determinations rather than read failures and stay orphan, or
+// the #595 cleanup this function exists for goes inert:
+//
+//   - PPID <= 1: the kernel has already reparented the client to init.
+//   - ESRCH from the liveness probe: the kernel confirming the parent is gone,
+//     i.e. the client is being orphaned right now. Any OTHER probe error is a
+//     read failure — EPERM in particular means the parent EXISTS and belongs to
+//     someone else, which is the opposite of what this branch used to conclude.
 //
 // Why not a heartbeat file: would need TUI-startup wiring + a refresh
 // goroutine + lifecycle cleanup. The PPID+exe check is zero-state and
 // agrees on the same answer.
-func isControlClientOrphan(pid int) bool {
-	ppid, err := readParentPID(pid)
-	if err != nil || ppid <= 1 {
+func isControlClientOrphan(pid int) (orphan bool, known bool) {
+	return isControlClientOrphanFor(readParentPID, probeProcessAlive, readProcessExe, pid)
+}
+
+// controlClientOrphanOf is the seam both sweeps call through, so their handling
+// of an indeterminate verdict can be tested without a host on which /proc reads
+// genuinely fail. isControlClientOrphanFor covers the decision itself.
+var controlClientOrphanOf = isControlClientOrphan
+
+// probeProcessAlive asks the kernel whether pid still exists, without signalling
+// it. Split out so isControlClientOrphanFor can be driven through every errno
+// that matters.
+func probeProcessAlive(pid int) error { return syscall.Kill(pid, 0) }
+
+// isControlClientOrphanFor is the injectable core of isControlClientOrphan.
+func isControlClientOrphanFor(
+	parentPID func(int) (int, error),
+	probeAlive func(int) error,
+	processExe func(int) (string, error),
+	pid int,
+) (orphan bool, known bool) {
+	ppid, err := parentPID(pid)
+	if err != nil {
+		return false, false
+	}
+	if ppid <= 1 {
 		// PPID == 1 means the kernel has already reparented the client to
 		// init — definitively an orphan.
-		return true
+		return true, true
 	}
-	// Liveness double-check on the parent. If the parent died between the
-	// list-clients call and now, the client is in the process of being
-	// orphaned right now — sweep it.
-	if err := syscall.Kill(ppid, 0); err != nil {
-		return true
+	// Liveness check on the parent. If the parent died between the list-clients
+	// call and now, the client is in the process of being orphaned right now.
+	if err := probeAlive(ppid); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return true, true
+		}
+		// The parent is there and we cannot look at it (EPERM), or the probe
+		// failed for a reason we cannot name. Neither says "orphan".
+		return false, false
 	}
-	parentExe, err := readProcessExe(ppid)
+	parentExe, err := processExe(ppid)
 	if err != nil {
-		// On Linux without /proc-read permission, or macOS with `ps`
-		// failing, we can't verify the parent. Fall back to "treat as
-		// orphan" so #595 cleanup still happens; the cost is that this
-		// regresses the #927 behaviour only on hosts where /proc is
-		// inaccessible AND `ps` doesn't work — which is essentially never.
-		return true
+		// Linux without /proc-read permission, or macOS with `ps` failing. The
+		// parent is alive; we simply cannot tell whose it is.
+		return false, false
 	}
-	return !looksLikeAgentDeckBinary(parentExe)
+	return !looksLikeAgentDeckBinary(parentExe), true
 }
 
 // looksLikeAgentDeckBinary returns true when exePath plausibly refers to an

--- a/internal/tmux/softkill_group_reuse_test.go
+++ b/internal/tmux/softkill_group_reuse_test.go
@@ -1,6 +1,9 @@
 package tmux
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -8,6 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubGroupKillSyscall swaps the syscall seam softKillProcessGroup itself calls,
+// so these tests drive the PRODUCTION entry point. Testing an injectable core
+// instead leaves the wrapper free to stop calling it: the pre-fix EPERM
+// escalation can be pasted straight back into softKillProcessGroup and a
+// core-only test suite stays green.
+func stubGroupKillSyscall(t *testing.T, fn func(pid int, sig syscall.Signal) error) {
+	t.Helper()
+	original := groupKillSyscall
+	t.Cleanup(func() { groupKillSyscall = original })
+	groupKillSyscall = fn
+}
+
+// alwaysOurs is the ownership predicate for tests that are not about ownership.
+func alwaysOurs() bool { return true }
 
 // reapWithEOFGrace's fallback has two arms and only the narrow one was ever
 // hardened. The else arm — one pid, resolved through its handle — is guarded
@@ -60,22 +78,81 @@ func TestReapWithEOFGrace_RefusesTheGroupKillOnceTheChildHasBeenWaitedOn(t *test
 	assert.True(t, <-fellBack, "the fallback path must still report that it ran")
 }
 
+// spawnHelperJoiningGroup starts a helper INTO an existing process group rather
+// than leading one of its own, so a test can tell a group kill from a pid kill.
+//
+// Not registerOrphanReaper: that helper signals -pid for anything started with
+// Setpgid, which is right for a leader (pid == pgid) and wrong here — this
+// child's pid names no group, and a raw negative signal on a number that is not
+// a pgid is the friendly-fire shape this whole file is about. Teardown goes
+// through the handle instead.
+func spawnHelperJoiningGroup(t *testing.T, pgid int, role string) *exec.Cmd {
+	t.Helper()
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	cmd := exec.Command(exe, "-test.run=^$")
+	ready := filepath.Join(t.TempDir(), "ready")
+	cmd.Env = append(os.Environ(), "SOFTKILL_TEST_HELPER="+role, softkillReadyEnv+"="+ready)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: pgid}
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	waitForReady(t, ready, 5*time.Second)
+
+	// The premise of every assertion that follows.
+	got, err := syscall.Getpgid(cmd.Process.Pid)
+	require.NoError(t, err)
+	require.Equal(t, pgid, got, "the helper did not join the group under test")
+	return cmd
+}
+
 // TestReapWithEOFGrace_StillGroupKillsAWedgedLiveChild is the positive control.
 // Failing closed is only worth anything if the fallback still does its job in
 // the case it exists for: a child that ignores both stdin EOF and SIGTERM, and
 // whose handle has NOT been waited on.
+//
+// It asserts the GROUP dies, not just the child. Killing the group is the whole
+// reason this arm exists — a `tmux -C` client that spawned descendants leaves
+// them orphaned otherwise — and with a single-process group in the fixture,
+// "kill the pid" and "kill the group" are indistinguishable, so a regression
+// that quietly drops to the handle path would pass.
 func TestReapWithEOFGrace_StillGroupKillsAWedgedLiveChild(t *testing.T) {
-	cmd := spawnHelperInOwnGroup(t, "ignore")
-	exited := waitForExit(t, cmd)
+	leader := spawnHelperInOwnGroup(t, "ignore")
+	pgid := leader.Process.Pid
+	joiner := spawnHelperJoiningGroup(t, pgid, "ignore")
 
-	usedFallback := reapWithEOFGrace(func() { <-exited }, cmd.Process, cmd.Process.Pid,
-		50*time.Millisecond, 500*time.Millisecond)
+	leaderExited := waitForExit(t, leader)
+	joinerExited := waitForExit(t, joiner)
+
+	// A reap that gives up rather than blocking forever. `func() { <-exited }`
+	// deadlocks reapWithEOFGrace's closing `<-reapDone` if a regression makes
+	// the fallback inert, and the test then hangs the whole package until the
+	// 10-minute suite panic — which also strands TestMain's tmux server,
+	// because the deferred kill-server never runs. A test must fail, not hang.
+	reap := func() {
+		select {
+		case <-leaderExited:
+		case <-time.After(5 * time.Second):
+		}
+	}
+
+	usedFallback := reapWithEOFGrace(reap, leader.Process, pgid, 50*time.Millisecond, 500*time.Millisecond)
 
 	assert.True(t, usedFallback)
 	select {
-	case <-exited:
+	case <-leaderExited:
 	case <-time.After(2 * time.Second):
 		t.Fatal("a wedged live child survived the fallback; the guard has made the path inert")
+	}
+	select {
+	case <-joinerExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a process sharing the child's group survived: the fallback killed the pid, " +
+			"not the group, and a client's descendants would be left behind")
 	}
 }
 
@@ -87,12 +164,12 @@ func TestReapWithEOFGrace_StillGroupKillsAWedgedLiveChild(t *testing.T) {
 // not have made.
 func TestSoftKillProcessGroup_RefusesAGroupItMayNotSignal(t *testing.T) {
 	var sent []syscall.Signal
-	kill := func(_ int, sig syscall.Signal) error {
+	stubGroupKillSyscall(t, func(_ int, sig syscall.Signal) error {
 		sent = append(sent, sig)
 		return syscall.EPERM
-	}
+	})
 
-	usedSIGKILL := softKillProcessGroupWith(kill, 4242, 50*time.Millisecond)
+	usedSIGKILL := softKillProcessGroup(4242, 50*time.Millisecond, alwaysOurs)
 
 	assert.False(t, usedSIGKILL,
 		"a group we may not signal must not be reported as killed")
@@ -105,7 +182,32 @@ func TestSoftKillProcessGroup_RefusesAGroupItMayNotSignal(t *testing.T) {
 // contract pinned alongside the new EPERM one, so a later simplification of the
 // error handling cannot collapse the two into one answer.
 func TestSoftKillProcessGroup_ReportsNothingForAnEmptyGroup(t *testing.T) {
-	kill := func(int, syscall.Signal) error { return syscall.ESRCH }
+	stubGroupKillSyscall(t, func(int, syscall.Signal) error { return syscall.ESRCH })
 
-	assert.False(t, softKillProcessGroupWith(kill, 4242, 50*time.Millisecond))
+	assert.False(t, softKillProcessGroup(4242, 50*time.Millisecond, alwaysOurs))
+}
+
+// TestSoftKillProcessGroup_RefusesToEscalateOnceTheGroupIsNoLongerOurs covers
+// the window the spawn-time pgid alone does not close. The gate in
+// reapWithEOFGrace is a point-in-time check; the escalation happens a full grace
+// LATER, and the child can exit and be reaped inside that window — freeing its
+// pid, which is also the pgid, for reuse. The SIGKILL at the deadline must not
+// go out on a number that stopped being ours in the meantime.
+func TestSoftKillProcessGroup_RefusesToEscalateOnceTheGroupIsNoLongerOurs(t *testing.T) {
+	var sent []syscall.Signal
+	stubGroupKillSyscall(t, func(_ int, sig syscall.Signal) error {
+		sent = append(sent, sig)
+		return nil // the group answers throughout: only ownership changes
+	})
+
+	// Ours when the SIGTERM goes out, not ours by the time the grace expires.
+	ours := true
+	usedSIGKILL := softKillProcessGroup(4242, 100*time.Millisecond, func() bool {
+		defer func() { ours = false }()
+		return ours
+	})
+
+	assert.False(t, usedSIGKILL, "an escalation onto a pgid that changed hands must not be reported as a kill")
+	assert.NotContains(t, sent, syscall.SIGKILL,
+		"the group-wide SIGKILL went out after the pgid stopped naming our child")
 }

--- a/internal/tmux/softkill_group_reuse_test.go
+++ b/internal/tmux/softkill_group_reuse_test.go
@@ -1,0 +1,111 @@
+package tmux
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reapWithEOFGrace's fallback has two arms and only the narrow one was ever
+// hardened. The else arm — one pid, resolved through its handle — is guarded
+// against the pid having been recycled. The if arm resolved a whole PROCESS
+// GROUP from that same raw pid (syscall.Getpgid(proc.Pid)) and then SIGTERMed
+// it, SIGKILLing 500ms later. Same hazard, strictly wider blast radius, on what
+// was the unguarded arm.
+//
+// A recycled pid cannot be forced here — it would take a pid_max wrap inside
+// the window and prove no more — so these tests hand the fallback a group id
+// that names a stranger, which is what a stored pgid becomes once the number
+// has been handed on. The victim is real: a live helper in a group that is
+// nobody's business but its own.
+
+// TestReapWithEOFGrace_RefusesTheGroupKillOnceTheChildHasBeenWaitedOn is the
+// friendly-fire case. The child has already been reaped, the reap function has
+// not returned yet so the fallback fires, and the group id it was given now
+// belongs to someone else.
+func TestReapWithEOFGrace_RefusesTheGroupKillOnceTheChildHasBeenWaitedOn(t *testing.T) {
+	// The stranger. "ignore" drains SIGTERM, so only the escalation's SIGKILL
+	// can end it — which makes its death unambiguous rather than a race with
+	// its own shutdown.
+	bystander := spawnHelperInOwnGroup(t, "ignore")
+	bystanderExited := waitForExit(t, bystander)
+	strangerPgid := bystander.Process.Pid
+
+	cmd := spawnHelperInOwnGroup(t, "ignore")
+	proc := cmd.Process
+	require.NoError(t, proc.Kill())
+	_, err := proc.Wait() // reaped: from here the number belongs to whoever gets it next
+	require.NoError(t, err)
+
+	release := make(chan struct{})
+	fellBack := make(chan bool, 1)
+	go func() {
+		// A reap that has not returned is the only way into the fallback.
+		fellBack <- reapWithEOFGrace(func() { <-release }, proc, strangerPgid,
+			50*time.Millisecond, 200*time.Millisecond)
+	}()
+
+	// Long enough for the fallback's SIGTERM, its full grace and the SIGKILL
+	// that follows to have landed, if they were ever sent.
+	select {
+	case <-bystanderExited:
+		t.Fatal("a process group that never belonged to this pipe was signalled")
+	case <-time.After(600 * time.Millisecond):
+	}
+
+	close(release)
+	assert.True(t, <-fellBack, "the fallback path must still report that it ran")
+}
+
+// TestReapWithEOFGrace_StillGroupKillsAWedgedLiveChild is the positive control.
+// Failing closed is only worth anything if the fallback still does its job in
+// the case it exists for: a child that ignores both stdin EOF and SIGTERM, and
+// whose handle has NOT been waited on.
+func TestReapWithEOFGrace_StillGroupKillsAWedgedLiveChild(t *testing.T) {
+	cmd := spawnHelperInOwnGroup(t, "ignore")
+	exited := waitForExit(t, cmd)
+
+	usedFallback := reapWithEOFGrace(func() { <-exited }, cmd.Process, cmd.Process.Pid,
+		50*time.Millisecond, 500*time.Millisecond)
+
+	assert.True(t, usedFallback)
+	select {
+	case <-exited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a wedged live child survived the fallback; the guard has made the path inert")
+	}
+}
+
+// TestSoftKillProcessGroup_RefusesAGroupItMayNotSignal covers the second half of
+// the same finding. EPERM from kill(2) is the kernel saying "not one member of
+// that group is yours" — the exact answer a recycled pgid produces. The old
+// branch treated it as a reason to try harder: it escalated to a group-wide
+// SIGKILL and returned true, reporting a kill it had no right to make and could
+// not have made.
+func TestSoftKillProcessGroup_RefusesAGroupItMayNotSignal(t *testing.T) {
+	var sent []syscall.Signal
+	kill := func(_ int, sig syscall.Signal) error {
+		sent = append(sent, sig)
+		return syscall.EPERM
+	}
+
+	usedSIGKILL := softKillProcessGroupWith(kill, 4242, 50*time.Millisecond)
+
+	assert.False(t, usedSIGKILL,
+		"a group we may not signal must not be reported as killed")
+	assert.Equal(t, []syscall.Signal{syscall.SIGTERM}, sent,
+		"escalating after EPERM cannot succeed — the permission check is identical for "+
+			"SIGKILL — so the only thing a second signal can do is reach a group that is not ours")
+}
+
+// TestSoftKillProcessGroup_ReportsNothingForAnEmptyGroup keeps the ESRCH
+// contract pinned alongside the new EPERM one, so a later simplification of the
+// error handling cannot collapse the two into one answer.
+func TestSoftKillProcessGroup_ReportsNothingForAnEmptyGroup(t *testing.T) {
+	kill := func(int, syscall.Signal) error { return syscall.ESRCH }
+
+	assert.False(t, softKillProcessGroupWith(kill, 4242, 50*time.Millisecond))
+}

--- a/internal/tmux/softkill_pid_reuse_test.go
+++ b/internal/tmux/softkill_pid_reuse_test.go
@@ -148,14 +148,17 @@ func TestSoftKillProcessChecked_RefusesWhenIdentityUnknown(t *testing.T) {
 	assert.Error(t, statErr, "no SIGTERM may reach a pid the caller could not identify")
 }
 
-// TestSoftKillProcess_RefusesWhenIdentityUnreadable is the same rule one level
-// up, where the identity is captured by the helper itself rather than handed
-// in. A host on which neither /proc nor `ps` answers must lose the kill, not
-// the guard.
-func TestSoftKillProcess_RefusesWhenIdentityUnreadable(t *testing.T) {
+// TestSoftKillProcessChecked_RefusesWhenTheCurrentIdentityCannotBeRead is the
+// same rule on the other side of the comparison: the caller has an identity,
+// but the live process can no longer be read to check it against. A host on
+// which neither /proc nor `ps` answers must lose the kill, not the guard.
+func TestSoftKillProcessChecked_RefusesWhenTheCurrentIdentityCannotBeRead(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "term-handled")
 	cmd := spawnHelper(t, "clean", "MARKER="+marker)
 	exited := waitForExit(t, cmd)
+
+	identity, err := readProcessIdentity(context.Background(), cmd.Process.Pid)
+	require.NoError(t, err)
 
 	original := processIdentityOf
 	t.Cleanup(func() { processIdentityOf = original })
@@ -163,9 +166,10 @@ func TestSoftKillProcess_RefusesWhenIdentityUnreadable(t *testing.T) {
 		return "", errors.New("no /proc and no ps on this host")
 	}
 
-	usedSIGKILL := softKillProcess(cmd.Process.Pid, 100*time.Millisecond)
+	usedSIGKILL, signalled := softKillProcessChecked(context.Background(), cmd.Process.Pid, identity, 100*time.Millisecond)
 
-	assert.False(t, usedSIGKILL, "an unidentifiable pid must not be escalated to SIGKILL")
+	assert.False(t, signalled, "a pid that cannot be re-identified must not be signalled")
+	assert.False(t, usedSIGKILL, "nor escalated to SIGKILL")
 	select {
 	case <-exited:
 		t.Fatal("a pid whose identity could not be read was signalled anyway")
@@ -175,7 +179,7 @@ func TestSoftKillProcess_RefusesWhenIdentityUnreadable(t *testing.T) {
 	assert.Error(t, statErr, "no SIGTERM may reach a pid whose identity could not be read")
 }
 
-// TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace covers the
+// TestSoftKillProcessChecked_SkipsEscalationWhenPIDRecycledDuringGrace covers the
 // second window, which no caller can close for itself: the victim accepted the
 // SIGTERM, exited inside the grace period, and its number was reissued before
 // the escalation. kill(pid, 0) still succeeds, so the unguarded code reads that
@@ -185,7 +189,7 @@ func TestSoftKillProcess_RefusesWhenIdentityUnreadable(t *testing.T) {
 // one afterwards, which is what a PID handed to a new process looks like from
 // here. The "ignore" helper drains SIGTERM and blocks forever, so it survives
 // to the escalation and its death would be unambiguous evidence of a SIGKILL.
-func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T) {
+func TestSoftKillProcessChecked_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T) {
 	cmd := spawnHelper(t, "ignore")
 	pid := cmd.Process.Pid
 
@@ -195,14 +199,14 @@ func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T)
 	original := processIdentityOf
 	t.Cleanup(func() { processIdentityOf = original })
 
-	// Two reads happen before the SIGTERM — softKillProcess captures the
-	// identity, then the pre-signal check confirms it — and both must agree or
-	// the SIGTERM never goes out and the escalation is never reached. Every
-	// read after that is the escalation check, which must see a stranger.
+	// One read happens before the SIGTERM — the pre-signal check — and it must
+	// agree with the captured identity or the SIGTERM never goes out and the
+	// escalation is never reached. Every read after that is the escalation
+	// check, which must see a stranger.
 	calls := 0
 	processIdentityOf = func(ctx context.Context, p int) (string, error) {
 		calls++
-		if calls <= 2 {
+		if calls <= 1 {
 			return live, nil
 		}
 		return "recycled-during-grace", nil
@@ -210,16 +214,17 @@ func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T)
 
 	exited := waitForExit(t, cmd)
 
-	usedSIGKILL := softKillProcess(pid, 100*time.Millisecond)
+	usedSIGKILL, signalled := softKillProcessChecked(context.Background(), pid, live, 100*time.Millisecond)
 
 	assert.False(t, usedSIGKILL, "escalation must not fire once the pid changed hands")
+	assert.True(t, signalled, "the SIGTERM half did go out; only the escalation was refused")
 	// Without this, the test passes just as happily when the SIGTERM never went
 	// out at all — a pre-signal check that started failing would skip straight
 	// past the escalation this test exists to cover, and usedSIGKILL would be
-	// false for the wrong reason. The third read IS the escalation check, so
+	// false for the wrong reason. The second read IS the escalation check, so
 	// reaching it proves the guarded path ran end to end.
-	assert.GreaterOrEqual(t, calls, 3,
-		"the escalation check must have been reached (capture, pre-signal check, then escalation)")
+	assert.GreaterOrEqual(t, calls, 2,
+		"the escalation check must have been reached (pre-signal check, then escalation)")
 	select {
 	case <-exited:
 		t.Fatal("the new occupant of the pid was SIGKILL'd by the escalation")

--- a/internal/tmux/softkill_pid_reuse_test.go
+++ b/internal/tmux/softkill_pid_reuse_test.go
@@ -1,0 +1,263 @@
+package tmux
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A PID is not a stable name for a process. The sweeps in this file signal PIDs
+// they read out of a `list-clients` snapshot, and between that read and the
+// signal the client can exit and the kernel can hand its number to something
+// else. Two windows exist:
+//
+//   - Snapshot → SIGTERM. reapStaleControlClients kills sequentially and
+//     softKillProcess blocks up to controlClientKillGrace per victim, so with N
+//     stale clients the last line of the snapshot is up to N × 500ms old by the
+//     time it is acted on.
+//   - SIGTERM → SIGKILL. The escalation fires grace later, and the poll that
+//     decides it uses kill(pid, 0) — which cannot tell "still alive" from
+//     "died and the number was reissued".
+//
+// The guard is an identity captured with the decision and re-checked against
+// the live process immediately before each signal. These tests pin that the
+// guard blocks a signal when the identity no longer matches, and — just as
+// important — that it does not otherwise change who gets killed.
+
+// TestReadProcessIdentity_StableForOneIncarnation pins the property the guard
+// rests on: reading the same live process twice yields the same identity, so a
+// mismatch means the PID changed hands rather than that the read is noisy.
+func TestReadProcessIdentity_StableForOneIncarnation(t *testing.T) {
+	first, err := readProcessIdentity(os.Getpid())
+	require.NoError(t, err, "own identity must be readable")
+	require.NotEmpty(t, first, "identity must not be empty for a live process")
+
+	time.Sleep(20 * time.Millisecond)
+
+	second, err := readProcessIdentity(os.Getpid())
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "identity must not drift while the process lives")
+}
+
+// TestReadProcessIdentity_FailsForDeadProcess pins that a reaped PID has no
+// identity to compare against, which is what makes the guard fail closed for a
+// victim that is already gone.
+func TestReadProcessIdentity_FailsForDeadProcess(t *testing.T) {
+	cmd := spawnHelper(t, "clean")
+	pid := cmd.Process.Pid
+	require.NoError(t, cmd.Process.Kill())
+	_, _ = cmd.Process.Wait()
+
+	_, err := readProcessIdentity(pid)
+	assert.Error(t, err, "a reaped pid must not report an identity")
+}
+
+// TestSoftKillProcessChecked_SignalsWhenIdentityMatches is the no-regression
+// half: the guard must not turn the sweep inert. The child's SIGTERM handler
+// writes a marker, and SIGKILL cannot be trapped, so the marker is proof the
+// TERM path ran.
+func TestSoftKillProcessChecked_SignalsWhenIdentityMatches(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+	pid := cmd.Process.Pid
+
+	// Reap concurrently so the kill(pid, 0) poll sees ESRCH rather than a
+	// zombie — production has tmux reaping its own clients.
+	waitForExit(t, cmd)
+
+	identity, err := readProcessIdentity(pid)
+	require.NoError(t, err)
+
+	_, signalled := softKillProcessChecked(pid, identity, 500*time.Millisecond)
+
+	assert.True(t, signalled, "a matching identity must report the kill as delivered")
+	assert.NoError(t, waitForFile(marker, 5*time.Second),
+		"a matching identity must not block the SIGTERM")
+}
+
+// TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged is the guard doing
+// its job on the snapshot→SIGTERM window. A stale identity stands in for the
+// real hazard — the PID we validated died and its number now belongs to an
+// unrelated process — because forcing a genuine PID wrap inside a test would
+// take pid_max allocations and prove no more than this does.
+//
+// Both assertions matter: the process outliving the call proves no signal of
+// either kind landed, and the marker's absence identifies which one would have
+// (the "clean" helper writes it from its SIGTERM handler).
+func TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+	pid := cmd.Process.Pid
+
+	// Survival is asserted by waiting on the process rather than by
+	// kill(pid, 0): between a signal landing and the parent's wait() the pid
+	// is a zombie that still answers signal 0, so a bare liveness probe would
+	// pass against the unguarded code and prove nothing.
+	exited := waitForExit(t, cmd)
+
+	usedSIGKILL, signalled := softKillProcessChecked(pid, "not-the-identity-we-validated", 100*time.Millisecond)
+
+	assert.False(t, usedSIGKILL, "a process we refused to signal cannot have been SIGKILL'd")
+	// The caller counts kills and logs one line per victim from this flag, so a
+	// skipped signal must not be reported as a kill.
+	assert.False(t, signalled, "a skipped signal must not be reported as delivered")
+
+	select {
+	case <-exited:
+		t.Fatal("a pid whose identity changed was signalled anyway")
+	case <-time.After(300 * time.Millisecond):
+	}
+	_, statErr := os.Stat(marker)
+	assert.Error(t, statErr, "no SIGTERM may reach a pid whose identity changed")
+}
+
+// TestSoftKillProcessChecked_RefusesWhenIdentityUnknown pins the fail-closed
+// rule at the boundary where it is cheapest to get wrong: an identity the
+// caller never established.
+//
+// An earlier revision of this guard proceeded here, on the argument that a host
+// unable to report start times should keep the #595 cleanup it had before.
+// That is the wrong way round for code whose failure mode is SIGKILLing a live
+// process: an inert sweep is recoverable and, since every refusal is logged,
+// visible — a kill aimed at a pid nothing can tie to a real decision is
+// neither. Nothing may be signalled, and the caller must not be told a kill
+// happened.
+func TestSoftKillProcessChecked_RefusesWhenIdentityUnknown(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+	exited := waitForExit(t, cmd)
+
+	usedSIGKILL, signalled := softKillProcessChecked(cmd.Process.Pid, "", 500*time.Millisecond)
+
+	assert.False(t, signalled, "an unidentified pid must not be reported as signalled")
+	assert.False(t, usedSIGKILL, "an unidentified pid must not be escalated to SIGKILL")
+	select {
+	case <-exited:
+		t.Fatal("an unidentified pid was signalled anyway")
+	case <-time.After(300 * time.Millisecond):
+	}
+	_, statErr := os.Stat(marker)
+	assert.Error(t, statErr, "no SIGTERM may reach a pid the caller could not identify")
+}
+
+// TestSoftKillProcess_RefusesWhenIdentityUnreadable is the same rule one level
+// up, where the identity is captured by the helper itself rather than handed
+// in. A host on which neither /proc nor `ps` answers must lose the kill, not
+// the guard.
+func TestSoftKillProcess_RefusesWhenIdentityUnreadable(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "term-handled")
+	cmd := spawnHelper(t, "clean", "MARKER="+marker)
+	exited := waitForExit(t, cmd)
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+	processIdentityOf = func(int) (string, error) {
+		return "", errors.New("no /proc and no ps on this host")
+	}
+
+	usedSIGKILL := softKillProcess(cmd.Process.Pid, 100*time.Millisecond)
+
+	assert.False(t, usedSIGKILL, "an unidentifiable pid must not be escalated to SIGKILL")
+	select {
+	case <-exited:
+		t.Fatal("a pid whose identity could not be read was signalled anyway")
+	case <-time.After(300 * time.Millisecond):
+	}
+	_, statErr := os.Stat(marker)
+	assert.Error(t, statErr, "no SIGTERM may reach a pid whose identity could not be read")
+}
+
+// TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace covers the
+// second window, which no caller can close for itself: the victim accepted the
+// SIGTERM, exited inside the grace period, and its number was reissued before
+// the escalation. kill(pid, 0) still succeeds, so the unguarded code reads that
+// as "ignored my SIGTERM" and SIGKILLs whoever holds the number now.
+//
+// The seam supplies the real identity for the pre-SIGTERM check and a different
+// one afterwards, which is what a PID handed to a new process looks like from
+// here. The "ignore" helper drains SIGTERM and blocks forever, so it survives
+// to the escalation and its death would be unambiguous evidence of a SIGKILL.
+func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T) {
+	cmd := spawnHelper(t, "ignore")
+	pid := cmd.Process.Pid
+
+	live, err := readProcessIdentity(pid)
+	require.NoError(t, err)
+
+	original := processIdentityOf
+	t.Cleanup(func() { processIdentityOf = original })
+
+	// Two reads happen before the SIGTERM — softKillProcess captures the
+	// identity, then the pre-signal check confirms it — and both must agree or
+	// the SIGTERM never goes out and the escalation is never reached. Every
+	// read after that is the escalation check, which must see a stranger.
+	calls := 0
+	processIdentityOf = func(p int) (string, error) {
+		calls++
+		if calls <= 2 {
+			return live, nil
+		}
+		return "recycled-during-grace", nil
+	}
+
+	exited := waitForExit(t, cmd)
+
+	usedSIGKILL := softKillProcess(pid, 100*time.Millisecond)
+
+	assert.False(t, usedSIGKILL, "escalation must not fire once the pid changed hands")
+	// Without this, the test passes just as happily when the SIGTERM never went
+	// out at all — a pre-signal check that started failing would skip straight
+	// past the escalation this test exists to cover, and usedSIGKILL would be
+	// false for the wrong reason. The third read IS the escalation check, so
+	// reaching it proves the guarded path ran end to end.
+	assert.GreaterOrEqual(t, calls, 3,
+		"the escalation check must have been reached (capture, pre-signal check, then escalation)")
+	select {
+	case <-exited:
+		t.Fatal("the new occupant of the pid was SIGKILL'd by the escalation")
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// waitForExit reaps cmd in ONE owning goroutine and returns a channel closed
+// when it exits. Waiting is the only conclusive way to assert a process was NOT
+// signalled: a killed-but-unwaited child stays a zombie that answers
+// kill(pid, 0) with nil, so a liveness probe passes whether or not the signal
+// was sent (see the bash/zombie notes in CLAUDE.md).
+//
+// It also registers the teardown for the survival tests, which is not
+// decoration: every one of them asserts that a helper is STILL RUNNING at the
+// end, and two of the helper roles ("ignore", "clean" pre-SIGTERM) block
+// forever by design. Left to itself such a helper outlives the test binary.
+// spawnHelper's registerOrphanReaper is the backstop for that, but it Waits on
+// the same process this goroutine is already blocked in — two concurrent Waits
+// on one os.Process, where whichever loses gets ECHILD and the reap that
+// actually happened is a matter of scheduling. Stopping the child here, and
+// blocking until this goroutine's Wait returns, makes the teardown a single
+// ordered kill-then-reap instead. Cleanups run LIFO, so this one runs before
+// the backstop, which then finds nothing to do.
+func waitForExit(t *testing.T, cmd *exec.Cmd) <-chan struct{} {
+	t.Helper()
+	exited := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		select {
+		case <-exited:
+		case <-time.After(5 * time.Second):
+			t.Errorf("helper pid %d did not exit after SIGKILL; a test child was leaked",
+				cmd.Process.Pid)
+		}
+	})
+	return exited
+}

--- a/internal/tmux/softkill_pid_reuse_test.go
+++ b/internal/tmux/softkill_pid_reuse_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -35,13 +36,13 @@ import (
 // rests on: reading the same live process twice yields the same identity, so a
 // mismatch means the PID changed hands rather than that the read is noisy.
 func TestReadProcessIdentity_StableForOneIncarnation(t *testing.T) {
-	first, err := readProcessIdentity(os.Getpid())
+	first, err := readProcessIdentity(context.Background(), os.Getpid())
 	require.NoError(t, err, "own identity must be readable")
 	require.NotEmpty(t, first, "identity must not be empty for a live process")
 
 	time.Sleep(20 * time.Millisecond)
 
-	second, err := readProcessIdentity(os.Getpid())
+	second, err := readProcessIdentity(context.Background(), os.Getpid())
 	require.NoError(t, err)
 	assert.Equal(t, first, second, "identity must not drift while the process lives")
 }
@@ -55,7 +56,7 @@ func TestReadProcessIdentity_FailsForDeadProcess(t *testing.T) {
 	require.NoError(t, cmd.Process.Kill())
 	_, _ = cmd.Process.Wait()
 
-	_, err := readProcessIdentity(pid)
+	_, err := readProcessIdentity(context.Background(), pid)
 	assert.Error(t, err, "a reaped pid must not report an identity")
 }
 
@@ -72,10 +73,10 @@ func TestSoftKillProcessChecked_SignalsWhenIdentityMatches(t *testing.T) {
 	// zombie — production has tmux reaping its own clients.
 	waitForExit(t, cmd)
 
-	identity, err := readProcessIdentity(pid)
+	identity, err := readProcessIdentity(context.Background(), pid)
 	require.NoError(t, err)
 
-	_, signalled := softKillProcessChecked(pid, identity, 500*time.Millisecond)
+	_, signalled := softKillProcessChecked(context.Background(), pid, identity, 500*time.Millisecond)
 
 	assert.True(t, signalled, "a matching identity must report the kill as delivered")
 	assert.NoError(t, waitForFile(marker, 5*time.Second),
@@ -102,7 +103,7 @@ func TestSoftKillProcessChecked_SkipsSignalWhenIdentityChanged(t *testing.T) {
 	// pass against the unguarded code and prove nothing.
 	exited := waitForExit(t, cmd)
 
-	usedSIGKILL, signalled := softKillProcessChecked(pid, "not-the-identity-we-validated", 100*time.Millisecond)
+	usedSIGKILL, signalled := softKillProcessChecked(context.Background(), pid, "not-the-identity-we-validated", 100*time.Millisecond)
 
 	assert.False(t, usedSIGKILL, "a process we refused to signal cannot have been SIGKILL'd")
 	// The caller counts kills and logs one line per victim from this flag, so a
@@ -134,7 +135,7 @@ func TestSoftKillProcessChecked_RefusesWhenIdentityUnknown(t *testing.T) {
 	cmd := spawnHelper(t, "clean", "MARKER="+marker)
 	exited := waitForExit(t, cmd)
 
-	usedSIGKILL, signalled := softKillProcessChecked(cmd.Process.Pid, "", 500*time.Millisecond)
+	usedSIGKILL, signalled := softKillProcessChecked(context.Background(), cmd.Process.Pid, "", 500*time.Millisecond)
 
 	assert.False(t, signalled, "an unidentified pid must not be reported as signalled")
 	assert.False(t, usedSIGKILL, "an unidentified pid must not be escalated to SIGKILL")
@@ -158,7 +159,7 @@ func TestSoftKillProcess_RefusesWhenIdentityUnreadable(t *testing.T) {
 
 	original := processIdentityOf
 	t.Cleanup(func() { processIdentityOf = original })
-	processIdentityOf = func(int) (string, error) {
+	processIdentityOf = func(context.Context, int) (string, error) {
 		return "", errors.New("no /proc and no ps on this host")
 	}
 
@@ -188,7 +189,7 @@ func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T)
 	cmd := spawnHelper(t, "ignore")
 	pid := cmd.Process.Pid
 
-	live, err := readProcessIdentity(pid)
+	live, err := readProcessIdentity(context.Background(), pid)
 	require.NoError(t, err)
 
 	original := processIdentityOf
@@ -199,7 +200,7 @@ func TestSoftKillProcess_SkipsEscalationWhenPIDRecycledDuringGrace(t *testing.T)
 	// the SIGTERM never goes out and the escalation is never reached. Every
 	// read after that is the escalation check, which must see a stranger.
 	calls := 0
-	processIdentityOf = func(p int) (string, error) {
+	processIdentityOf = func(ctx context.Context, p int) (string, error) {
 		calls++
 		if calls <= 2 {
 			return live, nil

--- a/internal/tmux/softkill_test.go
+++ b/internal/tmux/softkill_test.go
@@ -395,7 +395,7 @@ func TestControlPipeClose_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 		<-waitDone
 	})
 
-	_ = softKillProcessGroup(pgid, 500*time.Millisecond)
+	_ = softKillProcessGroup(pgid, 500*time.Millisecond, alwaysOurs)
 
 	select {
 	case <-waitDone:
@@ -444,7 +444,7 @@ func TestControlPipeClose_FallsBackToSIGKILL(t *testing.T) {
 	})
 
 	start := time.Now()
-	usedSIGKILL := softKillProcessGroup(pgid, 500*time.Millisecond)
+	usedSIGKILL := softKillProcessGroup(pgid, 500*time.Millisecond, alwaysOurs)
 	elapsed := time.Since(start)
 
 	select {
@@ -613,6 +613,6 @@ func TestSoftKillProcessGroup_AlreadyDeadIsNoop(t *testing.T) {
 	require.NoError(t, err)
 	_, _ = cmd.Process.Wait() // fully reap; group is now empty
 
-	usedSIGKILL := softKillProcessGroup(pgid, 100*time.Millisecond)
+	usedSIGKILL := softKillProcessGroup(pgid, 100*time.Millisecond, alwaysOurs)
 	assert.False(t, usedSIGKILL, "already-empty pgroup should not trigger SIGKILL")
 }

--- a/internal/tmux/softkill_test.go
+++ b/internal/tmux/softkill_test.go
@@ -525,7 +525,7 @@ func TestReapWithEOFGrace_FastPathOnEOF(t *testing.T) {
 	// takes >200ms). The assertion that matters is usedFallback=false +
 	// antimarker-absence, not strict timing — those prove the EOF path
 	// completed without a signal.
-	usedFallback := reapWithEOFGrace(reap, cmd.Process, 5*time.Second, 500*time.Millisecond)
+	usedFallback := reapWithEOFGrace(reap, cmd.Process, cmd.Process.Pid, 5*time.Second, 500*time.Millisecond)
 
 	assert.False(t, usedFallback, "EOF-clean child must not trigger signal-driven fallback")
 
@@ -559,7 +559,7 @@ func TestReapWithEOFGrace_FallbackOnHungChild(t *testing.T) {
 
 	start := time.Now()
 	// Short eofGrace so the test runs fast; killGrace controls SIGTERM→SIGKILL.
-	usedFallback := reapWithEOFGrace(reap, cmd.Process, 50*time.Millisecond, 200*time.Millisecond)
+	usedFallback := reapWithEOFGrace(reap, cmd.Process, pgid, 50*time.Millisecond, 200*time.Millisecond)
 	elapsed := time.Since(start)
 
 	assert.True(t, usedFallback, "hung child must trigger signal-driven fallback")
@@ -593,7 +593,7 @@ func TestReapWithEOFGrace_AlreadyDeadIsNoop(t *testing.T) {
 		})
 	}
 
-	usedFallback := reapWithEOFGrace(reap, proc, 100*time.Millisecond, 100*time.Millisecond)
+	usedFallback := reapWithEOFGrace(reap, proc, proc.Pid, 100*time.Millisecond, 100*time.Millisecond)
 	assert.False(t, usedFallback, "already-exiting child should not trigger fallback")
 	assert.True(t, reaped, "reap function must have been called")
 }

--- a/internal/tmux/softkill_test.go
+++ b/internal/tmux/softkill_test.go
@@ -260,7 +260,7 @@ func TestKillStaleControlClients_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 		<-waitDone
 	})
 
-	_ = softKillProcess(pid, 500*time.Millisecond)
+	_ = softKillProcessHandle(cmd.Process, 500*time.Millisecond)
 
 	// Let the reaper goroutine finish before asserting on the marker.
 	select {
@@ -270,7 +270,7 @@ func TestKillStaleControlClients_TerminatesCleanlyOnSIGTERM(t *testing.T) {
 
 	// Marker must exist — proves the child actually ran its SIGTERM
 	// handler. SIGKILL cannot be trapped, so a missing marker means
-	// softKillProcess skipped SIGTERM and went straight to SIGKILL —
+	// softKillProcessHandle skipped SIGTERM and went straight to SIGKILL —
 	// exactly the #737 regression we're guarding against.
 	//
 	// We deliberately do NOT assert on softKillProcess's return value
@@ -328,7 +328,7 @@ func TestKillStaleControlClients_FallsBackToSIGKILL(t *testing.T) {
 	})
 
 	start := time.Now()
-	usedSIGKILL := softKillProcess(pid, 500*time.Millisecond)
+	usedSIGKILL := softKillProcessHandle(cmd.Process, 500*time.Millisecond)
 	elapsed := time.Since(start)
 
 	select {
@@ -336,10 +336,10 @@ func TestKillStaleControlClients_FallsBackToSIGKILL(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 	}
 
-	assert.True(t, usedSIGKILL, "softKillProcess must escalate to SIGKILL when TERM is ignored")
+	assert.True(t, usedSIGKILL, "softKillProcessHandle must escalate to SIGKILL when TERM is ignored")
 	// Allow generous slack for scheduler jitter — the important
 	// invariant is that it didn't hang for seconds.
-	assert.Less(t, elapsed, 1500*time.Millisecond, "softKillProcess should return promptly after grace")
+	assert.Less(t, elapsed, 1500*time.Millisecond, "softKillProcessHandle should return promptly after grace")
 
 	// Confirm the child is actually dead.
 	err := syscall.Kill(pid, 0)
@@ -347,7 +347,7 @@ func TestKillStaleControlClients_FallsBackToSIGKILL(t *testing.T) {
 }
 
 // TestSoftKillProcess_AlreadyDeadIsNoop asserts that calling
-// softKillProcess on a PID that is already gone returns false (no
+// softKillProcessHandle on a child that is already gone returns false (no
 // SIGKILL needed) and does not panic.
 func TestSoftKillProcess_AlreadyDeadIsNoop(t *testing.T) {
 	cmd := exec.Command("sh", "-c", "exit 0")
@@ -356,9 +356,10 @@ func TestSoftKillProcess_AlreadyDeadIsNoop(t *testing.T) {
 	pid := cmd.Process.Pid
 	_, _ = cmd.Process.Wait() // fully reap
 
-	// Race: pid may be recycled on extremely fast systems, but for a
-	// freshly-reaped pid within the same goroutine this is stable.
-	usedSIGKILL := softKillProcess(pid, 100*time.Millisecond)
+	// No recycling race to reason about: the handle refuses to signal once
+	// the child has been waited on, whoever holds the number by then.
+	_ = pid
+	usedSIGKILL := softKillProcessHandle(cmd.Process, 100*time.Millisecond)
 	assert.False(t, usedSIGKILL, "already-dead pid should not trigger SIGKILL")
 }
 

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -114,6 +114,16 @@ func runTestMain(m *testing.M) int {
 	cleanupBootstrap := bootstrapTmuxServer()
 	defer cleanupBootstrap()
 
+	// Keep the process-wide orphan sweep from firing implicitly. Every
+	// PipeManager.Connect calls startOrphanReapOnce, and the sweep walks all of
+	// /proc and SIGTERMs what it judges — against the developer's real process
+	// table, since /proc has no isolated equivalent of TMUX_TMPDIR. Inline that
+	// was at least ordered; launched in the background it would also race the
+	// tests that swap its seams. Marking it already-started means no Connect
+	// launches one, and both halves are covered directly instead
+	// (orphan_reap_identity_test.go, orphan_reap_budget_test.go).
+	orphanReapStarted.Store(true)
+
 	// Force _test profile for all tests in this package
 	os.Setenv("AGENTDECK_PROFILE", "_test")
 


### PR DESCRIPTION
## What problem does this solve?

`reapOrphanedPollClients` never reaped anything on Linux: it filtered on `comm == "tmux"`, and tmux renames both roles after startup (`tmux: client` / `tmux: server`), so the equality test matched no process at all. Two orphaned one-shot query clients spun at ~98% CPU for 14 hours as a result.

This is the composed, current-`main` chain for that whole area, as asked for on #1832, #1837 and #1872 (2026-08-14): alias handling, live identity, PID reuse, bounded teardown, and no signalling of unrelated processes, in one reviewable branch. It supersedes all three.

## Why this change

The sweep is kill-safety code with a fleet-destroying incident behind it, so each layer here exists because the one before it turned out not to be a boundary.

1. **comm matching** (commits 1–3, unchanged from #1832). Match the role token, not the program name; refuse to classify a comm whose role was truncated away.
2. **Live identity replaces the argv denylist** (commit 4, @asheshgoplani's from #1837, carrying his authorship, date and message). **Correction, raised in review and correct:** the content is not unchanged. That commit also folds in his own follow-up `c3e1f3a0` — +7 lines in `orphan_reap_live_identity_test.go`, six `-S`→`-L` substitutions — which should have been said here or carried as its own commit. Oversight, not intent; stated now rather than quietly left. `neverReapVerbs` matched literal verb strings, and tmux resolves command names by unambiguous prefix — `attach`, `attac`, `att`, `at`, bare `a` all reach `attach-session`, so a chained `tmux attach -t agentdeck_x \; set-option status on` cleared the denylist while `set-option` satisfied the allowlist. `isLiveTmuxClientOrServer` asks the server instead (`#{pid}`, `list-clients`); registration happens on connect, so there is no spelling to get around it.
3. **Identity across the gauntlet** (commit 5). Every check reads /proc or a tmux server *for a PID*, and a PID is not a stable name for a process. The identity (starttime, field 22 of `/proc/<pid>/stat`) is captured **before** the classify reads, which are bracketed by two identity reads that must agree, and re-checked immediately before each signal. Capturing it at kill time — as the first version of this guard did — defeats it in the exact case it exists for: the facts would describe the process that died and the identity the one that took its number, and they would agree at signal time.
4. **Fail closed** (commit 5). A pid whose identity cannot be read is not signalled at all. The earlier revision proceeded there, reasoning that a host unable to report start times should keep the #595 cleanup it had. That trade is the wrong way round for code whose failure mode is SIGKILLing a live process: an inert sweep is recoverable and, since every refusal is logged and counted, visible — a kill aimed at a pid nothing can tie to a decision is neither.
5. **One deadline, off the Connect path** (commit 6), which is the review finding on #1837. Asking a tmux server per candidate is not free, and the queries are slowest exactly on the unhealthy host that produced the orphans. The whole sweep now runs under one budget that every probe derives from (the per-probe caps nest inside it, so one wedged probe cannot starve the rest), and it is launched in the background — nothing on the Connect path consumes its result.

6. **The other sweep, and the reporting** (commit 7, after an adversarial review of the chain). `reapStaleControlClients` still had the window this chain claims to close: killing is sequential and each victim can hold the loop for a full grace, so with the identity captured inline the Nth pid was identified N × grace after tmux listed it — and it has no comm check and no live query to catch a recycled pid, only `isControlClientOrphan`, which calls anything not parented to agent-deck an orphan. Identities for the whole snapshot are now captured before the first kill. Owned children (`reapWithEOFGrace` → `ControlPipe.Close`, `KeySender.Close`) are signalled through their `*os.Process` rather than a pid, which is the "stable OS handle" half of the same problem and cannot land on a recycled number by construction. EPERM is no longer counted and logged as a kill.

Deliberately **not** done: caching the two tmux queries per socket. A cached client list can go stale inside one sweep, and a client that connects mid-sweep would then be absent from the cache and eligible to be killed. Freshness is the safety property; the fix for the cost is to stop blocking startup on it.

## User impact

Leaked one-shot tmux clients are actually reaped on Linux instead of spinning at 100% CPU until reboot. Session startup no longer waits on that sweep. Nothing a live client, a live server, or an unidentifiable process does can get it killed — every uncertain path refuses and says so in the log.

One limitation worth stating plainly, measured on tmux 3.0a (the version the incident happened on): a server that is running but holds **zero sessions** answers both identity queries with `no current target`, so orphans left behind on such a server are unclassifiable and therefore never reaped. Refusing is the correct verdict, but it does mean the incident-shaped host is not fully covered. (The *other* half of that sentence in the original version of this body — that "cannot reach a server" is indistinguishable from "reached a different server" — was true when written and is not any more: see ask 1 below.) Widening it needs a query that identifies a server without a session; that is a change to make deliberately, not by relaxing a kill guard. It is documented at `isLiveTmuxClientOrServer` and named in the skip log.

## Evidence

Measured on this host (Linux 5.4, tmux 3.0a, 982 processes):

```
EVIDENCE: /proc entries=982  collect=14.783734ms  candidates=5  unidentifiable=0
EVIDENCE: identity read avg=16.457µs
```

Per-query cost of the live-identity check against a real server, and against a socket with no server:

```
$ for i in 1 2 3 4 5; do /usr/bin/time -f '%e s' tmux -L evid display-message -p '#{pid}'; done
99833 0.00 s
99833 0.01 s
99833 0.01 s
99833 0.00 s
99833 0.00 s
$ /usr/bin/time -f '%e s' tmux -L definitely-not-here display-message -p '#{pid}'
error connecting to .../definitely-not-here (No such file or directory)   0.00 s
```

So the healthy case is milliseconds; the cost only appears when a server is wedged, where each query rides its 2s cap. That is the case the budget and the background launch exist for — before this, N wedged candidates cost N × ~4s **on the Connect path**, serialised behind a `sync.Once` that every other session's Connect waited on.

Startup cost after the change is one CAS and a `go` statement. `TestStartOrphanReapOnce_RunsInTheBackgroundExactlyOnce` fails if the caller ever blocks on the sweep again: it stubs the sweep to block, asserts the launcher returned anyway, and asserts a second call does not queue a second sweep.

Package suite, sandboxed, serial (`-p 1`, per this repo's tmux-contention note), with and without the race detector:

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/tmux/ -count=1 -p 1
ok  	github.com/asheshgoplani/agent-deck/internal/tmux	57.575s

$ ... go test ./internal/tmux/ -count=1 -p 1 -race
ok  	github.com/asheshgoplani/agent-deck/internal/tmux	83.098s

$ golangci-lint run ./internal/tmux/...
0 issues.

$ go build ./... && go vet ./...     # clean
$ gofmt -l internal/tmux/            # clean
```

Whole suite sandboxed (`go test ./... -count=1 -p 1`): three failures, every one of them reproduced on pristine `upstream/main` in a worktree on this same host, and none in a touched package.

```
--- FAIL: TestPersistence_TmuxDiesWithoutUserScope   # cgroup v2 only; this host is cgroup v1
--- FAIL: TestAggregateSize_ReportsLargestClient     # tmux 3.0a reports 80x23, test wants 80x24
--- FAIL: TestPerf_ColdStart_Help                    # perf budget on a loaded box
```

The perf one is load-sensitive rather than environmental — re-run on an idle box it passes on this branch (`--help` trimmed mean 32.1ms against a 40ms budget), and CI sets `PERF_BUDGET_MULTIPLIER=2.0` for exactly this reason.

Re-run after the review response (commits 10–14), stated separately because the scope differs — this round is `./internal/...`, not the whole `./...` above:

```
$ go test ./internal/tmux/ -p 1 -count=1
ok  	github.com/asheshgoplani/agent-deck/internal/tmux	61.488s

$ go test ./internal/... -p 1 -count=1     # ×3, identical each time
--- FAIL: TestPersistence_TmuxDiesWithoutUserScope   # cgroup v2 only; this host is cgroup v1
--- FAIL: TestAggregateSize_ReportsLargestClient     # tmux 3.0a reports 80x23, test wants 80x24
```

Same two environment failures as above, in untouched packages, and no others. `-race` green on every test touched or added; `gofmt`, `go vet ./internal/tmux/` and `go build ./...` clean.

New tests, all against real processes rather than synthetic argv, since the code under test reads /proc for itself:

- `TestReadOrphanCandidate_AcceptsAStableCandidate` — the no-regression half: bracketing must not stop the collector collecting.
- `TestReadOrphanCandidate_DropsWhenIdentityChangesBetweenReads` / `_DropsWhenIdentityUnreadable` — facts spanning two incarnations produce no candidate, and the drop is reported rather than silent.
- `TestSweepOrphanCandidates_KillsAnIdentifiedOrphan` — positive control; the guard must not make the sweep inert again.
- `TestSweepOrphanCandidates_RefusesWhenPIDChangesHandsDuringTheLiveQuery` — the boundary this chain exists for. Fails if the identity is ever captured at kill time again.
- `TestSoftKillProcessChecked_RefusesWhenIdentityUnknown`, `TestSoftKillProcess_RefusesWhenIdentityUnreadable` — fail-closed at both levels.
- `TestSweepOrphanCandidates_StopsAndReportsWhenTheBudgetIsSpent` / `_BudgetIsAggregateNotPerCandidate`, `TestIsLiveTmuxClientOrServer_RefusesOnceTheBudgetIsSpent` — one aggregate deadline, and the per-probe caps nesting inside it.

- `TestReapStaleControlClients_RefusesAPIDRecycledDuringAnEarlierVictimsGrace` — the other sweep's window: a first victim that ignores SIGTERM holds the loop for a full grace while a second victim's identity changes underneath it. Fails against the inline capture.
- `TestKillStaleControlClients_LaunchesTheOrphanSweep` — the wiring; without it the launcher call could be deleted with the suite still green.

The chain was then reviewed adversarially end to end (independent model, mutation-testing each guard: every headline test was confirmed to fail against its corresponding unfixed behaviour). Commit 7 is that review's fallout — see its message. No path in the orphan sweep was found that signals a live client, a live server, or a pid the facts were not read from.

Candidates in those tests are spawned through a symlink named `tmux` (the kernel takes comm from the execve path's basename) and reparented away from the test binary, so the comm classification and `isControlClientOrphan`'s parentage check answer for the real reason instead of by accident.

Survival tests now stop and reap their helper children through a single owning goroutine. The previous shape left that to a backstop cleanup that `Wait`s on the same process the test's own goroutine is blocked in, so which of the two concurrent `Wait`s reaped the child was a matter of scheduling.

Last commit is test-only and worth flagging: `reparentedControlClient` waited for `ppid == 1`, but the kernel hands an orphan to the nearest **subreaper**, which under a `systemd --user` session is the user manager. All three chained/abbreviated/full-verb attach tests failed the deadline on such a host — including the box this was developed on — against correct code. They now wait for "no longer the wrapper shell's child", which is the property the helper actually needs.

Self-check (`BASE_REF=upstream/main`), stated rather than left silent — now **14 PASS / 1 WARN / 1 FAIL**:

- **revert-check** — the tests do not compile against the base commit, because they exercise symbols this branch introduces (`readOrphanCandidate`, `sweepOrphanCandidates`, `startOrphanReapOnce`, the budgeted signatures). Expected for a change that adds a mechanism rather than altering one.
- **diff-size (now a FAIL, not a WARN)** — the review response added ~1000 lines, most of them tests, so the gate now flags it as needs-discussion for want of a linked issue. Set `LINKED_ISSUE=` or read it as already-discussed: this is the composed chain of #1832 + #1837 + #1872 that the 2026-08-14 reviews asked for plus the fixes the 2026-08-16 reviews asked for, not one problem grown large. It splits along its own commit boundaries if you would rather take it in pieces, and each commit builds, vets and tests green on its own.

## Response to the 2026-08-16 review (commits 10–14)

Both reviewers returned FAIL on the same hole, reached two ways: the ownership boundary was unproven, and the suite could not have proven it. Reviewer A's route is the one worth repeating — every case in `orphan_reap_live_identity_test.go` creates the server with `-L <sock>` and puts that same `-L <sock>` in the candidate argv, so the candidate's socket always equalled the resolved socket and the wrong-server case was untested *by construction*. Green CI was never going to say anything about it.

1. **Resolve the candidate's socket from the candidate** (`29df9724`). `candidateSocketPath` reads `/proc/<pid>/environ` and, with the candidate's own argv, resolves the socket tmux actually picked; it is compared against the socket the query will reach. Differ, or unreadable, and the verdict is `ok=false`. A same-uid candidate in another **mount namespace** is also refused: a path only names a file within one namespace, so a container process resolves to a byte-identical string that is a different socket — the false-match direction, which costs a live client rather than a leaked one. It needs no reach the environ read did not already need (both gated by `PTRACE_MODE_READ`, checked on a same-uid non-descendant under yama `ptrace_scope=1`).

2. **getopt spellings** (`af019817`, then corrected in `26c53183`). `-L work`, `-Lwork` and `-CLwork` are the same flag to tmux; so is a repeated `-L a -L b`, where getopt keeps **b**. Measured on 3.0a rather than assumed. The first attempt taught the parser the attached and bundled forms but still returned the *first* of a repeated flag, which is worse than it sounds twice over: `-S <isolated> -S <the user's default> kill-server` then reads as an isolated spawn to `assertTmuxSpawnIsolated` while tmux kill-servers the real fleet, and a wrong parse is invisible to the socket comparison in ask 1 because both sides mis-read the same argv the same way and agree. Also: `--` ends the globals, and values are not trimmed (`-L ' name'` really does name a socket with a leading space).

3. **Fail closed on parentage** (`9c2f3fa8`). The gate answered "orphan, sweep it" for every failure to read the facts it judges on — the only fail-open gate left in the gauntlet. It now returns a verdict: unknown (refuse, and say so at Warn), orphaned (the only one that authorises a signal), owned, or candidate-gone. ESRCH is deliberately **not** folded into the refusals as asked: it is the kernel confirming the parent is dead, a determination rather than a read failure, and inverting it would have made the #595 cleanup inert on its main path. Every other errno refuses, EPERM especially — it means the parent exists and is someone else's, the opposite of what that branch concluded.

4. **The EOF fallback's group kill** (`8195658e`, extended in `26c53183`). The pgid is captured at spawn instead of being re-derived from a pid that may have been recycled, both arms are gated on the handle, and — the part the first attempt got wrong — ownership is re-asked immediately before the escalation, because the gate is true only of the instant it runs in and the SIGKILL is a full grace later. `softKillProcessGroup` no longer answers EPERM by escalating: the permission check is identical for both signals, so that could only ever hit a group that is not ours, and it reported a kill that never happened.

5. **The tests that prove it** (`29df9724`). The wrong-server case is now constructed: two live servers carrying the same `-L` name under different bases, a real control client attached to the foreign one, and ours up and answering so a refusal cannot come from "no server there". Against the pre-fix code it returns `ok=true, live=false` — the kill verdict against an attached, live client. Both guards the mutation run scored as unpinned (`SessionPrefix` scope, the `isKnownCadenceArgv` call site) are pinned by a live process that fails one guard and passes everything else; re-running those mutations now kills the helper and fails the test.

6. **Attribution** — corrected in "Why this change" above.

Every guard added or changed across these commits was re-broken afterwards to confirm its test fails, rather than the claim being made from the shape of the code.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** `claude-opus-5` (implementation, both rounds). `claude-fable-5` ran the adversarial review passes — one on the original chain (commit 7 is its fallout) and, after the 2026-08-16 review response, two more: one on the production changes and one that re-derived the mutation for every new test rather than trusting the claim that each had been mutation-verified. Between them they found 12 further defects in the fixes, all closed in the last commit; the two that mattered are described above.

## What actually bothered you

Two orphaned tmux query clients pinned a core each on my machine for 14 hours after an agent-deck crash, and nothing cleaned them up — that is what started this work. This PR is the follow-through on the maintainer's 2026-08-14 request: "Please rebase this with #1832 and #1872 into one reviewable chain that proves alias handling, PID reuse, live identity, and no signalling of unrelated processes." My ask to the agent was exactly that: build the composed branch.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — apart from three failures that reproduce identically on pristine `upstream/main` here, listed in Evidence
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux cleanup to safely identify and remove stale control clients and orphaned one-shot processes.
  * Prevented cleanup from terminating active or unrelated processes when ownership, identity, or parentage cannot be verified.
  * Improved handling of tmux socket options, command aliases, and process-group termination.
  * Added bounded cleanup handling to prevent indefinite reaping.
* **Reliability**
  * Prevented duplicate cleanup sweeps and protected active tmux clients and servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
