### PR TITLE
fix(send): don't Ctrl+C-and-resend while the body is on screen (#1979)

### DIFF
--- a/cmd/agent-deck/issue1979_resend_after_arrival_test.go
+++ b/cmd/agent-deck/issue1979_resend_after_arrival_test.go
@@ -162,3 +162,30 @@ func TestResendSuppressedWhenPaneCannotBeRead(t *testing.T) {
 			"an unreadable pane is not evidence that the message is absent (#1979)", n)
 	}
 }
+
+// TestResendSuppressedForShortQueuedMessage covers messages below the delivery
+// token's 12-byte floor. messageDeliveryToken returns "" for those, so
+// bodyInPaneNow can never become true no matter what is on screen — which would
+// leave a short queued message ("OK") firing the very Ctrl+C-and-resend this
+// change exists to prevent. With no usable needle we cannot distinguish arrival
+// from absence, so the destructive branch must not fire.
+func TestResendSuppressedForShortQueuedMessage(t *testing.T) {
+	const msg = "OK"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{busyPaneWithBody(msg)},
+	}
+
+	_, _ = sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries: 25,
+		checkDelay: 0,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Errorf("SendCtrlC called %d times for a short queued message, want 0 — "+
+			"a body below the delivery-token floor is still a body (#1979)", n)
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n != 1 {
+		t.Errorf("SendKeysAndEnter called %d times, want exactly 1 — a short message was duplicated", n)
+	}
+}

--- a/cmd/agent-deck/issue1979_resend_after_arrival_test.go
+++ b/cmd/agent-deck/issue1979_resend_after_arrival_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Issue #1979: the Ctrl+C-then-resend recovery exists for a message lost during
+// TUI init, where nothing ever reached the pane. It fired on a different case
+// too — a target that is busy and has the message queued, whose working state
+// simply is not being observed — and there it interrupted the in-flight turn
+// and delivered the body a second time, at exit 0.
+//
+// #479 established that this path double-sends and disabled it for --no-wait
+// (noWaitSendOptions sets maxFullResends: -1). The verified path kept it.
+//
+// The distinguishing signal is already in the loop: the body appearing in the
+// pane is arrival evidence. Once arrival is observed, a resend cannot be a
+// recovery — it can only duplicate.
+
+// busyPaneWithBody is what a queued-but-unobserved target looks like: the body
+// is present above the composer rules, and the status never reads active.
+func busyPaneWithBody(msg string) string {
+	return strings.Join([]string{
+		"  ⎿  earlier output",
+		"❯ " + msg,
+		"────────────────────────────────────────",
+		"❯ Press up to edit queued messages",
+		"────────────────────────────────────────",
+	}, "\n")
+}
+
+// TestResendSuppressedOnceBodyHasArrived pins the fix: with the body already
+// visible, the loop must never Ctrl+C the target nor retype the message, no
+// matter how long it sits without an observable "active".
+func TestResendSuppressedOnceBodyHasArrived(t *testing.T) {
+	const msg = "PROBE reply with only OK"
+	pane := busyPaneWithBody(msg)
+
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{pane},
+	}
+
+	// Budget well past fullResendThreshold (8) so the resend has every chance.
+	_, _ = sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries: 25,
+		checkDelay: 0,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Errorf("SendCtrlC called %d times after the body had already arrived, want 0 — "+
+			"Ctrl+C interrupts whatever the target is doing (#1979)", n)
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n != 1 {
+		t.Errorf("SendKeysAndEnter called %d times, want exactly 1 — "+
+			"a resend after arrival duplicates the message (#1979, #479)", n)
+	}
+}
+
+// TestResendStillFiresWhenNothingArrived guards the other direction: the #876
+// TUI-init case, where the body never reached the pane, must still be
+// recovered. A fix that suppressed the resend unconditionally would break it.
+func TestResendStillFiresWhenNothingArrived(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{"❯ \n────────────────────────────────────────"}, // empty composer, no body
+	}
+
+	_, _ = sendWithRetryTarget(mock, "vanished message", false, sendRetryOptions{
+		maxRetries: 25,
+		checkDelay: 0,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n == 0 {
+		t.Error("SendCtrlC never called although nothing ever arrived — " +
+			"the #876 TUI-init recovery must survive the #1979 fix")
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n < 2 {
+		t.Errorf("SendKeysAndEnter called %d times, want >1 — the lost-message resend must still fire", n)
+	}
+}
+
+// composerHoldingBody is the first step of the TUI-init loss the resend exists
+// for: the keys land in the composer before the input handler is ready.
+func composerHoldingBody(msg string) string {
+	return strings.Join([]string{
+		"  earlier output",
+		"────────────────────────────────────────",
+		"❯ " + msg,
+		"────────────────────────────────────────",
+	}, "\n")
+}
+
+func emptyComposerPane() string {
+	return strings.Join([]string{
+		"  earlier output",
+		"────────────────────────────────────────",
+		"❯ ",
+		"────────────────────────────────────────",
+	}, "\n")
+}
+
+// TestResendStillFiresAfterComposerMarkerCleared is the regression guard for the
+// review finding on the first attempt at this fix. That attempt gated the resend
+// on sawDeliveryEvidence, which latches — and one of its sources is the composer
+// merely HOLDING the message, which is the opening step of the TUI-init loss
+// this recovery exists for. Gating on the latch therefore suppressed the resend
+// exactly when it was needed, losing the message; and because the same flag
+// suppresses the #876 error at the end of the budget, the loss was reported as
+// success. Gating on a per-iteration observation instead keeps the recovery.
+//
+// Marker first, then a cleared composer: nothing was ever submitted.
+func TestResendStillFiresAfterComposerMarkerCleared(t *testing.T) {
+	const msg = "recover me please"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{composerHoldingBody(msg), emptyComposerPane(), emptyComposerPane()},
+	}
+
+	_, _ = sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries: 25,
+		checkDelay: 0,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n == 0 {
+		t.Error("resend never fired after the composer marker cleared — the message " +
+			"landed in the composer, was discarded, and was not recovered (#876 regression)")
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n < 2 {
+		t.Errorf("SendKeysAndEnter called %d times, want >1 — the lost message was never re-sent", n)
+	}
+	// Note: on this path the call still returns success, both before and after
+	// this change, because the loop treats held-then-cleared as submission
+	// evidence. That is pre-existing and out of scope here; asserting on it
+	// would fail on base for a reason this change does not address.
+}
+
+// TestResendSuppressedWhenPaneCannotBeRead pins the capture-failure case. The
+// resend is destructive — it Ctrl+Cs the target — so it must require positive
+// evidence that nothing is on screen. A failed capture is not that evidence:
+// bodyInPaneNow is only assigned when the capture succeeded, so without the
+// paneNow.OK term it would read false by absence of an observation rather than
+// by an observation of absence, and an unreadable pane would re-authorize the
+// interrupt against a target that is working fine.
+func TestResendSuppressedWhenPaneCannotBeRead(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{""},
+		paneErrs: []error{errors.New("capture failed")},
+	}
+
+	_, _ = sendWithRetryTarget(mock, "some message", false, sendRetryOptions{
+		maxRetries: 25,
+		checkDelay: 0,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Errorf("SendCtrlC called %d times while the pane could not be read, want 0 — "+
+			"an unreadable pane is not evidence that the message is absent (#1979)", n)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3517,6 +3517,9 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		time.Sleep(opts.checkDelay)
 
 		unsentPromptDetected := false
+		// bodyInPaneNow is this iteration's answer to "is the body on screen
+		// right now", deliberately not latched. See the resend branch below.
+		bodyInPaneNow := false
 		// paneNow is this iteration's observation (raw ANSI + whether the
 		// capture succeeded at all), and is what the attribution gate reads.
 		captured, captureErr := target.CapturePaneFresh()
@@ -3524,6 +3527,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		if paneNow.OK {
 			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.ComposerHoldsPasteMarker(captured, tmux.StripANSI) || send.HasUnsentComposerPrompt(content, message)
+			bodyInPaneNow = deliveryToken != "" && strings.Contains(content, deliveryToken)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
 				sawDeliveryEvidence = true
 			}
@@ -3567,7 +3571,37 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// Message may have been lost during TUI init: the prompt was
 				// visible but the input handler wasn't ready, so sent keys were
 				// discarded. Clear stale input and re-send the full message.
-				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends {
+				//
+				// Only when nothing is there NOW. bodyInPaneNow is recomputed
+				// every iteration on purpose: "a resend would duplicate" is a
+				// claim about the present, and the latched sawDeliveryEvidence
+				// cannot carry it. That flag also latches on the composer
+				// merely HOLDING the message, which is the first step of the
+				// very TUI-init loss this recovery exists for — gating on it
+				// would suppress the recovery exactly when it is needed, and
+				// (because the same flag suppresses the #876 error at the end
+				// of the budget) report the lost message as delivered. Compare
+				// sawUnsentMarker, which is tracked separately for the same
+				// provenance reason. A recovery for a body that is on screen
+				// right now can only duplicate it. paneNow.OK is required for the
+				// same reason one level down: bodyInPaneNow is only assigned when
+				// the capture succeeded, so without this it would read false by
+				// ABSENCE of an observation rather than by an observation of
+				// absence, and a failed CapturePaneFresh would re-authorize the
+				// Ctrl+C against a target that is working fine. A destructive
+				// branch should need positive evidence, not silence. Meanwhile
+				// the
+				// Ctrl+C that precedes it interrupts whatever the target is
+				// doing. That is #1979: a busy target with the message queued
+				// and a target that never received it both fail to report
+				// "active" — they are indistinguishable BY STATUS ALONE, which is
+				// why this reaches for pane evidence instead. This branch fired
+				// on the busy target and destroyed in-flight
+				// work at exit 0. #479 established the same double-send on the
+				// --no-wait path, which noWaitSendOptions disables outright;
+				// this keeps the recovery for the case it was written for.
+				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends &&
+					paneNow.OK && !bodyInPaneNow {
 					// The resend types the message and presses Enter, so it
 					// submits whatever the composer still holds. Ctrl+C is
 					// meant to empty it first — but a failed Ctrl+C, or one

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3504,6 +3504,18 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	// Take the first run of non-whitespace content, capped, to avoid false
 	// positives from matching common short strings.
 	deliveryToken := messageDeliveryToken(message)
+	// presenceNeedle answers "is this message on screen", which is a different
+	// question from deliveryToken's "is this a distinctive enough string to
+	// treat as proof of delivery". The token is empty below 12 bytes, so
+	// without a fallback a short queued message like "OK" would read as absent
+	// forever and take the Ctrl+C-and-resend this guard exists to prevent.
+	// Falling back to the trimmed body can over-match a common short string,
+	// but the consequence is declining to interrupt a live target, which is the
+	// safe direction: such a message still surfaces via the #876 check.
+	presenceNeedle := deliveryToken
+	if presenceNeedle == "" {
+		presenceNeedle = strings.TrimSpace(message)
+	}
 	// attrib is the #1777 attribution gate. EVERY bare Enter in this loop —
 	// including the unsent-prompt branch, which used to press unconditionally
 	// whenever a "[Pasted text …]" marker appeared anywhere in the pane —
@@ -3527,7 +3539,7 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		if paneNow.OK {
 			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.ComposerHoldsPasteMarker(captured, tmux.StripANSI) || send.HasUnsentComposerPrompt(content, message)
-			bodyInPaneNow = deliveryToken != "" && strings.Contains(content, deliveryToken)
+			bodyInPaneNow = presenceNeedle != "" && strings.Contains(content, presenceNeedle)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
 				sawDeliveryEvidence = true
 			}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3584,34 +3584,41 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// visible but the input handler wasn't ready, so sent keys were
 				// discarded. Clear stale input and re-send the full message.
 				//
-				// Only when nothing is there NOW. bodyInPaneNow is recomputed
-				// every iteration on purpose: "a resend would duplicate" is a
-				// claim about the present, and the latched sawDeliveryEvidence
-				// cannot carry it. That flag also latches on the composer
-				// merely HOLDING the message, which is the first step of the
-				// very TUI-init loss this recovery exists for — gating on it
-				// would suppress the recovery exactly when it is needed, and
-				// (because the same flag suppresses the #876 error at the end
-				// of the budget) report the lost message as delivered. Compare
+				// THE GATE: fire only when the body is not on screen right now.
+				// A recovery for a body that is already there can only
+				// duplicate it, and the Ctrl+C that precedes it interrupts
+				// whatever the target is doing meanwhile. bodyInPaneNow is
+				// recomputed every iteration on purpose: "a resend would
+				// duplicate" is a claim about the present, so it needs a
+				// present-tense signal.
+				//
+				// NOT sawDeliveryEvidence, which is the obvious candidate and
+				// is wrong. It latches, and one of its sources is the composer
+				// merely HOLDING the message — the first step of the very
+				// TUI-init loss this recovery exists for. Gating on it would
+				// suppress the recovery exactly when it is needed and then,
+				// because the same flag suppresses the #876 error at the end of
+				// the budget, report the lost message as delivered. Compare
 				// sawUnsentMarker, which is tracked separately for the same
-				// provenance reason. A recovery for a body that is on screen
-				// right now can only duplicate it. paneNow.OK is required for the
-				// same reason one level down: bodyInPaneNow is only assigned when
-				// the capture succeeded, so without this it would read false by
-				// ABSENCE of an observation rather than by an observation of
-				// absence, and a failed CapturePaneFresh would re-authorize the
-				// Ctrl+C against a target that is working fine. A destructive
-				// branch should need positive evidence, not silence. Meanwhile
-				// the
-				// Ctrl+C that precedes it interrupts whatever the target is
-				// doing. That is #1979: a busy target with the message queued
-				// and a target that never received it both fail to report
-				// "active" — they are indistinguishable BY STATUS ALONE, which is
-				// why this reaches for pane evidence instead. This branch fired
-				// on the busy target and destroyed in-flight
-				// work at exit 0. #479 established the same double-send on the
-				// --no-wait path, which noWaitSendOptions disables outright;
-				// this keeps the recovery for the case it was written for.
+				// provenance reason.
+				//
+				// paneNow.OK is required for a related reason one level down:
+				// bodyInPaneNow is only assigned when the capture succeeded, so
+				// without it the gate would read false by ABSENCE of an
+				// observation rather than by an observation of absence, and a
+				// failed CapturePaneFresh would re-authorize the Ctrl+C against
+				// a target that is working fine. A destructive branch should
+				// need positive evidence, not silence.
+				//
+				// History: #1979 is the busy target with the message already
+				// queued. It and a target that never received the message both
+				// fail to report "active" — they are indistinguishable BY
+				// STATUS ALONE, which is why this reaches for pane evidence
+				// instead. Ungated, the branch fired on the busy one and
+				// destroyed in-flight work at exit 0. #479 established the same
+				// double-send on the --no-wait path, which noWaitSendOptions
+				// disables outright; this keeps the recovery for the case it was
+				// written for.
 				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends &&
 					paneNow.OK && !bodyInPaneNow {
 					// The resend types the message and presses Enter, so it


### PR DESCRIPTION
## What problem does this solve?

`session send` to a target that is busy interrupts the work in progress and
delivers the message twice, while exiting 0. Fixes #1979.

## Why this change

The Ctrl+C-then-resend recovery exists for a message lost during TUI init — the
prompt was visible but the input handler was not ready, the keys were discarded,
and nothing reached the pane. It fires after 8 consecutive checks with no
observed activity and no unsent-prompt marker.

A target that is busy with the message already queued looks identical at that
point: it does not report `active` either. So the recovery fires on it, and
there it is the damage rather than the repair — the `Ctrl+C` interrupts the
in-flight turn, and the resend puts a second copy of the body in. A
work-triggering message runs twice, and the caller sees exit 0 for both.

#479 established that this path double-sends and disabled it for `--no-wait`;
`noWaitSendOptions()` sets `maxFullResends: -1` with a comment saying so. The
verified path kept `maxFullResends = 3`.

Gate the resend on a per-iteration observation of whether the body is on screen
*right now*. "A resend would duplicate" is a claim about the present, so it
needs a present-tense signal.

Notably **not** `sawDeliveryEvidence`, which is the obvious candidate and is
wrong. It latches, and one of its three sources is the composer merely *holding*
the message — which is the opening step of the very TUI-init loss this recovery
exists for. Gating on it plays out as:

1. Keys land in the composer during init → marker seen → flag latched true.
2. Init completes and discards the composer contents. Nothing was submitted.
3. Status stays `waiting`, the no-activity count climbs to the threshold.
4. The resend is suppressed, because the flag remembers a composer state from
   several checks earlier. **The message is lost.**
5. At the end of the budget the same latched flag suppresses the #876 error, so
   the loss is reported as **success**.

That is strictly worse than the bug being fixed, so the fix uses a separate
non-latching signal and leaves `sawDeliveryEvidence` alone — it is load-bearing
for the #876 check. There is in-tree precedent for exactly this
provenance-sensitivity: `sawUnsentMarker` is tracked separately, and the loop
already notes where it "intentionally do[es] NOT set `sawDeliveryEvidence`".

Worth noting why gating on present-tense arrival is safe: while the composer
marker is live, that branch resets the no-activity counter and continues, so the
resend cannot fire in that state at all — a swallowed Enter is handled by
`NudgeEnter`, not by Ctrl+C-and-resend. Only the *memory* of the marker was
doing harm.

I kept this to the one condition rather than disabling the path on the verified
side as well, so the TUI-init recovery keeps working.

### Presence is a different question from proof of delivery

Review caught a hole in the first version of the guard: `messageDeliveryToken`
returns `""` below 12 bytes, so a short queued message like `OK` read as absent
no matter what was on screen and still took the Ctrl+C and the duplicate — the
exact case the change exists to prevent.

Requiring a nonempty token before the resend fixes that case and breaks the
other direction: it suppresses recovery for *every* short message, which failed
two existing tests that send `"hello"` into an empty pane and rightly expect the
resend.

So the two questions the token was being asked to answer are now separate:

- `deliveryToken` — "is this string distinctive enough to treat as proof of
  delivery" — keeps its 12-byte floor and its existing role as the pane source
  of `sawDeliveryEvidence`.
- `presenceNeedle` — "is this message on screen right now" — falls back to the
  trimmed body when the token is empty, and feeds only the resend gate.

Over-matching a common short string can then only make us *decline to interrupt*
a live target, which is the safe direction.

### Known limitation

The gate uses "the body is on screen right now" as a proxy for "a resend would
duplicate". That holds wherever the composer state is observable: while the
composer is holding the message, the loop takes the unsent-prompt branch, resets
the no-activity counter and nudges Enter, so the resend cannot fire there
anyway.

Where it would not hold is a TUI whose composer markers do not fire at all,
leaving an *unsent* body visible on screen. In that state this change would also
suppress the resend, where before it would eventually retype and submit. I have
not observed that case — in every capture taken while investigating, a visible
body came with the agent already working — so this is a reasoned boundary rather
than a reproduced one. It is also the same underlying problem as #1978: per-tool
pane heuristics do not generalise, and a submission signal that did not depend on
them would remove this proxy entirely.

Capture failures are treated as "no evidence" rather than "no body": the resend
requires a successful capture that shows nothing, because an unreadable pane is
not grounds for interrupting a target that may be working fine.

Two further boundaries, both raised in review and confirmed by measurement
rather than argued (probe details under Evidence):

**Busy target with the body not visible still reaches the Ctrl+C.** The gate
tests arrival, not busy-ness, and `CapturePaneFresh` runs `capture-pane -p -e`
with no `-S`, so it sees the visible pane only. Once the body scrolls above the
top line the gate reads absent, and a target streaming output can push it off a
short pane inside the 8-check / 300ms budget. This is a narrower version of the
same defect — with the body on screen it is now closed — and closing the rest
means teaching the default loop to read the hook-driven status that
`--defer-if-busy` already polls, which is a change to the loop's signal source
rather than to this guard. Identified by @asheshgoplani, who is staging that as
a follow-up; not widened here.

**For a short message, suppressing the resend can turn a loss silent in one
compound case.** The direct worry — the strict token being empty leaves #876 as
the only net — does not hold: `sawDeliveryEvidence`'s pane source still requires
the nonempty token, so a lost short message whose body only coincidentally
appears on screen still exits nonzero as `no_evidence`. The case that does bite
needs all three of: message under 12 bytes, the composer observed *holding* it
and then clearing (which latches `sawUnsentMarker`, and held-then-cleared is
read as submission), and the trimmed body still matching somewhere in the
visible pane. Before the fallback the resend fired there; with it the send
returns `submitted` at exit 0 with nothing delivered. The same compound is
reachable for long messages too — where the presence read at least rests on the
distinctive token — so the exit-0 verdict itself comes from the held-then-cleared
rule, not from this fallback; the fallback only lets the presence half of it rest
on a coincidence. Left alone deliberately: the verdict logic is #1793/#1978
territory.

## User impact

Sending to a busy session no longer interrupts what it is doing, and no longer
delivers the message twice. Sends to a target that genuinely never received the
message are unaffected — that recovery still runs.

## Evidence

Reproduction on the default path, before the change: one `session send` to a
mid-turn target, exit 0, and the pane showed the turn interrupted with the body
present twice — one copy submitted and running, one queued.

```
  ⎿  Interrupted · What should Claude do instead?
❯ PROBE reply with only OK          <- copy 1, submitted
  ❯ PROBE reply with only OK        <- copy 2, queued
❯ Press up to edit queued messages
```

The same send on `--no-wait`, where #479 already disabled the path, produced one
copy, queued cleanly, with the turn untouched. That A/B is what identified the
path split; it was independently reproduced by a second person on a different
machine.

Tests use the existing `mockSendRetryTarget`. Each fails where it should:

| | base (no fix) | latched-flag version | this change |
|---|---|---|---|
| `TestResendSuppressedOnceBodyHasArrived` | **FAIL** | pass | pass |
| `TestResendStillFiresAfterComposerMarkerCleared` | pass | **FAIL** | pass |
| `TestResendStillFiresWhenNothingArrived` | pass | pass | pass |
| `TestResendSuppressedWhenPaneCannotBeRead` | **FAIL** | pass | pass |
| `TestResendSuppressedForShortQueuedMessage` | **FAIL** | **FAIL** | pass |

The first is the defect being fixed. The second is the regression described
above — it is why the fix does not gate on `sawDeliveryEvidence`. The third
guards against a fix that disabled the resend outright. The last is the
short-message hole; it fails on base and against the token-only version with
`SendCtrlC called 18 times for a short queued message, want 0`.

The interrupt count is worth stating plainly: it is 18 per send, not one.
`SendCtrlC()` runs *before* the resend budget is consumed and the
`EnterWouldSubmitForeignDraft` abort path `continue`s without charging it, so
while the composer keeps reading as foreign the budget is never spent and the
interrupt repeats on every check.

Probes for the two review questions under Known limitation, run against
`mockSendRetryTarget` with `verifyDelivery: true` and a 25-check budget
(throwaway tests, not committed — they characterise current behaviour rather
than pin it):

| scenario | verdict | Ctrl+C | resends |
|---|---|---|---|
| short msg lost, body only coincidentally on screen | `no_evidence` + error | 0 | 0 |
| short msg held-then-cleared, body coincidentally on screen | `submitted`, exit 0 | 0 | 0 |
| ...same, with the `presenceNeedle` fallback removed | `submitted`, exit 0 | 3 | 3 |
| long msg held-then-cleared, body still on screen | `submitted`, exit 0 | 0 | 0 |

Row 1 is the answer to "is #876 still the net for a short message": yes. Rows
2-4 are the compound case and show the fallback moves the presence half of it,
while the exit-0 verdict comes from the held-then-cleared rule that applies at
any length.

Full `./cmd/agent-deck` package suite passes (95s). gofmt and vet clean.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):**

## What actually bothered you

We drive agent sessions from scripts, and a send to a session that was busy kept
interrupting whatever it was doing and running the same instruction twice, with
the CLI reporting success both times. Losing an agent's in-flight work to a
routine status ping is bad; silently running a work-triggering instruction twice
is worse, because nothing in the exit code tells you it happened.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- Hot-path box left unchecked: this adds one boolean to an existing condition on the send verification path. No hot path is touched and there is nothing meaningful to time. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message delivery verification to prevent duplicate resends when a message is already visible.
  * Preserved recovery behavior when messages are not detected or composer indicators are cleared.
  * Added safeguards to avoid resending when pane capture is unsuccessful or messages lack a distinctive delivery token.
  * Improved handling of short messages and interruptions during message submission and retry attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
