### PR TITLE
fix(tmux): bound stalled startup handover

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -145,3 +145,44 @@ concurrency behavior. The test reaches the existing targeted
 replacing the bounded/concurrency-safe launch save mechanism. The existing
 missing-value test continues to prove fail-closed ordering: malformed
 `--account --no-wait` input is rejected before state or tmux side effects.
+
+# PR #2052 round-5 fix results
+
+## Decision and fix
+
+The round-4 blocker was valid. `RespawnPane` serialized pane replacement with
+the startup-timeout generation claim, but its `respawn-pane` client had no
+deadline while `s.mu` was held. The mutation now uses
+`context.WithTimeout(..., tmuxMutationTimeout)`, `s.tmuxCmdContext`, and
+`annotateDeadline`, matching the established bounded mutation path. Failure
+unlocks without publishing a new generation; success still publishes the
+fresh startup clock and clears timeout state before unlock.
+
+`TestIssue1892_RespawnPaneMutationIsBounded` is the permanent deterministic
+probe. Its fake tmux answers setup probes immediately and sleeps only for
+`respawn-pane`; with a 50 ms mutation deadline, the call must return an error
+within the 500 ms test ceiling and leave `s.mu` acquirable.
+
+## Rebase and ancestry
+
+- Reviewed round-4 head: `47124312bd533c935d0fd85edb8f29a61c7c29af`.
+- Rebased onto current `github/main` `bf506898` before diagnosis.
+- The fixed history has `0` main-only commits, preserving all prior issue-1892
+  generation, banner, hold-idempotence, return-revalidation, and manual-restart
+  fixes.
+
+## Mutation and gate receipts
+
+- Predecessor-red synthetic commit `4b70204f50ed6cc2e5bf9c221a63ebf57528ebc2`
+  contains the permanent probe on the rebased predecessor production code.
+  Build-service gate `20260823T185717-fix_2052_r5_predecessor-4b70204f-container-targeted`
+  failed the probe after 1.01 s because the unbounded respawn succeeded.
+- Fixed production commit `c157089c25c84db6f09f9845b6f102af53e99409`
+  no longer reports that probe among failures in the same package gate; the
+  package gate remains environment-red only because the build-service image
+  lacks the real `tmux` binary required by pre-existing integration tests.
+- Build-service build/vet receipt for the fixed production commit:
+  `c157089c25c84db6f09f9845b6f102af53e99409/build`, green on g14.
+
+The final result JSON records the final documentation commit, exact-head
+build/test receipts, pushed branch ancestry, and GitHub CI state.

--- a/internal/tmux/issue1892_startup_timeout_test.go
+++ b/internal/tmux/issue1892_startup_timeout_test.go
@@ -71,6 +71,7 @@ func TestIssue1892_RespawnPaneMutationIsBounded(t *testing.T) {
 	locked := make(chan struct{})
 	go func() {
 		s.mu.Lock()
+		_ = s.startupTimedOut
 		s.mu.Unlock()
 		close(locked)
 	}()

--- a/internal/tmux/issue1892_startup_timeout_test.go
+++ b/internal/tmux/issue1892_startup_timeout_test.go
@@ -6,6 +6,40 @@ import (
 	"time"
 )
 
+func TestIssue1892_RestartedGenerationIgnoresPreservedTimeoutBanner(t *testing.T) {
+	s := NewSession("issue1892-restarted", t.TempDir())
+	s.startupTimedOut = false // RespawnPane resets this for the new generation.
+
+	content := "Session startup timed out before the agent became interactive.\n\n❯ ready"
+	if s.hasErrorBannerIndicator(content) {
+		t.Fatal("timeout evidence from the previous pane generation poisoned the restarted generation")
+	}
+}
+
+func TestIssue1892_RespawnCannotCrossTimeoutGenerationClaim(t *testing.T) {
+	s := NewSession("issue1892-generation-race", t.TempDir())
+	if err := s.Start("sleep 300"); err != nil {
+		t.Fatalf("start inert pane: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Kill() })
+
+	oldPID, _ := s.getPaneProcessTree()
+	s.mu.Lock() // models expireStartupHandover's claimed generation
+	done := make(chan error, 1)
+	go func() { done <- s.RespawnPane("sleep 300") }()
+	time.Sleep(150 * time.Millisecond)
+	newPID, _ := s.getPaneProcessTree()
+	if newPID != oldPID {
+		s.mu.Unlock()
+		<-done
+		t.Fatalf("respawn replaced pane while timeout generation claim was held: pid %d -> %d", oldPID, newPID)
+	}
+	s.mu.Unlock()
+	if err := <-done; err != nil {
+		t.Fatalf("respawn after generation claim released: %v", err)
+	}
+}
+
 // TestIssue1892_StartupWithoutAgentSignalTimesOutHonesty reproduces the stuck
 // startup handover with a real tmux pane.  The pane process remains alive but
 // never renders either an agent prompt or a busy signal, exactly the condition

--- a/internal/tmux/issue1892_startup_timeout_test.go
+++ b/internal/tmux/issue1892_startup_timeout_test.go
@@ -1,10 +1,46 @@
 package tmux
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestIssue1892_ReloadedGenericErrorIsNotAStartupTimeout(t *testing.T) {
+	s := ReconnectSessionLazy("issue1892-generic-error", "generic-error", t.TempDir(), "claude", "error")
+
+	if s.startupTimedOut {
+		t.Fatal("generic persisted error was restored as a terminal startup timeout")
+	}
+	if s.hasErrorBannerIndicator("credentials repaired\n\n❯ ready") {
+		t.Fatal("repaired generic error remained terminal after reload")
+	}
+}
+
+func TestIssue1892_StartupTimeoutRespawnIsBounded(t *testing.T) {
+	binDir := t.TempDir()
+	fakeTmux := filepath.Join(binDir, "tmux")
+	if err := os.WriteFile(fakeTmux, []byte("#!/bin/sh\nexec sleep 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldTimeout := tmuxMutationTimeout
+	tmuxMutationTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { tmuxMutationTimeout = oldTimeout })
+
+	s := NewSession("issue1892-bounded-timeout", t.TempDir())
+	s.startupAt = time.Now().Add(-startupStateWindow - time.Second)
+	started := time.Now()
+	if !s.expireStartupHandover() {
+		t.Fatal("expired startup was not claimed")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("startup timeout respawn exceeded mutation deadline: %v", elapsed)
+	}
+}
 
 func TestIssue1892_RestartedGenerationIgnoresPreservedTimeoutBanner(t *testing.T) {
 	s := NewSession("issue1892-restarted", t.TempDir())

--- a/internal/tmux/issue1892_startup_timeout_test.go
+++ b/internal/tmux/issue1892_startup_timeout_test.go
@@ -1,0 +1,58 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIssue1892_StartupWithoutAgentSignalTimesOutHonesty reproduces the stuck
+// startup handover with a real tmux pane.  The pane process remains alive but
+// never renders either an agent prompt or a busy signal, exactly the condition
+// from #1892.  Once the bounded startup window is exhausted, that is a failed
+// handover, not an ordinary waiting session.
+func TestIssue1892_StartupWithoutAgentSignalTimesOutHonesty(t *testing.T) {
+	s := NewSession("issue1892-timeout", t.TempDir())
+	if err := s.Start("sleep 300"); err != nil {
+		t.Fatalf("start inert pane: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Kill() })
+
+	s.mu.Lock()
+	s.startupAt = time.Now().Add(-startupStateWindow - time.Second)
+	s.lastStableStatus = "starting"
+	s.mu.Unlock()
+
+	status, err := s.GetStatus()
+	if err != nil {
+		t.Fatalf("GetStatus after startup deadline: %v", err)
+	}
+	if status != "error" {
+		t.Fatalf("stuck startup status = %q, want error", status)
+	}
+
+	var pane string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pane, err = s.CapturePaneFresh()
+		if err == nil && strings.Contains(strings.ToLower(StripANSI(pane)), "timed out") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("capture timed-out pane: %v", err)
+	}
+	for _, want := range []string{"timed out", "agent-deck session restart"} {
+		if !strings.Contains(strings.ToLower(StripANSI(pane)), want) {
+			t.Fatalf("timed-out pane does not contain %q:\n%s", want, pane)
+		}
+	}
+
+	// The hold text is the cross-process evidence. A fresh status reader has no
+	// in-memory startup clock, but must still report the timeout honestly.
+	reloaded := ReconnectSessionLazy(s.Name, s.DisplayName, s.WorkDir, s.Command, "error")
+	if got, reloadErr := reloaded.GetStatus(); reloadErr != nil || got != "error" {
+		t.Fatalf("reloaded status = %q, %v; want durable error", got, reloadErr)
+	}
+}

--- a/internal/tmux/issue1892_startup_timeout_test.go
+++ b/internal/tmux/issue1892_startup_timeout_test.go
@@ -42,6 +42,45 @@ func TestIssue1892_StartupTimeoutRespawnIsBounded(t *testing.T) {
 	}
 }
 
+// TestIssue1892_RespawnPaneMutationIsBounded is the permanent reviewer probe
+// for the general restart path. Only respawn-pane stalls: the setup probes
+// remain immediate so the elapsed bound measures the mutation guarded by s.mu.
+func TestIssue1892_RespawnPaneMutationIsBounded(t *testing.T) {
+	binDir := t.TempDir()
+	fakeTmux := filepath.Join(binDir, "tmux")
+	if err := os.WriteFile(fakeTmux, []byte("#!/bin/sh\ncase \" $* \" in\n  *\" respawn-pane \"*) exec sleep 1 ;;\nesac\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldTimeout := tmuxMutationTimeout
+	tmuxMutationTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { tmuxMutationTimeout = oldTimeout })
+
+	s := NewSession("issue1892-bounded-respawn", t.TempDir())
+	started := time.Now()
+	err := s.RespawnPane("sleep 300")
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatal("stalled respawn unexpectedly succeeded")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("respawn mutation exceeded test ceiling: %v", elapsed)
+	}
+
+	locked := make(chan struct{})
+	go func() {
+		s.mu.Lock()
+		s.mu.Unlock()
+		close(locked)
+	}()
+	select {
+	case <-locked:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("respawn timeout left the session mutex locked")
+	}
+}
+
 func TestIssue1892_RestartedGenerationIgnoresPreservedTimeoutBanner(t *testing.T) {
 	s := NewSession("issue1892-restarted", t.TempDir())
 	s.startupTimedOut = false // RespawnPane resets this for the new generation.

--- a/internal/tmux/issue1892_startup_timeout_test.go
+++ b/internal/tmux/issue1892_startup_timeout_test.go
@@ -76,6 +76,32 @@ func TestIssue1892_RespawnCannotCrossTimeoutGenerationClaim(t *testing.T) {
 	}
 }
 
+func TestIssue1892_GetStatusDoesNotReturnTimeoutForReplacementGeneration(t *testing.T) {
+	s := NewSession("issue1892-timeout-return-race", t.TempDir())
+	if err := s.Start("sleep 300"); err != nil {
+		t.Fatalf("start inert pane: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Kill() })
+
+	s.mu.Lock()
+	s.startupAt = time.Now().Add(-startupStateWindow - time.Second)
+	s.lastStableStatus = "starting"
+	s.afterStartupTimeoutClaim = func() {
+		if err := s.RespawnPane("sleep 300"); err != nil {
+			t.Fatalf("replace timed-out pane generation: %v", err)
+		}
+	}
+	s.mu.Unlock()
+
+	status, err := s.GetStatus()
+	if err != nil {
+		t.Fatalf("GetStatus across replacement generation: %v", err)
+	}
+	if status == "error" {
+		t.Fatal("GetStatus returned the expired generation's timeout for its replacement")
+	}
+}
+
 // TestIssue1892_StartupWithoutAgentSignalTimesOutHonesty reproduces the stuck
 // startup handover with a real tmux pane.  The pane process remains alive but
 // never renders either an agent prompt or a busy signal, exactly the condition

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3550,8 +3550,11 @@ func (s *Session) RespawnPane(command string) error {
 	s.mu.Lock()
 
 	mcpLog.Debug("respawn_pane_executing", slog.Any("args", args))
-	cmd := s.tmuxCmd(args...)
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxMutationTimeout)
+	cmd := s.tmuxCmdContext(ctx, args...)
 	output, err := cmd.CombinedOutput()
+	cancel()
+	err = annotateDeadline(ctx.Err(), err)
 	if err != nil {
 		s.mu.Unlock()
 		mcpLog.Debug("respawn_pane_error", slog.String("error", err.Error()), slog.String("output", string(output)))

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1595,11 +1595,20 @@ func (s *Session) expireStartupHandover() bool {
 		restartTarget = s.Name
 	}
 	message := fmt.Sprintf("Session startup timed out before the agent became interactive.\n\nRecovery: agent-deck session restart %s\n", shellescape.Quote(restartTarget))
-	hold := fmt.Sprintf("printf %%s %s; stty -echo 2>/dev/null || true; exec sleep 2147483647", shellescape.Quote(message))
+	// A tmux pane command normally inherits the pane's controlling terminal on
+	// stdin, which is what stty requires. Name /dev/tty explicitly so this does
+	// not silently depend on stdin surviving a wrapper change. If the pane has
+	// no controlling terminal, stty remains best-effort: the recovery message
+	// and inert hold still appear, but typed input may be echoed.
+	hold := fmt.Sprintf("printf %%s %s; stty -echo </dev/tty 2>/dev/null || true; exec sleep 2147483647", shellescape.Quote(message))
 	wrapped, err := wrapRespawnCommand(hold)
 	if err == nil {
 		args := append([]string{"respawn-pane", "-k", "-t", s.Name + ":"}, wrapped...)
-		if output, respawnErr := s.tmuxCmd(args...).CombinedOutput(); respawnErr != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxMutationTimeout)
+		output, respawnErr := s.tmuxCmdContext(ctx, args...).CombinedOutput()
+		respawnErr = annotateDeadline(ctx.Err(), respawnErr)
+		cancel()
+		if respawnErr != nil {
 			statusLog.Warn("startup_timeout_hold_failed", slog.String("session", s.Name), slog.String("error", respawnErr.Error()), slog.String("output", string(output)))
 		}
 	} else {
@@ -1768,7 +1777,11 @@ func ReconnectSessionWithStatus(tmuxName, displayName, workDir, command string, 
 
 	switch previousStatus {
 	case "error":
-		sess.startupTimedOut = true
+		// "error" is shared by startup timeouts and live tool failures (auth,
+		// connection, unavailable model). Do not make that lossy persisted value
+		// terminal. GetStatus reclassifies current pane content; the distinctive
+		// timeout hold remains recoverable because a reconnected session has no
+		// fresh startup generation.
 		sess.lastStableStatus = "error"
 
 	case "idle":
@@ -1824,7 +1837,8 @@ func ReconnectSessionLazy(tmuxName, displayName, workDir, command string, previo
 	// Restore state tracker based on previous status (without running tmux commands)
 	switch previousStatus {
 	case "error":
-		sess.startupTimedOut = true
+		// See ReconnectSessionWithStatus: generic persisted errors must remain
+		// recoverable from the pane's current content.
 		sess.lastStableStatus = "error"
 
 	case "idle":
@@ -5097,7 +5111,12 @@ func (s *Session) hasErrorBannerIndicator(content string) bool {
 	// Agent-deck's own startup hold is tool-neutral. Only recognize its text
 	// while the current/restored generation owns the timeout; tmux preserves old
 	// pane contents across RespawnPane, so text alone is stale-prone evidence.
-	if s.startupTimedOut && strings.Contains(strings.ToLower(StripANSI(content)), "session startup timed out before the agent became interactive") {
+	// A live generation owns timeout evidence only after it has actually timed
+	// out. A reconnected session has no startup clock, so the hold text itself
+	// is the durable, timeout-specific reason. RespawnPane publishes a fresh
+	// startupAt before unlocking, preventing preserved old scrollback from
+	// poisoning the new generation.
+	if (s.startupTimedOut || s.startupAt.IsZero()) && strings.Contains(strings.ToLower(StripANSI(content)), "session startup timed out before the agent became interactive") {
 		return true
 	}
 	tool := inferToolFromSessionFields(s.detectedTool, s.customToolName, s.Command)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1579,18 +1579,16 @@ func (s *Session) inStartupWindowLocked() bool {
 // respawning the pane more than once.
 func (s *Session) expireStartupHandover() bool {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.startupTimedOut {
-		s.mu.Unlock()
 		return true
 	}
 	if s.startupAt.IsZero() || time.Since(s.startupAt) < startupStateWindow {
-		s.mu.Unlock()
 		return false
 	}
 	s.startupTimedOut = true
 	s.startupAt = time.Time{}
 	s.lastStableStatus = "error"
-	s.mu.Unlock()
 
 	restartTarget := s.DisplayName
 	if strings.TrimSpace(restartTarget) == "" {
@@ -1769,6 +1767,10 @@ func ReconnectSessionWithStatus(tmuxName, displayName, workDir, command string, 
 	sess := ReconnectSession(tmuxName, displayName, workDir, command)
 
 	switch previousStatus {
+	case "error":
+		sess.startupTimedOut = true
+		sess.lastStableStatus = "error"
+
 	case "idle":
 		// Session was acknowledged (user saw it) - restore as GRAY
 		sess.stateTracker = &StateTracker{
@@ -1821,6 +1823,10 @@ func ReconnectSessionLazy(tmuxName, displayName, workDir, command string, previo
 
 	// Restore state tracker based on previous status (without running tmux commands)
 	switch previousStatus {
+	case "error":
+		sess.startupTimedOut = true
+		sess.lastStableStatus = "error"
+
 	case "idle":
 		sess.stateTracker = &StateTracker{
 			lastHash:       "",
@@ -3510,14 +3516,30 @@ func (s *Session) RespawnPane(command string) error {
 		args = append(args, wrapped...)
 	}
 
+	// Serialize the pane replacement with expireStartupHandover. The mutex is
+	// the generation claim: neither path may kill a pane and then publish state
+	// for a different process generation.
+	s.mu.Lock()
+
 	mcpLog.Debug("respawn_pane_executing", slog.Any("args", args))
 	cmd := s.tmuxCmd(args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		s.mu.Unlock()
 		mcpLog.Debug("respawn_pane_error", slog.String("error", err.Error()), slog.String("output", string(output)))
 		return fmt.Errorf("failed to respawn pane: %w (output: %s)", err, string(output))
 	}
 	mcpLog.Debug("respawn_pane_output", slog.String("output", string(output)))
+
+	// Publish the new generation before releasing the claim. A timeout poll can
+	// only proceed after it observes this fresh startup clock.
+	s.startupAt = time.Now()
+	s.startupTimedOut = false
+	s.lastStableStatus = "waiting"
+	s.stateTracker = nil
+	s.cachedPromptDetector = nil
+	s.cachedPromptDetectorTool = ""
+	s.mu.Unlock()
 
 	// Capture the NEW process tree so we don't accidentally kill anything the
 	// respawn just created. Keep the probe error: "could not tell" must not be
@@ -3540,16 +3562,6 @@ func (s *Session) RespawnPane(command string) error {
 			)
 		}
 	}
-
-	// Reset startup/status trackers so GetStatus can classify the fresh process correctly.
-	s.mu.Lock()
-	s.startupAt = time.Now()
-	s.startupTimedOut = false
-	s.lastStableStatus = "waiting"
-	s.stateTracker = nil
-	s.cachedPromptDetector = nil
-	s.cachedPromptDetectorTool = ""
-	s.mu.Unlock()
 
 	return nil
 }
@@ -5082,10 +5094,10 @@ func (s *Session) hasPromptIndicator(content string) bool {
 // redraws its input prompt below the banner, so prompt detection alone would
 // report "waiting" for a session that cannot make progress).
 func (s *Session) hasErrorBannerIndicator(content string) bool {
-	// Agent-deck's own startup hold is tool-neutral and survives process
-	// restarts in the pane contents. Recognize it before tool inference so a
-	// fresh CLI/TUI process reports the same error verdict (#1892).
-	if strings.Contains(strings.ToLower(StripANSI(content)), "session startup timed out before the agent became interactive") {
+	// Agent-deck's own startup hold is tool-neutral. Only recognize its text
+	// while the current/restored generation owns the timeout; tmux preserves old
+	// pane contents across RespawnPane, so text alone is stale-prone evidence.
+	if s.startupTimedOut && strings.Contains(strings.ToLower(StripANSI(content)), "session startup timed out before the agent became interactive") {
 		return true
 	}
 	tool := inferToolFromSessionFields(s.detectedTool, s.customToolName, s.Command)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1039,13 +1039,14 @@ func isBrailleSpinnerChar(ch string) bool {
 // NOTE: All mutable fields are protected by mu. The Bubble Tea event loop is single-threaded,
 // but we use mutex protection for defensive programming and future-proofing.
 type Session struct {
-	Name        string
-	DisplayName string
-	WorkDir     string
-	Command     string
-	Created     time.Time
-	InstanceID  string // Agent-deck instance ID for hook callbacks
-	startupAt   time.Time
+	Name            string
+	DisplayName     string
+	WorkDir         string
+	Command         string
+	Created         time.Time
+	InstanceID      string // Agent-deck instance ID for hook callbacks
+	startupAt       time.Time
+	startupTimedOut bool // terminal for this pane generation after #1892's deadline
 
 	// WorkDirIsPlaceholder marks a session whose local WorkDir is not where the
 	// work happens — today that means an SSH session, whose pane only runs an
@@ -1570,6 +1571,43 @@ func (s *Session) resetPromptNoBusyHoldLocked() {
 // MUST be called with s.mu held.
 func (s *Session) inStartupWindowLocked() bool {
 	return !s.startupAt.IsZero() && time.Since(s.startupAt) < startupStateWindow
+}
+
+// expireStartupHandover replaces an alive-but-unowned pane with an inert,
+// non-echoing recovery hold when the startup deadline expires. It is called
+// without s.mu held; claiming the flag prevents concurrent pollers from
+// respawning the pane more than once.
+func (s *Session) expireStartupHandover() bool {
+	s.mu.Lock()
+	if s.startupTimedOut {
+		s.mu.Unlock()
+		return true
+	}
+	if s.startupAt.IsZero() || time.Since(s.startupAt) < startupStateWindow {
+		s.mu.Unlock()
+		return false
+	}
+	s.startupTimedOut = true
+	s.startupAt = time.Time{}
+	s.lastStableStatus = "error"
+	s.mu.Unlock()
+
+	restartTarget := s.DisplayName
+	if strings.TrimSpace(restartTarget) == "" {
+		restartTarget = s.Name
+	}
+	message := fmt.Sprintf("Session startup timed out before the agent became interactive.\n\nRecovery: agent-deck session restart %s\n", shellescape.Quote(restartTarget))
+	hold := fmt.Sprintf("printf %%s %s; stty -echo 2>/dev/null || true; exec sleep 2147483647", shellescape.Quote(message))
+	wrapped, err := wrapRespawnCommand(hold)
+	if err == nil {
+		args := append([]string{"respawn-pane", "-k", "-t", s.Name + ":"}, wrapped...)
+		if output, respawnErr := s.tmuxCmd(args...).CombinedOutput(); respawnErr != nil {
+			statusLog.Warn("startup_timeout_hold_failed", slog.String("session", s.Name), slog.String("error", respawnErr.Error()), slog.String("output", string(output)))
+		}
+	} else {
+		statusLog.Warn("startup_timeout_hold_wrap_failed", slog.String("session", s.Name), slog.String("error", err.Error()))
+	}
+	return true
 }
 
 // SetCustomPatterns sets custom patterns for generic tool support
@@ -2266,6 +2304,7 @@ func (s *Session) Start(command string) error {
 	s.invalidateCache()
 	s.Created = time.Now()
 	s.startupAt = s.Created
+	s.startupTimedOut = false
 	s.mu.Lock()
 	s.lastStableStatus = "waiting"
 	s.stateTracker = nil
@@ -3505,6 +3544,7 @@ func (s *Session) RespawnPane(command string) error {
 	// Reset startup/status trackers so GetStatus can classify the fresh process correctly.
 	s.mu.Lock()
 	s.startupAt = time.Now()
+	s.startupTimedOut = false
 	s.lastStableStatus = "waiting"
 	s.stateTracker = nil
 	s.cachedPromptDetector = nil
@@ -3939,6 +3979,10 @@ func (s *Session) GetStatus() (string, error) {
 		s.mu.Unlock()
 		statusLog.Debug("pane_dead", slog.String("session", shortName))
 		return "inactive", nil
+	}
+
+	if s.expireStartupHandover() {
+		return "error", nil
 	}
 
 	// FAST PATH: Title-based state detection for Claude Code sessions.
@@ -5038,6 +5082,12 @@ func (s *Session) hasPromptIndicator(content string) bool {
 // redraws its input prompt below the banner, so prompt detection alone would
 // report "waiting" for a session that cannot make progress).
 func (s *Session) hasErrorBannerIndicator(content string) bool {
+	// Agent-deck's own startup hold is tool-neutral and survives process
+	// restarts in the pane contents. Recognize it before tool inference so a
+	// fresh CLI/TUI process reports the same error verdict (#1892).
+	if strings.Contains(strings.ToLower(StripANSI(content)), "session startup timed out before the agent became interactive") {
+		return true
+	}
 	tool := inferToolFromSessionFields(s.detectedTool, s.customToolName, s.Command)
 	if tool == "" {
 		return false

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1047,6 +1047,10 @@ type Session struct {
 	InstanceID      string // Agent-deck instance ID for hook callbacks
 	startupAt       time.Time
 	startupTimedOut bool // terminal for this pane generation after #1892's deadline
+	// afterStartupTimeoutClaim is a test seam for scheduling a competing pane
+	// generation after timeout recovery releases mu but before GetStatus decides
+	// which generation's status to return.
+	afterStartupTimeoutClaim func()
 
 	// WorkDirIsPlaceholder marks a session whose local WorkDir is not where the
 	// work happens — today that means an SSH session, whose pane only runs an
@@ -1615,6 +1619,16 @@ func (s *Session) expireStartupHandover() bool {
 		statusLog.Warn("startup_timeout_hold_wrap_failed", slog.String("session", s.Name), slog.String("error", err.Error()))
 	}
 	return true
+}
+
+// startupTimeoutIsCurrent reports whether the timeout claim still belongs to
+// the pane generation GetStatus is about to describe. A successful respawn
+// clears the claim while publishing its fresh startup clock under the same
+// mutex, so this is the status return's generation-validation point.
+func (s *Session) startupTimeoutIsCurrent() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.startupTimedOut
 }
 
 // SetCustomPatterns sets custom patterns for generic tool support
@@ -4008,7 +4022,12 @@ func (s *Session) GetStatus() (string, error) {
 	}
 
 	if s.expireStartupHandover() {
-		return "error", nil
+		if s.afterStartupTimeoutClaim != nil {
+			s.afterStartupTimeoutClaim()
+		}
+		if s.startupTimeoutIsCurrent() {
+			return "error", nil
+		}
 	}
 
 	// FAST PATH: Title-based state detection for Claude Code sessions.


### PR DESCRIPTION
## What problem does this solve?

An agent process that stays alive but never becomes interactive leaves users with a permanently stuck startup state and no honest recovery path. Fixes #1892.

## Why this change

The startup handover now has a bounded, generation-owned timeout. On expiry, agent-deck installs an inert recovery hold with an explicit restart command; timeout and manual restart pane replacements are serialized so an old timeout cannot kill a fresh generation, and preserved pane text is accepted only as evidence for the generation that owns the timeout.

## User impact

Stalled startup becomes an explicit error with a usable recovery command. Restarting that session no longer risks a false sticky error or termination by a concurrent timeout poll.

## Evidence

- Before the initial fix: `stuck startup status = "waiting", want error`.
- Before the round-2 stale-banner fix: `timeout evidence from the previous pane generation poisoned the restarted generation`.
- Before the round-2 race fix: the real pane PID changed from `4168` to `4189` while the timeout generation claim remained held.
- After: all three `TestIssue1892_` real-tmux regressions pass.
- Full `internal/tmux` package passes (`43.600s`).
- Go 1.25 container `go build ./... && go vet ./...` passes.
- Initial visual gauntlet passed; settled frames were captured under the task artifact directory.

See `RESULTS.md` for the complete reproduce-first record.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5

**Prompt / session log (optional):** Not published.

## What actually bothered you

My human asked: "Address every reviewer finding on PR 2052 with reproduce-first tests, push to the branch, write RESULTS.md."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for sessions that exceed the startup timeout.
  * Timed-out sessions now show a clear error state and restart command instead of remaining unresponsive.
  * Timeout errors persist across reconnections without incorrectly affecting unrelated sessions.
  * Restarting or respawning a session clears stale timeout messages and starts a fresh recovery cycle.
  * Prevented session replacement while timeout recovery is still in progress.
  * Ensured timeout status is not incorrectly carried over to replacement sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->