### PR TITLE
fix(conductor): recover delayed codex replies

### DIFF
--- a/conductor/tests/test_async_reply_on_idle_timeout.py
+++ b/conductor/tests/test_async_reply_on_idle_timeout.py
@@ -22,6 +22,7 @@ import asyncio
 import subprocess
 import sys
 import types
+from collections import deque
 from pathlib import Path
 from unittest import mock
 
@@ -34,8 +35,13 @@ except ModuleNotFoundError:
 import bridge  # noqa: E402
 from bridge import (  # noqa: E402
     _is_still_running_timeout,
+    _is_unconfirmed_submission,
+    _pane_reports_active,
+    _drain_queue,
+    _message_queue,
     _register_pending_reply,
     _watch_pending_reply,
+    get_session_status,
     send_to_conductor,
 )
 
@@ -69,6 +75,46 @@ def test_is_still_running_timeout_rejects_genuine_failures():
     assert not _is_still_running_timeout("")
 
 
+def test_is_unconfirmed_submission_matches_only_1793_verdict():
+    assert _is_unconfirmed_submission(
+        "message reached the pane but submission was never confirmed after 10 "
+        "checks (issue #1793): the agent never began processing it"
+    )
+    assert not _is_unconfirmed_submission("session not found")
+    assert not _is_unconfirmed_submission("timeout waiting for completion")
+
+
+def test_pane_reports_active_from_recent_codex_interrupt_affordance():
+    assert _pane_reports_active("\n".join([
+        "old output",
+        "• Working (13s • esc to interrupt)",
+        "› Use /skills to list available skills",
+    ]))
+    assert not _pane_reports_active("\n".join(
+        ["• Working (old • esc to interrupt)"] + ["settled output"] * 40
+    ))
+
+
+def test_get_session_status_promotes_codex_waiting_from_live_pane():
+    with mock.patch(
+        "bridge.run_cli",
+        side_effect=[
+            _completed(0, stdout='{"status":"waiting","tool":"codex"}'),
+            _completed(0, stdout="• Working (3s • esc to interrupt)\n"),
+        ],
+    ):
+        assert get_session_status("conductor-ops", profile="work") == "active"
+
+
+def test_get_session_status_does_not_probe_non_codex_pane():
+    with mock.patch(
+        "bridge.run_cli",
+        return_value=_completed(0, stdout='{"status":"waiting","tool":"claude"}'),
+    ) as run_cli:
+        assert get_session_status("conductor-ops", profile="work") == "waiting"
+    run_cli.assert_called_once()
+
+
 # --- send_to_conductor wait-path signalling --------------------------------
 
 def test_wait_timeout_still_running_signals_third_tuple():
@@ -97,6 +143,40 @@ def test_wait_genuine_failure_is_not_still_running():
     assert still_running is False
 
 
+def test_wait_1793_false_negative_with_live_codex_turn_becomes_pending_reply():
+    failure = _completed(
+        1,
+        stderr=(
+            "message reached the pane but submission was never confirmed after "
+            "10 checks (issue #1793): the agent never began processing it"
+        ),
+    )
+    with mock.patch("bridge.run_cli", return_value=failure), mock.patch(
+        "bridge.get_session_status", return_value="active",
+    ):
+        ok, response, still_running = send_to_conductor(
+            "conductor-ops", "hi", profile="work", wait_for_reply=True,
+        )
+    assert (ok, response, still_running) == (False, "", True)
+
+
+def test_wait_1793_without_live_activity_remains_hard_failure():
+    failure = _completed(
+        1,
+        stderr=(
+            "message reached the pane but submission was never confirmed after "
+            "10 checks (issue #1793): the agent never began processing it"
+        ),
+    )
+    with mock.patch("bridge.run_cli", return_value=failure), mock.patch(
+        "bridge.get_session_status", return_value="waiting",
+    ):
+        ok, response, still_running = send_to_conductor(
+            "conductor-ops", "hi", profile="work", wait_for_reply=True,
+        )
+    assert (ok, response, still_running) == (False, "", False)
+
+
 def test_wait_success_returns_output():
     with mock.patch(
         "bridge.run_cli", return_value=_completed(0, stdout="the answer\n"),
@@ -105,6 +185,73 @@ def test_wait_success_returns_output():
             "conductor-ops", "hi", profile="work", wait_for_reply=True,
         )
     assert (ok, response, still_running) == (True, "the answer", False)
+
+
+# --- queued delivery with delayed confirmation -----------------------------
+
+def test_queue_drain_1793_with_live_turn_switches_to_reply_watcher():
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    failure = _completed(
+        1,
+        stderr=(
+            "message reached the pane but submission was never confirmed after "
+            "10 checks (issue #1793): the agent never began processing it"
+        ),
+    )
+
+    async def driver() -> None:
+        _message_queue.clear()
+        _message_queue["conductor-ops"] = deque([("hi", "work", cb)])
+        try:
+            with mock.patch(
+                "bridge.get_session_status", side_effect=["waiting", "active"],
+            ), mock.patch(
+                "bridge.run_cli", return_value=failure,
+            ), mock.patch(
+                "bridge._register_pending_reply",
+            ) as register:
+                await _drain_queue()
+            register.assert_called_once_with("conductor-ops", "work", cb)
+            assert "conductor-ops" not in _message_queue
+        finally:
+            _message_queue.clear()
+
+    _run(driver())
+    assert delivered == []  # the watcher, not the queue, owns final delivery
+
+
+def test_queue_drain_1793_without_live_turn_fails_closed():
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    failure = _completed(
+        1,
+        stderr=(
+            "message reached the pane but submission was never confirmed after "
+            "10 checks (issue #1793): the agent never began processing it"
+        ),
+    )
+
+    async def driver() -> None:
+        _message_queue.clear()
+        _message_queue["conductor-ops"] = deque([("hi", "work", cb)])
+        try:
+            with mock.patch(
+                "bridge.get_session_status", side_effect=["waiting", "waiting"],
+            ), mock.patch("bridge.run_cli", return_value=failure):
+                await _drain_queue()
+        finally:
+            _message_queue.clear()
+
+    _run(driver())
+    assert len(delivered) == 1
+    assert "send failed" in delivered[0].lower()
 
 
 # --- the reply-only watcher ------------------------------------------------

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -398,6 +398,11 @@ def get_session_status(session: str, profile: str | None = None) -> str:
 
     Returns "unknown" on CLI failure or parse error — callers should treat
     this as a transient condition and retry rather than dropping state.
+
+    Codex's durable completion hook can leave ``session show`` at waiting/idle
+    while the live pane already shows the current turn's interrupt affordance.
+    The bridge must not send a second message into that turn or conclude that a
+    pending reply is complete, so promote that live pane evidence to active.
     """
     result = run_cli(
         "session", "show", session, "--json", profile=profile, timeout=30
@@ -406,9 +411,44 @@ def get_session_status(session: str, profile: str | None = None) -> str:
         return "unknown"  # transient CLI failure — not the same as conductor broken
     try:
         data = json.loads(result.stdout)
-        return data.get("status", "unknown")
+        status = data.get("status", "unknown")
+        tool = str(data.get("tool", "") or "").lower()
+        if tool == "codex" and status in ("waiting", "idle"):
+            pane = get_session_pane(session, profile=profile)
+            if _pane_reports_active(pane):
+                log.info(
+                    "Codex session %s: pane is active while session status is %s",
+                    session, status,
+                )
+                return "active"
+        return status
     except (json.JSONDecodeError, KeyError):
         return "unknown"
+
+
+def get_session_pane(session: str, profile: str | None = None) -> str:
+    """Capture the live visible pane without parsing it as an assistant reply."""
+    result = run_cli(
+        "session", "output", session, "--pane", profile=profile, timeout=30
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _pane_reports_active(content: str) -> bool:
+    """Return true for an explicit busy affordance in the visible pane.
+
+    Limit matching to recent visible lines so an old transcript mention does
+    not keep the session busy. These are the same interrupt affordances Codex
+    renders on an in-flight turn and Agent Deck's status detector recognizes.
+    """
+    recent = "\n".join(content.splitlines()[-40:]).lower()
+    return any(marker in recent for marker in (
+        "esc to interrupt",
+        "press esc to interrupt",
+        "ctrl+c to interrupt",
+    ))
 
 
 def get_session_output(session: str, profile: str | None = None) -> str:
@@ -447,6 +487,19 @@ def _is_still_running_timeout(stderr: str) -> bool:
     """
     s = stderr.lower()
     return "timeout waiting for completion" in s or "still running" in s
+
+
+def _is_unconfirmed_submission(stderr: str) -> bool:
+    """True for Agent Deck's fail-closed #1793 delivery verdict.
+
+    The verdict remains a genuine failure unless independent live-pane evidence
+    proves that Codex did begin processing the turn.
+    """
+    s = stderr.lower()
+    return (
+        ("never confirmed submitted" in s or "submission was never confirmed" in s)
+        and ("issue #1793" in s or "agent never began processing" in s)
+    )
 
 
 def send_to_conductor(
@@ -534,6 +587,20 @@ def send_to_conductor(
                 session, stderr,
             )
             return False, "", True
+        # Agent Deck deliberately fails closed when it saw the body reach the
+        # pane but did not observe submission in its short verification window
+        # (#1793). Codex can begin the turn just after that window while its
+        # hook-backed status still says waiting. Only explicit live busy evidence
+        # upgrades this ambiguous verdict; otherwise preserve the hard failure.
+        if _is_unconfirmed_submission(stderr):
+            status = get_session_status(session, profile=profile)
+            if status in ("running", "active", "starting"):
+                log.info(
+                    "Conductor %s: submission confirmation lagged but live pane "
+                    "proves the turn is active (reply pending): %s",
+                    session, stderr,
+                )
+                return False, "", True
         log.error("Failed to send to conductor: %s", stderr)
         return False, "", False
     return True, get_session_output(session, profile=profile), False
@@ -704,7 +771,32 @@ async def _drain_queue() -> None:
                     loop.create_task(_fire_callback(reply_callback, text))
             else:
                 stderr = result.stderr.strip()
-                if "timeout" in stderr.lower() or "not ready" in stderr.lower():
+                pending_reply = _is_still_running_timeout(stderr)
+                if _is_unconfirmed_submission(stderr):
+                    live_status = await loop.run_in_executor(
+                        None,
+                        functools.partial(
+                            get_session_status, session, profile=profile,
+                        ),
+                    )
+                    pending_reply = live_status in ("running", "active", "starting")
+
+                if pending_reply:
+                    # The queued message was accepted after all; remove it from
+                    # the delivery queue and switch to reply-only observation.
+                    # Re-sending here would process the user's request twice.
+                    items.popleft()
+                    remaining = len(items)
+                    if not remaining:
+                        _message_queue.pop(session, None)
+                    log.info(
+                        "Conductor %s accepted queued message but confirmation "
+                        "lagged (%d remaining); watching reply",
+                        session, remaining,
+                    )
+                    if reply_callback is not None:
+                        _register_pending_reply(session, profile, reply_callback)
+                elif "timeout" in stderr.lower() or "not ready" in stderr.lower():
                     log.info(
                         "Conductor %s busy again during drain, will retry",
                         session,


### PR DESCRIPTION
## Summary

- treat a live Codex interrupt affordance as authoritative when hook-backed session status lags at `waiting`/`idle`
- convert #1793 send failures into reply-only watchers only when independent pane evidence proves the turn started
- apply the same no-resend behavior to queued bridge messages while preserving fail-closed delivery otherwise

## Why

A Telegram message can reach a Codex conductor and start processing after Agent Deck's short submission-confirmation window. The CLI correctly fails closed with the #1793 verdict, but the bridge currently reports a hard Telegram failure and never watches for the eventual reply. Codex can also remain reported as `waiting` while its pane visibly shows `Working (... esc to interrupt)`, causing premature reply capture or a second send into an active turn.

## Tests

- `uv run --with pytest --with toml pytest -q conductor/tests` (80 passed, 8 skipped)
- `go test ./internal/session ./cmd/agent-deck`
- `git diff --check`

AI-authored with GPT-5 Codex, directed and reviewed by a human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of messages that appear unconfirmed while a live Codex turn is still running.
  - Prevented duplicate message submissions by switching to reply-only monitoring when activity is detected.
  - Improved detection of active sessions from visible session state.
  - Queue processing now safely handles pending replies, genuine failures, empty responses, and timeouts.
  - Inactive or uncertain sessions fail safely without resending messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->