### PR TITLE
fix(send): preserve composer drafts without automatic interrupts

### DIFF
--- a/cmd/agent-deck/issue1409_1413_send_guard_integration_test.go
+++ b/cmd/agent-deck/issue1409_1413_send_guard_integration_test.go
@@ -90,7 +90,7 @@ func TestExecuteSend_OperatorDraftNotMerged_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(content, "instruct deploy ag") || strings.Contains(content, msg) || strings.Contains(content, "GOT:") {
+	if !strings.Contains(content, "instruct deploy ag") || strings.Contains(content, msg) || strings.Contains(content, "\nGOT: ") {
 		t.Fatalf("draft changed or automated input leaked into pane: %q", content)
 	}
 }
@@ -99,9 +99,14 @@ func TestExecuteSend_OperatorDraftNotMerged_Integration(t *testing.T) {
 // characters back onto the prompt line but never accepts Enter — the
 // typed-but-unsubmitted state of issue #1413.
 const fakeClaudeSwallowsEnter = `bash -c '
-	printf "❯ "
-	buf=""
-	while IFS= read -r -n1 c; do [ -n "$c" ] && buf="$buf$c" && printf "\r❯ %s" "$buf"; done
+ stty -echo
+ divider="────────────────────────────────────────"
+ buf=""
+ render() { printf "\033[2J\033[H%s\n❯ %s\n%s\n" "$divider" "$buf" "$divider"; }
+ render
+ while IFS= read -r -n1 c; do
+  if [ -n "$c" ]; then buf="$buf$c"; render; fi
+ done
 '`
 
 func TestExecuteSend_TypedNotSubmitted_Integration(t *testing.T) {
@@ -137,7 +142,7 @@ func TestExecuteSend_NoWaitGuardsDraft_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(content, "instruct deploy ag") || strings.Contains(content, msg) || strings.Contains(content, "GOT:") {
+	if !strings.Contains(content, "instruct deploy ag") || strings.Contains(content, msg) || strings.Contains(content, "\nGOT: ") {
 		t.Fatalf("draft changed or automated input leaked into pane: %q", content)
 	}
 }

--- a/cmd/agent-deck/issue1409_1413_send_guard_integration_test.go
+++ b/cmd/agent-deck/issue1409_1413_send_guard_integration_test.go
@@ -80,49 +80,20 @@ const fakeClaudeWithDraft = `bash -c '
 
 func TestExecuteSend_OperatorDraftNotMerged_Integration(t *testing.T) {
 	skipUnlessIntegration(t)
-	sess := startFakeClaudePane(t, "send-1409-draft", fakeClaudeWithDraft)
-
-	const msg = "EVENT_1409_AUTOMATED_MESSAGE"
+	sess := startFakeClaudePane(t, "send-preserve-draft", fakeClaudeWithDraft)
+	const msg = "AUTOMATED_MUST_NOT_APPEAR"
 	res, err := executeSend(sess, "claude", msg, false, integrationGuardTuning())
-	if err != nil {
-		t.Fatalf("executeSend failed: %v (result %+v)", err, res)
+	if err == nil || res.delivery != deliveryComposerBlocked {
+		t.Fatalf("expected unsent refusal: %+v %v", res, err)
 	}
-
-	// Give the restore keystrokes time to echo.
-	time.Sleep(time.Second)
 	content, err := sess.CapturePane()
 	if err != nil {
-		t.Fatalf("CapturePane failed: %v", err)
+		t.Fatal(err)
 	}
-	t.Logf("pane after guarded send:\n%s", content)
-
-	if !strings.Contains(content, "GOT: "+msg) {
-		t.Errorf("automated message was not delivered standalone.\npane:\n%s", content)
-	}
-	if strings.Contains(content, "GOT: instruct deploy ag") {
-		t.Errorf("issue #1409: operator draft was merged/submitted with the automated send.\npane:\n%s", content)
-	}
-	if res.draftSaved != "instruct deploy ag" {
-		t.Errorf("saved draft: want %q, got %q", "instruct deploy ag", res.draftSaved)
-	}
-	if !res.draftRestored {
-		t.Errorf("operator draft must be restored after delivery, result %+v", res)
-	}
-	// Restore evidence: the draft is typed back (echoed) after the GOT line.
-	gotIdx := strings.Index(content, "GOT: "+msg)
-	if gotIdx >= 0 && !strings.Contains(content[gotIdx:], "instruct deploy ag") {
-		t.Errorf("restored draft not visible after delivery.\npane:\n%s", content)
+	if !strings.Contains(content, "instruct deploy ag") || strings.Contains(content, msg) || strings.Contains(content, "GOT:") {
+		t.Fatalf("draft changed or automated input leaked into pane: %q", content)
 	}
 }
-
-// fakeClaudeSwallowsEnter renders an empty composer and echoes typed
-// characters back onto the prompt line but never accepts Enter — the
-// typed-but-unsubmitted state of issue #1413.
-const fakeClaudeSwallowsEnter = `bash -c '
-	printf "❯ "
-	buf=""
-	while IFS= read -r -n1 c; do [ -n "$c" ] && buf="$buf$c" && printf "\r❯ %s" "$buf"; done
-'`
 
 func TestExecuteSend_TypedNotSubmitted_Integration(t *testing.T) {
 	skipUnlessIntegration(t)
@@ -147,38 +118,17 @@ func TestExecuteSend_TypedNotSubmitted_Integration(t *testing.T) {
 
 func TestExecuteSend_NoWaitGuardsDraft_Integration(t *testing.T) {
 	skipUnlessIntegration(t)
-	sess := startFakeClaudePane(t, "send-1409-nowait", fakeClaudeWithDraft)
-
-	tun := noWaitSendTuning()
-	tun.guardHold = 700 * time.Millisecond
-	tun.guardPoll = 100 * time.Millisecond
-	tun.settleDelay = 100 * time.Millisecond
-	tun.retry = sendRetryOptions{
-		maxRetries:     12,
-		checkDelay:     150 * time.Millisecond,
-		maxFullResends: -1,
-		verifyDelivery: true,
+	sess := startFakeClaudePane(t, "send-preserve-draft", fakeClaudeWithDraft)
+	const msg = "AUTOMATED_MUST_NOT_APPEAR"
+	res, err := executeSend(sess, "claude", msg, true, integrationGuardTuning())
+	if err == nil || res.delivery != deliveryComposerBlocked {
+		t.Fatalf("expected unsent refusal: %+v %v", res, err)
 	}
-
-	const msg = "INBOX_1409_NOWAIT_NUDGE"
-	res, err := executeSend(sess, "claude", msg, true, tun)
-	if err != nil {
-		t.Fatalf("executeSend --no-wait failed: %v (result %+v)", err, res)
-	}
-
 	content, err := sess.CapturePane()
 	if err != nil {
-		t.Fatalf("CapturePane failed: %v", err)
+		t.Fatal(err)
 	}
-	t.Logf("pane after guarded --no-wait send:\n%s", content)
-
-	if !strings.Contains(content, "GOT: "+msg) {
-		t.Errorf("--no-wait automated message was not delivered standalone.\npane:\n%s", content)
-	}
-	if strings.Contains(content, "GOT: instruct deploy ag") {
-		t.Errorf("issue #1409: --no-wait merged the operator draft.\npane:\n%s", content)
-	}
-	if res.draftSaved != "instruct deploy ag" || !res.draftRestored {
-		t.Errorf("--no-wait must save+restore the draft, result %+v", res)
+	if !strings.Contains(content, "instruct deploy ag") || strings.Contains(content, msg) || strings.Contains(content, "GOT:") {
+		t.Fatalf("draft changed or automated input leaked into pane: %q", content)
 	}
 }

--- a/cmd/agent-deck/issue1409_1413_send_guard_integration_test.go
+++ b/cmd/agent-deck/issue1409_1413_send_guard_integration_test.go
@@ -95,6 +95,15 @@ func TestExecuteSend_OperatorDraftNotMerged_Integration(t *testing.T) {
 	}
 }
 
+// fakeClaudeSwallowsEnter renders an empty composer and echoes typed
+// characters back onto the prompt line but never accepts Enter — the
+// typed-but-unsubmitted state of issue #1413.
+const fakeClaudeSwallowsEnter = `bash -c '
+	printf "❯ "
+	buf=""
+	while IFS= read -r -n1 c; do [ -n "$c" ] && buf="$buf$c" && printf "\r❯ %s" "$buf"; done
+'`
+
 func TestExecuteSend_TypedNotSubmitted_Integration(t *testing.T) {
 	skipUnlessIntegration(t)
 	sess := startFakeClaudePane(t, "send-1413-stuck", fakeClaudeSwallowsEnter)

--- a/cmd/agent-deck/issue1409_1413_send_guard_test.go
+++ b/cmd/agent-deck/issue1409_1413_send_guard_test.go
@@ -232,123 +232,63 @@ func TestExecuteSend_HoldsWhileOperatorDraftPresent(t *testing.T) {
 	}
 }
 
-func TestExecuteSend_SaveClearRestoreAroundBusyComposer(t *testing.T) {
-	// The operator draft never clears on its own: at the hold bound the guard
-	// must save it, clear the composer, deliver the automated message, and
-	// restore the draft after delivery is confirmed.
-	mock := &guardedSendMock{
-		draftPane:        claudeComposer("instruct deploy ag"),
-		postSendPanes:    []string{""},
-		postSendStatuses: []string{"active", "active"},
+func TestExecuteSend_RefusesBusyComposer(t *testing.T) {
+	mock := &guardedSendMock{draftPane: claudeComposer("operator draft"), chunkedErr: errors.New("typing unavailable")}
+	tun := testGuardTuning(sendRetryOptions{maxRetries: 40, checkDelay: 0, verifyDelivery: true})
+	res, err := executeSend(mock, "claude", "AUTOMATED", false, tun)
+	if err == nil || res.delivery != deliveryComposerBlocked {
+		t.Fatalf("expected explicit unsent refusal, got %+v %v", res, err)
 	}
-	tun := testGuardTuning(sendRetryOptions{maxRetries: 5, checkDelay: 0, verifyDelivery: true})
-	res, err := executeSend(mock, "claude", "[EVENT] child waiting", false, tun)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if mock.ctrlCCalls != 0 || mock.sendKeysCalls != 0 || mock.enterCalls != 0 || mock.chunkedCalls != 0 {
+		t.Fatalf("refusal mutated composer: %+v", mock)
 	}
-	if got := atomic.LoadInt32(&mock.ctrlCCalls); got != 1 {
-		t.Fatalf("expected 1 Ctrl+C to clear the busy composer, got %d", got)
-	}
-	if res.draftSaved != "instruct deploy ag" {
-		t.Fatalf("saved draft: want %q, got %q", "instruct deploy ag", res.draftSaved)
-	}
-	if !res.draftRestored {
-		t.Fatal("issue #1409: operator draft must be restored after delivery")
-	}
-	if mock.chunkedText != "instruct deploy ag" {
-		t.Fatalf("restored text: want %q, got %q", "instruct deploy ag", mock.chunkedText)
-	}
-	if mock.restoredBeforeSend {
-		t.Fatal("draft restore must happen after the automated delivery, not before")
-	}
-	if res.delivery != deliverySubmitted {
-		t.Fatalf("delivery: want %q, got %q", deliverySubmitted, res.delivery)
+	if res.draftSaved != "" || res.draftRestored || res.draftCleared {
+		t.Fatalf("draft must stay in place: %+v", res)
 	}
 }
 
-func TestExecuteSend_NoRestoreWhenTypedNotSubmitted(t *testing.T) {
-	// If the automated message itself ends typed-but-unsubmitted, restoring
-	// the operator draft would merge it into the stuck composer — exactly the
-	// #1409 collision. The draft must stay saved (surfaced to the caller),
-	// not retyped.
-	const msg = "[EVENT] child waiting on approval gate"
-	mock := &guardedSendMock{
-		draftPane:        claudeComposer("instruct deploy ag"),
-		postSendPanes:    []string{claudeComposer(msg)},
-		postSendStatuses: []string{"waiting"},
+func TestExecuteSend_RefusesBeforeTypingIntoOccupiedComposer(t *testing.T) {
+	mock := &guardedSendMock{draftPane: claudeComposer("operator draft"), chunkedErr: errors.New("typing unavailable")}
+	tun := testGuardTuning(sendRetryOptions{maxRetries: 40, checkDelay: 0, verifyDelivery: true})
+	res, err := executeSend(mock, "claude", "AUTOMATED", false, tun)
+	if err == nil || res.delivery != deliveryComposerBlocked {
+		t.Fatalf("expected explicit unsent refusal, got %+v %v", res, err)
 	}
-	tun := testGuardTuning(sendRetryOptions{maxRetries: 4, checkDelay: 0, verifyDelivery: true})
-	res, err := executeSend(mock, "claude", msg, false, tun)
-	if err == nil {
-		t.Fatal("expected typed_not_submitted error")
+	if mock.ctrlCCalls != 0 || mock.sendKeysCalls != 0 || mock.enterCalls != 0 || mock.chunkedCalls != 0 {
+		t.Fatalf("refusal mutated composer: %+v", mock)
 	}
-	if res.delivery != deliveryTypedNotSubmitted {
-		t.Fatalf("delivery: want %q, got %q", deliveryTypedNotSubmitted, res.delivery)
-	}
-	if res.draftRestored || atomic.LoadInt32(&mock.chunkedCalls) != 0 {
-		t.Fatal("draft must NOT be restored into a composer stuck holding the automated message")
-	}
-	if res.draftSaved != "instruct deploy ag" {
-		t.Fatalf("saved draft must be surfaced for recovery, got %q", res.draftSaved)
+	if res.draftSaved != "" || res.draftRestored || res.draftCleared {
+		t.Fatalf("draft must stay in place: %+v", res)
 	}
 }
 
-func TestExecuteSend_RestoreFailureIsSurfacedNotSwallowed(t *testing.T) {
-	// Delivery succeeds and the guard cleared the operator draft, but typing
-	// the draft back fails (SendKeysChunked errors). The draft is no longer on
-	// screen, so the result must flag the restore failure and keep draftSaved
-	// for recovery — not report a clean success that silently lost the draft.
-	mock := &guardedSendMock{
-		draftPane:        claudeComposer("instruct deploy ag"),
-		postSendPanes:    []string{""},
-		postSendStatuses: []string{"active", "active"},
-		chunkedErr:       errors.New("tmux send-keys failed"),
+func TestExecuteSend_PreservesDraftWithoutDependingOnRestoration(t *testing.T) {
+	mock := &guardedSendMock{draftPane: claudeComposer("operator draft"), chunkedErr: errors.New("typing unavailable")}
+	tun := testGuardTuning(sendRetryOptions{maxRetries: 40, checkDelay: 0, verifyDelivery: true})
+	res, err := executeSend(mock, "claude", "AUTOMATED", false, tun)
+	if err == nil || res.delivery != deliveryComposerBlocked {
+		t.Fatalf("expected explicit unsent refusal, got %+v %v", res, err)
 	}
-	tun := testGuardTuning(sendRetryOptions{maxRetries: 5, checkDelay: 0, verifyDelivery: true})
-	res, err := executeSend(mock, "claude", "[EVENT] child waiting", false, tun)
-	if err != nil {
-		t.Fatalf("delivery should still succeed (the automated message went through): %v", err)
+	if mock.ctrlCCalls != 0 || mock.sendKeysCalls != 0 || mock.enterCalls != 0 || mock.chunkedCalls != 0 {
+		t.Fatalf("refusal mutated composer: %+v", mock)
 	}
-	if res.delivery != deliverySubmitted {
-		t.Fatalf("delivery: want %q, got %q", deliverySubmitted, res.delivery)
-	}
-	if res.draftSaved != "instruct deploy ag" {
-		t.Fatalf("saved draft must be retained for recovery, got %q", res.draftSaved)
-	}
-	if res.draftRestored {
-		t.Fatal("draftRestored must be false when the type-back failed")
-	}
-	if !res.draftRestoreFailed {
-		t.Fatal("draftRestoreFailed must be set so the lost draft is surfaced, not swallowed")
-	}
-	if _, ok := res.jsonFields()["draft_restore_failed"]; !ok {
-		t.Fatal("draft_restore_failed must appear in jsonFields for machine-readable recovery")
+	if res.draftSaved != "" || res.draftRestored || res.draftCleared {
+		t.Fatalf("draft must stay in place: %+v", res)
 	}
 }
 
 func TestExecuteSend_NoWaitStillGuardsComposer(t *testing.T) {
-	// --no-wait skips the readiness wait, NOT the composer guard (#1409) or
-	// submit verification (#1413).
-	mock := &guardedSendMock{
-		draftPane:        claudeComposer("half typed operator message"),
-		postSendPanes:    []string{""},
-		postSendStatuses: []string{"active", "active"},
+	mock := &guardedSendMock{draftPane: claudeComposer("operator draft"), chunkedErr: errors.New("typing unavailable")}
+	tun := testGuardTuning(sendRetryOptions{maxRetries: 40, checkDelay: 0, verifyDelivery: true})
+	res, err := executeSend(mock, "claude", "AUTOMATED", true, tun)
+	if err == nil || res.delivery != deliveryComposerBlocked {
+		t.Fatalf("expected explicit unsent refusal, got %+v %v", res, err)
 	}
-	tun := testGuardTuning(noWaitSendOptions())
-	tun.retry.checkDelay = 0
-	res, err := executeSend(mock, "claude", "[INBOX] wake", true, tun)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if mock.ctrlCCalls != 0 || mock.sendKeysCalls != 0 || mock.enterCalls != 0 || mock.chunkedCalls != 0 {
+		t.Fatalf("refusal mutated composer: %+v", mock)
 	}
-	if got := atomic.LoadInt32(&mock.ctrlCCalls); got != 1 {
-		t.Fatalf("--no-wait must still clear a busy composer, got %d Ctrl+C calls", got)
-	}
-	if !res.draftRestored || mock.chunkedText != "half typed operator message" {
-		t.Fatalf("--no-wait must still restore the draft, got restored=%v text=%q",
-			res.draftRestored, mock.chunkedText)
-	}
-	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
-		t.Fatalf("#479 guard: exactly 1 SendKeysAndEnter expected, got %d", got)
+	if res.draftSaved != "" || res.draftRestored || res.draftCleared {
+		t.Fatalf("draft must stay in place: %+v", res)
 	}
 }
 

--- a/cmd/agent-deck/issue1979_resend_after_arrival_test.go
+++ b/cmd/agent-deck/issue1979_resend_after_arrival_test.go
@@ -60,10 +60,10 @@ func TestResendSuppressedOnceBodyHasArrived(t *testing.T) {
 	}
 }
 
-// TestResendStillFiresWhenNothingArrived guards the other direction: the #876
+// TestNoResendWhenNothingArrived guards the other direction: the #876
 // TUI-init case, where the body never reached the pane, must still be
 // recovered. A fix that suppressed the resend unconditionally would break it.
-func TestResendStillFiresWhenNothingArrived(t *testing.T) {
+func TestNoResendWhenNothingArrived(t *testing.T) {
 	mock := &mockSendRetryTarget{
 		statuses: []string{"waiting"},
 		panes:    []string{"❯ \n────────────────────────────────────────"}, // empty composer, no body
@@ -74,12 +74,11 @@ func TestResendStillFiresWhenNothingArrived(t *testing.T) {
 		checkDelay: 0,
 	})
 
-	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n == 0 {
-		t.Error("SendCtrlC never called although nothing ever arrived — " +
-			"the #876 TUI-init recovery must survive the #1979 fix")
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Error("automatic recovery must never interrupt an unconfirmed recipient")
 	}
-	if n := atomic.LoadInt32(&mock.sendKeysCalls); n < 2 {
-		t.Errorf("SendKeysAndEnter called %d times, want >1 — the lost-message resend must still fire", n)
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n != 1 {
+		t.Errorf("SendKeysAndEnter called %d times, want exactly1 without an automatic resend", n)
 	}
 }
 
@@ -103,7 +102,7 @@ func emptyComposerPane() string {
 	}, "\n")
 }
 
-// TestResendStillFiresAfterComposerMarkerCleared is the regression guard for the
+// TestNoResendAfterComposerMarkerCleared is the regression guard for the
 // review finding on the first attempt at this fix. That attempt gated the resend
 // on sawDeliveryEvidence, which latches — and one of its sources is the composer
 // merely HOLDING the message, which is the opening step of the TUI-init loss
@@ -113,7 +112,7 @@ func emptyComposerPane() string {
 // success. Gating on a per-iteration observation instead keeps the recovery.
 //
 // Marker first, then a cleared composer: nothing was ever submitted.
-func TestResendStillFiresAfterComposerMarkerCleared(t *testing.T) {
+func TestNoResendAfterComposerMarkerCleared(t *testing.T) {
 	const msg = "recover me please"
 	mock := &mockSendRetryTarget{
 		statuses: []string{"waiting"},
@@ -125,12 +124,11 @@ func TestResendStillFiresAfterComposerMarkerCleared(t *testing.T) {
 		checkDelay: 0,
 	})
 
-	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n == 0 {
-		t.Error("resend never fired after the composer marker cleared — the message " +
-			"landed in the composer, was discarded, and was not recovered (#876 regression)")
+	if n := atomic.LoadInt32(&mock.sendCtrlCCalls); n != 0 {
+		t.Error("automatic recovery must never interrupt after a marker disappears")
 	}
-	if n := atomic.LoadInt32(&mock.sendKeysCalls); n < 2 {
-		t.Errorf("SendKeysAndEnter called %d times, want >1 — the lost message was never re-sent", n)
+	if n := atomic.LoadInt32(&mock.sendKeysCalls); n != 1 {
+		t.Errorf("SendKeysAndEnter called %d times, want exactly1 without an automatic resend", n)
 	}
 	// Note: on this path the call still returns success, both before and after
 	// this change, because the loop treats held-then-cleared as submission

--- a/cmd/agent-deck/issue2104_preservation_test.go
+++ b/cmd/agent-deck/issue2104_preservation_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIssue2104RefusalNeverTypesOrInterrupts(t *testing.T) {
+	for _, noWait := range []bool{false, true} {
+		mock := &guardedSendMock{draftPane: claudeComposer("user draft")}
+		res, err := executeSend(mock, "claude", "automation", noWait, testGuardTuning(sendRetryOptions{maxRetries: 40, verifyDelivery: true}))
+		if err == nil || res.jsonFields()["submitted"] != false {
+			t.Fatalf("expected unsent refusal: %+v %v", res, err)
+		}
+		if mock.ctrlCCalls != 0 || mock.sendKeysCalls != 0 || mock.enterCalls != 0 || mock.chunkedCalls != 0 {
+			t.Fatalf("refusal mutated pane: %+v", mock)
+		}
+		if _, ok := res.jsonFields()["saved_draft"]; ok {
+			t.Fatal("preserved draft should not be copied into response")
+		}
+	}
+}
+
+func TestIssue2104FailedCaptureRefusesBeforeTyping(t *testing.T) {
+	mock := &mockSendRetryTarget{paneErrs: []error{errors.New("capture unavailable")}}
+	res, err := executeSend(mock, "claude", "automation", false, testGuardTuning(sendRetryOptions{verifyDelivery: true}))
+	if err == nil || res.jsonFields()["submitted"] != false {
+		t.Fatalf("capture failure authorized delivery: %+v %v", res, err)
+	}
+	if mock.sendKeysCalls != 0 || mock.sendEnterCalls != 0 || mock.sendCtrlCCalls != 0 {
+		t.Fatalf("capture failure mutated pane: %+v", mock)
+	}
+}

--- a/cmd/agent-deck/issue2104_preservation_test.go
+++ b/cmd/agent-deck/issue2104_preservation_test.go
@@ -22,7 +22,7 @@ func TestIssue2104RefusalNeverTypesOrInterrupts(t *testing.T) {
 }
 
 func TestIssue2104FailedCaptureRefusesBeforeTyping(t *testing.T) {
-	mock := &mockSendRetryTarget{paneErrs: []error{errors.New("capture unavailable")}}
+	mock := &mockSendRetryTarget{panes: []string{""}, paneErrs: []error{errors.New("capture unavailable")}}
 	res, err := executeSend(mock, "claude", "automation", false, testGuardTuning(sendRetryOptions{verifyDelivery: true}))
 	if err == nil || res.jsonFields()["submitted"] != false {
 		t.Fatalf("capture failure authorized delivery: %+v %v", res, err)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3482,18 +3482,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	// Take the first run of non-whitespace content, capped, to avoid false
 	// positives from matching common short strings.
 	deliveryToken := messageDeliveryToken(message)
-	// presenceNeedle answers "is this message on screen", which is a different
-	// question from deliveryToken's "is this a distinctive enough string to
-	// treat as proof of delivery". The token is empty below 12 bytes, so
-	// without a fallback a short queued message like "OK" would read as absent
-	// forever and take the Ctrl+C-and-resend this guard exists to prevent.
-	// Falling back to the trimmed body can over-match a common short string,
-	// but the consequence is declining to interrupt a live target, which is the
-	// safe direction: such a message still surfaces via the #876 check.
-	presenceNeedle := deliveryToken
-	if presenceNeedle == "" {
-		presenceNeedle = strings.TrimSpace(message)
-	}
 	// attrib is the #1777 attribution gate. EVERY bare Enter in this loop —
 	// including the unsent-prompt branch, which used to press unconditionally
 	// whenever a "[Pasted text …]" marker appeared anywhere in the pane —
@@ -3507,9 +3495,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		time.Sleep(opts.checkDelay)
 
 		unsentPromptDetected := false
-		// bodyInPaneNow is this iteration's answer to "is the body on screen
-		// right now", deliberately not latched. See the resend branch below.
-		bodyInPaneNow := false
 		// paneNow is this iteration's observation (raw ANSI + whether the
 		// capture succeeded at all), and is what the attribution gate reads.
 		captured, captureErr := target.CapturePaneFresh()
@@ -3517,7 +3502,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		if paneNow.OK {
 			content := tmux.StripANSI(captured)
 			unsentPromptDetected = send.ComposerHoldsPasteMarker(captured, tmux.StripANSI) || send.HasUnsentComposerPrompt(content, message)
-			bodyInPaneNow = presenceNeedle != "" && strings.Contains(content, presenceNeedle)
 			if !sawDeliveryEvidence && deliveryToken != "" && strings.Contains(content, deliveryToken) {
 				sawDeliveryEvidence = true
 			}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3086,6 +3086,8 @@ const (
 	deliveryNoEvidence = "no_evidence"
 	// deliverySendFailed: the initial tmux send-keys itself failed.
 	deliverySendFailed = "send_failed"
+	// deliveryComposerBlocked: no input sent because composer safety was not established.
+	deliveryComposerBlocked = "composer_blocked"
 )
 
 // sendDeliveryResult is the prompt-state-aware outcome of executeSend.
@@ -3142,7 +3144,7 @@ func (r sendDeliveryResult) jsonFields() map[string]interface{} {
 type sendExecTuning struct {
 	// guardHold bounds the #1409 hold-and-retry phase: how long an automated
 	// send waits for a non-empty operator draft to clear on its own before
-	// falling back to save-clear-restore.
+	// refusing delivery while preserving it.
 	guardHold      time.Duration
 	guardPoll      time.Duration
 	guardClearWait time.Duration
@@ -3225,8 +3227,10 @@ func executeSend(target sendRetryTarget, tool, message string, noWait bool, tun 
 			Strip:        tmux.StripANSI,
 		})
 		res.held = guard.Held
-		res.draftSaved = guard.SavedDraft
-		res.draftCleared = guard.DraftCleared
+		if guard.Refused {
+			res.delivery = deliveryComposerBlocked
+			return res, fmt.Errorf("message not sent: composer is occupied or unreadable; existing draft preserved")
+		}
 		// Provenance for the #1777 attribution gate, taken from the capture
 		// the guard already made just before we type: with no paste marker
 		// parked in the composer then, a marker seen during verification is
@@ -3237,17 +3241,6 @@ func executeSend(target sendRetryTarget, tool, message string, noWait bool, tun 
 	delivery, err := sendWithRetryTarget(target, message, skipClaudeDeliveryVerify(tool), tun.retry)
 	res.delivery = delivery
 
-	if res.draftSaved != "" && delivery != deliveryTypedNotSubmitted {
-		if restoreErr := target.SendKeysChunked(res.draftSaved); restoreErr == nil {
-			res.draftRestored = true
-		} else {
-			// The composer was cleared (Ctrl+C) but the type-back failed, so
-			// the operator's draft is no longer on screen. Don't silently
-			// drop it: flag the failure so the caller surfaces draftSaved for
-			// recovery instead of reporting a clean success.
-			res.draftRestoreFailed = true
-		}
-	}
 	return res, err
 }
 
@@ -3365,7 +3358,7 @@ type sendRetryTarget interface {
 type sendRetryOptions struct {
 	maxRetries     int
 	checkDelay     time.Duration
-	maxFullResends int // >0 overrides default (3); <0 disables Ctrl+C-then-resend; 0 uses default
+	maxFullResends int // Legacy option; full-body interrupt/resend recovery is disabled.
 
 	// verifyDelivery, when true, requires the verification loop to observe at
 	// least one positive signal that the message reached the inner agent (an
@@ -3455,27 +3448,12 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	// - If we never observe active and remain in waiting/idle, keep a periodic
 	//   fallback Enter cadence instead of returning early (handles late unsent
 	//   prompt rendering races seen in Claude startup).
-	// - If the message appears completely lost (no prompt marker, no activity
-	//   after several retries), clear stale input with Ctrl+C and re-send the
-	//   full message. This handles the TUI init race where the prompt renders
-	//   before the input handler is ready, causing sent keys to be discarded.
 	const activeSuccessThreshold = 2
 	const waitingAfterActiveThreshold = 2
-	// fullResendThreshold: after this many consecutive waiting/idle checks
-	// with no activity and no unsent prompt, assume the message was lost
-	// during TUI init and re-send the full message.
-	const fullResendThreshold = 8
-	maxFullResends := 3 // default
-	if opts.maxFullResends > 0 {
-		maxFullResends = opts.maxFullResends
-	} else if opts.maxFullResends < 0 {
-		maxFullResends = 0
-	}
 	waitingNoMarkerChecks := 0
-	waitingNoActivityChecks := 0
 	activeChecks := 0
 	sawActiveAfterSend := false
-	fullResendCount := 0
+
 	// sawDeliveryEvidence flips true on any positive signal that the message
 	// reached the agent: an "active" status transition, an unsent-prompt
 	// composer marker, or the message body appearing verbatim in the pane.
@@ -3550,7 +3528,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 			sawDeliveryEvidence = true
 			sawUnsentMarker = true
 			waitingNoMarkerChecks = 0
-			waitingNoActivityChecks = 0
 			activeChecks = 0
 			attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
 			continue
@@ -3560,7 +3537,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 			sawActiveAfterSend = true
 			sawDeliveryEvidence = true
 			waitingNoMarkerChecks = 0
-			waitingNoActivityChecks = 0
 			activeChecks++
 			if activeChecks >= activeSuccessThreshold {
 				return deliverySubmitted, nil
@@ -3572,91 +3548,15 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 		if err == nil && (status == "waiting" || status == "idle") {
 			if sawActiveAfterSend {
 				waitingNoMarkerChecks++
-				waitingNoActivityChecks = 0
 				if waitingNoMarkerChecks >= waitingAfterActiveThreshold {
 					return deliverySubmitted, nil
 				}
 			} else {
 				waitingNoMarkerChecks = 0
-				waitingNoActivityChecks++
 
-				// Message may have been lost during TUI init: the prompt was
-				// visible but the input handler wasn't ready, so sent keys were
-				// discarded. Clear stale input and re-send the full message.
-				//
-				// THE GATE: fire only when the body is not on screen right now.
-				// A recovery for a body that is already there can only
-				// duplicate it, and the Ctrl+C that precedes it interrupts
-				// whatever the target is doing meanwhile. bodyInPaneNow is
-				// recomputed every iteration on purpose: "a resend would
-				// duplicate" is a claim about the present, so it needs a
-				// present-tense signal.
-				//
-				// NOT sawDeliveryEvidence, which is the obvious candidate and
-				// is wrong. It latches, and one of its sources is the composer
-				// merely HOLDING the message — the first step of the very
-				// TUI-init loss this recovery exists for. Gating on it would
-				// suppress the recovery exactly when it is needed and then,
-				// because the same flag suppresses the #876 error at the end of
-				// the budget, report the lost message as delivered. Compare
-				// sawUnsentMarker, which is tracked separately for the same
-				// provenance reason.
-				//
-				// paneNow.OK is required for a related reason one level down:
-				// bodyInPaneNow is only assigned when the capture succeeded, so
-				// without it the gate would read false by ABSENCE of an
-				// observation rather than by an observation of absence, and a
-				// failed CapturePaneFresh would re-authorize the Ctrl+C against
-				// a target that is working fine. A destructive branch should
-				// need positive evidence, not silence.
-				//
-				// History: #1979 is the busy target with the message already
-				// queued. It and a target that never received the message both
-				// fail to report "active" — they are indistinguishable BY
-				// STATUS ALONE, which is why this reaches for pane evidence
-				// instead. Ungated, the branch fired on the busy one and
-				// destroyed in-flight work at exit 0. #479 established the same
-				// double-send on the --no-wait path, which noWaitSendOptions
-				// disables outright; this keeps the recovery for the case it was
-				// written for.
-				if waitingNoActivityChecks >= fullResendThreshold && fullResendCount < maxFullResends &&
-					paneNow.OK && !bodyInPaneNow {
-					// The resend types the message and presses Enter, so it
-					// submits whatever the composer still holds. Ctrl+C is
-					// meant to empty it first — but a failed Ctrl+C, or one
-					// the agent ignored, would leave foreign content to be
-					// submitted with our payload appended (#1777). Re-read
-					// the pane and skip the resend unless the composer is
-					// verifiably clear of content we cannot attribute.
-					//
-					// fullResendCount and waitingNoActivityChecks are consumed
-					// below, ONLY once a resend is actually about to fire —
-					// not here. Either abort path (Ctrl+C error, or a pane
-					// that still reads as foreign after it) sends nothing, so
-					// charging the finite resend budget or resetting the
-					// waiting-check counter here would burn a scarce slot for
-					// no send and force a fresh fullResendThreshold wait
-					// before the next attempt, right after Ctrl+C may have
-					// already wiped the composer (#1778 review finding 3).
-					if ctrlCErr := target.SendCtrlC(); ctrlCErr != nil {
-						continue
-					}
-					time.Sleep(200 * time.Millisecond)
-					if attrib.EnterWouldSubmitForeignDraft(
-						send.CaptureOutcome(target.CapturePaneFresh()), tmux.StripANSI) {
-						continue
-					}
-					fullResendCount++
-					waitingNoActivityChecks = 0
-					// A successful resend is not yet evidence of receipt — the
-					// next iteration must still observe a positive signal — so
-					// we intentionally do NOT set sawDeliveryEvidence here, even
-					// when SendKeysAndEnter returns nil. The send attempt is
-					// recorded only so verifyDelivery can distinguish "pipe ever
-					// fired" from "never even acked".
-					_ = target.SendKeysAndEnter(message)
-					continue
-				}
+				// Never clear or resend a body to force progress. Automatic Ctrl-C
+				// can erase operator input or become a session-exit gesture.
+				// Only the attribution gate may authorize an Enter retry.
 
 				// We haven't observed any post-send activity yet. Nudge Enter
 				// aggressively in the early window (every iteration for first 5
@@ -3669,7 +3569,6 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 			continue
 		}
 		waitingNoMarkerChecks = 0
-		waitingNoActivityChecks = 0
 
 		// Ambiguous state: keep a best-effort Enter retry budget.
 		// Increased from 2 to 4 because some TUI frameworks take longer

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3095,7 +3095,7 @@ type sendDeliveryResult struct {
 	// delivery is one of the delivery* constants above.
 	delivery string
 	// held is how long the composer guard waited/worked before the send
-	// (issue #1409 hold-and-retry plus save-clear time).
+	// (bounded hold plus the final read-only settle check).
 	held time.Duration
 	// draftSaved is the operator draft that was cleared from the composer to
 	// make way for the automated send (empty when no clear was needed).
@@ -3275,7 +3275,8 @@ func executeDraft(target draftSender, message string) error {
 // submitted. Budget must be long enough to see the composer either
 // accept or reject the submission.
 //
-// maxFullResends=-1 is load-bearing: it disables the Ctrl+C-then-resend
+// Full-body resend recovery is disabled for every send mode. Historically,
+// maxFullResends=-1 disabled the Ctrl+C-then-resend
 // path (issue #479 — would otherwise double-send).
 func noWaitSendOptions() sendRetryOptions {
 	return sendRetryOptions{
@@ -3341,8 +3342,8 @@ func awaitComposerReadyBestEffort(target sendRetryTarget, maxWait, pollInterval 
 //     after the initial send, keeps detecting unsent-prompt markers and
 //     re-firing SendEnter if the composer still holds our message.
 //
-// maxFullResends=-1 is load-bearing for the #479 regression (never
-// double-send). Non-Claude tools skip the preflight — they have their
+// Full-body resend recovery stays disabled (#479). Non-Claude tools skip
+// the preflight; they have their
 // own readiness shapes and upstream gating. Issue #1409 added a fourth
 // layer between 2 and 3: the composer-draft guard.
 
@@ -3362,8 +3363,8 @@ type sendRetryOptions struct {
 
 	// verifyDelivery, when true, requires the verification loop to observe at
 	// least one positive signal that the message reached the inner agent (an
-	// "active" status transition, an unsent-prompt composer marker, a full
-	// resend, or the message body appearing in the captured pane). If the
+	// "active" status transition, an unsent-prompt composer marker, or the
+	// message body appearing in the captured pane). If the
 	// budget is exhausted without any such signal, the function returns an
 	// error instead of the prior best-effort `nil`. Closes the silent-drop
 	// path reported in issue #876.

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -677,19 +677,13 @@ func TestSendWithRetryTarget_IncreasedAmbiguousBudget(t *testing.T) {
 	}
 }
 
-func TestSendWithRetryTarget_FullResendAfterMessageLost(t *testing.T) {
-	// Simulate the TUI init race: agent reports "waiting" but never transitions
-	// to "active" because the message was lost during init. After
-	// fullResendThreshold (8) consecutive waiting checks with no activity,
-	// sendWithRetryTarget should Ctrl+C and re-send the full message.
-	// After re-send, the agent transitions to "active".
+func TestSendWithRetryTarget_NeverInterruptsBeforeDelayedActivity(t *testing.T) {
 	statuses := make([]string, 12)
 	panes := make([]string, 12)
 	for i := range statuses {
 		statuses[i] = "waiting"
 		panes[i] = ""
 	}
-	// After the full resend (at check ~9), agent becomes active
 	statuses[10] = "active"
 	statuses[11] = "active"
 
@@ -701,26 +695,15 @@ func TestSendWithRetryTarget_FullResendAfterMessageLost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 1 {
-		t.Fatalf("expected 1 SendCtrlC call for full resend, got %d", got)
+	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+		t.Fatalf("expected 0 SendCtrlC calls, got %d", got)
 	}
-	// sendKeysCalls: 1 initial + 1 resend = 2
-	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 2 {
-		t.Fatalf("expected 2 SendKeysAndEnter calls (initial + resend), got %d", got)
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("expected 1 SendKeysAndEnter call, got %d", got)
 	}
 }
 
-// TestSendWithRetryTarget_FullResendMaxLimit guards the full-resend cap (3)
-// AND the post-#876 silent-drop contract. Note: the impl deliberately does
-// NOT count a successful Ctrl+C+resend attempt as positive evidence —
-// `sawDeliveryEvidence` is intentionally NOT set on a resend (session_cmd.go
-// "intentionally NOT setting sawDeliveryEvidence here" comment). So even
-// after 3 successful resends, if the agent never transitions to active and
-// no marker appears, verifyDelivery must error. State-machine assertions
-// (3 Ctrl+C, 4 SendKeysAndEnter) preserved.
-func TestSendWithRetryTarget_FullResendMaxLimit(t *testing.T) {
-	// With fullResendThreshold=8 we need at least 8*4=32 retries to trigger
-	// all 3 resends plus some trailing checks.
+func TestSendWithRetryTarget_NeverInterruptsOrResendsAfterUnconfirmedDelivery(t *testing.T) {
 	n := 40
 	statuses := make([]string, n)
 	panes := make([]string, n)
@@ -742,13 +725,11 @@ func TestSendWithRetryTarget_FullResendMaxLimit(t *testing.T) {
 	if !strings.Contains(err.Error(), "876") {
 		t.Errorf("expected error to reference issue #876, got: %v", err)
 	}
-	// Should have exactly 3 full resends (the cap)
-	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 3 {
-		t.Fatalf("expected 3 SendCtrlC calls (max resends), got %d", got)
+	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+		t.Fatalf("expected 0 SendCtrlC calls, got %d", got)
 	}
-	// 1 initial + 3 resends = 4
-	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 4 {
-		t.Fatalf("expected 4 SendKeysAndEnter calls (initial + 3 resends), got %d", got)
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("expected 1 SendKeysAndEnter call, got %d", got)
 	}
 }
 

--- a/internal/send/guard.go
+++ b/internal/send/guard.go
@@ -65,21 +65,19 @@ func ComposerHasDraft(raw string, strip func(string) string) bool {
 // *tmux.Session satisfies it.
 type ComposerGuardTarget interface {
 	CapturePaneFresh() (string, error)
-	SendCtrlC() error
 }
 
 // ComposerGuardOptions tunes GuardComposerDraft. All bounds are mandatory so
 // the guard can never hold a delivery indefinitely.
 type ComposerGuardOptions struct {
 	// HoldWait is the maximum time to wait for an operator draft to clear on
-	// its own (operator submits or erases it) before falling back to
-	// save-clear-restore.
+	// its own (operator submits or erases it) before refusing delivery.
 	HoldWait time.Duration
 	// PollInterval is the capture cadence during the hold phase.
 	// Defaults to 250ms when <= 0.
 	PollInterval time.Duration
-	// ClearWait is the maximum time to wait, per Ctrl+C attempt, for the
-	// composer to actually clear.
+	// ClearWait is retained for caller compatibility. The guard never clears
+	// operator input, so this value is ignored.
 	ClearWait time.Duration
 	// Strip is applied to raw captured pane content before composer
 	// introspection (pass tmux.StripANSI). nil means identity.
@@ -90,19 +88,14 @@ type ComposerGuardOptions struct {
 type ComposerGuardResult struct {
 	// Held is the total wall-clock time the guard spent before returning.
 	Held time.Duration
-	// SavedDraft is the operator draft that was cleared to make way for the
-	// automated send. Empty when the composer was empty or cleared on its
-	// own. Callers must restore it (type it back, without Enter) after the
-	// automated delivery is confirmed.
-	SavedDraft string
-	// DraftCleared is true when the guard issued Ctrl+C and confirmed the
-	// composer emptied.
+	// Refused means the composer remains occupied or could not be captured.
+	// Callers must return without typing or pressing Enter.
+	Refused bool
+	// Legacy delivery metadata remains zero: operator input is preserved in
+	// place, never saved, cleared, or restored by automated delivery.
+	SavedDraft   string
 	DraftCleared bool
-	// ClearFailed is true when Ctrl+C attempts were exhausted and the
-	// composer still held the draft. The caller proceeds with the send
-	// regardless (delivery must not be dropped), accepting the residual
-	// merge risk for this pathological case.
-	ClearFailed bool
+	ClearFailed  bool
 	// ComposerPasteMarkerFree is true when the guard's LAST successful
 	// capture showed a composer holding no "[Pasted text …]" marker. It is
 	// the pre-send provenance evidence the attribution gate needs to tell
@@ -114,9 +107,6 @@ type ComposerGuardResult struct {
 	// Enter nudge.
 	ComposerPasteMarkerFree bool
 }
-
-// maxComposerClearAttempts bounds Ctrl+C attempts during save-clear.
-const maxComposerClearAttempts = 2
 
 // saveReconfirmDelay is the settle time before the save-step re-capture. A
 // suggestion sampled in the sub-frame where its text is painted but the dim
@@ -147,21 +137,10 @@ func composerProvenanceFree(raw string, strip func(string) string) bool {
 	return !ComposerHoldsPasteMarker(raw, strip)
 }
 
-// GuardComposerDraft implements the composer-collision guard for automated
-// sends (issue #1409): an automated SendKeysAndEnter against a composer that
-// already holds half-typed operator input would merge with it and submit the
-// merged prompt. The guard:
-//
-//  1. Holds (bounded by HoldWait) while the composer shows a non-empty
-//     operator draft, polling for it to clear on its own.
-//  2. If the draft is still present at the bound, saves it, clears the
-//     composer with Ctrl+C (Claude clears the current input on a single
-//     Ctrl+C; same primitive the full-resend recovery path already uses)
-//     and confirms the clear, bounded by ClearWait per attempt.
-//
-// The guard never blocks delivery indefinitely and never errors: on capture
-// failures or a composer that refuses to clear it returns and lets the caller
-// proceed, because watchers/conductors depend on the send going through.
+// GuardComposerDraft holds an automated send while operator input occupies
+// the composer. At the bound it rechecks once for an autosuggestion redraw,
+// then refuses delivery without changing the draft. Capture failure also
+// refuses delivery. It never sends an interrupt or other keystroke.
 func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) ComposerGuardResult {
 	strip := opts.Strip
 	if strip == nil {
@@ -178,8 +157,8 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 	for {
 		raw, err := t.CapturePaneFresh()
 		if err != nil {
-			// Pane not introspectable: never block delivery on it.
-			return ComposerGuardResult{Held: time.Since(start)}
+			// An unreadable pane cannot authorize input.
+			return ComposerGuardResult{Held: time.Since(start), Refused: true}
 		}
 		if composerProvenanceFree(raw, strip) {
 			return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
@@ -196,75 +175,12 @@ func GuardComposerDraft(t ComposerGuardTarget, opts ComposerGuardOptions) Compos
 		}
 	}
 
-	// Hold bound reached with the operator draft still present. Before
-	// committing to save-clear-restore, re-capture and re-classify: a single
-	// mid-render sample can show suggestion text whose dim/grey SGR has not
-	// landed yet, and saving it would later RESTORE the suggestion as real,
-	// normal-coloured composer text that a bare Enter could submit (issue
-	// #1777). Only content that classifies as an operator draft on a second,
-	// settled capture is ever saved. On a capture failure nothing is saved —
-	// the guard must not attribute content it cannot re-read.
+	// A redraw can paint suggestion text before its dim attributes arrive.
+	// Reclassify one settled frame without modifying the composer.
 	time.Sleep(saveReconfirmDelay)
 	raw, err := t.CapturePaneFresh()
-	if err != nil {
-		return ComposerGuardResult{Held: time.Since(start)}
-	}
-	if composerProvenanceFree(raw, strip) {
+	if err == nil && composerProvenanceFree(raw, strip) {
 		return ComposerGuardResult{Held: time.Since(start), ComposerPasteMarkerFree: true}
 	}
-	draft, visible := ComposerDraft(raw, strip)
-	if !visible {
-		// No introspectable composer, yet the pane still shows a foreign
-		// paste-marker pattern: provenance cannot be established and there
-		// is no composer to clear. Fail safe without a blind Ctrl+C (#1778
-		// review finding 1) rather than falling through into the save-clear
-		// flow with an empty draft.
-		return ComposerGuardResult{Held: time.Since(start)}
-	}
-
-	// Save the confirmed operator draft and clear the composer so the
-	// automated message cannot merge with it.
-	res := ComposerGuardResult{SavedDraft: draft}
-	clearPoll := poll
-	if clearPoll > 100*time.Millisecond {
-		clearPoll = 100 * time.Millisecond
-	}
-	for attempt := 0; attempt < maxComposerClearAttempts; attempt++ {
-		if err := t.SendCtrlC(); err != nil {
-			break
-		}
-		clearDeadline := time.Now().Add(opts.ClearWait)
-		for {
-			raw, err := t.CapturePaneFresh()
-			// Require a POSITIVELY visible, empty composer before granting
-			// ComposerPasteMarkerFree: a capture that comes back !visible
-			// (transiently unreadable pane, dialog, etc.) is not evidence the
-			// clear succeeded, so it must not be folded into "cleared" (#1778
-			// review finding 2 — ComposerHasDraft is false for !visible too,
-			// which previously let this branch grant provenance it never
-			// established).
-			clearedDraft, clearedVisible := ComposerDraft(raw, strip)
-			if err == nil && clearedVisible && clearedDraft == "" {
-				res.DraftCleared = true
-				// The composer is confirmed empty right before the send, so
-				// any paste marker appearing afterwards is our own (#1777).
-				res.ComposerPasteMarkerFree = true
-				res.Held = time.Since(start)
-				return res
-			}
-			if !time.Now().Before(clearDeadline) {
-				break
-			}
-			sleepFor := clearPoll
-			if remaining := time.Until(clearDeadline); remaining < sleepFor {
-				sleepFor = remaining
-			}
-			if sleepFor > 0 {
-				time.Sleep(sleepFor)
-			}
-		}
-	}
-	res.ClearFailed = true
-	res.Held = time.Since(start)
-	return res
+	return ComposerGuardResult{Held: time.Since(start), Refused: true}
 }

--- a/internal/send/guard_test.go
+++ b/internal/send/guard_test.go
@@ -152,54 +152,33 @@ func TestGuardComposerDraft_HoldsUntilOperatorDraftClears(t *testing.T) {
 	}
 }
 
-func TestGuardComposerDraft_SaveClearAtHoldBound(t *testing.T) {
-	target := &fakeGuardTarget{
-		captures:     []string{renderComposer("instruct deploy ag")},
-		clearOnCtrlC: true,
-	}
-	res := GuardComposerDraft(target, ComposerGuardOptions{
-		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: 50 * time.Millisecond,
-	})
-	if res.SavedDraft != "instruct deploy ag" {
-		t.Fatalf("expected operator draft to be saved, got %q", res.SavedDraft)
-	}
-	if !res.DraftCleared {
-		t.Fatal("expected DraftCleared after Ctrl+C emptied the composer")
-	}
-	if res.ClearFailed {
-		t.Fatal("did not expect ClearFailed")
-	}
-	if target.ctrlCCalls != 1 {
-		t.Fatalf("expected exactly 1 Ctrl+C, got %d", target.ctrlCCalls)
+func TestGuardComposerDraft_RefusesAtHoldBound(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{renderComposer("operator draft")}, clearOnCtrlC: true}
+	for i := 0; i < 3; i++ {
+		res := GuardComposerDraft(target, ComposerGuardOptions{HoldWait: time.Millisecond, PollInterval: time.Millisecond})
+		if !res.Refused || res.SavedDraft != "" || res.DraftCleared || target.ctrlCCalls != 0 {
+			t.Fatalf("must refuse without changing input: %+v, interrupts=%d", res, target.ctrlCCalls)
+		}
 	}
 }
 
-func TestGuardComposerDraft_ClearFailureIsBoundedAndReported(t *testing.T) {
-	// Composer never clears even after Ctrl+C: the guard must give up after a
-	// bounded number of attempts and report ClearFailed (delivery proceeds —
-	// watchers/conductors depend on the send going through).
-	target := &fakeGuardTarget{captures: []string{renderComposer("stuck draft")}}
-	res := GuardComposerDraft(target, ComposerGuardOptions{
-		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
-	})
-	if res.SavedDraft != "stuck draft" {
-		t.Fatalf("expected draft saved even when clear fails, got %q", res.SavedDraft)
-	}
-	if !res.ClearFailed || res.DraftCleared {
-		t.Fatalf("expected ClearFailed without DraftCleared, got %+v", res)
-	}
-	if target.ctrlCCalls != 2 {
-		t.Fatalf("clear attempts must be bounded at 2, got %d", target.ctrlCCalls)
+func TestGuardComposerDraft_RepeatedRefusalNeverInterrupts(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{renderComposer("operator draft")}, clearOnCtrlC: true}
+	for i := 0; i < 3; i++ {
+		res := GuardComposerDraft(target, ComposerGuardOptions{HoldWait: time.Millisecond, PollInterval: time.Millisecond})
+		if !res.Refused || res.SavedDraft != "" || res.DraftCleared || target.ctrlCCalls != 0 {
+			t.Fatalf("must refuse without changing input: %+v, interrupts=%d", res, target.ctrlCCalls)
+		}
 	}
 }
 
-func TestGuardComposerDraft_CaptureErrorProceedsWithoutBlocking(t *testing.T) {
+func TestGuardComposerDraft_CaptureErrorRefusesWithoutMutation(t *testing.T) {
 	target := &fakeGuardTarget{captureErr: errors.New("pane gone")}
 	res := GuardComposerDraft(target, ComposerGuardOptions{
 		HoldWait: time.Second, PollInterval: time.Millisecond, ClearWait: time.Millisecond,
 	})
-	if res.SavedDraft != "" || res.ClearFailed || target.ctrlCCalls != 0 {
-		t.Fatalf("capture errors must not block or mutate the pane, got %+v (ctrlC=%d)", res, target.ctrlCCalls)
+	if !res.Refused || res.SavedDraft != "" || res.ClearFailed || target.ctrlCCalls != 0 {
+		t.Fatalf("capture errors must refuse without mutating the pane, got %+v (ctrlC=%d)", res, target.ctrlCCalls)
 	}
 }
 

--- a/internal/send/suggestion_test.go
+++ b/internal/send/suggestion_test.go
@@ -142,7 +142,7 @@ func TestGuardComposerDraft_IgnoresDimAutosuggestion(t *testing.T) {
 }
 
 // The #1409 protection must survive intact: a real draft carrying ANSI colour
-// is still held, saved and cleared.
+// is still held, then refused without modification.
 func TestGuardComposerDraft_StillGuardsRealDraftWithANSI(t *testing.T) {
 	target := &fakeGuardTarget{captures: []string{pane(fixtureRealDraftComposer)}, clearOnCtrlC: true}
 	res := GuardComposerDraft(target, ComposerGuardOptions{HoldWait: time.Millisecond, PollInterval: time.Millisecond, Strip: stripANSI})
@@ -150,6 +150,28 @@ func TestGuardComposerDraft_StillGuardsRealDraftWithANSI(t *testing.T) {
 		t.Fatalf("real draft must remain untouched: %+v, interrupts=%d", res, target.ctrlCCalls)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1777 — the inverse gap: suggestions that render normal-coloured, and
+// suggestions rendered grey instead of dim. Composer lines below mirror the
+// reporter's `tmux capture-pane -e -p` evidence.
+// ---------------------------------------------------------------------------
+
+const (
+	// Suggestion rendered bright-black (SGR 90) instead of dim — a Claude
+	// build / terminal profile rendering the ghost in grey defeats a
+	// dim-only check.
+	fixtureGreyBrightBlackComposer = "\x1b[39m❯ \x1b[90mupgrade agent-deck on carrollton and archive the five error sessions\x1b[0m"
+
+	// Same ghost via 256-colour grey (colour index 8, bright black).
+	fixtureGrey256Composer = "\x1b[39m❯ \x1b[38;5;8mprune the stale cluster\x1b[0m"
+
+	// A suggestion that MATERIALIZED as real, normal-coloured (\e[39m)
+	// unsubmitted input — the #1777 defect case. Colour alone cannot prove
+	// this is not an operator draft, so it must be treated as one for
+	// guard purposes but must NEVER be submitted by a bare Enter.
+	fixtureMaterializedComposer = "\x1b[39m❯ wrap up the session — anything left uncommitted?"
+)
 
 func TestComposerBodyIsSuggestion_GreyBrightBlackIsDetected(t *testing.T) {
 	if !ComposerBodyIsSuggestion(pane(fixtureGreyBrightBlackComposer)) {
@@ -234,8 +256,7 @@ func TestGuardComposerDraft_MidRenderSuggestionIsNotSaved(t *testing.T) {
 	}
 }
 
-// The save-step re-capture must not weaken #1409: a REAL draft that is still
-// present on the second capture is saved and cleared exactly as before.
+// Reconfirmation must preserve a real draft that remains in the composer.
 func TestGuardComposerDraft_ReconfirmStillPreservesRealDraft(t *testing.T) {
 	target := &fakeGuardTarget{captures: []string{pane(fixtureRealDraftComposer)}, clearOnCtrlC: true}
 	res := GuardComposerDraft(target, ComposerGuardOptions{HoldWait: time.Millisecond, PollInterval: time.Millisecond, Strip: stripANSI})

--- a/internal/send/suggestion_test.go
+++ b/internal/send/suggestion_test.go
@@ -144,46 +144,12 @@ func TestGuardComposerDraft_IgnoresDimAutosuggestion(t *testing.T) {
 // The #1409 protection must survive intact: a real draft carrying ANSI colour
 // is still held, saved and cleared.
 func TestGuardComposerDraft_StillGuardsRealDraftWithANSI(t *testing.T) {
-	target := &fakeGuardTarget{
-		captures:     []string{pane(fixtureRealDraftComposer)},
-		clearOnCtrlC: true,
-	}
-	res := GuardComposerDraft(target, ComposerGuardOptions{
-		HoldWait: 10 * time.Millisecond, PollInterval: time.Millisecond, ClearWait: 50 * time.Millisecond,
-		Strip: stripANSI,
-	})
-	if res.SavedDraft != "REALDRAFT typed by a human" {
-		t.Fatalf("real draft must still be saved for restore, got %q", res.SavedDraft)
-	}
-	if !res.DraftCleared {
-		t.Fatalf("real draft must still be cleared before delivery, got %+v", res)
-	}
-	if target.ctrlCCalls == 0 {
-		t.Fatal("expected Ctrl+C for a real operator draft")
+	target := &fakeGuardTarget{captures: []string{pane(fixtureRealDraftComposer)}, clearOnCtrlC: true}
+	res := GuardComposerDraft(target, ComposerGuardOptions{HoldWait: time.Millisecond, PollInterval: time.Millisecond, Strip: stripANSI})
+	if !res.Refused || res.SavedDraft != "" || res.DraftCleared || target.ctrlCCalls != 0 {
+		t.Fatalf("real draft must remain untouched: %+v, interrupts=%d", res, target.ctrlCCalls)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Issue #1777 — the inverse gap: suggestions that render normal-coloured, and
-// suggestions rendered grey instead of dim. Composer lines below mirror the
-// reporter's `tmux capture-pane -e -p` evidence.
-// ---------------------------------------------------------------------------
-
-const (
-	// Suggestion rendered bright-black (SGR 90) instead of dim — a Claude
-	// build / terminal profile rendering the ghost in grey defeats a
-	// dim-only check.
-	fixtureGreyBrightBlackComposer = "\x1b[39m❯ \x1b[90mupgrade agent-deck on carrollton and archive the five error sessions\x1b[0m"
-
-	// Same ghost via 256-colour grey (colour index 8, bright black).
-	fixtureGrey256Composer = "\x1b[39m❯ \x1b[38;5;8mprune the stale cluster\x1b[0m"
-
-	// A suggestion that MATERIALIZED as real, normal-coloured (\e[39m)
-	// unsubmitted input — the #1777 defect case. Colour alone cannot prove
-	// this is not an operator draft, so it must be treated as one for
-	// guard purposes but must NEVER be submitted by a bare Enter.
-	fixtureMaterializedComposer = "\x1b[39m❯ wrap up the session — anything left uncommitted?"
-)
 
 func TestComposerBodyIsSuggestion_GreyBrightBlackIsDetected(t *testing.T) {
 	if !ComposerBodyIsSuggestion(pane(fixtureGreyBrightBlackComposer)) {
@@ -270,19 +236,10 @@ func TestGuardComposerDraft_MidRenderSuggestionIsNotSaved(t *testing.T) {
 
 // The save-step re-capture must not weaken #1409: a REAL draft that is still
 // present on the second capture is saved and cleared exactly as before.
-func TestGuardComposerDraft_ReconfirmStillSavesRealDraft(t *testing.T) {
-	target := &fakeGuardTarget{
-		captures:     []string{pane(fixtureRealDraftComposer)},
-		clearOnCtrlC: true,
-	}
-	res := GuardComposerDraft(target, ComposerGuardOptions{
-		HoldWait: 0, PollInterval: time.Millisecond, ClearWait: 50 * time.Millisecond,
-		Strip: stripANSI,
-	})
-	if res.SavedDraft != "REALDRAFT typed by a human" {
-		t.Fatalf("confirmed operator draft must still be saved, got %q", res.SavedDraft)
-	}
-	if !res.DraftCleared {
-		t.Fatalf("confirmed operator draft must still be cleared, got %+v", res)
+func TestGuardComposerDraft_ReconfirmStillPreservesRealDraft(t *testing.T) {
+	target := &fakeGuardTarget{captures: []string{pane(fixtureRealDraftComposer)}, clearOnCtrlC: true}
+	res := GuardComposerDraft(target, ComposerGuardOptions{HoldWait: time.Millisecond, PollInterval: time.Millisecond, Strip: stripANSI})
+	if !res.Refused || res.SavedDraft != "" || res.DraftCleared || target.ctrlCCalls != 0 {
+		t.Fatalf("real draft must remain untouched: %+v, interrupts=%d", res, target.ctrlCCalls)
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4621,15 +4621,12 @@ func (h *Home) backgroundStatusUpdate() {
 				conductorName := strings.TrimPrefix(inst.Title, "conductor-")
 				safego.Go(uiLog, "conductor_clear_and_heartbeat", func() {
 					time.Sleep(500 * time.Millisecond)
-					_ = tmuxSess.SendKeysAndEnter("/clear")
-					// After /clear wipes context, immediately send heartbeat to restore orientation
-					time.Sleep(3 * time.Second)
-					_ = session.DefaultProfile
-					if meta, err := session.LoadConductorMeta(conductorName); err == nil {
-						_ = meta.Profile
-					}
 					msg := fmt.Sprintf("Heartbeat: Check sessions in your group (%s). List any that are waiting, auto-respond where safe, and report what needs my attention.", conductorName)
-					_ = tmuxSess.SendKeysAndEnter(msg)
+					if err := clearConductorAndHeartbeat(func(body string) error {
+						return deliverToConductorPane(tmuxSess, body)
+					}, msg, 3*time.Second); err != nil {
+						uiLog.Warn("conductor_clear_heartbeat_refused", slog.String("error", err.Error()))
+					}
 				})
 			}
 		}
@@ -10543,10 +10540,21 @@ func (h *Home) dispatchWatcherEvent(evt watcher.Event) {
 // Intended to run inside a goroutine.
 //
 // Issue #1409: delivery is composer-guarded — a pane whose composer holds a
-// half-typed operator draft is held briefly, then the draft is saved, cleared
-// and restored around the automated send so it cannot merge with it.
+// half-typed operator draft is held briefly, then refused without modifying it.
 func deliverToConductorPane(p guardableConductorPane, msg string) error {
 	return deliverToConductorPaneGuarded(p, msg, conductorComposerGuardOptions(), 40, 250*time.Millisecond)
+}
+
+// clearConductorAndHeartbeat rechecks the composer independently for each
+// delivery. A failed clear must never be followed by a heartbeat.
+func clearConductorAndHeartbeat(deliver func(string) error, heartbeat string, settle time.Duration) error {
+	if err := deliver("/clear"); err != nil {
+		return err
+	}
+	if settle > 0 {
+		time.Sleep(settle)
+	}
+	return deliver(heartbeat)
 }
 
 // conductorComposerGuardOptions are the production bounds of the watcher/
@@ -10562,37 +10570,18 @@ func conductorComposerGuardOptions() send.ComposerGuardOptions {
 	}
 }
 
-// deliverToConductorPaneGuarded wraps deliverToConductorPaneTuned with the
-// issue #1409 composer-draft guard: hold while an operator draft occupies the
-// composer; at the bound save-clear it; restore it (typed back, no Enter)
-// once the automated delivery is confirmed. When delivery is NOT confirmed
-// the draft is intentionally not retyped — the composer may still hold the
-// automated message and restoring would recreate the merge this guard exists
-// to prevent; the saved draft is logged instead.
+// deliverToConductorPaneGuarded waits for operator input to clear naturally.
+// If it remains or cannot be read, refuse before sending any input.
 func deliverToConductorPaneGuarded(p guardableConductorPane, msg string, guardOpts send.ComposerGuardOptions, maxChecks int, checkDelay time.Duration) error {
 	guard := send.GuardComposerDraft(p, guardOpts)
+	if guard.Refused {
+		return fmt.Errorf("message not sent: composer is occupied or unreadable; existing draft preserved")
+	}
 	// guard.ComposerPasteMarkerFree is the #1777 provenance the verify loop
 	// needs: the guard's pre-send capture saw a composer with no
 	// "[Pasted text …]" marker, so a marker seen during verification is the
 	// collapsed rendering of OUR framed multi-line payload (issue #1855).
-	err := deliverToConductorPaneAttributed(p, msg, guard.ComposerPasteMarkerFree, maxChecks, checkDelay)
-	if guard.SavedDraft != "" {
-		if err == nil {
-			// Delivery confirmed: type the operator draft back. If the
-			// type-back itself fails the draft is no longer on screen — log
-			// it so the loss is visible and recoverable, not swallowed.
-			if restoreErr := p.SendKeysChunked(guard.SavedDraft); restoreErr != nil {
-				uiLog.Warn("conductor_dispatch_draft_restore_failed",
-					slog.String("saved_draft", guard.SavedDraft),
-					slog.String("error", restoreErr.Error()))
-			}
-		} else {
-			uiLog.Warn("conductor_dispatch_draft_not_restored",
-				slog.String("saved_draft", guard.SavedDraft),
-				slog.String("error", err.Error()))
-		}
-	}
-	return err
+	return deliverToConductorPaneAttributed(p, msg, guard.ComposerPasteMarkerFree, maxChecks, checkDelay)
 }
 
 // conductorPane is the slice of *tmux.Session that reliable delivery needs.
@@ -10609,8 +10598,6 @@ type conductorPane interface {
 // composer guard needs. *tmux.Session satisfies it.
 type guardableConductorPane interface {
 	conductorPane
-	SendCtrlC() error
-	SendKeysChunked(string) error
 }
 
 // blindEnterCap bounds the fallback Enter presses for agents whose composer is

--- a/internal/ui/issue1409_watcher_guard_test.go
+++ b/internal/ui/issue1409_watcher_guard_test.go
@@ -82,29 +82,19 @@ func testConductorGuardOpts() send.ComposerGuardOptions {
 // against a composer holding a half-typed operator draft must not merge with
 // it (#1409): the draft is cleared before the send and restored (without
 // Enter) after the delivery is confirmed.
-func TestDeliverToConductorPaneGuarded_SaveClearRestore(t *testing.T) {
-	p := &guardedFakePane{
-		draftPane:        composerWith("instruct deploy ag"),
-		postSendCaptures: []string{emptyComposer()},
-	}
-	err := deliverToConductorPaneGuarded(p, "[slack] u: hi", testConductorGuardOpts(), 40, 0)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.ctrlCCalls != 1 {
-		t.Fatalf("expected 1 Ctrl+C to clear the operator draft, got %d", p.ctrlCCalls)
-	}
-	if p.chunkedText != "instruct deploy ag" {
-		t.Fatalf("restored draft: want %q, got %q", "instruct deploy ag", p.chunkedText)
-	}
-	if p.restoredBeforeSend {
-		t.Fatal("draft restore must happen after the automated delivery")
+func TestDeliverToConductorPaneGuarded_RefusesAndPreservesDraft(t *testing.T) {
+	for _, msg := range []string{"[slack] u: hi", "/clear", "Heartbeat: check sessions"} {
+		p := &guardedFakePane{draftPane: composerWith("operator draft")}
+		err := deliverToConductorPaneGuarded(p, msg, testConductorGuardOpts(), 40, 0)
+		if err == nil {
+			t.Fatal("occupied composer must refuse delivery")
+		}
+		if p.ctrlCCalls != 0 || p.sendKeysCalls != 0 || p.enterCalls != 0 || p.chunkedCalls != 0 {
+			t.Fatalf("refusal mutated composer: %+v", p)
+		}
 	}
 }
 
-// TestDeliverToConductorPaneGuarded_HoldsWhileDraftClearsItself: when the
-// operator submits/erases their draft within the hold window, no Ctrl+C and
-// no restore happen.
 func TestDeliverToConductorPaneGuarded_HoldsWhileDraftClearsItself(t *testing.T) {
 	p := &fakeConductorPane{captures: []string{
 		composerWith("operator wip"), // guard: busy

--- a/internal/ui/issue2104_clear_heartbeat_test.go
+++ b/internal/ui/issue2104_clear_heartbeat_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClearConductorAndHeartbeat_StopsOnClearFailure(t *testing.T) {
+	calls := 0
+	err := clearConductorAndHeartbeat(func(body string) error {
+		calls++
+		if body != "/clear" {
+			t.Fatalf("unexpected body %q", body)
+		}
+		return errors.New("clear not delivered")
+	}, "heartbeat", 0)
+	if err == nil || calls != 1 {
+		t.Fatalf("clear failure allowed heartbeat: %d, %v", calls, err)
+	}
+}
+
+func TestClearConductorAndHeartbeat_RechecksNewDraft(t *testing.T) {
+	for _, occupied := range []bool{false, true} {
+		t.Run(map[bool]string{false: "empty", true: "new draft"}[occupied], func(t *testing.T) {
+			first := &guardedFakePane{draftPane: emptyComposer(), postSendCaptures: []string{emptyComposer()}}
+			second := &guardedFakePane{draftPane: emptyComposer(), postSendCaptures: []string{emptyComposer()}}
+			if occupied {
+				second.draftPane = composerWith("new operator draft")
+			}
+			calls := 0
+			err := clearConductorAndHeartbeat(func(body string) error {
+				calls++
+				p := first
+				want := "/clear"
+				if calls == 2 {
+					p = second
+					want = "heartbeat"
+				}
+				if body != want {
+					t.Fatalf("stage%d body = %q", calls, body)
+				}
+				return deliverToConductorPaneGuarded(p, body, testConductorGuardOpts(), 4, 0)
+			}, "heartbeat", 0)
+			if calls != 2 || first.sendKeysCalls != 1 {
+				t.Fatalf("clear sequence failed: calls%d first%+v", calls, first)
+			}
+			if occupied {
+				if err == nil || second.sendKeysCalls != 0 || second.enterCalls != 0 || second.ctrlCCalls != 0 || second.chunkedCalls != 0 {
+					t.Fatalf("new draft not preserved: %+v err%v", second, err)
+				}
+			} else if err != nil || second.sendKeysCalls != 1 {
+				t.Fatalf("heartbeat not delivered: %+v %v", second, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Automated delivery could clear an operator's draft with Ctrl-C, repeat that interrupt during recovery, and then type into an occupied or unreadable composer. Repeated interrupts can become a session-exit gesture. This addresses the interrupt and draft-preservation behavior reported in #2104.

## Why this change

The composer guard now only reads and waits. A persistent draft or capture error refuses delivery before any keystroke. CLI output reports delivery=composer_blocked and submitted=false with a nonzero exit. The original draft remains in place. Full-body interrupt/resend recovery is removed; bounded Enter retries retain their existing attribution checks. Automatic clear-on-compact and its later heartbeat each use guarded delivery, and a failed clear stops the sequence.

## User impact

Occupied composers hold for the existing 10-second default, 2-second no-wait, or 5-second watcher budget, plus a final 50-millisecond read-only settle check. Delivery is refused if input remains. This deliberately favors preserving the session and draft over forcing delivery. It does not claim a queue accepted refused messages.

Capture/send/Enter transactions are not yet serialized across processes. A new draft can arrive after capture, and non-introspectable tool compatibility remains. This patch does not claim concurrent sends or open pickers are fully safe, and does not close the broader #2104 concurrency work or #1981.

## Evidence

On the original main, the new preservation regression observes 4 interrupts, 4 payload writes and a draft restoration during repeated recovery; the corrected capture-error test also detects an initial write. Both fail before this patch. At fdad542222d992a4fd5ef630b9855d99544bc45e, all three affected Go packages pass in Docker. Three opt-in real-tmux tests pass: default and no-wait refusal preserve the fake composer's draft, and the Enter-swallowing composer retains the typed-not-submitted result. CLI/UI unit tests require zero writes on refusal and recheck the heartbeat after a newly appearing draft. Independent final source and fixture review found no blocker.

The tmux fixture is a shell stand-in, not a live Claude exit reproduction. Its original stuck-input test fails identically on baseline because the rendering omitted composer dividers; the corrected bordered, no-echo fixture preserves the original submission assertion. Prior failed logs are retained. Fresh contributor self-check: 14 PASS, 0 FAIL, 2 WARN. The +274/-568 aggregate changes include removal of destructive recovery and migration of its existing caller/fixture tests. Main lacks new result symbols, so the aggregate revert does not compile; the independent original-main behavioral red supplies runtime evidence. Latest-head CI remains required. No live user session was accessed.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** GPT-6 for implementation and separate independent review.

## What actually bothered you

The owner chose: "preserve user draft and refuse delivery after bounded wait" because repeated automatic Ctrl-C conflicts with session and draft preservation.

## Checklist

- [x] Targeted diff: one delivery-safety policy, including affected callers and tests
- [x] Tests added or updated for new behavior
- [ ] Full repository suite passes sandboxed
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed with validation limits
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6 intent=yes -->
