### PR TITLE
fix(web): send the bearer token from the MCP pane and key MCP stores by tool

### DIFF
--- a/internal/web/handlers_mcps.go
+++ b/internal/web/handlers_mcps.go
@@ -15,27 +15,46 @@ package web
 //	DELETE /api/sessions/{id}/mcps/{name}         -> detach (body: {scope?})
 //	PATCH  /api/sessions/{id}/mcps/{name}         -> move scope (toggle pooled ↔ local)
 //
-// Scope is one of "local" (default, writes <project>/.mcp.json), "global"
-// (writes the profile's Claude config), or "user" (writes ~/.claude.json).
+// Scope is one of "local", "global" or "user". Which files those name depends
+// on the session's TOOL, not just its project path: Claude, Codex, Gemini,
+// Cursor and OpenCode each keep MCP servers somewhere different, and Codex and
+// Gemini have no local scope at all. Requests carry an MCPTarget (tool +
+// project path) and route through the same per-tool helpers the TUI uses, so a
+// Codex session can never rewrite Claude's config. Scopes a tool does not have
+// are refused, not redirected.
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
+	"strconv"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
+
+// MCPTarget identifies the session whose MCP configuration is being read or
+// written. The tool is part of the identity, not decoration: Claude, Codex,
+// Gemini, Cursor and OpenCode each keep their MCP servers in a different file,
+// so a target without a tool cannot say which store to touch. Passing only a
+// project path is what let the web manager write Claude config for a Codex
+// session.
+type MCPTarget struct {
+	Tool        string
+	ProjectPath string
+}
 
 // MCPManager is the seam between web HTTP handlers and the on-disk MCP
 // catalog + scope-specific config files. Tests inject a fake; production
 // gets defaultMCPManager which delegates to internal/session.
 type MCPManager interface {
 	ListCatalog() []MCPCatalogEntry
-	ListAttached(projectPath string) (map[string][]string, error)
-	Attach(projectPath, name, scope string) error
-	Detach(projectPath, name, scope string) error
-	Move(projectPath, name, fromScope, toScope string) error
+	ListAttached(target MCPTarget) (map[string][]string, error)
+	Attach(target MCPTarget, name, scope string) error
+	Detach(target MCPTarget, name, scope string) error
+	Move(target MCPTarget, name, fromScope, toScope string) error
 }
 
 // MCPCatalogEntry describes one MCP available in the catalog (config.toml).
@@ -119,9 +138,18 @@ func (s *Server) handleSessionMCPs(w http.ResponseWriter, r *http.Request, sessi
 		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "session id is required")
 		return
 	}
-	projectPath, ok := s.lookupSessionProjectPath(sessionID)
+	target, ok := s.lookupSessionMCPTarget(sessionID)
 	if !ok {
 		writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, "session not found")
+		return
+	}
+	// Refuse rather than silently writing some other tool's config. The TUI
+	// gates its MCP dialog on exactly this predicate (see home.go), and the
+	// web surface has to agree or selecting an unsupported session would
+	// mutate an unrelated store.
+	if !session.ToolSupportsMCPManager(target.Tool) {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest,
+			"MCP management is not supported for tool "+strconv.Quote(target.Tool))
 		return
 	}
 
@@ -130,7 +158,7 @@ func (s *Server) handleSessionMCPs(w http.ResponseWriter, r *http.Request, sessi
 			writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
 			return
 		}
-		attached, err := s.mcpMgr.ListAttached(projectPath)
+		attached, err := s.mcpMgr.ListAttached(target)
 		if err != nil {
 			writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
 			return
@@ -152,17 +180,17 @@ func (s *Server) handleSessionMCPs(w http.ResponseWriter, r *http.Request, sessi
 
 	switch r.Method {
 	case http.MethodPost:
-		s.handleMCPAttach(w, r, projectPath, name)
+		s.handleMCPAttach(w, r, target, name)
 	case http.MethodDelete:
-		s.handleMCPDetach(w, r, projectPath, name)
+		s.handleMCPDetach(w, r, target, name)
 	case http.MethodPatch:
-		s.handleMCPMove(w, r, projectPath, name)
+		s.handleMCPMove(w, r, target, name)
 	default:
 		writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
 	}
 }
 
-func (s *Server) handleMCPAttach(w http.ResponseWriter, r *http.Request, projectPath, name string) {
+func (s *Server) handleMCPAttach(w http.ResponseWriter, r *http.Request, target MCPTarget, name string) {
 	if !s.checkMutationsAllowed(w) {
 		return
 	}
@@ -178,7 +206,7 @@ func (s *Server) handleMCPAttach(w http.ResponseWriter, r *http.Request, project
 		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|global|user)")
 		return
 	}
-	if err := s.mcpMgr.Attach(projectPath, name, scope); err != nil {
+	if err := s.mcpMgr.Attach(target, name, scope); err != nil {
 		writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
 		return
 	}
@@ -186,14 +214,14 @@ func (s *Server) handleMCPAttach(w http.ResponseWriter, r *http.Request, project
 	writeJSON(w, http.StatusOK, map[string]string{"attached": name, "scope": scope})
 }
 
-func (s *Server) handleMCPDetach(w http.ResponseWriter, r *http.Request, projectPath, name string) {
+func (s *Server) handleMCPDetach(w http.ResponseWriter, r *http.Request, target MCPTarget, name string) {
 	if !s.checkMutationsAllowed(w) {
 		return
 	}
 	if !s.checkMutationRateLimit(w) {
 		return
 	}
-	scope := s.detectAttachedScope(projectPath, name)
+	scope := s.detectAttachedScope(target, name)
 	if scope == "" {
 		scope = "local"
 	}
@@ -209,7 +237,7 @@ func (s *Server) handleMCPDetach(w http.ResponseWriter, r *http.Request, project
 			return
 		}
 	}
-	if err := s.mcpMgr.Detach(projectPath, name, scope); err != nil {
+	if err := s.mcpMgr.Detach(target, name, scope); err != nil {
 		writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
 		return
 	}
@@ -217,7 +245,7 @@ func (s *Server) handleMCPDetach(w http.ResponseWriter, r *http.Request, project
 	writeJSON(w, http.StatusOK, map[string]string{"detached": name, "scope": scope})
 }
 
-func (s *Server) handleMCPMove(w http.ResponseWriter, r *http.Request, projectPath, name string) {
+func (s *Server) handleMCPMove(w http.ResponseWriter, r *http.Request, target MCPTarget, name string) {
 	if !s.checkMutationsAllowed(w) {
 		return
 	}
@@ -237,7 +265,7 @@ func (s *Server) handleMCPMove(w http.ResponseWriter, r *http.Request, projectPa
 		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|global|user)")
 		return
 	}
-	fromScope := s.detectAttachedScope(projectPath, name)
+	fromScope := s.detectAttachedScope(target, name)
 	if fromScope == "" {
 		writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, "MCP not attached to this session")
 		return
@@ -246,7 +274,7 @@ func (s *Server) handleMCPMove(w http.ResponseWriter, r *http.Request, projectPa
 		writeJSON(w, http.StatusOK, map[string]string{"scope": toScope})
 		return
 	}
-	if err := s.mcpMgr.Move(projectPath, name, fromScope, toScope); err != nil {
+	if err := s.mcpMgr.Move(target, name, fromScope, toScope); err != nil {
 		writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
 		return
 	}
@@ -256,24 +284,27 @@ func (s *Server) handleMCPMove(w http.ResponseWriter, r *http.Request, projectPa
 	})
 }
 
-func (s *Server) lookupSessionProjectPath(sessionID string) (string, bool) {
+// lookupSessionMCPTarget resolves a session id to the tool + project path that
+// together select an on-disk MCP store. Both halves come from the same menu
+// snapshot entry, so they cannot disagree.
+func (s *Server) lookupSessionMCPTarget(sessionID string) (MCPTarget, bool) {
 	if s.menuData == nil {
-		return "", false
+		return MCPTarget{}, false
 	}
 	snap, err := s.menuData.LoadMenuSnapshot()
 	if err != nil || snap == nil {
-		return "", false
+		return MCPTarget{}, false
 	}
 	for _, item := range snap.Items {
 		if item.Type == MenuItemTypeSession && item.Session != nil && item.Session.ID == sessionID {
-			return item.Session.ProjectPath, true
+			return MCPTarget{Tool: item.Session.Tool, ProjectPath: item.Session.ProjectPath}, true
 		}
 	}
-	return "", false
+	return MCPTarget{}, false
 }
 
-func (s *Server) detectAttachedScope(projectPath, name string) string {
-	attached, err := s.mcpMgr.ListAttached(projectPath)
+func (s *Server) detectAttachedScope(target MCPTarget, name string) string {
+	attached, err := s.mcpMgr.ListAttached(target)
 	if err != nil {
 		return ""
 	}
@@ -354,16 +385,93 @@ func (defaultMCPManager) ListCatalog() []MCPCatalogEntry {
 	return out
 }
 
-func (defaultMCPManager) ListAttached(projectPath string) (map[string][]string, error) {
+// scopesForTool lists the MCP scopes a tool actually has, mirroring the TUI
+// dialog (internal/ui/mcp_dialog.go), which is the source of truth:
+//
+//   - Codex and Gemini keep MCPs only in their own user-level config;
+//   - Cursor and OpenCode have a project file and a user file;
+//   - Claude-compatible tools additionally have ~/.claude.json ("user").
+//
+// A scope missing here is refused rather than silently redirected to Claude's
+// store, which is what the previous project-path-only manager did.
+func scopesForTool(tool string) []string {
+	switch {
+	case session.IsCodexCompatible(tool), tool == "gemini":
+		return []string{"global"}
+	case tool == "cursor", tool == "opencode":
+		return []string{"local", "global"}
+	case session.IsClaudeCompatible(tool):
+		return []string{"local", "global", "user"}
+	default:
+		return nil
+	}
+}
+
+func toolHasScope(tool, scope string) bool {
+	return slices.Contains(scopesForTool(tool), scope)
+}
+
+// attachedNamesForTool reads each scope from the store that tool actually
+// uses, and — critically — from the store that scope's write path targets.
+//
+// The bug this replaces: "local" was read from GetProjectMCPNames, which is
+// the Claude config's projects[path].mcpServers map, while "local" was written
+// to <project>/.mcp.json. Those are different files (MCPInfo keeps them as
+// Project vs LocalMCPs), so attaching one server rewrote .mcp.json from a list
+// that never contained the servers already in it, silently dropping them.
+// Claude's projects[path] entries belong to the GLOBAL bucket here, exactly as
+// the TUI groups them.
+func attachedNamesForTool(target MCPTarget) (local, global, user []string) {
+	switch {
+	case session.IsCodexCompatible(target.Tool):
+		return nil, mcpInfoGlobal(session.GetCodexMCPInfo("")), nil
+	case target.Tool == "gemini":
+		return nil, mcpInfoGlobal(session.GetGeminiMCPInfo(target.ProjectPath)), nil
+	case target.Tool == "cursor":
+		info := session.GetCursorMCPInfo(target.ProjectPath)
+		return mcpInfoLocal(info), mcpInfoGlobal(info), nil
+	case target.Tool == "opencode":
+		info := session.GetOpenCodeMCPInfo(target.ProjectPath)
+		return mcpInfoLocal(info), mcpInfoGlobal(info), nil
+	case session.IsClaudeCompatible(target.Tool):
+		info := session.GetMCPInfo(target.ProjectPath)
+		// Global mirrors the TUI: the config's own mcpServers plus its
+		// per-project entries.
+		globals := append([]string(nil), session.GetGlobalMCPNames()...)
+		globals = append(globals, session.GetProjectMCPNames(target.ProjectPath)...)
+		return mcpInfoLocal(info), globals, session.GetUserMCPNames()
+	default:
+		return nil, nil, nil
+	}
+}
+
+func mcpInfoLocal(info *session.MCPInfo) []string {
+	if info == nil {
+		return nil
+	}
+	return info.Local()
+}
+
+func mcpInfoGlobal(info *session.MCPInfo) []string {
+	if info == nil {
+		return nil
+	}
+	return info.Global
+}
+
+// ListAttached reports the catalog-defined MCPs attached to the target, per
+// scope, reading the same store each scope's write path targets.
+func (defaultMCPManager) ListAttached(target MCPTarget) (map[string][]string, error) {
+	local, global, user := attachedNamesForTool(target)
 	return map[string][]string{
-		"local":  filterDefined(session.GetProjectMCPNames(projectPath)),
-		"global": filterDefined(session.GetGlobalMCPNames()),
-		"user":   filterDefined(session.GetUserMCPNames()),
+		"local":  filterDefined(local),
+		"global": filterDefined(global),
+		"user":   filterDefined(user),
 	}, nil
 }
 
-func (m defaultMCPManager) Attach(projectPath, name, scope string) error {
-	names, err := m.namesAt(projectPath, scope)
+func (m defaultMCPManager) Attach(target MCPTarget, name, scope string) error {
+	names, err := m.namesAt(target, scope)
 	if err != nil {
 		return err
 	}
@@ -372,54 +480,85 @@ func (m defaultMCPManager) Attach(projectPath, name, scope string) error {
 			return nil
 		}
 	}
-	return m.writeScope(projectPath, scope, append(names, name))
+	return m.writeScope(target, scope, append(names, name))
 }
 
-func (m defaultMCPManager) Detach(projectPath, name, scope string) error {
-	names, err := m.namesAt(projectPath, scope)
+func (m defaultMCPManager) Detach(target MCPTarget, name, scope string) error {
+	names, err := m.namesAt(target, scope)
 	if err != nil {
 		return err
 	}
-	out := names[:0]
+	out := make([]string, 0, len(names))
 	for _, n := range names {
 		if n != name {
 			out = append(out, n)
 		}
 	}
-	return m.writeScope(projectPath, scope, out)
+	return m.writeScope(target, scope, out)
 }
 
-func (m defaultMCPManager) Move(projectPath, name, fromScope, toScope string) error {
-	if err := m.Detach(projectPath, name, fromScope); err != nil {
+func (m defaultMCPManager) Move(target MCPTarget, name, fromScope, toScope string) error {
+	if err := m.Detach(target, name, fromScope); err != nil {
 		return err
 	}
-	return m.Attach(projectPath, name, toScope)
+	return m.Attach(target, name, toScope)
 }
 
-func (defaultMCPManager) namesAt(projectPath, scope string) ([]string, error) {
+// namesAt returns the current contents of one scope's store. It must stay the
+// exact inverse of writeScope: every read/write pair has to name the same file,
+// or attach becomes a partial overwrite.
+func (defaultMCPManager) namesAt(target MCPTarget, scope string) ([]string, error) {
+	if err := checkScope(target.Tool, scope); err != nil {
+		return nil, err
+	}
+	local, global, user := attachedNamesForTool(target)
 	switch scope {
 	case "local":
-		return filterDefined(session.GetProjectMCPNames(projectPath)), nil
+		return filterDefined(local), nil
 	case "global":
-		return filterDefined(session.GetGlobalMCPNames()), nil
-	case "user":
-		return filterDefined(session.GetUserMCPNames()), nil
+		return filterDefined(global), nil
 	default:
-		return nil, errInvalidScope(scope)
+		return filterDefined(user), nil
 	}
 }
 
-func (defaultMCPManager) writeScope(projectPath, scope string, names []string) error {
+func (defaultMCPManager) writeScope(target MCPTarget, scope string, names []string) error {
+	if err := checkScope(target.Tool, scope); err != nil {
+		return err
+	}
 	switch scope {
 	case "local":
-		return session.WriteMCPJsonFromConfig(projectPath, names)
+		return session.WriteLocalMCPConfigForTool(target.Tool, target.ProjectPath, names)
 	case "global":
-		return session.WriteGlobalMCP(names)
-	case "user":
+		return session.WriteGlobalMCPConfigForTool(target.Tool, names)
+	default:
+		// ~/.claude.json is Claude's own user-level store; checkScope has
+		// already established the tool is Claude-compatible.
 		return session.WriteUserMCP(names)
+	}
+}
+
+func checkScope(tool, scope string) error {
+	switch scope {
+	case "local", "global", "user":
 	default:
 		return errInvalidScope(scope)
 	}
+	if !toolHasScope(tool, scope) {
+		return errUnsupportedScope{scope: scope, tool: tool}
+	}
+	return nil
+}
+
+// errUnsupportedScope explains a scope that exists for some tools but not this
+// one, so the API can say why instead of failing opaquely.
+type errUnsupportedScope struct {
+	scope string
+	tool  string
+}
+
+func (e errUnsupportedScope) Error() string {
+	return fmt.Sprintf("scope %q is not supported for tool %q", e.scope, e.tool)
 }
 
 // filterDefined keeps only catalog-defined names. Write paths preserve any

--- a/internal/web/handlers_mcps_stores_test.go
+++ b/internal/web/handlers_mcps_stores_test.go
@@ -1,0 +1,249 @@
+package web
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Store-coherence tests for the production MCP manager.
+//
+// These exercise defaultMCPManager against real files rather than a fake,
+// because the defects they pin are entirely about WHICH file gets read and
+// written:
+//
+//  1. "local" used to read the Claude config's projects[path].mcpServers map
+//     while writing <project>/.mcp.json. Attaching one server therefore
+//     rewrote .mcp.json from a list that never contained the servers already
+//     in it, silently dropping them.
+//  2. Every scope hardcoded the Claude helpers, so selecting a Codex, Gemini,
+//     Cursor or OpenCode session mutated Claude's configuration.
+
+// mcpStoreEnv points the whole session config layer at a temp HOME and writes
+// a config.toml catalog, so GetAvailableMCPs (and therefore filterDefined)
+// recognises the names under test.
+func mcpStoreEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude-cfg"))
+	if err := os.MkdirAll(filepath.Join(home, ".claude-cfg"), 0o755); err != nil {
+		t.Fatalf("mkdir claude config dir: %v", err)
+	}
+
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	const catalog = `
+[mcps.alpha]
+command = "alpha-server"
+description = "alpha"
+
+[mcps.beta]
+command = "beta-server"
+description = "beta"
+
+[mcps.gamma]
+command = "gamma-server"
+description = "gamma"
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(catalog), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	if len(session.GetAvailableMCPs()) == 0 {
+		t.Skip("catalog did not load from the temp config; skipping rather than asserting vacuously")
+	}
+	return home
+}
+
+func readMCPJSONNames(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var doc struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	names := make([]string, 0, len(doc.MCPServers))
+	for name := range doc.MCPServers {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// TestLocalAttachPreservesServersAlreadyInMcpJSON is the regression test for
+// the read/write store mismatch. `beta` exists only in .mcp.json; attaching
+// `alpha` must not remove it.
+func TestLocalAttachPreservesServersAlreadyInMcpJSON(t *testing.T) {
+	mcpStoreEnv(t)
+	project := t.TempDir()
+	target := MCPTarget{Tool: "claude", ProjectPath: project}
+	mgr := NewDefaultMCPManager()
+
+	// Seed .mcp.json with beta through the same writer production uses, so the
+	// file shape is exactly what the app would have produced.
+	if err := session.WriteMCPJsonFromConfig(project, []string{"beta"}); err != nil {
+		t.Fatalf("seed .mcp.json: %v", err)
+	}
+	mcpJSON := filepath.Join(project, ".mcp.json")
+	if got := readMCPJSONNames(t, mcpJSON); !slices.Contains(got, "beta") {
+		t.Fatalf("precondition failed: .mcp.json should contain beta, got %v", got)
+	}
+
+	// The local list must reflect .mcp.json, the file the local writer targets.
+	attached, err := mgr.ListAttached(target)
+	if err != nil {
+		t.Fatalf("ListAttached: %v", err)
+	}
+	if !slices.Contains(attached["local"], "beta") {
+		t.Fatalf("local scope should read .mcp.json and report beta, got %v", attached["local"])
+	}
+
+	if err := mgr.Attach(target, "alpha", "local"); err != nil {
+		t.Fatalf("Attach alpha local: %v", err)
+	}
+
+	got := readMCPJSONNames(t, mcpJSON)
+	if !slices.Contains(got, "alpha") {
+		t.Errorf("attach did not add alpha to .mcp.json: %v", got)
+	}
+	if !slices.Contains(got, "beta") {
+		t.Errorf("attaching alpha DROPPED beta from .mcp.json: %v — "+
+			"the local read and the local write must target the same store", got)
+	}
+}
+
+// TestLocalDetachPreservesOtherServers is the mirror case: removing one server
+// must not take the rest with it.
+func TestLocalDetachPreservesOtherServers(t *testing.T) {
+	mcpStoreEnv(t)
+	project := t.TempDir()
+	target := MCPTarget{Tool: "claude", ProjectPath: project}
+	mgr := NewDefaultMCPManager()
+
+	if err := session.WriteMCPJsonFromConfig(project, []string{"alpha", "beta"}); err != nil {
+		t.Fatalf("seed .mcp.json: %v", err)
+	}
+	if err := mgr.Detach(target, "alpha", "local"); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	got := readMCPJSONNames(t, filepath.Join(project, ".mcp.json"))
+	if slices.Contains(got, "alpha") {
+		t.Errorf("detach left alpha behind: %v", got)
+	}
+	if !slices.Contains(got, "beta") {
+		t.Errorf("detaching alpha DROPPED beta: %v", got)
+	}
+}
+
+// TestNonClaudeToolDoesNotTouchClaudeConfig is the regression test for the
+// hardcoded Claude helpers. A Codex session's attach must leave Claude's
+// config byte-identical.
+func TestNonClaudeToolDoesNotTouchClaudeConfig(t *testing.T) {
+	home := mcpStoreEnv(t)
+	project := t.TempDir()
+	mgr := NewDefaultMCPManager()
+
+	claudeConfig := filepath.Join(home, ".claude-cfg", ".claude.json")
+	seed := []byte(`{"mcpServers":{"alpha":{"command":"alpha-server"}}}`)
+	if err := os.WriteFile(claudeConfig, seed, 0o600); err != nil {
+		t.Fatalf("seed claude config: %v", err)
+	}
+
+	// Codex is supported by the MCP manager but keeps its servers in its own
+	// config, so this must not write Claude's file.
+	target := MCPTarget{Tool: "codex", ProjectPath: project}
+	_ = mgr.Attach(target, "beta", "global")
+
+	after, err := os.ReadFile(claudeConfig)
+	if err != nil {
+		t.Fatalf("read claude config: %v", err)
+	}
+	if string(after) != string(seed) {
+		t.Errorf("a codex session's MCP attach modified Claude's config.\nbefore: %s\nafter:  %s", seed, after)
+	}
+
+	// It also must not write the project's Claude-style .mcp.json.
+	if _, err := os.Stat(filepath.Join(project, ".mcp.json")); err == nil {
+		t.Error("a codex session's MCP attach created a Claude-style .mcp.json in the project")
+	}
+}
+
+// TestScopesAreRefusedWhenTheToolDoesNotHaveThem pins the honest-refusal
+// behaviour: rather than redirecting an impossible scope to Claude's store,
+// the manager says the scope does not exist for that tool.
+func TestScopesAreRefusedWhenTheToolDoesNotHaveThem(t *testing.T) {
+	mcpStoreEnv(t)
+	project := t.TempDir()
+	mgr := NewDefaultMCPManager()
+
+	for _, tc := range []struct {
+		tool  string
+		scope string
+	}{
+		{"codex", "local"},  // Codex has no project-local MCP file
+		{"codex", "user"},   // ~/.claude.json is Claude's alone
+		{"gemini", "local"}, // Gemini is global-only
+		{"cursor", "user"},
+		{"opencode", "user"},
+	} {
+		t.Run(tc.tool+"/"+tc.scope, func(t *testing.T) {
+			err := mgr.Attach(MCPTarget{Tool: tc.tool, ProjectPath: project}, "alpha", tc.scope)
+			if err == nil {
+				t.Fatalf("attaching in scope %q for tool %q should be refused, not silently redirected", tc.scope, tc.tool)
+			}
+		})
+	}
+}
+
+// TestClaudeGlobalScopeCoversProjectEntries documents where the Claude config's
+// projects[path].mcpServers entries belong. They are part of the GLOBAL bucket,
+// exactly as the TUI dialog groups them; treating them as "local" is what
+// crossed the stores in the first place.
+func TestClaudeGlobalScopeCoversProjectEntries(t *testing.T) {
+	home := mcpStoreEnv(t)
+	project := t.TempDir()
+
+	cfg := map[string]any{
+		"projects": map[string]any{
+			project: map[string]any{
+				"mcpServers": map[string]any{"gamma": map[string]any{"command": "gamma-server"}},
+			},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude-cfg", ".claude.json"), data, 0o600); err != nil {
+		t.Fatalf("write claude config: %v", err)
+	}
+
+	attached, err := NewDefaultMCPManager().ListAttached(MCPTarget{Tool: "claude", ProjectPath: project})
+	if err != nil {
+		t.Fatalf("ListAttached: %v", err)
+	}
+	if !slices.Contains(attached["global"], "gamma") {
+		t.Errorf("Claude projects[path] entries belong to the global scope, got global=%v local=%v",
+			attached["global"], attached["local"])
+	}
+	if slices.Contains(attached["local"], "gamma") {
+		t.Errorf("Claude projects[path] entries must NOT be reported as local (.mcp.json), got %v", attached["local"])
+	}
+}

--- a/internal/web/handlers_mcps_test.go
+++ b/internal/web/handlers_mcps_test.go
@@ -30,6 +30,9 @@ type fakeMCPManager struct {
 	attachCalls []mcpAttachCall
 	detachCalls []mcpAttachCall
 	moveCalls   []mcpMoveCall
+	// targets records every MCPTarget the handler passed through, so tests
+	// can assert the session's tool reaches the manager and not just its path.
+	targets []MCPTarget
 }
 
 type mcpAttachCall struct {
@@ -49,15 +52,16 @@ func (f *fakeMCPManager) ListCatalog() []MCPCatalogEntry {
 	return append([]MCPCatalogEntry(nil), f.catalog...)
 }
 
-func (f *fakeMCPManager) ListAttached(projectPath string) (map[string][]string, error) {
+func (f *fakeMCPManager) ListAttached(target MCPTarget) (map[string][]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.targets = append(f.targets, target)
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
 	out := make(map[string][]string, 3)
 	for _, scope := range []string{"local", "global", "user"} {
-		if names := f.attached[projectPath][scope]; names != nil {
+		if names := f.attached[target.ProjectPath][scope]; names != nil {
 			cp := append([]string(nil), names...)
 			sort.Strings(cp)
 			out[scope] = cp
@@ -68,70 +72,72 @@ func (f *fakeMCPManager) ListAttached(projectPath string) (map[string][]string, 
 	return out, nil
 }
 
-func (f *fakeMCPManager) Attach(projectPath, name, scope string) error {
+func (f *fakeMCPManager) Attach(target MCPTarget, name, scope string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.targets = append(f.targets, target)
 	if f.attachErr != nil {
 		return f.attachErr
 	}
-	f.attachCalls = append(f.attachCalls, mcpAttachCall{projectPath, name, scope})
-	if f.attached[projectPath] == nil {
-		f.attached[projectPath] = map[string][]string{}
+	f.attachCalls = append(f.attachCalls, mcpAttachCall{target.ProjectPath, name, scope})
+	if f.attached[target.ProjectPath] == nil {
+		f.attached[target.ProjectPath] = map[string][]string{}
 	}
-	for _, existing := range f.attached[projectPath][scope] {
+	for _, existing := range f.attached[target.ProjectPath][scope] {
 		if existing == name {
 			return nil
 		}
 	}
-	f.attached[projectPath][scope] = append(f.attached[projectPath][scope], name)
+	f.attached[target.ProjectPath][scope] = append(f.attached[target.ProjectPath][scope], name)
 	return nil
 }
 
-func (f *fakeMCPManager) Detach(projectPath, name, scope string) error {
+func (f *fakeMCPManager) Detach(target MCPTarget, name, scope string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.targets = append(f.targets, target)
 	if f.detachErr != nil {
 		return f.detachErr
 	}
-	f.detachCalls = append(f.detachCalls, mcpAttachCall{projectPath, name, scope})
-	names := f.attached[projectPath][scope]
+	f.detachCalls = append(f.detachCalls, mcpAttachCall{target.ProjectPath, name, scope})
+	names := f.attached[target.ProjectPath][scope]
 	out := names[:0]
 	for _, n := range names {
 		if n != name {
 			out = append(out, n)
 		}
 	}
-	if f.attached[projectPath] == nil {
-		f.attached[projectPath] = map[string][]string{}
+	if f.attached[target.ProjectPath] == nil {
+		f.attached[target.ProjectPath] = map[string][]string{}
 	}
-	f.attached[projectPath][scope] = out
+	f.attached[target.ProjectPath][scope] = out
 	return nil
 }
 
-func (f *fakeMCPManager) Move(projectPath, name, fromScope, toScope string) error {
+func (f *fakeMCPManager) Move(target MCPTarget, name, fromScope, toScope string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.moveErr != nil {
 		return f.moveErr
 	}
-	f.moveCalls = append(f.moveCalls, mcpMoveCall{projectPath, name, fromScope, toScope})
-	if f.attached[projectPath] == nil {
-		f.attached[projectPath] = map[string][]string{}
+	f.moveCalls = append(f.moveCalls, mcpMoveCall{target.ProjectPath, name, fromScope, toScope})
+	if f.attached[target.ProjectPath] == nil {
+		f.attached[target.ProjectPath] = map[string][]string{}
 	}
-	from := f.attached[projectPath][fromScope]
+	from := f.attached[target.ProjectPath][fromScope]
 	out := from[:0]
 	for _, n := range from {
 		if n != name {
 			out = append(out, n)
 		}
 	}
-	f.attached[projectPath][fromScope] = out
-	for _, existing := range f.attached[projectPath][toScope] {
+	f.attached[target.ProjectPath][fromScope] = out
+	for _, existing := range f.attached[target.ProjectPath][toScope] {
 		if existing == name {
 			return nil
 		}
 	}
-	f.attached[projectPath][toScope] = append(f.attached[projectPath][toScope], name)
+	f.attached[target.ProjectPath][toScope] = append(f.attached[target.ProjectPath][toScope], name)
 	return nil
 }
 
@@ -148,6 +154,12 @@ func newMCPTestServer(t *testing.T, mgr MCPManager, mutationsAllowed bool) *Serv
 				{Type: MenuItemTypeSession, Session: &MenuSession{
 					ID: "sess-002", Title: "beta", Tool: "gemini",
 					Status: session.StatusRunning, ProjectPath: "/srv/beta",
+				}},
+				// A tool with no MCP support at all, so the handler's gate has
+				// something to refuse (see TestMCPRoutesRefuseUnsupportedTool).
+				{Type: MenuItemTypeSession, Session: &MenuSession{
+					ID: "sess-shell", Title: "scratch", Tool: "shell",
+					Status: session.StatusRunning, ProjectPath: "/srv/scratch",
 				}},
 			},
 		},
@@ -451,3 +463,63 @@ func slicesEqual(a, b []string) bool {
 }
 
 var _ MCPManager = (*fakeMCPManager)(nil)
+
+// TestMCPRoutesRefuseUnsupportedTool pins the honest gate. The MCP endpoints
+// are exposed for every session, but a shell session has no MCP store; before
+// the tool became part of the target, selecting one wrote Claude's config on
+// its behalf. It must now be refused with a reason that names the tool.
+func TestMCPRoutesRefuseUnsupportedTool(t *testing.T) {
+	mgr := newFakeMCPManager()
+	srv := newMCPTestServer(t, mgr, true)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"list", http.MethodGet, "/api/sessions/sess-shell/mcps"},
+		{"attach", http.MethodPost, "/api/sessions/sess-shell/mcps/exa"},
+		{"detach", http.MethodDelete, "/api/sessions/sess-shell/mcps/exa"},
+		{"move", http.MethodPatch, "/api/sessions/sess-shell/mcps/exa"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), "shell") {
+				t.Errorf("refusal should name the unsupported tool, got %s", rr.Body.String())
+			}
+		})
+	}
+
+	if len(mgr.attachCalls) != 0 || len(mgr.detachCalls) != 0 || len(mgr.moveCalls) != 0 {
+		t.Errorf("an unsupported tool reached the manager: attach=%v detach=%v move=%v",
+			mgr.attachCalls, mgr.detachCalls, mgr.moveCalls)
+	}
+}
+
+// TestMCPTargetCarriesTheSessionTool proves the tool reaches the manager, so a
+// per-tool implementation can route to the right store.
+func TestMCPTargetCarriesTheSessionTool(t *testing.T) {
+	mgr := newFakeMCPManager()
+	srv := newMCPTestServer(t, mgr, true)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/sess-002/mcps/exa", nil)
+	req.Header.Set("Origin", "http://"+req.Host)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if len(mgr.targets) == 0 {
+		t.Fatal("manager saw no target")
+	}
+	last := mgr.targets[len(mgr.targets)-1]
+	if last.Tool != "gemini" || last.ProjectPath != "/srv/beta" {
+		t.Errorf("manager got target %+v, want tool=gemini path=/srv/beta", last)
+	}
+}

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -57,13 +57,19 @@ type MenuGroup struct {
 
 // MenuSession contains metadata for a session item.
 type MenuSession struct {
-	ID           string         `json:"id"`
-	Title        string         `json:"title"`
-	Tool         string         `json:"tool"`
-	ModelID      string         `json:"modelId,omitempty"`
-	Model        string         `json:"model,omitempty"`
-	ModelVersion string         `json:"modelVersion,omitempty"`
-	CanFork      bool           `json:"canFork"`
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	Tool         string `json:"tool"`
+	ModelID      string `json:"modelId,omitempty"`
+	Model        string `json:"model,omitempty"`
+	ModelVersion string `json:"modelVersion,omitempty"`
+	CanFork      bool   `json:"canFork"`
+	// MCPSupported mirrors session.ToolSupportsMCPManager for this session's
+	// tool. It is computed server-side on purpose: the predicate is
+	// config-driven (a user tool can declare compatible_with = "claude"), so a
+	// duplicated client-side list would be wrong for custom tools and would
+	// drift. The web MCP pane reads this instead of guessing from the name.
+	MCPSupported bool           `json:"mcpSupported"`
 	Status       session.Status `json:"status"`
 	// Substate is the additive Honest-Status-v2 refinement of Status
 	// (e.g. "model-unavailable", "auth-401", "idle-at-empty-prompt"). It
@@ -300,6 +306,7 @@ func toMenuSession(inst *session.Instance) *MenuSession {
 		Model:              modelInfo.Model,
 		ModelVersion:       modelInfo.Version,
 		CanFork:            inst.CanFork(),
+		MCPSupported:       session.ToolSupportsMCPManager(inst.GetToolThreadSafe()),
 		Status:             inst.GetStatusThreadSafe(),
 		Substate:           string(inst.CachedSubstate()),
 		GroupPath:          inst.GroupPath,

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -46,7 +46,7 @@ import { ToastContainer, addToast } from './Toast.js'
 import { ToastHistoryDrawer } from './ToastHistoryDrawer.js'
 import { SettingsPanel } from './SettingsPanel.js'
 import { KeyboardShortcuts } from './KeyboardShortcuts.js'
-import { apiFetch } from './api.js'
+import { apiFetch, authHeaders } from './api.js'
 import { shortcutsOverlaySignal } from './state.js'
 
 function WorkHead() {
@@ -137,7 +137,7 @@ export function AppShell() {
   // Also hydrates the show_only_installed_tools filter (issue #1259) so the
   // new-session dialog can hide tools whose command is not on PATH.
   useEffect(() => {
-    fetch('/api/settings')
+    fetch('/api/settings', { headers: authHeaders() })
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (!data) return
@@ -174,7 +174,7 @@ export function AppShell() {
   // dropdown options and uses the `current` field to seed profileSignal
   // (UI-side selection) on first load.
   useEffect(() => {
-    fetch('/api/profiles')
+    fetch('/api/profiles', { headers: authHeaders() })
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (data && Array.isArray(data.profiles)) {
@@ -191,7 +191,7 @@ export function AppShell() {
   useEffect(() => {
     let cancelled = false
     const fetchStats = () => {
-      fetch('/api/system/stats')
+      fetch('/api/system/stats', { headers: authHeaders() })
         .then(r => r.ok ? r.json() : null)
         .then(data => { if (!cancelled && data) systemStatsSignal.value = data })
         .catch(() => {})

--- a/internal/web/static/app/SettingsPanel.js
+++ b/internal/web/static/app/SettingsPanel.js
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { useState, useEffect } from 'preact/hooks'
 import { settingsSignal } from './state.js'
+import { authHeaders } from './api.js'
 
 export function SettingsPanel() {
   const [error, setError] = useState(null)
@@ -10,7 +11,7 @@ export function SettingsPanel() {
 
   useEffect(() => {
     if (settings) return
-    fetch('/api/settings')
+    fetch('/api/settings', { headers: authHeaders() })
       .then(r => { if (!r.ok) throw new Error('Settings request failed: ' + r.status); return r.json() })
       .then(data => { settingsSignal.value = data })
       .catch(err => setError(err.message || 'Failed to load settings'))

--- a/internal/web/static/app/api.js
+++ b/internal/web/static/app/api.js
@@ -3,10 +3,24 @@
 import { authTokenSignal } from './state.js'
 import { addToast } from './Toast.js'
 
-export async function apiFetch(method, path, body) {
-  const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' }
+// authHeaders returns the headers every /api/ request must carry.
+//
+// The bearer token lives only in authTokenSignal (main.js reads it from the
+// URL and strips it), so any call site that hand-rolls its own fetch silently
+// drops it and 401s the moment the server is started with --token/--token-file.
+// That is exactly how the MCP pane broke: it had a private copy of this helper
+// that never grew the Authorization header. Every /api/ caller must go through
+// apiFetch or at minimum spread authHeaders() — see
+// TestAppScriptsUseTheSharedAuthenticatedFetch for the regression gate.
+export function authHeaders(extra) {
+  const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', ...extra }
   const token = authTokenSignal.value
   if (token) headers['Authorization'] = 'Bearer ' + token
+  return headers
+}
+
+export async function apiFetch(method, path, body) {
+  const headers = authHeaders()
   let res
   try {
     res = await fetch(path, {

--- a/internal/web/static/app/dataModel.js
+++ b/internal/web/static/app/dataModel.js
@@ -34,6 +34,9 @@ function projectSession(item) {
     model: s.model || '',
     modelVersion: s.modelVersion || '',
     canFork: !!s.canFork,
+    // Server-computed (session.ToolSupportsMCPManager). Default true so a
+    // payload predating the field does not hide the MCP pane.
+    mcpSupported: s.mcpSupported !== false,
     status: s.status || 'idle',
     branch: s.branch || '—',
     path: s.projectPath || '',

--- a/internal/web/static/app/panes/McpPane.js
+++ b/internal/web/static/app/panes/McpPane.js
@@ -14,19 +14,36 @@ import { useEffect, useState, useCallback } from 'preact/hooks'
 import { menuModelSignal } from '../dataModel.js'
 import { selectedIdSignal, mutationsEnabledSignal } from '../state.js'
 import { addToast } from '../Toast.js'
+import { authHeaders } from '../api.js'
 
 const SCOPES = ['local', 'global', 'user']
 
+// Whether a session's tool has any MCP store is decided server-side and
+// delivered as `mcpSupported` on the menu session (see MenuSession in
+// internal/web/session_data_service.go). Do NOT reimplement the predicate
+// here: session.ToolSupportsMCPManager is config-driven, so a user tool
+// declaring compatible_with = "claude" is supported even though its name is
+// not in any hardcoded list.
+function toolSupportsMCP(session) {
+  return session.mcpSupported !== false
+}
+
+// jsonFetch keeps this pane's 204 handling and error shaping, but the headers
+// (and therefore the bearer token) come from the shared helper. Building them
+// locally is what made every MCP call 401 against an authenticated server.
 async function jsonFetch(path, opts = {}) {
   const res = await fetch(path, {
-    headers: { 'Content-Type': 'application/json' },
     ...opts,
+    headers: authHeaders(opts.headers),
   })
   if (!res.ok) {
     let msg = `${res.status} ${res.statusText}`
     try {
       const body = await res.json()
-      if (body && body.error) msg = body.error
+      // The API error envelope is {error: {code, message}}; reading
+      // body.error directly rendered "[object Object]" and hid the reason.
+      const apiMsg = body && body.error && body.error.message
+      if (apiMsg) msg = apiMsg
     } catch (_) { /* ignore */ }
     throw new Error(msg)
   }
@@ -46,7 +63,10 @@ export function McpPane() {
   const [error, setError] = useState('')
 
   const refresh = useCallback(async () => {
-    if (!session) return
+    // Hooks must run unconditionally, so guard here rather than relying on the
+    // unsupported-tool early return below: without this the pane would fire a
+    // request the server is obliged to refuse.
+    if (!session || !toolSupportsMCP(session)) return
     setLoading(true)
     setError('')
     try {
@@ -126,6 +146,23 @@ export function McpPane() {
           <div class="title" style="font-size: 16px;">MCP Manager</div>
           <div style="font-family: var(--mono); font-size: 12px; color: var(--text-dim); padding-top: 8px;">
             Select a session in the sidebar to manage MCPs.
+          </div>
+        </div>
+      </div>
+    `
+  }
+
+  // Say so rather than rendering a catalog whose buttons the server will
+  // refuse. The tool decides which MCP store exists; a shell session has none.
+  if (!toolSupportsMCP(session)) {
+    return html`
+      <div class="costs" data-testid="mcp-pane">
+        <div class="chart-card" style="text-align: center; padding: 48px 24px;">
+          <div class="title" style="font-size: 16px;">MCP Manager</div>
+          <div data-testid="mcp-unsupported-tool"
+               style="font-family: var(--mono); font-size: 12px; color: var(--text-dim); padding-top: 8px;">
+            MCP management is not available for ${session.tool || 'this'} sessions.
+            Supported tools: Claude, Codex, Gemini, Cursor, OpenCode.
           </div>
         </div>
       </div>

--- a/internal/web/static_files_test.go
+++ b/internal/web/static_files_test.go
@@ -169,6 +169,112 @@ func TestAuthTokenIsNeverPersistedToWebStorage(t *testing.T) {
 	}
 }
 
+// TestAppScriptsUseTheSharedAuthenticatedFetch is the regression gate for the
+// MCP pane breaking against an authenticated server.
+//
+// The bearer token exists only in authTokenSignal, so a call site that
+// hand-rolls fetch() silently omits Authorization and 401s the moment the
+// server runs with --token or --token-file. McpPane.js shipped exactly that:
+// a private copy of the fetch helper that never grew the header, which made
+// the whole MCP pane unusable through the UI while every server-side test
+// passed. AppShell.js and SettingsPanel.js carried the same shape.
+//
+// Rule: inside static/app, only api.js may call fetch() without authHeaders().
+// The check reads the whole balanced call expression rather than one line,
+// because the call that actually broke was `fetch(path, {` — a variable URL
+// spread over several lines, which a line-oriented or URL-matching check walks
+// straight past. (sw.js is a service worker outside static/app; it proxies
+// requests it did not originate and is correctly out of scope.)
+func TestAppScriptsUseTheSharedAuthenticatedFetch(t *testing.T) {
+	var scripts []string
+	err := fs.WalkDir(embeddedStaticFiles, "static/app", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".js") {
+			scripts = append(scripts, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk app scripts: %v", err)
+	}
+	if len(scripts) == 0 {
+		t.Fatal("no app scripts found; the guard would pass vacuously")
+	}
+
+	checked := 0
+	for _, path := range scripts {
+		// api.js is the shared helper itself: the one place allowed to call
+		// fetch() directly, because it is what adds the header.
+		if path == "static/app/api.js" {
+			continue
+		}
+		body, err := embeddedStaticFiles.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		src := string(body)
+		for _, call := range fetchCallExpressions(src) {
+			checked++
+			if !strings.Contains(call.args, "authHeaders") {
+				t.Errorf("%s:%d calls fetch() without authHeaders(); it will 401 against a "+
+					"server started with --token/--token-file:\n\t%s",
+					path, 1+strings.Count(src[:call.offset], "\n"), strings.TrimSpace(call.args))
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no fetch() call sites found outside api.js; the guard has gone stale")
+	}
+}
+
+type fetchCall struct {
+	offset int
+	args   string
+}
+
+// fetchCallExpressions returns the balanced argument text of every fetch(...)
+// call in src, skipping `apiFetch(`/`jsonFetch(`-style wrappers whose name
+// merely ends in "fetch".
+func fetchCallExpressions(src string) []fetchCall {
+	var out []fetchCall
+	for i := 0; i+6 <= len(src); i++ {
+		if src[i:i+6] != "fetch(" {
+			continue
+		}
+		// Require a non-identifier character before "fetch" so apiFetch( and
+		// jsonFetch( (which do carry the header, or are the helper itself)
+		// are not double-counted.
+		if i > 0 && isJSIdentByte(src[i-1]) {
+			continue
+		}
+		depth, j := 0, i+5
+		for ; j < len(src); j++ {
+			switch src[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+			if depth == 0 {
+				break
+			}
+		}
+		if j >= len(src) {
+			break
+		}
+		out = append(out, fetchCall{offset: i, args: src[i : j+1]})
+		i = j
+	}
+	return out
+}
+
+func isJSIdentByte(b byte) bool {
+	return b == '_' || b == '$' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
 // TestAddonCanvasDeleted is the regression gate for Phase 8 / Plan 03
 // (PERF-C). xterm v6 never references the canvas renderer, so the 94 KB
 // vendor file was dead weight. This test ensures the file stays deleted:

--- a/tests/web/e2e/mcp-auth.spec.js
+++ b/tests/web/e2e/mcp-auth.spec.js
@@ -1,0 +1,178 @@
+// e2e/mcp-auth.spec.js -- the authenticated browser path for MCP management.
+//
+// Why this file exists separately from mcps.spec.js:
+//
+// The shared fixture in helpers/global-setup.js runs with NO bearer token, so
+// Server.authorize() short-circuits to "allowed" and every request succeeds
+// regardless of headers. That made the whole suite blind to a pane that never
+// sends Authorization — which is exactly what shipped: McpPane.js had a private
+// fetch helper with no token, so every catalog read and every mutation 401'd
+// against a real `agent-deck web --token` deployment while 595 e2e tests stayed
+// green.
+//
+// So this spec boots its OWN fixture WITH --auth-token and drives the real UI:
+// click the MCPs tab, click Attach, and require the attachment to appear. The
+// negative case loads the same page without the token and requires the pane to
+// surface the failure, which proves the positive case actually depends on the
+// header rather than passing because auth is off.
+
+import { test, expect } from '@playwright/test'
+import { spawn, execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..')
+const BIN_PATH = resolve(REPO_ROOT, 'tests/web/.tmp/web-fixture')
+const TOKEN = 'e2e-bearer-token-for-mcp-auth'
+const SESSION_ID = 'sess-001'
+
+let proc
+let baseURL
+
+test.beforeAll(async () => {
+  // global-setup already builds this binary; build defensively so the spec can
+  // also run on its own.
+  if (!existsSync(BIN_PATH)) {
+    execFileSync('go', ['build', '-o', BIN_PATH, './tests/web/fixtures/cmd/web-fixture/'], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+      env: { ...process.env, GOTOOLCHAIN: 'go1.25.13' },
+    })
+  }
+
+  const portFile = join(mkdtempSync(join(tmpdir(), 'ad-mcp-auth-')), 'port')
+  proc = spawn(BIN_PATH, ['--listen', '127.0.0.1:0', '--port-file', portFile, '--auth-token', TOKEN], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
+
+  const deadline = Date.now() + 15_000
+  let port
+  while (Date.now() < deadline) {
+    if (existsSync(portFile)) {
+      port = readFileSync(portFile, 'utf8').trim()
+      if (port && port !== '0') break
+    }
+    await sleep(100)
+  }
+  if (!port) throw new Error('authenticated web-fixture never published a port')
+  baseURL = `http://127.0.0.1:${port}`
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseURL}/healthz`)
+      if (res.ok) return
+    } catch (_) { /* not up yet */ }
+    await sleep(100)
+  }
+  throw new Error('authenticated web-fixture never became healthy')
+})
+
+test.afterAll(async () => {
+  if (proc && !proc.killed) proc.kill('SIGTERM')
+})
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('MCP management — authenticated browser path', () => {
+  // The MCP pane is desktop/tablet only, same skip as mcps.spec.js.
+  test.skip(({ viewport }) => (viewport?.width || 1280) < 768, 'phone viewport: MCP management UI is desktop/tablet only')
+
+  test.beforeEach(async () => {
+    const res = await fetch(`${baseURL}/__fixture/reset`, { method: 'POST' })
+    expect(res.status).toBe(204)
+  })
+
+  test('the server really is authenticated (guards against a false pass)', async ({ page }) => {
+    const noToken = await page.request.get(`${baseURL}/api/mcps`)
+    expect(noToken.status()).toBe(401)
+
+    const withToken = await page.request.get(`${baseURL}/api/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+    expect(withToken.status()).toBe(200)
+  })
+
+  test('attaching an MCP through the UI succeeds against an authenticated server', async ({ page }) => {
+    // main.js reads ?token= into authTokenSignal and strips it from the URL.
+    await page.goto(`${baseURL}/s/${SESSION_ID}?token=${TOKEN}`)
+
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+    await expect(page.getByTestId('mcp-pane')).toBeVisible()
+
+    // A 401 renders here. Requiring it absent is the actual regression
+    // assertion: before the fix, the catalog read failed and this filled in
+    // with "unauthorized".
+    await expect(page.getByTestId('mcp-error')).toBeHidden()
+
+    // The catalog only renders if the authenticated GET /api/mcps succeeded.
+    const attachButton = page.getByTestId('mcp-attach-exa')
+    await expect(attachButton).toBeVisible()
+    await attachButton.click()
+
+    // The mutation (POST) and the refresh (GET) must both carry the token.
+    await expect(page.getByTestId('mcp-attached-exa')).toBeVisible()
+    await expect(page.getByTestId('mcp-error')).toBeHidden()
+
+    // Confirm it landed server-side, not just in local component state.
+    const list = await page.request.get(`${baseURL}/api/sessions/${SESSION_ID}/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+    expect(list.status()).toBe(200)
+    expect((await list.json()).local).toContain('exa')
+  })
+
+  test('detaching through the UI also carries the token', async ({ page }) => {
+    await fetch(`${baseURL}/api/sessions/${SESSION_ID}/mcps/exa`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json', Origin: baseURL },
+      body: JSON.stringify({ scope: 'local' }),
+    })
+
+    await page.goto(`${baseURL}/s/${SESSION_ID}?token=${TOKEN}`)
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+    await expect(page.getByTestId('mcp-attached-exa')).toBeVisible()
+
+    await page.getByTestId('mcp-detach-exa').click()
+    await expect(page.getByTestId('mcp-attached-exa')).toBeHidden()
+    await expect(page.getByTestId('mcp-error')).toBeHidden()
+  })
+
+  test('a session whose tool has no MCP store says so instead of offering buttons', async ({ page }) => {
+    // sess-004 is a shell session. The server refuses MCP routes for it, so the
+    // pane must not render a catalog whose every button would fail.
+    await page.goto(`${baseURL}/s/sess-004?token=${TOKEN}`)
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+
+    await expect(page.getByTestId('mcp-unsupported-tool')).toBeVisible()
+    await expect(page.getByTestId('mcp-unsupported-tool')).toContainText('shell')
+    await expect(page.getByTestId('mcp-attach-exa')).toHaveCount(0)
+
+    // And the API agrees, so the UI is not merely hiding a working surface.
+    const res = await page.request.get(`${baseURL}/api/sessions/sess-004/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('without the token no MCP catalog is reachable through the UI', async ({ page }) => {
+    // The HTML shell is served unauthenticated on purpose (handleIndex does not
+    // authorize, so the page can boot and read ?token= out of the URL), but
+    // every data path behind it is authenticated: the menu SSE 401s, so no
+    // session ever populates and the pane cannot reach a catalog. The point of
+    // this case is the anti-false-pass one — if an attach button were reachable
+    // here, the passing test above would not be proving anything about the
+    // Authorization header.
+    await page.goto(`${baseURL}/s/${SESSION_ID}`)
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+
+    // Deliberately no assertion that the pane mounts: with the menu SSE
+    // rejected there is no session to select, so the MCP pane is never reached
+    // at all. What matters is that nothing actionable appears.
+    await expect(page.getByTestId('mcp-attach-exa')).toHaveCount(0)
+    await expect(page.getByTestId('mcp-attached-exa')).toHaveCount(0)
+    await expect(page.getByTestId('mcp-catalog')).toHaveCount(0)
+  })
+})

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -36,6 +36,7 @@ func main() {
 	startupToken := flag.String("startup-token", "", "Echoed at /__fixture/whoami so callers can verify they're talking to this exact process")
 	trustedDomains := flag.String("trusted-domains", "", "Comma-separated `[web].trusted_domains` hosts served by GET /api/settings (issue #1682)")
 	confirmLinkOpen := flag.Bool("confirm-link-open", true, "Value of `[web].confirm_link_open` served by GET /api/settings (issue #1682)")
+	authToken := flag.String("auth-token", "", "Bearer token for API/WS access. When set the fixture behaves like `agent-deck web --token`, so specs can exercise the authenticated browser path.")
 	flag.Parse()
 
 	store := newFixtureStore()
@@ -71,6 +72,11 @@ func main() {
 		ConfirmLinkOpen: confirmLinkOpen,
 		MenuData:        store,
 		RemoteFleet:     store,
+		// Empty by default, so the existing suite keeps running
+		// unauthenticated. mcp-auth.spec.js boots a second fixture WITH a
+		// token: without that, no browser test ever exercises the
+		// Authorization header and a pane can drop it unnoticed.
+		Token: *authToken,
 	})
 	server.SetMutator(store)
 	// Hold the MCP manager on the store so /__fixture/reset clears its
@@ -204,7 +210,7 @@ func (s *fixtureStore) seed() {
 	sandboxCPU := "2.0"
 	s.sessions = map[string]*web.MenuSession{
 		"sess-001": {
-			ID: "sess-001", Title: "agent-deck", Tool: "claude",
+			ID: "sess-001", Title: "agent-deck", Tool: "claude", MCPSupported: true,
 			Status: session.StatusIdle, GroupPath: "work", ProjectPath: "/srv/agent-deck",
 			Order: 0, CreatedAt: now,
 			// Populate every promoted MenuSession field on a single session so
@@ -249,7 +255,7 @@ func (s *fixtureStore) seed() {
 			},
 		},
 		"sess-002": {
-			ID: "sess-002", Title: "frontend", Tool: "claude",
+			ID: "sess-002", Title: "frontend", Tool: "claude", MCPSupported: true,
 			Status: session.StatusRunning, GroupPath: "work", ProjectPath: "/srv/frontend",
 			Order: 1, CreatedAt: now,
 			// Populate tmux internals on the running session so parity-state
@@ -259,12 +265,12 @@ func (s *fixtureStore) seed() {
 			TmuxSocketName: "agentdeck-fixture",
 		},
 		"sess-003": {
-			ID: "sess-003", Title: "innotrade-api", Tool: "codex",
+			ID: "sess-003", Title: "innotrade-api", Tool: "codex", MCPSupported: true,
 			Status: session.StatusIdle, GroupPath: "work/innotrade", ProjectPath: "/srv/innotrade-api",
 			Order: 0, CreatedAt: now,
 		},
 		"sess-004": {
-			ID: "sess-004", Title: "scratch", Tool: "shell",
+			ID: "sess-004", Title: "scratch", Tool: "shell", MCPSupported: false,
 			Status: session.StatusIdle, GroupPath: "personal", ProjectPath: "/home/dev/scratch",
 			Order: 0, CreatedAt: now,
 		},
@@ -353,7 +359,7 @@ func (s *fixtureStore) CreateSession(title, tool, projectPath, groupPath, modelI
 	id := fmt.Sprintf("sess-%03d", s.nextID)
 	s.nextID++
 	s.sessions[id] = &web.MenuSession{
-		ID: id, Title: title, Tool: tool,
+		ID: id, Title: title, Tool: tool, MCPSupported: session.ToolSupportsMCPManager(tool),
 		Status: session.StatusIdle, GroupPath: groupPath, ProjectPath: projectPath,
 		Order: len(s.order), CreatedAt: s.now(),
 	}
@@ -507,7 +513,7 @@ func (s *fixtureStore) ForkSession(parentID string) (string, error) {
 	id := fmt.Sprintf("sess-%03d", s.nextID)
 	s.nextID++
 	s.sessions[id] = &web.MenuSession{
-		ID: id, Title: parent.Title + " (fork)", Tool: parent.Tool,
+		ID: id, Title: parent.Title + " (fork)", Tool: parent.Tool, MCPSupported: parent.MCPSupported,
 		Status: session.StatusIdle, GroupPath: parent.GroupPath, ProjectPath: parent.ProjectPath,
 		ParentSessionID: parentID, Order: len(s.order), CreatedAt: s.now(),
 	}

--- a/tests/web/fixtures/cmd/web-fixture/mcp.go
+++ b/tests/web/fixtures/cmd/web-fixture/mcp.go
@@ -37,12 +37,12 @@ func (f *fixtureMCPManager) ListCatalog() []web.MCPCatalogEntry {
 	return append([]web.MCPCatalogEntry(nil), f.catalog...)
 }
 
-func (f *fixtureMCPManager) ListAttached(projectPath string) (map[string][]string, error) {
+func (f *fixtureMCPManager) ListAttached(target web.MCPTarget) (map[string][]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := make(map[string][]string, 3)
 	for _, scope := range []string{"local", "global", "user"} {
-		names := f.attached[projectPath][scope]
+		names := f.attached[target.ProjectPath][scope]
 		cp := append([]string(nil), names...)
 		sort.Strings(cp)
 		if cp == nil {
@@ -53,43 +53,43 @@ func (f *fixtureMCPManager) ListAttached(projectPath string) (map[string][]strin
 	return out, nil
 }
 
-func (f *fixtureMCPManager) Attach(projectPath, name, scope string) error {
+func (f *fixtureMCPManager) Attach(target web.MCPTarget, name, scope string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.attached[projectPath] == nil {
-		f.attached[projectPath] = make(map[string][]string)
+	if f.attached[target.ProjectPath] == nil {
+		f.attached[target.ProjectPath] = make(map[string][]string)
 	}
-	for _, n := range f.attached[projectPath][scope] {
+	for _, n := range f.attached[target.ProjectPath][scope] {
 		if n == name {
 			return nil
 		}
 	}
-	f.attached[projectPath][scope] = append(f.attached[projectPath][scope], name)
+	f.attached[target.ProjectPath][scope] = append(f.attached[target.ProjectPath][scope], name)
 	return nil
 }
 
-func (f *fixtureMCPManager) Detach(projectPath, name, scope string) error {
+func (f *fixtureMCPManager) Detach(target web.MCPTarget, name, scope string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.attached[projectPath] == nil {
+	if f.attached[target.ProjectPath] == nil {
 		return nil
 	}
-	src := f.attached[projectPath][scope]
+	src := f.attached[target.ProjectPath][scope]
 	out := src[:0]
 	for _, n := range src {
 		if n != name {
 			out = append(out, n)
 		}
 	}
-	f.attached[projectPath][scope] = out
+	f.attached[target.ProjectPath][scope] = out
 	return nil
 }
 
-func (f *fixtureMCPManager) Move(projectPath, name, fromScope, toScope string) error {
-	if err := f.Detach(projectPath, name, fromScope); err != nil {
+func (f *fixtureMCPManager) Move(target web.MCPTarget, name, fromScope, toScope string) error {
+	if err := f.Detach(target, name, fromScope); err != nil {
 		return err
 	}
-	return f.Attach(projectPath, name, toScope)
+	return f.Attach(target, name, toScope)
 }
 
 // Reset clears all attached MCPs (called by /__fixture/reset).


### PR DESCRIPTION
## Summary

Fix-forward for three defects in the web MCP surface, reported against #1953. The first makes the MCP pane unusable against an authenticated server; the other two make it destructive. All three are reproduced by tests that were verified to fail against the unfixed code.

## 1. The pane never sent the bearer token (P1)

`McpPane.js` carried a private copy of the fetch helper that built its own headers and never grew `Authorization`. The token lives only in `authTokenSignal`, so every catalog read and every mutation from the browser answered 401 against a server started with `--token` or `--token-file` — the exact deployment #1953 was meant to enable. The manager was unusable through the UI.

`AppShell.js` and `SettingsPanel.js` had the same shape against `/api/settings`, `/api/profiles` and `/api/system/stats`, which are authenticated too. Those were already broken before #1953; they are fixed here as well. `api.js` now exports `authHeaders()` and every `/api/` caller uses it.

The pane's error rendering also read `body.error` from an envelope shaped `{error: {code, message}}`, so a failure displayed as `[object Object]` and hid the reason. It now reads `body.error.message`.

### Why nothing caught it

The Playwright fixture runs with **no** token, so `Server.authorize()` short-circuits to "allowed" and a missing header is invisible. 595 e2e tests passed over a completely broken pane.

The fixture now takes `--auth-token`, and `e2e/mcp-auth.spec.js` boots a second fixture with one and drives the real UI: click the MCPs tab, click Attach, require the attachment to render and the server to agree. A companion case asserts `/api/mcps` really does 401 without the header, so the positive case cannot pass for the wrong reason.

## 2. Local attach/detach read one store and wrote another (P1)

`local` read `session.GetProjectMCPNames` — the Claude config's `projects[path].mcpServers` map — but wrote `<project>/.mcp.json`. `MCPInfo` keeps those as separate fields (`Project` vs `LocalMCPs`) because they are separate files. So attaching one server rewrote `.mcp.json` from a list that never contained the servers already in it, silently dropping them.

`local` now reads and writes `.mcp.json`. The Claude config's per-project entries move into the **global** bucket, which is where the TUI dialog has always grouped them.

## 3. The manager hardcoded Claude helpers for every tool (P1)

The manager was keyed by project path alone, so selecting a Codex, Gemini, Cursor or OpenCode session mutated Claude's configuration. Requests now carry an `MCPTarget` (tool + project path, both read from the same menu snapshot entry) and route through the per-tool helpers the TUI already uses.

Scopes a tool does not have are refused with a reason rather than redirected:

| Tool | local | global | user |
|---|---|---|---|
| Claude-compatible | ✅ | ✅ | ✅ |
| Cursor, OpenCode | ✅ | ✅ | ❌ |
| Codex, Gemini | ❌ | ✅ | ❌ |
| everything else | refused at the handler | | |

`~/.claude.json` stays Claude's alone. Sessions whose tool has no MCP store are refused by the handler and told so by the pane, instead of being offered buttons that fail.

Whether a tool is supported is computed server-side and delivered as `MenuSession.mcpSupported`, because `session.ToolSupportsMCPManager` is config-driven: a user tool declaring `compatible_with = "claude"` is supported even though no hardcoded client-side list would say so. Duplicating the predicate in JS would have been wrong for custom tools.

## Regression gates

Each was run against the unfixed code and confirmed to fail:

- `TestAppScriptsUseTheSharedAuthenticatedFetch` — parses the balanced `fetch()` call expression in every served app script and requires `authHeaders()`. It reads the whole expression rather than a line because the call that actually broke was `fetch(path, {`: a variable URL spread over several lines, which a line-oriented or URL-matching check walks straight past. My first attempt at this guard *was* line-oriented and passed against the broken pane; the negative control caught that before it shipped.
- `TestLocalAttachPreservesServersAlreadyInMcpJSON` and its detach mirror.
- `TestNonClaudeToolDoesNotTouchClaudeConfig` — a Codex attach must leave Claude's config byte-identical.
- `TestScopesAreRefusedWhenTheToolDoesNotHaveThem`.
- `TestClaudeGlobalScopeCoversProjectEntries` — pins where `projects[path]` belongs.
- `TestMCPRoutesRefuseUnsupportedTool`, `TestMCPTargetCarriesTheSessionTool`.
- `e2e/mcp-auth.spec.js` — authenticated attach and detach through the real UI, plus the unsupported-tool pane state.

## Validation

Sandboxed (`HOME` a temp dir, XDG vars empty), package-scoped, `-p 1`.

- `make css-verify`, `gofmt`, `go build` (agent-deck + web-fixture), `go vet`, `golangci-lint`: all passed
- `go test ./internal/web` (full package): passed
- `go test ./cmd/agent-deck -run '^(TestBuildWebServer_|TestResolveWebToken_)'`: passed
- Web unit (Vitest): 10 files, 131 passed
- Playwright e2e + screenshots: **605 passed**, 0 failed (up from 595; the new spec adds 10 across desktop and tablet)

Fixes the three defects reported on #1953.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP management now uses the correct tool and project configuration.
  * Unsupported tools and scopes are clearly identified, with unavailable-state messaging in the interface.
  * MCP operations support authenticated requests.

* **Bug Fixes**
  * Prevented MCP changes from overwriting configuration belonging to other tools.
  * Preserved existing MCP entries during attach and detach operations.
  * Improved API error messages and authentication consistency.

* **Tests**
  * Added regression and end-to-end coverage for authentication, persistence, unsupported tools, and configuration safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->