### PR TITLE
fix(ui): group headers count the partition they are heading (#1987)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -16540,15 +16540,34 @@ func (h *Home) buildGroupRenderStats(snapshot map[string]sessionRenderState) map
 		return stats
 	}
 
+	// #1987: count the partition being rendered, not the whole slice. A group's
+	// Sessions holds active and archived rows together while the deck renders
+	// exactly one partition at a time (rebuildFlatItems keeps only the rows whose
+	// IsArchived matches the current view), so a raw len() reports sessions the
+	// header is not heading — `demo (5)` above two rows, or `My Sessions (180)`
+	// above 19. The running/waiting tallies are wrong for a second reason that
+	// the same filter fixes: archiving does not reset Status and the status
+	// updater skips archived sessions (see shouldPollStatusInLoop), so an archived
+	// session contributes whatever it was doing when it was archived, forever.
+	//
+	// The rule is partition-aware rather than archive-excluding: in the archived
+	// view (^) the header must count archived rows, because those are the rows
+	// underneath it. Same shape as SameArchivePartition in the reorder path.
+	viewArchived := h.statusFilter == FilterModeArchived
+
 	for path, g := range h.groupTree.Groups {
 		if g == nil {
 			continue
 		}
 
-		directSessions := len(g.Sessions)
+		directSessions := 0
 		directRunning := 0
 		directWaiting := 0
 		for _, sess := range g.Sessions {
+			if sess.IsArchived() != viewArchived {
+				continue
+			}
+			directSessions++
 			state, ok := snapshot[sess.ID]
 			status := sess.Status
 			if ok {

--- a/internal/ui/issue1987_group_header_counts_test.go
+++ b/internal/ui/issue1987_group_header_counts_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func archivedAt() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) }
+
+// #1987: the group header counted the raw session slice, which holds both
+// archive partitions, while the deck renders exactly one. The reporter saw
+// `demo (5)` above two rows, and `My Sessions (180)` above 19 reachable ones —
+// 161 sessions that read as lost.
+//
+// The running/waiting tallies were wrong for a second reason the same filter
+// fixes: archiving does not reset Status and the status updater skips archived
+// sessions, so an archived session keeps contributing whatever it was doing
+// when it was archived. A group holding an archived-while-running session
+// reported a running session with no row and no process.
+func TestBuildGroupRenderStats_CountsOnlyTheRenderedPartition(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "a1", Title: "active1", GroupPath: "demo", Status: session.StatusRunning},
+		{ID: "z1", Title: "arch1", GroupPath: "demo", Status: session.StatusRunning, ArchivedAt: archivedAt()},
+		{ID: "z2", Title: "arch2", GroupPath: "demo", Status: session.StatusWaiting, ArchivedAt: archivedAt()},
+		{ID: "z3", Title: "arch3", GroupPath: "demo", Status: session.StatusRunning, ArchivedAt: archivedAt()},
+		{ID: "a2", Title: "active2", GroupPath: "demo", Status: session.StatusWaiting},
+	}
+	h := &Home{groupTree: session.NewGroupTree(instances)}
+
+	stats := h.buildGroupRenderStats(map[string]sessionRenderState{})
+	got := stats["demo"]
+	if got.sessionCount != 2 {
+		t.Errorf("active view: sessionCount = %d, want 2 — the header must count the rows it heads (#1987)", got.sessionCount)
+	}
+	if got.running != 1 {
+		t.Errorf("active view: running = %d, want 1 — an archived session keeps a live Status and has no process (#1987)", got.running)
+	}
+	if got.waiting != 1 {
+		t.Errorf("active view: waiting = %d, want 1 (#1987)", got.waiting)
+	}
+
+	// The archived view (^) renders the other partition, so the header must
+	// follow it there rather than excluding archived rows unconditionally.
+	h.statusFilter = FilterModeArchived
+	archived := h.buildGroupRenderStats(map[string]sessionRenderState{})["demo"]
+	if archived.sessionCount != 3 {
+		t.Errorf("archived view: sessionCount = %d, want 3 — in ^ the archived rows ARE the rows (#1987)", archived.sessionCount)
+	}
+	if archived.running != 2 || archived.waiting != 1 {
+		t.Errorf("archived view: (running, waiting) = (%d, %d), want (2, 1)", archived.running, archived.waiting)
+	}
+}
+
+// The live snapshot overrides the stored status, and the partition filter must
+// apply to snapshot-backed rows too — otherwise the fix would hold only until
+// the first render pass populated the cache.
+func TestBuildGroupRenderStats_SnapshotRowsRespectThePartition(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "a1", Title: "active1", GroupPath: "demo", Status: session.StatusIdle},
+		{ID: "z1", Title: "arch1", GroupPath: "demo", Status: session.StatusIdle, ArchivedAt: archivedAt()},
+	}
+	h := &Home{groupTree: session.NewGroupTree(instances)}
+
+	snap := map[string]sessionRenderState{
+		"a1": {status: session.StatusRunning},
+		"z1": {status: session.StatusRunning},
+	}
+	got := h.buildGroupRenderStats(snap)["demo"]
+	if got.running != 1 || got.sessionCount != 1 {
+		t.Errorf("(running, sessionCount) = (%d, %d), want (1, 1) — a snapshot must not resurrect an archived row into the header (#1987)", got.running, got.sessionCount)
+	}
+}


### PR DESCRIPTION
`buildGroupRenderStats` took `len(g.Sessions)` and tallied every row's status. A group's `Sessions` holds both archive partitions while the deck renders exactly one, so the header reported sessions it was not heading — the reporter's `demo (5)` above two rows, and `My Sessions (180)` above 19 reachable ones.

The running/waiting tallies were wrong for a second reason the same filter fixes: archiving does not reset `Status` and `shouldPollStatusInLoop` skips archived sessions, so an archived session contributes whatever it was doing when it was archived, forever. A group holding an archived-while-running session reported a running session with no row and no process.

**Partition-aware rather than archive-excluding:** in the archived view (`^`) the header counts archived rows, because those are the rows underneath it.

**Revert-check** (container, no host tmux). With the fix the package is green. Neutering the filter reproduces the report exactly:

```
active view: sessionCount = 5, want 2
active view: running = 3, want 1
archived view: sessionCount = 5, want 3
(running, sessionCount) = (2, 2), want (1, 1)   [snapshot case]
```

That first line is the reporter's own paste — a header reading 5 above two rendered rows.

Fixes #1987. The remote twin is #1945.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group headers now show session totals and running/waiting counts for the selected view only.
  * Archived sessions no longer appear in active-view statistics, while archived views include their correct counts.

* **Tests**
  * Added coverage to verify accurate counts and status tallies across active and archived sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->