### PR TITLE
fix(web): model MCP scopes honestly and make scope moves transactional

### DIFF
--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -283,59 +283,8 @@ func WriteGlobalMCP(enabledNames []string) error {
 		rawConfig = make(map[string]interface{})
 	}
 
-	// Build new mcpServers from enabled names using config.toml definitions
 	availableMCPs := GetAvailableMCPs()
-	pool := GetGlobalPool() // Get pool instance (may be nil)
-	mcpServers := make(map[string]MCPServerConfig)
-
-	for _, name := range enabledNames {
-		if def, ok := availableMCPs[name]; ok {
-			// Check if this is an HTTP/SSE MCP (has URL configured)
-			if def.URL != "" {
-				// Start HTTP server if configured
-				if def.HasAutoStartServer() {
-					if err := StartHTTPServer(name, &def); err != nil {
-						mcpCatLog.Warn("http_server_start_failed", slog.String("mcp", name), slog.String("scope", "global"), slog.Any("error", err))
-					}
-				}
-
-				transport := def.Transport
-				if transport == "" {
-					transport = "http" // default to http if URL is set
-				}
-				mcpServers[name] = MCPServerConfig{
-					Type:    transport,
-					URL:     def.URL,
-					Headers: def.Headers,
-				}
-				mcpCatLog.Info("transport_http", slog.String("mcp", name), slog.String("scope", "global"), slog.String("transport", transport), slog.String("url", def.URL))
-				continue
-			}
-
-			// Try to use pool socket for this MCP (stdio only)
-			if socketCfg, used := tryPoolSocket(pool, name, "global"); used {
-				mcpServers[name] = socketCfg
-				continue
-			}
-
-			// Fallback to stdio mode (pool disabled, excluded, or socket failed with fallback enabled)
-			args := def.Args
-			if args == nil {
-				args = []string{}
-			}
-			env := def.Env
-			if env == nil {
-				env = map[string]string{}
-			}
-			mcpServers[name] = MCPServerConfig{
-				Type:    "stdio",
-				Command: def.Command,
-				Args:    args,
-				Env:     env,
-			}
-			mcpCatLog.Info("transport_stdio", slog.String("mcp", name), slog.String("scope", "global"))
-		}
-	}
+	mcpServers := buildManagedMCPServers(enabledNames, "global")
 
 	// Merge: preserve non-agent-deck entries from existing config (#146)
 	mergedMCPs := make(map[string]interface{})
@@ -419,6 +368,115 @@ func GetProjectMCPNames(projectPath string) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// buildManagedMCPServers turns catalog names into the mcpServers entries that
+// go into a Claude-style config, honouring HTTP/SSE definitions and the shared
+// stdio pool. scope is used only for log attribution.
+func buildManagedMCPServers(enabledNames []string, scope string) map[string]MCPServerConfig {
+	availableMCPs := GetAvailableMCPs()
+	pool := GetGlobalPool() // may be nil
+	mcpServers := make(map[string]MCPServerConfig)
+
+	for _, name := range enabledNames {
+		def, ok := availableMCPs[name]
+		if !ok {
+			continue
+		}
+		if def.URL != "" {
+			if def.HasAutoStartServer() {
+				if err := StartHTTPServer(name, &def); err != nil {
+					mcpCatLog.Warn("http_server_start_failed", slog.String("mcp", name), slog.String("scope", scope), slog.Any("error", err))
+				}
+			}
+			transport := def.Transport
+			if transport == "" {
+				transport = "http"
+			}
+			mcpServers[name] = MCPServerConfig{Type: transport, URL: def.URL, Headers: def.Headers}
+			mcpCatLog.Info("transport_http", slog.String("mcp", name), slog.String("scope", scope), slog.String("transport", transport), slog.String("url", def.URL))
+			continue
+		}
+		if socketCfg, used := tryPoolSocket(pool, name, scope); used {
+			mcpServers[name] = socketCfg
+			continue
+		}
+		args := def.Args
+		if args == nil {
+			args = []string{}
+		}
+		env := def.Env
+		if env == nil {
+			env = map[string]string{}
+		}
+		mcpServers[name] = MCPServerConfig{Type: "stdio", Command: def.Command, Args: args, Env: env}
+		mcpCatLog.Info("transport_stdio", slog.String("mcp", name), slog.String("scope", scope))
+	}
+	return mcpServers
+}
+
+// WriteProjectMCP writes enabled catalog MCPs into
+// projects[projectPath].mcpServers of Claude's config.
+//
+// This is the write counterpart to GetProjectMCPNames. Claude keeps
+// per-project servers there, distinct from the root mcpServers map that
+// WriteGlobalMCP owns and from the project's own .mcp.json. Without this,
+// anything reporting project entries had to write them through the root map,
+// which silently moved servers between scopes.
+//
+// Entries not defined in config.toml are preserved (#146).
+func WriteProjectMCP(projectPath string, enabledNames []string) error {
+	if projectPath == "" {
+		return fmt.Errorf("project MCP write: empty project path")
+	}
+	configDir := GetClaudeConfigDir()
+	configFile := filepath.Join(configDir, ".claude.json")
+
+	var rawConfig map[string]interface{}
+	if data, err := os.ReadFile(configFile); err == nil {
+		if err := json.Unmarshal(data, &rawConfig); err != nil {
+			rawConfig = make(map[string]interface{})
+		}
+	} else {
+		rawConfig = make(map[string]interface{})
+	}
+
+	projects, _ := rawConfig["projects"].(map[string]interface{})
+	if projects == nil {
+		projects = make(map[string]interface{})
+	}
+	proj, _ := projects[projectPath].(map[string]interface{})
+	if proj == nil {
+		proj = make(map[string]interface{})
+	}
+
+	availableMCPs := GetAvailableMCPs()
+	managed := buildManagedMCPServers(enabledNames, "project")
+
+	merged := make(map[string]interface{})
+	if existing, ok := proj["mcpServers"].(map[string]interface{}); ok {
+		for name, cfg := range existing {
+			if _, isManaged := availableMCPs[name]; !isManaged {
+				merged[name] = cfg
+			}
+		}
+	}
+	for name, cfg := range managed {
+		merged[name] = cfg
+	}
+
+	proj["mcpServers"] = merged
+	projects[projectPath] = proj
+	rawConfig["projects"] = projects
+
+	data, err := json.MarshalIndent(rawConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if err := writeJSONFileAtomic(configFile, data, 0600); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
 }
 
 // ClearProjectMCPs removes all MCPs from projects[path].mcpServers in Claude's config

--- a/internal/web/handlers_mcps.go
+++ b/internal/web/handlers_mcps.go
@@ -75,8 +75,15 @@ type MCPCatalogResponse struct {
 type SessionMCPsResponse struct {
 	SessionID string   `json:"sessionId"`
 	Local     []string `json:"local"`
-	Global    []string `json:"global"`
-	User      []string `json:"user"`
+	// Project is Claude's projects[path].mcpServers map — a distinct store
+	// from both Local (<project>/.mcp.json) and Global (root mcpServers).
+	Project []string `json:"project"`
+	Global  []string `json:"global"`
+	User    []string `json:"user"`
+	// Scopes lists the scopes this session's tool actually has, most specific
+	// first. The client renders and defaults from this instead of assuming
+	// every tool has all four.
+	Scopes []string `json:"scopes"`
 }
 
 // mcpMutateRequest is the JSON body for POST/DELETE/PATCH endpoints.
@@ -166,8 +173,10 @@ func (s *Server) handleSessionMCPs(w http.ResponseWriter, r *http.Request, sessi
 		writeJSON(w, http.StatusOK, SessionMCPsResponse{
 			SessionID: sessionID,
 			Local:     sortedScope(attached, "local"),
+			Project:   sortedScope(attached, "project"),
 			Global:    sortedScope(attached, "global"),
 			User:      sortedScope(attached, "user"),
+			Scopes:    scopesForTool(target.Tool),
 		})
 		return
 	}
@@ -201,9 +210,12 @@ func (s *Server) handleMCPAttach(w http.ResponseWriter, r *http.Request, target 
 	if !ok {
 		return
 	}
-	scope, ok := resolveScope(req, "local")
+	// Default to the tool's most specific store rather than a hardcoded
+	// "local": Codex and Gemini have no local scope, so a bodyless attach
+	// would otherwise always be refused for them.
+	scope, ok := resolveScope(req, defaultAttachScope(target.Tool))
 	if !ok {
-		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|global|user)")
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|project|global|user)")
 		return
 	}
 	if err := s.mcpMgr.Attach(target, name, scope); err != nil {
@@ -223,7 +235,9 @@ func (s *Server) handleMCPDetach(w http.ResponseWriter, r *http.Request, target 
 	}
 	scope := s.detectAttachedScope(target, name)
 	if scope == "" {
-		scope = "local"
+		// Not found in any scope; fall back to the tool's default rather than
+		// a hardcoded "local" that Codex and Gemini do not have.
+		scope = defaultAttachScope(target.Tool)
 	}
 	if r.ContentLength > 0 {
 		req, ok := decodeMCPMutateBody(w, r)
@@ -233,7 +247,7 @@ func (s *Server) handleMCPDetach(w http.ResponseWriter, r *http.Request, target 
 		if resolved, ok := resolveScope(req, scope); ok {
 			scope = resolved
 		} else {
-			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|global|user)")
+			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|project|global|user)")
 			return
 		}
 	}
@@ -262,7 +276,7 @@ func (s *Server) handleMCPMove(w http.ResponseWriter, r *http.Request, target MC
 	}
 	toScope, ok := resolveScope(req, "")
 	if !ok {
-		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|global|user)")
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid scope (want local|project|global|user)")
 		return
 	}
 	fromScope := s.detectAttachedScope(target, name)
@@ -308,7 +322,7 @@ func (s *Server) detectAttachedScope(target MCPTarget, name string) string {
 	if err != nil {
 		return ""
 	}
-	for _, scope := range []string{"local", "global", "user"} {
+	for _, scope := range scopesForTool(target.Tool) {
 		for _, n := range attached[scope] {
 			if n == name {
 				return scope
@@ -343,7 +357,7 @@ func resolveScope(req mcpMutateRequest, defaultScope string) (string, bool) {
 		scope = defaultScope
 	}
 	switch scope {
-	case "local", "global", "user":
+	case "local", "project", "global", "user":
 		return scope, true
 	default:
 		return "", false
@@ -401,10 +415,26 @@ func scopesForTool(tool string) []string {
 	case tool == "cursor", tool == "opencode":
 		return []string{"local", "global"}
 	case session.IsClaudeCompatible(tool):
-		return []string{"local", "global", "user"}
+		// "project" is Claude's projects[path].mcpServers map. It is a real,
+		// separately-written store, so it gets its own scope instead of being
+		// folded into "global": folding it there meant a detach reported
+		// success while leaving the server attached at project level, and an
+		// attach could copy project-only entries up into the root map.
+		return []string{"local", "project", "global", "user"}
 	default:
 		return nil
 	}
+}
+
+// defaultAttachScope is the scope the UI should preselect for a tool: the most
+// specific store it actually has. Codex and Gemini have no local scope, which
+// is why the pane must ask instead of hardcoding "local".
+func defaultAttachScope(tool string) string {
+	scopes := scopesForTool(tool)
+	if len(scopes) == 0 {
+		return ""
+	}
+	return scopes[0]
 }
 
 func toolHasScope(tool, scope string) bool {
@@ -421,28 +451,30 @@ func toolHasScope(tool, scope string) bool {
 // that never contained the servers already in it, silently dropping them.
 // Claude's projects[path] entries belong to the GLOBAL bucket here, exactly as
 // the TUI groups them.
-func attachedNamesForTool(target MCPTarget) (local, global, user []string) {
+// scopeNames maps each scope a tool has to the names currently in that scope's
+// store. Every entry must be read from the exact file its writeScope
+// counterpart targets, or a read-modify-write crosses a store boundary.
+func attachedNamesForTool(target MCPTarget) map[string][]string {
+	out := map[string][]string{}
 	switch {
 	case session.IsCodexCompatible(target.Tool):
-		return nil, mcpInfoGlobal(session.GetCodexMCPInfo("")), nil
+		out["global"] = mcpInfoGlobal(session.GetCodexMCPInfo(""))
 	case target.Tool == "gemini":
-		return nil, mcpInfoGlobal(session.GetGeminiMCPInfo(target.ProjectPath)), nil
+		out["global"] = mcpInfoGlobal(session.GetGeminiMCPInfo(target.ProjectPath))
 	case target.Tool == "cursor":
 		info := session.GetCursorMCPInfo(target.ProjectPath)
-		return mcpInfoLocal(info), mcpInfoGlobal(info), nil
+		out["local"], out["global"] = mcpInfoLocal(info), mcpInfoGlobal(info)
 	case target.Tool == "opencode":
 		info := session.GetOpenCodeMCPInfo(target.ProjectPath)
-		return mcpInfoLocal(info), mcpInfoGlobal(info), nil
+		out["local"], out["global"] = mcpInfoLocal(info), mcpInfoGlobal(info)
 	case session.IsClaudeCompatible(target.Tool):
 		info := session.GetMCPInfo(target.ProjectPath)
-		// Global mirrors the TUI: the config's own mcpServers plus its
-		// per-project entries.
-		globals := append([]string(nil), session.GetGlobalMCPNames()...)
-		globals = append(globals, session.GetProjectMCPNames(target.ProjectPath)...)
-		return mcpInfoLocal(info), globals, session.GetUserMCPNames()
-	default:
-		return nil, nil, nil
+		out["local"] = mcpInfoLocal(info)                               // <project>/.mcp.json
+		out["project"] = session.GetProjectMCPNames(target.ProjectPath) // projects[path].mcpServers
+		out["global"] = session.GetGlobalMCPNames()                     // root mcpServers
+		out["user"] = session.GetUserMCPNames()                         // ~/.claude.json
 	}
+	return out
 }
 
 func mcpInfoLocal(info *session.MCPInfo) []string {
@@ -462,12 +494,11 @@ func mcpInfoGlobal(info *session.MCPInfo) []string {
 // ListAttached reports the catalog-defined MCPs attached to the target, per
 // scope, reading the same store each scope's write path targets.
 func (defaultMCPManager) ListAttached(target MCPTarget) (map[string][]string, error) {
-	local, global, user := attachedNamesForTool(target)
-	return map[string][]string{
-		"local":  filterDefined(local),
-		"global": filterDefined(global),
-		"user":   filterDefined(user),
-	}, nil
+	out := map[string][]string{}
+	for scope, names := range attachedNamesForTool(target) {
+		out[scope] = filterDefined(names)
+	}
+	return out, nil
 }
 
 func (m defaultMCPManager) Attach(target MCPTarget, name, scope string) error {
@@ -497,11 +528,42 @@ func (m defaultMCPManager) Detach(target MCPTarget, name, scope string) error {
 	return m.writeScope(target, scope, out)
 }
 
+// Move relocates an MCP between two scopes without ever leaving it detached
+// from both.
+//
+// The previous implementation detached first and only discovered an
+// unsupported destination when the subsequent attach failed — by which point
+// the server had already been removed from disk and the caller got nothing but
+// an error. That was reachable straight from the UI, which offered every scope
+// for every tool.
+//
+// Both scopes are validated before anything is written, and if the attach
+// still fails the source attachment is restored, so a failed move is a no-op
+// rather than a deletion.
 func (m defaultMCPManager) Move(target MCPTarget, name, fromScope, toScope string) error {
+	if err := checkScope(target.Tool, fromScope); err != nil {
+		return err
+	}
+	if err := checkScope(target.Tool, toScope); err != nil {
+		return err
+	}
+	if fromScope == toScope {
+		return nil
+	}
+
 	if err := m.Detach(target, name, fromScope); err != nil {
 		return err
 	}
-	return m.Attach(target, name, toScope)
+	if err := m.Attach(target, name, toScope); err != nil {
+		// Put it back. If the restore also fails, say both things: the caller
+		// needs to know the configuration was left short a server.
+		if restoreErr := m.Attach(target, name, fromScope); restoreErr != nil {
+			return fmt.Errorf("move %q from %q to %q failed: %w; restoring the original scope ALSO failed: %v — %q is now detached from both scopes",
+				name, fromScope, toScope, err, restoreErr, name)
+		}
+		return fmt.Errorf("move %q from %q to %q failed: %w (original scope restored)", name, fromScope, toScope, err)
+	}
+	return nil
 }
 
 // namesAt returns the current contents of one scope's store. It must stay the
@@ -511,36 +573,40 @@ func (defaultMCPManager) namesAt(target MCPTarget, scope string) ([]string, erro
 	if err := checkScope(target.Tool, scope); err != nil {
 		return nil, err
 	}
-	local, global, user := attachedNamesForTool(target)
-	switch scope {
-	case "local":
-		return filterDefined(local), nil
-	case "global":
-		return filterDefined(global), nil
-	default:
-		return filterDefined(user), nil
-	}
+	return filterDefined(attachedNamesForTool(target)[scope]), nil
 }
 
 func (defaultMCPManager) writeScope(target MCPTarget, scope string, names []string) error {
 	if err := checkScope(target.Tool, scope); err != nil {
 		return err
 	}
+	var err error
 	switch scope {
 	case "local":
-		return session.WriteLocalMCPConfigForTool(target.Tool, target.ProjectPath, names)
+		err = session.WriteLocalMCPConfigForTool(target.Tool, target.ProjectPath, names)
+	case "project":
+		// checkScope has already established the tool is Claude-compatible.
+		err = session.WriteProjectMCP(target.ProjectPath, names)
 	case "global":
-		return session.WriteGlobalMCPConfigForTool(target.Tool, names)
+		err = session.WriteGlobalMCPConfigForTool(target.Tool, names)
 	default:
-		// ~/.claude.json is Claude's own user-level store; checkScope has
-		// already established the tool is Claude-compatible.
-		return session.WriteUserMCP(names)
+		// ~/.claude.json is Claude's own user-level store.
+		err = session.WriteUserMCP(names)
 	}
+	if err != nil {
+		return err
+	}
+	// The readers above are cached (30s TTL for the Claude, Cursor and
+	// OpenCode project readers). Without this, the pane's refresh immediately
+	// after a mutation returns the pre-mutation list and the change looks like
+	// it failed. The TUI apply path invalidates for the same reason.
+	session.InvalidateProjectMCPIntegrationsCache(target.ProjectPath)
+	return nil
 }
 
 func checkScope(tool, scope string) error {
 	switch scope {
-	case "local", "global", "user":
+	case "local", "project", "global", "user":
 	default:
 		return errInvalidScope(scope)
 	}

--- a/internal/web/handlers_mcps_matrix_test.go
+++ b/internal/web/handlers_mcps_matrix_test.go
@@ -1,0 +1,395 @@
+package web
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// The scope matrix: tool x scope x {attach, detach, move}, against the real
+// stores. This exists so the chain of scope findings ends here rather than
+// producing a fifth round. Every combination is exercised, and every one is
+// asserted against the file the scope actually names.
+
+// toolScopeMatrix is the authority this test enforces. It must agree with
+// scopesForTool; the first entry of each list is the tool's default attach
+// scope, so a UI that asks the server can never pick an unsupported one.
+var toolScopeMatrix = map[string][]string{
+	"claude":   {"local", "project", "global", "user"},
+	"codex":    {"global"},
+	"gemini":   {"global"},
+	"cursor":   {"local", "global"},
+	"opencode": {"local", "global"},
+}
+
+func allScopes() []string { return []string{"local", "project", "global", "user"} }
+
+// TestScopeMatrixMatchesScopesForTool keeps the table above and the production
+// predicate from drifting apart.
+func TestScopeMatrixMatchesScopesForTool(t *testing.T) {
+	for tool, want := range toolScopeMatrix {
+		got := scopesForTool(tool)
+		if !slices.Equal(got, want) {
+			t.Errorf("scopesForTool(%q) = %v, want %v", tool, got, want)
+		}
+		if def := defaultAttachScope(tool); def != want[0] {
+			t.Errorf("defaultAttachScope(%q) = %q, want %q (the most specific store)", tool, def, want[0])
+		}
+	}
+	if got := scopesForTool("shell"); len(got) != 0 {
+		t.Errorf("scopesForTool(shell) = %v, want none", got)
+	}
+	if got := defaultAttachScope("shell"); got != "" {
+		t.Errorf("defaultAttachScope(shell) = %q, want empty", got)
+	}
+}
+
+// TestScopeMatrixAttachDetachMove walks every tool x scope pair. Supported
+// pairs must round-trip attach -> list -> detach; unsupported pairs must be
+// refused for all three operations without writing anything.
+func TestScopeMatrixAttachDetachMove(t *testing.T) {
+	for tool, supported := range toolScopeMatrix {
+		for _, scope := range allScopes() {
+			t.Run(tool+"/"+scope, func(t *testing.T) {
+				mcpStoreEnv(t)
+				project := t.TempDir()
+				target := MCPTarget{Tool: tool, ProjectPath: project}
+				mgr := NewDefaultMCPManager()
+				isSupported := slices.Contains(supported, scope)
+
+				attachErr := mgr.Attach(target, "alpha", scope)
+				if !isSupported {
+					if attachErr == nil {
+						t.Fatalf("attach in unsupported scope %q for %q should be refused", scope, tool)
+					}
+					if err := mgr.Detach(target, "alpha", scope); err == nil {
+						t.Errorf("detach in unsupported scope %q for %q should be refused", scope, tool)
+					}
+					if err := mgr.Move(target, "alpha", scope, supported[0]); err == nil {
+						t.Errorf("move FROM unsupported scope %q for %q should be refused", scope, tool)
+					}
+					if err := mgr.Move(target, "alpha", supported[0], scope); err == nil {
+						t.Errorf("move TO unsupported scope %q for %q should be refused", scope, tool)
+					}
+					return
+				}
+
+				if attachErr != nil {
+					t.Fatalf("attach alpha in %q for %q: %v", scope, tool, attachErr)
+				}
+				attached, err := mgr.ListAttached(target)
+				if err != nil {
+					t.Fatalf("ListAttached: %v", err)
+				}
+				if !slices.Contains(attached[scope], "alpha") {
+					t.Fatalf("after attach, scope %q for %q reports %v, want it to contain alpha",
+						scope, tool, attached[scope])
+				}
+				// It must appear in exactly the scope written, nowhere else.
+				for _, other := range allScopes() {
+					if other == scope {
+						continue
+					}
+					if slices.Contains(attached[other], "alpha") {
+						t.Errorf("attaching in %q for %q also made it appear in %q (%v) — scopes are leaking",
+							scope, tool, other, attached[other])
+					}
+				}
+
+				if err := mgr.Detach(target, "alpha", scope); err != nil {
+					t.Fatalf("detach: %v", err)
+				}
+				attached, err = mgr.ListAttached(target)
+				if err != nil {
+					t.Fatalf("ListAttached after detach: %v", err)
+				}
+				if slices.Contains(attached[scope], "alpha") {
+					t.Errorf("after detach, scope %q for %q still reports alpha: %v", scope, tool, attached[scope])
+				}
+			})
+		}
+	}
+}
+
+// TestScopeMatrixMoveBetweenSupportedScopes round-trips a move across every
+// ordered pair of supported scopes and asserts the server lands in exactly one.
+func TestScopeMatrixMoveBetweenSupportedScopes(t *testing.T) {
+	for tool, supported := range toolScopeMatrix {
+		if len(supported) < 2 {
+			continue
+		}
+		for _, from := range supported {
+			for _, to := range supported {
+				if from == to {
+					continue
+				}
+				t.Run(tool+"/"+from+"->"+to, func(t *testing.T) {
+					mcpStoreEnv(t)
+					project := t.TempDir()
+					target := MCPTarget{Tool: tool, ProjectPath: project}
+					mgr := NewDefaultMCPManager()
+
+					if err := mgr.Attach(target, "alpha", from); err != nil {
+						t.Fatalf("seed attach in %q: %v", from, err)
+					}
+					if err := mgr.Move(target, "alpha", from, to); err != nil {
+						t.Fatalf("move %q -> %q: %v", from, to, err)
+					}
+					attached, err := mgr.ListAttached(target)
+					if err != nil {
+						t.Fatalf("ListAttached: %v", err)
+					}
+					if !slices.Contains(attached[to], "alpha") {
+						t.Errorf("after move, destination %q = %v, want alpha", to, attached[to])
+					}
+					if slices.Contains(attached[from], "alpha") {
+						t.Errorf("after move, source %q still holds alpha: %v", from, attached[from])
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestMoveWithUnsupportedDestinationLeavesSourceAttached is the regression test
+// for the destructive move.
+//
+// Move used to detach from the source and only then discover the destination
+// was unsupported, so the API returned an error with the server already gone
+// from disk. The UI offered every scope for every tool, so this was one click
+// away. Validation now happens before any write.
+func TestMoveWithUnsupportedDestinationLeavesSourceAttached(t *testing.T) {
+	for _, tc := range []struct {
+		tool, from, to string
+	}{
+		{"cursor", "local", "user"},      // Cursor has no user scope
+		{"opencode", "local", "project"}, // nor a Claude project map
+		{"codex", "global", "local"},     // Codex is global-only
+		{"gemini", "global", "local"},
+	} {
+		t.Run(tc.tool+"/"+tc.from+"->"+tc.to, func(t *testing.T) {
+			mcpStoreEnv(t)
+			project := t.TempDir()
+			target := MCPTarget{Tool: tc.tool, ProjectPath: project}
+			mgr := NewDefaultMCPManager()
+
+			if err := mgr.Attach(target, "alpha", tc.from); err != nil {
+				t.Fatalf("seed attach: %v", err)
+			}
+			before, err := mgr.ListAttached(target)
+			if err != nil {
+				t.Fatalf("ListAttached: %v", err)
+			}
+			if !slices.Contains(before[tc.from], "alpha") {
+				t.Fatalf("precondition failed: %q should hold alpha, got %v", tc.from, before[tc.from])
+			}
+
+			if err := mgr.Move(target, "alpha", tc.from, tc.to); err == nil {
+				t.Fatalf("move to unsupported scope %q should fail", tc.to)
+			}
+
+			after, err := mgr.ListAttached(target)
+			if err != nil {
+				t.Fatalf("ListAttached after failed move: %v", err)
+			}
+			if !slices.Contains(after[tc.from], "alpha") {
+				t.Errorf("a failed move DELETED alpha from %q (now %v) — a rejected move must not "+
+					"change the configuration at all", tc.from, after[tc.from])
+			}
+		})
+	}
+}
+
+// TestMoveRestoresSourceWhenDestinationWriteFails covers the other half of the
+// transaction: validation passes, but the destination write fails on disk. The
+// source attachment must come back rather than being lost.
+func TestMoveRestoresSourceWhenDestinationWriteFails(t *testing.T) {
+	if u, err := user.Current(); err == nil && u.Uid == "0" {
+		t.Skip("running as root: file permissions would not block the write")
+	}
+	home := mcpStoreEnv(t)
+	project := t.TempDir()
+	target := MCPTarget{Tool: "claude", ProjectPath: project}
+	mgr := NewDefaultMCPManager()
+
+	if err := mgr.Attach(target, "alpha", "local"); err != nil {
+		t.Fatalf("seed attach local: %v", err)
+	}
+
+	// Make the Claude config directory unwritable so the "project" write fails
+	// after validation has already passed.
+	claudeDir := filepath.Join(home, ".claude-cfg")
+	if err := os.Chmod(claudeDir, 0o500); err != nil {
+		t.Fatalf("chmod claude dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(claudeDir, 0o755) })
+
+	err := mgr.Move(target, "alpha", "local", "project")
+	if err == nil {
+		t.Skip("destination write unexpectedly succeeded; cannot exercise the rollback path here")
+	}
+
+	if err := os.Chmod(claudeDir, 0o755); err != nil {
+		t.Fatalf("restore perms: %v", err)
+	}
+	session.InvalidateProjectMCPIntegrationsCache(project)
+
+	attached, listErr := mgr.ListAttached(target)
+	if listErr != nil {
+		t.Fatalf("ListAttached: %v", listErr)
+	}
+	if !slices.Contains(attached["local"], "alpha") {
+		t.Errorf("a failed move lost alpha: local=%v project=%v. The source attachment must be "+
+			"restored when the destination write fails (move error was: %v)",
+			attached["local"], attached["project"], err)
+	}
+}
+
+// TestClaudeProjectScopeIsWrittenWhereItIsReported is the regression test for
+// the project/global conflation.
+//
+// projects[path].mcpServers used to be reported as "global" while writes went
+// only to the root mcpServers map. Detaching such an entry therefore returned
+// success while leaving it attached at project level, and attaching another
+// global could copy project-only entries up into the root.
+func TestClaudeProjectScopeIsWrittenWhereItIsReported(t *testing.T) {
+	home := mcpStoreEnv(t)
+	project := t.TempDir()
+	target := MCPTarget{Tool: "claude", ProjectPath: project}
+	mgr := NewDefaultMCPManager()
+	configFile := filepath.Join(home, ".claude-cfg", ".claude.json")
+
+	// gamma lives ONLY in projects[path].mcpServers.
+	if err := session.WriteProjectMCP(project, []string{"gamma"}); err != nil {
+		t.Fatalf("seed project scope: %v", err)
+	}
+	session.InvalidateProjectMCPIntegrationsCache(project)
+
+	attached, err := mgr.ListAttached(target)
+	if err != nil {
+		t.Fatalf("ListAttached: %v", err)
+	}
+	if !slices.Contains(attached["project"], "gamma") {
+		t.Fatalf("gamma should be reported in the project scope, got project=%v global=%v",
+			attached["project"], attached["global"])
+	}
+	if slices.Contains(attached["global"], "gamma") {
+		t.Errorf("a project-scoped entry must not also be reported as global: global=%v", attached["global"])
+	}
+
+	// Detaching it in the scope it was reported in must actually remove it.
+	if err := mgr.Detach(target, "gamma", "project"); err != nil {
+		t.Fatalf("detach project: %v", err)
+	}
+	session.InvalidateProjectMCPIntegrationsCache(project)
+	if names := claudeProjectMCPNames(t, configFile, project); slices.Contains(names, "gamma") {
+		t.Errorf("detach reported success but gamma is still in projects[%s].mcpServers: %v", project, names)
+	}
+
+	// Attaching a global must not drag project entries into the root map.
+	if err := session.WriteProjectMCP(project, []string{"gamma"}); err != nil {
+		t.Fatalf("re-seed project scope: %v", err)
+	}
+	session.InvalidateProjectMCPIntegrationsCache(project)
+	if err := mgr.Attach(target, "alpha", "global"); err != nil {
+		t.Fatalf("attach global: %v", err)
+	}
+	if names := claudeRootMCPNames(t, configFile); slices.Contains(names, "gamma") {
+		t.Errorf("attaching a global copied the project-only entry gamma into root mcpServers: %v", names)
+	}
+	if names := claudeProjectMCPNames(t, configFile, project); !slices.Contains(names, "gamma") {
+		t.Errorf("attaching a global removed the project entry gamma: %v", names)
+	}
+}
+
+func claudeConfigDoc(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return doc
+}
+
+func claudeRootMCPNames(t *testing.T, path string) []string {
+	t.Helper()
+	servers, _ := claudeConfigDoc(t, path)["mcpServers"].(map[string]any)
+	return sortedKeys(servers)
+}
+
+func claudeProjectMCPNames(t *testing.T, path, projectPath string) []string {
+	t.Helper()
+	projects, _ := claudeConfigDoc(t, path)["projects"].(map[string]any)
+	proj, _ := projects[projectPath].(map[string]any)
+	servers, _ := proj["mcpServers"].(map[string]any)
+	return sortedKeys(servers)
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestLocalWriteInvalidatesMCPInfoCache reproduces the pane's exact sequence:
+// refresh, mutate, refresh. The Claude/Cursor/OpenCode project readers cache
+// for 30s, so without invalidation the second refresh returns the pre-mutation
+// list and the UI shows the change as having failed — while inviting the user
+// to repeat an action that already succeeded.
+func TestLocalWriteInvalidatesMCPInfoCache(t *testing.T) {
+	for _, tool := range []string{"claude", "cursor", "opencode"} {
+		t.Run(tool, func(t *testing.T) {
+			mcpStoreEnv(t)
+			project := t.TempDir()
+			target := MCPTarget{Tool: tool, ProjectPath: project}
+			mgr := NewDefaultMCPManager()
+
+			// First refresh: populates the reader cache with an empty list.
+			before, err := mgr.ListAttached(target)
+			if err != nil {
+				t.Fatalf("initial ListAttached: %v", err)
+			}
+			if slices.Contains(before["local"], "alpha") {
+				t.Fatalf("precondition failed: local already holds alpha: %v", before["local"])
+			}
+
+			if err := mgr.Attach(target, "alpha", "local"); err != nil {
+				t.Fatalf("attach: %v", err)
+			}
+
+			// Second refresh, immediately after — no sleeping past the TTL.
+			after, err := mgr.ListAttached(target)
+			if err != nil {
+				t.Fatalf("ListAttached after attach: %v", err)
+			}
+			if !slices.Contains(after["local"], "alpha") {
+				t.Errorf("the refresh right after a successful local attach still reports %v: the "+
+					"write path must invalidate the cached MCP info, or the UI shows pre-mutation state",
+					after["local"])
+			}
+
+			if err := mgr.Detach(target, "alpha", "local"); err != nil {
+				t.Fatalf("detach: %v", err)
+			}
+			afterDetach, err := mgr.ListAttached(target)
+			if err != nil {
+				t.Fatalf("ListAttached after detach: %v", err)
+			}
+			if slices.Contains(afterDetach["local"], "alpha") {
+				t.Errorf("the refresh right after a successful detach still reports alpha: %v", afterDetach["local"])
+			}
+		})
+	}
+}

--- a/internal/web/handlers_mcps_stores_test.go
+++ b/internal/web/handlers_mcps_stores_test.go
@@ -169,11 +169,24 @@ func TestNonClaudeToolDoesNotTouchClaudeConfig(t *testing.T) {
 	// Codex is supported by the MCP manager but keeps its servers in its own
 	// config, so this must not write Claude's file.
 	target := MCPTarget{Tool: "codex", ProjectPath: project}
-	_ = mgr.Attach(target, "beta", "global")
+	if err := mgr.Attach(target, "beta", "global"); err != nil {
+		t.Fatalf("attach beta in codex global scope: %v", err)
+	}
 
-	after, err := os.ReadFile(claudeConfig)
+	// Confirm the write actually landed in Codex's own store. Without this the
+	// two assertions below would hold trivially for a no-op attach, and the
+	// test would pass for the wrong reason.
+	attached, err := mgr.ListAttached(target)
 	if err != nil {
-		t.Fatalf("read claude config: %v", err)
+		t.Fatalf("ListAttached: %v", err)
+	}
+	if !slices.Contains(attached["global"], "beta") {
+		t.Fatalf("codex attach did not reach the codex store; global=%v", attached["global"])
+	}
+
+	after, readErr := os.ReadFile(claudeConfig)
+	if readErr != nil {
+		t.Fatalf("read claude config: %v", readErr)
 	}
 	if string(after) != string(seed) {
 		t.Errorf("a codex session's MCP attach modified Claude's config.\nbefore: %s\nafter:  %s", seed, after)
@@ -212,11 +225,16 @@ func TestScopesAreRefusedWhenTheToolDoesNotHaveThem(t *testing.T) {
 	}
 }
 
-// TestClaudeGlobalScopeCoversProjectEntries documents where the Claude config's
-// projects[path].mcpServers entries belong. They are part of the GLOBAL bucket,
-// exactly as the TUI dialog groups them; treating them as "local" is what
-// crossed the stores in the first place.
-func TestClaudeGlobalScopeCoversProjectEntries(t *testing.T) {
+// TestClaudeProjectEntriesAreTheirOwnScope replaces an earlier test that
+// asserted projects[path].mcpServers belonged to the GLOBAL bucket, mirroring
+// how the TUI dialog merges the two for display.
+//
+// That grouping was wrong for a read/write API: the global write path only
+// touches the root mcpServers map, so a "global" detach of a project entry
+// reported success and left it attached. The scopes are modelled separately
+// now, and each is written where it is reported. See
+// TestClaudeProjectScopeIsWrittenWhereItIsReported for the write half.
+func TestClaudeProjectEntriesAreTheirOwnScope(t *testing.T) {
 	home := mcpStoreEnv(t)
 	project := t.TempDir()
 
@@ -239,11 +257,14 @@ func TestClaudeGlobalScopeCoversProjectEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAttached: %v", err)
 	}
-	if !slices.Contains(attached["global"], "gamma") {
-		t.Errorf("Claude projects[path] entries belong to the global scope, got global=%v local=%v",
-			attached["global"], attached["local"])
+	if !slices.Contains(attached["project"], "gamma") {
+		t.Errorf("projects[path] entries belong to the project scope, got project=%v", attached["project"])
+	}
+	if slices.Contains(attached["global"], "gamma") {
+		t.Errorf("project entries must not be folded into global (the global write path cannot "+
+			"remove them), got global=%v", attached["global"])
 	}
 	if slices.Contains(attached["local"], "gamma") {
-		t.Errorf("Claude projects[path] entries must NOT be reported as local (.mcp.json), got %v", attached["local"])
+		t.Errorf("project entries must not be reported as local (.mcp.json), got %v", attached["local"])
 	}
 }

--- a/internal/web/handlers_mcps_test.go
+++ b/internal/web/handlers_mcps_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -521,5 +522,84 @@ func TestMCPTargetCarriesTheSessionTool(t *testing.T) {
 	last := mgr.targets[len(mgr.targets)-1]
 	if last.Tool != "gemini" || last.ProjectPath != "/srv/beta" {
 		t.Errorf("manager got target %+v, want tool=gemini path=/srv/beta", last)
+	}
+}
+
+// TestAttachDefaultsToTheToolsOwnScope is the regression test for the pane
+// hardcoding "local".
+//
+// Codex and Gemini are global-only, so a bodyless attach that defaulted to
+// "local" was refused every time — the primary MCP workflow was unusable for
+// both tools. The default now comes from the tool's capability, and the
+// response reports the scope actually used so the client can show it.
+func TestAttachDefaultsToTheToolsOwnScope(t *testing.T) {
+	for _, tc := range []struct {
+		sessionID string
+		tool      string
+		wantScope string
+	}{
+		{"sess-001", "claude", "local"},
+		{"sess-002", "gemini", "global"},
+	} {
+		t.Run(tc.tool, func(t *testing.T) {
+			mgr := newFakeMCPManager()
+			srv := newMCPTestServer(t, mgr, true)
+
+			// No body at all: the server must pick the scope, not the caller.
+			req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+tc.sessionID+"/mcps/exa", nil)
+			req.Header.Set("Origin", "http://"+req.Host)
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			var resp map[string]string
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp["scope"] != tc.wantScope {
+				t.Errorf("attach for %q used scope %q, want %q", tc.tool, resp["scope"], tc.wantScope)
+			}
+			if len(mgr.attachCalls) != 1 || mgr.attachCalls[0].Scope != tc.wantScope {
+				t.Errorf("manager saw %+v, want a single attach in %q", mgr.attachCalls, tc.wantScope)
+			}
+		})
+	}
+}
+
+// TestSessionMCPsResponseReportsScopesAndProject pins the contract the pane
+// depends on: the server states which scopes exist, so the client never
+// hardcodes one, and Claude's project map is its own field.
+func TestSessionMCPsResponseReportsScopesAndProject(t *testing.T) {
+	mgr := newFakeMCPManager()
+	srv := newMCPTestServer(t, mgr, true)
+
+	for _, tc := range []struct {
+		sessionID  string
+		tool       string
+		wantScopes []string
+	}{
+		{"sess-001", "claude", []string{"local", "project", "global", "user"}},
+		{"sess-002", "gemini", []string{"global"}},
+	} {
+		t.Run(tc.tool, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+tc.sessionID+"/mcps", nil)
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+			var resp SessionMCPsResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if !slices.Equal(resp.Scopes, tc.wantScopes) {
+				t.Errorf("scopes = %v, want %v", resp.Scopes, tc.wantScopes)
+			}
+			if resp.Project == nil {
+				t.Error("project must be present (empty array, not null) so clients can render it")
+			}
+		})
 	}
 }

--- a/internal/web/static/app/panes/McpPane.js
+++ b/internal/web/static/app/panes/McpPane.js
@@ -16,7 +16,14 @@ import { selectedIdSignal, mutationsEnabledSignal } from '../state.js'
 import { addToast } from '../Toast.js'
 import { authHeaders } from '../api.js'
 
-const SCOPES = ['local', 'global', 'user']
+// Every scope the API can report, most specific first. Which of these a given
+// session actually has is decided server-side and returned as `scopes` on
+// GET /api/sessions/{id}/mcps — Codex and Gemini are global-only, Cursor and
+// OpenCode have no user scope, and `project` (Claude's
+// projects[path].mcpServers) is distinct from `local` (<project>/.mcp.json).
+// Never hardcode a scope: doing so made every Codex/Gemini attach fail.
+const ALL_SCOPES = ['local', 'project', 'global', 'user']
+const EMPTY_ATTACHED = { local: [], project: [], global: [], user: [] }
 
 // Whether a session's tool has any MCP store is decided server-side and
 // delivered as `mcpSupported` on the menu session (see MenuSession in
@@ -58,7 +65,9 @@ export function McpPane() {
   const session = sessions.find(s => s.id === selectedId)
 
   const [catalog, setCatalog] = useState([])
-  const [attached, setAttached] = useState({ local: [], global: [], user: [] })
+  const [attached, setAttached] = useState(EMPTY_ATTACHED)
+  // Scopes this session's tool actually has, as reported by the server.
+  const [scopes, setScopes] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -77,9 +86,12 @@ export function McpPane() {
       setCatalog(catalogResp.mcps || [])
       setAttached({
         local: attachedResp.local || [],
+        project: attachedResp.project || [],
         global: attachedResp.global || [],
         user: attachedResp.user || [],
       })
+      // Fall back to every scope only if an older server omits the field.
+      setScopes(attachedResp.scopes && attachedResp.scopes.length ? attachedResp.scopes : ALL_SCOPES)
     } catch (err) {
       setError(err.message)
     } finally {
@@ -90,11 +102,14 @@ export function McpPane() {
   useEffect(() => { refresh() }, [refresh])
 
   const findScope = (name) => {
-    for (const s of SCOPES) {
-      if (attached[s].includes(name)) return s
+    for (const s of ALL_SCOPES) {
+      if ((attached[s] || []).includes(name)) return s
     }
     return null
   }
+
+  // The scope a fresh attach lands in: the tool's most specific store.
+  const defaultScope = scopes[0] || ''
 
   const attach = async (name, scope) => {
     if (!session) return
@@ -186,6 +201,7 @@ export function McpPane() {
         <div style="display: grid; grid-template-columns: 1fr; gap: 24px;">
           <${AttachedSection}
             attached=${attached}
+            scopes=${scopes}
             mutationsEnabled=${mutationsEnabled}
             onDetach=${detach}
             onMove=${moveScope}/>
@@ -193,6 +209,8 @@ export function McpPane() {
           <${CatalogSection}
             catalog=${catalog}
             attached=${attached}
+            scopes=${scopes}
+            defaultScope=${defaultScope}
             mutationsEnabled=${mutationsEnabled}
             onAttach=${attach}
             loading=${loading}/>
@@ -202,9 +220,9 @@ export function McpPane() {
   `
 }
 
-function AttachedSection({ attached, mutationsEnabled, onDetach, onMove }) {
-  const allAttached = SCOPES.flatMap(scope =>
-    attached[scope].map(name => ({ name, scope }))
+function AttachedSection({ attached, scopes, mutationsEnabled, onDetach, onMove }) {
+  const allAttached = ALL_SCOPES.flatMap(scope =>
+    (attached[scope] || []).map(name => ({ name, scope }))
   )
 
   return html`
@@ -232,7 +250,7 @@ function AttachedSection({ attached, mutationsEnabled, onDetach, onMove }) {
                     value=${scope}
                     onChange=${e => onMove(name, e.target.value)}
                     style="font-family: var(--mono); font-size: 11px; background: var(--bg); color: var(--text); border: 1px solid var(--border); padding: 2px 6px; border-radius: 3px;">
-              ${SCOPES.map(s => html`<option value=${s} key=${s}>${s}</option>`)}
+              ${(scopes.length ? scopes : ALL_SCOPES).map(s => html`<option value=${s} key=${s}>${s}</option>`)}
             </select>
             <button disabled=${!mutationsEnabled}
                     data-testid=${`mcp-detach-${name}`}
@@ -247,8 +265,8 @@ function AttachedSection({ attached, mutationsEnabled, onDetach, onMove }) {
   `
 }
 
-function CatalogSection({ catalog, attached, mutationsEnabled, onAttach, loading }) {
-  const isAttachedAnywhere = (name) => SCOPES.some(s => attached[s].includes(name))
+function CatalogSection({ catalog, attached, scopes, defaultScope, mutationsEnabled, onAttach, loading }) {
+  const isAttachedAnywhere = (name) => ALL_SCOPES.some(s => (attached[s] || []).includes(name))
 
   return html`
     <div data-testid="mcp-catalog">
@@ -273,9 +291,9 @@ function CatalogSection({ catalog, attached, mutationsEnabled, onAttach, loading
                 ${(entry.transport || 'stdio').toUpperCase()}${entry.command ? ` · ${entry.command}` : ''}
               </span>
             </div>
-            <button disabled=${!mutationsEnabled || attachedHere}
+            <button disabled=${!mutationsEnabled || attachedHere || !defaultScope}
                     data-testid=${`mcp-attach-${entry.name}`}
-                    onClick=${() => onAttach(entry.name, 'local')}
+                    onClick=${() => onAttach(entry.name, defaultScope)}
                     style="font-family: var(--mono); font-size: 11px; background: ${attachedHere ? 'transparent' : 'var(--accent)'}; color: ${attachedHere ? 'var(--muted)' : 'var(--bg)'}; border: 1px solid ${attachedHere ? 'var(--border)' : 'var(--accent)'}; padding: 4px 12px; border-radius: 3px; cursor: ${attachedHere ? 'default' : 'pointer'};">
               ${attachedHere ? 'Attached' : 'Attach'}
             </button>

--- a/tests/web/e2e/mcp-auth.spec.js
+++ b/tests/web/e2e/mcp-auth.spec.js
@@ -140,6 +140,31 @@ test.describe('MCP management — authenticated browser path', () => {
     await expect(page.getByTestId('mcp-error')).toBeHidden()
   })
 
+  test('attaching for a global-only tool uses that tool\'s scope, not a hardcoded local', async ({ page }) => {
+    // sess-003 is a Codex session. Codex has no project-local MCP store, so a
+    // pane that hardcoded scope "local" had every attach rejected. The pane
+    // now takes the scope list from the server and defaults to the tool's own
+    // most-specific store.
+    await page.goto(`${baseURL}/s/sess-003?token=${TOKEN}`)
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+    await expect(page.getByTestId('mcp-pane')).toBeVisible()
+
+    await page.getByTestId('mcp-attach-exa').click()
+    await expect(page.getByTestId('mcp-attached-exa')).toBeVisible()
+    await expect(page.getByTestId('mcp-error')).toBeHidden()
+
+    // It must have landed in Codex's global scope.
+    const list = await page.request.get(`${baseURL}/api/sessions/sess-003/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+    const body = await list.json()
+    expect(body.global).toContain('exa')
+    expect(body.local).not.toContain('exa')
+    // And the server tells the client Codex is global-only, so the scope
+    // dropdown cannot offer an unsupported destination.
+    expect(body.scopes).toEqual(['global'])
+  })
+
   test('a session whose tool has no MCP store says so instead of offering buttons', async ({ page }) => {
     // sess-004 is a shell session. The server refuses MCP routes for it, so the
     // pane must not render a catalog whose every button would fail.

--- a/tests/web/fixtures/cmd/web-fixture/mcp.go
+++ b/tests/web/fixtures/cmd/web-fixture/mcp.go
@@ -41,7 +41,7 @@ func (f *fixtureMCPManager) ListAttached(target web.MCPTarget) (map[string][]str
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := make(map[string][]string, 3)
-	for _, scope := range []string{"local", "global", "user"} {
+	for _, scope := range []string{"local", "project", "global", "user"} {
 		names := f.attached[target.ProjectPath][scope]
 		cp := append([]string(nil), names...)
 		sort.Strings(cp)


### PR DESCRIPTION
## Summary

Round-2 findings on the web MCP surface, reported against #1954. One is destructive; the rest leave the pane unusable or misleading. Each fix has a regression test that was run against the unfixed code and confirmed to fail first.

## 1. Attach hardcoded `local`, so every Codex/Gemini attach was rejected

The pane called `onAttach(name, 'local')` for every tool, and the handler defaulted a bodyless attach to `local` too. Codex and Gemini are global-only, so once #1954 started enforcing scopes, **every attach from the pane was refused** for both tools.

`GET /api/sessions/{id}/mcps` now reports the tool's scopes, most specific first. The pane renders its dropdown and picks its default from that list; the handler defaults to `defaultAttachScope(tool)`. Nothing client-side hardcodes a scope any more — that was the root cause, so removing the hardcoding matters more than the specific value.

## 2. `Move` detached before validating the destination — DESTRUCTIVE

`Move` ran `Detach(from)` then `Attach(to)`. An unsupported destination — `local` for Codex, `user` for Cursor, both offered by the pane's dropdown — removed the server from disk and returned only an error. One click from the UI.

`Move` now validates **both** scopes before writing anything. If the destination write still fails, the source attachment is restored, so a failed move is a no-op. If the restore also fails, the error says so explicitly rather than reporting a plain failure over a half-applied change.

## 3. Claude project entries were reported as global but written to the root map

`projects[path].mcpServers` was folded into the `global` bucket for display (mirroring how the TUI dialog merges them), while the global write path only touches the root `mcpServers` map. So detaching such an entry returned success and left it attached, and attaching another global could copy project-only entries up into the root.

Rather than papering over it with `ClearProjectMCPs`, `project` is now **its own scope** with its own reader and its own writer (`session.WriteProjectMCP`), so every scope is written exactly where it is reported. Claude therefore has four scopes:

| Scope | Store |
|---|---|
| `local` | `<project>/.mcp.json` |
| `project` | `projects[path].mcpServers` in the Claude config |
| `global` | root `mcpServers` in the Claude config |
| `user` | `~/.claude.json` |

Codex and Gemini remain `global` only; Cursor and OpenCode are `local` + `global`.

## 4. Local writes did not invalidate the MCP info cache

The Claude, Cursor and OpenCode project readers cache for 30s, so the pane's refresh straight after a mutation returned pre-mutation state — the change looked like it had failed, inviting a repeat of an action that had already succeeded. Every successful write now invalidates, as the TUI apply path does.

## Also fixed: a test of mine that could pass for the wrong reason

CodeRabbit correctly flagged that `TestNonClaudeToolDoesNotTouchClaudeConfig` discarded the `Attach` error. A no-op write would still have satisfied both assertions (Claude's config unchanged, no `.mcp.json`). It now requires the write to reach the Codex store first.

## The scope matrix

Added so this chain of findings ends here rather than producing a round 3:

- `TestScopeMatrixMatchesScopesForTool` — keeps the table and the production predicate aligned.
- `TestScopeMatrixAttachDetachMove` — walks every tool × scope pair. Supported pairs round-trip attach → list → detach and must appear in **exactly** the scope written, nowhere else; unsupported pairs are refused for attach, detach and move in both directions.
- `TestScopeMatrixMoveBetweenSupportedScopes` — every ordered pair of supported scopes.
- `TestMoveWithUnsupportedDestinationLeavesSourceAttached` and `TestMoveRestoresSourceWhenDestinationWriteFails` — both halves of the transaction.
- `TestClaudeProjectScopeIsWrittenWhereItIsReported`, `TestClaudeProjectEntriesAreTheirOwnScope`.
- `TestLocalWriteInvalidatesMCPInfoCache` — reproduces the pane's refresh-mutate-refresh sequence.
- `TestAttachDefaultsToTheToolsOwnScope`, `TestSessionMCPsResponseReportsScopesAndProject`.
- `e2e/mcp-auth.spec.js` — attaches through the real UI for a Codex session and asserts it lands in `global`.

### Negative controls

Each finding's fix was reverted and the corresponding test confirmed to fail:

| Reverted | Result |
|---|---|
| attach default back to `"local"` | `attach for "gemini" used scope "local", want "global"` |
| detach-before-validate `Move` | `a failed move DELETED alpha from "local" (now [])` ×4 tools |
| project folded into global | `gamma should be reported in the project scope, got project=[] global=[gamma]` |
| cache invalidation removed | `the refresh right after a successful local attach still reports []` |

## Validation

Sandboxed, package-scoped, `-p 1`, no `-race`, no `./...`.

- `make css-verify`, `gofmt`, `go build` (agent-deck + web-fixture), `go vet`, `golangci-lint`: passed
- `go test ./internal/web` (full package): passed
- `go test ./internal/session -run '(?i)mcp'`: passed (covers the new `WriteProjectMCP` and the extracted `buildManagedMCPServers`)
- `go test ./cmd/agent-deck -run '^(TestBuildWebServer_|TestResolveWebToken_)'`: passed
- Web unit (Vitest): 10 files, 131 passed
- Playwright e2e + screenshots: **607 passed**, 0 failed

Fixes the four findings reported on #1954.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-level MCP server configuration and management.
  * MCP attachments now support tool-specific scopes, including project scope where available.
  * Session MCP details report available scopes and project attachments.
  * Added safer scope moves with validation and rollback on failed updates.

* **Bug Fixes**
  * Improved MCP configuration separation across tools and scopes.
  * Ensured attached servers and cached MCP information stay synchronized after changes.

* **Tests**
  * Added coverage for scope handling, project configuration, default behavior, rollback, and authenticated attachment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->