### PR TITLE
Fix to reporting of Pi messages

### DIFF
--- a/cmd/agent-deck/issue1238_toolaware_send_test.go
+++ b/cmd/agent-deck/issue1238_toolaware_send_test.go
@@ -47,41 +47,73 @@ func TestSend_NonClaudeTool_NotReportedDropped(t *testing.T) {
 }
 
 func TestSend_PiComposerDistinguishesSubmittedFromTyped(t *testing.T) {
-	const message = "Reply with exactly this text and nothing else"
-	border := strings.Repeat("\u2500", 40)
+	const ordinaryMessage = "Reply with exactly this text and nothing else"
+	border := strings.Repeat("─", 40)
 	cases := []struct {
-		name    string
-		pane    string
-		want    string
-		wantErr bool
+		name, message, pane, status, want string
+		wantErr                           bool
 	}{
 		{
-			name: "submitted",
-			pane: "transcript\n" + message + "\n\nHello, world!\n" + border + "\n  \n" + border + "\n~/src/project",
+			name: "submitted", message: ordinaryMessage,
+			pane: "transcript\n" + ordinaryMessage + "\n\nHello, world!\n" + border + "\n  \n" + border + "\n~/src/project",
 			want: deliverySubmitted,
 		},
 		{
-			name:    "still in composer",
-			pane:    "transcript\n" + border + "\n" + message + "\n" + border + "\n~/src/project",
-			want:    deliveryTyped,
-			wantErr: true,
+			name: "still in composer", message: ordinaryMessage,
+			pane: "transcript\n" + border + "\n" + ordinaryMessage + "\n" + border + "\n~/src/project",
+			want: deliveryTyped, wantErr: true,
+		},
+		{
+			name: "unsent divider tail", message: ordinaryMessage + "\n" + border,
+			pane: "transcript\n" + border + "\n" + ordinaryMessage + "\n" + border + "\n" + border + "\n~/src/project",
+			want: deliveryTyped, wantErr: true,
+		},
+		{
+			name: "unsent divider and blank tail", message: ordinaryMessage + "\n" + border + "\n  ",
+			pane: "transcript\n" + border + "\n" + ordinaryMessage + "\n" + border + "\n  \n" + border + "\n~/src/project",
+			want: deliveryTyped, wantErr: true,
+		},
+		{
+			name: "ambiguous accepted divider requires evidence", message: ordinaryMessage + "\n" + border,
+			pane: "transcript\n" + ordinaryMessage + "\n" + border + "\nanswer\n" + border + "\n  \n" + border + "\n~/src/project",
+			want: deliveryTyped, wantErr: true,
+		},
+		{
+			name: "transcript divider is not payload", message: ordinaryMessage,
+			pane: "earlier transcript\n" + border + "\n" + ordinaryMessage + "\nanswer\n" + border + "\n  \n" + border,
+			want: deliverySubmitted,
+		},
+		{
+			name: "missing editor border", message: ordinaryMessage,
+			pane: ordinaryMessage + "\n" + border,
+			want: deliveryTyped, wantErr: true,
+		},
+		{
+			name: "narrow editor", message: ordinaryMessage,
+			pane: ordinaryMessage + "\n" + strings.Repeat("─", 19) + "\n  \n" + strings.Repeat("─", 19),
+			want: deliveryTyped, wantErr: true,
+		},
+		{
+			name: "divider with activity evidence", message: ordinaryMessage + "\n" + border,
+			pane:   "transcript\n" + ordinaryMessage + "\n" + border,
+			status: "active", want: deliverySubmitted,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := &mockSendRetryTarget{
-				statuses: []string{"waiting"},
-				panes:    []string{"transcript", tc.pane},
+			statuses := []string{"waiting"}
+			if tc.status != "" {
+				statuses = append(statuses, tc.status)
 			}
-			res, err := executeSend(mock, "pi", message, false, sendExecTuning{
+			mock := &mockSendRetryTarget{statuses: statuses, panes: []string{"transcript", tc.pane}}
+			res, err := executeSend(mock, "pi", tc.message, false, sendExecTuning{
 				retry: sendRetryOptions{maxRetries: 1, checkDelay: 0, verifyDelivery: true},
 			})
-			delivery := res.delivery
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tc.wantErr)
 			}
-			if delivery != tc.want {
-				t.Fatalf("delivery = %q, want %q", delivery, tc.want)
+			if res.delivery != tc.want {
+				t.Fatalf("delivery = %q, want %q", res.delivery, tc.want)
 			}
 		})
 	}

--- a/cmd/agent-deck/issue1238_toolaware_send_test.go
+++ b/cmd/agent-deck/issue1238_toolaware_send_test.go
@@ -46,6 +46,47 @@ func TestSend_NonClaudeTool_NotReportedDropped(t *testing.T) {
 	}
 }
 
+func TestSend_PiComposerDistinguishesSubmittedFromTyped(t *testing.T) {
+	const message = "Reply with exactly this text and nothing else"
+	border := strings.Repeat("\u2500", 40)
+	cases := []struct {
+		name    string
+		pane    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "submitted",
+			pane: "transcript\n" + message + "\n\nHello, world!\n" + border + "\n  \n" + border + "\n~/src/project",
+			want: deliverySubmitted,
+		},
+		{
+			name:    "still in composer",
+			pane:    "transcript\n" + border + "\n" + message + "\n" + border + "\n~/src/project",
+			want:    deliveryTyped,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockSendRetryTarget{
+				statuses: []string{"waiting"},
+				panes:    []string{"transcript", tc.pane},
+			}
+			res, err := executeSend(mock, "pi", message, false, sendExecTuning{
+				retry: sendRetryOptions{maxRetries: 1, checkDelay: 0, verifyDelivery: true},
+			})
+			delivery := res.delivery
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if delivery != tc.want {
+				t.Fatalf("delivery = %q, want %q", delivery, tc.want)
+			}
+		})
+	}
+}
+
 // TestSend_ClaudeTool_VerifyPreserved guards against over-skipping: Claude tools
 // must still run the #876 verify, so a genuinely silent drop (no markers, never
 // active) is still surfaced as an error.

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -738,6 +738,7 @@ func handleLaunch(profile string, args []string) {
 			if _, err := sendWithRetryTarget(tmuxSess, initialMessage, skipClaudeDeliveryVerify(newInstance.Tool), sendRetryOptions{
 				maxRetries:                  8,
 				checkDelay:                  150 * time.Millisecond,
+				tool:                        newInstance.Tool,
 				composerPasteFreeBeforeSend: pasteFreeBeforeSend,
 			}); err != nil {
 				out.Error(fmt.Sprintf("failed to send initial message: %v", err), ErrCodeInvalidOperation)

--- a/cmd/agent-deck/pi_fresh_output_test.go
+++ b/cmd/agent-deck/pi_fresh_output_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestWaitForFreshOutputPi(t *testing.T) {
+	for _, scenario := range []string{"fresh", "stale", "recent previous turn", "missing timestamp"} {
+		t.Run(scenario, func(t *testing.T) {
+			fresh := scenario == "fresh"
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			dir := filepath.Join(home, ".pi", "agent-deck", "pi-fresh")
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "session.jsonl")
+			record := func(ts, text string) string {
+				return fmt.Sprintf(`{"type":"message","timestamp":%q,"message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`+"\n", ts, text)
+			}
+			timestamp := "2026-01-01T00:00:00Z"
+			if scenario == "recent previous turn" {
+				timestamp = "2026-08-28T06:41:19.900Z"
+			}
+			if scenario == "missing timestamp" {
+				timestamp = ""
+			}
+			if err := os.WriteFile(path, []byte(record(timestamp, "old answer")), 0600); err != nil {
+				t.Fatal(err)
+			}
+			setFastFreshOutputConfig(t, 400*time.Millisecond)
+			sentAt := time.Date(2026, 8, 28, 6, 41, 20, 0, time.UTC)
+			if fresh {
+				done := make(chan error, 1)
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+					if err != nil {
+						done <- err
+						return
+					}
+					_, err = f.WriteString(record(sentAt.Add(time.Second).Format(time.RFC3339Nano), "fresh answer"))
+					closeErr := f.Close()
+					if err == nil {
+						err = closeErr
+					}
+					done <- err
+				}()
+				t.Cleanup(func() {
+					if err := <-done; err != nil {
+						t.Error(err)
+					}
+				})
+			}
+			got, err := waitForFreshOutput(&session.Instance{ID: "pi-fresh", Tool: "pi"}, sentAt, nil)
+			if fresh {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.Content != "fresh answer" {
+					t.Fatalf("got stale answer: %+v", got)
+				}
+			} else if err == nil || got != nil || !strings.Contains(err.Error(), "freshness timeout") {
+				t.Fatalf("missing fresh reply must fail, got %+v, %v", got, err)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3881,7 +3881,7 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		if baseline.paneOK {
 			if n, markers, content, ok := paneArrivalObservation(target, message); ok {
 				if n > baseline.occurrences {
-					if opts.tool == "pi" && piComposerEmpty(content) {
+					if opts.tool == "pi" && piComposerEmpty(content, message) {
 						return deliverySubmitted, nil
 					}
 					// Keep polling: the body is in, but the turn may still
@@ -4022,7 +4022,13 @@ func paneArrivalObservation(target sendRetryTarget, message string) (int, int, s
 // piComposerEmpty recognizes Pi's editor between its final two horizontal
 // borders. Once this send's body is in the pane and that editor is empty, Enter
 // was accepted; an unsent message would still occupy the editor.
-func piComposerEmpty(content string) bool {
+func piComposerEmpty(content, message string) bool {
+	// User-provided rules can impersonate the editor's top border. A pane
+	// capture cannot distinguish those bytes from Pi's own empty editor, so
+	// these messages require an activity transition instead of visual inference.
+	if strings.Contains(tmux.StripANSI(message), strings.Repeat("─", 20)) {
+		return false
+	}
 	lines := strings.Split(content, "\n")
 	borders := make([]int, 0, 2)
 	for i, line := range lines {
@@ -4186,12 +4192,11 @@ var freshOutputTestConfig *freshOutputConfig
 // This bridges the gap between the UI prompt reappearing (detected by
 // waitForCompletion) and the JSONL being flushed to disk.
 //
-// For non-Claude tools (Codex, Gemini, etc.) the JSONL freshness check is
-// skipped entirely to avoid an unnecessary 5s penalty, since those tools
-// don't use the same JSONL format.
+// Local Pi sessions also expose structured timestamps. Other tools and
+// nonlocal Pi sessions retain best-effort output without a freshness claim.
 //
-// Falls back to the best-effort response if the freshness timeout expires,
-// logging a warning to stderr so the caller knows the data may be stale.
+// Claude retains its best-effort response with a warning on timeout. Pi
+// returns an error instead of reporting an earlier turn as this send's reply.
 //
 // peers carries the profile snapshot for the #1400 collision guard: a
 // claude_session_id shared by multiple live instances resolves to ONE
@@ -4199,14 +4204,18 @@ var freshOutputTestConfig *freshOutputConfig
 // Fail fast (same semantics as --stream's #1352 guard) instead of polling
 // a colliding transcript until the freshness timeout.
 func waitForFreshOutput(inst *session.Instance, sentAt time.Time, peers []*session.Instance) (*session.ResponseOutput, error) {
-	// Non-Claude tools don't use JSONL timestamps — skip the freshness loop.
-	if !session.IsClaudeCompatible(inst.Tool) {
+	// Pi's transcript lives in the tool's HOME. Legacy SSH/sandbox instances
+	// use terminal fallback, which does not provide timestamp evidence.
+	localPi := inst.Tool == "pi" && !inst.IsSSH() && !inst.IsSandboxed()
+	if !session.IsClaudeCompatible(inst.Tool) && !localPi {
 		return inst.GetLastResponseBestEffort()
 	}
 
 	// #1400: refuse a colliding transcript before entering the poll loop.
-	if _, err := inst.GetJSONLPathChecked(peers); err != nil {
-		return nil, fmt.Errorf("refusing to read a colliding transcript: %w", err)
+	if session.IsClaudeCompatible(inst.Tool) {
+		if _, err := inst.GetJSONLPathChecked(peers); err != nil {
+			return nil, fmt.Errorf("refusing to read a colliding transcript: %w", err)
+		}
 	}
 
 	pollInterval := 250 * time.Millisecond
@@ -4221,6 +4230,11 @@ func waitForFreshOutput(inst *session.Instance, sentAt time.Time, peers []*sessi
 	// time.Now() can be slightly ahead of Claude's clock. Tighter than the
 	// original 2s to reduce false positives on genuinely stale output.
 	threshold := sentAt.Add(-250 * time.Millisecond)
+	if localPi {
+		// Pi records milliseconds; do not accept a previous turn under Claude's
+		// wider clock-skew allowance.
+		threshold = sentAt.Truncate(time.Millisecond)
+	}
 
 	deadline := time.Now().Add(timeout)
 	var lastResp *session.ResponseOutput
@@ -4252,7 +4266,15 @@ func waitForFreshOutput(inst *session.Instance, sentAt time.Time, peers []*sessi
 		time.Sleep(pollInterval)
 	}
 
-	// Freshness timeout: return whatever we have but warn that it may be stale
+	// Pi's send --wait result must belong to this turn. Neither stale text nor
+	// a terminal fallback without a timestamp can establish that relationship.
+	if localPi {
+		if lastErr != nil {
+			return nil, fmt.Errorf("Pi output freshness timeout (%s): %w", timeout, lastErr)
+		}
+		return nil, fmt.Errorf("Pi output freshness timeout (%s): no fresh assistant response", timeout)
+	}
+	// Preserve Claude's historical warning-and-best-effort timeout behavior.
 	if lastResp != nil {
 		fmt.Fprintf(os.Stderr, "Warning: output freshness timeout (%s) — response may be stale\n", timeout)
 		return lastResp, nil

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3234,6 +3234,7 @@ func executeSend(target sendRetryTarget, tool, message string, noWait bool, tun 
 		tun.retry.composerPasteFreeBeforeSend = guard.ComposerPasteMarkerFree
 	}
 
+	tun.retry.tool = tool
 	delivery, err := sendWithRetryTarget(target, message, skipClaudeDeliveryVerify(tool), tun.retry)
 	res.delivery = delivery
 
@@ -3366,6 +3367,7 @@ type sendRetryOptions struct {
 	maxRetries     int
 	checkDelay     time.Duration
 	maxFullResends int // >0 overrides default (3); <0 disables Ctrl+C-then-resend; 0 uses default
+	tool           string
 
 	// verifyDelivery, when true, requires the verification loop to observe at
 	// least one positive signal that the message reached the inner agent (an
@@ -3790,7 +3792,7 @@ type sendArrivalBaseline struct {
 // baseline is disabled, never guessed.
 func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
 	base := sendArrivalBaseline{}
-	if n, markers, ok := paneArrivalObservation(target, message); ok {
+	if n, markers, _, ok := paneArrivalObservation(target, message); ok {
 		base.occurrences, base.pasteMarkers, base.paneOK = n, markers, true
 	}
 	if status, err := target.GetStatus(); err == nil {
@@ -3877,8 +3879,11 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 			}
 		}
 		if baseline.paneOK {
-			if n, markers, ok := paneArrivalObservation(target, message); ok {
+			if n, markers, content, ok := paneArrivalObservation(target, message); ok {
 				if n > baseline.occurrences {
+					if opts.tool == "pi" && piComposerEmpty(content) {
+						return deliverySubmitted, nil
+					}
 					// Keep polling: the body is in, but the turn may still
 					// start within the budget and upgrade this to submitted.
 					sawBody = true
@@ -3980,7 +3985,8 @@ func maxDeliverableLineBytes(target sendRetryTarget) int {
 // paneArrivalObservation reads the pane ONCE and reports both arrival signals
 // the check compares against its baseline: how many times the message's
 // distinctive token is visible in the pane, and how many "[Pasted text …]"
-// collapse markers the COMPOSER holds. One capture serving both signals is
+// collapse markers the COMPOSER holds. It also returns stripped pane content
+// for tool-specific submission checks. One capture serving all signals is
 // deliberate — they must describe the same instant, and the scripted-capture
 // test fakes index captures by call count. The final bool reports whether the
 // pane was actually read: a failed look is not "zero occurrences", it is no
@@ -3999,18 +4005,37 @@ func maxDeliverableLineBytes(target sendRetryTarget) int {
 // composer holding one more marker than before is unsubmitted payload.
 //
 // Both counts are raw observations; the caller compares them to its baseline.
-func paneArrivalObservation(target sendRetryTarget, message string) (int, int, bool) {
+func paneArrivalObservation(target sendRetryTarget, message string) (int, int, string, bool) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
-		return 0, 0, false
+		return 0, 0, "", false
 	}
 	raw, err := target.CapturePaneFresh()
 	if err != nil {
-		return 0, 0, false
+		return 0, 0, "", false
 	}
 	content := tmux.StripANSI(raw)
 	return strings.Count(collapseWhitespace(content), token),
-		send.ComposerPasteMarkerCount(raw, tmux.StripANSI), true
+		send.ComposerPasteMarkerCount(raw, tmux.StripANSI), content, true
+}
+
+// piComposerEmpty recognizes Pi's editor between its final two horizontal
+// borders. Once this send's body is in the pane and that editor is empty, Enter
+// was accepted; an unsent message would still occupy the editor.
+func piComposerEmpty(content string) bool {
+	lines := strings.Split(content, "\n")
+	borders := make([]int, 0, 2)
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.Count(line, "\u2500") >= 20 && strings.Trim(line, "\u2500") == "" {
+			borders = append(borders, i)
+		}
+	}
+	if len(borders) < 2 {
+		return false
+	}
+	top, bottom := borders[len(borders)-2], borders[len(borders)-1]
+	return strings.TrimSpace(strings.Join(lines[top+1:bottom], "\n")) == ""
 }
 
 // collapseWhitespace removes every whitespace byte, so a comparison survives

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -7298,6 +7298,9 @@ func (i *Instance) GetLastResponse() (*ResponseOutput, error) {
 	if i.Tool == "gemini" {
 		return i.getGeminiLastResponse()
 	}
+	if i.Tool == "pi" {
+		return i.getPiLastResponse()
+	}
 	return i.getTerminalLastResponse()
 }
 
@@ -8164,6 +8167,87 @@ func parseGeminiLastAssistantMessage(data []byte) (*ResponseOutput, error) {
 	}
 
 	return nil, fmt.Errorf("no assistant response found in session")
+}
+
+func (i *Instance) getPiLastResponse() (*ResponseOutput, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(home, ".pi", "agent-deck", i.ID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var latest string
+	var latestTime time.Time
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
+			continue
+		}
+		info, err := entry.Info()
+		if err == nil && (latest == "" || info.ModTime().After(latestTime)) {
+			latest = filepath.Join(dir, entry.Name())
+			latestTime = info.ModTime()
+		}
+	}
+	if latest == "" {
+		return nil, fmt.Errorf("no Pi session transcript found")
+	}
+	data, err := os.ReadFile(latest)
+	if err != nil {
+		return nil, err
+	}
+	return parsePiLastAssistantMessage(data)
+}
+
+func parsePiLastAssistantMessage(data []byte) (*ResponseOutput, error) {
+	type contentPart struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	var sessionID string
+	var last *ResponseOutput
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var event struct {
+			Type      string `json:"type"`
+			ID        string `json:"id"`
+			Timestamp string `json:"timestamp"`
+			Message   struct {
+				Role    string        `json:"role"`
+				Content []contentPart `json:"content"`
+			} `json:"message"`
+		}
+		if json.Unmarshal(line, &event) != nil {
+			continue
+		}
+		if event.Type == "session" {
+			sessionID = event.ID
+			continue
+		}
+		if event.Type != "message" || event.Message.Role != "assistant" {
+			continue
+		}
+		var text []string
+		for _, part := range event.Message.Content {
+			if part.Type == "text" {
+				text = append(text, part.Text)
+			}
+		}
+		if len(text) != 0 {
+			last = &ResponseOutput{
+				Tool: "pi", Role: "assistant", Content: strings.Join(text, "\n"),
+				Timestamp: event.Timestamp, SessionID: sessionID,
+			}
+		}
+	}
+	if last == nil {
+		return nil, fmt.Errorf("no assistant response found in Pi session")
+	}
+	return last, nil
 }
 
 // getTerminalLastResponse extracts the last response from terminal output

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8170,6 +8170,9 @@ func parseGeminiLastAssistantMessage(data []byte) (*ResponseOutput, error) {
 }
 
 func (i *Instance) getPiLastResponse() (*ResponseOutput, error) {
+	if i.IsSSH() || i.IsSandboxed() {
+		return nil, fmt.Errorf("instance %s runs outside this host; its Pi transcript is not on this machine", i.ID)
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err

--- a/internal/session/pi_output_test.go
+++ b/internal/session/pi_output_test.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPiLastResponseReadsStructuredTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".pi", "agent-deck", "deck-session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"type":"session","id":"pi-session","timestamp":"2026-08-28T06:36:55.364Z"}
+{"type":"message","timestamp":"2026-08-28T06:41:18.413Z","message":{"role":"user","content":[{"type":"text","text":"Hello"}]}}
+{"type":"message","timestamp":"2026-08-28T06:41:23.295Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"brief"},{"type":"text","text":"Hello, world!"}]}}
+`)
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&Instance{ID: "deck-session", Tool: "pi"}).GetLastResponse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tool != "pi" || got.Role != "assistant" || got.Content != "Hello, world!" ||
+		got.Timestamp != "2026-08-28T06:41:23.295Z" || got.SessionID != "pi-session" {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}

--- a/internal/session/pi_output_test.go
+++ b/internal/session/pi_output_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 func TestPiLastResponseReadsStructuredTranscript(t *testing.T) {
@@ -28,5 +30,64 @@ func TestPiLastResponseReadsStructuredTranscript(t *testing.T) {
 	if got.Tool != "pi" || got.Role != "assistant" || got.Content != "Hello, world!" ||
 		got.Timestamp != "2026-08-28T06:41:23.295Z" || got.SessionID != "pi-session" {
 		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+// A legacy SSH instance's transcript belongs to the target HOME, even when a
+// stale local directory happens to carry the same instance ID.
+func TestPiLastResponseNonlocalRefusesLocalTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".pi", "agent-deck", "remote-session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"type":"message","timestamp":"2026-08-28T06:41:23.295Z","message":{"role":"assistant","content":[{"type":"text","text":"WRONG LOCAL RESPONSE"}]}}`)
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The transport boundary returns a different pane response, never the
+	// controller's stale transcript. No SSH network access is needed here.
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "tmux"), []byte("#!/bin/sh\nprintf 'REMOTE PANE RESPONSE\\n'\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for _, inst := range []*Instance{
+		{ID: "remote-session", Tool: "pi", SSHHost: "remote.example"},
+		{ID: "remote-session", Tool: "pi", Sandbox: &SandboxConfig{Enabled: true}},
+	} {
+		if got, err := inst.GetLastResponse(); err == nil {
+			t.Fatalf("read local transcript for nonlocal instance: %+v", got)
+		}
+		if got, err := inst.GetLastResponseBestEffort(); err == nil {
+			t.Fatalf("best effort read local transcript for nonlocal instance without a pane: %+v", got)
+		}
+		inst.tmuxSession = tmux.NewSession("pi-nonlocal-output", home)
+		got, err := inst.GetLastResponseBestEffort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Content != "REMOTE PANE RESPONSE" || got.Timestamp != "" {
+			t.Fatalf("nonlocal output must come from the pane without a timestamp: %+v", got)
+		}
+	}
+}
+
+func TestPiResponseParserHandlesPartialAndNontextRecords(t *testing.T) {
+	data := []byte(`{"type":"session","id":"pi-selected"}
+{"type":"message","timestamp":"2026-08-28T06:41:23.295Z","message":{"role":"assistant","content":[{"type":"text","text":"first"},{"type":"text","text":"second"}]}}
+{"type":"message","timestamp":"2026-08-28T06:41:24Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"hidden"},{"type":"toolCall","name":"read"}]}}
+{"type":"message","message":{"role":"user","content":[{"type":"text","text":"later user"}]}}
+{"type":"message",`)
+	got, err := parsePiLastAssistantMessage(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Content != "first\nsecond" || got.Timestamp != "2026-08-28T06:41:23.295Z" || got.SessionID != "pi-selected" {
+		t.Fatalf("unexpected parsed response: %+v", got)
+	}
+	if got, err := parsePiLastAssistantMessage([]byte(`{"type":"session","id":"no-replies"}`)); err == nil || got != nil {
+		t.Fatalf("missing assistant must fail: %+v, %v", got, err)
 	}
 }


### PR DESCRIPTION
## What problem does this solve?

Fast Pi turns can finish before activity polling observes them, causing send to report an accepted prompt as unconfirmed. Pi output previously scraped terminal UI instead of structured assistant text. This repair also prevents unsent horizontal-rule payloads from masquerading as an empty editor, stale local files from shadowing SSH or sandbox output, and earlier Pi replies from satisfying `send --wait`.

Related: #1238 and #1793.

## Why this change

John Wiegley's (@jwiegley) tool-aware dispatch and instance-scoped Pi transcript reader are retained. Ordinary new message text followed by an empty Pi editor can confirm a fast turn. Payloads containing border-length rules require observed activity because their bytes can impersonate editor boundaries. An ambiguous screen remains unconfirmed, even if a fast turn may actually have completed; no durable receipt is claimed from that screen.

Local Pi replies must reach this send's millisecond timestamp before the bounded output wait expires. Missing or stale timestamps produce an explicit timeout error. Legacy SSH and sandbox instances retain terminal fallback without reading controller-side Pi transcripts or claiming structured freshness. Configured `agent-deck remote` forwarding still reads the server-local transcript on the server.

## User impact

Ordinary fast Pi sends avoid false delivery failures. Unsent divider-containing messages cannot report submission merely because their own rule resembles the editor border. Local `send --wait` cannot return an earlier turn as success. Direct Pi output returns structured assistant text locally, with terminal fallback for legacy nonlocal sessions.

## Evidence

Candidate repair: `83474dc2889a427d518f2f748a5c0c4e8ec5218b`. Applying only the new tests to the original contributor head reproduces the false-submission, stale-output and nonlocal-shadowing bugs with failing assertions. The corrected candidate passes focused tests and focused `-race` tests, `go vet ./...`, and the full sandboxed `go test -p 1 ./... -count=1`: 56 packages pass, 3 have no tests. Command package 70.772s, session package 65.476s, UI 22.270s. These are test execution times, not CLI latency benchmarks.

Contributor self-check: **14 PASS, 0 FAIL, 2 WARN, 0 skipped**. The complete PR's revert check against pre-Pi main cannot compile because the Pi parser is a new symbol. The independent repair red run against the actual contributor head compiles and fails on behavior, then passes with the corrections. The overall diff is +393/-17, mainly table-driven regression fixtures for the three interacting Pi send/output defects; retaining these in one Pi repair avoids landing partially corrected submission/output behavior. Existing contributor live reproduction established the original fast-turn failure. New amended-head CI and combined-main verification are still required.

No host Go tests are permitted for this repair. Validation uses an isolated Docker HOME, cleared XDG paths, container-local source, `GOMAXPROCS=4`, CPU limits, and serial full-package execution. No tests are excluded.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** Original contribution: `openai-codex/gpt-5.6-sol`. Maintainer repair: `gpt-6-astra`.

## What actually bothered you

> “Fix agent-deck session submission confirmation failures”

> “The following command fails to correctly talk to my DeepSeek agent-deck session.”

The contributor reported that the model answered while the send command exited nonzero, causing a fallback model and a duplicate request.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed
- [ ] Hot-path timing evidence included
- [x] CHANGELOG.md untouched
- [x] AI use disclosed
- [x] Allow edits from maintainers enabled (verified via GitHub API)

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message delivery detection for Pi sessions, distinguishing submitted messages from text remaining in the composer.
  - Improved verification when submitted messages clear the Pi editor.
  - Prevented transcript dividers and ambiguous editor layouts from being mistaken for user messages.

- **Reliability**
  - Pi sessions now retrieve the latest assistant response from structured conversation transcripts.
  - Improved handling of fresh responses, stale output, missing timestamps, and unavailable transcript data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->