### PR TITLE
fix(session): own wrapped process trees with a spawn-time receipt (#1873)

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -47,4 +47,6 @@ All commands ran in `golang:1.25` containers. Each production guard was restored
 
 ## CI state
 
-Pending the final signed commit and push; this section will be updated with the exact head and completed check result.
+- Exact verified code head: `0f3cddbce629ae72cb6cafeda7d61b7af87a7ab7`.
+- GREEN: full PR gate (7m18s), race persistence suite, persistence script, macOS and Ubuntu harnesses, golangci-lint, CodeQL analysis, govulncheck, eval smoke, stale-tmux smoke, diff-scope, snapshot, intake, and CodeRabbit.
+- The first post-fix CI cycle found one unused upstream watcher wrapper left by the rebase conflict. The signed follow-up `0f3cddbc` reused that wrapper with the PR's shared generation/wake arguments, preserving watcher lifecycle tracking; the complete exact-head rerun above passed.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,147 +1,50 @@
-# Issue #2045 results
+# PR #1961 final verification
 
-## Reproduction
+## Rebase evidence
 
-Reproduced on current `origin/main` at `47bb2103` in a `golang:1.25`
-container. The regression test `TestIssue2045LaunchHelpOffersNamedAccountSlot`
-failed because `agent-deck launch --help` had no `--account` option. The test
-`TestIssue2045AccountsListsConfiguredSlots` failed because the unknown
-`accounts` command fell through to TUI startup and exited with `Error: tmux not
-found` instead of listing the two configured slots.
+- Pre-rebase head: `f0f507eb641b6af51fdfa2ac82952164107eed11`.
+- Fetched `origin/main` from `47bb2103` to `7771aca6`, then rebased before making any finding fixes.
+- Resolved the only conflict in `internal/session/instance.go` by preserving both upstream DeepSeek fast-exit/prompt guards and the PR's shared ownership-generation watcher.
+- `git range-diff 47bb2103..f0f507eb origin/main..384eeaf7` preserved all four PR commits. The config-lock file removed from the second patch was already present on the new main.
+- Rebased head `384eeaf7` was force-pushed with lease before review work.
 
-## Root cause
+## Findings addressed
 
-- `cmd/agent-deck/launch_cmd.go:124` had no account flag, and the instance
-  construction path near `cmd/agent-deck/launch_cmd.go:441` therefore never
-  copied a selected slot into `Instance.Account`. The existing start-time
-  resolver already consumes that field, so the missing launch wiring was the
-  gap.
-- The top-level command switch in `cmd/agent-deck/main.go:334` had no
-  `accounts` route. Unknown commands continue into TUI startup, which explains
-  the unrelated tmux error seen in the reproduction.
+- Darwin `ps` cancellation/timeouts now remain unreadable and fail closed; only a genuinely exited `ps` with empty output means the PID is gone.
+- Descendant attribution revalidates the exact leader observation used as its walk root (PID, start identity, and UID).
+- `Claim` validates the completed receipt, rejecting missing instance IDs or start identities immediately.
+- Restart receipts record the prepared command actually launched. DeepSeek task validation occurs before spawn stamps, generation changes, or pane termination.
+- Restart generation replacement carries forward every still-owned prior identity, preserving escaped descendants rather than silently dropping ownership.
+- Receipt `Clear` preserves corrupt evidence; only explicit `ForceClear`/abandon discards it.
+- Store construction requires an explicit cross-process lock choice.
+- Config-file/receipt locking now has a bounded 30-second wait for both the in-process mutex and host flock.
+- Ownership CLI treats omitted IDs as usage errors, storage failures as invalid operations, reports post-abandon state, and avoids verb-free `Fprintf` calls.
+- The receipt-race child handshake preserves partial reads and has an effective deadline.
+- Fake-prober fields are mutex-protected; Linux attribution asserts returned members; nil-receipt reap is covered; escaped-tree PPID checks the actual pane; remote ownership is explicitly documented as host-local via a skipped test.
 
-## Fix
+## Revert proofs
 
-- Added `launch --account <slot>` and persist the trimmed value on the new
-  instance before it is saved and started.
-- Added a read-only `accounts [--json]` command. It lists profiles with a
-  configured Claude `config_dir`, expands paths through the existing config
-  resolver, and sorts by slot name for deterministic human and JSON output.
-- Updated top-level help, README documentation, and the bundled agent-deck
-  skill/reference.
+All commands ran in `golang:1.25` containers. Each production guard was restored immediately after the failing run.
 
-## Proof
+- Removed the second-observation leader identity comparison: `TestAttribute_RefusesLeaderReusedBetweenVerificationAndWalk` failed because attribution returned nil error and would accept the stranger's tree.
+- Removed final receipt validation from `Claim`: `TestClaim_RefusesWhatItCannotProve` failed because an empty instance ID produced no error.
+- Restored corrupt-receipt deletion in ordinary `Clear`: `TestStore_ClearPreservesCorruptReceiptForExplicitAbandon` failed because clear returned nil and deleted the evidence.
 
-- PASS: `go test ./cmd/agent-deck -run "TestIssue2045" -count=1 -v`
-- PASS: `go build ./... && go vet ./...`
-- Both commands ran only in `golang:1.25` containers.
-- The full `go test ./cmd/agent-deck -count=1` suite was also attempted in the
-  stock Go container. It is not green there because tmux is absent; existing
-  tmux-dependent tests fail with `Error: tmux not found`, and the two existing
-  40 ms cold-start budgets also exceeded the shared-container timings. The
-  issue-specific tests pass in that same environment.
+## Local verification
 
-## Pull request
+- PASS: `go build ./... && go vet ./...` in `golang:1.25` after marking `/src` as a Git safe directory for VCS stamping.
+- PASS: full `internal/procowner` tests.
+- PASS: targeted ownership, issue-1873, config-lock, DeepSeek, and CLI ownership tests.
+- The stock container's full affected-package attempt additionally exposed only known environment failures: no `tmux`, root bypassing a read-only-directory assertion, and nested test builds rejecting the bind-mounted Git ownership. These are unrelated and are exercised by repository CI's prepared environment.
 
-https://github.com/asheshgoplani/agent-deck/pull/2053
+## Invariant check
 
-# PR #2053 round-2 review results
+- Bounds: receipt `MaxMembers` remains enforced while carrying identities across restart.
+- Ordering: task validation and ownership admission precede all state mutation; identity is rechecked immediately before descendant traversal and again before every signal.
+- Idempotence/CAS: duplicate members are key-deduplicated; generation and leader checks remain under one cross-process lock; attribution cancellation/barrier behavior is unchanged.
+- Fail closed: unreadable probes, lock timeouts, corrupt receipts, and identity changes never authorize a signal or a replacement spawn.
+- Sibling parity: `Start`, `StartWithMessage`, restart fallback, and every respawn-pane branch now feed the actual launched command into ownership; DeepSeek validation covers all three spawn families.
 
-## Finding: launch consumed the next flag as `--account`'s value
+## CI state
 
-### Reproduction
-
-On the pre-fix parent `4ccce635`, I applied only the new regression test and
-ran it in `golang:1.25`. The `launch` table case failed with:
-
-```text
-launch accepted a flag-shaped account value; output:
-    ✓ Launched session: agent-deck
-```
-
-This reproduces the review's exact `launch . --account --no-wait` scenario:
-the command reported success instead of rejecting the missing account name.
-The test also enumerates both session-creation commands with an `--account`
-surface (`add` and `launch`) so the existing sibling guard cannot silently
-diverge again.
-
-### Root cause
-
-`cmd/agent-deck/launch_cmd.go:167` proceeded to argument reordering and Go flag
-parsing without calling the shared `checkFlagValueNotFlag` guard. Go's flag
-parser therefore bound the registered `--no-wait` token as the string value of
-`--account`; account resolution then treated that unknown slot as a fallback.
-The sibling `add` command already invoked the guard on original argv at
-`cmd/agent-deck/main.go:1445`.
-
-### Fix
-
-`cmd/agent-deck/launch_cmd.go:167` now invokes `checkFlagValueNotFlag` before
-argument reordering, parsing, account fallback, state writes, or tmux launch.
-The shared guard recognizes that the following token is another flag from the
-same launch `FlagSet` and exits with an actionable error. The CLI reference now
-documents the required explicit account name and the `--account=<name>` escape
-hatch for an intentional dash-prefixed name.
-
-### Test and evidence
-
-- RED on `4ccce635`: `TestIssue2053AccountGuardCoversSessionCreationCommands/launch`
-  reported that launch accepted the malformed argv and launched a session.
-- GREEN on the fixed branch: both the `add` and `launch` enumeration cases
-  reject the malformed argv, name the swallowed flag, and prove that neither
-  state nor tmux side effects occurred.
-- PASS: `go test ./cmd/agent-deck -run 'TestIssue2053|TestIssue1923|TestIssue1928' -count=1 -v`
-- PASS: `go build ./... && go vet ./...`
-
-All Go commands above ran only in a `golang:1.25` container.
-
-# PR #2053 round-3 verification results
-
-## Blocking finding: launch account persistence had no effective test
-
-### Reproduction
-
-The verifier selectively removed the assignment at
-`cmd/agent-deck/launch_cmd.go:452-454` while retaining flag registration and
-parsing. The old help-only test remained green, proving it did not cover the
-user-visible persistence behavior.
-
-### Root cause
-
-`cmd/agent-deck/issue2045_accounts_cli_test.go:12` exercised only `launch
---help`; it never entered the creation path or inspected the saved
-`Instance.Account`. The production assignment itself is at
-`cmd/agent-deck/launch_cmd.go:452-454`.
-
-### Fix
-
-`TestIssue2045LaunchPersistsNamedAccountSlot` now configures the `work` Claude
-account, drives the real `launch` command through creation, start, and save with
-an isolated fake tmux executable, opens the isolated profile storage, and
-asserts that exactly one saved instance has `Account == "work"`.
-
-The test also contains the requested focused `RemoteSession` skip marker.
-`launch` creates a local session and has no remote target argument or
-RemoteSession dispatch branch, so remote runtime behavior is not applicable.
-
-### Revert-proof
-
-All commands below ran in `golang:1.25` containers with
-`GOFLAGS=-buildvcs=false` for the bind-mounted linked worktree.
-
-- GREEN with the production assignment present:
-  `TestIssue2045LaunchPersistsNamedAccountSlot` exited 0.
-- RED after replacing only `launch_cmd.go:452-454` with `_ = account`:
-  `issue2045_accounts_cli_test.go:55: persisted launch account = "", want work`.
-- The assignment was then restored before the final verification.
-- Final combined container command passed:
-  `go test ./cmd/agent-deck -run "TestIssue2045|TestIssue2053" -count=1 -v && go build ./... && go vet ./...`.
-
-### Preserved invariant
-
-The change is test-only and does not alter launch ordering, persistence, or
-concurrency behavior. The test reaches the existing targeted
-`InsertSessionAndVerify` path, so it verifies account persistence without
-replacing the bounded/concurrency-safe launch save mechanism. The existing
-missing-value test continues to prove fail-closed ordering: malformed
-`--account --no-wait` input is rejected before state or tmux side effects.
+Pending the final signed commit and push; this section will be updated with the exact head and completed check result.

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -91,6 +91,8 @@ func handleSession(profile string, args []string) {
 		handleSessionOutput(profile, args[1:])
 	case "children":
 		handleSessionChildren(profile, args[1:])
+	case "ownership":
+		handleSessionOwnership(profile, args[1:])
 	case "search":
 		handleSessionSearch(profile, args[1:])
 	case "help", "--help", "-h":
@@ -130,6 +132,7 @@ func printSessionHelp() {
 	fmt.Println("  approve <id> [choice]   Resolve a visible Codex approval prompt")
 	fmt.Println("  output <id>             Get the last response from a session")
 	fmt.Println("  children [id]           List sub-sessions with status + last completion")
+	fmt.Println("  ownership <cmd> <id>    Inspect/reconcile the processes a session owns (#1873)")
 	fmt.Println("  search <query>          Search message content across Claude sessions")
 	fmt.Println("  set-parent <id> <parent>  Link session as sub-session of parent")
 	fmt.Println("  unset-parent <id>       Remove sub-session link")

--- a/cmd/agent-deck/session_ownership_cmd.go
+++ b/cmd/agent-deck/session_ownership_cmd.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/procowner"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// `agent-deck session ownership` — the recovery surface for #1873.
+//
+// When a restart is refused because the session still owns a process tree that
+// escaped its pane, the operator needs three things and nothing else: see what
+// is claimed, reap what is provably ours, and — only as a deliberate act —
+// discard a claim that can no longer be verified. Everything here goes through
+// the receipt; none of it matches on names, paths or command lines.
+
+func handleSessionOwnership(profile string, args []string) {
+	if len(args) == 0 {
+		printSessionOwnershipHelp()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "inspect", "status", "show":
+		handleSessionOwnershipInspect(profile, args[1:])
+	case "reconcile":
+		handleSessionOwnershipReconcile(profile, args[1:])
+	case "abandon":
+		handleSessionOwnershipAbandon(profile, args[1:])
+	case "help", "--help", "-h":
+		printSessionOwnershipHelp()
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown session ownership command: %s\n", args[0])
+		printSessionOwnershipHelp()
+		os.Exit(1)
+	}
+}
+
+func printSessionOwnershipHelp() {
+	fmt.Println("Usage: agent-deck session ownership <command> <id|title> [options]")
+	fmt.Println()
+	fmt.Println("Inspect and recover the processes a session owns (#1873).")
+	fmt.Println()
+	fmt.Println("Commands:")
+	fmt.Println("  inspect <id>     Show the ownership receipt and what it verifies to (read-only)")
+	fmt.Println("  reconcile <id>   Terminate every process the receipt owns, verify, and clear it")
+	fmt.Println("  abandon <id>     Discard an unverifiable receipt WITHOUT signalling anything")
+	fmt.Println()
+	fmt.Println("A session records, at spawn, the pid of its pane process bound to that")
+	fmt.Println("process's start identity. Only an exact match of both may be signalled;")
+	fmt.Println("anything else is reported and left alone.")
+}
+
+// resolveOwnershipTarget loads and resolves the session named on the command
+// line, exiting with the shared CLI codes when it cannot.
+func resolveOwnershipTarget(profile, identifier string, out *CLIOutput) *session.Instance {
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	inst, errMsg, errCode := ResolveSession(identifier, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+	}
+	return inst
+}
+
+func handleSessionOwnershipInspect(profile string, args []string) {
+	fs := flag.NewFlagSet("session ownership inspect", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session ownership inspect <id|title> [--json]")
+		fmt.Println()
+		fmt.Println("Show what this session owns. Read-only: signals nothing, changes nothing.")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	out := NewCLIOutput(*jsonOutput, false)
+	inst := resolveOwnershipTarget(profile, fs.Arg(0), out)
+
+	status := inst.OwnershipStatus()
+	payload := ownershipPayload(status)
+	out.Print(renderOwnershipStatus(inst, status), payload)
+	if !status.Admissible() {
+		// A non-zero exit lets a script tell "this session is blocked" from
+		// "this session is fine" without parsing prose.
+		os.Exit(3)
+	}
+}
+
+func handleSessionOwnershipReconcile(profile string, args []string) {
+	fs := flag.NewFlagSet("session ownership reconcile", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session ownership reconcile <id|title> [--json]")
+		fmt.Println()
+		fmt.Println("Terminate every process this session's receipt owns — identity-checked,")
+		fmt.Println("SIGTERM then SIGKILL, death verified — and clear the receipt.")
+		fmt.Println()
+		fmt.Println("This includes a live pane process if the session is still running: it")
+		fmt.Println("reconciles the SESSION's ownership, not just its strays.")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	out := NewCLIOutput(*jsonOutput, false)
+	inst := resolveOwnershipTarget(profile, fs.Arg(0), out)
+
+	report, err := inst.ReconcileOwnership()
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to reconcile ownership: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	payload := map[string]interface{}{
+		"instance_id": inst.ID,
+		"verdict":     string(report.Verdict),
+		"reason":      report.Reason,
+		"signalled":   report.Signalled(),
+		"outcomes":    reapOutcomePayload(report),
+	}
+	if report.Verdict != procowner.VerdictClear {
+		out.ErrorWithData(
+			fmt.Sprintf("ownership could not be fully reconciled: %s", report.Reason),
+			ErrCodeInvalidOperation, payload)
+		if !*jsonOutput {
+			fmt.Fprintln(os.Stderr, report.Describe())
+			fmt.Fprintf(os.Stderr,
+				"\nNothing unverified was signalled. The receipt is kept so it stays visible;\n"+
+					"`agent-deck session ownership abandon %s` discards it without killing anything.\n",
+				inst.ID)
+		}
+		os.Exit(3)
+	}
+	out.Success(fmt.Sprintf("ownership reconciled: %s", report.Reason), payload)
+	if !*jsonOutput && report.Signalled() > 0 {
+		fmt.Println(report.Describe())
+	}
+}
+
+func handleSessionOwnershipAbandon(profile string, args []string) {
+	fs := flag.NewFlagSet("session ownership abandon", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	yes := fs.Bool("yes", false, "Confirm: stop managing whatever the receipt named")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session ownership abandon <id|title> --yes [--json]")
+		fmt.Println()
+		fmt.Println("Discard an ownership receipt WITHOUT signalling anything.")
+		fmt.Println()
+		fmt.Println("Use this when a receipt can no longer be verified — an unreadable /proc")
+		fmt.Println("entry, a truncated receipt — and the session must be startable again.")
+		fmt.Println("Any process that receipt named keeps running and agent-deck stops")
+		fmt.Println("managing it; find it with the pids from `ownership inspect` first.")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	out := NewCLIOutput(*jsonOutput, false)
+	inst := resolveOwnershipTarget(profile, fs.Arg(0), out)
+
+	status := inst.OwnershipStatus()
+	if !*yes {
+		out.Error("refusing to abandon an ownership receipt without --yes: "+
+			"any process it named will keep running unmanaged", ErrCodeInvalidOperation)
+		if !*jsonOutput {
+			fmt.Fprintln(os.Stderr, renderOwnershipStatus(inst, status))
+		}
+		os.Exit(1)
+	}
+	if err := inst.AbandonOwnership(); err != nil {
+		out.Error(fmt.Sprintf("failed to abandon ownership receipt: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	out.Success("ownership receipt discarded; nothing was signalled", ownershipPayload(status))
+}
+
+func renderOwnershipStatus(inst *session.Instance, status session.OwnershipStatus) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Session:  %s (%s)\n", inst.Title, inst.ID)
+	switch {
+	case status.LoadErr != nil:
+		fmt.Fprintf(&b, "Receipt:  UNREADABLE — %v\n", status.LoadErr)
+		fmt.Fprintf(&b, "Verdict:  unknown (nothing will be signalled)\n")
+		return b.String()
+	case status.Receipt == nil:
+		fmt.Fprintf(&b, "Receipt:  none — this session owns no recorded processes\n")
+		return b.String()
+	}
+	r := status.Receipt
+	fmt.Fprintf(&b, "Receipt:  generation %d, state %s, provider %s\n", r.Generation, r.State, r.Provider)
+	fmt.Fprintf(&b, "Leader:   %s\n", r.Leader)
+	fmt.Fprintf(&b, "Members:  %d recorded\n", len(r.Members))
+	fmt.Fprintf(&b, "Pane:     %s\n", paneAttachmentLabel(status.PaneAttached))
+	fmt.Fprintf(&b, "Verdict:  %s\n", status.Report.Describe())
+	if len(status.Survivors) > 0 {
+		fmt.Fprintf(&b, "\n%d owned process(es) are alive outside this session's pane:\n", len(status.Survivors))
+		for _, m := range status.Survivors {
+			fmt.Fprintf(&b, "  %s\n", m)
+		}
+		fmt.Fprintf(&b, "\nA start or restart is refused until these are reaped:\n")
+		fmt.Fprintf(&b, "  agent-deck session ownership reconcile %s\n", inst.ID)
+	}
+	return b.String()
+}
+
+func paneAttachmentLabel(attached bool) string {
+	if attached {
+		return "the live pane runs this receipt's leader"
+	}
+	return "no live pane accounts for this receipt"
+}
+
+func ownershipPayload(status session.OwnershipStatus) map[string]interface{} {
+	payload := map[string]interface{}{
+		"instance_id":   status.InstanceID,
+		"admissible":    status.Admissible(),
+		"reason":        status.Reason(),
+		"pane_attached": status.PaneAttached,
+		"survivors":     memberPayload(status.Survivors),
+	}
+	if status.LoadErr != nil {
+		payload["receipt_error"] = status.LoadErr.Error()
+	}
+	if status.Receipt != nil {
+		payload["generation"] = status.Receipt.Generation
+		payload["state"] = status.Receipt.State
+		payload["provider"] = status.Receipt.Provider
+		payload["leader"] = memberPayload([]procowner.Member{status.Receipt.Leader})[0]
+		payload["members"] = memberPayload(status.Receipt.Members)
+		payload["verdict"] = string(status.Report.Verdict)
+	}
+	return payload
+}
+
+func memberPayload(members []procowner.Member) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(members))
+	for _, m := range members {
+		out = append(out, map[string]interface{}{
+			"pid":      m.PID,
+			"start_id": m.StartID,
+			"pgid":     m.PGID,
+			"uid":      m.UID,
+			"role":     m.Role,
+		})
+	}
+	return out
+}
+
+func reapOutcomePayload(report procowner.ReapReport) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(report.Outcomes))
+	for _, o := range report.Outcomes {
+		out = append(out, map[string]interface{}{
+			"pid":      o.Member.PID,
+			"start_id": o.Member.StartID,
+			"outcome":  o.Outcome,
+			"detail":   o.Detail,
+		})
+	}
+	return out
+}

--- a/cmd/agent-deck/session_ownership_cmd.go
+++ b/cmd/agent-deck/session_ownership_cmd.go
@@ -47,6 +47,7 @@ func printSessionOwnershipHelp() {
 	fmt.Println("Commands:")
 	fmt.Println("  inspect <id>     Show the ownership receipt and what it verifies to (read-only)")
 	fmt.Println("  reconcile <id>   Terminate every process the receipt owns, verify, and clear it")
+	fmt.Println("                   (--yes required only when the session's pane is still running)")
 	fmt.Println("  abandon <id>     Discard an unverifiable receipt WITHOUT signalling anything")
 	fmt.Println()
 	fmt.Println("A session records, at spawn, the pid of its pane process bound to that")
@@ -100,20 +101,39 @@ func handleSessionOwnershipInspect(profile string, args []string) {
 func handleSessionOwnershipReconcile(profile string, args []string) {
 	fs := flag.NewFlagSet("session ownership reconcile", flag.ExitOnError)
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	yes := fs.Bool("yes", false, "Confirm reconciling a session whose pane is still running")
 	fs.Usage = func() {
-		fmt.Println("Usage: agent-deck session ownership reconcile <id|title> [--json]")
+		fmt.Println("Usage: agent-deck session ownership reconcile <id|title> [--yes] [--json]")
 		fmt.Println()
 		fmt.Println("Terminate every process this session's receipt owns — identity-checked,")
 		fmt.Println("SIGTERM then SIGKILL, death verified — and clear the receipt.")
 		fmt.Println()
-		fmt.Println("This includes a live pane process if the session is still running: it")
-		fmt.Println("reconciles the SESSION's ownership, not just its strays.")
+		fmt.Println("Reaping an escaped tree needs no confirmation: its pane is already gone,")
+		fmt.Println("which is why the restart was refused. --yes is required only when the")
+		fmt.Println("receipt's leader is still the live pane process, because reconciling then")
+		fmt.Println("stops the running session rather than cleaning up after a dead one.")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
 	}
 	out := NewCLIOutput(*jsonOutput, false)
 	inst := resolveOwnershipTarget(profile, fs.Arg(0), out)
+
+	// Confirmation is asked exactly where the operator might not realise what
+	// they are ending. The recovery flow the refusal message points at — an
+	// escaped tree whose pane died — is not that case, and making it demand a
+	// flag would train people to pass --yes reflexively, which is how a
+	// confirmation gate stops being one.
+	if status := inst.OwnershipStatus(); status.PaneAttached && !*yes {
+		out.Error(fmt.Sprintf(
+			"session %s is still running: reconciling would stop its live pane process. "+
+				"Re-run with --yes, or use `agent-deck session stop %s`", inst.Title, inst.ID),
+			ErrCodeInvalidOperation)
+		if !*jsonOutput {
+			fmt.Fprintln(os.Stderr, renderOwnershipStatus(inst, status))
+		}
+		os.Exit(1)
+	}
 
 	report, err := inst.ReconcileOwnership()
 	if err != nil {

--- a/cmd/agent-deck/session_ownership_cmd.go
+++ b/cmd/agent-deck/session_ownership_cmd.go
@@ -58,9 +58,13 @@ func printSessionOwnershipHelp() {
 // resolveOwnershipTarget loads and resolves the session named on the command
 // line, exiting with the shared CLI codes when it cannot.
 func resolveOwnershipTarget(profile, identifier string, out *CLIOutput) *session.Instance {
+	if strings.TrimSpace(identifier) == "" {
+		out.Error("session identifier is required", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 	_, instances, _, err := loadSessionData(profile)
 	if err != nil {
-		out.Error(err.Error(), ErrCodeNotFound)
+		out.Error(err.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 	inst, errMsg, errCode := ResolveSession(identifier, instances)
@@ -199,7 +203,7 @@ func handleSessionOwnershipAbandon(profile string, args []string) {
 		out.Error(fmt.Sprintf("failed to abandon ownership receipt: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
-	out.Success("ownership receipt discarded; nothing was signalled", ownershipPayload(status))
+	out.Success("ownership receipt discarded; nothing was signalled", ownershipPayload(inst.OwnershipStatus()))
 }
 
 func renderOwnershipStatus(inst *session.Instance, status session.OwnershipStatus) string {
@@ -208,10 +212,10 @@ func renderOwnershipStatus(inst *session.Instance, status session.OwnershipStatu
 	switch {
 	case status.LoadErr != nil:
 		fmt.Fprintf(&b, "Receipt:  UNREADABLE — %v\n", status.LoadErr)
-		fmt.Fprintf(&b, "Verdict:  unknown (nothing will be signalled)\n")
+		b.WriteString("Verdict:  unknown (nothing will be signalled)\n")
 		return b.String()
 	case status.Receipt == nil:
-		fmt.Fprintf(&b, "Receipt:  none — this session owns no recorded processes\n")
+		b.WriteString("Receipt:  none — this session owns no recorded processes\n")
 		return b.String()
 	}
 	r := status.Receipt

--- a/cmd/agent-deck/session_ownership_cmd_test.go
+++ b/cmd/agent-deck/session_ownership_cmd_test.go
@@ -112,3 +112,26 @@ func TestReapOutcomePayload(t *testing.T) {
 	assert.Equal(t, 4242, payload[0]["pid"])
 	assert.Equal(t, procowner.OutcomeReaped, payload[0]["outcome"])
 }
+
+// The confirmation gate on reconcile is scoped to the one case where it is a
+// confirmation and not a speed bump: the receipt's leader is the live pane, so
+// reconciling stops a running session. The escaped-tree case — the one the
+// refusal message tells the operator to run — has no live pane by definition,
+// and requiring a flag there would train people to pass --yes without reading.
+func TestReconcileConfirmation_ScopedToALivePane(t *testing.T) {
+	live := session.OwnershipStatus{
+		InstanceID:   "inst-live",
+		PaneAttached: true,
+		Receipt:      &procowner.Receipt{Version: procowner.ReceiptVersion, InstanceID: "inst-live"},
+	}
+	escaped := session.OwnershipStatus{
+		InstanceID:   "inst-escaped",
+		PaneAttached: false,
+		Survivors:    []procowner.Member{{PID: 4242, StartID: "5000"}},
+		Receipt:      &procowner.Receipt{Version: procowner.ReceiptVersion, InstanceID: "inst-escaped"},
+	}
+
+	assert.True(t, live.PaneAttached, "a live pane must require --yes")
+	assert.False(t, escaped.PaneAttached, "an escaped tree must not")
+	assert.False(t, escaped.Admissible(), "and it must still block a restart until reconciled")
+}

--- a/cmd/agent-deck/session_ownership_cmd_test.go
+++ b/cmd/agent-deck/session_ownership_cmd_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
+func TestSessionOwnership_RemoteSessionRunsOnOwningHost(t *testing.T) {
+	t.Skip("ownership receipts are host-local; remote recovery must execute on the remote agent, not inspect controller PIDs")
+}
+
 // The recovery surface is the only thing an operator sees when a restart is
 // refused, so it has to name the processes and the exact command that resolves
 // them. A verdict with no pids is a dead end.

--- a/cmd/agent-deck/session_ownership_cmd_test.go
+++ b/cmd/agent-deck/session_ownership_cmd_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asheshgoplani/agent-deck/internal/procowner"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// The recovery surface is the only thing an operator sees when a restart is
+// refused, so it has to name the processes and the exact command that resolves
+// them. A verdict with no pids is a dead end.
+
+func TestRenderOwnershipStatus_NamesSurvivorsAndTheRecoveryCommand(t *testing.T) {
+	inst := session.NewInstance("owner-render", t.TempDir())
+	survivor := procowner.Member{PID: 4242, StartID: "99887766", UID: 1000, Role: procowner.RoleDescendant}
+	status := session.OwnershipStatus{
+		InstanceID: inst.ID,
+		Receipt: &procowner.Receipt{
+			Version:    procowner.ReceiptVersion,
+			InstanceID: inst.ID,
+			Generation: 2,
+			State:      procowner.StateLive,
+			Provider:   procowner.ProviderLinuxProc,
+			BootID:     "boot",
+			Leader:     procowner.Member{PID: 4240, StartID: "99887700", UID: 1000, Role: procowner.RoleLeader},
+			Members:    []procowner.Member{survivor},
+		},
+		Report: procowner.Report{
+			Verdict: procowner.VerdictOwned,
+			Reason:  "1 owned process(es) are still alive",
+			Members: []procowner.MemberStatus{{Member: survivor, State: procowner.StateOwned}},
+		},
+		Survivors: []procowner.Member{survivor},
+	}
+
+	out := renderOwnershipStatus(inst, status)
+	assert.Contains(t, out, "generation 2")
+	assert.Contains(t, out, "pid=4242")
+	assert.Contains(t, out, "no live pane accounts for this receipt")
+	assert.Contains(t, out, "agent-deck session ownership reconcile "+inst.ID)
+	assert.False(t, status.Admissible())
+}
+
+func TestRenderOwnershipStatus_UnreadableReceiptSaysSo(t *testing.T) {
+	inst := session.NewInstance("owner-render-corrupt", t.TempDir())
+	status := session.OwnershipStatus{
+		InstanceID: inst.ID,
+		LoadErr:    errors.New("ownership receipt is unreadable or incomplete: unexpected end of JSON input"),
+	}
+
+	out := renderOwnershipStatus(inst, status)
+	assert.Contains(t, out, "UNREADABLE")
+	assert.Contains(t, out, "nothing will be signalled")
+	assert.False(t, status.Admissible(), "an unreadable receipt is never admissible")
+}
+
+func TestRenderOwnershipStatus_NoReceipt(t *testing.T) {
+	inst := session.NewInstance("owner-render-none", t.TempDir())
+	status := session.OwnershipStatus{InstanceID: inst.ID}
+
+	out := renderOwnershipStatus(inst, status)
+	assert.Contains(t, out, "owns no recorded processes")
+	assert.True(t, status.Admissible())
+	assert.NotContains(t, strings.ToLower(out), "reconcile")
+}
+
+func TestOwnershipPayload_CarriesTheMachineReadableFacts(t *testing.T) {
+	leader := procowner.Member{PID: 4240, StartID: "99887700", UID: 1000, Role: procowner.RoleLeader}
+	status := session.OwnershipStatus{
+		InstanceID: "inst-json",
+		Receipt: &procowner.Receipt{
+			Version:    procowner.ReceiptVersion,
+			InstanceID: "inst-json",
+			Generation: 7,
+			State:      procowner.StateLive,
+			Provider:   procowner.ProviderLinuxProc,
+			BootID:     "boot",
+			Leader:     leader,
+		},
+		Report: procowner.Report{Verdict: procowner.VerdictClear, Reason: "every recorded process is gone"},
+	}
+
+	payload := ownershipPayload(status)
+	assert.Equal(t, "inst-json", payload["instance_id"])
+	assert.Equal(t, uint64(7), payload["generation"])
+	assert.Equal(t, string(procowner.VerdictClear), payload["verdict"])
+	assert.Equal(t, true, payload["admissible"])
+	leaderPayload, ok := payload["leader"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 4240, leaderPayload["pid"])
+	assert.Equal(t, "99887700", leaderPayload["start_id"])
+}
+
+func TestReapOutcomePayload(t *testing.T) {
+	report := procowner.ReapReport{
+		Verdict: procowner.VerdictClear,
+		Reason:  "every recorded process is gone",
+		Outcomes: []procowner.ReapOutcome{{
+			Member:  procowner.Member{PID: 4242, StartID: "99887766"},
+			Outcome: procowner.OutcomeReaped,
+			Detail:  "exited after terminated",
+		}},
+	}
+	payload := reapOutcomePayload(report)
+	require.Len(t, payload, 1)
+	assert.Equal(t, 4242, payload[0]["pid"])
+	assert.Equal(t, procowner.OutcomeReaped, payload[0]["outcome"])
+}

--- a/internal/procowner/claim.go
+++ b/internal/procowner/claim.go
@@ -60,7 +60,7 @@ func Claim(p Prober, in ClaimInput) (*Receipt, error) {
 		now = time.Now
 	}
 	stamp := now().Unix()
-	return &Receipt{
+	r := &Receipt{
 		Version:    ReceiptVersion,
 		InstanceID: in.InstanceID,
 		Generation: in.Generation,
@@ -81,7 +81,11 @@ func Claim(p Prober, in ClaimInput) (*Receipt, error) {
 			Role:    RoleLeader,
 			SeenAt:  stamp,
 		},
-	}, nil
+	}
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
 // Attribute adds the leader's live descendants to the receipt, each with its
@@ -121,6 +125,9 @@ func Attribute(p Prober, r *Receipt, now func() time.Time) ([]Member, error) {
 	leaderInfo, err := p.Inspect(r.Leader.PID)
 	if err != nil {
 		return nil, err
+	}
+	if leaderInfo.PID != r.Leader.PID || leaderInfo.StartID != r.Leader.StartID || leaderInfo.UID != r.Leader.UID {
+		return nil, fmt.Errorf("%w: leader pid %d changed identity during attribution", ErrNoProcess, r.Leader.PID)
 	}
 	descendants, err := p.Descendants(leaderInfo)
 	if err != nil {

--- a/internal/procowner/claim.go
+++ b/internal/procowner/claim.go
@@ -1,0 +1,198 @@
+package procowner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// MaxMembers caps how many identities one receipt records.
+//
+// A tool that forks short-lived helpers (a shell loop, an MCP child per
+// request) produces a new pid every fraction of a second, and every one of them
+// is a genuine descendant while it lives. Without a ceiling the receipt would
+// grow for as long as the attribution window lasts, and a receipt that cannot
+// be written is a receipt that cannot be verified. The cap fails in the safe
+// direction: past it we record fewer processes, never more, so the worst case
+// is a process we decline to claim — and therefore never signal.
+const MaxMembers = 512
+
+// ClaimInput is everything a spawn knows about what it just launched.
+type ClaimInput struct {
+	InstanceID string
+	Generation uint64
+	// PanePID is the pane's initial process: the leader of the tree this spawn
+	// owns.
+	PanePID    int
+	TmuxName   string
+	TmuxSocket string
+	Command    string
+	Now        func() time.Time
+}
+
+// Claim builds the spawn-time receipt for a freshly launched pane.
+//
+// It runs at spawn, in the caller, before anything can have died — that is the
+// whole difference between a receipt and a guess. If the leader's identity
+// cannot be read here, no receipt is written at all: agent-deck records no
+// ownership rather than a claim it could not substantiate, and consequently
+// will never signal on the strength of one.
+func Claim(p Prober, in ClaimInput) (*Receipt, error) {
+	if in.PanePID <= 1 {
+		return nil, fmt.Errorf("%w: pane pid %d", ErrNoProcess, in.PanePID)
+	}
+	if in.PanePID == os.Getpid() {
+		// Defensive: a receipt naming agent-deck itself would authorise
+		// agent-deck to kill agent-deck.
+		return nil, fmt.Errorf("%w: pane pid %d is this process", ErrUnreadable, in.PanePID)
+	}
+	boot, err := p.BootID()
+	if err != nil {
+		return nil, err
+	}
+	info, err := p.Inspect(in.PanePID)
+	if err != nil {
+		return nil, err
+	}
+	now := in.Now
+	if now == nil {
+		now = time.Now
+	}
+	stamp := now().Unix()
+	return &Receipt{
+		Version:    ReceiptVersion,
+		InstanceID: in.InstanceID,
+		Generation: in.Generation,
+		State:      StateLive,
+		Provider:   p.Name(),
+		BootID:     boot,
+		TmuxName:   in.TmuxName,
+		TmuxSocket: in.TmuxSocket,
+		Command:    in.Command,
+		CreatedAt:  stamp,
+		UpdatedAt:  stamp,
+		Leader: Member{
+			PID:     info.PID,
+			StartID: info.StartID,
+			PGID:    info.PGID,
+			UID:     info.UID,
+			Comm:    info.Comm,
+			Role:    RoleLeader,
+			SeenAt:  stamp,
+		},
+	}, nil
+}
+
+// Attribute adds the leader's live descendants to the receipt, each with its
+// own start identity.
+//
+// It is the only way a member ever enters a receipt, and it refuses to run
+// unless the LEADER still verifies as owned. That is what makes the result
+// ownership rather than a process-table guess: every member recorded here was,
+// at the moment of a single stat read, a live descendant of a process this
+// spawn is proven to own.
+//
+// Two further narrowings, both cheap and both one-directional (they can only
+// reject a candidate, never admit one):
+//
+//   - a descendant cannot have started before its ancestor, so a member whose
+//     start identity predates the leader's is dropped;
+//   - agent-deck's own pid is never recorded.
+//
+// Returns the members added. The caller decides whether to persist; nothing
+// here writes to disk.
+func Attribute(p Prober, r *Receipt, now func() time.Time) ([]Member, error) {
+	if r == nil {
+		return nil, errors.New("procowner: nil receipt")
+	}
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	if p.Name() != r.Provider {
+		return nil, fmt.Errorf("provider mismatch: receipt %q, host %q", r.Provider, p.Name())
+	}
+	leaderStatus := VerifyMember(p, r.Leader)
+	if leaderStatus.State != StateOwned {
+		// The leader is gone, reused or unreadable. Anything reachable from
+		// that pid now is not attributable to this spawn.
+		return nil, fmt.Errorf("leader is %s: %s", leaderStatus.State, leaderStatus.Detail)
+	}
+	leaderInfo, err := p.Inspect(r.Leader.PID)
+	if err != nil {
+		return nil, err
+	}
+	descendants, err := p.Descendants(leaderInfo)
+	if err != nil {
+		return nil, err
+	}
+	if now == nil {
+		now = time.Now
+	}
+	stamp := now().Unix()
+	self := os.Getpid()
+
+	var added []Member
+	for _, info := range descendants {
+		if len(r.Members) >= MaxMembers {
+			break
+		}
+		if info.PID <= 1 || info.PID == self {
+			continue
+		}
+		notBefore, cmpErr := startNotBefore(p, info.StartID, r.Leader.StartID)
+		if cmpErr != nil || !notBefore {
+			// Either the start identities are not comparable, or this process
+			// started before the leader did and therefore cannot be its
+			// descendant. Both mean: do not claim it.
+			continue
+		}
+		m := Member{
+			PID:     info.PID,
+			StartID: info.StartID,
+			PGID:    info.PGID,
+			UID:     info.UID,
+			Comm:    info.Comm,
+			Role:    RoleDescendant,
+			SeenAt:  stamp,
+		}
+		if r.HasMember(m) {
+			continue
+		}
+		r.Members = append(r.Members, m)
+		added = append(added, m)
+	}
+	if len(added) > 0 {
+		r.UpdatedAt = stamp
+	}
+	return added, nil
+}
+
+// startNotBefore reports whether start identity a is no earlier than b.
+func startNotBefore(p Prober, a, b string) (bool, error) {
+	cmp, err := CompareStart(p, a, b)
+	if err != nil {
+		return false, err
+	}
+	return cmp >= 0, nil
+}
+
+// StartComparer is implemented by providers whose start identities are ordered.
+// Ordering is what lets Attribute reject a "descendant" that started before its
+// ancestor.
+type StartComparer interface {
+	// CompareStart returns -1, 0 or 1, or an error when the identities cannot
+	// be compared.
+	CompareStart(a, b string) (int, error)
+}
+
+// CompareStart compares two start identities using the provider's own ordering.
+// A provider that cannot order its identities makes every comparison an error,
+// which Attribute treats as "do not record" rather than "record anyway".
+func CompareStart(p Prober, a, b string) (int, error) {
+	comparer, ok := p.(StartComparer)
+	if !ok {
+		return 0, fmt.Errorf("%w: provider %q cannot order start identities", ErrUnsupported, p.Name())
+	}
+	return comparer.CompareStart(a, b)
+}

--- a/internal/procowner/fake_prober_test.go
+++ b/internal/procowner/fake_prober_test.go
@@ -37,9 +37,15 @@ func newFakeProber() *fakeProber {
 	}
 }
 
-func (f *fakeProber) Name() string { return f.name }
+func (f *fakeProber) Name() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.name
+}
 
 func (f *fakeProber) BootID() (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.bootErr != nil {
 		return "", f.bootErr
 	}
@@ -70,8 +76,11 @@ func (f *fakeProber) setErr(pid int, err error) {
 }
 
 func (f *fakeProber) Inspect(pid int) (ProcInfo, error) {
-	if f.onInspect != nil {
-		f.onInspect(pid)
+	f.mu.Lock()
+	onInspect := f.onInspect
+	f.mu.Unlock()
+	if onInspect != nil {
+		onInspect(pid)
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -87,11 +96,11 @@ func (f *fakeProber) Inspect(pid int) (ProcInfo, error) {
 }
 
 func (f *fakeProber) Descendants(root ProcInfo) ([]ProcInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.descErr != nil {
 		return nil, f.descErr
 	}
-	f.mu.Lock()
-	defer f.mu.Unlock()
 	var out []ProcInfo
 	queue := []int{root.PID}
 	seen := map[int]bool{root.PID: true}

--- a/internal/procowner/fake_prober_test.go
+++ b/internal/procowner/fake_prober_test.go
@@ -1,0 +1,207 @@
+package procowner
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"syscall"
+)
+
+// fakeProber is a scriptable process table. Every failure shape this package
+// has to fail closed on — a reused pid, an unreadable entry, a uid change, a
+// process that exits between the check and the signal — is a two-line setup
+// here, which is the point: none of them can be built reliably by spawning real
+// processes and hoping.
+type fakeProber struct {
+	mu       sync.Mutex
+	name     string
+	boot     string
+	bootErr  error
+	procs    map[int]ProcInfo
+	errs     map[int]error
+	children map[int][]int
+	descErr  error
+	// onInspect fires before each Inspect, so a test can mutate the table
+	// mid-verification (pid reuse racing a signal).
+	onInspect func(pid int)
+	inspects  int
+}
+
+func newFakeProber() *fakeProber {
+	return &fakeProber{
+		name:     ProviderLinuxProc,
+		boot:     "boot-1",
+		procs:    map[int]ProcInfo{},
+		errs:     map[int]error{},
+		children: map[int][]int{},
+	}
+}
+
+func (f *fakeProber) Name() string { return f.name }
+
+func (f *fakeProber) BootID() (string, error) {
+	if f.bootErr != nil {
+		return "", f.bootErr
+	}
+	return f.boot, nil
+}
+
+func (f *fakeProber) add(pid, ppid int, start string, uid int) ProcInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	info := ProcInfo{PID: pid, PPID: ppid, PGID: pid, UID: uid, StartID: start, Comm: "fake"}
+	f.procs[pid] = info
+	if ppid > 0 {
+		f.children[ppid] = append(f.children[ppid], pid)
+	}
+	return info
+}
+
+func (f *fakeProber) remove(pid int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.procs, pid)
+}
+
+func (f *fakeProber) setErr(pid int, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errs[pid] = err
+}
+
+func (f *fakeProber) Inspect(pid int) (ProcInfo, error) {
+	if f.onInspect != nil {
+		f.onInspect(pid)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inspects++
+	if err, ok := f.errs[pid]; ok {
+		return ProcInfo{}, err
+	}
+	info, ok := f.procs[pid]
+	if !ok {
+		return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
+	}
+	return info, nil
+}
+
+func (f *fakeProber) Descendants(root ProcInfo) ([]ProcInfo, error) {
+	if f.descErr != nil {
+		return nil, f.descErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []ProcInfo
+	queue := []int{root.PID}
+	seen := map[int]bool{root.PID: true}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, child := range f.children[parent] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			if info, ok := f.procs[child]; ok {
+				out = append(out, info)
+				queue = append(queue, child)
+			}
+		}
+	}
+	return out, nil
+}
+
+// CompareStart orders the numeric start identities the fake hands out.
+func (f *fakeProber) CompareStart(a, b string) (int, error) {
+	av, err := strconv.ParseUint(a, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q", ErrUnreadable, a)
+	}
+	bv, err := strconv.ParseUint(b, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %q", ErrUnreadable, b)
+	}
+	switch {
+	case av < bv:
+		return -1, nil
+	case av > bv:
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}
+
+// recordingSignaler records every signal it is asked to deliver and, by
+// default, kills the target in the fake table. Tests assert on `sent` — what
+// was signalled matters more than what died.
+type recordingSignaler struct {
+	mu     sync.Mutex
+	sent   []signalCall
+	err    map[int]error
+	onSend func(pid int, sig syscall.Signal)
+}
+
+type signalCall struct {
+	PID int
+	Sig syscall.Signal
+}
+
+func newRecordingSignaler() *recordingSignaler {
+	return &recordingSignaler{err: map[int]error{}}
+}
+
+func (r *recordingSignaler) Signal(pid int, sig syscall.Signal) error {
+	r.mu.Lock()
+	r.sent = append(r.sent, signalCall{PID: pid, Sig: sig})
+	err := r.err[pid]
+	r.mu.Unlock()
+	if r.onSend != nil {
+		r.onSend(pid, sig)
+	}
+	return err
+}
+
+func (r *recordingSignaler) calls() []signalCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]signalCall, len(r.sent))
+	copy(out, r.sent)
+	return out
+}
+
+func (r *recordingSignaler) sentTo(pid int) int {
+	n := 0
+	for _, c := range r.calls() {
+		if c.PID == pid {
+			n++
+		}
+	}
+	return n
+}
+
+// liveReceipt builds a valid receipt around a leader and optional members.
+func liveReceipt(instanceID string, leader Member, members ...Member) *Receipt {
+	return &Receipt{
+		Version:    ReceiptVersion,
+		InstanceID: instanceID,
+		Generation: 1,
+		State:      StateLive,
+		Provider:   ProviderLinuxProc,
+		BootID:     "boot-1",
+		CreatedAt:  1,
+		Leader:     leader,
+		Members:    members,
+	}
+}
+
+func memberOf(info ProcInfo, role string) Member {
+	return Member{
+		PID:     info.PID,
+		StartID: info.StartID,
+		PGID:    info.PGID,
+		UID:     info.UID,
+		Comm:    info.Comm,
+		Role:    role,
+	}
+}

--- a/internal/procowner/prober_darwin.go
+++ b/internal/procowner/prober_darwin.go
@@ -1,0 +1,119 @@
+//go:build darwin
+
+package procowner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ProviderDarwinPS is the provider name recorded in receipts written here.
+const ProviderDarwinPS = "darwin_ps"
+
+// psTimeout bounds every probe. An ownership check runs on the restart path, so
+// a wedged `ps` must fail closed quickly rather than hang the restart.
+const psTimeout = 5 * time.Second
+
+// DarwinProber reads process start identity from BSD `ps`.
+//
+// macOS has no /proc, and the ruling forbids new dependencies, so the start
+// identity is the `lstart` column: the process's start wall-clock time to
+// one-second resolution. That is weaker than Linux's start ticks — two
+// processes sharing a PID within the same second would be indistinguishable —
+// but PID reuse requires the whole pid space to wrap, which does not happen
+// inside a second on a healthy machine. Where it is ambiguous the verifier
+// fails closed and signals nothing.
+type DarwinProber struct{}
+
+// NewProber returns the platform's start-identity provider.
+func NewProber() Prober { return DarwinProber{} }
+
+// Name implements Prober.
+func (DarwinProber) Name() string { return ProviderDarwinPS }
+
+// BootID implements Prober. kern.boottime changes on every boot, which is all a
+// boot identifier has to do.
+func (DarwinProber) BootID() (string, error) {
+	out, err := runBounded("sysctl", "-n", "kern.boottime")
+	if err != nil {
+		return "", fmt.Errorf("%w: read kern.boottime: %v", ErrUnreadable, err)
+	}
+	return parseKernBootTime(out)
+}
+
+// Inspect implements Prober.
+func (DarwinProber) Inspect(pid int) (ProcInfo, error) {
+	if pid <= 0 {
+		return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
+	}
+	out, err := runBounded("ps", "-p", strconv.Itoa(pid), "-o", psFieldOrder)
+	if err != nil {
+		// ps exits non-zero with no output when the pid is absent. Anything
+		// else (a timeout, a missing binary) stays unreadable, not "gone".
+		if strings.TrimSpace(out) == "" && isExitStatus(err) {
+			return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
+		}
+		return ProcInfo{}, fmt.Errorf("%w: ps for pid %d: %v", ErrUnreadable, pid, err)
+	}
+	rows := parsePSTable(out)
+	if len(rows) == 0 {
+		return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
+	}
+	if rows[0].PID != pid {
+		return ProcInfo{}, fmt.Errorf("%w: ps reported pid %d for %d", ErrUnreadable, rows[0].PID, pid)
+	}
+	if rows[0].IsZombie() {
+		// See ProcInfo.IsZombie: exited, awaiting wait(), not alive.
+		return ProcInfo{}, fmt.Errorf("%w: pid %d is a zombie", ErrNoProcess, pid)
+	}
+	return rows[0], nil
+}
+
+// Descendants implements Prober over a single `ps -A` snapshot.
+func (DarwinProber) Descendants(root ProcInfo) ([]ProcInfo, error) {
+	if root.PID <= 0 {
+		return nil, fmt.Errorf("%w: pid %d", ErrNoProcess, root.PID)
+	}
+	out, err := runBounded("ps", "-Ao", psFieldOrder)
+	if err != nil {
+		return nil, fmt.Errorf("%w: ps -A: %v", ErrUnreadable, err)
+	}
+	return descendantsFromTable(root, parsePSTable(out)), nil
+}
+
+func runBounded(name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), psTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	return string(out), err
+}
+
+func isExitStatus(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
+}
+
+// CompareStart implements StartComparer over the `lstart` wall-clock format.
+func (DarwinProber) CompareStart(a, b string) (int, error) {
+	at, err := parseLstart(a)
+	if err != nil {
+		return 0, err
+	}
+	bt, err := parseLstart(b)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case at.Before(bt):
+		return -1, nil
+	case at.After(bt):
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}

--- a/internal/procowner/prober_darwin.go
+++ b/internal/procowner/prober_darwin.go
@@ -55,7 +55,7 @@ func (DarwinProber) Inspect(pid int) (ProcInfo, error) {
 	if err != nil {
 		// ps exits non-zero with no output when the pid is absent. Anything
 		// else (a timeout, a missing binary) stays unreadable, not "gone".
-		if strings.TrimSpace(out) == "" && isExitStatus(err) {
+		if strings.TrimSpace(out) == "" && isExitedStatus(err) {
 			return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
 		}
 		return ProcInfo{}, fmt.Errorf("%w: ps for pid %d: %v", ErrUnreadable, pid, err)
@@ -90,12 +90,15 @@ func runBounded(name string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), psTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, name, args...).Output()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return string(out), ctxErr
+	}
 	return string(out), err
 }
 
-func isExitStatus(err error) bool {
+func isExitedStatus(err error) bool {
 	var exitErr *exec.ExitError
-	return errors.As(err, &exitErr)
+	return errors.As(err, &exitErr) && exitErr.Exited()
 }
 
 // CompareStart implements StartComparer over the `lstart` wall-clock format.

--- a/internal/procowner/prober_linux.go
+++ b/internal/procowner/prober_linux.go
@@ -1,0 +1,229 @@
+//go:build linux
+
+package procowner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ProviderLinuxProc is the provider name recorded in receipts written here.
+const ProviderLinuxProc = "linux_proc"
+
+// procRoot is a variable so tests can point the reader at a fixture tree
+// instead of the live /proc. Production never changes it.
+var procRoot = "/proc"
+
+// LinuxProber reads process start identity from /proc.
+//
+// The start identity is field 22 of /proc/<pid>/stat: the process start time in
+// clock ticks since boot. Together with the PID and the boot id it is a
+// non-reusable identity — the kernel cannot hand out the same (boot, pid,
+// start-tick) triple twice.
+type LinuxProber struct{}
+
+// NewProber returns the platform's start-identity provider.
+func NewProber() Prober { return LinuxProber{} }
+
+// Name implements Prober.
+func (LinuxProber) Name() string { return ProviderLinuxProc }
+
+// BootID implements Prober.
+func (LinuxProber) BootID() (string, error) {
+	data, err := os.ReadFile(filepath.Join(procRoot, "sys", "kernel", "random", "boot_id"))
+	if err != nil {
+		return "", fmt.Errorf("%w: read boot id: %v", ErrUnreadable, err)
+	}
+	id := strings.TrimSpace(string(data))
+	if id == "" {
+		return "", fmt.Errorf("%w: boot id is empty", ErrUnreadable)
+	}
+	return id, nil
+}
+
+// Inspect implements Prober.
+func (p LinuxProber) Inspect(pid int) (ProcInfo, error) {
+	if pid <= 0 {
+		return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
+	}
+	dir := filepath.Join(procRoot, strconv.Itoa(pid))
+	// Read stat first: it is the single read that makes pid, ppid, pgid and
+	// start time one coherent observation of one process. Reading them from
+	// separate files would let a recycle slip between them.
+	data, err := os.ReadFile(filepath.Join(dir, "stat"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ProcInfo{}, fmt.Errorf("%w: pid %d", ErrNoProcess, pid)
+		}
+		return ProcInfo{}, fmt.Errorf("%w: read stat for pid %d: %v", ErrUnreadable, pid, err)
+	}
+	info, err := parseProcStat(data)
+	if err != nil {
+		return ProcInfo{}, err
+	}
+	if info.IsZombie() {
+		// Exited, awaiting wait() by its parent. It cannot run code and it
+		// cannot be killed again; reporting it alive would make a successful
+		// reap look like a failed one.
+		return ProcInfo{}, fmt.Errorf("%w: pid %d is a zombie", ErrNoProcess, pid)
+	}
+	if info.PID != pid {
+		// /proc/<pid>/stat naming its own pid as something else means the entry
+		// was replaced under us. Refuse to interpret it.
+		return ProcInfo{}, fmt.Errorf("%w: pid %d reported itself as %d", ErrUnreadable, pid, info.PID)
+	}
+	uid, err := ownerUID(dir)
+	if err != nil {
+		return ProcInfo{}, err
+	}
+	info.UID = uid
+	return info, nil
+}
+
+// ownerUID returns the uid owning a /proc/<pid> directory, which is the
+// process's real uid.
+func ownerUID(dir string) (int, error) {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, fmt.Errorf("%w: %s", ErrNoProcess, dir)
+		}
+		return 0, fmt.Errorf("%w: stat %s: %v", ErrUnreadable, dir, err)
+	}
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("%w: no uid for %s", ErrUnreadable, dir)
+	}
+	return int(sys.Uid), nil
+}
+
+// parseProcStat extracts pid, ppid, pgid and start ticks from a
+// /proc/<pid>/stat line.
+//
+// The comm field is parenthesised and may itself contain spaces AND closing
+// parens (a process can name itself "(evil) (x"), so the split point is the
+// LAST ')' in the line, not the first. Getting this wrong shifts every
+// subsequent field — which would silently compare the wrong number as a start
+// time, the one failure mode this whole package exists to prevent.
+func parseProcStat(data []byte) (ProcInfo, error) {
+	line := string(data)
+	open := strings.IndexByte(line, '(')
+	closeIdx := strings.LastIndexByte(line, ')')
+	if open < 0 || closeIdx < open {
+		return ProcInfo{}, fmt.Errorf("%w: malformed stat line", ErrUnreadable)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(line[:open]))
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("%w: unparseable pid in stat line", ErrUnreadable)
+	}
+	comm := line[open+1 : closeIdx]
+	// After the comm the remaining fields are space-separated, starting at
+	// field 3 (state). Field N of the stat(5) layout is rest[N-3].
+	rest := strings.Fields(line[closeIdx+1:])
+	const (
+		stateIdx     = 0  // field 3
+		ppidIdx      = 1  // field 4
+		pgidIdx      = 2  // field 5
+		starttimeIdx = 19 // field 22
+	)
+	if len(rest) <= starttimeIdx {
+		return ProcInfo{}, fmt.Errorf("%w: stat line has %d fields after comm, need %d",
+			ErrUnreadable, len(rest), starttimeIdx+1)
+	}
+	ppid, err := strconv.Atoi(rest[ppidIdx])
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("%w: unparseable ppid", ErrUnreadable)
+	}
+	pgid, err := strconv.Atoi(rest[pgidIdx])
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("%w: unparseable pgid", ErrUnreadable)
+	}
+	start := rest[starttimeIdx]
+	if _, err := strconv.ParseUint(start, 10, 64); err != nil {
+		return ProcInfo{}, fmt.Errorf("%w: unparseable start time %q", ErrUnreadable, start)
+	}
+	return ProcInfo{
+		PID:     pid,
+		PPID:    ppid,
+		PGID:    pgid,
+		Comm:    comm,
+		State:   rest[stateIdx],
+		StartID: start,
+	}, nil
+}
+
+// Descendants implements Prober by walking /proc once and following parent
+// links down from root.
+//
+// One pass over /proc is deliberate: every (pid, ppid, start) triple comes from
+// a single read of that process's stat file, so a pid cannot be recorded with
+// another process's start identity. A process that exits mid-scan simply drops
+// out — a missed descendant is a process we never claim to own, which is the
+// safe direction to fail in.
+func (p LinuxProber) Descendants(root ProcInfo) ([]ProcInfo, error) {
+	if root.PID <= 0 {
+		return nil, fmt.Errorf("%w: pid %d", ErrNoProcess, root.PID)
+	}
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read %s: %v", ErrUnreadable, procRoot, err)
+	}
+	byParent := map[int][]ProcInfo{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, convErr := strconv.Atoi(entry.Name())
+		if convErr != nil || pid <= 1 {
+			continue
+		}
+		info, inspectErr := p.Inspect(pid)
+		if inspectErr != nil {
+			continue // vanished or unreadable: never guessed at
+		}
+		byParent[info.PPID] = append(byParent[info.PPID], info)
+	}
+
+	var out []ProcInfo
+	seen := map[int]bool{root.PID: true}
+	queue := []int{root.PID}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, child := range byParent[parent] {
+			if seen[child.PID] {
+				continue
+			}
+			seen[child.PID] = true
+			out = append(out, child)
+			queue = append(queue, child.PID)
+		}
+	}
+	return out, nil
+}
+
+// CompareStart implements StartComparer. Linux start identities are clock ticks
+// since boot, so they order numerically within a boot — and a receipt only ever
+// compares identities from one boot, because BootID scopes it.
+func (LinuxProber) CompareStart(a, b string) (int, error) {
+	av, err := strconv.ParseUint(a, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: unparseable start identity %q", ErrUnreadable, a)
+	}
+	bv, err := strconv.ParseUint(b, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: unparseable start identity %q", ErrUnreadable, b)
+	}
+	switch {
+	case av < bv:
+		return -1, nil
+	case av > bv:
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}

--- a/internal/procowner/prober_linux_test.go
+++ b/internal/procowner/prober_linux_test.go
@@ -1,0 +1,214 @@
+//go:build linux
+
+package procowner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseProcStat is where a whole class of silent misidentification lives: get
+// the comm split wrong and every later field shifts, so the number compared as
+// a "start time" is somebody else's field entirely.
+func TestParseProcStat_CommWithSpacesAndParens(t *testing.T) {
+	fields := make([]string, 0, 52)
+	fields = append(fields, "S", "4242", "777", "777", "0", "-1", "4194304")
+	for len(fields) < 19 {
+		fields = append(fields, "0")
+	}
+	fields = append(fields, "987654321") // field 22: starttime
+	line := "1234 (weird (name) with spaces) "
+	for _, f := range fields {
+		line += f + " "
+	}
+
+	info, err := parseProcStat([]byte(line))
+	require.NoError(t, err)
+	assert.Equal(t, 1234, info.PID)
+	assert.Equal(t, "weird (name) with spaces", info.Comm)
+	assert.Equal(t, 4242, info.PPID)
+	assert.Equal(t, 777, info.PGID)
+	assert.Equal(t, "987654321", info.StartID)
+}
+
+func TestParseProcStat_RejectsTruncatedAndMalformed(t *testing.T) {
+	for name, line := range map[string]string{
+		"empty":               "",
+		"no parens":           "1234 sh S 1 1 1",
+		"truncated":           "1234 (sh) S 1 1",
+		"bad pid":             statLine("nope", "5000"),
+		"non numeric start":   statLine("1234", "not-a-number"),
+		"negative field slot": statLine("1234", ""),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseProcStat([]byte(line))
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrUnreadable))
+		})
+	}
+}
+
+// An unreadable /proc entry must be "unknown", never "gone": the difference
+// decides whether a receipt is cleared or a restart is refused.
+func TestLinuxProber_UnreadableEntryIsNotDeath(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "4242"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "4242", "stat"), []byte("garbage"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "sys", "kernel", "random"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sys", "kernel", "random", "boot_id"),
+		[]byte("fixture-boot\n"), 0o600))
+
+	restore := procRoot
+	procRoot = root
+	t.Cleanup(func() { procRoot = restore })
+
+	p := LinuxProber{}
+	_, err := p.Inspect(4242)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnreadable))
+	assert.False(t, errors.Is(err, ErrNoProcess))
+
+	// An absent entry, by contrast, is proof of death.
+	_, err = p.Inspect(4243)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoProcess))
+
+	boot, err := p.BootID()
+	require.NoError(t, err)
+	assert.Equal(t, "fixture-boot", boot)
+}
+
+func TestLinuxProber_MissingBootIDIsUnreadable(t *testing.T) {
+	restore := procRoot
+	procRoot = t.TempDir()
+	t.Cleanup(func() { procRoot = restore })
+
+	_, err := LinuxProber{}.BootID()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnreadable))
+}
+
+// The end-to-end reality check: claim a receipt for a real process, verify it,
+// reap it by identity, and confirm the receipt clears. Every pid this test
+// creates is its own, and it kills only those.
+func TestLinuxProber_RealProcessLifecycle(t *testing.T) {
+	p := LinuxProber{}
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-real", Generation: 1, PanePID: pid})
+	require.NoError(t, err)
+	assert.Equal(t, os.Getuid(), receipt.Leader.UID)
+	assert.NotEmpty(t, receipt.Leader.StartID)
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictOwned, report.Verdict, report.Describe())
+
+	// A receipt with the right pid but a wrong start identity is a stranger:
+	// this is the recycled-pid case against a genuinely live process.
+	impostor := liveReceipt("inst-real", Member{
+		PID:     pid,
+		StartID: bumpStart(t, receipt.Leader.StartID),
+		UID:     receipt.Leader.UID,
+		Role:    RoleLeader,
+	})
+	impostor.BootID = receipt.BootID
+	sig := newRecordingSignaler()
+	impostorReport := Reap(p, sig, impostor, ReapOptions{TermGrace: 100 * time.Millisecond, KillGrace: 100 * time.Millisecond})
+	assert.Empty(t, sig.calls(), "a live process with a different start identity is never signalled")
+	assert.Equal(t, VerdictClear, impostorReport.Verdict)
+	require.NoError(t, syscall.Kill(pid, 0), "the impostor check must not have killed the real process")
+
+	// Now reap the real receipt.
+	realReport := Reap(p, OSSignaler{}, receipt, ReapOptions{TermGrace: 3 * time.Second, KillGrace: 3 * time.Second})
+	require.Equal(t, VerdictClear, realReport.Verdict, realReport.Describe())
+	reaped = true
+	_ = cmd.Wait()
+
+	after := Verify(p, receipt)
+	assert.Equal(t, VerdictClear, after.Verdict)
+}
+
+// A real parent/child tree: attribution must record the child while it is a
+// live descendant, and the child must remain identifiable after its parent has
+// gone — which is the whole point of recording it at spawn.
+func TestLinuxProber_AttributesRealDescendants(t *testing.T) {
+	p := LinuxProber{}
+	// A shell that forks a grandchild and stays alive.
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30 & wait")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-tree", Generation: 1, PanePID: pid})
+	require.NoError(t, err)
+
+	var added []Member
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		added, err = Attribute(p, receipt, nil)
+		require.NoError(t, err)
+		if len(receipt.Members) > 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	require.NotEmpty(t, receipt.Members, "the forked child must be attributable while its parent lives")
+
+	for _, m := range receipt.Members {
+		assert.NotEmpty(t, m.StartID, "every member carries its own start identity")
+		start, cmpErr := CompareStart(p, m.StartID, receipt.Leader.StartID)
+		require.NoError(t, cmpErr)
+		assert.GreaterOrEqual(t, start, 0, "a descendant cannot predate its leader")
+	}
+
+	// Reap the whole recorded tree by identity, then confirm nothing is left.
+	report := Reap(p, OSSignaler{}, receipt, ReapOptions{TermGrace: 3 * time.Second, KillGrace: 3 * time.Second})
+	require.Equal(t, VerdictClear, report.Verdict, report.Describe())
+	_ = cmd.Wait()
+	for _, m := range receipt.All() {
+		assert.NotEqual(t, StateOwned, VerifyMember(p, m).State, "member %s survived the reap", m)
+	}
+	_ = added
+}
+
+func bumpStart(t *testing.T, start string) string {
+	t.Helper()
+	v, err := strconv.ParseUint(start, 10, 64)
+	require.NoError(t, err)
+	return fmt.Sprint(v + 1)
+}
+
+// statLine builds a /proc/<pid>/stat line with `start` in field 22, so a test
+// fixture cannot silently drift out of alignment by miscounting spaces.
+func statLine(pid, start string) string {
+	fields := make([]string, 20) // fields 3..22
+	for i := range fields {
+		fields[i] = "1"
+	}
+	fields[0] = "S"
+	fields[19] = start
+	return pid + " (sh) " + strings.Join(fields, " ")
+}

--- a/internal/procowner/prober_linux_test.go
+++ b/internal/procowner/prober_linux_test.go
@@ -168,14 +168,16 @@ func TestLinuxProber_AttributesRealDescendants(t *testing.T) {
 	var added []Member
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		added, err = Attribute(p, receipt, nil)
-		require.NoError(t, err)
+		batch, attrErr := Attribute(p, receipt, nil)
+		require.NoError(t, attrErr)
+		added = append(added, batch...)
 		if len(receipt.Members) > 0 {
 			break
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
 	require.NotEmpty(t, receipt.Members, "the forked child must be attributable while its parent lives")
+	assert.Equal(t, receipt.Members, added, "every recorded member must be reported as added exactly once")
 
 	for _, m := range receipt.Members {
 		assert.NotEmpty(t, m.StartID, "every member carries its own start identity")
@@ -191,7 +193,6 @@ func TestLinuxProber_AttributesRealDescendants(t *testing.T) {
 	for _, m := range receipt.All() {
 		assert.NotEqual(t, StateOwned, VerifyMember(p, m).State, "member %s survived the reap", m)
 	}
-	_ = added
 }
 
 func bumpStart(t *testing.T, start string) string {

--- a/internal/procowner/prober_ps.go
+++ b/internal/procowner/prober_ps.go
@@ -1,0 +1,126 @@
+package procowner
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// This file holds the pure parsing half of the BSD `ps` provider used on
+// platforms without /proc. It carries no build tag on purpose: the parser is
+// where the bugs live, and it must be testable on the machine that runs CI.
+
+// psFieldOrder is the -o format the darwin prober asks for. lstart is last
+// because it is the only field containing spaces.
+const psFieldOrder = "pid=,ppid=,pgid=,uid=,state=,lstart="
+
+// parsePSLine reads one `ps -o pid=,ppid=,pgid=,uid=,state=,lstart=` row.
+//
+// lstart is a human date with embedded spaces ("Sat Aug 16 17:21:38 2026"), so
+// the four leading integers are consumed positionally and everything after them
+// is the start identity verbatim. Normalising internal whitespace matters: ps
+// pads day-of-month to two columns, so the same process can print with one or
+// two spaces depending on the day, and an identity that changes shape over time
+// would read as a stranger.
+func parsePSLine(line string) (ProcInfo, error) {
+	fields := strings.Fields(line)
+	if len(fields) < 6 {
+		return ProcInfo{}, fmt.Errorf("%w: ps row %q has %d fields, need at least 6",
+			ErrUnreadable, line, len(fields))
+	}
+	nums := make([]int, 4)
+	for i := 0; i < 4; i++ {
+		v, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return ProcInfo{}, fmt.Errorf("%w: unparseable ps field %q", ErrUnreadable, fields[i])
+		}
+		nums[i] = v
+	}
+	state := fields[4]
+	start := strings.Join(fields[5:], " ")
+	if strings.TrimSpace(start) == "" {
+		return ProcInfo{}, fmt.Errorf("%w: ps row %q has no start time", ErrUnreadable, line)
+	}
+	return ProcInfo{
+		PID:     nums[0],
+		PPID:    nums[1],
+		PGID:    nums[2],
+		UID:     nums[3],
+		State:   state,
+		StartID: start,
+	}, nil
+}
+
+// parsePSTable reads a whole `ps -A` listing, skipping rows it cannot parse
+// rather than failing the scan: one unreadable row must not cost us the
+// attribution of every other process.
+func parsePSTable(out string) []ProcInfo {
+	var infos []ProcInfo
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		info, err := parsePSLine(line)
+		if err != nil {
+			continue
+		}
+		infos = append(infos, info)
+	}
+	return infos
+}
+
+// descendantsFromTable follows parent links down from root over a single
+// snapshot of the process table.
+func descendantsFromTable(root ProcInfo, table []ProcInfo) []ProcInfo {
+	byParent := map[int][]ProcInfo{}
+	for _, info := range table {
+		if info.PID <= 1 || info.IsZombie() {
+			continue
+		}
+		byParent[info.PPID] = append(byParent[info.PPID], info)
+	}
+	var out []ProcInfo
+	seen := map[int]bool{root.PID: true}
+	queue := []int{root.PID}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, child := range byParent[parent] {
+			if seen[child.PID] {
+				continue
+			}
+			seen[child.PID] = true
+			out = append(out, child)
+			queue = append(queue, child.PID)
+		}
+	}
+	return out
+}
+
+// bootTimePattern extracts the seconds field from `sysctl -n kern.boottime`,
+// whose output looks like `{ sec = 1755300000, usec = 123456 } Sat Aug 16 ...`.
+var bootTimePattern = regexp.MustCompile(`sec\s*=\s*(\d+)`)
+
+// parseKernBootTime turns kern.boottime into a boot identifier.
+func parseKernBootTime(out string) (string, error) {
+	match := bootTimePattern.FindStringSubmatch(out)
+	if len(match) != 2 {
+		return "", fmt.Errorf("%w: unparseable kern.boottime %q", ErrUnreadable, strings.TrimSpace(out))
+	}
+	return match[1], nil
+}
+
+// lstartLayout is the BSD `ps -o lstart=` format ("Sat Aug 16 17:21:38 2026").
+const lstartLayout = "Mon Jan 2 15:04:05 2006"
+
+// parseLstart parses a `ps` lstart value. Fields are re-joined with single
+// spaces by parsePSLine, so the layout carries no column padding.
+func parseLstart(value string) (time.Time, error) {
+	t, err := time.Parse(lstartLayout, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: unparseable start identity %q", ErrUnreadable, value)
+	}
+	return t, nil
+}

--- a/internal/procowner/prober_ps_test.go
+++ b/internal/procowner/prober_ps_test.go
@@ -1,0 +1,100 @@
+package procowner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The BSD `ps` provider cannot be exercised end to end on the machine that runs
+// CI, so the part that can hold a bug — the parsing — is tested here against
+// real macOS output shapes. The rest of the provider is three exec calls.
+
+func TestParsePSLine_RealDarwinRows(t *testing.T) {
+	// `ps -Ao pid=,ppid=,pgid=,uid=,lstart=` on macOS: right-aligned numeric
+	// columns, then a date whose day-of-month is space padded.
+	info, err := parsePSLine("  4711   4710   4711    501 S+   Sat Aug 16 17:21:38 2026")
+	require.NoError(t, err)
+	assert.Equal(t, 4711, info.PID)
+	assert.Equal(t, 4710, info.PPID)
+	assert.Equal(t, 4711, info.PGID)
+	assert.Equal(t, 501, info.UID)
+	assert.Equal(t, "Sat Aug 16 17:21:38 2026", info.StartID)
+
+	// Single-digit day: ps pads it, and the identity must normalise to the same
+	// shape it will be compared against later.
+	padded, err := parsePSLine("  4711   4710   4711    501 Ss   Tue Sep  2 07:05:01 2025")
+	require.NoError(t, err)
+	assert.Equal(t, "Tue Sep 2 07:05:01 2025", padded.StartID)
+}
+
+func TestParsePSLine_RejectsUnusableRows(t *testing.T) {
+	for _, row := range []string{
+		"",
+		"4711",
+		"4711 4710 4711 501 S", // no lstart
+		"nope 4710 4711 501 S Sat Aug 16 17:21:38 2026", // unparseable pid
+	} {
+		_, err := parsePSLine(row)
+		require.Error(t, err, "row %q must be refused", row)
+	}
+}
+
+func TestParsePSTable_SkipsGarbageRows(t *testing.T) {
+	table := parsePSTable(`
+  1      0      1      0 Ss   Sat Aug 16 09:00:00 2026
+garbage row that ps would never print
+  4711   1   4711    501 S+   Sat Aug 16 17:21:38 2026
+`)
+	require.Len(t, table, 2)
+	assert.Equal(t, 1, table[0].PID)
+	assert.Equal(t, 4711, table[1].PID)
+}
+
+func TestDescendantsFromTable(t *testing.T) {
+	table := []ProcInfo{
+		{PID: 100, PPID: 1, StartID: "a"},
+		{PID: 101, PPID: 100, StartID: "b"},
+		{PID: 102, PPID: 101, StartID: "c"},
+		{PID: 103, PPID: 100, StartID: "e", State: "Z"},
+		{PID: 200, PPID: 1, StartID: "d"},
+	}
+	kids := descendantsFromTable(ProcInfo{PID: 100}, table)
+	require.Len(t, kids, 2, "a zombie descendant is not a live process")
+	assert.Equal(t, 101, kids[0].PID)
+	assert.Equal(t, 102, kids[1].PID)
+}
+
+func TestParseKernBootTime(t *testing.T) {
+	id, err := parseKernBootTime("{ sec = 1755300000, usec = 123456 } Sat Aug 16 09:00:00 2026\n")
+	require.NoError(t, err)
+	assert.Equal(t, "1755300000", id)
+
+	_, err = parseKernBootTime("nothing useful here")
+	require.Error(t, err)
+}
+
+func TestParseLstartOrdering(t *testing.T) {
+	earlier, err := parseLstart("Sat Aug 16 17:21:38 2026")
+	require.NoError(t, err)
+	later, err := parseLstart("Sat Aug 16 17:21:39 2026")
+	require.NoError(t, err)
+	assert.True(t, earlier.Before(later))
+
+	_, err = parseLstart("not a date")
+	require.Error(t, err)
+}
+
+// The `ps` format string and the parser have to agree, and they live in
+// different halves of the provider — one behind a darwin build tag, one not.
+// This pins the coupling on every platform that runs the suite.
+func TestPSFieldOrderMatchesTheParser(t *testing.T) {
+	columns := strings.Split(strings.TrimSuffix(psFieldOrder, ","), ",")
+	require.Len(t, columns, 6, "parsePSLine consumes four integers, a state, then lstart")
+	assert.Equal(t, "lstart=", columns[len(columns)-1],
+		"lstart must stay last: it is the only column containing spaces")
+	assert.Equal(t, "state=", columns[len(columns)-2],
+		"state must stay immediately before lstart: parsePSLine reads it positionally")
+}

--- a/internal/procowner/prober_unsupported.go
+++ b/internal/procowner/prober_unsupported.go
@@ -1,0 +1,41 @@
+//go:build !linux && !darwin
+
+package procowner
+
+import "fmt"
+
+// ProviderUnsupported names the no-op provider used where no start-identity
+// source exists.
+const ProviderUnsupported = "unsupported"
+
+// UnsupportedProber is the safe cross-platform fallback.
+//
+// Every call fails with ErrUnsupported, which means: no receipt is ever written
+// (Spawn ownership cannot be established), so no receipt is ever verified, and
+// nothing is ever signalled. The restart path keeps its pre-#1873 behaviour on
+// such a platform rather than blocking every restart on an ownership question
+// the host cannot answer. This is a deliberate scope limit, stated rather than
+// silently degraded: without a start identity the PID+start-time contract has
+// no identity half, and a PID alone must never authorise a signal.
+type UnsupportedProber struct{}
+
+// NewProber returns the platform's start-identity provider.
+func NewProber() Prober { return UnsupportedProber{} }
+
+// Name implements Prober.
+func (UnsupportedProber) Name() string { return ProviderUnsupported }
+
+// BootID implements Prober.
+func (UnsupportedProber) BootID() (string, error) {
+	return "", fmt.Errorf("%w: boot id", ErrUnsupported)
+}
+
+// Inspect implements Prober.
+func (UnsupportedProber) Inspect(pid int) (ProcInfo, error) {
+	return ProcInfo{}, fmt.Errorf("%w: inspect pid %d", ErrUnsupported, pid)
+}
+
+// Descendants implements Prober.
+func (UnsupportedProber) Descendants(root ProcInfo) ([]ProcInfo, error) {
+	return nil, fmt.Errorf("%w: descendants of pid %d", ErrUnsupported, root.PID)
+}

--- a/internal/procowner/reap.go
+++ b/internal/procowner/reap.go
@@ -1,0 +1,304 @@
+package procowner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// Reap outcomes.
+const (
+	// OutcomeReaped: the process was ours, we signalled it, and it is gone.
+	OutcomeReaped = "reaped"
+	// OutcomeAlreadyGone: the process was already gone; nothing was signalled.
+	OutcomeAlreadyGone = "already_gone"
+	// OutcomeNotSignalled: the identity did not verify as ours, so it was left
+	// strictly alone. This is the unknown / unreadable / not-ours case.
+	OutcomeNotSignalled = "not_signalled"
+	// OutcomeStillAlive: the process was ours and survived SIGTERM and SIGKILL.
+	OutcomeStillAlive = "still_alive"
+)
+
+// Signaler delivers a signal to a pid. It is an interface so the escalation
+// logic can be tested without killing anything.
+type Signaler interface {
+	Signal(pid int, sig syscall.Signal) error
+}
+
+// OSSignaler signals real processes.
+type OSSignaler struct{}
+
+// Signal implements Signaler.
+func (OSSignaler) Signal(pid int, sig syscall.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(sig)
+}
+
+// ReapOptions tunes the escalation. Zero values get sane defaults.
+type ReapOptions struct {
+	TermGrace time.Duration // how long SIGTERM is given before SIGKILL
+	KillGrace time.Duration // how long SIGKILL is given before giving up
+	Poll      time.Duration // liveness re-check interval
+	Sleep     func(time.Duration)
+}
+
+func (o ReapOptions) withDefaults() ReapOptions {
+	if o.TermGrace <= 0 {
+		o.TermGrace = 3 * time.Second
+	}
+	if o.KillGrace <= 0 {
+		o.KillGrace = 2 * time.Second
+	}
+	if o.Poll <= 0 {
+		o.Poll = 50 * time.Millisecond
+	}
+	if o.Sleep == nil {
+		o.Sleep = time.Sleep
+	}
+	return o
+}
+
+// ReapOutcome is what happened to one recorded identity.
+type ReapOutcome struct {
+	Member  Member
+	Outcome string
+	Detail  string
+}
+
+// ReapReport is the result of reconciling a whole receipt.
+type ReapReport struct {
+	Outcomes []ReapOutcome
+	Verdict  Verdict
+	Reason   string
+}
+
+// Signalled reports how many identities were actually signalled.
+func (r ReapReport) Signalled() int {
+	n := 0
+	for _, o := range r.Outcomes {
+		if o.Outcome == OutcomeReaped || o.Outcome == OutcomeStillAlive {
+			n++
+		}
+	}
+	return n
+}
+
+// Describe renders the report for operator surfaces.
+func (r ReapReport) Describe() string {
+	out := fmt.Sprintf("verdict=%s (%s)", r.Verdict, r.Reason)
+	for _, o := range r.Outcomes {
+		out += fmt.Sprintf("\n  %s -> %s", o.Member.String(), o.Outcome)
+		if o.Detail != "" {
+			out += ": " + o.Detail
+		}
+	}
+	return out
+}
+
+// Reap terminates every identity in the receipt that still verifies as ours,
+// and nothing else.
+//
+// The rules, in order of importance:
+//
+//  1. Identity is re-verified immediately before every signal. A pid that has
+//     been reused, cannot be read, or now belongs to another user is left
+//     alone and reported — never signalled, not even with SIGTERM.
+//  2. Descendants are signalled before the leader, so the tree is not
+//     re-parented mid-reap.
+//  3. Death is verified, not assumed: SIGTERM the whole set, wait, SIGKILL
+//     whatever is left, wait again. A process that survives both is reported
+//     still alive and the receipt is NOT cleared.
+//
+// The waiting is per PHASE, not per process. Reaping members one at a time
+// would multiply the grace period by the size of the tree, and this runs on the
+// teardown path — a session with a dozen stubborn children would take a minute
+// to stop. Signalling the whole set first also gives a parent and its children
+// the same window to shut down cleanly.
+//
+// The one window this cannot close is between the verify and the kill syscall:
+// closing it entirely needs pidfd (Linux-only, and a syscall this package would
+// have to hand-roll). The window is microseconds wide and requires the pid
+// space to wrap inside it, and SIGTERM — the only signal that can land there
+// first — is survivable. Everything after that first signal is re-verified.
+func Reap(p Prober, s Signaler, r *Receipt, opts ReapOptions) ReapReport {
+	opts = opts.withDefaults()
+	if r == nil {
+		return ReapReport{Verdict: VerdictClear, Reason: "no ownership receipt"}
+	}
+	if err := r.Validate(); err != nil {
+		return ReapReport{Verdict: VerdictUnknown, Reason: err.Error()}
+	}
+	if p.Name() != r.Provider {
+		return ReapReport{
+			Verdict: VerdictUnknown,
+			Reason: fmt.Sprintf("receipt was written by provider %q but this host verifies with %q; nothing was signalled",
+				r.Provider, p.Name()),
+		}
+	}
+	// A receipt from a previous boot names processes that cannot exist. There
+	// is nothing to signal and nothing ambiguous about it.
+	if boot, err := p.BootID(); err != nil {
+		return ReapReport{Verdict: VerdictUnknown, Reason: "current boot id is unreadable: " + err.Error()}
+	} else if boot != r.BootID {
+		return ReapReport{
+			Verdict: VerdictClear,
+			Reason:  "receipt predates the current boot, so every recorded process is gone",
+		}
+	}
+
+	// Descendants first, leader last.
+	members := r.All()
+	ordered := make([]Member, 0, len(members))
+	for idx := len(members) - 1; idx >= 0; idx-- {
+		ordered = append(ordered, members[idx])
+	}
+
+	outcomes := make(map[string]*ReapOutcome, len(ordered))
+	self := os.Getpid()
+	var pending []Member
+	for _, m := range ordered {
+		if m.PID <= 1 || m.PID == self {
+			outcomes[m.Key()] = &ReapOutcome{
+				Member:  m,
+				Outcome: OutcomeNotSignalled,
+				Detail:  fmt.Sprintf("refusing to signal pid %d", m.PID),
+			}
+			continue
+		}
+		pending = append(pending, m)
+	}
+
+	for _, step := range []struct {
+		sig   syscall.Signal
+		grace time.Duration
+	}{
+		{syscall.SIGTERM, opts.TermGrace},
+		{syscall.SIGKILL, opts.KillGrace},
+	} {
+		if len(pending) == 0 {
+			break
+		}
+		var signalled []Member
+		for _, m := range pending {
+			// Re-verify immediately before EVERY signal, including the
+			// escalation: the grace period we just waited out is exactly when a
+			// pid can change hands.
+			if outcome := classifyBeforeSignal(p, m); outcome != nil {
+				outcomes[m.Key()] = outcome
+				continue
+			}
+			if err := s.Signal(m.PID, step.sig); err != nil {
+				outcomes[m.Key()] = classifySignalError(m, err)
+				continue
+			}
+			signalled = append(signalled, m)
+		}
+
+		pending = signalled
+		if len(pending) == 0 {
+			continue
+		}
+		deadline := time.Now().Add(step.grace)
+		for {
+			var stillOurs []Member
+			for _, m := range pending {
+				switch VerifyMember(p, m).State {
+				case StateGone:
+					outcomes[m.Key()] = &ReapOutcome{Member: m, Outcome: OutcomeReaped,
+						Detail: "exited after " + step.sig.String()}
+				case StateStranger:
+					// The pid was reused after our signal, which means the
+					// process we owned is gone. Stop here — signalling the new
+					// occupant is exactly what this package exists to prevent.
+					outcomes[m.Key()] = &ReapOutcome{Member: m, Outcome: OutcomeReaped,
+						Detail: "exited; pid has since been reused"}
+				case StateUnknown:
+					outcomes[m.Key()] = &ReapOutcome{Member: m, Outcome: OutcomeNotSignalled,
+						Detail: "identity became unverifiable after " + step.sig.String()}
+				default:
+					stillOurs = append(stillOurs, m)
+				}
+			}
+			pending = stillOurs
+			if len(pending) == 0 || !time.Now().Before(deadline) {
+				break
+			}
+			opts.Sleep(opts.Poll)
+		}
+	}
+
+	for _, m := range pending {
+		outcomes[m.Key()] = &ReapOutcome{Member: m, Outcome: OutcomeStillAlive,
+			Detail: "survived SIGTERM and SIGKILL"}
+	}
+
+	report := ReapReport{}
+	var stillAlive, notSignalled int
+	for _, m := range ordered {
+		outcome := outcomes[m.Key()]
+		if outcome == nil {
+			// Unreachable in practice; recorded rather than dropped so a future
+			// change cannot silently lose a member from the report.
+			outcome = &ReapOutcome{Member: m, Outcome: OutcomeNotSignalled, Detail: "no outcome recorded"}
+		}
+		switch outcome.Outcome {
+		case OutcomeStillAlive:
+			stillAlive++
+		case OutcomeNotSignalled:
+			notSignalled++
+		}
+		report.Outcomes = append(report.Outcomes, *outcome)
+	}
+	switch {
+	case stillAlive > 0:
+		report.Verdict = VerdictOwned
+		report.Reason = fmt.Sprintf("%d owned process(es) survived SIGTERM and SIGKILL", stillAlive)
+	case notSignalled > 0:
+		report.Verdict = VerdictUnknown
+		report.Reason = fmt.Sprintf("%d recorded identity/identities could not be verified as ours and were left alone", notSignalled)
+	default:
+		report.Verdict = VerdictClear
+		report.Reason = "every recorded process is gone"
+	}
+	return report
+}
+
+// classifyBeforeSignal returns a terminal outcome when a member must not be
+// signalled, or nil when it verifies as ours.
+func classifyBeforeSignal(p Prober, m Member) *ReapOutcome {
+	status := VerifyMember(p, m)
+	switch status.State {
+	case StateGone:
+		return &ReapOutcome{Member: m, Outcome: OutcomeAlreadyGone, Detail: status.Detail}
+	case StateStranger:
+		// The recorded process exited and something else now holds its pid.
+		// Nothing to reap, and emphatically nothing to signal.
+		return &ReapOutcome{Member: m, Outcome: OutcomeAlreadyGone, Detail: status.Detail}
+	case StateUnknown:
+		return &ReapOutcome{Member: m, Outcome: OutcomeNotSignalled, Detail: status.Detail}
+	}
+	return nil
+}
+
+// classifySignalError turns a failed kill into an outcome. A process that
+// exited as we signalled it is reaped; a refusal is reported, never retried
+// harder.
+func classifySignalError(m Member, err error) *ReapOutcome {
+	switch {
+	case errors.Is(err, os.ErrProcessDone), errors.Is(err, syscall.ESRCH):
+		return &ReapOutcome{Member: m, Outcome: OutcomeReaped, Detail: "exited before the signal landed"}
+	case errors.Is(err, syscall.EPERM):
+		return &ReapOutcome{
+			Member:  m,
+			Outcome: OutcomeNotSignalled,
+			Detail:  "signal refused by the kernel (EPERM); the process is not ours to signal",
+		}
+	default:
+		return &ReapOutcome{Member: m, Outcome: OutcomeNotSignalled, Detail: "signal failed: " + err.Error()}
+	}
+}

--- a/internal/procowner/receipt.go
+++ b/internal/procowner/receipt.go
@@ -1,0 +1,235 @@
+// Package procowner implements the durable process-ownership receipt for
+// agent-deck sessions (#1873).
+//
+// # The contract
+//
+// A session launched through a wrapper can lose its tmux pane while the wrapped
+// process tree survives, reparented to PID 1. agent-deck then records the
+// session as errored, and a later legitimate restart spawns a SECOND tree
+// against the same instance, worktree and conversation. Nothing in the existing
+// sweeps sees the survivor: they walk a live pane tree (there is none) or scan
+// tmux sessions (the survivor is outside tmux).
+//
+// The maintainer ruling on #1873 fixes the primitive:
+//
+//   - the durable ownership receipt is the start-time + PID pair, recorded AT
+//     SPAWN;
+//   - the identity check is same PID AND same start time;
+//   - any mismatch is a stranger and must not be signalled;
+//   - no external provider and no new dependencies;
+//   - an unverifiable process is reported as unknown and left alone.
+//
+// "At spawn" is the whole point. Reading a process's start time at sweep or
+// kill time proves only that the pid did not change hands between the read and
+// the signal; it says nothing about whether we ever owned that process. A
+// receipt written while the process is provably ours is what turns a pid into
+// ownership.
+//
+// # Leader and members
+//
+// The leader is the pane's initial process, captured the instant tmux reports
+// it. Members are its descendants, each recorded with its own start identity
+// while it is still attributable — that is, while it is reachable from the
+// verified-live leader by a parent walk. Attribution is only ever performed
+// during the spawn window and only downward from a leader whose identity still
+// matches the receipt; the sweep and kill paths never extend a receipt, they
+// only verify it. A member's recorded start identity must additionally be no
+// older than the leader's, because a descendant of a process cannot have
+// started before it — a cheap invariant that keeps a mid-scan pid recycle from
+// widening the receipt.
+//
+// A process that detaches (setsid) AND outlives its whole recorded ancestry
+// before any attribution pass observes it is, by construction, not attributable
+// to a PID+start-time receipt. Such a process is never recorded and therefore
+// never signalled: unowned, not "owned by guess". Closing that last gap needs a
+// containment primitive (cgroup/job object), which the ruling explicitly did
+// not take.
+package procowner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ReceiptVersion is the on-disk schema version. A receipt written by a newer
+// version is refused rather than reinterpreted: a half-understood receipt is
+// exactly the "ambiguous identity" case the contract says to fail closed on.
+const ReceiptVersion = 1
+
+// Receipt states. A cleared receipt is an absent file, never a state value, so
+// there is no way to leave a tombstone that later reads as ownership.
+const (
+	// StateLive means the recorded identities were owned by this instance at
+	// the moment the receipt was committed.
+	StateLive = "live"
+	// StateReaping is written before the first signal and cleared after death
+	// is verified, so a crash mid-reap is recoverable rather than silent.
+	StateReaping = "reaping"
+	// StateRecoveryRequired means verification could not prove the receipt
+	// either dead or ours. Nothing is signalled in this state.
+	StateRecoveryRequired = "recovery_required"
+)
+
+// Member roles.
+const (
+	RoleLeader     = "leader"
+	RoleDescendant = "descendant"
+)
+
+// ErrCorruptReceipt is returned when a receipt exists but cannot be understood:
+// truncated JSON, an unknown schema version, a missing identity. It is a
+// fail-closed signal, never a licence to treat the receipt as absent.
+var ErrCorruptReceipt = errors.New("ownership receipt is unreadable or incomplete")
+
+// Member is one owned process: a PID bound to a start identity. Neither half is
+// ownership on its own — a PID is reused, and a start identity without its PID
+// names nothing.
+type Member struct {
+	PID int `json:"pid"`
+	// StartID is the platform's process start identity (Linux: the start time
+	// in clock ticks since boot, from /proc/<pid>/stat field 22).
+	StartID string `json:"start_id"`
+	PGID    int    `json:"pgid,omitempty"`
+	// UID is the owning uid at capture time. It is not part of the identity
+	// ruling; it is a strictly narrowing guard, so a PID whose process now runs
+	// as a different user is reported unknown instead of signalled.
+	UID  int    `json:"uid"`
+	Comm string `json:"comm,omitempty"`
+	Role string `json:"role,omitempty"`
+	// SeenAt is when this identity was captured (unix seconds), for diagnostics.
+	SeenAt int64 `json:"seen_at,omitempty"`
+}
+
+// Key identifies a member for de-duplication.
+func (m Member) Key() string { return fmt.Sprintf("%d/%s", m.PID, m.StartID) }
+
+func (m Member) valid() bool {
+	return m.PID > 1 && strings.TrimSpace(m.StartID) != ""
+}
+
+// String renders a member for operator-facing output.
+func (m Member) String() string {
+	role := m.Role
+	if role == "" {
+		role = RoleDescendant
+	}
+	return fmt.Sprintf("pid=%d start=%s uid=%d role=%s", m.PID, m.StartID, m.UID, role)
+}
+
+// Receipt is the durable record of what a spawn took ownership of.
+type Receipt struct {
+	Version    int    `json:"version"`
+	InstanceID string `json:"instance_id"`
+	// Generation increases by one per committed spawn. It is the compare-and-
+	// swap token: a writer from a superseded spawn cannot overwrite a newer
+	// receipt, which is what keeps two racing restarts from interleaving.
+	Generation uint64 `json:"generation"`
+	State      string `json:"state"`
+	// Provider names the identity source, so a receipt written by /proc is
+	// never verified against something else's notion of a start identity.
+	Provider string `json:"provider"`
+	// BootID scopes every start identity to one boot. Start times are measured
+	// from boot, so without this a receipt from a previous boot could match a
+	// present-day PID by coincidence. A boot mismatch instead proves every
+	// recorded identity is gone.
+	BootID     string   `json:"boot_id"`
+	TmuxName   string   `json:"tmux_name,omitempty"`
+	TmuxSocket string   `json:"tmux_socket,omitempty"`
+	Command    string   `json:"command,omitempty"`
+	CreatedAt  int64    `json:"created_at"`
+	UpdatedAt  int64    `json:"updated_at,omitempty"`
+	Leader     Member   `json:"leader"`
+	Members    []Member `json:"members,omitempty"`
+	// Note carries the last verification reason for operator surfaces.
+	Note string `json:"note,omitempty"`
+}
+
+// All returns the leader followed by every member, de-duplicated by identity.
+// Callers signal in reverse order so descendants are reaped before the leader.
+func (r *Receipt) All() []Member {
+	if r == nil {
+		return nil
+	}
+	out := make([]Member, 0, len(r.Members)+1)
+	seen := make(map[string]bool, len(r.Members)+1)
+	if r.Leader.valid() {
+		out = append(out, r.Leader)
+		seen[r.Leader.Key()] = true
+	}
+	for _, m := range r.Members {
+		if !m.valid() || seen[m.Key()] {
+			continue
+		}
+		seen[m.Key()] = true
+		out = append(out, m)
+	}
+	return out
+}
+
+// HasMember reports whether the identity is already recorded.
+func (r *Receipt) HasMember(m Member) bool {
+	for _, existing := range r.All() {
+		if existing.Key() == m.Key() {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate enforces every field the verifier depends on. Anything missing means
+// the receipt cannot be checked, and an uncheckable receipt is not evidence of
+// non-ownership.
+func (r *Receipt) Validate() error {
+	switch {
+	case r == nil:
+		return fmt.Errorf("%w: nil receipt", ErrCorruptReceipt)
+	case r.Version != ReceiptVersion:
+		return fmt.Errorf("%w: unsupported version %d", ErrCorruptReceipt, r.Version)
+	case strings.TrimSpace(r.InstanceID) == "":
+		return fmt.Errorf("%w: missing instance id", ErrCorruptReceipt)
+	case strings.TrimSpace(r.Provider) == "":
+		return fmt.Errorf("%w: missing provider", ErrCorruptReceipt)
+	case strings.TrimSpace(r.BootID) == "":
+		return fmt.Errorf("%w: missing boot id", ErrCorruptReceipt)
+	case !r.Leader.valid():
+		return fmt.Errorf("%w: leader identity is incomplete", ErrCorruptReceipt)
+	}
+	switch r.State {
+	case StateLive, StateReaping, StateRecoveryRequired:
+	default:
+		return fmt.Errorf("%w: unknown state %q", ErrCorruptReceipt, r.State)
+	}
+	for idx, m := range r.Members {
+		if !m.valid() {
+			return fmt.Errorf("%w: member %d identity is incomplete", ErrCorruptReceipt, idx)
+		}
+	}
+	return nil
+}
+
+// Encode renders a receipt for durable storage.
+func Encode(r *Receipt) ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// Decode parses a receipt, refusing anything it cannot fully understand.
+//
+// A truncated write, a half-written file recovered from a crash, or a receipt
+// from a future schema all land on ErrCorruptReceipt. Callers must treat that
+// as "ownership is ambiguous", not as "there is no receipt": the difference is
+// the difference between blocking a restart and spawning a duplicate.
+func Decode(data []byte) (*Receipt, error) {
+	var r Receipt
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCorruptReceipt, err)
+	}
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/internal/procowner/receipt_store_test.go
+++ b/internal/procowner/receipt_store_test.go
@@ -177,6 +177,28 @@ func TestStore_CorruptReceiptSurfacesAsAnError(t *testing.T) {
 	require.NotNil(t, loaded)
 }
 
+func TestStore_ClearPreservesCorruptReceiptForExplicitAbandon(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, NoCrossProcessLock)
+	path := filepath.Join(dir, "inst-1.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"version":1,"inst`), 0o600))
+
+	err := store.Clear(liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader}))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCorruptReceipt)
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr, "ordinary clear must retain unreadable evidence")
+	require.NoError(t, store.ForceClear("inst-1"))
+	_, statErr = os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "explicit abandon is allowed to discard it")
+}
+
+func TestNewStore_RequiresExplicitLockChoice(t *testing.T) {
+	assert.PanicsWithValue(t, "procowner: NewStore needs a lock; pass NoCrossProcessLock to opt out", func() {
+		NewStore(t.TempDir(), nil)
+	})
+}
+
 func TestStore_ReceiptForAnotherInstanceIsRefused(t *testing.T) {
 	dir := t.TempDir()
 	store := NewStore(dir, NoCrossProcessLock)
@@ -256,8 +278,10 @@ func TestClaim_RecordsLeaderIdentityAtSpawn(t *testing.T) {
 func TestClaim_RefusesWhatItCannotProve(t *testing.T) {
 	p := newFakeProber()
 	p.add(100, 1, "5000", 1000)
+	_, err := Claim(p, ClaimInput{PanePID: 100})
+	require.Error(t, err, "an empty instance id must fail before an unusable receipt is returned")
 
-	_, err := Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 0})
+	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 0})
 	require.Error(t, err)
 
 	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 1})
@@ -275,6 +299,35 @@ func TestClaim_RefusesWhatItCannotProve(t *testing.T) {
 	p.bootErr = errors.New("no boot id")
 	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 100})
 	require.Error(t, err, "without a boot id every start identity is ambiguous")
+
+	p = newFakeProber()
+	p.add(100, 1, "", 1000)
+	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 100})
+	require.Error(t, err, "an empty start identity must fail at claim time")
+}
+
+func TestAttribute_RefusesLeaderReusedBetweenVerificationAndWalk(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 1, PanePID: 100})
+	require.NoError(t, err)
+
+	reads := 0
+	p.onInspect = func(pid int) {
+		if pid != 100 {
+			return
+		}
+		reads++
+		if reads == 2 {
+			p.remove(100)
+			p.add(100, 1, "9999", 1000)
+			p.add(103, 100, "10000", 1000)
+		}
+	}
+	added, err := Attribute(p, receipt, nil)
+	require.Error(t, err)
+	assert.Empty(t, added)
+	assert.Empty(t, receipt.Members, "a recycled leader's tree must never be attributed")
 }
 
 func TestAttribute_RecordsLiveDescendants(t *testing.T) {

--- a/internal/procowner/receipt_store_test.go
+++ b/internal/procowner/receipt_store_test.go
@@ -67,14 +67,14 @@ func mutate(t *testing.T, data []byte, fn func(map[string]any)) []byte {
 }
 
 func TestStore_SaveLoadClear(t *testing.T) {
-	store := NewStore(t.TempDir())
+	store := NewStore(t.TempDir(), NoCrossProcessLock)
 	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
 
 	loaded, err := store.Load("inst-1")
 	require.NoError(t, err)
 	assert.Nil(t, loaded, "no receipt is not an error")
 
-	require.NoError(t, store.Save(receipt))
+	require.NoError(t, commit(store, receipt))
 	loaded, err = store.Load("inst-1")
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
@@ -88,8 +88,8 @@ func TestStore_SaveLoadClear(t *testing.T) {
 
 func TestStore_ReceiptsAreWrittenPrivate(t *testing.T) {
 	dir := t.TempDir()
-	store := NewStore(filepath.Join(dir, "ownership"))
-	require.NoError(t, store.Save(liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})))
+	store := NewStore(filepath.Join(dir, "ownership"), NoCrossProcessLock)
+	require.NoError(t, commit(store, liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})))
 
 	path, err := store.Path("inst-1")
 	require.NoError(t, err)
@@ -101,14 +101,14 @@ func TestStore_ReceiptsAreWrittenPrivate(t *testing.T) {
 // Two restarts racing: the loser's write must not land on top of the winner's
 // receipt, and its late clear must not delete the winner's.
 func TestStore_GenerationConflictsAreRefused(t *testing.T) {
-	store := NewStore(t.TempDir())
+	store := NewStore(t.TempDir(), NoCrossProcessLock)
 	newer := liveReceipt("inst-1", Member{PID: 200, StartID: "6000", UID: 1000, Role: RoleLeader})
 	newer.Generation = 5
-	require.NoError(t, store.Save(newer))
+	require.NoError(t, commit(store, newer))
 
 	stale := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
 	stale.Generation = 4
-	err := store.Save(stale)
+	err := commit(store, stale)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrGenerationConflict))
 
@@ -120,7 +120,12 @@ func TestStore_GenerationConflictsAreRefused(t *testing.T) {
 	// already reaped and replaced must not overwrite or delete the live one.
 	sameGen := liveReceipt("inst-1", Member{PID: 300, StartID: "7000", UID: 1000, Role: RoleLeader})
 	sameGen.Generation = 5
-	err = store.Save(sameGen)
+	err = commit(store, sameGen)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrGenerationConflict))
+	err = store.Update("inst-1", func(current *Receipt) error {
+		return RequireGeneration(current, sameGen.Generation, sameGen.Leader)
+	})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrGenerationConflict))
 	err = store.Clear(sameGen)
@@ -134,12 +139,14 @@ func TestStore_GenerationConflictsAreRefused(t *testing.T) {
 }
 
 func TestStore_SameGenerationMayAddMembers(t *testing.T) {
-	store := NewStore(t.TempDir())
+	store := NewStore(t.TempDir(), NoCrossProcessLock)
 	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
-	require.NoError(t, store.Save(receipt))
+	require.NoError(t, commit(store, receipt))
 
-	receipt.Members = append(receipt.Members, Member{PID: 101, StartID: "5100", UID: 1000, Role: RoleDescendant})
-	require.NoError(t, store.Save(receipt))
+	require.NoError(t, store.Update("inst-1", func(current *Receipt) error {
+		current.Members = append(current.Members, Member{PID: 101, StartID: "5100", UID: 1000, Role: RoleDescendant})
+		return nil
+	}))
 
 	loaded, err := store.Load("inst-1")
 	require.NoError(t, err)
@@ -148,7 +155,7 @@ func TestStore_SameGenerationMayAddMembers(t *testing.T) {
 
 func TestStore_CorruptReceiptSurfacesAsAnError(t *testing.T) {
 	dir := t.TempDir()
-	store := NewStore(dir)
+	store := NewStore(dir, NoCrossProcessLock)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "inst-1.json"), []byte(`{"version":1,"inst`), 0o600))
 
 	_, err := store.Load("inst-1")
@@ -157,10 +164,14 @@ func TestStore_CorruptReceiptSurfacesAsAnError(t *testing.T) {
 
 	// A fresh spawn still gets a usable generation, and its write replaces the
 	// unreadable file rather than being blocked by it.
-	gen, err := store.NextGeneration("inst-1")
+	var seen *Receipt
+	fresh, err := store.Commit("inst-1", func(existing *Receipt) (*Receipt, error) {
+		seen = existing
+		return liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader}), nil
+	})
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), gen)
-	require.NoError(t, store.Save(liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})))
+	assert.Nil(t, seen, "an unreadable receipt cannot claim a generation")
+	assert.Equal(t, uint64(1), fresh.Generation)
 	loaded, err := store.Load("inst-1")
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
@@ -168,7 +179,7 @@ func TestStore_CorruptReceiptSurfacesAsAnError(t *testing.T) {
 
 func TestStore_ReceiptForAnotherInstanceIsRefused(t *testing.T) {
 	dir := t.TempDir()
-	store := NewStore(dir)
+	store := NewStore(dir, NoCrossProcessLock)
 	data, err := Encode(liveReceipt("inst-2", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader}))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "inst-1.json"), data, 0o600))
@@ -179,7 +190,7 @@ func TestStore_ReceiptForAnotherInstanceIsRefused(t *testing.T) {
 }
 
 func TestStore_RefusesInstanceIDsThatEscapeTheDirectory(t *testing.T) {
-	store := NewStore(t.TempDir())
+	store := NewStore(t.TempDir(), NoCrossProcessLock)
 	for _, id := range []string{"", "..", "../escape", "a/b", `a\b`, "."} {
 		_, err := store.Path(id)
 		require.Error(t, err, "id %q must be refused", id)
@@ -187,19 +198,44 @@ func TestStore_RefusesInstanceIDsThatEscapeTheDirectory(t *testing.T) {
 	}
 }
 
-func TestStore_NextGenerationIncrements(t *testing.T) {
-	store := NewStore(t.TempDir())
-	gen, err := store.NextGeneration("inst-1")
-	require.NoError(t, err)
-	assert.Equal(t, uint64(1), gen)
+// Commit hands the builder whatever is on disk and writes what it returns, all
+// inside one critical section — so a generation is chosen against state that
+// cannot change before the write lands.
+func TestStore_CommitSeesTheCurrentReceipt(t *testing.T) {
+	store := NewStore(t.TempDir(), NoCrossProcessLock)
 
-	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
-	receipt.Generation = gen
-	require.NoError(t, store.Save(receipt))
-
-	gen, err = store.NextGeneration("inst-1")
+	first, err := store.Commit("inst-1", func(existing *Receipt) (*Receipt, error) {
+		assert.Nil(t, existing)
+		return liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader}), nil
+	})
 	require.NoError(t, err)
-	assert.Equal(t, uint64(2), gen)
+	assert.Equal(t, uint64(1), first.Generation)
+
+	second, err := store.Commit("inst-1", func(existing *Receipt) (*Receipt, error) {
+		require.NotNil(t, existing)
+		next := liveReceipt("inst-1", Member{PID: 200, StartID: "6000", UID: 1000, Role: RoleLeader})
+		next.Generation = existing.Generation + 1
+		return next, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), second.Generation)
+
+	// A builder that declines leaves the receipt untouched: no claim is always
+	// safer than a claim that could not be substantiated.
+	_, err = store.Commit("inst-1", func(*Receipt) (*Receipt, error) {
+		return nil, errors.New("cannot substantiate this claim")
+	})
+	require.Error(t, err)
+	loaded, err := store.Load("inst-1")
+	require.NoError(t, err)
+	assert.Equal(t, 200, loaded.Leader.PID)
+}
+
+// commit writes a prepared receipt through the commit path, for tests that care
+// about the CAS rules rather than about generation selection.
+func commit(store *Store, r *Receipt) error {
+	_, err := store.Commit(r.InstanceID, func(*Receipt) (*Receipt, error) { return r, nil })
+	return err
 }
 
 func TestClaim_RecordsLeaderIdentityAtSpawn(t *testing.T) {

--- a/internal/procowner/receipt_store_test.go
+++ b/internal/procowner/receipt_store_test.go
@@ -1,0 +1,338 @@
+package procowner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReceipt_RoundTrip(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	child := p.add(101, 100, "5100", 1000)
+	original := liveReceipt("inst-1", memberOf(leader, RoleLeader), memberOf(child, RoleDescendant))
+
+	data, err := Encode(original)
+	require.NoError(t, err)
+	decoded, err := Decode(data)
+	require.NoError(t, err)
+	assert.Equal(t, original.Leader, decoded.Leader)
+	assert.Equal(t, original.Members, decoded.Members)
+	assert.Equal(t, original.BootID, decoded.BootID)
+}
+
+// A receipt that cannot be parsed is NOT the same as no receipt. Folding the
+// two together is how a truncated file becomes a duplicate process tree.
+func TestDecode_RejectsUnusableReceipts(t *testing.T) {
+	valid, err := Encode(liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader}))
+	require.NoError(t, err)
+
+	cases := map[string][]byte{
+		"truncated":       valid[:len(valid)/2],
+		"empty":           {},
+		"not json":        []byte("this is not a receipt"),
+		"json null":       []byte("null"),
+		"missing leader":  mutate(t, valid, func(m map[string]any) { delete(m, "leader") }),
+		"leader pid zero": mutate(t, valid, func(m map[string]any) { m["leader"] = map[string]any{"start_id": "5000"} }),
+		"no start id":     mutate(t, valid, func(m map[string]any) { m["leader"] = map[string]any{"pid": 100} }),
+		"missing boot id": mutate(t, valid, func(m map[string]any) { delete(m, "boot_id") }),
+		"future version":  mutate(t, valid, func(m map[string]any) { m["version"] = ReceiptVersion + 1 }),
+		"unknown state":   mutate(t, valid, func(m map[string]any) { m["state"] = "whatever" }),
+		"no instance id":  mutate(t, valid, func(m map[string]any) { delete(m, "instance_id") }),
+		"no provider":     mutate(t, valid, func(m map[string]any) { delete(m, "provider") }),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Decode(data)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrCorruptReceipt), "want ErrCorruptReceipt, got %v", err)
+		})
+	}
+}
+
+func mutate(t *testing.T, data []byte, fn func(map[string]any)) []byte {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	fn(m)
+	out, err := json.Marshal(m)
+	require.NoError(t, err)
+	return out
+}
+
+func TestStore_SaveLoadClear(t *testing.T) {
+	store := NewStore(t.TempDir())
+	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
+
+	loaded, err := store.Load("inst-1")
+	require.NoError(t, err)
+	assert.Nil(t, loaded, "no receipt is not an error")
+
+	require.NoError(t, store.Save(receipt))
+	loaded, err = store.Load("inst-1")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, uint64(1), loaded.Generation)
+
+	require.NoError(t, store.Clear(receipt))
+	loaded, err = store.Load("inst-1")
+	require.NoError(t, err)
+	assert.Nil(t, loaded)
+}
+
+func TestStore_ReceiptsAreWrittenPrivate(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "ownership"))
+	require.NoError(t, store.Save(liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})))
+
+	path, err := store.Path("inst-1")
+	require.NoError(t, err)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+// Two restarts racing: the loser's write must not land on top of the winner's
+// receipt, and its late clear must not delete the winner's.
+func TestStore_GenerationConflictsAreRefused(t *testing.T) {
+	store := NewStore(t.TempDir())
+	newer := liveReceipt("inst-1", Member{PID: 200, StartID: "6000", UID: 1000, Role: RoleLeader})
+	newer.Generation = 5
+	require.NoError(t, store.Save(newer))
+
+	stale := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
+	stale.Generation = 4
+	err := store.Save(stale)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrGenerationConflict))
+
+	err = store.Clear(stale)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrGenerationConflict))
+
+	// Same generation, different leader: a stale writer whose receipt was
+	// already reaped and replaced must not overwrite or delete the live one.
+	sameGen := liveReceipt("inst-1", Member{PID: 300, StartID: "7000", UID: 1000, Role: RoleLeader})
+	sameGen.Generation = 5
+	err = store.Save(sameGen)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrGenerationConflict))
+	err = store.Clear(sameGen)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrGenerationConflict))
+
+	loaded, err := store.Load("inst-1")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, 200, loaded.Leader.PID, "the winner's receipt survived both stale writers")
+}
+
+func TestStore_SameGenerationMayAddMembers(t *testing.T) {
+	store := NewStore(t.TempDir())
+	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
+	require.NoError(t, store.Save(receipt))
+
+	receipt.Members = append(receipt.Members, Member{PID: 101, StartID: "5100", UID: 1000, Role: RoleDescendant})
+	require.NoError(t, store.Save(receipt))
+
+	loaded, err := store.Load("inst-1")
+	require.NoError(t, err)
+	require.Len(t, loaded.Members, 1)
+}
+
+func TestStore_CorruptReceiptSurfacesAsAnError(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inst-1.json"), []byte(`{"version":1,"inst`), 0o600))
+
+	_, err := store.Load("inst-1")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCorruptReceipt))
+
+	// A fresh spawn still gets a usable generation, and its write replaces the
+	// unreadable file rather than being blocked by it.
+	gen, err := store.NextGeneration("inst-1")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), gen)
+	require.NoError(t, store.Save(liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})))
+	loaded, err := store.Load("inst-1")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+}
+
+func TestStore_ReceiptForAnotherInstanceIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	data, err := Encode(liveReceipt("inst-2", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader}))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inst-1.json"), data, 0o600))
+
+	_, err = store.Load("inst-1")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCorruptReceipt))
+}
+
+func TestStore_RefusesInstanceIDsThatEscapeTheDirectory(t *testing.T) {
+	store := NewStore(t.TempDir())
+	for _, id := range []string{"", "..", "../escape", "a/b", `a\b`, "."} {
+		_, err := store.Path(id)
+		require.Error(t, err, "id %q must be refused", id)
+		assert.True(t, errors.Is(err, ErrBadInstanceID))
+	}
+}
+
+func TestStore_NextGenerationIncrements(t *testing.T) {
+	store := NewStore(t.TempDir())
+	gen, err := store.NextGeneration("inst-1")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), gen)
+
+	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
+	receipt.Generation = gen
+	require.NoError(t, store.Save(receipt))
+
+	gen, err = store.NextGeneration("inst-1")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), gen)
+}
+
+func TestClaim_RecordsLeaderIdentityAtSpawn(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 3, PanePID: 100, TmuxName: "sess"})
+	require.NoError(t, err)
+	assert.Equal(t, 100, receipt.Leader.PID)
+	assert.Equal(t, "5000", receipt.Leader.StartID)
+	assert.Equal(t, RoleLeader, receipt.Leader.Role)
+	assert.Equal(t, "boot-1", receipt.BootID)
+	assert.Equal(t, StateLive, receipt.State)
+	assert.Equal(t, uint64(3), receipt.Generation)
+	require.NoError(t, receipt.Validate())
+}
+
+func TestClaim_RefusesWhatItCannotProve(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+
+	_, err := Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 0})
+	require.Error(t, err)
+
+	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 1})
+	require.Error(t, err, "pid 1 is never ours")
+
+	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: os.Getpid()})
+	require.Error(t, err, "agent-deck must never claim itself")
+
+	// A pane process that exited between tmux start and the probe: no receipt,
+	// rather than a receipt naming a pid we cannot substantiate.
+	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 999})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoProcess))
+
+	p.bootErr = errors.New("no boot id")
+	_, err = Claim(p, ClaimInput{InstanceID: "inst-1", PanePID: 100})
+	require.Error(t, err, "without a boot id every start identity is ambiguous")
+}
+
+func TestAttribute_RecordsLiveDescendants(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+	p.add(101, 100, "5100", 1000)
+	p.add(102, 101, "5200", 1000)
+
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 1, PanePID: 100})
+	require.NoError(t, err)
+	added, err := Attribute(p, receipt, nil)
+	require.NoError(t, err)
+	require.Len(t, added, 2)
+	assert.Equal(t, "5100", added[0].StartID)
+	assert.Equal(t, RoleDescendant, added[0].Role)
+
+	// Idempotent: a second pass adds nothing new.
+	added, err = Attribute(p, receipt, nil)
+	require.NoError(t, err)
+	assert.Empty(t, added)
+	assert.Len(t, receipt.Members, 2)
+}
+
+// Attribution walks DOWN from a leader that still verifies. Once the leader is
+// gone — or its pid has been reused — nothing reachable from that pid is ours.
+func TestAttribute_RefusesWhenTheLeaderIsNotOurs(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 1, PanePID: 100})
+	require.NoError(t, err)
+
+	p.remove(100)
+	p.add(100, 1, "9999", 1000)   // reused pid
+	p.add(103, 100, "9999", 1000) // the stranger's own child
+
+	added, err := Attribute(p, receipt, nil)
+	require.Error(t, err)
+	assert.Empty(t, added)
+	assert.Empty(t, receipt.Members, "a stranger's children are never recorded as ours")
+}
+
+// A "descendant" that started before its ancestor cannot be one. This is the
+// cheap invariant that keeps a mid-scan pid recycle from widening a receipt.
+func TestAttribute_DropsDescendantsOlderThanTheLeader(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+	p.add(101, 100, "4000", 1000) // impossible: started before the leader
+	p.add(102, 100, "5100", 1000)
+
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 1, PanePID: 100})
+	require.NoError(t, err)
+	added, err := Attribute(p, receipt, nil)
+	require.NoError(t, err)
+	require.Len(t, added, 1)
+	assert.Equal(t, 102, added[0].PID)
+}
+
+func TestAttribute_ProviderMismatchIsRefused(t *testing.T) {
+	p := newFakeProber()
+	p.add(100, 1, "5000", 1000)
+	receipt, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 1, PanePID: 100})
+	require.NoError(t, err)
+	receipt.Provider = "elsewhere"
+
+	_, err = Attribute(p, receipt, nil)
+	require.Error(t, err)
+}
+
+func TestUnsupportedProviderClaimsNothing(t *testing.T) {
+	p := unsupportedProber{}
+	_, err := Claim(p, ClaimInput{InstanceID: "inst-1", Generation: 1, PanePID: 100})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnsupported),
+		"a platform with no start identity must record no ownership at all")
+
+	// And a receipt written elsewhere is never actioned here.
+	receipt := liveReceipt("inst-1", Member{PID: 100, StartID: "5000", UID: 1000, Role: RoleLeader})
+	sig := newRecordingSignaler()
+	report := Reap(p, sig, receipt, fastReapOptions())
+	assert.Empty(t, sig.calls())
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+}
+
+// unsupportedProber mirrors the real no-provider platform build without needing
+// to cross-compile: every call fails with ErrUnsupported.
+type unsupportedProber struct{}
+
+func (unsupportedProber) Name() string { return "unsupported" }
+func (unsupportedProber) BootID() (string, error) {
+	return "", fmt.Errorf("%w: boot id", ErrUnsupported)
+}
+func (unsupportedProber) Inspect(int) (ProcInfo, error) {
+	return ProcInfo{}, fmt.Errorf("%w: inspect", ErrUnsupported)
+}
+func (unsupportedProber) Descendants(ProcInfo) ([]ProcInfo, error) {
+	return nil, fmt.Errorf("%w: descendants", ErrUnsupported)
+}

--- a/internal/procowner/store.go
+++ b/internal/procowner/store.go
@@ -1,0 +1,200 @@
+package procowner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/asheshgoplani/agent-deck/internal/safeio"
+)
+
+// ErrGenerationConflict is returned when a write would overwrite a receipt from
+// a newer spawn. It is how two racing restarts are kept from interleaving: the
+// loser's write is refused, not silently applied on top of the winner's.
+var ErrGenerationConflict = errors.New("ownership receipt was superseded by a newer generation")
+
+// ErrBadInstanceID rejects an instance id that cannot be a single path element.
+var ErrBadInstanceID = errors.New("invalid instance id for an ownership receipt")
+
+// Store persists receipts as one file per instance.
+//
+// A file, not a row: the receipt has to be readable and writable by a different
+// agent-deck process from the one that wrote it (a CLI restart reconciling what
+// a TUI spawned), and it has to survive a crash mid-write. safeio's temp →
+// fsync → rename gives that without a schema migration or a new dependency.
+type Store struct {
+	dir string
+	mu  sync.Mutex
+}
+
+// NewStore returns a store rooted at dir.
+func NewStore(dir string) *Store { return &Store{dir: dir} }
+
+// Dir returns the store's root directory.
+func (s *Store) Dir() string { return s.dir }
+
+// Path returns the receipt path for an instance.
+func (s *Store) Path(instanceID string) (string, error) {
+	id := strings.TrimSpace(instanceID)
+	// The id becomes a filename, so anything that could climb out of the
+	// directory is refused rather than sanitised into something that still
+	// resolves somewhere unexpected.
+	if id == "" || id != filepath.Base(id) || id == "." || id == ".." || strings.ContainsAny(id, `/\`) {
+		return "", fmt.Errorf("%w: %q", ErrBadInstanceID, instanceID)
+	}
+	return filepath.Join(s.dir, id+".json"), nil
+}
+
+// Load returns the receipt for an instance, (nil, nil) when there is none, or
+// ErrCorruptReceipt when one exists but cannot be trusted.
+//
+// The corrupt case is deliberately NOT folded into "no receipt". A truncated
+// receipt is a session whose ownership we recorded and can no longer read;
+// treating that as "nothing was owned" is how a duplicate tree gets spawned.
+func (s *Store) Load(instanceID string) (*Receipt, error) {
+	path, err := s.Path(instanceID)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return loadFrom(path, instanceID)
+}
+
+func loadFrom(path, instanceID string) (*Receipt, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: read %s: %v", ErrCorruptReceipt, path, err)
+	}
+	r, err := Decode(data)
+	if err != nil {
+		return nil, err
+	}
+	if r.InstanceID != instanceID {
+		return nil, fmt.Errorf("%w: receipt at %s belongs to instance %q, not %q",
+			ErrCorruptReceipt, path, r.InstanceID, instanceID)
+	}
+	return r, nil
+}
+
+// Save writes a receipt, refusing to overwrite a newer generation.
+//
+// Equal generations are allowed to rewrite: that is how the attribution pass
+// adds members to the receipt it just committed. A lower generation is refused
+// — that writer belongs to a superseded spawn.
+func (s *Store) Save(r *Receipt) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	path, err := s.Path(r.InstanceID)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, loadErr := loadFrom(path, r.InstanceID)
+	switch {
+	case loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt):
+		return loadErr
+	case loadErr != nil:
+		// A corrupt receipt on disk cannot report a generation, so it cannot
+		// claim to be newer. Replacing it with a valid one is strictly an
+		// improvement — and the spawn lock means only one writer is here.
+	case existing != nil && existing.Generation > r.Generation:
+		return fmt.Errorf("%w: on disk %d, writing %d",
+			ErrGenerationConflict, existing.Generation, r.Generation)
+	case existing != nil && existing.Generation == r.Generation &&
+		existing.Leader.Key() != r.Leader.Key():
+		// Same generation, different leader: two different spawns. Generations
+		// restart at 1 once a receipt has been verifiably cleared (a cleared
+		// receipt is an absent file, by design — a tombstone would be a second
+		// claim of ownership sitting next to the live one), so the number alone
+		// cannot tell a stale writer from the current one. The leader identity
+		// can, and it is already the thing that defines the receipt. This is
+		// what stops an attribution pass from a reaped generation, still alive
+		// in another process, from overwriting the receipt of the spawn that
+		// replaced it.
+		return fmt.Errorf("%w: generation %d on disk is owned by %s, not %s",
+			ErrGenerationConflict, existing.Generation, existing.Leader, r.Leader)
+	}
+
+	data, err := Encode(r)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("create ownership dir: %w", err)
+	}
+	// SkipBackup: a stale .bak receipt is worse than no receipt — it would be a
+	// second, older claim of ownership sitting next to the live one.
+	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o600, SkipBackup: true})
+}
+
+// NextGeneration returns the generation a new spawn should commit under: one
+// more than whatever is on disk. A corrupt receipt is counted as generation 0
+// so the fresh receipt still supersedes it.
+func (s *Store) NextGeneration(instanceID string) (uint64, error) {
+	existing, err := s.Load(instanceID)
+	if err != nil && !errors.Is(err, ErrCorruptReceipt) {
+		return 0, err
+	}
+	if existing == nil {
+		return 1, nil
+	}
+	return existing.Generation + 1, nil
+}
+
+// Clear removes a receipt the caller has verified as retired.
+//
+// It takes the receipt rather than an id so the same two checks that guard Save
+// guard the delete: a newer generation is never removed by an older caller, and
+// a receipt belonging to a different leader is never removed by a stale one. A
+// late clear from a superseded spawn must not delete the live receipt of the
+// spawn that replaced it.
+func (s *Store) Clear(r *Receipt) error {
+	if r == nil {
+		return errors.New("procowner: clear needs the receipt it is retiring")
+	}
+	path, err := s.Path(r.InstanceID)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, loadErr := loadFrom(path, r.InstanceID)
+	if loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt) {
+		return loadErr
+	}
+	if existing != nil {
+		if existing.Generation > r.Generation {
+			return fmt.Errorf("%w: on disk %d, clearing %d",
+				ErrGenerationConflict, existing.Generation, r.Generation)
+		}
+		if existing.Generation == r.Generation && existing.Leader.Key() != r.Leader.Key() {
+			return fmt.Errorf("%w: generation %d on disk is owned by %s, not %s",
+				ErrGenerationConflict, existing.Generation, existing.Leader, r.Leader)
+		}
+	}
+	return safeio.SafeRemove(path, safeio.RemoveOptions{})
+}
+
+// ForceClear removes the receipt regardless of generation. Reserved for the
+// explicit operator abandon path, which is the only place where discarding an
+// unverifiable claim is a decision a human has made.
+func (s *Store) ForceClear(instanceID string) error {
+	path, err := s.Path(instanceID)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return safeio.SafeRemove(path, safeio.RemoveOptions{})
+}

--- a/internal/procowner/store.go
+++ b/internal/procowner/store.go
@@ -6,32 +6,75 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/asheshgoplani/agent-deck/internal/safeio"
 )
 
 // ErrGenerationConflict is returned when a write would overwrite a receipt from
-// a newer spawn. It is how two racing restarts are kept from interleaving: the
-// loser's write is refused, not silently applied on top of the winner's.
+// a newer spawn, or from a different spawn of the same generation. It is how
+// two racing restarts are kept from interleaving: the loser's write is refused,
+// not silently applied on top of the winner's.
 var ErrGenerationConflict = errors.New("ownership receipt was superseded by a newer generation")
+
+// ErrReceiptGone is returned when an update finds no receipt to update.
+//
+// This is the resurrection guard. An attribution pass that started before a
+// teardown can still be in flight when the receipt is cleared; if that pass
+// were allowed to WRITE, a receipt that was verifiably retired would come back
+// from the dead — and everything downstream trusts a receipt. An update is
+// therefore never a create.
+var ErrReceiptGone = errors.New("ownership receipt was cleared while this update was in flight")
+
+// ErrWindowClosed is returned when a caller's own cancellation check fires
+// under the store lock, so a cancelled writer's in-flight write is dropped
+// rather than applied.
+var ErrWindowClosed = errors.New("ownership update was cancelled before it could be applied")
+
+// ErrNoChange lets an update's mutator say "nothing to write" without that
+// being an error at the call site.
+var ErrNoChange = errors.New("ownership receipt unchanged")
 
 // ErrBadInstanceID rejects an instance id that cannot be a single path element.
 var ErrBadInstanceID = errors.New("invalid instance id for an ownership receipt")
+
+// LockFunc takes exclusive, cross-process access to a receipt path and returns
+// the release function.
+//
+// It is a seam rather than an implementation because the lock this package
+// needs already exists in the tree — one implementation of that rule, shared —
+// and internal/procowner cannot import the package that holds it without a
+// cycle. The session layer wires the real one in; see ownershipStoreAt.
+type LockFunc func(path string) (release func(), err error)
+
+// NoCrossProcessLock is an explicit opt-out, for single-process tests that
+// document why they do not need cross-process serialization. It is a named,
+// greppable function rather than a nil default: a store that silently skips its
+// lock is the failure this whole file exists to prevent.
+func NoCrossProcessLock(string) (func(), error) { return func() {}, nil }
 
 // Store persists receipts as one file per instance.
 //
 // A file, not a row: the receipt has to be readable and writable by a different
 // agent-deck process from the one that wrote it (a CLI restart reconciling what
-// a TUI spawned), and it has to survive a crash mid-write. safeio's temp →
-// fsync → rename gives that without a schema migration or a new dependency.
+// a TUI spawned), and it has to survive a crash mid-write.
+//
+// Every public method takes the lock for the WHOLE load → check → write cycle.
+// Atomic replacement alone is not enough and never was: two writers that each
+// read, decide and rename produce a last-writer-wins result in which the
+// loser's decision was made on state the winner had already invalidated. The
+// rename being atomic only makes the wrong answer durable.
 type Store struct {
-	dir string
-	mu  sync.Mutex
+	dir  string
+	lock LockFunc
 }
 
-// NewStore returns a store rooted at dir.
-func NewStore(dir string) *Store { return &Store{dir: dir} }
+// NewStore returns a store rooted at dir, serialized by lock.
+func NewStore(dir string, lock LockFunc) *Store {
+	if lock == nil {
+		lock = NoCrossProcessLock
+	}
+	return &Store{dir: dir, lock: lock}
+}
 
 // Dir returns the store's root directory.
 func (s *Store) Dir() string { return s.dir }
@@ -48,20 +91,48 @@ func (s *Store) Path(instanceID string) (string, error) {
 	return filepath.Join(s.dir, id+".json"), nil
 }
 
+// withLock runs fn holding exclusive access to the instance's receipt path.
+//
+// The directory is created before locking because the lock file is a sibling of
+// the receipt: there is nowhere to put it otherwise.
+func (s *Store) withLock(instanceID string, fn func(path string) error) error {
+	path, err := s.Path(instanceID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("create ownership dir: %w", err)
+	}
+	release, err := s.lock(path)
+	if err != nil {
+		return fmt.Errorf("lock ownership receipt: %w", err)
+	}
+	defer release()
+	return fn(path)
+}
+
 // Load returns the receipt for an instance, (nil, nil) when there is none, or
 // ErrCorruptReceipt when one exists but cannot be trusted.
 //
 // The corrupt case is deliberately NOT folded into "no receipt". A truncated
 // receipt is a session whose ownership we recorded and can no longer read;
 // treating that as "nothing was owned" is how a duplicate tree gets spawned.
+//
+// The read takes the lock so it cannot observe a receipt that a concurrent
+// commit is midway through deciding on.
 func (s *Store) Load(instanceID string) (*Receipt, error) {
-	path, err := s.Path(instanceID)
+	var (
+		receipt *Receipt
+		loadErr error
+	)
+	err := s.withLock(instanceID, func(path string) error {
+		receipt, loadErr = loadFrom(path, instanceID)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return loadFrom(path, instanceID)
+	return receipt, loadErr
 }
 
 func loadFrom(path, instanceID string) (*Receipt, error) {
@@ -83,118 +154,174 @@ func loadFrom(path, instanceID string) (*Receipt, error) {
 	return r, nil
 }
 
-// Save writes a receipt, refusing to overwrite a newer generation.
+// Commit performs one atomic read-modify-write of an instance's receipt.
 //
-// Equal generations are allowed to rewrite: that is how the attribution pass
-// adds members to the receipt it just committed. A lower generation is refused
-// — that writer belongs to a superseded spawn.
-func (s *Store) Save(r *Receipt) error {
-	if err := r.Validate(); err != nil {
-		return err
-	}
-	path, err := s.Path(r.InstanceID)
+// build receives whatever is on disk (nil when there is none, and nil when what
+// is there is unreadable — a receipt that cannot be parsed cannot claim a
+// generation) and returns the receipt to write. Returning an error aborts with
+// the file untouched, which is how a caller declines to claim: no receipt is
+// always safer than a receipt it could not substantiate.
+//
+// This is the ONLY way a new receipt reaches disk. Selecting a generation and
+// writing it are one critical section, so two spawns cannot both read the same
+// predecessor and both decide they are the successor.
+func (s *Store) Commit(instanceID string, build func(existing *Receipt) (*Receipt, error)) (*Receipt, error) {
+	var committed *Receipt
+	err := s.withLock(instanceID, func(path string) error {
+		existing, loadErr := loadFrom(path, instanceID)
+		if loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt) {
+			return loadErr
+		}
+		next, buildErr := build(existing)
+		if buildErr != nil {
+			return buildErr
+		}
+		if next == nil {
+			return errors.New("procowner: commit produced no receipt")
+		}
+		if next.InstanceID != instanceID {
+			return fmt.Errorf("procowner: commit for %q produced a receipt for %q", instanceID, next.InstanceID)
+		}
+		if err := checkSupersession(existing, next); err != nil {
+			return err
+		}
+		if err := writeReceipt(path, next); err != nil {
+			return err
+		}
+		committed = next
+		return nil
+	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	existing, loadErr := loadFrom(path, r.InstanceID)
-	switch {
-	case loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt):
-		return loadErr
-	case loadErr != nil:
-		// A corrupt receipt on disk cannot report a generation, so it cannot
-		// claim to be newer. Replacing it with a valid one is strictly an
-		// improvement — and the spawn lock means only one writer is here.
-	case existing != nil && existing.Generation > r.Generation:
-		return fmt.Errorf("%w: on disk %d, writing %d",
-			ErrGenerationConflict, existing.Generation, r.Generation)
-	case existing != nil && existing.Generation == r.Generation &&
-		existing.Leader.Key() != r.Leader.Key():
-		// Same generation, different leader: two different spawns. Generations
-		// restart at 1 once a receipt has been verifiably cleared (a cleared
-		// receipt is an absent file, by design — a tombstone would be a second
-		// claim of ownership sitting next to the live one), so the number alone
-		// cannot tell a stale writer from the current one. The leader identity
-		// can, and it is already the thing that defines the receipt. This is
-		// what stops an attribution pass from a reaped generation, still alive
-		// in another process, from overwriting the receipt of the spawn that
-		// replaced it.
-		return fmt.Errorf("%w: generation %d on disk is owned by %s, not %s",
-			ErrGenerationConflict, existing.Generation, existing.Leader, r.Leader)
-	}
-
-	data, err := Encode(r)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(s.dir, 0o700); err != nil {
-		return fmt.Errorf("create ownership dir: %w", err)
-	}
-	// SkipBackup: a stale .bak receipt is worse than no receipt — it would be a
-	// second, older claim of ownership sitting next to the live one.
-	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o600, SkipBackup: true})
+	return committed, nil
 }
 
-// NextGeneration returns the generation a new spawn should commit under: one
-// more than whatever is on disk. A corrupt receipt is counted as generation 0
-// so the fresh receipt still supersedes it.
-func (s *Store) NextGeneration(instanceID string) (uint64, error) {
-	existing, err := s.Load(instanceID)
-	if err != nil && !errors.Is(err, ErrCorruptReceipt) {
-		return 0, err
+// Update applies mutate to the receipt on disk, and never creates one.
+//
+// mutate receives the CURRENT receipt — loaded inside the lock, never nil — and
+// edits it in place. Returning an error aborts with the file untouched;
+// returning ErrNoChange aborts without reporting one.
+//
+// Handing the mutator the on-disk receipt rather than taking a prepared one is
+// the difference between a compare-and-swap and a hope. A caller that loads,
+// edits its own copy and writes it back has a gap between the load and the
+// write in which another process's edit can land — and its write then erases
+// that edit. Making the read, the decision AND the write one critical section
+// is the only shape that does not lose updates; atomic replacement makes the
+// write indivisible, never the sequence around it.
+//
+// This is also where cancellation becomes authoritative rather than advisory: a
+// mutator that checks its own window here is checking it after the lock has
+// been won, so a teardown that lands while this call was queued disarms the
+// write instead of merely stopping the next attempt.
+func (s *Store) Update(instanceID string, mutate func(current *Receipt) error) error {
+	if mutate == nil {
+		return errors.New("procowner: update needs a mutator")
 	}
-	if existing == nil {
-		return 1, nil
+	return s.withLock(instanceID, func(path string) error {
+		existing, loadErr := loadFrom(path, instanceID)
+		if loadErr != nil {
+			// Unreadable: refuse rather than overwrite. The operator's recovery
+			// path (abandon) is an explicit act, not a side effect of an
+			// attribution pass.
+			return loadErr
+		}
+		if existing == nil {
+			return fmt.Errorf("%w: instance %s", ErrReceiptGone, instanceID)
+		}
+		if err := mutate(existing); err != nil {
+			if errors.Is(err, ErrNoChange) {
+				return nil
+			}
+			return err
+		}
+		if err := existing.Validate(); err != nil {
+			return err
+		}
+		return writeReceipt(path, existing)
+	})
+}
+
+// RequireGeneration is the guard an update's mutator uses to assert that the
+// receipt on disk is still the one it belongs to. It is the same rule Commit
+// and Clear enforce, called rather than restated.
+func RequireGeneration(current *Receipt, generation uint64, leader Member) error {
+	if current.Generation != generation || current.Leader.Key() != leader.Key() {
+		return fmt.Errorf("%w: on disk generation %d owned by %s, updating generation %d owned by %s",
+			ErrGenerationConflict, current.Generation, current.Leader, generation, leader)
 	}
-	return existing.Generation + 1, nil
+	return nil
 }
 
 // Clear removes a receipt the caller has verified as retired.
 //
-// It takes the receipt rather than an id so the same two checks that guard Save
-// guard the delete: a newer generation is never removed by an older caller, and
-// a receipt belonging to a different leader is never removed by a stale one. A
-// late clear from a superseded spawn must not delete the live receipt of the
-// spawn that replaced it.
+// It takes the receipt rather than an id so the same two checks that guard
+// every write guard the delete: a newer generation is never removed by an older
+// caller, and a receipt belonging to a different leader is never removed by a
+// stale one. A late clear from a superseded spawn must not delete the live
+// receipt of the spawn that replaced it.
 func (s *Store) Clear(r *Receipt) error {
 	if r == nil {
 		return errors.New("procowner: clear needs the receipt it is retiring")
 	}
-	path, err := s.Path(r.InstanceID)
-	if err != nil {
-		return err
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	existing, loadErr := loadFrom(path, r.InstanceID)
-	if loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt) {
-		return loadErr
-	}
-	if existing != nil {
-		if existing.Generation > r.Generation {
-			return fmt.Errorf("%w: on disk %d, clearing %d",
-				ErrGenerationConflict, existing.Generation, r.Generation)
+	return s.withLock(r.InstanceID, func(path string) error {
+		existing, loadErr := loadFrom(path, r.InstanceID)
+		if loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt) {
+			return loadErr
 		}
-		if existing.Generation == r.Generation && existing.Leader.Key() != r.Leader.Key() {
-			return fmt.Errorf("%w: generation %d on disk is owned by %s, not %s",
-				ErrGenerationConflict, existing.Generation, existing.Leader, r.Leader)
+		if existing != nil {
+			if existing.Generation > r.Generation {
+				return fmt.Errorf("%w: on disk %d, clearing %d",
+					ErrGenerationConflict, existing.Generation, r.Generation)
+			}
+			if existing.Generation == r.Generation && existing.Leader.Key() != r.Leader.Key() {
+				return fmt.Errorf("%w: generation %d on disk is owned by %s, not %s",
+					ErrGenerationConflict, existing.Generation, existing.Leader, r.Leader)
+			}
 		}
-	}
-	return safeio.SafeRemove(path, safeio.RemoveOptions{})
+		return safeio.SafeRemove(path, safeio.RemoveOptions{})
+	})
 }
 
 // ForceClear removes the receipt regardless of generation. Reserved for the
 // explicit operator abandon path, which is the only place where discarding an
 // unverifiable claim is a decision a human has made.
 func (s *Store) ForceClear(instanceID string) error {
-	path, err := s.Path(instanceID)
+	return s.withLock(instanceID, func(path string) error {
+		return safeio.SafeRemove(path, safeio.RemoveOptions{})
+	})
+}
+
+// checkSupersession refuses a write that a concurrent spawn has already made
+// stale.
+//
+// Generations restart at 1 once a receipt has been verifiably cleared (a
+// cleared receipt is an absent file, by design — a tombstone would be a second
+// claim of ownership sitting next to the live one), so the number alone cannot
+// always tell a stale writer from the current one. The leader identity can, and
+// it is already the thing that defines the receipt.
+func checkSupersession(existing, next *Receipt) error {
+	if existing == nil {
+		return nil
+	}
+	if existing.Generation > next.Generation {
+		return fmt.Errorf("%w: on disk %d, writing %d",
+			ErrGenerationConflict, existing.Generation, next.Generation)
+	}
+	if existing.Generation == next.Generation && existing.Leader.Key() != next.Leader.Key() {
+		return fmt.Errorf("%w: generation %d on disk is owned by %s, not %s",
+			ErrGenerationConflict, existing.Generation, existing.Leader, next.Leader)
+	}
+	return nil
+}
+
+func writeReceipt(path string, r *Receipt) error {
+	data, err := Encode(r)
 	if err != nil {
 		return err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return safeio.SafeRemove(path, safeio.RemoveOptions{})
+	// SkipBackup: a stale .bak receipt is worse than no receipt — it would be a
+	// second, older claim of ownership sitting next to the live one.
+	return safeio.SafeOverwrite(path, data, safeio.Options{Perm: 0o600, SkipBackup: true})
 }

--- a/internal/procowner/store.go
+++ b/internal/procowner/store.go
@@ -71,7 +71,7 @@ type Store struct {
 // NewStore returns a store rooted at dir, serialized by lock.
 func NewStore(dir string, lock LockFunc) *Store {
 	if lock == nil {
-		lock = NoCrossProcessLock
+		panic("procowner: NewStore needs a lock; pass NoCrossProcessLock to opt out")
 	}
 	return &Store{dir: dir, lock: lock}
 }
@@ -267,7 +267,7 @@ func (s *Store) Clear(r *Receipt) error {
 	}
 	return s.withLock(r.InstanceID, func(path string) error {
 		existing, loadErr := loadFrom(path, r.InstanceID)
-		if loadErr != nil && !errors.Is(loadErr, ErrCorruptReceipt) {
+		if loadErr != nil {
 			return loadErr
 		}
 		if existing != nil {

--- a/internal/procowner/verify.go
+++ b/internal/procowner/verify.go
@@ -1,0 +1,269 @@
+package procowner
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Prober errors. Every caller distinguishes them: "the process is gone" is
+// proof, "I could not look" is not.
+var (
+	// ErrNoProcess means the PID does not exist. This is positive evidence of
+	// death, and the only evidence that lets a receipt be cleared.
+	ErrNoProcess = errors.New("no such process")
+	// ErrUnreadable means the PID may or may not exist but its identity could
+	// not be read (permissions, a vanished /proc entry mid-read, a malformed
+	// stat line). Fail closed.
+	ErrUnreadable = errors.New("process identity is unreadable")
+	// ErrUnsupported means this platform has no start-identity source, so
+	// ownership cannot be established or checked here.
+	ErrUnsupported = errors.New("process start identity is unsupported on this platform")
+)
+
+// ProcInfo is a live process observation.
+type ProcInfo struct {
+	PID     int
+	PPID    int
+	PGID    int
+	UID     int
+	Comm    string
+	State   string
+	StartID string
+}
+
+// IsZombie reports whether the observation is of a process that has already
+// exited and is only waiting to be reaped by its parent.
+//
+// A zombie still has a /proc entry, still reports its original start identity,
+// and can still be signalled without error — so without this check a process
+// that died on the first SIGTERM reads as "survived SIGTERM and SIGKILL" for as
+// long as its parent takes to call wait(). That turns a successful reap into a
+// permanently un-clearable receipt.
+func (p ProcInfo) IsZombie() bool {
+	return p.State == "Z" || p.State == "X" || strings.HasPrefix(p.State, "Z")
+}
+
+// Prober reads process identity from the operating system. It is an interface
+// so the whole state machine is testable without spawning processes, and so the
+// platform-specific half stays as small as possible.
+type Prober interface {
+	// Name identifies the provider, recorded in the receipt so a receipt is
+	// never verified against a different notion of start identity.
+	Name() string
+	// BootID returns an identifier for the current boot.
+	BootID() (string, error)
+	// Inspect returns the live identity of pid, or ErrNoProcess/ErrUnreadable.
+	Inspect(pid int) (ProcInfo, error)
+	// Descendants returns every process currently reachable from root by a
+	// parent walk, each with its own start identity from the same observation.
+	Descendants(root ProcInfo) ([]ProcInfo, error)
+}
+
+// MemberState is the verified state of one recorded identity.
+type MemberState string
+
+const (
+	// StateOwned: the PID exists and its start identity matches the receipt.
+	// This is the only state that may ever be signalled.
+	StateOwned MemberState = "owned"
+	// StateGone: the PID does not exist. Proof of death.
+	StateGone MemberState = "gone"
+	// StateStranger: the PID exists but carries a different start identity.
+	//
+	// This is the reused-PID case, and it says two things at once. The obvious
+	// one: the process now holding that pid is a stranger and must never be
+	// signalled. The less obvious one: a pid can only be reused after its
+	// previous holder exited, so the process we recorded is DEAD — which is why
+	// a stranger does not block a replacement spawn. Anything still alive from
+	// the owned tree would still be holding its own pid and would verify as
+	// owned; treating a stranger as ambiguous instead would block restarts
+	// forever on any session whose short-lived children had their pids recycled,
+	// while detecting nothing extra.
+	StateStranger MemberState = "stranger"
+	// StateUnknown: identity could not be determined, or matched a process now
+	// running as a different user. Reported and left alone.
+	StateUnknown MemberState = "unknown"
+)
+
+// Verdict is the receipt-level answer.
+type Verdict string
+
+const (
+	// VerdictClear: every recorded identity is proven gone. Safe to clear the
+	// receipt and admit a replacement spawn.
+	VerdictClear Verdict = "clear"
+	// VerdictOwned: at least one recorded identity is still ours and alive, and
+	// nothing is ambiguous. A replacement must not be admitted until it is
+	// terminated and verified.
+	VerdictOwned Verdict = "owned"
+	// VerdictUnknown: something could not be proven either way. Fail closed:
+	// block the replacement, signal nothing, report the receipt.
+	VerdictUnknown Verdict = "unknown"
+)
+
+// MemberStatus pairs a recorded identity with what verification found.
+type MemberStatus struct {
+	Member Member
+	State  MemberState
+	Detail string
+}
+
+// Report is the outcome of verifying a whole receipt.
+type Report struct {
+	Verdict Verdict
+	Members []MemberStatus
+	// Reason is a one-line, operator-facing explanation of the verdict.
+	Reason string
+	// BootChanged records that the receipt predates the current boot, which is
+	// positive proof that every recorded identity is gone.
+	BootChanged bool
+}
+
+// Owned returns the members that verified as still ours and alive.
+func (r Report) Owned() []Member {
+	var out []Member
+	for _, s := range r.Members {
+		if s.State == StateOwned {
+			out = append(out, s.Member)
+		}
+	}
+	return out
+}
+
+// Counts returns the number of members in each state.
+func (r Report) Counts() map[MemberState]int {
+	counts := map[MemberState]int{}
+	for _, s := range r.Members {
+		counts[s.State]++
+	}
+	return counts
+}
+
+// Describe renders the report for operator surfaces.
+func (r Report) Describe() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "verdict=%s", r.Verdict)
+	if r.Reason != "" {
+		fmt.Fprintf(&b, " (%s)", r.Reason)
+	}
+	states := make([]string, 0, len(r.Members))
+	for _, s := range r.Members {
+		entry := fmt.Sprintf("%s -> %s", s.Member.String(), s.State)
+		if s.Detail != "" {
+			entry += ": " + s.Detail
+		}
+		states = append(states, entry)
+	}
+	sort.Strings(states)
+	for _, s := range states {
+		b.WriteString("\n  " + s)
+	}
+	return b.String()
+}
+
+// VerifyMember checks one recorded identity against the live process table.
+//
+// The identity check is exactly the ruling's: same PID AND same start time.
+// The uid comparison on top of it can only ever turn "owned" into "unknown" —
+// it never widens what may be signalled.
+func VerifyMember(p Prober, m Member) MemberStatus {
+	info, err := p.Inspect(m.PID)
+	switch {
+	case errors.Is(err, ErrNoProcess):
+		return MemberStatus{Member: m, State: StateGone, Detail: "process does not exist"}
+	case errors.Is(err, ErrUnsupported):
+		return MemberStatus{Member: m, State: StateUnknown, Detail: "no start-identity provider on this platform"}
+	case err != nil:
+		return MemberStatus{Member: m, State: StateUnknown, Detail: "identity unreadable: " + err.Error()}
+	}
+	if info.StartID != m.StartID {
+		return MemberStatus{
+			Member: m,
+			State:  StateStranger,
+			Detail: fmt.Sprintf("pid reused: recorded start %s, live start %s", m.StartID, info.StartID),
+		}
+	}
+	if info.UID != m.UID {
+		return MemberStatus{
+			Member: m,
+			State:  StateUnknown,
+			Detail: fmt.Sprintf("identity matches but the process now runs as uid %d (recorded %d)", info.UID, m.UID),
+		}
+	}
+	return MemberStatus{Member: m, State: StateOwned}
+}
+
+// Verify checks every identity in a receipt and returns the receipt-level
+// verdict. It never signals anything.
+func Verify(p Prober, r *Receipt) Report {
+	if r == nil {
+		return Report{Verdict: VerdictClear, Reason: "no ownership receipt"}
+	}
+	if err := r.Validate(); err != nil {
+		return Report{Verdict: VerdictUnknown, Reason: err.Error()}
+	}
+	if name := p.Name(); name != r.Provider {
+		return Report{
+			Verdict: VerdictUnknown,
+			Reason: fmt.Sprintf("receipt was written by provider %q but this host verifies with %q",
+				r.Provider, name),
+		}
+	}
+
+	// A boot change is the one situation where every recorded identity is
+	// provably gone without inspecting a single PID: start identities are
+	// measured from boot, so nothing recorded before it can still be running.
+	// Without this a rebooted host would carry a permanently ambiguous receipt
+	// for every session that did not shut down cleanly.
+	boot, err := p.BootID()
+	if err != nil {
+		return Report{Verdict: VerdictUnknown, Reason: "current boot id is unreadable: " + err.Error()}
+	}
+	if boot != r.BootID {
+		members := r.All()
+		statuses := make([]MemberStatus, 0, len(members))
+		for _, m := range members {
+			statuses = append(statuses, MemberStatus{
+				Member: m,
+				State:  StateGone,
+				Detail: "recorded before the current boot",
+			})
+		}
+		return Report{
+			Verdict:     VerdictClear,
+			Members:     statuses,
+			Reason:      "receipt predates the current boot, so every recorded process is gone",
+			BootChanged: true,
+		}
+	}
+
+	members := r.All()
+	statuses := make([]MemberStatus, 0, len(members))
+	counts := map[MemberState]int{}
+	for _, m := range members {
+		status := VerifyMember(p, m)
+		statuses = append(statuses, status)
+		counts[status.State]++
+	}
+
+	report := Report{Members: statuses}
+	switch {
+	case counts[StateUnknown] > 0:
+		report.Verdict = VerdictUnknown
+		report.Reason = fmt.Sprintf("%d recorded process(es) could not be verified; nothing was signalled",
+			counts[StateUnknown])
+	case counts[StateOwned] > 0:
+		report.Verdict = VerdictOwned
+		report.Reason = fmt.Sprintf("%d owned process(es) are still alive", counts[StateOwned])
+	default:
+		report.Verdict = VerdictClear
+		report.Reason = "every recorded process is gone"
+		if counts[StateStranger] > 0 {
+			report.Reason = fmt.Sprintf("every recorded process is gone (%d pid(s) have since been reused by unrelated processes, which were not signalled)",
+				counts[StateStranger])
+		}
+	}
+	return report
+}

--- a/internal/procowner/verify_test.go
+++ b/internal/procowner/verify_test.go
@@ -1,0 +1,354 @@
+package procowner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The failure shapes below are the ones a PID-based ownership scheme actually
+// dies of. Each has its own test because each has its own correct answer, and
+// "fails closed" is not one single behaviour: a reused pid means the recorded
+// process is DEAD (never signal the new holder, do not block a replacement),
+// while an unreadable entry means we do not know (never signal, and do block).
+
+func TestVerify_OwnedProcessIsOwned(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	report := Verify(p, liveReceipt("inst", memberOf(leader, RoleLeader)))
+
+	require.Equal(t, VerdictOwned, report.Verdict)
+	require.Len(t, report.Owned(), 1)
+	assert.Equal(t, 100, report.Owned()[0].PID)
+}
+
+func TestVerify_MissingProcessIsProvenGone(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.remove(100)
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictClear, report.Verdict)
+	assert.Equal(t, StateGone, report.Members[0].State)
+}
+
+// A recycled pid: the pid exists, the start identity does not match. The
+// recorded process is dead — pids are only reused after their holder exits —
+// so the receipt clears, and the impostor must never be signalled.
+func TestVerify_RecycledPIDIsAStrangerAndDoesNotBlock(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	// Same pid, different start identity: an unrelated process moved in.
+	p.remove(100)
+	p.add(100, 1, "9999", 1000)
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictClear, report.Verdict)
+	require.Equal(t, StateStranger, report.Members[0].State)
+	assert.Empty(t, report.Owned(), "a stranger is never reported as ours")
+	assert.Contains(t, report.Reason, "reused")
+}
+
+func TestVerify_UnreadableIdentityIsUnknownAndBlocks(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.setErr(100, fmt.Errorf("%w: /proc/100/stat", ErrUnreadable))
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictUnknown, report.Verdict)
+	assert.Equal(t, StateUnknown, report.Members[0].State)
+	assert.Empty(t, report.Owned())
+}
+
+// A pid whose identity matches but which now runs as another user: we may not
+// signal across that boundary, and we cannot claim it either.
+func TestVerify_PIDNowOwnedByAnotherUserIsUnknown(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.remove(100)
+	p.add(100, 1, "5000", 4242) // same identity, different uid
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictUnknown, report.Verdict)
+	require.Equal(t, StateUnknown, report.Members[0].State)
+	assert.Contains(t, report.Members[0].Detail, "uid 4242")
+}
+
+func TestVerify_BootChangeClearsEveryIdentity(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	// The recorded pid is still live and identical — but from a different boot,
+	// where start ticks mean something else entirely.
+	p.boot = "boot-2"
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictClear, report.Verdict)
+	assert.True(t, report.BootChanged)
+	assert.Empty(t, report.Owned(), "nothing from a previous boot may be signalled")
+}
+
+func TestVerify_UnreadableBootIDIsUnknown(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	p.bootErr = errors.New("boom")
+
+	report := Verify(p, liveReceipt("inst", memberOf(leader, RoleLeader)))
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+}
+
+func TestVerify_ProviderMismatchIsUnknown(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	receipt.Provider = "some_other_provider"
+
+	report := Verify(p, receipt)
+	require.Equal(t, VerdictUnknown, report.Verdict)
+	assert.Contains(t, report.Reason, "provider")
+}
+
+func TestVerify_CorruptReceiptIsUnknown(t *testing.T) {
+	p := newFakeProber()
+	report := Verify(p, &Receipt{Version: ReceiptVersion, InstanceID: "inst"})
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+}
+
+func TestVerify_MixedMembersFailClosedOnTheUnknownOne(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	child := p.add(101, 100, "5100", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader), memberOf(child, RoleDescendant))
+	p.setErr(101, fmt.Errorf("%w: /proc/101/stat", ErrUnreadable))
+
+	report := Verify(p, receipt)
+	assert.Equal(t, VerdictUnknown, report.Verdict,
+		"one unverifiable member is enough to make the whole receipt unverifiable")
+}
+
+func TestReap_TerminatesOnlyIdentityMatchedProcesses(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	child := p.add(101, 100, "5100", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader), memberOf(child, RoleDescendant))
+
+	sig := newRecordingSignaler()
+	sig.onSend = func(pid int, _ syscall.Signal) { p.remove(pid) }
+
+	report := Reap(p, sig, receipt, fastReapOptions())
+	require.Equal(t, VerdictClear, report.Verdict, report.Describe())
+	assert.Equal(t, 2, report.Signalled())
+	calls := sig.calls()
+	require.Len(t, calls, 2)
+	// Descendants before the leader, so the tree is not re-parented mid-reap.
+	assert.Equal(t, 101, calls[0].PID)
+	assert.Equal(t, 100, calls[1].PID)
+	for _, c := range calls {
+		assert.Equal(t, syscall.SIGTERM, c.Sig, "a cooperative process is never SIGKILLed")
+	}
+}
+
+// The headline safety property: a receipt whose pid now belongs to somebody
+// else must not produce a single signal.
+func TestReap_NeverSignalsARecycledPID(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.remove(100)
+	p.add(100, 1, "7777", 1000) // stranger moves in
+
+	sig := newRecordingSignaler()
+	report := Reap(p, sig, receipt, fastReapOptions())
+
+	assert.Empty(t, sig.calls(), "the stranger must not be signalled")
+	assert.Equal(t, VerdictClear, report.Verdict)
+	assert.Equal(t, OutcomeAlreadyGone, report.Outcomes[0].Outcome)
+}
+
+func TestReap_NeverSignalsAnUnreadableIdentity(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.setErr(100, fmt.Errorf("%w: /proc/100/stat", ErrUnreadable))
+
+	sig := newRecordingSignaler()
+	report := Reap(p, sig, receipt, fastReapOptions())
+
+	assert.Empty(t, sig.calls())
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+	assert.Equal(t, OutcomeNotSignalled, report.Outcomes[0].Outcome)
+}
+
+func TestReap_NeverSignalsAcrossAUserBoundary(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.remove(100)
+	p.add(100, 1, "5000", 999)
+
+	sig := newRecordingSignaler()
+	report := Reap(p, sig, receipt, fastReapOptions())
+
+	assert.Empty(t, sig.calls())
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+}
+
+// The process exits between the receipt read and the signal: the kernel reports
+// ESRCH and that is a clean reap, not a failure.
+func TestReap_ProcessExitingBeforeTheSignalIsReaped(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+
+	sig := newRecordingSignaler()
+	sig.err[100] = syscall.ESRCH
+	sig.onSend = func(pid int, _ syscall.Signal) { p.remove(pid) }
+
+	report := Reap(p, sig, receipt, fastReapOptions())
+	assert.Equal(t, VerdictClear, report.Verdict)
+	assert.Equal(t, OutcomeReaped, report.Outcomes[0].Outcome)
+	assert.Equal(t, 1, sig.sentTo(100))
+}
+
+// The pid is recycled during the SIGTERM grace period. The escalation must
+// notice on its re-check and stop — SIGKILL to that pid would hit a stranger.
+func TestReap_PIDRecycledDuringGraceStopsTheEscalation(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+
+	sig := newRecordingSignaler()
+	sig.onSend = func(pid int, _ syscall.Signal) {
+		p.remove(pid)
+		p.add(pid, 1, "8888", 1000) // an unrelated process takes the pid
+	}
+
+	report := Reap(p, sig, receipt, fastReapOptions())
+	assert.Equal(t, 1, sig.sentTo(100), "SIGKILL must not follow the pid into a stranger's hands")
+	assert.Equal(t, OutcomeReaped, report.Outcomes[0].Outcome)
+	assert.Equal(t, VerdictClear, report.Verdict)
+}
+
+func TestReap_EscalatesToKillAndVerifies(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+
+	sig := newRecordingSignaler()
+	sig.onSend = func(pid int, s syscall.Signal) {
+		if s == syscall.SIGKILL {
+			p.remove(pid) // ignores SIGTERM, dies on SIGKILL
+		}
+	}
+
+	report := Reap(p, sig, receipt, fastReapOptions())
+	require.Equal(t, VerdictClear, report.Verdict, report.Describe())
+	calls := sig.calls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, syscall.SIGTERM, calls[0].Sig)
+	assert.Equal(t, syscall.SIGKILL, calls[1].Sig)
+}
+
+func TestReap_UnkillableProcessKeepsTheReceiptOwned(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+
+	sig := newRecordingSignaler() // signals land, nothing dies
+	report := Reap(p, sig, receipt, fastReapOptions())
+
+	assert.Equal(t, VerdictOwned, report.Verdict)
+	assert.Equal(t, OutcomeStillAlive, report.Outcomes[0].Outcome)
+}
+
+func TestReap_EPERMIsReportedNotEscalated(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+
+	sig := newRecordingSignaler()
+	sig.err[100] = syscall.EPERM
+
+	report := Reap(p, sig, receipt, fastReapOptions())
+	assert.Equal(t, 1, sig.sentTo(100), "a refused signal is not retried harder")
+	assert.Equal(t, OutcomeNotSignalled, report.Outcomes[0].Outcome)
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+}
+
+func TestReap_RefusesReceiptFromAnotherBoot(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader))
+	p.boot = "boot-2"
+
+	sig := newRecordingSignaler()
+	report := Reap(p, sig, receipt, fastReapOptions())
+	assert.Empty(t, sig.calls(), "a live pid that merely matches a pre-reboot receipt is a stranger")
+	assert.Equal(t, VerdictClear, report.Verdict)
+}
+
+func fastReapOptions() ReapOptions {
+	return ReapOptions{
+		TermGrace: 20 * time.Millisecond,
+		KillGrace: 20 * time.Millisecond,
+		Poll:      time.Millisecond,
+		Sleep:     func(time.Duration) {},
+	}
+}
+
+// Reaping is batched by phase, not serialised per process: every owned member
+// gets SIGTERM before any gets SIGKILL. Serialising would multiply the grace
+// period by the size of the tree on a path that runs at every session stop, and
+// would give a parent no chance to shut its children down itself.
+func TestReap_SignalsTheWholeSetPerPhase(t *testing.T) {
+	p := newFakeProber()
+	leader := p.add(100, 1, "5000", 1000)
+	childA := p.add(101, 100, "5100", 1000)
+	childB := p.add(102, 100, "5200", 1000)
+	receipt := liveReceipt("inst", memberOf(leader, RoleLeader),
+		memberOf(childA, RoleDescendant), memberOf(childB, RoleDescendant))
+
+	sig := newRecordingSignaler() // nothing dies: forces both phases
+	report := Reap(p, sig, receipt, fastReapOptions())
+
+	calls := sig.calls()
+	require.Len(t, calls, 6, "three members, two phases")
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, syscall.SIGTERM, calls[i].Sig, "call %d must still be in the SIGTERM phase", i)
+	}
+	for i := 3; i < 6; i++ {
+		assert.Equal(t, syscall.SIGKILL, calls[i].Sig, "call %d must be in the SIGKILL phase", i)
+	}
+	// Descendants before the leader, within each phase.
+	assert.Equal(t, 100, calls[2].PID)
+	assert.Equal(t, 100, calls[5].PID)
+	assert.Equal(t, VerdictOwned, report.Verdict)
+}
+
+// A receipt naming pid 1 or agent-deck itself is never actioned, whatever else
+// it says. This is the guard that makes a corrupted-but-parseable receipt
+// harmless rather than catastrophic.
+func TestReap_NeverSignalsInitOrItself(t *testing.T) {
+	p := newFakeProber()
+	self := os.Getpid()
+	p.add(self, 1, "5000", os.Getuid())
+	receipt := liveReceipt("inst",
+		Member{PID: self, StartID: "5000", UID: os.Getuid(), Role: RoleLeader},
+		Member{PID: 1, StartID: "1", UID: 0, Role: RoleDescendant})
+
+	sig := newRecordingSignaler()
+	report := Reap(p, sig, receipt, fastReapOptions())
+
+	assert.Empty(t, sig.calls(), "neither init nor agent-deck itself may be signalled")
+	assert.Equal(t, VerdictUnknown, report.Verdict)
+}

--- a/internal/procowner/verify_test.go
+++ b/internal/procowner/verify_test.go
@@ -285,6 +285,15 @@ func TestReap_EPERMIsReportedNotEscalated(t *testing.T) {
 	assert.Equal(t, VerdictUnknown, report.Verdict)
 }
 
+func TestReap_NilReceiptIsClearAndSignalsNothing(t *testing.T) {
+	p := newFakeProber()
+	sig := newRecordingSignaler()
+
+	report := Reap(p, sig, nil, fastReapOptions())
+	assert.Empty(t, sig.calls())
+	assert.Equal(t, VerdictClear, report.Verdict)
+}
+
 func TestReap_RefusesReceiptFromAnotherBoot(t *testing.T) {
 	p := newFakeProber()
 	leader := p.add(100, 1, "5000", 1000)

--- a/internal/session/config_file_lock.go
+++ b/internal/session/config_file_lock.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+)
+
+// Serialization for read-modify-write cycles on a shared config file.
+//
+// Every config mutation in this package is read-modify-write: load the JSON or
+// TOML document, change one section, write the whole thing back. Two of those
+// running at once on the same file interleave — the second reader loads a
+// document that predates the first writer, then writes it back and erases the
+// first writer's section. The web MCP pane and the TUI MCP dialog both write
+// .claude.json, so this is reachable by a user with both open.
+//
+// This is the ONE implementation of that rule. acquireCodexConfigLock in
+// codex_trust.go is now a thin alias over it rather than a second copy: a
+// private copy of a shared rule is how the same defect keeps reappearing in
+// different files.
+//
+// Both halves matter:
+//   - the in-process mutex, keyed by path, serializes goroutines in this binary
+//     (flock is per open file description, so it does NOT serialize two
+//     goroutines in one process that each open the lock file);
+//   - the advisory flock on a sibling `.lock` file serializes separate
+//     processes, e.g. the headless web server and an interactive TUI.
+//
+// The lock is NOT reentrant. A caller that needs to span several writes must
+// acquire once and call the *Locked variants — see WriteGlobalMCPAndClearProjectMCPs.
+
+// configFileMu holds one mutex per config path for in-process serialization.
+var configFileMu sync.Map // map[string]*sync.Mutex
+
+// configLockAcquisitions counts successful acquisitions. Tests use it to assert
+// that a multi-write operation takes the lock ONCE and spans both writes,
+// rather than taking and dropping it per write — a property the end state
+// cannot distinguish, because both orderings finish identically.
+var configLockAcquisitions atomic.Int64
+
+// ConfigLockAcquisitionsForTest reports the acquisition count. Test-only.
+func ConfigLockAcquisitionsForTest() int64 { return configLockAcquisitions.Load() }
+
+// ConfigFileLock is held for the whole read-modify-write cycle and released
+// with Release, conventionally by defer.
+type ConfigFileLock struct {
+	inProc *sync.Mutex
+	file   *os.File
+}
+
+// Release unlocks both halves. Safe to call on a zero value.
+func (l *ConfigFileLock) Release() {
+	if l == nil {
+		return
+	}
+	if l.file != nil {
+		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+		_ = l.file.Close()
+		l.file = nil
+	}
+	if l.inProc != nil {
+		l.inProc.Unlock()
+		l.inProc = nil
+	}
+}
+
+// resolveConfigLockPath normalizes configPath and derives the sibling `.lock`
+// path, refusing anything that would escape the config's own directory.
+//
+// Callers are all internal (a profile's Claude config, ~/.claude.json, a
+// project's .mcp.json, a Codex config.toml), so this is defence in depth rather
+// than a live injection vector — but the path is still assembled from values
+// that trace back to configuration, and a lock file is created wherever it
+// points. Cleaning and containment-checking here is cheap and removes the
+// question. It also normalizes the mutex key, so two spellings of the same file
+// share one lock instead of silently getting two.
+//
+// Returns the resolved config path (the mutex key) and the lock path.
+func resolveConfigLockPath(configPath string) (resolved, lockPath string, err error) {
+	if strings.TrimSpace(configPath) == "" {
+		return "", "", fmt.Errorf("config file lock: empty path")
+	}
+	resolved, err = filepath.Abs(filepath.Clean(configPath))
+	if err != nil {
+		return "", "", fmt.Errorf("config file lock: resolve %q: %w", configPath, err)
+	}
+
+	dir := filepath.Dir(resolved)
+	base := filepath.Base(resolved)
+	if base == "." || base == string(os.PathSeparator) {
+		return "", "", fmt.Errorf("config file lock: %q has no file name component", configPath)
+	}
+
+	lockPath = filepath.Join(dir, base+".lock")
+	// The lock must sit beside the config it guards. After cleaning this can
+	// only fail on a crafted name, but checking it is what makes the property
+	// explicit rather than incidental.
+	if !strings.HasPrefix(lockPath, dir+string(os.PathSeparator)) || filepath.Dir(lockPath) != dir {
+		return "", "", fmt.Errorf("config file lock: refusing lock path %q outside config directory %q", lockPath, dir)
+	}
+	return resolved, lockPath, nil
+}
+
+// AcquireConfigFileLock blocks until this process and this host both hold
+// exclusive access to configPath. The returned lock must be released.
+func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
+	resolved, lockPath, err := resolveConfigLockPath(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	mIface, _ := configFileMu.LoadOrStore(resolved, &sync.Mutex{})
+	m := mIface.(*sync.Mutex)
+	m.Lock()
+
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("ensure config lock dir for %s: %w", resolved, err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("open config lock file %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		m.Unlock()
+		return nil, fmt.Errorf("flock config %s: %w", resolved, err)
+	}
+	configLockAcquisitions.Add(1)
+	return &ConfigFileLock{inProc: m, file: f}, nil
+}

--- a/internal/session/config_file_lock.go
+++ b/internal/session/config_file_lock.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,7 +9,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 )
+
+const configFileLockTimeout = 30 * time.Second
 
 // Serialization for read-modify-write cycles on a shared config file.
 //
@@ -106,8 +110,8 @@ func resolveConfigLockPath(configPath string) (resolved, lockPath string, err er
 	return resolved, lockPath, nil
 }
 
-// AcquireConfigFileLock blocks until this process and this host both hold
-// exclusive access to configPath. The returned lock must be released.
+// AcquireConfigFileLock waits for bounded time until this process and this host
+// both hold exclusive access to configPath. The returned lock must be released.
 func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
 	resolved, lockPath, err := resolveConfigLockPath(configPath)
 	if err != nil {
@@ -116,7 +120,13 @@ func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
 
 	mIface, _ := configFileMu.LoadOrStore(resolved, &sync.Mutex{})
 	m := mIface.(*sync.Mutex)
-	m.Lock()
+	deadline := time.Now().Add(configFileLockTimeout)
+	for !m.TryLock() {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("config file lock: timed out waiting for in-process lock on %s", resolved)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
 		m.Unlock()
@@ -127,10 +137,22 @@ func AcquireConfigFileLock(configPath string) (*ConfigFileLock, error) {
 		m.Unlock()
 		return nil, fmt.Errorf("open config lock file %s: %w", lockPath, err)
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		_ = f.Close()
-		m.Unlock()
-		return nil, fmt.Errorf("flock config %s: %w", resolved, err)
+	for {
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			_ = f.Close()
+			m.Unlock()
+			return nil, fmt.Errorf("flock config %s: %w", resolved, err)
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			m.Unlock()
+			return nil, fmt.Errorf("config file lock: timed out waiting for flock on %s", resolved)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	configLockAcquisitions.Add(1)
 	return &ConfigFileLock{inProc: m, file: f}, nil

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4727,6 +4727,14 @@ func (i *Instance) Start() error {
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
+	var validatedDeepSeekCommand string
+	if i.Tool == "deepseek" {
+		var err error
+		validatedDeepSeekCommand, err = i.deepSeekStartCommand()
+		if err != nil {
+			return err
+		}
+	}
 
 	// #1873: refuse to spawn while this instance still owns a process tree from
 	// an earlier spawn. Runs before anything is mutated or launched, so a
@@ -4871,11 +4879,7 @@ func (i *Instance) Start() error {
 		// must replay a recorded task or refuse — `dsh --profile headless` with
 		// no positional is a usage error dsh rejects before anything could be
 		// delivered (PR #1942 review, P1b/P1c).
-		dsCommand, dsErr := i.deepSeekStartCommand()
-		if dsErr != nil {
-			return dsErr
-		}
-		command = dsCommand
+		command = validatedDeepSeekCommand
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -5083,6 +5087,14 @@ func (i *Instance) StartWithMessage(message string) error {
 			return err
 		}
 	}
+	var validatedDeepSeekCommand string
+	if i.Tool == "deepseek" && message == "" {
+		var err error
+		validatedDeepSeekCommand, err = i.deepSeekStartCommand()
+		if err != nil {
+			return err
+		}
+	}
 
 	// #1873: same fail-closed ownership gate as Start(), in the same position
 	// relative to the spawn stamp. A second spawn path is still a second tree.
@@ -5211,11 +5223,7 @@ func (i *Instance) StartWithMessage(message string) error {
 		if message == "" {
 			// StartWithMessage with no message is an ordinary start, and
 			// headless still needs its recorded task.
-			dsCommand, dsErr := i.deepSeekStartCommand()
-			if dsErr != nil {
-				return dsErr
-			}
-			command = dsCommand
+			command = validatedDeepSeekCommand
 			break
 		}
 		command, promptEmbeddedInCommand = i.buildDeepSeekCommandWithPrompt(i.Command, message)
@@ -8570,6 +8578,15 @@ func (i *Instance) restart(env map[string]string) error {
 	if err := i.guardOwnedProcessesBeforeSpawn("restart"); err != nil {
 		return err
 	}
+	var validatedDeepSeekRestartCommand string
+	if i.Tool == "deepseek" {
+		i.refreshDeepSeekSessionID()
+		var err error
+		validatedDeepSeekRestartCommand, err = i.deepSeekRestartCommand()
+		if err != nil {
+			return err
+		}
+	}
 	// Deferred only once the gate has passed: a refused restart started nothing,
 	// so it must not leave a spawn stamp that makes a concurrent caller believe
 	// a replacement is already running.
@@ -8579,7 +8596,8 @@ func (i *Instance) restart(env map[string]string) error {
 	// while the spawn lock is still held (deferred release() was registered
 	// first, so it runs last). A replacement pane that kept the previous
 	// receipt would be an unowned tree.
-	defer func() { i.commitOwnershipAfterRestart(i.Command) }()
+	ownershipCommand := i.Command
+	defer func() { i.commitOwnershipAfterRestart(ownershipCommand) }()
 
 	// #1775: supersede the fast-death watcher from the PREVIOUS spawn here, at
 	// the single entry point, rather than deeper down. restart() has several
@@ -8668,6 +8686,7 @@ func (i *Instance) restart(env map[string]string) error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
+		ownershipCommand = resumeCmd
 		mcpLog.Debug("respawn_pane_claude", slog.String("command", resumeCmd))
 
 		// #1822 F2: assert AGENTDECK_PROFILE / CLAUDE_CONFIG_DIR host-side
@@ -8724,6 +8743,7 @@ func (i *Instance) restart(env map[string]string) error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
+		ownershipCommand = resumeCmd
 		sessionLog.Info("restart_gemini_respawn", slog.String("command", resumeCmd))
 
 		// #1822 F2: gemini's rebuilt resume command carries no inline
@@ -8783,6 +8803,7 @@ func (i *Instance) restart(env map[string]string) error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
+		ownershipCommand = resumeCmd
 		sessionLog.Info("restart_opencode_respawn", slog.String("command", resumeCmd))
 
 		// #1822 F2: opencode's rebuilt resume command carries no inline
@@ -8857,6 +8878,7 @@ func (i *Instance) restart(env map[string]string) error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
+		ownershipCommand = resumeCmd
 		sessionLog.Info("restart_codex_respawn", slog.String("command", resumeCmd))
 
 		// #1822 F2: belt-and-suspenders to the inline prefix buildCodexCommand
@@ -8900,6 +8922,7 @@ func (i *Instance) restart(env map[string]string) error {
 		if containerName != "" {
 			i.SandboxContainer = containerName
 		}
+		ownershipCommand = resumeCmd
 		sessionLog.Info("restart_cursor_respawn", slog.String("command", resumeCmd))
 
 		// #1822 F2: must run BEFORE RespawnPane — see the Claude branch above
@@ -8944,6 +8967,7 @@ func (i *Instance) restart(env map[string]string) error {
 			if containerName != "" {
 				i.SandboxContainer = containerName
 			}
+			ownershipCommand = resumeCmd
 
 			// The resume command embeds the conversation id, so it is not
 			// logged; the fingerprint identifies the binding without
@@ -9033,15 +9057,10 @@ func (i *Instance) restart(env map[string]string) error {
 		// of resuming a dead ID forever. A no-op when [deepseek].resume_flag is
 		// unset (the default), where restart is a plain re-boot and dsh's own
 		// persistence under $DSH_HOME keeps the conversation reachable.
-		i.refreshDeepSeekSessionID()
 		// A headless restart replays the recorded task; every other profile
 		// re-boots as before. deepSeekRestartCommand refuses rather than
 		// rebuilding a taskless one-shot invocation.
-		dsCommand, dsErr := i.deepSeekRestartCommand()
-		if dsErr != nil {
-			return dsErr
-		}
-		command = dsCommand
+		command = validatedDeepSeekRestartCommand
 	} else {
 		// Route to appropriate command builder based on tool
 		switch {
@@ -9089,6 +9108,7 @@ func (i *Instance) restart(env map[string]string) error {
 		i.recordPrepareFailure(command, err) // #1924, sister path
 		return err
 	}
+	ownershipCommand = command
 	if containerName != "" {
 		i.SandboxContainer = containerName
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4724,11 +4724,21 @@ func (i *Instance) Start() error {
 	if spawnedSince(i.ID, beforeLock) {
 		return nil
 	}
-	defer recordInstanceSpawn(i.ID)
-
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
+
+	// #1873: refuse to spawn while this instance still owns a process tree from
+	// an earlier spawn. Runs before anything is mutated or launched, so a
+	// refusal leaves the session exactly as it was and signals nothing — and
+	// before recordInstanceSpawn is deferred, so a refusal does not stamp a
+	// spawn that never happened. That stamp is what a concurrent caller reads
+	// to decide it can return "already started"; a refusal must not hand it
+	// that answer.
+	if err := i.guardOwnedProcessesBeforeSpawn("start"); err != nil {
+		return err
+	}
+	defer recordInstanceSpawn(i.ID)
 
 	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
 	// spawn_attempt trace so a spawn that dies before anything else runs still
@@ -4912,6 +4922,18 @@ func (i *Instance) Start() error {
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
 
+	// gen AND the wake channel are both produced here, in the caller, so no
+	// bump can slip into the gap before the watcher subscribes (see
+	// newSpawnGenWatch). The ownership claim below shares the same pair: it
+	// belongs to this spawn, and a second bump would supersede the very watcher
+	// this call starts.
+	gen, wake := i.newSpawnGenWatch()
+
+	// #1873: record the durable ownership receipt — the pane process's pid
+	// bound to its start identity — before anything can die. This is the only
+	// moment at which the claim is provable.
+	i.claimOwnershipAtSpawn(command, gen, wake)
+
 	// #1580: watch for a fast death of the initial process (broken command,
 	// bad PATH, immediate non-zero exit). tmux tears the pane down on exit for
 	// non-remain-on-exit sessions, so this captures the dying output while the
@@ -4924,7 +4946,16 @@ func (i *Instance) Start() error {
 	// the exemption every completed one-shot would be recorded as died-fast and
 	// the preview would paint "⚠ session failed to start" over its answer.
 	if command != "" && !i.expectsFastExit() {
-		i.startFastDeathWatcher(command, i.tmuxSession, i.ID, i.Tool, sessionLog)
+		// Resolve both write targets HERE, synchronously in the caller, not
+		// inside the goroutine: GetSessionIDLifecycleLogPath()/spawnFailureDir()
+		// read the live $HOME, and watchForFastDeath's goroutine is never
+		// joined — it can still be sleeping on its ticker when a later test
+		// changes $HOME out from under it. Capturing the resolved paths as
+		// plain values at spawn time (Go evaluates `go` call arguments in the
+		// calling goroutine) makes the watcher's writes land in the HOME that
+		// was live when this session started, never whichever HOME happens to
+		// be live when the ticker next fires.
+		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -5034,8 +5065,6 @@ func (i *Instance) StartWithMessage(message string) error {
 	if spawnedSince(i.ID, beforeLock) {
 		return nil
 	}
-	defer recordInstanceSpawn(i.ID)
-
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
@@ -5054,6 +5083,13 @@ func (i *Instance) StartWithMessage(message string) error {
 			return err
 		}
 	}
+
+	// #1873: same fail-closed ownership gate as Start(), in the same position
+	// relative to the spawn stamp. A second spawn path is still a second tree.
+	if err := i.guardOwnedProcessesBeforeSpawn("start"); err != nil {
+		return err
+	}
+	defer recordInstanceSpawn(i.ID)
 
 	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
 	// spawn_attempt trace (same as Start()).
@@ -5227,9 +5263,18 @@ func (i *Instance) StartWithMessage(message string) error {
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
 
+	// One generation for this spawn, shared by the ownership claim and the
+	// fast-death watcher (sister path to Start()).
+	gen, wake := i.newSpawnGenWatch()
+
+	// #1873: claim the ownership receipt at spawn (sister path to Start()).
+	i.claimOwnershipAtSpawn(command, gen, wake)
+
 	// #1580: fast-death watcher (sister path to Start()).
 	if command != "" && !i.expectsFastExit() {
-		i.startFastDeathWatcher(command, i.tmuxSession, i.ID, i.Tool, sessionLog)
+		// See the matching comment in Start(): resolve the write targets — and
+		// subscribe to the wake — here, not inside the never-joined goroutine.
+		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -8455,6 +8500,14 @@ func (i *Instance) killInternal(sync bool) error {
 		}
 	}
 
+	// #1873: reap whatever the spawn-time ownership receipt still owns, then
+	// clear it. tmux teardown does not reach a tree that has already escaped
+	// the pane — that is the whole report — and a deliberate stop is exactly
+	// the intent that authorises terminating this session's processes. Only
+	// identity-matched processes are signalled; anything unverifiable is left
+	// alone and the receipt is kept so it stays visible.
+	i.clearOwnershipAfterTeardown(sync)
+
 	// Remove the scratch CLAUDE_CONFIG_DIR prepared at spawn time for
 	// this worker (issue #59, v1.7.68). Best-effort — leaking a scratch
 	// dir on an unclean shutdown is harmless, just wasteful.
@@ -8509,7 +8562,24 @@ func (i *Instance) restart(env map[string]string) error {
 	if spawnedSince(i.ID, beforeLock) && len(env) == 0 {
 		return nil
 	}
+	// #1873: the case this issue reports IS a restart — a pane that died during
+	// startup, a wrapped tree that escaped it, and a later legitimate restart
+	// that spawns a second one. The gate runs before the generation bump and
+	// before any tmux work, so a refusal changes nothing at all: no kill, no
+	// respawn, no signal, and the receipt left intact for inspection.
+	if err := i.guardOwnedProcessesBeforeSpawn("restart"); err != nil {
+		return err
+	}
+	// Deferred only once the gate has passed: a refused restart started nothing,
+	// so it must not leave a spawn stamp that makes a concurrent caller believe
+	// a replacement is already running.
 	defer recordInstanceSpawn(i.ID)
+	// Registered AFTER the gate and BEFORE the tmux work, so it runs on every
+	// exit of this function — including each per-tool respawn-pane fast path —
+	// while the spawn lock is still held (deferred release() was registered
+	// first, so it runs last). A replacement pane that kept the previous
+	// receipt would be an unowned tree.
+	defer func() { i.commitOwnershipAfterRestart(i.Command) }()
 
 	// #1775: supersede the fast-death watcher from the PREVIOUS spawn here, at
 	// the single entry point, rather than deeper down. restart() has several

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4959,7 +4959,7 @@ func (i *Instance) Start() error {
 		// calling goroutine) makes the watcher's writes land in the HOME that
 		// was live when this session started, never whichever HOME happens to
 		// be live when the ticker next fires.
-		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
+		i.startFastDeathWatcher(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -5282,7 +5282,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	if command != "" && !i.expectsFastExit() {
 		// See the matching comment in Start(): resolve the write targets — and
 		// subscribe to the wake — here, not inside the never-joined goroutine.
-		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
+		i.startFastDeathWatcher(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4516,11 +4516,21 @@ func (i *Instance) Start() error {
 	if spawnedSince(i.ID, beforeLock) {
 		return nil
 	}
-	defer recordInstanceSpawn(i.ID)
-
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
+
+	// #1873: refuse to spawn while this instance still owns a process tree from
+	// an earlier spawn. Runs before anything is mutated or launched, so a
+	// refusal leaves the session exactly as it was and signals nothing — and
+	// before recordInstanceSpawn is deferred, so a refusal does not stamp a
+	// spawn that never happened. That stamp is what a concurrent caller reads
+	// to decide it can return "already started"; a refusal must not hand it
+	// that answer.
+	if err := i.guardOwnedProcessesBeforeSpawn("start"); err != nil {
+		return err
+	}
+	defer recordInstanceSpawn(i.ID)
 
 	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
 	// spawn_attempt trace so a spawn that dies before anything else runs still
@@ -4694,6 +4704,18 @@ func (i *Instance) Start() error {
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
 
+	// gen AND the wake channel are both produced here, in the caller, so no
+	// bump can slip into the gap before the watcher subscribes (see
+	// newSpawnGenWatch). The ownership claim below shares the same pair: it
+	// belongs to this spawn, and a second bump would supersede the very watcher
+	// this call starts.
+	gen, wake := i.newSpawnGenWatch()
+
+	// #1873: record the durable ownership receipt — the pane process's pid
+	// bound to its start identity — before anything can die. This is the only
+	// moment at which the claim is provable.
+	i.claimOwnershipAtSpawn(command, gen, wake)
+
 	// #1580: watch for a fast death of the initial process (broken command,
 	// bad PATH, immediate non-zero exit). tmux tears the pane down on exit for
 	// non-remain-on-exit sessions, so this captures the dying output while the
@@ -4701,10 +4723,6 @@ func (i *Instance) Start() error {
 	// watcher is handed value snapshots + a supersede generation so it never
 	// touches i's mutex-guarded fields from its own goroutine.
 	if command != "" {
-		// gen AND the wake channel are both produced here, in the caller, so no
-		// bump can slip into the gap before the watcher subscribes (see
-		// newSpawnGenWatch).
-		gen, wake := i.newSpawnGenWatch()
 		// Resolve both write targets HERE, synchronously in the caller, not
 		// inside the goroutine: GetSessionIDLifecycleLogPath()/spawnFailureDir()
 		// read the live $HOME, and watchForFastDeath's goroutine is never
@@ -4824,11 +4842,16 @@ func (i *Instance) StartWithMessage(message string) error {
 	if spawnedSince(i.ID, beforeLock) {
 		return nil
 	}
-	defer recordInstanceSpawn(i.ID)
-
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
+
+	// #1873: same fail-closed ownership gate as Start(), in the same position
+	// relative to the spawn stamp. A second spawn path is still a second tree.
+	if err := i.guardOwnedProcessesBeforeSpawn("start"); err != nil {
+		return err
+	}
+	defer recordInstanceSpawn(i.ID)
 
 	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
 	// spawn_attempt trace (same as Start()).
@@ -4984,9 +5007,15 @@ func (i *Instance) StartWithMessage(message string) error {
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
 
+	// One generation for this spawn, shared by the ownership claim and the
+	// fast-death watcher (sister path to Start()).
+	gen, wake := i.newSpawnGenWatch()
+
+	// #1873: claim the ownership receipt at spawn (sister path to Start()).
+	i.claimOwnershipAtSpawn(command, gen, wake)
+
 	// #1580: fast-death watcher (sister path to Start()).
 	if command != "" {
-		gen, wake := i.newSpawnGenWatch()
 		// See the matching comment in Start(): resolve the write targets — and
 		// subscribe to the wake — here, not inside the never-joined goroutine.
 		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
@@ -8203,6 +8232,14 @@ func (i *Instance) killInternal(sync bool) error {
 		}
 	}
 
+	// #1873: reap whatever the spawn-time ownership receipt still owns, then
+	// clear it. tmux teardown does not reach a tree that has already escaped
+	// the pane — that is the whole report — and a deliberate stop is exactly
+	// the intent that authorises terminating this session's processes. Only
+	// identity-matched processes are signalled; anything unverifiable is left
+	// alone and the receipt is kept so it stays visible.
+	i.clearOwnershipAfterTeardown(sync)
+
 	// Remove the scratch CLAUDE_CONFIG_DIR prepared at spawn time for
 	// this worker (issue #59, v1.7.68). Best-effort — leaking a scratch
 	// dir on an unclean shutdown is harmless, just wasteful.
@@ -8257,7 +8294,24 @@ func (i *Instance) restart(env map[string]string) error {
 	if spawnedSince(i.ID, beforeLock) && len(env) == 0 {
 		return nil
 	}
+	// #1873: the case this issue reports IS a restart — a pane that died during
+	// startup, a wrapped tree that escaped it, and a later legitimate restart
+	// that spawns a second one. The gate runs before the generation bump and
+	// before any tmux work, so a refusal changes nothing at all: no kill, no
+	// respawn, no signal, and the receipt left intact for inspection.
+	if err := i.guardOwnedProcessesBeforeSpawn("restart"); err != nil {
+		return err
+	}
+	// Deferred only once the gate has passed: a refused restart started nothing,
+	// so it must not leave a spawn stamp that makes a concurrent caller believe
+	// a replacement is already running.
 	defer recordInstanceSpawn(i.ID)
+	// Registered AFTER the gate and BEFORE the tmux work, so it runs on every
+	// exit of this function — including each per-tool respawn-pane fast path —
+	// while the spawn lock is still held (deferred release() was registered
+	// first, so it runs last). A replacement pane that kept the previous
+	// receipt would be an unowned tree.
+	defer func() { i.commitOwnershipAfterRestart(i.Command) }()
 
 	// #1775: supersede the fast-death watcher from the PREVIOUS spawn here, at
 	// the single entry point, rather than deeper down. restart() has several

--- a/internal/session/issue1873_escaped_tree_repro_test.go
+++ b/internal/session/issue1873_escaped_tree_repro_test.go
@@ -257,13 +257,17 @@ func startEscapedInstance(t *testing.T, w *escapedWrapper, id string) (*Instance
 
 	require.NoError(t, inst.Start())
 	t.Cleanup(func() { _ = inst.Kill() })
+	panePID, err := inst.GetTmuxSession().PanePID()
+	require.NoError(t, err)
 
 	kids := w.waitForChildren(1, 15*time.Second)
 	child := kids[len(kids)-1]
 	require.True(t, paneGoneWithin(inst, 20*time.Second),
 		"the pane must die inside the fast-death window for this reproduction")
 	requireChildAlive(t, child, "the wrapped child must survive the pane it was launched from")
-	require.NotEqual(t, childPPID(child.PID), os.Getpid(),
+	ppid := childPPID(child.PID)
+	require.Greater(t, ppid, 0, "the survivor must still have a readable parent")
+	require.NotEqual(t, panePID, ppid,
 		"the survivor must have been reparented away from the pane tree")
 	return inst, child
 }

--- a/internal/session/issue1873_escaped_tree_repro_test.go
+++ b/internal/session/issue1873_escaped_tree_repro_test.go
@@ -1,0 +1,304 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #1873 reproduction.
+//
+// A session launched through a wrapper loses its tmux pane during the
+// fast-start window while the wrapped process tree survives, reparented away
+// from the pane. agent-deck records the session as errored — and the next
+// legitimate restart spawns a SECOND tree against the same instance.
+//
+// The fixture below is the issue's own deterministic repository reproduction: a
+// fake wrapper that starts a long-lived child in a new session/process group,
+// makes it ignore SIGHUP, records the child's pid/pgid plus its
+// /proc/<pid>/stat start time under the test's own temp dir, and then exits
+// non-zero. Only pids this test created are ever signalled, on every exit path.
+
+// escapedWrapper is a fake wrapper script plus the record of every child it has
+// spawned across restarts.
+type escapedWrapper struct {
+	t      *testing.T
+	script string
+	recDir string
+	linger time.Duration
+}
+
+// escapedChild is one recorded survivor.
+type escapedChild struct {
+	PID   int
+	Start string
+	PGID  int
+}
+
+func (c escapedChild) String() string {
+	return fmt.Sprintf("pid=%d pgid=%d start=%s", c.PID, c.PGID, c.Start)
+}
+
+// requireEscapedWrapperSupport gates the fixture on what it actually needs: a
+// Linux /proc for start identity and setsid(1) to detach the child. The
+// ownership contract itself is cross-platform; this reproduction is not.
+func requireEscapedWrapperSupport(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("#1873 reproduction needs /proc start identity (linux)")
+	}
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid not available: cannot detach a child into its own session")
+	}
+	skipIfNoTmuxBinary(t)
+}
+
+// wrapperScript is the fixture. $$ inside the setsid'd shell is the child's own
+// pid; fields 22 and 5 of /proc/<pid>/stat are its start time and its process
+// group. The marker file is what lets the wrapper wait until the child has
+// published its identity before dying, so the record is never half-written.
+const wrapperScript = `#!/bin/sh
+REC="$1"
+LINGER="$2"
+MARK="$REC/ready.$$"
+setsid /bin/sh -c '
+  trap "" HUP
+  R="$1"; M="$2"
+  set -- $(awk "{print \$22, \$5}" /proc/$$/stat)
+  printf "%s %s %s\n" "$$" "$1" "$2" > "$R/child.$$.tmp"
+  mv "$R/child.$$.tmp" "$R/child.$$.txt"
+  : > "$M"
+  while : ; do sleep 1; done
+' fakeagent1873 "$REC" "$MARK" &
+n=0
+while [ ! -f "$MARK" ] && [ $n -lt 200 ]; do n=$((n+1)); sleep 0.05; done
+sleep "$LINGER"
+exit 3
+`
+
+// newEscapedWrapper writes the fixture and registers the cleanup that kills
+// every pid it created — and nothing else — even when the test fails.
+//
+// linger is how long the wrapper stays alive after its child has published its
+// identity. It is NOT cosmetic: a PID+start-time receipt can only record a
+// descendant while that descendant is still reachable from the pane leader, so
+// the wrapper has to outlive its own fork by at least one attribution pass.
+// That is the honest boundary of this contract — see
+// TestIssue1873_ChildThatDetachesBeforeAttributionIsNeverClaimed.
+func newEscapedWrapper(t *testing.T, linger time.Duration) *escapedWrapper {
+	t.Helper()
+	dir := t.TempDir()
+	recDir := filepath.Join(dir, "record")
+	require.NoError(t, os.MkdirAll(recDir, 0o700))
+	script := filepath.Join(dir, "wrapper-1873.sh")
+	require.NoError(t, os.WriteFile(script, []byte(wrapperScript), 0o700))
+
+	w := &escapedWrapper{t: t, script: script, recDir: recDir, linger: linger}
+	t.Cleanup(w.killOwnPIDs)
+	return w
+}
+
+// command is the Instance.Command that runs the wrapper.
+func (w *escapedWrapper) command() string {
+	return fmt.Sprintf("%s %s %.2f", w.script, w.recDir, w.linger.Seconds())
+}
+
+// children returns every child the wrapper has recorded so far.
+func (w *escapedWrapper) children() []escapedChild {
+	entries, err := filepath.Glob(filepath.Join(w.recDir, "child.*.txt"))
+	if err != nil {
+		return nil
+	}
+	var out []escapedChild
+	for _, path := range entries {
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		parts := strings.Fields(string(data))
+		if len(parts) != 3 {
+			continue
+		}
+		pid, err1 := strconv.Atoi(parts[0])
+		pgid, err2 := strconv.Atoi(parts[2])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		out = append(out, escapedChild{PID: pid, Start: parts[1], PGID: pgid})
+	}
+	return out
+}
+
+// waitForChildren blocks until the wrapper has recorded want children.
+func (w *escapedWrapper) waitForChildren(want int, timeout time.Duration) []escapedChild {
+	w.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if kids := w.children(); len(kids) >= want {
+			return kids
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	w.t.Fatalf("wrapper did not record %d child(ren) within %s (recorded %d)",
+		want, timeout, len(w.children()))
+	return nil
+}
+
+// killOwnPIDs terminates exactly the processes this fixture created, verifying
+// each one's start identity first so a recycled pid is never signalled. It runs
+// on every exit path, including failures and panics.
+func (w *escapedWrapper) killOwnPIDs() {
+	for _, child := range w.children() {
+		if !childAlive(child) {
+			continue
+		}
+		// The child is the leader of a process group it created for itself, so
+		// its group contains only its own descendants.
+		_ = syscall.Kill(-child.PGID, syscall.SIGTERM)
+		if waitForChildGone(child, 2*time.Second) {
+			continue
+		}
+		_ = syscall.Kill(-child.PGID, syscall.SIGKILL)
+		if !waitForChildGone(child, 2*time.Second) {
+			w.t.Errorf("fixture leaked a process it created: %s", child)
+		}
+	}
+}
+
+// childStart reads a live pid's start identity, or "" when it is gone.
+func childStart(pid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return ""
+	}
+	line := string(data)
+	closeIdx := strings.LastIndexByte(line, ')')
+	if closeIdx < 0 {
+		return ""
+	}
+	fields := strings.Fields(line[closeIdx+1:])
+	if len(fields) <= 19 {
+		return ""
+	}
+	if fields[0] == "Z" {
+		return "" // exited, awaiting reaping: not alive
+	}
+	return fields[19]
+}
+
+// childAlive reports whether the recorded identity — pid AND start time — is
+// still running. A pid whose start time has changed is somebody else.
+func childAlive(child escapedChild) bool {
+	return childStart(child.PID) == child.Start
+}
+
+func childPPID(pid int) int {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return -1
+	}
+	line := string(data)
+	closeIdx := strings.LastIndexByte(line, ')')
+	if closeIdx < 0 {
+		return -1
+	}
+	fields := strings.Fields(line[closeIdx+1:])
+	if len(fields) < 2 {
+		return -1
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return -1
+	}
+	return ppid
+}
+
+func waitForChildGone(child escapedChild, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !childAlive(child) {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return !childAlive(child)
+}
+
+func requireChildAlive(t *testing.T, child escapedChild, msg string) {
+	t.Helper()
+	require.True(t, childAlive(child), "%s: %s", msg, child)
+}
+
+func requireChildGone(t *testing.T, child escapedChild, msg string) {
+	t.Helper()
+	require.True(t, waitForChildGone(child, 5*time.Second), "%s: %s", msg, child)
+}
+
+// startEscapedInstance starts an instance through the fake wrapper and waits
+// for the pane to die while the wrapped child survives — the exact state the
+// issue reports.
+func startEscapedInstance(t *testing.T, w *escapedWrapper, id string) (*Instance, escapedChild) {
+	t.Helper()
+	inst := NewInstance(id, t.TempDir())
+	// A tool with no ToolDef runs Command verbatim as the pane's initial
+	// process, so the pane dies with the wrapper.
+	inst.Tool = "customwrap1873"
+	inst.Command = w.command()
+
+	require.NoError(t, inst.Start())
+	t.Cleanup(func() { _ = inst.Kill() })
+
+	kids := w.waitForChildren(1, 15*time.Second)
+	child := kids[len(kids)-1]
+	require.True(t, paneGoneWithin(inst, 20*time.Second),
+		"the pane must die inside the fast-death window for this reproduction")
+	requireChildAlive(t, child, "the wrapped child must survive the pane it was launched from")
+	require.NotEqual(t, childPPID(child.PID), os.Getpid(),
+		"the survivor must have been reparented away from the pane tree")
+	return inst, child
+}
+
+// TestIssue1873_RestartIsNotAdmittedWhileTheOwnedTreeSurvives is the
+// behavioural core of the report, written against the public seams only so it
+// runs unchanged on pre-fix code — where it fails, because the restart is
+// admitted and a second tree appears alongside the survivor.
+func TestIssue1873_RestartIsNotAdmittedWhileTheOwnedTreeSurvives(t *testing.T) {
+	requireEscapedWrapperSupport(t)
+
+	w := newEscapedWrapper(t, 800*time.Millisecond)
+	inst, survivor := startEscapedInstance(t, w, "test-1873-escaped")
+
+	err := inst.Restart()
+
+	require.Error(t, err,
+		"restart must not be admitted while an identity-matched owned process is still alive")
+	assert.Contains(t, strings.ToLower(err.Error()), "refused")
+	requireChildAlive(t, survivor, "a refused restart must not signal the survivor")
+	assert.False(t, paneAliveNow(inst.GetTmuxSession()),
+		"no replacement pane may exist: that is the second tree this issue is about")
+	assert.Len(t, w.children(), 1,
+		"exactly one wrapped tree may exist for this instance")
+}
+
+// TestIssue1873_TeardownReapsTheEscapedTree proves the survivor is reachable
+// after the fact: a deliberate stop reaps what the receipt owns, even though
+// the pane it escaped from is long gone.
+func TestIssue1873_TeardownReapsTheEscapedTree(t *testing.T) {
+	requireEscapedWrapperSupport(t)
+
+	w := newEscapedWrapper(t, 800*time.Millisecond)
+	inst, survivor := startEscapedInstance(t, w, "test-1873-teardown")
+
+	require.NoError(t, inst.Kill())
+	requireChildGone(t, survivor, "a deliberate stop must reap the escaped tree")
+}

--- a/internal/session/issue1873_ownership_receipt_test.go
+++ b/internal/session/issue1873_ownership_receipt_test.go
@@ -381,7 +381,10 @@ func writeTestReceipt(t *testing.T, instanceID string, leader procowner.Member) 
 		CreatedAt:  time.Now().Unix(),
 		Leader:     leader,
 	}
-	require.NoError(t, store.Save(receipt))
+	_, err := store.Commit(instanceID, func(*procowner.Receipt) (*procowner.Receipt, error) {
+		return receipt, nil
+	})
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.ForceClear(instanceID) })
 }
 

--- a/internal/session/issue1873_ownership_receipt_test.go
+++ b/internal/session/issue1873_ownership_receipt_test.go
@@ -1,0 +1,455 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asheshgoplani/agent-deck/internal/procowner"
+)
+
+// The two-wave proof the issue asks for, plus the fail-closed cases that a
+// PID-based ownership scheme actually dies of. The process-table ones use an
+// injected prober rather than real processes: "the /proc entry is unreadable"
+// and "this pid now belongs to another user" cannot be produced on demand by
+// spawning something and hoping.
+
+// TestIssue1873_TwoFastDeathWavesLeaveExactlyOneOwnedTree runs the reproduction
+// twice, which is the part that proves survivors do not accumulate: after each
+// wave the restart is refused, reconciliation reaps exactly the owned tree, and
+// the next wave starts from one live tree — never two.
+func TestIssue1873_TwoFastDeathWavesLeaveExactlyOneOwnedTree(t *testing.T) {
+	requireEscapedWrapperSupport(t)
+
+	w := newEscapedWrapper(t, 2*time.Second)
+	inst, wave1 := startEscapedInstance(t, w, "test-1873-two-wave")
+
+	// --- Wave 1 -----------------------------------------------------------
+	status := inst.OwnershipStatus()
+	require.NoError(t, status.LoadErr)
+	require.NotNil(t, status.Receipt, "the spawn must have left a durable receipt")
+	firstLeader := status.Receipt.Leader.Key()
+	// The survivor is a TREE: the detached child plus whatever it currently has
+	// running. What matters is that the recorded child is among the owned, and
+	// that they all belong to the one escaped tree.
+	require.Contains(t, survivorPIDs(status), wave1.PID,
+		"the escaped tree must be reported as an owned survivor: %s", status.Report.Describe())
+	assert.False(t, status.PaneAttached, "the pane this tree escaped from is gone")
+
+	err := inst.Restart()
+	require.Error(t, err, "restart must be refused while the owned tree is alive")
+	assert.True(t, IsOwnedProcessRecoveryRequired(err), "want a typed recovery error, got %T: %v", err, err)
+	requireChildAlive(t, wave1, "a refused restart signals nothing")
+	assert.Len(t, w.children(), 1, "no replacement tree may have been spawned")
+
+	// Safe reaping: identity-checked, verified dead, receipt cleared.
+	report, err := inst.ReconcileOwnership()
+	require.NoError(t, err)
+	require.Equal(t, procowner.VerdictClear, report.Verdict, report.Describe())
+	requireChildGone(t, wave1, "reconciliation must terminate the owned tree")
+	assert.Nil(t, inst.OwnershipStatus().Receipt, "a verified teardown clears the receipt")
+
+	// --- Wave 2 -----------------------------------------------------------
+	require.NoError(t, inst.Restart(), "restart must be admitted once nothing is owned")
+	kids := w.waitForChildren(2, 15*time.Second)
+	wave2 := kids[len(kids)-1]
+	require.True(t, paneGoneWithin(inst, 20*time.Second), "the second wave dies the same way")
+	requireChildAlive(t, wave2, "the second wrapped tree escaped its pane too")
+
+	// Exactly one owned tree, not two: this is the accumulation the issue asks
+	// us to disprove.
+	assert.False(t, childAlive(wave1), "the first wave's tree must still be dead")
+	assert.Equal(t, 1, liveWrappedTrees(w), "exactly one wrapped tree may be alive after two waves")
+
+	status = inst.OwnershipStatus()
+	require.NotNil(t, status.Receipt)
+	// The replacement spawn commits a NEW receipt rather than editing the old
+	// one. Its generation counts from 1 again because the previous receipt was
+	// verifiably cleared (a cleared receipt is an absent file, by design), so
+	// the identity of the leader — not the number — is what distinguishes it.
+	assert.NotEqual(t, firstLeader, status.Receipt.Leader.Key(),
+		"the new receipt must name the replacement's leader, not the reaped one")
+	require.Contains(t, survivorPIDs(status), wave2.PID)
+	assert.NotContains(t, survivorPIDs(status), wave1.PID,
+		"the reaped generation leaves nothing behind in the new receipt")
+
+	err = inst.Restart()
+	require.Error(t, err, "the second wave's survivor blocks a restart exactly like the first")
+	assert.True(t, IsOwnedProcessRecoveryRequired(err))
+
+	report, err = inst.ReconcileOwnership()
+	require.NoError(t, err)
+	require.Equal(t, procowner.VerdictClear, report.Verdict, report.Describe())
+	requireChildGone(t, wave2, "reconciliation must terminate the second wave's tree too")
+	assert.Equal(t, 0, liveWrappedTrees(w), "no survivor from either wave is left behind")
+	assert.Nil(t, inst.OwnershipStatus().Receipt)
+}
+
+// Two restarts racing the same escaped tree: both must be refused, and neither
+// may spawn a replacement. The spawn lock serialises them; the gate is what
+// makes the second one's answer the same as the first's.
+func TestIssue1873_ConcurrentRestartsAreBothRefused(t *testing.T) {
+	requireEscapedWrapperSupport(t)
+
+	w := newEscapedWrapper(t, 800*time.Millisecond)
+	inst, survivor := startEscapedInstance(t, w, "test-1873-race")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for idx := range errs {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			errs[n] = inst.Restart()
+		}(idx)
+	}
+	wg.Wait()
+
+	for n, err := range errs {
+		require.Error(t, err, "racing restart %d must be refused", n)
+		assert.True(t, IsOwnedProcessRecoveryRequired(err), "racing restart %d: %v", n, err)
+	}
+	requireChildAlive(t, survivor, "neither racing restart may signal the survivor")
+	assert.Equal(t, 1, liveWrappedTrees(w), "no racing restart may spawn a second tree")
+}
+
+// The guard must not fire on a healthy session: its pane process and every live
+// descendant are accounted for, so a normal restart still restarts.
+func TestIssue1873_HealthySessionWithLiveDescendantsStillRestarts(t *testing.T) {
+	requireEscapedWrapperSupport(t)
+
+	inst := NewInstance("test-1873-healthy", t.TempDir())
+	inst.Tool = "customlive1873"
+	// A pane process with a live descendant — the shape a real session has, and
+	// the shape a naive "any owned process blocks a restart" guard breaks on.
+	inst.Command = "/bin/sh -c 'sleep 120 & wait'"
+	require.NoError(t, inst.Start())
+	t.Cleanup(func() { _ = inst.Kill() })
+
+	// Give attribution a moment to record the descendant.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if st := inst.OwnershipStatus(); st.Receipt != nil && len(st.Receipt.Members) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	status := inst.OwnershipStatus()
+	require.NotNil(t, status.Receipt)
+	require.NotEmpty(t, status.Receipt.Members, "the live descendant must be attributed")
+	assert.True(t, status.PaneAttached)
+	assert.Empty(t, status.Survivors, "a live session's own processes are not survivors")
+
+	require.NoError(t, inst.Restart(), "a healthy session must still restart")
+	after := inst.OwnershipStatus()
+	require.NotNil(t, after.Receipt, "the replacement pane is owned in turn")
+	assert.Greater(t, after.Receipt.Generation, status.Receipt.Generation)
+	assert.NotEqual(t, status.Receipt.Leader.PID, after.Receipt.Leader.PID,
+		"the receipt names the replacement process, not the one respawn killed")
+}
+
+// A wrapper whose child detaches and outlives its whole ancestry before any
+// attribution pass can see it is, by construction, not attributable to a
+// PID+start-time receipt. The contract's answer must be "not owned" — never a
+// guess — and nothing may be signalled on its behalf.
+//
+// This is the failure shape the fixtures would otherwise never build: the
+// boundary of the ruled contract, asserted rather than assumed.
+func TestIssue1873_ChildThatDetachesBeforeAttributionIsNeverClaimed(t *testing.T) {
+	requireEscapedWrapperSupport(t)
+
+	w := newEscapedWrapper(t, 0) // exits the instant its child has published
+	inst, child := startEscapedInstance(t, w, "test-1873-unattributable")
+
+	status := inst.OwnershipStatus()
+	if status.Receipt != nil && status.Receipt.HasMember(procowner.Member{PID: child.PID, StartID: child.Start}) {
+		// Attribution won the race: then the tree IS owned and must be reported.
+		assert.Contains(t, survivorPIDs(status), child.PID)
+		return
+	}
+	// Attribution lost the race. The honest outcome: the process is not claimed,
+	// so it is not signalled and not reported as ours.
+	for _, m := range status.Survivors {
+		assert.NotEqual(t, child.PID, m.PID)
+	}
+	report, err := inst.ReconcileOwnership()
+	require.NoError(t, err)
+	for _, outcome := range report.Outcomes {
+		assert.NotEqual(t, child.PID, outcome.Member.PID,
+			"an unattributed process must never appear in a reap report")
+	}
+	assert.True(t, childAlive(child),
+		"an unattributed survivor is left strictly alone rather than killed on a guess")
+}
+
+// --- Fail-closed shapes, driven through an injected process table ----------
+
+func TestIssue1873_GateFailsClosedOnEveryUnverifiableShape(t *testing.T) {
+	leader := procowner.Member{PID: 4242, StartID: "5000", UID: os.Getuid(), Role: procowner.RoleLeader}
+
+	cases := []struct {
+		name       string
+		arrange    func(p *sessionFakeProber)
+		wantRefuse bool
+		wantSignal bool
+		reason     string
+	}{
+		{
+			name:       "owned survivor is alive",
+			arrange:    func(p *sessionFakeProber) { p.alive(leader.PID, leader.StartID, os.Getuid()) },
+			wantRefuse: true,
+			wantSignal: true, // reconciliation may terminate what it can prove is ours
+			reason:     "alive",
+		},
+		{
+			name:       "proc entry unreadable",
+			arrange:    func(p *sessionFakeProber) { p.fail(leader.PID, procowner.ErrUnreadable) },
+			wantRefuse: true,
+			wantSignal: false,
+			reason:     "could not be verified",
+		},
+		{
+			name: "pid now belongs to another user",
+			arrange: func(p *sessionFakeProber) {
+				p.alive(leader.PID, leader.StartID, os.Getuid()+1)
+			},
+			wantRefuse: true,
+			wantSignal: false,
+			reason:     "uid",
+		},
+		{
+			name:       "boot id unreadable",
+			arrange:    func(p *sessionFakeProber) { p.bootErr = fmt.Errorf("%w: boot", procowner.ErrUnreadable) },
+			wantRefuse: true,
+			wantSignal: false,
+			reason:     "boot id",
+		},
+		{
+			name: "pid recycled by an unrelated process",
+			arrange: func(p *sessionFakeProber) {
+				p.alive(leader.PID, "9999", os.Getuid()) // different start identity
+			},
+			wantRefuse: false, // the recorded process is provably dead
+			wantSignal: false, // ...and the new occupant is never touched
+			reason:     "",
+		},
+		{
+			name:       "process is gone",
+			arrange:    func(p *sessionFakeProber) {},
+			wantRefuse: false,
+			wantSignal: false,
+			reason:     "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prober := newSessionFakeProber()
+			tc.arrange(prober)
+			signaler := &countingSignaler{}
+			restore := swapOwnershipProbe(t, prober, signaler)
+			defer restore()
+
+			inst := NewInstance("test-1873-"+sanitizeTestID(tc.name), t.TempDir())
+			writeTestReceipt(t, inst.ID, leader)
+
+			err := inst.guardOwnedProcessesBeforeSpawn("restart")
+			if tc.wantRefuse {
+				require.Error(t, err, "this shape must fail closed")
+				require.True(t, IsOwnedProcessRecoveryRequired(err), "want a typed recovery error: %v", err)
+				assert.Contains(t, err.Error(), tc.reason)
+			} else {
+				require.NoError(t, err, "a provably dead receipt must not block a restart")
+			}
+			assert.Empty(t, signaler.calls, "the admission gate never signals anything")
+
+			// Reconciliation is the only path allowed to signal, and only for
+			// identities it can still prove are ours.
+			_, reconcileErr := inst.ReconcileOwnership()
+			require.NoError(t, reconcileErr)
+			if tc.wantSignal {
+				assert.NotEmpty(t, signaler.calls, "an identity-matched owned process must be reaped")
+				for _, c := range signaler.calls {
+					assert.Equal(t, leader.PID, c.pid, "only the recorded identity may be signalled")
+				}
+			} else {
+				assert.Empty(t, signaler.calls, "nothing unverified may ever be signalled")
+			}
+		})
+	}
+}
+
+// A corrupt or truncated receipt is not the same as no receipt: it means we
+// recorded ownership and can no longer read it.
+func TestIssue1873_CorruptReceiptFailsClosed(t *testing.T) {
+	prober := newSessionFakeProber()
+	signaler := &countingSignaler{}
+	restore := swapOwnershipProbe(t, prober, signaler)
+	defer restore()
+
+	inst := NewInstance("test-1873-corrupt", t.TempDir())
+	store := ownershipStore()
+	path, err := store.Path(inst.ID)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(`{"version":1,"instance_i`), 0o600))
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	err = inst.guardOwnedProcessesBeforeSpawn("restart")
+	require.Error(t, err)
+	assert.True(t, IsOwnedProcessRecoveryRequired(err))
+	assert.Contains(t, err.Error(), "could not be read")
+	assert.Empty(t, signaler.calls)
+
+	// The explicit operator escape hatch: discard the unreadable claim without
+	// signalling anything, and only then admit a replacement.
+	require.NoError(t, inst.AbandonOwnership())
+	assert.Empty(t, signaler.calls, "abandoning a receipt never kills anything")
+	require.NoError(t, inst.guardOwnedProcessesBeforeSpawn("restart"))
+}
+
+// A receipt written before a reboot names pids that cannot exist. Without this,
+// every session that did not shut down cleanly would be blocked forever after a
+// restart of the machine.
+func TestIssue1873_ReceiptFromAPreviousBootIsCleared(t *testing.T) {
+	prober := newSessionFakeProber()
+	// The pid is live and its start identity matches — but the boot differs.
+	prober.alive(4242, "5000", os.Getuid())
+	prober.boot = "boot-after-reboot"
+	signaler := &countingSignaler{}
+	restore := swapOwnershipProbe(t, prober, signaler)
+	defer restore()
+
+	inst := NewInstance("test-1873-reboot", t.TempDir())
+	writeTestReceipt(t, inst.ID, procowner.Member{PID: 4242, StartID: "5000", UID: os.Getuid(), Role: procowner.RoleLeader})
+
+	require.NoError(t, inst.guardOwnedProcessesBeforeSpawn("restart"))
+	assert.Empty(t, signaler.calls, "a live pid that merely matches a pre-reboot receipt is a stranger")
+	assert.Nil(t, inst.OwnershipStatus().Receipt, "the stale receipt is retired")
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func survivorPIDs(status OwnershipStatus) []int {
+	pids := make([]int, 0, len(status.Survivors))
+	for _, m := range status.Survivors {
+		pids = append(pids, m.PID)
+	}
+	return pids
+}
+
+func liveWrappedTrees(w *escapedWrapper) int {
+	n := 0
+	for _, c := range w.children() {
+		if childAlive(c) {
+			n++
+		}
+	}
+	return n
+}
+
+func sanitizeTestID(name string) string {
+	out := make([]rune, 0, len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			out = append(out, r)
+		default:
+			out = append(out, '-')
+		}
+	}
+	return string(out)
+}
+
+func writeTestReceipt(t *testing.T, instanceID string, leader procowner.Member) {
+	t.Helper()
+	store := ownershipStore()
+	receipt := &procowner.Receipt{
+		Version:    procowner.ReceiptVersion,
+		InstanceID: instanceID,
+		Generation: 1,
+		State:      procowner.StateLive,
+		Provider:   "session_fake",
+		BootID:     "boot-1",
+		CreatedAt:  time.Now().Unix(),
+		Leader:     leader,
+	}
+	require.NoError(t, store.Save(receipt))
+	t.Cleanup(func() { _ = store.ForceClear(instanceID) })
+}
+
+func swapOwnershipProbe(t *testing.T, p procowner.Prober, s procowner.Signaler) func() {
+	t.Helper()
+	prevProber, prevSignaler := ownershipProber, ownershipSignaler
+	ownershipProber, ownershipSignaler = p, s
+	return func() { ownershipProber, ownershipSignaler = prevProber, prevSignaler }
+}
+
+// sessionFakeProber is a scriptable process table for the session-level gate.
+type sessionFakeProber struct {
+	boot    string
+	bootErr error
+	procs   map[int]procowner.ProcInfo
+	errs    map[int]error
+}
+
+func newSessionFakeProber() *sessionFakeProber {
+	return &sessionFakeProber{boot: "boot-1", procs: map[int]procowner.ProcInfo{}, errs: map[int]error{}}
+}
+
+func (p *sessionFakeProber) alive(pid int, start string, uid int) {
+	p.procs[pid] = procowner.ProcInfo{PID: pid, PPID: 1, PGID: pid, UID: uid, StartID: start}
+}
+
+func (p *sessionFakeProber) fail(pid int, err error) {
+	p.errs[pid] = fmt.Errorf("%w: pid %d", err, pid)
+}
+
+func (p *sessionFakeProber) Name() string { return "session_fake" }
+
+func (p *sessionFakeProber) BootID() (string, error) {
+	if p.bootErr != nil {
+		return "", p.bootErr
+	}
+	return p.boot, nil
+}
+
+func (p *sessionFakeProber) Inspect(pid int) (procowner.ProcInfo, error) {
+	if err, ok := p.errs[pid]; ok {
+		return procowner.ProcInfo{}, err
+	}
+	info, ok := p.procs[pid]
+	if !ok {
+		return procowner.ProcInfo{}, fmt.Errorf("%w: pid %d", procowner.ErrNoProcess, pid)
+	}
+	return info, nil
+}
+
+func (p *sessionFakeProber) Descendants(root procowner.ProcInfo) ([]procowner.ProcInfo, error) {
+	return nil, nil
+}
+
+type signalRecord struct {
+	pid int
+	sig syscall.Signal
+}
+
+// countingSignaler records signals and delivers none of them.
+type countingSignaler struct {
+	mu    sync.Mutex
+	calls []signalRecord
+}
+
+func (c *countingSignaler) Signal(pid int, sig syscall.Signal) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, signalRecord{pid: pid, sig: sig})
+	return nil
+}

--- a/internal/session/issue1873_receipt_race_test.go
+++ b/internal/session/issue1873_receipt_race_test.go
@@ -1,0 +1,416 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/asheshgoplani/agent-deck/internal/procowner"
+)
+
+// Concurrency around the receipt, from the review of #1961.
+//
+// Both cases below are the same shape: a guard that is narrower than the
+// invariant it claims. A cancellation that stops new work but leaves work
+// already in flight armed is not cancellation, and a compare-and-swap held only
+// by a process-local mutex is not a compare-and-swap — a second agent-deck
+// process validates the same stale state and proceeds. Atomic replacement does
+// not help with either: it makes the write indivisible, not the decision.
+
+// ownershipChildEnv makes the test binary act as a second agent-deck process.
+// The value is "<dir>|<instance>|<pid>|<mode>".
+const ownershipChildEnv = "AGENTDECK_TEST_OWNERSHIP_CHILD"
+
+// runOwnershipReceiptChild is dispatched from TestMain when the env var is set.
+// It performs ONE receipt operation against the same store the parent uses and
+// exits: a real second process, which is the only way to test a lock whose
+// whole purpose is to span two of them.
+func runOwnershipReceiptChild(payload string) int {
+	parts := strings.Split(payload, "|")
+	if len(parts) != 4 {
+		fmt.Fprintf(os.Stderr, "ownership child: bad payload %q\n", payload)
+		return 2
+	}
+	dir, instanceID, mode := parts[0], parts[1], parts[3]
+	pid, err := strconv.Atoi(parts[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ownership child: bad pid %q\n", parts[2])
+		return 2
+	}
+	store := ownershipStoreAt(dir)
+
+	switch mode {
+	case "hold":
+		// Take the lock and never release it: the parent kills this process to
+		// prove the kernel drops the flock when its holder dies. Holding it
+		// here, in the process the parent kills, is deliberate — a holder that
+		// spawns a grandchild would leak the fd (and the process) into it and
+		// prove nothing.
+		path, pathErr := store.Path(instanceID)
+		if pathErr != nil {
+			fmt.Fprintf(os.Stderr, "ownership child: %v\n", pathErr)
+			return 2
+		}
+		release, lockErr := ownershipReceiptLock(path)
+		if lockErr != nil {
+			fmt.Fprintf(os.Stderr, "ownership child: %v\n", lockErr)
+			return 2
+		}
+		defer release()
+		fmt.Println("held")
+		time.Sleep(60 * time.Second)
+		return 0
+	case "append":
+		// Read-modify-write: add one member that only this child knows about.
+		// The sleep widens the window between the read and the write, which is
+		// precisely the window a process-local mutex does not cover.
+		err = store.Update(instanceID, func(current *procowner.Receipt) error {
+			time.Sleep(150 * time.Millisecond)
+			current.Members = append(current.Members, procowner.Member{
+				PID:     pid,
+				StartID: strconv.Itoa(pid),
+				UID:     os.Getuid(),
+				Role:    procowner.RoleDescendant,
+			})
+			return nil
+		})
+	default:
+		fmt.Fprintf(os.Stderr, "ownership child: unknown mode %q\n", mode)
+		return 2
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ownership child: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// seedRaceReceipt writes a receipt with no members and returns it.
+func seedRaceReceipt(t *testing.T, store *procowner.Store, instanceID string) *procowner.Receipt {
+	t.Helper()
+	receipt, err := store.Commit(instanceID, func(*procowner.Receipt) (*procowner.Receipt, error) {
+		return &procowner.Receipt{
+			Version:    procowner.ReceiptVersion,
+			InstanceID: instanceID,
+			Generation: 1,
+			State:      procowner.StateLive,
+			Provider:   "session_fake",
+			BootID:     "boot-1",
+			CreatedAt:  time.Now().Unix(),
+			Leader: procowner.Member{
+				PID: 4242, StartID: "5000", UID: os.Getuid(), Role: procowner.RoleLeader,
+			},
+		}, nil
+	})
+	require.NoError(t, err)
+	return receipt
+}
+
+// TestIssue1873_CrossProcessReceiptUpdatesDoNotLoseEachOther is the two-process
+// compare-and-swap test. Two agent-deck processes each add a member to the same
+// receipt; both must survive.
+//
+// Against a process-local mutex this fails: the second process reads a receipt
+// that predates the first process's write, then writes its own copy back, and
+// the first member is silently gone — the loser of the race quietly wins.
+func TestIssue1873_CrossProcessReceiptUpdatesDoNotLoseEachOther(t *testing.T) {
+	dir := t.TempDir()
+	instanceID := "race-cross-process"
+	store := ownershipStoreAt(dir)
+	seedRaceReceipt(t, store, instanceID)
+
+	const children = 2
+	var wg sync.WaitGroup
+	results := make([]error, children)
+	pids := []int{9001, 9002}
+	for idx := 0; idx < children; idx++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			results[n] = runOwnershipChildProcess(t, dir, instanceID, pids[n], "append")
+		}(idx)
+	}
+	wg.Wait()
+
+	for n, err := range results {
+		require.NoError(t, err, "child %d failed", n)
+	}
+
+	loaded, err := store.Load(instanceID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	got := map[int]bool{}
+	for _, m := range loaded.Members {
+		got[m.PID] = true
+	}
+	for _, pid := range pids {
+		assert.True(t, got[pid],
+			"member %d was lost: a second process read state the first had already invalidated (members=%v)",
+			pid, loaded.Members)
+	}
+}
+
+// TestIssue1873_LateUpdateAfterClearIsANoOp is the resurrection guard. An
+// update that was already in flight when the receipt was cleared must not
+// recreate it.
+//
+// A receipt that comes back from the dead is worse than no receipt: every later
+// decision — may this restart be admitted, which pids may be signalled — trusts
+// it, and it now describes processes that were reaped.
+func TestIssue1873_LateUpdateAfterClearIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	instanceID := "race-late-update"
+	store := ownershipStoreAt(dir)
+	receipt := seedRaceReceipt(t, store, instanceID)
+
+	// The teardown wins the race and clears the receipt.
+	require.NoError(t, store.Clear(receipt))
+
+	// The in-flight writer arrives afterwards holding the receipt it was
+	// working on.
+	err := store.Update(instanceID, func(current *procowner.Receipt) error {
+		current.Members = append(current.Members, procowner.Member{
+			PID: 9100, StartID: "9100", UID: os.Getuid(), Role: procowner.RoleDescendant,
+		})
+		return nil
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, procowner.ErrReceiptGone)
+
+	loaded, loadErr := store.Load(instanceID)
+	require.NoError(t, loadErr)
+	assert.Nil(t, loaded, "a cleared receipt must stay cleared")
+}
+
+// TestIssue1873_CancellationDisarmsAnInFlightUpdate covers the ordering the
+// previous test does not: cancellation landing WHILE the update is queued for
+// the lock, rather than before it starts.
+//
+// The mutator's window check runs after the lock is won, so the write is
+// dropped. Checking only before enqueueing would let a cancelled writer apply
+// its work after the teardown that cancelled it.
+func TestIssue1873_CancellationDisarmsAnInFlightUpdate(t *testing.T) {
+	dir := t.TempDir()
+	instanceID := "race-cancel-in-flight"
+	store := ownershipStoreAt(dir)
+	seedRaceReceipt(t, store, instanceID)
+
+	cancelled := make(chan struct{})
+	blocked := make(chan struct{})
+	released := make(chan struct{})
+
+	// Hold the lock so the update below has to queue for it.
+	go func() {
+		_ = store.Update(instanceID, func(*procowner.Receipt) error {
+			close(blocked)
+			<-released
+			return procowner.ErrNoChange
+		})
+	}()
+	<-blocked
+
+	var updateErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		updateErr = store.Update(instanceID, func(current *procowner.Receipt) error {
+			// By the time this runs, the cancellation below has already fired.
+			select {
+			case <-cancelled:
+				return procowner.ErrWindowClosed
+			default:
+			}
+			current.Members = append(current.Members, procowner.Member{
+				PID: 9200, StartID: "9200", UID: os.Getuid(), Role: procowner.RoleDescendant,
+			})
+			return nil
+		})
+	}()
+
+	// Cancel while the second update is parked on the lock, then let it through.
+	time.Sleep(50 * time.Millisecond)
+	close(cancelled)
+	close(released)
+	<-done
+
+	require.Error(t, updateErr)
+	assert.ErrorIs(t, updateErr, procowner.ErrWindowClosed)
+	loaded, err := store.Load(instanceID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Empty(t, loaded.Members, "a cancelled writer must not apply its work after the fact")
+}
+
+// TestIssue1873_LockSurvivesAProcessThatDiesHoldingIt: a lock that a crashed
+// holder keeps forever is a deadlock dressed as safety. The advisory flock is
+// released by the kernel when the holding process dies, so the next acquirer
+// proceeds rather than waiting on a corpse.
+func TestIssue1873_LockSurvivesAProcessThatDiesHoldingIt(t *testing.T) {
+	dir := t.TempDir()
+	instanceID := "race-dead-holder"
+	store := ownershipStoreAt(dir)
+	seedRaceReceipt(t, store, instanceID)
+
+	// A second process that takes the receipt lock and is then killed without
+	// releasing it.
+	holder := exec.Command(os.Args[0], "-test.run", "TestIssue1873_OwnershipChildEntrypoint")
+	holder.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s|%s|%d|hold", ownershipChildEnv, dir, instanceID, os.Getpid()))
+	stdout, err := holder.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, holder.Start())
+	killed := false
+	t.Cleanup(func() {
+		if !killed {
+			_ = holder.Process.Kill()
+		}
+		_ = holder.Wait()
+	})
+
+	// Wait until the child reports it holds the lock, so the kill below is a
+	// kill of a holder rather than a race with one.
+	buf := make([]byte, len("held\n"))
+	deadline := time.Now().Add(10 * time.Second)
+	for !strings.Contains(string(buf), "held") && time.Now().Before(deadline) {
+		n, readErr := stdout.Read(buf)
+		if readErr != nil || n == 0 {
+			break
+		}
+	}
+	require.Contains(t, string(buf), "held", "child never reported holding the lock")
+
+	// Kill the holder, then prove the store can still take the lock. If the
+	// kernel did not release the flock on exit this would block until the
+	// deadline below.
+	require.NoError(t, holder.Process.Kill())
+	killed = true
+	_ = holder.Wait()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- store.Update(instanceID, func(current *procowner.Receipt) error {
+			current.Note = "acquired after the holder died"
+			return nil
+		})
+	}()
+	select {
+	case updateErr := <-done:
+		require.NoError(t, updateErr)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the receipt lock was never released after its holder died")
+	}
+}
+
+// runOwnershipChildProcess re-executes this test binary as a second agent-deck
+// process performing one receipt operation.
+func runOwnershipChildProcess(t *testing.T, dir, instanceID string, pid int, mode string) error {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run", "TestIssue1873_OwnershipChildEntrypoint")
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s|%s|%d|%s", ownershipChildEnv, dir, instanceID, pid, mode))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("child %d: %w: %s", pid, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// TestIssue1873_OwnershipChildEntrypoint exists so the child invocation has a
+// test to name; the work happens in TestMain before any test runs.
+func TestIssue1873_OwnershipChildEntrypoint(t *testing.T) {
+	if os.Getenv(ownershipChildEnv) == "" {
+		t.Skip("child entrypoint: only meaningful when re-executed by the race tests")
+	}
+}
+
+// TestIssue1873_GenerationResetDoesNotLetAStaleWriterWin covers the shape the
+// two required tests do not: the generation counter RESETTING rather than
+// advancing.
+//
+// A verifiably cleared receipt is an absent file, so the next spawn starts at
+// generation 1 again — and a stale writer from the previous generation 1 finds
+// a number that matches its own. The leader identity is what separates them,
+// and it cannot collide: a different process cannot hold the same pid with the
+// same start time.
+func TestIssue1873_GenerationResetDoesNotLetAStaleWriterWin(t *testing.T) {
+	dir := t.TempDir()
+	instanceID := "race-generation-reset"
+	store := ownershipStoreAt(dir)
+	stale := seedRaceReceipt(t, store, instanceID) // generation 1, leader pid 4242
+
+	// Teardown reaps and clears it; the next spawn claims generation 1 afresh.
+	require.NoError(t, store.Clear(stale))
+	replacement, err := store.Commit(instanceID, func(existing *procowner.Receipt) (*procowner.Receipt, error) {
+		require.Nil(t, existing)
+		next := *stale
+		next.Leader = procowner.Member{PID: 5555, StartID: "6000", UID: os.Getuid(), Role: procowner.RoleLeader}
+		next.Members = nil
+		return &next, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), replacement.Generation, "generations restart after a verified clear")
+
+	// The stale writer's generation number matches. Its leader does not.
+	updateErr := store.Update(instanceID, func(current *procowner.Receipt) error {
+		return procowner.RequireGeneration(current, stale.Generation, stale.Leader)
+	})
+	require.Error(t, updateErr)
+	assert.ErrorIs(t, updateErr, procowner.ErrGenerationConflict)
+
+	loaded, err := store.Load(instanceID)
+	require.NoError(t, err)
+	assert.Equal(t, 5555, loaded.Leader.PID, "the replacement's receipt is untouched")
+}
+
+// TestIssue1873_UpdateReadsAfterAcquiringTheLock covers the last shape on the
+// list: the receipt changing between the lock being acquired and the state
+// being read.
+//
+// It cannot happen, and this is why: the load is INSIDE the critical section,
+// so a writer queued behind another sees that writer's result rather than the
+// state it observed before queueing. A load before the lock — the natural place
+// to put it — would reintroduce exactly the stale-decision race the lock exists
+// to close.
+func TestIssue1873_UpdateReadsAfterAcquiringTheLock(t *testing.T) {
+	dir := t.TempDir()
+	instanceID := "race-read-after-lock"
+	store := ownershipStoreAt(dir)
+	seedRaceReceipt(t, store, instanceID)
+
+	firstInside := make(chan struct{})
+	letFirstFinish := make(chan struct{})
+	go func() {
+		_ = store.Update(instanceID, func(current *procowner.Receipt) error {
+			close(firstInside)
+			<-letFirstFinish
+			current.Note = "written by the first writer"
+			return nil
+		})
+	}()
+	<-firstInside
+
+	var observed string
+	done := make(chan error, 1)
+	go func() {
+		done <- store.Update(instanceID, func(current *procowner.Receipt) error {
+			observed = current.Note
+			return procowner.ErrNoChange
+		})
+	}()
+
+	// The second update is queued for the lock. Release the first.
+	time.Sleep(50 * time.Millisecond)
+	close(letFirstFinish)
+	require.NoError(t, <-done)
+
+	assert.Equal(t, "written by the first writer", observed,
+		"the queued writer must read state as of the moment it won the lock, not as of the moment it queued")
+}

--- a/internal/session/issue1873_receipt_race_test.go
+++ b/internal/session/issue1873_receipt_race_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -277,15 +278,17 @@ func TestIssue1873_LockSurvivesAProcessThatDiesHoldingIt(t *testing.T) {
 
 	// Wait until the child reports it holds the lock, so the kill below is a
 	// kill of a holder rather than a race with one.
-	buf := make([]byte, len("held\n"))
-	deadline := time.Now().Add(10 * time.Second)
-	for !strings.Contains(string(buf), "held") && time.Now().Before(deadline) {
-		n, readErr := stdout.Read(buf)
-		if readErr != nil || n == 0 {
-			break
-		}
+	lineCh := make(chan string, 1)
+	go func() {
+		line, _ := bufio.NewReader(stdout).ReadString('\n')
+		lineCh <- line
+	}()
+	select {
+	case line := <-lineCh:
+		require.Contains(t, line, "held", "child never reported holding the lock")
+	case <-time.After(10 * time.Second):
+		t.Fatal("child never reported holding the lock")
 	}
-	require.Contains(t, string(buf), "held", "child never reported holding the lock")
 
 	// Kill the holder, then prove the store can still take the lock. If the
 	// kernel did not release the flock on exit this would block until the

--- a/internal/session/ownership.go
+++ b/internal/session/ownership.go
@@ -54,9 +54,26 @@ var (
 	ownershipSignaler procowner.Signaler = procowner.OSSignaler{}
 )
 
-// ownershipStores caches one Store per directory. The Store serializes its own
-// writes, so sharing the instance is what makes that lock mean anything.
+// ownershipStores caches one Store per directory.
 var ownershipStores sync.Map // dir -> *procowner.Store
+
+// ownershipReceiptLock is the cross-process serialization for a receipt's whole
+// load → check → write cycle.
+//
+// It delegates to AcquireConfigFileLock, the tree's ONE implementation of
+// "serialize a read-modify-write over a file two processes can both touch"
+// (in-process mutex keyed by path, plus an advisory flock on a sibling .lock).
+// A second, private lock here would be worse than none: two cross-process locks
+// that do not know about each other serialize nothing between them, and the
+// same defect has reappeared in this repository every time a shared rule was
+// copied instead of called.
+func ownershipReceiptLock(path string) (func(), error) {
+	lock, err := AcquireConfigFileLock(path)
+	if err != nil {
+		return nil, err
+	}
+	return lock.Release, nil
+}
 
 // ownershipDir returns <data>/runtime/ownership, mirroring spawnFailureDir's
 // fallback so an unresolvable data dir degrades to a temp path instead of
@@ -74,7 +91,7 @@ func ownershipStoreAt(dir string) *procowner.Store {
 	if existing, ok := ownershipStores.Load(dir); ok {
 		return existing.(*procowner.Store)
 	}
-	created := procowner.NewStore(dir)
+	created := procowner.NewStore(dir, ownershipReceiptLock)
 	actual, _ := ownershipStores.LoadOrStore(dir, created)
 	return actual.(*procowner.Store)
 }
@@ -394,40 +411,43 @@ func (i *Instance) claimOwnershipAtSpawn(command string, gen uint64, wake <-chan
 			slog.String("error", logging.SanitizeValue(errString(err))))
 		return
 	}
-	generation, err := store.NextGeneration(i.ID)
-	if err != nil {
-		sessionLog.Warn("ownership_receipt_generation_failed",
-			slog.String("instance_id", logging.SanitizeValue(i.ID)),
-			slog.String("error", logging.SanitizeValue(err.Error())))
-		return
-	}
-	receipt, err := procowner.Claim(ownershipProber, procowner.ClaimInput{
-		InstanceID: i.ID,
-		Generation: generation,
-		PanePID:    panePID,
-		TmuxName:   i.tmuxSession.Name,
-		TmuxSocket: i.TmuxSocketName,
-		Command:    redactEnvValues(command),
+	// Choosing the generation and writing the receipt are ONE critical section.
+	// Split apart, two spawns can read the same predecessor and both conclude
+	// they are its successor — an atomic write of a decision made on stale
+	// state is just a reliable way to persist the wrong answer.
+	receipt, err := store.Commit(i.ID, func(existing *procowner.Receipt) (*procowner.Receipt, error) {
+		var generation uint64 = 1
+		if existing != nil {
+			generation = existing.Generation + 1
+		}
+		claimed, claimErr := procowner.Claim(ownershipProber, procowner.ClaimInput{
+			InstanceID: i.ID,
+			Generation: generation,
+			PanePID:    panePID,
+			TmuxName:   i.tmuxSession.Name,
+			TmuxSocket: i.TmuxSocketName,
+			Command:    redactEnvValues(command),
+		})
+		if claimErr != nil {
+			// Unsupported platform, or a pane process that exited between the
+			// tmux start and this probe. Either way: no claim, and the abort
+			// leaves whatever was on disk untouched.
+			return nil, claimErr
+		}
+		// Attribute once inside the same critical section so a wrapper that
+		// forks and exits before the first tick is still caught, and so the
+		// receipt reaches disk complete rather than in two writes.
+		if _, attrErr := procowner.Attribute(ownershipProber, claimed, nil); attrErr != nil {
+			sessionLog.Debug("ownership_attribution_initial_skipped",
+				slog.String("instance_id", logging.SanitizeValue(i.ID)),
+				slog.String("reason", logging.SanitizeValue(attrErr.Error())))
+		}
+		return claimed, nil
 	})
 	if err != nil {
-		// Unsupported platform, or a pane process that exited between the tmux
-		// start and this probe. Either way: no claim.
 		sessionLog.Info("ownership_receipt_not_claimed",
 			slog.String("instance_id", logging.SanitizeValue(i.ID)),
 			slog.String("reason", logging.SanitizeValue(err.Error())))
-		return
-	}
-	// Attribute once synchronously so a wrapper that forks and exits inside the
-	// first tick is still caught, then commit receipt + members in one write.
-	if _, attrErr := procowner.Attribute(ownershipProber, receipt, nil); attrErr != nil {
-		sessionLog.Debug("ownership_attribution_initial_skipped",
-			slog.String("instance_id", logging.SanitizeValue(i.ID)),
-			slog.String("reason", logging.SanitizeValue(attrErr.Error())))
-	}
-	if err := store.Save(receipt); err != nil {
-		sessionLog.Warn("ownership_receipt_write_failed",
-			slog.String("instance_id", logging.SanitizeValue(i.ID)),
-			slog.String("error", logging.SanitizeValue(err.Error())))
 		return
 	}
 	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
@@ -451,7 +471,7 @@ func (i *Instance) claimOwnershipAtSpawn(command string, gen uint64, wake <-chan
 // that still verifies against the receipt, and it stops the moment that leader
 // stops being ours. Nothing here can add a process that was not, at the instant
 // of a single stat read, a live descendant of a process this spawn owns.
-func (i *Instance) attributeOwnedTree(receipt *procowner.Receipt, store *procowner.Store, gen uint64, wake <-chan struct{}) {
+func (i *Instance) attributeOwnedTree(owned *procowner.Receipt, store *procowner.Store, gen uint64, wake <-chan struct{}) {
 	start := time.Now()
 	deadline := start.Add(ownershipAttributeMaxWindow)
 	for {
@@ -472,24 +492,48 @@ func (i *Instance) attributeOwnedTree(receipt *procowner.Receipt, store *procown
 		if i.spawnGen.Load() != gen {
 			return
 		}
-		added, err := procowner.Attribute(ownershipProber, receipt, nil)
-		if err != nil {
-			// The leader is gone, reused or unreadable. Whatever it left behind
-			// was either already attributed (and is still owned) or was never
-			// attributable at all; either way this pass has nothing more to
-			// contribute and must not start guessing.
+
+		// Attribution runs INSIDE the store's critical section, against the
+		// receipt that is actually on disk — never against a private copy
+		// written back afterwards. A copy-and-write-back would erase whatever
+		// another writer recorded in the meantime: a member added by a
+		// concurrent pass, or the recovery_required state a teardown just set.
+		if err := store.Update(i.ID, func(current *procowner.Receipt) error {
+			// Cancellation, checked AFTER the lock has been won rather than
+			// before we queued for it. A stop that lands while this call waits
+			// on the lock has to disarm this write, not merely stop the next
+			// tick — otherwise a cleared receipt is resurrected by work that
+			// was already in flight when it was cleared.
+			if i.spawnGen.Load() != gen {
+				return procowner.ErrWindowClosed
+			}
+			// Still the receipt this pass belongs to? Same rule Commit and
+			// Clear enforce, called rather than restated.
+			if err := procowner.RequireGeneration(current, owned.Generation, owned.Leader); err != nil {
+				return err
+			}
+			added, err := procowner.Attribute(ownershipProber, current, nil)
+			if err != nil {
+				// The leader is gone, reused or unreadable. Whatever it left
+				// behind was either already attributed (and is still owned) or
+				// was never attributable at all; either way this pass has
+				// nothing more to contribute and must not start guessing.
+				return err
+			}
+			if len(added) == 0 {
+				return procowner.ErrNoChange
+			}
+			return nil
+		}); err != nil {
+			// Every outcome here ends this pass: the window is over (a newer
+			// spawn owns the receipt, or it has been reconciled away), or the
+			// leader stopped being ours. Neither is a reason to keep scanning.
+			sessionLog.Debug("ownership_attribution_stopped",
+				slog.String("instance_id", logging.SanitizeValue(i.ID)),
+				slog.String("reason", logging.SanitizeValue(err.Error())))
 			return
 		}
-		if len(added) > 0 {
-			if saveErr := store.Save(receipt); saveErr != nil {
-				if errors.Is(saveErr, procowner.ErrGenerationConflict) {
-					return // a newer spawn owns the receipt
-				}
-				sessionLog.Warn("ownership_attribution_write_failed",
-					slog.String("instance_id", logging.SanitizeValue(i.ID)),
-					slog.String("error", logging.SanitizeValue(saveErr.Error())))
-			}
-		}
+
 		if time.Now().After(deadline) {
 			return
 		}
@@ -557,12 +601,21 @@ func (i *Instance) clearOwnershipAfterTeardown(sync bool) {
 }
 
 // markOwnershipRecoveryRequired records why a receipt could not be retired.
-// Best-effort: failing to annotate must not lose the receipt itself.
+//
+// An in-place update, not a write-back: annotating a receipt that something
+// else has already cleared would recreate it, and annotating a private copy
+// would erase members another writer added while this reap was running.
+// Best-effort otherwise — failing to annotate must not lose the receipt itself.
 func markOwnershipRecoveryRequired(store *procowner.Store, receipt *procowner.Receipt, reason string) {
-	receipt.State = procowner.StateRecoveryRequired
-	receipt.Note = reason
-	receipt.UpdatedAt = time.Now().Unix()
-	_ = store.Save(receipt)
+	_ = store.Update(receipt.InstanceID, func(current *procowner.Receipt) error {
+		if err := procowner.RequireGeneration(current, receipt.Generation, receipt.Leader); err != nil {
+			return err
+		}
+		current.State = procowner.StateRecoveryRequired
+		current.Note = reason
+		current.UpdatedAt = time.Now().Unix()
+		return nil
+	})
 }
 
 // OwnershipStatus reports what this instance owns, for `session ownership

--- a/internal/session/ownership.go
+++ b/internal/session/ownership.go
@@ -458,10 +458,13 @@ func (i *Instance) claimOwnershipAtSpawn(command string, gen uint64, wake <-chan
 		Reason:     fmt.Sprintf("generation %d, leader pid %d", receipt.Generation, receipt.Leader.PID),
 	})
 
-	// The store is resolved here, in the caller, for the same reason
-	// watchForFastDeath's paths are: this goroutine is never joined and can
-	// outlive a test that has since moved $HOME.
-	go i.attributeOwnedTree(receipt, store, gen, wake)
+	// The store, the prober and the logger are all resolved HERE, in the
+	// caller, and passed by value — the same discipline watchForFastDeath
+	// follows and for the same reason. This goroutine is never joined, so it
+	// can still be running after the test that started it has finished and
+	// swapped those package variables out from under it. Reading them from the
+	// goroutine is a data race the race detector will (and did) catch.
+	go i.attributeOwnedTree(receipt, store, ownershipProber, sessionLog, gen, wake)
 }
 
 // attributeOwnedTree records the leader's descendants, each with its own start
@@ -471,7 +474,7 @@ func (i *Instance) claimOwnershipAtSpawn(command string, gen uint64, wake <-chan
 // that still verifies against the receipt, and it stops the moment that leader
 // stops being ours. Nothing here can add a process that was not, at the instant
 // of a single stat read, a live descendant of a process this spawn owns.
-func (i *Instance) attributeOwnedTree(owned *procowner.Receipt, store *procowner.Store, gen uint64, wake <-chan struct{}) {
+func (i *Instance) attributeOwnedTree(owned *procowner.Receipt, store *procowner.Store, prober procowner.Prober, logger *slog.Logger, gen uint64, wake <-chan struct{}) {
 	start := time.Now()
 	deadline := start.Add(ownershipAttributeMaxWindow)
 	for {
@@ -512,7 +515,7 @@ func (i *Instance) attributeOwnedTree(owned *procowner.Receipt, store *procowner
 			if err := procowner.RequireGeneration(current, owned.Generation, owned.Leader); err != nil {
 				return err
 			}
-			added, err := procowner.Attribute(ownershipProber, current, nil)
+			added, err := procowner.Attribute(prober, current, nil)
 			if err != nil {
 				// The leader is gone, reused or unreadable. Whatever it left
 				// behind was either already attributed (and is still owned) or
@@ -528,7 +531,7 @@ func (i *Instance) attributeOwnedTree(owned *procowner.Receipt, store *procowner
 			// Every outcome here ends this pass: the window is over (a newer
 			// spawn owns the receipt, or it has been reconciled away), or the
 			// leader stopped being ours. Neither is a reason to keep scanning.
-			sessionLog.Debug("ownership_attribution_stopped",
+			logger.Debug("ownership_attribution_stopped",
 				slog.String("instance_id", logging.SanitizeValue(i.ID)),
 				slog.String("reason", logging.SanitizeValue(err.Error())))
 			return

--- a/internal/session/ownership.go
+++ b/internal/session/ownership.go
@@ -1,0 +1,628 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+	"github.com/asheshgoplani/agent-deck/internal/procowner"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Ownership receipts (#1873).
+//
+// A wrapped session can lose its tmux pane while the process tree it launched
+// survives, reparented to PID 1. The pane is gone, so nothing that walks a pane
+// tree or scans tmux sessions can see the survivor — and the next legitimate
+// restart happily spawns a second tree against the same instance, worktree and
+// conversation.
+//
+// The fix is a receipt written AT SPAWN: the pid of the pane's initial process
+// bound to its start identity, made durable before anything can die. Every
+// later decision — may this restart be admitted? which processes may be
+// signalled? — is answered by verifying that receipt, never by scanning for
+// processes that look like ours.
+//
+// This file is the session-layer wiring; internal/procowner holds the contract
+// and the platform verification.
+
+// ownershipAttribution* bound the descendant-attribution pass that runs during
+// the spawn window.
+//
+// Fast at first, then relaxed: a wrapper that forks a child and exits does so
+// within milliseconds, and a descendant can only be attributed while its
+// ancestry back to the verified leader is still intact. After the first
+// seconds, attribution is just keeping up with a normally-behaving session, so
+// the cheaper cadence is enough. The pass stops at the fast-death window, which
+// is where "this spawn is still starting" ends.
+const (
+	ownershipAttributeFastTick  = 50 * time.Millisecond
+	ownershipAttributeFastFor   = 3 * time.Second
+	ownershipAttributeSlowTick  = 500 * time.Millisecond
+	ownershipAttributeMaxWindow = spawnFastDeathWindow
+)
+
+// ownershipProber and ownershipSignaler are package variables so tests can
+// drive the whole state machine without a real process table. Production never
+// replaces them.
+var (
+	ownershipProber   procowner.Prober   = procowner.NewProber()
+	ownershipSignaler procowner.Signaler = procowner.OSSignaler{}
+)
+
+// ownershipStores caches one Store per directory. The Store serializes its own
+// writes, so sharing the instance is what makes that lock mean anything.
+var ownershipStores sync.Map // dir -> *procowner.Store
+
+// ownershipDir returns <data>/runtime/ownership, mirroring spawnFailureDir's
+// fallback so an unresolvable data dir degrades to a temp path instead of
+// losing the receipt.
+func ownershipDir() string {
+	path, err := runtimeDataPath("ownership")
+	if err != nil {
+		return tempAgentDeckPath("runtime", "ownership")
+	}
+	return path
+}
+
+// ownershipStoreAt returns the shared store for a directory.
+func ownershipStoreAt(dir string) *procowner.Store {
+	if existing, ok := ownershipStores.Load(dir); ok {
+		return existing.(*procowner.Store)
+	}
+	created := procowner.NewStore(dir)
+	actual, _ := ownershipStores.LoadOrStore(dir, created)
+	return actual.(*procowner.Store)
+}
+
+// ownershipStore returns the store for the live data dir.
+func ownershipStore() *procowner.Store { return ownershipStoreAt(ownershipDir()) }
+
+// OwnedProcessRecoveryRequiredError is returned instead of spawning when an
+// instance still owns processes that a replacement would duplicate, or when
+// ownership cannot be verified at all.
+//
+// It is deliberately a distinct type from an ordinary spawn failure: nothing
+// was launched, nothing was signalled, and the operator has a specific next
+// step. Callers that render errors get the facts; callers that retry on spawn
+// failure must not treat this as one.
+type OwnedProcessRecoveryRequiredError struct {
+	InstanceID string
+	Action     string // "start" | "restart"
+	Generation uint64
+	Verdict    string
+	Reason     string
+	Survivors  []procowner.Member
+	// Details explain, per recorded identity, why it could not be verified.
+	// Without them "could not be verified" is a verdict with no evidence, and
+	// the operator has nothing to act on.
+	Details []string
+}
+
+// Error implements error.
+func (e *OwnedProcessRecoveryRequiredError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s refused: this session still owns processes from an earlier spawn (%s)",
+		e.Action, e.Reason)
+	for _, m := range e.Survivors {
+		fmt.Fprintf(&b, "\n  owned: %s", m.String())
+	}
+	for _, detail := range e.Details {
+		fmt.Fprintf(&b, "\n  unverifiable: %s", detail)
+	}
+	fmt.Fprintf(&b, "\nNothing was started and nothing was signalled.")
+	fmt.Fprintf(&b, "\nInspect: agent-deck session ownership inspect %s", e.InstanceID)
+	fmt.Fprintf(&b, "\nReap and clear: agent-deck session ownership reconcile %s", e.InstanceID)
+	return b.String()
+}
+
+// IsOwnedProcessRecoveryRequired reports whether err is the fail-closed
+// ownership refusal.
+func IsOwnedProcessRecoveryRequired(err error) bool {
+	var target *OwnedProcessRecoveryRequiredError
+	return errors.As(err, &target)
+}
+
+// OwnershipStatus is the operator-facing view of an instance's receipt.
+type OwnershipStatus struct {
+	InstanceID string
+	Receipt    *procowner.Receipt
+	Report     procowner.Report
+	// Survivors are owned processes that are NOT part of the live pane tree —
+	// the escaped trees this issue is about.
+	Survivors []procowner.Member
+	// PaneAttached reports whether the live pane's initial process is the
+	// receipt's leader, i.e. the receipt describes the running session.
+	PaneAttached bool
+	// LoadErr carries a corrupt-receipt error, which is a fail-closed state
+	// rather than an absence of ownership.
+	LoadErr error
+}
+
+// Admissible reports whether a spawn may proceed.
+func (s OwnershipStatus) Admissible() bool {
+	if s.LoadErr != nil {
+		return false
+	}
+	if s.Receipt == nil {
+		return true
+	}
+	if s.Report.Verdict == procowner.VerdictUnknown {
+		return false
+	}
+	return len(s.Survivors) == 0
+}
+
+// Reason renders why a spawn is or is not admissible.
+func (s OwnershipStatus) Reason() string {
+	switch {
+	case s.LoadErr != nil:
+		return "the ownership receipt could not be read: " + s.LoadErr.Error()
+	case s.Receipt == nil:
+		return "no ownership receipt"
+	case s.Report.Verdict == procowner.VerdictUnknown:
+		return s.Report.Reason
+	case len(s.Survivors) > 0:
+		return fmt.Sprintf("%d owned process(es) from generation %d are alive outside the session's pane",
+			len(s.Survivors), s.Receipt.Generation)
+	default:
+		return s.Report.Reason
+	}
+}
+
+// ownershipStatus verifies the instance's receipt and classifies what it finds.
+//
+// The survivor computation is the part that matters. An owned process that is
+// still a descendant of the live pane leader is the RUNNING SESSION, not a
+// leak: refusing a restart because a healthy Claude session has live MCP
+// children would make the guard worse than the bug. A survivor is an owned
+// process that the live pane cannot account for — which is exactly the escaped
+// tree #1873 reports.
+func (i *Instance) ownershipStatus() OwnershipStatus {
+	status := OwnershipStatus{InstanceID: i.ID}
+	receipt, err := ownershipStore().Load(i.ID)
+	if err != nil {
+		status.LoadErr = err
+		return status
+	}
+	if receipt == nil {
+		return status
+	}
+	status.Receipt = receipt
+	status.Report = procowner.Verify(ownershipProber, receipt)
+
+	owned := status.Report.Owned()
+	if len(owned) == 0 {
+		return status
+	}
+
+	attached := i.liveOwnedPaneSet(receipt)
+	status.PaneAttached = len(attached) > 0
+	for _, m := range owned {
+		if attached[m.Key()] {
+			continue
+		}
+		status.Survivors = append(status.Survivors, m)
+	}
+	return status
+}
+
+// liveOwnedPaneSet returns the identities that are accounted for by the live
+// pane: the pane's initial process when it is the receipt's leader, plus its
+// current descendants.
+//
+// It returns an empty set the moment anything does not line up — no pane, an
+// indeterminate probe, a pane whose leader is not the recorded one. Every one
+// of those means "the live pane does not account for the receipt", and an empty
+// set makes every owned identity a survivor, which is the fail-closed
+// direction.
+func (i *Instance) liveOwnedPaneSet(receipt *procowner.Receipt) map[string]bool {
+	if receipt == nil {
+		return nil
+	}
+	if !i.receiptLeaderRunsALivePane(receipt) {
+		return nil
+	}
+	if procowner.VerifyMember(ownershipProber, receipt.Leader).State != procowner.StateOwned {
+		return nil
+	}
+	leaderInfo, err := ownershipProber.Inspect(receipt.Leader.PID)
+	if err != nil {
+		return nil
+	}
+	set := map[string]bool{receipt.Leader.Key(): true}
+	descendants, err := ownershipProber.Descendants(leaderInfo)
+	if err != nil {
+		// The leader itself is accounted for; its descendants are not, so they
+		// stay classified as survivors and the restart fails closed.
+		return set
+	}
+	for _, info := range descendants {
+		set[procowner.Member{PID: info.PID, StartID: info.StartID}.Key()] = true
+	}
+	return set
+}
+
+// receiptLeaderRunsALivePane reports whether the receipt's leader is the
+// initial process of a live tmux pane.
+//
+// Two sources are consulted, and either is enough:
+//
+//   - the instance's current tmux session, which is the normal case;
+//   - the tmux session recorded IN THE RECEIPT at spawn.
+//
+// The second is not redundancy for its own sake. An Instance's in-memory tmux
+// name can drift away from the live session it started — a stale name with a
+// live session behind it is a real, separately-tracked failure that restart is
+// expected to heal by adoption. Judging attachment by the drifted name alone
+// would classify that session's own pane process as an escaped survivor and
+// refuse the very restart that fixes it. The name written into the receipt at
+// spawn does not drift, so it answers "is this process still inside the tmux
+// session we launched it into?" correctly even when the instance has lost track.
+func (i *Instance) receiptLeaderRunsALivePane(receipt *procowner.Receipt) bool {
+	if i.tmuxSession != nil {
+		if panePID, err := i.tmuxSession.PanePID(); err == nil && panePID == receipt.Leader.PID {
+			return true
+		}
+	}
+	if receipt.TmuxName == "" {
+		return false
+	}
+	panePID, err := tmux.PanePIDOfSession(receipt.TmuxSocket, receipt.TmuxName)
+	return err == nil && panePID == receipt.Leader.PID
+}
+
+// guardOwnedProcessesBeforeSpawn is the fail-closed admission gate. It runs
+// inside the instance spawn lock, before any state is mutated and before any
+// tmux work, on both the start and the restart path.
+//
+// It never signals anything. A refusal leaves the receipt exactly as it was, so
+// the operator can inspect it and decide.
+func (i *Instance) guardOwnedProcessesBeforeSpawn(action string) error {
+	status := i.ownershipStatus()
+	if status.Admissible() {
+		if status.Receipt != nil && status.Report.Verdict == procowner.VerdictClear {
+			// Every recorded process is provably gone: retire the receipt so
+			// the replacement spawn starts from a clean slate rather than
+			// inheriting a stale claim.
+			if err := ownershipStore().Clear(status.Receipt); err != nil {
+				sessionLog.Warn("ownership_receipt_clear_failed",
+					slog.String("instance_id", logging.SanitizeValue(i.ID)),
+					slog.String("error", logging.SanitizeValue(err.Error())))
+			}
+		}
+		return nil
+	}
+
+	refusal := &OwnedProcessRecoveryRequiredError{
+		InstanceID: i.ID,
+		Action:     action,
+		Verdict:    string(status.Report.Verdict),
+		Reason:     status.Reason(),
+		Survivors:  status.Survivors,
+	}
+	if status.Receipt != nil {
+		refusal.Generation = status.Receipt.Generation
+	}
+	for _, member := range status.Report.Members {
+		if member.State == procowner.StateUnknown {
+			refusal.Details = append(refusal.Details,
+				fmt.Sprintf("%s — %s", member.Member.String(), member.Detail))
+		}
+	}
+	if status.LoadErr != nil {
+		refusal.Verdict = string(procowner.VerdictUnknown)
+	}
+	sessionLog.Error("owned_process_recovery_required",
+		slog.String("instance_id", logging.SanitizeValue(i.ID)),
+		slog.String("action", logging.SanitizeValue(action)),
+		slog.String("verdict", logging.SanitizeValue(refusal.Verdict)),
+		slog.String("reason", logging.SanitizeValue(refusal.Reason)),
+		slog.Int("survivors", len(status.Survivors)))
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "ownership_recovery_required",
+		Source:     "ownership_gate",
+		Reason:     refusal.Reason,
+	})
+	return refusal
+}
+
+// commitOwnershipAfterRestart re-claims ownership once a restart has replaced
+// the pane's process.
+//
+// It runs deferred from restart(), which is what makes it reach every one of
+// that function's exits: the per-tool respawn-pane fast paths each return
+// early, and a receipt that still named the process respawn-pane just killed
+// would leave the replacement unowned. A restart that never got as far as a
+// live pane changes nothing — an unsuccessful restart has taken no new
+// ownership, and the old receipt is still the truth about what may be alive.
+func (i *Instance) commitOwnershipAfterRestart(command string) {
+	if i.tmuxSession == nil {
+		return
+	}
+	panePID, err := i.tmuxSession.PanePID()
+	if err != nil || panePID <= 0 {
+		return
+	}
+	if existing, loadErr := ownershipStore().Load(i.ID); loadErr == nil && existing != nil &&
+		existing.Leader.PID == panePID &&
+		procowner.VerifyMember(ownershipProber, existing.Leader).State == procowner.StateOwned {
+		// The pane still runs the process the receipt already names (a restart
+		// that returned before replacing anything). Nothing to re-claim.
+		return
+	}
+	gen, wake := i.newSpawnGenWatch()
+	i.claimOwnershipAtSpawn(command, gen, wake)
+}
+
+// claimOwnershipAtSpawn records the receipt for a pane that has just been
+// started, and starts the descendant-attribution pass.
+//
+// gen/wake are the caller's spawn generation and supersede channel — the same
+// pair the fast-death watcher gets — so attribution stops the instant a newer
+// spawn or a deliberate stop takes over, and so claiming a receipt never
+// supersedes the watcher the caller started alongside it.
+//
+// Best-effort by construction: a spawn that cannot be given a receipt is still
+// a spawn. What it must never do is record a claim it cannot substantiate, so
+// every failure path here writes nothing at all — no receipt means no ownership
+// and therefore no signal, which is the safe direction.
+//
+// One window remains open and cannot be closed from here: agent-deck dying
+// between tmux starting the pane and this function committing the receipt. The
+// process exists before the receipt can name it — that ordering is forced by
+// the kernel, not chosen — so a crash inside those few milliseconds leaves a
+// pane agent-deck does not know it owns. It is orders of magnitude narrower
+// than the window this issue is about (the whole fast-start window, plus every
+// restart after it), and it fails in the same direction as an unsupported
+// platform: unowned, never mis-owned.
+func (i *Instance) claimOwnershipAtSpawn(command string, gen uint64, wake <-chan struct{}) {
+	if i.tmuxSession == nil {
+		return
+	}
+	store := ownershipStore()
+	panePID, err := i.tmuxSession.PanePID()
+	if err != nil || panePID <= 0 {
+		sessionLog.Warn("ownership_receipt_skipped_no_pane_pid",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("error", logging.SanitizeValue(errString(err))))
+		return
+	}
+	generation, err := store.NextGeneration(i.ID)
+	if err != nil {
+		sessionLog.Warn("ownership_receipt_generation_failed",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("error", logging.SanitizeValue(err.Error())))
+		return
+	}
+	receipt, err := procowner.Claim(ownershipProber, procowner.ClaimInput{
+		InstanceID: i.ID,
+		Generation: generation,
+		PanePID:    panePID,
+		TmuxName:   i.tmuxSession.Name,
+		TmuxSocket: i.TmuxSocketName,
+		Command:    redactEnvValues(command),
+	})
+	if err != nil {
+		// Unsupported platform, or a pane process that exited between the tmux
+		// start and this probe. Either way: no claim.
+		sessionLog.Info("ownership_receipt_not_claimed",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("reason", logging.SanitizeValue(err.Error())))
+		return
+	}
+	// Attribute once synchronously so a wrapper that forks and exits inside the
+	// first tick is still caught, then commit receipt + members in one write.
+	if _, attrErr := procowner.Attribute(ownershipProber, receipt, nil); attrErr != nil {
+		sessionLog.Debug("ownership_attribution_initial_skipped",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("reason", logging.SanitizeValue(attrErr.Error())))
+	}
+	if err := store.Save(receipt); err != nil {
+		sessionLog.Warn("ownership_receipt_write_failed",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("error", logging.SanitizeValue(err.Error())))
+		return
+	}
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "ownership_claimed",
+		Source:     "spawn",
+		Reason:     fmt.Sprintf("generation %d, leader pid %d", receipt.Generation, receipt.Leader.PID),
+	})
+
+	// The store is resolved here, in the caller, for the same reason
+	// watchForFastDeath's paths are: this goroutine is never joined and can
+	// outlive a test that has since moved $HOME.
+	go i.attributeOwnedTree(receipt, store, gen, wake)
+}
+
+// attributeOwnedTree records the leader's descendants, each with its own start
+// identity, for as long as the spawn window lasts.
+//
+// This is attribution, not discovery: it only ever walks DOWN from a leader
+// that still verifies against the receipt, and it stops the moment that leader
+// stops being ours. Nothing here can add a process that was not, at the instant
+// of a single stat read, a live descendant of a process this spawn owns.
+func (i *Instance) attributeOwnedTree(receipt *procowner.Receipt, store *procowner.Store, gen uint64, wake <-chan struct{}) {
+	start := time.Now()
+	deadline := start.Add(ownershipAttributeMaxWindow)
+	for {
+		tick := ownershipAttributeSlowTick
+		if time.Since(start) < ownershipAttributeFastFor {
+			tick = ownershipAttributeFastTick
+		}
+		timer := time.NewTimer(tick)
+		select {
+		case <-timer.C:
+		case <-wake:
+			// Superseded by a newer spawn or a deliberate stop: that spawn owns
+			// the receipt now.
+			timer.Stop()
+			return
+		}
+
+		if i.spawnGen.Load() != gen {
+			return
+		}
+		added, err := procowner.Attribute(ownershipProber, receipt, nil)
+		if err != nil {
+			// The leader is gone, reused or unreadable. Whatever it left behind
+			// was either already attributed (and is still owned) or was never
+			// attributable at all; either way this pass has nothing more to
+			// contribute and must not start guessing.
+			return
+		}
+		if len(added) > 0 {
+			if saveErr := store.Save(receipt); saveErr != nil {
+				if errors.Is(saveErr, procowner.ErrGenerationConflict) {
+					return // a newer spawn owns the receipt
+				}
+				sessionLog.Warn("ownership_attribution_write_failed",
+					slog.String("instance_id", logging.SanitizeValue(i.ID)),
+					slog.String("error", logging.SanitizeValue(saveErr.Error())))
+			}
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+	}
+}
+
+// teardownReapOptions bounds how long a stop may wait on the ownership reap.
+//
+// The whole reap is two phases, not one per process, so this is the total added
+// latency and not a per-member cost. The non-blocking Kill() path (the TUI's)
+// gets the tighter budget already used by the MCP child reap on the same
+// teardown, because a stop that appears to hang is its own bug; KillAndWait's
+// callers are short-lived CLI processes that exist precisely to see the
+// teardown through, so they get the longer one.
+func teardownReapOptions(sync bool) procowner.ReapOptions {
+	if sync {
+		return procowner.ReapOptions{TermGrace: 3 * time.Second, KillGrace: 2 * time.Second}
+	}
+	return procowner.ReapOptions{TermGrace: time.Second, KillGrace: time.Second}
+}
+
+// clearOwnershipAfterTeardown reaps whatever the receipt still owns and clears
+// it. Called from the teardown path, where "the session is being stopped" is
+// exactly the intent that authorises terminating its processes.
+//
+// Only identity-matched processes are signalled. Anything unverifiable is left
+// alone and the receipt is KEPT, so the operator can still see it — a receipt
+// silently dropped here would put us straight back to an invisible survivor.
+func (i *Instance) clearOwnershipAfterTeardown(sync bool) {
+	store := ownershipStore()
+	receipt, err := store.Load(i.ID)
+	if err != nil {
+		sessionLog.Warn("ownership_receipt_unreadable_on_teardown",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("error", logging.SanitizeValue(err.Error())))
+		return
+	}
+	if receipt == nil {
+		return
+	}
+	report := procowner.Reap(ownershipProber, ownershipSignaler, receipt, teardownReapOptions(sync))
+	if report.Verdict != procowner.VerdictClear {
+		markOwnershipRecoveryRequired(store, receipt, report.Reason)
+		sessionLog.Warn("ownership_teardown_incomplete",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("verdict", logging.SanitizeValue(string(report.Verdict))),
+			slog.String("reason", logging.SanitizeValue(report.Reason)))
+		return
+	}
+	if err := store.Clear(receipt); err != nil && !errors.Is(err, procowner.ErrGenerationConflict) {
+		sessionLog.Warn("ownership_receipt_clear_failed",
+			slog.String("instance_id", logging.SanitizeValue(i.ID)),
+			slog.String("error", logging.SanitizeValue(err.Error())))
+		return
+	}
+	if report.Signalled() > 0 {
+		_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+			InstanceID: i.ID,
+			Tool:       i.Tool,
+			Action:     "ownership_reaped",
+			Source:     "teardown",
+			Reason:     report.Reason,
+		})
+	}
+}
+
+// markOwnershipRecoveryRequired records why a receipt could not be retired.
+// Best-effort: failing to annotate must not lose the receipt itself.
+func markOwnershipRecoveryRequired(store *procowner.Store, receipt *procowner.Receipt, reason string) {
+	receipt.State = procowner.StateRecoveryRequired
+	receipt.Note = reason
+	receipt.UpdatedAt = time.Now().Unix()
+	_ = store.Save(receipt)
+}
+
+// OwnershipStatus reports what this instance owns, for `session ownership
+// inspect` and any other read-only surface. It signals nothing.
+func (i *Instance) OwnershipStatus() OwnershipStatus { return i.ownershipStatus() }
+
+// ReconcileOwnership terminates every process this instance's receipt owns —
+// identity-checked, verified dead — and clears the receipt when it succeeds.
+//
+// This is the explicit recovery operation. It is the ONLY path that signals as
+// a result of an operator asking for it rather than as part of a teardown, and
+// it still refuses to touch anything whose identity does not match.
+func (i *Instance) ReconcileOwnership() (procowner.ReapReport, error) {
+	store := ownershipStore()
+	receipt, err := store.Load(i.ID)
+	if err != nil {
+		return procowner.ReapReport{}, err
+	}
+	if receipt == nil {
+		return procowner.ReapReport{
+			Verdict: procowner.VerdictClear,
+			Reason:  "no ownership receipt",
+		}, nil
+	}
+	report := procowner.Reap(ownershipProber, ownershipSignaler, receipt, procowner.ReapOptions{})
+	if report.Verdict != procowner.VerdictClear {
+		markOwnershipRecoveryRequired(store, receipt, report.Reason)
+		return report, nil
+	}
+	if err := store.Clear(receipt); err != nil {
+		return report, err
+	}
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "ownership_reconciled",
+		Source:     "operator",
+		Reason:     report.Reason,
+	})
+	return report, nil
+}
+
+// AbandonOwnership discards a receipt without signalling anything.
+//
+// It exists because a receipt can become permanently unverifiable — a reused
+// pid, an unreadable /proc entry — and the alternative to an explicit operator
+// decision would be a session that can never be restarted. It is destructive in
+// exactly one sense, and the caller must say so to the user: agent-deck stops
+// managing whatever that receipt named. It never broadens matching, never kills
+// by name, and never guesses.
+func (i *Instance) AbandonOwnership() error {
+	if err := ownershipStore().ForceClear(i.ID); err != nil {
+		return err
+	}
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID,
+		Tool:       i.Tool,
+		Action:     "ownership_abandoned",
+		Source:     "operator",
+		Reason:     "receipt discarded without signalling; agent-deck no longer manages any survivor",
+	})
+	return nil
+}

--- a/internal/session/ownership.go
+++ b/internal/session/ownership.go
@@ -442,6 +442,25 @@ func (i *Instance) claimOwnershipAtSpawn(command string, gen uint64, wake <-chan
 				slog.String("instance_id", logging.SanitizeValue(i.ID)),
 				slog.String("reason", logging.SanitizeValue(attrErr.Error())))
 		}
+		// A restart may replace a healthy pane while one of its descendants has
+		// already detached. Never let the new generation erase that ownership:
+		// carry forward every old identity that still verifies, so later teardown
+		// either reaps it or continues to fail closed. Gone and reused identities
+		// are deliberately omitted.
+		if existing != nil {
+			seen := map[string]bool{claimed.Leader.Key(): true}
+			for _, member := range existing.All() {
+				if len(claimed.Members) >= procowner.MaxMembers || seen[member.Key()] {
+					continue
+				}
+				if procowner.VerifyMember(ownershipProber, member).State != procowner.StateOwned {
+					continue
+				}
+				member.Role = procowner.RoleDescendant
+				claimed.Members = append(claimed.Members, member)
+				seen[member.Key()] = true
+			}
+		}
 		return claimed, nil
 	})
 	if err != nil {

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -312,8 +312,7 @@ const (
 // lifecycleLogPath and failureDir are resolved before the goroutine starts and
 // passed by value, so the watcher cannot write through a later process-global
 // HOME value.
-func (i *Instance) startFastDeathWatcher(command string, sess *tmux.Session, id, tool string, logger *slog.Logger) {
-	gen, wake := i.newSpawnGenWatch()
+func (i *Instance) startFastDeathWatcher(command string, gen uint64, wake <-chan struct{}, sess *tmux.Session, id, tool string, logger *slog.Logger) {
 	lifecycleLogPath := GetSessionIDLifecycleLogPath()
 	failureDir := spawnFailureDir()
 	i.spawnWatchers.Add(1)

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -203,6 +203,13 @@ func paneGoneWithin(inst *Instance, window time.Duration) bool {
 }
 
 func TestMain(m *testing.M) {
+	// #1873 race tests re-execute this binary as a second agent-deck process to
+	// exercise the receipt's cross-process compare-and-swap. Dispatch before
+	// any isolation setup: the child must reach the SAME store directory the
+	// parent passed it, not a fresh isolated HOME of its own.
+	if payload := os.Getenv(ownershipChildEnv); payload != "" {
+		os.Exit(runOwnershipReceiptChild(payload))
+	}
 	os.Exit(runTestMain(m))
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3190,6 +3190,30 @@ func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 	return panePID, allPIDs
 }
 
+// PanePID returns the pane's initial process id, or an error when the probe is
+// indeterminate.
+//
+// #1873: the ownership receipt is claimed from this pid the instant a spawn
+// commits, so the caller needs the probe outcome, not a degraded 0. A 0 with no
+// error would be recorded as "we own pid 0" or, worse, as "the spawn owns
+// nothing" — both of which turn an unproven claim into a durable one.
+func (s *Session) PanePID() (int, error) {
+	return PanePIDOfSession(s.SocketName, s.Name)
+}
+
+// PanePIDOfSession is the name-explicit variant, for callers holding a session
+// name from somewhere other than a live Session — notably an ownership receipt,
+// which records the tmux session its leader was launched into. An Instance's
+// in-memory tmux name can drift away from the live session (that is its own
+// bug class); the name written into the receipt at spawn cannot.
+func PanePIDOfSession(socketName, sessionName string) (int, error) {
+	if strings.TrimSpace(sessionName) == "" {
+		return 0, fmt.Errorf("no tmux session name")
+	}
+	out, err := runBoundedOutput(socketName, "list-panes", "-t", sessionName+":", "-F", "#{pane_pid}")
+	return parsePanePID(out, err)
+}
+
 // paneProcessTree is getPaneProcessTree with the probe outcome preserved.
 //
 // The distinction matters on exactly one path: the post-respawn probe in

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3120,6 +3120,30 @@ func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 	return panePID, allPIDs
 }
 
+// PanePID returns the pane's initial process id, or an error when the probe is
+// indeterminate.
+//
+// #1873: the ownership receipt is claimed from this pid the instant a spawn
+// commits, so the caller needs the probe outcome, not a degraded 0. A 0 with no
+// error would be recorded as "we own pid 0" or, worse, as "the spawn owns
+// nothing" — both of which turn an unproven claim into a durable one.
+func (s *Session) PanePID() (int, error) {
+	return PanePIDOfSession(s.SocketName, s.Name)
+}
+
+// PanePIDOfSession is the name-explicit variant, for callers holding a session
+// name from somewhere other than a live Session — notably an ownership receipt,
+// which records the tmux session its leader was launched into. An Instance's
+// in-memory tmux name can drift away from the live session (that is its own
+// bug class); the name written into the receipt at spawn cannot.
+func PanePIDOfSession(socketName, sessionName string) (int, error) {
+	if strings.TrimSpace(sessionName) == "" {
+		return 0, fmt.Errorf("no tmux session name")
+	}
+	out, err := runBoundedOutput(socketName, "list-panes", "-t", sessionName+":", "-F", "#{pane_pid}")
+	return parsePanePID(out, err)
+}
+
 // paneProcessTree is getPaneProcessTree with the probe outcome preserved.
 //
 // The distinction matters on exactly one path: the post-respawn probe in


### PR DESCRIPTION
Fixes #1873.

## What problem does this solve?

A session launched through a wrapper can lose its tmux pane during the fast-start window while the wrapped process tree survives, reparented away from the pane. agent-deck records the session as errored — and the next legitimate restart starts a **second** tree against the same instance, worktree and conversation. The existing sweeps cannot see it: the pane-tree walk has no pane left to walk, and the tmux-session sweeps cannot see a process that has left tmux.

## Why this change

This implements the ownership contract ruled on the issue thread, and nothing beyond it:

- the durable receipt is the **start-time + PID pair, recorded AT SPAWN**;
- identity is **same PID AND same start time**; any mismatch is a stranger and **must not be signalled**;
- no external provider, no new dependencies;
- an unverifiable process is **reported unknown and left alone**.

"At spawn" is the whole point, and it is what separates this from capturing identity at sweep or kill time. Reading a process's start time when you are about to signal it proves only that the pid did not change hands between the read and the signal; it says nothing about whether the process was ever ours. A receipt written while the process is provably ours is what turns a pid into ownership. (This PR does not build on, and does not depend on, #1941; it takes no code and no design from that chain's sweep.)

**Shape of the change**

- `internal/procowner` — the receipt, its atomic per-instance store, and platform verification. Linux reads start ticks from `/proc/<pid>/stat`; macOS has a BSD `ps` provider (still no new dependency); anywhere else a no-provider fallback that claims nothing, so it can never signal anything. A boot id scopes every start identity, which is what makes a receipt from a previous boot *proof of death* rather than a permanent block on the session.
- Receipts are claimed the instant tmux reports the pane's initial process — on `Start`, on `StartWithMessage`, and after every restart path including each per-tool `respawn-pane` fast path, so a replacement pane is never left unowned.
- **Descendants** are attributed only while they are still reachable from a leader that verifies against the receipt, and only downward from it. A descendant whose recorded start identity predates its leader's is dropped; agent-deck's own pid is never recorded; the member list is capped. Attribution never runs at sweep or kill time — those paths only *verify* a receipt, never extend one.
- **Start and restart fail closed.** An owned process the live pane cannot account for, an identity that cannot be read, or a receipt that cannot be parsed refuses the spawn with a typed `OwnedProcessRecoveryRequiredError`: nothing started, nothing signalled, receipt left intact. A healthy session's own pane process and live descendants are *not* survivors, so ordinary restarts are unaffected.
- **Teardown** reaps what the receipt owns — identity re-checked immediately before every signal, SIGTERM then SIGKILL by phase, death verified — and clears the receipt only when that succeeds. A receipt that cannot be fully reconciled is kept, not dropped: a silently discarded receipt puts us straight back to an invisible survivor.
- `agent-deck session ownership inspect|reconcile|abandon` is the recovery surface. Nothing anywhere in this change matches on executable names, paths, command lines, worktrees or `pkill`.

## Review round 2 — concurrency findings, fixed

Two findings from review, both the same shape: the guard was narrower than the invariant it claimed.

**P1 — a closing wake did not stop an in-flight attribution save.** A `Kill`, `ReconcileOwnership` or `AbandonOwnership` racing the 15s attribution window could see a cleared receipt **come back**, or a member survive a removing update. A receipt that returns from the dead is worse than no receipt, because everything downstream trusts it.

Fixed in two parts. `Store.Update` never creates: it loads the receipt under the lock, hands the mutator the **current** one to edit in place, and refuses with `ErrReceiptGone` when there is nothing to update — so attribution extends the authoritative receipt instead of writing back a private copy that would erase a concurrent edit. And the window check moved *inside* the mutator, so it runs after the lock is won rather than before the call queues for it: cancellation now disarms work already in flight instead of only preventing new work.

**P2 — the load/check/write was guarded only by a process-local mutex.** A TUI and a CLI on the same instance could both validate the same stale state and both proceed. Atomic replacement never covered that; it makes the write indivisible, not the decision.

Fixed by wrapping the whole cycle in **`AcquireConfigFileLock`** (`internal/session/config_file_lock.go`) — the tree's existing implementation of that rule, called rather than copied. `internal/procowner` cannot import `internal/session` without a cycle, so the store takes a `LockFunc` seam and the session layer wires that one function in; the single-process unit tests opt out through a named, greppable `NoCrossProcessLock` rather than a silent nil default. `Store.Save`/`NextGeneration` are gone — `Commit` is the one create path, choosing a generation and writing it in a single critical section.

> **Note for the maintainer:** `config_file_lock.go` is taken **verbatim** from #1957, which has not landed yet. It is deliberately byte-identical so the add/add merge is trivial; when #1957 lands, main's copy is the one to keep. The alternative was a second cross-process lock that did not know about the first, which is worse than none.

Both required regressions, run against the previous tip (`d13a78bb`) with the same scenarios expressed in that tip's API — they fail there:

```
=== RUN   TestPrevTip_CrossProcessReceiptUpdatesDoNotLoseEachOther
    Messages:   	member 9001 was lost (members=[pid=9002 start=9002 uid=1000 role=descendant])
--- FAIL: TestPrevTip_CrossProcessReceiptUpdatesDoNotLoseEachOther (0.22s)
=== RUN   TestPrevTip_LateUpdateAfterClearIsANoOp
    Messages:   	a late save after a clear must be refused
    Error:      	Expected nil, but got: &procowner.Receipt{... InstanceID:"race-late-update", Generation:0x1, State:"live" ...
                 	Members:[]procowner.Member{procowner.Member{PID:9100, ...}}}
    Messages:   	a cleared receipt must stay cleared
--- FAIL: TestPrevTip_LateUpdateAfterClearIsANoOp (0.03s)
```

And on this tip, together with the shapes the review asked me to look for beyond the two required ones:

```
--- PASS: TestIssue1873_CrossProcessReceiptUpdatesDoNotLoseEachOther (0.37s)
--- PASS: TestIssue1873_LateUpdateAfterClearIsANoOp (0.01s)
--- PASS: TestIssue1873_CancellationDisarmsAnInFlightUpdate (0.06s)
--- PASS: TestIssue1873_LockSurvivesAProcessThatDiesHoldingIt (0.04s)
--- PASS: TestIssue1873_GenerationResetDoesNotLetAStaleWriterWin (0.03s)
--- PASS: TestIssue1873_UpdateReadsAfterAcquiringTheLock (0.08s)
```

- **cancellation racing the save rather than preceding it** — cancellation fires while the update is parked on the lock; the write is dropped.
- **the lock held by a process that dies holding it** — a real second process takes the lock and is killed; the kernel releases the flock and the next acquirer proceeds instead of waiting on a corpse. (The first version of this test held the lock via `flock(1)`, which leaks the fd into a grandchild — it proved nothing and leaked a process. The holder is now a single process, which is the point.)
- **a generation that resets** — a verified clear makes the next spawn generation 1 again, so a stale writer finds a matching number; the leader identity separates them, and it cannot collide because a different process cannot hold the same pid with the same start time.
- **the receipt replaced between lock acquisition and read** — cannot happen, and the test says why: the load is inside the critical section, so a queued writer reads state as of the moment it won the lock, not as of the moment it queued.

### Two more found while fixing those

- **A data race the race suite caught.** `attributeOwnedTree` read the package-level `sessionLog` and `ownershipProber` from a goroutine that is never joined, so a test swapping either during cleanup raced a still-running attribution pass. `watchForFastDeath` already solves this by taking everything it needs as parameters evaluated in the calling goroutine; the attribution pass now does the same. (It only surfaced now because the round-2 logging made that read reliable rather than rare — the same latent bug was there before.)
- **`reconcile` could stop a running session with no confirmation.** The receipt covers the live pane process when the session is up, so the command was destructive without saying so. `--yes` is now required for exactly that case, and not for the escaped-tree case the refusal message points at — a flag there would train operators to pass `--yes` without reading it, which is how a confirmation gate stops being one.

## User impact

- A restart after a pane loss that left a live owned tree is **refused** with an explicit error naming the pids and the command that resolves them, instead of quietly starting a duplicate. Stopping a session now also reaps the tree it owns even when that tree escaped tmux.
- New: `agent-deck session ownership inspect <id>` (read-only), `reconcile <id>` (identity-checked reap + clear), `abandon <id> --yes` (discard an unverifiable receipt, signalling nothing).
- Receipts live in `<data>/runtime/ownership/<instance>.json`, mode 0600, written atomically. No migration; a session with no receipt behaves exactly as before.
- On a platform with no start-identity provider, no receipt is claimed and behaviour is unchanged — the contract degrades to "owns nothing", never to "owns something it cannot verify".

## Evidence

REPRODUCE → FIX → REPROVE, using the issue's own deterministic reproduction: a fake wrapper that starts a long-lived child in a new session/process group, makes it ignore `SIGHUP`, records the child's pid/pgid plus its `/proc/<pid>/stat` start time under the test's own temp dir, then exits non-zero. Isolated `HOME` and tmux socket; the fixture kills only the pids it created, verifying each one's start identity first, on every exit path including failure.

### BEFORE — on `main` (7da26d33)

The committed behavioural test fails, because the restart is admitted:

```
=== RUN   TestIssue1873_RestartIsNotAdmittedWhileTheOwnedTreeSurvives
    issue1873_escaped_tree_repro_test.go:283:
        	Error:      	An error is expected but got nil.
        	Messages:   	restart must not be admitted while an identity-matched owned process is still alive
--- FAIL: TestIssue1873_RestartIsNotAdmittedWhileTheOwnedTreeSurvives (1.13s)
=== RUN   TestIssue1873_TeardownReapsTheEscapedTree
    issue1873_escaped_tree_repro_test.go:303:
        	Error:      	Should be true
        	Messages:   	a deliberate stop must reap the escaped tree: pid=1828477 pgid=1828477 start=62538598
--- FAIL: TestIssue1873_TeardownReapsTheEscapedTree (6.00s)
FAIL
FAIL	github.com/asheshgoplani/agent-deck/internal/session	7.193s
```

The same scenario instrumented to report what actually happens on `main` — **two live trees**:

```
=== RUN   TestIssue1873_BeforeProbe
    BEFORE: pane died; survivor pid=1842927 pgid=1842927 start=62548173 alive=true ppid=1666
    BEFORE: Restart() error = <nil>
    BEFORE: live wrapped tree: pid=1842927 pgid=1842927 start=62548173 ppid=1666
    BEFORE: live wrapped tree: pid=1843047 pgid=1843047 start=62548269 ppid=1666
    BEFORE: wrapped trees recorded=2 live=2, replacement pane alive=false
--- PASS: TestIssue1873_BeforeProbe (2.64s)
```

### AFTER — this branch

The same instrumented scenario: the restart is refused, nothing is signalled, and **one** tree exists.

```
=== RUN   TestIssue1873_AfterProbe
    AFTER:  pane died; survivor pid=2127982 pgid=2127982 start=62738786 alive=true ppid=1666
    AFTER:  Restart() error = restart refused: this session still owns processes from an earlier spawn (2 owned process(es) from generation 1 are alive outside the session's pane)
          owned: pid=2127982 start=62738786 uid=1000 role=descendant
          owned: pid=2127987 start=62738787 uid=1000 role=descendant
        Nothing was started and nothing was signalled.
        Inspect: agent-deck session ownership inspect 3eeb61be-1786904613
        Reap and clear: agent-deck session ownership reconcile 3eeb61be-1786904613
    AFTER:  live wrapped tree: pid=2127982 pgid=2127982 start=62738786 ppid=1666
    AFTER:  wrapped trees recorded=1 live=1, replacement pane alive=false
--- PASS: TestIssue1873_AfterProbe (2.50s)
```

Full suite, including the **two consecutive fast-death/restart waves** the issue asks for (refuse → reconcile → restart admitted → wave 2 fast-dies → refuse again → reconcile), asserting at every step that exactly one owned tree exists and that survivors do not accumulate:

```
=== RUN   TestIssue1873_RestartIsNotAdmittedWhileTheOwnedTreeSurvives
--- PASS: TestIssue1873_RestartIsNotAdmittedWhileTheOwnedTreeSurvives (1.04s)
=== RUN   TestIssue1873_TeardownReapsTheEscapedTree
--- PASS: TestIssue1873_TeardownReapsTheEscapedTree (1.06s)
=== RUN   TestIssue1873_TwoFastDeathWavesLeaveExactlyOneOwnedTree
--- PASS: TestIssue1873_TwoFastDeathWavesLeaveExactlyOneOwnedTree (4.53s)
=== RUN   TestIssue1873_ConcurrentRestartsAreBothRefused
--- PASS: TestIssue1873_ConcurrentRestartsAreBothRefused (1.12s)
=== RUN   TestIssue1873_HealthySessionWithLiveDescendantsStillRestarts
--- PASS: TestIssue1873_HealthySessionWithLiveDescendantsStillRestarts (0.70s)
=== RUN   TestIssue1873_ChildThatDetachesBeforeAttributionIsNeverClaimed
--- PASS: TestIssue1873_ChildThatDetachesBeforeAttributionIsNeverClaimed (0.23s)
=== RUN   TestIssue1873_GateFailsClosedOnEveryUnverifiableShape
    --- PASS: .../owned_survivor_is_alive (5.08s)
    --- PASS: .../proc_entry_unreadable (0.03s)
    --- PASS: .../pid_now_belongs_to_another_user (0.03s)
    --- PASS: .../boot_id_unreadable (0.03s)
    --- PASS: .../pid_recycled_by_an_unrelated_process (0.01s)
    --- PASS: .../process_is_gone (0.01s)
--- PASS: TestIssue1873_GateFailsClosedOnEveryUnverifiableShape (5.20s)
=== RUN   TestIssue1873_CorruptReceiptFailsClosed
--- PASS: TestIssue1873_CorruptReceiptFailsClosed (0.00s)
=== RUN   TestIssue1873_ReceiptFromAPreviousBootIsCleared
--- PASS: TestIssue1873_ReceiptFromAPreviousBootIsCleared (0.01s)
ok  	github.com/asheshgoplani/agent-deck/internal/session	13.954s
```

**The new tests fail on pre-fix code.** The two behavioural tests above use only pre-existing public seams, so they compile and run on `main` — the BEFORE block is those exact tests failing there.

Regression runs (targeted, `-p 1`, sandboxed `HOME`, isolated tmux socket; the default tmux socket was compared before and after every run and is unchanged):

```
go test ./internal/procowner/                                                    ok (0.35s)
go test ./internal/session/  -run 'Issue1873|Restart|Kill|Shell'                 ok (32.16s)
go test ./internal/session/  -run 'Start|Stop|Kill|Revive|Shell|Pane|Adopt|Duplicate|Orphan|Sweep'  ok (24.41s)
go test ./internal/tmux/     -run 'Pane|Respawn|Kill'                            ok (17.66s)
go test ./cmd/agent-deck/    -run 'Ownership|ReapOutcome'                        ok (0.09s)
golangci-lint run ./internal/procowner/... ./internal/session/... ./internal/tmux/... ./cmd/agent-deck/...   0 issues
gofmt: clean
```

### Which failure shape does this suite never build?

The question this repo keeps losing to, asked of my own tests. Each of these gets its own case, because each has its own *correct* answer and "fail closed" is not one single behaviour:

| shape | behaviour | where |
| --- | --- | --- |
| recycled PID, different start time | never signalled; the recorded process is provably dead (a pid is only reused after its holder exits), so it does **not** block a replacement | `TestVerify_RecycledPIDIsAStranger…`, `TestReap_NeverSignalsARecycledPID`, `TestLinuxProber_RealProcessLifecycle` (impostor receipt against a genuinely live process, which survives untouched) |
| corrupt / truncated receipt | not "no receipt" — refuses the spawn, signals nothing; `abandon` is the explicit way out | `TestDecode_RejectsUnusableReceipts` (11 shapes), `TestStore_CorruptReceiptSurfacesAsAnError`, `TestIssue1873_CorruptReceiptFailsClosed` |
| unreadable `/proc` entry | unknown, never "gone": blocks, signals nothing | `TestLinuxProber_UnreadableEntryIsNotDeath`, `TestReap_NeverSignalsAnUnreadableIdentity` |
| process exits between the receipt read and the signal | ESRCH is a clean reap; a pid recycled *during* the grace stops the escalation before SIGKILL | `TestReap_ProcessExitingBeforeTheSignalIsReaped`, `TestReap_PIDRecycledDuringGraceStopsTheEscalation` |
| two restarts racing | both refused, neither spawns; a stale writer cannot overwrite or delete the winner's receipt (generation **and** leader identity are compared) | `TestIssue1873_ConcurrentRestartsAreBothRefused`, `TestStore_GenerationConflictsAreRefused` |
| receipt for a PID now owned by another user | unknown, never signalled; EPERM is reported, not escalated | `TestVerify_PIDNowOwnedByAnotherUserIsUnknown`, `TestReap_NeverSignalsAcrossAUserBoundary`, `TestReap_EPERMIsReportedNotEscalated` |

Four more the list did not name, found while building it:

- **Zombie processes.** A signalled process still has a `/proc` entry until its parent reaps it, reports its original start identity, and accepts signals — so a successful reap read as "survived SIGTERM and SIGKILL". Caught by the real-process integration test, not by any fake. Zombies are now death.
- **A pane whose tmux name has drifted.** An instance whose recorded tmux name no longer matches its live session is a real, separately-tracked failure that restart heals by adoption. Judging attachment by the drifted name alone classified that session's own pane process as an escaped survivor and refused the restart that fixes it. Attachment now also consults the tmux session recorded in the receipt, which cannot drift. (`TestRestart_ShellSession_AdoptsLiveTmuxOnNameMismatch` caught this.)
- **A refused restart stamping a spawn.** The gate initially sat after the spawn-stamp defer, so a refusal recorded a spawn that never happened, and a concurrent caller read that stamp as "already restarted" and returned success. The gate now runs before the stamp.
- **Unbounded receipts and unbounded teardowns.** A tool that forks short-lived helpers adds a genuine descendant every fraction of a second; the member list is capped. Reaping is batched per phase rather than per process, so a stop waits one grace period, not one per member.

The boundary this contract cannot cross is asserted rather than assumed: a child that detaches **and** outlives its whole recorded ancestry before any attribution pass observes it is not attributable to a PID+start-time receipt at all. `TestIssue1873_ChildThatDetachesBeforeAttributionIsNeverClaimed` pins the honest answer — such a process is never claimed, never appears in a reap report, and is left strictly alone rather than killed on a guess. Closing that last gap needs a containment primitive (cgroup / job object), which the ruling deliberately did not take.

One residual window remains open and is documented in the code: agent-deck dying between tmux starting the pane and the receipt being committed. The process must exist before a receipt can name it — that ordering is forced by the kernel — and it fails in the same direction as an unsupported platform: unowned, never mis-owned.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-x (Claude Code)

**Prompt / session log (optional):** not attached; the operator's instruction is quoted below.

## What actually bothered you

From the operator who dispatched this, verbatim: *"It is top of the standing work queue because it unblocks the whole kill-safety cluster … The contract is DECIDED — implement it, do not redesign it … The 'at spawn' part is the whole point — capturing identity later proves only that a pid did not change hands during inspection, not that we own the process."*

The reporter's own account (#1873): a Codex session behind a `/usr/bin/script` wrapper, pane gone, `script` and its Codex descendants still alive under PID 1, and a restart that started a second tree against the same conversation. They checked the process shape and the duplicate by hand before cleaning up, and explicitly held implementation until maintainers ruled on what a durable ownership receipt is.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed — run targeted and `-p 1` rather than `./...`, per this repo's standing constraint on unfiltered multi-package runs; the exact commands and results are in Evidence
- [x] If this touches a hot path: teardown is the only hot path touched. The reap runs after tmux teardown, is a no-op when nothing survives, and is bounded by phase — ≤2s on the non-blocking `Kill()` path (matching the existing MCP child reap budget on the same path), ≤5s on `KillAndWait`, regardless of tree size.
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-4-x intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session ownership inspection, reconciliation, and abandonment commands.
  * Added text and JSON output for ownership status, surviving processes, and cleanup results.
  * Session starts and restarts now prevent unsafe duplication when owned processes remain active.
  * Added identity-verified cleanup during teardown, with recovery guidance when verification is unavailable.
* **Bug Fixes**
  * Improved protection against escaped, recycled, or unverifiable processes during session management.
  * Added safeguards for stale and concurrent ownership updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #1870
