### PR TITLE
feat(ui): add recency filter for session list (today / 3d / 7d / all)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2303,7 +2303,7 @@ func handleList(profile string, args []string) {
 				Color:             inst.Color,
 				Archived:          inst.IsArchived(),
 				ArchivedAt:        inst.ArchivedAt,
-				LastActivityAt:    inst.DisplayLastActivityTime().Format(time.RFC3339),
+				LastActivityAt:    inst.DisplayLastActivityTime().Format(time.RFC3339Nano),
 			}
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
 				sj.TmuxSession = tmuxSess.Name

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2271,6 +2271,10 @@ func handleList(profile string, args []string) {
 			Color             string    `json:"color,omitempty"` // issue #391
 			Archived          bool      `json:"archived"`
 			ArchivedAt        time.Time `json:"archived_at,omitempty"`
+			// LastActivityAt lets a remote caller (session.RemoteSessionInfo)
+			// apply the local recency filter (session.TimeFilterMode) to this
+			// session, the same way it applies to a local one.
+			LastActivityAt string `json:"last_activity_at,omitempty"`
 		}
 		// Warm tmux pane-title cache + load hook statuses so the CLI
 		// reports the same Status the TUI and /api/menu do (issue #610).
@@ -2299,6 +2303,7 @@ func handleList(profile string, args []string) {
 				Color:             inst.Color,
 				Archived:          inst.IsArchived(),
 				ArchivedAt:        inst.ArchivedAt,
+				LastActivityAt:    inst.DisplayLastActivityTime().Format(time.RFC3339),
 			}
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
 				sj.TmuxSession = tmuxSess.Name

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1058,8 +1058,31 @@ type RemoteSessionInfo struct {
 	Substate string `json:"substate"`
 	Archived bool   `json:"archived"`
 
+	// LastActivityAt is the remote session's Instance.DisplayLastActivityTime(),
+	// RFC3339-formatted, so the local recency filter (session.TimeFilterMode)
+	// can apply to remote rows the same way it applies to local ones. Same
+	// degradation story as Substate/Archived above: a remote too old to send
+	// it omits the key, which unmarshals to "" — see LastActivity below.
+	LastActivityAt string `json:"last_activity_at,omitempty"`
+
 	// Set locally, not from JSON
 	RemoteName string `json:"-"`
+}
+
+// LastActivity parses LastActivityAt. ok is false when the field is empty or
+// unparseable — a remote agent-deck build too old to send it, or a malformed
+// value — and callers should treat that as "unknown" (matches any recency
+// filter) rather than "very old", so an old remote's sessions don't just
+// vanish under a time filter.
+func (r RemoteSessionInfo) LastActivity() (t time.Time, ok bool) {
+	if r.LastActivityAt == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, r.LastActivityAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
 }
 
 // RemoteLatency is a live round-trip-time sample for a configured remote.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1059,10 +1059,13 @@ type RemoteSessionInfo struct {
 	Archived bool   `json:"archived"`
 
 	// LastActivityAt is the remote session's Instance.DisplayLastActivityTime(),
-	// RFC3339-formatted, so the local recency filter (session.TimeFilterMode)
-	// can apply to remote rows the same way it applies to local ones. Same
-	// degradation story as Substate/Archived above: a remote too old to send
-	// it omits the key, which unmarshals to "" — see LastActivity below.
+	// RFC3339Nano-formatted (fractional seconds kept: TimeFilterMode's 3/7-day
+	// cutoffs are exact instants, and truncating to whole seconds could flip a
+	// session sitting right on one), so the local recency filter
+	// (session.TimeFilterMode) can apply to remote rows the same way it
+	// applies to local ones. Same degradation story as Substate/Archived
+	// above: a remote too old to send it omits the key, which unmarshals to
+	// "" — see LastActivity below.
 	LastActivityAt string `json:"last_activity_at,omitempty"`
 
 	// Set locally, not from JSON
@@ -1078,7 +1081,7 @@ func (r RemoteSessionInfo) LastActivity() (t time.Time, ok bool) {
 	if r.LastActivityAt == "" {
 		return time.Time{}, false
 	}
-	parsed, err := time.Parse(time.RFC3339, r.LastActivityAt)
+	parsed, err := time.Parse(time.RFC3339Nano, r.LastActivityAt)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -340,16 +340,22 @@ func TestParseRemoteVersion(t *testing.T) {
 }
 
 func TestRemoteSessionInfoLastActivity(t *testing.T) {
-	now := time.Now().Truncate(time.Second)
+	now := time.Now()
 
-	t.Run("valid RFC3339 parses", func(t *testing.T) {
-		r := RemoteSessionInfo{LastActivityAt: now.Format(time.RFC3339)}
+	t.Run("valid RFC3339Nano round-trips exactly, sub-second included", func(t *testing.T) {
+		// Sub-second precision matters here: RemoteSessionInfo is formatted
+		// with RFC3339Nano (not RFC3339) specifically so a session sitting
+		// right on a TimeFilterMode 3/7-day cutoff isn't misclassified by
+		// rounding down to the nearest second. now (not now.Truncate(time.
+		// Second)) exercises that: it round-trips only if fractional seconds
+		// actually survive the format/parse.
+		r := RemoteSessionInfo{LastActivityAt: now.Format(time.RFC3339Nano)}
 		got, ok := r.LastActivity()
 		if !ok {
 			t.Fatalf("LastActivity() ok = false, want true")
 		}
 		if !got.Equal(now) {
-			t.Errorf("LastActivity() = %v, want %v", got, now)
+			t.Errorf("LastActivity() = %v, want %v (sub-second precision lost)", got, now)
 		}
 	})
 
@@ -366,4 +372,30 @@ func TestRemoteSessionInfoLastActivity(t *testing.T) {
 			t.Errorf("LastActivity() ok = true for malformed field, want false")
 		}
 	})
+}
+
+// TestRemoteSessionInfoLastActivity_BoundaryPrecision covers the scenario a
+// review caught: a session active a few hundred milliseconds inside a
+// TimeFilterMode 3-day cutoff round-trips as "inside" the window. Formatting
+// with RFC3339 (whole seconds only) can round down across the cutoff and
+// misclassify it as outside; RFC3339Nano cannot.
+func TestRemoteSessionInfoLastActivity_BoundaryPrecision(t *testing.T) {
+	now := time.Now()
+	cutoff := now.Add(-3 * 24 * time.Hour)
+	// 300ms inside the 3-day window (i.e. after the cutoff). A whole-second
+	// truncation could floor this across the cutoff if the sub-second part
+	// were dropped and the second itself landed exactly on it.
+	justInside := cutoff.Add(300 * time.Millisecond)
+
+	r := RemoteSessionInfo{LastActivityAt: justInside.Format(time.RFC3339Nano)}
+	got, ok := r.LastActivity()
+	if !ok {
+		t.Fatalf("LastActivity() ok = false, want true")
+	}
+	if got.Before(cutoff) {
+		t.Fatalf("LastActivity() = %v, which is before the 3-day cutoff %v (precision lost)", got, cutoff)
+	}
+	if !TimeFilter3Days.Matches(got, now) {
+		t.Errorf("TimeFilter3Days.Matches(%v, %v) = false, want true (300ms inside the window)", got, now)
+	}
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSSHRunnerBuildRemoteCommand_QuotesAllDynamicArgs(t *testing.T) {
@@ -336,4 +337,33 @@ func TestParseRemoteVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoteSessionInfoLastActivity(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
+	t.Run("valid RFC3339 parses", func(t *testing.T) {
+		r := RemoteSessionInfo{LastActivityAt: now.Format(time.RFC3339)}
+		got, ok := r.LastActivity()
+		if !ok {
+			t.Fatalf("LastActivity() ok = false, want true")
+		}
+		if !got.Equal(now) {
+			t.Errorf("LastActivity() = %v, want %v", got, now)
+		}
+	})
+
+	t.Run("empty is unknown, not zero-time", func(t *testing.T) {
+		r := RemoteSessionInfo{}
+		if _, ok := r.LastActivity(); ok {
+			t.Errorf("LastActivity() ok = true for empty field, want false (older remote, field never sent)")
+		}
+	})
+
+	t.Run("malformed value is unknown, not an error a caller must handle", func(t *testing.T) {
+		r := RemoteSessionInfo{LastActivityAt: "not-a-timestamp"}
+		if _, ok := r.LastActivity(); ok {
+			t.Errorf("LastActivity() ok = true for malformed field, want false")
+		}
+	})
 }

--- a/internal/session/time_filter_mode.go
+++ b/internal/session/time_filter_mode.go
@@ -1,0 +1,64 @@
+package session
+
+import "time"
+
+// TimeFilterMode narrows the session list to sessions whose last activity
+// falls within a recency window. It is toggled from the TUI (cycled by a
+// hotkey) and persisted across restarts, the same way GroupViewMode is (see
+// group_view_mode.go).
+type TimeFilterMode int
+
+const (
+	// TimeFilterAll shows every session regardless of activity time. This is
+	// the default (zero value), matching the existing statusFilter="" and
+	// GroupViewNormal=0 convention: an unset filter must be the no-op state.
+	TimeFilterAll TimeFilterMode = iota
+	// TimeFilterToday shows sessions active since local midnight.
+	TimeFilterToday
+	// TimeFilter3Days shows sessions active within the last 3*24h.
+	TimeFilter3Days
+	// TimeFilter7Days shows sessions active within the last 7*24h.
+	TimeFilter7Days
+)
+
+// TimeFilterModeCount is the number of cycle-able modes (used for "(mode+1)%N").
+const TimeFilterModeCount = 4
+
+// Label returns a short human-readable name for the mode (for status hints).
+func (m TimeFilterMode) Label() string {
+	switch m {
+	case TimeFilterToday:
+		return "Today"
+	case TimeFilter3Days:
+		return "Last 3 days"
+	case TimeFilter7Days:
+		return "Last 7 days"
+	default:
+		return "All time"
+	}
+}
+
+// Matches reports whether t (a session's last-activity time, typically
+// Instance.DisplayLastActivityTime()) falls within this mode's window,
+// evaluated relative to now.
+//
+// TimeFilterToday uses a local-calendar-day boundary (since local midnight)
+// rather than "within the last 24h": that is how a human reads the word
+// "today" regardless of what time it currently is. The multi-day modes use a
+// simple rolling N*24h window instead of a calendar-day count — the
+// day-boundary fuzziness that matters for "today" is negligible at 3-7 days,
+// and a rolling window avoids re-deriving "N calendar days ago" per timezone.
+func (m TimeFilterMode) Matches(t, now time.Time) bool {
+	switch m {
+	case TimeFilterToday:
+		y, mo, d := now.Date()
+		startOfToday := time.Date(y, mo, d, 0, 0, 0, 0, now.Location())
+		return !t.Before(startOfToday)
+	case TimeFilter3Days:
+		return !t.Before(now.Add(-3 * 24 * time.Hour))
+	case TimeFilter7Days:
+		return !t.Before(now.Add(-7 * 24 * time.Hour))
+	default:
+		return true
+	}
+}

--- a/internal/session/time_filter_mode_test.go
+++ b/internal/session/time_filter_mode_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeFilterModeMatches(t *testing.T) {
+	now := time.Date(2026, 6, 15, 14, 30, 0, 0, time.UTC) // Monday, mid-afternoon
+
+	tests := []struct {
+		name string
+		mode TimeFilterMode
+		t    time.Time
+		want bool
+	}{
+		{"all matches far past", TimeFilterAll, now.AddDate(-1, 0, 0), true},
+		{"all matches future", TimeFilterAll, now.Add(time.Hour), true},
+
+		{"today matches earlier today", TimeFilterToday, now.Add(-2 * time.Hour), true},
+		{"today matches exactly midnight", TimeFilterToday, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC), true},
+		{"today excludes yesterday 23:59", TimeFilterToday, time.Date(2026, 6, 14, 23, 59, 59, 0, time.UTC), false},
+		{"today excludes 3 days ago", TimeFilterToday, now.AddDate(0, 0, -3), false},
+
+		{"3days matches today", TimeFilter3Days, now.Add(-time.Hour), true},
+		{"3days matches exactly 3*24h ago", TimeFilter3Days, now.Add(-3 * 24 * time.Hour), true},
+		{"3days excludes just past 3*24h ago", TimeFilter3Days, now.Add(-3*24*time.Hour - time.Second), false},
+		{"3days excludes 7 days ago", TimeFilter3Days, now.AddDate(0, 0, -7), false},
+
+		{"7days matches 5 days ago", TimeFilter7Days, now.AddDate(0, 0, -5), true},
+		{"7days matches exactly 7*24h ago", TimeFilter7Days, now.Add(-7 * 24 * time.Hour), true},
+		{"7days excludes just past 7*24h ago", TimeFilter7Days, now.Add(-7*24*time.Hour - time.Second), false},
+		{"7days excludes 30 days ago", TimeFilter7Days, now.AddDate(0, 0, -30), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.mode.Matches(tt.t, now); got != tt.want {
+				t.Errorf("%v.Matches(%v, %v) = %v, want %v", tt.mode, tt.t, now, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeFilterModeLabel(t *testing.T) {
+	tests := []struct {
+		mode TimeFilterMode
+		want string
+	}{
+		{TimeFilterAll, "All time"},
+		{TimeFilterToday, "Today"},
+		{TimeFilter3Days, "Last 3 days"},
+		{TimeFilter7Days, "Last 7 days"},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.Label(); got != tt.want {
+			t.Errorf("%v.Label() = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}
+
+// TestTimeFilterModeCycle guards the invariant the TUI hotkey relies on:
+// cycling TimeFilterModeCount times returns to the starting (default) mode.
+func TestTimeFilterModeCycle(t *testing.T) {
+	mode := TimeFilterAll
+	seen := []TimeFilterMode{mode}
+	for i := 0; i < TimeFilterModeCount-1; i++ {
+		mode = TimeFilterMode((int(mode) + 1) % TimeFilterModeCount)
+		seen = append(seen, mode)
+	}
+	mode = TimeFilterMode((int(mode) + 1) % TimeFilterModeCount)
+	if mode != TimeFilterAll {
+		t.Errorf("cycling %d times should return to TimeFilterAll, got %v", TimeFilterModeCount, mode)
+	}
+	want := []TimeFilterMode{TimeFilterAll, TimeFilterToday, TimeFilter3Days, TimeFilter7Days}
+	if len(seen) != len(want) {
+		t.Fatalf("cycle produced %d distinct steps, want %d", len(seen), len(want))
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Errorf("cycle step %d = %v, want %v", i, seen[i], want[i])
+		}
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -199,6 +199,7 @@ func (h *HelpOverlay) View() string {
 	skillsKey := h.key(hotkeySkillsManager, "s")
 	previewKey := h.key(hotkeyTogglePreview, "v")
 	groupViewKey := h.key(hotkeyCycleGroupView, "t")
+	timeFilterKey := h.key(hotkeyCycleTimeFilter, "*")
 	// Opt-in: empty when switch_session is unbound, so the filter drops the row.
 	switchKey := h.key(hotkeySwitchSession, "")
 	// In-attach scrollback pager (#1491). Its trigger is resolved directly (it is
@@ -343,6 +344,7 @@ func (h *HelpOverlay) View() string {
 				{"/running", "Filter running"},
 				{"/idle", "Filter idle"},
 				{groupViewKey, "Cycle view: active-on-top / populated-on-top"},
+				{timeFilterKey, "Cycle time filter: today / 3 days / 7 days / all"},
 			},
 		},
 		{

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -316,17 +316,18 @@ type Home struct {
 	analyticsCacheTime     map[string]time.Time                       // TTL cache: sessionID -> cache timestamp
 
 	// State
-	cursor              int                   // Selected item index in flatItems
-	viewOffset          int                   // First visible item index (for scrolling)
-	previewScrollOffset int                   // Lines scrolled up from tail in the preview pane (#574). 0 = tail (default). Reset on cursor move.
-	isAttaching         atomic.Bool           // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
-	lastRenderedFrame   string                // Last non-empty frame View produced; re-served while isAttaching so no frame is ever black (#1753). Event-loop goroutine only.
-	statusFilter        session.Status        // Filter sessions by status ("" = all, or specific status)
-	groupScope          string                // Limit TUI to a specific group path ("" = all groups)
-	initialSelect       string                // Session ID or title to preselect on first load (#709). Does NOT scope groups.
-	initialSelectDone   bool                  // Guard so preselection only fires once
-	previewMode         PreviewMode           // What to show in preview pane (both, output-only, analytics-only)
-	groupViewMode       session.GroupViewMode // List partition: normal, active-on-top, populated-on-top (cycled by hotkey 't')
+	cursor              int                    // Selected item index in flatItems
+	viewOffset          int                    // First visible item index (for scrolling)
+	previewScrollOffset int                    // Lines scrolled up from tail in the preview pane (#574). 0 = tail (default). Reset on cursor move.
+	isAttaching         atomic.Bool            // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
+	lastRenderedFrame   string                 // Last non-empty frame View produced; re-served while isAttaching so no frame is ever black (#1753). Event-loop goroutine only.
+	statusFilter        session.Status         // Filter sessions by status ("" = all, or specific status)
+	groupScope          string                 // Limit TUI to a specific group path ("" = all groups)
+	initialSelect       string                 // Session ID or title to preselect on first load (#709). Does NOT scope groups.
+	initialSelectDone   bool                   // Guard so preselection only fires once
+	previewMode         PreviewMode            // What to show in preview pane (both, output-only, analytics-only)
+	groupViewMode       session.GroupViewMode  // List partition: normal, active-on-top, populated-on-top (cycled by hotkey 't')
+	timeFilter          session.TimeFilterMode // Recency filter: all, today, 3 days, 7 days (cycled by hotkey '*')
 	err                 error
 	errTime             time.Time  // When error occurred (for auto-dismiss)
 	isReloading         bool       // Visual feedback during auto-reload
@@ -761,6 +762,7 @@ type uiState struct {
 	PreviewMode     int    `json:"preview_mode"`
 	StatusFilter    string `json:"status_filter,omitempty"`
 	GroupViewMode   int    `json:"group_view_mode,omitempty"`
+	TimeFilterMode  int    `json:"time_filter_mode,omitempty"`
 	// Collapsed remote headers, keyed like Item.Path. Local group folds live in
 	// groupTree, which is persisted separately by saveGroupState; remote groups
 	// are synthetic UI rows and have no home there.
@@ -2561,6 +2563,45 @@ func (h *Home) rebuildFlatItems() {
 		}
 	} else {
 		h.flatItems = allItems
+	}
+
+	// Apply time-range filter if active (composes with status filter above,
+	// same two-pass group/session shape, same auto-clear-when-empty safety
+	// net: a session's activity clock keeps ticking while a time filter is
+	// open, so a filter that matched something a moment ago can go stale
+	// exactly like a status filter can).
+	if h.timeFilter != session.TimeFilterAll {
+		now := time.Now()
+		groupsWithMatches := make(map[string]bool)
+		for _, item := range h.flatItems {
+			if item.Type == session.ItemTypeSession && item.Session != nil {
+				if h.timeFilter.Matches(item.Session.DisplayLastActivityTime(), now) {
+					groupsWithMatches[item.Path] = true
+					parts := strings.Split(item.Path, "/")
+					for i := range parts {
+						groupsWithMatches[strings.Join(parts[:i+1], "/")] = true
+					}
+				}
+			}
+		}
+
+		filtered := make([]session.Item, 0, len(h.flatItems))
+		for _, item := range h.flatItems {
+			if item.Type == session.ItemTypeGroup {
+				if groupsWithMatches[item.Path] {
+					filtered = append(filtered, item)
+				}
+			} else if item.Type == session.ItemTypeSession && item.Session != nil {
+				if h.timeFilter.Matches(item.Session.DisplayLastActivityTime(), now) {
+					filtered = append(filtered, item)
+				}
+			}
+		}
+		if len(filtered) == 0 && len(h.flatItems) > 0 {
+			h.timeFilter = session.TimeFilterAll
+		} else {
+			h.flatItems = filtered
+		}
 	}
 
 	// Apply group scope filter (composes with status filter above)
@@ -9646,6 +9687,17 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.saveUIState()
 		return h, h.fetchSelectedPreview()
 
+	case "*":
+		// Cycle time-range filter: all → today → 3 days → 7 days → all.
+		// Preserve the cursor's row identity across the rebuild, same as the
+		// 't' view-mode cycle above.
+		selectedBefore := h.captureSelectedItemIdentity()
+		h.timeFilter = session.TimeFilterMode((int(h.timeFilter) + 1) % session.TimeFilterModeCount)
+		h.rebuildFlatItemsPreservingSelection(selectedBefore)
+		h.syncViewport()
+		h.saveUIState()
+		return h, h.fetchSelectedPreview()
+
 	case "y":
 		// Toggle YOLO mode for Gemini or Codex sessions (requires restart)
 		if h.cursor < len(h.flatItems) {
@@ -11748,6 +11800,7 @@ func (h *Home) saveUIStateErr() error {
 		PreviewMode:        int(h.previewMode),
 		StatusFilter:       string(h.statusFilter),
 		GroupViewMode:      int(h.groupViewMode),
+		TimeFilterMode:     int(h.timeFilter),
 		RemoteSessionOrder: h.remoteSessionOrder,
 	}
 
@@ -11829,6 +11882,10 @@ func (h *Home) loadUIState() {
 	h.groupViewMode = session.GroupViewMode(state.GroupViewMode)
 	if h.groupViewMode < session.GroupViewNormal || h.groupViewMode >= session.GroupViewModeCount {
 		h.groupViewMode = session.GroupViewNormal
+	}
+	h.timeFilter = session.TimeFilterMode(state.TimeFilterMode)
+	if h.timeFilter < session.TimeFilterAll || h.timeFilter >= session.TimeFilterModeCount {
+		h.timeFilter = session.TimeFilterAll
 	}
 
 	// #1875: restore the manual remote row order. Entries for remotes that no
@@ -20416,6 +20473,13 @@ func (h *Home) renderFilterBarHint() string {
 		hint += dim.Render(" • ") + mark("t", true) + dim.Render(" "+h.groupViewMode.Label())
 	} else {
 		hint += dim.Render(" • ") + mark("t", false) + dim.Render(" view")
+	}
+
+	// Time-range filter indicator (today / 3 days / 7 days), only when active.
+	if h.timeFilter != session.TimeFilterAll {
+		hint += dim.Render(" • ") + mark("*", true) + dim.Render(" "+h.timeFilter.Label())
+	} else {
+		hint += dim.Render(" • ") + mark("*", false) + dim.Render(" time")
 	}
 	return hint
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -339,6 +339,9 @@ type Home struct {
 	reloadMu            sync.Mutex // Protects reloadVersion, isReloading, and lastLoadMtime for thread-safe access
 	lastLoadMtime       time.Time  // File mtime when we last loaded (for external change detection)
 
+	// Earliest eligible membership expiry; ordinary ticks only compare clocks.
+	nextTimeFilterExpiry time.Time
+
 	// Preview cache (async fetching - View() must be pure, no blocking I/O)
 	previewCache      map[string]string    // previewKey -> cached preview content
 	previewCacheTime  map[string]time.Time // previewKey -> when cached (for expiration)
@@ -2491,7 +2494,11 @@ func (h *Home) restoreSelectedItemIdentity(identity selectedItemIdentity) bool {
 }
 
 func (h *Home) rebuildFlatItemsPreservingSelection(identity selectedItemIdentity) {
-	h.rebuildFlatItems()
+	h.rebuildFlatItemsPreservingSelectionAt(identity, time.Now())
+}
+
+func (h *Home) rebuildFlatItemsPreservingSelectionAt(identity selectedItemIdentity, now time.Time) {
+	h.rebuildFlatItemsAt(now)
 	if !h.restoreSelectedItemIdentity(identity) && len(h.flatItems) > 0 {
 		h.cursor = min(h.cursor, len(h.flatItems)-1)
 		h.cursor = max(h.cursor, 0)
@@ -2501,6 +2508,11 @@ func (h *Home) rebuildFlatItemsPreservingSelection(identity selectedItemIdentity
 
 // rebuildFlatItems rebuilds the flattened view from group tree
 func (h *Home) rebuildFlatItems() {
+	h.rebuildFlatItemsAt(time.Now())
+}
+
+func (h *Home) rebuildFlatItemsAt(now time.Time) {
+	h.nextTimeFilterExpiry = time.Time{}
 	h.jumpMode = false
 	h.jumpBuffer = ""
 
@@ -2590,7 +2602,6 @@ func (h *Home) rebuildFlatItems() {
 
 	// Decide fallback across eligible local and remote sessions before hiding
 	// rows. Full group membership keeps collapsed matches available to reopen.
-	now := time.Now()
 	remoteMatchesTime := func(remote session.RemoteSessionInfo) bool {
 		activity, known := remote.LastActivity()
 		return !known || h.timeFilter.Matches(activity, now)
@@ -2611,6 +2622,7 @@ func (h *Home) rebuildFlatItems() {
 				}
 				hasCandidates = true
 				if h.timeFilter.Matches(inst.DisplayLastActivityTime(), now) {
+					h.recordTimeFilterExpiry(inst.DisplayLastActivityTime(), now)
 					hasMatches = true
 					markGroupPathAndAncestors(groupsWithMatches, group.Path)
 				}
@@ -2621,6 +2633,9 @@ func (h *Home) rebuildFlatItems() {
 				for _, remote := range sessions {
 					hasCandidates = true
 					if remoteMatchesTime(remote) {
+						if activity, known := remote.LastActivity(); known {
+							h.recordTimeFilterExpiry(activity, now)
+						}
 						hasMatches = true
 					}
 				}
@@ -7185,9 +7200,14 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var remoteFetchCmd tea.Cmd
 		var remoteLatencyCmd tea.Cmd
 
-		if h.groupViewMode != session.GroupViewNormal {
+		now := time.Time(msg)
+		if now.IsZero() {
+			now = time.Now()
+		}
+		filterExpired := h.timeFilter != session.TimeFilterAll && !h.nextTimeFilterExpiry.IsZero() && !now.Before(h.nextTimeFilterExpiry)
+		if h.groupViewMode != session.GroupViewNormal || filterExpired {
 			selectedBefore := h.captureSelectedItemIdentity()
-			h.rebuildFlatItemsPreservingSelection(selectedBefore)
+			h.rebuildFlatItemsPreservingSelectionAt(selectedBefore, now)
 		}
 
 		// Auto-dismiss errors after 5 seconds

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2522,19 +2522,17 @@ func (h *Home) rebuildFlatItems() {
 
 	// Apply status filter if active (skip when browsing archived list).
 	if h.statusFilter != "" && h.statusFilter != FilterModeArchived {
-		// First pass: identify groups that have matching sessions
+		// Use full membership so a collapsed match retains a header. The
+		// recency pass below must not count sessions whose status header was
+		// discarded merely because their group is folded.
 		groupsWithMatches := make(map[string]bool)
-		for _, item := range allItems {
-			if item.Type == session.ItemTypeSession && item.Session != nil {
-				if h.matchesStatusFilter(h.statusFilter, item.Session.Status) {
-					// Mark this session's group and all parent groups as having matches
-					groupsWithMatches[item.Path] = true
-					// Also mark parent paths
-					parts := strings.Split(item.Path, "/")
-					for i := range parts {
-						parentPath := strings.Join(parts[:i+1], "/")
-						groupsWithMatches[parentPath] = true
-					}
+		for _, group := range h.groupTree.GroupList {
+			if group == nil {
+				continue
+			}
+			for _, inst := range group.Sessions {
+				if inst != nil && !inst.IsArchived() && h.matchesStatusFilter(h.statusFilter, inst.Status) {
+					markGroupPathAndAncestors(groupsWithMatches, group.Path)
 				}
 			}
 		}
@@ -2565,41 +2563,66 @@ func (h *Home) rebuildFlatItems() {
 		h.flatItems = allItems
 	}
 
-	// Apply time-range filter if active (composes with status filter above,
-	// same two-pass group/session shape, same auto-clear-when-empty safety
-	// net: a session's activity clock keeps ticking while a time filter is
-	// open, so a filter that matched something a moment ago can go stale
-	// exactly like a status filter can).
+	// Use one remote snapshot for recency fallback and row construction.
+	h.remoteSessionsMu.RLock()
+	remoteNames := make([]string, 0, len(h.remoteSessions))
+	remotes := make(map[string][]session.RemoteSessionInfo, len(h.remoteSessions))
+	for name, sessions := range h.remoteSessions {
+		remoteNames = append(remoteNames, name)
+		remotes[name] = append([]session.RemoteSessionInfo(nil), sessions...)
+	}
+	h.remoteSessionsMu.RUnlock()
+	sort.Strings(remoteNames)
+
+	// Decide fallback across eligible local and remote sessions before hiding
+	// rows. Full group membership keeps collapsed matches available to reopen.
+	now := time.Now()
+	remoteMatchesTime := func(remote session.RemoteSessionInfo) bool {
+		activity, known := remote.LastActivity()
+		return !known || h.timeFilter.Matches(activity, now)
+	}
 	if h.timeFilter != session.TimeFilterAll {
-		now := time.Now()
 		groupsWithMatches := make(map[string]bool)
-		for _, item := range h.flatItems {
-			if item.Type == session.ItemTypeSession && item.Session != nil {
-				if h.timeFilter.Matches(item.Session.DisplayLastActivityTime(), now) {
-					groupsWithMatches[item.Path] = true
-					parts := strings.Split(item.Path, "/")
-					for i := range parts {
-						groupsWithMatches[strings.Join(parts[:i+1], "/")] = true
+		hasCandidates, hasMatches := false, false
+		for _, group := range h.groupTree.GroupList {
+			if group == nil || !h.isInGroupScope(group.Path) {
+				continue
+			}
+			for _, inst := range group.Sessions {
+				if inst == nil || inst.IsArchived() != viewArchived {
+					continue
+				}
+				if h.statusFilter != "" && !viewArchived && !h.matchesStatusFilter(h.statusFilter, inst.Status) {
+					continue
+				}
+				hasCandidates = true
+				if h.timeFilter.Matches(inst.DisplayLastActivityTime(), now) {
+					hasMatches = true
+					markGroupPathAndAncestors(groupsWithMatches, group.Path)
+				}
+			}
+		}
+		if !viewArchived {
+			for _, sessions := range remotes {
+				for _, remote := range sessions {
+					hasCandidates = true
+					if remoteMatchesTime(remote) {
+						hasMatches = true
 					}
 				}
 			}
 		}
-
-		filtered := make([]session.Item, 0, len(h.flatItems))
-		for _, item := range h.flatItems {
-			if item.Type == session.ItemTypeGroup {
-				if groupsWithMatches[item.Path] {
+		if hasCandidates && !hasMatches {
+			h.timeFilter = session.TimeFilterAll
+		} else {
+			filtered := make([]session.Item, 0, len(h.flatItems))
+			for _, item := range h.flatItems {
+				if item.Type == session.ItemTypeGroup && groupsWithMatches[item.Path] {
 					filtered = append(filtered, item)
-				}
-			} else if item.Type == session.ItemTypeSession && item.Session != nil {
-				if h.timeFilter.Matches(item.Session.DisplayLastActivityTime(), now) {
+				} else if item.Type == session.ItemTypeSession && item.Session != nil && h.timeFilter.Matches(item.Session.DisplayLastActivityTime(), now) {
 					filtered = append(filtered, item)
 				}
 			}
-		}
-		if len(filtered) == 0 && len(h.flatItems) > 0 {
-			h.timeFilter = session.TimeFilterAll
-		} else {
 			h.flatItems = filtered
 		}
 	}
@@ -2697,73 +2720,28 @@ func (h *Home) rebuildFlatItems() {
 		h.flatItems = expanded
 	}
 
-	// Append remote sessions as selectable items
-	h.remoteSessionsMu.RLock()
-	remoteNames := make([]string, 0, len(h.remoteSessions))
-	remotes := make(map[string][]session.RemoteSessionInfo, len(h.remoteSessions))
-	for name, sessions := range h.remoteSessions {
-		remoteNames = append(remoteNames, name)
-		remotes[name] = append([]session.RemoteSessionInfo(nil), sessions...)
-	}
-	h.remoteSessionsMu.RUnlock()
-	sort.Strings(remoteNames)
 	if len(remotes) > 0 && h.statusFilter != FilterModeArchived {
 		for _, remoteName := range remoteNames {
+			sessions := remotes[remoteName]
+			if h.timeFilter != session.TimeFilterAll {
+				filtered := make([]session.RemoteSessionInfo, 0, len(sessions))
+				for _, remote := range sessions {
+					if remoteMatchesTime(remote) {
+						filtered = append(filtered, remote)
+					}
+				}
+				if len(filtered) == 0 {
+					continue
+				}
+				sessions = filtered
+			}
+			// Filter before building rows so collapsed headers and connectors
+			// describe the surviving sessions.
 			// #1553: nest each remote's sessions under their Group paths
 			// instead of dumping them flat at Level 1.
 			// #1875: apply the user's manual row order for this remote.
-			h.flatItems = append(h.flatItems, buildRemoteFlatItemsOrdered(remoteName, remotes[remoteName], h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName))...)
+			h.flatItems = append(h.flatItems, buildRemoteFlatItemsOrdered(remoteName, sessions, h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName))...)
 		}
-	}
-
-	// Apply the same recency filter to the remote rows just appended. This
-	// runs as its own pass, separate from the local time-filter pass above,
-	// because remote rows don't exist yet when that one runs (they're
-	// appended after local filtering/partitioning/window-injection, which
-	// don't apply to them). Same two-pass mark/filter shape, scoped to
-	// ItemTypeRemoteGroup/ItemTypeRemoteSession so it's a no-op for local
-	// rows. A remote session with no (or unparseable) last-activity time — an
-	// older remote binary that predates the field — always matches, same
-	// graceful-degradation convention as RemoteSessionInfo's Substate/Archived
-	// fields: it stays visible rather than vanishing.
-	if len(remotes) > 0 && h.timeFilter != session.TimeFilterAll {
-		now := time.Now()
-		remoteMatches := func(item session.Item) bool {
-			if item.RemoteSession == nil {
-				return true
-			}
-			t, ok := item.RemoteSession.LastActivity()
-			if !ok {
-				return true
-			}
-			return h.timeFilter.Matches(t, now)
-		}
-		remoteGroupsWithMatches := make(map[string]bool)
-		for _, item := range h.flatItems {
-			if item.Type == session.ItemTypeRemoteSession && remoteMatches(item) {
-				remoteGroupsWithMatches[item.Path] = true
-				parts := strings.Split(item.Path, "/")
-				for i := range parts {
-					remoteGroupsWithMatches[strings.Join(parts[:i+1], "/")] = true
-				}
-			}
-		}
-		filtered := make([]session.Item, 0, len(h.flatItems))
-		for _, item := range h.flatItems {
-			switch item.Type {
-			case session.ItemTypeRemoteGroup:
-				if remoteGroupsWithMatches[item.Path] {
-					filtered = append(filtered, item)
-				}
-			case session.ItemTypeRemoteSession:
-				if remoteMatches(item) {
-					filtered = append(filtered, item)
-				}
-			default:
-				filtered = append(filtered, item)
-			}
-		}
-		h.flatItems = filtered
 	}
 
 	// Pre-compute root group numbers for O(1) hotkey lookup (replaces O(n) loop in renderGroupItem).

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2716,6 +2716,56 @@ func (h *Home) rebuildFlatItems() {
 		}
 	}
 
+	// Apply the same recency filter to the remote rows just appended. This
+	// runs as its own pass, separate from the local time-filter pass above,
+	// because remote rows don't exist yet when that one runs (they're
+	// appended after local filtering/partitioning/window-injection, which
+	// don't apply to them). Same two-pass mark/filter shape, scoped to
+	// ItemTypeRemoteGroup/ItemTypeRemoteSession so it's a no-op for local
+	// rows. A remote session with no (or unparseable) last-activity time — an
+	// older remote binary that predates the field — always matches, same
+	// graceful-degradation convention as RemoteSessionInfo's Substate/Archived
+	// fields: it stays visible rather than vanishing.
+	if len(remotes) > 0 && h.timeFilter != session.TimeFilterAll {
+		now := time.Now()
+		remoteMatches := func(item session.Item) bool {
+			if item.RemoteSession == nil {
+				return true
+			}
+			t, ok := item.RemoteSession.LastActivity()
+			if !ok {
+				return true
+			}
+			return h.timeFilter.Matches(t, now)
+		}
+		remoteGroupsWithMatches := make(map[string]bool)
+		for _, item := range h.flatItems {
+			if item.Type == session.ItemTypeRemoteSession && remoteMatches(item) {
+				remoteGroupsWithMatches[item.Path] = true
+				parts := strings.Split(item.Path, "/")
+				for i := range parts {
+					remoteGroupsWithMatches[strings.Join(parts[:i+1], "/")] = true
+				}
+			}
+		}
+		filtered := make([]session.Item, 0, len(h.flatItems))
+		for _, item := range h.flatItems {
+			switch item.Type {
+			case session.ItemTypeRemoteGroup:
+				if remoteGroupsWithMatches[item.Path] {
+					filtered = append(filtered, item)
+				}
+			case session.ItemTypeRemoteSession:
+				if remoteMatches(item) {
+					filtered = append(filtered, item)
+				}
+			default:
+				filtered = append(filtered, item)
+			}
+		}
+		h.flatItems = filtered
+	}
+
 	// Pre-compute root group numbers for O(1) hotkey lookup (replaces O(n) loop in renderGroupItem).
 	// View-mode partitioning can duplicate root headers; every copy of the same
 	// logical root reuses the same digit.
@@ -20476,10 +20526,14 @@ func (h *Home) renderFilterBarHint() string {
 	}
 
 	// Time-range filter indicator (today / 3 days / 7 days), only when active.
+	timeFilterKey := h.actionKey(hotkeyCycleTimeFilter)
+	if timeFilterKey == "" {
+		timeFilterKey = "*"
+	}
 	if h.timeFilter != session.TimeFilterAll {
-		hint += dim.Render(" • ") + mark("*", true) + dim.Render(" "+h.timeFilter.Label())
+		hint += dim.Render(" • ") + mark(timeFilterKey, true) + dim.Render(" "+h.timeFilter.Label())
 	} else {
-		hint += dim.Render(" • ") + mark("*", false) + dim.Render(" time")
+		hint += dim.Render(" • ") + mark(timeFilterKey, false) + dim.Render(" time")
 	}
 	return hint
 }

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3472,7 +3472,12 @@ func TestRebuildFlatItemsGroupScopeComposesWithStatusFilter(t *testing.T) {
 func TestRebuildFlatItemsTimeFilter(t *testing.T) {
 	now := time.Now()
 
-	instToday := &session.Instance{ID: "s-today", Title: "today", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.Add(-time.Hour)}
+	// instToday uses now itself (not now.Add(-time.Hour)): TimeFilterToday's
+	// calendar-day boundary means an hour-old timestamp can fall into
+	// yesterday when the suite happens to run in the first hour after local
+	// midnight, making the "today" case flaky. now is always >= its own
+	// day's start, so it's unconditionally "today".
+	instToday := &session.Instance{ID: "s-today", Title: "today", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now}
 	inst2DaysAgo := &session.Instance{ID: "s-2days", Title: "2days", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.AddDate(0, 0, -2)}
 	inst5DaysAgo := &session.Instance{ID: "s-5days", Title: "5days", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.AddDate(0, 0, -5)}
 	inst30DaysAgo := &session.Instance{ID: "s-30days", Title: "30days", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.AddDate(0, 0, -30)}
@@ -3551,8 +3556,11 @@ func TestRebuildFlatItemsAutoClearsEmptyTimeFilter(t *testing.T) {
 func TestRebuildFlatItemsTimeFilterComposesWithStatusFilter(t *testing.T) {
 	h := &Home{}
 	now := time.Now()
-	recentRunning := &session.Instance{ID: "s1", Title: "recent-running", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now.Add(-time.Hour)}
-	recentIdle := &session.Instance{ID: "s2", Title: "recent-idle", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.Add(-time.Hour)}
+	// now itself, not now.Add(-time.Hour): see the comment on instToday in
+	// TestRebuildFlatItemsTimeFilter for why an hour-old "today" fixture is
+	// flaky around local midnight.
+	recentRunning := &session.Instance{ID: "s1", Title: "recent-running", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now}
+	recentIdle := &session.Instance{ID: "s2", Title: "recent-idle", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now}
 	oldRunning := &session.Instance{ID: "s3", Title: "old-running", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now.AddDate(0, 0, -30)}
 
 	h.statusFilter = session.StatusRunning
@@ -3570,6 +3578,54 @@ func TestRebuildFlatItemsTimeFilterComposesWithStatusFilter(t *testing.T) {
 	}
 	if len(ids) != 1 || ids[0] != "s1" {
 		t.Errorf("expected only s1 (running AND today), got %v", ids)
+	}
+}
+
+// TestRebuildFlatItemsTimeFilterAppliesToRemoteSessions covers the gap a
+// review caught: remote rows are appended after the local time-filter pass
+// runs (they skip local group-tree/window-injection entirely), so without a
+// second, remote-scoped pass they'd stay visible regardless of the selected
+// time range. Also covers the backward-compat case: a remote session with no
+// LastActivityAt (an older remote binary that predates the field) must
+// still match, not be treated as arbitrarily old.
+func TestRebuildFlatItemsTimeFilterAppliesToRemoteSessions(t *testing.T) {
+	h := NewHome()
+	h.timeFilter = session.TimeFilterToday
+
+	now := time.Now()
+	h.remoteSessionsMu.Lock()
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "r-recent", Title: "recent", RemoteName: "dev", LastActivityAt: now.Format(time.RFC3339)},
+			{ID: "r-old", Title: "old", RemoteName: "dev", LastActivityAt: now.AddDate(0, 0, -30).Format(time.RFC3339)},
+			{ID: "r-unknown", Title: "unknown-activity", RemoteName: "dev", LastActivityAt: ""},
+		},
+	}
+	h.remoteSessionsMu.Unlock()
+
+	h.groupTree = session.NewGroupTree(nil)
+	h.windowsCollapsed = make(map[string]bool)
+
+	h.rebuildFlatItems()
+
+	var ids []string
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+			ids = append(ids, item.RemoteSession.ID)
+		}
+	}
+	got := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		got[id] = true
+	}
+	if !got["r-recent"] {
+		t.Errorf("expected r-recent (matches today) to remain visible, got %v", ids)
+	}
+	if !got["r-unknown"] {
+		t.Errorf("expected r-unknown (no LastActivityAt, unknown treated as always-matching) to remain visible, got %v", ids)
+	}
+	if got["r-old"] {
+		t.Errorf("expected r-old (30 days ago) to be filtered out under Today, got %v", ids)
 	}
 }
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1051,6 +1051,33 @@ func TestHandleMainKeyEditNotesStartsEditor(t *testing.T) {
 	}
 }
 
+func TestHandleMainKeyCyclesTimeFilter(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.storage = nil // Avoid touching persistence in this unit test.
+
+	inst := &session.Instance{ID: "s1", Title: "s1", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: time.Now()}
+	home.groupTree = session.NewGroupTree([]*session.Instance{inst})
+
+	wantCycle := []session.TimeFilterMode{
+		session.TimeFilterToday,
+		session.TimeFilter3Days,
+		session.TimeFilter7Days,
+		session.TimeFilterAll,
+	}
+	for i, want := range wantCycle {
+		model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'*'}})
+		h, ok := model.(*Home)
+		if !ok {
+			t.Fatalf("step %d: handleMainKey should return *Home", i)
+		}
+		if h.timeFilter != want {
+			t.Errorf("step %d: timeFilter = %v, want %v", i, h.timeFilter, want)
+		}
+	}
+}
+
 func TestHandleNotesEditorKeySave(t *testing.T) {
 	home := NewHome()
 	home.width = 100
@@ -3439,6 +3466,110 @@ func TestRebuildFlatItemsGroupScopeComposesWithStatusFilter(t *testing.T) {
 				t.Errorf("found non-running session %q, expected only running", item.Session.Title)
 			}
 		}
+	}
+}
+
+func TestRebuildFlatItemsTimeFilter(t *testing.T) {
+	now := time.Now()
+
+	instToday := &session.Instance{ID: "s-today", Title: "today", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.Add(-time.Hour)}
+	inst2DaysAgo := &session.Instance{ID: "s-2days", Title: "2days", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.AddDate(0, 0, -2)}
+	inst5DaysAgo := &session.Instance{ID: "s-5days", Title: "5days", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.AddDate(0, 0, -5)}
+	inst30DaysAgo := &session.Instance{ID: "s-30days", Title: "30days", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.AddDate(0, 0, -30)}
+	all := []*session.Instance{instToday, inst2DaysAgo, inst5DaysAgo, inst30DaysAgo}
+
+	sessionIDs := func(h *Home) []string {
+		var ids []string
+		for _, item := range h.flatItems {
+			if item.Type == session.ItemTypeSession && item.Session != nil {
+				ids = append(ids, item.Session.ID)
+			}
+		}
+		return ids
+	}
+
+	tests := []struct {
+		name string
+		mode session.TimeFilterMode
+		want []string
+	}{
+		{"all", session.TimeFilterAll, []string{"s-today", "s-2days", "s-5days", "s-30days"}},
+		{"today", session.TimeFilterToday, []string{"s-today"}},
+		{"3 days", session.TimeFilter3Days, []string{"s-today", "s-2days"}},
+		{"7 days", session.TimeFilter7Days, []string{"s-today", "s-2days", "s-5days"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Home{}
+			h.timeFilter = tt.mode
+			h.groupTree = session.NewGroupTree(all)
+			h.windowsCollapsed = make(map[string]bool)
+			h.rebuildFlatItems()
+
+			got := sessionIDs(h)
+			if len(got) != len(tt.want) {
+				t.Fatalf("session count = %v, want %v", got, tt.want)
+			}
+			gotSet := make(map[string]bool, len(got))
+			for _, id := range got {
+				gotSet[id] = true
+			}
+			for _, id := range tt.want {
+				if !gotSet[id] {
+					t.Errorf("expected session %q in filtered list, got %v", id, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRebuildFlatItemsAutoClearsEmptyTimeFilter(t *testing.T) {
+	h := &Home{}
+	// Only session is 30 days old; "today" should match nothing.
+	inst := &session.Instance{ID: "s1", Title: "old", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: time.Now().AddDate(0, 0, -30)}
+	h.timeFilter = session.TimeFilterToday
+	h.groupTree = session.NewGroupTree([]*session.Instance{inst})
+	h.windowsCollapsed = make(map[string]bool)
+
+	h.rebuildFlatItems()
+
+	if h.timeFilter != session.TimeFilterAll {
+		t.Errorf("timeFilter should be auto-cleared when it matches nothing, got %v", h.timeFilter)
+	}
+	sessionCount := 0
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession {
+			sessionCount++
+		}
+	}
+	if sessionCount != 1 {
+		t.Errorf("expected 1 session in flatItems after auto-clear, got %d", sessionCount)
+	}
+}
+
+func TestRebuildFlatItemsTimeFilterComposesWithStatusFilter(t *testing.T) {
+	h := &Home{}
+	now := time.Now()
+	recentRunning := &session.Instance{ID: "s1", Title: "recent-running", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now.Add(-time.Hour)}
+	recentIdle := &session.Instance{ID: "s2", Title: "recent-idle", Tool: "claude", Status: session.StatusIdle, LastAccessedAt: now.Add(-time.Hour)}
+	oldRunning := &session.Instance{ID: "s3", Title: "old-running", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now.AddDate(0, 0, -30)}
+
+	h.statusFilter = session.StatusRunning
+	h.timeFilter = session.TimeFilterToday
+	h.groupTree = session.NewGroupTree([]*session.Instance{recentRunning, recentIdle, oldRunning})
+	h.windowsCollapsed = make(map[string]bool)
+
+	h.rebuildFlatItems()
+
+	var ids []string
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil {
+			ids = append(ids, item.Session.ID)
+		}
+	}
+	if len(ids) != 1 || ids[0] != "s1" {
+		t.Errorf("expected only s1 (running AND today), got %v", ids)
 	}
 }
 

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -26,6 +26,7 @@ const (
 	hotkeySkillsManager    = "skills_manager"
 	hotkeyTogglePreview    = "toggle_preview"
 	hotkeyCycleGroupView   = "cycle_group_view"
+	hotkeyCycleTimeFilter  = "cycle_time_filter"
 	hotkeyMarkUnread       = "mark_unread"
 	hotkeyQuickApprove     = "quick_approve"
 	hotkeyPromptSession    = "prompt_session" // #1410: prompt the highlighted session without attaching
@@ -103,6 +104,7 @@ var hotkeyActionOrder = []string{
 	hotkeySkillsManager,
 	hotkeyTogglePreview,
 	hotkeyCycleGroupView,
+	hotkeyCycleTimeFilter,
 	hotkeyMarkUnread,
 	hotkeyQuickApprove,
 	hotkeyPromptSession,
@@ -150,6 +152,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeySkillsManager:    "s",
 	hotkeyTogglePreview:    "v",
 	hotkeyCycleGroupView:   "t",
+	hotkeyCycleTimeFilter:  "*",
 	hotkeyMarkUnread:       "u",
 	hotkeyQuickApprove:     "a",
 	hotkeyPromptSession:    "o",

--- a/internal/ui/time_filter_clock.go
+++ b/internal/ui/time_filter_clock.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// recordTimeFilterExpiry runs only for known timestamps that passed the same
+// eligibility and recency checks as row filtering. Collapsed groups participate.
+func (h *Home) recordTimeFilterExpiry(activity, now time.Time) {
+	var expiry time.Time
+	switch h.timeFilter {
+	case session.TimeFilterToday:
+		local := activity.In(now.Location())
+		// Calendar arithmetic handles 23/25-hour days. A future activity timestamp
+		// stays eligible until its own local day ends, matching TimeFilterMode.Matches.
+		expiry = time.Date(local.Year(), local.Month(), local.Day()+1, 0, 0, 0, 0, now.Location())
+	case session.TimeFilter3Days:
+		expiry = activity.Add(3*24*time.Hour + time.Nanosecond)
+	case session.TimeFilter7Days:
+		expiry = activity.Add(7*24*time.Hour + time.Nanosecond)
+	default:
+		return
+	}
+	// Rolling Matches includes the cutoff itself, so expiry is one ns later.
+	if h.nextTimeFilterExpiry.IsZero() || expiry.Before(h.nextTimeFilterExpiry) {
+		h.nextTimeFilterExpiry = expiry
+	}
+}

--- a/internal/ui/time_filter_clock_test.go
+++ b/internal/ui/time_filter_clock_test.go
@@ -1,0 +1,137 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func clockFilterHome(mode session.TimeFilterMode, locals []*session.Instance, remotes []session.RemoteSessionInfo) *Home {
+	h := NewHome()
+	h.width, h.height, h.initialLoading = 120, 40, false
+	h.instances = locals
+	h.groupTree = session.NewGroupTree(locals)
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{"dev": remotes}
+	h.timeFilter = mode
+	h.groupViewMode = session.GroupViewNormal
+	h.rebuildFlatItems()
+	return h
+}
+
+func clockFilterTick(h *Home, at time.Time) {
+	// Exercise real Update without dispatching unrelated background commands.
+	now := time.Now()
+	h.lastLogCheck, h.lastCachePrune = now, now
+	h.agentsLoaded, h.agentsLastRefresh = true, now
+	h.uiStateSaveTicks = 0
+	h.Update(tickMsg(at))
+}
+
+func clockLocal(id string, at time.Time) *session.Instance {
+	return &session.Instance{ID: id, Title: id, GroupPath: "work", LastAccessedAt: at, Status: session.StatusIdle}
+}
+
+func clockVisibleIDs(h *Home) []string {
+	var ids []string
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil {
+			ids = append(ids, item.Session.ID)
+		}
+		if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+			ids = append(ids, item.RemoteSession.ID)
+		}
+	}
+	return ids
+}
+
+func TestTimeFilterClockExpiresAndPreservesSelection(t *testing.T) {
+	for _, mode := range []session.TimeFilterMode{session.TimeFilterToday, session.TimeFilter3Days, session.TimeFilter7Days} {
+		for _, remote := range []bool{false, true} {
+			name := mode.Label() + "/local"
+			if remote {
+				name = mode.Label() + "/remote"
+			}
+			t.Run(name, func(t *testing.T) {
+				now := time.Now()
+				activity, boundary := now, time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
+				if mode != session.TimeFilterToday {
+					days := 3
+					if mode == session.TimeFilter7Days {
+						days = 7
+					}
+					activity = now.Add(-time.Duration(days)*24*time.Hour + time.Hour)
+					boundary = activity.Add(time.Duration(days) * 24 * time.Hour)
+				}
+				keeper := boundary.Add(time.Hour)
+				locals := []*session.Instance{clockLocal("expires", activity), clockLocal("selected", keeper)}
+				var remotes []session.RemoteSessionInfo
+				if remote {
+					locals = nil
+					remotes = []session.RemoteSessionInfo{{ID: "expires", RemoteName: "dev", Group: "work", LastActivityAt: activity.Format(time.RFC3339Nano)}, {ID: "selected", RemoteName: "dev", Group: "work", LastActivityAt: keeper.Format(time.RFC3339Nano)}}
+				}
+				h := clockFilterHome(mode, locals, remotes)
+				require.ElementsMatch(t, []string{"expires", "selected"}, clockVisibleIDs(h))
+				for n, item := range h.flatItems {
+					if (item.Session != nil && item.Session.ID == "selected") || (item.RemoteSession != nil && item.RemoteSession.ID == "selected") {
+						h.cursor = n
+					}
+				}
+				selected := h.captureSelectedItemIdentity()
+				// Rolling comparisons include the exact cutoff; Today changes at midnight.
+				before := boundary.Add(-time.Nanosecond)
+				if mode != session.TimeFilterToday {
+					before = boundary
+				}
+				h.jumpMode, h.jumpBuffer = true, "2"
+				first := &h.flatItems[0]
+				clockFilterTick(h, before)
+				require.ElementsMatch(t, []string{"expires", "selected"}, clockVisibleIDs(h))
+				require.Equal(t, "2", h.jumpBuffer, "a pre-boundary tick must not reset jump input")
+				require.Same(t, first, &h.flatItems[0], "a pre-boundary tick must not rebuild rows")
+				clockFilterTick(h, boundary.Add(time.Nanosecond))
+				require.Equal(t, []string{"selected"}, clockVisibleIDs(h), "clock expiry must remove old membership")
+				require.Equal(t, selected, h.captureSelectedItemIdentity())
+				require.Equal(t, mode, h.timeFilter)
+			})
+		}
+	}
+}
+
+func TestTimeFilterClockExpiryClearsEmptyFilter(t *testing.T) {
+	for _, mode := range []session.TimeFilterMode{session.TimeFilterToday, session.TimeFilter3Days, session.TimeFilter7Days} {
+		t.Run(mode.Label(), func(t *testing.T) {
+			now := time.Now()
+			h := clockFilterHome(mode, []*session.Instance{clockLocal("only", now)}, nil)
+			clockFilterTick(h, now.AddDate(0, 0, 8))
+			require.Equal(t, session.TimeFilterAll, h.timeFilter, "last matching row expired; fallback must run")
+			require.Equal(t, []string{"only"}, clockVisibleIDs(h))
+		})
+	}
+}
+
+func TestTimeFilterClockCollapsedAndUnknownRemote(t *testing.T) {
+	now := time.Now()
+	h := clockFilterHome(session.TimeFilter3Days, []*session.Instance{clockLocal("collapsed", now.Add(-72*time.Hour+time.Hour))}, []session.RemoteSessionInfo{{ID: "unknown", RemoteName: "dev", LastActivityAt: "invalid"}})
+	h.groupTree.GroupList[0].Expanded = false
+	h.rebuildFlatItems()
+	clockFilterTick(h, now.Add(2*time.Hour))
+	for _, item := range h.flatItems {
+		require.False(t, item.Type == session.ItemTypeGroup && item.Path == "work", "expired collapsed group must disappear")
+	}
+	require.Equal(t, []string{"unknown"}, clockVisibleIDs(h))
+	require.Equal(t, session.TimeFilter3Days, h.timeFilter, "unknown remote remains eligible")
+	h.jumpMode, h.jumpBuffer = true, "2"
+	clockFilterTick(h, now.Add(3*time.Hour))
+	require.Equal(t, "2", h.jumpBuffer, "unknown-only results have no next expiry")
+}
+
+func TestTimeFilterClockAllDoesNotRebuild(t *testing.T) {
+	h := clockFilterHome(session.TimeFilterAll, []*session.Instance{clockLocal("all", time.Now())}, nil)
+	h.jumpMode, h.jumpBuffer = true, "2"
+	first := &h.flatItems[0]
+	clockFilterTick(h, time.Now().AddDate(0, 0, 30))
+	require.Equal(t, "2", h.jumpBuffer)
+	require.Same(t, first, &h.flatItems[0])
+}

--- a/internal/ui/time_filter_clock_test.go
+++ b/internal/ui/time_filter_clock_test.go
@@ -135,3 +135,64 @@ func TestTimeFilterClockAllDoesNotRebuild(t *testing.T) {
 	require.Equal(t, "2", h.jumpBuffer)
 	require.Same(t, first, &h.flatItems[0])
 }
+
+func TestTimeFilterClockCivilMidnight(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	for _, day := range []struct {
+		month time.Month
+		day   int
+		hours time.Duration
+	}{{time.March, 8, 23}, {time.November, 1, 25}} {
+		t.Run(day.month.String(), func(t *testing.T) {
+			now := time.Date(2026, day.month, day.day, 0, 0, 0, 0, loc)
+			h := clockFilterHome(session.TimeFilterAll, []*session.Instance{clockLocal("today", now)}, nil)
+			h.timeFilter = session.TimeFilterToday
+			h.rebuildFlatItemsAt(now)
+			boundary := time.Date(2026, day.month, day.day+1, 0, 0, 0, 0, loc)
+			require.Equal(t, day.hours*time.Hour, boundary.Sub(now))
+			require.Equal(t, boundary, h.nextTimeFilterExpiry)
+			clockFilterTick(h, boundary.Add(-time.Nanosecond))
+			require.Equal(t, session.TimeFilterToday, h.timeFilter)
+			clockFilterTick(h, boundary)
+			require.Equal(t, session.TimeFilterAll, h.timeFilter)
+		})
+	}
+}
+
+func TestTimeFilterClockEligibilityAndRebuildReschedule(t *testing.T) {
+	now := time.Now()
+	near, far := now.Add(-72*time.Hour+time.Hour), now
+	for _, exclude := range []string{"scope", "status", "archive"} {
+		t.Run(exclude, func(t *testing.T) {
+			excluded, selected := clockLocal("excluded", near), clockLocal("selected", far)
+			excluded.GroupPath = "outside"
+			h := clockFilterHome(session.TimeFilter3Days, []*session.Instance{excluded, selected}, nil)
+			switch exclude {
+			case "scope":
+				h.groupScope = "work"
+			case "status":
+				h.statusFilter = session.StatusIdle
+				excluded.Status = session.StatusRunning
+			case "archive":
+				excluded.ArchivedAt = now
+			}
+			h.rebuildFlatItemsAt(now)
+			require.Equal(t, far.Add(72*time.Hour+time.Nanosecond), h.nextTimeFilterExpiry)
+			h.jumpMode, h.jumpBuffer = true, "2"
+			clockFilterTick(h, now.Add(2*time.Hour))
+			require.Equal(t, "2", h.jumpBuffer, "ineligible rows must not schedule expiry")
+			require.Equal(t, []string{"selected"}, clockVisibleIDs(h))
+			// Normal fleet/state rebuilds replace deadlines, not retain old minima.
+			selected.LastAccessedAt = now.Add(time.Hour)
+			h.rebuildFlatItemsAt(now)
+			require.Equal(t, selected.LastAccessedAt.Add(72*time.Hour+time.Nanosecond), h.nextTimeFilterExpiry)
+			h.timeFilter = session.TimeFilter7Days
+			h.rebuildFlatItemsAt(now)
+			require.Equal(t, selected.LastAccessedAt.Add(168*time.Hour+time.Nanosecond), h.nextTimeFilterExpiry)
+			h.timeFilter = session.TimeFilterAll
+			h.rebuildFlatItemsAt(now)
+			require.True(t, h.nextTimeFilterExpiry.IsZero())
+		})
+	}
+}

--- a/internal/ui/time_filter_fleet_test.go
+++ b/internal/ui/time_filter_fleet_test.go
@@ -1,0 +1,176 @@
+package ui
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestTimeFilterFleetFallback(t *testing.T) {
+	now := time.Now()
+	old := now.AddDate(0, 0, -30)
+	local := func(id, group string, at time.Time) *session.Instance {
+		return &session.Instance{ID: id, Title: id, GroupPath: group, Status: session.StatusIdle, LastAccessedAt: at}
+	}
+	remote := func(id, at string) session.RemoteSessionInfo {
+		return session.RemoteSessionInfo{ID: id, Title: id, Group: "work", RemoteName: "dev", LastActivityAt: at}
+	}
+	cases := []struct {
+		name     string
+		locals   []*session.Instance
+		remotes  []session.RemoteSessionInfo
+		scope    string
+		archived bool
+		wantMode session.TimeFilterMode
+		wantIDs  []string
+	}{
+		{name: "mixed fleet", locals: []*session.Instance{local("local-old", "work", old)}, remotes: []session.RemoteSessionInfo{remote("remote-recent", now.Format(time.RFC3339Nano)), remote("remote-old", old.Format(time.RFC3339Nano))}, wantMode: session.TimeFilter3Days, wantIDs: []string{"remote-recent"}},
+		{name: "missing remote timestamp", locals: []*session.Instance{local("local-old", "work", old)}, remotes: []session.RemoteSessionInfo{remote("remote-unknown", ""), remote("remote-old", old.Format(time.RFC3339Nano))}, wantMode: session.TimeFilter3Days, wantIDs: []string{"remote-unknown"}},
+		{name: "malformed remote timestamp", locals: []*session.Instance{local("local-old", "work", old)}, remotes: []session.RemoteSessionInfo{remote("remote-unknown", "invalid"), remote("remote-old", old.Format(time.RFC3339Nano))}, wantMode: session.TimeFilter3Days, wantIDs: []string{"remote-unknown"}},
+		{name: "all old", locals: []*session.Instance{local("local-old", "work", old)}, remotes: []session.RemoteSessionInfo{remote("remote-old", old.Format(time.RFC3339Nano))}, wantMode: session.TimeFilterAll, wantIDs: []string{"local-old", "remote-old"}},
+		{name: "remote only old", remotes: []session.RemoteSessionInfo{remote("remote-old", old.Format(time.RFC3339Nano))}, wantMode: session.TimeFilterAll, wantIDs: []string{"remote-old"}},
+		{name: "empty fleet", wantMode: session.TimeFilter3Days},
+		{name: "scope excludes recent local", locals: []*session.Instance{local("local-old", "work", old), local("local-recent", "personal", now)}, scope: "work", wantMode: session.TimeFilterAll, wantIDs: []string{"local-old"}},
+		{name: "scope retains remote match", locals: []*session.Instance{local("local-old", "work", old), local("local-recent", "personal", now)}, remotes: []session.RemoteSessionInfo{remote("remote-recent", now.Format(time.RFC3339Nano))}, scope: "work", wantMode: session.TimeFilter3Days, wantIDs: []string{"remote-recent"}},
+		{name: "archive excludes remotes", locals: []*session.Instance{local("local-old", "work", old)}, remotes: []session.RemoteSessionInfo{remote("remote-recent", now.Format(time.RFC3339Nano))}, archived: true, wantMode: session.TimeFilterAll, wantIDs: []string{"local-old"}},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Home{timeFilter: session.TimeFilter3Days, groupScope: tt.scope, remoteSessions: map[string][]session.RemoteSessionInfo{"dev": tt.remotes}}
+			if tt.archived {
+				h.statusFilter = FilterModeArchived
+				for _, inst := range tt.locals {
+					inst.ArchivedAt = now
+				}
+			}
+			h.groupTree = session.NewGroupTree(tt.locals)
+			originalRemotes := append([]session.RemoteSessionInfo(nil), tt.remotes...)
+			h.rebuildFlatItems()
+			if h.timeFilter != tt.wantMode {
+				t.Errorf("mode = %v, want %v", h.timeFilter, tt.wantMode)
+			}
+			var ids []string
+			for _, item := range h.flatItems {
+				if item.Type == session.ItemTypeSession && item.Session != nil {
+					ids = append(ids, item.Session.ID)
+				}
+				if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+					ids = append(ids, item.RemoteSession.ID)
+				}
+			}
+			sort.Strings(ids)
+			if !reflect.DeepEqual(ids, tt.wantIDs) {
+				t.Errorf("visible session IDs = %v, want %v", ids, tt.wantIDs)
+			}
+			if !reflect.DeepEqual(h.remoteSessions["dev"], originalRemotes) {
+				t.Error("filter mutated remote snapshot")
+			}
+		})
+	}
+}
+
+func TestTimeFilterFleetPreservesCollapsedMatches(t *testing.T) {
+	now := time.Now()
+	for _, collapse := range []string{"local", "remotes/dev", "remotes/dev/work"} {
+		t.Run(collapse, func(t *testing.T) {
+			h := &Home{
+				timeFilter: session.TimeFilter3Days,
+				groupTree: session.NewGroupTree([]*session.Instance{
+					{ID: "local-recent", Title: "recent", GroupPath: "local", LastAccessedAt: now},
+					{ID: "local-other", Title: "other", GroupPath: "other", LastAccessedAt: now},
+				}),
+				remoteSessions: map[string][]session.RemoteSessionInfo{"dev": {
+					{ID: "remote-recent", Group: "work", LastActivityAt: now.Format(time.RFC3339Nano)},
+					{ID: "remote-old", Group: "old", LastActivityAt: now.AddDate(0, 0, -30).Format(time.RFC3339Nano)},
+				}},
+				remoteGroupsCollapsed: map[string]bool{collapse: true},
+			}
+			for _, group := range h.groupTree.GroupList {
+				if group.Path == collapse {
+					group.Expanded = false
+				}
+			}
+			h.rebuildFlatItems()
+			foundHeader := false
+			for _, item := range h.flatItems {
+				if item.Path == collapse && (item.Type == session.ItemTypeGroup || item.Type == session.ItemTypeRemoteGroup) {
+					foundHeader = true
+				}
+				if collapse == "local" && item.Session != nil && item.Session.ID == "local-recent" {
+					t.Error("collapsed local child visible")
+				}
+				if item.RemoteSession != nil && (item.RemoteSession.ID == "remote-old" || collapse != "local") {
+					t.Errorf("filtered or collapsed remote child visible: %s", item.RemoteSession.ID)
+				}
+			}
+			if !foundHeader {
+				t.Error("matching collapsed header disappeared")
+			}
+			if h.timeFilter != session.TimeFilter3Days {
+				t.Error("matching collapsed group caused fallback")
+			}
+		})
+	}
+}
+
+func TestTimeFilterFleetCollapsedStatusMatchRemainsReachable(t *testing.T) {
+	now := time.Now()
+	h := &Home{
+		statusFilter: session.StatusRunning,
+		timeFilter:   session.TimeFilter3Days,
+		groupTree: session.NewGroupTree([]*session.Instance{
+			{ID: "old-running", Title: "old", GroupPath: "expanded", Status: session.StatusRunning, LastAccessedAt: now.AddDate(0, 0, -30)},
+			{ID: "recent-running", Title: "recent", GroupPath: "collapsed", Status: session.StatusRunning, LastAccessedAt: now},
+		}),
+	}
+	for _, group := range h.groupTree.GroupList {
+		if group.Path == "collapsed" {
+			group.Expanded = false
+		}
+	}
+	h.rebuildFlatItems()
+	if h.timeFilter != session.TimeFilter3Days || h.statusFilter != session.StatusRunning {
+		t.Error("matching collapsed status group should retain both filters")
+	}
+	found := false
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeGroup && item.Path == "collapsed" {
+			found = true
+		}
+		if item.Type == session.ItemTypeSession {
+			t.Errorf("unexpected visible session: %s", item.Session.ID)
+		}
+	}
+	if !found {
+		t.Error("collapsed match cannot be reopened")
+	}
+}
+
+func TestTimeFilterFleetPreservesRemoteSelectionAndConnector(t *testing.T) {
+	now := time.Now()
+	h := &Home{
+		groupTree: session.NewGroupTree([]*session.Instance{{ID: "old", Title: "old", LastAccessedAt: now.AddDate(0, 0, -30)}}),
+		remoteSessions: map[string][]session.RemoteSessionInfo{"dev": {
+			{ID: "recent", Group: "work", LastActivityAt: now.Format(time.RFC3339Nano)},
+			{ID: "old", Group: "work", LastActivityAt: now.AddDate(0, 0, -30).Format(time.RFC3339Nano)},
+		}},
+	}
+	h.rebuildFlatItems()
+	h.cursor = remoteSessionIndexByID(h, "recent")
+	if h.cursor < 0 {
+		t.Fatal("fixture lacks recent remote")
+	}
+	selected := h.captureSelectedItemIdentity()
+	h.timeFilter = session.TimeFilter3Days
+	h.rebuildFlatItemsPreservingSelection(selected)
+	idx := remoteSessionIndexByID(h, "recent")
+	if idx < 0 || h.cursor != idx {
+		t.Fatalf("selection moved: cursor=%d recent=%d", h.cursor, idx)
+	}
+	if !h.flatItems[idx].IsLastInGroup {
+		t.Error("surviving last remote retained a middle-row connector")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

There's no way to narrow the session list down to "what did I actually touch recently" ; the existing filters (`!`/`@`/`#`/`&` for status, `^` for archived) all filter on *state*, not *when*. Discussion: https://github.com/asheshgoplani/agent-deck/discussions/2097

## Why this change

Adds a recency filter cycled with `*` (shift+8, the next unclaimed slot in the existing filter-key row ; `$` cost dashboard, `%` open, `^` archived, `&` error all sit on shift+4..7): **All (default) → Today → Last 3 days → Last 7 days → All**.

- "Today" uses a local-calendar-day boundary (since local midnight) ; that's how a human reads "today" regardless of the current hour.
- "Last 3/7 days" use rolling `N*24h` windows from now.
- Both are evaluated against `Instance.DisplayLastActivityTime()`, the same timestamp already shown as "⏱ last active" in the UI, so the filter agrees with what's on screen.
- It composes with the existing status filter as an AND, reusing the same two-pass mark/filter shape and auto-clear-to-default-on-empty-result safety net the status filter already has (`internal/ui/home.go`'s `rebuildFlatItems`).
- Registered as a first-class configurable hotkey (`cycle_time_filter` in `internal/ui/hotkeys.go`), rebindable the same way as `cycle_group_view` (`t`), rather than a hardcoded const like the older status-filter keys.
- Persisted across restarts via `uiState`, same as preview mode / status filter / group view mode.

Alternatives considered (also in the Discussion): a dedicated hotkey per range (rejected ; the ranges are an ordered progression, today ⊂ 3 days ⊂ 7 days ⊂ all, which is a closer match to the `t` view-mode cycle than to the status filter's mutually-exclusive multi-key pattern); calendar-day windows for 3/7 days too (rejected ; the day-boundary fuzziness that matters for "today" is negligible at 3-7 days, and a rolling window avoids re-deriving "N calendar days ago" per timezone).

## User impact

Active filters refresh on the first regular UI tick after a relevant time boundary, preserving a surviving selected row. New hotkey `*` cycles the session list through Today / Last 3 days / Last 7 days / All (default, unchanged behavior for anyone who doesn't press it). The filter bar hint and in-app help overlay (`?`) both show the new binding and current state, e.g. `•  * today`.

## Evidence

Current published composition `02b1b5135d40e908a3880b1f1ba4c938911d8feb`, tree `108ab53d708b0dd993d216dd9c9965bd37a2d313`, incorporates actual main `778a26bbb99ffc62d9fa0ed294d22c3e2bec3387` by a normal merge with no manual edits. Its sole shared main.go path retains the new command-help/registry behavior and the recency JSON timestamp field in separate functions. UI/parser/filter files retain their exact reviewed parent blobs. This last composition is source-only; runtime results below retain their original source binding. Original contributor history is retained, and this PR closes no issue automatically.

The subsequent clock-expiry review found that normal group view did not rebuild solely because time passed. Corrected source `c0909cf30d98fb16d231a741674b8cce5fa506b8`, tree `defc911a6eb8ccc15e65eec5870b59698755f694`, records the next eligible expiry during the existing membership scan. Ordinary ticks compare that deadline without rescanning. At expiry, the list rebuilds with selection preserved. Today uses local civil midnight, including DST; rolling windows retain their inclusive cutoff and expire one nanosecond afterward. Known local and remote timestamps participate, including collapsed groups; unknown remote timestamps keep their existing inclusion behavior.

A baseline-compatible real `Home.Update(tickMsg(...))` regression on unchanged pre-fix UI source produced **12 failing test/subtest events and one passing All-filter control**. Failures were wrong visible membership or missing fallback, not compilation errors. The corrected c090 source passed **51 RUN / 51 PASS / 0 FAIL / 0 SKIP**: 46 affected UI test/subtest events under race instrumentation, then five mandatory isolation events separately without race so both real bootstrap child checks ran. Coverage includes local/remote selection, midnight, exact rolling boundaries, collapsed/unknown rows, 23/25-hour DST days, eligibility and deadline recalculation. Test stages and runner exited zero, and source stayed clean. Independent source and code-simplifier review approved this exact correction. Affected `internal/ui` vet passed. A prebuilt, identical 1,000-local/1,000-remote rebuild fixture used 50 iterations per sample and three alternating before/after samples: All median 1.147 ms before / 1.477 ms after; active 3-day filter 1.877 ms / 2.271 ms. These bounded samples include noise even in All and show observed extra rebuild cost, not a speedup or general latency guarantee. Ordinary normal-view ticks before expiry do not rebuild, as the behavior controls verify.

The previous frozen composition `3bc1615d79ea1f2b0ca437b368dfc35ecc2bd5eb`, tree `4ef22934be547d7ebaff829fa7d82fafd9ac0a13`, passed the complete `internal/ui` package under `-race` in 67.455s and focused changed recency-mode/remote timestamp tests. All 47 required parent/child controls ran and passed. Combined result: 1,964 passing events, 17 existing unrelated skips (eight require jj, nine are documented unsupported or inapplicable paths), zero failures. No required test skipped. These results bind that earlier tree, not a repository-wide full run or the final publication head.

Earlier landed-storage intersection acceptance on `d421f98ad96aebc3633a4039067abb57afb6e6a9`: **58 RUN / 58 PASS / 0 FAIL / 0 SKIP** under `-race`, covering recency, mixed local/remote filtering, collapsed groups, selection, reload races, committed group snapshot/deletion behavior and account persistence. Tests and frozen runner both exited 0; source stayed clean. Run used Go 1.25.14, tmux 3.3a, sandboxed HOME/XDG, four CPUs and serial package execution. That focused run lasted 65 seconds and remains attributed to d421. No final publication-head full UI or repository-wide rerun is claimed. Account persistence checks do not claim new account-slot display behavior.

The corrected candidate `1603b07976cca45fb1a5cf818763adfd5de075ef` has meaningful original-head failures for mixed local/remote filtering, scope, collapsed groups and connectors. Corrected focused tests, the full UI package and vet pass in disposable Docker. Independent correction review found no remaining source blocker. One snapshot supplies a global fallback decision; remote sessions are filtered before rows are built. Status membership now includes collapsed groups so composed filters retain a reachable header.

A synthetic 1,000-local/1,000-remote all-recent benchmark measured median 809603 ns/op before and 534929 ns/op after across three samples. This is container-local timing, not a universal speedup claim. Fresh contributor gate: 13 PASS / 0 FAIL. The two substantive warnings are aggregate +739/-34 size and the baseline new-symbol revert compile warning; the separate original-PR behavioral red proof avoids treating that compile failure as evidence. The remaining body-marker placement warning is corrected here. The larger diff implements one recency feature and its mixed-fleet/collapse regressions; splitting the correction from the unmerged feature would leave that feature knowingly broken. Those results bind the stated earlier correction head. Current published-head full CI is still required before merge.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-5; GPT-6 for the scoped correction and separate independent review.

## What actually bothered you

"i would like to add feature to agent-deck that is filtering only showing sessions that are in range of times, like today, 3day, 7 day, and then no filter like current default to show all." ; my session list has grown across enough groups that I couldn't quickly answer "what did I touch today/this week" without scanning the whole thing by eye.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=claude-sonnet-5+gpt-6 intent=yes -->
