### PR TITLE
fix(cmd): load update settings in main, not package init

### DIFF
--- a/cmd/agent-deck/issue2012_init_no_real_home_test.go
+++ b/cmd/agent-deck/issue2012_init_no_real_home_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+	"testing"
+)
+
+// Issue #2012: package init() used to call initUpdateSettings(), which loads
+// the user config and therefore resolves an agent-deck path BEFORE TestMain
+// can call testutil.IsolateHome(). The agentpaths unsandboxed-test guard then
+// fired on every run of this package, which made the guard worthless: a real
+// isolation escape printed exactly what a clean run printed.
+//
+// This test re-executes the test binary with HOME pointed at the OS user's
+// real home (the un-isolated state every `go test` starts in) and no tests
+// selected, so only package init and TestMain run. The guard must stay
+// silent: nothing may resolve an agent-deck path before TestMain isolates.
+func TestIssue2012_PackageInitDoesNotResolveRealHome(t *testing.T) {
+	if os.Getenv("AGENT_DECK_ISSUE2012_CHILD") != "" {
+		t.Skip("child process")
+	}
+	u, err := user.Current()
+	if err != nil || u.HomeDir == "" {
+		t.Skip("cannot determine real home directory from OS user database")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	env := []string{"AGENT_DECK_ISSUE2012_CHILD=1"}
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		switch key {
+		case "HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME",
+			"XDG_STATE_HOME", "AGENTDECK_PROFILE", "AGENT_DECK_TEST_HOME_ISOLATED":
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = append(env, "HOME="+u.HomeDir)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("re-exec of test binary failed: %v\n%s", err, out)
+	}
+	if strings.Contains(string(out), "resolved agent-deck path under the real home") {
+		t.Fatalf("package init resolved an agent-deck path under the real home before TestMain isolated HOME (issue #2012):\n%s", out)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -52,10 +52,15 @@ const (
 // init sets up color profile for consistent terminal colors across environments
 func init() {
 	initColorProfile()
-	initUpdateSettings()
 }
 
-// initUpdateSettings configures update checking from user config
+// initUpdateSettings configures update checking from user config.
+//
+// Called from main(), NOT from package init(): it loads the user config,
+// which resolves an agent-deck path. Under `go test`, package init runs
+// before TestMain gets to call testutil.IsolateHome(), so an init-time load
+// resolved the developer's REAL config and tripped the agentpaths
+// unsandboxed-test warning on every run of this package (issue #2012).
 func initUpdateSettings() {
 	settings := session.GetUpdateSettings()
 	update.SetCheckInterval(settings.CheckIntervalHours)
@@ -215,6 +220,10 @@ func main() {
 	// whose launchd PATH omits Homebrew's /opt/homebrew/bin). Must run before any
 	// tmux probe below. No-op when tmux is already on PATH.
 	ensureTmuxOnPath()
+
+	// Configure update checking before any command path can reach an update
+	// check (printUpdateNotice, `update`, `version`). See the doc comment.
+	initUpdateSettings()
 
 	// Extract global -p/--profile flag before subcommand dispatch
 	profile, args := extractProfileFlag(os.Args[1:])


### PR DESCRIPTION
`cmd/agent-deck`'s package `init()` called `initUpdateSettings()`, which loads the user config — before `TestMain` could call `testutil.IsolateHome()`. So every `go test ./cmd/agent-deck/...` run printed the agentpaths "resolved agent-deck path under the real home" guard, and a warning that always fires is a warning nobody reads. As the issue established, isolation still defeats the init-time load — the sandboxed tests never saw the real config — so this is a hermeticity and signal fix, not a data-safety one.

- `initUpdateSettings()` now runs at the top of `main()` (after `ensureTmuxOnPath()`); every consumer of what it sets — the update notice, `update`/`version`, the bridge installer — sits downstream in `main()`'s dispatch, and no other `init()` or package-level initializer resolves a path.
- `TestIssue2012_PackageInitDoesNotResolveRealHome` re-executes the test binary with the real `HOME` and `-test.run=^$` so only package init and `TestMain` run, and fails if the guard line appears. It fails with the call back in `init()` and passes with it in `main()`; it does not recurse and writes nothing to the real home.

Adversarial review (one round, PASS): ordering verified file-by-file; mutation check discriminates; test passes as root, non-root and with `HOME` unset; failure set of `./cmd/agent-deck/...` identical to the parent commit in the container.

Fixes #2012
