### PR TITLE
feat(web): option to hide empty sidebar groups

### DIFF
--- a/internal/web/static/app/Sidebar.js
+++ b/internal/web/static/app/Sidebar.js
@@ -13,7 +13,7 @@ import {
   selectedIdSignal, mutationsEnabledSignal, confirmDialogSignal,
   createSessionDialogSignal, editSessionDialogSignal,
 } from './state.js'
-import { statusFiltersSignal, showColsSignal, activeTabSignal } from './uiState.js'
+import { statusFiltersSignal, showColsSignal, activeTabSignal, hideEmptyGroupsSignal } from './uiState.js'
 import { apiFetch } from './api.js'
 import { addToast } from './Toast.js'
 import { formatRelativeTime } from './timeFmt.js'
@@ -140,6 +140,7 @@ export function Sidebar() {
   const { groups, byGroup, sessions } = menuModelSignal.value
   const selected = selectedIdSignal.value
   const statusFilters = statusFiltersSignal.value
+  const hideEmptyGroups = hideEmptyGroupsSignal.value
   const showCols = showColsSignal.value
   const [filter, setFilter] = useState('')
   const [showMenu, setShowMenu] = useState(false)
@@ -223,7 +224,9 @@ export function Sidebar() {
       <div class="side-list">
         ${groups.map(g => {
           const members = (byGroup[g.path] || []).filter(matches)
-          if (filter && members.length === 0) return null
+          // members is post-filter, and the "(N)" badge below is rendered from
+          // it too, so this hides exactly the groups that would read "(0)".
+          if ((filter || hideEmptyGroups) && members.length === 0) return null
           const open = expanded[g.path] !== false
           return html`
             <div key=${g.path}>

--- a/internal/web/static/app/TweaksPanel.js
+++ b/internal/web/static/app/TweaksPanel.js
@@ -3,7 +3,7 @@
 import { html } from 'htm/preact'
 import { Icon, ICONS } from './icons.js'
 import {
-  tweaksOpenSignal, accentSignal, densitySignal, railSignal,
+  tweaksOpenSignal, accentSignal, densitySignal, railSignal, hideEmptyGroupsSignal,
 } from './uiState.js'
 
 const SWATCHES = [
@@ -18,6 +18,7 @@ export function TweaksPanel() {
   const accent = accentSignal.value
   const density = densitySignal.value
   const rail = railSignal.value
+  const hideEmpty = hideEmptyGroupsSignal.value
   const close = () => (tweaksOpenSignal.value = false)
 
   return html`
@@ -61,6 +62,17 @@ export function TweaksPanel() {
                  onClick=${() => (railSignal.value = rail === 'visible' ? 'hidden' : 'visible')}/>
             <span style="font-family: var(--mono); font-size: 11px; color: var(--text-dim);">
               ${rail === 'visible' ? 'visible' : 'hidden'}
+            </span>
+          </div>
+        </div>
+        <div>
+          <label>EMPTY GROUPS</label>
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <div class=${`switch ${hideEmpty ? 'on' : ''}`}
+                 data-testid="tweaks-hide-empty-groups-switch"
+                 onClick=${() => (hideEmptyGroupsSignal.value = !hideEmpty)}/>
+            <span style="font-family: var(--mono); font-size: 11px; color: var(--text-dim);">
+              ${hideEmpty ? 'hidden' : 'shown'}
             </span>
           </div>
         </div>

--- a/internal/web/static/app/uiState.js
+++ b/internal/web/static/app/uiState.js
@@ -53,6 +53,15 @@ persist(rightRailPanelsSignal, 'agentdeck.rightRailPanels')
 // Sidebar status filter chips (running/waiting/error/idle).
 export const statusFiltersSignal = signal([])
 
+// Hide sidebar groups that have no visible sessions.
+// A large board accumulates groups that are empty most of the time, and the
+// status chips make it worse: filtering to "error" still renders every
+// non-matching group as a "(0)" header, so the matches you asked for are
+// buried in headers for groups that have nothing in them. This is a layout
+// preference, so unlike statusFiltersSignal above it persists.
+export const hideEmptyGroupsSignal = signal(loadJSON('agentdeck.hideEmptyGroups', false))
+persist(hideEmptyGroupsSignal, 'agentdeck.hideEmptyGroups')
+
 // Mobile bottom tab (mirror of activeTab on phones).
 export const mobileTabSignal = signal('fleet')
 


### PR DESCRIPTION
On a board with many groups the sidebar fills up with headers for groups that have nothing in them. The status chips make this worse rather than better: filtering to `error` still renders every non-matching group as a `(0)` header, so the handful of sessions you asked for end up buried among headers for groups with no matches at all.

Adds a persisted preference plus an **EMPTY GROUPS** switch in the Tweaks panel, next to the existing RIGHT RAIL switch. Default is `false`, so nothing changes unless it is turned on.

### What "empty" means

"No sessions matching the current filter" — the same number already shown in the group's own `(N)` badge. So turning the option on hides exactly the groups that read `(0)`, and there is no second definition of empty to reason about.

### Implementation

One condition. `Sidebar.js` already had this guard for the text filter:

```js
if (filter && members.length === 0) return null
```

`members` is the post-filter array, and it is also what the badge renders from, so this generalizes the existing early-return rather than adding a parallel path:

```js
if ((filter || hideEmptyGroups) && members.length === 0) return null
```

The signal follows the established pattern in `uiState.js` (`loadJSON` + `persist`, key `agentdeck.hideEmptyGroups`), and the toggle reuses the existing `.switch` markup and CSS, so no new styles are needed. It persists rather than being session-scoped because it is a layout preference — like rail, density and accent — not a transient filter.

### Verification

Built locally against a board with 18 groups, 3 of them empty (`MY SESSIONS (0)`, `DAILY (0)`, `DAILY-OPS-DIGEST (0)`):

- option on → sidebar drops to 15 groups, no `(0)` headers remain
- preference survives a reload
- no non-empty group is affected

`go test ./internal/web/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “EMPTY GROUPS” toggle to show or hide groups without matching members.
  * The preference is saved and restored between sessions.
  * Empty groups are automatically hidden when filtering produces no matching members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->