### PR TITLE
fix(ui): offer Fable 5.1 in both model pickers

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1008,6 +1008,7 @@ func knownModelIDsForTool(tool string) []string {
 		return []string{
 			"claude-opus-5",
 			"claude-sonnet-5",
+			"claude-fable-5-1",
 			"claude-fable-5",
 			"claude-sonnet-4-6",
 			"claude-opus-4-8",
@@ -1038,6 +1039,7 @@ func knownModelIDsForTool(tool string) []string {
 			"openai/o3",
 			"anthropic/claude-opus-5",
 			"anthropic/claude-sonnet-5",
+			"anthropic/claude-fable-5-1",
 			"anthropic/claude-fable-5",
 			"anthropic/claude-sonnet-4-6",
 			"anthropic/claude-opus-4-8",

--- a/internal/web/static/app/CreateSessionDialog.js
+++ b/internal/web/static/app/CreateSessionDialog.js
@@ -34,6 +34,7 @@ const MODEL_ID_CATALOG = {
   claude: [
     { value: 'claude-opus-5', label: 'Claude Opus 5' },
     { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
+    { value: 'claude-fable-5-1', label: 'Claude Fable 5.1' },
     { value: 'claude-fable-5', label: 'Claude Fable 5' },
     { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
     { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
@@ -87,6 +88,7 @@ const MODEL_ID_CATALOG = {
     { value: 'openai/o3', label: 'OpenAI o3' },
     { value: 'anthropic/claude-opus-5', label: 'Anthropic Claude Opus 5' },
     { value: 'anthropic/claude-sonnet-5', label: 'Anthropic Claude Sonnet 5' },
+    { value: 'anthropic/claude-fable-5-1', label: 'Anthropic Claude Fable 5.1' },
     { value: 'anthropic/claude-fable-5', label: 'Anthropic Claude Fable 5' },
     { value: 'anthropic/claude-sonnet-4-6', label: 'Anthropic Claude Sonnet 4.6' },
     { value: 'anthropic/claude-opus-4-8', label: 'Anthropic Claude Opus 4.8' },


### PR DESCRIPTION
## What problem does this solve?

The TUI and web session dialogs do not offer Claude Fable 5.1. This addresses the picker portion of #2107.

## Why this change

Add claude-fable-5-1 to both Claude-compatible catalogs and the corresponding anthropic/claude-fable-5-1 choice to both OpenCode catalogs. Existing models, defaults and custom entry remain.

The official Anthropic Python SDK lists the bare model identifier: https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/model.py (verified blob 5098bbbcbc11df78fda1177d959c8316af513a0f). The OpenCode prefix follows the repository's existing provider naming convention; no account entitlement or executed launch is claimed.

## User impact

Users can select the new identifier directly in either UI. No price or context-window value is added. The SDK ID does not establish a 1M window, and existing analytics already prefix-match the family. Window inference and destructive consumers remain tracked in #2026 and the related #2011 review.

## Evidence

Independent review verified the exact four-line, two-file change at 0e0063c9cc5f0bff43f774fd134d1661edf245fa. Fresh Docker contributor self-check: 14 PASS, 0 FAIL, 1 WARN. The full affected UI package, build, vet and formatting passed. No mirrored test is added for this small catalog-only change; that contributor warning is explicit. Browser interaction and live provider launch are not claimed.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** GPT-6 for implementation and separate independent review.

## What actually bothered you

The reporter asked to add claude-fable-5-1 to the model picker. The owner verified the identifier and requested coordination with the context-window issue.

## Checklist

- [x] Targeted diff: model picker metadata only
- [ ] New tests added; existing catalog tests are used for this small metadata change
- [ ] Test suite passes sandboxed
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed with validation limits
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6 intent=yes -->
