### PR TITLE
fix(web): keep line breaks when pasting into the web terminal

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -162,7 +162,7 @@ func TestServiceWorkerServed(t *testing.T) {
 	if !strings.Contains(rr.Body.String(), "CACHE_VERSION") {
 		t.Fatalf("expected service worker payload, got: %s", rr.Body.String())
 	}
-	if !strings.Contains(rr.Body.String(), `agentdeck-shell-v7`) {
+	if !strings.Contains(rr.Body.String(), `agentdeck-shell-v8`) {
 		t.Fatalf("expected bumped service worker cache version, got: %s", rr.Body.String())
 	}
 }

--- a/internal/web/static/app/TerminalPanel.js
+++ b/internal/web/static/app/TerminalPanel.js
@@ -9,6 +9,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { EmptyStateDashboard } from './EmptyStateDashboard.js'
 import { terminalKeymap } from './terminalKeys.js'
+import { createPasteHandler } from './terminalPaste.js'
 import { createTerminalLinkHandler } from './terminalLinks.js'
 
 // Mobile detection: pointer:coarse for touch devices
@@ -284,22 +285,15 @@ export function TerminalPanel() {
 
     // WSL2+Chrome paste fix: xterm.js 6.0's default paste path can fail and
     // destroy the system clipboard when focus is not on .xterm-helper-textarea.
-    // Capture the paste on the container first, read clipboardData directly,
-    // and forward through the same path as terminal.onData.
+    // Capture the paste on the container first and read clipboardData directly,
+    // then hand the text to terminal.paste() so xterm still owns the ENCODING
+    // (CR line breaks + bracketed-paste markers) and the bytes reach sendInput
+    // through onData like any other input. See createPasteHandler.
     if (!mobile) {
-      container.addEventListener('paste', (event) => {
-        if (readOnlySignal.value) return
-        if (!ctx.ws || ctx.ws.readyState !== WebSocket.OPEN || !ctx.terminalAttached) return
-        const cd = event.clipboardData
-        if (!cd) return
-        let text = cd.getData('text/plain')
-        if (!text) return
-        // Normalize CRLF/CR to LF; shells expect LF, bare CR re-runs input.
-        text = text.replace(/\r\n?/g, '\n')
-        event.preventDefault()
-        event.stopPropagation()
-        sendInput(text)
-      }, { capture: true, signal: controller.signal })
+      container.addEventListener('paste', createPasteHandler(terminal), {
+        capture: true,
+        signal: controller.signal,
+      })
     }
 
     terminal.writeln('Connecting to terminal...')

--- a/internal/web/static/app/terminalPaste.js
+++ b/internal/web/static/app/terminalPaste.js
@@ -1,0 +1,37 @@
+// terminalPaste.js -- clipboard bridge for the web terminal.
+//
+// xterm 6.0's own paste path can fail and destroy the system clipboard on
+// WSL2+Chrome when focus is not on .xterm-helper-textarea, so TerminalPanel
+// captures the paste event first and reads clipboardData itself. What it must
+// NOT do is take over the ENCODING as well: the text goes back to
+// terminal.paste(), which is xterm's public paste entry point.
+//
+// That encoding is the whole fix. terminal.paste() rewrites line breaks to CR
+// and -- when the pane's app has enabled DECSET 2004 -- wraps the payload in
+// the bracketed-paste markers ESC[200~ ... ESC[201~. Those markers are what
+// tell an agent TUI "this is a paste, insert the newlines" instead of "these
+// are keystrokes". Writing the raw clipboard text to the pane instead made
+// Claude Code drop every line break, landing a multi-line paste as one run-on
+// line, while the same paste through a native terminal kept its lines. (tmux
+// is bracketed-paste aware in both directions: it forwards the markers to
+// panes whose app enabled 2004 and strips them for panes that did not, so a
+// bare shell prompt still behaves.)
+//
+// Routing through terminal.paste() also puts paste back on the pane's single
+// guarded write path -- it emits through onData, the same as typing, so
+// TerminalPanel's sendInput() applies the read-only/socket checks once for
+// every producer. No xterm import here: the terminal is passed in, which keeps
+// this module unit-testable on its own.
+
+// createPasteHandler returns a `paste` event listener for the terminal
+// container. It is installed in the capture phase, so stopping the event also
+// stops xterm's own listener from pasting the same text a second time.
+export function createPasteHandler(terminal) {
+  return (event) => {
+    const text = event.clipboardData?.getData('text/plain')
+    if (!text) return
+    event.preventDefault()
+    event.stopPropagation()
+    terminal.paste(text)
+  }
+}

--- a/internal/web/static/sw.js
+++ b/internal/web/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "agentdeck-shell-v7"
+const CACHE_VERSION = "agentdeck-shell-v8"
 const SHELL_CACHE = CACHE_VERSION
 const APP_SHELL_URLS = [
   "/",

--- a/tests/web/unit/terminalPaste.test.js
+++ b/tests/web/unit/terminalPaste.test.js
@@ -1,0 +1,102 @@
+// unit/terminalPaste.test.js -- the web terminal's clipboard bridge.
+//
+// TerminalPanel captures the paste event itself (xterm 6.0's own paste path can
+// fail and destroy the system clipboard on WSL2+Chrome when focus is not on
+// .xterm-helper-textarea), which means it must hand the text back to
+// terminal.paste() rather than write it to the pane directly. xterm's paste
+// path is what applies the encoding a native terminal uses -- CR line breaks,
+// wrapped in the DECSET 2004 bracketed-paste markers when the pane's app
+// enabled them -- and only that encoding tells an agent TUI "this is a paste,
+// insert the newlines". Forwarding the raw clipboard text made Claude Code
+// swallow every line break and land a multi-line paste as one run-on line.
+
+import { describe, it, expect, vi } from 'vitest'
+
+const modulePath = '../../../internal/web/static/app/terminalPaste.js'
+
+const handlerFor = async (terminal) => {
+  const { createPasteHandler } = await import(modulePath)
+  return createPasteHandler(terminal)
+}
+
+// jsdom implements neither ClipboardEvent nor DataTransfer, and the handler
+// only ever reads clipboardData.getData('text/plain').
+function pasteEvent(clipboardData) {
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: clipboardData })
+  vi.spyOn(event, 'stopPropagation')
+  return event
+}
+
+const clipboard = (text) => ({ getData: vi.fn(() => text) })
+const fakeTerminal = () => ({ paste: vi.fn() })
+
+describe('createPasteHandler', () => {
+  it('hands multi-line clipboard text to terminal.paste', async () => {
+    const terminal = fakeTerminal()
+    const handler = await handlerFor(terminal)
+
+    handler(pasteEvent(clipboard('This is a test:\n - abc\n - def')))
+
+    expect(terminal.paste).toHaveBeenCalledTimes(1)
+    expect(terminal.paste).toHaveBeenCalledWith('This is a test:\n - abc\n - def')
+  })
+
+  // The bug this file exists for: the old handler rewrote line breaks itself
+  // and wrote the result straight to the pane, so the bytes never picked up the
+  // bracketed-paste markers. Line-break encoding belongs to xterm -- the text
+  // must arrive verbatim.
+  it('passes CRLF through untouched instead of normalizing it', async () => {
+    const terminal = fakeTerminal()
+    const handler = await handlerFor(terminal)
+
+    handler(pasteEvent(clipboard('a\r\nb')))
+
+    expect(terminal.paste).toHaveBeenCalledWith('a\r\nb')
+  })
+
+  it('reads the text/plain flavour of the clipboard', async () => {
+    const terminal = fakeTerminal()
+    const handler = await handlerFor(terminal)
+    const cd = clipboard('hi')
+
+    handler(pasteEvent(cd))
+
+    expect(cd.getData).toHaveBeenCalledWith('text/plain')
+  })
+
+  it('suppresses xterm\'s own paste path so the text is not sent twice', async () => {
+    const terminal = fakeTerminal()
+    const handler = await handlerFor(terminal)
+    const event = pasteEvent(clipboard('hi'))
+
+    handler(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(event.stopPropagation).toHaveBeenCalled()
+  })
+
+  describe('nothing to paste', () => {
+    it('ignores an event with no clipboardData', async () => {
+      const terminal = fakeTerminal()
+      const handler = await handlerFor(terminal)
+      const event = pasteEvent(null)
+
+      handler(event)
+
+      expect(terminal.paste).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('ignores an empty clipboard', async () => {
+      const terminal = fakeTerminal()
+      const handler = await handlerFor(terminal)
+      const event = pasteEvent(clipboard(''))
+
+      handler(event)
+
+      expect(terminal.paste).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## What problem does this solve?

Pasting multi-line text into a session through the **web UI** silently loses
every line break. Copying

    This is a test:
     - abc
     - def

and pasting it at a Claude Code prompt in the web terminal lands it as one
run-on line: `This is a test: - abc - def`. Pasting the exact same clipboard
into the exact same session from a native terminal (`agent-deck attach`) keeps
the three lines, so the loss is in the web input path, not the agent.

## Why this change

`TerminalPanel.js` captures the paste event itself and forwards the clipboard
text over the WebSocket. That interceptor exists on purpose — #651 added it
because xterm.js 6.0's own paste path relies on focus routing through the
hidden `.xterm-helper-textarea`, which on WSL2+Chrome delivered nothing and
destroyed the system clipboard.

The bug is that taking over the paste *event* also took over the paste
*encoding*, and only the event handling was broken. xterm's encoder does two
things the raw forward skipped: it rewrites line breaks to CR, and — when the
pane's app has enabled DECSET 2004 — wraps the payload in the bracketed-paste
markers `ESC[200~ … ESC[201~`. Those markers are what tell an agent TUI "this
is a paste, insert the newlines" rather than "these are keystrokes". Without
them Claude Code drops every LF.

So this keeps bypassing xterm's paste *event handling* (the part that is broken
on WSL2+Chrome: the capture-phase listener, the direct `clipboardData` read and
the `preventDefault`/`stopPropagation` are all unchanged) and hands the text
back to `terminal.paste()` for the *encoding*. `terminal.paste()` never touches
the focus/textarea read path that #651 worked around; it is string
normalization plus an `onData` emit.

Two consequences worth calling out:

- Paste is now a normal `onData` producer, so `sendInput()`'s read-only /
  socket-open / terminal-attached checks apply to it like every other input.
  #651 duplicated those checks inline specifically to "mirror `terminal.onData`
  exactly"; routing through `onData` achieves that directly, so the duplicates
  are gone. Read-only is still guarded three ways (`sendInput`, xterm's own
  `disableStdin`, and the server rejecting `input` when `ReadOnly`).
- I did not reimplement the encoding locally. A hand-rolled version was the
  first thing I tried and it produced byte-identical output, but it is vendor
  logic that would silently drift on the next xterm bump.

Mobile was never affected — the interceptor is desktop-only, so mobile already
went through xterm's own (correct) paste path. This aligns desktop with it.

## User impact

Multi-line pastes into the web terminal keep their line breaks, matching what a
native terminal already did. Desktop web UI only; no change to mobile, to the
native TUI, or to typing. As a side effect the viewport now scrolls to the
prompt on paste (xterm's `scrollOnUserInput`), which the raw forward skipped.

## Evidence

Same tmux session, same live Claude Code pane, same clipboard text — only the
bytes written to the pane's PTY differ. Driven by writing to a `tmux attach`
PTY master, which is exactly what `tmuxPTYBridge.WriteInput` does. (Trailing
`Q` is the harness's stop sentinel.)

Before — raw LF, no markers (what the web UI sent):

    ❯ This is a test: - abc - defQ

After — the bytes this branch puts on the wire:

    ❯ This is a test:
       - abc
       - defQ

The "after" payload was not hand-written: it was captured out of the shipped
code path. A real `xterm.Terminal` with DECSET 2004 enabled, the real
`createPasteHandler` from this branch installed on its container, and a real
`paste` event dispatched, emitted exactly

    "[200~This is a test:\r - abc\r - def[201~"

on `onData`, and replaying those bytes into the live pane produced the "after"
capture above.

Layer isolation, so the fix is at the right level: the Go bridge writes the
bytes untouched, and tmux is bracketed-paste aware in both directions — with a
byte-dumper as the pane it forwarded `ESC[200~…ESC[201~` intact to a pane whose
app had enabled 2004, and stripped the markers for a pane that had not (so a
bare shell prompt still behaves). Neither layer altered the payload; only the
frontend encoding was wrong.

Suites:

- `cd tests/web && npm run test:unit` → 137 passed (11 files), including 6 new
  tests in `unit/terminalPaste.test.js`.
- `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
  → ok. `gofmt -l ./cmd ./internal` clean, `go vet ./...` clean.

Revert-check: the new unit tests import `terminalPaste.js`, which does not
exist on base, so they fail to resolve there rather than fail an assertion —
the "new symbols" case. The behavioral proof is the before/after capture above,
which is a live agent pane, not a mock.

Not tested by me: WSL2+Chrome itself (no such machine here). The clipboard read
path #651 fixed is untouched by this diff — the only new call is
`terminal.paste(text)`, which does not read the clipboard or depend on textarea
focus.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human asked: "There is an issue when I interact with agent-deck through the
webapp. When I paste text inside the input section it looses all the line
break. […] When I access the agent session through agent deck directly, not
going through the web ui then the paste keeps the proper line breaks."

They were pasting a multi-line prompt into a session from the web UI and it
arrived at the agent as a single line.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

🤖 Opened with [Claude Code](https://claude.com/claude-code)

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal paste handling by consistently forwarding plain-text clipboard content, including multiline and CRLF text.
  * Prevented duplicate or unintended native paste behavior.
  * Ignored empty clipboard content safely.

* **Chores**
  * Updated the service-worker cache version to ensure users receive the latest web application assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->