### PR TITLE
fix(web): keep the sidebar status chips inside the panel

### DIFF
--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -159,7 +159,10 @@ body[data-rail="hidden"] .rightrail { display: none; }
   display: flex; gap: 6px; align-items: center;
 }
 .side-filter input {
-  flex: 1; height: 28px;
+  /* min-width:0 is required here: a flex item defaults to min-width:auto, so
+     the input refuses to shrink below its intrinsic width and pushes the
+     status chips past the sidebar's right padding on narrow viewports. */
+  flex: 1; min-width: 0; height: 28px;
   background: var(--bg); border: 1px solid var(--border);
   color: var(--text); border-radius: var(--radius);
   padding: 0 8px; font: inherit; font-size: 12px;


### PR DESCRIPTION
The sidebar filter row spills its status chips outside the panel on narrow viewports. Reported from a tablet; reproduced and measured at 1024x768.

### What is wrong

`.side-filter` is a `nowrap` flex row holding the filter input and the four status chips. The input is `flex: 1`, but a flex item's `min-width` defaults to `auto`, so the input will not shrink below its intrinsic width. The chips get pushed out of the panel instead.

Measured at 1024x768, sidebar at its default 300px, before the change:

| element | left | right |
|---|---|---|
| `.side-filter` content box | 12 | **287.3** |
| `input` | 12 | 189.3 (177.3px wide) |
| chips | 195.3 | **295.5** |

The last chip ends **8.1px past the content edge** and 4.5px from the panel border.

### The fix

Add `min-width: 0` to `.side-filter input` so it can give back the space it is over-claiming. One declaration, no layout restructuring.

After: the input is 169.2px, the last chip ends at x=287.3 — exactly the content edge, 0px overflow — and all four chips stay visible and clickable.

### Verification

Built this branch locally and loaded it in Chrome, measuring the boxes via `getBoundingClientRect()` rather than by eye. Checked that all four chips still render and that the input still takes the remaining space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar filter layout on narrow screens.
  * Prevented filter inputs from pushing status chips outside the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### The resize floor makes it worse

The sidebar is resizable and clamps to a 200px minimum. At that floor the chips do not merely spill past the padding — they overflow the container itself and become invisible:

| | scrollWidth | clientWidth |
|---|---|---|
| before | 295px | 199px |

That is ~96px of chips clipped out of view, so the status filters cannot be reached at all at the narrowest sidebar width.

With `min-width: 0` applied and re-measured at 200px: the input shrinks to 69.2px (the `/ filter` placeholder still fits) and the last chip lands exactly on the padding boundary (187.3 == 187.3). The chips cannot over-shrink in turn — each has its own `min-width: auto` floor at glyph + padding — so no additional constraint is needed.