### PR TITLE
fix(web): align topbar section dividers with the three columns below

### DIFF
--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -45,6 +45,12 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .topbar {
   display: flex;
   align-items: stretch;
+  /* The legacy sheet (styles.css, loaded before this one) sets
+     `padding: 0 16px` here. That inset shifts .top-brand 16px right of the
+     sidebar it sits above, so the topbar's section dividers no longer line up
+     with the three columns below. The sections carry their own padding, so
+     dropping this does not push content against the window edge. */
+  padding: 0;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
   z-index: 20;
@@ -113,8 +119,15 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .top-right {
   display: flex; align-items: center; gap: 6px;
   padding: 0 12px; border-left: 1px solid var(--border);
-  flex: 0 0 auto;
+  /* Match the right rail's width so this section's left border lands on the
+     same x as the rail's left edge. Sized by content it came out 292px against
+     the rail's 340px, putting the two dividers ~32px apart. .top-brand already
+     does the equivalent with `min-width: var(--sidebar-w)`. */
+  flex: 0 0 var(--rightrail-w);
+  justify-content: flex-end;
 }
+/* With the rail hidden there is no column to align to, so let it size itself. */
+body[data-rail="hidden"] .top-right { flex: 0 0 auto; }
 .top-mid { flex: 1 1 auto; min-width: 0; overflow: hidden; }
 .top-search { flex: 0 1 420px; min-width: 0; }
 @media (max-width: 1180px) {
@@ -938,7 +951,9 @@ body[data-rail="hidden"] .rightrail { display: none; }
   .top-mid { padding: 0 8px; gap: 6px; }
   .top-tabs { display: none; }
   .top-search { display: none; }
-  .top-right { padding: 0 8px; gap: 4px; }
+  /* The rail is display:none at this width, so there is no column to align to
+     — size this section by its content instead of reserving the rail's width. */
+  .top-right { padding: 0 8px; gap: 4px; flex: 0 0 auto; }
   .top-right select { display: none; }
 
   .work-head {


### PR DESCRIPTION
The topbar is split into three sections by vertical borders, sitting directly above the three columns — sidebar, work surface, right rail. The borders do not land on the same x as the column edges below them, so the app reads as two rows of dividers that do not line up.

Measured at a 1025px viewport, before this change:

| boundary | topbar divider | column edge | off by |
|---|---|---|---|
| sidebar ↔ work surface | x=316 | x=300 | **16px** |
| work surface ↔ right rail | x=717.1 | x=685.3 | **31.8px** |

### Two independent causes

**1. A legacy inset on `.topbar`.** `index.html` loads both stylesheet generations — `styles.css` first, then `app.css`. The legacy sheet still carries:

```css
.topbar { ... padding: 0 16px; ... }
```

That 16px shifts `.top-brand` right of the sidebar it sits above. The three sections each carry their own padding (`.top-brand` 14px, `.top-mid` 14px, `.top-right` 12px), so dropping the outer inset does not push content against the window edge.

**2. `.top-right` was content-sized.** `flex: 0 0 auto` put it at 292px against the rail's 340px. `.top-brand` already pins itself to its column with `min-width: var(--sidebar-w)`; this change does the equivalent on the other side with `flex: 0 0 var(--rightrail-w)`, so both dividers keep following their column if either width token changes.

### Where there is no column to align to

`.top-right` goes back to sizing itself in the two states where the rail is not on screen:

- `body[data-rail="hidden"]` — it shrinks to content and sits flush against the right edge
- the `max-width: 720px` breakpoint, where `.rightrail` is `display: none`

Without that second override the topbar would reserve 340px of a ≤720px window for four icon buttons.

### Note on `.top-tabs`

`.top-tabs` already overflows the topbar at ~1025px — a pre-existing clip (`.top-mid` has `overflow: hidden`, `.top-tabs` has `flex-wrap: nowrap`). Reclaiming the 16px of right padding **reduces** that overflow from 54.6px to 38.6px. This PR does not fix it, and does not make it worse.

### Verification

Built locally, measured with `getBoundingClientRect()`:

- **1025px** — both mismatches **0px**; no child of `.top-right` clipped (scrollWidth == clientWidth)
- **rail hidden** — `.top-right` back to 292.3px, right edge flush with the topbar, `.main` full width, left divider still 0px off
- **641px** — `flex-basis: auto`, nothing in the topbar overflows it

`go test ./internal/web/...` passes.
