### PR TITLE
fix(session): use per-session custom command on resume

### DIFF
--- a/internal/session/conductorconfig_test.go
+++ b/internal/session/conductorconfig_test.go
@@ -487,19 +487,26 @@ config_dir = %q
 }
 
 // TestBuildClaudeResumeCommand_CustomCommand verifies that a per-session
-// custom command (i.Command from `launch -c <wrapper>`) is used on the
-// resume path, not the literal "claude" binary. Also checks that the
-// CLAUDE_CONFIG_DIR export IS present for a per-session custom command
-// (the F3 gate does not apply), while a config-level alias suppresses it.
+// custom command (i.Command from `launch -c <wrapper>`) is used on the resume
+// path, not the literal "claude" binary. The first case pins the actual F3
+// gate delta this PR introduces: when BOTH a per-session custom command AND a
+// config-level alias are present, the per-session command overrides the alias
+// AND the CLAUDE_CONFIG_DIR export is present (before this PR, the alias
+// suppressed the export). The second case confirms a config-level alias with
+// the default Command still suppresses the export.
 func TestBuildClaudeResumeCommand_CustomCommand(t *testing.T) {
 	tmpHome := setupConductorTest(t)
 	configDir := filepath.Join(tmpHome, "claude-config")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
+	// Config carries BOTH a config_dir and a config-level alias (cdw). This
+	// is the combination the F3 gate delta turns on: the per-session custom
+	// command must override the alias and still export CLAUDE_CONFIG_DIR.
 	writeConductorConfig(t, tmpHome, fmt.Sprintf(`
 [conductors.foo.claude]
 config_dir = %q
+command = "cdw"
 `, configDir))
 	projectPath := filepath.Join(tmpHome, "project")
 	if err := os.MkdirAll(projectPath, 0o755); err != nil {
@@ -519,7 +526,10 @@ config_dir = %q
 		t.Fatalf("write jsonl: %v", err)
 	}
 
-	// --- Per-session custom command: used on resume, CLAUDE_CONFIG_DIR exported ---
+	// --- Case 1: per-session custom command overrides config-level alias ---
+	// Before this PR: claudeCmd resolved to "cdw" (alias), F3 gate suppressed
+	// the export. After: claudeCmd = i.Command, F3 gate does not apply, export
+	// is present. This is the delta the PR deliberately introduces.
 	inst := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
 	inst.ClaudeSessionID = sessionID
 	inst.Command = "/tmp/wrapper.sh"
@@ -528,8 +538,8 @@ config_dir = %q
 	if !strings.Contains(cmd, "/tmp/wrapper.sh") {
 		t.Errorf("resume should use per-session custom command /tmp/wrapper.sh; got %q", cmd)
 	}
-	if strings.Contains(cmd, " claude ") || strings.HasSuffix(cmd, " claude") {
-		t.Errorf("resume should not use literal claude binary; got %q", cmd)
+	if strings.Contains(cmd, "cdw") {
+		t.Errorf("per-session custom command must override config-level alias cdw; got %q", cmd)
 	}
 	// F3 gate does not apply for per-session custom commands — the export
 	// should be present, matching buildClaudeCommandWithMessage's custom branch.
@@ -541,15 +551,10 @@ config_dir = %q
 		t.Errorf("resume should contain --resume %s; got %q", sessionID, cmd)
 	}
 
-	// --- Config-level alias: used on resume, CLAUDE_CONFIG_DIR suppressed ---
-	writeConductorConfig(t, tmpHome, fmt.Sprintf(`
-[conductors.foo.claude]
-config_dir = %q
-command = "cdw"
-`, configDir))
+	// --- Case 2: config-level alias with default Command suppresses export ---
 	inst2 := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
 	inst2.ClaudeSessionID = sessionID
-	inst2.Command = "claude" // default command — exercises the config-level alias path
+	inst2.Command = "claude" // default — exercises the config-level alias path
 
 	cmd2 := inst2.buildClaudeResumeCommand()
 	if !strings.Contains(cmd2, "cdw") {

--- a/internal/session/conductorconfig_test.go
+++ b/internal/session/conductorconfig_test.go
@@ -493,10 +493,14 @@ config_dir = %q
 // (the F3 gate does not apply), while a config-level alias suppresses it.
 func TestBuildClaudeResumeCommand_CustomCommand(t *testing.T) {
 	tmpHome := setupConductorTest(t)
-	writeConductorConfig(t, tmpHome, `
+	configDir := filepath.Join(tmpHome, "claude-config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	writeConductorConfig(t, tmpHome, fmt.Sprintf(`
 [conductors.foo.claude]
-config_dir = "/tmp/x"
-`)
+config_dir = %q
+`, configDir))
 	projectPath := filepath.Join(tmpHome, "project")
 	if err := os.MkdirAll(projectPath, 0o755); err != nil {
 		t.Fatalf("mkdir project: %v", err)
@@ -505,7 +509,7 @@ config_dir = "/tmp/x"
 
 	// JSONL with conversation data so --resume (not --session-id) is used.
 	encoded := ConvertToClaudeDirName(projectPath)
-	projectsDir := filepath.Join("/tmp/x", "projects", encoded)
+	projectsDir := filepath.Join(configDir, "projects", encoded)
 	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
 		t.Fatalf("mkdir projects dir: %v", err)
 	}
@@ -529,22 +533,23 @@ config_dir = "/tmp/x"
 	}
 	// F3 gate does not apply for per-session custom commands — the export
 	// should be present, matching buildClaudeCommandWithMessage's custom branch.
-	if !strings.Contains(cmd, "export CLAUDE_CONFIG_DIR=/tmp/x;") {
-		t.Errorf("resume with per-session custom command should export CLAUDE_CONFIG_DIR; got %q", cmd)
+	expectedExport := "export CLAUDE_CONFIG_DIR=" + configDir + ";"
+	if !strings.Contains(cmd, expectedExport) {
+		t.Errorf("resume with per-session custom command should export %q; got %q", expectedExport, cmd)
 	}
 	if !strings.Contains(cmd, "--resume "+sessionID) {
 		t.Errorf("resume should contain --resume %s; got %q", sessionID, cmd)
 	}
 
 	// --- Config-level alias: used on resume, CLAUDE_CONFIG_DIR suppressed ---
-	writeConductorConfig(t, tmpHome, `
+	writeConductorConfig(t, tmpHome, fmt.Sprintf(`
 [conductors.foo.claude]
-config_dir = "/tmp/x"
+config_dir = %q
 command = "cdw"
-`)
+`, configDir))
 	inst2 := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
 	inst2.ClaudeSessionID = sessionID
-	inst2.Command = "" // no per-session custom command
+	inst2.Command = "claude" // default command — exercises the config-level alias path
 
 	cmd2 := inst2.buildClaudeResumeCommand()
 	if !strings.Contains(cmd2, "cdw") {

--- a/internal/session/conductorconfig_test.go
+++ b/internal/session/conductorconfig_test.go
@@ -485,3 +485,74 @@ config_dir = %q
 		t.Errorf("buildClaudeResumeCommand must NOT contain %q when history exists at per-instance config_dir; got %q", sessionIDFlag, cmd)
 	}
 }
+
+// TestBuildClaudeResumeCommand_CustomCommand verifies that a per-session
+// custom command (i.Command from `launch -c <wrapper>`) is used on the
+// resume path, not the literal "claude" binary. Also checks that the
+// CLAUDE_CONFIG_DIR export IS present for a per-session custom command
+// (the F3 gate does not apply), while a config-level alias suppresses it.
+func TestBuildClaudeResumeCommand_CustomCommand(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+	writeConductorConfig(t, tmpHome, `
+[conductors.foo.claude]
+config_dir = "/tmp/x"
+`)
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	sessionID := "d4bdd524-210c-47f9-a505-9bc49969e278"
+
+	// JSONL with conversation data so --resume (not --session-id) is used.
+	encoded := ConvertToClaudeDirName(projectPath)
+	projectsDir := filepath.Join("/tmp/x", "projects", encoded)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+	jsonl := filepath.Join(projectsDir, sessionID+".jsonl")
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(jsonl, []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	// --- Per-session custom command: used on resume, CLAUDE_CONFIG_DIR exported ---
+	inst := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
+	inst.ClaudeSessionID = sessionID
+	inst.Command = "/tmp/wrapper.sh"
+
+	cmd := inst.buildClaudeResumeCommand()
+	if !strings.Contains(cmd, "/tmp/wrapper.sh") {
+		t.Errorf("resume should use per-session custom command /tmp/wrapper.sh; got %q", cmd)
+	}
+	if strings.Contains(cmd, " claude ") || strings.HasSuffix(cmd, " claude") {
+		t.Errorf("resume should not use literal claude binary; got %q", cmd)
+	}
+	// F3 gate does not apply for per-session custom commands — the export
+	// should be present, matching buildClaudeCommandWithMessage's custom branch.
+	if !strings.Contains(cmd, "export CLAUDE_CONFIG_DIR=/tmp/x;") {
+		t.Errorf("resume with per-session custom command should export CLAUDE_CONFIG_DIR; got %q", cmd)
+	}
+	if !strings.Contains(cmd, "--resume "+sessionID) {
+		t.Errorf("resume should contain --resume %s; got %q", sessionID, cmd)
+	}
+
+	// --- Config-level alias: used on resume, CLAUDE_CONFIG_DIR suppressed ---
+	writeConductorConfig(t, tmpHome, `
+[conductors.foo.claude]
+config_dir = "/tmp/x"
+command = "cdw"
+`)
+	inst2 := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
+	inst2.ClaudeSessionID = sessionID
+	inst2.Command = "" // no per-session custom command
+
+	cmd2 := inst2.buildClaudeResumeCommand()
+	if !strings.Contains(cmd2, "cdw") {
+		t.Errorf("resume should use config-level alias cdw; got %q", cmd2)
+	}
+	// F3 gate applies for config-level aliases — CLAUDE_CONFIG_DIR should
+	// NOT be exported (the alias handles it itself).
+	if strings.Contains(cmd2, "export CLAUDE_CONFIG_DIR") {
+		t.Errorf("resume with config-level alias should NOT export CLAUDE_CONFIG_DIR; got %q", cmd2)
+	}
+}

--- a/internal/session/fork_start_dispatch_test.go
+++ b/internal/session/fork_start_dispatch_test.go
@@ -134,6 +134,46 @@ func startDispatchHonorsForkSentinel() bool {
 	return earlyIdx[0] < resumeIdx[0]
 }
 
+// TestRegression_ForkSecondStartDoesNotReuseForkCommandAsCustomCommand pins the
+// review finding on PR #1984: buildClaudeResumeCommand's per-session custom
+// command precedence (i.Command != "" && i.Command != "claude") also fires on a
+// fork target's SECOND start. CreateForkedInstanceWithOptions stores the whole
+// pre-built fork command in Command:
+//
+//	cd '<path>' && export ...; exec claude --session-id "<fork-uuid>" --resume <parent-id> --fork-session ...
+//
+// and IsForkAwaitingStart (the sentinel that routes the first start around
+// buildClaudeResumeCommand) is transient (json:"-"), so it is gone after the
+// first Start(). A subsequent Restart() takes the normal resume path, where the
+// compound string is mistaken for a per-session custom command and spliced in
+// as the claude binary. The parent's id and --fork-session come back
+// (double-counting the parent conversation) and the pane dies with
+// `exec: cd: not found` (exit 127) because the string starts with `exec cd`.
+// This is the same shape as the #1830 finding, one path over.
+//
+// Setup mirrors the first Start(): consumeForkStartCommand clears
+// IsForkAwaitingStart but leaves Command holding the compound string on disk.
+func TestRegression_ForkSecondStartDoesNotReuseForkCommandAsCustomCommand(t *testing.T) {
+	parent := NewInstanceWithTool("parent", "/tmp", "claude")
+	parent.ClaudeSessionID = "parent-abc-123"
+	parent.ClaudeDetectedAt = time.Now()
+
+	forked, _, err := parent.CreateForkedInstance("forked-second-start", "")
+	require.NoError(t, err, "CreateForkedInstance should succeed")
+
+	// Simulate the first Start() consuming the sentinel: IsForkAwaitingStart
+	// is cleared (transient, not persisted) but Command retains the compound
+	// fork string — the on-disk shape a Restart() sees.
+	forked.IsForkAwaitingStart = false
+
+	cmd := forked.buildClaudeResumeCommand()
+
+	require.NotContains(t, cmd, "--fork-session",
+		"second start of a forked session must not re-emit --fork-session (double-counts the parent conversation)")
+	require.NotContains(t, cmd, "parent-abc-123",
+		"second start of a forked session must not re-reference the parent's conversation id")
+}
+
 func TestCodexForkStartDispatchConsumesAwaitingStart(t *testing.T) {
 	requireCodexForkStartGuard(t, "Start")
 	requireCodexForkStartGuard(t, "StartWithMessage")

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8987,8 +8987,24 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// GetClaudeCommandForInstance never sees (see its doc comment). Without
 	// this, resume falls back to the literal "claude" binary and bypasses
 	// the wrapper script that sets up gateway env vars.
+	//
+	// The --fork-session / --session-id exclusions reuse the same predicate
+	// adoptExplicitClaudeSessionID uses for the same discrimination: a fork
+	// target's Command holds the whole compound fork command (cd '<path>' &&
+	// ... exec claude --session-id "<uuid>" --resume <parent-id> --fork-session)
+	// baked by buildClaudeForkCommandForTarget and persisted to disk. The
+	// IsForkAwaitingStart sentinel that routes the first Start() around this
+	// function is transient (json:"-"), so it is gone after the first start —
+	// a subsequent Restart() reaches here with that compound string in Command.
+	// Treating it as a custom command splices it in as the claude binary:
+	// --fork-session and the parent's id come back (double-counting the parent
+	// conversation) and the pane dies with `exec: cd: not found` (exit 127)
+	// because the string starts with `exec cd`. Same shape as the #1830
+	// finding, one path over.
 	claudeCmd := GetClaudeCommandForInstance(i)
-	customCommand := i.Command != "" && i.Command != "claude"
+	customCommand := i.Command != "" && i.Command != "claude" &&
+		!commandHasToken(i.Command, "--fork-session") &&
+		!commandHasToken(i.Command, "--session-id")
 	if customCommand {
 		claudeCmd = i.Command
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8981,16 +8981,28 @@ func (i *Instance) buildClaudeResumeCommand() string {
 
 	// Get the configured Claude command (e.g., "claude", "cdw", "cdp"),
 	// resolved per instance: conductor > group (ancestor-walk) > global.
+	// A per-session custom command (i.Command, e.g. from `launch -c
+	// claude-dbx`) takes precedence — mirroring buildClaudeCommandWithMessage,
+	// where the per-session Command field is a distinct axis that
+	// GetClaudeCommandForInstance never sees (see its doc comment). Without
+	// this, resume falls back to the literal "claude" binary and bypasses
+	// the wrapper script that sets up gateway env vars.
 	claudeCmd := GetClaudeCommandForInstance(i)
+	customCommand := i.Command != "" && i.Command != "claude"
+	if customCommand {
+		claudeCmd = i.Command
+	}
 
 	// #1791/#1822 F5: use the shared `export ...;` prefix, not a bare
 	// `KEY=val cmd` prefix — see the identical comment in
 	// buildClaudeCommandWithMessage for why (exit_to_shell's trailing
 	// `exec "$SHELL" -i` only inherits exported vars, not a single-command
 	// prefix scoped to the claude invocation alone). #1822 F3: skip the
-	// CLAUDE_CONFIG_DIR export when claudeCmd resolves to a custom alias —
-	// the alias handles it itself.
-	bashExportPrefix := i.buildBashExportPrefix(claudeCmd != "claude")
+	// CLAUDE_CONFIG_DIR export when claudeCmd resolves to a config-level
+	// alias — the alias handles it itself. A per-session custom command is
+	// the same axis as the fresh-start custom-command path, so the F3 gate
+	// does not apply there (pass false), matching buildClaudeCommandWithMessage.
+	bashExportPrefix := i.buildBashExportPrefix(!customCommand && claudeCmd != "claude")
 
 	// Get per-session permission settings (falls back to config if not persisted)
 	opts := i.GetClaudeOptions()


### PR DESCRIPTION
## What problem does this solve?

Resuming a session that was started with a custom wrapper script (e.g. a gateway launcher that sets `ANTHROPIC_BASE_URL`, `ANTHROPIC_CUSTOM_HEADERS`, model overrides, etc.) bypasses that wrapper entirely. The resumed session runs the literal `claude` binary without the wrapper's env vars, silently falling back to a different backend.

Fresh start doesn't have this bug — `buildClaudeCommandWithMessage` uses `i.Command` when it's a custom command. The per-session `Command` field is a distinct axis that `GetClaudeCommandForInstance` deliberately never sees (per its doc comment).

## Why this change

`buildClaudeResumeCommand` resolved the command via `GetClaudeCommandForInstance`, which only checks conductor/group/global config and falls back to `"claude"`. It never considered `i.Command` (the per-session custom command from `launch -c <wrapper>`).

The fix prefers `i.Command` in `buildClaudeResumeCommand` when it's a non-empty, non-`"claude"` custom command — same pattern as the fresh-start path. The `buildBashExportPrefix` F3 gate is adjusted to match: for a per-session custom command, the gate doesn't apply (pass `false`), since the custom command handles its own config dir — consistent with `buildClaudeCommandWithMessage`'s custom-command branch.

## User impact

Sessions started with a custom wrapper command (via `launch -c <wrapper>`) now resume through that same wrapper instead of falling back to the bare `claude` binary. Sessions using the default `claude` command or a config-level alias are unaffected.

## Evidence

Before the fix, resuming via `agent-deck launch . -c claude-dbx --resume-session <id>` ran the literal `claude` binary (no gateway env vars):

```
Session model glm-5-2-colo-on-sp-v1 could not be restored (not a model this version of Claude Code recognizes) — using opus instead.
```

After the fix, the resume command uses `claude-dbx` (the per-session custom command), env vars are set, and GLM 5.2 is used correctly.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** glm-5.2 (via Databricks AI Gateway)

## What actually bothered you

My human asked: "i want your help in understanding why crdbx alias (goes through agent-deck) doesn't work properly. resuming via `claude-dbx --resume` works correctly, but when resuming via `crdbx` i get 'Session model glm-5-2-colo-on-sp-v1 could not be restored' and it seems to be using the standard claude config, not this new setup."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=glm-5.2 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming sessions now reliably preserves configured Claude commands.
  * Forked sessions no longer reuse fork-specific options when restarted.
  * Explicit session settings and configuration directory handling are preserved across resume operations.

* **Tests**
  * Expanded coverage for custom commands, command aliases, configuration directories, and forked-session restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->