### PR TITLE
fix(inbox): error transitions deliver — and when they cannot, they land in the unowned ledger honestly

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -36,9 +36,16 @@ func (e *inboxTargetAmbiguousError) Error() string {
 	return "Error: inbox drain target is ambiguous. Nothing was drained.\n" + e.message
 }
 
-// inboxExitCode is the #1991 drain-resolution contract: 2 means the target
-// does not exist, 3 means the supplied title/prefix is ambiguous, and 1 is a
-// storage, usage, or drain failure. Resolution failures never drain events.
+type deadLettersPendingError struct{ count int }
+
+func (e *deadLettersPendingError) Error() string {
+	return fmt.Sprintf("inbox drain incomplete: %d dead-lettered event(s) require attention", e.count)
+}
+
+// inboxExitCode is the drain-resolution contract (#1991, extended): 2 means the
+// target does not exist, 3 means the supplied title/prefix is ambiguous, 4 means
+// the drain ran but dead-lettered events remain and require attention, and 1 is
+// a storage, usage, or drain failure. Resolution failures never drain events.
 func inboxExitCode(err error) int {
 	var notFound *inboxTargetNotFoundError
 	if errors.As(err, &notFound) {
@@ -47,6 +54,10 @@ func inboxExitCode(err error) int {
 	var ambiguous *inboxTargetAmbiguousError
 	if errors.As(err, &ambiguous) {
 		return 3
+	}
+	var pending *deadLettersPendingError
+	if errors.As(err, &pending) {
+		return 4
 	}
 	return 1
 }
@@ -132,10 +143,23 @@ func runInboxDrain(stdout io.Writer, args []string, explicitProfile string) erro
 			events = []session.TransitionNotificationEvent{}
 		}
 		enc := json.NewEncoder(stdout)
-		return enc.Encode(events)
+		if err := enc.Encode(events); err != nil {
+			return err
+		}
+	} else {
+		printInboxEvents(stdout, events)
 	}
 
-	printInboxEvents(stdout, events)
+	deadLetters, err := session.CountDeadLetterRecords()
+	if err != nil {
+		return fmt.Errorf("count dead letters: %w", err)
+	}
+	if deadLetters > 0 {
+		if !*asJSON {
+			fmt.Fprintf(stdout, "WARNING: %d dead-lettered event(s) require attention.\n", deadLetters)
+		}
+		return &deadLettersPendingError{count: deadLetters}
+	}
 	return nil
 }
 

--- a/cmd/agent-deck/issue2007_delivery_guards_test.go
+++ b/cmd/agent-deck/issue2007_delivery_guards_test.go
@@ -22,6 +22,10 @@ func TestIssue1877_AutoParentIdentityMustResolve(t *testing.T) {
 
 func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
 	cliInboxTestHome(t)
+	// The #1991/#2030 resolution contract rejects unknown drain targets before
+	// any reporting runs, so the parent must exist for the dead-letter check
+	// to be reachable.
+	registerInboxDrainTarget(t, "parent-1877")
 	event := session.TransitionNotificationEvent{
 		ChildSessionID: "dead-child-1877", Profile: "default",
 		FromStatus: "running", ToStatus: "error", Timestamp: time.Now(),

--- a/cmd/agent-deck/issue2007_delivery_guards_test.go
+++ b/cmd/agent-deck/issue2007_delivery_guards_test.go
@@ -45,3 +45,20 @@ func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
 		t.Fatalf("drain must report non-zero dead-letter count, got %q", out.String())
 	}
 }
+
+func TestIssue1877_CorruptNonEmptyDeadLetterIsNotReportedClean(t *testing.T) {
+	cliInboxTestHome(t)
+	if err := os.MkdirAll(session.DeadLetterDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(session.DeadLetterPathFor("truncated-1877"), []byte(`{"child_session_id":"truncated`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runInbox(&out, []string{"drain", "parent-corrupt-1877"})
+	var pending *deadLettersPendingError
+	if !errors.As(err, &pending) || pending.count != 1 || inboxExitCode(err) != 2 {
+		t.Fatalf("non-empty corrupt dead-letter must be loud: output=%q err=%v", out.String(), err)
+	}
+}

--- a/cmd/agent-deck/issue2007_delivery_guards_test.go
+++ b/cmd/agent-deck/issue2007_delivery_guards_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestIssue1877_AutoParentIdentityMustResolve(t *testing.T) {
+	t.Setenv("AGENT_DECK_SESSION_ID", "")
+	t.Setenv("AGENTDECK_INSTANCE_ID", "stale-parent-1877")
+	parent, unresolved := resolveAutoParentInstanceChecked(nil)
+	if parent != nil || unresolved != "stale-parent-1877" {
+		t.Fatalf("stale injected identity must fail loudly: parent=%v unresolved=%q", parent, unresolved)
+	}
+}
+
+func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
+	cliInboxTestHome(t)
+	event := session.TransitionNotificationEvent{
+		ChildSessionID: "dead-child-1877", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Now(),
+		DeadLetterReason: "unresolvable", Attempts: 5,
+	}
+	raw := []byte(`{"child_session_id":"dead-child-1877","profile":"default","from_status":"running","to_status":"error","timestamp":"` + event.Timestamp.Format(time.RFC3339Nano) + `","attempts":5,"dead_letter_reason":"unresolvable"}` + "\n")
+	if err := os.MkdirAll(session.DeadLetterDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(session.DeadLetterPathFor(event.ChildSessionID), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runInbox(&out, []string{"drain", "parent-1877"})
+	var pending *deadLettersPendingError
+	if !errors.As(err, &pending) || inboxExitCode(err) == 0 {
+		t.Fatalf("dead letters must make drain non-clean: err=%v", err)
+	}
+	if !strings.Contains(out.String(), "1 dead-lettered event") {
+		t.Fatalf("drain must report non-zero dead-letter count, got %q", out.String())
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -360,7 +360,12 @@ func handleLaunch(profile string, args []string) {
 		}
 		sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided, inheritParentGroup)
 	} else if !*noParent {
-		parentInstance = resolveAutoParentInstance(instances)
+		var unresolvedParent string
+		parentInstance, unresolvedParent = resolveAutoParentInstanceChecked(instances)
+		if parentInstance == nil && unresolvedParent != "" {
+			out.Error(fmt.Sprintf("automatic parent %q could not be resolved; use --parent with a valid session or --no-parent for an intentional top-level session", unresolvedParent), ErrCodeNotFound)
+			os.Exit(1)
+		}
 		if parentInstance != nil && !parentInstance.IsSubSession() {
 			sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided, inheritParentGroup)
 		} else {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1201,9 +1201,25 @@ func isWorktreeAlreadyExistsError(err error) bool {
 }
 
 func resolveAutoParentInstance(instances []*session.Instance) *session.Instance {
+	inst, _ := resolveAutoParentInstanceChecked(instances)
+	return inst
+}
+
+// resolveAutoParentInstanceChecked distinguishes a top-level invocation (no
+// managed caller identity) from a child creation whose authoritative injected
+// identity is stale. The latter must fail at creation instead of silently
+// producing an orphan that can only be discovered in delivery dead-letter.
+func resolveAutoParentInstanceChecked(instances []*session.Instance) (*session.Instance, string) {
 	candidates := []string{
 		strings.TrimSpace(os.Getenv("AGENT_DECK_SESSION_ID")),
 		strings.TrimSpace(os.Getenv("AGENTDECK_INSTANCE_ID")),
+	}
+	authoritative := ""
+	for _, candidate := range candidates {
+		if candidate != "" {
+			authoritative = candidate
+			break
+		}
 	}
 
 	if tmuxCurrent := strings.TrimSpace(GetCurrentSessionID()); tmuxCurrent != "" {
@@ -1217,10 +1233,10 @@ func resolveAutoParentInstance(instances []*session.Instance) *session.Instance 
 		}
 		seen[candidate] = true
 		if inst, _, _ := ResolveSession(candidate, instances); inst != nil {
-			return inst
+			return inst, ""
 		}
 	}
-	return nil
+	return nil, authoritative
 }
 
 // resolveGroupPathForAdd resolves a user-provided group selector to a stored group path.
@@ -1523,7 +1539,12 @@ func handleAdd(profile string, args []string) {
 		// is wired into `launch` where path is already known at this point.
 		sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided, false)
 	} else if !*noParent {
-		parentInstance = resolveAutoParentInstance(instances)
+		var unresolvedParent string
+		parentInstance, unresolvedParent = resolveAutoParentInstanceChecked(instances)
+		if parentInstance == nil && unresolvedParent != "" {
+			fmt.Printf("Error: automatic parent %q could not be resolved; use --parent with a valid session or --no-parent for an intentional top-level session\n", unresolvedParent)
+			os.Exit(1)
+		}
 		if parentInstance != nil && !parentInstance.IsSubSession() {
 			sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided, false)
 		} else {

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -180,6 +181,11 @@ func WriteInboxEventIfNew(parentSessionID string, event TransitionNotificationEv
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return false, err
 	}
+	fileLock, err := AcquireConfigFileLock(path)
+	if err != nil {
+		return false, fmt.Errorf("lock inbox append: %w", err)
+	}
+	defer fileLock.Release()
 
 	fp := EventFingerprint(event)
 
@@ -198,33 +204,37 @@ func WriteInboxEventIfNew(parentSessionID string, event TransitionNotificationEv
 		return false, nil
 	}
 
-	// Embed the fingerprint into the persisted JSON so on-disk state is
-	// self-describing — the file-scan recovery path can reconstruct the
-	// dedup set without re-deriving fingerprints from the event body.
-	type wireEvent struct {
-		TransitionNotificationEvent
-		Fingerprint string `json:"fp,omitempty"`
-	}
-	line, err := json.Marshal(wireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
+	line, err := json.Marshal(inboxWireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
 	if err != nil {
 		return false, err
 	}
-
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return false, err
-	}
-	defer f.Close()
-	if _, err := f.Write(append(line, '\n')); err != nil {
-		return false, err
-	}
-	// Audit B2: fsync the append so a crash after Write cannot lose a record the
-	// producer reported as committed.
-	if err := f.Sync(); err != nil {
+	if err := atomicAppendInboxLineLocked(path, line); err != nil {
 		return false, err
 	}
 	seen[fp] = struct{}{}
 	return true, nil
+}
+
+// atomicAppendInboxLineLocked gives an inbox append an old-or-new crash
+// boundary. It builds a complete replacement beside the inbox, fsyncs it, and
+// atomically renames it over the old file. SIGKILL before rename leaves the old
+// complete inbox; SIGKILL after rename leaves the new complete inbox. A partial
+// JSONL tail is never installed as the authoritative file.
+//
+// Caller holds inboxWriteMu.
+func atomicAppendInboxLineLocked(path string, line []byte) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	data := make([]byte, 0, len(existing)+len(line)+1)
+	data = append(data, existing...)
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		data = append(data, '\n')
+	}
+	data = append(data, line...)
+	data = append(data, '\n')
+	return writeFileDurable(path, data, 0o644)
 }
 
 // loadInboxFingerprintsLocked scans an existing inbox file and returns the

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -167,12 +167,18 @@ func sanitizeInboxName(id string) string {
 // The #1225 drain path layers turn_fingerprint dedup on top for at-least-once
 // delivery with exactly-once effects (see inbox_consumer.go).
 func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) error {
+	_, err := WriteInboxEventIfNew(parentSessionID, event)
+	return err
+}
+
+// WriteInboxEventIfNew is WriteInboxEvent with the dedup decision exposed.
+func WriteInboxEventIfNew(parentSessionID string, event TransitionNotificationEvent) (bool, error) {
 	if strings.TrimSpace(parentSessionID) == "" {
-		return errors.New("inbox: empty parent session id")
+		return false, errors.New("inbox: empty parent session id")
 	}
 	path := InboxPathFor(parentSessionID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return false, err
 	}
 
 	fp := EventFingerprint(event)
@@ -189,7 +195,7 @@ func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) 
 		inboxFingerprintCache[path] = seen
 	}
 	if _, dup := seen[fp]; dup {
-		return nil
+		return false, nil
 	}
 
 	// Embed the fingerprint into the persisted JSON so on-disk state is
@@ -201,24 +207,24 @@ func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) 
 	}
 	line, err := json.Marshal(wireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer f.Close()
 	if _, err := f.Write(append(line, '\n')); err != nil {
-		return err
+		return false, err
 	}
 	// Audit B2: fsync the append so a crash after Write cannot lose a record the
 	// producer reported as committed.
 	if err := f.Sync(); err != nil {
-		return err
+		return false, err
 	}
 	seen[fp] = struct{}{}
-	return nil
+	return true, nil
 }
 
 // loadInboxFingerprintsLocked scans an existing inbox file and returns the

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -321,6 +321,45 @@ func writeDeadLetter(event TransitionNotificationEvent) error {
 	return f.Sync()
 }
 
+// CountDeadLetterRecords returns the number of parseable records currently in
+// the dead-letter directory. Inbox drain uses this to avoid reporting a clean
+// state while undelivered events are parked out of sight.
+func CountDeadLetterRecords() (int, error) {
+	entries, err := os.ReadDir(DeadLetterDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(DeadLetterDir(), entry.Name()))
+		if err != nil {
+			return count, err
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
+		for scanner.Scan() {
+			if _, err := decodeInboxLine(scanner.Bytes()); err == nil {
+				count++
+			}
+		}
+		scanErr := scanner.Err()
+		closeErr := f.Close()
+		if scanErr != nil {
+			return count, scanErr
+		}
+		if closeErr != nil {
+			return count, closeErr
+		}
+	}
+	return count, nil
+}
+
 // --- unified producer commit (shared by interactive + one-shot) -------------
 
 // resolveParentIDForInbox loads the registry and applies the
@@ -393,6 +432,24 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 		return false, true, ""
 	}
 	if parent == nil {
+		// Missing and non-live parents do not make the event disposable. Persist
+		// it in the reserved, drainable unowned ledger. Deliberate suppression
+		// and a removed child remain terminal drops.
+		if isUnownedReason(reason) {
+			written, err := recordUnownedTransition(event)
+			if err != nil {
+				return false, true, ""
+			}
+			if written {
+				event.TargetKind = "unowned"
+				event.DeliveryResult = transitionDeliveryCommitted
+				n.logEvent(event)
+			}
+			// Preserve the existing operator-visible terminal accounting as well;
+			// the important invariant is that dead-letter is no longer the only
+			// copy and the event is now drainable from _unowned.
+			return false, false, reason
+		}
 		return false, false, reason
 	}
 	parentID := parent.ID

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -133,6 +134,11 @@ func CommitToInbox(parentSessionID string, event TransitionNotificationEvent) er
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
+	fileLock, err := AcquireConfigFileLock(path)
+	if err != nil {
+		return fmt.Errorf("lock inbox commit: %w", err)
+	}
+	defer fileLock.Release()
 
 	inboxWriteMu.Lock()
 	defer inboxWriteMu.Unlock()
@@ -150,8 +156,8 @@ func CommitToInbox(parentSessionID string, event TransitionNotificationEvent) er
 	return appendInboxLineLocked(path, event)
 }
 
-// appendInboxLineLocked marshals one event (with its EventFingerprint embedded)
-// and appends it as a JSONL line. Caller holds inboxWriteMu. Also refreshes the
+// appendInboxLineLocked marshals one event and atomically installs an old-or-new
+// complete inbox file. Caller holds inboxWriteMu. It also refreshes the
 // process-local fingerprint cache so WriteInboxEvent's dedup stays consistent.
 func appendInboxLineLocked(path string, event TransitionNotificationEvent) error {
 	fp := EventFingerprint(event)
@@ -159,19 +165,7 @@ func appendInboxLineLocked(path string, event TransitionNotificationEvent) error
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if _, err := f.Write(append(line, '\n')); err != nil {
-		return err
-	}
-	// Audit B2: fsync the append before reporting success. CommitToInbox is the
-	// PRIMARY delivery path; without this a crash after Write returns but before
-	// the kernel flushes loses the record while the producer believes it
-	// committed. Completions are low-frequency, so the flush cost is negligible.
-	if err := f.Sync(); err != nil {
+	if err := atomicAppendInboxLineLocked(path, line); err != nil {
 		return err
 	}
 	seen, ok := inboxFingerprintCache[path]
@@ -344,7 +338,10 @@ func CountDeadLetterRecords() (int, error) {
 		scanner := bufio.NewScanner(f)
 		scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
 		for scanner.Scan() {
-			if _, err := decodeInboxLine(scanner.Bytes()); err == nil {
+			// Unknown/corrupt is still pending operator work. Counting every
+			// nonblank physical record prevents a truncated legacy append from
+			// making a non-empty ledger look clean (#1877).
+			if strings.TrimSpace(scanner.Text()) != "" {
 				count++
 			}
 		}
@@ -436,6 +433,7 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 		// it in the reserved, drainable unowned ledger. Deliberate suppression
 		// and a removed child remain terminal drops.
 		if isUnownedReason(reason) {
+			event.DeadLetterReason = reason
 			written, err := recordUnownedTransition(event)
 			if err != nil {
 				return false, true, ""
@@ -445,10 +443,13 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 				event.DeliveryResult = transitionDeliveryCommitted
 				n.logEvent(event)
 			}
-			// Preserve the existing operator-visible terminal accounting as well;
-			// the important invariant is that dead-letter is no longer the only
-			// copy and the event is now drainable from _unowned.
-			return false, false, reason
+			// Keep the existing operator-visible forensic copy/missed-log for
+			// non-benign terminal reasons. The durable delivery result remains a
+			// success because _unowned is now the actionable copy.
+			n.terminalDrop(event, reason)
+			// A duplicate means the identical durable event already exists. Both a
+			// new append and that idempotent replay are successful commits.
+			return true, false, ""
 		}
 		return false, false, reason
 	}

--- a/internal/session/issue1225_deadletter_reason_test.go
+++ b/internal/session/issue1225_deadletter_reason_test.go
@@ -61,11 +61,12 @@ func TestB5_ParentRemovedMidFlight_DeadLettersWithReasonAndLogs(t *testing.T) {
 		ToStatus:       "waiting",
 		Timestamp:      now,
 	})
-	if res.DeliveryResult != transitionDeliveryDropped {
-		t.Fatalf("expected dropped, got %q", res.DeliveryResult)
+	if res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("durable _unowned persistence must report committed, got %q", res.DeliveryResult)
 	}
-	if res.DeadLetterReason != deadLetterReasonParentMissing {
-		t.Fatalf("expected reason %q, got %q", deadLetterReasonParentMissing, res.DeadLetterReason)
+	unowned, err := ReadAndTruncateInbox(UnownedInboxID)
+	if err != nil || len(unowned) != 1 || unowned[0].DeadLetterReason != deadLetterReasonParentMissing {
+		t.Fatalf("_unowned must preserve parent removal reason: events=%+v err=%v", unowned, err)
 	}
 
 	// Dead-letter record exists with the reason.

--- a/internal/session/issue2007_atomic_append_crash_test.go
+++ b/internal/session/issue2007_atomic_append_crash_test.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const issue2007CrashHelperEnv = "AGENTDECK_TEST_2007_CRASH_APPEND"
+
+// TestIssue2007_AppendCrashHelper is invoked as a subprocess by the test below.
+// It blocks after the replacement file has been written and fsync'd but before
+// rename, giving the parent an exact SIGKILL boundary inside the append.
+func TestIssue2007_AppendCrashHelper(t *testing.T) {
+	if os.Getenv(issue2007CrashHelperEnv) != "1" {
+		return
+	}
+	marker := os.Getenv("AGENTDECK_TEST_2007_CRASH_MARKER")
+	restore := SetFsyncHookForTest(func(f *os.File) error {
+		if filepath.Ext(f.Name()) == ".tmp" {
+			if err := os.WriteFile(marker, []byte("fsynced-before-rename"), 0o600); err != nil {
+				return err
+			}
+			select {}
+		}
+		return f.Sync()
+	})
+	defer restore()
+	ResetInboxFingerprintCacheForTest()
+	err := WriteInboxEvent("parent-atomic-2007", TransitionNotificationEvent{
+		ChildSessionID: "new-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Unix(200, 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIssue2007_SIGKILLDuringAppendLeavesOldOrNewCompleteFile(t *testing.T) {
+	inboxTestHome(t)
+	parent := "parent-atomic-2007"
+	old := TransitionNotificationEvent{
+		ChildSessionID: "old-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "waiting", Timestamp: time.Unix(100, 0),
+	}
+	if err := WriteInboxEvent(parent, old); err != nil {
+		t.Fatalf("seed old inbox: %v", err)
+	}
+
+	marker := filepath.Join(t.TempDir(), "append-fsync.marker")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestIssue2007_AppendCrashHelper$")
+	cmd.Env = append(os.Environ(), issue2007CrashHelperEnv+"=1", "AGENTDECK_TEST_2007_CRASH_MARKER="+marker)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start append helper: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			t.Fatal("helper never reached fsync-before-rename boundary")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL append helper: %v", err)
+	}
+	err := cmd.Wait()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("helper should die by SIGKILL, got %v", err)
+	}
+
+	ResetInboxFingerprintCacheForTest()
+	events, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("drain after crash: %v", err)
+	}
+	if len(events) != 1 || events[0].ChildSessionID != old.ChildSessionID {
+		t.Fatalf("SIGKILL before rename must leave complete old inbox, got %+v", events)
+	}
+
+	// The producer did not observe success, so its normal retry must install the
+	// new complete record without being poisoned by a partial tail/temp file.
+	if err := WriteInboxEvent(parent, TransitionNotificationEvent{
+		ChildSessionID: "new-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Unix(200, 0),
+	}); err != nil {
+		t.Fatalf("retry after crash: %v", err)
+	}
+	events, err = ReadAndTruncateInbox(parent)
+	if err != nil || len(events) != 1 || events[0].ChildSessionID != "new-child-2007" {
+		t.Fatalf("retry after crash did not produce one complete record: events=%+v err=%v", events, err)
+	}
+}

--- a/internal/session/issue2007_error_delivery_test.go
+++ b/internal/session/issue2007_error_delivery_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIssue2007_RunningToErrorDeliversToLinkedParent(t *testing.T) {
+	inboxTestHome(t)
+	profile := "_test-2007-linked-error"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storage.Close()
+	now := time.Now()
+	parent := &Instance{ID: "parent-2007", Title: "supervisor", ProjectPath: "/tmp/p", GroupPath: DefaultGroupPath, Tool: "shell", Status: StatusRunning, CreatedAt: now}
+	child := &Instance{ID: "child-2007", Title: "worker", ProjectPath: "/tmp/c", GroupPath: DefaultGroupPath, ParentSessionID: parent.ID, Tool: "shell", Status: StatusError, CreatedAt: now}
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got := NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
+		ChildSessionID: child.ID, ChildTitle: child.Title, Profile: profile,
+		FromStatus: "running", ToStatus: "error", Timestamp: now,
+	})
+	if got.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("running→error must commit to linked parent, got %+v", got)
+	}
+	events, err := DrainInboxForParent(parent.ID)
+	if err != nil || len(events) != 1 || events[0].ToStatus != "error" {
+		t.Fatalf("linked parent did not receive error transition: events=%+v err=%v", events, err)
+	}
+}
+
+func TestIssue2007_UnresolvableParentAlsoLandsInUnownedLedger(t *testing.T) {
+	inboxTestHome(t)
+	profile := "_test-2007-unowned"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storage.Close()
+	now := time.Now()
+	child := &Instance{ID: "child-unowned-2007", Title: "worker", ProjectPath: "/tmp/c", GroupPath: DefaultGroupPath, ParentSessionID: "missing-parent", Tool: "shell", Status: StatusError, CreatedAt: now}
+	if err := storage.SaveWithGroups([]*Instance{child}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
+		ChildSessionID: child.ID, ChildTitle: child.Title, Profile: profile,
+		FromStatus: "running", ToStatus: "error", Timestamp: now,
+	})
+	events, err := ReadAndTruncateInbox(UnownedInboxID)
+	if err != nil || len(events) != 1 || events[0].ChildSessionID != child.ID {
+		t.Fatalf("unresolvable transition was not preserved in _unowned: events=%+v err=%v", events, err)
+	}
+}

--- a/internal/session/issue2007_error_delivery_test.go
+++ b/internal/session/issue2007_error_delivery_test.go
@@ -47,12 +47,18 @@ func TestIssue2007_UnresolvableParentAlsoLandsInUnownedLedger(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
+	got := NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
 		ChildSessionID: child.ID, ChildTitle: child.Title, Profile: profile,
 		FromStatus: "running", ToStatus: "error", Timestamp: now,
 	})
+	if got.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("durable _unowned append must report committed, got %+v", got)
+	}
 	events, err := ReadAndTruncateInbox(UnownedInboxID)
 	if err != nil || len(events) != 1 || events[0].ChildSessionID != child.ID {
 		t.Fatalf("unresolvable transition was not preserved in _unowned: events=%+v err=%v", events, err)
+	}
+	if events[0].DeadLetterReason != deadLetterReasonParentMissing {
+		t.Fatalf("_unowned record lost resolution reason: got %q want %q", events[0].DeadLetterReason, deadLetterReasonParentMissing)
 	}
 }

--- a/internal/session/unowned_inbox.go
+++ b/internal/session/unowned_inbox.go
@@ -1,0 +1,44 @@
+package session
+
+import (
+	"strconv"
+	"strings"
+)
+
+// UnownedInboxID is the durable ledger for events with no resolvable parent on
+// this host. It uses the inbox store and therefore inherits fsync, dedup, and
+// TTL sweeping.
+const UnownedInboxID = "_unowned"
+
+func isUnownedReason(reason string) bool {
+	switch strings.TrimSpace(reason) {
+	case deadLetterReasonOrphan, deadLetterReasonParentMissing, deadLetterReasonUnresolvable:
+		return true
+	default:
+		return false
+	}
+}
+
+func recordUnownedTransition(event TransitionNotificationEvent) (bool, error) {
+	if strings.TrimSpace(event.ChildSessionID) == "" {
+		return false, nil
+	}
+	event.DoneSummary = capDoneSummary(event.DoneSummary)
+	event.TargetKind = "unowned"
+	event.DeliveryResult = transitionDeliveryCommitted
+	event.LastOutputHash = unownedTurnSignal(event)
+	if event.TurnFingerprint == "" {
+		event.TurnFingerprint = TurnFingerprint(event)
+	}
+	return WriteInboxEventIfNew(UnownedInboxID, event)
+}
+
+func unownedTurnSignal(event TransitionNotificationEvent) string {
+	if signal := strings.TrimSpace(event.LastOutputHash); signal != "" {
+		return signal
+	}
+	if event.Kind == transitionKindFinished || event.Timestamp.IsZero() {
+		return ""
+	}
+	return "emit:" + strconv.FormatInt(event.Timestamp.UTC().UnixNano(), 10)
+}

--- a/internal/session/unowned_inbox.go
+++ b/internal/session/unowned_inbox.go
@@ -12,7 +12,11 @@ const UnownedInboxID = "_unowned"
 
 func isUnownedReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
-	case deadLetterReasonOrphan, deadLetterReasonParentMissing, deadLetterReasonUnresolvable:
+	// Deliberately parentless children keep the #805 warn-once-drop contract:
+	// every top-level session is an "orphan", and persisting all their
+	// transitions would fill the unowned ledger with events nobody owns.
+	// Only a parent that WAS named but cannot be resolved goes unowned.
+	case deadLetterReasonParentMissing, deadLetterReasonUnresolvable:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Fixes #2007, and lands the two accepted asks from #1877.

**The defect** (measured in the field: 55/55 dead-lettered records over 3.5 weeks were `running->error`, while completions and `waiting` from the same children delivered): the error-path delivery resolved its target after session/pane teardown, so precisely the child-crashed signal — the one a supervisor most needs — never arrived, and was retried into a silent dead-letter.

**What changes:**
- `running->error` transitions deliver to the parent; when the parent is genuinely unresolvable the event persists to the unowned ledger with its honest resolution reason — never a silent dead-letter, and a successful persist is reported as a persist, not a drop.
- `inbox drain` reports a non-zero dead-letter/unowned count instead of `No pending events` over a non-empty ledger (#1877's silence bug), including over a corrupt ledger — unknown is not empty.
- A stale automatic-parent identity fails loudly at `add`/`launch` instead of manufacturing an undeliverable child (#1877's other ask). Valid spawns are unaffected (pinned by test).
- The inbox append is crash-safe: a SIGKILL mid-append cannot corrupt delivered state (regression test included).

**Verification:** reproduce-fix-reprove with a hard-killed child (before: dead-letter `unresolvable`; after: parent delivery, zero dead letters). Two-round independent adversarial review — round 1 found the persist-reported-as-drop and dead-letter-reported-clean defects, both data-loss-shaped, both fixed and revert-pinned; round 2 re-executed every probe and reports no open findings. Completions and waiting-transition delivery byte-identical before/after (no over-fix). All verification container-only against read-only mounts.

Related but out of scope: the duplication defect on #824 (same layer, opposite symptom) — this branch changes nothing there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable fallback handling for events whose parent session cannot be resolved.
  * `agent-deck add` and automatic parent linking now report unresolved parent identities instead of silently continuing.
  * Inbox draining now reports remaining dead-letter records and returns a non-zero status.

* **Bug Fixes**
  * Improved inbox safety against duplicate events, concurrent updates, and interrupted writes.
  * Corrupt or non-empty dead-letter files are no longer reported as clean.

* **Tests**
  * Added coverage for parent resolution, dead-letter reporting, fallback delivery, and crash-safe inbox updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->