### PR TITLE
test(tmux): stabilize live client identity fixtures

### DIFF
--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -353,18 +353,24 @@ func TestIsLiveTmuxClientOrServer_ServerItself(t *testing.T) {
 // test by simply always returning live=true, which would silently restore
 // the original 2026-08-01 bug (the sweep reaps nothing).
 //
-// The client is frozen with SIGSTOP immediately after starting, mid-flight,
-// to stand in for the tmux-3.0a fd leak this sweep exists to mop up: verified
-// live that a SIGSTOPped one-shot list-clients client does not appear in the
-// server's own list-clients output even while its process is still alive —
-// one-shot cadence commands never register as persistent clients the way an
-// attach does, whether or not they are hung.
+// The command queue signals readiness and then waits, proving the real client
+// has completed startup before we freeze it. Start followed immediately by
+// SIGSTOP can expose a transient empty /proc environ during exec, which the
+// classifier must refuse. Holding the queue also prevents a fast query from
+// exiting before the stop signal is observed.
 func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
 	socket := orphanLiveTestSocket(t)
 	const session = "agentdeck_1832_oneshot"
 	startOrphanLiveSession(t, socket, session)
 
-	cmd := exec.Command("tmux", "-L", socket, "list-clients", "-F", "#{client_pid}")
+	ready, release := socket+"-ready", socket+"-release"
+	waitFor := func(args ...string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return exec.CommandContext(ctx, "tmux", append([]string{"-L", socket, "wait-for"}, args...)...).Run()
+	}
+	cmd := exec.Command("tmux", "-L", socket,
+		"wait-for", "-S", ready, ";", "wait-for", release, ";", "list-clients", "-F", "#{client_pid}")
 	devnull, err := os.Open(os.DevNull)
 	if err != nil {
 		t.Fatalf("open devnull: %v", err)
@@ -376,14 +382,58 @@ func TestIsLiveTmuxClientOrServer_OneShotClient_NotLive(t *testing.T) {
 	}
 	pid := cmd.Process.Pid
 	t.Cleanup(func() {
+		if err := waitFor("-S", release); err != nil {
+			t.Errorf("release one-shot client: %v", err)
+		}
 		_ = cmd.Process.Signal(syscall.SIGCONT)
-		_, _ = cmd.Process.Wait()
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("one-shot client exit: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			_ = cmd.Process.Kill()
+			<-done
+			t.Error("one-shot client did not exit after release")
+		}
 	})
+	if err := waitFor(ready); err != nil {
+		t.Fatalf("one-shot client readiness: %v", err)
+	}
+	if _, err := readProcessEnviron(pid); err != nil {
+		t.Fatalf("ready client environment: %v", err)
+	}
 	if err := cmd.Process.Signal(syscall.SIGSTOP); err != nil {
 		t.Fatalf("SIGSTOP one-shot client: %v", err)
 	}
 
-	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, []string{"tmux", "-L", socket, "list-clients", "-F", "#{client_pid}"})
+	// A successful signal syscall is not an acknowledgement that the child is
+	// stopped. Observe the stop without reaping it before releasing its queue.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var status syscall.WaitStatus
+		waited, err := syscall.Wait4(pid, &status, syscall.WUNTRACED|syscall.WNOHANG, nil)
+		if err != nil {
+			t.Fatalf("wait for one-shot client stop: %v", err)
+		}
+		if waited == pid {
+			if !status.Stopped() {
+				t.Fatalf("one-shot client exited before stop: %v", status)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("one-shot client did not acknowledge SIGSTOP")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := waitFor("-S", release); err != nil {
+		t.Fatalf("release frozen client queue: %v", err)
+	}
+
+	live, ok := isLiveTmuxClientOrServer(context.Background(), pid, cmd.Args)
 	if !ok {
 		t.Fatalf("isLiveTmuxClientOrServer could not classify the frozen one-shot client %d", pid)
 	}

--- a/internal/tmux/orphan_reap_socket_memo_test.go
+++ b/internal/tmux/orphan_reap_socket_memo_test.go
@@ -33,6 +33,7 @@ func TestIsLiveTmuxClientOrServer_MemoizesAnUnreachableSocketForTheSweep(t *test
 	}
 	socket := orphanLiveTestSocket(t)
 	resetUnreachableSockets()
+	t.Cleanup(resetUnreachableSockets)
 
 	// A live candidate whose argv points at a socket with no server on it.
 	pid := fakeTmuxCandidateArgv(t, "ignore",


### PR DESCRIPTION
## What problem does this solve?

A real-tmux process identity test intermittently freezes its one-shot client before startup is stable, then treats an unclassifiable process as a classifier bug. On the same Linux Docker environment, unchanged main failed 10 of 100 focused repetitions and a candidate integration failed 11 of 100.

Diagnostic probes found an empty `/proc/<pid>/environ` on the initial classifier read, followed by a readable nonempty environment for the same stopped process. The production classifier correctly refuses the empty observation.

## Why this change

The test now uses a real tmux command queue that signals readiness, waits for release, and performs the one-shot query. It waits for readiness before freezing the client, observes its stopped status, releases the command queue, and passes the actual arguments to the classifier. The existing `ok=true` and `live=false` assertions remain intact. Cleanup resumes and reaps only the owned child with bounded waits. The adjacent sweep-memo fixture now clears its own memo on cleanup; its within-sweep refusal assertions remain intact.

## User impact

Integration gates exercise a stable live-client fixture while retaining production's refusal to classify unreadable or empty process identity data. No production code changes.

## Evidence

Candidate `c28f77f81dedd9418322f4775d85e4b9f5b5deb6`. Original baseline: 90 PASS / 10 FAIL in 100 repetitions. Unchanged candidate: 89 PASS / 11 FAIL. Diagnostic evidence identifies the transient empty environment at the actual refusal point, without dumping environment contents.

The handshake-only revision passed 100 of 100 repetitions. Its expanded five-round race run then exposed an independent fixture cleanup omission: the memo test left unreachable-socket state for subsequent rounds, causing 20 false failures. This revision adds the missing cleanup. Final candidate: **100/100 focused repetitions PASS**, **50/50 related assertions PASS across five race-enabled rounds**, and contributor gate **15 PASS, 0 FAIL, 0 WARN, 0 skipped**, including the complete affected tmux package. These ran in isolated Docker with a sandbox HOME, cleared XDG paths, four CPUs, `GOMAXPROCS=4`, and serial package execution. Required CI is still pending on the published head. The original failed full integration log and exact source hashes remain preserved. CI must pass on this new head before landing.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** `gpt-6-astra`.

## What actually bothered you

The owner requested fixing, independently verifying, and properly merging the repository's outstanding work. A full integration run then failed with this concrete error:

> isLiveTmuxClientOrServer could not classify the frozen one-shot client

An unstable test fixture prevented establishing whether unrelated fixes were safe to merge. The correction establishes a real ready and stopped client instead of relaxing the production safety check or skipping the test.

## Checklist

- [x] Targeted test-only change
- [x] Meaningful original failure reproduced and preserved
- [x] Corrected tests pass under sandboxed HOME
- [x] CHANGELOG.md untouched
- [x] AI use disclosed

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability when handling paused and one-shot tmux clients.
  * Added safer cleanup and timeout handling to prevent stalled test processes.
  * Prevented unreachable-socket state from affecting subsequent tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->