### PR TITLE
test(agents): make health freshness fixture deterministic

### DIFF
--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -436,10 +436,14 @@ func TestCheckHealthDistinguishesUnknownFromDown(t *testing.T) {
 }
 
 func TestCheckHealthFreshAndStale(t *testing.T) {
-	now := time.Now()
+	now := time.Unix(1755000000, 0)
 	dir := t.TempDir()
 	seen := filepath.Join(dir, "seen.db")
 	writeTestFile(t, seen, "x")
+	// Pin freshness to the reference time instead of the filesystem write clock.
+	if err := os.Chtimes(seen, now, now); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
 
 	fresh := CheckHealth("gmail", "mail", dir, 30*time.Minute, now)
 	if fresh.State != HealthOK {


### PR DESCRIPTION
## What problem does this solve?

`TestCheckHealthFreshAndStale` can fail when the just-written evidence file receives an mtime later than the reference time captured before the write. A full integration run reported `unknown` with `0s in the future`, despite expecting fresh evidence.

## Why this change

Give the fixture a fixed, whole-second reference time and explicitly set the fresh file's mtime to it. The stale case still uses a timestamp three hours earlier. This removes filesystem-clock and scheduling dependence without relaxing the production future-timestamp guard.

## User impact

None at runtime. Only one existing test changes, with five added lines and one removed line. No dependencies, workflows or production code change.

## Evidence

- Base: `e23fd454ce06e90d77e0daf9c8108a23871263fc`.
- A controlled diagnostic copy forces the initial file mtime to exactly one second after a fixed reference time. The original test fails with `a just-written seen.db gave "unknown", want "ok" (seen.db is dated 1s in the future; clock or mtime is wrong)`, Go/Docker exit 1.
- Applying the test-only fix with the same diagnostic injection passes, Go/Docker exit 0. The existing `TestCheckHealthFutureMtimeIsNotFresh` passes in both copies; production `health.go` is byte-identical.
- The clean fixed checkout passes `go test -json -race -p 1 ./internal/agents -count=1 -timeout=300s` and 100 repetitions each of the fresh/stale and future-mtime tests.
- Docker uses `--init`, four CPUs, `GOMAXPROCS=4`, a disposable HOME with cleared XDG, container-local source, a valid shell and DAC_OVERRIDE dropped. No host Go tests.
- The contributor pre-open gate is run with its default affected-package selection, plus repository-wide vet/build. Its external runner retains temporary artifacts instead of deleting them; checks are unchanged. A redundant full suite is outside this bounded test-only maintenance task, so the full-suite checklist below remains unchecked.
- The original intermittent integration failure is preserved separately. The earlier unchanged baseline and candidate comparisons both passed 100 runs. They did not dynamically reproduce that failure; the new deterministic diagnostic demonstrates the timestamp-ordering mechanism under explicitly injected conditions.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** GPT-6

## What actually bothered you

> repair TestCheckHealthFreshAndStale reference-time/mtime fixture deterministically without weakening production future-timestamp guard.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [ ] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-6 intent=yes -->
