### PR TITLE
fix(ui): sanitize the worktree branch prefilled from the session name

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -327,6 +327,29 @@ func ValidateBranchName(name string) error {
 		return errors.New("branch name cannot be just '@'")
 	}
 
+	// git check-ref-format applies several rules per slash-separated component
+	// rather than to the ref as a whole, so "feature/.x", "feature/x.lock" and
+	// "feature//x" all pass the whole-string checks above while git still
+	// refuses them. Without this, an invalid name reaches `git worktree add`
+	// and fails there instead of at the input that produced it.
+	if strings.HasSuffix(name, "/") {
+		return errors.New("branch name cannot end with '/'")
+	}
+	if strings.HasSuffix(name, ".") {
+		return errors.New("branch name cannot end with '.'")
+	}
+	for _, component := range strings.Split(name, "/") {
+		if component == "" {
+			return errors.New("branch name cannot contain an empty path component")
+		}
+		if strings.HasPrefix(component, ".") {
+			return fmt.Errorf("branch name component %q cannot start with '.'", component)
+		}
+		if strings.HasSuffix(component, ".lock") {
+			return fmt.Errorf("branch name component %q cannot end with '.lock'", component)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -246,6 +246,7 @@ func TestValidateBranchName(t *testing.T) {
 			"bugfix-123",
 			"release-v1.0.0",
 			"user/feature",
+			"feature/a/b/c", // multiple components, all valid
 		}
 
 		for _, name := range validNames {
@@ -281,6 +282,11 @@ func TestValidateBranchName(t *testing.T) {
 			"feature/",        // trailing slash
 			"feature/thing.",  // ends with a dot
 			"feature/a-/.b",   // invalid char before a dot-leading component
+			// Same rules on a non-final component, so a pass that only
+			// inspected the last one would let these through.
+			"feature/.hidden/ok",    // dot-prefixed interior component
+			"feature/x.lock/ok",     // .lock-suffixed interior component
+			"feature/ok/.hidden/ok", // dot-prefixed component in the middle
 		}
 
 		for _, name := range invalidNames {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -273,6 +273,14 @@ func TestValidateBranchName(t *testing.T) {
 			"branch\\name",   // contains backslash
 			"@",              // just @
 			"branch@{name",   // contains @{
+			// Per-component rules git applies but a whole-string check misses.
+			"feature/.hidden", // component starts with a dot
+			"feature/x.lock",  // component ends with .lock
+			"feature//thing",  // empty component
+			"/feature",        // leading slash: empty first component
+			"feature/",        // trailing slash
+			"feature/thing.",  // ends with a dot
+			"feature/a-/.b",   // invalid char before a dot-leading component
 		}
 
 		for _, name := range invalidNames {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1115,7 +1115,25 @@ func (d *NewDialog) autoBranchFromName() {
 	if name == "" {
 		return
 	}
-	branch := d.branchPrefix + name
+	// Run the name through the git sanitizer (same as the fork dialog) so a
+	// title with spaces or ':' doesn't prefill a branch the dialog's own
+	// ValidateBranchName then refuses. The prefix is user config and may
+	// legitimately contain '/', so only the name part is sanitized.
+	//
+	// The sanitizer can still leave a leading/trailing '.' or '/' (e.g. "*.foo"
+	// -> ".foo", "~/x" -> "/x"); git rejects a ref component starting with '.'
+	// and an empty one, so trim those before they reach `worktree add`.
+	slug := strings.Trim(git.SanitizeBranchName(name), "./")
+	branch := d.branchPrefix + slug
+	if slug == "" || git.ValidateBranchName(branch) != nil {
+		// Nothing usable came out. Clear rather than return, so the field can't
+		// keep a branch derived from an earlier name; an empty branch surfaces
+		// as "Branch name required for worktree" on submit instead of silently
+		// creating the worktree on the wrong branch.
+		d.branchInput.SetValue("")
+		d.branchAutoSet = true
+		return
+	}
 	d.branchInput.SetValue(branch)
 	d.branchAutoSet = true
 }

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1543,6 +1543,11 @@ func TestNewDialog_ToggleWorktree_SanitizesBranchFromName(t *testing.T) {
 		{"sanitizes to a .lock suffix", "*.lock*", "feature/lock"},
 		{"sanitizes to a leading slash", "~/x", "feature/x"},
 		{"sanitizes to a leading dot", "*.foo", "feature/foo"},
+		// An interior component the sanitizer leaves invalid: git rejects
+		// "feature/a-/.b", so the prefill must be dropped rather than handed to
+		// `worktree add`.
+		{"interior dot-leading component", "a?/.b", ""},
+		{"interior empty component", "a//b", ""},
 	}
 
 	for _, tt := range tests {
@@ -1552,11 +1557,21 @@ func TestNewDialog_ToggleWorktree_SanitizesBranchFromName(t *testing.T) {
 
 			d.ToggleWorktree()
 
-			if got := d.branchInput.Value(); got != tt.wantBranch {
+			got := d.branchInput.Value()
+			if got != tt.wantBranch {
 				t.Errorf("branch = %q, want %q", got, tt.wantBranch)
 			}
-			if err := git.ValidateBranchName(d.branchInput.Value()); err != nil {
-				t.Errorf("prefilled branch %q is invalid: %v", d.branchInput.Value(), err)
+			// An empty want means the name yields nothing git would accept, so
+			// the field must be left empty and the refusal must be the dialog's
+			// own "branch required" rather than a late `worktree add` failure.
+			if tt.wantBranch == "" {
+				if msg := d.Validate(); msg != "Branch name required for worktree" {
+					t.Errorf("Validate() = %q, want the branch-required refusal", msg)
+				}
+				return
+			}
+			if err := git.ValidateBranchName(got); err != nil {
+				t.Errorf("prefilled branch %q is invalid: %v", got, err)
 			}
 			if msg := d.Validate(); msg != "" {
 				t.Errorf("dialog refused its own prefill: %s", msg)

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	tea "github.com/charmbracelet/bubbletea"
@@ -1524,6 +1525,81 @@ func TestNewDialog_ToggleWorktree_AutoPopulatesBranch(t *testing.T) {
 	}
 	if !d.branchAutoSet {
 		t.Error("branchAutoSet should be true after auto-population")
+	}
+}
+
+func TestNewDialog_ToggleWorktree_SanitizesBranchFromName(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionName string
+		wantBranch  string
+	}{
+		{"spaces", "my new feature", "feature/my-new-feature"},
+		{"colon and question mark", "fix: why?", "feature/fix-why"},
+		{"tabs and repeated spaces", "add\tretry  logic", "feature/add-retry-logic"},
+		{"already clean", "amber-falcon", "feature/amber-falcon"},
+		// The sanitizer alone leaves ".lock", "/x" and ".foo" here, which either
+		// the dialog's own validator or git itself would then reject.
+		{"sanitizes to a .lock suffix", "*.lock*", "feature/lock"},
+		{"sanitizes to a leading slash", "~/x", "feature/x"},
+		{"sanitizes to a leading dot", "*.foo", "feature/foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewNewDialog()
+			d.nameInput.SetValue(tt.sessionName)
+
+			d.ToggleWorktree()
+
+			if got := d.branchInput.Value(); got != tt.wantBranch {
+				t.Errorf("branch = %q, want %q", got, tt.wantBranch)
+			}
+			if err := git.ValidateBranchName(d.branchInput.Value()); err != nil {
+				t.Errorf("prefilled branch %q is invalid: %v", d.branchInput.Value(), err)
+			}
+			if msg := d.Validate(); msg != "" {
+				t.Errorf("dialog refused its own prefill: %s", msg)
+			}
+		})
+	}
+}
+
+// A name that sanitizes to nothing must not prefill a bare "feature/" that git
+// would reject.
+func TestNewDialog_ToggleWorktree_UnsanitizableName_NoBranch(t *testing.T) {
+	d := NewNewDialog()
+	d.nameInput.SetValue("***")
+
+	d.ToggleWorktree()
+
+	if got := d.branchInput.Value(); got != "" {
+		t.Errorf("branch = %q, want empty", got)
+	}
+	if msg := d.Validate(); msg != "Branch name required for worktree" {
+		t.Errorf("Validate() = %q, want the branch-required refusal", msg)
+	}
+}
+
+// Editing the name to something unsanitizable must clear the auto-derived
+// branch, not leave the one derived from the previous name. Otherwise submit
+// silently creates (or checks out) a branch belonging to unrelated work.
+func TestNewDialog_AutoBranch_NameEditedToUnsanitizable_ClearsStaleBranch(t *testing.T) {
+	d := NewNewDialog()
+	d.nameInput.SetValue("hi")
+	d.ToggleWorktree()
+
+	if got := d.branchInput.Value(); got != "feature/hi" {
+		t.Fatalf("setup: branch = %q, want %q", got, "feature/hi")
+	}
+
+	// Mirrors the name-input handler, which re-derives on every keystroke
+	// while branchAutoSet is true.
+	d.nameInput.SetValue("***")
+	d.autoBranchFromName()
+
+	if got := d.branchInput.Value(); got != "" {
+		t.Errorf("branch = %q, want empty; stale branch from the previous name was kept", got)
 	}
 }
 


### PR DESCRIPTION
## What problem does this solve?

In the TUI new-session dialog, ticking **Create in worktree** prefills the Branch field with the session name verbatim. If the session name contains a space (or `:`, `?`, `~`, `^`, `*`, `[`, `\`), the prefilled branch is one the dialog's own validator rejects, so pressing Ctrl+S just fails with `branch name cannot contain ' '`. The user never typed that branch, agent-deck did.

## Why this change

`autoBranchFromName` concatenated the raw name onto the prefix:

```go
branch := d.branchPrefix + name
```

`Validate()` two hundred lines down then runs `git.ValidateBranchName` on it, which rejects spaces. So the dialog generates a value it will refuse.

The fork dialog already hit and fixed exactly this, and left the reason in a comment (`internal/ui/forkdialog.go:236`):

```go
// Auto-suggest branch name based on fork title. Use the git sanitizer (same
// as quick fork's quickForkInputs) so titles with ':' '?' etc. don't produce
// an invalid branch like "fork/fix:-bug".
d.branchInput.SetValue(forkSettings.GetBranchPrefix() + git.SanitizeBranchName(strings.ToLower(originalName)))
```

Quick fork does the same (`internal/ui/home.go:12089`). The new-session dialog was the one prefill site that never got it. This change routes it through the same `git.SanitizeBranchName`, so all three branch-suggestion paths agree.

`SanitizeBranchName` on its own is not quite enough, which I only caught while testing the edge cases:

- It can leave a leading `.` or `/`: `*.foo` becomes `.foo`, `~/x` becomes `/x`. `ValidateBranchName` accepts both (it only checks a leading `.` on the whole string, never per path component), but `git check-ref-format` rejects a component starting with `.` and rejects empty components, so those would have sailed past the dialog and blown up later in `worktree add`. Trimming `./` off the slug handles it.
- It can also leave a `.lock` suffix: `*.lock*` becomes `.lock`, because the trailing-`.lock` strip runs while the string still ends in `-`, and the later `Trim("-")` re-exposes it. That one the dialog still refuses, so the original bug would survive for that input.

So the assembled branch is checked with `ValidateBranchName` before it is written. If it doesn't pass, or the name sanitizes to nothing (`***`), the field is cleared rather than left alone, and submit stops on the existing `Branch name required for worktree`. Clearing matters: the name handler re-derives on every keystroke, so an early `return` would leave a branch derived from an *earlier* name sitting in the field while still claiming to track the current one. That branch may already exist, in which case `resolveWorktreeBranch` checks it out and quietly attaches the new session to unrelated work.

Two deliberate narrowings:

- Only the name is sanitized, not `d.branchPrefix`. The prefix is user config (`[worktree] prefix`, default `feature/`) and legitimately contains `/`.
- Unlike the fork dialog I do **not** lowercase. Mixed-case names are already valid branch names today, and lowercasing them would change working behavior for people who aren't hitting this bug. The reported bug is invalid characters, so that's all this touches.

### Why `ValidateBranchName` changed too

I first shipped this as dialog-only and flagged the interior-component case as a known gap. Two reviewers independently pointed at the same hole, and they were right that it isn't really a gap in the prefill — it's a gap in the validator the submit path trusts.

`ValidateBranchName` applied git's `.`-prefix, `.lock`-suffix and empty-name rules to the whole string, but git applies them **per slash-separated component**. So `feature/.hidden`, `feature/x.lock`, `feature//thing`, `feature/thing.` and `/feature` all passed while git refuses every one of them, and the failure landed in `git worktree add` instead of at the input that produced it. That also reached the CLI (`--worktree -b`), not just this dialog.

It now walks the components. Checked against real git — every newly rejected name is one `git check-ref-format --branch` rejects, and everything previously accepted still is:

```
feature/.hidden        git:REJECT      feature/new-thing      git:ACCEPT
feature/x.lock         git:REJECT      release-v1.0.0         git:ACCEPT
feature//thing         git:REJECT      user/feature           git:ACCEPT
/feature               git:REJECT      feature/my-new-feature git:ACCEPT
feature/               git:REJECT      feature/lock           git:ACCEPT
feature/thing.         git:REJECT
feature/a-/.b          git:REJECT
```

So nothing that works today starts failing; names that were going to fail later now fail at the dialog. With that in place a name like `a?/.b` produces no prefill at all and stops on `Branch name required for worktree`, instead of building `feature/a-/.b` and dying in `worktree add`.

Scope note: this is TUI-only. The web new-session dialog (`internal/web/static/app/CreateSessionDialog.js`) has no worktree control and its create payload carries no branch, so there is nothing to fix there.

## User impact

Naming a session the way people actually name things (`my new feature`, `fix: login redirect`) and ticking the worktree box now works. Before, it was a dead end unless you knew to hand-edit the Branch field.

Branch names that were already valid are unchanged: `SanitizeBranchName` is a no-op on them (covered by the `already clean` case in the new test).

## Evidence

Reproduced against a stock build of `main` (f4af88d3) in an isolated `HOME`/repo sandbox, driving the real TUI: press `n`, type `my new feature`, Tab, `w`, Ctrl+S.

**Before** — prefill, then the refusal on submit:

```
│      Name:                                          │
│      > my new feature                               │
...
│      [x] Create in worktree                         │
│    ▶ Branch:                                        │
│      > feature/my new feature                       │
...
│      ⚠ branch name cannot contain ' '               │
```

**After** — same keystrokes, same sandbox:

```
│      [x] Create in worktree                         │
│    ▶ Branch:                                        │
│      > feature/my-new-feature                       │
```

Ctrl+S now creates the session, no error, and the worktree lands on disk:

```
$ git -C /tmp/adk-repro/proj worktree list
/private/tmp/adk-repro/proj                                   a7947b0 [main]
/private/tmp/adk-repro/proj/.worktrees/feature-my-new-feature a7947b0 [feature/my-new-feature]
```

**Revert-check** — reverting the `newdialog.go` hunk and re-running the new tests:

```
--- FAIL: TestNewDialog_ToggleWorktree_SanitizesBranchFromName/spaces
    branch = "feature/my new feature", want "feature/my-new-feature"
    prefilled branch "feature/my new feature" is invalid: branch name cannot contain ' '
    dialog refused its own prefill: branch name cannot contain ' '
--- FAIL: TestNewDialog_ToggleWorktree_SanitizesBranchFromName/colon_and_question_mark
--- FAIL: TestNewDialog_ToggleWorktree_SanitizesBranchFromName/tabs_and_repeated_spaces
--- PASS: TestNewDialog_ToggleWorktree_SanitizesBranchFromName/already_clean
--- FAIL: TestNewDialog_ToggleWorktree_UnsanitizableName_NoBranch
    branch = "feature/***", want empty
--- FAIL: TestNewDialog_AutoBranch_NameEditedToUnsanitizable_ClearsStaleBranch
```

The `already clean` subtest passing on both sides is the no-regression half.

**The three edge cases, before and after** (`feature/` prefix):

| session name | before | after |
|---|---|---|
| `my new feature` | `feature/my new feature` — dialog refuses | `feature/my-new-feature` |
| `*.lock*` | `feature/*.lock*` — dialog refuses | `feature/lock` |
| `*.foo` | `feature/*.foo` — dialog refuses | `feature/foo` |
| `~/x` | `feature/~/x` — dialog refuses | `feature/x` |
| `***` | `feature/***` — dialog refuses | cleared, `Branch name required for worktree` |
| `hi` then edited to `***` | `feature/***` — dialog refuses | cleared (not the stale `feature/hi`) |
| `a?/.b` | `feature/a?/.b` — dialog refuses | cleared, `Branch name required for worktree` |

**Package under change, sandboxed:**

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./internal/ui/
ok  	github.com/asheshgoplani/agent-deck/internal/ui	31.776s
```

`gofmt` and `go vet ./...` clean.

**Full-suite honesty note.** CI's "Full test suite (PR gate)" is green on every SHA pushed here. `go test ./...` on my own machine (macOS 15, MacPorts tmux 3.7b) is not fully green, but every failure reproduces identically on unmodified `main` — none are in the packages this PR touches:

- `cmd/agent-deck`: `TestEnsureTmuxInPath/not_found_anywhere`
- `internal/session`: `TestForbidigo_BansRawOSEnvironInSpawnPath`, `TestIssue1421_CleanStaleSSHSockets`, `TestEnsureClaudeSessionIDFromDiskForRestart_RemoteNeverAdoptsLocalUUID`, `TestFindLatestClaudeTranscriptOnDisk_RemoteRefuses`, `TestRemoteCDPrefix_IdentityAndExecutionAgree`
- `internal/tmuxutf8`: `TestIssue1867_NonUTF8Client_StatusStillReadsSpinner`

Two more (`TestAgentDeckLaunch_ParallelSafe_AllSessionsPersist_RegressionFor1031`, `TestConductorTitledChild_DeliverCompletion_ParentedIsCommitted`) fail only under the full parallel run and pass in isolation with this change applied. These look environment-dependent to me rather than related to this diff, but I'm flagging them rather than claiming a clean sweep.

Not a hot path: this runs once on a checkbox toggle in a modal.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human hit this and asked for it directly:

> "When a user creates a new session and toggles worktree, the prefilled name of the worktree path is made from the current/proposed session name. If the proposed session name has spaces it will still be used in the worktree path only to fail session creation because of whitespaces not allowed."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — green in CI ("Full test suite (PR gate)") on both pushed SHAs. My own machine additionally shows failures that reproduce identically on unmodified `main` and are in packages this PR doesn't touch; they're listed in Evidence so nobody has to take my word for which is which.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — n/a, one call on a checkbox toggle
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic branch naming from session names using Git-compatible rules.
  * Prevented invalid or empty branch names from being populated.
  * Cleared outdated automatically generated branches when session names are edited.
  * Strengthened branch validation for invalid components, trailing characters, and prohibited patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
