### PR TITLE
feat(cli): add bash, zsh, and fish completion scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#uninstalli
 
 </details>
 
+<details>
+<summary>Shell completion</summary>
+
+`agent-deck completion <bash|zsh|fish>` prints a completion script for commands and subcommands (`agent-deck se<Tab>` → `session`, `agent-deck session st<Tab>` → `start`/`stop`), plus live resource names where it matters — `agent-deck remote update <Tab>` offers your configured remotes, `agent-deck session set-parent <Tab> <Tab>` offers session titles at both positions, and `agent-deck -p <Tab>` offers your profiles.
+
+```bash
+# bash
+echo 'source <(agent-deck completion bash)' >> ~/.bashrc
+
+# zsh
+echo 'source <(agent-deck completion zsh)' >> ~/.zshrc
+
+# fish
+agent-deck completion fish > ~/.config/fish/completions/agent-deck.fish
+```
+
+Open a new shell (or re-source the config file) afterwards.
+
+</details>
+
 ## Quick Start
 
 ```bash

--- a/cmd/agent-deck/completion_cmd.go
+++ b/cmd/agent-deck/completion_cmd.go
@@ -1,0 +1,811 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"al.essio.dev/pkg/shellescape"
+
+	"github.com/asheshgoplani/agent-deck/internal/agents"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// remoteSessionCompletionTimeout bounds how long `agent-deck remote
+// attach|rename <TAB>` will wait on the SSH round trip to list a remote's
+// sessions. This runs on every Tab press, so it must fail fast rather than
+// ride FetchSessions' normal 30s command timeout (or, per ssh.go's
+// CleanStaleSSHSockets doc comment, an even longer hang against a stale
+// ControlMaster socket) — a slow or unreachable remote should just leave the
+// shell to fall back to plain filename completion, not freeze the terminal.
+const remoteSessionCompletionTimeout = 3 * time.Second
+
+// argKind identifies what a positional argument after a command (or
+// command+subcommand) should dynamically complete to. argNone means "no
+// dynamic completer" — the shell falls back to its default (filename)
+// completion, which is what a real command like `add <path>` wants anyway.
+type argKind int
+
+const (
+	argNone argKind = iota
+	argSession
+	argRemote
+	argProfile
+	argGroup
+	argAgent
+	// argRemoteSession names a session on the remote given by the preceding
+	// positional argument (`remote attach <remote> <session>`, `remote
+	// rename <remote> <session> <new-title>`) — plain argSession would offer
+	// this machine's own local session titles, which don't exist on the
+	// remote and just get in the way (a session's completion candidates and
+	// its ID/title namespace are both scoped to the remote it fetched from).
+	argRemoteSession
+)
+
+// completeKeyword is the string `agent-deck __complete` accepts to produce
+// candidates for this kind. Keep in sync with handleComplete's switch.
+func (k argKind) completeKeyword() string {
+	switch k {
+	case argSession:
+		return "sessions"
+	case argRemote:
+		return "remotes"
+	case argProfile:
+		return "profiles"
+	case argGroup:
+		return "groups"
+	case argAgent:
+		return "agents"
+	case argRemoteSession:
+		return "remote-sessions"
+	default:
+		return ""
+	}
+}
+
+// completionNode describes one node of the agent-deck command tree for
+// shell-completion purposes: a top-level command name, the subcommands its
+// own dispatch switch accepts (nil for leaf commands like `add` or
+// `launch`), and — for the positions worth completing dynamically — which
+// resource each one names.
+//
+// args maps a subcommand name to the ordered completers for the positional
+// arguments that follow it (0-indexed). Nodes with no subcommands (subs ==
+// nil) key this by "" for the args following the command name itself. A
+// position past the end of the list, or a leaf command with no args entry,
+// gets the shell's default completion.
+//
+// This is a hand-maintained mirror of the switch in main() and each
+// handleX() dispatcher — the same relationship printHelp() already has to
+// those switches. A new subcommand needs a one-line addition here to show
+// up in completion menus; it won't be wrong to omit one, only less helpful.
+type completionNode struct {
+	name string
+	subs []string
+	args map[string][]argKind
+}
+
+// completionTree lists every user-facing agent-deck command. Pure plumbing
+// invoked by other processes rather than typed by a user (hook-handler,
+// codex-notify, notify-daemon, mcp-proxy, and the __complete helper below)
+// is left out on purpose, matching printHelp()'s existing omission of those
+// from its command list.
+var completionTree = []completionNode{
+	{name: "add"},
+	{name: "list"},
+	{name: "ls"},
+	{name: "remove", args: map[string][]argKind{"": {argSession}}},
+	{name: "rm", args: map[string][]argKind{"": {argSession}}},
+	{name: "rename", args: map[string][]argKind{"": {argSession}}},
+	{name: "mv", args: map[string][]argKind{"": {argSession}}},
+	{name: "status"},
+	{name: "update"},
+	{name: "launch"},
+	{name: "try"},
+	{name: "accounts"},
+	{name: "web"},
+	{name: "debug-dump"},
+	{name: "migrate-paths"},
+	{name: "uninstall"},
+	{name: "run-task"},
+	{name: "feedback"},
+	{name: "creds-refresh"},
+	{name: "telegram-doctor"},
+	{name: "version"},
+	{name: "help"},
+	{name: "completion", subs: []string{"bash", "zsh", "fish"}},
+	{
+		name: "profile",
+		subs: []string{"list", "create", "delete", "default"},
+		args: map[string][]argKind{
+			"delete":  {argProfile},
+			"default": {argProfile},
+		},
+	},
+	{name: "inbox", subs: []string{"drain"}},
+	{
+		name: "session",
+		subs: []string{
+			"start", "stop", "remove", "cleanup", "prune", "archive", "unarchive",
+			"restart", "revive", "fork", "handoff", "attach", "focus", "show",
+			"current", "set-parent", "unset-parent", "update", "set-transition-notify",
+			"set-title-lock", "set", "switch-account", "move", "send", "approve",
+			"send-keys", "output", "children", "search",
+		},
+		args: map[string][]argKind{
+			"start":                 {argSession},
+			"stop":                  {argSession},
+			"remove":                {argSession},
+			"archive":               {argSession},
+			"unarchive":             {argSession},
+			"restart":               {argSession},
+			"fork":                  {argSession},
+			"handoff":               {argSession},
+			"attach":                {argSession},
+			"focus":                 {argSession},
+			"show":                  {argSession},
+			"set-parent":            {argSession, argSession},
+			"unset-parent":          {argSession},
+			"update":                {argSession},
+			"set-transition-notify": {argSession},
+			"set-title-lock":        {argSession},
+			"set":                   {argSession},
+			"switch-account":        {argSession, argProfile},
+			"move":                  {argSession},
+			"send":                  {argSession},
+			"approve":               {argSession},
+			"send-keys":             {argSession},
+			"output":                {argSession},
+			"children":              {argSession},
+		},
+	},
+	{name: "fleet", subs: []string{"status", "recover"}},
+	{
+		name: "mcp",
+		subs: []string{"list", "attached", "attach", "detach", "server"},
+		args: map[string][]argKind{
+			"attached": {argSession},
+			"attach":   {argSession},
+			"detach":   {argSession},
+		},
+	},
+	{
+		name: "plugin",
+		subs: []string{"list", "attached", "attach", "detach"},
+		args: map[string][]argKind{
+			"attached": {argSession},
+			"attach":   {argSession},
+			"detach":   {argSession},
+		},
+	},
+	{
+		name: "skill",
+		subs: []string{"list", "attached", "attach", "detach", "source"},
+		args: map[string][]argKind{
+			"attached": {argSession},
+			"attach":   {argSession},
+			"detach":   {argSession},
+		},
+	},
+	{
+		name: "group",
+		subs: []string{"list", "show", "create", "update", "delete", "move", "change", "reorder"},
+		args: map[string][]argKind{
+			"show":    {argGroup},
+			"update":  {argGroup},
+			"delete":  {argGroup},
+			"move":    {argSession, argGroup},
+			"change":  {argGroup, argGroup},
+			"reorder": {argGroup},
+		},
+	},
+	{
+		name: "conductor",
+		subs: []string{"setup", "teardown", "status", "list", "move", "migrate-dir"},
+		args: map[string][]argKind{
+			"move": {argSession},
+		},
+	},
+	{
+		name: "agents",
+		subs: []string{"adopt", "list", "show"},
+		args: map[string][]argKind{"show": {argAgent}},
+	},
+	{
+		name: "agent",
+		subs: []string{"adopt", "list", "show"},
+		args: map[string][]argKind{"show": {argAgent}},
+	},
+	{name: "watcher", subs: []string{"import", "create", "start", "stop", "list", "status", "test", "routes", "install-skill"}},
+	{name: "openclaw", subs: []string{"sync", "bridge", "status", "list", "send"}},
+	{name: "oc", subs: []string{"sync", "bridge", "status", "list", "send"}},
+	{
+		name: "remote",
+		subs: []string{"add", "remove", "list", "sessions", "drain", "attach", "rename", "update"},
+		args: map[string][]argKind{
+			"remove":   {argRemote},
+			"sessions": {argRemote},
+			"attach":   {argRemote, argRemoteSession},
+			"rename":   {argRemote, argRemoteSession},
+			"update":   {argRemote},
+		},
+	},
+	{
+		name: "worktree",
+		subs: []string{"list", "info", "cleanup", "finish", "trust-scripts"},
+		args: map[string][]argKind{
+			"info":   {argSession},
+			"finish": {argSession},
+		},
+	},
+	{
+		name: "wt",
+		subs: []string{"list", "info", "cleanup", "finish", "trust-scripts"},
+		args: map[string][]argKind{
+			"info":   {argSession},
+			"finish": {argSession},
+		},
+	},
+	{name: "costs", subs: []string{"sync", "summary", "recompute"}},
+	{name: "hooks", subs: []string{"install", "uninstall", "status"}},
+	{name: "codex-hooks", subs: []string{"install", "uninstall", "status"}},
+	{name: "gemini-hooks", subs: []string{"install", "uninstall", "status"}},
+	{name: "hermes-hooks", subs: []string{"install", "uninstall", "status"}},
+	{name: "cursor-hooks", subs: []string{"install", "uninstall", "status"}},
+	{name: "deepseek", subs: []string{"status", "profiles", "sessions"}},
+}
+
+// completionTopLevelNames returns every completable top-level command name,
+// in the order completionTree declares them.
+func completionTopLevelNames() []string {
+	names := make([]string, len(completionTree))
+	for i, n := range completionTree {
+		names[i] = n.name
+	}
+	return names
+}
+
+// completionRule is one (command, subcommand, position) -> resource-kind
+// mapping, flattened out of completionTree.args for the shell generators.
+// sub is "" for a leaf command's own positional args.
+type completionRule struct {
+	cmd      string
+	sub      string
+	argIndex int
+	kind     argKind
+}
+
+// completionRules flattens completionTree.args into a deterministically
+// ordered list every shell generator renders identically from.
+func completionRules() []completionRule {
+	var rules []completionRule
+	for _, n := range completionTree {
+		for sub, kinds := range n.args {
+			for i, k := range kinds {
+				if k == argNone {
+					continue
+				}
+				rules = append(rules, completionRule{cmd: n.name, sub: sub, argIndex: i, kind: k})
+			}
+		}
+	}
+	sort.Slice(rules, func(i, j int) bool {
+		if rules[i].cmd != rules[j].cmd {
+			return rules[i].cmd < rules[j].cmd
+		}
+		if rules[i].sub != rules[j].sub {
+			return rules[i].sub < rules[j].sub
+		}
+		return rules[i].argIndex < rules[j].argIndex
+	})
+	return rules
+}
+
+// handleCompletion dispatches `agent-deck completion <bash|zsh|fish>`,
+// printing a self-contained completion script to stdout.
+func handleCompletion(args []string) {
+	if len(args) == 0 {
+		printCompletionHelp(os.Stderr)
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "help", "--help", "-h":
+		printCompletionHelp(os.Stdout)
+	case "bash":
+		fmt.Print(bashCompletionScript())
+	case "zsh":
+		fmt.Print(zshCompletionScript())
+	case "fish":
+		fmt.Print(fishCompletionScript())
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown shell %q (want bash, zsh, or fish)\n\n", args[0])
+		printCompletionHelp(os.Stderr)
+		os.Exit(1)
+	}
+}
+
+func printCompletionHelp(w io.Writer) {
+	fmt.Fprintln(w, "Usage: agent-deck completion <bash|zsh|fish>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Print a shell completion script for agent-deck's commands, subcommands,")
+	fmt.Fprintln(w, "and resource names (sessions, remotes, profiles, groups, agents) to stdout.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Bash:  echo 'source <(agent-deck completion bash)' >> ~/.bashrc")
+	fmt.Fprintln(w, "  Zsh:   echo 'source <(agent-deck completion zsh)' >> ~/.zshrc")
+	fmt.Fprintln(w, "         (or save as a file named '_agent_deck' in a directory on $fpath)")
+	fmt.Fprintln(w, "  Fish:  agent-deck completion fish > ~/.config/fish/completions/agent-deck.fish")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Open a new shell (or re-source the config file) afterwards.")
+}
+
+// handleComplete implements the internal `agent-deck __complete <kind>`
+// helper the generated shell scripts shell out to for dynamic candidates.
+// It is not a user-facing command — omitted from completionTree and
+// printHelp, dispatched from its own case in main()'s switch.
+//
+// Best-effort by design: this runs on every Tab press, so a missing
+// profile, a locked database, or a corrupt config must never print an
+// error — that would show up as a bogus completion candidate or corrupt
+// the terminal. On any failure it prints nothing and the shell falls back
+// to its normal filename completion.
+func handleComplete(profile string, args []string) {
+	if len(args) == 0 {
+		return
+	}
+	switch args[0] {
+	case "sessions":
+		printSessionCompletions(profile)
+	case "remotes":
+		printRemoteCompletions()
+	case "profiles":
+		printProfileCompletions()
+	case "groups":
+		printGroupCompletions(profile)
+	case "agents":
+		printAgentCompletions()
+	case "remote-sessions":
+		if len(args) > 1 {
+			printRemoteSessionCompletions(args[1])
+		}
+	}
+}
+
+// completionCandidate prints name as one completion candidate, skipping
+// anything empty or containing a newline (which would otherwise be split
+// into two bogus candidates or corrupt the shell script's parsing of the
+// output).
+func completionCandidate(name string) (string, bool) {
+	if name == "" || strings.ContainsAny(name, "\r\n") {
+		return "", false
+	}
+	return name, true
+}
+
+// printSortedCompletions sorts names and prints each on its own line — the
+// common tail every printXCompletions function below ends with.
+func printSortedCompletions(names []string) {
+	sort.Strings(names)
+	for _, n := range names {
+		fmt.Println(n)
+	}
+}
+
+// appendTitleOrIDCandidate falls back from title to id (the same "prefer the
+// title, an untitled session is named by its ID" rule session and remote
+// listings share), validates the result via completionCandidate, and skips
+// it if already present in seen — the common dedup step printSessionCompletions
+// and printRemoteSessionCompletions both need over their respective session
+// slices.
+func appendTitleOrIDCandidate(names []string, seen map[string]bool, title, id string) []string {
+	name := title
+	if name == "" {
+		name = id
+	}
+	cand, ok := completionCandidate(name)
+	if !ok || seen[cand] {
+		return names
+	}
+	seen[cand] = true
+	return append(names, cand)
+}
+
+func printSessionCompletions(profile string) {
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		return
+	}
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		return
+	}
+	seen := make(map[string]bool)
+	var names []string
+	for _, inst := range instances {
+		names = appendTitleOrIDCandidate(names, seen, inst.Title, inst.ID)
+	}
+	printSortedCompletions(names)
+}
+
+func printRemoteCompletions() {
+	config, err := session.LoadUserConfig()
+	if err != nil || config == nil {
+		return
+	}
+	names := make([]string, 0, len(config.Remotes))
+	for name := range config.Remotes {
+		if cand, ok := completionCandidate(name); ok {
+			names = append(names, cand)
+		}
+	}
+	printSortedCompletions(names)
+}
+
+// printRemoteSessionCompletions lists the session titles/IDs that live on
+// the named remote — the completer for `remote attach`/`remote rename`'s
+// session argument. Unlike printSessionCompletions this can't just read the
+// local store: the session being renamed or attached to lives on the
+// remote's own store, fetched over SSH (mirroring handleRemoteAttach and
+// handleRemoteRename's own resolution).
+func printRemoteSessionCompletions(remoteName string) {
+	rc, exists, err := resolveRemoteConfig(remoteName)
+	if err != nil || !exists {
+		return
+	}
+
+	session.CleanStaleSSHSockets()
+	runner := session.NewSSHRunner(remoteName, rc)
+	ctx, cancel := context.WithTimeout(context.Background(), remoteSessionCompletionTimeout)
+	defer cancel()
+	sessions, err := runner.FetchSessions(ctx)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[string]bool)
+	var names []string
+	for _, s := range sessions {
+		names = appendTitleOrIDCandidate(names, seen, s.Title, s.ID)
+	}
+	printSortedCompletions(names)
+}
+
+func printProfileCompletions() {
+	profiles, err := session.ListProfiles()
+	if err != nil {
+		return
+	}
+	var names []string
+	for _, p := range profiles {
+		// Underscore-prefixed profiles are test fixtures and scratch state
+		// (#1926) — noise in a completion menu, so left out here the same
+		// way handleProfileList visually separates them.
+		if isInternalProfileName(p) {
+			continue
+		}
+		if cand, ok := completionCandidate(p); ok {
+			names = append(names, cand)
+		}
+	}
+	printSortedCompletions(names)
+}
+
+func printGroupCompletions(profile string) {
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		return
+	}
+	instances, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		return
+	}
+	tree := session.NewGroupTreeWithGroups(instances, groups)
+	var paths []string
+	for _, g := range tree.GroupList {
+		if g.Path == session.DefaultGroupPath {
+			continue
+		}
+		if cand, ok := completionCandidate(g.Path); ok {
+			paths = append(paths, cand)
+		}
+	}
+	printSortedCompletions(paths)
+}
+
+func printAgentCompletions() {
+	defs, err := agents.LoadAll()
+	if err != nil {
+		return
+	}
+	var names []string
+	for _, def := range defs {
+		if cand, ok := completionCandidate(def.Name); ok {
+			names = append(names, cand)
+		}
+	}
+	printSortedCompletions(names)
+}
+
+// bashCompletionScript renders a self-contained bash completion function.
+// It only needs COMP_WORDS/COMP_CWORD/compgen — no dependency on the
+// separate bash-completion package.
+//
+// Positional args past the command (and subcommand, if any) resolve to a
+// dynamic resource lookup via the "$cmd:$sub:$arg_index" case below, which
+// shells out to `agent-deck __complete <kind>` — this is what lets
+// `agent-deck remote update <TAB>` offer configured remote names, and
+// `agent-deck session set-parent <TAB> <TAB>` offer session names at BOTH
+// positions, three and four words in. A leading `-p`/`--profile` shifts
+// every position that follows by 2 (or 1 for the `-p=value` form) and is
+// forwarded to `__complete` so dynamic candidates match the profile being
+// completed for, not just the default one.
+func bashCompletionScript() string {
+	var b strings.Builder
+	b.WriteString("# agent-deck bash completion\n")
+	b.WriteString("# Install: source <(agent-deck completion bash)\n\n")
+	b.WriteString("_agent_deck_completion() {\n")
+	b.WriteString("    local cur words cword start cmd sub arg_index kind\n")
+	b.WriteString("    cur=\"${COMP_WORDS[COMP_CWORD]}\"\n")
+	b.WriteString("    words=(\"${COMP_WORDS[@]}\")\n")
+	b.WriteString("    cword=$COMP_CWORD\n\n")
+	b.WriteString("    # A leading -p/--profile shifts every position that follows. Complete the\n")
+	b.WriteString("    # profile name itself right after it.\n")
+	b.WriteString("    start=1\n")
+	b.WriteString("    case \"${words[1]}\" in\n")
+	b.WriteString("        -p|--profile)\n")
+	b.WriteString("            if ((cword == 2)); then\n")
+	b.WriteString("                local IFS=$'\\n'\n")
+	b.WriteString("                COMPREPLY=($(compgen -W \"$(agent-deck __complete profiles 2>/dev/null)\" -- \"$cur\"))\n")
+	b.WriteString("                return 0\n")
+	b.WriteString("            fi\n")
+	b.WriteString("            start=3\n")
+	b.WriteString("            ;;\n")
+	b.WriteString("        -p=*|--profile=*)\n")
+	b.WriteString("            start=2\n")
+	b.WriteString("            ;;\n")
+	b.WriteString("    esac\n\n")
+	b.WriteString("    if ((cword < start)); then\n")
+	b.WriteString("        return 0\n")
+	b.WriteString("    fi\n")
+	b.WriteString("    if ((cword == start)); then\n")
+	fmt.Fprintf(&b, "        COMPREPLY=($(compgen -W %s -- \"$cur\"))\n", shellescape.Quote(strings.Join(completionTopLevelNames(), " ")))
+	b.WriteString("        return 0\n")
+	b.WriteString("    fi\n\n")
+	b.WriteString("    cmd=${words[start]}\n")
+	b.WriteString("    sub=\"\"\n")
+	b.WriteString("    arg_index=$((cword - start - 1))\n\n")
+	b.WriteString("    case \"$cmd\" in\n")
+	for _, n := range completionTree {
+		if len(n.subs) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "        %s)\n", n.name)
+		b.WriteString("            if ((cword == start + 1)); then\n")
+		fmt.Fprintf(&b, "                COMPREPLY=($(compgen -W %s -- \"$cur\"))\n", shellescape.Quote(strings.Join(n.subs, " ")))
+		b.WriteString("                return 0\n")
+		b.WriteString("            fi\n")
+		b.WriteString("            sub=${words[start+1]}\n")
+		b.WriteString("            arg_index=$((cword - start - 2))\n")
+		b.WriteString("            ;;\n")
+	}
+	b.WriteString("    esac\n\n")
+	b.WriteString("    kind=\"\"\n")
+	b.WriteString("    case \"$cmd:$sub:$arg_index\" in\n")
+	for _, r := range completionRules() {
+		fmt.Fprintf(&b, "        %s) kind=%s ;;\n",
+			shellescape.Quote(fmt.Sprintf("%s:%s:%d", r.cmd, r.sub, r.argIndex)), r.kind.completeKeyword())
+	}
+	b.WriteString("    esac\n\n")
+	b.WriteString("    if [[ -n $kind ]]; then\n")
+	b.WriteString("        local -a profile_args=()\n")
+	b.WriteString("        if ((start > 1)); then\n")
+	b.WriteString("            if [[ ${words[1]} == -p || ${words[1]} == --profile ]]; then\n")
+	b.WriteString("                profile_args=(-p \"${words[2]}\")\n")
+	b.WriteString("            else\n")
+	b.WriteString("                profile_args=(-p \"${words[1]#*=}\")\n")
+	b.WriteString("            fi\n")
+	b.WriteString("        fi\n")
+	b.WriteString("        # remote-sessions scopes to the remote named in the preceding\n")
+	b.WriteString("        # positional (`remote attach <remote> <session>`, `remote rename\n")
+	b.WriteString("        # <remote> <session> <new-title>`) — forward it as an extra arg.\n")
+	b.WriteString("        local -a extra_args=()\n")
+	b.WriteString("        if [[ $kind == remote-sessions ]]; then\n")
+	b.WriteString("            extra_args=(\"${words[start+1+arg_index]}\")\n")
+	b.WriteString("        fi\n")
+	b.WriteString("        local -a names\n")
+	b.WriteString("        local IFS=$'\\n'\n")
+	b.WriteString("        names=($(agent-deck \"${profile_args[@]}\" __complete \"$kind\" \"${extra_args[@]}\" 2>/dev/null))\n")
+	b.WriteString("        # Candidates may contain spaces (session titles); compgen -W would\n")
+	b.WriteString("        # re-split them on whitespace and lose the escaping bash needs to\n")
+	b.WriteString("        # insert a multi-word completion as one argument, so filter and\n")
+	b.WriteString("        # escape by hand instead of going through it.\n")
+	b.WriteString("        COMPREPLY=()\n")
+	b.WriteString("        local n\n")
+	b.WriteString("        for n in \"${names[@]}\"; do\n")
+	b.WriteString("            if [[ $n == \"$cur\"* ]]; then\n")
+	b.WriteString("                COMPREPLY+=(\"${n// /\\\\ }\")\n")
+	b.WriteString("            fi\n")
+	b.WriteString("        done\n")
+	b.WriteString("        return 0\n")
+	b.WriteString("    fi\n")
+	b.WriteString("}\n")
+	b.WriteString("complete -F _agent_deck_completion agent-deck\n")
+	return b.String()
+}
+
+// zshCompletionScript renders a completion function using zsh's native
+// compadd, guarded so the script works both loaded directly via `source`
+// and installed as an autoloaded `_agent_deck` file on $fpath. Mirrors
+// bashCompletionScript's position math (words[1] == "agent-deck" here,
+// versus words[0] in bash) — see its doc comment for the dynamic-arg and
+// leading -p/--profile handling both share.
+func zshCompletionScript() string {
+	var b strings.Builder
+	b.WriteString("#compdef agent-deck\n")
+	b.WriteString("# agent-deck zsh completion\n\n")
+	b.WriteString("_agent_deck() {\n")
+	b.WriteString("    local -a top_commands subs cands profile_args extra_args\n")
+	b.WriteString("    local start cmd sub arg_index kind\n")
+	fmt.Fprintf(&b, "    top_commands=(%s)\n\n", strings.Join(completionTopLevelNames(), " "))
+	b.WriteString("    start=2\n")
+	b.WriteString("    case ${words[2]} in\n")
+	b.WriteString("        -p|--profile)\n")
+	b.WriteString("            if (( CURRENT == 3 )); then\n")
+	b.WriteString("                cands=(${(f)\"$(agent-deck __complete profiles 2>/dev/null)\"})\n")
+	b.WriteString("                compadd -a cands\n")
+	b.WriteString("                return\n")
+	b.WriteString("            fi\n")
+	b.WriteString("            start=4\n")
+	b.WriteString("            ;;\n")
+	b.WriteString("        -p=*|--profile=*)\n")
+	b.WriteString("            start=3\n")
+	b.WriteString("            ;;\n")
+	b.WriteString("    esac\n\n")
+	b.WriteString("    if (( CURRENT < start )); then\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n")
+	b.WriteString("    if (( CURRENT == start )); then\n")
+	b.WriteString("        compadd -a top_commands\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n\n")
+	b.WriteString("    cmd=${words[start]}\n")
+	b.WriteString("    sub=\"\"\n")
+	b.WriteString("    arg_index=$(( CURRENT - start - 1 ))\n\n")
+	b.WriteString("    case $cmd in\n")
+	for _, n := range completionTree {
+		if len(n.subs) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "    %s)\n", n.name)
+		b.WriteString("        if (( CURRENT == start + 1 )); then\n")
+		fmt.Fprintf(&b, "            subs=(%s)\n", strings.Join(n.subs, " "))
+		b.WriteString("            compadd -a subs\n")
+		b.WriteString("            return\n")
+		b.WriteString("        fi\n")
+		b.WriteString("        sub=${words[start+1]}\n")
+		b.WriteString("        arg_index=$(( CURRENT - start - 2 ))\n")
+		b.WriteString("        ;;\n")
+	}
+	b.WriteString("    esac\n\n")
+	b.WriteString("    kind=\"\"\n")
+	b.WriteString("    case \"$cmd:$sub:$arg_index\" in\n")
+	for _, r := range completionRules() {
+		fmt.Fprintf(&b, "    %s) kind=%s ;;\n",
+			shellescape.Quote(fmt.Sprintf("%s:%s:%d", r.cmd, r.sub, r.argIndex)), r.kind.completeKeyword())
+	}
+	b.WriteString("    esac\n\n")
+	b.WriteString("    if [[ -n $kind ]]; then\n")
+	b.WriteString("        profile_args=()\n")
+	b.WriteString("        if (( start > 2 )); then\n")
+	b.WriteString("            if [[ ${words[2]} == -p || ${words[2]} == --profile ]]; then\n")
+	b.WriteString("                profile_args=(-p ${words[3]})\n")
+	b.WriteString("            else\n")
+	b.WriteString("                profile_args=(-p ${words[2]#*=})\n")
+	b.WriteString("            fi\n")
+	b.WriteString("        fi\n")
+	b.WriteString("        # remote-sessions scopes to the remote named in the preceding\n")
+	b.WriteString("        # positional (`remote attach <remote> <session>`, `remote rename\n")
+	b.WriteString("        # <remote> <session> <new-title>`) — forward it as an extra arg.\n")
+	b.WriteString("        extra_args=()\n")
+	b.WriteString("        if [[ $kind == remote-sessions ]]; then\n")
+	b.WriteString("            extra_args=(${words[start+1+arg_index]})\n")
+	b.WriteString("        fi\n")
+	b.WriteString("        cands=(${(f)\"$(agent-deck ${profile_args[@]} __complete $kind ${extra_args[@]} 2>/dev/null)\"})\n")
+	b.WriteString("        compadd -a cands\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n")
+	b.WriteString("}\n\n")
+	b.WriteString("if [[ $(type compdef) = *function* ]]; then\n")
+	b.WriteString("    compdef _agent_deck agent-deck\n")
+	b.WriteString("fi\n")
+	return b.String()
+}
+
+// fishCompletionScript renders `complete -c agent-deck` rules gated by a
+// small helper (__agent_deck_at) that counts tokens up to the cursor —
+// fish's own bundled completions (e.g. git.fish) use the same
+// commandline-token-counting idiom. __agent_deck_toks first strips a
+// leading -p/--profile pair so every position downstream lines up the same
+// way regardless of whether one was typed.
+func fishCompletionScript() string {
+	var b strings.Builder
+	b.WriteString("# agent-deck fish completion\n")
+	b.WriteString("# Install: agent-deck completion fish > ~/.config/fish/completions/agent-deck.fish\n\n")
+
+	b.WriteString("function __agent_deck_toks\n")
+	b.WriteString("    set -l toks (commandline -opc)\n")
+	b.WriteString("    if [ (count $toks) -ge 3 ]; and contains -- $toks[2] -p --profile\n")
+	b.WriteString("        set toks $toks[1] $toks[4..-1]\n")
+	b.WriteString("    else if [ (count $toks) -ge 2 ]; and string match -q -- '-p=*' $toks[2]\n")
+	b.WriteString("        set toks $toks[1] $toks[3..-1]\n")
+	b.WriteString("    else if [ (count $toks) -ge 2 ]; and string match -q -- '--profile=*' $toks[2]\n")
+	b.WriteString("        set toks $toks[1] $toks[3..-1]\n")
+	b.WriteString("    end\n")
+	b.WriteString("    for t in $toks\n")
+	b.WriteString("        echo $t\n")
+	b.WriteString("    end\n")
+	b.WriteString("end\n\n")
+
+	b.WriteString("function __agent_deck_profile_arg\n")
+	b.WriteString("    set -l toks (commandline -opc)\n")
+	b.WriteString("    if [ (count $toks) -ge 3 ]; and contains -- $toks[2] -p --profile\n")
+	b.WriteString("        echo -p\n")
+	b.WriteString("        echo $toks[3]\n")
+	b.WriteString("    else if [ (count $toks) -ge 2 ]; and string match -q -- '-p=*' $toks[2]\n")
+	b.WriteString("        echo -p\n")
+	b.WriteString("        echo (string replace -r '^-p=' '' $toks[2])\n")
+	b.WriteString("    else if [ (count $toks) -ge 2 ]; and string match -q -- '--profile=*' $toks[2]\n")
+	b.WriteString("        echo -p\n")
+	b.WriteString("        echo (string replace -r '^--profile=' '' $toks[2])\n")
+	b.WriteString("    end\n")
+	b.WriteString("end\n\n")
+
+	b.WriteString("function __agent_deck_at\n")
+	b.WriteString("    set -l toks (__agent_deck_toks)\n")
+	b.WriteString("    if [ (count $toks) -ne $argv[3] ]\n")
+	b.WriteString("        return 1\n")
+	b.WriteString("    end\n")
+	b.WriteString("    if [ -n \"$argv[1]\" ]; and [ \"$toks[2]\" != \"$argv[1]\" ]\n")
+	b.WriteString("        return 1\n")
+	b.WriteString("    end\n")
+	b.WriteString("    if [ -n \"$argv[2]\" ]; and [ \"$toks[3]\" != \"$argv[2]\" ]\n")
+	b.WriteString("        return 1\n")
+	b.WriteString("    end\n")
+	b.WriteString("    return 0\n")
+	b.WriteString("end\n\n")
+
+	b.WriteString("# Profile name right after a leading -p/--profile.\n")
+	b.WriteString("complete -c agent-deck -f -n \"test (count (commandline -opc)) -eq 2; and contains -- (commandline -opc)[2] -p --profile\" -a \"(agent-deck __complete profiles)\"\n\n")
+
+	b.WriteString("# Top-level commands.\n")
+	fmt.Fprintf(&b, "complete -c agent-deck -f -n \"__agent_deck_at '' '' 1\" -a \"%s\"\n\n", strings.Join(completionTopLevelNames(), " "))
+
+	b.WriteString("# Subcommands.\n")
+	for _, n := range completionTree {
+		if len(n.subs) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "complete -c agent-deck -f -n \"__agent_deck_at %s '' 2\" -a \"%s\"\n", shellescape.Quote(n.name), strings.Join(n.subs, " "))
+	}
+	b.WriteString("\n# Dynamic resource-name completion.\n")
+	for _, r := range completionRules() {
+		n := 2 + r.argIndex
+		if r.sub != "" {
+			n = 3 + r.argIndex
+		}
+		// remote-sessions scopes to the remote named in the preceding
+		// positional (`remote attach <remote> <session>`, `remote rename
+		// <remote> <session> <new-title>`) — that's always the last token
+		// __agent_deck_toks has produced right before completing this one.
+		extra := ""
+		if r.kind == argRemoteSession {
+			extra = " (__agent_deck_toks)[-1]"
+		}
+		fmt.Fprintf(&b, "complete -c agent-deck -f -n \"__agent_deck_at %s %s %d\" -a \"(agent-deck (__agent_deck_profile_arg) __complete %s%s)\"\n",
+			shellescape.Quote(r.cmd), shellescape.Quote(r.sub), n, r.kind.completeKeyword(), extra)
+	}
+	return b.String()
+}

--- a/cmd/agent-deck/completion_cmd.go
+++ b/cmd/agent-deck/completion_cmd.go
@@ -328,6 +328,10 @@ func handleCompletion(args []string) {
 	}
 }
 
+// printCompletionHelp writes usage for `agent-deck completion` to w — stdout
+// for the explicit help forms, stderr when handleCompletion falls back to it
+// after bad or missing arguments, so the message lands wherever the caller
+// was already looking.
 func printCompletionHelp(w io.Writer) {
 	fmt.Fprintln(w, "Usage: agent-deck completion <bash|zsh|fish>")
 	fmt.Fprintln(w)
@@ -413,6 +417,11 @@ func appendTitleOrIDCandidate(names []string, seen map[string]bool, title, id st
 	return append(names, cand)
 }
 
+// printSessionCompletions prints this machine's own local session titles
+// (falling back to ID for an untitled session), one per line — the
+// completer behind every plain argSession position. Any failure to open the
+// profile's store is swallowed: it prints nothing rather than an error line
+// a shell would otherwise offer as a bogus candidate.
 func printSessionCompletions(profile string) {
 	storage, err := session.NewStorageWithProfile(profile)
 	if err != nil {
@@ -430,6 +439,10 @@ func printSessionCompletions(profile string) {
 	printSortedCompletions(names)
 }
 
+// printRemoteCompletions prints the names of every remote configured in the
+// user's config file — the completer for argRemote positions like `remote
+// update <TAB>`. A missing or unreadable config prints nothing rather than
+// an error line.
 func printRemoteCompletions() {
 	config, err := session.LoadUserConfig()
 	if err != nil || config == nil {
@@ -473,6 +486,11 @@ func printRemoteSessionCompletions(remoteName string) {
 	printSortedCompletions(names)
 }
 
+// printProfileCompletions prints every non-internal profile name — the
+// completer for argProfile positions such as `profile delete <TAB>` and the
+// leading `-p <TAB>` flag. Underscore-prefixed profiles are test fixtures
+// and scratch state (#1926), so they're filtered out the same way
+// handleProfileList visually separates them.
 func printProfileCompletions() {
 	profiles, err := session.ListProfiles()
 	if err != nil {
@@ -493,6 +511,10 @@ func printProfileCompletions() {
 	printSortedCompletions(names)
 }
 
+// printGroupCompletions prints every group path in profile's session tree
+// except the default group — the completer for argGroup positions like
+// `group show <TAB>`. The default group is where ungrouped sessions live,
+// not a real move/rename destination, so offering it would just be noise.
 func printGroupCompletions(profile string) {
 	storage, err := session.NewStorageWithProfile(profile)
 	if err != nil {
@@ -515,6 +537,8 @@ func printGroupCompletions(profile string) {
 	printSortedCompletions(paths)
 }
 
+// printAgentCompletions prints the name of every adopted agent definition —
+// the completer for argAgent positions such as `agent show <TAB>`.
 func printAgentCompletions() {
 	defs, err := agents.LoadAll()
 	if err != nil {
@@ -615,15 +639,19 @@ func bashCompletionScript() string {
 	b.WriteString("        if [[ $kind == remote-sessions ]]; then\n")
 	b.WriteString("            extra_args=(\"${words[start+1+arg_index]}\")\n")
 	b.WriteString("        fi\n")
-	b.WriteString("        local -a names\n")
-	b.WriteString("        local IFS=$'\\n'\n")
-	b.WriteString("        names=($(agent-deck \"${profile_args[@]}\" __complete \"$kind\" \"${extra_args[@]}\" 2>/dev/null))\n")
+	b.WriteString("        local -a names=()\n")
+	b.WriteString("        local n\n")
+	b.WriteString("        # Read line-by-line (not `names=($(...))`) so a candidate\n")
+	b.WriteString("        # containing a glob character (*, ?, [) is kept literal instead\n")
+	b.WriteString("        # of being pathname-expanded against files in cwd.\n")
+	b.WriteString("        while IFS= read -r n; do\n")
+	b.WriteString("            names+=(\"$n\")\n")
+	b.WriteString("        done < <(agent-deck \"${profile_args[@]}\" __complete \"$kind\" \"${extra_args[@]}\" 2>/dev/null)\n")
 	b.WriteString("        # Candidates may contain spaces (session titles); compgen -W would\n")
 	b.WriteString("        # re-split them on whitespace and lose the escaping bash needs to\n")
 	b.WriteString("        # insert a multi-word completion as one argument, so filter and\n")
 	b.WriteString("        # escape by hand instead of going through it.\n")
 	b.WriteString("        COMPREPLY=()\n")
-	b.WriteString("        local n\n")
 	b.WriteString("        for n in \"${names[@]}\"; do\n")
 	b.WriteString("            if [[ $n == \"$cur\"* ]]; then\n")
 	b.WriteString("                COMPREPLY+=(\"${n// /\\\\ }\")\n")
@@ -632,7 +660,10 @@ func bashCompletionScript() string {
 	b.WriteString("        return 0\n")
 	b.WriteString("    fi\n")
 	b.WriteString("}\n")
-	b.WriteString("complete -F _agent_deck_completion agent-deck\n")
+	// -o default lets readline fall back to its own filename completion
+	// whenever the function above leaves COMPREPLY empty — e.g. `add
+	// <TAB>`, a leaf command with no dynamic completer at all.
+	b.WriteString("complete -o default -F _agent_deck_completion agent-deck\n")
 	return b.String()
 }
 
@@ -714,8 +745,14 @@ func zshCompletionScript() string {
 	b.WriteString("            extra_args=(${words[start+1+arg_index]})\n")
 	b.WriteString("        fi\n")
 	b.WriteString("        cands=(${(f)\"$(agent-deck ${profile_args[@]} __complete $kind ${extra_args[@]} 2>/dev/null)\"})\n")
+	b.WriteString("    fi\n")
+	b.WriteString("    # No dynamic completer applies (a leaf command's own positional args,\n")
+	b.WriteString("    # e.g. `add <TAB>`) or it produced no candidates — fall back to\n")
+	b.WriteString("    # filename completion, matching bash's `complete -o default`.\n")
+	b.WriteString("    if (( ${#cands[@]} )); then\n")
 	b.WriteString("        compadd -a cands\n")
-	b.WriteString("        return\n")
+	b.WriteString("    else\n")
+	b.WriteString("        _files\n")
 	b.WriteString("    fi\n")
 	b.WriteString("}\n\n")
 	b.WriteString("if [[ $(type compdef) = *function* ]]; then\n")

--- a/cmd/agent-deck/completion_cmd_test.go
+++ b/cmd/agent-deck/completion_cmd_test.go
@@ -352,7 +352,6 @@ func TestHandleComplete_Agents(t *testing.T) {
 	// No adopted agents in the test-isolated registry; must print nothing
 	// and, critically, nothing on stderr/panic.
 	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"agents"}) })
-	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"agents"}) })
 	if out != "" {
 		t.Fatalf("expected no agent completions, got %q", out)
 	}

--- a/cmd/agent-deck/completion_cmd_test.go
+++ b/cmd/agent-deck/completion_cmd_test.go
@@ -352,7 +352,10 @@ func TestHandleComplete_Agents(t *testing.T) {
 	// No adopted agents in the test-isolated registry; must print nothing
 	// and, critically, nothing on stderr/panic.
 	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"agents"}) })
-	_ = out
+	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"agents"}) })
+	if out != "" {
+		t.Fatalf("expected no agent completions, got %q", out)
+	}
 }
 
 // Group completions list configured groups but omit the default group.

--- a/cmd/agent-deck/completion_cmd_test.go
+++ b/cmd/agent-deck/completion_cmd_test.go
@@ -48,6 +48,7 @@ func TestCompletionTree_Consistent(t *testing.T) {
 	}
 }
 
+// Top-level completions include user-facing commands and exclude internal ones.
 func TestCompletionTopLevelNames_IncludesCoreCommands(t *testing.T) {
 	names := completionTopLevelNames()
 	for _, want := range []string{"add", "session", "mcp", "group", "completion", "profile", "remote"} {
@@ -142,11 +143,12 @@ func TestCompletionRules_KnownCases(t *testing.T) {
 	}
 }
 
+// The generated bash script contains the expected structure and rule cases.
 func TestBashCompletionScript_WellFormed(t *testing.T) {
 	script := bashCompletionScript()
 	for _, want := range []string{
 		"_agent_deck_completion()",
-		"complete -F _agent_deck_completion agent-deck",
+		"complete -o default -F _agent_deck_completion agent-deck",
 		"COMP_WORDS",
 		"'start stop remove cleanup",
 		"remote:update:0) kind=remotes ;;",
@@ -162,6 +164,7 @@ func TestBashCompletionScript_WellFormed(t *testing.T) {
 	}
 }
 
+// The generated zsh script contains the expected structure and rule cases.
 func TestZshCompletionScript_WellFormed(t *testing.T) {
 	script := zshCompletionScript()
 	for _, want := range []string{
@@ -180,6 +183,7 @@ func TestZshCompletionScript_WellFormed(t *testing.T) {
 	}
 }
 
+// The generated fish script contains the expected structure and rule cases.
 func TestFishCompletionScript_WellFormed(t *testing.T) {
 	script := fishCompletionScript()
 	for _, want := range []string{
@@ -252,6 +256,7 @@ func TestCompletionScripts_CarryEverySubcommandList(t *testing.T) {
 
 // captureStdout is defined in cursor_hooks_cmd_test.go.
 
+// Session completions list every saved session by title, falling back to ID.
 func TestHandleComplete_Sessions(t *testing.T) {
 	storage, err := session.NewStorageWithProfile("_test_completion")
 	if err != nil {
@@ -284,6 +289,7 @@ func TestHandleComplete_Sessions(t *testing.T) {
 	}
 }
 
+// An unknown completion kind prints nothing.
 func TestHandleComplete_UnknownProfileIsSilent(t *testing.T) {
 	// A profile that doesn't resolve (or any other failure along the way)
 	// must never print an error line — the shell would offer it as a bogus
@@ -294,6 +300,7 @@ func TestHandleComplete_UnknownProfileIsSilent(t *testing.T) {
 	}
 }
 
+// With no remotes configured, remote completion prints nothing and doesn't crash.
 func TestHandleComplete_Remotes(t *testing.T) {
 	// LoadUserConfig reads the real (test-isolated, per TestMain) config
 	// file; without any [[remotes]] configured this should print nothing
@@ -317,6 +324,7 @@ func TestHandleComplete_RemotesListsConfigured(t *testing.T) {
 	}
 }
 
+// An unconfigured remote name prints nothing rather than shelling out.
 func TestHandleComplete_RemoteSessionsUnknownRemoteIsSilent(t *testing.T) {
 	// No such remote configured in the isolated test config; must print
 	// nothing and, critically, never shell out to ssh trying to reach it.
@@ -328,6 +336,7 @@ func TestHandleComplete_RemoteSessionsUnknownRemoteIsSilent(t *testing.T) {
 	}
 }
 
+// A missing remote argument prints nothing instead of panicking.
 func TestHandleComplete_RemoteSessionsMissingRemoteArgIsSilent(t *testing.T) {
 	// The shell scripts always forward the remote name, but handleComplete
 	// must degrade gracefully (never index out of range) if invoked without
@@ -338,6 +347,7 @@ func TestHandleComplete_RemoteSessionsMissingRemoteArgIsSilent(t *testing.T) {
 	}
 }
 
+// With no adopted agents, agent completion prints nothing and doesn't crash.
 func TestHandleComplete_Agents(t *testing.T) {
 	// No adopted agents in the test-isolated registry; must print nothing
 	// and, critically, nothing on stderr/panic.
@@ -345,6 +355,7 @@ func TestHandleComplete_Agents(t *testing.T) {
 	_ = out
 }
 
+// Group completions list configured groups but omit the default group.
 func TestHandleComplete_Groups(t *testing.T) {
 	storage, err := session.NewStorageWithProfile("_test_completion_groups")
 	if err != nil {
@@ -368,6 +379,7 @@ func TestHandleComplete_Groups(t *testing.T) {
 	}
 }
 
+// Underscore-prefixed (internal) profiles are filtered out of completions.
 func TestPrintProfileCompletions_FiltersInternalNames(t *testing.T) {
 	if err := session.CreateProfile("_test_completion_internal"); err != nil {
 		t.Fatalf("CreateProfile: %v", err)
@@ -385,6 +397,7 @@ func TestPrintProfileCompletions_FiltersInternalNames(t *testing.T) {
 	}
 }
 
+// Completion help output includes usage for every supported shell.
 func TestPrintCompletionHelp_WritesUsage(t *testing.T) {
 	var buf bytes.Buffer
 	printCompletionHelp(&buf)
@@ -400,6 +413,7 @@ func TestPrintCompletionHelp_WritesUsage(t *testing.T) {
 	}
 }
 
+// handleCompletion dispatches to the right script or help text per argument.
 func TestHandleCompletion_DispatchesEachShellAndHelp(t *testing.T) {
 	cases := []struct {
 		args []string
@@ -472,6 +486,7 @@ func TestCompletionHelperProcess(t *testing.T) {
 	os.Exit(0)
 }
 
+// No arguments exits 1 with usage on stderr.
 func TestHandleCompletion_NoArgsExitsNonZeroWithUsageOnStderr(t *testing.T) {
 	stdout, stderr, code := runCompletionHelperProcess(t)
 	if code != 1 {
@@ -482,6 +497,7 @@ func TestHandleCompletion_NoArgsExitsNonZeroWithUsageOnStderr(t *testing.T) {
 	}
 }
 
+// An unknown shell name exits 1 with an error and usage on stderr.
 func TestHandleCompletion_UnknownShellExitsNonZeroWithMessage(t *testing.T) {
 	stdout, stderr, code := runCompletionHelperProcess(t, "bogus")
 	if code != 1 {

--- a/cmd/agent-deck/completion_cmd_test.go
+++ b/cmd/agent-deck/completion_cmd_test.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Every node in completionTree must have a unique name; a subcommand named
+// in n.args must actually be one of n.subs (or "" for a leaf command); and
+// argument lists must never be empty (use nil / omit the key instead).
+func TestCompletionTree_Consistent(t *testing.T) {
+	seen := make(map[string]bool)
+	for _, n := range completionTree {
+		if seen[n.name] {
+			t.Errorf("duplicate completion node %q", n.name)
+		}
+		seen[n.name] = true
+		if n.subs != nil && len(n.subs) == 0 {
+			t.Errorf("node %q has a non-nil empty subs slice; use nil for leaf commands", n.name)
+		}
+
+		validSub := map[string]bool{"": len(n.subs) == 0}
+		for _, s := range n.subs {
+			validSub[s] = true
+		}
+		for sub, kinds := range n.args {
+			if !validSub[sub] {
+				t.Errorf("node %q: args key %q is not a declared subcommand (or \"\" for a leaf)", n.name, sub)
+			}
+			if len(kinds) == 0 {
+				t.Errorf("node %q sub %q: empty arg-kind list; omit the key instead", n.name, sub)
+			}
+			for i, k := range kinds {
+				if k == argNone {
+					t.Errorf("node %q sub %q position %d: argNone in an args list is a no-op; omit it", n.name, sub, i)
+				}
+				if k.completeKeyword() == "" {
+					t.Errorf("node %q sub %q position %d: argKind %d has no completeKeyword()", n.name, sub, i, k)
+				}
+			}
+		}
+	}
+}
+
+func TestCompletionTopLevelNames_IncludesCoreCommands(t *testing.T) {
+	names := completionTopLevelNames()
+	for _, want := range []string{"add", "session", "mcp", "group", "completion", "profile", "remote"} {
+		found := false
+		for _, n := range names {
+			if n == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("completionTopLevelNames() missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"__complete", "hook-handler", "codex-notify", "notify-daemon", "mcp-proxy"} {
+		for _, n := range names {
+			if n == unwanted {
+				t.Errorf("completionTopLevelNames() should not offer internal command %q", unwanted)
+			}
+		}
+	}
+}
+
+// completionRules must find every rule declared in the tree (no case falls
+// through silently) and must never emit a duplicate (cmd, sub, argIndex)
+// key, which would make one shell's generated case statement pick whichever
+// arm happened to sort first instead of failing to build.
+func TestCompletionRules_NoDuplicateKeys(t *testing.T) {
+	seen := make(map[string]bool)
+	count := 0
+	for _, n := range completionTree {
+		for _, kinds := range n.args {
+			count += len(kinds)
+		}
+	}
+	rules := completionRules()
+	if len(rules) != count {
+		t.Fatalf("completionRules() returned %d rules, want %d (every entry in every node.args list)", len(rules), count)
+	}
+	for _, r := range rules {
+		key := fmt.Sprintf("%s:%s:%d", r.cmd, r.sub, r.argIndex)
+		if seen[key] {
+			t.Errorf("duplicate completion rule %s:%s:%d", r.cmd, r.sub, r.argIndex)
+		}
+		seen[key] = true
+	}
+}
+
+// Known real cases from the CLI's own usage strings: `remote update`
+// completes a remote name, and `session set-parent` completes a session
+// name at BOTH positions (three and four words deep) — the "more than two
+// levels" case.
+func TestCompletionRules_KnownCases(t *testing.T) {
+	rules := completionRules()
+	find := func(cmd, sub string, idx int) (argKind, bool) {
+		for _, r := range rules {
+			if r.cmd == cmd && r.sub == sub && r.argIndex == idx {
+				return r.kind, true
+			}
+		}
+		return argNone, false
+	}
+
+	cases := []struct {
+		cmd, sub string
+		idx      int
+		want     argKind
+	}{
+		{"remote", "update", 0, argRemote},
+		{"remote", "attach", 0, argRemote},
+		{"remote", "attach", 1, argRemoteSession},
+		{"remote", "rename", 0, argRemote},
+		{"remote", "rename", 1, argRemoteSession},
+		{"remove", "", 0, argSession},
+		{"rename", "", 0, argSession},
+		{"session", "set-parent", 0, argSession},
+		{"session", "set-parent", 1, argSession},
+		{"profile", "delete", 0, argProfile},
+		{"group", "move", 0, argSession},
+		{"group", "move", 1, argGroup},
+		{"agent", "show", 0, argAgent},
+	}
+	for _, c := range cases {
+		got, ok := find(c.cmd, c.sub, c.idx)
+		if !ok {
+			t.Errorf("no completion rule for %s %s (position %d)", c.cmd, c.sub, c.idx)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%s %s position %d: got kind %d, want %d", c.cmd, c.sub, c.idx, got, c.want)
+		}
+	}
+}
+
+func TestBashCompletionScript_WellFormed(t *testing.T) {
+	script := bashCompletionScript()
+	for _, want := range []string{
+		"_agent_deck_completion()",
+		"complete -F _agent_deck_completion agent-deck",
+		"COMP_WORDS",
+		"'start stop remove cleanup",
+		"remote:update:0) kind=remotes ;;",
+		"remote:rename:1) kind=remote-sessions ;;",
+		"session:set-parent:1) kind=sessions ;;",
+		"__complete profiles",
+		`extra_args=("${words[start+1+arg_index]}")`,
+		`COMPREPLY+=("${n// /\\ }")`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("bash completion script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestZshCompletionScript_WellFormed(t *testing.T) {
+	script := zshCompletionScript()
+	for _, want := range []string{
+		"#compdef agent-deck",
+		"_agent_deck()",
+		"compdef _agent_deck agent-deck",
+		"subs=(start stop",
+		"remote:update:0) kind=remotes ;;",
+		"remote:rename:1) kind=remote-sessions ;;",
+		"session:set-parent:1) kind=sessions ;;",
+		"extra_args=(${words[start+1+arg_index]})",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("zsh completion script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestFishCompletionScript_WellFormed(t *testing.T) {
+	script := fishCompletionScript()
+	for _, want := range []string{
+		"complete -c agent-deck",
+		"function __agent_deck_at",
+		"__agent_deck_at session '' 2",
+		"start stop remove",
+		"__agent_deck_at remote update 3",
+		"__complete remotes",
+		"__agent_deck_at session set-parent 4",
+		`__agent_deck_at remote rename 4" -a "(agent-deck (__agent_deck_profile_arg) __complete remote-sessions (__agent_deck_toks)[-1])`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("fish completion script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+// TestCompletionScripts_ShellSyntaxIsValid runs each generated script
+// through its own shell's syntax-check flag (bash/zsh/fish all support
+// checking, rather than executing, a script read from stdin via -n). The
+// WellFormed tests above only assert substrings are present in the
+// generated text; a quoting bug that corrupts the script without dropping
+// any of those substrings would slip past them but not past a real parser.
+// Skips a shell that isn't installed on the machine running the test rather
+// than failing — CI images vary in which shells they carry.
+func TestCompletionScripts_ShellSyntaxIsValid(t *testing.T) {
+	scripts := map[string]func() string{
+		"bash": bashCompletionScript,
+		"zsh":  zshCompletionScript,
+		"fish": fishCompletionScript,
+	}
+	for shell, gen := range scripts {
+		t.Run(shell, func(t *testing.T) {
+			if _, err := exec.LookPath(shell); err != nil {
+				t.Skipf("%s not installed: %v", shell, err)
+			}
+			cmd := exec.Command(shell, "-n")
+			cmd.Stdin = strings.NewReader(gen())
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Errorf("%s -n rejected the generated script: %v\n%s", shell, err, stderr.String())
+			}
+		})
+	}
+}
+
+// Every subcommand list a script renders must appear verbatim, so a stray
+// quoting bug in one generator can't silently truncate a command's
+// subcommand menu.
+func TestCompletionScripts_CarryEverySubcommandList(t *testing.T) {
+	scripts := map[string]string{
+		"bash": bashCompletionScript(),
+		"zsh":  zshCompletionScript(),
+		"fish": fishCompletionScript(),
+	}
+	for _, n := range completionTree {
+		if len(n.subs) == 0 {
+			continue
+		}
+		joined := strings.Join(n.subs, " ")
+		for shell, script := range scripts {
+			if !strings.Contains(script, joined) {
+				t.Errorf("%s completion script missing subcommand list for %q: %q", shell, n.name, joined)
+			}
+		}
+	}
+}
+
+// captureStdout is defined in cursor_hooks_cmd_test.go.
+
+func TestHandleComplete_Sessions(t *testing.T) {
+	storage, err := session.NewStorageWithProfile("_test_completion")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	instances := []*session.Instance{
+		{ID: "aaaaaaaa-1", Title: "My Project"},
+		{ID: "bbbbbbbb-2", Title: "another-session"},
+		{ID: "cccccccc-3", Title: ""}, // falls back to ID
+	}
+	tree := session.NewGroupTreeWithGroups(instances, nil)
+	if err := storage.SaveWithGroups(instances, tree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"sessions"}) })
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+
+	for _, want := range []string{"My Project", "another-session", "cccccccc-3"} {
+		found := false
+		for _, l := range lines {
+			if l == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("session completion candidates %v missing %q", lines, want)
+		}
+	}
+}
+
+func TestHandleComplete_UnknownProfileIsSilent(t *testing.T) {
+	// A profile that doesn't resolve (or any other failure along the way)
+	// must never print an error line — the shell would offer it as a bogus
+	// completion candidate.
+	out := captureStdout(t, func() { handleComplete("", []string{"bogus-kind"}) })
+	if out != "" {
+		t.Errorf("unknown kind should print nothing, got %q", out)
+	}
+}
+
+func TestHandleComplete_Remotes(t *testing.T) {
+	// LoadUserConfig reads the real (test-isolated, per TestMain) config
+	// file; without any [[remotes]] configured this should print nothing
+	// and, critically, nothing on stderr/panic.
+	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"remotes"}) })
+	_ = out // no remotes configured in the isolated test config; just must not crash
+}
+
+// TestHandleComplete_RemotesListsConfigured is the positive-path
+// counterpart to TestHandleComplete_Remotes above: with a remote actually
+// configured, it must be offered as a completion candidate. Uses its own
+// HOME (t.Setenv auto-restores it) rather than the package-shared isolated
+// config, so the remote this test writes never leaks into a sibling test.
+func TestHandleComplete_RemotesListsConfigured(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	configureRemote(t, "boxb", "worker@box-b")
+
+	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"remotes"}) })
+	if strings.TrimSpace(out) != "boxb" {
+		t.Errorf("remote completion candidates = %q, want just %q", out, "boxb")
+	}
+}
+
+func TestHandleComplete_RemoteSessionsUnknownRemoteIsSilent(t *testing.T) {
+	// No such remote configured in the isolated test config; must print
+	// nothing and, critically, never shell out to ssh trying to reach it.
+	out := captureStdout(t, func() {
+		handleComplete("_test_completion", []string{"remote-sessions", "no-such-remote"})
+	})
+	if out != "" {
+		t.Errorf("unknown remote should print nothing, got %q", out)
+	}
+}
+
+func TestHandleComplete_RemoteSessionsMissingRemoteArgIsSilent(t *testing.T) {
+	// The shell scripts always forward the remote name, but handleComplete
+	// must degrade gracefully (never index out of range) if invoked without
+	// one.
+	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"remote-sessions"}) })
+	if out != "" {
+		t.Errorf("missing remote arg should print nothing, got %q", out)
+	}
+}
+
+func TestHandleComplete_Agents(t *testing.T) {
+	// No adopted agents in the test-isolated registry; must print nothing
+	// and, critically, nothing on stderr/panic.
+	out := captureStdout(t, func() { handleComplete("_test_completion", []string{"agents"}) })
+	_ = out
+}
+
+func TestHandleComplete_Groups(t *testing.T) {
+	storage, err := session.NewStorageWithProfile("_test_completion_groups")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	tree := session.NewGroupTreeWithGroups(nil, []*session.GroupData{
+		{Name: "My Team", Path: "my-team", Expanded: true, Order: 0},
+	})
+	if err := storage.SaveWithGroups(nil, tree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	out := captureStdout(t, func() { handleComplete("_test_completion_groups", []string{"groups"}) })
+	if !strings.Contains(out, "my-team") {
+		t.Errorf("group completion candidates %q missing %q", out, "my-team")
+	}
+	// The default group is where ungrouped sessions live — offering it as a
+	// completion candidate would be noise, not a real destination.
+	if strings.Contains(out, session.DefaultGroupPath) {
+		t.Errorf("group completions must not include the default group path, got %q", out)
+	}
+}
+
+func TestPrintProfileCompletions_FiltersInternalNames(t *testing.T) {
+	if err := session.CreateProfile("_test_completion_internal"); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	if err := session.CreateProfile("test-completion-visible"); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+
+	out := captureStdout(t, printProfileCompletions)
+	if strings.Contains(out, "_test_completion_internal") {
+		t.Errorf("underscore-prefixed profile should be filtered out, got %q", out)
+	}
+	if !strings.Contains(out, "test-completion-visible") {
+		t.Errorf("visible profile missing from completions, got %q", out)
+	}
+}
+
+func TestPrintCompletionHelp_WritesUsage(t *testing.T) {
+	var buf bytes.Buffer
+	printCompletionHelp(&buf)
+	for _, want := range []string{
+		"Usage: agent-deck completion <bash|zsh|fish>",
+		"source <(agent-deck completion bash)",
+		"source <(agent-deck completion zsh)",
+		"agent-deck completion fish >",
+	} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("completion help missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
+func TestHandleCompletion_DispatchesEachShellAndHelp(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"bash"}, "_agent_deck_completion()"},
+		{[]string{"zsh"}, "#compdef agent-deck"},
+		{[]string{"fish"}, "function __agent_deck_at"},
+		{[]string{"help"}, "Usage: agent-deck completion <bash|zsh|fish>"},
+		{[]string{"--help"}, "Usage: agent-deck completion <bash|zsh|fish>"},
+		{[]string{"-h"}, "Usage: agent-deck completion <bash|zsh|fish>"},
+	}
+	for _, c := range cases {
+		t.Run(strings.Join(c.args, " "), func(t *testing.T) {
+			out := captureStdout(t, func() { handleCompletion(c.args) })
+			if !strings.Contains(out, c.want) {
+				t.Errorf("handleCompletion(%v) stdout missing %q, got %q", c.args, c.want, out)
+			}
+		})
+	}
+}
+
+// --- exit-path coverage via helper subprocess ---
+//
+// handleCompletion calls os.Exit(1) for both empty args and an unknown
+// shell name. Testing that in-process would kill the whole test binary, so
+// (mirroring TestCursorHooksHelperProcess) we re-exec the test binary itself
+// with -test.run pinned to the helper entrypoint below.
+
+func runCompletionHelperProcess(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	cmdArgs := append([]string{"-test.run=TestCompletionHelperProcess", "--"}, args...)
+	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(), "AGENT_DECK_COMPLETION_HELPER=1")
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("helper process failed to start/run: %v (stderr=%q)", err, errBuf.String())
+		}
+		code = exitErr.ExitCode()
+	}
+	return outBuf.String(), errBuf.String(), code
+}
+
+// TestCompletionHelperProcess is not a real test; go test invokes it (via
+// -test.run) as a subprocess entrypoint that calls handleCompletion directly
+// so its os.Exit calls terminate the subprocess, not the parent test binary.
+// It is a no-op unless AGENT_DECK_COMPLETION_HELPER=1 is set.
+func TestCompletionHelperProcess(t *testing.T) {
+	if os.Getenv("AGENT_DECK_COMPLETION_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	handleCompletion(args)
+	// Valid shells/help return normally; give the parent a clean signal.
+	os.Exit(0)
+}
+
+func TestHandleCompletion_NoArgsExitsNonZeroWithUsageOnStderr(t *testing.T) {
+	stdout, stderr, code := runCompletionHelperProcess(t)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stdout=%q stderr=%q)", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "Usage: agent-deck completion <bash|zsh|fish>") {
+		t.Fatalf("stderr missing usage on empty args, got: %q", stderr)
+	}
+}
+
+func TestHandleCompletion_UnknownShellExitsNonZeroWithMessage(t *testing.T) {
+	stdout, stderr, code := runCompletionHelperProcess(t, "bogus")
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stdout=%q stderr=%q)", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, `unknown shell "bogus"`) {
+		t.Fatalf("stderr missing unknown-shell message, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Usage: agent-deck completion <bash|zsh|fish>") {
+		t.Fatalf("stderr missing usage fallback after unknown shell, got: %q", stderr)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -282,6 +282,12 @@ func main() {
 		case "help", "--help", "-h":
 			printHelp()
 			return
+		case "completion":
+			handleCompletion(args[1:])
+			return
+		case "__complete":
+			handleComplete(profile, args[1:])
+			return
 		case "add":
 			handleAdd(profile, args[1:])
 			return
@@ -990,7 +996,8 @@ var globalFlagSubcommands = map[string]bool{
 	"codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
 	"hermes-hooks": true, "cursor-hooks": true, "deepseek": true, "notify-daemon": true,
 	"run-task": true, "inbox": true, "feedback": true, "creds-refresh": true,
-	"debug-dump": true, "version": true, "help": true,
+	"debug-dump": true, "version": true, "help": true, "completion": true,
+	"__complete": true,
 }
 
 // extractProfileFlag extracts the global -p or --profile flag from args,
@@ -3574,6 +3581,7 @@ func printHelp() {
 	fmt.Println("  uninstall        Uninstall Agent Deck")
 	fmt.Println("  version          Show version")
 	fmt.Println("  help             Show this help")
+	fmt.Println("  completion       Print a shell completion script (bash, zsh, fish)")
 	fmt.Println()
 	fmt.Println("Session Commands:")
 	fmt.Println("  session start <id>        Start a session's tmux process")
@@ -3667,6 +3675,11 @@ func printHelp() {
 	fmt.Println("  agent-deck web --read-only            # TUI + web in read-only mode")
 	fmt.Println("  agent-deck web --token secret         # auth token (REQUIRED to bind a non-loopback address)")
 	fmt.Println("  agent-deck web --help                 # Show web command flags")
+	fmt.Println()
+	fmt.Println("Shell Completion:")
+	fmt.Println("  agent-deck completion bash             # Print bash completion script")
+	fmt.Println("  agent-deck completion zsh              # Print zsh completion script")
+	fmt.Println("  agent-deck completion fish             # Print fish completion script")
 	fmt.Println()
 	fmt.Println("Environment Variables:")
 	fmt.Println("  AGENTDECK_PROFILE    Default profile to use")

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -15,6 +15,25 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/update"
 )
 
+// resolveRemoteConfig loads the user config and looks up the RemoteConfig
+// for name — the "load config, check config.Remotes, check the key"
+// resolution every remote subcommand (and completion_cmd.go's
+// printRemoteSessionCompletions) needs before it can build an SSHRunner.
+// loadErr is only set when LoadUserConfig itself failed; exists is false
+// whenever config.Remotes is nil or has no entry for name — callers that
+// want a distinct message for each case check loadErr first.
+func resolveRemoteConfig(name string) (rc session.RemoteConfig, exists bool, loadErr error) {
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		return session.RemoteConfig{}, false, err
+	}
+	if config.Remotes == nil {
+		return session.RemoteConfig{}, false, nil
+	}
+	rc, exists = config.Remotes[name]
+	return rc, exists, nil
+}
+
 func handleRemote(profile string, args []string) {
 	if len(args) == 0 {
 		printRemoteUsage()
@@ -355,18 +374,11 @@ func handleRemoteAttach(args []string) {
 	remoteName := args[0]
 	sessionRef := args[1]
 
-	config, err := session.LoadUserConfig()
+	rc, exists, err := resolveRemoteConfig(remoteName)
 	if err != nil {
 		fmt.Printf("Error: failed to load config: %v\n", err)
 		os.Exit(1)
 	}
-
-	if config.Remotes == nil {
-		fmt.Printf("Error: remote '%s' not found\n", remoteName)
-		os.Exit(1)
-	}
-
-	rc, exists := config.Remotes[remoteName]
 	if !exists {
 		fmt.Printf("Error: remote '%s' not found\n", remoteName)
 		os.Exit(1)
@@ -412,18 +424,11 @@ func handleRemoteRename(args []string) {
 	sessionRef := args[1]
 	newTitle := strings.Join(args[2:], " ")
 
-	config, err := session.LoadUserConfig()
+	rc, exists, err := resolveRemoteConfig(remoteName)
 	if err != nil {
 		fmt.Printf("Error: failed to load config: %v\n", err)
 		os.Exit(1)
 	}
-
-	if config.Remotes == nil {
-		fmt.Printf("Error: remote '%s' not found\n", remoteName)
-		os.Exit(1)
-	}
-
-	rc, exists := config.Remotes[remoteName]
 	if !exists {
 		fmt.Printf("Error: remote '%s' not found\n", remoteName)
 		os.Exit(1)

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -6,6 +6,7 @@ Complete reference for all agent-deck CLI commands.
 
 - [Global Options](#global-options)
 - [Basic Commands](#basic-commands)
+- [Shell Completion](#shell-completion)
 - [Web Command](#web-command)
 - [Session Commands](#session-commands)
 - [Fleet Recovery Commands](#fleet-recovery-commands)
@@ -125,6 +126,44 @@ agent-deck migrate-paths [--dry-run] [--force]
 ```
 
 Copies known legacy `~/.agent-deck` files into the split XDG layout (config under `~/.config/agent-deck`, durable data under `~/.local/share/agent-deck`, cache under `~/.cache/agent-deck`) without deleting the legacy directory. Use `--dry-run` to preview what would be copied.
+
+## Shell Completion
+
+### completion - Print a shell completion script
+
+```bash
+agent-deck completion bash    # -> stdout
+agent-deck completion zsh     # -> stdout
+agent-deck completion fish    # -> stdout
+```
+
+Completes top-level commands and, for the ones with their own subcommand dispatch (`session`, `mcp`, `skill`, `group`, `remote`, `worktree`, `profile`, `conductor`, `agent(s)`, `watcher`, `openclaw`, `costs`, `hooks`, the `*-hooks` family, `deepseek`), the next word too.
+
+For commands that name a specific resource, the argument after that completes to live values, fetched via the hidden `agent-deck __complete <kind>` helper (not a command you'd run directly):
+
+| Kind | Used by |
+|------|---------|
+| session titles | `remove`/`rename`, most `session <verb>` subcommands (including both positions of `set-parent`), `mcp`/`plugin`/`skill attached\|attach\|detach`, `worktree info\|finish`, `group move`, `conductor move`, `remote attach\|rename` (2nd arg) |
+| remote names | `remote remove\|sessions\|attach\|rename\|update` |
+| profile names | `profile delete\|default`, `session switch-account` (2nd arg), and right after a leading `-p`/`--profile` |
+| group paths | `group show\|update\|delete\|move (2nd arg)\|change\|reorder` |
+| adopted agent names | `agent show` |
+
+This is what lets `agent-deck remote update <Tab>` offer your configured remotes and `agent-deck session set-parent <Tab> <Tab>` offer session titles at both positions, three and four words in — dynamic completion isn't limited to the first word after a subcommand. A leading `-p`/`--profile` is detected and forwarded, so completions match the profile being typed rather than the default one. Any other argument (paths, free-form text) falls back to the shell's default completion.
+
+```bash
+# bash
+echo 'source <(agent-deck completion bash)' >> ~/.bashrc
+
+# zsh — either source it directly, or save it as a file named `_agent_deck`
+# in a directory on $fpath for autoload
+echo 'source <(agent-deck completion zsh)' >> ~/.zshrc
+
+# fish
+agent-deck completion fish > ~/.config/fish/completions/agent-deck.fish
+```
+
+Open a new shell (or re-source the config file) for it to take effect.
 
 ## Web Command
 


### PR DESCRIPTION
## What problem does this solve?

`agent-deck` has a large and growing command surface (session, remote, group, mcp, worktree, etc.), and typing every command, subcommand, and resource name (session titles, remote names, profiles) by hand is slow and error-prone. There's no shell completion today.

## Why this change

Rather than hand-writing three separate completion scripts and letting them drift, static completion (commands/subcommands) is generated from one command tree (`completionTree`) that mirrors `main()`'s dispatch switch, so bash/zsh/fish render it identically. Dynamic completion (session titles, remote names, profiles, groups, agents) is served by a hidden `agent-deck __complete <kind>` helper the generated scripts shell out to on Tab, rather than baking live data into the static script.

`remote attach`/`remote rename` needed their own remote-scoped session completer (this machine's local session titles don't exist on a remote), bounded to a 3s timeout so an unreachable remote falls back to filename completion instead of hanging the shell on every Tab press.

## User impact

New opt-in feature: `agent-deck completion <bash|zsh|fish>` prints a completion script to source/save. No change to existing behavior for anyone not using it.

## Evidence

```
$ agent-deck completion bash | source /dev/stdin
$ agent-deck remote update <Tab>
prod  staging

$ agent-deck session set-parent <Tab>
<local session titles>
```

Full test suite (sandboxed): completion-related tests pass; the 3 pre-existing failures in `worktree_cleanup_safety_test.go` are unrelated and reproduce identically on `main`.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-5 (Claude Code)

**Prompt / session log (optional):**

## What actually bothered you

<!-- placeholder — replace with your own words before marking ready for review -->
Typing out full `agent-deck` command names and remote/session identifiers by hand got tedious; wanted Tab completion like most CLIs have.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (3 pre-existing, unrelated failures in worktree_cleanup_safety_test.go also reproduce on main)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-sonnet-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shell completion support for Bash, Zsh, and Fish.
  * Completion suggests available commands, sessions, remotes, profiles, groups, and agents.
  * Remote session suggestions are supported with graceful fallback when unavailable.
  * Filename completion remains available when dynamic suggestions cannot be provided.

* **Documentation**
  * Updated CLI help with completion setup instructions and supported shells.

* **Refactor**
  * Improved consistency when loading and resolving remote configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->