### PR TITLE
fix: gate heartbeat sends on an open picker or unsent composer draft (#1981)

### DIFF
--- a/conductor/tests/test_issue1981_heartbeat_send_guard.py
+++ b/conductor/tests/test_issue1981_heartbeat_send_guard.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #1981.
+
+A routine/heartbeat ``session send`` types text and presses Enter. When the
+target Claude Code pane is mid-interaction that Enter is destructive:
+
+  (a) an open AskUserQuestion picker resolves to its highlighted default — the
+      model receives an answer the user never gave; and
+  (b) a composer holding the user's half-typed input gets overwritten.
+
+Both states still report status ``waiting``, so status alone cannot gate the
+send. ``heartbeat_loop`` now captures the pane and skips the cycle when
+``_pane_blocks_automated_send`` reports either state; any capture/parse failure
+fails OPEN (the send proceeds) so heartbeats are never permanently blocked.
+
+These are pure function tests on synthetic pane strings — no agent-deck runtime
+and no third-party packages required.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# The bridge's only unconditional third-party import; stub it when absent so the
+# test needs no packages (mirrors test_async_reply_on_idle_timeout.py).
+try:
+    import toml  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["toml"] = types.SimpleNamespace(load=lambda *_a, **_k: {})
+
+# conftest.py registers the canonical bridge as module "bridge" under pytest;
+# when this file is run directly there is no conftest, so load it by path.
+try:
+    import bridge  # noqa: E402
+except ModuleNotFoundError:
+    import importlib.util
+
+    _canon = Path(__file__).resolve().parents[2] / "internal" / "session" / "conductor_bridge.py"
+    _spec = importlib.util.spec_from_file_location("bridge", _canon)
+    bridge = importlib.util.module_from_spec(_spec)
+    sys.modules["bridge"] = bridge
+    _spec.loader.exec_module(bridge)
+
+ESC = "\x1b"
+RULE = "─" * 48  # a composer box border
+
+
+def _pane(*lines: str) -> str:
+    return "\n".join(lines) + "\n"
+
+
+# A real, bright (non-dim) user draft sitting unsent in the composer.
+REAL_DRAFT = _pane(
+    "  Assistant: finished the last task.",
+    RULE,
+    " ❯ can you also update the readme before we ship",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+# Only a dim (SGR 2) Claude-suggested ghost prompt — clobberable, not a draft.
+GHOST_ONLY = _pane(
+    "  Assistant: finished the last task.",
+    RULE,
+    f" ❯ {ESC}[2mTry running the test suite next{ESC}[22m",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+# An empty composer (bare prompt).
+EMPTY_COMPOSER = _pane(
+    "  Assistant: finished the last task.",
+    RULE,
+    " ❯ ",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+# An open AskUserQuestion option-picker.
+OPEN_PICKER = _pane(
+    " ☐ Sequencing",
+    "❯ 1. Identity fix first",
+    "  2. One combined build",
+    RULE,
+    "Enter to select · ↑/↓ to navigate · Esc to cancel",
+)
+
+# Prose that merely mentions picker words but has no numbered options — must not
+# be mistaken for an open picker (else heartbeats would starve).
+PROSE_MENTIONING_PICKER = _pane(
+    "  Assistant: press Enter to select the default in most editors.",
+    RULE,
+    " ❯ ",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+
+def _skips(pane: str) -> bool:
+    """True if the heartbeat would SKIP this cycle for this pane."""
+    return bridge._pane_blocks_automated_send(pane) is not None
+
+
+class TestPaneBlocksAutomatedSend(unittest.TestCase):
+    def test_real_draft_skips(self):
+        self.assertEqual(
+            bridge._pane_blocks_automated_send(REAL_DRAFT),
+            "composer-holds-unsent-input",
+        )
+
+    def test_ghost_suggestion_sends(self):
+        # A dim ghost suggestion is not a real draft — the send is allowed.
+        self.assertIsNone(bridge._pane_blocks_automated_send(GHOST_ONLY))
+
+    def test_empty_composer_sends(self):
+        self.assertIsNone(bridge._pane_blocks_automated_send(EMPTY_COMPOSER))
+
+    def test_open_picker_skips(self):
+        self.assertEqual(
+            bridge._pane_blocks_automated_send(OPEN_PICKER),
+            "askuserquestion-picker-open",
+        )
+
+    def test_empty_capture_sends_fail_open(self):
+        # capture_pane returns "" on failure -> send is allowed (fail open).
+        self.assertIsNone(bridge._pane_blocks_automated_send(""))
+
+    def test_unparseable_pane_sends_fail_open(self):
+        garbage = f"garbage {ESC}[ truncated pane with no structure at all"
+        self.assertIsNone(bridge._pane_blocks_automated_send(garbage))
+
+    def test_prose_mentioning_picker_sends(self):
+        self.assertFalse(_skips(PROSE_MENTIONING_PICKER))
+
+
+class TestComponentDetectors(unittest.TestCase):
+    def test_ghost_line_is_ghost(self):
+        self.assertTrue(
+            bridge._post_prompt_is_ghost(f" ❯ {ESC}[2mghost text{ESC}[22m")
+        )
+
+    def test_bright_line_is_not_ghost(self):
+        self.assertFalse(bridge._post_prompt_is_ghost(" ❯ real user text"))
+
+    def test_picker_detector_true_and_false(self):
+        self.assertTrue(bridge._pane_has_open_picker(OPEN_PICKER))
+        self.assertFalse(bridge._pane_has_open_picker(PROSE_MENTIONING_PICKER))
+        self.assertFalse(bridge._pane_has_open_picker(EMPTY_COMPOSER))
+
+    def test_draft_detector_true_and_false(self):
+        self.assertTrue(bridge._composer_has_unsent_draft(REAL_DRAFT))
+        self.assertFalse(bridge._composer_has_unsent_draft(EMPTY_COMPOSER))
+        self.assertFalse(bridge._composer_has_unsent_draft(GHOST_ONLY))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -431,6 +431,198 @@ def get_session_output(session: str, profile: str | None = None) -> str:
         return result.stdout.strip()
 
 
+def capture_pane(session: str, profile: str | None = None) -> str:
+    """Raw tmux pane capture for a session, via ``session output --pane``.
+
+    Unlike get_session_output (which returns the parsed "last response"), this
+    returns the live pane content WITH ANSI/SGR escapes preserved — the only
+    reliable way to see an open option-picker or the current composer contents.
+    Returns "" on any failure so callers fail OPEN (never block on an unknown
+    pane state).
+    """
+    result = run_cli(
+        "session", "output", session, "--pane", "--json", profile=profile, timeout=15
+    )
+    if result.returncode != 0:
+        return ""
+    try:
+        data = json.loads(result.stdout)
+        return data.get("content") or ""
+    except json.JSONDecodeError:
+        # Legacy/quiet builds may print the raw pane directly.
+        return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Interactive-state guard for automated sends (issue #1981)
+# ---------------------------------------------------------------------------
+#
+# A routine/heartbeat ``session send`` types text and presses Enter. When the
+# target Claude Code pane is mid-interaction, that Enter is destructive:
+#
+#   (a) an open AskUserQuestion option-picker resolves to its HIGHLIGHTED
+#       default — the model receives an answer the user never gave; and
+#   (b) a composer holding the user's half-typed input gets overwritten.
+#
+# Both states still report session status ``waiting`` (waiting fires on
+# AskUserQuestion / EnterPlanMode), so status alone cannot gate the send. The
+# helpers below inspect a raw pane capture and report whether an automated send
+# would clobber live interaction, so the caller can skip that cycle. Every
+# check fails OPEN: any capture/parse failure is treated as "safe to send".
+
+# Matches a full CSI escape sequence (used to strip ANSI for plain-text scans).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+# Matches only an SGR sequence and captures its parameters (for dim detection).
+_SGR_RE = re.compile(r"\x1b\[([0-9;]*)m")
+
+# AskUserQuestion option-picker markers. The footer strings mirror the ones the
+# Go prompt detector already keys on ("Press Enter to select" / "Use arrow keys
+# to navigate"), so the two agree about what a picker looks like.
+_PICKER_OPTION_RE = re.compile(r"^\s*[❯>]?\s*(\d+)\.\s+(.+?)\s*$")
+_PICKER_TITLE_RE = re.compile(r"^\s*[☐☑☒◻◼▢]\s*(.+?)\s*$")
+_PICKER_FOOTER_RE = re.compile(r"enter to select|to navigate", re.I)
+_PICKER_FREETEXT_RE = re.compile(r"^type something\b", re.I)
+_PICKER_META_RES = (re.compile(r"^chat about this\b", re.I),)
+
+# Composer region markers: the hint line under the input box, and a box border
+# made of horizontal rules.
+_INPUT_FOOTER_RE = re.compile(r"⏵⏵|bypass permissions|esc to interrupt|shift\+tab", re.I)
+_BORDERISH = re.compile(r"^[│\s]*[─—-]{4,}")
+
+
+def _pane_has_open_picker(pane_text: str) -> bool:
+    """True if an AskUserQuestion option-picker is currently open in the pane.
+
+    Requires the picker footer PLUS two or more real numbered answer options
+    PLUS a checkbox-style title above them, so ordinary transcript prose that
+    merely mentions "enter to select" does not match. The "Type something"
+    free-text row and meta rows ("Chat about this") are not counted as answer
+    options.
+    """
+    lines = _ANSI_RE.sub("", pane_text).splitlines()
+    footer_idx = next((i for i, ln in enumerate(lines) if _PICKER_FOOTER_RE.search(ln)), None)
+    if footer_idx is None:
+        return False
+    real = 0
+    first_opt = None
+    for i in range(footer_idx):
+        m = _PICKER_OPTION_RE.match(lines[i])
+        if not m:
+            continue
+        if first_opt is None:
+            first_opt = i
+        label = m.group(2).strip()
+        if _PICKER_FREETEXT_RE.match(label) or any(p.match(label) for p in _PICKER_META_RES):
+            continue
+        real += 1
+    if real < 2 or first_opt is None:
+        return False
+    return any(_PICKER_TITLE_RE.match(lines[i]) for i in range(first_opt))
+
+
+def _post_prompt_is_ghost(raw_line: str) -> bool:
+    """True iff the composer body on this RAW (ansi-bearing) line has visible
+    text and ALL of it is DIM.
+
+    Claude Code renders a SUGGESTED (ghost) next prompt in the composer as
+    dim/faint text (SGR 2); a real user-typed draft is bright/default. A ghost
+    is clobberable (Claude offers one nearly every turn, so protecting them
+    would starve automated sends); a real draft is not. This errs toward False
+    (i.e. "not a ghost — protect it") the moment any visible char is non-dim,
+    so real user input is never mistaken for a ghost. SGR param "2" = faint-on;
+    "0"/"22"/empty = faint-off.
+    """
+    m = re.search(r"[❯>]", raw_line)
+    seg = raw_line[m.end():] if m else raw_line
+    dim = False
+    saw_visible = False
+    i = 0
+    n = len(seg)
+    while i < n:
+        if seg[i] == "\x1b":
+            sm = _SGR_RE.match(seg, i)
+            if sm:
+                params = sm.group(1)
+                for p in (params.split(";") if params else ["0"]):
+                    if p == "2":
+                        dim = True
+                    elif p in ("0", "22", ""):
+                        dim = False
+                i = sm.end()
+                continue
+            am = _ANSI_RE.match(seg, i)  # non-SGR CSI/escape → skip it
+            if am:
+                i = am.end()
+                continue
+        ch = seg[i]
+        if not ch.isspace() and ch not in ("│", "❯", ">"):
+            saw_visible = True
+            if not dim:
+                return False
+        i += 1
+    return saw_visible
+
+
+def _composer_has_unsent_draft(pane_text: str) -> bool:
+    """True if the live composer holds the user's unsent text (mid-typing) that
+    a routine send would clobber.
+
+    Walks up from the input footer to the ``❯`` prompt, stopping at the box
+    border; an empty prompt (``❯`` with nothing after it) is not a draft. A
+    Claude-suggested ghost draft (rendered dim, SGR 2) is NOT protected — only
+    real, non-dim user input counts (see _post_prompt_is_ghost).
+    """
+    raw_lines = pane_text.splitlines()
+    text = _ANSI_RE.sub("", pane_text)
+    lines = text.splitlines()  # index-aligned with raw_lines (SGR strip keeps line count)
+    fi = None
+    for i in range(len(lines) - 1, -1, -1):
+        if _INPUT_FOOTER_RE.search(lines[i]):
+            fi = i
+            break
+    if fi is None:
+        return False
+    bi = next((j for j in range(fi - 1, -1, -1) if _BORDERISH.match(lines[j])), None)
+    if bi is None:
+        return False
+    for j in range(bi - 1, max(-1, bi - 40), -1):
+        raw = lines[j].rstrip()
+        if _BORDERISH.match(raw):  # top border / titled bar → stop before the transcript
+            break
+        s = raw.strip().lstrip("│").strip()
+        starts = s[:1] in ("❯", ">")
+        body = s[1:].strip() if starts else s
+        if body:
+            rawline = raw_lines[j] if j < len(raw_lines) else ""
+            if _post_prompt_is_ghost(rawline):
+                # dim ghost suggestion — clobberable, not a real draft
+                if starts:
+                    break     # composer prompt line holds only a ghost → no real draft
+                continue      # a dim continuation line → keep scanning up
+            return True
+        if starts:  # reached an empty ❯ prompt → no draft
+            break
+    return False
+
+
+def _pane_blocks_automated_send(pane_text: str) -> str | None:
+    """Reason string if an automated send into this pane would disrupt live
+    interaction — an AskUserQuestion picker is open (the send's Enter selects
+    its default), or the composer holds the user's unsent draft (the send
+    clobbers it) — else None. Cheapest check first.
+
+    Pure and total: an empty or unparseable capture yields None (send allowed),
+    so callers fail OPEN.
+    """
+    if not pane_text:
+        return None
+    if _pane_has_open_picker(pane_text):
+        return "askuserquestion-picker-open"
+    if _composer_has_unsent_draft(pane_text):
+        return "composer-holds-unsent-input"
+    return None
+
+
 # Async callable type for reply notifications: (response_text: str) -> None
 ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]
 
@@ -2888,6 +3080,33 @@ async def heartbeat_loop(
                     log.info(
                         "Heartbeat [%s]: conductor busy (%s), skipping this cycle",
                         name, conductor_status,
+                    )
+                    continue
+
+                # issue #1981: a routine send types text + Enter. If the pane is
+                # mid-interaction — an AskUserQuestion picker is open, or the
+                # composer holds the user's unsent draft — that Enter selects the
+                # picker default or clobbers the draft. Skip this cycle when the
+                # pane shows either. Fail OPEN: any capture/parse failure leaves
+                # block_reason None so the send still goes out (heartbeats are
+                # never permanently blocked). The capture runs in the executor so
+                # the blocking CLI call never freezes the event loop.
+                try:
+                    pane_text = await loop.run_in_executor(
+                        None,
+                        functools.partial(capture_pane, session_title, profile=profile),
+                    )
+                    block_reason = _pane_blocks_automated_send(pane_text)
+                except Exception as e:
+                    log.warning(
+                        "Heartbeat [%s]: interactive-state check failed (%s); allowing send",
+                        name, e,
+                    )
+                    block_reason = None
+                if block_reason:
+                    log.info(
+                        "Heartbeat [%s]: skipping this cycle — %s",
+                        name, block_reason,
                     )
                     continue
 


### PR DESCRIPTION
## What problem does this solve?

In an agent-deck-managed Claude Code session, the heartbeat loop fires a routine `session send` into the conductor pane while the user is mid-interaction, causing two data-loss/wrong-input failures (Fixes #1981):

- **AskUserQuestion picker hijack:** when an option-picker is open, the send's Enter selects the *highlighted default option* — the model receives an answer the user never gave (and can act on it).
- **Composer clobber:** when the composer holds the user's half-typed input, the send overwrites it.

Both an open picker and an active composer report session status `waiting` (waiting fires on AskUserQuestion / EnterPlanMode), and `heartbeat_loop` treats `waiting` as a green light to send — so status alone cannot gate the send.

## Why this change

The fix gates the routine send on the actual interactive substate, read from the pane, before delivering the heartbeat. In `heartbeat_loop`, right after the existing "conductor busy" skip, the bridge now captures the target pane (`session output --pane`, which preserves ANSI) and **skips the cycle** when either:

- an AskUserQuestion option-picker is open (`_pane_has_open_picker`), or
- the composer holds the user's unsent draft (`_composer_has_unsent_draft`).

A subtlety that makes this safe to enable: Claude Code renders a *suggested* next-prompt in the composer as **dim** text (SGR 2) nearly every turn. Protecting those "ghost" suggestions would starve heartbeats, so `_post_prompt_is_ghost` distinguishes a dim ghost (clobberable → send allowed) from real, non-dim user input (protected → skip). It errs toward protecting the moment any visible character is non-dim.

Everything **fails OPEN**: an empty/unparseable capture, or any exception during the check, leaves the send enabled — heartbeats are never permanently blocked.

The picker footer strings the detector keys on ("Press Enter to select" / "Use arrow keys to navigate") are the same ones the Go prompt detector (`internal/tmux/detector.go`) already uses, so the two agree about what a picker looks like.

**Scope:** this fixes only the picker/draft clobber (#1981). It intentionally does **not** touch #1860 (heartbeat deferral false-positives while the director is composing) — that is a separate problem and out of scope for this diff.

**Note for reviewers:** the issue text mentions `parse_option_picker` / `_pane_question`; those live in a downstream fork, not in upstream's Python bridge (upstream's picker detection is in Go). This PR adds a minimal, self-contained Python detector sufficient to gate the send, rather than porting a structured parser the gate would not use.

## User impact

A heartbeat cycle no longer answers an open AskUserQuestion picker for you or overwrites a half-typed prompt: when the pane is mid-interaction the bridge quietly skips that cycle and tries again next interval. When the pane is idle (or holds only Claude's dim ghost suggestion), heartbeats fire exactly as before. Cost is one `session output --pane` capture per waiting conductor per heartbeat cycle (minutes apart) — not a hot path.

## Evidence

Focused pure-function tests over synthetic pane strings (no agent-deck runtime, no third-party deps), covering every branch:

```
$ python3 conductor/tests/test_issue1981_heartbeat_send_guard.py
test_bright_line_is_not_ghost ... ok
test_draft_detector_true_and_false ... ok
test_ghost_line_is_ghost ... ok
test_picker_detector_true_and_false ... ok
test_empty_capture_sends_fail_open ... ok
test_empty_composer_sends ... ok
test_ghost_suggestion_sends ... ok
test_open_picker_skips ... ok
test_prose_mentioning_picker_sends ... ok
test_real_draft_skips ... ok
test_unparseable_pane_sends_fail_open ... ok
Ran 11 tests in 0.001s
OK
```

Decision matrix proven by the suite (`_pane_blocks_automated_send`):

| Pane state | Result |
|---|---|
| Real (non-dim) draft after `❯` | **SKIP** (`composer-holds-unsent-input`) |
| Dim (SGR-2) ghost suggestion only | SEND |
| Empty composer | SEND |
| Open AskUserQuestion picker | **SKIP** (`askuserquestion-picker-open`) |
| Empty / unparseable capture | SEND (fail-open) |

Python compatibility (the #864 floor) verified on Python 3.8:

```
$ python3 -m py_compile internal/session/conductor_bridge.py   # clean
# compile() + exec-import of the bridge on 3.8: PASS
# no runtime PEP 585 collections.abc subscripts: PASS
```

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-4-8

## What actually bothered you

I run agent-deck-managed Claude Code conductor sessions. Twice now a heartbeat fired while I was mid-interaction: once it hit Enter on an open AskUserQuestion picker and "answered" it with the highlighted default (which I never chose, and the model then acted on it), and once it overwrote a multi-line prompt I was still typing. The heartbeat treats `waiting` as "safe to send", but an open picker and a half-typed composer both report `waiting`.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — Python-only change; the Go embed tests (`internal/session/conductor_bridge_embed_test.go`) ast-parse and import-check the modified bridge. Go was not installed in the authoring environment; run this before merge. The `python-compat` equivalents (py_compile + exec-import on 3.8) are shown in Evidence.
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — N/A: adds one capture per heartbeat cycle (minutes), does not modify a hot-path implementation.
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [ ] "Allow edits from maintainers" is enabled — enable at PR creation.

<!-- gate:ai=authored model=claude-opus-4-8 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated heartbeat messages now detect active user drafts and open question pickers before sending.
  * Sends are paused when interaction could overwrite input or select an unintended option.
  * Detection safely allows sending when no interaction is present or when pane capture cannot be interpreted.

* **Bug Fixes**
  * Prevented automated messages from interfering with ongoing interactive prompts or unsent drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->