### PR TITLE
feat(ui): add window mode for open-shell-here hotkey

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -376,7 +376,8 @@ type UISettings struct {
 	// ShellSplit controls the terminal used by the open_shell_here hotkey.
 	// Valid values:
 	//   "iterm"  — always open an iTerm2 vertical split pane (macOS only)
-	//   "tmux"   — always open a new tmux window
+	//   "tmux"   — always open an inline tmux split pane
+	//   "window" — always open a tmux window (tab) inside the session
 	//   ""       — auto: use iTerm2 split when LC_TERMINAL=iTerm2 or
 	//              TERM_PROGRAM=iTerm.app, otherwise tmux
 	// Default: "" (auto). Issue #1470.
@@ -505,8 +506,9 @@ const (
 
 // ShellSplit modes for the open_shell_here hotkey (issue #1470).
 const (
-	ShellSplitITerm = "iterm"
-	ShellSplitTmux  = "tmux"
+	ShellSplitITerm  = "iterm"
+	ShellSplitTmux   = "tmux"
+	ShellSplitWindow = "window"
 )
 
 // Preview-pane orientation modes for wide terminals (>= 80 cols).
@@ -585,6 +587,8 @@ func (u UISettings) GetShellSplit() string {
 		return ShellSplitITerm
 	case ShellSplitTmux:
 		return ShellSplitTmux
+	case ShellSplitWindow:
+		return ShellSplitWindow
 	}
 	return ""
 }

--- a/internal/session/userconfig_shell_split_test.go
+++ b/internal/session/userconfig_shell_split_test.go
@@ -12,6 +12,8 @@ func TestUISettings_GetShellSplit(t *testing.T) {
 		{"iTerm", ShellSplitITerm},
 		{"tmux", ShellSplitTmux},
 		{"TMUX", ShellSplitTmux},
+		{"window", ShellSplitWindow},
+		{"WINDOW", ShellSplitWindow},
 		{"", ""},
 		{"unknown", ""},
 		{"auto", ""},

--- a/internal/tmux/shell_window_test.go
+++ b/internal/tmux/shell_window_test.go
@@ -1,0 +1,49 @@
+package tmux
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSession_NewShellWindow verifies that NewShellWindow adds a second
+// window to the session (instead of splitting the current one) and that the
+// new window's pane starts in the requested workdir.
+func TestSession_NewShellWindow(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	workdir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+
+	s := &Session{Name: target, SocketName: socket}
+	if err := s.NewShellWindow(workdir); err != nil {
+		t.Fatalf("NewShellWindow: %v", err)
+	}
+
+	out, err := exec.Command("tmux", "-L", socket, "list-windows", "-t", target, "-F", "#{window_index}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-windows: %v: %s", err, out)
+	}
+	windows := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(windows) != 2 {
+		t.Fatalf("window count = %d, want 2 (windows: %v)", len(windows), windows)
+	}
+
+	// new-window selects the new window, so the session's active pane must
+	// be in workdir.
+	out, err = exec.Command("tmux", "-L", socket, "display-message", "-p", "-t", target, "#{pane_current_path}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("display-message: %v: %s", err, out)
+	}
+	got, err := filepath.EvalSymlinks(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("EvalSymlinks(pane_current_path): %v", err)
+	}
+	if got != workdir {
+		t.Errorf("active pane path = %q, want %q", got, workdir)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6010,6 +6010,22 @@ func (s *Session) SplitShellPane(workdir string) error {
 	return tmuxExec(s.SocketName, args...).Run()
 }
 
+// NewShellWindow adds a new window (tab) to this session running shell in
+// workdir, instead of splitting the current window. If workdir is empty the
+// window inherits the session's current working directory.
+func (s *Session) NewShellWindow(workdir string) error {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	args := []string{"new-window", "-t", s.Name}
+	if workdir != "" {
+		args = append(args, "-c", workdir)
+	}
+	args = append(args, shell)
+	return tmuxExec(s.SocketName, args...).Run()
+}
+
 // ListAllSessions returns all Agent Deck tmux sessions
 func ListAllSessions() ([]*Session, error) {
 	socket := DefaultSocketName()

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -304,7 +304,7 @@ func (h *HelpOverlay) View() string {
 				{copyPaneKey, "Copy visible terminal text, including links"},
 				{sendKey, "Send output to session"},
 				{execShellKey, "Exec shell in sandbox container"},
-				{openShellHereKey, "Open shell in session's worktree (split pane / tmux)"},
+				{openShellHereKey, "Open shell in session's worktree (split pane / window)"},
 				{editPathsKey, "Edit multi-repo paths"},
 				{editSessionKey, "Edit session settings (title/color/...)"},
 				{notesKey, "Edit notes"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -962,13 +962,14 @@ func (h *Home) openInSplitPane(req terminal.AttachRequest) error {
 }
 
 // resolveShellSplitMode returns session.ShellSplitITerm when an iTerm2 split
-// should be used, session.ShellSplitTmux otherwise. Reads [ui].shell_split
-// first; falls back to auto-detection via TERM_PROGRAM / LC_TERMINAL. Issue #1470.
+// should be used, session.ShellSplitWindow for a tmux window (tab), and
+// session.ShellSplitTmux otherwise. Reads [ui].shell_split first; falls back
+// to auto-detection via TERM_PROGRAM / LC_TERMINAL. Issue #1470.
 func resolveShellSplitMode() string {
 	cfg, _ := session.LoadUserConfig()
 	if cfg != nil {
 		mode := cfg.UI.GetShellSplit()
-		if mode == session.ShellSplitITerm || mode == session.ShellSplitTmux {
+		if mode == session.ShellSplitITerm || mode == session.ShellSplitTmux || mode == session.ShellSplitWindow {
 			return mode
 		}
 	}
@@ -996,7 +997,17 @@ func (h *Home) openShellHere(inst *session.Instance) tea.Cmd {
 		Name:       tmuxSess.Name,
 		SocketName: tmuxSess.SocketName,
 	}
-	if resolveShellSplitMode() == session.ShellSplitITerm {
+	mode := resolveShellSplitMode()
+	if mode == session.ShellSplitWindow {
+		// Shell as a tmux window (tab) instead of a split pane; attach so
+		// the new window is visible immediately.
+		if err := tmuxSess.NewShellWindow(workdir); err != nil {
+			h.setError(fmt.Errorf("open shell here: %w", err))
+			return nil
+		}
+		return h.attachSession(inst)
+	}
+	if mode == session.ShellSplitITerm {
 		// Launch iTerm2 split before mutating tmux so a failed osascript
 		// call does not leave an orphaned pane. Issue #1470.
 		if err := h.openInSplitPane(req); err != nil {

--- a/internal/ui/issue1470_shell_split_test.go
+++ b/internal/ui/issue1470_shell_split_test.go
@@ -33,6 +33,20 @@ func TestResolveShellSplitMode_AutoDetect(t *testing.T) {
 	})
 }
 
+// TestResolveShellSplitMode_ConfigWindow verifies that [ui].shell_split =
+// "window" is honored, including over iTerm2 env auto-detection, so the
+// open_shell_here hotkey opens a tmux window instead of a split pane.
+func TestResolveShellSplitMode_ConfigWindow(t *testing.T) {
+	home := setXDGTestHome(t)
+	writeXDGTestConfig(t, home, "[ui]\nshell_split = \"window\"\n")
+	t.Setenv("LC_TERMINAL", "iTerm2")
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+
+	if got := resolveShellSplitMode(); got != session.ShellSplitWindow {
+		t.Errorf("resolveShellSplitMode() = %q, want %q", got, session.ShellSplitWindow)
+	}
+}
+
 // TestResolveShellSplitMode_DefaultIsTmux verifies that the safe default (tmux)
 // is returned when no config and no iTerm env vars are set. Issue #1470.
 func TestResolveShellSplitMode_DefaultIsTmux(t *testing.T) {

--- a/internal/ui/issue1470_shell_split_test.go
+++ b/internal/ui/issue1470_shell_split_test.go
@@ -47,6 +47,19 @@ func TestResolveShellSplitMode_ConfigWindow(t *testing.T) {
 	}
 }
 
+// TestResolveShellSplitMode_RemoteSessionNotApplicable documents that
+// shell_split — including the "window" mode — is intentionally local-only.
+// The open_shell_here hotkey handler acts solely on ItemTypeSession rows
+// (item.Type == session.ItemTypeSession in the hotkeyOpenShellHere case), so
+// ItemTypeRemoteSession rows never reach openShellHere or
+// resolveShellSplitMode: the shell pane/window must land in the session's
+// local worktree, which a remote SSH session does not have on this machine.
+// If open_shell_here ever gains remote support, this skip should be replaced
+// with real RemoteSession coverage.
+func TestResolveShellSplitMode_RemoteSessionNotApplicable(t *testing.T) {
+	t.Skip("shell_split is local-only by design: open_shell_here ignores RemoteSession rows (no local worktree to open a shell in)")
+}
+
 // TestResolveShellSplitMode_DefaultIsTmux verifies that the safe default (tmux)
 // is returned when no config and no iTerm env vars are set. Issue #1470.
 func TestResolveShellSplitMode_DefaultIsTmux(t *testing.T) {


### PR DESCRIPTION
## What problem does this solve?

The `open_shell_here` hotkey (`H`) always opens the shell in a split — an iTerm2 split pane or a tmux `split-window -h`. On smaller terminals the split halves the agent's pane, and some users would rather have the shell as a full-screen tab they can flip to and back. There was no way to get that: `[ui] shell_split` only accepts `"iterm"` and `"tmux"`, and both produce splits.

## Why this change

A new `shell_split = "window"` value opens the shell as a tmux **window** (tab) inside the agent's session instead of a split pane, then attaches — so the shell gets the full screen and tmux window navigation flips between agent and shell. A config value (rather than a new hotkey) keeps the existing `H` muscle memory and follows the established pattern of `shell_split` selecting the container. An explicit config value wins over the iTerm2 env auto-detection, consistent with how `"tmux"` already behaves.

While in there, this also corrects the `ShellSplit` field's doc comment, which described the `"tmux"` mode as opening "a new tmux window" when it actually opens a split pane.

## User impact

Opt-in only. Users who set `shell_split = "window"` in `[ui]` get the shell as a tmux window; the default (auto), `"iterm"`, and `"tmux"` behaviors are byte-for-byte unchanged. The help overlay hint for `H` now says "(split pane / window)".

## Evidence

Real tmux capture of the new code path (window created in the session's worktree, other windows untouched):

```
--- before H (window mode):
1: /tmp (/private/tmp)
--- after H (window mode):
1: /tmp (/private/tmp)
2: /agent-deck (~/Code/agent-deck)
```

Tests (the tmux one runs against a real isolated tmux server):

```
=== RUN   TestSession_NewShellWindow
--- PASS: TestSession_NewShellWindow (0.22s)
ok      github.com/asheshgoplani/agent-deck/internal/tmux

=== RUN   TestResolveShellSplitMode_ConfigWindow
--- PASS: TestResolveShellSplitMode_ConfigWindow (0.00s)
ok      github.com/asheshgoplani/agent-deck/internal/ui
```

`TestUISettings_GetShellSplit` extended with `"window"`/`"WINDOW"` cases; `TestResolveShellSplitMode_ConfigWindow` asserts the config value wins over `LC_TERMINAL=iTerm2` / `TERM_PROGRAM=iTerm.app`. All tests were written first and watched fail before implementation.

Sandboxed suite (`HOME=$(mktemp -d) ... go test ./...`) on my Mac: every package passes except `internal/testutil`, `internal/tmux`, and `internal/tmuxutf8`, which fail identically on a pristine `upstream/main` worktree in the same environment (tmux client-classification and socket-path-length issues specific to this machine) — I verified side by side, so this branch introduces no new failures. `gofmt -l ./cmd ./internal` prints nothing; `go vet ./...` is clean.

## AI disclosure

- [ ] Human-authored
- [x] AI-assisted (a model helped, a human wrote most of it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

## What actually bothered you

My human asked: "when I hit H it starts a shell in a split, any way that could be a tab?" — and picked the tmux-window option when offered the choice between an iTerm2 tab and a tmux window.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — three packages fail on this machine, but the identical set fails on pristine `upstream/main` here (environment-specific tmux issues; details under Evidence)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shell-opening option that creates a new tmux window instead of a split pane.
  - Supports configuring the new mode with `window` (case-insensitive).
  - Shell windows open in the selected working directory and attach automatically.

- **Documentation**
  - Updated the session help text to describe the new split-pane/window options.

- **Bug Fixes**
  - Explicitly configured window mode now takes precedence over automatic terminal detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->