### PR TITLE
fix(inbox): fail closed on unsafe drain targets — title/id collisions and corrupt-profile ordering

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -274,6 +274,9 @@ func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, exp
 		return "", &inboxProfileCorruptError{profiles: loadFailures}
 	}
 	if len(exactIDs) == 1 {
+		if explicitlyQualified && exactIDs[0].profile != effectiveProfile {
+			return "", &inboxTargetNotFoundError{identifier: identifier}
+		}
 		return identifier, nil
 	}
 

--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -37,15 +37,44 @@ func (e *inboxTargetAmbiguousError) Error() string {
 }
 
 type inboxProfileCorruptError struct {
+	profiles []profileLoadError
+}
+
+func (e *inboxProfileCorruptError) Error() string {
+	var failures []string
+	for _, failure := range e.profiles {
+		failures = append(failures, fmt.Sprintf("profile %q: %v", failure.profile, failure.err))
+	}
+	return fmt.Sprintf("Error: inbox drain resolution aborted because these profiles could not be read: %s. Nothing was drained.", strings.Join(failures, "; "))
+}
+
+func (e *inboxProfileCorruptError) Unwrap() []error {
+	errs := make([]error, 0, len(e.profiles))
+	for _, failure := range e.profiles {
+		errs = append(errs, failure.err)
+	}
+	return errs
+}
+
+type profileLoadError struct {
 	profile string
 	err     error
 }
 
-func (e *inboxProfileCorruptError) Error() string {
-	return fmt.Sprintf("Error: inbox drain resolution aborted because profile %q could not be read: %v. Nothing was drained.", e.profile, e.err)
+func newInboxProfileCorruptError(profile string, err error) *inboxProfileCorruptError {
+	return &inboxProfileCorruptError{profiles: []profileLoadError{{profile: profile, err: err}}}
 }
 
-func (e *inboxProfileCorruptError) Unwrap() error { return e.err }
+func unreadableProfilesNote(failures []profileLoadError) string {
+	if len(failures) == 0 {
+		return ""
+	}
+	var profiles []string
+	for _, failure := range failures {
+		profiles = append(profiles, fmt.Sprintf("%q", failure.profile))
+	}
+	return fmt.Sprintf("\nUnreadable profiles encountered during resolution: %s.", strings.Join(profiles, ", "))
+}
 
 // inboxExitCode is the #1991 drain-resolution contract: 2 means the target
 // does not exist, 3 means the supplied title/prefix is ambiguous, and 1 is a
@@ -184,12 +213,14 @@ func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, exp
 		inst    *session.Instance
 	}
 	var exactIDs, titleMatches []candidate
+	var loadFailures []profileLoadError
 	for _, profile := range profiles {
 		_, profileInstances, _, loadErr := loadSessionData(profile)
 		if loadErr != nil {
-			// Fail closed. Skipping an unreadable store could conceal another
-			// exact ID or a title collision and make the subsequent drain unsafe.
-			return "", &inboxProfileCorruptError{profile: profile, err: loadErr}
+			// Keep scanning readable stores: a provable ambiguity takes precedence
+			// over an unreadable store, independent of profile directory order.
+			loadFailures = append(loadFailures, profileLoadError{profile: profile, err: loadErr})
+			continue
 		}
 		for _, inst := range profileInstances {
 			if inst.ID == identifier {
@@ -213,11 +244,8 @@ func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, exp
 			named = append(named, fmt.Sprintf("%s (%s, profile %q)", match.inst.Title, match.inst.ID, match.profile))
 		}
 		return "", &inboxTargetAmbiguousError{message: fmt.Sprintf(
-			"%q is both a full session ID and another session's exact title:\n  - %s\nRename the title or use -p/--profile only if it uniquely identifies the intended session.",
-			identifier, strings.Join(named, "\n  - "))}
-	}
-	if len(exactIDs) == 1 {
-		return identifier, nil
+			"%q is both a full session ID and another session's exact title:\n  - %s\nRename the title or use -p/--profile only if it uniquely identifies the intended session.%s",
+			identifier, strings.Join(named, "\n  - "), unreadableProfilesNote(loadFailures))}
 	}
 	if len(exactIDs) > 1 {
 		if explicitlyQualified {
@@ -228,6 +256,9 @@ func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, exp
 				}
 			}
 			if len(qualified) == 1 {
+				if len(loadFailures) > 0 {
+					return "", &inboxProfileCorruptError{profiles: loadFailures}
+				}
 				return identifier, nil
 			}
 		}
@@ -236,8 +267,14 @@ func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, exp
 			exactProfiles = append(exactProfiles, match.profile)
 		}
 		return "", &inboxTargetAmbiguousError{message: fmt.Sprintf(
-			"Full session ID %q exists in profiles %s. Use -p/--profile to choose one.",
-			identifier, strings.Join(exactProfiles, ", "))}
+			"Full session ID %q exists in profiles %s. Use -p/--profile to choose one.%s",
+			identifier, strings.Join(exactProfiles, ", "), unreadableProfilesNote(loadFailures))}
+	}
+	if len(loadFailures) > 0 {
+		return "", &inboxProfileCorruptError{profiles: loadFailures}
+	}
+	if len(exactIDs) == 1 {
+		return identifier, nil
 	}
 
 	return resolveInboxDrainSessionLocally(identifier, effectiveProfile)
@@ -246,7 +283,7 @@ func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, exp
 func resolveInboxDrainSessionLocally(identifier, profile string) (string, error) {
 	_, instances, _, err := loadSessionData(profile)
 	if err != nil {
-		return "", &inboxProfileCorruptError{profile: profile, err: err}
+		return "", newInboxProfileCorruptError(profile, err)
 	}
 	inst, errMsg, errCode := ResolveSession(identifier, instances)
 	if inst == nil {

--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -36,6 +36,17 @@ func (e *inboxTargetAmbiguousError) Error() string {
 	return "Error: inbox drain target is ambiguous. Nothing was drained.\n" + e.message
 }
 
+type inboxProfileCorruptError struct {
+	profile string
+	err     error
+}
+
+func (e *inboxProfileCorruptError) Error() string {
+	return fmt.Sprintf("Error: inbox drain resolution aborted because profile %q could not be read: %v. Nothing was drained.", e.profile, e.err)
+}
+
+func (e *inboxProfileCorruptError) Unwrap() error { return e.err }
+
 // inboxExitCode is the #1991 drain-resolution contract: 2 means the target
 // does not exist, 3 means the supplied title/prefix is ambiguous, and 1 is a
 // storage, usage, or drain failure. Resolution failures never drain events.
@@ -144,12 +155,6 @@ func resolveInboxDrainSession(identifier string) (string, error) {
 }
 
 func resolveInboxDrainSessionInProfile(identifier, explicitProfile string) (string, error) {
-	// An explicit global -p/--profile qualifier is authoritative, including
-	// when corrupt/restored registries contain the same full ID elsewhere.
-	if explicitProfile != "" {
-		return resolveInboxDrainSessionLocally(identifier, explicitProfile)
-	}
-
 	// Check exact IDs in every profile before applying the profile-local
 	// flexible resolver. Do not assume registry uniqueness: draining is
 	// destructive, so duplicate full IDs must fail closed and name every
@@ -158,35 +163,90 @@ func resolveInboxDrainSessionInProfile(identifier, explicitProfile string) (stri
 	if err != nil {
 		return "", fmt.Errorf("list profiles: %w", err)
 	}
-	var exactProfiles []string
+	effectiveProfile := explicitProfile
+	if effectiveProfile == "" {
+		effectiveProfile, err = session.ResolveProfileForStorage("")
+		if err != nil {
+			return "", fmt.Errorf("resolve effective profile: %w", err)
+		}
+	}
+	return resolveInboxDrainSessionInProfiles(identifier, effectiveProfile, explicitProfile != "", profiles)
+}
+
+// resolveInboxDrainSessionInProfiles performs the destructive resolver's
+// global exact-ID pass while retaining title matches from the effective
+// profile. ResolveSession normally gives an exact title precedence over IDs;
+// that is convenient for non-destructive commands, but unsafe here when a
+// title is literally another session's full ID.
+func resolveInboxDrainSessionInProfiles(identifier, effectiveProfile string, explicitlyQualified bool, profiles []string) (string, error) {
+	type candidate struct {
+		profile string
+		inst    *session.Instance
+	}
+	var exactIDs, titleMatches []candidate
 	for _, profile := range profiles {
 		_, profileInstances, _, loadErr := loadSessionData(profile)
 		if loadErr != nil {
-			return "", fmt.Errorf("load profile %q: %w", profile, loadErr)
+			// Fail closed. Skipping an unreadable store could conceal another
+			// exact ID or a title collision and make the subsequent drain unsafe.
+			return "", &inboxProfileCorruptError{profile: profile, err: loadErr}
 		}
 		for _, inst := range profileInstances {
 			if inst.ID == identifier {
-				exactProfiles = append(exactProfiles, profile)
-				break
+				exactIDs = append(exactIDs, candidate{profile: profile, inst: inst})
+			}
+			if profile == effectiveProfile && inst.Title == identifier {
+				titleMatches = append(titleMatches, candidate{profile: profile, inst: inst})
 			}
 		}
 	}
-	if len(exactProfiles) == 1 {
+
+	var conflictingTitles []candidate
+	for _, title := range titleMatches {
+		if title.inst.ID != identifier {
+			conflictingTitles = append(conflictingTitles, title)
+		}
+	}
+	if len(exactIDs) > 0 && len(conflictingTitles) > 0 {
+		var named []string
+		for _, match := range append(exactIDs, conflictingTitles...) {
+			named = append(named, fmt.Sprintf("%s (%s, profile %q)", match.inst.Title, match.inst.ID, match.profile))
+		}
+		return "", &inboxTargetAmbiguousError{message: fmt.Sprintf(
+			"%q is both a full session ID and another session's exact title:\n  - %s\nRename the title or use -p/--profile only if it uniquely identifies the intended session.",
+			identifier, strings.Join(named, "\n  - "))}
+	}
+	if len(exactIDs) == 1 {
 		return identifier, nil
 	}
-	if len(exactProfiles) > 1 {
+	if len(exactIDs) > 1 {
+		if explicitlyQualified {
+			var qualified []candidate
+			for _, match := range exactIDs {
+				if match.profile == effectiveProfile {
+					qualified = append(qualified, match)
+				}
+			}
+			if len(qualified) == 1 {
+				return identifier, nil
+			}
+		}
+		var exactProfiles []string
+		for _, match := range exactIDs {
+			exactProfiles = append(exactProfiles, match.profile)
+		}
 		return "", &inboxTargetAmbiguousError{message: fmt.Sprintf(
 			"Full session ID %q exists in profiles %s. Use -p/--profile to choose one.",
 			identifier, strings.Join(exactProfiles, ", "))}
 	}
 
-	return resolveInboxDrainSessionLocally(identifier, "")
+	return resolveInboxDrainSessionLocally(identifier, effectiveProfile)
 }
 
 func resolveInboxDrainSessionLocally(identifier, profile string) (string, error) {
 	_, instances, _, err := loadSessionData(profile)
 	if err != nil {
-		return "", err
+		return "", &inboxProfileCorruptError{profile: profile, err: err}
 	}
 	inst, errMsg, errCode := ResolveSession(identifier, instances)
 	if inst == nil {

--- a/cmd/agent-deck/inbox_drain_resolution_followup_test.go
+++ b/cmd/agent-deck/inbox_drain_resolution_followup_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,8 +16,84 @@ func saveInboxResolutionSessions(t *testing.T, profile string, instances ...*ses
 	if err != nil {
 		t.Fatalf("storage %q: %v", profile, err)
 	}
+	t.Cleanup(func() { _ = storage.Close() })
 	if err := storage.SaveWithGroups(instances, session.NewGroupTreeWithGroups(instances, nil)); err != nil {
 		t.Fatalf("save profile %q: %v", profile, err)
+	}
+}
+
+func TestInboxDrain_FullIDAndLocalTitleCollisionRefusesWithoutDraining(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	const targetID = "deadbeef-1777000300"
+	exact := session.NewInstance("remote-exact-id", t.TempDir())
+	exact.ID = targetID
+	localTitle := session.NewInstance(targetID, t.TempDir())
+	localTitle.ID = "cafefeed-1777000301"
+	saveInboxResolutionSessions(t, "personal", exact)
+	saveInboxResolutionSessions(t, "work", localTitle)
+
+	if err := session.CommitToInbox(targetID, session.TransitionNotificationEvent{ChildSessionID: "must-survive-title-collision"}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	var stdout bytes.Buffer
+	// The explicit profile is the reproducer: before the fix it bypassed the
+	// cross-profile exact-ID pass and ResolveSession chose this profile's title.
+	err := runInboxWithProfile(&stdout, []string{"drain", targetID}, "work")
+	if err == nil {
+		t.Fatalf("ID/title collision silently drained an inbox: %q", stdout.String())
+	}
+	if got := inboxExitCode(err); got != 3 {
+		t.Fatalf("exit code = %d, want 3 (ambiguous): %v", got, err)
+	}
+	for _, want := range []string{"remote-exact-id", targetID, localTitle.ID, "personal", "work", "Nothing was drained"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("collision error %q missing candidate detail %q", err, want)
+		}
+	}
+	if !session.InboxHasPending(targetID) {
+		t.Fatal("ambiguous ID/title collision destructively drained the target inbox")
+	}
+}
+
+func TestInboxDrain_CorruptProfileAbortsNamesProfileAndPreservesInbox(t *testing.T) {
+	cliInboxTestHome(t)
+	t.Setenv("AGENTDECK_PROFILE", "work")
+
+	target := session.NewInstance("healthy-target", t.TempDir())
+	target.ID = "deadbeef-1777000310"
+	saveInboxResolutionSessions(t, "work", target)
+
+	dbPath, err := session.GetDBPathForProfile("aaa-corrupt")
+	if err != nil {
+		t.Fatalf("corrupt profile path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		t.Fatalf("mkdir corrupt profile: %v", err)
+	}
+	if err := os.WriteFile(dbPath, []byte("this is not sqlite"), 0o600); err != nil {
+		t.Fatalf("write corrupt profile: %v", err)
+	}
+	if err := session.CommitToInbox(target.ID, session.TransitionNotificationEvent{ChildSessionID: "must-survive-corrupt-profile"}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = runInbox(&stdout, []string{"drain", target.ID})
+	if err == nil {
+		t.Fatalf("corrupt profile was silently skipped: %q", stdout.String())
+	}
+	if got := inboxExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1 (storage failure): %v", got, err)
+	}
+	for _, want := range []string{"aaa-corrupt", "resolution aborted", "Nothing was drained"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("corrupt-profile error %q missing %q", err, want)
+		}
+	}
+	if !session.InboxHasPending(target.ID) {
+		t.Fatal("resolution failure on corrupt profile destructively drained the target inbox")
 	}
 }
 

--- a/cmd/agent-deck/inbox_drain_resolution_followup_test.go
+++ b/cmd/agent-deck/inbox_drain_resolution_followup_test.go
@@ -97,6 +97,60 @@ func TestInboxDrain_CorruptProfileAbortsNamesProfileAndPreservesInbox(t *testing
 	}
 }
 
+// Revert pin for cfd424c9: the old resolver either drained the exact-ID owner
+// or returned on aaa-corrupt before discovering this cross-profile collision.
+func TestInboxDrain_CorruptProfileAndKnownCollisionRefusesRegardlessOfOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		profiles []string
+	}{
+		{name: "corrupt first", profiles: []string{"aaa-corrupt", "personal", "work"}},
+		{name: "corrupt last", profiles: []string{"personal", "work", "aaa-corrupt"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cliInboxTestHome(t)
+			t.Setenv("AGENTDECK_PROFILE", "work")
+
+			exact := session.NewInstance("exact-owner", t.TempDir())
+			exact.ID = "collision-id"
+			title := session.NewInstance("collision-id", t.TempDir())
+			title.ID = "title-owner"
+			saveInboxResolutionSessions(t, "personal", exact)
+			saveInboxResolutionSessions(t, "work", title)
+
+			dbPath, err := session.GetDBPathForProfile("aaa-corrupt")
+			if err != nil {
+				t.Fatalf("corrupt profile path: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+				t.Fatalf("mkdir corrupt profile: %v", err)
+			}
+			if err := os.WriteFile(dbPath, []byte("this is not sqlite"), 0o600); err != nil {
+				t.Fatalf("write corrupt profile: %v", err)
+			}
+			if err := session.CommitToInbox(exact.ID, session.TransitionNotificationEvent{ChildSessionID: "must-survive-combined-failure"}); err != nil {
+				t.Fatalf("commit: %v", err)
+			}
+
+			_, err = resolveInboxDrainSessionInProfiles(exact.ID, "work", false, tc.profiles)
+			if err == nil {
+				t.Fatal("corrupt profile and known collision resolved successfully")
+			}
+			if got := inboxExitCode(err); got != 3 {
+				t.Fatalf("exit code = %d, want 3 (known ambiguity): %v", got, err)
+			}
+			for _, want := range []string{"exact-owner", "collision-id", "personal", "title-owner", "work", "aaa-corrupt", "Nothing was drained"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("combined-state error %q missing %q", err, want)
+				}
+			}
+			if !session.InboxHasPending(exact.ID) {
+				t.Fatal("combined failure destructively drained the target inbox")
+			}
+		})
+	}
+}
+
 func TestInboxDrain_FullIDResolvesAcrossProfiles(t *testing.T) {
 	cliInboxTestHome(t)
 	t.Setenv("AGENTDECK_PROFILE", "work")

--- a/cmd/agent-deck/inbox_drain_resolution_followup_test.go
+++ b/cmd/agent-deck/inbox_drain_resolution_followup_test.go
@@ -171,6 +171,36 @@ func TestInboxDrain_FullIDResolvesAcrossProfiles(t *testing.T) {
 	}
 }
 
+// An explicit profile is a hard namespace boundary. Even a globally unique,
+// exact ID must not escape it: the caller asked to act only in "work".
+func TestInboxDrain_ExplicitProfileRejectsForeignExactIDWithoutDraining(t *testing.T) {
+	cliInboxTestHome(t)
+
+	target := session.NewInstance("personal-target", t.TempDir())
+	target.ID = "deadbeef-1777000320"
+	saveInboxResolutionSessions(t, "personal", target)
+	saveInboxResolutionSessions(t, "work")
+
+	if err := session.CommitToInbox(target.ID, session.TransitionNotificationEvent{ChildSessionID: "must-survive-profile-boundary"}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := runInboxWithProfile(&stdout, []string{"drain", target.ID}, "work")
+	if err == nil {
+		t.Fatalf("explicit work profile drained a personal session: %q", stdout.String())
+	}
+	if got := inboxExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2 (unresolved): %v", got, err)
+	}
+	if !strings.Contains(err.Error(), "could not be resolved") || !strings.Contains(err.Error(), "Nothing was drained") {
+		t.Fatalf("unresolved error lacks fail-closed contract: %v", err)
+	}
+	if !session.InboxHasPending(target.ID) {
+		t.Fatal("foreign-profile inbox was destructively drained")
+	}
+}
+
 func TestInboxDrain_AmbiguousPrefixPreservesDisambiguationAndExitCode(t *testing.T) {
 	cliInboxTestHome(t)
 	t.Setenv("AGENTDECK_PROFILE", "work")


### PR DESCRIPTION
Two post-merge review findings on #2030's resolution path, plus one found during this branch's own review — all fixed and mutation-pinned, two-round adversarial PASS:

- **Destructive wrong-target (data-safety):** a session title exactly equal to another session's full id resolved the title and drained the wrong inbox. Full-id-shaped input now resolves exact-id-first; a title/id collision refuses with the ambiguity contract (exit 3, both candidates named). Fixture covers both collision directions; the explicit profile qualifier is pinned to drain only the named profile.
- **Corrupt-profile handling:** an unreadable profile mid-resolution aborted the whole drain. Load errors are now collected, ambiguity is decided from all readable profiles first (the reviewer's ordering fixture — corrupt profile sorted before the colliding ones — now reports the collision, both orders), and the storage abort surfaces only when no known ambiguity exists, naming the corrupt profile either way.

The #1991/#2030 exit-code contract is unchanged and its tests pass unmodified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Inbox draining now checks all readable profiles before resolving items.
  - Reports every unreadable or corrupted profile instead of stopping at the first failure.
  - Prevents draining when IDs or titles are ambiguous across profiles.
  - Handles duplicate IDs with clear profile qualification requirements.
  - Preserves inbox contents when resolution fails and retains “nothing was drained” messaging.
  - Provides improved diagnostic errors, including support for underlying error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->