### PR TITLE
docs(README): fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 If Agent Deck saves you time, give us a star! It helps others discover the project.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=asheshgoplani/agent-deck&type=Date)](https://star-history.com/#asheshgoplani/agent-deck&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=asheshgoplani/agent-deck&type=Date)](https://star-history.dera.page/#asheshgoplani/agent-deck&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart on the README is currently broken because it relies on a data source that has been cut off by GitHub stargazer API restrictions. This switches the chart to a working mirror so the project's star history renders correctly again.