### PR TITLE
fix(worktree): cleanup no longer destroys unpushed or active work

### DIFF
--- a/cmd/agent-deck/worktree_cleanup_safety.go
+++ b/cmd/agent-deck/worktree_cleanup_safety.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+// worktreeCleanupFacts is the reality check applied before an unregistered
+// worktree may enter the orphan set. Inspection errors fail closed: cleanup is
+// a destructive convenience operation, so uncertainty is not permission.
+type worktreeCleanupFacts struct {
+	Worktree   vcs.Worktree
+	Unpushed   int
+	Dirty      bool
+	LivePID    int
+	InspectErr error
+}
+
+// classifyUnregisteredWorktrees runs before --force is considered. Consequently
+// force can only authorize removal of the returned orphan slice; it can never
+// promote a protected worktree into that slice.
+func classifyUnregisteredWorktrees(worktrees []vcs.Worktree, occupied map[string]bool) ([]vcs.Worktree, []worktreeCleanupFacts) {
+	var orphans []vcs.Worktree
+	var protected []worktreeCleanupFacts
+	for i, wt := range worktrees {
+		if i == 0 || occupied[wt.Path] { // first entry is the main worktree
+			continue
+		}
+		facts := inspectWorktreeForCleanup(wt)
+		if facts.safeToRemove() {
+			orphans = append(orphans, wt)
+		} else {
+			protected = append(protected, facts)
+		}
+	}
+	return orphans, protected
+}
+
+func (f worktreeCleanupFacts) safeToRemove() bool {
+	return f.Unpushed == 0 && !f.Dirty && f.LivePID == 0 && f.InspectErr == nil
+}
+
+func (f worktreeCleanupFacts) summary() string {
+	parts := []string{fmt.Sprintf("%d unpushed", f.Unpushed), fmt.Sprintf("dirty=%t", f.Dirty)}
+	if f.LivePID != 0 {
+		parts = append(parts, fmt.Sprintf("pid %d", f.LivePID))
+	} else {
+		parts = append(parts, "pid none")
+	}
+	if f.InspectErr != nil {
+		parts = append(parts, "inspection failed: "+f.InspectErr.Error())
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (f worktreeCleanupFacts) jsonData() map[string]interface{} {
+	data := map[string]interface{}{
+		"path": f.Worktree.Path, "branch": f.Worktree.Branch,
+		"unpushed": f.Unpushed, "dirty": f.Dirty, "live_pid": f.LivePID,
+	}
+	if f.InspectErr != nil {
+		data["inspection_error"] = f.InspectErr.Error()
+	}
+	return data
+}
+
+func inspectWorktreeForCleanup(wt vcs.Worktree) worktreeCleanupFacts {
+	facts := worktreeCleanupFacts{Worktree: wt}
+	out, err := exec.Command("git", "-C", wt.Path, "rev-list", "--count", "HEAD", "--not", "--remotes").Output()
+	if err != nil {
+		facts.InspectErr = fmt.Errorf("count unpushed commits: %w", err)
+		return facts
+	}
+	facts.Unpushed, err = strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		facts.InspectErr = fmt.Errorf("parse unpushed count: %w", err)
+		return facts
+	}
+	out, err = exec.Command("git", "-C", wt.Path, "status", "--porcelain", "--untracked-files=normal").Output()
+	if err != nil {
+		facts.InspectErr = fmt.Errorf("inspect working tree: %w", err)
+		return facts
+	}
+	facts.Dirty = len(out) != 0
+	facts.LivePID, err = processWithCWDInside(wt.Path)
+	if err != nil {
+		facts.InspectErr = fmt.Errorf("inspect live processes: %w", err)
+	}
+	return facts
+}
+
+func processWithCWDInside(root string) (int, error) {
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return 0, err
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return processWithCWDInsideLsof(root)
+	}
+	for _, entry := range entries {
+		pid, convErr := strconv.Atoi(entry.Name())
+		if convErr != nil || pid == os.Getpid() {
+			continue
+		}
+		cwd, linkErr := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
+		if linkErr == nil && pathInside(root, cwd) {
+			return pid, nil
+		}
+	}
+	return 0, nil
+}
+
+func processWithCWDInsideLsof(root string) (int, error) {
+	out, err := exec.Command("lsof", "-a", "-d", "cwd", "+D", root, "-F", "p").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && len(out) == 0 {
+			return 0, nil
+		}
+		return 0, err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "p") {
+			if pid, convErr := strconv.Atoi(strings.TrimPrefix(line, "p")); convErr == nil && pid != os.Getpid() {
+				return pid, nil
+			}
+		}
+	}
+	return 0, nil
+}
+
+func pathInside(root, candidate string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/cmd/agent-deck/worktree_cleanup_safety.go
+++ b/cmd/agent-deck/worktree_cleanup_safety.go
@@ -127,6 +127,8 @@ func (f worktreeCleanupFacts) jsonData() map[string]interface{} {
 
 func inspectWorktreeForCleanup(wt vcs.Worktree) worktreeCleanupFacts {
 	facts := worktreeCleanupFacts{Worktree: wt}
+	// #nosec G204 -- "git" is a fixed binary invoked with an argv (no shell);
+	// wt.Path comes from `git worktree list --porcelain` on the local repo.
 	out, err := exec.Command("git", "-C", wt.Path, "rev-list", "--count", "HEAD", "--not", "--remotes").Output()
 	if err != nil {
 		facts.InspectErr = fmt.Errorf("count unpushed commits: %w", err)
@@ -138,6 +140,7 @@ func inspectWorktreeForCleanup(wt vcs.Worktree) worktreeCleanupFacts {
 		return facts
 	}
 	facts.Unpushed = &unpushed
+	// #nosec G204 -- same as above: fixed binary, argv exec, repo-derived path.
 	out, err = exec.Command("git", "-C", wt.Path, "status", "--porcelain", "--untracked-files=normal").Output()
 	if err != nil {
 		facts.InspectErr = fmt.Errorf("inspect working tree: %w", err)
@@ -254,6 +257,8 @@ func processWithCWDInside(root string) (int, error) {
 }
 
 func processWithCWDInsideLsof(root string) (int, error) {
+	// #nosec G204 G702 -- "lsof" is a fixed binary invoked with an argv (no
+	// shell); root is a worktree path from the repo's own worktree list.
 	out, err := exec.Command("lsof", "-a", "-d", "cwd", "+D", root, "-F", "p").Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && len(out) == 0 {

--- a/cmd/agent-deck/worktree_cleanup_safety.go
+++ b/cmd/agent-deck/worktree_cleanup_safety.go
@@ -7,18 +7,49 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
+
+type worktreeCleanupLock struct{ file *os.File }
+
+func acquireWorktreeCleanupLock(repoDir string) (*worktreeCleanupLock, error) {
+	out, err := exec.Command("git", "-C", repoDir, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		return nil, fmt.Errorf("resolve git common directory: %w", err)
+	}
+	commonDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(repoDir, commonDir)
+	}
+	file, err := os.OpenFile(filepath.Join(commonDir, "agent-deck-worktree-cleanup.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &worktreeCleanupLock{file: file}, nil
+}
+
+func (l *worktreeCleanupLock) release() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	_ = l.file.Close()
+}
 
 // worktreeCleanupFacts is the reality check applied before an unregistered
 // worktree may enter the orphan set. Inspection errors fail closed: cleanup is
 // a destructive convenience operation, so uncertainty is not permission.
 type worktreeCleanupFacts struct {
 	Worktree   vcs.Worktree
-	Unpushed   int
-	Dirty      bool
-	LivePID    int
+	Unpushed   *int
+	Dirty      *bool
+	LivePID    *int
 	InspectErr error
 }
 
@@ -26,10 +57,11 @@ type worktreeCleanupFacts struct {
 // force can only authorize removal of the returned orphan slice; it can never
 // promote a protected worktree into that slice.
 func classifyUnregisteredWorktrees(worktrees []vcs.Worktree, occupied map[string]bool) ([]vcs.Worktree, []worktreeCleanupFacts) {
+	occupied = canonicalizePathSet(occupied)
 	var orphans []vcs.Worktree
 	var protected []worktreeCleanupFacts
 	for i, wt := range worktrees {
-		if i == 0 || occupied[wt.Path] { // first entry is the main worktree
+		if i == 0 || occupied[canonicalPathKey(wt.Path)] { // first entry is the main worktree
 			continue
 		}
 		facts := inspectWorktreeForCleanup(wt)
@@ -43,13 +75,28 @@ func classifyUnregisteredWorktrees(worktrees []vcs.Worktree, occupied map[string
 }
 
 func (f worktreeCleanupFacts) safeToRemove() bool {
-	return f.Unpushed == 0 && !f.Dirty && f.LivePID == 0 && f.InspectErr == nil
+	return f.Unpushed != nil && *f.Unpushed == 0 &&
+		f.Dirty != nil && !*f.Dirty &&
+		f.LivePID != nil && *f.LivePID == 0 &&
+		f.InspectErr == nil
 }
 
 func (f worktreeCleanupFacts) summary() string {
-	parts := []string{fmt.Sprintf("%d unpushed", f.Unpushed), fmt.Sprintf("dirty=%t", f.Dirty)}
-	if f.LivePID != 0 {
-		parts = append(parts, fmt.Sprintf("pid %d", f.LivePID))
+	parts := make([]string, 0, 4)
+	if f.Unpushed == nil {
+		parts = append(parts, "unpushed unknown")
+	} else {
+		parts = append(parts, fmt.Sprintf("%d unpushed", *f.Unpushed))
+	}
+	if f.Dirty == nil {
+		parts = append(parts, "dirty=unknown")
+	} else {
+		parts = append(parts, fmt.Sprintf("dirty=%t", *f.Dirty))
+	}
+	if f.LivePID == nil {
+		parts = append(parts, "pid unknown")
+	} else if *f.LivePID != 0 {
+		parts = append(parts, fmt.Sprintf("pid %d", *f.LivePID))
 	} else {
 		parts = append(parts, "pid none")
 	}
@@ -62,7 +109,15 @@ func (f worktreeCleanupFacts) summary() string {
 func (f worktreeCleanupFacts) jsonData() map[string]interface{} {
 	data := map[string]interface{}{
 		"path": f.Worktree.Path, "branch": f.Worktree.Branch,
-		"unpushed": f.Unpushed, "dirty": f.Dirty, "live_pid": f.LivePID,
+	}
+	if f.Unpushed != nil {
+		data["unpushed"] = *f.Unpushed
+	}
+	if f.Dirty != nil {
+		data["dirty"] = *f.Dirty
+	}
+	if f.LivePID != nil {
+		data["live_pid"] = *f.LivePID
 	}
 	if f.InspectErr != nil {
 		data["inspection_error"] = f.InspectErr.Error()
@@ -77,22 +132,97 @@ func inspectWorktreeForCleanup(wt vcs.Worktree) worktreeCleanupFacts {
 		facts.InspectErr = fmt.Errorf("count unpushed commits: %w", err)
 		return facts
 	}
-	facts.Unpushed, err = strconv.Atoi(strings.TrimSpace(string(out)))
+	unpushed, err := strconv.Atoi(strings.TrimSpace(string(out)))
 	if err != nil {
 		facts.InspectErr = fmt.Errorf("parse unpushed count: %w", err)
 		return facts
 	}
+	facts.Unpushed = &unpushed
 	out, err = exec.Command("git", "-C", wt.Path, "status", "--porcelain", "--untracked-files=normal").Output()
 	if err != nil {
 		facts.InspectErr = fmt.Errorf("inspect working tree: %w", err)
 		return facts
 	}
-	facts.Dirty = len(out) != 0
-	facts.LivePID, err = processWithCWDInside(wt.Path)
+	dirty := len(out) != 0
+	facts.Dirty = &dirty
+	livePID, err := processWithCWDInside(wt.Path)
 	if err != nil {
 		facts.InspectErr = fmt.Errorf("inspect live processes: %w", err)
+		return facts
 	}
+	facts.LivePID = &livePID
 	return facts
+}
+
+func canonicalizePathSet(paths map[string]bool) map[string]bool {
+	canonical := make(map[string]bool, len(paths))
+	for path, occupied := range paths {
+		if occupied {
+			canonical[canonicalPathKey(path)] = true
+		}
+	}
+	return canonical
+}
+
+func canonicalPathKey(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = filepath.Clean(path)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(abs); resolveErr == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(abs)
+}
+
+// revalidateCleanupCandidate is the last gate before removal. The caller must
+// supply freshly loaded registry occupancy and a freshly listed worktree set.
+func revalidateCleanupCandidate(candidate vcs.Worktree, current []vcs.Worktree, occupied map[string]bool) (worktreeCleanupFacts, string) {
+	candidateKey := canonicalPathKey(candidate.Path)
+	found := false
+	for _, wt := range current {
+		if canonicalPathKey(wt.Path) == candidateKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return worktreeCleanupFacts{Worktree: candidate}, "no longer registered as a worktree"
+	}
+	if canonicalizePathSet(occupied)[candidateKey] {
+		return worktreeCleanupFacts{Worktree: candidate}, "now associated with a session"
+	}
+	facts := inspectWorktreeForCleanup(candidate)
+	if !facts.safeToRemove() {
+		return facts, "reality changed: " + facts.summary()
+	}
+	return facts, ""
+}
+
+// removeCleanupCandidate serializes the deletion boundary across cleanup
+// processes, then reloads every input that can have changed since dry-run.
+func removeCleanupCandidate(backend vcs.Backend, candidate vcs.Worktree, loadOccupied func() (map[string]bool, error)) (bool, string, error) {
+	lock, err := acquireWorktreeCleanupLock(backend.RepoDir())
+	if err != nil {
+		return false, "could not acquire cleanup lock", err
+	}
+	defer lock.release()
+	occupied, err := loadOccupied()
+	if err != nil {
+		return false, "could not revalidate session ownership", err
+	}
+	current, err := backend.ListWorktrees()
+	if err != nil {
+		return false, "could not relist worktrees", err
+	}
+	_, reason := revalidateCleanupCandidate(candidate, current, occupied)
+	if reason != "" {
+		return false, reason, nil
+	}
+	if err := backend.RemoveWorktree(candidate.Path, false); err != nil {
+		return false, "removal failed", err
+	}
+	return true, "", nil
 }
 
 func processWithCWDInside(root string) (int, error) {
@@ -100,13 +230,19 @@ func processWithCWDInside(root string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	// Check self explicitly before platform-specific enumeration. Besides
+	// closing the original self-deletion hole, this protects platforms where
+	// process listing tools omit or cannot inspect their caller.
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil && pathInside(root, cwd) {
+		return os.Getpid(), nil
+	}
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return processWithCWDInsideLsof(root)
 	}
 	for _, entry := range entries {
 		pid, convErr := strconv.Atoi(entry.Name())
-		if convErr != nil || pid == os.Getpid() {
+		if convErr != nil {
 			continue
 		}
 		cwd, linkErr := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
@@ -127,7 +263,7 @@ func processWithCWDInsideLsof(root string) (int, error) {
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		if strings.HasPrefix(line, "p") {
-			if pid, convErr := strconv.Atoi(strings.TrimPrefix(line, "p")); convErr == nil && pid != os.Getpid() {
+			if pid, convErr := strconv.Atoi(strings.TrimPrefix(line, "p")); convErr == nil {
 				return pid, nil
 			}
 		}

--- a/cmd/agent-deck/worktree_cleanup_safety_test.go
+++ b/cmd/agent-deck/worktree_cleanup_safety_test.go
@@ -266,6 +266,44 @@ func TestCleanupConcurrentLoserSkipsMissingWorktree(t *testing.T) {
 	}
 }
 
+type cleanupRemovalSpyBackend struct {
+	vcs.Backend
+	removeCalls int
+}
+
+func (b *cleanupRemovalSpyBackend) RemoveWorktree(path string, force bool) error {
+	b.removeCalls++
+	return b.Backend.RemoveWorktree(path, force)
+}
+
+// Regression for E7: a session can claim a candidate while cleanup waits for
+// confirmation. Fresh canonical occupancy must veto the destructive backend
+// call even though the worktree itself is still clean and present.
+func TestCleanupDeletionTimeSessionOwnershipVeto(t *testing.T) {
+	main, _, _, _, worktrees := cleanupFixture(t)
+	backend, err := detectAndCreateBackend(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &cleanupRemovalSpyBackend{Backend: backend}
+	candidate := worktrees[3]
+	removed, reason, err := removeCleanupCandidate(spy, candidate, func() (map[string]bool, error) {
+		return map[string]bool{canonicalPathKey(candidate.Path): true}, nil
+	})
+	if err != nil {
+		t.Fatalf("deletion-time ownership check: %v", err)
+	}
+	if removed {
+		t.Fatal("session-owned worktree reported removed")
+	}
+	if reason != "now associated with a session" {
+		t.Fatalf("reason = %q, want %q", reason, "now associated with a session")
+	}
+	if spy.removeCalls != 0 {
+		t.Fatalf("backend removal called %d time(s), want 0", spy.removeCalls)
+	}
+}
+
 func TestCleanupForceCannotOverrideRealityExclusions(t *testing.T) {
 	_, unpushed, busy, empty, worktrees := cleanupFixture(t)
 	cmd := exec.Command("sh", "-c", fmt.Sprintf("cd %q && exec sleep 30", busy))

--- a/cmd/agent-deck/worktree_cleanup_safety_test.go
+++ b/cmd/agent-deck/worktree_cleanup_safety_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+func cleanupFixture(t *testing.T) (main, unpushed, busy, empty string, worktrees []vcs.Worktree) {
+	t.Helper()
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	main = filepath.Join(root, "main")
+	runFixtureGit(t, root, "init", "--bare", remote)
+	runFixtureGit(t, root, "clone", remote, main)
+	runFixtureGit(t, main, "config", "user.email", "fixture@example.invalid")
+	runFixtureGit(t, main, "config", "user.name", "Fixture")
+	if err := os.WriteFile(filepath.Join(main, "README"), []byte("fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runFixtureGit(t, main, "add", "README")
+	runFixtureGit(t, main, "commit", "-m", "base")
+	runFixtureGit(t, main, "push", "-u", "origin", "HEAD")
+	unpushed, busy, empty = filepath.Join(root, "unpushed"), filepath.Join(root, "busy"), filepath.Join(root, "empty")
+	runFixtureGit(t, main, "worktree", "add", "-b", "unpushed", unpushed)
+	runFixtureGit(t, main, "worktree", "add", "-b", "busy", busy)
+	runFixtureGit(t, main, "worktree", "add", "-b", "empty", empty)
+	if err := os.WriteFile(filepath.Join(unpushed, "work"), []byte("precious\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runFixtureGit(t, unpushed, "add", "work")
+	runFixtureGit(t, unpushed, "commit", "-m", "unpushed work")
+	worktrees = []vcs.Worktree{{Path: main, Branch: "main"}, {Path: unpushed, Branch: "unpushed"}, {Path: busy, Branch: "busy"}, {Path: empty, Branch: "empty"}}
+	return
+}
+
+func runFixtureGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func factsByPath(facts []worktreeCleanupFacts) map[string]worktreeCleanupFacts {
+	m := make(map[string]worktreeCleanupFacts, len(facts))
+	for _, f := range facts {
+		m[f.Worktree.Path] = f
+	}
+	return m
+}
+
+func pathsContain(worktrees []vcs.Worktree, path string) bool {
+	for _, wt := range worktrees {
+		if wt.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForFixtureCWD(t *testing.T, pid int, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, err := processWithCWDInside(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got == pid {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process %d cwd was not observed", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestCleanupExcludesUnpushedCommit(t *testing.T) {
+	_, unpushed, _, empty, worktrees := cleanupFixture(t)
+	orphans, protected := classifyUnregisteredWorktrees(worktrees, nil)
+	if pathsContain(orphans, unpushed) || !pathsContain(orphans, empty) {
+		t.Fatalf("orphans = %+v, must exclude %s and include %s", orphans, unpushed, empty)
+	}
+	if got := factsByPath(protected)[unpushed].Unpushed; got != 1 {
+		t.Fatalf("unpushed count = %d, want 1", got)
+	}
+}
+
+func TestCleanupExcludesUncommittedChanges(t *testing.T) {
+	_, _, _, empty, worktrees := cleanupFixture(t)
+	dirty := worktrees[2].Path
+	if err := os.WriteFile(filepath.Join(dirty, "uncommitted"), []byte("precious\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	orphans, protected := classifyUnregisteredWorktrees(worktrees, nil)
+	if pathsContain(orphans, dirty) || !pathContainsFacts(protected, dirty) {
+		t.Fatalf("dirty worktree was not protected: orphans=%+v protected=%+v", orphans, protected)
+	}
+	if !factsByPath(protected)[dirty].Dirty {
+		t.Fatal("dirty fact was not surfaced")
+	}
+	if !pathsContain(orphans, empty) {
+		t.Fatalf("empty worktree %s was not an orphan", empty)
+	}
+}
+
+func pathContainsFacts(facts []worktreeCleanupFacts, path string) bool {
+	_, ok := factsByPath(facts)[path]
+	return ok
+}
+
+func TestCleanupExcludesLiveProcessCWDInside(t *testing.T) {
+	_, _, busy, empty, worktrees := cleanupFixture(t)
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("cd %q && exec sleep 30", busy))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	waitForFixtureCWD(t, cmd.Process.Pid, busy)
+	orphans, protected := classifyUnregisteredWorktrees(worktrees, nil)
+	if len(orphans) != 1 || orphans[0].Path != empty {
+		t.Fatalf("orphans = %+v, want only %s", orphans, empty)
+	}
+	if got := factsByPath(protected)[busy].LivePID; got != cmd.Process.Pid {
+		t.Fatalf("live pid = %d, want %d", got, cmd.Process.Pid)
+	}
+}
+
+func TestCleanupForceCannotOverrideRealityExclusions(t *testing.T) {
+	_, unpushed, busy, empty, worktrees := cleanupFixture(t)
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("cd %q && exec sleep 30", busy))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	waitForFixtureCWD(t, cmd.Process.Pid, busy)
+	// --force is intentionally absent from classification: it acts only after
+	// this immutable deletion set has been constructed.
+	orphans, protected := classifyUnregisteredWorktrees(worktrees, nil)
+	if len(orphans) != 1 || orphans[0].Path != empty {
+		t.Fatalf("force deletion set = %+v, want only %s", orphans, empty)
+	}
+	got := factsByPath(protected)
+	if _, ok := got[unpushed]; !ok {
+		t.Fatal("--force could reach unpushed worktree")
+	}
+	if _, ok := got[busy]; !ok {
+		t.Fatal("--force could reach live-process worktree")
+	}
+}

--- a/cmd/agent-deck/worktree_cleanup_safety_test.go
+++ b/cmd/agent-deck/worktree_cleanup_safety_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,8 +89,8 @@ func TestCleanupExcludesUnpushedCommit(t *testing.T) {
 	if pathsContain(orphans, unpushed) || !pathsContain(orphans, empty) {
 		t.Fatalf("orphans = %+v, must exclude %s and include %s", orphans, unpushed, empty)
 	}
-	if got := factsByPath(protected)[unpushed].Unpushed; got != 1 {
-		t.Fatalf("unpushed count = %d, want 1", got)
+	if got := factsByPath(protected)[unpushed].Unpushed; got == nil || *got != 1 {
+		t.Fatalf("unpushed count = %v, want 1", got)
 	}
 }
 
@@ -103,7 +104,7 @@ func TestCleanupExcludesUncommittedChanges(t *testing.T) {
 	if pathsContain(orphans, dirty) || !pathContainsFacts(protected, dirty) {
 		t.Fatalf("dirty worktree was not protected: orphans=%+v protected=%+v", orphans, protected)
 	}
-	if !factsByPath(protected)[dirty].Dirty {
+	if got := factsByPath(protected)[dirty].Dirty; got == nil || !*got {
 		t.Fatal("dirty fact was not surfaced")
 	}
 	if !pathsContain(orphans, empty) {
@@ -128,8 +129,140 @@ func TestCleanupExcludesLiveProcessCWDInside(t *testing.T) {
 	if len(orphans) != 1 || orphans[0].Path != empty {
 		t.Fatalf("orphans = %+v, want only %s", orphans, empty)
 	}
-	if got := factsByPath(protected)[busy].LivePID; got != cmd.Process.Pid {
-		t.Fatalf("live pid = %d, want %d", got, cmd.Process.Pid)
+	if got := factsByPath(protected)[busy].LivePID; got == nil || *got != cmd.Process.Pid {
+		t.Fatalf("live pid = %v, want %d", got, cmd.Process.Pid)
+	}
+}
+
+func TestCleanupSelfProbeHelper(t *testing.T) {
+	path := os.Getenv("AGENTDECK_TEST_SELF_CWD")
+	if path == "" {
+		return
+	}
+	if err := os.Chdir(path); err != nil {
+		t.Fatal(err)
+	}
+	pid, err := processWithCWDInside(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("self cwd pid = %d, want %d", pid, os.Getpid())
+	}
+}
+
+// Regression for E1: cleanup itself is a live cwd-inside process and must veto
+// deleting the worktree from which it is directly executed.
+func TestCleanupExcludesOwnProcessCWD(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCleanupSelfProbeHelper$")
+	cmd.Env = append(os.Environ(), "AGENTDECK_TEST_SELF_CWD="+dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("self-cwd helper: %v\n%s", err, out)
+	}
+}
+
+// Regression for E2: a candidate that becomes busy during confirmation is
+// re-inspected and rejected at the removal boundary.
+func TestCleanupRevalidatesRealityBeforeRemoval(t *testing.T) {
+	_, _, busy, _, worktrees := cleanupFixture(t)
+	initial := inspectWorktreeForCleanup(worktrees[2])
+	if !initial.safeToRemove() {
+		t.Fatalf("initial candidate unexpectedly protected: %s", initial.summary())
+	}
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("cd %q && exec sleep 30", busy))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	waitForFixtureCWD(t, cmd.Process.Pid, busy)
+	_, reason := revalidateCleanupCandidate(worktrees[2], worktrees, nil)
+	if !strings.Contains(reason, fmt.Sprintf("pid %d", cmd.Process.Pid)) {
+		t.Fatalf("revalidation reason = %q, want live pid", reason)
+	}
+}
+
+// Regression for E3: registry occupancy through a symlink is the same path as
+// Git's canonical worktree path.
+func TestCleanupCanonicalizesSymlinkOccupancy(t *testing.T) {
+	_, _, _, empty, worktrees := cleanupFixture(t)
+	link := filepath.Join(filepath.Dir(empty), "empty-link")
+	if err := os.Symlink(empty, link); err != nil {
+		t.Fatal(err)
+	}
+	orphans, _ := classifyUnregisteredWorktrees(worktrees, map[string]bool{link: true})
+	if pathsContain(orphans, empty) {
+		t.Fatalf("symlink-occupied worktree %s entered orphan set", empty)
+	}
+}
+
+// Regression for E4: fields after a failed probe were never observed and must
+// not be serialized or described as empty.
+func TestCleanupUnknownFactsAreNotEmpty(t *testing.T) {
+	facts := inspectWorktreeForCleanup(vcs.Worktree{Path: filepath.Join(t.TempDir(), "missing"), Branch: "gone"})
+	data := facts.jsonData()
+	for _, key := range []string{"unpushed", "dirty", "live_pid"} {
+		if _, exists := data[key]; exists {
+			t.Fatalf("unknown field %q serialized as known: %#v", key, data)
+		}
+	}
+	for _, want := range []string{"unpushed unknown", "dirty=unknown", "pid unknown"} {
+		if !strings.Contains(facts.summary(), want) {
+			t.Fatalf("summary %q missing %q", facts.summary(), want)
+		}
+	}
+}
+
+// Regression for E5: an inspection failure alone is a deletion veto. This
+// fails if the InspectErr predicate is removed from safeToRemove.
+func TestCleanupInspectionErrorFailsClosed(t *testing.T) {
+	zero := 0
+	clean := false
+	facts := worktreeCleanupFacts{Unpushed: &zero, Dirty: &clean, LivePID: &zero, InspectErr: fmt.Errorf("probe failed")}
+	if facts.safeToRemove() {
+		t.Fatal("inspection error was treated as permission to remove")
+	}
+}
+
+// Regression for E6: after another cleanup wins, the absent worktree is a
+// skipped candidate rather than a second successful removal.
+func TestCleanupConcurrentLoserSkipsMissingWorktree(t *testing.T) {
+	main, _, _, empty, worktrees := cleanupFixture(t)
+	backend, err := detectAndCreateBackend(main)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := worktrees[3]
+	type result struct {
+		removed bool
+		reason  string
+		err     error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			<-start
+			removed, reason, err := removeCleanupCandidate(backend, candidate, func() (map[string]bool, error) { return nil, nil })
+			results <- result{removed: removed, reason: reason, err: err}
+		}()
+	}
+	close(start)
+	first, second := <-results, <-results
+	removedCount := 0
+	loserReason := ""
+	for _, got := range []result{first, second} {
+		if got.err != nil {
+			t.Fatalf("concurrent cleanup error: %v (%s)", got.err, got.reason)
+		}
+		if got.removed {
+			removedCount++
+		} else {
+			loserReason = got.reason
+		}
+	}
+	if removedCount != 1 || loserReason != "no longer registered as a worktree" {
+		t.Fatalf("removed=%d loser reason=%q; both calls must not report success for %s", removedCount, loserReason, empty)
 	}
 }
 

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -595,8 +595,22 @@ func handleWorktreeCleanup(profile string, args []string) {
 			fmt.Fprintf(os.Stderr, "Warning: no VCS backend for worktree removal\n")
 			break
 		}
-		if err := cleanupBackend.RemoveWorktree(wt.Path, false); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove worktree %s: %v\n", wt.Path, err)
+		// Confirmation may wait indefinitely. Reload both registry ownership and
+		// repository state, then inspect the candidate again at the destructive
+		// boundary. --force authorizes removal; it never bypasses this gate.
+		removed, skipReason, removeErr := removeCleanupCandidate(cleanupBackend, wt, func() (map[string]bool, error) {
+			_, currentInstances, _, err := loadSessionData(profile)
+			if err != nil {
+				return nil, err
+			}
+			return localSessionPaths(currentInstances), nil
+		})
+		if !removed {
+			if removeErr != nil {
+				fmt.Printf("Skipped worktree: %s (%s: %v)\n", FormatPath(wt.Path), skipReason, removeErr)
+			} else {
+				fmt.Printf("Skipped worktree: %s (%s)\n", FormatPath(wt.Path), skipReason)
+			}
 			continue
 		}
 		removedWorktrees++

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -450,6 +450,7 @@ func handleWorktreeCleanup(profile string, args []string) {
 
 	// Find orphaned worktrees (exist but no session points to them)
 	var orphanedWorktrees []vcs.Worktree
+	var protectedWorktrees []worktreeCleanupFacts
 	var cleanupBackend vcs.Backend
 
 	if backend, bErr := detectAndCreateBackend(cwd); bErr == nil {
@@ -462,15 +463,7 @@ func handleWorktreeCleanup(profile string, args []string) {
 			// cleanup silently skips it forever.
 			sessionPaths := localSessionPaths(instances)
 
-			// Check each worktree (skip the first one which is usually the main repo)
-			for i, wt := range worktrees {
-				if i == 0 {
-					continue // Skip main repo
-				}
-				if !sessionPaths[wt.Path] {
-					orphanedWorktrees = append(orphanedWorktrees, wt)
-				}
-			}
+			orphanedWorktrees, protectedWorktrees = classifyUnregisteredWorktrees(worktrees, sessionPaths)
 		}
 	}
 
@@ -492,11 +485,16 @@ func handleWorktreeCleanup(profile string, args []string) {
 				"branch": wt.Branch,
 			})
 		}
+		protectedWorktreeData := make([]map[string]interface{}, 0, len(protectedWorktrees))
+		for _, facts := range protectedWorktrees {
+			protectedWorktreeData = append(protectedWorktreeData, facts.jsonData())
+		}
 
 		result := map[string]interface{}{
-			"orphaned_sessions":  orphanedSessionData,
-			"orphaned_worktrees": orphanedWorktreeData,
-			"dry_run":            !*force,
+			"orphaned_sessions":   orphanedSessionData,
+			"orphaned_worktrees":  orphanedWorktreeData,
+			"protected_worktrees": protectedWorktreeData,
+			"dry_run":             !*force,
 		}
 
 		out.Print("", result)
@@ -508,7 +506,7 @@ func handleWorktreeCleanup(profile string, args []string) {
 
 	// Human-readable output
 	if !*jsonOutput {
-		if len(orphanedSessions) == 0 && len(orphanedWorktrees) == 0 {
+		if len(orphanedSessions) == 0 && len(orphanedWorktrees) == 0 && len(protectedWorktrees) == 0 {
 			fmt.Println("No orphans found. Everything is clean!")
 			return
 		}
@@ -525,6 +523,14 @@ func handleWorktreeCleanup(profile string, args []string) {
 			fmt.Println("Orphaned Worktrees (no session associated):")
 			for _, wt := range orphanedWorktrees {
 				fmt.Printf("  - %s (branch: %s)\n", FormatPath(wt.Path), wt.Branch)
+			}
+			fmt.Println()
+		}
+
+		if len(protectedWorktrees) > 0 {
+			fmt.Println("Protected Worktrees (not orphans; cleanup will not remove):")
+			for _, facts := range protectedWorktrees {
+				fmt.Printf("  - %s (branch: %s; %s)\n", FormatPath(facts.Worktree.Path), facts.Worktree.Branch, facts.summary())
 			}
 			fmt.Println()
 		}


### PR DESCRIPTION
`worktree cleanup` could destroy real work (#1995: unpushed commits lost). This makes cleanup honest about reality, in three reviewed rounds:

- **Exclusions that hold:** unpushed, dirty, live-process, and inspection-failure worktrees are never proposed for removal, and `--force` cannot override any exclusion class. An inspection failure protects rather than exposes — unknown is not empty.
- **Revalidation at deletion time:** facts are re-inspected immediately before each removal, so a worktree that gains a commit, a dirty file, a live process, or a session association while the confirmation prompt is open is skipped with an honest per-item reason. Cleanup also refuses candidates containing its own working directory, canonicalizes occupancy paths so symlinked session paths protect their targets, and a concurrent loser reports skipped rather than a duplicate success.
- **Every guard is regression-pinned.** An independent adversarial review (two rounds, all probes re-executed against each tip) drove the second round; each guard was verified by mutation — removing any single guard fails a specific named test, including the deletion-time ownership veto.

`--dry-run` and `--json` expose per-worktree facts with uninspected fields absent rather than zero-filled. Verification ran container-only against read-only mounts throughout. Fixes #1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree cleanup safety by protecting worktrees with unpushed commits, uncommitted changes, active processes, or session ownership.
  * Added clear human-readable and JSON details explaining why worktrees are protected.
  * Rechecks worktree and session state immediately before removal to prevent accidental deletion during concurrent changes.
  * Correctly handles symlinked paths, inspection failures, and race conditions.
  * Force cleanup no longer overrides safety protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->