### PR TITLE
feat(agents): phase 1 — adopt existing agent setups and render them read-only

### DIFF
--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -345,7 +345,9 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 	fmt.Printf("  ·  %s\n", agents.SanitizeForDisplay(row.Machine))
 	fmt.Printf("post: %s  ·  reports to: %s  ·  state: %s\n",
 		agents.SanitizeForDisplay(row.PostID), agents.SanitizeForDisplay(row.ReportsTo), row.State)
-	if row.ReportsToIssue != "" {
+	// Attention now folds the escalation finding in, so guard against printing
+	// the same sentence twice — the same guard printAgentsView already has.
+	if row.ReportsToIssue != "" && !strings.Contains(row.Attention, row.ReportsToIssue) {
 		fmt.Printf("!  %s\n", agents.SanitizeForDisplay(row.ReportsToIssue))
 	}
 

--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -110,7 +109,6 @@ func printAgentUsage() {
 func handleAgentAdopt(profile string, args []string) {
 	fs := flag.NewFlagSet("agent adopt", flag.ExitOnError)
 	write := fs.Bool("write", false, "Write the generated definitions (default: dry run)")
-	output := fs.String("output", "", "Write definitions under this directory instead of the agents registry")
 	jsonOutput := fs.Bool("json", false, "Output the plan as JSON")
 	manager := fs.String("manager", "", "Post name that non-manager roles report to")
 	fs.Usage = func() {
@@ -175,13 +173,10 @@ func handleAgentAdopt(profile string, args []string) {
 		}
 	}
 
-	root := *output
-	if root == "" {
-		root, err = agents.Dir()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
+	root, err := agents.Dir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: create registry: %v\n", err)
@@ -542,7 +537,7 @@ func localMachineName() string {
 // authoritative for what a runtime is doing.
 func loadSessionStates(profile string) map[string]agents.SessionState {
 	states := map[string]agents.SessionState{}
-	storage, err := session.NewStorageWithProfile(profile)
+	storage, err := session.NewReadOnlyStorageWithProfile(profile)
 	if err != nil {
 		return states
 	}
@@ -561,7 +556,7 @@ func loadSessionStates(profile string) map[string]agents.SessionState {
 // loadAdoptSessions converts the local fleet into the shape the adoption
 // resolvers accept.
 func loadAdoptSessions(profile string) []agents.SessionInfo {
-	storage, err := session.NewStorageWithProfile(profile)
+	storage, err := session.NewReadOnlyStorageWithProfile(profile)
 	if err != nil {
 		return nil
 	}
@@ -646,7 +641,7 @@ func ledgerLookup() func(string) []agents.LedgerEntry {
 		}
 
 		// What its children reported to it.
-		if events, err := session.PeekInboxEvents(sessionID); err == nil {
+		if events, err := session.ReadInboxEventsForDisplay(sessionID); err == nil {
 			for _, event := range events {
 				title := event.ChildTitle
 				if title == "" {
@@ -665,11 +660,9 @@ func ledgerLookup() func(string) []agents.LedgerEntry {
 	}
 }
 
-// fetchRemoteAgents asks each configured remote for its agents.
-//
-// Link honesty is the point: a remote that does not answer is reported
-// UNCONFIRMED with the reason, never omitted (which would understate the
-// fleet) and never rendered as if its rows were current.
+// fetchRemoteAgents reports configured remotes from cached observations only.
+// Phase 1 has no refresh action, so a cache miss is explicit and this default
+// list path never starts a process or transport.
 func fetchRemoteAgents(skip bool) []agents.RemoteMachineData {
 	if skip {
 		return nil
@@ -685,40 +678,12 @@ func fetchRemoteAgents(skip bool) []agents.RemoteMachineData {
 	}
 	sort.Strings(names)
 
-	var result []agents.RemoteMachineData
+	result := make([]agents.RemoteMachineData, 0, len(names))
 	for _, name := range names {
 		rc := config.Remotes[name]
-		runner := session.NewSSHRunner(name, rc)
-		ctx, cancel := context.WithTimeout(context.Background(), rc.GetCommandTimeout())
-		out, runErr := runner.RunCommand(ctx, "agents", "--json", "--no-remote")
-		cancel()
-
-		if runErr != nil {
-			result = append(result, agents.RemoteMachineData{
-				Name: name, Link: agents.LinkUnconfirmed,
-				Detail: "could not reach " + rc.Host + ": " + runErr.Error(),
-			})
-			continue
-		}
-
-		var remoteView agents.View
-		if jsonErr := json.Unmarshal(out, &remoteView); jsonErr != nil {
-			result = append(result, agents.RemoteMachineData{
-				Name: name, Link: agents.LinkUnconfirmed,
-				Detail: "unreadable response from " + rc.Host + " (remote may predate agents support)",
-			})
-			continue
-		}
-
-		var rows []agents.AgentRow
-		for _, machine := range remoteView.Machines {
-			for _, row := range machine.Agents {
-				row.Machine = name
-				rows = append(rows, row)
-			}
-		}
 		result = append(result, agents.RemoteMachineData{
-			Name: name, Link: agents.LinkOK, Detail: "answered just now", Agents: rows,
+			Name: name, Link: agents.LinkUnconfirmed,
+			Detail: "no cached agents observation for " + rc.Host + "; phase 1 does not contact remotes",
 		})
 	}
 	return result

--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -312,16 +312,22 @@ func printAgentsView(view agents.View) {
 }
 
 func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
-	roleLine := row.Role
+	// Definition-sourced text, all of it untrusted.
+	roleLine := agents.SanitizeForDisplay(row.Role)
 	if row.RoleVersion != "" {
-		roleLine += " " + row.RoleVersion
+		roleLine += " " + agents.SanitizeForDisplay(row.RoleVersion)
 	}
-	fmt.Printf("%s  ·  role: %s  ·  %s", row.Name, roleLine, row.Harness)
+	fmt.Printf("%s  ·  role: %s  ·  %s",
+		agents.SanitizeForDisplay(row.Name), roleLine, agents.SanitizeForDisplay(row.Harness))
 	if row.Account != "" {
-		fmt.Printf(" / %s", row.Account)
+		fmt.Printf(" / %s", agents.SanitizeForDisplay(row.Account))
 	}
-	fmt.Printf("  ·  %s\n", row.Machine)
-	fmt.Printf("post: %s  ·  reports to: %s  ·  state: %s\n", row.PostID, row.ReportsTo, row.State)
+	fmt.Printf("  ·  %s\n", agents.SanitizeForDisplay(row.Machine))
+	fmt.Printf("post: %s  ·  reports to: %s  ·  state: %s\n",
+		agents.SanitizeForDisplay(row.PostID), agents.SanitizeForDisplay(row.ReportsTo), row.State)
+	if row.ReportsToIssue != "" {
+		fmt.Printf("!  %s\n", agents.SanitizeForDisplay(row.ReportsToIssue))
+	}
 
 	// The loudest facts about a row must not vanish when you drill into it.
 	if row.LoadError != "" {
@@ -331,7 +337,10 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 	for _, violation := range row.Violations {
 		fmt.Printf("\n!! %s\n", agents.SanitizeForDisplay(violation))
 	}
-	if row.Attention != "" {
+	// Attention restates whichever problem was already printed above — the
+	// load error or the first violation — so printing it again here would
+	// duplicate the line.
+	if row.Attention != "" && len(row.Violations) == 0 && row.LoadError == "" {
 		fmt.Printf("\n!  %s\n", agents.SanitizeForDisplay(row.Attention))
 	}
 
@@ -342,12 +351,13 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 			if !t.External {
 				owner = "ARMED HERE — phase 1 never emits this"
 			}
-			fmt.Printf("  %-24s %-18s %-16s [%s]\n", t.Name, t.Kind, t.NextDueText, owner)
+			fmt.Printf("  %-24s %-18s %-16s [%s]\n", agents.SanitizeForDisplay(t.Name),
+				agents.SanitizeForDisplay(t.Kind), agents.SanitizeForDisplay(t.NextDueText), owner)
 			if t.NextDue != nil {
 				fmt.Printf("      next due %s\n", t.NextDue.Format("Mon 15:04 MST"))
 			}
 			if t.Note != "" {
-				fmt.Printf("      %s\n", t.Note)
+				fmt.Printf("      %s\n", agents.SanitizeForDisplay(t.Note))
 			}
 		}
 	}
@@ -371,7 +381,7 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 		if len(def.Role.Spec.Policy) > 0 {
 			fmt.Println("\nRULES")
 			for _, policy := range def.Role.Spec.Policy {
-				fmt.Printf("  · %s\n", policy)
+				fmt.Printf("  · %s\n", agents.SanitizeForDisplay(policy))
 			}
 		}
 	}

--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -1,0 +1,660 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/agents"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleAgents implements `agent-deck agents`: the grouped-by-machine fleet
+// view. It is read-only. Nothing it prints is scheduled, started, or fired by
+// agent-deck — declared triggers still belong to the plists and timers that
+// own them today, and rows say so.
+func handleAgents(profile string, args []string) {
+	fs := flag.NewFlagSet("agents", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	noRemote := fs.Bool("no-remote", false, "Skip remote machines")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck agents [options]")
+		fmt.Println()
+		fmt.Println("List adopted agents, grouped by machine.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	defs, err := agents.LoadAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Zero-config users see nothing new. An empty registry is not an error
+	// and not an empty table — it is a short sentence saying how to start.
+	if len(defs) == 0 {
+		if *jsonOutput {
+			emitJSON(agents.View{})
+			return
+		}
+		fmt.Println("No agents adopted yet.")
+		fmt.Println("Run `agent-deck agent adopt <conductor-dir|session|plist|unit>` to make an existing setup visible.")
+		return
+	}
+
+	view := agents.BuildView(agents.BuildOptions{
+		Definitions:   defs,
+		SessionStates: loadSessionStates(profile),
+		Ledger:        ledgerLookup(),
+		LocalMachine:  localMachineName(),
+		Remotes:       fetchRemoteAgents(*noRemote),
+		Now:           time.Now(),
+	})
+
+	if *jsonOutput {
+		emitJSON(view)
+		return
+	}
+	printAgentsView(view)
+}
+
+// handleAgent implements `agent-deck agent <subcommand>`.
+func handleAgent(profile string, args []string) {
+	if len(args) == 0 {
+		printAgentUsage()
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "adopt":
+		handleAgentAdopt(profile, args[1:])
+	case "list", "ls":
+		handleAgents(profile, args[1:])
+	case "show":
+		handleAgentShow(profile, args[1:])
+	case "help", "--help", "-h":
+		printAgentUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown agent subcommand: %s\n\n", args[0])
+		printAgentUsage()
+		os.Exit(1)
+	}
+}
+
+func printAgentUsage() {
+	fmt.Println("Usage: agent-deck agent <command>")
+	fmt.Println()
+	fmt.Println("Commands:")
+	fmt.Println("  adopt <target>   Read an existing conductor dir, session, plist or unit")
+	fmt.Println("                   and emit a disabled definition for it")
+	fmt.Println("  list             List adopted agents (same as `agent-deck agents`)")
+	fmt.Println("  show <name>      Show one agent's definition, triggers and connectors")
+	fmt.Println()
+	fmt.Println("Adoption never modifies the source. It is a dry run unless you pass --write.")
+}
+
+// handleAgentAdopt introspects a target and prints the plan. Writing is a
+// separate, explicit step behind --write, so the default invocation cannot
+// change anything on disk.
+func handleAgentAdopt(profile string, args []string) {
+	fs := flag.NewFlagSet("agent adopt", flag.ExitOnError)
+	write := fs.Bool("write", false, "Write the generated definitions (default: dry run)")
+	output := fs.String("output", "", "Write definitions under this directory instead of the agents registry")
+	jsonOutput := fs.Bool("json", false, "Output the plan as JSON")
+	manager := fs.String("manager", "", "Post name that non-manager roles report to")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck agent adopt <conductor-dir|session|plist|unit> [options]")
+		fmt.Println()
+		fmt.Println("Introspects the target and emits a DISABLED definition with an evidence report.")
+		fmt.Println("The source is never modified: no plist is unloaded, no unit is edited, no")
+		fmt.Println("credential is moved, and no live session is taken over.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	if fs.NArg() == 0 {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	opts := agents.Options{
+		Target:          fs.Arg(0),
+		ManagerPost:     *manager,
+		Sessions:        loadAdoptSessions(profile),
+		ConductorBlocks: loadConductorBlocks(),
+		UnitDirs:        launchUnitDirs(),
+		Machine:         localMachineName(),
+	}
+
+	plan, err := agents.Adopt(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *jsonOutput {
+		emitJSON(plan)
+	} else {
+		printAdoptPlan(plan)
+	}
+
+	if !*write {
+		if !*jsonOutput {
+			fmt.Println()
+			fmt.Println("Dry run — nothing was written. Re-run with --write to emit these definitions.")
+		}
+		return
+	}
+
+	// A definition that does not validate is not written. Adoption that
+	// emitted a broken record and reported success would put the registry in
+	// a state the reader has to defend against forever.
+	for _, def := range plan.Definitions {
+		if def.Findings.HasErrors() {
+			fmt.Fprintf(os.Stderr, "\nError: %q did not validate; nothing was written.\n", def.Name)
+			for _, f := range def.Findings {
+				if f.Severity == agents.SeverityError {
+					fmt.Fprintf(os.Stderr, "  %s: %s\n", f.Field, f.Message)
+				}
+			}
+			os.Exit(1)
+		}
+	}
+
+	root := *output
+	if root == "" {
+		root, err = agents.Dir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: create registry: %v\n", err)
+		os.Exit(1)
+	}
+	written, err := plan.WriteTo(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if !*jsonOutput {
+		fmt.Println()
+		for _, dir := range written {
+			fmt.Printf("wrote %s\n", dir)
+		}
+		fmt.Println()
+		fmt.Println("These definitions are disabled. The source automation still owns every trigger above.")
+	}
+}
+
+// handleAgentShow prints one agent's detail, matching the TUI detail screen.
+func handleAgentShow(profile string, args []string) {
+	fs := flag.NewFlagSet("agent show", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	if fs.NArg() == 0 {
+		fmt.Println("Usage: agent-deck agent show <name>")
+		os.Exit(1)
+	}
+	name := fs.Arg(0)
+
+	defs, err := agents.LoadAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	var match *agents.Definition
+	for _, def := range defs {
+		if def.Name == name {
+			match = def
+			break
+		}
+	}
+	if match == nil {
+		fmt.Fprintf(os.Stderr, "Error: no adopted agent named %q\n", name)
+		os.Exit(1)
+	}
+
+	view := agents.BuildView(agents.BuildOptions{
+		Definitions:   []*agents.Definition{match},
+		SessionStates: loadSessionStates(profile),
+		Ledger:        ledgerLookup(),
+		LocalMachine:  localMachineName(),
+		Now:           time.Now(),
+	})
+	if len(view.Machines) == 0 || len(view.Machines[0].Agents) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: %q could not be rendered\n", name)
+		os.Exit(1)
+	}
+	row := view.Machines[0].Agents[0]
+
+	if *jsonOutput {
+		emitJSON(row)
+		return
+	}
+	printAgentDetail(row, match)
+}
+
+// --- rendering ----------------------------------------------------------
+
+func printAgentsView(view agents.View) {
+	attention := ""
+	if view.NeedAttention > 0 {
+		attention = fmt.Sprintf(" · %d need attention", view.NeedAttention)
+	}
+	fmt.Printf("%d agents%s\n", view.TotalAgents, attention)
+
+	now := time.Now()
+	for _, machine := range view.Machines {
+		fmt.Println()
+		header := strings.ToUpper(machine.Name)
+		switch machine.Link {
+		case agents.LinkUnconfirmed:
+			detail := machine.LinkDetail
+			if detail == "" {
+				detail = "unreachable"
+			}
+			fmt.Printf("%s   — UNCONFIRMED: %s\n", header, detail)
+		case agents.LinkOK:
+			if machine.LinkDetail != "" {
+				fmt.Printf("%s   — link ok, %s\n", header, machine.LinkDetail)
+			} else {
+				fmt.Printf("%s   — link ok\n", header)
+			}
+		default:
+			fmt.Println(header)
+		}
+
+		for _, row := range machine.Agents {
+			glyph := stateGlyph(row.State)
+			role := row.Role
+			if row.Class != agents.ClassAgent {
+				role = string(row.Class)
+			}
+			line := fmt.Sprintf(" %s %-18s %-12s %-11s", glyph, truncateCell(row.Name, 18), truncateCell(role, 12), row.State)
+			if last := agents.FormatLastDid(row, now); last != "" {
+				line += "  last: " + truncateCell(last, 34)
+			}
+			if next := agents.FormatNextDue(row); next != "" {
+				line += "  next: " + next
+			}
+			fmt.Println(line)
+			if row.Attention != "" {
+				fmt.Printf("     ! %s\n", row.Attention)
+			}
+		}
+	}
+
+	for _, notice := range view.Notices {
+		fmt.Printf("\nnote: %s\n", notice)
+	}
+}
+
+func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
+	roleLine := row.Role
+	if row.RoleVersion != "" {
+		roleLine += " " + row.RoleVersion
+	}
+	fmt.Printf("%s  ·  role: %s  ·  %s", row.Name, roleLine, row.Harness)
+	if row.Account != "" {
+		fmt.Printf(" / %s", row.Account)
+	}
+	fmt.Printf("  ·  %s\n", row.Machine)
+	fmt.Printf("post: %s  ·  reports to: %s  ·  state: %s\n", row.PostID, row.ReportsTo, row.State)
+
+	if len(row.Triggers) > 0 {
+		fmt.Println("\nTRIGGERS")
+		for _, t := range row.Triggers {
+			owner := "agent-deck"
+			if t.External {
+				owner = "external: " + filepath.Base(t.ExternalSource)
+			}
+			fmt.Printf("  %-24s %-18s %-16s [%s]\n", t.Name, t.Kind, t.NextDueText, owner)
+			if t.NextDue != nil {
+				fmt.Printf("      next due %s\n", t.NextDue.Format("Mon 15:04 MST"))
+			}
+			if t.Note != "" {
+				fmt.Printf("      %s\n", t.Note)
+			}
+		}
+	}
+
+	if len(row.Connectors) > 0 {
+		fmt.Println("\nCONNECTORS")
+		for _, c := range row.Connectors {
+			fmt.Printf("  %s %-20s %s\n", healthGlyph(c.State), c.Name, c.Detail)
+		}
+	}
+
+	if len(row.Recent) > 0 {
+		fmt.Println("\nRECENT WORK")
+		for _, entry := range row.Recent {
+			fmt.Printf("  %s  %s\n", entry.At.Format("15:04"), entry.Summary)
+		}
+	}
+
+	if def != nil && def.Role != nil {
+		if len(def.Role.Spec.Policy) > 0 {
+			fmt.Println("\nRULES")
+			for _, policy := range def.Role.Spec.Policy {
+				fmt.Printf("  · %s\n", policy)
+			}
+		}
+	}
+
+	if len(row.Unresolved) > 0 {
+		fmt.Println("\nUNRESOLVED")
+		for _, item := range row.Unresolved {
+			fmt.Printf("  · %s\n", item)
+		}
+	}
+	fmt.Println("\nThis definition is disabled. agent-deck displays it; it does not run it.")
+}
+
+func printAdoptPlan(plan *agents.Plan) {
+	fmt.Printf("target: %s  (%s)\n", plan.Target, plan.TargetKind)
+	for _, def := range plan.Definitions {
+		post := def.Post
+		fmt.Printf("\n%s\n", def.Name)
+		fmt.Printf("  classification: %s\n", post.Spec.Classification)
+		fmt.Printf("  role:           %s\n", post.Spec.Role.Name)
+		fmt.Printf("  reports to:     %s\n", post.Spec.Placement.ReportsTo)
+		fmt.Printf("  post id:        %s\n", post.Metadata.PostID)
+		if post.Spec.Runtime.AdoptedSessionID != "" {
+			fmt.Printf("  session:        %s (provenance only)\n", post.Spec.Runtime.AdoptedSessionID)
+		}
+		if len(post.Spec.Triggers) > 0 {
+			fmt.Println("  triggers (declared, disabled, still fired by their source):")
+			for _, t := range post.Spec.Triggers {
+				schedule := t.Schedule
+				if schedule == "" && t.IntervalSeconds > 0 {
+					schedule = agents.DescribeInterval(t.IntervalSeconds)
+				}
+				fmt.Printf("    - %-22s %-16s %s\n", t.Name, t.Type, schedule)
+				fmt.Printf("      owned by %s\n", t.ExternalSource)
+			}
+		}
+		if len(post.Spec.Connectors) > 0 {
+			fmt.Println("  connectors (referenced, NOT enabled):")
+			for _, c := range post.Spec.Connectors {
+				fmt.Printf("    - %s (%s) evidence: %s\n", c.Name, c.Kind, c.EvidencePath)
+			}
+		}
+		if len(def.RoleFiles) > 0 {
+			names := make([]string, 0, len(def.RoleFiles))
+			for name := range def.RoleFiles {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			fmt.Printf("  role files: %s\n", strings.Join(names, ", "))
+		}
+		if len(post.Spec.Unresolved) > 0 {
+			fmt.Println("  unresolved:")
+			for _, item := range post.Spec.Unresolved {
+				fmt.Printf("    · %s\n", item)
+			}
+		}
+		for _, f := range def.Findings {
+			fmt.Printf("  %s %s: %s\n", strings.ToUpper(string(f.Severity)), f.Field, f.Message)
+		}
+	}
+	for _, note := range plan.Notes {
+		fmt.Printf("\nnote: %s\n", note)
+	}
+}
+
+func stateGlyph(state agents.RunState) string {
+	switch state {
+	case agents.RunWorking:
+		return "●"
+	case agents.RunIdle:
+		return "●"
+	case agents.RunNeedsYou:
+		return "◐"
+	case agents.RunError:
+		return "✕"
+	case agents.RunStopped:
+		return "○"
+	case agents.RunNoRuntime:
+		return "◍"
+	default:
+		return "?"
+	}
+}
+
+func healthGlyph(state agents.HealthState) string {
+	switch state {
+	case agents.HealthOK:
+		return "●"
+	case agents.HealthStale:
+		return "◐"
+	case agents.HealthDown:
+		return "●"
+	default:
+		return "○"
+	}
+}
+
+func emitJSON(value any) {
+	out, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: format JSON: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}
+
+// --- data gathering -----------------------------------------------------
+
+// localMachineName labels the local machine in the grouped view.
+func localMachineName() string {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		return "local"
+	}
+	if short, _, found := strings.Cut(host, "."); found {
+		return short
+	}
+	return host
+}
+
+// loadSessionStates reads live session status. The session store stays
+// authoritative for what a runtime is doing.
+func loadSessionStates(profile string) map[string]agents.SessionState {
+	states := map[string]agents.SessionState{}
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		return states
+	}
+	defer func() { _ = storage.Close() }()
+
+	instances, err := storage.Load()
+	if err != nil {
+		return states
+	}
+	for _, inst := range instances {
+		states[inst.ID] = agents.SessionState{Status: string(inst.Status), Present: true}
+	}
+	return states
+}
+
+// loadAdoptSessions converts the local fleet into the shape the adoption
+// resolvers accept.
+func loadAdoptSessions(profile string) []agents.SessionInfo {
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = storage.Close() }()
+
+	instances, err := storage.Load()
+	if err != nil {
+		return nil
+	}
+	infos := make([]agents.SessionInfo, 0, len(instances))
+	for _, inst := range instances {
+		infos = append(infos, agents.SessionInfo{
+			ID:          inst.ID,
+			Title:       inst.Title,
+			Tool:        inst.Tool,
+			Account:     inst.Account,
+			GroupPath:   inst.GroupPath,
+			ProjectPath: inst.ProjectPath,
+			Command:     inst.Command,
+			Status:      string(inst.Status),
+			IsConductor: inst.IsConductor,
+		})
+	}
+	return infos
+}
+
+// loadConductorBlocks reads the `[conductors.*]` blocks from the config the
+// binary actually reads.
+func loadConductorBlocks() map[string]agents.ConductorBlock {
+	blocks := map[string]agents.ConductorBlock{}
+	config, err := session.LoadUserConfig()
+	if err != nil || config == nil {
+		return blocks
+	}
+	source := "config.toml [conductors.*]"
+	for name, overrides := range config.Conductors {
+		block := agents.ConductorBlock{Name: name, Account: overrides.Account, Source: source}
+		switch {
+		case overrides.Claude.ConfigDir != "":
+			block.Tool = "claude"
+		case overrides.DeepSeek.Command != "":
+			block.Tool = "deepseek"
+		}
+		blocks[strings.ToLower(name)] = block
+	}
+	return blocks
+}
+
+// launchUnitDirs are the directories adoption scans for a plist or unit that
+// fires a target. They are read-only inputs.
+func launchUnitDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, "Library", "LaunchAgents"),
+		filepath.Join(home, ".config", "systemd", "user"),
+		"/etc/systemd/system",
+	}
+}
+
+// ledgerLookup returns recent work for a session from the completion and
+// talkback ledgers. Both are existing durable records; nothing new is written.
+func ledgerLookup() func(string) []agents.LedgerEntry {
+	return func(sessionID string) []agents.LedgerEntry {
+		var entries []agents.LedgerEntry
+
+		// What this session itself reported when it finished.
+		if entry, ok := session.ReadLedgerEntry(sessionID); ok {
+			summary := entry.Summary
+			if summary == "" {
+				// A ledger entry without a summary still tells us the turn
+				// ended and how. Say that, rather than printing a bare
+				// status word that reads like a description of the work.
+				summary = "reported " + entry.Status
+			}
+			entries = append(entries, agents.LedgerEntry{
+				At: entry.FinishedAt, Summary: summary, Status: entry.Status,
+			})
+		}
+
+		// What its children reported to it.
+		if events, err := session.ReadInboxEvents(sessionID); err == nil {
+			for _, event := range events {
+				title := event.ChildTitle
+				if title == "" {
+					title = event.ChildSessionID
+				}
+				entries = append(entries, agents.LedgerEntry{
+					At:      event.Timestamp,
+					Summary: fmt.Sprintf("%s → %s", title, event.ToStatus),
+					Status:  event.ToStatus,
+				})
+			}
+		}
+
+		sort.Slice(entries, func(i, j int) bool { return entries[i].At.After(entries[j].At) })
+		return entries
+	}
+}
+
+// fetchRemoteAgents asks each configured remote for its agents.
+//
+// Link honesty is the point: a remote that does not answer is reported
+// UNCONFIRMED with the reason, never omitted (which would understate the
+// fleet) and never rendered as if its rows were current.
+func fetchRemoteAgents(skip bool) []agents.RemoteMachineData {
+	if skip {
+		return nil
+	}
+	config, err := session.LoadUserConfig()
+	if err != nil || config == nil || len(config.Remotes) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(config.Remotes))
+	for name := range config.Remotes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var result []agents.RemoteMachineData
+	for _, name := range names {
+		rc := config.Remotes[name]
+		runner := session.NewSSHRunner(name, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), rc.GetCommandTimeout())
+		out, runErr := runner.RunCommand(ctx, "agents", "--json", "--no-remote")
+		cancel()
+
+		if runErr != nil {
+			result = append(result, agents.RemoteMachineData{
+				Name: name, Link: agents.LinkUnconfirmed,
+				Detail: "could not reach " + rc.Host + ": " + runErr.Error(),
+			})
+			continue
+		}
+
+		var remoteView agents.View
+		if jsonErr := json.Unmarshal(out, &remoteView); jsonErr != nil {
+			result = append(result, agents.RemoteMachineData{
+				Name: name, Link: agents.LinkUnconfirmed,
+				Detail: "unreadable response from " + rc.Host + " (remote may predate agents support)",
+			})
+			continue
+		}
+
+		var rows []agents.AgentRow
+		for _, machine := range remoteView.Machines {
+			for _, row := range machine.Agents {
+				row.Machine = name
+				rows = append(rows, row)
+			}
+		}
+		result = append(result, agents.RemoteMachineData{
+			Name: name, Link: agents.LinkOK, Detail: "answered just now", Agents: rows,
+		})
+	}
+	return result
+}

--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -231,18 +231,23 @@ func handleAgentShow(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	// Build the view from the WHOLE registry, not just this definition. The
+	// escalation graph can only be judged across the set: with one post in
+	// hand, every legitimate manager reference reads as unknown, so every post
+	// adopted with --manager — which is every post Amendment 02 describes —
+	// got warned about a manager sitting in the same registry.
 	view := agents.BuildView(agents.BuildOptions{
-		Definitions:   []*agents.Definition{match},
+		Definitions:   defs,
 		SessionStates: loadSessionStates(profile),
 		Ledger:        ledgerLookup(),
 		LocalMachine:  localMachineName(),
 		Now:           time.Now(),
 	})
-	if len(view.Machines) == 0 || len(view.Machines[0].Agents) == 0 {
+	row, found := findAgentRow(view, name)
+	if !found {
 		fmt.Fprintf(os.Stderr, "Error: %q could not be rendered\n", name)
 		os.Exit(1)
 	}
-	row := view.Machines[0].Agents[0]
 
 	if *jsonOutput {
 		emitJSON(row)
@@ -252,6 +257,18 @@ func handleAgentShow(profile string, args []string) {
 }
 
 // --- rendering ----------------------------------------------------------
+
+// findAgentRow locates one agent's row in a whole-fleet view.
+func findAgentRow(view agents.View, name string) (agents.AgentRow, bool) {
+	for _, machine := range view.Machines {
+		for _, row := range machine.Agents {
+			if row.Name == name {
+				return row, true
+			}
+		}
+	}
+	return agents.AgentRow{}, false
+}
 
 func printAgentsView(view agents.View) {
 	attention := ""
@@ -302,6 +319,9 @@ func printAgentsView(view agents.View) {
 			fmt.Println(line)
 			if row.Attention != "" {
 				fmt.Printf("     ! %s\n", agents.SanitizeForDisplay(row.Attention))
+			}
+			if row.ReportsToIssue != "" && !strings.Contains(row.Attention, row.ReportsToIssue) {
+				fmt.Printf("     ! %s\n", agents.SanitizeForDisplay(row.ReportsToIssue))
 			}
 		}
 	}

--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -270,13 +270,16 @@ func printAgentsView(view agents.View) {
 			if detail == "" {
 				detail = "unreachable"
 			}
-			fmt.Printf("%s   — UNCONFIRMED: %s\n", header, detail)
+			fmt.Printf("%s   — UNCONFIRMED: %s\n", header, agents.SanitizeForDisplay(detail))
 		case agents.LinkOK:
 			if machine.LinkDetail != "" {
-				fmt.Printf("%s   — link ok, %s\n", header, machine.LinkDetail)
+				fmt.Printf("%s   — link ok, %s\n", header, agents.SanitizeForDisplay(machine.LinkDetail))
 			} else {
 				fmt.Printf("%s   — link ok\n", header)
 			}
+		case agents.LinkNotContacted:
+			// Never claim a round trip that did not happen.
+			fmt.Printf("%s   — not contacted; placement only\n", header)
 		default:
 			fmt.Println(header)
 		}
@@ -287,16 +290,18 @@ func printAgentsView(view agents.View) {
 			if row.Class != agents.ClassAgent {
 				role = string(row.Class)
 			}
-			line := fmt.Sprintf(" %s %-18s %-12s %-11s", glyph, truncateCell(row.Name, 18), truncateCell(role, 12), row.State)
+			line := fmt.Sprintf(" %s %-18s %-12s %-11s", glyph,
+				truncateCell(agents.SanitizeForDisplay(row.Name), 18),
+				truncateCell(agents.SanitizeForDisplay(role), 12), row.State)
 			if last := agents.FormatLastDid(row, now); last != "" {
-				line += "  last: " + truncateCell(last, 34)
+				line += "  last: " + truncateCell(agents.SanitizeForDisplay(last), 34)
 			}
 			if next := agents.FormatNextDue(row); next != "" {
 				line += "  next: " + next
 			}
 			fmt.Println(line)
 			if row.Attention != "" {
-				fmt.Printf("     ! %s\n", row.Attention)
+				fmt.Printf("     ! %s\n", agents.SanitizeForDisplay(row.Attention))
 			}
 		}
 	}
@@ -318,12 +323,24 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 	fmt.Printf("  ·  %s\n", row.Machine)
 	fmt.Printf("post: %s  ·  reports to: %s  ·  state: %s\n", row.PostID, row.ReportsTo, row.State)
 
+	// The loudest facts about a row must not vanish when you drill into it.
+	if row.LoadError != "" {
+		fmt.Printf("\n!! this definition could not be read: %s\n", agents.SanitizeForDisplay(row.LoadError))
+		fmt.Println("   nothing below is trustworthy.")
+	}
+	for _, violation := range row.Violations {
+		fmt.Printf("\n!! %s\n", agents.SanitizeForDisplay(violation))
+	}
+	if row.Attention != "" {
+		fmt.Printf("\n!  %s\n", agents.SanitizeForDisplay(row.Attention))
+	}
+
 	if len(row.Triggers) > 0 {
 		fmt.Println("\nTRIGGERS")
 		for _, t := range row.Triggers {
-			owner := "agent-deck"
-			if t.External {
-				owner = "external: " + filepath.Base(t.ExternalSource)
+			owner := "external: " + filepath.Base(t.ExternalSource)
+			if !t.External {
+				owner = "ARMED HERE — phase 1 never emits this"
 			}
 			fmt.Printf("  %-24s %-18s %-16s [%s]\n", t.Name, t.Kind, t.NextDueText, owner)
 			if t.NextDue != nil {
@@ -338,14 +355,15 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 	if len(row.Connectors) > 0 {
 		fmt.Println("\nCONNECTORS")
 		for _, c := range row.Connectors {
-			fmt.Printf("  %s %-20s %s\n", healthGlyph(c.State), c.Name, c.Detail)
+			fmt.Printf("  %s %-20s %s\n", healthGlyph(c.State),
+				agents.SanitizeForDisplay(c.Name), agents.SanitizeForDisplay(c.Detail))
 		}
 	}
 
 	if len(row.Recent) > 0 {
 		fmt.Println("\nRECENT WORK")
 		for _, entry := range row.Recent {
-			fmt.Printf("  %s  %s\n", entry.At.Format("15:04"), entry.Summary)
+			fmt.Printf("  %s  %s\n", entry.At.Format("15:04"), agents.SanitizeForDisplay(entry.Summary))
 		}
 	}
 
@@ -361,10 +379,20 @@ func printAgentDetail(row agents.AgentRow, def *agents.Definition) {
 	if len(row.Unresolved) > 0 {
 		fmt.Println("\nUNRESOLVED")
 		for _, item := range row.Unresolved {
-			fmt.Printf("  · %s\n", item)
+			fmt.Printf("  · %s\n", agents.SanitizeForDisplay(item))
 		}
 	}
-	fmt.Println("\nThis definition is disabled. agent-deck displays it; it does not run it.")
+	fmt.Println()
+	switch {
+	case row.LoadError != "":
+		fmt.Println("This definition could not be read. agent-deck is showing what little it parsed.")
+	case len(row.Violations) > 0 || row.Armed():
+		// Never print "this is disabled" over data that says otherwise.
+		fmt.Println("This definition claims to be ARMED, which phase 1 never emits.")
+		fmt.Println("agent-deck still does not run it — but the record is not what adoption writes.")
+	default:
+		fmt.Println("This definition is disabled. agent-deck displays it; it does not run it.")
+	}
 }
 
 func printAdoptPlan(plan *agents.Plan) {
@@ -438,6 +466,9 @@ func stateGlyph(state agents.RunState) string {
 	}
 }
 
+// healthGlyph must distinguish states by SHAPE. CLI output has no color, so
+// giving "ok" and "down" the same ● made a dead connector look healthy —
+// the worse of the two possible confusions.
 func healthGlyph(state agents.HealthState) string {
 	switch state {
 	case agents.HealthOK:
@@ -445,7 +476,7 @@ func healthGlyph(state agents.HealthState) string {
 	case agents.HealthStale:
 		return "◐"
 	case agents.HealthDown:
-		return "●"
+		return "✕"
 	default:
 		return "○"
 	}

--- a/cmd/agent-deck/agents_cmd.go
+++ b/cmd/agent-deck/agents_cmd.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/asheshgoplani/agent-deck/internal/agents"
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -597,7 +598,8 @@ func loadConductorBlocks() map[string]agents.ConductorBlock {
 	}
 	source := "config.toml [conductors.*]"
 	for name, overrides := range config.Conductors {
-		block := agents.ConductorBlock{Name: name, Account: overrides.Account, Source: source}
+		block := agents.ConductorBlock{Name: name, Account: "", // per-conductor account overrides arrive with the accounts feature (E14); empty until it merges
+			Source: source}
 		switch {
 		case overrides.Claude.ConfigDir != "":
 			block.Tool = "claude"
@@ -644,7 +646,7 @@ func ledgerLookup() func(string) []agents.LedgerEntry {
 		}
 
 		// What its children reported to it.
-		if events, err := session.ReadInboxEvents(sessionID); err == nil {
+		if events, err := session.PeekInboxEvents(sessionID); err == nil {
 			for _, event := range events {
 				title := event.ChildTitle
 				if title == "" {
@@ -720,4 +722,14 @@ func fetchRemoteAgents(skip bool) []agents.RemoteMachineData {
 		})
 	}
 	return result
+}
+
+// truncateCell shortens a table cell to max runes with an ellipsis. Local
+// copy: the shared one lives on the context-inspector branch (PR #2011) and
+// arrives with it; same 6 lines, same semantics.
+func truncateCell(s string, max int) string {
+	if max < 4 || utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	return string([]rune(s)[:max-1]) + "…"
 }

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -328,6 +328,12 @@ func main() {
 		case "conductor":
 			handleConductor(profile, args[1:])
 			return
+		case "agents":
+			handleAgents(profile, args[1:])
+			return
+		case "agent":
+			handleAgent(profile, args[1:])
+			return
 		case "telegram-doctor":
 			handleTelegramDoctor(profile, args[1:])
 			return
@@ -3529,6 +3535,8 @@ func printHelp() {
 	fmt.Println("  web              Start TUI with web UI server running alongside")
 	fmt.Println("  remote           Manage remote agent-deck instances")
 	fmt.Println("  conductor        Manage conductor meta-agent orchestration")
+	fmt.Println("  agents           List adopted agents, grouped by machine")
+	fmt.Println("  agent            Adopt and inspect agent definitions")
 	fmt.Println("  telegram-doctor  Audit channel-owning sessions for telegram drops (#1138)")
 	fmt.Println("  profile          Manage profiles")
 	fmt.Println("  update           Check for and install updates")

--- a/internal/agents/adopt.go
+++ b/internal/agents/adopt.go
@@ -455,6 +455,20 @@ func applyUnitToPost(post *Post, unit *LaunchSource) {
 		})
 		post.AddEvidence("spec.triggers."+base+"-keepalive", "KeepAlive", unit.Path, ConfidenceHigh,
 			"kept alive by the launcher rather than fired on a schedule")
+	case unit.HasUnrepresentableSchedule:
+		// The source demonstrably fires this post; we just cannot express its
+		// schedule. Declining the SCHEDULE is right, but dropping the TRIGGER
+		// would show an agent with nothing firing it — understating the fleet,
+		// which is the failure this phase exists to avoid. Same vocabulary the
+		// systemd path already uses for an inexpressible OnCalendar.
+		post.Spec.Triggers = append(post.Spec.Triggers, Trigger{
+			Name: base + "-calendar", Type: TriggerOpaque,
+			Schedule: unit.RawScheduleText,
+			Enabled:  false, External: true, ExternalSource: unit.Path,
+			Deliver: fixedDeliveryFor(post.Spec.Role.Name),
+		})
+		post.AddEvidence("spec.triggers."+base+"-calendar", unit.RawScheduleText, unit.Path, ConfidenceHigh,
+			"this fires on a schedule with no exact cron equivalent; no next-due time is computed")
 	}
 
 	if unit.RestartMode != "" {

--- a/internal/agents/adopt.go
+++ b/internal/agents/adopt.go
@@ -195,9 +195,28 @@ func adoptConductorDir(dir string, opts Options) (*Plan, error) {
 		}
 		seenTargets[mapping.target] = true
 		sourcePaths = append(sourcePaths, sourcePath)
+
+		contentFindings := ValidateRoleContent("role/"+mapping.target, string(body))
+		if contentFindings.HasErrors() {
+			// The body carries something that looks like a credential. Copying
+			// it would put that secret in a second place on disk, so the file
+			// is left where it is and the definition records why it is absent.
+			// The source is not touched: fixing it is the user's call.
+			//
+			// The finding is downgraded to a warning here because it has been
+			// ACTED on — the leak cannot happen now. Leaving it fatal would
+			// refuse the whole definition and leave the user with no inventory
+			// of an agent that plainly exists, which is the opposite of what
+			// this phase is for.
+			findings = append(findings, handledCredentialFindings(contentFindings)...)
+			post.AddUnresolved(mapping.source + " was not copied into the role because it looks like it " +
+				"contains a credential; move the value to a connector's private store, then re-adopt")
+			continue
+		}
+		findings = append(findings, contentFindings...)
+
 		roleFiles[mapping.target] = body
 		role.Spec.Digests[mapping.target] = Digest(body)
-		findings = append(findings, ValidateRoleContent("role/"+mapping.target, string(body))...)
 
 		switch {
 		case mapping.target == "INSTRUCTIONS.md":
@@ -228,11 +247,20 @@ func adoptConductorDir(dir string, opts Options) (*Plan, error) {
 			}
 			rel := filepath.Join("workflows", entry.Name())
 			workflowName := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+			sourcePaths = append(sourcePaths, sourcePath)
+
+			contentFindings := ValidateRoleContent("role/"+rel, string(body))
+			if contentFindings.HasErrors() {
+				findings = append(findings, handledCredentialFindings(contentFindings)...)
+				post.AddUnresolved("workflows/" + entry.Name() + " was not copied into the role because it " +
+					"looks like it contains a credential; move the value to a connector's private store, then re-adopt")
+				continue
+			}
+			findings = append(findings, contentFindings...)
+
 			role.Spec.Workflows[workflowName] = rel
 			roleFiles[rel] = body
 			role.Spec.Digests[rel] = Digest(body)
-			sourcePaths = append(sourcePaths, sourcePath)
-			findings = append(findings, ValidateRoleContent("role/"+rel, string(body))...)
 		}
 	}
 
@@ -240,10 +268,15 @@ func adoptConductorDir(dir string, opts Options) (*Plan, error) {
 		post.AddUnresolved("no instruction file found; the role has no entry point yet")
 	}
 
+	// The role must be set before bindings run: applyConductorBindings folds
+	// in any unit that fires this post, and the trigger's fixed delivery
+	// string is chosen from the role name. Assigning it afterwards gave every
+	// adopted conductor the generic fallback string.
+	post.Spec.Role = RoleRef{Name: classified.Role, Path: "./" + RoleDirName, Version: role.Metadata.Version}
+
 	// Correlate the live runtime, the config block, and any unit that fires it.
 	applyConductorBindings(post, absDir, name, opts, &sourcePaths)
 
-	post.Spec.Role = RoleRef{Name: classified.Role, Path: "./" + RoleDirName, Version: role.Metadata.Version}
 	if classified.Role == RoleUnresolved {
 		post.AddUnresolved("role is unresolved; a human must say what this agent is for")
 	}
@@ -683,8 +716,13 @@ func (p *Plan) WriteTo(root string) ([]string, error) {
 	var written []string
 	for _, def := range p.Definitions {
 		dir := filepath.Join(root, def.Name)
-		if _, err := os.Stat(filepath.Join(dir, PostFileName)); err == nil {
-			return written, fmt.Errorf("definition %q already exists at %s; remove it or adopt under a different name", def.Name, dir)
+		// Guard on the whole directory, not just agent.yaml. A directory that
+		// already holds role/INSTRUCTIONS.md or ADOPTION-REPORT.md but no
+		// agent.yaml would otherwise have those files silently overwritten —
+		// which matters most for --output, where the root is arbitrary.
+		if entries, err := os.ReadDir(dir); err == nil && len(entries) > 0 {
+			return written, fmt.Errorf("refusing to write definition %q: %s already exists and is not empty; "+
+				"remove it or adopt under a different name", def.Name, dir)
 		}
 		if err := Write(dir, def.Post, def.Role, def.RoleFiles, def.Report); err != nil {
 			return written, err
@@ -695,6 +733,20 @@ func (p *Plan) WriteTo(root string) ([]string, error) {
 }
 
 // --- helpers ------------------------------------------------------------
+
+// handledCredentialFindings downgrades a credential error to a warning, for
+// the case where adoption has already prevented the leak by not copying the
+// file. The text still says what was found and what to do about it.
+func handledCredentialFindings(in Findings) Findings {
+	out := make(Findings, 0, len(in))
+	for _, f := range in {
+		if f.Severity == SeverityError {
+			f.Severity = SeverityWarn
+		}
+		out = append(out, f)
+	}
+	return out
+}
 
 func readCapped(path string) ([]byte, error) {
 	info, err := os.Stat(path)

--- a/internal/agents/adopt.go
+++ b/internal/agents/adopt.go
@@ -333,7 +333,7 @@ func applyConductorBindings(post *Post, absDir, name string, opts Options, sourc
 	}
 
 	for _, unit := range findRelatedUnits(name, opts.UnitDirs) {
-		*sourcePaths = append(*sourcePaths, unit.Path)
+		*sourcePaths = append(*sourcePaths, launchSourcePaths(unit)...)
 		applyUnitToPost(post, unit)
 	}
 }
@@ -417,36 +417,50 @@ func dropPairedTimers(sources []*LaunchSource) []*LaunchSource {
 // triggers on the post.
 func applyUnitToPost(post *Post, unit *LaunchSource) {
 	base := sanitizeName(unit.Label)
+	scheduleSource := unit.ScheduleSource
+	if scheduleSource == "" {
+		scheduleSource = unit.Path
+	}
 	switch {
-	case unit.CalendarSpec != "":
+	case len(unit.CalendarSpecs) > 0 || unit.CalendarSpec != "":
 		// launchd already produced cron; systemd produces OnCalendar syntax,
 		// which only sometimes has an exact cron equivalent. A spec that
 		// cannot be converted is recorded verbatim as an opaque trigger so
 		// the row shows the real schedule text instead of a cron expression
 		// that would never parse.
-		trigger := Trigger{
-			Name: base + "-calendar", Type: TriggerCron, Schedule: unit.CalendarSpec,
-			Enabled: false, External: true, ExternalSource: unit.Path,
-			Deliver: fixedDeliveryFor(post.Spec.Role.Name),
+		specs := unit.CalendarSpecs
+		if len(specs) == 0 {
+			specs = []string{unit.CalendarSpec}
 		}
-		note := "the unit still owns this firing; agent-deck only displays it"
-		if unit.Kind == "systemd" {
-			if converted, ok := SystemdCalendarToCron(unit.CalendarSpec); ok {
-				trigger.Schedule = converted
-			} else {
-				trigger.Type = TriggerOpaque
-				note = "OnCalendar=" + unit.CalendarSpec + " has no exact cron equivalent; no next-due time is computed"
+		for i, spec := range specs {
+			name := base + "-calendar"
+			if len(specs) > 1 {
+				name = fmt.Sprintf("%s-calendar-%d", base, i+1)
 			}
+			trigger := Trigger{
+				Name: name, Type: TriggerCron, Schedule: spec,
+				Enabled: false, External: true, ExternalSource: scheduleSource,
+				Deliver: fixedDeliveryFor(post.Spec.Role.Name),
+			}
+			note := "the unit still owns this firing; agent-deck only displays it"
+			if unit.Kind == "systemd" {
+				if converted, ok := SystemdCalendarToCron(spec); ok {
+					trigger.Schedule = converted
+				} else {
+					trigger.Type = TriggerOpaque
+					note = "OnCalendar=" + spec + " has no exact cron equivalent; no next-due time is computed"
+				}
+			}
+			post.Spec.Triggers = append(post.Spec.Triggers, trigger)
+			post.AddEvidence("spec.triggers."+name, spec, scheduleSource, ConfidenceHigh, note)
 		}
-		post.Spec.Triggers = append(post.Spec.Triggers, trigger)
-		post.AddEvidence("spec.triggers."+base+"-calendar", unit.CalendarSpec, unit.Path, ConfidenceHigh, note)
 	case unit.IntervalSeconds > 0:
 		post.Spec.Triggers = append(post.Spec.Triggers, Trigger{
 			Name: base + "-interval", Type: TriggerCron, IntervalSeconds: unit.IntervalSeconds,
-			Enabled: false, External: true, ExternalSource: unit.Path,
+			Enabled: false, External: true, ExternalSource: scheduleSource,
 			Deliver: fixedDeliveryFor(post.Spec.Role.Name),
 		})
-		post.AddEvidence("spec.triggers."+base+"-interval", fmt.Sprintf("every %ds", unit.IntervalSeconds), unit.Path,
+		post.AddEvidence("spec.triggers."+base+"-interval", fmt.Sprintf("every %ds", unit.IntervalSeconds), scheduleSource,
 			ConfidenceHigh, "a poll cadence is not proof of the desired business cadence")
 	case unit.KeepAlive:
 		post.Spec.Triggers = append(post.Spec.Triggers, Trigger{
@@ -464,10 +478,10 @@ func applyUnitToPost(post *Post, unit *LaunchSource) {
 		post.Spec.Triggers = append(post.Spec.Triggers, Trigger{
 			Name: base + "-calendar", Type: TriggerOpaque,
 			Schedule: unit.RawScheduleText,
-			Enabled:  false, External: true, ExternalSource: unit.Path,
+			Enabled:  false, External: true, ExternalSource: scheduleSource,
 			Deliver: fixedDeliveryFor(post.Spec.Role.Name),
 		})
-		post.AddEvidence("spec.triggers."+base+"-calendar", unit.RawScheduleText, unit.Path, ConfidenceHigh,
+		post.AddEvidence("spec.triggers."+base+"-calendar", unit.RawScheduleText, scheduleSource, ConfidenceHigh,
 			"this fires on a schedule with no exact cron equivalent; no next-due time is computed")
 	}
 
@@ -488,6 +502,13 @@ func applyUnitToPost(post *Post, unit *LaunchSource) {
 	for _, warning := range unit.Warnings {
 		post.AddEvidence("source."+filepath.Base(unit.Path), "", unit.Path, ConfidenceLow, warning)
 	}
+}
+
+func launchSourcePaths(unit *LaunchSource) []string {
+	if len(unit.SourcePaths) > 0 {
+		return unit.SourcePaths
+	}
+	return []string{unit.Path}
 }
 
 // fixedDeliveryFor returns the fixed, locally declared delivery string for a
@@ -532,7 +553,8 @@ func adoptSystemd(path string, opts Options) (*Plan, error) {
 
 func planFromUnit(src *LaunchSource, opts Options) (*Plan, error) {
 	name := sanitizeName(src.Label)
-	plan := &Plan{Target: src.Path, TargetKind: src.Kind, SourcePaths: []string{src.Path}}
+	paths := launchSourcePaths(src)
+	plan := &Plan{Target: src.Path, TargetKind: src.Kind, SourcePaths: append([]string(nil), paths...)}
 
 	classified := ClassifyLaunchSource(src)
 	post := NewPost(name, postID(name, src.Path))
@@ -682,7 +704,7 @@ func adoptSession(target string, opts Options) (*Plan, error) {
 
 	sourcePaths := []string{}
 	for _, unit := range findRelatedUnits(name, opts.UnitDirs) {
-		sourcePaths = append(sourcePaths, unit.Path)
+		sourcePaths = append(sourcePaths, launchSourcePaths(unit)...)
 		applyUnitToPost(post, unit)
 	}
 	post.Spec.SourceFingerprint = FingerprintPaths(sourcePaths)
@@ -733,7 +755,7 @@ func (p *Plan) WriteTo(root string) ([]string, error) {
 		// Guard on the whole directory, not just agent.yaml. A directory that
 		// already holds role/INSTRUCTIONS.md or ADOPTION-REPORT.md but no
 		// agent.yaml would otherwise have those files silently overwritten —
-		// which matters most for --output, where the root is arbitrary.
+		// even if a caller supplies a pre-existing registry root.
 		if entries, err := os.ReadDir(dir); err == nil && len(entries) > 0 {
 			return written, fmt.Errorf("refusing to write definition %q: %s already exists and is not empty; "+
 				"remove it or adopt under a different name", def.Name, dir)

--- a/internal/agents/adopt.go
+++ b/internal/agents/adopt.go
@@ -1,0 +1,847 @@
+package agents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxRoleFileBytes caps a copied role body. A role is instructions and policy;
+// anything larger is almost certainly a log or a database that wandered into
+// the directory, and copying it would bloat every export.
+const maxRoleFileBytes = 512 * 1024
+
+// SessionInfo is the subset of an agent-deck session record adoption needs.
+// The caller supplies these, which keeps this package free of the session
+// store and makes every resolver testable from a literal.
+type SessionInfo struct {
+	ID          string
+	Title       string
+	Tool        string
+	Account     string
+	GroupPath   string
+	ProjectPath string
+	Command     string
+	Status      string
+	IsConductor bool
+	Machine     string
+}
+
+// ConductorBlock is the `[conductors.<name>]` configuration for a conductor,
+// supplied by the caller from the config the binary actually reads.
+type ConductorBlock struct {
+	Name    string
+	Account string
+	Tool    string
+	// Source is the config file the block came from, for the evidence map.
+	Source string
+}
+
+// Options controls one adoption run.
+type Options struct {
+	// Target is a conductor directory, a session id or title, a launchd
+	// plist, or a systemd unit.
+	Target string
+	// ManagerPost is the post name that non-manager roles report to. Empty
+	// means everything reports to the human principal directly.
+	ManagerPost string
+	// Sessions is the local session fleet, used by the session resolver and
+	// to correlate a conductor directory with its live runtime.
+	Sessions []SessionInfo
+	// ConductorBlocks maps conductor name to its config block.
+	ConductorBlocks map[string]ConductorBlock
+	// UnitDirs are searched for a plist or unit that references the target.
+	UnitDirs []string
+	// Machine labels the machine this adoption ran on.
+	Machine string
+	// Now is injected so reports are reproducible under test.
+	Now time.Time
+}
+
+func (o Options) now() time.Time {
+	if o.Now.IsZero() {
+		return time.Now().UTC()
+	}
+	return o.Now.UTC()
+}
+
+// Planned is one definition adoption proposes to write.
+type Planned struct {
+	Name      string            `json:"name"`
+	Post      *Post             `json:"post"`
+	Role      *Role             `json:"role,omitempty"`
+	RoleFiles map[string][]byte `json:"-"`
+	Report    string            `json:"-"`
+	Findings  Findings          `json:"findings,omitempty"`
+}
+
+// Plan is the full result of an adoption. Producing a plan never writes
+// anything; WriteTo is a separate, explicit step.
+type Plan struct {
+	Target      string     `json:"target"`
+	TargetKind  string     `json:"target_kind"`
+	Definitions []*Planned `json:"definitions"`
+	Notes       []string   `json:"notes,omitempty"`
+	SourcePaths []string   `json:"source_paths,omitempty"`
+}
+
+// Adopt introspects a target and produces a plan of disabled definitions.
+//
+// It is strictly read-only with respect to the target: it opens files for
+// reading, stats paths, and reads the session records the caller handed it. It
+// does not unload a plist, edit a unit, move a credential, or touch a live
+// session.
+func Adopt(opts Options) (*Plan, error) {
+	target := strings.TrimSpace(opts.Target)
+	if target == "" {
+		return nil, fmt.Errorf("adopt: empty target")
+	}
+
+	switch detectTargetKind(target) {
+	case "launchd":
+		return adoptLaunchd(target, opts)
+	case "systemd":
+		return adoptSystemd(target, opts)
+	case "conductor-dir":
+		return adoptConductorDir(target, opts)
+	default:
+		return adoptSession(target, opts)
+	}
+}
+
+// detectTargetKind resolves what the user pointed at.
+func detectTargetKind(target string) string {
+	switch strings.ToLower(filepath.Ext(target)) {
+	case ".plist":
+		return "launchd"
+	case ".service", ".timer":
+		return "systemd"
+	}
+	if info, err := os.Stat(target); err == nil && info.IsDir() {
+		return "conductor-dir"
+	}
+	return "session"
+}
+
+// --- conductor directory ------------------------------------------------
+
+// conductorRoleFiles maps a source filename to its portable role filename. The
+// design's migration keeps the useful separation and only renames the entry
+// point.
+var conductorRoleFiles = []struct {
+	source string
+	target string
+	field  string
+}{
+	{"CLAUDE.md", "INSTRUCTIONS.md", "role.spec.entrypoint"},
+	{"AGENTS.md", "INSTRUCTIONS.md", "role.spec.entrypoint"},
+	{"INSTRUCTIONS.md", "INSTRUCTIONS.md", "role.spec.entrypoint"},
+	{"POLICY.md", "POLICY.md", "role.spec.policy[0]"},
+	{"PR-POLICY.md", "PR-POLICY.md", "role.spec.policy[1]"},
+	{"LEARNINGS.md", "LEARNINGS.md", "role.spec.learnings.file"},
+}
+
+func adoptConductorDir(dir string, opts Options) (*Plan, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("adopt conductor dir: %w", err)
+	}
+	name := sanitizeName(filepath.Base(absDir))
+	plan := &Plan{Target: absDir, TargetKind: "conductor-dir"}
+
+	classified := ClassifyRole(filepath.Base(absDir), false)
+	// A directory carrying CLAUDE.md/POLICY.md is conductor-shaped whatever
+	// it is called; the org chart puts conductors at manager.
+	if _, statErr := os.Stat(filepath.Join(absDir, "CLAUDE.md")); statErr == nil && classified.Role == RoleUnresolved {
+		classified = ClassifyResult{
+			Class: ClassAgent, Role: RoleManager, Confidence: ConfidenceMedium,
+			Reason: "directory holds CLAUDE.md, the conductor instruction shape",
+		}
+	}
+
+	post := NewPost(name, postID(name, absDir))
+	post.Spec.Classification = classified.Class
+	post.Spec.AdoptedFrom = absDir
+	post.Spec.AdoptedAt = opts.now()
+	post.Spec.Placement.Machine = opts.Machine
+	post.Spec.Placement.Project = absDir
+	post.Spec.Placement.ReportsTo = ReportsToFor(classified.Role, opts.ManagerPost)
+	post.AddInference("spec.classification", string(classified.Class), absDir, classified.Confidence, classified.Reason)
+	post.AddInference("spec.role.name", classified.Role, absDir, classified.Confidence, classified.Reason)
+	post.AddEvidence("spec.placement.project", absDir, "adoption target path", ConfidenceHigh, "")
+
+	role := NewRole(classified.Role, "0.1.0")
+	role.Spec.RequiresAgentDeck = ">=1.14.0"
+	role.Spec.Description = "adopted from " + filepath.Base(absDir)
+	role.Spec.Digests = map[string]string{}
+	roleFiles := map[string][]byte{}
+	var findings Findings
+	var sourcePaths []string
+
+	seenTargets := map[string]bool{}
+	for _, mapping := range conductorRoleFiles {
+		sourcePath := filepath.Join(absDir, mapping.source)
+		body, readErr := readCapped(sourcePath)
+		if readErr != nil {
+			continue
+		}
+		if seenTargets[mapping.target] {
+			continue
+		}
+		seenTargets[mapping.target] = true
+		sourcePaths = append(sourcePaths, sourcePath)
+		roleFiles[mapping.target] = body
+		role.Spec.Digests[mapping.target] = Digest(body)
+		findings = append(findings, ValidateRoleContent("role/"+mapping.target, string(body))...)
+
+		switch {
+		case mapping.target == "INSTRUCTIONS.md":
+			role.Spec.Entrypoint = "INSTRUCTIONS.md"
+		case mapping.target == "LEARNINGS.md":
+			role.Spec.Learnings = &LearningsSpec{File: "LEARNINGS.md", Promotion: "reviewed-version-change"}
+		default:
+			role.Spec.Policy = append(role.Spec.Policy, mapping.target)
+		}
+		post.AddEvidence("role."+mapping.target, mapping.source, sourcePath, ConfidenceHigh, "")
+	}
+	sort.Strings(role.Spec.Policy)
+
+	// workflows/ becomes named workflows, verbatim. The design is explicit
+	// that a workflow is the user's Markdown, not a DSL we translate it into.
+	workflowDir := filepath.Join(absDir, "workflows")
+	if entries, dirErr := os.ReadDir(workflowDir); dirErr == nil {
+		role.Spec.Workflows = map[string]string{}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+				continue
+			}
+			sourcePath := filepath.Join(workflowDir, entry.Name())
+			body, readErr := readCapped(sourcePath)
+			if readErr != nil {
+				findings.warnf("role/workflows/"+entry.Name(), "%v", readErr)
+				continue
+			}
+			rel := filepath.Join("workflows", entry.Name())
+			workflowName := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+			role.Spec.Workflows[workflowName] = rel
+			roleFiles[rel] = body
+			role.Spec.Digests[rel] = Digest(body)
+			sourcePaths = append(sourcePaths, sourcePath)
+			findings = append(findings, ValidateRoleContent("role/"+rel, string(body))...)
+		}
+	}
+
+	if role.Spec.Entrypoint == "" {
+		post.AddUnresolved("no instruction file found; the role has no entry point yet")
+	}
+
+	// Correlate the live runtime, the config block, and any unit that fires it.
+	applyConductorBindings(post, absDir, name, opts, &sourcePaths)
+
+	post.Spec.Role = RoleRef{Name: classified.Role, Path: "./" + RoleDirName, Version: role.Metadata.Version}
+	if classified.Role == RoleUnresolved {
+		post.AddUnresolved("role is unresolved; a human must say what this agent is for")
+	}
+	post.Spec.SourceFingerprint = FingerprintPaths(sourcePaths)
+
+	planned := &Planned{Name: name, Post: post, Role: role, RoleFiles: roleFiles}
+	planned.Findings = append(findings, ValidateDefinition(post, role)...)
+	planned.Report = renderReport(planned, plan.TargetKind, absDir, classified)
+	plan.Definitions = append(plan.Definitions, planned)
+	plan.SourcePaths = sourcePaths
+
+	if pair := PairFor(classified.Role); pair != "" {
+		plan.Notes = append(plan.Notes, fmt.Sprintf(
+			"role %s is half of a pair; its %s seat is unfilled on this machine", classified.Role, pair))
+	}
+	return plan, nil
+}
+
+// applyConductorBindings folds the config block, the live session, and any
+// firing unit into a conductor post.
+func applyConductorBindings(post *Post, absDir, name string, opts Options, sourcePaths *[]string) {
+	if block, ok := opts.ConductorBlocks[name]; ok {
+		if block.Account != "" {
+			post.Spec.Runtime.Account = block.Account
+			post.AddEvidence("spec.runtime.account", block.Account, block.Source, ConfidenceHigh, "")
+		}
+		if block.Tool != "" {
+			post.Spec.Runtime.Harness = block.Tool
+			post.AddEvidence("spec.runtime.harness", block.Tool, block.Source, ConfidenceHigh, "")
+		}
+	}
+
+	for _, s := range opts.Sessions {
+		if !sessionMatchesConductor(s, name, absDir) {
+			continue
+		}
+		post.Spec.Runtime.AdoptedSessionID = s.ID
+		post.Metadata.Title = s.Title
+		post.AddEvidence("spec.runtime.adoptedSessionId", s.ID, "agent-deck session record", ConfidenceHigh,
+			"provenance only; phase 1 does not take the session over")
+		if post.Spec.Runtime.Harness == "" && s.Tool != "" {
+			post.Spec.Runtime.Harness = s.Tool
+			post.AddEvidence("spec.runtime.harness", s.Tool, "agent-deck session record", ConfidenceHigh, "")
+		}
+		if post.Spec.Runtime.Account == "" && s.Account != "" {
+			post.Spec.Runtime.Account = s.Account
+			post.AddEvidence("spec.runtime.account", s.Account, "agent-deck session record", ConfidenceHigh, "")
+		}
+		if s.GroupPath != "" {
+			post.Spec.Placement.Group = s.GroupPath
+			post.AddEvidence("spec.placement.group", s.GroupPath, "agent-deck session record", ConfidenceHigh, "")
+		}
+		break
+	}
+
+	for _, unit := range findRelatedUnits(name, opts.UnitDirs) {
+		*sourcePaths = append(*sourcePaths, unit.Path)
+		applyUnitToPost(post, unit)
+	}
+}
+
+func sessionMatchesConductor(s SessionInfo, name, dir string) bool {
+	if s.IsConductor && sanitizeName(s.Title) == name {
+		return true
+	}
+	if s.ProjectPath != "" && filepath.Clean(s.ProjectPath) == filepath.Clean(dir) {
+		return true
+	}
+	return sanitizeName(s.Title) == name
+}
+
+// findRelatedUnits scans the caller's unit directories for a plist or unit
+// whose name refers to the target. It reads; it never loads or unloads.
+func findRelatedUnits(name string, dirs []string) []*LaunchSource {
+	var found []*LaunchSource
+	matcher, err := unitNameMatcher(name)
+	if err != nil {
+		return nil
+	}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			lower := strings.ToLower(entry.Name())
+			if !matcher.MatchString(unitStem(lower)) {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			var (
+				src *LaunchSource
+				err error
+			)
+			switch {
+			case strings.HasSuffix(lower, ".plist"):
+				src, err = ParseLaunchdPlist(path)
+			case strings.HasSuffix(lower, ".service"), strings.HasSuffix(lower, ".timer"):
+				src, err = ParseSystemdUnit(path)
+			default:
+				continue
+			}
+			if err == nil && src != nil {
+				found = append(found, src)
+			}
+		}
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].Path < found[j].Path })
+	return dropPairedTimers(found)
+}
+
+// dropPairedTimers removes a systemd .timer whose sibling .service was also
+// found. ParseSystemdUnit already folds a paired timer's schedule into its
+// service, so keeping both would emit the same firing twice — once as
+// "x.service" and once as "x.timer" — and a fleet view that double-counts a
+// schedule is worse than one that misses it.
+func dropPairedTimers(sources []*LaunchSource) []*LaunchSource {
+	services := map[string]bool{}
+	for _, src := range sources {
+		if strings.HasSuffix(src.Path, ".service") {
+			services[strings.TrimSuffix(src.Path, ".service")] = true
+		}
+	}
+	kept := make([]*LaunchSource, 0, len(sources))
+	for _, src := range sources {
+		if strings.HasSuffix(src.Path, ".timer") && services[strings.TrimSuffix(src.Path, ".timer")] {
+			continue
+		}
+		kept = append(kept, src)
+	}
+	return kept
+}
+
+// applyUnitToPost turns a firing unit into declared, external, disabled
+// triggers on the post.
+func applyUnitToPost(post *Post, unit *LaunchSource) {
+	base := sanitizeName(unit.Label)
+	switch {
+	case unit.CalendarSpec != "":
+		// launchd already produced cron; systemd produces OnCalendar syntax,
+		// which only sometimes has an exact cron equivalent. A spec that
+		// cannot be converted is recorded verbatim as an opaque trigger so
+		// the row shows the real schedule text instead of a cron expression
+		// that would never parse.
+		trigger := Trigger{
+			Name: base + "-calendar", Type: TriggerCron, Schedule: unit.CalendarSpec,
+			Enabled: false, External: true, ExternalSource: unit.Path,
+			Deliver: fixedDeliveryFor(post.Spec.Role.Name),
+		}
+		note := "the unit still owns this firing; agent-deck only displays it"
+		if unit.Kind == "systemd" {
+			if converted, ok := SystemdCalendarToCron(unit.CalendarSpec); ok {
+				trigger.Schedule = converted
+			} else {
+				trigger.Type = TriggerOpaque
+				note = "OnCalendar=" + unit.CalendarSpec + " has no exact cron equivalent; no next-due time is computed"
+			}
+		}
+		post.Spec.Triggers = append(post.Spec.Triggers, trigger)
+		post.AddEvidence("spec.triggers."+base+"-calendar", unit.CalendarSpec, unit.Path, ConfidenceHigh, note)
+	case unit.IntervalSeconds > 0:
+		post.Spec.Triggers = append(post.Spec.Triggers, Trigger{
+			Name: base + "-interval", Type: TriggerCron, IntervalSeconds: unit.IntervalSeconds,
+			Enabled: false, External: true, ExternalSource: unit.Path,
+			Deliver: fixedDeliveryFor(post.Spec.Role.Name),
+		})
+		post.AddEvidence("spec.triggers."+base+"-interval", fmt.Sprintf("every %ds", unit.IntervalSeconds), unit.Path,
+			ConfidenceHigh, "a poll cadence is not proof of the desired business cadence")
+	case unit.KeepAlive:
+		post.Spec.Triggers = append(post.Spec.Triggers, Trigger{
+			Name: base + "-keepalive", Type: TriggerOpaque,
+			Enabled: false, External: true, ExternalSource: unit.Path,
+		})
+		post.AddEvidence("spec.triggers."+base+"-keepalive", "KeepAlive", unit.Path, ConfidenceHigh,
+			"kept alive by the launcher rather than fired on a schedule")
+	}
+
+	if unit.RestartMode != "" {
+		post.Spec.RestartPolicy = &RestartPolicy{Mode: unit.RestartMode}
+		post.AddEvidence("spec.restartPolicy.mode", unit.RestartMode, unit.Path, ConfidenceHigh, "")
+	}
+	for _, key := range unit.EnvKeys {
+		if secretPattern.MatchString(key) {
+			post.AddUnresolved("unit " + filepath.Base(unit.Path) + " depends on environment key " + key +
+				"; bind it as a connector credential rather than copying the value")
+		}
+	}
+	for _, envFile := range unit.EnvFiles {
+		post.AddUnresolved("unit " + filepath.Base(unit.Path) + " reads env file " + envFile +
+			"; its contents were not read and must not be copied into a definition")
+	}
+	for _, warning := range unit.Warnings {
+		post.AddEvidence("source."+filepath.Base(unit.Path), "", unit.Path, ConfidenceLow, warning)
+	}
+}
+
+// fixedDeliveryFor returns the fixed, locally declared delivery string for a
+// role. It is a constant per role by construction — no source content can
+// reach it, which is the injection invariant expressed as code.
+func fixedDeliveryFor(role string) string {
+	switch role {
+	case RoleManager:
+		return "MANAGER CYCLE: run one supervision cycle, update status, then end the turn."
+	case RoleBuilder:
+		return "BUILDER CYCLE: pick up the next assigned item, do bounded work, then end the turn."
+	case RoleReviewer:
+		return "REVIEW CYCLE: review what is waiting, record a verdict, then end the turn."
+	case RoleTriage:
+		return "TRIAGE: new work may be waiting; check the source through its connector and triage it."
+	case RoleDevOps:
+		return "DEVOPS CYCLE: check deployment and infrastructure state, then end the turn."
+	case RoleRegistrar:
+		return "REGISTRAR CYCLE: reconcile the registry with reality, then end the turn."
+	default:
+		return "CYCLE: run one cycle of your declared workflow, then end the turn."
+	}
+}
+
+// --- launchd / systemd targets -----------------------------------------
+
+func adoptLaunchd(path string, opts Options) (*Plan, error) {
+	src, err := ParseLaunchdPlist(path)
+	if err != nil {
+		return nil, err
+	}
+	return planFromUnit(src, opts)
+}
+
+func adoptSystemd(path string, opts Options) (*Plan, error) {
+	src, err := ParseSystemdUnit(path)
+	if err != nil {
+		return nil, err
+	}
+	return planFromUnit(src, opts)
+}
+
+func planFromUnit(src *LaunchSource, opts Options) (*Plan, error) {
+	name := sanitizeName(src.Label)
+	plan := &Plan{Target: src.Path, TargetKind: src.Kind, SourcePaths: []string{src.Path}}
+
+	classified := ClassifyLaunchSource(src)
+	post := NewPost(name, postID(name, src.Path))
+	post.Spec.Classification = classified.Class
+	post.Spec.AdoptedFrom = src.Path
+	post.Spec.AdoptedAt = opts.now()
+	post.Spec.Placement.Machine = opts.Machine
+	post.Spec.Placement.Project = src.WorkingDirectory
+	post.Spec.Role = RoleRef{Name: classified.Role}
+	post.Spec.Placement.ReportsTo = ReportsToFor(classified.Role, opts.ManagerPost)
+
+	post.AddInference("spec.classification", string(classified.Class), src.Path, classified.Confidence, classified.Reason)
+	post.AddInference("spec.role.name", classified.Role, src.Path, classified.Confidence, classified.Reason)
+	if src.Program != "" {
+		post.AddEvidence("source.program", src.Program, src.Path, ConfidenceHigh, "")
+	}
+	if src.WorkingDirectory != "" {
+		post.AddEvidence("spec.placement.project", src.WorkingDirectory, src.Path, ConfidenceHigh, "")
+	}
+
+	applyUnitToPost(post, src)
+
+	// A connector-classified unit gets a connector reference with the local
+	// freshness evidence we can actually check later.
+	if classified.Class == ClassConnector {
+		connector := ConnectorRef{
+			Name: name, Kind: connectorKindFor(src),
+			EvidencePath: connectorEvidencePath(src),
+		}
+		post.Spec.Connectors = append(post.Spec.Connectors, connector)
+		post.AddEvidence("spec.connectors[0].name", connector.Name, src.Path, ConfidenceMedium,
+			"naming a connector never creates or enables one")
+	}
+
+	switch classified.Class {
+	case ClassDebris:
+		post.AddUnresolved("this unit's program is missing; decide whether to remove the unit")
+	case ClassExternal, ClassConnector, ClassService:
+		post.AddUnresolved("adopted for visibility; agent-deck does not control this")
+	}
+	if classified.Role == RoleUnresolved {
+		post.AddUnresolved("role is unresolved; a human must say what this does before it can be hired")
+	}
+	post.Spec.SourceFingerprint = FingerprintPaths(plan.SourcePaths)
+
+	planned := &Planned{Name: name, Post: post}
+	planned.Findings = ValidateDefinition(post, nil)
+	planned.Report = renderReport(planned, plan.TargetKind, src.Path, classified)
+	plan.Definitions = append(plan.Definitions, planned)
+	for _, warning := range src.Warnings {
+		plan.Notes = append(plan.Notes, warning)
+	}
+	return plan, nil
+}
+
+func connectorKindFor(src *LaunchSource) string {
+	joined := strings.ToLower(src.Label + " " + strings.Join(src.Arguments, " "))
+	switch {
+	case strings.Contains(joined, "imap"), strings.Contains(joined, "mail"), strings.Contains(joined, "gmail"):
+		return "mail"
+	case strings.Contains(joined, "telegram"):
+		return "telegram"
+	case strings.Contains(joined, "slack"):
+		return "slack"
+	case strings.Contains(joined, "webhook"):
+		return "webhook"
+	default:
+		return "unknown"
+	}
+}
+
+// connectorEvidencePath guesses where this connector leaves a freshness trace.
+// A guess that turns out to be absent is reported as UNKNOWN health later, not
+// as a failure — the difference between "quiet" and "not looking" is the whole
+// point of the health row.
+func connectorEvidencePath(src *LaunchSource) string {
+	if src.WorkingDirectory != "" {
+		return src.WorkingDirectory
+	}
+	if src.Program != "" && strings.ContainsAny(src.Program, "/\\") {
+		return filepath.Dir(src.Program)
+	}
+	return ""
+}
+
+// --- session target -----------------------------------------------------
+
+func adoptSession(target string, opts Options) (*Plan, error) {
+	var match *SessionInfo
+	for i := range opts.Sessions {
+		s := opts.Sessions[i]
+		if s.ID == target || strings.EqualFold(s.Title, target) {
+			match = &opts.Sessions[i]
+			break
+		}
+	}
+	if match == nil {
+		return nil, fmt.Errorf("adopt: no session, directory, plist or unit matches %q", target)
+	}
+
+	name := sanitizeName(match.Title)
+	if name == "" {
+		name = sanitizeName(match.ID)
+	}
+	plan := &Plan{Target: target, TargetKind: "session"}
+
+	classified := ClassifyRole(match.Title, match.IsConductor)
+	post := NewPost(name, postID(name, match.ID))
+	post.Metadata.Title = match.Title
+	post.Spec.Classification = classified.Class
+	post.Spec.AdoptedFrom = "session:" + match.ID
+	post.Spec.AdoptedAt = opts.now()
+	post.Spec.Role = RoleRef{Name: classified.Role}
+	post.Spec.Placement = Placement{
+		Project:   match.ProjectPath,
+		Group:     match.GroupPath,
+		Machine:   firstNonEmpty(match.Machine, opts.Machine),
+		ReportsTo: ReportsToFor(classified.Role, opts.ManagerPost),
+	}
+	post.Spec.Runtime = RuntimeSpec{
+		Harness:          match.Tool,
+		Account:          match.Account,
+		AdoptedSessionID: match.ID,
+	}
+
+	post.AddInference("spec.classification", string(classified.Class), "agent-deck session record", classified.Confidence, classified.Reason)
+	post.AddInference("spec.role.name", classified.Role, "session title "+match.Title, classified.Confidence, classified.Reason)
+	post.AddEvidence("spec.runtime.harness", match.Tool, "agent-deck session record", ConfidenceHigh, "")
+	post.AddEvidence("spec.runtime.adoptedSessionId", match.ID, "agent-deck session record", ConfidenceHigh,
+		"provenance only; the session keeps its own id, title and lifecycle")
+	if match.Account != "" {
+		post.AddEvidence("spec.runtime.account", match.Account, "agent-deck session record", ConfidenceHigh, "")
+	}
+	if match.GroupPath != "" {
+		post.AddEvidence("spec.placement.group", match.GroupPath, "agent-deck session record", ConfidenceHigh, "")
+	}
+
+	// A watcher usually references a poller directory in its command. Record
+	// it as a connector with a freshness path, and nothing more.
+	if dir := pollerDirFromCommand(match.Command); dir != "" {
+		post.Spec.Connectors = append(post.Spec.Connectors, ConnectorRef{
+			Name: sanitizeName(filepath.Base(dir)), Kind: "unknown", EvidencePath: dir,
+		})
+		post.AddEvidence("spec.connectors[0].evidencePath", dir, "session command line", ConfidenceMedium,
+			"inferred from the command; confirm before binding")
+	}
+
+	sourcePaths := []string{}
+	for _, unit := range findRelatedUnits(name, opts.UnitDirs) {
+		sourcePaths = append(sourcePaths, unit.Path)
+		applyUnitToPost(post, unit)
+	}
+	post.Spec.SourceFingerprint = FingerprintPaths(sourcePaths)
+
+	if classified.Role == RoleUnresolved {
+		post.AddUnresolved("role is unresolved; a human must say what this session is for")
+	}
+	post.AddUnresolved("no role content was recovered from a live session; supply instructions or adopt its directory")
+
+	planned := &Planned{Name: name, Post: post}
+	planned.Findings = ValidateDefinition(post, nil)
+	planned.Report = renderReport(planned, plan.TargetKind, "session:"+match.ID, classified)
+	plan.Definitions = append(plan.Definitions, planned)
+	plan.SourcePaths = sourcePaths
+
+	if pair := PairFor(classified.Role); pair != "" {
+		plan.Notes = append(plan.Notes, fmt.Sprintf(
+			"role %s is half of a pair; its %s seat is unfilled", classified.Role, pair))
+	}
+	return plan, nil
+}
+
+var pollerDirPattern = regexp.MustCompile(`(/[\w.\-/]*(?:poll|imap|watch|bridge)[\w.\-/]*)`)
+
+func pollerDirFromCommand(command string) string {
+	match := pollerDirPattern.FindString(command)
+	if match == "" {
+		return ""
+	}
+	if info, err := os.Stat(match); err == nil {
+		if info.IsDir() {
+			return match
+		}
+		return filepath.Dir(match)
+	}
+	return ""
+}
+
+// --- writing ------------------------------------------------------------
+
+// WriteTo writes every definition in the plan under root and returns the
+// directories written. It refuses to overwrite an existing definition, so a
+// re-run cannot silently clobber a definition a human has edited.
+func (p *Plan) WriteTo(root string) ([]string, error) {
+	var written []string
+	for _, def := range p.Definitions {
+		dir := filepath.Join(root, def.Name)
+		if _, err := os.Stat(filepath.Join(dir, PostFileName)); err == nil {
+			return written, fmt.Errorf("definition %q already exists at %s; remove it or adopt under a different name", def.Name, dir)
+		}
+		if err := Write(dir, def.Post, def.Role, def.RoleFiles, def.Report); err != nil {
+			return written, err
+		}
+		written = append(written, dir)
+	}
+	return written, nil
+}
+
+// --- helpers ------------------------------------------------------------
+
+func readCapped(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory", path)
+	}
+	if info.Size() > maxRoleFileBytes {
+		return nil, fmt.Errorf("%s is %d bytes, over the %d byte role-file cap; not copied",
+			filepath.Base(path), info.Size(), maxRoleFileBytes)
+	}
+	return os.ReadFile(path)
+}
+
+// unitNameMatcher matches a unit whose name refers to the post, at a token
+// boundary rather than anywhere in the string.
+//
+// Plain substring matching is wrong here: "gmail-watcher.plist" contains
+// "mail-watcher", so a mail-watcher post silently inherited a different
+// agent's schedule and displayed it as its own. A boundary is any character
+// that is not a letter or digit, which still matches the real-world reverse
+// DNS shapes ("com.ashesh.gmail-watcher.plist") and the bare stem
+// ("repo-maintainer.service").
+func unitNameMatcher(name string) (*regexp.Regexp, error) {
+	needle := regexp.QuoteMeta(strings.ToLower(strings.TrimSpace(name)))
+	if needle == "" {
+		return nil, fmt.Errorf("empty unit name")
+	}
+	return regexp.Compile(`(^|[^a-z0-9])` + needle + `([^a-z0-9]|$)`)
+}
+
+// unitStem strips the unit suffix so the boundary check sees the name only.
+func unitStem(fileName string) string {
+	for _, suffix := range []string{".plist", ".service", ".timer"} {
+		if strings.HasSuffix(fileName, suffix) {
+			return strings.TrimSuffix(fileName, suffix)
+		}
+	}
+	return fileName
+}
+
+var unsafeNameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func sanitizeName(raw string) string {
+	cleaned := unsafeNameChars.ReplaceAllString(strings.TrimSpace(raw), "-")
+	cleaned = strings.Trim(cleaned, "-._")
+	if cleaned == "" {
+		return ""
+	}
+	if len(cleaned) > 64 {
+		cleaned = cleaned[:64]
+	}
+	return strings.ToLower(cleaned)
+}
+
+// postID is stable for a given (name, source) pair so re-adopting the same
+// target does not mint a new identity.
+func postID(name, source string) string {
+	digest := Digest([]byte(name + "\x00" + source))
+	return "post-" + strings.TrimPrefix(digest, "sha256:")[:16]
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// renderReport writes the evidence map. Every generated field appears here
+// with where it came from and how much to trust it.
+func renderReport(def *Planned, targetKind, target string, classified ClassifyResult) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Adoption report: %s\n\n", def.Name)
+	fmt.Fprintf(&sb, "- target: `%s`\n", target)
+	fmt.Fprintf(&sb, "- target kind: %s\n", targetKind)
+	fmt.Fprintf(&sb, "- post id: `%s`\n", def.Post.Metadata.PostID)
+	fmt.Fprintf(&sb, "- classification: **%s** (%s confidence)\n", def.Post.Spec.Classification, classified.Confidence)
+	fmt.Fprintf(&sb, "- role: **%s** — %s\n", def.Post.Spec.Role.Name, classified.Reason)
+	fmt.Fprintf(&sb, "- reports to: `%s`\n", def.Post.Spec.Placement.ReportsTo)
+	fmt.Fprintf(&sb, "- source fingerprint: `%s`\n\n", def.Post.Spec.SourceFingerprint)
+
+	sb.WriteString("This definition is **disabled**. Nothing in it fires. ")
+	sb.WriteString("The source automation was read, never modified, and still owns every trigger listed below.\n\n")
+
+	sb.WriteString("## Where each generated field came from\n\n")
+	sb.WriteString("| field | value | source | confidence | note |\n")
+	sb.WriteString("|---|---|---|---|---|\n")
+	for _, e := range def.Post.Spec.Provenance {
+		note := e.Reason
+		if e.Warning != "" {
+			// A warning is louder than a derivation note, so it wins the
+			// column and is marked as the caution it is.
+			note = "warning: " + e.Warning
+		}
+		fmt.Fprintf(&sb, "| `%s` | %s | `%s` | %s | %s |\n",
+			e.Field, mdCell(e.Value), e.Source, e.Confidence, mdCell(note))
+	}
+	sb.WriteString("\n")
+
+	if len(def.Post.Spec.Triggers) > 0 {
+		sb.WriteString("## Declared triggers (display only)\n\n")
+		sb.WriteString("| name | kind | schedule | owned by |\n|---|---|---|---|\n")
+		for _, t := range def.Post.Spec.Triggers {
+			schedule := t.Schedule
+			if schedule == "" && t.IntervalSeconds > 0 {
+				schedule = "every " + strconv.Itoa(t.IntervalSeconds) + "s"
+			}
+			fmt.Fprintf(&sb, "| %s | %s | %s | `%s` |\n", t.Name, t.Type, mdCell(schedule), t.ExternalSource)
+		}
+		sb.WriteString("\nagent-deck renders the next due time for these. It does not schedule them.\n\n")
+	}
+
+	if len(def.Post.Spec.Unresolved) > 0 {
+		sb.WriteString("## Unresolved — a human owes this definition an answer\n\n")
+		for _, item := range def.Post.Spec.Unresolved {
+			fmt.Fprintf(&sb, "- %s\n", item)
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(def.Findings) > 0 {
+		sb.WriteString("## Validation\n\n")
+		for _, f := range def.Findings {
+			fmt.Fprintf(&sb, "- **%s** `%s`: %s\n", f.Severity, f.Field, f.Message)
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Rollback\n\n")
+	fmt.Fprintf(&sb, "Delete the definition directory. The source at `%s` was never modified, ", target)
+	sb.WriteString("so there is nothing else to undo.\n")
+	return sb.String()
+}
+
+func mdCell(value string) string {
+	cleaned := strings.ReplaceAll(value, "|", "\\|")
+	cleaned = strings.ReplaceAll(cleaned, "\n", " ")
+	if cleaned == "" {
+		return "—"
+	}
+	if len(cleaned) > 120 {
+		cleaned = cleaned[:117] + "..."
+	}
+	return cleaned
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1195,3 +1195,53 @@ func TestAttentionNamesBothInvariantAndConnector(t *testing.T) {
 		t.Errorf("attention %q hides the dead connector behind the schema complaint", attention)
 	}
 }
+
+// --- regressions from review round 3 ---------------------------------------
+
+// A legitimate manager reference must not be reported as unknown, and a real
+// cycle must reach the row's attention (and therefore the "need attention"
+// count) rather than living only in --json.
+func TestReportsToFindingsNeedTheWholeSet(t *testing.T) {
+	mgr := NewPost("mgr", "post-mgr")
+	mgr.Spec.Classification = ClassAgent
+	mgr.Spec.Role = RoleRef{Name: RoleManager}
+	mgr.Spec.Placement.ReportsTo = PrincipalHuman
+
+	wrk := NewPost("wrk", "post-wrk")
+	wrk.Spec.Classification = ClassAgent
+	wrk.Spec.Role = RoleRef{Name: RoleBuilder}
+	wrk.Spec.Placement.ReportsTo = "mgr"
+
+	full := BuildView(BuildOptions{
+		Definitions:  []*Definition{{Name: "mgr", Post: mgr}, {Name: "wrk", Post: wrk}},
+		LocalMachine: "g14", Now: time.Now(), SkipHealth: true,
+	})
+	for _, row := range full.Machines[0].Agents {
+		if row.ReportsToIssue != "" {
+			t.Errorf("%s warned about a manager that is in the same registry: %s", row.Name, row.ReportsToIssue)
+		}
+	}
+
+	// A real cycle must be loud in the list, not just in JSON.
+	a := NewPost("cyc-a", "post-a")
+	a.Spec.Classification = ClassAgent
+	a.Spec.Role = RoleRef{Name: RoleTriage}
+	a.Spec.Placement.ReportsTo = "cyc-b"
+	b := NewPost("cyc-b", "post-b")
+	b.Spec.Classification = ClassAgent
+	b.Spec.Role = RoleRef{Name: RoleManager}
+	b.Spec.Placement.ReportsTo = "cyc-a"
+
+	cycle := BuildView(BuildOptions{
+		Definitions:  []*Definition{{Name: "cyc-a", Post: a}, {Name: "cyc-b", Post: b}},
+		LocalMachine: "g14", Now: time.Now(), SkipHealth: true,
+	})
+	if cycle.NeedAttention == 0 {
+		t.Error("a reports_to cycle produced no attention; the list would show nothing")
+	}
+	for _, row := range cycle.Machines[0].Agents {
+		if row.Attention == "" {
+			t.Errorf("%s: a cycle is invisible on the row", row.Name)
+		}
+	}
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -754,3 +754,324 @@ func minimalPlist(label string) string {
 </plist>
 `
 }
+
+// --- regressions from the phase-1 adversarial review ------------------------
+
+// A running unit whose ExecStart uses %h must not be called debris. Three of
+// the six real user units on g14 do this, and debris is the one label that
+// invites a human to delete something.
+func TestSystemdSpecifierPathIsNotDebris(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(binDir, "ios"), "#!/bin/sh\n")
+
+	dir := t.TempDir()
+	service := filepath.Join(dir, "go-ios-tunnel.service")
+	writeTestFile(t, service, "[Service]\nExecStart=%h/bin/ios tunnel start --userspace\n")
+
+	src, err := ParseSystemdUnit(service)
+	if err != nil {
+		t.Fatalf("ParseSystemdUnit: %v", err)
+	}
+	if src.Program != filepath.Join(home, "bin", "ios") {
+		t.Errorf("Program = %q, want %%h expanded to the home dir", src.Program)
+	}
+	if got := src.ProgramStatus(); got != ProgramPresent {
+		t.Errorf("ProgramStatus = %q, want %q", got, ProgramPresent)
+	}
+	if got := ClassifyLaunchSource(src); got.Class == ClassDebris {
+		t.Errorf("a running unit classified as debris: %+v", got)
+	}
+}
+
+// A specifier this reader does NOT expand leaves the path unresolved, and an
+// unresolved path is unknown — never missing.
+func TestUnexpandedSpecifierIsUnknownNotMissing(t *testing.T) {
+	dir := t.TempDir()
+	service := filepath.Join(dir, "tmpl@.service")
+	writeTestFile(t, service, "[Service]\nExecStart=%t/run/%i/helper\n")
+
+	src, err := ParseSystemdUnit(service)
+	if err != nil {
+		t.Fatalf("ParseSystemdUnit: %v", err)
+	}
+	if got := src.ProgramStatus(); got != ProgramUnknown {
+		t.Errorf("ProgramStatus = %q, want %q for an unexpanded specifier", got, ProgramUnknown)
+	}
+	if got := ClassifyLaunchSource(src); got.Class == ClassDebris {
+		t.Errorf("an unresolvable path classified as debris: %+v", got)
+	}
+}
+
+// Credentials in an adopted role body must never be copied into the registry,
+// including the shapes a prefix-only detector misses.
+func TestAdoptDoesNotCopyCredentialBearingRoleBody(t *testing.T) {
+	source := t.TempDir()
+	writeTestFile(t, filepath.Join(source, "CLAUDE.md"), strings.Join([]string{
+		"You are the release conductor.",
+		"Login to imap.gmail.com with the app password abcd efgh ijkl mnop",
+		"The API key for the bridge is 7f3a-91b2-cc40",
+		"GMAIL_APP_PASSWORD=abcd efgh ijkl mnop",
+		"export SLACK_TOKEN=xoxb-4242424242-abcdefgh",
+	}, "\n"))
+	writeTestFile(t, filepath.Join(source, "POLICY.md"),
+		"Never put a token or password in a role directory. Escalate on ambiguity.\n")
+
+	plan, err := Adopt(Options{Target: source, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	def := plan.Definitions[0]
+
+	if _, copied := def.RoleFiles["INSTRUCTIONS.md"]; copied {
+		t.Error("a credential-bearing body was copied into the role")
+	}
+	// The policy file only TALKS about tokens; it must still be adopted.
+	if _, copied := def.RoleFiles["POLICY.md"]; !copied {
+		t.Error("prose about credentials was mistaken for a credential")
+	}
+	// Write it out and prove no secret material reaches disk.
+	root := t.TempDir()
+	if _, err := plan.WriteTo(root); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	var found []string
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		for _, secret := range []string{"xoxb-", "abcd efgh", "7f3a-91b2"} {
+			if strings.Contains(string(body), secret) {
+				found = append(found, path+" contains "+secret)
+			}
+		}
+		return nil
+	})
+	if len(found) > 0 {
+		t.Errorf("secret material reached the registry: %v", found)
+	}
+	// And the definition says why the file is absent.
+	if len(def.Post.Spec.Unresolved) == 0 ||
+		!strings.Contains(strings.Join(def.Post.Spec.Unresolved, " "), "credential") {
+		t.Errorf("no unresolved entry explains the missing file: %v", def.Post.Spec.Unresolved)
+	}
+}
+
+func TestScanForCredentialsShapes(t *testing.T) {
+	catches := []string{
+		"Login with the app password abcd efgh ijkl mnop",
+		"The API key for the bridge is 7f3a-91b2-cc40",
+		"GMAIL_APP_PASSWORD=abcd efgh ijkl mnop",
+		"export SLACK_TOKEN=xoxb-4242424242-abcdefgh",
+		"token: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"-----BEGIN RSA PRIVATE KEY-----",
+	}
+	for _, line := range catches {
+		if len(ScanForCredentials(line)) == 0 {
+			t.Errorf("ScanForCredentials missed: %q", line)
+		}
+	}
+
+	// Policy prose must not be mistaken for a leak.
+	clean := []string{
+		"Never put a token or password in a role directory.",
+		"Ask the user for the API key rather than storing it.",
+		"Escalate to the human on ambiguity.",
+		"Run the pr-review workflow before merging.",
+	}
+	for _, line := range clean {
+		if lines := ScanForCredentials(line); len(lines) != 0 {
+			t.Errorf("ScanForCredentials false-positived on: %q", line)
+		}
+	}
+}
+
+// launchd ANDs Day and Weekday; cron ORs them. No cron string is correct, so
+// none is emitted.
+func TestLaunchdDayAndWeekdayProducesNoSchedule(t *testing.T) {
+	dir := t.TempDir()
+	plist := filepath.Join(dir, "monthly-monday.plist")
+	writeTestFile(t, plist, `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>monthly-monday</string>
+  <key>ProgramArguments</key><array><string>/bin/true</string></array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Day</key><integer>1</integer>
+    <key>Weekday</key><integer>1</integer>
+    <key>Hour</key><integer>3</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+</dict>
+</plist>
+`)
+	src, err := ParseLaunchdPlist(plist)
+	if err != nil {
+		t.Fatalf("ParseLaunchdPlist: %v", err)
+	}
+	if src.CalendarSpec != "" {
+		t.Errorf("CalendarSpec = %q, want empty: launchd ANDs Day and Weekday, cron ORs them", src.CalendarSpec)
+	}
+	if len(src.Warnings) == 0 {
+		t.Error("no warning explains why no schedule was produced")
+	}
+}
+
+// An uncontacted machine must not be reported as a healthy link, and a post
+// placed elsewhere must not be resolved against the LOCAL session index.
+func TestBuildViewNeverClaimsLinkOKForUncontactedMachine(t *testing.T) {
+	post := NewPost("mac-thing", "post-m")
+	post.Spec.Classification = ClassAgent
+	post.Spec.Role = RoleRef{Name: RoleTriage}
+	post.Spec.Placement.Machine = "mac-studio"
+	post.Spec.Runtime.AdoptedSessionID = "sess-elsewhere"
+
+	view := BuildView(BuildOptions{
+		Definitions:   []*Definition{{Name: "mac-thing", Post: post}},
+		SessionStates: map[string]SessionState{},
+		LocalMachine:  "g14",
+		Now:           time.Now(),
+		SkipHealth:    true,
+	})
+	if len(view.Machines) != 1 {
+		t.Fatalf("machines = %d, want 1", len(view.Machines))
+	}
+	if view.Machines[0].Link != LinkNotContacted {
+		t.Errorf("link = %q, want %q — nothing was contacted", view.Machines[0].Link, LinkNotContacted)
+	}
+	if got := view.Machines[0].Agents[0].State; got != RunUnknown {
+		t.Errorf("state = %q, want %q: a remote post cannot be resolved against the local session index", got, RunUnknown)
+	}
+}
+
+// The renderer must be told when a registry record breaks a phase-1 invariant.
+func TestBuildViewFlagsArmedRegistryRecord(t *testing.T) {
+	post := NewPost("armed", "post-a")
+	post.Spec.Classification = ClassAgent
+	post.Spec.Role = RoleRef{Name: RoleBuilder}
+	post.Spec.Triggers = []Trigger{{
+		Name: "cron", Type: TriggerCron, Schedule: "*/5 * * * *",
+		Enabled: true, External: false,
+	}}
+
+	view := BuildView(BuildOptions{
+		Definitions:  []*Definition{{Name: "armed", Post: post}},
+		LocalMachine: "g14",
+		Now:          time.Now(),
+		SkipHealth:   true,
+	})
+	row := view.Machines[0].Agents[0]
+	if len(row.Violations) == 0 {
+		t.Error("an armed registry record produced no violation")
+	}
+	if !row.Armed() {
+		t.Error("Armed() did not report an armed trigger")
+	}
+	if row.Attention == "" {
+		t.Error("an armed record is not called out for attention")
+	}
+}
+
+func TestValidateReportsToFlagsOrphanChain(t *testing.T) {
+	orphan := NewPost("a", "post-a")
+	orphan.Spec.Placement.ReportsTo = "b"
+	parent := NewPost("b", "post-b")
+	parent.Spec.Placement.ReportsTo = "c" // c does not exist
+
+	findings := ValidateReportsTo([]*Post{orphan, parent})
+	if len(findings) == 0 {
+		t.Fatal("a chain that never reaches a human principal produced no finding")
+	}
+}
+
+func TestPlaceholderPatternCatchesShellShapes(t *testing.T) {
+	for _, deliver := range []string{
+		"New mail from {{sender}}",
+		"File ${PATH} changed",
+		"Subject $SUBJECT arrived",
+		"Run $(whoami)",
+		"Run `id`",
+		"Path %(path)s changed",
+		"Got %s",
+	} {
+		post := validTestPost()
+		post.Spec.Triggers = []Trigger{{
+			Name: "t", Type: TriggerMailDoorbell, External: true,
+			ExternalSource: "/x.plist", Deliver: deliver,
+		}}
+		if !ValidatePost(post).HasErrors() {
+			t.Errorf("interpolated delivery accepted: %q", deliver)
+		}
+	}
+}
+
+func TestDescribeIntervalDoesNotFloorAwaySeconds(t *testing.T) {
+	if got := DescribeInterval(90); got == "every 1m" {
+		t.Errorf("DescribeInterval(90) = %q, which is a wrong cadence, not a coarse one", got)
+	}
+	if got := DescribeInterval(300); got != "every 5m" {
+		t.Errorf("DescribeInterval(300) = %q, want %q", got, "every 5m")
+	}
+	if got := DescribeInterval(7200); got != "every 2h" {
+		t.Errorf("DescribeInterval(7200) = %q, want %q", got, "every 2h")
+	}
+}
+
+func TestCheckHealthFutureMtimeIsNotFresh(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	seen := filepath.Join(dir, "seen.db")
+	writeTestFile(t, seen, "x")
+	future := now.Add(48 * time.Hour)
+	if err := os.Chtimes(seen, future, future); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	got := CheckHealth("c", "mail", dir, 30*time.Minute, now)
+	if got.State == HealthOK {
+		t.Errorf("a file dated in the future reported %q; that is a clock problem, not proof of work", got.State)
+	}
+}
+
+func TestWriteToRefusesNonEmptyDirectory(t *testing.T) {
+	source := t.TempDir()
+	writeTestFile(t, filepath.Join(source, "CLAUDE.md"), "conductor\n")
+	plan, err := Adopt(Options{Target: source, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+
+	root := t.TempDir()
+	// A directory holding role content but NO agent.yaml must still be safe.
+	occupied := filepath.Join(root, plan.Definitions[0].Name, RoleDirName)
+	if err := os.MkdirAll(occupied, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(occupied, "INSTRUCTIONS.md"), "someone's edit\n")
+
+	if _, err := plan.WriteTo(root); err == nil {
+		t.Fatal("WriteTo overwrote a non-empty directory that had no agent.yaml")
+	}
+	body, readErr := os.ReadFile(filepath.Join(occupied, "INSTRUCTIONS.md"))
+	if readErr != nil || string(body) != "someone's edit\n" {
+		t.Error("the existing file was modified")
+	}
+}
+
+func TestSanitizeForDisplayStripsControlCharacters(t *testing.T) {
+	got := SanitizeForDisplay("link\x1b[2K\rok\ttab\x07")
+	if strings.ContainsAny(got, "\x1b\r\x07") {
+		t.Errorf("SanitizeForDisplay left control characters: %q", got)
+	}
+	if !strings.Contains(got, "tab") {
+		t.Errorf("SanitizeForDisplay dropped ordinary text: %q", got)
+	}
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -111,6 +111,9 @@ OnUnitInactiveSec=5min
 	if src.ScheduleKey != "OnUnitInactiveSec" {
 		t.Errorf("ScheduleKey = %q, want OnUnitInactiveSec", src.ScheduleKey)
 	}
+	if src.ScheduleSource != filepath.Join(dir, "demo.timer") {
+		t.Errorf("ScheduleSource = %q, want sibling timer", src.ScheduleSource)
+	}
 	// Environment VALUES must never be captured.
 	if len(src.EnvKeys) != 1 || src.EnvKeys[0] != "API_TOKEN" {
 		t.Errorf("EnvKeys = %v, want [API_TOKEN]", src.EnvKeys)
@@ -120,6 +123,126 @@ OnUnitInactiveSec=5min
 			t.Fatal("an environment value leaked into the parsed unit")
 		}
 	}
+}
+
+func TestParseBareSystemdTimerReadsSiblingServiceRuntime(t *testing.T) {
+	dir := t.TempDir()
+	timer := filepath.Join(dir, "truth.timer")
+	service := filepath.Join(dir, "truth.service")
+	writeTestFile(t, timer, "[Timer]\nOnCalendar=*-*-* 03:15:00\n")
+	writeTestFile(t, service, "[Service]\nExecStart=/bin/echo hello\nEnvironment=TOKEN_NAME=discard-me\nWorkingDirectory=/srv/truth\nRestart=on-failure\n")
+
+	src, err := ParseSystemdUnit(timer)
+	if err != nil {
+		t.Fatalf("ParseSystemdUnit(timer): %v", err)
+	}
+	if src.Program != "/bin/echo" || src.WorkingDirectory != "/srv/truth" || src.RestartMode != "on-failure" {
+		t.Fatalf("bare timer lost sibling service runtime: %+v", src)
+	}
+	if len(src.EnvKeys) != 1 || src.EnvKeys[0] != "TOKEN_NAME" {
+		t.Fatalf("EnvKeys = %v, want names from sibling service", src.EnvKeys)
+	}
+	if len(src.SourcePaths) != 2 || src.SourcePaths[0] != timer || src.SourcePaths[1] != service {
+		t.Fatalf("SourcePaths = %v, want timer and sibling service", src.SourcePaths)
+	}
+}
+
+func TestAdoptSystemdPreservesEveryOnCalendar(t *testing.T) {
+	dir := t.TempDir()
+	timer := filepath.Join(dir, "many.timer")
+	writeTestFile(t, timer, "[Timer]\nOnCalendar=Mon *-*-* 09:00:00\nOnCalendar=Fri *-*-* 17:00:00\n")
+
+	plan, err := Adopt(Options{Target: timer, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	triggers := plan.Definitions[0].Post.Spec.Triggers
+	if len(triggers) != 2 {
+		t.Fatalf("got %d triggers, want both OnCalendar directives: %+v", len(triggers), triggers)
+	}
+	if triggers[0].Schedule == triggers[1].Schedule {
+		t.Fatalf("distinct OnCalendar directives collapsed: %+v", triggers)
+	}
+}
+
+func TestBareTimerFingerprintTracksTimerEdits(t *testing.T) {
+	dir := t.TempDir()
+	timer := filepath.Join(dir, "fingerprint.timer")
+	service := filepath.Join(dir, "fingerprint.service")
+	writeTestFile(t, timer, "[Timer]\nOnCalendar=*-*-* 01:00:00\n")
+	writeTestFile(t, service, "[Service]\nExecStart=/bin/true\n")
+	first, err := Adopt(Options{Target: timer, Machine: "testbox"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Millisecond)
+	writeTestFile(t, timer, "[Timer]\nOnCalendar=*-*-* 02:00:00\n")
+	second, err := Adopt(Options{Target: timer, Machine: "testbox"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Definitions[0].Post.Spec.SourceFingerprint == second.Definitions[0].Post.Spec.SourceFingerprint {
+		t.Fatal("timer-only edit did not change source fingerprint")
+	}
+}
+
+func TestConfirmedAdoptionTreeDiffIsConfinedToDefinitionsStore(t *testing.T) {
+	parent := t.TempDir()
+	registry := filepath.Join(parent, "agents")
+	sentinel := filepath.Join(parent, "outside.txt")
+	writeTestFile(t, sentinel, "unchanged")
+	source := filepath.Join(parent, "source.service")
+	writeTestFile(t, source, "[Service]\nExecStart=/bin/true\n")
+	plan, err := Adopt(Options{Target: source, Machine: "testbox"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTree(t, parent)
+	if _, err := plan.WriteTo(registry); err != nil {
+		t.Fatal(err)
+	}
+	after := snapshotTree(t, parent)
+	for path, digest := range after {
+		if before[path] == digest {
+			continue
+		}
+		if path != "agents" && !strings.HasPrefix(path, "agents"+string(filepath.Separator)) {
+			t.Errorf("confirmed adoption changed path outside definitions store: %s", path)
+		}
+	}
+	for path := range before {
+		if _, exists := after[path]; !exists && path != "agents" && !strings.HasPrefix(path, "agents"+string(filepath.Separator)) {
+			t.Errorf("confirmed adoption removed path outside definitions store: %s", path)
+		}
+	}
+}
+
+func snapshotTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			out[rel] = info.Mode().String()
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out[rel] = string(body)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
 }
 
 // A unit whose script merely lives under a path containing "agent-deck" is not

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,0 +1,756 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	restore := testutil.IsolateHome()
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
+
+func TestParseCronNext(t *testing.T) {
+	utc := time.UTC
+	base := time.Date(2026, 8, 20, 14, 3, 0, 0, utc)
+
+	cases := []struct {
+		spec string
+		want time.Time
+	}{
+		{"*/5 * * * *", time.Date(2026, 8, 20, 14, 5, 0, 0, utc)},
+		{"0 2 * * *", time.Date(2026, 8, 21, 2, 0, 0, 0, utc)},
+		{"0 * * * *", time.Date(2026, 8, 20, 15, 0, 0, 0, utc)},
+		{"30 14 * * *", time.Date(2026, 8, 20, 14, 30, 0, 0, utc)},
+	}
+	for _, tc := range cases {
+		schedule, err := ParseCron(tc.spec, utc)
+		if err != nil {
+			t.Fatalf("ParseCron(%q): %v", tc.spec, err)
+		}
+		got, ok := schedule.Next(base)
+		if !ok {
+			t.Fatalf("ParseCron(%q).Next: no occurrence found", tc.spec)
+		}
+		if !got.Equal(tc.want) {
+			t.Errorf("ParseCron(%q).Next = %s, want %s", tc.spec, got, tc.want)
+		}
+	}
+}
+
+// A schedule that cannot recur must report that, not return a plausible time.
+func TestParseCronImpossibleScheduleReportsNoOccurrence(t *testing.T) {
+	schedule, err := ParseCron("0 0 30 2 *", time.UTC)
+	if err != nil {
+		t.Fatalf("ParseCron: %v", err)
+	}
+	if _, ok := schedule.Next(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); ok {
+		t.Fatal("February 30th reported an occurrence; it must report none")
+	}
+}
+
+func TestParseCronRejectsMalformed(t *testing.T) {
+	for _, spec := range []string{"* * * *", "bad * * * *", "*/0 * * * *", "60 * * * *", "* 25 * * *"} {
+		if _, err := ParseCron(spec, time.UTC); err == nil {
+			t.Errorf("ParseCron(%q) accepted a malformed expression", spec)
+		}
+	}
+}
+
+// Cron's day-of-month / day-of-week OR rule.
+func TestCronDayWeekdayOrRule(t *testing.T) {
+	schedule, err := ParseCron("0 0 1 * 5", time.UTC)
+	if err != nil {
+		t.Fatalf("ParseCron: %v", err)
+	}
+	// 2026-08-21 is a Friday and not the 1st; it must still match.
+	friday := time.Date(2026, 8, 20, 23, 59, 0, 0, time.UTC)
+	next, ok := schedule.Next(friday)
+	if !ok {
+		t.Fatal("no occurrence")
+	}
+	if next.Weekday() != time.Friday {
+		t.Errorf("next = %s, want a Friday via the day/weekday OR rule", next)
+	}
+}
+
+func TestParseSystemdUnitReadsPairedTimerCadence(t *testing.T) {
+	dir := t.TempDir()
+	service := filepath.Join(dir, "demo.service")
+	writeTestFile(t, service, `[Unit]
+Description=demo tick
+[Service]
+Type=oneshot
+ExecStart=/home/someone/projects/agent-deck-g14/overnight/manager.sh
+Environment="API_TOKEN=shhh"
+WorkingDirectory=/tmp
+`)
+	writeTestFile(t, filepath.Join(dir, "demo.timer"), `[Unit]
+Description=tick
+[Timer]
+OnBootSec=2min
+OnUnitInactiveSec=5min
+`)
+
+	src, err := ParseSystemdUnit(service)
+	if err != nil {
+		t.Fatalf("ParseSystemdUnit: %v", err)
+	}
+	// OnUnitInactiveSec is the repeating cadence and must win over OnBootSec,
+	// which only says when the first run happens.
+	if src.IntervalSeconds != 300 {
+		t.Errorf("IntervalSeconds = %d, want 300 from OnUnitInactiveSec", src.IntervalSeconds)
+	}
+	if src.ScheduleKey != "OnUnitInactiveSec" {
+		t.Errorf("ScheduleKey = %q, want OnUnitInactiveSec", src.ScheduleKey)
+	}
+	// Environment VALUES must never be captured.
+	if len(src.EnvKeys) != 1 || src.EnvKeys[0] != "API_TOKEN" {
+		t.Errorf("EnvKeys = %v, want [API_TOKEN]", src.EnvKeys)
+	}
+	for _, key := range src.EnvKeys {
+		if strings.Contains(key, "shhh") {
+			t.Fatal("an environment value leaked into the parsed unit")
+		}
+	}
+}
+
+// A unit whose script merely lives under a path containing "agent-deck" is not
+// an agent. This is the false positive that made the notify daemon and a shell
+// tick both classify as agents.
+func TestClassifyIgnoresAgentDeckInPath(t *testing.T) {
+	src := &LaunchSource{
+		Kind:      "systemd",
+		Label:     "agentdeck-overnight",
+		Program:   "/bin/sh",
+		Arguments: []string{"/home/someone/projects/agent-deck-g14/overnight/overnight-manager.sh"},
+	}
+	got := ClassifyLaunchSource(src)
+	if got.Class == ClassAgent {
+		t.Errorf("classified as agent from a path substring; got %+v", got)
+	}
+}
+
+func TestClassifyDaemonSubcommandIsService(t *testing.T) {
+	// The program must actually exist: a missing program is debris, and that
+	// verdict deliberately outranks every other reading, because a unit whose
+	// binary is gone cannot be doing any of them.
+	binary := filepath.Join(t.TempDir(), "agent-deck")
+	writeTestFile(t, binary, "#!/bin/sh\n")
+
+	src := &LaunchSource{
+		Kind:      "systemd",
+		Label:     "agent-deck-transition-notifier",
+		Program:   binary,
+		Arguments: []string{binary, "notify-daemon"},
+	}
+	got := ClassifyLaunchSource(src)
+	if got.Class != ClassService {
+		t.Errorf("Class = %q, want %q for a daemon subcommand", got.Class, ClassService)
+	}
+}
+
+// A missing program outranks a daemon reading.
+func TestClassifyMissingProgramOutranksDaemonReading(t *testing.T) {
+	src := &LaunchSource{
+		Kind:      "systemd",
+		Label:     "gone-notifier",
+		Program:   "/definitely/not/here/agent-deck",
+		Arguments: []string{"/definitely/not/here/agent-deck", "notify-daemon"},
+	}
+	if got := ClassifyLaunchSource(src); got.Class != ClassDebris {
+		t.Errorf("Class = %q, want %q", got.Class, ClassDebris)
+	}
+}
+
+func TestClassifyMissingProgramIsDebris(t *testing.T) {
+	src := &LaunchSource{Kind: "launchd", Label: "gone", Program: "/definitely/not/here/binary"}
+	if got := ClassifyLaunchSource(src); got.Class != ClassDebris {
+		t.Errorf("Class = %q, want %q", got.Class, ClassDebris)
+	}
+}
+
+// The reference org chart: conductors are managers, watchers are triage,
+// maintainers are builders, and a builder implies an unfilled reviewer seat.
+func TestClassifyRoleFollowsOrgChart(t *testing.T) {
+	cases := []struct {
+		name     string
+		conduct  bool
+		wantRole string
+		wantPair string
+	}{
+		{"conductor-agent-deck", false, RoleManager, ""},
+		{"anything", true, RoleManager, ""},
+		{"gmail-watcher", false, RoleTriage, ""},
+		{"repo-maintainer", false, RoleBuilder, RoleReviewer},
+		{"wat", false, RoleUnresolved, ""},
+	}
+	for _, tc := range cases {
+		got := ClassifyRole(tc.name, tc.conduct)
+		if got.Role != tc.wantRole {
+			t.Errorf("ClassifyRole(%q).Role = %q, want %q", tc.name, got.Role, tc.wantRole)
+		}
+		if PairFor(got.Role) != tc.wantPair {
+			t.Errorf("PairFor(%q) = %q, want %q", got.Role, PairFor(got.Role), tc.wantPair)
+		}
+	}
+}
+
+func TestReportsToChain(t *testing.T) {
+	if got := ReportsToFor(RoleManager, "boss"); got != PrincipalHuman {
+		t.Errorf("manager reports to %q, want the human principal", got)
+	}
+	if got := ReportsToFor(RoleBuilder, "boss"); got != "boss" {
+		t.Errorf("builder reports to %q, want boss", got)
+	}
+	if got := ReportsToFor(RoleBuilder, ""); got != PrincipalHuman {
+		t.Errorf("builder with no manager reports to %q, want the human principal", got)
+	}
+}
+
+func TestValidateReportsToDetectsCycle(t *testing.T) {
+	a := NewPost("a", "post-a")
+	b := NewPost("b", "post-b")
+	a.Spec.Placement.ReportsTo = "b"
+	b.Spec.Placement.ReportsTo = "a"
+
+	findings := ValidateReportsTo([]*Post{a, b})
+	if !findings.HasErrors() {
+		t.Fatal("a reports_to cycle was not reported")
+	}
+}
+
+// The injection invariant, as a test rather than a comment.
+func TestValidatePostRejectsInterpolatedDelivery(t *testing.T) {
+	post := validTestPost()
+	post.Spec.Triggers = []Trigger{{
+		Name: "mail", Type: TriggerMailDoorbell, External: true,
+		ExternalSource: "/x.plist",
+		Deliver:        "New mail from {{sender}}: {{subject}}",
+	}}
+	findings := ValidatePost(post)
+	if !findings.HasErrors() {
+		t.Fatal("a templated delivery string was accepted; it is a prompt-injection path")
+	}
+}
+
+func TestValidatePostRejectsEnabledPhase1(t *testing.T) {
+	post := validTestPost()
+	post.Spec.Enabled = true
+	if !ValidatePost(post).HasErrors() {
+		t.Fatal("an enabled post was accepted in phase 1")
+	}
+
+	post = validTestPost()
+	post.Spec.Triggers = []Trigger{{
+		Name: "t", Type: TriggerCron, Schedule: "*/5 * * * *", Timezone: "UTC",
+		Enabled: true, External: true, ExternalSource: "/x.timer",
+	}}
+	if !ValidatePost(post).HasErrors() {
+		t.Fatal("an enabled trigger was accepted in phase 1")
+	}
+}
+
+func TestValidatePostRequiresExternalSource(t *testing.T) {
+	post := validTestPost()
+	post.Spec.Triggers = []Trigger{{
+		Name: "t", Type: TriggerCron, Schedule: "*/5 * * * *", Timezone: "UTC",
+		External: true, // no ExternalSource
+	}}
+	if !ValidatePost(post).HasErrors() {
+		t.Fatal("an external trigger with no owning file was accepted")
+	}
+}
+
+func TestValidateRoleRejectsEscapingReference(t *testing.T) {
+	role := NewRole("manager", "0.1.0")
+	role.Spec.Entrypoint = "../../etc/passwd"
+	if !ValidateRole(role).HasErrors() {
+		t.Fatal("a role reference escaping the role directory was accepted")
+	}
+
+	role = NewRole("manager", "0.1.0")
+	role.Spec.Entrypoint = "/etc/passwd"
+	if !ValidateRole(role).HasErrors() {
+		t.Fatal("an absolute role reference was accepted")
+	}
+}
+
+func TestValidateRoleContentFlagsPortabilityRot(t *testing.T) {
+	body := "Work out of /home/someone/x\nBox at build.local\nexport GITHUB_TOKEN=ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+	findings := ValidateRoleContent("role/INSTRUCTIONS.md", body)
+	if len(findings) < 3 {
+		t.Errorf("got %d findings, want at least 3 (path, hostname, credential): %v", len(findings), findings)
+	}
+}
+
+func TestCheckHealthDistinguishesUnknownFromDown(t *testing.T) {
+	now := time.Now()
+
+	unknown := CheckHealth("c", "mail", "", DefaultStaleAfter, now)
+	if unknown.State != HealthUnknown {
+		t.Errorf("no evidence path gave %q, want %q", unknown.State, HealthUnknown)
+	}
+
+	missing := CheckHealth("c", "mail", filepath.Join(t.TempDir(), "nope"), DefaultStaleAfter, now)
+	if missing.State != HealthUnknown {
+		t.Errorf("missing evidence path gave %q, want %q — absence is not proof of death", missing.State, HealthUnknown)
+	}
+
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "pid"), "999999\n")
+	dead := CheckHealth("c", "mail", dir, DefaultStaleAfter, now)
+	if dead.State != HealthDown {
+		t.Errorf("a pid file naming a dead process gave %q, want %q", dead.State, HealthDown)
+	}
+}
+
+func TestCheckHealthFreshAndStale(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	seen := filepath.Join(dir, "seen.db")
+	writeTestFile(t, seen, "x")
+
+	fresh := CheckHealth("gmail", "mail", dir, 30*time.Minute, now)
+	if fresh.State != HealthOK {
+		t.Errorf("a just-written seen.db gave %q, want %q (%s)", fresh.State, HealthOK, fresh.Detail)
+	}
+
+	old := now.Add(-3 * time.Hour)
+	if err := os.Chtimes(seen, old, old); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	stale := CheckHealth("gmail", "mail", dir, 30*time.Minute, now)
+	if stale.State != HealthStale {
+		t.Errorf("a 3h-old seen.db gave %q, want %q", stale.State, HealthStale)
+	}
+	if stale.FreshnessFile != seen {
+		t.Errorf("FreshnessFile = %q, want %q", stale.FreshnessFile, seen)
+	}
+}
+
+func TestAdoptConductorDirIsReadOnlyAndDisabled(t *testing.T) {
+	source := t.TempDir()
+	writeTestFile(t, filepath.Join(source, "CLAUDE.md"), "You are the conductor.\n")
+	writeTestFile(t, filepath.Join(source, "POLICY.md"), "Never merge unreviewed.\n")
+	writeTestFile(t, filepath.Join(source, "LEARNINGS.md"), "Commit state before notifying.\n")
+	if err := os.MkdirAll(filepath.Join(source, "workflows"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(source, "workflows", "cut-a-release.md"), "1. tag\n2. push\n")
+
+	before := snapshotDir(t, source)
+
+	plan, err := Adopt(Options{Target: source, Machine: "testbox", Now: time.Unix(1755000000, 0)})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	if len(plan.Definitions) != 1 {
+		t.Fatalf("got %d definitions, want 1", len(plan.Definitions))
+	}
+	def := plan.Definitions[0]
+
+	if def.Post.Spec.Role.Name != RoleManager {
+		t.Errorf("role = %q, want %q for a conductor directory", def.Post.Spec.Role.Name, RoleManager)
+	}
+	if def.Post.Spec.Enabled {
+		t.Error("adoption emitted an enabled post")
+	}
+	if def.Post.Spec.Placement.ReportsTo != PrincipalHuman {
+		t.Errorf("reportsTo = %q, want the human principal", def.Post.Spec.Placement.ReportsTo)
+	}
+	// CLAUDE.md becomes the portable entry point.
+	if _, ok := def.RoleFiles["INSTRUCTIONS.md"]; !ok {
+		t.Error("CLAUDE.md was not mapped to INSTRUCTIONS.md")
+	}
+	if _, ok := def.RoleFiles[filepath.Join("workflows", "cut-a-release.md")]; !ok {
+		t.Error("workflow file was not carried into the role")
+	}
+	if len(def.Post.Spec.Provenance) == 0 {
+		t.Error("no provenance was recorded")
+	}
+	if findings := ValidateDefinition(def.Post, def.Role); findings.HasErrors() {
+		t.Errorf("emitted definition does not validate: %v", findings)
+	}
+
+	// The source must be byte-identical afterwards.
+	if after := snapshotDir(t, source); after != before {
+		t.Error("adoption modified the source directory")
+	}
+}
+
+func TestAdoptPlanWriteRefusesToClobber(t *testing.T) {
+	source := t.TempDir()
+	writeTestFile(t, filepath.Join(source, "CLAUDE.md"), "conductor\n")
+
+	plan, err := Adopt(Options{Target: source, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	root := t.TempDir()
+	if _, err := plan.WriteTo(root); err != nil {
+		t.Fatalf("first WriteTo: %v", err)
+	}
+	if _, err := plan.WriteTo(root); err == nil {
+		t.Fatal("a second write silently overwrote an existing definition")
+	}
+}
+
+func TestAdoptSessionUsesOrgChartAndKeepsSessionIntact(t *testing.T) {
+	sessions := []SessionInfo{{
+		ID: "abc-123", Title: "repo-maintainer", Tool: "claude",
+		Account: "work", GroupPath: "maintainers", ProjectPath: "/tmp/x", Status: "running",
+	}}
+	plan, err := Adopt(Options{Target: "repo-maintainer", Sessions: sessions, ManagerPost: "conductor-x"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	post := plan.Definitions[0].Post
+	if post.Spec.Role.Name != RoleBuilder {
+		t.Errorf("role = %q, want %q", post.Spec.Role.Name, RoleBuilder)
+	}
+	if post.Spec.Placement.ReportsTo != "conductor-x" {
+		t.Errorf("reportsTo = %q, want conductor-x", post.Spec.Placement.ReportsTo)
+	}
+	if post.Spec.Runtime.AdoptedSessionID != "abc-123" {
+		t.Errorf("adoptedSessionId = %q, want abc-123", post.Spec.Runtime.AdoptedSessionID)
+	}
+	// The pair rule must surface the empty reviewer seat.
+	joined := strings.Join(plan.Notes, " ")
+	if !strings.Contains(joined, RoleReviewer) {
+		t.Errorf("notes = %v, want a note about the unfilled reviewer seat", plan.Notes)
+	}
+}
+
+func TestAdoptUnknownTargetIsAnError(t *testing.T) {
+	if _, err := Adopt(Options{Target: "no-such-thing"}); err == nil {
+		t.Fatal("an unknown target was accepted")
+	}
+}
+
+// A round trip through the registry must preserve the definition.
+func TestWriteAndLoadRoundTrip(t *testing.T) {
+	source := t.TempDir()
+	writeTestFile(t, filepath.Join(source, "CLAUDE.md"), "conductor\n")
+	writeTestFile(t, filepath.Join(source, "POLICY.md"), "policy\n")
+
+	plan, err := Adopt(Options{Target: source, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	root := t.TempDir()
+	written, err := plan.WriteTo(root)
+	if err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	def, err := Load(written[0])
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if def.Post.Metadata.PostID != plan.Definitions[0].Post.Metadata.PostID {
+		t.Error("post id did not survive the round trip")
+	}
+	if def.Role == nil || def.Role.Spec.Entrypoint != "INSTRUCTIONS.md" {
+		t.Error("role did not survive the round trip")
+	}
+	// Definitions are private by default.
+	info, err := os.Stat(filepath.Join(written[0], PostFileName))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("agent.yaml mode = %o, want 600", perm)
+	}
+}
+
+// A malformed definition must be reported, not silently dropped: the fleet
+// must never look smaller than it is.
+func TestLoadAllReportsMalformedDefinition(t *testing.T) {
+	root := t.TempDir()
+	bad := filepath.Join(root, "broken")
+	if err := os.MkdirAll(bad, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(bad, PostFileName), "this: is: not: a: post\n")
+
+	def, err := Load(bad)
+	if err == nil {
+		t.Fatal("a malformed post loaded without error")
+	}
+	if def != nil {
+		t.Error("a malformed post returned a definition")
+	}
+}
+
+func TestBuildViewCountsAndGrouping(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+	working := NewPost("builder-one", "post-1")
+	working.Spec.Classification = ClassAgent
+	working.Spec.Role = RoleRef{Name: RoleBuilder, Version: "0.1.0"}
+	working.Spec.Runtime.AdoptedSessionID = "sess-1"
+	working.Spec.Placement.Machine = "g14"
+
+	orphan := NewPost("triage-one", "post-2")
+	orphan.Spec.Classification = ClassAgent
+	orphan.Spec.Role = RoleRef{Name: RoleTriage}
+	orphan.Spec.Placement.Machine = "g14"
+
+	view := BuildView(BuildOptions{
+		Definitions: []*Definition{
+			{Name: "builder-one", Post: working},
+			{Name: "triage-one", Post: orphan},
+		},
+		SessionStates: map[string]SessionState{"sess-1": {Status: "running", Present: true}},
+		LocalMachine:  "g14",
+		Now:           now,
+		SkipHealth:    true,
+	})
+
+	if view.TotalAgents != 2 {
+		t.Errorf("TotalAgents = %d, want 2", view.TotalAgents)
+	}
+	if len(view.Machines) != 1 || view.Machines[0].Name != "g14" {
+		t.Fatalf("machines = %+v, want a single g14 group", view.Machines)
+	}
+	rows := view.Machines[0].Agents
+	if rows[0].State != RunWorking {
+		t.Errorf("row state = %q, want %q", rows[0].State, RunWorking)
+	}
+	// A post whose session is gone says so; it does not borrow a state.
+	if rows[1].State != RunNoRuntime {
+		t.Errorf("orphan state = %q, want %q", rows[1].State, RunNoRuntime)
+	}
+}
+
+// An unreachable remote must be reported as unconfirmed, and its rows must
+// carry that through, so nothing reads as current when it is not.
+func TestBuildViewMarksUnconfirmedRemote(t *testing.T) {
+	view := BuildView(BuildOptions{
+		LocalMachine: "g14",
+		Now:          time.Now(),
+		SkipHealth:   true,
+		Remotes: []RemoteMachineData{{
+			Name: "mac", Link: LinkUnconfirmed, Detail: "ssh timeout",
+			Agents: []AgentRow{{Name: "gmail-watcher", Role: RoleTriage, State: RunIdle}},
+		}},
+	})
+	if len(view.Machines) != 1 {
+		t.Fatalf("machines = %d, want 1", len(view.Machines))
+	}
+	machine := view.Machines[0]
+	if machine.Link != LinkUnconfirmed {
+		t.Errorf("link = %q, want %q", machine.Link, LinkUnconfirmed)
+	}
+	row := machine.Agents[0]
+	if row.LinkState != LinkUnconfirmed {
+		t.Errorf("row link = %q, want %q", row.LinkState, LinkUnconfirmed)
+	}
+	if row.Attention == "" {
+		t.Error("an unconfirmed row carries no attention note")
+	}
+	if view.NeedAttention != 1 {
+		t.Errorf("NeedAttention = %d, want 1", view.NeedAttention)
+	}
+}
+
+func TestBuildTriggerRowRendersDeclaredNextDue(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+	cron := buildTriggerRow(Trigger{
+		Name: "hygiene", Type: TriggerCron, Schedule: "0 2 * * *", Timezone: "UTC",
+		External: true, ExternalSource: "/x.timer",
+	}, now)
+	if cron.NextDue == nil {
+		t.Fatal("a declared cron trigger produced no next-due time")
+	}
+	if !cron.NextDue.Equal(time.Date(2026, 8, 21, 2, 0, 0, 0, time.UTC)) {
+		t.Errorf("next due = %s, want 2026-08-21 02:00 UTC", cron.NextDue)
+	}
+
+	// An interval owned by a launcher has no visible phase, so it must show
+	// the cadence and say why that is all it can show.
+	interval := buildTriggerRow(Trigger{
+		Name: "tick", Type: TriggerCron, IntervalSeconds: 300,
+		External: true, ExternalSource: "/x.timer",
+	}, now)
+	if interval.NextDue != nil {
+		t.Error("an externally phased interval claimed an exact next-due time")
+	}
+	if interval.NextDueText != "every 5m" {
+		t.Errorf("NextDueText = %q, want %q", interval.NextDueText, "every 5m")
+	}
+	if interval.Note == "" {
+		t.Error("no note explaining why there is no exact time")
+	}
+}
+
+func TestFingerprintOfNothingIsEmpty(t *testing.T) {
+	if got := FingerprintPaths(nil); got != "" {
+		t.Errorf("FingerprintPaths(nil) = %q, want an empty string", got)
+	}
+}
+
+// --- helpers ------------------------------------------------------------
+
+func validTestPost() *Post {
+	post := NewPost("x", "post-x")
+	post.Spec.Classification = ClassAgent
+	post.Spec.Role = RoleRef{Name: RoleBuilder}
+	return post
+}
+
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// snapshotDir renders a directory's contents as a comparable string.
+func snapshotDir(t *testing.T, root string) string {
+	t.Helper()
+	var sb strings.Builder
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, _ := filepath.Rel(root, path)
+		sb.WriteString(rel)
+		sb.WriteString("\x00")
+		sb.Write(body)
+		sb.WriteString("\x00")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", root, err)
+	}
+	return sb.String()
+}
+
+func TestSystemdCalendarToCron(t *testing.T) {
+	ok := map[string]string{
+		"daily":          "0 0 * * *",
+		"hourly":         "0 * * * *",
+		"*-*-* 02:00:00": "0 2 * * *",
+		"*-*-* 06:30":    "30 6 * * *",
+		"*-*-* 23:59:00": "59 23 * * *",
+	}
+	for spec, want := range ok {
+		got, converted := SystemdCalendarToCron(spec)
+		if !converted {
+			t.Errorf("SystemdCalendarToCron(%q) declined to convert", spec)
+			continue
+		}
+		if got != want {
+			t.Errorf("SystemdCalendarToCron(%q) = %q, want %q", spec, got, want)
+		}
+		if _, err := ParseCron(got, time.UTC); err != nil {
+			t.Errorf("conversion of %q produced unparseable cron %q: %v", spec, got, err)
+		}
+	}
+
+	// Forms with no exact cron equivalent must be declined, not approximated.
+	for _, spec := range []string{"Mon..Fri *-*-* 09:00:00", "*-*-* 00/15:00:00", "*-*-* 02:00:30", "weird"} {
+		if _, converted := SystemdCalendarToCron(spec); converted {
+			t.Errorf("SystemdCalendarToCron(%q) claimed a conversion it cannot make exactly", spec)
+		}
+	}
+}
+
+// A systemd OnCalendar that cannot become cron must reach the view as an
+// opaque trigger showing the real text, never as a cron that fails to parse.
+func TestAdoptSystemdUnconvertibleCalendarStaysOpaque(t *testing.T) {
+	dir := t.TempDir()
+	service := filepath.Join(dir, "weekday.service")
+	writeTestFile(t, service, "[Service]\nExecStart=/bin/true\n")
+	writeTestFile(t, filepath.Join(dir, "weekday.timer"),
+		"[Timer]\nOnCalendar=Mon..Fri *-*-* 09:00:00\n")
+
+	plan, err := Adopt(Options{Target: service, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	triggers := plan.Definitions[0].Post.Spec.Triggers
+	if len(triggers) != 1 {
+		t.Fatalf("got %d triggers, want 1", len(triggers))
+	}
+	if triggers[0].Type != TriggerOpaque {
+		t.Errorf("type = %q, want %q for an unconvertible OnCalendar", triggers[0].Type, TriggerOpaque)
+	}
+	if triggers[0].Schedule != "Mon..Fri *-*-* 09:00:00" {
+		t.Errorf("schedule = %q, want the verbatim OnCalendar text", triggers[0].Schedule)
+	}
+}
+
+// A unit belonging to a different agent must not be adopted as this one's,
+// even when one name is a substring of the other.
+func TestFindRelatedUnitsMatchesOnTokenBoundary(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "gmail-watcher.plist"), minimalPlist("gmail-watcher"))
+	writeTestFile(t, filepath.Join(dir, "com.ashesh.repo-maintainer.plist"), minimalPlist("repo-maintainer"))
+
+	// "mail-watcher" is a substring of "gmail-watcher" but not a token of it.
+	if got := findRelatedUnits("mail-watcher", []string{dir}); len(got) != 0 {
+		t.Errorf("mail-watcher matched %d units, want 0 — substring is not a reference", len(got))
+	}
+	if got := findRelatedUnits("gmail-watcher", []string{dir}); len(got) != 1 {
+		t.Errorf("gmail-watcher matched %d units, want 1", len(got))
+	}
+	// A reverse-DNS label still matches on the dot boundary.
+	if got := findRelatedUnits("repo-maintainer", []string{dir}); len(got) != 1 {
+		t.Errorf("repo-maintainer matched %d units, want 1", len(got))
+	}
+}
+
+// A .service and its paired .timer describe one firing, not two.
+func TestAdoptDoesNotDoubleCountPairedTimer(t *testing.T) {
+	unitDir := t.TempDir()
+	writeTestFile(t, filepath.Join(unitDir, "repo-maintainer.service"),
+		"[Service]\nExecStart=/bin/true\n")
+	writeTestFile(t, filepath.Join(unitDir, "repo-maintainer.timer"),
+		"[Timer]\nOnCalendar=*-*-* 02:00:00\n")
+
+	plan, err := Adopt(Options{
+		Target:   "repo-maintainer",
+		Sessions: []SessionInfo{{ID: "s1", Title: "repo-maintainer", Tool: "claude"}},
+		UnitDirs: []string{unitDir},
+	})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	triggers := plan.Definitions[0].Post.Spec.Triggers
+	if len(triggers) != 1 {
+		t.Fatalf("got %d triggers, want 1 for one service+timer pair: %+v", len(triggers), triggers)
+	}
+	if findings := ValidatePost(plan.Definitions[0].Post); findings.HasErrors() {
+		t.Errorf("duplicate trigger names slipped through: %v", findings)
+	}
+}
+
+func minimalPlist(label string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>` + label + `</string>
+  <key>ProgramArguments</key><array><string>/bin/true</string></array>
+  <key>StartInterval</key><integer>300</integer>
+</dict>
+</plist>
+`
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1075,3 +1075,123 @@ func TestSanitizeForDisplayStripsControlCharacters(t *testing.T) {
 		t.Errorf("SanitizeForDisplay dropped ordinary text: %q", got)
 	}
 }
+
+// --- regressions from review round 2 ---------------------------------------
+
+// A launchd schedule with no cron equivalent must still produce a trigger.
+// Declining the schedule is right; dropping the trigger understates the fleet.
+func TestLaunchdUnrepresentableScheduleStillEmitsOpaqueTrigger(t *testing.T) {
+	dir := t.TempDir()
+	plist := filepath.Join(dir, "com.ashesh.daywk.plist")
+	writeTestFile(t, plist, `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.ashesh.daywk</string>
+  <key>ProgramArguments</key><array><string>/bin/true</string></array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Day</key><integer>1</integer>
+    <key>Weekday</key><integer>1</integer>
+    <key>Hour</key><integer>3</integer>
+  </dict>
+</dict>
+</plist>
+`)
+	plan, err := Adopt(Options{Target: plist, Machine: "testbox"})
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	triggers := plan.Definitions[0].Post.Spec.Triggers
+	if len(triggers) != 1 {
+		t.Fatalf("got %d triggers, want 1: a plist that demonstrably fires must not show as firing nothing", len(triggers))
+	}
+	if triggers[0].Type != TriggerOpaque {
+		t.Errorf("type = %q, want %q", triggers[0].Type, TriggerOpaque)
+	}
+	if !strings.Contains(triggers[0].Schedule, "Day=1") {
+		t.Errorf("schedule = %q, want the source's own terms", triggers[0].Schedule)
+	}
+	// And the row renders that, rather than an empty next-due.
+	view := BuildView(BuildOptions{
+		Definitions:  []*Definition{{Name: "daywk", Post: plan.Definitions[0].Post}},
+		LocalMachine: "testbox", Now: time.Now(), SkipHealth: true,
+	})
+	if got := FormatNextDue(view.Machines[0].Agents[0]); got == "" {
+		t.Error("the row shows no schedule at all for a post that is demonstrably fired")
+	}
+}
+
+// A system-scope unit's %h belongs to its User=, not to the adopting process.
+func TestSystemScopeUnitDoesNotExpandOurIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	userUnit := filepath.Join(dir, "mine.service")
+	writeTestFile(t, userUnit, "[Service]\nExecStart=%h/bin/tool\n")
+	src, err := ParseSystemdUnit(userUnit)
+	if err != nil {
+		t.Fatalf("ParseSystemdUnit: %v", err)
+	}
+	if !strings.HasPrefix(src.Program, home) {
+		t.Errorf("a user unit did not expand %%h: %q", src.Program)
+	}
+
+	// A unit that sets User= runs as someone else.
+	otherUser := filepath.Join(dir, "theirs.service")
+	writeTestFile(t, otherUser, "[Service]\nUser=svc\nExecStart=%h/bin/tool\n")
+	src, err = ParseSystemdUnit(otherUser)
+	if err != nil {
+		t.Fatalf("ParseSystemdUnit: %v", err)
+	}
+	if strings.HasPrefix(src.Program, home) {
+		t.Errorf("expanded %%h with OUR home for a unit that runs as another user: %q", src.Program)
+	}
+	if got := src.ProgramStatus(); got != ProgramUnknown {
+		t.Errorf("ProgramStatus = %q, want %q — and it must never be debris", got, ProgramUnknown)
+	}
+	if got := ClassifyLaunchSource(src); got.Class == ClassDebris {
+		t.Error("a unit running as another user was classified debris")
+	}
+}
+
+// A broken escalation chain must actually reach the user.
+func TestBuildViewSurfacesBrokenReportsToChain(t *testing.T) {
+	orphan := NewPost("worker", "post-w")
+	orphan.Spec.Classification = ClassAgent
+	orphan.Spec.Role = RoleRef{Name: RoleBuilder}
+	orphan.Spec.Placement.ReportsTo = "nobody-post"
+
+	view := BuildView(BuildOptions{
+		Definitions:  []*Definition{{Name: "worker", Post: orphan}},
+		LocalMachine: "g14", Now: time.Now(), SkipHealth: true,
+	})
+	row := view.Machines[0].Agents[0]
+	if row.ReportsToIssue == "" {
+		t.Error("a post reporting to a nonexistent manager rendered with no complaint")
+	}
+}
+
+// A schema complaint must not hide a dead connector.
+func TestAttentionNamesBothInvariantAndConnector(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "pid"), "999999\n")
+
+	post := NewPost("both", "post-b")
+	post.Spec.Classification = ClassAgent
+	post.Spec.Role = RoleRef{Name: RoleTriage}
+	post.Spec.Triggers = []Trigger{{Name: "t", Type: TriggerCron, Enabled: true, External: false}}
+	post.Spec.Connectors = []ConnectorRef{{Name: "mail", Kind: "mail", EvidencePath: dir}}
+
+	view := BuildView(BuildOptions{
+		Definitions:  []*Definition{{Name: "both", Post: post}},
+		LocalMachine: "g14", Now: time.Now(),
+	})
+	attention := view.Machines[0].Agents[0].Attention
+	if !strings.Contains(attention, "invariant") {
+		t.Errorf("attention %q does not mention the invariant", attention)
+	}
+	if !strings.Contains(attention, "connector") {
+		t.Errorf("attention %q hides the dead connector behind the schema complaint", attention)
+	}
+}

--- a/internal/agents/classify.go
+++ b/internal/agents/classify.go
@@ -1,0 +1,197 @@
+package agents
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ClassifyResult is what classification concluded about a target, with the
+// evidence that got it there. Adoption never records a conclusion without one.
+type ClassifyResult struct {
+	Class      Classification `json:"class"`
+	Role       string         `json:"role"`
+	Confidence Confidence     `json:"confidence"`
+	Reason     string         `json:"reason"`
+	// PairWith names the role that must be hired alongside this one. The
+	// reference org chart pairs Builder with Reviewer, so recognizing a
+	// builder means recognizing that its reviewer seat is currently empty.
+	PairWith string `json:"pair_with,omitempty"`
+}
+
+// The reference org chart:
+//
+//	human:ashesh
+//	  └─ manager
+//	       ├─ registrar
+//	       ├─ builder + reviewer   (always a pair)
+//	       ├─ devops
+//	       └─ triage/monitor
+//
+// ReportsToFor returns the manager a recognized role reports to. Everything
+// except the manager itself reports to the manager; the manager reports to the
+// human principal. A role we could not recognize reports to the human directly
+// rather than being filed under a manager that may not want it.
+func ReportsToFor(role, managerPost string) string {
+	switch role {
+	case RoleManager, RoleUnresolved, "":
+		return PrincipalHuman
+	default:
+		if strings.TrimSpace(managerPost) == "" {
+			return PrincipalHuman
+		}
+		return managerPost
+	}
+}
+
+// PairFor returns the role that must be hired alongside this one, if any.
+func PairFor(role string) string {
+	switch role {
+	case RoleBuilder:
+		return RoleReviewer
+	case RoleReviewer:
+		return RoleBuilder
+	default:
+		return ""
+	}
+}
+
+var (
+	conductorNamePattern  = regexp.MustCompile(`(?i)\bconductor\b`)
+	watcherNamePattern    = regexp.MustCompile(`(?i)\b(watcher|watch|doorbell|triage)\b`)
+	monitorNamePattern    = regexp.MustCompile(`(?i)\b(monitor|poll|poller)\b`)
+	maintainerNamePattern = regexp.MustCompile(`(?i)\b(maintainer|repo-maintainer|hygiene)\b`)
+	registrarNamePattern  = regexp.MustCompile(`(?i)\b(registrar|registry|inventory|steward|cred-steward)\b`)
+	devopsNamePattern     = regexp.MustCompile(`(?i)\b(devops|deploy|release|infra|ops|ci)\b`)
+	builderNamePattern    = regexp.MustCompile(`(?i)\b(builder|worker|impl|exec)\b`)
+	reviewerNamePattern   = regexp.MustCompile(`(?i)\b(reviewer|review|verifier|adversarial|vet)\b`)
+)
+
+// ClassifyRole maps a target's name and evidence onto the reference org chart.
+// It fires only when the evidence is obvious. Anything else is RoleUnresolved,
+// which is not a failure: it is the tool declining to invent a job description
+// for something it does not understand.
+func ClassifyRole(name string, isConductor bool) ClassifyResult {
+	base := filepath.Base(strings.TrimSpace(name))
+
+	if isConductor {
+		return ClassifyResult{
+			Class:      ClassAgent,
+			Role:       RoleManager,
+			Confidence: ConfidenceHigh,
+			Reason:     "marked as a conductor by agent-deck's own session record",
+		}
+	}
+
+	switch {
+	case conductorNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleManager, Confidence: ConfidenceHigh,
+			Reason: "name contains \"conductor\"; conductors supervise other posts",
+		}
+	case maintainerNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleBuilder, Confidence: ConfidenceMedium,
+			Reason: "name matches the maintainer family, which does bounded repository work", PairWith: RoleReviewer,
+		}
+	case watcherNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleTriage, Confidence: ConfidenceHigh,
+			Reason: "name matches the watcher family, which triages arriving work",
+		}
+	case monitorNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleTriage, Confidence: ConfidenceMedium,
+			Reason: "name suggests a monitor; monitors and triage share the triage role",
+		}
+	case reviewerNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleReviewer, Confidence: ConfidenceMedium,
+			Reason: "name matches the reviewer family", PairWith: RoleBuilder,
+		}
+	case registrarNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleRegistrar, Confidence: ConfidenceLow,
+			Reason: "name suggests registry or steward work",
+		}
+	case devopsNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleDevOps, Confidence: ConfidenceLow,
+			Reason: "name suggests deployment or infrastructure work",
+		}
+	case builderNamePattern.MatchString(base):
+		return ClassifyResult{
+			Class: ClassAgent, Role: RoleBuilder, Confidence: ConfidenceLow,
+			Reason: "name suggests implementation work", PairWith: RoleReviewer,
+		}
+	}
+
+	return ClassifyResult{
+		Class: ClassAgent, Role: RoleUnresolved, Confidence: ConfidenceLow,
+		Reason: "no obvious role in the name; a human must say what this does",
+	}
+}
+
+var (
+	pollerCmdPattern  = regexp.MustCompile(`(?i)(imap|gmail|poll|seen\.db|doorbell|bridge|webhook)`)
+	harnessCmdPattern = regexp.MustCompile(`(?i)^(agent-deck|claude|codex|deepseek|hermes)`)
+	// daemonSubcommandPattern recognizes an invocation that keeps something
+	// alive rather than doing a unit of work. It is checked against the
+	// ARGUMENTS, so `agent-deck notify-daemon` is correctly a service even
+	// though the binary is also how agents are launched.
+	daemonSubcommandPattern = regexp.MustCompile(`(?i)(^|\s)(notify-daemon|[\w-]*daemon|--daemon|serve|supervisor)(\s|$)`)
+	serviceNamePattern      = regexp.MustCompile(`(?i)\b(daemon|keepalive|notifier|notify|steward|supervisor|automount|tunnel)\b`)
+	opaqueCmdPattern        = regexp.MustCompile(`(?i)\b(curl|wget)\b`)
+)
+
+// ClassifyLaunchSource labels a launchd plist or systemd unit from what it
+// actually runs.
+//
+// Matching is deliberately anchored to the program's BASENAME and its
+// arguments, never to the full path. A unit whose script merely lives under
+// a directory called agent-deck-g14 is not thereby an agent — that path
+// substring is a fact about the filesystem, not about the job.
+func ClassifyLaunchSource(src *LaunchSource) ClassifyResult {
+	if src == nil {
+		return ClassifyResult{Class: ClassExternal, Role: RoleUnresolved, Confidence: ConfidenceLow,
+			Reason: "no source to inspect"}
+	}
+	if strings.TrimSpace(src.Program) != "" && !src.ProgramExists() {
+		return ClassifyResult{
+			Class: ClassDebris, Role: RoleUnresolved, Confidence: ConfidenceHigh,
+			Reason: "its program path does not exist on this machine",
+		}
+	}
+
+	program := filepath.Base(strings.TrimSpace(src.Program))
+	args := strings.Join(src.Arguments, " ")
+	label := src.Label
+
+	switch {
+	// A daemon subcommand wins over everything: it is what the job DOES.
+	case daemonSubcommandPattern.MatchString(args), serviceNamePattern.MatchString(label), serviceNamePattern.MatchString(program):
+		return ClassifyResult{
+			Class: ClassService, Role: RoleUnresolved, Confidence: ConfidenceHigh,
+			Reason: "runs a daemon that keeps local infrastructure alive, not a unit of agent work",
+		}
+	case pollerCmdPattern.MatchString(program), pollerCmdPattern.MatchString(args), pollerCmdPattern.MatchString(label):
+		return ClassifyResult{
+			Class: ClassConnector, Role: RoleUnresolved, Confidence: ConfidenceMedium,
+			Reason: "runs a poller or bridge; this is a boundary to an external source, not an agent",
+		}
+	case harnessCmdPattern.MatchString(program):
+		result := ClassifyRole(label, false)
+		result.Reason = "invokes an agent harness (" + program + "): " + result.Reason
+		return result
+	case opaqueCmdPattern.MatchString(args):
+		return ClassifyResult{
+			Class: ClassExternal, Role: RoleUnresolved, Confidence: ConfidenceLow,
+			Reason: "fetches and runs something opaque; adoption will not pretend to understand it",
+		}
+	}
+
+	return ClassifyResult{
+		Class: ClassExternal, Role: RoleUnresolved, Confidence: ConfidenceLow,
+		Reason: "runs on this machine but agent-deck cannot tell what it is for",
+	}
+}

--- a/internal/agents/classify.go
+++ b/internal/agents/classify.go
@@ -156,7 +156,10 @@ func ClassifyLaunchSource(src *LaunchSource) ClassifyResult {
 		return ClassifyResult{Class: ClassExternal, Role: RoleUnresolved, Confidence: ConfidenceLow,
 			Reason: "no source to inspect"}
 	}
-	if strings.TrimSpace(src.Program) != "" && !src.ProgramExists() {
+	// Only a program we resolved AND found absent is debris. An unresolved
+	// path is unknown, and unknown must never be rendered as a leftover to
+	// delete.
+	if src.ProgramStatus() == ProgramMissing {
 		return ClassifyResult{
 			Class: ClassDebris, Role: RoleUnresolved, Confidence: ConfidenceHigh,
 			Reason: "its program path does not exist on this machine",

--- a/internal/agents/credential_scan_test.go
+++ b/internal/agents/credential_scan_test.go
@@ -155,3 +155,64 @@ func TestScanForCredentialsRoundFourResiduals(t *testing.T) {
 		}
 	}
 }
+
+// Round 5 N1: a relative path on a line that also mentions a credential is
+// ordinary engineering documentation, not a leak.
+func TestScanForCredentialsRelativePaths(t *testing.T) {
+	mustCopy := []string{
+		"The API key is read from internal/agents/validate.go\n",
+		"Token handling lives in internal/session/userconfig.go\n",
+		"Password rules are in docs/policy/credentials.md\n",
+		"| secret | internal/session/userconfig.go |\n",
+		"The secret loader is cmd/agent-deck/agents_cmd.go\n",
+		"Logs live in /home/ashesh/.local/share/agent-deck/logs/transition.log\n",
+		"See https://github.com/asheshgoplani/agent-deck/pull/1996 for context.\n",
+		"Run ./scripts/overnight-manager.sh from the repo root.\n",
+	}
+	for _, line := range mustCopy {
+		if lines := ScanForCredentials(line); len(lines) != 0 {
+			t.Errorf("FALSE POSITIVE on a path: %q -> lines %v", line, lines)
+		}
+	}
+
+	// ...without reopening F2: a slash-bearing base64 secret spans several
+	// character classes and must still be caught.
+	mustRefuse := []string{
+		"aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+		"The AWS secret is wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+		"The API key is aGVsbG9Xb3JsZFRoaXNJc0/EzMkNoYXJz\n",
+	}
+	for _, line := range mustRefuse {
+		if len(ScanForCredentials(line)) == 0 {
+			t.Errorf("MISS a slash-bearing secret: %q", line)
+		}
+	}
+}
+
+// Round 5 N2 is an accepted trade, pinned here so the behaviour is deliberate
+// rather than accidental: a passphrase password and a kebab-case document slug
+// are indistinguishable by shape, so a secret-named key introducing a slug is
+// refused. The failure is loud (a warning plus an unresolved item), and the
+// alternative — missing a real passphrase — is silent.
+func TestScanForCredentialsPassphraseSlugAmbiguityIsDeliberate(t *testing.T) {
+	// The credential half of the trade must stay caught.
+	for _, line := range []string{
+		"password: Tr0ub4dor-and-3-horses\n",
+		"The app password is correct-horse-battery-staple\n",
+	} {
+		if len(ScanForCredentials(line)) == 0 {
+			t.Errorf("MISS a passphrase: %q", line)
+		}
+	}
+
+	// A slug in ordinary prose, with no secret-named key introducing it, is
+	// still copied — which is the common case.
+	for _, line := range []string{
+		"See workflow release-candidate-verification-checklist-v2.\n",
+		"The session is agent-deck-transition-notifier and it is healthy.\n",
+	} {
+		if lines := ScanForCredentials(line); len(lines) != 0 {
+			t.Errorf("FALSE POSITIVE on a slug in prose: %q -> %v", line, lines)
+		}
+	}
+}

--- a/internal/agents/credential_scan_test.go
+++ b/internal/agents/credential_scan_test.go
@@ -1,6 +1,11 @@
 package agents
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // The reviewer's twelve cases, six that must be refused and six that must be
 // copied.
@@ -45,5 +50,75 @@ func TestScanForCredentialsRealConductorProse(t *testing.T) {
 		if lines := ScanForCredentials(line); len(lines) != 0 {
 			t.Errorf("FALSE POSITIVE on conductor prose: %q -> lines %v", line, lines)
 		}
+	}
+}
+
+// The regression test this needed from the start: the scanner must return
+// nothing on the real conductor directory's own files.
+//
+// Round 3 refused the real 10,889-byte CLAUDE.md over "60s", "g14" and a
+// [HEARTBEAT] example — dropping the entry point of the flagship adoption
+// target — and nothing caught it, because every case pinned until then was a
+// line I had written myself. Fixture copies of the real files live under
+// testdata/ so this runs anywhere, with no dependency on the host's home.
+func TestScanForCredentialsRealConductorFiles(t *testing.T) {
+	entries, err := os.ReadDir(filepath.Join("testdata", "conductor"))
+	if err != nil {
+		t.Skipf("conductor fixture not present: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join("testdata", "conductor", entry.Name())
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read %s: %v", path, readErr)
+		}
+		if lines := ScanForCredentials(string(body)); len(lines) != 0 {
+			bodyLines := strings.Split(string(body), "\n")
+			for _, line := range lines {
+				if line-1 < len(bodyLines) {
+					t.Errorf("%s:%d flagged as a credential: %q", entry.Name(), line, bodyLines[line-1])
+				}
+			}
+		}
+	}
+}
+
+// The fleet's own vocabulary must survive the scanner.
+func TestScanForCredentialsFleetVocabulary(t *testing.T) {
+	for _, line := range []string{
+		"Has built-in 60s wait for agent readiness.",
+		"Advance the g14 fleet one bounded step per tick.",
+		"Check the g14 fleet manager before restarting anything.",
+		"Compare the sha256 digest before copying a role file.",
+		"Write every report as utf8 text only.",
+		"Build both x86 and arm targets before release.",
+		"PR 1996 fixed the g14 fleet drain.",
+		"## Secrets\nNever keep them near your code.",
+		"Token handling rules follow.\nKeep them safe from harm when possible.",
+	} {
+		if lines := ScanForCredentials(line); len(lines) != 0 {
+			t.Errorf("FALSE POSITIVE on fleet prose %q -> lines %v", line, lines)
+		}
+	}
+}
+
+// Shapes round 3 found were still missed.
+func TestScanForCredentialsRoundThreeMisses(t *testing.T) {
+	for name, body := range map[string]string{
+		"base32 TOTP seed":        "Seed for the authenticator:\nJBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP\n",
+		"hex key with assignment": "API key: 3f8a91c4be27d05e6a1fbc9370d24e85af610b73\n",
+		"lowercase 32-char key":   "Use nkjhgfdsapoiuytrewqmnbvcxzasdfgh when connecting.\n",
+	} {
+		if len(ScanForCredentials(body)) == 0 {
+			t.Errorf("MISS %s: %q", name, body)
+		}
+	}
+
+	// ...without reintroducing the git-SHA false positive.
+	if lines := ScanForCredentials("Fixed in 9f8e7d6c5b4a39281706f5e4d3c2b1a098765432 after review.\n"); len(lines) != 0 {
+		t.Errorf("git SHA flagged again: %v", lines)
 	}
 }

--- a/internal/agents/credential_scan_test.go
+++ b/internal/agents/credential_scan_test.go
@@ -1,0 +1,49 @@
+package agents
+
+import "testing"
+
+// The reviewer's twelve cases, six that must be refused and six that must be
+// copied.
+func TestScanForCredentialsReviewerCases(t *testing.T) {
+	mustRefuse := []struct{ name, body string }{
+		{"16-char app password, no spaces", "The Gmail app password is abcdefghijklmnop\n"},
+		{"password on the line after its heading", "## Gmail app password\nabcd efgh ijkl mnop\n"},
+		{"password inside a code fence", "## Gmail app password\n```\nabcd efgh ijkl mnop\n```\n"},
+		{"dash-grouped key, no secret word", "Use 7f3a-91b2-cc40 when connecting to the bridge.\n"},
+		{"32-char base64 blob", "Bridge value: aGVsbG9Xb3JsZFRoaXNJc0EzMkNoYXJz\n"},
+		{"password inside a connection URI", "postgres://svc:hunter2brown@db.example.com:5432/app\n"},
+	}
+	for _, tc := range mustRefuse {
+		if len(ScanForCredentials(tc.body)) == 0 {
+			t.Errorf("MISS (should refuse) %s: %q", tc.name, tc.body)
+		}
+	}
+
+	mustCopy := []struct{ name, body string }{
+		{"policy prose with colon", "Never commit a token: use the connector store instead.\n"},
+		{"policy prose heading", "Password handling: the agent never sees one.\n"},
+		{"git SHA in learnings", "Fixed in 9f8e7d6c5b4a39281706f5e4d3c2b1a098765432 after review.\n"},
+		{"kebab identifier", "See workflow release-candidate-verification-checklist-v2.\n"},
+		{"secrets prose", "Secrets: never inline them in a role directory.\n"},
+		{"api key rotation prose", "API key rotation: quarterly, tracked in the runbook.\n"},
+	}
+	for _, tc := range mustCopy {
+		if lines := ScanForCredentials(tc.body); len(lines) != 0 {
+			t.Errorf("FALSE POSITIVE (should copy) %s: %q -> lines %v", tc.name, tc.body, lines)
+		}
+	}
+}
+
+// His real POLICY.md line, and the one-character variant the reviewer said
+// would break it.
+func TestScanForCredentialsRealConductorProse(t *testing.T) {
+	for _, line := range []string{
+		`- "I need API keys / credentials / tokens"` + "\n",
+		`- "I need API keys: ask the human"` + "\n",
+		"Never merge without review.\nEscalate to the human on ambiguity.\n",
+	} {
+		if lines := ScanForCredentials(line); len(lines) != 0 {
+			t.Errorf("FALSE POSITIVE on conductor prose: %q -> lines %v", line, lines)
+		}
+	}
+}

--- a/internal/agents/credential_scan_test.go
+++ b/internal/agents/credential_scan_test.go
@@ -122,3 +122,36 @@ func TestScanForCredentialsRoundThreeMisses(t *testing.T) {
 		t.Errorf("git SHA flagged again: %v", lines)
 	}
 }
+
+// Round 4 residuals.
+func TestScanForCredentialsRoundFourResiduals(t *testing.T) {
+	mustRefuse := map[string]string{
+		"AWS key with slashes, assignment": "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+		"AWS key with slashes, prose":      "The AWS secret is wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
+		"passphrase, assignment":           "password: Tr0ub4dor-and-3-horses\n",
+		"passphrase, prose":                "The app password is correct-horse-battery-staple\n",
+		"credential in a table cell":       "| GMAIL_APP_PASSWORD | abcd efgh ijkl mnop |\n",
+	}
+	for name, body := range mustRefuse {
+		if len(ScanForCredentials(body)) == 0 {
+			t.Errorf("MISS %s: %q", name, body)
+		}
+	}
+
+	mustCopy := map[string]string{
+		"go test name":          "The failure is TestVerifyTabAnchorBlockIsWrappedNotClipped and it predates this branch.\n",
+		"go test name 2":        "See TestContextPagerNilReceiverIsSafe for the panic.\n",
+		"long constructor name": "Call NewHomeWithProfileAndModeForTesting from the seam.\n",
+		"long type name":        "The struct is RemoteSessionTransitionNotificationEvent.\n",
+		"env var name":          "Set AGENT_DECK_ALLOW_OUTER_TMUX before launching the TUI.\n",
+		"absolute path":         "Logs land in /home/ashesh/.local/share/agent-deck/logs/notify.log today.\n",
+		"kebab workflow name":   "See workflow release-candidate-verification-checklist-v2.\n",
+		"markdown table rule":   "|--------|---------|-------------|\n",
+		"table row, no secret":  "| status | meaning | example |\n",
+	}
+	for name, body := range mustCopy {
+		if lines := ScanForCredentials(body); len(lines) != 0 {
+			t.Errorf("FALSE POSITIVE %s: %q -> lines %v", name, body, lines)
+		}
+	}
+}

--- a/internal/agents/cron.go
+++ b/internal/agents/cron.go
@@ -1,0 +1,283 @@
+package agents
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CronSchedule is a parsed five-field cron expression.
+//
+// This exists to RENDER a next-due time for a trigger whose firing lives in a
+// plist or a systemd timer. It is a display calculation over a declared
+// schedule. Nothing in this package acts on the result.
+type CronSchedule struct {
+	Minute  fieldSet
+	Hour    fieldSet
+	Day     fieldSet
+	Month   fieldSet
+	Weekday fieldSet
+	// Location is the timezone the expression is evaluated in.
+	Location *time.Location
+	// RawSpec is the original text, kept for display.
+	RawSpec string
+}
+
+// fieldSet is a bitmask over the legal values of one cron field.
+type fieldSet struct {
+	bits uint64
+	// star records that the field was "*", which cron's day/weekday rule
+	// needs in order to behave correctly.
+	star bool
+}
+
+func (f fieldSet) has(value int) bool {
+	if value < 0 || value > 63 {
+		return false
+	}
+	return f.bits&(1<<uint(value)) != 0
+}
+
+// ParseCron parses a five-field cron expression: minute hour day month weekday.
+//
+// It supports *, numbers, lists (1,2), ranges (1-5) and steps (*/5, 1-9/2) —
+// the syntax the design commits to for v1. Anything else is rejected rather
+// than approximated, because a wrong next-due time is worse than none.
+func ParseCron(spec string, loc *time.Location) (*CronSchedule, error) {
+	if loc == nil {
+		loc = time.Local
+	}
+	fields := strings.Fields(strings.TrimSpace(spec))
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("cron %q: want 5 fields, got %d", spec, len(fields))
+	}
+
+	minute, err := parseCronField(fields[0], 0, 59)
+	if err != nil {
+		return nil, fmt.Errorf("cron %q minute: %w", spec, err)
+	}
+	hour, err := parseCronField(fields[1], 0, 23)
+	if err != nil {
+		return nil, fmt.Errorf("cron %q hour: %w", spec, err)
+	}
+	day, err := parseCronField(fields[2], 1, 31)
+	if err != nil {
+		return nil, fmt.Errorf("cron %q day: %w", spec, err)
+	}
+	month, err := parseCronField(fields[3], 1, 12)
+	if err != nil {
+		return nil, fmt.Errorf("cron %q month: %w", spec, err)
+	}
+	weekday, err := parseCronField(fields[4], 0, 7)
+	if err != nil {
+		return nil, fmt.Errorf("cron %q weekday: %w", spec, err)
+	}
+	// Cron accepts both 0 and 7 for Sunday.
+	if weekday.has(7) {
+		weekday.bits |= 1
+	}
+
+	return &CronSchedule{
+		Minute: minute, Hour: hour, Day: day, Month: month, Weekday: weekday,
+		Location: loc, RawSpec: strings.TrimSpace(spec),
+	}, nil
+}
+
+func parseCronField(field string, min, max int) (fieldSet, error) {
+	var result fieldSet
+	if field == "*" {
+		result.star = true
+		for v := min; v <= max; v++ {
+			result.bits |= 1 << uint(v)
+		}
+		return result, nil
+	}
+
+	for _, part := range strings.Split(field, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return result, fmt.Errorf("empty element in %q", field)
+		}
+
+		step := 1
+		if base, stepText, found := strings.Cut(part, "/"); found {
+			parsed, err := strconv.Atoi(strings.TrimSpace(stepText))
+			if err != nil || parsed <= 0 {
+				return result, fmt.Errorf("bad step %q", stepText)
+			}
+			step = parsed
+			part = strings.TrimSpace(base)
+		}
+
+		rangeStart, rangeEnd := min, max
+		switch {
+		case part == "*":
+			result.star = result.star || step == 1
+		case strings.Contains(part, "-"):
+			startText, endText, _ := strings.Cut(part, "-")
+			start, err := strconv.Atoi(strings.TrimSpace(startText))
+			if err != nil {
+				return result, fmt.Errorf("bad range start %q", startText)
+			}
+			end, err := strconv.Atoi(strings.TrimSpace(endText))
+			if err != nil {
+				return result, fmt.Errorf("bad range end %q", endText)
+			}
+			rangeStart, rangeEnd = start, end
+		default:
+			value, err := strconv.Atoi(part)
+			if err != nil {
+				return result, fmt.Errorf("bad value %q", part)
+			}
+			rangeStart, rangeEnd = value, value
+		}
+
+		if rangeStart < min || rangeEnd > max || rangeStart > rangeEnd {
+			return result, fmt.Errorf("range %d-%d out of bounds %d-%d", rangeStart, rangeEnd, min, max)
+		}
+		for v := rangeStart; v <= rangeEnd; v += step {
+			result.bits |= 1 << uint(v)
+		}
+	}
+	return result, nil
+}
+
+// maxCronSearchMinutes bounds the next-occurrence search at roughly four
+// years, enough to cover a Feb-29-only schedule and to terminate on an
+// expression that can never match.
+const maxCronSearchMinutes = 4 * 366 * 24 * 60
+
+// Next returns the next time the schedule fires strictly after `after`.
+// The second return is false when the expression cannot fire within the
+// search bound — the honest answer for "0 0 30 2 *".
+func (c *CronSchedule) Next(after time.Time) (time.Time, bool) {
+	if c == nil {
+		return time.Time{}, false
+	}
+	t := after.In(c.Location).Truncate(time.Minute).Add(time.Minute)
+
+	for i := 0; i < maxCronSearchMinutes; i++ {
+		if c.matches(t) {
+			return t, true
+		}
+		t = t.Add(time.Minute)
+	}
+	return time.Time{}, false
+}
+
+// matches implements cron's day-of-month / day-of-week rule: when both fields
+// are restricted, a match on EITHER counts.
+func (c *CronSchedule) matches(t time.Time) bool {
+	if !c.Minute.has(t.Minute()) || !c.Hour.has(t.Hour()) || !c.Month.has(int(t.Month())) {
+		return false
+	}
+
+	dayMatch := c.Day.has(t.Day())
+	weekdayMatch := c.Weekday.has(int(t.Weekday()))
+
+	switch {
+	case c.Day.star && c.Weekday.star:
+		return true
+	case c.Day.star:
+		return weekdayMatch
+	case c.Weekday.star:
+		return dayMatch
+	default:
+		return dayMatch || weekdayMatch
+	}
+}
+
+// DescribeCron renders a schedule the way the fleet list shows it. It stays
+// short and falls back to the raw expression rather than inventing prose for
+// something it does not recognize.
+func DescribeCron(spec string) string {
+	fields := strings.Fields(strings.TrimSpace(spec))
+	if len(fields) != 5 {
+		return spec
+	}
+	minute, hour, day, month, weekday := fields[0], fields[1], fields[2], fields[3], fields[4]
+
+	if day == "*" && month == "*" && weekday == "*" {
+		if strings.HasPrefix(minute, "*/") && hour == "*" {
+			return "cron " + strings.TrimPrefix(minute, "*/") + "m"
+		}
+		if hour == "*" && minute == "*" {
+			return "cron 1m"
+		}
+		if hour == "*" {
+			if _, err := strconv.Atoi(minute); err == nil {
+				return "cron hourly"
+			}
+		}
+		if minuteNum, err := strconv.Atoi(minute); err == nil {
+			if hourNum, hourErr := strconv.Atoi(hour); hourErr == nil {
+				return fmt.Sprintf("daily %02d:%02d", hourNum, minuteNum)
+			}
+		}
+	}
+	return "cron " + spec
+}
+
+// DescribeInterval renders a StartInterval-style cadence.
+func DescribeInterval(seconds int) string {
+	switch {
+	case seconds <= 0:
+		return ""
+	case seconds < 60:
+		return fmt.Sprintf("every %ds", seconds)
+	case seconds < 3600:
+		return fmt.Sprintf("every %dm", seconds/60)
+	case seconds%3600 == 0:
+		return fmt.Sprintf("every %dh", seconds/3600)
+	default:
+		return fmt.Sprintf("every %dm", seconds/60)
+	}
+}
+
+// SystemdCalendarToCron converts the simple, unambiguous OnCalendar forms to a
+// five-field cron expression so a next-due time can be rendered.
+//
+// It is deliberately conservative. systemd's calendar syntax is richer than
+// cron (weekday sets, repetition inside a field, sub-minute precision), and a
+// spec this function cannot convert exactly returns ok=false so the caller
+// keeps the raw text and says it could not compute a time. Rendering a wrong
+// next-due for a real timer would be worse than rendering none.
+func SystemdCalendarToCron(spec string) (string, bool) {
+	trimmed := strings.TrimSpace(spec)
+	switch strings.ToLower(trimmed) {
+	case "hourly":
+		return "0 * * * *", true
+	case "daily", "midnight":
+		return "0 0 * * *", true
+	case "weekly":
+		return "0 0 * * 1", true
+	case "monthly":
+		return "0 0 1 * *", true
+	case "yearly", "annually":
+		return "0 0 1 1 *", true
+	}
+
+	// "*-*-* HH:MM:SS" and "*-*-* HH:MM" — every day at a fixed time.
+	fields := strings.Fields(trimmed)
+	if len(fields) != 2 || fields[0] != "*-*-*" {
+		return "", false
+	}
+	timeParts := strings.Split(fields[1], ":")
+	if len(timeParts) < 2 || len(timeParts) > 3 {
+		return "", false
+	}
+	// A non-zero seconds field cannot be expressed in cron at all.
+	if len(timeParts) == 3 && strings.TrimSpace(timeParts[2]) != "00" && strings.TrimSpace(timeParts[2]) != "0" {
+		return "", false
+	}
+	hour, err := strconv.Atoi(strings.TrimSpace(timeParts[0]))
+	if err != nil || hour < 0 || hour > 23 {
+		return "", false
+	}
+	minute, err := strconv.Atoi(strings.TrimSpace(timeParts[1]))
+	if err != nil || minute < 0 || minute > 59 {
+		return "", false
+	}
+	return fmt.Sprintf("%d %d * * *", minute, hour), true
+}

--- a/internal/agents/cron.go
+++ b/internal/agents/cron.go
@@ -226,12 +226,14 @@ func DescribeInterval(seconds int) string {
 		return ""
 	case seconds < 60:
 		return fmt.Sprintf("every %ds", seconds)
-	case seconds < 3600:
-		return fmt.Sprintf("every %dm", seconds/60)
 	case seconds%3600 == 0:
 		return fmt.Sprintf("every %dh", seconds/3600)
-	default:
+	case seconds%60 == 0:
 		return fmt.Sprintf("every %dm", seconds/60)
+	default:
+		// Not a whole number of minutes. Flooring turned a 90-second cadence
+		// into "every 1m", which is a WRONG cadence rather than a coarse one.
+		return fmt.Sprintf("every %dm%ds", seconds/60, seconds%60)
 	}
 }
 

--- a/internal/agents/definition.go
+++ b/internal/agents/definition.go
@@ -1,0 +1,364 @@
+// Package agents implements the phase-1 slice of the Agents concept: portable
+// role/post definitions, adoption of an existing organic setup into those
+// definitions, and read-only views over them.
+//
+// Phase 1 is recognition before automation. Nothing in this package fires a
+// trigger, starts a runtime, or writes to a source system. Triggers carried in
+// a definition are DECLARATIVE ONLY: the plists and systemd units that own the
+// firing today keep owning it, and such rows are marked External so no reader
+// mistakes a rendered "next due" for a schedule agent-deck controls.
+package agents
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// APIVersion is stamped on every emitted document.
+	APIVersion = "agent-deck.io/v1alpha1"
+	// KindPost is the assignment-in-a-place document (agent.yaml).
+	KindPost = "AgentPost"
+	// KindRole is the portable-profession document (role/role.yaml).
+	KindRole = "AgentRole"
+
+	// PostFileName is the canonical post filename inside a definition dir.
+	// Design open question 1 chose the friendlier spelling; the directory is
+	// the "agent definition" and the role lives under ./role.
+	PostFileName = "agent.yaml"
+	// RoleDirName is the role subdirectory of a definition dir.
+	RoleDirName = "role"
+	// RoleFileName is the role manifest inside RoleDirName.
+	RoleFileName = "role.yaml"
+	// ReportFileName is the human-readable evidence map emitted by adoption.
+	ReportFileName = "ADOPTION-REPORT.md"
+)
+
+// Confidence grades an inferred field. Adoption is skeptical by construction:
+// anything it could not read directly out of the source is Low, and Low fields
+// never silently become behavior.
+type Confidence string
+
+const (
+	ConfidenceHigh   Confidence = "high"
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceLow    Confidence = "low"
+)
+
+// Classification labels what a target actually turned out to be. Only Agent
+// targets produce a post worth hiring; the rest are recorded so the fleet
+// inventory is honest about what else is running.
+type Classification string
+
+const (
+	// ClassAgent is something that does work on the user's behalf.
+	ClassAgent Classification = "agent"
+	// ClassConnector is a boundary to an external source (mail poller, bridge).
+	ClassConnector Classification = "connector"
+	// ClassService is local infrastructure that keeps other things alive.
+	ClassService Classification = "service"
+	// ClassExternal is real, running, and owned by something other than
+	// agent-deck — adopted for visibility, never for control.
+	ClassExternal Classification = "external"
+	// ClassDebris is a leftover: a unit pointing at a path that is gone, a
+	// plist for a binary that no longer exists.
+	ClassDebris Classification = "debris"
+)
+
+// Role names from the reference org chart. Adoption maps a target onto one of
+// these only when the evidence is obvious; everything else stays RoleUnresolved
+// so a human supplies the purpose rather than the tool guessing it.
+const (
+	RoleManager    = "manager"
+	RoleRegistrar  = "registrar"
+	RoleBuilder    = "builder"
+	RoleReviewer   = "reviewer"
+	RoleDevOps     = "devops"
+	RoleTriage     = "triage"
+	RoleUnresolved = "unresolved"
+)
+
+// PrincipalHuman is the root of every reports_to chain.
+const PrincipalHuman = "human:ashesh"
+
+// Evidence records how one generated field got its value. Every inferred field
+// in an emitted definition has exactly one of these; a field with no evidence
+// is a bug, not a default.
+type Evidence struct {
+	Field      string     `yaml:"field" json:"field"`
+	Value      string     `yaml:"value" json:"value"`
+	Source     string     `yaml:"source" json:"source"`
+	Confidence Confidence `yaml:"confidence" json:"confidence"`
+	// Reason says why the value was inferred. It is not a problem report.
+	Reason string `yaml:"reason,omitempty" json:"reason,omitempty"`
+	// Warning is a caution about trusting or acting on the value. Keeping it
+	// separate from Reason matters: a reader scanning for warnings should not
+	// have to read ordinary derivation notes filed under the same key.
+	Warning string `yaml:"warning,omitempty" json:"warning,omitempty"`
+}
+
+// RoleRef points a post at its role.
+type RoleRef struct {
+	Name    string `yaml:"name" json:"name"`
+	Path    string `yaml:"path,omitempty" json:"path,omitempty"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	Digest  string `yaml:"digest,omitempty" json:"digest,omitempty"`
+}
+
+// Placement binds a post to a project, a group, a machine and a manager.
+type Placement struct {
+	Project   string `yaml:"project,omitempty" json:"project,omitempty"`
+	Group     string `yaml:"group,omitempty" json:"group,omitempty"`
+	Machine   string `yaml:"machine,omitempty" json:"machine,omitempty"`
+	ReportsTo string `yaml:"reportsTo,omitempty" json:"reportsTo,omitempty"`
+}
+
+// RuntimeSpec selects the harness and account. Roles stay harness-neutral; this
+// is the only place a tool name is allowed to appear.
+type RuntimeSpec struct {
+	Harness string `yaml:"harness,omitempty" json:"harness,omitempty"`
+	Account string `yaml:"account,omitempty" json:"account,omitempty"`
+	Start   string `yaml:"start,omitempty" json:"start,omitempty"`
+	// AdoptedSessionID records which live session this post was recognized
+	// from. It is provenance, not control: phase 1 never takes the session
+	// over, renames it, or changes its lifecycle.
+	AdoptedSessionID string `yaml:"adoptedSessionId,omitempty" json:"adopted_session_id,omitempty"`
+}
+
+// RestartPolicy is recorded from the source's own settings so a later phase has
+// something to compare against. Phase 1 never acts on it.
+type RestartPolicy struct {
+	Mode        string `yaml:"mode,omitempty" json:"mode,omitempty"`
+	MaxAttempts int    `yaml:"maxAttempts,omitempty" json:"max_attempts,omitempty"`
+	Window      string `yaml:"window,omitempty" json:"window,omitempty"`
+}
+
+// ConnectorRef names a connector and the capabilities the post needs from it.
+// Naming a connector never creates or enables one.
+type ConnectorRef struct {
+	Name    string   `yaml:"name" json:"name"`
+	Require []string `yaml:"require,omitempty" json:"require,omitempty"`
+	// Kind is descriptive ("mail", "telegram", "webhook", "drain").
+	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
+	// EvidencePath is a local directory or file whose freshness tells us
+	// whether this connector is actually working (a seen-db, a health stamp).
+	// It is read, never written.
+	EvidencePath string `yaml:"evidencePath,omitempty" json:"evidence_path,omitempty"`
+}
+
+// Trigger kinds from the design's v1 set, plus the honest phase-1 addition.
+const (
+	TriggerCron              = "cron"
+	TriggerMailDoorbell      = "mail-doorbell"
+	TriggerFileWatch         = "file-watch"
+	TriggerWebhook           = "webhook"
+	TriggerSessionTransition = "session-transition"
+	// TriggerOpaque is what adoption emits when it can see that something
+	// fires but cannot honestly say on what terms.
+	TriggerOpaque = "opaque"
+)
+
+// Trigger is a DECLARED trigger. In phase 1 it is display-only.
+type Trigger struct {
+	Name     string `yaml:"name" json:"name"`
+	Type     string `yaml:"type" json:"type"`
+	Schedule string `yaml:"schedule,omitempty" json:"schedule,omitempty"`
+	// IntervalSeconds carries a StartInterval-style cadence that has no cron
+	// spelling.
+	IntervalSeconds int    `yaml:"intervalSeconds,omitempty" json:"interval_seconds,omitempty"`
+	Timezone        string `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	Workflow        string `yaml:"workflow,omitempty" json:"workflow,omitempty"`
+	// Deliver is the fixed, locally declared string. External content is never
+	// interpolated into it — see the injection invariant in the design.
+	Deliver  string `yaml:"deliver,omitempty" json:"deliver,omitempty"`
+	Coalesce string `yaml:"coalesce,omitempty" json:"coalesce,omitempty"`
+	// Enabled is false for everything adoption emits. A definition that
+	// arrived disabled must never be rendered as if it were live.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// External marks a trigger whose firing still lives in a plist, a systemd
+	// timer, or a shell manager. agent-deck displays its next due time and
+	// does not schedule it. Phase 1 sets this on every adopted trigger.
+	External bool `yaml:"external" json:"external"`
+	// ExternalSource is the file that actually owns the firing.
+	ExternalSource string `yaml:"externalSource,omitempty" json:"external_source,omitempty"`
+	// Connector names the source connector where applicable.
+	Connector string `yaml:"connector,omitempty" json:"connector,omitempty"`
+}
+
+// PostMetadata identifies the post.
+type PostMetadata struct {
+	Name   string `yaml:"name" json:"name"`
+	PostID string `yaml:"postId" json:"post_id"`
+	Title  string `yaml:"title,omitempty" json:"title,omitempty"`
+}
+
+// PostSpec is the body of an agent.yaml.
+type PostSpec struct {
+	Role           RoleRef        `yaml:"role" json:"role"`
+	Placement      Placement      `yaml:"placement" json:"placement"`
+	Runtime        RuntimeSpec    `yaml:"runtime" json:"runtime"`
+	RestartPolicy  *RestartPolicy `yaml:"restartPolicy,omitempty" json:"restart_policy,omitempty"`
+	Connectors     []ConnectorRef `yaml:"connectors,omitempty" json:"connectors,omitempty"`
+	Triggers       []Trigger      `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	Classification Classification `yaml:"classification" json:"classification"`
+	// Enabled is always false in phase 1. It exists so the field is present
+	// and inspectable, not so it can be flipped here.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Unresolved lists the decisions a human still owes this definition.
+	Unresolved []string   `yaml:"unresolved,omitempty" json:"unresolved,omitempty"`
+	Provenance []Evidence `yaml:"provenance,omitempty" json:"provenance,omitempty"`
+	// SourceFingerprint lets a later `adopt --refresh` show drift.
+	SourceFingerprint string    `yaml:"sourceFingerprint,omitempty" json:"source_fingerprint,omitempty"`
+	AdoptedAt         time.Time `yaml:"adoptedAt,omitempty" json:"adopted_at,omitempty"`
+	AdoptedFrom       string    `yaml:"adoptedFrom,omitempty" json:"adopted_from,omitempty"`
+}
+
+// Post is a full agent.yaml document.
+type Post struct {
+	APIVersion string       `yaml:"apiVersion" json:"api_version"`
+	Kind       string       `yaml:"kind" json:"kind"`
+	Metadata   PostMetadata `yaml:"metadata" json:"metadata"`
+	Spec       PostSpec     `yaml:"spec" json:"spec"`
+}
+
+// RoleMetadata identifies a role.
+type RoleMetadata struct {
+	Name    string `yaml:"name" json:"name"`
+	Version string `yaml:"version" json:"version"`
+}
+
+// LearningsSpec points at the curated learning surface.
+type LearningsSpec struct {
+	File      string `yaml:"file,omitempty" json:"file,omitempty"`
+	Promotion string `yaml:"promotion,omitempty" json:"promotion,omitempty"`
+}
+
+// RoleSpec is the body of a role.yaml. It names files; it never re-expresses
+// their steps.
+type RoleSpec struct {
+	RequiresAgentDeck string            `yaml:"requiresAgentDeck,omitempty" json:"requires_agent_deck,omitempty"`
+	Description       string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Entrypoint        string            `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Policy            []string          `yaml:"policy,omitempty" json:"policy,omitempty"`
+	Playbooks         map[string]string `yaml:"playbooks,omitempty" json:"playbooks,omitempty"`
+	Workflows         map[string]string `yaml:"workflows,omitempty" json:"workflows,omitempty"`
+	Learnings         *LearningsSpec    `yaml:"learnings,omitempty" json:"learnings,omitempty"`
+	RequiresCaps      []string          `yaml:"requiresCapabilities,omitempty" json:"requires_capabilities,omitempty"`
+	// Digests records a content digest per copied file so a runtime's inputs
+	// are inspectable by digest.
+	Digests map[string]string `yaml:"digests,omitempty" json:"digests,omitempty"`
+}
+
+// Role is a full role.yaml document.
+type Role struct {
+	APIVersion string       `yaml:"apiVersion" json:"api_version"`
+	Kind       string       `yaml:"kind" json:"kind"`
+	Metadata   RoleMetadata `yaml:"metadata" json:"metadata"`
+	Spec       RoleSpec     `yaml:"spec" json:"spec"`
+}
+
+// NewPost returns a post skeleton with the invariant fields already correct:
+// disabled, reporting to a human principal, and stamped with this API version.
+func NewPost(name, postID string) *Post {
+	return &Post{
+		APIVersion: APIVersion,
+		Kind:       KindPost,
+		Metadata:   PostMetadata{Name: name, PostID: postID},
+		Spec: PostSpec{
+			Enabled:   false,
+			Placement: Placement{ReportsTo: PrincipalHuman},
+		},
+	}
+}
+
+// NewRole returns a role skeleton.
+func NewRole(name, version string) *Role {
+	return &Role{
+		APIVersion: APIVersion,
+		Kind:       KindRole,
+		Metadata:   RoleMetadata{Name: name, Version: version},
+	}
+}
+
+// AddEvidence records provenance for one generated field.
+func (p *Post) AddEvidence(field, value, source string, confidence Confidence, warning string) {
+	p.Spec.Provenance = append(p.Spec.Provenance, Evidence{
+		Field:      field,
+		Value:      value,
+		Source:     source,
+		Confidence: confidence,
+		Warning:    warning,
+	})
+}
+
+// AddInference records provenance whose note explains HOW the value was
+// derived rather than warning about it.
+func (p *Post) AddInference(field, value, source string, confidence Confidence, reason string) {
+	p.Spec.Provenance = append(p.Spec.Provenance, Evidence{
+		Field:      field,
+		Value:      value,
+		Source:     source,
+		Confidence: confidence,
+		Reason:     reason,
+	})
+}
+
+// AddUnresolved records a decision the definition still owes a human. Repeated
+// entries collapse so a refresh does not grow the list without bound.
+func (p *Post) AddUnresolved(item string) {
+	for _, existing := range p.Spec.Unresolved {
+		if existing == item {
+			return
+		}
+	}
+	p.Spec.Unresolved = append(p.Spec.Unresolved, item)
+}
+
+// MarshalPost renders a post as YAML.
+func MarshalPost(p *Post) ([]byte, error) {
+	out, err := yaml.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal post %q: %w", p.Metadata.Name, err)
+	}
+	return out, nil
+}
+
+// MarshalRole renders a role as YAML.
+func MarshalRole(r *Role) ([]byte, error) {
+	out, err := yaml.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("marshal role %q: %w", r.Metadata.Name, err)
+	}
+	return out, nil
+}
+
+// ParsePost decodes an agent.yaml. It is strict about the document header so a
+// stray YAML file in the agents directory is reported rather than half-read.
+func ParsePost(data []byte) (*Post, error) {
+	var p Post
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse post: %w", err)
+	}
+	if strings.TrimSpace(p.Kind) != KindPost {
+		return nil, fmt.Errorf("parse post: kind is %q, want %q", p.Kind, KindPost)
+	}
+	if strings.TrimSpace(p.APIVersion) == "" {
+		return nil, fmt.Errorf("parse post %q: missing apiVersion", p.Metadata.Name)
+	}
+	return &p, nil
+}
+
+// ParseRole decodes a role.yaml.
+func ParseRole(data []byte) (*Role, error) {
+	var r Role
+	if err := yaml.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse role: %w", err)
+	}
+	if strings.TrimSpace(r.Kind) != KindRole {
+		return nil, fmt.Errorf("parse role: kind is %q, want %q", r.Kind, KindRole)
+	}
+	return &r, nil
+}

--- a/internal/agents/health.go
+++ b/internal/agents/health.go
@@ -1,0 +1,233 @@
+package agents
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// HealthState is what we can actually prove about a connector or service.
+type HealthState string
+
+const (
+	// HealthOK means we found positive evidence it is working: a live process,
+	// or a freshness file touched inside the staleness window.
+	HealthOK HealthState = "ok"
+	// HealthStale means the evidence exists but is old. The thing may be
+	// running and idle, or it may be wedged — the age is reported so a human
+	// can tell.
+	HealthStale HealthState = "stale"
+	// HealthDown means we found positive evidence it is NOT working: a pid
+	// file naming a process that is gone.
+	HealthDown HealthState = "down"
+	// HealthUnknown means we could not find evidence either way. It is not a
+	// synonym for down, and must never be rendered as one.
+	HealthUnknown HealthState = "unknown"
+)
+
+// DefaultStaleAfter is the age past which freshness evidence stops counting as
+// proof of life. It is a display threshold, not a policy: the exact age is
+// always reported alongside the state.
+const DefaultStaleAfter = 30 * time.Minute
+
+// Health is one connector or service row.
+type Health struct {
+	Name  string      `json:"name"`
+	Kind  string      `json:"kind,omitempty"`
+	State HealthState `json:"state"`
+	// Detail is the human-readable reason for State, always naming the
+	// evidence it rests on.
+	Detail string `json:"detail"`
+	// PID is set when a pid file was found and read.
+	PID int `json:"pid,omitempty"`
+	// LastFresh is the newest mtime found under the evidence path.
+	LastFresh time.Time `json:"last_fresh,omitempty"`
+	// EvidencePath is what was inspected.
+	EvidencePath string `json:"evidence_path,omitempty"`
+	// FreshnessFile is the specific file whose mtime produced LastFresh.
+	FreshnessFile string `json:"freshness_file,omitempty"`
+}
+
+// freshnessNames are the file names that indicate a poller did work, in the
+// order we prefer them. A seen-database that just grew is the strongest
+// evidence a mail poller actually fetched.
+var freshnessNames = []string{
+	"seen.db", "seen.json", "seen", "state.json", "cursor", "cursor.json",
+	"health", "health.json", "health.txt", "last-run", "last_run", "heartbeat",
+}
+
+// pidFileNames are where a poller or service typically records its pid.
+var pidFileNames = []string{"pid", "run.pid", "daemon.pid", "service.pid"}
+
+// CheckHealth inspects a connector or service and reports what the evidence
+// supports. It reads mtimes and pid files, and probes process liveness with a
+// null signal. It never starts, stops, or signals anything for real.
+func CheckHealth(name, kind, evidencePath string, staleAfter time.Duration, now time.Time) Health {
+	h := Health{Name: name, Kind: kind, EvidencePath: evidencePath, State: HealthUnknown}
+	if staleAfter <= 0 {
+		staleAfter = DefaultStaleAfter
+	}
+	if strings.TrimSpace(evidencePath) == "" {
+		h.Detail = "no local evidence path is bound; health cannot be determined"
+		return h
+	}
+
+	info, err := os.Stat(evidencePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			h.Detail = "evidence path does not exist: " + evidencePath
+			return h
+		}
+		h.Detail = "cannot read evidence path: " + err.Error()
+		return h
+	}
+
+	// A pid file is the strongest signal, because it can prove the negative.
+	if info.IsDir() {
+		if pid, pidPath, found := readPIDFile(evidencePath); found {
+			h.PID = pid
+			if processAlive(pid) {
+				h.State = HealthOK
+				h.Detail = fmt.Sprintf("pid %d from %s is alive", pid, filepath.Base(pidPath))
+			} else {
+				h.State = HealthDown
+				h.Detail = fmt.Sprintf("pid %d from %s is not running", pid, filepath.Base(pidPath))
+				return h
+			}
+		}
+	}
+
+	freshFile, freshTime, found := newestFreshness(evidencePath, info)
+	if !found {
+		if h.State == HealthOK {
+			// Live process, no freshness trace. Say exactly that.
+			h.Detail += "; no freshness file found, so recent work is unproven"
+		} else {
+			h.Detail = "no pid file and no freshness file under " + evidencePath
+		}
+		return h
+	}
+
+	h.LastFresh = freshTime
+	h.FreshnessFile = freshFile
+	age := now.Sub(freshTime)
+	ageText := fmt.Sprintf("%s ago", RoundDuration(age))
+
+	switch {
+	case age <= staleAfter:
+		if h.State != HealthOK {
+			h.State = HealthOK
+		}
+		h.Detail = fmt.Sprintf("%s updated %s", filepath.Base(freshFile), ageText)
+	default:
+		if h.State == HealthOK {
+			// Process is alive but has not done anything in a while. That is
+			// stale work, not a dead service, and the row should say so.
+			h.State = HealthStale
+			h.Detail = fmt.Sprintf("pid %d alive but %s last updated %s", h.PID, filepath.Base(freshFile), ageText)
+		} else {
+			h.State = HealthStale
+			h.Detail = fmt.Sprintf("%s last updated %s", filepath.Base(freshFile), ageText)
+		}
+	}
+	return h
+}
+
+// readPIDFile looks for a pid file in a directory and reads it.
+func readPIDFile(dir string) (int, string, bool) {
+	for _, name := range pidFileNames {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var pid int
+		if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid); err != nil || pid <= 0 {
+			continue
+		}
+		return pid, path, true
+	}
+	return 0, "", false
+}
+
+// processAlive probes a pid with signal 0: it asks the kernel whether the
+// process exists without delivering anything.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	// EPERM means it exists and belongs to someone else.
+	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EPERM)
+}
+
+// newestFreshness finds the most recent freshness evidence at a path. For a
+// file, that is the file itself. For a directory, it prefers a known freshness
+// name and otherwise falls back to the newest regular file directly inside it.
+func newestFreshness(path string, info os.FileInfo) (string, time.Time, bool) {
+	if !info.IsDir() {
+		return path, info.ModTime(), true
+	}
+
+	for _, name := range freshnessNames {
+		candidate := filepath.Join(path, name)
+		if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+			return candidate, stat.ModTime(), true
+		}
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return "", time.Time{}, false
+	}
+	var (
+		newestPath string
+		newestTime time.Time
+		found      bool
+	)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		stat, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if !found || stat.ModTime().After(newestTime) {
+			newestPath = filepath.Join(path, entry.Name())
+			newestTime = stat.ModTime()
+			found = true
+		}
+	}
+	return newestPath, newestTime, found
+}
+
+// RoundDuration renders an age the way the fleet views do: coarse, and never
+// more precise than it is meaningful.
+func RoundDuration(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 48*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/internal/agents/health.go
+++ b/internal/agents/health.go
@@ -117,6 +117,15 @@ func CheckHealth(name, kind, evidencePath string, staleAfter time.Duration, now 
 	h.FreshnessFile = freshFile
 	age := now.Sub(freshTime)
 	ageText := fmt.Sprintf("%s ago", RoundDuration(age))
+	if age < 0 {
+		// A future timestamp is not proof of recent work, it is a clock
+		// problem. RoundDuration takes an absolute value, so without this a
+		// file dated next week would read as "5m ago" and count as fresh.
+		h.State = HealthUnknown
+		h.Detail = fmt.Sprintf("%s is dated %s in the future; clock or mtime is wrong",
+			filepath.Base(freshFile), RoundDuration(age))
+		return h
+	}
 
 	switch {
 	case age <= staleAfter:

--- a/internal/agents/store.go
+++ b/internal/agents/store.go
@@ -1,0 +1,263 @@
+package agents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+)
+
+// dirName is the registry directory under agent-deck's data root.
+const dirName = "agents"
+
+// Dir returns the agents registry directory.
+//
+// The marker is the directory's own name, which is the convention every other
+// data directory in the binary follows (inboxes, logs, conductor, locks…).
+// Resolution is therefore per-directory: an install that already has
+// ~/.agent-deck/agents keeps using it, and a new registry is created under the
+// XDG data dir. Deliberately NOT keyed off a sibling marker like "runtime" —
+// this deployment has runtime/ in the legacy root while inboxes/, logs/ and
+// profiles/ are already XDG, so borrowing another directory's marker would
+// strand the registry in whichever root happened to be checked first.
+func Dir() (string, error) {
+	return agentpaths.EffectiveDataPath(dirName, dirName)
+}
+
+// DefinitionDir returns the directory for one named definition.
+func DefinitionDir(name string) (string, error) {
+	if err := validName(name); err != nil {
+		return "", err
+	}
+	root, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, name), nil
+}
+
+// validName keeps a generated definition name from escaping the registry.
+func validName(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return errors.New("agents: empty definition name")
+	}
+	if trimmed != filepath.Clean(trimmed) || !filepath.IsLocal(trimmed) {
+		return fmt.Errorf("agents: unsafe definition name %q", name)
+	}
+	if strings.ContainsAny(trimmed, `/\`) {
+		return fmt.Errorf("agents: definition name %q must not contain a path separator", name)
+	}
+	return nil
+}
+
+// Definition is a loaded post plus its role, as found on disk.
+type Definition struct {
+	// Name is the registry directory name.
+	Name string `json:"name"`
+	// Dir is the absolute definition directory.
+	Dir  string `json:"dir"`
+	Post *Post  `json:"post"`
+	Role *Role  `json:"role,omitempty"`
+	// LoadError is set when the directory exists but could not be read as a
+	// definition. A malformed record is reported, never silently skipped:
+	// one bad record must not make the rest of the fleet look smaller than
+	// it is.
+	LoadError string `json:"load_error,omitempty"`
+}
+
+// Load reads one definition directory.
+func Load(dir string) (*Definition, error) {
+	def := &Definition{Name: filepath.Base(dir), Dir: dir}
+
+	postBytes, err := os.ReadFile(filepath.Join(dir, PostFileName))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", PostFileName, err)
+	}
+	post, err := ParsePost(postBytes)
+	if err != nil {
+		return nil, err
+	}
+	def.Post = post
+
+	roleBytes, err := os.ReadFile(filepath.Join(dir, RoleDirName, RoleFileName))
+	switch {
+	case err == nil:
+		role, parseErr := ParseRole(roleBytes)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		def.Role = role
+	case errors.Is(err, fs.ErrNotExist):
+		// A post may reference an external role; that is legal.
+	default:
+		return nil, fmt.Errorf("read %s: %w", RoleFileName, err)
+	}
+
+	return def, nil
+}
+
+// LoadAll reads every definition in the registry, sorted by name.
+//
+// A missing registry directory is not an error: it is the zero-config user,
+// who must see nothing new. Callers distinguish "no agents" from "could not
+// look" by the returned error, never by an empty slice.
+func LoadAll() ([]*Definition, error) {
+	root, err := Dir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read agents registry %q: %w", root, err)
+	}
+
+	var defs []*Definition
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		dir := filepath.Join(root, entry.Name())
+		if _, statErr := os.Stat(filepath.Join(dir, PostFileName)); statErr != nil {
+			// Not a definition directory. Leave it alone rather than
+			// guessing at it.
+			continue
+		}
+		def, loadErr := Load(dir)
+		if loadErr != nil {
+			defs = append(defs, &Definition{
+				Name:      entry.Name(),
+				Dir:       dir,
+				LoadError: loadErr.Error(),
+			})
+			continue
+		}
+		defs = append(defs, def)
+	}
+	sort.Slice(defs, func(i, j int) bool { return defs[i].Name < defs[j].Name })
+	return defs, nil
+}
+
+// Exists reports whether the registry directory is present. A zero-config user
+// has no registry, and every new surface keys off this.
+func Exists() (bool, error) {
+	root, err := Dir()
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.IsDir(), nil
+}
+
+// Write persists a definition directory: agent.yaml, role/role.yaml, the
+// copied role bodies, and the adoption report.
+//
+// It writes only inside the registry. Nothing here touches the source that was
+// adopted; that is the whole contract of phase 1.
+func Write(dir string, post *Post, role *Role, roleFiles map[string][]byte, report string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create definition dir: %w", err)
+	}
+
+	postBytes, err := MarshalPost(post)
+	if err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(dir, PostFileName), postBytes); err != nil {
+		return err
+	}
+
+	if role != nil {
+		roleDir := filepath.Join(dir, RoleDirName)
+		if err := os.MkdirAll(roleDir, 0o700); err != nil {
+			return fmt.Errorf("create role dir: %w", err)
+		}
+		roleBytes, err := MarshalRole(role)
+		if err != nil {
+			return err
+		}
+		if err := writeFile(filepath.Join(roleDir, RoleFileName), roleBytes); err != nil {
+			return err
+		}
+		names := make([]string, 0, len(roleFiles))
+		for name := range roleFiles {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if !filepath.IsLocal(name) {
+				return fmt.Errorf("role file %q escapes the role directory", name)
+			}
+			target := filepath.Join(roleDir, name)
+			if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+				return fmt.Errorf("create role subdir for %q: %w", name, err)
+			}
+			if err := writeFile(target, roleFiles[name]); err != nil {
+				return err
+			}
+		}
+	}
+
+	if strings.TrimSpace(report) != "" {
+		if err := writeFile(filepath.Join(dir, ReportFileName), []byte(report)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeFile writes with owner-only permissions. Roles are private by default;
+// a definition may encode confidential working methods even though it must
+// never hold a credential.
+func writeFile(path string, data []byte) error {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return nil
+}
+
+// Digest returns the content digest recorded for role files, so a runtime's
+// inputs stay inspectable by digest.
+func Digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// FingerprintPaths produces a stable fingerprint over the source files an
+// adoption read, so a later refresh can show drift without storing the bodies.
+func FingerprintPaths(paths []string) string {
+	// No source files read means no fingerprint. Returning the digest of an
+	// empty stream would look like a real fingerprint and would compare
+	// equal across unrelated definitions.
+	if len(paths) == 0 {
+		return ""
+	}
+	sorted := append([]string(nil), paths...)
+	sort.Strings(sorted)
+	hasher := sha256.New()
+	for _, path := range sorted {
+		info, err := os.Stat(path)
+		if err != nil {
+			fmt.Fprintf(hasher, "%s\x00missing\x00", path)
+			continue
+		}
+		fmt.Fprintf(hasher, "%s\x00%d\x00%d\x00", path, info.Size(), info.ModTime().UnixNano())
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/agents/testdata/conductor/CLAUDE.md
+++ b/internal/agents/testdata/conductor/CLAUDE.md
@@ -1,0 +1,205 @@
+# Conductor: Shared Knowledge Base
+
+This file contains shared infrastructure knowledge (CLI reference, protocols, formats) for all conductor sessions.
+Each conductor has its own identity in its subdirectory and its own policy in POLICY.md.
+
+## Agent-Deck CLI Reference
+
+### Status & Listing
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p <PROFILE> status --json` | Get counts: `{"waiting": N, "running": N, "idle": N, "error": N, "stopped": N, "total": N}` |
+| `agent-deck -p <PROFILE> list --json` | List all sessions with details (id, title, path, tool, status, group) |
+| `agent-deck -p <PROFILE> session show --json <id_or_title>` | Full details for one session |
+
+### Reading Session Output
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p <PROFILE> session output <id_or_title> -q` | Get the last response (raw text, perfect for reading) |
+
+### Sending Messages to Sessions
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p <PROFILE> session send <id_or_title> "message"` | Send a message. Has built-in 60s wait for agent readiness. |
+| `agent-deck -p <PROFILE> session send <id_or_title> "message" --wait -q --timeout 300s` | Single-call send + wait + raw output (preferred when you need the reply now). |
+| `agent-deck -p <PROFILE> session send <id_or_title> "message" --no-wait` | Send immediately without waiting for ready state. |
+| `agent-deck -p <PROFILE> session approve <id_or_title> [once|always|session|N]` | Resolve a visible Codex approval prompt with one keypress. Never use `session send "1"` for Codex approvals. |
+
+### Session Control
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p <PROFILE> session start <id_or_title>` | Start a stopped session |
+| `agent-deck -p <PROFILE> session stop <id_or_title>` | Stop a running session |
+| `agent-deck -p <PROFILE> session restart <id_or_title>` | Restart a managed session |
+| `agent-deck -p <PROFILE> add <path> -t "Title" -c claude -g "group"` | Create a new Claude Code session |
+| `agent-deck -p <PROFILE> launch <path> -t "Title" -c claude -g "group" -m "prompt"` | Create + start + send initial prompt in one command (preferred for new task sessions) |
+| `agent-deck -p <PROFILE> add <path> -t "Title" -c claude --worktree feature/branch -b` | Create a new Claude Code session with a worktree |
+
+### Session Resolution
+Commands accept: **exact title**, **ID prefix** (e.g., first 4 chars), **path**, or **fuzzy match**.
+
+## Session Status Values
+
+| Status | Meaning | Your Action |
+|--------|---------|-------------|
+| `running` (green) | The conductor is actively processing | Do nothing. Wait. |
+| `waiting` (yellow) | The conductor finished and needs input | Read output, decide: auto-respond or escalate |
+| `idle` (gray) | Waiting, but user acknowledged | User knows about it. Skip unless asked. |
+| `error` (red) | Crashed, missing, or wedged (auth/model failure) | Check the substate first. Then try `session restart`; if that fails, escalate. |
+
+**Substate (Claude sessions only; refines status in `list`/`show` JSON):** `auth-401` covers two different pane banners. A credential banner (`Please run /login`, `API Error: 401`) means the fleet is HOLDING the session; restarting will NOT fix it. Check `session show --json <id>` for the `auth_hold` object (the authoritative source, present even after the pane exits) and escalate for re-login. A dropped-socket banner (`socket connection closed`) also classifies as `auth-401` but is NOT held and IS restart-recoverable: restart it. `model-unavailable` means the selected model is down (shows as error, not running); self-heal currently only observes this and takes no action, so switch it yourself with `agent-deck -p <PROFILE> session set <id> model <model>` then `agent-deck -p <PROFILE> session restart <id>`. `idle-at-empty-prompt` (shown as coarse status `idle` or `waiting`) means the session is genuinely sitting at its prompt with nothing happening. Never restart-loop an `error` session that `auth_hold` confirms is credential-held.
+
+## Heartbeat Protocol
+
+Every N minutes, the bridge sends you a message like:
+
+```
+[HEARTBEAT] [<name>] Status: 2 waiting, 3 running, 1 idle, 0 error. Waiting sessions: frontend (project: ~/src/app), api-fix (project: ~/src/api). Check if any need auto-response or user attention.
+```
+
+**FIRST step of EVERY heartbeat — drain your inbox:**
+
+```bash
+agent-deck inbox drain self
+```
+
+This pulls any child completions that landed in your durable outbox while you were
+busy (issue #1225/#1226). Delivery is pull, not push: a child that finished mid-turn
+committed its completion to `~/.agent-deck/inboxes/<your-id>.jsonl` rather than typing
+into your pane. The drain marks records consumed (exactly-once effects) and prints
+them; act on each before composing your status. Your Stop hook drains the same queue
+automatically at each turn boundary, so this heartbeat drain is the idle-conductor
+fallback — together they guarantee no completion is missed whether you are busy or idle.
+
+**Your heartbeat response format:**
+
+```
+[STATUS] All clear.
+```
+
+or:
+
+```
+[STATUS] Auto-responded to 1 session. 1 needs your attention.
+
+AUTO: frontend - told it to use the existing auth middleware
+NEED: api-fix - asking whether to run integration tests against staging or prod
+```
+
+Your response is parsed: if it contains `NEED:` lines, those get forwarded to the user (via remote channels if configured, or visible in the TUI/task-log).
+
+## State Management
+
+Maintain `./state.json` for persistent context across compactions:
+
+```json
+{
+  "sessions": {
+    "session-id-here": {
+      "title": "frontend",
+      "project": "~/src/app",
+      "summary": "Building auth flow with React Router v7",
+      "last_auto_response": "2025-01-15T10:30:00Z",
+      "escalated": false
+    }
+  },
+  "last_heartbeat": "2025-01-15T10:30:00Z",
+  "auto_responses_today": 5,
+  "escalations_today": 2
+}
+```
+
+Read state.json at the start of each interaction. Update it after taking action. Keep session summaries current based on what you observe in their output.
+
+## Task Log
+
+Append every action to `./task-log.md`:
+
+```markdown
+## 2025-01-15 10:30 - Heartbeat
+- Scanned 5 sessions (2 waiting, 3 running)
+- Auto-responded to frontend: "Use the existing AuthProvider component"
+- Escalated api-fix: needs decision on test environment
+
+## 2025-01-15 10:15 - User Message
+- User asked: "What's the status of the api server?"
+- Checked session 'api-server': running, working on endpoint validation
+- Responded with summary
+```
+
+## Self-Improvement
+
+Maintain `LEARNINGS.md` to track orchestration patterns. Two tiers exist:
+- `../LEARNINGS.md` (shared): patterns that work across all conductors
+- `./LEARNINGS.md` (per-conductor): patterns specific to your profile and sessions
+
+### When to Log
+
+| Situation | Entry Type |
+|-----------|-----------|
+| You auto-responded and user later said it was wrong | `auto_response_wrong` |
+| You auto-responded and it worked well | `auto_response_ok` |
+| You escalated but user said it was fine to auto-respond | `escalation_unnecessary` |
+| You escalated and user confirmed it needed attention | `escalation_correct` |
+| You notice a recurring session behavior | `session_behavior` |
+| You discover a useful pattern | `pattern` |
+
+### Promotion to Policy
+
+When an entry reaches Recurrence 3+ and has proven reliable, promote it:
+1. Distill into a concise rule
+2. Add to `./POLICY.md` (create if needed) or request update to `../POLICY.md` (shared)
+3. Set entry Status to `promoted`
+
+### At Startup
+
+Read both `./LEARNINGS.md` and `../LEARNINGS.md` before responding. Past patterns inform current decisions.
+
+## Quick Commands
+
+You may receive these special commands (from remote channels or the CLI):
+
+| Command | What to Do |
+|---------|------------|
+| `/status` | Run `agent-deck -p <PROFILE> status --json` and format a brief summary |
+| `/sessions` | Run `agent-deck -p <PROFILE> list --json` and list active sessions with status |
+| `/check <name>` | Run `agent-deck -p <PROFILE> session output <name> -q` and summarize what it's doing |
+| `/send <name> <msg>` | Forward the message to that session via `agent-deck -p <PROFILE> session send` |
+| `/help` | List available commands |
+
+For any other text, treat it as a conversational message from the user. They might ask about session progress, give instructions for specific sessions, or ask you to create/manage sessions.
+
+## Slack Message Format
+
+When messages arrive from Slack, the bridge tags them with sender and channel context:
+
+```
+[from:alice (U12345)] [channel:#bugs (C67890)] the login button is broken
+[from:bob (U11111)] [dm] can you check the API?
+[from:charlie (U22222)] [channel:#feature-requests (C33333)] add dark mode support
+```
+
+- `[from:<name> (<user_id>)]` — The Slack display name and stable user ID of the sender
+- `[channel:#<name> (<channel_id>)]` — The Slack channel name and stable channel ID
+- `[dm]` — The message was sent via direct message
+
+Use these tags to:
+- **Identify the requester** when logging actions or escalating
+- **Route by channel** — messages from #bugs are likely bug reports, #ideas are feature requests
+- **Include sender context in escalations** — e.g., "NEED: @alice (#bugs): login button broken"
+
+If the bridge cannot resolve a name (temporary API failure), the raw Slack ID appears alone (e.g., `[from:U12345 (U12345)]`, `[channel:C99999]`). Failed lookups are retried automatically after 5 minutes.
+
+## Important Notes
+
+- This project is `asheshgoplani/agent-deck` on GitHub. When referencing GitHub issues or PRs, always use owner `asheshgoplani` and repo `agent-deck`. Never use `anthropics` as the owner.
+- You cannot directly access other sessions' files. Use `session output` to read their latest response.
+- Prefer `launch ... -m "prompt"` over separate `add` + `session start` + `session send` when creating a new task session.
+- Keep parent linkage for event routing; if you need a specific group, pass `-g <group>` explicitly (it overrides inherited parent group).
+- Transition notifications are parent-linked. If `parent_session_id` is empty or points elsewhere, this conductor will not receive child completion events.
+- `session send` waits up to ~80 seconds for the agent to be ready. If the session is running (busy), the send will wait.
+- When a Codex child shows a numbered approval menu, use `session approve <id> <choice>`. A digit sent through `session send` is composer text plus Enter and can interrupt the resumed turn.
+- For periodic nudges/heartbeats where blocking is harmful, prefer `session send --no-wait -q`.
+- Remote channels send with `session send --wait -q` and wait in a single CLI call. Reply promptly.
+- Your own session can be restarted by the bridge if it detects you're in an error state.
+- Keep state.json small (no large output dumps). Store summaries, not full text.

--- a/internal/agents/testdata/conductor/LEARNINGS.md
+++ b/internal/agents/testdata/conductor/LEARNINGS.md
@@ -1,0 +1,21 @@
+# Conductor Learnings
+
+Orchestration patterns learned from experience. Review at startup and before heartbeat responses.
+
+## How to Use This File
+
+- **Log** a new entry when: you auto-respond and later learn it was wrong, you escalate and user says it was unnecessary, you discover a pattern in session behavior, or a recurring situation emerges.
+- **Promote** entries to POLICY.md when they recur 3+ times and prove reliable.
+- **Delete** entries that turn out to be wrong or no longer relevant.
+
+## Entry Format
+
+### [YYYYMMDD-NNN] Short description
+- **Type**: auto_response_ok | auto_response_wrong | escalation_unnecessary | escalation_correct | pattern | session_behavior
+- **Sessions**: which session(s) this involved
+- **Context**: what happened
+- **Lesson**: what to do differently (or keep doing)
+- **Recurrence**: N (increment when seen again)
+- **Status**: active | promoted | retired
+
+---

--- a/internal/agents/testdata/conductor/POLICY.md
+++ b/internal/agents/testdata/conductor/POLICY.md
@@ -1,0 +1,35 @@
+# Conductor Policy
+
+Operating rules that govern how the conductor behaves.
+This file can be overridden per conductor by placing a POLICY.md in the conductor's directory.
+
+## Core Rules
+
+1. **Keep responses SHORT.** The user reads them on their phone. 1-3 sentences max for status updates. Use bullet points for lists.
+2. **Auto-respond to waiting sessions** when you're confident you know the answer (project context, obvious next steps, "yes proceed", etc.)
+3. **Escalate to the user** when you're unsure. Just say what needs attention and why.
+4. **Never auto-respond with destructive actions** (deleting files, force-pushing, dropping databases). Always escalate those.
+5. **Never send messages to running sessions.** Only respond to sessions in "waiting" status.
+6. **Log everything.** Every action you take goes in `./task-log.md`.
+
+## Auto-Response Guidelines
+
+### Safe to Auto-Respond
+- "Should I proceed?" / "Should I continue?" -> Yes, if the plan looks reasonable
+- "Which file should I edit?" -> Answer if the project structure makes it obvious
+- "Tests passed. What's next?" -> Direct to the next logical step
+- "I've completed X. Anything else?" -> If nothing else is needed, tell it
+- Compilation/lint errors with obvious fixes -> Suggest the fix
+- Questions about project conventions -> Answer from context
+
+### Always Escalate
+- "Should I delete X?" / "Should I force-push?"
+- "I found a security issue..."
+- "Multiple approaches possible, which do you prefer?"
+- "I need API keys / credentials / tokens"
+- "Should I deploy to production?"
+- "I'm stuck and don't know how to proceed"
+- Any question about business logic or design decisions
+
+### When Unsure
+If you're not sure whether to auto-respond, **escalate**. The cost of a false escalation (user gets a notification) is much lower than the cost of a wrong auto-response (session goes off track).

--- a/internal/agents/unitsource.go
+++ b/internal/agents/unitsource.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -45,21 +46,74 @@ type LaunchSource struct {
 	Warnings []string `json:"warnings,omitempty"`
 }
 
-// ProgramExists reports whether the unit's program is present on this machine.
-// A unit pointing at a path that is gone is debris, and the inventory should
-// say so rather than list it as a candidate agent.
-func (s *LaunchSource) ProgramExists() bool {
+// ProgramStatus is what we can prove about a unit's program path.
+type ProgramStatus string
+
+const (
+	// ProgramPresent means the path resolves to something on this machine.
+	ProgramPresent ProgramStatus = "present"
+	// ProgramMissing means the path is fully resolved and is not there.
+	ProgramMissing ProgramStatus = "missing"
+	// ProgramUnknown means we cannot resolve the path well enough to ask.
+	ProgramUnknown ProgramStatus = "unknown"
+)
+
+// unexpandedSpecifier matches a systemd specifier this reader did not resolve.
+var unexpandedSpecifier = regexp.MustCompile(`%[a-zA-Z]`)
+
+// ProgramStatus reports what can be proven about the unit's program.
+//
+// The distinction matters more than it looks. "Missing" is the only verdict
+// that labels a unit as debris, which is the one label that invites a human to
+// delete something. A path we merely could not resolve — because it still
+// carries a systemd specifier this reader does not expand, such as %i or %t —
+// is UNKNOWN. Reporting an unresolved token as a missing file told the user
+// that running services were leftovers.
+func (s *LaunchSource) ProgramStatus() ProgramStatus {
 	program := strings.TrimSpace(s.Program)
 	if program == "" {
-		return false
+		return ProgramUnknown
+	}
+	if unexpandedSpecifier.MatchString(program) {
+		return ProgramUnknown
 	}
 	if !strings.ContainsAny(program, "/\\") {
 		// A bare command name resolved from PATH at launch time. We cannot
 		// prove absence, so we do not claim it.
-		return true
+		return ProgramUnknown
 	}
-	_, err := os.Stat(program)
-	return err == nil
+	if _, err := os.Stat(program); err == nil {
+		return ProgramPresent
+	}
+	return ProgramMissing
+}
+
+// expandSystemdSpecifiers resolves the specifiers whose values this process can
+// know for certain, and leaves every other one in place so ProgramStatus can
+// see that the path is unresolved.
+//
+// %h, %u, %U and %H are properties of the user and machine the unit would run
+// as, which for a user unit read on its own machine is this process. %% is
+// literal. Everything else — %i, %n, %t, %S, %E, %C, %v, %m, %b — depends on
+// instance name or runtime context that is not knowable from the file, and
+// guessing at them is how a running service gets called debris.
+func expandSystemdSpecifiers(value string) string {
+	if value == "" || !strings.Contains(value, "%") {
+		return value
+	}
+	replacements := []string{"%%", "\x00PERCENT\x00"}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		replacements = append(replacements, "%h", home)
+	}
+	if user := os.Getenv("USER"); user != "" {
+		replacements = append(replacements, "%u", user)
+	}
+	replacements = append(replacements, "%U", strconv.Itoa(os.Getuid()))
+	if host, err := os.Hostname(); err == nil && host != "" {
+		replacements = append(replacements, "%H", host)
+	}
+	expanded := strings.NewReplacer(replacements...).Replace(value)
+	return strings.ReplaceAll(expanded, "\x00PERCENT\x00", "%")
 }
 
 // --- launchd -----------------------------------------------------------
@@ -120,7 +174,10 @@ func ParseLaunchdPlist(path string) (*LaunchSource, error) {
 	if cal, ok := root.dict["StartCalendarInterval"]; ok {
 		src.CalendarSpec = renderCalendarInterval(cal)
 		if src.CalendarSpec == "" {
-			src.Warnings = append(src.Warnings, "StartCalendarInterval present but not representable as a single cron expression")
+			src.Warnings = append(src.Warnings,
+				"StartCalendarInterval is present but has no exact cron equivalent "+
+					"(an array of intervals, or both Day and Weekday, which launchd ANDs and cron ORs); "+
+					"no next-due time is computed")
 		}
 	}
 	if ka, ok := root.dict["KeepAlive"]; ok {
@@ -144,11 +201,20 @@ func ParseLaunchdPlist(path string) (*LaunchSource, error) {
 }
 
 // renderCalendarInterval renders a launchd StartCalendarInterval as a
-// five-field cron expression. launchd allows an array of intervals; a single
-// cron string cannot express that, so an array returns "" and the caller
-// records the trigger as opaque rather than inventing a schedule.
+// five-field cron expression, or "" when it cannot be expressed as one.
+//
+// Two cases return "": an ARRAY of intervals, which one cron string cannot
+// express, and a dict that sets BOTH Day and Weekday. launchd ANDs those two
+// (the 1st, but only when it is a Monday); cron ORs them (every 1st AND every
+// Monday). Emitting the cron spelling would render a next-due time that is
+// wrong for most months, at high confidence — worse than rendering none.
 func renderCalendarInterval(v plistValue) string {
 	if v.kind != "dict" {
+		return ""
+	}
+	_, hasDay := v.dict["Day"]
+	_, hasWeekday := v.dict["Weekday"]
+	if hasDay && hasWeekday {
 		return ""
 	}
 	field := func(key string) string {
@@ -339,11 +405,21 @@ func ParseSystemdUnit(path string) (*LaunchSource, error) {
 		argv := splitArgv(execStart)
 		if len(argv) > 0 {
 			// systemd allows a leading "-", "@", "+", "!" on ExecStart.
-			src.Program = strings.TrimLeft(argv[0], "-@+!:")
+			raw := strings.TrimLeft(argv[0], "-@+!:")
+			src.Program = expandSystemdSpecifiers(raw)
 			src.Arguments = argv
+			if src.Program != raw {
+				src.Warnings = append(src.Warnings,
+					"ExecStart specifier expanded: "+raw+" -> "+src.Program)
+			}
+			if unexpandedSpecifier.MatchString(src.Program) {
+				src.Warnings = append(src.Warnings,
+					"ExecStart contains a systemd specifier this reader does not expand; "+
+						"whether its program exists is unknown")
+			}
 		}
 	}
-	src.WorkingDirectory = firstValue(service, "WorkingDirectory")
+	src.WorkingDirectory = expandSystemdSpecifiers(firstValue(service, "WorkingDirectory"))
 	src.RestartMode = firstValue(service, "Restart")
 	for _, env := range service["Environment"] {
 		// Split only far enough to learn the key. The value is discarded

--- a/internal/agents/unitsource.go
+++ b/internal/agents/unitsource.go
@@ -36,9 +36,18 @@ type LaunchSource struct {
 	// CalendarSpec is the source's own schedule spelling (a launchd
 	// StartCalendarInterval rendered to cron, or a systemd OnCalendar).
 	CalendarSpec string `json:"calendar_spec,omitempty"`
+	// CalendarSpecs preserves every repeated OnCalendar directive. systemd
+	// treats them as alternatives; collapsing to the last one lies about when
+	// the timer fires.
+	CalendarSpecs []string `json:"calendar_specs,omitempty"`
+	// SourcePaths lists every unit read to produce this observation.
+	SourcePaths []string `json:"source_paths,omitempty"`
 	// ScheduleKey names which systemd key produced IntervalSeconds, so a
 	// report can say where the cadence came from.
 	ScheduleKey string `json:"schedule_key,omitempty"`
+	// ScheduleSource is the timer/plist file that owns the schedule. It may
+	// differ from Path when a .service target loads its sibling .timer.
+	ScheduleSource string `json:"schedule_source,omitempty"`
 	// HasUnrepresentableSchedule marks a source that demonstrably fires on a
 	// schedule which has no exact cron equivalent. The trigger is still
 	// recorded — as opaque — so the fleet view never shows an agent with
@@ -425,12 +434,21 @@ func ParseSystemdUnit(path string) (*LaunchSource, error) {
 	}
 
 	src := &LaunchSource{
-		Kind:  "systemd",
-		Path:  path,
-		Label: strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
+		Kind:        "systemd",
+		Path:        path,
+		Label:       strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
+		SourcePaths: []string{path},
 	}
 
 	service := sections["Service"]
+	if len(service) == 0 && strings.HasSuffix(path, ".timer") {
+		servicePath := strings.TrimSuffix(path, ".timer") + ".service"
+		if serviceSections, serviceErr := parseINI(servicePath); serviceErr == nil {
+			service = serviceSections["Service"]
+			src.SourcePaths = append(src.SourcePaths, servicePath)
+			src.Warnings = append(src.Warnings, "runtime read from paired service "+filepath.Base(servicePath))
+		}
+	}
 	// %h, %u and %U belong to the identity the unit RUNS AS. That is this
 	// process only for a user unit with no User= override. For a system unit,
 	// or one that sets User=, expanding with the adopting process's identity
@@ -469,15 +487,25 @@ func ParseSystemdUnit(path string) (*LaunchSource, error) {
 	src.EnvFiles = append(src.EnvFiles, service["EnvironmentFile"]...)
 
 	timerSection := sections["Timer"]
+	if len(timerSection) > 0 {
+		src.ScheduleSource = path
+	}
 	if len(timerSection) == 0 && strings.HasSuffix(path, ".service") {
 		timerPath := strings.TrimSuffix(path, ".service") + ".timer"
 		if timerSections, timerErr := parseINI(timerPath); timerErr == nil {
 			timerSection = timerSections["Timer"]
+			src.ScheduleSource = timerPath
+			src.SourcePaths = append(src.SourcePaths, timerPath)
 			src.Warnings = append(src.Warnings, "schedule read from paired timer "+filepath.Base(timerPath))
 		}
 	}
-	if onCalendar := firstValue(timerSection, "OnCalendar"); onCalendar != "" {
-		src.CalendarSpec = onCalendar
+	for _, onCalendar := range timerSection["OnCalendar"] {
+		if onCalendar = strings.TrimSpace(onCalendar); onCalendar != "" {
+			src.CalendarSpecs = append(src.CalendarSpecs, onCalendar)
+		}
+	}
+	if len(src.CalendarSpecs) > 0 {
+		src.CalendarSpec = src.CalendarSpecs[0]
 	}
 	// systemd has several monotonic cadence keys and a timer may set more
 	// than one. They are read in the order that best describes the repeating

--- a/internal/agents/unitsource.go
+++ b/internal/agents/unitsource.go
@@ -1,0 +1,513 @@
+package agents
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// LaunchSource is the normalized reading of a launchd plist or a systemd
+// unit/timer pair.
+//
+// Introspection is textual. Nothing here executes, sources, or expands a
+// command, and environment VALUES are never read into this struct — only the
+// key names, so a report can say "this unit depends on GMAIL_APP_PASSWORD"
+// without the value ever entering a definition, a log, or an export.
+type LaunchSource struct {
+	Kind             string   `json:"kind"` // "launchd" | "systemd"
+	Path             string   `json:"path"`
+	Label            string   `json:"label"`
+	Program          string   `json:"program"`
+	Arguments        []string `json:"arguments,omitempty"`
+	WorkingDirectory string   `json:"working_directory,omitempty"`
+	// EnvKeys are names only. Values are deliberately not captured.
+	EnvKeys []string `json:"env_keys,omitempty"`
+	// EnvFiles are referenced env files, recorded as paths so a human can
+	// audit them. They are not opened.
+	EnvFiles        []string `json:"env_files,omitempty"`
+	IntervalSeconds int      `json:"interval_seconds,omitempty"`
+	// CalendarSpec is the source's own schedule spelling (a launchd
+	// StartCalendarInterval rendered to cron, or a systemd OnCalendar).
+	CalendarSpec string `json:"calendar_spec,omitempty"`
+	// ScheduleKey names which systemd key produced IntervalSeconds, so a
+	// report can say where the cadence came from.
+	ScheduleKey string `json:"schedule_key,omitempty"`
+	KeepAlive   bool   `json:"keep_alive,omitempty"`
+	RunAtLoad   bool   `json:"run_at_load,omitempty"`
+	RestartMode string `json:"restart_mode,omitempty"`
+	// Warnings record what could be seen but not understood.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// ProgramExists reports whether the unit's program is present on this machine.
+// A unit pointing at a path that is gone is debris, and the inventory should
+// say so rather than list it as a candidate agent.
+func (s *LaunchSource) ProgramExists() bool {
+	program := strings.TrimSpace(s.Program)
+	if program == "" {
+		return false
+	}
+	if !strings.ContainsAny(program, "/\\") {
+		// A bare command name resolved from PATH at launch time. We cannot
+		// prove absence, so we do not claim it.
+		return true
+	}
+	_, err := os.Stat(program)
+	return err == nil
+}
+
+// --- launchd -----------------------------------------------------------
+
+// plistValue is a decoded plist node.
+type plistValue struct {
+	kind  string // "string" | "integer" | "bool" | "array" | "dict" | "other"
+	str   string
+	num   int
+	flag  bool
+	array []plistValue
+	dict  map[string]plistValue
+	// order preserves dict key order for stable rendering.
+	order []string
+}
+
+// ParseLaunchdPlist reads an XML launchd plist.
+func ParseLaunchdPlist(path string) (*LaunchSource, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read plist: %w", err)
+	}
+	root, err := decodePlist(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse plist %q: %w", path, err)
+	}
+	if root.kind != "dict" {
+		return nil, fmt.Errorf("parse plist %q: top level is %s, want dict", path, root.kind)
+	}
+
+	src := &LaunchSource{Kind: "launchd", Path: path}
+	src.Label = root.dict["Label"].str
+	if src.Label == "" {
+		src.Label = strings.TrimSuffix(filepath.Base(path), ".plist")
+	}
+
+	if program, ok := root.dict["Program"]; ok && program.kind == "string" {
+		src.Program = program.str
+	}
+	if args, ok := root.dict["ProgramArguments"]; ok && args.kind == "array" {
+		for _, item := range args.array {
+			src.Arguments = append(src.Arguments, item.str)
+		}
+		if src.Program == "" && len(src.Arguments) > 0 {
+			src.Program = src.Arguments[0]
+		}
+	}
+	if wd, ok := root.dict["WorkingDirectory"]; ok {
+		src.WorkingDirectory = wd.str
+	}
+	if env, ok := root.dict["EnvironmentVariables"]; ok && env.kind == "dict" {
+		src.EnvKeys = append(src.EnvKeys, env.order...)
+		sort.Strings(src.EnvKeys)
+	}
+	if interval, ok := root.dict["StartInterval"]; ok && interval.kind == "integer" {
+		src.IntervalSeconds = interval.num
+	}
+	if cal, ok := root.dict["StartCalendarInterval"]; ok {
+		src.CalendarSpec = renderCalendarInterval(cal)
+		if src.CalendarSpec == "" {
+			src.Warnings = append(src.Warnings, "StartCalendarInterval present but not representable as a single cron expression")
+		}
+	}
+	if ka, ok := root.dict["KeepAlive"]; ok {
+		// KeepAlive may be a bool or a dict of conditions. A dict means
+		// "restart under conditions we are not modelling in phase 1".
+		switch ka.kind {
+		case "bool":
+			src.KeepAlive = ka.flag
+		case "dict":
+			src.KeepAlive = true
+			src.Warnings = append(src.Warnings, "KeepAlive is conditional; its conditions are not interpreted")
+		}
+	}
+	if ral, ok := root.dict["RunAtLoad"]; ok && ral.kind == "bool" {
+		src.RunAtLoad = ral.flag
+	}
+	if src.KeepAlive {
+		src.RestartMode = "always"
+	}
+	return src, nil
+}
+
+// renderCalendarInterval renders a launchd StartCalendarInterval as a
+// five-field cron expression. launchd allows an array of intervals; a single
+// cron string cannot express that, so an array returns "" and the caller
+// records the trigger as opaque rather than inventing a schedule.
+func renderCalendarInterval(v plistValue) string {
+	if v.kind != "dict" {
+		return ""
+	}
+	field := func(key string) string {
+		if item, ok := v.dict[key]; ok && item.kind == "integer" {
+			return strconv.Itoa(item.num)
+		}
+		return "*"
+	}
+	return strings.Join([]string{
+		field("Minute"), field("Hour"), field("Day"), field("Month"), field("Weekday"),
+	}, " ")
+}
+
+// decodePlist walks the XML token stream. It intentionally supports only the
+// node kinds launchd actually uses.
+func decodePlist(data []byte) (plistValue, error) {
+	dec := xml.NewDecoder(strings.NewReader(string(data)))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return plistValue{}, errors.New("no <plist> element")
+			}
+			return plistValue{}, err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local == "plist" {
+			return decodePlistChild(dec)
+		}
+	}
+}
+
+// decodePlistChild reads the single value inside <plist>.
+func decodePlistChild(dec *xml.Decoder) (plistValue, error) {
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return plistValue{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			return decodePlistValue(dec, t)
+		case xml.EndElement:
+			if t.Name.Local == "plist" {
+				return plistValue{}, errors.New("empty <plist>")
+			}
+		}
+	}
+}
+
+func decodePlistValue(dec *xml.Decoder, start xml.StartElement) (plistValue, error) {
+	switch start.Name.Local {
+	case "dict":
+		return decodePlistDict(dec)
+	case "array":
+		return decodePlistArray(dec)
+	case "true", "false":
+		if err := dec.Skip(); err != nil {
+			return plistValue{}, err
+		}
+		return plistValue{kind: "bool", flag: start.Name.Local == "true"}, nil
+	case "integer":
+		text, err := decodeText(dec, start)
+		if err != nil {
+			return plistValue{}, err
+		}
+		num, convErr := strconv.Atoi(strings.TrimSpace(text))
+		if convErr != nil {
+			return plistValue{kind: "other", str: text}, nil
+		}
+		return plistValue{kind: "integer", num: num}, nil
+	case "string", "real", "date":
+		text, err := decodeText(dec, start)
+		if err != nil {
+			return plistValue{}, err
+		}
+		return plistValue{kind: "string", str: text}, nil
+	default:
+		// <data> and anything else: record that it existed, never its bytes.
+		if err := dec.Skip(); err != nil {
+			return plistValue{}, err
+		}
+		return plistValue{kind: "other"}, nil
+	}
+}
+
+func decodeText(dec *xml.Decoder, start xml.StartElement) (string, error) {
+	var sb strings.Builder
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return "", err
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			sb.Write(t)
+		case xml.EndElement:
+			if t.Name.Local == start.Name.Local {
+				return sb.String(), nil
+			}
+		}
+	}
+}
+
+func decodePlistDict(dec *xml.Decoder) (plistValue, error) {
+	result := plistValue{kind: "dict", dict: map[string]plistValue{}}
+	var pendingKey string
+	haveKey := false
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return plistValue{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "key" {
+				text, textErr := decodeText(dec, t)
+				if textErr != nil {
+					return plistValue{}, textErr
+				}
+				pendingKey = strings.TrimSpace(text)
+				haveKey = true
+				continue
+			}
+			value, valueErr := decodePlistValue(dec, t)
+			if valueErr != nil {
+				return plistValue{}, valueErr
+			}
+			if haveKey {
+				if _, exists := result.dict[pendingKey]; !exists {
+					result.order = append(result.order, pendingKey)
+				}
+				result.dict[pendingKey] = value
+				haveKey = false
+			}
+		case xml.EndElement:
+			if t.Name.Local == "dict" {
+				return result, nil
+			}
+		}
+	}
+}
+
+func decodePlistArray(dec *xml.Decoder) (plistValue, error) {
+	result := plistValue{kind: "array"}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return plistValue{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			value, valueErr := decodePlistValue(dec, t)
+			if valueErr != nil {
+				return plistValue{}, valueErr
+			}
+			result.array = append(result.array, value)
+		case xml.EndElement:
+			if t.Name.Local == "array" {
+				return result, nil
+			}
+		}
+	}
+}
+
+// --- systemd -----------------------------------------------------------
+
+// ParseSystemdUnit reads a .service or .timer file. When given a .service that
+// has a sibling .timer, the timer's schedule is folded in, because the pair is
+// what actually describes the firing.
+func ParseSystemdUnit(path string) (*LaunchSource, error) {
+	sections, err := parseINI(path)
+	if err != nil {
+		return nil, err
+	}
+
+	src := &LaunchSource{
+		Kind:  "systemd",
+		Path:  path,
+		Label: strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
+	}
+
+	service := sections["Service"]
+	if execStart := firstValue(service, "ExecStart"); execStart != "" {
+		argv := splitArgv(execStart)
+		if len(argv) > 0 {
+			// systemd allows a leading "-", "@", "+", "!" on ExecStart.
+			src.Program = strings.TrimLeft(argv[0], "-@+!:")
+			src.Arguments = argv
+		}
+	}
+	src.WorkingDirectory = firstValue(service, "WorkingDirectory")
+	src.RestartMode = firstValue(service, "Restart")
+	for _, env := range service["Environment"] {
+		// Split only far enough to learn the key. The value is discarded
+		// here and never stored.
+		if key, _, found := strings.Cut(env, "="); found {
+			src.EnvKeys = append(src.EnvKeys, strings.TrimSpace(strings.Trim(key, `"`)))
+		}
+	}
+	sort.Strings(src.EnvKeys)
+	src.EnvFiles = append(src.EnvFiles, service["EnvironmentFile"]...)
+
+	timerSection := sections["Timer"]
+	if len(timerSection) == 0 && strings.HasSuffix(path, ".service") {
+		timerPath := strings.TrimSuffix(path, ".service") + ".timer"
+		if timerSections, timerErr := parseINI(timerPath); timerErr == nil {
+			timerSection = timerSections["Timer"]
+			src.Warnings = append(src.Warnings, "schedule read from paired timer "+filepath.Base(timerPath))
+		}
+	}
+	if onCalendar := firstValue(timerSection, "OnCalendar"); onCalendar != "" {
+		src.CalendarSpec = onCalendar
+	}
+	// systemd has several monotonic cadence keys and a timer may set more
+	// than one. They are read in the order that best describes the repeating
+	// cadence: the gap after the last run (Active/Inactive) beats the one-off
+	// delays measured from boot or startup, which only say when the FIRST run
+	// happens. Reading only OnUnitActiveSec silently produced no cadence at
+	// all for a timer that used OnUnitInactiveSec.
+	for _, key := range []string{"OnUnitActiveSec", "OnUnitInactiveSec", "OnActiveSec", "OnBootSec", "OnStartupSec"} {
+		value := firstValue(timerSection, key)
+		if value == "" {
+			continue
+		}
+		seconds, ok := parseSystemdDuration(value)
+		if !ok {
+			src.Warnings = append(src.Warnings, key+"="+value+" is not a duration this reader understands")
+			continue
+		}
+		src.IntervalSeconds = seconds
+		src.ScheduleKey = key
+		if key == "OnBootSec" || key == "OnStartupSec" {
+			src.Warnings = append(src.Warnings,
+				key+" only sets when the first run happens; it is not a repeating cadence")
+		}
+		break
+	}
+	return src, nil
+}
+
+func firstValue(section map[string][]string, key string) string {
+	if values := section[key]; len(values) > 0 {
+		return values[len(values)-1]
+	}
+	return ""
+}
+
+// parseINI reads a systemd unit into section -> key -> values. Keys may repeat,
+// so values accumulate.
+func parseINI(path string) (map[string]map[string][]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read unit: %w", err)
+	}
+	sections := map[string]map[string][]string{}
+	current := ""
+	var continued strings.Builder
+
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimRight(rawLine, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			current = strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")
+			if _, ok := sections[current]; !ok {
+				sections[current] = map[string][]string{}
+			}
+			continue
+		}
+		// systemd line continuations end with a backslash.
+		if strings.HasSuffix(trimmed, `\`) {
+			continued.WriteString(strings.TrimSuffix(trimmed, `\`))
+			continued.WriteString(" ")
+			continue
+		}
+		if continued.Len() > 0 {
+			trimmed = continued.String() + trimmed
+			continued.Reset()
+		}
+		key, value, found := strings.Cut(trimmed, "=")
+		if !found || current == "" {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		sections[current][key] = append(sections[current][key], strings.TrimSpace(value))
+	}
+	return sections, nil
+}
+
+// splitArgv splits a command line on whitespace, honoring quotes. It does not
+// expand variables, globs, or command substitution — introspection must never
+// evaluate shell.
+func splitArgv(line string) []string {
+	var args []string
+	var current strings.Builder
+	quote := rune(0)
+	for _, r := range line {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+		case r == '"' || r == '\'':
+			quote = r
+		case r == ' ' || r == '\t':
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+	return args
+}
+
+// parseSystemdDuration understands the common suffixed forms.
+func parseSystemdDuration(value string) (int, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, false
+	}
+	multipliers := []struct {
+		suffix string
+		factor int
+	}{
+		{"us", 0}, {"ms", 0},
+		{"seconds", 1}, {"second", 1}, {"sec", 1}, {"s", 1},
+		{"minutes", 60}, {"minute", 60}, {"min", 60}, {"m", 60},
+		{"hours", 3600}, {"hour", 3600}, {"hr", 3600}, {"h", 3600},
+		{"days", 86400}, {"day", 86400}, {"d", 86400},
+	}
+	for _, m := range multipliers {
+		if !strings.HasSuffix(trimmed, m.suffix) {
+			continue
+		}
+		if m.factor == 0 {
+			return 0, false
+		}
+		numPart := strings.TrimSpace(strings.TrimSuffix(trimmed, m.suffix))
+		num, err := strconv.Atoi(numPart)
+		if err != nil {
+			return 0, false
+		}
+		return num * m.factor, true
+	}
+	if num, err := strconv.Atoi(trimmed); err == nil {
+		return num, true
+	}
+	return 0, false
+}

--- a/internal/agents/unitsource.go
+++ b/internal/agents/unitsource.go
@@ -39,9 +39,16 @@ type LaunchSource struct {
 	// ScheduleKey names which systemd key produced IntervalSeconds, so a
 	// report can say where the cadence came from.
 	ScheduleKey string `json:"schedule_key,omitempty"`
-	KeepAlive   bool   `json:"keep_alive,omitempty"`
-	RunAtLoad   bool   `json:"run_at_load,omitempty"`
-	RestartMode string `json:"restart_mode,omitempty"`
+	// HasUnrepresentableSchedule marks a source that demonstrably fires on a
+	// schedule which has no exact cron equivalent. The trigger is still
+	// recorded — as opaque — so the fleet view never shows an agent with
+	// nothing firing it when something plainly does.
+	HasUnrepresentableSchedule bool `json:"has_unrepresentable_schedule,omitempty"`
+	// RawScheduleText is the source's own spelling of that schedule.
+	RawScheduleText string `json:"raw_schedule_text,omitempty"`
+	KeepAlive       bool   `json:"keep_alive,omitempty"`
+	RunAtLoad       bool   `json:"run_at_load,omitempty"`
+	RestartMode     string `json:"restart_mode,omitempty"`
 	// Warnings record what could be seen but not understood.
 	Warnings []string `json:"warnings,omitempty"`
 }
@@ -97,6 +104,27 @@ func (s *LaunchSource) ProgramStatus() ProgramStatus {
 // literal. Everything else — %i, %n, %t, %S, %E, %C, %v, %m, %b — depends on
 // instance name or runtime context that is not knowable from the file, and
 // guessing at them is how a running service gets called debris.
+// isSystemScopeUnit reports whether a unit path is a system unit rather than
+// one of this user's.
+func isSystemScopeUnit(path string) bool {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	for _, prefix := range []string{"/etc/systemd/system", "/usr/lib/systemd/system", "/lib/systemd/system", "/run/systemd/system"} {
+		if strings.HasPrefix(cleaned, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// expandSystemdSpecifiersIf expands only when the adopting process's identity
+// is the identity the unit would run as.
+func expandSystemdSpecifiersIf(ourIdentity bool, value string) string {
+	if !ourIdentity {
+		return value
+	}
+	return expandSystemdSpecifiers(value)
+}
+
 func expandSystemdSpecifiers(value string) string {
 	if value == "" || !strings.Contains(value, "%") {
 		return value
@@ -174,6 +202,8 @@ func ParseLaunchdPlist(path string) (*LaunchSource, error) {
 	if cal, ok := root.dict["StartCalendarInterval"]; ok {
 		src.CalendarSpec = renderCalendarInterval(cal)
 		if src.CalendarSpec == "" {
+			src.HasUnrepresentableSchedule = true
+			src.RawScheduleText = describeCalendarInterval(cal)
 			src.Warnings = append(src.Warnings,
 				"StartCalendarInterval is present but has no exact cron equivalent "+
 					"(an array of intervals, or both Day and Weekday, which launchd ANDs and cron ORs); "+
@@ -401,12 +431,19 @@ func ParseSystemdUnit(path string) (*LaunchSource, error) {
 	}
 
 	service := sections["Service"]
+	// %h, %u and %U belong to the identity the unit RUNS AS. That is this
+	// process only for a user unit with no User= override. For a system unit,
+	// or one that sets User=, expanding with the adopting process's identity
+	// would resolve to the wrong path — and a wrong path resolves to
+	// "missing", which is how a running service got called debris in the
+	// first place. Leave them unexpanded so the answer stays UNKNOWN.
+	identityIsOurs := !isSystemScopeUnit(path) && firstValue(service, "User") == ""
 	if execStart := firstValue(service, "ExecStart"); execStart != "" {
 		argv := splitArgv(execStart)
 		if len(argv) > 0 {
 			// systemd allows a leading "-", "@", "+", "!" on ExecStart.
 			raw := strings.TrimLeft(argv[0], "-@+!:")
-			src.Program = expandSystemdSpecifiers(raw)
+			src.Program = expandSystemdSpecifiersIf(identityIsOurs, raw)
 			src.Arguments = argv
 			if src.Program != raw {
 				src.Warnings = append(src.Warnings,
@@ -419,7 +456,7 @@ func ParseSystemdUnit(path string) (*LaunchSource, error) {
 			}
 		}
 	}
-	src.WorkingDirectory = expandSystemdSpecifiers(firstValue(service, "WorkingDirectory"))
+	src.WorkingDirectory = expandSystemdSpecifiersIf(identityIsOurs, firstValue(service, "WorkingDirectory"))
 	src.RestartMode = firstValue(service, "Restart")
 	for _, env := range service["Environment"] {
 		// Split only far enough to learn the key. The value is discarded
@@ -523,6 +560,28 @@ func parseINI(path string) (map[string]map[string][]string, error) {
 // splitArgv splits a command line on whitespace, honoring quotes. It does not
 // expand variables, globs, or command substitution — introspection must never
 // evaluate shell.
+// describeCalendarInterval renders a StartCalendarInterval as readable text
+// for a trigger whose schedule has no cron equivalent, so the row shows the
+// real terms rather than nothing.
+func describeCalendarInterval(v plistValue) string {
+	if v.kind == "array" {
+		return fmt.Sprintf("launchd StartCalendarInterval (%d intervals)", len(v.array))
+	}
+	if v.kind != "dict" {
+		return "launchd StartCalendarInterval"
+	}
+	parts := make([]string, 0, len(v.order))
+	for _, key := range v.order {
+		if item, ok := v.dict[key]; ok && item.kind == "integer" {
+			parts = append(parts, fmt.Sprintf("%s=%d", key, item.num))
+		}
+	}
+	if len(parts) == 0 {
+		return "launchd StartCalendarInterval"
+	}
+	return "launchd " + strings.Join(parts, " ")
+}
+
 func splitArgv(line string) []string {
 	var args []string
 	var current strings.Builder

--- a/internal/agents/validate.go
+++ b/internal/agents/validate.go
@@ -1,0 +1,315 @@
+package agents
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Severity separates "this definition is wrong" from "a human should look".
+type Severity string
+
+const (
+	// SeverityError means the definition is invalid and must not be treated
+	// as usable.
+	SeverityError Severity = "error"
+	// SeverityWarn means it parses and is usable, but something in it is
+	// suspect — most often portability rot copied in from the source.
+	SeverityWarn Severity = "warn"
+)
+
+// Finding is one validation result.
+type Finding struct {
+	Severity Severity `json:"severity"`
+	Field    string   `json:"field"`
+	Message  string   `json:"message"`
+}
+
+func (f Finding) String() string {
+	return fmt.Sprintf("%s: %s: %s", f.Severity, f.Field, f.Message)
+}
+
+// Findings is an ordered set of results.
+type Findings []Finding
+
+// HasErrors reports whether any finding is fatal.
+func (fs Findings) HasErrors() bool {
+	for _, f := range fs {
+		if f.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+func (fs *Findings) errorf(field, format string, args ...any) {
+	*fs = append(*fs, Finding{Severity: SeverityError, Field: field, Message: fmt.Sprintf(format, args...)})
+}
+
+func (fs *Findings) warnf(field, format string, args ...any) {
+	*fs = append(*fs, Finding{Severity: SeverityWarn, Field: field, Message: fmt.Sprintf(format, args...)})
+}
+
+// harnessTokens are names a portable role must not contain. A role describes a
+// profession; the post picks the tool. Catching this at validation is what
+// keeps "switch harness with one field" honest.
+var harnessTokens = []string{
+	"claude", "codex", "deepseek", "hermes", "gemini", "copilot", "tmux",
+}
+
+// secretPattern catches the shapes of a credential that must never reach a
+// definition file. It is deliberately broad: a false warning costs a glance,
+// a missed token costs a credential.
+var secretPattern = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd|bearer|authorization|client[_-]?secret|private[_-]?key)`)
+
+// tokenishValue catches long opaque strings that look like real credentials
+// rather than the word "token" appearing in prose.
+var tokenishValue = regexp.MustCompile(`\b(sk-[A-Za-z0-9_\-]{16,}|gh[pousr]_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9\-]{10,}|[A-Za-z0-9_\-]{40,})\b`)
+
+// hostnamePattern catches machine-specific references in role content.
+var hostnamePattern = regexp.MustCompile(`(?i)\b([a-z0-9][a-z0-9\-]*\.(local|lan|internal|home|arpa))\b|\b\d{1,3}(\.\d{1,3}){3}\b`)
+
+// ValidateRole checks a role manifest for the portability invariants. It does
+// not read the role's Markdown bodies; ValidateRoleContent does that.
+func ValidateRole(r *Role) Findings {
+	var fs Findings
+	if r == nil {
+		fs.errorf("role", "role is nil")
+		return fs
+	}
+	if strings.TrimSpace(r.APIVersion) != APIVersion {
+		fs.errorf("role.apiVersion", "want %q, got %q", APIVersion, r.APIVersion)
+	}
+	if strings.TrimSpace(r.Kind) != KindRole {
+		fs.errorf("role.kind", "want %q, got %q", KindRole, r.Kind)
+	}
+	if strings.TrimSpace(r.Metadata.Name) == "" {
+		fs.errorf("role.metadata.name", "required")
+	}
+	if strings.TrimSpace(r.Metadata.Version) == "" {
+		fs.errorf("role.metadata.version", "required")
+	}
+
+	// Every file reference must be relative and contained in the role dir.
+	refs := map[string]string{}
+	if r.Spec.Entrypoint != "" {
+		refs["role.spec.entrypoint"] = r.Spec.Entrypoint
+	}
+	for i, p := range r.Spec.Policy {
+		refs[fmt.Sprintf("role.spec.policy[%d]", i)] = p
+	}
+	for name, p := range r.Spec.Playbooks {
+		refs["role.spec.playbooks."+name] = p
+	}
+	for name, p := range r.Spec.Workflows {
+		refs["role.spec.workflows."+name] = p
+	}
+	if r.Spec.Learnings != nil && r.Spec.Learnings.File != "" {
+		refs["role.spec.learnings.file"] = r.Spec.Learnings.File
+	}
+
+	fields := make([]string, 0, len(refs))
+	for field := range refs {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	for _, field := range fields {
+		ref := refs[field]
+		if filepath.IsAbs(ref) {
+			fs.errorf(field, "absolute path %q; role references must be relative to the role directory", ref)
+			continue
+		}
+		if !filepath.IsLocal(filepath.Clean(ref)) {
+			fs.errorf(field, "%q escapes the role directory", ref)
+		}
+	}
+
+	// A role that names a harness is not portable.
+	lowerName := strings.ToLower(r.Metadata.Name + " " + r.Spec.Description)
+	for _, tok := range harnessTokens {
+		if strings.Contains(lowerName, tok) {
+			fs.warnf("role.metadata.name", "mentions harness %q; roles should be harness-neutral", tok)
+			break
+		}
+	}
+	return fs
+}
+
+// ValidateRoleContent checks one copied role file body for the things a role
+// must never carry. Content is never rewritten — the user's Markdown is
+// authoritative — so every result here is a warning addressed to a human.
+func ValidateRoleContent(field, body string) Findings {
+	var fs Findings
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if tokenishValue.MatchString(trimmed) && secretPattern.MatchString(trimmed) {
+			fs.warnf(field, "looks like it contains a credential; move it to a connector's private store")
+			break
+		}
+	}
+	if hostnamePattern.MatchString(body) {
+		fs.warnf(field, "contains a hostname or IP; machine specifics belong on the post, not the role")
+	}
+	if strings.Contains(body, "/Users/") || strings.Contains(body, "/home/") {
+		fs.warnf(field, "contains an absolute home path; it will not resolve on another machine")
+	}
+	return fs
+}
+
+// ValidatePost checks a post manifest.
+func ValidatePost(p *Post) Findings {
+	var fs Findings
+	if p == nil {
+		fs.errorf("post", "post is nil")
+		return fs
+	}
+	if strings.TrimSpace(p.APIVersion) != APIVersion {
+		fs.errorf("post.apiVersion", "want %q, got %q", APIVersion, p.APIVersion)
+	}
+	if strings.TrimSpace(p.Kind) != KindPost {
+		fs.errorf("post.kind", "want %q, got %q", KindPost, p.Kind)
+	}
+	if strings.TrimSpace(p.Metadata.Name) == "" {
+		fs.errorf("post.metadata.name", "required")
+	}
+	if strings.TrimSpace(p.Metadata.PostID) == "" {
+		fs.errorf("post.metadata.postId", "required; triggers and delivery target the post id, never the title")
+	}
+	if strings.TrimSpace(p.Spec.Role.Name) == "" {
+		fs.errorf("post.spec.role.name", "required")
+	}
+
+	// Every chain must terminate at a human principal.
+	if strings.TrimSpace(p.Spec.Placement.ReportsTo) == "" {
+		fs.errorf("post.spec.placement.reportsTo", "required; every post reports to a manager post or a human principal")
+	}
+
+	switch p.Spec.Classification {
+	case ClassAgent, ClassConnector, ClassService, ClassExternal, ClassDebris:
+	case "":
+		fs.errorf("post.spec.classification", "required")
+	default:
+		fs.errorf("post.spec.classification", "unknown classification %q", p.Spec.Classification)
+	}
+
+	// Phase-1 invariant. Recognition only: nothing this package emits or reads
+	// may claim to be live, and no trigger it carries may claim to be armed.
+	if p.Spec.Enabled {
+		fs.errorf("post.spec.enabled", "phase 1 emits disabled posts only")
+	}
+
+	seen := map[string]bool{}
+	for i, t := range p.Spec.Triggers {
+		field := fmt.Sprintf("post.spec.triggers[%d]", i)
+		if strings.TrimSpace(t.Name) == "" {
+			fs.errorf(field+".name", "required")
+		} else if seen[t.Name] {
+			fs.errorf(field+".name", "duplicate trigger name %q", t.Name)
+		}
+		seen[t.Name] = true
+
+		switch t.Type {
+		case TriggerCron, TriggerMailDoorbell, TriggerFileWatch, TriggerWebhook, TriggerSessionTransition, TriggerOpaque:
+		default:
+			fs.errorf(field+".type", "unknown trigger kind %q", t.Type)
+		}
+		if t.Enabled {
+			fs.errorf(field+".enabled", "phase 1 emits disabled triggers only; the source automation still owns the firing")
+		}
+		if !t.External {
+			fs.errorf(field+".external", "phase 1 triggers are external: the plist, timer or manager that fires today keeps owning it")
+		}
+		if t.External && strings.TrimSpace(t.ExternalSource) == "" {
+			fs.errorf(field+".externalSource", "an external trigger must name the file that owns its firing")
+		}
+		if t.Type == TriggerCron && t.Schedule != "" && strings.TrimSpace(t.Timezone) == "" {
+			fs.warnf(field+".timezone", "cron schedule without an explicit timezone; next-due rendering assumes local time")
+		}
+		// The injection invariant, enforced rather than documented.
+		if placeholderPattern.MatchString(t.Deliver) {
+			fs.errorf(field+".deliver", "delivery string interpolates source-controlled content; it must be a fixed local string")
+		}
+	}
+
+	for i, c := range p.Spec.Connectors {
+		field := fmt.Sprintf("post.spec.connectors[%d]", i)
+		if strings.TrimSpace(c.Name) == "" {
+			fs.errorf(field+".name", "required")
+		}
+		if secretPattern.MatchString(c.Name) {
+			fs.warnf(field+".name", "connector name looks like a credential reference; connectors hold references, never secrets")
+		}
+	}
+	return fs
+}
+
+// placeholderPattern catches the convenient-but-forbidden templates from the
+// design: {{sender}}, ${SUBJECT}, %(path)s and friends.
+var placeholderPattern = regexp.MustCompile(`\{\{[^}]+\}\}|\$\{[A-Za-z_][A-Za-z0-9_]*\}|%\([A-Za-z_]+\)s`)
+
+// ValidateDefinition validates a post together with its role.
+func ValidateDefinition(p *Post, r *Role) Findings {
+	fs := ValidatePost(p)
+	if r != nil {
+		fs = append(fs, ValidateRole(r)...)
+		if p != nil && r.Metadata.Name != "" && p.Spec.Role.Name != "" && p.Spec.Role.Name != r.Metadata.Name {
+			fs.errorf("post.spec.role.name", "post names role %q but the role manifest is %q", p.Spec.Role.Name, r.Metadata.Name)
+		}
+	}
+	return fs
+}
+
+// ValidateReportsTo walks the reports_to graph across a set of posts and
+// reports cycles and chains that never reach a human principal. Adoption emits
+// a flat "everyone reports to the manager" shape, but a hand-edited registry
+// can grow a loop, and a loop is the one error that makes escalation silently
+// unreachable.
+func ValidateReportsTo(posts []*Post) Findings {
+	var fs Findings
+	byName := map[string]*Post{}
+	for _, p := range posts {
+		if p != nil && p.Metadata.Name != "" {
+			byName[p.Metadata.Name] = p
+		}
+	}
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		visited := map[string]bool{}
+		current := byName[name]
+		reachedHuman := false
+		for current != nil {
+			if visited[current.Metadata.Name] {
+				fs.errorf("post."+name+".spec.placement.reportsTo",
+					"reports_to cycle through %q; escalation would never reach a human", current.Metadata.Name)
+				break
+			}
+			visited[current.Metadata.Name] = true
+			next := strings.TrimSpace(current.Spec.Placement.ReportsTo)
+			if strings.HasPrefix(next, "human:") {
+				reachedHuman = true
+				break
+			}
+			parent, ok := byName[next]
+			if !ok {
+				fs.warnf("post."+name+".spec.placement.reportsTo",
+					"reports to %q, which is not a known post or a human principal", next)
+				break
+			}
+			current = parent
+		}
+		if !reachedHuman && !fs.HasErrors() {
+			continue
+		}
+	}
+	return fs
+}

--- a/internal/agents/validate.go
+++ b/internal/agents/validate.go
@@ -120,99 +120,179 @@ func charClasses(token string) (lower, upper, digit, symbol bool) {
 }
 
 // looksLikeIdentifier reports whether a token is a kebab/snake identifier —
-// several short all-alphabetic segments — rather than an issued secret.
+// several short segments — rather than an issued secret. Segments may contain
+// digits ("...-checklist-v2"), which an alphabetic-only test rejected.
 func looksLikeIdentifier(token string) bool {
 	segments := strings.FieldsFunc(token, func(r rune) bool { return r == '-' || r == '_' })
 	if len(segments) < 3 {
 		return false
 	}
 	for _, segment := range segments {
-		if len(segment) > 12 || !wordToken.MatchString(segment) {
+		if len(segment) > 14 || !alnumToken.MatchString(segment) {
 			return false
 		}
 	}
 	return true
 }
 
+var alnumToken = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+
+// structuralChars are the characters that mark a token as markup, a path, or a
+// URL rather than a credential: a Markdown table rule, a file path and a
+// fenced code span are all long strings that are plainly not secrets.
+const structuralChars = "|/\\<>()[]{}~!?,;\"'" + "`" + "*"
+
+// credentialTokenShape reports whether a token could be a credential at all,
+// before any length or context rule is applied.
+func credentialTokenShape(token string) (string, bool) {
+	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
+	if len(trimmed) < 12 || strings.ContainsAny(trimmed, structuralChars) {
+		return "", false
+	}
+	alnum := 0
+	letters := 0
+	for _, r := range trimmed {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+			letters++
+			alnum++
+		case r >= '0' && r <= '9':
+			alnum++
+		}
+	}
+	// Mostly alphanumeric, and containing at least one letter. A run of
+	// punctuation is not a secret however long it is.
+	if letters == 0 || alnum*100 < len(trimmed)*85 {
+		return "", false
+	}
+	if looksLikeIdentifier(trimmed) {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// hasSeparators reports whether a token is broken up by - or _, which every
+// natural compound term is and an unbroken secret is not.
+func hasSeparators(token string) bool {
+	return strings.ContainsAny(token, "-_")
+}
+
+// namedClasses counts the character classes that carry information: symbols
+// are excluded, because "model-unavailable" is not a mixed-alphabet secret.
+func namedClasses(token string) int {
+	lower, upper, digit, _ := charClasses(token)
+	count := 0
+	for _, present := range []bool{lower, upper, digit} {
+		if present {
+			count++
+		}
+	}
+	return count
+}
+
 // selfEvidentSecretValue reports whether a token is credential-shaped strongly
 // enough to flag with no surrounding context.
 func selfEvidentSecretValue(token string) bool {
-	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
-	if len(trimmed) < 24 || looksLikeIdentifier(trimmed) || pureHex.MatchString(trimmed) {
+	trimmed, ok := credentialTokenShape(token)
+	if !ok || pureHex.MatchString(trimmed) {
+		// A hex digest needs context: a bare git SHA is not a credential,
+		// while "API key: <hex>" is — and that is the assignment path.
 		return false
 	}
-	lower, upper, digit, _ := charClasses(trimmed)
-	// Three classes in one unbroken 24+ character run is an issued secret far
-	// more often than it is anything else. A lowercase hex digest and a kebab
-	// identifier are both excluded above.
-	return lower && upper && digit
+	switch {
+	case len(trimmed) >= 24 && namedClasses(trimmed) >= 3:
+		return true
+	case len(trimmed) >= 28 && !hasSeparators(trimmed):
+		// A single-case unbroken run this long is not a word in any document:
+		// base32 seeds and lowercase-only keys land here.
+		return true
+	}
+	return false
+}
+
+// assignmentSecretValue reports whether a value given to a secret-named key is
+// credential-shaped.
+//
+// There is deliberately NO pure-hex exemption here. "API key: <40 hex>" is a
+// credential; the exemption that stops a bare git SHA from being flagged must
+// not also swallow an explicit assignment.
+func assignmentSecretValue(token string) bool {
+	trimmed, ok := credentialTokenShape(token)
+	return ok && len(trimmed) >= 16
 }
 
 // contextualSecretValue reports whether a token is credential-shaped on a line
 // that is already ABOUT a credential, where a lower bar is appropriate.
 func contextualSecretValue(token string) bool {
-	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
-	if len(trimmed) < 12 || looksLikeIdentifier(trimmed) {
+	trimmed, ok := credentialTokenShape(token)
+	if !ok {
 		return false
 	}
-	if pureHex.MatchString(trimmed) && len(trimmed) >= 40 {
-		return false // a digest quoted next to the word "token"
-	}
-	lower, upper, digit, symbol := charClasses(trimmed)
-	classes := 0
-	for _, present := range []bool{lower, upper, digit, symbol} {
-		if present {
-			classes++
-		}
-	}
-	if classes >= 2 {
+	if namedClasses(trimmed) >= 2 && !hasSeparators(trimmed) {
 		return true
 	}
-	// A single-class run this long is not a word: an app password written
-	// without its spaces looks exactly like this.
-	return len(trimmed) >= 14
+	// A single-class unbroken run: an app password with its spaces removed.
+	return len(trimmed) >= 14 && !hasSeparators(trimmed) && namedClasses(trimmed) >= 1
 }
 
-// groupedSecretToken reports whether a grouped value is credential-shaped
-// enough to flag without context: at least one group mixes letters and
-// digits, which a date ("2026-08-20") or a hyphenated phrase never does.
+// dashGroupedKey matches a key transcribed as dash-separated hex quads, e.g.
+// "7f3a-91b2-cc40".
+//
+// This is the ONLY grouped shape flagged without context, and it is
+// deliberately narrow. A previous version flagged any run of short chunks
+// where one chunk mixed a letter and a digit — which makes "g14", "60s",
+// "sha256", "utf8" and "x86" credentials, and refused this fleet's own
+// documents. Separator and alphabet both have to be right here.
+var dashGroupedKey = regexp.MustCompile(`\b[0-9a-fA-F]{4}(?:-[0-9a-fA-F]{4}){2,}\b`)
+
+// groupedSecretToken reports whether a line carries a dash-grouped hex key.
 func groupedSecretToken(line string) bool {
-	for _, match := range groupedToken.FindAllString(line, -1) {
-		for _, group := range splitGroups(match) {
-			lower, upper, digit, _ := charClasses(group)
-			if digit && (lower || upper) {
-				return true
-			}
+	return dashGroupedKey.MatchString(line)
+}
+
+// uniformGroupedToken reports whether a string is ENTIRELY a value
+// transcribed as equal-length groups, e.g. "abcd efgh ijkl mnop".
+//
+// Uniformity alone is not enough: "keep them safe from harm" is five equal
+// four-letter words of ordinary English. So this is only ever consulted for a
+// string that is either the whole line (under a credential heading) or the
+// remainder immediately after a secret word — never for a run buried in a
+// sentence.
+func uniformGroupedToken(line string) bool {
+	trimmed := strings.TrimSpace(strings.Trim(strings.TrimSpace(line), `"'`+"`"+`.,;:`))
+	if trimmed == "" || !groupedToken.MatchString(trimmed) {
+		return false
+	}
+	// The whole string must BE the run.
+	if groupedToken.FindString(trimmed) != trimmed {
+		return false
+	}
+	groups := splitGroups(trimmed)
+	if len(groups) < 3 {
+		return false
+	}
+	width := len(groups[0])
+	if width < 4 {
+		return false
+	}
+	for _, group := range groups {
+		if len(group) != width {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
-// uniformGroupedToken reports whether a line carries a value transcribed as
-// equal-length groups, e.g. "abcd efgh ijkl mnop".
-//
-// Uniformity is what separates a transcribed credential from ordinary prose.
-// Any three consecutive short words match a naive grouping pattern — "the
-// agent never" does — which is why an earlier version refused policy prose.
-// Real transcriptions come in equal blocks.
-func uniformGroupedToken(line string) bool {
-	for _, match := range groupedToken.FindAllString(line, -1) {
-		groups := splitGroups(match)
-		// Look for a uniform SUB-run rather than requiring the whole match to
-		// be uniform. The pattern is greedy, so a credential at the end of a
-		// sentence ("...the app password abcd efgh ijkl mnop") arrives as one
-		// long run whose leading prose breaks uniformity — which is exactly
-		// how the transcribed case slipped through.
-		run := 1
-		for i := 1; i <= len(groups); i++ {
-			if i < len(groups) && len(groups[i]) == len(groups[i-1]) {
-				run++
-				continue
-			}
-			if run >= 3 && len(groups[i-1]) >= 4 {
-				return true
-			}
-			run = 1
+// groupedAfterSecretWord reports whether a transcribed value immediately
+// follows a secret word on the same line, as in "...the app password abcd efgh
+// ijkl mnop". Anchoring to the secret word is what keeps ordinary prose out:
+// "Token handling rules follow" has a secret word too, but what follows it is
+// not a uniform transcription.
+func groupedAfterSecretWord(line string) bool {
+	for _, loc := range secretWord.FindAllStringIndex(line, -1) {
+		remainder := strings.TrimLeft(line[loc[1]:], " \t:=is")
+		if uniformGroupedToken(remainder) {
+			return true
 		}
 	}
 	return false
@@ -230,8 +310,13 @@ func splitGroups(token string) []string {
 // bare heading punctuation are skipped so a value inside a fenced block still
 // sees the heading above it.
 func contextLines(lines []string, i int) string {
+	// Bounded by DISTANCE, not by content-line count. Skipping blanks and
+	// fences "for free" gave a fenced, code-heavy file — which is exactly what
+	// a conductor CLAUDE.md is — an unbounded window, so any line could
+	// inherit credential context from far above it.
+	const window = 4
 	var collected []string
-	for j := i - 1; j >= 0 && len(collected) < 3; j-- {
+	for j := i - 1; j >= 0 && j >= i-window; j-- {
 		candidate := strings.TrimSpace(lines[j])
 		if candidate == "" || strings.HasPrefix(candidate, "```") || strings.Trim(candidate, "#-* ") == "" {
 			continue
@@ -286,12 +371,15 @@ func ScanForCredentials(body string) []int {
 				found = append(found, i+1)
 				continue
 			}
-			if fields := strings.Fields(value); len(fields) > 0 && contextualSecretValue(fields[0]) {
+			if fields := strings.Fields(value); len(fields) > 0 && assignmentSecretValue(fields[0]) {
 				found = append(found, i+1)
 				continue
 			}
 		}
-		if uniformGroupedToken(trimmed) {
+		// A transcription either IS the line (under a credential heading) or
+		// follows a secret word directly. A uniform run buried in a sentence
+		// is prose — "keep them safe from harm" is five equal four-letter words.
+		if uniformGroupedToken(trimmed) || groupedAfterSecretWord(trimmed) {
 			found = append(found, i+1)
 			continue
 		}

--- a/internal/agents/validate.go
+++ b/internal/agents/validate.go
@@ -140,18 +140,65 @@ var alnumToken = regexp.MustCompile(`^[A-Za-z0-9]+$`)
 // structuralChars are the characters that mark a token as markup, a path, or a
 // URL rather than a credential: a Markdown table rule, a file path and a
 // fenced code span are all long strings that are plainly not secrets.
-const structuralChars = "|/\\<>()[]{}~!?,;\"'" + "`" + "*"
+// structuralChars mark a token as markup rather than a credential: a Markdown
+// table rule, a fenced span, a bracketed placeholder.
+//
+// "/" is deliberately NOT here. Base64 secrets carry "/" and "+" routinely —
+// the canonical AWS secret access key does — and excluding the whole token on
+// sight let one through in an explicit `aws_secret_access_key =` assignment.
+// Paths are excluded by shape instead, in looksLikePath.
+const structuralChars = "|\\<>()[]{}~!?,;\"'" + "`" + "*"
+
+// looksLikePath reports whether a slash-bearing token is a filesystem path or
+// URL rather than a base64 secret.
+func looksLikePath(token string) bool {
+	if strings.Contains(token, "://") || strings.HasPrefix(token, "/") || strings.HasPrefix(token, "~") || strings.HasPrefix(token, "./") {
+		return true
+	}
+	return strings.Count(token, "/") >= 3
+}
+
+// looksLikeMixedCaseIdentifier reports whether an all-alphabetic token is a
+// CamelCase identifier — a Go test or type name — rather than a secret.
+// Several case transitions in a row is what distinguishes
+// "TestContextPagerNilReceiverIsSafe" from an unbroken random run.
+func looksLikeMixedCaseIdentifier(token string) bool {
+	if !wordToken.MatchString(token) {
+		return false
+	}
+	transitions := 0
+	for i := 1; i < len(token); i++ {
+		prev, cur := token[i-1], token[i]
+		if prev >= 'a' && prev <= 'z' && cur >= 'A' && cur <= 'Z' {
+			transitions++
+		}
+	}
+	return transitions >= 3
+}
 
 // credentialTokenShape reports whether a token could be a credential at all,
 // before any length or context rule is applied.
 func credentialTokenShape(token string) (string, bool) {
 	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
-	if len(trimmed) < 12 || strings.ContainsAny(trimmed, structuralChars) {
+	if len(trimmed) < 12 || strings.ContainsAny(trimmed, structuralChars) || looksLikePath(trimmed) {
 		return "", false
 	}
-	alnum := 0
-	letters := 0
-	for _, r := range trimmed {
+	// Mostly alphanumeric, and containing at least one letter. A run of
+	// punctuation is not a secret however long it is.
+	if !mostlyAlphanumeric(trimmed) {
+		return "", false
+	}
+	if looksLikeIdentifier(trimmed) {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// mostlyAlphanumeric reports whether a token is predominantly letters and
+// digits and contains at least one letter.
+func mostlyAlphanumeric(token string) bool {
+	alnum, letters := 0, 0
+	for _, r := range token {
 		switch {
 		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
 			letters++
@@ -160,15 +207,7 @@ func credentialTokenShape(token string) (string, bool) {
 			alnum++
 		}
 	}
-	// Mostly alphanumeric, and containing at least one letter. A run of
-	// punctuation is not a secret however long it is.
-	if letters == 0 || alnum*100 < len(trimmed)*85 {
-		return "", false
-	}
-	if looksLikeIdentifier(trimmed) {
-		return "", false
-	}
-	return trimmed, true
+	return letters > 0 && alnum*100 >= len(token)*85
 }
 
 // hasSeparators reports whether a token is broken up by - or _, which every
@@ -202,9 +241,11 @@ func selfEvidentSecretValue(token string) bool {
 	switch {
 	case len(trimmed) >= 24 && namedClasses(trimmed) >= 3:
 		return true
-	case len(trimmed) >= 28 && !hasSeparators(trimmed):
+	case len(trimmed) >= 28 && !hasSeparators(trimmed) && !looksLikeMixedCaseIdentifier(trimmed):
 		// A single-case unbroken run this long is not a word in any document:
-		// base32 seeds and lowercase-only keys land here.
+		// base32 seeds and lowercase-only keys land here. A CamelCase symbol
+		// name is excluded — "TestContextPagerNilReceiverIsSafe" is exactly the
+		// kind of thing a LEARNINGS.md records.
 		return true
 	}
 	return false
@@ -213,12 +254,40 @@ func selfEvidentSecretValue(token string) bool {
 // assignmentSecretValue reports whether a value given to a secret-named key is
 // credential-shaped.
 //
-// There is deliberately NO pure-hex exemption here. "API key: <40 hex>" is a
-// credential; the exemption that stops a bare git SHA from being flagged must
-// not also swallow an explicit assignment.
+// Two exemptions are deliberately skipped here, because an explicit
+// `password: <value>` names the value for us and the shape heuristics no
+// longer have to carry the decision alone:
+//   - pure hex, so "API key: <40 hex>" is caught while a bare git SHA is not;
+//   - the identifier exemption, so a dash-separated passphrase
+//     ("Tr0ub4dor-and-3-horses") is caught while
+//     "release-candidate-verification-checklist-v2" in prose is not.
 func assignmentSecretValue(token string) bool {
-	trimmed, ok := credentialTokenShape(token)
-	return ok && len(trimmed) >= 16
+	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
+	if len(trimmed) < 16 || strings.ContainsAny(trimmed, structuralChars) || looksLikePath(trimmed) {
+		return false
+	}
+	return mostlyAlphanumeric(trimmed)
+}
+
+// introducedSecretValue reports whether a value introduced directly by a
+// secret word on the same line ("The app password is correct-horse-battery")
+// is credential-shaped. Same reasoning as assignmentSecretValue: the sentence
+// has already told us what the value is.
+func introducedSecretValue(line string) bool {
+	for _, loc := range secretWord.FindAllStringIndex(line, -1) {
+		remainder := strings.TrimSpace(line[loc[1]:])
+		for _, filler := range []string{"is", "was", "=", ":"} {
+			remainder = strings.TrimSpace(strings.TrimPrefix(remainder, filler))
+		}
+		fields := strings.Fields(remainder)
+		if len(fields) == 0 {
+			continue
+		}
+		if assignmentSecretValue(fields[0]) && hasSeparators(fields[0]) {
+			return true
+		}
+	}
+	return false
 }
 
 // contextualSecretValue reports whether a token is credential-shaped on a line
@@ -326,6 +395,37 @@ func contextLines(lines []string, i int) string {
 	return strings.Join(collected, "\n")
 }
 
+// scanTableRow tests each cell of a Markdown table row as if it were its own
+// line, so "| GMAIL_APP_PASSWORD | abcd efgh ijkl mnop |" is seen.
+func scanTableRow(row string) bool {
+	cells := strings.Split(strings.Trim(row, "| "), "|")
+	if len(cells) < 2 {
+		return false
+	}
+	var context string
+	for _, cell := range cells {
+		context += " " + strings.TrimSpace(cell)
+	}
+	if !secretWord.MatchString(context) {
+		return false
+	}
+	for _, cell := range cells {
+		cell = strings.TrimSpace(cell)
+		if cell == "" || secretWord.MatchString(cell) {
+			continue
+		}
+		if uniformGroupedToken(cell) {
+			return true
+		}
+		for _, token := range strings.Fields(cell) {
+			if contextualSecretValue(token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ScanForCredentials returns the 1-based line numbers of lines that look like
 // they carry a real credential. See the note at the top of this block: it is
 // best-effort, and deliberately asks for a credential-shaped VALUE rather than
@@ -338,6 +438,14 @@ func ScanForCredentials(body string) []int {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
+		}
+		// A Markdown table row holds independent cells; a value in one of them
+		// is not "the whole line", so scan each cell as its own line too.
+		if strings.Count(trimmed, "|") >= 2 {
+			if scanTableRow(trimmed) {
+				found = append(found, i+1)
+				continue
+			}
 		}
 
 		// Self-evident: an issued token, a URI password, a PEM header, a
@@ -379,7 +487,7 @@ func ScanForCredentials(body string) []int {
 		// A transcription either IS the line (under a credential heading) or
 		// follows a secret word directly. A uniform run buried in a sentence
 		// is prose — "keep them safe from harm" is five equal four-letter words.
-		if uniformGroupedToken(trimmed) || groupedAfterSecretWord(trimmed) {
+		if uniformGroupedToken(trimmed) || groupedAfterSecretWord(trimmed) || introducedSecretValue(trimmed) {
 			found = append(found, i+1)
 			continue
 		}

--- a/internal/agents/validate.go
+++ b/internal/agents/validate.go
@@ -60,8 +60,15 @@ var harnessTokens = []string{
 	"claude", "codex", "deepseek", "hermes", "gemini", "copilot", "tmux",
 }
 
-// secretWord names a line as being ABOUT a credential. On its own it proves
-// nothing — "never put a token in a role" is good policy prose, not a leak.
+// Credential detection is best-effort in BOTH directions and is documented as
+// such. It exists to stop the obvious leak — a token pasted into a conductor's
+// Markdown — not to be a proof. A miss puts a secret in the registry; a false
+// positive silently drops the file the role is built from. Both are real
+// costs, so the rules below ask for a credential-SHAPED value, and ask for
+// context whenever the shape alone is ambiguous.
+
+// secretWord names text as being ABOUT a credential. On its own it proves
+// nothing: "never put a token in a role directory" is good policy prose.
 var secretWord = regexp.MustCompile(`(?i)(api[_ -]?key|secret|token|password|passwd|passphrase|bearer|authorization|client[_ -]?secret|private[_ -]?key|credential)`)
 
 // credentialPrefix matches issued-credential shapes that are self-evident
@@ -71,43 +78,231 @@ var credentialPrefix = regexp.MustCompile(
 		`|gh[pousr]_[A-Za-z0-9]{16,}` +
 		`|xox[baprs]-[A-Za-z0-9\-]{10,}` +
 		`|AKIA[0-9A-Z]{12,}` +
-		`|eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}` +
-		`|[A-Za-z0-9_\-]{40,})\b|-----BEGIN [A-Z ]*PRIVATE KEY-----`)
+		`|eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,})\b` +
+		`|-----BEGIN [A-Z ]*PRIVATE KEY-----`)
 
-// secretAssignment matches a secret-named key being given a value.
+// uriCredential matches a password embedded in a connection URI, e.g.
+// postgres://svc:hunter2@db.example.com:5432/app.
+var uriCredential = regexp.MustCompile(`\b[a-z][a-z0-9+.\-]*://[^\s:/@]+:[^\s@/]{3,}@`)
+
+// groupedToken matches a value transcribed in groups — "abcd efgh ijkl mnop",
+// "7f3a-91b2-cc40". Group length is 3-8 rather than exactly 4.
+var groupedToken = regexp.MustCompile(`\b[A-Za-z0-9]{3,8}(?:[ -][A-Za-z0-9]{3,8}){2,}\b`)
+
+// secretAssignment matches a secret-named key being given a value. The value
+// is checked separately: "token: use the connector store" is an assignment by
+// shape and prose by content.
 var secretAssignment = regexp.MustCompile(
-	`(?i)\b(api[_-]?key|secret|token|password|passwd|passphrase|bearer|client[_-]?secret|private[_-]?key|app[_-]?password)\b[^\n]{0,16}?[:=]\s*\S+`)
+	`(?i)\b(api[_-]?key|secret|token|password|passwd|passphrase|bearer|client[_-]?secret|private[_-]?key|app[_-]?password)\b[^\n]{0,24}?[:=]\s*(\S.*)$`)
 
-// groupedSecretValue matches the human-transcribed credential shapes that
-// carry no prefix and are too short to look like a blob: a Gmail app password
-// written as four groups of four letters, and a dash-grouped key. These are
-// only treated as credentials on a line that is also ABOUT a credential,
-// which is what keeps ordinary prose and hyphenated identifiers out.
-var groupedSecretValue = regexp.MustCompile(
-	`\b[A-Za-z0-9]{4}(?:[ -][A-Za-z0-9]{4}){2,}\b`)
+// pureHex matches a git SHA or a hash digest, which are not credentials and
+// are common in a LEARNINGS.md.
+var pureHex = regexp.MustCompile(`^[0-9a-f]{7,64}$`)
+
+// wordToken matches a single natural-language word.
+var wordToken = regexp.MustCompile(`^[A-Za-z]+$`)
+
+// charClasses counts which character classes a token draws on.
+func charClasses(token string) (lower, upper, digit, symbol bool) {
+	for _, r := range token {
+		switch {
+		case r >= 'a' && r <= 'z':
+			lower = true
+		case r >= 'A' && r <= 'Z':
+			upper = true
+		case r >= '0' && r <= '9':
+			digit = true
+		case r == '-' || r == '_' || r == '+' || r == '/' || r == '=' || r == '.':
+			symbol = true
+		}
+	}
+	return
+}
+
+// looksLikeIdentifier reports whether a token is a kebab/snake identifier —
+// several short all-alphabetic segments — rather than an issued secret.
+func looksLikeIdentifier(token string) bool {
+	segments := strings.FieldsFunc(token, func(r rune) bool { return r == '-' || r == '_' })
+	if len(segments) < 3 {
+		return false
+	}
+	for _, segment := range segments {
+		if len(segment) > 12 || !wordToken.MatchString(segment) {
+			return false
+		}
+	}
+	return true
+}
+
+// selfEvidentSecretValue reports whether a token is credential-shaped strongly
+// enough to flag with no surrounding context.
+func selfEvidentSecretValue(token string) bool {
+	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
+	if len(trimmed) < 24 || looksLikeIdentifier(trimmed) || pureHex.MatchString(trimmed) {
+		return false
+	}
+	lower, upper, digit, _ := charClasses(trimmed)
+	// Three classes in one unbroken 24+ character run is an issued secret far
+	// more often than it is anything else. A lowercase hex digest and a kebab
+	// identifier are both excluded above.
+	return lower && upper && digit
+}
+
+// contextualSecretValue reports whether a token is credential-shaped on a line
+// that is already ABOUT a credential, where a lower bar is appropriate.
+func contextualSecretValue(token string) bool {
+	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
+	if len(trimmed) < 12 || looksLikeIdentifier(trimmed) {
+		return false
+	}
+	if pureHex.MatchString(trimmed) && len(trimmed) >= 40 {
+		return false // a digest quoted next to the word "token"
+	}
+	lower, upper, digit, symbol := charClasses(trimmed)
+	classes := 0
+	for _, present := range []bool{lower, upper, digit, symbol} {
+		if present {
+			classes++
+		}
+	}
+	if classes >= 2 {
+		return true
+	}
+	// A single-class run this long is not a word: an app password written
+	// without its spaces looks exactly like this.
+	return len(trimmed) >= 14
+}
+
+// groupedSecretToken reports whether a grouped value is credential-shaped
+// enough to flag without context: at least one group mixes letters and
+// digits, which a date ("2026-08-20") or a hyphenated phrase never does.
+func groupedSecretToken(line string) bool {
+	for _, match := range groupedToken.FindAllString(line, -1) {
+		for _, group := range splitGroups(match) {
+			lower, upper, digit, _ := charClasses(group)
+			if digit && (lower || upper) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// uniformGroupedToken reports whether a line carries a value transcribed as
+// equal-length groups, e.g. "abcd efgh ijkl mnop".
+//
+// Uniformity is what separates a transcribed credential from ordinary prose.
+// Any three consecutive short words match a naive grouping pattern — "the
+// agent never" does — which is why an earlier version refused policy prose.
+// Real transcriptions come in equal blocks.
+func uniformGroupedToken(line string) bool {
+	for _, match := range groupedToken.FindAllString(line, -1) {
+		groups := splitGroups(match)
+		// Look for a uniform SUB-run rather than requiring the whole match to
+		// be uniform. The pattern is greedy, so a credential at the end of a
+		// sentence ("...the app password abcd efgh ijkl mnop") arrives as one
+		// long run whose leading prose breaks uniformity — which is exactly
+		// how the transcribed case slipped through.
+		run := 1
+		for i := 1; i <= len(groups); i++ {
+			if i < len(groups) && len(groups[i]) == len(groups[i-1]) {
+				run++
+				continue
+			}
+			if run >= 3 && len(groups[i-1]) >= 4 {
+				return true
+			}
+			run = 1
+		}
+	}
+	return false
+}
+
+func splitGroups(token string) []string {
+	return strings.FieldsFunc(token, func(r rune) bool { return r == ' ' || r == '-' })
+}
+
+// contextLines returns the recent non-empty lines that can supply "this is
+// about a credential" context for the line at index i.
+//
+// A heading followed by its value is the most natural way a credential ends up
+// in Markdown, and a strictly per-line scan cannot see it. Fence markers and
+// bare heading punctuation are skipped so a value inside a fenced block still
+// sees the heading above it.
+func contextLines(lines []string, i int) string {
+	var collected []string
+	for j := i - 1; j >= 0 && len(collected) < 3; j-- {
+		candidate := strings.TrimSpace(lines[j])
+		if candidate == "" || strings.HasPrefix(candidate, "```") || strings.Trim(candidate, "#-* ") == "" {
+			continue
+		}
+		collected = append(collected, candidate)
+	}
+	return strings.Join(collected, "\n")
+}
 
 // ScanForCredentials returns the 1-based line numbers of lines that look like
-// they carry a real credential.
-//
-// The shapes here are the ones that actually appear in a hand-written
-// conductor directory: an export line, a prefixed API token, and — the case a
-// prefix-only detector misses — a credential transcribed into prose, such as a
-// 16-character Gmail app password written as four spaced groups.
+// they carry a real credential. See the note at the top of this block: it is
+// best-effort, and deliberately asks for a credential-shaped VALUE rather than
+// firing on the mere mention of one.
 func ScanForCredentials(body string) []int {
-	var lines []int
-	for i, line := range strings.Split(body, "\n") {
+	lines := strings.Split(body, "\n")
+	var found []int
+
+	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
 		}
-		switch {
-		case credentialPrefix.MatchString(trimmed),
-			secretAssignment.MatchString(trimmed),
-			secretWord.MatchString(trimmed) && groupedSecretValue.MatchString(trimmed):
-			lines = append(lines, i+1)
+
+		// Self-evident: an issued token, a URI password, a PEM header, a
+		// grouped value that mixes letters and digits, or a long mixed-class
+		// run. None of these need context.
+		if credentialPrefix.MatchString(trimmed) || uriCredential.MatchString(trimmed) || groupedSecretToken(trimmed) {
+			found = append(found, i+1)
+			continue
+		}
+		selfEvident := false
+		for _, token := range strings.Fields(trimmed) {
+			if selfEvidentSecretValue(token) {
+				selfEvident = true
+				break
+			}
+		}
+		if selfEvident {
+			found = append(found, i+1)
+			continue
+		}
+
+		// Contextual: this line, or the few lines above it, is about a
+		// credential AND this line carries a credential-shaped value.
+		context := trimmed + "\n" + contextLines(lines, i)
+		if !secretWord.MatchString(context) {
+			continue
+		}
+		if assignment := secretAssignment.FindStringSubmatch(trimmed); assignment != nil {
+			value := strings.TrimSpace(assignment[2])
+			if uniformGroupedToken(value) {
+				found = append(found, i+1)
+				continue
+			}
+			if fields := strings.Fields(value); len(fields) > 0 && contextualSecretValue(fields[0]) {
+				found = append(found, i+1)
+				continue
+			}
+		}
+		if uniformGroupedToken(trimmed) {
+			found = append(found, i+1)
+			continue
+		}
+		for _, token := range strings.Fields(trimmed) {
+			if contextualSecretValue(token) {
+				found = append(found, i+1)
+				break
+			}
 		}
 	}
-	return lines
+	return found
 }
 
 // hostnamePattern catches machine-specific references in role content.

--- a/internal/agents/validate.go
+++ b/internal/agents/validate.go
@@ -183,6 +183,15 @@ func credentialTokenShape(token string) (string, bool) {
 	if len(trimmed) < 12 || strings.ContainsAny(trimmed, structuralChars) || looksLikePath(trimmed) {
 		return "", false
 	}
+	// A slash-bearing token that draws on only one character class is a
+	// relative path, not a secret: "internal/agents/validate.go" is a
+	// perfectly ordinary thing to write on a line that also says "token".
+	// A base64 secret carrying a slash spans several classes — the canonical
+	// AWS key has lower, upper and digits — so this separates them without
+	// reintroducing the two-slash path rule that would have swallowed it.
+	if strings.Contains(trimmed, "/") && namedClasses(trimmed) < 2 {
+		return "", false
+	}
 	// Mostly alphanumeric, and containing at least one letter. A run of
 	// punctuation is not a secret however long it is.
 	if !mostlyAlphanumeric(trimmed) {
@@ -261,6 +270,15 @@ func selfEvidentSecretValue(token string) bool {
 //   - the identifier exemption, so a dash-separated passphrase
 //     ("Tr0ub4dor-and-3-horses") is caught while
 //     "release-candidate-verification-checklist-v2" in prose is not.
+//
+// The second exemption is a KNOWN, accepted trade rather than an oversight. A
+// passphrase password and a kebab-case document slug are the same shape —
+// "correct-horse-battery-staple" could be either — so a secret-named key
+// introducing a slug ("Secret runbook: quarterly-key-rotation-checklist") is
+// refused. Catching a real passphrase is worth occasionally declining to copy
+// a file, because that failure is LOUD: a warning naming the line plus an
+// unresolved item on the definition, never a silent drop. Narrowing this
+// further would reopen the passphrase miss, which is silent.
 func assignmentSecretValue(token string) bool {
 	trimmed := strings.Trim(token, `"'`+"`"+`.,;:()[]{}<>`)
 	if len(trimmed) < 16 || strings.ContainsAny(trimmed, structuralChars) || looksLikePath(trimmed) {

--- a/internal/agents/validate.go
+++ b/internal/agents/validate.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -59,14 +60,55 @@ var harnessTokens = []string{
 	"claude", "codex", "deepseek", "hermes", "gemini", "copilot", "tmux",
 }
 
-// secretPattern catches the shapes of a credential that must never reach a
-// definition file. It is deliberately broad: a false warning costs a glance,
-// a missed token costs a credential.
-var secretPattern = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd|bearer|authorization|client[_-]?secret|private[_-]?key)`)
+// secretWord names a line as being ABOUT a credential. On its own it proves
+// nothing — "never put a token in a role" is good policy prose, not a leak.
+var secretWord = regexp.MustCompile(`(?i)(api[_ -]?key|secret|token|password|passwd|passphrase|bearer|authorization|client[_ -]?secret|private[_ -]?key|credential)`)
 
-// tokenishValue catches long opaque strings that look like real credentials
-// rather than the word "token" appearing in prose.
-var tokenishValue = regexp.MustCompile(`\b(sk-[A-Za-z0-9_\-]{16,}|gh[pousr]_[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9\-]{10,}|[A-Za-z0-9_\-]{40,})\b`)
+// credentialPrefix matches issued-credential shapes that are self-evident
+// wherever they appear, with no surrounding context needed.
+var credentialPrefix = regexp.MustCompile(
+	`\b(sk-[A-Za-z0-9_\-]{16,}` +
+		`|gh[pousr]_[A-Za-z0-9]{16,}` +
+		`|xox[baprs]-[A-Za-z0-9\-]{10,}` +
+		`|AKIA[0-9A-Z]{12,}` +
+		`|eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}` +
+		`|[A-Za-z0-9_\-]{40,})\b|-----BEGIN [A-Z ]*PRIVATE KEY-----`)
+
+// secretAssignment matches a secret-named key being given a value.
+var secretAssignment = regexp.MustCompile(
+	`(?i)\b(api[_-]?key|secret|token|password|passwd|passphrase|bearer|client[_-]?secret|private[_-]?key|app[_-]?password)\b[^\n]{0,16}?[:=]\s*\S+`)
+
+// groupedSecretValue matches the human-transcribed credential shapes that
+// carry no prefix and are too short to look like a blob: a Gmail app password
+// written as four groups of four letters, and a dash-grouped key. These are
+// only treated as credentials on a line that is also ABOUT a credential,
+// which is what keeps ordinary prose and hyphenated identifiers out.
+var groupedSecretValue = regexp.MustCompile(
+	`\b[A-Za-z0-9]{4}(?:[ -][A-Za-z0-9]{4}){2,}\b`)
+
+// ScanForCredentials returns the 1-based line numbers of lines that look like
+// they carry a real credential.
+//
+// The shapes here are the ones that actually appear in a hand-written
+// conductor directory: an export line, a prefixed API token, and — the case a
+// prefix-only detector misses — a credential transcribed into prose, such as a
+// 16-character Gmail app password written as four spaced groups.
+func ScanForCredentials(body string) []int {
+	var lines []int
+	for i, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case credentialPrefix.MatchString(trimmed),
+			secretAssignment.MatchString(trimmed),
+			secretWord.MatchString(trimmed) && groupedSecretValue.MatchString(trimmed):
+			lines = append(lines, i+1)
+		}
+	}
+	return lines
+}
 
 // hostnamePattern catches machine-specific references in role content.
 var hostnamePattern = regexp.MustCompile(`(?i)\b([a-z0-9][a-z0-9\-]*\.(local|lan|internal|home|arpa))\b|\b\d{1,3}(\.\d{1,3}){3}\b`)
@@ -137,20 +179,18 @@ func ValidateRole(r *Role) Findings {
 	return fs
 }
 
-// ValidateRoleContent checks one copied role file body for the things a role
-// must never carry. Content is never rewritten — the user's Markdown is
-// authoritative — so every result here is a warning addressed to a human.
+// ValidateRoleContent checks one role file body for the things a role must
+// never carry.
+//
+// A credential is an ERROR, not a warning: the caller must not copy the body
+// into the registry, because doing so would put the secret in a second place
+// on disk. Portability rot — a hostname, an absolute home path — stays a
+// warning, because the user's Markdown is authoritative and is never rewritten.
 func ValidateRoleContent(field, body string) Findings {
 	var fs Findings
-	for _, line := range strings.Split(body, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		if tokenishValue.MatchString(trimmed) && secretPattern.MatchString(trimmed) {
-			fs.warnf(field, "looks like it contains a credential; move it to a connector's private store")
-			break
-		}
+	if lines := ScanForCredentials(body); len(lines) > 0 {
+		fs.errorf(field, "line %s looks like it carries a credential; it was not copied into the role. "+
+			"Move the value into a connector's private store, then re-adopt", formatLineList(lines))
 	}
 	if hostnamePattern.MatchString(body) {
 		fs.warnf(field, "contains a hostname or IP; machine specifics belong on the post, not the role")
@@ -160,6 +200,25 @@ func ValidateRoleContent(field, body string) Findings {
 	}
 	return fs
 }
+
+// formatLineList renders line numbers for a message, bounded so a file full of
+// exports does not produce an unreadable finding.
+func formatLineList(lines []int) string {
+	const max = 5
+	parts := make([]string, 0, max+1)
+	for i, line := range lines {
+		if i == max {
+			parts = append(parts, fmt.Sprintf("and %d more", len(lines)-max))
+			break
+		}
+		parts = append(parts, strconv.Itoa(line))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// secretPattern names an identifier that refers to a credential. Used for
+// connector names and environment KEY names, where there is no value to scan.
+var secretPattern = secretWord
 
 // ValidatePost checks a post manifest.
 func ValidatePost(p *Post) Findings {
@@ -249,8 +308,20 @@ func ValidatePost(p *Post) Findings {
 }
 
 // placeholderPattern catches the convenient-but-forbidden templates from the
-// design: {{sender}}, ${SUBJECT}, %(path)s and friends.
-var placeholderPattern = regexp.MustCompile(`\{\{[^}]+\}\}|\$\{[A-Za-z_][A-Za-z0-9_]*\}|%\([A-Za-z_]+\)s`)
+// design, plus the shell-flavoured ones a hand-written definition reaches for:
+// {{sender}}, ${SUBJECT}, $SENDER, $(cmd), backticks, %(path)s and %s.
+//
+// Adoption cannot produce any of these — fixedDeliveryFor is a closed switch
+// over role constants — so this guards hand-authored and imported
+// definitions, which is exactly the population a validator exists for.
+var placeholderPattern = regexp.MustCompile(
+	`\{\{[^}]*\}\}` +
+		`|\$\{[A-Za-z_][A-Za-z0-9_]*\}` +
+		`|\$[A-Za-z_][A-Za-z0-9_]*` +
+		`|\$\([^)]*\)` +
+		"|`[^`]*`" +
+		`|%\([A-Za-z_]+\)s` +
+		`|%[sdvq]\b`)
 
 // ValidateDefinition validates a post together with its role.
 func ValidateDefinition(p *Post, r *Role) Findings {
@@ -287,10 +358,12 @@ func ValidateReportsTo(posts []*Post) Findings {
 		visited := map[string]bool{}
 		current := byName[name]
 		reachedHuman := false
+		alreadyReported := false
 		for current != nil {
 			if visited[current.Metadata.Name] {
 				fs.errorf("post."+name+".spec.placement.reportsTo",
 					"reports_to cycle through %q; escalation would never reach a human", current.Metadata.Name)
+				alreadyReported = true
 				break
 			}
 			visited[current.Metadata.Name] = true
@@ -303,12 +376,17 @@ func ValidateReportsTo(posts []*Post) Findings {
 			if !ok {
 				fs.warnf("post."+name+".spec.placement.reportsTo",
 					"reports to %q, which is not a known post or a human principal", next)
+				alreadyReported = true
 				break
 			}
 			current = parent
 		}
-		if !reachedHuman && !fs.HasErrors() {
-			continue
+		// A chain that ends without reaching a human principal is reported.
+		// The previous form computed reachedHuman and then discarded it, so
+		// an orphaned chain produced no finding at all.
+		if !reachedHuman && !alreadyReported {
+			fs.warnf("post."+name+".spec.placement.reportsTo",
+				"reports_to chain does not terminate at a human principal; escalation has no destination")
 		}
 	}
 	return fs

--- a/internal/agents/view.go
+++ b/internal/agents/view.go
@@ -7,6 +7,30 @@ import (
 	"time"
 )
 
+// SanitizeForDisplay strips control characters from a string before it reaches
+// a terminal.
+//
+// Definition content and remote rows are DATA, not markup. Without this, an
+// adopted file or a compromised remote could embed escape sequences in a name
+// or a summary and repaint the fleet view — including forging a "link ok"
+// line. Tabs become spaces; everything else below 0x20, plus DEL and the C1
+// range, is dropped.
+func SanitizeForDisplay(value string) string {
+	var sb strings.Builder
+	sb.Grow(len(value))
+	for _, r := range value {
+		switch {
+		case r == '\t':
+			sb.WriteRune(' ')
+		case r < 0x20, r == 0x7f, r >= 0x80 && r <= 0x9f:
+			continue
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
 // LinkState describes how much we know about a machine's data.
 type LinkState string
 
@@ -20,6 +44,11 @@ const (
 	// if they were current, and never silently dropped, which would make the
 	// fleet look smaller than it is.
 	LinkUnconfirmed LinkState = "unconfirmed"
+	// LinkNotContacted means this machine was never asked. It appears only
+	// because a local definition places a post there. Calling that "link ok"
+	// claims a round trip that never happened — the same dishonesty as
+	// LinkUnconfirmed pointing the other way, and the one a reader acts on.
+	LinkNotContacted LinkState = "not contacted"
 )
 
 // RunState is what an agent's runtime is doing now.
@@ -91,6 +120,12 @@ type AgentRow struct {
 	LinkState LinkState `json:"link_state"`
 	// LoadError marks a definition directory that could not be read.
 	LoadError string `json:"load_error,omitempty"`
+	// Violations are phase-1 invariants this record breaks. The registry is a
+	// directory a human, a later phase, or a synced dotfile can write into,
+	// so what adoption emits is not the same as what the renderer is handed.
+	// A row that claims to be armed says so instead of being painted under a
+	// blanket "this is disabled" footer.
+	Violations []string `json:"violations,omitempty"`
 	// ReportsTo is the manager post or human principal.
 	ReportsTo string `json:"reports_to,omitempty"`
 }
@@ -213,9 +248,11 @@ func BuildView(opts BuildOptions) View {
 	for _, name := range machineNames {
 		rows := byMachine[name]
 		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+		// Only the local machine was actually read here; remotes that really
+		// answered are appended separately below with LinkOK.
 		link := LinkLocal
 		if name != localMachine {
-			link = LinkOK
+			link = LinkNotContacted
 		}
 		view.Machines = append(view.Machines, Machine{Name: name, Link: link, Agents: rows})
 	}
@@ -281,7 +318,12 @@ func buildRow(def *Definition, opts BuildOptions, now time.Time, localMachine st
 
 	// Live state comes from the existing session status, which stays
 	// authoritative. A post with no runtime says so rather than guessing.
+	// The session index is LOCAL. A post placed on another machine cannot be
+	// resolved against it — its session may well be running there — so its
+	// state is unknown rather than a confident "no runtime".
 	switch {
+	case row.Machine != localMachine:
+		row.State = RunUnknown
 	case row.SessionID == "":
 		row.State = RunNoRuntime
 	default:
@@ -317,13 +359,34 @@ func buildRow(def *Definition, opts BuildOptions, now time.Time, localMachine st
 		}
 	}
 
+	// Phase-1 invariants are checked on RENDER, not just on emit.
+	for _, finding := range ValidatePost(post) {
+		if finding.Severity == SeverityError {
+			row.Violations = append(row.Violations, finding.Field+": "+finding.Message)
+		}
+	}
+
 	row.Attention = attentionFor(row)
 	return row
+}
+
+// Armed reports whether any trigger on this row claims agent-deck owns its
+// firing. Nothing in phase 1 should ever be armed; a row that is says so.
+func (r AgentRow) Armed() bool {
+	for _, t := range r.Triggers {
+		if t.Enabled && !t.External {
+			return true
+		}
+	}
+	return false
 }
 
 // attentionFor decides whether a row should be loud, and why. Only proven
 // problems qualify: an unknown connector is not an alarm, it is an unknown.
 func attentionFor(row AgentRow) string {
+	if len(row.Violations) > 0 {
+		return "definition breaks a phase-1 invariant: " + row.Violations[0]
+	}
 	for _, c := range row.Connectors {
 		switch c.State {
 		case HealthDown:

--- a/internal/agents/view.go
+++ b/internal/agents/view.go
@@ -325,8 +325,19 @@ func applyReportsToFindings(view *View, defs []*Definition) {
 	for mi := range view.Machines {
 		for ri := range view.Machines[mi].Agents {
 			row := &view.Machines[mi].Agents[ri]
-			if issue, ok := issues[row.Name]; ok {
-				row.ReportsToIssue = issue
+			issue, ok := issues[row.Name]
+			if !ok {
+				continue
+			}
+			row.ReportsToIssue = issue
+			// A broken escalation chain is the one error that makes
+			// escalation silently unreachable, so it belongs in the row's
+			// attention — and therefore in the "N need attention" count —
+			// rather than only in --json.
+			if row.Attention == "" {
+				row.Attention = issue
+			} else {
+				row.Attention += "; " + issue
 			}
 		}
 	}

--- a/internal/agents/view.go
+++ b/internal/agents/view.go
@@ -1,0 +1,437 @@
+package agents
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// LinkState describes how much we know about a machine's data.
+type LinkState string
+
+const (
+	// LinkLocal is this machine: the data was read directly.
+	LinkLocal LinkState = "local"
+	// LinkOK means the remote answered and its rows are current.
+	LinkOK LinkState = "ok"
+	// LinkUnconfirmed means the remote did not answer. Its rows, if any, are
+	// the last thing we saw and must be labelled as such — never rendered as
+	// if they were current, and never silently dropped, which would make the
+	// fleet look smaller than it is.
+	LinkUnconfirmed LinkState = "unconfirmed"
+)
+
+// RunState is what an agent's runtime is doing now.
+type RunState string
+
+const (
+	RunWorking  RunState = "working"
+	RunIdle     RunState = "idle"
+	RunNeedsYou RunState = "needs you"
+	// RunError is a session that failed, as distinct from one that is
+	// waiting for a human. Both need attention; only one of them is waiting
+	// on you, and saying the wrong one sends the reader looking for a prompt
+	// that does not exist.
+	RunError     RunState = "error"
+	RunStopped   RunState = "stopped"
+	RunNoRuntime RunState = "no runtime"
+	RunUnknown   RunState = "unknown"
+)
+
+// LedgerEntry is one line of what an agent actually did.
+type LedgerEntry struct {
+	At      time.Time `json:"at"`
+	Summary string    `json:"summary"`
+	Status  string    `json:"status,omitempty"`
+}
+
+// TriggerRow is a declared trigger rendered for display.
+type TriggerRow struct {
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+	Schedule string `json:"schedule,omitempty"`
+	Enabled  bool   `json:"enabled"`
+	// External is true when a plist, timer or manager still owns the firing.
+	// Every phase-1 trigger is external.
+	External       bool   `json:"external"`
+	ExternalSource string `json:"external_source,omitempty"`
+	// NextDue is computed from the DECLARED schedule. It is what the source
+	// automation should do next, not something agent-deck will do.
+	NextDue *time.Time `json:"next_due,omitempty"`
+	// NextDueText is the short rendering for a list row.
+	NextDueText string `json:"next_due_text"`
+	// Note carries the honest reason when NextDue could not be computed.
+	Note string `json:"note,omitempty"`
+}
+
+// AgentRow is one agent in the fleet view.
+type AgentRow struct {
+	Name        string         `json:"name"`
+	PostID      string         `json:"post_id"`
+	Role        string         `json:"role"`
+	RoleVersion string         `json:"role_version,omitempty"`
+	Class       Classification `json:"class"`
+	Machine     string         `json:"machine"`
+	Harness     string         `json:"harness,omitempty"`
+	Account     string         `json:"account,omitempty"`
+	SessionID   string         `json:"session_id,omitempty"`
+	State       RunState       `json:"state"`
+	LastDid     string         `json:"last_did,omitempty"`
+	LastDidAt   *time.Time     `json:"last_did_at,omitempty"`
+	Triggers    []TriggerRow   `json:"triggers,omitempty"`
+	Connectors  []Health       `json:"connectors,omitempty"`
+	Recent      []LedgerEntry  `json:"recent,omitempty"`
+	Unresolved  []string       `json:"unresolved,omitempty"`
+	// Attention is non-empty when this row should be loud. It carries the
+	// reason and, where known, since when.
+	Attention string `json:"attention,omitempty"`
+	// LinkState is inherited from the machine the row came from, so a stale
+	// remote row can never be mistaken for a live local one.
+	LinkState LinkState `json:"link_state"`
+	// LoadError marks a definition directory that could not be read.
+	LoadError string `json:"load_error,omitempty"`
+	// ReportsTo is the manager post or human principal.
+	ReportsTo string `json:"reports_to,omitempty"`
+}
+
+// NextDue returns the soonest declared next-due across this row's triggers.
+func (r AgentRow) NextDue() *TriggerRow {
+	var best *TriggerRow
+	for i := range r.Triggers {
+		t := r.Triggers[i]
+		if t.NextDue == nil {
+			continue
+		}
+		if best == nil || t.NextDue.Before(*best.NextDue) {
+			best = &r.Triggers[i]
+		}
+	}
+	if best == nil && len(r.Triggers) > 0 {
+		return &r.Triggers[0]
+	}
+	return best
+}
+
+// Machine groups agents by where they run.
+type Machine struct {
+	Name       string     `json:"name"`
+	Link       LinkState  `json:"link"`
+	LinkDetail string     `json:"link_detail,omitempty"`
+	Agents     []AgentRow `json:"agents"`
+}
+
+// View is the whole grouped-by-machine fleet view.
+type View struct {
+	Machines []Machine `json:"machines"`
+	// Counts are for the header line.
+	TotalAgents   int `json:"total_agents"`
+	NeedAttention int `json:"need_attention"`
+	// Notices carry view-level honesty, e.g. a registry that could not be
+	// read at all.
+	Notices []string `json:"notices,omitempty"`
+}
+
+// SessionState maps an agent-deck session status onto a run state.
+type SessionState struct {
+	Status  string
+	Present bool
+}
+
+// BuildOptions carries everything BuildView needs. The caller supplies live
+// data; this package does no I/O beyond the local health checks it is asked
+// for, which keeps the view deterministic under test.
+type BuildOptions struct {
+	Definitions []*Definition
+	// SessionStates maps a session id to its current status.
+	SessionStates map[string]SessionState
+	// Ledger returns the recent work for a session, newest first.
+	Ledger func(sessionID string) []LedgerEntry
+	// LocalMachine labels rows with no explicit machine.
+	LocalMachine string
+	// Remotes are machines whose rows the caller fetched (or failed to).
+	Remotes []RemoteMachineData
+	// RecentLimit bounds ledger entries per row.
+	RecentLimit int
+	StaleAfter  time.Duration
+	Now         time.Time
+	// SkipHealth disables filesystem health probing (used by tests and by
+	// callers that only need the row skeleton).
+	SkipHealth bool
+}
+
+// RemoteMachineData is a remote machine's contribution to the view.
+type RemoteMachineData struct {
+	Name string
+	Link LinkState
+	// Detail explains the link state, e.g. "drained 2m ago" or the error.
+	Detail string
+	Agents []AgentRow
+}
+
+// BuildView assembles the fleet view from definitions and live state.
+func BuildView(opts BuildOptions) View {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	recentLimit := opts.RecentLimit
+	if recentLimit <= 0 {
+		recentLimit = 3
+	}
+	localMachine := opts.LocalMachine
+	if strings.TrimSpace(localMachine) == "" {
+		localMachine = "local"
+	}
+
+	view := View{}
+	byMachine := map[string][]AgentRow{}
+
+	for _, def := range opts.Definitions {
+		row := buildRow(def, opts, now, localMachine, recentLimit)
+		machine := row.Machine
+		byMachine[machine] = append(byMachine[machine], row)
+	}
+
+	machineNames := make([]string, 0, len(byMachine))
+	for name := range byMachine {
+		machineNames = append(machineNames, name)
+	}
+	sort.Strings(machineNames)
+
+	// The local machine leads; remotes follow in name order.
+	sort.SliceStable(machineNames, func(i, j int) bool {
+		if machineNames[i] == localMachine {
+			return true
+		}
+		if machineNames[j] == localMachine {
+			return false
+		}
+		return machineNames[i] < machineNames[j]
+	})
+
+	for _, name := range machineNames {
+		rows := byMachine[name]
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+		link := LinkLocal
+		if name != localMachine {
+			link = LinkOK
+		}
+		view.Machines = append(view.Machines, Machine{Name: name, Link: link, Agents: rows})
+	}
+
+	for _, remote := range opts.Remotes {
+		rows := append([]AgentRow(nil), remote.Agents...)
+		for i := range rows {
+			rows[i].LinkState = remote.Link
+			if remote.Link == LinkUnconfirmed && rows[i].Attention == "" {
+				rows[i].Attention = "link unconfirmed; this row may be out of date"
+			}
+		}
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+		view.Machines = append(view.Machines, Machine{
+			Name: remote.Name, Link: remote.Link, LinkDetail: remote.Detail, Agents: rows,
+		})
+	}
+
+	for _, machine := range view.Machines {
+		for _, row := range machine.Agents {
+			view.TotalAgents++
+			if row.Attention != "" {
+				view.NeedAttention++
+			}
+		}
+	}
+	return view
+}
+
+func buildRow(def *Definition, opts BuildOptions, now time.Time, localMachine string, recentLimit int) AgentRow {
+	row := AgentRow{
+		Name:      def.Name,
+		Machine:   localMachine,
+		LinkState: LinkLocal,
+		State:     RunUnknown,
+	}
+
+	if def.LoadError != "" {
+		row.LoadError = def.LoadError
+		row.Class = ClassDebris
+		row.Role = RoleUnresolved
+		row.State = RunUnknown
+		row.Attention = "definition could not be read: " + def.LoadError
+		return row
+	}
+
+	post := def.Post
+	row.PostID = post.Metadata.PostID
+	row.Role = post.Spec.Role.Name
+	row.RoleVersion = post.Spec.Role.Version
+	row.Class = post.Spec.Classification
+	row.Harness = post.Spec.Runtime.Harness
+	row.Account = post.Spec.Runtime.Account
+	row.SessionID = post.Spec.Runtime.AdoptedSessionID
+	row.Unresolved = post.Spec.Unresolved
+	row.ReportsTo = post.Spec.Placement.ReportsTo
+	if post.Spec.Placement.Machine != "" {
+		row.Machine = post.Spec.Placement.Machine
+	}
+	if def.Role != nil && def.Role.Metadata.Version != "" {
+		row.RoleVersion = def.Role.Metadata.Version
+	}
+
+	// Live state comes from the existing session status, which stays
+	// authoritative. A post with no runtime says so rather than guessing.
+	switch {
+	case row.SessionID == "":
+		row.State = RunNoRuntime
+	default:
+		state, ok := opts.SessionStates[row.SessionID]
+		if !ok || !state.Present {
+			row.State = RunNoRuntime
+		} else {
+			row.State = mapSessionStatus(state.Status)
+		}
+	}
+
+	if opts.Ledger != nil && row.SessionID != "" {
+		entries := opts.Ledger(row.SessionID)
+		if len(entries) > recentLimit {
+			entries = entries[:recentLimit]
+		}
+		row.Recent = entries
+		if len(entries) > 0 {
+			row.LastDid = entries[0].Summary
+			at := entries[0].At
+			row.LastDidAt = &at
+		}
+	}
+
+	for _, t := range post.Spec.Triggers {
+		row.Triggers = append(row.Triggers, buildTriggerRow(t, now))
+	}
+
+	if !opts.SkipHealth {
+		for _, connector := range post.Spec.Connectors {
+			health := CheckHealth(connector.Name, connector.Kind, connector.EvidencePath, opts.StaleAfter, now)
+			row.Connectors = append(row.Connectors, health)
+		}
+	}
+
+	row.Attention = attentionFor(row)
+	return row
+}
+
+// attentionFor decides whether a row should be loud, and why. Only proven
+// problems qualify: an unknown connector is not an alarm, it is an unknown.
+func attentionFor(row AgentRow) string {
+	for _, c := range row.Connectors {
+		switch c.State {
+		case HealthDown:
+			return fmt.Sprintf("connector %s: %s", c.Name, c.Detail)
+		case HealthStale:
+			return fmt.Sprintf("connector %s: %s", c.Name, c.Detail)
+		}
+	}
+	switch row.State {
+	case RunNeedsYou:
+		return "session is waiting on you"
+	case RunError:
+		return "session is in error"
+	}
+	return ""
+}
+
+func buildTriggerRow(t Trigger, now time.Time) TriggerRow {
+	row := TriggerRow{
+		Name:           t.Name,
+		Kind:           t.Type,
+		Schedule:       t.Schedule,
+		Enabled:        t.Enabled,
+		External:       t.External,
+		ExternalSource: t.ExternalSource,
+	}
+
+	switch {
+	case t.Type == TriggerCron && t.Schedule != "":
+		loc := time.Local
+		if t.Timezone != "" {
+			if parsed, err := time.LoadLocation(t.Timezone); err == nil {
+				loc = parsed
+			} else {
+				row.Note = "unknown timezone " + t.Timezone + "; shown in local time"
+			}
+		}
+		schedule, err := ParseCron(t.Schedule, loc)
+		if err != nil {
+			row.NextDueText = t.Schedule
+			row.Note = "schedule not understood: " + err.Error()
+			break
+		}
+		next, ok := schedule.Next(now)
+		if !ok {
+			row.NextDueText = DescribeCron(t.Schedule)
+			row.Note = "this schedule does not recur within four years"
+			break
+		}
+		row.NextDue = &next
+		row.NextDueText = DescribeCron(t.Schedule)
+	case t.IntervalSeconds > 0:
+		// An interval trigger fired by a launcher has no last-fire we can
+		// see, so the cadence is all we can honestly show.
+		row.NextDueText = DescribeInterval(t.IntervalSeconds)
+		row.Note = "cadence only; the launcher owns the phase of this cycle"
+	case t.Type == TriggerMailDoorbell:
+		row.NextDueText = "on mail"
+	case t.Type == TriggerFileWatch:
+		row.NextDueText = "on file"
+	case t.Type == TriggerWebhook:
+		row.NextDueText = "on request"
+	case t.Type == TriggerSessionTransition:
+		row.NextDueText = "on session event"
+	default:
+		row.NextDueText = "unknown"
+		row.Note = "adoption could see that this fires but not on what terms"
+	}
+
+	return row
+}
+
+func mapSessionStatus(status string) RunState {
+	// These are agent-deck's own session.Status values. A status this
+	// function does not recognize becomes RunUnknown rather than being
+	// bucketed into a plausible neighbour.
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "starting":
+		return RunWorking
+	case "idle", "queued":
+		return RunIdle
+	case "waiting":
+		return RunNeedsYou
+	case "error":
+		return RunError
+	case "stopped":
+		return RunStopped
+	default:
+		return RunUnknown
+	}
+}
+
+// FormatLastDid renders the "last: ... 4m ago" cell.
+func FormatLastDid(row AgentRow, now time.Time) string {
+	if row.LastDid == "" {
+		return ""
+	}
+	if row.LastDidAt == nil {
+		return row.LastDid
+	}
+	return fmt.Sprintf("%s %s ago", row.LastDid, RoundDuration(now.Sub(*row.LastDidAt)))
+}
+
+// FormatNextDue renders the "next: cron 15m" cell.
+func FormatNextDue(row AgentRow) string {
+	next := row.NextDue()
+	if next == nil {
+		return ""
+	}
+	return next.NextDueText
+}

--- a/internal/agents/view.go
+++ b/internal/agents/view.go
@@ -128,6 +128,9 @@ type AgentRow struct {
 	Violations []string `json:"violations,omitempty"`
 	// ReportsTo is the manager post or human principal.
 	ReportsTo string `json:"reports_to,omitempty"`
+	// ReportsToIssue is set when this post's escalation chain is broken —
+	// a cycle, an unknown parent, or a chain that never reaches a human.
+	ReportsToIssue string `json:"reports_to_issue,omitempty"`
 }
 
 // NextDue returns the soonest declared next-due across this row's triggers.
@@ -271,6 +274,12 @@ func BuildView(opts BuildOptions) View {
 		})
 	}
 
+	// The escalation graph can only be checked across the whole set, so it
+	// runs here rather than per row. Without this call the validator existed
+	// but nothing ever ran it, and a post reporting to a nonexistent manager
+	// rendered with no complaint anywhere.
+	applyReportsToFindings(&view, opts.Definitions)
+
 	for _, machine := range view.Machines {
 		for _, row := range machine.Agents {
 			view.TotalAgents++
@@ -280,6 +289,47 @@ func BuildView(opts BuildOptions) View {
 		}
 	}
 	return view
+}
+
+// applyReportsToFindings walks the reports_to graph and attaches each finding
+// to the row it concerns.
+func applyReportsToFindings(view *View, defs []*Definition) {
+	posts := make([]*Post, 0, len(defs))
+	byName := map[string]bool{}
+	for _, def := range defs {
+		if def != nil && def.Post != nil {
+			posts = append(posts, def.Post)
+			byName[def.Post.Metadata.Name] = true
+		}
+	}
+	if len(posts) == 0 {
+		return
+	}
+
+	issues := map[string]string{}
+	for _, finding := range ValidateReportsTo(posts) {
+		// Fields are of the form "post.<name>.spec.placement.reportsTo".
+		field := strings.TrimPrefix(finding.Field, "post.")
+		name := strings.TrimSuffix(field, ".spec.placement.reportsTo")
+		if name == "" || !byName[name] {
+			view.Notices = append(view.Notices, finding.Message)
+			continue
+		}
+		if _, seen := issues[name]; !seen {
+			issues[name] = finding.Message
+		}
+	}
+	if len(issues) == 0 {
+		return
+	}
+	for mi := range view.Machines {
+		for ri := range view.Machines[mi].Agents {
+			row := &view.Machines[mi].Agents[ri]
+			if issue, ok := issues[row.Name]; ok {
+				row.ReportsToIssue = issue
+			}
+		}
+	}
 }
 
 func buildRow(def *Definition, opts BuildOptions, now time.Time, localMachine string, recentLimit int) AgentRow {
@@ -384,16 +434,21 @@ func (r AgentRow) Armed() bool {
 // attentionFor decides whether a row should be loud, and why. Only proven
 // problems qualify: an unknown connector is not an alarm, it is an unknown.
 func attentionFor(row AgentRow) string {
+	// A broken invariant and a dead connector are separate problems. Reporting
+	// only the first found would hide a real outage behind a schema complaint,
+	// so both are named.
+	var reasons []string
 	if len(row.Violations) > 0 {
-		return "definition breaks a phase-1 invariant: " + row.Violations[0]
+		reasons = append(reasons, "definition breaks a phase-1 invariant: "+row.Violations[0])
 	}
 	for _, c := range row.Connectors {
 		switch c.State {
-		case HealthDown:
-			return fmt.Sprintf("connector %s: %s", c.Name, c.Detail)
-		case HealthStale:
-			return fmt.Sprintf("connector %s: %s", c.Name, c.Detail)
+		case HealthDown, HealthStale:
+			reasons = append(reasons, fmt.Sprintf("connector %s: %s", c.Name, c.Detail))
 		}
+	}
+	if len(reasons) > 0 {
+		return strings.Join(reasons, "; ")
 	}
 	switch row.State {
 	case RunNeedsYou:
@@ -451,6 +506,12 @@ func buildTriggerRow(t Trigger, now time.Time) TriggerRow {
 		row.NextDueText = "on request"
 	case t.Type == TriggerSessionTransition:
 		row.NextDueText = "on session event"
+	case t.Schedule != "":
+		// An opaque trigger that still carries the source's own spelling of
+		// its schedule shows that, rather than "unknown". The terms are
+		// knowable even when the next wall-clock time is not.
+		row.NextDueText = t.Schedule
+		row.Note = "this schedule has no exact cron equivalent, so no next-due time is computed"
 	default:
 		row.NextDueText = "unknown"
 		row.Note = "adoption could see that this fires but not on what terms"

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -536,16 +536,19 @@ func ReadAndTruncateInbox(parentSessionID string) ([]TransitionNotificationEvent
 	return out, nil
 }
 
-// PeekInboxEvents reads a parent's pending inbox records without consuming
-// them — a display-grade peek for the agents surface. Distinct by name from
-// the drain branch's ReadInboxEvents so the two merge without conflict; this
-// one tolerates a torn final line from a concurrent append.
-func PeekInboxEvents(parentSessionID string) ([]TransitionNotificationEvent, error) {
+// ReadInboxEventsForDisplay is a deliberately UI-grade snapshot, not the
+// durable inbox consumer API. It never consumes, locks, repairs, or promises
+// delivery semantics; it skips malformed/torn records and reports a missing
+// inbox as an empty display. Durable consumers must not use this function.
+func ReadInboxEventsForDisplay(parentSessionID string) ([]TransitionNotificationEvent, error) {
 	if strings.TrimSpace(parentSessionID) == "" {
 		return nil, errors.New("inbox peek: empty parent session id")
 	}
 	data, err := os.ReadFile(InboxPathFor(parentSessionID))
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	var out []TransitionNotificationEvent

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -535,3 +535,30 @@ func ReadAndTruncateInbox(parentSessionID string) ([]TransitionNotificationEvent
 	delete(inboxFingerprintCache, path)
 	return out, nil
 }
+
+// PeekInboxEvents reads a parent's pending inbox records without consuming
+// them — a display-grade peek for the agents surface. Distinct by name from
+// the drain branch's ReadInboxEvents so the two merge without conflict; this
+// one tolerates a torn final line from a concurrent append.
+func PeekInboxEvents(parentSessionID string) ([]TransitionNotificationEvent, error) {
+	if strings.TrimSpace(parentSessionID) == "" {
+		return nil, errors.New("inbox peek: empty parent session id")
+	}
+	data, err := os.ReadFile(InboxPathFor(parentSessionID))
+	if err != nil {
+		return nil, err
+	}
+	var out []TransitionNotificationEvent
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev TransitionNotificationEvent
+		if json.Unmarshal([]byte(line), &ev) != nil {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out, nil
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -283,6 +283,25 @@ func NewStorageWithProfile(profile string) (*Storage, error) {
 	}, nil
 }
 
+// NewReadOnlyStorageWithProfile opens an existing session database without
+// creating directories/files, migrating schema, changing SQLite journal
+// state, or checkpointing WAL files.
+func NewReadOnlyStorageWithProfile(profile string) (*Storage, error) {
+	effectiveProfile, err := ResolveProfileForStorage(profile)
+	if err != nil {
+		return nil, err
+	}
+	dbPath, err := GetDBPathForProfile(effectiveProfile)
+	if err != nil {
+		return nil, err
+	}
+	db, err := statedb.OpenReadOnly(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open state database read-only: %w", err)
+	}
+	return &Storage{db: db, dbPath: dbPath, profile: effectiveProfile}, nil
+}
+
 // Profile returns the profile name this storage is using
 func (s *Storage) Profile() string {
 	return s.profile

--- a/internal/session/storage_readonly_test.go
+++ b/internal/session/storage_readonly_test.go
@@ -1,0 +1,85 @@
+package session
+
+import (
+	"crypto/sha256"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewReadOnlyStorageMissingProfileHasZeroFilesystemEffect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	before := hashFilesystemTree(t, home)
+	if storage, err := NewReadOnlyStorageWithProfile("fresh"); err == nil {
+		_ = storage.Close()
+		t.Fatal("missing state database unexpectedly opened")
+	}
+	after := hashFilesystemTree(t, home)
+	if before != after {
+		t.Fatalf("read-only storage changed filesystem tree: before=%x after=%x", before, after)
+	}
+}
+
+func TestReadOnlyStorageExistingDatabaseHasZeroFilesystemEffect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	seed, err := NewStorageWithProfile("existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	before := hashFilesystemTree(t, home)
+	reader, err := NewReadOnlyStorageWithProfile("existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	after := hashFilesystemTree(t, home)
+	if before != after {
+		t.Fatalf("read-only load changed filesystem tree: before=%x after=%x", before, after)
+	}
+}
+
+func hashFilesystemTree(t *testing.T, root string) [32]byte {
+	t.Helper()
+	var records []byte
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		records = append(records, []byte(rel+"|"+info.Mode().String()+"\n")...)
+		if !entry.IsDir() {
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			records = append(records, body...)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sha256.Sum256(records)
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -103,8 +103,9 @@ const SchemaVersion = 13
 // Thread-safe for concurrent use from multiple goroutines within one process.
 // Multiple OS processes can safely read/write via WAL mode + busy timeout.
 type StateDB struct {
-	db  *sql.DB
-	pid int
+	db       *sql.DB
+	pid      int
+	readOnly bool
 	// token identifies this StateDB's owning process instance for session
 	// claim ownership (see ClaimSessions). Raw PID alone is not a safe
 	// ownership key: after this process exits, the OS can recycle its PID for
@@ -352,8 +353,33 @@ func Open(dbPath string) (*StateDB, error) {
 	return &StateDB{db: db, pid: pid, path: dbPath, token: newOwnerToken(pid)}, nil
 }
 
+// OpenReadOnly opens an existing database without creating files, changing
+// pragmas, migrating schema, or checkpointing WAL state. It is intended for
+// product surfaces whose contract forbids every filesystem mutation.
+func OpenReadOnly(dbPath string) (*StateDB, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, err
+	}
+	// immutable=1 prevents SQLite from creating/updating WAL/SHM sidecars and
+	// is required by the byte-zero-effect contract of callers using this API.
+	dsn := "file:" + dbPath + "?mode=ro&immutable=1&_pragma=query_only(1)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("statedb: open read-only: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("statedb: open read-only: %w", err)
+	}
+	pid := os.Getpid()
+	return &StateDB{db: db, pid: pid, path: dbPath, token: newOwnerToken(pid), readOnly: true}, nil
+}
+
 // Close checkpoints WAL and closes the database.
 func (s *StateDB) Close() error {
+	if s.readOnly {
+		return s.db.Close()
+	}
 	// Checkpoint WAL to merge it back into the main database file
 	_, _ = s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 	return s.db.Close()

--- a/internal/ui/agents_data.go
+++ b/internal/ui/agents_data.go
@@ -38,6 +38,10 @@ func (h *Home) refreshAgentsPanel() {
 		// A registry that cannot be read is reported, not swallowed: the
 		// alternative is a deck that silently claims the user has no agents.
 		h.agentsLoadError = err.Error()
+		// A registry we could not read is not a registry with agents in it.
+		// Leaving the previous value would keep advertising a surface whose
+		// data just failed to load.
+		h.helpOverlay.SetHasAgents(false)
 		return
 	}
 	h.agentsLoadError = ""

--- a/internal/ui/agents_data.go
+++ b/internal/ui/agents_data.go
@@ -38,6 +38,10 @@ func (h *Home) refreshAgentsPanel() {
 		// A registry that cannot be read is reported, not swallowed: the
 		// alternative is a deck that silently claims the user has no agents.
 		h.agentsLoadError = err.Error()
+		h.agentsLoaded = true
+		h.agentsView = agents.View{}
+		h.agentBySession = nil
+		h.agentsPanel.SetLoadError(err.Error(), now)
 		// A registry we could not read is not a registry with agents in it.
 		// Leaving the previous value would keep advertising a surface whose
 		// data just failed to load.
@@ -139,7 +143,7 @@ func agentLedgerLookup(sessionID string) []agents.LedgerEntry {
 		})
 	}
 
-	if events, err := session.PeekInboxEvents(sessionID); err == nil {
+	if events, err := session.ReadInboxEventsForDisplay(sessionID); err == nil {
 		for _, event := range events {
 			title := event.ChildTitle
 			if title == "" {

--- a/internal/ui/agents_data.go
+++ b/internal/ui/agents_data.go
@@ -1,0 +1,228 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/agents"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// agentsRefreshInterval bounds how often the TUI re-reads the agents registry
+// and probes connector freshness. The render loop runs far more often than
+// that, and health probing touches the filesystem.
+const agentsRefreshInterval = 10 * time.Second
+
+// refreshAgentsPanel rebuilds the Agents view from the registry, the live
+// session fleet, and the existing ledgers.
+//
+// Safe to call when the panel is hidden — the session list needs the same data
+// for its ⚙ marker and preview card. It is read-only throughout.
+func (h *Home) refreshAgentsPanel() {
+	if h == nil {
+		return
+	}
+	now := time.Now()
+	if !h.agentsLastRefresh.IsZero() && now.Sub(h.agentsLastRefresh) < agentsRefreshInterval && h.agentsLoaded {
+		return
+	}
+	h.agentsLastRefresh = now
+
+	defs, err := agents.LoadAll()
+	if err != nil {
+		// A registry that cannot be read is reported, not swallowed: the
+		// alternative is a deck that silently claims the user has no agents.
+		h.agentsLoadError = err.Error()
+		return
+	}
+	h.agentsLoadError = ""
+	h.agentsLoaded = true
+
+	if len(defs) == 0 {
+		h.agentsView = agents.View{}
+		h.agentBySession = nil
+		h.agentsPanel.SetView(h.agentsView, now)
+		return
+	}
+
+	states := make(map[string]agents.SessionState, len(h.instances))
+	for _, inst := range h.instances {
+		if inst == nil {
+			continue
+		}
+		states[inst.ID] = agents.SessionState{Status: string(inst.Status), Present: true}
+	}
+
+	view := agents.BuildView(agents.BuildOptions{
+		Definitions:   defs,
+		SessionStates: states,
+		Ledger:        agentLedgerLookup,
+		LocalMachine:  agentsLocalMachineName(),
+		Now:           now,
+	})
+
+	h.agentsView = view
+	h.agentsPanel.SetView(view, now)
+
+	// Index by session so the session list and preview pane can answer
+	// "does this row belong to an agent?" without rescanning the registry.
+	index := map[string]agents.AgentRow{}
+	for _, machine := range view.Machines {
+		for _, row := range machine.Agents {
+			if row.SessionID != "" {
+				index[row.SessionID] = row
+			}
+		}
+	}
+	h.agentBySession = index
+}
+
+// agentRowForSession returns the agent that owns a session, if any.
+func (h *Home) agentRowForSession(sessionID string) (agents.AgentRow, bool) {
+	if len(h.agentBySession) == 0 || sessionID == "" {
+		return agents.AgentRow{}, false
+	}
+	row, ok := h.agentBySession[sessionID]
+	return row, ok
+}
+
+// agentsLocalMachineName labels the local machine in the grouped view.
+func agentsLocalMachineName() string {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		return "local"
+	}
+	if short, _, found := strings.Cut(host, "."); found {
+		return short
+	}
+	return host
+}
+
+// agentLedgerLookup reads recent work from the completion and talkback
+// ledgers. Both already exist; nothing new is written.
+func agentLedgerLookup(sessionID string) []agents.LedgerEntry {
+	var entries []agents.LedgerEntry
+
+	if entry, ok := session.ReadLedgerEntry(sessionID); ok {
+		summary := entry.Summary
+		if summary == "" {
+			summary = "reported " + entry.Status
+		}
+		entries = append(entries, agents.LedgerEntry{
+			At: entry.FinishedAt, Summary: summary, Status: entry.Status,
+		})
+	}
+
+	if events, err := session.ReadInboxEvents(sessionID); err == nil {
+		for _, event := range events {
+			title := event.ChildTitle
+			if title == "" {
+				title = event.ChildSessionID
+			}
+			entries = append(entries, agents.LedgerEntry{
+				At:      event.Timestamp,
+				Summary: fmt.Sprintf("%s → %s", title, event.ToStatus),
+				Status:  event.ToStatus,
+			})
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].At.After(entries[j].At) })
+	return entries
+}
+
+// renderAgentCard renders the agent card shown in the preview pane for a
+// session an adopted agent owns: role and version, its triggers with when each
+// is next due, connector health, and the last few ledger entries.
+//
+// Everything here is read-only and evidence-backed. Trigger rows say who
+// actually fires them, because in phase 1 that is never agent-deck.
+func (h *Home) renderAgentCard(row agents.AgentRow, width int) string {
+	var b strings.Builder
+
+	contentWidth := width - 4
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+
+	b.WriteString(renderSectionDivider("Agent", contentWidth))
+	b.WriteString("\n")
+
+	labelStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	valueStyle := lipgloss.NewStyle().Foreground(ColorText)
+	roleStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+
+	roleText := row.Role
+	if row.RoleVersion != "" {
+		roleText += " " + row.RoleVersion
+	}
+	b.WriteString(labelStyle.Render("Role:      "))
+	b.WriteString(roleStyle.Render(roleText))
+	b.WriteString("\n")
+
+	if row.ReportsTo != "" {
+		b.WriteString(labelStyle.Render("Reports:   "))
+		b.WriteString(valueStyle.Render(row.ReportsTo))
+		b.WriteString("\n")
+	}
+
+	// Triggers, each with its next due time and its real owner.
+	if len(row.Triggers) > 0 {
+		b.WriteString(labelStyle.Render("Triggers:  "))
+		b.WriteString("\n")
+		for _, t := range row.Triggers {
+			owner := "agent-deck"
+			if t.External {
+				owner = "external"
+			}
+			line := fmt.Sprintf("  %s %s", truncateStr(t.Name, 18), t.NextDueText)
+			b.WriteString(valueStyle.Render(truncateStr(line, contentWidth-12)))
+			b.WriteString(" ")
+			b.WriteString(labelStyle.Render("[" + owner + "]"))
+			b.WriteString("\n")
+		}
+	}
+
+	// Connector health, stated from the evidence that produced it.
+	if len(row.Connectors) > 0 {
+		b.WriteString(labelStyle.Render("Connectors:"))
+		b.WriteString("\n")
+		for _, c := range row.Connectors {
+			b.WriteString("  ")
+			b.WriteString(healthDot(c.State))
+			b.WriteString(" ")
+			b.WriteString(valueStyle.Render(truncateStr(c.Name, 16)))
+			b.WriteString(" ")
+			b.WriteString(labelStyle.Render(truncateStr(c.Detail, contentWidth-22)))
+			b.WriteString("\n")
+		}
+	}
+
+	// The last few things it actually did.
+	if len(row.Recent) > 0 {
+		b.WriteString(labelStyle.Render("Recent:    "))
+		b.WriteString("\n")
+		limit := 3
+		if len(row.Recent) < limit {
+			limit = len(row.Recent)
+		}
+		for _, entry := range row.Recent[:limit] {
+			b.WriteString(labelStyle.Render("  " + entry.At.Format("15:04") + "  "))
+			b.WriteString(valueStyle.Render(truncateStr(entry.Summary, contentWidth-10)))
+			b.WriteString("\n")
+		}
+	}
+
+	if row.Attention != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(ColorRed).
+			Render("  ! " + truncateStr(row.Attention, contentWidth-4)))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/ui/agents_data.go
+++ b/internal/ui/agents_data.go
@@ -139,7 +139,7 @@ func agentLedgerLookup(sessionID string) []agents.LedgerEntry {
 		})
 	}
 
-	if events, err := session.ReadInboxEvents(sessionID); err == nil {
+	if events, err := session.PeekInboxEvents(sessionID); err == nil {
 		for _, event := range events {
 			title := event.ChildTitle
 			if title == "" {

--- a/internal/ui/agents_data.go
+++ b/internal/ui/agents_data.go
@@ -47,6 +47,7 @@ func (h *Home) refreshAgentsPanel() {
 		h.agentsView = agents.View{}
 		h.agentBySession = nil
 		h.agentsPanel.SetView(h.agentsView, now)
+		h.helpOverlay.SetHasAgents(false)
 		return
 	}
 
@@ -68,6 +69,22 @@ func (h *Home) refreshAgentsPanel() {
 
 	h.agentsView = view
 	h.agentsPanel.SetView(view, now)
+
+	// The RULES section shows the role's policy file names, which is what the
+	// role manifest actually asserts. A session-adopted post has no role
+	// package and therefore no rules, which the screen shows as absent rather
+	// than inventing.
+	rules := map[string][]string{}
+	for _, def := range defs {
+		if def.Role == nil {
+			continue
+		}
+		if len(def.Role.Spec.Policy) > 0 {
+			rules[def.Name] = append([]string(nil), def.Role.Spec.Policy...)
+		}
+	}
+	h.agentsPanel.SetRules(rules)
+	h.helpOverlay.SetHasAgents(h.agentsPanel.HasAgents())
 
 	// Index by session so the session list and preview pane can answer
 	// "does this row belong to an agent?" without rescanning the registry.
@@ -157,9 +174,15 @@ func (h *Home) renderAgentCard(row agents.AgentRow, width int) string {
 	valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 	roleStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
 
-	roleText := row.Role
+	// Amendment 01 asks the card for role AND version. A session-adopted post
+	// has no role package, so there is genuinely no version to show; say that
+	// rather than rendering a bare role name that looks like the version was
+	// simply forgotten.
+	roleText := agents.SanitizeForDisplay(row.Role)
 	if row.RoleVersion != "" {
-		roleText += " " + row.RoleVersion
+		roleText += " " + agents.SanitizeForDisplay(row.RoleVersion)
+	} else {
+		roleText += " (no role package)"
 	}
 	b.WriteString(labelStyle.Render("Role:      "))
 	b.WriteString(roleStyle.Render(roleText))
@@ -167,7 +190,7 @@ func (h *Home) renderAgentCard(row agents.AgentRow, width int) string {
 
 	if row.ReportsTo != "" {
 		b.WriteString(labelStyle.Render("Reports:   "))
-		b.WriteString(valueStyle.Render(row.ReportsTo))
+		b.WriteString(valueStyle.Render(agents.SanitizeForDisplay(row.ReportsTo)))
 		b.WriteString("\n")
 	}
 
@@ -176,11 +199,11 @@ func (h *Home) renderAgentCard(row agents.AgentRow, width int) string {
 		b.WriteString(labelStyle.Render("Triggers:  "))
 		b.WriteString("\n")
 		for _, t := range row.Triggers {
-			owner := "agent-deck"
-			if t.External {
-				owner = "external"
+			owner := "external"
+			if !t.External {
+				owner = "ARMED HERE"
 			}
-			line := fmt.Sprintf("  %s %s", truncateStr(t.Name, 18), t.NextDueText)
+			line := fmt.Sprintf("  %s %s", truncateStr(agents.SanitizeForDisplay(t.Name), 18), t.NextDueText)
 			b.WriteString(valueStyle.Render(truncateStr(line, contentWidth-12)))
 			b.WriteString(" ")
 			b.WriteString(labelStyle.Render("[" + owner + "]"))
@@ -196,9 +219,9 @@ func (h *Home) renderAgentCard(row agents.AgentRow, width int) string {
 			b.WriteString("  ")
 			b.WriteString(healthDot(c.State))
 			b.WriteString(" ")
-			b.WriteString(valueStyle.Render(truncateStr(c.Name, 16)))
+			b.WriteString(valueStyle.Render(truncateStr(agents.SanitizeForDisplay(c.Name), 16)))
 			b.WriteString(" ")
-			b.WriteString(labelStyle.Render(truncateStr(c.Detail, contentWidth-22)))
+			b.WriteString(labelStyle.Render(truncateStr(agents.SanitizeForDisplay(c.Detail), contentWidth-22)))
 			b.WriteString("\n")
 		}
 	}
@@ -213,14 +236,14 @@ func (h *Home) renderAgentCard(row agents.AgentRow, width int) string {
 		}
 		for _, entry := range row.Recent[:limit] {
 			b.WriteString(labelStyle.Render("  " + entry.At.Format("15:04") + "  "))
-			b.WriteString(valueStyle.Render(truncateStr(entry.Summary, contentWidth-10)))
+			b.WriteString(valueStyle.Render(truncateStr(agents.SanitizeForDisplay(entry.Summary), contentWidth-10)))
 			b.WriteString("\n")
 		}
 	}
 
 	if row.Attention != "" {
 		b.WriteString(lipgloss.NewStyle().Foreground(ColorRed).
-			Render("  ! " + truncateStr(row.Attention, contentWidth-4)))
+			Render("  ! " + truncateStr(agents.SanitizeForDisplay(row.Attention), contentWidth-4)))
 		b.WriteString("\n")
 	}
 

--- a/internal/ui/agents_panel.go
+++ b/internal/ui/agents_panel.go
@@ -35,7 +35,8 @@ type AgentsPanel struct {
 	// can show the RULES section the mockup and the prompt both call for.
 	rulesByAgent map[string][]string
 	// rules is the selected agent's rules, resolved at render time.
-	rules []string
+	rules     []string
+	loadError string
 }
 
 // agentPanelRow is one rendered line.
@@ -94,6 +95,7 @@ func (ap *AgentsPanel) SetView(view agents.View, now time.Time) {
 		return
 	}
 	ap.view = view
+	ap.loadError = ""
 	ap.now = now
 	ap.rows = ap.rows[:0]
 
@@ -117,6 +119,17 @@ func (ap *AgentsPanel) SetView(view agents.View, now time.Time) {
 	if len(ap.rows) > 0 && ap.rows[ap.cursor].isHeader {
 		ap.moveCursor(1)
 	}
+}
+
+// SetLoadError replaces fleet data with an explicit unknown/error state.
+func (ap *AgentsPanel) SetLoadError(err string, now time.Time) {
+	if ap == nil {
+		return
+	}
+	ap.view = agents.View{}
+	ap.rows = nil
+	ap.loadError = agents.SanitizeForDisplay(err)
+	ap.now = now
 }
 
 // SetRules supplies each agent's policy file names, keyed by agent name.
@@ -233,6 +246,9 @@ func (ap *AgentsPanel) renderList(width int) string {
 	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
 
 	summary := fmt.Sprintf("%d agents", ap.view.TotalAgents)
+	if ap.loadError != "" {
+		summary = "status unknown"
+	}
 	if ap.view.NeedAttention > 0 {
 		summary += fmt.Sprintf(" · %d need attention", ap.view.NeedAttention)
 	}
@@ -242,6 +258,18 @@ func (ap *AgentsPanel) renderList(width int) string {
 	sb.WriteString("\n")
 	sb.WriteString(strings.Repeat("─", width))
 	sb.WriteString("\n")
+
+	if ap.loadError != "" {
+		alertStyle := lipgloss.NewStyle().Foreground(ColorRed).Bold(true)
+		sb.WriteString(alertStyle.Render("  ERROR: agents registry could not be loaded"))
+		sb.WriteString("\n")
+		sb.WriteString(dimStyle.Render("  " + truncateStr(ap.loadError, width-2)))
+		sb.WriteString("\n")
+		sb.WriteString(strings.Repeat("─", width))
+		sb.WriteString("\n")
+		sb.WriteString(dimStyle.Render("[Esc] Close"))
+		return sb.String()
+	}
 
 	if len(ap.rows) == 0 {
 		sb.WriteString(dimStyle.Render("  Nothing adopted yet."))

--- a/internal/ui/agents_panel.go
+++ b/internal/ui/agents_panel.go
@@ -31,6 +31,11 @@ type AgentsPanel struct {
 	// now is injected by the refresh so relative times in a single frame all
 	// agree with each other.
 	now time.Time
+	// rulesByAgent holds each agent's policy file names, so the detail screen
+	// can show the RULES section the mockup and the prompt both call for.
+	rulesByAgent map[string][]string
+	// rules is the selected agent's rules, resolved at render time.
+	rules []string
 }
 
 // agentPanelRow is one rendered line.
@@ -112,6 +117,14 @@ func (ap *AgentsPanel) SetView(view agents.View, now time.Time) {
 	if len(ap.rows) > 0 && ap.rows[ap.cursor].isHeader {
 		ap.moveCursor(1)
 	}
+}
+
+// SetRules supplies each agent's policy file names, keyed by agent name.
+func (ap *AgentsPanel) SetRules(rules map[string][]string) {
+	if ap == nil {
+		return
+	}
+	ap.rulesByAgent = rules
 }
 
 // HasAgents reports whether anything has been adopted. The Agents surfaces
@@ -278,7 +291,7 @@ func (ap *AgentsPanel) renderList(width int) string {
 		sb.WriteString("\n")
 
 		if row.agent.Attention != "" {
-			sb.WriteString(alertStyle.Render("   ! " + truncateStr(row.agent.Attention, width-6)))
+			sb.WriteString(alertStyle.Render("   ! " + truncateStr(agents.SanitizeForDisplay(row.agent.Attention), width-6)))
 			sb.WriteString("\n")
 		}
 	}
@@ -300,9 +313,11 @@ func (ap *AgentsPanel) linkNoteFor(row agentPanelRow) string {
 		return "— UNCONFIRMED: unreachable"
 	case agents.LinkOK:
 		if row.linkNote != "" {
-			return "— link ok, " + row.linkNote
+			return "— link ok, " + agents.SanitizeForDisplay(row.linkNote)
 		}
 		return "— link ok"
+	case agents.LinkNotContacted:
+		return "— not contacted; placement only"
 	default:
 		return ""
 	}
@@ -317,7 +332,8 @@ func (ap *AgentsPanel) renderAgentLine(row agents.AgentRow, width int) string {
 
 	nameWidth := 18
 	line := fmt.Sprintf(" %s %-*s %-11s %-10s",
-		glyph, nameWidth, truncateStr(row.Name, nameWidth), truncateStr(role, 11), truncateStr(string(row.State), 10))
+		glyph, nameWidth, truncateStr(agents.SanitizeForDisplay(row.Name), nameWidth),
+		truncateStr(agents.SanitizeForDisplay(role), 11), truncateStr(string(row.State), 10))
 
 	if last := agents.FormatLastDid(row, ap.now); last != "" {
 		line += "  last: " + truncateStr(last, 30)
@@ -325,8 +341,13 @@ func (ap *AgentsPanel) renderAgentLine(row agents.AgentRow, width int) string {
 	if next := agents.FormatNextDue(row); next != "" {
 		line += "  next: " + truncateStr(next, 14)
 	}
-	if len(line) > width {
-		line = truncateStr(line, width)
+	// Measure by display cells, not bytes: `line` starts with a lipgloss
+	// glyph carrying an SGR escape, so len() counted ~20 invisible bytes and
+	// truncated the row that much too early at every width. cellWidth and
+	// cellTruncate are the repo's ANSI-aware helpers, already used by the
+	// session-row renderer in home.go.
+	if cellWidth(line) > width {
+		line = cellTruncate(line, width, "…")
 	}
 	return line
 }
@@ -351,11 +372,13 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 		return ap.renderList(width)
 	}
 	row := *selected
+	ap.rules = ap.rulesByAgent[row.Name]
 
 	var sb strings.Builder
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
 	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
 	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorCyan)
+	valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 
 	roleLine := row.Role
 	if row.RoleVersion != "" {
@@ -378,9 +401,9 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 		sb.WriteString("\n")
 	} else {
 		for _, t := range row.Triggers {
-			owner := "agent-deck"
-			if t.External {
-				owner = "external"
+			owner := "external"
+			if !t.External {
+				owner = "ARMED HERE"
 			}
 			sb.WriteString(fmt.Sprintf("   %s %-20s %-14s %s\n",
 				triggerGlyph(t), truncateStr(t.Name, 20), truncateStr(t.NextDueText, 14),
@@ -402,7 +425,7 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 		for _, c := range row.Connectors {
 			sb.WriteString(fmt.Sprintf("   %s %-16s %s\n",
 				healthDot(c.State), truncateStr(c.Name, 16),
-				truncateStr(c.Detail, width-24)))
+				truncateStr(agents.SanitizeForDisplay(c.Detail), width-24)))
 		}
 	}
 	sb.WriteString("\n")
@@ -415,7 +438,18 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 	} else {
 		for _, entry := range row.Recent {
 			sb.WriteString(fmt.Sprintf("   %s  %s\n",
-				entry.At.Format("15:04"), truncateStr(entry.Summary, width-12)))
+				entry.At.Format("15:04"), truncateStr(agents.SanitizeForDisplay(entry.Summary), width-12)))
+		}
+	}
+
+	if len(ap.rules) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString(sectionStyle.Render(" RULES"))
+		sb.WriteString("\n")
+		for _, rule := range ap.rules {
+			sb.WriteString("   · ")
+			sb.WriteString(valueStyle.Render(truncateStr(agents.SanitizeForDisplay(rule), width-8)))
+			sb.WriteString("\n")
 		}
 	}
 
@@ -424,14 +458,20 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 		sb.WriteString(sectionStyle.Render(" UNRESOLVED"))
 		sb.WriteString("\n")
 		for _, item := range row.Unresolved {
-			sb.WriteString(dimStyle.Render("   · " + truncateStr(item, width-6)))
+			sb.WriteString(dimStyle.Render("   · " + truncateStr(agents.SanitizeForDisplay(item), width-6)))
 			sb.WriteString("\n")
 		}
 	}
 
 	sb.WriteString(strings.Repeat("─", width))
 	sb.WriteString("\n")
-	sb.WriteString(dimStyle.Render("Read-only. agent-deck displays this; it does not run it.  [h/Esc] Back"))
+	footer := "Read-only. agent-deck displays this; it does not run it.  [h/Esc] Back"
+	if row.LoadError != "" {
+		footer = "This definition could not be read.  [h/Esc] Back"
+	} else if len(row.Violations) > 0 || row.Armed() {
+		footer = "This record claims to be ARMED, which phase 1 never emits.  [h/Esc] Back"
+	}
+	sb.WriteString(dimStyle.Render(footer))
 	return sb.String()
 }
 

--- a/internal/ui/agents_panel.go
+++ b/internal/ui/agents_panel.go
@@ -1,0 +1,489 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/agents"
+)
+
+// AgentsPanel is the Agents tab: the grouped-by-machine fleet list and one
+// agent's detail screen.
+//
+// It is strictly a reader. No key it handles starts, stops, pauses or fires
+// anything — phase 1 renders what already exists and says who owns it.
+type AgentsPanel struct {
+	visible    bool
+	width      int
+	height     int
+	cursor     int
+	scroll     int
+	detailMode bool
+
+	view agents.View
+	// rows is the flattened, navigable list: machine headers are rendered but
+	// not selectable, so the cursor only ever lands on an agent.
+	rows []agentPanelRow
+	// now is injected by the refresh so relative times in a single frame all
+	// agree with each other.
+	now time.Time
+}
+
+// agentPanelRow is one rendered line.
+type agentPanelRow struct {
+	machine  string
+	isHeader bool
+	link     agents.LinkState
+	linkNote string
+	agent    agents.AgentRow
+}
+
+// NewAgentsPanel creates the panel.
+func NewAgentsPanel() *AgentsPanel {
+	return &AgentsPanel{now: time.Now()}
+}
+
+// Show makes the panel visible and resets navigation.
+//
+// Every method on this type tolerates a nil receiver. Home values built
+// directly by tests (rather than through NewHome) leave optional panels nil,
+// and the render/update path must be total over those values rather than
+// panicking on a field it did not expect to be set.
+func (ap *AgentsPanel) Show() {
+	if ap == nil {
+		return
+	}
+	ap.visible = true
+	ap.cursor = 0
+	ap.scroll = 0
+	ap.detailMode = false
+}
+
+// Hide hides the panel.
+func (ap *AgentsPanel) Hide() {
+	if ap == nil {
+		return
+	}
+	ap.visible = false
+}
+
+// IsVisible reports whether the panel is shown.
+func (ap *AgentsPanel) IsVisible() bool { return ap != nil && ap.visible }
+
+// SetSize records the terminal dimensions.
+func (ap *AgentsPanel) SetSize(w, h int) {
+	if ap == nil {
+		return
+	}
+	ap.width = w
+	ap.height = h
+}
+
+// SetView replaces the rendered fleet view.
+func (ap *AgentsPanel) SetView(view agents.View, now time.Time) {
+	if ap == nil {
+		return
+	}
+	ap.view = view
+	ap.now = now
+	ap.rows = ap.rows[:0]
+
+	for _, machine := range view.Machines {
+		ap.rows = append(ap.rows, agentPanelRow{
+			machine: machine.Name, isHeader: true,
+			link: machine.Link, linkNote: machine.LinkDetail,
+		})
+		for _, row := range machine.Agents {
+			ap.rows = append(ap.rows, agentPanelRow{machine: machine.Name, agent: row})
+		}
+	}
+
+	// Keep the cursor on a real agent after a refresh changes the list.
+	if ap.cursor >= len(ap.rows) {
+		ap.cursor = len(ap.rows) - 1
+	}
+	if ap.cursor < 0 {
+		ap.cursor = 0
+	}
+	if len(ap.rows) > 0 && ap.rows[ap.cursor].isHeader {
+		ap.moveCursor(1)
+	}
+}
+
+// HasAgents reports whether anything has been adopted. The Agents surfaces
+// are opt-in by presence: a user with no definitions must see no new UI.
+func (ap *AgentsPanel) HasAgents() bool { return ap != nil && ap.view.TotalAgents > 0 }
+
+// Selected returns the highlighted agent, or nil.
+func (ap *AgentsPanel) Selected() *agents.AgentRow {
+	if ap == nil || ap.cursor < 0 || ap.cursor >= len(ap.rows) {
+		return nil
+	}
+	row := ap.rows[ap.cursor]
+	if row.isHeader {
+		return nil
+	}
+	return &row.agent
+}
+
+// moveCursor steps by delta, skipping machine headers.
+func (ap *AgentsPanel) moveCursor(delta int) {
+	if ap == nil || len(ap.rows) == 0 {
+		return
+	}
+	next := ap.cursor
+	for i := 0; i < len(ap.rows); i++ {
+		next += delta
+		if next < 0 || next >= len(ap.rows) {
+			return
+		}
+		if !ap.rows[next].isHeader {
+			ap.cursor = next
+			return
+		}
+	}
+}
+
+// Update handles keyboard input.
+func (ap *AgentsPanel) Update(msg tea.Msg) (*AgentsPanel, tea.Cmd) {
+	if ap == nil || !ap.visible {
+		return ap, nil
+	}
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return ap, nil
+	}
+
+	switch key.String() {
+	case "esc", "q", "alt+a":
+		if ap.detailMode {
+			ap.detailMode = false
+		} else {
+			ap.Hide()
+		}
+	case "j", "down", "ctrl+n":
+		if !ap.detailMode {
+			ap.moveCursor(1)
+		}
+	case "k", "up", "ctrl+p":
+		if !ap.detailMode {
+			ap.moveCursor(-1)
+		}
+	case "enter", "l":
+		if !ap.detailMode && ap.Selected() != nil {
+			ap.detailMode = true
+		}
+	case "h", "backspace":
+		ap.detailMode = false
+	}
+	return ap, nil
+}
+
+// View renders the panel.
+func (ap *AgentsPanel) View() string {
+	if ap == nil || !ap.visible {
+		return ""
+	}
+	width := ap.width - 4
+	if width < 40 {
+		width = 40
+	}
+	if width > 120 {
+		width = 120
+	}
+
+	borderStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorBorder).
+		Padding(0, 1).
+		Width(width)
+
+	// The border style reserves two columns of padding, so the rules drawn
+	// inside it must be narrower than the box or they wrap onto a stub line.
+	inner := width - 2
+	if inner < 20 {
+		inner = 20
+	}
+	if ap.detailMode {
+		return borderStyle.Render(ap.renderDetail(inner))
+	}
+	return borderStyle.Render(ap.renderList(inner))
+}
+
+func (ap *AgentsPanel) renderList(width int) string {
+	var sb strings.Builder
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+
+	summary := fmt.Sprintf("%d agents", ap.view.TotalAgents)
+	if ap.view.NeedAttention > 0 {
+		summary += fmt.Sprintf(" · %d need attention", ap.view.NeedAttention)
+	}
+	sb.WriteString(titleStyle.Render("AGENTS"))
+	sb.WriteString("  ")
+	sb.WriteString(dimStyle.Render(summary))
+	sb.WriteString("\n")
+	sb.WriteString(strings.Repeat("─", width))
+	sb.WriteString("\n")
+
+	if len(ap.rows) == 0 {
+		sb.WriteString(dimStyle.Render("  Nothing adopted yet."))
+		sb.WriteString("\n")
+		sb.WriteString(dimStyle.Render("  agent-deck agent adopt <conductor-dir|session|plist|unit>"))
+		sb.WriteString("\n")
+		sb.WriteString(strings.Repeat("─", width))
+		sb.WriteString("\n")
+		sb.WriteString(dimStyle.Render("[Esc] Close"))
+		return sb.String()
+	}
+
+	machineStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
+	selectedStyle := lipgloss.NewStyle().Background(ColorSurface).Foreground(ColorText).Bold(true)
+	normalStyle := lipgloss.NewStyle().Foreground(ColorText)
+	alertStyle := lipgloss.NewStyle().Foreground(ColorRed)
+
+	visible := ap.height - 8
+	if visible < 5 {
+		visible = 5
+	}
+	ap.clampScroll(visible)
+
+	end := ap.scroll + visible
+	if end > len(ap.rows) {
+		end = len(ap.rows)
+	}
+
+	for i := ap.scroll; i < end; i++ {
+		row := ap.rows[i]
+		if row.isHeader {
+			header := " " + strings.ToUpper(row.machine)
+			sb.WriteString(machineStyle.Render(header))
+			if note := ap.linkNoteFor(row); note != "" {
+				sb.WriteString(dimStyle.Render("   " + note))
+			}
+			sb.WriteString("\n")
+			continue
+		}
+
+		line := ap.renderAgentLine(row.agent, width)
+		if i == ap.cursor {
+			sb.WriteString(selectedStyle.Render(line))
+		} else {
+			sb.WriteString(normalStyle.Render(line))
+		}
+		sb.WriteString("\n")
+
+		if row.agent.Attention != "" {
+			sb.WriteString(alertStyle.Render("   ! " + truncateStr(row.agent.Attention, width-6)))
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString(strings.Repeat("─", width))
+	sb.WriteString("\n")
+	sb.WriteString(dimStyle.Render("[Enter] Details  [j/k] Move  [Esc] Close"))
+	return sb.String()
+}
+
+// linkNoteFor renders a machine's link health. An unreachable remote says so
+// loudly: its rows are the last thing we saw, not the current truth.
+func (ap *AgentsPanel) linkNoteFor(row agentPanelRow) string {
+	switch row.link {
+	case agents.LinkUnconfirmed:
+		if row.linkNote != "" {
+			return "— UNCONFIRMED: " + row.linkNote
+		}
+		return "— UNCONFIRMED: unreachable"
+	case agents.LinkOK:
+		if row.linkNote != "" {
+			return "— link ok, " + row.linkNote
+		}
+		return "— link ok"
+	default:
+		return ""
+	}
+}
+
+func (ap *AgentsPanel) renderAgentLine(row agents.AgentRow, width int) string {
+	glyph := agentStateGlyph(row.State)
+	role := row.Role
+	if row.Class != agents.ClassAgent {
+		role = string(row.Class)
+	}
+
+	nameWidth := 18
+	line := fmt.Sprintf(" %s %-*s %-11s %-10s",
+		glyph, nameWidth, truncateStr(row.Name, nameWidth), truncateStr(role, 11), truncateStr(string(row.State), 10))
+
+	if last := agents.FormatLastDid(row, ap.now); last != "" {
+		line += "  last: " + truncateStr(last, 30)
+	}
+	if next := agents.FormatNextDue(row); next != "" {
+		line += "  next: " + truncateStr(next, 14)
+	}
+	if len(line) > width {
+		line = truncateStr(line, width)
+	}
+	return line
+}
+
+func (ap *AgentsPanel) clampScroll(visible int) {
+	if ap.cursor < ap.scroll {
+		ap.scroll = ap.cursor
+	}
+	if ap.cursor >= ap.scroll+visible {
+		ap.scroll = ap.cursor - visible + 1
+	}
+	if ap.scroll < 0 {
+		ap.scroll = 0
+	}
+}
+
+// renderDetail renders one agent's desk: triggers, connectors, recent work and
+// rules. Every trigger row names who actually fires it.
+func (ap *AgentsPanel) renderDetail(width int) string {
+	selected := ap.Selected()
+	if selected == nil {
+		return ap.renderList(width)
+	}
+	row := *selected
+
+	var sb strings.Builder
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorCyan)
+
+	roleLine := row.Role
+	if row.RoleVersion != "" {
+		roleLine += " " + row.RoleVersion
+	}
+	sb.WriteString(titleStyle.Render(" " + row.Name))
+	sb.WriteString(dimStyle.Render(fmt.Sprintf("  ·  role: %s  ·  %s  ·  %s",
+		roleLine, harnessLabel(row), row.Machine)))
+	sb.WriteString("\n")
+	sb.WriteString(dimStyle.Render(fmt.Sprintf(" post %s  ·  reports to %s  ·  %s",
+		row.PostID, row.ReportsTo, row.State)))
+	sb.WriteString("\n")
+	sb.WriteString(strings.Repeat("─", width))
+	sb.WriteString("\n")
+
+	sb.WriteString(sectionStyle.Render(" TRIGGERS"))
+	sb.WriteString("\n")
+	if len(row.Triggers) == 0 {
+		sb.WriteString(dimStyle.Render("   none declared"))
+		sb.WriteString("\n")
+	} else {
+		for _, t := range row.Triggers {
+			owner := "agent-deck"
+			if t.External {
+				owner = "external"
+			}
+			sb.WriteString(fmt.Sprintf("   %s %-20s %-14s %s\n",
+				triggerGlyph(t), truncateStr(t.Name, 20), truncateStr(t.NextDueText, 14),
+				dimStyle.Render("["+owner+"]")))
+			if t.Note != "" {
+				sb.WriteString(dimStyle.Render("       " + truncateStr(t.Note, width-8)))
+				sb.WriteString("\n")
+			}
+		}
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString(sectionStyle.Render(" CONNECTORS"))
+	sb.WriteString("\n")
+	if len(row.Connectors) == 0 {
+		sb.WriteString(dimStyle.Render("   none bound"))
+		sb.WriteString("\n")
+	} else {
+		for _, c := range row.Connectors {
+			sb.WriteString(fmt.Sprintf("   %s %-16s %s\n",
+				healthDot(c.State), truncateStr(c.Name, 16),
+				truncateStr(c.Detail, width-24)))
+		}
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString(sectionStyle.Render(" RECENT WORK"))
+	sb.WriteString("\n")
+	if len(row.Recent) == 0 {
+		sb.WriteString(dimStyle.Render("   nothing recorded"))
+		sb.WriteString("\n")
+	} else {
+		for _, entry := range row.Recent {
+			sb.WriteString(fmt.Sprintf("   %s  %s\n",
+				entry.At.Format("15:04"), truncateStr(entry.Summary, width-12)))
+		}
+	}
+
+	if len(row.Unresolved) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString(sectionStyle.Render(" UNRESOLVED"))
+		sb.WriteString("\n")
+		for _, item := range row.Unresolved {
+			sb.WriteString(dimStyle.Render("   · " + truncateStr(item, width-6)))
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString(strings.Repeat("─", width))
+	sb.WriteString("\n")
+	sb.WriteString(dimStyle.Render("Read-only. agent-deck displays this; it does not run it.  [h/Esc] Back"))
+	return sb.String()
+}
+
+func harnessLabel(row agents.AgentRow) string {
+	if row.Harness == "" {
+		return "no harness"
+	}
+	if row.Account != "" {
+		return row.Harness + " / " + row.Account
+	}
+	return row.Harness
+}
+
+// agentStateGlyph maps a run state to the list glyph.
+func agentStateGlyph(state agents.RunState) string {
+	switch state {
+	case agents.RunWorking:
+		return lipgloss.NewStyle().Foreground(ColorGreen).Render("●")
+	case agents.RunIdle:
+		return lipgloss.NewStyle().Foreground(ColorGreen).Render("●")
+	case agents.RunNeedsYou:
+		return lipgloss.NewStyle().Foreground(ColorYellow).Render("◐")
+	case agents.RunError:
+		return lipgloss.NewStyle().Foreground(ColorRed).Render("✕")
+	case agents.RunStopped:
+		return lipgloss.NewStyle().Foreground(ColorTextDim).Render("○")
+	case agents.RunNoRuntime:
+		return lipgloss.NewStyle().Foreground(ColorTextDim).Render("◍")
+	default:
+		return lipgloss.NewStyle().Foreground(ColorTextDim).Render("?")
+	}
+}
+
+// triggerGlyph marks whether a trigger is armed here. In phase 1 none are, so
+// this is always the dim external marker — but it is computed, not hardcoded,
+// so the day a trigger really is owned here the glyph changes with it.
+func triggerGlyph(t agents.TriggerRow) string {
+	if t.Enabled && !t.External {
+		return lipgloss.NewStyle().Foreground(ColorGreen).Render("●")
+	}
+	return lipgloss.NewStyle().Foreground(ColorTextDim).Render("○")
+}
+
+func healthDot(state agents.HealthState) string {
+	switch state {
+	case agents.HealthOK:
+		return lipgloss.NewStyle().Foreground(ColorGreen).Render("●")
+	case agents.HealthStale:
+		return lipgloss.NewStyle().Foreground(ColorYellow).Render("◐")
+	case agents.HealthDown:
+		return lipgloss.NewStyle().Foreground(ColorRed).Render("●")
+	default:
+		return lipgloss.NewStyle().Foreground(ColorTextDim).Render("○")
+	}
+}

--- a/internal/ui/agents_panel.go
+++ b/internal/ui/agents_panel.go
@@ -380,17 +380,26 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorCyan)
 	valueStyle := lipgloss.NewStyle().Foreground(ColorText)
 
-	roleLine := row.Role
+	// Every field on this header comes from a definition file, so all of it
+	// is untrusted text. An unsanitized post id or role name could erase the
+	// panel border and forge a "link ok" line — the exact string this feature
+	// exists to make trustworthy.
+	roleLine := agents.SanitizeForDisplay(row.Role)
 	if row.RoleVersion != "" {
-		roleLine += " " + row.RoleVersion
+		roleLine += " " + agents.SanitizeForDisplay(row.RoleVersion)
 	}
-	sb.WriteString(titleStyle.Render(" " + row.Name))
+	sb.WriteString(titleStyle.Render(" " + agents.SanitizeForDisplay(row.Name)))
 	sb.WriteString(dimStyle.Render(fmt.Sprintf("  ·  role: %s  ·  %s  ·  %s",
-		roleLine, harnessLabel(row), row.Machine)))
+		roleLine, agents.SanitizeForDisplay(harnessLabel(row)), agents.SanitizeForDisplay(row.Machine))))
 	sb.WriteString("\n")
 	sb.WriteString(dimStyle.Render(fmt.Sprintf(" post %s  ·  reports to %s  ·  %s",
-		row.PostID, row.ReportsTo, row.State)))
+		agents.SanitizeForDisplay(row.PostID), agents.SanitizeForDisplay(row.ReportsTo), row.State)))
 	sb.WriteString("\n")
+	if row.ReportsToIssue != "" {
+		sb.WriteString(lipgloss.NewStyle().Foreground(ColorRed).
+			Render(" ! " + truncateStr(agents.SanitizeForDisplay(row.ReportsToIssue), width-4)))
+		sb.WriteString("\n")
+	}
 	sb.WriteString(strings.Repeat("─", width))
 	sb.WriteString("\n")
 
@@ -406,10 +415,11 @@ func (ap *AgentsPanel) renderDetail(width int) string {
 				owner = "ARMED HERE"
 			}
 			sb.WriteString(fmt.Sprintf("   %s %-20s %-14s %s\n",
-				triggerGlyph(t), truncateStr(t.Name, 20), truncateStr(t.NextDueText, 14),
+				triggerGlyph(t), truncateStr(agents.SanitizeForDisplay(t.Name), 20),
+				truncateStr(agents.SanitizeForDisplay(t.NextDueText), 14),
 				dimStyle.Render("["+owner+"]")))
 			if t.Note != "" {
-				sb.WriteString(dimStyle.Render("       " + truncateStr(t.Note, width-8)))
+				sb.WriteString(dimStyle.Render("       " + truncateStr(agents.SanitizeForDisplay(t.Note), width-8)))
 				sb.WriteString("\n")
 			}
 		}

--- a/internal/ui/agents_panel_test.go
+++ b/internal/ui/agents_panel_test.go
@@ -1,0 +1,225 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/agents"
+)
+
+// A Home built directly by a test (rather than through NewHome) leaves
+// optional panels nil. Every entry point must tolerate that instead of
+// panicking in the update or render path.
+func TestAgentsPanelNilReceiverIsSafe(t *testing.T) {
+	var ap *AgentsPanel
+
+	if ap.IsVisible() {
+		t.Error("nil panel reports visible")
+	}
+	if ap.HasAgents() {
+		t.Error("nil panel reports agents")
+	}
+	if got := ap.View(); got != "" {
+		t.Errorf("nil panel rendered %q, want empty", got)
+	}
+	if sel := ap.Selected(); sel != nil {
+		t.Error("nil panel returned a selection")
+	}
+	// None of these may panic.
+	ap.Show()
+	ap.Hide()
+	ap.SetSize(80, 24)
+	ap.SetView(agents.View{}, time.Now())
+	ap.SetRules(map[string][]string{"x": {"POLICY.md"}})
+	if _, cmd := ap.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}); cmd != nil {
+		t.Error("nil panel returned a command")
+	}
+}
+
+func TestAgentsPanelEmptyRegistryHasNoAgents(t *testing.T) {
+	ap := NewAgentsPanel()
+	ap.SetView(agents.View{}, time.Now())
+	if ap.HasAgents() {
+		t.Error("an empty view reports agents; the panel would open for a zero-config user")
+	}
+}
+
+func testView() agents.View {
+	return agents.View{
+		TotalAgents: 2,
+		Machines: []agents.Machine{{
+			Name: "g14",
+			Link: agents.LinkLocal,
+			Agents: []agents.AgentRow{
+				{Name: "conductor", Role: "manager", RoleVersion: "0.1.0", Class: agents.ClassAgent, State: agents.RunIdle},
+				{Name: "mail-watcher", Role: "triage", Class: agents.ClassAgent, State: agents.RunNeedsYou},
+			},
+		}},
+	}
+}
+
+// The cursor must land on agents, never on a machine header.
+func TestAgentsPanelCursorSkipsMachineHeaders(t *testing.T) {
+	ap := NewAgentsPanel()
+	ap.SetSize(120, 40)
+	ap.Show()
+	ap.SetView(testView(), time.Now())
+
+	sel := ap.Selected()
+	if sel == nil {
+		t.Fatal("no selection after SetView; cursor is parked on a header")
+	}
+	if sel.Name != "conductor" {
+		t.Errorf("first selection is %q, want conductor", sel.Name)
+	}
+
+	ap.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if sel = ap.Selected(); sel == nil || sel.Name != "mail-watcher" {
+		t.Errorf("after j, selection is %+v, want mail-watcher", sel)
+	}
+	// Past the end, the cursor stays put rather than falling off.
+	ap.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if sel = ap.Selected(); sel == nil || sel.Name != "mail-watcher" {
+		t.Errorf("cursor moved past the last row: %+v", sel)
+	}
+}
+
+// Rows are measured in display cells. The glyph carries an SGR escape, so a
+// byte-length check silently lost ~20 columns at every width.
+func TestAgentsPanelRowsUseDisplayWidthNotBytes(t *testing.T) {
+	view := agents.View{
+		TotalAgents: 1,
+		Machines: []agents.Machine{{
+			Name: "g14", Link: agents.LinkLocal,
+			Agents: []agents.AgentRow{{
+				Name: "gmail-watcher-imap-poll", Role: "connector",
+				Class: agents.ClassAgent, State: agents.RunIdle,
+				Triggers: []agents.TriggerRow{{
+					Name: "poll", Kind: agents.TriggerCron, External: true,
+					ExternalSource: "/x.plist", NextDueText: "every 5m",
+				}},
+			}},
+		}},
+	}
+
+	for _, width := range []int{80, 100, 120} {
+		ap := NewAgentsPanel()
+		ap.SetSize(width, 40)
+		ap.Show()
+		ap.SetView(view, time.Now())
+
+		out := ap.View()
+		for _, line := range strings.Split(out, "\n") {
+			if got := cellWidth(line); got > width {
+				t.Errorf("width %d: rendered line is %d cells wide:\n%s", width, got, line)
+			}
+		}
+		// At 80 columns there is room for the next-due cell; a byte-length
+		// truncation dropped it while leaving the row visibly short.
+		if width >= 80 && !strings.Contains(out, "every 5m") {
+			t.Errorf("width %d: next-due was truncated away though the row had room:\n%s", width, out)
+		}
+	}
+}
+
+// The prompt names RULES as part of the detail screen.
+func TestAgentsPanelDetailRendersRules(t *testing.T) {
+	ap := NewAgentsPanel()
+	ap.SetSize(120, 40)
+	ap.Show()
+	ap.SetView(testView(), time.Now())
+	ap.SetRules(map[string][]string{"conductor": {"POLICY.md", "PR-POLICY.md"}})
+
+	ap.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	out := ap.View()
+
+	if !strings.Contains(out, "RULES") {
+		t.Errorf("detail screen has no RULES section:\n%s", out)
+	}
+	if !strings.Contains(out, "PR-POLICY.md") {
+		t.Errorf("detail screen does not list the role's policy files:\n%s", out)
+	}
+}
+
+// A record that claims to be armed must not be painted under a blanket
+// "this is disabled" footer.
+func TestAgentsPanelDoesNotCallAnArmedRecordDisabled(t *testing.T) {
+	view := agents.View{
+		TotalAgents: 1,
+		Machines: []agents.Machine{{
+			Name: "g14", Link: agents.LinkLocal,
+			Agents: []agents.AgentRow{{
+				Name: "armed", Role: "builder", Class: agents.ClassAgent, State: agents.RunIdle,
+				Triggers: []agents.TriggerRow{{
+					Name: "cron", Kind: agents.TriggerCron, Enabled: true, External: false,
+					NextDueText: "cron 5m",
+				}},
+			}},
+		}},
+	}
+	ap := NewAgentsPanel()
+	ap.SetSize(120, 40)
+	ap.Show()
+	ap.SetView(view, time.Now())
+	ap.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	out := ap.View()
+	if strings.Contains(out, "it does not run it") {
+		t.Errorf("an armed record was rendered under the disabled footer:\n%s", out)
+	}
+	if !strings.Contains(out, "ARMED") {
+		t.Errorf("an armed trigger is not called out:\n%s", out)
+	}
+}
+
+// Definition content is data, not markup.
+func TestAgentsPanelStripsControlSequencesFromContent(t *testing.T) {
+	view := agents.View{
+		TotalAgents: 1,
+		Machines: []agents.Machine{{
+			Name: "g14", Link: agents.LinkLocal,
+			Agents: []agents.AgentRow{{
+				Name:      "evil\x1b[2K\rforged",
+				Role:      "triage",
+				Class:     agents.ClassAgent,
+				State:     agents.RunIdle,
+				Attention: "x\x1b[31mred",
+			}},
+		}},
+	}
+	ap := NewAgentsPanel()
+	ap.SetSize(120, 40)
+	ap.Show()
+	ap.SetView(view, time.Now())
+
+	out := ap.View()
+	if strings.Contains(out, "\x1b[2K") || strings.Contains(out, "\r") {
+		t.Errorf("a control sequence from definition content reached the rendered output:\n%q", out)
+	}
+}
+
+// A machine that was never contacted must not be labelled "link ok".
+func TestAgentsPanelNeverContactedMachineSaysSo(t *testing.T) {
+	view := agents.View{
+		TotalAgents: 1,
+		Machines: []agents.Machine{{
+			Name: "mac-studio", Link: agents.LinkNotContacted,
+			Agents: []agents.AgentRow{{Name: "x", Role: "triage", Class: agents.ClassAgent, State: agents.RunUnknown}},
+		}},
+	}
+	ap := NewAgentsPanel()
+	ap.SetSize(120, 40)
+	ap.Show()
+	ap.SetView(view, time.Now())
+
+	out := ap.View()
+	if strings.Contains(out, "link ok") {
+		t.Errorf("an uncontacted machine claims link ok:\n%s", out)
+	}
+	if !strings.Contains(out, "not contacted") {
+		t.Errorf("an uncontacted machine does not say so:\n%s", out)
+	}
+}

--- a/internal/ui/agents_panel_test.go
+++ b/internal/ui/agents_panel_test.go
@@ -47,6 +47,20 @@ func TestAgentsPanelEmptyRegistryHasNoAgents(t *testing.T) {
 	}
 }
 
+func TestAgentsPanelRendersRegistryLoadFailureAsUnknown(t *testing.T) {
+	ap := NewAgentsPanel()
+	ap.SetLoadError("permission denied", time.Now())
+	ap.Show()
+	ap.SetSize(100, 30)
+	out := ap.View()
+	if !strings.Contains(out, "ERROR: agents registry could not be loaded") || !strings.Contains(out, "permission denied") {
+		t.Fatalf("load failure rendered as empty instead of explicit error:\n%s", out)
+	}
+	if strings.Contains(out, "Nothing adopted yet") {
+		t.Fatalf("unknown registry rendered as zero agents:\n%s", out)
+	}
+}
+
 func testView() agents.View {
 	return agents.View{
 		TotalAgents: 2,

--- a/internal/ui/agents_panel_test.go
+++ b/internal/ui/agents_panel_test.go
@@ -223,3 +223,40 @@ func TestAgentsPanelNeverContactedMachineSaysSo(t *testing.T) {
 		t.Errorf("an uncontacted machine does not say so:\n%s", out)
 	}
 }
+
+// Round 2 R1: the DETAIL screen's header and trigger fields are definition
+// content too, and were not sanitized. An unsanitized post id could erase the
+// panel border and forge the "link ok" line this feature exists to make
+// trustworthy.
+func TestAgentsPanelDetailStripsControlSequences(t *testing.T) {
+	view := agents.View{
+		TotalAgents: 1,
+		Machines: []agents.Machine{{
+			Name: "g14", Link: agents.LinkLocal,
+			Agents: []agents.AgentRow{{
+				Name:      "ok-name",
+				Role:      "manager\x1b[2K\rlink ok, drained 2m ago",
+				PostID:    "post\x1b[2K\rforged",
+				ReportsTo: "human:root\x1b[31m",
+				Machine:   "g14\x1b[2K",
+				Class:     agents.ClassAgent,
+				State:     agents.RunIdle,
+				Triggers: []agents.TriggerRow{{
+					Name: "trig\x1b[2K\rDISABLED", Kind: agents.TriggerCron,
+					External: true, ExternalSource: "/x.plist",
+					NextDueText: "cron 5m\x1b[2K", Note: "note\x1b[2K",
+				}},
+			}},
+		}},
+	}
+	ap := NewAgentsPanel()
+	ap.SetSize(120, 40)
+	ap.Show()
+	ap.SetView(view, time.Now())
+	ap.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	out := ap.View()
+	if strings.Contains(out, "\x1b[2K") || strings.Contains(out, "\r") {
+		t.Errorf("detail screen passed a control sequence through:\n%q", out)
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -50,6 +50,18 @@ type HelpOverlay struct {
 	height       int
 	scrollOffset int // Current scroll position for small screens
 	hotkeys      map[string]string
+	// hasAgents gates the Agents row. The feature is opt-in by presence, and
+	// this overlay is part of the TUI: a user who has adopted nothing must not
+	// find a key here for a surface that does not exist for them.
+	hasAgents bool
+}
+
+// SetHasAgents records whether anything has been adopted.
+func (h *HelpOverlay) SetHasAgents(has bool) {
+	if h == nil {
+		return
+	}
+	h.hasAgents = has
 }
 
 // NewHelpOverlay creates a new help overlay
@@ -311,7 +323,6 @@ func (h *HelpOverlay) View() string {
 			title: "WATCHERS",
 			items: [][2]string{
 				{watcherPanelKey, "Watcher panel"},
-				{agentsPanelKey, "Agents"},
 			},
 		},
 		{
@@ -353,6 +364,19 @@ func (h *HelpOverlay) View() string {
 				{"--profile <name>", "Use specific profile"},
 			},
 		},
+	}
+
+	// The Agents row appears only once something has been adopted. The whole
+	// feature is opt-in by presence, and the help overlay is part of the TUI:
+	// a user with no agents must not find a key here for a surface that does
+	// not exist for them.
+	if h.hasAgents {
+		for i := range sections {
+			if sections[i].title == "WATCHERS" {
+				sections[i].items = append(sections[i].items, [2]string{agentsPanelKey, "Agents"})
+				break
+			}
+		}
 	}
 
 	for i := range sections {

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -209,6 +209,7 @@ func (h *HelpOverlay) View() string {
 	worktreeSetupKey := h.key(hotkeyWorktreeSetup, "b")
 	worktreeKey := h.key(hotkeyWorktreeFinish, "W")
 	watcherPanelKey := h.key(hotkeyWatcherPanel, "w")
+	agentsPanelKey := h.key(hotkeyAgentsPanel, "alt+a")
 	groupKey := h.key(hotkeyCreateGroup, "g")
 	undoKey := h.key(hotkeyUndoDelete, "Ctrl+Z")
 	archiveKey := h.key(hotkeyArchiveSession, "A")
@@ -310,6 +311,7 @@ func (h *HelpOverlay) View() string {
 			title: "WATCHERS",
 			items: [][2]string{
 				{watcherPanelKey, "Watcher panel"},
+				{agentsPanelKey, "Agents"},
 			},
 		},
 		{

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/agents"
 	"github.com/asheshgoplani/agent-deck/internal/clipboard"
 	"github.com/asheshgoplani/agent-deck/internal/costs"
 	"github.com/asheshgoplani/agent-deck/internal/docker"
@@ -280,8 +281,19 @@ type Home struct {
 	feedbackState        *feedback.State       // Loaded at first show, avoids repeated disk I/O
 	feedbackSender       *feedback.Sender      // Sender constructed once in NewHome (Phase 3, per D-05)
 	watcherPanel         *WatcherPanel         // For showing watcher status and events
-	toolVisibilityPanel  *ToolVisibilityPanel  // Edits [ui].hidden_tools
-	watcherEngine        *watcher.Engine       // nil until Init (D-07: lifecycle tied to TUI startup)
+	agentsPanel          *AgentsPanel          // Agents tab: adopted agents, grouped by machine
+	// agentsView is the last built fleet view; agentBySession indexes its
+	// rows by adopted session id so the session list can mark agent-owned
+	// rows and the preview pane can render their card. Both are empty for a
+	// user who has adopted nothing, which is what keeps those surfaces
+	// invisible by default.
+	agentsView          agents.View
+	agentBySession      map[string]agents.AgentRow
+	agentsLastRefresh   time.Time
+	agentsLoaded        bool
+	agentsLoadError     string
+	toolVisibilityPanel *ToolVisibilityPanel // Edits [ui].hidden_tools
+	watcherEngine       *watcher.Engine      // nil until Init (D-07: lifecycle tied to TUI startup)
 
 	// Configurable hotkeys
 	hotkeys        map[string]string // action -> configured key
@@ -1496,6 +1508,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		zoxidePicker:              NewZoxidePicker(),
 		feedbackSender:            feedback.NewSender(),
 		watcherPanel:              NewWatcherPanel(),
+		agentsPanel:               NewAgentsPanel(),
 		toolVisibilityPanel:       NewToolVisibilityPanel(),
 		insertBatchDuration:       defaultInsertBatchDuration,
 		insertOpenKeySender:       defaultInsertOpenKeySender,
@@ -5373,6 +5386,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.setupWizard.SetSize(msg.Width, msg.Height)
 		h.settingsPanel.SetSize(msg.Width, msg.Height)
 		h.watcherPanel.SetSize(msg.Width, msg.Height)
+		h.agentsPanel.SetSize(msg.Width, msg.Height)
 		if h.toolVisibilityPanel != nil {
 			h.toolVisibilityPanel.SetSize(msg.Width, msg.Height)
 		}
@@ -7038,6 +7052,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, tea.Batch(focusCmd, h.tick())
 		}
 
+		// Keep the agents index current so the ⚙ marker and the preview
+		// card reflect live state without the panel being open. Internally
+		// rate-limited, and a no-op when nothing has been adopted.
+		h.refreshAgentsPanel()
+
 		var remoteFetchCmd tea.Cmd
 		var remoteLatencyCmd tea.Cmd
 
@@ -7309,6 +7328,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Handle watcher panel (before settings panel)
+		if h.agentsPanel.IsVisible() {
+			var cmd tea.Cmd
+			h.agentsPanel, cmd = h.agentsPanel.Update(msg)
+			return h, cmd
+		}
 		if h.watcherPanel.IsVisible() {
 			var cmd tea.Cmd
 			h.watcherPanel, cmd = h.watcherPanel.Update(msg)
@@ -8221,6 +8245,7 @@ func (h *Home) hasModalVisible() bool {
 		h.setupWizard.IsVisible() || h.settingsPanel.IsVisible() ||
 		(h.toolVisibilityPanel != nil && h.toolVisibilityPanel.IsVisible()) ||
 		h.watcherPanel.IsVisible() || // hotkeyWatcherPanel overlay
+		h.agentsPanel.IsVisible() || // hotkeyAgentsPanel overlay
 		h.helpOverlay.IsVisible() || h.search.IsVisible() || h.globalSearch.IsVisible() ||
 		h.newDialog.IsVisible() || h.groupDialog.IsVisible() || h.forkDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.pluginDialog.IsVisible() || h.skillDialog.IsVisible() ||
@@ -9251,6 +9276,18 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.refreshWatcherPanel()
 		h.watcherPanel.Show()
 		h.watcherPanel.SetSize(h.width, h.height)
+		return h, nil
+
+	case defaultHotkeyBindings[hotkeyAgentsPanel]:
+		// Open the Agents tab. Opt-in by presence: with nothing adopted there
+		// is no panel to open and the key stays inert, so a zero-config deck
+		// is unchanged.
+		h.refreshAgentsPanel()
+		if !h.agentsPanel.HasAgents() {
+			return h, nil
+		}
+		h.agentsPanel.Show()
+		h.agentsPanel.SetSize(h.width, h.height)
 		return h, nil
 
 	case "E":
@@ -14503,6 +14540,9 @@ func (h *Home) renderFrame() string {
 	}
 
 	// Watcher panel is modal (before settings panel)
+	if h.agentsPanel.IsVisible() {
+		return h.agentsPanel.View()
+	}
 	if h.watcherPanel.IsVisible() {
 		return h.watcherPanel.View()
 	}
@@ -17129,6 +17169,22 @@ func (h *Home) renderSessionItem(
 		sshBadge = sshStyle.Render(" [ssh:" + host + "]")
 	}
 
+	// Agent marker for a session owned by an adopted agent.
+	//
+	// Deliberately one glyph and nothing more. The role, its version, its
+	// triggers and its connector health belong in the preview panel's agent
+	// card, where there is room to be honest about them; crowding them onto
+	// the row would cost the scannability the list depends on. A deck with
+	// nothing adopted has an empty index, so no marker renders at all.
+	agentBadge := ""
+	if _, owned := h.agentRowForSession(inst.ID); owned {
+		agStyle := lipgloss.NewStyle().Foreground(ColorCyan)
+		if selected {
+			agStyle = SessionStatusSelStyle
+		}
+		agentBadge = agStyle.Render(" ⚙")
+	}
+
 	// Last-update timestamp badge — see pickBadgeTime for the formula.
 	// Selected rows reuse the selection-bar style instead of dim, so the
 	// badge stays legible inside the highlight.
@@ -17191,7 +17247,7 @@ func (h *Home) renderSessionItem(
 			cellWidth(status) + 1 /* space before title */ + cellWidth(tool) +
 			cellWidth(maestroBadge) + cellWidth(yoloBadge) + cellWidth(worktreeBadge) +
 			cellWidth(sandboxBadge) + cellWidth(multiRepoBadge) + cellWidth(sshBadge) +
-			cellWidth(timestampBadge)
+			cellWidth(agentBadge) + cellWidth(timestampBadge)
 		budget := listWidth - reserved - 1 // -1 trailing margin
 		if budget > 0 && cellWidth(displayTitle) > budget {
 			displayTitle = cellTruncate(displayTitle, budget, "…")
@@ -17203,7 +17259,7 @@ func (h *Home) renderSessionItem(
 	// The leading gutter (leftGutterWidth) keeps sessions aligned with group
 	// rows, which reserve the same gutter for root hotkey numbers.
 	row := fmt.Sprintf(
-		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s%s",
 		strings.Repeat(" ", leftGutterWidth),
 		baseIndent,
 		selectionPrefix,
@@ -17218,6 +17274,7 @@ func (h *Home) renderSessionItem(
 		sandboxBadge,
 		multiRepoBadge,
 		sshBadge,
+		agentBadge,
 		timestampBadge,
 	)
 
@@ -18128,6 +18185,15 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	b.WriteString(" ")
 	b.WriteString(groupBadge)
 	b.WriteString("\n")
+
+	// Agent card. When the selected session belongs to an adopted agent, its
+	// role, triggers, connector health and recent ledger entries render here
+	// — high in the preview, where there is room to be accurate — instead of
+	// being crushed into the session row, which carries only the ⚙ marker.
+	// Sessions with no agent, and decks with nothing adopted, render nothing.
+	if agentRow, owned := h.agentRowForSession(selected.ID); owned {
+		b.WriteString(h.renderAgentCard(agentRow, width))
+	}
 
 	// Worktree info section (for sessions running in git worktrees)
 	if selected.IsWorktree() {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9283,7 +9283,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// is no panel to open and the key stays inert, so a zero-config deck
 		// is unchanged.
 		h.refreshAgentsPanel()
-		if !h.agentsPanel.HasAgents() {
+		if !h.agentsPanel.HasAgents() && h.agentsLoadError == "" {
 			return h, nil
 		}
 		h.agentsPanel.Show()

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -50,6 +50,17 @@ const (
 	hotkeyReload           = "reload"
 	hotkeyDetach           = "detach"
 	hotkeyWatcherPanel     = "watcher_panel"
+	// hotkeyAgentsPanel opens the Agents tab.
+	//
+	// The design mockup asks for "a". Every plain letter that reads as
+	// "agents" is already taken by a shipped binding — "a" is quick_approve,
+	// "A" is archive_session, and "G" is the hardcoded global-search case in
+	// updateInner — and rebinding one of those out from under existing muscle
+	// memory is not this feature's call to make. "alt+a" keeps the mockup's
+	// mnemonic on a chord that nothing else claims. A user who would rather
+	// have the bare key can set [hotkeys].agents_panel = "a" and move
+	// quick_approve.
+	hotkeyAgentsPanel = "agents_panel"
 	// Session switcher. While attached it is intercepted in the tmux attach
 	// loop (see internal/tmux/pty.go AttachOptions); on the home screen it is
 	// dispatched like any other hotkey. Must resolve to a "ctrl+<letter>" chord.
@@ -116,6 +127,7 @@ var hotkeyActionOrder = []string{
 	hotkeyReload,
 	hotkeyDetach,
 	hotkeyWatcherPanel,
+	hotkeyAgentsPanel,
 	hotkeySwitchSession,
 }
 
@@ -162,6 +174,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyReload:           "ctrl+r",
 	hotkeyDetach:           "ctrl+q",
 	hotkeyWatcherPanel:     "w",
+	hotkeyAgentsPanel:      "alt+a",
 	hotkeySwitchSession:    "ctrl+s",
 }
 


### PR DESCRIPTION
Agents become a first-class observation surface: agent-deck agents (list/show/health) and an agents panel in the TUI with an agent card in the preview pane. agents adopt scans existing conductor/cron/systemd setups and renders them as agent definitions — dry-run by default; a real adopt writes only to the agents definitions store (owner-only permissions), never to the scanned sources.

What this is and is not: phase 1 observes and adopts what already exists. It creates no sessions and starts no processes of its own. Independently verified at 4415e566 (round-2 adversarial review, transcripts archived):

- Dry-run has byte-zero filesystem effect — full-tree SHA-256 identical before/after against a fresh HOME/XDG tree.
- The default list path executes no transport: remote data is rendered from cache only, and cache absence is shown honestly rather than triggering a connection.
- Confirmed (non-dry-run) writes are confined to the definitions store.
- A registry that fails to load renders as an explicit ERROR state, not as an empty healthy list.
- The inbox integration seam is ReadInboxEventsForDisplay — a display-only read with a deliberately narrow contract; it cannot drain, ack, or mutate events.

Earlier revisions of this description overclaimed ("read-only, zero new execution paths") before review found transport reachable from the default list path; that was fixed in round 2 and the claims above are the re-verified ones. Systemd adoption preserves every OnCalendar entry, pairs bare timers with sibling service runtimes, and tracks timer edits by fingerprint (regression-tested).

The creation wizard, triggers, and messaging integrations are phase 2+ and are not built; nothing in this surface implies they exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added agent fleet and detail views in the CLI and app interface.
  - View agent status, roles, triggers, connector health, recent activity, policies, and unresolved items.
  - Added read-only agent adoption planning for existing schedules, services, and sessions, with validation and safe preview reports.
  - Added JSON and human-readable output options.
  - Added machine grouping, remote status reporting, attention indicators, and the `Alt+A` Agents panel shortcut.
- **Safety**
  - Sensitive content is filtered, and existing automation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->