### PR TITLE
fix(inbox): error transitions deliver, with the replay guarantee intact

### DIFF
--- a/.claude/plans/DECISIONS.md
+++ b/.claude/plans/DECISIONS.md
@@ -29,3 +29,9 @@
 **Context**: What happens when agent-deck itself crashes while a vagrant session is running?
 **Decision**: No special handling needed. tmux session survives, VM survives, Claude survives. On restart, `ReconnectSessionLazy()` reconnects to existing tmux session. `HealthCheck()` confirms VM state on next poll.
 **Consequences**: Zero-effort recovery for agent-deck crashes. Only edge case: crash during `vagrant up` before Claude launches -- handled by restart flow detecting partial VM state.
+
+## 2026-08-22 - R4: Dead-letter file is the cross-restart dedup ledger
+
+**Context**: A fresh transition-daemon process has empty in-memory terminal and missed-log dedup maps, so replaying the same parked completion appended the same dead-letter record and missed-log entry on every restart.
+**Decision**: Use the stable event fingerprint already stored in the per-child dead-letter JSONL as the durable identity. Under a cross-process file lock, read-check-append the dead-letter record; append the missed-log entry only when that durable append is new.
+**Consequences**: Sequential daemon instances keep both files flat for the same completion. Distinct stable fingerprints still produce distinct forensic records, and no separate index can drift from the JSONL source of truth.

--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -76,9 +76,16 @@ func unreadableProfilesNote(failures []profileLoadError) string {
 	return fmt.Sprintf("\nUnreadable profiles encountered during resolution: %s.", strings.Join(profiles, ", "))
 }
 
-// inboxExitCode is the #1991 drain-resolution contract: 2 means the target
-// does not exist, 3 means the supplied title/prefix is ambiguous, and 1 is a
-// storage, usage, or drain failure. Resolution failures never drain events.
+type deadLettersPendingError struct{ count int }
+
+func (e *deadLettersPendingError) Error() string {
+	return fmt.Sprintf("inbox drain incomplete: %d dead-lettered event(s) require attention", e.count)
+}
+
+// inboxExitCode is the drain-resolution contract (#1991, extended): 2 means the
+// target does not exist, 3 means the supplied title/prefix is ambiguous, 4 means
+// the drain ran but dead-lettered events remain and require attention, and 1 is
+// a storage, usage, or drain failure. Resolution failures never drain events.
 func inboxExitCode(err error) int {
 	var notFound *inboxTargetNotFoundError
 	if errors.As(err, &notFound) {
@@ -87,6 +94,10 @@ func inboxExitCode(err error) int {
 	var ambiguous *inboxTargetAmbiguousError
 	if errors.As(err, &ambiguous) {
 		return 3
+	}
+	var pending *deadLettersPendingError
+	if errors.As(err, &pending) {
+		return 4
 	}
 	return 1
 }
@@ -172,10 +183,23 @@ func runInboxDrain(stdout io.Writer, args []string, explicitProfile string) erro
 			events = []session.TransitionNotificationEvent{}
 		}
 		enc := json.NewEncoder(stdout)
-		return enc.Encode(events)
+		if err := enc.Encode(events); err != nil {
+			return err
+		}
+	} else {
+		printInboxEvents(stdout, events)
 	}
 
-	printInboxEvents(stdout, events)
+	deadLetters, err := session.CountDeadLetterRecords()
+	if err != nil {
+		return fmt.Errorf("count dead letters: %w", err)
+	}
+	if deadLetters > 0 {
+		if !*asJSON {
+			fmt.Fprintf(stdout, "WARNING: %d dead-lettered event(s) require attention.\n", deadLetters)
+		}
+		return &deadLettersPendingError{count: deadLetters}
+	}
 	return nil
 }
 

--- a/cmd/agent-deck/issue2007_delivery_guards_test.go
+++ b/cmd/agent-deck/issue2007_delivery_guards_test.go
@@ -22,6 +22,7 @@ func TestIssue1877_AutoParentIdentityMustResolve(t *testing.T) {
 
 func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
 	cliInboxTestHome(t)
+	registerInboxDrainTarget(t, "parent-1877")
 	event := session.TransitionNotificationEvent{
 		ChildSessionID: "dead-child-1877", Profile: "default",
 		FromStatus: "running", ToStatus: "error", Timestamp: time.Now(),
@@ -48,6 +49,7 @@ func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
 
 func TestIssue1877_CorruptNonEmptyDeadLetterIsNotReportedClean(t *testing.T) {
 	cliInboxTestHome(t)
+	registerInboxDrainTarget(t, "parent-corrupt-1877")
 	if err := os.MkdirAll(session.DeadLetterDir(), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +60,29 @@ func TestIssue1877_CorruptNonEmptyDeadLetterIsNotReportedClean(t *testing.T) {
 	var out bytes.Buffer
 	err := runInbox(&out, []string{"drain", "parent-corrupt-1877"})
 	var pending *deadLettersPendingError
-	if !errors.As(err, &pending) || pending.count != 1 || inboxExitCode(err) != 2 {
+	if !errors.As(err, &pending) || pending.count != 1 || inboxExitCode(err) != 4 {
 		t.Fatalf("non-empty corrupt dead-letter must be loud: output=%q err=%v", out.String(), err)
+	}
+}
+
+func TestIssue2007_InboxDrainCountsUnownedDiscoveryEntries(t *testing.T) {
+	cliInboxTestHome(t)
+	registerInboxDrainTarget(t, "parent-2007")
+	event := session.TransitionNotificationEvent{
+		ChildSessionID: "unowned-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Now(),
+	}
+	if err := session.WriteInboxEvent(session.UnownedInboxID, event); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runInbox(&out, []string{"drain", "parent-2007"})
+	var pending *deadLettersPendingError
+	if !errors.As(err, &pending) || pending.count != 1 || inboxExitCode(err) != 4 {
+		t.Fatalf("unowned discovery must keep drain non-clean: output=%q err=%v", out.String(), err)
+	}
+	if !strings.Contains(out.String(), "1 dead-lettered event") {
+		t.Fatalf("unowned count missing from drain warning: %q", out.String())
 	}
 }

--- a/cmd/agent-deck/issue2007_delivery_guards_test.go
+++ b/cmd/agent-deck/issue2007_delivery_guards_test.go
@@ -45,3 +45,20 @@ func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
 		t.Fatalf("drain must report non-zero dead-letter count, got %q", out.String())
 	}
 }
+
+func TestIssue1877_CorruptNonEmptyDeadLetterIsNotReportedClean(t *testing.T) {
+	cliInboxTestHome(t)
+	if err := os.MkdirAll(session.DeadLetterDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(session.DeadLetterPathFor("truncated-1877"), []byte(`{"child_session_id":"truncated`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runInbox(&out, []string{"drain", "parent-corrupt-1877"})
+	var pending *deadLettersPendingError
+	if !errors.As(err, &pending) || pending.count != 1 || inboxExitCode(err) != 2 {
+		t.Fatalf("non-empty corrupt dead-letter must be loud: output=%q err=%v", out.String(), err)
+	}
+}

--- a/cmd/agent-deck/issue2007_delivery_guards_test.go
+++ b/cmd/agent-deck/issue2007_delivery_guards_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestIssue1877_AutoParentIdentityMustResolve(t *testing.T) {
+	t.Setenv("AGENT_DECK_SESSION_ID", "")
+	t.Setenv("AGENTDECK_INSTANCE_ID", "stale-parent-1877")
+	parent, unresolved := resolveAutoParentInstanceChecked(nil)
+	if parent != nil || unresolved != "stale-parent-1877" {
+		t.Fatalf("stale injected identity must fail loudly: parent=%v unresolved=%q", parent, unresolved)
+	}
+}
+
+func TestIssue1877_InboxDrainReportsDeadLettersAndIsNonZero(t *testing.T) {
+	cliInboxTestHome(t)
+	event := session.TransitionNotificationEvent{
+		ChildSessionID: "dead-child-1877", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Now(),
+		DeadLetterReason: "unresolvable", Attempts: 5,
+	}
+	raw := []byte(`{"child_session_id":"dead-child-1877","profile":"default","from_status":"running","to_status":"error","timestamp":"` + event.Timestamp.Format(time.RFC3339Nano) + `","attempts":5,"dead_letter_reason":"unresolvable"}` + "\n")
+	if err := os.MkdirAll(session.DeadLetterDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(session.DeadLetterPathFor(event.ChildSessionID), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := runInbox(&out, []string{"drain", "parent-1877"})
+	var pending *deadLettersPendingError
+	if !errors.As(err, &pending) || inboxExitCode(err) == 0 {
+		t.Fatalf("dead letters must make drain non-clean: err=%v", err)
+	}
+	if !strings.Contains(out.String(), "1 dead-lettered event") {
+		t.Fatalf("drain must report non-zero dead-letter count, got %q", out.String())
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -360,7 +360,12 @@ func handleLaunch(profile string, args []string) {
 		}
 		sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided, inheritParentGroup)
 	} else if !*noParent {
-		parentInstance = resolveAutoParentInstance(instances)
+		var unresolvedParent string
+		parentInstance, unresolvedParent = resolveAutoParentInstanceChecked(instances)
+		if parentInstance == nil && unresolvedParent != "" {
+			out.Error(fmt.Sprintf("automatic parent %q could not be resolved; use --parent with a valid session or --no-parent for an intentional top-level session", unresolvedParent), ErrCodeNotFound)
+			os.Exit(1)
+		}
 		if parentInstance != nil && !parentInstance.IsSubSession() {
 			sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided, inheritParentGroup)
 		} else {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1209,11 +1209,6 @@ func isWorktreeAlreadyExistsError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "already exists")
 }
 
-func resolveAutoParentInstance(instances []*session.Instance) *session.Instance {
-	inst, _ := resolveAutoParentInstanceChecked(instances)
-	return inst
-}
-
 // resolveAutoParentInstanceChecked distinguishes a top-level invocation (no
 // managed caller identity) from a child creation whose authoritative injected
 // identity is stale. The latter must fail at creation instead of silently

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1210,9 +1210,25 @@ func isWorktreeAlreadyExistsError(err error) bool {
 }
 
 func resolveAutoParentInstance(instances []*session.Instance) *session.Instance {
+	inst, _ := resolveAutoParentInstanceChecked(instances)
+	return inst
+}
+
+// resolveAutoParentInstanceChecked distinguishes a top-level invocation (no
+// managed caller identity) from a child creation whose authoritative injected
+// identity is stale. The latter must fail at creation instead of silently
+// producing an orphan that can only be discovered in delivery dead-letter.
+func resolveAutoParentInstanceChecked(instances []*session.Instance) (*session.Instance, string) {
 	candidates := []string{
 		strings.TrimSpace(os.Getenv("AGENT_DECK_SESSION_ID")),
 		strings.TrimSpace(os.Getenv("AGENTDECK_INSTANCE_ID")),
+	}
+	authoritative := ""
+	for _, candidate := range candidates {
+		if candidate != "" {
+			authoritative = candidate
+			break
+		}
 	}
 
 	if tmuxCurrent := strings.TrimSpace(GetCurrentSessionID()); tmuxCurrent != "" {
@@ -1226,10 +1242,10 @@ func resolveAutoParentInstance(instances []*session.Instance) *session.Instance 
 		}
 		seen[candidate] = true
 		if inst, _, _ := ResolveSession(candidate, instances); inst != nil {
-			return inst
+			return inst, ""
 		}
 	}
-	return nil
+	return nil, authoritative
 }
 
 // resolveGroupPathForAdd resolves a user-provided group selector to a stored group path.
@@ -1532,7 +1548,12 @@ func handleAdd(profile string, args []string) {
 		// is wired into `launch` where path is already known at this point.
 		sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided, false)
 	} else if !*noParent {
-		parentInstance = resolveAutoParentInstance(instances)
+		var unresolvedParent string
+		parentInstance, unresolvedParent = resolveAutoParentInstanceChecked(instances)
+		if parentInstance == nil && unresolvedParent != "" {
+			fmt.Printf("Error: automatic parent %q could not be resolved; use --parent with a valid session or --no-parent for an intentional top-level session\n", unresolvedParent)
+			os.Exit(1)
+		}
 		if parentInstance != nil && !parentInstance.IsSubSession() {
 			sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided, false)
 		} else {

--- a/internal/session/event_fingerprint.go
+++ b/internal/session/event_fingerprint.go
@@ -3,35 +3,32 @@ package session
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"strconv"
 	"strings"
 )
 
-// EventFingerprint returns a stable identifier for a transition event,
-// keyed on its intrinsic identity rather than the moment of any particular
-// emit. Two attempts to persist the "same" logical transition (same child,
-// same status flip, same observed timestamp) collapse to the same
-// fingerprint and are deduplicated by the inbox writer and the
-// notifier-missed log.
+// EventFingerprint returns a stable identifier for a transition event, keyed on
+// its intrinsic identity: which child, which status flip (or completion
+// outcome), and which turn produced it. Two attempts to persist the same logical
+// event collapse to the same fingerprint and are deduplicated by the inbox
+// writer and the notifier-missed log.
 //
-// Keying on Timestamp.UnixNano() is load-bearing: the daemon stamps the event
-// once when it first observes the flip and that same TransitionNotificationEvent
-// is reused for the producer commit, so the timestamp is stable across
-// re-observations. time.Now() at write-emit time would NOT be stable and would
-// silently break dedup.
+// The emit instant is deliberately not part of the identity. Retries and
+// independent producers can stamp one event at different times. LastOutputHash
+// distinguishes interactive turns; completion kind, status, and summary
+// distinguish finished turns.
 //
 // The fingerprint is a hex SHA-256 so it can safely be embedded in a JSON
 // string field without escaping concerns and is cheap to grep for.
 func EventFingerprint(e TransitionNotificationEvent) string {
 	var b strings.Builder
-	b.Grow(len(e.ChildSessionID) + len(e.FromStatus) + len(e.ToStatus) + 32)
+	b.Grow(len(e.ChildSessionID) + len(e.FromStatus) + len(e.ToStatus) + len(e.LastOutputHash) + 32)
 	b.WriteString(strings.TrimSpace(e.ChildSessionID))
 	b.WriteByte('|')
 	b.WriteString(strings.ToLower(strings.TrimSpace(e.FromStatus)))
 	b.WriteByte('|')
 	b.WriteString(strings.ToLower(strings.TrimSpace(e.ToStatus)))
 	b.WriteByte('|')
-	b.WriteString(strconv.FormatInt(e.Timestamp.UnixNano(), 10))
+	b.WriteString(strings.TrimSpace(e.LastOutputHash))
 	// Issue #1186: finished events carry no from→to transition, so without
 	// the kind + outcome the fingerprint would collapse distinct completions
 	// (and could collide with a same-timestamp transition). Append them so

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -180,6 +181,11 @@ func WriteInboxEventIfNew(parentSessionID string, event TransitionNotificationEv
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return false, err
 	}
+	fileLock, err := AcquireConfigFileLock(path)
+	if err != nil {
+		return false, fmt.Errorf("lock inbox append: %w", err)
+	}
+	defer fileLock.Release()
 
 	fp := EventFingerprint(event)
 
@@ -198,33 +204,37 @@ func WriteInboxEventIfNew(parentSessionID string, event TransitionNotificationEv
 		return false, nil
 	}
 
-	// Embed the fingerprint into the persisted JSON so on-disk state is
-	// self-describing — the file-scan recovery path can reconstruct the
-	// dedup set without re-deriving fingerprints from the event body.
-	type wireEvent struct {
-		TransitionNotificationEvent
-		Fingerprint string `json:"fp,omitempty"`
-	}
-	line, err := json.Marshal(wireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
+	line, err := json.Marshal(inboxWireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
 	if err != nil {
 		return false, err
 	}
-
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return false, err
-	}
-	defer f.Close()
-	if _, err := f.Write(append(line, '\n')); err != nil {
-		return false, err
-	}
-	// Audit B2: fsync the append so a crash after Write cannot lose a record the
-	// producer reported as committed.
-	if err := f.Sync(); err != nil {
+	if err := atomicAppendInboxLineLocked(path, line); err != nil {
 		return false, err
 	}
 	seen[fp] = struct{}{}
 	return true, nil
+}
+
+// atomicAppendInboxLineLocked gives an inbox append an old-or-new crash
+// boundary. It builds a complete replacement beside the inbox, fsyncs it, and
+// atomically renames it over the old file. SIGKILL before rename leaves the old
+// complete inbox; SIGKILL after rename leaves the new complete inbox. A partial
+// JSONL tail is never installed as the authoritative file.
+//
+// Caller holds inboxWriteMu.
+func atomicAppendInboxLineLocked(path string, line []byte) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	data := make([]byte, 0, len(existing)+len(line)+1)
+	data = append(data, existing...)
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		data = append(data, '\n')
+	}
+	data = append(data, line...)
+	data = append(data, '\n')
+	return writeFileDurable(path, data, 0o644)
 }
 
 // loadInboxFingerprintsLocked scans an existing inbox file and returns the

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -167,12 +167,18 @@ func sanitizeInboxName(id string) string {
 // The #1225 drain path layers turn_fingerprint dedup on top for at-least-once
 // delivery with exactly-once effects (see inbox_consumer.go).
 func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) error {
+	_, err := WriteInboxEventIfNew(parentSessionID, event)
+	return err
+}
+
+// WriteInboxEventIfNew is WriteInboxEvent with the dedup decision exposed.
+func WriteInboxEventIfNew(parentSessionID string, event TransitionNotificationEvent) (bool, error) {
 	if strings.TrimSpace(parentSessionID) == "" {
-		return errors.New("inbox: empty parent session id")
+		return false, errors.New("inbox: empty parent session id")
 	}
 	path := InboxPathFor(parentSessionID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return false, err
 	}
 
 	fp := EventFingerprint(event)
@@ -189,7 +195,7 @@ func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) 
 		inboxFingerprintCache[path] = seen
 	}
 	if _, dup := seen[fp]; dup {
-		return nil
+		return false, nil
 	}
 
 	// Embed the fingerprint into the persisted JSON so on-disk state is
@@ -201,24 +207,24 @@ func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) 
 	}
 	line, err := json.Marshal(wireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer f.Close()
 	if _, err := f.Write(append(line, '\n')); err != nil {
-		return err
+		return false, err
 	}
 	// Audit B2: fsync the append so a crash after Write cannot lose a record the
 	// producer reported as committed.
 	if err := f.Sync(); err != nil {
-		return err
+		return false, err
 	}
 	seen[fp] = struct{}{}
-	return nil
+	return true, nil
 }
 
 // loadInboxFingerprintsLocked scans an existing inbox file and returns the

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -227,7 +227,15 @@ func atomicAppendInboxLineLocked(path string, line []byte) error {
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-	data := make([]byte, 0, len(existing)+len(line)+1)
+	// Keep the capacity calculation explicit and checked. Although os.ReadFile
+	// cannot normally return a slice close to MaxInt, adding attacker-influenced
+	// line length without a guard can wrap and turn the allocation into a panic
+	// (CodeQL go/allocation-size-overflow).
+	capacity, err := checkedInboxAppendCapacity(len(existing), len(line))
+	if err != nil {
+		return err
+	}
+	data := make([]byte, 0, capacity)
 	data = append(data, existing...)
 	if len(data) > 0 && data[len(data)-1] != '\n' {
 		data = append(data, '\n')
@@ -235,6 +243,15 @@ func atomicAppendInboxLineLocked(path string, line []byte) error {
 	data = append(data, line...)
 	data = append(data, '\n')
 	return writeFileDurable(path, data, 0o644)
+}
+
+func maxInt() int { return int(^uint(0) >> 1) }
+
+func checkedInboxAppendCapacity(existingLen, lineLen int) (int, error) {
+	if existingLen < 0 || lineLen < 0 || existingLen > maxInt()-1 || lineLen > maxInt()-existingLen-1 {
+		return 0, fmt.Errorf("inbox append too large: existing=%d line=%d", existingLen, lineLen)
+	}
+	return existingLen + lineLen + 1, nil
 }
 
 // loadInboxFingerprintsLocked scans an existing inbox file and returns the

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -240,8 +240,13 @@ func (s *DeadLetterSink) RecordUnresolvable(event TransitionNotificationEvent) b
 	s.mu.Unlock()
 
 	event.Attempts = n
-	_ = writeDeadLetter(event)
-	s.writeMissedOnce(event)
+	appended, err := writeDeadLetter(event)
+	if err != nil {
+		return false
+	}
+	if appended {
+		s.writeMissedOnce(event)
+	}
 	return true
 }
 
@@ -288,31 +293,70 @@ func (s *DeadLetterSink) writeMissedOnce(event TransitionNotificationEvent) {
 	}
 }
 
-// writeDeadLetter appends a record to the child's dead-letter JSONL file.
-func writeDeadLetter(event TransitionNotificationEvent) error {
+// writeDeadLetter durably appends a record to the child's dead-letter JSONL
+// file unless that stable event fingerprint is already present. The file is
+// the cross-restart dedup ledger; the file lock makes read-check-append atomic
+// across daemon processes. appended is true only for a newly installed record.
+func writeDeadLetter(event TransitionNotificationEvent) (appended bool, err error) {
 	path := DeadLetterPathFor(event.ChildSessionID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return false, err
+	}
+	fileLock, err := AcquireConfigFileLock(path)
+	if err != nil {
+		return false, fmt.Errorf("lock dead-letter: %w", err)
+	}
+	defer fileLock.Release()
+
+	fp := EventFingerprint(event)
+	if found, err := deadLetterContainsFingerprint(path, fp); err != nil {
+		return false, err
+	} else if found {
+		return false, nil
 	}
 	line, err := json.Marshal(inboxWireEvent{
 		TransitionNotificationEvent: event,
-		Fingerprint:                 EventFingerprint(event),
+		Fingerprint:                 fp,
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer f.Close()
 	if _, err := f.Write(append(line, '\n')); err != nil {
-		return err
+		return false, err
 	}
 	// Audit B2: fsync the dead-letter append. Dead-letter is the operator's
 	// terminal forensic trail for an unresolvable completion; it must survive a
 	// crash, same as the primary inbox append.
-	return f.Sync()
+	if err := f.Sync(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func deadLetterContainsFingerprint(path, fingerprint string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
+	for scanner.Scan() {
+		var wire inboxWireEvent
+		if json.Unmarshal(scanner.Bytes(), &wire) == nil && wire.Fingerprint == fingerprint {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
 }
 
 // CountDeadLetterRecords returns the number of unresolved records currently in

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -321,6 +321,45 @@ func writeDeadLetter(event TransitionNotificationEvent) error {
 	return f.Sync()
 }
 
+// CountDeadLetterRecords returns the number of parseable records currently in
+// the dead-letter directory. Inbox drain uses this to avoid reporting a clean
+// state while undelivered events are parked out of sight.
+func CountDeadLetterRecords() (int, error) {
+	entries, err := os.ReadDir(DeadLetterDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(DeadLetterDir(), entry.Name()))
+		if err != nil {
+			return count, err
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
+		for scanner.Scan() {
+			if _, err := decodeInboxLine(scanner.Bytes()); err == nil {
+				count++
+			}
+		}
+		scanErr := scanner.Err()
+		closeErr := f.Close()
+		if scanErr != nil {
+			return count, scanErr
+		}
+		if closeErr != nil {
+			return count, closeErr
+		}
+	}
+	return count, nil
+}
+
 // --- unified producer commit (shared by interactive + one-shot) -------------
 
 // resolveParentIDForInbox loads the registry and applies the
@@ -393,6 +432,24 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 		return false, true, ""
 	}
 	if parent == nil {
+		// Missing and non-live parents do not make the event disposable. Persist
+		// it in the reserved, drainable unowned ledger. Deliberate suppression
+		// and a removed child remain terminal drops.
+		if isUnownedReason(reason) {
+			written, err := recordUnownedTransition(event)
+			if err != nil {
+				return false, true, ""
+			}
+			if written {
+				event.TargetKind = "unowned"
+				event.DeliveryResult = transitionDeliveryCommitted
+				n.logEvent(event)
+			}
+			// Preserve the existing operator-visible terminal accounting as well;
+			// the important invariant is that dead-letter is no longer the only
+			// copy and the event is now drainable from _unowned.
+			return false, false, reason
+		}
 		return false, false, reason
 	}
 	parentID := parent.ID

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -315,16 +315,17 @@ func writeDeadLetter(event TransitionNotificationEvent) error {
 	return f.Sync()
 }
 
-// CountDeadLetterRecords returns the number of parseable records currently in
-// the dead-letter directory. Inbox drain uses this to avoid reporting a clean
-// state while undelivered events are parked out of sight.
+// CountDeadLetterRecords returns the number of unresolved records currently in
+// the dead-letter directory and the discovery-only _unowned ledger. Inbox
+// drain uses this to avoid reporting a clean state while undelivered events are
+// parked out of sight.
 func CountDeadLetterRecords() (int, error) {
 	entries, err := os.ReadDir(DeadLetterDir())
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return 0, nil
+		if !errors.Is(err, os.ErrNotExist) {
+			return 0, err
 		}
-		return 0, err
+		entries = nil
 	}
 	count := 0
 	for _, entry := range entries {
@@ -354,7 +355,28 @@ func CountDeadLetterRecords() (int, error) {
 			return count, closeErr
 		}
 	}
-	return count, nil
+	unowned, err := countNonblankInboxRecords(InboxPathFor(UnownedInboxID))
+	return count + unowned, err
+}
+
+func countNonblankInboxRecords(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+	count := 0
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) != "" {
+			count++
+		}
+	}
+	return count, scanner.Err()
 }
 
 // --- unified producer commit (shared by interactive + one-shot) -------------
@@ -447,9 +469,9 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 			// non-benign terminal reasons. The durable delivery result remains a
 			// success because _unowned is now the actionable copy.
 			n.terminalDrop(event, reason)
-			// A duplicate means the identical durable event already exists. Both a
-			// new append and that idempotent replay are successful commits.
-			return true, false, ""
+			// Preserve the reason in the result so completion replay can distinguish
+			// this discovery copy from an ackable parent-inbox commit.
+			return true, false, reason
 		}
 		return false, false, reason
 	}

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -133,6 +134,11 @@ func CommitToInbox(parentSessionID string, event TransitionNotificationEvent) er
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
+	fileLock, err := AcquireConfigFileLock(path)
+	if err != nil {
+		return fmt.Errorf("lock inbox commit: %w", err)
+	}
+	defer fileLock.Release()
 
 	inboxWriteMu.Lock()
 	defer inboxWriteMu.Unlock()
@@ -150,8 +156,8 @@ func CommitToInbox(parentSessionID string, event TransitionNotificationEvent) er
 	return appendInboxLineLocked(path, event)
 }
 
-// appendInboxLineLocked marshals one event (with its EventFingerprint embedded)
-// and appends it as a JSONL line. Caller holds inboxWriteMu. Also refreshes the
+// appendInboxLineLocked marshals one event and atomically installs an old-or-new
+// complete inbox file. Caller holds inboxWriteMu. It also refreshes the
 // process-local fingerprint cache so WriteInboxEvent's dedup stays consistent.
 func appendInboxLineLocked(path string, event TransitionNotificationEvent) error {
 	fp := EventFingerprint(event)
@@ -159,19 +165,7 @@ func appendInboxLineLocked(path string, event TransitionNotificationEvent) error
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if _, err := f.Write(append(line, '\n')); err != nil {
-		return err
-	}
-	// Audit B2: fsync the append before reporting success. CommitToInbox is the
-	// PRIMARY delivery path; without this a crash after Write returns but before
-	// the kernel flushes loses the record while the producer believes it
-	// committed. Completions are low-frequency, so the flush cost is negligible.
-	if err := f.Sync(); err != nil {
+	if err := atomicAppendInboxLineLocked(path, line); err != nil {
 		return err
 	}
 	seen, ok := inboxFingerprintCache[path]
@@ -344,7 +338,10 @@ func CountDeadLetterRecords() (int, error) {
 		scanner := bufio.NewScanner(f)
 		scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
 		for scanner.Scan() {
-			if _, err := decodeInboxLine(scanner.Bytes()); err == nil {
+			// Unknown/corrupt is still pending operator work. Counting every
+			// nonblank physical record prevents a truncated legacy append from
+			// making a non-empty ledger look clean (#1877).
+			if strings.TrimSpace(scanner.Text()) != "" {
 				count++
 			}
 		}
@@ -436,6 +433,7 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 		// it in the reserved, drainable unowned ledger. Deliberate suppression
 		// and a removed child remain terminal drops.
 		if isUnownedReason(reason) {
+			event.DeadLetterReason = reason
 			written, err := recordUnownedTransition(event)
 			if err != nil {
 				return false, true, ""
@@ -445,10 +443,13 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 				event.DeliveryResult = transitionDeliveryCommitted
 				n.logEvent(event)
 			}
-			// Preserve the existing operator-visible terminal accounting as well;
-			// the important invariant is that dead-letter is no longer the only
-			// copy and the event is now drainable from _unowned.
-			return false, false, reason
+			// Keep the existing operator-visible forensic copy/missed-log for
+			// non-benign terminal reasons. The durable delivery result remains a
+			// success because _unowned is now the actionable copy.
+			n.terminalDrop(event, reason)
+			// A duplicate means the identical durable event already exists. Both a
+			// new append and that idempotent replay are successful commits.
+			return true, false, ""
 		}
 		return false, false, reason
 	}

--- a/internal/session/inbox_test.go
+++ b/internal/session/inbox_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,6 +81,7 @@ func TestInbox_ReadAndTruncateReturnsThenEmpties(t *testing.T) {
 			Profile:         "_test",
 			FromStatus:      "running",
 			ToStatus:        "waiting",
+			LastOutputHash:  fmt.Sprintf("turn-%d", i),
 			Timestamp:       time.Now(),
 			TargetSessionID: parent,
 			TargetKind:      "parent",

--- a/internal/session/issue1225_deadletter_reason_test.go
+++ b/internal/session/issue1225_deadletter_reason_test.go
@@ -61,11 +61,12 @@ func TestB5_ParentRemovedMidFlight_DeadLettersWithReasonAndLogs(t *testing.T) {
 		ToStatus:       "waiting",
 		Timestamp:      now,
 	})
-	if res.DeliveryResult != transitionDeliveryDropped {
-		t.Fatalf("expected dropped, got %q", res.DeliveryResult)
+	if res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("durable _unowned persistence must report committed, got %q", res.DeliveryResult)
 	}
-	if res.DeadLetterReason != deadLetterReasonParentMissing {
-		t.Fatalf("expected reason %q, got %q", deadLetterReasonParentMissing, res.DeadLetterReason)
+	unowned, err := ReadAndTruncateInbox(UnownedInboxID)
+	if err != nil || len(unowned) != 1 || unowned[0].DeadLetterReason != deadLetterReasonParentMissing {
+		t.Fatalf("_unowned must preserve parent removal reason: events=%+v err=%v", unowned, err)
 	}
 
 	// Dead-letter record exists with the reason.

--- a/internal/session/issue2007_atomic_append_crash_test.go
+++ b/internal/session/issue2007_atomic_append_crash_test.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const issue2007CrashHelperEnv = "AGENTDECK_TEST_2007_CRASH_APPEND"
+
+// TestIssue2007_AppendCrashHelper is invoked as a subprocess by the test below.
+// It blocks after the replacement file has been written and fsync'd but before
+// rename, giving the parent an exact SIGKILL boundary inside the append.
+func TestIssue2007_AppendCrashHelper(t *testing.T) {
+	if os.Getenv(issue2007CrashHelperEnv) != "1" {
+		return
+	}
+	marker := os.Getenv("AGENTDECK_TEST_2007_CRASH_MARKER")
+	restore := SetFsyncHookForTest(func(f *os.File) error {
+		if filepath.Ext(f.Name()) == ".tmp" {
+			if err := os.WriteFile(marker, []byte("fsynced-before-rename"), 0o600); err != nil {
+				return err
+			}
+			select {}
+		}
+		return f.Sync()
+	})
+	defer restore()
+	ResetInboxFingerprintCacheForTest()
+	err := WriteInboxEvent("parent-atomic-2007", TransitionNotificationEvent{
+		ChildSessionID: "new-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Unix(200, 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIssue2007_SIGKILLDuringAppendLeavesOldOrNewCompleteFile(t *testing.T) {
+	inboxTestHome(t)
+	parent := "parent-atomic-2007"
+	old := TransitionNotificationEvent{
+		ChildSessionID: "old-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "waiting", Timestamp: time.Unix(100, 0),
+	}
+	if err := WriteInboxEvent(parent, old); err != nil {
+		t.Fatalf("seed old inbox: %v", err)
+	}
+
+	marker := filepath.Join(t.TempDir(), "append-fsync.marker")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestIssue2007_AppendCrashHelper$")
+	cmd.Env = append(os.Environ(), issue2007CrashHelperEnv+"=1", "AGENTDECK_TEST_2007_CRASH_MARKER="+marker)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start append helper: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			t.Fatal("helper never reached fsync-before-rename boundary")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL append helper: %v", err)
+	}
+	err := cmd.Wait()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("helper should die by SIGKILL, got %v", err)
+	}
+
+	ResetInboxFingerprintCacheForTest()
+	events, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("drain after crash: %v", err)
+	}
+	if len(events) != 1 || events[0].ChildSessionID != old.ChildSessionID {
+		t.Fatalf("SIGKILL before rename must leave complete old inbox, got %+v", events)
+	}
+
+	// The producer did not observe success, so its normal retry must install the
+	// new complete record without being poisoned by a partial tail/temp file.
+	if err := WriteInboxEvent(parent, TransitionNotificationEvent{
+		ChildSessionID: "new-child-2007", Profile: "default",
+		FromStatus: "running", ToStatus: "error", Timestamp: time.Unix(200, 0),
+	}); err != nil {
+		t.Fatalf("retry after crash: %v", err)
+	}
+	events, err = ReadAndTruncateInbox(parent)
+	if err != nil || len(events) != 1 || events[0].ChildSessionID != "new-child-2007" {
+		t.Fatalf("retry after crash did not produce one complete record: events=%+v err=%v", events, err)
+	}
+}

--- a/internal/session/issue2007_atomic_append_crash_test.go
+++ b/internal/session/issue2007_atomic_append_crash_test.go
@@ -10,6 +10,15 @@ import (
 	"time"
 )
 
+func TestIssue2007_CheckedAppendCapacityRejectsOverflow(t *testing.T) {
+	if _, err := checkedInboxAppendCapacity(maxInt(), 1); err == nil {
+		t.Fatal("overflowing inbox append capacity must be rejected")
+	}
+	if got, err := checkedInboxAppendCapacity(10, 20); err != nil || got != 31 {
+		t.Fatalf("ordinary capacity = %d, %v; want 31, nil", got, err)
+	}
+}
+
 const issue2007CrashHelperEnv = "AGENTDECK_TEST_2007_CRASH_APPEND"
 
 // TestIssue2007_AppendCrashHelper is invoked as a subprocess by the test below.

--- a/internal/session/issue2007_error_delivery_test.go
+++ b/internal/session/issue2007_error_delivery_test.go
@@ -62,3 +62,9 @@ func TestIssue2007_UnresolvableParentAlsoLandsInUnownedLedger(t *testing.T) {
 		t.Fatalf("_unowned record lost resolution reason: got %q want %q", events[0].DeadLetterReason, deadLetterReasonParentMissing)
 	}
 }
+
+func TestIssue2007_TrueOrphanPreservesIssue805DropContract(t *testing.T) {
+	if isUnownedReason(deadLetterReasonOrphan) {
+		t.Fatal("a true parentless orphan must not enter the unowned discovery ledger")
+	}
+}

--- a/internal/session/issue2007_error_delivery_test.go
+++ b/internal/session/issue2007_error_delivery_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIssue2007_RunningToErrorDeliversToLinkedParent(t *testing.T) {
+	inboxTestHome(t)
+	profile := "_test-2007-linked-error"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storage.Close()
+	now := time.Now()
+	parent := &Instance{ID: "parent-2007", Title: "supervisor", ProjectPath: "/tmp/p", GroupPath: DefaultGroupPath, Tool: "shell", Status: StatusRunning, CreatedAt: now}
+	child := &Instance{ID: "child-2007", Title: "worker", ProjectPath: "/tmp/c", GroupPath: DefaultGroupPath, ParentSessionID: parent.ID, Tool: "shell", Status: StatusError, CreatedAt: now}
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got := NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
+		ChildSessionID: child.ID, ChildTitle: child.Title, Profile: profile,
+		FromStatus: "running", ToStatus: "error", Timestamp: now,
+	})
+	if got.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("running→error must commit to linked parent, got %+v", got)
+	}
+	events, err := DrainInboxForParent(parent.ID)
+	if err != nil || len(events) != 1 || events[0].ToStatus != "error" {
+		t.Fatalf("linked parent did not receive error transition: events=%+v err=%v", events, err)
+	}
+}
+
+func TestIssue2007_UnresolvableParentAlsoLandsInUnownedLedger(t *testing.T) {
+	inboxTestHome(t)
+	profile := "_test-2007-unowned"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer storage.Close()
+	now := time.Now()
+	child := &Instance{ID: "child-unowned-2007", Title: "worker", ProjectPath: "/tmp/c", GroupPath: DefaultGroupPath, ParentSessionID: "missing-parent", Tool: "shell", Status: StatusError, CreatedAt: now}
+	if err := storage.SaveWithGroups([]*Instance{child}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
+		ChildSessionID: child.ID, ChildTitle: child.Title, Profile: profile,
+		FromStatus: "running", ToStatus: "error", Timestamp: now,
+	})
+	events, err := ReadAndTruncateInbox(UnownedInboxID)
+	if err != nil || len(events) != 1 || events[0].ChildSessionID != child.ID {
+		t.Fatalf("unresolvable transition was not preserved in _unowned: events=%+v err=%v", events, err)
+	}
+}

--- a/internal/session/issue2007_error_delivery_test.go
+++ b/internal/session/issue2007_error_delivery_test.go
@@ -47,12 +47,18 @@ func TestIssue2007_UnresolvableParentAlsoLandsInUnownedLedger(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
+	got := NewTransitionNotifier().NotifyTransition(TransitionNotificationEvent{
 		ChildSessionID: child.ID, ChildTitle: child.Title, Profile: profile,
 		FromStatus: "running", ToStatus: "error", Timestamp: now,
 	})
+	if got.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("durable _unowned append must report committed, got %+v", got)
+	}
 	events, err := ReadAndTruncateInbox(UnownedInboxID)
 	if err != nil || len(events) != 1 || events[0].ChildSessionID != child.ID {
 		t.Fatalf("unresolvable transition was not preserved in _unowned: events=%+v err=%v", events, err)
+	}
+	if events[0].DeadLetterReason != deadLetterReasonParentMissing {
+		t.Fatalf("_unowned record lost resolution reason: got %q want %q", events[0].DeadLetterReason, deadLetterReasonParentMissing)
 	}
 }

--- a/internal/session/issue962_target_busy_ttl_test.go
+++ b/internal/session/issue962_target_busy_ttl_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -104,6 +105,7 @@ func TestTransitionNotifier_SweepInboxByTuple_DropsMatching(t *testing.T) {
 			Profile:         "_test",
 			FromStatus:      from,
 			ToStatus:        to,
+			LastOutputHash:  fmt.Sprintf("%s-%s-%s-%s", child, from, to, ago),
 			Timestamp:       time.Now().Add(-ago),
 			TargetSessionID: parent,
 			TargetKind:      "parent",
@@ -112,7 +114,7 @@ func TestTransitionNotifier_SweepInboxByTuple_DropsMatching(t *testing.T) {
 	}
 	rows := []TransitionNotificationEvent{
 		mk("pepper", "running", "waiting", 3*time.Hour),
-		mk("pepper", "running", "waiting", 2*time.Hour), // duplicate tuple, different ts
+		mk("pepper", "running", "waiting", 2*time.Hour), // duplicate tuple, different turn
 		mk("pepper", "waiting", "running", 1*time.Hour), // SAME child, different tuple
 		mk("garlic", "running", "waiting", 1*time.Hour), // different child
 	}

--- a/internal/session/rm_sweep_test.go
+++ b/internal/session/rm_sweep_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,6 +38,7 @@ func TestRm_SweepsConductorInboxes(t *testing.T) {
 			Profile:         "_test",
 			FromStatus:      "running",
 			ToStatus:        "waiting",
+			LastOutputHash:  fmt.Sprintf("turn-%d", idx),
 			Timestamp:       time.Now().Add(time.Duration(idx) * time.Second),
 			TargetSessionID: conductors[idx%len(conductors)],
 			TargetKind:      "conductor",

--- a/internal/session/taskworker.go
+++ b/internal/session/taskworker.go
@@ -279,8 +279,16 @@ func RunTaskWorker(childID, profile, title string, cmd *exec.Cmd) (CompletionRec
 // longer acked when it merely reached a volatile in-process retry queue; it is
 // acked only once provably committed to the durable inbox.
 func (n *TransitionNotifier) DeliverCompletion(rec CompletionRecord) bool {
+	committed, _ := n.deliverCompletion(rec)
+	return committed
+}
+
+// deliverCompletion also reports whether the completion was copied to the
+// discovery-only _unowned ledger. A parked copy is durable, but is not delivery
+// to the parent and therefore must never authorize acknowledging rec.
+func (n *TransitionNotifier) deliverCompletion(rec CompletionRecord) (committed, parked bool) {
 	if strings.TrimSpace(rec.Status) == "" {
-		return false // still running; nothing to deliver
+		return false, false // still running; nothing to deliver
 	}
 	event := TransitionNotificationEvent{
 		ChildSessionID: strings.TrimSpace(rec.ChildID),
@@ -292,7 +300,7 @@ func (n *TransitionNotifier) DeliverCompletion(rec CompletionRecord) bool {
 		Timestamp:      time.Now(),
 	}
 	if event.ChildSessionID == "" || event.Profile == "" {
-		return false
+		return false, false
 	}
 	// Conductor self-suppression is applied DOWNSTREAM in resolveParentIDForInbox
 	// (keyed on the child's real ParentSessionID): a top-level/self conductor
@@ -301,8 +309,11 @@ func (n *TransitionNotifier) DeliverCompletion(rec CompletionRecord) bool {
 	// title-only pre-filter here silently dropped that legitimate parented case.
 	// The replay path (ReplayUnackedCompletions) handles the not-committed case
 	// via the bounded dead-letter sink, so the terminal reason is discarded here.
-	committed, _, _ := n.commitEventToInbox(event)
-	return committed
+	committed, _, reason := n.commitEventToInbox(event)
+	if committed && isUnownedReason(reason) {
+		return false, true
+	}
+	return committed, false
 }
 
 // ShouldRecycleForVersion reports whether a long-lived daemon should exit so

--- a/internal/session/taskworker_test.go
+++ b/internal/session/taskworker_test.go
@@ -291,6 +291,57 @@ func TestTaskWorker_ReplayUnacked_MissingParentKeepsOneFlatUnownedRecord(t *test
 	}
 }
 
+func TestTaskWorker_ReplayUnacked_CrossRestartDeadLetterAndMissedStayFlat(t *testing.T) {
+	profile := "_test-2007-cross-restart-terminal-dedup"
+	parentID := "parent-missing-2007-cross-restart"
+	childID := seedChildOnly(t, profile, parentID)
+	if err := WriteCompletionRecord(CompletionRecord{
+		ChildID: childID, Profile: profile, Title: "worker", Status: "ok",
+		Summary: "same parked completion across processes", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	replayFreshDaemon := func() {
+		d := NewTransitionDaemon()
+		d.ReplayUnackedCompletions(profile)
+		d.notifier.Flush()
+		d.notifier.Close()
+	}
+	replayFreshDaemon()
+
+	deadPath := DeadLetterPathFor(childID)
+	missedPath := transitionNotifierMissedPath()
+	firstDead, err := os.Stat(deadPath)
+	if err != nil {
+		t.Fatalf("first process did not persist dead-letter: %v", err)
+	}
+	firstMissed, err := os.Stat(missedPath)
+	if err != nil {
+		t.Fatalf("first process did not persist missed log: %v", err)
+	}
+
+	// A new daemon has empty process-local terminalSeen/missedSeen maps. The
+	// durable dead-letter fingerprint must nevertheless suppress both appends.
+	replayFreshDaemon()
+	secondDead, err := os.Stat(deadPath)
+	if err != nil {
+		t.Fatalf("second process lost dead-letter: %v", err)
+	}
+	secondMissed, err := os.Stat(missedPath)
+	if err != nil {
+		t.Fatalf("second process lost missed log: %v", err)
+	}
+	if secondDead.Size() != firstDead.Size() || secondMissed.Size() != firstMissed.Size() {
+		t.Fatalf("cross-restart replay grew durable files: dead %d->%d, missed %d->%d",
+			firstDead.Size(), secondDead.Size(), firstMissed.Size(), secondMissed.Size())
+	}
+	recs, err := ReadDeadLetter(childID)
+	if err != nil || len(recs) != 1 {
+		t.Fatalf("cross-restart dead-letter records=%d, want 1 (err=%v)", len(recs), err)
+	}
+}
+
 // --- STEP 1: daemon never goes stale — version recycle guard ----------------
 
 func TestShouldRecycleForVersion(t *testing.T) {

--- a/internal/session/taskworker_test.go
+++ b/internal/session/taskworker_test.go
@@ -256,6 +256,41 @@ func TestTaskWorker_UnownedDiscoveryCopyDoesNotAckCompletion(t *testing.T) {
 	}
 }
 
+func TestTaskWorker_ReplayUnacked_MissingParentKeepsOneFlatUnownedRecord(t *testing.T) {
+	profile := "_test-2007-unowned-retry-stable"
+	parentID := "parent-missing-2007-retry-stable"
+	childID := seedChildOnly(t, profile, parentID)
+	if err := WriteCompletionRecord(CompletionRecord{
+		ChildID: childID, Profile: profile, Title: "worker", Status: "ok",
+		Summary: "stuck completion must park once", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewTransitionDaemon()
+	t.Cleanup(d.notifier.Close)
+	var firstSize int64
+	for attempt := 0; attempt < 16; attempt++ {
+		d.ReplayUnackedCompletions(profile)
+		d.notifier.Flush()
+
+		info, err := os.Stat(InboxPathFor(UnownedInboxID))
+		if err != nil {
+			t.Fatalf("attempt %d: stat _unowned: %v", attempt+1, err)
+		}
+		if attempt == 0 {
+			firstSize = info.Size()
+		} else if info.Size() != firstSize {
+			t.Fatalf("attempt %d grew _unowned from %d to %d bytes", attempt+1, firstSize, info.Size())
+		}
+	}
+
+	unowned := readInboxLines(t, UnownedInboxID)
+	if len(unowned) != 1 || unowned[0].ChildSessionID != childID {
+		t.Fatalf("retries parked %d records, want exactly one for %q: %+v", len(unowned), childID, unowned)
+	}
+}
+
 // --- STEP 1: daemon never goes stale — version recycle guard ----------------
 
 func TestShouldRecycleForVersion(t *testing.T) {

--- a/internal/session/taskworker_test.go
+++ b/internal/session/taskworker_test.go
@@ -230,6 +230,32 @@ func TestTaskWorker_ReplayUnacked_DeliversOncePerChildAcrossRestart(t *testing.T
 	}
 }
 
+func TestTaskWorker_UnownedDiscoveryCopyDoesNotAckCompletion(t *testing.T) {
+	profile := "_test-2007-unowned-not-ack"
+	parentID := "parent-missing-2007"
+	childID := seedChildOnly(t, profile, parentID)
+	if err := WriteCompletionRecord(CompletionRecord{
+		ChildID: childID, Profile: profile, Title: "worker", Status: "ok",
+		Summary: "discoverable but not delivered", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewTransitionDaemon()
+	t.Cleanup(d.notifier.Close)
+	d.ReplayUnackedCompletions(profile)
+	d.notifier.Flush()
+
+	recs, err := LoadCompletionRecords(profile)
+	if err != nil || len(recs) != 1 || recs[0].Acked {
+		t.Fatalf("discovery copy acknowledged replay record: records=%+v err=%v", recs, err)
+	}
+	unowned, err := ReadAndTruncateInbox(UnownedInboxID)
+	if err != nil || len(unowned) != 1 || unowned[0].ChildSessionID != childID {
+		t.Fatalf("missing discovery copy: events=%+v err=%v", unowned, err)
+	}
+}
+
 // --- STEP 1: daemon never goes stale — version recycle guard ----------------
 
 func TestShouldRecycleForVersion(t *testing.T) {

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -183,8 +183,15 @@ func (d *TransitionDaemon) ReplayUnackedCompletions(profile string) {
 		if rec.Acked || strings.TrimSpace(rec.Status) == "" {
 			continue
 		}
-		if d.notifier.DeliverCompletion(rec) {
+		committed, parked := d.notifier.deliverCompletion(rec)
+		if committed {
 			_ = AckCompletion(rec.Profile, rec.ChildID)
+			continue
+		}
+		// _unowned is a discovery copy, never an acknowledgement. Keep the
+		// completion record replayable across daemon/parent restart, but do not
+		// spend its dead-letter budget merely because the parent is absent.
+		if parked {
 			continue
 		}
 		// Not committed: the parent is unresolvable (e.g. removed) or a

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -224,8 +224,12 @@ func (n *TransitionNotifier) terminalDrop(event TransitionNotificationEvent, rea
 
 	event.DeadLetterReason = reason
 	event.Attempts = MaxUnresolvedAttempts // terminal: not a transient retry
-	n.logMissed(event, reason)
-	_ = writeDeadLetter(event)
+	// The durable dead-letter file, not terminalSeen, is the cross-process
+	// source of truth. Only the process that appends the stable fingerprint may
+	// append the corresponding missed-log line.
+	if appended, err := writeDeadLetter(event); err == nil && appended {
+		n.logMissed(event, reason)
+	}
 }
 
 // Close is retained for API compatibility with callers that defer cleanup of a

--- a/internal/session/transition_notifier_dedup_test.go
+++ b/internal/session/transition_notifier_dedup_test.go
@@ -59,8 +59,10 @@ func TestDedup_InboxSameFingerprintOnce(t *testing.T) {
 		t.Fatalf("inbox dedup: expected 1 event after 5 writes of same fingerprint, got %d", len(got))
 	}
 
-	// A different timestamp must NOT dedup — that's a different logical event.
+	// A different turn must not dedup. Re-stamping the same event does not
+	// change its identity; the pane-content signal is what distinguishes turns.
 	ev2 := ev
+	ev2.LastOutputHash = "turn-advanced"
 	ev2.Timestamp = ts.Add(1 * time.Second)
 	if err := WriteInboxEvent(parent, ev); err != nil {
 		t.Fatalf("re-write same fp: %v", err)

--- a/internal/session/unowned_inbox.go
+++ b/internal/session/unowned_inbox.go
@@ -12,7 +12,7 @@ const UnownedInboxID = "_unowned"
 
 func isUnownedReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
-	case deadLetterReasonOrphan, deadLetterReasonParentMissing, deadLetterReasonUnresolvable:
+	case deadLetterReasonParentMissing, deadLetterReasonUnresolvable:
 		return true
 	default:
 		return false

--- a/internal/session/unowned_inbox.go
+++ b/internal/session/unowned_inbox.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -34,11 +33,5 @@ func recordUnownedTransition(event TransitionNotificationEvent) (bool, error) {
 }
 
 func unownedTurnSignal(event TransitionNotificationEvent) string {
-	if signal := strings.TrimSpace(event.LastOutputHash); signal != "" {
-		return signal
-	}
-	if event.Kind == transitionKindFinished || event.Timestamp.IsZero() {
-		return ""
-	}
-	return "emit:" + strconv.FormatInt(event.Timestamp.UTC().UnixNano(), 10)
+	return strings.TrimSpace(event.LastOutputHash)
 }

--- a/internal/session/unowned_inbox.go
+++ b/internal/session/unowned_inbox.go
@@ -1,0 +1,44 @@
+package session
+
+import (
+	"strconv"
+	"strings"
+)
+
+// UnownedInboxID is the durable ledger for events with no resolvable parent on
+// this host. It uses the inbox store and therefore inherits fsync, dedup, and
+// TTL sweeping.
+const UnownedInboxID = "_unowned"
+
+func isUnownedReason(reason string) bool {
+	switch strings.TrimSpace(reason) {
+	case deadLetterReasonOrphan, deadLetterReasonParentMissing, deadLetterReasonUnresolvable:
+		return true
+	default:
+		return false
+	}
+}
+
+func recordUnownedTransition(event TransitionNotificationEvent) (bool, error) {
+	if strings.TrimSpace(event.ChildSessionID) == "" {
+		return false, nil
+	}
+	event.DoneSummary = capDoneSummary(event.DoneSummary)
+	event.TargetKind = "unowned"
+	event.DeliveryResult = transitionDeliveryCommitted
+	event.LastOutputHash = unownedTurnSignal(event)
+	if event.TurnFingerprint == "" {
+		event.TurnFingerprint = TurnFingerprint(event)
+	}
+	return WriteInboxEventIfNew(UnownedInboxID, event)
+}
+
+func unownedTurnSignal(event TransitionNotificationEvent) string {
+	if signal := strings.TrimSpace(event.LastOutputHash); signal != "" {
+		return signal
+	}
+	if event.Kind == transitionKindFinished || event.Timestamp.IsZero() {
+		return ""
+	}
+	return "emit:" + strconv.FormatInt(event.Timestamp.UTC().UnixNano(), 10)
+}


### PR DESCRIPTION
Second landing of the #2007 fix. The first (#2028) was reverted the same afternoon because parking a completion in the unowned ledger acknowledged it — a restarted parent lost replay for anything unowned, a worse failure than the reported one. This round rebuilds on the reviewed work with the revert reason as the bar:

- **Replay is untouched and proves itself**: main's restart-replay test is byte-unmodified by this branch and passes; a new test pins the fixed contract — an unowned *discovery copy* never acks the completion record, so replay is still owed and delivered after restart.
- **Error transitions deliver** to the parent; a genuinely unresolvable parent lands the event in the drainable unowned ledger with its honest resolution reason — never a silent dead-letter (the field defect: 55/55 running→error records dead-lettered over 3.5 weeks).
- **`inbox drain` counts include the unowned ledger** (the round-1 undercount), reports dead letters non-zero, and exits 4 on pending dead letters — extending the #1991/#2030 contract without colliding with it.
- Deliberately parentless children keep the #805 warn-once contract (every top-level session is an orphan; the unowned ledger is for *named-but-unresolvable* parents — the field case, where every record had a valid parent id).
- The round-1 CodeQL allocation finding is bounds-fixed; crash-mid-append is regression-tested.

Fixes #2007. Addresses the two accepted asks on #1877. Verification chain: two adversarial rounds plus maintainer-completed verification (the reviewer was filter-blocked on restart probes; the in-process-restart residual is stated in the records).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable handling for transitions whose parent session is missing or unresolved.
  * Added automatic-parent validation with clear errors when the parent cannot be found or is ambiguous.
  * Added dead-letter detection and reporting for inbox drains, including JSON-safe output and exit code 4.
  * Added deduplication and replay support for unowned records.

* **Bug Fixes**
  * Improved inbox durability and recovery during concurrent or interrupted writes.
  * Prevented unresolved deliveries from being incorrectly acknowledged or orphaned.
  * Preserved dead-letter reasons and improved missed-event reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #1877
