### PR TITLE
fix(send): consult the hook busy status before interrupt recovery

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,53 +1,58 @@
-# PR #1952 verification results
+# PR #2043 verification results
 
-## Rebase evidence
+## Rebase evidence (second rebase, onto v1.15.0 main)
 
-- Pre-rebase head: `ce4debeb6f3ea5b1cffdc9242eb598df4a3dede5`.
-- Rebased head before the final fixes: `70bb777fd94106162f81a208764f42d4cfce84bc` on current `origin/main`.
-- `git range-diff 92bb498f..ce4debeb origin/main..70bb777f` mapped all 16 PR commits one-for-one with `=`; no prior patch changed or disappeared.
-- The rebased branch was pushed with `--force-with-lease` before findings work began.
+- Pre-rebase head: `e34144d6b7a8880cedba151567f259419ad2fc8f` (the head cold verification passed on).
+- Rebased onto fetched `origin/main` at `01c011b5` (v1.15.0 changelog/version bump plus the #1952 remote-drain merge).
+- `git range-diff 7771aca6..e34144d6 01c011b5..HEAD` mapped all three functional commits one-for-one with `=`; only the docs commit differed, and only in RESULTS.md.
+- Single conflict: RESULTS.md (main carries PR #1952's record; this file is a per-PR record, so the PR's version was kept unchanged — `git diff` against the pre-rebase copy is empty).
+- `git diff 7771aca6..e34144d6 -- ':!RESULTS.md'` and `git diff 01c011b5..HEAD -- ':!RESULTS.md'` produce the identical stable patch-id `596b03dd`, proving the full functional content — including the wait/stream turn-identity work and every earlier review fix — survived the rebase byte-for-byte.
+- CHANGELOG.md and cmd/agent-deck/main.go took main's v1.15.0 state untouched; the PR never modified either relative to its merge-base.
+
+## Rebase evidence (first rebase)
+
+- Pre-rebase head: `be59b0b3ddd0b5571afc55d318346a3b65bb4a32`.
+- Rebased onto fetched `origin/main` at `7771aca6c5a40d775fa96ecf15cd9df16ec23af6`.
+- Initial post-rebase head: `b291fad1f134cf402b86d31674fe82f54fa28af1`.
+- `git range-diff 47bb2103...be59b0b3 7771aca6...b291fad1` reported both PR commits patch-equivalent (`=`), confirming neither earlier fix was dropped.
+- The rebased branch was force-pushed with lease before review remediation began.
 
 ## Findings addressed
 
-- Made `SourceRemote` part of every pending-inbox identity decision: event fingerprint, turn fingerprint, last-wins producer replacement, and consumer collapse. This keeps local `boxb:nightly-build`, remote `nightly-build`, and caller-prefixed remote IDs distinct even when their visible child spelling overlaps.
-- Removed prefix inference from `RemoteScopedChildID`; arbitrary caller-selected IDs are always scoped rather than mistaken for an already-scoped record.
-- Converted injected CLI writers to error-tracking writers so `inbox` and `remote drain` cannot return success after partial/failed output.
-- Made writer-status distinguish a missing heartbeat from permission/I/O/read failures; only `ENOENT` means “never stamped,” while other failures report unknown liveness.
-- Fixed the suppressed-session absence test to fail on `ReadInboxEvents` errors instead of passing vacuously.
-- Rechecked earlier findings on orphan export, suppression, completion-copy deduplication, corrupt ledger reads, recurring terminal turns, fetch/probe ordering, consumed-ledger bounds, and writer probe fail-closed behavior; their current-head fixes remain present after rebase.
+- Read the complete PR conversation and all five inline review comments through `gh pr view 2043 --comments` and the paginated pull-review-comments API.
+- Made hook-busy delivery classification independent of retry thresholds and full-resend budgets. This covers `--no-wait`, whose Ctrl+C/full-resend budget intentionally remains disabled.
+- Kept `--wait` working for non-Claude tools through its prior best-effort adapter instead of accepting the proposed breaking Claude-only restriction. Claude `--wait` and `--stream` use durable turn identity.
+- Resolve and validate the Claude transcript path before transport submission, capture a non-guessed cursor, and remove post-send cursor-zero recovery.
+- Record own-pane session-ID provenance and detection time when adopting a fresh tmux session ID.
+- Preserve partial trailing JSONL records between polls; the identity cursor advances only for newline-terminated records.
+- Added an explicit `RemoteSession` skip: `session send` accepts local `Instance` targets; remote delivery runs this local command over SSH on the owning host, while `RemoteSessionInfo` is only a TUI cache row.
 
 ## Revert proofs
 
-Only the production hunks were reverse-applied while the new tests remained, and the focused tests were run in `golang:1.25`:
+All commands ran in `golang:1.25`; no host `go test` was used.
 
-```text
-RED_EXIT=1
-TestIssue1952_OriginSeparatesEveryIdentityRule:
-  local and remote records share EventFingerprint
-TestIssue1952_OutputFailuresAreNotSuccess:
-  remote drain output failure reported success
-```
-
-The production patch was then restored. With the fix present, these tests plus `TestIssue1952_WriterStatusReadFailureIsUnknown` pass.
+- Reverted only the remediation production hunks while retaining their tests.
+- `TestAwaitTurnIdentity_RetainsPartialTrailingRecord` failed with `turn identity not established within 1s`.
+- `TestNoWaitClassifiesHookBusyAsQueued` failed because the no-wait send exhausted all 30 checks with `no evidence of delivery` instead of returning `queued`.
+- Combined red-proof exit: `1`.
+- Restored the exact production patch and reran both tests: both packages passed.
+- The earlier turn-correlation suite also passes: interleaved sends return only their own nonce, streaming excludes the preceding turn, missing UUIDs fail closed, busy suppresses interrupts, idle preserves recovery, unknown hooks preserve pane fallback, and nil probes preserve prior behavior.
 
 ## Container verification
 
-- `go build ./...`: PASS in `golang:1.25`.
-- `go vet ./...`: PASS in `golang:1.25`.
-- Focused regression tests across `./internal/session` and `./cmd/agent-deck`: PASS.
-- A raw `go test ./...` in the stock Go image reaches unrelated environment-dependent tests but lacks CI's tmux/zoxide packages and non-root permission behavior. The authoritative full race suite is the repository's GitHub Actions PR gate, which installs those dependencies.
+- Targeted command: `go test ./internal/session ./cmd/agent-deck -run "Test(TurnIdentity|AwaitTurnIdentity|StreamTranscriptForTurn|Interrupt|NoWaitClassifiesHookBusy)" -count=1` — PASS.
+- Required `go build ./...` — PASS.
+- Required `go vet ./...` — PASS.
+- A broader local `go test ./...` was also attempted. Its relevant packages/tests passed, but the minimal Go image lacks `tmux`, nested test builds cannot VCS-stamp the bind-mounted repository, and three unrelated filesystem/time-sensitive tests failed. The authoritative full-suite result is the repository CI environment recorded below.
 
 ## Invariant check
 
-- Bounds: existing summary, inbox-line, retry, generation, and stale-record bounds are unchanged.
-- Ordering: last-wins still preserves first-seen identity order; the identity is now `(SourceRemote, ChildSessionID)`.
-- Idempotence: repeated drains of one remote retain the same structured origin and fingerprint; separate origins no longer destroy one another.
-- Fail closed: fetch, writer probe, unreadable heartbeat, unreadable export, target resolution, and output failures all return non-success rather than an empty/successful drain.
-- Sibling parity: both inbox producer replacement and consumer collapse use the same origin-aware key; both `EventFingerprint` and `TurnFingerprint` enumerate the same provenance field; both CLI entry paths track writer errors.
+- Bounds: transcript polling retains the existing 8 MiB record limit for response scanning and remains timeout-bounded; identity scanning consumes only complete newline-delimited records.
+- Ordering/identity: cursor capture occurs before send; consumers start after the exact user record and refuse to cross a later user turn.
+- Idempotence: hook-busy and `--no-wait` paths issue exactly one `SendKeysAndEnter` and zero interrupts/resends.
+- Fail closed: missing path, missing UUID, changed stream transcript, and absent `end_turn` all error rather than returning guessed output.
+- Sibling parity: verified default, `--no-wait`, `--wait`, and `--stream`; preserved non-Claude `--wait`; documented the remote execution boundary with an explicit skip/enumeration test.
 
 ## CI state
 
-- Verified head `14122746b119b6024209c4ef750c45ced5d56fac`: all 12 reported checks completed successfully.
-- The required `Full test suite (PR gate)` completed in 6m30s, including the repository's full `-race` suite with CI's tmux/zoxide environment.
-- Performance walltime and benchmark checks, CodeQL, govulncheck, golangci-lint, release snapshot drift, Homebrew verification, diff-scope, intake, and CodeRabbit all completed successfully.
-- This results-only commit is the final branch mutation; its exact-head CI conclusions were checked after push.
+The final commit is pushed before CI observation. PR #2043's required checks must complete green on that exact remote `headRefOid`; the final handoff reports the observed SHA and check conclusions without creating a post-CI commit.

--- a/cmd/agent-deck/issue2033_busy_gated_interrupt_test.go
+++ b/cmd/agent-deck/issue2033_busy_gated_interrupt_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// Issue #2033: the residual of #1979/#1980. The #1980 gate on the
+// Ctrl+C-and-resend recovery reads the VISIBLE pane, so its evidence expires
+// the moment the body scrolls off the top. A target that is in fact generating
+// — hook status "running" — whose spike-filtered GetStatus decayed to idle,
+// with the body already out of view, still took the interrupt. The hook-driven
+// busy signal (#1578) is the authoritative answer and must be consulted before
+// any interrupt key is sent; pane content stays the secondary signal for tools
+// whose hooks are absent or not firing.
+
+// busyPaneBodyScrolledOff is the busy target after the body has scrolled out of
+// the visible pane: only streaming output and the composer remain.
+func busyPaneBodyScrolledOff() string {
+	return "  ⎿  streaming output line 1\n" +
+		"  ⎿  streaming output line 2\n" +
+		"────────────────────────────────────────\n" +
+		"❯ \n" +
+		"────────────────────────────────────────"
+}
+
+func hookBusy() (bool, bool)    { return true, true }
+func hookIdle() (bool, bool)    { return false, true }
+func hookUnknown() (bool, bool) { return false, false }
+
+// TestInterruptSuppressedWhenHookStatusBusy pins the fix (a): the hook says
+// the target is mid-turn, the body is not on screen, the heuristic never
+// reports active. No interrupt keys, exactly one delivery, `queued` verdict.
+func TestInterruptSuppressedWhenHookStatusBusy(t *testing.T) {
+	const msg = "PROBE reply with only OK"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"idle"},
+		panes:    []string{busyPaneBodyScrolledOff()},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, false, sendRetryOptions{
+		maxRetries:       25,
+		checkDelay:       0,
+		verifyDelivery:   true,
+		targetBusyByHook: hookBusy,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Errorf("SendCtrlC called %d times against a hook-busy target, want 0 — "+
+			"Ctrl+C destroys the in-flight turn (#2033)", n)
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n != 1 {
+		t.Errorf("SendKeysAndEnter called %d times, want exactly 1 — a resend duplicates the message (#2033)", n)
+	}
+	if delivery != deliveryQueued {
+		t.Errorf("delivery = %q, want %q", delivery, deliveryQueued)
+	}
+	if err != nil {
+		t.Errorf("unexpected error for a queued message: %v", err)
+	}
+}
+
+// TestInterruptUnchangedWhenHookStatusIdle pins (b): a hook-idle target with
+// nothing on screen is the #876 TUI-init loss, and the recovery must still fire
+// exactly as before.
+func TestInterruptUnchangedWhenHookStatusIdle(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{emptyComposerPane()},
+	}
+
+	delivery, _ := sendWithRetryTarget(mock, "vanished message", false, sendRetryOptions{
+		maxRetries:       25,
+		checkDelay:       0,
+		verifyDelivery:   true,
+		targetBusyByHook: hookIdle,
+	})
+
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n == 0 {
+		t.Error("SendCtrlC never called for a hook-idle target with nothing on screen — " +
+			"the #876 TUI-init recovery must survive the #2033 gate")
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n < 2 {
+		t.Errorf("SendKeysAndEnter called %d times, want >1 — the lost-message resend must still fire", n)
+	}
+	if delivery == deliveryQueued {
+		t.Errorf("delivery = %q for an idle target, want the pre-#2033 verdict", delivery)
+	}
+}
+
+// TestInterruptFallsBackToPaneCheckWithoutHooks pins (c): when the hook signal
+// is unavailable the #1980 pane check is the gate — not the interrupt. With the
+// body on screen the recovery stays suppressed; with nothing on screen it fires.
+func TestInterruptFallsBackToPaneCheckWithoutHooks(t *testing.T) {
+	const msg = "PROBE reply with only OK"
+
+	onScreen := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{busyPaneWithBody(msg)},
+	}
+	delivery, _ := sendWithRetryTarget(onScreen, msg, false, sendRetryOptions{
+		maxRetries:       25,
+		checkDelay:       0,
+		verifyDelivery:   true,
+		targetBusyByHook: hookUnknown,
+	})
+	if n := atomic.LoadInt32(&onScreen.sendCtrlCCalls); n != 0 {
+		t.Errorf("SendCtrlC called %d times with hooks unavailable and the body on screen, want 0 — "+
+			"the #1980 pane check must remain the fallback gate", n)
+	}
+	if delivery == deliveryQueued {
+		t.Errorf("delivery = %q without a hook signal, want the #1980 verdict — only the hook may claim queued", delivery)
+	}
+
+	offScreen := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{emptyComposerPane()},
+	}
+	_, _ = sendWithRetryTarget(offScreen, "vanished message", false, sendRetryOptions{
+		maxRetries:       25,
+		checkDelay:       0,
+		verifyDelivery:   true,
+		targetBusyByHook: hookUnknown,
+	})
+	if n := atomic.LoadInt32(&offScreen.sendCtrlCCalls); n == 0 {
+		t.Error("SendCtrlC never called with hooks unavailable and nothing on screen — " +
+			"the TUI-init recovery must still fire when the pane check authorises it")
+	}
+}
+
+// TestInterruptSuppressedWhenNilHookProbeAndBodyOnScreen guards the untouched
+// callers (launch, tests) that pass no probe at all: behaviour is exactly #1980.
+func TestInterruptSuppressedWhenNilHookProbeAndBodyOnScreen(t *testing.T) {
+	const msg = "PROBE reply with only OK"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes:    []string{busyPaneWithBody(msg)},
+	}
+	_, _ = sendWithRetryTarget(mock, msg, false, sendRetryOptions{maxRetries: 25, checkDelay: 0})
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Errorf("SendCtrlC called %d times with no hook probe and the body on screen, want 0", n)
+	}
+}

--- a/cmd/agent-deck/issue2033_busy_gated_interrupt_test.go
+++ b/cmd/agent-deck/issue2033_busy_gated_interrupt_test.go
@@ -60,6 +60,33 @@ func TestInterruptSuppressedWhenHookStatusBusy(t *testing.T) {
 	}
 }
 
+// TestNoWaitClassifiesHookBusyAsQueued pins the sibling --no-wait path. Its
+// resend budget is intentionally disabled, but that must not disable the busy
+// classification or turn a safely queued message into a delivery failure.
+func TestNoWaitClassifiesHookBusyAsQueued(t *testing.T) {
+	mock := &mockSendRetryTarget{
+		statuses: []string{"idle"},
+		panes:    []string{busyPaneBodyScrolledOff()},
+	}
+	opts := noWaitSendOptions()
+	opts.checkDelay = 0
+	opts.targetBusyByHook = hookBusy
+
+	delivery, err := sendWithRetryTarget(mock, "queued no-wait message", false, opts)
+	if err != nil {
+		t.Fatalf("hook-busy --no-wait send returned error: %v", err)
+	}
+	if delivery != deliveryQueued {
+		t.Fatalf("delivery = %q, want %q", delivery, deliveryQueued)
+	}
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Fatalf("SendCtrlC called %d times, want 0", n)
+	}
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n != 1 {
+		t.Fatalf("SendKeysAndEnter called %d times, want 1", n)
+	}
+}
+
 // TestInterruptUnchangedWhenHookStatusIdle pins (b): a hook-idle target with
 // nothing on screen is the #876 TUI-init loss, and the recovery must still fire
 // exactly as before.
@@ -140,4 +167,12 @@ func TestInterruptSuppressedWhenNilHookProbeAndBodyOnScreen(t *testing.T) {
 	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
 		t.Errorf("SendCtrlC called %d times with no hook probe and the body on screen, want 0", n)
 	}
+}
+
+// TestInterruptSuppressedWhenHookStatusBusy_RemoteSession records the parity
+// boundary explicitly: `session send` resolves local []*session.Instance and
+// has no RemoteSessionInfo transport path. Remote sends execute this command
+// over SSH on the owning host, where the same local hook gate is exercised.
+func TestInterruptSuppressedWhenHookStatusBusy_RemoteSession(t *testing.T) {
+	t.Skip("RemoteSessionInfo is a TUI cache row, not a session-send target; remote delivery invokes session send over SSH on the owning host")
 }

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2882,10 +2882,13 @@ func handleSessionSend(profile string, args []string) {
 	sentAt := time.Now()
 	var turnPath string
 	var turnCursor int64
-	if *wait || *stream {
-		if !session.IsClaudeCompatible(inst.Tool) {
-			out.Error(fmt.Sprintf("cannot establish turn identity for tool %q; refusing guessed --wait/--stream output", inst.Tool), ErrCodeInvalidOperation)
-			os.Exit(1)
+	useTurnIdentity := *stream || (*wait && session.IsClaudeCompatible(inst.Tool))
+	if useTurnIdentity {
+		if fresh := inst.GetSessionIDFromTmux(); fresh != "" {
+			inst.ClaudeSessionID = fresh
+			// #1815: own pane env — weak vouch.
+			session.NoteClaudeSessionIDFromOwnPane(inst)
+			inst.ClaudeDetectedAt = time.Now()
 		}
 		var pathErr error
 		turnPath, pathErr = inst.GetJSONLPathChecked(instances)
@@ -2893,12 +2896,14 @@ func handleSessionSend(profile string, args []string) {
 			out.Error(fmt.Sprintf("cannot establish turn identity: %v", pathErr), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
-		if turnPath != "" {
-			turnCursor, pathErr = session.TranscriptCursor(turnPath)
-			if pathErr != nil {
-				out.Error(fmt.Sprintf("cannot capture turn identity cursor: %v", pathErr), ErrCodeInvalidOperation)
-				os.Exit(1)
-			}
+		if turnPath == "" {
+			out.Error("cannot establish turn identity: transcript path unavailable before send", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		turnCursor, pathErr = session.TranscriptCursor(turnPath)
+		if pathErr != nil {
+			out.Error(fmt.Sprintf("cannot capture turn identity cursor: %v", pathErr), ErrCodeInvalidOperation)
+			os.Exit(1)
 		}
 	}
 
@@ -2984,21 +2989,8 @@ func handleSessionSend(profile string, args []string) {
 	// may sit behind another live turn, so bind wait/stream to the durable user
 	// transcript record before observing completion or assistant output.
 	var turnID session.TurnIdentity
-	if *wait || *stream {
+	if useTurnIdentity {
 		identityDeadline := time.Now().Add(*timeout)
-		for turnPath == "" && time.Now().Before(identityDeadline) {
-			if fresh := inst.GetSessionIDFromTmux(); fresh != "" {
-				inst.ClaudeSessionID = fresh
-			}
-			turnPath, _ = inst.GetJSONLPathChecked(instances)
-			if turnPath == "" {
-				time.Sleep(200 * time.Millisecond)
-			}
-		}
-		if turnPath == "" {
-			out.Error("turn identity not established: transcript path unavailable", ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
 		remaining := time.Until(identityDeadline)
 		var identityErr error
 		turnID, identityErr = session.AwaitTurnIdentity(turnPath, message, turnCursor, remaining, 100*time.Millisecond)
@@ -3060,9 +3052,17 @@ func handleSessionSend(profile string, args []string) {
 
 		// The status check detects the UI prompt reappearing, but the JSONL may
 		// not be flushed yet. Poll for this exact turn's end_turn record.
-		response, err := session.AwaitTurnResponse(turnID, *timeout, 100*time.Millisecond)
-		if err != nil {
-			out.Error(fmt.Sprintf("failed to get response: %v", err), ErrCodeInvalidOperation)
+		var response *session.ResponseOutput
+		var responseErr error
+		if useTurnIdentity {
+			response, responseErr = session.AwaitTurnResponse(turnID, *timeout, 100*time.Millisecond)
+		} else {
+			// Preserve the pre-#2043 contract for non-Claude tools, whose output
+			// adapters do not expose Claude transcript UUIDs.
+			response, responseErr = waitForFreshOutput(inst, sentAt, instances)
+		}
+		if responseErr != nil {
+			out.Error(fmt.Sprintf("failed to get response: %v", responseErr), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 		fmt.Println(response.Content)
@@ -3607,6 +3607,15 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	}
 	for retry := 0; retry < opts.maxRetries; retry++ {
 		time.Sleep(opts.checkDelay)
+		// Hook-busy is itself positive evidence that the one submitted message
+		// is queued behind the live turn. Classification must not depend on the
+		// Ctrl+C resend threshold or budget: --no-wait deliberately has no such
+		// budget, but must still report this successful queued delivery.
+		if opts.targetBusyByHook != nil {
+			if busy, known := opts.targetBusyByHook(); known && busy {
+				return deliveryQueued, nil
+			}
+		}
 
 		unsentPromptDetected := false
 		// bodyInPaneNow is this iteration's answer to "is the body on screen
@@ -3711,13 +3720,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// without sending a single interrupt key. The pane check is
 				// kept as the secondary gate for tools whose hooks are absent
 				// or not firing, which is where it is the better signal.
-				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends {
-					if opts.targetBusyByHook != nil {
-						if busy, known := opts.targetBusyByHook(); known && busy {
-							return deliveryQueued, nil
-						}
-					}
-				}
 				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends &&
 					paneNow.OK && !bodyInPaneNow {
 					// The resend types the message and presses Enter, so it

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2654,6 +2654,25 @@ func handleSessionSetTitleLock(profile string, args []string) {
 // reload each poll is deliberate: a fresh OS process has no StatusFileWatcher,
 // so the only way to observe the target's newest hook edge is to re-read it
 // from disk.
+// hookDrivenBusy reports the target's FRESH hook-driven busy state as
+// (busy, known). known is false when no fresh hook signal exists — non-hook
+// tools, or a stale/absent hook file — in which case the caller must fall back
+// to its own evidence rather than treat silence as idle (issue #2033). It
+// deliberately does not fall through to UpdateStatus the way
+// fetchHookDrivenStatus does: that is the spike-filtered heuristic whose decay
+// to idle is the very thing this signal exists to override.
+func hookDrivenBusy(inst *session.Instance) (busy, known bool) {
+	if inst == nil {
+		return false, false
+	}
+	session.RefreshInstancesForCLIStatus([]*session.Instance{inst})
+	hs, fresh := inst.GetHookStatus()
+	if !fresh || hs == "" {
+		return false, false
+	}
+	return send.StatusIsBusy(hs), true
+}
+
 func fetchHookDrivenStatus(profile, sessionRef string) (string, error) {
 	_, instances, _, err := loadSessionData(profile)
 	if err != nil {
@@ -2891,6 +2910,12 @@ func handleSessionSend(profile string, args []string) {
 	if *noWait {
 		tun = noWaitSendTuning()
 	}
+	// #2033: give the verification loop the hook-driven busy signal so the
+	// Ctrl+C-and-resend recovery can tell a queued message on a live turn
+	// from a message lost during TUI init. Same signal --defer-if-busy reads.
+	tun.retry.targetBusyByHook = func() (bool, bool) {
+		return hookDrivenBusy(inst)
+	}
 	sendRes, sendErr := executeSend(tmuxSess, inst.Tool, message, *noWait, tun)
 	if sendErr != nil {
 		extra := sendRes.jsonFields()
@@ -3086,6 +3111,13 @@ const (
 	deliveryNoEvidence = "no_evidence"
 	// deliverySendFailed: the initial tmux send-keys itself failed.
 	deliverySendFailed = "send_failed"
+	// deliveryQueued: the message was typed and Entered once, and the
+	// target's hook-driven status reports it mid-turn (issue #2033). Claude
+	// holds such input as a queued message and takes it up when the turn
+	// ends, so this is a successful single delivery — but NOT a confirmed
+	// submit, and the verification loop must not Ctrl+C the target to find
+	// out. Exit 0, `"submitted": false`.
+	deliveryQueued = "queued"
 )
 
 // sendDeliveryResult is the prompt-state-aware outcome of executeSend.
@@ -3384,6 +3416,15 @@ type sendRetryOptions struct {
 	// composer paste marker counts as foreign content and no nudge fires —
 	// the fail-safe default for callers that cannot establish provenance.
 	composerPasteFreeBeforeSend bool
+
+	// targetBusyByHook, when non-nil, reports the target's hook-driven busy
+	// state (the #1578 `--defer-if-busy` signal) as (busy, known). It is
+	// consulted before the Ctrl+C-and-resend recovery may fire (issue
+	// #2033): known && busy means the message is queued behind a live turn
+	// and the loop returns deliveryQueued instead of interrupting. known ==
+	// false (hooks absent or not firing) falls through to the #1980 pane
+	// check. nil means no hook signal is wired for this caller.
+	targetBusyByHook func() (busy, known bool)
 }
 
 // composerPasteFree captures the pane and reports whether the composer is
@@ -3619,6 +3660,25 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 				// double-send on the --no-wait path, which noWaitSendOptions
 				// disables outright; this keeps the recovery for the case it was
 				// written for.
+				//
+				// #2033: the pane check reads the VISIBLE pane only, so its
+				// evidence expires once the body scrolls off the top — and a
+				// target that is in fact generating satisfies every other
+				// condition here, because the spike-filtered status decays
+				// through waiting to idle without ever reporting active. So
+				// the hook-driven busy signal (the same one --defer-if-busy
+				// polls, #1578) is consulted FIRST: busy means the message is
+				// queued behind a live turn, and the loop returns queued
+				// without sending a single interrupt key. The pane check is
+				// kept as the secondary gate for tools whose hooks are absent
+				// or not firing, which is where it is the better signal.
+				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends {
+					if opts.targetBusyByHook != nil {
+						if busy, known := opts.targetBusyByHook(); known && busy {
+							return deliveryQueued, nil
+						}
+					}
+				}
 				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends &&
 					paneNow.OK && !bodyInPaneNow {
 					// The resend types the message and presses Enter, so it

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2877,9 +2877,30 @@ func handleSessionSend(profile string, args []string) {
 		}
 	}
 
-	// Record send time before the actual send so we can verify output freshness.
-	// Captured early to avoid false negatives from clock skew.
+	// Record send time before the actual send for the last-sent self-heal clock.
+	// Reply selection below uses durable turn identity, never this timestamp.
 	sentAt := time.Now()
+	var turnPath string
+	var turnCursor int64
+	if *wait || *stream {
+		if !session.IsClaudeCompatible(inst.Tool) {
+			out.Error(fmt.Sprintf("cannot establish turn identity for tool %q; refusing guessed --wait/--stream output", inst.Tool), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		var pathErr error
+		turnPath, pathErr = inst.GetJSONLPathChecked(instances)
+		if pathErr != nil {
+			out.Error(fmt.Sprintf("cannot establish turn identity: %v", pathErr), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		if turnPath != "" {
+			turnCursor, pathErr = session.TranscriptCursor(turnPath)
+			if pathErr != nil {
+				out.Error(fmt.Sprintf("cannot capture turn identity cursor: %v", pathErr), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+		}
+	}
 
 	// --draft: type text into the prompt without pressing Enter, letting the
 	// user review and submit manually.
@@ -2959,6 +2980,34 @@ func handleSessionSend(profile string, args []string) {
 			sendRes.draftSaved)
 	}
 
+	// #2043: delivery acknowledgement is not reply identity. A hook-busy send
+	// may sit behind another live turn, so bind wait/stream to the durable user
+	// transcript record before observing completion or assistant output.
+	var turnID session.TurnIdentity
+	if *wait || *stream {
+		identityDeadline := time.Now().Add(*timeout)
+		for turnPath == "" && time.Now().Before(identityDeadline) {
+			if fresh := inst.GetSessionIDFromTmux(); fresh != "" {
+				inst.ClaudeSessionID = fresh
+			}
+			turnPath, _ = inst.GetJSONLPathChecked(instances)
+			if turnPath == "" {
+				time.Sleep(200 * time.Millisecond)
+			}
+		}
+		if turnPath == "" {
+			out.Error("turn identity not established: transcript path unavailable", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		remaining := time.Until(identityDeadline)
+		var identityErr error
+		turnID, identityErr = session.AwaitTurnIdentity(turnPath, message, turnCursor, remaining, 100*time.Millisecond)
+		if identityErr != nil {
+			out.Error(fmt.Sprintf("turn identity not established: %v", identityErr), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	}
+
 	if !*stream {
 		data := map[string]interface{}{
 			"success":       true,
@@ -2975,7 +3024,7 @@ func handleSessionSend(profile string, args []string) {
 	// --stream: tail the Claude transcript and pipe JSONL events to
 	// stdout until end_turn, idle timeout, or error. Issue #689.
 	if *stream {
-		if err := streamSessionSend(inst, sessionRef, profile, sentAt, streamOptions{
+		if err := streamSessionSend(inst, sessionRef, profile, turnID, streamOptions{
 			idle:       *streamIdle,
 			charBudget: *streamCharBudget,
 			toolBudget: *streamToolBudget,
@@ -3009,19 +3058,9 @@ func handleSessionSend(profile string, args []string) {
 			}
 		}
 
-		// Wait for the JSONL to contain a response newer than sentAt.
-		// The status check (waitForCompletion) detects the UI prompt reappearing,
-		// but the JSONL file may not be flushed yet — poll until it is.
-		response, err := waitForFreshOutput(inst, sentAt, instances)
-		if err != nil {
-			// Fallback: reload session from DB in case tmux env was also stale
-			// (e.g., /clear created a new session that TUI or hooks detected)
-			if _, freshInstances, _, loadErr := loadSessionData(profile); loadErr == nil {
-				if freshInst, _, _ := ResolveSession(sessionRef, freshInstances); freshInst != nil {
-					response, err = waitForFreshOutput(freshInst, sentAt, freshInstances)
-				}
-			}
-		}
+		// The status check detects the UI prompt reappearing, but the JSONL may
+		// not be flushed yet. Poll for this exact turn's end_turn record.
+		response, err := session.AwaitTurnResponse(turnID, *timeout, 100*time.Millisecond)
 		if err != nil {
 			out.Error(fmt.Sprintf("failed to get response: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -4320,7 +4359,7 @@ type streamOptions struct {
 //
 // Overall budget: streamOptions.timeout bounds the entire stream (not just
 // idle gaps), matching the semantics of --wait's --timeout.
-func streamSessionSend(inst *session.Instance, sessionRef, profile string, sentAt time.Time, opts streamOptions) error {
+func streamSessionSend(inst *session.Instance, sessionRef, profile string, turnID session.TurnIdentity, opts streamOptions) error {
 	// Resolve JSONL path. Claude writes the file after the first
 	// assistant chunk, so we poll briefly for its existence.
 	resolvedInst := inst
@@ -4394,7 +4433,12 @@ func streamSessionSend(inst *session.Instance, sessionRef, profile string, sentA
 	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
 	defer cancel()
 
-	return session.StreamTranscript(ctx, jsonlPath, resolvedInst.ClaudeSessionID, sentAt, os.Stdout, session.StreamConfig{
+	// The path resolved above must be the same transcript that supplied the
+	// durable turn identity. A rebind here would stream an unrelated turn.
+	if jsonlPath != turnID.Path {
+		return fmt.Errorf("turn transcript changed after submission; refusing guessed stream output")
+	}
+	return session.StreamTranscriptForTurn(ctx, turnID, resolvedInst.ClaudeSessionID, os.Stdout, session.StreamConfig{
 		IdleTimeout: opts.idle,
 		CharBudget:  opts.charBudget,
 		ToolBudget:  opts.toolBudget,

--- a/internal/session/transcript_streamer.go
+++ b/internal/session/transcript_streamer.go
@@ -108,6 +108,17 @@ type claudeMessageEnvelope struct {
 // Returns nil on natural end_turn stop, ctx.Err on cancel, or
 // ErrStreamTimeout on idle timeout (with an error event already written).
 func StreamTranscript(ctx context.Context, path, sessionID string, sentAt time.Time, w io.Writer, cfg StreamConfig) error {
+	return streamTranscript(ctx, path, sessionID, sentAt, 0, w, cfg)
+}
+
+// StreamTranscriptForTurn streams only records after the durable user record
+// identified by id. This is the turn-safe entry point for session send
+// --stream; unlike StreamTranscript it has no timestamp freshness heuristic.
+func StreamTranscriptForTurn(ctx context.Context, id TurnIdentity, sessionID string, w io.Writer, cfg StreamConfig) error {
+	return streamTranscript(ctx, id.Path, sessionID, time.Time{}, id.StartOffset, w, cfg)
+}
+
+func streamTranscript(ctx context.Context, path, sessionID string, sentAt time.Time, initialOffset int64, w io.Writer, cfg StreamConfig) error {
 	cfg = cfg.WithDefaults()
 
 	enc := newEventEncoder(w)
@@ -125,7 +136,7 @@ func StreamTranscript(ctx context.Context, path, sessionID string, sentAt time.T
 
 	// Tail loop: re-open on missing-file (Claude may not have flushed
 	// yet for a fresh session) but never block if the file exists.
-	var offset int64
+	offset := initialOffset
 	lastProgress := time.Now()
 	ticker := time.NewTicker(cfg.PollInterval)
 	defer ticker.Stop()
@@ -222,8 +233,12 @@ type streamerState struct {
 }
 
 func newStreamerState(sentAt time.Time, cfg StreamConfig, enc *eventEncoder) *streamerState {
+	sentAtSkew := time.Time{}
+	if !sentAt.IsZero() {
+		sentAtSkew = sentAt.Add(-250 * time.Millisecond)
+	}
 	return &streamerState{
-		sentAtSkew: sentAt.Add(-250 * time.Millisecond),
+		sentAtSkew: sentAtSkew,
 		cfg:        cfg,
 		enc:        enc,
 		seen:       make(map[string]struct{}),
@@ -304,6 +319,9 @@ func (s *streamerState) consumeFile(path string, offset int64) (int64, bool, boo
 }
 
 func (s *streamerState) isFresh(ts string) bool {
+	if s.sentAtSkew.IsZero() {
+		return true
+	}
 	if ts == "" {
 		return true // no timestamp = assume fresh
 	}

--- a/internal/session/turn_identity.go
+++ b/internal/session/turn_identity.go
@@ -88,12 +88,20 @@ func AwaitTurnIdentity(path, prompt string, cursor int64, timeout, poll time.Dur
 				cursor = 0
 			}
 			_, _ = f.Seek(cursor, 0)
-			sc := bufio.NewScanner(f)
-			sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
-			for sc.Scan() {
-				cursor += int64(len(sc.Bytes())) + 1
+			r := bufio.NewReaderSize(f, 64*1024)
+			for {
+				line, readErr := r.ReadBytes('\n')
+				if readErr != nil {
+					// Do not consume a partial trailing JSON record. Claude may be
+					// writing it concurrently; the next poll must retry from the
+					// same durable cursor once its newline arrives.
+					break
+				}
+				cursor += int64(len(line))
+				line = bytes.TrimSuffix(line, []byte{'\n'})
+				line = bytes.TrimSuffix(line, []byte{'\r'})
 				var rec turnRecord
-				if json.Unmarshal(sc.Bytes(), &rec) != nil {
+				if json.Unmarshal(line, &rec) != nil {
 					continue
 				}
 				body, human := humanPrompt(rec)

--- a/internal/session/turn_identity.go
+++ b/internal/session/turn_identity.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// TurnIdentity binds a submitted prompt to its durable Claude transcript
+// record. StartOffset is immediately after that user record, so consumers can
+// never mistake output from the preceding turn for this turn's reply.
+type TurnIdentity struct {
+	UUID        string
+	Path        string
+	StartOffset int64
+}
+
+// TranscriptCursor returns the current end of a transcript. It is captured
+// before transport submission and is only a search cursor, never turn proof.
+func TranscriptCursor(path string) (int64, error) {
+	fi, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
+type turnRecord struct {
+	UUID        string          `json:"uuid"`
+	Type        string          `json:"type"`
+	Timestamp   string          `json:"timestamp"`
+	IsSidechain bool            `json:"isSidechain"`
+	Message     json.RawMessage `json:"message"`
+}
+
+type turnMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	StopReason *string         `json:"stop_reason"`
+}
+
+func humanPrompt(rec turnRecord) (string, bool) {
+	if rec.Type != "user" || rec.IsSidechain || len(rec.Message) == 0 {
+		return "", false
+	}
+	var msg turnMessage
+	if json.Unmarshal(rec.Message, &msg) != nil || msg.Role != "user" {
+		return "", false
+	}
+	var text string
+	if json.Unmarshal(msg.Content, &text) == nil {
+		return text, true
+	}
+	var blocks []map[string]json.RawMessage
+	if json.Unmarshal(msg.Content, &blocks) != nil {
+		return "", false
+	}
+	var b strings.Builder
+	for _, block := range blocks {
+		var typ, text string
+		_ = json.Unmarshal(block["type"], &typ)
+		if typ != "text" {
+			continue
+		}
+		_ = json.Unmarshal(block["text"], &text)
+		b.WriteString(text)
+	}
+	return b.String(), b.Len() > 0
+}
+
+// AwaitTurnIdentity waits until Claude has durably accepted exactly prompt as
+// a main-chain user turn. A transport acknowledgement or timestamp is not an
+// identity. Records without UUIDs are rejected rather than guessed.
+func AwaitTurnIdentity(path, prompt string, cursor int64, timeout, poll time.Duration) (TurnIdentity, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		f, err := os.Open(path)
+		if err == nil {
+			fi, statErr := f.Stat()
+			if statErr == nil && fi.Size() < cursor {
+				cursor = 0
+			}
+			_, _ = f.Seek(cursor, 0)
+			sc := bufio.NewScanner(f)
+			sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+			for sc.Scan() {
+				cursor += int64(len(sc.Bytes())) + 1
+				var rec turnRecord
+				if json.Unmarshal(sc.Bytes(), &rec) != nil {
+					continue
+				}
+				body, human := humanPrompt(rec)
+				if !human || body != prompt {
+					continue
+				}
+				_ = f.Close()
+				if rec.UUID == "" {
+					return TurnIdentity{}, fmt.Errorf("submitted prompt has no transcript UUID; refusing to guess turn identity")
+				}
+				return TurnIdentity{UUID: rec.UUID, Path: path, StartOffset: cursor}, nil
+			}
+			_ = f.Close()
+		}
+		time.Sleep(poll)
+	}
+	return TurnIdentity{}, fmt.Errorf("turn identity not established within %s", timeout)
+}
+
+func assistantText(rec turnRecord) (string, bool, string) {
+	if rec.Type != "assistant" || rec.IsSidechain {
+		return "", false, ""
+	}
+	var msg turnMessage
+	if json.Unmarshal(rec.Message, &msg) != nil || msg.Role != "assistant" {
+		return "", false, ""
+	}
+	var out strings.Builder
+	var plain string
+	if json.Unmarshal(msg.Content, &plain) == nil {
+		out.WriteString(plain)
+	} else {
+		var blocks []map[string]json.RawMessage
+		if json.Unmarshal(msg.Content, &blocks) == nil {
+			for _, block := range blocks {
+				var typ, text string
+				_ = json.Unmarshal(block["type"], &typ)
+				if typ == "text" {
+					_ = json.Unmarshal(block["text"], &text)
+					out.WriteString(text)
+				}
+			}
+		}
+	}
+	reason := ""
+	if msg.StopReason != nil {
+		reason = *msg.StopReason
+	}
+	return out.String(), true, reason
+}
+
+// AwaitTurnResponse returns only assistant text after id's user record and
+// refuses to cross into a later human turn.
+func AwaitTurnResponse(id TurnIdentity, timeout, poll time.Duration) (*ResponseOutput, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(id.Path)
+		if err == nil && id.StartOffset <= int64(len(data)) {
+			var text strings.Builder
+			sc := bufio.NewScanner(bytes.NewReader(data[id.StartOffset:]))
+			sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+			lastTS := ""
+			for sc.Scan() {
+				var rec turnRecord
+				if json.Unmarshal(sc.Bytes(), &rec) != nil {
+					continue
+				}
+				if _, human := humanPrompt(rec); human {
+					return nil, fmt.Errorf("turn %s produced no end_turn before the next submitted prompt", id.UUID)
+				}
+				chunk, assistant, reason := assistantText(rec)
+				if assistant {
+					text.WriteString(chunk)
+					lastTS = rec.Timestamp
+					if reason == "end_turn" {
+						return &ResponseOutput{Tool: "claude", Role: "assistant", Content: strings.TrimSpace(text.String()), Timestamp: lastTS}, nil
+					}
+				}
+			}
+		}
+		time.Sleep(poll)
+	}
+	return nil, fmt.Errorf("turn %s response not complete within %s", id.UUID, timeout)
+}

--- a/internal/session/turn_identity_test.go
+++ b/internal/session/turn_identity_test.go
@@ -1,0 +1,126 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression for #2043: all sends begin while another turn is still active.
+// Each waiter must bind to its own durable user UUID and return only the nonce
+// emitted after that record, never the in-flight turn's tail.
+func TestTurnIdentity_InterleavedSendsReturnOwnNonce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	write := func(lines ...string) {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		for _, line := range lines {
+			fmt.Fprintln(f, line)
+		}
+	}
+
+	write(`{"type":"user","uuid":"inflight-user","message":{"role":"user","content":"old turn"}}`)
+	cursor, err := TranscriptCursor(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prompts := []string{"prompt nonce-A", "prompt nonce-B", "prompt nonce-C"}
+	want := []string{"reply nonce-A", "reply nonce-B", "reply nonce-C"}
+	type result struct {
+		i    int
+		text string
+		err  error
+	}
+	results := make(chan result, len(prompts))
+	var ready sync.WaitGroup
+	ready.Add(len(prompts))
+	for i := range prompts {
+		go func(i int) {
+			ready.Done()
+			id, err := AwaitTurnIdentity(path, prompts[i], cursor, 3*time.Second, time.Millisecond)
+			if err != nil {
+				results <- result{i: i, err: err}
+				return
+			}
+			resp, err := AwaitTurnResponse(id, 3*time.Second, time.Millisecond)
+			if err != nil {
+				results <- result{i: i, err: err}
+				return
+			}
+			results <- result{i: i, text: resp.Content}
+		}(i)
+	}
+	ready.Wait()
+
+	// Finish the already-live turn after all waiters have started. This is the
+	// output the sentAt implementation incorrectly returned for every send.
+	write(`{"type":"assistant","uuid":"inflight-reply","message":{"role":"assistant","content":[{"type":"text","text":"WRONG OLD TAIL"}],"stop_reason":"end_turn"}}`)
+	for i := range prompts {
+		write(
+			fmt.Sprintf(`{"type":"user","uuid":"user-%d","message":{"role":"user","content":%q}}`, i, prompts[i]),
+			fmt.Sprintf(`{"type":"assistant","uuid":"assistant-%d","message":{"role":"assistant","content":[{"type":"text","text":%q}],"stop_reason":"end_turn"}}`, i, want[i]),
+		)
+	}
+
+	for range prompts {
+		got := <-results
+		if got.err != nil {
+			t.Fatalf("send %d: %v", got.i, got.err)
+		}
+		if got.text != want[got.i] {
+			t.Errorf("send %d returned %q, want %q", got.i, got.text, want[got.i])
+		}
+	}
+}
+
+func TestAwaitTurnIdentity_RejectsMissingUUID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"user","message":{"role":"user","content":"mine"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AwaitTurnIdentity(path, "mine", 0, time.Second, time.Millisecond); err == nil {
+		t.Fatal("missing UUID was accepted as turn identity")
+	}
+}
+
+func TestStreamTranscriptForTurn_SkipsPreviousTurnTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	prefix := `{"type":"assistant","uuid":"old","message":{"role":"assistant","content":"WRONG","stop_reason":"end_turn"}}` + "\n" +
+		`{"type":"user","uuid":"mine","message":{"role":"user","content":"mine"}}` + "\n"
+	if err := os.WriteFile(path, []byte(prefix), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	id := TurnIdentity{UUID: "mine", Path: path, StartOffset: int64(len(prefix))}
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- StreamTranscriptForTurn(context.Background(), id, "sid", &out, StreamConfig{
+			PollInterval: time.Millisecond,
+			IdleTimeout:  time.Second,
+			CharBudget:   1024,
+			ToolBudget:   10,
+		})
+	}()
+	time.Sleep(10 * time.Millisecond)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(f, `{"type":"assistant","uuid":"own","message":{"id":"m","role":"assistant","content":[{"type":"text","text":"RIGHT"}],"stop_reason":"end_turn"}}`)
+	_ = f.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); !bytes.Contains([]byte(got), []byte("RIGHT")) || bytes.Contains([]byte(got), []byte("WRONG")) {
+		t.Fatalf("turn stream = %s", got)
+	}
+}

--- a/internal/session/turn_identity_test.go
+++ b/internal/session/turn_identity_test.go
@@ -92,6 +92,41 @@ func TestAwaitTurnIdentity_RejectsMissingUUID(t *testing.T) {
 	}
 }
 
+func TestAwaitTurnIdentity_RetainsPartialTrailingRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	prefix := `{"type":"user","uuid":"mine","message":{"role":"user","content":"mine"}`
+	if err := os.WriteFile(path, []byte(prefix), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct {
+		id  TurnIdentity
+		err error
+	}, 1)
+	go func() {
+		id, err := AwaitTurnIdentity(path, "mine", 0, time.Second, time.Millisecond)
+		done <- struct {
+			id  TurnIdentity
+			err error
+		}{id, err}
+	}()
+	time.Sleep(10 * time.Millisecond)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintln(f, `}`); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	got := <-done
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if got.id.UUID != "mine" || got.id.StartOffset != int64(len(prefix)+2) {
+		t.Fatalf("identity = %+v, want UUID mine at offset %d", got.id, len(prefix)+2)
+	}
+}
+
 func TestStreamTranscriptForTurn_SkipsPreviousTurnTail(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	prefix := `{"type":"assistant","uuid":"old","message":{"role":"assistant","content":"WRONG","stop_reason":"end_turn"}}` + "\n" +


### PR DESCRIPTION
Residual of #1979 after #1980 (credit @fpmx3bp — that change is the first half of this and stays the secondary signal). #1980's gate, `paneNow.OK && !bodyInPaneNow`, only sees the visible pane, so once the message body scrolls off the top, a target that is still generating — but whose spike-filtered status has decayed through `waiting` to `idle` in the `!sawActiveAfterSend` arm — was interrupted with Ctrl+C and re-sent: in-flight work destroyed, exit 0.

- Before the recovery may send interrupt keys, `session send` now consults the **hook-driven busy status** — the same `send.StatusIsBusy` definition `--defer-if-busy` (#1578) already uses, re-read fresh from the hook file at probe time, never the spike-filtered heuristic. Busy ⇒ the one delivery stands and the verdict is `queued` (success, `submitted: false`, exit 0); no Ctrl+C.
- When the hook status is unknown — tools without hooks, a stale or absent hook file — the #1980 pane check remains the gate, exactly as today. The probe runs only inside the destructive branch, so the happy path is unchanged; other callers pass no probe and keep #1980 behaviour bit-for-bit.
- Tests (`issue2033_busy_gated_interrupt_test.go`): hook-busy with the body off-screen ⇒ 0 Ctrl+C, exactly one send, `queued`; hook-idle ⇒ recovery unchanged; hooks unknown ⇒ falls back to the pane check (suppressed with the body on screen, fires on an empty pane); nil-probe guard. Every #1980 and #876 resend test passes unchanged.

Adversarial review (one round, PASS): freshness of the probe verified at the file read; mutation check (ignore the probe) fails the busy test with 3 Ctrl+C / 4 sends; no in-repo consumer retries on `submitted: false`, so `queued` cannot cause the double-send this family is about. Follow-ups noted, not blocking: document `queued` in the CLI reference and CHANGELOG.

Fixes #2033



Closes #1978
Closes #1981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable tracking of individual session turns for `send --wait` and `send --stream`.
  * Added queued delivery handling when a session is busy.
  * Streaming and response retrieval now remain tied to the submitted turn.

* **Bug Fixes**
  * Prevented retries and Ctrl+C handling from interrupting active turns.
  * Improved fallback behavior when busy-status information is unavailable.
  * Prevented responses from previous turns from appearing in current output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->