### PR TITLE
fix(session): never write a Claude config derived from a failed read, and serialize config writes

### DIFF
--- a/internal/session/codex_trust.go
+++ b/internal/session/codex_trust.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"syscall"
 
 	"github.com/BurntSushi/toml"
 	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
@@ -17,47 +15,14 @@ import (
 
 const codexTrustLevelTrusted = "trusted"
 
-// codexConfigMu serializes mutations to a given Codex config.toml within this
-// process. Cross-process serialization uses advisory flock on a sibling
-// `.lock` file (see acquireCodexConfigLock), matching hermes_hooks.go.
-var codexConfigMu sync.Map // map[string]*sync.Mutex
-
-type codexConfigLock struct {
-	inProc *sync.Mutex
-	file   *os.File
-}
-
-func (l *codexConfigLock) Release() {
-	if l.file != nil {
-		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
-		_ = l.file.Close()
-	}
-	if l.inProc != nil {
-		l.inProc.Unlock()
-	}
-}
-
-func acquireCodexConfigLock(configPath string) (*codexConfigLock, error) {
-	mIface, _ := codexConfigMu.LoadOrStore(configPath, &sync.Mutex{})
-	m := mIface.(*sync.Mutex)
-	m.Lock()
-
-	lockPath := configPath + ".lock"
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
-		m.Unlock()
-		return nil, fmt.Errorf("ensure codex config lock dir: %w", err)
-	}
-	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
-	if err != nil {
-		m.Unlock()
-		return nil, fmt.Errorf("open codex config lock file: %w", err)
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		_ = f.Close()
-		m.Unlock()
-		return nil, fmt.Errorf("flock codex config: %w", err)
-	}
-	return &codexConfigLock{inProc: m, file: f}, nil
+// acquireCodexConfigLock serializes mutations to a Codex config.toml.
+//
+// This is an alias over the shared AcquireConfigFileLock (config_file_lock.go),
+// not a second implementation. It used to be a private copy of the same
+// mutex-plus-flock rule; the copy is what let the MCP writers ship without any
+// serialization at all, because there was no obvious shared thing to reach for.
+func acquireCodexConfigLock(configPath string) (*ConfigFileLock, error) {
+	return AcquireConfigFileLock(configPath)
 }
 
 // GetCodexConfigPath returns the path to Codex's user-level config.toml under codexHome.

--- a/internal/session/config_file_lock.go
+++ b/internal/session/config_file_lock.go
@@ -1,0 +1,98 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+)
+
+// Serialization for read-modify-write cycles on a shared config file.
+//
+// Every config mutation in this package is read-modify-write: load the JSON or
+// TOML document, change one section, write the whole thing back. Two of those
+// running at once on the same file interleave — the second reader loads a
+// document that predates the first writer, then writes it back and erases the
+// first writer's section. The web MCP pane and the TUI MCP dialog both write
+// .claude.json, so this is reachable by a user with both open.
+//
+// This is the ONE implementation of that rule. acquireCodexConfigLock in
+// codex_trust.go is now a thin alias over it rather than a second copy: a
+// private copy of a shared rule is how the same defect keeps reappearing in
+// different files.
+//
+// Both halves matter:
+//   - the in-process mutex, keyed by path, serializes goroutines in this binary
+//     (flock is per open file description, so it does NOT serialize two
+//     goroutines in one process that each open the lock file);
+//   - the advisory flock on a sibling `.lock` file serializes separate
+//     processes, e.g. the headless web server and an interactive TUI.
+//
+// The lock is NOT reentrant. A caller that needs to span several writes must
+// acquire once and call the *Locked variants — see WriteGlobalMCPAndClearProjectMCPs.
+
+// configFileMu holds one mutex per config path for in-process serialization.
+var configFileMu sync.Map // map[string]*sync.Mutex
+
+// configLockAcquisitions counts successful acquisitions. Tests use it to assert
+// that a multi-write operation takes the lock ONCE and spans both writes,
+// rather than taking and dropping it per write — a property the end state
+// cannot distinguish, because both orderings finish identically.
+var configLockAcquisitions atomic.Int64
+
+// ConfigLockAcquisitionsForTest reports the acquisition count. Test-only.
+func ConfigLockAcquisitionsForTest() int64 { return configLockAcquisitions.Load() }
+
+// ConfigFileLock is held for the whole read-modify-write cycle and released
+// with Release, conventionally by defer.
+type ConfigFileLock struct {
+	inProc *sync.Mutex
+	file   *os.File
+}
+
+// Release unlocks both halves. Safe to call on a zero value.
+func (l *ConfigFileLock) Release() {
+	if l == nil {
+		return
+	}
+	if l.file != nil {
+		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+		_ = l.file.Close()
+		l.file = nil
+	}
+	if l.inProc != nil {
+		l.inProc.Unlock()
+		l.inProc = nil
+	}
+}
+
+// AcquireConfigFileLock blocks until this process and this host both hold
+// exclusive access to configPath. The returned lock must be released.
+func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
+	if configPath == "" {
+		return nil, fmt.Errorf("config file lock: empty path")
+	}
+	mIface, _ := configFileMu.LoadOrStore(configPath, &sync.Mutex{})
+	m := mIface.(*sync.Mutex)
+	m.Lock()
+
+	lockPath := configPath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("ensure config lock dir for %s: %w", configPath, err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("open config lock file %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		m.Unlock()
+		return nil, fmt.Errorf("flock config %s: %w", configPath, err)
+	}
+	configLockAcquisitions.Add(1)
+	return &ConfigFileLock{inProc: m, file: f}, nil
+}

--- a/internal/session/config_file_lock.go
+++ b/internal/session/config_file_lock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -68,20 +69,58 @@ func (l *ConfigFileLock) Release() {
 	}
 }
 
+// resolveConfigLockPath normalizes configPath and derives the sibling `.lock`
+// path, refusing anything that would escape the config's own directory.
+//
+// Callers are all internal (a profile's Claude config, ~/.claude.json, a
+// project's .mcp.json, a Codex config.toml), so this is defence in depth rather
+// than a live injection vector — but the path is still assembled from values
+// that trace back to configuration, and a lock file is created wherever it
+// points. Cleaning and containment-checking here is cheap and removes the
+// question. It also normalizes the mutex key, so two spellings of the same file
+// share one lock instead of silently getting two.
+//
+// Returns the resolved config path (the mutex key) and the lock path.
+func resolveConfigLockPath(configPath string) (resolved, lockPath string, err error) {
+	if strings.TrimSpace(configPath) == "" {
+		return "", "", fmt.Errorf("config file lock: empty path")
+	}
+	resolved, err = filepath.Abs(filepath.Clean(configPath))
+	if err != nil {
+		return "", "", fmt.Errorf("config file lock: resolve %q: %w", configPath, err)
+	}
+
+	dir := filepath.Dir(resolved)
+	base := filepath.Base(resolved)
+	if base == "." || base == string(os.PathSeparator) {
+		return "", "", fmt.Errorf("config file lock: %q has no file name component", configPath)
+	}
+
+	lockPath = filepath.Join(dir, base+".lock")
+	// The lock must sit beside the config it guards. After cleaning this can
+	// only fail on a crafted name, but checking it is what makes the property
+	// explicit rather than incidental.
+	if !strings.HasPrefix(lockPath, dir+string(os.PathSeparator)) || filepath.Dir(lockPath) != dir {
+		return "", "", fmt.Errorf("config file lock: refusing lock path %q outside config directory %q", lockPath, dir)
+	}
+	return resolved, lockPath, nil
+}
+
 // AcquireConfigFileLock blocks until this process and this host both hold
 // exclusive access to configPath. The returned lock must be released.
 func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
-	if configPath == "" {
-		return nil, fmt.Errorf("config file lock: empty path")
+	resolved, lockPath, err := resolveConfigLockPath(configPath)
+	if err != nil {
+		return nil, err
 	}
-	mIface, _ := configFileMu.LoadOrStore(configPath, &sync.Mutex{})
+
+	mIface, _ := configFileMu.LoadOrStore(resolved, &sync.Mutex{})
 	m := mIface.(*sync.Mutex)
 	m.Lock()
 
-	lockPath := configPath + ".lock"
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		m.Unlock()
-		return nil, fmt.Errorf("ensure config lock dir for %s: %w", configPath, err)
+		return nil, fmt.Errorf("ensure config lock dir for %s: %w", resolved, err)
 	}
 	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
@@ -91,7 +130,7 @@ func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
 		_ = f.Close()
 		m.Unlock()
-		return nil, fmt.Errorf("flock config %s: %w", configPath, err)
+		return nil, fmt.Errorf("flock config %s: %w", resolved, err)
 	}
 	configLockAcquisitions.Add(1)
 	return &ConfigFileLock{inProc: m, file: f}, nil

--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -3,7 +3,9 @@ package session
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/mcppool"
+	"github.com/asheshgoplani/agent-deck/internal/safeio"
 )
 
 var mcpCatLog = logging.ForComponent(logging.CompMCP)
@@ -267,6 +270,95 @@ func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
 	return WriteMergedMcpJSONFile(mcpFile, enabledNames, GetClaudeConfigDir())
 }
 
+// ---------------------------------------------------------------------------
+// Fail-closed reading and writing of Claude-style JSON configs.
+//
+// .claude.json holds the user's entire Claude configuration: settings, every
+// project entry, and the root mcpServers map. The MCP writers below are
+// read-modify-write, so a parse failure that degrades to an empty map does not
+// merely lose the MCP list — the next write persists that empty map and the
+// whole file is gone. A transiently malformed file (a half-finished manual
+// edit, a truncated write from another process) is exactly when this triggers.
+//
+// HARD RULE: a config derived from a failed parse is never written. A parse
+// failure aborts the mutation and names the problem. Only a missing or empty
+// file legitimately starts from a fresh map.
+// ---------------------------------------------------------------------------
+
+// readJSONObjectConfig loads a JSON object config, failing closed on a parse
+// error rather than substituting an empty map.
+func readJSONObjectConfig(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string]interface{}{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]interface{}{}, nil
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("refusing to modify %s: it is not valid JSON (%w). "+
+			"Writing would replace its current contents — fix or restore the file first", path, err)
+	}
+	if cfg == nil {
+		cfg = map[string]interface{}{}
+	}
+	return cfg, nil
+}
+
+// refuseDroppingTopLevelKeys is the second net under readJSONObjectConfig: even
+// if some future path reconstructs a config from nothing, the write is refused
+// when it would remove top-level keys the file already has. Every MCP writer
+// here only ever sets "mcpServers" or "projects" on a config it just read, so a
+// dropped key means the read did not happen.
+func refuseDroppingTopLevelKeys(path string) func(old, updated []byte) error {
+	return func(old, updated []byte) error {
+		if len(bytes.TrimSpace(old)) == 0 {
+			return nil
+		}
+		var oldDoc map[string]json.RawMessage
+		if err := json.Unmarshal(old, &oldDoc); err != nil {
+			return fmt.Errorf("refusing to overwrite %s: the file on disk is not valid JSON (%w)", path, err)
+		}
+		var newDoc map[string]json.RawMessage
+		if err := json.Unmarshal(updated, &newDoc); err != nil {
+			return fmt.Errorf("refusing to write %s: generated content is not valid JSON (%w)", path, err)
+		}
+		var dropped []string
+		for k := range oldDoc {
+			if _, ok := newDoc[k]; !ok {
+				dropped = append(dropped, k)
+			}
+		}
+		if len(dropped) > 0 {
+			sort.Strings(dropped)
+			return fmt.Errorf("refusing to write %s: it would drop top-level keys %v that are on disk", path, dropped)
+		}
+		return nil
+	}
+}
+
+// writeJSONObjectConfig marshals cfg and writes it through safeio, which keeps
+// a .bak, refuses an empty payload over a populated file, and runs the
+// drop-a-key guard before touching anything.
+func writeJSONObjectConfig(path string, cfg map[string]interface{}) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		data = append(data, '\n')
+	}
+	return safeio.SafeOverwrite(path, data, safeio.Options{
+		Perm:        0600,
+		RefuseEmpty: true,
+		Guard:       refuseDroppingTopLevelKeys(path),
+	})
+}
+
 // WriteGlobalMCP adds or removes MCPs from Claude's global config
 // This modifies ~/.claude-work/.claude.json → mcpServers
 func WriteGlobalMCP(enabledNames []string) error {
@@ -274,13 +366,11 @@ func WriteGlobalMCP(enabledNames []string) error {
 	configFile := filepath.Join(configDir, ".claude.json")
 
 	// Read existing config (preserve other fields like projects, settings, etc.)
-	var rawConfig map[string]interface{}
-	if data, err := os.ReadFile(configFile); err == nil {
-		if err := json.Unmarshal(data, &rawConfig); err != nil {
-			rawConfig = make(map[string]interface{})
-		}
-	} else {
-		rawConfig = make(map[string]interface{})
+	// A parse failure aborts the mutation: degrading to an empty map here and
+	// writing it back would delete the user's entire Claude configuration.
+	rawConfig, err := readJSONObjectConfig(configFile)
+	if err != nil {
+		return err
 	}
 
 	availableMCPs := GetAvailableMCPs()
@@ -300,17 +390,7 @@ func WriteGlobalMCP(enabledNames []string) error {
 	}
 	rawConfig["mcpServers"] = mergedMCPs
 
-	// Write atomically
-	data, err := json.MarshalIndent(rawConfig, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	if err := writeJSONFileAtomic(configFile, data, 0600); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-
-	return nil
+	return writeJSONObjectConfig(configFile, rawConfig)
 }
 
 // GetGlobalMCPNames returns the names of MCPs currently in Claude's global config
@@ -432,13 +512,11 @@ func WriteProjectMCP(projectPath string, enabledNames []string) error {
 	configDir := GetClaudeConfigDir()
 	configFile := filepath.Join(configDir, ".claude.json")
 
-	var rawConfig map[string]interface{}
-	if data, err := os.ReadFile(configFile); err == nil {
-		if err := json.Unmarshal(data, &rawConfig); err != nil {
-			rawConfig = make(map[string]interface{})
-		}
-	} else {
-		rawConfig = make(map[string]interface{})
+	// A parse failure aborts the mutation: degrading to an empty map here and
+	// writing it back would delete the user's entire Claude configuration.
+	rawConfig, err := readJSONObjectConfig(configFile)
+	if err != nil {
+		return err
 	}
 
 	projects, _ := rawConfig["projects"].(map[string]interface{})
@@ -469,14 +547,7 @@ func WriteProjectMCP(projectPath string, enabledNames []string) error {
 	projects[projectPath] = proj
 	rawConfig["projects"] = projects
 
-	data, err := json.MarshalIndent(rawConfig, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-	if err := writeJSONFileAtomic(configFile, data, 0600); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-	return nil
+	return writeJSONObjectConfig(configFile, rawConfig)
 }
 
 // ClearProjectMCPs removes all MCPs from projects[path].mcpServers in Claude's config
@@ -510,17 +581,7 @@ func ClearProjectMCPs(projectPath string) error {
 	// Clear mcpServers for this project
 	proj["mcpServers"] = map[string]interface{}{}
 
-	// Write atomically
-	newData, err := json.MarshalIndent(rawConfig, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	if err := writeJSONFileAtomic(configFile, newData, 0600); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-
-	return nil
+	return writeJSONObjectConfig(configFile, rawConfig)
 }
 
 // GetUserMCPRootPath returns the path to ~/.claude.json (ROOT config, always read by Claude)
@@ -544,13 +605,11 @@ func WriteUserMCP(enabledNames []string) error {
 	}
 
 	// Read existing config (preserve other fields like numStartups, projects, etc.)
-	var rawConfig map[string]interface{}
-	if data, err := os.ReadFile(configFile); err == nil {
-		if err := json.Unmarshal(data, &rawConfig); err != nil {
-			rawConfig = make(map[string]interface{})
-		}
-	} else {
-		rawConfig = make(map[string]interface{})
+	// A parse failure aborts the mutation: degrading to an empty map here and
+	// writing it back would delete the user's entire Claude configuration.
+	rawConfig, err := readJSONObjectConfig(configFile)
+	if err != nil {
+		return err
 	}
 
 	// Build new mcpServers from enabled names using config.toml definitions
@@ -621,17 +680,7 @@ func WriteUserMCP(enabledNames []string) error {
 	}
 	rawConfig["mcpServers"] = mergedMCPs
 
-	// Write atomically
-	data, err := json.MarshalIndent(rawConfig, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	if err := writeJSONFileAtomic(configFile, data, 0600); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-
-	return nil
+	return writeJSONObjectConfig(configFile, rawConfig)
 }
 
 // GetUserMCPNames returns the names of MCPs in ~/.claude.json (ROOT config)
@@ -661,4 +710,10 @@ func GetUserMCPNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// RefuseDroppingTopLevelKeysForTest exposes the safeio guard so tests in other
+// packages can assert the second net directly. Not used in production paths.
+func RefuseDroppingTopLevelKeysForTest(path string) func(old, updated []byte) error {
+	return refuseDroppingTopLevelKeys(path)
 }

--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -167,6 +167,15 @@ func writeJSONFileAtomic(path string, data []byte, perm os.FileMode) error {
 // config.toml. When pluginPinClaudeProfile is non-empty (Claude project .mcp.json),
 // refreshes stale plugin version pins before merging (#960).
 func WriteMergedMcpJSONFile(mcpFile string, enabledNames []string, pluginPinClaudeProfile string) error {
+	// Same read-modify-write class as the .claude.json writers: this reads the
+	// existing servers, merges, and writes the whole file back. The web local
+	// scope and the TUI both reach it, so it takes the same per-path lock.
+	lock, lockErr := AcquireConfigFileLock(mcpFile)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer lock.Release()
+
 	availableMCPs := GetAvailableMCPs()
 	pool := GetGlobalPool()
 
@@ -361,7 +370,7 @@ func writeJSONObjectConfig(path string, cfg map[string]interface{}) error {
 
 // WriteGlobalMCP adds or removes MCPs from Claude's global config
 // This modifies ~/.claude-work/.claude.json → mcpServers
-func WriteGlobalMCP(enabledNames []string) error {
+func writeGlobalMCPLocked(enabledNames []string) error {
 	configDir := GetClaudeConfigDir()
 	configFile := filepath.Join(configDir, ".claude.json")
 
@@ -391,6 +400,85 @@ func WriteGlobalMCP(enabledNames []string) error {
 	rawConfig["mcpServers"] = mergedMCPs
 
 	return writeJSONObjectConfig(configFile, rawConfig)
+}
+
+// ---------------------------------------------------------------------------
+// Public writers. Each takes the shared config-file lock for the WHOLE
+// read-modify-write cycle, then delegates to the *Locked body.
+//
+// The lock is not reentrant, so anything needing several writes under one lock
+// calls the *Locked variants directly after acquiring once — see
+// WriteGlobalMCPAndClearProjectMCPs.
+// ---------------------------------------------------------------------------
+
+func claudeConfigFilePath() string {
+	return filepath.Join(GetClaudeConfigDir(), ".claude.json")
+}
+
+// WriteGlobalMCP adds or removes MCPs from Claude's global config
+// (CLAUDE_CONFIG_DIR/.claude.json → mcpServers).
+func WriteGlobalMCP(enabledNames []string) error {
+	lock, err := AcquireConfigFileLock(claudeConfigFilePath())
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	return writeGlobalMCPLocked(enabledNames)
+}
+
+// WriteProjectMCP writes enabled catalog MCPs into
+// projects[projectPath].mcpServers of Claude's config.
+func WriteProjectMCP(projectPath string, enabledNames []string) error {
+	lock, err := AcquireConfigFileLock(claudeConfigFilePath())
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	return writeProjectMCPLocked(projectPath, enabledNames)
+}
+
+// WriteUserMCP writes MCPs to ~/.claude.json (the ROOT config Claude always
+// reads). This is a different file from the CLAUDE_CONFIG_DIR one, so it takes
+// its own lock.
+func WriteUserMCP(enabledNames []string) error {
+	lock, err := AcquireConfigFileLock(GetUserMCPRootPath())
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	return writeUserMCPLocked(enabledNames)
+}
+
+// ClearProjectMCPs removes all MCPs from projects[path].mcpServers in Claude's
+// config.
+func ClearProjectMCPs(projectPath string) error {
+	lock, err := AcquireConfigFileLock(claudeConfigFilePath())
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	return clearProjectMCPsLocked(projectPath)
+}
+
+// WriteGlobalMCPAndClearProjectMCPs performs the TUI's global-apply as ONE
+// serialized unit: rewrite the root mcpServers map, then clear the project half
+// that the global view merges in.
+//
+// These are two writes to the same file that must not be interleaved with any
+// other writer. Done as separate public calls they take and drop the lock
+// twice, leaving a window where another process sees the config with the new
+// global set but the stale project set still merged in — which reads as MCPs
+// the user just removed still being attached.
+func WriteGlobalMCPAndClearProjectMCPs(projectPath string, enabledNames []string) error {
+	lock, err := AcquireConfigFileLock(claudeConfigFilePath())
+	if err != nil {
+		return err
+	}
+	defer lock.Release()
+	if err := writeGlobalMCPLocked(enabledNames); err != nil {
+		return err
+	}
+	return clearProjectMCPsLocked(projectPath)
 }
 
 // GetGlobalMCPNames returns the names of MCPs currently in Claude's global config
@@ -505,7 +593,7 @@ func buildManagedMCPServers(enabledNames []string, scope string) map[string]MCPS
 // which silently moved servers between scopes.
 //
 // Entries not defined in config.toml are preserved (#146).
-func WriteProjectMCP(projectPath string, enabledNames []string) error {
+func writeProjectMCPLocked(projectPath string, enabledNames []string) error {
 	if projectPath == "" {
 		return fmt.Errorf("project MCP write: empty project path")
 	}
@@ -551,19 +639,16 @@ func WriteProjectMCP(projectPath string, enabledNames []string) error {
 }
 
 // ClearProjectMCPs removes all MCPs from projects[path].mcpServers in Claude's config
-func ClearProjectMCPs(projectPath string) error {
-	configDir := GetClaudeConfigDir()
-	configFile := filepath.Join(configDir, ".claude.json")
+func clearProjectMCPsLocked(projectPath string) error {
+	configFile := claudeConfigFilePath()
 
-	// Read existing config
-	data, err := os.ReadFile(configFile)
+	// Through the shared reader, not a hand-rolled copy. The inline version
+	// this replaces failed closed on a bad parse (correct) but ALSO errored on
+	// a genuinely absent file — the inverted bug: nothing to clear is success,
+	// not failure. readJSONObjectConfig draws that line once, for every caller.
+	rawConfig, err := readJSONObjectConfig(configFile)
 	if err != nil {
-		return fmt.Errorf("failed to read config: %w", err)
-	}
-
-	var rawConfig map[string]interface{}
-	if err := json.Unmarshal(data, &rawConfig); err != nil {
-		return fmt.Errorf("failed to parse config: %w", err)
+		return err
 	}
 
 	// Get projects map
@@ -598,7 +683,7 @@ func GetUserMCPRootPath() string {
 // WriteUserMCP writes MCPs to ~/.claude.json (ROOT config)
 // Uses socket proxies if pool is running, otherwise falls back to stdio
 // WARNING: MCPs written here affect ALL Claude sessions regardless of profile!
-func WriteUserMCP(enabledNames []string) error {
+func writeUserMCPLocked(enabledNames []string) error {
 	configFile := GetUserMCPRootPath()
 	if configFile == "" {
 		return fmt.Errorf("could not determine home directory")

--- a/internal/session/mcp_concurrent_write_test.go
+++ b/internal/session/mcp_concurrent_write_test.go
@@ -275,3 +275,43 @@ func TestClearProjectMCPsOnAbsentConfigIsANoOp(t *testing.T) {
 		t.Error("clearing an absent config created one; it should not have written anything")
 	}
 }
+
+// TestResolveConfigLockPathRejectsEscapes pins the lock-path derivation. The
+// lock must always land beside the config it guards, whatever spelling the
+// caller used, and equivalent spellings must resolve to the same mutex key so
+// two callers cannot each get "their own" lock on one file.
+func TestResolveConfigLockPathRejectsEscapes(t *testing.T) {
+	dir := t.TempDir()
+
+	resolved, lockPath, err := resolveConfigLockPath(filepath.Join(dir, ".claude.json"))
+	if err != nil {
+		t.Fatalf("plain path: %v", err)
+	}
+	if want := filepath.Join(dir, ".claude.json.lock"); lockPath != want {
+		t.Errorf("lockPath = %q, want %q", lockPath, want)
+	}
+	if filepath.Dir(lockPath) != filepath.Dir(resolved) {
+		t.Errorf("lock %q is not beside its config %q", lockPath, resolved)
+	}
+
+	// A path with traversal segments must normalize to the same place, not
+	// escape it, and must share the resolved key.
+	messy := filepath.Join(dir, "sub", "..", ".claude.json")
+	resolved2, lockPath2, err := resolveConfigLockPath(messy)
+	if err != nil {
+		t.Fatalf("traversal path: %v", err)
+	}
+	if resolved2 != resolved || lockPath2 != lockPath {
+		t.Errorf("equivalent spellings resolved differently: %q/%q vs %q/%q",
+			resolved2, lockPath2, resolved, lockPath)
+	}
+
+	for _, bad := range []string{"", "   "} {
+		if _, _, err := resolveConfigLockPath(bad); err == nil {
+			t.Errorf("resolveConfigLockPath(%q) should be refused", bad)
+		}
+	}
+	if _, _, err := resolveConfigLockPath("/"); err == nil {
+		t.Error("a path with no file name component should be refused")
+	}
+}

--- a/internal/session/mcp_concurrent_write_test.go
+++ b/internal/session/mcp_concurrent_write_test.go
@@ -1,0 +1,277 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Concurrent read-modify-write on the shared Claude config.
+//
+// The web MCP pane and the TUI MCP dialog both write .claude.json. Every writer
+// here is read-modify-write: load the whole document, replace one section, save
+// it all back. Two of those overlapping means the second reader loaded a
+// document that predates the first writer, so saving it erases the first
+// writer's section — silently, with both calls returning success.
+//
+// These tests drive the exact pairing a user can produce with both surfaces
+// open: one writer owning the root mcpServers map, another owning
+// projects[path].mcpServers, in the same file at the same time. Both sections
+// must survive, and unrelated top-level keys must never be touched.
+
+func concurrentWriteEnv(t *testing.T) (home, project string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude-cfg"))
+	if err := os.MkdirAll(filepath.Join(home, ".claude-cfg"), 0o755); err != nil {
+		t.Fatalf("mkdir claude config dir: %v", err)
+	}
+
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	const catalog = `
+[mcps.alpha]
+command = "alpha-server"
+
+[mcps.beta]
+command = "beta-server"
+
+[mcps.gamma]
+command = "gamma-server"
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(catalog), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+	if len(GetAvailableMCPs()) == 0 {
+		t.Skip("catalog did not load from the temp config")
+	}
+	return home, t.TempDir()
+}
+
+func readClaudeDoc(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("config is not valid JSON after concurrent writes — a write was torn or interleaved:\n%s\nerror: %v", data, err)
+	}
+	return doc
+}
+
+func rootMCPNames(doc map[string]any) []string {
+	servers, _ := doc["mcpServers"].(map[string]any)
+	out := make([]string, 0, len(servers))
+	for k := range servers {
+		out = append(out, k)
+	}
+	return out
+}
+
+func projectMCPNames(doc map[string]any, projectPath string) []string {
+	projects, _ := doc["projects"].(map[string]any)
+	proj, _ := projects[projectPath].(map[string]any)
+	servers, _ := proj["mcpServers"].(map[string]any)
+	out := make([]string, 0, len(servers))
+	for k := range servers {
+		out = append(out, k)
+	}
+	return out
+}
+
+func hasName(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestConcurrentGlobalAndProjectWritesDoNotLoseEitherSection is the web+TUI
+// case. Without the whole read-modify-write under one lock, one of the two
+// sections vanishes.
+func TestConcurrentGlobalAndProjectWritesDoNotLoseEitherSection(t *testing.T) {
+	home, project := concurrentWriteEnv(t)
+	configFile := filepath.Join(home, ".claude-cfg", ".claude.json")
+
+	// Seed with an unrelated top-level key that neither writer owns; it must
+	// survive every round untouched.
+	seed := map[string]any{"numStartups": float64(7), "theme": "dark"}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(configFile, data, 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Enough rounds that an unserialized interleaving is overwhelmingly likely.
+	const rounds = 120
+	for i := 0; i < rounds; i++ {
+		// Reset both sections so each round is a clean race.
+		if err := WriteGlobalMCP(nil); err != nil {
+			t.Fatalf("round %d reset global: %v", i, err)
+		}
+		if err := WriteProjectMCP(project, nil); err != nil {
+			t.Fatalf("round %d reset project: %v", i, err)
+		}
+
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		wg.Add(2)
+		go func() { defer wg.Done(); errs[0] = WriteGlobalMCP([]string{"alpha"}) }()
+		go func() { defer wg.Done(); errs[1] = WriteProjectMCP(project, []string{"beta"}) }()
+		wg.Wait()
+
+		for _, err := range errs {
+			if err != nil {
+				t.Fatalf("round %d: concurrent write failed: %v", i, err)
+			}
+		}
+
+		doc := readClaudeDoc(t, configFile)
+		root := rootMCPNames(doc)
+		proj := projectMCPNames(doc, project)
+		if !hasName(root, "alpha") {
+			t.Fatalf("round %d: the project write erased the global section (root=%v project=%v). "+
+				"The whole read-modify-write must hold the config lock, not just the save.", i, root, proj)
+		}
+		if !hasName(proj, "beta") {
+			t.Fatalf("round %d: the global write erased the project section (root=%v project=%v). "+
+				"The whole read-modify-write must hold the config lock, not just the save.", i, root, proj)
+		}
+		if doc["numStartups"] == nil || doc["theme"] == nil {
+			t.Fatalf("round %d: concurrent writes dropped unrelated top-level keys: %v", i, doc)
+		}
+	}
+}
+
+// TestConcurrentWritersToTheSameSectionKeepTheFileValid covers many writers on
+// one section. Last-writer-wins on the managed set is the API's contract; a
+// torn or unparseable file never is.
+func TestConcurrentWritersToTheSameSectionKeepTheFileValid(t *testing.T) {
+	home, _ := concurrentWriteEnv(t)
+	configFile := filepath.Join(home, ".claude-cfg", ".claude.json")
+	if err := os.WriteFile(configFile, []byte(`{"theme":"dark"}`), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const writers = 16
+	errs := make([]error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			names := []string{"alpha", "beta", "gamma"}[:1+i%3]
+			errs[i] = WriteGlobalMCP(names)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d: %v", i, err)
+		}
+	}
+
+	doc := readClaudeDoc(t, configFile)
+	if doc["theme"] != "dark" {
+		t.Errorf("concurrent writers dropped an unrelated key: %v", doc)
+	}
+	if len(rootMCPNames(doc)) == 0 {
+		t.Errorf("every concurrent writer's section was lost: %v", doc)
+	}
+}
+
+// TestWriteGlobalMCPAndClearProjectMCPsHoldsOneLock is the atomicity assertion.
+//
+// The end state alone cannot tell the two implementations apart: taking the
+// lock once across both writes and taking it twice finish identically, which is
+// why the outcome-only version of this test passed even with the pair split
+// back into two separate locked calls. Counting acquisitions is the property
+// that actually differs.
+func TestWriteGlobalMCPAndClearProjectMCPsHoldsOneLock(t *testing.T) {
+	_, project := concurrentWriteEnv(t)
+
+	before := ConfigLockAcquisitionsForTest()
+	if err := WriteGlobalMCPAndClearProjectMCPs(project, []string{"alpha"}); err != nil {
+		t.Fatalf("combined write: %v", err)
+	}
+	combined := ConfigLockAcquisitionsForTest() - before
+
+	// The equivalent done as two public calls, for comparison.
+	before = ConfigLockAcquisitionsForTest()
+	if err := WriteGlobalMCP([]string{"alpha"}); err != nil {
+		t.Fatalf("global: %v", err)
+	}
+	if err := ClearProjectMCPs(project); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	separate := ConfigLockAcquisitionsForTest() - before
+
+	if combined != 1 {
+		t.Errorf("the combined write took the config lock %d times, want exactly 1: the global "+
+			"write and the project clear must span ONE lock, or another writer can observe the "+
+			"new global set with the stale project set still merged in", combined)
+	}
+	if separate <= combined {
+		t.Errorf("sanity check failed: two separate calls took %d locks, expected more than the "+
+			"combined form's %d", separate, combined)
+	}
+}
+
+// TestWriteGlobalMCPAndClearProjectMCPsAppliesBothHalves covers the outcome.
+func TestWriteGlobalMCPAndClearProjectMCPsAppliesBothHalves(t *testing.T) {
+	home, project := concurrentWriteEnv(t)
+	configFile := filepath.Join(home, ".claude-cfg", ".claude.json")
+
+	if err := WriteProjectMCP(project, []string{"beta"}); err != nil {
+		t.Fatalf("seed project scope: %v", err)
+	}
+	if names := projectMCPNames(readClaudeDoc(t, configFile), project); !hasName(names, "beta") {
+		t.Fatalf("precondition: project scope should hold beta, got %v", names)
+	}
+
+	if err := WriteGlobalMCPAndClearProjectMCPs(project, []string{"alpha"}); err != nil {
+		t.Fatalf("combined write: %v", err)
+	}
+
+	doc := readClaudeDoc(t, configFile)
+	if !hasName(rootMCPNames(doc), "alpha") {
+		t.Errorf("global half did not apply: %v", rootMCPNames(doc))
+	}
+	if names := projectMCPNames(doc, project); hasName(names, "beta") {
+		t.Errorf("project half was not cleared, so a removed MCP still reads as attached: %v", names)
+	}
+}
+
+// TestClearProjectMCPsOnAbsentConfigIsANoOp pins the inverted-bug fix. The
+// hand-rolled read this replaced errored when the config did not exist yet;
+// nothing to clear is success.
+func TestClearProjectMCPsOnAbsentConfigIsANoOp(t *testing.T) {
+	home, project := concurrentWriteEnv(t)
+	configFile := filepath.Join(home, ".claude-cfg", ".claude.json")
+	if err := os.Remove(configFile); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove config: %v", err)
+	}
+
+	if err := ClearProjectMCPs(project); err != nil {
+		t.Errorf("clearing an absent config should be a no-op, got: %v", err)
+	}
+	if _, err := os.Stat(configFile); err == nil {
+		t.Error("clearing an absent config created one; it should not have written anything")
+	}
+}

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -660,15 +660,13 @@ func (m *MCPDialog) Apply() error {
 			enabledNames[i] = item.Name
 		}
 
-		// Write to Claude's global config
-		if err := session.WriteGlobalMCP(enabledNames); err != nil {
-			m.err = err
-			return err
-		}
-
-		// Also clear project-specific MCPs (they were shown in global view)
-		// This ensures removed MCPs are actually removed
-		if err := session.ClearProjectMCPs(m.projectPath); err != nil {
+		// Write the global set and clear the project half under ONE lock. The
+		// global view merges projects[path].mcpServers into what it shows, so
+		// these two writes are a single logical change: run as separate calls
+		// they take and drop the lock twice, and another writer landing in
+		// between sees the new global set with the stale project set still
+		// merged in — MCPs the user just removed reading as still attached.
+		if err := session.WriteGlobalMCPAndClearProjectMCPs(m.projectPath, enabledNames); err != nil {
 			m.err = err
 			return err
 		}

--- a/internal/web/handlers_mcps_corrupt_config_test.go
+++ b/internal/web/handlers_mcps_corrupt_config_test.go
@@ -1,0 +1,184 @@
+package web
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/safeio"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Data-loss guard: a temporarily malformed .claude.json must never be replaced
+// by a config reconstructed from a failed parse.
+//
+// .claude.json holds the user's whole Claude configuration — settings, every
+// project entry, and the root mcpServers map. The MCP writers are
+// read-modify-write. When the read degraded to an empty map on a parse error,
+// the very next attach/detach/move persisted that empty map and the file was
+// gone. A half-finished manual edit or a truncated write from another process
+// is exactly when this fires.
+//
+// The rule these tests pin: parse failure aborts the mutation, names the
+// problem, and leaves the file byte-identical.
+
+const corruptClaudeConfig = `{
+  "numStartups": 42,
+  "theme": "dark",
+  "projects": {
+    "/srv/important": {
+      "hasTrustDialogAccepted": true,
+      "mcpServers": {"gamma": {"command": "gamma-server"}}
+    }
+  },
+  "mcpServers": {"beta": {"command": "beta-server"}}
+  "oops": "the comma above is missing, so this file does not parse"
+}`
+
+// writeCorruptClaudeConfig corrupts BOTH Claude config files: the one under
+// CLAUDE_CONFIG_DIR (which backs the project and global scopes) and the
+// user-root ~/.claude.json (which backs the user scope). They are separate
+// files, so corrupting only one leaves the other scope legitimately writable
+// and the test would pass for the wrong reason.
+func writeCorruptClaudeConfig(t *testing.T, home string) (paths []string, originals [][]byte) {
+	t.Helper()
+	for _, path := range []string{
+		filepath.Join(home, ".claude-cfg", ".claude.json"),
+		filepath.Join(home, ".claude.json"),
+	} {
+		if err := os.WriteFile(path, []byte(corruptClaudeConfig), 0o600); err != nil {
+			t.Fatalf("seed corrupt config %s: %v", path, err)
+		}
+		original, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read back seed %s: %v", path, err)
+		}
+		paths = append(paths, path)
+		originals = append(originals, original)
+	}
+	return paths, originals
+}
+
+func assertByteIdentical(t *testing.T, path string, original []byte, what string) {
+	t.Helper()
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("%s: config disappeared entirely: %v", what, err)
+	}
+	if string(after) != string(original) {
+		t.Errorf("%s REWROTE a malformed config — the user's settings and project entries are gone.\n"+
+			"before (%d bytes):\n%s\nafter (%d bytes):\n%s",
+			what, len(original), original, len(after), after)
+	}
+}
+
+// TestMalformedClaudeConfigIsNeverRewritten walks every mutation the web MCP
+// surface can perform against a Claude session and requires each to refuse.
+func TestMalformedClaudeConfigIsNeverRewritten(t *testing.T) {
+	scopes := []string{"project", "global", "user"}
+
+	for _, scope := range scopes {
+		for _, op := range []string{"attach", "detach", "move"} {
+			t.Run(scope+"/"+op, func(t *testing.T) {
+				home := mcpStoreEnv(t)
+				project := t.TempDir()
+				paths, originals := writeCorruptClaudeConfig(t, home)
+				target := MCPTarget{Tool: "claude", ProjectPath: project}
+				mgr := NewDefaultMCPManager()
+
+				var err error
+				switch op {
+				case "attach":
+					err = mgr.Attach(target, "alpha", scope)
+				case "detach":
+					err = mgr.Detach(target, "alpha", scope)
+				case "move":
+					err = mgr.Move(target, "alpha", scope, "local")
+				}
+
+				if err == nil {
+					t.Errorf("%s in scope %q silently succeeded against a malformed config; "+
+						"it must fail closed", op, scope)
+				} else if !mentionsParseFailure(err) {
+					t.Errorf("%s in scope %q failed, but the error does not name the parse problem: %v",
+						op, scope, err)
+				}
+
+				for i, path := range paths {
+					assertByteIdentical(t, path, originals[i], op+" in scope "+scope)
+				}
+			})
+		}
+	}
+}
+
+// TestMalformedClaudeConfigLeavesUserScopeAlone covers ~/.claude.json, the
+// other file the same read-modify-write pattern owns.
+func TestMalformedClaudeConfigLeavesUserScopeAlone(t *testing.T) {
+	home := mcpStoreEnv(t)
+	userConfig := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(userConfig, []byte(corruptClaudeConfig), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	original, err := os.ReadFile(userConfig)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	// The project-scoped config must be valid so the failure under test is the
+	// user-scope one.
+	if err := session.WriteProjectMCP(t.TempDir(), nil); err != nil {
+		t.Logf("project seed: %v", err)
+	}
+
+	writeErr := session.WriteUserMCP([]string{"alpha"})
+	if writeErr == nil {
+		t.Error("WriteUserMCP silently succeeded against a malformed ~/.claude.json")
+	} else if !mentionsParseFailure(writeErr) {
+		t.Errorf("WriteUserMCP error does not name the parse problem: %v", writeErr)
+	}
+	assertByteIdentical(t, userConfig, original, "WriteUserMCP")
+}
+
+// TestSafeioRefusesDroppingTopLevelKeys pins the second net. Even if some
+// future path reconstructs a config from nothing, the write must be refused
+// because it would remove keys the file already has.
+func TestSafeioRefusesDroppingTopLevelKeys(t *testing.T) {
+	home := mcpStoreEnv(t)
+	path := filepath.Join(home, ".claude-cfg", ".claude.json")
+	populated := []byte(`{"numStartups":42,"theme":"dark","mcpServers":{"beta":{"command":"b"}}}`)
+	if err := os.WriteFile(path, populated, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// A payload that keeps only mcpServers — the exact shape the old
+	// empty-fallback produced.
+	err := safeio.SafeOverwrite(path, []byte(`{"mcpServers":{}}`), safeio.Options{
+		Perm:        0o600,
+		RefuseEmpty: true,
+		Guard:       session.RefuseDroppingTopLevelKeysForTest(path),
+	})
+	if err == nil {
+		t.Fatal("safeio guard allowed a write that drops top-level keys")
+	}
+	if !strings.Contains(err.Error(), "numStartups") || !strings.Contains(err.Error(), "theme") {
+		t.Errorf("guard error should name the dropped keys, got: %v", err)
+	}
+	assertByteIdentical(t, path, populated, "guarded SafeOverwrite")
+
+	// And an outright empty payload is refused by RefuseEmpty.
+	err = safeio.SafeOverwrite(path, nil, safeio.Options{Perm: 0o600, RefuseEmpty: true})
+	if !errors.Is(err, safeio.ErrRefusingEmptyOverwrite) {
+		t.Errorf("empty payload over a populated file should hit ErrRefusingEmptyOverwrite, got %v", err)
+	}
+	assertByteIdentical(t, path, populated, "empty SafeOverwrite")
+}
+
+func mentionsParseFailure(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not valid json") ||
+		strings.Contains(msg, "failed to parse") ||
+		strings.Contains(msg, "invalid character")
+}

--- a/internal/web/handlers_mcps_corrupt_config_test.go
+++ b/internal/web/handlers_mcps_corrupt_config_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"errors"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,8 +12,15 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// Data-loss guard: a temporarily malformed .claude.json must never be replaced
-// by a config reconstructed from a failed parse.
+// Data-loss guard: a config that could not be READ must never be replaced by
+// one reconstructed from that failure.
+//
+// The first version of this file said "parse", and so did its fixtures: the
+// only degraded input it built was malformed JSON. That narrowness was the
+// tell. A parse error is one way a read fails; an unreadable file (permissions,
+// a directory where a file belongs, an I/O error) is another, and every one of
+// them must abort the mutation rather than produce an empty document to write
+// back. The cases below cover the whole read boundary.
 //
 // .claude.json holds the user's whole Claude configuration — settings, every
 // project entry, and the root mcpServers map. The MCP writers are
@@ -21,7 +29,7 @@ import (
 // gone. A half-finished manual edit or a truncated write from another process
 // is exactly when this fires.
 //
-// The rule these tests pin: parse failure aborts the mutation, names the
+// The rule these tests pin: ANY read failure aborts the mutation, names the
 // problem, and leaves the file byte-identical.
 
 const corruptClaudeConfig = `{
@@ -101,8 +109,8 @@ func TestMalformedClaudeConfigIsNeverRewritten(t *testing.T) {
 				if err == nil {
 					t.Errorf("%s in scope %q silently succeeded against a malformed config; "+
 						"it must fail closed", op, scope)
-				} else if !mentionsParseFailure(err) {
-					t.Errorf("%s in scope %q failed, but the error does not name the parse problem: %v",
+				} else if !mentionsReadFailure(err) {
+					t.Errorf("%s in scope %q failed, but the error does not name why the read failed: %v",
 						op, scope, err)
 				}
 
@@ -136,8 +144,8 @@ func TestMalformedClaudeConfigLeavesUserScopeAlone(t *testing.T) {
 	writeErr := session.WriteUserMCP([]string{"alpha"})
 	if writeErr == nil {
 		t.Error("WriteUserMCP silently succeeded against a malformed ~/.claude.json")
-	} else if !mentionsParseFailure(writeErr) {
-		t.Errorf("WriteUserMCP error does not name the parse problem: %v", writeErr)
+	} else if !mentionsReadFailure(writeErr) {
+		t.Errorf("WriteUserMCP error does not name why the read failed: %v", writeErr)
 	}
 	assertByteIdentical(t, userConfig, original, "WriteUserMCP")
 }
@@ -176,9 +184,115 @@ func TestSafeioRefusesDroppingTopLevelKeys(t *testing.T) {
 	assertByteIdentical(t, path, populated, "empty SafeOverwrite")
 }
 
-func mentionsParseFailure(err error) bool {
+// mentionsReadFailure accepts any error that names why the config could not be
+// read — a parse problem or an I/O one. Named for the boundary, not for the one
+// failure mode the first version of these tests happened to build.
+func mentionsReadFailure(err error) bool {
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "not valid json") ||
-		strings.Contains(msg, "failed to parse") ||
-		strings.Contains(msg, "invalid character")
+	for _, want := range []string{
+		"not valid json", "failed to parse", "invalid character",
+		"permission denied", "is a directory", "read ",
+	} {
+		if strings.Contains(msg, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestUnreadableClaudeConfigIsNeverRewritten widens the guard past malformed
+// JSON: a config that cannot be read at all must abort the mutation too, not
+// fall through to a fresh document.
+func TestUnreadableClaudeConfigIsNeverRewritten(t *testing.T) {
+	if u, err := user.Current(); err == nil && u.Uid == "0" {
+		t.Skip("running as root: file permissions would not block the read")
+	}
+	for _, scope := range []string{"project", "global"} {
+		t.Run(scope, func(t *testing.T) {
+			home := mcpStoreEnv(t)
+			project := t.TempDir()
+			path := filepath.Join(home, ".claude-cfg", ".claude.json")
+			populated := []byte(`{"numStartups":9,"theme":"dark","mcpServers":{"beta":{"command":"b"}}}`)
+			if err := os.WriteFile(path, populated, 0o600); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			// Unreadable, but present and non-empty.
+			if err := os.Chmod(path, 0o000); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+			err := NewDefaultMCPManager().Attach(MCPTarget{Tool: "claude", ProjectPath: project}, "alpha", scope)
+			if err == nil {
+				t.Fatalf("attach in scope %q silently succeeded against an unreadable config", scope)
+			}
+
+			if err := os.Chmod(path, 0o600); err != nil {
+				t.Fatalf("restore perms: %v", err)
+			}
+			assertByteIdentical(t, path, populated, "attach against an unreadable config")
+		})
+	}
+}
+
+// TestConfigDirectoryInPlaceOfFileIsNeverRewritten covers the other read
+// failure: something that is not a regular file where the config belongs.
+func TestConfigDirectoryInPlaceOfFileIsNeverRewritten(t *testing.T) {
+	home := mcpStoreEnv(t)
+	project := t.TempDir()
+	path := filepath.Join(home, ".claude-cfg", ".claude.json")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir in place of config: %v", err)
+	}
+	marker := filepath.Join(path, "keep-me")
+	if err := os.WriteFile(marker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	if err := NewDefaultMCPManager().Attach(MCPTarget{Tool: "claude", ProjectPath: project}, "alpha", "global"); err == nil {
+		t.Error("attach silently succeeded with a directory where the config belongs")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("the directory standing in for the config was clobbered: %v", err)
+	}
+}
+
+// TestEmptyConfigStartsFreshRatherThanFailing draws the other side of the line:
+// a missing or empty file is NOT a read failure. Refusing there would make a
+// first-ever attach impossible, which is the inverted bug the hand-rolled
+// ClearProjectMCPs copy had.
+func TestEmptyConfigStartsFreshRatherThanFailing(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, path string)
+	}{
+		{"absent", func(t *testing.T, path string) {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("remove: %v", err)
+			}
+		}},
+		{"empty", func(t *testing.T, path string) {
+			if err := os.WriteFile(path, nil, 0o600); err != nil {
+				t.Fatalf("truncate: %v", err)
+			}
+		}},
+		{"whitespace only", func(t *testing.T, path string) {
+			if err := os.WriteFile(path, []byte("\n  \n"), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := mcpStoreEnv(t)
+			project := t.TempDir()
+			tc.setup(t, filepath.Join(home, ".claude-cfg", ".claude.json"))
+
+			if err := NewDefaultMCPManager().Attach(MCPTarget{Tool: "claude", ProjectPath: project}, "alpha", "global"); err != nil {
+				t.Errorf("a %s config should start fresh, not fail: %v", tc.name, err)
+			}
+		})
+	}
 }

--- a/internal/web/static/app/panes/McpPane.js
+++ b/internal/web/static/app/panes/McpPane.js
@@ -90,15 +90,62 @@ async function jsonFetch(path, opts = {}) {
   return res.json()
 }
 
+// McpPane resolves the selected session and hands off to a child keyed by
+// session id.
+//
+// The key is the fix for the stale-frame window: resetting per-session state in
+// a useEffect runs AFTER the render commits, so the first frame of a new
+// session painted the previous session's catalog, attachments and scopes while
+// the mutation callbacks were already bound to the new session. A click landing
+// in that frame mutated the new session using the old session's data. Keying
+// the child means switching sessions unmounts it and mounts a fresh one, so the
+// old state cannot be painted at all — the reset is structural, not deferred.
 export function McpPane() {
   const { sessions } = menuModelSignal.value
   const selectedId = selectedIdSignal.value
-  const mutationsEnabled = mutationsEnabledSignal.value
   const session = sessions.find(s => s.id === selectedId)
 
-  // The session the pane is currently showing. Async refreshes compare against
-  // this so a response for a previous session cannot overwrite the new one.
-  const sessionId = session ? session.id : null
+  if (!session) {
+    return html`
+      <div class="costs">
+        <div class="chart-card" style="text-align: center; padding: 48px 24px;">
+          <div class="title" style="font-size: 16px;">MCP Manager</div>
+          <div style="font-family: var(--mono); font-size: 12px; color: var(--text-dim); padding-top: 8px;">
+            Select a session in the sidebar to manage MCPs.
+          </div>
+        </div>
+      </div>
+    `
+  }
+
+  // Say so rather than rendering a catalog whose buttons the server will
+  // refuse. The tool decides which MCP store exists; a shell session has none.
+  if (!toolSupportsMCP(session)) {
+    return html`
+      <div class="costs" data-testid="mcp-pane" data-session-id=${session.id}>
+        <div class="chart-card" style="text-align: center; padding: 48px 24px;">
+          <div class="title" style="font-size: 16px;">MCP Manager</div>
+          <div data-testid="mcp-unsupported-tool"
+               style="font-family: var(--mono); font-size: 12px; color: var(--text-dim); padding-top: 8px;">
+            MCP management is not available for ${session.tool || 'this'} sessions.
+            Supported tools: Claude, Codex, Gemini, Cursor, OpenCode.
+          </div>
+        </div>
+      </div>
+    `
+  }
+
+  return html`<${McpPaneForSession} key=${session.id} session=${session}/>`
+}
+
+// McpPaneForSession owns all per-session state. It is mounted fresh for each
+// session (see the key above), so every useState below starts empty and no
+// value can leak across a switch.
+function McpPaneForSession({ session }) {
+  const mutationsEnabled = mutationsEnabledSignal.value
+  const sessionId = session.id
+  // Still keyed defensively: a refresh in flight when this instance unmounts
+  // must not apply, and mcpStateForResponse is the tested seam for that.
   const activeSessionRef = useRef(sessionId)
 
   const [catalog, setCatalog] = useState([])
@@ -109,11 +156,7 @@ export function McpPane() {
   const [error, setError] = useState('')
 
   const refresh = useCallback(async () => {
-    // Hooks must run unconditionally, so guard here rather than relying on the
-    // unsupported-tool early return below: without this the pane would fire a
-    // request the server is obliged to refuse.
-    if (!session || !toolSupportsMCP(session)) return
-    const forSession = session.id
+    const forSession = sessionId
     setLoading(true)
     setError('')
     try {
@@ -137,18 +180,12 @@ export function McpPane() {
     } finally {
       if (activeSessionRef.current === forSession) setLoading(false)
     }
-  }, [session && session.id])
+  }, [sessionId])
 
-  // Re-key every piece of per-session state the moment the selection changes,
-  // so nothing from the previous session is on screen (or usable) while the
-  // new session's refresh is in flight.
   useEffect(() => {
     activeSessionRef.current = sessionId
-    setCatalog([])
-    setAttached(EMPTY_ATTACHED)
-    setScopes([])
-    setError('')
     refresh()
+    return () => { activeSessionRef.current = null }
   }, [sessionId, refresh])
 
   const findScope = (name) => {
@@ -162,7 +199,6 @@ export function McpPane() {
   const defaultScope = scopes[0] || ''
 
   const attach = async (name, scope) => {
-    if (!session) return
     try {
       await jsonFetch(`/api/sessions/${encodeURIComponent(session.id)}/mcps/${encodeURIComponent(name)}`, {
         method: 'POST',
@@ -176,7 +212,6 @@ export function McpPane() {
   }
 
   const detach = async (name) => {
-    if (!session) return
     const scope = findScope(name)
     try {
       await jsonFetch(`/api/sessions/${encodeURIComponent(session.id)}/mcps/${encodeURIComponent(name)}`, {
@@ -191,7 +226,6 @@ export function McpPane() {
   }
 
   const moveScope = async (name, toScope) => {
-    if (!session) return
     try {
       await jsonFetch(`/api/sessions/${encodeURIComponent(session.id)}/mcps/${encodeURIComponent(name)}`, {
         method: 'PATCH',
@@ -204,38 +238,8 @@ export function McpPane() {
     }
   }
 
-  if (!session) {
-    return html`
-      <div class="costs">
-        <div class="chart-card" style="text-align: center; padding: 48px 24px;">
-          <div class="title" style="font-size: 16px;">MCP Manager</div>
-          <div style="font-family: var(--mono); font-size: 12px; color: var(--text-dim); padding-top: 8px;">
-            Select a session in the sidebar to manage MCPs.
-          </div>
-        </div>
-      </div>
-    `
-  }
-
-  // Say so rather than rendering a catalog whose buttons the server will
-  // refuse. The tool decides which MCP store exists; a shell session has none.
-  if (!toolSupportsMCP(session)) {
-    return html`
-      <div class="costs" data-testid="mcp-pane">
-        <div class="chart-card" style="text-align: center; padding: 48px 24px;">
-          <div class="title" style="font-size: 16px;">MCP Manager</div>
-          <div data-testid="mcp-unsupported-tool"
-               style="font-family: var(--mono); font-size: 12px; color: var(--text-dim); padding-top: 8px;">
-            MCP management is not available for ${session.tool || 'this'} sessions.
-            Supported tools: Claude, Codex, Gemini, Cursor, OpenCode.
-          </div>
-        </div>
-      </div>
-    `
-  }
-
   return html`
-    <div class="costs" data-testid="mcp-pane">
+    <div class="costs" data-testid="mcp-pane" data-session-id=${sessionId}>
       <div class="chart-card" style="padding: 24px;">
         <div class="title" style="font-size: 16px; margin-bottom: 4px;">MCP Manager</div>
         <div style="font-family: var(--mono); font-size: 11px; color: var(--text-dim); margin-bottom: 16px;">

--- a/internal/web/static/app/panes/McpPane.js
+++ b/internal/web/static/app/panes/McpPane.js
@@ -10,7 +10,7 @@
 //   DELETE /api/sessions/{id}/mcps/{name}         -> detach (scope in body)
 //   PATCH  /api/sessions/{id}/mcps/{name}         -> move scope (toggle pooled ↔ local)
 import { html } from 'htm/preact'
-import { useEffect, useState, useCallback } from 'preact/hooks'
+import { useEffect, useState, useCallback, useRef } from 'preact/hooks'
 import { menuModelSignal } from '../dataModel.js'
 import { selectedIdSignal, mutationsEnabledSignal } from '../state.js'
 import { addToast } from '../Toast.js'
@@ -33,6 +33,38 @@ const EMPTY_ATTACHED = { local: [], project: [], global: [], user: [] }
 // not in any hardcoded list.
 function toolSupportsMCP(session) {
   return session.mcpSupported !== false
+}
+
+
+// mcpStateForResponse reduces a completed refresh into pane state, or returns
+// null when the response belongs to a session the user has already navigated
+// away from.
+//
+// Refreshes are async, so switching sessions mid-flight used to let the old
+// session's catalog, attachments and — worst — its SCOPE LIST land on the new
+// session. The next attach then used a scope the new session's tool may not
+// have. Responses are keyed by session id and mismatches are discarded.
+//
+// Exported for tests: rendering preact components under vitest is broken in
+// this repo (see unit/archivedPane.test.js), so the logic that matters is
+// asserted directly.
+export function mcpStateForResponse({ forSessionId, activeSessionId, catalogResp, attachedResp }) {
+  if (!forSessionId || forSessionId !== activeSessionId) return null
+  const scopes = attachedResp && attachedResp.scopes && attachedResp.scopes.length
+    ? attachedResp.scopes
+    : ALL_SCOPES
+  return {
+    sessionId: forSessionId,
+    catalog: (catalogResp && catalogResp.mcps) || [],
+    attached: {
+      local: (attachedResp && attachedResp.local) || [],
+      project: (attachedResp && attachedResp.project) || [],
+      global: (attachedResp && attachedResp.global) || [],
+      user: (attachedResp && attachedResp.user) || [],
+    },
+    scopes,
+    defaultScope: scopes[0] || '',
+  }
 }
 
 // jsonFetch keeps this pane's 204 handling and error shaping, but the headers
@@ -64,6 +96,11 @@ export function McpPane() {
   const mutationsEnabled = mutationsEnabledSignal.value
   const session = sessions.find(s => s.id === selectedId)
 
+  // The session the pane is currently showing. Async refreshes compare against
+  // this so a response for a previous session cannot overwrite the new one.
+  const sessionId = session ? session.id : null
+  const activeSessionRef = useRef(sessionId)
+
   const [catalog, setCatalog] = useState([])
   const [attached, setAttached] = useState(EMPTY_ATTACHED)
   // Scopes this session's tool actually has, as reported by the server.
@@ -76,6 +113,7 @@ export function McpPane() {
     // unsupported-tool early return below: without this the pane would fire a
     // request the server is obliged to refuse.
     if (!session || !toolSupportsMCP(session)) return
+    const forSession = session.id
     setLoading(true)
     setError('')
     try {
@@ -83,23 +121,35 @@ export function McpPane() {
         jsonFetch('/api/mcps'),
         jsonFetch(`/api/sessions/${encodeURIComponent(session.id)}/mcps`),
       ])
-      setCatalog(catalogResp.mcps || [])
-      setAttached({
-        local: attachedResp.local || [],
-        project: attachedResp.project || [],
-        global: attachedResp.global || [],
-        user: attachedResp.user || [],
+      const next = mcpStateForResponse({
+        forSessionId: forSession,
+        activeSessionId: activeSessionRef.current,
+        catalogResp,
+        attachedResp,
       })
-      // Fall back to every scope only if an older server omits the field.
-      setScopes(attachedResp.scopes && attachedResp.scopes.length ? attachedResp.scopes : ALL_SCOPES)
+      // Stale: the user switched sessions while this was in flight.
+      if (!next) return
+      setCatalog(next.catalog)
+      setAttached(next.attached)
+      setScopes(next.scopes)
     } catch (err) {
-      setError(err.message)
+      if (activeSessionRef.current === forSession) setError(err.message)
     } finally {
-      setLoading(false)
+      if (activeSessionRef.current === forSession) setLoading(false)
     }
   }, [session && session.id])
 
-  useEffect(() => { refresh() }, [refresh])
+  // Re-key every piece of per-session state the moment the selection changes,
+  // so nothing from the previous session is on screen (or usable) while the
+  // new session's refresh is in flight.
+  useEffect(() => {
+    activeSessionRef.current = sessionId
+    setCatalog([])
+    setAttached(EMPTY_ATTACHED)
+    setScopes([])
+    setError('')
+    refresh()
+  }, [sessionId, refresh])
 
   const findScope = (name) => {
     for (const s of ALL_SCOPES) {

--- a/tests/web/e2e/mcp-auth.spec.js
+++ b/tests/web/e2e/mcp-auth.spec.js
@@ -165,34 +165,102 @@ test.describe('MCP management — authenticated browser path', () => {
     expect(body.scopes).toEqual(['global'])
   })
 
-  test('switching sessions mid-refresh lands the attach in the NEW session\'s scope', async ({ page }) => {
-    // Hold the Claude session's MCP response open so the switch happens while
-    // it is genuinely in flight. Only that one route is delayed; everything
-    // else, including both sessions' real handlers, runs untouched.
-    await page.route(`**/api/sessions/${SESSION_ID}/mcps`, async route => {
+  test('switching sessions mid-refresh never paints a stale frame', async ({ page }) => {
+    // Give the Claude session something visible to go stale: an attached row.
+    await fetch(`${baseURL}/api/sessions/${SESSION_ID}/mcps/exa`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json', Origin: baseURL },
+      body: JSON.stringify({ scope: 'local' }),
+    })
+
+    // Hold the Codex session's response open, so the new pane sits in flight
+    // and any stale frame would be on screen for a long, observable window.
+    await page.route('**/api/sessions/sess-003/mcps', async route => {
       await new Promise(r => setTimeout(r, 2500))
       await route.continue()
     })
 
     await page.goto(`${baseURL}/s/${SESSION_ID}?token=${TOKEN}`)
     await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+    await expect(page.getByTestId('mcp-attached-exa')).toBeVisible()
 
-    // Switch to the Codex session (global-only) before the Claude response
-    // resolves. The stale response must be discarded rather than installing
-    // Claude's scope list — which would make the next attach send "local".
+    // Record EVERY DOM state from here on. A MutationObserver sees each commit,
+    // so a stale frame lasting a single render is still captured — a poll-based
+    // assertion could sail straight past it.
+    await page.evaluate(() => {
+      window.__mcpFrames = []
+      const sample = () => {
+        const pane = document.querySelector('[data-testid="mcp-pane"]')
+        if (!pane) return
+        const rows = Array.from(document.querySelectorAll('[data-testid^="mcp-attached-"]'))
+          .map(el => el.getAttribute('data-testid').slice('mcp-attached-'.length))
+          .filter(Boolean)
+        window.__mcpFrames.push({ sid: pane.getAttribute('data-session-id'), rows })
+      }
+      sample()
+      new MutationObserver(sample).observe(document.body, {
+        subtree: true, childList: true, attributes: true, characterData: true,
+      })
+    })
 
-    await page.goto(`${baseURL}/s/sess-003?token=${TOKEN}`)
+    // Switch the selected session WITHOUT leaving the MCP tab.
+    //
+    // Neither shipped navigation path can do this today: Sidebar.onSelect and
+    // the command palette both set activeTab to 'terminal', which unmounts the
+    // pane and hides the defect. Driving the signal directly is therefore the
+    // only way to reach the scenario, and it is the component's real contract:
+    // the pane must be correct for whatever session is selected while it is
+    // mounted. Importing the module by URL returns the same instance the app
+    // is already using (ESM modules are cached per URL).
+    await page.evaluate(async () => {
+      const state = await import('/static/app/state.js')
+      state.selectedIdSignal.value = 'sess-003'
+    })
+
+    // Wait until the pane is showing the Codex session.
+    await expect(page.locator('[data-testid="mcp-pane"][data-session-id="sess-003"]')).toBeVisible()
+    await page.waitForTimeout(3000) // past the delayed response
+
+    const frames = await page.evaluate(() => window.__mcpFrames)
+    expect(frames.length).toBeGreaterThan(0)
+
+    // The assertion: no frame ever showed the Codex session holding the Claude
+    // session's attachment. One such frame is a click away from mutating the
+    // wrong thing, because the callbacks are already bound to sess-003.
+    const stale = frames.filter(f => f.sid === 'sess-003' && f.rows.includes('exa'))
+    expect(stale, `stale frames painted sess-003 with sess-001 data: ${JSON.stringify(stale)}`).toEqual([])
+
+    // And the Codex session really is empty, so the check above was not vacuous.
+    const codex = await (await page.request.get(`${baseURL}/api/sessions/sess-003/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })).json()
+    expect(codex.global).not.toContain('exa')
+    expect(codex.scopes).toEqual(['global'])
+  })
+
+  test('after a mid-flight switch an attach lands in the NEW session\'s scope', async ({ page }) => {
+    await page.route('**/api/sessions/sess-001/mcps', async route => {
+      await new Promise(r => setTimeout(r, 2000))
+      await route.continue()
+    })
+
+    await page.goto(`${baseURL}/s/${SESSION_ID}?token=${TOKEN}`)
     await page.getByRole('button', { name: 'MCPs', exact: true }).click()
-    await expect(page.getByTestId('mcp-pane')).toBeVisible()
+
+    // Switch to the Codex session while the Claude refresh is still in flight,
+    // staying on the MCP tab (see the note in the stale-frame test above).
+    await page.evaluate(async () => {
+      const state = await import('/static/app/state.js')
+      state.selectedIdSignal.value = 'sess-003'
+    })
+    await expect(page.locator('[data-testid="mcp-pane"][data-session-id="sess-003"]')).toBeVisible()
 
     const attachButton = page.getByTestId('mcp-attach-exa')
     await expect(attachButton).toBeVisible()
     await attachButton.click()
     await expect(page.getByTestId('mcp-attached-exa')).toBeVisible()
 
-    // Wait past the delayed response so a late arrival would have had its
-    // chance to corrupt the state.
-    await page.waitForTimeout(3000)
+    await page.waitForTimeout(2500) // let the stale Claude response arrive late
     await expect(page.getByTestId('mcp-error')).toBeHidden()
 
     const codex = await (await page.request.get(`${baseURL}/api/sessions/sess-003/mcps`, {
@@ -201,7 +269,6 @@ test.describe('MCP management — authenticated browser path', () => {
     expect(codex.global).toContain('exa')
     expect(codex.local).not.toContain('exa')
 
-    // And nothing was written to the session we navigated away from.
     const claude = await (await page.request.get(`${baseURL}/api/sessions/${SESSION_ID}/mcps`, {
       headers: { Authorization: `Bearer ${TOKEN}` },
     })).json()

--- a/tests/web/e2e/mcp-auth.spec.js
+++ b/tests/web/e2e/mcp-auth.spec.js
@@ -165,6 +165,49 @@ test.describe('MCP management — authenticated browser path', () => {
     expect(body.scopes).toEqual(['global'])
   })
 
+  test('switching sessions mid-refresh lands the attach in the NEW session\'s scope', async ({ page }) => {
+    // Hold the Claude session's MCP response open so the switch happens while
+    // it is genuinely in flight. Only that one route is delayed; everything
+    // else, including both sessions' real handlers, runs untouched.
+    await page.route(`**/api/sessions/${SESSION_ID}/mcps`, async route => {
+      await new Promise(r => setTimeout(r, 2500))
+      await route.continue()
+    })
+
+    await page.goto(`${baseURL}/s/${SESSION_ID}?token=${TOKEN}`)
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+
+    // Switch to the Codex session (global-only) before the Claude response
+    // resolves. The stale response must be discarded rather than installing
+    // Claude's scope list — which would make the next attach send "local".
+
+    await page.goto(`${baseURL}/s/sess-003?token=${TOKEN}`)
+    await page.getByRole('button', { name: 'MCPs', exact: true }).click()
+    await expect(page.getByTestId('mcp-pane')).toBeVisible()
+
+    const attachButton = page.getByTestId('mcp-attach-exa')
+    await expect(attachButton).toBeVisible()
+    await attachButton.click()
+    await expect(page.getByTestId('mcp-attached-exa')).toBeVisible()
+
+    // Wait past the delayed response so a late arrival would have had its
+    // chance to corrupt the state.
+    await page.waitForTimeout(3000)
+    await expect(page.getByTestId('mcp-error')).toBeHidden()
+
+    const codex = await (await page.request.get(`${baseURL}/api/sessions/sess-003/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })).json()
+    expect(codex.global).toContain('exa')
+    expect(codex.local).not.toContain('exa')
+
+    // And nothing was written to the session we navigated away from.
+    const claude = await (await page.request.get(`${baseURL}/api/sessions/${SESSION_ID}/mcps`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })).json()
+    expect(claude.local).not.toContain('exa')
+  })
+
   test('a session whose tool has no MCP store says so instead of offering buttons', async ({ page }) => {
     // sess-004 is a shell session. The server refuses MCP routes for it, so the
     // pane must not render a catalog whose every button would fail.

--- a/tests/web/unit/mcpPaneSessionSwitch.test.js
+++ b/tests/web/unit/mcpPaneSessionSwitch.test.js
@@ -1,0 +1,124 @@
+// Switching sessions while an MCP refresh is in flight must not let the old
+// session's response land on the new one.
+//
+// The refresh is two async GETs. Before this guard, a slow response for session
+// A could resolve after the user had already selected session B and overwrite
+// B's catalog, attachments and — the damaging part — B's SCOPE LIST. The next
+// attach then used A's default scope, which B's tool may not even have: a
+// Claude session leaves "local" behind, and a Codex session (global-only) would
+// send "local" and be refused.
+//
+// Asserts mcpStateForResponse directly rather than rendering McpPane: rendering
+// preact components under this vitest alias map throws from @preact/signals (see
+// unit/archivedPane.test.js for the same constraint). This function is the whole
+// of the stale-response decision.
+import { describe, expect, it } from 'vitest'
+
+const mcpPaneModulePath = '../../../internal/web/static/app/panes/McpPane.js'
+
+const claudeResponse = {
+  sessionId: 'sess-claude',
+  local: ['exa'],
+  project: [],
+  global: [],
+  user: [],
+  scopes: ['local', 'project', 'global', 'user'],
+}
+
+const codexResponse = {
+  sessionId: 'sess-codex',
+  local: [],
+  project: [],
+  global: ['youtube'],
+  user: [],
+  scopes: ['global'],
+}
+
+const catalog = { mcps: [{ name: 'exa' }, { name: 'youtube' }] }
+
+describe('mcpStateForResponse — session re-keying', () => {
+  it('discards a response whose session is no longer selected', async () => {
+    const { mcpStateForResponse } = await import(mcpPaneModulePath)
+
+    // The refresh was started for the Claude session; by the time it resolved
+    // the user had switched to the Codex one.
+    const stale = mcpStateForResponse({
+      forSessionId: 'sess-claude',
+      activeSessionId: 'sess-codex',
+      catalogResp: catalog,
+      attachedResp: claudeResponse,
+    })
+
+    expect(stale).toBeNull()
+  })
+
+  it('applies a response for the session that is still selected', async () => {
+    const { mcpStateForResponse } = await import(mcpPaneModulePath)
+
+    const fresh = mcpStateForResponse({
+      forSessionId: 'sess-codex',
+      activeSessionId: 'sess-codex',
+      catalogResp: catalog,
+      attachedResp: codexResponse,
+    })
+
+    expect(fresh).not.toBeNull()
+    expect(fresh.sessionId).toBe('sess-codex')
+    expect(fresh.scopes).toEqual(['global'])
+    expect(fresh.attached.global).toEqual(['youtube'])
+  })
+
+  it('an attach after a mid-flight switch uses the NEW session’s scope', async () => {
+    const { mcpStateForResponse } = await import(mcpPaneModulePath)
+
+    // Order of arrival: the user switches Claude -> Codex, the Codex response
+    // lands first, then the stale Claude response arrives late.
+    let state = mcpStateForResponse({
+      forSessionId: 'sess-codex',
+      activeSessionId: 'sess-codex',
+      catalogResp: catalog,
+      attachedResp: codexResponse,
+    })
+    expect(state.defaultScope).toBe('global')
+
+    const late = mcpStateForResponse({
+      forSessionId: 'sess-claude',
+      activeSessionId: 'sess-codex',
+      catalogResp: catalog,
+      attachedResp: claudeResponse,
+    })
+    // Null means the component keeps the state it already has.
+    expect(late).toBeNull()
+    if (late) state = late
+
+    // The scope an attach would now send. "local" here would be refused by the
+    // server, because Codex has no local store.
+    expect(state.defaultScope).toBe('global')
+    expect(state.scopes).not.toContain('local')
+  })
+
+  it('a session with no id never applies a response', async () => {
+    const { mcpStateForResponse } = await import(mcpPaneModulePath)
+
+    expect(mcpStateForResponse({
+      forSessionId: null,
+      activeSessionId: null,
+      catalogResp: catalog,
+      attachedResp: claudeResponse,
+    })).toBeNull()
+  })
+
+  it('falls back to every scope when an older server omits the field', async () => {
+    const { mcpStateForResponse } = await import(mcpPaneModulePath)
+
+    const state = mcpStateForResponse({
+      forSessionId: 'sess-claude',
+      activeSessionId: 'sess-claude',
+      catalogResp: catalog,
+      attachedResp: { local: [], project: [], global: [], user: [] },
+    })
+
+    expect(state.scopes).toEqual(['local', 'project', 'global', 'user'])
+    expect(state.defaultScope).toBe('local')
+  })
+})


### PR DESCRIPTION
## Summary

Two round-3 findings on the web MCP surface. The first is a live data-loss bug on `main`.

## P1 — a config that could not be READ was silently replaced (DATA LOSS)

`.claude.json` holds the user's whole Claude configuration: settings, every project entry, and the root `mcpServers` map. `WriteGlobalMCP`, `WriteProjectMCP` and `WriteUserMCP` are read-modify-write, and all three degraded to an empty map when the file failed to parse:

```go
if err := json.Unmarshal(data, &rawConfig); err != nil {
    rawConfig = make(map[string]interface{})
}
```

The next attach, detach or move then **persisted that empty map**. A transiently malformed file — a half-finished manual edit, a truncated write from another process — was silently replaced by a config containing nothing but the MCP list being written. Every setting and every project entry gone.

Two of the three writers predate this chain; `WriteProjectMCP` was added in #1955 and inherited the pattern from its neighbours. All three are fixed.

**Hard rule, now enforced: a config derived from a failed read is never written.**

- `readJSONObjectConfig` fails closed. A missing, empty or whitespace-only file legitimately starts from a fresh map; anything else that cannot be read — malformed JSON, a permissions error, a directory where the file belongs — aborts the mutation with an error naming the file and the reason. All five call sites now go through it, including `ClearProjectMCPs`.

  *Correction to the earlier version of this description:* it claimed all four writers already went through the shared helper. That was false. `ClearProjectMCPs` kept its own inline `os.ReadFile` + `json.Unmarshal` — a fifth hand-rolled copy. It happened to fail closed on a bad parse, so it was safe, but it errored on a genuinely **absent** file, which is the inverted bug: nothing to clear is success. It is routed through the shared helper in this revision and has a test pinning the absent-file case.
- Writes route through `safeio.SafeOverwrite` as a **second net**: `RefuseEmpty` blocks an empty payload over a populated file, a `Guard` refuses any write that would drop top-level keys already on disk, and a `.bak` is taken first. Both refusals happen before anything is touched.

### Regression test

*The title said "parse" where the defect is "read", and the fixtures were narrowed the same way — they built only malformed JSON. The reviewer's point that the narrow title was the tell for the narrow fixture is correct; title, fixtures and scope are all widened here.*

`TestMalformedClaudeConfigIsNeverRewritten` corrupts **both** Claude config files — the `CLAUDE_CONFIG_DIR` one (project and global scopes) and the user-root `~/.claude.json` (user scope) are separate files, so corrupting only one lets the other scope pass for the wrong reason — then drives attach, detach and move across all three scopes. Every case must error naming the parse failure and leave both files **byte-identical**. `TestSafeioRefusesDroppingTopLevelKeys` pins the second net directly. `TestUnreadableClaudeConfigIsNeverRewritten` and `TestConfigDirectoryInPlaceOfFileIsNeverRewritten` cover read failures that are not parse failures, and `TestEmptyConfigStartsFreshRatherThanFailing` pins the other side of the line.

## P3 — concurrent read-modify-write was unserialized (BLOCKING GAP)

The writers failed closed on a bad read but had no serialization at all. The web MCP pane and the TUI MCP dialog both write `.claude.json`, and every writer is read-modify-write, so two overlapping writers meant the second loaded a document predating the first and saved it back — erasing that writer's section, with both calls returning success.

- `acquireCodexConfigLock` is **generalized** out of `codex_trust.go` into `AcquireConfigFileLock` (`config_file_lock.go`), not copied. `codex_trust.go` now aliases it. The private copy is precisely why the MCP writers shipped unserialized: there was no shared thing to reach for.
- Every writer holds the lock across the **whole** read-modify-write: `WriteGlobalMCP`, `WriteProjectMCP`, `WriteUserMCP`, `ClearProjectMCPs`, and `WriteMergedMcpJSONFile` (`.mcp.json` is the same class, reached by both surfaces).
- `WriteGlobalMCPAndClearProjectMCPs` spans the TUI's pair under **one** lock; `mcp_dialog.go` calls it. As two public calls the lock is taken and dropped twice, leaving a window where another process observes the new global set with the stale project set still merged in.
- The lock is deliberately non-reentrant; multi-write callers acquire once and use the `*Locked` bodies.

Both halves matter and are documented at the definition: the per-path in-process mutex (flock does not serialize goroutines within one process) and the advisory flock on a sibling `.lock` file (for the headless server vs. an interactive TUI).

## P2 — the pane did not re-key state on session switch

A refresh is two async GETs. Switching sessions mid-flight let the previous session's catalog, attachments and **scope list** land on the new one. The next attach then used the old tool's default scope, which the new tool may not have: a Claude session leaving `local` behind would have every Codex attach refused.

Responses are now keyed by session id and mismatches discarded, and all per-session state resets the moment the selection changes, so nothing stale is on screen or usable while the new refresh is in flight.

The decision is factored into an exported `mcpStateForResponse` so it can be tested directly — rendering preact components under this repo's vitest alias map throws from `@preact/signals` (see `unit/archivedPane.test.js` for the same constraint). An e2e case additionally delays the Claude session's response, switches to the Codex session mid-flight, attaches, and asserts it landed in `global` and that nothing was written to the session navigated away from.

## Negative controls

Both fixes were reverted and the tests confirmed to fail:

| Reverted | Result |
|---|---|
| the empty-config fallback | `REWROTE a malformed config — the user's settings and project entries are gone` on every scope |
| the config lock | `round 0: the global write erased the project section` |
| the one-lock pair | `the combined write took the config lock 3 times, want exactly 1` |
| the shared reader in `ClearProjectMCPs` | `clearing an absent config should be a no-op, got: ... no such file` |
| the staleness check | 3 of 5 session-switch cases fail |

## The surface is stable

Full scope matrix re-run on this branch alongside the two new tests:

- `TestScopeMatrixMatchesScopesForTool`, `TestScopeMatrixAttachDetachMove`, `TestScopeMatrixMoveBetweenSupportedScopes` — every tool × scope × {attach, detach, move}
- `TestMoveWithUnsupportedDestinationLeavesSourceAttached`, `TestMoveRestoresSourceWhenDestinationWriteFails`
- `TestClaudeProjectScopeIsWrittenWhereItIsReported`, `TestClaudeProjectEntriesAreTheirOwnScope`
- `TestLocalWriteInvalidatesMCPInfoCache`, `TestLocalAttachPreservesServersAlreadyInMcpJSON`, `TestLocalDetachPreservesOtherServers`, `TestNonClaudeToolDoesNotTouchClaudeConfig`, `TestScopesAreRefusedWhenTheToolDoesNotHaveThem`
- `TestMalformedClaudeConfigIsNeverRewritten`, `TestSafeioRefusesDroppingTopLevelKeys`, `mcpPaneSessionSwitch`

With the read/write stores coherent per tool, the scopes modelled and written where they are reported, moves transactional, caches invalidated, writes fail-closed on a bad parse, and the pane re-keyed per session, I consider this surface stable.

## Validation

Sandboxed, package-scoped, `-p 1`, no `-race`, no `./...`.

- `make css-verify`, `gofmt`, `go build` (agent-deck + web-fixture), `go vet`, `golangci-lint`: passed
- `go test ./internal/web` (full package): passed
- `go test ./internal/session -run '(?i)mcp|claude|config'`: passed
- `go test ./internal/safeio`: passed
- `go test ./cmd/agent-deck -run '^(TestBuildWebServer_|TestResolveWebToken_)'`: passed
- Web unit (Vitest): 11 files, **136 passed**
- `go test ./internal/session` (full package): passed
- `go test ./internal/ui -run '(?i)mcp'`: passed
- Playwright e2e + screenshots: **611 passed**, 0 failed

### A correction to my own test

The first version of the TUI-pair test asserted only the end state, which is identical whether the lock is held once or twice — it **passed** against the split implementation. Atomicity is now asserted by counting lock acquisitions, the property that actually differs. Reported because it is the same failure mode as the narrow fixture: a test named for a property it did not check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MCP configuration changes now fail safely when files are malformed, unreadable, or unexpectedly empty.
  - Existing settings are preserved when updates cannot be safely applied.
  - Concurrent MCP updates are coordinated to prevent lost changes or corrupted configuration.
  - Switching sessions during MCP refreshes no longer displays outdated results.
  - MCP attachments and scopes remain associated with the correct session.

- **Tests**
  - Added coverage for configuration protection, concurrent updates, and session-switching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->