### PR TITLE
fix(accounts): add launch parity and slot listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Closes [issue #602](https://github.com/asheshgoplani/agent-deck/issues/602).
 
 #### Switch a session's account on the fly
 
+For a new one-shot session, use `agent-deck launch . -c claude --account <name>`.
+Run `agent-deck accounts` (or `agent-deck accounts --json`) to list named slots
+configured under `[profiles.<name>.claude].config_dir`.
+
 `agent-deck session switch-account <session> <account>` moves an existing session to another Claude account — **conversation included**. The session stops, its conversation file is migrated into the target account's config dir (copy-only, with a destination backup and size verification), the account is set, and the session restarts with `--resume`. `session set <session> account <name>` auto-migrates too.
 
 ### Session naming

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -43,4 +43,4 @@ found` instead of listing the two configured slots.
 
 ## Pull request
 
-Pending.
+https://github.com/asheshgoplani/agent-deck/pull/2053

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -44,3 +44,53 @@ found` instead of listing the two configured slots.
 ## Pull request
 
 https://github.com/asheshgoplani/agent-deck/pull/2053
+
+# PR #2053 round-2 review results
+
+## Finding: launch consumed the next flag as `--account`'s value
+
+### Reproduction
+
+On the pre-fix parent `4ccce635`, I applied only the new regression test and
+ran it in `golang:1.25`. The `launch` table case failed with:
+
+```text
+launch accepted a flag-shaped account value; output:
+    ✓ Launched session: agent-deck
+```
+
+This reproduces the review's exact `launch . --account --no-wait` scenario:
+the command reported success instead of rejecting the missing account name.
+The test also enumerates both session-creation commands with an `--account`
+surface (`add` and `launch`) so the existing sibling guard cannot silently
+diverge again.
+
+### Root cause
+
+`cmd/agent-deck/launch_cmd.go:167` proceeded to argument reordering and Go flag
+parsing without calling the shared `checkFlagValueNotFlag` guard. Go's flag
+parser therefore bound the registered `--no-wait` token as the string value of
+`--account`; account resolution then treated that unknown slot as a fallback.
+The sibling `add` command already invoked the guard on original argv at
+`cmd/agent-deck/main.go:1445`.
+
+### Fix
+
+`cmd/agent-deck/launch_cmd.go:167` now invokes `checkFlagValueNotFlag` before
+argument reordering, parsing, account fallback, state writes, or tmux launch.
+The shared guard recognizes that the following token is another flag from the
+same launch `FlagSet` and exits with an actionable error. The CLI reference now
+documents the required explicit account name and the `--account=<name>` escape
+hatch for an intentional dash-prefixed name.
+
+### Test and evidence
+
+- RED on `4ccce635`: `TestIssue2053AccountGuardCoversSessionCreationCommands/launch`
+  reported that launch accepted the malformed argv and launched a session.
+- GREEN on the fixed branch: both the `add` and `launch` enumeration cases
+  reject the malformed argv, name the swallowed flag, and prove that neither
+  state nor tmux side effects occurred.
+- PASS: `go test ./cmd/agent-deck -run 'TestIssue2053|TestIssue1923|TestIssue1928' -count=1 -v`
+- PASS: `go build ./... && go vet ./...`
+
+All Go commands above ran only in a `golang:1.25` container.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,46 @@
+# Issue #2045 results
+
+## Reproduction
+
+Reproduced on current `origin/main` at `47bb2103` in a `golang:1.25`
+container. The regression test `TestIssue2045LaunchHelpOffersNamedAccountSlot`
+failed because `agent-deck launch --help` had no `--account` option. The test
+`TestIssue2045AccountsListsConfiguredSlots` failed because the unknown
+`accounts` command fell through to TUI startup and exited with `Error: tmux not
+found` instead of listing the two configured slots.
+
+## Root cause
+
+- `cmd/agent-deck/launch_cmd.go:124` had no account flag, and the instance
+  construction path near `cmd/agent-deck/launch_cmd.go:441` therefore never
+  copied a selected slot into `Instance.Account`. The existing start-time
+  resolver already consumes that field, so the missing launch wiring was the
+  gap.
+- The top-level command switch in `cmd/agent-deck/main.go:334` had no
+  `accounts` route. Unknown commands continue into TUI startup, which explains
+  the unrelated tmux error seen in the reproduction.
+
+## Fix
+
+- Added `launch --account <slot>` and persist the trimmed value on the new
+  instance before it is saved and started.
+- Added a read-only `accounts [--json]` command. It lists profiles with a
+  configured Claude `config_dir`, expands paths through the existing config
+  resolver, and sorts by slot name for deterministic human and JSON output.
+- Updated top-level help, README documentation, and the bundled agent-deck
+  skill/reference.
+
+## Proof
+
+- PASS: `go test ./cmd/agent-deck -run "TestIssue2045" -count=1 -v`
+- PASS: `go build ./... && go vet ./...`
+- Both commands ran only in `golang:1.25` containers.
+- The full `go test ./cmd/agent-deck -count=1` suite was also attempted in the
+  stock Go container. It is not green there because tmux is absent; existing
+  tmux-dependent tests fail with `Error: tmux not found`, and the two existing
+  40 ms cold-start budgets also exceeded the shared-container timings. The
+  issue-specific tests pass in that same environment.
+
+## Pull request
+
+Pending.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -94,3 +94,54 @@ hatch for an intentional dash-prefixed name.
 - PASS: `go build ./... && go vet ./...`
 
 All Go commands above ran only in a `golang:1.25` container.
+
+# PR #2053 round-3 verification results
+
+## Blocking finding: launch account persistence had no effective test
+
+### Reproduction
+
+The verifier selectively removed the assignment at
+`cmd/agent-deck/launch_cmd.go:452-454` while retaining flag registration and
+parsing. The old help-only test remained green, proving it did not cover the
+user-visible persistence behavior.
+
+### Root cause
+
+`cmd/agent-deck/issue2045_accounts_cli_test.go:12` exercised only `launch
+--help`; it never entered the creation path or inspected the saved
+`Instance.Account`. The production assignment itself is at
+`cmd/agent-deck/launch_cmd.go:452-454`.
+
+### Fix
+
+`TestIssue2045LaunchPersistsNamedAccountSlot` now configures the `work` Claude
+account, drives the real `launch` command through creation, start, and save with
+an isolated fake tmux executable, opens the isolated profile storage, and
+asserts that exactly one saved instance has `Account == "work"`.
+
+The test also contains the requested focused `RemoteSession` skip marker.
+`launch` creates a local session and has no remote target argument or
+RemoteSession dispatch branch, so remote runtime behavior is not applicable.
+
+### Revert-proof
+
+All commands below ran in `golang:1.25` containers with
+`GOFLAGS=-buildvcs=false` for the bind-mounted linked worktree.
+
+- GREEN with the production assignment present:
+  `TestIssue2045LaunchPersistsNamedAccountSlot` exited 0.
+- RED after replacing only `launch_cmd.go:452-454` with `_ = account`:
+  `issue2045_accounts_cli_test.go:55: persisted launch account = "", want work`.
+- The assignment was then restored before the final verification.
+- Final combined container command passed:
+  `go test ./cmd/agent-deck -run "TestIssue2045|TestIssue2053" -count=1 -v && go build ./... && go vet ./...`.
+
+### Preserved invariant
+
+The change is test-only and does not alter launch ordering, persistence, or
+concurrency behavior. The test reaches the existing targeted
+`InsertSessionAndVerify` path, so it verifies account persistence without
+replacing the bounded/concurrency-safe launch save mechanism. The existing
+missing-value test continues to prove fail-closed ordering: malformed
+`--account --no-wait` input is rejected before state or tmux side effects.

--- a/cmd/agent-deck/accounts_cmd.go
+++ b/cmd/agent-deck/accounts_cmd.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+type accountListEntry struct {
+	Name      string `json:"name"`
+	ConfigDir string `json:"config_dir"`
+}
+
+func configuredAccountSlots(config *session.UserConfig) []accountListEntry {
+	accounts := make([]accountListEntry, 0)
+	if config == nil {
+		return accounts
+	}
+	for name := range config.Profiles {
+		if dir := config.GetProfileClaudeConfigDir(name); dir != "" {
+			accounts = append(accounts, accountListEntry{Name: name, ConfigDir: dir})
+		}
+	}
+	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Name < accounts[j].Name })
+	return accounts
+}
+
+func handleAccounts(args []string) {
+	fs := flag.NewFlagSet("accounts", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: agent-deck accounts [--json]")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "List named account slots configured as [profiles.<name>.claude].config_dir.")
+		fmt.Fprintln(fs.Output())
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return
+		}
+		os.Exit(2)
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(os.Stderr, "accounts does not accept positional arguments: %s\n", strings.Join(fs.Args(), " "))
+		os.Exit(2)
+	}
+
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: load config: %v\n", err)
+		os.Exit(1)
+	}
+	accounts := configuredAccountSlots(config)
+	if *jsonOutput {
+		if err := json.NewEncoder(os.Stdout).Encode(accounts); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: encode accounts: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if len(accounts) == 0 {
+		fmt.Println("No named account slots configured.")
+		return
+	}
+	for _, account := range accounts {
+		fmt.Printf("%-20s %s\n", account.Name, account.ConfigDir)
+	}
+}

--- a/cmd/agent-deck/issue2045_accounts_cli_test.go
+++ b/cmd/agent-deck/issue2045_accounts_cli_test.go
@@ -4,19 +4,60 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-func TestIssue2045LaunchHelpOffersNamedAccountSlot(t *testing.T) {
+func TestIssue2045LaunchPersistsNamedAccountSlot(t *testing.T) {
 	home := t.TempDir()
-	stdout, stderr, code := runAgentDeck(t, home, "launch", "--help")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("AGENTDECK_PROFILE", "ch_support_test")
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`[profiles.work.claude]
+config_dir = "~/.claude-work"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The launch path requires tmux, but persistence is the behavior under
+	// test. A successful no-op executable lets the real command reach every
+	// create/start/save stage without sharing the developer's tmux server.
+	binDir := t.TempDir()
+	fakeTmux := "#!/bin/sh\ncase \" $* \" in\n  *' has-session '*) exit 1 ;;\nesac\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(fakeTmux), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	stdout, stderr, code := runAgentDeck(t, home, "launch", home, "-c", "shell", "--account", "work", "--no-wait")
 	if code != 0 {
-		t.Fatalf("launch --help exit = %d\nstdout: %s\nstderr: %s", code, stdout, stderr)
+		t.Fatalf("launch exit = %d\nstdout: %s\nstderr: %s", code, stdout, stderr)
 	}
-	if !strings.Contains(stdout+stderr, "-account") {
-		t.Fatalf("launch --help does not offer --account:\n%s%s", stdout, stderr)
+
+	storage, err := session.NewStorageWithProfile("ch_support_test")
+	if err != nil {
+		t.Fatalf("open launch storage: %v", err)
 	}
+	sessions, err := storage.Load()
+	if err != nil {
+		t.Fatalf("load launched session: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("persisted sessions = %d, want 1", len(sessions))
+	}
+	if sessions[0].Account != "work" {
+		t.Fatalf("persisted launch account = %q, want work", sessions[0].Account)
+	}
+
+	t.Run("RemoteSession", func(t *testing.T) {
+		t.Skip("RemoteSession out of scope: launch creates a local session and accepts no remote target")
+	})
 }
 
 func TestIssue2045AccountsListsConfiguredSlots(t *testing.T) {

--- a/cmd/agent-deck/issue2045_accounts_cli_test.go
+++ b/cmd/agent-deck/issue2045_accounts_cli_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIssue2045LaunchHelpOffersNamedAccountSlot(t *testing.T) {
+	home := t.TempDir()
+	stdout, stderr, code := runAgentDeck(t, home, "launch", "--help")
+	if code != 0 {
+		t.Fatalf("launch --help exit = %d\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout+stderr, "-account") {
+		t.Fatalf("launch --help does not offer --account:\n%s%s", stdout, stderr)
+	}
+}
+
+func TestIssue2045AccountsListsConfiguredSlots(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := `[profiles.personal.claude]
+config_dir = "~/.claude-personal"
+
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "accounts", "--json")
+	if code != 0 {
+		t.Fatalf("accounts --json exit = %d\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var got []struct {
+		Name      string `json:"name"`
+		ConfigDir string `json:"config_dir"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("accounts --json returned invalid JSON: %v\n%s", err, stdout)
+	}
+	if len(got) != 2 || got[0].Name != "personal" || got[1].Name != "work" {
+		t.Fatalf("accounts = %#v, want personal and work sorted by name", got)
+	}
+	if got[0].ConfigDir != filepath.Join(home, ".claude-personal") || got[1].ConfigDir != filepath.Join(home, ".claude-work") {
+		t.Fatalf("accounts did not return resolved config dirs: %#v", got)
+	}
+}

--- a/cmd/agent-deck/issue2053_launch_account_guard_test.go
+++ b/cmd/agent-deck/issue2053_launch_account_guard_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The reported launch shape used to consume --no-wait as the account name,
+// then continue into account fallback and session creation. Exercise the real
+// command in a subprocess because its error path intentionally calls os.Exit.
+func TestIssue2053AccountGuardCoversSessionCreationCommands(t *testing.T) {
+	if command := os.Getenv("AGENT_DECK_ISSUE2053_HELPER"); command != "" {
+		if command == "add" {
+			handleAdd("_test", []string{".", "--account", "--quick"})
+		} else {
+			handleLaunch("_test", []string{".", "--account", "--no-wait"})
+		}
+		os.Exit(0)
+	}
+
+	commands := []struct {
+		name     string
+		nextFlag string
+	}{
+		{name: "add", nextFlag: "--quick"},
+		{name: "launch", nextFlag: "--no-wait"},
+	}
+	for _, command := range commands {
+		t.Run(command.name, func(t *testing.T) {
+			home := t.TempDir()
+			marker := filepath.Join(home, "tmux-invoked")
+			binDir := t.TempDir()
+			tmuxPath := filepath.Join(binDir, "tmux")
+			if err := os.WriteFile(tmuxPath, []byte("#!/bin/sh\ntouch \"$AGENT_DECK_ISSUE2053_MARKER\"\nexit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=^TestIssue2053AccountGuardCoversSessionCreationCommands$")
+			cmd.Env = append(os.Environ(),
+				"AGENT_DECK_TASK6_HELPER_PROCESS=1",
+				"AGENT_DECK_ISSUE2053_HELPER="+command.name,
+				"AGENT_DECK_ISSUE2053_MARKER="+marker,
+				"HOME="+home,
+				"XDG_CONFIG_HOME="+filepath.Join(home, "config"),
+				"XDG_DATA_HOME="+filepath.Join(home, "data"),
+				"XDG_STATE_HOME="+filepath.Join(home, "state"),
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+			)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("%s accepted a flag-shaped account value; output:\n%s", command.name, out)
+			}
+			for _, want := range []string{"account", command.nextFlag, "needs a value"} {
+				if !strings.Contains(string(out), want) {
+					t.Errorf("error output %q does not explain %q", out, want)
+				}
+			}
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("%s reached tmux after rejecting argv (stat error %v)", command.name, err)
+			}
+			entries, err := os.ReadDir(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("%s/account fallback wrote state before rejecting argv: %v", command.name, entries)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -160,6 +160,15 @@ func handleLaunch(profile string, args []string) {
 		fmt.Println("  agent-deck launch . -c claude -w feature/new -b -m \"Start work\"")
 	}
 
+	// Reject an omitted --account value before either reordering pass can bind
+	// the following flag as the account name. Besides swallowing that flag, an
+	// unknown account silently falls through to another credential source, so
+	// this check must happen before any launch or fallback resolution begins.
+	if err := checkFlagValueNotFlag(fs, args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Reorder args: move path to end so flags are parsed correctly
 	args = reorderArgsForFlagParsing(args)
 

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -121,6 +121,7 @@ func handleLaunch(profile string, args []string) {
 	// Resume session flag
 	resumeSession := fs.String("resume-session", "", "Claude session ID to resume")
 	modelID := fs.String("model", "", "Model ID/version to use for this session (claude, codex, gemini, opencode)")
+	account := fs.String("account", "", "Named account slot (resolves via [profiles.<account>.claude].config_dir; #924)")
 
 	// Socket isolation (v1.7.50+, issue #687). Same semantics as
 	// `agent-deck add --tmux-socket`: overrides `[tmux].socket_name` for
@@ -435,6 +436,12 @@ func handleLaunch(profile string, args []string) {
 		if ts := newInstance.GetTmuxSession(); ts != nil {
 			ts.SocketName = flagSocket
 		}
+	}
+
+	// #2045: launch must preserve the same per-session named account slot as
+	// add. Start-time resolution already consumes Instance.Account.
+	if trimmed := strings.TrimSpace(*account); trimmed != "" {
+		newInstance.Account = trimmed
 	}
 
 	if parentInstance != nil {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -334,6 +334,9 @@ func main() {
 		case "launch":
 			handleLaunch(profile, args[1:])
 			return
+		case "accounts":
+			handleAccounts(args[1:])
+			return
 		case "conductor":
 			handleConductor(profile, args[1:])
 			return
@@ -3541,6 +3544,7 @@ func printHelp() {
 	fmt.Println("  (none)           Start the TUI")
 	fmt.Println("  add <path>       Add a new session")
 	fmt.Println("  launch [path]    Add, start, and optionally send a message in one step")
+	fmt.Println("  accounts         List configured named account slots")
 	fmt.Println("  try <name>       Quick experiment (create/find dated folder + session)")
 	fmt.Println("  list, ls         List all sessions")
 	fmt.Println("  remove, rm       Remove a session")

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -110,6 +110,8 @@ The table above is what *agent-deck* does. This one is what the *CLI inside a se
 |---------|---------|
 | `agent-deck` | Launch interactive TUI |
 | `agent-deck add -t "Name" -c claude /path` | Create session |
+| `agent-deck launch . -c claude --account <name>` | Create and start a session under a named account slot |
+| `agent-deck accounts [--json]` | List configured named account slots |
 | `agent-deck session start/stop/restart <name>` | Control session |
 | `agent-deck session send <name> "message"` | Send message |
 | `agent-deck session send <name> --message-file <file>` | Send message from file (`-` = stdin); no shell quoting. Also on `launch`/`session start` |
@@ -818,6 +820,12 @@ Move a session — conversation included — to a different Claude account (work
 **Commands:**
 
 ```bash
+# Inspect the account names available to add/launch/switch-account
+agent-deck accounts
+
+# Create and start a new session directly under one named account
+agent-deck launch . -c claude --account <account>
+
 # Full flow: stop → copy conversation into the target account → set account → restart with --resume
 agent-deck session switch-account <session> <account>
 

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -84,6 +84,7 @@ agent-deck launch -g book-keeper -c claude   # no path: lands on the group's def
 Notes:
 - `[path]` omitted: resolves the target group's `default_path`, then the global `default_path` config key, then cwd — the same chain as `add` (#1303). An explicit `.` always means the current directory.
 - `--account <name>` selects a named slot from `[profiles.<name>.claude].config_dir` for this session, matching `add --account`.
+- `--account` requires an explicit name. If the next token is another launch flag, launch stops with an error before resolving a fallback account or creating a session; use `--account=<name>` when a name intentionally begins with a dash.
 
 ### accounts - List named account slots
 

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -75,6 +75,7 @@ Examples:
 
 ```bash
 agent-deck launch . -c claude -m "Review this module"
+agent-deck launch . -c claude --account work -m "Review this module"
 agent-deck launch . -g ard -c claude -m "Review dataset"
 agent-deck launch . -c "codex --dangerously-bypass-approvals-and-sandbox"
 agent-deck launch -g book-keeper -c claude   # no path: lands on the group's default_path
@@ -82,6 +83,15 @@ agent-deck launch -g book-keeper -c claude   # no path: lands on the group's def
 
 Notes:
 - `[path]` omitted: resolves the target group's `default_path`, then the global `default_path` config key, then cwd — the same chain as `add` (#1303). An explicit `.` always means the current directory.
+- `--account <name>` selects a named slot from `[profiles.<name>.claude].config_dir` for this session, matching `add --account`.
+
+### accounts - List named account slots
+
+```bash
+agent-deck accounts [--json]
+```
+
+Lists profiles that configure a Claude `config_dir`; these names are accepted by `add --account` and `launch --account`.
 
 ### list - List sessions
 


### PR DESCRIPTION
## Summary

- add `launch --account <slot>` and persist it through the existing `Instance.Account` resolution path
- add deterministic `accounts [--json]` listing for configured Claude account slots
- update CLI help, README, and the bundled agent-deck skill/reference

## Reproduction and proof

- Added regression coverage that failed on current main because `launch --help` omitted `--account` and `accounts --json` fell through to tmux/TUI startup.
- `go test ./cmd/agent-deck -run "TestIssue2045" -count=1 -v` passes in `golang:1.25`.
- `go build ./... && go vet ./...` passes in `golang:1.25`.
- Full evidence, including stock-container suite limitations, is in `RESULTS.md`.

Thanks @asheshgoplani for reporting and precisely tracing the released CLI gap.

Closes #2045


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `accounts` command to list configured account profiles and their configuration directories.
  - Supports human-readable and JSON output, with accounts sorted by name.
  - Added the `--account` option to `launch` for selecting a named account.
  - Updated command help to include the new accounts functionality.

- **Bug Fixes**
  - Improved validation for missing or invalid account values in session creation commands.
  - Account paths using home-directory notation are now resolved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->