### PR TITLE
fix(ui): remote group management — M offers empty groups, g creates groups on remote

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -537,6 +538,69 @@ func (r *SSHRunner) FetchSessionPane(ctx context.Context, sessionID string) (str
 	}
 
 	return parseRemoteSessionOutput(output)
+}
+
+// groupListJSON mirrors the subset of `agent-deck group list --json` output
+// the TUI needs: the recursive group path tree. Counts and status are
+// ignored — a group with zero sessions is still a valid move/create target.
+type groupListJSON struct {
+	Groups []groupListEntryJSON `json:"groups"`
+}
+
+type groupListEntryJSON struct {
+	Path     string               `json:"path"`
+	Children []groupListEntryJSON `json:"children,omitempty"`
+}
+
+// FetchGroupPaths retrieves the remote's full group path list from its own
+// state DB via `agent-deck group list --json`. Unlike session-derived group
+// buckets (which can only ever contain groups that currently hold sessions),
+// the remote's group list includes EMPTY groups, so the local move dialog (M
+// key on a remote session) can still offer a folder after every session has
+// been moved out of it. Paths are normalized, deduped and sorted.
+//
+// Returns nil with no error when the remote returns empty output (older
+// agent-deck builds that predate the JSON shape); callers fall back to the
+// groups observed on the fetched sessions.
+func (r *SSHRunner) FetchGroupPaths(ctx context.Context) ([]string, error) {
+	output, err := r.Run(ctx, "group", "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, nil
+	}
+
+	var parsed groupListJSON
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse remote group list: %w", err)
+	}
+
+	return parseGroupListPaths(parsed), nil
+}
+
+// parseGroupListPaths flattens the recursive group tree from `group list
+// --json` into normalized, deduped, sorted group paths. Extracted as a pure
+// function so the parsing is unit-testable without an SSH round-trip.
+func parseGroupListPaths(parsed groupListJSON) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	var walk func(entries []groupListEntryJSON)
+	walk = func(entries []groupListEntryJSON) {
+		for _, e := range entries {
+			p := strings.Trim(strings.TrimSpace(e.Path), "/")
+			if p != "" && !seen[p] {
+				seen[p] = true
+				paths = append(paths, p)
+			}
+			walk(e.Children)
+		}
+	}
+	walk(parsed.Groups)
+	sort.Strings(paths)
+	return paths
 }
 
 // FetchCostSummary retrieves the remote agent-deck's cost summary as JSON.

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -333,6 +334,70 @@ func TestParseRemoteVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := parseRemoteVersion(tt.raw); got != tt.want {
 				t.Errorf("parseRemoteVersion(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseGroupListPaths pins the group-list flattener that backs
+// SSHRunner.FetchGroupPaths: `group list --json` returns a recursive tree
+// whose paths (including EMPTY groups — session_count 0) must all surface,
+// deduped and sorted, for the remote move/create dialogs.
+func TestParseGroupListPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty list",
+			input: `{"groups":[],"total_groups":0,"total_sessions":0}`,
+			want:  []string{},
+		},
+		{
+			name: "flat groups incl. an empty one",
+			input: `{"groups":[
+				{"name":"emptytest","path":"emptytest","session_count":0},
+				{"name":"work","path":"work","session_count":3}
+			],"total_groups":2,"total_sessions":3}`,
+			want: []string{"emptytest", "work"},
+		},
+		{
+			name: "nested children flattened with full paths",
+			input: `{"groups":[
+				{"name":"my-sessions","path":"my-sessions","session_count":7,
+				 "children":[
+					{"name":"done","path":"my-sessions/done","session_count":6,
+					 "children":[
+						{"name":"deep","path":"my-sessions/done/deep","session_count":0}
+					 ]}
+				 ]}
+			],"total_groups":3,"total_sessions":7}`,
+			want: []string{"my-sessions", "my-sessions/done", "my-sessions/done/deep"},
+		},
+		{
+			name: "slashes and whitespace normalized",
+			input: `{"groups":[
+				{"name":"a","path":"/a/","session_count":0}
+			],"total_groups":1,"total_sessions":0}`,
+			want: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var parsed groupListJSON
+			if err := json.Unmarshal([]byte(tt.input), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := parseGroupListPaths(parsed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseGroupListPaths = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseGroupListPaths[%d] = %q, want %q (all: %v)", i, got[i], tt.want[i], got)
+				}
 			}
 		})
 	}

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -38,6 +38,12 @@ type GroupDialog struct {
 	// Tab toggle between Root and Subgroup modes (Issue #111)
 	contextParentPath string // Original cursor context parent path (for toggling back)
 	contextParentName string // Original cursor context parent name (for toggling back)
+
+	// remoteName is non-empty when the dialog was opened on a REMOTE row
+	// (g key on a remote session/group header). The group is then created in
+	// the remote's own state DB via SSH instead of the local group tree; the
+	// create handler in home.go uses RemoteName() to pick the routing.
+	remoteName string
 }
 
 // NewGroupDialog creates a new group dialog
@@ -64,7 +70,8 @@ func NewGroupDialog() *GroupDialog {
 func (g *GroupDialog) Show() {
 	g.visible = true
 	g.mode = GroupDialogCreate
-	g.groupPath = "" // No parent = root level
+	g.remoteName = "" // local
+	g.groupPath = ""  // No parent = root level
 	g.parentName = ""
 	g.validationErr = ""
 	g.nameInput.SetValue("")
@@ -77,6 +84,7 @@ func (g *GroupDialog) Show() {
 func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = ""        // local
 	g.groupPath = parentPath // Parent path for the new subgroup
 	g.parentName = parentName
 	g.validationErr = ""
@@ -92,6 +100,7 @@ func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 func (g *GroupDialog) ShowCreateWithContext(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = "" // local
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
 	g.validationErr = ""
@@ -119,6 +128,57 @@ func (g *GroupDialog) ShowCreateWithContextDefaultRoot(parentPath, parentName st
 	g.mode = GroupDialogCreate
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
+	g.remoteName = "" // local
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	// Default to root mode, Tab toggles to subgroup
+	g.groupPath = ""
+	g.parentName = ""
+}
+
+// ShowCreateRemoteWithContext opens the create dialog for a REMOTE context
+// (g key on a remote group header): the new group is created on the remote
+// host via SSH (see home.go createRemoteGroup), with parentPath set to the
+// header's own group path so the remote creates a subgroup under it. Pass an
+// empty parentPath for the level-0 host header (root-level remote group).
+func (g *GroupDialog) ShowCreateRemoteWithContext(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	if parentPath != "" {
+		// Default to subgroup mode
+		g.groupPath = parentPath
+		g.parentName = parentName
+	} else {
+		// Root mode, no toggle
+		g.groupPath = ""
+		g.parentName = ""
+	}
+}
+
+// ShowCreateRemoteWithContextDefaultRoot is the remote counterpart of
+// ShowCreateWithContextDefaultRoot: opens the create dialog defaulting to
+// root mode on the remote, storing the cursor context so Tab can toggle to
+// subgroup mode under the session's current group. The created group is
+// routed to the remote's own state DB (home.go createRemoteGroup).
+func (g *GroupDialog) ShowCreateRemoteWithContextDefaultRoot(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
@@ -157,6 +217,7 @@ func (g *GroupDialog) ToggleRootSubgroup() {
 func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRename
+	g.remoteName = "" // not a create
 	g.groupPath = currentPath
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -170,6 +231,7 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 func (g *GroupDialog) ShowMove(groupPaths []string) {
 	g.visible = true
 	g.mode = GroupDialogMove
+	g.remoteName = "" // not a create; reset any stale remote create context
 	g.validationErr = ""
 	g.groupPaths = groupPaths
 	g.selected = 0
@@ -179,6 +241,7 @@ func (g *GroupDialog) ShowMove(groupPaths []string) {
 func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRenameSession
+	g.remoteName = "" // not a create
 	g.sessionID = sessionID
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -193,9 +256,17 @@ func (g *GroupDialog) GetSessionID() string {
 	return g.sessionID
 }
 
+// RemoteName returns the remote the create dialog is scoped to (g key on a
+// remote row), or "" when the dialog creates a LOCAL group. The create
+// handler routes to the remote's own state DB via SSH when non-empty.
+func (g *GroupDialog) RemoteName() string {
+	return g.remoteName
+}
+
 // Hide hides the dialog
 func (g *GroupDialog) Hide() {
 	g.visible = false
+	g.remoteName = ""
 	g.nameInput.Blur()
 }
 
@@ -399,6 +470,15 @@ func (g *GroupDialog) View() string {
 		} else {
 			title = "Create New Group"
 			content = fields
+		}
+
+		// Remote create (g on a remote row): make the routing explicit so the
+		// user knows the group will be created on the remote host, not locally.
+		if g.remoteName != "" {
+			remoteInfo := lipgloss.NewStyle().
+				Foreground(ColorCyan).
+				Render("Remote: " + g.remoteName)
+			content = remoteInfo + "\n\n" + content
 		}
 
 		// Add Root/Subgroup toggle indicator when Tab toggle is available

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1343,6 +1343,16 @@ type remoteMoveResultMsg struct {
 	err        error
 }
 
+// remoteGroupResultMsg reports the outcome of an SSH-routed "create group"
+// for a remote context (g key on a remote row → GroupDialogCreate). The
+// group must be created in the remote's own state DB; groupPath is the full
+// path the remote assigned (parent/name, or name for a root-level group).
+type remoteGroupResultMsg struct {
+	remoteName string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2154,6 +2164,56 @@ func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGrou
 		}
 		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
 	}
+}
+
+// createRemoteGroup routes a TUI "create group" (g key on a remote row) over
+// SSH: the group must be created in the remote's own state DB, not the local
+// tree. Runs `agent-deck group create <name> [--parent <parent>]` on the
+// remote and returns a remoteGroupResultMsg so the local group-path cache is
+// updated only on remote confirmation. Mirrors moveRemoteSessionToGroup and
+// the remote-rename path in GroupDialogRenameSession.
+func (h *Home) createRemoteGroup(name, remoteName, parentPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': failed to load remotes config: %v", name, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': remote '%s' is not configured", name, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		args := []string{"group", "create", name}
+		if parentPath != "" {
+			args = append(args, "--parent", parentPath)
+		}
+		if _, err := runner.RunCommand(ctx, args...); err != nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("failed to create group '%s' on %s: %v", name, remoteName, err)}
+		}
+		full := name
+		if parentPath != "" {
+			full = parentPath + "/" + name
+		}
+		return remoteGroupResultMsg{remoteName: remoteName, groupPath: full}
+	}
+}
+
+// remoteGroupPathFromItem extracts the remote-relative group path from a
+// remote group header's Item.Path ("remotes/<name>/<group-path>"); returns
+// "" for the level-0 host header (Path == "remotes/<name>"). Used by the g
+// key handler to decide the parent for a remote subgroup create.
+func remoteGroupPathFromItem(item session.Item) string {
+	prefix := "remotes/" + item.RemoteName + "/"
+	p := strings.TrimPrefix(item.Path, prefix)
+	if p == item.Path {
+		return "" // level-0 host header
+	}
+	return p
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6539,6 +6599,35 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.rebuildFlatItems()
 		return h, nil
 
+	case remoteGroupResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed the group exists; add it to the cached group list
+		// so the M move dialog (and subsequent subgroup creates) offer it
+		// immediately, before the next fleet poll re-confirms from the
+		// remote's own DB. The sessions map is untouched — creating a group
+		// moves no sessions.
+		h.remoteSessionsMu.Lock()
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		seen := false
+		for _, p := range h.remoteGroups[msg.remoteName] {
+			if p == msg.groupPath {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			h.remoteGroups[msg.remoteName] = append(h.remoteGroups[msg.remoteName], msg.groupPath)
+			sort.Strings(h.remoteGroups[msg.remoteName])
+		}
+		h.remoteSessionsMu.Unlock()
+		h.setError(fmt.Errorf("created group '%s' on %s", msg.groupPath, msg.remoteName))
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9349,7 +9438,32 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		} else if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeGroup {
+			if item.Type == session.ItemTypeRemoteGroup {
+				// Remote group header (incl. the level-0 host header): create
+				// the group on the remote itself. The parent defaults to the
+				// header's own group path so Enter creates a remote subgroup;
+				// Tab toggles to root-level remote create (issue #111 parity).
+				parentPath := remoteGroupPathFromItem(item)
+				parentName := parentPath
+				if idx := strings.LastIndex(parentPath, "/"); idx >= 0 {
+					parentName = parentPath[idx+1:]
+				}
+				h.groupDialog.ShowCreateRemoteWithContext(parentPath, parentName, item.RemoteName)
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote session: default to a root-level group on the remote;
+				// Tab toggles to a subgroup under the session's current group.
+				if gPath := item.RemoteSession.Group; gPath != "" {
+					gName := gPath
+					if idx := strings.LastIndex(gPath, "/"); idx >= 0 {
+						gName = gPath[idx+1:]
+					}
+					h.groupDialog.ShowCreateRemoteWithContextDefaultRoot(gPath, gName, item.RemoteName)
+				} else {
+					// Ungrouped remote session: root only, no toggle (mirrors
+					// the local ungrouped case below).
+					h.groupDialog.ShowCreateRemoteWithContext("", "", item.RemoteName)
+				}
+			} else if item.Type == session.ItemTypeGroup {
 				// On group header: default to subgroup mode
 				h.groupDialog.ShowCreateWithContext(item.Group.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.GroupPath != "" {
@@ -11395,14 +11509,29 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
-		// moveCmd is set when the confirmed action is a remote-session move,
-		// which runs over SSH and reports back via remoteMoveResultMsg.
-		var moveCmd tea.Cmd
+		// remoteCmd is set when the confirmed action runs over SSH against a
+		// remote's own state DB (remote-session move, remote group create) and
+		// reports back via remoteMoveResultMsg / remoteGroupResultMsg.
+		var remoteCmd tea.Cmd
 
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
 			if name != "" {
+				if remoteName := h.groupDialog.RemoteName(); remoteName != "" {
+					// g was pressed on a REMOTE row: the group must be created
+					// in the remote's own state DB, not the local tree. Run
+					// `agent-deck group create` there over SSH (mirrors the
+					// remote-move and remote-rename paths); the local group
+					// path cache updates when the remote confirms via
+					// remoteGroupResultMsg.
+					parentPath := ""
+					if h.groupDialog.HasParent() {
+						parentPath = h.groupDialog.GetParentPath()
+					}
+					remoteCmd = h.createRemoteGroup(name, remoteName, parentPath)
+					break
+				}
 				// Seed the new-group default from [group_defaults].max_concurrent.
 				if cfg, _ := session.LoadUserConfig(); cfg != nil {
 					h.groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
@@ -11477,7 +11606,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					// `agent-deck group move` there over SSH (mirrors the
 					// remote-rename path) and refresh the fleet cache when the
 					// remote confirms via remoteMoveResultMsg.
-					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
+					remoteCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11566,7 +11695,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, moveCmd
+		return h, remoteCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1326,6 +1326,17 @@ type maintenanceCompleteMsg struct {
 	result session.MaintenanceResult
 }
 
+// remoteMoveResultMsg reports the outcome of an SSH-routed "move to group"
+// for a remote session (M key → GroupDialogMove). The session's row lives in
+// the remote's own state DB, so the move is executed there and the local
+// fleet cache is patched only after the remote confirms.
+type remoteMoveResultMsg struct {
+	remoteName string
+	sessionID  string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2070,6 +2081,55 @@ func (h *Home) scopedGroupPaths() []string {
 		}
 	}
 	return scoped
+}
+
+// remoteGroupPaths returns the distinct, normalized group paths currently
+// observed on a remote, sorted for the move dialog (M key on a remote
+// session). These are the only groups the remote knows about; a remote move
+// is executed with `agent-deck group move <id> <group>` on that host.
+func (h *Home) remoteGroupPaths(remoteName string) []string {
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	seen := make(map[string]bool)
+	var paths []string
+	for _, s := range h.remoteSessions[remoteName] {
+		p := normalizeRemoteGroupPath(s.Group)
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// moveRemoteSessionToGroup routes a TUI "move to group" for a remote session
+// over SSH: the session's row lives in the remote's own state DB, so the
+// local tree cannot move it. Runs `agent-deck group move <id> <group>` on the
+// remote (the same command the remote's own TUI would run) and returns a
+// remoteMoveResultMsg so the fleet cache is updated only on remote
+// confirmation. Mirrors the remote-rename path in GroupDialogRenameSession.
+func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGroupPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': failed to load remotes config: %v", title, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': remote '%s' is not configured", title, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := runner.RunCommand(ctx, "group", "move", sessionID, targetGroupPath); err != nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("failed to move '%s' on %s: %v", title, remoteName, err)}
+		}
+		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
+	}
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6386,6 +6446,29 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case remoteMoveResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed; patch the local fleet cache so the row moves
+		// groups immediately, before the next poll re-fetches the truth.
+		// The persisted local order overlay for the old bucket is harmless:
+		// applyRemoteSessionOrder skips overlay IDs the remote no longer
+		// reports in that bucket.
+		h.remoteSessionsMu.Lock()
+		if sessions, ok := h.remoteSessions[msg.remoteName]; ok {
+			for i := range sessions {
+				if sessions[i].ID == msg.sessionID {
+					sessions[i].Group = msg.groupPath
+					break
+				}
+			}
+		}
+		h.remoteSessionsMu.Unlock()
+		h.rebuildFlatItems()
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9103,6 +9186,13 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.setError(errSessionStillCreating)
 			} else if item.Type == session.ItemTypeSession {
 				h.groupDialog.ShowMove(h.scopedGroupPaths())
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote sessions live in the remote's own state DB, so the
+				// local tree cannot move them. Offer the group paths currently
+				// observed on that remote (the only groups the remote knows
+				// about); the confirmed move is routed over SSH in
+				// GroupDialogMove (see moveRemoteSessionToGroup).
+				h.groupDialog.ShowMove(h.remoteGroupPaths(item.RemoteName))
 			}
 		}
 		return h, nil
@@ -11235,6 +11325,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
+		// moveCmd is set when the confirmed action is a remote-session move,
+		// which runs over SSH and reports back via remoteMoveResultMsg.
+		var moveCmd tea.Cmd
+
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
@@ -11308,6 +11402,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.instancesMu.Unlock()
 					h.rebuildFlatItems()
 					h.saveInstances()
+				} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && item.RemoteName != "" {
+					// The row lives in the remote's own DB; run
+					// `agent-deck group move` there over SSH (mirrors the
+					// remote-rename path) and refresh the fleet cache when the
+					// remote confirms via remoteMoveResultMsg.
+					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11396,7 +11496,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, nil
+		return h, moveCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -617,9 +617,15 @@ type Home struct {
 	uiStateSaveTicks     int      // Counter for periodic UI state saves in tick handler
 
 	// Remote sessions (Phase 2: Agent-Deck Remotes)
-	remoteSessions     map[string][]session.RemoteSessionInfo // remoteName -> sessions
-	remoteFromCache    map[string]bool                        // remoteName -> data is a startup cache snapshot, not live yet
-	remoteFetchedAt    map[string]time.Time                   // remoteName -> when its sessions last came from a live fetch
+	remoteSessions map[string][]session.RemoteSessionInfo // remoteName -> sessions
+	// remoteGroups holds each remote's FULL group path list as reported by
+	// its own state DB (`agent-deck group list --json`, fetched on the same
+	// fleet poll). Unlike session-derived buckets it includes EMPTY groups,
+	// so the M move dialog can still offer a remote folder after every
+	// session has been moved out of it. Guarded by remoteSessionsMu.
+	remoteGroups       map[string][]string  // remoteName -> sorted group paths (incl. empty groups)
+	remoteFromCache    map[string]bool      // remoteName -> data is a startup cache snapshot, not live yet
+	remoteFetchedAt    map[string]time.Time // remoteName -> when its sessions last came from a live fetch
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
@@ -1360,6 +1366,14 @@ type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
 	// #1101: per-remote cost summary collected on the same SSH fanout.
 	costs map[string]*costs.RemoteCostSummary
+	// groups holds each remote's FULL group path list (incl. empty groups)
+	// from `group list --json`, so the move/create dialogs can offer folders
+	// that currently hold no sessions. Only remotes that reported a fresh
+	// list appear here.
+	groups map[string][]string
+	// groupsFailed marks remotes whose group-list fetch errored this round;
+	// the handler keeps their last-good cached group paths.
+	groupsFailed map[string]bool
 	// failed marks remotes whose fetch errored this round (issue #1170).
 	// The handler keeps their last-good sessions instead of wiping them,
 	// so one slow/offline remote can't flicker the whole list.
@@ -2083,21 +2097,31 @@ func (h *Home) scopedGroupPaths() []string {
 	return scoped
 }
 
-// remoteGroupPaths returns the distinct, normalized group paths currently
-// observed on a remote, sorted for the move dialog (M key on a remote
-// session). These are the only groups the remote knows about; a remote move
-// is executed with `agent-deck group move <id> <group>` on that host.
+// remoteGroupPaths returns the distinct, normalized group paths available as
+// move targets on a remote, sorted for the move dialog (M key on a remote
+// session). The remote's own group list (fetched on the fleet poll via
+// `group list --json`) is the primary source: unlike session-derived buckets
+// it includes EMPTY groups, so a folder that currently holds no sessions is
+// still offered after every session has been moved out of it. Groups observed
+// on the fetched sessions are unioned in as a fallback for remotes whose
+// group-list fetch failed or predates the JSON shape.
 func (h *Home) remoteGroupPaths(remoteName string) []string {
 	h.remoteSessionsMu.RLock()
 	defer h.remoteSessionsMu.RUnlock()
 	seen := make(map[string]bool)
 	var paths []string
-	for _, s := range h.remoteSessions[remoteName] {
-		p := normalizeRemoteGroupPath(s.Group)
+	add := func(p string) {
+		p = normalizeRemoteGroupPath(p)
 		if !seen[p] {
 			seen[p] = true
 			paths = append(paths, p)
 		}
+	}
+	for _, p := range h.remoteGroups[remoteName] {
+		add(p)
+	}
+	for _, s := range h.remoteSessions[remoteName] {
+		add(s.Group)
 	}
 	sort.Strings(paths)
 	return paths
@@ -3418,6 +3442,14 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	// as "remote contributes zero" so a single broken remote can't poison
 	// the displayed total.
 	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
+	// Remote group lists (group list --json) ride the same fanout so the
+	// move/create dialogs can offer EMPTY remote folders — a folder that
+	// currently holds no sessions is invisible to session-derived buckets
+	// but is still a valid target. Successful fetches land in groupResults;
+	// failures in groupsFailed keep last-good cache entries (same contract
+	// as the sessions map, issue #1170).
+	groupResults := make(map[string][]string, len(config.Remotes))
+	groupsFailed := make(map[string]bool, len(config.Remotes))
 	// #1170: track remotes that errored so the handler keeps their last-good
 	// sessions instead of dropping them.
 	failed := make(map[string]bool, len(config.Remotes))
@@ -3443,6 +3475,8 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			if err != nil {
 				mu.Lock()
 				failed[name] = true
+				// The group list can't be trusted either — keep last-good.
+				groupsFailed[name] = true
 				mu.Unlock()
 				return
 			}
@@ -3456,17 +3490,33 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			summary, costErr := runner.FetchCostSummary(costCtx)
 			costCancel()
 
+			// Group list fetch has the same isolation: a slow `group list`
+			// on one remote must not starve the session/cost data of any
+			// other remote, and a failure degrades to the session-derived
+			// group fallback in remoteGroupPaths.
+			groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+			groupPaths, groupErr := runner.FetchGroupPaths(groupCtx)
+			groupCancel()
+
 			mu.Lock()
 			results[name] = sessions
 			if costErr == nil && summary != nil {
 				costResults[name] = summary
+			}
+			if groupErr == nil {
+				if groupPaths == nil {
+					groupPaths = []string{}
+				}
+				groupResults[name] = groupPaths
+			} else {
+				groupsFailed[name] = true
 			}
 			mu.Unlock()
 		}(name, rc)
 	}
 	wg.Wait()
 
-	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, failed: failed}
+	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -6334,6 +6384,26 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// #1170: merge rather than wholesale-replace so a remote that errored
 		// this round keeps its last-good sessions instead of flickering out.
 		h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
+		// Remote group lists: replace wholesale for remotes that reported a
+		// fresh list; failed remotes keep their last-good cached paths so the
+		// move dialog doesn't lose empty-group targets on a transient SSH
+		// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
+		for name, paths := range msg.groups {
+			h.remoteGroups[name] = paths
+			keepGroups[name] = true
+		}
+		for name := range msg.groupsFailed {
+			keepGroups[name] = true
+		}
+		for name := range h.remoteGroups {
+			if !keepGroups[name] {
+				delete(h.remoteGroups, name)
+			}
+		}
 		for name := range msg.sessions {
 			if !msg.failed[name] {
 				delete(h.remoteFromCache, name)

--- a/internal/ui/remote_create_group_test.go
+++ b/internal/ui/remote_create_group_test.go
@@ -1,0 +1,221 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "g (create group) only creates LOCAL groups, even when
+// the cursor is on a remote row".
+//
+// The g-key dispatch in handleMainKey offered the create dialog without any
+// remote awareness, so confirming it created the group in the local tree via
+// GroupDialogCreate → groupTree.CreateGroup even though the cursor sat on a
+// remote session/header whose groups live in the remote's own state DB. These
+// tests pin the remote create path at the same dispatch boundary used by the
+// remote-move (#2081) and remote-shift-enter (#1100) tests: the dialog must
+// carry the remote name, and Enter must return an SSH-routed tea.Cmd instead
+// of mutating the local tree.
+
+// TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH pins the dispatch:
+// g on a remote-session row must open the create dialog scoped to that remote
+// (RemoteName == "lab"), and confirming it must return the SSH-routed create
+// cmd without touching the local group tree.
+func TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote session did not open the create dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogCreate {
+		t.Fatalf("expected GroupDialogCreate mode, got %v", home.groupDialog.Mode())
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	// The helper's cursor session lives in group "work", so the dialog
+	// defaults to root mode with Tab toggling to a subgroup under "work".
+	if home.groupDialog.CanToggle() {
+		if got := home.groupDialog.GetParentPath(); got != "" {
+			t.Fatalf("root-mode create should have no parent, got %q", got)
+		}
+	} else {
+		t.Fatal("grouped remote session create dialog should offer the Root/Subgroup toggle")
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the group lives on the remote.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote group create: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup pins the
+// header path: g on a remote group header opens the create dialog scoped to
+// that remote WITH the header's group as the parent (subgroup mode), so Enter
+// runs `group create <name> --parent <header>` on the remote.
+func TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Cursor sits on the "work" group header of remote "lab" (the session
+	// row keeps the header present in the flat list, as in the real TUI).
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			Path:       "remotes/lab/work",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab/work", Level: 1},
+	}
+	home.cursor = 1
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote group header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if !home.groupDialog.HasParent() {
+		t.Fatal("remote group header create should default to subgroup mode")
+	}
+	if got := home.groupDialog.GetParentPath(); got != "work" {
+		t.Fatalf("create dialog parent path = %q, want \"work\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("sub")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote subgroup create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup pins the
+// level-0 host-header path: g on "remotes/<name>" (the host header itself)
+// opens a root-level remote create with no parent.
+func TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab", Level: 0},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on the remote host header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if home.groupDialog.HasParent() {
+		t.Fatalf("host-header create should be root-level, got parent %q", home.groupDialog.GetParentPath())
+	}
+}
+
+// TestRemoteCreateGroup_LocalSessionStillCreatesLocally guards the other side
+// of the branch: g on a LOCAL session keeps creating the group in the local
+// tree, with no remote name and no SSH cmd.
+func TestRemoteCreateGroup_LocalSessionStillCreatesLocally(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.groupTree = session.NewGroupTree([]*session.Instance{})
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a local session did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "" {
+		t.Fatalf("local create dialog remoteName = %q, want \"\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local group create returned a non-nil cmd %v; local creates are synchronous", cmd)
+	}
+}
+
+// TestRemoteGroupResultMsgPatchesCache pins the create confirmation: when the
+// remote reports a successful `group create`, the new path is added to the
+// cached group list so the M move dialog offers it immediately (before the
+// next fleet poll re-confirms from the remote's own DB).
+func TestRemoteGroupResultMsgPatchesCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{"lab": {"work"}}
+	home.remoteSessionsMu.Unlock()
+
+	model, _ := home.Update(remoteGroupResultMsg{remoteName: "lab", groupPath: "work/newgroup"})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"work", "work/newgroup"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "M (move to group) does nothing on remote sessions".
+//
+// The M-key dispatch in handleMainKey only offered the move dialog for
+// ItemTypeSession, so pressing M on a remote-session row was a silent no-op
+// even though the remote-rename path (GroupDialogRenameSession) already knows
+// how to mutate a remote session over SSH. These tests pin the remote move
+// path at the same dispatch boundary used by the #1100 remote-shift-enter
+// tests.
+
+// armHomeWithOneRemoteSessionInGroups sets up a Home whose cursor sits on a
+// remote session row, with a populated remote fleet cache so remoteGroupPaths
+// has something to offer. The remote is declared in $HOME's config.toml so
+// any executed SSH command can resolve it (tests that would execute SSH only
+// assert the returned tea.Cmd is non-nil and never run it).
+func armHomeWithOneRemoteSessionInGroups(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Remote fleet cache: two sessions across two groups, plus the row the
+	// cursor will sit on.
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"lab": {
+			{ID: "remote-id-xyz", Title: "remote session", Group: "work"},
+			{ID: "remote-id-abc", Title: "other session", Group: "personal"},
+			{ID: "remote-id-ungrouped", Title: "loose session", Group: ""},
+		},
+	}
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+	}
+	home.cursor = 0
+	return home
+}
+
+// TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups pins the dispatch:
+// pressing M on a remote-session row must open the move dialog (the same one
+// local sessions get) with the groups observed on that remote.
+func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogMove {
+		t.Fatalf("expected GroupDialogMove mode, got %v", home.groupDialog.Mode())
+	}
+
+	// The dialog must offer the remote's own groups (normalized, sorted,
+	// deduped) — not the local group tree, which knows nothing about the
+	// remote. Empty remote group normalizes to the default group path.
+	want := []string{"my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
+// the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
+// must NOT mutate the local group tree.
+func TestRemoteMoveToGroup_EnterReturnsMoveCmd(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote move dialog returned a nil cmd; expected the SSH-routed move")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the remote row is not a local
+	// instance, so MoveSessionToGroup must never have been called.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote move: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree guards the other side
+// of the branch: moving a LOCAL session must keep using the local tree and
+// return no SSH cmd.
+func TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a local session did not open the move dialog")
+	}
+
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local move returned a non-nil cmd %v; local moves are synchronous", cmd)
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -89,6 +89,79 @@ func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
 	}
 }
 
+// TestRemoteMoveToGroup_MKeyIncludesEmptyGroups pins the empty-folder fix:
+// the move dialog must offer groups that currently hold NO sessions on the
+// remote (a folder left empty after every session was moved out of it).
+// Session-derived buckets can never contain an empty group, so this relies on
+// the fleet poll's cached `group list --json` (Home.remoteGroups) being
+// unioned into remoteGroupPaths.
+func TestRemoteMoveToGroup_MKeyIncludesEmptyGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	// The remote's own group DB reports an extra EMPTY folder (no sessions):
+	// it must still be offered as a move target.
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{
+		"lab": {"empty-folder", "personal", "work"},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	// Union of the remote's own group list (incl. the empty folder) and the
+	// session-derived groups (empty remote group normalizes to my-sessions).
+	want := []string{"empty-folder", "my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteSessionsFetchedMsgPopulatesGroupCache pins the fleet-poll wiring:
+// the remote group lists carried on remoteSessionsFetchedMsg land in
+// Home.remoteGroups (guarded by remoteSessionsMu), which is what the M move
+// dialog reads to offer empty remote folders.
+func TestRemoteSessionsFetchedMsgPopulatesGroupCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"lab": {{ID: "x", Title: "s", Group: "work"}},
+		},
+		groups: map[string][]string{
+			"lab": {"empty-folder", "work"},
+		},
+	})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"empty-folder", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 // TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
 // the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
 // must NOT mutate the local group tree.


### PR DESCRIPTION
## What problem does this solve?

Three related gaps in remote group management from the local TUI (rows under the remote/fleet headers from `agent-deck remote add`):

1. **`M` (move to group) was a silent no-op on remote sessions.** The dispatch in `handleMainKey` only handled `ItemTypeSession` (local rows), and the `GroupDialogMove` submit path only called `h.groupTree.MoveSessionToGroup` for local instances. Remote sessions live in the **remote's own state DB**, so the move must run on the remote over SSH — the sibling remote-rename feature already does this (`GroupDialogRenameSession` → `session.NewSSHRunner`).
2. **`M` did not offer empty remote folders.** The move dialog's group list for a remote row was derived only from sessions in the fleet cache, so a folder with **zero sessions** was invisible — after moving every session out of a folder, it could no longer be selected as a move target.
3. **`g` (create group) only created LOCAL groups.** Pressing `g` on a remote session/header and confirming created the group in the local tree, even though the row's groups live in the remote's own DB — the folder never appeared remotely.

## Why this change

1. **Remote move:** `M` on a remote row opens the move dialog (new `remoteGroupPaths`); confirming runs `agent-deck group move <id> <group>` over SSH via `moveRemoteSessionToGroup` (10s timeout, mirrors remote rename), reporting via `remoteMoveResultMsg`. Success patches the local fleet cache so the row re-renders under the new group immediately; failure surfaces in the footer.
2. **Empty remote folders:** each remote's full group list is fetched with `agent-deck group list --json` on the same fleet poll that fetches sessions (piggy-backing the #1101 cost channel), cached in `Home.remoteGroups`, and unioned into `remoteGroupPaths`. The remote's own group DB includes empty groups, so `M` now offers every folder the remote knows about; session-derived groups remain as a fallback for remotes whose group-list fetch failed or predates the JSON shape (failed fetches keep last-good cache entries — same contract as the sessions map, issue #1170).
3. **Remote create:** the create dialog carries a `remoteName` (new `ShowCreateRemoteWithContext` / `ShowCreateRemoteWithContextDefaultRoot`, with a "Remote: <name>" line in the dialog so the routing is explicit); the `g` dispatch recognizes `ItemTypeRemoteSession` and `ItemTypeRemoteGroup` (incl. the level-0 host header — parent defaults to the header's group path, Tab still toggles Root/Subgroup for issue #111 parity); confirming routes `agent-deck group create <name> [--parent <parent>]` over SSH via `createRemoteGroup`, reporting via `remoteGroupResultMsg` which inserts the new path into the cached group list so `M` offers it immediately.

Local moves and local group creation are unchanged (synchronous, local tree).

## User impact

Fleet/TUI users with remotes configured can now, from their own machine: move remote sessions between groups (`M`), move sessions into empty remote folders, and create groups/subgroups on remotes (`g`) — without opening a shell on the remote host. Failures surface in the footer instead of a silent no-op.

## Evidence

New/extended tests (follow the #1100 remote-test harness pattern):

- `TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups` — M on a remote row opens the move dialog with the remote's groups (incl. `my-sessions` for ungrouped rows).
- `TestRemoteMoveToGroup_MKeyIncludesEmptyGroups` — an empty remote folder (zero sessions) is still offered as a move target.
- `TestRemoteSessionsFetchedMsgPopulatesGroupCache` — fleet-poll group lists land in `Home.remoteGroups`.
- `TestRemoteMoveToGroup_EnterReturnsMoveCmd` — Enter returns the SSH-routed move cmd and never touches the local tree.
- `TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree` — local moves stay synchronous.
- `TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH` / `_GKeyOnRemoteGroupHeaderDefaultsToSubgroup` / `_GKeyOnRemoteHostHeaderCreatesRootGroup` — g on remote rows opens the dialog scoped to the remote (header case defaults to subgroup mode with the header's path as parent).
- `TestRemoteCreateGroup_LocalSessionStillCreatesLocally` — local create stays synchronous with no SSH cmd.
- `TestRemoteGroupResultMsgPatchesCache` — a confirmed remote create adds the new path to the cached group list.
- `TestParseGroupListPaths` (internal/session) — `group list --json` flattening: empty groups, nested children, normalization.

Validation: full `internal/ui` and `internal/session` suites pass; `go vet` clean. Also verified end-to-end against a live remote (created a throwaway session, moved it over SSH with the same command, confirmed via `list --json`, cleaned up).

Note: on our box the sandboxed `cmd/agent-deck` suite has one pre-existing, environment-dependent failure (`TestHandleAddUsesGlobalDefaultPath` — identical on a clean v1.15.0 checkout, unrelated to this diff).

## AI disclosure

- [ ] Human-written (I wrote it myself)
- [ ] AI-assisted (I wrote it with AI help)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** unsure

## What actually bothered you

My human asked: "M was not working for move on remote machines. I need move to work properly without requiring to access remote machines." Follow-ups: empty remote folders (zero sessions) were invisible to the M dialog after all sessions were moved out, and `g` only created local groups instead of creating them on the remote.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create groups directly on remote hosts, including nested groups.
  - Remote group creation is labeled and routed to the selected host.
  - Remote group lists include empty folders and remain available during temporary connection failures.
  - Move sessions between remote groups using normalized, sorted group paths.
- **Bug Fixes**
  - Improved remote operation feedback, including success confirmations and surfaced errors.
- **Tests**
  - Added coverage for remote group creation, session moves, and remote group synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->