### PR TITLE
fix(ui): expand tabs so a captured line cannot overflow the frame

### DIFF
--- a/internal/ui/cellwidth.go
+++ b/internal/ui/cellwidth.go
@@ -178,3 +178,104 @@ func fitDialogWidth(preferred, minWidth, termWidth int) int {
 	}
 	return w
 }
+
+// terminalTabWidth is the tab-stop interval every terminal we target uses: a
+// TAB advances the cursor to the next column that is a multiple of 8.
+const terminalTabWidth = 8
+
+// expandTabs replaces every TAB in s with the spaces a terminal would render in
+// its place, counting columns from the start of each line.
+//
+// Why this exists. ansi.StringWidth — and therefore cellWidth, fitCellWidth and
+// every width gate built on them — measures a TAB as ZERO cells, while the
+// terminal expands it to the next multiple-of-8 column. A captured pane line
+// carrying tabs (git status, `ls` column output) therefore passes the frame's
+// width clamp measuring exactly h.width while rendering 8 to 90 cells wider.
+// That row wraps, the alternate screen scrolls, and the header / filter bar /
+// SESSIONS title are pushed off the top. Bubble Tea's renderer repaints only
+// rows whose content changed, so the static rows never come back — they stay
+// blank until an attach/detach forces a full repaint. Expanding tabs to spaces
+// makes the measurement and the rendering agree, which is the only way a
+// fixed-cell frame can hold a tab at all.
+//
+// Escape sequences occupy no columns and are copied through untouched, so an
+// ANSI-coloured line expands at the same stops as its plain-text equivalent.
+// Column accounting is per grapheme cluster via cellWidth, so a wide glyph
+// before a tab moves the stop by the cells it actually occupies. CR and LF
+// reset the column, which makes the function safe on whole multi-line captures
+// as well as on single frame rows.
+func expandTabs(s string) string {
+	if !strings.ContainsRune(s, '\t') {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s) + terminalTabWidth)
+
+	col := 0
+	state := -1
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			n := escapeSequenceLen(s[i:])
+			b.WriteString(s[i : i+n])
+			i += n
+			continue
+		}
+
+		cluster, _, _, newState := uniseg.FirstGraphemeClusterInString(s[i:], state)
+		state = newState
+		if cluster == "" { // defensive: never spin on a malformed tail
+			b.WriteString(s[i:])
+			break
+		}
+		i += len(cluster)
+
+		switch cluster {
+		case "\t":
+			pad := terminalTabWidth - col%terminalTabWidth
+			b.WriteString(strings.Repeat(" ", pad))
+			col += pad
+		case "\n", "\r", "\r\n":
+			b.WriteString(cluster)
+			col = 0
+		default:
+			b.WriteString(cluster)
+			col += cellWidth(cluster)
+		}
+	}
+
+	return b.String()
+}
+
+// escapeSequenceLen returns the byte length of the escape sequence at the start
+// of s, which must begin with ESC. Handles CSI (ESC [ … final byte 0x40-0x7E),
+// OSC (ESC ] … BEL or ST) — the two shapes captured pane content actually
+// carries, SGR colour and OSC 8 hyperlinks — and treats anything else as a
+// two-byte escape. An unterminated sequence consumes the remainder, which
+// matches how a terminal would swallow it.
+func escapeSequenceLen(s string) int {
+	if len(s) < 2 {
+		return len(s)
+	}
+	switch s[1] {
+	case '[':
+		for i := 2; i < len(s); i++ {
+			if s[i] >= 0x40 && s[i] <= 0x7e {
+				return i + 1
+			}
+		}
+		return len(s)
+	case ']':
+		for i := 2; i < len(s); i++ {
+			if s[i] == 0x07 {
+				return i + 1
+			}
+			if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '\\' {
+				return i + 2
+			}
+		}
+		return len(s)
+	default:
+		return 2
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6836,7 +6836,13 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.previewFetchingID = ""
 		h.previewCacheTime[msg.previewKey] = time.Now()
 		if msg.err == nil {
-			h.previewCache[msg.previewKey] = msg.content
+			// Tabs cannot survive into a fixed-cell frame: ansi.StringWidth
+			// measures a TAB as zero cells while the terminal expands it to the
+			// next multiple-of-8 column, so a captured `git status` or `ls` line
+			// passes every width gate and still overflows the pane. Expand at
+			// ingest — one chokepoint for local and remote previews alike — so
+			// the cached content is already what the terminal will render.
+			h.previewCache[msg.previewKey] = expandTabs(msg.content)
 		}
 		h.previewCacheMu.Unlock()
 		return h, nil
@@ -15277,8 +15283,16 @@ func clampViewToViewport(content string, width, height int) string {
 		if i > 0 {
 			rendered.WriteByte('\n')
 		}
+		//
+		// expandTabs before fitting: a TAB measures zero cells through
+		// cellWidth but advances the terminal's cursor to the next
+		// multiple-of-8 column, so an un-expanded tab makes this clamp pad a
+		// row to width that the terminal then renders wider, wrapping it and
+		// scrolling the header off the alternate screen. Every row starts at
+		// column 0 here, so per-row expansion lands on the same stops the
+		// terminal would use.
 		rendered.WriteString(sgrReset)
-		rendered.WriteString(fitCellWidth(line, width))
+		rendered.WriteString(fitCellWidth(expandTabs(line), width))
 		rendered.WriteString(sgrReset)
 	}
 

--- a/internal/ui/tab_overflow_test.go
+++ b/internal/ui/tab_overflow_test.go
@@ -1,0 +1,161 @@
+// A TAB in rendered content used to garble the whole deck.
+//
+// ansi.StringWidth measures a TAB as ZERO cells. The terminal expands it to the
+// next multiple-of-8 column. So a preview row captured from a pane running
+// `git status` or `ls` (both emit real tabs, and tmux's capture-pane preserves
+// them) measured exactly h.width at every width gate — clampViewToViewport
+// included — and then rendered 8 to 90 cells wider. The row wrapped, the
+// alternate screen scrolled, and the header, filter bar and SESSIONS title were
+// pushed off the top. Bubble Tea repaints only rows whose content changed, so
+// the live header came back on its next tick while the static rows stayed blank
+// until an attach/detach forced a full repaint.
+//
+// Observed on a 131-column window: rows the deck measured at exactly 131 cells
+// rendered at 139, 163, 210 and 219.
+//
+// These tests gate both halves of the fix: expansion at the preview ingest
+// chokepoint, and the safety net in the final frame clamp.
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/rivo/uniseg"
+)
+
+// terminalRowWidth measures a row the way a terminal renders it: escape
+// sequences occupy nothing, a TAB advances to the next multiple-of-8 column,
+// everything else costs its grapheme-cluster width.
+//
+// Deliberately independent of cellWidth/expandTabs — measuring the fix with the
+// function under test would pass no matter what it did. The TAB arm here is the
+// entire contract: it is what a terminal does and what ansi.StringWidth does
+// not.
+func terminalRowWidth(row string) int {
+	plain := ansi.Strip(row)
+	col := 0
+	state := -1
+	for len(plain) > 0 {
+		cluster, rest, width, newState := uniseg.FirstGraphemeClusterInString(plain, state)
+		state = newState
+		plain = rest
+		if cluster == "\t" {
+			col += 8 - col%8
+			continue
+		}
+		col += width
+	}
+	return col
+}
+
+func TestTerminalRowWidth_CountsTabsToTheNextStop(t *testing.T) {
+	// Guard the guard: if this measurement ever stops disagreeing with
+	// ansi.StringWidth about tabs, the regression tests below become vacuous.
+	const row = "a\tb"
+	if got := ansi.StringWidth(row); got != 2 {
+		t.Fatalf("ansi.StringWidth(%q) = %d, want 2 (a TAB it does not count)", row, got)
+	}
+	if got := terminalRowWidth(row); got != 9 {
+		t.Fatalf("terminalRowWidth(%q) = %d, want 9 (tab stop at column 8)", row, got)
+	}
+}
+
+// TestClampViewToViewport_TabRowRendersExactlyViewportWidth is the regression.
+// Every row of a clamped frame must render at exactly the viewport width — the
+// contract the whole fixed-cell frame depends on — including rows carrying
+// tabs.
+func TestClampViewToViewport_TabRowRendersExactlyViewportWidth(t *testing.T) {
+	const width, height = 131, 6
+
+	// Shapes taken from the real capture that reproduced the bug: `ls` column
+	// output and a git-status body, in the right-hand pane of the dual-column
+	// layout, with and without SGR colour.
+	frame := strings.Join([]string{
+		strings.Repeat(" ", 46) + "│ capacity-assessment.md\t\t\t\tcutover-runbook.md\t\t\t\tgitops-layout.md",
+		strings.Repeat(" ", 46) + "│ \tdocs/capacity-assessment.md",
+		strings.Repeat(" ", 46) + "│ \x1b[31mdeleted:\x1b[0m\tapps/focus/acc/prometheus.yaml",
+		strings.Repeat(" ", 46) + "│ 📁 wide\tglyph before the stop",
+		strings.Repeat(" ", 46) + "│ no tabs on this row at all",
+		"",
+	}, "\n")
+
+	clamped := clampViewToViewport(frame, width, height)
+
+	rows := strings.Split(clamped, "\n")
+	if len(rows) != height {
+		t.Fatalf("clamped frame has %d rows, want %d", len(rows), height)
+	}
+	for i, row := range rows {
+		if strings.ContainsRune(row, '\t') {
+			t.Errorf("row %d still contains a TAB: %q", i, ansi.Strip(row))
+		}
+		if got := terminalRowWidth(row); got != width {
+			t.Errorf("row %d renders %d cells, want exactly %d: %q", i, got, width, ansi.Strip(row))
+		}
+	}
+}
+
+func TestExpandTabs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no tabs is returned unchanged", "plain row", "plain row"},
+		{"tab at column 0 fills the first stop", "\tx", "        x"},
+		{"tab advances to the next stop, not by a fixed width", "a\tb", "a       b"},
+		{"a full stop still advances a whole stop", "12345678\tx", "12345678        x"},
+		{"consecutive tabs each land on their own stop", "a\t\tb", "a               b"},
+		{"escape sequences occupy no columns", "\x1b[31ma\x1b[0m\tb", "\x1b[31ma\x1b[0m       b"},
+		{"OSC 8 hyperlinks occupy no columns", "\x1b]8;;http://x\x1b\\a\x1b]8;;\x1b\\\tb", "\x1b]8;;http://x\x1b\\a\x1b]8;;\x1b\\       b"},
+		{"a wide glyph moves the stop by the cells it occupies", "📁\tx", "📁      x"},
+		{"the column resets on each line", "a\tb\nc\td", "a       b\nc       d"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := expandTabs(tc.in); got != tc.want {
+				t.Fatalf("expandTabs(%q)\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExpandTabs_PreservesRenderedWidth(t *testing.T) {
+	// The point of the expansion: after it, the width the deck measures and the
+	// width the terminal renders agree.
+	const row = "deleted:\tapps/focus/acc/prometheus.yaml\tHEAD"
+	expanded := expandTabs(row)
+	if cellWidth(expanded) != terminalRowWidth(row) {
+		t.Fatalf("cellWidth(expanded) = %d, terminal renders %d cells",
+			cellWidth(expanded), terminalRowWidth(row))
+	}
+}
+
+// TestPreviewFetchedMsg_ExpandsTabs pins the ingest chokepoint: content cached
+// for a preview is already what the terminal will render, for local and remote
+// fetches alike (both land in this one handler).
+func TestPreviewFetchedMsg_ExpandsTabs(t *testing.T) {
+	home := NewHome()
+	const key = "session-with-tabs"
+
+	model, _ := home.Update(previewFetchedMsg{
+		previewKey: key,
+		content:    "modified:\tinternal/ui/home.go\nnew file:\tinternal/ui/cellwidth.go\n",
+	})
+	updated := model.(*Home)
+
+	cached := updated.previewCache[key]
+	if cached == "" {
+		t.Fatal("preview content was not cached")
+	}
+	if strings.ContainsRune(cached, '\t') {
+		t.Fatalf("cached preview still contains a TAB: %q", cached)
+	}
+	if want := "modified:       internal/ui/home.go\nnew file:       internal/ui/cellwidth.go\n"; cached != want {
+		t.Fatalf("cached preview\n got: %q\nwant: %q", cached, want)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Scrolling the session list garbles the deck. The header, the filter bar and the `SESSIONS` title vanish and everything below sits at an offset; the header returns on its next stats tick, but the two static rows stay blank until you attach to a session and detach again. It happens whenever a session whose pane output contains tabs (`git status`, `ls` column output) scrolls into the preview.

## Why this change

`ansi.StringWidth` measures a TAB as **zero cells**; the terminal expands it to the next multiple-of-8 column. Every width gate in the TUI — `cellWidth`, `fitCellWidth`, and the final `clampViewToViewport` safety net — is built on that measurement. So a captured row carrying tabs measures exactly `h.width`, passes every gate, and then renders 8–90 cells wider. It wraps, the alternate screen scrolls, and the top rows are pushed off. Bubble Tea repaints only rows whose content changed, which is exactly why the live header comes back and the static rows do not.

A tab cannot be represented in a fixed-cell frame at all, so the fix is to expand it at the boundary rather than to teach the measurement about it — every consumer (truncation, padding, `JoinHorizontal`) then agrees with the terminal for free.

Two call sites, deliberately different in kind:

- **Ingest** — `previewFetchedMsg`, the one handler both local and remote preview fetches land in, so cached content is already what the terminal will render.
- **Frame** — `clampViewToViewport`, so no path that assembles a row can pad it to a width the terminal then exceeds.

Rejected: stripping tabs (destroys the column alignment the output is using), and making `cellWidth` tab-aware (the width would be right while the emitted row still carried a tab, so `ansi.Truncate` and `JoinHorizontal` would keep disagreeing with the terminal).

## User impact

The session list no longer garbles when a tab-bearing preview scrolls into view. Preview content that used tabs for alignment now shows those columns aligned instead of collapsed. No config, no API, no behavior change for tab-free content.

## Evidence

Reproduced on a real deck (28 sessions, 9 groups, one remote), kitty 131x85, driven through a pty and recorded at the byte level. Workload: 45 `Down` then 45 `Up`, identical on both builds.

Before — rows the TUI measured at exactly 131 cells, as the terminal actually renders them:

```
/tmp/ab_old.raw: rows_with_tab=17  rows_over_131_cells=17
   OVER 210 '                                              │ capacity-assessment.md\t\t\t\tcutove'
   OVER 219 '                                              │ capacity-handoff.md\t\t\t\tdiagrams/'
   OVER 163 '                                              │ capacity-nprod-review-20260803.m'
   OVER 139 '                                              │ \tapps/devtools/onepassworditem_s'
```

After:

```
/tmp/ab_new.raw: rows_with_tab=0  rows_over_131_cells=0
```

On-screen confirmation via kitty's remote control, same 80-keystroke sweep on the patched build: `get-text --extent=screen` returns exactly 85 lines for the 85-row screen (zero wrapped rows) and the header, filter bar and `SESSIONS` title are intact. Before the fix the same query returned 64 lines for 85 rows — 21 wrapped continuations — with rows 2–4 holding stale content from an earlier frame.

Hot path (`clampViewToViewport` runs on every `View`), 85-row frame, `-benchtime 300x -count 5`, medians:

| frame | before | after | allocs |
|---|---|---|---|
| no tabs (the normal case) | 87.4 µs | 83.0 µs | 87 → 87 |
| 8 of 85 rows carry tabs | 89.2 µs | 93.6 µs | 88 → 96 |

Tab-free rows cost one `strings.ContainsRune` and allocate nothing extra; only rows that actually carry a tab allocate, one each. For scale, `View` itself is ~1.5–2 ms (#1753).

Tests: `go test ./internal/ui/` passes (all packages green). `gofmt -l ./cmd ./internal` prints nothing; `go vet ./...` clean.

Full sandboxed suite: I did **not** check that box, because 10 tests fail in my environment — `TestCheckHealthFreshAndStale`, 3 in `internal/agents` (remote Claude transcript/CD-prefix), 5 `TestIsLiveTmuxClientOrServer_*`, and `TestIssue1867_NonUTF8Client_StatusStillReadsSpinner`. They are pre-existing and unrelated: the identical 10 fail on unmodified `01c011b5` in the same sandbox, and my change touches no package they cover.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human asked: "new issue in agent-deck when in the session-overview: if I scroll up or down in all the sessions the screen gets garbled because the top header in agent-deck seems to disappear and everything shows with an offset." They followed up with what they were seeing: "its basically the top 3 lines disappearing, but then the 1st line reappears. These two stay gone until i go into a session and back out."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — 10 pre-existing failures in my environment, identical on unmodified `01c011b5`; see Evidence. `./internal/ui` is green.
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
