### PR TITLE
fix: case-insensitive path completion with visible match list

### DIFF
--- a/internal/session/utils.go
+++ b/internal/session/utils.go
@@ -75,7 +75,7 @@ func GetDirectoryCompletions(input string) ([]string, error) {
 		}
 
 		name := entry.Name()
-		if strings.HasPrefix(name, prefix) {
+		if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
 			match := filepath.Join(dir, name)
 
 			// If original input used tilde, convert back

--- a/internal/session/utils.go
+++ b/internal/session/utils.go
@@ -116,6 +116,20 @@ func (c *CompletionCycler) SetMatches(matches []string) {
 	c.index = -1
 }
 
+// Matches returns the current completion matches (nil when inactive).
+func (c *CompletionCycler) Matches() []string {
+	return c.matches
+}
+
+// Index returns the index of the currently selected match, or -1 when
+// inactive or before the first Next() call.
+func (c *CompletionCycler) Index() int {
+	if !c.IsActive() || c.index < 0 || c.index >= len(c.matches) {
+		return -1
+	}
+	return c.index
+}
+
 // Next returns the next match in the cycle.
 // Wraps around to the beginning if the end is reached.
 func (c *CompletionCycler) Next() string {

--- a/internal/session/utils_test.go
+++ b/internal/session/utils_test.go
@@ -21,6 +21,7 @@ func TestGetDirectoryCompletions(t *testing.T) {
 		"personal",
 		"work/agent-deck",
 		"work/other",
+		"Documents",
 	}
 	for _, d := range dirs {
 		err := os.MkdirAll(filepath.Join(tmpDir, d), 0755)
@@ -61,6 +62,16 @@ func TestGetDirectoryCompletions(t *testing.T) {
 			name:     "Exact match directory (should return itself and any subdirs starting with it)",
 			input:    filepath.Join(tmpDir, "projects"),
 			expected: []string{filepath.Join(tmpDir, "projects")},
+		},
+		{
+			name:     "Lowercase prefix matches capitalized directory",
+			input:    filepath.Join(tmpDir, "doc"),
+			expected: []string{filepath.Join(tmpDir, "Documents")},
+		},
+		{
+			name:     "Uppercase prefix matches lowercase directories",
+			input:    filepath.Join(tmpDir, "P"),
+			expected: []string{filepath.Join(tmpDir, "personal"), filepath.Join(tmpDir, "playground"), filepath.Join(tmpDir, "projects")},
 		},
 		{
 			name:     "Trailing slash lists directory contents",

--- a/internal/session/utils_test.go
+++ b/internal/session/utils_test.go
@@ -119,3 +119,32 @@ func TestCompletionCycler(t *testing.T) {
 	assert.Equal(t, "/x", cycler.Next())
 	assert.Equal(t, "/x", cycler.Next())
 }
+
+func TestCompletionCycler_MatchesAndIndex(t *testing.T) {
+	cycler := &CompletionCycler{}
+
+	// Inactive cycler exposes no matches and no selection.
+	assert.Nil(t, cycler.Matches())
+	assert.Equal(t, -1, cycler.Index())
+
+	matches := []string{"/a", "/b", "/c"}
+	cycler.SetMatches(matches)
+
+	// Before the first Next(), nothing is selected yet.
+	assert.Equal(t, matches, cycler.Matches())
+	assert.Equal(t, -1, cycler.Index())
+
+	cycler.Next()
+	assert.Equal(t, 0, cycler.Index())
+	cycler.Next()
+	assert.Equal(t, 1, cycler.Index())
+
+	// Wrap around.
+	cycler.Next()
+	cycler.Next()
+	assert.Equal(t, 0, cycler.Index())
+
+	cycler.Reset()
+	assert.Nil(t, cycler.Matches())
+	assert.Equal(t, -1, cycler.Index())
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -2978,6 +2978,13 @@ func (d *NewDialog) renderSuggestionsDropdown() string {
 		return ""
 	}
 
+	// While Tab-completion is cycling through multiple filesystem matches,
+	// show those matches instead of the recent-path suggestions so the user
+	// can see what Tab is cycling through (terminal-style menu completion).
+	if len(d.pathCycler.Matches()) > 1 {
+		return d.renderCompletionDropdown()
+	}
+
 	menuBg := dropdownMenuBg()
 	suggestionStyle := lipgloss.NewStyle().Foreground(ColorComment).Background(menuBg)
 	customStyle := lipgloss.NewStyle().Foreground(ColorPurple).Italic(true).Background(menuBg)
@@ -3065,6 +3072,72 @@ func (d *NewDialog) renderSuggestionsDropdown() string {
 	menuStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
+		Background(menuBg).
+		Padding(0, 1)
+
+	return menuStyle.Render(b.String())
+}
+
+// renderCompletionDropdown renders the active Tab-completion matches as a
+// menu, highlighting the match currently applied to the path input.
+func (d *NewDialog) renderCompletionDropdown() string {
+	menuBg := dropdownMenuBg()
+	matchStyle := lipgloss.NewStyle().Foreground(ColorComment).Background(menuBg)
+	selectedStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true).Background(menuBg)
+
+	matches := d.pathCycler.Matches()
+	cursor := d.pathCycler.Index()
+	total := len(matches)
+
+	// Paginated scrolling window around the selected match.
+	maxShow := 5
+	startIdx := 0
+	endIdx := total
+	if total > maxShow {
+		anchor := cursor
+		if anchor < 0 {
+			anchor = 0
+		}
+		startIdx = anchor - maxShow/2
+		if startIdx < 0 {
+			startIdx = 0
+		}
+		endIdx = startIdx + maxShow
+		if endIdx > total {
+			endIdx = total
+			startIdx = endIdx - maxShow
+		}
+	}
+
+	var b strings.Builder
+	if startIdx > 0 {
+		b.WriteString(matchStyle.Render(fmt.Sprintf("  ↑ %d more above", startIdx)))
+		b.WriteString("\n")
+	}
+	for i := startIdx; i < endIdx; i++ {
+		if i > startIdx {
+			b.WriteString("\n")
+		}
+		style := matchStyle
+		prefix := "  "
+		if i == cursor {
+			style = selectedStyle
+			prefix = "▶ "
+		}
+		b.WriteString(style.Render(prefix + matches[i]))
+	}
+	if endIdx < total {
+		b.WriteString("\n")
+		b.WriteString(matchStyle.Render(fmt.Sprintf("  ↓ %d more below", total-endIdx)))
+	}
+
+	b.WriteString("\n")
+	footerText := fmt.Sprintf(" %d matches │ Tab cycle │ type to edit ", total)
+	b.WriteString(lipgloss.NewStyle().Foreground(ColorBorder).Background(menuBg).Render(footerText))
+
+	menuStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorCyan).
 		Background(menuBg).
 		Padding(0, 1)
 

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -3078,6 +3079,22 @@ func (d *NewDialog) renderSuggestionsDropdown() string {
 	return menuStyle.Render(b.String())
 }
 
+// sanitizeMatchForDisplay neutralizes control characters in a
+// filesystem-derived name before it is rendered. Directory names may carry
+// ESC/BEL/CR/LF and OSC sequences (repo checkouts, extracted archives), which
+// would otherwise become live terminal escape sequences inside the dropdown —
+// able to alter terminal state or forge menu contents. Each control rune is
+// replaced with U+FFFD for display only; callers keep the raw name for
+// selection so completion still targets the real directory.
+func sanitizeMatchForDisplay(name string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '�'
+		}
+		return r
+	}, name)
+}
+
 // renderCompletionDropdown renders the active Tab-completion matches as a
 // menu, highlighting the match currently applied to the path input.
 func (d *NewDialog) renderCompletionDropdown() string {
@@ -3124,7 +3141,7 @@ func (d *NewDialog) renderCompletionDropdown() string {
 			style = selectedStyle
 			prefix = "▶ "
 		}
-		b.WriteString(style.Render(prefix + matches[i]))
+		b.WriteString(style.Render(prefix + sanitizeMatchForDisplay(matches[i])))
 	}
 	if endIdx < total {
 		b.WriteString("\n")

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -6,6 +6,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
@@ -662,6 +666,66 @@ func TestNewDialog_TabShowsCompletionMatches(t *testing.T) {
 	}
 	if strings.Contains(view, "▶ "+first) {
 		t.Errorf("after second Tab, %q should no longer be highlighted", first)
+	}
+}
+
+// TestNewDialog_CompletionDropdown_SanitizesControlBytes: directory names can
+// carry ESC/BEL/OSC sequences and newlines (repo checkouts, extracted
+// archives). The dropdown renders filesystem-derived names, so control bytes
+// must be neutralized at the render boundary — while the raw names stay
+// intact in the match set so selection still targets the real directory.
+func TestNewDialog_CompletionDropdown_SanitizesControlBytes(t *testing.T) {
+	// Pin the global lipgloss profile to Ascii so the render carries no
+	// style-generated escapes (issue391 tests force TrueColor binary-wide);
+	// any control byte left in the output can then only come from a filename.
+	oldProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(oldProfile) })
+
+	d := NewNewDialog()
+	d.SetSize(200, 50)
+	d.Show()
+
+	tmpDir := t.TempDir()
+	oscName := "evil\x1b]52;c;cGF5bG9hZA==\x07osc"
+	nlName := "evil\nnewline"
+	for _, sub := range []string{oscName, nlName, "evilclean"} {
+		if err := os.Mkdir(filepath.Join(tmpDir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Focus the path field and Tab on a prefix matching all three.
+	d.focusIndex = 2
+	d.updateFocus()
+	d.pathInput.SetValue(filepath.Join(tmpDir, "evil"))
+	d.pathInput.SetCursor(len(d.pathInput.Value()))
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if !d.pathCycler.IsActive() {
+		t.Fatal("expected completion cycler to be active after Tab on partial path")
+	}
+
+	// Raw bytes must survive in the match set used for selection.
+	var rawOSC, rawNL bool
+	for _, m := range d.pathCycler.Matches() {
+		if strings.HasSuffix(m, oscName) {
+			rawOSC = true
+		}
+		if strings.HasSuffix(m, nlName) {
+			rawNL = true
+		}
+	}
+	if !rawOSC || !rawNL {
+		t.Errorf("raw control-byte names must remain selectable, matches: %q", d.pathCycler.Matches())
+	}
+
+	// The rendered menu must carry no control bytes (newlines between menu
+	// rows are layout, not payload).
+	menu := d.renderCompletionDropdown()
+	for _, r := range menu {
+		if r != '\n' && unicode.IsControl(r) {
+			t.Fatalf("rendered dropdown contains control rune %q:\n%q", r, menu)
+		}
 	}
 }
 

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -602,6 +603,65 @@ func TestNewDialog_MalformedPathFix(t *testing.T) {
 				t.Errorf("GetValues() path = %q, want %q", path, tt.expected)
 			}
 		})
+	}
+}
+
+// TestNewDialog_TabShowsCompletionMatches: when Tab autocompletes a partial
+// path with multiple matches, the matches must be listed in the dropdown
+// (terminal-style menu completion) with the current one highlighted, and
+// repeated Tab must move the highlight through the list.
+func TestNewDialog_TabShowsCompletionMatches(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(200, 50)
+	d.Show()
+
+	tmpDir := t.TempDir()
+	subdirs := []string{"alpha", "amber", "apple"}
+	for _, sub := range subdirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Focus the path field.
+	d.focusIndex = 2
+	d.updateFocus()
+	if d.currentTarget() != focusPath {
+		t.Fatalf("expected focusPath, got %v", d.currentTarget())
+	}
+
+	d.pathInput.SetValue(filepath.Join(tmpDir, "a"))
+	d.pathInput.SetCursor(len(d.pathInput.Value()))
+
+	// First Tab: completes to the first match and shows the match list.
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	if !d.pathCycler.IsActive() {
+		t.Fatal("expected completion cycler to be active after Tab on partial path")
+	}
+	view := d.View()
+	for _, sub := range subdirs {
+		if !strings.Contains(view, sub) {
+			t.Errorf("completion list should show %q, view:\n%s", sub, view)
+		}
+	}
+	first := d.pathCycler.Matches()[0]
+	if !strings.Contains(view, "▶ "+first) {
+		t.Errorf("current match %q should be highlighted with ▶", first)
+	}
+
+	// Second Tab: cycles to the next match and moves the highlight.
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
+	second := d.pathCycler.Matches()[1]
+	if got := d.pathInput.Value(); got != second {
+		t.Errorf("second Tab should complete to %q, got %q", second, got)
+	}
+	view = d.View()
+	if !strings.Contains(view, "▶ "+second) {
+		t.Errorf("after second Tab, %q should be highlighted with ▶", second)
+	}
+	if strings.Contains(view, "▶ "+first) {
+		t.Errorf("after second Tab, %q should no longer be highlighted", first)
 	}
 }
 


### PR DESCRIPTION
## What problem does this solve?

Tab path completion in the new session dialog fails on case mismatches: in a directory containing a `MyApp` folder, typing `m` and pressing Tab never suggests it. And because Tab cycles through matches invisibly (it just swaps the input text), there is no way to see what the suggestions are — or whether there are any at all.

## Why this change

Two targeted fixes to the same Tab flow, in separate commits:

1. `GetDirectoryCompletions` compared the typed prefix byte-for-byte (`strings.HasPrefix`). On macOS the default APFS volume is case-insensitive, so `os.Stat` accepts wrong-case paths while the prefix filter rejects them — Tab silently finds zero matches. The filter now lowercases both sides before comparing; completed paths keep their real on-disk casing. Chosen over smart-case for simplicity and because it matches shell behavior on the platform where the mismatch occurs.
2. The dropdown now renders the cycler's matches (terminal-style menu completion) while Tab is cycling, reusing the existing menu styling — bordered box, scrolling window of 5, more-above/below indicators — with a `▶` highlight that follows each Tab press and a footer showing the match count. `CompletionCycler` gains read-only `Matches()`/`Index()` getters so the UI can render state it previously couldn't see. The list disappears when the cycler resets (typing, backspace, leaving the field); a single match still completes silently; the recent-paths dropdown returns once cycling ends.

## User impact

In the new session dialog path field, Tab now completes regardless of typed case, and multiple matches are listed with the current one highlighted as Tab cycles. The multi-repo path editor gets the case-insensitivity fix too (same function); its rendering is untouched. Focus advancement rules (#896) are unchanged.

## Evidence

Before: `~/code/ag` + Tab → nothing happens (zero matches from the case-sensitive filter). After: completes to `~/Code/Agent-Deck`, and with several matches the dropdown lists them:

    ▶ /Users/alan/Code/agent-deck
      /Users/alan/Code/agent-tools
      /Users/alan/Code/AgentKit
     3 matches │ Tab cycle │ type to edit

New tests (each watched failing before the fix, then passing):

    --- PASS: TestGetDirectoryCompletions (0.00s)
    --- PASS: TestCompletionCycler (0.00s)
    --- PASS: TestCompletionCycler_MatchesAndIndex (0.00s)
    ok      github.com/asheshgoplani/agent-deck/internal/session   0.362s
    --- PASS: TestNewDialog_TabShowsCompletionMatches (0.01s)
    ok      github.com/asheshgoplani/agent-deck/internal/ui 0.430s

`gofmt -l ./cmd ./internal` prints nothing; `go vet` clean. Sandboxed suite (`HOME=$(mktemp -d) … go test`): `internal/ui` passes in full; `internal/session` has 4 failures (`TestIssue1421_CleanStaleSSHSockets`, `TestEnsureClaudeSessionIDFromDiskForRestart_RemoteNeverAdoptsLocalUUID`, `TestFindLatestClaudeTranscriptOnDisk_RemoteRefuses`, `TestRemoteCDPrefix_IdentityAndExecutionAgree`) that fail identically on clean upstream `main` with the change stashed — pre-existing and unrelated, which is why the suite checklist box below is left unchecked.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

**Prompt / session log (optional):**

## What actually bothered you

Quoting the human directing this PR: "In a directory with MyApp folder if I type 'm' and tab the uppercase folder never got suggested" and "I couldn't see the suggestions list" — plus, on the follow-up: "anyway to list the options with tab like we do on a terminal?"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- Your PR will be validated (applied, built, tested) by the maintainer's AI pipeline within about a day. You'll get a structured comment with the result. Merges are always human. -->

<!-- gate:ai=assisted model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added case-insensitive directory path completion.
  - Added a completion dropdown when cycling through multiple matches with Tab.
  - Added match highlighting, pagination, match counts, and navigation hints.
  - Sanitized control characters in displayed filesystem names while preserving selectable paths.

- **Bug Fixes**
  - Improved completion behavior for uppercase and lowercase path prefixes.
  - Ensured completion state resets and cycles correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->