### PR TITLE
feat(session): inspect and reject Codex approvals

### DIFF
--- a/cmd/agent-deck/session_approval_cmd.go
+++ b/cmd/agent-deck/session_approval_cmd.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/asheshgoplani/agent-deck/internal/send"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleSessionApproval inspects one live Codex approval overlay without
+// sending terminal input.
+func handleSessionApproval(profile string, args []string) {
+	fs := flag.NewFlagSet("session approval", flag.ExitOnError)
+	fs.SetOutput(os.Stdout)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("q", false, "Quiet mode")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session approval <id|title> [options]")
+		fmt.Println()
+		fmt.Println("Inspect one currently visible Codex approval prompt without sending input.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	out := NewCLIOutput(*jsonOutput, *quiet)
+	if fs.NArg() != 1 {
+		fs.Usage()
+		out.Error("session is required", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	inst, message, code := ResolveSession(fs.Arg(0), instances)
+	if inst == nil {
+		out.Error(message, code)
+		if code == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+		return
+	}
+	if !session.IsCodexCompatible(inst.Tool) {
+		out.Error(
+			fmt.Sprintf("session approval currently supports Codex sessions; '%s' uses %s", inst.Title, inst.Tool),
+			ErrCodeInvalidOperation,
+		)
+		os.Exit(1)
+	}
+	if !inst.Exists() {
+		out.Error(fmt.Sprintf("session '%s' is not running", inst.Title), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	target := inst.GetTmuxSession()
+	if target == nil {
+		out.Error("could not determine tmux session", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	request, inspectErr := send.InspectCodexApprovalPrompt(target)
+	if inspectErr != nil {
+		out.Error(fmt.Sprintf("failed to inspect Codex prompt: %v", inspectErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	data := map[string]interface{}{
+		"active":        request != nil,
+		"session_id":    inst.ID,
+		"session_title": inst.Title,
+	}
+	if request != nil {
+		data["fingerprint"] = request.Fingerprint
+		data["context"] = request.Context
+		data["options"] = request.Options
+	}
+	out.Success("Inspected Codex approval prompt", data)
+}

--- a/cmd/agent-deck/session_approval_cmd_test.go
+++ b/cmd/agent-deck/session_approval_cmd_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSessionApprovalCommandIsExposed(t *testing.T) {
+	home := t.TempDir()
+	stdout, stderr, code := runAgentDeck(t, home, "session", "approval", "--help")
+	if code != 0 {
+		t.Fatalf("session approval --help exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "session approval <id|title>") {
+		t.Fatalf("session approval help missing command usage: %s", stdout)
+	}
+}
+
+func TestSessionRejectCommandIsExposed(t *testing.T) {
+	home := t.TempDir()
+	stdout, stderr, code := runAgentDeck(t, home, "session", "reject", "--help")
+	if code != 0 {
+		t.Fatalf("session reject --help exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "session reject <id|title>") {
+		t.Fatalf("session reject help missing command usage: %s", stdout)
+	}
+}

--- a/cmd/agent-deck/session_approve_cmd.go
+++ b/cmd/agent-deck/session_approve_cmd.go
@@ -16,7 +16,7 @@ import (
 func handleSessionApprove(profile string, args []string) {
 	fs := flag.NewFlagSet("session approve", flag.ExitOnError)
 	fs.SetOutput(os.Stdout)
-	choiceFlag := fs.String("choice", "", "Approval choice: once, always, session, or displayed option number")
+	choiceFlag := fs.String("choice", "", "Approval choice: once, always, session, reject, or displayed option number")
 	timeout := fs.Duration("timeout", 5*time.Second, "Max time to verify that the original approval prompt cleared")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("q", false, "Quiet mode")
@@ -31,6 +31,7 @@ func handleSessionApprove(profile string, args []string) {
 		fmt.Println("  once       Select \"Yes, proceed\" (default)")
 		fmt.Println("  always     Select the persistent/prefix approval, when offered")
 		fmt.Println("  session    Select the session-scoped approval, when offered")
+		fmt.Println("  reject     Select the unique displayed negative option")
 		fmt.Println("  1-9        Select that displayed option directly")
 		fmt.Println()
 		fmt.Println("Options:")
@@ -128,12 +129,38 @@ func handleSessionApprove(profile string, args []string) {
 		if result.KeySent {
 			code = ErrCodeDeliveryFailed
 		}
-		out.ErrorWithData(fmt.Sprintf("failed to approve Codex prompt: %v", approveErr), code, data)
+		out.ErrorWithData(fmt.Sprintf("failed to resolve Codex prompt: %v", approveErr), code, data)
 		os.Exit(1)
 	}
 
+	verb := "Approved"
+	if result.Choice == "reject" {
+		verb = "Rejected"
+	}
 	out.Success(
-		fmt.Sprintf("Approved option %d in '%s'", result.OptionNumber, inst.Title),
+		fmt.Sprintf("%s option %d in '%s'", verb, result.OptionNumber, inst.Title),
 		data,
 	)
+}
+
+// handleSessionReject is the explicit negative-decision command used by
+// coordinators. It reuses the guarded `session approve` path and cannot select
+// a positive option.
+func handleSessionReject(profile string, args []string) {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			fmt.Println("Usage: agent-deck session reject <id|title> [options]")
+			fmt.Println()
+			fmt.Println("Reject one currently visible Codex approval prompt with exactly one")
+			fmt.Println("keypress. Fails closed when no unique negative option is visible.")
+			fmt.Println()
+			fmt.Println("Options:")
+			fmt.Println("  --timeout duration   Max time to verify that the prompt cleared (default 5s)")
+			fmt.Println("  --json               Output as JSON")
+			fmt.Println("  -q                   Quiet mode")
+			return
+		}
+	}
+	forwarded := append(append([]string{}, args...), "reject")
+	handleSessionApprove(profile, forwarded)
 }

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -85,6 +85,10 @@ func handleSession(profile string, args []string) {
 		handleSessionSend(profile, args[1:])
 	case "approve":
 		handleSessionApprove(profile, args[1:])
+	case "reject":
+		handleSessionReject(profile, args[1:])
+	case "approval":
+		handleSessionApproval(profile, args[1:])
 	case "send-keys":
 		handleSessionSendKeys(profile, args[1:])
 	case "output":
@@ -128,6 +132,8 @@ func printSessionHelp() {
 	fmt.Println("  move <id> <path>        Move session to a new path (migrates Claude history)")
 	fmt.Println("  send <id> <message>     Send a message to a running session")
 	fmt.Println("  approve <id> [choice]   Resolve a visible Codex approval prompt")
+	fmt.Println("  reject <id>             Reject a visible Codex approval prompt")
+	fmt.Println("  approval <id>           Inspect a visible Codex approval prompt (read-only)")
 	fmt.Println("  output <id>             Get the last response from a session")
 	fmt.Println("  children [id]           List sub-sessions with status + last completion")
 	fmt.Println("  search <query>          Search message content across Claude sessions")

--- a/internal/send/codex_approval.go
+++ b/internal/send/codex_approval.go
@@ -1,6 +1,7 @@
 package send
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -35,6 +36,20 @@ type CodexApprovalResult struct {
 	NextPromptSeen bool
 }
 
+// CodexApprovalInfo is a read-only description of one live Codex approval
+// prompt. Fingerprint is stable for identical normalized prompt content.
+type CodexApprovalInfo struct {
+	Fingerprint string                `json:"fingerprint"`
+	Context     string                `json:"context"`
+	Options     []CodexApprovalChoice `json:"options"`
+}
+
+// CodexApprovalChoice is one numbered option displayed by Codex.
+type CodexApprovalChoice struct {
+	Number int    `json:"number"`
+	Label  string `json:"label"`
+}
+
 type codexApprovalOption struct {
 	number int
 	label  string
@@ -47,10 +62,30 @@ type codexApprovalPrompt struct {
 
 var codexApprovalOptionPattern = regexp.MustCompile(`^\s*(›\s*)?([1-9][0-9]*)\.\s+(.+?)\s*$`)
 
+// InspectCodexApprovalPrompt returns a stable description of the currently
+// visible approval gate without sending input to the session.
+func InspectCodexApprovalPrompt(target CodexApprovalTarget) (*CodexApprovalInfo, error) {
+	prompt, err := captureCodexApprovalPrompt(target)
+	if err != nil || prompt == nil {
+		return nil, err
+	}
+
+	choices := make([]CodexApprovalChoice, 0, len(prompt.options))
+	for _, option := range prompt.options {
+		choices = append(choices, CodexApprovalChoice{Number: option.number, Label: option.label})
+	}
+	fingerprint := fmt.Sprintf("%x", sha256.Sum256([]byte(prompt.fingerprint)))
+	return &CodexApprovalInfo{
+		Fingerprint: fingerprint,
+		Context:     prompt.fingerprint,
+		Options:     choices,
+	}, nil
+}
+
 // ApproveCodexPrompt resolves one currently visible Codex approval menu.
 //
-// choice accepts a displayed option number, or one of "once", "always", and
-// "session". The displayed number is sent as one literal keypress; Enter is
+// choice accepts a displayed option number, or one of "once", "always",
+// "session", and "reject". The displayed number is sent as one literal keypress; Enter is
 // intentionally not sent because Codex selects numbered approval options on
 // the digit KeyEvent itself.
 func ApproveCodexPrompt(target CodexApprovalTarget, choice string, opts CodexApprovalOptions) (CodexApprovalResult, error) {
@@ -237,6 +272,26 @@ func selectCodexApprovalOption(prompt *codexApprovalPrompt, choice string) (code
 		return codexApprovalOption{}, normalized, fmt.Errorf("Codex approval option %d is not displayed", number)
 	}
 
+	if normalized == "reject" || normalized == "no" {
+		var negative *codexApprovalOption
+		for i := range prompt.options {
+			option := &prompt.options[i]
+			if !strings.HasPrefix(strings.ToLower(option.label), "no") {
+				continue
+			}
+			if negative != nil {
+				return codexApprovalOption{}, "reject", fmt.Errorf(
+					"Codex approval prompt has multiple negative options; select a displayed option number",
+				)
+			}
+			negative = option
+		}
+		if negative != nil {
+			return *negative, "reject", nil
+		}
+		return codexApprovalOption{}, "reject", fmt.Errorf("Codex approval prompt does not offer a negative option")
+	}
+
 	for _, option := range prompt.options {
 		label := strings.ToLower(option.label)
 		switch normalized {
@@ -259,7 +314,7 @@ func selectCodexApprovalOption(prompt *codexApprovalPrompt, choice string) (code
 			}
 		default:
 			return codexApprovalOption{}, normalized, fmt.Errorf(
-				"invalid approval choice %q (use once, always, session, or a displayed option number)",
+				"invalid approval choice %q (use once, always, session, reject, or a displayed option number)",
 				choice,
 			)
 		}

--- a/internal/send/codex_approval_test.go
+++ b/internal/send/codex_approval_test.go
@@ -78,6 +78,89 @@ func TestApproveCodexPrompt_OnceSendsOneDigitWithoutEnter(t *testing.T) {
 	}
 }
 
+func TestInspectCodexApprovalPrompt_IsReadOnlyAndStable(t *testing.T) {
+	target := &fakeCodexApprovalTarget{captures: []string{codexExecApprovalPrompt}}
+
+	request, err := InspectCodexApprovalPrompt(target)
+	if err != nil {
+		t.Fatalf("InspectCodexApprovalPrompt: %v", err)
+	}
+	if request == nil {
+		t.Fatal("expected a live approval request")
+	}
+	if len(request.Fingerprint) != 64 {
+		t.Fatalf("fingerprint length = %d, want 64", len(request.Fingerprint))
+	}
+	if request.Context == "" || len(request.Options) != 3 {
+		t.Fatalf("unexpected request: %+v", request)
+	}
+	if len(target.sent) != 0 {
+		t.Fatalf("inspection sent keys: %v", target.sent)
+	}
+
+	secondTarget := &fakeCodexApprovalTarget{captures: []string{codexExecApprovalPrompt}}
+	second, err := InspectCodexApprovalPrompt(secondTarget)
+	if err != nil {
+		t.Fatalf("second InspectCodexApprovalPrompt: %v", err)
+	}
+	if second.Fingerprint != request.Fingerprint {
+		t.Fatalf("fingerprint changed: %q != %q", second.Fingerprint, request.Fingerprint)
+	}
+}
+
+func TestInspectCodexApprovalPrompt_NoActivePrompt(t *testing.T) {
+	target := &fakeCodexApprovalTarget{captures: []string{"› Continue\n"}}
+
+	request, err := InspectCodexApprovalPrompt(target)
+	if err != nil {
+		t.Fatalf("InspectCodexApprovalPrompt: %v", err)
+	}
+	if request != nil {
+		t.Fatalf("request = %+v, want nil", request)
+	}
+	if len(target.sent) != 0 {
+		t.Fatalf("inspection sent keys: %v", target.sent)
+	}
+}
+
+func TestApproveCodexPrompt_RejectSelectsDisplayedNoOption(t *testing.T) {
+	target := &fakeCodexApprovalTarget{
+		captures: []string{codexExecApprovalPrompt, codexExecApprovalPrompt, "› Continue\n"},
+	}
+
+	result, err := ApproveCodexPrompt(target, "reject", CodexApprovalOptions{
+		VerifyTimeout: 50 * time.Millisecond,
+		PollInterval:  time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("ApproveCodexPrompt: %v", err)
+	}
+	if len(target.sent) != 1 || target.sent[0] != "3" {
+		t.Fatalf("sent keys = %v, want exactly [3]", target.sent)
+	}
+	if result.Choice != "reject" || result.OptionNumber != 3 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestApproveCodexPrompt_RejectFailsClosedForAmbiguousNegativeOptions(t *testing.T) {
+	prompt := strings.Replace(
+		codexExecApprovalPrompt,
+		"  3. No, and tell Codex what to do differently (esc)",
+		"  3. No, return to the prompt (esc)\n  4. No, cancel the task (c)",
+		1,
+	)
+	target := &fakeCodexApprovalTarget{captures: []string{prompt}}
+
+	_, err := ApproveCodexPrompt(target, "reject", CodexApprovalOptions{})
+	if err == nil || !strings.Contains(err.Error(), "multiple negative options") {
+		t.Fatalf("expected ambiguous-negative error, got %v", err)
+	}
+	if len(target.sent) != 0 {
+		t.Fatalf("ambiguous rejection must not send a key; sent %v", target.sent)
+	}
+}
+
 func TestApproveCodexPrompt_AlwaysSelectsDisplayedPersistentOption(t *testing.T) {
 	target := &fakeCodexApprovalTarget{
 		captures: []string{


### PR DESCRIPTION
## What problem does this solve?

Agent Deck can approve a visible Codex approval prompt, but coordinator tooling
cannot inspect the prompt without terminal input or express a semantic rejection.
That leaves integrations either scraping panes themselves or sending an unsafe,
hard-coded option number. This implements the native primitives proposed in
[Discussion #2066](https://github.com/asheshgoplani/agent-deck/discussions/2066).

## Why this change

The existing guarded Codex approval parser already stabilizes the visible menu,
sends exactly one digit, and verifies that the original prompt cleared. This
change reuses that path:

- `session approval <id> --json` returns a read-only, stable fingerprint,
  normalized context, and displayed choices.
- `session approve <id> reject` selects the unique displayed option whose label
  begins with `No`.
- `session reject <id>` is an explicit negative-only alias.

Rejection fails closed when no negative option exists or more than one is
displayed. It does not add routing, authentication, or notification state;
coordinator integrations remain responsible for those concerns.

## User impact

Users and coordinator integrations can inspect a pending Codex approval and
reject it without pane scraping or guessing an option number. Existing approval
choices and commands are unchanged.

## Evidence

Focused regression tests pass:

    go test ./internal/send ./cmd/agent-deck -run 'Test(InspectCodexApprovalPrompt|ApproveCodexPrompt_Reject|SessionApprovalCommand|SessionRejectCommand)'
    ok github.com/asheshgoplani/agent-deck/internal/send
    ok github.com/asheshgoplani/agent-deck/cmd/agent-deck

`go vet ./...`, `go build ./...`, `gofmt -l`, and `git diff --check` pass.

A real tmux-backed smoke test with a synthetic Codex approval overlay returned
`active: true` with a stable SHA-256 fingerprint and three displayed options.
`session reject ... --json` then sent exactly option `3` (`No...`) and returned
`key_sent: true`, `verified: true`, and `success: true`.

The repository-wide sandboxed suite was also run. The changed `internal/send`
package passed. Untouched upstream tests failed on this macOS host in worktree
cleanup, tmux bootstrap/socket handling, filesystem clock, and `/var` versus
`/private/var` path identity. The representative worktree-cleanup failures were
reproduced unchanged in a detached `upstream/main` worktree.

Revert-check: copying the new tests onto `upstream/main` fails to compile because
the new inspection symbol is absent; the behavior tests therefore cannot pass
without the production change.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6

**Prompt / session log (optional):** —

## What actually bothered you

My human asked: "please go ahead and implement this feature and open a PR on
upstream and also deploy this locally as well so that things are unblocked."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: the changed package passes; unrelated upstream macOS failures are documented in Evidence
- [ ] Hot-path timing: this adds opt-in CLI commands and does not change list, status, output, startup, or background polling
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5.6 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only command to inspect active Codex approval prompts, including available choices and prompt details.
  - Added `session reject` to decline an approval using the displayed negative option.
  - Added JSON and quiet output options for approval inspection.

- **Bug Fixes**
  - Rejection now safely fails when the prompt has no unique negative option.

- **Tests**
  - Added coverage for approval inspection, stable prompt identification, rejection behavior, and command help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->