### PR TITLE
feat: add muse code cli as builtin tool with resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Agent Deck works with any terminal-based AI tool:
 | **Codex** | Status detection, MCP, organization, conductor, fork |
 | **Copilot** | Organization, launch |
 | **Crush** (charmbracelet/crush) | Status detection, organization, launch |
+| **Muse Code** (`muse`) | Status detection, organization, launch, resume |
 | **Cursor** (terminal) | Status detection, organization |
 | **Hermes Agent** | Organization, launch |
 | **DeepSeek Harness** (`dsh`) | Status detection, organization, launch, restart, per-account `DSH_HOME` |

--- a/cmd/agent-deck/muse_detect_test.go
+++ b/cmd/agent-deck/muse_detect_test.go
@@ -29,13 +29,16 @@ func TestDetectTool_Muse(t *testing.T) {
 }
 
 func TestDetectTool_Muse_Negative(t *testing.T) {
-	// Note: detectTool matches on substrings, so any string containing
-	// "muse" will match. Only truly unrelated strings are tested here.
+	// Token match only: substrings must not claim unrelated commands.
 	tests := []struct {
 		name string
 		cmd  string
 	}{
 		{"empty string", ""},
+		{"echo muse", "echo muse"},
+		{"amuse", "amuse"},
+		{"museum", "echo museum"},
+		{"muse in path", "git -C /tmp/muse-project status"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/agent-deck/muse_detect_test.go
+++ b/cmd/agent-deck/muse_detect_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+// Muse Code CLI (`muse`): `agent-deck add -c muse .` must set
+// Instance.Tool = "muse" instead of falling back to "shell". This is the
+// CLI-layer detection (not tmux's detectToolFromCommand) — it lives in
+// main.go via session.MatchTool.
+
+func TestDetectTool_Muse(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"bare", "muse", "muse"},
+		{"with trust flag", "muse --trust-workspace", "muse"},
+		{"with yolo", "muse --yolo", "muse"},
+		{"uppercase", "Muse", "muse"},
+		{"resume subcommand", "muse resume 01a063dd-45dd-7402-b516-4346e923db3e", "muse"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTool_Muse_Negative(t *testing.T) {
+	// Note: detectTool matches on substrings, so any string containing
+	// "muse" will match. Only truly unrelated strings are tested here.
+	tests := []struct {
+		name string
+		cmd  string
+	}{
+		{"empty string", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got == "muse" {
+				t.Errorf("detectTool(%q) = %q, should NOT match muse", tt.cmd, got)
+			}
+		})
+	}
+}

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -62,6 +62,7 @@ func builtinTools() []builtinTool {
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
+		{Name: "muse", Icon: "🔮", detectSubstrings: []string{"muse"}},
 		// detectTokens includes bare "agent" (standalone Cursor Agent CLI).
 		// Token match only: substring "agent" would false-match "agent-deck".
 		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}, detectTokens: []string{"agent"}},

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -34,6 +34,14 @@ type builtinTool struct {
 	// "epic"/"tapioca". Mirrors detectTool()'s hasCommandToken() arm.
 	detectTokens []string
 
+	// executableOnly restricts token matching to the executable position
+	// (first shellwords field, basename-compared). For collision-prone
+	// names like "muse" (vs "amuse", "museum", or `echo muse`) even a
+	// whole-token match is too loose anywhere but the executable slot.
+	// Unset preserves the legacy whole-line token match, so every other
+	// tool is byte-identical in behavior.
+	executableOnly bool
+
 	// Installed reports whether this tool's command resolved on the host PATH at
 	// registry-init time. It is ONLY populated when the show_only_installed_tools
 	// filter is on (issue #1259); with the filter off the probe is skipped
@@ -62,7 +70,12 @@ func builtinTools() []builtinTool {
 		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
 		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
 		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
-		{Name: "muse", Icon: "🔮", detectSubstrings: []string{"muse"}},
+		// Executable-position token match only: substring "muse" would
+		// false-match "amuse", "museum", and paths like
+		// "/tmp/muse-project", and even a whole-token match fires on
+		// `echo muse`. Basename comparison keeps bare paths
+		// ("/x/bin/muse") working.
+		{Name: "muse", Icon: "🔮", detectTokens: []string{"muse"}, executableOnly: true},
 		// detectTokens includes bare "agent" (standalone Cursor Agent CLI).
 		// Token match only: substring "agent" would false-match "agent-deck".
 		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}, detectTokens: []string{"agent"}},

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -609,6 +609,8 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Copilot.EnvFile
 	case "crush":
 		return config.Crush.EnvFile
+	case "muse":
+		return config.Muse.EnvFile
 	case "cursor":
 		return config.Cursor.EnvFile
 	case "hermes":

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4845,6 +4845,8 @@ func (i *Instance) Start() error {
 		command = i.buildPiCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
+	case i.Tool == "muse":
+		command = i.buildMuseCommand(i.Command)
 	case i.Tool == "cursor":
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
@@ -5156,6 +5158,8 @@ func (i *Instance) StartWithMessage(message string) error {
 		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "crush":
 		command = i.buildCrushCommand(i.Command)
+	case i.Tool == "muse":
+		command = i.buildMuseCommand(i.Command)
 	case i.Tool == "cursor":
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
@@ -8972,6 +8976,18 @@ func (i *Instance) restart(env map[string]string) error {
 			return dsErr
 		}
 		command = dsCommand
+	} else if i.Tool == "muse" {
+		// Re-discover the workspace's newest muse session on EVERY restart,
+		// for the same self-healing reason as hermes/deepseek: a pruned
+		// session yields the current newest, or "" — in which case the
+		// launch boots fresh instead of resuming a dead ID forever. Bounded
+		// by the last start so a restart cannot rebind to an older
+		// unrelated conversation.
+		if sid := i.discoverMuseResumeID(); sid != "" {
+			command = i.buildMuseResumeCommand(sid)
+		} else {
+			command = i.buildMuseCommand(i.Command)
+		}
 	} else {
 		// Route to appropriate command builder based on tool
 		switch {
@@ -11053,6 +11069,7 @@ var builtinAgentTools = map[string]bool{
 	"cursor":   true,
 	"hermes":   true,
 	"crush":    true,
+	"muse":     true,
 }
 
 // isBuiltinAgentTool reports whether tool is a first-party agent (or a custom

--- a/internal/session/muse.go
+++ b/internal/session/muse.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"strings"
+
+	"al.essio.dev/pkg/shellescape"
 )
 
 // Muse adapter.
@@ -132,7 +134,7 @@ func (i *Instance) buildMuseResumeCommand(sessionID string) string {
 	if trimmed := strings.TrimSpace(i.Command); trimmed != "" && trimmed != "muse" {
 		base, passthrough = trimmed, true
 	}
-	cmd := base + " resume " + strings.TrimSpace(sessionID)
+	cmd := base + " resume " + shellescape.Quote(strings.TrimSpace(sessionID))
 	if !passthrough {
 		opts, optsOK := i.museLaunchOptions()
 		config, _ := LoadUserConfig()

--- a/internal/session/muse.go
+++ b/internal/session/muse.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"strings"
+)
+
+// Muse adapter.
+//
+// Muse Code is an interactive terminal coding agent (the `muse` binary).
+// The muse CLI is a single TUI binary:
+//
+//	muse                          # interactive TUI (blocks on a workspace-trust
+//	                                prompt in a fresh directory)
+//	muse --trust-workspace         # trust this workspace for this run (no prompt)
+//	muse --yolo                     # disable approval + sandbox + trust workspace
+//	muse resume <uuid> | --last     # resume a previous session
+//	muse exec <prompt>              # headless single prompt
+//	muse export --session <id>      # export a session transcript to JSON
+//
+// agent-deck integrates muse at the same level as crush: launch the TUI in
+// a tmux pane with optional env_file sourcing, an optional command override
+// (e.g. for a provider/model preset), and an optional --yolo flag from
+// `[muse].yolo_mode`. Per-session flags flow through MuseOptions
+// (ToolOptionsJSON) when wired by the UI.
+//
+// Status detection: content patterns in internal/tmux/patterns.go, captured
+// live from Muse Code 1.0.2: busy `◈ Thinking (Ns · esc to interrupt)`,
+// idle prompt `⟩` + "Type @ to search and insert workspace file paths".
+// Session discovery lives in muse_discovery.go; restart() re-discovers the
+// workspace's newest session and resumes it via buildMuseResumeCommand.
+
+// defaultMuseCommand is the default invocation for Muse sessions.
+// Bare `muse` blocks on "Do you trust this workspace?" in a fresh directory
+// (captured live in a tmux pane), which would wedge every agent-deck spawn,
+// so the default carries --trust-workspace. A [muse].command override
+// replaces this default wholesale, flags included.
+const defaultMuseCommand = "muse --trust-workspace"
+
+// GetMuseCommand returns the configured muse command.
+// Mirrors GetCrushCommand: prefer the user config override, fall back to
+// the default invocation.
+func GetMuseCommand() string {
+	userConfig, _ := LoadUserConfig()
+	if userConfig != nil && strings.TrimSpace(userConfig.Muse.Command) != "" {
+		return strings.TrimSpace(userConfig.Muse.Command)
+	}
+	return defaultMuseCommand
+}
+
+// museYoloSuffix resolves the --yolo flag for muse launches from one place
+// so fresh and resume builders agree. Per-session ToolOptionsJSON takes
+// priority over global config when it unmarshals: an explicit YoloMode
+// (true or false) is authoritative and the config is ignored; only when no
+// usable per-session options exist does [muse].yolo_mode apply.
+func museYoloSuffix(opts *MuseOptions, optsOK bool, config *UserConfig) string {
+	if optsOK && opts != nil {
+		if opts.YoloMode != nil && *opts.YoloMode {
+			return " --yolo"
+		}
+		return ""
+	}
+	if config != nil && config.Muse.YoloMode {
+		return " --yolo"
+	}
+	return ""
+}
+
+// museLaunchOptions unmarshals the instance's per-session muse options.
+// The second return reports whether usable options exist (drives the
+// config-fallback rule in museYoloSuffix).
+func (i *Instance) museLaunchOptions() (*MuseOptions, bool) {
+	if len(i.ToolOptionsJSON) == 0 {
+		return nil, false
+	}
+	opts, err := UnmarshalMuseOptions(i.ToolOptionsJSON)
+	if err != nil || opts == nil {
+		return nil, false
+	}
+	return opts, true
+}
+
+// buildMuseCommand builds the launch command for Muse Code.
+// Applies env sourcing, command override, and any per-session flags.
+// If baseCommand differs from the bare tool name "muse", it is treated
+// as a user-supplied passthrough command and returned without flag
+// injection — matching the buildCrushCommand pattern.
+func (i *Instance) buildMuseCommand(baseCommand string) string {
+	if i.Tool != "muse" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+
+	// Passthrough: custom command from CLI (not the bare name)
+	trimmed := strings.TrimSpace(baseCommand)
+	if trimmed != "" && trimmed != "muse" {
+		return envPrefix + trimmed
+	}
+
+	cmd := GetMuseCommand()
+	opts, optsOK := i.museLaunchOptions()
+	config, _ := LoadUserConfig()
+	return envPrefix + cmd + museYoloSuffix(opts, optsOK, config)
+}
+
+// buildMuseResumeCommand builds the launch command that resumes a known
+// muse session: the resolved base command plus the `resume <uuid>`
+// subcommand (muse takes resume as a subcommand, not a flag; root options
+// may appear on either side of it). An empty session ID falls back to a
+// fresh launch rather than emitting a broken `resume` with no target.
+func (i *Instance) buildMuseResumeCommand(sessionID string) string {
+	if i.Tool != "muse" {
+		return ""
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		return i.buildMuseCommand(i.Command)
+	}
+	envPrefix := i.buildEnvSourceCommand()
+	opts, optsOK := i.museLaunchOptions()
+	config, _ := LoadUserConfig()
+	return envPrefix + GetMuseCommand() + " resume " + strings.TrimSpace(sessionID) + museYoloSuffix(opts, optsOK, config)
+}
+
+// discoverMuseResumeID returns the newest muse session ID bound to the
+// instance's working directory, bounded by the instance's last start (so a
+// restart cannot rebind to an older unrelated conversation), or "" when
+// none qualifies.
+func (i *Instance) discoverMuseResumeID() string {
+	return FindLatestMuseSession(i.EffectiveWorkingDir(), i.LastStartedAt)
+}

--- a/internal/session/muse.go
+++ b/internal/session/muse.go
@@ -53,12 +53,17 @@ func GetMuseCommand() string {
 // (true or false) is authoritative and the config is ignored; only when no
 // usable per-session options exist does [muse].yolo_mode apply.
 func museYoloSuffix(opts *MuseOptions, optsOK bool, config *UserConfig) string {
-	if optsOK && opts != nil {
-		if opts.YoloMode != nil && *opts.YoloMode {
+	if optsOK && opts != nil && opts.YoloMode != nil {
+		// Explicit per-session override wins both ways: true forces
+		// --yolo, false suppresses the global [muse].yolo_mode.
+		if *opts.YoloMode {
 			return " --yolo"
 		}
 		return ""
 	}
+	// No usable per-session value: absent, unparseable, or a serialized
+	// default whose YoloMode is nil. Nil is not a choice, so inherit the
+	// global config instead of silently dropping it.
 	if config != nil && config.Muse.YoloMode {
 		return " --yolo"
 	}

--- a/internal/session/muse.go
+++ b/internal/session/muse.go
@@ -104,10 +104,16 @@ func (i *Instance) buildMuseCommand(baseCommand string) string {
 }
 
 // buildMuseResumeCommand builds the launch command that resumes a known
-// muse session: the resolved base command plus the `resume <uuid>`
-// subcommand (muse takes resume as a subcommand, not a flag; root options
-// may appear on either side of it). An empty session ID falls back to a
-// fresh launch rather than emitting a broken `resume` with no target.
+// muse session: the base command plus the `resume <uuid>` subcommand (muse
+// takes resume as a subcommand, not a flag; root options may appear on
+// either side of it). An empty session ID falls back to a fresh launch
+// rather than emitting a broken `resume` with no target.
+//
+// The base mirrors buildMuseCommand exactly: the instance's persisted
+// command when it is a non-bare custom invocation (wrapper, provider or
+// model flags), otherwise the configured default. A custom base is used
+// verbatim with no flag injection, same as the fresh passthrough path, so
+// a restart never silently drops the operator's explicit invocation.
 func (i *Instance) buildMuseResumeCommand(sessionID string) string {
 	if i.Tool != "muse" {
 		return ""
@@ -116,9 +122,18 @@ func (i *Instance) buildMuseResumeCommand(sessionID string) string {
 		return i.buildMuseCommand(i.Command)
 	}
 	envPrefix := i.buildEnvSourceCommand()
-	opts, optsOK := i.museLaunchOptions()
-	config, _ := LoadUserConfig()
-	return envPrefix + GetMuseCommand() + " resume " + strings.TrimSpace(sessionID) + museYoloSuffix(opts, optsOK, config)
+	base := GetMuseCommand()
+	passthrough := false
+	if trimmed := strings.TrimSpace(i.Command); trimmed != "" && trimmed != "muse" {
+		base, passthrough = trimmed, true
+	}
+	cmd := base + " resume " + strings.TrimSpace(sessionID)
+	if !passthrough {
+		opts, optsOK := i.museLaunchOptions()
+		config, _ := LoadUserConfig()
+		cmd += museYoloSuffix(opts, optsOK, config)
+	}
+	return envPrefix + cmd
 }
 
 // discoverMuseResumeID returns the newest muse session ID bound to the

--- a/internal/session/muse_discovery.go
+++ b/internal/session/muse_discovery.go
@@ -1,0 +1,247 @@
+package session
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Muse session discovery.
+//
+// Muse persists one directory per session, sharded by date:
+//
+//	<root>/YYYY/MM/DD/<uuid>/session.jsonl
+//
+// where <root> is $XDG_DATA_HOME/muse/sessions when XDG_DATA_HOME is set
+// (muse honors it; observed a pane inheriting XDG_DATA_HOME persist plugin
+// cache and tracing underneath it) and ~/.local/share/muse/sessions
+// otherwise. Each session.jsonl line is either a framed transaction
+// ({"retained_frame":..., "children":[{"record_json":"<escaped record>"}]})
+// or a bare record; the workspace binding lives in the record with
+// payload_type "runtime.session.metadata" as payload.record.workspace_root
+// (symlink-resolved, e.g. /private/tmp/...).
+//
+// Restart-resume reads the store on EVERY restart and takes the newest
+// session for the working directory (bounded by the instance's last start),
+// so a pruned session simply yields the current newest, or "" for a fresh
+// boot — the same self-healing shape as the deepseek restart path.
+
+// museSessionsRootOverride redirects the store root in tests (mirrors
+// geminiConfigDirOverride). Production code uses the real resolution.
+var museSessionsRootOverride string
+
+// museDiscoveryMaxFiles bounds a single store scan. Session logs can reach
+// megabytes, but the metadata record sits at the top of the file (observed
+// at line 2 of a 7.6MB log), so each file costs one short prefix read;
+// the cap only guards pathological stores.
+const museDiscoveryMaxFiles = 2000
+
+// museDiscoverySkew tolerates clock skew between the instance's recorded
+// start time and session-file mtimes when bounding a resume scan.
+const museDiscoverySkew = 5 * time.Minute
+
+// MuseSessionInfo is one discovered muse session.
+type MuseSessionInfo struct {
+	SessionID     string
+	WorkspaceRoot string
+	ProviderID    string
+	LastUpdated   time.Time // file mtime (cheap recency signal)
+}
+
+// GetMuseSessionsRoot returns the muse session store root.
+func GetMuseSessionsRoot() string {
+	if museSessionsRootOverride != "" {
+		return museSessionsRootOverride
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); xdg != "" {
+		if abs, err := filepath.Abs(xdg); err == nil {
+			return filepath.Join(abs, "muse", "sessions")
+		}
+		return filepath.Join(xdg, "muse", "sessions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share", "muse", "sessions")
+}
+
+// museRecord is one inner session-log record (framed or bare).
+type museRecord struct {
+	Stream struct {
+		ID string `json:"id"`
+	} `json:"stream"`
+	RecordedAt  int64  `json:"recorded_at"`
+	PayloadType string `json:"payload_type"`
+	Payload     struct {
+		Record struct {
+			WorkspaceRoot string `json:"workspace_root"`
+			ProviderID    string `json:"provider_id"`
+		} `json:"record"`
+	} `json:"payload"`
+}
+
+// museFrame is one framed session.jsonl line.
+type museFrame struct {
+	Children []struct {
+		RecordJSON string `json:"record_json"`
+	} `json:"children"`
+}
+
+// parseMuseMetadataLine extracts the session-metadata record from one
+// session.jsonl line. It returns nil when the line carries no metadata
+// record (the common case: permission frames, tool calls, echoes).
+func parseMuseMetadataLine(line string) *museRecord {
+	if !strings.Contains(line, "runtime.session.metadata") {
+		return nil
+	}
+	tryRecord := func(raw string) *museRecord {
+		var rec museRecord
+		if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+			return nil
+		}
+		if rec.PayloadType != "runtime.session.metadata" {
+			return nil
+		}
+		return &rec
+	}
+	// Framed line: unwrap children first.
+	var frame museFrame
+	if err := json.Unmarshal([]byte(line), &frame); err == nil {
+		for _, child := range frame.Children {
+			if rec := tryRecord(child.RecordJSON); rec != nil {
+				return rec
+			}
+		}
+	}
+	// Bare record line.
+	return tryRecord(line)
+}
+
+// readMuseSessionMetadata returns the FIRST metadata record in a session
+// log (workspace binding is written at session start) without reading the
+// whole file: it streams lines and stops at the first hit.
+func readMuseSessionMetadata(sessionFile string) *museRecord {
+	data, err := os.ReadFile(sessionFile)
+	if err != nil {
+		return nil
+	}
+	// Lines are long (framed transactions); scan incrementally and stop at
+	// the first metadata line. A 64KB prefix covers the startup records in
+	// every observed log; fall back to the whole file past that.
+	const prefixLimit = 64 * 1024
+	text := string(data)
+	if len(text) > prefixLimit {
+		if rec := scanMuseMetadataPrefix(text[:prefixLimit]); rec != nil {
+			return rec
+		}
+	}
+	return scanMuseMetadataPrefix(text)
+}
+
+// scanMuseMetadataPrefix returns the first metadata record in text.
+func scanMuseMetadataPrefix(text string) *museRecord {
+	start := 0
+	for start < len(text) {
+		end := strings.IndexByte(text[start:], '\n')
+		var line string
+		if end < 0 {
+			line = text[start:]
+			start = len(text)
+		} else {
+			line = text[start : start+end]
+			start += end + 1
+		}
+		if rec := parseMuseMetadataLine(line); rec != nil {
+			return rec
+		}
+	}
+	return nil
+}
+
+// normalizeMuseWorkspace absolutizes and symlink-resolves a workspace path
+// for comparison: muse records the resolved path (/private/tmp/...), while
+// callers may hold the unresolved one (/tmp/...).
+func normalizeMuseWorkspace(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = real
+	}
+	return filepath.Clean(abs)
+}
+
+// ListMuseSessions scans the session store (newest files first, bounded)
+// and returns every session carrying a workspace binding.
+func ListMuseSessions() []MuseSessionInfo {
+	root := GetMuseSessionsRoot()
+	if root == "" {
+		return nil
+	}
+	type candidate struct {
+		path  string
+		mtime time.Time
+	}
+	var files []candidate
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Name() != "session.jsonl" {
+			return nil
+		}
+		if len(files) >= museDiscoveryMaxFiles {
+			return filepath.SkipAll
+		}
+		if info, err := d.Info(); err == nil {
+			files = append(files, candidate{path: path, mtime: info.ModTime()})
+		}
+		return nil
+	})
+	sort.Slice(files, func(a, b int) bool {
+		return files[a].mtime.After(files[b].mtime)
+	})
+
+	var out []MuseSessionInfo
+	for _, f := range files {
+		rec := readMuseSessionMetadata(f.path)
+		if rec == nil || rec.Stream.ID == "" {
+			continue
+		}
+		out = append(out, MuseSessionInfo{
+			SessionID:     rec.Stream.ID,
+			WorkspaceRoot: rec.Payload.Record.WorkspaceRoot,
+			ProviderID:    rec.Payload.Record.ProviderID,
+			LastUpdated:   f.mtime,
+		})
+	}
+	return out
+}
+
+// FindLatestMuseSession returns the newest session ID bound to workspace.
+// since bounds the scan when non-zero (file mtime must be newer than
+// since minus skew); zero since scans unbound. Returns "" when nothing
+// matches.
+func FindLatestMuseSession(workspace string, since time.Time) string {
+	want := normalizeMuseWorkspace(workspace)
+	if want == "" {
+		return ""
+	}
+	var bound time.Time
+	if !since.IsZero() {
+		bound = since.Add(-museDiscoverySkew)
+	}
+	for _, s := range ListMuseSessions() {
+		if normalizeMuseWorkspace(s.WorkspaceRoot) != want {
+			continue
+		}
+		if !bound.IsZero() && s.LastUpdated.Before(bound) {
+			continue
+		}
+		return s.SessionID
+	}
+	return ""
+}

--- a/internal/session/muse_discovery.go
+++ b/internal/session/muse_discovery.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bufio"
 	"encoding/json"
 	"io/fs"
 	"os"
@@ -123,44 +124,29 @@ func parseMuseMetadataLine(line string) *museRecord {
 }
 
 // readMuseSessionMetadata returns the FIRST metadata record in a session
-// log (workspace binding is written at session start) without reading the
-// whole file: it streams lines and stops at the first hit.
+// log (workspace binding is written at session start). It streams the file
+// line by line and stops at the first hit, so a multi-megabyte log costs
+// one short prefix read instead of a full load (os.ReadFile would load the
+// whole file before any prefix could apply).
 func readMuseSessionMetadata(sessionFile string) *museRecord {
-	data, err := os.ReadFile(sessionFile)
+	f, err := os.Open(sessionFile)
 	if err != nil {
 		return nil
 	}
-	// Lines are long (framed transactions); scan incrementally and stop at
-	// the first metadata line. A 64KB prefix covers the startup records in
-	// every observed log; fall back to the whole file past that.
-	const prefixLimit = 64 * 1024
-	text := string(data)
-	if len(text) > prefixLimit {
-		if rec := scanMuseMetadataPrefix(text[:prefixLimit]); rec != nil {
-			return rec
-		}
-	}
-	return scanMuseMetadataPrefix(text)
-}
-
-// scanMuseMetadataPrefix returns the first metadata record in text.
-func scanMuseMetadataPrefix(text string) *museRecord {
-	start := 0
-	for start < len(text) {
-		end := strings.IndexByte(text[start:], '\n')
-		var line string
-		if end < 0 {
-			line = text[start:]
-			start = len(text)
-		} else {
-			line = text[start : start+end]
-			start += end + 1
-		}
+	defer f.Close()
+	reader := bufio.NewReader(f)
+	for {
+		// ReadString grows past the default buffer for the very long
+		// framed-transaction lines; the final line without a newline is
+		// still returned alongside io.EOF and parsed below.
+		line, err := reader.ReadString('\n')
 		if rec := parseMuseMetadataLine(line); rec != nil {
 			return rec
 		}
+		if err != nil {
+			return nil
+		}
 	}
-	return nil
 }
 
 // normalizeMuseWorkspace absolutizes and symlink-resolves a workspace path
@@ -188,13 +174,14 @@ func ListMuseSessions() []MuseSessionInfo {
 		path  string
 		mtime time.Time
 	}
+	// Phase 1: gather candidates (paths + mtimes only, no file reads).
+	// Uncapped: gathering is cheap, and capping here would cut in lexical
+	// YYYY/MM/DD order (oldest first). The parse cap applies in phase 2
+	// after sorting newest-first.
 	var files []candidate
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || d.Name() != "session.jsonl" {
 			return nil
-		}
-		if len(files) >= museDiscoveryMaxFiles {
-			return filepath.SkipAll
 		}
 		if info, err := d.Info(); err == nil {
 			files = append(files, candidate{path: path, mtime: info.ModTime()})
@@ -206,7 +193,14 @@ func ListMuseSessions() []MuseSessionInfo {
 	})
 
 	var out []MuseSessionInfo
-	for _, f := range files {
+	for i, f := range files {
+		// Parse newest first and stop at the cap: gathering is cheap
+		// (paths + mtimes), parsing is not, so the limit applies here,
+		// never mid-walk where lexical YYYY/MM/DD order would cut the
+		// newest sessions first.
+		if i >= museDiscoveryMaxFiles {
+			break
+		}
 		rec := readMuseSessionMetadata(f.path)
 		if rec == nil || rec.Stream.ID == "" {
 			continue

--- a/internal/session/muse_discovery_test.go
+++ b/internal/session/muse_discovery_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -218,6 +219,36 @@ func TestFindLatestMuseSession_SinceBound(t *testing.T) {
 	if got := FindLatestMuseSession(ws, now.Add(-3*time.Hour)); got != "uuid-old" {
 		t.Errorf("bounded scan = %q, want uuid-old", got)
 	}
+}
+
+func TestFindLatestMuseSession_OverCapFindsNewest(t *testing.T) {
+	root := withMuseFixtureRoot(t)
+	old := time.Now().Add(-48 * time.Hour)
+	wsOld := filepath.Join(root, "oldproj")
+	wsNew := filepath.Join(root, "newproj")
+	if err := os.MkdirAll(wsOld, 0o755); err != nil {
+		t.Fatalf("mkdir ws: %v", err)
+	}
+	if err := os.MkdirAll(wsNew, 0o755); err != nil {
+		t.Fatalf("mkdir ws: %v", err)
+	}
+	// More sessions than museDiscoveryMaxFiles, all lexically BEFORE the
+	// newest UUID: a lexical-order cap would cut the newest session off.
+	for i := 0; i < museDiscoveryMaxFiles+5; i++ {
+		writeMuseFixtureSession(t, root, "aaa-"+padMuseTestNum(i), wsOld, "echo", old)
+	}
+	// Lexically last, newest by mtime: must still be found.
+	writeMuseFixtureSession(t, root, "zzz-newest", wsNew, "echo", time.Now())
+	if got := FindLatestMuseSession(wsNew, time.Time{}); got != "zzz-newest" {
+		t.Errorf("over-cap scan = %q, want zzz-newest", got)
+	}
+	if got := FindLatestMuseSession(wsOld, time.Time{}); got == "" || got == "zzz-newest" {
+		t.Errorf("over-cap scan for old ws = %q, want one of the old sessions", got)
+	}
+}
+
+func padMuseTestNum(i int) string {
+	return fmt.Sprintf("%04d", i)
 }
 
 func TestFindLatestMuseSession_SymlinkResolved(t *testing.T) {

--- a/internal/session/muse_discovery_test.go
+++ b/internal/session/muse_discovery_test.go
@@ -1,0 +1,238 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Muse session discovery tests. Fixtures mirror the real store shape
+// (<root>/YYYY/MM/DD/<uuid>/session.jsonl with framed + bare records),
+// built with encoding/json so the escaping matches production logs.
+
+// writeMuseFixtureSession writes one fixture session log and stamps its
+// mtime. metaWS/metaProvider describe the metadata record; when metaWS is
+// empty no metadata record is written (negative fixture).
+func writeMuseFixtureSession(t *testing.T, root, uuid, metaWS, metaProvider string, mtime time.Time) {
+	t.Helper()
+	dir := filepath.Join(root, "2026", "09", "02", uuid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	var lines []string
+	// A non-metadata framed line first (permission transaction shape).
+	permInner, _ := json.Marshal(map[string]any{
+		"schema_version": 1,
+		"stream":         map[string]any{"kind": "session", "id": uuid},
+		"record_type":    "event",
+		"payload_type":   "runtime.session.permission_format_declared",
+		"payload":        map[string]any{"format": "profile_v1"},
+	})
+	frame, _ := json.Marshal(map[string]any{
+		"retained_frame":       "session_permission_transaction",
+		"frame_schema_version": 1,
+		"outer_log_ordinal":    1,
+		"transaction_id":       "frame-1",
+		"children":             []any{map[string]any{"child_index": 0, "record_json": string(permInner)}},
+	})
+	lines = append(lines, string(frame))
+	if metaWS != "" {
+		metaInner, _ := json.Marshal(map[string]any{
+			"schema_version": 1,
+			"stream":         map[string]any{"kind": "session", "id": uuid},
+			"recorded_at":    1788381840883708,
+			"record_type":    "event",
+			"payload_type":   "runtime.session.metadata",
+			"payload": map[string]any{
+				"kind": "metadata",
+				"record": map[string]any{
+					"workspace_root": metaWS,
+					"provider_id":    metaProvider,
+				},
+			},
+		})
+		metaFrame, _ := json.Marshal(map[string]any{
+			"retained_frame":       "session_metadata",
+			"frame_schema_version": 1,
+			"outer_log_ordinal":    2,
+			"transaction_id":       "frame-2",
+			"children":             []any{map[string]any{"child_index": 0, "record_json": string(metaInner)}},
+		})
+		lines = append(lines, string(metaFrame))
+	}
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes fixture: %v", err)
+	}
+}
+
+// withMuseFixtureRoot redirects discovery at a temp store for one test.
+func withMuseFixtureRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	old := museSessionsRootOverride
+	museSessionsRootOverride = root
+	t.Cleanup(func() { museSessionsRootOverride = old })
+	return root
+}
+
+func TestParseMuseMetadataLine_Framed(t *testing.T) {
+	root := withMuseFixtureRoot(t)
+	writeMuseFixtureSession(t, root, "uuid-1", "/ws/proj", "echo", time.Now())
+	data, err := os.ReadFile(filepath.Join(root, "2026", "09", "02", "uuid-1", "session.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	lines := splitMuseTestLines(string(data))
+	if len(lines) != 2 {
+		t.Fatalf("fixture has %d lines, want 2", len(lines))
+	}
+	if rec := parseMuseMetadataLine(lines[0]); rec != nil {
+		t.Errorf("permission line parsed as metadata: %+v", rec)
+	}
+	rec := parseMuseMetadataLine(lines[1])
+	if rec == nil {
+		t.Fatal("metadata line returned nil")
+	}
+	if rec.Stream.ID != "uuid-1" {
+		t.Errorf("stream id = %q, want uuid-1", rec.Stream.ID)
+	}
+	if rec.Payload.Record.WorkspaceRoot != "/ws/proj" {
+		t.Errorf("workspace = %q, want /ws/proj", rec.Payload.Record.WorkspaceRoot)
+	}
+	if rec.Payload.Record.ProviderID != "echo" {
+		t.Errorf("provider = %q, want echo", rec.Payload.Record.ProviderID)
+	}
+}
+
+func splitMuseTestLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return out
+}
+
+func TestParseMuseMetadataLine_BareRecord(t *testing.T) {
+	inner, _ := json.Marshal(map[string]any{
+		"stream":       map[string]any{"kind": "session", "id": "uuid-bare"},
+		"payload_type": "runtime.session.metadata",
+		"payload": map[string]any{
+			"record": map[string]any{"workspace_root": "/ws/bare"},
+		},
+	})
+	rec := parseMuseMetadataLine(string(inner))
+	if rec == nil {
+		t.Fatal("bare metadata record returned nil")
+	}
+	if rec.Payload.Record.WorkspaceRoot != "/ws/bare" {
+		t.Errorf("workspace = %q, want /ws/bare", rec.Payload.Record.WorkspaceRoot)
+	}
+}
+
+func TestParseMuseMetadataLine_Miss(t *testing.T) {
+	for _, line := range []string{"", "not json", `{"a":1}`, `{"payload_type":"other"}`} {
+		if rec := parseMuseMetadataLine(line); rec != nil {
+			t.Errorf("line %q parsed as metadata: %+v", line, rec)
+		}
+	}
+}
+
+func TestListMuseSessions(t *testing.T) {
+	root := withMuseFixtureRoot(t)
+	now := time.Now()
+	writeMuseFixtureSession(t, root, "uuid-a", "/ws/a", "echo", now.Add(-time.Hour))
+	writeMuseFixtureSession(t, root, "uuid-b", "/ws/b", "meta", now)
+	writeMuseFixtureSession(t, root, "uuid-nometa", "", "", now)
+
+	sessions := ListMuseSessions()
+	if len(sessions) != 2 {
+		t.Fatalf("listed %d sessions, want 2 (metadata-less excluded)", len(sessions))
+	}
+	// Newest first.
+	if sessions[0].SessionID != "uuid-b" {
+		t.Errorf("first = %q, want uuid-b (newest)", sessions[0].SessionID)
+	}
+	if sessions[1].WorkspaceRoot != "/ws/a" || sessions[1].ProviderID != "echo" {
+		t.Errorf("second = %+v, want /ws/a echo", sessions[1])
+	}
+}
+
+func TestListMuseSessions_MissingRoot(t *testing.T) {
+	withMuseFixtureRoot(t)
+	museSessionsRootOverride = filepath.Join(t.TempDir(), "does-not-exist")
+	if got := ListMuseSessions(); len(got) != 0 {
+		t.Errorf("missing root listed %d sessions, want 0", len(got))
+	}
+}
+
+func TestFindLatestMuseSession(t *testing.T) {
+	root := withMuseFixtureRoot(t)
+	now := time.Now()
+	ws := filepath.Join(root, "proj")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir ws: %v", err)
+	}
+	writeMuseFixtureSession(t, root, "uuid-old", ws, "echo", now.Add(-2*time.Hour))
+	writeMuseFixtureSession(t, root, "uuid-new", ws, "echo", now.Add(-time.Hour))
+	writeMuseFixtureSession(t, root, "uuid-other", filepath.Join(root, "other"), "echo", now)
+
+	if got := FindLatestMuseSession(ws, time.Time{}); got != "uuid-new" {
+		t.Errorf("latest = %q, want uuid-new", got)
+	}
+	if got := FindLatestMuseSession(filepath.Join(root, "other"), time.Time{}); got != "uuid-other" {
+		t.Errorf("other ws = %q, want uuid-other", got)
+	}
+	if got := FindLatestMuseSession(filepath.Join(root, "missing"), time.Time{}); got != "" {
+		t.Errorf("missing ws = %q, want empty", got)
+	}
+}
+
+func TestFindLatestMuseSession_SinceBound(t *testing.T) {
+	root := withMuseFixtureRoot(t)
+	now := time.Now()
+	ws := filepath.Join(root, "proj")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir ws: %v", err)
+	}
+	writeMuseFixtureSession(t, root, "uuid-old", ws, "echo", now.Add(-2*time.Hour))
+
+	// Bound after the session: excluded.
+	if got := FindLatestMuseSession(ws, now); got != "" {
+		t.Errorf("bounded scan = %q, want empty", got)
+	}
+	// Bound before the session: included.
+	if got := FindLatestMuseSession(ws, now.Add(-3*time.Hour)); got != "uuid-old" {
+		t.Errorf("bounded scan = %q, want uuid-old", got)
+	}
+}
+
+func TestFindLatestMuseSession_SymlinkResolved(t *testing.T) {
+	root := withMuseFixtureRoot(t)
+	realWS := filepath.Join(root, "realproj")
+	if err := os.MkdirAll(realWS, 0o755); err != nil {
+		t.Fatalf("mkdir ws: %v", err)
+	}
+	linkWS := filepath.Join(root, "linkproj")
+	if err := os.Symlink(realWS, linkWS); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Fixture records the resolved path (as muse does); query via symlink.
+	writeMuseFixtureSession(t, root, "uuid-link", realWS, "echo", time.Now())
+	if got := FindLatestMuseSession(linkWS, time.Time{}); got != "uuid-link" {
+		t.Errorf("symlink query = %q, want uuid-link", got)
+	}
+}

--- a/internal/session/muse_resume_argument_test.go
+++ b/internal/session/muse_resume_argument_test.go
@@ -14,10 +14,6 @@ func TestMuseResumePreservesLiteralArgument(t *testing.T) {
 	old := userConfigCache
 	userConfigCache = &UserConfig{Muse: MuseSettings{YoloMode: true}}
 	t.Cleanup(func() { userConfigCache = old })
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, id := range []string{"sess-uuid-1", "two words", "owner's-session", "literal$MUSE_LITERAL", "line\nbreak", "unicode-日本"} {
 		for _, custom := range []bool{false, true} {
 			t.Run(id+"/custom="+map[bool]string{false: "false", true: "true"}[custom], func(t *testing.T) {
@@ -27,25 +23,85 @@ func TestMuseResumePreservesLiteralArgument(t *testing.T) {
 					inst.Command = "muse --provider fixture"
 					want = []string{"--provider", "fixture", "resume", id}
 				}
-				// The only executable is bash. Its muse function prints arguments; no
-				// actual provider, login initialization, tmux or network is involved.
-				script := "muse() { printf '%s\\0' \"$@\"; }; " + inst.buildMuseResumeCommand(id)
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", script)
-				cmd.Env = []string{"PATH=/usr/bin:/bin", "HOME=" + t.TempDir(), "MUSE_LITERAL=expanded"}
-				cmd.Dir = t.TempDir()
-				var stderr bytes.Buffer
-				cmd.Stderr = &stderr
-				out, err := cmd.Output()
-				if err != nil {
-					t.Fatalf("argument fixture failed: %v stderr=%q", err, stderr.String())
-				}
-				got := strings.Split(strings.TrimSuffix(string(out), "\x00"), "\x00")
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("argv=%q, want %q", got, want)
-				}
+				assertMuseCommandArguments(t, inst.buildMuseResumeCommand(id), want)
 			})
 		}
+	}
+}
+
+func TestMuseTrustPolicyArguments(t *testing.T) {
+	yoloFalse := false
+	cases := []struct {
+		name        string
+		settings    MuseSettings
+		sessionYolo *bool
+		wantFresh   []string
+	}{
+		{
+			name:      "default trust without yolo",
+			wantFresh: []string{"--trust-workspace"},
+		},
+		{
+			name:      "bare configured command opts out of trust",
+			settings:  MuseSettings{Command: "muse"},
+			wantFresh: []string{},
+		},
+		{
+			name:        "explicit session false overrides global yolo",
+			settings:    MuseSettings{YoloMode: true},
+			sessionYolo: &yoloFalse,
+			wantFresh:   []string{"--trust-workspace"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := userConfigCache
+			userConfigCache = &UserConfig{Muse: tc.settings}
+			t.Cleanup(func() { userConfigCache = old })
+			inst := &Instance{Tool: "muse", Command: "muse"}
+			if tc.sessionYolo != nil {
+				opts, err := MarshalToolOptions(&MuseOptions{YoloMode: tc.sessionYolo})
+				if err != nil {
+					t.Fatal(err)
+				}
+				inst.ToolOptionsJSON = opts
+			}
+			t.Run("fresh", func(t *testing.T) {
+				assertMuseCommandArguments(t, inst.buildMuseCommand(inst.Command), tc.wantFresh)
+			})
+			t.Run("resume", func(t *testing.T) {
+				want := append(append([]string{}, tc.wantFresh...), "resume", "session-id")
+				assertMuseCommandArguments(t, inst.buildMuseResumeCommand("session-id"), want)
+			})
+		})
+	}
+}
+
+func assertMuseCommandArguments(t *testing.T, command string, want []string) {
+	t.Helper()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only bash executes. The muse function prints each argument, including an
+	// empty argument, but emits nothing for a bare command with no arguments.
+	script := "muse() { for arg in \"$@\"; do printf '%s\\0' \"$arg\"; done; }; " + command
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", script)
+	cmd.Env = []string{"PATH=/usr/bin:/bin", "HOME=" + t.TempDir(), "MUSE_LITERAL=expanded"}
+	cmd.Dir = t.TempDir()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("argument fixture failed: %v stderr=%q", err, stderr.String())
+	}
+	got := []string{}
+	if len(out) > 0 {
+		got = strings.Split(strings.TrimSuffix(string(out), "\x00"), "\x00")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("argv=%q, want %q", got, want)
 	}
 }

--- a/internal/session/muse_resume_argument_test.go
+++ b/internal/session/muse_resume_argument_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMuseResumePreservesLiteralArgument(t *testing.T) {
+	old := userConfigCache
+	userConfigCache = &UserConfig{Muse: MuseSettings{YoloMode: true}}
+	t.Cleanup(func() { userConfigCache = old })
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"sess-uuid-1", "two words", "owner's-session", "literal$MUSE_LITERAL", "line\nbreak", "unicode-日本"} {
+		for _, custom := range []bool{false, true} {
+			t.Run(id+"/custom="+map[bool]string{false: "false", true: "true"}[custom], func(t *testing.T) {
+				inst := &Instance{Tool: "muse", Command: "muse"}
+				want := []string{"--trust-workspace", "resume", id, "--yolo"}
+				if custom {
+					inst.Command = "muse --provider fixture"
+					want = []string{"--provider", "fixture", "resume", id}
+				}
+				// The only executable is bash. Its muse function prints arguments; no
+				// actual provider, login initialization, tmux or network is involved.
+				script := "muse() { printf '%s\\0' \"$@\"; }; " + inst.buildMuseResumeCommand(id)
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", script)
+				cmd.Env = []string{"PATH=/usr/bin:/bin", "HOME=" + t.TempDir(), "MUSE_LITERAL=expanded"}
+				cmd.Dir = t.TempDir()
+				var stderr bytes.Buffer
+				cmd.Stderr = &stderr
+				out, err := cmd.Output()
+				if err != nil {
+					t.Fatalf("argument fixture failed: %v stderr=%q", err, stderr.String())
+				}
+				got := strings.Split(strings.TrimSuffix(string(out), "\x00"), "\x00")
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("argv=%q, want %q", got, want)
+				}
+			})
+		}
+	}
+}

--- a/internal/session/muse_test.go
+++ b/internal/session/muse_test.go
@@ -369,6 +369,29 @@ func TestBuildMuseResumeCommand_WrongTool(t *testing.T) {
 	}
 }
 
+func TestBuildMuseResumeCommand_CustomCommandPreserved(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{YoloMode: true},
+	}
+
+	// A session launched with a custom invocation (wrapper/provider flags)
+	// must resume through it, verbatim: no default substitution and no
+	// flag injection, mirroring the fresh passthrough path.
+	inst := &Instance{Tool: "muse", Command: "muse --provider echo"}
+	cmd := inst.buildMuseResumeCommand("sess-uuid-1")
+	if !strings.HasSuffix(cmd, "muse --provider echo resume sess-uuid-1") {
+		t.Errorf("buildMuseResumeCommand() = %q, want custom command preserved with resume suffix", cmd)
+	}
+	if strings.Contains(cmd, "--yolo") {
+		t.Errorf("passthrough resume must not inject --yolo, got %q", cmd)
+	}
+	if strings.Contains(cmd, "--trust-workspace") {
+		t.Errorf("custom base must replace the default wholesale, got %q", cmd)
+	}
+}
+
 func TestGetToolEnvFile_Muse(t *testing.T) {
 	oldCache := userConfigCache
 	defer func() { userConfigCache = oldCache }()
@@ -385,9 +408,36 @@ func TestGetToolEnvFile_Muse(t *testing.T) {
 
 func TestMatchTool_Muse(t *testing.T) {
 	r := Init(nil)
-	for _, cmd := range []string{"muse", "muse --trust-workspace", "muse --yolo", "MUSE"} {
+	for _, cmd := range []string{
+		"muse",
+		"muse --trust-workspace",
+		"muse --yolo",
+		"MUSE",
+		"muse resume 01a063dd-45dd-7402-b516-4346e923db3e",
+		"/usr/local/bin/muse",
+		"/usr/local/bin/muse --trust-workspace",
+	} {
 		if got := r.Match(cmd); got != "muse" {
 			t.Errorf("Match(%q) = %q, want %q", cmd, got, "muse")
+		}
+	}
+}
+
+func TestMatchTool_Muse_Negative(t *testing.T) {
+	// Executable-position match only: the name must lead the command.
+	r := Init(nil)
+	for _, cmd := range []string{
+		"echo muse",
+		"amuse",
+		"echo museum",
+		"git -C /tmp/muse-project status",
+		// Non-leading occurrences fail closed, even for wrappers: only
+		// the executable slot classifies.
+		"my-wrapper muse --flag",
+		"my-wrapper muse",
+	} {
+		if got := r.Match(cmd); got == "muse" {
+			t.Errorf("Match(%q) = %q, should NOT match muse", cmd, got)
 		}
 	}
 }

--- a/internal/session/muse_test.go
+++ b/internal/session/muse_test.go
@@ -1,0 +1,393 @@
+package session
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Muse Code CLI support (Meta's `muse` binary, "Muse Code" TUI).
+// These tests define the Tool="muse" contract: options marshalling,
+// ToArgs for yolo, factory from config, launch-command building with the
+// empirically required --trust-workspace default, and the basic identity
+// gates (icon, IsClaudeCompatible, builtin-name filter).
+//
+// Binary: `muse`. Interactive TUI.
+// Key flags: --trust-workspace, --yolo, --provider, --model.
+// Resume: `muse resume <uuid>` subcommand (wired in a follow-up).
+//
+// Launch evidence (captured live from Muse Code 1.0.2 in a tmux pane):
+//   - bare `muse` blocks on "Do you trust this workspace?" in a fresh dir,
+//     so the default command carries --trust-workspace.
+//   - idle prompt: `⟩` + "Type @ to search and insert workspace file paths".
+//   - busy: `◈ Thinking (Ns · esc to interrupt)`.
+//   - assistant message marker: `◆`.
+//   - status bar: `<provider> · /abs/path`.
+
+func TestMuseOptions_ToolName(t *testing.T) {
+	opts := &MuseOptions{}
+	if got := opts.ToolName(); got != "muse" {
+		t.Errorf("MuseOptions.ToolName() = %q, want %q", got, "muse")
+	}
+}
+
+func TestMuseOptions_ToArgs(t *testing.T) {
+	yoloTrue := true
+	yoloFalse := false
+
+	tests := []struct {
+		name     string
+		opts     MuseOptions
+		expected []string
+	}{
+		{
+			name:     "default - no args",
+			opts:     MuseOptions{},
+			expected: nil,
+		},
+		{
+			name:     "yolo nil - no args",
+			opts:     MuseOptions{YoloMode: nil},
+			expected: nil,
+		},
+		{
+			name:     "yolo false - no args",
+			opts:     MuseOptions{YoloMode: &yoloFalse},
+			expected: nil,
+		},
+		{
+			name:     "yolo true - --yolo present",
+			opts:     MuseOptions{YoloMode: &yoloTrue},
+			expected: []string{"--yolo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.ToArgs()
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ToArgs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewMuseOptions_Defaults(t *testing.T) {
+	opts := NewMuseOptions(nil)
+	if opts == nil {
+		t.Fatal("NewMuseOptions(nil) returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("default YoloMode = %v, want nil", opts.YoloMode)
+	}
+}
+
+func TestNewMuseOptions_WithYoloConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Muse: MuseSettings{YoloMode: true},
+	}
+	opts := NewMuseOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewMuseOptions returned nil")
+	}
+	if opts.YoloMode == nil || !*opts.YoloMode {
+		t.Errorf("YoloMode = %v, want true", opts.YoloMode)
+	}
+}
+
+func TestNewMuseOptions_WithoutYoloConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Muse: MuseSettings{YoloMode: false},
+	}
+	opts := NewMuseOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewMuseOptions returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("YoloMode = %v, want nil (not set when config is false)", opts.YoloMode)
+	}
+}
+
+func TestMuseOptions_MarshalUnmarshalRoundtrip(t *testing.T) {
+	yolo := true
+	orig := &MuseOptions{YoloMode: &yolo}
+
+	data, err := MarshalToolOptions(orig)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+	if wrapper.Tool != "muse" {
+		t.Errorf("wrapper.Tool = %q, want %q", wrapper.Tool, "muse")
+	}
+
+	got, err := UnmarshalMuseOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalMuseOptions: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UnmarshalMuseOptions returned nil")
+	}
+	if got.YoloMode == nil || !*got.YoloMode {
+		t.Errorf("roundtrip YoloMode = %v, want true", got.YoloMode)
+	}
+}
+
+func TestUnmarshalMuseOptions_WrongTool(t *testing.T) {
+	raw := json.RawMessage(`{"tool":"codex","options":{}}`)
+	got, err := UnmarshalMuseOptions(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalMuseOptions: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for wrong tool, got %+v", got)
+	}
+}
+
+func TestIsClaudeCompatible_MuseNotCompatible(t *testing.T) {
+	if IsClaudeCompatible("muse") {
+		t.Error("IsClaudeCompatible(\"muse\") must be false")
+	}
+}
+
+func TestGetToolIcon_Muse(t *testing.T) {
+	icon := GetToolIcon("muse")
+	if icon == "" {
+		t.Error("GetToolIcon(\"muse\") returned empty")
+	}
+	if icon == GetToolIcon("shell") {
+		t.Errorf("GetToolIcon(\"muse\") = %q equals shell fallback (want a distinct icon)", icon)
+	}
+}
+
+func TestGetCustomToolNames_MuseIsBuiltin(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+
+	userConfigCache = &UserConfig{
+		Tools: map[string]ToolDef{
+			"muse":       {Command: "muse"},
+			"my-wrapper": {Command: "claude"},
+		},
+	}
+
+	names := GetCustomToolNames()
+	for _, n := range names {
+		if n == "muse" {
+			t.Errorf("GetCustomToolNames() returned %q as custom; muse is built-in", n)
+		}
+	}
+}
+
+func TestNewInstanceWithTool_Muse(t *testing.T) {
+	inst := NewInstanceWithTool("muse-test", "/tmp/muse-test-proj", "muse")
+	if inst == nil {
+		t.Fatal("NewInstanceWithTool returned nil")
+	}
+	if inst.Tool != "muse" {
+		t.Errorf("inst.Tool = %q, want %q", inst.Tool, "muse")
+	}
+}
+
+func TestGetMuseCommand_Default(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	// Bare muse blocks on the workspace-trust prompt in a fresh directory
+	// (captured live), so the default carries --trust-workspace.
+	if got := GetMuseCommand(); got != "muse --trust-workspace" {
+		t.Errorf("GetMuseCommand() = %q, want %q", got, "muse --trust-workspace")
+	}
+}
+
+func TestGetMuseCommand_Override(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{Command: "muse --provider echo"},
+	}
+
+	if got := GetMuseCommand(); got != "muse --provider echo" {
+		t.Errorf("GetMuseCommand() = %q, want override", got)
+	}
+}
+
+func TestBuildMuseCommand_BareName(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "muse"}
+	cmd := inst.buildMuseCommand("muse")
+	if cmd == "" {
+		t.Fatal("buildMuseCommand(\"muse\") returned empty")
+	}
+	if !strings.HasSuffix(cmd, "muse --trust-workspace") {
+		t.Errorf("buildMuseCommand(\"muse\") = %q, want suffix %q", cmd, "muse --trust-workspace")
+	}
+}
+
+func TestBuildMuseCommand_YoloFromConfig(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{YoloMode: true},
+	}
+
+	inst := &Instance{Tool: "muse"}
+	cmd := inst.buildMuseCommand("muse")
+	if !strings.HasSuffix(cmd, "muse --trust-workspace --yolo") {
+		t.Errorf("buildMuseCommand() = %q, want suffix %q", cmd, "muse --trust-workspace --yolo")
+	}
+}
+
+func TestBuildMuseCommand_YoloFromOptions(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	yolo := true
+	opts, err := MarshalToolOptions(&MuseOptions{YoloMode: &yolo})
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	inst := &Instance{Tool: "muse", ToolOptionsJSON: opts}
+	cmd := inst.buildMuseCommand("muse")
+	if !strings.HasSuffix(cmd, "muse --trust-workspace --yolo") {
+		t.Errorf("buildMuseCommand() = %q, want suffix %q", cmd, "muse --trust-workspace --yolo")
+	}
+}
+
+func TestBuildMuseCommand_CommandOverride(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{Command: "muse --provider echo"},
+	}
+
+	inst := &Instance{Tool: "muse"}
+	cmd := inst.buildMuseCommand("muse")
+	if !strings.HasSuffix(cmd, "muse --provider echo") {
+		t.Errorf("buildMuseCommand() = %q, want suffix %q", cmd, "muse --provider echo")
+	}
+}
+
+func TestBuildMuseCommand_Passthrough(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "muse"}
+	got := inst.buildMuseCommand("muse --provider echo")
+	if !strings.HasSuffix(got, "muse --provider echo") {
+		t.Errorf("buildMuseCommand passthrough = %q, want suffix %q", got, "muse --provider echo")
+	}
+}
+
+func TestBuildMuseCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	got := inst.buildMuseCommand("anything")
+	if got != "anything" {
+		t.Errorf("buildMuseCommand with wrong tool = %q, want %q", got, "anything")
+	}
+}
+
+func TestBuildMuseResumeCommand(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "muse", Command: "muse"}
+	cmd := inst.buildMuseResumeCommand("sess-uuid-1")
+	if !strings.HasSuffix(cmd, "muse --trust-workspace resume sess-uuid-1") {
+		t.Errorf("buildMuseResumeCommand() = %q, want suffix %q", cmd, "muse --trust-workspace resume sess-uuid-1")
+	}
+}
+
+func TestBuildMuseResumeCommand_Yolo(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{YoloMode: true},
+	}
+
+	inst := &Instance{Tool: "muse", Command: "muse"}
+	cmd := inst.buildMuseResumeCommand("sess-uuid-1")
+	if !strings.HasSuffix(cmd, "muse --trust-workspace resume sess-uuid-1 --yolo") {
+		t.Errorf("buildMuseResumeCommand() = %q, want yolo suffix", cmd)
+	}
+}
+
+func TestBuildMuseResumeCommand_ExplicitYoloFalseBeatsConfig(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{YoloMode: true},
+	}
+
+	yolo := false
+	opts, err := MarshalToolOptions(&MuseOptions{YoloMode: &yolo})
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+	inst := &Instance{Tool: "muse", Command: "muse", ToolOptionsJSON: opts}
+	cmd := inst.buildMuseResumeCommand("sess-uuid-1")
+	if strings.Contains(cmd, "--yolo") {
+		t.Errorf("explicit yolo=false must suppress config yolo, got %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "resume sess-uuid-1") {
+		t.Errorf("buildMuseResumeCommand() = %q, want resume suffix", cmd)
+	}
+}
+
+func TestBuildMuseResumeCommand_EmptyIDFallsBackToFresh(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "muse", Command: "muse"}
+	cmd := inst.buildMuseResumeCommand("  ")
+	if strings.Contains(cmd, "resume") {
+		t.Errorf("empty session id must not emit resume, got %q", cmd)
+	}
+	if !strings.HasSuffix(cmd, "muse --trust-workspace") {
+		t.Errorf("empty session id must boot fresh, got %q", cmd)
+	}
+}
+
+func TestBuildMuseResumeCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	if got := inst.buildMuseResumeCommand("sess-uuid-1"); got != "" {
+		t.Errorf("buildMuseResumeCommand with wrong tool = %q, want empty", got)
+	}
+}
+
+func TestGetToolEnvFile_Muse(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{EnvFile: "/tmp/muse.env"},
+	}
+
+	inst := &Instance{Tool: "muse"}
+	got := inst.getToolEnvFile()
+	if got != "/tmp/muse.env" {
+		t.Errorf("getToolEnvFile() for muse = %q, want %q", got, "/tmp/muse.env")
+	}
+}
+
+func TestMatchTool_Muse(t *testing.T) {
+	r := Init(nil)
+	for _, cmd := range []string{"muse", "muse --trust-workspace", "muse --yolo", "MUSE"} {
+		if got := r.Match(cmd); got != "muse" {
+			t.Errorf("Match(%q) = %q, want %q", cmd, got, "muse")
+		}
+	}
+}

--- a/internal/session/muse_test.go
+++ b/internal/session/muse_test.go
@@ -347,6 +347,28 @@ func TestBuildMuseResumeCommand_ExplicitYoloFalseBeatsConfig(t *testing.T) {
 	}
 }
 
+func TestBuildMuseCommand_NilYoloInheritsConfig(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Muse: MuseSettings{YoloMode: true},
+	}
+
+	// A serialized default (YoloMode nil) is not a choice: the global
+	// config applies instead of being silently dropped.
+	opts, err := MarshalToolOptions(&MuseOptions{})
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+	inst := &Instance{Tool: "muse", Command: "muse", ToolOptionsJSON: opts}
+	if cmd := inst.buildMuseCommand("muse"); !strings.HasSuffix(cmd, "muse --trust-workspace --yolo") {
+		t.Errorf("nil YoloMode must inherit config yolo, got %q", cmd)
+	}
+	if cmd := inst.buildMuseResumeCommand("sess-uuid-1"); !strings.HasSuffix(cmd, "resume sess-uuid-1 --yolo") {
+		t.Errorf("nil YoloMode must inherit config yolo on resume, got %q", cmd)
+	}
+}
+
 func TestBuildMuseResumeCommand_EmptyIDFallsBackToFresh(t *testing.T) {
 	oldCache := userConfigCache
 	defer func() { userConfigCache = oldCache }()

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -469,6 +469,64 @@ func UnmarshalCrushOptions(data json.RawMessage) (*CrushOptions, error) {
 	return &opts, nil
 }
 
+// MuseOptions holds launch options for Muse Code CLI sessions.
+// Binary: `muse`. Interactive TUI.
+// Session resume (`muse resume <uuid>`) is a subcommand, not a flag, so it
+// is built by buildMuseResumeCommand in muse.go, not expressed here.
+type MuseOptions struct {
+	// YoloMode enables --yolo flag (disable approval + sandboxing and
+	// trust the workspace for the run).
+	// nil = inherit from config, true/false = explicit override.
+	YoloMode *bool `json:"yolo_mode,omitempty"`
+}
+
+// ToolName returns "muse"
+func (o *MuseOptions) ToolName() string {
+	return "muse"
+}
+
+// ToArgs returns command-line arguments based on options.
+func (o *MuseOptions) ToArgs() []string {
+	var args []string
+	if o.YoloMode != nil && *o.YoloMode {
+		args = append(args, "--yolo")
+	}
+	return args
+}
+
+// NewMuseOptions creates MuseOptions with defaults from global config.
+func NewMuseOptions(config *UserConfig) *MuseOptions {
+	opts := &MuseOptions{}
+	if config != nil && config.Muse.YoloMode {
+		yolo := true
+		opts.YoloMode = &yolo
+	}
+	return opts
+}
+
+// UnmarshalMuseOptions deserializes MuseOptions from JSON wrapper.
+func UnmarshalMuseOptions(data json.RawMessage) (*MuseOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	if wrapper.Tool != "muse" {
+		return nil, nil
+	}
+
+	var opts MuseOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
 // StripResumeFields removes session-specific fields (resume_session_id,
 // session_mode) from serialized ToolOptionsJSON so that a new session
 // inheriting another session's settings starts fresh instead of resuming

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -259,6 +259,15 @@ func (r *Registry) Match(cmd string) string {
 		// position gets basename treatment — argument paths such as
 		// "copilot --cwd /home/pi" must not flip detection.
 		for _, tok := range bt.detectTokens {
+			// executableOnly tools (muse) match solely on the executable
+			// slot: `echo muse` must not classify. All other tools keep
+			// the legacy whole-line token match.
+			if bt.executableOnly {
+				if exe != "" && exe == tok {
+					return name
+				}
+				continue
+			}
 			if slices.Contains(fields, tok) || exe == tok {
 				return name
 			}

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -9,7 +9,7 @@ import (
 // Registry.Match() (and the legacy detectTool() switch) walk.
 var canonicalBuiltins = []string{
 	"claude", "opencode", "gemini", "codex", "pi",
-	"copilot", "crush", "cursor", "hermes", "deepseek", "aider", "shell",
+	"copilot", "crush", "muse", "cursor", "hermes", "deepseek", "aider", "shell",
 }
 
 func TestRegistry_AllReturnsCanonicalBuiltins(t *testing.T) {
@@ -56,6 +56,9 @@ func TestRegistry_MatchAllBranches(t *testing.T) {
 		{"copilot with flags", "copilot --resume", "copilot"},
 		// crush
 		{"crush bare", "crush", "crush"},
+		// muse
+		{"muse bare", "muse", "muse"},
+		{"muse with trust flag", "muse --trust-workspace", "muse"},
 		// cursor
 		{"cursor agent subcommand", "cursor agent", "cursor"},
 		{"standalone agent binary", "agent", "cursor"},

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -59,6 +59,8 @@ func TestRegistry_MatchAllBranches(t *testing.T) {
 		// muse
 		{"muse bare", "muse", "muse"},
 		{"muse with trust flag", "muse --trust-workspace", "muse"},
+		{"muse no match echo", "echo muse", "shell"},
+		{"muse no match museum", "museum visit", "shell"},
 		// cursor
 		{"cursor agent subcommand", "cursor agent", "cursor"},
 		{"standalone agent binary", "agent", "cursor"},

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -152,6 +152,9 @@ type UserConfig struct {
 	// Crush defines charmbracelet/crush CLI integration settings (Issue #940)
 	Crush CrushSettings `toml:"crush,omitempty"`
 
+	// Muse defines Muse Code CLI integration settings
+	Muse MuseSettings `toml:"muse,omitempty"`
+
 	// Hermes defines Hermes Agent CLI integration settings
 	Hermes HermesSettings `toml:"hermes,omitempty"`
 
@@ -2213,6 +2216,29 @@ type CrushSettings struct {
 	YoloMode bool `toml:"yolo_mode,omitempty"`
 }
 
+// MuseSettings defines Muse Code CLI configuration.
+// Binary: `muse`. Interactive TUI.
+// Key flags: --trust-workspace, --yolo, --provider, --model.
+// Resume is a subcommand (`muse resume <uuid>`), wired in a follow-up.
+type MuseSettings struct {
+	// Command overrides the default invocation for Muse sessions.
+	// Supports flags (e.g., "muse --provider echo"). Replaces the default
+	// "muse --trust-workspace" wholesale, so include --trust-workspace
+	// yourself if the override drops it: bare `muse` blocks on the
+	// workspace-trust prompt in a fresh directory.
+	Command string `toml:"command,omitempty"`
+
+	// EnvFile is a .env file specific to Muse sessions (sourced before
+	// the `muse` command runs, like [crush].env_file). Optional.
+	// Useful for provider credentials (e.g. a Meta API key): panes do not
+	// inherit interactive-shell exports.
+	EnvFile string `toml:"env_file,omitempty"`
+
+	// YoloMode enables --yolo flag for Muse sessions (disable approval +
+	// sandboxing and trust the workspace for the run). Default: false
+	YoloMode bool `toml:"yolo_mode,omitempty"`
+}
+
 // WorktreeSettings contains git worktree preferences.
 type WorktreeSettings struct {
 	// AutoCleanup: remove worktree when session is deleted (default: true, nil = true)
@@ -3749,6 +3775,8 @@ func GetToolIcon(toolName string) string {
 		return "🐙"
 	case "crush":
 		return "💘"
+	case "muse":
+		return "🔮"
 	case "cursor":
 		return "📝"
 	case "hermes":

--- a/internal/tmux/muse_test.go
+++ b/internal/tmux/muse_test.go
@@ -46,11 +46,15 @@ func TestDetectToolFromCommand_Muse_Negative(t *testing.T) {
 		name    string
 		command string
 	}{
-		// Truly unrelated strings — the strings.Contains fallback is
-		// intentionally permissive (matches the crush/copilot precedent),
-		// so only blatant false positives are guarded here.
+		// Token-position matching (not substring): English words and paths
+		// containing "muse" must not claim the pane.
 		{"empty", ""},
 		{"unrelated tool", "ls -la"},
+		{"echo muse", "echo muse"},
+		{"amuse", "amuse"},
+		{"museum", "echo museum"},
+		{"muse in path", "git -C /tmp/muse-project status"},
+		{"wrapper trailing bare muse fails closed", "my-wrapper muse"},
 	}
 
 	for _, tt := range tests {
@@ -60,6 +64,13 @@ func TestDetectToolFromCommand_Muse_Negative(t *testing.T) {
 				t.Fatalf("detectToolFromCommand(%q) = %q, should NOT match muse", tt.command, got)
 			}
 		})
+	}
+}
+
+func TestDetectToolFromCommand_Muse_Wrapper(t *testing.T) {
+	// Wrapper with trailing flags still resolves via the token arm.
+	if got := detectToolFromCommand("my-wrapper muse --trust-workspace"); got != "muse" {
+		t.Fatalf("detectToolFromCommand(wrapper) = %q, want muse", got)
 	}
 }
 
@@ -79,6 +90,19 @@ func TestDetectToolFromContent_Muse(t *testing.T) {
 				t.Fatalf("detectToolFromContent(%q) = %q, want %q", tt.content, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDetectToolFromContent_Muse_Negative(t *testing.T) {
+	// Content patterns anchor on the product banner and busy marker, so
+	// prose containing "muse" must not claim the pane.
+	for _, content := range []string{
+		"planning a museum visit",
+		"this will amuse the team",
+	} {
+		if got := detectToolFromContent(content); got == "muse" {
+			t.Errorf("detectToolFromContent(%q) = %q, should NOT match muse", content, got)
+		}
 	}
 }
 

--- a/internal/tmux/muse_test.go
+++ b/internal/tmux/muse_test.go
@@ -55,6 +55,11 @@ func TestDetectToolFromCommand_Muse_Negative(t *testing.T) {
 		{"museum", "echo museum"},
 		{"muse in path", "git -C /tmp/muse-project status"},
 		{"wrapper trailing bare muse fails closed", "my-wrapper muse"},
+		// Executable-only classification: mid-line tokens never match,
+		// even with trailing args. Wrappers still launch verbatim via
+		// passthrough; they just do not claim the pane here.
+		{"wrapper with flags fails closed", "my-wrapper muse --trust-workspace"},
+		{"echo with flags fails closed", "echo muse --help"},
 	}
 
 	for _, tt := range tests {
@@ -67,10 +72,19 @@ func TestDetectToolFromCommand_Muse_Negative(t *testing.T) {
 	}
 }
 
-func TestDetectToolFromCommand_Muse_Wrapper(t *testing.T) {
-	// Wrapper with trailing flags still resolves via the token arm.
-	if got := detectToolFromCommand("my-wrapper muse --trust-workspace"); got != "muse" {
-		t.Fatalf("detectToolFromCommand(wrapper) = %q, want muse", got)
+func TestDetectToolFromCommand_Muse_ExecutableForms(t *testing.T) {
+	// Only the executable slot classifies: bare, flagged, quoted, and
+	// absolute-path invocations all resolve via the basename switch.
+	for _, cmd := range []string{
+		"muse",
+		"muse --trust-workspace",
+		"/usr/local/bin/muse",
+		"/usr/local/bin/muse --yolo",
+		`"muse" --trust-workspace`,
+	} {
+		if got := detectToolFromCommand(cmd); got != "muse" {
+			t.Errorf("detectToolFromCommand(%q) = %q, want muse", cmd, got)
+		}
 	}
 }
 

--- a/internal/tmux/muse_test.go
+++ b/internal/tmux/muse_test.go
@@ -1,0 +1,154 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// Muse Code CLI (`muse`). tmux-layer detection + pattern defaults.
+// All content fixtures are verbatim tmux capture-pane lines from Muse Code
+// 1.0.2 running in a pane (echo provider).
+
+// Captured busy line: reply delayed 8s via --echo-delay-ms.
+const museCapturedBusyLine = "◈ Thinking (2s · esc to interrupt)"
+
+// Captured idle screen lines.
+const museCapturedBanner = "Muse Code 1.0.2"
+
+const museCapturedIdlePrompt = "⟩ Type @ to search and insert workspace file paths"
+const museCapturedStatusBar = "echo · /private/tmp/muse-probe-proj"
+
+func TestDetectToolFromCommand_Muse(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare muse", "muse", "muse"},
+		{"muse with trust flag", "muse --trust-workspace", "muse"},
+		{"muse with yolo flag", "muse --yolo", "muse"},
+		{"muse absolute path", "/Users/x/.local/bin/muse", "muse"},
+		{"muse resume subcommand", "muse resume 01a063dd-45dd-7402-b516-4346e923db3e", "muse"},
+		{"uppercase binary", "MUSE", "muse"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromCommand_Muse_Negative(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		// Truly unrelated strings — the strings.Contains fallback is
+		// intentionally permissive (matches the crush/copilot precedent),
+		// so only blatant false positives are guarded here.
+		{"empty", ""},
+		{"unrelated tool", "ls -la"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectToolFromCommand(tt.command)
+			if got == "muse" {
+				t.Fatalf("detectToolFromCommand(%q) = %q, should NOT match muse", tt.command, got)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromContent_Muse(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"muse code banner", "  Muse Code 1.0.2\n  Log in with browser", "muse"},
+		{"thinking marker", museCapturedBusyLine, "muse"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromContent(tt.content); got != tt.want {
+				t.Fatalf("detectToolFromContent(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRawPatterns_Muse(t *testing.T) {
+	raw := DefaultRawPatterns("muse")
+	if raw == nil {
+		t.Fatal("expected non-nil RawPatterns for muse")
+	}
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("muse should have busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("muse should have prompt patterns")
+	}
+}
+
+// TestMuseBusyPattern_MatchesCapturedLine pins the captured busy line
+// against the compiled busy strings using the same case-insensitive
+// substring semantics as hasBusyIndicatorResolved.
+func TestMuseBusyPattern_MatchesCapturedLine(t *testing.T) {
+	raw := DefaultRawPatterns("muse")
+	if raw == nil {
+		t.Fatal("expected non-nil RawPatterns for muse")
+	}
+	resolved, err := CompilePatterns(raw)
+	if err != nil {
+		t.Fatalf("CompilePatterns: %v", err)
+	}
+	lowerLine := strings.ToLower(museCapturedBusyLine)
+	matched := false
+	for _, str := range resolved.BusyStrings {
+		if strings.Contains(lowerLine, strings.ToLower(str)) {
+			matched = true
+			break
+		}
+	}
+	for _, re := range resolved.BusyRegexps {
+		if re.MatchString(museCapturedBusyLine) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		t.Errorf("captured busy line %q matched no muse busy pattern", museCapturedBusyLine)
+	}
+}
+
+// TestMusePromptPattern_MatchesCapturedIdle pins the captured idle
+// placeholder against the prompt patterns.
+func TestMusePromptPattern_MatchesCapturedIdle(t *testing.T) {
+	raw := DefaultRawPatterns("muse")
+	if raw == nil {
+		t.Fatal("expected non-nil RawPatterns for muse")
+	}
+	found := false
+	for _, p := range raw.PromptPatterns {
+		if strings.Contains(museCapturedIdlePrompt, strings.TrimPrefix(p, "re:")) && !strings.HasPrefix(p, "re:") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("captured idle prompt %q matched no muse prompt pattern", museCapturedIdlePrompt)
+	}
+}
+
+// TestMuseFixtures_Documented pins the remaining captured fixtures so a
+// future edit cannot silently drop the evidence they carry.
+func TestMuseFixtures_Documented(t *testing.T) {
+	if museCapturedBanner == "" || museCapturedStatusBar == "" {
+		t.Error("captured fixtures must be non-empty")
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -200,6 +200,29 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				"Switch modes",
 			},
 		}
+	case "muse":
+		// Muse Code CLI (`muse`). All patterns CAPTURED live from 1.0.2
+		// in a tmux pane (echo provider):
+		//
+		//   busy:  "◈ Thinking (2s · esc to interrupt)"
+		//   idle:  "⟩" + placeholder "Type @ to search and insert workspace
+		//           file paths", status bar "<provider> · /abs/path"
+		//   reply: "◆ <text>" assistant marker
+		//
+		// Deliberately NOT a prompt pattern: the bare "⟩" (U+27E9). Submitted
+		// prompts stay in history as "⟩ <text>", so it describes a state that
+		// is not necessarily waiting; the placeholder only ever renders in
+		// the live input box. Busy is checked before prompt in the detector,
+		// so the history lines cannot mask a working session.
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"◈ Thinking (",
+				"esc to interrupt",
+			},
+			PromptPatterns: []string{
+				"Type @ to search and insert workspace file paths",
+			},
+		}
 	case "shell":
 		return &RawPatterns{
 			PromptPatterns: []string{"$ ", "# ", "% "},

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -873,7 +873,13 @@ func detectToolFromCommand(command string) string {
 		return "copilot"
 	case strings.Contains(cmdLower, "crush"):
 		return "crush"
-	case strings.Contains(cmdLower, "muse"):
+	// Token-position match only (pi precedent): a bare substring would
+	// false-match "amuse", "museum", or paths like "/tmp/muse-project".
+	// The executable basename is already handled by the base switch above,
+	// so this arm covers only wrapper forms ("my-wrapper muse --flag").
+	// A wrapper ending in bare "muse" with no trailing args is
+	// indistinguishable from `echo muse` and stays unmatched (fail closed).
+	case strings.Contains(cmdLower, " muse ") || strings.HasPrefix(cmdLower, "muse "):
 		return "muse"
 	case strings.Contains(cmdLower, "cursor"):
 		return "cursor"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -748,7 +748,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "deepseek", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "muse", "cursor", "hermes", "deepseek", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -781,6 +781,13 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		// Distinct phrases to avoid colliding with the English word "crush".
 		regexp.MustCompile(`(?i)\bcharm\s+crush\b`),
 		regexp.MustCompile(`(?i)\bcrush>\s*`),
+	},
+	"muse": {
+		// Muse Code CLI (`muse`). Anchored on the product banner and the
+		// busy marker so the English words "muse"/"amuse"/"museum" in a
+		// pane cannot claim it.
+		regexp.MustCompile(`(?i)\bmuse\s+code\b`),
+		regexp.MustCompile(`◈ Thinking \(`),
 	},
 	"hermes": {
 		// Hermes Agent CLI (github.com/NousResearch/hermes-agent).
@@ -835,6 +842,8 @@ func detectToolFromCommand(command string) string {
 			return "copilot"
 		case "crush":
 			return "crush"
+		case "muse":
+			return "muse"
 		case "cursor":
 			return "cursor"
 		case "agent":
@@ -864,6 +873,8 @@ func detectToolFromCommand(command string) string {
 		return "copilot"
 	case strings.Contains(cmdLower, "crush"):
 		return "crush"
+	case strings.Contains(cmdLower, "muse"):
+		return "muse"
 	case strings.Contains(cmdLower, "cursor"):
 		return "cursor"
 	case strings.Contains(cmdLower, "hermes"):

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -873,14 +873,12 @@ func detectToolFromCommand(command string) string {
 		return "copilot"
 	case strings.Contains(cmdLower, "crush"):
 		return "crush"
-	// Token-position match only (pi precedent): a bare substring would
-	// false-match "amuse", "museum", or paths like "/tmp/muse-project".
-	// The executable basename is already handled by the base switch above,
-	// so this arm covers only wrapper forms ("my-wrapper muse --flag").
-	// A wrapper ending in bare "muse" with no trailing args is
-	// indistinguishable from `echo muse` and stays unmatched (fail closed).
-	case strings.Contains(cmdLower, " muse ") || strings.HasPrefix(cmdLower, "muse "):
-		return "muse"
+	// No fallback arm for muse: the executable basename in the base switch
+	// above is the only classifier. Any mid-line token form (`my-wrapper
+	// muse --flag`, `echo muse --help`) is indistinguishable from prose or
+	// another tool's arguments at this layer, so wrappers fail closed to
+	// shell here (they still launch verbatim via passthrough). This keeps
+	// the tmux layer consistent with the registry's executableOnly rule.
 	case strings.Contains(cmdLower, "cursor"):
 		return "cursor"
 	case strings.Contains(cmdLower, "hermes"):

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12172,6 +12172,8 @@ func createSessionTool(command string) (string, string) {
 		tool = "copilot"
 	case "crush":
 		tool = "crush"
+	case "muse":
+		tool = "muse"
 	case "cursor":
 		tool = "cursor"
 		command = session.GetToolCommand("cursor")

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -153,6 +153,16 @@ func TestCreateSessionTool_Crush(t *testing.T) {
 	}
 }
 
+// TUI session creation must produce Tool="muse" rather than
+// Tool="shell" with Command="muse", matching the tmux/userconfig
+// wiring for the Muse Code CLI integration.
+func TestCreateSessionTool_Muse(t *testing.T) {
+	tool, command := createSessionTool("muse")
+	if tool != "muse" || command != "muse" {
+		t.Fatalf("createSessionTool(\"muse\") = (%q, %q), want (\"muse\", \"muse\")", tool, command)
+	}
+}
+
 // TUI session creation must produce Tool="hermes" rather than
 // Tool="shell" with Command="hermes", matching the tmux/userconfig
 // wiring for the Hermes Agent CLI integration.

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -362,7 +362,7 @@ func displayCommandPreset(cmd string) string {
 // flag off FilterVisibleToolNames is a no-op, so the list is byte-identical to
 // before.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "muse", "cursor", "hermes", "deepseek"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -428,8 +428,8 @@ func TestDisplayCommandPreset(t *testing.T) {
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes, deepseek
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, muse, cursor, hermes, deepseek
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "muse", "cursor", "hermes", "deepseek"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -120,8 +120,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "DeepSeek"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Muse", "Cursor", "Hermes", "DeepSeek"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "muse", "cursor", "hermes", "deepseek"}
 )
 
 // Search tier names for radio selection
@@ -352,7 +352,7 @@ func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
 			"claude": true, "gemini": true, "opencode": true,
 			"codex": true, "pi": true, "crush": true, "copilot": true,
 			"shell": true, "cursor": true, "aider": true, "hermes": true,
-			"deepseek": true,
+			"deepseek": true, "muse": true,
 		}
 		var custom []string
 		for name := range config.Tools {

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -165,6 +165,7 @@ func TestSettingsPanel_LoadConfig_DefaultTool(t *testing.T) {
 		{"pi", "pi", "pi"},
 		{"copilot", "copilot", "copilot"},
 		{"crush", "crush", "crush"},
+		{"muse", "muse", "muse"},
 		{"cursor", "cursor", "cursor"},
 		{"hermes", "hermes", "hermes"},
 		{"empty", "", ""}, // None
@@ -199,8 +200,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "DeepSeek", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "deepseek", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Muse", "Cursor", "Hermes", "DeepSeek", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "muse", "cursor", "hermes", "deepseek", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)
@@ -360,6 +361,7 @@ func TestSettingsPanel_GetConfig_ToolMapping(t *testing.T) {
 		{"pi", "pi", "pi"},
 		{"copilot", "copilot", "copilot"},
 		{"crush", "crush", "crush"},
+		{"muse", "muse", "muse"},
 		{"cursor", "cursor", "cursor"},
 		{"hermes", "hermes", "hermes"},
 		{"none", "", ""},

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "deepseek"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "muse", "cursor", "hermes", "deepseek"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,
@@ -392,6 +392,7 @@ func (w *SetupWizard) View() string {
 			"codex":    "Codex CLI - OpenAI's coding assistant",
 			"pi":       "Pi CLI - lightweight coding assistant",
 			"crush":    "Crush - Charm's terminal-first AI coding assistant",
+			"muse":     "Muse Code - Meta's terminal AI coding assistant",
 			"shell":    "Shell - No AI tool (plain terminal)",
 			"cursor":   "Cursor Agent - Cursor CLI (agent / cursor agent)",
 		}

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "deepseek"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "muse", "cursor", "hermes", "deepseek"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -530,6 +530,7 @@ func initStyles() {
 		"shell":    lipgloss.NewStyle().Foreground(ColorText),
 		"opencode": lipgloss.NewStyle().Foreground(ColorText),
 		"crush":    lipgloss.NewStyle().Foreground(ColorPurple),
+		"muse":     lipgloss.NewStyle().Foreground(ColorGreen),
 	}
 
 	// DefaultToolStyle
@@ -607,6 +608,8 @@ func ToolIcon(tool string) string {
 		return "🐙"
 	case "crush":
 		return "💘"
+	case "muse":
+		return "🔮"
 	case "cursor":
 		return "📝"
 	case "hermes":
@@ -636,6 +639,8 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorAccent // Blue for GitHub Copilot
 	case "crush":
 		return ColorPurple // Pink/magenta for Charm Crush
+	case "muse":
+		return ColorGreen // Green for Muse Code
 	case "cursor":
 		return ColorAccent // Blue for Cursor
 	case "hermes":

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -339,6 +339,16 @@ yolo_mode = false
 | `env_file` | string | `""` | A .env file sourced for Muse sessions only. Useful for provider credentials: panes do not inherit interactive-shell exports. See [Path Resolution](#path-resolution). |
 | `yolo_mode` | bool | `false` | Maps to `muse --yolo` (disable approval + sandboxing and trust the workspace for the run). |
 
+The default automatically trusts the workspace for this run, including its project rules. `--trust-workspace` does not bypass permission approvals or sandboxing; `yolo_mode` remains `false` by default. To keep the workspace-trust prompt instead, override the command with bare `muse`:
+
+```toml
+[muse]
+command = "muse"
+yolo_mode = false
+```
+
+This command override applies to fresh launches and restart-resume. An explicit per-session `yolo_mode = false` overrides a global `yolo_mode = true`.
+
 Status detection: pane content patterns (busy `◈ Thinking (… · esc to interrupt)`, idle prompt placeholder). Restart re-discovers the workspace's newest session in the muse store (`~/.local/share/muse/sessions`, `runtime.session.metadata` workspace binding) and resumes it via `muse resume <uuid>`; a pruned store boots fresh. Plain `start` always boots a fresh session, never resumes.
 
 ## [docker] Section

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -15,6 +15,7 @@ All options for `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/ag
 - [[copilot] Section](#copilot-section)
 - [[cursor] Section](#cursor-section)
 - [[hermes] Section](#hermes-section)
+- [[muse] Section](#muse-section)
 - [[docker] Section](#docker-section)
 - [[worktree] Section](#worktree-section)
 - [[fork] Section](#fork-section)
@@ -320,6 +321,25 @@ yolo_mode = false
 Status detection: process-alive/dead only. Content-sniffing planned for future release.
 
 When using a different Codex home, prefer an inline command such as `CODEX_HOME=~/.codex-work codex` or export `CODEX_HOME` before starting agent-deck. Shell aliases are allowed, but agent-deck cannot infer `CODEX_HOME` hidden inside an alias for resume-file discovery.
+
+## [muse] Section
+
+Muse Code CLI integration settings (Meta's `muse` terminal agent).
+
+```toml
+[muse]
+command = "muse --trust-workspace"
+env_file = "~/.muse.env"
+yolo_mode = false
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | `"muse --trust-workspace"` | Override the binary/invocation. Replaces the default wholesale: bare `muse` blocks on the workspace-trust prompt in a fresh directory, so keep `--trust-workspace` in your override unless you want that prompt. |
+| `env_file` | string | `""` | A .env file sourced for Muse sessions only. Useful for provider credentials: panes do not inherit interactive-shell exports. See [Path Resolution](#path-resolution). |
+| `yolo_mode` | bool | `false` | Maps to `muse --yolo` (disable approval + sandboxing and trust the workspace for the run). |
+
+Status detection: pane content patterns (busy `◈ Thinking (… · esc to interrupt)`, idle prompt placeholder). Restart re-discovers the workspace's newest session in the muse store (`~/.local/share/muse/sessions`, `runtime.session.metadata` workspace binding) and resumes it via `muse resume <uuid>`; a pruned store boots fresh. Plain `start` always boots a fresh session, never resumes.
 
 ## [docker] Section
 
@@ -914,6 +934,11 @@ env_file = "~/.copilot.env"
 [hermes]
 command = "hermes --model gpt-5.5-pro --provider openai"
 env_file = "~/.hermes.env"
+yolo_mode = false
+
+[muse]
+command = "muse --trust-workspace"
+env_file = "~/.muse.env"
 yolo_mode = false
 
 [docker]


### PR DESCRIPTION
## What problem does this solve?

Agent Deck lacks a Muse Code preset with launch, status detection and restart-resume support. This contribution adds that adapter. The follow-up fixes resume IDs being interpreted as shell syntax and verifies the accepted workspace-trust policy at the actual command boundary.

## Why this change

The adapter supplies the Muse registry/UI entry, command and environment configuration, pane-status detection, workspace-scoped session discovery and restart-resume. Fresh starts remain fresh. Resume IDs use the existing shell argument quoting helper.

The accepted default is `muse --trust-workspace` with `yolo_mode = false`, consistent with the existing workspace-trust policy for Codex and Cursor. It automatically trusts project rules for the run. Workspace trust does not mean bypassing permission approvals or sandboxing. The separate explicit YOLO option controls that behavior.

## User impact

Muse appears in session creation and settings, with status detection and restart-resume support. To retain the workspace-trust prompt, configure:

```toml
[muse]
command = "muse"
yolo_mode = false
```

That override applies to fresh and resumed launches. An explicit session `yolo_mode = false` takes precedence over a global `true` setting.

## Evidence

The production correction at ff2f23940f6c35731cd447cd2b10fd1957364739 passed meaningful original-head shell-argument regressions, the full session package, vet, affected-package contributor checks and all fresh CI. Independent review found no remaining scoped argument-quoting defect. The generic revert check cannot compile newly introduced Muse APIs on main; the separate original-contributor-head assertions establish the actual quoting failure.

Follow-up 1c5e7745b3f62bd04052fb689ee00641565c2d8c changes only tests and documentation. It reuses an inert Bash function to capture actual argument boundaries; no Muse binary, account, provider or network runs. The six additional cases check both fresh and resumed commands:

| Configuration | Expected fresh arguments | Expected resume arguments |
|---|---|---|
| Default | `--trust-workspace` | `--trust-workspace resume session-id` |
| `[muse] command = "muse"` | none | `resume session-id` |
| Global YOLO true, explicit session false | `--trust-workspace` | `--trust-workspace resume session-id` |

The existing twelve literal-ID cases remain, including spaces, apostrophes, a literal dollar sign, newline and Unicode, with default and custom command bases. Updated Docker tests pass all eighteen argument cases. The contributor gate reports 14 PASS, 0 FAIL, 2 explained WARN, 0 skipped, including full affected command/session/tmux/UI packages and repository vet/build. The warnings concern aggregate diff size and the generic new-API revert compile limitation described above. Updated-head CI and root cumulative integration remain pending. No installed-Muse runtime claim is made for this correction or policy validation.

The aggregate adapter/discovery diff exceeds the contributor size guideline. Its registry, lifecycle, detection, configuration and regression files implement one built-in adapter; the production repair itself is a quoted argument and import, and the policy follow-up adds no new production behavior. No dependency, workflow or CHANGELOG changes are included.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** muse-spark-1.3 for the original contribution; GPT-6 for the correction, policy controls and separate independent review.

## What actually bothered you

The original request was: "i want to be able to use it with muse cli tool." The owner subsequently accepted default workspace trust with YOLO disabled and requested explicit opt-out documentation and fresh/resume argument controls.

## Checklist

- [x] Scoped adapter and corrections; no unrelated production additions
- [x] Literal-argument regressions and explicit trust-policy controls
- [x] Updated Docker/contributor checks pass
- [ ] Updated-head CI and root cumulative integration pass
- [x] Independent correction review
- [x] CHANGELOG.md untouched
- [x] AI authorship disclosed
- [x] No merge by worker

<!-- gate:ai=authored model=muse-spark-1.3+gpt-6 intent=yes -->
