### PR TITLE
fix(web): keep every topbar tab reachable at narrow widths

### DIFF
--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -95,8 +95,27 @@ body[data-rail="hidden"] .rightrail { display: none; }
 }
 .top-search .kbd { font-family: var(--mono); font-size: 10.5px; color: var(--muted); border: 1px solid var(--border); border-radius: 3px; padding: 1px 5px; }
 
-.top-tabs { display: flex; gap: 2px; margin-left: auto; flex: 0 0 auto; flex-wrap: nowrap; }
+.top-tabs {
+  display: flex; gap: 2px; margin-left: auto; flex-wrap: nowrap;
+  /* The strip needs ~700px for its ten tabs. `.top-mid` is what is left of the
+     row after the brand (300px) and the controls (~290px), so on anything short
+     of a wide desktop the strip is wider than its container. It sat in a parent
+     with `overflow: hidden` and no scroller of its own, so the tabs that did
+     not fit were simply clipped and unreachable — at 820px that left one tab of
+     ten usable.
+
+     `flex: 0 0 auto` is kept, so the search box still yields its width to the
+     tabs first. `max-width` is what clamps the box once even the whole row is
+     not enough, and that is what lets the scroller below engage. */
+  flex: 0 0 auto; min-width: 0; max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;          /* Firefox */
+  -ms-overflow-style: none;       /* old Edge */
+}
+.top-tabs::-webkit-scrollbar { display: none; }
 .top-tab {
+  flex: 0 0 auto;
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px; border-radius: var(--radius);
   font-size: 12px; color: var(--text-dim);
@@ -116,14 +135,22 @@ body[data-rail="hidden"] .rightrail { display: none; }
   flex: 0 0 auto;
 }
 .top-mid { flex: 1 1 auto; min-width: 0; overflow: hidden; }
-.top-search { flex: 0 1 420px; min-width: 0; }
+/* Stop the search box shrinking into an unusable stub — it was landing at 21px
+   wide at 1300px, taking room from the tab strip and being useless itself. It
+   is hidden outright below the width where both it and the tabs fit (below). */
+.top-search { flex: 0 1 420px; min-width: 160px; }
 @media (max-width: 1180px) {
   .top-tab .badge { display: none; }
   .top-tab span.lbl-long { display: none; }
   .top-search .kbd { display: none; }
 }
-@media (max-width: 1000px) {
+/* The search box and the tab strip share one row. Below this width there is not
+   enough for both, and the tabs are the navigation — the search is a duplicate
+   of the command palette, which stays available on every width. */
+@media (max-width: 1440px) {
   .top-search { display: none; }
+}
+@media (max-width: 1000px) {
   .top-tab { padding: 5px 7px; }
 }
 


### PR DESCRIPTION
The tab strip in the topbar is the app's navigation — Command Center, Fleet, Terminal, MCPs, Skills, Conductor, Watchers, Costs, Search, Archived. Below a wide desktop, most of those tabs are clipped and there is no way to reach them.

`.top-tabs` needs ~700px for its ten tabs. `.top-mid` only gets what is left of the row after the brand block (300px) and the controls (~290px). The strip was `flex: 0 0 auto` inside a parent with `overflow: hidden`, and had no scroller of its own — so the tabs that did not fit were simply painted outside the box and clipped.

Measured before this change:

| viewport | tabs reachable |
|---|---|
| 1101px | **5 of 10** |
| 821px | **1 of 10** |

A tablet in portrait can therefore only ever open Command Center.

### Changes

**1. The strip scrolls instead of clipping.** `max-width: 100%` plus `overflow-x: auto`, with the scrollbar hidden — it is a swipe target on the devices where it matters. `flex: 0 0 auto` is deliberately kept, so the search box still yields its width to the tabs first, exactly as before; the `max-width` is what clamps the box once even the whole row is not enough, and that is what lets the scroller engage. `scrollbar-width: none` means the scroller costs no height, so the topbar still measures the same.

**2. The search box no longer shrinks into a stub.** At 1300px it was landing **21px wide** — useless as a search box, and still taking room from the tabs. It now has `min-width: 160px` and is hidden below 1440px, which is the width where both it and the full strip fit. It duplicates the ⌘K command palette, which is available at every width.

### Verification

Built locally, measured with `getBoundingClientRect()`:

| viewport | result |
|---|---|
| 1601px | all 10 tabs visible, no scrolling, search 178px |
| 1501px | all 10 tabs visible, no scrolling, search at its 160px floor |
| 1301px | search hidden, strip scrolls, last tab (`Archived`) reachable |
| 821px | search hidden, strip scrolls, last tab reachable |
| 641px | mobile layout unchanged — strip hidden, bottom tabs |

Tab height unchanged at 28.7px; the scroller adds 0px to the topbar.

`go test ./internal/web/...` passes.

### Not addressed here

At tablet widths the strip is only ~145px of visible track, because the brand block still reserves the sidebar's 300px and the controls another ~290px. Scrolling makes every tab reachable, but a tablet-width treatment — moving the tabs to the bottom bar the way the ≤720px breakpoint already does, or collapsing them to icons — would be a better answer than a 145px scroller. That is a design call rather than a defect fix, so it is left out of this PR.
