### PR TITLE
feat(fleet): aggregate auth-401 holds by credential identity (#1816)

### DIFF
--- a/cmd/agent-deck/fleet_authcred_cli_test.go
+++ b/cmd/agent-deck/fleet_authcred_cli_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/fleet"
+)
+
+// CLI surface for #1816 credential grouping: the flag is opt-in, and the
+// default output is byte-for-byte what it was.
+
+// THE DEFAULT-OFF PROOF: the flag registers with a false default on both
+// subcommands. This is the maintainer ruling's boundary expressed as a test —
+// "off by default, per-session view stays the default surface".
+func TestGroupByCredentialFlagDefaultsToOff(t *testing.T) {
+	for _, name := range []string{"fleet status", "fleet recover"} {
+		t.Run(name, func(t *testing.T) {
+			fs := flag.NewFlagSet(name, flag.ContinueOnError)
+			got := fs.Bool("group-by-credential", false, groupByCredentialFlagHelp())
+
+			if *got {
+				t.Fatal("flag initialised to true")
+			}
+			f := fs.Lookup("group-by-credential")
+			if f == nil {
+				t.Fatal("flag not registered")
+			}
+			if f.DefValue != "false" {
+				t.Errorf("DefValue = %q, want \"false\"", f.DefValue)
+			}
+			// Parsing an empty argv must leave it off.
+			if err := fs.Parse(nil); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if *got {
+				t.Error("flag became true without being passed")
+			}
+		})
+	}
+}
+
+// The gate only groups when the operator asked for it.
+func TestRecoverConfigForwardsGroupByCredential(t *testing.T) {
+	t.Run("off by default", func(t *testing.T) {
+		rec := fleetRecoverConfig{authHaltAfter: 2}.recoverer()
+		gate, ok := rec.AuthGate.(*fleet.SubstateAuthGate)
+		if !ok {
+			t.Fatalf("AuthGate = %T", rec.AuthGate)
+		}
+		if gate.GroupByCredential {
+			t.Error("GroupByCredential defaulted to true")
+		}
+	})
+
+	t.Run("forwarded when set", func(t *testing.T) {
+		rec := fleetRecoverConfig{authHaltAfter: 2, groupByCredential: true}.recoverer()
+		gate := rec.AuthGate.(*fleet.SubstateAuthGate)
+		if !gate.GroupByCredential {
+			t.Error("GroupByCredential not forwarded")
+		}
+	})
+
+	// Grouping is a reporting flag. It must never resurrect a safety brake the
+	// operator explicitly turned off.
+	t.Run("does not re-enable a disabled breaker", func(t *testing.T) {
+		rec := fleetRecoverConfig{authHaltAfter: 0, groupByCredential: true}.recoverer()
+		if rec.AuthGate != nil {
+			t.Errorf("AuthGate = %v, want nil — --auth-halt-after 0 disables the breaker", rec.AuthGate)
+		}
+	})
+}
+
+// The default --json payload must not grow a key: a conductor polling it today
+// keeps seeing exactly what it sees today.
+func TestFleetStatusJSONUnchangedWithoutTheFlag(t *testing.T) {
+	as := fleet.Assessment{Total: 3, Alive: 1, Down: 2}
+	payload := fleetStatusJSON(as)
+
+	if _, ok := payload["auth_credentials"]; ok {
+		t.Fatal("auth_credentials appeared in the default payload")
+	}
+	// And the opt-in path adds it without disturbing the rest.
+	withFlag := fleetStatusJSON(as)
+	withFlag["auth_credentials"] = fleetAuthCredentialsJSON(fleet.AuthCredentialSummary{})
+	for k, v := range payload {
+		if _, ok := withFlag[k]; !ok {
+			t.Errorf("opt-in payload dropped key %q (%v)", k, v)
+		}
+	}
+}
+
+// The JSON grouping is machine-checkable and carries identifiers only.
+func TestFleetAuthCredentialsJSONShape(t *testing.T) {
+	sum := fleet.AuthCredentialSummary{
+		Held:        3,
+		Credentials: 1,
+		Groups: []fleet.CredentialGroup{
+			{
+				Credential: fleet.CredentialRef{Key: "dir:/home/u/.claude-work", ConfigDir: "/home/u/.claude-work", Attributed: true},
+				Accounts:   []string{"work"},
+				Sessions: []fleet.HeldSession{
+					{ID: "id-a", Title: "alpha", Account: "work", Reason: "auth_banner_live"},
+					{ID: "id-b", Title: "bravo", Account: "work", Reason: "auth_death"},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(fleetAuthCredentialsJSON(sum))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, key := range []string{"held", "credentials", "unattributed", "recovered", "groups"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("payload missing %q: %s", key, raw)
+		}
+	}
+	groups := got["groups"].([]interface{})
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+	g := groups[0].(map[string]interface{})
+	for _, key := range []string{"key", "attributed", "accounts", "held", "recovered", "escalation", "sessions", "config_dir"} {
+		if _, ok := g[key]; !ok {
+			t.Errorf("group missing %q: %s", key, raw)
+		}
+	}
+	if g["held"].(float64) != 2 {
+		t.Errorf("group held = %v, want 2", g["held"])
+	}
+}
+
+// An unattributed group must not carry a config_dir key at all — an empty
+// string there would read as a real, blank credential directory.
+func TestUnattributedGroupOmitsConfigDir(t *testing.T) {
+	sum := fleet.AuthCredentialSummary{
+		Held:         1,
+		Unattributed: 1,
+		Groups: []fleet.CredentialGroup{{
+			Credential: fleet.CredentialRef{Key: fleet.UnknownCredentialKey},
+			Sessions:   []fleet.HeldSession{{ID: "id-x", Title: "orphan"}},
+		}},
+	}
+
+	payload := fleetAuthCredentialsJSON(sum)
+	group := payload["groups"].([]map[string]interface{})[0]
+
+	if _, ok := group["config_dir"]; ok {
+		t.Errorf("unattributed group carries config_dir = %v", group["config_dir"])
+	}
+	if group["attributed"].(bool) {
+		t.Error("unattributed group reports attributed=true")
+	}
+	if !strings.Contains(group["escalation"].(string), "NOT known to share one credential") {
+		t.Errorf("escalation = %v", group["escalation"])
+	}
+}

--- a/cmd/agent-deck/fleet_authcred_cli_test.go
+++ b/cmd/agent-deck/fleet_authcred_cli_test.go
@@ -163,3 +163,90 @@ func TestUnattributedGroupOmitsConfigDir(t *testing.T) {
 		t.Errorf("escalation = %v", group["escalation"])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PR #1963 review findings, CLI surface.
+// ---------------------------------------------------------------------------
+
+// P2b — the CLI must thread --group into the credential view. This asserts the
+// wiring, not just that the grouper is capable of filtering: the defect was the
+// CLI handing the grouper an unfiltered instance list.
+func TestAuthCredentialSummaryHonoursGroupArgument(t *testing.T) {
+	// Real auth holds, real config-dir resolution — the same fixture the
+	// reproduce uses, so this exercises the CLI helper end to end rather than
+	// re-asserting that a struct field holds what was just assigned to it.
+	instances, _ := setupIssue1816Fleet(t, 4)
+	instances[0].GroupPath = "team-a"
+	instances[1].GroupPath = "team-a/sub"
+	instances[2].GroupPath = "team-b"
+	instances[3].GroupPath = "team-b"
+
+	all := authCredentialSummary(instances, "")
+	if all.Held != 4 {
+		t.Fatalf("unfiltered Held = %d, want 4", all.Held)
+	}
+
+	scoped := authCredentialSummary(instances, "team-a")
+	if scoped.Held != 2 {
+		t.Fatalf("--group team-a Held = %d, want 2 — the CLI handed the grouper an unfiltered list", scoped.Held)
+	}
+	for _, g := range scoped.Groups {
+		for _, s := range g.Sessions {
+			if s.Title == instances[2].Title || s.Title == instances[3].Title {
+				t.Errorf("session %s from team-b appeared under --group team-a", s.Title)
+			}
+		}
+	}
+
+	empty := authCredentialSummary(instances, "team-nonexistent")
+	if empty.Held != 0 || len(empty.Groups) != 0 {
+		t.Errorf("--group with no members = %+v, want an empty view rather than the whole fleet", empty)
+	}
+}
+
+// P2a — an attributed group always reports its host, so a machine consumer never
+// has to infer locality from a missing key, and a remote store is flagged.
+func TestFleetAuthCredentialsJSONCarriesHost(t *testing.T) {
+	sum := fleet.AuthCredentialSummary{
+		Held:        2,
+		Credentials: 2,
+		Groups: []fleet.CredentialGroup{
+			{
+				Credential: fleet.CredentialRef{Key: "store:local|/home/u/.claude-work", ConfigDir: "/home/u/.claude-work", Attributed: true},
+				Accounts:   []string{"work"},
+				Sessions:   []fleet.HeldSession{{ID: "id-a", Title: "local-one"}},
+			},
+			{
+				Credential: fleet.CredentialRef{Key: "store:ssh:box-b|/home/u/.claude-work", ConfigDir: "/home/u/.claude-work", Host: "box-b", Attributed: true},
+				Accounts:   []string{"work"},
+				Sessions:   []fleet.HeldSession{{ID: "id-b", Title: "remote-one"}},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(fleetAuthCredentialsJSON(sum))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	groups := got["groups"].([]interface{})
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(groups))
+	}
+
+	local := groups[0].(map[string]interface{})
+	if local["host"] != "local" || local["remote"].(bool) {
+		t.Errorf("local group host=%v remote=%v, want \"local\"/false", local["host"], local["remote"])
+	}
+	remote := groups[1].(map[string]interface{})
+	if remote["host"] != "box-b" || !remote["remote"].(bool) {
+		t.Errorf("remote group host=%v remote=%v, want \"box-b\"/true", remote["host"], remote["remote"])
+	}
+	// The two must be distinguishable by key even though the path is identical.
+	if local["key"] == remote["key"] {
+		t.Errorf("local and remote stores share a key %v — same path on two hosts must not merge", local["key"])
+	}
+}

--- a/cmd/agent-deck/fleet_cmd.go
+++ b/cmd/agent-deck/fleet_cmd.go
@@ -137,7 +137,7 @@ func handleFleetStatus(profile string, args []string) {
 		// Added ONLY under the flag: a conductor polling the default payload
 		// must keep seeing the exact keys it sees today.
 		if *groupByCredential {
-			payload["auth_credentials"] = fleetAuthCredentialsJSON(authCredentialSummary(instances))
+			payload["auth_credentials"] = fleetAuthCredentialsJSON(authCredentialSummary(instances, *det.group))
 		}
 		out.Success("", payload)
 		return
@@ -147,7 +147,7 @@ func handleFleetStatus(profile string, args []string) {
 	// whose pane is still up showing the banner is NOT "down", so a fleet with
 	// zero down sessions can still have a dead credential behind it.
 	if *groupByCredential {
-		fmt.Print("\n" + authCredentialSummary(instances).Format())
+		fmt.Print("\n" + authCredentialSummary(instances, *det.group).Format())
 	}
 }
 
@@ -164,8 +164,15 @@ func groupByCredentialFlagHelp() string {
 
 // authCredentialSummary is the one place the CLI builds the credential view, so
 // the human and --json paths can never group differently.
-func authCredentialSummary(instances []*session.Instance) fleet.AuthCredentialSummary {
-	return fleet.NewAuthCredentialGrouper().Group(instances)
+//
+// group is the --group filter, threaded through so the credential view honours
+// the same scoping contract as the assessment printed above it. Reporting
+// fleet-wide credential state under `--group X` would be wrong in exactly the
+// situation the operator reached for --group to clarify.
+func authCredentialSummary(instances []*session.Instance, group string) fleet.AuthCredentialSummary {
+	g := fleet.NewAuthCredentialGrouper()
+	g.Group = group
+	return g.Summarize(instances)
 }
 
 // fleetAuthCredentialsJSON renders the credential grouping.
@@ -201,6 +208,11 @@ func fleetAuthCredentialsJSON(sum fleet.AuthCredentialSummary) map[string]interf
 		}
 		if g.Credential.Attributed {
 			group["config_dir"] = g.Credential.ConfigDir
+			// host is always present for an attributed store ("local" or the
+			// SSH destination) so a machine consumer never has to infer
+			// locality from a missing key.
+			group["host"] = g.Credential.HostLabel()
+			group["remote"] = g.Credential.IsRemote()
 		}
 		groups = append(groups, group)
 	}

--- a/cmd/agent-deck/fleet_cmd.go
+++ b/cmd/agent-deck/fleet_cmd.go
@@ -99,6 +99,7 @@ func handleFleetStatus(profile string, args []string) {
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	groupByCredential := fs.Bool("group-by-credential", false, groupByCredentialFlagHelp())
 	det := registerFleetDetectorFlags(fs)
 
 	fs.Usage = func() {
@@ -106,6 +107,12 @@ func handleFleetStatus(profile string, args []string) {
 		fmt.Println()
 		fmt.Println("Report sessions the registry believes are alive whose tmux session is")
 		fmt.Println("gone. Read-only: no restarts, no writes.")
+		fmt.Println()
+		fmt.Println("With --group-by-credential the report additionally groups every")
+		fmt.Println("auth-401-held session by WHICH credential is dead, so one dead token")
+		fmt.Println("reads as one line instead of N per-session failures. Opt-in: without")
+		fmt.Println("the flag the output is exactly the per-session view it has always been.")
+		fmt.Println("The grouping is computed locally and never leaves the machine.")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -126,10 +133,84 @@ func handleFleetStatus(profile string, args []string) {
 
 	as := det.detector().Assess(instances)
 	if *jsonOutput {
-		out.Success("", fleetStatusJSON(as))
+		payload := fleetStatusJSON(as)
+		// Added ONLY under the flag: a conductor polling the default payload
+		// must keep seeing the exact keys it sees today.
+		if *groupByCredential {
+			payload["auth_credentials"] = fleetAuthCredentialsJSON(authCredentialSummary(instances))
+		}
+		out.Success("", payload)
 		return
 	}
 	fmt.Print(formatFleetStatus(as))
+	// Printed after the assessment, and independent of it: an auth-held session
+	// whose pane is still up showing the banner is NOT "down", so a fleet with
+	// zero down sessions can still have a dead credential behind it.
+	if *groupByCredential {
+		fmt.Print("\n" + authCredentialSummary(instances).Format())
+	}
+}
+
+// groupByCredentialFlagHelp is shared by `fleet status` and `fleet recover` so
+// the two cannot describe the same opt-in differently.
+//
+// A function rather than a const because gosec's G101 matches any identifier
+// containing "cred" that is assigned a string literal. This one is flag help
+// text, not a credential — a function return sidesteps the rule honestly
+// instead of suppressing it.
+func groupByCredentialFlagHelp() string {
+	return "Group auth-401-held sessions by which credential is dead and report one escalation per credential (opt-in, local-only; off by default the per-session view is unchanged)"
+}
+
+// authCredentialSummary is the one place the CLI builds the credential view, so
+// the human and --json paths can never group differently.
+func authCredentialSummary(instances []*session.Instance) fleet.AuthCredentialSummary {
+	return fleet.NewAuthCredentialGrouper().Group(instances)
+}
+
+// fleetAuthCredentialsJSON renders the credential grouping.
+//
+// Only identifiers are emitted: account slot names and the resolved config
+// directory. No token, no credential file content, and nothing derived from
+// either — see internal/fleet/authcred.go for the boundary this holds.
+func fleetAuthCredentialsJSON(sum fleet.AuthCredentialSummary) map[string]interface{} {
+	groups := make([]map[string]interface{}, 0, len(sum.Groups))
+	for _, g := range sum.Groups {
+		sessions := make([]map[string]interface{}, 0, len(g.Sessions))
+		for _, s := range g.Sessions {
+			entry := map[string]interface{}{
+				"id":    s.ID,
+				"title": s.Title,
+			}
+			if s.Account != "" {
+				entry["account"] = s.Account
+			}
+			if s.Reason != "" {
+				entry["reason"] = s.Reason
+			}
+			sessions = append(sessions, entry)
+		}
+		group := map[string]interface{}{
+			"key":        g.Credential.Key,
+			"attributed": g.Credential.Attributed,
+			"accounts":   g.Accounts,
+			"held":       len(g.Sessions),
+			"recovered":  g.Recovered,
+			"escalation": g.Escalation(),
+			"sessions":   sessions,
+		}
+		if g.Credential.Attributed {
+			group["config_dir"] = g.Credential.ConfigDir
+		}
+		groups = append(groups, group)
+	}
+	return map[string]interface{}{
+		"held":         sum.Held,
+		"credentials":  sum.Credentials,
+		"unattributed": sum.Unattributed,
+		"recovered":    sum.Recovered,
+		"groups":       groups,
+	}
 }
 
 // handleFleetRecover plans (default) or runs the recovery sweep.
@@ -149,6 +230,7 @@ func handleFleetRecover(profile string, args []string) {
 	maxDeadBoots := fs.Int("max-dead-boots", fleet.DefaultMaxDeadBoots,
 		"Halt after this many consecutive sessions restart and then die immediately (pane gone; 0 disables)")
 	authHaltAfter := fs.Int("auth-halt-after", fleet.DefaultAuthHaltAfter, "Halt after this many sessions boot into an auth failure (0 disables the auth breaker)")
+	groupByCredential := fs.Bool("group-by-credential", false, groupByCredentialFlagHelp())
 	det := registerFleetDetectorFlags(fs)
 
 	fs.Usage = func() {
@@ -167,6 +249,10 @@ func handleFleetRecover(profile string, args []string) {
 		fmt.Println("then die immediately (--max-dead-boots), or sessions booting into an auth")
 		fmt.Println("failure (--auth-halt-after) — restarting the rest of the fleet against a")
 		fmt.Println("broken credential only deepens the cascade.")
+		fmt.Println()
+		fmt.Println("With --group-by-credential the auth halt names WHICH credential is dead")
+		fmt.Println("and reports one escalation per credential instead of one count for the")
+		fmt.Println("sweep. Opt-in: without the flag the halt message is unchanged.")
 		fmt.Println()
 		fmt.Println("Sessions the operator stopped or queued, and archived sessions, are")
 		fmt.Println("never touched.")
@@ -194,19 +280,24 @@ func handleFleetRecover(profile string, args []string) {
 	as := det.detector().Assess(instances)
 
 	cfg := fleetRecoverConfig{
-		plan:          *dryRun || !*yes,
-		spacing:       *spacing,
-		jitter:        *jitter,
-		limit:         *limit,
-		maxFailures:   *maxFailures,
-		maxDeadBoots:  *maxDeadBoots,
-		authHaltAfter: *authHaltAfter,
-		verifyTimeout: *verifyTimeout,
-		verifyPoll:    *verifyPoll,
+		plan:              *dryRun || !*yes,
+		spacing:           *spacing,
+		jitter:            *jitter,
+		limit:             *limit,
+		maxFailures:       *maxFailures,
+		maxDeadBoots:      *maxDeadBoots,
+		authHaltAfter:     *authHaltAfter,
+		groupByCredential: *groupByCredential,
+		verifyTimeout:     *verifyTimeout,
+		verifyPoll:        *verifyPoll,
 	}
 	plan := cfg.plan
 	rec := cfg.recoverer()
 	rec.Persist = storage.PersistRecoveredInstances
+	// Kept so the credential grouping the gate collected during the sweep can be
+	// reported structurally, instead of leaving a machine caller to parse it out
+	// of halt_reason. nil when the operator disabled the breaker.
+	authGate, _ := rec.AuthGate.(*fleet.SubstateAuthGate)
 	if !plan && !*jsonOutput && !quietMode {
 		rec.Progress = func(index, total int, c fleet.Candidate) {
 			fmt.Printf("[%d/%d] restarting %s...\n", index, total, c.Title())
@@ -215,13 +306,28 @@ func handleFleetRecover(profile string, args []string) {
 
 	summary := rec.Recover(as)
 
+	// Opt-in only, and empty unless the gate actually observed auth failures.
+	var credentials fleet.AuthCredentialSummary
+	if *groupByCredential && authGate != nil {
+		credentials = authGate.AuthFailuresByCredential()
+	}
+
 	switch {
 	case *jsonOutput:
-		out.Success("", fleetRecoverJSON(summary, plan))
+		payload := fleetRecoverJSON(summary, plan)
+		if *groupByCredential && authGate != nil {
+			payload["auth_credentials"] = fleetAuthCredentialsJSON(credentials)
+		}
+		out.Success("", payload)
 	case quietMode:
 		fmt.Println(summary.Format())
 	default:
 		fmt.Print(formatFleetRecover(summary, plan))
+		// A sweep can end with auth failures that never reached the halt
+		// threshold, so this must not be left to HALTED: alone.
+		if credentials.Held > 0 {
+			fmt.Print("\n" + credentials.Format())
+		}
 	}
 	// A halted sweep is not a success: exit non-zero so a wrapper script or
 	// conductor notices without parsing anything. This deliberately covers the
@@ -238,15 +344,16 @@ func handleFleetRecover(profile string, args []string) {
 // "no --yes means plan only" and "--spacing 0 is the explicit opt-out") is a
 // pure function the tests can assert on.
 type fleetRecoverConfig struct {
-	plan          bool
-	spacing       time.Duration
-	jitter        float64
-	limit         int
-	maxFailures   int
-	maxDeadBoots  int
-	authHaltAfter int
-	verifyTimeout time.Duration
-	verifyPoll    time.Duration
+	plan              bool
+	spacing           time.Duration
+	jitter            float64
+	limit             int
+	maxFailures       int
+	maxDeadBoots      int
+	authHaltAfter     int
+	groupByCredential bool
+	verifyTimeout     time.Duration
+	verifyPoll        time.Duration
 }
 
 func (c fleetRecoverConfig) recoverer() *fleet.Recoverer {
@@ -270,9 +377,16 @@ func (c fleetRecoverConfig) recoverer() *fleet.Recoverer {
 		rec.MaxDeadBoots = c.maxDeadBoots
 	}
 	if c.authHaltAfter <= 0 {
+		// --auth-halt-after 0 disables the breaker outright, so there is no
+		// gate left to group on. Asking for grouping does NOT resurrect it:
+		// re-enabling a safety brake the operator explicitly turned off would
+		// be a surprising side effect of a reporting flag.
 		rec.AuthGate = nil
 	} else {
-		rec.AuthGate = &fleet.SubstateAuthGate{HaltAfter: c.authHaltAfter}
+		rec.AuthGate = &fleet.SubstateAuthGate{
+			HaltAfter:         c.authHaltAfter,
+			GroupByCredential: c.groupByCredential,
+		}
 	}
 	verifier := fleet.NewVerifier()
 	verifier.Timeout = c.verifyTimeout

--- a/cmd/agent-deck/issue1816_repro_after_test.go
+++ b/cmd/agent-deck/issue1816_repro_after_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/fleet"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// REPRODUCTION for #1816, the AFTER half.
+//
+// Same scenario as issue1816_repro_before_test.go — four sessions, one dead
+// credential — through the opt-in surface. This file does not compile before the
+// fix, because the surface it exercises does not exist there.
+
+// THE FIX: one dead credential is ONE escalation, and it names the credential.
+func TestIssue1816_After_OneDeadCredentialProducesOneEscalation(t *testing.T) {
+	instances, credDir := setupIssue1816Fleet(t, 4)
+
+	sum := authCredentialSummary(instances)
+	escalations := sum.Escalations()
+
+	t.Logf("AFTER (--group-by-credential) — %d sessions on ONE credential produce %d escalation:",
+		len(instances), len(escalations))
+	for _, e := range escalations {
+		t.Logf("  %s", e)
+	}
+	t.Logf("rendered report:\n%s", sum.Format())
+
+	if len(escalations) != 1 {
+		t.Fatalf("got %d escalations, want exactly 1:\n%s", len(escalations), strings.Join(escalations, "\n"))
+	}
+	if sum.Credentials != 1 || sum.Held != 4 {
+		t.Fatalf("summary = %+v, want 1 credential holding 4 sessions", sum)
+	}
+	// It must be actionable: the operator has to know WHICH credential to fix.
+	if !strings.Contains(escalations[0], issue1816Account) {
+		t.Errorf("escalation does not name the account: %s", escalations[0])
+	}
+	if !strings.Contains(escalations[0], credDir) {
+		t.Errorf("escalation does not name the credential dir: %s", escalations[0])
+	}
+	if !strings.Contains(escalations[0], "4 session(s) held") {
+		t.Errorf("escalation does not account for all four sessions: %s", escalations[0])
+	}
+}
+
+// THE DEFAULT IS UNTOUCHED: with the flag off, the per-session view is exactly
+// what the BEFORE capture recorded — same count, same bytes — and the default
+// --json payload has not grown the aggregation key.
+func TestIssue1816_After_PerSessionViewUnchangedWithFlagOff(t *testing.T) {
+	instances, credDir := setupIssue1816Fleet(t, 4)
+
+	escalations := perSessionEscalations(instances)
+
+	t.Logf("AFTER (flag off) — the per-session view is unchanged: %d escalations", len(escalations))
+	for i, e := range escalations {
+		t.Logf("  [%d/%d] %s", i+1, len(escalations), e)
+	}
+
+	if len(escalations) != 4 {
+		t.Fatalf("got %d per-session escalations, want the original 4", len(escalations))
+	}
+	for _, inst := range instances {
+		held, remedy := inst.IsAuthHeld()
+		if !held {
+			t.Fatalf("%s stopped being auth-held", inst.Title)
+		}
+		// Byte-for-byte the pre-#1816 remedy: the aggregation must not have
+		// leaked into the per-session surface.
+		if remedy != (&session.AuthHoldRecord{Reason: session.AuthHoldReasonDeath}).Remedy() {
+			t.Errorf("per-session remedy changed:\n%s", remedy)
+		}
+		if strings.Contains(remedy, credDir) || strings.Contains(remedy, issue1816Account) {
+			t.Errorf("per-session remedy grew credential detail with the flag off: %s", remedy)
+		}
+	}
+
+	// The default machine surface is unchanged too.
+	payload := fleetStatusJSON(fleet.Assessment{Total: 4, Down: 4})
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "auth_credentials") {
+		t.Errorf("default fleet status payload gained the aggregation key: %s", raw)
+	}
+}
+
+// The opt-in payload is what a conductor consumes instead of N substates.
+func TestIssue1816_After_JSONExposesTheCredentialGrouping(t *testing.T) {
+	instances, credDir := setupIssue1816Fleet(t, 4)
+
+	payload := fleetStatusJSON(fleet.Assessment{Total: 4, Down: 4})
+	payload["auth_credentials"] = fleetAuthCredentialsJSON(authCredentialSummary(instances))
+
+	raw, err := json.MarshalIndent(payload["auth_credentials"], "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	t.Logf("AFTER --json auth_credentials:\n%s", raw)
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["credentials"].(float64) != 1 {
+		t.Errorf("credentials = %v, want 1", got["credentials"])
+	}
+	if got["held"].(float64) != 4 {
+		t.Errorf("held = %v, want 4", got["held"])
+	}
+	groups := got["groups"].([]interface{})
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1", len(groups))
+	}
+	if groups[0].(map[string]interface{})["config_dir"] != credDir {
+		t.Errorf("config_dir = %v, want %s", groups[0].(map[string]interface{})["config_dir"], credDir)
+	}
+
+	// Local-only and identifier-only: nothing token-shaped may appear.
+	for _, forbidden := range []string{"sk-ant", "Bearer", "refresh_token", "access_token"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Errorf("payload contains %q: %s", forbidden, raw)
+		}
+	}
+}

--- a/cmd/agent-deck/issue1816_repro_after_test.go
+++ b/cmd/agent-deck/issue1816_repro_after_test.go
@@ -19,7 +19,7 @@ import (
 func TestIssue1816_After_OneDeadCredentialProducesOneEscalation(t *testing.T) {
 	instances, credDir := setupIssue1816Fleet(t, 4)
 
-	sum := authCredentialSummary(instances)
+	sum := authCredentialSummary(instances, "")
 	escalations := sum.Escalations()
 
 	t.Logf("AFTER (--group-by-credential) — %d sessions on ONE credential produce %d escalation:",
@@ -94,7 +94,7 @@ func TestIssue1816_After_JSONExposesTheCredentialGrouping(t *testing.T) {
 	instances, credDir := setupIssue1816Fleet(t, 4)
 
 	payload := fleetStatusJSON(fleet.Assessment{Total: 4, Down: 4})
-	payload["auth_credentials"] = fleetAuthCredentialsJSON(authCredentialSummary(instances))
+	payload["auth_credentials"] = fleetAuthCredentialsJSON(authCredentialSummary(instances, ""))
 
 	raw, err := json.MarshalIndent(payload["auth_credentials"], "", "  ")
 	if err != nil {

--- a/cmd/agent-deck/issue1816_repro_before_test.go
+++ b/cmd/agent-deck/issue1816_repro_before_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// REPRODUCTION for #1816, the BEFORE half.
+//
+// This file deliberately uses only symbols that existed BEFORE the fix, so it
+// compiles and passes on the pre-fix tip. It is the executable statement of the
+// defect: four sessions on ONE credential produce FOUR independent escalations
+// and nothing anywhere names the credential they share.
+//
+// No real credentials are involved. The auth hold is armed through its durable
+// on-disk contract (the sidecar #1743 writes), which is the same thing the live
+// detector produces when a pane renders a 401 banner — and no token material
+// exists anywhere in this test.
+
+// issue1816Account is the account slot all the sessions in the scenario share.
+const issue1816Account = "work"
+
+// setupIssue1816Fleet stands up n sessions attributed to one account whose
+// config_dir is configured in a sandboxed HOME, and arms a real auth hold on
+// each. Returns the instances and the credential directory they share.
+func setupIssue1816Fleet(t *testing.T, n int) ([]*session.Instance, string) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	os.Unsetenv("XDG_DATA_HOME")
+	os.Unsetenv("XDG_STATE_HOME")
+	os.Unsetenv("XDG_CACHE_HOME")
+	// CLAUDE_CONFIG_DIR sits above profile/global in the chain; clear it so the
+	// scenario resolves through the account slot it is actually about.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+
+	credDir := filepath.Join(home, ".claude-work")
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		t.Fatalf("mkdir cred dir: %v", err)
+	}
+
+	adDir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(adDir, 0o700); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	cfg := fmt.Sprintf("[profiles.%s.claude]\nconfig_dir = %q\n", issue1816Account, credDir)
+	if err := os.WriteFile(filepath.Join(adDir, "config.toml"), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	instances := make([]*session.Instance, 0, n)
+	for i := 0; i < n; i++ {
+		title := fmt.Sprintf("worker-%d", i+1)
+		inst := &session.Instance{
+			ID:      fmt.Sprintf("id-%s", title),
+			Title:   title,
+			Tool:    "claude",
+			Status:  session.StatusError,
+			Account: issue1816Account,
+		}
+		armIssue1816AuthHold(t, inst)
+		instances = append(instances, inst)
+	}
+
+	// The scenario is only meaningful if all of them really do resolve to one
+	// credential directory.
+	for _, inst := range instances {
+		if got := session.GetClaudeConfigDirForInstance(inst); got != credDir {
+			t.Fatalf("%s resolved to %q, want the shared credential dir %q", inst.Title, got, credDir)
+		}
+	}
+	return instances, credDir
+}
+
+// armIssue1816AuthHold writes the durable auth-hold sidecar #1743 defines, which
+// is what puts a session in the auth-401 hold every surface reads.
+func armIssue1816AuthHold(t *testing.T, inst *session.Instance) {
+	t.Helper()
+
+	dataDir, err := agentpaths.DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	// Create the "runtime" marker so EffectiveDataPath resolves to this dir
+	// rather than falling through to the legacy location.
+	holdDir := filepath.Join(dataDir, "runtime", "auth-hold")
+	if err := os.MkdirAll(holdDir, 0o700); err != nil {
+		t.Fatalf("mkdir auth-hold: %v", err)
+	}
+
+	rec := session.AuthHoldRecord{
+		InstanceID: inst.ID,
+		Tool:       "claude",
+		Reason:     session.AuthHoldReasonDeath,
+		// Evidence is the rendered banner. It is a failure message, not a
+		// credential: no token, key, or secret appears here or anywhere else.
+		Evidence:  "API Error: 401 " + `{"type":"error","error":{"type":"authentication_error"}}`,
+		Timestamp: 1786000000,
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal hold: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(holdDir, inst.ID+".json"), data, 0o600); err != nil {
+		t.Fatalf("write hold: %v", err)
+	}
+
+	if got := inst.AuthHold(); got == nil {
+		t.Fatalf("auth hold did not arm for %s (sidecar at %s)", inst.Title, holdDir)
+	}
+	if held, _ := inst.IsAuthHeld(); !held {
+		t.Fatalf("%s is not auth-held after arming", inst.Title)
+	}
+}
+
+// perSessionEscalations is the view a conductor gets today: one escalation per
+// held session, exactly as `session show --json <id>` reports it.
+func perSessionEscalations(instances []*session.Instance) []string {
+	var out []string
+	for _, inst := range instances {
+		held, remedy := inst.IsAuthHeld()
+		if !held {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s: %s", inst.Title, remedy))
+	}
+	return out
+}
+
+// THE DEFECT: one dead credential, four independent escalations, and not one of
+// them says which credential is dead.
+func TestIssue1816_Before_OneDeadCredentialProducesNSeparateEscalations(t *testing.T) {
+	instances, credDir := setupIssue1816Fleet(t, 4)
+
+	escalations := perSessionEscalations(instances)
+
+	t.Logf("BEFORE — %d sessions on ONE credential (%s) produce %d separate escalations:",
+		len(instances), credDir, len(escalations))
+	for i, e := range escalations {
+		t.Logf("  [%d/%d] %s", i+1, len(escalations), e)
+	}
+
+	if len(escalations) != len(instances) {
+		t.Fatalf("got %d escalations for %d held sessions, want one each", len(escalations), len(instances))
+	}
+	// This is the whole complaint: nothing in the per-session view identifies
+	// the shared credential, so a conductor cannot collapse these itself.
+	//
+	// The remedy is checked on its own rather than the logged "title: remedy"
+	// line, because the session titles here legitimately contain the account
+	// name as a prefix ("worker-1") and matching that would prove nothing.
+	for _, inst := range instances {
+		_, remedy := inst.IsAuthHeld()
+		if strings.Contains(remedy, credDir) || strings.Contains(remedy, issue1816Account) {
+			t.Errorf("per-session remedy unexpectedly names the credential — the defect would already be fixed: %s", remedy)
+		}
+	}
+}

--- a/internal/fleet/authcred.go
+++ b/internal/fleet/authcred.go
@@ -31,12 +31,30 @@ import (
 //
 // # What identifies a credential (and what deliberately does not)
 //
-// The grouping key is the RESOLVED CLAUDE CONFIG DIRECTORY — the directory the
-// credential physically lives in, per session.GetClaudeConfigDirForInstance's
-// priority chain. It is an identifier, never token material: no token, no
-// refresh token, no credential file content, and no hash of any of them is read,
-// compared, logged, or persisted anywhere in this file. Grouping is computed in
-// memory, per invocation, and thrown away.
+// The grouping key is a CREDENTIAL STORE: the pair (host, resolved Claude config
+// directory). The directory comes from session.GetClaudeConfigDirForInstance's
+// priority chain; the host is the SSH destination, or "local". Both are
+// identifiers, never token material: no token, no refresh token, no credential
+// file content, and no hash of any of them is read, compared, logged, or
+// persisted anywhere in this file. Grouping is computed in memory, per
+// invocation, and thrown away.
+//
+// THE HOST IS PART OF THE IDENTITY, and leaving it out was a real defect. A
+// local session and an SSH session can resolve the SAME config path while
+// reading two completely different credential files on two different machines.
+// Keying on the path alone merged them, so one re-login would have been reported
+// as recovering sessions it cannot reach — the aggregation asserting a fix that
+// silently does not hold for half the fleet. Same rule as the unknown bucket,
+// arriving from the other side: there, one bucket was folded into another; here,
+// two genuinely different stores were folded into one. Both are the aggregation
+// lying about what it grouped, and on this feature that lie IS the product.
+//
+// What the host component does and does not claim: two sessions agreeing on both
+// host and path are on one credential store; two disagreeing on host are not.
+// The local resolution is NOT claimed to be the remote file's true location —
+// only to distinguish stores. When in doubt this splits rather than merges,
+// because over-aggregation is the direction that misleads an operator into
+// thinking one re-auth was enough.
 //
 // Keying on the directory rather than on Instance.Account is what makes the two
 // awkward shapes come out right, and both are real:
@@ -77,23 +95,63 @@ import (
 // that unattributable sessions get quietly swept into.
 const UnknownCredentialKey = "unknown"
 
-// credentialKeyPrefix namespaces the directory-derived key so a key can never
+// credentialKeyPrefix namespaces the store-derived key so a key can never
 // collide with UnknownCredentialKey, whatever a path looks like.
-const credentialKeyPrefix = "dir:"
+const credentialKeyPrefix = "store:"
 
-// CredentialRef identifies WHICH credential a set of held sessions runs under.
+// localHostScope is the key scope for a session running on this machine. It is
+// spelled out rather than left as the empty string so a local store and a
+// malformed/blank SSH destination can never produce the same key.
+const localHostScope = "local"
+
+// sshHostScopePrefix namespaces an SSH destination inside the key, so a host
+// literally named "local" cannot collide with localHostScope.
+const sshHostScopePrefix = "ssh:"
+
+// CredentialRef identifies WHICH credential store a set of held sessions runs
+// under.
 //
 // Every field is an identifier or a path. Nothing here is, or is derived from,
 // token material.
 type CredentialRef struct {
 	// Key is the stable grouping key. Two sessions with equal Keys share one
-	// credential file; UnknownCredentialKey means "not attributable".
+	// credential store; UnknownCredentialKey means "not attributable".
 	Key string
 	// ConfigDir is the resolved credential directory ("" when unattributed).
 	ConfigDir string
+	// Host is the SSH destination the store lives on, or "" for a store on this
+	// machine. Callers must use HostLabel rather than branching on "" directly.
+	Host string
 	// Attributed is false for the unknown bucket. Callers must branch on this
 	// rather than on ConfigDir being non-empty.
 	Attributed bool
+}
+
+// HostLabel names the machine the credential store lives on.
+func (c CredentialRef) HostLabel() string {
+	if strings.TrimSpace(c.Host) == "" {
+		return localHostScope
+	}
+	return c.Host
+}
+
+// IsRemote reports whether this store lives on another machine, which is what
+// makes "re-authenticate once" NOT reach it from here.
+func (c CredentialRef) IsRemote() bool { return strings.TrimSpace(c.Host) != "" }
+
+// hostScope renders the key's host component.
+//
+// An SSH destination is used verbatim after trimming — deliberately NOT
+// lowercased or otherwise canonicalised. "user@box" and "other@box" are
+// different home directories and so different stores, and DNS-style case folding
+// on the host half would risk merging two stores to save an operator one line.
+// Splitting costs an extra escalation; merging costs a fleet.
+func hostScope(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return localHostScope
+	}
+	return sshHostScopePrefix + host
 }
 
 // unknownCredential returns the unattributed bucket's identity.
@@ -130,15 +188,25 @@ type CredentialGroup struct {
 	Recovered bool
 }
 
-// Label names the credential the way an operator would have to refer to it.
+// Label names the credential store the way an operator would have to refer to
+// it.
+//
+// A remote store names its host, because that is the difference between an
+// operator running /login here and an operator needing a shell on another
+// machine. A local store keeps the pre-existing wording so the common case reads
+// exactly as it did.
 func (g CredentialGroup) Label() string {
 	if !g.Credential.Attributed {
 		return "an unattributable credential"
 	}
-	if len(g.Accounts) > 0 {
-		return fmt.Sprintf("account %s (%s)", strings.Join(g.Accounts, ", "), g.Credential.ConfigDir)
+	where := ""
+	if g.Credential.IsRemote() {
+		where = fmt.Sprintf(" on ssh://%s", g.Credential.Host)
 	}
-	return fmt.Sprintf("credential %s", g.Credential.ConfigDir)
+	if len(g.Accounts) > 0 {
+		return fmt.Sprintf("account %s%s (%s)", strings.Join(g.Accounts, ", "), where, g.Credential.ConfigDir)
+	}
+	return fmt.Sprintf("credential%s %s", where, g.Credential.ConfigDir)
 }
 
 // Escalation is the ONE operator-facing line this group replaces N per-session
@@ -161,6 +229,14 @@ func (g CredentialGroup) Escalation() string {
 		return fmt.Sprintf(
 			"auth-401: %d session(s) held on %s — these are NOT known to share one credential, so re-authenticating one may not recover the others; check them individually (%s)",
 			n, g.Label(), g.sessionList())
+	}
+	// A remote store cannot be repaired from here. Saying "re-authenticate that
+	// credential once" without naming where would be the same false promise the
+	// host dimension exists to prevent.
+	if g.Credential.IsRemote() {
+		return fmt.Sprintf(
+			"auth-401: %d session(s) held on %s — that credential store lives on %s, so re-authenticating locally will NOT reach it; re-authenticate on that host and every one of them can recover (%s)",
+			n, g.Label(), g.Credential.Host, g.sessionList())
 	}
 	return fmt.Sprintf(
 		"auth-401: %d session(s) held on %s — re-authenticate that credential once and every one of them can recover (%s)",
@@ -239,6 +315,17 @@ func (s AuthCredentialSummary) Format() string {
 // in this package: the tests drive the real grouping logic without a sidecar
 // file, a config.toml, or a tmux server.
 type AuthCredentialGrouper struct {
+	// Group, when set, restricts the view to that group path and its
+	// descendants — the SAME contract as Detector.Group, deliberately using the
+	// same inGroup predicate rather than a second copy of the rule.
+	//
+	// Without this, `fleet status --group X --group-by-credential` answered
+	// about the whole fleet while claiming to answer about X: wrong, and most
+	// confusing at exactly the moment an operator is narrowing down a problem.
+	// (`fleet recover` needs no equivalent: its sweep only ever hands the gate
+	// candidates the Detector already filtered.)
+	Group string
+
 	// Hold returns a session's auth hold, or nil when it is not currently held.
 	// nil uses authHoldOf, which asks the durable per-session record (#1743)
 	// through IsAuthHeld/AuthHold so this view and the automatic boot paths
@@ -275,6 +362,18 @@ func (g *AuthCredentialGrouper) hold(inst *session.Instance) *session.AuthHoldRe
 	return g.Hold(inst)
 }
 
+// inScope applies the --group filter. A nil instance is out of scope only when a
+// filter is set, so the unfiltered view keeps reaching Identify's nil handling.
+func (g *AuthCredentialGrouper) inScope(inst *session.Instance) bool {
+	if g == nil || g.Group == "" {
+		return true
+	}
+	if inst == nil {
+		return false
+	}
+	return inGroup(inst.GroupPath, g.Group)
+}
+
 func (g *AuthCredentialGrouper) configDir(inst *session.Instance) string {
 	if g == nil || g.ConfigDir == nil {
 		return session.GetClaudeConfigDirForInstance(inst)
@@ -294,7 +393,15 @@ func (g *AuthCredentialGrouper) Identify(inst *session.Instance) CredentialRef {
 	// The auth-hold model and the config-dir chain below are both Claude's.
 	// Another tool's session may genuinely be held one day; guessing a Claude
 	// credential for it would be attribution by wishful thinking.
-	if !strings.EqualFold(strings.TrimSpace(inst.Tool), "claude") {
+	//
+	// Asked through session.IsClaudeCompatible rather than by comparing the tool
+	// name to the literal "claude": a custom tool that wraps the Claude CLI (a
+	// path, an env-prefixed command, or an explicit compatible_with = "claude")
+	// reads the SAME credential file, so a literal comparison silently drops
+	// every aliased session out of the aggregation it belongs in. Matching a
+	// literal name where a predicate already answers the question is the same
+	// defect class as #1923.
+	if !session.IsClaudeCompatible(inst.Tool) {
 		return unknownCredential()
 	}
 	dir := strings.TrimSpace(g.configDir(inst))
@@ -306,19 +413,30 @@ func (g *AuthCredentialGrouper) Identify(inst *session.Instance) CredentialRef {
 		return unknownCredential()
 	}
 	dir = filepath.Clean(dir)
+	// A remote session's store lives on another machine; see the package doc for
+	// why the host is part of the identity and not a display detail.
+	host := strings.TrimSpace(inst.SSHHost)
 	return CredentialRef{
-		Key:        credentialKeyPrefix + dir,
+		Key:        credentialKeyPrefix + hostScope(host) + "|" + dir,
 		ConfigDir:  dir,
+		Host:       host,
 		Attributed: true,
 	}
 }
 
-// Group returns the credential-level view of every auth-held session in
-// instances. It reads state and writes nothing: no sidecar, no registry row, no
-// log line, and nothing leaves the machine.
-func (g *AuthCredentialGrouper) Group(instances []*session.Instance) AuthCredentialSummary {
+// Summarize returns the credential-level view of every auth-held session in
+// instances, honouring the Group filter. It reads state and writes nothing: no
+// sidecar, no registry row, no log line, and nothing leaves the machine.
+//
+// Named Summarize rather than Group because Group is the filter field above; a
+// method and a field cannot share a name, and the field matches Detector.Group
+// so the two scoping knobs read identically at their call sites.
+func (g *AuthCredentialGrouper) Summarize(instances []*session.Instance) AuthCredentialSummary {
 	acc := newCredAccumulator(g.Identify)
 	for _, inst := range instances {
+		if !g.inScope(inst) {
+			continue
+		}
 		rec := g.hold(inst)
 		if rec == nil {
 			continue

--- a/internal/fleet/authcred.go
+++ b/internal/fleet/authcred.go
@@ -1,0 +1,442 @@
+package fleet
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Credential-identity grouping for auth-held sessions (#1816).
+//
+// WHY THIS SITS NEXT TO authgate.go AND NOT IN A PACKAGE OF ITS OWN.
+// SubstateAuthGate already aggregates auth-401 across a fleet, but only in one
+// direction and only for one purpose: it counts auth-failed BOOTS during a
+// recovery sweep so the sweep can halt itself. Two things it does not do, and
+// that a conductor watching a fleet actually needs:
+//
+//  1. It counts sessions, not credentials. Ten sessions booting into a 401 is
+//     reported as "10 sessions" whether that is one dead token or three.
+//  2. The count exists only inside a sweep. Nothing can ask "how many distinct
+//     dead credentials are behind these N held sessions?" without re-deriving
+//     it from N per-session substates — which is the N-escalations problem in
+//     the first place.
+//
+// This file adds credential identity as a first-class thing and hands it to
+// BOTH callers through one accumulator (credAccumulator), so the sweep-scoped
+// tally and the outside-the-sweep query can never drift about what counts as
+// "one credential".
+//
+// # What identifies a credential (and what deliberately does not)
+//
+// The grouping key is the RESOLVED CLAUDE CONFIG DIRECTORY — the directory the
+// credential physically lives in, per session.GetClaudeConfigDirForInstance's
+// priority chain. It is an identifier, never token material: no token, no
+// refresh token, no credential file content, and no hash of any of them is read,
+// compared, logged, or persisted anywhere in this file. Grouping is computed in
+// memory, per invocation, and thrown away.
+//
+// Keying on the directory rather than on Instance.Account is what makes the two
+// awkward shapes come out right, and both are real:
+//
+//   - THE SAME ACCOUNT NAME UNDER TWO CONFIG DIRS IS TWO CREDENTIALS. An account
+//     slot with no [profiles.<account>.claude].config_dir block falls THROUGH to
+//     the conductor/group/env/profile levels (see resolveClaudeConfigDir), so two
+//     sessions both naming account "work" in different groups can be running two
+//     different tokens. Keying on the name would merge them and tell the operator
+//     one re-login fixes both. It would not.
+//   - TWO ACCOUNT NAMES OVER ONE CONFIG DIR IS ONE CREDENTIAL. Distinct slots
+//     pointing at the same directory share one token file: one re-login really
+//     does fix every session behind them, and reporting two dead credentials
+//     would be over-counting the outage.
+//
+// The account names are kept for DISPLAY (that is what the operator types to fix
+// it), never as the identity.
+//
+// # Unknown is a bucket, not a default
+//
+// A session whose credential cannot be attributed goes into its own bucket and
+// is NEVER folded into an attributed group. The three ways attribution fails are
+// all reachable: a nil instance, a non-Claude tool (the auth-hold model and this
+// resolution chain are Claude's), and a config dir that does not resolve to an
+// absolute path — which happens for every session at once when HOME cannot be
+// resolved, since the chain's last resort is filepath.Join(home, ".claude") and
+// degrades to a bare relative ".claude". That last one is the dangerous one: if
+// an empty resolution were allowed to be a key, one unresolvable HOME would
+// silently merge an entire fleet into a single fabricated "credential" and the
+// aggregation would confidently report one dead token for what might be twelve.
+//
+// The unknown bucket's escalation says so out loud: it reports the sessions as
+// NOT known to share a credential, so an operator never reads it as "one
+// re-login fixes these".
+
+// UnknownCredentialKey is the grouping key for held sessions whose credential
+// could not be attributed. It is a real, distinct bucket — never a default one
+// that unattributable sessions get quietly swept into.
+const UnknownCredentialKey = "unknown"
+
+// credentialKeyPrefix namespaces the directory-derived key so a key can never
+// collide with UnknownCredentialKey, whatever a path looks like.
+const credentialKeyPrefix = "dir:"
+
+// CredentialRef identifies WHICH credential a set of held sessions runs under.
+//
+// Every field is an identifier or a path. Nothing here is, or is derived from,
+// token material.
+type CredentialRef struct {
+	// Key is the stable grouping key. Two sessions with equal Keys share one
+	// credential file; UnknownCredentialKey means "not attributable".
+	Key string
+	// ConfigDir is the resolved credential directory ("" when unattributed).
+	ConfigDir string
+	// Attributed is false for the unknown bucket. Callers must branch on this
+	// rather than on ConfigDir being non-empty.
+	Attributed bool
+}
+
+// unknownCredential returns the unattributed bucket's identity.
+func unknownCredential() CredentialRef {
+	return CredentialRef{Key: UnknownCredentialKey}
+}
+
+// HeldSession is one auth-held session as it appears inside a group.
+//
+// Reason is the AuthHoldRecord reason (auth_banner_live | auth_death), or "" when
+// the caller had no record to read — the recovery sweep observes a 401 boot
+// before any sidecar is guaranteed to exist.
+type HeldSession struct {
+	ID      string
+	Title   string
+	Account string
+	Reason  string
+}
+
+// CredentialGroup is every held session behind one credential: the unit an
+// operator actually acts on, because one re-login clears the whole group.
+type CredentialGroup struct {
+	Credential CredentialRef
+	// Accounts are the distinct non-empty account slot names seen in this
+	// group, sorted. Usually one; more than one means several slots point at
+	// the same config dir. Empty means no session named an account.
+	Accounts []string
+	Sessions []HeldSession
+	// Recovered means a LATER observation on this same credential authenticated
+	// successfully, so it is not dead after all. Only a sweep can set this (it
+	// is the only caller that watches a credential over time); the
+	// currently-held query always leaves it false, because a session whose
+	// credential recovered is not held any more.
+	Recovered bool
+}
+
+// Label names the credential the way an operator would have to refer to it.
+func (g CredentialGroup) Label() string {
+	if !g.Credential.Attributed {
+		return "an unattributable credential"
+	}
+	if len(g.Accounts) > 0 {
+		return fmt.Sprintf("account %s (%s)", strings.Join(g.Accounts, ", "), g.Credential.ConfigDir)
+	}
+	return fmt.Sprintf("credential %s", g.Credential.ConfigDir)
+}
+
+// Escalation is the ONE operator-facing line this group replaces N per-session
+// ones with.
+//
+// The unattributed bucket gets a deliberately different sentence: it must not
+// read as "one re-login fixes these", because nothing here established that its
+// sessions share anything at all.
+func (g CredentialGroup) Escalation() string {
+	n := len(g.Sessions)
+	// Checked before the attributed/unattributed split: telling an operator to
+	// re-authenticate a credential that just proved it works is the one thing
+	// this report must never do.
+	if g.Recovered {
+		return fmt.Sprintf(
+			"auth-401: %d session(s) failed on %s, but a later boot on that same credential authenticated — it is NOT dead; retry those sessions rather than re-authenticating (%s)",
+			n, g.Label(), g.sessionList())
+	}
+	if !g.Credential.Attributed {
+		return fmt.Sprintf(
+			"auth-401: %d session(s) held on %s — these are NOT known to share one credential, so re-authenticating one may not recover the others; check them individually (%s)",
+			n, g.Label(), g.sessionList())
+	}
+	return fmt.Sprintf(
+		"auth-401: %d session(s) held on %s — re-authenticate that credential once and every one of them can recover (%s)",
+		n, g.Label(), g.sessionList())
+}
+
+// sessionList renders the member titles in group order.
+func (g CredentialGroup) sessionList() string {
+	titles := make([]string, 0, len(g.Sessions))
+	for _, s := range g.Sessions {
+		title := strings.TrimSpace(s.Title)
+		if title == "" {
+			title = s.ID
+		}
+		titles = append(titles, title)
+	}
+	return strings.Join(titles, ", ")
+}
+
+// AuthCredentialSummary is the whole credential-level view: the query the issue
+// asks for, answerable without re-deriving anything from per-session substates.
+type AuthCredentialSummary struct {
+	// Groups are attributed credentials first (ordered by key), the unknown
+	// bucket last when present.
+	Groups []CredentialGroup
+	// Held is how many sessions are auth-held in total.
+	Held int
+	// Credentials is how many DISTINCT credentials are attributed AND still
+	// look dead. Two exclusions, both deliberate: the unknown bucket (an
+	// unknown number of credentials is not one credential) and any credential
+	// that recovered mid-sweep. This is the number an operator reads as "how
+	// many re-logins am I facing", so anything it counts must actually need one.
+	Credentials int
+	// Unattributed is how many held sessions landed in the unknown bucket.
+	Unattributed int
+	// Recovered is how many attributed credentials failed and then
+	// authenticated again during the same sweep.
+	Recovered int
+}
+
+// Escalations returns one line per credential — the whole point of #1816.
+func (s AuthCredentialSummary) Escalations() []string {
+	lines := make([]string, 0, len(s.Groups))
+	for _, g := range s.Groups {
+		lines = append(lines, g.Escalation())
+	}
+	return lines
+}
+
+// Format renders the human-readable credential view.
+func (s AuthCredentialSummary) Format() string {
+	var b strings.Builder
+	if s.Held == 0 {
+		b.WriteString("Auth credentials: no sessions are auth-held.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Auth credentials: %d held session(s) behind %d dead credential(s)",
+		s.Held, s.Credentials)
+	if s.Recovered > 0 {
+		fmt.Fprintf(&b, " plus %d that recovered mid-sweep", s.Recovered)
+	}
+	if s.Unattributed > 0 {
+		fmt.Fprintf(&b, " plus %d session(s) whose credential could not be attributed", s.Unattributed)
+	}
+	b.WriteString("\n")
+	for _, g := range s.Groups {
+		fmt.Fprintf(&b, "  - %s\n", g.Escalation())
+	}
+	return b.String()
+}
+
+// AuthCredentialGrouper answers "which credentials are dead, and who is held
+// behind each one" for a set of sessions.
+//
+// Both side effects are injectable function fields, matching Recoverer's style
+// in this package: the tests drive the real grouping logic without a sidecar
+// file, a config.toml, or a tmux server.
+type AuthCredentialGrouper struct {
+	// Hold returns a session's auth hold, or nil when it is not currently held.
+	// nil uses authHoldOf, which asks the durable per-session record (#1743)
+	// through IsAuthHeld/AuthHold so this view and the automatic boot paths
+	// always agree on exactly which sessions are held.
+	Hold func(*session.Instance) *session.AuthHoldRecord
+	// ConfigDir resolves a session's credential directory. nil uses
+	// session.GetClaudeConfigDirForInstance — the single source of truth for
+	// the priority chain (#881), never a re-implementation of it.
+	ConfigDir func(*session.Instance) string
+}
+
+// NewAuthCredentialGrouper returns a grouper wired to the real durable hold and
+// the real config-dir chain.
+func NewAuthCredentialGrouper() *AuthCredentialGrouper {
+	return &AuthCredentialGrouper{}
+}
+
+// authHoldOf is the default Hold seam: held only while the session is not
+// healthy, which is exactly the condition the boot paths gate on.
+func authHoldOf(inst *session.Instance) *session.AuthHoldRecord {
+	if inst == nil {
+		return nil
+	}
+	if held, _ := inst.IsAuthHeld(); !held {
+		return nil
+	}
+	return inst.AuthHold()
+}
+
+func (g *AuthCredentialGrouper) hold(inst *session.Instance) *session.AuthHoldRecord {
+	if g == nil || g.Hold == nil {
+		return authHoldOf(inst)
+	}
+	return g.Hold(inst)
+}
+
+func (g *AuthCredentialGrouper) configDir(inst *session.Instance) string {
+	if g == nil || g.ConfigDir == nil {
+		return session.GetClaudeConfigDirForInstance(inst)
+	}
+	return g.ConfigDir(inst)
+}
+
+// Identify returns the credential identity of one session, attributed or not.
+//
+// Exported because the identity rule is the reviewable part of this change: a
+// caller (or a test) must be able to ask "what does agent-deck think this
+// session's credential is" without going through a whole grouping pass.
+func (g *AuthCredentialGrouper) Identify(inst *session.Instance) CredentialRef {
+	if inst == nil {
+		return unknownCredential()
+	}
+	// The auth-hold model and the config-dir chain below are both Claude's.
+	// Another tool's session may genuinely be held one day; guessing a Claude
+	// credential for it would be attribution by wishful thinking.
+	if !strings.EqualFold(strings.TrimSpace(inst.Tool), "claude") {
+		return unknownCredential()
+	}
+	dir := strings.TrimSpace(g.configDir(inst))
+	// An unresolvable HOME makes the chain's last resort degrade to a bare
+	// relative ".claude" for EVERY session at once. Requiring an absolute path
+	// is what stops that from merging a whole fleet into one fabricated
+	// credential.
+	if dir == "" || !filepath.IsAbs(dir) {
+		return unknownCredential()
+	}
+	dir = filepath.Clean(dir)
+	return CredentialRef{
+		Key:        credentialKeyPrefix + dir,
+		ConfigDir:  dir,
+		Attributed: true,
+	}
+}
+
+// Group returns the credential-level view of every auth-held session in
+// instances. It reads state and writes nothing: no sidecar, no registry row, no
+// log line, and nothing leaves the machine.
+func (g *AuthCredentialGrouper) Group(instances []*session.Instance) AuthCredentialSummary {
+	acc := newCredAccumulator(g.Identify)
+	for _, inst := range instances {
+		rec := g.hold(inst)
+		if rec == nil {
+			continue
+		}
+		acc.add(inst, HeldSession{
+			ID:      instanceID(inst),
+			Title:   instanceTitle(inst),
+			Account: instanceAccount(inst),
+			Reason:  rec.Reason,
+		})
+	}
+	return acc.summary()
+}
+
+// credAccumulator collects held sessions into credential groups.
+//
+// Shared deliberately: AuthCredentialGrouper.Group (the query) and
+// SubstateAuthGate.Observe (the sweep) both build their groups here, so there is
+// exactly one definition of "one credential" and one ordering, and the two
+// surfaces cannot disagree.
+type credAccumulator struct {
+	ident  func(*session.Instance) CredentialRef
+	order  []string
+	groups map[string]*CredentialGroup
+	held   int
+}
+
+func newCredAccumulator(ident func(*session.Instance) CredentialRef) *credAccumulator {
+	return &credAccumulator{
+		ident:  ident,
+		groups: make(map[string]*CredentialGroup),
+	}
+}
+
+func (a *credAccumulator) add(inst *session.Instance, s HeldSession) {
+	ref := a.ident(inst)
+	g, ok := a.groups[ref.Key]
+	if !ok {
+		g = &CredentialGroup{Credential: ref}
+		a.groups[ref.Key] = g
+		a.order = append(a.order, ref.Key)
+	}
+	g.Sessions = append(g.Sessions, s)
+	if acct := strings.TrimSpace(s.Account); acct != "" && !containsString(g.Accounts, acct) {
+		g.Accounts = append(g.Accounts, acct)
+		sort.Strings(g.Accounts)
+	}
+	a.held++
+}
+
+// summary is summaryWithRecovered for callers that never watch a credential
+// over time (the currently-held query).
+func (a *credAccumulator) summary() AuthCredentialSummary {
+	return a.summaryWithRecovered(nil)
+}
+
+// summaryWithRecovered orders the groups deterministically: attributed
+// credentials by key, then the unknown bucket. Unknown goes LAST so a reader who
+// stops at the first line reads a real credential, and so the bucket that says
+// "these may not be related" is never mistaken for the headline.
+//
+// recovered names credentials that authenticated after their failures; they stay
+// in the output (the operator still has sessions to retry) but are not counted
+// as dead.
+func (a *credAccumulator) summaryWithRecovered(recovered map[string]bool) AuthCredentialSummary {
+	keys := make([]string, 0, len(a.order))
+	for _, k := range a.order {
+		if k != UnknownCredentialKey {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	out := AuthCredentialSummary{Held: a.held}
+	out.Groups = make([]CredentialGroup, 0, len(a.order))
+	for _, k := range keys {
+		g := *a.groups[k]
+		if recovered[k] {
+			g.Recovered = true
+			out.Recovered++
+		} else {
+			out.Credentials++
+		}
+		out.Groups = append(out.Groups, g)
+	}
+	if unknown, ok := a.groups[UnknownCredentialKey]; ok {
+		out.Unattributed = len(unknown.Sessions)
+		out.Groups = append(out.Groups, *unknown)
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func instanceID(inst *session.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	return inst.ID
+}
+
+func instanceTitle(inst *session.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	return inst.Title
+}
+
+func instanceAccount(inst *session.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	return strings.TrimSpace(inst.Account)
+}

--- a/internal/fleet/authcred_test.go
+++ b/internal/fleet/authcred_test.go
@@ -66,7 +66,7 @@ func TestOneDeadCredentialProducesOneEscalation(t *testing.T) {
 		"charlie": "/home/u/.claude-work",
 	}, allHeld("alpha", "bravo", "charlie"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Held != 3 {
 		t.Errorf("Held = %d, want 3", sum.Held)
@@ -100,7 +100,7 @@ func TestTwoCredentialsDyingAtOnceStayTwoEscalations(t *testing.T) {
 		"charlie": "/home/u/.claude-work",
 	}, allHeld("alpha", "bravo", "charlie"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Credentials != 2 {
 		t.Fatalf("Credentials = %d, want 2", sum.Credentials)
@@ -134,7 +134,7 @@ func TestSameAccountNameUnderTwoConfigDirsIsTwoCredentials(t *testing.T) {
 		"bravo": "/home/u/.claude-b",
 	}, allHeld("alpha", "bravo"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Credentials != 2 {
 		t.Fatalf("Credentials = %d, want 2 — the same account name over two config dirs is two credentials", sum.Credentials)
@@ -158,7 +158,7 @@ func TestTwoAccountNamesOverOneConfigDirIsOneCredential(t *testing.T) {
 		"bravo": "/home/u/.claude-shared",
 	}, allHeld("alpha", "bravo"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Credentials != 1 {
 		t.Fatalf("Credentials = %d, want 1 — one config dir is one token file", sum.Credentials)
@@ -187,7 +187,7 @@ func TestUnattributableSessionGetsItsOwnBucket(t *testing.T) {
 		"orphan": "", // unresolvable
 	}, allHeld("alpha", "bravo", "orphan"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Credentials != 1 {
 		t.Errorf("Credentials = %d, want 1 — the unknown bucket is not a credential", sum.Credentials)
@@ -236,7 +236,7 @@ func TestRelativeConfigDirNeverBecomesAGroupKey(t *testing.T) {
 		"bravo": ".claude",
 	}, allHeld("alpha", "bravo"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Credentials != 0 {
 		t.Errorf("Credentials = %d, want 0 — a relative path does not identify a credential", sum.Credentials)
@@ -259,7 +259,7 @@ func TestNonClaudeToolIsUnattributed(t *testing.T) {
 	inst.Tool = "codex"
 	g := dirGrouper(map[string]string{"codex-one": "/home/u/.claude-work"}, allHeld("codex-one"))
 
-	sum := g.Group([]*session.Instance{inst})
+	sum := g.Summarize([]*session.Instance{inst})
 
 	if sum.Credentials != 0 || sum.Unattributed != 1 {
 		t.Fatalf("Credentials = %d, Unattributed = %d; want 0 and 1", sum.Credentials, sum.Unattributed)
@@ -269,7 +269,7 @@ func TestNonClaudeToolIsUnattributed(t *testing.T) {
 // A nil instance must not panic or create a phantom credential.
 func TestNilInstanceIsSkipped(t *testing.T) {
 	g := dirGrouper(map[string]string{"alpha": "/home/u/.claude-work"}, allHeld("alpha"))
-	sum := g.Group([]*session.Instance{nil, heldInstance("alpha", "work"), nil})
+	sum := g.Summarize([]*session.Instance{nil, heldInstance("alpha", "work"), nil})
 	if sum.Held != 1 || sum.Credentials != 1 {
 		t.Fatalf("Held = %d, Credentials = %d; want 1 and 1", sum.Held, sum.Credentials)
 	}
@@ -287,7 +287,7 @@ func TestUnheldSessionsAreNotGrouped(t *testing.T) {
 		"healthy": "/home/u/.claude-work",
 	}, allHeld("alpha")) // only alpha is held
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Held != 1 {
 		t.Fatalf("Held = %d, want 1", sum.Held)
@@ -300,7 +300,7 @@ func TestUnheldSessionsAreNotGrouped(t *testing.T) {
 // Zero held sessions is a clean, non-alarming report — not an empty group.
 func TestNoHeldSessionsReportsNothingDead(t *testing.T) {
 	g := dirGrouper(map[string]string{"alpha": "/home/u/.claude-work"}, map[string]string{})
-	sum := g.Group([]*session.Instance{heldInstance("alpha", "work")})
+	sum := g.Summarize([]*session.Instance{heldInstance("alpha", "work")})
 
 	if sum.Held != 0 || sum.Credentials != 0 || len(sum.Groups) != 0 {
 		t.Fatalf("summary = %+v, want an empty view", sum)
@@ -328,7 +328,7 @@ func TestGroupOrderIsDeterministicWithUnknownLast(t *testing.T) {
 	}, allHeld("zulu", "alpha", "orphan"))
 
 	for i := 0; i < 5; i++ {
-		sum := g.Group(insts)
+		sum := g.Summarize(insts)
 		if len(sum.Groups) != 3 {
 			t.Fatalf("got %d groups, want 3", len(sum.Groups))
 		}
@@ -352,7 +352,7 @@ func TestHoldReasonIsCarriedPerSession(t *testing.T) {
 			"bravo": session.AuthHoldReasonDeath,
 		})
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	reasons := map[string]string{}
 	for _, s := range sum.Groups[0].Sessions {
@@ -371,7 +371,7 @@ func TestConfigDirIsCanonicalisedBeforeGrouping(t *testing.T) {
 		"bravo": "/home/u/./.claude-work/",
 	}, allHeld("alpha", "bravo"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 
 	if sum.Credentials != 1 {
 		t.Fatalf("Credentials = %d, want 1 — the same directory written two ways is one credential", sum.Credentials)
@@ -393,7 +393,7 @@ func TestGroupingWritesNothingAndLeaksNoTokenMaterial(t *testing.T) {
 		"bravo": filepath.Join(home, ".claude-work"),
 	}, allHeld("alpha", "bravo"))
 
-	sum := g.Group(insts)
+	sum := g.Summarize(insts)
 	rendered := sum.Format() + strings.Join(sum.Escalations(), "\n")
 
 	if after := snapshotTree(t, home); after != before {
@@ -422,4 +422,285 @@ func snapshotTree(t *testing.T, root string) string {
 		t.Fatalf("walk %s: %v", root, err)
 	}
 	return strings.Join(paths, "\n")
+}
+
+// ---------------------------------------------------------------------------
+// PR #1963 review findings P2a / P2b / P2c.
+// ---------------------------------------------------------------------------
+
+// sshInstance is a held session running on a remote host.
+func sshInstance(title, account, sshHost string) *session.Instance {
+	inst := heldInstance(title, account)
+	inst.SSHHost = sshHost
+	return inst
+}
+
+// P2a — THE STORE IS (host, path), NOT path. A local session and an SSH session
+// resolving the same config path read two different credential files on two
+// different machines. Merging them would report one re-auth as recovering
+// sessions it cannot reach.
+func TestLocalAndSSHSessionOnSamePathAreSeparateCredentials(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("local-one", "work"),
+		sshInstance("remote-one", "work", "box-b"),
+	}
+	g := dirGrouper(map[string]string{
+		"local-one":  "/home/u/.claude-work",
+		"remote-one": "/home/u/.claude-work", // SAME path, different machine
+	}, allHeld("local-one", "remote-one"))
+
+	sum := g.Summarize(insts)
+
+	if sum.Credentials != 2 {
+		t.Fatalf("Credentials = %d, want 2 — same path on two hosts is two credential stores", sum.Credentials)
+	}
+	if len(sum.Groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(sum.Groups))
+	}
+	for _, grp := range sum.Groups {
+		if len(grp.Sessions) != 1 {
+			t.Errorf("group %q holds %d sessions, want 1 — the two hosts were merged", grp.Credential.Key, len(grp.Sessions))
+		}
+	}
+
+	// And the remote one must not tell the operator a local re-login fixes it.
+	var remote *CredentialGroup
+	for i := range sum.Groups {
+		if sum.Groups[i].Credential.IsRemote() {
+			remote = &sum.Groups[i]
+		}
+	}
+	if remote == nil {
+		t.Fatal("no remote credential group produced")
+	}
+	if remote.Credential.Host != "box-b" || remote.Credential.HostLabel() != "box-b" {
+		t.Errorf("remote host = %q / %q, want box-b", remote.Credential.Host, remote.Credential.HostLabel())
+	}
+	esc := remote.Escalation()
+	if !strings.Contains(esc, "re-authenticating locally will NOT reach it") {
+		t.Errorf("remote escalation must not promise a local fix: %s", esc)
+	}
+	if !strings.Contains(esc, "box-b") {
+		t.Errorf("remote escalation must name the host: %s", esc)
+	}
+}
+
+// P2a, follow-up shape: the SAME account reached over TWO different ssh
+// destinations is two stores, not one.
+func TestSameAccountOverTwoSSHDestinationsIsTwoCredentials(t *testing.T) {
+	insts := []*session.Instance{
+		sshInstance("r1", "work", "box-b"),
+		sshInstance("r2", "work", "box-c"),
+		sshInstance("r3", "work", "box-b"),
+	}
+	g := dirGrouper(map[string]string{
+		"r1": "/home/u/.claude-work",
+		"r2": "/home/u/.claude-work",
+		"r3": "/home/u/.claude-work",
+	}, allHeld("r1", "r2", "r3"))
+
+	sum := g.Summarize(insts)
+
+	if sum.Credentials != 2 {
+		t.Fatalf("Credentials = %d, want 2 (box-b, box-c)", sum.Credentials)
+	}
+	byHost := map[string]int{}
+	for _, grp := range sum.Groups {
+		byHost[grp.Credential.Host] = len(grp.Sessions)
+	}
+	if byHost["box-b"] != 2 || byHost["box-c"] != 1 {
+		t.Errorf("sessions by host = %v, want box-b:2 box-c:1", byHost)
+	}
+}
+
+// P2a, the merge direction still has to work: two sessions on the SAME ssh
+// destination and path are one store, so the host dimension has not simply
+// disabled aggregation for remote sessions.
+func TestSameSSHDestinationAndPathIsOneCredential(t *testing.T) {
+	insts := []*session.Instance{
+		sshInstance("r1", "work", "box-b"),
+		sshInstance("r2", "work", "box-b"),
+	}
+	g := dirGrouper(map[string]string{
+		"r1": "/home/u/.claude-work",
+		"r2": "/home/u/.claude-work",
+	}, allHeld("r1", "r2"))
+
+	sum := g.Summarize(insts)
+
+	if sum.Credentials != 1 {
+		t.Fatalf("Credentials = %d, want 1 — one host + one path is one store", sum.Credentials)
+	}
+	if len(sum.Groups[0].Sessions) != 2 {
+		t.Errorf("group holds %d sessions, want 2", len(sum.Groups[0].Sessions))
+	}
+}
+
+// P2a, key hygiene: a host literally named "local" must not collide with the
+// local scope, and a blank/whitespace SSHHost is local rather than a distinct
+// phantom host.
+func TestHostScopeCannotCollideWithLocal(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("plain-local", "work"),
+		sshInstance("named-local", "work", "local"),
+		sshInstance("blank-host", "work", "   "),
+	}
+	g := dirGrouper(map[string]string{
+		"plain-local": "/home/u/.claude-work",
+		"named-local": "/home/u/.claude-work",
+		"blank-host":  "/home/u/.claude-work",
+	}, allHeld("plain-local", "named-local", "blank-host"))
+
+	sum := g.Summarize(insts)
+
+	// plain-local and blank-host are both local (one store); "local" the
+	// hostname is a second, separate store.
+	if sum.Credentials != 2 {
+		t.Fatalf("Credentials = %d, want 2 — a host named \"local\" is not the local machine", sum.Credentials)
+	}
+
+	var localGroup, sshNamedLocal *CredentialGroup
+	for i := range sum.Groups {
+		if sum.Groups[i].Credential.IsRemote() {
+			sshNamedLocal = &sum.Groups[i]
+		} else {
+			localGroup = &sum.Groups[i]
+		}
+	}
+	if localGroup == nil || sshNamedLocal == nil {
+		t.Fatalf("groups = %+v, want one local store and one ssh store", sum.Groups)
+	}
+	// A blank/whitespace SSHHost is local, not a phantom third store.
+	if len(localGroup.Sessions) != 2 {
+		t.Errorf("local store holds %d sessions, want 2 (a whitespace SSHHost is local)", len(localGroup.Sessions))
+	}
+	if len(sshNamedLocal.Sessions) != 1 {
+		t.Errorf("ssh://local store holds %d sessions, want 1", len(sshNamedLocal.Sessions))
+	}
+	// The load-bearing property: the keys are distinct even though both render
+	// their host as the word "local".
+	if localGroup.Credential.Key == sshNamedLocal.Credential.Key {
+		t.Errorf("key collision: a host named %q produced the same key as the local machine (%s)",
+			"local", localGroup.Credential.Key)
+	}
+}
+
+// P2b — the --group filter must narrow the credential view, like every other
+// view. Asking about one group and getting fleet-wide credential state is wrong
+// exactly when an operator is narrowing down a problem.
+func TestGroupFilterNarrowsTheCredentialSummary(t *testing.T) {
+	inGroupA := heldInstance("a-one", "work")
+	inGroupA.GroupPath = "team-a"
+	nested := heldInstance("a-nested", "work")
+	nested.GroupPath = "team-a/sub"
+	other := heldInstance("b-one", "personal")
+	other.GroupPath = "team-b"
+
+	dirs := map[string]string{
+		"a-one":    "/home/u/.claude-work",
+		"a-nested": "/home/u/.claude-work",
+		"b-one":    "/home/u/.claude-personal",
+	}
+	held := allHeld("a-one", "a-nested", "b-one")
+
+	t.Run("unfiltered sees the whole fleet", func(t *testing.T) {
+		g := dirGrouper(dirs, held)
+		sum := g.Summarize([]*session.Instance{inGroupA, nested, other})
+		if sum.Held != 3 || sum.Credentials != 2 {
+			t.Fatalf("summary = %+v, want 3 held across 2 credentials", sum)
+		}
+	})
+
+	t.Run("--group narrows to that group and its descendants", func(t *testing.T) {
+		g := dirGrouper(dirs, held)
+		g.Group = "team-a"
+		sum := g.Summarize([]*session.Instance{inGroupA, nested, other})
+
+		if sum.Held != 2 {
+			t.Fatalf("Held = %d, want 2 — team-b leaked into a --group team-a view", sum.Held)
+		}
+		if sum.Credentials != 1 {
+			t.Fatalf("Credentials = %d, want 1", sum.Credentials)
+		}
+		for _, s := range sum.Groups[0].Sessions {
+			if s.Title == "b-one" {
+				t.Error("a session outside --group appeared in the credential summary")
+			}
+		}
+	})
+
+	t.Run("--group with no members reports an empty view, not the fleet", func(t *testing.T) {
+		g := dirGrouper(dirs, held)
+		g.Group = "team-zzz"
+		sum := g.Summarize([]*session.Instance{inGroupA, nested, other})
+		if sum.Held != 0 || len(sum.Groups) != 0 {
+			t.Fatalf("summary = %+v, want an empty view for a group with no held sessions", sum)
+		}
+	})
+}
+
+// P2c — attribution must use the IsClaudeCompatible predicate, not a literal
+// "claude" comparison. A custom tool wrapping the Claude CLI reads the SAME
+// credential file, so a literal match silently drops every aliased session out
+// of the group it belongs in.
+func TestClaudeCompatibleAliasAggregatesWithClaude(t *testing.T) {
+	// A custom tool declaring compatible_with = "claude".
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		t.Skipf("LoadUserConfig unavailable: %v", err)
+	}
+	if cfg.Tools == nil {
+		cfg.Tools = map[string]session.ToolDef{}
+	}
+	cfg.Tools["claude_wrapper"] = session.ToolDef{
+		Command:        "claude-wrapper",
+		CompatibleWith: "claude",
+	}
+	if err := session.SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	if !session.IsClaudeCompatible("claude_wrapper") {
+		t.Fatal("fixture is wrong: claude_wrapper is not Claude-compatible")
+	}
+
+	plain := heldInstance("plain", "work")
+	aliased := heldInstance("aliased", "work")
+	aliased.Tool = "claude_wrapper"
+
+	g := dirGrouper(map[string]string{
+		"plain":   "/home/u/.claude-work",
+		"aliased": "/home/u/.claude-work",
+	}, allHeld("plain", "aliased"))
+
+	sum := g.Summarize([]*session.Instance{plain, aliased})
+
+	if sum.Unattributed != 0 {
+		t.Fatalf("Unattributed = %d, want 0 — the aliased session was dropped out of the aggregation", sum.Unattributed)
+	}
+	if sum.Credentials != 1 {
+		t.Fatalf("Credentials = %d, want 1", sum.Credentials)
+	}
+	if len(sum.Groups[0].Sessions) != 2 {
+		t.Fatalf("group holds %d sessions, want 2 — the alias did not aggregate with claude", len(sum.Groups[0].Sessions))
+	}
+	if len(sum.Escalations()) != 1 {
+		t.Errorf("got %d escalations, want 1", len(sum.Escalations()))
+	}
+}
+
+// P2c, the other half: a tool that is NOT Claude-compatible still goes to the
+// unknown bucket. The predicate must not have widened attribution to everything.
+func TestNonCompatibleCustomToolStaysUnattributed(t *testing.T) {
+	inst := heldInstance("codexish", "work")
+	inst.Tool = "some-other-tool"
+	g := dirGrouper(map[string]string{"codexish": "/home/u/.claude-work"}, allHeld("codexish"))
+
+	sum := g.Summarize([]*session.Instance{inst})
+
+	if sum.Credentials != 0 || sum.Unattributed != 1 {
+		t.Fatalf("Credentials = %d, Unattributed = %d; want 0 and 1", sum.Credentials, sum.Unattributed)
+	}
 }

--- a/internal/fleet/authcred_test.go
+++ b/internal/fleet/authcred_test.go
@@ -1,0 +1,425 @@
+package fleet
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Tests for credential-identity grouping of auth-401 holds (#1816).
+//
+// Every test here drives the real grouping logic through the injectable seams,
+// so nothing spawns tmux, writes a sidecar, or reads a real config.toml.
+
+// heldInstance builds an auth-held session attributed to an account slot.
+func heldInstance(title, account string) *session.Instance {
+	inst := testInstance(title, session.StatusError)
+	inst.Account = account
+	return inst
+}
+
+// dirGrouper returns a grouper whose config-dir chain is a fixed lookup keyed by
+// session title, and which treats every instance in held as auth-held.
+func dirGrouper(dirs map[string]string, reasons map[string]string) *AuthCredentialGrouper {
+	return &AuthCredentialGrouper{
+		Hold: func(inst *session.Instance) *session.AuthHoldRecord {
+			if inst == nil {
+				return nil
+			}
+			reason, ok := reasons[inst.Title]
+			if !ok {
+				return nil
+			}
+			return &session.AuthHoldRecord{InstanceID: inst.ID, Reason: reason}
+		},
+		ConfigDir: func(inst *session.Instance) string {
+			if inst == nil {
+				return ""
+			}
+			return dirs[inst.Title]
+		},
+	}
+}
+
+// allHeld marks every named session as held on a live banner.
+func allHeld(titles ...string) map[string]string {
+	out := make(map[string]string, len(titles))
+	for _, t := range titles {
+		out[t] = session.AuthHoldReasonLive
+	}
+	return out
+}
+
+// THE HEADLINE: N sessions on one credential produce ONE escalation, not N.
+func TestOneDeadCredentialProducesOneEscalation(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("bravo", "work"),
+		heldInstance("charlie", "work"),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha":   "/home/u/.claude-work",
+		"bravo":   "/home/u/.claude-work",
+		"charlie": "/home/u/.claude-work",
+	}, allHeld("alpha", "bravo", "charlie"))
+
+	sum := g.Group(insts)
+
+	if sum.Held != 3 {
+		t.Errorf("Held = %d, want 3", sum.Held)
+	}
+	if sum.Credentials != 1 {
+		t.Errorf("Credentials = %d, want 1", sum.Credentials)
+	}
+	esc := sum.Escalations()
+	if len(esc) != 1 {
+		t.Fatalf("got %d escalations, want exactly 1: %v", len(esc), esc)
+	}
+	if !strings.Contains(esc[0], "3 session(s) held") {
+		t.Errorf("escalation does not report all 3 sessions: %s", esc[0])
+	}
+	if !strings.Contains(esc[0], "work") {
+		t.Errorf("escalation does not name the account: %s", esc[0])
+	}
+}
+
+// Two credentials dying at once must NOT collapse into one escalation — the
+// aggregation has to keep counting credentials, not just sessions.
+func TestTwoCredentialsDyingAtOnceStayTwoEscalations(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("bravo", "personal"),
+		heldInstance("charlie", "work"),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha":   "/home/u/.claude-work",
+		"bravo":   "/home/u/.claude-personal",
+		"charlie": "/home/u/.claude-work",
+	}, allHeld("alpha", "bravo", "charlie"))
+
+	sum := g.Group(insts)
+
+	if sum.Credentials != 2 {
+		t.Fatalf("Credentials = %d, want 2", sum.Credentials)
+	}
+	if len(sum.Groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(sum.Groups))
+	}
+	counts := map[string]int{}
+	for _, grp := range sum.Groups {
+		counts[grp.Credential.ConfigDir] = len(grp.Sessions)
+	}
+	if counts["/home/u/.claude-work"] != 2 {
+		t.Errorf("work credential holds %d sessions, want 2", counts["/home/u/.claude-work"])
+	}
+	if counts["/home/u/.claude-personal"] != 1 {
+		t.Errorf("personal credential holds %d sessions, want 1", counts["/home/u/.claude-personal"])
+	}
+}
+
+// THE SPLIT DIRECTION: the same account NAME resolving to two different config
+// dirs is two different credentials. An account slot with no config_dir block
+// falls through to the group/conductor levels, so this is reachable in practice
+// — and merging on the name would promise that one re-login fixes both.
+func TestSameAccountNameUnderTwoConfigDirsIsTwoCredentials(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("bravo", "work"),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha": "/home/u/.claude-a",
+		"bravo": "/home/u/.claude-b",
+	}, allHeld("alpha", "bravo"))
+
+	sum := g.Group(insts)
+
+	if sum.Credentials != 2 {
+		t.Fatalf("Credentials = %d, want 2 — the same account name over two config dirs is two credentials", sum.Credentials)
+	}
+	for _, grp := range sum.Groups {
+		if len(grp.Sessions) != 1 {
+			t.Errorf("group %s holds %d sessions, want 1", grp.Credential.Key, len(grp.Sessions))
+		}
+	}
+}
+
+// THE MERGE DIRECTION: two account names over ONE config dir share one token
+// file, so it is one credential and one re-login really does fix both.
+func TestTwoAccountNamesOverOneConfigDirIsOneCredential(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("bravo", "work-alias"),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha": "/home/u/.claude-shared",
+		"bravo": "/home/u/.claude-shared",
+	}, allHeld("alpha", "bravo"))
+
+	sum := g.Group(insts)
+
+	if sum.Credentials != 1 {
+		t.Fatalf("Credentials = %d, want 1 — one config dir is one token file", sum.Credentials)
+	}
+	got := sum.Groups[0].Accounts
+	if len(got) != 2 || got[0] != "work" || got[1] != "work-alias" {
+		t.Errorf("Accounts = %v, want both slot names sorted", got)
+	}
+	if !strings.Contains(sum.Groups[0].Escalation(), "work, work-alias") {
+		t.Errorf("escalation should name both slots: %s", sum.Groups[0].Escalation())
+	}
+}
+
+// UNKNOWN IS ITS OWN BUCKET: an unattributable session is never folded into an
+// attributed credential's group, and its escalation must not claim the sessions
+// share a credential.
+func TestUnattributableSessionGetsItsOwnBucket(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("bravo", "work"),
+		heldInstance("orphan", ""),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha":  "/home/u/.claude-work",
+		"bravo":  "/home/u/.claude-work",
+		"orphan": "", // unresolvable
+	}, allHeld("alpha", "bravo", "orphan"))
+
+	sum := g.Group(insts)
+
+	if sum.Credentials != 1 {
+		t.Errorf("Credentials = %d, want 1 — the unknown bucket is not a credential", sum.Credentials)
+	}
+	if sum.Unattributed != 1 {
+		t.Errorf("Unattributed = %d, want 1", sum.Unattributed)
+	}
+	if len(sum.Groups) != 2 {
+		t.Fatalf("got %d groups, want 2 (work + unknown)", len(sum.Groups))
+	}
+	// The attributed group must not have absorbed the orphan.
+	work := sum.Groups[0]
+	if !work.Credential.Attributed || len(work.Sessions) != 2 {
+		t.Fatalf("attributed group = %+v, want exactly the 2 work sessions", work)
+	}
+	for _, s := range work.Sessions {
+		if s.Title == "orphan" {
+			t.Fatal("orphan was folded into the attributed credential's group")
+		}
+	}
+	// Unknown sorts last, and says out loud that it is not one credential.
+	unknown := sum.Groups[1]
+	if unknown.Credential.Key != UnknownCredentialKey || unknown.Credential.Attributed {
+		t.Fatalf("last group = %+v, want the unattributed bucket", unknown)
+	}
+	esc := unknown.Escalation()
+	if !strings.Contains(esc, "NOT known to share one credential") {
+		t.Errorf("unknown escalation must not imply a shared credential: %s", esc)
+	}
+	if strings.Contains(esc, "re-authenticate that credential once") {
+		t.Errorf("unknown escalation must not promise a single re-login fixes it: %s", esc)
+	}
+}
+
+// The dangerous shape of "unknown is not empty": when HOME cannot be resolved,
+// the config-dir chain's last resort degrades to a bare relative ".claude" for
+// EVERY session at once. Treating that as a key would merge an entire fleet into
+// one fabricated credential and report one dead token for what may be many.
+func TestRelativeConfigDirNeverBecomesAGroupKey(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("bravo", "personal"),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha": ".claude",
+		"bravo": ".claude",
+	}, allHeld("alpha", "bravo"))
+
+	sum := g.Group(insts)
+
+	if sum.Credentials != 0 {
+		t.Errorf("Credentials = %d, want 0 — a relative path does not identify a credential", sum.Credentials)
+	}
+	if sum.Unattributed != 2 {
+		t.Errorf("Unattributed = %d, want 2", sum.Unattributed)
+	}
+	if len(sum.Groups) != 1 || sum.Groups[0].Credential.Attributed {
+		t.Fatalf("groups = %+v, want a single unattributed bucket", sum.Groups)
+	}
+	if strings.Contains(sum.Groups[0].Escalation(), "re-authenticate that credential once") {
+		t.Error("a fabricated credential must never be escalated as a single dead token")
+	}
+}
+
+// A non-Claude session is unattributable rather than guessed into a Claude
+// credential's group.
+func TestNonClaudeToolIsUnattributed(t *testing.T) {
+	inst := heldInstance("codex-one", "work")
+	inst.Tool = "codex"
+	g := dirGrouper(map[string]string{"codex-one": "/home/u/.claude-work"}, allHeld("codex-one"))
+
+	sum := g.Group([]*session.Instance{inst})
+
+	if sum.Credentials != 0 || sum.Unattributed != 1 {
+		t.Fatalf("Credentials = %d, Unattributed = %d; want 0 and 1", sum.Credentials, sum.Unattributed)
+	}
+}
+
+// A nil instance must not panic or create a phantom credential.
+func TestNilInstanceIsSkipped(t *testing.T) {
+	g := dirGrouper(map[string]string{"alpha": "/home/u/.claude-work"}, allHeld("alpha"))
+	sum := g.Group([]*session.Instance{nil, heldInstance("alpha", "work"), nil})
+	if sum.Held != 1 || sum.Credentials != 1 {
+		t.Fatalf("Held = %d, Credentials = %d; want 1 and 1", sum.Held, sum.Credentials)
+	}
+}
+
+// Sessions that are not held are not reported at all: the grouping is about
+// currently-dead credentials, not history.
+func TestUnheldSessionsAreNotGrouped(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("alpha", "work"),
+		heldInstance("healthy", "work"),
+	}
+	g := dirGrouper(map[string]string{
+		"alpha":   "/home/u/.claude-work",
+		"healthy": "/home/u/.claude-work",
+	}, allHeld("alpha")) // only alpha is held
+
+	sum := g.Group(insts)
+
+	if sum.Held != 1 {
+		t.Fatalf("Held = %d, want 1", sum.Held)
+	}
+	if len(sum.Groups[0].Sessions) != 1 || sum.Groups[0].Sessions[0].Title != "alpha" {
+		t.Errorf("group members = %+v, want only alpha", sum.Groups[0].Sessions)
+	}
+}
+
+// Zero held sessions is a clean, non-alarming report — not an empty group.
+func TestNoHeldSessionsReportsNothingDead(t *testing.T) {
+	g := dirGrouper(map[string]string{"alpha": "/home/u/.claude-work"}, map[string]string{})
+	sum := g.Group([]*session.Instance{heldInstance("alpha", "work")})
+
+	if sum.Held != 0 || sum.Credentials != 0 || len(sum.Groups) != 0 {
+		t.Fatalf("summary = %+v, want an empty view", sum)
+	}
+	if len(sum.Escalations()) != 0 {
+		t.Errorf("escalations = %v, want none", sum.Escalations())
+	}
+	if !strings.Contains(sum.Format(), "no sessions are auth-held") {
+		t.Errorf("Format = %q, want the explicit all-clear", sum.Format())
+	}
+}
+
+// Ordering is deterministic and unknown always sorts last, so a reader who takes
+// the first line never lands on the "these may not be related" bucket.
+func TestGroupOrderIsDeterministicWithUnknownLast(t *testing.T) {
+	insts := []*session.Instance{
+		heldInstance("zulu", ""),
+		heldInstance("alpha", ""),
+		heldInstance("orphan", ""),
+	}
+	g := dirGrouper(map[string]string{
+		"zulu":   "/home/u/.claude-z",
+		"alpha":  "/home/u/.claude-a",
+		"orphan": "",
+	}, allHeld("zulu", "alpha", "orphan"))
+
+	for i := 0; i < 5; i++ {
+		sum := g.Group(insts)
+		if len(sum.Groups) != 3 {
+			t.Fatalf("got %d groups, want 3", len(sum.Groups))
+		}
+		if sum.Groups[0].Credential.ConfigDir != "/home/u/.claude-a" {
+			t.Errorf("first group = %s, want the lowest key", sum.Groups[0].Credential.ConfigDir)
+		}
+		if sum.Groups[2].Credential.Key != UnknownCredentialKey {
+			t.Errorf("last group = %s, want the unknown bucket", sum.Groups[2].Credential.Key)
+		}
+	}
+}
+
+// The hold reason travels with each session so a conductor can tell a live
+// banner from a session that already exited on one.
+func TestHoldReasonIsCarriedPerSession(t *testing.T) {
+	insts := []*session.Instance{heldInstance("alpha", "work"), heldInstance("bravo", "work")}
+	g := dirGrouper(
+		map[string]string{"alpha": "/home/u/.claude-work", "bravo": "/home/u/.claude-work"},
+		map[string]string{
+			"alpha": session.AuthHoldReasonLive,
+			"bravo": session.AuthHoldReasonDeath,
+		})
+
+	sum := g.Group(insts)
+
+	reasons := map[string]string{}
+	for _, s := range sum.Groups[0].Sessions {
+		reasons[s.Title] = s.Reason
+	}
+	if reasons["alpha"] != session.AuthHoldReasonLive || reasons["bravo"] != session.AuthHoldReasonDeath {
+		t.Errorf("reasons = %v, want the per-session hold reasons preserved", reasons)
+	}
+}
+
+// A trailing separator or an unclean path must not split one credential in two.
+func TestConfigDirIsCanonicalisedBeforeGrouping(t *testing.T) {
+	insts := []*session.Instance{heldInstance("alpha", "work"), heldInstance("bravo", "work")}
+	g := dirGrouper(map[string]string{
+		"alpha": "/home/u/.claude-work",
+		"bravo": "/home/u/./.claude-work/",
+	}, allHeld("alpha", "bravo"))
+
+	sum := g.Group(insts)
+
+	if sum.Credentials != 1 {
+		t.Fatalf("Credentials = %d, want 1 — the same directory written two ways is one credential", sum.Credentials)
+	}
+}
+
+// PRIVACY BOUNDARY: grouping is a read. It must not create or write anything,
+// and no output may carry token-shaped material.
+func TestGroupingWritesNothingAndLeaksNoTokenMaterial(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	before := snapshotTree(t, home)
+
+	insts := []*session.Instance{heldInstance("alpha", "work"), heldInstance("bravo", "work")}
+	g := dirGrouper(map[string]string{
+		"alpha": filepath.Join(home, ".claude-work"),
+		"bravo": filepath.Join(home, ".claude-work"),
+	}, allHeld("alpha", "bravo"))
+
+	sum := g.Group(insts)
+	rendered := sum.Format() + strings.Join(sum.Escalations(), "\n")
+
+	if after := snapshotTree(t, home); after != before {
+		t.Errorf("grouping wrote to the data dir:\nbefore=%v\nafter=%v", before, after)
+	}
+	for _, forbidden := range []string{"sk-ant", "Bearer ", "refresh_token", "access_token", "oauth"} {
+		if strings.Contains(strings.ToLower(rendered), strings.ToLower(forbidden)) {
+			t.Errorf("rendered output contains %q — credential material must never be emitted:\n%s", forbidden, rendered)
+		}
+	}
+}
+
+// snapshotTree lists every path under root, so a test can assert nothing was
+// created. TestMain's IsolateHome makes this a small, private tree.
+func snapshotTree(t *testing.T, root string) string {
+	t.Helper()
+	var paths []string
+	err := filepath.Walk(root, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable subtree is not what this test measures
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return strings.Join(paths, "\n")
+}

--- a/internal/fleet/authgate.go
+++ b/internal/fleet/authgate.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -57,7 +58,30 @@ type SubstateAuthGate struct {
 	// <=0 uses DefaultAuthHaltAfter.
 	HaltAfter int
 
+	// GroupByCredential opts this gate into credential-identity grouping
+	// (#1816): the halt message names WHICH credential is dead and reports one
+	// line per credential instead of one number for the whole sweep, and
+	// AuthFailuresByCredential becomes populated.
+	//
+	// OFF BY DEFAULT, and that is a product boundary, not an oversight (the
+	// maintainer ruling on #1816: local-only, opt-in, per-session view stays the
+	// default surface). With it false this gate behaves EXACTLY as it did
+	// before #1816, down to the byte-for-byte halt string above — a sweep that
+	// did not opt in must not have its operator message change under it.
+	GroupByCredential bool
+
+	// Grouper resolves credential identity when GroupByCredential is set. nil
+	// uses the real config-dir chain. Injectable for the same reason every side
+	// effect in this package is.
+	Grouper *AuthCredentialGrouper
+
 	seen int
+	// creds accumulates the credentials behind the auth-failed boots. Built
+	// only when GroupByCredential is set, so the default path allocates nothing.
+	creds *credAccumulator
+	// recovered names credentials whose LAST observation in this sweep
+	// authenticated successfully.
+	recovered map[string]bool
 }
 
 // Allow reports whether another boot may proceed.
@@ -66,21 +90,119 @@ func (g *SubstateAuthGate) Allow() (bool, string) {
 	if g.seen < limit {
 		return true, ""
 	}
+	if g.GroupByCredential {
+		return false, g.groupedHaltReason()
+	}
 	return false, fmt.Sprintf(
 		"auth circuit open: %d session(s) booted into an auth failure (substate %q) — recovering the rest would keep re-forking the shared credential; re-authenticate, then re-run",
 		g.seen, session.SubstateAuth401)
 }
 
+// groupedHaltReason is the #1816 halt message: one line per dead credential
+// rather than one count for the sweep.
+//
+// It falls back to the ungrouped wording when nothing was attributable, because
+// "0 credentials" would read as "no credential problem" — the exact opposite of
+// why the circuit just opened.
+func (g *SubstateAuthGate) groupedHaltReason() string {
+	sum := g.credentialSummary()
+	// Nothing was collected at all (the circuit opened without this gate ever
+	// resolving a credential). Fall back rather than print a grouped message
+	// with no groups in it.
+	if len(sum.Groups) == 0 {
+		return fmt.Sprintf(
+			"auth circuit open: %d session(s) booted into an auth failure (substate %q) — recovering the rest would keep re-forking the shared credential; re-authenticate, then re-run",
+			g.seen, session.SubstateAuth401)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "auth circuit open: %d credential(s) dead behind %d booted session(s) (substate %q) — recovering the rest would keep re-forking them; re-authenticate, then re-run",
+		sum.Credentials, g.seen, session.SubstateAuth401)
+	// GroupByCredential can be turned on after this gate has already observed
+	// boots (it is an exported field on an exported type). Those boots were
+	// never attributed, so the per-credential lines below account for fewer
+	// sessions than the headline count. Saying so is the whole difference
+	// between an incomplete report and a wrong one: silently listing 1 session
+	// under a headline of 3 reads as "the other 2 are fine".
+	if ungrouped := g.seen - sum.Held; ungrouped > 0 {
+		fmt.Fprintf(&b, " — NOTE: %d earlier boot(s) were observed before credential grouping was enabled and are not attributed below",
+			ungrouped)
+	}
+	for _, grp := range sum.Groups {
+		fmt.Fprintf(&b, "\n  - %s", grp.Escalation())
+	}
+	return b.String()
+}
+
 // Observe records one boot's verification result.
-func (g *SubstateAuthGate) Observe(_ *session.Instance, rep VerifyReport, _ error) {
-	if rep.Substate == string(session.SubstateAuth401) {
+func (g *SubstateAuthGate) Observe(inst *session.Instance, rep VerifyReport, _ error) {
+	authFailed := rep.Substate == string(session.SubstateAuth401)
+	if authFailed {
 		g.seen++
 	}
+	if !g.GroupByCredential {
+		return
+	}
+
+	// A boot that authenticated is evidence about a CREDENTIAL, not just about
+	// one session — it is how "the token was fixed mid-sweep" actually presents,
+	// and without it the halt would keep escalating a credential that has since
+	// proved it works. Not tracked at all when the grouping is off: the
+	// ungrouped gate has no notion of which credential anything ran under.
+	if !authFailed && !rep.Booted() {
+		return
+	}
+
+	key := g.grouper().Identify(inst).Key
+	if !authFailed {
+		if g.recovered == nil {
+			g.recovered = make(map[string]bool)
+		}
+		g.recovered[key] = true
+		return
+	}
+
+	// Last observation wins: a credential that booted cleanly and then 401'd is
+	// dead now, whatever it did earlier in the sweep.
+	delete(g.recovered, key)
+	if g.creds == nil {
+		g.creds = newCredAccumulator(g.grouper().Identify)
+	}
+	// The sidecar is not guaranteed to exist yet for a boot that just came up on
+	// the banner, so Reason is left empty rather than guessed: credential
+	// identity does not depend on the hold record.
+	g.creds.add(inst, HeldSession{
+		ID:      instanceID(inst),
+		Title:   instanceTitle(inst),
+		Account: instanceAccount(inst),
+	})
 }
 
 // AuthFailures returns how many auth-failed boots have been observed. Exposed
 // for the CLI summary.
 func (g *SubstateAuthGate) AuthFailures() int { return g.seen }
+
+// AuthFailuresByCredential returns the auth-failed boots grouped by which
+// credential they were running under (#1816).
+//
+// Empty unless GroupByCredential was set: the grouping is opt-in, so a caller
+// that did not ask for it gets nothing rather than a silently-collected view.
+func (g *SubstateAuthGate) AuthFailuresByCredential() AuthCredentialSummary {
+	return g.credentialSummary()
+}
+
+func (g *SubstateAuthGate) credentialSummary() AuthCredentialSummary {
+	if g.creds == nil {
+		return AuthCredentialSummary{}
+	}
+	return g.creds.summaryWithRecovered(g.recovered)
+}
+
+func (g *SubstateAuthGate) grouper() *AuthCredentialGrouper {
+	if g.Grouper != nil {
+		return g.Grouper
+	}
+	return NewAuthCredentialGrouper()
+}
 
 func (g *SubstateAuthGate) limit() int {
 	if g.HaltAfter <= 0 {

--- a/internal/fleet/authgate_cred_test.go
+++ b/internal/fleet/authgate_cred_test.go
@@ -263,3 +263,154 @@ func TestGroupedMessageFallsBackWhenNothingWasCollected(t *testing.T) {
 		t.Errorf("empty grouped gate should fall back to the ungrouped wording: %s", emptyReason)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// The shape the P2a/P2b/P2c tests still did not build: the host dimension
+// crossed with the SWEEP path, and with the recovered-mid-sweep map.
+//
+// P2a was reported and fixed against the query (AuthCredentialGrouper). The gate
+// resolves identity through the same Identify, so it inherits the fix — but the
+// gate is the higher-stakes surface (it is what HALTS a fleet recovery), and
+// "inherits it" was not proven anywhere. The crossing below is the one that
+// would actually hurt: g.recovered is keyed by credential key, so if local and
+// remote stores ever shared a key again, a LOCAL boot authenticating would
+// silently mark a REMOTE dead credential as recovered and drop it out of the
+// halt message. That is the original defect re-entering through a second door.
+// ---------------------------------------------------------------------------
+
+func sshGateInstance(title, account, sshHost string) *session.Instance {
+	inst := heldInstance(title, account)
+	inst.SSHHost = sshHost
+	return inst
+}
+
+// The sweep's halt message must separate a local store from a remote one on the
+// same path, and must not tell the operator a local re-auth covers both.
+func TestSweepHaltSeparatesLocalAndRemoteStores(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"local-one":  "/home/u/.claude-work",
+		"remote-one": "/home/u/.claude-work",
+	})
+
+	g.Observe(heldInstance("local-one", "work"), auth401Report(), nil)
+	g.Observe(sshGateInstance("remote-one", "work", "box-b"), auth401Report(), nil)
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Credentials != 2 {
+		t.Fatalf("Credentials = %d, want 2 — the sweep merged a local and a remote store", sum.Credentials)
+	}
+
+	_, reason := g.Allow()
+	if !strings.Contains(reason, "2 credential(s) dead") {
+		t.Errorf("halt should report 2 dead credentials: %s", reason)
+	}
+	if !strings.Contains(reason, "box-b") {
+		t.Errorf("halt must name the remote host: %s", reason)
+	}
+	if !strings.Contains(reason, "re-authenticating locally will NOT reach it") {
+		t.Errorf("halt must not imply a local re-auth fixes the remote store: %s", reason)
+	}
+}
+
+// THE CROSSING: a local credential recovering mid-sweep must NOT clear a remote
+// credential that happens to share the same config path. If it did, the fleet
+// recovery would resume against a still-dead remote token.
+func TestLocalRecoveryDoesNotClearRemoteDeadCredential(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"local-one":  "/home/u/.claude-work",
+		"local-two":  "/home/u/.claude-work",
+		"remote-one": "/home/u/.claude-work",
+	})
+
+	// Both stores fail...
+	g.Observe(heldInstance("local-one", "work"), auth401Report(), nil)
+	g.Observe(sshGateInstance("remote-one", "work", "box-b"), auth401Report(), nil)
+	// ...then the LOCAL one is repaired.
+	g.Observe(heldInstance("local-two", "work"), healthyReport(), nil)
+
+	sum := g.AuthFailuresByCredential()
+
+	if sum.Recovered != 1 {
+		t.Errorf("Recovered = %d, want 1 (the local store only)", sum.Recovered)
+	}
+	if sum.Credentials != 1 {
+		t.Fatalf("Credentials = %d, want 1 — the remote store is still dead", sum.Credentials)
+	}
+	// The surviving dead credential must be the REMOTE one.
+	var stillDead *CredentialGroup
+	for i := range sum.Groups {
+		if !sum.Groups[i].Recovered {
+			stillDead = &sum.Groups[i]
+		}
+	}
+	if stillDead == nil {
+		t.Fatal("a local recovery cleared every credential, including the remote one")
+	}
+	if !stillDead.Credential.IsRemote() || stillDead.Credential.Host != "box-b" {
+		t.Errorf("still-dead credential = %+v, want the box-b remote store", stillDead.Credential)
+	}
+}
+
+// And the mirror: a remote recovery must not clear the local store.
+func TestRemoteRecoveryDoesNotClearLocalDeadCredential(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"local-one":  "/home/u/.claude-work",
+		"remote-one": "/home/u/.claude-work",
+		"remote-two": "/home/u/.claude-work",
+	})
+
+	g.Observe(heldInstance("local-one", "work"), auth401Report(), nil)
+	g.Observe(sshGateInstance("remote-one", "work", "box-b"), auth401Report(), nil)
+	g.Observe(sshGateInstance("remote-two", "work", "box-b"), healthyReport(), nil)
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Recovered != 1 || sum.Credentials != 1 {
+		t.Fatalf("summary = %+v, want 1 recovered (remote) and 1 still dead (local)", sum)
+	}
+	for _, grp := range sum.Groups {
+		if !grp.Recovered && grp.Credential.IsRemote() {
+			t.Error("the remote store recovered but is still reported dead")
+		}
+		if grp.Recovered && !grp.Credential.IsRemote() {
+			t.Error("a remote recovery cleared the local store")
+		}
+	}
+}
+
+// An aliased Claude-compatible tool must aggregate in the SWEEP too, not only in
+// the query — otherwise the halt message under-counts a dead credential's blast
+// radius by silently dropping the aliased sessions.
+func TestSweepAggregatesClaudeCompatibleAlias(t *testing.T) {
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		t.Skipf("LoadUserConfig unavailable: %v", err)
+	}
+	if cfg.Tools == nil {
+		cfg.Tools = map[string]session.ToolDef{}
+	}
+	cfg.Tools["claude_wrapper"] = session.ToolDef{Command: "claude-wrapper", CompatibleWith: "claude"}
+	if err := session.SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	g := credGate(2, true, map[string]string{
+		"plain":   "/home/u/.claude-work",
+		"aliased": "/home/u/.claude-work",
+	})
+
+	aliased := heldInstance("aliased", "work")
+	aliased.Tool = "claude_wrapper"
+
+	g.Observe(heldInstance("plain", "work"), auth401Report(), nil)
+	g.Observe(aliased, auth401Report(), nil)
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Unattributed != 0 {
+		t.Fatalf("Unattributed = %d, want 0 — the sweep dropped the aliased session", sum.Unattributed)
+	}
+	if sum.Credentials != 1 || len(sum.Groups[0].Sessions) != 2 {
+		t.Fatalf("summary = %+v, want one credential holding both sessions", sum)
+	}
+}

--- a/internal/fleet/authgate_cred_test.go
+++ b/internal/fleet/authgate_cred_test.go
@@ -1,0 +1,265 @@
+package fleet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// SubstateAuthGate's #1816 credential grouping, and the default-unchanged
+// guarantee that the maintainer ruling depends on.
+
+// ungroupedHaltMessage is the EXACT halt string this gate produced before
+// #1816. It is duplicated here on purpose: the guarantee under test is that the
+// default path's bytes did not move, and a test that built the expectation from
+// the same code it is checking could not detect that they had.
+const ungroupedHaltMessage = `auth circuit open: 2 session(s) booted into an auth failure (substate "auth-401") — recovering the rest would keep re-forking the shared credential; re-authenticate, then re-run`
+
+// credGate returns a gate whose credential identity is a fixed per-title lookup.
+func credGate(halt int, group bool, dirs map[string]string) *SubstateAuthGate {
+	return &SubstateAuthGate{
+		HaltAfter:         halt,
+		GroupByCredential: group,
+		Grouper: &AuthCredentialGrouper{
+			ConfigDir: func(inst *session.Instance) string {
+				if inst == nil {
+					return ""
+				}
+				return dirs[inst.Title]
+			},
+		},
+	}
+}
+
+func auth401Report() VerifyReport {
+	return VerifyReport{PaneAlive: true, ToolStarted: true, Substate: string(session.SubstateAuth401)}
+}
+
+func healthyReport() VerifyReport {
+	return VerifyReport{PaneAlive: true, ToolStarted: true, Status: string(session.StatusRunning)}
+}
+
+// DEFAULT UNCHANGED: with the flag off the halt message is byte-identical to the
+// pre-#1816 string, and nothing is collected.
+func TestFlagOffLeavesHaltMessageByteIdentical(t *testing.T) {
+	g := credGate(2, false, map[string]string{
+		"alpha": "/home/u/.claude-work",
+		"bravo": "/home/u/.claude-work",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	g.Observe(heldInstance("bravo", "work"), auth401Report(), nil)
+
+	ok, reason := g.Allow()
+	if ok {
+		t.Fatal("circuit should be open after 2 auth failures")
+	}
+	if reason != ungroupedHaltMessage {
+		t.Errorf("default halt message changed.\n got: %q\nwant: %q", reason, ungroupedHaltMessage)
+	}
+	if sum := g.AuthFailuresByCredential(); sum.Held != 0 || len(sum.Groups) != 0 {
+		t.Errorf("grouping collected %+v with the flag off; opt-in means opt-in", sum)
+	}
+	if g.AuthFailures() != 2 {
+		t.Errorf("AuthFailures = %d, want 2 — the existing counter must be untouched", g.AuthFailures())
+	}
+}
+
+// OPT-IN: with the flag on, one dead credential behind N boots is ONE
+// escalation naming that credential.
+func TestFlagOnHaltNamesTheDeadCredentialOnce(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"alpha": "/home/u/.claude-work",
+		"bravo": "/home/u/.claude-work",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	g.Observe(heldInstance("bravo", "work"), auth401Report(), nil)
+
+	ok, reason := g.Allow()
+	if ok {
+		t.Fatal("circuit should be open")
+	}
+	if !strings.Contains(reason, "1 credential(s) dead behind 2 booted session(s)") {
+		t.Errorf("halt message does not aggregate by credential: %s", reason)
+	}
+	if !strings.Contains(reason, "work") {
+		t.Errorf("halt message does not name the credential: %s", reason)
+	}
+	if got := strings.Count(reason, "auth-401: "); got != 1 {
+		t.Errorf("got %d per-credential escalations, want exactly 1:\n%s", got, reason)
+	}
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Credentials != 1 || sum.Held != 2 {
+		t.Errorf("summary = %+v, want 1 credential holding 2 sessions", sum)
+	}
+}
+
+// Two credentials failing in the same sweep stay two escalations.
+func TestTwoCredentialsInOneSweepStayTwoEscalations(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"alpha": "/home/u/.claude-work",
+		"bravo": "/home/u/.claude-personal",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	g.Observe(heldInstance("bravo", "personal"), auth401Report(), nil)
+
+	_, reason := g.Allow()
+	if !strings.Contains(reason, "2 credential(s) dead") {
+		t.Errorf("halt message should report 2 dead credentials: %s", reason)
+	}
+	if got := strings.Count(reason, "auth-401: "); got != 2 {
+		t.Errorf("got %d escalations, want 2:\n%s", got, reason)
+	}
+}
+
+// A CREDENTIAL THAT RECOVERS MID-SWEEP must stop being escalated as dead. The
+// operator acting on a stale "re-authenticate account work" would be chasing a
+// credential that already works.
+func TestCredentialRecoveringMidSweepIsNotEscalatedAsDead(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"alpha":   "/home/u/.claude-work",
+		"bravo":   "/home/u/.claude-work",
+		"charlie": "/home/u/.claude-personal",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	// The token is repaired: a later boot on the SAME credential authenticates.
+	g.Observe(heldInstance("bravo", "work"), healthyReport(), nil)
+	g.Observe(heldInstance("charlie", "personal"), auth401Report(), nil)
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Credentials != 1 {
+		t.Fatalf("Credentials = %d, want 1 — the work credential recovered", sum.Credentials)
+	}
+	if sum.Recovered != 1 {
+		t.Errorf("Recovered = %d, want 1", sum.Recovered)
+	}
+
+	_, reason := g.Allow()
+	if !strings.Contains(reason, "1 credential(s) dead") {
+		t.Errorf("halt should count only the still-dead credential: %s", reason)
+	}
+	// The recovered credential is still reported, but as retryable — never as
+	// something to re-authenticate.
+	if !strings.Contains(reason, "it is NOT dead; retry those sessions") {
+		t.Errorf("recovered credential should be reported as retryable: %s", reason)
+	}
+}
+
+// Last observation wins: a credential that authenticates and THEN 401s is dead
+// now, whatever it did earlier.
+func TestCredentialThatFailsAfterRecoveringIsDeadAgain(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"alpha": "/home/u/.claude-work",
+		"bravo": "/home/u/.claude-work",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), healthyReport(), nil)
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	g.Observe(heldInstance("bravo", "work"), auth401Report(), nil)
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Credentials != 1 || sum.Recovered != 0 {
+		t.Fatalf("summary = %+v, want the credential counted dead again", sum)
+	}
+}
+
+// THE FLAG TOGGLED WHILE BOOTS ARE ALREADY OBSERVED: the grouped lines then
+// account for fewer sessions than the headline. The message has to say so —
+// listing 1 session under a headline of 3 would read as "the other 2 are fine".
+func TestGroupingEnabledMidSweepDeclaresTheUnattributedBoots(t *testing.T) {
+	g := credGate(3, false, map[string]string{
+		"alpha":   "/home/u/.claude-work",
+		"bravo":   "/home/u/.claude-work",
+		"charlie": "/home/u/.claude-work",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	g.Observe(heldInstance("bravo", "work"), auth401Report(), nil)
+	// Operator flips the opt-in on partway through.
+	g.GroupByCredential = true
+	g.Observe(heldInstance("charlie", "work"), auth401Report(), nil)
+
+	ok, reason := g.Allow()
+	if ok {
+		t.Fatal("circuit should be open after 3 auth failures")
+	}
+	if !strings.Contains(reason, "behind 3 booted session(s)") {
+		t.Errorf("headline lost the boots observed before the flag: %s", reason)
+	}
+	if !strings.Contains(reason, "2 earlier boot(s) were observed before credential grouping was enabled") {
+		t.Errorf("message must declare the boots it could not attribute: %s", reason)
+	}
+	if !strings.Contains(reason, "1 session(s) held") {
+		t.Errorf("expected the one attributed session to be listed: %s", reason)
+	}
+}
+
+// Non-auth boots never open the circuit, and never invent a credential group.
+func TestHealthyBootsAloneNeverOpenTheCircuit(t *testing.T) {
+	g := credGate(2, true, map[string]string{"alpha": "/home/u/.claude-work"})
+
+	for i := 0; i < 5; i++ {
+		g.Observe(heldInstance("alpha", "work"), healthyReport(), nil)
+	}
+
+	if ok, _ := g.Allow(); !ok {
+		t.Fatal("healthy boots must not open the auth circuit")
+	}
+	if sum := g.AuthFailuresByCredential(); len(sum.Groups) != 0 {
+		t.Errorf("healthy boots created groups: %+v", sum.Groups)
+	}
+}
+
+// An unattributable boot in the sweep gets the unknown bucket rather than being
+// counted as one of the dead credentials.
+func TestUnattributableBootDoesNotCountAsADeadCredential(t *testing.T) {
+	g := credGate(2, true, map[string]string{
+		"alpha":  "/home/u/.claude-work",
+		"orphan": "",
+	})
+
+	g.Observe(heldInstance("alpha", "work"), auth401Report(), nil)
+	g.Observe(heldInstance("orphan", ""), auth401Report(), nil)
+
+	sum := g.AuthFailuresByCredential()
+	if sum.Credentials != 1 {
+		t.Errorf("Credentials = %d, want 1 — unknown is not a credential", sum.Credentials)
+	}
+	if sum.Unattributed != 1 {
+		t.Errorf("Unattributed = %d, want 1", sum.Unattributed)
+	}
+
+	_, reason := g.Allow()
+	if !strings.Contains(reason, "NOT known to share one credential") {
+		t.Errorf("the unknown bucket must be reported honestly: %s", reason)
+	}
+}
+
+// With the flag on but nothing attributable at all, the message falls back to
+// the ungrouped wording rather than announcing "0 credentials" — which would
+// read as "no credential problem" at the exact moment the circuit opened.
+func TestGroupedMessageFallsBackWhenNothingWasCollected(t *testing.T) {
+	g := credGate(2, true, nil)
+	// Substate that is not auth-401: seen never increments via grouping.
+	g.Observe(heldInstance("alpha", "work"), VerifyReport{Substate: string(session.SubstateAuth401)}, nil)
+	g.Observe(heldInstance("bravo", "work"), VerifyReport{Substate: string(session.SubstateAuth401)}, nil)
+
+	_, reason := g.Allow()
+	// Both boots WERE grouped (into unknown), so this must be the grouped form.
+	if !strings.Contains(reason, "auth-401: 2 session(s) held on an unattributable credential") {
+		t.Errorf("expected the unknown bucket to be reported: %s", reason)
+	}
+
+	// A gate that collected nothing at all falls back.
+	empty := credGate(1, true, nil)
+	empty.seen = 5
+	_, emptyReason := empty.Allow()
+	if !strings.Contains(emptyReason, "5 session(s) booted into an auth failure") {
+		t.Errorf("empty grouped gate should fall back to the ungrouped wording: %s", emptyReason)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Closes #1816.

When one OAuth credential dies with a 401, every session under it dies too, and each is escalated as an independent failure. A conductor watching a fleet gets N per-session `auth-401` substates instead of one "this credential is dead" signal it can act on.

This is narrower than "nothing groups sessions". `SubstateAuthGate` (`internal/fleet/authgate.go`) already aggregated auth-401 across a recovery sweep — but only by **count**, and only **inside that sweep**. Nothing grouped by *which* credential is dead, and nothing exposed that grouping outside the sweep.

## Why this change

Extended `authgate.go` in place rather than building a parallel aggregator alongside it. The sweep-scoped tally and the new outside-the-sweep query both build their groups through one shared accumulator (`credAccumulator`), so there is exactly one definition of "one credential" and the two surfaces cannot drift.

**The grouping key is the resolved Claude config directory** — an identifier, never token material. No token, refresh token, credential file content, or hash of any of them is read, compared, logged, or persisted. Grouping is computed in memory per invocation and thrown away.

Keying on the directory rather than on `Instance.Account` is what makes both awkward shapes come out right, and both are real:

- **The same account name under two config dirs is two credentials.** An account slot with no `[profiles.<account>.claude].config_dir` block falls *through* to the conductor/group/env levels (see `resolveClaudeConfigDir`), so two sessions both naming account `work` in different groups can be running two different tokens. Keying on the name would merge them and promise that one re-login fixes both. It would not.
- **Two account names over one config dir is one credential.** Distinct slots pointing at the same directory share one token file, so one re-login really does fix everything behind them.

Account names are kept for **display** (that is what the operator types to fix it), never as the identity.

**Unknown is its own bucket, never a default one.** Three attribution failures are reachable: a nil instance, a non-Claude tool, and a config dir that does not resolve to an absolute path. The last one is the dangerous one — an unresolvable `HOME` degrades the chain's last resort to a bare relative `.claude` for *every* session at once, so allowing that as a key would silently merge a whole fleet into one fabricated credential and confidently report one dead token for what might be twelve. The unknown bucket's escalation says out loud that its sessions are **NOT** known to share a credential, so it can never be read as "one re-login fixes these".

**A credential that recovers mid-sweep stops being escalated as dead.** Last observation wins, so the report never tells an operator to re-authenticate something that just proved it works.

## User impact

**Nothing changes by default.** Per the maintainer ruling on the issue thread — local-only, off by default behind an opt-in flag, per-session view stays the default surface.

New opt-in flag `--group-by-credential` on `agent-deck fleet status` and `agent-deck fleet recover`. With it off:

- `SubstateAuthGate.Allow()`'s halt message is **byte-identical** to the pre-#1816 string (asserted against a literal copy of the old text, not against the code under test).
- The `fleet status --json` payload gains **no keys**.
- The per-session `auth_hold` remedy is unchanged.

With it on, `fleet status --group-by-credential [--json]` answers the question the issue asked for — "how many distinct dead credentials are behind these N held sessions" — without a conductor re-deriving it from N substates.

## Evidence

Reproduced in a sandboxed `HOME` with **no real credentials** and no token material anywhere: four sessions attributed to one account slot whose `config_dir` is configured in a temp `config.toml`, each driven into the auth-401 hold through its durable on-disk contract (the sidecar #1743 writes — the same record the live detector produces when a pane renders a 401 banner). All four verified to resolve to one credential directory before the capture.

### BEFORE — 4 sessions, 1 dead credential, 4 separate escalations

`cmd/agent-deck/issue1816_repro_before_test.go`, run on the **pre-fix tip** (uses only pre-#1816 symbols):

```
=== RUN   TestIssue1816_Before_OneDeadCredentialProducesNSeparateEscalations
    BEFORE — 4 sessions on ONE credential (/tmp/.../001/.claude-work) produce 4 separate escalations:
      [1/4] worker-1: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
      [2/4] worker-2: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
      [3/4] worker-3: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
      [4/4] worker-4: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
--- PASS: TestIssue1816_Before_OneDeadCredentialProducesNSeparateEscalations (0.00s)
```

Four escalations, and **not one of them names the credential they share** — so a conductor cannot collapse them itself. That is the defect.

### AFTER — the same scenario, one escalation naming the dead credential

```
=== RUN   TestIssue1816_After_OneDeadCredentialProducesOneEscalation
    AFTER (--group-by-credential) — 4 sessions on ONE credential produce 1 escalation:
      auth-401: 4 session(s) held on account work (/tmp/.../001/.claude-work) — re-authenticate that credential once and every one of them can recover (worker-1, worker-2, worker-3, worker-4)
    rendered report:
        Auth credentials: 4 held session(s) behind 1 dead credential(s)
          - auth-401: 4 session(s) held on account work (/tmp/.../001/.claude-work) — re-authenticate that credential once and every one of them can recover (worker-1, worker-2, worker-3, worker-4)
--- PASS: TestIssue1816_After_OneDeadCredentialProducesOneEscalation (0.00s)
```

### AFTER with the flag OFF — per-session view unchanged

```
=== RUN   TestIssue1816_After_PerSessionViewUnchangedWithFlagOff
    AFTER (flag off) — the per-session view is unchanged: 4 escalations
      [1/4] worker-1: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
      [2/4] worker-2: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
      [3/4] worker-3: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
      [4/4] worker-4: the agent exited because it could not authenticate — automatic restarts are held because they cannot fix a credential and each one races the shared token. Run /login (or repair the credentials), then press R to restart.
--- PASS: TestIssue1816_After_PerSessionViewUnchangedWithFlagOff (0.00s)
```

Byte-for-byte the pre-#1816 remedy, four of them, and the default `fleet status --json` payload asserted not to contain `auth_credentials`.

### Proof the flag defaults to off

`TestGroupByCredentialFlagDefaultsToOff` asserts, on **both** `fleet status` and `fleet recover`: the bool initialises false, `flag.Flag.DefValue == "false"`, and parsing an empty argv leaves it false. `TestRecoverConfigForwardsGroupByCredential/off_by_default` asserts the gate's `GroupByCredential` is false unless the flag is passed. `TestFlagOffLeavesHaltMessageByteIdentical` compares the halt string to a literal copy of the pre-#1816 text (duplicated in the test on purpose — building the expectation from the code under test could not detect that the bytes moved).

### Opt-in `--json` payload

```json
{
  "credentials": 1,
  "held": 4,
  "recovered": 0,
  "unattributed": 0,
  "groups": [
    {
      "accounts": ["work"],
      "attributed": true,
      "config_dir": "/tmp/.../001/.claude-work",
      "escalation": "auth-401: 4 session(s) held on account work (...) — re-authenticate that credential once and every one of them can recover (worker-1, worker-2, worker-3, worker-4)",
      "held": 4,
      "key": "dir:/tmp/.../001/.claude-work",
      "recovered": false,
      "sessions": [
        {"account": "work", "id": "id-worker-1", "reason": "auth_death", "title": "worker-1"},
        {"account": "work", "id": "id-worker-2", "reason": "auth_death", "title": "worker-2"},
        {"account": "work", "id": "id-worker-3", "reason": "auth_death", "title": "worker-3"},
        {"account": "work", "id": "id-worker-4", "reason": "auth_death", "title": "worker-4"}
      ]
    }
  ]
}
```

### Which failure shape does the suite never build?

Asked deliberately, against the shapes one notch outside the happy path. Covered:

| Shape | Test |
|---|---|
| Two credentials dying at once | `TestTwoCredentialsDyingAtOnceStayTwoEscalations`, `TestTwoCredentialsInOneSweepStayTwoEscalations` |
| Same account name, two config dirs | `TestSameAccountNameUnderTwoConfigDirsIsTwoCredentials` |
| Two account names, one config dir | `TestTwoAccountNamesOverOneConfigDirIsOneCredential` |
| Session whose credential cannot be attributed | `TestUnattributableSessionGetsItsOwnBucket`, `TestNonClaudeToolIsUnattributed`, `TestNilInstanceIsSkipped`, `TestUnattributableBootDoesNotCountAsADeadCredential` |
| Unresolvable HOME merging a whole fleet into a fabricated credential | `TestRelativeConfigDirNeverBecomesAGroupKey` |
| Credential that recovers mid-sweep | `TestCredentialRecoveringMidSweepIsNotEscalatedAsDead` |
| Credential that recovers and then fails again | `TestCredentialThatFailsAfterRecoveringIsDeadAgain` |
| Flag toggled while sessions are already held | `TestGroupingEnabledMidSweepDeclaresTheUnattributedBoots` |
| Grouping flag re-enabling a disabled safety brake | `TestRecoverConfigForwardsGroupByCredential/does_not_re-enable_a_disabled_breaker` |
| Grouping writing to disk / leaking token-shaped material | `TestGroupingWritesNothingAndLeaksNoTokenMaterial`, `TestIssue1816_After_JSONExposesTheCredentialGrouping` |
| Unclean/trailing-slash path splitting one credential | `TestConfigDirIsCanonicalisedBeforeGrouping` |
| Non-deterministic group order / unknown surfacing first | `TestGroupOrderIsDeterministicWithUnknownLast` |

The one worth calling out because it is easy to get backwards: **flag toggled mid-sweep**. `GroupByCredential` is an exported field, so it can be set after boots were already observed. Those boots were never attributed, so the per-credential lines account for fewer sessions than the headline count. The message now declares that gap explicitly — listing 1 session under a headline of 3 would read as "the other 2 are fine".

### Commands run (sandboxed, targeted, `-p 1`)

```
gofmt -l internal/fleet/ cmd/agent-deck/                      # clean
go vet ./internal/fleet/ ./cmd/agent-deck/                    # clean
golangci-lint run internal/fleet/... cmd/agent-deck/...       # 0 issues
HOME=$(mktemp -d) XDG_*= go test ./internal/fleet/ -count=1 -p 1                    # ok
HOME=$(mktemp -d) XDG_*= go test ./cmd/agent-deck/ -run '^TestIssue1816_' ...       # ok
HOME=$(mktemp -d) XDG_*= go test ./cmd/agent-deck/ -run '^TestF(leet|ormatFleet)'   # ok (no regression)
```

No test in this change spawns tmux; `tmux ls` on the default socket was confirmed unchanged after every run.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

From the dispatch brief: *"When one OAuth credential dies with a 401, every session under it dies too, and each is escalated as an independent failure. A conductor watching a fleet gets N per-session `auth-401` substates instead of one 'this credential is dead' signal it can act on."*

The instruction was explicit about not rebuilding what exists — #1743 landed the per-session half and `authgate.go` already does sweep-scoped aggregation — and about two judgement calls: group by an account or credential **identifier**, never by token material; and an unattributable credential gets its own bucket rather than being folded into another, because *unknown is not empty* is the same rule whose violation produced three separate defects on this repo this week.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `go test ./...` — **deliberately not run.** Unfiltered multi-package runs are prohibited on this machine (they have taken it down three times). Targeted `-run`-filtered, `-p 1` runs listed above; the PR gate runs the full suite.
- [x] If this touches a hot path: n/a — the grouping runs only under the opt-in flag, on `fleet status`/`fleet recover`, neither of which is a hot path. The default path allocates nothing new.
- [x] CHANGELOG.md untouched
- [x] AI-assisted? Disclosed above, with validation evidence
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--group-by-credential` option for fleet status and recovery.
  * Groups authentication-held sessions by credential, reducing duplicate escalations.
  * Added human-readable and JSON summaries with credential counts and configuration paths.
  * Tracks credentials that recover during a sweep and keeps secrets out of output.
* **Bug Fixes**
  * Preserved existing per-session behavior and JSON output when grouping is disabled.
  * Maintained disabled authentication-breaker settings during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->