### PR TITLE
feat: add native Oh My Pi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ Agent Deck works with any terminal-based AI tool:
 | **Cursor** (terminal) | Status detection, organization |
 | **Hermes Agent** | Organization, launch |
 | **DeepSeek Harness** (`dsh`) | Status detection, organization, launch, restart, per-account `DSH_HOME` |
-| **Oh My Pi** (`omp`) | Full (status, MCP, fork, resume) |
+| **Oh My Pi** (`omp`) | Status detection, organization, launch, restart, resume, fork, project skills |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 
 Codex status detection uses Codex's notify hook. Install and verify it once for each Codex home:

--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ Agent Deck works with any terminal-based AI tool:
 | **Cursor** (terminal) | Status detection, organization |
 | **Hermes Agent** | Organization, launch |
 | **DeepSeek Harness** (`dsh`) | Status detection, organization, launch, restart, per-account `DSH_HOME` |
+| **Oh My Pi** (`omp`) | Full (status, MCP, fork, resume) |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 
 Codex status detection uses Codex's notify hook. Install and verify it once for each Codex home:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Two short guides to read next:
 
 ### Fork Sessions
 
-Try different approaches without losing context. Fork Claude, OpenCode, Pi, and Codex sessions instantly. Each fork inherits the parent conversation history through the tool's native fork support.
+Try different approaches without losing context. Fork Claude, OpenCode, Pi, Codex, and Oh My Pi sessions instantly. Each fork inherits the parent conversation history through the tool's native fork support.
 
 - Press `f` for quick fork, `F` to customize name/group
 - Fork your forks to explore as many branches as you need
@@ -470,7 +470,7 @@ See the [Docker Sandbox Guide](skills/agent-deck/references/sandbox.md) for the 
 
 ### Forking sessions
 
-Press `f` to **quick-fork** the selected session, or `Shift+F` for the fork **dialog** (customize title, group, branch, and toggles). A fork inherits the parent's conversation context through each tool's native fork — supported for **Claude, OpenCode, Pi, and Codex** (and Codex-compatible custom tools) across the TUI, CLI (`agent-deck session fork <id>`), and Web UI.
+Press `f` to **quick-fork** the selected session, or `Shift+F` for the fork **dialog** (customize title, group, branch, and toggles). A fork inherits the parent's conversation context through each tool's native fork — supported for **Claude, OpenCode, Pi, Codex, and Oh My Pi** (and Codex-compatible custom tools) across the TUI, CLI (`agent-deck session fork <id>`), and Web UI.
 
 Quick fork (`f`) is **comprehensive by default**: it creates a new git worktree + branch, carries the parent's uncommitted working-tree state, matches the parent's Docker isolation, and inherits the parent's Claude launch options. The `Shift+F` dialog opens pre-seeded from the same defaults ("comprehensive, tweak down"). Jujutsu (jj) repos are supported too — the fork materializes the parent's working state into a new jj workspace.
 

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,45 @@
+# Issue #1977 results
+
+PR: https://github.com/asheshgoplani/agent-deck/pull/2054
+
+## Reproduction evidence
+
+Reproduced on current `main` commit `47bb2103` in `golang:1.25` containers before importing any implementation. The new regression tests failed as follows:
+
+- `Match("omp")`, `Match("omp --model sonnet")`, and `Match("/usr/local/bin/omp --continue")` returned `shell`; `IsBuiltin("omp")` was false.
+- `DefaultRawPatterns("omp")` returned nil.
+- A captured OMP approval pane beginning `Allow tool: bash` was not classified as waiting.
+
+Command:
+
+```sh
+docker run --rm -v "$PWD":/src -w /src golang:1.25 sh -c 'go test ./internal/session -run TestIssue1977_OMPIsRecognizedAsBuiltin -count=1; go test ./internal/tmux -run TestIssue1977_OMP -count=1'
+```
+
+## Root cause
+
+OMP was absent from the canonical built-in registry, so registry matching necessarily reached the shell fallback (`internal/session/builtins.go:56`). It also had no default status preset (`internal/tmux/patterns.go:149`) and no OMP arm in the independent readiness detector, which therefore used shell prompt glyphs (`internal/tmux/detector.go:91`). Finally, the generic model surface had no OMP-backed persistent options or command-builder consumer (`internal/session/instance.go:9340`, `internal/session/omp.go:81`).
+
+## Fix
+
+- Registered `omp` as a basename/token-matched built-in, avoiding substring false positives such as `compass`.
+- Added the approved adapter surfaces from reporter @khiladisngh's `feat/omp-native-support` branch: instance-scoped session directories, resume/restart, JSONL fork, environment/config, skills, TUI/Web discovery, and captured v17.3.8 status patterns.
+- Added an OMP-specific readiness arm that gives the captured busy marker priority, recognizes approval prompts, and otherwise preserves the previous generic fallback.
+- Added persistent per-session model options and `[omp].default_model`; the command builder emits shell-escaped `--model` before lifecycle flags.
+- Added `docs/tools/omp.md` and updated the bundled Agent Deck skill configuration reference.
+
+## Proof
+
+The originally failing regression tests now pass. Additional proof:
+
+- `TestOMPLifecycle_LaunchSendRestart` passed in a Go 1.25 container with tmux installed. The fake binary proves launch, instance/model propagation, prompt delivery, response, restart, and resume from the same scoped JSONL directory.
+- Targeted OMP session, registry, tmux detector/pattern, and UI tests passed.
+- Required build/vet passed:
+
+```sh
+docker run --rm -v "$PWD":/src -w /src golang:1.25 sh -c 'git config --global --add safe.directory /src && go build ./... && go vet ./...'
+```
+
+The prescribed screenshot gauntlet ran and produced frames under `/tmp/iss1977-proof.ZQLNTE/shots`, but the script hardcodes `/usr/local/bin/agent-deck` and host permissions prevented replacing that binary with the branch build. The run returned cached frames from the installed v1.14.0 binary, so they are explicitly not claimed or attached as proof of this patch. The changed OMP picker/settings/setup surfaces are covered by targeted UI tests.
+
+An attempted full run of `internal/session`, `internal/tmux`, and `internal/ui` exposed unrelated environment failures: the base image lacked tmux, and a read-only-directory test behaves differently as root. Targeted tests were rerun with tmux installed and passed; build/vet passed separately as required.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,45 +1,142 @@
-# Issue #1977 results
+# Round-3 Results — PR #2054
 
-PR: https://github.com/asheshgoplani/agent-deck/pull/2054
+Base: `b1252e08a23fe921f2829c4a0c16e4975c4fe1d8` (already even with `origin/main`).
+Fix commit: `9f9883df` plus this results-only follow-up. All Go commands ran in
+`golang:1.25` containers; no host `go test` was used.
 
-## Reproduction evidence
+## 1. Built-in launcher aliases
 
-Reproduced on current `main` commit `47bb2103` in `golang:1.25` containers before importing any implementation. The new regression tests failed as follows:
+- Reproduction: `Registry.Match("oh-my-pi")` and
+  `Registry.Match("npx @oh-my-pi/pi-coding-agent --model opus")` returned
+  `shell`.
+- Root cause: `internal/session/builtins.go:67` registered only the `omp`
+  token.
+- Fix: registered the two supported package/launcher substrings while retaining
+  token-only matching for bare `omp` (so words such as `component` remain
+  non-matches).
+- Red-without-fix: in `/tmp/r3-2054/mutation` (parent production plus the new
+  tests), the session test group failed to compile because the same group also
+  pins the newly introduced structured option contract. The tmux mutation below
+  independently produced assertion-level red for both aliases. This is genuine
+  contract red, not an environment failure.
+- Preserved invariant: short bare `omp` is not substring-matched; ambiguous
+  containing words retain shell behavior.
 
-- `Match("omp")`, `Match("omp --model sonnet")`, and `Match("/usr/local/bin/omp --continue")` returned `shell`; `IsBuiltin("omp")` was false.
-- `DefaultRawPatterns("omp")` returned nil.
-- A captured OMP approval pane beginning `Allow tool: bash` was not classified as waiting.
+## 2. Initial native fork model/options
 
-Command:
+- Reproduction: an SSH-target parent with persisted model `review/model`, model
+  cycle `fast,slow`, and profile `review` generated a fork command containing
+  none of those flags, and the child did not persist those options.
+- Root cause: `internal/session/omp.go:122-152` built the fork invocation from
+  only the executable, fork source, session directory, and approval default.
+- Fix: copy the parent's structured OMP options to the child and append all
+  non-session harness arguments to the initial native fork command. The normal
+  start/restart builder at `internal/session/omp.go:92-120` uses the same option
+  model.
+- Red-without-fix: `/tmp/r3-2054/mutation-fork` restores only `omp.go` to the
+  parent while retaining current options/tests. `go test ./internal/session
+  -run TestOMPForkCarriesModelAndHarnessOptions` failed assertions for missing
+  `--model review/model`, `--models fast,slow`, `--profile review`, and missing
+  persisted child options (`FORK_MUTATION_EXIT=1`).
+- Preserved invariant: forks still use `--fork` and distinct parent/child
+  instance-scoped directories; normal restart still defaults to `--continue`.
 
-```sh
-docker run --rm -v "$PWD":/src -w /src golang:1.25 sh -c 'go test ./internal/session -run TestIssue1977_OMPIsRecognizedAsBuiltin -count=1; go test ./internal/tmux -run TestIssue1977_OMP -count=1'
-```
+## 3. tmux detection aliases and false positive
 
-## Root cause
+- Reproduction: supported `oh-my-pi` and `npx
+  @oh-my-pi/pi-coding-agent` commands returned empty, while `grep omp README.md`
+  returned `omp`.
+- Root cause: `internal/tmux/tmux.go:861-902` recognized literal `omp` and then
+  used a permissive fallback that searched argument text.
+- Fix: `isOMPCommand` at `internal/tmux/tmux.go:906-928` recognizes `omp`,
+  `oh-my-pi`, and the exact npx package only in command position, including
+  environment prefixes; the incidental-text fallback was removed.
+- Red-without-fix: parent production plus
+  `internal/tmux/omp_round3_test.go` failed four intended assertions: all three
+  supported alias forms were missed and `grep omp README.md` false-matched
+  (`TMUX_MUTATION_EXIT=1`).
+- Preserved invariant: executable paths and environment-prefixed launches are
+  recognized, while ordinary shell arguments cannot select OMP status rules.
 
-OMP was absent from the canonical built-in registry, so registry matching necessarily reached the shell fallback (`internal/session/builtins.go:56`). It also had no default status preset (`internal/tmux/patterns.go:149`) and no OMP arm in the independent readiness detector, which therefore used shell prompt glyphs (`internal/tmux/detector.go:91`). Finally, the generic model surface had no OMP-backed persistent options or command-builder consumer (`internal/session/instance.go:9340`, `internal/session/omp.go:81`).
+## 4. Complete launch/harness controls
 
-## Fix
+- Reproduction: `OMPOptions` held only `Model`; the new-session UI displayed
+  only the shared model input, so every other issue-requested flag required a
+  raw command workaround.
+- Root cause: `internal/session/tooloptions.go:323-360` and
+  `internal/session/userconfig.go:2127-2148` modeled only the initial subset,
+  and `internal/ui/newdialog.go` had no OMP options panel/wiring.
+- Fix: `internal/session/tooloptions.go:323-450` models session mode/resume,
+  no-session, model/models, smol/slow/plan roles, thoughts, approval,
+  auto-approve, max-time, profile, and both imports. Configuration now supplies
+  default profile and role models. `internal/ui/ompoptions.go:12-173` exposes
+  every control and `internal/ui/home.go` persists the structured selection.
+  Documentation was updated in `docs/tools/omp.md` and the agent-deck skill
+  config reference.
+- Red-without-fix: parent production plus the session option tests failed to
+  compile on the absent fields (`SESSION_MUTATION_EXIT=1`); parent production
+  plus the UI tests failed on absent `NewOMPOptionsPanel`, dialog field, and
+  getter (`UI_MUTATION_EXIT=1`). Both are API-contract failures caused by the
+  reverted production hunks.
+- Preserved invariant: default managed sessions remain `--continue` and
+  instance-scoped; explicit `new`, `resume`, and `no-session` choices alter the
+  lifecycle flag without dropping shell quoting or model/config defaults.
 
-- Registered `omp` as a basename/token-matched built-in, avoiding substring false positives such as `compass`.
-- Added the approved adapter surfaces from reporter @khiladisngh's `feat/omp-native-support` branch: instance-scoped session directories, resume/restart, JSONL fork, environment/config, skills, TUI/Web discovery, and captured v17.3.8 status patterns.
-- Added an OMP-specific readiness arm that gives the captured busy marker priority, recognizes approval prompts, and otherwise preserves the previous generic fallback.
-- Added persistent per-session model options and `[omp].default_model`; the command builder emits shell-escaped `--model` before lifecycle flags.
-- Added `docs/tools/omp.md` and updated the bundled Agent Deck skill configuration reference.
+## 5. Web SkillsPane surface
 
-## Proof
+- Reproduction: no test executed or pinned the shipped JavaScript OMP support
+  branch and its attach/detach actions.
+- Root cause: `internal/web/static/app/panes/SkillsPane.js:16-74` was changed
+  without a Web-package regression test.
+- Fix: `internal/web/omp_skills_surface_test.go` reads the actual embedded JS
+  asset and pins the OMP support entry, supported rendering branch, and POST /
+  DELETE attach/detach actions.
+- Red-without-fix: after removing only `'omp'` from the embedded SkillsPane set
+  in `/tmp/r3-2054/mutation`, the test failed `embedded SkillsPane missing
+  "'omp'"` (`WEB_MUTATION_EXIT=1`).
+- Preserved invariant: unsupported tools still take the explicit unsupported
+  rendering branch; existing attach/detach endpoint behavior is unchanged.
 
-The originally failing regression tests now pass. Additional proof:
+## 6. Remote parity
 
-- `TestOMPLifecycle_LaunchSendRestart` passed in a Go 1.25 container with tmux installed. The fake binary proves launch, instance/model propagation, prompt delivery, response, restart, and resume from the same scoped JSONL directory.
-- Targeted OMP session, registry, tmux detector/pattern, and UI tests passed.
-- Required build/vet passed:
+- Reproduction: the remote/sandbox `CanForkOMP` branch returned true without a
+  lifecycle/fork assertion proving that target-side validation and options were
+  retained.
+- Root cause: `internal/session/omp.go:155-167` intentionally defers JSONL
+  validation to the target command, but no remote-shaped fork test covered the
+  resulting command.
+- Fix: `TestOMPForkCarriesModelAndHarnessOptions` uses an OMP instance with
+  `SSHHost` set, proves it reaches native fork creation without local filesystem
+  inspection, and asserts target-side `$HOME` session paths, `--fork`, model,
+  model cycle, profile, and persisted child options.
+- Red-without-fix: the isolated `omp.go` mutation failed the exact remote fork
+  assertions described in finding 2 (`FORK_MUTATION_EXIT=1`).
+- Preserved invariant: local forks remain fail-closed when no JSONL exists;
+  remote/sandbox forks retain runtime target-side validation because the local
+  process cannot safely inspect the target filesystem.
 
-```sh
-docker run --rm -v "$PWD":/src -w /src golang:1.25 sh -c 'git config --global --add safe.directory /src && go build ./... && go vet ./...'
-```
+## 7. GitHub intake metadata
 
-The prescribed screenshot gauntlet ran and produced frames under `/tmp/iss1977-proof.ZQLNTE/shots`, but the script hardcodes `/usr/local/bin/agent-deck` and host permissions prevented replacing that binary with the branch build. The run returned cached frames from the installed v1.14.0 binary, so they are explicitly not claimed or attached as proof of this patch. The changed OMP picker/settings/setup surfaces are covered by targeted UI tests.
+- Reproduction: the PR body used legacy headings and lacked the required intake
+  checklist and checked AI-disclosure choice.
+- Root cause: PR metadata had not been migrated to the current repository
+  template.
+- Fix/proof: `gh pr edit 2054` replaced the body with all required headings,
+  checklist, checked `AI-assisted`, named model, and gate marker; `gh pr view`
+  readback confirmed the exact persisted body.
+- Red-without-fix: metadata is not executable source and has no repository test;
+  the before/after `gh pr view` readbacks are the direct proof. This is the one
+  finding for which a code mutation test is inapplicable.
+- Preserved invariant: the body still closes #1977 and retains concrete build,
+  targeted-test, and mutation evidence; unchecked items were not falsely marked
+  complete.
 
-An attempted full run of `internal/session`, `internal/tmux`, and `internal/ui` exposed unrelated environment failures: the base image lacked tmux, and a read-only-directory test behaves differently as root. Targeted tests were rerun with tmux installed and passed; build/vet passed separately as required.
+## Verification summary
+
+- `go build ./... && go vet ./...`: PASS in `golang:1.25`.
+- Focused current-head tests in `internal/session`, `internal/tmux`,
+  `internal/ui`, and `internal/web`: PASS.
+- Pre-existing OMP builder/fork tests included in the focused session run: PASS.
+- Mutation exits: session 1, tmux 1, UI 1, Web 1, isolated fork 1, all for the
+  intended missing contract/assertions documented above.
+- No CHANGELOG or workflow files changed. PR was not merged.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -208,3 +208,27 @@ a stale base.
 - Preserved invariant: unsupported tools (`shell`, Gemini, Cursor) remain
   outside the native fork gate, and `Instance.CanFork()` still separately
   checks whether the particular session currently has forkable source state.
+
+### Go full-suite failure after 91164adc
+
+- Hosted reproduction: Go workflow `32634096274` ran 9,950 tests and failed
+  only `cmd/agent-deck/TestSessionFork_AdmitsOpenCode`, including both automatic
+  reruns. Main was green and the PR was zero behind.
+- Root cause: production had intentionally replaced five hand-maintained local
+  gate booleans with `session.SupportsNativeFork`, but the existing test still
+  asserted the exact deleted source string
+  `isOpenCodeFork := inst.Tool == "opencode"`. OpenCode remained admitted at
+  runtime; the test encoded implementation shape rather than behavior.
+- Fix: the existing test now calls the canonical capability contract for
+  OpenCode and retains its separate assertion that CLI dispatch routes through
+  `CreateForkedInstanceForTool`.
+- Red without fix: overlaying the corrected test onto `51338619` (before the
+  canonical helper) fails to compile with
+  `undefined: session.SupportsNativeFork` (`OPENCODE_TEST_MUTATION_EXIT=1`).
+  This proves the corrected test requires the production gate consolidation;
+  it is not a test-only tautology.
+- Preserved invariant: the dispatcher-wiring assertion remains, and the shared
+  table test still checks every supported and unsupported native-fork tool.
+- Re-verification: the exact failing test passes at current head. The whole
+  `cmd/agent-deck` race package was also run in a Go 1.25 container with tmux
+  installed, matching CI prerequisites.

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -140,3 +140,71 @@ Fix commit: `9f9883df` plus this results-only follow-up. All Go commands ran in
 - Mutation exits: session 1, tmux 1, UI 1, Web 1, isolated fork 1, all for the
   intended missing contract/assertions documented above.
 - No CHANGELOG or workflow files changed. PR was not merged.
+
+## Post-51338619 CI/Codex re-measurement
+
+This follow-up began by fetching `origin/main` and the PR branch. The measured
+relationship was `16 0` for `HEAD...origin/main`: the PR was 16 commits ahead
+and **zero behind**, so no rebase was necessary and no finding was attributed to
+a stale base.
+
+### golangci-lint — survived and fixed
+
+- Reproduction: both GitHub Actions run `32633307304` and an exact local
+  `golangci/golangci-lint:v2.13.1` container reported
+  `internal/tmux/tmux.go:920:3: ineffectual assignment to commandSeen`.
+- Root cause/fix: `isOMPCommand` returns immediately after inspecting the first
+  command-position token, making its `commandSeen = true` assignment dead. The
+  dead state was removed without changing command-position parsing.
+- Red without fix: `/tmp/r3-2054/mutation-lint` at `51338619` produced the
+  exact `ineffassign` diagnostic above. Current head reports `0 issues` under
+  the same linter image/version.
+- Preserved invariant: the existing alias/environment-prefix/false-positive
+  detector test remains green.
+
+### CodeQL log injection — suppressed, no source change
+
+- Re-measurement: current CodeQL CI is green. The historical alert's source is
+  session-controlled instance/path text; its sink is a `slog.String` attribute
+  passed through `logging.dynamicHandler` to Go's `slog.TextHandler` or
+  `slog.JSONHandler` (`internal/logging/logger.go:143-147,193-205`). There is no
+  raw string concatenation into the log stream.
+- Dynamic validation: a Go 1.25 reproduction passed embedded newline and CR
+  bytes through both production handler types. Both emitted exactly one record
+  and encoded the bytes as `\\n`/`\\r` inside the attribute.
+- Disposition: false positive, high confidence. No logging-boundary defect
+  exists, so no feature-branch change and no separate security PR are needed.
+- Durable validation report and PoC:
+  `/tmp/codex-security-scans/agent-deck/51338619_20260823T1025Z/artifacts/05_findings/codeql-log-injection/`.
+
+### CLI fork gate and configured command — already fixed, re-proved
+
+- The CLI gate contains the OMP path and
+  `TestSessionFork_OMPReachesNativeForkPath` passes at current head. Its original
+  red-without-fix proof remains commit `b1252e08`'s parent overlay: OMP was
+  rejected as `not forkable` before reaching native dispatch.
+- `resolveOMPCommand` treats persisted literal `omp` as the configured-command
+  sentinel, while retaining explicit per-session commands.
+  `TestBuildOMPCommand_ConfiguredCommandWinsForInitialStartAndRestart` passes at
+  current head; on `b1252e08`'s parent it failed because configured flags were
+  absent. No duplicate fix was added.
+
+### Other tool-gated command sweep
+
+- The fork command's hand-maintained five-way boolean gate was the only CLI
+  rejection gate of that shape. It now uses
+  `session.SupportsNativeFork`, the same canonical capability helper covering
+  Claude-compatible, Pi, OpenCode, Codex-compatible, and OMP dispatchers.
+- The sweep found one sibling surface bug: `session show --json` exposed
+  `can_fork` only inside its Claude block, so OMP/Pi/OpenCode/Codex sessions
+  silently omitted the capability. It now uses the same helper.
+- Red without fix:
+  - parent production plus `TestSupportsNativeForkCoversEveryDispatcher` fails
+    to compile because the canonical contract is absent
+    (`SUPPORT_GATE_MUTATION_EXIT=1`);
+  - restoring only `session_cmd.go` to the parent makes
+    `TestSessionShowJSONReportsOMPForkCapability` fail with a real OMP JSON
+    response lacking `can_fork`.
+- Preserved invariant: unsupported tools (`shell`, Gemini, Cursor) remain
+  outside the native fork gate, and `Instance.CanFork()` still separately
+  checks whether the particular session currently has forkable source state.

--- a/cmd/agent-deck/omp_fork_docs_test.go
+++ b/cmd/agent-deck/omp_fork_docs_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentDeckSkillDocumentsOMPForkSupport(t *testing.T) {
+	t.Parallel()
+
+	checks := map[string][]string{
+		filepath.Join("..", "..", "skills", "agent-deck", "SKILL.md"): {
+			"| `agent-deck session fork <name>` | Fork Claude/OpenCode/Pi/Codex/Oh My Pi conversation |",
+			"| `f/F` | Fork Claude/OpenCode/Pi/Codex/Oh My Pi session |",
+		},
+		filepath.Join("..", "..", "skills", "agent-deck", "references", "tui-reference.md"): {
+			"| `f` | Quick fork (Claude/OpenCode/Pi/Codex/Oh My Pi) |",
+			"| `F` | Fork with options (Claude/OpenCode/Pi/Codex/Oh My Pi) |",
+		},
+	}
+
+	for path, required := range checks {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, entry := range required {
+			if !strings.Contains(string(content), entry) {
+				t.Errorf("%s must advertise Oh My Pi fork support in %q", path, entry)
+			}
+		}
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -117,7 +117,7 @@ func printSessionHelp() {
 	fmt.Println("  unarchive <id|title>    Restore an archived session (does not restart it)")
 	fmt.Println("  restart [id] [--all] [--env KEY=VALUE]  Restart session (Claude: reload MCPs)")
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
-	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, or Codex session with context")
+	fmt.Println("  fork <id>               Fork Claude, OpenCode, Pi, Codex, or Oh My Pi session with context")
 	fmt.Println("  handoff <id>            Build a cross-tool handoff prompt from the session's conversation (read-only)")
 	fmt.Println("  attach <id>             Attach to session interactively")
 	fmt.Println("  focus <id> [--attach]   Signal the running TUI to select (or --attach) a session")
@@ -914,7 +914,7 @@ func handleSessionFork(profile string, args []string) {
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session fork <id|title> [options]")
 		fmt.Println()
-		fmt.Println("Fork a Claude, OpenCode, Pi, or Codex session with conversation context.")
+		fmt.Println("Fork a Claude, OpenCode, Pi, Codex, or Oh My Pi session with conversation context.")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -961,11 +961,7 @@ func handleSessionFork(profile string, args []string) {
 
 	// Verify this tool has a session-fork implementation.
 	isClaudeFork := session.IsClaudeCompatible(inst.Tool)
-	isPiFork := inst.Tool == "pi"
-	isOpenCodeFork := inst.Tool == "opencode"
-	isCodexFork := session.IsCodexCompatible(inst.Tool)
-	isOMPFork := inst.Tool == "omp"
-	if !isClaudeFork && !isPiFork && !isOpenCodeFork && !isCodexFork && !isOMPFork {
+	if !session.SupportsNativeFork(inst.Tool) {
 		out.Error(
 			fmt.Sprintf("session '%s' is not a forkable session (tool: %s)", inst.Title, inst.Tool),
 			ErrCodeInvalidOperation,
@@ -1675,9 +1671,11 @@ func handleSessionShow(profile string, args []string) {
 	// bug report against the wrong component.
 	jsonData["wrapper"] = inst.Wrapper
 
+	if session.SupportsNativeFork(inst.Tool) {
+		jsonData["can_fork"] = inst.CanFork()
+	}
 	if session.IsClaudeCompatible(inst.Tool) {
 		jsonData["claude_session_id"] = inst.ClaudeSessionID
-		jsonData["can_fork"] = inst.CanFork()
 		jsonData["can_restart"] = inst.CanRestart()
 
 		if mcps := mcpInfoForJSON(mcpInfo); mcps != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -964,7 +964,8 @@ func handleSessionFork(profile string, args []string) {
 	isPiFork := inst.Tool == "pi"
 	isOpenCodeFork := inst.Tool == "opencode"
 	isCodexFork := session.IsCodexCompatible(inst.Tool)
-	if !isClaudeFork && !isPiFork && !isOpenCodeFork && !isCodexFork {
+	isOMPFork := inst.Tool == "omp"
+	if !isClaudeFork && !isPiFork && !isOpenCodeFork && !isCodexFork && !isOMPFork {
 		out.Error(
 			fmt.Sprintf("session '%s' is not a forkable session (tool: %s)", inst.Title, inst.Tool),
 			ErrCodeInvalidOperation,

--- a/cmd/agent-deck/session_cmd_fork_state_test.go
+++ b/cmd/agent-deck/session_cmd_fork_state_test.go
@@ -618,14 +618,14 @@ func TestSessionFork_WithState_RoutesJujutsu(t *testing.T) {
 }
 
 func TestSessionFork_AdmitsOpenCode(t *testing.T) {
+	if !session.SupportsNativeFork("opencode") {
+		t.Fatal("fork capability gate must recognize opencode")
+	}
 	src, err := os.ReadFile("session_cmd.go")
 	if err != nil {
 		t.Fatalf("read session_cmd.go: %v", err)
 	}
 	s := string(src)
-	if !strings.Contains(s, `isOpenCodeFork := inst.Tool == "opencode"`) {
-		t.Fatal("fork gate must recognize opencode")
-	}
 	if !strings.Contains(s, "CreateForkedInstanceForTool") {
 		t.Fatal("fork dispatch must route through the shared cross-tool create method")
 	}

--- a/cmd/agent-deck/session_cmd_omp_fork_test.go
+++ b/cmd/agent-deck/session_cmd_omp_fork_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Behavioral red-path guard: a real forkable OMP record must pass the CLI's
+// tool gate and reach the shared native fork dispatcher.
+func TestSessionFork_OMPReachesNativeForkPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	parent := session.NewInstanceWithGroupAndTool("omp-parent", home, "omp-group", "omp")
+	parent.Command = "omp"
+	parentSessionDir := filepath.Join(home, ".omp", "agent-deck", parent.ID)
+	if err := os.MkdirAll(parentSessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent OMP session dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentSessionDir, "session.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write parent OMP JSONL: %v", err)
+	}
+
+	profile := "omp_fork_hook"
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+	if err := storage.SaveWithGroups([]*session.Instance{parent}, session.NewGroupTreeWithGroups([]*session.Instance{parent}, nil)); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	var capturedFork *session.Instance
+	oldHook := sessionForkBeforeStartHook
+	sessionForkBeforeStartHook = func(_ *session.Instance, forked *session.Instance, _ git.WorktreeStateOptions) {
+		capturedFork = forked
+	}
+	t.Cleanup(func() { sessionForkBeforeStartHook = oldHook })
+
+	handleSessionFork(profile, []string{"omp-parent", "-t", "omp-child"})
+
+	if capturedFork == nil || capturedFork.Tool != "omp" {
+		t.Fatalf("CLI fork did not reach OMP dispatcher: %+v", capturedFork)
+	}
+	if !capturedFork.IsForkAwaitingStart || !strings.Contains(capturedFork.ForkStartCommand, `omp --fork "$source_file"`) {
+		t.Fatalf("captured OMP native fork command = %q", capturedFork.ForkStartCommand)
+	}
+}

--- a/cmd/agent-deck/session_show_omp_capability_test.go
+++ b/cmd/agent-deck/session_show_omp_capability_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSessionShowJSONReportsOMPForkCapability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	project := filepath.Join(home, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := runAgentDeck(t, home, "add", "-t", "omp-show", "-c", "omp", "--no-parent", "--json", project)
+	if code != 0 {
+		t.Fatalf("add failed (%d): %s\n%s", code, stdout, stderr)
+	}
+	var added struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &added); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code = runAgentDeck(t, home, "session", "show", added.ID, "--json")
+	if code != 0 {
+		t.Fatalf("show failed (%d): %s\n%s", code, stdout, stderr)
+	}
+	var shown map[string]any
+	if err := json.Unmarshal([]byte(stdout), &shown); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := shown["can_fork"]; !ok {
+		t.Fatalf("OMP session show omitted can_fork: %s", stdout)
+	}
+}

--- a/docs/tools/omp.md
+++ b/docs/tools/omp.md
@@ -1,0 +1,21 @@
+# Oh My Pi (`omp`)
+
+Agent Deck recognizes the `omp` binary from [Oh My Pi](https://github.com/can1357/oh-my-pi) as a built-in tool. The integration was verified against `omp` v17.3.8.
+
+Each instance launches with `--continue --session-dir "$HOME/.omp/agent-deck/<instance-id>"`. This isolates conversations in the same workspace and lets restart resume the same conversation. Forking starts a child from the newest JSONL file in the parent instance directory.
+
+## Configuration
+
+```toml
+[omp]
+command = "omp"
+env_file = "~/.config/omp.env"
+default_model = "anthropic/claude-sonnet-4-6"
+approval_mode = "write" # always-ask | write | yolo
+```
+
+The new-session model field accepts any model identifier and passes it as `--model`; a per-session selection takes precedence over `default_model`. Other OMP flags can be included in `command`.
+
+## Status detection
+
+Agent Deck treats OMP's captured `⟨esc⟩` footer as busy and its `Allow tool:` dialog as waiting for input. These patterns came from v17.3.8; custom patterns remain available if a later OMP release changes its TUI vocabulary.

--- a/docs/tools/omp.md
+++ b/docs/tools/omp.md
@@ -11,10 +11,17 @@ Each instance launches with `--continue --session-dir "$HOME/.omp/agent-deck/<in
 command = "omp"
 env_file = "~/.config/omp.env"
 default_model = "anthropic/claude-sonnet-4-6"
+default_profile = "default"
 approval_mode = "write" # always-ask | write | yolo
+smol_model = "google/gemini-3-flash"
+slow_model = "anthropic/claude-opus-4-6"
+plan_model = "openai/gpt-5-codex"
 ```
 
-The new-session model field accepts any model identifier and passes it as `--model`; a per-session selection takes precedence over `default_model`. Other OMP flags can be included in `command`.
+The new-session dialog has first-class controls for session/no-session mode,
+primary and cycling models, role models, thought printing, approval and
+auto-approval, maximum duration, profile isolation, and Claude/Codex imports.
+A per-session selection takes precedence over the `[omp]` defaults.
 
 ## Status detection
 

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -60,6 +60,11 @@ func builtinTools() []builtinTool {
 		{Name: "gemini", Icon: "✨", detectSubstrings: []string{"gemini"}},
 		{Name: "codex", Icon: "💻", detectSubstrings: []string{"codex"}},
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
+		// Oh My Pi (github.com/can1357/oh-my-pi). Binary is `omp` (npm
+		// @oh-my-pi/pi-coding-agent, bin: "omp"). Token match only: "omp" as a
+		// substring would false-match "compass"/"accomplish"/"component" —
+		// the same reason "pi" and "dsh" are token-matched.
+		{Name: "omp", Icon: "⌥", detectTokens: []string{"omp"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
 		// detectTokens includes bare "agent" (standalone Cursor Agent CLI).

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -64,7 +64,7 @@ func builtinTools() []builtinTool {
 		// @oh-my-pi/pi-coding-agent, bin: "omp"). Token match only: "omp" as a
 		// substring would false-match "compass"/"accomplish"/"component" —
 		// the same reason "pi" and "dsh" are token-matched.
-		{Name: "omp", Icon: "⌥", detectTokens: []string{"omp"}},
+		{Name: "omp", Icon: "⌥", detectSubstrings: []string{"oh-my-pi", "@oh-my-pi/pi-coding-agent"}, detectTokens: []string{"omp"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
 		// detectTokens includes bare "agent" (standalone Cursor Agent CLI).

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -374,6 +374,95 @@ func TestCanRestartPi(t *testing.T) {
 	}
 }
 
+func TestCreateForkedOMPInstance_UsesNativeForkAndPersistsBaseCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	parent := NewInstanceWithTool("parent", "/tmp/project", "omp")
+	parent.ID = "parent-omp-id"
+	parent.GroupPath = "projects/omp"
+	parent.Command = "omp"
+	seedLocalOMPSessionFile(t, parent)
+
+	forked, cmd, err := parent.CreateForkedOMPInstanceWithOptions("forked", "", nil)
+	if err != nil {
+		t.Fatalf("CreateForkedOMPInstanceWithOptions() failed: %v", err)
+	}
+
+	if forked.Tool != "omp" {
+		t.Fatalf("forked.Tool = %q, want omp", forked.Tool)
+	}
+	if forked.GroupPath != "projects/omp" {
+		t.Fatalf("forked.GroupPath = %q, want inherited group", forked.GroupPath)
+	}
+	if forked.Command != "omp" {
+		t.Fatalf("forked.Command = %q, want base command for later --continue restarts", forked.Command)
+	}
+	if !forked.IsForkAwaitingStart {
+		t.Fatal("forked omp instance should carry IsForkAwaitingStart for first launch")
+	}
+	if forked.ForkStartCommand != cmd {
+		t.Fatalf("ForkStartCommand should hold the first-start fork command")
+	}
+
+	for _, want := range []string{
+		"parent_session_dir=${HOME}/.omp/agent-deck/parent-omp-id",
+		"session_dir=${HOME}/.omp/agent-deck/" + forked.ID,
+		`source_file=$(find "$parent_session_dir" -type f -name '*.jsonl' -exec ls -t {} +`,
+		`AGENTDECK_INSTANCE_ID=` + forked.ID,
+		`omp --fork "$source_file" --session-dir "$session_dir"`,
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("omp fork command = %q, want to contain %q", cmd, want)
+		}
+	}
+	if strings.Contains(cmd, "--continue") {
+		t.Fatalf("omp fork command must not include --continue: %s", cmd)
+	}
+
+	resumeCmd := forked.buildOMPCommand(forked.Command)
+	if !strings.Contains(resumeCmd, `omp --continue --session-dir "$session_dir"`) {
+		t.Fatalf("omp forked instance restart command should resume with --continue, got: %s", resumeCmd)
+	}
+	if strings.Contains(resumeCmd, "--fork") {
+		t.Fatalf("omp forked instance restart command must not replay --fork, got: %s", resumeCmd)
+	}
+}
+
+func TestCreateForkedOMPInstance_WorktreeOptions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	parent := NewInstanceWithTool("parent", "/tmp/project", "omp")
+	parent.ID = "parent-omp-id"
+	seedLocalOMPSessionFile(t, parent)
+
+	opts := &ClaudeOptions{
+		WorkDir:          "/tmp/project-wt",
+		WorktreePath:     "/tmp/project-wt",
+		WorktreeRepoRoot: "/tmp/project",
+		WorktreeBranch:   "fork/omp",
+	}
+	forked, _, err := parent.CreateForkedOMPInstanceWithOptions("forked", "custom", opts)
+	if err != nil {
+		t.Fatalf("CreateForkedOMPInstanceWithOptions() failed: %v", err)
+	}
+	if forked.ProjectPath != "/tmp/project-wt" {
+		t.Fatalf("forked.ProjectPath = %q, want worktree path", forked.ProjectPath)
+	}
+	if forked.WorktreePath != "/tmp/project-wt" || forked.WorktreeRepoRoot != "/tmp/project" || forked.WorktreeBranch != "fork/omp" {
+		t.Fatalf("forked worktree fields not copied: %+v", forked)
+	}
+}
+
+func TestCanForkOMP_RequiresLocalSessionFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := &Instance{ID: "no-session-omp", Tool: "omp"}
+	if inst.CanForkOMP() {
+		t.Fatal("CanForkOMP() should be false with no local session JSONL")
+	}
+	seedLocalOMPSessionFile(t, inst)
+	if !inst.CanForkOMP() {
+		t.Fatal("CanForkOMP() should be true once a local session JSONL exists")
+	}
+}
+
 func TestGetToolEnvFile_AllBuiltins(t *testing.T) {
 	cfg := &UserConfig{
 		Claude:   ClaudeSettings{EnvFile: "/tmp/claude.env"},

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -296,6 +296,17 @@ func TestBuildOMPCommand_AppliesApprovalMode(t *testing.T) {
 	}
 }
 
+func TestBuildOMPCommand_AppliesPerSessionModel(t *testing.T) {
+	inst := &Instance{ID: "model-test-id", Tool: "omp"}
+	if err := inst.SetOMPOptions(&OMPOptions{Model: "anthropic/claude-sonnet-4-6"}); err != nil {
+		t.Fatal(err)
+	}
+	got := inst.buildOMPCommand("omp")
+	if !strings.Contains(got, `omp --model anthropic/claude-sonnet-4-6 --continue`) {
+		t.Errorf("buildOMPCommand() = %q, want per-session --model before lifecycle flags", got)
+	}
+}
+
 func TestCanRestartOMP(t *testing.T) {
 	inst := &Instance{Tool: "omp", Status: StatusWaiting}
 	if !inst.CanRestart() {

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -265,6 +265,38 @@ func TestBuildOMPCommand_UsesInstanceScopedSessionDir(t *testing.T) {
 	}
 }
 
+func TestBuildOMPCommand_ConfiguredCommandWinsForInitialStartAndRestart(t *testing.T) {
+	restore := resetUserConfigCache(t, &UserConfig{OMP: OMPSettings{Command: "/opt/omp-custom --channel nightly"}})
+	defer restore()
+
+	// TUI/Web creation persists the built-in preset literally. Both Start and
+	// Restart dispatch through buildOMPCommand with this stored value.
+	inst := &Instance{ID: "configured-omp", Tool: "omp", Command: "omp"}
+	for _, phase := range []string{"initial start", "restart"} {
+		got := inst.buildOMPCommand(inst.Command)
+		if !strings.Contains(got, "/opt/omp-custom --channel nightly --continue") {
+			t.Fatalf("%s ignored [omp].command flags: %q", phase, got)
+		}
+		if strings.Contains(got, " AGENTDECK_PROFILE=default omp --continue") {
+			t.Fatalf("%s used persisted default instead of configured command: %q", phase, got)
+		}
+	}
+}
+
+func TestBuildOMPCommand_ExplicitSessionOverrideWinsOverConfig(t *testing.T) {
+	restore := resetUserConfigCache(t, &UserConfig{OMP: OMPSettings{Command: "/opt/omp-configured --flag"}})
+	defer restore()
+
+	inst := &Instance{ID: "override-omp", Tool: "omp", Command: "/tmp/omp-session --local"}
+	got := inst.buildOMPCommand(inst.Command)
+	if !strings.Contains(got, "/tmp/omp-session --local --continue") {
+		t.Fatalf("explicit per-session command was not preserved: %q", got)
+	}
+	if strings.Contains(got, "/opt/omp-configured") {
+		t.Fatalf("configured command replaced explicit per-session override: %q", got)
+	}
+}
+
 func TestBuildOMPCommand_QuotesInstanceIDPathComponent(t *testing.T) {
 	inst := &Instance{ID: "test instance'id", Tool: "omp"}
 	got := inst.buildOMPCommand("omp")

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -283,6 +283,19 @@ func TestBuildOMPCommand_WrongTool(t *testing.T) {
 	}
 }
 
+func TestBuildOMPCommand_AppliesApprovalMode(t *testing.T) {
+	cfg := &UserConfig{OMP: OMPSettings{ApprovalMode: "yolo"}}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{ID: "approval-test-id", Tool: "omp"}
+	got := inst.buildOMPCommand("omp")
+
+	if !strings.Contains(got, `--approval-mode yolo`) {
+		t.Errorf("buildOMPCommand() = %q, want to contain %q", got, "--approval-mode yolo")
+	}
+}
+
 func TestCanRestartOMP(t *testing.T) {
 	inst := &Instance{Tool: "omp", Status: StatusWaiting}
 	if !inst.CanRestart() {

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -32,7 +32,7 @@ func TestGetToolCommand_NoConfig(t *testing.T) {
 	ClearUserConfigCache()
 	defer ClearUserConfigCache()
 
-	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes"}
+	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes", "omp"}
 	for _, tool := range tools {
 		got := GetToolCommand(tool)
 		if got != tool {
@@ -49,6 +49,7 @@ func TestGetToolCommand_WithOverride(t *testing.T) {
 		Codex:    CodexSettings{Command: "codex --experimental"},
 		Copilot:  CopilotSettings{Command: "gh copilot"},
 		Hermes:   HermesSettings{Command: "hermes --model gpt-5.5-pro --provider openai"},
+		OMP:      OMPSettings{Command: "omp --smol haiku"},
 	}
 	restore := resetUserConfigCache(t, cfg)
 	defer restore()
@@ -63,13 +64,26 @@ func TestGetToolCommand_WithOverride(t *testing.T) {
 		{"codex", "codex --experimental"},
 		{"copilot", "gh copilot"},
 		{"hermes", "hermes --model gpt-5.5-pro --provider openai"},
+		{"omp", "omp --smol haiku"},
 	}
-
 	for _, tt := range tests {
 		got := GetToolCommand(tt.tool)
 		if got != tt.expected {
 			t.Errorf("GetToolCommand(%q) = %q, want %q", tt.tool, got, tt.expected)
 		}
+	}
+}
+
+func TestGetToolIcon_OMP(t *testing.T) {
+	icon := GetToolIcon("omp")
+	if icon == "" {
+		t.Error("GetToolIcon(\"omp\") returned empty")
+	}
+	if icon == GetToolIcon("shell") {
+		t.Errorf("GetToolIcon(\"omp\") = %q equals shell fallback (want a distinct icon)", icon)
+	}
+	if icon == GetToolIcon("pi") {
+		t.Errorf("GetToolIcon(\"omp\") = %q must not collide with the unrelated \"pi\" tool's icon", icon)
 	}
 }
 

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -229,6 +229,67 @@ func TestBuildPiCommand_WrongTool(t *testing.T) {
 	}
 }
 
+func seedLocalOMPSessionFile(t *testing.T, inst *Instance) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HOME"), ".omp", "agent-deck", inst.ID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir omp session dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write omp session file: %v", err)
+	}
+}
+
+func TestBuildOMPCommand_UsesInstanceScopedSessionDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	inst := &Instance{ID: "test-instance-id", Tool: "omp"}
+	got := inst.buildOMPCommand("omp")
+
+	wantSessionDir := "${HOME}/.omp/agent-deck/test-instance-id"
+	for _, want := range []string{
+		"session_dir=" + wantSessionDir,
+		"mkdir -p \"$session_dir\"",
+		"AGENTDECK_INSTANCE_ID=test-instance-id",
+		"omp --continue --session-dir \"$session_dir\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildOMPCommand() = %q, want to contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, tmpDir) {
+		t.Errorf("buildOMPCommand() must use target-side $HOME, got host path in %q", got)
+	}
+}
+
+func TestBuildOMPCommand_QuotesInstanceIDPathComponent(t *testing.T) {
+	inst := &Instance{ID: "test instance'id", Tool: "omp"}
+	got := inst.buildOMPCommand("omp")
+
+	wantSessionDir := `${HOME}/.omp/agent-deck/` + shellescape.Quote(inst.ID)
+	if !strings.Contains(got, "session_dir="+wantSessionDir) {
+		t.Errorf("buildOMPCommand() should quote instance ID path component %q, got %q", wantSessionDir, got)
+	}
+}
+
+func TestBuildOMPCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	got := inst.buildOMPCommand("some-command")
+	if got != "some-command" {
+		t.Errorf("buildOMPCommand with wrong tool = %q, want %q", got, "some-command")
+	}
+}
+
+func TestCanRestartOMP(t *testing.T) {
+	inst := &Instance{Tool: "omp", Status: StatusWaiting}
+	if !inst.CanRestart() {
+		t.Fatal("omp sessions should be restartable so Agent Deck can relaunch with --continue")
+	}
+}
+
 func TestCreateForkedPiInstance_UsesNativeForkAndPersistsBaseCommand(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	parent := NewInstanceWithTool("parent", "/tmp/project", "pi")

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -609,6 +609,8 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Copilot.EnvFile
 	case "crush":
 		return config.Crush.EnvFile
+	case "omp":
+		return config.OMP.EnvFile
 	case "cursor":
 		return config.Cursor.EnvFile
 	case "hermes":

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -9581,6 +9581,12 @@ func (i *Instance) CanFork() bool {
 		return i.CanForkPi()
 	}
 
+	// omp sessions fork by source JSONL path under Agent Deck's per-instance
+	// omp session directory, identical shape to Pi's fork gate.
+	if i.Tool == "omp" {
+		return i.CanForkOMP()
+	}
+
 	// Codex-compatible sessions fork via `codex fork <sid>`, gated on a
 	// flushed on-disk rollout (same invariant as `codex resume`).
 	if IsCodexCompatible(i.Tool) {
@@ -9816,6 +9822,8 @@ func (i *Instance) CreateForkedInstanceForTool(newTitle, newGroupPath string, op
 		return i.CreateForkedOpenCodeInstanceWithOptionsAndWorkDir(newTitle, newGroupPath, nil, workDir, repoRoot, branch)
 	case i.Tool == "pi":
 		return i.CreateForkedPiInstanceWithOptions(newTitle, newGroupPath, opts)
+	case i.Tool == "omp":
+		return i.CreateForkedOMPInstanceWithOptions(newTitle, newGroupPath, opts)
 	case IsCodexCompatible(i.Tool):
 		return i.CreateForkedCodexInstanceWithOptions(newTitle, newGroupPath, opts)
 	default:

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -9569,7 +9569,17 @@ func (i *Instance) CanRestartFresh() bool {
 	return i.CanRestartGeneric()
 }
 
-// CanFork returns true if this session can be forked
+// SupportsNativeFork reports whether tool has a concrete native fork
+// dispatcher. Keep CLI/API capability gates routed through this helper so a
+// newly supported tool cannot be admitted by Instance.CanFork while remaining
+// rejected or hidden at another surface.
+func SupportsNativeFork(tool string) bool {
+	return IsClaudeCompatible(tool) || tool == "pi" || tool == "opencode" ||
+		IsCodexCompatible(tool) || tool == "omp"
+}
+
+// CanFork returns true if this session currently has the source state needed
+// by its native fork implementation.
 func (i *Instance) CanFork() bool {
 	// Gemini CLI doesn't support forking
 	if i.Tool == "gemini" {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4843,6 +4843,16 @@ func (i *Instance) Start() error {
 			break
 		}
 		command = i.buildPiCommand(i.Command)
+	case i.Tool == "omp":
+		if i.IsForkAwaitingStart {
+			command = i.consumeForkStartCommand()
+			sessionLog.Info("resume: none reason=fork_awaiting_start",
+				slog.String("instance_id", i.ID),
+				slog.String("path", i.ProjectPath),
+				slog.String("reason", "fork_awaiting_start"))
+			break
+		}
+		command = i.buildOMPCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "cursor":
@@ -5152,6 +5162,16 @@ func (i *Instance) StartWithMessage(message string) error {
 			break
 		}
 		command = i.buildPiCommand(i.Command)
+	case i.Tool == "omp":
+		if i.IsForkAwaitingStart {
+			command = i.consumeForkStartCommand()
+			sessionLog.Info("resume: none reason=fork_awaiting_start",
+				slog.String("instance_id", i.ID),
+				slog.String("path", i.ProjectPath),
+				slog.String("reason", "fork_awaiting_start"))
+			break
+		}
+		command = i.buildOMPCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "crush":
@@ -8989,6 +9009,8 @@ func (i *Instance) restart(env map[string]string) error {
 			i.CodexStartedAt = time.Now().UnixMilli()
 		case i.Tool == "pi":
 			command = i.buildPiCommand(i.Command)
+		case i.Tool == "omp":
+			command = i.buildOMPCommand(i.Command)
 		case i.Tool == "copilot":
 			command = i.buildCopilotCommand(i.Command)
 		case i.Tool == "crush":
@@ -9453,6 +9475,13 @@ func (i *Instance) CanRestart() bool {
 	// Pi sessions are scoped to an Agent Deck instance-specific session dir and
 	// can always be relaunched with --continue.
 	if i.Tool == "pi" {
+		return true
+	}
+
+	// omp sessions are scoped to an Agent Deck instance-specific session dir
+	// and can always be relaunched with --continue (verified live: --continue
+	// on a fresh empty --session-dir starts a new session gracefully).
+	if i.Tool == "omp" {
 		return true
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -9338,7 +9338,7 @@ func (i *Instance) SetGeminiModel(model string) error {
 // SupportsLaunchModel reports whether a newly-created session can receive an
 // explicit model override through Agent Deck's generic session creation path.
 func SupportsLaunchModel(tool string) bool {
-	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "opencode" || IsCodexCompatible(tool)
+	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "opencode" || tool == "omp" || IsCodexCompatible(tool)
 }
 
 // ApplyLaunchModel stores a per-session model override in the tool-specific
@@ -9369,6 +9369,14 @@ func (i *Instance) ApplyLaunchModel(model string) error {
 		}
 		opts.Model = model
 		return i.SetOpenCodeOptions(opts)
+	case i.Tool == "omp":
+		opts := i.GetOMPOptions()
+		if opts == nil {
+			userConfig, _ := LoadUserConfig()
+			opts = NewOMPOptions(userConfig)
+		}
+		opts.Model = model
+		return i.SetOMPOptions(opts)
 	case IsCodexCompatible(i.Tool):
 		opts := i.GetCodexOptions()
 		if opts == nil {
@@ -9408,6 +9416,13 @@ func (i *Instance) ClearLaunchModel() error {
 		}
 		opts.Model = ""
 		return i.SetOpenCodeOptions(opts)
+	case i.Tool == "omp":
+		opts := i.GetOMPOptions()
+		if opts == nil {
+			return nil
+		}
+		opts.Model = ""
+		return i.SetOMPOptions(opts)
 	case IsCodexCompatible(i.Tool):
 		opts := i.GetCodexOptions()
 		if opts == nil {
@@ -10286,6 +10301,27 @@ func (i *Instance) GetOpenCodeOptions() *OpenCodeOptions {
 
 // SetOpenCodeOptions stores OpenCode-specific options
 func (i *Instance) SetOpenCodeOptions(opts *OpenCodeOptions) error {
+	if opts == nil {
+		i.ToolOptionsJSON = nil
+		return nil
+	}
+	data, err := MarshalToolOptions(opts)
+	if err != nil {
+		return err
+	}
+	i.ToolOptionsJSON = data
+	return nil
+}
+
+func (i *Instance) GetOMPOptions() *OMPOptions {
+	opts, err := UnmarshalOMPOptions(i.ToolOptionsJSON)
+	if err != nil {
+		return nil
+	}
+	return opts
+}
+
+func (i *Instance) SetOMPOptions(opts *OMPOptions) error {
 	if opts == nil {
 		i.ToolOptionsJSON = nil
 		return nil

--- a/internal/session/issue1977_omp_test.go
+++ b/internal/session/issue1977_omp_test.go
@@ -1,0 +1,16 @@
+package session
+
+import "testing"
+
+func TestIssue1977_OMPIsRecognizedAsBuiltin(t *testing.T) {
+	r := Init(nil)
+
+	for _, command := range []string{"omp", "omp --model sonnet", "/usr/local/bin/omp --continue"} {
+		if got := r.Match(command); got != "omp" {
+			t.Errorf("Match(%q) = %q, want omp", command, got)
+		}
+	}
+	if !r.IsBuiltin("omp") {
+		t.Error("IsBuiltin(\"omp\") = false, want true")
+	}
+}

--- a/internal/session/model_info.go
+++ b/internal/session/model_info.go
@@ -32,6 +32,10 @@ func (i *Instance) LaunchModelID() string {
 		if opts := i.GetOpenCodeOptions(); opts != nil {
 			return strings.TrimSpace(opts.Model)
 		}
+	case i.Tool == "omp":
+		if opts := i.GetOMPOptions(); opts != nil {
+			return strings.TrimSpace(opts.Model)
+		}
 	case IsCodexCompatible(i.Tool):
 		if opts := i.GetCodexOptions(); opts != nil {
 			return strings.TrimSpace(opts.Model)

--- a/internal/session/native_fork_support_test.go
+++ b/internal/session/native_fork_support_test.go
@@ -1,0 +1,16 @@
+package session
+
+import "testing"
+
+func TestSupportsNativeForkCoversEveryDispatcher(t *testing.T) {
+	for _, tool := range []string{"claude", "pi", "opencode", "codex", "omp"} {
+		if !SupportsNativeFork(tool) {
+			t.Errorf("SupportsNativeFork(%q) = false", tool)
+		}
+	}
+	for _, tool := range []string{"shell", "gemini", "cursor"} {
+		if SupportsNativeFork(tool) {
+			t.Errorf("SupportsNativeFork(%q) = true without a native dispatcher", tool)
+		}
+	}
+}

--- a/internal/session/omp.go
+++ b/internal/session/omp.go
@@ -71,8 +71,7 @@ func resolveOMPCommand(baseCommand string) string {
 	return cmd
 }
 
-// ompApprovalModeFlag returns the ` --approval-mode <value>` suffix for the
-// configured [omp].approval_mode, or "" when unset.
+// ompArgsSuffix shell-quotes a structured OMP argument list for the target.
 func ompArgsSuffix(args []string) string {
 	if len(args) == 0 {
 		return ""

--- a/internal/session/omp.go
+++ b/internal/session/omp.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+// Oh My Pi (`omp`) adapter.
+//
+// github.com/can1357/oh-my-pi (npm @oh-my-pi/pi-coding-agent, MIT) is a fork
+// of badlogic/pi-mono's "Pi", rewritten as a batteries-included coding-agent
+// CLI. The binary is `omp`:
+//
+//	omp                                  # interactive TUI
+//	omp -p "prompt"                      # non-interactive, prints and exits
+//	omp --session-dir <dir> --continue   # resume/start the session in <dir>
+//	omp --session-dir <dir> --fork <src.jsonl>  # fork <src.jsonl> into <dir>
+//	omp --approval-mode always-ask|write|yolo   # permission gating
+//
+// Verified LIVE against the real installed binary (v17.3.8) via a PTY:
+// `--session-dir <dir> --continue` on a brand-new empty <dir> starts a fresh
+// session there; on a populated <dir> it resumes with full context; and
+// `--session-dir <newdir> --fork <path>` forks a source JSONL's context into
+// a new directory. This is a materially different on-disk layout from omp's
+// own DEFAULT session store (`~/.omp/agent/sessions/<encoded-cwd>/...`),
+// but --session-dir overrides it to a flat, single-purpose directory —
+// exactly the same shape agent-deck already relies on for the unrelated
+// "pi" tool. See docs/superpowers/plans/2026-08-20-oh-my-pi-native-support.md
+// for the full evidence trail.
+//
+// agent-deck scopes omp's session directory to the Agent Deck instance
+// (${HOME}/.omp/agent-deck/<instance-id>, a sibling of omp's own
+// ~/.omp/agent/ root — never inside it, to avoid colliding with omp's
+// default per-cwd session buckets) and always launches with --continue so
+// restarts resume that instance without colliding with other Agent Deck omp
+// sessions in the same project.
+
+// ompAgentDeckSessionDirExpr returns a target-shell expression for the omp
+// session directory Agent Deck owns for an instance. Uses target-side $HOME
+// rather than resolving the Agent Deck process' home directory, keeping
+// local, SSH, and sandbox launch paths consistent (mirrors
+// piAgentDeckSessionDirExpr).
+func ompAgentDeckSessionDirExpr(instanceID string) string {
+	return "${HOME}/.omp/agent-deck/" + shellescape.Quote(instanceID)
+}
+
+// GetOMPCommand returns the configured omp command/alias.
+// Mirrors GetCrushCommand: prefer the user config override, fall back to
+// the bare binary name.
+func GetOMPCommand() string {
+	userConfig, _ := LoadUserConfig()
+	if userConfig != nil && strings.TrimSpace(userConfig.OMP.Command) != "" {
+		return strings.TrimSpace(userConfig.OMP.Command)
+	}
+	return "omp"
+}
+
+// ompApprovalModeFlag returns the ` --approval-mode <value>` suffix for the
+// configured [omp].approval_mode, or "" when unset.
+func ompApprovalModeFlag() string {
+	config, _ := LoadUserConfig()
+	if config == nil {
+		return ""
+	}
+	mode := strings.TrimSpace(config.OMP.ApprovalMode)
+	if mode == "" {
+		return ""
+	}
+	return " --approval-mode " + shellescape.Quote(mode)
+}
+
+// buildOMPCommand builds the command for the Oh My Pi CLI.
+// omp sessions are JSONL files, not externally named sessions like
+// Claude/Codex. Scope omp's session directory to the Agent Deck instance and
+// always launch with --continue so restarts resume that instance without
+// colliding with other Agent Deck omp sessions in the same project.
+func (i *Instance) buildOMPCommand(baseCommand string) string {
+	if i.Tool != "omp" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" {
+		cmd = GetOMPCommand()
+	}
+
+	sessionDir := ompAgentDeckSessionDirExpr(i.ID)
+	quotedInstanceID := shellescape.Quote(i.ID)
+	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
+
+	return envPrefix + fmt.Sprintf(
+		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --continue --session-dir \"$session_dir\"%s",
+		sessionDir,
+		quotedInstanceID,
+		quotedProfile,
+		cmd,
+		ompApprovalModeFlag(),
+	)
+}

--- a/internal/session/omp.go
+++ b/internal/session/omp.go
@@ -92,13 +92,22 @@ func (i *Instance) buildOMPCommand(baseCommand string) string {
 	sessionDir := ompAgentDeckSessionDirExpr(i.ID)
 	quotedInstanceID := shellescape.Quote(i.ID)
 	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
+	modelFlag := ""
+	opts := i.GetOMPOptions()
+	if opts == nil {
+		config, _ := LoadUserConfig()
+		opts = NewOMPOptions(config)
+	}
+	if args := opts.ToArgs(); len(args) == 2 {
+		modelFlag = " --model " + shellescape.Quote(args[1])
+	}
 
 	return envPrefix + fmt.Sprintf(
 		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --continue --session-dir \"$session_dir\"%s",
 		sessionDir,
 		quotedInstanceID,
 		quotedProfile,
-		cmd,
+		cmd+modelFlag,
 		ompApprovalModeFlag(),
 	)
 }

--- a/internal/session/omp.go
+++ b/internal/session/omp.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"al.essio.dev/pkg/shellescape"
@@ -99,4 +101,112 @@ func (i *Instance) buildOMPCommand(baseCommand string) string {
 		cmd,
 		ompApprovalModeFlag(),
 	)
+}
+
+func (i *Instance) buildOMPForkCommandForTarget(target *Instance, baseCommand string) (string, error) {
+	if target == nil {
+		return "", fmt.Errorf("cannot build omp fork command: target instance is nil")
+	}
+	if !i.CanForkOMP() {
+		return "", fmt.Errorf("cannot fork: no Agent Deck omp session directory")
+	}
+
+	envPrefix := target.buildEnvSourceCommand()
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" {
+		cmd = GetOMPCommand()
+	}
+
+	parentSessionDir := ompAgentDeckSessionDirExpr(i.ID)
+	sessionDir := ompAgentDeckSessionDirExpr(target.ID)
+	quotedInstanceID := shellescape.Quote(target.ID)
+	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
+
+	return envPrefix + fmt.Sprintf(
+		"parent_session_dir=%s; session_dir=%s; mkdir -p \"$session_dir\" && source_file=$(find \"$parent_session_dir\" -type f -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head -n 1); if [ -z \"$source_file\" ]; then echo \"No omp session file found in $parent_session_dir\" >&2; exit 1; fi; AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --fork \"$source_file\" --session-dir \"$session_dir\"%s",
+		parentSessionDir,
+		sessionDir,
+		quotedInstanceID,
+		quotedProfile,
+		cmd,
+		ompApprovalModeFlag(),
+	), nil
+}
+
+// CanForkOMP returns true if this omp session can be forked by Agent Deck.
+func (i *Instance) CanForkOMP() bool {
+	if i.Tool != "omp" || i.ID == "" {
+		return false
+	}
+	// For local non-sandboxed omp sessions, require an actual source JSONL so
+	// CLI/TUI fork attempts fail before creating an immediately-dead child tmux
+	// pane. Remote/sandboxed sessions use target-side $HOME, which this process
+	// cannot inspect, so the launch command performs the runtime validation.
+	if i.SSHHost == "" && !i.IsSandboxed() {
+		return i.hasLocalOMPSessionFile()
+	}
+	return true
+}
+
+func (i *Instance) hasLocalOMPSessionFile() bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	sessionDir := filepath.Join(home, ".omp", "agent-deck", i.ID)
+	found := false
+	_ = filepath.WalkDir(sessionDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d == nil || d.IsDir() {
+			return nil
+		}
+		if strings.EqualFold(filepath.Ext(path), ".jsonl") {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// CreateForkedOMPInstanceWithOptions creates a new Instance configured for
+// forking an omp session. The opts parameter is accepted for the shared fork
+// worktree flow; only WorkDir and Worktree* fields are consumed for omp.
+func (i *Instance) CreateForkedOMPInstanceWithOptions(
+	newTitle, newGroupPath string,
+	opts *ClaudeOptions,
+) (*Instance, string, error) {
+	projectPath := i.ProjectPath
+	if opts != nil && opts.WorkDir != "" {
+		projectPath = opts.WorkDir
+	}
+
+	forked := NewInstance(newTitle, projectPath)
+	if newGroupPath != "" {
+		forked.GroupPath = newGroupPath
+	} else {
+		forked.GroupPath = i.GroupPath
+	}
+	forked.Tool = "omp"
+	forked.Wrapper = i.Wrapper
+
+	baseCommand := strings.TrimSpace(i.Command)
+	if baseCommand == "" {
+		baseCommand = GetOMPCommand()
+	}
+	forked.Command = baseCommand
+
+	cmd, err := i.buildOMPForkCommandForTarget(forked, baseCommand)
+	if err != nil {
+		return nil, "", err
+	}
+	forked.ForkStartCommand = cmd
+	forked.IsForkAwaitingStart = true
+
+	if opts != nil && opts.WorktreePath != "" {
+		forked.WorktreePath = opts.WorktreePath
+		forked.WorktreeRepoRoot = opts.WorktreeRepoRoot
+		forked.WorktreeBranch = opts.WorktreeBranch
+	}
+
+	return forked, cmd, nil
 }

--- a/internal/session/omp.go
+++ b/internal/session/omp.go
@@ -59,6 +59,18 @@ func GetOMPCommand() string {
 	return "omp"
 }
 
+// resolveOMPCommand treats the bare built-in name as the default-command
+// sentinel. Session creation surfaces persist that name, so consulting the
+// configured command only for an empty string would silently ignore
+// [omp].command. Any other stored command is an explicit per-session override.
+func resolveOMPCommand(baseCommand string) string {
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" || cmd == "omp" {
+		return GetOMPCommand()
+	}
+	return cmd
+}
+
 // ompApprovalModeFlag returns the ` --approval-mode <value>` suffix for the
 // configured [omp].approval_mode, or "" when unset.
 func ompApprovalModeFlag() string {
@@ -84,10 +96,7 @@ func (i *Instance) buildOMPCommand(baseCommand string) string {
 	}
 
 	envPrefix := i.buildEnvSourceCommand()
-	cmd := strings.TrimSpace(baseCommand)
-	if cmd == "" {
-		cmd = GetOMPCommand()
-	}
+	cmd := resolveOMPCommand(baseCommand)
 
 	sessionDir := ompAgentDeckSessionDirExpr(i.ID)
 	quotedInstanceID := shellescape.Quote(i.ID)
@@ -121,10 +130,7 @@ func (i *Instance) buildOMPForkCommandForTarget(target *Instance, baseCommand st
 	}
 
 	envPrefix := target.buildEnvSourceCommand()
-	cmd := strings.TrimSpace(baseCommand)
-	if cmd == "" {
-		cmd = GetOMPCommand()
-	}
+	cmd := resolveOMPCommand(baseCommand)
 
 	parentSessionDir := ompAgentDeckSessionDirExpr(i.ID)
 	sessionDir := ompAgentDeckSessionDirExpr(target.ID)
@@ -198,10 +204,7 @@ func (i *Instance) CreateForkedOMPInstanceWithOptions(
 	forked.Tool = "omp"
 	forked.Wrapper = i.Wrapper
 
-	baseCommand := strings.TrimSpace(i.Command)
-	if baseCommand == "" {
-		baseCommand = GetOMPCommand()
-	}
+	baseCommand := resolveOMPCommand(i.Command)
 	forked.Command = baseCommand
 
 	cmd, err := i.buildOMPForkCommandForTarget(forked, baseCommand)

--- a/internal/session/omp.go
+++ b/internal/session/omp.go
@@ -73,16 +73,15 @@ func resolveOMPCommand(baseCommand string) string {
 
 // ompApprovalModeFlag returns the ` --approval-mode <value>` suffix for the
 // configured [omp].approval_mode, or "" when unset.
-func ompApprovalModeFlag() string {
-	config, _ := LoadUserConfig()
-	if config == nil {
+func ompArgsSuffix(args []string) string {
+	if len(args) == 0 {
 		return ""
 	}
-	mode := strings.TrimSpace(config.OMP.ApprovalMode)
-	if mode == "" {
-		return ""
+	quoted := make([]string, len(args))
+	for idx, arg := range args {
+		quoted[idx] = shellescape.Quote(arg)
 	}
-	return " --approval-mode " + shellescape.Quote(mode)
+	return " " + strings.Join(quoted, " ")
 }
 
 // buildOMPCommand builds the command for the Oh My Pi CLI.
@@ -101,23 +100,22 @@ func (i *Instance) buildOMPCommand(baseCommand string) string {
 	sessionDir := ompAgentDeckSessionDirExpr(i.ID)
 	quotedInstanceID := shellescape.Quote(i.ID)
 	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
-	modelFlag := ""
 	opts := i.GetOMPOptions()
 	if opts == nil {
 		config, _ := LoadUserConfig()
 		opts = NewOMPOptions(config)
 	}
-	if args := opts.ToArgs(); len(args) == 2 {
-		modelFlag = " --model " + shellescape.Quote(args[1])
-	}
+	harnessSuffix := ompArgsSuffix(opts.harnessArgs())
+	lifecycleSuffix := ompArgsSuffix(opts.sessionArgs())
 
 	return envPrefix + fmt.Sprintf(
-		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --continue --session-dir \"$session_dir\"%s",
+		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s%s%s --session-dir \"$session_dir\"",
 		sessionDir,
 		quotedInstanceID,
 		quotedProfile,
-		cmd+modelFlag,
-		ompApprovalModeFlag(),
+		cmd,
+		harnessSuffix,
+		lifecycleSuffix,
 	)
 }
 
@@ -136,6 +134,12 @@ func (i *Instance) buildOMPForkCommandForTarget(target *Instance, baseCommand st
 	sessionDir := ompAgentDeckSessionDirExpr(target.ID)
 	quotedInstanceID := shellescape.Quote(target.ID)
 	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
+	opts := target.GetOMPOptions()
+	if opts == nil {
+		config, _ := LoadUserConfig()
+		opts = NewOMPOptions(config)
+	}
+	argsSuffix := ompArgsSuffix(opts.harnessArgs())
 
 	return envPrefix + fmt.Sprintf(
 		"parent_session_dir=%s; session_dir=%s; mkdir -p \"$session_dir\" && source_file=$(find \"$parent_session_dir\" -type f -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head -n 1); if [ -z \"$source_file\" ]; then echo \"No omp session file found in $parent_session_dir\" >&2; exit 1; fi; AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --fork \"$source_file\" --session-dir \"$session_dir\"%s",
@@ -144,7 +148,7 @@ func (i *Instance) buildOMPForkCommandForTarget(target *Instance, baseCommand st
 		quotedInstanceID,
 		quotedProfile,
 		cmd,
-		ompApprovalModeFlag(),
+		argsSuffix,
 	), nil
 }
 
@@ -206,6 +210,13 @@ func (i *Instance) CreateForkedOMPInstanceWithOptions(
 
 	baseCommand := resolveOMPCommand(i.Command)
 	forked.Command = baseCommand
+	if parentOpts := i.GetOMPOptions(); parentOpts != nil {
+		copied := *parentOpts
+		copied.Models = append([]string(nil), parentOpts.Models...)
+		if err := forked.SetOMPOptions(&copied); err != nil {
+			return nil, "", err
+		}
+	}
 
 	cmd, err := i.buildOMPForkCommandForTarget(forked, baseCommand)
 	if err != nil {

--- a/internal/session/omp_lifecycle_test.go
+++ b/internal/session/omp_lifecycle_test.go
@@ -19,15 +19,18 @@ func TestOMPLifecycle_LaunchSendRestart(t *testing.T) {
 	}
 
 	t.Setenv("HOME", t.TempDir())
-	withConfig(t, &UserConfig{OMP: OMPSettings{Command: fake, DefaultModel: "test/model"}})
+	withConfig(t, &UserConfig{OMP: OMPSettings{Command: fake + " --configured-marker yes", DefaultModel: "test/model"}})
 	inst := NewInstanceWithTool("omp-lifecycle", t.TempDir(), "omp")
+	// TUI/Web preset creation persists this literal built-in command. The
+	// configured executable and flags must still be authoritative.
+	inst.Command = "omp"
 	t.Cleanup(func() { _ = inst.Kill() })
 
 	if err := inst.Start(); err != nil {
 		t.Fatalf("Start(): %v", err)
 	}
 	started := waitForPane(t, inst, "OMP started", 15*time.Second)
-	if !strings.Contains(started, "model=test/model") || !strings.Contains(started, "instance="+inst.ID) {
+	if !strings.Contains(started, "model=test/model") || !strings.Contains(started, "instance="+inst.ID) || !strings.Contains(started, "configured=yes") {
 		t.Fatalf("launch did not propagate model and instance identity:\n%s", started)
 	}
 	if err := inst.tmuxSession.SendKeysAndEnter("hello omp"); err != nil {
@@ -38,5 +41,8 @@ func TestOMPLifecycle_LaunchSendRestart(t *testing.T) {
 	if err := inst.Restart(); err != nil {
 		t.Fatalf("Restart(): %v", err)
 	}
-	waitForPane(t, inst, "OMP resumed", 15*time.Second)
+	resumed := waitForPane(t, inst, "OMP resumed", 15*time.Second)
+	if !strings.Contains(resumed, "configured=yes") {
+		t.Fatalf("restart ignored configured OMP command flags:\n%s", resumed)
+	}
 }

--- a/internal/session/omp_lifecycle_test.go
+++ b/internal/session/omp_lifecycle_test.go
@@ -1,0 +1,42 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOMPLifecycle_LaunchSendRestart(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	fake, err := filepath.Abs(filepath.Join("testdata", "fake-omp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(fake); err != nil || info.Mode()&0o111 == 0 {
+		t.Fatalf("fake-omp must exist and be executable: %v", err)
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	withConfig(t, &UserConfig{OMP: OMPSettings{Command: fake, DefaultModel: "test/model"}})
+	inst := NewInstanceWithTool("omp-lifecycle", t.TempDir(), "omp")
+	t.Cleanup(func() { _ = inst.Kill() })
+
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+	started := waitForPane(t, inst, "OMP started", 15*time.Second)
+	if !strings.Contains(started, "model=test/model") || !strings.Contains(started, "instance="+inst.ID) {
+		t.Fatalf("launch did not propagate model and instance identity:\n%s", started)
+	}
+	if err := inst.tmuxSession.SendKeysAndEnter("hello omp"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	waitForPane(t, inst, "answered: hello omp", 15*time.Second)
+
+	if err := inst.Restart(); err != nil {
+		t.Fatalf("Restart(): %v", err)
+	}
+	waitForPane(t, inst, "OMP resumed", 15*time.Second)
+}

--- a/internal/session/omp_round3_test.go
+++ b/internal/session/omp_round3_test.go
@@ -1,0 +1,52 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryMatchesSupportedOMPLaunchers(t *testing.T) {
+	r := Init(nil)
+	for _, cmd := range []string{"omp", "oh-my-pi", "npx @oh-my-pi/pi-coding-agent --model opus"} {
+		if got := r.Match(cmd); got != "omp" {
+			t.Fatalf("Match(%q) = %q, want omp", cmd, got)
+		}
+	}
+}
+
+func TestOMPOptionsExposeCompleteHarnessSurface(t *testing.T) {
+	opts := &OMPOptions{SessionMode: "resume", ResumeID: "s-1", Model: "main", Models: []string{"a", "b"}, SmolModel: "small", SlowModel: "deep", PlanModel: "planner", PrintThoughts: true, ApprovalMode: "write", AutoApprove: true, MaxTime: "10m", Profile: "isolated", FromClaude: true, FromCodex: true}
+	got := strings.Join(opts.ToArgs(), " ")
+	for _, want := range []string{"--resume s-1", "--model main", "--models a,b", "--smol small", "--slow deep", "--plan planner", "--print-thoughts", "--approval-mode write", "--auto-approve", "--max-time 10m", "--profile isolated", "--from-claude", "--from-codex"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("args %q missing %q", got, want)
+		}
+	}
+}
+
+func TestOMPForkCarriesModelAndHarnessOptions(t *testing.T) {
+	parent := NewInstance("parent", "/tmp/project")
+	parent.ID, parent.Tool, parent.SSHHost = "parent-id", "omp", "remote"
+	if err := parent.SetOMPOptions(&OMPOptions{Model: "review/model", Models: []string{"fast", "slow"}, Profile: "review"}); err != nil {
+		t.Fatal(err)
+	}
+	child, cmd, err := parent.CreateForkedOMPInstanceWithOptions("child", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"--model review/model", "--models fast,slow", "--profile review", "--fork"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("fork command %q missing %q", cmd, want)
+		}
+	}
+	if child.GetOMPOptions() == nil || child.GetOMPOptions().Model != "review/model" {
+		t.Fatal("fork did not persist inherited OMP options")
+	}
+}
+
+func TestNewOMPOptionsAppliesRoleAndProfileDefaults(t *testing.T) {
+	opts := NewOMPOptions(&UserConfig{OMP: OMPSettings{DefaultModel: "main", DefaultProfile: "work", ApprovalMode: "write", SmolModel: "small", SlowModel: "slow", PlanModel: "plan"}})
+	if opts.SessionMode != "continue" || opts.Profile != "work" || opts.SmolModel != "small" || opts.SlowModel != "slow" || opts.PlanModel != "plan" {
+		t.Fatalf("defaults not applied: %+v", opts)
+	}
+}

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -34,6 +34,13 @@ const (
 	defaultSkillSourceClaude = "claude-global"
 )
 
+// projectOMPSkillsDir is the project-local skills directory Oh My Pi
+// discovers on its own (`.omp/skills/<name>/SKILL.md` — a directory-per-skill
+// shape matching Claude's own convention, confirmed against the upstream
+// repo's own `.omp/skills/semantic-compression/SKILL.md` layout), distinct
+// from the flat AGENTS.md-adjacent dir gemini/codex/pi share.
+const projectOMPSkillsDir = ".omp/skills"
+
 var (
 	ErrSkillSourceExists    = errors.New("skill source already exists")
 	ErrSkillSourceNotFound  = errors.New("skill source not found")
@@ -131,7 +138,7 @@ func skillIDForAttachment(a ProjectSkillAttachment) string {
 }
 
 func knownProjectSkillsDirs() []string {
-	return []string{projectClaudeSkillsDir, projectAgentsSkillsDir, projectHermesSkillsDir}
+	return []string{projectClaudeSkillsDir, projectAgentsSkillsDir, projectHermesSkillsDir, projectOMPSkillsDir}
 }
 
 // SupportsProjectSkills reports whether the runtime supports project skill materialization.
@@ -155,6 +162,8 @@ func GetProjectSkillsDir(tool string) (string, bool) {
 		return projectAgentsSkillsDir, true
 	case tool == "hermes":
 		return projectHermesSkillsDir, true
+	case tool == "omp":
+		return projectOMPSkillsDir, true
 	default:
 		return "", false
 	}

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -794,3 +794,13 @@ func TestAttachSkill_PluginManifestDirIsAttachable(t *testing.T) {
 		t.Fatalf("expected symlink materialized: %v", err)
 	}
 }
+
+func TestGetProjectSkillsDir_OMP(t *testing.T) {
+	dir, ok := GetProjectSkillsDir("omp")
+	if !ok {
+		t.Fatal("GetProjectSkillsDir(\"omp\") should be supported")
+	}
+	if dir != ".omp/skills" {
+		t.Errorf("GetProjectSkillsDir(\"omp\") = %q, want \".omp/skills\"", dir)
+	}
+}

--- a/internal/session/testdata/fake-omp
+++ b/internal/session/testdata/fake-omp
@@ -3,12 +3,14 @@ set -eu
 
 session_dir=
 model=
+configured_marker=
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --session-dir) session_dir=$2; shift 2 ;;
     --model) model=$2; shift 2 ;;
     --continue) shift ;;
     --approval-mode) shift 2 ;;
+    --configured-marker) configured_marker=$2; shift 2 ;;
     *) shift ;;
   esac
 done
@@ -17,10 +19,10 @@ done
 mkdir -p "$session_dir"
 transcript="$session_dir/session.jsonl"
 if [ -s "$transcript" ]; then
-  echo "OMP resumed model=$model instance=$AGENTDECK_INSTANCE_ID"
+  echo "OMP resumed model=$model instance=$AGENTDECK_INSTANCE_ID configured=$configured_marker"
 else
   echo '{"type":"session"}' > "$transcript"
-  echo "OMP started model=$model instance=$AGENTDECK_INSTANCE_ID"
+  echo "OMP started model=$model instance=$AGENTDECK_INSTANCE_ID configured=$configured_marker"
 fi
 printf 'omp> '
 while IFS= read -r line; do

--- a/internal/session/testdata/fake-omp
+++ b/internal/session/testdata/fake-omp
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+session_dir=
+model=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --session-dir) session_dir=$2; shift 2 ;;
+    --model) model=$2; shift 2 ;;
+    --continue) shift ;;
+    --approval-mode) shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+[ -n "$session_dir" ] || { echo "missing --session-dir" >&2; exit 2; }
+mkdir -p "$session_dir"
+transcript="$session_dir/session.jsonl"
+if [ -s "$transcript" ]; then
+  echo "OMP resumed model=$model instance=$AGENTDECK_INSTANCE_ID"
+else
+  echo '{"type":"session"}' > "$transcript"
+  echo "OMP started model=$model instance=$AGENTDECK_INSTANCE_ID"
+fi
+printf 'omp> '
+while IFS= read -r line; do
+  printf '\n⠋ Working… ⟨esc⟩'
+  sleep 1
+  printf '\r\033[Kanswered: %s\nomp> ' "$line"
+  printf '{"type":"message"}\n' >> "$transcript"
+done

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -322,22 +322,112 @@ func UnmarshalOpenCodeOptions(data json.RawMessage) (*OpenCodeOptions, error) {
 
 // OMPOptions holds per-session launch options for Oh My Pi.
 type OMPOptions struct {
-	Model string `json:"model,omitempty"`
+	SessionMode   string   `json:"session_mode,omitempty"`
+	ResumeID      string   `json:"resume_id,omitempty"`
+	NoSession     bool     `json:"no_session,omitempty"`
+	Model         string   `json:"model,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	SmolModel     string   `json:"smol_model,omitempty"`
+	SlowModel     string   `json:"slow_model,omitempty"`
+	PlanModel     string   `json:"plan_model,omitempty"`
+	PrintThoughts bool     `json:"print_thoughts,omitempty"`
+	ApprovalMode  string   `json:"approval_mode,omitempty"`
+	AutoApprove   bool     `json:"auto_approve,omitempty"`
+	MaxTime       string   `json:"max_time,omitempty"`
+	Profile       string   `json:"profile,omitempty"`
+	FromClaude    bool     `json:"from_claude,omitempty"`
+	FromCodex     bool     `json:"from_codex,omitempty"`
 }
 
 func (o *OMPOptions) ToolName() string { return "omp" }
 
 func (o *OMPOptions) ToArgs() []string {
-	if o == nil || strings.TrimSpace(o.Model) == "" {
+	return o.toArgs(true)
+}
+
+func (o *OMPOptions) harnessArgs() []string {
+	return o.toArgs(false)
+}
+
+func (o *OMPOptions) sessionArgs() []string {
+	if o == nil {
+		return []string{"--continue"}
+	}
+	if o.NoSession {
+		return []string{"--no-session"}
+	}
+	switch o.SessionMode {
+	case "new":
+		return nil
+	case "resume":
+		args := []string{"--resume"}
+		if id := strings.TrimSpace(o.ResumeID); id != "" {
+			args = append(args, id)
+		}
+		return args
+	default:
+		return []string{"--continue"}
+	}
+}
+
+func (o *OMPOptions) toArgs(includeSession bool) []string {
+	if o == nil {
 		return nil
 	}
-	return []string{"--model", strings.TrimSpace(o.Model)}
+	var args []string
+	if includeSession && o.NoSession {
+		args = append(args, "--no-session")
+	} else if includeSession {
+		switch o.SessionMode {
+		case "new":
+		case "resume":
+			args = append(args, "--resume")
+			if id := strings.TrimSpace(o.ResumeID); id != "" {
+				args = append(args, id)
+			}
+		default:
+			args = append(args, "--continue")
+		}
+	}
+	appendValue := func(flag, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			args = append(args, flag, value)
+		}
+	}
+	appendValue("--model", o.Model)
+	if len(o.Models) > 0 {
+		appendValue("--models", strings.Join(o.Models, ","))
+	}
+	appendValue("--smol", o.SmolModel)
+	appendValue("--slow", o.SlowModel)
+	appendValue("--plan", o.PlanModel)
+	if o.PrintThoughts {
+		args = append(args, "--print-thoughts")
+	}
+	appendValue("--approval-mode", o.ApprovalMode)
+	if o.AutoApprove {
+		args = append(args, "--auto-approve")
+	}
+	appendValue("--max-time", o.MaxTime)
+	appendValue("--profile", o.Profile)
+	if o.FromClaude {
+		args = append(args, "--from-claude")
+	}
+	if o.FromCodex {
+		args = append(args, "--from-codex")
+	}
+	return args
 }
 
 func NewOMPOptions(config *UserConfig) *OMPOptions {
-	opts := &OMPOptions{}
+	opts := &OMPOptions{SessionMode: "continue"}
 	if config != nil {
 		opts.Model = config.OMP.DefaultModel
+		opts.Profile = config.OMP.DefaultProfile
+		opts.ApprovalMode = config.OMP.ApprovalMode
+		opts.SmolModel = config.OMP.SmolModel
+		opts.SlowModel = config.OMP.SlowModel
+		opts.PlanModel = config.OMP.PlanModel
 	}
 	return opts
 }

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 // ToolOptions is the interface for tool-specific launch options
@@ -316,6 +317,46 @@ func UnmarshalOpenCodeOptions(data json.RawMessage) (*OpenCodeOptions, error) {
 		return nil, err
 	}
 
+	return &opts, nil
+}
+
+// OMPOptions holds per-session launch options for Oh My Pi.
+type OMPOptions struct {
+	Model string `json:"model,omitempty"`
+}
+
+func (o *OMPOptions) ToolName() string { return "omp" }
+
+func (o *OMPOptions) ToArgs() []string {
+	if o == nil || strings.TrimSpace(o.Model) == "" {
+		return nil
+	}
+	return []string{"--model", strings.TrimSpace(o.Model)}
+}
+
+func NewOMPOptions(config *UserConfig) *OMPOptions {
+	opts := &OMPOptions{}
+	if config != nil {
+		opts.Model = config.OMP.DefaultModel
+	}
+	return opts
+}
+
+func UnmarshalOMPOptions(data json.RawMessage) (*OMPOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+	if wrapper.Tool != "omp" {
+		return nil, nil
+	}
+	var opts OMPOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
 	return &opts, nil
 }
 

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -463,7 +463,7 @@ func ConfiguredHiddenToolNames() []string {
 }
 
 // pickerPresetOrder matches buildPresetCommands in internal/ui/newdialog.go.
-var pickerPresetOrder = []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+var pickerPresetOrder = []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "omp"}
 
 // PickerToolNames returns tool names for the new-session picker after applying
 // hidden_tools and show_only_installed_tools. The empty command "" is mapped

--- a/internal/session/toolregistry_installed_test.go
+++ b/internal/session/toolregistry_installed_test.go
@@ -381,3 +381,21 @@ func TestPickerToolNames_MapsShellAlias(t *testing.T) {
 		}
 	}
 }
+
+func TestPickerToolNames_IncludesOMP(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	got := PickerToolNames()
+	found := false
+	for _, name := range got {
+		if name == "omp" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("PickerToolNames() = %v, want to contain %q", got, "omp")
+	}
+}

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -8,7 +8,7 @@ import (
 // canonicalBuiltins is the canonical built-in set, in the precedence order that
 // Registry.Match() (and the legacy detectTool() switch) walk.
 var canonicalBuiltins = []string{
-	"claude", "opencode", "gemini", "codex", "pi",
+	"claude", "opencode", "gemini", "codex", "pi", "omp",
 	"copilot", "crush", "cursor", "hermes", "deepseek", "aider", "shell",
 }
 
@@ -52,6 +52,13 @@ func TestRegistry_MatchAllBranches(t *testing.T) {
 		{"pi uppercase", "Pi", "pi"},
 		{"pi no false match in epic", "epic", "shell"},
 		{"pi no false match in tapioca", "tapioca", "shell"},
+		// omp — whitespace-token match, NOT substring
+		{"omp bare", "omp", "omp"},
+		{"omp with flags", "omp --model sonnet", "omp"},
+		{"omp uppercase", "Omp", "omp"},
+		{"omp no false match in compass", "compass", "shell"},
+		{"omp no false match in accomplish", "accomplish", "shell"},
+		{"omp no false match in component", "component", "shell"},
 		// copilot
 		{"copilot with flags", "copilot --resume", "copilot"},
 		// crush

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2126,7 +2126,11 @@ type DeepSeekSettings struct {
 // internal/session/omp.go for the full invocation grammar this block feeds.
 type OMPSettings struct {
 	// DefaultModel is passed as --model unless a session has its own override.
-	DefaultModel string `toml:"default_model,omitempty"`
+	DefaultModel   string `toml:"default_model,omitempty"`
+	DefaultProfile string `toml:"default_profile,omitempty"`
+	SmolModel      string `toml:"smol_model,omitempty"`
+	SlowModel      string `toml:"slow_model,omitempty"`
+	PlanModel      string `toml:"plan_model,omitempty"`
 
 	// Command overrides the default binary/invocation for omp sessions.
 	// Supports flags (e.g., "omp --smol haiku"). Unlike buildCrushCommand's

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -158,6 +158,9 @@ type UserConfig struct {
 	// DeepSeek defines DeepSeek Harness (`dsh`) integration settings
 	DeepSeek DeepSeekSettings `toml:"deepseek,omitempty"`
 
+	// OMP defines Oh My Pi (`omp`, github.com/can1357/oh-my-pi) integration settings
+	OMP OMPSettings `toml:"omp,omitempty"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree,omitempty"`
 
@@ -2116,6 +2119,30 @@ type DeepSeekSettings struct {
 	ExtraArgs []string `toml:"extra_args,omitempty"`
 }
 
+// OMPSettings defines Oh My Pi (`omp`) integration configuration.
+//
+// Binary: `omp` from npm @oh-my-pi/pi-coding-agent (github.com/can1357/oh-my-pi,
+// MIT, a fork of badlogic/pi-mono). Verified against v17.3.8. See
+// internal/session/omp.go for the full invocation grammar this block feeds.
+type OMPSettings struct {
+	// Command overrides the default binary/invocation for omp sessions.
+	// Supports flags (e.g., "omp --smol haiku"). A value other than the bare
+	// binary name is treated as a passthrough and receives no flag injection
+	// (mirrors buildCrushCommand/buildPiCommand). Default: "omp"
+	Command string `toml:"command,omitempty"`
+
+	// EnvFile is a .env file specific to omp sessions, sourced before the
+	// `omp` command runs (like [gemini].env_file). This is where an
+	// ANTHROPIC_API_KEY/OPENAI_API_KEY belongs when it should not live in
+	// the user's shell.
+	EnvFile string `toml:"env_file,omitempty"`
+
+	// ApprovalMode maps directly to omp's `--approval-mode` flag
+	// ("always-ask", "write", or "yolo"). Empty (default) omits the flag
+	// entirely, so omp uses its own configured default.
+	ApprovalMode string `toml:"approval_mode,omitempty"`
+}
+
 // CursorSettings defines Cursor Agent CLI integration configuration (Issue #1672).
 type CursorSettings struct {
 	// Command overrides the default binary/invocation for Cursor sessions.
@@ -3707,6 +3734,10 @@ func GetToolCommand(toolName string) string {
 		if config.Hermes.Command != "" {
 			return config.Hermes.Command
 		}
+	case "omp":
+		if config.OMP.Command != "" {
+			return config.OMP.Command
+		}
 	case "deepseek":
 		// The tool is named for the vendor; the binary it launches is `dsh`.
 		// Returning the tool name here (the default tail of this function)
@@ -3757,6 +3788,8 @@ func GetToolIcon(toolName string) string {
 		return "🐋"
 	case "pi":
 		return "π"
+	case "omp":
+		return "⌥"
 	case "shell":
 		return "🐚"
 	default:

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2126,9 +2126,10 @@ type DeepSeekSettings struct {
 // internal/session/omp.go for the full invocation grammar this block feeds.
 type OMPSettings struct {
 	// Command overrides the default binary/invocation for omp sessions.
-	// Supports flags (e.g., "omp --smol haiku"). A value other than the bare
-	// binary name is treated as a passthrough and receives no flag injection
-	// (mirrors buildCrushCommand/buildPiCommand). Default: "omp"
+	// Supports flags (e.g., "omp --smol haiku"). Unlike buildCrushCommand's
+	// true passthrough, buildOMPCommand always appends --continue
+	// --session-dir (mirroring buildPiCommand) regardless of this value —
+	// there is no passthrough branch for omp/pi. Default: "omp"
 	Command string `toml:"command,omitempty"`
 
 	// EnvFile is a .env file specific to omp sessions, sourced before the

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2125,6 +2125,9 @@ type DeepSeekSettings struct {
 // MIT, a fork of badlogic/pi-mono). Verified against v17.3.8. See
 // internal/session/omp.go for the full invocation grammar this block feeds.
 type OMPSettings struct {
+	// DefaultModel is passed as --model unless a session has its own override.
+	DefaultModel string `toml:"default_model,omitempty"`
+
 	// Command overrides the default binary/invocation for omp sessions.
 	// Supports flags (e.g., "omp --smol haiku"). Unlike buildCrushCommand's
 	// true passthrough, buildOMPCommand always appends --continue

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -88,11 +88,26 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 	case "deepseek":
 		return d.hasDeepSeekPrompt(content)
 
+	case "omp":
+		return d.hasOMPPrompt(content)
+
 	default:
 		// Generic shell - check for common prompts
 		return d.hasShellPrompt(content)
 	}
 }
+
+func (d *PromptDetector) hasOMPPrompt(content string) bool {
+	if strings.Contains(content, "⟨esc⟩") {
+		return false
+	}
+	if ompApprovalPrompt.MatchString(content) {
+		return true
+	}
+	return d.hasShellPrompt(content)
+}
+
+var ompApprovalPrompt = regexp.MustCompile(`(?m)^\s*Allow tool:\s`)
 
 // hasDeepSeekPrompt detects a DeepSeek Harness pane that is waiting.
 //

--- a/internal/tmux/issue1977_omp_test.go
+++ b/internal/tmux/issue1977_omp_test.go
@@ -1,0 +1,30 @@
+package tmux
+
+import "testing"
+
+func TestIssue1977_OMPHasStatusPatterns(t *testing.T) {
+	raw := DefaultRawPatterns("omp")
+	if raw == nil {
+		t.Fatal("DefaultRawPatterns(\"omp\") = nil, want omp-specific patterns")
+	}
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("omp has no busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("omp has no prompt patterns")
+	}
+}
+
+func TestIssue1977_OMPReadinessUsesCapturedTUIStates(t *testing.T) {
+	d := NewPromptDetector("omp")
+
+	busy := "╭── Sonnet 5 · high ──╮\n⠋ Working… ⟨esc⟩"
+	if d.HasPrompt(busy) {
+		t.Fatal("busy omp pane was classified as waiting")
+	}
+
+	waiting := "Allow tool: bash\nCommand: echo hi\n\n  Approve\n   Deny"
+	if !d.HasPrompt(waiting) {
+		t.Fatal("omp approval prompt was not classified as waiting")
+	}
+}

--- a/internal/tmux/omp_round3_test.go
+++ b/internal/tmux/omp_round3_test.go
@@ -1,0 +1,18 @@
+package tmux
+
+import "testing"
+
+func TestDetectToolFromCommandOMPSupportedLaunchersAndNoArgumentFalsePositive(t *testing.T) {
+	tests := map[string]string{
+		"omp":                           "omp",
+		"oh-my-pi --model opus":         "omp",
+		"npx @oh-my-pi/pi-coding-agent": "omp",
+		"env OMP_PROFILE=work npx @oh-my-pi/pi-coding-agent": "omp",
+		"grep omp README.md": "",
+	}
+	for command, want := range tests {
+		if got := detectToolFromCommand(command); got != want {
+			t.Errorf("detectToolFromCommand(%q) = %q, want %q", command, got, want)
+		}
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -146,6 +146,35 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				`re:(?mi)^dsh web:\s+https?://`,
 			},
 		}
+	case "omp":
+		// Oh My Pi (github.com/can1357/oh-my-pi). PROVENANCE — CAPTURED LIVE
+		// against the real installed binary (v17.3.8) via a PTY-driven omp
+		// session (not inferred from docs):
+		//
+		//   Busy    "⠋ Working… ⟨esc⟩" (generic) or "⠴ Echo hi ⟨esc⟩" (tool-
+		//           derived label). The stable anchor across every busy state
+		//           is the literal "⟨esc⟩" marker (U+27E8/U+27E9 angle
+		//           brackets), which is distinct from every other registered
+		//           tool's ascii "esc to interrupt" phrasing.
+		//   Waiting "Allow tool: bash\nCommand: echo hi\n\n  Approve\n   Deny\n\n
+		//           up/down navigate  enter select  esc cancel" — captured by
+		//           launching with --approval-mode always-ask and triggering
+		//           a bash tool call.
+		//
+		// No distinct idle-only literal string was found: the idle status bar
+		// is visually identical (same box-drawn border) whether busy or not,
+		// differing only in the presence/absence of the spinner+"⟨esc⟩" line
+		// beneath it, which BusyPatterns already covers. This mirrors "pi"
+		// and "deepseek", which also rely on busy-pattern absence for idle.
+		return &RawPatterns{
+			BusyPatterns: []string{
+				`re:⟨esc⟩`,
+			},
+			PromptPatterns: []string{
+				`re:(?m)^\s*Allow tool:\s`,
+			},
+			SpinnerChars: []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+		}
 	case "pi":
 		return &RawPatterns{
 			BusyPatterns: []string{

--- a/internal/tmux/patterns_test.go
+++ b/internal/tmux/patterns_test.go
@@ -173,6 +173,22 @@ func TestDefaultRawPatterns_PiSubagentSignals(t *testing.T) {
 	}
 }
 
+func TestDefaultRawPatterns_Omp(t *testing.T) {
+	raw := DefaultRawPatterns("omp")
+	if raw == nil {
+		t.Fatal("expected non-nil for omp")
+	}
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("omp should have busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("omp should have prompt patterns")
+	}
+	if len(raw.SpinnerChars) == 0 {
+		t.Error("omp should define spinner chars")
+	}
+}
+
 func TestDefaultRawPatterns_Unknown(t *testing.T) {
 	raw := DefaultRawPatterns("unknowntool")
 	if raw != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -907,17 +907,15 @@ func detectToolFromCommand(command string) string {
 // In particular, incidental argument text such as `grep omp README.md` is not
 // evidence that the pane runs OMP.
 func isOMPCommand(fields []string) bool {
-	commandSeen := false
 	for idx, field := range fields {
-		if !commandSeen && isShellAssignmentToken(field) {
+		if isShellAssignmentToken(field) {
 			continue
 		}
 		base := filepath.Base(strings.Trim(field, `"'`))
 		base = strings.TrimSuffix(strings.TrimSuffix(base, ".exe"), ".cmd")
-		if base == "env" && !commandSeen {
+		if base == "env" {
 			continue
 		}
-		commandSeen = true
 		if base == "omp" || base == "oh-my-pi" {
 			return true
 		}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -748,7 +748,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "deepseek", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "deepseek", "pi", "omp"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -806,6 +806,16 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		regexp.MustCompile(`(?i)\bpi\s+cli\b`),
 		regexp.MustCompile(`(?i)\bpi\s+code\b`),
 	},
+	"omp": {
+		// Oh My Pi (github.com/can1357/oh-my-pi). Captured LIVE against the
+		// real installed binary (v17.3.8) via a PTY: the busy/streaming
+		// status line always contains the literal "⟨esc⟩" marker (U+27E8/
+		// U+27E9 angle brackets — NOT ascii "<esc>"), and the tool-approval
+		// dialog always contains "Allow tool: ". Neither string collides with
+		// any other registered tool's vocabulary.
+		regexp.MustCompile(`⟨esc⟩`),
+		regexp.MustCompile(`(?m)^\s*Allow tool:\s`),
+	},
 	"cursor": {
 		// Cursor CLI agent TUI
 		regexp.MustCompile(`(?i)\bcursor\s+agent\b`),
@@ -848,6 +858,8 @@ func detectToolFromCommand(command string) string {
 			return "deepseek"
 		case "pi":
 			return "pi"
+		case "omp":
+			return "omp"
 		}
 	}
 
@@ -883,6 +895,8 @@ func detectToolFromCommand(command string) string {
 		return "deepseek"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
+	case strings.Contains(cmdLower, " omp ") || strings.HasPrefix(cmdLower, "omp "):
+		return "omp"
 	default:
 		return ""
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -858,7 +858,10 @@ func detectToolFromCommand(command string) string {
 			return "deepseek"
 		case "pi":
 			return "pi"
-		case "omp":
+		case "omp", "oh-my-pi":
+			return "omp"
+		}
+		if isOMPCommand(fields) {
 			return "omp"
 		}
 	}
@@ -895,11 +898,33 @@ func detectToolFromCommand(command string) string {
 		return "deepseek"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
-	case strings.Contains(cmdLower, " omp ") || strings.HasPrefix(cmdLower, "omp "):
-		return "omp"
 	default:
 		return ""
 	}
+}
+
+// isOMPCommand recognizes only supported OMP launchers in command position.
+// In particular, incidental argument text such as `grep omp README.md` is not
+// evidence that the pane runs OMP.
+func isOMPCommand(fields []string) bool {
+	commandSeen := false
+	for idx, field := range fields {
+		if !commandSeen && isShellAssignmentToken(field) {
+			continue
+		}
+		base := filepath.Base(strings.Trim(field, `"'`))
+		base = strings.TrimSuffix(strings.TrimSuffix(base, ".exe"), ".cmd")
+		if base == "env" && !commandSeen {
+			continue
+		}
+		commandSeen = true
+		if base == "omp" || base == "oh-my-pi" {
+			return true
+		}
+		return base == "npx" && idx+1 < len(fields) &&
+			strings.Trim(fields[idx+1], `"'`) == "@oh-my-pi/pi-coding-agent"
+	}
+	return false
 }
 
 // isDeepSeekCommand reports whether the first COMMAND-position token of a

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -638,6 +638,9 @@ func TestDetectToolFromCommand(t *testing.T) {
 		{name: "opencode", command: "open-code --continue", want: "opencode"},
 		{name: "codex", command: "codex --dangerously-bypass-approvals-and-sandbox", want: "codex"},
 		{name: "pi", command: "pi --model fast", want: "pi"},
+		{name: "omp", command: "omp --model sonnet", want: "omp"},
+		{name: "omp bare", command: "omp", want: "omp"},
+		{name: "omp no false match", command: "compass", want: ""},
 		{name: "cursor", command: "cursor agent", want: "cursor"},
 		{name: "standalone agent", command: "agent", want: "cursor"},
 		{name: "standalone agent flags", command: "agent --continue", want: "cursor"},
@@ -687,6 +690,24 @@ Yes, allow once`,
 			content: `Welcome to Pi CLI
 pi> `,
 			want: "pi",
+		},
+		{
+			name: "omp busy marker detects omp",
+			content: `╭──     Sonnet 5 · high   my-session   2.4%/1M  (sub) ────────────────────────╮
+╰─                                                                              ─╯
+ ⠋ Working… ⟨esc⟩`,
+			want: "omp",
+		},
+		{
+			name: "omp approval dialog detects omp",
+			content: ` Allow tool: bash
+ Command: echo hi
+
+  Approve
+   Deny
+
+ up/down navigate  enter select  esc cancel`,
+			want: "omp",
 		},
 	}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7907,6 +7907,8 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			yolo := h.newDialog.GetHermesYoloMode()
 			hermesOpts := &session.HermesOptions{YoloMode: &yolo}
 			toolOptionsJSON, _ = session.MarshalToolOptions(hermesOpts)
+		} else if command == "omp" {
+			toolOptionsJSON, _ = session.MarshalToolOptions(h.newDialog.GetOMPOptions())
 		}
 
 		parentSessionID := h.newDialog.GetParentSessionID()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12168,6 +12168,8 @@ func createSessionTool(command string) (string, string) {
 		tool = "opencode"
 	case "pi":
 		tool = "pi"
+	case "omp":
+		tool = "omp"
 	case "copilot":
 		tool = "copilot"
 	case "crush":

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -165,6 +165,7 @@ type NewDialog struct {
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
 	hermesOptions         *YoloOptionsPanel   // Hermes YOLO panel (concrete for value extraction).
+	ompOptions            *OMPOptionsPanel    // Full OMP harness controls.
 	toolOptions           OptionsPanel        // Currently active tool options panel (nil if none).
 	focusTargets          []focusTarget       // Ordered list of active focusable elements.
 	focusIndex            int                 // Index into focusTargets.
@@ -473,6 +474,7 @@ func NewNewDialog() *NewDialog {
 		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
 		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
 		hermesOptions:   NewYoloOptionsPanel("Hermes", "YOLO mode - auto-approve all tool calls"),
+		ompOptions:      NewOMPOptionsPanel(),
 		focusIndex:      0,
 		visible:         false,
 		presetCommands:  buildPresetCommands(),
@@ -571,10 +573,12 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.geminiOptions.SetDefaults(false)
 	d.codexOptions.SetDefaults(false)
 	d.hermesOptions.SetDefaults(false)
+	d.ompOptions.SetDefaults(nil)
 	if userConfig, err := session.LoadUserConfig(); err == nil && userConfig != nil {
 		d.geminiOptions.SetDefaults(userConfig.Gemini.YoloMode)
 		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode)
 		d.hermesOptions.SetDefaults(userConfig.Hermes.YoloMode)
+		d.ompOptions.SetDefaults(session.NewOMPOptions(userConfig))
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
 		d.worktreeEnabled = userConfig.Worktree.DefaultEnabled
@@ -1373,6 +1377,8 @@ func (d *NewDialog) updateModelPlaceholder() {
 		d.modelInput.Placeholder = "gemini-3.1-pro-preview"
 	case cmd == "opencode":
 		d.modelInput.Placeholder = "openai/gpt-5.5"
+	case cmd == "omp":
+		d.modelInput.Placeholder = "provider/model"
 	case session.IsCodexCompatible(cmd):
 		d.modelInput.Placeholder = "gpt-5.6-sol"
 	default:
@@ -1388,6 +1394,8 @@ func (d *NewDialog) modelInputHint() string {
 		return "Examples: gemini-3.1-pro-preview, gemini-3-flash-preview, gemini-2.5-pro"
 	case cmd == "opencode":
 		return "Examples: openai/gpt-5.5, openai/gpt-5.4, anthropic/claude-opus-5"
+	case cmd == "omp":
+		return "Primary model; use OMP Options below for multi-model and role routing"
 	case session.IsCodexCompatible(cmd):
 		return "Examples: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5"
 	default:
@@ -1420,6 +1428,14 @@ func (d *NewDialog) GetClaudeOptions() *session.ClaudeOptions {
 	opts := d.claudeOptions.GetOptions()
 	opts.Effort = d.GetLaunchReasoningEffort()
 	return opts
+}
+
+// GetOMPOptions returns every first-class OMP launch control from the dialog.
+func (d *NewDialog) GetOMPOptions() *session.OMPOptions {
+	if d.GetSelectedCommand() != "omp" {
+		return nil
+	}
+	return d.ompOptions.GetOptions(d.GetLaunchModelID())
 }
 
 // GetClaudeExtraArgs returns the user-supplied claude CLI tokens from the
@@ -1615,6 +1631,8 @@ func (d *NewDialog) updateToolOptions() {
 		d.toolOptions = d.codexOptions
 	case cmd == "hermes":
 		d.toolOptions = d.hermesOptions
+	case cmd == "omp":
+		d.toolOptions = d.ompOptions
 	default:
 		d.toolOptions = nil
 	}
@@ -1631,6 +1649,7 @@ func (d *NewDialog) updateFocus() {
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
 	d.hermesOptions.Blur()
+	d.ompOptions.Blur()
 
 	// Reset dropdown and soft-select state when focus changes.
 	d.pathSoftSelected = false

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -362,7 +362,7 @@ func displayCommandPreset(cmd string) string {
 // flag off FilterVisibleToolNames is a no-op, so the list is byte-identical to
 // before.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "omp"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -428,8 +428,8 @@ func TestDisplayCommandPreset(t *testing.T) {
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes, deepseek
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes, deepseek, omp
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "omp"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))

--- a/internal/ui/ompoptions.go
+++ b/internal/ui/ompoptions.go
@@ -1,0 +1,173 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// OMPOptionsPanel exposes OMP's harness controls without requiring raw commands.
+type OMPOptionsPanel struct {
+	inputs                                                       []textinput.Model
+	cursor                                                       int
+	focused                                                      bool
+	mode                                                         int
+	noSession, printThoughts, autoApprove, fromClaude, fromCodex bool
+}
+
+var ompInputLabels = []string{"Resume ID", "Models", "Smol model", "Slow model", "Plan model", "Approval mode", "Max time", "Profile"}
+var ompModes = []string{"continue", "new", "resume"}
+
+func NewOMPOptionsPanel() *OMPOptionsPanel {
+	p := &OMPOptionsPanel{}
+	for _, placeholder := range []string{"session id", "model-a,model-b", "fast model", "reasoning model", "planning model", "always-ask | write | yolo", "10m | 1h", "profile name"} {
+		in := textinput.New()
+		in.Placeholder = placeholder
+		in.CharLimit = 256
+		in.Width = 42
+		p.inputs = append(p.inputs, in)
+	}
+	return p
+}
+
+func (p *OMPOptionsPanel) SetDefaults(opts *session.OMPOptions) {
+	p.mode = 0
+	p.noSession, p.printThoughts, p.autoApprove, p.fromClaude, p.fromCodex = false, false, false, false, false
+	for idx := range p.inputs {
+		p.inputs[idx].SetValue("")
+	}
+	if opts == nil {
+		return
+	}
+	for idx, mode := range ompModes {
+		if mode == opts.SessionMode {
+			p.mode = idx
+		}
+	}
+	values := []string{opts.ResumeID, strings.Join(opts.Models, ","), opts.SmolModel, opts.SlowModel, opts.PlanModel, opts.ApprovalMode, opts.MaxTime, opts.Profile}
+	for idx, value := range values {
+		p.inputs[idx].SetValue(value)
+	}
+	p.noSession, p.printThoughts, p.autoApprove, p.fromClaude, p.fromCodex = opts.NoSession, opts.PrintThoughts, opts.AutoApprove, opts.FromClaude, opts.FromCodex
+}
+
+func (p *OMPOptionsPanel) GetOptions(model string) *session.OMPOptions {
+	var models []string
+	for _, value := range strings.Split(p.inputs[1].Value(), ",") {
+		if value = strings.TrimSpace(value); value != "" {
+			models = append(models, value)
+		}
+	}
+	return &session.OMPOptions{SessionMode: ompModes[p.mode], ResumeID: strings.TrimSpace(p.inputs[0].Value()), NoSession: p.noSession, Model: strings.TrimSpace(model), Models: models, SmolModel: strings.TrimSpace(p.inputs[2].Value()), SlowModel: strings.TrimSpace(p.inputs[3].Value()), PlanModel: strings.TrimSpace(p.inputs[4].Value()), PrintThoughts: p.printThoughts, ApprovalMode: strings.TrimSpace(p.inputs[5].Value()), AutoApprove: p.autoApprove, MaxTime: strings.TrimSpace(p.inputs[6].Value()), Profile: strings.TrimSpace(p.inputs[7].Value()), FromClaude: p.fromClaude, FromCodex: p.fromCodex}
+}
+
+func (p *OMPOptionsPanel) Focus() { p.focused = true; p.syncFocus() }
+func (p *OMPOptionsPanel) Blur() {
+	p.focused = false
+	for idx := range p.inputs {
+		p.inputs[idx].Blur()
+	}
+}
+func (p *OMPOptionsPanel) IsFocused() bool { return p.focused }
+func (p *OMPOptionsPanel) AtTop() bool     { return p.cursor == 0 }
+func (p *OMPOptionsPanel) FocusedLine() int {
+	if !p.focused {
+		return -1
+	}
+	return p.cursor + 1
+}
+func (p *OMPOptionsPanel) syncFocus() {
+	for idx := range p.inputs {
+		if p.focused && p.cursor == idx+2 {
+			p.inputs[idx].Focus()
+		} else {
+			p.inputs[idx].Blur()
+		}
+	}
+}
+
+func (p *OMPOptionsPanel) Update(msg tea.Msg) tea.Cmd {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return nil
+	}
+	if p.cursor >= 2 && p.cursor <= 9 {
+		switch key.String() {
+		case "up", "shift+tab":
+			p.cursor--
+			p.syncFocus()
+			return nil
+		case "down", "tab", "enter":
+			p.cursor++
+			p.syncFocus()
+			return nil
+		}
+		var cmd tea.Cmd
+		p.inputs[p.cursor-2], cmd = p.inputs[p.cursor-2].Update(msg)
+		return cmd
+	}
+	switch key.String() {
+	case "up", "shift+tab":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case "down", "tab", "enter":
+		if p.cursor < 13 {
+			p.cursor++
+		}
+	case "left":
+		if p.cursor == 0 {
+			p.mode = (p.mode + len(ompModes) - 1) % len(ompModes)
+		}
+	case "right", " ":
+		switch p.cursor {
+		case 0:
+			p.mode = (p.mode + 1) % len(ompModes)
+		case 1:
+			p.noSession = !p.noSession
+		case 10:
+			p.printThoughts = !p.printThoughts
+		case 11:
+			p.autoApprove = !p.autoApprove
+		case 12:
+			p.fromClaude = !p.fromClaude
+		case 13:
+			p.fromCodex = !p.fromCodex
+		}
+	}
+	p.syncFocus()
+	return nil
+}
+
+func (p *OMPOptionsPanel) View() string {
+	header := lipgloss.NewStyle().Foreground(ColorComment).Render("─ OMP Harness Options ─") + "\n"
+	line := func(idx int, value string) string {
+		marker := "  "
+		if p.focused && p.cursor == idx {
+			marker = "▶ "
+		}
+		return marker + value + "\n"
+	}
+	out := header + line(0, "Session mode: "+ompModes[p.mode]+"  (←/→)") + line(1, ompCheckbox("No session (ephemeral)", p.noSession))
+	for idx := range p.inputs {
+		out += line(idx+2, ompInputLabels[idx]+": "+p.inputs[idx].View())
+	}
+	for idx, item := range []struct {
+		label string
+		value bool
+	}{{"Print thoughts", p.printThoughts}, {"Auto approve", p.autoApprove}, {"Import from Claude", p.fromClaude}, {"Import from Codex", p.fromCodex}} {
+		out += line(idx+10, ompCheckbox(item.label, item.value))
+	}
+	return strings.TrimSuffix(out, "\n")
+}
+
+func ompCheckbox(label string, checked bool) string {
+	mark := " "
+	if checked {
+		mark = "x"
+	}
+	return "[" + mark + "] " + label
+}

--- a/internal/ui/ompoptions_test.go
+++ b/internal/ui/ompoptions_test.go
@@ -1,0 +1,40 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestOMPOptionsPanelExposesAndCapturesAllHarnessControls(t *testing.T) {
+	p := NewOMPOptionsPanel()
+	view := p.View()
+	for _, label := range []string{"Session mode", "No session", "Models", "Smol model", "Slow model", "Plan model", "Print thoughts", "Approval mode", "Auto approve", "Max time", "Profile", "Import from Claude", "Import from Codex"} {
+		if !strings.Contains(view, label) {
+			t.Errorf("OMP panel missing %q", label)
+		}
+	}
+	p.Focus()
+	p.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := p.GetOptions("primary"); got.SessionMode != "new" || got.Model != "primary" {
+		t.Fatalf("panel options = %+v", got)
+	}
+}
+
+func TestNewDialogSelectsOMPStructuredOptionsPanel(t *testing.T) {
+	d := NewNewDialog()
+	for idx, command := range d.presetCommands {
+		if command == "omp" {
+			d.commandCursor = idx
+			break
+		}
+	}
+	d.updateToolOptions()
+	if d.toolOptions != d.ompOptions {
+		t.Fatal("OMP selection did not expose structured options panel")
+	}
+	if d.GetOMPOptions() == nil {
+		t.Fatal("OMP selection did not produce structured options")
+	}
+}

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -352,7 +352,7 @@ func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
 			"claude": true, "gemini": true, "opencode": true,
 			"codex": true, "pi": true, "crush": true, "copilot": true,
 			"shell": true, "cursor": true, "aider": true, "hermes": true,
-			"deepseek": true,
+			"deepseek": true, "omp": true,
 		}
 		var custom []string
 		for name := range config.Tools {

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -120,8 +120,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "DeepSeek"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "DeepSeek", "Oh My Pi"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "omp"}
 )
 
 // Search tier names for radio selection

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -199,8 +199,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "DeepSeek", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "DeepSeek", "Oh My Pi", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "omp", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "deepseek"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "deepseek", "omp"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,
@@ -391,6 +391,7 @@ func (w *SetupWizard) View() string {
 			"opencode": "OpenCode - Open source AI coding tool",
 			"codex":    "Codex CLI - OpenAI's coding assistant",
 			"pi":       "Pi CLI - lightweight coding assistant",
+			"omp":      "Oh My Pi - batteries-included coding agent (omp)",
 			"crush":    "Crush - Charm's terminal-first AI coding assistant",
 			"shell":    "Shell - No AI tool (plain terminal)",
 			"cursor":   "Cursor Agent - Cursor CLI (agent / cursor agent)",

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "deepseek", "omp"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -191,6 +191,7 @@ const (
 	IconOpenCode = "🌐"
 	IconCodex    = "💻"
 	IconPi       = "π"
+	IconOMP      = "⌥"
 	IconShell    = "🐚"
 )
 
@@ -525,6 +526,7 @@ func initStyles() {
 		"hermes":   lipgloss.NewStyle().Foreground(ColorYellow),
 		"deepseek": lipgloss.NewStyle().Foreground(ColorCyan),
 		"pi":       lipgloss.NewStyle().Foreground(ColorAccent),
+		"omp":      lipgloss.NewStyle().Foreground(ColorAccent),
 		"aider":    lipgloss.NewStyle().Foreground(ColorRed),
 		"cursor":   lipgloss.NewStyle().Foreground(ColorAccent),
 		"shell":    lipgloss.NewStyle().Foreground(ColorText),
@@ -615,6 +617,8 @@ func ToolIcon(tool string) string {
 		return "🐋"
 	case "pi":
 		return IconPi
+	case "omp":
+		return IconOMP
 	case "shell":
 		return IconShell
 	default:
@@ -643,6 +647,8 @@ func ToolColor(tool string) lipgloss.Color {
 	case "deepseek":
 		return ColorCyan // DeepSeek Harness
 	case "pi":
+		return ColorAccent
+	case "omp":
 		return ColorAccent
 	case "aider":
 		return ColorRed // Red for Aider

--- a/internal/ui/tool_visibility_panel.go
+++ b/internal/ui/tool_visibility_panel.go
@@ -80,7 +80,7 @@ func (p *ToolVisibilityPanel) LoadConfig(config *session.UserConfig) {
 		builtins := map[string]bool{
 			"claude": true, "gemini": true, "opencode": true, "codex": true,
 			"pi": true, "copilot": true, "crush": true, "cursor": true, "hermes": true,
-			"deepseek": true, "shell": true, "aider": true,
+			"deepseek": true, "shell": true, "aider": true, "omp": true,
 		}
 		var custom []string
 		for name := range config.Tools {

--- a/internal/ui/tool_visibility_panel.go
+++ b/internal/ui/tool_visibility_panel.go
@@ -14,7 +14,7 @@ import (
 // pickerToolNames lists built-in tools shown in the new-session picker (shell excluded).
 var pickerToolNames = []string{
 	"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes",
-	"deepseek",
+	"deepseek", "omp",
 }
 
 // ToolVisibilityPanel edits [ui].hidden_tools via a checklist overlay.

--- a/internal/web/omp_skills_surface_test.go
+++ b/internal/web/omp_skills_surface_test.go
@@ -1,0 +1,22 @@
+package web
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// This pins the shipped JavaScript surface (the embedded asset, not a duplicate
+// Go allowlist): OMP must take the supported rendering/attach/detach branch.
+func TestWebSkillsPaneShipsOMPSupportAndActions(t *testing.T) {
+	b, err := fs.ReadFile(embeddedStaticFiles, "static/app/panes/SkillsPane.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(b)
+	for _, want := range []string{"'omp'", "skill-attach-btn", "skill-detach-btn", "apiFetch('POST'", "apiFetch('DELETE'"} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("embedded SkillsPane missing %q", want)
+		}
+	}
+}

--- a/internal/web/static/app/panes/SkillsPane.js
+++ b/internal/web/static/app/panes/SkillsPane.js
@@ -13,7 +13,7 @@ import { menuModelSignal } from '../dataModel.js'
 import { apiFetch } from '../api.js'
 import { addToast } from '../Toast.js'
 
-const TOOLS_WITH_SKILLS = new Set(['claude', 'gemini', 'codex', 'pi'])
+const TOOLS_WITH_SKILLS = new Set(['claude', 'gemini', 'codex', 'pi', 'omp'])
 
 export function SkillsPane() {
   const selectedId = selectedIdSignal.value
@@ -71,7 +71,7 @@ export function SkillsPane() {
         <div class="chart-card" style="padding: 32px; text-align: center;">
           <div class="title">Skills not supported for ${session.tool}</div>
           <div style="color: var(--text-dim); margin-top: 12px;">
-            Project-scoped skills are available for Claude, Gemini, Codex, and Pi sessions only.
+            Project-scoped skills are available for Claude, Gemini, Codex, Pi, and Oh My Pi sessions only.
           </div>
         </div>
       </div>`

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -116,7 +116,7 @@ The table above is what *agent-deck* does. This one is what the *CLI inside a se
 | `agent-deck session output <name>` | Get last response |
 | `agent-deck session children --json` | Child sessions' live status + asserted completions (non-blocking, read-only) |
 | `agent-deck session current [-q\|--json]` | Auto-detect current session |
-| `agent-deck session fork <name>` | Fork Claude/Pi conversation |
+| `agent-deck session fork <name>` | Fork Claude/OpenCode/Pi/Codex/Oh My Pi conversation |
 | `agent-deck session switch-account <name> <account>` | Switch Claude account, conversation follows |
 | `agent-deck mcp list` | List available MCPs |
 | `agent-deck mcp attach <name> <mcp>` | Attach MCP (then restart) |
@@ -380,7 +380,7 @@ Key constraints:
 | `r/R` | Restart (reloads MCPs) |
 | `m` | MCP Manager |
 | `s` | Skills Manager |
-| `f/F` | Fork Claude/OpenCode/Pi/Codex session |
+| `f/F` | Fork Claude/OpenCode/Pi/Codex/Oh My Pi session |
 | `d` | Delete |
 | `A` | Archive (stops tmux, hides from default list) |
 | `Shift+U` | Unarchive (does not auto-start tmux) |

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -183,7 +183,7 @@ Use `--all --env KEY=VALUE` to inject the variable into every active session.
 Claude's existing protection that removes `TELEGRAM_*` variables from sessions
 that do not own a Telegram channel remains in effect.
 
-### session fork (Claude, OpenCode, Pi, Codex)
+### session fork (Claude, OpenCode, Pi, Codex, Oh My Pi)
 
 ```bash
 agent-deck session fork <id|title> [-t "title"] [-g "group"]

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -303,6 +303,7 @@ hooks_enabled = false      # Disable automatic Cursor hook injection on TUI star
 ## [omp] Section
 
 Oh My Pi sessions use an instance-scoped session directory and resume automatically.
+The configured `command`, including any flags, is used for both initial starts and restarts; an explicit per-session custom command takes precedence.
 
 ```toml
 [omp]

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -300,6 +300,20 @@ hooks_enabled = false      # Disable automatic Cursor hook injection on TUI star
 | `env_file` | string | `""` | A .env file sourced for Cursor sessions only. See [Path Resolution](#path-resolution). |
 | `hooks_enabled` | bool | `true` | When `true`, TUI startup silently injects agent-deck lifecycle hooks into `~/.cursor/hooks.json` whenever the resolved Cursor CLI binary is on `PATH` (real-time status detection). Set `false` to durably opt out; `agent-deck cursor-hooks uninstall` writes this automatically so the uninstall survives TUI restarts (issue #1672). Re-enable with `agent-deck cursor-hooks install` or by removing the key. Mirrors `[claude] hooks_enabled`. |
 
+## [omp] Section
+
+Oh My Pi sessions use an instance-scoped session directory and resume automatically.
+
+```toml
+[omp]
+command = "omp"
+env_file = "~/.config/omp.env"
+default_model = "anthropic/claude-sonnet-4-6"
+approval_mode = "write" # always-ask | write | yolo
+```
+
+`default_model` is passed as `--model`; a model selected for an individual session takes precedence.
+
 ## [hermes] Section
 
 Hermes Agent CLI integration settings ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)).

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -310,10 +310,18 @@ The configured `command`, including any flags, is used for both initial starts a
 command = "omp"
 env_file = "~/.config/omp.env"
 default_model = "anthropic/claude-sonnet-4-6"
+default_profile = "default"
 approval_mode = "write" # always-ask | write | yolo
+smol_model = "google/gemini-3-flash"
+slow_model = "anthropic/claude-opus-4-6"
+plan_model = "openai/gpt-5-codex"
 ```
 
-`default_model` is passed as `--model`; a model selected for an individual session takes precedence.
+These values map to `--model`, `--profile`, `--approval-mode`, `--smol`,
+`--slow`, and `--plan`. A value selected in the OMP launch panel takes
+precedence. The panel also exposes session/no-session mode, `--models`,
+`--print-thoughts`, `--auto-approve`, `--max-time`, `--from-claude`, and
+`--from-codex` per session.
 
 ## [hermes] Section
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -422,7 +422,7 @@ branch_prefix       = "fork/" # Auto branch name = <branch_prefix><sanitized-tit
 | `docker` | string | `"auto"` | Docker isolation for the fork: `"auto"` matches the parent (sandboxed parent → a fresh container; otherwise none), `"on"` always sandboxes, `"off"` never. |
 | `branch_prefix` | string | `"fork/"` | Prefix for the auto-suggested fork branch name. Applies to both quick fork and the `Shift+F` dialog. |
 
-> **Note:** Forking is supported across Claude, OpenCode, Pi, and Codex (and Codex-compatible custom tools) via each tool's native fork, in the TUI, CLI (`agent-deck session fork <id>`), and Web UI. The Web/API endpoint (`POST /api/sessions/{id}/fork`) performs a plain tool-native fork and does **not** apply these `[fork]` worktree/state/Docker defaults — those are TUI quick-fork/dialog scope. Codex forking requires a codex CLI with `codex fork <session-id>` support.
+> **Note:** Forking is supported across Claude, OpenCode, Pi, Codex, and Oh My Pi (and Codex-compatible custom tools) via each tool's native fork, in the TUI, CLI (`agent-deck session fork <id>`), and Web UI. The Web/API endpoint (`POST /api/sessions/{id}/fork`) performs a plain tool-native fork and does **not** apply these `[fork]` worktree/state/Docker defaults — those are TUI quick-fork/dialog scope. Codex forking requires a codex CLI with `codex fork <session-id>` support.
 
 ## [conductor] Section
 

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -33,8 +33,8 @@ Complete reference for agent-deck Terminal UI features.
 | `Shift+U` | Unarchive session (restores to list; does NOT auto-start tmux) |
 | `b` | Re-run worktree setup script (`.agent-deck/worktree-setup.sh`) |
 | `u` | Mark unread (idle -> waiting) |
-| `f` | Quick fork (Claude/OpenCode/Pi/Codex) |
-| `F` | Fork with options (Claude/OpenCode/Pi/Codex) |
+| `f` | Quick fork (Claude/OpenCode/Pi/Codex/Oh My Pi) |
+| `F` | Fork with options (Claude/OpenCode/Pi/Codex/Oh My Pi) |
 
 For remote group headers, `Enter`/`Tab` toggles collapse and `h`/Left collapses or moves to the parent. Remote-session reorder keys move only within the current remote group; the order is saved on the viewing machine, while remote group headers remain name-sorted.
 


### PR DESCRIPTION
## What problem does this solve?

Closes #1977. Oh My Pi sessions previously fell back to generic shell behavior, so aliases were missed, sessions could collide, forks could change model, and harness controls were unavailable in the launch UI.

## Why this change

OMP has native instance-scoped JSONL sessions and fork support. This adapter keeps those lifecycle semantics while modeling OMP's launch controls, supported launcher aliases, status rules, and project skills explicitly.

## User impact

`omp`, `oh-my-pi`, and `npx @oh-my-pi/pi-coding-agent` launches are recognized as OMP. The new-session dialog exposes session mode/no-session, model routing and roles, thoughts, approval/auto-approval, time limit, profile, and Claude/Codex import controls. Initial starts, restarts, and local/SSH/sandbox forks preserve the selected model and harness options.

## Evidence

In clean `golang:1.25` containers:

- `go build ./... && go vet ./...`: pass
- focused session, tmux detector, TUI OMP panel, and Web SkillsPane tests: pass
- pre-existing OMP command/lifecycle tests: pass
- mutation worktrees: session option tests fail to compile without the modeled contract; alias/false-positive assertions fail without tmux detection; fork assertions fail with model/models/profile absent when the fork hunk is reverted; TUI tests fail without its panel/wiring; Web test fails when OMP is removed from the shipped SkillsPane support set

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** GPT-5 Codex

**Prompt / session log (optional):** Round-3 verification remediation for PR #2054.

## What actually bothered you

The cold review showed that alias-launched OMP panes silently became shell sessions, while an initial fork could launch a different model from the model persisted for its restart.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full Oh My Pi (`omp`) integration, including session creation, launch, restart, messaging, and native forking.
  - Added configurable models, profiles, approval modes, timing, imports, commands, and environment files.
  - Added Oh My Pi to setup, session selection, settings, tool detection, and web skills support.
  - Added `.omp/skills` project skill support.
  - `session show` now reports fork capability for all natively forkable tools.

- **Bug Fixes**
  - Improved command detection and activity or approval-prompt detection for Oh My Pi sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->