### PR TITLE
feat(notifications): add Linux notify-send backend

### DIFF
--- a/internal/desknotify/desknotify.go
+++ b/internal/desknotify/desknotify.go
@@ -145,6 +145,27 @@ func deflagged(s string) string {
 	}
 }
 
+// notifySendBackend is the Linux fallback for a terminal that is not cmux.
+// It raises a desktop notification through the freedesktop.org notification
+// service when the notify-send client is installed.
+type notifySendBackend struct{}
+
+func (notifySendBackend) Name() string { return "notify-send" }
+
+func (notifySendBackend) Available() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	_, err := exec.LookPath("notify-send")
+	return err == nil
+}
+
+func (notifySendBackend) Notify(ctx context.Context, title, body string) error {
+	// #nosec G204 -- title/body are separate argv elements and no shell parses
+	// them. deflagged prevents exact help flags from suppressing the banner.
+	return exec.CommandContext(ctx, "notify-send", deflagged(title), deflagged(body)).Run()
+}
+
 // osascriptBackend is the macOS fallback for a terminal that is not cmux. It
 // raises a Notification Center banner with no persistent record.
 type osascriptBackend struct{}
@@ -182,9 +203,9 @@ type Notifier struct {
 	backends []Backend
 }
 
-// New returns a Notifier preferring cmux, falling back to macOS notifications.
+// New returns a Notifier preferring cmux, then platform-native notifications.
 func New() *Notifier {
-	return &Notifier{backends: []Backend{cmuxBackend{}, osascriptBackend{}}}
+	return &Notifier{backends: []Backend{cmuxBackend{}, notifySendBackend{}, osascriptBackend{}}}
 }
 
 // NewWithBackends builds a Notifier over an explicit backend list. Tests use

--- a/internal/desknotify/desknotify.go
+++ b/internal/desknotify/desknotify.go
@@ -162,8 +162,9 @@ func (notifySendBackend) Available() bool {
 
 func (notifySendBackend) Notify(ctx context.Context, title, body string) error {
 	// #nosec G204 -- title/body are separate argv elements and no shell parses
-	// them. deflagged prevents exact help flags from suppressing the banner.
-	return exec.CommandContext(ctx, "notify-send", deflagged(title), deflagged(body)).Run()
+	// them. -- ends option parsing, while deflagged preserves the same defense
+	// in depth used by the cmux backend for exact help flags.
+	return exec.CommandContext(ctx, "notify-send", "--", deflagged(title), deflagged(body)).Run()
 }
 
 // osascriptBackend is the macOS fallback for a terminal that is not cmux. It

--- a/internal/desknotify/desknotify_test.go
+++ b/internal/desknotify/desknotify_test.go
@@ -141,7 +141,7 @@ func TestNotifySendBackend_FakeBinaryReceivesDeflaggedArgs(t *testing.T) {
 		t.Fatalf("read fake notify-send args: %v", err)
 	}
 	got := strings.Split(strings.TrimSuffix(string(raw), "\n"), "\n")
-	want := []string{deflagged("--help"), deflagged("-h")}
+	want := []string{"--", deflagged("--help"), deflagged("-h")}
 	if len(got) != len(want) {
 		t.Fatalf("notify-send args = %q, want %q", got, want)
 	}

--- a/internal/desknotify/desknotify_test.go
+++ b/internal/desknotify/desknotify_test.go
@@ -3,9 +3,27 @@ package desknotify
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+const notifySendHelperEnv = "AGENT_DECK_NOTIFY_SEND_HELPER"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(notifySendHelperEnv) == "1" {
+		argsFile := os.Getenv("NOTIFY_SEND_ARGS_FILE")
+		if err := os.WriteFile(argsFile, []byte(strings.Join(os.Args[1:], "\n")+"\n"), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 // fakeBackend records what it was asked to deliver.
 type fakeBackend struct {
@@ -73,6 +91,79 @@ func TestNotify_NoBackendAvailableIsSilent(t *testing.T) {
 
 	if got != "" {
 		t.Errorf("backend = %q, want empty when nothing is available", got)
+	}
+}
+
+func TestNew_PrefersCmuxThenPlatformFallbacks(t *testing.T) {
+	backends := New().backends
+	names := make([]string, 0, len(backends))
+	for _, backend := range backends {
+		names = append(names, backend.Name())
+	}
+
+	if got, want := strings.Join(names, ","), "cmux,notify-send,osascript"; got != want {
+		t.Errorf("backend order = %q, want %q", got, want)
+	}
+}
+
+func TestNotifySendBackend_UnavailableWithoutBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	if (notifySendBackend{}).Available() {
+		t.Error("notify-send backend is available with no notify-send binary on PATH")
+	}
+}
+
+// No desktop session or libnotify daemon is needed to cover delivery. A copy
+// of this test binary acts as notify-send and records the real argv it receives.
+func TestNotifySendBackend_FakeBinaryReceivesDeflaggedArgs(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+	fakePath := filepath.Join(dir, "notify-send")
+	if runtime.GOOS == "windows" {
+		fakePath += ".exe"
+	}
+	copyTestExecutable(t, fakePath)
+	t.Setenv("PATH", dir)
+	t.Setenv("NOTIFY_SEND_ARGS_FILE", argsFile)
+	t.Setenv(notifySendHelperEnv, "1")
+
+	backend := notifySendBackend{}
+	if got, want := backend.Available(), runtime.GOOS == "linux"; got != want {
+		t.Fatalf("Available() = %v on %s with a fake binary, want %v", got, runtime.GOOS, want)
+	}
+	if err := backend.Notify(context.Background(), "--help", "-h"); err != nil {
+		t.Fatalf("Notify() with fake notify-send: %v", err)
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read fake notify-send args: %v", err)
+	}
+	got := strings.Split(strings.TrimSuffix(string(raw), "\n"), "\n")
+	want := []string{deflagged("--help"), deflagged("-h")}
+	if len(got) != len(want) {
+		t.Fatalf("notify-send args = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("notify-send arg %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func copyTestExecutable(t *testing.T, dst string) {
+	t.Helper()
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test executable: %v", err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read test executable: %v", err)
+	}
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		t.Fatalf("write fake notify-send: %v", err)
 	}
 }
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -630,7 +630,7 @@ desktop = false        # OS notification when a session needs input
 
 The other two signals only reach you in specific places: the notification bar is visible while you are looking at the TUI, and `transition_events` routes to a session's parent, so a top-level session with no parent reaches nobody. A background agent that blocks on a permission prompt while you work elsewhere therefore surfaces nowhere. `desktop = true` closes that gap.
 
-Delivery prefers the [cmux](https://cmux.com) terminal's notification panel when the `cmux` CLI is on `PATH`, which both raises a system banner and records the alert in cmux's sidebar so one missed while away is still discoverable. Otherwise it falls back to a macOS Notification Center banner via `osascript`. With neither available it is a silent no-op.
+Delivery prefers the [cmux](https://cmux.com) terminal's notification panel when the `cmux` CLI is on `PATH`, which both raises a system banner and records the alert in cmux's sidebar so one missed while away is still discoverable. Without cmux, Linux falls back to `notify-send` and macOS falls back to a Notification Center banner via `osascript`. On Linux without either cmux or `notify-send`, desktop notifications are a silent no-op.
 
 Notifications fire on the transition into `waiting` or `error`, once per transition rather than once per poll. `idle` is deliberately excluded: for a long-lived interactive agent it is the resting state, not an event, and alerting on it trains you to ignore the banners. The per-session `set-transition-notify off` opt-out is honoured here too, so a single noisy session can be muted without turning the feature off globally.
 


### PR DESCRIPTION
## What problem does this solve?

On Linux without cmux, enabling desktop notifications currently succeeds but produces no notification. This adds the `notify-send` fallback requested in #1950. Closes #1950.

## Why this change

The backend follows the existing notification interface and stays best-effort: it is available only on Linux when `notify-send` is on `PATH`, and a missing or failing binary still degrades to the next backend or silence. Title and body are passed as separate argv elements rather than through a shell, with the existing exact `-h`/`--help` de-flagging applied to both.

The fake-binary test copies the test executable under the `notify-send` name and records the argv from the child process. This exercises the actual process boundary without requiring a desktop session or notification daemon in CI.

## User impact

Linux users with `libnotify`/`notify-send` installed receive waiting and error banners when cmux is unavailable. Linux users without either binary retain the documented silent no-op; macOS behavior is unchanged.

## Evidence

Red phase on the pre-change package:

    internal\desknotify\desknotify_test.go:97:6: undefined: notifySendBackend
    internal\desknotify\desknotify_test.go:119:13: undefined: notifySendBackend
    FAIL github.com/asheshgoplani/agent-deck/internal/desknotify [build failed]

After the implementation, `go test -count=1 -v ./internal/desknotify` passes all 16 tests. `TestNotifySendBackend_FakeBinaryReceivesDeflaggedArgs` launches the copied test executable as `notify-send` and verifies the two recorded argv values after de-flagging.

Linux-targeted static checks from the exact Go version in `go.mod`:

    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet ./...   # pass
    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./... # pass
    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/desknotify # pass

The full sandboxed suite cannot execute on this Windows host because existing Unix-only packages use `syscall.Statfs_t`/`Setpgid`, Unix path assumptions, and privileged symlink semantics. The PR remains draft until the repository's Ubuntu suite runs the Linux fake-binary test and the full sandboxed suite.

Revert-check: with the production hunks removed, the new tests fail to compile with `undefined: notifySendBackend`, so they do not pass without the feature.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** unsure

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "Окей дальше ищи какой то проект и делай его, ну по такой же логике я думаю ты понял"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — pending the Ubuntu PR gate; this repository's full suite is not Windows-compatible
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — not a hot-path change
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=unsure intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux desktop notifications through `notify-send` when available.
  * Added automatic notification backend selection, prioritizing cmux, then Linux notifications, then macOS notifications.

* **Bug Fixes**
  * Improved reliability when notification tools are unavailable.
  * Notifications now safely handle message content that resembles command-line flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->