### PR TITLE
fix(cli): CLI answers match stored truth — inbox drain targets, parent linkage in JSON, raw model values

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -19,8 +20,22 @@ import (
 func handleInbox(args []string) {
 	if err := runInbox(os.Stdout, args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(inboxExitCode(err))
 	}
+}
+
+type inboxTargetNotFoundError struct{ identifier string }
+
+func (e *inboxTargetNotFoundError) Error() string {
+	return fmt.Sprintf("Error: inbox drain target %q could not be resolved. Nothing was drained; this is NOT an empty inbox.", e.identifier)
+}
+
+func inboxExitCode(err error) int {
+	var notFound *inboxTargetNotFoundError
+	if errors.As(err, &notFound) {
+		return 2
+	}
+	return 1
 }
 
 // runInbox is the testable seam — handleInbox wires it to os.Stdout/Stderr;
@@ -82,6 +97,10 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 		fs.Usage()
 		return err
 	}
+	sessionID, err = resolveInboxDrainSession(sessionID)
+	if err != nil {
+		return err
+	}
 
 	events, err := session.DrainInboxForParent(sessionID)
 	if err != nil {
@@ -98,6 +117,18 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 
 	printInboxEvents(stdout, events)
 	return nil
+}
+
+func resolveInboxDrainSession(identifier string) (string, error) {
+	_, instances, _, err := loadSessionData("")
+	if err != nil {
+		return "", err
+	}
+	inst, _, _ := ResolveSession(identifier, instances)
+	if inst == nil {
+		return "", &inboxTargetNotFoundError{identifier: identifier}
+	}
+	return inst.ID, nil
 }
 
 // resolveDrainTarget returns the session id to drain. With no positional arg,

--- a/cmd/agent-deck/issue1225_inbox_drain_cli_test.go
+++ b/cmd/agent-deck/issue1225_inbox_drain_cli_test.go
@@ -24,11 +24,26 @@ func cliInboxTestHome(t *testing.T) {
 	session.ResetInboxFingerprintCacheForTest()
 }
 
+func registerInboxDrainTarget(t *testing.T, id string) {
+	t.Helper()
+	storage, err := session.NewStorageWithProfile("")
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	inst := session.NewInstance("inbox-target", t.TempDir())
+	inst.ID = id
+	instances := []*session.Instance{inst}
+	if err := storage.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, nil)); err != nil {
+		t.Fatalf("save inbox target: %v", err)
+	}
+}
+
 // Case 2 (idle parent drains on heartbeat): a committed completion is surfaced
 // by `inbox drain`, and a second drain finds nothing (exactly-once).
 func TestIssue1225_InboxDrainCLI_HeartbeatDeliversThenEmpty(t *testing.T) {
 	cliInboxTestHome(t)
 	parent := "conductor-cli-1777000200"
+	registerInboxDrainTarget(t, parent)
 	if err := session.CommitToInbox(parent, session.TransitionNotificationEvent{
 		ChildSessionID: "child-cli-1", ChildTitle: "fix-auth", Profile: "personal",
 		FromStatus: "running", ToStatus: "waiting",
@@ -58,6 +73,7 @@ func TestIssue1225_InboxDrainCLI_HeartbeatDeliversThenEmpty(t *testing.T) {
 func TestIssue1225_InboxDrainCLI_JSONShape(t *testing.T) {
 	cliInboxTestHome(t)
 	parent := "conductor-cli-1777000210"
+	registerInboxDrainTarget(t, parent)
 	if err := session.CommitToInbox(parent, session.TransitionNotificationEvent{
 		ChildSessionID: "child-cli-2", ChildTitle: "worker", Profile: "personal",
 		FromStatus: "running", ToStatus: "waiting", LastOutputHash: "h2", Timestamp: time.Now(),
@@ -81,6 +97,7 @@ func TestIssue1225_InboxDrainCLI_JSONShape(t *testing.T) {
 // Boundary: draining an empty inbox is not an error.
 func TestIssue1225_InboxDrainCLI_EmptyInbox(t *testing.T) {
 	cliInboxTestHome(t)
+	registerInboxDrainTarget(t, "conductor-cli-empty")
 	var buf bytes.Buffer
 	if err := runInbox(&buf, []string{"drain", "conductor-cli-empty"}); err != nil {
 		t.Fatalf("drain empty: %v", err)

--- a/cmd/agent-deck/issue1225_inbox_drain_self_test.go
+++ b/cmd/agent-deck/issue1225_inbox_drain_self_test.go
@@ -19,6 +19,7 @@ import (
 func TestB7_InboxDrainSelf_ResolvesFromInstanceEnv(t *testing.T) {
 	cliInboxTestHome(t)
 	self := "conductor-self-1777800000"
+	registerInboxDrainTarget(t, self)
 	t.Setenv("AGENTDECK_INSTANCE_ID", self)
 
 	if err := session.CommitToInbox(self, session.TransitionNotificationEvent{

--- a/cmd/agent-deck/issue1991_inbox_unknown_test.go
+++ b/cmd/agent-deck/issue1991_inbox_unknown_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestIssue1991_InboxDrainUnknownIDIsNotEmpty(t *testing.T) {
+	cliInboxTestHome(t)
+	const missing = "does-not-exist-1991"
+
+	var stdout bytes.Buffer
+	err := runInbox(&stdout, []string{"drain", missing})
+	if err == nil {
+		t.Fatal("unknown drain target returned success")
+	}
+	if got := inboxExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (not found)", got)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("error %q does not name unresolvable id %q", err, missing)
+	}
+	if strings.Contains(stdout.String(), "No pending events") {
+		t.Fatalf("unknown target was reported as an empty inbox: %q", stdout.String())
+	}
+}

--- a/cmd/agent-deck/issue1992_list_parent_json_test.go
+++ b/cmd/agent-deck/issue1992_list_parent_json_test.go
@@ -41,25 +41,38 @@ func TestIssue1992_ListJSONCarriesChildParentLinkage(t *testing.T) {
 		t.Fatalf("parse child: %v\n%s", err, childOut)
 	}
 
-	listOut, stderr, code := runAgentDeck(t, home, "list", "--json")
-	if code != 0 {
-		t.Fatalf("list --json exit %d: %s", code, stderr)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "current profile", args: []string{"list", "--json"}},
+		{name: "all profiles", args: []string{"list", "--all", "--json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			listOut, stderr, code := runAgentDeck(t, home, tc.args...)
+			if code != 0 {
+				t.Fatalf("%v exit %d: %s", tc.args, code, stderr)
+			}
+			var rows []map[string]any
+			if err := json.Unmarshal([]byte(listOut), &rows); err != nil {
+				t.Fatalf("parse %v: %v\n%s", tc.args, err, listOut)
+			}
+			for _, row := range rows {
+				if row["id"] != child.ID {
+					continue
+				}
+				// Keep these assertions separate: the current-profile and
+				// all-profile emitters each have independent assignments for
+				// both fields, and every one is a regression guard.
+				if got := row["parent_session_id"]; got != parent.ID {
+					t.Fatalf("%s child parent_session_id = %#v, want %q; row=%#v", tc.name, got, parent.ID, row)
+				}
+				if got := row["parent_project_path"]; got != parentPath {
+					t.Fatalf("%s child parent_project_path = %#v, want %q; row=%#v", tc.name, got, parentPath, row)
+				}
+				return
+			}
+			t.Fatalf("child %q missing from %v: %s", child.ID, tc.args, listOut)
+		})
 	}
-	var rows []map[string]any
-	if err := json.Unmarshal([]byte(listOut), &rows); err != nil {
-		t.Fatalf("parse list: %v\n%s", err, listOut)
-	}
-	for _, row := range rows {
-		if row["id"] != child.ID {
-			continue
-		}
-		if got := row["parent_session_id"]; got != parent.ID {
-			t.Fatalf("child parent_session_id = %#v, want %q; row=%#v", got, parent.ID, row)
-		}
-		if got := row["parent_project_path"]; got != parentPath {
-			t.Fatalf("child parent_project_path = %#v, want %q; row=%#v", got, parentPath, row)
-		}
-		return
-	}
-	t.Fatalf("child %q missing from list: %s", child.ID, listOut)
 }

--- a/cmd/agent-deck/issue1992_list_parent_json_test.go
+++ b/cmd/agent-deck/issue1992_list_parent_json_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIssue1992_ListJSONCarriesChildParentLinkage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	parentPath := filepath.Join(home, "parent")
+	childPath := filepath.Join(home, "child")
+	for _, path := range []string{parentPath, childPath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	parentOut, stderr, code := runAgentDeck(t, home, "add", parentPath, "--title", "parent-1992", "--no-parent", "--json")
+	if code != 0 {
+		t.Fatalf("add parent exit %d: %s", code, stderr)
+	}
+	var parent struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(parentOut), &parent); err != nil {
+		t.Fatalf("parse parent: %v\n%s", err, parentOut)
+	}
+	childOut, stderr, code := runAgentDeck(t, home, "add", childPath, "--title", "child-1992", "--parent", parent.ID, "--json")
+	if code != 0 {
+		t.Fatalf("add child exit %d: %s", code, stderr)
+	}
+	var child struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(childOut), &child); err != nil {
+		t.Fatalf("parse child: %v\n%s", err, childOut)
+	}
+
+	listOut, stderr, code := runAgentDeck(t, home, "list", "--json")
+	if code != 0 {
+		t.Fatalf("list --json exit %d: %s", code, stderr)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(listOut), &rows); err != nil {
+		t.Fatalf("parse list: %v\n%s", err, listOut)
+	}
+	for _, row := range rows {
+		if row["id"] != child.ID {
+			continue
+		}
+		if got := row["parent_session_id"]; got != parent.ID {
+			t.Fatalf("child parent_session_id = %#v, want %q; row=%#v", got, parent.ID, row)
+		}
+		if got := row["parent_project_path"]; got != parentPath {
+			t.Fatalf("child parent_project_path = %#v, want %q; row=%#v", got, parentPath, row)
+		}
+		return
+	}
+	t.Fatalf("child %q missing from list: %s", child.ID, listOut)
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2271,7 +2271,7 @@ func handleList(profile string, args []string) {
 			}
 			if modelInfo := inst.LaunchModelInfo(); modelInfo.ModelID != "" {
 				sj.ModelID = modelInfo.ModelID
-				sj.Model = modelInfo.Model
+				sj.Model = modelInfo.ModelID
 				sj.ModelVersion = modelInfo.Version
 			}
 			sessions[i] = sj
@@ -2849,7 +2849,7 @@ func handleStatus(profile string, args []string) {
 				}
 				if modelInfo := inst.LaunchModelInfo(); modelInfo.ModelID != "" {
 					sj.ModelID = modelInfo.ModelID
-					sj.Model = modelInfo.Model
+					sj.Model = modelInfo.ModelID
 					sj.ModelVersion = modelInfo.Version
 				}
 				resp.Sessions = append(resp.Sessions, sj)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2214,27 +2214,29 @@ func handleList(profile string, args []string) {
 	if *jsonOutput {
 		// JSON output for scripting
 		type sessionJSON struct {
-			ID            string    `json:"id"`
-			Title         string    `json:"title"`
-			Path          string    `json:"path"`
-			Group         string    `json:"group"`
-			Tool          string    `json:"tool"`
-			Command       string    `json:"command,omitempty"`
-			ModelID       string    `json:"model_id,omitempty"`
-			Model         string    `json:"model,omitempty"`
-			ModelVersion  string    `json:"model_version,omitempty"`
-			Status        string    `json:"status"`
-			Substate      string    `json:"substate,omitempty"` // Honest Status v2: additive refinement
-			TmuxSession   string    `json:"tmux_session,omitempty"`
-			Profile       string    `json:"profile"`
-			CreatedAt     time.Time `json:"created_at"`
-			SSHHost       string    `json:"ssh_host,omitempty"`
-			SSHRemotePath string    `json:"ssh_remote_path,omitempty"`
-			Channels      []string  `json:"channels,omitempty"`
-			ExtraArgs     []string  `json:"extra_args,omitempty"`
-			Color         string    `json:"color,omitempty"` // issue #391
-			Archived      bool      `json:"archived"`
-			ArchivedAt    time.Time `json:"archived_at,omitempty"`
+			ID                string    `json:"id"`
+			ParentSessionID   string    `json:"parent_session_id,omitempty"`
+			ParentProjectPath string    `json:"parent_project_path,omitempty"`
+			Title             string    `json:"title"`
+			Path              string    `json:"path"`
+			Group             string    `json:"group"`
+			Tool              string    `json:"tool"`
+			Command           string    `json:"command,omitempty"`
+			ModelID           string    `json:"model_id,omitempty"`
+			Model             string    `json:"model,omitempty"`
+			ModelVersion      string    `json:"model_version,omitempty"`
+			Status            string    `json:"status"`
+			Substate          string    `json:"substate,omitempty"` // Honest Status v2: additive refinement
+			TmuxSession       string    `json:"tmux_session,omitempty"`
+			Profile           string    `json:"profile"`
+			CreatedAt         time.Time `json:"created_at"`
+			SSHHost           string    `json:"ssh_host,omitempty"`
+			SSHRemotePath     string    `json:"ssh_remote_path,omitempty"`
+			Channels          []string  `json:"channels,omitempty"`
+			ExtraArgs         []string  `json:"extra_args,omitempty"`
+			Color             string    `json:"color,omitempty"` // issue #391
+			Archived          bool      `json:"archived"`
+			ArchivedAt        time.Time `json:"archived_at,omitempty"`
 		}
 		// Warm tmux pane-title cache + load hook statuses so the CLI
 		// reports the same Status the TUI and /api/menu do (issue #610).
@@ -2242,24 +2244,27 @@ func handleList(profile string, args []string) {
 		sessions := make([]sessionJSON, len(instances))
 		for i, inst := range instances {
 			_ = inst.UpdateStatus()
+			parentProjectPath := listParentProjectPath(inst, instances)
 			sj := sessionJSON{
-				ID:            inst.ID,
-				Title:         inst.Title,
-				Path:          inst.ProjectPath,
-				Group:         inst.GroupPath,
-				Tool:          inst.Tool,
-				Command:       inst.Command,
-				Status:        StatusString(inst.Status),
-				Substate:      string(inst.Substate()),
-				Profile:       storage.Profile(),
-				CreatedAt:     inst.CreatedAt,
-				SSHHost:       inst.SSHHost,
-				SSHRemotePath: inst.SSHRemotePath,
-				Channels:      inst.Channels,
-				ExtraArgs:     inst.ExtraArgs,
-				Color:         inst.Color,
-				Archived:      inst.IsArchived(),
-				ArchivedAt:    inst.ArchivedAt,
+				ID:                inst.ID,
+				ParentSessionID:   inst.ParentSessionID,
+				ParentProjectPath: parentProjectPath,
+				Title:             inst.Title,
+				Path:              inst.ProjectPath,
+				Group:             inst.GroupPath,
+				Tool:              inst.Tool,
+				Command:           inst.Command,
+				Status:            StatusString(inst.Status),
+				Substate:          string(inst.Substate()),
+				Profile:           storage.Profile(),
+				CreatedAt:         inst.CreatedAt,
+				SSHHost:           inst.SSHHost,
+				SSHRemotePath:     inst.SSHRemotePath,
+				Channels:          inst.Channels,
+				ExtraArgs:         inst.ExtraArgs,
+				Color:             inst.Color,
+				Archived:          inst.IsArchived(),
+				ArchivedAt:        inst.ArchivedAt,
 			}
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
 				sj.TmuxSession = tmuxSess.Name
@@ -2316,16 +2321,18 @@ func handleListAllProfiles(jsonOutput bool) {
 
 	if jsonOutput {
 		type sessionJSON struct {
-			ID            string    `json:"id"`
-			Title         string    `json:"title"`
-			Path          string    `json:"path"`
-			Group         string    `json:"group"`
-			Tool          string    `json:"tool"`
-			Command       string    `json:"command,omitempty"`
-			Profile       string    `json:"profile"`
-			CreatedAt     time.Time `json:"created_at"`
-			SSHHost       string    `json:"ssh_host,omitempty"`
-			SSHRemotePath string    `json:"ssh_remote_path,omitempty"`
+			ID                string    `json:"id"`
+			ParentSessionID   string    `json:"parent_session_id,omitempty"`
+			ParentProjectPath string    `json:"parent_project_path,omitempty"`
+			Title             string    `json:"title"`
+			Path              string    `json:"path"`
+			Group             string    `json:"group"`
+			Tool              string    `json:"tool"`
+			Command           string    `json:"command,omitempty"`
+			Profile           string    `json:"profile"`
+			CreatedAt         time.Time `json:"created_at"`
+			SSHHost           string    `json:"ssh_host,omitempty"`
+			SSHRemotePath     string    `json:"ssh_remote_path,omitempty"`
 		}
 		var allSessions []sessionJSON
 
@@ -2340,16 +2347,18 @@ func handleListAllProfiles(jsonOutput bool) {
 			}
 			for _, inst := range instances {
 				allSessions = append(allSessions, sessionJSON{
-					ID:            inst.ID,
-					Title:         inst.Title,
-					Path:          inst.ProjectPath,
-					Group:         inst.GroupPath,
-					Tool:          inst.Tool,
-					Command:       inst.Command,
-					Profile:       profileName,
-					CreatedAt:     inst.CreatedAt,
-					SSHHost:       inst.SSHHost,
-					SSHRemotePath: inst.SSHRemotePath,
+					ID:                inst.ID,
+					ParentSessionID:   inst.ParentSessionID,
+					ParentProjectPath: listParentProjectPath(inst, instances),
+					Title:             inst.Title,
+					Path:              inst.ProjectPath,
+					Group:             inst.GroupPath,
+					Tool:              inst.Tool,
+					Command:           inst.Command,
+					Profile:           profileName,
+					CreatedAt:         inst.CreatedAt,
+					SSHHost:           inst.SSHHost,
+					SSHRemotePath:     inst.SSHRemotePath,
 				})
 			}
 		}
@@ -2399,6 +2408,24 @@ func handleListAllProfiles(jsonOutput bool) {
 
 	fmt.Printf("\n═══════════════════════════════════════\n")
 	fmt.Printf("Total: %d sessions across %d profiles\n", totalSessions, len(profiles))
+}
+
+// listParentProjectPath reports the parent path represented by the stored
+// parent id. Older SQLite rows did not persist the denormalized path field, so
+// recover it from the parent row instead of falsely reporting no relationship.
+func listParentProjectPath(inst *session.Instance, instances []*session.Instance) string {
+	if inst == nil || inst.ParentSessionID == "" {
+		return ""
+	}
+	if inst.ParentProjectPath != "" {
+		return inst.ParentProjectPath
+	}
+	for _, candidate := range instances {
+		if candidate.ID == inst.ParentSessionID {
+			return candidate.ProjectPath
+		}
+	}
+	return ""
 }
 
 // handleRemove removes a session by ID or title

--- a/cmd/agent-deck/model_cmd_test.go
+++ b/cmd/agent-deck/model_cmd_test.go
@@ -54,7 +54,7 @@ func TestAddModelFlagPersistsAndSurfacesInStatus(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &addResp); err != nil {
 		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
 	}
-	if addResp.ModelID != "gpt-5.5" || addResp.Model != "GPT" || addResp.ModelVersion != "5.5" {
+	if addResp.ModelID != "gpt-5.5" || addResp.Model != "gpt-5.5" || addResp.ModelVersion != "5.5" {
 		t.Fatalf("add model fields = id:%q model:%q version:%q", addResp.ModelID, addResp.Model, addResp.ModelVersion)
 	}
 
@@ -70,8 +70,32 @@ func TestAddModelFlagPersistsAndSurfacesInStatus(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
 		t.Fatalf("parse show response: %v\nstdout: %s", err, stdout)
 	}
-	if showResp.ModelID != "gpt-5.5" || showResp.Model != "GPT" || showResp.ModelVersion != "5.5" {
+	if showResp.ModelID != "gpt-5.5" || showResp.Model != "gpt-5.5" || showResp.ModelVersion != "5.5" {
 		t.Fatalf("show model fields = id:%q model:%q version:%q", showResp.ModelID, showResp.Model, showResp.ModelVersion)
+	}
+
+	stdout, stderr, code = runAgentDeck(t, home, "list", "--json")
+	if code != 0 {
+		t.Fatalf("agent-deck list --json failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var listResp []struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &listResp); err != nil {
+		t.Fatalf("parse list response: %v\nstdout: %s", err, stdout)
+	}
+	foundList := false
+	for _, sess := range listResp {
+		if sess.ID == addResp.ID {
+			foundList = true
+			if sess.Model != "gpt-5.5" {
+				t.Fatalf("list JSON leaked display model %q, want raw gpt-5.5", sess.Model)
+			}
+		}
+	}
+	if !foundList {
+		t.Fatalf("list --json did not include added session; response: %s", stdout)
 	}
 
 	stdout, stderr, code = runAgentDeck(t, home, "status", "--json", "--verbose")
@@ -95,7 +119,7 @@ func TestAddModelFlagPersistsAndSurfacesInStatus(t *testing.T) {
 			continue
 		}
 		found = true
-		if sess.ModelID != "gpt-5.5" || sess.Model != "GPT" || sess.ModelVersion != "5.5" {
+		if sess.ModelID != "gpt-5.5" || sess.Model != "gpt-5.5" || sess.ModelVersion != "5.5" {
 			t.Fatalf("status model fields = id:%q model:%q version:%q", sess.ModelID, sess.Model, sess.ModelVersion)
 		}
 	}
@@ -149,7 +173,7 @@ func TestSessionSetModelPersists(t *testing.T) {
 
 	// Switch the model — the operator's choice we want to survive restart.
 	stdout, stderr, code = runAgentDeck(t, home,
-		"session", "set", "--json", addResp.ID, "model", "opus",
+		"session", "set", "--json", addResp.ID, "model", "gpt-5.5",
 	)
 	if code != 0 {
 		t.Fatalf(
@@ -166,12 +190,13 @@ func TestSessionSetModelPersists(t *testing.T) {
 	}
 	var showResp struct {
 		ModelID string `json:"model_id"`
+		Model   string `json:"model"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
 		t.Fatalf("parse show response: %v\nstdout: %s", err, stdout)
 	}
-	if showResp.ModelID != "opus" {
-		t.Errorf("session set model did not persist opus; model_id = %q\nshow: %s", showResp.ModelID, stdout)
+	if showResp.ModelID != "gpt-5.5" || showResp.Model != "gpt-5.5" {
+		t.Errorf("session set model did not round-trip raw gpt-5.5; model_id = %q model = %q\nshow: %s", showResp.ModelID, showResp.Model, stdout)
 	}
 
 	// Re-set to a different model: the new choice must replace the old one.

--- a/cmd/agent-deck/model_status.go
+++ b/cmd/agent-deck/model_status.go
@@ -19,9 +19,9 @@ func addModelInfoJSON(target map[string]interface{}, info session.ModelInfo) {
 		return
 	}
 	target["model_id"] = info.ModelID
-	if info.Model != "" {
-		target["model"] = info.Model
-	}
+	// JSON is a data surface: return the exact persisted override. Family names
+	// such as "GPT" are presentation labels and belong in human output only.
+	target["model"] = info.ModelID
 	if info.Version != "" {
 		target["model_version"] = info.Version
 	}


### PR DESCRIPTION
Three fixes for the class the recent report series named: places where the CLI's answer differed from stored truth.

- **`inbox drain` rejects unresolvable targets** (exit 2, explicit error) instead of returning a clean `No pending events` for a target it could not resolve. Unknown is not empty. Fixes #1991
- **`list --json` exposes parent linkage** — both `parent_session_id` and `parent_project_path`, in the current-profile and `--all` paths, with legacy parent-path recovery by parent id. The second field covers the additional report on the same defect. Fixes #1992, fixes #2000
- **JSON surfaces return raw stored model values** (list, status, add/show) rather than normalized display names; human-readable output keeps its normalization. Fixes #1994

Each guard is regression-pinned: an independent review reverted every guard one at a time and confirmed a specific test kills each (10-row matrix, including both `--all`-profile assignments and the not-found exit code). Verification ran container-only against a read-only mount. Behavioral evidence for the happy paths (normal drain, list, status) is unchanged output byte-for-byte.