### PR TITLE
fix(inbox): resolve drain targets without losing ambiguity — cross-profile full ids, honest exit codes, duplicate-id refusal

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -30,10 +30,23 @@ func (e *inboxTargetNotFoundError) Error() string {
 	return fmt.Sprintf("Error: inbox drain target %q could not be resolved. Nothing was drained; this is NOT an empty inbox.", e.identifier)
 }
 
+type inboxTargetAmbiguousError struct{ message string }
+
+func (e *inboxTargetAmbiguousError) Error() string {
+	return "Error: inbox drain target is ambiguous. Nothing was drained.\n" + e.message
+}
+
+// inboxExitCode is the #1991 drain-resolution contract: 2 means the target
+// does not exist, 3 means the supplied title/prefix is ambiguous, and 1 is a
+// storage, usage, or drain failure. Resolution failures never drain events.
 func inboxExitCode(err error) int {
 	var notFound *inboxTargetNotFoundError
 	if errors.As(err, &notFound) {
 		return 2
+	}
+	var ambiguous *inboxTargetAmbiguousError
+	if errors.As(err, &ambiguous) {
+		return 3
 	}
 	return 1
 }
@@ -88,6 +101,8 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 	fs.Usage = func() {
 		fmt.Fprintln(stdout, "Usage: agent-deck inbox drain [--json] [<session-id>|self]")
 		fmt.Fprintln(stdout, "With no id (or 'self'), drains the caller's own session.")
+		fmt.Fprintln(stdout, "Full session IDs resolve across all profiles; titles and shortened IDs")
+		fmt.Fprintln(stdout, "resolve only within the effective profile.")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		return err
@@ -120,12 +135,35 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 }
 
 func resolveInboxDrainSession(identifier string) (string, error) {
+	// A complete session ID is globally unique. Check exact IDs in every
+	// profile before applying the profile-local flexible resolver. Titles and
+	// shortened ID prefixes intentionally remain scoped to the effective
+	// profile, avoiding cross-profile ambiguity for ordinary shorthand.
+	profiles, err := session.ListProfiles()
+	if err != nil {
+		return "", fmt.Errorf("list profiles: %w", err)
+	}
+	for _, profile := range profiles {
+		_, profileInstances, _, loadErr := loadSessionData(profile)
+		if loadErr != nil {
+			return "", fmt.Errorf("load profile %q: %w", profile, loadErr)
+		}
+		for _, inst := range profileInstances {
+			if inst.ID == identifier {
+				return inst.ID, nil
+			}
+		}
+	}
+
 	_, instances, _, err := loadSessionData("")
 	if err != nil {
 		return "", err
 	}
-	inst, _, _ := ResolveSession(identifier, instances)
+	inst, errMsg, errCode := ResolveSession(identifier, instances)
 	if inst == nil {
+		if errCode == ErrCodeAmbiguous {
+			return "", &inboxTargetAmbiguousError{message: errMsg}
+		}
 		return "", &inboxTargetNotFoundError{identifier: identifier}
 	}
 	return inst.ID, nil

--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -17,8 +17,8 @@ import (
 // completions to (issue #1225). The bare form is the legacy raw read+truncate
 // (at-most-once); the `drain` subcommand is the durable consumer path. See
 // internal/session/inbox.go.
-func handleInbox(args []string) {
-	if err := runInbox(os.Stdout, args); err != nil {
+func handleInbox(profile string, args []string) {
+	if err := runInboxWithProfile(os.Stdout, args, profile); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(inboxExitCode(err))
 	}
@@ -62,8 +62,12 @@ func inboxExitCode(err error) int {
 //	                                       re-delivery via turn_fingerprint. This
 //	                                       is the conductor's heartbeat step.
 func runInbox(stdout io.Writer, args []string) error {
+	return runInboxWithProfile(stdout, args, "")
+}
+
+func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string) error {
 	if len(args) > 0 && args[0] == "drain" {
-		return runInboxDrain(stdout, args[1:])
+		return runInboxDrain(stdout, args[1:], explicitProfile)
 	}
 
 	fs := flag.NewFlagSet("inbox", flag.ContinueOnError)
@@ -95,7 +99,7 @@ func runInbox(stdout io.Writer, args []string) error {
 
 // runInboxDrain is the issue #1225 consumer path: exactly-once-per-turn,
 // last-wins-per-child. Used by the conductor heartbeat and any machine consumer.
-func runInboxDrain(stdout io.Writer, args []string) error {
+func runInboxDrain(stdout io.Writer, args []string, explicitProfile string) error {
 	fs := flag.NewFlagSet("inbox drain", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the drained events as a JSON array")
 	fs.Usage = func() {
@@ -103,6 +107,7 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 		fmt.Fprintln(stdout, "With no id (or 'self'), drains the caller's own session.")
 		fmt.Fprintln(stdout, "Full session IDs resolve across all profiles; titles and shortened IDs")
 		fmt.Fprintln(stdout, "resolve only within the effective profile.")
+		fmt.Fprintln(stdout, "If a full ID exists in multiple profiles, qualify it with global -p/--profile.")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		return err
@@ -112,7 +117,7 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 		fs.Usage()
 		return err
 	}
-	sessionID, err = resolveInboxDrainSession(sessionID)
+	sessionID, err = resolveInboxDrainSessionInProfile(sessionID, explicitProfile)
 	if err != nil {
 		return err
 	}
@@ -135,14 +140,25 @@ func runInboxDrain(stdout io.Writer, args []string) error {
 }
 
 func resolveInboxDrainSession(identifier string) (string, error) {
-	// A complete session ID is globally unique. Check exact IDs in every
-	// profile before applying the profile-local flexible resolver. Titles and
-	// shortened ID prefixes intentionally remain scoped to the effective
-	// profile, avoiding cross-profile ambiguity for ordinary shorthand.
+	return resolveInboxDrainSessionInProfile(identifier, "")
+}
+
+func resolveInboxDrainSessionInProfile(identifier, explicitProfile string) (string, error) {
+	// An explicit global -p/--profile qualifier is authoritative, including
+	// when corrupt/restored registries contain the same full ID elsewhere.
+	if explicitProfile != "" {
+		return resolveInboxDrainSessionLocally(identifier, explicitProfile)
+	}
+
+	// Check exact IDs in every profile before applying the profile-local
+	// flexible resolver. Do not assume registry uniqueness: draining is
+	// destructive, so duplicate full IDs must fail closed and name every
+	// profile that must be disambiguated.
 	profiles, err := session.ListProfiles()
 	if err != nil {
 		return "", fmt.Errorf("list profiles: %w", err)
 	}
+	var exactProfiles []string
 	for _, profile := range profiles {
 		_, profileInstances, _, loadErr := loadSessionData(profile)
 		if loadErr != nil {
@@ -150,12 +166,25 @@ func resolveInboxDrainSession(identifier string) (string, error) {
 		}
 		for _, inst := range profileInstances {
 			if inst.ID == identifier {
-				return inst.ID, nil
+				exactProfiles = append(exactProfiles, profile)
+				break
 			}
 		}
 	}
+	if len(exactProfiles) == 1 {
+		return identifier, nil
+	}
+	if len(exactProfiles) > 1 {
+		return "", &inboxTargetAmbiguousError{message: fmt.Sprintf(
+			"Full session ID %q exists in profiles %s. Use -p/--profile to choose one.",
+			identifier, strings.Join(exactProfiles, ", "))}
+	}
 
-	_, instances, _, err := loadSessionData("")
+	return resolveInboxDrainSessionLocally(identifier, "")
+}
+
+func resolveInboxDrainSessionLocally(identifier, profile string) (string, error) {
+	_, instances, _, err := loadSessionData(profile)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agent-deck/inbox_drain_resolution_followup_test.go
+++ b/cmd/agent-deck/inbox_drain_resolution_followup_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func saveInboxResolutionSessions(t *testing.T, profile string, instances ...*session.Instance) {
+	t.Helper()
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage %q: %v", profile, err)
+	}
+	if err := storage.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, nil)); err != nil {
+		t.Fatalf("save profile %q: %v", profile, err)
+	}
+}
+
+func TestInboxDrain_FullIDResolvesAcrossProfiles(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	target := session.NewInstance("cross-profile-target", t.TempDir())
+	saveInboxResolutionSessions(t, "personal", target)
+	saveInboxResolutionSessions(t, "work")
+
+	if err := session.CommitToInbox(target.ID, session.TransitionNotificationEvent{ChildSessionID: "cross-profile-child"}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	var stdout bytes.Buffer
+	if err := runInbox(&stdout, []string{"drain", target.ID}); err != nil {
+		t.Fatalf("cross-profile full-id drain: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "cross-profile-child") {
+		t.Fatalf("event was not drained: %q", stdout.String())
+	}
+}
+
+func TestInboxDrain_AmbiguousPrefixPreservesDisambiguationAndExitCode(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	a := session.NewInstance("alpha", t.TempDir())
+	b := session.NewInstance("beta", t.TempDir())
+	a.ID = "abcdef01-1777000200"
+	b.ID = "abcdef02-1777000201"
+	saveInboxResolutionSessions(t, "work", a, b)
+
+	var stdout bytes.Buffer
+	err := runInbox(&stdout, []string{"drain", "abcdef"})
+	if err == nil {
+		t.Fatal("ambiguous prefix returned success")
+	}
+	if got := inboxExitCode(err); got != 3 {
+		t.Fatalf("exit code = %d, want 3 (ambiguous)", got)
+	}
+	for _, want := range []string{"matches multiple sessions", "alpha", "beta", "Use full ID"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("ambiguity error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestInboxDrain_ShortPrefixStaysEffectiveProfileScoped(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	local := session.NewInstance("local", t.TempDir())
+	remote := session.NewInstance("remote", t.TempDir())
+	local.ID = "abcdef01-1777000200"
+	remote.ID = "abcdef02-1777000201"
+	saveInboxResolutionSessions(t, "work", local)
+	saveInboxResolutionSessions(t, "personal", remote)
+
+	got, err := resolveInboxDrainSession("abcdef")
+	if err != nil {
+		t.Fatalf("profile-local prefix: %v", err)
+	}
+	if got != local.ID {
+		t.Fatalf("resolved %q, want effective-profile session %q", got, local.ID)
+	}
+}

--- a/cmd/agent-deck/inbox_drain_resolution_followup_test.go
+++ b/cmd/agent-deck/inbox_drain_resolution_followup_test.go
@@ -83,3 +83,71 @@ func TestInboxDrain_ShortPrefixStaysEffectiveProfileScoped(t *testing.T) {
 		t.Fatalf("resolved %q, want effective-profile session %q", got, local.ID)
 	}
 }
+
+func TestInboxDrain_DuplicateFullIDAcrossProfilesRequiresQualifier(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	const duplicate = "deadbeef-1777000200"
+	a := session.NewInstance("alpha", t.TempDir())
+	b := session.NewInstance("beta", t.TempDir())
+	a.ID = duplicate
+	b.ID = duplicate
+	saveInboxResolutionSessions(t, "aaa", a)
+	saveInboxResolutionSessions(t, "bbb", b)
+	saveInboxResolutionSessions(t, "work")
+
+	if err := session.CommitToInbox(duplicate, session.TransitionNotificationEvent{ChildSessionID: "must-survive"}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	var stdout bytes.Buffer
+	err := runInbox(&stdout, []string{"drain", duplicate})
+	if err == nil {
+		t.Fatalf("duplicate full ID silently succeeded and drained shared inbox: %q", stdout.String())
+	}
+	if got := inboxExitCode(err); got != 3 {
+		t.Fatalf("exit code = %d, want 3 (ambiguous): %v", got, err)
+	}
+	for _, want := range []string{"aaa", "bbb", "-p/--profile", "Nothing was drained"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("ambiguity error %q missing %q", err, want)
+		}
+	}
+	if !session.InboxHasPending(duplicate) {
+		t.Fatal("ambiguous duplicate-ID resolution destructively drained the inbox")
+	}
+
+	stdout.Reset()
+	if err := runInboxWithProfile(&stdout, []string{"drain", duplicate}, "bbb"); err != nil {
+		t.Fatalf("qualified duplicate-ID drain: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "must-survive") {
+		t.Fatalf("qualified drain did not return preserved event: %q", stdout.String())
+	}
+}
+
+// Mutation pin: changing the global exact-ID comparison in
+// resolveInboxDrainSessionInProfile from == to strings.HasPrefix makes the two
+// remote records capture this shorthand and this test fail with ambiguity.
+func TestInboxDrain_ShortPrefixRejectsGlobalPrefixMutation(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	local := session.NewInstance("local", t.TempDir())
+	remoteA := session.NewInstance("remote-a", t.TempDir())
+	remoteB := session.NewInstance("remote-b", t.TempDir())
+	local.ID = "abcdef01-1777000200"
+	remoteA.ID = "abcdef02-1777000201"
+	remoteB.ID = "abcdef03-1777000202"
+	saveInboxResolutionSessions(t, "work", local)
+	saveInboxResolutionSessions(t, "aaa", remoteA)
+	saveInboxResolutionSessions(t, "bbb", remoteB)
+
+	got, err := resolveInboxDrainSession("abcdef")
+	if err != nil {
+		t.Fatalf("effective-profile prefix: %v", err)
+	}
+	if got != local.ID {
+		t.Fatalf("resolved %q, want effective-profile session %q", got, local.ID)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -397,7 +397,7 @@ func main() {
 			handleRunTask(args[1:])
 			return
 		case "inbox":
-			handleInbox(args[1:])
+			handleInbox(profile, args[1:])
 			return
 		case "feedback":
 			handleFeedback(args[1:])


### PR DESCRIPTION
Follow-up to the merged #2022, fixing two verified defects on its resolution path and one found in review:

- **Cross-profile false-missing:** `inbox drain <full-id>` under a different effective profile reported a valid target missing (exit 2) and left its events undrained. Full ids now resolve across all profiles; short prefixes and titles stay effective-profile-scoped by documented rule.
- **Ambiguity surfaced, not collapsed:** an ambiguous identifier previously discarded `ResolveSession`'s AMBIGUOUS error and reported not-found. It now surfaces the disambiguation text with its own exit code, extending the #1991 contract coherently.
- **Duplicate-id refusal (found by adversarial review, security-shaped):** the same full id existing in two profiles — registry corruption or restore artifacts — silently authorized a destructive drain of whichever profile resolution picked. It now refuses with the ambiguity exit code naming both profiles; drain proceeds only with an explicit profile qualifier, and the qualifier path is pinned to drain the named profile.

Every guard is mutation-pinned (reverting any one fails a named test). Two-round independent adversarial review; round 1's security finding is the third bullet. Verification container-only with real CLI reproofs.