### PR TITLE
fix(tmux): ErrCaptureGone sentinel so vanished-pane captures degrade cleanly

### DIFF
--- a/internal/session/capture_gone_response_test.go
+++ b/internal/session/capture_gone_response_test.go
@@ -4,14 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // goneTmuxSession returns a *tmux.Session pointed at an isolated socket with no
-// running server, so any capture returns tmux.ErrCaptureGone — the reproducible
-// stand-in for the post-completion/resume vanish from plan 001.
+// running server, so any capture returns tmux.ErrCaptureGone.
 func goneTmuxSession() *tmux.Session {
 	return &tmux.Session{
 		Name:       "agentdeck_gone_response_probe",
@@ -24,8 +26,8 @@ func goneTmuxSession() *tmux.Session {
 // output: ... exit status 1"; it propagates tmux.ErrCaptureGone so callers can
 // degrade cleanly.
 func TestGetTerminalLastResponse_GonePropagatesSentinel(t *testing.T) {
-	if _, err := os.Stat("/bin/sh"); err != nil {
-		t.Skip("shell unavailable")
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
 	}
 	i := &Instance{Tool: "codex", tmuxSession: goneTmuxSession()}
 	_, err := i.getTerminalLastResponse()
@@ -39,6 +41,9 @@ func TestGetTerminalLastResponse_GonePropagatesSentinel(t *testing.T) {
 // for a non-Claude/Gemini tool — the exact case that was surfacing the scary
 // error string on codex children.
 func TestGetLastResponseBestEffort_GoneReturnsEmpty(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
 	i := &Instance{Tool: "codex", tmuxSession: goneTmuxSession()}
 	resp, err := i.GetLastResponseBestEffort()
 	if err != nil {
@@ -49,5 +54,44 @@ func TestGetLastResponseBestEffort_GoneReturnsEmpty(t *testing.T) {
 	}
 	if resp.Content != "" {
 		t.Fatalf("expected empty content for vanished session, got %q", resp.Content)
+	}
+}
+
+func TestGetLastResponseBestEffort_UsesFinalCaptureError(t *testing.T) {
+	for _, tc := range []struct {
+		name, first, last string
+		wantGone          bool
+	}{
+		{"gone then permission", "no server running on /tmp/test", "error connecting to /tmp/test (Permission denied)", false},
+		{"permission then gone", "error connecting to /tmp/test (Permission denied)", "no server running on /tmp/test", true},
+		{"other failure then gone", "unknown capture failure", "no server running on /tmp/test", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// Two attempts model a teardown/reconnect changing the socket between reads.
+			script := "#!/bin/sh\nif [ ! -f \"$CAPTURE_STATE\" ]; then touch \"$CAPTURE_STATE\"; printf '%s\\n' \"$FIRST_ERROR\" >&2; else printf '%s\\n' \"$LAST_ERROR\" >&2; fi\nexit 1\n"
+			if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CAPTURE_STATE", filepath.Join(dir, "captured"))
+			t.Setenv("FIRST_ERROR", tc.first)
+			t.Setenv("LAST_ERROR", tc.last)
+			i := &Instance{Tool: "codex", tmuxSession: goneTmuxSession()}
+			resp, err := i.GetLastResponseBestEffort()
+			if tc.wantGone {
+				if err != nil || resp == nil || resp.Content != "" {
+					t.Fatalf("final gone capture = %+v, %v; want empty response", resp, err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("final permission error was swallowed")
+				}
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || !strings.Contains(string(exitErr.Stderr), "Permission denied") {
+					t.Fatalf("wrong final error: %v", err)
+				}
+			}
+		})
 	}
 }

--- a/internal/session/capture_gone_response_test.go
+++ b/internal/session/capture_gone_response_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// goneTmuxSession returns a *tmux.Session pointed at an isolated socket with no
+// running server, so any capture returns tmux.ErrCaptureGone — the reproducible
+// stand-in for the post-completion/resume vanish from plan 001.
+func goneTmuxSession() *tmux.Session {
+	return &tmux.Session{
+		Name:       "agentdeck_gone_response_probe",
+		SocketName: fmt.Sprintf("adeck-gone-resp-%d", os.Getpid()),
+	}
+}
+
+// TestGetTerminalLastResponse_GonePropagatesSentinel verifies the read path no
+// longer wraps a vanished pane as the opaque "failed to capture terminal
+// output: ... exit status 1"; it propagates tmux.ErrCaptureGone so callers can
+// degrade cleanly.
+func TestGetTerminalLastResponse_GonePropagatesSentinel(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("shell unavailable")
+	}
+	i := &Instance{Tool: "codex", tmuxSession: goneTmuxSession()}
+	_, err := i.getTerminalLastResponse()
+	if !errors.Is(err, tmux.ErrCaptureGone) {
+		t.Fatalf("getTerminalLastResponse = %v, want tmux.ErrCaptureGone", err)
+	}
+}
+
+// TestGetLastResponseBestEffort_GoneReturnsEmpty verifies the conductor-facing
+// best-effort read degrades a vanished session to an empty response (no error)
+// for a non-Claude/Gemini tool — the exact case that was surfacing the scary
+// error string on codex children.
+func TestGetLastResponseBestEffort_GoneReturnsEmpty(t *testing.T) {
+	i := &Instance{Tool: "codex", tmuxSession: goneTmuxSession()}
+	resp, err := i.GetLastResponseBestEffort()
+	if err != nil {
+		t.Fatalf("GetLastResponseBestEffort returned error for vanished session: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected a non-nil empty response, got nil")
+	}
+	if resp.Content != "" {
+		t.Fatalf("expected empty content for vanished session, got %q", resp.Content)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -7401,6 +7401,22 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 		}
 	}
 
+	// A vanished session/pane is benign for EVERY tool: the session is simply
+	// gone (post-completion teardown / resume race), not crashed. Return an
+	// empty response rather than surfacing the capture-gone error. This is the
+	// read-path half of plan 001; it does not change status classification.
+	if errors.Is(err, tmux.ErrCaptureGone) {
+		toolName := i.Tool
+		if IsClaudeCompatible(toolName) {
+			toolName = "claude"
+		}
+		return &ResponseOutput{
+			Tool:    toolName,
+			Role:    "assistant",
+			Content: "",
+		}, nil
+	}
+
 	// For Claude and Gemini, prefer a graceful empty response instead of a hard error.
 	if IsClaudeCompatible(i.Tool) || i.Tool == "gemini" {
 		toolName := i.Tool
@@ -8176,6 +8192,14 @@ func (i *Instance) getTerminalLastResponse() (*ResponseOutput, error) {
 	// Capture full history
 	content, err := i.tmuxSession.CaptureFullHistory()
 	if err != nil {
+		// A vanished session/pane (post-completion teardown or resume race) is a
+		// benign, retryable non-event. Propagate the sentinel so best-effort
+		// callers can degrade to an empty response instead of the opaque
+		// "failed to capture terminal output: ... exit status 1" error that the
+		// conductor kept surfacing. See plan 001.
+		if errors.Is(err, tmux.ErrCaptureGone) {
+			return nil, tmux.ErrCaptureGone
+		}
 		return nil, fmt.Errorf("failed to capture terminal output: %w", err)
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -7396,29 +7396,16 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 
 	// Final fallback: terminal parsing (works for all tools).
 	if i.tmuxSession != nil {
-		if terminalResp, terminalErr := i.getTerminalLastResponse(); terminalErr == nil {
+		terminalResp, terminalErr := i.getTerminalLastResponse()
+		if terminalErr == nil {
 			return terminalResp, nil
 		}
+		err = terminalErr
 	}
 
-	// A vanished session/pane is benign for EVERY tool: the session is simply
-	// gone (post-completion teardown / resume race), not crashed. Return an
-	// empty response rather than surfacing the capture-gone error. This is the
-	// read-path half of plan 001; it does not change status classification.
-	if errors.Is(err, tmux.ErrCaptureGone) {
-		toolName := i.Tool
-		if IsClaudeCompatible(toolName) {
-			toolName = "claude"
-		}
-		return &ResponseOutput{
-			Tool:    toolName,
-			Role:    "assistant",
-			Content: "",
-		}, nil
-	}
-
-	// For Claude and Gemini, prefer a graceful empty response instead of a hard error.
-	if IsClaudeCompatible(i.Tool) || i.Tool == "gemini" {
+	// A vanished terminal is benign for every tool. Preserve the existing
+	// graceful-empty behavior for Claude and Gemini when recovery fails.
+	if errors.Is(err, tmux.ErrCaptureGone) || IsClaudeCompatible(i.Tool) || i.Tool == "gemini" {
 		toolName := i.Tool
 		if IsClaudeCompatible(toolName) {
 			toolName = "claude"
@@ -8192,14 +8179,6 @@ func (i *Instance) getTerminalLastResponse() (*ResponseOutput, error) {
 	// Capture full history
 	content, err := i.tmuxSession.CaptureFullHistory()
 	if err != nil {
-		// A vanished session/pane (post-completion teardown or resume race) is a
-		// benign, retryable non-event. Propagate the sentinel so best-effort
-		// callers can degrade to an empty response instead of the opaque
-		// "failed to capture terminal output: ... exit status 1" error that the
-		// conductor kept surfacing. See plan 001.
-		if errors.Is(err, tmux.ErrCaptureGone) {
-			return nil, tmux.ErrCaptureGone
-		}
 		return nil, fmt.Errorf("failed to capture terminal output: %w", err)
 	}
 

--- a/internal/tmux/capture_gone_test.go
+++ b/internal/tmux/capture_gone_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,10 @@ func TestCaptureGoneFromErr_KnownStderrMarkers(t *testing.T) {
 		{"lost server", "lost server", true},
 		{"server exited", "server exited unexpectedly", true},
 		{"stale socket", "error connecting to /private/tmp/tmux-501/adtmux (No such file or directory)", true},
+		{"permission denied", "error connecting to /tmp/blocked/socket (Permission denied)", false},
+		{"bad socket", "error connecting to /tmp/socket (Not a socket)", false},
+		{"connection refused", "error connecting to /tmp/socket (Connection refused)", false},
+		{"misleading socket path", "error connecting to /tmp/no server running/socket (Permission denied)", false},
 		{"case insensitive", "Can't Find Session: X", true},
 		{"marker mid-message", "capture-pane: can't find pane: %9", true},
 
@@ -101,24 +106,67 @@ func TestCaptureFullHistory_LiveSessionNotGone(t *testing.T) {
 	}
 	socket := fmt.Sprintf("adeck-live-test-%d", os.Getpid())
 	name := "agentdeck_capture_live_probe"
-	run := func(args ...string) {
-		_ = exec.Command("tmux", append([]string{"-L", socket}, args...)...).Run()
+	if out, err := exec.Command("tmux", "-L", socket, "new-session", "-d", "-s", name, "printf 'done-marker\\n'; sleep 30").CombinedOutput(); err != nil {
+		t.Fatalf("start isolated tmux: %v: %s", err, out)
 	}
-	// Keep the pane alive during capture so we test a present session, not a
-	// teardown race.
-	run("new-session", "-d", "-s", name, "printf 'done-marker\\n'; sleep 5")
-	defer run("kill-server")
-	time.Sleep(400 * time.Millisecond)
+	t.Cleanup(func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", name).Run() })
 
 	sess := &Session{Name: name, SocketName: socket}
-	out, err := sess.CaptureFullHistory()
-	if errors.Is(err, ErrCaptureGone) {
-		t.Fatalf("present session misclassified as gone: %v", err)
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		out, err := sess.CaptureFullHistory()
+		if err != nil {
+			t.Fatalf("CaptureFullHistory on live session: %v", err)
+		}
+		if strings.Contains(out, "done-marker") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("captured history missing expected content; got %q", out)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	if err != nil {
-		t.Fatalf("CaptureFullHistory on live session errored: %v", err)
+	// The server remains alive, but this particular capture target is absent.
+	missing := &Session{Name: name + "_missing", SocketName: socket}
+	if _, err := missing.CaptureFullHistory(); !errors.Is(err, ErrCaptureGone) {
+		t.Fatalf("missing target on live server = %v, want ErrCaptureGone", err)
 	}
-	if !strings.Contains(out, "done-marker") {
-		t.Fatalf("captured history missing expected content; got %q", out)
+}
+
+func TestCaptureHistory_PermissionDeniedIsNotGone(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	// An inaccessible parent directory makes the actual tmux connect fail with EACCES.
+	root := t.TempDir()
+	t.Setenv("TMUX_TMPDIR", root)
+	dir := filepath.Join(root, fmt.Sprintf("tmux-%d", os.Getuid()), "blocked")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+	if _, err := os.ReadDir(dir); err == nil {
+		t.Skip("process can bypass directory permissions")
+	}
+	sess := &Session{Name: "missing", SocketName: "blocked/socket"}
+	for _, capture := range []struct {
+		name string
+		run  func() (string, error)
+	}{
+		{"full", sess.CaptureFullHistory}, {"lines", func() (string, error) { return sess.CaptureHistoryLines(20) }},
+	} {
+		t.Run(capture.name, func(t *testing.T) {
+			_, err := capture.run()
+			if err == nil || errors.Is(err, ErrCaptureGone) {
+				t.Fatalf("permission failure = %v, want non-gone error", err)
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || !strings.Contains(strings.ToLower(string(exitErr.Stderr)), "permission denied") {
+				t.Fatalf("expected real tmux permission error: %v", err)
+			}
+		})
 	}
 }

--- a/internal/tmux/capture_gone_test.go
+++ b/internal/tmux/capture_gone_test.go
@@ -1,0 +1,124 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCaptureGoneFromErr_KnownStderrMarkers verifies that only tmux stderr that
+// explicitly says the target is absent is classified as gone. This is the H2
+// safeguard from plan 001: capture-pane exit 1 is generic, so an unrecognized
+// stderr must NOT be swallowed as a benign "gone".
+func TestCaptureGoneFromErr_KnownStderrMarkers(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		// Absent-target messages (various tmux versions) → gone.
+		{"cant find session", "can't find session: agentdeck_foo_123", true},
+		{"cant find pane", "can't find pane: %304", true},
+		{"cant find window", "can't find window: 0", true},
+		{"no such session", "no such session: agentdeck_bar", true},
+		{"no server running", "no server running on /private/tmp/tmux-501/default", true},
+		{"lost server", "lost server", true},
+		{"server exited", "server exited unexpectedly", true},
+		{"stale socket", "error connecting to /private/tmp/tmux-501/adtmux (No such file or directory)", true},
+		{"case insensitive", "Can't Find Session: X", true},
+		{"marker mid-message", "capture-pane: can't find pane: %9", true},
+
+		// NOT absent → must surface as a real error (conservative default).
+		{"empty stderr", "", false},
+		{"unknown error", "some unexpected tmux failure", false},
+		{"usage error", "usage: capture-pane [-aeJNpPqCM]", false},
+		{"bad flag", "unknown flag: -Z", false},
+		{"ambiguous", "ambiguous option: -S", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &exec.ExitError{Stderr: []byte(tc.stderr)}
+			if got := captureGoneFromErr(err); got != tc.want {
+				t.Fatalf("captureGoneFromErr(stderr=%q) = %v, want %v", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCaptureGoneFromErr_NonExitError verifies that non-ExitError failures
+// (e.g. a context kill / timeout wrapped as a generic error, or nil) are never
+// classified as gone, so ErrCaptureTimeout handling is unaffected.
+func TestCaptureGoneFromErr_NonExitError(t *testing.T) {
+	if captureGoneFromErr(nil) {
+		t.Fatal("nil error must not be classified as gone")
+	}
+	if captureGoneFromErr(errors.New("signal: killed")) {
+		t.Fatal("plain error must not be classified as gone")
+	}
+	// A wrapped ExitError with an absent-target stderr is still detected.
+	wrapped := fmt.Errorf("run failed: %w", &exec.ExitError{Stderr: []byte("no server running on /x")})
+	if !captureGoneFromErr(wrapped) {
+		t.Fatal("wrapped ExitError with gone marker must be detected via errors.As")
+	}
+}
+
+// TestCaptureFullHistory_GoneReturnsSentinel is an integration test (real tmux):
+// capturing history from a session on a socket with no running server must
+// return ErrCaptureGone, not an opaque "failed to capture history" error. This
+// is the exact post-completion/resume-race condition from plan 001, reproduced
+// deterministically as "no server running".
+func TestCaptureFullHistory_GoneReturnsSentinel(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	sess := &Session{
+		Name:       "agentdeck_capture_gone_probe",
+		SocketName: fmt.Sprintf("adeck-gone-test-%d", os.Getpid()),
+	}
+	// No server was ever started on this isolated socket.
+	_, err := sess.CaptureFullHistory()
+	if !errors.Is(err, ErrCaptureGone) {
+		t.Fatalf("CaptureFullHistory on absent server = %v, want ErrCaptureGone", err)
+	}
+	// CaptureHistoryLines must classify the same condition identically.
+	_, err = sess.CaptureHistoryLines(200)
+	if !errors.Is(err, ErrCaptureGone) {
+		t.Fatalf("CaptureHistoryLines on absent server = %v, want ErrCaptureGone", err)
+	}
+}
+
+// TestCaptureFullHistory_LiveSessionNotGone is the positive control: a present
+// session captures successfully and is NOT classified as gone. This guards
+// against captureGoneFromErr over-matching and misrouting a real session's
+// output. The pane is kept alive (sleep) so capture races nothing.
+func TestCaptureFullHistory_LiveSessionNotGone(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	socket := fmt.Sprintf("adeck-live-test-%d", os.Getpid())
+	name := "agentdeck_capture_live_probe"
+	run := func(args ...string) {
+		_ = exec.Command("tmux", append([]string{"-L", socket}, args...)...).Run()
+	}
+	// Keep the pane alive during capture so we test a present session, not a
+	// teardown race.
+	run("new-session", "-d", "-s", name, "printf 'done-marker\\n'; sleep 5")
+	defer run("kill-server")
+	time.Sleep(400 * time.Millisecond)
+
+	sess := &Session{Name: name, SocketName: socket}
+	out, err := sess.CaptureFullHistory()
+	if errors.Is(err, ErrCaptureGone) {
+		t.Fatalf("present session misclassified as gone: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("CaptureFullHistory on live session errored: %v", err)
+	}
+	if !strings.Contains(out, "done-marker") {
+		t.Fatalf("captured history missing expected content; got %q", out)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -175,14 +175,9 @@ func (s *Session) projectDisplayName() string {
 // Callers should preserve previous state rather than transitioning to error/inactive.
 var ErrCaptureTimeout = errors.New("capture-pane timed out")
 
-// ErrCaptureGone is returned by the history-capture helpers when capture-pane
-// failed specifically because the target session/pane (or the tmux server) is
-// gone — the post-completion teardown or resume race described in plan 001.
-// This is a benign, retryable non-event: callers on the response-read path
-// should degrade to an empty response instead of surfacing the opaque
-// "failed to capture terminal output: ... exit status 1" error. It deliberately
-// does NOT drive crash-vs-clean status classification (that stays gated for a
-// separate review); it only makes the read path honest.
+// ErrCaptureGone means a history capture failed because its target or server
+// disappeared. Best-effort response readers can return an empty response;
+// this sentinel does not change session status classification.
 var ErrCaptureGone = errors.New("capture-pane target is gone")
 
 // captureGoneMarkers are the lower-cased tmux stderr fragments that mean the
@@ -201,7 +196,6 @@ var captureGoneMarkers = []string{
 	"no server running",
 	"lost server",
 	"server exited unexpectedly",
-	"error connecting to", // stale/closed socket path
 }
 
 // captureGoneFromErr reports whether a capture-pane failure was caused by the
@@ -215,7 +209,12 @@ func captureGoneFromErr(err error) bool {
 	if !errors.As(err, &exitErr) {
 		return false
 	}
-	stderr := strings.ToLower(string(exitErr.Stderr))
+	stderr := strings.ToLower(strings.TrimSpace(string(exitErr.Stderr)))
+	// Connection errors also cover permissions and malformed sockets. Only an
+	// explicitly missing socket is benign; never match markers inside its path.
+	if strings.HasPrefix(stderr, "error connecting to ") {
+		return strings.HasSuffix(stderr, " (no such file or directory)")
+	}
 	if stderr == "" {
 		return false
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -175,6 +175,58 @@ func (s *Session) projectDisplayName() string {
 // Callers should preserve previous state rather than transitioning to error/inactive.
 var ErrCaptureTimeout = errors.New("capture-pane timed out")
 
+// ErrCaptureGone is returned by the history-capture helpers when capture-pane
+// failed specifically because the target session/pane (or the tmux server) is
+// gone — the post-completion teardown or resume race described in plan 001.
+// This is a benign, retryable non-event: callers on the response-read path
+// should degrade to an empty response instead of surfacing the opaque
+// "failed to capture terminal output: ... exit status 1" error. It deliberately
+// does NOT drive crash-vs-clean status classification (that stays gated for a
+// separate review); it only makes the read path honest.
+var ErrCaptureGone = errors.New("capture-pane target is gone")
+
+// captureGoneMarkers are the lower-cased tmux stderr fragments that mean the
+// capture target no longer exists. Detection is deliberately conservative:
+// capture-pane exits non-zero for many reasons (bad flags, malformed target,
+// permissions), so only an explicit "absent" message counts as gone; any
+// unrecognized stderr surfaces as a real error. tmux wording varies across
+// versions, so the list covers the session/pane/window/server-absence phrasings
+// observed across tmux 2.x–3.x.
+var captureGoneMarkers = []string{
+	"can't find session",
+	"can't find pane",
+	"can't find window",
+	"can't find client",
+	"no such session",
+	"no server running",
+	"lost server",
+	"server exited unexpectedly",
+	"error connecting to", // stale/closed socket path
+}
+
+// captureGoneFromErr reports whether a capture-pane failure was caused by the
+// target being gone, by matching tmux's stderr against captureGoneMarkers.
+// exec.Cmd.Output() populates (*exec.ExitError).Stderr, so the message is
+// available without a separate stderr pipe. Unrecognized stderr (or a
+// non-ExitError such as a context kill) returns false so real failures and
+// timeouts keep their existing handling.
+func captureGoneFromErr(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	stderr := strings.ToLower(string(exitErr.Stderr))
+	if stderr == "" {
+		return false
+	}
+	for _, marker := range captureGoneMarkers {
+		if strings.Contains(stderr, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 const SessionPrefix = "agentdeck_"
 
 // serverAlive tracks whether the tmux server is responsive.
@@ -3688,6 +3740,9 @@ func (s *Session) CaptureFullHistory() (string, error) {
 	// concurrent `capture-pane -S -2000` clients, each spinning >20 minutes.
 	output, err := s.runBoundedOutput("capture-pane", "-t", s.Name, "-p", "-e", "-S", "-2000")
 	if err != nil {
+		if captureGoneFromErr(err) {
+			return "", ErrCaptureGone
+		}
 		return "", fmt.Errorf("failed to capture history: %w", err)
 	}
 	return string(output), nil
@@ -3713,6 +3768,9 @@ func (s *Session) CaptureHistoryLines(n int) (string, error) {
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return "", ErrCaptureTimeout
+		}
+		if captureGoneFromErr(err) {
+			return "", ErrCaptureGone
 		}
 		return "", fmt.Errorf("failed to capture history: %w", err)
 	}


### PR DESCRIPTION
## What problem does this solve?

A completed session whose tmux pane disappears can make best-effort response reads fail with an opaque capture error. Tomasz Tunguz reported this intermittently in a conductor fleet. This keeps the original read-path fix and corrects two review findings before landing.

## Why this change

Classify explicit missing sessions, panes, windows, servers, and missing socket paths as `ErrCaptureGone`. A generic connection failure can also mean permissions or a malformed socket, so it must remain an error. Best-effort reads use the final capture attempt's error after recovery. Existing Claude/Gemini graceful-empty behavior remains unchanged. Session status and crash classification are outside this PR.

Original contribution and commit by Tomasz Tunguz are preserved. The maintainer follow-up adds narrower classification, error precedence, and stronger regression coverage.

## User impact

Best-effort reads return an empty response when a capture target disappears. Terminal-only tools still surface permission and unexpected capture failures. Successful captures and timeout handling remain unchanged.

## Evidence

- New tests fail on original contributor head `d63c373e7d90d6b82c1bc7006f0f627356bbbc16`: real tmux permission errors were classified as gone by both history helpers; final permission failures were swallowed; a final gone capture could return the first unrelated failure.
- Real tmux controls cover a missing server, a missing target on a live server, successful content capture, and an inaccessible socket directory. Socket error tables cover permission denied, malformed sockets, connection refused, and misleading socket path text.
- Sequential error injection covers teardown/reconnect changes between the initial and fallback attempts; both integration tests now check tmux availability.
- Exact candidate `fdc3a91d395567318108357d0593b22a07bb496b`: focused race tests passed (tmux 1.112s; session 1.376s). The full contributor gate passed: **15 PASS, 0 FAIL, 1 WARN**, including gofmt, vet, build, and sandboxed `go test ./...`, serial package execution with `GOFLAGS=-p=1`.
- The generic revert-check warning is expected: tests referencing the new sentinel do not compile on the pre-PR base. The separate regression run against the original PR's production code fails behaviorally as described above.
- Real missing-server capture timing, three 100-iteration samples in the same bounded Docker container: median 0.910 ms/call before the follow-up, 0.591 ms/call after. Source blob hashes were verified for each run. This is a contention-sensitive smoke measurement, not a speedup claim.
- Docker used sandboxed HOME, cleared XDG, `--init --cpus 4 --cap-drop DAC_OVERRIDE`, and `GOMAXPROCS=4`; no host Go tests. Fresh CI on the published head is still required.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-6-astra for the maintainer follow-up. The original PR did not specify its tooling.

## What actually bothered you

From the original contributor's report: "Observed repeatedly in a conductor fleet (~76 sessions, 2 s status sweep): the work had finished (`===AGENTDECK_DONE=== status=ok`) and a restart always recovered it, but the opaque error kept churning orchestration."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when terminal sessions or panes disappear during response retrieval.
  * Best-effort response retrieval now returns an empty response without an error when the underlying session is gone.
  * Other capture failures, including permission errors and unrecognized errors, continue to be reported normally.
  * Improved detection of common missing-session and stopped-server conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->