### PR TITLE
fix(web): stop the topbar painting over the sidebar, main and right rail

### DIFF
--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -45,6 +45,13 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .topbar {
   display: flex;
   align-items: stretch;
+  /* The legacy Tailwind sheet (styles.css, loaded before this one) still has
+     `.topbar { height: var(--topbar-height) }` with --topbar-height: 56px,
+     while the grid row above is sized from --topbar-h: 44px. Two variables for
+     one measurement: the header rendered 56px in a 44px row and, being
+     z-index 20, painted the 12px difference over .sidebar/.main/.rightrail.
+     Pin the height to the same token the row uses so the two cannot drift. */
+  height: var(--topbar-h);
   background: var(--panel);
   border-bottom: 1px solid var(--border);
   z-index: 20;


### PR DESCRIPTION
The web UI header covers the top 12px of all three panes below it, at every viewport width including desktop. The first row of the session list, the top of the main pane and the right rail heading all sit under it.

> **Updated after review** — my first version misdiagnosed this as intrinsic content height and grew the grid row to match. That hid the real problem and left the header 12px taller than designed. The actual cause and a smaller fix are below.

### Root cause: two variables for one measurement

`index.html` loads both stylesheet generations — the legacy Tailwind output first, the redesign second:

```html
<link rel="stylesheet" href="/static/styles.css" />          <!-- line 65 -->
<link rel="stylesheet" href="/static/app/design-tokens.css" />
<link rel="stylesheet" href="/static/app/app.css" />         <!-- line 71 -->
```

`styles.css` still carries the legacy rule:

```css
.topbar { height: var(--topbar-height); ... }   /* --topbar-height: 56px */
```

while the new shell sizes the grid row from a *different* token:

```css
.app { grid-template-rows: var(--topbar-h) ... }   /* --topbar-h: 44px */
```

`app.css` sets no height on `.topbar`, so the legacy 56px wins. The header renders 56px in a 44px row and, being `z-index: 20`, paints the 12px difference on top of `.sidebar`, `.main` and `.rightrail` instead of pushing them down.

Measured at 1024x768 before the change:

| element | top | note |
|---|---|---|
| `.topbar` | 0 | height 56px, bottom edge y=56 |
| `.sidebar` | 44 | **12px covered** |
| `.main` | 44 | **12px covered** |
| `.rightrail` | 44 | **12px covered** |

This also explains why the header ignores the layout around it: an explicit height beats stretch, so forcing the row to 100px still leaves `.topbar` at 56px, and `min-height: 0` on the header or its children changes nothing.

### The fix

Give `.topbar` an explicit `height: var(--topbar-h)` in `app.css`. It loads last, so it wins over the legacy rule, and the header is now sized from the same token as the row it occupies — the two cannot drift apart again.

44px is the redesign's intended header height, and the header content measures ~31px, so nothing is clipped by the change.

### Verification

Built this branch locally and measured with `getBoundingClientRect()` at 1024x768:

- header height **44px**
- overlap **0px** for `.sidebar`, `.main` and `.rightrail`
- grid rows unchanged at `44px 699.333px 26px`
- no descendant of `.topbar` overflows it — search box and all tabs still render

`go test ./internal/web/...` passes.