### PR TITLE
fix(ui): keep session dialogs usable in small terminals (100x30)

### DIFF
--- a/internal/ui/gemini_model_dialog.go
+++ b/internal/ui/gemini_model_dialog.go
@@ -33,6 +33,23 @@ type GeminiModelDialog struct {
 	current    string // Currently active model
 }
 
+// geminiModelVisibleRows is the list viewport after reserving the dialog's
+// title, separator, status/scroll indicators, primary action, border and
+// padding. Keeping this math separate makes the 100x30 contract testable.
+func geminiModelVisibleRows(height int) int {
+	if height <= 0 {
+		return 15
+	}
+	rows := height - 12
+	if rows < 3 {
+		rows = 3
+	}
+	if rows > 15 {
+		rows = 15
+	}
+	return rows
+}
+
 // NewGeminiModelDialog creates a new model selection dialog
 func NewGeminiModelDialog() *GeminiModelDialog {
 	return &GeminiModelDialog{}
@@ -173,13 +190,7 @@ func (d *GeminiModelDialog) View() string {
 	}
 
 	// Model list
-	maxVisible := 15
-	if d.height > 0 {
-		maxVisible = d.height/2 - 6
-		if maxVisible < 5 {
-			maxVisible = 5
-		}
-	}
+	maxVisible := geminiModelVisibleRows(d.height)
 
 	// Calculate scroll window
 	start := 0
@@ -213,9 +224,13 @@ func (d *GeminiModelDialog) View() string {
 		content.WriteString("\n")
 	}
 
-	if len(d.models) > maxVisible {
+	if start > 0 {
+		content.WriteString(dimStyle.Render("  ↑ more models"))
 		content.WriteString("\n")
-		content.WriteString(dimStyle.Render("  " + strings.Repeat(".", 3) + " scroll for more"))
+	}
+	if end < len(d.models) {
+		content.WriteString("\n")
+		content.WriteString(dimStyle.Render("  ↓ more models"))
 		content.WriteString("\n")
 	}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -15680,7 +15680,7 @@ func (h *Home) renderHelpBarWidthAdaptive() string {
 	switch {
 	case h.width < 70:
 		return h.renderHelpBarMinimal()
-	case h.width < 100:
+	case h.width <= 100:
 		return h.renderHelpBarCompact()
 	default:
 		return h.renderHelpBarFull()
@@ -15871,6 +15871,13 @@ func (h *Home) renderHelpBarCompact() string {
 			if key := h.actionKey(hotkeyRestart); key != "" {
 				contextHints = append(contextHints, h.helpKeyShort(key, "Restart"))
 			}
+			// Skills is a primary selected-session action. Keep it ahead of the
+			// rarer optional actions so the width fitter retains it at 100 cols.
+			if item.Session != nil && session.SupportsProjectSkills(item.Session.Tool) {
+				if key := h.actionKey(hotkeySkillsManager); key != "" {
+					contextHints = append(contextHints, h.helpKeyShort(key, "Skills"))
+				}
+			}
 			if item.Session != nil && item.Session.CanRestartFresh() && restartFreshKey != "" {
 				contextHints = append(contextHints, h.helpKeyShort(restartFreshKey, "Fresh"))
 			}
@@ -15885,11 +15892,6 @@ func (h *Home) renderHelpBarCompact() string {
 				}
 				if key := h.actionKey(hotkeyTogglePreview); key != "" {
 					contextHints = append(contextHints, h.helpKeyShort(key, h.previewModeShort()))
-				}
-			}
-			if item.Session != nil && session.SupportsProjectSkills(item.Session.Tool) {
-				if key := h.actionKey(hotkeySkillsManager); key != "" {
-					contextHints = append(contextHints, h.helpKeyShort(key, "Skills"))
 				}
 			}
 			if key := h.actionKey(hotkeyCopyOutput); key != "" {
@@ -15945,12 +15947,13 @@ func (h *Home) renderHelpBarCompact() string {
 
 	leftPart := strings.Join(contextHints, " ")
 	rightPart := globalHints
-	padding := h.width - lipgloss.Width(leftPart) - lipgloss.Width(rightPart) - 4
-	if padding < 2 {
-		// Content too wide for one line — drop right part to avoid overflow
-		padding = 2
-		rightPart = ""
+	// Drop lowest-priority context hints as whole units. MaxWidth alone can
+	// truncate a label (notably "Skills") halfway through at exactly 100 cols.
+	for len(contextHints) > 0 && lipgloss.Width(leftPart)+lipgloss.Width(rightPart)+6 > h.width {
+		contextHints = contextHints[:len(contextHints)-1]
+		leftPart = strings.Join(contextHints, " ")
 	}
+	padding := max(2, h.width-lipgloss.Width(leftPart)-lipgloss.Width(rightPart)-4)
 
 	content := leftPart + sep + strings.Repeat(" ", padding) + rightPart
 

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -244,10 +244,21 @@ func viewportDialogContent(content string, width, height int) string {
 		return strings.Join(lines, "\n")
 	}
 
-	// The title/group pair and the final action/help line are stable chrome.
-	headerEnd := min(2, len(lines)-1)
-	footer := lines[len(lines)-1]
-	bodyStart, bodyEnd := headerEnd, len(lines)-1
+	// The title/group pair and the final logical action/help line are stable
+	// chrome. The footer can occupy multiple visual rows after wrapping, and all
+	// of them must remain pinned so the primary action cannot scroll away.
+	logicalLines := strings.Split(content, "\n")
+	for len(logicalLines) > 0 && strings.TrimSpace(stripAnsi(logicalLines[len(logicalLines)-1])) == "" {
+		logicalLines = logicalLines[:len(logicalLines)-1]
+	}
+	footerHeight := 1
+	if len(logicalLines) > 0 {
+		footerHeight = lipgloss.Height(lipgloss.NewStyle().Width(width).Render(logicalLines[len(logicalLines)-1]))
+	}
+	footerHeight = min(footerHeight, len(lines)-1)
+	headerEnd := min(2, len(lines)-footerHeight)
+	bodyStart, bodyEnd := headerEnd, len(lines)-footerHeight
+	footer := lines[bodyEnd:]
 	focus := bodyStart
 	for i := bodyStart; i < bodyEnd; i++ {
 		if strings.Contains(stripAnsi(lines[i]), "▶") {
@@ -258,7 +269,7 @@ func viewportDialogContent(content string, width, height int) string {
 
 	// Reserve both indicator rows initially. Unused indicators are returned to
 	// the body below, maximizing useful content near either edge.
-	budget := max(1, height-headerEnd-1-2)
+	budget := max(1, height-headerEnd-footerHeight-2)
 	start := focus - budget/2
 	if start < bodyStart {
 		start = bodyStart
@@ -269,7 +280,7 @@ func viewportDialogContent(content string, width, height int) string {
 		start = max(bodyStart, end-budget)
 	}
 	showUp, showDown := start > bodyStart, end < bodyEnd
-	used := headerEnd + (end - start) + 1
+	used := headerEnd + (end - start) + footerHeight
 	if showUp {
 		used++
 	}
@@ -296,7 +307,7 @@ func viewportDialogContent(content string, width, height int) string {
 	if showDown {
 		visible = append(visible, dim.Render("  ↓ more fields"))
 	}
-	visible = append(visible, footer)
+	visible = append(visible, footer...)
 	return strings.Join(visible, "\n")
 }
 

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -224,6 +224,82 @@ type NewDialog struct {
 	enterAdvances bool
 }
 
+// viewportDialogContent keeps the dialog's identity and primary action pinned
+// while scrolling the form body around the focused control.  Lip Gloss Place
+// does not clip oversized content, so without this an ordinary 100x30 terminal
+// loses both ends of the form (#896).
+func viewportDialogContent(content string, width, height int) string {
+	if width < 1 || height < 1 {
+		return content
+	}
+	wrapped := lipgloss.NewStyle().Width(width).Render(content)
+	lines := strings.Split(wrapped, "\n")
+	for len(lines) > 0 && strings.TrimSpace(stripAnsi(lines[len(lines)-1])) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) <= height {
+		return content
+	}
+	if len(lines) < 4 {
+		return strings.Join(lines, "\n")
+	}
+
+	// The title/group pair and the final action/help line are stable chrome.
+	headerEnd := min(2, len(lines)-1)
+	footer := lines[len(lines)-1]
+	bodyStart, bodyEnd := headerEnd, len(lines)-1
+	focus := bodyStart
+	for i := bodyStart; i < bodyEnd; i++ {
+		if strings.Contains(stripAnsi(lines[i]), "▶") {
+			focus = i
+			break
+		}
+	}
+
+	// Reserve both indicator rows initially. Unused indicators are returned to
+	// the body below, maximizing useful content near either edge.
+	budget := max(1, height-headerEnd-1-2)
+	start := focus - budget/2
+	if start < bodyStart {
+		start = bodyStart
+	}
+	end := start + budget
+	if end > bodyEnd {
+		end = bodyEnd
+		start = max(bodyStart, end-budget)
+	}
+	showUp, showDown := start > bodyStart, end < bodyEnd
+	used := headerEnd + (end - start) + 1
+	if showUp {
+		used++
+	}
+	if showDown {
+		used++
+	}
+	for used < height && start > bodyStart {
+		start--
+		used++
+		showUp = start > bodyStart
+	}
+	for used < height && end < bodyEnd {
+		end++
+		used++
+		showDown = end < bodyEnd
+	}
+
+	dim := lipgloss.NewStyle().Foreground(ColorComment)
+	visible := append([]string(nil), lines[:headerEnd]...)
+	if showUp {
+		visible = append(visible, dim.Render("  ↑ more fields"))
+	}
+	visible = append(visible, lines[start:end]...)
+	if showDown {
+		visible = append(visible, dim.Render("  ↓ more fields"))
+	}
+	visible = append(visible, footer)
+	return strings.Join(visible, "\n")
+}
+
 // dialogSnapshot captures form state so the recent picker can restore on cancel.
 type dialogSnapshot struct {
 	name             string
@@ -2914,9 +2990,9 @@ func (d *NewDialog) View() string {
 		}
 	} else if cur == focusModel {
 		if d.modelSuggestionActive {
-			helpText = "↑/↓ navigate │ Space/Enter select │ Esc back │ Tab next"
+			helpText = "↑/↓ navigate │ Space/Enter select │ Esc back │ ^S create"
 		} else {
-			helpText = "Type custom model ID │ Enter browse known IDs │ Tab next"
+			helpText = "Type custom model ID │ Enter browse IDs │ Tab next │ ^S create"
 		}
 	} else if cur == focusReasoningEffort {
 		helpText = "←→/Space choose effort │ Tab next │ Enter/^S create │ Esc cancel"
@@ -2931,8 +3007,30 @@ func (d *NewDialog) View() string {
 	}
 	content.WriteString(helpStyle.Render(helpText))
 
+	// Border plus Padding(2, 4) consume six terminal rows. At constrained
+	// heights, viewport only the form body; wide/tall dialogs remain byte-for-
+	// byte on the original rendering path.
+	innerWidth := max(1, dialogWidth-8)
+	maxContentHeight := d.height - 6
+	fullContent := content.String()
+	viewported := viewportDialogContent(fullContent, innerWidth, maxContentHeight)
+
+	// Dropdown anchors are based on visual lines. Recompute them after the
+	// viewport has wrapped/scrolled so a picker follows its focused input.
+	if viewported != fullContent {
+		for i, line := range strings.Split(viewported, "\n") {
+			plain := stripAnsi(line)
+			if strings.Contains(plain, "▶ Model ID:") {
+				d.modelLineOffset = i + 3 // title margin + label + input
+			}
+			if strings.Contains(plain, "▶ Path:") {
+				d.suggestionsLineOffset = i + 3 // title margin + label + input
+			}
+		}
+	}
+
 	// Wrap in dialog box
-	dialog := dialogStyle.Render(content.String())
+	dialog := dialogStyle.Render(viewported)
 
 	// Center the dialog
 	placed := lipgloss.Place(
@@ -3018,6 +3116,9 @@ func (d *NewDialog) renderSuggestionsDropdown() string {
 
 	// Real suggestions below, with paginated scrolling around the selected one.
 	maxShow := 5
+	if d.height > 0 && d.height <= 30 {
+		maxShow = 3
+	}
 	total := len(d.pathSuggestions)
 	if total > 0 {
 		// Cursor 1..N maps to suggestions 0..N-1; -1 means "Type custom" is selected.
@@ -3116,6 +3217,11 @@ func (d *NewDialog) renderModelSuggestionsDropdown() string {
 	b.WriteString(style.Render(prefix + label))
 
 	maxShow := 6
+	if d.height > 0 && d.height <= 30 {
+		// Leave room for both the dropdown footer and the dialog's pinned
+		// create action; a six-row menu overwrote that action at 100x30.
+		maxShow = 3
+	}
 	total := len(d.modelSuggestions)
 	if total > 0 {
 		suggCursor := d.modelSuggestionCursor - 1

--- a/internal/ui/viewport_100x30_test.go
+++ b/internal/ui/viewport_100x30_test.go
@@ -1,0 +1,129 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestViewportDialogContentPinsChromeAndFocusedField(t *testing.T) {
+	var body strings.Builder
+	body.WriteString("New Session\n  in group: default\n")
+	for i := 0; i < 32; i++ {
+		prefix := "  "
+		if i == 21 {
+			prefix = "▶ "
+		}
+		fmt.Fprintf(&body, "%sfield %02d\n", prefix, i)
+	}
+	body.WriteString("Tab next │ Enter create │ Esc cancel")
+
+	got := viewportDialogContent(body.String(), 76, 24)
+	plain := stripAnsi(got)
+	for _, pin := range []string{"New Session", "▶ field 21", "Enter create", "↑ more fields"} {
+		if !strings.Contains(plain, pin) {
+			t.Fatalf("viewport lost pinned %q:\n%s", pin, plain)
+		}
+	}
+	if height := lipgloss.Height(got); height > 24 {
+		t.Fatalf("content height = %d, want <= 24 (30 rows minus dialog chrome)", height)
+	}
+}
+
+func TestViewportDialogContentDoesNotChangeTallLayout(t *testing.T) {
+	const content = "New Session\n  in group: default\n\n▶ Name:\n  demo\n\nEnter create"
+	if got := viewportDialogContent(content, 76, 42); got != content {
+		t.Fatalf("160x48 content changed:\n got %q\nwant %q", got, content)
+	}
+}
+
+func TestNewDialogFits100x30AtModelFocus(t *testing.T) {
+	d := NewNewDialog()
+	d.SetDefaultTool("codex")
+	d.SetSize(100, 30)
+	d.Show()
+	d.focusIndex = d.indexOf(focusModel)
+	d.updateFocus()
+
+	view := d.View()
+	plain := stripAnsi(view)
+	for _, pin := range []string{"New Session", "▶ Model ID:", "select", "create"} {
+		if !strings.Contains(plain, pin) {
+			t.Fatalf("100x30 model view lost %q:\n%s", pin, plain)
+		}
+	}
+	if got := lipgloss.Height(view); got > 30 {
+		t.Fatalf("100x30 dialog rendered %d rows", got)
+	}
+}
+
+func TestNewDialogWideLayoutRetainsAllFields(t *testing.T) {
+	d := NewNewDialog()
+	d.SetDefaultTool("codex")
+	d.SetSize(160, 48)
+	d.Show()
+	plain := stripAnsi(d.View())
+	for _, field := range []string{"New Session", "Name:", "Command:", "Model ID:", "Path:", "Create in worktree", "Run in Docker sandbox", "Multi-repo mode", "create"} {
+		if !strings.Contains(plain, field) {
+			t.Fatalf("160x48 layout lost %q:\n%s", field, plain)
+		}
+	}
+}
+
+func TestGeminiModelVisibleRowsMutationPins(t *testing.T) {
+	if got := geminiModelVisibleRows(30); got != 15 {
+		t.Fatalf("100x30 visible rows = %d, want 15", got)
+	}
+	if got := geminiModelVisibleRows(48); got != 15 {
+		t.Fatalf("160x48 visible rows = %d, want 15", got)
+	}
+	if got := geminiModelVisibleRows(14); got != 3 {
+		t.Fatalf("minimum visible rows = %d, want 3", got)
+	}
+}
+
+func TestGeminiModelPickerFits100x30AndPinsSelection(t *testing.T) {
+	d := NewGeminiModelDialog()
+	d.visible = true
+	d.SetSize(100, 30)
+	for i := 0; i < 24; i++ {
+		d.models = append(d.models, fmt.Sprintf("gemini-model-%02d", i))
+	}
+	d.cursor = 20
+
+	view := d.View()
+	plain := stripAnsi(view)
+	for _, pin := range []string{"Select Gemini Model", "gemini-model-20", "Enter Select", "↑ more models", "↓ more models"} {
+		if !strings.Contains(plain, pin) {
+			t.Fatalf("100x30 picker lost %q:\n%s", pin, plain)
+		}
+	}
+	if got := lipgloss.Height(view); got > 30 {
+		t.Fatalf("100x30 picker rendered %d rows", got)
+	}
+}
+
+func TestFullFooterUsesCompactReadableTierAt100Columns(t *testing.T) {
+	h := NewHome()
+	t.Cleanup(func() { h.cancel() })
+	h.width = 100
+	h.flatItems = []session.Item{{
+		Type:    session.ItemTypeSession,
+		Session: &session.Instance{ID: "skills-footer", Tool: "claude", Title: "Skills footer"},
+	}}
+	h.cursor = 0
+
+	footer := h.renderHelpBarWidthAdaptive()
+	plain := stripAnsi(footer)
+	if !strings.Contains(plain, "Skills") {
+		t.Fatalf("100-column selected-session footer lost Skills:\n%s", plain)
+	}
+	for _, line := range strings.Split(footer, "\n") {
+		if got := lipgloss.Width(line); got > 100 {
+			t.Fatalf("footer line width = %d, want <= 100", got)
+		}
+	}
+}

--- a/internal/ui/viewport_100x30_test.go
+++ b/internal/ui/viewport_100x30_test.go
@@ -33,6 +33,30 @@ func TestViewportDialogContentPinsChromeAndFocusedField(t *testing.T) {
 	}
 }
 
+func TestViewportDialogContentPinsEntireWrappedFooter(t *testing.T) {
+	var body strings.Builder
+	body.WriteString("New Session\n  in group: default\n")
+	for i := 0; i < 32; i++ {
+		prefix := "  "
+		if i == 21 {
+			prefix = "▶ "
+		}
+		fmt.Fprintf(&body, "%sfield %02d\n", prefix, i)
+	}
+	body.WriteString("Tab next │ Shift+Tab previous │ ^S create │ Esc cancel")
+
+	got := viewportDialogContent(body.String(), 40, 24)
+	plain := stripAnsi(got)
+	for _, pin := range []string{"New Session", "▶ field 21", "^S", "create", "Esc cancel"} {
+		if !strings.Contains(plain, pin) {
+			t.Fatalf("viewport lost pinned %q from wrapped footer:\n%s", pin, plain)
+		}
+	}
+	if height := lipgloss.Height(got); height > 24 {
+		t.Fatalf("content height = %d, want <= 24", height)
+	}
+}
+
 func TestViewportDialogContentDoesNotChangeTallLayout(t *testing.T) {
 	const content = "New Session\n  in group: default\n\n▶ Name:\n  demo\n\nEnter create"
 	if got := viewportDialogContent(content, 76, 42); got != content {
@@ -117,6 +141,14 @@ func TestFullFooterUsesCompactReadableTierAt100Columns(t *testing.T) {
 	h.cursor = 0
 
 	footer := h.renderHelpBarWidthAdaptive()
+	compact := h.renderHelpBarCompact()
+	full := h.renderHelpBarFull()
+	if footer != compact {
+		t.Fatalf("100-column footer did not use compact tier:\n%s", stripAnsi(footer))
+	}
+	if footer == full {
+		t.Fatal("test fixture does not distinguish compact and full footer tiers")
+	}
 	plain := stripAnsi(footer)
 	if !strings.Contains(plain, "Skills") {
 		t.Fatalf("100-column selected-session footer lost Skills:\n%s", plain)


### PR DESCRIPTION
From the TUI gauntlet's blocker list (2-judge agreement, corroborated by #896): the New Session dialog and model picker clipped their title, earlier fields, and primary action at 100x30. Dialogs now reflow/scroll so the title, the focused field, and the Create/select action stay visible at 100x30 with no 160x48 regression (byte-compared), and the selected-session footer stays readable at 100 columns.

Two-round adversarial review: round 1 caught an unpinned 100-column boundary guard (now mutation-pinned); round 2 re-ran the probe set (many-field tabbing both directions, 80x24 degradation, SIGWINCH mid-dialog, unicode-wide input, 160x48 byte-compare) and verified via the repaired gauntlet harness that the targeted station rows are resolved, with remaining station rejects demonstrably pre-existing.