### PR TITLE
feat(web): remember the auth token so a reload or PWA launch stays signed in

### DIFF
--- a/internal/web/static/app/api.js
+++ b/internal/web/static/app/api.js
@@ -38,7 +38,12 @@ export async function apiFetch(method, path, body) {
     const msg = data?.error?.message || res.statusText
     // Only show toast for mutation errors (not GET requests, which are often background)
     if (method !== 'GET') addToast(msg)
-    throw new Error(msg)
+    // Carry the HTTP status so callers can tell "the server rejected our
+    // credentials" (401) apart from "the server is unreachable" (the network
+    // error above). Only the former should invalidate a remembered token.
+    const err = new Error(msg)
+    err.status = res.status
+    throw err
   }
   return data
 }

--- a/internal/web/static/app/main.js
+++ b/internal/web/static/app/main.js
@@ -15,12 +15,50 @@ import { addToast } from './Toast.js'
 
 // ---------- Auth token extraction ----------
 
+// Where the bearer token is remembered between page loads.
+//
+// The token arrives once, in the URL, and is stripped immediately (see below).
+// Without somewhere to keep it, the app is authenticated for exactly one page
+// load: a reload, a hard refresh, or launching the installed PWA all land on a
+// tokenless URL and every /api/ call 401s with no way to recover but digging
+// the original ?token= link back out.
+//
+// This is not a hypothetical. manifest.webmanifest declares `"start_url": "/"`
+// and `"display": "standalone"`, so an installed instance ALWAYS starts without
+// a token -- the advertised install path cannot authenticate at all against a
+// server started with --token/--token-file.
+//
+// localStorage rather than sessionStorage is deliberate: sessionStorage is
+// cleared when the standalone window closes, which is the exact case this is
+// meant to fix. This does not widen the token's exposure much in practice --
+// it already travels in a URL query string, which is more readily copied,
+// shared and logged than an origin-scoped storage entry.
+const TOKEN_KEY = 'agentdeck.authToken'
+
+function loadStoredToken() {
+  try { return localStorage.getItem(TOKEN_KEY) || '' } catch (_) { return '' }
+}
+function storeToken(token) {
+  try { localStorage.setItem(TOKEN_KEY, token) } catch (_) { /* private mode */ }
+}
+export function clearStoredToken() {
+  try { localStorage.removeItem(TOKEN_KEY) } catch (_) { /* private mode */ }
+  authTokenSignal.value = ''
+}
+
 ;(function extractAuthToken() {
   const params = new URLSearchParams(window.location.search)
   const token = params.get('token')
-  if (!token) return
+  if (!token) {
+    // No token in the URL: fall back to one saved by an earlier visit, so a
+    // reload or a PWA launch stays signed in. A token in the URL always wins
+    // over the stored one, so re-opening a fresh ?token= link rotates it.
+    authTokenSignal.value = loadStoredToken()
+    return
+  }
 
   authTokenSignal.value = token
+  storeToken(token)
 
   // Strip token from URL so it isn't logged by the server or leaked via Referer header
   params.delete('token')
@@ -149,7 +187,13 @@ export async function loadMenu() {
     sessionsLoadedSignal.value = true
     startSSE()
     startCommandCenterSSE()
-  } catch (_) {
+  } catch (err) {
+    // A remembered token that the server rejects would otherwise wedge the app
+    // in a permanent 401 -- every reload would replay the same dead token. Drop
+    // it so the next visit starts clean and a fresh ?token= link can take over.
+    // Only on an explicit 401: a network error means the server is down, and
+    // the token is probably still good.
+    if (err && err.status === 401) clearStoredToken()
     connectionSignal.value = 'disconnected'
     // Still start SSE so it can reconnect when server comes back
     startSSE()


### PR DESCRIPTION
The bearer token arrives once in the URL and is deliberately stripped straight away. That part is right — it keeps the token out of server logs and out of the `Referer` header. But it is then held only in `authTokenSignal`, in memory, so **the app is authenticated for exactly one page load.**

Anything that starts a new document loses it: a reload, a hard refresh, a restored tab, or opening the app from the home screen. Every `/api/` call then 401s, and the only way back is to find the original `?token=` link again.

### The installed-app case is not a corner case

`manifest.webmanifest` declares:

```json
"start_url": "/",
"display": "standalone",
```

so an installed instance **always** starts on a tokenless URL. Against a server started with `--token` / `--token-file`, the install path the app itself advertises cannot authenticate at all.

### What this changes

- remembers the token under `agentdeck.authToken` when it arrives in the URL
- falls back to the remembered token when the URL has none
- lets a token in the URL win over the stored one, so re-opening a fresh `?token=` link **rotates** the credential rather than being ignored
- clears the stored token on an explicit 401, so a rotated or revoked token cannot wedge the app in a permanent 401 loop across reloads

`apiFetch` now carries `err.status`. That is what lets the caller tell *"the server rejected our credentials"* (401 — drop the token) apart from *"the server is unreachable"* (network error — the token is probably still fine). Without that distinction a simple server restart would silently log the user out.

### Why localStorage and not sessionStorage

sessionStorage is cleared when a standalone window closes, which is precisely the case this is meant to fix.

It also does not meaningfully widen exposure: the token already travels in a URL query string, which is more readily copied, shared and logged than an origin-scoped storage entry. The URL stripping and the `no-referrer` meta tag are both left exactly as they were.

Happy to switch this to sessionStorage, or to a server-set `HttpOnly` cookie, if you would rather — the cookie route would be strictly better but needs a server-side change and CSRF review, so I kept this one client-only and reversible.

### Verification

Built locally, server started with a token:

| step | result |
|---|---|
| open `/?token=...` | URL cleaned to `/`, token stored, board loads |
| reload `/` with no token in the URL | 100 sessions render, socket live — **before this change: an empty, 401ing app** |
| put a wrong token in storage, reload | cleared automatically, clean slate for the next `?token=` link |

`go test ./internal/web/...` passes, including `TestAppScriptsUseTheSharedAuthenticatedFetch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication tokens are now remembered between visits.
  * New login URLs automatically replace previously stored tokens.
  * Added an option to clear saved authentication credentials.

* **Bug Fixes**
  * Improved error reporting by including HTTP status codes.
  * Stored credentials are cleared when authentication expires.
  * Network failures no longer incorrectly appear as authentication errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->