### PR TITLE
feat(ui): fzf-style fuzzy path suggestions in session and group dialogs

### DIFF
--- a/internal/ui/editpaths_dialog.go
+++ b/internal/ui/editpaths_dialog.go
@@ -163,20 +163,16 @@ func (d *EditPathsDialog) Validate() string {
 	return ""
 }
 
+// filterPathSuggestions filters the corpus against the current input.
+// Matching is fuzzy (shared with NewDialog/GroupDialog); path-shaped queries
+// additionally pull live filesystem subdirectory completions.
 func (d *EditPathsDialog) filterPathSuggestions() {
 	input := strings.TrimSpace(d.pathInput.Value())
 	if input == "" {
 		d.pathSuggestions = d.allPathSuggestions
 		return
 	}
-	lower := strings.ToLower(input)
-	var filtered []string
-	for _, s := range d.allPathSuggestions {
-		if strings.Contains(strings.ToLower(s), lower) {
-			filtered = append(filtered, s)
-		}
-	}
-	d.pathSuggestions = filtered
+	d.pathSuggestions = filterPathSuggestions(d.allPathSuggestions, input)
 }
 
 func (d *EditPathsDialog) Update(msg tea.Msg) (*EditPathsDialog, tea.Cmd) {

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -38,6 +38,17 @@ type GroupDialog struct {
 	// Tab toggle between Root and Subgroup modes (Issue #111)
 	contextParentPath string // Original cursor context parent path (for toggling back)
 	contextParentName string // Original cursor context parent name (for toggling back)
+
+	// Fzf-like live suggestions for the Default Path field in Create mode.
+	// suggestProvider supplies the candidate corpus (recents + group defaults)
+	// each time the dialog opens; typing fuzzy-filters it live, and path-shaped
+	// queries additionally pull filesystem subdirectory completions.
+	suggestProvider        func() []string
+	allPathSuggestions     []string // full candidate corpus from the provider
+	pathSuggestions        []string // filtered subset shown in the dropdown
+	pathSuggestionCursor   int      // highlighted index into pathSuggestions (-1 = none)
+	pathSuggestionsHidden  bool     // true after Esc until the user types again
+	pathDropdownLineOffset int      // content line of the Default Path row (View-computed)
 }
 
 // NewGroupDialog creates a new group dialog
@@ -163,6 +174,7 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.nameInput.CursorEnd() // Issue #604: place cursor at end of pre-filled name.
 	// Issue #1068: must reset focusIndex and blur pathInput, otherwise stale
 	// state from a prior Create-dialog Tab routes keys to the invisible path.
+	g.resetPathInput() // also drops stale suggestion corpus (rename has no path field)
 	g.focusName()
 }
 
@@ -185,6 +197,7 @@ func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.nameInput.CursorEnd() // Issue #604: place cursor at end of pre-filled name.
 	// Issue #1068: must reset focusIndex and blur pathInput, otherwise stale
 	// state from a prior Create-dialog Tab routes keys to the invisible path.
+	g.resetPathInput() // also drops stale suggestion corpus (rename has no path field)
 	g.focusName()
 }
 
@@ -221,12 +234,114 @@ func (g *GroupDialog) GetDefaultPath() string {
 	return strings.TrimSpace(g.pathInput.Value())
 }
 
+// SetSuggestProvider wires the candidate corpus source for the Default Path
+// suggestions. It is consulted each time the dialog opens in Create mode, so
+// recents captured since the last open are included.
+func (g *GroupDialog) SetSuggestProvider(fn func() []string) {
+	g.suggestProvider = fn
+}
+
+// SetPathSuggestions overrides the candidate corpus directly (used by tests
+// and by callers that want to pin the list for a single dialog session).
+func (g *GroupDialog) SetPathSuggestions(paths []string) {
+	g.allPathSuggestions = paths
+	g.filterPathSuggestions()
+}
+
+// refreshPathSuggestions pulls a fresh corpus from the provider (when wired)
+// and refilters. Called on every Create-mode open so stale candidates never
+// linger across dialogs.
+func (g *GroupDialog) refreshPathSuggestions() {
+	if g.suggestProvider != nil {
+		g.allPathSuggestions = g.suggestProvider()
+	}
+	g.pathSuggestionsHidden = false
+	g.filterPathSuggestions()
+}
+
+// filterPathSuggestions fuzzy-filters the corpus against the current input.
+// The first match stays highlighted, fzf-style, so Tab/Enter accept without
+// any arrow keys when the top hit is already right.
+func (g *GroupDialog) filterPathSuggestions() {
+	query := strings.TrimSpace(g.pathInput.Value())
+	if query == "" {
+		g.pathSuggestions = g.allPathSuggestions
+	} else {
+		g.pathSuggestions = filterPathSuggestions(g.allPathSuggestions, query)
+	}
+	switch {
+	case len(g.pathSuggestions) == 0:
+		g.pathSuggestionCursor = -1
+	case g.pathSuggestionCursor < 0 || g.pathSuggestionCursor >= len(g.pathSuggestions):
+		g.pathSuggestionCursor = 0
+	}
+}
+
+// IsPathDropdownVisible reports whether the live suggestion dropdown should be
+// rendered: Create mode, path field focused, at least one candidate, and not
+// explicitly dismissed with Esc.
+func (g *GroupDialog) IsPathDropdownVisible() bool {
+	return g.mode == GroupDialogCreate &&
+		g.focusIndex == 1 &&
+		!g.pathSuggestionsHidden &&
+		len(g.pathSuggestions) > 0
+}
+
+// navigatePathSuggestions moves the dropdown highlight by delta. Returns
+// false (caller falls through to other bindings, e.g. Root/Subgroup toggle)
+// when the dropdown has nothing to navigate.
+func (g *GroupDialog) navigatePathSuggestions(delta int) bool {
+	if !g.IsPathDropdownVisible() {
+		return false
+	}
+	total := len(g.pathSuggestions)
+	g.pathSuggestionCursor = ((g.pathSuggestionCursor+delta)%total + total) % total
+	return true
+}
+
+// ApplyHighlightedPathSuggestion writes the highlighted suggestion into the
+// input and hides the dropdown so the next Enter submits instead of
+// re-accepting. Returns false when no suggestion was highlighted (caller
+// proceeds with its own handling).
+func (g *GroupDialog) ApplyHighlightedPathSuggestion() bool {
+	if !g.IsPathDropdownVisible() || g.pathSuggestionCursor < 0 ||
+		g.pathSuggestionCursor >= len(g.pathSuggestions) {
+		return false
+	}
+	g.pathInput.SetValue(g.pathSuggestions[g.pathSuggestionCursor])
+	g.pathInput.SetCursor(len(g.pathInput.Value()))
+	g.pathSuggestionsHidden = true
+	return true
+}
+
+// DismissPathSuggestions hides the dropdown until the user types again.
+// Returns true when a visible dropdown was dismissed, so the parent can treat
+// Esc as "dismiss picker first, close dialog second".
+func (g *GroupDialog) DismissPathSuggestions() bool {
+	if !g.IsPathDropdownVisible() {
+		return false
+	}
+	g.pathSuggestionsHidden = true
+	return true
+}
+
 // resetPathInput clears the path field and blurs it. Called by every Show*
 // entry point so a previous Create dialog never leaks its path into a Rename.
+// In Create mode it also refreshes the suggestion corpus from the provider.
 func (g *GroupDialog) resetPathInput() {
 	g.pathInput.SetValue("")
 	g.pathInput.CursorEnd()
 	g.pathInput.Blur()
+	if g.mode == GroupDialogCreate {
+		g.refreshPathSuggestions() // also unhides and refilters (cursor clamped)
+		return
+	}
+	// Non-create modes expose no path field: drop any suggestion state so a
+	// stale dropdown can never be resurrected by a later Tab traversal.
+	g.allPathSuggestions = nil
+	g.pathSuggestions = nil
+	g.pathSuggestionsHidden = false
+	g.pathSuggestionCursor = -1
 }
 
 // focusName focuses the name input and updates the focus index accordingly.
@@ -340,6 +455,11 @@ func (g *GroupDialog) Update(msg tea.KeyMsg) (*GroupDialog, tea.Cmd) {
 	if g.mode == GroupDialogCreate {
 		switch msg.String() {
 		case "tab":
+			// Accept the highlighted path suggestion instead of advancing
+			// focus; the dropdown closes so the next Enter submits the form.
+			if g.ApplyHighlightedPathSuggestion() {
+				return g, nil
+			}
 			if g.focusIndex == 0 {
 				g.focusPath()
 			} else {
@@ -354,21 +474,47 @@ func (g *GroupDialog) Update(msg tea.KeyMsg) (*GroupDialog, tea.Cmd) {
 			}
 			return g, nil
 		case "up", "down":
-			// Issue #1536: Root/Subgroup toggle, rebound off Tab. No-op (falls
-			// through to the text input, which ignores Up/Down) when there is no
-			// group context to toggle into.
+			// Navigate the suggestion dropdown while it has matches to show;
+			// only when it does not (or the field is not focused) does Up/Down
+			// keep its Issue #1536 Root/Subgroup toggle role. No-op (falls
+			// through to the text input, which ignores Up/Down) when there is
+			// neither a dropdown nor a group context to toggle into.
+			delta := 1
+			if msg.String() == "up" {
+				delta = -1
+			}
+			if g.focusIndex == 1 && g.navigatePathSuggestions(delta) {
+				return g, nil
+			}
 			if g.CanToggle() {
 				g.ToggleRootSubgroup()
+				return g, nil
+			}
+		case "ctrl+n", "ctrl+p":
+			// Emacs-style navigation that never collides with the Root/Subgroup
+			// toggle or text cursor movement.
+			delta := 1
+			if msg.String() == "ctrl+p" {
+				delta = -1
+			}
+			if g.navigatePathSuggestions(delta) {
 				return g, nil
 			}
 		}
 	}
 
 	var cmd tea.Cmd
+	prevPath := g.pathInput.Value()
 	if g.focusIndex == 1 {
 		g.pathInput, cmd = g.pathInput.Update(msg)
 	} else {
 		g.nameInput, cmd = g.nameInput.Update(msg)
+	}
+	// Live filtering: any edit to the path field re-runs the fuzzy match and
+	// re-opens a dropdown previously dismissed with Esc.
+	if g.mode == GroupDialogCreate && g.pathInput.Value() != prevPath {
+		g.pathSuggestionsHidden = false
+		g.filterPathSuggestions()
 	}
 	return g, cmd
 }
@@ -449,10 +595,26 @@ func (g *GroupDialog) View() string {
 	dialogWidth := fitDialogWidth(44, 30, g.width)
 	titleWidth := dialogWidth - 4
 
+	// Content line of the Default Path row (for anchoring the suggestion
+	// dropdown overlay): title + blank, then the optional toggle tabs block
+	// (2 lines) and parent info block (2 lines), then the Name row.
+	g.pathDropdownLineOffset = 2
+	if g.mode == GroupDialogCreate {
+		if g.CanToggle() {
+			g.pathDropdownLineOffset += 2
+		}
+		if g.parentName != "" {
+			g.pathDropdownLineOffset += 2
+		}
+		g.pathDropdownLineOffset += 1 // Name row
+	}
+
 	titleStyle := DialogTitleStyle.Width(titleWidth)
 	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	var hint string
 	switch {
+	case g.mode == GroupDialogCreate && g.IsPathDropdownVisible():
+		hint = hintStyle.Render("↑↓ select │ Tab/Enter accept │ Esc dismiss")
 	case g.mode == GroupDialogCreate && g.CanToggle():
 		hint = hintStyle.Render("↑↓ Root/Subgroup │ Tab next │ Shift+Tab prev │ Enter confirm │ Esc cancel")
 	case g.mode == GroupDialogCreate:
@@ -481,12 +643,118 @@ func (g *GroupDialog) View() string {
 		Width(dialogWidth).
 		Render(dialogContent)
 
-	// Center the dialog
-	return lipgloss.Place(
+	placed := lipgloss.Place(
 		g.width,
 		g.height,
 		lipgloss.Center,
 		lipgloss.Center,
 		dialog,
 	)
+
+	// Overlay the path suggestion dropdown as a floating menu anchored to the
+	// Default Path row, so its appearance/disappearance never shifts layout.
+	if suggestionsOverlay := g.renderPathDropdown(); suggestionsOverlay != "" {
+		topRow, leftCol := dialogOrigin(g.width, g.height, lipgloss.Width(dialog), lipgloss.Height(dialog))
+		// Rows: border (1) + vertical padding (1) + content offset. Columns:
+		// measure the rendered row's own leading spaces so JoinVertical's
+		// centering can never skew the anchor.
+		overlayRow := topRow + 1 + 1 + g.pathDropdownLineOffset
+		dialogLines := strings.Split(dialog, "\n")
+		lineIdx := overlayRow - topRow
+		leading := 0
+		if lineIdx >= 0 && lineIdx < len(dialogLines) {
+			leading = leadingVisibleSpaces(stripAnsi(dialogLines[lineIdx]))
+		}
+		overlayCol := leftCol + leading
+
+		placed = overlayDropdown(placed, suggestionsOverlay, overlayRow, overlayCol)
+	}
+
+	return placed
+}
+
+// renderPathDropdown renders the Default Path suggestions as a standalone
+// bordered block for overlay positioning. Empty when nothing should show.
+func (g *GroupDialog) renderPathDropdown() string {
+	if !g.IsPathDropdownVisible() {
+		return ""
+	}
+
+	menuBg := dropdownMenuBg()
+	suggestionStyle := lipgloss.NewStyle().Foreground(ColorComment).Background(menuBg)
+	selectedStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true).Background(menuBg)
+
+	var b strings.Builder
+
+	maxShow := 5
+	if g.height > 0 && g.height <= 30 {
+		maxShow = 3
+	}
+	total := len(g.pathSuggestions)
+	startIdx := 0
+	endIdx := total
+	if total > maxShow {
+		startIdx = g.pathSuggestionCursor - maxShow/2
+		if startIdx < 0 {
+			startIdx = 0
+		}
+		endIdx = startIdx + maxShow
+		if endIdx > total {
+			endIdx = total
+			startIdx = endIdx - maxShow
+		}
+	}
+
+	if startIdx > 0 {
+		b.WriteString(suggestionStyle.Render(fmt.Sprintf("  ↑ %d more above", startIdx)))
+		b.WriteString("\n")
+	}
+	for i := startIdx; i < endIdx; i++ {
+		if i > startIdx {
+			b.WriteString("\n")
+		}
+		style := suggestionStyle
+		prefix := "  "
+		if i == g.pathSuggestionCursor {
+			style = selectedStyle
+			prefix = "▶ "
+		}
+		b.WriteString(style.Render(prefix + g.pathSuggestions[i]))
+	}
+	if endIdx < total {
+		b.WriteString("\n")
+		b.WriteString(suggestionStyle.Render(fmt.Sprintf("  ↓ %d more below", total-endIdx)))
+	}
+
+	// Footer: match count when filtered, plus the key hints.
+	var footerText string
+	if len(g.pathSuggestions) < len(g.allPathSuggestions) {
+		footerText = fmt.Sprintf(" %d/%d matches │ ↑↓ select │ Tab/Enter accept │ Esc dismiss ",
+			len(g.pathSuggestions), len(g.allPathSuggestions))
+	} else {
+		footerText = " ↑↓ select │ Tab/Enter accept │ Esc dismiss "
+	}
+	b.WriteString("\n")
+	b.WriteString(lipgloss.NewStyle().Foreground(ColorBorder).Background(menuBg).Render(footerText))
+
+	menuStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorBorder).
+		Background(menuBg).
+		Padding(0, 1)
+
+	return menuStyle.Render(b.String())
+}
+
+// leadingVisibleSpaces counts the space characters before the first
+// non-space character of an ANSI-stripped line.
+func leadingVisibleSpaces(s string) int {
+	n := 0
+	for _, r := range s {
+		if r != ' ' {
+			break
+		}
+		n++
+	}
+	return n
 }

--- a/internal/ui/group_dialog_suggestions_test.go
+++ b/internal/ui/group_dialog_suggestions_test.go
@@ -1,0 +1,170 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func keyRunes(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func TestGroupDialogSuggestions_ProviderLoadedOnShow(t *testing.T) {
+	g := NewGroupDialog()
+	corpus := []string{"/home/me/agent-deck", "/home/me/other-project"}
+	g.SetSuggestProvider(func() []string { return corpus })
+
+	g.Show()
+	if len(g.allPathSuggestions) != 2 {
+		t.Fatalf("expected provider corpus loaded on Show, got %v", g.allPathSuggestions)
+	}
+	// Path field is not focused yet (name has focus): no dropdown.
+	if g.IsPathDropdownVisible() {
+		t.Fatal("dropdown must not be visible while the name field is focused")
+	}
+
+	g.focusPath()
+	if !g.IsPathDropdownVisible() {
+		t.Fatal("dropdown should be visible when the path field is focused with candidates")
+	}
+	if g.pathSuggestionCursor != 0 {
+		t.Fatalf("first candidate should be highlighted, got cursor %d", g.pathSuggestionCursor)
+	}
+}
+
+func TestGroupDialogSuggestions_LiveFuzzyFiltering(t *testing.T) {
+	g := NewGroupDialog()
+	g.Show()
+	g.SetPathSuggestions([]string{
+		"/home/me/projects/agent-deck",
+		"/home/me/documents",
+	})
+	g.focusPath()
+
+	g.Update(keyRunes("a"))
+	g.Update(keyRunes("d"))
+	g.Update(keyRunes("k"))
+
+	if len(g.pathSuggestions) != 1 || g.pathSuggestions[0] != "/home/me/projects/agent-deck" {
+		t.Fatalf("expected fuzzy hit for 'adk', got %v", g.pathSuggestions)
+	}
+	if !g.IsPathDropdownVisible() || g.pathSuggestionCursor != 0 {
+		t.Fatalf("dropdown should stay visible with first hit highlighted, cursor=%d", g.pathSuggestionCursor)
+	}
+}
+
+func TestGroupDialogSuggestions_NavigateAndAcceptWithTab(t *testing.T) {
+	g := NewGroupDialog()
+	g.Show()
+	g.SetPathSuggestions([]string{"/alpha", "/beta"})
+	g.focusPath()
+
+	// Down moves highlight to the second entry.
+	g.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if g.pathSuggestionCursor != 1 {
+		t.Fatalf("cursor = %d, want 1 after Down", g.pathSuggestionCursor)
+	}
+
+	g.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if got := g.GetDefaultPath(); got != "/beta" {
+		t.Fatalf("Tab should accept the highlighted suggestion, got %q", got)
+	}
+	if g.IsPathDropdownVisible() {
+		t.Fatal("dropdown should hide after acceptance")
+	}
+}
+
+func TestGroupDialogSuggestions_EnterConsumedByParentGuard(t *testing.T) {
+	g := NewGroupDialog()
+	g.Show()
+	g.SetPathSuggestions([]string{"/alpha"})
+	g.focusPath()
+
+	if !g.ApplyHighlightedPathSuggestion() {
+		t.Fatal("Enter guard should consume when a suggestion is highlighted")
+	}
+	if got := g.GetDefaultPath(); got != "/alpha" {
+		t.Fatalf("suggestion value not applied, got %q", got)
+	}
+	// After acceptance the next Enter must reach normal submit handling.
+	if g.ApplyHighlightedPathSuggestion() {
+		t.Fatal("guard must not consume twice; dropdown is dismissed")
+	}
+}
+
+func TestGroupDialogSuggestions_EscDismissesThenTypingReopens(t *testing.T) {
+	g := NewGroupDialog()
+	g.Show()
+	g.SetPathSuggestions([]string{"/alpha", "/beta"})
+	g.focusPath()
+
+	if !g.DismissPathSuggestions() {
+		t.Fatal("Esc should dismiss a visible dropdown")
+	}
+	if g.DismissPathSuggestions() {
+		t.Fatal("second Esc should fall through to dialog close")
+	}
+	if g.IsPathDropdownVisible() {
+		t.Fatal("dropdown should be hidden after Esc")
+	}
+
+	// Typing re-opens live filtering.
+	g.Update(keyRunes("a"))
+	if !g.IsPathDropdownVisible() {
+		t.Fatal("typing should reopen the dropdown after dismissal")
+	}
+}
+
+func TestGroupDialogSuggestions_UpDownFallThroughToToggleWithoutMatches(t *testing.T) {
+	g := NewGroupDialog()
+	g.ShowCreateWithContext("/work/team", "team") // Tab toggle available
+	g.SetPathSuggestions([]string{"/alpha"})
+	g.focusPath()
+
+	// Filter down to nothing so the dropdown cannot navigate.
+	g.Update(keyRunes("z"))
+	g.Update(keyRunes("z"))
+	g.Update(keyRunes("z"))
+	if len(g.pathSuggestions) != 0 {
+		t.Fatalf("expected zero matches, got %v", g.pathSuggestions)
+	}
+
+	before := g.groupPath
+	g.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if g.groupPath == before {
+		t.Fatal("Up should toggle Root/Subgroup when there is nothing to navigate")
+	}
+}
+
+func TestGroupDialogSuggestions_ViewRendersDropdownOverlay(t *testing.T) {
+	g := NewGroupDialog()
+	g.SetSize(100, 40)
+	g.Show()
+	g.SetPathSuggestions([]string{"/home/me/agent-deck"})
+	g.focusPath()
+
+	view := g.View()
+	if !strings.Contains(view, "/home/me/agent-deck") {
+		t.Fatal("rendered view should contain the path suggestion overlay")
+	}
+	if !strings.Contains(view, "Tab/Enter accept") {
+		t.Fatal("rendered dropdown footer hints missing")
+	}
+}
+
+func TestGroupDialogSuggestions_ResetOnRenameMode(t *testing.T) {
+	g := NewGroupDialog()
+	g.Show()
+	g.SetPathSuggestions([]string{"/alpha"})
+	g.focusPath()
+
+	g.ShowRename("/old", "old-name")
+	if len(g.pathSuggestions) != 0 {
+		t.Fatalf("rename mode should clear suggestions, got %v", g.pathSuggestions)
+	}
+	if g.IsPathDropdownVisible() {
+		t.Fatal("no dropdown in rename mode")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1560,6 +1560,10 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	h.reloadHotkeysFromConfig()
 
+	// Fzf-like Default Path suggestions in the group dialog share the unified
+	// frecency-ranked corpus (recents + group defaults) with the zoxide picker.
+	h.groupDialog.SetSuggestProvider(h.groupDialogPathCandidates)
+
 	// Cache display settings (config.toml [display]) and resolve the
 	// status-bar cost-line template once. The template + hide flag are
 	// reused on every render; see (*Home).renderStats.
@@ -11228,6 +11232,11 @@ func (h *Home) reapplyPendingGroupOps() bool {
 func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "enter":
+		// Enter with a highlighted path suggestion accepts it instead of
+		// submitting the form; the dropdown closes so the next Enter submits.
+		if h.groupDialog.ApplyHighlightedPathSuggestion() {
+			return h, nil
+		}
 		// Validate before proceeding
 		if validationErr := h.groupDialog.Validate(); validationErr != "" {
 			h.groupDialog.SetError(validationErr)
@@ -11398,6 +11407,11 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
 		return h, nil
 	case "esc":
+		// First Esc dismisses the path suggestion dropdown only; the dialog
+		// stays open (mirrors the model-picker Esc handling in #1162).
+		if h.groupDialog.DismissPathSuggestions() {
+			return h, nil
+		}
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
@@ -12541,6 +12555,38 @@ func (h *Home) pathSuggestProvider() func(string) []session.PathCandidate {
 			Query:         query,
 		})
 	}
+}
+
+// groupDialogPathCandidates snapshots the ranked candidate paths for the
+// group dialog's Default Path suggestions: recent session paths + group
+// default paths via session.PathSuggest. Zoxide is intentionally excluded —
+// the corpus is fetched once per dialog open, not per keystroke, and the
+// fuzzy filter plus live filesystem completions cover discovery from there.
+func (h *Home) groupDialogPathCandidates() []string {
+	var groupDefaults []string
+	if h.groupTree != nil {
+		for groupPath := range h.groupTree.Groups {
+			if dp := h.getDefaultPathForGroup(groupPath); dp != "" {
+				groupDefaults = append(groupDefaults, dp)
+			}
+		}
+	}
+
+	h.instancesMu.RLock()
+	insts := make([]*session.Instance, len(h.instances))
+	copy(insts, h.instances)
+	h.instancesMu.RUnlock()
+
+	cands := session.PathSuggest(session.PathSuggestInput{
+		Instances:     insts,
+		GroupDefaults: groupDefaults,
+		Limit:         20,
+	})
+	out := make([]string, 0, len(cands))
+	for _, c := range cands {
+		out = append(out, c.Path)
+	}
+	return out
 }
 
 // quickCreateSessionAt creates a session rooted at the given path with an

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -981,19 +981,16 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 	d.rebuildFocusTargets()
 }
 
-// filterPathSuggestions filters allPathSuggestions by the current path input value
+// filterPathSuggestions filters allPathSuggestions by the current path input
+// value. Matching is fuzzy ("adk" → /home/me/agent-deck), ranked by match
+// score; path-shaped queries ("/ho", "~/dev") additionally pull live
+// filesystem subdirectory completions.
 func (d *NewDialog) filterPathSuggestions() {
-	query := strings.ToLower(strings.TrimSpace(d.pathInput.Value()))
+	query := strings.TrimSpace(d.pathInput.Value())
 	if query == "" {
 		d.pathSuggestions = d.allPathSuggestions
 	} else {
-		filtered := make([]string, 0)
-		for _, p := range d.allPathSuggestions {
-			if strings.Contains(strings.ToLower(p), query) {
-				filtered = append(filtered, p)
-			}
-		}
-		d.pathSuggestions = filtered
+		d.pathSuggestions = filterPathSuggestions(d.allPathSuggestions, query)
 	}
 	// Cursor space: 0 = "Type custom", 1..N = pathSuggestions[0..N-1]
 	if d.pathSuggestionCursor > len(d.pathSuggestions) {

--- a/internal/ui/pathfuzzy.go
+++ b/internal/ui/pathfuzzy.go
@@ -1,0 +1,103 @@
+package ui
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/sahilm/fuzzy"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// dirCompletionsFn returns the directories matching a partial path prefix.
+// Package-level so tests can stub the filesystem out.
+var dirCompletionsFn = session.GetDirectoryCompletions
+
+// maxPathSuggestions caps how many entries a filtered suggestion list may
+// hold. The dropdowns paginate around the cursor, but an unbounded list
+// makes the "N more below" counter useless and keeps cursor math fiddly.
+const maxPathSuggestions = 20
+
+// fuzzyFilterPaths filters candidates against query with sahilm/fuzzy,
+// case-insensitively, best match first. An empty (or whitespace-only) query
+// returns the candidates unchanged. Ties keep the candidate order, so callers
+// can pre-sort their corpus by recency/frequency.
+func fuzzyFilterPaths(candidates []string, query string) []string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return candidates
+	}
+
+	// sahilm/fuzzy matches case-sensitively; lowercase both sides so "MYPROJ"
+	// finds "/home/me/MyProject".
+	lowered := make([]string, len(candidates))
+	for i, c := range candidates {
+		lowered[i] = strings.ToLower(c)
+	}
+	matches := fuzzy.FindFrom(strings.ToLower(query), loweredSource(lowered))
+
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, candidates[m.Index])
+	}
+	return out
+}
+
+// loweredSource adapts a []string to fuzzy.Source.
+type loweredSource []string
+
+func (s loweredSource) String(i int) string { return s[i] }
+func (s loweredSource) Len() int            { return len(s) }
+
+// looksLikePartialPath reports whether the query should also pull live
+// filesystem directory completions. Bare words ("deck") only fuzzy-filter the
+// known corpus; anything path-shaped ("/ho", "~/dev", "./proj", "work/proj")
+// is treated as navigation and gets real subdirectory suggestions appended.
+func looksLikePartialPath(query string) bool {
+	if strings.ContainsRune(query, '/') {
+		return true
+	}
+	return strings.HasPrefix(query, "~")
+}
+
+// filterPathSuggestions merges two sources:
+//  1. fuzzy-filtered corpus (recents, group defaults, …), ranked by match score;
+//  2. live filesystem subdirectory completions when the query looks like a
+//     partial path — this is what lets users discover directories they have
+//     never opened in agent-deck before.
+//
+// The result is deduplicated (corpus wins over filesystem on exact matches)
+// and capped at maxPathSuggestions.
+func filterPathSuggestions(corpus []string, query string) []string {
+	filtered := fuzzyFilterPaths(corpus, query)
+
+	query = strings.TrimSpace(query)
+	if !looksLikePartialPath(query) {
+		return filtered
+	}
+
+	completions, err := dirCompletionsFn(query)
+	if err != nil || len(completions) == 0 {
+		return filtered
+	}
+
+	seen := make(map[string]bool, len(filtered))
+	for _, p := range filtered {
+		seen[p] = true
+	}
+	for _, c := range completions {
+		c = filepath.Clean(c)
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		filtered = append(filtered, c)
+		if len(filtered) >= maxPathSuggestions {
+			break
+		}
+	}
+	if len(filtered) > maxPathSuggestions {
+		filtered = filtered[:maxPathSuggestions]
+	}
+	return filtered
+}

--- a/internal/ui/pathfuzzy_test.go
+++ b/internal/ui/pathfuzzy_test.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFuzzyFilterPaths_EmptyQueryReturnsAll(t *testing.T) {
+	corpus := []string{"/a/alpha", "/b/beta"}
+	got := fuzzyFilterPaths(corpus, "")
+	if len(got) != 2 {
+		t.Fatalf("expected full corpus for empty query, got %v", got)
+	}
+}
+
+func TestFuzzyFilterPaths_SubsequenceMatch(t *testing.T) {
+	corpus := []string{
+		"/home/me/projects/agent-deck",
+		"/home/me/documents",
+	}
+	got := fuzzyFilterPaths(corpus, "adk")
+	if len(got) != 1 || got[0] != corpus[0] {
+		t.Fatalf("expected fuzzy hit on %q for query 'adk', got %v", corpus[0], got)
+	}
+}
+
+func TestFuzzyFilterPaths_CaseInsensitive(t *testing.T) {
+	corpus := []string{"/home/me/MyProject"}
+	got := fuzzyFilterPaths(corpus, "myproj")
+	if len(got) != 1 {
+		t.Fatalf("expected case-insensitive match, got %v", got)
+	}
+}
+
+func TestFuzzyFilterPaths_NoMatch(t *testing.T) {
+	corpus := []string{"/a/alpha", "/b/beta"}
+	got := fuzzyFilterPaths(corpus, "zzz")
+	if len(got) != 0 {
+		t.Fatalf("expected no matches for 'zzz', got %v", got)
+	}
+}
+
+// stubDirCompletions swaps the filesystem completer for a fake and restores
+// it when the test finishes.
+func stubDirCompletions(t *testing.T, fn func(string) ([]string, error)) {
+	t.Helper()
+	prev := dirCompletionsFn
+	dirCompletionsFn = fn
+	t.Cleanup(func() { dirCompletionsFn = prev })
+}
+
+func TestFilterPathSuggestions_BareWordSkipsFilesystem(t *testing.T) {
+	stubDirCompletions(t, func(string) ([]string, error) {
+		t.Error("filesystem completions must not run for bare-word queries")
+		return nil, nil
+	})
+	corpus := []string{"/home/me/agent-deck", "/home/me/other"}
+	got := filterPathSuggestions(corpus, "deck")
+	if len(got) != 1 || got[0] != corpus[0] {
+		t.Fatalf("expected single fuzzy hit, got %v", got)
+	}
+}
+
+func TestFilterPathSuggestions_PathQueryMergesFilesystem(t *testing.T) {
+	stubDirCompletions(t, func(query string) ([]string, error) {
+		if query != "/ho" {
+			t.Errorf("unexpected completion query %q", query)
+		}
+		return []string{"/home"}, nil
+	})
+	corpus := []string{"/home/me/agent-deck"}
+	got := filterPathSuggestions(corpus, "/ho")
+	found := false
+	for _, p := range got {
+		if p == "/home" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected filesystem completion /home merged in, got %v", got)
+	}
+}
+
+func TestFilterPathSuggestions_DedupsCorpusOverFilesystem(t *testing.T) {
+	stubDirCompletions(t, func(string) ([]string, error) {
+		return []string{"/home/me/agent-deck", "/home/newdir"}, nil
+	})
+	corpus := []string{"/home/me/agent-deck"}
+	got := filterPathSuggestions(corpus, "/age")
+	if len(got) != 2 {
+		t.Fatalf("expected deduped result of 2, got %v", got)
+	}
+	if got[0] != "/home/me/agent-deck" {
+		t.Fatalf("corpus match should rank first, got %v", got)
+	}
+}
+
+func TestFilterPathSuggestions_CappedAtMax(t *testing.T) {
+	stubDirCompletions(t, func(string) ([]string, error) {
+		out := make([]string, 0, maxPathSuggestions+10)
+		for i := 0; i < maxPathSuggestions+10; i++ {
+			out = append(out, filepath.Join("/fs", string(rune('a'+i))))
+		}
+		return out, nil
+	})
+	var corpus []string
+	got := filterPathSuggestions(corpus, "/f")
+	if len(got) != maxPathSuggestions {
+		t.Fatalf("expected results capped at %d, got %d", maxPathSuggestions, len(got))
+	}
+}
+
+func TestFilterPathSuggestions_FilesystemErrorIgnored(t *testing.T) {
+	stubDirCompletions(t, func(string) ([]string, error) {
+		return nil, os.ErrPermission
+	})
+	corpus := []string{"/home/me/agent-deck"}
+	got := filterPathSuggestions(corpus, "/ag")
+	if len(got) != 1 {
+		t.Fatalf("expected corpus-only fallback on fs error, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Directory inputs in the TUI now offer live, fzf-style fuzzy suggestions when assigning a path to a **new session** or a **group's Default Path** (and multi-repo path editing), instead of plain substring filtering — and the group dialog, which previously had no suggestions at all, gains a full dropdown.

- **Fuzzy matching everywhere**: typing `adk` surfaces `/home/me/projects/agent-deck`. Matches are ranked by score (sahilm/fuzzy, already a dependency), case-insensitive.
- **Live filesystem completions for path-shaped queries**: queries containing `/` or starting with `~` (e.g. `/ho`, `~/dev`) merge real subdirectory completions, so users can discover directories never opened in agent-deck. Bare words ("deck") only filter the known corpus — no surprise filesystem scans.
- **GroupDialog Default Path dropdown** (#918 follow-up): corpus = recent session paths + group default paths via the existing frecency-ranked `session.PathSuggest`, refreshed on every dialog open. First match is pre-highlighted; `↑/↓` navigate (falling through to the Root/Subgroup toggle from #1536 only when there are no matches to select), `Ctrl+N/P` always navigate, `Tab/Enter` accept, first `Esc` dismisses only the dropdown (mirrors the #1162 model-picker pattern), second `Esc` cancels the dialog.
- **NewDialog / EditPathsDialog** share the same filter helper for consistent behavior.

## Implementation notes

- New shared helper `internal/ui/pathfuzzy.go`: deterministic, capped (20) candidate list; filesystem completer is an injectable package var for tests.
- The group dialog overlay anchors to the rendered Default Path row (measured leading spaces), so JoinVertical centering can't skew placement; it reuses the existing `overlayDropdown` z-order trick from NewDialog.
- No new dependencies.

## Testing

- 17 new unit tests (`pathfuzzy_test.go`, `group_dialog_suggestions_test.go`) covering fuzzy ranking, case-insensitivity, FS-merge gating/dedup/cap, provider refresh on open, navigation/accept/dismiss flows, Root/Subgroup fall-through, and rename-mode state reset.
- Full `internal/ui` and `internal/session` suites pass; `go vet` and `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live fuzzy suggestions for the Default Path field when creating groups.
  - Suggestions include recent and frequently used paths, plus matching directory completions.
  - Added keyboard navigation and controls to accept or dismiss suggestions.
  - Path suggestions are now ranked by match quality and limited to the most relevant results.

- **Bug Fixes**
  - Improved path filtering consistency across dialogs.
  - Preserved dialog navigation behavior when no path suggestions match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->