### PR TITLE
fix(#1981): heartbeat interactive-state guard + bounded consecutive skips

### DIFF
--- a/conductor/tests/test_issue1981_heartbeat_send_guard.py
+++ b/conductor/tests/test_issue1981_heartbeat_send_guard.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #1981.
+
+A routine/heartbeat ``session send`` types text and presses Enter. When the
+target Claude Code pane is mid-interaction that Enter is destructive:
+
+  (a) an open AskUserQuestion picker resolves to its highlighted default — the
+      model receives an answer the user never gave; and
+  (b) a composer holding the user's half-typed input gets overwritten.
+
+Both states still report status ``waiting``, so status alone cannot gate the
+send. ``heartbeat_loop`` now captures the pane and skips the cycle when
+``_pane_blocks_automated_send`` reports either state; any capture/parse failure
+fails OPEN (the send proceeds) so heartbeats are never permanently blocked.
+
+These are pure function tests on synthetic pane strings — no agent-deck runtime
+and no third-party packages required.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# The bridge's only unconditional third-party import; stub it when absent so the
+# test needs no packages (mirrors test_async_reply_on_idle_timeout.py).
+try:
+    import toml  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["toml"] = types.SimpleNamespace(load=lambda *_a, **_k: {})
+
+# conftest.py registers the canonical bridge as module "bridge" under pytest;
+# when this file is run directly there is no conftest, so load it by path.
+try:
+    import bridge  # noqa: E402
+except ModuleNotFoundError:
+    import importlib.util
+
+    _canon = Path(__file__).resolve().parents[2] / "internal" / "session" / "conductor_bridge.py"
+    _spec = importlib.util.spec_from_file_location("bridge", _canon)
+    bridge = importlib.util.module_from_spec(_spec)
+    sys.modules["bridge"] = bridge
+    _spec.loader.exec_module(bridge)
+
+ESC = "\x1b"
+RULE = "─" * 48  # a composer box border
+
+
+def _pane(*lines: str) -> str:
+    return "\n".join(lines) + "\n"
+
+
+# A real, bright (non-dim) user draft sitting unsent in the composer.
+REAL_DRAFT = _pane(
+    "  Assistant: finished the last task.",
+    RULE,
+    " ❯ can you also update the readme before we ship",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+# Only a dim (SGR 2) Claude-suggested ghost prompt — clobberable, not a draft.
+GHOST_ONLY = _pane(
+    "  Assistant: finished the last task.",
+    RULE,
+    f" ❯ {ESC}[2mTry running the test suite next{ESC}[22m",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+# An empty composer (bare prompt).
+EMPTY_COMPOSER = _pane(
+    "  Assistant: finished the last task.",
+    RULE,
+    " ❯ ",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+# An open AskUserQuestion option-picker.
+OPEN_PICKER = _pane(
+    " ☐ Sequencing",
+    "❯ 1. Identity fix first",
+    "  2. One combined build",
+    RULE,
+    "Enter to select · ↑/↓ to navigate · Esc to cancel",
+)
+
+# Prose that merely mentions picker words but has no numbered options — must not
+# be mistaken for an open picker (else heartbeats would starve).
+PROSE_MENTIONING_PICKER = _pane(
+    "  Assistant: press Enter to select the default in most editors.",
+    RULE,
+    " ❯ ",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
+
+def _skips(pane: str) -> bool:
+    """True if the heartbeat would SKIP this cycle for this pane."""
+    return bridge._pane_blocks_automated_send(pane) is not None
+
+
+class TestPaneBlocksAutomatedSend(unittest.TestCase):
+    def test_real_draft_skips(self):
+        self.assertEqual(
+            bridge._pane_blocks_automated_send(REAL_DRAFT),
+            "composer-holds-unsent-input",
+        )
+
+    def test_ghost_suggestion_sends(self):
+        # A dim ghost suggestion is not a real draft — the send is allowed.
+        self.assertIsNone(bridge._pane_blocks_automated_send(GHOST_ONLY))
+
+    def test_empty_composer_sends(self):
+        self.assertIsNone(bridge._pane_blocks_automated_send(EMPTY_COMPOSER))
+
+    def test_open_picker_skips(self):
+        self.assertEqual(
+            bridge._pane_blocks_automated_send(OPEN_PICKER),
+            "askuserquestion-picker-open",
+        )
+
+    def test_empty_capture_sends_fail_open(self):
+        # capture_pane returns "" on failure -> send is allowed (fail open).
+        self.assertIsNone(bridge._pane_blocks_automated_send(""))
+
+    def test_unparseable_pane_sends_fail_open(self):
+        garbage = f"garbage {ESC}[ truncated pane with no structure at all"
+        self.assertIsNone(bridge._pane_blocks_automated_send(garbage))
+
+    def test_prose_mentioning_picker_sends(self):
+        self.assertFalse(_skips(PROSE_MENTIONING_PICKER))
+
+
+class TestComponentDetectors(unittest.TestCase):
+    def test_ghost_line_is_ghost(self):
+        self.assertTrue(
+            bridge._post_prompt_is_ghost(f" ❯ {ESC}[2mghost text{ESC}[22m")
+        )
+
+    def test_bright_line_is_not_ghost(self):
+        self.assertFalse(bridge._post_prompt_is_ghost(" ❯ real user text"))
+
+    def test_picker_detector_true_and_false(self):
+        self.assertTrue(bridge._pane_has_open_picker(OPEN_PICKER))
+        self.assertFalse(bridge._pane_has_open_picker(PROSE_MENTIONING_PICKER))
+        self.assertFalse(bridge._pane_has_open_picker(EMPTY_COMPOSER))
+
+    def test_draft_detector_true_and_false(self):
+        self.assertTrue(bridge._composer_has_unsent_draft(REAL_DRAFT))
+        self.assertFalse(bridge._composer_has_unsent_draft(EMPTY_COMPOSER))
+        self.assertFalse(bridge._composer_has_unsent_draft(GHOST_ONLY))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/conductor/tests/test_issue1981_heartbeat_send_guard.py
+++ b/conductor/tests/test_issue1981_heartbeat_send_guard.py
@@ -100,6 +100,24 @@ PROSE_MENTIONING_PICKER = _pane(
     "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
 )
 
+# The realistic false positive: an assistant transcript that contains a numbered
+# LIST, a checkbox glyph, AND a prose line with picker wording — all sitting
+# ABOVE a normal, empty composer. An open picker replaces the composer, so the
+# composer footer below is the tell that this is prose, not a live picker. The
+# detector must return False here or ordinary transcript output would starve
+# heartbeats (CodeRabbit review on #1981).
+PROSE_WITH_NUMBERED_LIST = _pane(
+    "  Assistant: here is the plan.",
+    " ☐ Plan",
+    "  1. Fix identity first",
+    "  2. Combine the builds",
+    "  Then press Enter to select the option you prefer.",
+    RULE,
+    " ❯ ",
+    RULE,
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt",
+)
+
 
 def _skips(pane: str) -> bool:
     """True if the heartbeat would SKIP this cycle for this pane."""
@@ -137,6 +155,11 @@ class TestPaneBlocksAutomatedSend(unittest.TestCase):
     def test_prose_mentioning_picker_sends(self):
         self.assertFalse(_skips(PROSE_MENTIONING_PICKER))
 
+    def test_prose_with_numbered_list_sends(self):
+        # A numbered transcript list + checkbox glyph + picker-wording prose above
+        # a normal composer must NOT read as an open picker.
+        self.assertFalse(_skips(PROSE_WITH_NUMBERED_LIST))
+
 
 class TestComponentDetectors(unittest.TestCase):
     def test_ghost_line_is_ghost(self):
@@ -150,12 +173,46 @@ class TestComponentDetectors(unittest.TestCase):
     def test_picker_detector_true_and_false(self):
         self.assertTrue(bridge._pane_has_open_picker(OPEN_PICKER))
         self.assertFalse(bridge._pane_has_open_picker(PROSE_MENTIONING_PICKER))
+        self.assertFalse(bridge._pane_has_open_picker(PROSE_WITH_NUMBERED_LIST))
         self.assertFalse(bridge._pane_has_open_picker(EMPTY_COMPOSER))
 
     def test_draft_detector_true_and_false(self):
         self.assertTrue(bridge._composer_has_unsent_draft(REAL_DRAFT))
         self.assertFalse(bridge._composer_has_unsent_draft(EMPTY_COMPOSER))
         self.assertFalse(bridge._composer_has_unsent_draft(GHOST_ONLY))
+
+
+class TestBoundedSkip(unittest.TestCase):
+    """A persistently-blocking pane (e.g. the #1999 stale glyph buffer) must not
+    silence a conductor forever: after HEARTBEAT_SKIP_LIMIT consecutive gated
+    cycles the heartbeat overrides the guard and delivers."""
+
+    def test_holds_below_the_limit(self):
+        limit = bridge.HEARTBEAT_SKIP_LIMIT
+        for n in range(1, limit):
+            self.assertEqual(bridge._heartbeat_skip_action(n), "skip")
+
+    def test_overrides_at_the_limit(self):
+        limit = bridge.HEARTBEAT_SKIP_LIMIT
+        self.assertEqual(bridge._heartbeat_skip_action(limit), "override")
+        self.assertEqual(bridge._heartbeat_skip_action(limit + 1), "override")
+
+    def test_full_cycle_starves_then_delivers(self):
+        # Simulate heartbeat_loop's per-conductor counter: an unchanged blocking
+        # pane holds for (limit-1) cycles, then the limit-th cycle delivers.
+        limit = bridge.HEARTBEAT_SKIP_LIMIT
+        skips = 0
+        delivered_on = None
+        for cycle in range(1, limit + 1):
+            block_reason = "composer-holds-unsent-input"  # unchanged, stale pane
+            if block_reason:
+                skips += 1
+                if bridge._heartbeat_skip_action(skips) == "skip":
+                    continue
+                delivered_on = cycle  # override → send goes out
+                skips = 0
+        self.assertEqual(delivered_on, limit)
+        self.assertEqual(skips, 0)  # counter reset after the override
 
 
 if __name__ == "__main__":

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -431,6 +431,198 @@ def get_session_output(session: str, profile: str | None = None) -> str:
         return result.stdout.strip()
 
 
+def capture_pane(session: str, profile: str | None = None) -> str:
+    """Raw tmux pane capture for a session, via ``session output --pane``.
+
+    Unlike get_session_output (which returns the parsed "last response"), this
+    returns the live pane content WITH ANSI/SGR escapes preserved — the only
+    reliable way to see an open option-picker or the current composer contents.
+    Returns "" on any failure so callers fail OPEN (never block on an unknown
+    pane state).
+    """
+    result = run_cli(
+        "session", "output", session, "--pane", "--json", profile=profile, timeout=15
+    )
+    if result.returncode != 0:
+        return ""
+    try:
+        data = json.loads(result.stdout)
+        return data.get("content") or ""
+    except json.JSONDecodeError:
+        # Legacy/quiet builds may print the raw pane directly.
+        return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Interactive-state guard for automated sends (issue #1981)
+# ---------------------------------------------------------------------------
+#
+# A routine/heartbeat ``session send`` types text and presses Enter. When the
+# target Claude Code pane is mid-interaction, that Enter is destructive:
+#
+#   (a) an open AskUserQuestion option-picker resolves to its HIGHLIGHTED
+#       default — the model receives an answer the user never gave; and
+#   (b) a composer holding the user's half-typed input gets overwritten.
+#
+# Both states still report session status ``waiting`` (waiting fires on
+# AskUserQuestion / EnterPlanMode), so status alone cannot gate the send. The
+# helpers below inspect a raw pane capture and report whether an automated send
+# would clobber live interaction, so the caller can skip that cycle. Every
+# check fails OPEN: any capture/parse failure is treated as "safe to send".
+
+# Matches a full CSI escape sequence (used to strip ANSI for plain-text scans).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+# Matches only an SGR sequence and captures its parameters (for dim detection).
+_SGR_RE = re.compile(r"\x1b\[([0-9;]*)m")
+
+# AskUserQuestion option-picker markers. The footer strings mirror the ones the
+# Go prompt detector already keys on ("Press Enter to select" / "Use arrow keys
+# to navigate"), so the two agree about what a picker looks like.
+_PICKER_OPTION_RE = re.compile(r"^\s*[❯>]?\s*(\d+)\.\s+(.+?)\s*$")
+_PICKER_TITLE_RE = re.compile(r"^\s*[☐☑☒◻◼▢]\s*(.+?)\s*$")
+_PICKER_FOOTER_RE = re.compile(r"enter to select|to navigate", re.I)
+_PICKER_FREETEXT_RE = re.compile(r"^type something\b", re.I)
+_PICKER_META_RES = (re.compile(r"^chat about this\b", re.I),)
+
+# Composer region markers: the hint line under the input box, and a box border
+# made of horizontal rules.
+_INPUT_FOOTER_RE = re.compile(r"⏵⏵|bypass permissions|esc to interrupt|shift\+tab", re.I)
+_BORDERISH = re.compile(r"^[│\s]*[─—-]{4,}")
+
+
+def _pane_has_open_picker(pane_text: str) -> bool:
+    """True if an AskUserQuestion option-picker is currently open in the pane.
+
+    Requires the picker footer PLUS two or more real numbered answer options
+    PLUS a checkbox-style title above them, so ordinary transcript prose that
+    merely mentions "enter to select" does not match. The "Type something"
+    free-text row and meta rows ("Chat about this") are not counted as answer
+    options.
+    """
+    lines = _ANSI_RE.sub("", pane_text).splitlines()
+    footer_idx = next((i for i, ln in enumerate(lines) if _PICKER_FOOTER_RE.search(ln)), None)
+    if footer_idx is None:
+        return False
+    real = 0
+    first_opt = None
+    for i in range(footer_idx):
+        m = _PICKER_OPTION_RE.match(lines[i])
+        if not m:
+            continue
+        if first_opt is None:
+            first_opt = i
+        label = m.group(2).strip()
+        if _PICKER_FREETEXT_RE.match(label) or any(p.match(label) for p in _PICKER_META_RES):
+            continue
+        real += 1
+    if real < 2 or first_opt is None:
+        return False
+    return any(_PICKER_TITLE_RE.match(lines[i]) for i in range(first_opt))
+
+
+def _post_prompt_is_ghost(raw_line: str) -> bool:
+    """True iff the composer body on this RAW (ansi-bearing) line has visible
+    text and ALL of it is DIM.
+
+    Claude Code renders a SUGGESTED (ghost) next prompt in the composer as
+    dim/faint text (SGR 2); a real user-typed draft is bright/default. A ghost
+    is clobberable (Claude offers one nearly every turn, so protecting them
+    would starve automated sends); a real draft is not. This errs toward False
+    (i.e. "not a ghost — protect it") the moment any visible char is non-dim,
+    so real user input is never mistaken for a ghost. SGR param "2" = faint-on;
+    "0"/"22"/empty = faint-off.
+    """
+    m = re.search(r"[❯>]", raw_line)
+    seg = raw_line[m.end():] if m else raw_line
+    dim = False
+    saw_visible = False
+    i = 0
+    n = len(seg)
+    while i < n:
+        if seg[i] == "\x1b":
+            sm = _SGR_RE.match(seg, i)
+            if sm:
+                params = sm.group(1)
+                for p in (params.split(";") if params else ["0"]):
+                    if p == "2":
+                        dim = True
+                    elif p in ("0", "22", ""):
+                        dim = False
+                i = sm.end()
+                continue
+            am = _ANSI_RE.match(seg, i)  # non-SGR CSI/escape → skip it
+            if am:
+                i = am.end()
+                continue
+        ch = seg[i]
+        if not ch.isspace() and ch not in ("│", "❯", ">"):
+            saw_visible = True
+            if not dim:
+                return False
+        i += 1
+    return saw_visible
+
+
+def _composer_has_unsent_draft(pane_text: str) -> bool:
+    """True if the live composer holds the user's unsent text (mid-typing) that
+    a routine send would clobber.
+
+    Walks up from the input footer to the ``❯`` prompt, stopping at the box
+    border; an empty prompt (``❯`` with nothing after it) is not a draft. A
+    Claude-suggested ghost draft (rendered dim, SGR 2) is NOT protected — only
+    real, non-dim user input counts (see _post_prompt_is_ghost).
+    """
+    raw_lines = pane_text.splitlines()
+    text = _ANSI_RE.sub("", pane_text)
+    lines = text.splitlines()  # index-aligned with raw_lines (SGR strip keeps line count)
+    fi = None
+    for i in range(len(lines) - 1, -1, -1):
+        if _INPUT_FOOTER_RE.search(lines[i]):
+            fi = i
+            break
+    if fi is None:
+        return False
+    bi = next((j for j in range(fi - 1, -1, -1) if _BORDERISH.match(lines[j])), None)
+    if bi is None:
+        return False
+    for j in range(bi - 1, max(-1, bi - 40), -1):
+        raw = lines[j].rstrip()
+        if _BORDERISH.match(raw):  # top border / titled bar → stop before the transcript
+            break
+        s = raw.strip().lstrip("│").strip()
+        starts = s[:1] in ("❯", ">")
+        body = s[1:].strip() if starts else s
+        if body:
+            rawline = raw_lines[j] if j < len(raw_lines) else ""
+            if _post_prompt_is_ghost(rawline):
+                # dim ghost suggestion — clobberable, not a real draft
+                if starts:
+                    break     # composer prompt line holds only a ghost → no real draft
+                continue      # a dim continuation line → keep scanning up
+            return True
+        if starts:  # reached an empty ❯ prompt → no draft
+            break
+    return False
+
+
+def _pane_blocks_automated_send(pane_text: str) -> str | None:
+    """Reason string if an automated send into this pane would disrupt live
+    interaction — an AskUserQuestion picker is open (the send's Enter selects
+    its default), or the composer holds the user's unsent draft (the send
+    clobbers it) — else None. Cheapest check first.
+
+    Pure and total: an empty or unparseable capture yields None (send allowed),
+    so callers fail OPEN.
+    """
+    if not pane_text:
+        return None
+    if _pane_has_open_picker(pane_text):
+        return "askuserquestion-picker-open"
+    if _composer_has_unsent_draft(pane_text):
+        return "composer-holds-unsent-input"
+    return None
+
+
 # Async callable type for reply notifications: (response_text: str) -> None
 ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]
 
@@ -2888,6 +3080,33 @@ async def heartbeat_loop(
                     log.info(
                         "Heartbeat [%s]: conductor busy (%s), skipping this cycle",
                         name, conductor_status,
+                    )
+                    continue
+
+                # issue #1981: a routine send types text + Enter. If the pane is
+                # mid-interaction — an AskUserQuestion picker is open, or the
+                # composer holds the user's unsent draft — that Enter selects the
+                # picker default or clobbers the draft. Skip this cycle when the
+                # pane shows either. Fail OPEN: any capture/parse failure leaves
+                # block_reason None so the send still goes out (heartbeats are
+                # never permanently blocked). The capture runs in the executor so
+                # the blocking CLI call never freezes the event loop.
+                try:
+                    pane_text = await loop.run_in_executor(
+                        None,
+                        functools.partial(capture_pane, session_title, profile=profile),
+                    )
+                    block_reason = _pane_blocks_automated_send(pane_text)
+                except Exception as e:
+                    log.warning(
+                        "Heartbeat [%s]: interactive-state check failed (%s); allowing send",
+                        name, e,
+                    )
+                    block_reason = None
+                if block_reason:
+                    log.info(
+                        "Heartbeat [%s]: skipping this cycle — %s",
+                        name, block_reason,
                     )
                     continue
 

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -140,6 +140,15 @@ IMAGE_MARKER_RE = re.compile(r"\[IMAGE:(?P<path>[^\]]+)\]")
 # How long to wait for conductor to respond (seconds)
 RESPONSE_TIMEOUT = 300
 
+# issue #1981 / #1999: the interactive-state guard skips a heartbeat while a
+# picker or unsent draft is on screen. Its evidence is a single tmux pane
+# capture, which can LIE — a stale glyph buffer (#1999) keeps showing composer
+# text that is no longer really there and never repaints, so the guard would
+# report "blocked" every cycle and silence the conductor forever. After this
+# many CONSECUTIVE gated skips the heartbeat is delivered anyway (with a warning),
+# so a stale buffer or a forgotten draft cannot starve heartbeats indefinitely.
+HEARTBEAT_SKIP_LIMIT = 3
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -488,36 +497,68 @@ _PICKER_META_RES = (re.compile(r"^chat about this\b", re.I),)
 # made of horizontal rules.
 _INPUT_FOOTER_RE = re.compile(r"⏵⏵|bypass permissions|esc to interrupt|shift\+tab", re.I)
 _BORDERISH = re.compile(r"^[│\s]*[─—-]{4,}")
+# How far above the picker footer to look for the option block. A live picker's
+# options sit directly above the footer; a numbered list that merely scrolled by
+# earlier in the transcript is well outside this window.
+_PICKER_WINDOW = 12
 
 
 def _pane_has_open_picker(pane_text: str) -> bool:
     """True if an AskUserQuestion option-picker is currently open in the pane.
 
-    Requires the picker footer PLUS two or more real numbered answer options
-    PLUS a checkbox-style title above them, so ordinary transcript prose that
-    merely mentions "enter to select" does not match. The "Type something"
-    free-text row and meta rows ("Chat about this") are not counted as answer
-    options.
+    A live picker has, reading upward from the footer ("enter to select" /
+    "to navigate"): a CONTIGUOUS block of two or more real numbered answer
+    options immediately above it, and a checkbox-style title above that block.
+    Two guards stop ordinary transcript prose from matching (either would
+    otherwise starve heartbeats — issue #1981):
+
+      * an open picker REPLACES the composer, so if a composer input-footer
+        ("⏵⏵" / "bypass permissions" / "esc to interrupt") appears BELOW the
+        matched picker-footer line, that line is really prose sitting above a
+        normal composer, not a picker; and
+      * the option rows must be contiguous with the footer and within a small
+        window above it, so a numbered list elsewhere in the scrollback does not
+        count.
+
+    The "Type something" free-text row and meta rows ("Chat about this") are
+    tolerated inside the block but not counted as answer options.
     """
     lines = _ANSI_RE.sub("", pane_text).splitlines()
     footer_idx = next((i for i, ln in enumerate(lines) if _PICKER_FOOTER_RE.search(ln)), None)
     if footer_idx is None:
         return False
-    real = 0
-    first_opt = None
-    for i in range(footer_idx):
-        m = _PICKER_OPTION_RE.match(lines[i])
-        if not m:
-            continue
-        if first_opt is None:
-            first_opt = i
-        label = m.group(2).strip()
-        if _PICKER_FREETEXT_RE.match(label) or any(p.match(label) for p in _PICKER_META_RES):
-            continue
-        real += 1
-    if real < 2 or first_opt is None:
+    # A genuine picker occupies the input region — a composer footer below the
+    # match means we matched prose above an ordinary composer, not a picker.
+    if any(_INPUT_FOOTER_RE.search(ln) for ln in lines[footer_idx + 1:]):
         return False
-    return any(_PICKER_TITLE_RE.match(lines[i]) for i in range(first_opt))
+    window_top = max(-1, footer_idx - 1 - _PICKER_WINDOW)
+    # Skip a box border / blank lines directly beneath the footer.
+    i = footer_idx - 1
+    while i > window_top and (not lines[i].strip() or _BORDERISH.match(lines[i])):
+        i -= 1
+    # Walk the contiguous option block, tolerating blank / free-text rows.
+    real = 0
+    top_opt = None
+    while i > window_top:
+        m = _PICKER_OPTION_RE.match(lines[i])
+        if m:
+            label = m.group(2).strip()
+            if not (_PICKER_FREETEXT_RE.match(label) or any(p.match(label) for p in _PICKER_META_RES)):
+                real += 1
+            top_opt = i
+            i -= 1
+            continue
+        body = lines[i].strip().lstrip("❯>").strip()
+        if not body or _PICKER_FREETEXT_RE.match(body):
+            i -= 1
+            continue
+        break
+    if real < 2 or top_opt is None:
+        return False
+    # A checkbox-style title must sit just above the option block (blanks allowed).
+    while i > window_top and not lines[i].strip():
+        i -= 1
+    return i > window_top and bool(_PICKER_TITLE_RE.match(lines[i]))
 
 
 def _post_prompt_is_ghost(raw_line: str) -> bool:
@@ -621,6 +662,18 @@ def _pane_blocks_automated_send(pane_text: str) -> str | None:
     if _composer_has_unsent_draft(pane_text):
         return "composer-holds-unsent-input"
     return None
+
+
+def _heartbeat_skip_action(consecutive_skips: int, limit: int = HEARTBEAT_SKIP_LIMIT) -> str:
+    """Decide what a heartbeat should do given how many cycles the
+    interactive-state guard has blocked IN A ROW (counting the current one).
+
+    Returns ``"skip"`` to hold this cycle, or ``"override"`` to deliver anyway
+    despite the block. A real picker or draft rarely survives ``limit`` heartbeat
+    intervals; a stale pane buffer (#1999) would block forever, so at the limit
+    the heartbeat overrides the guard rather than starve (#1981/#1999).
+    """
+    return "override" if consecutive_skips >= limit else "skip"
 
 
 # Async callable type for reply notifications: (response_text: str) -> None
@@ -2955,6 +3008,11 @@ async def heartbeat_loop(
     # firing the same alert verbatim for 12+ hours.
     need_state_by_conductor: dict[str, dict] = {}
 
+    # issue #1981/#1999: consecutive interactive-state skips per conductor. Reset
+    # on any clear pane or successful send; once it reaches HEARTBEAT_SKIP_LIMIT we
+    # override the guard and deliver anyway (see the block below).
+    skip_count_by_conductor: dict[str, int] = {}
+
     log.info("Heartbeat loop started (global interval: %d minutes)", global_interval)
 
     while True:
@@ -3091,24 +3149,49 @@ async def heartbeat_loop(
                 # block_reason None so the send still goes out (heartbeats are
                 # never permanently blocked). The capture runs in the executor so
                 # the blocking CLI call never freezes the event loop.
+                #
+                # NOTE this narrows but does NOT close the clobber window: the
+                # capture and the send are separate steps, so a user who starts
+                # typing in the gap between them can still be clobbered. It is a
+                # best-effort guard, not a guarantee — see the bounded override
+                # below, which stops a persistently-blocking pane from starving
+                # heartbeats entirely (issue #1999).
                 try:
                     pane_text = await loop.run_in_executor(
                         None,
                         functools.partial(capture_pane, session_title, profile=profile),
                     )
                     block_reason = _pane_blocks_automated_send(pane_text)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 — fail-open: ANY capture/parse error must allow the send
                     log.warning(
                         "Heartbeat [%s]: interactive-state check failed (%s); allowing send",
                         name, e,
                     )
                     block_reason = None
                 if block_reason:
-                    log.info(
-                        "Heartbeat [%s]: skipping this cycle — %s",
-                        name, block_reason,
+                    skips = skip_count_by_conductor.get(name, 0) + 1
+                    skip_count_by_conductor[name] = skips
+                    if _heartbeat_skip_action(skips) == "skip":
+                        log.info(
+                            "Heartbeat [%s]: skipping this cycle (%d/%d) — %s",
+                            name, skips, HEARTBEAT_SKIP_LIMIT, block_reason,
+                        )
+                        continue
+                    # Bounded skip: the guard has blocked HEARTBEAT_SKIP_LIMIT
+                    # cycles in a row. A real picker or draft rarely survives that
+                    # many heartbeat intervals; a stale pane buffer (#1999) would
+                    # survive forever. Deliver anyway so the conductor is never
+                    # silenced permanently, and reset the counter.
+                    log.warning(
+                        "Heartbeat [%s]: interactive-state guard blocked %d consecutive "
+                        "cycles (%s); overriding and delivering to prevent heartbeat "
+                        "starvation (guards against the #1999 stale-pane-buffer case)",
+                        name, skips, block_reason,
                     )
-                    continue
+                    skip_count_by_conductor[name] = 0
+                    # fall through and deliver this cycle
+                else:
+                    skip_count_by_conductor[name] = 0  # pane read clear → reset
 
                 # Send heartbeat to conductor (wrapped in executor — blocks up to
                 # RESPONSE_TIMEOUT seconds and must not freeze the event loop)
@@ -3129,6 +3212,8 @@ async def heartbeat_loop(
                         name,
                     )
                     continue
+
+                skip_count_by_conductor[name] = 0  # delivered → reset skip counter
 
                 # Response is captured via get_session_output (see send_to_conductor).
                 log.info(


### PR DESCRIPTION
Supersedes #2009 (same branch, `jwr456:fix/1981-heartbeat-composer-picker-guard`). GitHub refuses to reopen #2009 because the head ref moved after it was closed, so this PR carries the branch forward instead — it contains both commits: the original guard (ff1ad56f) plus the requested bounded-skip follow-up (f04e685b).

## What's here

**1. Heartbeat interactive-state guard (#1981)** — `heartbeat_loop` skips a cycle when the conductor pane shows an open AskUserQuestion picker (a routine `session send`'s Enter would select its default) or an unsent composer draft (the send would clobber it).

**2. Bounded skip (the requested change on #2009, guards #1999)** — the guard's evidence is a single `capture_pane`, which can lie: a stale tmux glyph buffer keeps reporting a draft/picker that is no longer on screen, so the guard would block every cycle and silence the conductor forever — inverting the fix into starvation.

- `_heartbeat_skip_action(consecutive_skips, limit=HEARTBEAT_SKIP_LIMIT)` — a **pure helper** (`"skip"` / `"override"`), unit-testable without the runtime.
- `HEARTBEAT_SKIP_LIMIT = 3`: after 3 consecutive gated skips the heartbeat is **delivered anyway with a WARNING** naming the override and the block reason.
- Counter **resets on any clear/deliverable pane or a successful send**, so a real picker/draft costs at most `limit` intervals of silence, never permanent starvation.
- Also tightens `_pane_has_open_picker` against the CodeRabbit-flagged false positive: the option block must be contiguous with the picker footer, and a composer input-footer below it disqualifies the match as transcript prose.

## Tests

`conductor/tests/test_issue1981_heartbeat_send_guard.py`: 15 tests (11 guard cases + a numbered-list-transcript negative for the tightened detector + three bounded-skip cases: holds below the limit, overrides at it, and a full stale-pane cycle that starves then delivers and resets). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automated heartbeat actions now avoid sending while an unsent draft or interactive picker is present.
  * User-entered text is protected from being overwritten, and picker defaults are not selected unintentionally.
  * Temporary detection or capture failures no longer block heartbeat activity.
  * Persistent blocking is automatically cleared after several consecutive skipped cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->