### PR TITLE
fix(web): align the three column headers onto one line

### DIFF
--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -148,7 +148,11 @@ body[data-rail="hidden"] .rightrail { display: none; }
 
 /* ---------- sidebar ---------- */
 .sidebar { background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; }
-.side-head { display: flex; align-items: center; gap: 6px; padding: 10px 12px; border-bottom: 1px solid var(--border); }
+/* Column header. Shares --colhead-h with .work-head and .rail-head so the
+   three columns' header rules land on one line. Vertical padding is 8px, not
+   10px, because this header carries 30px icon buttons: at 10px its natural
+   height is 50.7px, i.e. taller than the shared strip. */
+.side-head { display: flex; align-items: center; gap: 6px; padding: 8px 12px; min-height: var(--colhead-h); border-bottom: 1px solid var(--border); }
 .side-head .label { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; color: var(--muted); }
 .side-head .count { font-family: var(--mono); font-size: 10.5px; color: var(--text-dim); }
 .side-head .spacer { flex: 1; }
@@ -299,7 +303,7 @@ body[data-rail="hidden"] .rightrail { display: none; }
   padding: 8px 14px;
   border-bottom: 1px solid var(--border);
   background: var(--panel);
-  min-height: 48px;
+  min-height: var(--colhead-h);
   flex-shrink: 0;
 }
 .work-head .path {
@@ -443,6 +447,10 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .rail-head {
   display: flex; align-items: center; gap: 6px;
   padding: 10px 12px;
+  /* Shares --colhead-h with .side-head and .work-head. This one holds only
+     text, so without the floor it renders 35.9px -- 12px shorter than the
+     work surface's header beside it. */
+  min-height: var(--colhead-h);
   border-bottom: 1px solid var(--border);
 }
 .rail-head .t { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; color: var(--muted); }

--- a/internal/web/static/app/design-tokens.css
+++ b/internal/web/static/app/design-tokens.css
@@ -167,6 +167,9 @@
   --footer-h:    26px;
   --sidebar-w:   300px;
   --rightrail-w: 340px;
+  /* Header strip at the top of each of the three columns (sidebar, work
+     surface, right rail). Shared so all three sit on one horizontal line. */
+  --colhead-h:   48px;
 
   /* === Density: row height + gap (override via [data-density]) === */
   --density-row: 30px;


### PR DESCRIPTION
Each of the three columns — sidebar, work surface, right rail — opens with its own header strip and a bottom border. The three strips are different heights, so the rule that should read as one horizontal line across the app is broken into three steps.

Measured at the top of each column, before this change:

| header | height | bottom edge |
|---|---|---|
| `.side-head` | 50.7px | y=94.7 |
| `.work-head` | 48.0px | y=92.0 |
| `.rail-head` | 35.9px | y=79.9 |

Three borders spread over ~15px, immediately below a topbar that spans the full width — so the misalignment sits right next to a straight edge, which is what makes it read as broken rather than deliberate.

### Cause

Only one of the three ever declared a height. `.work-head` sets `min-height: 48px`; the other two are content-driven and land wherever their contents put them:

- `.side-head` carries two 30px icon buttons → 30 + 2×10px padding + border = **50.7px**
- `.rail-head` holds a single line of 10.5px mono text → collapses to **35.9px**

### The fix

Promote that 48px into a shared token, `--colhead-h`, and apply it to all three headers.

`.side-head` also drops from 10px to 8px vertical padding. Its icon buttons put its natural height at 50.7px — *above* the shared strip — so a `min-height` alone cannot bring it down; without the trim it stays at 50.7px while the other two move to 48px.

`min-height` rather than `height`, so a header can still grow if its contents ever need more room instead of clipping them.

### Verification

Built locally and measured with `getBoundingClientRect()`:

- all three headers **48px**, top y=44, bottom y=92 — one continuous rule, **0px spread**
- no descendant of any of the three overflows its header
- the sidebar's icon buttons still measure 30px and remain fully visible

`go test ./internal/web/...` passes.
