### PR TITLE
fix(ssh): retain account slots and protect concurrent storage saves

### DIFF
--- a/cmd/agent-deck/account_registration_review_test.go
+++ b/cmd/agent-deck/account_registration_review_test.go
@@ -16,14 +16,15 @@ func TestAccountReviewRegistrationRejectsBeforePersistence(t *testing.T) {
 				home := t.TempDir()
 				configDir := filepath.Join(home, ".config", "agent-deck")
 				require.NoError(t, os.MkdirAll(configDir, 0700))
-				require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[profiles.incompatible]\n"), 0600))
-				args := []string{command, home, "--title", "invalid-account", "--no-parent", "--account", account, "-c", "claude", "--json"}
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[profiles.incompatible]\n[mcps.probe]\ncommand = 'echo'\n[groups.guarded.claude]\nmcps = ['probe']\n"), 0600))
+				args := []string{command, home, "--title", "invalid-account", "--no-parent", "--account", account, "--group", "guarded", "-c", "claude", "--json"}
 				if command == "launch" {
 					args = append(args, "-m", "hello")
 				}
 				stdout, stderr, code := runAgentDeck(t, home, args...)
 				require.NotZero(t, code, "%s %s", stdout, stderr)
 				require.Contains(t, stdout+stderr, "account")
+				require.NoFileExists(t, filepath.Join(home, ".mcp.json"), "invalid account must not materialize its loadout")
 				db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", "ch_support_test", "state.db"))
 				require.NoError(t, err)
 				defer db.Close()

--- a/cmd/agent-deck/account_registration_review_test.go
+++ b/cmd/agent-deck/account_registration_review_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountReviewRegistrationRejectsBeforePersistence(t *testing.T) {
+	for _, command := range []string{"add", "launch"} {
+		for _, account := range []string{"missing", "incompatible"} {
+			t.Run(command+"/"+account, func(t *testing.T) {
+				home := t.TempDir()
+				configDir := filepath.Join(home, ".config", "agent-deck")
+				require.NoError(t, os.MkdirAll(configDir, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[profiles.incompatible]\n"), 0600))
+				args := []string{command, home, "--title", "invalid-account", "--no-parent", "--account", account, "-c", "claude", "--json"}
+				if command == "launch" {
+					args = append(args, "-m", "hello")
+				}
+				stdout, stderr, code := runAgentDeck(t, home, args...)
+				require.NotZero(t, code, "%s %s", stdout, stderr)
+				require.Contains(t, stdout+stderr, "account")
+				db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", "ch_support_test", "state.db"))
+				require.NoError(t, err)
+				defer db.Close()
+				rows, err := db.LoadInstances()
+				require.NoError(t, err)
+				require.Empty(t, rows, "account failure must not leave a registered session")
+			})
+		}
+	}
+}

--- a/cmd/agent-deck/account_registration_review_test.go
+++ b/cmd/agent-deck/account_registration_review_test.go
@@ -28,6 +28,7 @@ func TestAccountReviewRegistrationRejectsBeforePersistence(t *testing.T) {
 				db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", "ch_support_test", "state.db"))
 				require.NoError(t, err)
 				defer db.Close()
+				require.NoError(t, db.Migrate())
 				rows, err := db.LoadInstances()
 				require.NoError(t, err)
 				require.Empty(t, rows, "account failure must not leave a registered session")

--- a/cmd/agent-deck/account_worktree_boundary_test.go
+++ b/cmd/agent-deck/account_worktree_boundary_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise real Git branches, worktrees and setup scripts so a rejected
+// account cannot appear safe merely because the fixture never reached setup.
+func TestAccountWorktreeBoundary(t *testing.T) {
+	cases := []struct {
+		name, command, flagAccount, envAccount string
+		valid                                  bool
+	}{
+		{"missing flag", "claude", "missing", "", false},
+		{"incompatible flag", "claude", "incompatible", "", false},
+		{"incompatible passthrough", "claude mcp", "incompatible", "", false},
+		{"missing environment", "claude", "", "missing", false},
+		{"valid overrides environment", "claude", "valid", "missing", true},
+		{"valid environment", "claude", "", "valid", true},
+		{"default remains shell", "", "incompatible", "", true},
+	}
+	for _, operation := range []string{"add", "launch"} {
+		for _, tc := range cases {
+			t.Run(operation+"/"+tc.name, func(t *testing.T) {
+				home := t.TempDir()
+				repo := filepath.Join(home, "project")
+				require.NoError(t, os.MkdirAll(repo, 0700))
+				runFixtureGit(t, repo, "init")
+				runFixtureGit(t, repo, "config", "user.name", "Fixture")
+				runFixtureGit(t, repo, "config", "user.email", "fixture@example.invalid")
+				scriptDir := filepath.Join(repo, ".agent-deck")
+				require.NoError(t, os.MkdirAll(scriptDir, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "worktree-setup.sh"), []byte("#!/bin/sh\nprintf '%s' \"$AGENT_DECK_WORKTREE_PATH\" > \"$AGENT_DECK_REPO_ROOT/setup-ran\"\n"), 0755))
+				runFixtureGit(t, repo, "add", ".agent-deck/worktree-setup.sh")
+				runFixtureGit(t, repo, "commit", "-m", "setup fixture")
+				configDir := filepath.Join(home, ".config", "agent-deck")
+				require.NoError(t, os.MkdirAll(configDir, 0700))
+				config := fmt.Sprintf("[profiles.incompatible]\n[profiles.valid.claude]\nconfig_dir = %q\n[mcps.probe]\ncommand = 'echo'\n[groups.guarded.claude]\nmcps = ['probe']\n", filepath.Join(home, "claude-slot"))
+				require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(config), 0600))
+				// The real CLI may start this inert provider, never a real account.
+				binDir := filepath.Join(home, "bin")
+				require.NoError(t, os.MkdirAll(binDir, 0700))
+				require.NoError(t, os.WriteFile(filepath.Join(binDir, "claude"), []byte("#!/bin/sh\nexec sleep 120\n"), 0755))
+				env := []string{"HOME=" + home, "PATH=" + binDir + ":" + os.Getenv("PATH"), "SHELL=/bin/bash", "TERM=dumb", "AGENTDECK_PROFILE=ch_support_test", "AGENTDECK_ACCOUNT=" + tc.envAccount, "XDG_CONFIG_HOME=" + filepath.Join(home, ".config"), "XDG_DATA_HOME=" + filepath.Join(home, ".local", "share"), "XDG_CACHE_HOME=" + filepath.Join(home, ".cache"), "TMUX_TMPDIR=" + os.Getenv("TMUX_TMPDIR")}
+				run := func(args ...string) (string, error) {
+					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+					cmd := exec.CommandContext(ctx, channelsCLIBinary(t), args...)
+					cmd.Env = env
+					out, err := cmd.CombinedOutput()
+					return string(out), err
+				}
+				gitState := func(args ...string) string {
+					cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+					out, err := cmd.CombinedOutput()
+					require.NoError(t, err, "%s", out)
+					return string(out)
+				}
+				branches := gitState("for-each-ref", "refs/heads")
+				worktrees := gitState("worktree", "list", "--porcelain")
+				args := []string{operation, repo, "--title", "guarded", "--no-parent", "--group", "guarded", "--worktree", "guarded-branch", "--new-branch", "--location", "subdirectory", "--allow-repo-scripts", "--json"}
+				if tc.command != "" {
+					args = append(args, "-c", tc.command)
+				}
+				if tc.flagAccount != "" {
+					args = append(args, "--account", tc.flagAccount)
+				}
+				if operation == "launch" {
+					args = append(args, "--no-wait")
+					t.Cleanup(func() { _, _ = run("session", "stop", "guarded") })
+				}
+				output, runErr := run(args...)
+				marker := filepath.Join(repo, "setup-ran")
+				if tc.valid {
+					require.NoError(t, runErr, "%s", output)
+					require.FileExists(t, marker, "positive control must run setup")
+					assert.NotEqual(t, branches, gitState("for-each-ref", "refs/heads"))
+					assert.NotEqual(t, worktrees, gitState("worktree", "list", "--porcelain"))
+				} else {
+					require.Error(t, runErr, "%s", output)
+					require.Contains(t, output, "account")
+					assert.NoFileExists(t, marker, "rejected account ran repository setup")
+					assert.Equal(t, branches, gitState("for-each-ref", "refs/heads"), "rejected account created a branch")
+					assert.Equal(t, worktrees, gitState("worktree", "list", "--porcelain"), "rejected account registered a worktree")
+					assert.NoDirExists(t, filepath.Join(repo, ".worktrees"), "rejected account created worktree directories")
+					assert.NoFileExists(t, filepath.Join(repo, ".mcp.json"))
+				}
+				db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", "ch_support_test", "state.db"))
+				require.NoError(t, err)
+				defer db.Close()
+				require.NoError(t, db.Migrate())
+				rows, err := db.LoadInstances()
+				require.NoError(t, err)
+				if !tc.valid {
+					assert.Empty(t, rows, "rejected account registered a session")
+					return
+				}
+				require.Len(t, rows, 1)
+				wantAccount := firstNonEmpty(tc.flagAccount, tc.envAccount)
+				assert.Equal(t, wantAccount, rows[0].Account)
+				assert.DirExists(t, rows[0].WorktreePath)
+				markerPath, err := os.ReadFile(marker)
+				require.NoError(t, err)
+				assert.Equal(t, rows[0].WorktreePath, strings.TrimSpace(string(markerPath)))
+				if tc.command == "" {
+					assert.Equal(t, "shell", rows[0].Tool)
+				}
+			})
+		}
+	}
+}

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -15,6 +15,23 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/tmuxutf8"
 )
 
+// resolveCLIAccountSlot validates the final command provenance before callers
+// create worktrees or run setup scripts. Empty commands keep NewInstance's
+// default shell; selecting a configured default tool here would change behavior.
+func resolveCLIAccountSlot(explicitAccount, resolvedTool, resolvedCommand string, passthrough bool) (string, error) {
+	account := strings.TrimSpace(explicitAccount)
+	if account == "" {
+		account = strings.TrimSpace(os.Getenv("AGENTDECK_ACCOUNT"))
+	}
+	candidate := session.Instance{
+		Account:               account,
+		Tool:                  firstNonEmpty(resolvedTool, "shell"),
+		Command:               resolvedCommand,
+		SubcommandPassthrough: passthrough,
+	}
+	return account, candidate.ValidateAccount()
+}
+
 // tmuxProbeTimeout bounds the plain-argv tmux probes the CLI fires to identify
 // the caller's own session. These deliberately omit -L so tmux auto-routes via
 // $TMUX (see the display-message entries in TestNoRawTmuxExec_OutsideAllowlist),

--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -938,13 +938,6 @@ func handleGroupDelete(profile string, args []string) {
 		groupTree.SyncWithInstances(groupTree.GetAllInstances())
 	}
 
-	// SaveGroups is additive (never prunes), so the deleted group's rows must be
-	// removed explicitly or the group resurrects on the next reload.
-	if err := storage.DeleteGroupSubtree(groupPath); err != nil {
-		out.Error(fmt.Sprintf("failed to delete group rows: %v", err), ErrCodeNotFound)
-		os.Exit(1)
-	}
-
 	// Save
 	if err := storage.SaveWithGroups(groupTree.GetAllInstances(), groupTree); err != nil {
 		out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeNotFound)
@@ -1489,14 +1482,6 @@ func handleGroupChange(profile string, args []string) {
 	newPath := baseName
 	if destPath != "" {
 		newPath = destPath + "/" + baseName
-	}
-
-	// A move re-paths the group and its subgroups; the old source path rows must
-	// be deleted explicitly (additive SaveGroups won't prune them) before the
-	// save re-adds the new paths, or the group lingers under its old path.
-	if err := storage.DeleteGroupSubtree(sourcePath); err != nil {
-		out.Error(fmt.Sprintf("failed to delete old group rows: %v", err), ErrCodeNotFound)
-		os.Exit(1)
 	}
 
 	// Persist.

--- a/cmd/agent-deck/group_cmd_test.go
+++ b/cmd/agent-deck/group_cmd_test.go
@@ -11,13 +11,22 @@ import (
 )
 
 // helper: create storage, add N root groups, return (storage, instances, groupTree).
-// Each call overwrites the _test profile, so tests are independent when run sequentially.
+// Each call uses an isolated profile directory; creation must not overwrite
+// a different test's reordered groups.
 func setupGroupsForReorder(t *testing.T, names ...string) *session.Storage {
 	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	for _, key := range []string{"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"} {
+		t.Setenv(key, "")
+	}
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
 	storage, err := session.NewStorageWithProfile("_test")
 	if err != nil {
 		t.Fatalf("NewStorageWithProfile: %v", err)
 	}
+
+	t.Cleanup(func() { _ = storage.Close() })
 
 	instances := []*session.Instance{}
 	groupTree := session.NewGroupTreeWithGroups(instances, nil)

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -121,7 +121,7 @@ func handleLaunch(profile string, args []string) {
 	// Resume session flag
 	resumeSession := fs.String("resume-session", "", "Claude session ID to resume")
 	modelID := fs.String("model", "", "Model ID/version to use for this session (claude, codex, gemini, opencode)")
-	account := fs.String("account", "", "Named account slot (resolves via [profiles.<account>.claude].config_dir; #924)")
+	account := fs.String("account", "", "Named account slot (uses its per-tool config_dir; overrides AGENTDECK_ACCOUNT)")
 
 	// Socket isolation (v1.7.50+, issue #687). Same semantics as
 	// `agent-deck add --tmux-socket`: overrides `[tmux].socket_name` for
@@ -206,6 +206,11 @@ func handleLaunch(profile string, args []string) {
 	sessionCommandTool, sessionCommandResolved, sessionWrapperResolved, sessionCommandNote, sessionCommandIsPassthrough, cmdErr := resolveSessionCommand(sessionCommandInput, *wrapper)
 	if cmdErr != nil {
 		out.Error(cmdErr.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	selectedAccount, accountErr := resolveCLIAccountSlot(*account, sessionCommandTool, sessionCommandResolved, sessionCommandIsPassthrough)
+	if accountErr != nil {
+		out.Error(accountErr.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 	sessionParent := mergeFlags(*parent, *parentShort)
@@ -447,11 +452,8 @@ func handleLaunch(profile string, args []string) {
 		}
 	}
 
-	// #2045: launch must preserve the same per-session named account slot as
-	// add. Start-time resolution already consumes Instance.Account.
-	if trimmed := strings.TrimSpace(*account); trimmed != "" {
-		newInstance.Account = trimmed
-	}
+	// Preserve the slot validated before any worktree setup effects.
+	newInstance.Account = selectedAccount
 
 	if parentInstance != nil {
 		newInstance.SetParentWithPath(parentInstance.ID, parentInstance.ProjectPath)

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -452,10 +452,6 @@ func handleLaunch(profile string, args []string) {
 	if trimmed := strings.TrimSpace(*account); trimmed != "" {
 		newInstance.Account = trimmed
 	}
-	if err := newInstance.ValidateAccount(); err != nil {
-		out.Error(err.Error(), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
 
 	if parentInstance != nil {
 		newInstance.SetParentWithPath(parentInstance.ID, parentInstance.ProjectPath)
@@ -486,6 +482,10 @@ func handleLaunch(profile string, args []string) {
 		newInstance.Tool = firstNonEmpty(sessionCommandTool, detectTool(sessionCommandInput))
 		newInstance.Command = sessionCommandResolved
 		newInstance.SubcommandPassthrough = sessionCommandIsPassthrough
+	}
+	if err := newInstance.ValidateAccount(); err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
 
 	// Apply --channel flags (claude only — channels is a Claude Code CLI flag).

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -452,6 +452,10 @@ func handleLaunch(profile string, args []string) {
 	if trimmed := strings.TrimSpace(*account); trimmed != "" {
 		newInstance.Account = trimmed
 	}
+	if err := newInstance.ValidateAccount(); err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 
 	if parentInstance != nil {
 		newInstance.SetParentWithPath(parentInstance.ID, parentInstance.ProjectPath)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1445,7 +1445,7 @@ func handleAdd(profile string, args []string) {
 	// [profiles.<account>.claude].config_dir in ~/.agent-deck/config.toml
 	// and becomes the most-specific level of CLAUDE_CONFIG_DIR resolution.
 	// Empty = fall through to conductor/group/env/profile/global/default.
-	account := fs.String("account", "", "Named account slot (resolves via [profiles.<account>.claude].config_dir; #924)")
+	account := fs.String("account", "", "Named account slot (uses its per-tool config_dir; overrides AGENTDECK_ACCOUNT)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck add [path] [options]")
@@ -1536,6 +1536,11 @@ func handleAdd(profile string, args []string) {
 	sessionCommandTool, sessionCommandResolved, sessionWrapperResolved, sessionCommandNote, sessionCommandIsPassthrough, cmdErr := resolveSessionCommand(sessionCommandInput, *wrapper)
 	if cmdErr != nil {
 		fmt.Printf("Error: %v\n", cmdErr)
+		os.Exit(1)
+	}
+	selectedAccount, accountErr := resolveCLIAccountSlot(*account, sessionCommandTool, sessionCommandResolved, sessionCommandIsPassthrough)
+	if accountErr != nil {
+		NewCLIOutput(*jsonOutput, *quiet || *quietShort).Error(accountErr.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 	sessionParent := mergeFlags(*parent, *parentShort)
@@ -1990,9 +1995,7 @@ func handleAdd(profile string, args []string) {
 	}
 
 	// Validate the selected slot before account-dependent loadout or registration.
-	if trimmed := strings.TrimSpace(*account); trimmed != "" {
-		newInstance.Account = trimmed
-	}
+	newInstance.Account = selectedAccount
 	if err := newInstance.ValidateAccount(); err != nil {
 		out.Error(err.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1989,11 +1989,13 @@ func handleAdd(profile string, args []string) {
 		newInstance.Wrapper = sessionWrapperResolved
 	}
 
-	// #924 per-session named account slot — captured verbatim. The
-	// resolver silently falls through when no matching [profiles.<account>]
-	// block exists, so unknown names are never an error here.
+	// Validate the selected slot before account-dependent loadout or registration.
 	if trimmed := strings.TrimSpace(*account); trimmed != "" {
 		newInstance.Account = trimmed
+	}
+	if err := newInstance.ValidateAccount(); err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
 
 	// Apply per-session model override after command/tool resolution so the

--- a/cmd/agent-deck/session_location.go
+++ b/cmd/agent-deck/session_location.go
@@ -305,6 +305,34 @@ func localSessionPaths(instances []*session.Instance) map[string]bool {
 	return paths
 }
 
+// allProfileSessionPaths protects worktrees owned by any local profile. A
+// cleanup invocation must not remove a live checkout merely because its
+// session row belongs to a different profile.
+func allProfileSessionPaths(currentProfile string, current []*session.Instance) map[string]bool {
+	paths := localSessionPaths(current)
+	profiles, err := session.ListProfiles()
+	if err != nil {
+		return paths
+	}
+	for _, profile := range profiles {
+		if profile == currentProfile {
+			continue
+		}
+		storage, err := session.NewStorageWithProfile(profile)
+		if err != nil {
+			continue
+		}
+		instances, _, err := storage.LoadWithGroups()
+		_ = storage.Close()
+		if err == nil {
+			for path := range localSessionPaths(instances) {
+				paths[path] = true
+			}
+		}
+	}
+	return paths
+}
+
 // localSessionsAtPath returns every session that runs locally at path. Callers
 // that can only mean a local session (worktree occupancy, `try`, the tmux-cwd
 // fallback) must use this rather than comparing ProjectPath, so a remote session

--- a/cmd/agent-deck/session_location.go
+++ b/cmd/agent-deck/session_location.go
@@ -308,11 +308,11 @@ func localSessionPaths(instances []*session.Instance) map[string]bool {
 // allProfileSessionPaths protects worktrees owned by any local profile. A
 // cleanup invocation must not remove a live checkout merely because its
 // session row belongs to a different profile.
-func allProfileSessionPaths(currentProfile string, current []*session.Instance) map[string]bool {
+func allProfileSessionPaths(currentProfile string, current []*session.Instance) (map[string]bool, error) {
 	paths := localSessionPaths(current)
 	profiles, err := session.ListProfiles()
 	if err != nil {
-		return paths
+		return nil, fmt.Errorf("list profiles for worktree ownership: %w", err)
 	}
 	for _, profile := range profiles {
 		if profile == currentProfile {
@@ -320,17 +320,18 @@ func allProfileSessionPaths(currentProfile string, current []*session.Instance) 
 		}
 		storage, err := session.NewStorageWithProfile(profile)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("open profile %q for worktree ownership: %w", profile, err)
 		}
 		instances, _, err := storage.LoadWithGroups()
 		_ = storage.Close()
-		if err == nil {
-			for path := range localSessionPaths(instances) {
-				paths[path] = true
-			}
+		if err != nil {
+			return nil, fmt.Errorf("load profile %q for worktree ownership: %w", profile, err)
+		}
+		for path := range localSessionPaths(instances) {
+			paths[path] = true
 		}
 	}
-	return paths
+	return paths, nil
 }
 
 // localSessionsAtPath returns every session that runs locally at path. Callers

--- a/cmd/agent-deck/storage_two_process_test.go
+++ b/cmd/agent-deck/storage_two_process_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+// These are independently executed production CLI binaries, not two handles or
+// test-helper processes. Only tmux is substituted: its ordinary set-environment call
+// pauses a session-ID edit after loading and before saving, without a production test hook.
+func TestStorageTwoCLIProcesses(t *testing.T) {
+	for _, scenario := range []string{"disjoint account", "same session id", "deleted row", "new addition", "group metadata"} {
+		t.Run(scenario, func(t *testing.T) {
+			home := t.TempDir()
+			configDir := filepath.Join(home, ".config", "agent-deck")
+			require.NoError(t, os.MkdirAll(configDir, 0700))
+			require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[profiles.seminno]\n"), 0600))
+			out, stderr, code := runAgentDeck(t, home, "list", "--json")
+			require.Zero(t, code, "%s %s", out, stderr)
+			db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", "ch_support_test", "state.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { db.Close() })
+			require.NoError(t, db.SaveInstance(&statedb.InstanceRow{
+				ID: "shared", Title: "original", ProjectPath: home, GroupPath: "test",
+				Tool: "shell", Status: "idle", Account: "personal", CreatedAt: time.Now(),
+				TmuxSession: "agentdeck_storage_acceptance",
+			}))
+			require.NoError(t, db.SaveGroups([]*statedb.GroupRow{{Path: "test", Name: "test", Expanded: true}}))
+			binDir := filepath.Join(home, "bin")
+			require.NoError(t, os.MkdirAll(binDir, 0700))
+			require.NoError(t, os.WriteFile(filepath.Join(binDir, "tmux"), []byte(`#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "set-environment" ] && [ -n "$STORAGE_BARRIER" ]; then
+    : > "$STORAGE_BARRIER.ready"
+    attempts=0
+    while [ ! -f "$STORAGE_BARRIER.release" ]; do
+      attempts=$((attempts + 1))
+      [ "$attempts" -lt 1000 ] || exit 1
+      sleep 0.02
+    done
+    break
+  fi
+done
+exit 0
+`), 0700))
+			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+			start := func(barrier string, args ...string) (*exec.Cmd, *bytes.Buffer) {
+				cmd := exec.CommandContext(ctx, channelsCLIBinary(t), args...)
+				for _, item := range cliEnvForIssue1031(home) {
+					if !strings.HasPrefix(item, "PATH=") && !strings.HasPrefix(item, "XDG_") {
+						cmd.Env = append(cmd.Env, item)
+					}
+				}
+				cmd.Env = append(cmd.Env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+					"XDG_CONFIG_HOME="+filepath.Join(home, ".config"), "XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+					"XDG_CACHE_HOME="+filepath.Join(home, ".cache"), "STORAGE_BARRIER="+barrier)
+				output := new(bytes.Buffer)
+				cmd.Stdout, cmd.Stderr = output, output
+				require.NoError(t, cmd.Start())
+				return cmd, output
+			}
+			waitReady := func(path string) {
+				require.Eventually(t, func() bool { _, err := os.Stat(path + ".ready"); return err == nil }, 15*time.Second, 10*time.Millisecond, "CLI did not reach the post-load barrier")
+			}
+			aBarrier := filepath.Join(home, "a")
+			a, aOut := start(aBarrier, "session", "set", "shared", "gemini-session-id", "alice", "--json")
+			waitReady(aBarrier)
+			var b *exec.Cmd
+			var bOut *bytes.Buffer
+			switch scenario {
+			case "same session id":
+				bBarrier := filepath.Join(home, "b")
+				b, bOut = start(bBarrier, "session", "set", "shared", "gemini-session-id", "bob", "--json")
+				waitReady(bBarrier)
+				require.NoError(t, os.WriteFile(bBarrier+".release", nil, 0600))
+			case "group metadata":
+				b, bOut = start("", "group", "update", "test", "--max-concurrent=2", "--json")
+			case "disjoint account":
+				b, bOut = start("", "session", "set", "shared", "account", "seminno", "--json")
+			case "deleted row":
+				b, bOut = start("", "rm", "shared")
+			case "new addition":
+				b, bOut = start("", "add", home, "--title", "bob", "--no-parent", "--json")
+			}
+			require.NoError(t, b.Wait(), "second CLI: %s", bOut)
+			require.NoError(t, os.WriteFile(aBarrier+".release", nil, 0600))
+			err = a.Wait()
+			if scenario == "same session id" || scenario == "deleted row" {
+				require.Error(t, err, "stale first CLI must fail: %s", aOut)
+				require.Contains(t, aOut.String(), "conflict")
+			} else {
+				require.NoError(t, err, "first CLI: %s", aOut)
+			}
+			// A fresh third database reader verifies both process outcomes.
+			check, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", "ch_support_test", "state.db"))
+			require.NoError(t, err)
+			defer check.Close()
+			rows, err := check.LoadInstances()
+			require.NoError(t, err)
+			var toolData struct {
+				GeminiSessionID string `json:"gemini_session_id"`
+			}
+			if len(rows) > 0 {
+				require.NoError(t, json.Unmarshal(rows[0].ToolData, &toolData))
+			}
+			switch scenario {
+			case "deleted row":
+				require.Empty(t, rows)
+			case "new addition":
+				require.Len(t, rows, 2)
+			case "same session id":
+				require.Len(t, rows, 1)
+				require.Equal(t, "bob", toolData.GeminiSessionID)
+			case "group metadata":
+				groups, err := check.LoadGroups()
+				require.NoError(t, err)
+				require.Len(t, groups, 1)
+				require.Equal(t, 2, groups[0].MaxConcurrent)
+				require.Equal(t, "alice", toolData.GeminiSessionID)
+			case "disjoint account":
+				require.Len(t, rows, 1)
+				require.Equal(t, "alice", toolData.GeminiSessionID)
+				require.Equal(t, "seminno", rows[0].Account)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -461,7 +461,11 @@ func handleWorktreeCleanup(profile string, args []string) {
 			// harmful direction of #1852 site 3: a remote session's placeholder
 			// inserted here makes a genuinely orphaned worktree look in-use, so
 			// cleanup silently skips it forever.
-			sessionPaths := allProfileSessionPaths(profile, instances)
+			sessionPaths, err := allProfileSessionPaths(profile, instances)
+			if err != nil {
+				out.Error(err.Error(), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
 
 			orphanedWorktrees, protectedWorktrees = classifyUnregisteredWorktrees(worktrees, sessionPaths)
 		}
@@ -599,11 +603,12 @@ func handleWorktreeCleanup(profile string, args []string) {
 		// repository state, then inspect the candidate again at the destructive
 		// boundary. --force authorizes removal; it never bypasses this gate.
 		removed, skipReason, removeErr := removeCleanupCandidate(cleanupBackend, wt, func() (map[string]bool, error) {
-			_, currentInstances, _, err := loadSessionData(profile)
+			currentStorage, currentInstances, _, err := loadSessionData(profile)
 			if err != nil {
 				return nil, err
 			}
-			return localSessionPaths(currentInstances), nil
+			defer currentStorage.Close()
+			return allProfileSessionPaths(profile, currentInstances)
 		})
 		if !removed {
 			if removeErr != nil {

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -461,7 +461,7 @@ func handleWorktreeCleanup(profile string, args []string) {
 			// harmful direction of #1852 site 3: a remote session's placeholder
 			// inserted here makes a genuinely orphaned worktree look in-use, so
 			// cleanup silently skips it forever.
-			sessionPaths := localSessionPaths(instances)
+			sessionPaths := allProfileSessionPaths(profile, instances)
 
 			orphanedWorktrees, protectedWorktrees = classifyUnregisteredWorktrees(worktrees, sessionPaths)
 		}

--- a/cmd/agent-deck/worktree_profiles_review_test.go
+++ b/cmd/agent-deck/worktree_profiles_review_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+// A real CLI waits at its confirmation prompt. Changes to another profile then
+// exercise the actual destructive callback, not a substitute ownership callback.
+func TestCleanupReviewCrossProfileBoundary(t *testing.T) {
+	for _, change := range []string{"owned before scan", "corrupt before scan", "unreadable before scan", "claimed after scan", "corrupt after scan", "unclaimed"} {
+		t.Run(change, func(t *testing.T) {
+			home := t.TempDir()
+			stdout, stderr, code := runAgentDeck(t, home, "list", "--json")
+			require.Zero(t, code, "%s %s", stdout, stderr)
+			main, _, _, candidate, _ := cleanupFixture(t)
+			otherDir := filepath.Join(home, ".local", "share", "agent-deck", "profiles", "other")
+			changeProfile := func() {
+				require.NoError(t, os.MkdirAll(otherDir, 0700))
+				path := filepath.Join(otherDir, "state.db")
+				if strings.Contains(change, "corrupt") {
+					require.NoError(t, os.WriteFile(path, []byte("not a database"), 0600))
+					return
+				}
+				db, err := statedb.Open(path)
+				require.NoError(t, err)
+				require.NoError(t, db.Migrate())
+				require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "owner", Title: "owner", Tool: "shell", ProjectPath: candidate, WorktreePath: candidate}))
+				require.NoError(t, db.Close())
+				if strings.Contains(change, "unreadable") {
+					require.NoError(t, os.Chmod(otherDir, 0000))
+					t.Cleanup(func() { _ = os.Chmod(otherDir, 0700) })
+					_, err := os.Stat(path)
+					require.Error(t, err, "fixture must deny access; sandbox must drop DAC_OVERRIDE")
+				}
+			}
+			if strings.Contains(change, "before scan") {
+				changeProfile()
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, channelsCLIBinary(t), "worktree", "cleanup", "--force")
+			cmd.Dir, cmd.Env = main, cliEnvForIssue1031(home)
+			input, err := cmd.StdinPipe()
+			require.NoError(t, err)
+			logPath := filepath.Join(home, "cleanup.log")
+			log, err := os.Create(logPath)
+			require.NoError(t, err)
+			defer log.Close()
+			cmd.Stdout, cmd.Stderr = log, log
+			require.NoError(t, cmd.Start())
+			if strings.Contains(change, "after scan") {
+				require.Eventually(t, func() bool {
+					data, _ := os.ReadFile(logPath)
+					return strings.Contains(string(data), "Continue? [y/N]")
+				}, 15*time.Second, 10*time.Millisecond)
+				changeProfile()
+			}
+			_, _ = input.Write([]byte("y\n"))
+			_ = input.Close()
+			err = cmd.Wait()
+			data, readErr := os.ReadFile(logPath)
+			require.NoError(t, readErr)
+			if strings.Contains(change, "before scan") && change != "owned before scan" {
+				require.Error(t, err, "%s", data)
+			} else {
+				require.NoError(t, err, "%s", data)
+			}
+			_, statErr := os.Stat(candidate)
+			if change == "unclaimed" {
+				require.True(t, os.IsNotExist(statErr), "unclaimed positive control was not removed: %s", data)
+			} else {
+				require.NoError(t, statErr, "owned/uncertain worktree removed: %s", data)
+			}
+		})
+	}
+}

--- a/docs/SSH-ACCOUNTS.md
+++ b/docs/SSH-ACCOUNTS.md
@@ -1,0 +1,24 @@
+# Account slots over SSH
+
+When two logins share one macOS user and profile, set `AGENTDECK_ACCOUNT` before
+starting the CLI. A session stores that slot, and later starts, restarts, forks,
+and nested commands continue using the saved slot instead of the caller's
+ambient credentials.
+
+```sh
+AGENTDECK_ACCOUNT=person_a agent-deck launch . --cmd claude
+agent-deck launch . --cmd claude --account person_b
+```
+
+`session list`, `session show`, JSON output, and the TUI display the saved slot
+as `account` and `owner`. `owner` identifies the credential slot, not a human.
+An empty account clears the override. Unknown or tool-incompatible slots fail
+before a session or conversation is changed.
+
+Remote commands execute on the selected host. Use `agent-deck remote NAME
+session show TITLE --json` to inspect the server's saved slot and
+`agent-deck remote NAME session send TITLE --message-file task.md` to send a
+message without moving the file to the controller.
+
+Worktree cleanup reads every local profile before removing an unregistered
+worktree. A live session from another profile therefore protects its checkout.

--- a/internal/session/account_review_test.go
+++ b/internal/session/account_review_test.go
@@ -1,0 +1,126 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"al.essio.dev/pkg/shellescape"
+	"github.com/stretchr/testify/require"
+)
+
+func accountReviewConfig(t *testing.T, config string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	dir := filepath.Join(home, "config", "agent-deck")
+	require.NoError(t, os.MkdirAll(dir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.toml"), []byte(config), 0600))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+	return home
+}
+
+func TestAccountReviewDeepSeekCannotUseAmbientHome(t *testing.T) {
+	accountReviewConfig(t, "[profiles.empty]\n[profiles.named.deepseek]\nconfig_dir = '~/.named-dsh'\n")
+	t.Setenv("DSH_HOME", t.TempDir())
+	require.ErrorContains(t, ValidateAccountSlot("empty", "deepseek"), "DeepSeek config_dir")
+	require.NoError(t, ValidateAccountSlot("named", "deepseek"))
+	require.NoError(t, ValidateAccountSlot("", "deepseek"))
+}
+
+func TestAccountReviewShellValidationMatchesProvenance(t *testing.T) {
+	accountReviewConfig(t, "[profiles.empty]\n")
+	for _, passthrough := range []bool{false, true} {
+		inst := &Instance{Tool: "shell", Command: "claude mcp list", SubcommandPassthrough: passthrough}
+		_, _, err := SetField(inst, FieldAccount, "empty", nil)
+		if passthrough {
+			require.ErrorContains(t, err, "Claude config_dir")
+			require.Empty(t, inst.Account)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, "empty", inst.Account)
+		}
+	}
+}
+
+func TestAccountReviewFallbackShellRestartKeepsTypedCommandAccount(t *testing.T) {
+	home := accountReviewConfig(t, "[profiles.saved]\n[profiles.ambient]\n")
+	t.Setenv("SHELL", "/bin/bash")
+	t.Setenv("AGENTDECK_ACCOUNT", "ambient")
+	inst := NewInstanceWithTool("account-shell", home, "shell")
+	inst.Account = "saved"
+	inst.Command = "true"
+	t.Cleanup(func() { _ = inst.Kill() })
+	require.NoError(t, inst.Start())
+	require.False(t, inst.GetTmuxSession().RunCommandAsInitialProcess)
+	for _, restart := range []bool{false, true} {
+		if restart {
+			require.NoError(t, inst.Restart())
+		}
+		output := filepath.Join(t.TempDir(), "account")
+		require.NoError(t, inst.GetTmuxSession().SendKeysAndEnter("printf '%s' \"$AGENTDECK_ACCOUNT\" > "+shellescape.Quote(output)))
+		require.Eventually(t, func() bool { _, err := os.Stat(output); return err == nil }, 5*time.Second, 10*time.Millisecond)
+		data, err := os.ReadFile(output)
+		require.NoError(t, err)
+		require.Equal(t, "saved", string(data), "typed command after restart=%v", restart)
+	}
+}
+
+func TestAccountReviewPassthroughLifecycleRejectsBeforeSpawn(t *testing.T) {
+	home := accountReviewConfig(t, "[profiles.empty]\n")
+	for _, tool := range []string{"claude", "codex"} {
+		for _, operation := range []string{"start", "message", "restart"} {
+			t.Run(tool+"/"+operation, func(t *testing.T) {
+				// An invalid project path is an independent early spawn failure on the
+				// old code. Account refusal must precede it, without starting a tool.
+				inst := NewInstanceWithTool("invalid-account", filepath.Join(home, "missing"), "shell")
+				inst.Account, inst.Command, inst.SubcommandPassthrough = "empty", tool+" mcp list", true
+				var err error
+				switch operation {
+				case "start":
+					err = inst.Start()
+				case "message":
+					err = inst.StartWithMessage("hello")
+				case "restart":
+					err = inst.Restart()
+				}
+				require.ErrorContains(t, err, "config_dir")
+			})
+		}
+	}
+}
+
+func TestAccountReviewPassthroughConfigPathsFollowExecutionHome(t *testing.T) {
+	home := accountReviewConfig(t, "[profiles.named.claude]\nconfig_dir = '~/.claude space; literal'\n")
+	bin := filepath.Join(home, "bin")
+	require.NoError(t, os.MkdirAll(bin, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(bin, "claude"), []byte("#!/bin/sh\nprintf '%s\\n' \"$CLAUDE_CONFIG_DIR\" \"$CLAUDE_SECURESTORAGE_CONFIG_DIR\"\n"), 0700))
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for _, remote := range []bool{false, true} {
+		inst := &Instance{Tool: "shell", Command: "claude mcp list", SubcommandPassthrough: true, Account: "named"}
+		executionHome := home
+		if remote {
+			inst.SSHHost = "fixture.invalid"
+			executionHome = t.TempDir()
+		}
+		payload := inst.buildShellPassthroughCommand(inst.Command)
+		cmd := exec.Command("bash", "-c", payload)
+		for _, item := range os.Environ() {
+			if !strings.HasPrefix(item, "HOME=") {
+				cmd.Env = append(cmd.Env, item)
+			}
+		}
+		cmd.Env = append(cmd.Env, "HOME="+executionHome)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s", output)
+		want := filepath.Join(executionHome, ".claude space; literal")
+		require.Equal(t, want+"\n"+want+"\n", string(output), "remote=%v", remote)
+	}
+}

--- a/internal/session/account_slot.go
+++ b/internal/session/account_slot.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateAccountSlot rejects a named slot that would otherwise fall through
+// to ambient credentials. An empty slot preserves the existing default chain.
+func ValidateAccountSlot(account, tool string) error {
+	account = strings.TrimSpace(account)
+	if account == "" {
+		return nil
+	}
+	config, err := LoadUserConfig()
+	if err != nil {
+		return fmt.Errorf("load account configuration: %w", err)
+	}
+	if config == nil {
+		return fmt.Errorf("account %q is not configured; run agent-deck accounts", account)
+	}
+	if _, exists := config.Profiles[account]; !exists {
+		return fmt.Errorf("account %q is not configured; run agent-deck accounts", account)
+	}
+	if IsClaudeCompatible(tool) && config.GetProfileClaudeConfigDir(account) == "" {
+		return fmt.Errorf("account %q has no Claude config_dir", account)
+	}
+	if IsCodexCompatible(tool) && config.GetProfileCodexConfigDir(account) == "" {
+		return fmt.Errorf("account %q has no Codex config_dir", account)
+	}
+	return nil
+}

--- a/internal/session/account_slot.go
+++ b/internal/session/account_slot.go
@@ -5,6 +5,23 @@ import (
 	"strings"
 )
 
+// accountTool follows the same explicit provenance gate as the shell command
+// builder. A regular shell command is not a tool-specific account operation.
+func (i *Instance) accountTool() string {
+	if i.Tool == "shell" && i.SubcommandPassthrough {
+		if fields := strings.Fields(i.Command); len(fields) > 0 {
+			return MatchTool(fields[0])
+		}
+	}
+	return i.Tool
+}
+
+// ValidateAccount must run before registration or account-dependent loadout
+// writes, as well as before starting an already registered session.
+func (i *Instance) ValidateAccount() error {
+	return ValidateAccountSlot(i.Account, i.accountTool())
+}
+
 // ValidateAccountSlot rejects a named slot that would otherwise fall through
 // to ambient credentials. An empty slot preserves the existing default chain.
 func ValidateAccountSlot(account, tool string) error {
@@ -27,6 +44,9 @@ func ValidateAccountSlot(account, tool string) error {
 	}
 	if IsCodexCompatible(tool) && config.GetProfileCodexConfigDir(account) == "" {
 		return fmt.Errorf("account %q has no Codex config_dir", account)
+	}
+	if tool == "deepseek" && config.GetProfileDeepSeekConfigDir(account) == "" {
+		return fmt.Errorf("account %q has no DeepSeek config_dir", account)
 	}
 	return nil
 }

--- a/internal/session/attack_generic_session_test.go
+++ b/internal/session/attack_generic_session_test.go
@@ -159,9 +159,7 @@ func TestAttack_StickyVsClearContracts(t *testing.T) {
 	}
 
 	// (1) Sticky: full save with empty id + cleared=false preserves A.
-	stale := NewInstance("sticky-contract", "/tmp")
-	stale.ID = inst.ID
-	stale.Tool = "shell"
+	stale := inst
 	stale.GenericSessionID = ""
 	stale.genericSessionIDCleared = false
 	if err := storage.SaveWithGroups([]*Instance{stale}, NewGroupTreeWithGroups([]*Instance{stale}, nil)); err != nil {

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -176,8 +176,12 @@ func ListProfiles() ([]string, error) {
 			jsonPath := filepath.Join(profilesDir, entry.Name(), "sessions.json")
 			if _, err := os.Stat(dbPath); err == nil {
 				profiles = append(profiles, entry.Name())
+			} else if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("inspect profile %q database: %w", entry.Name(), err)
 			} else if _, err := os.Stat(jsonPath); err == nil {
 				profiles = append(profiles, entry.Name())
+			} else if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("inspect profile %q legacy data: %w", entry.Name(), err)
 			}
 		}
 	}

--- a/internal/session/gemini_yolo_test.go
+++ b/internal/session/gemini_yolo_test.go
@@ -216,7 +216,6 @@ func TestInstance_buildGeminiCommand_YoloFlag(t *testing.T) {
 
 // TestInstance_GeminiYoloMode_Persistence tests that GeminiYoloMode persists through save/load
 func TestInstance_GeminiYoloMode_Persistence(t *testing.T) {
-	s := newTestStorage(t)
 
 	tests := []struct {
 		name              string
@@ -242,6 +241,7 @@ func TestInstance_GeminiYoloMode_Persistence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			s := newTestStorage(t)
 			// Create instance with YOLO mode
 			inst := &Instance{
 				ID:              "test-persist",

--- a/internal/session/generic_session_stress_test.go
+++ b/internal/session/generic_session_stress_test.go
@@ -39,9 +39,7 @@ func TestStress_StaleFullSavePreservesStickyGenericID(t *testing.T) {
 	}
 
 	// Stale full-table save: Instance still has empty GenericSessionID.
-	stale := NewInstance("sticky-stale", "/tmp/proj")
-	stale.ID = inst.ID
-	stale.Tool = "shell"
+	stale := inst
 	stale.Color = "#00ff00" // unrelated field change
 	stale.GenericSessionID = ""
 	stale.GenericDetectedAt = time.Time{}
@@ -83,10 +81,8 @@ func TestStress_ExplicitClearViaBindingThenLoad(t *testing.T) {
 	}
 
 	// Stale save after clear must not resurrect: DB keys are gone, so sticky
-	// has nothing to preserve. New Instance (do not copy *inst — it holds a mutex).
-	stale := NewInstance(inst.Title, inst.ProjectPath)
-	stale.ID = inst.ID
-	stale.Tool = inst.Tool
+	// has nothing to preserve. Retain the genuine snapshot from before the clear.
+	stale := inst
 	if err := storage.SaveWithGroups([]*Instance{stale}, NewGroupTreeWithGroups([]*Instance{stale}, nil)); err != nil {
 		t.Fatal(err)
 	}
@@ -273,6 +269,8 @@ func TestStress_DetectedAtZeroVsNonZero(t *testing.T) {
 		t.Fatalf("detected_at %v outside [%v,%v]", at, before, after)
 	}
 
+	// Explicit edits start from the binding just read, not the older snapshot.
+	inst = loaded[0]
 	// Explicit non-zero stamp round-trips via full Save path.
 	want := time.Unix(1_700_000_777, 0).UTC()
 	inst.GenericSessionID = "id-explicit-at"

--- a/internal/session/group_storage_snapshot.go
+++ b/internal/session/group_storage_snapshot.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+type groupStorageSnapshot struct {
+	dbPath   string
+	original *statedb.GroupRow
+	stored   *statedb.GroupRow
+	ensure   bool
+}
+
+type groupDeletion struct {
+	completed atomic.Bool
+	dbPath    string
+	update    statedb.GroupSnapshot
+}
+type groupDeletionQueue struct {
+	mu    sync.Mutex
+	items []*groupDeletion
+}
+
+func groupToRow(group *Group) *statedb.GroupRow {
+	return &statedb.GroupRow{Path: group.Path, Name: group.Name, Expanded: group.Expanded,
+		Order: group.Order, DefaultPath: group.DefaultPath, MaxConcurrent: group.MaxConcurrent}
+}
+
+func groupDataToRow(group *GroupData) *statedb.GroupRow {
+	return &statedb.GroupRow{Path: group.Path, Name: group.Name, Expanded: group.Expanded,
+		Order: group.Order, DefaultPath: group.DefaultPath, MaxConcurrent: group.MaxConcurrent}
+}
+
+func (tree *GroupTree) initializeDerivedSnapshots() {
+	for _, group := range tree.GroupList {
+		if group.derived && group.storageSnapshot.Load() == nil {
+			group.storageSnapshot.Store(&groupStorageSnapshot{original: groupToRow(group), ensure: true})
+		}
+	}
+}
+
+func (tree *GroupTree) queueGroupDeletion(group *Group) {
+	if tree.groupDeletes == nil {
+		tree.groupDeletes = &groupDeletionQueue{}
+	}
+	deletion := &groupDeletion{update: statedb.GroupSnapshot{Original: groupToRow(group)}}
+	if snapshot := group.storageSnapshot.Load(); snapshot != nil {
+		deletion.dbPath = snapshot.dbPath
+		deletion.update.Original, deletion.update.Stored = snapshot.original, snapshot.stored
+	}
+	tree.groupDeletes.mu.Lock()
+	tree.groupDeletes.items = append(tree.groupDeletes.items, deletion)
+	tree.groupDeletes.mu.Unlock()
+}
+
+func (tree *GroupTree) deletionSnapshot() []*groupDeletion {
+	if tree.frozenDeletes {
+		return tree.savedDeletes
+	}
+	if tree.groupDeletes == nil {
+		return nil
+	}
+	tree.groupDeletes.mu.Lock()
+	defer tree.groupDeletes.mu.Unlock()
+	return append([]*groupDeletion(nil), tree.groupDeletes.items...)
+}
+
+type groupSaveBatch struct {
+	updates     []statedb.GroupSnapshot
+	origins     []*groupStorageSnapshot
+	groups      []*Group
+	deletes     []*groupDeletion
+	deleteQueue *groupDeletionQueue
+}
+
+func (s *Storage) prepareGroupSave(tree *GroupTree) (groupSaveBatch, error) {
+	var batch groupSaveBatch
+	if tree == nil {
+		return batch, nil
+	}
+	batch.groups = tree.GroupList
+	batch.origins = make([]*groupStorageSnapshot, len(batch.groups))
+	for i, group := range batch.groups {
+		update := statedb.GroupSnapshot{Desired: groupToRow(group)}
+		snapshot := group.storageSnapshot.Load()
+		batch.origins[i] = snapshot
+		if snapshot != nil && (snapshot.dbPath == "" || snapshot.dbPath == s.dbPath) {
+			update.Original, update.Stored, update.Ensure = snapshot.original, snapshot.stored, snapshot.ensure
+		}
+		batch.updates = append(batch.updates, update)
+	}
+	batch.deleteQueue = tree.groupDeletes
+	for _, deletion := range tree.deletionSnapshot() {
+		if deletion.completed.Load() {
+			continue
+		}
+		batch.deletes = append(batch.deletes, deletion)
+		update := deletion.update
+		if deletion.dbPath != "" && deletion.dbPath != s.dbPath {
+			return groupSaveBatch{}, fmt.Errorf("group deletion belongs to a different database: %s", update.Original.Path)
+		}
+		batch.updates = append(batch.updates, update)
+	}
+	return batch, nil
+}
+
+func (s *Storage) finishGroupSave(batch groupSaveBatch, committed []*statedb.GroupRow) {
+	for i, group := range batch.groups {
+		next := &groupStorageSnapshot{dbPath: s.dbPath,
+			original: statedb.CloneGroupRow(batch.updates[i].Desired), stored: statedb.CloneGroupRow(committed[i]),
+			ensure: batch.updates[i].Ensure && committed[i] == nil}
+		// A copied payload owns its captured origin. Advance its live owner only
+		// if that owner still has the same origin; an older receipt cannot undo
+		// a newer save. Atomic pointers avoid touching live mutable group fields.
+		for owner := group; owner != nil; owner = owner.saveOwner {
+			owner.storageSnapshot.CompareAndSwap(batch.origins[i], next)
+		}
+	}
+	if batch.deleteQueue == nil || len(batch.deletes) == 0 {
+		return
+	}
+	completed := make(map[*groupDeletion]bool, len(batch.deletes))
+	for _, deletion := range batch.deletes {
+		deletion.completed.Store(true)
+		completed[deletion] = true
+	}
+	batch.deleteQueue.mu.Lock()
+	remaining := batch.deleteQueue.items[:0]
+	for _, deletion := range batch.deleteQueue.items {
+		if !completed[deletion] {
+			remaining = append(remaining, deletion)
+		}
+	}
+	batch.deleteQueue.items = remaining
+	batch.deleteQueue.mu.Unlock()
+}

--- a/internal/session/group_storage_snapshot_test.go
+++ b/internal/session/group_storage_snapshot_test.go
@@ -1,0 +1,333 @@
+package session
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"modernc.org/sqlite"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func groupSnapshotFixture(t *testing.T) (*Storage, []*Instance, *GroupTree, []*Instance, *GroupTree) {
+	t.Helper()
+	s, seed, _ := snapshotFixture(t)
+	require.NoError(t, s.SaveWithGroups(seed, NewGroupTree(seed)))
+	a, ga, err := s.LoadWithGroups()
+	require.NoError(t, err)
+	b, gb, err := s.LoadWithGroups()
+	require.NoError(t, err)
+	return s, a, NewGroupTreeWithGroups(a, ga), b, NewGroupTreeWithGroups(b, gb)
+}
+
+func storedGroup(t *testing.T, s *Storage, path string) *statedb.GroupRow {
+	t.Helper()
+	rows, err := s.db.LoadGroups()
+	require.NoError(t, err)
+	for _, row := range rows {
+		if row.Path == path {
+			return row
+		}
+	}
+	return nil
+}
+
+func TestGroupStorageSnapshotsMergeDisjointFields(t *testing.T) {
+	s, a, ta, _, tb := groupSnapshotFixture(t)
+	tb.Groups["test"].DefaultPath = t.TempDir()
+	require.NoError(t, s.SaveGroupsOnly(tb.ShallowCopyForSave()))
+	ta.Groups["test"].MaxConcurrent = 3
+	require.NoError(t, s.SaveWithGroups(a, ta.ShallowCopyForSave()))
+	got := storedGroup(t, s, "test")
+	require.Equal(t, tb.Groups["test"].DefaultPath, got.DefaultPath)
+	require.Equal(t, 3, got.MaxConcurrent)
+	// The live tree receives the successful copied save's baseline, while its
+	// unedited stale default path must not become a later overwrite intent.
+	ta.Groups["test"].MaxConcurrent = 4
+	require.NoError(t, s.SaveGroupsOnly(ta.ShallowCopyForSave()))
+	got = storedGroup(t, s, "test")
+	require.Equal(t, tb.Groups["test"].DefaultPath, got.DefaultPath)
+	require.Equal(t, 4, got.MaxConcurrent)
+}
+
+func TestGroupStorageSnapshotsOlderCopyCannotRebase(t *testing.T) {
+	s, _, ta, _, tb := groupSnapshotFixture(t)
+	older := ta.ShallowCopyForSave()
+	tb.Groups["test"].DefaultPath = t.TempDir()
+	require.NoError(t, s.SaveGroupsOnly(tb))
+	ta.Groups["test"].MaxConcurrent = 2
+	require.NoError(t, s.SaveGroupsOnly(ta.ShallowCopyForSave()))
+	older.GroupList[0].DefaultPath = t.TempDir()
+	require.ErrorContains(t, s.SaveGroupsOnly(older), "conflict")
+	require.Equal(t, tb.Groups["test"].DefaultPath, storedGroup(t, s, "test").DefaultPath)
+}
+
+func TestGroupStorageSnapshotsDeletionDoesNotResurrect(t *testing.T) {
+	s, _, ta, _, tb := groupSnapshotFixture(t)
+	tb.DeleteGroup("test")
+	require.NoError(t, s.SaveWithGroups(tb.GetAllInstances(), tb.ShallowCopyForSave()))
+	require.Nil(t, storedGroup(t, s, "test"))
+	require.ErrorContains(t, s.SaveGroupsOnly(ta), "deletion conflict")
+	require.Nil(t, storedGroup(t, s, "test"))
+	// Successful deletion intent is consumed on the live tree as well.
+	require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{{Path: "test", Name: "explicitly recreated", MaxConcurrent: 9}}))
+	require.NoError(t, s.SaveWithGroups(tb.GetAllInstances(), tb.ShallowCopyForSave()))
+	require.Equal(t, 9, storedGroup(t, s, "test").MaxConcurrent)
+}
+
+func TestGroupStorageSnapshotsRenameRejectsUnknownAdditions(t *testing.T) {
+	for _, kind := range []string{"session", "subgroup"} {
+		t.Run(kind, func(t *testing.T) {
+			s, a, ta, _, _ := groupSnapshotFixture(t)
+			if kind == "session" {
+				require.NoError(t, s.Save([]*Instance{{ID: "later", Title: "later", GroupPath: "test", Tool: "shell", ProjectPath: t.TempDir()}}))
+			} else {
+				require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{{Path: "test/later", Name: "later"}}))
+			}
+			require.NoError(t, ta.RenameGroup("test", "renamed"))
+			require.ErrorContains(t, s.SaveWithGroups(a, ta), "conflict")
+			require.NotNil(t, storedGroup(t, s, "test"))
+			require.Nil(t, storedGroup(t, s, "renamed"))
+			row, err := s.db.LoadInstanceByID("shared")
+			require.NoError(t, err)
+			require.Equal(t, "test", row.GroupPath)
+		})
+	}
+}
+
+func TestGroupStorageSnapshotsRenameRollsBackWithSessions(t *testing.T) {
+	s, a, ta, _, _ := groupSnapshotFixture(t)
+	require.NoError(t, ta.RenameGroup("test", "renamed"))
+	_, err := s.db.DB().Exec("CREATE TRIGGER reject_rename BEFORE INSERT ON groups BEGIN SELECT RAISE(ABORT, 'rename rejected'); END")
+	require.NoError(t, err)
+	require.ErrorContains(t, s.SaveWithGroups(a, ta.ShallowCopyForSave()), "rename rejected")
+	require.NotNil(t, storedGroup(t, s, "test"))
+	require.Nil(t, storedGroup(t, s, "renamed"))
+	row, err := s.db.LoadInstanceByID("shared")
+	require.NoError(t, err)
+	require.Equal(t, "test", row.GroupPath)
+	_, err = s.db.DB().Exec("DROP TRIGGER reject_rename")
+	require.NoError(t, err)
+	require.NoError(t, s.SaveWithGroups(a, ta.ShallowCopyForSave()))
+	require.Nil(t, storedGroup(t, s, "test"))
+	require.NotNil(t, storedGroup(t, s, "renamed"))
+}
+
+func TestGroupStorageSnapshotsSameFieldConflicts(t *testing.T) {
+	for _, field := range []string{"Name", "Expanded", "Order", "DefaultPath", "MaxConcurrent"} {
+		t.Run(field, func(t *testing.T) {
+			s, _, ta, _, tb := groupSnapshotFixture(t)
+			set := func(group *Group, version int) {
+				switch field {
+				case "Name":
+					group.Name = fmt.Sprintf("name%d", version)
+				case "Expanded":
+					group.Expanded = version == 2
+				case "Order":
+					group.Order = version
+				case "DefaultPath":
+					group.DefaultPath = fmt.Sprintf("/path%d", version)
+				case "MaxConcurrent":
+					group.MaxConcurrent = version
+				}
+			}
+			set(tb.Groups["test"], 1)
+			require.NoError(t, s.SaveGroupsOnly(tb.ShallowCopyForSave()))
+			// Expanded has only two values: a stale unchanged value is not an edit,
+			// and therefore preserves the other writer's change.
+			set(ta.Groups["test"], 2)
+			if field == "Expanded" {
+				require.NoError(t, s.SaveGroupsOnly(ta.ShallowCopyForSave()))
+				require.False(t, storedGroup(t, s, "test").Expanded)
+				return
+			}
+			require.ErrorContains(t, s.SaveGroupsOnly(ta.ShallowCopyForSave()), field+" conflict")
+			set(ta.Groups["test"], 1)
+			require.NoError(t, s.SaveGroupsOnly(ta.ShallowCopyForSave()), "identical concurrent edit converges")
+			set(ta.Groups["test"], 3)
+			require.NoError(t, s.SaveGroupsOnly(ta.ShallowCopyForSave()), "successful convergence advances the live copy owner")
+		})
+	}
+}
+
+func TestGroupStorageSnapshotsOldReceiptCannotUndoNewOwner(t *testing.T) {
+	s, _, tree, _, _ := groupSnapshotFixture(t)
+	older := tree.ShallowCopyForSave()
+	tree.Groups["test"].MaxConcurrent = 2
+	require.NoError(t, s.SaveGroupsOnly(tree.ShallowCopyForSave()))
+	require.NoError(t, s.SaveGroupsOnly(older), "unchanged old copy preserves current fields")
+	tree.Groups["test"].MaxConcurrent = 3
+	require.NoError(t, s.SaveGroupsOnly(tree.ShallowCopyForSave()), "old receipt must not roll back the live owner's baseline")
+	require.Equal(t, 3, storedGroup(t, s, "test").MaxConcurrent)
+}
+
+func TestGroupStorageSnapshotsDeletionRejectsUnknownAdditions(t *testing.T) {
+	for _, kind := range []string{"session", "subgroup"} {
+		t.Run(kind, func(t *testing.T) {
+			s, _, tree, _, _ := groupSnapshotFixture(t)
+			tree.DeleteGroup("test")
+			if kind == "session" {
+				require.NoError(t, s.Save([]*Instance{{ID: "later", Title: "later", GroupPath: "test", Tool: "shell", ProjectPath: t.TempDir()}}))
+			} else {
+				require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{{Path: "test/later", Name: "later"}}))
+			}
+			require.ErrorContains(t, s.SaveWithGroups(tree.GetAllInstances(), tree.ShallowCopyForSave()), "conflict")
+			require.NotNil(t, storedGroup(t, s, "test"))
+			row, err := s.db.LoadInstanceByID("shared")
+			require.NoError(t, err)
+			require.Equal(t, "test", row.GroupPath)
+		})
+	}
+}
+
+func TestGroupStorageSnapshotsDeletionFailureRetainsIntent(t *testing.T) {
+	s, _, tree, _, _ := groupSnapshotFixture(t)
+	tree.DeleteGroup("test")
+	_, err := s.db.DB().Exec("CREATE TRIGGER reject_delete BEFORE DELETE ON groups BEGIN SELECT RAISE(ABORT, 'delete rejected'); END")
+	require.NoError(t, err)
+	require.ErrorContains(t, s.SaveWithGroups(tree.GetAllInstances(), tree.ShallowCopyForSave()), "delete rejected")
+	require.NotNil(t, storedGroup(t, s, "test"))
+	_, err = s.db.DB().Exec("DROP TRIGGER reject_delete")
+	require.NoError(t, err)
+	require.NoError(t, s.SaveWithGroups(tree.GetAllInstances(), tree.ShallowCopyForSave()))
+	require.Nil(t, storedGroup(t, s, "test"))
+}
+
+func TestGroupStorageSnapshotsDeletionBoundToDatabase(t *testing.T) {
+	source, _, tree, _, _ := groupSnapshotFixture(t)
+	other := newTestStorage(t)
+	require.NoError(t, other.db.SaveGroups([]*statedb.GroupRow{storedGroup(t, source, "test")}))
+	tree.DeleteGroup("test")
+	require.ErrorContains(t, other.SaveGroupsOnly(tree.ShallowCopyForSave()), "different database")
+	require.NotNil(t, storedGroup(t, other, "test"))
+}
+
+func TestGroupStorageSnapshotsReadErrorsFailClosed(t *testing.T) {
+	s, a, tree, _, _ := groupSnapshotFixture(t)
+	_, err := s.db.DB().Exec("UPDATE groups SET sort_order='unreadable' WHERE path='test'")
+	require.NoError(t, err)
+	a[0].Title = "must not save"
+	require.ErrorContains(t, s.SaveWithGroups(a, tree), "read current groups")
+	row, err := s.db.LoadInstanceByID("shared")
+	require.NoError(t, err)
+	require.NotEqual(t, "must not save", row.Title)
+}
+
+func TestGroupStorageSnapshotsKeepsLiveEditPending(t *testing.T) {
+	var armed atomic.Bool
+	var live *Group
+	function := fmt.Sprintf("group_pending_edit_%d", time.Now().UnixNano())
+	require.NoError(t, sqlite.RegisterScalarFunction(function, 0, func(_ *sqlite.FunctionContext, _ []driver.Value) (driver.Value, error) {
+		if armed.CompareAndSwap(true, false) {
+			live.MaxConcurrent = 3
+		}
+		return int64(1), nil
+	}))
+	s, _, tree, _, _ := groupSnapshotFixture(t)
+	live = tree.Groups["test"]
+	_, err := s.db.DB().Exec("CREATE TRIGGER pending_group_edit AFTER UPDATE ON groups BEGIN SELECT " + function + "(); END")
+	require.NoError(t, err)
+	live.MaxConcurrent = 2
+	copy := tree.ShallowCopyForSave()
+	armed.Store(true)
+	require.NoError(t, s.SaveGroupsOnly(copy))
+	require.Equal(t, 2, storedGroup(t, s, "test").MaxConcurrent)
+	require.Equal(t, 3, live.MaxConcurrent)
+	require.NoError(t, s.SaveGroupsOnly(tree.ShallowCopyForSave()))
+	require.Equal(t, 3, storedGroup(t, s, "test").MaxConcurrent)
+}
+
+func TestGroupStorageSnapshotsCompletedPayloadCannotReplayDeletion(t *testing.T) {
+	s, _, tree, _, _ := groupSnapshotFixture(t)
+	original := storedGroup(t, s, "test")
+	tree.DeleteGroup("test")
+	copy := tree.ShallowCopyForSave()
+	require.NoError(t, s.SaveWithGroups(tree.GetAllInstances(), copy))
+	require.Nil(t, storedGroup(t, s, "test"))
+	require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{original}))
+	require.NoError(t, s.SaveWithGroups(tree.GetAllInstances(), copy))
+	require.Equal(t, original, storedGroup(t, s, "test"), "the same completed payload cannot delete a later recreation")
+}
+
+func TestGroupStorageSnapshotsForeignEmptyDBCannotAcknowledgeDeletion(t *testing.T) {
+	source, _, tree, _, _ := groupSnapshotFixture(t)
+	other := newTestStorage(t)
+	tree.DeleteGroup("test")
+	payload := tree.ShallowCopyForSave()
+	require.Error(t, other.SaveGroupsOnly(payload), "a foreign empty DB cannot consume the source deletion")
+	require.NotNil(t, storedGroup(t, source, "test"))
+	require.NoError(t, source.SaveWithGroups(tree.GetAllInstances(), payload))
+	require.Nil(t, storedGroup(t, source, "test"))
+}
+
+func TestGroupStorageSnapshotsDerivedTreeCannotRecreateMovedGroup(t *testing.T) {
+	s, a, _, b, tb := groupSnapshotFixture(t)
+	derived := NewGroupTree(a)
+	require.NoError(t, tb.RenameGroup("test", "renamed"))
+	require.NoError(t, s.SaveWithGroups(b, tb))
+	for i := 0; i < 2; i++ {
+		require.NoError(t, s.SaveWithGroups(a, derived.ShallowCopyForSave()))
+		require.Nil(t, storedGroup(t, s, "test"), "an implicit stale path without current members cannot become an empty group")
+		row, err := s.db.LoadInstanceByID("shared")
+		require.NoError(t, err)
+		require.Equal(t, "renamed", row.GroupPath)
+	}
+}
+
+func TestGroupStorageSnapshotsLoadUsesOneReadSnapshot(t *testing.T) {
+	var armed atomic.Bool
+	var other *statedb.StateDB
+	function := fmt.Sprintf("group_load_interleave_%d", time.Now().UnixNano())
+	writes := make(chan error, 1)
+	require.NoError(t, sqlite.RegisterScalarFunction(function, 1, func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+		if armed.CompareAndSwap(true, false) {
+			_, err := other.DB().Exec("BEGIN; UPDATE stored_instances SET group_path='renamed' WHERE id='shared'; UPDATE groups SET path='renamed', name='renamed' WHERE path='test'; COMMIT")
+			writes <- err
+		}
+		return args[0], nil
+	}))
+	s, _, _, _, _ := groupSnapshotFixture(t)
+	var err error
+	other, err = statedb.Open(s.dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { other.Close() })
+	columns, err := s.db.DB().Query("PRAGMA table_info(instances)")
+	require.NoError(t, err)
+	var selected []string
+	for columns.Next() {
+		var cid, notnull, pk int
+		var name, kind string
+		var defaultValue any
+		require.NoError(t, columns.Scan(&cid, &name, &kind, &notnull, &defaultValue, &pk))
+		if name == "title" {
+			selected = append(selected, function+"(title) AS title")
+		} else {
+			selected = append(selected, `"`+strings.ReplaceAll(name, `"`, `""`)+`"`)
+		}
+	}
+	require.NoError(t, columns.Err())
+	require.NoError(t, columns.Close())
+	_, err = s.db.DB().Exec("ALTER TABLE instances RENAME TO stored_instances")
+	require.NoError(t, err)
+	_, err = s.db.DB().Exec("CREATE VIEW instances AS SELECT " + strings.Join(selected, ",") + " FROM stored_instances")
+	require.NoError(t, err)
+	armed.Store(true)
+	instances, groups, err := s.LoadWithGroups()
+	require.NoError(t, err)
+	select {
+	case err := <-writes:
+		require.NoError(t, err, "WAL permits the concurrent committed rename during the read snapshot")
+	default:
+		t.Fatal("read probe did not run")
+	}
+	require.Len(t, instances, 1)
+	require.Len(t, groups, 1)
+	require.Equal(t, instances[0].GroupPath, groups[0].Path, "instances and groups must describe the same database snapshot")
+	require.ErrorContains(t, s.SaveWithGroups(instances, NewGroupTreeWithGroups(instances, groups)), "group deletion conflict")
+	require.Nil(t, storedGroup(t, s, "test"))
+	require.NotNil(t, storedGroup(t, s, "renamed"))
+}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -76,6 +76,10 @@ func (it Item) IsCreatingPlaceholder() bool {
 
 // Group represents a group of sessions
 type Group struct {
+	storageSnapshot atomic.Pointer[groupStorageSnapshot]
+	saveOwner       *Group
+	derived         bool
+
 	Name        string
 	Path        string // Full path like "projects" or "projects/devops"
 	Expanded    bool
@@ -91,6 +95,10 @@ type Group struct {
 
 // GroupTree manages hierarchical session organization
 type GroupTree struct {
+	groupDeletes  *groupDeletionQueue
+	frozenDeletes bool
+	savedDeletes  []*groupDeletion
+
 	Groups    map[string]*Group // path -> group
 	GroupList []*Group          // Ordered list of groups
 	Expanded  map[string]bool   // Collapsed state persistence
@@ -269,8 +277,9 @@ func currentGroupSortMode() string {
 // NewGroupTree creates a new group tree from instances
 func NewGroupTree(instances []*Instance) *GroupTree {
 	tree := &GroupTree{
-		Groups:   make(map[string]*Group),
-		Expanded: make(map[string]bool),
+		groupDeletes: &groupDeletionQueue{},
+		Groups:       make(map[string]*Group),
+		Expanded:     make(map[string]bool),
 	}
 
 	// Build groups from instances
@@ -290,6 +299,7 @@ func NewGroupTree(instances []*Instance) *GroupTree {
 				name = DefaultGroupName
 			}
 			group = &Group{
+				derived:  true,
 				Name:     name,
 				Path:     groupPath,
 				Expanded: true, // Default expanded
@@ -317,14 +327,16 @@ func NewGroupTree(instances []*Instance) *GroupTree {
 		tree.updateGroupDefaultPath(groupPath)
 	}
 
+	tree.initializeDerivedSnapshots()
 	return tree
 }
 
 // NewGroupTreeWithGroups creates a group tree from instances and stored group data
 func NewGroupTreeWithGroups(instances []*Instance, storedGroups []*GroupData) *GroupTree {
 	tree := &GroupTree{
-		Groups:   make(map[string]*Group),
-		Expanded: make(map[string]bool),
+		groupDeletes: &groupDeletionQueue{},
+		Groups:       make(map[string]*Group),
+		Expanded:     make(map[string]bool),
 	}
 
 	// First, create groups from stored data (preserves empty groups)
@@ -338,6 +350,7 @@ func NewGroupTreeWithGroups(instances []*Instance, storedGroups []*GroupData) *G
 			DefaultPath:   gd.DefaultPath,
 			MaxConcurrent: gd.MaxConcurrent,
 		}
+		group.storageSnapshot.Store(gd.storageSnapshot)
 		tree.Groups[gd.Path] = group
 		tree.Expanded[gd.Path] = gd.Expanded
 	}
@@ -360,6 +373,7 @@ func NewGroupTreeWithGroups(instances []*Instance, storedGroups []*GroupData) *G
 				name = DefaultGroupName
 			}
 			group = &Group{
+				derived:  true,
 				Name:     name,
 				Path:     groupPath,
 				Expanded: true,
@@ -387,6 +401,7 @@ func NewGroupTreeWithGroups(instances []*Instance, storedGroups []*GroupData) *G
 		tree.updateGroupDefaultPath(groupPath)
 	}
 
+	tree.initializeDerivedSnapshots()
 	return tree
 }
 
@@ -546,6 +561,7 @@ func (t *GroupTree) ensureParentGroupsExist(path string) {
 		if _, exists := t.Groups[currentPath]; !exists {
 			name := extractGroupName(currentPath)
 			group := &Group{
+				derived:  true,
 				Name:     name,
 				Path:     currentPath,
 				Expanded: true,
@@ -1047,6 +1063,7 @@ func (t *GroupTree) MoveSessionToGroup(inst *Instance, newGroupPath string) {
 	newGroup, exists := t.Groups[newGroupPath]
 	if !exists {
 		newGroup = &Group{
+			derived:  true,
 			Name:     newGroupPath,
 			Path:     newGroupPath,
 			Expanded: true,
@@ -1061,6 +1078,7 @@ func (t *GroupTree) MoveSessionToGroup(inst *Instance, newGroupPath string) {
 	// Update default paths for both old and new groups
 	t.updateGroupDefaultPath(oldGroupPath)
 	t.updateGroupDefaultPath(newGroupPath)
+	t.initializeDerivedSnapshots()
 }
 
 // sanitizeGroupName removes dangerous characters from group names
@@ -1396,11 +1414,14 @@ func (t *GroupTree) DeleteGroup(path string) []*Instance {
 	// Collect sessions from subgroups and delete them
 	for _, subPath := range subgroupPaths {
 		if subGroup, exists := t.Groups[subPath]; exists {
+			t.queueGroupDeletion(subGroup)
 			allMovedSessions = append(allMovedSessions, subGroup.Sessions...)
 			delete(t.Groups, subPath)
 			delete(t.Expanded, subPath)
 		}
 	}
+
+	t.queueGroupDeletion(group)
 
 	// Add sessions from the main group
 	allMovedSessions = append(allMovedSessions, group.Sessions...)
@@ -1416,6 +1437,7 @@ func (t *GroupTree) DeleteGroup(path string) []*Instance {
 		defaultGroup, exists := t.Groups[DefaultGroupPath]
 		if !exists {
 			defaultGroup = &Group{
+				derived:  true,
 				Name:     DefaultGroupName,
 				Path:     DefaultGroupPath,
 				Expanded: true,
@@ -1431,6 +1453,7 @@ func (t *GroupTree) DeleteGroup(path string) []*Instance {
 	delete(t.Expanded, path)
 	t.rebuildGroupList()
 
+	t.initializeDerivedSnapshots()
 	return allMovedSessions
 }
 
@@ -1497,6 +1520,7 @@ func (t *GroupTree) AddSession(inst *Instance) {
 			name = DefaultGroupName
 		}
 		group = &Group{
+			derived:  true,
 			Name:     name,
 			Path:     groupPath,
 			Expanded: true,
@@ -1510,6 +1534,7 @@ func (t *GroupTree) AddSession(inst *Instance) {
 	inst.Order = len(group.Sessions)
 	group.Sessions = append(group.Sessions, inst)
 	t.updateGroupDefaultPath(groupPath)
+	t.initializeDerivedSnapshots()
 }
 
 // RemoveSession removes a session from its group
@@ -1566,6 +1591,7 @@ func (t *GroupTree) SyncWithInstances(instances []*Instance) {
 				name = DefaultGroupName
 			}
 			group = &Group{
+				derived:  true,
 				Name:     name,
 				Path:     groupPath,
 				Expanded: true,
@@ -1596,6 +1622,7 @@ func (t *GroupTree) SyncWithInstances(instances []*Instance) {
 	for groupPath := range t.Groups {
 		t.updateGroupDefaultPath(groupPath)
 	}
+	t.initializeDerivedSnapshots()
 }
 
 // ShallowCopyForSave creates a copy of the GroupTree that's safe to use
@@ -1613,6 +1640,7 @@ func (t *GroupTree) ShallowCopyForSave() *GroupTree {
 	groupListCopy := make([]*Group, len(t.GroupList))
 	for i, g := range t.GroupList {
 		groupListCopy[i] = &Group{
+			saveOwner: g, derived: g.derived,
 			Name:          g.Name,
 			Path:          g.Path,
 			Expanded:      g.Expanded,
@@ -1621,9 +1649,11 @@ func (t *GroupTree) ShallowCopyForSave() *GroupTree {
 			MaxConcurrent: g.MaxConcurrent,
 			// Don't copy Sessions - not needed for save, only metadata is saved
 		}
+		groupListCopy[i].storageSnapshot.Store(g.storageSnapshot.Load())
 	}
 
 	return &GroupTree{
+		groupDeletes: t.groupDeletes, frozenDeletes: true, savedDeletes: t.deletionSnapshot(),
 		GroupList: groupListCopy,
 		// Groups and Expanded maps not needed since only GroupList is iterated in save
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -133,6 +133,8 @@ const (
 
 // Instance represents a single agent/shell session
 type Instance struct {
+	storageSnapshot *instanceStorageSnapshot
+
 	ID          string `json:"id"`
 	Title       string `json:"title"`
 	ProjectPath string `json:"project_path"`

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4965,7 +4965,7 @@ func (i *Instance) Start() error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
-	if i.Tool == "shell" && i.Account != "" && !i.RunCommandAsInitialProcess {
+	if i.Tool == "shell" && i.Account != "" && !i.tmuxSession.RunCommandAsInitialProcess {
 		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
 			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
 		}
@@ -5282,7 +5282,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
-	if i.Tool == "shell" && i.Account != "" && !i.RunCommandAsInitialProcess {
+	if i.Tool == "shell" && i.Account != "" && !i.tmuxSession.RunCommandAsInitialProcess {
 		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
 			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
 		}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1090,6 +1090,7 @@ func NewInstance(title, projectPath string) *Instance {
 
 	inst := &Instance{
 		ID:               id,
+		Account:          strings.TrimSpace(os.Getenv("AGENTDECK_ACCOUNT")),
 		Title:            title,
 		ProjectPath:      projectPath,
 		GroupPath:        extractGroupPath(projectPath), // Auto-assign group from path
@@ -1174,6 +1175,7 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 
 	inst := &Instance{
 		ID:               id,
+		Account:          strings.TrimSpace(os.Getenv("AGENTDECK_ACCOUNT")),
 		Title:            title,
 		ProjectPath:      projectPath,
 		GroupPath:        extractGroupPath(projectPath),
@@ -1471,6 +1473,9 @@ func (i *Instance) buildBashExportPrefix(skipConfigDirForCustomCommand bool) str
 		// instead of a local path that does not exist there (#1858).
 		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", i.configDirShellExpr(configDir))
 	}
+	if i.Account != "" && !skipConfigDirForCustomCommand {
+		prefix += fmt.Sprintf("export CLAUDE_SECURESTORAGE_CONFIG_DIR=%s; ", i.configDirShellExpr(GetClaudeConfigDirForInstance(i)))
+	}
 	prefix += i.buildResolvedAccountHintExports()
 	return prefix
 }
@@ -1558,6 +1563,13 @@ func resolvedProcessProfile() string {
 func (i *Instance) ensureProfileEnv() {
 	if i.tmuxSession == nil {
 		return
+	}
+	if i.Account != "" {
+		if err := i.tmuxSession.SetEnvironment("AGENTDECK_ACCOUNT", i.Account); err != nil {
+			sessionLog.Warn("set_account_failed", slog.String("error", err.Error()))
+		}
+	} else if err := i.tmuxSession.UnsetEnvironment("AGENTDECK_ACCOUNT"); err != nil {
+		sessionLog.Warn("unset_account_failed", slog.String("error", err.Error()))
 	}
 	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
 		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
@@ -4147,6 +4159,10 @@ func (i *Instance) buildShellPassthroughCommand(baseCommand string) string {
 			// spaces (e.g. a macOS $HOME with a space in the username).
 			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", shellescape.Quote(configDir))
 		}
+		secureStoragePrefix := ""
+		if !hasCustomClaudeCommand && i.Account != "" {
+			secureStoragePrefix = fmt.Sprintf("CLAUDE_SECURESTORAGE_CONFIG_DIR=%s ", shellescape.Quote(GetClaudeConfigDirForInstance(i)))
+		}
 		execEnvPrefix := ""
 		if flags := telegramExecEnvStripFlags(i); flags != "" {
 			execEnvPrefix = "env " + flags + " "
@@ -4187,7 +4203,7 @@ func (i *Instance) buildShellPassthroughCommand(baseCommand string) string {
 			"AGENTDECK_RESOLVED_CONFIG_DIR=%s AGENTDECK_RESOLVED_GROUP=%s AGENTDECK_RESOLVED_SOURCE=%s ",
 			shellescape.Quote(resolvedConfigDir), shellescape.Quote(i.GroupPath), shellescape.Quote(resolvedSource))
 		resolvedCommand := substituteResolvedBinary(baseCommand, "claude", claudeCmd)
-		return envPrefix + instanceIDPrefix + configDirPrefix + resolvedHintPrefix + execEnvPrefix + resolvedCommand
+		return envPrefix + instanceIDPrefix + configDirPrefix + secureStoragePrefix + resolvedHintPrefix + execEnvPrefix + resolvedCommand
 	case "codex":
 		// AGENTDECK_TOOL uses `matched` ("codex"), not i.Tool (which is
 		// "shell" for this passthrough instance) — buildCodexCommand's
@@ -4716,6 +4732,9 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 // SpawnAttempt helper) to preserve the structural-grep contract that
 // checks Start()'s body for the #745 IsForkAwaitingStart guard.
 func (i *Instance) Start() error {
+	if err := ValidateAccountSlot(i.Account, i.Tool); err != nil {
+		return err
+	}
 	beforeLock := nowFn()
 	release, lockErr := acquireInstanceSpawnLock(i.ID)
 	if lockErr != nil {
@@ -5030,6 +5049,9 @@ func (i *Instance) Start() error {
 // `launch -m "..."` racing with a poller-triggered Start() must not
 // produce two parallel tmux sessions.
 func (i *Instance) StartWithMessage(message string) error {
+	if err := ValidateAccountSlot(i.Account, i.Tool); err != nil {
+		return err
+	}
 	beforeLock := nowFn()
 	release, lockErr := acquireInstanceSpawnLock(i.ID)
 	if lockErr != nil {
@@ -8504,6 +8526,9 @@ func (i *Instance) RestartWithEnv(env map[string]string) error {
 }
 
 func (i *Instance) restart(env map[string]string) error {
+	if err := ValidateAccountSlot(i.Account, i.Tool); err != nil {
+		return err
+	}
 	beforeLock := nowFn()
 	release, lockErr := acquireInstanceSpawnLock(i.ID)
 	if lockErr != nil {
@@ -9630,6 +9655,7 @@ func (i *Instance) ForkWithOptions(newTitle, newGroupPath string, opts *ClaudeOp
 		projectPath = opts.WorkDir
 	}
 	target := NewInstance(newTitle, projectPath)
+	target.Account = i.Account
 	if newGroupPath != "" {
 		target.GroupPath = newGroupPath
 	} else {
@@ -9727,6 +9753,7 @@ func (i *Instance) CreateForkedInstanceWithOptions(
 		projectPath = opts.WorkDir
 	}
 	forked := NewInstance(newTitle, projectPath)
+	forked.Account = i.Account
 	if newGroupPath != "" {
 		forked.GroupPath = newGroupPath
 	} else {
@@ -11212,7 +11239,10 @@ func (i *Instance) prepareCommand(cmd string) (string, string, error) {
 	// is itself valid syntax in any shell, so wrapping guarantees the
 	// injected bash syntax is interpreted by bash regardless of the user's
 	// default shell.
-	if i.hasEffectiveWrapper() || (i.Tool == "shell" && i.SubcommandPassthrough) {
+	if i.Account != "" {
+		wrapped = "export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account) + "; " + wrapped
+	}
+	if i.hasEffectiveWrapper() || i.Account != "" || (i.Tool == "shell" && i.SubcommandPassthrough) {
 		escaped := strings.ReplaceAll(wrapped, "'", "'\"'\"'")
 		wrapped = fmt.Sprintf("bash -c '%s'", escaped)
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4965,6 +4965,11 @@ func (i *Instance) Start() error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
+	if i.Tool == "shell" && i.Account != "" && !i.RunCommandAsInitialProcess {
+		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
+			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
+		}
+	}
 	i.ensureClaudeConfigDirEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
@@ -5277,6 +5282,11 @@ func (i *Instance) StartWithMessage(message string) error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
+	if i.Tool == "shell" && i.Account != "" && !i.RunCommandAsInitialProcess {
+		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
+			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
+		}
+	}
 	i.ensureClaudeConfigDirEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1559,6 +1559,16 @@ func resolvedProcessProfile() string {
 	return resolved
 }
 
+// ensureInteractiveShellAccount updates the already-running shell as well as
+// tmux's environment. Setting a tmux option cannot change that shell's env.
+func (i *Instance) ensureInteractiveShellAccount() {
+	if i.Tool == "shell" && i.Account != "" && !i.tmuxSession.RunCommandAsInitialProcess {
+		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
+			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
+		}
+	}
+}
+
 // ensureProfileEnv sets AGENTDECK_PROFILE host-side on the instance's tmux
 // session so a bare `agent-deck` command run inside the session resolves the
 // session's own profile rather than falling back to "default". It is the
@@ -4165,11 +4175,11 @@ func (i *Instance) buildShellPassthroughCommand(baseCommand string) string {
 			configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 			// Shell-quote: configDir is a filesystem path and may contain
 			// spaces (e.g. a macOS $HOME with a space in the username).
-			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", shellescape.Quote(configDir))
+			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", i.configDirShellExpr(configDir))
 		}
 		secureStoragePrefix := ""
 		if !hasCustomClaudeCommand && i.Account != "" {
-			secureStoragePrefix = fmt.Sprintf("CLAUDE_SECURESTORAGE_CONFIG_DIR=%s ", shellescape.Quote(GetClaudeConfigDirForInstance(i)))
+			secureStoragePrefix = fmt.Sprintf("CLAUDE_SECURESTORAGE_CONFIG_DIR=%s ", i.configDirShellExpr(GetClaudeConfigDirForInstance(i)))
 		}
 		execEnvPrefix := ""
 		if flags := telegramExecEnvStripFlags(i); flags != "" {
@@ -4740,7 +4750,7 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 // SpawnAttempt helper) to preserve the structural-grep contract that
 // checks Start()'s body for the #745 IsForkAwaitingStart guard.
 func (i *Instance) Start() error {
-	if err := ValidateAccountSlot(i.Account, i.Tool); err != nil {
+	if err := i.ValidateAccount(); err != nil {
 		return err
 	}
 	beforeLock := nowFn()
@@ -4973,11 +4983,7 @@ func (i *Instance) Start() error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
-	if i.Tool == "shell" && i.Account != "" && !i.tmuxSession.RunCommandAsInitialProcess {
-		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
-			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
-		}
-	}
+	i.ensureInteractiveShellAccount()
 	i.ensureClaudeConfigDirEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
@@ -5062,7 +5068,7 @@ func (i *Instance) Start() error {
 // `launch -m "..."` racing with a poller-triggered Start() must not
 // produce two parallel tmux sessions.
 func (i *Instance) StartWithMessage(message string) error {
-	if err := ValidateAccountSlot(i.Account, i.Tool); err != nil {
+	if err := i.ValidateAccount(); err != nil {
 		return err
 	}
 	beforeLock := nowFn()
@@ -5290,11 +5296,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
-	if i.Tool == "shell" && i.Account != "" && !i.tmuxSession.RunCommandAsInitialProcess {
-		if err := i.tmuxSession.SendKeysAndEnter("export AGENTDECK_ACCOUNT=" + shellescape.Quote(i.Account)); err != nil {
-			sessionLog.Warn("set_interactive_account_failed", slog.String("error", err.Error()))
-		}
-	}
+	i.ensureInteractiveShellAccount()
 	i.ensureClaudeConfigDirEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
@@ -8635,7 +8637,7 @@ func (i *Instance) RestartWithEnv(env map[string]string) error {
 }
 
 func (i *Instance) restart(env map[string]string) error {
-	if err := ValidateAccountSlot(i.Account, i.Tool); err != nil {
+	if err := i.ValidateAccount(); err != nil {
 		return err
 	}
 	beforeLock := nowFn()
@@ -9209,6 +9211,7 @@ func (i *Instance) restart(env map[string]string) error {
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
 	i.ensureProfileEnv()
+	i.ensureInteractiveShellAccount()
 	i.ensureClaudeConfigDirEnv()
 
 	// Propagate all known tool session IDs to the tmux environment (host-side).

--- a/internal/session/issue924_account_field_test.go
+++ b/internal/session/issue924_account_field_test.go
@@ -10,6 +10,7 @@
 package session
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -137,6 +138,22 @@ func TestPersistence_Account_SchemaMigration(t *testing.T) {
 // "account" (FieldAccount) hits the right struct field, normalises
 // whitespace, and that the empty string clears the slot.
 func TestSetField_Account_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`[profiles.work.claude]
+config_dir = "~/.claude-work"
+[profiles.personal.claude]
+config_dir = "~/.claude-personal"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
 	inst := &Instance{ID: "x", Tool: "claude"}
 
 	old, _, err := SetField(inst, FieldAccount, "  work  ", nil)

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -433,7 +433,13 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 
 	case FieldAccount:
 		candidate := strings.TrimSpace(value)
-		if err := ValidateAccountSlot(candidate, inst.Tool); err != nil {
+		validationTool := inst.Tool
+		if validationTool == "shell" {
+			if fields := strings.Fields(inst.Command); len(fields) > 0 {
+				validationTool = MatchTool(fields[0])
+			}
+		}
+		if err := ValidateAccountSlot(candidate, validationTool); err != nil {
 			return inst.Account, nil, &MutationError{Field: field, Msg: err.Error()}
 		}
 		// #924 per-session named account slot. Stored verbatim; an

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -432,13 +432,17 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		}
 
 	case FieldAccount:
+		candidate := strings.TrimSpace(value)
+		if err := ValidateAccountSlot(candidate, inst.Tool); err != nil {
+			return inst.Account, nil, &MutationError{Field: field, Msg: err.Error()}
+		}
 		// #924 per-session named account slot. Stored verbatim; an
 		// unconfigured name silently falls through the resolver chain.
 		// Empty string clears the override (back to conductor/group/env).
 		// Restart required (see RestartPolicyFor) — the in-flight
 		// conversation is lost, that's the documented Option 1 tradeoff.
 		oldValue = inst.Account
-		inst.Account = strings.TrimSpace(value)
+		inst.Account = candidate
 
 	case FieldIdleTimeout:
 		// #1143: parses a Go duration like "30m"; 0 (or "0", "") disables.

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -433,17 +433,10 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 
 	case FieldAccount:
 		candidate := strings.TrimSpace(value)
-		validationTool := inst.Tool
-		if validationTool == "shell" {
-			if fields := strings.Fields(inst.Command); len(fields) > 0 {
-				validationTool = MatchTool(fields[0])
-			}
-		}
-		if err := ValidateAccountSlot(candidate, validationTool); err != nil {
+		if err := ValidateAccountSlot(candidate, inst.accountTool()); err != nil {
 			return inst.Account, nil, &MutationError{Field: field, Msg: err.Error()}
 		}
-		// #924 per-session named account slot. Stored verbatim; an
-		// unconfigured name silently falls through the resolver chain.
+		// #924 per-session named account slot, validated before assignment.
 		// Empty string clears the override (back to conductor/group/env).
 		// Restart required (see RestartPolicyFor) — the in-flight
 		// conversation is lost, that's the documented Option 1 tradeoff.

--- a/internal/session/ssh_account_slot_test.go
+++ b/internal/session/ssh_account_slot_test.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSHLoginAccountCapturedAtCreation(t *testing.T) {
+	for _, tool := range []string{"shell", "claude", "codex"} {
+		t.Run(tool, func(t *testing.T) {
+			t.Setenv("AGENTDECK_ACCOUNT", "person_a")
+			inst := NewInstanceWithTool("first", t.TempDir(), tool)
+			t.Setenv("AGENTDECK_ACCOUNT", "person_b")
+			next := NewInstance("second", t.TempDir())
+			if inst.Account != "person_a" || next.Account != "person_b" {
+				t.Fatalf("saved slots = %q, %q", inst.Account, next.Account)
+			}
+			inst.Account = "override"
+			if inst.Account != "override" {
+				t.Fatal("explicit override lost")
+			}
+		})
+	}
+}
+
+func TestSSHUnknownAccountRefusesStartBeforeSideEffects(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	config := filepath.Join(home, "config", "agent-deck")
+	if err := os.MkdirAll(config, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config, "config.toml"), []byte("[profiles.person_a.claude]\nconfig_dir = '~/.claude-a'\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range []string{"claude", "codex", "shell"} {
+		inst := NewInstanceWithTool("invalid", home, tool)
+		inst.Account = "missing"
+		if err := inst.Start(); err == nil {
+			t.Errorf("%s started with unknown account", tool)
+			inst.Kill()
+		}
+	}
+}
+
+func TestSSHNamedAccountActualChildStartRestart(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, name := range []string{"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"} {
+		t.Setenv(name, filepath.Join(home, name))
+	}
+	configDir := filepath.Join(home, "XDG_CONFIG_HOME", "agent-deck")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	first, second := filepath.Join(home, "account-a"), filepath.Join(home, "account-b")
+	envFile := filepath.Join(home, "probe.env")
+	if err := os.WriteFile(envFile, []byte("export PATH="+strconv.Quote(filepath.Join(home, "bin")+":"+os.Getenv("PATH"))+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	config := fmt.Sprintf("[shell]\nenv_files = ['%s']\n[profiles.person_a.claude]\nconfig_dir = '%s'\n[profiles.person_a.codex]\nconfig_dir = '%s'\n[profiles.person_b.claude]\nconfig_dir = '%s'\n[profiles.person_b.codex]\nconfig_dir = '%s'\n", envFile, first, first, second, second)
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+	bin := filepath.Join(home, "bin")
+	if err := os.MkdirAll(bin, 0700); err != nil {
+		t.Fatal(err)
+	}
+	record := filepath.Join(home, "child-env")
+	probe := "#!/bin/sh\nif [ \"$1\" = '--version' ]; then printf '2.0.0\\n'; exit 0; fi\nprintf '%s|%s|%s|%s\\n' \"$AGENTDECK_ACCOUNT\" \"$CODEX_HOME\" \"$CLAUDE_CONFIG_DIR\" \"$CLAUDE_SECURESTORAGE_CONFIG_DIR\" >> '" + record + "'\nexec sleep 600\n"
+	for _, tool := range []string{"claude", "codex"} {
+		if err := os.WriteFile(filepath.Join(bin, tool), []byte(probe), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", bin+":"+os.Getenv("PATH"))
+	t.Setenv("CODEX_HOME", filepath.Join(home, "wrong-codex"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, "wrong-claude"))
+	t.Setenv("CLAUDE_SECURESTORAGE_CONFIG_DIR", filepath.Join(home, "wrong-storage"))
+	for _, tool := range []string{"claude", "codex"} {
+		t.Run(tool, func(t *testing.T) {
+			t.Setenv("AGENTDECK_ACCOUNT", "person_a")
+			inst := NewInstanceWithTool("probe-"+tool, home, tool)
+			inst.Command = tool
+			t.Cleanup(func() { inst.Kill() })
+			before, _ := os.ReadFile(record)
+			if err := inst.Start(); err != nil {
+				t.Fatal(err)
+			}
+			expect := func(previous int) {
+				t.Helper()
+				deadline := time.Now().Add(5 * time.Second)
+				for time.Now().Before(deadline) {
+					data, _ := os.ReadFile(record)
+					if len(data) > previous {
+						line := strings.TrimSpace(string(data[previous:]))
+						fields := strings.Split(line, "|")
+						if len(fields) != 4 || fields[0] != "person_a" {
+							t.Fatalf("child slot: %q", line)
+						}
+						if tool == "codex" && fields[1] != first {
+							t.Fatalf("child CODEX_HOME: %q", line)
+						}
+						if tool == "claude" && (fields[2] != first || fields[3] != first) {
+							t.Fatalf("child Claude dirs: %q", line)
+						}
+						return
+					}
+					time.Sleep(20 * time.Millisecond)
+				}
+				output, _ := inst.tmuxSession.CapturePane()
+				t.Fatalf("no actual child probe record; pane: %s", output)
+			}
+			expect(len(before))
+			before, _ = os.ReadFile(record)
+			t.Setenv("AGENTDECK_ACCOUNT", "person_b")
+			if err := inst.Restart(); err != nil {
+				t.Fatal(err)
+			}
+			expect(len(before))
+		})
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -181,6 +181,8 @@ type InstanceData struct {
 
 // GroupData represents serializable group data
 type GroupData struct {
+	storageSnapshot *groupStorageSnapshot
+
 	Name        string `json:"name"`
 	Path        string `json:"path"`
 	Expanded    bool   `json:"expanded"`
@@ -368,56 +370,66 @@ func (s *Storage) Save(instances []*Instance) error {
 func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	if s.db == nil {
 		return fmt.Errorf("storage database not initialized")
 	}
-
-	// Enforce one Claude conversation owner across persisted sessions.
-	// This protects CLI-only flows as well (the TUI already applies this in-memory).
 	UpdateClaudeSessionsWithDedup(instances)
-
-	// Convert instances to database rows
-	rows := make([]*statedb.InstanceRow, len(instances))
+	updates := make([]statedb.InstanceSnapshot, len(instances))
+	clearIntents := make([]bool, len(instances))
 	for i, inst := range instances {
+		if inst == nil {
+			return fmt.Errorf("nil instance")
+		}
 		row, err := instanceToRow(inst)
 		if err != nil {
 			return err
 		}
-		rows[i] = row
+		updates[i].Desired = row
+		clearIntents[i] = inst.genericSessionIDCleared
+		if snapshot := inst.storageSnapshot; snapshot != nil && snapshot.dbPath == s.dbPath {
+			updates[i].Original = snapshot.original
+			updates[i].Stored = snapshot.stored
+		}
 	}
-
-	if err := s.db.UpsertInstances(rows); err != nil {
+	groupBatch, err := s.prepareGroupSave(groupTree)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.MergeRegistrySnapshots(updates, groupBatch.updates)
+	if err != nil {
 		return fmt.Errorf("failed to save instances: %w", err)
 	}
-
-	// Intentional generic_session_id clear is a one-shot for this save.
-	// Consume only after a successful write so a failed Upsert can retry
-	// with explicit empty still applied (see consumeGenericSessionIDCleared).
-	consumeGenericSessionIDCleared(instances...)
-
-	// Save groups (including empty ones)
-	if groupTree != nil {
-		groupRows := make([]*statedb.GroupRow, 0, len(groupTree.GroupList))
-		for _, g := range groupTree.GroupList {
-			groupRows = append(groupRows, &statedb.GroupRow{
-				Path:          g.Path,
-				Name:          g.Name,
-				Expanded:      g.Expanded,
-				Order:         g.Order,
-				DefaultPath:   g.DefaultPath,
-				MaxConcurrent: g.MaxConcurrent,
-			})
+	for i, inst := range instances {
+		// Only the submitted representation was saved. Reading the live model
+		// again here could acknowledge edits made while this save was in flight.
+		original := statedb.CloneInstanceRow(updates[i].Desired)
+		if clearIntents[i] {
+			inst.genericSessionIDCleared = false
+			original.ToolData = WriteGenericSessionIDToToolData(original.ToolData, "", time.Time{}, false)
+			original.ToolData = WriteGenericSessionScopeToToolData(original.ToolData, "", "", "", false)
 		}
-		if err := s.db.SaveGroups(groupRows); err != nil {
-			return fmt.Errorf("failed to save groups: %w", err)
-		}
+		s.rememberInstanceSnapshot(inst, original, result.Instances[i])
 	}
-
-	// Touch metadata for change detection by other instances
+	s.finishGroupSave(groupBatch, result.Groups)
 	_ = s.db.Touch()
-
 	return nil
+}
+
+// instanceStorageSnapshot belongs to the returned Instance, not to the Storage
+// handle's most recent load. Keep both representations: after a merge the caller
+// can still hold stale unedited fields, which must not become future edit intent.
+type instanceStorageSnapshot struct {
+	dbPath   string
+	original *statedb.InstanceRow
+	stored   *statedb.InstanceRow
+}
+
+func (s *Storage) rememberInstanceSnapshot(inst *Instance, original, stored *statedb.InstanceRow) {
+	inst.storageSnapshot = &instanceStorageSnapshot{
+		dbPath:   s.dbPath,
+		original: statedb.CloneInstanceRow(original),
+		stored:   statedb.CloneInstanceRow(stored),
+	}
 }
 
 // UpdateTitleIfUnlocked sets an instance's title with a single conditional
@@ -461,9 +473,8 @@ func (s *Storage) DeleteInstance(id string) error {
 }
 
 // DeleteGroupSubtree removes a group and all of its descendants from the groups
-// table. SaveGroups is additive (upsert, never prune), so intentional group
-// removal — delete, rename, move — must call this explicitly; otherwise the old
-// path rows linger and the group resurrects on the next reload.
+// table without snapshot conflict checks. Interactive edits use GroupTree
+// mutations with SaveWithGroups so member changes and deletion are atomic.
 func (s *Storage) DeleteGroupSubtree(path string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -596,119 +607,28 @@ func (s *Storage) RemoveSessionAndVerify(id string, remainingInstances []*Instan
 	return nil
 }
 
-// ErrInsertNotPersistent is returned by InsertSessionAndVerify when, after
-// retries, the row is still missing from the database. The most likely cause
-// is a concurrent SaveInstances rewrite from another agent-deck process
-// that loaded the instances slice before this INSERT landed and then
-// DELETE'd the row via the `DELETE FROM instances WHERE id NOT IN (...)`
-// step inside SaveInstances.
-//
-// Surfacing this as a real error (rather than silently returning success)
-// is the user-facing half of the issue #1031 fix.
+// ErrInsertNotPersistent reports that a successfully inserted row was removed
+// before verification. Do not retry the insertion over a deliberate deletion.
 var ErrInsertNotPersistent = errors.New("insert not persistent: row dropped by concurrent writer")
 
-// insertVerifyAttempts and insertVerifyBackoff control the post-commit
-// verify loop inside InsertSessionAndVerify. The defaults absorb the
-// bounded window in which a competing rewriter can DELETE this row
-// before its own SaveInstances commits (parallel xargs -P N launches).
-// Tests override via the package-private setters so they don't sit
-// through the production backoff schedule.
-var (
-	insertVerifyAttempts = 6
-	insertVerifyBackoff  = []time.Duration{
-		20 * time.Millisecond,
-		40 * time.Millisecond,
-		80 * time.Millisecond,
-		160 * time.Millisecond,
-		320 * time.Millisecond,
-	}
-)
-
-// InsertSessionAndVerify performs a durable single-row session insert.
-//
-// Flow (v1.9.x issue #1031 fix, parallel to #909's RemoveSessionAndVerify):
-//
-//  1. SaveInstance(row) — targeted INSERT OR REPLACE on the single new
-//     row only, NOT a full-table rewrite. This sidesteps the
-//     load-modify-write race where a sibling launch's
-//     `DELETE FROM instances WHERE id NOT IN (...)` inside
-//     SaveInstances would silently delete this row.
-//  2. SaveGroupsOnly(groupTree) — persist any group structure changes
-//     WITHOUT rewriting the instances table. Rewriting (SaveWithGroups)
-//     is the load-modify-write pattern that lets a concurrent launch
-//     drop this row; skipping it eliminates the structural race for
-//     our own write.
-//  3. Verify InstanceExists(id) is true. If not (some other process
-//     issued a SaveInstances rewrite that excluded this row because it
-//     loaded the instances slice pre-INSERT), re-issue the targeted
-//     INSERT and loop with linear backoff.
-//  4. After exhausting attempts, return ErrInsertNotPersistent so the
-//     caller can fail loudly instead of returning success on a row
-//     that's not actually there.
-//
-// instances is the post-insert session list, used only to compute group
-// sort_order / membership for SaveGroupsOnly. groupTree may be nil if
-// the caller doesn't care to persist groups.
+// InsertSessionAndVerify inserts one new snapshot and verifies its presence.
+// The insert and optional groups commit together. Missing rows are reported to
+// the caller; retrying an UPSERT here would undo another writer's deletion.
 func (s *Storage) InsertSessionAndVerify(newInstance *Instance, groupTree *GroupTree) error {
 	if newInstance == nil {
 		return fmt.Errorf("nil instance")
 	}
-	row, err := instanceToRow(newInstance)
-	if err != nil {
+	if err := s.SaveWithGroups([]*Instance{newInstance}, groupTree); err != nil {
 		return err
 	}
-
-	if err := s.saveSingleInstance(row); err != nil {
-		return err
-	}
-	// Consume one-shot clear intent after the first successful write, so
-	// verify-retries do not re-emit the explicit empty generic_session_id
-	// snapshot. A concurrent WriteGenericSessionBinding re-bind between
-	// attempts must be preserved by sticky merge (omission), not clobbered by
-	// a stale pre-consume row (CodeRabbit #1885). The retry loop below rebuilds
-	// the row from the instance each pass, so there is nothing to rebuild here
-	// — an extra conversion at this point would be written by no one (CodeQL
-	// go/useless-assignment-to-local).
-	consumeGenericSessionIDCleared(newInstance)
-
-	if groupTree != nil {
-		if err := s.SaveGroupsOnly(groupTree); err != nil {
-			return fmt.Errorf("failed to save groups during insert: %w", err)
-		}
-	}
-
-	for attempt := 0; attempt < insertVerifyAttempts; attempt++ {
-		exists, err := s.InstanceExists(newInstance.ID)
-		if err != nil {
-			return fmt.Errorf("verify insert of %s: %w", newInstance.ID, err)
-		}
-		if exists {
-			return nil
-		}
-		if attempt < len(insertVerifyBackoff) {
-			time.Sleep(insertVerifyBackoff[attempt])
-		}
-		// Re-issue the targeted INSERT; races against the concurrent
-		// rewriter but eventually wins because every retry shrinks the
-		// window. Rebuild row each retry so we never replay a stale
-		// intentional-clear snapshot after a concurrent re-bind.
-		row, err = instanceToRow(newInstance)
-		if err != nil {
-			return err
-		}
-		if err := s.saveSingleInstance(row); err != nil {
-			return err
-		}
-	}
-
 	exists, err := s.InstanceExists(newInstance.ID)
 	if err != nil {
 		return fmt.Errorf("verify insert of %s: %w", newInstance.ID, err)
 	}
-	if exists {
-		return nil
+	if !exists {
+		return fmt.Errorf("%w: concurrent deletion conflict for instance %s", ErrInsertNotPersistent, newInstance.ID)
 	}
-	return fmt.Errorf("%w: %s", ErrInsertNotPersistent, newInstance.ID)
+	return nil
 }
 
 // SyncInstanceCwd swaps the persisted project_path for id to newCwd, but ONLY
@@ -750,6 +670,7 @@ func (s *Storage) SyncInstanceCwd(id, newCwd string) (bool, error) {
 		)
 		return true, nil
 	}
+	original := statedb.CloneInstanceRow(row)
 	newToolData, err := swapAdditionalPath(row.ToolData, row.ProjectPath, newCwd)
 	if err != nil {
 		return true, err
@@ -757,7 +678,7 @@ func (s *Storage) SyncInstanceCwd(id, newCwd string) (bool, error) {
 	row.ToolData = newToolData
 	row.ProjectPath = newCwd
 	row.LastAccessed = time.Now()
-	if err := s.db.SaveInstance(row); err != nil {
+	if _, err := s.db.MergeInstanceSnapshots([]statedb.InstanceSnapshot{{Original: original, Stored: original, Desired: row}}, nil); err != nil {
 		return true, fmt.Errorf("failed to persist cwd for %s: %w", id, err)
 	}
 	_ = s.db.Touch()
@@ -827,23 +748,6 @@ func swapAdditionalPath(toolData json.RawMessage, oldCwd, newCwd string) (json.R
 	return out, nil
 }
 
-// saveSingleInstance writes one row via the targeted SaveInstance path
-// (single-row INSERT OR REPLACE — no DELETE-NOT-IN sweep). Wraps the
-// statedb call in the storage mutex and the nil-db guard so callers
-// stay symmetric with DeleteInstance.
-func (s *Storage) saveSingleInstance(row *statedb.InstanceRow) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.db == nil {
-		return fmt.Errorf("storage database not initialized")
-	}
-	if err := s.db.SaveInstance(row); err != nil {
-		return fmt.Errorf("failed to save instance %s: %w", row.ID, err)
-	}
-	_ = s.db.Touch()
-	return nil
-}
-
 // PersistRevivedInstances durably persists the status heal from a revive sweep
 // WITHOUT the full-table rewrite that SaveWithGroups performs and WITHOUT a
 // full-row INSERT OR REPLACE.
@@ -861,7 +765,7 @@ func (s *Storage) saveSingleInstance(row *statedb.InstanceRow) error {
 //     touched.
 //
 //  2. Clobber vs. concurrent edit of a row being revived. A full-row write
-//     (INSERT OR REPLACE / saveSingleInstance) would push EVERY column from
+//     (INSERT OR REPLACE) would push EVERY column from
 //     revive's stale in-memory snapshot, overwriting any field (title, group,
 //     tool_data, last_accessed, claude_session_id, …) a concurrent process
 //     edited between revive's load and its save. Revive owns exactly ONE field:
@@ -894,42 +798,18 @@ func (s *Storage) PersistRevivedInstances(instances []*Instance) error {
 	return s.db.PersistInstanceStatusesTx(updates)
 }
 
-// PersistRecoveredInstances persists the rows a fleet-recovery sweep restarted,
-// and ONLY those rows.
-//
-// Why it is not PersistRevivedInstances: a revive mutates exactly one field
-// (Status), so that method can use a status-only UPDATE. A restart replaces the
-// process — status, tmux session name, socket, and the tool conversation id in
-// tool_data can all change — so the recovered rows need a full-row write.
-//
-// Why it is not SaveWithGroups: that path converts and rewrites EVERY instance
-// in the caller's snapshot. During a 65-session recovery the sweep runs for
-// minutes, so its snapshot is stale by construction, and a full rewrite would
-// push stale columns over any edit another process made to a session the sweep
-// never touched. Writing one targeted row per restarted session (via
-// statedb.SaveInstance, which merges tool_data extras and auto-name fields
-// rather than blindly replacing them) keeps the blast radius to the sessions
-// the sweep actually owns. No path here deletes anything: there is no
-// DELETE-NOT-IN sweep, so a session added concurrently can never be lost
-// (the 2026-06-04 data-loss class).
-//
-// Errors are per-row and returned joined, so one bad row does not hide the rest.
+// PersistRecoveredInstances saves only the recovered sessions, using their
+// loaded snapshots to preserve concurrent edits and reject conflicting changes.
+// Failures are per-row and joined so one bad session does not hide the rest.
 func (s *Storage) PersistRecoveredInstances(instances []*Instance) error {
 	var errs []error
 	for _, inst := range instances {
 		if inst == nil {
 			continue
 		}
-		row, err := instanceToRow(inst)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("convert %s: %w", inst.ID, err))
-			continue
-		}
-		if err := s.saveSingleInstance(row); err != nil {
+		if err := s.Save([]*Instance{inst}); err != nil {
 			errs = append(errs, err)
-			continue
 		}
-		consumeGenericSessionIDCleared(inst)
 	}
 	return errors.Join(errs...)
 }
@@ -1110,21 +990,15 @@ func (s *Storage) SaveGroupsOnly(groupTree *GroupTree) error {
 		return nil
 	}
 
-	groupRows := make([]*statedb.GroupRow, 0, len(groupTree.GroupList))
-	for _, g := range groupTree.GroupList {
-		groupRows = append(groupRows, &statedb.GroupRow{
-			Path:          g.Path,
-			Name:          g.Name,
-			Expanded:      g.Expanded,
-			Order:         g.Order,
-			DefaultPath:   g.DefaultPath,
-			MaxConcurrent: g.MaxConcurrent,
-		})
+	batch, err := s.prepareGroupSave(groupTree)
+	if err != nil {
+		return err
 	}
-
-	if err := s.db.SaveGroups(groupRows); err != nil {
+	result, err := s.db.MergeRegistrySnapshots(nil, batch.updates)
+	if err != nil {
 		return fmt.Errorf("failed to save groups: %w", err)
 	}
+	s.finishGroupSave(batch, result.Groups)
 
 	return nil
 }
@@ -1148,15 +1022,11 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 	}
 
 	// Load from SQLite
-	dbRows, err := s.db.LoadInstances()
+	snapshot, err := s.db.LoadRegistrySnapshot()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load instances: %w", err)
+		return nil, nil, err
 	}
-
-	dbGroups, err := s.db.LoadGroups()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load groups: %w", err)
-	}
+	dbRows, dbGroups := snapshot.Instances, snapshot.Groups
 
 	// Convert to InstanceData format (for backward compat with CLI commands)
 	instances := make([]*InstanceData, len(dbRows))
@@ -1275,15 +1145,11 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 	}
 
 	// Load from SQLite
-	dbRows, err := s.db.LoadInstances()
+	snapshot, err := s.db.LoadRegistrySnapshot()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load instances: %w", err)
+		return nil, nil, err
 	}
-
-	dbGroups, err := s.db.LoadGroups()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load groups: %w", err)
-	}
+	dbRows, dbGroups := snapshot.Instances, snapshot.Groups
 
 	// Convert to InstanceData for the existing convertToInstances pipeline
 	data := &StorageData{
@@ -1390,7 +1256,29 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 		}
 	}
 
-	return s.convertToInstances(data)
+	instances, groups, err := s.convertToInstances(data)
+	if err == nil {
+		byID := make(map[string]*statedb.InstanceRow, len(dbRows))
+		for _, row := range dbRows {
+			byID[row.ID] = row
+		}
+		for _, inst := range instances {
+			original, convertErr := instanceToRow(inst)
+			if convertErr != nil {
+				return nil, nil, convertErr
+			}
+			s.rememberInstanceSnapshot(inst, original, byID[inst.ID])
+		}
+		groupsByPath := make(map[string]*statedb.GroupRow, len(dbGroups))
+		for _, row := range dbGroups {
+			groupsByPath[row.Path] = row
+		}
+		for _, group := range groups {
+			group.storageSnapshot = &groupStorageSnapshot{dbPath: s.dbPath,
+				original: groupDataToRow(group), stored: statedb.CloneGroupRow(groupsByPath[group.Path])}
+		}
+	}
+	return instances, groups, err
 }
 
 // SaveRecentSession captures a deleted session's config for quick re-creation.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -814,26 +814,6 @@ func (s *Storage) PersistRecoveredInstances(instances []*Instance) error {
 	return errors.Join(errs...)
 }
 
-// consumeGenericSessionIDCleared drops the one-shot intentional-clear flag
-// after a successful persistence of the corresponding tool_data write.
-//
-// Without this, a long-lived TUI Instance that once ran
-// `session set tool-session-id ""` keeps genericSessionIDCleared=true forever.
-// Every later SaveWithGroups (title rename, status tick, full table save)
-// would re-emit explicit empty generic_session_id and wipe a concurrent
-// WriteGenericSessionBinding / live-capture re-bind of a new conversation id.
-//
-// Must run only after the DB write succeeds: consuming before Upsert would
-// let a failed save + retry omit the key and sticky-merge resurrect the
-// pre-clear id when write-through (GetGlobal / Persist) was not used.
-func consumeGenericSessionIDCleared(insts ...*Instance) {
-	for _, inst := range insts {
-		if inst != nil {
-			inst.genericSessionIDCleared = false
-		}
-	}
-}
-
 // instanceToRow converts a session.Instance into the statedb row shape.
 // Shared by SaveWithGroups (bulk path) and InsertSessionAndVerify
 // (targeted single-row path) so the marshal/normalize logic stays in
@@ -929,7 +909,7 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	// intentionalClear makes sticky MergeToolDataExtras honor operator clears
 	// without breaking stale-empty full-table saves (see generic_session_persist.go).
 	// The genericSessionIDCleared flag is consumed by the save caller after a
-	// successful DB write (consumeGenericSessionIDCleared), not here: converting
+	// successful DB write, not here: converting
 	// without persisting must not drop clear intent.
 	toolData = WriteGenericSessionIDToToolData(toolData, inst.GenericSessionID, inst.GenericDetectedAt, inst.genericSessionIDCleared)
 	// The scope travels with the id, under the same omission/explicit-empty

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -1255,15 +1255,32 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			if convertErr != nil {
 				return nil, nil, convertErr
 			}
-			s.rememberInstanceSnapshot(inst, original, byID[inst.ID])
+			stored := byID[inst.ID]
+			if stored != nil && stored.GroupPath == DefaultGroupName {
+				// Known legacy normalization is migration intent, not an incidental
+				// display difference. Commit membership with the group's path move.
+				original.GroupPath = stored.GroupPath
+			}
+			s.rememberInstanceSnapshot(inst, original, stored)
 		}
 		groupsByPath := make(map[string]*statedb.GroupRow, len(dbGroups))
 		for _, row := range dbGroups {
 			groupsByPath[row.Path] = row
 		}
+		if legacy := groupsByPath[DefaultGroupName]; legacy != nil {
+			if groupsByPath[DefaultGroupPath] != nil {
+				return nil, nil, fmt.Errorf("legacy default group migration conflicts with existing %q group", DefaultGroupPath)
+			}
+			groupsByPath[DefaultGroupPath] = legacy
+		}
 		for _, group := range groups {
+			stored := groupsByPath[group.Path]
+			original := groupDataToRow(group)
+			if stored != nil && stored.Path == DefaultGroupName {
+				original.Path = stored.Path
+			}
 			group.storageSnapshot = &groupStorageSnapshot{dbPath: s.dbPath,
-				original: groupDataToRow(group), stored: statedb.CloneGroupRow(groupsByPath[group.Path])}
+				original: original, stored: statedb.CloneGroupRow(stored)}
 		}
 	}
 	return instances, groups, err

--- a/internal/session/storage_concurrent_test.go
+++ b/internal/session/storage_concurrent_test.go
@@ -102,3 +102,34 @@ func TestConcurrentStorageWrites(t *testing.T) {
 	assert.LessOrEqual(t, holdersCount, 1,
 		"at most one session should retain the shared ClaudeSessionID after load-time dedup")
 }
+
+// A stale TUI snapshot changing the title must not erase a concurrent CLI
+// status update on the same row. This is intentionally deterministic: both
+// handles load before either writer saves.
+func TestStaleSnapshotPreservesDisjointFieldUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	open := func() *Storage {
+		db, err := statedb.Open(filepath.Join(tmpDir, "state.db"))
+		require.NoError(t, err)
+		require.NoError(t, db.Migrate())
+		return &Storage{db: db, dbPath: filepath.Join(tmpDir, "state.db"), profile: "_test"}
+	}
+	seed := open()
+	base := &Instance{ID: "shared", Title: "original", ProjectPath: tmpDir, GroupPath: "test", Tool: "shell", Status: StatusIdle, CreatedAt: time.Now()}
+	require.NoError(t, seed.SaveWithGroups([]*Instance{base}, NewGroupTree([]*Instance{base})))
+	tui, cli := open(), open()
+	tuiRows, _, err := tui.LoadWithGroups()
+	require.NoError(t, err)
+	cliRows, _, err := cli.LoadWithGroups()
+	require.NoError(t, err)
+	cliRows[0].Status = StatusRunning
+	require.NoError(t, cli.SaveWithGroups(cliRows, nil))
+	tuiRows[0].Title = "renamed"
+	require.NoError(t, tui.SaveWithGroups(tuiRows, nil))
+	check := open()
+	got, err := check.Load()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "renamed", got[0].Title)
+	assert.Equal(t, StatusRunning, got[0].Status, "stale title save must preserve disjoint CLI status update")
+}

--- a/internal/session/storage_legacy_group_review_test.go
+++ b/internal/session/storage_legacy_group_review_test.go
@@ -1,0 +1,74 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func legacyGroupReviewFixture(t *testing.T, member bool) (*Storage, []*Instance, *GroupTree) {
+	t.Helper()
+	s := newTestStorage(t)
+	require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{{Path: DefaultGroupName, Name: DefaultGroupName, Expanded: true, MaxConcurrent: 2}}))
+	if member {
+		require.NoError(t, s.db.SaveInstance(&statedb.InstanceRow{ID: "legacy", Title: "legacy", Tool: "shell", ProjectPath: t.TempDir(), GroupPath: DefaultGroupName}))
+	}
+	instances, groups, err := s.LoadWithGroups()
+	require.NoError(t, err)
+	return s, instances, NewGroupTreeWithGroups(instances, groups)
+}
+
+func TestLegacyGroupReviewMigrationCommitsOnce(t *testing.T) {
+	for _, member := range []bool{false, true} {
+		s, instances, tree := legacyGroupReviewFixture(t, member)
+		for attempt := 0; attempt < 2; attempt++ {
+			require.NoError(t, s.SaveWithGroups(instances, tree.ShallowCopyForSave()))
+			groups, err := s.db.LoadGroups()
+			require.NoError(t, err)
+			require.Len(t, groups, 1)
+			require.Equal(t, DefaultGroupPath, groups[0].Path)
+			require.Equal(t, 2, groups[0].MaxConcurrent)
+			if member {
+				row, err := s.db.LoadInstanceByID("legacy")
+				require.NoError(t, err)
+				require.Equal(t, DefaultGroupPath, row.GroupPath)
+			}
+		}
+	}
+}
+
+func TestLegacyGroupReviewMigrationPreservesConcurrentMetadata(t *testing.T) {
+	s, instances, tree := legacyGroupReviewFixture(t, true)
+	_, err := s.db.DB().Exec("UPDATE groups SET max_concurrent = 7 WHERE path = ?", DefaultGroupName)
+	require.NoError(t, err)
+	require.NoError(t, s.SaveWithGroups(instances, tree.ShallowCopyForSave()))
+	require.Nil(t, storedGroup(t, s, DefaultGroupName))
+	require.Equal(t, 7, storedGroup(t, s, DefaultGroupPath).MaxConcurrent)
+}
+
+func TestLegacyGroupReviewMigrationConflictsAtomically(t *testing.T) {
+	for _, change := range []string{"target", "member", "group field"} {
+		t.Run(change, func(t *testing.T) {
+			s, instances, tree := legacyGroupReviewFixture(t, true)
+			switch change {
+			case "target":
+				require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{{Path: DefaultGroupPath, Name: "existing canonical"}}))
+			case "member":
+				require.NoError(t, s.db.SaveInstance(&statedb.InstanceRow{ID: "new-member", Tool: "shell", GroupPath: DefaultGroupName}))
+			case "group field":
+				_, err := s.db.DB().Exec("UPDATE groups SET max_concurrent = 7 WHERE path = ?", DefaultGroupName)
+				require.NoError(t, err)
+				tree.Groups[DefaultGroupPath].MaxConcurrent = 8
+			}
+			require.ErrorContains(t, s.SaveWithGroups(instances, tree.ShallowCopyForSave()), "conflict")
+			require.NotNil(t, storedGroup(t, s, DefaultGroupName))
+			row, err := s.db.LoadInstanceByID("legacy")
+			require.NoError(t, err)
+			require.Equal(t, DefaultGroupName, row.GroupPath)
+			if change != "target" {
+				require.Nil(t, storedGroup(t, s, DefaultGroupPath))
+			}
+		})
+	}
+}

--- a/internal/session/storage_legacy_group_review_test.go
+++ b/internal/session/storage_legacy_group_review_test.go
@@ -47,6 +47,18 @@ func TestLegacyGroupReviewMigrationPreservesConcurrentMetadata(t *testing.T) {
 	require.Equal(t, 7, storedGroup(t, s, DefaultGroupPath).MaxConcurrent)
 }
 
+func TestLegacyGroupReviewExistingCanonicalCollisionFailsClosed(t *testing.T) {
+	s := newTestStorage(t)
+	require.NoError(t, s.db.SaveGroups([]*statedb.GroupRow{
+		{Path: DefaultGroupName, Name: "legacy", MaxConcurrent: 2},
+		{Path: DefaultGroupPath, Name: "canonical", MaxConcurrent: 7},
+	}))
+	_, _, err := s.LoadWithGroups()
+	require.ErrorContains(t, err, "conflict")
+	require.Equal(t, 2, storedGroup(t, s, DefaultGroupName).MaxConcurrent)
+	require.Equal(t, 7, storedGroup(t, s, DefaultGroupPath).MaxConcurrent)
+}
+
 func TestLegacyGroupReviewMigrationConflictsAtomically(t *testing.T) {
 	for _, change := range []string{"target", "member", "group field"} {
 		t.Run(change, func(t *testing.T) {

--- a/internal/session/storage_snapshot_test.go
+++ b/internal/session/storage_snapshot_test.go
@@ -1,0 +1,159 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func snapshotFixture(t *testing.T) (*Storage, []*Instance, []*Instance) {
+	t.Helper()
+	s := newTestStorage(t)
+	seed := &Instance{ID: "shared", Title: "original", ProjectPath: t.TempDir(), GroupPath: "test", Tool: "shell", Status: StatusIdle, Account: "personal", CreatedAt: time.Now()}
+	require.NoError(t, s.Save([]*Instance{seed}))
+	a, err := s.Load()
+	require.NoError(t, err)
+	b, err := s.Load()
+	require.NoError(t, err)
+	return s, a, b
+}
+
+func TestStorageSnapshotDisjointFields(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		edit  func(*Instance)
+		check func(*testing.T, *Instance)
+	}{
+		{"account", func(i *Instance) { i.Account = "seminno" }, func(t *testing.T, i *Instance) { require.Equal(t, "seminno", i.Account) }},
+		{"parent", func(i *Instance) { i.ParentSessionID = "parent" }, func(t *testing.T, i *Instance) { require.Equal(t, "parent", i.ParentSessionID) }},
+		{"worktree", func(i *Instance) { i.WorktreeBranch = "feature" }, func(t *testing.T, i *Instance) { require.Equal(t, "feature", i.WorktreeBranch) }},
+		{"notes", func(i *Instance) { i.Notes = "remote notes" }, func(t *testing.T, i *Instance) { require.Equal(t, "remote notes", i.Notes) }},
+		{"color", func(i *Instance) { i.Color = "203" }, func(t *testing.T, i *Instance) { require.Equal(t, "203", i.Color) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, a, b := snapshotFixture(t)
+			tc.edit(b[0])
+			require.NoError(t, s.Save(b))
+			a[0].Title = "renamed"
+			require.NoError(t, s.Save(a))
+			got, err := s.Load()
+			require.NoError(t, err)
+			require.Equal(t, "renamed", got[0].Title)
+			tc.check(t, got[0])
+			// The caller still has its original account/notes. An unrelated second
+			// edit must not turn those stale values into new overwrite intent.
+			a[0].Title = "renamed again"
+			require.NoError(t, s.Save(a))
+			got, err = s.Load()
+			require.NoError(t, err)
+			tc.check(t, got[0])
+		})
+	}
+}
+
+func TestStorageSnapshotRepeatedSaves(t *testing.T) {
+	s, a, _ := snapshotFixture(t)
+	a[0].Title = "first"
+	require.NoError(t, s.Save(a))
+	a[0].Title = "second"
+	require.NoError(t, s.Save(a), "a writer must not conflict with its own last save")
+}
+
+func TestStorageSnapshotIncidentalLoadDoesNotRebase(t *testing.T) {
+	s, a, b := snapshotFixture(t)
+	b[0].Title = "other writer"
+	require.NoError(t, s.Save(b))
+	_, err := s.Load()
+	require.NoError(t, err)
+	a[0].Title = "pending older edit"
+	require.ErrorContains(t, s.Save(a), "conflict")
+	got, err := s.Load()
+	require.NoError(t, err)
+	require.Equal(t, "other writer", got[0].Title)
+}
+
+func TestStorageSnapshotReadErrorFailsClosed(t *testing.T) {
+	s, a, _ := snapshotFixture(t)
+	// SQLite's dynamic typing lets us make SELECT scanning fail while the
+	// subsequent unconditional old UPSERT would succeed and erase the evidence.
+	_, err := s.db.DB().Exec("UPDATE instances SET sort_order = 'unreadable' WHERE id = 'shared'")
+	require.NoError(t, err)
+	a[0].Title = "must not commit"
+	require.Error(t, s.Save(a))
+	var title string
+	require.NoError(t, s.db.DB().QueryRow("SELECT title FROM instances WHERE id = 'shared'").Scan(&title))
+	require.Equal(t, "original", title)
+}
+
+func TestStorageSnapshotSameFieldConflictsAndRetry(t *testing.T) {
+	s, a, b := snapshotFixture(t)
+	b[0].Account = "seminno"
+	require.NoError(t, s.Save(b))
+	a[0].Account = "work"
+	require.ErrorContains(t, s.Save(a), "conflict")
+	// Failure must not advance a's baseline. Converging on the already committed
+	// value is allowed, and later edits use that successful save as their origin.
+	a[0].Account = "seminno"
+	require.NoError(t, s.Save(a))
+	a[0].Account = "personal"
+	require.NoError(t, s.Save(a))
+}
+
+func TestStorageSnapshotDeletedRowsAreNotRecreated(t *testing.T) {
+	s, a, _ := snapshotFixture(t)
+	require.NoError(t, s.DeleteInstance(a[0].ID))
+	a[0].Title = "stale"
+	require.ErrorContains(t, s.Save(a), "deletion conflict")
+	exists, err := s.InstanceExists(a[0].ID)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestStorageSnapshotGroupFailureRollsBackAndKeepsBaseline(t *testing.T) {
+	s, a, _ := snapshotFixture(t)
+	_, err := s.db.DB().Exec("CREATE TRIGGER reject_group BEFORE INSERT ON groups BEGIN SELECT RAISE(ABORT, 'group rejected'); END")
+	require.NoError(t, err)
+	a[0].Title = "pending"
+	require.ErrorContains(t, s.SaveWithGroups(a, NewGroupTree(a)), "group rejected")
+	var title string
+	require.NoError(t, s.db.DB().QueryRow("SELECT title FROM instances WHERE id='shared'").Scan(&title))
+	require.Equal(t, "original", title)
+	_, err = s.db.DB().Exec("DROP TRIGGER reject_group")
+	require.NoError(t, err)
+	a[0].Title = "retry"
+	require.NoError(t, s.SaveWithGroups(a, NewGroupTree(a)))
+}
+
+func TestStorageSnapshotNoOpPreservesTargetedChanges(t *testing.T) {
+	s, a, _ := snapshotFixture(t)
+	_, err := s.db.DB().Exec("UPDATE instances SET title='new title', account='seminno', tool_data=json_set(tool_data, '$.unmodeled', 42) WHERE id='shared'")
+	require.NoError(t, err)
+	require.NoError(t, s.Save(a))
+	require.NoError(t, s.Save(a))
+	got, err := s.Load()
+	require.NoError(t, err)
+	require.Equal(t, "new title", got[0].Title)
+	require.Equal(t, "seminno", got[0].Account)
+	var extra int
+	require.NoError(t, s.db.DB().QueryRow("SELECT json_extract(tool_data, '$.unmodeled') FROM instances WHERE id='shared'").Scan(&extra))
+	require.Equal(t, 42, extra)
+}
+
+func TestStorageSnapshotWriteThroughClearConverges(t *testing.T) {
+	s, a, _ := snapshotFixture(t)
+	a[0].GenericSessionID = "bound"
+	a[0].GenericDetectedAt = time.Now()
+	require.NoError(t, s.Save(a))
+	a[0].GenericSessionID = ""
+	a[0].GenericDetectedAt = time.Time{}
+	a[0].genericSessionIDCleared = true
+	require.NoError(t, PersistGenericSessionBinding(s.db, a[0]))
+	require.NoError(t, s.Save(a), "targeted json_remove and explicit-empty full save must converge")
+	require.NoError(t, s.db.WriteGenericSessionBinding(a[0].ID, "new binding", "shell", "", "local", time.Now()))
+	a[0].Title = "unrelated edit"
+	require.NoError(t, s.Save(a), "a consumed clear marker must not clear a later binding")
+	got, err := s.Load()
+	require.NoError(t, err)
+	require.Equal(t, "new binding", got[0].GenericSessionID)
+}

--- a/internal/session/storage_transaction_test.go
+++ b/internal/session/storage_transaction_test.go
@@ -1,0 +1,121 @@
+package session
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+	"modernc.org/sqlite"
+)
+
+// A SQLite view evaluates our probe during the authoritative SELECT. The probe
+// attempts a real competing write using a second connection with no busy wait.
+// This pins the exact old read/write gap, without production instrumentation or
+// scheduling sleeps: a reserved transaction must exclude that writer already.
+func TestStorageSnapshotTransactionReservesBeforeRead(t *testing.T) {
+	for _, mutation := range []string{"UPDATE stored_instances SET account = 'seminno' WHERE id = 'shared'", "DELETE FROM stored_instances WHERE id = 'shared'"} {
+		t.Run(mutation, func(t *testing.T) {
+			var armed atomic.Bool
+			var other *statedb.StateDB
+			attempt := make(chan error, 1)
+			function := fmt.Sprintf("storage_probe_%d", time.Now().UnixNano())
+			require.NoError(t, sqlite.RegisterScalarFunction(function, 1, func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+				if armed.CompareAndSwap(true, false) {
+					_, err := other.DB().Exec(mutation)
+					attempt <- err
+				}
+				return args[0], nil
+			}))
+			s, a, _ := snapshotFixture(t)
+			var err error
+			other, err = statedb.Open(s.dbPath)
+			require.NoError(t, err)
+			t.Cleanup(func() { other.Close() })
+			other.DB().SetMaxOpenConns(1)
+			_, err = other.DB().Exec("PRAGMA busy_timeout=0")
+			require.NoError(t, err)
+			// Include every column so the view also supports the old writer. Names
+			// are schema-controlled, quoted, and never supplied by a CLI caller.
+			columns, err := s.db.DB().Query("PRAGMA table_info(instances)")
+			require.NoError(t, err)
+			var names, selected, values []string
+			for columns.Next() {
+				var cid, notnull, pk int
+				var name, kind string
+				var defaultValue any
+				require.NoError(t, columns.Scan(&cid, &name, &kind, &notnull, &defaultValue, &pk))
+				if name == "acknowledged" {
+					continue
+				}
+				quoted := `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+				names = append(names, quoted)
+				values = append(values, "NEW."+quoted)
+				if name == "title" {
+					selected = append(selected, function+"(title) AS title")
+				} else {
+					selected = append(selected, quoted)
+				}
+			}
+			require.NoError(t, columns.Err())
+			require.NoError(t, columns.Close())
+			_, err = s.db.DB().Exec("ALTER TABLE instances RENAME TO stored_instances")
+			require.NoError(t, err)
+			_, err = s.db.DB().Exec("CREATE VIEW instances AS SELECT " + strings.Join(selected, ",") + " FROM stored_instances")
+			require.NoError(t, err)
+			_, err = s.db.DB().Exec("CREATE TRIGGER store_instance INSTEAD OF INSERT ON instances BEGIN INSERT OR REPLACE INTO stored_instances (" + strings.Join(names, ",") + ") VALUES (" + strings.Join(values, ",") + "); END")
+			require.NoError(t, err)
+			assignments := make([]string, len(names))
+			for i, name := range names {
+				assignments[i] = name + " = " + values[i]
+			}
+			_, err = s.db.DB().Exec("CREATE TRIGGER update_instance INSTEAD OF UPDATE ON instances BEGIN UPDATE stored_instances SET " + strings.Join(assignments, ",") + " WHERE id = OLD.id; END")
+			require.NoError(t, err)
+			a[0].Title = "alice"
+			armed.Store(true)
+			saveErr := s.Save(a)
+			select {
+			case err := <-attempt:
+				require.ErrorContains(t, err, "locked", "a competing write must be excluded while the authoritative row is being read")
+			default:
+				t.Fatal("authoritative-read probe was not evaluated")
+			}
+			require.NoError(t, saveErr)
+			// The same competing mutation is allowed after commit, proving the
+			// reservation was released rather than leaking a lock or connection.
+			_, err = other.DB().Exec(mutation)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestStorageSnapshotKeepsEditsMadeDuringSavePending(t *testing.T) {
+	var armed atomic.Bool
+	var instance *Instance
+	function := fmt.Sprintf("storage_pending_edit_%d", time.Now().UnixNano())
+	require.NoError(t, sqlite.RegisterScalarFunction(function, 0, func(_ *sqlite.FunctionContext, _ []driver.Value) (driver.Value, error) {
+		if armed.CompareAndSwap(true, false) {
+			instance.Title = "edited while saving"
+		}
+		return int64(1), nil
+	}))
+	s, a, _ := snapshotFixture(t)
+	instance = a[0]
+	_, err := s.db.DB().Exec("CREATE TRIGGER pending_edit AFTER UPDATE ON instances BEGIN SELECT " + function + "(); END")
+	require.NoError(t, err)
+	instance.Title = "submitted"
+	armed.Store(true)
+	require.NoError(t, s.Save(a))
+	row, err := s.db.LoadInstanceByID(instance.ID)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", row.Title)
+	require.Equal(t, "edited while saving", instance.Title)
+	require.NoError(t, s.Save(a))
+	row, err = s.db.LoadInstanceByID(instance.ID)
+	require.NoError(t, err)
+	require.Equal(t, "edited while saving", row.Title, "the successful save baseline must contain submitted values, not a later live edit")
+}

--- a/internal/session/taskworker_test.go
+++ b/internal/session/taskworker_test.go
@@ -70,16 +70,11 @@ func addParentRow(t *testing.T, profile, parentID, childID string) {
 		Status:      StatusIdle,
 		CreatedAt:   time.Now(),
 	}
-	child := &Instance{
-		ID:              childID,
-		Title:           "worker",
-		ProjectPath:     "/tmp/c1214",
-		GroupPath:       DefaultGroupPath,
-		ParentSessionID: parentID,
-		Tool:            "claude",
-		Status:          StatusWaiting,
-		CreatedAt:       time.Now(),
+	children, err := storage.Load()
+	if err != nil || len(children) != 1 || children[0].ID != childID {
+		t.Fatalf("load existing child: instances=%v err=%v", children, err)
 	}
+	child := children[0]
 	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
 		t.Fatalf("save: %v", err)
 	}

--- a/internal/statedb/group_snapshot.go
+++ b/internal/statedb/group_snapshot.go
@@ -37,7 +37,7 @@ func mergeGroupSnapshots(updates []GroupSnapshot, current []*GroupRow, instances
 	merged := make([]*GroupRow, len(updates))
 	removed := make(map[string]bool)
 	seen := make(map[string]bool)
-	effectiveInstances := make(map[string]*InstanceRow, len(instances)+len(mergedInstances))
+	effectiveInstances := make(map[string]*InstanceRow, len(instances))
 	for _, row := range instances {
 		effectiveInstances[row.ID] = row
 	}

--- a/internal/statedb/group_snapshot.go
+++ b/internal/statedb/group_snapshot.go
@@ -1,0 +1,174 @@
+package statedb
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// GroupSnapshot carries a metadata edit, a path move, or an explicit deletion
+// (nil Desired). Ensure permits unchanged groups derived from session paths to
+// use existing metadata, rather than replacing it with synthesized defaults.
+type GroupSnapshot struct {
+	Original *GroupRow
+	Stored   *GroupRow
+	Desired  *GroupRow
+	Ensure   bool
+}
+
+func CloneGroupRow(row *GroupRow) *GroupRow {
+	if row == nil {
+		return nil
+	}
+	copy := *row
+	return &copy
+}
+
+type RegistrySnapshotResult struct {
+	Instances []*InstanceRow
+	Groups    []*GroupRow // Input order; nil for explicit deletions.
+}
+
+func mergeGroupSnapshots(updates []GroupSnapshot, current []*GroupRow, instances, mergedInstances []*InstanceRow) ([]*GroupRow, []string, error) {
+	byPath := make(map[string]*GroupRow, len(current))
+	for _, group := range current {
+		byPath[group.Path] = group
+	}
+	merged := make([]*GroupRow, len(updates))
+	removed := make(map[string]bool)
+	seen := make(map[string]bool)
+	effectiveInstances := make(map[string]*InstanceRow, len(instances)+len(mergedInstances))
+	for _, row := range instances {
+		effectiveInstances[row.ID] = row
+	}
+	for _, row := range mergedInstances {
+		effectiveInstances[row.ID] = row
+	}
+	targets := make(map[string]bool)
+	for i, update := range updates {
+		var path string
+		if update.Stored != nil {
+			path = update.Stored.Path
+		} else if update.Desired != nil {
+			path = update.Desired.Path
+		} else if update.Original != nil {
+			path = update.Original.Path
+		}
+		if path == "" || seen[path] {
+			return nil, nil, fmt.Errorf("invalid or duplicate group snapshot: %s", path)
+		}
+		seen[path] = true
+		if update.Ensure && update.Stored == nil && update.Desired != nil && byPath[path] == nil && reflect.DeepEqual(update.Original, update.Desired) {
+			hasMembers := false
+			for _, row := range effectiveInstances {
+				if inGroupSubtree(row.GroupPath, path) {
+					hasMembers = true
+					break
+				}
+			}
+			// A fallback tree may describe a member's stale group path. An unchanged
+			// implicit group without any authoritative members is not creation intent.
+			if !hasMembers {
+				continue
+			}
+		}
+		row, err := mergeGroupSnapshot(update, byPath[path])
+		if err != nil {
+			return nil, nil, err
+		}
+		merged[i] = row
+		if row != nil {
+			if targets[row.Path] {
+				return nil, nil, fmt.Errorf("duplicate group target conflict: %s", row.Path)
+			}
+			targets[row.Path] = true
+		}
+		if update.Stored != nil && (row == nil || row.Path != path) {
+			removed[path] = true
+		}
+		if row != nil && row.Path != path && byPath[row.Path] != nil {
+			return nil, nil, fmt.Errorf("concurrent group rename target conflict: %s", row.Path)
+		}
+	}
+	// Renaming or removing a subtree may not sweep or orphan additions that
+	// were absent from the caller's snapshot. Reloading makes them reviewable.
+	requestedInstances := make(map[string]*InstanceRow, len(mergedInstances))
+	for _, row := range mergedInstances {
+		requestedInstances[row.ID] = row
+	}
+	for path := range removed {
+		for _, group := range current {
+			if inGroupSubtree(group.Path, path) && !removed[group.Path] {
+				return nil, nil, fmt.Errorf("concurrent subgroup addition conflict: %s", group.Path)
+			}
+		}
+		for _, row := range instances {
+			if !inGroupSubtree(row.GroupPath, path) {
+				continue
+			}
+			desired := requestedInstances[row.ID]
+			if desired == nil || inGroupSubtree(desired.GroupPath, path) {
+				return nil, nil, fmt.Errorf("concurrent group membership conflict for instance %s", row.ID)
+			}
+		}
+	}
+	paths := make([]string, 0, len(removed))
+	for path := range removed {
+		paths = append(paths, path)
+	}
+	return merged, paths, nil
+}
+
+func inGroupSubtree(candidate, path string) bool {
+	return candidate == path || strings.HasPrefix(candidate, path+"/")
+}
+
+func mergeGroupSnapshot(update GroupSnapshot, current *GroupRow) (*GroupRow, error) {
+	if update.Stored == nil {
+		if update.Desired == nil {
+			if current == nil {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("unversioned group deletion conflict: %s", current.Path)
+		}
+		if current == nil {
+			return CloneGroupRow(update.Desired), nil
+		}
+		if reflect.DeepEqual(update.Desired, current) {
+			return CloneGroupRow(current), nil
+		}
+		if update.Ensure && reflect.DeepEqual(update.Original, update.Desired) {
+			return CloneGroupRow(current), nil
+		}
+		return nil, fmt.Errorf("concurrent group insertion conflict: %s", update.Desired.Path)
+	}
+	if update.Original == nil {
+		return nil, fmt.Errorf("invalid group snapshot: %s", update.Stored.Path)
+	}
+	if update.Desired == nil {
+		if current == nil {
+			return nil, nil
+		}
+		if !reflect.DeepEqual(current, update.Stored) {
+			return nil, fmt.Errorf("concurrent group deletion conflict: %s", update.Stored.Path)
+		}
+		return nil, nil
+	}
+	if current == nil {
+		return nil, fmt.Errorf("stale concurrent group deletion conflict: %s", update.Stored.Path)
+	}
+	merged := CloneGroupRow(current)
+	want, original := reflect.ValueOf(update.Desired).Elem(), reflect.ValueOf(update.Original).Elem()
+	stored, actual := reflect.ValueOf(update.Stored).Elem(), reflect.ValueOf(current).Elem()
+	out := reflect.ValueOf(merged).Elem()
+	for i := 0; i < want.NumField(); i++ {
+		if reflect.DeepEqual(want.Field(i).Interface(), original.Field(i).Interface()) {
+			continue
+		}
+		if !reflect.DeepEqual(actual.Field(i).Interface(), stored.Field(i).Interface()) && !reflect.DeepEqual(actual.Field(i).Interface(), want.Field(i).Interface()) {
+			return nil, fmt.Errorf("concurrent group %s conflict: %s", want.Type().Field(i).Name, current.Path)
+		}
+		out.Field(i).Set(want.Field(i))
+	}
+	return merged, nil
+}

--- a/internal/statedb/instance_snapshot.go
+++ b/internal/statedb/instance_snapshot.go
@@ -55,7 +55,7 @@ func (s *StateDB) LoadRegistrySnapshot() (*RegistrySnapshotResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	instances, err := loadInstances(tx.Query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load instances: %w", err)
@@ -266,7 +266,7 @@ func mergeSnapshotToolData(update InstanceSnapshot, current *InstanceRow) (json.
 	if err != nil {
 		return nil, err
 	}
-	keys := make(map[string]bool, len(original)+len(desired))
+	keys := make(map[string]bool, len(original))
 	for key := range original {
 		keys[key] = true
 	}

--- a/internal/statedb/instance_snapshot.go
+++ b/internal/statedb/instance_snapshot.go
@@ -1,0 +1,319 @@
+package statedb
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// InstanceSnapshot separates the caller's last submitted representation from
+// the row it observed. Load-time normalization and omitted ToolData extras must
+// not look like edits. Nil Stored and Original mean an insertion, never an
+// unconditional replacement of an existing ID.
+type InstanceSnapshot struct {
+	Original *InstanceRow
+	Stored   *InstanceRow
+	Desired  *InstanceRow
+}
+
+// CloneInstanceRow returns an owned snapshot, including the mutable JSON bytes.
+func CloneInstanceRow(row *InstanceRow) *InstanceRow {
+	if row == nil {
+		return nil
+	}
+	copy := *row
+	copy.ToolData = append(json.RawMessage(nil), row.ToolData...)
+	return &copy
+}
+
+// MergeInstanceSnapshots reserves the SQLite writer before reading current
+// values, then compares and writes within that reservation. Direct SQL UPDATEs
+// and DELETEs obey the same SQLite lock, including writers in other processes.
+// Every retry repeats the whole decision; no precomputed merge is replayed.
+// Rows absent from updates are never swept. Group rows here are insertions;
+// callers editing existing groups must supply baselines to MergeRegistrySnapshots.
+func (s *StateDB) MergeInstanceSnapshots(updates []InstanceSnapshot, groups []*GroupRow) ([]*InstanceRow, error) {
+	groupUpdates := make([]GroupSnapshot, len(groups))
+	for i, group := range groups {
+		groupUpdates[i] = GroupSnapshot{Desired: group}
+	}
+	result, err := s.MergeRegistrySnapshots(updates, groupUpdates)
+	if err != nil {
+		return nil, err
+	}
+	return result.Instances, nil
+}
+
+// LoadRegistrySnapshot reads both tables from one SQLite snapshot. A concurrent
+// group rename cannot produce old members paired with new group metadata.
+func (s *StateDB) LoadRegistrySnapshot() (*RegistrySnapshotResult, error) {
+	tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	instances, err := loadInstances(tx.Query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load instances: %w", err)
+	}
+	groups, err := loadGroups(tx.Query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load groups: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &RegistrySnapshotResult{Instances: instances, Groups: groups}, nil
+}
+
+// MergeRegistrySnapshots commits instance and group snapshots together. Both
+// returned slices preserve input order and are available only after COMMIT.
+func (s *StateDB) MergeRegistrySnapshots(updates []InstanceSnapshot, groups []GroupSnapshot) (*RegistrySnapshotResult, error) {
+	var committed *RegistrySnapshotResult
+	err := withBusyRetry(func() error {
+		var err error
+		committed, err = s.mergeRegistrySnapshotsOnce(updates, groups)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return committed, nil
+}
+
+func (s *StateDB) mergeRegistrySnapshotsOnce(updates []InstanceSnapshot, groups []GroupSnapshot) (*RegistrySnapshotResult, error) {
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, err
+	}
+	defer func() { _, _ = conn.ExecContext(ctx, "ROLLBACK") }()
+	current, err := loadInstances(func(query string, args ...any) (*sql.Rows, error) {
+		return conn.QueryContext(ctx, query, args...)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read current instances: %w", err)
+	}
+	byID := make(map[string]*InstanceRow, len(current))
+	for _, row := range current {
+		byID[row.ID] = row
+	}
+	merged := make([]*InstanceRow, len(updates))
+	seen := make(map[string]bool, len(updates))
+	for i, update := range updates {
+		if update.Desired == nil || update.Desired.ID == "" {
+			return nil, fmt.Errorf("instance snapshot requires an ID")
+		}
+		id := update.Desired.ID
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate instance snapshot: %s", id)
+		}
+		seen[id] = true
+		merged[i], err = mergeInstanceSnapshot(update, byID[id])
+		if err != nil {
+			return nil, err
+		}
+	}
+	currentGroups, err := loadGroups(func(query string, args ...any) (*sql.Rows, error) {
+		return conn.QueryContext(ctx, query, args...)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read current groups: %w", err)
+	}
+	mergedGroups, removedGroups, err := mergeGroupSnapshots(groups, currentGroups, current, merged)
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range removedGroups {
+		if _, err := conn.ExecContext(ctx, "DELETE FROM groups WHERE path = ?", path); err != nil {
+			return nil, err
+		}
+	}
+	for _, row := range merged {
+		if err := writeSnapshotRow(ctx, conn, row, byID[row.ID] != nil); err != nil {
+			return nil, err
+		}
+	}
+	for _, group := range mergedGroups {
+		if group == nil {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, upsertGroupSQL, group.Path, group.Name, group.Expanded, group.Order, group.DefaultPath, group.MaxConcurrent); err != nil {
+			return nil, fmt.Errorf("save group: %w", err)
+		}
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return nil, err
+	}
+	return &RegistrySnapshotResult{Instances: merged, Groups: mergedGroups}, nil
+}
+
+func mergeInstanceSnapshot(update InstanceSnapshot, current *InstanceRow) (*InstanceRow, error) {
+	id := update.Desired.ID
+	if update.Stored == nil {
+		if update.Original != nil || current != nil {
+			return nil, fmt.Errorf("concurrent insertion conflict for instance %s", id)
+		}
+		row := CloneInstanceRow(update.Desired)
+		if _, err := toolDataFields(row.ToolData); err != nil {
+			return nil, err
+		}
+		return row, nil
+	}
+	if update.Original == nil || update.Stored.ID != id || update.Original.ID != id {
+		return nil, fmt.Errorf("invalid snapshot identity for instance %s", id)
+	}
+	if current == nil {
+		return nil, fmt.Errorf("stale concurrent deletion conflict for instance %s", id)
+	}
+	merged := CloneInstanceRow(current)
+	// InstanceRow consists of scalar persisted columns plus ToolData. Iterating
+	// the row type keeps newly added columns in the same conflict contract.
+	want, original := reflect.ValueOf(update.Desired).Elem(), reflect.ValueOf(update.Original).Elem()
+	stored, actual := reflect.ValueOf(update.Stored).Elem(), reflect.ValueOf(current).Elem()
+	out := reflect.ValueOf(merged).Elem()
+	for i := 0; i < want.NumField(); i++ {
+		name := want.Type().Field(i).Name
+		if name == "ToolData" {
+			continue
+		}
+		if snapshotValueEqual(want.Field(i).Interface(), original.Field(i).Interface()) {
+			continue
+		}
+		if !snapshotValueEqual(actual.Field(i).Interface(), stored.Field(i).Interface()) && !snapshotValueEqual(actual.Field(i).Interface(), want.Field(i).Interface()) {
+			return nil, fmt.Errorf("stale concurrent %s conflict for instance %s", name, id)
+		}
+		out.Field(i).Set(want.Field(i))
+	}
+	var err error
+	merged.ToolData, err = mergeSnapshotToolData(update, current)
+	return merged, err
+}
+
+func snapshotValueEqual(a, b any) bool {
+	if timestamp, ok := a.(time.Time); ok {
+		// SQLite persists seconds, with no monotonic clock or location identity.
+		return timestamp.Unix() == b.(time.Time).Unix()
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func toolDataFields(data json.RawMessage) (map[string]json.RawMessage, error) {
+	fields := make(map[string]json.RawMessage)
+	if len(data) == 0 {
+		return fields, nil
+	}
+	if err := json.Unmarshal(data, &fields); err != nil || fields == nil {
+		return nil, fmt.Errorf("invalid instance tool_data: expected JSON object")
+	}
+	return fields, nil
+}
+
+func sameJSON(a, b json.RawMessage) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	var av, bv any
+	// The enclosing object was validated when building the maps.
+	ad, bd := json.NewDecoder(bytes.NewReader(a)), json.NewDecoder(bytes.NewReader(b))
+	ad.UseNumber()
+	bd.UseNumber()
+	_ = ad.Decode(&av)
+	_ = bd.Decode(&bv)
+	return reflect.DeepEqual(av, bv)
+}
+
+func sameStoredToolValue(key string, a, b json.RawMessage) bool {
+	if sameJSON(a, b) {
+		return true
+	}
+	// Targeted identity clears use json_remove; full saves carry explicit
+	// empty/zero markers. Those are the same committed clear, including when
+	// this caller's write-through already removed the key before the full save.
+	if stickyToolDataKeys()[key] {
+		isClear := func(value json.RawMessage) bool {
+			return value == nil || sameJSON(value, json.RawMessage(`""`)) || sameJSON(value, json.RawMessage(`0`))
+		}
+		return isClear(a) && isClear(b)
+	}
+	return false
+}
+
+func mergeSnapshotToolData(update InstanceSnapshot, current *InstanceRow) (json.RawMessage, error) {
+	original, err := toolDataFields(update.Original.ToolData)
+	if err != nil {
+		return nil, err
+	}
+	// Keep the existing omission/explicit-empty protocol for sticky identity
+	// and unknown extras, but derive intent from the caller's own snapshot.
+	desired, err := toolDataFields(MergeToolDataExtras(update.Original.ToolData, update.Desired.ToolData))
+	if err != nil {
+		return nil, err
+	}
+	stored, err := toolDataFields(update.Stored.ToolData)
+	if err != nil {
+		return nil, err
+	}
+	actual, err := toolDataFields(current.ToolData)
+	if err != nil {
+		return nil, err
+	}
+	keys := make(map[string]bool, len(original)+len(desired))
+	for key := range original {
+		keys[key] = true
+	}
+	for key := range desired {
+		keys[key] = true
+	}
+	for key := range keys {
+		if sameJSON(original[key], desired[key]) {
+			continue
+		}
+		if !sameStoredToolValue(key, actual[key], stored[key]) && !sameStoredToolValue(key, actual[key], desired[key]) {
+			return nil, fmt.Errorf("stale concurrent tool_data.%s conflict for instance %s", key, current.ID)
+		}
+		if value, exists := desired[key]; exists {
+			actual[key] = value
+		} else {
+			delete(actual, key)
+		}
+	}
+	return json.Marshal(actual)
+}
+
+func writeSnapshotRow(ctx context.Context, conn *sql.Conn, row *InstanceRow, exists bool) error {
+	data := row.ToolData
+	if len(data) == 0 {
+		data = json.RawMessage("{}")
+	}
+	args := []any{row.Title, row.ProjectPath, row.GroupPath, row.Order,
+		row.Command, row.Wrapper, row.Tool, row.Status, row.TmuxSession, row.TmuxSocketName,
+		row.CreatedAt.Unix(), row.LastAccessed.Unix(), row.ParentSessionID, row.IsConductor, row.NoTransitionNotify,
+		row.WorktreePath, row.WorktreeRepo, row.WorktreeBranch, row.Account, archivedAtUnix(row.ArchivedAt),
+		string(data), row.TitleLocked, row.AutoName, row.AutoNameDescription, row.Pin, row.ID}
+	// UPDATE preserves columns not represented by InstanceRow, such as the
+	// notification acknowledgement. REPLACE would reset their defaults.
+	query := `UPDATE instances SET title=?, project_path=?, group_path=?, sort_order=?,
+		command=?, wrapper=?, tool=?, status=?, tmux_session=?, tmux_socket_name=?,
+		created_at=?, last_accessed=?, parent_session_id=?, is_conductor=?, no_transition_notify=?,
+		worktree_path=?, worktree_repo=?, worktree_branch=?, account=?, archived_at=?,
+		tool_data=?, title_locked=?, auto_name=?, auto_name_description=?, pin=? WHERE id=?`
+	if !exists {
+		query = `INSERT INTO instances (title, project_path, group_path, sort_order,
+			command, wrapper, tool, status, tmux_session, tmux_socket_name,
+			created_at, last_accessed, parent_session_id, is_conductor, no_transition_notify,
+			worktree_path, worktree_repo, worktree_branch, account, archived_at,
+			tool_data, title_locked, auto_name, auto_name_description, pin, id)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+	}
+	_, err := conn.ExecContext(ctx, query, args...)
+	return err
+}

--- a/internal/statedb/instance_snapshot_test.go
+++ b/internal/statedb/instance_snapshot_test.go
@@ -1,0 +1,102 @@
+package statedb
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceSnapshotsPreserveEveryPersistedColumn(t *testing.T) {
+	rowType := reflect.TypeOf(InstanceRow{})
+	for field := 0; field < rowType.NumField(); field++ {
+		name := rowType.Field(field).Name
+		if name == "ID" || name == "ToolData" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newTestDB(t)
+			require.NoError(t, db.SaveInstance(&InstanceRow{ID: "shared", Title: "original", CreatedAt: time.Unix(100, 0)}))
+			rows, err := db.LoadInstances()
+			require.NoError(t, err)
+			base := rows[0]
+			other, desired := CloneInstanceRow(base), CloneInstanceRow(base)
+			value := reflect.ValueOf(other).Elem().Field(field)
+			switch value.Kind() {
+			case reflect.String:
+				value.SetString("other writer")
+			case reflect.Bool:
+				value.SetBool(true)
+			case reflect.Int:
+				value.SetInt(42)
+			case reflect.Struct:
+				value.Set(reflect.ValueOf(time.Unix(12345, 0)))
+			default:
+				t.Fatalf("add a persisted-column fixture for %s", name)
+			}
+			_, err = db.MergeInstanceSnapshots([]InstanceSnapshot{{Original: base, Stored: base, Desired: other}}, nil)
+			require.NoError(t, err)
+			if name == "Title" {
+				desired.Status = "running"
+			} else {
+				desired.Title = "alice"
+			}
+			_, err = db.MergeInstanceSnapshots([]InstanceSnapshot{{Original: base, Stored: base, Desired: desired}}, nil)
+			require.NoError(t, err)
+			rows, err = db.LoadInstances()
+			require.NoError(t, err)
+			got := reflect.ValueOf(rows[0]).Elem().Field(field).Interface()
+			if timestamp, ok := value.Interface().(time.Time); ok {
+				require.Equal(t, timestamp.Unix(), got.(time.Time).Unix())
+			} else {
+				require.Equal(t, value.Interface(), got)
+			}
+		})
+	}
+}
+
+func TestInstanceSnapshotsToolDataAndAcknowledgement(t *testing.T) {
+	db := newTestDB(t)
+	require.NoError(t, db.SaveInstance(&InstanceRow{ID: "shared", Title: "original", ToolData: json.RawMessage(`{"notes":"old","custom":{"counter":9007199254740993},"codex_session_id":"kept"}`)}))
+	rows, err := db.LoadInstances()
+	require.NoError(t, err)
+	base := rows[0]
+	other, desired := CloneInstanceRow(base), CloneInstanceRow(base)
+	other.ToolData = json.RawMessage(`{"notes":"bob","color":"203","custom":{"counter":9007199254740993},"codex_session_id":"kept"}`)
+	_, err = db.MergeInstanceSnapshots([]InstanceSnapshot{{Original: base, Stored: base, Desired: other}}, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.SetAcknowledged("shared", true))
+	desired.Title = "alice"
+	committed, err := db.MergeInstanceSnapshots([]InstanceSnapshot{{Original: base, Stored: base, Desired: desired}}, nil)
+	require.NoError(t, err)
+	require.JSONEq(t, string(other.ToolData), string(committed[0].ToolData))
+	var ack int
+	require.NoError(t, db.DB().QueryRow("SELECT acknowledged FROM instances WHERE id='shared'").Scan(&ack))
+	require.Equal(t, 1, ack, "saving metadata must not reset a targeted acknowledgement")
+	desired.ToolData = json.RawMessage(`{"notes":"alice"}`)
+	_, err = db.MergeInstanceSnapshots([]InstanceSnapshot{{Original: base, Stored: base, Desired: desired}}, nil)
+	require.ErrorContains(t, err, "tool_data.notes conflict")
+	// Copy ownership includes the raw JSON buffer.
+	copy := CloneInstanceRow(base)
+	copy.ToolData[0] = '['
+	require.Equal(t, byte('{'), base.ToolData[0])
+}
+
+func TestInstanceSnapshotsRejectCorruptJSONAndIDCollision(t *testing.T) {
+	db := newTestDB(t)
+	base := &InstanceRow{ID: "shared", Title: "original", ToolData: json.RawMessage(`{}`)}
+	require.NoError(t, db.SaveInstance(base))
+	_, err := db.MergeInstanceSnapshots([]InstanceSnapshot{{Desired: CloneInstanceRow(base)}}, nil)
+	require.ErrorContains(t, err, "insertion conflict")
+	_, err = db.DB().Exec("UPDATE instances SET tool_data = 'corrupt' WHERE id='shared'")
+	require.NoError(t, err)
+	desired := CloneInstanceRow(base)
+	desired.Title = "must not save"
+	_, err = db.MergeInstanceSnapshots([]InstanceSnapshot{{Original: base, Stored: base, Desired: desired}}, nil)
+	require.ErrorContains(t, err, "invalid instance tool_data")
+	var title string
+	require.NoError(t, db.DB().QueryRow("SELECT title FROM instances WHERE id='shared'").Scan(&title))
+	require.Equal(t, "original", title)
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1036,7 +1036,11 @@ func (s *StateDB) ClearAllInstances() error {
 
 // LoadInstances returns all instances ordered by sort_order.
 func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
-	rows, err := s.db.Query(`
+	return loadInstances(s.db.Query)
+}
+
+func loadInstances(query func(string, ...any) (*sql.Rows, error)) ([]*InstanceRow, error) {
+	rows, err := query(`
 		SELECT id, title, project_path, group_path, sort_order,
 			command, wrapper, tool, status, tmux_session, tmux_socket_name,
 			created_at, last_accessed,
@@ -1152,6 +1156,17 @@ func (s *StateDB) InstanceExists(id string) (bool, error) {
 
 // --- Group CRUD ---
 
+const upsertGroupSQL = `
+		INSERT INTO groups (path, name, expanded, sort_order, default_path, max_concurrent)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(path) DO UPDATE SET
+			name = excluded.name,
+			expanded = excluded.expanded,
+			sort_order = excluded.sort_order,
+			default_path = excluded.default_path,
+			max_concurrent = excluded.max_concurrent
+	`
+
 // SaveGroups upserts the given groups in a single transaction. It is ADDITIVE:
 // groups absent from the slice are left untouched, never deleted.
 //
@@ -1169,16 +1184,7 @@ func (s *StateDB) SaveGroups(groups []*GroupRow) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	stmt, err := tx.Prepare(`
-		INSERT INTO groups (path, name, expanded, sort_order, default_path, max_concurrent)
-		VALUES (?, ?, ?, ?, ?, ?)
-		ON CONFLICT(path) DO UPDATE SET
-			name = excluded.name,
-			expanded = excluded.expanded,
-			sort_order = excluded.sort_order,
-			default_path = excluded.default_path,
-			max_concurrent = excluded.max_concurrent
-	`)
+	stmt, err := tx.Prepare(upsertGroupSQL)
 	if err != nil {
 		return err
 	}
@@ -1199,7 +1205,11 @@ func (s *StateDB) SaveGroups(groups []*GroupRow) error {
 
 // LoadGroups returns all groups ordered by sort_order.
 func (s *StateDB) LoadGroups() ([]*GroupRow, error) {
-	rows, err := s.db.Query(`
+	return loadGroups(s.db.Query)
+}
+
+func loadGroups(query func(string, ...any) (*sql.Rows, error)) ([]*GroupRow, error) {
+	rows, err := query(`
 		SELECT path, name, expanded, sort_order, default_path, max_concurrent
 		FROM groups ORDER BY sort_order
 	`)

--- a/internal/tmux/terminal_features_slot_test.go
+++ b/internal/tmux/terminal_features_slot_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,8 +108,13 @@ func TestTerminalFeatures_StaleAbsenceOnReplacementServer(t *testing.T) {
 	socket, session := startPrivateTmuxServer(t)
 	before := readTerminalFeatures(socket)
 	require.True(t, before.known)
+	firstPID := tmuxServerPID(t, socket)
 	require.NoError(t, tmuxExec(socket, "kill-server").Run())
+	require.Eventually(t, func() bool {
+		return !readTerminalFeatures(socket).known
+	}, 5*time.Second, 20*time.Millisecond, "old server did not go away")
 	startPrivateTmuxSession(t, socket, session)
+	require.NotEqual(t, firstPID, tmuxServerPID(t, socket), "must be a different tmux server")
 	for range 2 {
 		ensureTerminalFeature(socket, before)
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10204,9 +10204,7 @@ func (h *Home) confirmAction() tea.Cmd {
 	case ConfirmDeleteGroup:
 		groupPath := h.confirmDialog.GetTargetID()
 		h.groupTree.DeleteGroup(groupPath)
-		// SaveGroups is additive (never prunes), so the removed group's rows must
-		// be deleted explicitly or it would resurrect on the next reload.
-		h.deleteGroupRows(groupPath)
+
 		h.instancesMu.Lock()
 		h.instances = h.groupTree.GetAllInstances()
 		h.instancesMu.Unlock()
@@ -11340,10 +11338,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.pendingGroupOps = append(h.pendingGroupOps, pendingGroupOp{
 					kind: groupOpRename, oldPath: oldPath, name: name,
 				})
-				// A rename re-paths the group and its subgroups; the old path rows
-				// must be deleted explicitly (additive SaveGroups won't prune them)
-				// or the group reappears under its old name on the next reload.
-				h.deleteGroupRows(oldPath)
+
 				h.instancesMu.Lock()
 				h.instances = h.groupTree.GetAllInstances()
 				h.instancesMu.Unlock()
@@ -11751,19 +11746,6 @@ func (h *Home) adoptRestartRecord(sessionID string) {
 	if h.storageWatcher != nil {
 		// Our own bump should not make the watcher schedule a reload either.
 		h.storageWatcher.NotifySave()
-	}
-}
-
-// deleteGroupRows removes a group and its descendants from the groups table.
-// SaveGroups is additive (upsert, never prune), so an intentional removal —
-// delete or the old path of a rename/move — must be persisted explicitly here,
-// otherwise the stale rows resurrect the group on the next reload.
-func (h *Home) deleteGroupRows(path string) {
-	if h.storage == nil || path == "" {
-		return
-	}
-	if err := h.storage.DeleteGroupSubtree(path); err != nil {
-		uiLog.Warn("delete_group_rows_failed", slog.String("path", path), slog.String("error", err.Error()))
 	}
 }
 

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -562,14 +562,6 @@ func (m *WebMutator) RenameGroup(groupPath, newName string) error {
 	}
 	defer storage.Close()
 
-	// SaveGroups is additive (never prunes), so the old path's rows must be
-	// deleted explicitly before the save re-adds the renamed paths — otherwise
-	// the group reappears under its old name on the next reload. Done before the
-	// save so a no-op rename (same name) is correctly re-added.
-	if err := storage.DeleteGroupSubtree(groupPath); err != nil {
-		return fmt.Errorf("delete old group rows: %w", err)
-	}
-
 	m.h.instancesMu.RLock()
 	instances := make([]*session.Instance, len(m.h.instances))
 	copy(instances, m.h.instances)
@@ -729,12 +721,6 @@ func (m *WebMutator) DeleteGroup(groupPath string) error {
 		return fmt.Errorf("open storage: %w", err)
 	}
 	defer storage.Close()
-
-	// SaveGroups is additive (never prunes), so the deleted group's rows must be
-	// removed explicitly or the group resurrects on the next reload.
-	if err := storage.DeleteGroupSubtree(groupPath); err != nil {
-		return fmt.Errorf("delete group rows: %w", err)
-	}
 
 	m.h.instancesMu.RLock()
 	instances := make([]*session.Instance, len(m.h.instances))


### PR DESCRIPTION
## What problem does this solve?

People sharing a Mac through separate SSH logins need sessions to retain their selected account slot, and simultaneous CLI/TUI saves must preserve each other's session and group changes. A stale save could overwrite disjoint edits, recreate deleted state, or conflict with its own previous save.

## Why this change

Persist and validate the session's account slot across launch, restart, fork and nested commands. Worktree cleanup fails closed on incomplete profile inspection and rechecks every profile after confirmation. Account validation follows final tool/passthrough resolution before worktree creation, setup scripts, loadout or registration, including DeepSeek mappings; restarted interactive shells retain the selected slot and remote Claude passthrough uses the remote home.

Reserve the SQLite writer before authoritative reads, compare every persisted session/group field against the caller's immutable snapshot, and commit session changes with group rename/deletion. Related tables load within one read snapshot. Known legacy default-group paths migrate with member rows in that same transaction. Copied TUI payloads advance baselines from submitted values and acknowledge deletions once; foreign databases cannot consume those deletions. Unchanged fallback groups cannot recreate obsolete empty groups.

The account/storage diff includes account/worktree behavior, the shared persistence boundary, and deterministic regressions. Existing fixture adjustments retain actual snapshots or isolate each test's database and account configuration; assertions remain intact.

## User impact

Saved account slots survive caller environment changes, and unknown or tool-incompatible slots fail explicitly. Disjoint edits survive, identical concurrent edits converge, and divergent same-field edits return a conflict requiring reload/retry. Rename/delete rejects previously unseen sessions or subgroups instead of sweeping them. Nested ToolData objects remain one conflict field per top-level key.

## Evidence

**Candidate `8194350304fd85a1540f0a277169e17300f9dc29`, tree `456f6b3ac822010dd4787bb8ae69b01cfa0fa85b`, includes actual main `461e094e`. Fresh published CI is pending. The later main `b06ad50` changes the worker prompt and its Python text assertions; its source-only composition has no overlapping paths or Go/runtime changes.**

- Full contributor gate on account/worktree correction `33ef1503`: **16 PASS, 0 FAIL, 0 WARN, 0 skipped**. Uncached full Go suite passed with 57 passing packages and three packages without tests. All **60 required controls** explicitly ran and passed, including the three isolation sentinels, storage concurrency/conflict controls and 14 actual worktree-account boundary cases. The revert check produced meaningful runtime failures. Full JSON SHA-256: `529844a451d539fc3ca6a483140a986a7273799357a95b0d88f17525e24d5063`.
- The account boundary baseline used unchanged `a0761f03` production: eight invalid flag/environment/tool/passthrough cases created branches/worktrees and ran setup before rejection; all eight failed the new assertions. Six valid, precedence and default-shell controls passed. Corrected focused race checks passed 44 test/subtest events with no failures. One older remote-launch child retains its documented skip because the local launch command has no remote target; none of the new boundary cases skips.
- Composing `33ef1503` with main `461e094e` produced `52188fe4` without overlapping files or manual resolutions. Independent source review passed. Its first bounded race run recorded **83 required passes, one terminal-fixture failure and one bootstrap-sentinel skip**. This unsuccessful receipt is preserved, not relabeled. The bootstrap sentinel deliberately skips under race instrumentation.
- The terminal failure occurred while restarting a private tmux server, before the terminal-entry insertion assertions. One matched 20-iteration run on main `461e094e` and one on `52188fe4` each reproduced three identical startup failures and 17 passes. This identified the existing fixture teardown race. Separate test-only commit `81943503` adds a bounded old-server wait and verifies a different replacement PID, preserving the original assertions. Independent source review passed. The corrected failing control then passed **20/20** under race instrumentation, and all **24 terminal-feature controls** ran and passed under race instrumentation with zero skips/failures.
- The mandatory bootstrap runtime sentinel ran separately without race instrumentation: its parent and both internal/tmux and internal/session children explicitly ran and passed. The remaining isolation controls passed under race instrumentation. The final control map covers **85 required controls in their valid execution modes**, retaining the original race failure/skip and the separate passing receipts. Corrected terminal JSON SHA-256: `257ba561046c8aea5a89d7ede4733add470f1b6c97cce018b36ede67454c442d`.
- These are scoped cumulative results: the full suite ran on `33ef1503`; the combined race run and bootstrap ran on `52188fe4`; the six-line test-only correction and targeted terminal checks ran on `81943503`. **No full-suite run on `81943503` is claimed.** Fresh GitHub checks on the PR merge tree are required before merge. Runtime used an isolated container with init, four CPUs, dropped DAC_OVERRIDE, private HOME/XDG and short temporary paths, GOMAXPROCS=4, serial packages and CI performance multiplier 2.0.
- Earlier atomic-storage behavior controls and timing remain scoped to their original candidates. Two actual production CLI processes share one sandbox HOME/database, with a bounded substituted transport barrier and independent database readback for disjoint edits, competing session IDs, deletion, addition and group metadata. This proves process/persistence behavior; real network SSH acceptance is outside this PR's scope. Shared transaction boundaries and regression coverage account for the overall diff size.
- The #2074 title callback remains after the storage lock is released and receives actual committed rows. Submitted session/group receipts and acknowledgements remain under the lock. The Pi transcript parent-chain finding belongs to the already-landed #2083 change and is handled separately; this PR adds no Pi repair.
- The final all-profile ownership scan narrows the confirmation interval but does not eliminate registration after that scan without a shared registration/removal lock. Real local WorktreePath ownership remains protected even if the owning session executes remotely.

Directional timing, median of three runs with ten iterations, comparing original `90c6de00` to reviewed `7e03a0e0`:

| Operation | Before | Reviewed candidate |
| --- | ---: | ---: |
| Load 100 rows | 0.913 ms | 2.434 ms |
| Save 100 rows | 4.248 ms | 4.560 ms |
| Load 1000 rows | 8.536 ms | 15.150 ms |
| Save 1000 rows | 28.259 ms | 41.212 ms |

Owned snapshots increase allocated bytes for 1000 rows: load approximately 8.0 to 15.6 MB, save 15.4 to 29.2 MB. Other validation was running in the container, so these measurements show overhead rather than a latency guarantee.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-6-astra

## What actually bothered you

The user requested: “Two SSH logins on one deck (same macOS user, default profile): both see the same session list and status within one refresh; concurrent mutations from two TUIs or CLIs never lose writes or corrupt the state DB; each person's launch lands on their own Claude config_dir via an env var (e.g. AGENTDECK_ACCOUNT) set by their login shell, with --account still overriding; list/show/TUI display the account slot per session; worktree cleanup never removes a worktree belonging to another live session; doctor warns when two slots point at one config_dir.”

Their requested tests were: “two concurrent CLI processes mutating state under one HOME; env-var slot selection; owner column present in list --json.” This PR addresses the account and persistence portion of that requirement; the evidence above defines the verified scope. It does not claim the entire shared-SSH brief is complete, or that cleanup is atomic with registrations after the final ownership scan.

## Checklist

- [x] Targeted diff: shared account/session ownership and concurrent persistence
- [x] Tests added or updated for new behavior
- [x] Scoped full and combined acceptance results recorded with exact candidates
- [ ] Fresh exact-head published CI passes
- [x] Before/after timing evidence included
- [x] CHANGELOG.md and dependency files untouched
- [x] AI assistance disclosed with reproducible evidence
- [x] Original account/worktree author history retained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-session account selection with validation and tool-specific configuration support, including DeepSeek.
  - Improved response detection for Pi sessions and handling of closed terminals.
  - Worktree cleanup now checks session ownership across all local profiles.

- **Bug Fixes**
  - Group deletions and renames now persist reliably without leaving stale group data.
  - Concurrent edits preserve non-conflicting changes and report conflicts for overlapping updates.
  - Group metadata and session paths remain consistent after saves, moves, and forks.
  - Invalid account configurations are rejected before sessions or loadouts are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->
