### PR TITLE
docs(changelog): point the trusted-domains entry at the PR that implemented it (#1758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Stability and correctness release: 30 commits, 21 pull requests and 19 closed is
 
 - Remote sessions reorder with shift+up/down ([#1875](https://github.com/asheshgoplani/agent-deck/issues/1875), [#1898](https://github.com/asheshgoplani/agent-deck/pull/1898)); remote group headers collapse ([#1874](https://github.com/asheshgoplani/agent-deck/pull/1874)) and descendants of collapsed ancestors stay hidden ([#1878](https://github.com/asheshgoplani/agent-deck/issues/1878), [#1899](https://github.com/asheshgoplani/agent-deck/pull/1899)).
 - The composer never submits content not attributable to the operator ([#1777](https://github.com/asheshgoplani/agent-deck/issues/1777), [#1778](https://github.com/asheshgoplani/agent-deck/pull/1778)).
-- Web link-opening honors a trusted-domains allowlist ([#1682](https://github.com/asheshgoplani/agent-deck/pull/1682)).
+- Web link-opening honors a trusted-domains allowlist, with an explicit `confirm_link_open` toggle ([#1758](https://github.com/asheshgoplani/agent-deck/pull/1758), closes [#1682](https://github.com/asheshgoplani/agent-deck/issues/1682)).
 
 ### Changed
 


### PR DESCRIPTION
#1834 lists "the missing CHANGELOG entry for #1758" as a separable unblocked sub-item. **The entry is not missing — its link is wrong**, in two ways worth fixing together:

- It cites **#1682**, which is the *issue*, not the PR that implemented it (**#1758**). So the changelog credits a request rather than an implementation, and #1758 appears nowhere in the file.
- The `#1682` reference is written as a `/pull/` URL, but #1682 is an issue. GitHub redirects, so it resolves — but it is wrong on its face and misleads anyone reading the raw markdown.

Also adds the `confirm_link_open` toggle to the description, which shipped in the same PR and is the part a user searching the changelog would actually be looking for.

No behaviour change; this is one line in the 1.12.0 section.