### PR TITLE
fix(web): refresh menu after external session changes

### DIFF
--- a/internal/web/handlers_events_test.go
+++ b/internal/web/handlers_events_test.go
@@ -4,12 +4,15 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 type rotatingMenuDataLoader struct {
@@ -196,6 +199,149 @@ func TestMenuEventsStreamPushesChanges(t *testing.T) {
 	if !strings.Contains(payload2, `"id":"sess-2"`) {
 		t.Fatalf("second payload missing sess-2: %s", payload2)
 	}
+}
+
+func TestExternalStorageChangeRefreshesMenuAPIAndSSE(t *testing.T) {
+	profile := fmt.Sprintf("external-refresh-%d", time.Now().UnixNano())
+	writeExternalMenuSession(t, profile, "sess-initial", "Initial")
+
+	menuData := NewMemoryMenuData(NewSessionDataService(profile))
+	srv := NewServer(Config{
+		ListenAddr: "127.0.0.1:0",
+		Profile:    profile,
+		MenuData:   menuData,
+	})
+	testServer := httptest.NewServer(srv.Handler())
+	defer testServer.Close()
+
+	initialAPI := loadMenuSnapshotFromAPI(t, testServer.URL)
+	if !menuSnapshotHasSession(initialAPI, "sess-initial") {
+		t.Fatalf("initial API snapshot does not contain sess-initial: %+v", initialAPI.Items)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, testServer.URL+"/events/menu", nil)
+	if err != nil {
+		t.Fatalf("new SSE request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("start SSE request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	_, initialPayload, err := readSSEEvent(reader)
+	if err != nil {
+		t.Fatalf("read initial SSE event: %v", err)
+	}
+	var initialSSE MenuSnapshot
+	if err := json.Unmarshal([]byte(initialPayload), &initialSSE); err != nil {
+		t.Fatalf("decode initial SSE event: %v", err)
+	}
+	if !menuSnapshotHasSession(&initialSSE, "sess-initial") {
+		t.Fatalf("initial SSE snapshot does not contain sess-initial: %+v", initialSSE.Items)
+	}
+
+	writeExternalMenuSession(t, profile, "sess-external", "External")
+
+	type sseResult struct {
+		snapshot MenuSnapshot
+		err      error
+	}
+	sseResultCh := make(chan sseResult, 1)
+	go func() {
+		_, payload, readErr := readSSEEvent(reader)
+		if readErr != nil {
+			sseResultCh <- sseResult{err: readErr}
+			return
+		}
+		var snapshot MenuSnapshot
+		if decodeErr := json.Unmarshal([]byte(payload), &snapshot); decodeErr != nil {
+			sseResultCh <- sseResult{err: decodeErr}
+			return
+		}
+		sseResultCh <- sseResult{snapshot: snapshot}
+	}()
+
+	apiDeadline := time.Now().Add(4 * time.Second)
+	var refreshedAPI *MenuSnapshot
+	for time.Now().Before(apiDeadline) {
+		candidate := loadMenuSnapshotFromAPI(t, testServer.URL)
+		if menuSnapshotHasSession(candidate, "sess-external") {
+			refreshedAPI = candidate
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if refreshedAPI == nil {
+		t.Error("API menu kept the stale snapshot after an external storage write")
+	}
+
+	result := <-sseResultCh
+	if result.err != nil {
+		t.Errorf("SSE menu did not emit the external storage change: %v", result.err)
+	} else if !menuSnapshotHasSession(&result.snapshot, "sess-external") {
+		t.Errorf("SSE menu emitted a snapshot without sess-external: %+v", result.snapshot.Items)
+	}
+}
+
+func writeExternalMenuSession(t *testing.T, profile, id, title string) {
+	t.Helper()
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("open external storage: %v", err)
+	}
+	defer func() {
+		if err := storage.Close(); err != nil {
+			t.Errorf("close external storage: %v", err)
+		}
+	}()
+
+	instances, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load external storage: %v", err)
+	}
+	inst := session.NewInstanceWithGroupAndTool(title, t.TempDir(), "external", "shell")
+	inst.ID = id
+	instances = append(instances, inst)
+	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+	groupTree.CreateGroupPath("external")
+	if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+		t.Fatalf("write external storage: %v", err)
+	}
+}
+
+func loadMenuSnapshotFromAPI(t *testing.T, serverURL string) *MenuSnapshot {
+	t.Helper()
+
+	resp, err := http.Get(serverURL + "/api/menu")
+	if err != nil {
+		t.Fatalf("load API menu: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("API menu status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var snapshot MenuSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode API menu: %v", err)
+	}
+	return &snapshot
+}
+
+func menuSnapshotHasSession(snapshot *MenuSnapshot, id string) bool {
+	if snapshot == nil {
+		return false
+	}
+	for _, item := range snapshot.Items {
+		if item.Session != nil && item.Session.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSSEReconnectSnapshot(t *testing.T) {

--- a/internal/web/memory_menu_data.go
+++ b/internal/web/memory_menu_data.go
@@ -26,6 +26,7 @@ type MemoryMenuData struct {
 	snapshotFromFallback bool
 	fallbackRevision     int64
 	lastRevisionCheck    time.Time
+	lastFallbackError    error
 }
 
 const (
@@ -48,13 +49,26 @@ func NewMemoryMenuData(fallback MenuDataLoader) *MemoryMenuData {
 
 // LoadMenuSnapshot returns the latest complete snapshot.
 // It rate-limits storage checks for fallback-owned snapshots.
-func (m *MemoryMenuData) LoadMenuSnapshot() (*MenuSnapshot, error) {
+func (m *MemoryMenuData) LoadMenuSnapshot() (snapshot *MenuSnapshot, err error) {
 	if m == nil {
 		return nil, fmt.Errorf("menu snapshot is unavailable")
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// Coalesce failed reads as well as successful revision checks. Keep the
+	// error visible during the retry interval instead of serving stale data
+	// as a successful refresh. Explicit invalidation or publishing resets it.
+	if m.lastFallbackError != nil && time.Since(m.lastRevisionCheck) < memoryMenuRevisionCheckInterval {
+		return nil, m.lastFallbackError
+	}
+	defer func() {
+		m.lastFallbackError = err
+		if err != nil {
+			m.lastRevisionCheck = time.Now()
+		}
+	}()
 
 	if m.snapshot == nil {
 		return m.loadFallbackSnapshotLocked()
@@ -153,6 +167,7 @@ func (m *MemoryMenuData) InvalidateCache() {
 	m.snapshotFromFallback = false
 	m.fallbackRevision = 0
 	m.lastRevisionCheck = time.Time{}
+	m.lastFallbackError = nil
 	m.mu.Unlock()
 }
 
@@ -166,6 +181,7 @@ func (m *MemoryMenuData) SetSnapshot(snapshot *MenuSnapshot) {
 	m.snapshotFromFallback = false
 	m.fallbackRevision = 0
 	m.lastRevisionCheck = time.Time{}
+	m.lastFallbackError = nil
 	m.mu.Unlock()
 }
 

--- a/internal/web/memory_menu_data.go
+++ b/internal/web/memory_menu_data.go
@@ -14,13 +14,29 @@ type MenuSessionState struct {
 	Tool   string
 }
 
-// MemoryMenuData is an in-memory menu snapshot store used by web mode.
-// It can optionally fall back to a loader (e.g. storage-backed) until the
-// first in-memory snapshot is published.
+// MemoryMenuData stores one menu snapshot for web mode.
+// SetSnapshot gives snapshot ownership to the in-process publisher.
+// A fallback-owned snapshot uses a storage revision to find external changes.
 type MemoryMenuData struct {
-	mu       sync.RWMutex
-	snapshot *MenuSnapshot
-	fallback MenuDataLoader
+	// mu guards the snapshot and all fields that describe its storage revision.
+	// A fallback load holds this mutex to give all callers one complete snapshot.
+	mu                   sync.Mutex
+	snapshot             *MenuSnapshot
+	fallback             MenuDataLoader
+	snapshotFromFallback bool
+	fallbackRevision     int64
+	lastRevisionCheck    time.Time
+}
+
+const (
+	memoryMenuRevisionCheckInterval  = time.Second
+	memoryMenuConsistentLoadAttempts = 3
+)
+
+// menuDataRevisionLoader gives the revision of persisted menu data.
+// Each persisted menu change must update this revision.
+type menuDataRevisionLoader interface {
+	MenuDataRevision() (int64, error)
 }
 
 // NewMemoryMenuData creates an in-memory menu data store.
@@ -30,25 +46,85 @@ func NewMemoryMenuData(fallback MenuDataLoader) *MemoryMenuData {
 	}
 }
 
-// LoadMenuSnapshot returns the latest in-memory snapshot.
-// If no snapshot exists yet, it falls back once to the configured loader.
+// LoadMenuSnapshot returns the latest complete snapshot.
+// It rate-limits storage checks for fallback-owned snapshots.
 func (m *MemoryMenuData) LoadMenuSnapshot() (*MenuSnapshot, error) {
-	m.mu.RLock()
-	current := cloneMenuSnapshot(m.snapshot)
-	m.mu.RUnlock()
-	if current != nil {
-		return current, nil
+	if m == nil {
+		return nil, fmt.Errorf("menu snapshot is unavailable")
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.snapshot == nil {
+		return m.loadFallbackSnapshotLocked()
+	}
+	if !m.snapshotFromFallback {
+		return cloneMenuSnapshot(m.snapshot), nil
+	}
+
+	revisionLoader, ok := m.fallback.(menuDataRevisionLoader)
+	if !ok || time.Since(m.lastRevisionCheck) < memoryMenuRevisionCheckInterval {
+		return cloneMenuSnapshot(m.snapshot), nil
+	}
+
+	revision, err := revisionLoader.MenuDataRevision()
+	if err != nil {
+		return nil, fmt.Errorf("load menu data revision: %w", err)
+	}
+	m.lastRevisionCheck = time.Now()
+	if revision == m.fallbackRevision {
+		return cloneMenuSnapshot(m.snapshot), nil
+	}
+
+	return m.loadFallbackSnapshotLocked()
+}
+
+// loadFallbackSnapshotLocked loads one snapshot with a stable storage revision.
+// The caller must hold m.mu.
+func (m *MemoryMenuData) loadFallbackSnapshotLocked() (*MenuSnapshot, error) {
 	if m.fallback == nil {
 		return nil, fmt.Errorf("menu snapshot is unavailable")
 	}
 
-	snapshot, err := m.fallback.LoadMenuSnapshot()
-	if err != nil {
-		return nil, err
+	revisionLoader, versioned := m.fallback.(menuDataRevisionLoader)
+	if !versioned {
+		snapshot, err := m.fallback.LoadMenuSnapshot()
+		if err != nil {
+			return nil, err
+		}
+		m.setFallbackSnapshotLocked(snapshot, 0)
+		return cloneMenuSnapshot(m.snapshot), nil
 	}
-	m.SetSnapshot(snapshot)
-	return cloneMenuSnapshot(snapshot), nil
+
+	revision, err := revisionLoader.MenuDataRevision()
+	if err != nil {
+		return nil, fmt.Errorf("load menu data revision: %w", err)
+	}
+	for attempt := 0; attempt < memoryMenuConsistentLoadAttempts; attempt++ {
+		snapshot, err := m.fallback.LoadMenuSnapshot()
+		if err != nil {
+			return nil, err
+		}
+		after, err := revisionLoader.MenuDataRevision()
+		if err != nil {
+			return nil, fmt.Errorf("load menu data revision: %w", err)
+		}
+		if revision == after {
+			m.setFallbackSnapshotLocked(snapshot, after)
+			return cloneMenuSnapshot(m.snapshot), nil
+		}
+		revision = after
+	}
+
+	return nil, fmt.Errorf("menu data changed during %d consecutive snapshot loads", memoryMenuConsistentLoadAttempts)
+}
+
+func (m *MemoryMenuData) setFallbackSnapshotLocked(snapshot *MenuSnapshot, revision int64) {
+	m.snapshot = cloneMenuSnapshot(snapshot)
+	m.snapshotFromFallback = true
+	m.fallbackRevision = revision
+	m.lastRevisionCheck = time.Now()
 }
 
 // LoadArchivedMenuSnapshot returns archived sessions from the storage fallback.
@@ -74,6 +150,9 @@ func (m *MemoryMenuData) InvalidateCache() {
 	}
 	m.mu.Lock()
 	m.snapshot = nil
+	m.snapshotFromFallback = false
+	m.fallbackRevision = 0
+	m.lastRevisionCheck = time.Time{}
 	m.mu.Unlock()
 }
 
@@ -84,6 +163,9 @@ func (m *MemoryMenuData) SetSnapshot(snapshot *MenuSnapshot) {
 	}
 	m.mu.Lock()
 	m.snapshot = cloneMenuSnapshot(snapshot)
+	m.snapshotFromFallback = false
+	m.fallbackRevision = 0
+	m.lastRevisionCheck = time.Time{}
 	m.mu.Unlock()
 }
 

--- a/internal/web/memory_menu_data_test.go
+++ b/internal/web/memory_menu_data_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +11,43 @@ import (
 type staticMenuLoader struct {
 	calls    int
 	snapshot *MenuSnapshot
+}
+
+type revisionedMenuLoader struct {
+	mu                sync.Mutex
+	revision          int64
+	revisionCalls     int
+	loadCalls         int
+	snapshot          *MenuSnapshot
+	nextSnapshot      *MenuSnapshot
+	changeOnFirstLoad bool
+}
+
+func (r *revisionedMenuLoader) MenuDataRevision() (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.revisionCalls++
+	return r.revision, nil
+}
+
+func (r *revisionedMenuLoader) LoadMenuSnapshot() (*MenuSnapshot, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.loadCalls++
+	if r.changeOnFirstLoad && r.loadCalls == 1 {
+		r.revision++
+		return r.snapshot, nil
+	}
+	if r.nextSnapshot != nil {
+		return r.nextSnapshot, nil
+	}
+	return r.snapshot, nil
+}
+
+func (r *revisionedMenuLoader) calls() (revision, load int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.revisionCalls, r.loadCalls
 }
 
 func (s *staticMenuLoader) LoadMenuSnapshot() (*MenuSnapshot, error) {
@@ -119,6 +157,128 @@ func TestMemoryMenuData_InvalidateCacheForcesReload(t *testing.T) {
 	}
 	if got := third.Items[0].Session.Title; got != "Updated" {
 		t.Fatalf("after invalidation title = %q, want %q", got, "Updated")
+	}
+}
+
+func TestMemoryMenuData_ConcurrentLoadsCoalesceRevisionCheck(t *testing.T) {
+	loader := &revisionedMenuLoader{
+		revision: 1,
+		snapshot: &MenuSnapshot{
+			TotalSessions: 1,
+			Items: []MenuItem{{
+				Type:    MenuItemTypeSession,
+				Session: &MenuSession{ID: "sess-1"},
+			}},
+		},
+	}
+	store := NewMemoryMenuData(loader)
+	if _, err := store.LoadMenuSnapshot(); err != nil {
+		t.Fatalf("initial LoadMenuSnapshot() error = %v", err)
+	}
+
+	store.mu.Lock()
+	store.lastRevisionCheck = time.Now().Add(-2 * memoryMenuRevisionCheckInterval)
+	store.mu.Unlock()
+
+	const callers = 32
+	errCh := make(chan error, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := store.LoadMenuSnapshot()
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Errorf("concurrent LoadMenuSnapshot() error = %v", err)
+		}
+	}
+
+	revisionCalls, loadCalls := loader.calls()
+	if revisionCalls != 3 {
+		t.Fatalf("revision calls = %d, want 3", revisionCalls)
+	}
+	if loadCalls != 1 {
+		t.Fatalf("snapshot loads = %d, want 1", loadCalls)
+	}
+}
+
+func TestMemoryMenuData_RetriesSnapshotChangedDuringLoad(t *testing.T) {
+	loader := &revisionedMenuLoader{
+		revision:          1,
+		changeOnFirstLoad: true,
+		snapshot: &MenuSnapshot{
+			TotalSessions: 1,
+			Items: []MenuItem{{
+				Type:    MenuItemTypeSession,
+				Session: &MenuSession{ID: "sess-old"},
+			}},
+		},
+		nextSnapshot: &MenuSnapshot{
+			TotalSessions: 1,
+			Items: []MenuItem{{
+				Type:    MenuItemTypeSession,
+				Session: &MenuSession{ID: "sess-new"},
+			}},
+		},
+	}
+
+	snapshot, err := NewMemoryMenuData(loader).LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("LoadMenuSnapshot() error = %v", err)
+	}
+	if !menuSnapshotHasSession(snapshot, "sess-new") {
+		t.Fatalf("stable snapshot does not contain sess-new: %+v", snapshot.Items)
+	}
+	if menuSnapshotHasSession(snapshot, "sess-old") {
+		t.Fatalf("stable snapshot contains stale sess-old: %+v", snapshot.Items)
+	}
+
+	_, loadCalls := loader.calls()
+	if loadCalls != 2 {
+		t.Fatalf("snapshot loads = %d, want 2", loadCalls)
+	}
+}
+
+func TestMemoryMenuData_SetSnapshotKeepsPublisherOwnership(t *testing.T) {
+	loader := &revisionedMenuLoader{
+		revision: 1,
+		snapshot: &MenuSnapshot{
+			TotalSessions: 1,
+			Items: []MenuItem{{
+				Type:    MenuItemTypeSession,
+				Session: &MenuSession{ID: "sess-fallback"},
+			}},
+		},
+	}
+	store := NewMemoryMenuData(loader)
+	store.SetSnapshot(&MenuSnapshot{
+		TotalSessions: 1,
+		Items: []MenuItem{{
+			Type:    MenuItemTypeSession,
+			Session: &MenuSession{ID: "sess-published"},
+		}},
+	})
+
+	snapshot, err := store.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("LoadMenuSnapshot() error = %v", err)
+	}
+	if !menuSnapshotHasSession(snapshot, "sess-published") {
+		t.Fatalf("snapshot does not contain sess-published: %+v", snapshot.Items)
+	}
+	if menuSnapshotHasSession(snapshot, "sess-fallback") {
+		t.Fatalf("snapshot contains fallback-owned sess-fallback: %+v", snapshot.Items)
+	}
+
+	revisionCalls, loadCalls := loader.calls()
+	if revisionCalls != 0 || loadCalls != 0 {
+		t.Fatalf("fallback calls after SetSnapshot() = revision %d, load %d; want 0, 0", revisionCalls, loadCalls)
 	}
 }
 

--- a/internal/web/memory_menu_failure_test.go
+++ b/internal/web/memory_menu_failure_test.go
@@ -1,0 +1,97 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type failingRevisionMenuLoader struct {
+	revision      int64
+	mode          string
+	probes, loads int
+}
+
+func (l *failingRevisionMenuLoader) MenuDataRevision() (int64, error) {
+	l.probes++
+	if l.mode == "revision" {
+		return 0, errors.New("revision unavailable")
+	}
+	if l.mode == "unstable" {
+		l.revision++
+	}
+	return l.revision, nil
+}
+
+func (l *failingRevisionMenuLoader) LoadMenuSnapshot() (*MenuSnapshot, error) {
+	l.loads++
+	if l.mode == "load" {
+		return nil, errors.New("snapshot unavailable")
+	}
+	return &MenuSnapshot{Profile: fmt.Sprint(l.revision)}, nil
+}
+
+func TestMemoryMenuData_FailureBurstIsBoundedAndNeverReturnsStaleSuccess(t *testing.T) {
+	for _, mode := range []string{"revision", "load", "unstable"} {
+		for _, cached := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/cached=%t", mode, cached), func(t *testing.T) {
+				loader := &failingRevisionMenuLoader{revision: 1}
+				store := NewMemoryMenuData(loader)
+				if cached {
+					if _, err := store.LoadMenuSnapshot(); err != nil {
+						t.Fatal(err)
+					}
+					store.lastRevisionCheck = time.Now().Add(-2 * memoryMenuRevisionCheckInterval)
+				}
+				loader.revision++
+				loader.mode = mode
+				if snapshot, err := store.LoadMenuSnapshot(); err == nil || snapshot != nil {
+					t.Fatalf("failure = (%v, %v), want nil snapshot and error", snapshot, err)
+				}
+				probes, loads := loader.probes, loader.loads
+				var wg sync.WaitGroup
+				for i := 0; i < 32; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						if snapshot, err := store.LoadMenuSnapshot(); err == nil || snapshot != nil {
+							t.Errorf("cached failure = (%v, %v), want nil snapshot and error", snapshot, err)
+						}
+					}()
+				}
+				wg.Wait()
+				if loader.probes != probes || loader.loads != loads {
+					t.Fatalf("burst retried storage: probes %d -> %d, loads %d -> %d", probes, loader.probes, loads, loader.loads)
+				}
+				loader.mode = ""
+				store.lastRevisionCheck = time.Now().Add(-2 * memoryMenuRevisionCheckInterval)
+				if snapshot, err := store.LoadMenuSnapshot(); err != nil || snapshot.Profile != fmt.Sprint(loader.revision) {
+					t.Fatalf("recovery = (%v, %v)", snapshot, err)
+				}
+			})
+		}
+	}
+}
+
+func TestMemoryMenuData_ExplicitUpdatesClearFailureBackoff(t *testing.T) {
+	for _, publish := range []bool{false, true} {
+		t.Run(fmt.Sprint(publish), func(t *testing.T) {
+			loader := &failingRevisionMenuLoader{mode: "revision"}
+			store := NewMemoryMenuData(loader)
+			if _, err := store.LoadMenuSnapshot(); err == nil {
+				t.Fatal("expected failure")
+			}
+			loader.mode = ""
+			if publish {
+				store.SetSnapshot(&MenuSnapshot{Profile: "publisher"})
+			} else {
+				store.InvalidateCache()
+			}
+			if _, err := store.LoadMenuSnapshot(); err != nil {
+				t.Fatalf("explicit update retained failure: %v", err)
+			}
+		})
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -448,6 +448,12 @@ func (s *Server) HasMutator() bool {
 }
 
 func (s *Server) notifyMenuChanged() {
+	// Clear the fallback cache before a subscriber loads the changed menu.
+	// Headless mode has no TUI publisher, so the next load reads storage.
+	if mmd, ok := s.menuData.(*MemoryMenuData); ok {
+		mmd.InvalidateCache()
+	}
+
 	s.menuSubscribersMu.Lock()
 	for ch := range s.menuSubscribers {
 		select {
@@ -456,15 +462,6 @@ func (s *Server) notifyMenuChanged() {
 		}
 	}
 	s.menuSubscribersMu.Unlock()
-
-	// Invalidate the MemoryMenuData cache so the next LoadMenuSnapshot()
-	// reloads from the storage-backed fallback. In headless (--no-tui) mode
-	// there is no TUI loop to call publishWebMenuSnapshot(), so without this
-	// the menu snapshot would remain frozen at its first-load state and new
-	// sessions created via the API would never appear until server restart.
-	if mmd, ok := s.menuData.(*MemoryMenuData); ok {
-		mmd.InvalidateCache()
-	}
 }
 
 // checkMutationsAllowed writes a 403 response and returns false when web mutations are disabled.

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -141,6 +141,7 @@ type MenuSession struct {
 
 type storageLoader interface {
 	LoadWithGroups() ([]*session.Instance, []*session.GroupData, error)
+	GetUpdatedAt() (time.Time, error)
 	Close() error
 	// Profile returns the profile name actually opened — which, per the
 	// #1790 guard inside NewStorageWithProfile, may differ from the raw
@@ -263,6 +264,31 @@ func (s *SessionDataService) LoadMenuSnapshot() (*MenuSnapshot, error) {
 
 	active := session.FilterInstancesByArchive(instances, false)
 	return BuildMenuSnapshot(profile, active, groupsData, s.now()), nil
+}
+
+// MenuDataRevision returns the storage revision that changes after a persisted mutation.
+func (s *SessionDataService) MenuDataRevision() (int64, error) {
+	if s == nil {
+		return 0, fmt.Errorf("session data service is nil")
+	}
+	if s.openStorage == nil {
+		return 0, fmt.Errorf("storage opener is not configured")
+	}
+
+	storage, profile, err := s.resolveAndOpenStorage()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = storage.Close() }()
+
+	updatedAt, err := storage.GetUpdatedAt()
+	if err != nil {
+		return 0, fmt.Errorf("load menu data revision for profile %q: %w", profile, err)
+	}
+	if updatedAt.IsZero() {
+		return 0, nil
+	}
+	return updatedAt.UnixNano(), nil
 }
 
 // LoadArchivedMenuSnapshot returns a menu containing only archived sessions.

--- a/internal/web/session_data_service_test.go
+++ b/internal/web/session_data_service_test.go
@@ -12,6 +12,7 @@ type fakeStorage struct {
 	instances []*session.Instance
 	groups    []*session.GroupData
 	loadErr   error
+	updatedAt time.Time
 	closed    bool
 	// profile, if set, is what Profile() reports was actually opened. Left
 	// "" in most fixtures so SessionDataService.resolveAndOpenStorage
@@ -24,6 +25,10 @@ func (f *fakeStorage) LoadWithGroups() ([]*session.Instance, []*session.GroupDat
 		return nil, nil, f.loadErr
 	}
 	return f.instances, f.groups, nil
+}
+
+func (f *fakeStorage) GetUpdatedAt() (time.Time, error) {
+	return f.updatedAt, nil
 }
 
 func (f *fakeStorage) Close() error {
@@ -132,6 +137,26 @@ func TestSessionDataService_LoadMenuSnapshot(t *testing.T) {
 	if snapshot.Items[3].Session.Model != "Gemini Pro" || snapshot.Items[3].Session.ModelVersion != "3.1 Preview" {
 		t.Fatalf("unexpected model fields: model=%q version=%q",
 			snapshot.Items[3].Session.Model, snapshot.Items[3].Session.ModelVersion)
+	}
+}
+
+func TestSessionDataService_MenuDataRevision(t *testing.T) {
+	updatedAt := time.Date(2026, time.September, 1, 12, 0, 0, 123, time.UTC)
+	fake := &fakeStorage{updatedAt: updatedAt}
+	svc := &SessionDataService{
+		profile:     "test-profile",
+		openStorage: func(string) (storageLoader, error) { return fake, nil },
+	}
+
+	revision, err := svc.MenuDataRevision()
+	if err != nil {
+		t.Fatalf("MenuDataRevision() error = %v", err)
+	}
+	if revision != updatedAt.UnixNano() {
+		t.Fatalf("MenuDataRevision() = %d, want %d", revision, updatedAt.UnixNano())
+	}
+	if !fake.closed {
+		t.Fatal("expected storage Close() to be called")
 	}
 }
 


### PR DESCRIPTION
## What problem does this solve?

A headless web menu could keep its first storage snapshot after another CLI process changed sessions. The original refresh patch detected external revisions, but failed revision reads bypassed its polling bound. A failed reload could also return the old snapshot as success to the next caller.

## Why this change

Fallback-owned snapshots check the persisted revision at most once per interval. Stable before/after revision checks retry changed loads. The corrective follow-up coalesces failed reads too, retaining their error during the retry interval. Explicit invalidation and publisher snapshots reset that error state. Invalidation still precedes subscriber notification.

## User impact

External changes become visible without restarting the headless service. Storage failures produce a bounded retry and an honest error instead of a polling burst or stale success. This does not add transactional consistency across independently saved tables or change the publisher-invalidation policy.

## Evidence

Fresh Docker behavioral tests on the original PR fail for initial and cached revision errors, snapshot-load errors and repeated revision changes. The corrected entire web package passes with the race detector. The tests include32 concurrent callers, interval expiry/recovery and explicit invalidation/publishing. Independent source review found no blocker. The burst test assumes callers finish within the one-second interval; severe host contention must be distinguished from a legitimate later retry. Fresh contributor check at26ecb882c680a146679dca27fdebd3fd40184df3:14PASS,0FAIL,2WARN. Build, vet, formatting and full affected web package pass. The aggregate +576/-27 size includes the original external-refresh regressions and the corrective failure-path coverage for the same cache contract. Main lacks newly introduced test symbols, so the aggregate revert does not compile; the separate original-PR red test supplies meaningful runtime failure evidence. Latest-head GitHub CI remains required.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** Original contribution model unsure; correction and independent review GPT-6.

## What actually bothered you

The reported headless web menu did not show a session created by another CLI process until restart. The owner authorized review and correction of this existing PR.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed with validation limits
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6 intent=yes -->
