### PR TITLE
fix(update): pin gh token lookup to github.com

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -193,9 +193,13 @@ func saveCache(cache *UpdateCache) error {
 }
 
 // resolveGitHubToken returns a GitHub token from (in order) GITHUB_TOKEN,
-// GH_TOKEN, or `gh auth token`. Returns "" if none are available. Any
-// failure invoking `gh` is treated as "no token" so we fall back to
-// anonymous requests.
+// GH_TOKEN, or `gh auth token --hostname github.com`. Returns "" if none
+// are available. The gh lookup is pinned to github.com because that is the
+// only host we talk to: without the flag gh returns the token for its
+// "default" host, which on a GitHub Enterprise-only machine is the
+// enterprise credential. Any failure invoking `gh` (including "no token
+// for github.com") is treated as "no token" so we fall back to anonymous
+// requests.
 func resolveGitHubToken() string {
 	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
 		return t
@@ -206,7 +210,7 @@ func resolveGitHubToken() string {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return ""
 	}
-	out, err := exec.Command("gh", "auth", "token").Output()
+	out, err := exec.Command("gh", "auth", "token", "--hostname", "github.com").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -563,4 +564,40 @@ func TestHomebrewUpgradeHint(t *testing.T) {
 			assert.Equal(t, tt.wantHint, hint)
 		})
 	}
+}
+
+// installFakeGh writes an executable `gh` shell script into a temp dir and
+// prepends that dir to PATH so resolveGitHubToken's fallback runs it.
+func installFakeGh(t *testing.T, script string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script requires a POSIX shell")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gh"), []byte("#!/bin/sh\n"+script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	return dir
+}
+
+func TestResolveGitHubToken_OnlyUsesGithubComScopedGhToken(t *testing.T) {
+	t.Run("passes --hostname github.com", func(t *testing.T) {
+		dir := installFakeGh(t, `echo "$@" >> "$(dirname "$0")/args"; echo tok`)
+		assert.Equal(t, "tok", resolveGitHubToken())
+		argv, err := os.ReadFile(filepath.Join(dir, "args"))
+		require.NoError(t, err)
+		assert.Equal(t, "auth token --hostname github.com", strings.TrimSpace(string(argv)))
+	})
+
+	t.Run("GHE-only gh yields no token", func(t *testing.T) {
+		// Mimics gh on a machine whose hosts.yml only knows an enterprise
+		// host: the hostless form returns the enterprise token, the
+		// github.com-scoped form fails.
+		installFakeGh(t, `case " $* " in
+  *" --hostname github.com "*) echo "no oauth token found for github.com" >&2; exit 1 ;;
+  *) echo ghe_fake_token ;;
+esac`)
+		assert.Equal(t, "", resolveGitHubToken())
+	})
 }


### PR DESCRIPTION
## What problem does this solve?

The update checker can obtain a GitHub Enterprise credential from gh and send it to the public GitHub API, causing a 401. Fixes #2096.

## Why this change

Request `gh auth token --hostname github.com`, matching the existing HTTPS API destination. If gh has no public-host credential, the existing error path falls back to anonymous requests. This recovers the prior scoped implementation after independent source review.

## User impact

Enterprise-only gh installations can check for updates anonymously. Explicit `GITHUB_TOKEN`, then `GH_TOKEN`, precedence remains unchanged. Both CLI and TUI update checks use this resolver.

## Evidence

Independent source review of `4868631fd025325394b69a7892abc5182d39e4d0` found no blocker. The tests record the child process argv and simulate an Enterprise-only gh installation. The latter must yield no credential for a public-host request. Fresh Docker contributor self-check: 16 PASS, 0 FAIL, 0 WARN. `go vet ./...`, `go build ./...`, and `go test -p 2 ./...` passed with sandboxed HOME/XDG and GOMAXPROCS=4. Reverting the production changes made the new tests fail, confirming the regression coverage. No real credentials or live Enterprise service are used in these tests. API transport remains HTTPS.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** GPT-6 for recovery and independent review; prior implementation model unsure.

## What actually bothered you

The issue author reported: "Update checker sends a GitHub Enterprise-scoped gh token to api.github.com, gets rejected (401)".

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed with validation limits
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub authentication now consistently uses credentials scoped to `github.com`.
  * Prevented unintended fallback to enterprise-hosted GitHub credentials when resolving GitHub CLI authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->