### PR TITLE
fix(session): add Claude 5-family model context windows

### DIFF
--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -75,6 +75,12 @@ var modelContextWindowPrefixes = []struct {
 	prefix string
 	size   int
 }{
+	// 5 models: 1M context (must precede any future 5.x-with-suffix fallback,
+	// and checked before the 4.x block purely by convention — "-5" vs "-4"
+	// prefixes never collide, so ordering relative to that block doesn't matter)
+	{"claude-opus-5", 1_000_000},
+	{"claude-sonnet-5", 1_000_000},
+	{"claude-fable-5", 1_000_000},
 	// 4.8 models: 1M context (must precede 4.x fallback)
 	{"claude-opus-4-8", 1_000_000},
 	// 4.7 models: 1M context (must precede 4.x fallback)

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -60,6 +60,10 @@ func TestSessionAnalytics_ContextPercent_OpusModel(t *testing.T) {
 }
 
 func TestContextWindowForModel(t *testing.T) {
+	// 5 models: 1M
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-sonnet-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-fable-5"))
 	// 4.8 models: 1M (must match before 4.x fallback)
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-4-8"))
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-4-8-20260801"))

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -62,8 +62,11 @@ func TestSessionAnalytics_ContextPercent_OpusModel(t *testing.T) {
 func TestContextWindowForModel(t *testing.T) {
 	// 5 models: 1M
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-5-20260101"))
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-sonnet-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-sonnet-5-20260101"))
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-fable-5"))
+	assert.Equal(t, 1_000_000, contextWindowForModel("claude-fable-5-20260101"))
 	// 4.8 models: 1M (must match before 4.x fallback)
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-4-8"))
 	assert.Equal(t, 1_000_000, contextWindowForModel("claude-opus-4-8-20260801"))


### PR DESCRIPTION
## What problem does this solve?

`modelContextWindowPrefixes` (internal/session/analytics.go) has no entries for the Claude 5-family model IDs — `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`. `contextWindowForModel` falls through to the 200k default for all of them, so the Session Analytics panel misreports context usage (e.g. shows ~167%, clamped to 100%, for a session actually at 35% of its real ~1M window) and the `clear_on_compact` threshold check (home.go) fires against the wrong denominator, triggering `/clear` far too early on Claude 5-family sessions.

## Why this change

Add explicit 1M-context entries for the three `claude-*-5` prefixes, following the exact same pattern already used for the 4.6/4.7/4.8 1M-context entries in the same table. No new code paths, no behavior change outside the lookup table itself.

## User impact

Session Analytics panel and clear-on-compact threshold now report/act on the correct context window for Claude 5-family sessions (`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, including dated/version-suffixed variants).

## Evidence

Before this fix, a live session on `claude-sonnet-5` at 335.6k tokens reported 100% (clamped) via agent-deck's own Session Analytics, while Claude Code's own `/context` command correctly reported 35% against the model's real window. `go test ./internal/session/...` passes with the added assertions covering both bare and dated `claude-*-5` identifiers.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-5

## What actually bothered you

My human asked: "why does Session Analytics in the agent-deck PREVIEW show 100% but the session is actually only 35%?" — after I traced it to this missing table entry, they said "yes fix it and rebuild."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (ran `./internal/session/...`, the only affected package)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-sonnet-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 1-million-token context windows for Claude Opus 5, Sonnet 5, and Fable 5 models, including dated model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->