### PR TITLE
fix(tui): reorder and demote skip archived sessions

### DIFF
--- a/internal/session/archive.go
+++ b/internal/session/archive.go
@@ -32,3 +32,17 @@ func ArchiveTimeUTC(t time.Time) time.Time {
 	}
 	return t.UTC()
 }
+
+// SameArchivePartition reports whether two sessions sit in the same archive
+// partition — both active, or both archived.
+//
+// The deck renders exactly one partition at a time: rebuildFlatItems keeps
+// only the rows whose IsArchived matches the current view, so an archived
+// session is not on screen in the active list and vice versa. Ordering
+// operations on GroupTree therefore have to pick their neighbour from the
+// same partition as the session being moved; a neighbour from the other
+// partition is a row the user cannot see, which makes the move look like it
+// did nothing.
+func SameArchivePartition(a, b *Instance) bool {
+	return a.IsArchived() == b.IsArchived()
+}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -862,7 +862,7 @@ func (t *GroupTree) MoveSessionUp(inst *Instance) {
 			currentIdx = i
 			continue
 		}
-		if currentIdx < 0 && s.ParentSessionID == inst.ParentSessionID {
+		if currentIdx < 0 && s.ParentSessionID == inst.ParentSessionID && SameArchivePartition(s, inst) {
 			prevSiblingIdx = i
 		}
 		if inst.ParentSessionID != "" && s.ID == inst.ParentSessionID {
@@ -917,7 +917,7 @@ func (t *GroupTree) MoveSessionDown(inst *Instance) {
 			currentIdx = i
 			continue
 		}
-		if currentIdx >= 0 && s.ParentSessionID == inst.ParentSessionID && nextSiblingIdx < 0 {
+		if currentIdx >= 0 && s.ParentSessionID == inst.ParentSessionID && SameArchivePartition(s, inst) && nextSiblingIdx < 0 {
 			nextSiblingIdx = i
 		}
 	}
@@ -988,7 +988,7 @@ func (t *GroupTree) DemoteSession(inst *Instance) {
 			currentIdx = i
 			break
 		}
-		if s.ParentSessionID == "" {
+		if s.ParentSessionID == "" && SameArchivePartition(s, inst) {
 			prevTopIdx = i
 		}
 	}

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -2438,3 +2438,175 @@ func TestRenameTargetPath_MatchesRenameGroup(t *testing.T) {
 		}
 	}
 }
+
+// testArchivedAt is a fixed, non-zero archive timestamp for the reorder tests
+// below. The value never matters — only that IsArchived() reports true.
+var testArchivedAt = time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+// visibleTopLevel returns the top-level session IDs the deck actually renders
+// for one archive partition. It is the test-side equivalent of the archive
+// partitioning rebuildFlatItems applies to Flatten's output: the active list
+// never shows archived rows, and the archived view (^) never shows active ones.
+func visibleTopLevel(group *Group, archived bool) []string {
+	var ids []string
+	for _, s := range group.Sessions {
+		if s.ParentSessionID == "" && s.IsArchived() == archived {
+			ids = append(ids, s.ID)
+		}
+	}
+	return ids
+}
+
+func sessionByID(group *Group, id string) *Instance {
+	for _, s := range group.Sessions {
+		if s.ID == id {
+			return s
+		}
+	}
+	return nil
+}
+
+func sessionOrder(group *Group) []string {
+	ids := make([]string, 0, len(group.Sessions))
+	for _, s := range group.Sessions {
+		ids = append(ids, s.ID)
+	}
+	return ids
+}
+
+func assertOrder(t *testing.T, what string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", what, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", what, got, want)
+		}
+	}
+}
+
+// TestMoveSessionUp_SkipsArchivedNeighbour: with archived sessions sitting
+// between two active ones, one MoveSessionUp must swap the two *active* rows.
+// Swapping with an archived neighbour instead moves the session past a row the
+// active list does not render, so the deck shows no movement at all.
+func TestMoveSessionUp_SkipsArchivedNeighbour(t *testing.T) {
+	instances := []*Instance{
+		{ID: "a1", Title: "active1", GroupPath: "test"},
+		{ID: "z1", Title: "archived1", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "z2", Title: "archived2", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "z3", Title: "archived3", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "a2", Title: "active2", GroupPath: "test"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	assertOrder(t, "active list before", visibleTopLevel(group, false), []string{"a1", "a2"})
+
+	tree.MoveSessionUp(sessionByID(group, "a2"))
+
+	assertOrder(t, "active list after one MoveSessionUp(a2)",
+		visibleTopLevel(group, false), []string{"a2", "a1"})
+}
+
+// TestMoveSessionDown_SkipsArchivedNeighbour is the mirror of the above.
+func TestMoveSessionDown_SkipsArchivedNeighbour(t *testing.T) {
+	instances := []*Instance{
+		{ID: "a1", Title: "active1", GroupPath: "test"},
+		{ID: "z1", Title: "archived1", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "z2", Title: "archived2", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "z3", Title: "archived3", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "a2", Title: "active2", GroupPath: "test"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	tree.MoveSessionDown(sessionByID(group, "a1"))
+
+	assertOrder(t, "active list after one MoveSessionDown(a1)",
+		visibleTopLevel(group, false), []string{"a2", "a1"})
+}
+
+// TestMoveSessionUp_ArchivedRowMovesWithinArchivedList: reordering is a
+// same-partition operation, not "ignore archived". Rows in the archived view
+// (^) must reorder against each other, skipping the active rows between them.
+func TestMoveSessionUp_ArchivedRowMovesWithinArchivedList(t *testing.T) {
+	instances := []*Instance{
+		{ID: "z1", Title: "archived1", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "a1", Title: "active1", GroupPath: "test"},
+		{ID: "a2", Title: "active2", GroupPath: "test"},
+		{ID: "z2", Title: "archived2", GroupPath: "test", ArchivedAt: testArchivedAt},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	tree.MoveSessionUp(sessionByID(group, "z2"))
+
+	assertOrder(t, "archived list after one MoveSessionUp(z2)",
+		visibleTopLevel(group, true), []string{"z2", "z1"})
+	assertOrder(t, "active list must be undisturbed",
+		visibleTopLevel(group, false), []string{"a1", "a2"})
+}
+
+// TestMoveSessionUp_FirstActiveAboveArchivedIsNoOp: the first row of the active
+// list has nowhere to go, even when archived rows sit above it in the slice.
+// Asserts the whole slice, because the pre-fix bug is invisible in the active
+// list alone: it silently shuffles the session past archived rows on every
+// press while the rendered order never changes.
+func TestMoveSessionUp_FirstActiveAboveArchivedIsNoOp(t *testing.T) {
+	instances := []*Instance{
+		{ID: "z1", Title: "archived1", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "z2", Title: "archived2", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "a1", Title: "active1", GroupPath: "test"},
+		{ID: "a2", Title: "active2", GroupPath: "test"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	tree.MoveSessionUp(sessionByID(group, "a1"))
+
+	assertOrder(t, "session order after no-op MoveSessionUp(a1)",
+		sessionOrder(group), []string{"z1", "z2", "a1", "a2"})
+}
+
+// TestDemoteSession_SkipsArchivedPeer: demoting nests a session under the
+// previous top-level peer *in the same partition*. Nesting it under an
+// archived peer would park an active session beneath a row the active list
+// does not render.
+func TestDemoteSession_SkipsArchivedPeer(t *testing.T) {
+	instances := []*Instance{
+		{ID: "a1", Title: "active1", GroupPath: "test"},
+		{ID: "z1", Title: "archived1", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "a2", Title: "active2", GroupPath: "test"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	a2 := sessionByID(group, "a2")
+	tree.DemoteSession(a2)
+
+	if a2.ParentSessionID != "a1" {
+		t.Errorf("a2.ParentSessionID after demote = %q, want %q", a2.ParentSessionID, "a1")
+	}
+	assertOrder(t, "a1's children", childrenOf(group, "a1"), []string{"a2"})
+}
+
+// TestDemoteSession_FirstActiveAboveArchivedIsNoOp: the first row of the active
+// list has no peer to nest under, so demote is a no-op — an archived row above
+// it is not a candidate parent.
+func TestDemoteSession_FirstActiveAboveArchivedIsNoOp(t *testing.T) {
+	instances := []*Instance{
+		{ID: "z1", Title: "archived1", GroupPath: "test", ArchivedAt: testArchivedAt},
+		{ID: "a1", Title: "active1", GroupPath: "test"},
+		{ID: "a2", Title: "active2", GroupPath: "test"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	a1 := sessionByID(group, "a1")
+	tree.DemoteSession(a1)
+
+	if a1.ParentSessionID != "" {
+		t.Errorf("a1.ParentSessionID after no-op demote = %q, want %q", a1.ParentSessionID, "")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Shift+Up / Ctrl+Up stops reordering sessions once a group has archived sessions in it. The session does move — one slot per press through the archived rows — but the archived rows are not rendered in the active list, so the list on screen does not change. You press the key repeatedly and nothing happens, then after N presses the row suddenly jumps. N is the number of archived sessions that happen to sit between the two active rows.

Same defect in demote: it nests the session under the previous top-level peer in the slice, which can be an archived session, so an active row gets parked under a parent the active list does not render.

Fixes #1985.

## Why this change

`GroupTree.MoveSessionUp`, `MoveSessionDown` and `DemoteSession` pick their neighbour by scanning `group.Sessions`, which holds both archive partitions. The deck renders exactly one partition at a time — `rebuildFlatItems` keeps only the rows whose `IsArchived()` matches the current view — so a neighbour from the other partition is a row the user cannot see. Archiving landed after these functions were written and they were never taught about it.

The fix adds `SameArchivePartition` next to the existing archive predicates in `internal/session/archive.go` and requires it of the neighbour at all three sites. It is a partition *match*, not an archived *skip*: a row in the archived view (`^`) still reorders against the other archived rows, and takes the same one-press-one-row behaviour the active list gets. Using the moved session's own `IsArchived()` as the partition key means the tree layer needs no knowledge of the current view — the row under the cursor is by definition in the partition being rendered.

Three call sites rather than one because it is one defect with one predicate; splitting it would leave the same bug reachable from the demote key.

The parent-promotion branch of `MoveSessionUp`/`MoveSessionDown` is deliberately untouched. Promoting a child whose parent is archived is a one-shot de-indent that the user does see, not the repeat-press trap reported here.

## User impact

In a group containing archived sessions, one press of Shift+Up / Ctrl+Up (or Shift+Down / Ctrl+Down) moves a session exactly one visible row again, and demote nests under the peer directly above it in the list. No change for groups with nothing archived. No storage, config or key-binding changes.

Not fixed here, and visible in the capture below: the group header count (`demo (5)` with two rows rendered) counts archived sessions too. That is `buildGroupRenderStats` in `internal/ui/home.go`, a separate defect in a different layer — the local twin of #1945 — and it is left out to keep this diff to one problem.

## Evidence

Sandbox deck, one group `demo`, five sessions created in this order: `alpha` (active), `arch-1`/`arch-2`/`arch-3` (archived via `agent-deck session archive`), `beta` (active). The active list renders two rows. Cursor on `beta`, **one** Shift+Up. Identical starting `sort_order` and cleared `ui_state` before each run:

```
[baseline] cursor is on: beta          [fixed] cursor is on: beta
[baseline] BEFORE:                     [fixed] BEFORE:
1·▾ demo (5)                           1·▾ demo (5)
   ├─ ✕ alpha shell                       ├─ ✕ alpha shell
  ▶└─ ✕ beta shell                       ▶└─ ✕ beta shell
[baseline] AFTER one Shift+Up:         [fixed] AFTER one Shift+Up:
1·▾ demo (5)                           1·▾ demo (5)
   ├─ ✕ alpha shell                      ▶├─ ✕ beta shell
  ▶└─ ✕ beta shell                        └─ ✕ alpha shell
```

Baseline: three presses are needed to cross the three archived rows. Fixed: one.

Where it was hit for real — an active `my-sessions` group holding 180 rows, 161 of them archived, 19 rendered. The archived rows fall in long contiguous runs, so the press count varies per session:

```
idx   1  <active session A>
idx  64  <active session B>    <- 62 archived rows above it
idx 101  <active session C>    <- 36 archived rows above it
idx 130  <active session D>    <- 27 archived rows above it
idx 152  <active session E>    <-  0 archived rows above it   (moves on one press)
```

Moving B up one visible row took 63 presses; E took one. That is the reported "works, until sometimes I have to press it many times".

Revert-check — reverting only `internal/session/groups.go` (keeping the new tests) fails all six:

```
groups_test.go:2508: active list after one MoveSessionUp(a2) = [a1 a2], want [a2 a1]
--- FAIL: TestMoveSessionUp_SkipsArchivedNeighbour
groups_test.go:2526: active list after one MoveSessionDown(a1) = [a1 a2], want [a2 a1]
--- FAIL: TestMoveSessionDown_SkipsArchivedNeighbour
groups_test.go:2545: archived list after one MoveSessionUp(z2) = [z1 z2], want [z2 z1]
--- FAIL: TestMoveSessionUp_ArchivedRowMovesWithinArchivedList
groups_test.go:2568: session order after no-op MoveSessionUp(a1) = [z1 a1 z2 a2], want [z1 z2 a1 a2]
--- FAIL: TestMoveSessionUp_FirstActiveAboveArchivedIsNoOp
groups_test.go:2589: a2.ParentSessionID after demote = "z1", want "a1"
--- FAIL: TestDemoteSession_SkipsArchivedPeer
groups_test.go:2610: a1.ParentSessionID after no-op demote = "z1", want ""
--- FAIL: TestDemoteSession_FirstActiveAboveArchivedIsNoOp
```

With the fix all six pass. `gofmt -l ./cmd ./internal` is empty, `go vet ./...` is clean, `go build ./...` succeeds.

Sandboxed suite, `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`: `internal/ui` (the caller of the changed code) passes clean. `internal/session` reports only `TestDeepSeekLifecycle_*` failures. Those are pre-existing and environment-bound on this box (WSL2), not caused by this change:

- they fail identically on unmodified `origin/main`;
- the failing *subset* varies run to run on unmodified `main` — run 1: `LaunchSendRestart`, `WebReadyBanner`, `HeadlessRestartReplaysTask`; run 2: `LaunchSendRestart`, `WebReadyBanner`;
- they fail on tmux pane timing, not on ordering: `deepseek_lifecycle_test.go:185: pane never showed "resumed session" within 20s`;
- `internal/tmux` and `internal/testutil` fail here on unmodified `main` too, in the same way (`tmux bootstrap not ready within 10s`, keystroke-latency e2e), which is the same root environment problem.

Nothing in this diff is reachable from those tests — they never call `MoveSessionUp`, `MoveSessionDown` or `DemoteSession`. I could not get a fully green baseline on this machine, so I am reporting that rather than claiming a green run.

Not a hot path: the change adds one boolean comparison inside loops that already run per keypress over one group's sessions.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human asked, verbatim: *"My agent-deck is a bit buggy. When I try to reorder the conversations at TUI, I send a conversation up (ctrl + up arrow), it works until a time that I need to click a lot of times to actually move the conversation. It seems that there are 'hidden' conversations in the middle that my session is virtually moving up, but it doesnt move anything on screen because they are hidden (buggy)."*

That guess turned out to be exactly right — the hidden rows are the archived ones. They had archived 161 sessions in one group over a week in July and had been fighting the reorder key ever since.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

The suite box is left unchecked deliberately: the touched packages are clean, but `internal/session` (DeepSeek), `internal/tmux` and `internal/testutil` do not go green on this WSL2 machine *before* my change either, so I cannot honestly claim a green run. Details in Evidence.

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session reordering now stays within the active or archived section.
  * Moving sessions up, down, or into lower positions no longer crosses archive boundaries.
  * Improved handling when no eligible session is available, preserving the existing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->