### PR TITLE
fix(ui): archived remote sessions are not running or waiting (#1945)

### DIFF
--- a/internal/ui/issue1945_remote_header_counts_test.go
+++ b/internal/ui/issue1945_remote_header_counts_test.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// #1945: archiving tears down the pane but does not reset Status, so an
+// archived remote session keeps whatever it was doing when it was archived.
+// remoteStatusCounts matched the raw wire string and had no case for the
+// archived override, so the header counted a session as running while #1944
+// gave that same row the stopped glyph — the number and the glyphs describing
+// different sets of the same rows.
+//
+// Note what this test does NOT assert: that archived rows are excluded from the
+// header's TOTAL. They are not, and must not be — unlike the local list, the
+// remote list does not partition by archive state, so an archived remote row is
+// rendered (with ■) in the normal view. Its total belongs in the count; only
+// the running/waiting tallies must exclude it.
+func TestRemoteStatusCounts_ArchivedIsNeitherRunningNorWaiting(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{ID: "a", Group: "work", Status: "running"},
+		{ID: "b", Group: "work", Status: "waiting"},
+		{ID: "c", Group: "work", Status: "running", Archived: true},
+		{ID: "d", Group: "work", Status: "waiting", Archived: true},
+	}
+
+	running, waiting := remoteStatusCounts(sessions, "work")
+	if running != 1 {
+		t.Errorf("running = %d, want 1 — an archived session keeps a live Status and must not be counted (#1945)", running)
+	}
+	if waiting != 1 {
+		t.Errorf("waiting = %d, want 1 — same for waiting (#1945)", waiting)
+	}
+
+	// The subtree total is a different question and keeps every rendered row.
+	if got := remoteSubGroupCount(sessions, "work"); got != 4 {
+		t.Errorf("remoteSubGroupCount = %d, want 4 — archived remote rows ARE rendered, so the header total includes them", got)
+	}
+}
+
+// The whole-remote header (empty groupPath) follows the same rule.
+func TestRemoteStatusCounts_HostHeaderSkipsArchived(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{ID: "a", Group: "one", Status: "running"},
+		{ID: "b", Group: "two", Status: "running", Archived: true},
+	}
+	running, waiting := remoteStatusCounts(sessions, "")
+	if running != 1 || waiting != 0 {
+		t.Errorf("host header counts = (%d running, %d waiting), want (1, 0) (#1945)", running, waiting)
+	}
+}

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -166,6 +166,16 @@ func remoteStatusCounts(sessions []session.RemoteSessionInfo, groupPath string) 
 				continue
 			}
 		}
+		// #1945: archiving tears down the pane but does NOT reset Status, so an
+		// archived remote session keeps whatever it was doing when it was
+		// archived — commonly "running". Counting it here makes the header
+		// disagree with its own rows: #1944 gives the archived row the stopped
+		// glyph while this tally still calls it running. rowStatusGlyph applies
+		// the same override for exactly this reason; the counts have to follow
+		// the same rule or the number and the glyphs describe different sets.
+		if sessions[i].Archived {
+			continue
+		}
 		switch sessions[i].Status {
 		case "running":
 			running++


### PR DESCRIPTION
`remoteStatusCounts` matched the raw wire status and had no case for the archived override. Archiving tears down the pane but does not reset `Status`, so an archived remote session keeps whatever it was doing — commonly `running` — and the group header counted it as such while #1944 gave that same row the stopped glyph. The number and the glyphs described different sets of the same rows.

`rowStatusGlyph` applies the archived override for exactly this reason; the tallies now follow the same rule.

**Deliberately not changed: the header's total.** Unlike the local list, the remote list does not partition by archive state — an archived remote row is rendered, with ■, in the normal view — so excluding it from the total would introduce the inverse of this defect. The test pins both halves.

**Revert-check** (container, no host tmux): with the guard, four tests pass. Neutering the guard fails both new cases with the reported symptom — `running = 2, want 1`, `waiting = 2, want 1`, and `host header counts = (2 running, 0 waiting), want (1, 0)`. The subtree-total assertion passes either way, which is the point of including it.

Fixes #1945.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived remote sessions are no longer included in running or waiting status counts.
  * Archived sessions remain included in overall remote totals.
  * Corrected counts across both grouped and whole-host views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->