### PR TITLE
feat(ui): kill tmux windows from session sub-tabs with d

### DIFF
--- a/internal/tmux/kill_window_test.go
+++ b/internal/tmux/kill_window_test.go
@@ -51,6 +51,33 @@ func TestSession_KillWindow(t *testing.T) {
 	}
 }
 
+// TestSession_WindowCount verifies that WindowCount reports the live number
+// of windows in the session.
+func TestSession_WindowCount(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	s := &Session{Name: target, SocketName: socket}
+	n, err := s.WindowCount()
+	if err != nil {
+		t.Fatalf("WindowCount: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("WindowCount = %d, want 1", n)
+	}
+
+	if out, err := exec.Command("tmux", "-L", socket, "new-window", "-t", target, "sleep", "60").CombinedOutput(); err != nil {
+		t.Fatalf("new-window: %v: %s", err, out)
+	}
+	n, err = s.WindowCount()
+	if err != nil {
+		t.Fatalf("WindowCount after new-window: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("WindowCount after new-window = %d, want 2", n)
+	}
+}
+
 // TestRemoveCachedWindow verifies that RemoveCachedWindow prunes one window
 // from the cache so the TUI drops the row immediately instead of waiting for
 // the next background refresh.

--- a/internal/tmux/kill_window_test.go
+++ b/internal/tmux/kill_window_test.go
@@ -1,0 +1,79 @@
+package tmux
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSession_KillWindow verifies that KillWindow removes the targeted window
+// while leaving the rest of the session intact.
+func TestSession_KillWindow(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	// Add a second window directly so the test only exercises KillWindow.
+	if out, err := exec.Command("tmux", "-L", socket, "new-window", "-t", target, "sleep", "60").CombinedOutput(); err != nil {
+		t.Fatalf("new-window: %v: %s", err, out)
+	}
+
+	listWindows := func() []string {
+		t.Helper()
+		out, err := exec.Command("tmux", "-L", socket, "list-windows", "-t", target, "-F", "#{window_index}").CombinedOutput()
+		if err != nil {
+			t.Fatalf("list-windows: %v: %s", err, out)
+		}
+		return strings.Split(strings.TrimSpace(string(out)), "\n")
+	}
+
+	windows := listWindows()
+	if len(windows) != 2 {
+		t.Fatalf("setup: window count = %d, want 2", len(windows))
+	}
+	newIndex, err := strconv.Atoi(windows[1])
+	if err != nil {
+		t.Fatalf("parse window index %q: %v", windows[1], err)
+	}
+
+	s := &Session{Name: target, SocketName: socket}
+	if err := s.KillWindow(newIndex); err != nil {
+		t.Fatalf("KillWindow: %v", err)
+	}
+
+	windows = listWindows()
+	if len(windows) != 1 {
+		t.Fatalf("window count after kill = %d, want 1 (windows: %v)", len(windows), windows)
+	}
+	if windows[0] == strconv.Itoa(newIndex) {
+		t.Errorf("killed window %d still present", newIndex)
+	}
+}
+
+// TestRemoveCachedWindow verifies that RemoveCachedWindow prunes one window
+// from the cache so the TUI drops the row immediately instead of waiting for
+// the next background refresh.
+func TestRemoveCachedWindow(t *testing.T) {
+	windowCacheMu.Lock()
+	windowCacheData = map[string][]WindowInfo{
+		"sess": {{Index: 1, Name: "agent"}, {Index: 2, Name: "shell"}},
+	}
+	windowCacheTime = time.Now()
+	windowCacheMu.Unlock()
+	t.Cleanup(func() {
+		windowCacheMu.Lock()
+		windowCacheData = nil
+		windowCacheMu.Unlock()
+	})
+
+	RemoveCachedWindow("sess", 2)
+
+	wins := GetCachedWindows("sess")
+	if len(wins) != 1 {
+		t.Fatalf("cached window count = %d, want 1 (windows: %v)", len(wins), wins)
+	}
+	if wins[0].Index != 1 {
+		t.Errorf("remaining window index = %d, want 1", wins[0].Index)
+	}
+}

--- a/internal/tmux/kill_window_test.go
+++ b/internal/tmux/kill_window_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -51,30 +52,25 @@ func TestSession_KillWindow(t *testing.T) {
 	}
 }
 
-// TestSession_WindowCount verifies that WindowCount reports the live number
-// of windows in the session.
-func TestSession_WindowCount(t *testing.T) {
+// TestSession_KillWindow_RefusesLastWindow verifies that KillWindow returns
+// ErrLastWindow instead of killing the session's only remaining window
+// (which would take the whole session down).
+func TestSession_KillWindow_RefusesLastWindow(t *testing.T) {
 	requireTmux(t)
 	socket, target := makeIsolatedServer(t)
 
 	s := &Session{Name: target, SocketName: socket}
-	n, err := s.WindowCount()
-	if err != nil {
-		t.Fatalf("WindowCount: %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("WindowCount = %d, want 1", n)
+	err := s.KillWindow(1)
+	if !errors.Is(err, ErrLastWindow) {
+		t.Fatalf("KillWindow on the last window = %v, want ErrLastWindow", err)
 	}
 
-	if out, err := exec.Command("tmux", "-L", socket, "new-window", "-t", target, "sleep", "60").CombinedOutput(); err != nil {
-		t.Fatalf("new-window: %v: %s", err, out)
-	}
-	n, err = s.WindowCount()
+	out, err := exec.Command("tmux", "-L", socket, "list-windows", "-t", target, "-F", "#{window_index}").CombinedOutput()
 	if err != nil {
-		t.Fatalf("WindowCount after new-window: %v", err)
+		t.Fatalf("list-windows after refused kill: %v: %s", err, out)
 	}
-	if n != 2 {
-		t.Fatalf("WindowCount after new-window = %d, want 2", n)
+	if got := len(strings.Split(strings.TrimSpace(string(out)), "\n")); got != 1 {
+		t.Fatalf("window count = %d, want 1 (the last window must survive)", got)
 	}
 }
 

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -95,6 +95,21 @@ func GetCachedWindows(sessionName string) []WindowInfo {
 	return result
 }
 
+// RemoveCachedWindow prunes one window from the cache so the TUI drops the
+// row immediately after a kill-window instead of waiting up to a full
+// refresh tick for the stale entry to age out.
+func RemoveCachedWindow(sessionName string, index int) {
+	windowCacheMu.Lock()
+	defer windowCacheMu.Unlock()
+	wins := windowCacheData[sessionName]
+	for i, w := range wins {
+		if w.Index == index {
+			windowCacheData[sessionName] = append(wins[:i:i], wins[i+1:]...)
+			return
+		}
+	}
+}
+
 // updateWindowToolCache replaces the entire tool cache with new data.
 // Called ONLY by RefreshPaneInfoCache — tool detection lives there.
 func updateWindowToolCache(windowTools map[string]map[int]string) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6010,25 +6010,32 @@ func (s *Session) SplitShellPane(workdir string) error {
 	return tmuxExec(s.SocketName, args...).Run()
 }
 
+// ErrLastWindow is returned by KillWindow when the target is the session's
+// only remaining window; killing it would kill the whole session.
+var ErrLastWindow = errors.New("window is the session's last window")
+
 // KillWindow kills the window with the given index in this session, leaving
-// the session's other windows intact.
+// the session's other windows intact. The live window count is checked and
+// the window killed in a single server-side command (if-shell -F), so the
+// count cannot change between check and kill; when the target is the
+// session's last window it returns ErrLastWindow instead of killing the
+// session. Bounded (runBoundedOutput) so a wedged server cannot hang the UI.
 func (s *Session) KillWindow(index int) error {
 	target := fmt.Sprintf("%s:%d", s.Name, index)
-	return tmuxExec(s.SocketName, "kill-window", "-t", target).Run()
-}
-
-// WindowCount returns the live number of windows in this session, queried
-// from the tmux server rather than the window cache.
-func (s *Session) WindowCount() (int, error) {
-	out, err := tmuxExec(s.SocketName, "display-message", "-p", "-t", s.Name, "#{session_windows}").Output()
+	// The nested command is a tmux command string; s.Name is an agent-deck
+	// generated session name (sanitized charset), so embedding it is safe.
+	out, err := runBoundedOutput(s.SocketName,
+		"if-shell", "-F", "-t", target,
+		"#{>:#{session_windows},1}",
+		"kill-window -t \""+target+"\"",
+		"display-message -p last-window")
 	if err != nil {
-		return 0, fmt.Errorf("window count: %w", err)
+		return err
 	}
-	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
-	if err != nil {
-		return 0, fmt.Errorf("window count: parse %q: %w", strings.TrimSpace(string(out)), err)
+	if strings.Contains(string(out), "last-window") {
+		return ErrLastWindow
 	}
-	return n, nil
+	return nil
 }
 
 // ListAllSessions returns all Agent Deck tmux sessions

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6010,6 +6010,13 @@ func (s *Session) SplitShellPane(workdir string) error {
 	return tmuxExec(s.SocketName, args...).Run()
 }
 
+// KillWindow kills the window with the given index in this session, leaving
+// the session's other windows intact.
+func (s *Session) KillWindow(index int) error {
+	target := fmt.Sprintf("%s:%d", s.Name, index)
+	return tmuxExec(s.SocketName, "kill-window", "-t", target).Run()
+}
+
 // ListAllSessions returns all Agent Deck tmux sessions
 func ListAllSessions() ([]*Session, error) {
 	socket := DefaultSocketName()

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6017,6 +6017,20 @@ func (s *Session) KillWindow(index int) error {
 	return tmuxExec(s.SocketName, "kill-window", "-t", target).Run()
 }
 
+// WindowCount returns the live number of windows in this session, queried
+// from the tmux server rather than the window cache.
+func (s *Session) WindowCount() (int, error) {
+	out, err := tmuxExec(s.SocketName, "display-message", "-p", "-t", s.Name, "#{session_windows}").Output()
+	if err != nil {
+		return 0, fmt.Errorf("window count: %w", err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("window count: parse %q: %w", strings.TrimSpace(string(out)), err)
+	}
+	return n, nil
+}
+
 // ListAllSessions returns all Agent Deck tmux sessions
 func ListAllSessions() ([]*Session, error) {
 	socket := DefaultSocketName()

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -27,6 +27,7 @@ const (
 	ConfirmUnarchiveSession
 	ConfirmNotice // acknowledge-only message (single OK button), e.g. protected-action blocks
 	ConfirmInstallHermesHooks
+	ConfirmKillWindow
 )
 
 // ConfirmDialog handles confirmation for destructive actions
@@ -43,6 +44,8 @@ type ConfirmDialog struct {
 	hookEvents  []string
 
 	remoteName string // Remote name for remote session confirmations.
+
+	windowIndex int // Tmux window index for ConfirmKillWindow.
 
 	// Notice (ConfirmNotice) carries an acknowledge-only title/body.
 	noticeTitle string
@@ -81,6 +84,18 @@ func (c *ConfirmDialog) ShowDeleteSession(sessionID string, sessionName string, 
 	c.targetName = sessionName
 	c.sandboxed = sandboxed
 	c.worktree = worktree
+	c.buttonCount = 2
+	c.focusedButton = 1 // default to Cancel
+}
+
+// ShowKillWindow shows confirmation for killing a tmux window (sub-tab)
+// inside a session.
+func (c *ConfirmDialog) ShowKillWindow(sessionID string, windowIndex int, windowName string) {
+	c.visible = true
+	c.confirmType = ConfirmKillWindow
+	c.targetID = sessionID
+	c.targetName = windowName
+	c.windowIndex = windowIndex
 	c.buttonCount = 2
 	c.focusedButton = 1 // default to Cancel
 }
@@ -284,6 +299,11 @@ func (c *ConfirmDialog) GetConfirmType() ConfirmType {
 	return c.confirmType
 }
 
+// GetWindowIndex returns the tmux window index for ConfirmKillWindow.
+func (c *ConfirmDialog) GetWindowIndex() int {
+	return c.windowIndex
+}
+
 // GetRemoteName returns the remote name for remote session confirmations.
 func (c *ConfirmDialog) GetRemoteName() string {
 	return c.remoteName
@@ -404,6 +424,17 @@ func (c *ConfirmDialog) View() string {
 			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
 		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
 			hintStyle.Render("y close · n cancel · ←/→ navigate · Enter select · Esc"))
+
+	case ConfirmKillWindow:
+		title = "⚠  Kill Window?"
+		warning = fmt.Sprintf("This will kill tmux window %d:\n\n  \"%s\"", c.windowIndex, c.targetName)
+		details = "• Any processes in the window will be killed\n• Other windows in the session are unaffected"
+		borderColor = ColorRed
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Kill", ColorRed, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y kill · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmDeleteRemoteSession:
 		title = "⚠  Delete Remote Session?"

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10134,14 +10134,14 @@ func (h *Home) confirmAction() tea.Cmd {
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
 				// The window row was rendered when the session had 2+
 				// windows, but the other window can close between rendering
-				// and confirmation — and killing the last window kills the
-				// whole session. Re-check the live count before acting.
-				if n, err := tmuxSess.WindowCount(); err == nil && n < 2 {
-					h.setError(fmt.Errorf("not killing window %d: it is the session's last window", windowIndex))
-					return nil
-				}
+				// and confirmation — KillWindow checks and kills atomically
+				// server-side and refuses the session's last window.
 				if err := tmuxSess.KillWindow(windowIndex); err != nil {
-					h.setError(fmt.Errorf("kill window %d: %w", windowIndex, err))
+					if errors.Is(err, tmux.ErrLastWindow) {
+						h.setError(fmt.Errorf("not killing window %d: it is the session's last window", windowIndex))
+					} else {
+						h.setError(fmt.Errorf("kill window %d: %w", windowIndex, err))
+					}
 					return nil
 				}
 				// Prune the cache so the row disappears now, not on the

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9451,6 +9451,8 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
 				h.confirmDialog.ShowDeleteSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed(), item.Session.IsWorktree())
+			} else if item.Type == session.ItemTypeWindow {
+				h.confirmDialog.ShowKillWindow(item.WindowSessionID, item.WindowIndex, item.WindowName)
 			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
 				h.confirmDialog.ShowDeleteRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
 			} else if item.Type == session.ItemTypeGroup && item.Path == session.DefaultGroupPath {
@@ -10123,6 +10125,22 @@ func (h *Home) confirmAction() tea.Cmd {
 		if inst := h.getInstanceByID(sessionID); inst != nil {
 			h.confirmDialog.Hide()
 			return h.deleteSession(inst)
+		}
+	case ConfirmKillWindow:
+		sessionID := h.confirmDialog.GetTargetID()
+		windowIndex := h.confirmDialog.GetWindowIndex()
+		h.confirmDialog.Hide()
+		if inst := h.getInstanceByID(sessionID); inst != nil {
+			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+				if err := tmuxSess.KillWindow(windowIndex); err != nil {
+					h.setError(fmt.Errorf("kill window %d: %w", windowIndex, err))
+					return nil
+				}
+				// Prune the cache so the row disappears now, not on the
+				// next background refresh tick.
+				tmux.RemoveCachedWindow(tmuxSess.Name, windowIndex)
+				h.rebuildFlatItems()
+			}
 		}
 	case ConfirmCloseSession:
 		sessionID := h.confirmDialog.GetTargetID()
@@ -16413,8 +16431,10 @@ func (h *Home) curatedContextHints(item session.Item) []footerHint {
 		}
 
 	case session.ItemTypeWindow:
-		// A tmux window row attaches just like its session.
+		// A tmux window row attaches just like its session, and 'd' kills
+		// the selected window (with confirmation).
 		add("⏎", "attach")
+		add(h.actionKey(hotkeyDelete), "delete")
 
 	case session.ItemTypeRemoteSession:
 		// A remote session row attaches over SSH just like a local session;

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10132,6 +10132,14 @@ func (h *Home) confirmAction() tea.Cmd {
 		h.confirmDialog.Hide()
 		if inst := h.getInstanceByID(sessionID); inst != nil {
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+				// The window row was rendered when the session had 2+
+				// windows, but the other window can close between rendering
+				// and confirmation — and killing the last window kills the
+				// whole session. Re-check the live count before acting.
+				if n, err := tmuxSess.WindowCount(); err == nil && n < 2 {
+					h.setError(fmt.Errorf("not killing window %d: it is the session's last window", windowIndex))
+					return nil
+				}
 				if err := tmuxSess.KillWindow(windowIndex); err != nil {
 					h.setError(fmt.Errorf("kill window %d: %w", windowIndex, err))
 					return nil

--- a/internal/ui/window_delete_test.go
+++ b/internal/ui/window_delete_test.go
@@ -1,11 +1,110 @@
 package ui
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// armKillWindowHome builds a Home whose confirm dialog targets a live
+// isolated tmux session, so confirmAction's ConfirmKillWindow path can be
+// exercised end to end. Returns the home and the socket name.
+func armKillWindowHome(t *testing.T) (*Home, string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux binary not on PATH; skipping")
+	}
+
+	socket := fmt.Sprintf("kwg%d", os.Getpid())
+	target := "agentdeck_kwguard"
+	if out, err := exec.Command("tmux", "-L", socket, "new-session", "-d", "-x", "80", "-y", "24", "-s", target, "sleep", "300").CombinedOutput(); err != nil {
+		t.Fatalf("create tmux session: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	})
+
+	inst := &session.Instance{ID: "kw-1", Title: "kw", Status: session.StatusRunning}
+	inst.SetTmuxSessionForTest(&tmux.Session{Name: target, SocketName: socket})
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	home.instancesMu.Unlock()
+
+	return home, socket, target
+}
+
+func windowCountVia(t *testing.T, socket, target string) int {
+	t.Helper()
+	out, err := exec.Command("tmux", "-L", socket, "list-windows", "-t", target, "-F", "#{window_index}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-windows: %v: %s", err, out)
+	}
+	return len(strings.Split(strings.TrimSpace(string(out)), "\n"))
+}
+
+// TestConfirmKillWindow_RefusesLastWindow — confirming a kill when the
+// session has only one window left must refuse with an error instead of
+// killing the window (which would take the whole session down). The window
+// row was rendered when 2+ windows existed, but the other window can close
+// between rendering and confirmation.
+func TestConfirmKillWindow_RefusesLastWindow(t *testing.T) {
+	home, socket, target := armKillWindowHome(t)
+
+	home.confirmDialog.ShowKillWindow("kw-1", 1, "agent")
+	_ = home.confirmAction()
+
+	if home.err == nil || !strings.Contains(home.err.Error(), "last window") {
+		t.Fatalf("confirmAction on a 1-window session should refuse with a last-window error, got %v", home.err)
+	}
+	if got := windowCountVia(t, socket, target); got != 1 {
+		t.Fatalf("window count = %d, want 1 (the last window must survive)", got)
+	}
+}
+
+// TestConfirmKillWindow_KillsWhenMultipleWindows — with 2+ windows the
+// confirmed kill removes exactly the targeted window.
+func TestConfirmKillWindow_KillsWhenMultipleWindows(t *testing.T) {
+	home, socket, target := armKillWindowHome(t)
+
+	if out, err := exec.Command("tmux", "-L", socket, "new-window", "-t", target, "sleep", "300").CombinedOutput(); err != nil {
+		t.Fatalf("new-window: %v: %s", err, out)
+	}
+	out, err := exec.Command("tmux", "-L", socket, "list-windows", "-t", target, "-F", "#{window_index}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-windows: %v: %s", err, out)
+	}
+	windows := strings.Fields(strings.TrimSpace(string(out)))
+	if len(windows) != 2 {
+		t.Fatalf("setup: window count = %d, want 2", len(windows))
+	}
+
+	var newIndex int
+	if _, err := fmt.Sscanf(windows[1], "%d", &newIndex); err != nil {
+		t.Fatalf("parse window index %q: %v", windows[1], err)
+	}
+
+	home.confirmDialog.ShowKillWindow("kw-1", newIndex, "shell")
+	_ = home.confirmAction()
+
+	if home.err != nil {
+		t.Fatalf("confirmAction with 2 windows should kill without error, got %v", home.err)
+	}
+	if got := windowCountVia(t, socket, target); got != 1 {
+		t.Fatalf("window count = %d, want 1 after kill", got)
+	}
+}
 
 // TestDeleteKey_OnWindowItem_OpensKillWindowConfirm — 'd' over a window
 // sub-item opens a kill-window confirmation, mirroring the delete-session

--- a/internal/ui/window_delete_test.go
+++ b/internal/ui/window_delete_test.go
@@ -54,6 +54,17 @@ func windowCountVia(t *testing.T, socket, target string) int {
 	return len(strings.Split(strings.TrimSpace(string(out)), "\n"))
 }
 
+// TestKillWindow_RemoteSessionNotApplicable documents that the kill-window
+// flow is intentionally local-only. Window sub-items (ItemTypeWindow) are
+// injected under local sessions from the local tmux window cache
+// (GetCachedWindows in rebuildFlatItems); ItemTypeRemoteSession rows never
+// grow window sub-items, so the 'd' handler's ItemTypeWindow branch is
+// unreachable for remote sessions. If remote window listing is ever added,
+// this skip should be replaced with real RemoteSession coverage.
+func TestKillWindow_RemoteSessionNotApplicable(t *testing.T) {
+	t.Skip("kill-window is local-only by design: remote sessions have no window sub-items to select")
+}
+
 // TestConfirmKillWindow_RefusesLastWindow — confirming a kill when the
 // session has only one window left must refuse with an error instead of
 // killing the window (which would take the whole session down). The window

--- a/internal/ui/window_delete_test.go
+++ b/internal/ui/window_delete_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestDeleteKey_OnWindowItem_OpensKillWindowConfirm — 'd' over a window
+// sub-item opens a kill-window confirmation, mirroring the delete-session
+// confirmation shown for session rows.
+func TestDeleteKey_OnWindowItem_OpensKillWindowConfirm(t *testing.T) {
+	h := newSeamATestHome()
+	h.flatItems = []session.Item{
+		newRemoveTestItem("id-1", "agent-deck", session.StatusRunning),
+		{
+			Type:            session.ItemTypeWindow,
+			WindowIndex:     2,
+			WindowName:      "/agent-deck",
+			WindowSessionID: "id-1",
+		},
+	}
+	h.cursor = 1
+
+	newModel, _ := h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	got := newModel.(*Home)
+
+	if !got.confirmDialog.IsVisible() {
+		t.Fatalf("confirm dialog should be visible after 'd' on window item")
+	}
+	if got.confirmDialog.GetConfirmType() != ConfirmKillWindow {
+		t.Fatalf("expected ConfirmKillWindow, got %v", got.confirmDialog.GetConfirmType())
+	}
+	if got.confirmDialog.GetTargetID() != "id-1" {
+		t.Fatalf("expected targetID 'id-1', got %q", got.confirmDialog.GetTargetID())
+	}
+	if got.confirmDialog.GetWindowIndex() != 2 {
+		t.Fatalf("expected window index 2, got %d", got.confirmDialog.GetWindowIndex())
+	}
+}
+
+// TestCuratedFooterWindowItemShowsDelete — the curated footer on a window
+// sub-item advertises attach then delete, mirroring session rows now that
+// 'd' kills the selected window.
+func TestCuratedFooterWindowItemShowsDelete(t *testing.T) {
+	home := curatedHome()
+	home.flatItems = []session.Item{{
+		Type:            session.ItemTypeWindow,
+		WindowIndex:     2,
+		WindowName:      "/agent-deck",
+		WindowSessionID: "id-1",
+	}}
+	home.cursor = 0
+
+	hints := home.curatedContextHints(home.flatItems[0])
+	got := make([]string, len(hints))
+	for i, hint := range hints {
+		got[i] = hint.label
+	}
+	want := []string{"attach", "delete"}
+	if len(got) != len(want) {
+		t.Fatalf("window item context hints = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("window item context hints = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Pressing `d` on a session row asks to delete the session, but on a window sub-item (`[1] [2] [3]` under a session) it silently did nothing. Once a session accumulates extra windows — a shell opened next to the agent, for instance — there is no way to close one from the deck; you have to attach and kill it by hand inside tmux.

## Why this change

Mirrors the existing delete flow at the window level: `d` on a window row opens a confirmation dialog (defaulting to Cancel, like delete-session), and confirming runs `tmux kill-window` on just that window. A confirmation dialog rather than an instant kill keeps parity with how every other destructive action in the TUI behaves. The window cache entry is pruned on confirm so the row disappears immediately instead of lingering until the next background refresh tick. The curated footer on window rows now advertises `attach · delete` so the capability is discoverable.

## User impact

New behavior only where `d` previously did nothing (window sub-items). Session, group, and remote delete flows are untouched. Note the agent's own window is also killable this way — the confirmation dialog is the guard, same as for sessions.

## Evidence

Real tmux capture of the flow (windows renumber per tmux config):

```
--- before d on window [2] (shell-a):
1: agent
2: shell-a
3: shell-b
--- after confirming kill:
1: agent
2: shell-b
```

Tests (the KillWindow one runs against a real isolated tmux server):

```
--- PASS: TestSession_KillWindow (0.04s)
--- PASS: TestRemoveCachedWindow (0.00s)
ok      github.com/asheshgoplani/agent-deck/internal/tmux
--- PASS: TestDeleteKey_OnWindowItem_OpensKillWindowConfirm (0.00s)
--- PASS: TestCuratedFooterWindowItemShowsDelete (0.02s)
ok      github.com/asheshgoplani/agent-deck/internal/ui
```

All four tests were written first and watched fail before implementation. Full `internal/ui` suite passes; `gofmt -l ./cmd ./internal` prints nothing; `go vet` is clean. Sandboxed suite on my Mac fails in `internal/testutil`/`internal/tmux`/`internal/tmuxutf8` identically on pristine `upstream/main` (machine-specific tmux client-classification and socket-path-length issues, verified side by side) — this branch introduces no new failures.

## AI disclosure

- [ ] Human-authored
- [x] AI-assisted (a model helped, a human wrote most of it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5

## What actually bothered you

My human asked: "when I hit d on a session it asks me to delete, can we have the same behavior on the sub tabs?"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — three packages fail on this machine, but the identical set fails on pristine `upstream/main` here (environment-specific tmux issues; details under Evidence)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=claude-fable-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete individual terminal windows directly from the window list.
  * Added a confirmation dialog showing the target window and available keyboard actions.
  * Window lists now update immediately after deletion.
  * Added a delete action alongside the existing attach action.
  * Prevented deletion of the last remaining window.

* **Tests**
  * Added coverage for window deletion, cache updates, confirmation behavior, and action hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->