### PR TITLE
fix(cli): help flags anywhere in hooks args print usage, never install

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -302,6 +302,13 @@ func handleCodexHooks(args []string) {
 		os.Exit(1)
 	}
 
+	// A help request anywhere in the argument list must print usage and exit
+	// without side effects (#1993).
+	if hooksHelpRequested(args) {
+		printCodexHooksUsage(os.Stdout)
+		return
+	}
+
 	switch args[0] {
 	case "help", "--help", "-h":
 		printCodexHooksUsage(os.Stdout)

--- a/cmd/agent-deck/cursor_hooks_cmd.go
+++ b/cmd/agent-deck/cursor_hooks_cmd.go
@@ -15,6 +15,13 @@ func handleCursorHooks(args []string) {
 		os.Exit(1)
 	}
 
+	// A help request anywhere in the argument list must print usage and exit
+	// without side effects (#1993).
+	if hooksHelpRequested(args) {
+		printCursorHooksUsage(os.Stdout)
+		return
+	}
+
 	switch args[0] {
 	case "help", "--help", "-h":
 		printCursorHooksUsage(os.Stdout)

--- a/cmd/agent-deck/gemini_hooks_cmd.go
+++ b/cmd/agent-deck/gemini_hooks_cmd.go
@@ -15,6 +15,13 @@ func handleGeminiHooks(args []string) {
 		os.Exit(1)
 	}
 
+	// A help request anywhere in the argument list must print usage and exit
+	// without side effects (#1993).
+	if hooksHelpRequested(args) {
+		printGeminiHooksUsage(os.Stdout)
+		return
+	}
+
 	switch args[0] {
 	case "help", "--help", "-h":
 		printGeminiHooksUsage(os.Stdout)

--- a/cmd/agent-deck/hermes_hooks_cmd.go
+++ b/cmd/agent-deck/hermes_hooks_cmd.go
@@ -15,6 +15,13 @@ func handleHermesHooks(args []string) {
 		os.Exit(1)
 	}
 
+	// A help request anywhere in the argument list must print usage and exit
+	// without side effects (#1993).
+	if hooksHelpRequested(args) {
+		printHermesHooksUsage(os.Stdout)
+		return
+	}
+
 	switch args[0] {
 	case "help", "--help", "-h":
 		printHermesHooksUsage(os.Stdout)

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -620,6 +620,15 @@ func handleHooks(args []string) {
 		os.Exit(1)
 	}
 
+	// A help request anywhere in the argument list must print usage and exit
+	// without side effects: an install triggered by `hooks install --help`
+	// would write to another tool's settings file from a command whose
+	// documented purpose in that invocation was to describe itself (#1993).
+	if hooksHelpRequested(args) {
+		printClaudeHooksUsage(os.Stdout)
+		return
+	}
+
 	switch args[0] {
 	case "install":
 		handleHooksInstall()
@@ -629,9 +638,32 @@ func handleHooks(args []string) {
 		handleHooksStatus()
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown hooks subcommand: %s\n", args[0])
-		fmt.Fprintln(os.Stderr, "Usage: agent-deck hooks <install|uninstall|status>")
+		printClaudeHooksUsage(os.Stderr)
 		os.Exit(1)
 	}
+}
+
+func printClaudeHooksUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: agent-deck hooks <install|uninstall|status>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Manage agent-deck hook integration for Claude Code.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  install      Install or upgrade agent-deck Claude Code hooks")
+	fmt.Fprintln(w, "  uninstall    Remove agent-deck Claude Code hooks")
+	fmt.Fprintln(w, "  status       Show current hook install status")
+}
+
+// hooksHelpRequested reports whether any argument asks for help. Every hooks
+// handler runs this before dispatching so `... install --help` can never
+// reach an install path.
+func hooksHelpRequested(args []string) bool {
+	for _, a := range args {
+		if a == "--help" || a == "-h" || a == "help" {
+			return true
+		}
+	}
+	return false
 }
 
 func handleHooksInstall() {

--- a/cmd/agent-deck/hooks_help_test.go
+++ b/cmd/agent-deck/hooks_help_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// setupHooksHelpTest sandboxes HOME so a regression that actually installs
+// writes into a throwaway dir instead of the developer's real agent config.
+func setupHooksHelpTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	return home
+}
+
+// assertNoClaudeHooksInstalled fails when the help request had side effects.
+func assertNoClaudeHooksInstalled(t *testing.T, home string) {
+	t.Helper()
+	configDir := filepath.Join(home, ".claude")
+	if session.CheckClaudeHooksInstalled(configDir) {
+		t.Fatalf("`--help` installed Claude Code hooks into %s", configDir)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "settings.json")); err == nil {
+		t.Fatalf("`--help` wrote %s", filepath.Join(configDir, "settings.json"))
+	}
+}
+
+// The reported repro: `hooks install --help` must describe itself, not install.
+func TestHooksInstallHelpDoesNotInstall(t *testing.T) {
+	home := setupHooksHelpTest(t)
+
+	out := captureStdout(t, func() { handleHooks([]string{"install", "--help"}) })
+
+	if !strings.Contains(out, "Usage: agent-deck hooks") {
+		t.Fatalf("expected usage output; got:\n%s", out)
+	}
+
+	assertNoClaudeHooksInstalled(t, home)
+}
+
+func TestHooksBareHelpPrintsUsageWithoutSideEffects(t *testing.T) {
+	home := setupHooksHelpTest(t)
+
+	out := captureStdout(t, func() { handleHooks([]string{"--help"}) })
+
+	if !strings.Contains(out, "Usage: agent-deck hooks") {
+		t.Fatalf("expected usage output; got:\n%s", out)
+	}
+	assertNoClaudeHooksInstalled(t, home)
+}
+
+// The four sibling handlers already handled bare `--help`; the guard must
+// also cover flags AFTER the subcommand, which previously fell through to
+// the install path on every one of them.
+func TestSiblingHooksInstallHelpDoesNotInstall(t *testing.T) {
+	cases := []struct {
+		name    string
+		run     func(args []string)
+		checkFn func(configDir string) bool
+		dirName string
+	}{
+		{"codex", handleCodexHooks, nil, ".codex"},
+		{"cursor", handleCursorHooks, session.CheckCursorHooksInstalled, ".cursor"},
+		{"gemini", handleGeminiHooks, nil, ".gemini"},
+		{"hermes", handleHermesHooks, nil, ".hermes"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := setupHooksHelpTest(t)
+
+			out := captureStdout(t, func() { tc.run([]string{"install", "--help"}) })
+
+			if !strings.Contains(out, "Usage: agent-deck") {
+				t.Fatalf("expected usage output; got:\n%s", out)
+			}
+			if tc.checkFn != nil {
+				configDir := filepath.Join(home, tc.dirName)
+				if tc.checkFn(configDir) {
+					t.Fatalf("`--help` installed hooks into %s", configDir)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

`agent-deck hooks install --help` installed Claude Code hooks and wrote to `~/.claude/settings.json` instead of printing usage (#1993). The dispatcher only looked at `args[0]`, so the trailing `--help` was silently discarded. The four sibling handlers handled bare `--help` but fell through the same way once a subcommand preceded the flag.

## Why this change

A help request anywhere in the argument list must be a no-op: an install triggered from a command whose purpose in that invocation was to describe itself is a consent violation, same theme as #1965. A single `hooksHelpRequested(args)` guard now runs before dispatch in all five hooks handlers, and `handleHooks` gains the per-tool usage printer its siblings already had, so behaviour is consistent across the CLI.

## User impact

`hooks --help`, `hooks install --help`, and the same for codex/cursor/gemini/hermes variants now print usage and change nothing. No-args and unknown-subcommand paths are unchanged (stderr + exit 1). Nobody's installed hooks are affected.

## Evidence

```
$ go test ./cmd/agent-deck/ -run "TestHooks" -v
--- PASS: TestHooksInstallHelpDoesNotInstall
--- PASS: TestHooksBareHelpPrintsUsageWithoutSideEffects
--- PASS: TestSiblingHooksInstallHelpDoesNotInstall (codex/cursor/gemini/hermes)
```

The main test fails against unpatched code (verified by stashing the source change with tests kept): unpatched, `hooks install --help` writes `<home>/.claude/settings.json` and the assertion catches it. `go build ./...`, `go vet ./cmd/agent-deck/`, `gofmt -l`: clean.

Full sandboxed suite: 16/16 gate checks pass. Note on the cold-start perf tests: this Apple-Silicon host measures ~48ms against the 40ms Xeon-derived budget on clean `main` too, so the suite was run with the project's own `PERF_BUDGET_MULTIPLIER=1.5` machine-speed scaling (`internal/testutil/perfbudget.go`); both perf tests pass at that setting and the diff touches no init or dispatch-timing code.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** ox-alpha (opencode autonomous session), directed by @Mr-Neutr0n

**Prompt / session log (optional):** Hari asked for repo contributions across agent-harness projects; this issue was picked from the tracker and worked end-to-end including this gate.

## What actually bothered you

Hari's standing instruction for this session: "find repos, fix issues properly." Issue #1993 was picked because the repro was crisp and locally verifiable; the reported user scenario (ran `--help` to read usage before deciding, got an install instead) is quoted in the issue and drove the test assertions.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — all except two pre-existing perf-budget failures identical on clean main
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included

<!-- gate:ai=assisted model=ox-alpha intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved help handling for hook commands, including help flags and the `help` argument in any position.
  * Help requests now display usage information without installing hooks, changing configuration, or triggering other actions.
  * Unknown hook subcommands now provide consistent usage guidance.

* **Tests**
  * Added coverage verifying help output and confirming no side effects occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->