### PR TITLE
docs(web): the claude scope comment described the pre-fix grouping (#1960)

### DIFF
--- a/internal/web/handlers_mcps.go
+++ b/internal/web/handlers_mcps.go
@@ -449,8 +449,13 @@ func toolHasScope(tool, scope string) bool {
 // to <project>/.mcp.json. Those are different files (MCPInfo keeps them as
 // Project vs LocalMCPs), so attaching one server rewrote .mcp.json from a list
 // that never contained the servers already in it, silently dropping them.
-// Claude's projects[path] entries belong to the GLOBAL bucket here, exactly as
-// the TUI groups them.
+// Claude's projects[path] entries are their OWN scope here ("project"), not part
+// of the global bucket. That matters because the global write path rewrites only
+// the root mcpServers and cannot remove a projects[path] entry: folding the two
+// together would report a server the global write can never detach, and any
+// attempt to "correct" that by clearing the project half on a global write would
+// delete project-scoped servers the user never touched.
+// TestClaudeProjectEntriesAreTheirOwnScope pins the separation.
 // scopeNames maps each scope a tool has to the names currently in that scope's
 // store. Every entry must be read from the exact file its writeScope
 // counterpart targets, or a read-modify-write crosses a store boundary.


### PR DESCRIPTION
`attachedNamesForTool`'s header still said *"Claude's projects[path] entries belong to the GLOBAL bucket here, exactly as the TUI groups them"*. They have not since the scopes were separated — the function maps `local`, `project`, `global` and `user` to four distinct stores, and `TestClaudeProjectEntriesAreTheirOwnScope` pins it.

**The stale sentence is not cosmetic.** Read as current, the obvious next move is to make the global write clear `projects[path]` the way the TUI's combined helper does — which would delete project-scoped servers the user never touched, every time they edited a global one. I know because I wrote that patch before checking the code against the comment.

The comment now states why the two stores must stay apart and names the test that holds them there.