### PR TITLE
fix(conductor): make the PEP 668 remediation actually work

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -1278,6 +1278,7 @@ type pipFailureDiagnostic struct {
 	Packages        []string // packages pip was asked to install
 	HasMise         bool     // mise binary on PATH at install time
 	RawStderr       string   // captured stderr from the failing pip call
+	VenvDir         string   // conductor venv path findPython3 prefers (session.ConductorVenvDir)
 }
 
 // formatPipFailureMessage renders the user-facing error block. The PEP 668
@@ -1287,6 +1288,17 @@ type pipFailureDiagnostic struct {
 // without speculating on the cause.
 func formatPipFailureMessage(d pipFailureDiagnostic) string {
 	pkgs := strings.Join(d.Packages, " ")
+
+	// Never print a venv path the resolver would not look at. Falling back to
+	// the resolver keeps the message correct even when the caller forgot to
+	// populate the field.
+	venvDir := d.VenvDir
+	if venvDir == "" {
+		venvDir = session.ConductorVenvDir()
+	}
+	if venvDir == "" {
+		venvDir = filepath.Join("~", ".agent-deck", "conductor", "venv")
+	}
 
 	if d.Kind != pipFailurePEP668 {
 		var b strings.Builder
@@ -1335,10 +1347,10 @@ func formatPipFailureMessage(d pipFailureDiagnostic) string {
 	b.WriteString("         # <VERSION> is any Python 3.11+ — e.g. 3.12 or 3.13.\n")
 	b.WriteString("         # agent-deck does not pin a specific version.\n\n")
 	fmt.Fprintf(&b, "    %s\n", venvHeader)
-	b.WriteString("         python3 -m venv ~/.agent-deck/conductor/.venv\n")
-	fmt.Fprintf(&b, "         ~/.agent-deck/conductor/.venv/bin/pip install %s\n", pkgs)
-	b.WriteString("         # (manual: edit ~/Library/LaunchAgents/com.agentdeck.conductor-bridge.plist\n")
-	b.WriteString("         #  to point at ~/.agent-deck/conductor/.venv/bin/python3)\n\n")
+	fmt.Fprintf(&b, "         python3 -m venv %s\n", venvDir)
+	fmt.Fprintf(&b, "         %s/bin/pip install %s\n", venvDir, pkgs)
+	b.WriteString("         # agent-deck prefers this interpreter automatically once it\n")
+	b.WriteString("         # exists — no plist or unit file to edit by hand.\n\n")
 	b.WriteString("    3. Override the policy (works, but the policy exists for a reason):\n")
 	fmt.Fprintf(&b, "         python3 -m pip install --user --break-system-packages %s\n\n", pkgs)
 	b.WriteString("  After fixing, verify with:  agent-deck conductor status\n")
@@ -1376,13 +1388,26 @@ func installPythonDeps() bool {
 	// Try with --user first; fall back to no --user (venvs, containers).
 	// We capture stderr on the second attempt so a failure can be classified
 	// and surfaced with a remediation message.
+	// Resolve the interpreter the generated daemon unit will actually run
+	// (session.FindPython3 prefers the conductor venv) instead of whatever
+	// "python3" means on the current PATH. Installing into a different
+	// interpreter than the daemon uses is how a "successful" setup still
+	// produced a bridge that could not import aiogram — and, in the PEP 668
+	// case, how the remediation the message printed could not take effect:
+	// the user built the venv, re-ran setup, and setup went straight back to
+	// the externally-managed PATH python and refused to install the daemon.
+	python := session.FindPython3()
+	if python == "" {
+		python = "python3"
+	}
+
 	args := append([]string{"-m", "pip", "install", "--quiet", "--user"}, packages...)
-	if err := exec.Command("python3", args...).Run(); err == nil {
+	if err := exec.Command(python, args...).Run(); err == nil {
 		return true
 	}
 	var stderrBuf bytes.Buffer
 	args = append([]string{"-m", "pip", "install"}, packages...)
-	cmd := exec.Command("python3", args...)
+	cmd := exec.Command(python, args...)
 	cmd.Stderr = &stderrBuf
 	if err := cmd.Run(); err == nil {
 		return true
@@ -1393,7 +1418,8 @@ func installPythonDeps() bool {
 		Packages:  packages,
 		RawStderr: stderrBuf.String(),
 	}
-	diag.InterpreterPath, diag.InterpreterVer = probePythonInterpreter()
+	diag.InterpreterPath, diag.InterpreterVer = probePythonInterpreter(python)
+	diag.VenvDir = session.ConductorVenvDir()
 	if _, err := exec.LookPath("mise"); err == nil {
 		diag.HasMise = true
 	}
@@ -1410,8 +1436,11 @@ func installPythonDeps() bool {
 // probePythonInterpreter returns (path, version) by asking python3 to print
 // sys.executable and sys.version. Empty strings on any probe failure — the
 // formatter renders gracefully without them.
-func probePythonInterpreter() (path, version string) {
-	out, err := exec.Command("python3", "-c",
+func probePythonInterpreter(python string) (path, version string) {
+	if python == "" {
+		python = "python3"
+	}
+	out, err := exec.Command(python, "-c",
 		"import sys; print(sys.executable); print(sys.version.split()[0])").Output()
 	if err != nil {
 		return "", ""

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 
+	"al.essio.dev/pkg/shellescape"
+
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
@@ -1296,8 +1298,9 @@ func formatPipFailureMessage(d pipFailureDiagnostic) string {
 	if venvDir == "" {
 		venvDir = session.ConductorVenvDir()
 	}
+	venvCommandDir := shellescape.Quote(venvDir)
 	if venvDir == "" {
-		venvDir = filepath.Join("~", ".agent-deck", "conductor", "venv")
+		venvCommandDir = `"$HOME"/.agent-deck/conductor/venv`
 	}
 
 	if d.Kind != pipFailurePEP668 {
@@ -1347,8 +1350,8 @@ func formatPipFailureMessage(d pipFailureDiagnostic) string {
 	b.WriteString("         # <VERSION> is any Python 3.11+ — e.g. 3.12 or 3.13.\n")
 	b.WriteString("         # agent-deck does not pin a specific version.\n\n")
 	fmt.Fprintf(&b, "    %s\n", venvHeader)
-	fmt.Fprintf(&b, "         python3 -m venv %s\n", venvDir)
-	fmt.Fprintf(&b, "         %s/bin/pip install %s\n", venvDir, pkgs)
+	fmt.Fprintf(&b, "         python3 -m venv %s\n", venvCommandDir)
+	fmt.Fprintf(&b, "         %s/bin/pip install %s\n", venvCommandDir, pkgs)
 	b.WriteString("         # agent-deck prefers this interpreter automatically once it\n")
 	b.WriteString("         # exists — no plist or unit file to edit by hand.\n\n")
 	b.WriteString("    3. Override the policy (works, but the policy exists for a reason):\n")

--- a/cmd/agent-deck/conductor_venv_remediation_test.go
+++ b/cmd/agent-deck/conductor_venv_remediation_test.go
@@ -68,11 +68,20 @@ func TestFormatPipFailureMessage_VenvPathFallsBackWhenUnset(t *testing.T) {
 	}
 	want := session.ConductorVenvDir()
 	if want == "" {
-		want = filepath.Join("~", ".agent-deck", "conductor", "venv")
+		want = filepath.Join(os.Getenv("HOME"), ".agent-deck", "conductor", "venv")
 	}
-	if !strings.Contains(msg, "python3 -m venv "+want) {
-		t.Fatalf("message venv path is not the resolver's\n want: %s\n----- full message -----\n%s", want, msg)
+	for _, line := range strings.Split(msg, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "python3 -m venv ") {
+			command := "python3() { printf '%s\\n' \"$@\"; }; " + line
+			out, err := exec.Command("sh", "-c", command).CombinedOutput()
+			if err != nil || string(out) != "-m\nvenv\n"+want+"\n" {
+				t.Fatalf("fallback command does not target the resolver's directory: err=%v, got %q, want %q", err, out, want)
+			}
+			return
+		}
 	}
+	t.Fatal("message contains no venv creation command")
 }
 
 // probePythonInterpreter reports the interpreter the installer actually used,

--- a/cmd/agent-deck/conductor_venv_remediation_test.go
+++ b/cmd/agent-deck/conductor_venv_remediation_test.go
@@ -14,6 +14,8 @@
 package main
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -83,5 +85,48 @@ func TestProbePythonInterpreter_UsesTheGivenInterpreter(t *testing.T) {
 	}
 	if path == "" {
 		t.Fatalf("probe returned empty path with version %q", version)
+	}
+}
+
+// Exercise the printed commands with a real shell and harmless executables.
+// A valid configured directory must remain one literal argument.
+func TestFormatPipFailureMessage_VenvCommandsPreserveLiteralPaths(t *testing.T) {
+	for _, name := range []string{"plain", "with spaces", "literal $EXPAND_ME", "single'quote"} {
+		t.Run(name, func(t *testing.T) {
+			venvDir := filepath.Join(t.TempDir(), name, "venv")
+			binDir := filepath.Join(venvDir, "bin")
+			if err := os.MkdirAll(binDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			pip := filepath.Join(binDir, "pip")
+			if err := os.WriteFile(pip, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\"\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("EXPAND_ME", "wrong-directory")
+			msg := formatPipFailureMessage(pipFailureDiagnostic{
+				Kind: pipFailurePEP668, Packages: []string{"toml", "aiogram"}, VenvDir: venvDir,
+			})
+			commands := 0
+			for _, line := range strings.Split(msg, "\n") {
+				line = strings.TrimSpace(line)
+				var want string
+				if strings.HasPrefix(line, "python3 -m venv ") {
+					want = "-m\nvenv\n" + venvDir + "\n"
+					line = "python3() { printf '%s\\n' \"$@\"; }; " + line
+				} else if strings.Contains(line, "/bin/pip") && strings.HasSuffix(line, " install toml aiogram") {
+					want = "install\ntoml\naiogram\n"
+				} else {
+					continue
+				}
+				commands++
+				out, err := exec.Command("sh", "-c", line).CombinedOutput()
+				if err != nil || string(out) != want {
+					t.Errorf("repair command did not preserve its arguments: err=%v, got %q, want %q", err, out, want)
+				}
+			}
+			if commands != 2 {
+				t.Fatalf("found %d repair commands, want 2", commands)
+			}
+		})
 	}
 }

--- a/cmd/agent-deck/conductor_venv_remediation_test.go
+++ b/cmd/agent-deck/conductor_venv_remediation_test.go
@@ -1,0 +1,87 @@
+// The PEP 668 remediation told the user to build a venv at a path the binary
+// never looks at.
+//
+// findPython3 prefers <ConductorDir>/venv/bin/python3. The message printed
+// ~/.agent-deck/conductor/.venv — dot-prefixed — so a user who followed it
+// verbatim got a venv agent-deck could not see, and the message itself
+// conceded the point by telling them to hand-edit the launchd plist.
+//
+// Worse, following it did not help even with the right path: installPythonDeps
+// shelled out to "python3" from PATH, so re-running setup went straight back to
+// the externally-managed interpreter, failed the same way, and refused to
+// install the bridge daemon again.
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestFormatPipFailureMessage_VenvPathIsTheOneTheResolverPrefers(t *testing.T) {
+	venvDir := "/home/u/.local/share/agent-deck/conductor/venv"
+	msg := formatPipFailureMessage(pipFailureDiagnostic{
+		Kind:            pipFailurePEP668,
+		InterpreterPath: "/opt/homebrew/opt/python@3.14/bin/python3.14",
+		InterpreterVer:  "3.14.7",
+		Packages:        []string{"toml", "aiogram"},
+		VenvDir:         venvDir,
+	})
+
+	for _, want := range []string{
+		"python3 -m venv " + venvDir,
+		filepath.Join(venvDir, "bin", "pip") + " install toml aiogram",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q\n----- full message -----\n%s", want, msg)
+		}
+	}
+
+	// The specific regression: a dot-prefixed venv is not on findPython3's
+	// search path, so the message must never name one.
+	if strings.Contains(msg, "/.venv") {
+		t.Errorf("message still points at a dot-prefixed venv findPython3 ignores\n----- full message -----\n%s", msg)
+	}
+
+	// The hand-edit instruction only existed because the advertised path was
+	// undiscoverable. With the resolver's own path there is nothing to edit.
+	if strings.Contains(strings.ToLower(msg), "edit ~/library/launchagents") {
+		t.Errorf("message still tells the user to hand-edit the plist\n----- full message -----\n%s", msg)
+	}
+}
+
+// The formatter is reachable from a path that does not populate VenvDir; it
+// must still print a real venv path rather than an empty one.
+func TestFormatPipFailureMessage_VenvPathFallsBackWhenUnset(t *testing.T) {
+	msg := formatPipFailureMessage(pipFailureDiagnostic{
+		Kind:     pipFailurePEP668,
+		Packages: []string{"toml"},
+	})
+
+	if strings.Contains(msg, "python3 -m venv \n") {
+		t.Fatalf("message printed an empty venv path\n----- full message -----\n%s", msg)
+	}
+	want := session.ConductorVenvDir()
+	if want == "" {
+		want = filepath.Join("~", ".agent-deck", "conductor", "venv")
+	}
+	if !strings.Contains(msg, "python3 -m venv "+want) {
+		t.Fatalf("message venv path is not the resolver's\n want: %s\n----- full message -----\n%s", want, msg)
+	}
+}
+
+// probePythonInterpreter reports the interpreter the installer actually used,
+// so the "Python:" line names the interpreter that failed rather than whatever
+// PATH resolves at render time.
+func TestProbePythonInterpreter_UsesTheGivenInterpreter(t *testing.T) {
+	path, version := probePythonInterpreter("")
+	if path == "" && version == "" {
+		t.Skip("no python3 on PATH in this environment")
+	}
+	if path == "" {
+		t.Fatalf("probe returned empty path with version %q", version)
+	}
+}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -1876,6 +1876,27 @@ func LaunchdPlistPath() (string, error) {
 	return filepath.Join(homeDir, "Library", "LaunchAgents", LaunchdPlistName+".plist"), nil
 }
 
+// ConductorVenvDir returns the directory of the conductor-owned virtualenv that
+// findPython3 prefers. It does not create or check the directory — callers use
+// it to tell the user where to build the venv, so the instructions and the
+// lookup can never drift apart (they did: the PEP 668 remediation printed
+// ".venv" while findPython3 only ever looked for "venv").
+func ConductorVenvDir() string {
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(conductorDir, "venv")
+}
+
+// FindPython3 is the exported form of findPython3, for the CLI layer: the
+// dependency installer must use the same interpreter the generated launchd /
+// systemd unit will run, or it installs the bridge's dependencies somewhere the
+// daemon cannot see them.
+func FindPython3() string {
+	return findPython3()
+}
+
 // findPython3 resolves python3 for daemon configs.
 // Prefer the conductor venv (has required deps like toml), then the current
 // PATH (so pyenv/asdf-selected interpreters win), then common absolute paths.

--- a/internal/session/conductor_venv_python_test.go
+++ b/internal/session/conductor_venv_python_test.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// findPython3 prefers the conductor-owned venv because the bridge's Python
+// dependencies (toml, aiogram) live there on any host whose system interpreter
+// is externally managed (PEP 668 — Homebrew, Debian/Ubuntu). ConductorVenvDir
+// is what the CLI prints in that remediation, so the two must name the same
+// directory: when they drifted, users built a venv at ".venv" that nothing
+// ever looked at.
+func TestConductorVenvDir_IsWhatFindPython3Prefers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	venvDir := ConductorVenvDir()
+	if venvDir == "" {
+		t.Fatal("ConductorVenvDir returned empty")
+	}
+	if filepath.Base(venvDir) != "venv" {
+		t.Fatalf("ConductorVenvDir = %q, want a directory named \"venv\" (a dot-prefixed name is invisible to findPython3)", venvDir)
+	}
+
+	venvPython := filepath.Join(venvDir, "bin", "python3")
+	if err := os.MkdirAll(filepath.Dir(venvPython), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(venvPython, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake interpreter: %v", err)
+	}
+
+	if got := FindPython3(); got != venvPython {
+		t.Fatalf("FindPython3() = %q, want the conductor venv interpreter %q", got, venvPython)
+	}
+}
+
+// Without a venv, resolution falls through to PATH exactly as before — the
+// fallback is what every host that has no PEP 668 problem relies on.
+func TestFindPython3_FallsThroughToPathWithoutVenv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	got := FindPython3()
+	if got == "" {
+		t.Skip("no python3 resolvable in this environment")
+	}
+	if got == filepath.Join(ConductorVenvDir(), "bin", "python3") {
+		t.Fatalf("FindPython3() returned the venv interpreter %q, but no venv exists", got)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Conductor setup printed a dot-prefixed venv path that the interpreter resolver never used. Dependency installation also selected Python from PATH independently of the daemon resolver, so following the advice could return to the same externally managed interpreter. Configured paths containing spaces, dollar signs or apostrophes additionally produced broken shell commands.

## Why this change

Use the existing interpreter and venv resolvers consistently. Quote resolved paths with the already pinned shellescape helper. Preserve HOME expansion only for the resolver-unavailable fallback. No new dependency or installation strategy.

## User impact

The printed repair commands use the path the resolver searches and preserve literal path characters. Setup and daemon generation select Python through the same resolver. The automated checks do not install Python packages or modify a live daemon.

## Evidence

Fresh Docker shell-argv tests fail on the original PR for spaces, literal dollar signs and apostrophes, then pass with the quoting change. Harmless fake Python/pip functions record operands. The fallback assertion now executes the printed command rather than comparing quote characters. Independent final-head source review found no blocker for these absolute-path cases. Forced resolver failure and relative leading-dash paths remain coverage limits. Fresh Docker contributor self-check at85133acbcbf9c4f8630d33524196db1b26af380f:15PASS,0FAIL,1WARN. Both affected packages (cmd/agent-deck and internal/session), gofmt, go vet and build passed. The warning is that new resolver-symbol tests do not compile on main during the aggregate revert check; the separate original-PR red test proves the quoted-path regression without a compile failure. Prior host receipts are not used as fresh evidence. Latest-head GitHub CI remains required.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** Original contribution Claude Opus 5; scoped correction and independent review GPT-6.

## What actually bothered you

The original reporter followed the printed venv repair instructions and setup skipped the daemon again. The owner authorized reconciliation and fixes for the existing PR.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed with validation limits
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6 intent=yes -->
