### PR TITLE
feat(inbox): inspect physical dead-letter and unowned records

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -140,6 +140,9 @@ func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string
 			retErr = fmt.Errorf("write inbox output: %w", tracked.err)
 		}
 	}()
+	if len(args) > 0 && args[0] == "dead-letter" {
+		return runInboxDeadLetter(stdout, args[1:])
+	}
 	if len(args) > 0 && args[0] == "drain" {
 		return runInboxDrain(stdout, args[1:], explicitProfile)
 	}
@@ -155,6 +158,7 @@ func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string
 		fmt.Fprintln(stdout, "Usage: agent-deck inbox <session-id>")
 		fmt.Fprintln(stdout, "       agent-deck inbox drain [--json] <session-id>")
 		fmt.Fprintln(stdout, "       agent-deck inbox export [--json]")
+		fmt.Fprintln(stdout, "       agent-deck inbox dead-letter list|show [--json]")
 		fmt.Fprintln(stdout, "       agent-deck inbox writer-status [--json]")
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "Drain pending completion events from the parent's durable outbox.")

--- a/cmd/agent-deck/inbox_deadletter_cmd.go
+++ b/cmd/agent-deck/inbox_deadletter_cmd.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"unicode/utf8"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func runInboxDeadLetter(stdout io.Writer, args []string) error {
+	if len(args) == 0 || (args[0] != "list" && args[0] != "show") {
+		return fmt.Errorf("usage: inbox dead-letter list [--store all|dead-letter|unowned] [--json], or show <ref> [--json]")
+	}
+	action := args[0]
+	fs := flag.NewFlagSet("inbox dead-letter "+action, flag.ContinueOnError)
+	fs.SetOutput(stdout)
+	asJSON := fs.Bool("json", false, "output JSON")
+	store := fs.String("store", "all", "host store: all, dead-letter, or unowned")
+	if err := fs.Parse(normalizeArgs(fs, args[1:])); err != nil {
+		return err
+	}
+	if action == "list" && fs.NArg() != 0 || action == "show" && fs.NArg() != 1 {
+		return fmt.Errorf("list takes no record reference; show requires exactly one reference")
+	}
+	if action == "show" {
+		decoded, err := hex.DecodeString(fs.Arg(0))
+		if err != nil || len(decoded) != 32 {
+			return fmt.Errorf("invalid record reference; use inbox dead-letter list")
+		}
+	}
+	records, err := session.InspectDeadLetters(*store)
+	if err != nil {
+		return fmt.Errorf("inspect dead letters: %w", err)
+	}
+	if action == "list" {
+		if *asJSON {
+			return json.NewEncoder(stdout).Encode(records)
+		}
+		fmt.Fprintf(stdout, "%d host-level record(s); inspection does not consume records\n", len(records))
+		for _, rec := range records {
+			fmt.Fprintf(stdout, "%s store=%s source=%q child=%q profile=%q problem=%q\n", rec.Ref, rec.Store, rec.Source, rec.ChildSessionID, rec.Profile, rec.Problem)
+		}
+		return nil
+	}
+	for _, rec := range records {
+		if rec.Ref != fs.Arg(0) {
+			continue
+		}
+		// Base64 is lossless for malformed bytes, line endings and unknown fields.
+		raw := base64.StdEncoding.EncodeToString(rec.Raw)
+		if *asJSON {
+			var event json.RawMessage
+			if utf8.Valid(rec.Raw) && json.Valid(rec.Raw) {
+				event = rec.Raw
+			}
+			return json.NewEncoder(stdout).Encode(struct {
+				session.DeadLetterRecord
+				Event     json.RawMessage `json:"event,omitempty"`
+				RawBase64 string          `json:"raw_base64"`
+			}{rec, event, raw})
+		}
+		fmt.Fprintf(stdout, "%s store=%s source=%q offset=%d problem=%q\nraw=%q\n", rec.Ref, rec.Store, rec.Source, rec.Offset, rec.Problem, rec.Raw)
+		return nil
+	}
+	return fmt.Errorf("record reference is stale or absent; list records again")
+}

--- a/cmd/agent-deck/inbox_deadletter_cmd_test.go
+++ b/cmd/agent-deck/inbox_deadletter_cmd_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestDeadLetterInspectionPreservesBothRawStores(t *testing.T) {
+	cliInboxTestHome(t)
+	if err := os.MkdirAll(session.DeadLetterDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	valid := `{"child_session_id":"child","profile":"default","future_field":{"keep":true}}` + "\r\n"
+	invalid := []byte("\xffbroken\x1b]52;tail")
+	dead := append([]byte("\n"+valid+valid), invalid...)
+	unowned := []byte("null\n{}\n{\"child_session_id\":\"orphan\"}\n")
+	paths := map[string][]byte{session.DeadLetterPathFor("child"): dead, session.InboxPathFor(session.UnownedInboxID): unowned}
+	for path, raw := range paths {
+		if err := os.WriteFile(path, raw, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out bytes.Buffer
+	if err := runInbox(&out, []string{"dead-letter", "list", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var records []struct {
+		Ref   string `json:"ref"`
+		Store string `json:"store"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &records); err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 6 {
+		t.Fatalf("physical record count=%d, want6", len(records))
+	}
+	seen := make(map[string]bool)
+	var gotDead, gotUnowned []byte
+	for _, rec := range records {
+		if seen[rec.Ref] {
+			t.Fatal("duplicate physical lines have same reference")
+		}
+		seen[rec.Ref] = true
+		out.Reset()
+		if err := runInbox(&out, []string{"dead-letter", "show", rec.Ref, "--json"}); err != nil {
+			t.Fatal(err)
+		}
+		var shown struct {
+			RawBase64 string          `json:"raw_base64"`
+			Event     json.RawMessage `json:"event"`
+		}
+		if err := json.Unmarshal(out.Bytes(), &shown); err != nil {
+			t.Fatal(err)
+		}
+		raw, err := base64.StdEncoding.DecodeString(shown.RawBase64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.Store == "dead-letter" {
+			gotDead = append(gotDead, raw...)
+		} else {
+			gotUnowned = append(gotUnowned, raw...)
+		}
+		if bytes.Equal(raw, []byte(valid)) && !bytes.Contains(shown.Event, []byte("future_field")) {
+			t.Error("unknown parsed field lost")
+		}
+	}
+	if !bytes.Equal(gotDead, dead[1:]) || !bytes.Equal(gotUnowned, unowned) {
+		t.Fatal("show lost raw bytes, duplicates or line endings")
+	}
+	for path, want := range paths {
+		got, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(got, want) {
+			t.Fatalf("inspection mutated %s", filepath.Base(path))
+		}
+	}
+	out.Reset()
+	if err := runInbox(&out, []string{"dead-letter", "show", records[2].Ref}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsRune(out.String(), '\x1b') {
+		t.Fatal("human inspection emitted a raw terminal escape")
+	}
+	// An append invalidates refs rather than selecting another physical record.
+	if err := os.WriteFile(session.DeadLetterPathFor("child"), append(dead, '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runInbox(&out, []string{"dead-letter", "show", records[0].Ref}); err == nil {
+		t.Fatal("stale source snapshot reference accepted")
+	}
+}
+
+func TestDeadLetterInspectionRejectsUnsafeOrUnknownRequests(t *testing.T) {
+	cliInboxTestHome(t)
+	for _, args := range [][]string{
+		{"dead-letter", "clear", "--all", "--yes"},
+		{"dead-letter", "retry", "anything"},
+		{"dead-letter", "show", "../../outside"},
+		{"dead-letter", "list", "--store", "unknown"},
+	} {
+		if err := runInbox(&bytes.Buffer{}, args); err == nil {
+			t.Errorf("accepted unsupported request %q", args)
+		}
+	}
+	if _, err := os.Stat(session.InboxDir()); !os.IsNotExist(err) {
+		t.Fatalf("inspection created inbox storage: %v", err)
+	}
+	if err := os.MkdirAll(session.DeadLetterDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "private")
+	if err := os.WriteFile(outside, []byte("private-record"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, session.DeadLetterPathFor("link")); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runInbox(&out, []string{"dead-letter", "list", "--json"}); err == nil {
+		t.Fatal("followed nonregular ledger source")
+	}
+	if strings.Contains(out.String(), "private-record") {
+		t.Fatal("printed symlink target content")
+	}
+}

--- a/internal/session/deadletter_inspection.go
+++ b/internal/session/deadletter_inspection.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"unicode/utf8"
+)
+
+// DeadLetterRecord describes one physical nonblank record. Ref identifies its
+// exact source snapshot and offset; an append or rewrite invalidates old refs.
+// Raw is retained separately so malformed bytes and unknown fields remain
+// available to inspection without routing, consuming or repairing anything.
+type DeadLetterRecord struct {
+	Ref            string `json:"ref"`
+	Store          string `json:"store"`
+	Source         string `json:"source"`
+	Offset         int    `json:"offset"`
+	ChildSessionID string `json:"child_session_id,omitempty"`
+	Profile        string `json:"profile,omitempty"`
+	Problem        string `json:"problem,omitempty"`
+	Raw            []byte `json:"-"`
+}
+
+const (
+	maxDeadLetterInspectionBytes   = maxInboxLineBytes
+	maxDeadLetterInspectionRecords = 10000
+)
+
+type deadLetterInspectionError struct{ cause error }
+
+func (e *deadLetterInspectionError) Error() string {
+	return fmt.Sprintf("dead-letter inspection failed: %q", e.cause.Error())
+}
+func (e *deadLetterInspectionError) Unwrap() error { return e.cause }
+
+// InspectDeadLetters reads both host-level stores, independently of profile
+// registry availability. It returns no partial list on an unreadable source.
+// Store must be all, dead-letter or unowned. No directories or locks are created.
+func InspectDeadLetters(store string) (result []DeadLetterRecord, retErr error) {
+	defer func() {
+		if retErr != nil {
+			retErr = &deadLetterInspectionError{cause: retErr}
+		}
+	}()
+	if store != "all" && store != "dead-letter" && store != "unowned" {
+		return nil, fmt.Errorf("unknown dead-letter store %q", store)
+	}
+	records := make([]DeadLetterRecord, 0)
+	remainingBytes := int64(maxDeadLetterInspectionBytes)
+	read := func(path, kind, name string) error {
+		info, err := os.Lstat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("inspection source %q is not a regular file", name)
+		}
+		f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			return err
+		}
+		opened, statErr := f.Stat()
+		if statErr != nil || !os.SameFile(info, opened) {
+			_ = f.Close()
+			return fmt.Errorf("inspection source %q changed while opening", name)
+		}
+		raw, readErr := io.ReadAll(io.LimitReader(f, remainingBytes+1))
+		closeErr := f.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if int64(len(raw)) > remainingBytes {
+			return fmt.Errorf("inspection exceeds total limit of %d bytes", maxDeadLetterInspectionBytes)
+		}
+		remainingBytes -= int64(len(raw))
+		generation := sha256.Sum256(raw)
+		offset := 0
+		for offset < len(raw) {
+			length := bytes.IndexByte(raw[offset:], '\n')
+			if length < 0 {
+				length = len(raw) - offset
+			} else {
+				length++
+			}
+			line := raw[offset : offset+length]
+			if len(bytes.TrimSpace(line)) > 0 {
+				if len(records) >= maxDeadLetterInspectionRecords {
+					return fmt.Errorf("inspection exceeds %d records", maxDeadLetterInspectionRecords)
+				}
+				digest := sha256.Sum256([]byte(fmt.Sprintf("%s\x00%s\x00%x\x00%d", kind, name, generation, offset)))
+				rec := DeadLetterRecord{Ref: hex.EncodeToString(digest[:]), Store: kind, Source: name, Offset: offset, Raw: append([]byte(nil), line...)}
+				var event *TransitionNotificationEvent
+				switch {
+				case !utf8.Valid(line):
+					rec.Problem = "invalid UTF-8"
+				case json.Unmarshal(line, &event) != nil:
+					rec.Problem = "invalid event JSON"
+				case event == nil:
+					rec.Problem = "event must be an object"
+				default:
+					rec.ChildSessionID, rec.Profile = event.ChildSessionID, event.Profile
+					if strings.TrimSpace(event.ChildSessionID) == "" {
+						rec.Problem = "missing child_session_id"
+					}
+				}
+				records = append(records, rec)
+			}
+			offset += length
+		}
+		return nil
+	}
+	if store == "all" || store == "dead-letter" {
+		entries, err := os.ReadDir(DeadLetterDir())
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".jsonl") {
+				if err := read(filepath.Join(DeadLetterDir(), entry.Name()), "dead-letter", entry.Name()); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	if store == "all" || store == "unowned" {
+		if err := read(InboxPathFor(UnownedInboxID), "unowned", UnownedInboxID+".jsonl"); err != nil {
+			return nil, err
+		}
+	}
+	return records, nil
+}

--- a/internal/session/deadletter_inspection_test.go
+++ b/internal/session/deadletter_inspection_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDeadLetterInspectionBudgetsAndEscapedErrors(t *testing.T) {
+	inboxTestHome(t)
+	if err := os.MkdirAll(DeadLetterDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := DeadLetterPathFor("limit")
+	raw := bytes.Repeat([]byte("x\n"), maxDeadLetterInspectionRecords+1)
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := InspectDeadLetters("all"); err == nil || got != nil {
+		t.Fatal("record limit returned success or partial data")
+	}
+	// Two individually bounded files must still respect a shared byte budget.
+	half := bytes.Repeat([]byte(" "), maxDeadLetterInspectionBytes/2+1)
+	if err := os.WriteFile(path, half, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(InboxPathFor(UnownedInboxID), half, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := InspectDeadLetters("all"); err == nil || got != nil {
+		t.Fatal("aggregate byte budget not enforced")
+	}
+	if _, err := InspectDeadLetters("bad\x1b[2Jstore"); err == nil || strings.ContainsRune(err.Error(), '\x1b') {
+		t.Fatal("error emitted raw terminal escape")
+	}
+}
+
+func TestDeadLetterInspectionErrorQuotesPathAndPreservesCause(t *testing.T) {
+	cause := &os.PathError{Op: "open", Path: "ledger\x1b[2J\n.jsonl", Err: os.ErrPermission}
+	err := &deadLetterInspectionError{cause: cause}
+	if strings.ContainsAny(err.Error(), "\x1b\n") {
+		t.Fatal("error contains raw terminal controls")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || !errors.Is(err, os.ErrPermission) {
+		t.Fatal("wrapped storage cause lost")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Drain reports unresolved records but operators cannot inspect every physical record through the CLI. Existing readers skip malformed entries, and unresolved records can be stored in both dead-letter files and the unowned ledger. This addresses the inspection portion of #2062 and #2101; it does not close either issue.

## Why this change

Add inbox dead-letter list and show. Listing identifies each physical nonblank record by an opaque snapshot reference. Show preserves unknown fields and offers lossless raw bytes even when JSON or UTF-8 is malformed. An appended or rewritten source invalidates old references. Both stores are host-level and inspection requires no profile registry.

Reading is bounded across the entire selection by bytes and record count. Nonregular files are refused, I/O errors and human output are escaped, and output failures propagate. No records are consumed, retried or purged. Retry/clear need shared producer/sweeper lock and dedup coordination, so unsupported requests fail explicitly.

## User impact

Operators can identify unresolved and malformed records without manually opening storage files or accidentally draining them. JSON list output contains metadata; show includes parsed JSON when valid and raw_base64 for exact recovery. Human show escapes raw bytes to keep terminal control sequences inert.

## Evidence

At bbc218b0, CLI regressions fail meaningfully on unchanged main0e1ca2ae and pass on the candidate. Focused CLI/session tests, the full command package and vet pass in disposable Docker. Tests cover both stores, duplicate physical lines, malformed/invalid UTF-8 records, unknown fields, stale refs, refusal of unsupported mutation/path selectors, no implicit storage creation, aggregate limits and escaped errors. Independent source review found and cleared aggregate-memory/error-rendering gaps. Contributor gate:14PASS,0FAIL,2WARN. The automatic revert check cannot compile new API-dependent tests on the base; the separate CLI-only original-main comparison fails actual assertions and establishes the missing behavior. Current-head CI runs after publication.

The approximately404 added lines span the inspection API, CLI dispatch and meaningful regression coverage. The mutating operator surface is deliberately a separate dependency because its lock/dedup contract is not established.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** GPT-6 for implementation and separate independent review.

## What actually bothered you

The owner requested continuing reconciliation and fixes of all actionable issues. The dead-letter count theory was refuted by fresh tests, while #2062/#2101 still require an operator surface covering both unresolved stores. This change makes those records inspectable; it does not falsely report the ledger clean.

## Checklist

- [x] Targeted diff with meaningful tests
- [x] Contributor gate passes
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6 intent=yes -->
