### PR TITLE
fix(hermes): require consent before installing hooks

### DIFF
--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -123,6 +123,13 @@ func hermesHookEventsForInstall() []string {
 	return hermesLegacyHookEvents
 }
 
+// HermesHookEventsForInstall returns the lifecycle events an install would
+// write for the configured Hermes version. The copy is safe for callers to
+// retain and is used by consent UIs to disclose the exact proposed mutation.
+func HermesHookEventsForInstall() []string {
+	return append([]string(nil), hermesHookEventsForInstall()...)
+}
+
 // GetHermesConfigDir returns the Hermes config directory (~/.hermes).
 func GetHermesConfigDir() string {
 	home, err := os.UserHomeDir()

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -26,6 +26,7 @@ const (
 	ConfirmArchiveSession
 	ConfirmUnarchiveSession
 	ConfirmNotice // acknowledge-only message (single OK button), e.g. protected-action blocks
+	ConfirmInstallHermesHooks
 )
 
 // ConfirmDialog handles confirmation for destructive actions
@@ -39,6 +40,7 @@ type ConfirmDialog struct {
 	mcpCount    int  // Number of running MCPs (for quit confirmation)
 	sandboxed   bool // Whether the session uses a Docker sandbox.
 	worktree    bool // Whether the session has an associated git worktree.
+	hookEvents  []string
 
 	remoteName string // Remote name for remote session confirmations.
 
@@ -239,6 +241,17 @@ func (c *ConfirmDialog) ShowInstallHooks() {
 	c.focusedButton = 1
 }
 
+// ShowInstallHermesHooks shows the Hermes-specific hook consent boundary.
+func (c *ConfirmDialog) ShowInstallHermesHooks(configPath string, events []string) {
+	c.visible = true
+	c.confirmType = ConfirmInstallHermesHooks
+	c.targetID = configPath
+	c.targetName = ""
+	c.hookEvents = append(c.hookEvents[:0], events...)
+	c.buttonCount = 2
+	c.focusedButton = 1
+}
+
 // GetPendingSession returns the pending session creation data
 func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, claudeExtraArgs []string, claudeStartQuery, launchModelID string, parentSessionID, parentProjectPath string) {
 	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
@@ -253,6 +266,7 @@ func (c *ConfirmDialog) Hide() {
 	c.remoteName = ""
 	c.noticeTitle = ""
 	c.noticeBody = ""
+	c.hookEvents = nil
 }
 
 // IsVisible returns whether the dialog is visible
@@ -480,6 +494,17 @@ func (c *ConfirmDialog) View() string {
 		title = "Claude Code Hooks"
 		warning = "Agent-deck can install Claude Code lifecycle hooks\nfor real-time status detection (instant green/yellow/gray)."
 		details = "This writes to your Claude settings.json (preserves existing settings).\nNew/restarted sessions will use hooks; existing sessions continue unchanged.\nYou can disable later with: hooks_enabled = false in config.toml"
+		borderColor = ColorAccent
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Install", ColorGreen, c.focusedButton == 0), "  ",
+			renderButton("Skip", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y install · n skip · ←/→ navigate · Enter select · Esc"))
+
+	case ConfirmInstallHermesHooks:
+		title = "Hermes Agent Hooks"
+		warning = "Agent-deck can install Hermes lifecycle hooks\nfor real-time status detection (instant green/yellow/gray)."
+		details = fmt.Sprintf("Config: %s\nCommand: agent-deck hook-handler\nEvents: %s\nHermes runs this command with your user permissions and sends each event as JSON on stdin.\nExisting settings and hooks are preserved.", c.targetID, strings.Join(c.hookEvents, ", "))
 		borderColor = ColorAccent
 		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
 			renderButton("Install", ColorGreen, c.focusedButton == 0), "  ",

--- a/internal/ui/hermes_hooks_consent_test.go
+++ b/internal/ui/hermes_hooks_consent_test.go
@@ -1,0 +1,262 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+func TestHermesDetectionDoesNotWriteConfigBeforeConsent(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial []byte
+	}{
+		{name: "missing config"},
+		{name: "existing config", initial: []byte("model: test-model\n")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+			t.Setenv("AGENTDECK_PROFILE", "hermes-consent-"+tt.name)
+			t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "legacy")
+
+			binDir := t.TempDir()
+			hermesBin := filepath.Join(binDir, "hermes")
+			if err := os.WriteFile(hermesBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatalf("write fake Hermes binary: %v", err)
+			}
+			t.Setenv("PATH", binDir)
+
+			configPath := filepath.Join(homeDir, ".hermes", "config.yaml")
+			if tt.initial != nil {
+				if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+					t.Fatalf("mkdir Hermes config dir: %v", err)
+				}
+				if err := os.WriteFile(configPath, tt.initial, 0o600); err != nil {
+					t.Fatalf("seed Hermes config: %v", err)
+				}
+			}
+
+			previousWorkers := homeBackgroundWorkersEnabled
+			homeBackgroundWorkersEnabled = true
+			t.Cleanup(func() { homeBackgroundWorkersEnabled = previousWorkers })
+			previousDB := statedb.GetGlobal()
+			statedb.SetGlobal(nil)
+			t.Cleanup(func() { statedb.SetGlobal(previousDB) })
+
+			home := NewHome()
+			t.Cleanup(func() {
+				home.cancel()
+				if home.hookWatcher != nil {
+					home.hookWatcher.Stop()
+				}
+				if home.storageWatcher != nil {
+					home.storageWatcher.Close()
+				}
+				if home.storage != nil {
+					_ = home.storage.Close()
+				}
+			})
+			if !home.pendingHermesHooksPrompt {
+				t.Fatal("Hermes detection did not queue a Hermes-specific consent prompt")
+			}
+
+			got, err := os.ReadFile(configPath)
+			if tt.initial == nil {
+				if !os.IsNotExist(err) {
+					t.Fatalf("Hermes detection wrote %s before consent; read err=%v, content=%q", configPath, err, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("read Hermes config after detection: %v", err)
+			}
+			if string(got) != string(tt.initial) {
+				t.Fatalf("Hermes detection mutated config before consent:\n got %q\nwant %q", got, tt.initial)
+			}
+			if session.CheckHermesHooksInstalled(filepath.Dir(configPath)) {
+				t.Fatal("Hermes hooks installed before consent")
+			}
+		})
+	}
+}
+
+func TestHermesHooksDialogDisclosesMutationAndDefaultsToSkip(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".hermes", "config.yaml")
+	t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "extended")
+	dialog := NewConfirmDialog()
+	dialog.ShowInstallHermesHooks(configPath, session.HermesHookEventsForInstall())
+
+	if dialog.GetConfirmType() != ConfirmInstallHermesHooks {
+		t.Fatalf("confirm type = %v, want ConfirmInstallHermesHooks", dialog.GetConfirmType())
+	}
+	if dialog.GetFocusedButton() != 1 {
+		t.Fatalf("focused button = %d, want 1 (Skip)", dialog.GetFocusedButton())
+	}
+	view := dialog.View()
+	if dialog.GetTargetID() != configPath {
+		t.Errorf("dialog config path = %q, want %q", dialog.GetTargetID(), configPath)
+	}
+	if !strings.Contains(view, "Config:") {
+		t.Errorf("dialog does not label the config path:\n%s", view)
+	}
+	for _, disclosed := range []string{
+		"Hermes Agent Hooks",
+		"agent-deck hook-handler",
+		"user", "permissions", "JSON", "stdin",
+		"pre_llm_call", "post_llm_call", "pre_api_request", "post_api_request",
+		"pre_tool_call", "post_tool_call", "on_session_start", "on_session_end", "on_session_finalize",
+	} {
+		if !strings.Contains(view, disclosed) {
+			t.Errorf("dialog does not disclose %q:\n%s", disclosed, view)
+		}
+	}
+}
+
+func TestPendingHookPromptsAreSequencedClaudeThenHermes(t *testing.T) {
+	home := &Home{
+		confirmDialog:            NewConfirmDialog(),
+		pendingHooksPrompt:       true,
+		pendingHermesHooksPrompt: true,
+	}
+	home.showPendingHooksPrompt()
+	if got := home.confirmDialog.GetConfirmType(); got != ConfirmInstallHooks {
+		t.Fatalf("first prompt = %v, want Claude hooks", got)
+	}
+	home.pendingHooksPrompt = false
+	home.showPendingHooksPrompt()
+	if got := home.confirmDialog.GetConfirmType(); got != ConfirmInstallHermesHooks {
+		t.Fatalf("second prompt = %v, want Hermes hooks", got)
+	}
+}
+
+func TestShouldPromptHermesHooks(t *testing.T) {
+	tests := []struct {
+		name      string
+		installed bool
+		decision  string
+		want      bool
+	}{
+		{name: "new install", want: true},
+		{name: "existing Agent Deck hooks", installed: true, want: false},
+		{name: "durable decline", decision: "declined", want: false},
+		{name: "removed after acceptance is revocation", decision: "accepted", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldPromptHermesHooks(tt.installed, tt.decision); got != tt.want {
+				t.Fatalf("shouldPromptHermesHooks(%v, %q) = %v, want %v", tt.installed, tt.decision, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHermesHookConsentDecisionsAreDurable(t *testing.T) {
+	tests := []struct {
+		name      string
+		accept    bool
+		wantMeta  string
+		wantHooks bool
+	}{
+		{name: "accept", accept: true, wantMeta: "accepted", wantHooks: true},
+		{name: "decline", wantMeta: "declined", wantHooks: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+			t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "legacy")
+			db, err := statedb.Open(filepath.Join(t.TempDir(), "state.db"))
+			if err != nil {
+				t.Fatalf("open state db: %v", err)
+			}
+			if err := db.Migrate(); err != nil {
+				t.Fatalf("migrate state db: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			previousDB := statedb.GetGlobal()
+			statedb.SetGlobal(db)
+			t.Cleanup(func() { statedb.SetGlobal(previousDB) })
+
+			home := &Home{confirmDialog: NewConfirmDialog(), pendingHermesHooksPrompt: true}
+			if tt.accept {
+				home.confirmInstallHermesHooks()
+				if home.hookWatcher != nil {
+					t.Cleanup(home.hookWatcher.Stop)
+				}
+			} else {
+				home.declineInstallHermesHooks()
+			}
+
+			gotMeta, err := db.GetMeta("hermes_hooks_prompted")
+			if err != nil {
+				t.Fatalf("read Hermes consent: %v", err)
+			}
+			if gotMeta != tt.wantMeta {
+				t.Fatalf("Hermes consent = %q, want %q", gotMeta, tt.wantMeta)
+			}
+			installed := session.CheckHermesHooksInstalled(session.GetHermesConfigDir())
+			if installed != tt.wantHooks {
+				t.Fatalf("Hermes hooks installed = %v, want %v", installed, tt.wantHooks)
+			}
+		})
+	}
+}
+
+func TestAcceptedHermesHooksRemovedLaterAreNotReinstalled(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("AGENTDECK_PROFILE", "hermes-revocation")
+	t.Setenv("AGENTDECK_HERMES_HOOK_VOCABULARY", "legacy")
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "hermes"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake Hermes binary: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	db, err := statedb.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state db: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate state db: %v", err)
+	}
+	if err := db.SetMeta("hermes_hooks_prompted", "accepted"); err != nil {
+		t.Fatalf("record accepted consent: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	previousDB := statedb.GetGlobal()
+	statedb.SetGlobal(db)
+	t.Cleanup(func() { statedb.SetGlobal(previousDB) })
+	previousWorkers := homeBackgroundWorkersEnabled
+	homeBackgroundWorkersEnabled = true
+	t.Cleanup(func() { homeBackgroundWorkersEnabled = previousWorkers })
+
+	home := NewHome()
+	t.Cleanup(func() {
+		home.cancel()
+		if home.hookWatcher != nil {
+			home.hookWatcher.Stop()
+		}
+		if home.storageWatcher != nil {
+			home.storageWatcher.Close()
+		}
+		if home.storage != nil {
+			_ = home.storage.Close()
+		}
+	})
+
+	configPath := filepath.Join(homeDir, ".hermes", "config.yaml")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("startup reinstalled revoked Hermes hooks at %s; stat err=%v", configPath, err)
+	}
+	if home.pendingHermesHooksPrompt {
+		t.Fatal("revoked Hermes hooks prompted again despite a durable prior decision")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -393,8 +393,9 @@ type Home struct {
 	lastCachePrune time.Time
 
 	// Hook-based status detection (Claude Code lifecycle hooks)
-	hookWatcher        *session.StatusFileWatcher
-	pendingHooksPrompt bool // True if user should be prompted to install hooks
+	hookWatcher              *session.StatusFileWatcher
+	pendingHooksPrompt       bool // True if user should be prompted to install Claude hooks
+	pendingHermesHooksPrompt bool // True if user should be prompted to install Hermes hooks
 
 	// SSE-based status detection for OpenCode sessions (issue #1614)
 	sseWatcher *session.OpenCodeSSEWatcher
@@ -1417,6 +1418,10 @@ func shouldAutoInstallCursorHooks(userConfig *session.UserConfig, cursorCmd stri
 	return homeBackgroundWorkersEnabled && cursorHooksEnabled && cursorCmd != ""
 }
 
+func shouldPromptHermesHooks(installed bool, decision string) bool {
+	return !installed && decision == ""
+}
+
 // NewHomeWithProfileAndMode creates a new Home with the specified profile.
 // All instances manage the notification bar equally via shared SQLite state.
 func NewHomeWithProfileAndMode(profile string) *Home {
@@ -1740,10 +1745,11 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		}
 	}
 
-	// Hermes shell hooks: auto-inject silently if the hermes binary is available.
-	// No user prompt needed — config.yaml is Hermes's own config file, not a
-	// shared settings file. The shared hook watcher (h.hookWatcher) covers all
-	// tools, so start it here if Claude hooks didn't already start it.
+	// Hermes shell hooks require their own consent because they mutate Hermes's
+	// config.yaml. An installed hook set predates (or embodies) consent and does
+	// not prompt. Any recorded decision suppresses future prompts; in particular,
+	// accepted hooks that are later removed stay removed because removal revokes
+	// consent rather than triggering a silent reinstall.
 	if hermesCmd := strings.TrimSpace(session.GetToolCommand("hermes")); homeBackgroundWorkersEnabled && hermesCmd != "" {
 		// GetToolCommand may return a full command string with arguments
 		// (e.g. "hermes --gateway-url=..."). LookPath needs the binary name only.
@@ -1753,14 +1759,15 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 			hermesBin := hermesFields[0]
 			if _, err := exec.LookPath(hermesBin); err == nil {
 				hermesConfigDir := session.GetHermesConfigDir()
-				if !session.CheckHermesHooksInstalled(hermesConfigDir) {
-					if _, err := session.InjectHermesHooks(hermesConfigDir); err != nil {
-						uiLog.Warn("hermes_hooks_inject_failed", slog.String("error", err.Error()))
-					} else {
-						uiLog.Info("hermes_hooks_installed", slog.String("config_dir", hermesConfigDir))
-					}
+				installed := session.CheckHermesHooksInstalled(hermesConfigDir)
+				decision := ""
+				if db := statedb.GetGlobal(); db != nil {
+					decision, _ = db.GetMeta("hermes_hooks_prompted")
 				}
-				if h.hookWatcher == nil {
+				if shouldPromptHermesHooks(installed, decision) {
+					h.pendingHermesHooksPrompt = true
+				}
+				if installed && h.hookWatcher == nil {
 					if hookWatcher, err := session.NewStatusFileWatcher(nil); err == nil {
 						h.hookWatcher = hookWatcher
 						go hookWatcher.Start()
@@ -5519,9 +5526,8 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.reloadHotkeysFromConfig()
 
 		// Show hooks installation prompt (after splash screen is gone)
-		if h.pendingHooksPrompt && !h.setupWizard.IsVisible() {
-			h.confirmDialog.ShowInstallHooks()
-			h.confirmDialog.SetSize(h.width, h.height)
+		if !h.setupWizard.IsVisible() {
+			h.showPendingHooksPrompt()
 		}
 
 		// Show feedback popup if user has a new version and hasn't rated yet (D-11/D-12).
@@ -10005,16 +10011,28 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
-	case ConfirmInstallHooks:
+	case ConfirmInstallHooks, ConfirmInstallHermesHooks:
 		switch msg.String() {
 		case "y", "Y":
+			if h.confirmDialog.GetConfirmType() == ConfirmInstallHermesHooks {
+				return h, h.confirmInstallHermesHooks()
+			}
 			return h, h.confirmInstallHooks()
 		case "enter":
 			if h.confirmDialog.GetFocusedButton() == 0 {
+				if h.confirmDialog.GetConfirmType() == ConfirmInstallHermesHooks {
+					return h, h.confirmInstallHermesHooks()
+				}
 				return h, h.confirmInstallHooks()
+			}
+			if h.confirmDialog.GetConfirmType() == ConfirmInstallHermesHooks {
+				return h, h.declineInstallHermesHooks()
 			}
 			return h, h.declineInstallHooks()
 		case "n", "N", "esc":
+			if h.confirmDialog.GetConfirmType() == ConfirmInstallHermesHooks {
+				return h, h.declineInstallHermesHooks()
+			}
 			return h, h.declineInstallHooks()
 		}
 		return h, nil
@@ -10156,6 +10174,7 @@ func (h *Home) confirmInstallHooks() tea.Cmd {
 	if db := statedb.GetGlobal(); db != nil {
 		_ = db.SetMeta("hooks_prompted", "accepted")
 	}
+	h.showPendingHooksPrompt()
 	return nil
 }
 
@@ -10167,6 +10186,51 @@ func (h *Home) declineInstallHooks() tea.Cmd {
 	if db := statedb.GetGlobal(); db != nil {
 		_ = db.SetMeta("hooks_prompted", "declined")
 	}
+	h.showPendingHooksPrompt()
+	return nil
+}
+
+func (h *Home) showPendingHooksPrompt() {
+	if h.pendingHooksPrompt {
+		h.confirmDialog.ShowInstallHooks()
+	} else if h.pendingHermesHooksPrompt {
+		h.confirmDialog.ShowInstallHermesHooks(filepath.Join(session.GetHermesConfigDir(), "config.yaml"), session.HermesHookEventsForInstall())
+	} else {
+		return
+	}
+	h.confirmDialog.SetSize(h.width, h.height)
+}
+
+func (h *Home) confirmInstallHermesHooks() tea.Cmd {
+	h.confirmDialog.Hide()
+	h.pendingHermesHooksPrompt = false
+	configDir := session.GetHermesConfigDir()
+	if _, err := session.InjectHermesHooks(configDir); err != nil {
+		uiLog.Warn("hermes_hooks_install_failed", slog.String("error", err.Error()))
+		return nil
+	}
+	if db := statedb.GetGlobal(); db != nil {
+		_ = db.SetMeta("hermes_hooks_prompted", "accepted")
+	}
+	if h.hookWatcher == nil {
+		if hookWatcher, err := session.NewStatusFileWatcher(nil); err != nil {
+			uiLog.Warn("hook_watcher_init_failed", slog.String("error", err.Error()))
+		} else {
+			h.hookWatcher = hookWatcher
+			go hookWatcher.Start()
+		}
+	}
+	h.showPendingHooksPrompt()
+	return nil
+}
+
+func (h *Home) declineInstallHermesHooks() tea.Cmd {
+	h.confirmDialog.Hide()
+	h.pendingHermesHooksPrompt = false
+	if db := statedb.GetGlobal(); db != nil {
+		_ = db.SetMeta("hermes_hooks_prompted", "declined")
+	}
+	h.showPendingHooksPrompt()
 	return nil
 }
 


### PR DESCRIPTION
## What problem does this solve?

Agent Deck's first-run flow asked permission to modify Claude Code settings, but then separately detected Hermes and wrote lifecycle hooks into `~/.hermes/config.yaml` without a Hermes-specific decision. Installing Agent Deck should not implicitly authorize shell command registration in another tool.

## Why this change

This adds a separate Hermes consent state and prompt before any Hermes config mutation. The prompt defaults to Skip and discloses the target config path, exact command, lifecycle events, execution privileges, and JSON stdin payload. Accept and decline are persisted independently from Claude hook consent, Claude and Hermes prompts are queued deterministically, and removing previously accepted Hermes hooks is treated as revocation rather than a reason to reinstall them silently.

The existing `agent-deck hermes-hooks install|status|uninstall` commands remain the manual control surface. Existing Agent Deck Hermes hooks are preserved and do not trigger a migration prompt.

## User impact

On first startup with Hermes available and no Agent Deck Hermes hooks configured, Agent Deck asks before writing Hermes configuration. Accept installs the disclosed hooks; Skip writes nothing and is remembered. If hooks are later removed, startup leaves them removed. Existing installations and manual Hermes hook commands continue to work.

## Evidence

The automated revert-check warns because the complete new test file references new consent symbols that do not exist on the base. The base-compatible sabotage harness below isolates the mutation invariant and fails on the old source for the intended reason.

Behavioral RED against untouched base `f4af88d3`:

```text
$ go test ./internal/ui -run '^TestHermesDetectionRequiresConsent$' -count=1
--- FAIL: TestHermesDetectionRequiresConsent
    startup wrote Hermes config before consent at .../.hermes/config.yaml; stat err=<nil>
FAIL
```

Focused consent tests on the changed tree:

```text
$ go test ./internal/ui -run '^(TestHermesDetectionDoesNotWriteConfigBeforeConsent|TestHermesHooksDialogDisclosesMutationAndDefaultsToSkip|TestPendingHookPromptsAreSequencedClaudeThenHermes|TestShouldPromptHermesHooks|TestHermesHookConsentDecisionsAreDurable|TestAcceptedHermesHooksRemovedLaterAreNotReinstalled)$' -count=1
ok  github.com/asheshgoplani/agent-deck/internal/ui
```

Cumulative package and static gates:

```text
$ go test ./internal/session ./internal/ui -count=1
ok  github.com/asheshgoplani/agent-deck/internal/session
ok  github.com/asheshgoplani/agent-deck/internal/ui

$ go vet ./...
# exit 0

$ gofmt -l ./cmd ./internal
# no output
```

Independent exact full-suite run on the frozen final tree:

```text
$ go test ./... -count=1
# 53 packages passed, 3 packages had no tests, exit 0
```

Exact parallel full-suite gate, run twice on the frozen final tree:

```text
$ go test ./... -count=1
--- FAIL: TestApplyClaudeTitleSync_SyncsWhenEnabled
    post-sync Title = "loupe", want "renamed-by-user"
FAIL  github.com/asheshgoplani/agent-deck/cmd/agent-deck
```

The unrelated title-sync test failed identically in both parallel full-suite runs. Its immediate isolated rerun passed, and the complete `cmd/agent-deck` package passed when run alone on both untouched base and final trees. No title-sync files are changed here.

Diagnostic serialized full suite:

```text
$ go test -p 1 ./... -count=1
# all packages passed, exit 0
```

Independent repetition confirmed the title-sync defect on both base and final trees: the enabled test passes 100/100 alone but fails 10/100 when preceded by the disabled test. `LoadUserConfig` caches by mtime without including config path, so HOME-switching tests can reuse the prior config when mtimes collide. This baseline defect is disclosed rather than mixed into the Hermes consent patch.

Temporary identical `NewHome()` benchmark, five runs of ten first-run iterations against base and final trees:

```text
median latency:     4,741,829 -> 4,543,270 ns/op  (-4.19%)
median allocated:     862,894 ->   809,524 B/op  (-6.19%)
median allocations:     1,624 ->     1,427 allocs/op (-12.13%)
```

The benchmark code was kept outside the PR.

The manual Hermes CLI sequence also passed on both base and final trees:

```text
NOT INSTALLED -> install -> INSTALLED -> uninstall -> NOT INSTALLED
# every subcommand exit 0; config mode 0600
```


## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol

**Prompt / session log (optional):** Not published; the human intent is quoted below and validation evidence is included above.

## What actually bothered you

Danny asked: "Can you make a request into agent deck as a source change to create a consent boundary for Hermes."

The observed behavior was that Agent Deck's Claude-specific consent screen did not disclose or authorize the separate Hermes config mutation that followed detection.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5.6-sol intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt before installing Hermes hooks.
  * The prompt displays the proposed command, events, permissions, and what existing settings will be preserved.
  * Users can accept or skip installation, with their decision remembered for future sessions.
  * Claude and Hermes setup prompts are shown sequentially when applicable.

* **Bug Fixes**
  * Hermes configuration is no longer modified before consent.
  * Declined or later-removed hooks are not silently reinstalled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->