### PR TITLE
fix(codex): quote configured CODEX_HOME on launch

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2236,7 +2236,7 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 				slog.String("path", codexHome),
 				slog.String("error", err.Error()))
 		}
-		envPrefix += "CODEX_HOME=" + codexHome + " "
+		envPrefix += "CODEX_HOME=" + shellescape.Quote(codexHome) + " "
 	}
 
 	yoloFlag := i.resolveCodexYoloFlag()

--- a/internal/session/issue1946_codex_home_quote_test.go
+++ b/internal/session/issue1946_codex_home_quote_test.go
@@ -1,0 +1,41 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #1946: buildCodexCommand exported CODEX_HOME without shell-quoting it. A
+// configured home containing a space was split into an assignment plus a bogus
+// command, so Codex never started under the home selected by the resume gate.
+func TestIssue1946_CodexHomeWithSpaceSurvivesShell(t *testing.T) {
+	home := withTempHome(t)
+	t.Setenv("CODEX_HOME", "")
+
+	codexHome := filepath.Join(home, "codex config")
+	cfg := &UserConfig{Codex: CodexSettings{ConfigDir: codexHome}}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	binDir := t.TempDir()
+	fakeCodex := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(fakeCodex, []byte("#!/bin/sh\nprintf '%s' \"$CODEX_HOME\"\n"), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	inst := &Instance{ID: "i1946", Title: "space-home", Tool: "codex", Command: "codex"}
+	command := inst.buildCodexCommand("codex")
+	out, err := exec.Command("sh", "-c", command).CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute generated Codex command: %v\ncommand: %s\noutput: %s", err, command, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != codexHome {
+		t.Fatalf("CODEX_HOME seen by Codex = %q, want %q\ncommand: %s", got, codexHome, command)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

When `[codex].config_dir` or an account-specific Codex config directory contains a space, the normal launch command splits `CODEX_HOME` and tries to execute the remainder of the path as a command. Codex therefore does not start under the home selected by the resume gate. Fixes #1946.

## Why this change

The fork launch path already protects the same value with `shellescape.Quote`. This applies that existing rule to the normal launch path and adds an execution-level regression test that runs the generated command against a fake `codex` binary.

The `sh -c` call is test-only and uses fixed test data; production gains no new command execution path.

## User impact

Codex sessions now launch with the configured `CODEX_HOME` when its path contains spaces. Paths without spaces and non-Codex tools are unchanged.

## Evidence

Reproduction on upstream `main` (`f4af88d3`), using the new execution-level test before the production change:

    command: ... CODEX_HOME=/var/.../codex config codex
    output: sh: config: command not found
    --- FAIL: TestIssue1946_CodexHomeWithSpaceSurvivesShell

After the change:

    === RUN   TestIssue1946_CodexHomeWithSpaceSurvivesShell
    --- PASS: TestIssue1946_CodexHomeWithSpaceSurvivesShell

Related Codex home/resume/fork regression tests: 11 PASS.

    go test ./internal/session -count=1
    ok  github.com/asheshgoplani/agent-deck/internal/session  141.484s

`go vet ./...`, `go build ./...`, and `golangci-lint run` all pass (`0 issues`).

The full sandboxed suite was also run. It is not green on this macOS host: the pristine baseline already fails in tmux/testutil/web around temporary-path aliases, socket length, bootstrap cleanup, and keepalive timing; the branch also hit the existing 40 ms cold-start budget at 40.18 ms/42.01 ms. The touched `internal/session` package is green, and no startup/tmux/web code changed.

Revert-check: before applying the one-line production fix, the new test fails with `sh: config: command not found`; with the fix it passes.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** OpenAI Codex; exact runtime model ID unavailable (`unsure`)

**Prompt / session log (optional):** —

## What actually bothered you

The maintainer reported: "A codex config directory whose path contains a space splits at the space when unquoted." Lee asked me to select the highest-probability accepted issue and produce a real, verifiable upstream PR.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=unsure intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex startup when its configured home path contains spaces or special shell characters.
  * Codex now correctly uses the selected configuration directory without misinterpreting the path.

* **Tests**
  * Added regression coverage to verify Codex starts successfully with paths containing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->