### PR TITLE
fix(analytics): resolve the Claude 5 family's 1M context window

### DIFF
--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -75,6 +75,11 @@ var modelContextWindowPrefixes = []struct {
 	prefix string
 	size   int
 }{
+	// Claude 5 family: 1M context
+	{"claude-fable-5", 1_000_000},
+	{"claude-mythos-5", 1_000_000},
+	{"claude-opus-5", 1_000_000},
+	{"claude-sonnet-5", 1_000_000},
 	// 4.8 models: 1M context (must precede 4.x fallback)
 	{"claude-opus-4-8", 1_000_000},
 	// 4.7 models: 1M context (must precede 4.x fallback)

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -59,7 +59,24 @@ func TestSessionAnalytics_ContextPercent_OpusModel(t *testing.T) {
 	assert.InDelta(t, 50.0, analytics.ContextPercent(0), 0.01)
 }
 
+func TestSessionAnalytics_ContextPercent_Fable5Model(t *testing.T) {
+	// Regression for the 100%-clamped context bar: a real Fable 5 session at
+	// ~494k context tokens is at ~49% of its 1M window, not 247% of 200k.
+	analytics := &SessionAnalytics{
+		CurrentContextTokens: 494561,
+		Model:                "claude-fable-5",
+	}
+
+	// 494561 / 1000000 (fable-5 context window) * 100 = 49.46%
+	assert.InDelta(t, 49.46, analytics.ContextPercent(0), 0.01)
+}
+
 func TestContextWindowForModel(t *testing.T) {
+	// Claude 5 family: 1M
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-fable-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-mythos-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-sonnet-5"))
 	// 4.8 models: 1M (must match before 4.x fallback)
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-4-8"))
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-4-8-20260801"))


### PR DESCRIPTION
## What problem does this solve?

The Session Analytics context bar pegs at a solid red 100.0% for sessions running Claude 5 family models (`claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`) long before the window is actually exhausted — a Fable 5 session at ~49% real usage renders as 100%. Fixes #1988.

## Why this change

`modelContextWindowPrefixes` in `internal/session/analytics.go` has no entry for any Claude 5 model, so `contextWindowForModel` falls through to the 200k default while these models have a 1M window. `ContextPercent` then computes 247% and `renderContextBar` clamps it to 100%. The same inflated value feeds the conductor `clear_on_compact` check in `internal/ui/home.go`, which would send `/clear` at roughly 16% of the real window. Adding the four 1M prefixes (fable, mythos, opus-5, sonnet-5) ahead of the 4.x entries is the same shape as the existing 4.6/4.7/4.8 rows and fixes both call sites at the source.

## User impact

The context bar for Claude 5 family sessions shows real usage (green/yellow/red at the intended thresholds) instead of a permanent red 100%, and conductor `clear_on_compact` no longer fires at ~16% of the real window for these models.

## Evidence

`ParseSessionJSONL` + `ContextPercent(0)` over a real Fable 5 session JSONL (last assistant entry: `input_tokens=2`, `cache_read_input_tokens=494559`), before and after:

    before: model=claude-fable-5 currentContextTokens=494561 window=200000  contextPercent=247.3%  (TUI renders 100.0%)
    after:  model=claude-fable-5 currentContextTokens=494561 window=1000000 contextPercent=49.5%

Claude Code's own statusline showed `49% ctx` for the same session at the same moment, matching the corrected value.

New regression tests (`TestSessionAnalytics_ContextPercent_Fable5Model`, Claude 5 rows in `TestContextWindowForModel`) fail on `main` and pass with this change. Sandboxed suite: all packages pass except pre-existing local macOS environment failures that reproduce identically on a clean `upstream/main` baseline worktree (TestIssue1421 and the issue1851/location remote-boundary tests in `internal/session`, TestIssue1867 in `internal/tmuxutf8`, TestRunBounded_KillsProcessGroup in `tests/eval/harness`) plus the load-sensitive TestPerf_* budget tests.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):**

## What actually bothered you

Active user; the analytics context bar sat at a red 100% for a session whose own statusline showed 49%, which made the panel useless for judging when to compact.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 1-million-token context windows for Claude 5 Fable, Mythos, Opus, and Sonnet models.
  * Context usage reporting now accurately reflects the expanded limits.

* **Bug Fixes**
  * Corrected context usage calculations for Claude 5 models, including accurate percentage reporting near the 1-million-token limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->