### PR TITLE
fix(web): --token gets the same validation as --token-file

### DIFF
--- a/cmd/agent-deck/web_cmd.go
+++ b/cmd/agent-deck/web_cmd.go
@@ -191,12 +191,39 @@ const maxWebTokenFileSize = 4096
 // (Server.authorize allows everything when Config.Token is ""), so anything
 // less than a clean read has to fail closed and stop the server from booting.
 // Errors name the offending path but never echo file contents.
+// validateInlineWebToken applies to --token the checks --token-file already
+// performs. The two inputs feed the same field and deserve the same floor: a
+// token carrying whitespace or control bytes can never match a Bearer header,
+// so it boots a server nobody can authenticate to while still satisfying the
+// non-loopback bind check — a lockout that looks like working auth.
+//
+// An empty token is the documented "authorization disabled" setting and passes
+// through untouched. A token that TRIMS to empty is deliberately an error
+// rather than a fall-through to that setting: `--token "   "` is an operator
+// setting a token, and silently converting it into no-auth would be the one
+// outcome this function exists to prevent.
+func validateInlineWebToken(token string) (string, error) {
+	if token == "" {
+		return "", nil
+	}
+	resolved := strings.TrimSpace(token)
+	if resolved == "" {
+		return "", fmt.Errorf("--token is only whitespace; pass a real token, or omit the flag to run without authorization")
+	}
+	if strings.ContainsFunc(resolved, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) {
+		return "", fmt.Errorf("--token must be a single value with no whitespace or control characters")
+	}
+	return resolved, nil
+}
+
 func resolveWebToken(token, tokenFile string) (string, error) {
 	if token != "" && tokenFile != "" {
 		return "", fmt.Errorf("--token and --token-file are mutually exclusive")
 	}
 	if tokenFile == "" {
-		return token, nil
+		return validateInlineWebToken(token)
 	}
 
 	f, err := os.Open(tokenFile)

--- a/cmd/agent-deck/web_token_inline_test.go
+++ b/cmd/agent-deck/web_token_inline_test.go
@@ -1,0 +1,70 @@
+package main
+
+import "testing"
+
+// `--token-file` is read, trimmed, and rejected when it is empty or carries
+// whitespace or control bytes — with the reason stated in resolveWebToken's own
+// comment: such a token can never match a Bearer header, so it boots a server
+// nobody can authenticate to while still satisfying the non-loopback bind
+// check. `--token` fed the same field and got none of it.
+//
+// The case that matters most is `--token "   "`. Trimming it to empty would
+// hand back the documented "authorization disabled" value, turning an operator
+// who set a token into a server with no auth at all — fail-open, from an input
+// that looks like a credential. It must be an error.
+func TestResolveWebToken_InlineTokenGetsTheSameFloorAsTokenFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		want    string
+		wantErr bool
+		why     string
+	}{
+		{
+			name:  "whitespace-only is an error, never a fall-through to no-auth",
+			token: "   ", wantErr: true,
+			why: "trimming to empty would disable authorization on an input that reads as setting it",
+		},
+		{
+			name:  "interior whitespace cannot appear in a Bearer header",
+			token: "ab cd", wantErr: true,
+			why: "the server would boot and refuse everyone, which looks like working auth",
+		},
+		{
+			name:  "control characters are rejected for the same reason",
+			token: "abc\tdef", wantErr: true,
+		},
+		{
+			name:  "surrounding whitespace is trimmed, matching the file path",
+			token: "  s3cret  ", want: "s3cret",
+			why: "--token-file trims before validating; the flag should not be stricter or looser",
+		},
+		{
+			name:  "an unset token still means authorization disabled",
+			token: "", want: "",
+			why: "documented behaviour: Server.authorize allows everything when Token is empty",
+		},
+		{
+			name:  "an ordinary token is unchanged",
+			token: "s3cret", want: "s3cret",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveWebToken(tc.token, "")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveWebToken(%q, \"\") = %q, nil — want an error. %s", tc.token, got, tc.why)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveWebToken(%q, \"\") returned %v, want %q. %s", tc.token, err, tc.want, tc.why)
+			}
+			if got != tc.want {
+				t.Errorf("resolveWebToken(%q, \"\") = %q, want %q. %s", tc.token, got, tc.want, tc.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The two flags feed one field and had different floors. `--token-file` is read, trimmed, and rejected when it is empty or carries whitespace or control bytes — for the reason `resolveWebToken` already states in its own comment: such a token can never match a `Bearer` header, so it boots a server nobody can authenticate to while still satisfying the non-loopback bind check, *a lockout that looks like working auth*. `--token` was returned verbatim.

So `agent-deck web --token "   "` boots with a three-space token today.

**The whitespace-only case is an error rather than a trim-to-empty**, and that is the whole point of the change: an empty token is the documented *authorization disabled* setting, so trimming `"   "` down to it would turn an operator who set a token into a server with no authorization at all. Fail-open, from an input that reads as a credential. An unset `--token` still disables authorization, unchanged.

**Revert-check** (container). With the fix the package is green. Restoring `return token, nil`:

```
--- FAIL: …/whitespace-only_is_an_error,_never_a_fall-through_to_no-auth
    resolveWebToken("   ", "") = "   ", nil — want an error
--- FAIL: …/interior_whitespace_cannot_appear_in_a_Bearer_header
--- FAIL: …/control_characters_are_rejected_for_the_same_reason
--- FAIL: …/surrounding_whitespace_is_trimmed,_matching_the_file_path
```

Noted originally as a pre-existing item in #1960's audit and never split out.