### PR TITLE
perf(codex): replace macOS lsof probing with libproc (#1687), credit @jwiegley

### DIFF
--- a/cmd/agent-deck/cgroup_isolation_wiring_test.go
+++ b/cmd/agent-deck/cgroup_isolation_wiring_test.go
@@ -17,8 +17,8 @@ import (
 //   - "wire_up_line_exists" — line-level grep over main.go. Fails fast (no
 //     subprocess required) when a future refactor deletes the call line.
 //   - "tui_startup_emits_line" — subprocess integration. Builds the binary,
-//     launches the TUI under an isolated HOME, kills it after a short window,
-//     and greps the resulting debug.log for the canonical OBS-01 substring.
+//     launches the TUI under an isolated HOME, waits for the canonical log line,
+//     then terminates it. Catches the failure mode where the call line is present
 //     Catches the failure mode where the call line is present but unreachable
 //     (e.g. moved after an early os.Exit) — line-level grep cannot detect this.
 //
@@ -79,6 +79,7 @@ func TestLogCgroupIsolationDecision_WiredIntoBootstrap(t *testing.T) {
 			"XDG_DATA_HOME="+xdgDataHome,
 			"XDG_CACHE_HOME="+xdgCacheHome,
 			"AGENTDECK_DEBUG=1",
+			"AGENTDECK_SKIP_UPDATE_CHECK=1",
 			"AGENTDECK_PROFILE=test-obs01",
 			"TERM=dumb",
 		)
@@ -108,6 +109,7 @@ func TestLogCgroupIsolationDecision_WiredIntoBootstrap(t *testing.T) {
 		// own go build, leaving the fixed sleeps with no slack). Poll with a
 		// generous overall ceiling so a genuine wiring regression still
 		// fails, just not on a coin flip.
+
 		logPath := filepath.Join(xdgCacheHome, "agent-deck", "debug.log")
 		deadline := time.Now().Add(20 * time.Second)
 		var data []byte

--- a/docs/specs/SESSION-SWITCH-ACCOUNT-SPEC.md
+++ b/docs/specs/SESSION-SWITCH-ACCOUNT-SPEC.md
@@ -74,7 +74,7 @@ TUI picker; `--move` (delete source after verify); cross-machine transfer.
 
 - Copy-only with pre-overwrite backup; no destructive operation anywhere.
 - All tests run under sandboxed `HOME` + cleared `XDG_*`; no test may touch a real
-  config dir (`isolatePackageHome` pattern).
+  config dir (`testutil.IsolateHome` pattern).
 
 ## Tests
 

--- a/internal/procfd/procfd.go
+++ b/internal/procfd/procfd.go
@@ -1,0 +1,27 @@
+// Package procfd lists the filesystem paths a process has open, in-process,
+// without spawning external tools.
+//
+// On macOS it uses the public libproc API (proc_pidinfo / proc_pidfdinfo)
+// through libSystem trampolines — the same CGO_ENABLED=0-compatible mechanism
+// used by golang.org/x/sys/unix. This avoids spawning the general-purpose lsof
+// tool per PID and asks the kernel for paths only for vnode descriptors
+// (issue #1552).
+//
+// Other platforms return ErrUnsupported: Linux callers read /proc/<pid>/fd
+// directly and never need this package.
+package procfd
+
+import "errors"
+
+// ErrUnsupported is returned by OpenVnodePaths on platforms without a native
+// implementation.
+var ErrUnsupported = errors.New("procfd: not supported on this platform")
+
+// OpenVnodePaths returns the filesystem paths of the vnode (file-backed) file
+// descriptors currently open in pid. A non-nil error means the returned paths
+// may be incomplete. Probing a dead PID or another user's process fails; current
+// macOS reports EINVAL for both
+// (not ESRCH/EPERM as one might expect).
+func OpenVnodePaths(pid int) ([]string, error) {
+	return openVnodePaths(pid)
+}

--- a/internal/procfd/procfd_darwin.go
+++ b/internal/procfd/procfd_darwin.go
@@ -1,0 +1,150 @@
+//go:build darwin
+
+package procfd
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"unsafe" // for go:linkname and libproc buffer passing
+)
+
+// Constants from <sys/proc_info.h>. This is public, stable ABI (unchanged
+// since macOS 10.5); lsof itself is built on the same interface.
+const (
+	procPIDListFDs         = 1 // PROC_PIDLISTFDS
+	procPIDFDVnodePathInfo = 2 // PROC_PIDFDVNODEPATHINFO
+	proxFDTypeVnode        = 1 // PROX_FDTYPE_VNODE
+	maxPathLen             = 1024
+)
+
+// procFDInfo mirrors struct proc_fdinfo.
+type procFDInfo struct {
+	FD     int32
+	FDType uint32
+}
+
+// vnode_fdinfowithpath ends with the only field we need: a MAXPATHLEN
+// pathname. Keep the unused ABI prefix opaque instead of mirroring every C
+// field. The layout test pins these Go assumptions; OpenVnodePaths behavior
+// tests verify them against the running libproc/kernel.
+const vnodeFDInfoWithPathSize = 1200
+
+type vnodeFDInfoWithPath struct {
+	Prefix [vnodeFDInfoWithPathSize - maxPathLen]byte
+	Path   [maxPathLen]byte
+}
+
+var (
+	procPidinfoFn   = procPidinfo
+	procPidfdinfoFn = procPidfdinfo
+)
+
+func openVnodePaths(pid int) ([]string, error) {
+	const fdInfoSize = int(unsafe.Sizeof(procFDInfo{}))
+
+	// Sizing call: with a nil buffer proc_pidinfo returns the byte size of the
+	// current fd table.
+	n, err := procPidinfoFn(pid, procPIDListFDs, 0, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("procfd: sizing fd list for pid %d: %w", pid, err)
+	}
+	if n%fdInfoSize != 0 {
+		return nil, fmt.Errorf("procfd: fd list size for pid %d is not record-aligned: %d bytes", pid, n)
+	}
+	// Headroom for fds opened between the sizing call and the fill call.
+	fds := make([]procFDInfo, n/fdInfoSize+32)
+	bufSize := len(fds) * fdInfoSize
+	n, err = procPidinfoFn(pid, procPIDListFDs, 0, unsafe.Pointer(&fds[0]), bufSize)
+	if err != nil {
+		return nil, fmt.Errorf("procfd: listing fds for pid %d: %w", pid, err)
+	}
+	if n >= bufSize {
+		return nil, fmt.Errorf("procfd: fd list for pid %d may be truncated", pid)
+	}
+	if n%fdInfoSize != 0 {
+		return nil, fmt.Errorf("procfd: fd list for pid %d ends with a partial record: %d bytes", pid, n)
+	}
+	fds = fds[:n/fdInfoSize]
+
+	var (
+		paths    []string
+		probeErr error
+	)
+	for _, fd := range fds {
+		if fd.FDType != proxFDTypeVnode {
+			continue
+		}
+		var info vnodeFDInfoWithPath
+		size, err := procPidfdinfoFn(pid, int(fd.FD), procPIDFDVnodePathInfo, unsafe.Pointer(&info), int(unsafe.Sizeof(info)))
+		if err != nil {
+			probeErr = errors.Join(probeErr, fmt.Errorf("procfd: reading vnode fd %d for pid %d: %w", fd.FD, pid, err))
+			continue
+		}
+		if size < int(unsafe.Sizeof(info)) {
+			probeErr = errors.Join(probeErr, fmt.Errorf("procfd: short vnode fd %d result for pid %d: got %d bytes, want %d", fd.FD, pid, size, unsafe.Sizeof(info)))
+			continue
+		}
+		path := cString(info.Path[:])
+		if path == "" {
+			probeErr = errors.Join(probeErr, fmt.Errorf("procfd: empty vnode path for fd %d in pid %d", fd.FD, pid))
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths, probeErr
+}
+
+func cString(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}
+
+// int proc_pidinfo(int pid, int flavor, uint64_t arg, void *buffer, int buffersize)
+// Returns the number of bytes written (or needed, for a nil buffer); <= 0 means error.
+func procPidinfo(pid, flavor int, arg uint64, buf unsafe.Pointer, size int) (int, error) {
+	r1, _, errno := syscall_syscall6(libc_proc_pidinfo_trampoline_addr,
+		uintptr(pid), uintptr(flavor), uintptr(arg), uintptr(buf), uintptr(size), 0)
+	// #nosec G115 -- the libc function returns a C int (32-bit) in a 64-bit
+	// register; truncating to int32 recovers the real return value.
+	if n := int(int32(r1)); n > 0 {
+		return n, nil
+	}
+	if errno != 0 {
+		return 0, errno
+	}
+	return 0, syscall.EINVAL
+}
+
+// int proc_pidfdinfo(int pid, int fd, int flavor, void *buffer, int buffersize)
+func procPidfdinfo(pid, fd, flavor int, buf unsafe.Pointer, size int) (int, error) {
+	r1, _, errno := syscall_syscall6(libc_proc_pidfdinfo_trampoline_addr,
+		uintptr(pid), uintptr(fd), uintptr(flavor), uintptr(buf), uintptr(size), 0)
+	// #nosec G115 -- the libc function returns a C int (32-bit) in a 64-bit
+	// register; truncating to int32 recovers the real return value.
+	if n := int(int32(r1)); n > 0 {
+		return n, nil
+	}
+	if errno != 0 {
+		return 0, errno
+	}
+	return 0, syscall.EINVAL
+}
+
+// syscall_syscall6 is the runtime's darwin libc-call gate, pushed into package
+// syscall by the runtime and pulled from there by golang.org/x/sys/unix and by
+// this package alike. It calls fn (a libc function pointer) with the given
+// arguments and returns errno on failure.
+//
+//go:linkname syscall_syscall6 syscall.syscall6
+func syscall_syscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
+
+//go:cgo_import_dynamic libc_proc_pidinfo proc_pidinfo "/usr/lib/libSystem.B.dylib"
+//go:cgo_import_dynamic libc_proc_pidfdinfo proc_pidfdinfo "/usr/lib/libSystem.B.dylib"
+
+var libc_proc_pidinfo_trampoline_addr uintptr
+var libc_proc_pidfdinfo_trampoline_addr uintptr

--- a/internal/procfd/procfd_darwin.s
+++ b/internal/procfd/procfd_darwin.s
@@ -1,0 +1,18 @@
+//go:build darwin
+
+#include "textflag.h"
+
+// libSystem trampolines for the libproc calls in procfd_darwin.go, in the
+// same form golang.org/x/sys/unix generates for every darwin libc function.
+
+TEXT libc_proc_pidinfo_trampoline<>(SB), NOSPLIT, $0-0
+	JMP	libc_proc_pidinfo(SB)
+
+GLOBL	·libc_proc_pidinfo_trampoline_addr(SB), RODATA, $8
+DATA	·libc_proc_pidinfo_trampoline_addr(SB)/8, $libc_proc_pidinfo_trampoline<>(SB)
+
+TEXT libc_proc_pidfdinfo_trampoline<>(SB), NOSPLIT, $0-0
+	JMP	libc_proc_pidfdinfo(SB)
+
+GLOBL	·libc_proc_pidfdinfo_trampoline_addr(SB), RODATA, $8
+DATA	·libc_proc_pidfdinfo_trampoline_addr(SB)/8, $libc_proc_pidfdinfo_trampoline<>(SB)

--- a/internal/procfd/procfd_darwin_test.go
+++ b/internal/procfd/procfd_darwin_test.go
@@ -1,0 +1,196 @@
+//go:build darwin
+
+package procfd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+// TestStructLayoutMatchesProcInfoHeader pins the Go struct layout expected by
+// the libproc calls. It does not read SDK headers; the OpenVnodePaths behavior
+// tests verify these assumptions against the running macOS kernel.
+func TestStructLayoutMatchesProcInfoHeader(t *testing.T) {
+	if got := unsafe.Sizeof(procFDInfo{}); got != 8 {
+		t.Errorf("sizeof(proc_fdinfo) = %d, want 8", got)
+	}
+	var info vnodeFDInfoWithPath
+	if got := unsafe.Sizeof(info); got != 1200 {
+		t.Errorf("sizeof(vnode_fdinfowithpath) = %d, want 1200", got)
+	}
+	if got := unsafe.Offsetof(info.Path); got != 176 {
+		t.Errorf("offsetof(vnode_fdinfowithpath, path) = %d, want 176", got)
+	}
+}
+
+func TestOpenVnodePathsRejectsPossiblyTruncatedFDList(t *testing.T) {
+	previous := procPidinfoFn
+	t.Cleanup(func() { procPidinfoFn = previous })
+	procPidinfoFn = func(_ int, _ int, _ uint64, buf unsafe.Pointer, size int) (int, error) {
+		if buf == nil {
+			return int(unsafe.Sizeof(procFDInfo{})), nil
+		}
+		return size, nil
+	}
+
+	_, err := openVnodePaths(123)
+	if err == nil || !strings.Contains(err.Error(), "may be truncated") {
+		t.Fatalf("openVnodePaths full fd buffer error = %v, want truncation error", err)
+	}
+}
+
+func TestOpenVnodePathsRejectsPartialFDRecord(t *testing.T) {
+	previous := procPidinfoFn
+	t.Cleanup(func() { procPidinfoFn = previous })
+	procPidinfoFn = func(_ int, _ int, _ uint64, buf unsafe.Pointer, _ int) (int, error) {
+		if buf == nil {
+			return int(unsafe.Sizeof(procFDInfo{})), nil
+		}
+		return int(unsafe.Sizeof(procFDInfo{})) - 1, nil
+	}
+
+	_, err := openVnodePaths(123)
+	if err == nil || !strings.Contains(err.Error(), "partial record") {
+		t.Fatalf("openVnodePaths partial fd record error = %v, want partial-record error", err)
+	}
+}
+
+func TestOpenVnodePathsReportsUnresolvedVnodes(t *testing.T) {
+	previousInfo, previousFDInfo := procPidinfoFn, procPidfdinfoFn
+	t.Cleanup(func() {
+		procPidinfoFn = previousInfo
+		procPidfdinfoFn = previousFDInfo
+	})
+	procPidinfoFn = func(_ int, _ int, _ uint64, buf unsafe.Pointer, _ int) (int, error) {
+		if buf == nil {
+			return int(unsafe.Sizeof(procFDInfo{})), nil
+		}
+		*(*procFDInfo)(buf) = procFDInfo{FD: 7, FDType: proxFDTypeVnode}
+		return int(unsafe.Sizeof(procFDInfo{})), nil
+	}
+
+	tests := []struct {
+		name  string
+		probe func(unsafe.Pointer, int) (int, error)
+		want  string
+	}{
+		{
+			name: "error",
+			probe: func(_ unsafe.Pointer, _ int) (int, error) {
+				return 0, errors.New("fd closed")
+			},
+			want: "reading vnode fd 7",
+		},
+		{
+			name: "short result",
+			probe: func(_ unsafe.Pointer, size int) (int, error) {
+				return size - 1, nil
+			},
+			want: "short vnode fd 7 result",
+		},
+		{
+			name: "empty path",
+			probe: func(_ unsafe.Pointer, size int) (int, error) {
+				return size, nil
+			},
+			want: "empty vnode path for fd 7",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			procPidfdinfoFn = func(_ int, _ int, _ int, buf unsafe.Pointer, size int) (int, error) {
+				return test.probe(buf, size)
+			}
+			paths, err := openVnodePaths(123)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("openVnodePaths unresolved vnode error = %v, want %q", err, test.want)
+			}
+			if len(paths) != 0 {
+				t.Fatalf("openVnodePaths unresolved vnode paths = %v, want none", paths)
+			}
+		})
+	}
+}
+
+func TestOpenVnodePathsSelf(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "procfd-self-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// The kernel reports the real (symlink-resolved) vnode path; the temp dir
+	// on macOS lives under /var -> /private/var.
+	want, err := filepath.EvalSymlinks(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := OpenVnodePaths(os.Getpid())
+	if err != nil {
+		t.Fatalf("OpenVnodePaths(self): %v", err)
+	}
+	if !slices.Contains(paths, want) {
+		t.Errorf("open file %q not found in %d vnode paths: %v", want, len(paths), paths)
+	}
+}
+
+// TestOpenVnodePathsChildProcess exercises the cross-process case the session
+// probe actually uses: another (same-uid) process holding a file open.
+func TestOpenVnodePathsChildProcess(t *testing.T) {
+	out, err := os.CreateTemp(t.TempDir(), "procfd-child-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	cmd := exec.Command("/bin/sleep", "30")
+	cmd.Stdout = out
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	want, err := filepath.EvalSymlinks(out.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := OpenVnodePaths(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("OpenVnodePaths(child %d): %v", cmd.Process.Pid, err)
+	}
+	if !slices.Contains(paths, want) {
+		t.Errorf("child's stdout file %q not found in %d vnode paths: %v", want, len(paths), paths)
+	}
+}
+
+func TestOpenVnodePathsDeadPID(t *testing.T) {
+	// Spawn and reap a process so its PID is (almost certainly) unused.
+	cmd := exec.Command("/usr/bin/true")
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenVnodePaths(cmd.Process.Pid); err == nil {
+		t.Error("expected an error probing a dead PID, got nil")
+	}
+}
+
+func BenchmarkOpenVnodePaths(b *testing.B) {
+	pid := os.Getpid()
+	for b.Loop() {
+		if _, err := OpenVnodePaths(pid); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/procfd/procfd_other.go
+++ b/internal/procfd/procfd_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package procfd
+
+func openVnodePaths(int) ([]string, error) {
+	return nil, ErrUnsupported
+}

--- a/internal/procfd/procfd_other_test.go
+++ b/internal/procfd/procfd_other_test.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+package procfd
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestOpenVnodePathsUnsupported(t *testing.T) {
+	if _, err := OpenVnodePaths(os.Getpid()); !errors.Is(err, ErrUnsupported) {
+		t.Errorf("OpenVnodePaths on non-darwin = %v, want ErrUnsupported", err)
+	}
+}

--- a/internal/session/codex_subagent_gate.go
+++ b/internal/session/codex_subagent_gate.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bufio"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ import (
 // <sid>` is the escape: it mints a fresh thread_source=user thread carrying
 // the full context, which accepts turns indefinitely.
 //
-// Three defenses, all keyed off the rollout's session_meta head line:
+// Two defenses, both keyed off the rollout's session_meta head line:
 //  1. Rebind gate — never rebind to a thread whose rollout says
 //     thread_source=subagent (shouldRejectCodexSubagentRebind). This guards
 //     every id-rotation path that can pick a subagent rollout: the notify
@@ -157,6 +158,21 @@ func codexThreadMetaForSession(sessionID, codexHome string) (codexThreadMeta, bo
 func (i *Instance) shouldRejectCodexSubagentRebind(candidateID string) bool {
 	meta, ok := codexThreadMetaForSession(candidateID, i.getCodexHomeDir())
 	return ok && meta.ThreadSource == "subagent"
+}
+
+func (i *Instance) filterCodexProcessProbeCandidate(candidateID string) string {
+	if candidateID == "" || !i.shouldRejectCodexSubagentRebind(candidateID) {
+		return candidateID
+	}
+	_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+		InstanceID: i.ID, Tool: i.Tool, Action: "reject",
+		Source: "process_probe", OldID: i.CodexSessionID, Candidate: candidateID,
+		Reason: "candidate_is_subagent_thread",
+	})
+	sessionLog.Debug("codex_session_probe_rejected_subagent",
+		slog.String("old_id", i.CodexSessionID),
+		slog.String("candidate", candidateID))
+	return ""
 }
 
 // codexSessionNeedsFork reports whether the bound session id names a

--- a/internal/session/codex_subagent_gate_test.go
+++ b/internal/session/codex_subagent_gate_test.go
@@ -282,8 +282,56 @@ func seedCodexRolloutCwd(t *testing.T, codexHome, sid, threadSource, cwd string)
 	}
 }
 
+func TestResolveCodexDetectionCandidateRejectsSubagent(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+	userSID := uniqueSID(t)
+	subSID := uniqueSID(t)
+	seedCodexRolloutCwd(t, codexHome, userSID, "user", inst.ProjectPath)
+	seedCodexRolloutCwd(t, codexHome, subSID, "subagent", inst.ProjectPath)
+
+	if got := inst.resolveCodexDetectionCandidate(subSID, nil); got != userSID {
+		t.Fatalf("async candidate resolution = %q, want user thread %q", got, userSID)
+	}
+}
+
+func TestRejectedSubagentProbePreservesIncompleteResult(t *testing.T) {
+	inst, codexHome := newCodexGateInstance(t)
+	userSID := uniqueSID(t)
+	subSID := uniqueSID(t)
+	seedCodexRolloutCwd(t, codexHome, userSID, "user", inst.ProjectPath)
+	seedCodexRolloutCwd(t, codexHome, subSID, "subagent", inst.ProjectPath)
+	subPath := codexRolloutPathInHome(subSID, codexHome)
+
+	restore := procfdOpenVnodePaths
+	t.Cleanup(func() { procfdOpenVnodePaths = restore })
+	procfdOpenVnodePaths = func(int) ([]string, error) {
+		return []string{subPath}, os.ErrPermission
+	}
+	sessionID, probeErr := inst.queryCodexSessionFromHostNative([]int{123})
+	if sessionID != "" || probeErr == nil {
+		t.Fatalf("native subagent partial probe = (%q, %v), want (empty, error)", sessionID, probeErr)
+	}
+	if got := inst.resolveCodexDetectionCandidate(sessionID, probeErr); got != "" {
+		t.Fatalf("undetermined async probe fell through to disk ID %q", got)
+	}
+
+	dir := t.TempDir()
+	fakeDocker := filepath.Join(dir, "docker")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' %q\nexit 2\n", subPath)
+	if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	inst.SandboxContainer = "test"
+	sessionID, _, probeErr = inst.queryCodexSessionFromDockerProcFD()
+	if sessionID != "" || probeErr == nil {
+		t.Fatalf("docker subagent partial probe = (%q, %v), want (empty, error)", sessionID, probeErr)
+	}
+}
+
 func TestUpdateCodexSession_DiskScan_PrefersUserOverSubagent(t *testing.T) {
 	inst, codexHome := newCodexGateInstance(t)
+	inst.lastCodexProbeAt = time.Now().Add(time.Hour) // This test isolates disk selection.
 	if err := os.MkdirAll(inst.ProjectPath, 0o755); err != nil {
 		t.Fatalf("mkdir project: %v", err)
 	}
@@ -308,6 +356,7 @@ func TestUpdateCodexSession_DiskScan_PrefersUserOverSubagent(t *testing.T) {
 
 func TestUpdateCodexSession_DiskScan_RejectsLoneSubagent(t *testing.T) {
 	inst, codexHome := newCodexGateInstance(t)
+	inst.lastCodexProbeAt = time.Now().Add(time.Hour) // This test isolates disk selection.
 	if err := os.MkdirAll(inst.ProjectPath, 0o755); err != nil {
 		t.Fatalf("mkdir project: %v", err)
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/docker"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
+	"github.com/asheshgoplani/agent-deck/internal/procfd"
 	"github.com/asheshgoplani/agent-deck/internal/send"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -118,8 +119,9 @@ const (
 	// its /event stream roughly every 10s, and the watcher refreshes the
 	// timestamp on every received line, so 30s of silence means the stream
 	// (and likely the process) is gone — fall back to tmux polling.
-	opencodeSSEFreshnessWindow = 30 * time.Second
-	codexProbeMissingSentinel  = "__AGENT_DECK_MISSING_TOOL__"
+	opencodeSSEFreshnessWindow   = 30 * time.Second
+	codexProbeMissingSentinel    = "__AGENT_DECK_MISSING_TOOL__"
+	codexProbeIncompleteSentinel = "__AGENT_DECK_INCOMPLETE_PROBE__"
 	// codexLsofProbeTimeout hard-caps a single lsof invocation so a slow or
 	// hung child can never stall the shared status pass. lsof is also run with
 	// -n -P (no host/port name resolution) to avoid reverse-DNS PTR lookups on
@@ -567,11 +569,10 @@ type Instance struct {
 	// UpdateStatus() acquires the write lock internally.
 	mu sync.RWMutex
 
-	// spawnGen is bumped on every Start/StartWithMessage/Stop so the fast-death
-	// watcher (#1580) can detect that a newer spawn or a deliberate stop has
-	// superseded it — race-free, without reading the mutex-guarded status fields
-	// from its own goroutine.
-	spawnGen atomic.Uint64
+	// spawnGen supersedes stale fast-death watchers; spawnWatchers lets tests join
+	// them before restoring process-global filesystem environment.
+	spawnGen      atomic.Uint64
+	spawnWatchers sync.WaitGroup
 
 	// spawnGenMu guards spawnGenWake. spawnGenWake lets a generation bump wake a
 	// running watchForFastDeath goroutine immediately instead of it only
@@ -2924,6 +2925,14 @@ func (i *Instance) DetectCodexSession() {
 // Codex stores sessions in ~/.codex/sessions/YYYY/MM/DD/*.jsonl
 // Session ID is a UUID that can be extracted from the filename
 // Since Codex has no "session list" command, we scan the filesystem
+func (i *Instance) resolveCodexDetectionCandidate(sessionID string, probeErr error) string {
+	sessionID = i.filterCodexProcessProbeCandidate(sessionID)
+	if sessionID == "" && probeErr == nil {
+		return i.queryCodexSession(i.collectOtherCodexSessionIDs(), true)
+	}
+	return sessionID
+}
+
 func (i *Instance) detectCodexSessionAsync() {
 	// Brief wait for Codex to initialize
 	time.Sleep(1 * time.Second)
@@ -2936,10 +2945,8 @@ func (i *Instance) detectCodexSessionAsync() {
 			time.Sleep(delay)
 		}
 
-		sessionID, _ := i.queryCodexSessionFromProcessFiles()
-		if sessionID == "" {
-			sessionID = i.queryCodexSession(i.collectOtherCodexSessionIDs(), true)
-		}
+		sessionID, _, probeErr := i.queryCodexSessionFromProcessFiles()
+		sessionID = i.resolveCodexDetectionCandidate(sessionID, probeErr)
 		if sessionID != "" {
 			i.CodexSessionID = sessionID
 			i.CodexDetectedAt = time.Now()
@@ -2959,7 +2966,11 @@ func (i *Instance) detectCodexSessionAsync() {
 			return
 		}
 
-		sessionLog.Debug("codex_session_not_found", slog.Int("attempt", attempt+1), slog.Int("total", len(delays)))
+		if probeErr != nil {
+			sessionLog.Debug("codex_session_probe_undetermined", slog.Int("attempt", attempt+1), slog.Any("error", probeErr))
+		} else {
+			sessionLog.Debug("codex_session_not_found", slog.Int("attempt", attempt+1), slog.Int("total", len(delays)))
+		}
 	}
 
 	sessionLog.Warn("codex_detection_failed", slog.Int("attempts", len(delays)))
@@ -3300,55 +3311,114 @@ func (i *Instance) shouldRunCodexProcessProbe(force bool) bool {
 	return true
 }
 
-// collectTmuxPaneProcessTreePIDs returns pane PID + descendant PIDs for this instance.
-func (i *Instance) collectTmuxPaneProcessTreePIDs() []int {
+// collectTmuxPaneProcessTreePIDs returns every pane PID and descendant. A
+// non-nil error means the returned process forest may be incomplete.
+func (i *Instance) collectTmuxPaneProcessTreePIDs() ([]int, error) {
 	if i.tmuxSession == nil || !i.tmuxSession.Exists() {
-		return nil
+		return nil, errors.New("codex process probe: tmux session is unavailable")
 	}
 
-	target := i.tmuxSession.Name + ":"
+	target := i.tmuxSession.Name
 	// Target the same tmux server the session was created on (issue #687).
 	// A session on an isolated agent-deck socket would return no panes from
 	// the default server and we would mistakenly treat it as empty.
 	// Bounded — see tmux.OutputBounded. Exec(...).Output() has no deadline, and
 	// a tmux client that has exhausted its fd table never exits, so this probe
-	// would hang the caller forever.
-	out, err := tmux.OutputBounded(i.TmuxSocketName, "list-panes", "-t", target, "-F", "#{pane_pid}")
+	// would hang the caller forever. -s makes list-panes cover every window in
+	// the session rather than only the target's current window.
+	out, err := tmux.OutputBounded(i.TmuxSocketName, "list-panes", "-s", "-t", target, "-F", "#{pane_pid}")
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("codex process probe: list tmux panes: %w", err)
 	}
-
-	pidStr := strings.TrimSpace(string(out))
-	if idx := strings.IndexByte(pidStr, '\n'); idx >= 0 {
-		pidStr = pidStr[:idx]
-	}
-	panePID, err := strconv.Atoi(pidStr)
-	if err != nil || panePID <= 0 {
-		return nil
+	panePIDs, paneErr := parsePositivePIDs(out, "tmux pane")
+	if len(panePIDs) == 0 {
+		return nil, paneErr
 	}
 
 	// Single snapshot of the process table is substantially cheaper than
 	// spawning pgrep once per node in deep process trees.
-	procTable, err := exec.Command("ps", "-eo", "pid=,ppid=").Output()
-	if err == nil {
-		if allPIDs := collectProcessTreePIDsFromTable(panePID, procTable); len(allPIDs) > 0 {
-			return allPIDs
+	procTable, psErr := exec.Command("ps", "-eo", "pid=,ppid=").Output()
+	if psErr == nil {
+		allPIDs, treeErr := collectProcessTreePIDsFromTable(panePIDs, procTable)
+		if treeErr == nil {
+			return allPIDs, paneErr
 		}
+		psErr = treeErr
 	}
 
 	// Fallback path for environments where ps output is unavailable/unexpected.
-	return collectProcessTreePIDsViaPgrep(panePID)
+	var (
+		allPIDs  []int
+		pgrepErr error
+	)
+	seen := make(map[int]bool)
+	for _, panePID := range panePIDs {
+		pids, err := collectProcessTreePIDsViaPgrep(panePID)
+		pgrepErr = errors.Join(pgrepErr, err)
+		for _, pid := range pids {
+			if !seen[pid] {
+				seen[pid] = true
+				allPIDs = append(allPIDs, pid)
+			}
+		}
+	}
+	if pgrepErr != nil {
+		pgrepErr = errors.Join(fmt.Errorf("codex process probe: ps: %w", psErr), pgrepErr)
+	}
+	return allPIDs, errors.Join(paneErr, pgrepErr)
 }
 
-func collectProcessTreePIDsFromTable(rootPID int, procTable []byte) []int {
-	childrenByParent := parsePSParentChildMap(procTable)
-	if len(childrenByParent) == 0 {
-		return []int{rootPID}
+func parsePositivePIDs(output []byte, source string) ([]int, error) {
+	var (
+		pids     []int
+		parseErr error
+	)
+	seen := make(map[int]bool)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for line := 1; scanner.Scan(); line++ {
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(text)
+		if err != nil || pid <= 0 {
+			parseErr = errors.Join(parseErr, fmt.Errorf("codex process probe: invalid %s pid on line %d: %q", source, line, text))
+			continue
+		}
+		if !seen[pid] {
+			seen[pid] = true
+			pids = append(pids, pid)
+		}
+	}
+	parseErr = errors.Join(parseErr, scanner.Err())
+	if len(pids) == 0 && parseErr == nil {
+		parseErr = fmt.Errorf("codex process probe: %s output contained no pids", source)
+	}
+	return pids, parseErr
+}
+
+func collectProcessTreePIDsFromTable(rootPIDs []int, procTable []byte) ([]int, error) {
+	childrenByParent, parseErr := parsePSParentChildMap(procTable)
+	present := make(map[int]bool)
+	for _, children := range childrenByParent {
+		for _, pid := range children {
+			present[pid] = true
+		}
 	}
 
 	var allPIDs []int
-	seen := map[int]bool{rootPID: true}
-	queue := []int{rootPID}
+	seen := make(map[int]bool)
+	queue := make([]int, 0, len(rootPIDs))
+	for _, rootPID := range rootPIDs {
+		if !present[rootPID] {
+			parseErr = errors.Join(parseErr, fmt.Errorf("codex process probe: pane pid %d missing from ps process table", rootPID))
+			continue
+		}
+		if !seen[rootPID] {
+			seen[rootPID] = true
+			queue = append(queue, rootPID)
+		}
+	}
 	for len(queue) > 0 {
 		parent := queue[0]
 		queue = queue[1:]
@@ -3362,30 +3432,37 @@ func collectProcessTreePIDsFromTable(rootPID int, procTable []byte) []int {
 			queue = append(queue, childPID)
 		}
 	}
-	return allPIDs
+	return allPIDs, parseErr
 }
 
-func parsePSParentChildMap(procTable []byte) map[int][]int {
+func parsePSParentChildMap(procTable []byte) (map[int][]int, error) {
 	childrenByParent := make(map[int][]int)
+	var parseErr error
 	scanner := bufio.NewScanner(bytes.NewReader(procTable))
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		// tolerant of trailing columns so the same snapshot can carry comm=
-		// for callers that also need to identify the pane leader
+	for line := 1; scanner.Scan(); line++ {
+		text := scanner.Text()
+		fields := strings.Fields(text)
+		// Tolerant of TRAILING columns so one snapshot can also carry comm=
+		// for callers that identify the pane leader (parsePSCommandNames).
+		// A row with fewer than two fields is genuinely malformed, and #1687's
+		// fail-closed intent is kept by recording it rather than skipping it.
 		if len(fields) < 2 {
+			parseErr = errors.Join(parseErr, fmt.Errorf("codex process probe: invalid ps row %d: %q", line, text))
 			continue
 		}
 		pid, err := strconv.Atoi(fields[0])
 		if err != nil || pid <= 0 {
+			parseErr = errors.Join(parseErr, fmt.Errorf("codex process probe: invalid ps pid on row %d: %q", line, fields[0]))
 			continue
 		}
 		ppid, err := strconv.Atoi(fields[1])
-		if err != nil || ppid <= 0 {
+		if err != nil || ppid < 0 {
+			parseErr = errors.Join(parseErr, fmt.Errorf("codex process probe: invalid ps parent pid on row %d: %q", line, fields[1]))
 			continue
 		}
 		childrenByParent[ppid] = append(childrenByParent[ppid], pid)
 	}
-	return childrenByParent
+	return childrenByParent, errors.Join(parseErr, scanner.Err())
 }
 
 // parsePSCommandNames reads `pid=,ppid=,comm=` output into pid -> command
@@ -3410,8 +3487,11 @@ func parsePSCommandNames(procTable []byte) map[int]string {
 	return commByPID
 }
 
-func collectProcessTreePIDsViaPgrep(rootPID int) []int {
-	var allPIDs []int
+func collectProcessTreePIDsViaPgrep(rootPID int) ([]int, error) {
+	var (
+		allPIDs  []int
+		probeErr error
+	)
 	seen := map[int]bool{rootPID: true}
 	queue := []int{rootPID}
 	for len(queue) > 0 {
@@ -3423,27 +3503,49 @@ func collectProcessTreePIDsViaPgrep(rootPID int) []int {
 		// strconv.Itoa(int), never reachable from external input.
 		childrenRaw, err := exec.Command("pgrep", "-P", strconv.Itoa(parent)).Output()
 		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+				continue // pgrep uses exit 1 when the process has no children.
+			}
+			probeErr = errors.Join(probeErr, fmt.Errorf("codex process probe: pgrep children of %d: %w", parent, err))
 			continue
 		}
-		for _, line := range strings.Split(strings.TrimSpace(string(childrenRaw)), "\n") {
-			childPID, convErr := strconv.Atoi(strings.TrimSpace(line))
-			if convErr != nil || childPID <= 0 || seen[childPID] {
+		children, parseErr := parsePositivePIDs(childrenRaw, "pgrep")
+		probeErr = errors.Join(probeErr, parseErr)
+		for _, childPID := range children {
+			if seen[childPID] {
 				continue
 			}
 			seen[childPID] = true
 			queue = append(queue, childPID)
 		}
 	}
-	return allPIDs
+	return allPIDs, probeErr
 }
 
-func isLikelyCodexProcessPID(pid int) bool {
+func isLikelyCodexProcessPID(pid int) (bool, error) {
 	// #nosec G204 -- "ps" is a fixed binary; only arg is strconv.Itoa(int).
 	argsOut, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("codex process probe: inspect pid %d: %w", pid, err)
 	}
-	return strings.Contains(strings.ToLower(strings.TrimSpace(string(argsOut))), "codex")
+	return strings.Contains(strings.ToLower(strings.TrimSpace(string(argsOut))), "codex"), nil
+}
+
+func (i *Instance) collectCodexProcessCandidates() ([]int, error) {
+	pids, probeErr := i.collectTmuxPaneProcessTreePIDs()
+	candidates := make([]int, 0, len(pids))
+	for _, pid := range pids {
+		likely, err := isLikelyCodexProcessPID(pid)
+		if err != nil {
+			probeErr = errors.Join(probeErr, err)
+			continue
+		}
+		if likely {
+			candidates = append(candidates, pid)
+		}
+	}
+	return candidates, probeErr
 }
 
 func extractCodexSessionIDFromPath(path string) string {
@@ -3466,84 +3568,171 @@ func extractCodexSessionIDFromLsofOutput(output []byte) string {
 	return ""
 }
 
-func extractCodexSessionIDFromProcFD(pid int) string {
+func (i *Instance) extractAcceptedCodexSessionIDFromOutput(output []byte) string {
+	seen := make(map[string]bool)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		candidateID := extractCodexSessionIDFromPath(scanner.Text())
+		if candidateID == "" || seen[candidateID] {
+			continue
+		}
+		seen[candidateID] = true
+		if sessionID := i.filterCodexProcessProbeCandidate(candidateID); sessionID != "" {
+			return sessionID
+		}
+	}
+	return ""
+}
+
+func (i *Instance) extractCodexSessionIDFromProcFD(pid int) (string, error) {
 	fdDir := filepath.Join("/proc", strconv.Itoa(pid), "fd")
 	entries, err := os.ReadDir(fdDir)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("codex process probe: read %s: %w", fdDir, err)
 	}
 
+	var probeErr error
 	for _, entry := range entries {
 		targetPath := filepath.Join(fdDir, entry.Name())
 		target, err := os.Readlink(targetPath)
 		if err != nil {
+			probeErr = errors.Join(probeErr, fmt.Errorf("codex process probe: readlink %s: %w", targetPath, err))
 			continue
 		}
-		if sessionID := extractCodexSessionIDFromPath(target); sessionID != "" {
-			return sessionID
+		if candidateID := extractCodexSessionIDFromPath(target); candidateID != "" {
+			if sessionID := i.filterCodexProcessProbeCandidate(candidateID); sessionID != "" {
+				return sessionID, nil
+			}
 		}
 	}
-	return ""
+	return "", probeErr
 }
 
-func (i *Instance) queryCodexSessionFromHostProcFD() string {
-	for _, pid := range i.collectTmuxPaneProcessTreePIDs() {
-		if !isLikelyCodexProcessPID(pid) {
-			continue
+func (i *Instance) queryCodexSessionFromHostProcFD() (string, error) {
+	candidates, probeErr := i.collectCodexProcessCandidates()
+	for _, pid := range candidates {
+		sessionID, err := i.extractCodexSessionIDFromProcFD(pid)
+		if sessionID != "" {
+			return sessionID, nil
 		}
-		if sessionID := extractCodexSessionIDFromProcFD(pid); sessionID != "" {
-			return sessionID
-		}
+		probeErr = errors.Join(probeErr, err)
 	}
-	return ""
+	return "", probeErr
 }
 
-func (i *Instance) queryCodexSessionFromDockerProcFD() (string, string) {
-	if strings.TrimSpace(i.SandboxContainer) == "" {
-		return "", ""
-	}
-
-	script := fmt.Sprintf(
+func codexProcFDProbeScript(procRoot string) string {
+	root := shellescape.Quote(strings.TrimRight(procRoot, "/"))
+	return fmt.Sprintf(
 		`command -v readlink >/dev/null 2>&1 || {
 	echo %q
 	exit 0
 }
-for f in /proc/[0-9]*/fd/*; do
-	t=$(readlink "$f" 2>/dev/null || true)
-	case "$t" in
-		*/sessions/*rollout-*.jsonl*)
-			printf '%%s\n' "$t"
-			;;
-	esac
-done`,
+proc_root=%s
+saw_process=0
+incomplete=0
+for p in "$proc_root"/[0-9]*; do
+	if [ "$p" = "$proc_root/[0-9]*" ]; then
+		break
+	fi
+	saw_process=1
+	if [ ! -d "$p" ]; then
+		incomplete=1
+		continue
+	fi
+	d="$p/fd"
+	if [ ! -d "$d" ] || [ ! -r "$d" ] || [ ! -x "$d" ]; then
+		incomplete=1
+		continue
+	fi
+	for f in "$d"/*; do
+		if [ "$f" = "$d/*" ]; then
+			incomplete=1
+			break
+		fi
+		if ! t=$(readlink "$f" 2>/dev/null); then
+			incomplete=1
+			continue
+		fi
+		case "$t" in
+			*/sessions/*rollout-*.jsonl*)
+				printf '%%s\n' "$t"
+				;;
+		esac
+	done
+done
+if [ "$saw_process" -eq 0 ]; then
+	incomplete=1
+fi
+if [ "$incomplete" -ne 0 ]; then
+	echo %q
+fi`,
 		codexProbeMissingSentinel,
+		root,
+		codexProbeIncompleteSentinel,
 	)
-	// #nosec G204 -- "docker exec" with internal SandboxContainer name and a
-	// hardcoded shell probe script (codexProbeMissingSentinel is a compile-time
-	// constant); no external input flows here.
-	out, err := exec.Command("docker", "exec", i.SandboxContainer, "sh", "-lc", script).Output()
-	if err != nil {
-		return "", ""
-	}
-	if bytes.Contains(out, []byte(codexProbeMissingSentinel)) {
-		return "", "readlink"
-	}
-	if sessionID := extractCodexSessionIDFromLsofOutput(out); sessionID != "" {
-		return sessionID, ""
-	}
-	return "", ""
 }
 
-func (i *Instance) queryCodexSessionFromHostLsof() (string, string) {
-	if _, err := exec.LookPath("lsof"); err != nil {
-		return "", "lsof"
+func (i *Instance) queryCodexSessionFromDockerProcFD() (string, string, error) {
+	if strings.TrimSpace(i.SandboxContainer) == "" {
+		return "", "", errors.New("codex process probe: sandbox container is unavailable")
 	}
 
-	for _, pid := range i.collectTmuxPaneProcessTreePIDs() {
-		if !isLikelyCodexProcessPID(pid) {
-			continue
-		}
+	script := codexProcFDProbeScript("/proc")
+	// #nosec G204 -- "docker exec" with internal SandboxContainer name and a
+	// hardcoded shell probe script (the sentinels are compile-time constants);
+	// no external input flows here.
+	out, err := exec.Command("docker", "exec", i.SandboxContainer, "sh", "-lc", script).Output()
+	if sessionID := i.extractAcceptedCodexSessionIDFromOutput(out); sessionID != "" {
+		return sessionID, "", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("codex process probe: docker exec: %w", err)
+	}
+	if bytes.Contains(out, []byte(codexProbeMissingSentinel)) {
+		return "", "readlink", errors.New("codex process probe: readlink is unavailable")
+	}
+	if bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) {
+		return "", "", errors.New("codex process probe: container fd scan is incomplete")
+	}
+	return "", "", nil
+}
 
+// procfdOpenVnodePaths is a test seam over procfd.OpenVnodePaths so the
+// native-probe semantics (ID extraction, answered/lsof-fallback logic) stay
+// testable on platforms where the real scan is unsupported.
+var procfdOpenVnodePaths = procfd.OpenVnodePaths
+
+// queryCodexSessionFromHostNative probes candidate PIDs with the in-process
+// libproc FD scan (issue #1552: spawning lsof per PID on macOS walks every FD
+// and resolves every vnode path, and polling it stalled whole machines). A
+// non-nil error means the negative result is incomplete and requires fallback.
+func (i *Instance) queryCodexSessionFromHostNative(pids []int) (string, error) {
+	var probeErr error
+	for _, pid := range pids {
+		paths, err := procfdOpenVnodePaths(pid)
+		for _, path := range paths {
+			candidateID := extractCodexSessionIDFromPath(path)
+			if sessionID := i.filterCodexProcessProbeCandidate(candidateID); sessionID != "" {
+				return sessionID, nil
+			}
+		}
+		if err != nil {
+			if !errors.Is(err, procfd.ErrUnsupported) {
+				sessionLog.Debug("codex_procfd_probe_failed", slog.Int("pid", pid), slog.Any("error", err))
+			}
+			probeErr = errors.Join(probeErr, fmt.Errorf("codex native probe pid %d: %w", pid, err))
+		}
+	}
+	return "", probeErr
+}
+
+func (i *Instance) queryCodexSessionFromHostLsof(pids []int) (string, string, error) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		return "", "lsof", fmt.Errorf("codex process probe: find lsof: %w", err)
+	}
+
+	var probeErr error
+	for _, pid := range pids {
 		// -n -P disables reverse-DNS host and port-name resolution so a resolver
 		// that drops PTR queries cannot stall the probe (issue #1581); the
 		// context timeout bounds the call even if lsof hangs for any other reason.
@@ -3551,27 +3740,28 @@ func (i *Instance) queryCodexSessionFromHostLsof() (string, string) {
 		// #nosec G204 -- "lsof" is a fixed binary; only dynamic arg is strconv.Itoa(int).
 		out, err := exec.CommandContext(ctx, "lsof", "-n", "-P", "-p", strconv.Itoa(pid)).Output()
 		cancel()
+		if sessionID := i.extractAcceptedCodexSessionIDFromOutput(out); sessionID != "" {
+			return sessionID, "", nil
+		}
 		if err != nil {
 			var execErr *exec.Error
 			if errors.As(err, &execErr) && execErr.Err == exec.ErrNotFound {
-				return "", "lsof"
+				return "", "lsof", fmt.Errorf("codex process probe: run lsof: %w", err)
 			}
 			sessionLog.Debug("codex_lsof_probe_failed", slog.Int("pid", pid), slog.Any("error", err))
+			probeErr = errors.Join(probeErr, fmt.Errorf("codex process probe: lsof pid %d: %w", pid, err))
 			continue
-		}
-
-		if sessionID := extractCodexSessionIDFromLsofOutput(out); sessionID != "" {
-			return sessionID, ""
 		}
 	}
 
-	return "", ""
+	return "", "", probeErr
 }
 
 // queryCodexSessionFromProcessFiles inspects live Codex processes and returns
-// the active session UUID inferred from open rollout JSONL files.
-// The second return value is the missing dependency name (if any).
-func (i *Instance) queryCodexSessionFromProcessFiles() (string, string) {
+// the active session UUID inferred from open rollout JSONL files. Empty ID with
+// nil error means definitely absent; a non-nil error means undetermined. The
+// second return value names a missing dependency, when applicable.
+func (i *Instance) queryCodexSessionFromProcessFiles() (string, string, error) {
 	// Sandboxed sessions run Codex inside Docker; probe container /proc.
 	if i.IsSandboxed() {
 		return i.queryCodexSessionFromDockerProcFD()
@@ -3579,14 +3769,24 @@ func (i *Instance) queryCodexSessionFromProcessFiles() (string, string) {
 
 	// Linux/WSL: pure in-process /proc scanning (no lsof dependency).
 	if runtime.GOOS == "linux" {
-		if sessionID := i.queryCodexSessionFromHostProcFD(); sessionID != "" {
-			return sessionID, ""
-		}
-		return "", ""
+		sessionID, err := i.queryCodexSessionFromHostProcFD()
+		return sessionID, "", err
 	}
 
-	// Non-Linux (e.g. macOS): fallback to lsof compatibility path.
-	return i.queryCodexSessionFromHostLsof()
+	// Non-Linux (e.g. macOS): in-process libproc FD scan first, with lsof kept
+	// only as a compatibility fallback when the native probe cannot answer.
+	candidates, candidateErr := i.collectCodexProcessCandidates()
+	if sessionID, nativeErr := i.queryCodexSessionFromHostNative(candidates); sessionID != "" {
+		return sessionID, "", nil
+	} else if nativeErr == nil && candidateErr == nil {
+		return "", "", nil
+	}
+
+	sessionID, missingDep, lsofErr := i.queryCodexSessionFromHostLsof(candidates)
+	if sessionID != "" {
+		return sessionID, "", nil
+	}
+	return "", missingDep, errors.Join(candidateErr, lsofErr)
 }
 
 // ConsumeCodexRestartWarning returns and clears any pending Codex restart warning.
@@ -3636,42 +3836,30 @@ func (i *Instance) updateCodexSession(excludeIDs map[string]bool, forceProbe boo
 	// 2. Prefer live-process file detection (Linux /proc, macOS lsof fallback).
 	missingProbeDep := ""
 	if i.shouldRunCodexProcessProbe(forceProbe) {
-		if sessionID, missingDep := i.queryCodexSessionFromProcessFiles(); sessionID != "" {
-			// Subagent-thread gate (incident 2026-07-15): a codex TUI holds the
-			// rollouts of the subagents it spawned open alongside its main
-			// thread, so the FD probe can surface a subagent id. Binding it here
-			// is the same poisoning the hook gate prevents, reached by the other
-			// rotation path — and once bound, a restart resumes a thread codex
-			// refuses user turns on. Reject it and keep the current binding; the
-			// probe will pick the main thread on a later cycle. See
-			// codex_subagent_gate.go.
-			if i.shouldRejectCodexSubagentRebind(sessionID) {
-				_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
-					InstanceID: i.ID, Tool: i.Tool, Action: "reject",
-					Source: "process_probe", OldID: i.CodexSessionID, Candidate: sessionID,
-					Reason: "candidate_is_subagent_thread",
-				})
-				sessionLog.Debug("codex_session_probe_rejected_subagent",
+		sessionID, missingDep, probeErr := i.queryCodexSessionFromProcessFiles()
+		sessionID = i.filterCodexProcessProbeCandidate(sessionID)
+		if sessionID != "" {
+			changed := sessionID != i.CodexSessionID
+			if changed {
+				sessionLog.Debug(
+					"codex_session_update_from_probe",
 					slog.String("old_id", i.CodexSessionID),
-					slog.String("candidate", sessionID))
-			} else {
-				changed := sessionID != i.CodexSessionID
-				if changed {
-					sessionLog.Debug(
-						"codex_session_update_from_probe",
-						slog.String("old_id", i.CodexSessionID),
-						slog.String("new_id", sessionID),
-					)
-				}
-				i.CodexSessionID = sessionID
-				i.CodexDetectedAt = time.Now()
-				if i.tmuxSession != nil && i.tmuxSession.Exists() && (changed || envSessionID == "") {
-					_ = i.tmuxSession.SetEnvironment("CODEX_SESSION_ID", i.CodexSessionID)
-				}
-				return ""
+					slog.String("new_id", sessionID),
+				)
 			}
-		} else if missingDep != "" {
+			i.CodexSessionID = sessionID
+			i.CodexDetectedAt = time.Now()
+			if i.tmuxSession != nil && i.tmuxSession.Exists() && (changed || envSessionID == "") {
+				_ = i.tmuxSession.SetEnvironment("CODEX_SESSION_ID", i.CodexSessionID)
+			}
+			return ""
+		}
+		if missingDep != "" {
 			missingProbeDep = missingDep
+		}
+		if probeErr != nil {
+			sessionLog.Debug("codex_session_probe_undetermined", slog.Any("error", probeErr))
+			return missingProbeDep
 		}
 	}
 
@@ -8947,6 +9135,7 @@ func (i *Instance) restart(env map[string]string) error {
 // so the next start gets a brand-new tool session ID.
 func (i *Instance) RestartFresh() error {
 	i.prepareRestartMCPConfig()
+	i.spawnGen.Add(1)
 
 	i.clearSessionBindingForFreshStart()
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -569,11 +569,10 @@ type Instance struct {
 	// UpdateStatus() acquires the write lock internally.
 	mu sync.RWMutex
 
-	// spawnGen is bumped on every Start/StartWithMessage/Stop so the fast-death
-	// watcher (#1580) can detect that a newer spawn or a deliberate stop has
-	// superseded it — race-free, without reading the mutex-guarded status fields
-	// from its own goroutine.
-	spawnGen atomic.Uint64
+	// spawnGen supersedes stale fast-death watchers; spawnWatchers lets teardown
+	// and tests join them before restoring process-global filesystem environment.
+	spawnGen      atomic.Uint64
+	spawnWatchers sync.WaitGroup
 
 	// spawnGenMu guards spawnGenWake. spawnGenWake lets a generation bump wake a
 	// running watchForFastDeath goroutine immediately instead of it only
@@ -4925,20 +4924,7 @@ func (i *Instance) Start() error {
 	// the exemption every completed one-shot would be recorded as died-fast and
 	// the preview would paint "⚠ session failed to start" over its answer.
 	if command != "" && !i.expectsFastExit() {
-		// gen AND the wake channel are both produced here, in the caller, so no
-		// bump can slip into the gap before the watcher subscribes (see
-		// newSpawnGenWatch).
-		gen, wake := i.newSpawnGenWatch()
-		// Resolve both write targets HERE, synchronously in the caller, not
-		// inside the goroutine: GetSessionIDLifecycleLogPath()/spawnFailureDir()
-		// read the live $HOME, and watchForFastDeath's goroutine is never
-		// joined — it can still be sleeping on its ticker when a later test
-		// changes $HOME out from under it. Capturing the resolved paths as
-		// plain values at spawn time (Go evaluates `go` call arguments in the
-		// calling goroutine) makes the watcher's writes land in the HOME that
-		// was live when this session started, never whichever HOME happens to
-		// be live when the ticker next fires.
-		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
+		i.startFastDeathWatcher(command, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level
@@ -5242,11 +5228,8 @@ func (i *Instance) StartWithMessage(message string) error {
 	}
 
 	// #1580: fast-death watcher (sister path to Start()).
-	if command != "" {
-		gen, wake := i.newSpawnGenWatch()
-		// See the matching comment in Start(): resolve the write targets — and
-		// subscribe to the wake — here, not inside the never-joined goroutine.
-		go i.watchForFastDeath(command, gen, wake, i.tmuxSession, i.ID, i.Tool, sessionLog, GetSessionIDLifecycleLogPath(), spawnFailureDir())
+	if command != "" && !i.expectsFastExit() {
+		i.startFastDeathWatcher(command, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -569,10 +569,11 @@ type Instance struct {
 	// UpdateStatus() acquires the write lock internally.
 	mu sync.RWMutex
 
-	// spawnGen supersedes stale fast-death watchers; spawnWatchers lets tests join
-	// them before restoring process-global filesystem environment.
-	spawnGen      atomic.Uint64
-	spawnWatchers sync.WaitGroup
+	// spawnGen is bumped on every Start/StartWithMessage/Stop so the fast-death
+	// watcher (#1580) can detect that a newer spawn or a deliberate stop has
+	// superseded it — race-free, without reading the mutex-guarded status fields
+	// from its own goroutine.
+	spawnGen atomic.Uint64
 
 	// spawnGenMu guards spawnGenWake. spawnGenWake lets a generation bump wake a
 	// running watchForFastDeath goroutine immediately instead of it only

--- a/internal/session/instance_cli_parity_test.go
+++ b/internal/session/instance_cli_parity_test.go
@@ -156,7 +156,6 @@ func TestUpdateStatus_CLIvsTUIParity_SameTmuxState(t *testing.T) {
 
 	writeHookFile(t, base.ID, "running", 180)
 	setPaneTitle(t, base.tmuxSession.Name, "⠴ Running tool")
-	time.Sleep(2 * time.Second)
 
 	tuiInst := reloadInstanceForParityTest(base)
 	cliInst := reloadInstanceForParityTest(base)

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -3856,7 +3856,7 @@ exit 1
 		t.Fatal(err)
 	}
 	gotArgs := strings.Fields(string(rawArgs))
-	wantArgs := []string{"-L", "test-socket", "list-panes", "-s", "-t", "multi-window", "-F", "#{pane_pid}"}
+	wantArgs := []string{"-u", "-L", "test-socket", "list-panes", "-s", "-t", "multi-window", "-F", "#{pane_pid}"}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
 		t.Fatalf("tmux args = %q, want %q", gotArgs, wantArgs)
 	}

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +19,8 @@ import (
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/asheshgoplani/agent-deck/internal/docker"
+	"github.com/asheshgoplani/agent-deck/internal/procfd"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1801,7 +1805,9 @@ func TestCanRestartCursor(t *testing.T) {
 	skipIfNoTmuxBinary(t)
 
 	inst := NewInstanceWithTool("cursor-restart-test", "/tmp", "cursor")
-	inst.Command = "sleep 60"
+	// Keep the synthetic process alive when Restart appends --continue; CI does
+	// not install Cursor.
+	inst.Command = "sh -c 'sleep 60' --"
 	err := inst.Start()
 	if err != nil {
 		t.Fatalf("Failed to start session: %v", err)
@@ -3483,6 +3489,7 @@ func TestInstance_UpdateCodexSession_ScanCooldown(t *testing.T) {
 	}
 
 	inst := NewInstanceWithTool("codex-cooldown", projectPath, "codex")
+	inst.lastCodexProbeAt = time.Now().Add(time.Hour) // This test isolates disk-scan cooldown.
 
 	sessionID1 := "11111111-1111-4111-8111-111111111111"
 	sessionID2 := "22222222-2222-4222-8222-222222222222"
@@ -3583,6 +3590,7 @@ func TestInstance_CodexSessionExclusion_SameProjectPath(t *testing.T) {
 
 	// Instance 1 picks up sessionB (most recent) with no exclusions.
 	inst1 := NewInstanceWithTool("codex-excl-1", projectPath, "codex")
+	inst1.lastCodexProbeAt = time.Now().Add(time.Hour) // This test isolates disk exclusion.
 	inst1.UpdateCodexSession(nil)
 	if inst1.CodexSessionID != sessionB {
 		t.Fatalf("inst1 picked %q, want %q", inst1.CodexSessionID, sessionB)
@@ -3590,6 +3598,7 @@ func TestInstance_CodexSessionExclusion_SameProjectPath(t *testing.T) {
 
 	// Instance 2 excludes inst1's session and gets sessionA instead.
 	inst2 := NewInstanceWithTool("codex-excl-2", projectPath, "codex")
+	inst2.lastCodexProbeAt = time.Now().Add(time.Hour)
 	exclude := map[string]bool{sessionB: true}
 	inst2.UpdateCodexSession(exclude)
 	if inst2.CodexSessionID != sessionA {
@@ -3692,6 +3701,48 @@ func TestCodexLsofProbe_TimeoutBoundsHungLsof(t *testing.T) {
 	}
 }
 
+func TestQueryCodexSessionFromHostLsofCompleteness(t *testing.T) {
+	const wantID = "019c9ffa-c9d6-7be1-9e1c-527080e68951"
+	tests := []struct {
+		name    string
+		script  string
+		wantID  string
+		wantErr bool
+	}{
+		{name: "all probes fail", script: "exit 2\n", wantErr: true},
+		{
+			name:    "one failed probe makes a negative incomplete",
+			script:  "[ \"$4\" = 123 ] && exit 2\necho /dev/null\n",
+			wantErr: true,
+		},
+		{name: "all successful probes with no match", script: "echo /dev/null\n"},
+		{
+			name:   "positive output is definitive despite command failure",
+			script: "echo /tmp/sessions/2026/07/01/rollout-2026-07-01T00-00-00-" + wantID + ".jsonl\nexit 2\n",
+			wantID: wantID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			fakeLsof := filepath.Join(dir, "lsof")
+			if err := os.WriteFile(fakeLsof, []byte("#!/bin/sh\n"+test.script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir)
+
+			gotID, missingDep, err := (&Instance{}).queryCodexSessionFromHostLsof([]int{123, 456})
+			if gotID != test.wantID || (err != nil) != test.wantErr {
+				t.Fatalf("lsof probe = (%q, %q, %v), want ID %q, error=%v", gotID, missingDep, err, test.wantID, test.wantErr)
+			}
+			if missingDep != "" {
+				t.Fatalf("lsof probe missing dependency = %q, want empty", missingDep)
+			}
+		})
+	}
+}
+
 func TestExtractCodexSessionIDFromLsofOutput_DockerStyleLine(t *testing.T) {
 	lsofOutput := []byte(`codex 44 root 36w REG 0,608 3392413 5176210 /root/.codex/sessions/2026/02/23/rollout-2026-02-23T18-37-01-019c8a12-e903-7670-bd12-709c6a4c5451.jsonl
 `)
@@ -3723,9 +3774,10 @@ func TestExtractCodexSessionIDFromPath_CustomCodexHome(t *testing.T) {
 
 func TestParsePSParentChildMap(t *testing.T) {
 	procTable := []byte("100 1\n101 100\n102 100\n103 101\nbad-line\n104 invalid\n105 0\n")
-	got := parsePSParentChildMap(procTable)
+	got, err := parsePSParentChildMap(procTable)
 
 	want := map[int][]int{
+		0:   {105},
 		1:   {100},
 		100: {101, 102},
 		101: {103},
@@ -3733,14 +3785,294 @@ func TestParsePSParentChildMap(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("parsePSParentChildMap() = %#v, want %#v", got, want)
 	}
+	if err == nil {
+		t.Fatal("malformed ps rows must make the process table incomplete")
+	}
 }
 
 func TestCollectProcessTreePIDsFromTable(t *testing.T) {
 	procTable := []byte("100 1\n101 100\n102 100\n103 101\n104 999\n")
-	got := collectProcessTreePIDsFromTable(100, procTable)
-	want := []int{100, 101, 102, 103}
+	got, err := collectProcessTreePIDsFromTable([]int{100, 104}, procTable)
+	want := []int{100, 104, 101, 102, 103}
+	if err != nil {
+		t.Fatalf("collectProcessTreePIDsFromTable() error = %v", err)
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("collectProcessTreePIDsFromTable() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectProcessTreePIDsFromTableRequiresRoot(t *testing.T) {
+	got, err := collectProcessTreePIDsFromTable([]int{100}, []byte("101 1\n"))
+	if len(got) != 0 || err == nil {
+		t.Fatalf("process tree without root = (%v, %v), want (empty, error)", got, err)
+	}
+}
+
+func TestParsePositivePIDsReportsPartialOutput(t *testing.T) {
+	pids, err := parsePositivePIDs([]byte("100\ninvalid\n200\n"), "tmux pane")
+	if want := []int{100, 200}; !reflect.DeepEqual(pids, want) {
+		t.Fatalf("parsed pane pids = %v, want %v", pids, want)
+	}
+	if err == nil {
+		t.Fatal("invalid pane pid must make candidate discovery incomplete")
+	}
+}
+
+func TestCollectTmuxPaneProcessTreePIDsUsesEveryWindow(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	fakeTmux := filepath.Join(dir, "tmux")
+	script := fmt.Sprintf(`#!/bin/sh
+case " $* " in
+*" has-session "*) exit 0 ;;
+*" list-panes "*)
+	printf '%%s\n' "$@" > %s
+	printf '99999990\n99999991\n'
+	exit 0
+	;;
+esac
+exit 1
+`, shellescape.Quote(argsFile))
+	if err := os.WriteFile(fakeTmux, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	inst := &Instance{
+		TmuxSocketName: "test-socket",
+		tmuxSession:    &tmux.Session{Name: "multi-window", SocketName: "test-socket"},
+	}
+	pids, err := inst.collectTmuxPaneProcessTreePIDs()
+	if err != nil {
+		t.Fatalf("collect session panes: %v", err)
+	}
+	if want := []int{99999990, 99999991}; !reflect.DeepEqual(pids, want) {
+		t.Fatalf("collected pane pids = %v, want %v", pids, want)
+	}
+
+	rawArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotArgs := strings.Fields(string(rawArgs))
+	wantArgs := []string{"-L", "test-socket", "list-panes", "-s", "-t", "multi-window", "-F", "#{pane_pid}"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("tmux args = %q, want %q", gotArgs, wantArgs)
+	}
+}
+
+func TestCollectProcessTreePIDsViaPgrepReportsFailure(t *testing.T) {
+	dir := t.TempDir()
+	fakePgrep := filepath.Join(dir, "pgrep")
+	if err := os.WriteFile(fakePgrep, []byte("#!/bin/sh\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	pids, err := collectProcessTreePIDsViaPgrep(100)
+	if err == nil {
+		t.Fatal("pgrep execution failure must make process-tree discovery incomplete")
+	}
+	if want := []int{100}; !reflect.DeepEqual(pids, want) {
+		t.Fatalf("partial process tree = %v, want %v", pids, want)
+	}
+}
+
+func TestIsLikelyCodexProcessPIDReportsPSFailure(t *testing.T) {
+	if _, err := isLikelyCodexProcessPID(99999999); err == nil {
+		t.Fatal("ps failure must not be reported as a non-Codex process")
+	}
+}
+
+func TestCodexProcFDProbeScriptCompleteness(t *testing.T) {
+	const wantID = "019c9ffa-c9d6-7be1-9e1c-527080e68951"
+	run := func(t *testing.T, root string) []byte {
+		t.Helper()
+		out, err := exec.Command("/bin/sh", "-c", codexProcFDProbeScript(root)).CombinedOutput()
+		if err != nil {
+			t.Fatalf("run procfd probe script: %v\n%s", err, out)
+		}
+		return out
+	}
+
+	t.Run("clean absence", func(t *testing.T) {
+		root := t.TempDir()
+		fdDir := filepath.Join(root, "100", "fd")
+		if err := os.MkdirAll(fdDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("/dev/null", filepath.Join(fdDir, "3")); err != nil {
+			t.Fatal(err)
+		}
+		out := run(t, root)
+		if bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) || extractCodexSessionIDFromLsofOutput(out) != "" {
+			t.Fatalf("clean procfd output = %q, want complete absence", out)
+		}
+	})
+
+	t.Run("empty proc root is incomplete", func(t *testing.T) {
+		out := run(t, t.TempDir())
+		if !bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) {
+			t.Fatalf("empty proc root output = %q, want incomplete sentinel", out)
+		}
+	})
+
+	t.Run("missing fd directory is incomplete", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, "100"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		out := run(t, root)
+		if !bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) {
+			t.Fatalf("missing fd directory output = %q, want incomplete sentinel", out)
+		}
+	})
+
+	t.Run("empty fd directory is incomplete", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "100", "fd"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		out := run(t, root)
+		if !bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) {
+			t.Fatalf("empty fd directory output = %q, want incomplete sentinel", out)
+		}
+	})
+
+	t.Run("failed fd readlink is incomplete", func(t *testing.T) {
+		root := t.TempDir()
+		fdDir := filepath.Join(root, "100", "fd")
+		if err := os.MkdirAll(fdDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(fdDir, "3"), []byte("not a symlink"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out := run(t, root)
+		if !bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) {
+			t.Fatalf("failed readlink output = %q, want incomplete sentinel", out)
+		}
+	})
+
+	t.Run("deleted open rollout remains discoverable", func(t *testing.T) {
+		root := t.TempDir()
+		fdDir := filepath.Join(root, "100", "fd")
+		rolloutDir := filepath.Join(root, "sessions", "2026", "08", "03")
+		if err := os.MkdirAll(fdDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(rolloutDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rollout := filepath.Join(rolloutDir, "rollout-2026-08-03T00-00-00-"+wantID+".jsonl")
+		if err := os.WriteFile(rollout, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(rollout, filepath.Join(fdDir, "4")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(rollout); err != nil {
+			t.Fatal(err)
+		}
+		if got := extractCodexSessionIDFromLsofOutput(run(t, root)); got != wantID {
+			t.Fatalf("deleted rollout session ID = %q, want %q", got, wantID)
+		}
+	})
+
+	t.Run("unreadable fd directory is incomplete", func(t *testing.T) {
+		root := t.TempDir()
+		fdDir := filepath.Join(root, "100", "fd")
+		if err := os.MkdirAll(fdDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(fdDir, 0); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(fdDir, 0o700) })
+		out := run(t, root)
+		if !bytes.Contains(out, []byte(codexProbeIncompleteSentinel)) {
+			t.Fatalf("unreadable fd directory output = %q, want incomplete sentinel", out)
+		}
+	})
+}
+
+func TestQueryCodexSessionFromDockerProcFDCompleteness(t *testing.T) {
+	const wantID = "019c9ffa-c9d6-7be1-9e1c-527080e68951"
+	tests := []struct {
+		name        string
+		output      string
+		exitCode    int
+		wantID      string
+		wantMissing string
+		wantErr     bool
+	}{
+		{name: "clean absence"},
+		{name: "readlink missing", output: codexProbeMissingSentinel, wantMissing: "readlink", wantErr: true},
+		{name: "incomplete fd scan", output: codexProbeIncompleteSentinel, wantErr: true},
+		{name: "docker failure", exitCode: 2, wantErr: true},
+		{
+			name:     "positive output wins over docker failure",
+			output:   "/tmp/sessions/2026/08/03/rollout-2026-08-03T00-00-00-" + wantID + ".jsonl",
+			exitCode: 2,
+			wantID:   wantID,
+		},
+		{
+			name:   "positive path wins over incomplete sentinel",
+			output: "/tmp/sessions/2026/08/03/rollout-2026-08-03T00-00-00-" + wantID + ".jsonl\n" + codexProbeIncompleteSentinel,
+			wantID: wantID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			fakeDocker := filepath.Join(dir, "docker")
+			script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' %q\nexit %d\n", test.output, test.exitCode)
+			if err := os.WriteFile(fakeDocker, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir)
+
+			inst := &Instance{SandboxContainer: "test"}
+			gotID, missingDep, err := inst.queryCodexSessionFromDockerProcFD()
+			if gotID != test.wantID || missingDep != test.wantMissing || (err != nil) != test.wantErr {
+				t.Fatalf("docker probe = (%q, %q, %v), want (%q, %q, error=%v)", gotID, missingDep, err, test.wantID, test.wantMissing, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestCodexProcessCandidateDiscoveryFailureIsUndetermined(t *testing.T) {
+	inst := &Instance{}
+	if _, err := inst.collectCodexProcessCandidates(); err == nil {
+		t.Fatal("missing tmux session must make candidate discovery undetermined")
+	}
+	if _, _, err := inst.queryCodexSessionFromProcessFiles(); err == nil {
+		t.Fatal("incomplete candidate discovery must reach the process-file caller")
+	}
+}
+
+func TestUpdateCodexSessionUndeterminedProbeSkipsDiskFallback(t *testing.T) {
+	const diskID = "019c9ffa-c9d6-7be1-9e1c-527080e68951"
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	dir := filepath.Join(codexHome, "sessions", "2026", "08", "03")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inst := &Instance{
+		Tool:           "codex",
+		CodexStartedAt: time.Now().Add(-time.Second).UnixMilli(),
+	}
+	path := filepath.Join(dir, "rollout-2026-08-03T00-00-00-"+diskID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	inst.updateCodexSession(nil, true)
+	if inst.CodexSessionID != "" {
+		t.Fatalf("undetermined process probe fell through to disk ID %q", inst.CodexSessionID)
 	}
 }
 
@@ -4679,6 +5011,137 @@ func TestInstance_RefreshLiveSessionIDs_NoOpForNonAgenticTool(t *testing.T) {
 	if inst.GeminiSessionID != "leftover-gemini" {
 		t.Errorf("GeminiSessionID mutated for non-agentic tool: got %q", inst.GeminiSessionID)
 	}
+}
+
+// TestQueryCodexSessionFromHostNative exercises the issue #1552 replacement
+// for per-PID lsof against the real libproc scan: a child process holding a
+// rollout-shaped file open, probed in-process via internal/procfd. The probe
+// semantics themselves are pinned cross-platform by
+// TestQueryCodexSessionFromHostNativeSemantics below.
+func TestQueryCodexSessionFromHostNative(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("real native probe requires darwin; semantics covered by TestQueryCodexSessionFromHostNativeSemantics")
+	}
+
+	const wantID = "019c9ffa-c9d6-7be1-9e1c-527080e68951"
+	dir := filepath.Join(t.TempDir(), "sessions", "2026", "07", "01")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rollout, err := os.Create(filepath.Join(dir, "rollout-2026-07-01T00-00-00-"+wantID+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rollout.Close()
+
+	cmd := exec.Command("/bin/sleep", "30")
+	cmd.Stdout = rollout
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	inst := &Instance{}
+	gotID, err := inst.queryCodexSessionFromHostNative([]int{cmd.Process.Pid})
+	if err != nil {
+		t.Fatalf("native probe failed to answer on darwin: %v", err)
+	}
+	if gotID != wantID {
+		t.Errorf("native probe session ID = %q, want %q", gotID, wantID)
+	}
+}
+
+// TestQueryCodexSessionFromHostNativeSemantics pins the native probe's
+// found/absent/undetermined contract and its ID extraction on every platform
+// via the procfdOpenVnodePaths seam, so the ubuntu CI gate exercises the logic
+// that decides whether the lsof fallback runs (#1552).
+func TestQueryCodexSessionFromHostNativeSemantics(t *testing.T) {
+	const wantID = "019c9ffa-c9d6-7be1-9e1c-527080e68951"
+	restore := procfdOpenVnodePaths
+	defer func() { procfdOpenVnodePaths = restore }()
+
+	inst := &Instance{}
+
+	t.Run("extracts session ID from an open rollout path", func(t *testing.T) {
+		procfdOpenVnodePaths = func(int) ([]string, error) {
+			return []string{
+				"/dev/null",
+				"/Users/u/.codex/sessions/2026/07/01/rollout-2026-07-01T00-00-00-" + wantID + ".jsonl",
+			}, nil
+		}
+		gotID, err := inst.queryCodexSessionFromHostNative([]int{123})
+		if err != nil || gotID != wantID {
+			t.Fatalf("got (%q, %v), want (%q, nil)", gotID, err, wantID)
+		}
+	})
+
+	t.Run("all PIDs erroring means unanswered so lsof fallback stays reachable", func(t *testing.T) {
+		procfdOpenVnodePaths = func(int) ([]string, error) {
+			return nil, fmt.Errorf("proc_pidinfo: %w", os.ErrPermission)
+		}
+		if _, err := inst.queryCodexSessionFromHostNative([]int{123, 456}); err == nil {
+			t.Fatal("errored probes must return undetermined to trigger the lsof fallback")
+		}
+	})
+
+	t.Run("unsupported platform is unanswered", func(t *testing.T) {
+		procfdOpenVnodePaths = func(int) ([]string, error) { return nil, procfd.ErrUnsupported }
+		if _, err := inst.queryCodexSessionFromHostNative([]int{123}); !errors.Is(err, procfd.ErrUnsupported) {
+			t.Fatalf("ErrUnsupported probe error = %v, want ErrUnsupported", err)
+		}
+	})
+
+	t.Run("partial scan failure falls back to lsof", func(t *testing.T) {
+		calls := 0
+		procfdOpenVnodePaths = func(int) ([]string, error) {
+			calls++
+			if calls == 1 {
+				return nil, fmt.Errorf("proc_pidinfo: %w", os.ErrPermission)
+			}
+			return []string{"/dev/null"}, nil
+		}
+		gotID, err := inst.queryCodexSessionFromHostNative([]int{123, 456})
+		if err == nil || gotID != "" {
+			t.Fatalf("got (%q, %v), want (\"\", error): a partial scan cannot answer conclusively", gotID, err)
+		}
+	})
+
+	t.Run("a positive partial scan is still definitive", func(t *testing.T) {
+		procfdOpenVnodePaths = func(int) ([]string, error) {
+			return []string{
+				"/Users/u/.codex/sessions/2026/07/01/rollout-2026-07-01T00-00-00-" + wantID + ".jsonl",
+			}, os.ErrPermission
+		}
+		gotID, err := inst.queryCodexSessionFromHostNative([]int{123})
+		if err != nil || gotID != wantID {
+			t.Fatalf("got (%q, %v), want (%q, nil)", gotID, err, wantID)
+		}
+	})
+
+	t.Run("all successful scans with no match answer negatively", func(t *testing.T) {
+		procfdOpenVnodePaths = func(int) ([]string, error) {
+			return []string{"/dev/null"}, nil
+		}
+		gotID, err := inst.queryCodexSessionFromHostNative([]int{123, 456})
+		if err != nil || gotID != "" {
+			t.Fatalf("got (%q, %v), want (\"\", nil)", gotID, err)
+		}
+	})
+
+	t.Run("empty candidate list counts as answered", func(t *testing.T) {
+		procfdOpenVnodePaths = func(int) ([]string, error) {
+			t.Fatal("probe must not be called with no candidates")
+			return nil, nil
+		}
+		// lsof would scan nothing either, so the fallback (and its
+		// missing-lsof warning) must not be triggered.
+		if _, err := inst.queryCodexSessionFromHostNative(nil); err != nil {
+			t.Errorf("empty candidate list error = %v, want nil", err)
+		}
+	})
 }
 
 // TestShouldRunCodexProcessProbeSteadyStateBackoff covers issue #1552: once a

--- a/internal/session/issue1421_stale_ssh_socket_test.go
+++ b/internal/session/issue1421_stale_ssh_socket_test.go
@@ -18,7 +18,12 @@ import (
 // bound the Unix-socket dial. The sweep removes the dead socket so the next ssh
 // opens a fresh master instead of blocking.
 func TestIssue1421_CleanStaleSSHSockets(t *testing.T) {
-	dir := t.TempDir()
+	// t.TempDir includes the long test name, which can exceed Darwin's 104-byte sun_path limit.
+	dir, err := os.MkdirTemp("", "ad-ssh-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 
 	// (a) Stale socket: a leftover socket inode with no listener — exactly the
 	// on-disk state a crashed/killed SSH master leaves behind. SetUnlinkOnClose

--- a/internal/session/issue1580_spawn_failure_test.go
+++ b/internal/session/issue1580_spawn_failure_test.go
@@ -96,6 +96,22 @@ func TestIssue1580_TmuxStartFailureRecorded(t *testing.T) {
 	assert.Contains(t, readLifecycleLog(t), "spawn_failed")
 }
 
+func TestIssue1580_DeliberateKillDoesNotRecordFastDeath(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstance("test-1580-deliberate-kill", "/tmp")
+	inst.Tool = "customlive1580"
+	inst.Command = "sleep 60"
+	t.Cleanup(func() { clearSpawnFailureRecord(inst.ID) })
+
+	require.NoError(t, inst.Start())
+	require.NoError(t, inst.Kill())
+	inst.waitForFastDeathWatchers()
+	rec, err := readSpawnFailureRecord(inst.ID)
+	require.NoError(t, err)
+	assert.Nil(t, rec)
+}
+
 // TestIssue1580_FastDeathWatcherCapturesDyingOutput is the behavioral repro. A
 // real tmux session runs a custom command whose initial process prints a marker
 // then exits non-zero. The watcher must capture the dying output and persist a
@@ -118,11 +134,14 @@ func TestIssue1580_FastDeathWatcherCapturesDyingOutput(t *testing.T) {
 	defer func() { _ = inst.Kill() }()
 
 	// Wait for the watcher (250ms tick, 15s window) to observe the death and
-	// persist the record.
+	// persist both the record and lifecycle event.
 	var rec *SpawnFailureRecord
+	var lifecycle string
 	deadline := time.Now().Add(8 * time.Second)
 	for time.Now().Before(deadline) {
-		if rec = inst.SpawnFailure(); rec != nil && rec.Reason == "spawn_died_fast" {
+		rec = inst.SpawnFailure()
+		lifecycle = readLifecycleLog(t)
+		if rec != nil && rec.Reason == "spawn_died_fast" && strings.Contains(lifecycle, "spawn_died_fast") {
 			break
 		}
 		time.Sleep(150 * time.Millisecond)
@@ -135,7 +154,7 @@ func TestIssue1580_FastDeathWatcherCapturesDyingOutput(t *testing.T) {
 	assert.Greater(t, rec.ElapsedMs, int64(0), "elapsed time must be positive")
 
 	// The lifecycle log must carry the spawn_died_fast trace.
-	assert.Contains(t, readLifecycleLog(t), "spawn_died_fast")
+	assert.Contains(t, lifecycle, "spawn_died_fast")
 
 	// PreviewFull falls back to the record now that the pane is gone.
 	preview, err := inst.PreviewFull()

--- a/internal/session/issue1580_spawn_failure_test.go
+++ b/internal/session/issue1580_spawn_failure_test.go
@@ -106,7 +106,6 @@ func TestIssue1580_DeliberateKillDoesNotRecordFastDeath(t *testing.T) {
 
 	require.NoError(t, inst.Start())
 	require.NoError(t, inst.Kill())
-	inst.waitForFastDeathWatchers()
 	rec, err := readSpawnFailureRecord(inst.ID)
 	require.NoError(t, err)
 	assert.Nil(t, rec)

--- a/internal/session/issue1580_spawn_failure_test.go
+++ b/internal/session/issue1580_spawn_failure_test.go
@@ -105,7 +105,22 @@ func TestIssue1580_DeliberateKillDoesNotRecordFastDeath(t *testing.T) {
 	t.Cleanup(func() { clearSpawnFailureRecord(inst.ID) })
 
 	require.NoError(t, inst.Start())
+	watcherDone := make(chan struct{})
+	go func() {
+		inst.waitForFastDeathWatchers()
+		close(watcherDone)
+	}()
+	select {
+	case <-watcherDone:
+		t.Fatal("fast-death watcher was not registered before Start returned")
+	case <-time.After(50 * time.Millisecond):
+	}
 	require.NoError(t, inst.Kill())
+	select {
+	case <-watcherDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast-death watcher did not stop after Kill superseded it")
+	}
 	rec, err := readSpawnFailureRecord(inst.ID)
 	require.NoError(t, err)
 	assert.Nil(t, rec)

--- a/internal/session/mcp_child_reap.go
+++ b/internal/session/mcp_child_reap.go
@@ -133,8 +133,8 @@ func (i *Instance) discoverMCPChildrenFromPaneTree() {
 	if err != nil || len(procTable) == 0 {
 		return
 	}
-	childrenByParent := parsePSParentChildMap(procTable)
-	if len(childrenByParent) == 0 {
+	childrenByParent, parseErr := parsePSParentChildMap(procTable)
+	if parseErr != nil || len(childrenByParent) == 0 {
 		return
 	}
 	// Same snapshot, so the leader identity cannot disagree with the tree.

--- a/internal/session/mcp_reap_depth_test.go
+++ b/internal/session/mcp_reap_depth_test.go
@@ -66,14 +66,14 @@ func TestParsePSCommandNames(t *testing.T) {
 		}
 	}
 
-	// the same snapshot must still yield a usable parent/child map, since both
-	// classifications are made against one ps call by design
-	// #1687 made this fail-closed: it now also reports malformed rows. A
-	// 3-column snapshot is well-formed by design here, so err must be nil --
-	// that is the assertion protecting the shared-snapshot contract above.
+	// The same snapshot must still yield the valid parent/child relationships,
+	// since both classifications are made against one ps call by design. Unlike
+	// parsePSCommandNames, #1687 deliberately makes the process-tree parser
+	// report malformed rows (the "garbage line" above) so an incomplete process
+	// scan cannot be mistaken for an empty one.
 	children, err := parsePSParentChildMap(procTable)
-	if err != nil {
-		t.Errorf("3-column ps output must parse cleanly, got: %v", err)
+	if err == nil {
+		t.Error("malformed ps row must be reported")
 	}
 	if len(children[100]) != 1 || children[100][0] != 200 {
 		t.Errorf("parent/child map lost entries on 3-column output: %#v", children)

--- a/internal/session/mcp_reap_depth_test.go
+++ b/internal/session/mcp_reap_depth_test.go
@@ -68,7 +68,13 @@ func TestParsePSCommandNames(t *testing.T) {
 
 	// the same snapshot must still yield a usable parent/child map, since both
 	// classifications are made against one ps call by design
-	children := parsePSParentChildMap(procTable)
+	// #1687 made this fail-closed: it now also reports malformed rows. A
+	// 3-column snapshot is well-formed by design here, so err must be nil --
+	// that is the assertion protecting the shared-snapshot contract above.
+	children, err := parsePSParentChildMap(procTable)
+	if err != nil {
+		t.Errorf("3-column ps output must parse cleanly, got: %v", err)
+	}
 	if len(children[100]) != 1 || children[100][0] != 200 {
 		t.Errorf("parent/child map lost entries on 3-column output: %#v", children)
 	}

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -461,8 +461,8 @@ func readCapturedClaudeArgv(t *testing.T, logPath string, timeout time.Duration)
 //   - generates a uuid-shaped inst.ClaudeSessionID from 16 random bytes,
 //   - sets inst.Command = "claude" so buildClaudeCommandWithMessage takes
 //     the `baseCommand == "claude"` branch,
-//   - registers t.Cleanup to kill the tmux session via the safe (Name-
-//     scoped) (*tmux.Session).Kill() path.
+//   - registers t.Cleanup to stop the instance through its lifecycle path so
+//     background spawn watchers are joined before the per-test HOME is restored.
 func newClaudeInstanceForDispatch(t *testing.T, home string) *Instance {
 	t.Helper()
 	var idb [4]byte
@@ -491,11 +491,8 @@ func newClaudeInstanceForDispatch(t *testing.T, home string) *Instance {
 	inst.Command = "claude"
 
 	t.Cleanup(func() {
-		// inst.tmuxSession.Kill() targets the unique session Name — SAFE;
-		// does NOT call bare `tmux kill-server`.
-		if inst.tmuxSession != nil {
-			_ = inst.tmuxSession.Kill()
-		}
+		_ = inst.Kill()
+		inst.waitForFastDeathWatchers()
 	})
 	return inst
 }

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -492,6 +492,7 @@ func newClaudeInstanceForDispatch(t *testing.T, home string) *Instance {
 
 	t.Cleanup(func() {
 		_ = inst.Kill()
+		inst.waitForFastDeathWatchers()
 	})
 	return inst
 }

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -492,7 +492,6 @@ func newClaudeInstanceForDispatch(t *testing.T, home string) *Instance {
 
 	t.Cleanup(func() {
 		_ = inst.Kill()
-		inst.waitForFastDeathWatchers()
 	})
 	return inst
 }

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -289,11 +289,10 @@ const (
 // stop or a restart/respawn bumps i.spawnGen, so a mismatch means this watcher
 // has been superseded and must exit quietly (#1580 data-race fix).
 //
-// wake is the supersede channel, subscribed by the caller via
-// newSpawnGenWatch() before this goroutine starts (see instance.go). Closing
-// it lets a supersession be noticed immediately rather than only on the next
-// spawnFastDeathTick poll — see spawnGenWake's doc comment for why the
-// up-to-one-tick tail mattered.
+// wake is the supersede channel, subscribed synchronously by
+// startFastDeathWatcher before the goroutine starts. Closing it lets a
+// supersession be noticed immediately rather than only on the next
+// spawnFastDeathTick poll.
 //
 // The generation is re-checked immediately before each write, not just once
 // per iteration: sess.Exists() shells out to tmux and can take tens of
@@ -310,12 +309,24 @@ const (
 // is suppressed. Only the writes are covered, never the tmux calls, so a stop
 // never waits on tmux.
 //
-// lifecycleLogPath and failureDir are likewise passed by value rather than
-// resolved here from the live $HOME: this goroutine is never joined, so it
-// can still be alive (parked on the ticker) after its caller's test has
-// finished and a later test has repointed $HOME. Resolving live at write
-// time would make the watcher write into whatever $HOME happens to be
-// current when it fires, not the one that was current when it was spawned.
+// lifecycleLogPath and failureDir are resolved before the goroutine starts and
+// passed by value, so the watcher cannot write through a later process-global
+// HOME value.
+func (i *Instance) startFastDeathWatcher(command string, sess *tmux.Session, id, tool string, logger *slog.Logger) {
+	gen, wake := i.newSpawnGenWatch()
+	lifecycleLogPath := GetSessionIDLifecycleLogPath()
+	failureDir := spawnFailureDir()
+	i.spawnWatchers.Add(1)
+	go func() {
+		defer i.spawnWatchers.Done()
+		i.watchForFastDeath(command, gen, wake, sess, id, tool, logger, lifecycleLogPath, failureDir)
+	}()
+}
+
+func (i *Instance) waitForFastDeathWatchers() {
+	i.spawnWatchers.Wait()
+}
+
 func (i *Instance) watchForFastDeath(command string, gen uint64, wake <-chan struct{}, sess *tmux.Session, id, tool string, logger *slog.Logger, lifecycleLogPath, failureDir string) {
 	if sess == nil {
 		return

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -289,33 +289,39 @@ const (
 // stop or a restart/respawn bumps i.spawnGen, so a mismatch means this watcher
 // has been superseded and must exit quietly (#1580 data-race fix).
 //
-// wake is the supersede channel, subscribed by the caller via
-// newSpawnGenWatch() before this goroutine starts (see instance.go). Closing
-// it lets a supersession be noticed immediately rather than only on the next
-// spawnFastDeathTick poll — see spawnGenWake's doc comment for why the
-// up-to-one-tick tail mattered.
+// wake is the supersede channel, subscribed synchronously by
+// startFastDeathWatcher via newSpawnGenWatch before the goroutine starts.
+// Closing it lets a supersession be noticed immediately rather than only on
+// the next spawnFastDeathTick poll.
 //
 // The generation is re-checked immediately before each write, not just once
 // per iteration: sess.Exists() shells out to tmux and can take tens of
 // milliseconds, and a Stop/Kill landing inside that call would otherwise be
-// observed as a vanished session — i.e. recorded as a spurious
-// spawn_died_fast for what was a deliberate teardown (and written into a HOME
-// the owning test may already be tearing down).
+// recorded as a spurious spawn_died_fast event.
 //
 // Every write additionally goes through commitSpawnWatchWrite, which re-checks
-// the generation while holding spawnWriteMu. That is what turns the remaining
-// check-then-write gap from small into closed: a teardown that bumps and then
-// takes the same mutex (bumpSpawnGenAndBarrier) is guaranteed that any write
-// still pending here either completed before it, or sees the new generation and
-// is suppressed. Only the writes are covered, never the tmux calls, so a stop
-// never waits on tmux.
+// the generation while holding spawnWriteMu. A teardown that bumps and then
+// takes the same mutex is therefore guaranteed that any pending write either
+// completed before it or sees the new generation and is suppressed.
 //
-// lifecycleLogPath and failureDir are likewise passed by value rather than
-// resolved here from the live $HOME: this goroutine is never joined, so it
-// can still be alive (parked on the ticker) after its caller's test has
-// finished and a later test has repointed $HOME. Resolving live at write
-// time would make the watcher write into whatever $HOME happens to be
-// current when it fires, not the one that was current when it was spawned.
+// lifecycleLogPath and failureDir are resolved before the goroutine starts and
+// passed by value, so even callers that do not explicitly join the watcher
+// cannot make it write through a later process-global HOME value.
+func (i *Instance) startFastDeathWatcher(command string, sess *tmux.Session, id, tool string, logger *slog.Logger) {
+	gen, wake := i.newSpawnGenWatch()
+	lifecycleLogPath := GetSessionIDLifecycleLogPath()
+	failureDir := spawnFailureDir()
+	i.spawnWatchers.Add(1)
+	go func() {
+		defer i.spawnWatchers.Done()
+		i.watchForFastDeath(command, gen, wake, sess, id, tool, logger, lifecycleLogPath, failureDir)
+	}()
+}
+
+func (i *Instance) waitForFastDeathWatchers() {
+	i.spawnWatchers.Wait()
+}
+
 func (i *Instance) watchForFastDeath(command string, gen uint64, wake <-chan struct{}, sess *tmux.Session, id, tool string, logger *slog.Logger, lifecycleLogPath, failureDir string) {
 	if sess == nil {
 		return
@@ -371,6 +377,9 @@ func (i *Instance) watchForFastDeath(command string, gen uint64, wake <-chan str
 				return
 			}
 			continue
+		}
+		if i.spawnGen.Load() != gen {
+			return
 		}
 
 		// Session is gone — but sess.Exists() shells out to tmux, so a

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -289,39 +289,33 @@ const (
 // stop or a restart/respawn bumps i.spawnGen, so a mismatch means this watcher
 // has been superseded and must exit quietly (#1580 data-race fix).
 //
-// wake is the supersede channel, subscribed synchronously by
-// startFastDeathWatcher via newSpawnGenWatch before the goroutine starts.
-// Closing it lets a supersession be noticed immediately rather than only on
-// the next spawnFastDeathTick poll.
+// wake is the supersede channel, subscribed by the caller via
+// newSpawnGenWatch() before this goroutine starts (see instance.go). Closing
+// it lets a supersession be noticed immediately rather than only on the next
+// spawnFastDeathTick poll — see spawnGenWake's doc comment for why the
+// up-to-one-tick tail mattered.
 //
 // The generation is re-checked immediately before each write, not just once
 // per iteration: sess.Exists() shells out to tmux and can take tens of
 // milliseconds, and a Stop/Kill landing inside that call would otherwise be
-// recorded as a spurious spawn_died_fast event.
+// observed as a vanished session — i.e. recorded as a spurious
+// spawn_died_fast for what was a deliberate teardown (and written into a HOME
+// the owning test may already be tearing down).
 //
 // Every write additionally goes through commitSpawnWatchWrite, which re-checks
-// the generation while holding spawnWriteMu. A teardown that bumps and then
-// takes the same mutex is therefore guaranteed that any pending write either
-// completed before it or sees the new generation and is suppressed.
+// the generation while holding spawnWriteMu. That is what turns the remaining
+// check-then-write gap from small into closed: a teardown that bumps and then
+// takes the same mutex (bumpSpawnGenAndBarrier) is guaranteed that any write
+// still pending here either completed before it, or sees the new generation and
+// is suppressed. Only the writes are covered, never the tmux calls, so a stop
+// never waits on tmux.
 //
-// lifecycleLogPath and failureDir are resolved before the goroutine starts and
-// passed by value, so even callers that do not explicitly join the watcher
-// cannot make it write through a later process-global HOME value.
-func (i *Instance) startFastDeathWatcher(command string, sess *tmux.Session, id, tool string, logger *slog.Logger) {
-	gen, wake := i.newSpawnGenWatch()
-	lifecycleLogPath := GetSessionIDLifecycleLogPath()
-	failureDir := spawnFailureDir()
-	i.spawnWatchers.Add(1)
-	go func() {
-		defer i.spawnWatchers.Done()
-		i.watchForFastDeath(command, gen, wake, sess, id, tool, logger, lifecycleLogPath, failureDir)
-	}()
-}
-
-func (i *Instance) waitForFastDeathWatchers() {
-	i.spawnWatchers.Wait()
-}
-
+// lifecycleLogPath and failureDir are likewise passed by value rather than
+// resolved here from the live $HOME: this goroutine is never joined, so it
+// can still be alive (parked on the ticker) after its caller's test has
+// finished and a later test has repointed $HOME. Resolving live at write
+// time would make the watcher write into whatever $HOME happens to be
+// current when it fires, not the one that was current when it was spawned.
 func (i *Instance) watchForFastDeath(command string, gen uint64, wake <-chan struct{}, sess *tmux.Session, id, tool string, logger *slog.Logger, lifecycleLogPath, failureDir string) {
 	if sess == nil {
 		return

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -223,7 +223,6 @@ func runTestMain(m *testing.M) int {
 	// Git hooks export GIT_DIR/GIT_WORK_TREE; clear them so test subprocess git
 	// commands operate on their temp repos instead of the real repository.
 	testutil.UnsetGitRepoEnv()
-	isolatePackageHome("agent-deck-session-tests-home-*")
 
 	// Isolate the tmux socket. Without this, tests spawn tmux sessions on the
 	// user's default socket and destabilize live agent-deck sessions.
@@ -255,22 +254,6 @@ func runTestMain(m *testing.M) int {
 	cleanupTestSessions()
 
 	return code
-}
-
-func isolatePackageHome(pattern string) {
-	home, err := os.MkdirTemp("", pattern)
-	if err != nil {
-		panic(err)
-	}
-	os.Setenv("HOME", home)
-	// Clear (do NOT pin) XDG base dirs so they track HOME and don't accumulate
-	// stale config/data across tests in this shared package home. See
-	// testutil.IsolateHome's doc comment (2026-06-07 ~96-test isolation
-	// regression from #1294's "prefer XDG if it exists" path resolution).
-	os.Unsetenv("XDG_CONFIG_HOME")
-	os.Unsetenv("XDG_DATA_HOME")
-	os.Unsetenv("XDG_CACHE_HOME")
-	os.Unsetenv("XDG_STATE_HOME")
 }
 
 // cleanupTestSessions kills any tmux sessions created during testing.

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -133,10 +133,7 @@ func RefreshPaneInfoCache() {
 		tmuxFmt("#{session_name}", "#{pane_current_command}", "#{pane_dead}", "#{window_index}", "#{pane_index}", "#{pane_title}"))
 	output, err := cmd.Output()
 	if err != nil {
-		paneCacheMu.Lock()
-		paneCacheData = nil
-		paneCacheTime = time.Time{}
-		paneCacheMu.Unlock()
+		statusLog.Debug("pane_cache_refresh_failed", "error", err)
 		return
 	}
 

--- a/internal/tmux/title_detection_test.go
+++ b/internal/tmux/title_detection_test.go
@@ -144,6 +144,34 @@ func TestRefreshPaneInfoCache(t *testing.T) {
 	}
 }
 
+func TestRefreshPaneInfoCachePreservesFreshDataOnFailure(t *testing.T) {
+	paneCacheMu.Lock()
+	previousData := paneCacheData
+	previousTime := paneCacheTime
+	paneCacheData = map[string]PaneInfo{
+		"known-good": {Title: "⠴ Running tool", CurrentCommand: "bash"},
+	}
+	paneCacheTime = time.Now()
+	paneCacheMu.Unlock()
+
+	previousSocket := DefaultSocketName()
+	SetDefaultSocketName("missing-pane-cache-refresh")
+	t.Cleanup(func() {
+		SetDefaultSocketName(previousSocket)
+		paneCacheMu.Lock()
+		paneCacheData = previousData
+		paneCacheTime = previousTime
+		paneCacheMu.Unlock()
+	})
+
+	RefreshPaneInfoCache()
+
+	info, ok := GetCachedPaneInfo("known-good")
+	if !ok || info.Title != "⠴ Running tool" {
+		t.Fatalf("refresh failure discarded fresh pane cache: info=%+v, ok=%v", info, ok)
+	}
+}
+
 func TestGetCachedPaneInfo_StaleCache(t *testing.T) {
 	// Set cache data with a time far in the past (stale)
 	paneCacheMu.Lock()


### PR DESCRIPTION
Takeover of #1687 at @jwiegley's request. **The commit is authored by him and carries a `Co-authored-by` trailer** — this is his work carried forward, not a reimplementation.

He asked us to take it over because the branch kept going stale across rebase cycles while `main` moved underneath it. That is our latency, not his, and it is the reason this exists rather than another rebase request.

**Built locally against `main` at `f4af88d3`.** Four conflicts and one stale caller, resolved as follows:

- **`parsePSParentChildMap`** — `main` now reuses one `ps` snapshot for both the parent/child map and the pane-leader lookup, so it tolerates a trailing `comm=` column. #1687's strict `len(fields) != 2` would reject every row from those callers. Kept main's tolerance **and** #1687's fail-closed intent: a row with fewer than two fields is recorded as a parse error rather than silently skipped.
- **`collectProcessTreePIDsViaPgrep`** — kept #1687's `([]int, error)` signature alongside `parsePSCommandNames`, which landed on main after the branch was cut.
- **`watchForFastDeath`** (both call sites) — kept main's newer wiring. The branch predates the one-shot exemption, the spawn-generation subscription and the synchronous write-target resolution, and its `startFastDeathWatcher` helper no longer exists on main.
- **`mcp_reap_depth_test.go`** — a caller that landed on main after the branch, updated for the new two-value return.

**One of those was not flagged by the merge.** The second `startFastDeathWatcher` call applied *cleanly* — no conflict marker — but referenced a function `main` had already removed. A clean apply is not a correct apply; `go vet` is what surfaced it.

**The two workflow files from the original PR are deliberately excluded** (`procfd-darwin.yml` and the `release-snapshot.yml` change), per the ruling that the CI surface gets its own security review. They are staged separately.

Local gate: `gofmt` clean, `go build ./...` clean, `go vet` clean on `internal/session`, `internal/procfd`, `internal/tmux`, `cmd/agent-deck`. **No tests were run locally** — this box serialises heavy operations and a full suite here is what took it down three times, so the real gate is CI on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Codex session detection across native, containerized, and filesystem-based environments.
  * Prevented internal subagent processes from being mistaken for user sessions.
  * Improved handling of incomplete or unavailable process information.
  * Reduced false spawn-failure alerts during intentional session termination.
  * Preserved existing pane titles when refreshing tmux metadata fails.

* **Reliability**
  * Improved process-tree discovery and recovery from malformed or incomplete system information.
  * Expanded cross-platform support and validation for session and process detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->