### PR TITLE
fix(session): verify Claude/Codex completion after pane loss

### DIFF
--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -202,7 +202,11 @@ func handleCodexNotify() {
 		sessionID = strings.TrimSpace(os.Getenv("CODEX_SESSION_ID"))
 	}
 
-	writeCodexHookStatus(instanceID, status, sessionID, event, turnID)
+	var completionPayload struct {
+		LastAssistant string `json:"last-assistant-message"`
+	}
+	_ = json.Unmarshal(data, &completionPayload)
+	writeCodexHookStatus(instanceID, status, sessionID, event, turnID, completionPayload.LastAssistant)
 }
 
 func codexTurnEdge(event string) (started, completed bool) {
@@ -212,6 +216,11 @@ func codexTurnEdge(event string) (started, completed bool) {
 	}
 	return strings.Contains(canon, "start"), strings.Contains(canon, "complete") ||
 		strings.Contains(canon, "fail") || strings.Contains(canon, "abort") || strings.Contains(canon, "cancel")
+}
+
+func codexSuccessfulCompletion(event string) bool {
+	canon := strings.NewReplacer(".", "/", "-", "/", "_", "/").Replace(strings.ToLower(strings.TrimSpace(event)))
+	return canon == "agent/turn/complete" || canon == "agent/turn/completed" || canon == "turn/complete" || canon == "turn/completed"
 }
 
 // writeCodexHookStatus retains both edges of the current turn under a file
@@ -253,9 +262,6 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 		_ = json.Unmarshal(data, &prior)
 	}
 	sessionID = strings.TrimSpace(sessionID)
-	if sessionID != "" {
-		session.WriteHookSessionAnchor(instanceID, sessionID)
-	}
 	evidenceSessionID := sessionID
 	if evidenceSessionID == "" {
 		evidenceSessionID = session.ReadHookSessionAnchor(instanceID)
@@ -266,10 +272,14 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 		turnID = strings.TrimSpace(turnIDs[0])
 	}
 	if started {
+		prior.CodexStartObserved = true
 		prior.CodexCompletedGeneration = ""
 		prior.CodexCompletedSessionID = ""
 		if evidenceSessionID != "" && turnID != "" {
 			prior.CodexStartedGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
+			if prior.CodexStartedGeneration != prior.CodexFailedGeneration {
+				prior.CodexFailedGeneration = ""
+			}
 			prior.CodexStartedSessionID = evidenceSessionID
 		} else {
 			prior.CodexStartedGeneration = ""
@@ -280,20 +290,36 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 	if evidenceSessionID != "" && turnID != "" {
 		completionGeneration = fmt.Sprintf("%s:%s", evidenceSessionID, turnID)
 	}
-	// Codex's legacy notify contract emits only agent-turn-complete. A complete
-	// thread/turn identity therefore supplies both sides of the generation
-	// proof; waiting must not depend on a start notification that never occurs.
-	if completed && completionGeneration != "" &&
-		(prior.Status != "running" || prior.CodexStartedGeneration == "" || completionGeneration == prior.CodexStartedGeneration) {
-		prior.CodexStartedGeneration = completionGeneration
-		prior.CodexStartedSessionID = evidenceSessionID
+	// An observed start remains authoritative after failure/cancellation too.
+	// Legacy notify supplies completion only, so it may advance when no start
+	// was observed. Never infer positive proof from inherited turn fields.
+	if completed && completionGeneration != "" && prior.CodexStartObserved &&
+		prior.CodexStartedGeneration != completionGeneration {
+		return
+	}
+	if completed && completionGeneration != "" && prior.CodexFailedGeneration == completionGeneration {
+		return
+	}
+	if completed {
+		if !codexSuccessfulCompletion(event) && completionGeneration != "" {
+			prior.CodexFailedGeneration = completionGeneration
+		}
 		prior.CodexCompletedGeneration = completionGeneration
 		prior.CodexCompletedSessionID = evidenceSessionID
+		if !prior.CodexStartObserved {
+			prior.CodexStartedGeneration = completionGeneration
+			prior.CodexStartedSessionID = evidenceSessionID
+		}
 	}
 	prior.Status, prior.SessionID, prior.Event = status, sessionID, event
 	prior.Timestamp = time.Now().Unix()
 	prior.DoneStatus, prior.DoneSummary, prior.TranscriptPath, prior.Cwd = "", "", "", ""
-	writeHookStatusFile(instanceID, prior, false)
+	if len(turnIDs) > 1 && sessionID != "" && completionGeneration != "" && codexSuccessfulCompletion(event) {
+		if signal, ok := session.ScanDoneSentinel(turnIDs[1]); ok {
+			prior.DoneStatus, prior.DoneSummary = signal.Status, signal.Summary
+		}
+	}
+	writeHookStatusFile(instanceID, prior, true)
 }
 
 func handleCodexHooks(args []string) {

--- a/cmd/agent-deck/codex_hooks_cmd.go
+++ b/cmd/agent-deck/codex_hooks_cmd.go
@@ -301,8 +301,14 @@ func writeCodexHookStatus(instanceID, status, sessionID, event string, turnIDs .
 		return
 	}
 	if completed {
-		if !codexSuccessfulCompletion(event) && completionGeneration != "" {
-			prior.CodexFailedGeneration = completionGeneration
+		if !codexSuccessfulCompletion(event) {
+			failedGeneration := completionGeneration
+			if failedGeneration == "" {
+				failedGeneration = prior.CodexStartedGeneration
+			}
+			if failedGeneration != "" {
+				prior.CodexFailedGeneration = failedGeneration
+			}
 		}
 		prior.CodexCompletedGeneration = completionGeneration
 		prior.CodexCompletedSessionID = evidenceSessionID

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -99,9 +99,10 @@ type hookStatusFile struct {
 }
 
 type hookGenerationControl struct {
-	Generation            string `json:"generation"`
-	NextSequence          uint64 `json:"next_sequence"`
-	InitialMessagePending bool   `json:"initial_message_pending,omitempty"`
+	LaunchAt              time.Time `json:"launch_at,omitempty"`
+	Generation            string    `json:"generation"`
+	NextSequence          uint64    `json:"next_sequence"`
+	InitialMessagePending bool      `json:"initial_message_pending,omitempty"`
 }
 
 // normalizeHookEventKey folds hook event names from Claude (PascalCase), Cursor

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -68,6 +68,8 @@ type hookStatusFile struct {
 	SessionID                string `json:"session_id,omitempty"`
 	Event                    string `json:"event"`
 	Timestamp                int64  `json:"ts"`
+	CodexFailedGeneration    string `json:"codex_failed_generation,omitempty"`
+	CodexStartObserved       bool   `json:"codex_start_observed,omitempty"`
 	CodexStartedGeneration   string `json:"codex_started_generation,omitempty"`
 	CodexCompletedGeneration string `json:"codex_completed_generation,omitempty"`
 	CodexStartedSessionID    string `json:"codex_started_session_id,omitempty"`
@@ -79,8 +81,9 @@ type hookStatusFile struct {
 	// detected on the Stop edge (issue #1186). omitempty so ordinary Stops
 	// (no sentinel) leave the fields absent, which the daemon reads as
 	// "no finished event to emit."
-	DoneStatus  string `json:"done_status,omitempty"`
-	DoneSummary string `json:"done_summary,omitempty"`
+	DoneAt      time.Time `json:"done_at,omitempty"`
+	DoneStatus  string    `json:"done_status,omitempty"`
+	DoneSummary string    `json:"done_summary,omitempty"`
 	// TranscriptPath is persisted ONLY when the Stop-edge sentinel scan was
 	// inconclusive because the turn's assistant record had not flushed yet
 	// (issue #1186 flush race). The daemon re-scans this path on its poll
@@ -373,6 +376,7 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 	if scan.signal != nil {
 		statusFile.DoneStatus = scan.signal.Status
 		statusFile.DoneSummary = scan.signal.Summary
+		statusFile.DoneAt = scan.signal.Timestamp
 	}
 	statusFile.TranscriptPath = scan.pendingTranscript
 	writeHookStatusFile(instanceID, statusFile, true)
@@ -381,6 +385,11 @@ func writeHookStatusWithScan(instanceID, status, sessionID, event, cwd string, s
 func writeHookStatusFile(instanceID string, statusFile hookStatusFile, mutateAnchor bool) bool {
 	hooksDir := getHooksDir()
 	generation := strings.TrimSpace(os.Getenv("AGENTDECK_HOOK_GENERATION"))
+	if generation == "" {
+		if _, err := os.Lstat(filepath.Join(hooksDir, filepath.Base(instanceID)+".generation.json")); err == nil || !os.IsNotExist(err) {
+			return false
+		}
+	}
 	if generation != "" {
 		lockPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".lock")
 		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)

--- a/cmd/agent-deck/issue2091_codex_done_test.go
+++ b/cmd/agent-deck/issue2091_codex_done_test.go
@@ -117,7 +117,7 @@ func TestIssue2091DelayedCodexDoneCannotReplaceNewTurn(t *testing.T) {
 }
 
 func TestIssue2091CodexFailureAndMissingTurnVeto(t *testing.T) {
-	for _, terminal := range []string{"turn-failed", "turn-cancelled", "metadata-after-failure", "unknown-failure-after-failure", "duplicate-start-after-failure", "missing-turn"} {
+	for _, terminal := range []string{"turn-failed", "turn-cancelled", "metadata-after-failure", "unknown-failure-after-failure", "first-unknown-failure", "duplicate-start-after-failure", "missing-turn"} {
 		t.Run(terminal, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir())
 			t.Setenv("XDG_DATA_HOME", "")
@@ -128,12 +128,14 @@ func TestIssue2091CodexFailureAndMissingTurnVeto(t *testing.T) {
 			writeCodexHookStatus(id, "waiting", "thread", "agent-turn-complete", "A", "===AGENTDECK_DONE=== status=ok summary=A")
 			if terminal != "missing-turn" {
 				writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "B")
-				if terminal == "metadata-after-failure" || terminal == "unknown-failure-after-failure" || terminal == "duplicate-start-after-failure" {
-					writeCodexHookStatus(id, "waiting", "thread", "turn-failed", "B")
+				if terminal == "metadata-after-failure" || terminal == "unknown-failure-after-failure" || terminal == "first-unknown-failure" || terminal == "duplicate-start-after-failure" {
+					if terminal != "first-unknown-failure" {
+						writeCodexHookStatus(id, "waiting", "thread", "turn-failed", "B")
+					}
 					switch terminal {
 					case "metadata-after-failure":
 						writeCodexHookStatus(id, "waiting", "thread", "session.configured")
-					case "unknown-failure-after-failure":
+					case "unknown-failure-after-failure", "first-unknown-failure":
 						writeCodexHookStatus(id, "waiting", "thread", "turn-failed", "")
 					case "duplicate-start-after-failure":
 						writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "B")
@@ -143,7 +145,7 @@ func TestIssue2091CodexFailureAndMissingTurnVeto(t *testing.T) {
 				}
 			}
 			turn := "A"
-			if terminal == "metadata-after-failure" || terminal == "unknown-failure-after-failure" || terminal == "duplicate-start-after-failure" {
+			if terminal == "metadata-after-failure" || terminal == "unknown-failure-after-failure" || terminal == "first-unknown-failure" || terminal == "duplicate-start-after-failure" {
 				turn = "B"
 			}
 			if terminal == "missing-turn" {
@@ -162,5 +164,28 @@ func TestIssue2091CodexFailureAndMissingTurnVeto(t *testing.T) {
 				t.Fatalf("ambiguous/contradicted completion became DONE: %+v", got)
 			}
 		})
+	}
+}
+
+func TestIssue2091NewTurnRecoversFromUnidentifiedFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "")
+	id := "issue2091-new-valid-turn"
+	writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "B")
+	writeCodexHookStatus(id, "waiting", "thread", "turn-failed", "")
+	writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "C")
+	writeCodexHookStatus(id, "waiting", "thread", "agent-turn-complete", "C", "===AGENTDECK_DONE=== status=ok summary=C")
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), id+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got hookStatusFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.DoneStatus != "ok" || got.CodexCompletedGeneration != "thread:C" {
+		t.Fatalf("new valid turn did not recover: %+v", got)
 	}
 }

--- a/cmd/agent-deck/issue2091_codex_done_test.go
+++ b/cmd/agent-deck/issue2091_codex_done_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Exercise the actual notify entrypoint, not synthetic DONE fields written by
+// the test. Only the successful assistant completion payload can carry proof.
+func TestIssue2091CodexNotifyPersistsExplicitDone(t *testing.T) {
+	for _, tc := range []struct {
+		name, event, assistant, input, want string
+	}{
+		{"explicit assistant done", "agent-turn-complete", "===AGENTDECK_DONE=== status=ok summary=finished", "", "ok"},
+		{"ordinary turn", "agent-turn-complete", "What next?", "", ""},
+		{"input is not assistant proof", "agent-turn-complete", "Working", "===AGENTDECK_DONE=== status=ok summary=spoof", ""},
+		{"failed turn veto", "turn-failed", "===AGENTDECK_DONE=== status=ok summary=stale", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			t.Setenv("AGENTDECK_INSTANCE_ID", "issue2091-notify")
+			t.Setenv("AGENTDECK_HOOK_GENERATION", "")
+			payload, err := json.Marshal(map[string]any{
+				"type": tc.event, "thread-id": "thread2091", "turn-id": "turn2091",
+				"last-assistant-message": tc.assistant, "input-messages": []string{tc.input},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			previous := os.Args
+			os.Args = []string{"agent-deck", "codex-notify", string(payload)}
+			t.Cleanup(func() { os.Args = previous })
+			handleCodexNotify()
+			data, err := os.ReadFile(filepath.Join(getHooksDir(), "issue2091-notify.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var record hookStatusFile
+			if err := json.Unmarshal(data, &record); err != nil {
+				t.Fatal(err)
+			}
+			if record.DoneStatus != tc.want {
+				t.Fatalf("actual notify DONE = %q, want %q", record.DoneStatus, tc.want)
+			}
+		})
+	}
+}
+
+func TestIssue2091CodexProducerRejectsPriorLaunch(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "current")
+	id := "issue2091-bound"
+	if err := os.MkdirAll(getHooksDir(), 0700); err != nil {
+		t.Fatal(err)
+	}
+	control := filepath.Join(getHooksDir(), id+".generation.json")
+	if err := os.WriteFile(control, []byte(`{"generation":"current","next_sequence":0}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeCodexHookStatus(id, "waiting", "current-thread", "agent-turn-complete", "turn", "===AGENTDECK_DONE=== status=ok summary=done")
+	path := filepath.Join(getHooksDir(), id+".json")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record hookStatusFile
+	if err := json.Unmarshal(before, &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.HookGeneration != "current" || record.Sequence != 1 || record.DoneStatus != "ok" {
+		t.Fatalf("producer did not bind evidence: %+v", record)
+	}
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "old")
+	writeCodexHookStatus(id, "waiting", "old-thread", "agent-turn-complete", "old-turn", "===AGENTDECK_DONE=== status=ok summary=old")
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("old launch replaced current completion")
+	}
+	if got := session.ReadHookSessionAnchor(id); got != "current-thread" {
+		t.Fatalf("old launch changed current anchor to %q", got)
+	}
+}
+
+func TestIssue2091DelayedCodexDoneCannotReplaceNewTurn(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("AGENTDECK_HOOK_GENERATION", "")
+	id := "issue2091-turn-order"
+	writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "A")
+	writeCodexHookStatus(id, "waiting", "thread", "agent-turn-complete", "A", "===AGENTDECK_DONE=== status=ok summary=A")
+	writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "B")
+	path := filepath.Join(getHooksDir(), id+".json")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCodexHookStatus(id, "waiting", "thread", "agent-turn-complete", "A", "===AGENTDECK_DONE=== status=ok summary=late A")
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("late A replaced running B")
+	}
+}
+
+func TestIssue2091CodexFailureAndMissingTurnVeto(t *testing.T) {
+	for _, terminal := range []string{"turn-failed", "turn-cancelled", "metadata-after-failure", "unknown-failure-after-failure", "duplicate-start-after-failure", "missing-turn"} {
+		t.Run(terminal, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_DATA_HOME", "")
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("AGENTDECK_HOOK_GENERATION", "")
+			id := "issue2091-terminal-order"
+			writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "A")
+			writeCodexHookStatus(id, "waiting", "thread", "agent-turn-complete", "A", "===AGENTDECK_DONE=== status=ok summary=A")
+			if terminal != "missing-turn" {
+				writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "B")
+				if terminal == "metadata-after-failure" || terminal == "unknown-failure-after-failure" || terminal == "duplicate-start-after-failure" {
+					writeCodexHookStatus(id, "waiting", "thread", "turn-failed", "B")
+					switch terminal {
+					case "metadata-after-failure":
+						writeCodexHookStatus(id, "waiting", "thread", "session.configured")
+					case "unknown-failure-after-failure":
+						writeCodexHookStatus(id, "waiting", "thread", "turn-failed", "")
+					case "duplicate-start-after-failure":
+						writeCodexHookStatus(id, "running", "thread", "agent-turn-start", "B")
+					}
+				} else {
+					writeCodexHookStatus(id, "waiting", "thread", terminal, "B")
+				}
+			}
+			turn := "A"
+			if terminal == "metadata-after-failure" || terminal == "unknown-failure-after-failure" || terminal == "duplicate-start-after-failure" {
+				turn = "B"
+			}
+			if terminal == "missing-turn" {
+				turn = ""
+			}
+			writeCodexHookStatus(id, "waiting", "thread", "agent-turn-complete", turn, "===AGENTDECK_DONE=== status=ok summary=late")
+			data, err := os.ReadFile(filepath.Join(getHooksDir(), id+".json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got hookStatusFile
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.DoneStatus != "" {
+				t.Fatalf("ambiguous/contradicted completion became DONE: %+v", got)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -437,6 +437,16 @@ func main() {
 		case "hook-handler":
 			handleHookHandler()
 			return
+		case "completion-launch":
+			if len(args) != 3 {
+				fmt.Fprintln(os.Stderr, "invalid completion launch arguments")
+				os.Exit(1)
+			}
+			if err := session.RecordCompletionLaunch(args[1], args[2]); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			return
 		case "codex-notify":
 			handleCodexNotify()
 			return
@@ -1043,7 +1053,7 @@ var globalFlagSubcommands = map[string]bool{
 	"telegram-doctor": true, "watcher": true, "openclaw": true, "oc": true,
 	"remote": true, "worktree": true, "wt": true, "costs": true, "web": true,
 	"uninstall": true, "migrate-paths": true, "hook-handler": true,
-	"codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
+	"completion-launch": true, "codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
 	"hermes-hooks": true, "cursor-hooks": true, "deepseek": true, "notify-daemon": true,
 	"run-task": true, "inbox": true, "feedback": true, "creds-refresh": true, "telemetry": true,
 	"debug-dump": true, "version": true, "help": true,

--- a/docs/terminated-completion-activation.md
+++ b/docs/terminated-completion-activation.md
@@ -1,0 +1,54 @@
+# Terminated completion protocol activation
+
+This candidate adds opt-in recovery for vanished local Claude/Codex panes using
+current-launch completion evidence. It does not add a Pi producer. Default sandbox
+images do not contain the matching helper executable, so sandbox launches continue
+without this positive fallback.
+
+## Quiescent upgrade is required
+
+Before activation, stop every Deck controller that can acquire these locks:
+TUIs, watchers, one-shot CLI jobs, automation, and SSH launch paths sharing the
+same state/locks namespace. Upgrade all executable paths and prevent later use
+of legacy binaries. Agent processes and tmux sessions need not be killed.
+
+Activation is an operator declaration that this coordinated boundary has been
+established. Neither a file nor a process/version snapshot proves it. Invoking a
+legacy controller later invalidates the exclusion guarantee. No live migration
+or automatic activation is performed by this change.
+
+After completing that operation, the operator may create a regular private
+completion-protocol.json in the resolved Deck locks directory with:
+version: 1, quiescent_upgrade_declared: true, and locks_namespace equal to the
+canonical absolute path of that directory. These are JSON fields. An absent,
+invalid, unsupported, or mismatched declaration disables positive fallback.
+
+Before activation, an empty marker permits the existing terminated classification;
+an occupied or ambiguous marker defers classification. Positive completion fallback
+is disabled even if the marker is empty, since a legacy controller could still
+have a delayed unlink operation.
+
+## Ownership
+
+Upgraded controllers retain a permanent per-instance guard inode for the whole
+protected operation. Never delete or recreate guard files. Status uses nonblocking
+locking. Versioned marker ownership contains a PID and random nonce. Only proven
+ESRCH death is reclaimable under the guard after activation. Age, EPERM, malformed
+records, and unversioned legacy markers are not proof of death.
+
+Dead legacy markers require separately coordinated operator handling after
+quiescence. The original baseline control that expects transparent dead legacy
+recovery remains a failed unsupported case in the preserved baseline receipts.
+It is not presented as fixed.
+
+## Completion boundary
+
+The replacement command invokes the currently running local Deck executable before
+the agent. This stamps a one-shot precise boundary under hook writer locks. It does
+not reacquire the parent-held spawn marker. Missing/invalid boundary or helper
+failure cannot authorize completion. Old transcript sentinels remain invalid even
+when emitted after early restart invalidation but before actual replacement.
+
+The final status decision requires unique generation authority, matching durable
+sequence, correct conversation/turn evidence, current timestamps, and no contrary
+status. A missing tmux server is not completion proof.

--- a/internal/session/done_sentinel.go
+++ b/internal/session/done_sentinel.go
@@ -1,6 +1,9 @@
 package session
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 // DoneSentinelMarker is the token a worker prints to assert that it has
 // finished its assigned task. Issue #1186: the conductor previously had no
@@ -14,8 +17,10 @@ const DoneSentinelMarker = "===AGENTDECK_DONE==="
 
 // DoneSignal is the parsed payload of a completion sentinel.
 type DoneSignal struct {
-	Status  string // "ok" or "fail"
-	Summary string // free text to end of line; may be empty
+	// Timestamp is populated only from a transcript record, never a hook receipt.
+	Timestamp time.Time
+	Status    string // "ok" or "fail"
+	Summary   string // free text to end of line; may be empty
 }
 
 // ParseDoneSentinel parses a single line. It returns the signal and true only

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -18,9 +18,10 @@ import (
 )
 
 type hermesHookControl struct {
-	Generation            string `json:"generation"`
-	NextSequence          uint64 `json:"next_sequence"`
-	InitialMessagePending bool   `json:"initial_message_pending,omitempty"`
+	LaunchAt              time.Time `json:"launch_at,omitempty"`
+	Generation            string    `json:"generation"`
+	NextSequence          uint64    `json:"next_sequence"`
+	InitialMessagePending bool      `json:"initial_message_pending,omitempty"`
 }
 type hermesHookSeed struct {
 	Status                string `json:"status"`

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -108,6 +108,10 @@ func atomicHermesJSON(path string, value any) error {
 }
 
 func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string, error) {
+	return i.seedHookGeneration(status, pending)
+}
+
+func (i *Instance) seedHookGeneration(status string, pending bool) (string, error) {
 	if !hermesHookInstanceIDPattern.MatchString(i.ID) || strings.Contains(i.ID, "..") {
 		return "", fmt.Errorf("invalid instance id %q", i.ID)
 	}
@@ -143,6 +147,7 @@ func (i *Instance) seedHermesHookGeneration(status string, pending bool) (string
 	// temporarily override the restart baseline until fsnotify catches up.
 	i.mu.Lock()
 	i.HermesHookGeneration = generation
+	i.hookLaunchGeneration = generation
 	i.hookStatus = status
 	i.hookEvent = seed.Event
 	i.hookLastUpdate = now

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -134,6 +134,7 @@ func maskConsumedCodexCompletion(instanceID string, status *HookStatus) {
 
 // HookStatus holds the decoded status from a hook status file.
 type HookStatus struct {
+	TimestampKnown           bool      // true only when the durable producer supplied a positive timestamp
 	Status                   string    // running, idle, waiting, dead
 	SessionID                string    // Claude session ID
 	Event                    string    // Hook event name
@@ -147,8 +148,9 @@ type HookStatus struct {
 	codexCompletionConsumed  bool
 	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
-	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
-	DoneSummary string // free-text completion summary
+	DoneAt      time.Time // Timestamp of the sentinel-bearing transcript record.
+	DoneStatus  string    // "ok" or "fail" when a completion sentinel was seen
+	DoneSummary string    // free-text completion summary
 	// TranscriptPath is set when the Stop-edge sentinel scan was inconclusive
 	// because the turn's assistant record had not flushed yet (issue #1186
 	// flush race). The transition daemon re-scans this path on its poll loop.
@@ -485,20 +487,21 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			continue
 		}
 		var raw struct {
-			Status                   string `json:"status"`
-			SessionID                string `json:"session_id"`
-			Event                    string `json:"event"`
-			Timestamp                int64  `json:"ts"`
-			DoneStatus               string `json:"done_status"`
-			DoneSummary              string `json:"done_summary"`
-			TranscriptPath           string `json:"transcript_path"`
-			Cwd                      string `json:"cwd"`
-			CodexStartedGeneration   string `json:"codex_started_generation"`
-			CodexCompletedGeneration string `json:"codex_completed_generation"`
-			CodexStartedSessionID    string `json:"codex_started_session_id"`
-			CodexCompletedSessionID  string `json:"codex_completed_session_id"`
-			HookGeneration           string `json:"hook_generation"`
-			Sequence                 uint64 `json:"sequence"`
+			Status                   string    `json:"status"`
+			SessionID                string    `json:"session_id"`
+			Event                    string    `json:"event"`
+			Timestamp                int64     `json:"ts"`
+			DoneAt                   time.Time `json:"done_at"`
+			DoneStatus               string    `json:"done_status"`
+			DoneSummary              string    `json:"done_summary"`
+			TranscriptPath           string    `json:"transcript_path"`
+			Cwd                      string    `json:"cwd"`
+			CodexStartedGeneration   string    `json:"codex_started_generation"`
+			CodexCompletedGeneration string    `json:"codex_completed_generation"`
+			CodexStartedSessionID    string    `json:"codex_started_session_id"`
+			CodexCompletedSessionID  string    `json:"codex_completed_session_id"`
+			HookGeneration           string    `json:"hook_generation"`
+			Sequence                 uint64    `json:"sequence"`
 		}
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
@@ -511,6 +514,7 @@ func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir s
 			SessionID:                raw.SessionID,
 			Event:                    raw.Event,
 			UpdatedAt:                time.Unix(raw.Timestamp, 0),
+			DoneAt:                   raw.DoneAt,
 			DoneStatus:               raw.DoneStatus,
 			DoneSummary:              raw.DoneSummary,
 			TranscriptPath:           raw.TranscriptPath,
@@ -654,20 +658,21 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	}
 
 	var status struct {
-		Status                   string `json:"status"`
-		SessionID                string `json:"session_id"`
-		Event                    string `json:"event"`
-		Timestamp                int64  `json:"ts"`
-		DoneStatus               string `json:"done_status"`
-		DoneSummary              string `json:"done_summary"`
-		TranscriptPath           string `json:"transcript_path"`
-		Cwd                      string `json:"cwd"`
-		CodexStartedGeneration   string `json:"codex_started_generation"`
-		CodexCompletedGeneration string `json:"codex_completed_generation"`
-		CodexStartedSessionID    string `json:"codex_started_session_id"`
-		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
-		HookGeneration           string `json:"hook_generation"`
-		Sequence                 uint64 `json:"sequence"`
+		Status                   string    `json:"status"`
+		SessionID                string    `json:"session_id"`
+		Event                    string    `json:"event"`
+		Timestamp                int64     `json:"ts"`
+		DoneAt                   time.Time `json:"done_at"`
+		DoneStatus               string    `json:"done_status"`
+		DoneSummary              string    `json:"done_summary"`
+		TranscriptPath           string    `json:"transcript_path"`
+		Cwd                      string    `json:"cwd"`
+		CodexStartedGeneration   string    `json:"codex_started_generation"`
+		CodexCompletedGeneration string    `json:"codex_completed_generation"`
+		CodexStartedSessionID    string    `json:"codex_started_session_id"`
+		CodexCompletedSessionID  string    `json:"codex_completed_session_id"`
+		HookGeneration           string    `json:"hook_generation"`
+		Sequence                 uint64    `json:"sequence"`
 	}
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
@@ -687,6 +692,7 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		SessionID:                status.SessionID,
 		Event:                    status.Event,
 		UpdatedAt:                time.Unix(status.Timestamp, 0),
+		DoneAt:                   status.DoneAt,
 		DoneStatus:               status.DoneStatus,
 		DoneSummary:              status.DoneSummary,
 		TranscriptPath:           status.TranscriptPath,

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -134,6 +134,7 @@ func maskConsumedCodexCompletion(instanceID string, status *HookStatus) {
 
 // HookStatus holds the decoded status from a hook status file.
 type HookStatus struct {
+	CompletionLaunchAt       time.Time // Populated only from locked generation authority.
 	TimestampKnown           bool      // true only when the durable producer supplied a positive timestamp
 	Status                   string    // running, idle, waiting, dead
 	SessionID                string    // Claude session ID

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -526,6 +526,8 @@ type Instance struct {
 
 	tmuxSession *tmux.Session // Internal tmux session
 
+	serverHasSessionsForTest  func() bool
+	hookLaunchGeneration      string
 	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
@@ -4730,6 +4732,9 @@ func (i *Instance) Start() error {
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
+	if err := i.seedCompletionLaunch(); err != nil {
+		return err
+	}
 
 	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
 	// spawn_attempt trace so a spawn that dies before anything else runs still
@@ -5058,6 +5063,9 @@ func (i *Instance) StartWithMessage(message string) error {
 		if err := i.PromptDeliveryError(); err != nil {
 			return err
 		}
+	}
+	if err := i.seedCompletionLaunch(); err != nil {
+		return err
 	}
 
 	// #1580 diagnosability: clear any stale spawn-failure sidecar and drop a
@@ -5674,8 +5682,12 @@ func (i *Instance) applyTerminatedPaneStatus() {
 	tmuxSession := i.tmuxSession
 	tool := i.Tool
 	paneDeadExitStatus := i.paneDeadExitStatusForTest
+	serverHasSessions := i.serverHasSessionsForTest
+	started, spawnGen, launch := i.LastStartedAt, i.spawnGen.Load(), i.hookLaunchGeneration
+	instanceID, sessionID := i.ID, i.completionSessionIDLocked()
 
 	i.mu.Unlock()
+	generation, authority := hookGenerationForInstance(instanceID)
 	exitCode, haveExitCode := 0, false
 	if tmuxSession != nil {
 		if paneDeadExitStatus == nil {
@@ -5684,8 +5696,51 @@ func (i *Instance) applyTerminatedPaneStatus() {
 		exitCode, haveExitCode = paneDeadExitStatus()
 	}
 	status := classifyTerminatedPane(exitCode, haveExitCode, tool)
+	var completion *HookStatus
+	serverPresent := false
+	if !haveExitCode && tmuxSession != nil && completionHookTool(tool) && authority == hookGenerationValid {
+		completion = readHookStatusFile(instanceID)
+		if completion != nil && completion.DoneStatus == "ok" {
+			if serverHasSessions == nil {
+				serverHasSessions = func() bool {
+					names, err := tmux.ListSessionNamesOnSocket(tmuxSession.SocketName)
+					_, targetExists := names[tmuxSession.Name]
+					return err == nil && len(names) > 0 && !targetExists
+				}
+			}
+			serverPresent = serverHasSessions()
+		}
+	}
+	// Serialize the final evidence read/commit with cross-process lifecycle
+	// operations, without waiting on a start that already owns the marker.
+	releaseCommit := func() {}
+	if instanceID != "" {
+		var ok bool
+		releaseCommit, ok = tryTerminatedStatusCommit(instanceID)
+		if !ok {
+			i.mu.Lock()
+			return
+		}
+	}
+	defer releaseCommit()
+	if completion != nil {
+		latest := readHookStatusFile(instanceID)
+		if latest == nil || latest.HookGeneration != completion.HookGeneration || latest.Sequence != completion.Sequence {
+			completion = nil
+		} else {
+			completion = latest
+		}
+	}
+	currentGeneration, currentAuthority := hookGenerationForInstance(instanceID)
 	i.mu.Lock()
-
+	if i.tmuxSession != tmuxSession || !i.LastStartedAt.Equal(started) || i.spawnGen.Load() != spawnGen || i.hookLaunchGeneration != launch || currentGeneration != generation || currentAuthority != authority {
+		return
+	}
+	if !haveExitCode && serverPresent && completion != nil && (i.Status == StatusWaiting || i.Status == StatusIdle) &&
+		!i.hookLastUpdate.After(completion.UpdatedAt) &&
+		validTerminatedCompletion(completion, tool, generation, sessionID, started, time.Now()) {
+		status = StatusStopped
+	}
 	if i.Status != StatusStopped {
 		i.Status = status
 	}
@@ -8517,6 +8572,9 @@ func (i *Instance) restart(env map[string]string) error {
 		return nil
 	}
 	defer recordInstanceSpawn(i.ID)
+	if err := i.seedCompletionLaunch(); err != nil {
+		return err
+	}
 
 	// #1775: supersede the fast-death watcher from the PREVIOUS spawn here, at
 	// the single entry point, rather than deeper down. restart() has several
@@ -11168,6 +11226,7 @@ func (i *Instance) wrapLaunchShell(command string) string {
 // All code paths that launch or respawn a tmux pane should use this instead of calling
 // applyWrapper/wrapForSandbox/wrapIgnoreSuspend individually.
 func (i *Instance) prepareCommand(cmd string) (string, string, error) {
+	cmd = i.bindCompletionLaunchCommand(cmd)
 	// Exit-to-shell wrap FIRST, on the bare agent command, so the agent's own
 	// `exec ` launcher is still visible to neutralise and the trailing shell
 	// exec stays the outermost statement before any user-wrapper / bash -c /

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -529,6 +529,7 @@ type Instance struct {
 	serverHasSessionsForTest       func() bool
 	terminatedCommitBarrierForTest func()
 	hookLaunchGeneration           string
+	completionExecutableForTest    string
 	paneDeadExitStatusForTest      func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
@@ -5699,18 +5700,18 @@ func (i *Instance) applyTerminatedPaneStatus() {
 	status := classifyTerminatedPane(exitCode, haveExitCode, tool)
 	var completion *HookStatus
 	serverPresent := false
-	if !haveExitCode && tmuxSession != nil && completionHookTool(tool) && authority == hookGenerationValid {
-		completion = readHookStatusFile(instanceID)
-		if completion != nil && completion.DoneStatus == "ok" {
-			if serverHasSessions == nil {
-				serverHasSessions = func() bool {
-					names, err := tmux.ListSessionNamesOnSocket(tmuxSession.SocketName)
-					_, targetExists := names[tmuxSession.Name]
-					return err == nil && len(names) > 0 && !targetExists
-				}
+	completionEligible := completionProtocolActive() && !haveExitCode && tmuxSession != nil && completionHookTool(tool) && authority == hookGenerationValid
+	if completionEligible {
+		// A producer can publish DONE after this probe begins. Probe the server
+		// independently of an early status snapshot, without holding i.mu.
+		if serverHasSessions == nil {
+			serverHasSessions = func() bool {
+				names, err := tmux.ListSessionNamesOnSocket(tmuxSession.SocketName)
+				_, targetExists := names[tmuxSession.Name]
+				return err == nil && len(names) > 0 && !targetExists
 			}
-			serverPresent = serverHasSessions()
 		}
+		serverPresent = serverHasSessions()
 	}
 	// Serialize the final evidence read/commit with cross-process lifecycle
 	// operations, without waiting on a start that already owns the marker.
@@ -5729,26 +5730,23 @@ func (i *Instance) applyTerminatedPaneStatus() {
 		i.terminatedCommitBarrierForTest()
 	}
 	i.mu.Lock()
-	if completion != nil {
+	if completionEligible {
 		locks, ok := tryCompletionWriterLocks(instanceID)
 		if !ok {
 			return
 		}
 		defer locks.release()
-		// The final authority and proof read remain protected through assignment.
-		// A writer publishes its control sequence before its status record.
-		latest := readSequencedCompletionLocked(instanceID)
+		// Accept the latest proof, including a new completion during the probe.
+		// Control/status sequence equality is checked under the writer locks,
+		// which remain held through assignment and exclude contradictions.
+		completion = readSequencedCompletionLocked(instanceID)
 		currentGeneration, currentAuthority = hookGenerationForInstance(instanceID)
-		if latest == nil || latest.HookGeneration != completion.HookGeneration || latest.Sequence != completion.Sequence {
-			completion = nil
-		} else {
-			completion = latest
-		}
 	}
+
 	if i.tmuxSession != tmuxSession || !i.LastStartedAt.Equal(started) || i.spawnGen.Load() != spawnGen || i.hookLaunchGeneration != launch || currentGeneration != generation || currentAuthority != authority {
 		return
 	}
-	if !haveExitCode && serverPresent && completion != nil && (i.Status == StatusWaiting || i.Status == StatusIdle) &&
+	if completionProtocolActive() && !haveExitCode && serverPresent && completion != nil && (i.Status == StatusWaiting || i.Status == StatusIdle) &&
 		!i.hookLastUpdate.After(completion.UpdatedAt) &&
 		validTerminatedCompletion(completion, tool, generation, sessionID, started, time.Now()) {
 		status = StatusStopped

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -526,9 +526,10 @@ type Instance struct {
 
 	tmuxSession *tmux.Session // Internal tmux session
 
-	serverHasSessionsForTest  func() bool
-	hookLaunchGeneration      string
-	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
+	serverHasSessionsForTest       func() bool
+	terminatedCommitBarrierForTest func()
+	hookLaunchGeneration           string
+	paneDeadExitStatusForTest      func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
 	hookStatus                  string    // running, idle, waiting, dead (empty = no hook data)
@@ -5723,16 +5724,27 @@ func (i *Instance) applyTerminatedPaneStatus() {
 		}
 	}
 	defer releaseCommit()
+	currentGeneration, currentAuthority := hookGenerationForInstance(instanceID)
+	if i.terminatedCommitBarrierForTest != nil {
+		i.terminatedCommitBarrierForTest()
+	}
+	i.mu.Lock()
 	if completion != nil {
-		latest := readHookStatusFile(instanceID)
+		locks, ok := tryCompletionWriterLocks(instanceID)
+		if !ok {
+			return
+		}
+		defer locks.release()
+		// The final authority and proof read remain protected through assignment.
+		// A writer publishes its control sequence before its status record.
+		latest := readSequencedCompletionLocked(instanceID)
+		currentGeneration, currentAuthority = hookGenerationForInstance(instanceID)
 		if latest == nil || latest.HookGeneration != completion.HookGeneration || latest.Sequence != completion.Sequence {
 			completion = nil
 		} else {
 			completion = latest
 		}
 	}
-	currentGeneration, currentAuthority := hookGenerationForInstance(instanceID)
-	i.mu.Lock()
 	if i.tmuxSession != tmuxSession || !i.LastStartedAt.Equal(started) || i.spawnGen.Load() != spawnGen || i.hookLaunchGeneration != launch || currentGeneration != generation || currentAuthority != authority {
 		return
 	}

--- a/internal/session/instance_spawn_guard.go
+++ b/internal/session/instance_spawn_guard.go
@@ -232,25 +232,6 @@ func resolveLocksDirForSpawnLock() (string, error) {
 	return dataPath("locks", "locks")
 }
 
-// Legacy standalone reclamation cannot safely participate in the new guard.
-// Kept for old callers/tests; acquisition reclaims versioned owners under guard.
-func reclaimStaleInstanceSpawnLock(path string) bool { return false }
-
-func parseInstanceSpawnLockPID(content string) (int, error) {
-	trimmed := strings.TrimSpace(content)
-	if trimmed == "" {
-		return 0, fmt.Errorf("empty marker")
-	}
-	var pid int
-	if _, err := fmt.Sscanf(trimmed, "%d", &pid); err != nil {
-		return 0, err
-	}
-	if pid <= 0 {
-		return 0, fmt.Errorf("invalid pid %d", pid)
-	}
-	return pid, nil
-}
-
 // Status never waits on a lifecycle operation. Both status and upgraded
 // lifecycle callers hold the stable guard throughout marker ownership.
 func tryTerminatedStatusCommit(instanceID string) (func(), bool) {

--- a/internal/session/instance_spawn_guard.go
+++ b/internal/session/instance_spawn_guard.go
@@ -290,3 +290,24 @@ func parseInstanceSpawnLockPID(content string) (int, error) {
 	}
 	return pid, nil
 }
+
+// tryTerminatedStatusCommit uses the same marker as Start/Restart, but never
+// waits or reclaims it on the status path. An active/ambiguous owner vetoes an
+// old terminated-pane result. The caller releases immediately after commit.
+func tryTerminatedStatusCommit(instanceID string) (func(), bool) {
+	path, err := instanceSpawnLockPath(instanceID)
+	if err != nil {
+		return nil, false
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, false
+	}
+	_, writeErr := fmt.Fprintf(f, "%d", os.Getpid())
+	closeErr := f.Close()
+	if writeErr != nil || closeErr != nil {
+		_ = os.Remove(path)
+		return nil, false
+	}
+	return func() { _ = os.Remove(path) }, true
+}

--- a/internal/session/instance_spawn_guard.go
+++ b/internal/session/instance_spawn_guard.go
@@ -19,7 +19,7 @@
 // ~/.agent-deck/locks/instance-spawn-<safeID>.lock around the spawn step,
 // with an in-lock AlreadyAlive gate so the second waiter exits with nil
 // instead of re-spawning. Mirrors acquirePluginLock (#735, plugin_install.go):
-// O_CREATE|O_EXCL marker + PID + stale-reclaim by `kill -0` or by age TTL.
+// Permanent guard plus versioned ownership; legacy markers remain deferred.
 //
 // Related-but-not-the-same: #1031 was a *storage-layer* race in
 // SaveInstances' DELETE-NOT-IN sweep during concurrent `launch`. The fix
@@ -35,7 +35,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -171,28 +170,17 @@ func acquireInstanceSpawnLock(instanceID string) (func(), error) {
 }
 
 func defaultAcquireInstanceSpawnLock(instanceID string) (func(), error) {
-	path, err := instanceSpawnLockPath(instanceID)
-	if err != nil {
-		return nil, err
-	}
 	deadline := time.Now().Add(instanceSpawnLockBudget)
 	for {
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-		if err == nil {
-			fmt.Fprintf(f, "%d", os.Getpid())
-			_ = f.Close()
-			return func() { _ = os.Remove(path) }, nil
+		release, ok, err := tryGuardedSpawnOwnership(instanceID)
+		if err != nil {
+			return nil, err
 		}
-
-		if reclaimStaleInstanceSpawnLock(path) {
-			continue
+		if ok {
+			return release, nil
 		}
-
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf(
-				"instance spawn lock %q held by live process; gave up after %s",
-				path, instanceSpawnLockBudget,
-			)
+			return nil, fmt.Errorf("instance spawn ownership remains live or ambiguous")
 		}
 		time.Sleep(instanceSpawnLockRetryInterval)
 	}
@@ -244,37 +232,9 @@ func resolveLocksDirForSpawnLock() (string, error) {
 	return dataPath("locks", "locks")
 }
 
-// reclaimStaleInstanceSpawnLock mirrors reclaimStalePluginLock — older
-// than 2m means the holder timed out anyway; PID-not-alive means the
-// holder crashed without unlinking.
-func reclaimStaleInstanceSpawnLock(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if time.Since(info.ModTime()) > instanceSpawnLockLegacyStaleTTL {
-		_ = os.Remove(path)
-		return true
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	pid, parseErr := parseInstanceSpawnLockPID(string(data))
-	if parseErr != nil {
-		return false
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		_ = os.Remove(path)
-		return true
-	}
-	if err := proc.Signal(syscall.Signal(0)); err != nil {
-		_ = os.Remove(path)
-		return true
-	}
-	return false
-}
+// Legacy standalone reclamation cannot safely participate in the new guard.
+// Kept for old callers/tests; acquisition reclaims versioned owners under guard.
+func reclaimStaleInstanceSpawnLock(path string) bool { return false }
 
 func parseInstanceSpawnLockPID(content string) (int, error) {
 	trimmed := strings.TrimSpace(content)
@@ -291,23 +251,9 @@ func parseInstanceSpawnLockPID(content string) (int, error) {
 	return pid, nil
 }
 
-// tryTerminatedStatusCommit uses the same marker as Start/Restart, but never
-// waits or reclaims it on the status path. An active/ambiguous owner vetoes an
-// old terminated-pane result. The caller releases immediately after commit.
+// Status never waits on a lifecycle operation. Both status and upgraded
+// lifecycle callers hold the stable guard throughout marker ownership.
 func tryTerminatedStatusCommit(instanceID string) (func(), bool) {
-	path, err := instanceSpawnLockPath(instanceID)
-	if err != nil {
-		return nil, false
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-	if err != nil {
-		return nil, false
-	}
-	_, writeErr := fmt.Fprintf(f, "%d", os.Getpid())
-	closeErr := f.Close()
-	if writeErr != nil || closeErr != nil {
-		_ = os.Remove(path)
-		return nil, false
-	}
-	return func() { _ = os.Remove(path) }, true
+	release, ok, err := tryGuardedSpawnOwnership(instanceID)
+	return release, ok && err == nil
 }

--- a/internal/session/instance_spawn_protocol.go
+++ b/internal/session/instance_spawn_protocol.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+var spawnOwnerSignal = syscall.Kill
+
+type spawnGuardOwner struct {
+	Version int    `json:"version"`
+	PID     int    `json:"pid"`
+	Nonce   string `json:"nonce"`
+}
+
+func decodeSpawnProtocol(data []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return fmt.Errorf("trailing protocol data")
+	}
+	return nil
+}
+
+// This declaration is an operator-established quiescent upgrade boundary,
+// never proof that no legacy executable can be invoked later.
+func completionProtocolActive() bool {
+	dir, err := resolveLocksDirForSpawnLock()
+	if err != nil {
+		return false
+	}
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return false
+	}
+	data, _, err := readSpawnProtocolFile(filepath.Join(dir, "completion-protocol.json"))
+	if err != nil {
+		return false
+	}
+	var declaration struct {
+		Version          int    `json:"version"`
+		QuiescentUpgrade bool   `json:"quiescent_upgrade_declared"`
+		Namespace        string `json:"locks_namespace"`
+	}
+	return decodeSpawnProtocol(data, &declaration) == nil && declaration.Version == 1 &&
+		declaration.QuiescentUpgrade && declaration.Namespace == canonical
+}
+
+func readSpawnProtocolFile(path string) ([]byte, os.FileInfo, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("nonregular spawn protocol")
+	}
+	data, err := io.ReadAll(io.LimitReader(f, 4097))
+	if err != nil || len(data) > 4096 {
+		return nil, nil, fmt.Errorf("invalid spawn protocol size")
+	}
+	return data, info, nil
+}
+
+func readSpawnGuardOwner(path string) (spawnGuardOwner, os.FileInfo, error) {
+	data, info, err := readSpawnProtocolFile(path)
+	var owner spawnGuardOwner
+	if err != nil {
+		return owner, info, err
+	}
+	if decodeSpawnProtocol(data, &owner) != nil || owner.Version != 1 || owner.PID <= 0 || len(owner.Nonce) != 32 {
+		return owner, info, fmt.Errorf("legacy or ambiguous spawn ownership")
+	}
+	if _, err := hex.DecodeString(owner.Nonce); err != nil {
+		return owner, info, err
+	}
+	return owner, info, nil
+}
+
+// Every upgraded acquisition, reclaim and release holds this permanent inode.
+// Legacy controllers that ignore it must be quiesced before activation.
+func tryGuardedSpawnOwnership(instanceID string) (func(), bool, error) {
+	path, err := instanceSpawnLockPath(instanceID)
+	if err != nil {
+		return nil, false, err
+	}
+	guard, err := os.OpenFile(path+".guard", os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0600)
+	if err != nil {
+		return nil, false, err
+	}
+	closeGuard := func() { _ = syscall.Flock(int(guard.Fd()), syscall.LOCK_UN); _ = guard.Close() }
+	info, err := guard.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		_ = guard.Close()
+		return nil, false, fmt.Errorf("invalid spawn guard")
+	}
+	if err := syscall.Flock(int(guard.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = guard.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	owner, markerInfo, readErr := readSpawnGuardOwner(path)
+	if readErr == nil {
+		if !completionProtocolActive() {
+			closeGuard()
+			return nil, false, nil
+		}
+		// Age, EPERM, PID reuse and every unknown outcome retain ownership.
+		if !errors.Is(spawnOwnerSignal(owner.PID, 0), syscall.ESRCH) {
+			closeGuard()
+			return nil, false, nil
+		}
+		current, err := os.Lstat(path)
+		if err != nil || !os.SameFile(markerInfo, current) {
+			closeGuard()
+			return nil, false, nil
+		}
+		if err := os.Remove(path); err != nil {
+			closeGuard()
+			return nil, false, err
+		}
+	} else if !os.IsNotExist(readErr) {
+		closeGuard()
+		return nil, false, nil
+	}
+	var token [16]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		closeGuard()
+		return nil, false, err
+	}
+	owned := spawnGuardOwner{Version: 1, PID: os.Getpid(), Nonce: hex.EncodeToString(token[:])}
+	data, err := json.Marshal(owned)
+	if err != nil {
+		closeGuard()
+		return nil, false, err
+	}
+	marker, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY|syscall.O_NOFOLLOW, 0600)
+	if err != nil {
+		closeGuard()
+		return nil, false, err
+	}
+	ownedInfo, statErr := marker.Stat()
+	_, writeErr := marker.Write(data)
+	syncErr := marker.Sync()
+	closeErr := marker.Close()
+	if statErr != nil || writeErr != nil || syncErr != nil || closeErr != nil {
+		// Preserve an ambiguous partial marker for operator inspection.
+		closeGuard()
+		return nil, false, fmt.Errorf("persist spawn ownership failed")
+	}
+	released := false
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		current, currentInfo, err := readSpawnGuardOwner(path)
+		if err == nil && current == owned && os.SameFile(ownedInfo, currentInfo) {
+			_ = os.Remove(path)
+		}
+		closeGuard()
+	}, true, nil
+}

--- a/internal/session/issue2007_atomic_append_crash_test.go
+++ b/internal/session/issue2007_atomic_append_crash_test.go
@@ -61,7 +61,7 @@ func TestIssue2007_SIGKILLDuringAppendLeavesOldOrNewCompleteFile(t *testing.T) {
 	}
 
 	marker := filepath.Join(t.TempDir(), "append-fsync.marker")
-	cmd := exec.Command(os.Args[0], "-test.run=^TestIssue2007_AppendCrashHelper$")
+	cmd := sessionTestChildCommand(t, "TestIssue2007_AppendCrashHelper")
 	cmd.Env = append(os.Environ(), issue2007CrashHelperEnv+"=1", "AGENTDECK_TEST_2007_CRASH_MARKER="+marker)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start append helper: %v", err)

--- a/internal/session/issue2091_commit_writer_test.go
+++ b/internal/session/issue2091_commit_writer_test.go
@@ -17,18 +17,19 @@ import (
 // reacquired. A real hook subprocess finishes publishing N+1 while the watcher
 // remains delayed. Cached DONE N must not authorize the later status commit.
 func TestIssue2091RealWriterBeforeStatusCommit(t *testing.T) {
-	binary := os.Getenv("ISSUE2091_BIN")
-	if binary == "" {
-		t.Skip("set ISSUE2091_BIN to the built agent-deck CLI")
-	}
+	binary := review2115Binary(t)
 	for _, event := range []string{"agent-turn-start", "turn-failed"} {
 		t.Run(event, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir())
 			t.Setenv("XDG_CONFIG_HOME", "")
 			t.Setenv("XDG_DATA_HOME", "")
+			review2115Activate(t)
 			id := "issue2091-commit-writer"
 			producer := &Instance{ID: id, Tool: "codex"}
 			if err := producer.seedCompletionLaunch(); err != nil {
+				t.Fatal(err)
+			}
+			if err := RecordCompletionLaunch(producer.ID, producer.hookLaunchGeneration); err != nil {
 				t.Fatal(err)
 			}
 			write := func(event, turn, text string) {
@@ -73,6 +74,7 @@ func issue2091ProofObserver(t *testing.T, sandbox bool) (*Instance, string) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
 	id := "issue2091-lock-proof"
 	producer := &Instance{ID: id, Tool: "claude"}
 	if sandbox {
@@ -84,7 +86,7 @@ func issue2091ProofObserver(t *testing.T, sandbox bool) (*Instance, string) {
 	scope := hermesHookScope(id, sandbox)
 	now := time.Now().Truncate(time.Second)
 	status, _ := json.Marshal(map[string]any{"status": "waiting", "event": "Stop", "session_id": "thread", "ts": now.Unix(), "done_at": now.Format(time.RFC3339Nano), "done_status": "ok", "hook_generation": producer.hookLaunchGeneration, "sequence": 2})
-	control, _ := json.Marshal(map[string]any{"generation": producer.hookLaunchGeneration, "next_sequence": 2})
+	control, _ := json.Marshal(map[string]any{"generation": producer.hookLaunchGeneration, "next_sequence": 2, "launch_at": now.Add(-10 * time.Second)})
 	for name, data := range map[string][]byte{id + ".json": status, id + ".generation.json": control} {
 		if err := os.WriteFile(filepath.Join(scope, name), data, 0600); err != nil {
 			t.Fatal(err)

--- a/internal/session/issue2091_commit_writer_test.go
+++ b/internal/session/issue2091_commit_writer_test.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// The barrier is after the formerly final authority read, before i.mu is
+// reacquired. A real hook subprocess finishes publishing N+1 while the watcher
+// remains delayed. Cached DONE N must not authorize the later status commit.
+func TestIssue2091RealWriterBeforeStatusCommit(t *testing.T) {
+	binary := os.Getenv("ISSUE2091_BIN")
+	if binary == "" {
+		t.Skip("set ISSUE2091_BIN to the built agent-deck CLI")
+	}
+	for _, event := range []string{"agent-turn-start", "turn-failed"} {
+		t.Run(event, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			id := "issue2091-commit-writer"
+			producer := &Instance{ID: id, Tool: "codex"}
+			if err := producer.seedCompletionLaunch(); err != nil {
+				t.Fatal(err)
+			}
+			write := func(event, turn, text string) {
+				t.Helper()
+				payload, _ := json.Marshal(map[string]string{"type": event, "thread-id": "thread", "turn-id": turn, "last-assistant-message": text})
+				cmd := exec.Command(binary, "codex-notify", string(payload))
+				cmd.Env = append(os.Environ(), "AGENTDECK_INSTANCE_ID="+id, "AGENTDECK_HOOK_GENERATION="+producer.hookLaunchGeneration)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("actual hook: %v: %s", err, out)
+				}
+			}
+			write("agent-turn-complete", "A", "===AGENTDECK_DONE=== status=ok summary=done")
+			before := readHookStatusFile(id)
+			if before == nil || before.DoneStatus != "ok" {
+				t.Fatalf("missing initial proof: %+v", before)
+			}
+			observer := &Instance{ID: id, Tool: "codex", CodexSessionID: "thread", Status: StatusWaiting, LastStartedAt: time.Now().Add(-time.Minute), tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }, serverHasSessionsForTest: func() bool { return true }}
+			observer.terminatedCommitBarrierForTest = func() {
+				turn := "A"
+				if event == "agent-turn-start" {
+					turn = "B"
+				}
+				write(event, turn, "")
+				after := readHookStatusFile(id)
+				if after == nil || after.Sequence <= before.Sequence || after.DoneStatus != "" {
+					t.Fatalf("contradiction not published: %+v", after)
+				}
+			}
+			observer.mu.Lock()
+			observer.applyTerminatedPaneStatus()
+			got := observer.Status
+			observer.mu.Unlock()
+			if got != StatusError {
+				t.Fatalf("completed real writer before commit was ignored: %s", got)
+			}
+		})
+	}
+}
+
+func issue2091ProofObserver(t *testing.T, sandbox bool) (*Instance, string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	id := "issue2091-lock-proof"
+	producer := &Instance{ID: id, Tool: "claude"}
+	if sandbox {
+		producer.Sandbox = &SandboxConfig{Enabled: true}
+	}
+	if err := producer.seedCompletionLaunch(); err != nil {
+		t.Fatal(err)
+	}
+	scope := hermesHookScope(id, sandbox)
+	now := time.Now().Truncate(time.Second)
+	status, _ := json.Marshal(map[string]any{"status": "waiting", "event": "Stop", "session_id": "thread", "ts": now.Unix(), "done_at": now.Format(time.RFC3339Nano), "done_status": "ok", "hook_generation": producer.hookLaunchGeneration, "sequence": 2})
+	control, _ := json.Marshal(map[string]any{"generation": producer.hookLaunchGeneration, "next_sequence": 2})
+	for name, data := range map[string][]byte{id + ".json": status, id + ".generation.json": control} {
+		if err := os.WriteFile(filepath.Join(scope, name), data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Instance{ID: id, Tool: "claude", ClaudeSessionID: "thread", Status: StatusWaiting, LastStartedAt: now.Add(-time.Minute), tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }, serverHasSessionsForTest: func() bool { return true }}, scope
+}
+
+func TestIssue2091TornControlPublication(t *testing.T) {
+	for _, sandbox := range []bool{false, true} {
+		t.Run(fmt.Sprint(sandbox), func(t *testing.T) {
+			i, scope := issue2091ProofObserver(t, sandbox)
+			generation, _ := hookGenerationForInstance(i.ID)
+			// Producer published its next control but failed to replace old DONE status.
+			data, _ := json.Marshal(map[string]any{"generation": generation, "next_sequence": 3})
+			if err := os.WriteFile(filepath.Join(scope, i.ID+".generation.json"), data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			i.mu.Lock()
+			i.applyTerminatedPaneStatus()
+			got := i.Status
+			i.mu.Unlock()
+			if got != StatusError {
+				t.Fatalf("torn publication accepted old DONE: %s", got)
+			}
+		})
+	}
+}
+
+func TestIssue2091HeldWriterLockDefersPromptly(t *testing.T) {
+	for _, sandbox := range []bool{false, true} {
+		t.Run(fmt.Sprint(sandbox), func(t *testing.T) {
+			i, _ := issue2091ProofObserver(t, sandbox)
+			scope := hermesHookScope(i.ID, sandbox)
+			lock, err := os.OpenFile(filepath.Join(scope, i.ID+".lock"), os.O_CREATE|os.O_RDWR, 0600)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer lock.Close()
+			if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+				t.Fatal(err)
+			}
+			defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+			finished := make(chan Status, 1)
+			go func() { i.mu.Lock(); i.applyTerminatedPaneStatus(); got := i.Status; i.mu.Unlock(); finished <- got }()
+			select {
+			case got := <-finished:
+				if got != StatusWaiting {
+					t.Fatalf("held writer did not defer classification: %s", got)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("status blocked on hook writer")
+			}
+		})
+	}
+}
+
+func TestIssue2091FinalProofScopeControls(t *testing.T) {
+	for _, scenario := range []string{"valid", "missing-sequence", "boolean-sequence", "duplicate-authority", "symlink-control", "wrong-status-scope"} {
+		t.Run(scenario, func(t *testing.T) {
+			i, scope := issue2091ProofObserver(t, false)
+			control := filepath.Join(scope, i.ID+".generation.json")
+			generation, _ := hookGenerationForInstance(i.ID)
+			switch scenario {
+			case "missing-sequence":
+				data, _ := json.Marshal(map[string]any{"generation": generation})
+				if err := os.WriteFile(control, data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "boolean-sequence":
+				data, _ := json.Marshal(map[string]any{"generation": generation, "next_sequence": false})
+				if err := os.WriteFile(control, data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "duplicate-authority", "wrong-status-scope":
+				other := hermesHookScope(i.ID, true)
+				if err := os.MkdirAll(other, 0700); err != nil {
+					t.Fatal(err)
+				}
+				name := i.ID + ".generation.json"
+				if scenario == "wrong-status-scope" {
+					name = i.ID + ".json"
+				}
+				data, err := os.ReadFile(filepath.Join(scope, name))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(other, name), data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink-control":
+				if err := os.Rename(control, control+".saved"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(control+".saved", control); err != nil {
+					t.Fatal(err)
+				}
+			}
+			i.mu.Lock()
+			i.applyTerminatedPaneStatus()
+			got := i.Status
+			i.mu.Unlock()
+			want := StatusError
+			if scenario == "valid" {
+				want = StatusStopped
+			}
+			if got != want {
+				t.Fatalf("%s: got %s, want %s", scenario, got, want)
+			}
+		})
+	}
+}

--- a/internal/session/issue2091_completion_test.go
+++ b/internal/session/issue2091_completion_test.go
@@ -71,6 +71,10 @@ func TestIssue2091DurableColdCompletionAndContradictions(t *testing.T) {
 				t.Fatal(err)
 			}
 			gen := producer.hookLaunchGeneration
+			control, _ := json.Marshal(map[string]any{"generation": gen, "next_sequence": 2})
+			if err := os.WriteFile(filepath.Join(GetHooksDir(), id+".generation.json"), control, 0600); err != nil {
+				t.Fatal(err)
+			}
 			if !strings.Contains(producer.bindCompletionLaunchCommand("codex"), gen) {
 				t.Fatal("launch token missing from real command")
 			}
@@ -138,6 +142,10 @@ func TestIssue2091DurableContradictionDuringServerProbe(t *testing.T) {
 		}
 	}
 	write()
+	control, _ := json.Marshal(map[string]any{"generation": i.hookLaunchGeneration, "next_sequence": 1})
+	if err := os.WriteFile(filepath.Join(GetHooksDir(), i.ID+".generation.json"), control, 0600); err != nil {
+		t.Fatal(err)
+	}
 	i.serverHasSessionsForTest = func() bool {
 		record["status"] = "running"
 		record["sequence"] = 2

--- a/internal/session/issue2091_completion_test.go
+++ b/internal/session/issue2091_completion_test.go
@@ -1,0 +1,218 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+func TestIssue2091CompletionEvidenceControls(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	base := HookStatus{Status: "waiting", Event: "Stop", SessionID: "thread", HookGeneration: "launch", Sequence: 2, TimestampKnown: true, UpdatedAt: now.Add(-time.Second), DoneAt: now.Add(-time.Second), DoneStatus: "ok"}
+	for _, tc := range []struct {
+		name   string
+		change func(*HookStatus)
+		want   bool
+	}{
+		{"current explicit done", func(*HookStatus) {}, true},
+		{"prior launch transcript", func(h *HookStatus) { h.DoneAt = now.Add(-time.Hour) }, false},
+		{"missing transcript timestamp", func(h *HookStatus) { h.DoneAt = time.Time{} }, false},
+		{"future transcript timestamp", func(h *HookStatus) { h.DoneAt = now.Add(time.Second) }, false},
+		{"ordinary stop", func(h *HookStatus) { h.DoneStatus = "" }, false},
+		{"waiting alone", func(h *HookStatus) { h.Event = ""; h.DoneStatus = "" }, false},
+		{"wrong launch", func(h *HookStatus) { h.HookGeneration = "prior" }, false},
+		{"wrong conversation", func(h *HookStatus) { h.SessionID = "other" }, false},
+		{"unknown timestamp", func(h *HookStatus) { h.TimestampKnown = false }, false},
+		{"future", func(h *HookStatus) { h.UpdatedAt = now.Add(time.Second) }, false},
+		{"expired", func(h *HookStatus) { h.UpdatedAt = now.Add(-time.Minute) }, false},
+		{"failed done", func(h *HookStatus) { h.DoneStatus = "fail" }, false},
+		{"new running", func(h *HookStatus) { h.Status = "running" }, false},
+		{"unsequenced", func(h *HookStatus) { h.Sequence = 0 }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := base
+			tc.change(&h)
+			if got := validTerminatedCompletion(&h, "claude", "launch", "thread", now.Add(-10*time.Second), now); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIssue2091DurableColdCompletionAndContradictions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	now := time.Now().Truncate(time.Second)
+	for _, tc := range []struct {
+		name          string
+		exit          int
+		known, server bool
+		memory        Status
+		newer         bool
+		want          Status
+	}{
+		{"reload valid", 0, false, true, StatusWaiting, false, StatusStopped},
+		{"explicit failure", 3, true, true, StatusWaiting, false, StatusError},
+		{"explicit success", 0, true, false, StatusWaiting, false, StatusStopped},
+		{"server vanished", 0, false, false, StatusWaiting, false, StatusError},
+		{"running contradicts", 0, false, true, StatusRunning, false, StatusError},
+		{"newer hook contradicts", 0, false, true, StatusWaiting, true, StatusError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id := "issue2091-" + strings.ReplaceAll(tc.name, " ", "-")
+			producer := &Instance{ID: id, Tool: "codex"}
+			if err := producer.seedCompletionLaunch(); err != nil {
+				t.Fatal(err)
+			}
+			gen := producer.hookLaunchGeneration
+			if !strings.Contains(producer.bindCompletionLaunchCommand("codex"), gen) {
+				t.Fatal("launch token missing from real command")
+			}
+			data, _ := json.Marshal(map[string]any{"status": "waiting", "event": "agent-turn-complete", "session_id": "thread", "ts": now.Unix(), "hook_generation": gen, "sequence": 2, "done_status": "ok", "codex_started_generation": "thread:turn", "codex_completed_generation": "thread:turn", "codex_started_session_id": "thread", "codex_completed_session_id": "thread"})
+			if err := os.WriteFile(filepath.Join(GetHooksDir(), id+".json"), data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			// A separate observer has no in-memory launch token or hook state.
+			observer := &Instance{ID: id, Tool: "codex", CodexSessionID: "thread", Status: tc.memory, LastStartedAt: now.Add(-10 * time.Second), tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return tc.exit, tc.known }, serverHasSessionsForTest: func() bool { return tc.server }}
+			if tc.newer {
+				observer.hookLastUpdate = now.Add(time.Second)
+			}
+			observer.mu.Lock()
+			observer.applyTerminatedPaneStatus()
+			got := observer.Status
+			observer.mu.Unlock()
+			if got != tc.want {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIssue2091PiHasNoSupportedPositiveProducer(t *testing.T) {
+	inst := &Instance{ID: "pi-unbound", Tool: "pi"}
+	if completionHookTool(inst.Tool) {
+		t.Fatal("Pi must remain fail-closed pending supported producer")
+	}
+	if err := inst.seedCompletionLaunch(); err != nil {
+		t.Fatal(err)
+	}
+	if got := inst.bindCompletionLaunchCommand("pi"); got != "pi" {
+		t.Fatalf("unsupported token injection: %s", got)
+	}
+}
+
+func TestIssue2091ConsumedCodexCompletionIsNotProof(t *testing.T) {
+	now := time.Now()
+	h := &HookStatus{Status: "waiting", SessionID: "thread", HookGeneration: "launch", Sequence: 1, TimestampKnown: true, UpdatedAt: now, DoneStatus: "ok", CodexStartedGeneration: "thread:turn", CodexCompletedGeneration: "thread:turn", CodexStartedSessionID: "thread", CodexCompletedSessionID: "thread"}
+	if !validTerminatedCompletion(h, "codex", "launch", "thread", now.Add(-time.Minute), now) {
+		t.Fatal("valid control rejected")
+	}
+	h.codexCompletionConsumed = true
+	if validTerminatedCompletion(h, "codex", "launch", "thread", now.Add(-time.Minute), now) {
+		t.Fatal("consumed completion accepted")
+	}
+}
+
+func TestIssue2091DurableContradictionDuringServerProbe(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	now := time.Now().Truncate(time.Second)
+	i := &Instance{ID: "issue2091-durable-race", Tool: "claude", ClaudeSessionID: "thread", Status: StatusWaiting, LastStartedAt: now.Add(-time.Minute), tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }}
+	if err := i.seedCompletionLaunch(); err != nil {
+		t.Fatal(err)
+	}
+	i.Status = StatusWaiting
+	i.hookLastUpdate = time.Time{}
+	record := map[string]any{"status": "waiting", "session_id": "thread", "ts": now.Unix(), "hook_generation": i.hookLaunchGeneration, "sequence": 1, "done_status": "ok", "done_at": now.Format(time.RFC3339Nano)}
+	write := func() {
+		b, _ := json.Marshal(record)
+		if err := os.WriteFile(filepath.Join(GetHooksDir(), i.ID+".json"), b, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write()
+	i.serverHasSessionsForTest = func() bool {
+		record["status"] = "running"
+		record["sequence"] = 2
+		delete(record, "done_status")
+		write()
+		return true
+	}
+	i.mu.Lock()
+	i.applyTerminatedPaneStatus()
+	got := i.Status
+	i.mu.Unlock()
+	if got != StatusError {
+		t.Fatalf("new durable running ignored: %s", got)
+	}
+}
+
+func TestIssue2091SpawnOwnerVetoesTerminationCommit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	i := &Instance{ID: "issue2091-owned", Tool: "claude", Status: StatusWaiting}
+	release, err := acquireInstanceSpawnLock(i.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	i.mu.Lock()
+	i.applyTerminatedPaneStatus()
+	got := i.Status
+	i.mu.Unlock()
+	if got != StatusWaiting {
+		t.Fatalf("active launch owner overwritten: %s", got)
+	}
+}
+
+func TestIssue2091LaunchPublicationVetoesOldProbe(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	entered, releaseProbe, finished := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	i := &Instance{ID: "issue2091-publication", Tool: "claude", Status: StatusRunning, tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { close(entered); <-releaseProbe; return 7, true }}
+	locks, err := acquireHermesHookLocks(i.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			locks.release()
+		}
+	}()
+	go func() { i.mu.Lock(); i.applyTerminatedPaneStatus(); i.mu.Unlock(); close(finished) }()
+	<-entered
+	seeded := make(chan error, 1)
+	epoch := i.spawnGen.Load()
+	go func() { seeded <- i.seedCompletionLaunch() }()
+	deadline := time.Now().Add(time.Second)
+	for i.spawnGen.Load() == epoch {
+		if time.Now().After(deadline) {
+			t.Fatal("launch epoch not advanced before blocked publication")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(releaseProbe)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("old probe blocked on publication")
+	}
+	if got := i.GetStatusThreadSafe(); got != StatusRunning {
+		t.Fatalf("old probe committed while seed was blocked: %s", got)
+	}
+	locks.release()
+	released = true
+	if err := <-seeded; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/session/issue2091_completion_test.go
+++ b/internal/session/issue2091_completion_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestIssue2091CompletionEvidenceControls(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
-	base := HookStatus{Status: "waiting", Event: "Stop", SessionID: "thread", HookGeneration: "launch", Sequence: 2, TimestampKnown: true, UpdatedAt: now.Add(-time.Second), DoneAt: now.Add(-time.Second), DoneStatus: "ok"}
+	base := HookStatus{CompletionLaunchAt: now.Add(-10 * time.Second), Status: "waiting", Event: "Stop", SessionID: "thread", HookGeneration: "launch", Sequence: 2, TimestampKnown: true, UpdatedAt: now.Add(-time.Second), DoneAt: now.Add(-time.Second), DoneStatus: "ok"}
 	for _, tc := range []struct {
 		name   string
 		change func(*HookStatus)
@@ -47,6 +47,7 @@ func TestIssue2091CompletionEvidenceControls(t *testing.T) {
 func TestIssue2091DurableColdCompletionAndContradictions(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	now := time.Now().Truncate(time.Second)
 	for _, tc := range []struct {
@@ -71,7 +72,7 @@ func TestIssue2091DurableColdCompletionAndContradictions(t *testing.T) {
 				t.Fatal(err)
 			}
 			gen := producer.hookLaunchGeneration
-			control, _ := json.Marshal(map[string]any{"generation": gen, "next_sequence": 2})
+			control, _ := json.Marshal(map[string]any{"generation": gen, "next_sequence": 2, "launch_at": now.Add(-10 * time.Second)})
 			if err := os.WriteFile(filepath.Join(GetHooksDir(), id+".generation.json"), control, 0600); err != nil {
 				t.Fatal(err)
 			}
@@ -113,7 +114,7 @@ func TestIssue2091PiHasNoSupportedPositiveProducer(t *testing.T) {
 
 func TestIssue2091ConsumedCodexCompletionIsNotProof(t *testing.T) {
 	now := time.Now()
-	h := &HookStatus{Status: "waiting", SessionID: "thread", HookGeneration: "launch", Sequence: 1, TimestampKnown: true, UpdatedAt: now, DoneStatus: "ok", CodexStartedGeneration: "thread:turn", CodexCompletedGeneration: "thread:turn", CodexStartedSessionID: "thread", CodexCompletedSessionID: "thread"}
+	h := &HookStatus{CompletionLaunchAt: now.Add(-time.Minute), Status: "waiting", SessionID: "thread", HookGeneration: "launch", Sequence: 1, TimestampKnown: true, UpdatedAt: now, DoneStatus: "ok", CodexStartedGeneration: "thread:turn", CodexCompletedGeneration: "thread:turn", CodexStartedSessionID: "thread", CodexCompletedSessionID: "thread"}
 	if !validTerminatedCompletion(h, "codex", "launch", "thread", now.Add(-time.Minute), now) {
 		t.Fatal("valid control rejected")
 	}
@@ -126,6 +127,7 @@ func TestIssue2091ConsumedCodexCompletionIsNotProof(t *testing.T) {
 func TestIssue2091DurableContradictionDuringServerProbe(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	now := time.Now().Truncate(time.Second)
 	i := &Instance{ID: "issue2091-durable-race", Tool: "claude", ClaudeSessionID: "thread", Status: StatusWaiting, LastStartedAt: now.Add(-time.Minute), tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }}
@@ -142,7 +144,7 @@ func TestIssue2091DurableContradictionDuringServerProbe(t *testing.T) {
 		}
 	}
 	write()
-	control, _ := json.Marshal(map[string]any{"generation": i.hookLaunchGeneration, "next_sequence": 1})
+	control, _ := json.Marshal(map[string]any{"generation": i.hookLaunchGeneration, "next_sequence": 1, "launch_at": now.Add(-10 * time.Second)})
 	if err := os.WriteFile(filepath.Join(GetHooksDir(), i.ID+".generation.json"), control, 0600); err != nil {
 		t.Fatal(err)
 	}
@@ -165,6 +167,7 @@ func TestIssue2091DurableContradictionDuringServerProbe(t *testing.T) {
 func TestIssue2091SpawnOwnerVetoesTerminationCommit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	i := &Instance{ID: "issue2091-owned", Tool: "claude", Status: StatusWaiting}
 	release, err := acquireInstanceSpawnLock(i.ID)
@@ -185,6 +188,7 @@ func TestIssue2091LaunchPublicationVetoesOldProbe(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
 	entered, releaseProbe, finished := make(chan struct{}), make(chan struct{}), make(chan struct{})
 	i := &Instance{ID: "issue2091-publication", Tool: "claude", Status: StatusRunning, tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { close(entered); <-releaseProbe; return 7, true }}
 	locks, err := acquireHermesHookLocks(i.ID)

--- a/internal/session/issue2091_real_tmux_test.go
+++ b/internal/session/issue2091_real_tmux_test.go
@@ -1,0 +1,114 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"al.essio.dev/pkg/shellescape"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Opt-in integration: the runner builds the actual CLI and supplies its path.
+// Every process lives on this test's private socket and exits naturally.
+func TestIssue2091RealProducersAndVanishedServer(t *testing.T) {
+	binary := os.Getenv("ISSUE2091_BIN")
+	if binary == "" {
+		t.Skip("set ISSUE2091_BIN to the built agent-deck CLI")
+	}
+	for _, tool := range []string{"claude", "codex"} {
+		for _, scenario := range []string{"done", "ordinary", "prior-launch"} {
+			done := scenario != "ordinary"
+			t.Run(fmt.Sprintf("%s/%s", tool, scenario), func(t *testing.T) {
+				home := t.TempDir()
+				t.Setenv("HOME", home)
+				t.Setenv("XDG_CONFIG_HOME", "")
+				t.Setenv("XDG_DATA_HOME", "")
+				t.Setenv("CLAUDE_CONFIG_DIR", "")
+				socket := fmt.Sprintf("i2091-%d", time.Now().UnixNano())
+				tm := func(args ...string) []byte {
+					t.Helper()
+					out, err := exec.Command("tmux", append([]string{"-L", socket}, args...)...).CombinedOutput()
+					if err != nil {
+						t.Fatalf("private tmux %v: %v: %s", args, err, out)
+					}
+					return out
+				}
+				tm("new-session", "-d", "-s", "keeper", "sleep 60")
+				t.Cleanup(func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", "keeper").Run() })
+				id := "issue2091-real"
+				producer := &Instance{ID: id, Tool: tool}
+				if err := producer.seedCompletionLaunch(); err != nil {
+					t.Fatal(err)
+				}
+				text := "ordinary turn"
+				if done {
+					text = "===AGENTDECK_DONE=== status=ok summary=finished"
+				}
+				payload := map[string]any{"type": "agent-turn-complete", "thread-id": "thread", "turn-id": "turn", "last-assistant-message": text}
+				subcommand := "codex-notify"
+				if tool == "claude" {
+					dir := filepath.Join(home, ".claude", "projects", "test")
+					if err := os.MkdirAll(dir, 0700); err != nil {
+						t.Fatal(err)
+					}
+					transcript := filepath.Join(dir, "thread.jsonl")
+					record, _ := json.Marshal(map[string]any{"timestamp": time.Now().Add(-time.Hour).Format(time.RFC3339Nano), "type": "assistant", "message": map[string]any{"role": "assistant", "content": []map[string]string{{"type": "text", "text": text}}}})
+					if err := os.WriteFile(transcript, append(record, '\n'), 0600); err != nil {
+						t.Fatal(err)
+					}
+					payload = map[string]any{"hook_event_name": "Stop", "session_id": "thread", "transcript_path": transcript, "stop_hook_active": true, "cwd": home}
+					subcommand = "hook-handler"
+				}
+				data, _ := json.Marshal(payload)
+				// Sleep past hook timestamp's second precision after the actual launch.
+				command := "export HOME=" + shellescape.Quote(home) + " AGENTDECK_INSTANCE_ID=" + id + "; sleep 2; printf '%s' " + shellescape.Quote(string(data)) + " | " + shellescape.Quote(binary) + " " + subcommand
+				if tool == "codex" {
+					command = "export HOME=" + shellescape.Quote(home) + " AGENTDECK_INSTANCE_ID=" + id + "; sleep 2; " + shellescape.Quote(binary) + " " + subcommand + " " + shellescape.Quote(string(data))
+				}
+				started := time.Now()
+				tm("new-session", "-d", "-s", "worker", producer.bindCompletionLaunchCommand(command))
+				if tool == "claude" && scenario != "prior-launch" {
+					record, _ := json.Marshal(map[string]any{"timestamp": time.Now().Format(time.RFC3339Nano), "type": "assistant", "message": map[string]any{"role": "assistant", "content": text}})
+					if err := os.WriteFile(payload["transcript_path"].(string), append(record, '\n'), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				deadline := time.Now().Add(10 * time.Second)
+				for exec.Command("tmux", "-L", socket, "has-session", "-t", "worker").Run() == nil {
+					if time.Now().After(deadline) {
+						t.Fatal("worker did not exit")
+					}
+					time.Sleep(50 * time.Millisecond)
+				}
+				hook := readHookStatusFile(id)
+				if hook == nil || hook.SessionID != "thread" || hook.HookGeneration != producer.hookLaunchGeneration || (hook.DoneStatus == "ok") != done {
+					t.Fatalf("actual producer evidence: %+v", hook)
+				}
+				classify := func() Status {
+					observer := &Instance{ID: id, Tool: tool, ClaudeSessionID: "thread", CodexSessionID: "thread", Status: StatusWaiting, LastStartedAt: started, tmuxSession: &tmux.Session{Name: "worker", SocketName: socket}}
+					observer.mu.Lock()
+					observer.applyTerminatedPaneStatus()
+					got := observer.Status
+					observer.mu.Unlock()
+					return got
+				}
+				want := StatusError
+				if done && !(tool == "claude" && scenario == "prior-launch") {
+					want = StatusStopped
+				}
+				if got := classify(); got != want {
+					t.Fatalf("vanished worker: %s, want %s", got, want)
+				}
+				tm("kill-session", "-t", "keeper")
+				if got := classify(); got != StatusError {
+					t.Fatalf("vanished server: %s", got)
+				}
+			})
+		}
+	}
+}

--- a/internal/session/issue2091_real_tmux_test.go
+++ b/internal/session/issue2091_real_tmux_test.go
@@ -16,10 +16,7 @@ import (
 // Opt-in integration: the runner builds the actual CLI and supplies its path.
 // Every process lives on this test's private socket and exits naturally.
 func TestIssue2091RealProducersAndVanishedServer(t *testing.T) {
-	binary := os.Getenv("ISSUE2091_BIN")
-	if binary == "" {
-		t.Skip("set ISSUE2091_BIN to the built agent-deck CLI")
-	}
+	binary := review2115Binary(t)
 	for _, tool := range []string{"claude", "codex"} {
 		for _, scenario := range []string{"done", "ordinary", "prior-launch"} {
 			done := scenario != "ordinary"
@@ -28,6 +25,7 @@ func TestIssue2091RealProducersAndVanishedServer(t *testing.T) {
 				t.Setenv("HOME", home)
 				t.Setenv("XDG_CONFIG_HOME", "")
 				t.Setenv("XDG_DATA_HOME", "")
+				review2115Activate(t)
 				t.Setenv("CLAUDE_CONFIG_DIR", "")
 				socket := fmt.Sprintf("i2091-%d", time.Now().UnixNano())
 				tm := func(args ...string) []byte {
@@ -41,7 +39,7 @@ func TestIssue2091RealProducersAndVanishedServer(t *testing.T) {
 				tm("new-session", "-d", "-s", "keeper", "sleep 60")
 				t.Cleanup(func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", "keeper").Run() })
 				id := "issue2091-real"
-				producer := &Instance{ID: id, Tool: tool}
+				producer := &Instance{ID: id, Tool: tool, completionExecutableForTest: binary}
 				if err := producer.seedCompletionLaunch(); err != nil {
 					t.Fatal(err)
 				}
@@ -70,14 +68,13 @@ func TestIssue2091RealProducersAndVanishedServer(t *testing.T) {
 				if tool == "codex" {
 					command = "export HOME=" + shellescape.Quote(home) + " AGENTDECK_INSTANCE_ID=" + id + "; sleep 2; " + shellescape.Quote(binary) + " " + subcommand + " " + shellescape.Quote(string(data))
 				}
+				if tool == "claude" && scenario != "prior-launch" {
+					script := fmt.Sprintf("import json,datetime; open(%q,'w').write(json.dumps({'timestamp':datetime.datetime.now(datetime.timezone.utc).isoformat(),'type':'assistant','message':{'role':'assistant','content':%q}})+'\\n')", payload["transcript_path"].(string), text)
+					command = "python3 -c " + shellescape.Quote(script) + "; " + command
+				}
 				started := time.Now()
 				tm("new-session", "-d", "-s", "worker", producer.bindCompletionLaunchCommand(command))
-				if tool == "claude" && scenario != "prior-launch" {
-					record, _ := json.Marshal(map[string]any{"timestamp": time.Now().Format(time.RFC3339Nano), "type": "assistant", "message": map[string]any{"role": "assistant", "content": text}})
-					if err := os.WriteFile(payload["transcript_path"].(string), append(record, '\n'), 0600); err != nil {
-						t.Fatal(err)
-					}
-				}
+
 				deadline := time.Now().Add(10 * time.Second)
 				for exec.Command("tmux", "-L", socket, "has-session", "-t", "worker").Run() == nil {
 					if time.Now().After(deadline) {

--- a/internal/session/issue2091_terminated_launch_test.go
+++ b/internal/session/issue2091_terminated_launch_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// A probe begun for an old process must not classify the replacement process.
+// The channel handoff drives the actual lock-dropping path without real tmux.
+func TestIssue2091TerminatedProbeCannotOverwriteNewLaunch(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	inst := &Instance{
+		Tool: "codex", Status: StatusRunning,
+		LastStartedAt: time.Now().Add(-time.Minute),
+		tmuxSession:   &tmux.Session{Name: "issue2091-test-only"},
+		paneDeadExitStatusForTest: func() (int, bool) {
+			close(entered)
+			<-release
+			return 7, true
+		},
+	}
+	go func() {
+		inst.mu.Lock()
+		inst.applyTerminatedPaneStatus()
+		inst.mu.Unlock()
+		close(finished)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("exit probe did not start")
+	}
+	inst.mu.Lock()
+	inst.LastStartedAt = time.Now()
+	inst.Status = StatusStarting
+	inst.mu.Unlock()
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("exit probe did not finish")
+	}
+	if got := inst.GetStatusThreadSafe(); got != StatusStarting {
+		t.Fatalf("old exit probe overwrote new launch: got %s, want %s", got, StatusStarting)
+	}
+}

--- a/internal/session/issue2091_timing_test.go
+++ b/internal/session/issue2091_timing_test.go
@@ -1,0 +1,22 @@
+package session
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"testing"
+)
+
+// Includes local durable evidence/coordination overhead; excludes the unchanged
+// tmux subprocess latency so the additional classification cost is visible.
+func BenchmarkIssue2091UnknownExit(b *testing.B) {
+	b.Setenv("HOME", b.TempDir())
+	b.Setenv("XDG_CONFIG_HOME", "")
+	b.Setenv("XDG_DATA_HOME", "")
+	i := &Instance{ID: "issue2091-benchmark", Tool: "codex", Status: StatusWaiting, tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		i.mu.Lock()
+		i.Status = StatusWaiting
+		i.applyTerminatedPaneStatus()
+		i.mu.Unlock()
+	}
+}

--- a/internal/session/issue2115_boundary_test.go
+++ b/internal/session/issue2115_boundary_test.go
@@ -1,0 +1,190 @@
+package session
+
+import (
+	"al.essio.dev/pkg/shellescape"
+	"encoding/json"
+	"fmt"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReview2115BoundaryHelperControls(t *testing.T) {
+	binary := review2115Binary(t)
+	for _, scenario := range []string{"valid", "missing", "reseed", "duplicate", "writer-held", "missing-sequence", "null-sequence", "nonzero-sequence", "null-launch"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			review2115Activate(t)
+			p := &Instance{ID: "boundary-control", Tool: "codex"}
+			if err := p.seedCompletionLaunch(); err != nil {
+				t.Fatal(err)
+			}
+			gen := p.hookLaunchGeneration
+			if scenario == "missing-sequence" || scenario == "null-sequence" || scenario == "nonzero-sequence" || scenario == "null-launch" {
+				control := map[string]any{"generation": gen, "next_sequence": 0}
+				switch scenario {
+				case "missing-sequence":
+					delete(control, "next_sequence")
+				case "null-sequence":
+					control["next_sequence"] = nil
+				case "nonzero-sequence":
+					control["next_sequence"] = 1
+				case "null-launch":
+					control["launch_at"] = nil
+				}
+				data, _ := json.Marshal(control)
+				if err := os.WriteFile(filepath.Join(GetHooksDir(), p.ID+".generation.json"), data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if scenario == "missing" {
+				gen = "missing"
+			}
+			if scenario == "reseed" {
+				if err := p.seedCompletionLaunch(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if scenario == "duplicate" {
+				if err := RecordCompletionLaunch(p.ID, gen); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if scenario == "writer-held" {
+				locks, ok := tryCompletionWriterLocks(p.ID)
+				if !ok {
+					t.Fatal("lock")
+				}
+				defer locks.release()
+			}
+			cmd := exec.Command(binary, "completion-launch", p.ID, gen)
+			out, err := cmd.CombinedOutput()
+			if (err == nil) != (scenario == "valid") {
+				t.Fatalf("helper outcome %v %s", err, out)
+			}
+		})
+	}
+}
+
+func TestReview2115ImmediateCompletionColdObserver(t *testing.T) {
+	binary := review2115Binary(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
+	// Begin early in the second so immediate producer events share its precision.
+	for time.Now().Nanosecond() > 300000000 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	p := &Instance{ID: "boundary-immediate", Tool: "codex"}
+	if err := p.seedCompletionLaunch(); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command(binary, "completion-launch", p.ID, p.hookLaunchGeneration).CombinedOutput(); err != nil {
+		t.Fatalf("%v %s", err, out)
+	}
+	for _, event := range []string{"agent-turn-start", "agent-turn-complete"} {
+		data, _ := json.Marshal(map[string]string{"type": event, "thread-id": "thread", "turn-id": "A", "last-assistant-message": "===AGENTDECK_DONE=== status=ok summary=done"})
+		cmd := exec.Command(binary, "codex-notify", string(data))
+		cmd.Env = append(os.Environ(), "AGENTDECK_INSTANCE_ID="+p.ID, "AGENTDECK_HOOK_GENERATION="+p.hookLaunchGeneration)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v %s", err, out)
+		}
+	}
+	// The persisted post-spawn stamp can be later than completion.
+	postSpawn := time.Now()
+	hook := readHookStatusFile(p.ID)
+	if hook == nil || hook.UpdatedAt.Unix() != postSpawn.Unix() {
+		t.Fatal("control failed to exercise same-second completion")
+	}
+	observer := &Instance{ID: p.ID, Tool: "codex", CodexSessionID: "thread", Status: StatusWaiting, LastStartedAt: postSpawn, tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }, serverHasSessionsForTest: func() bool { return true }}
+	observer.mu.Lock()
+	observer.applyTerminatedPaneStatus()
+	got := observer.Status
+	observer.mu.Unlock()
+	if got != StatusStopped {
+		t.Fatalf("cold observer immediate completion: %s", got)
+	}
+}
+
+func TestReview2115RespawnRejectsOldSentinel(t *testing.T) {
+	binary := review2115Binary(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
+	t.Setenv("PATH", filepath.Dir(binary)+":"+os.Getenv("PATH"))
+	socket := fmt.Sprintf("r215-%d", time.Now().UnixNano())
+	tm := func(args ...string) {
+		t.Helper()
+		if out, err := exec.Command("tmux", append([]string{"-L", socket}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("%v %s", err, out)
+		}
+	}
+	tm("new-session", "-d", "-s", "keeper", "sleep 60")
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socket, "kill-session", "-t", "keeper").Run()
+		_ = exec.Command("tmux", "-L", socket, "kill-session", "-t", "worker").Run()
+	})
+	tm("new-session", "-d", "-s", "worker", "sleep 60")
+	p := &Instance{ID: "boundary-respawn", Tool: "claude", completionExecutableForTest: binary}
+	if err := p.seedCompletionLaunch(); err != nil {
+		t.Fatal(err)
+	}
+	// A sentinel written after early invalidation but before replacement prelude
+	// belongs to the old process, even though it is newer than the seed.
+	dir := filepath.Join(home, ".claude", "projects", "test")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(dir, "thread.jsonl")
+	record, _ := json.Marshal(map[string]any{"timestamp": time.Now().Format(time.RFC3339Nano), "type": "assistant", "message": map[string]string{"role": "assistant", "content": "===AGENTDECK_DONE=== status=ok summary=old"}})
+	if err := os.WriteFile(transcript, append(record, '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	payload, _ := json.Marshal(map[string]any{"hook_event_name": "Stop", "session_id": "thread", "transcript_path": transcript, "stop_hook_active": true, "cwd": home})
+	done := filepath.Join(home, "published")
+	command := "export AGENTDECK_INSTANCE_ID=" + p.ID + "; printf '%s' " + shellescape.Quote(string(payload)) + " | " + shellescape.Quote(binary) + " hook-handler; touch " + shellescape.Quote(done)
+	tm("respawn-pane", "-k", "-t", "worker", p.bindCompletionLaunchCommand(command))
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(done); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("replacement failed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	observer := &Instance{ID: p.ID, Tool: "claude", ClaudeSessionID: "thread", Status: StatusWaiting, LastStartedAt: time.Now(), tmuxSession: &tmux.Session{Name: "worker", SocketName: socket}}
+	// Wait for natural exit before asking the actual tmux disappearance probe.
+	for exec.Command("tmux", "-L", socket, "has-session", "-t", "worker").Run() == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("worker did not exit")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	observer.mu.Lock()
+	observer.applyTerminatedPaneStatus()
+	got := observer.Status
+	observer.mu.Unlock()
+	if got != StatusError {
+		t.Fatalf("old sentinel accepted after real respawn: %s", got)
+	}
+	locks, ok := tryCompletionWriterLocks(p.ID)
+	if !ok {
+		t.Fatal("lock")
+	}
+	proof := readSequencedCompletionLocked(p.ID)
+	locks.release()
+	if proof == nil || proof.DoneStatus != "ok" || !proof.DoneAt.Before(proof.CompletionLaunchAt) {
+		t.Fatalf("negative control lacked stale proof: %+v", proof)
+	}
+}

--- a/internal/session/issue2115_protocol_test.go
+++ b/internal/session/issue2115_protocol_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -96,7 +95,7 @@ func TestReview2115GuardProcesses(t *testing.T) {
 			review2115Activate(t)
 			childTemp := t.TempDir()
 			ready := filepath.Join(childTemp, "ready")
-			cmd := exec.Command(os.Args[0], "-test.run=^TestReview2115GuardChild$")
+			cmd := sessionTestChildCommand(t, "TestReview2115GuardChild")
 			cmd.Env = append(os.Environ(), "TMPDIR="+childTemp, "REVIEW2115_CHILD=1", "REVIEW2115_READY="+ready, "REVIEW2115_HOME="+os.Getenv("HOME"))
 			if err := cmd.Start(); err != nil {
 				t.Fatal(err)

--- a/internal/session/issue2115_protocol_test.go
+++ b/internal/session/issue2115_protocol_test.go
@@ -1,0 +1,261 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func review2115Activate(t *testing.T) {
+	t.Helper()
+	dir, err := resolveLocksDirForSpawnLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(map[string]any{"version": 1, "quiescent_upgrade_declared": true, "locks_namespace": canonical})
+	if err := os.WriteFile(filepath.Join(dir, "completion-protocol.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReview2115Activation(t *testing.T) {
+	for _, scenario := range []string{"missing", "malformed", "unsupported", "wrong-namespace", "valid"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			review2115Activate(t)
+			dir, _ := resolveLocksDirForSpawnLock()
+			path := filepath.Join(dir, "completion-protocol.json")
+			switch scenario {
+			case "missing":
+				if err := os.Rename(path, path+".saved"); err != nil {
+					t.Fatal(err)
+				}
+			case "malformed":
+				os.WriteFile(path, []byte("null"), 0600)
+			case "unsupported":
+				os.WriteFile(path, []byte("{\"version\":2}"), 0600)
+			case "wrong-namespace":
+				os.WriteFile(path, []byte("{\"version\":1,\"quiescent_upgrade_declared\":true,\"locks_namespace\":\"/wrong\"}"), 0600)
+			}
+			if got := completionProtocolActive(); got != (scenario == "valid") {
+				t.Fatalf("activation %s: %v", scenario, got)
+			}
+		})
+	}
+}
+
+// A real separate controller holds the guard until released or killed.
+func TestReview2115GuardChild(t *testing.T) {
+	if os.Getenv("REVIEW2115_CHILD") != "1" {
+		return
+	}
+	t.Setenv("HOME", os.Getenv("REVIEW2115_HOME"))
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	release, err := defaultAcquireInstanceSpawnLock("process-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	ready := os.Getenv("REVIEW2115_READY")
+	if err := os.WriteFile(ready, []byte(os.Getenv("HOME")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if _, err := os.Stat(ready + ".release"); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child release timeout")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestReview2115GuardProcesses(t *testing.T) {
+	for _, scenario := range []string{"release", "killed"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			review2115Activate(t)
+			childTemp := t.TempDir()
+			ready := filepath.Join(childTemp, "ready")
+			cmd := exec.Command(os.Args[0], "-test.run=^TestReview2115GuardChild$")
+			cmd.Env = append(os.Environ(), "TMPDIR="+childTemp, "REVIEW2115_CHILD=1", "REVIEW2115_READY="+ready, "REVIEW2115_HOME="+os.Getenv("HOME"))
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if cmd.ProcessState == nil {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+				}
+			}()
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				if _, err := os.Stat(ready); err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("child not ready")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			childHome, err := os.ReadFile(ready)
+			if err != nil || string(childHome) != os.Getenv("HOME") {
+				t.Fatal("controllers did not share sandbox HOME")
+			}
+			before := time.Now()
+			if release, ok := tryTerminatedStatusCommit("process-test"); ok {
+				release()
+				t.Fatal("two controllers acquired ownership")
+			}
+			if time.Since(before) > time.Second {
+				t.Fatal("status blocked")
+			}
+			path, _ := instanceSpawnLockPath("process-test")
+			guardBefore, err := os.Stat(path + ".guard")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "killed" {
+				if err := cmd.Process.Kill(); err != nil {
+					t.Fatal(err)
+				}
+				_ = cmd.Wait()
+			} else {
+				if err := os.WriteFile(ready+".release", nil, 0600); err != nil {
+					t.Fatal(err)
+				}
+				if err := cmd.Wait(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			release, ok := tryTerminatedStatusCommit("process-test")
+			if !ok {
+				t.Fatal("upgraded released/dead owner did not recover")
+			}
+			release()
+			guardAfter, err := os.Stat(path + ".guard")
+			if err != nil || !os.SameFile(guardBefore, guardAfter) {
+				t.Fatal("guard inode replaced")
+			}
+		})
+	}
+}
+
+func TestReview2115GuardPreservesReplacement(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
+	release, ok := tryTerminatedStatusCommit("replacement")
+	if !ok {
+		t.Fatal("acquire")
+	}
+	path, _ := instanceSpawnLockPath("replacement")
+	replacement := []byte("ambiguous replacement")
+	if err := os.WriteFile(path+".replacement", replacement, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path+".replacement", path); err != nil {
+		t.Fatal(err)
+	}
+	release()
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != string(replacement) {
+		t.Fatal("release removed replacement")
+	}
+}
+
+func TestReview2115GuardAmbiguousOwner(t *testing.T) {
+	for _, scenario := range []string{"legacy-dead", "live-old", "eperm"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			review2115Activate(t)
+			path, _ := instanceSpawnLockPath("ambiguous")
+			data := []byte("2147483647")
+			if scenario != "legacy-dead" {
+				data, _ = json.Marshal(spawnGuardOwner{Version: 1, PID: os.Getpid(), Nonce: "0123456789abcdef0123456789abcdef"})
+			}
+			if err := os.WriteFile(path, data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			old := time.Now().Add(-time.Hour)
+			os.Chtimes(path, old, old)
+			if scenario == "eperm" {
+				original := spawnOwnerSignal
+				spawnOwnerSignal = func(int, syscall.Signal) error { return syscall.EPERM }
+				defer func() { spawnOwnerSignal = original }()
+			}
+			if release, ok := tryTerminatedStatusCommit("ambiguous"); ok {
+				release()
+				t.Fatal("ambiguous owner reclaimed")
+			}
+			retained, err := os.ReadFile(path)
+			if err != nil || string(retained) != string(data) {
+				t.Fatal("owner changed")
+			}
+		})
+	}
+}
+
+func TestReview2115PreactivationClassification(t *testing.T) {
+	for _, scenario := range []string{"empty", "occupied", "active"} {
+		t.Run(scenario, func(t *testing.T) {
+			observer, scope := issue2091ProofObserver(t, false)
+			if scenario != "active" {
+				dir, _ := resolveLocksDirForSpawnLock()
+				if err := os.Rename(filepath.Join(dir, "completion-protocol.json"), filepath.Join(dir, "completion-protocol.json.saved")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			generation, _ := hookGenerationForInstance(observer.ID)
+			data, _ := json.Marshal(map[string]any{"generation": generation, "next_sequence": 2, "launch_at": time.Now().Add(-2 * time.Second)})
+			if err := os.WriteFile(filepath.Join(scope, observer.ID+".generation.json"), data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "active" {
+				review2115Activate(t)
+			}
+			if scenario == "occupied" {
+				path, _ := instanceSpawnLockPath(observer.ID)
+				if err := os.WriteFile(path, []byte("legacy"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			observer.mu.Lock()
+			observer.applyTerminatedPaneStatus()
+			got := observer.Status
+			observer.mu.Unlock()
+			want := StatusError
+			if scenario == "occupied" {
+				want = StatusWaiting
+			}
+			if scenario == "active" {
+				want = StatusStopped
+			}
+			if got != want {
+				t.Fatalf("%s: got %s want %s", scenario, got, want)
+			}
+		})
+	}
+}

--- a/internal/session/issue2115_review_test.go
+++ b/internal/session/issue2115_review_test.go
@@ -1,0 +1,128 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+func review2115Binary(t *testing.T) string {
+	t.Helper()
+	if completionExecutableForTests == "" {
+		t.Fatal("TestMain did not provision matching agent-deck helper")
+	}
+	return completionExecutableForTests
+}
+
+// This writer runs after the initial hook read, at the actual later interval.
+func TestReview2115LatePositiveWriter(t *testing.T) {
+	binary := review2115Binary(t)
+	for _, initial := range []string{"seed", "done"} {
+		t.Run(initial, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_DATA_HOME", "")
+			review2115Activate(t)
+			id := "review2115-late"
+			producer := &Instance{ID: id, Tool: "codex"}
+			if err := producer.seedCompletionLaunch(); err != nil {
+				t.Fatal(err)
+			}
+			if err := RecordCompletionLaunch(producer.ID, producer.hookLaunchGeneration); err != nil {
+				t.Fatal(err)
+			}
+			write := func(event, turn, text string) {
+				t.Helper()
+				payload, _ := json.Marshal(map[string]string{"type": event, "thread-id": "thread", "turn-id": turn, "last-assistant-message": text})
+				cmd := exec.Command(binary, "codex-notify", string(payload))
+				cmd.Env = append(os.Environ(), "AGENTDECK_INSTANCE_ID="+id, "AGENTDECK_HOOK_GENERATION="+producer.hookLaunchGeneration)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("writer: %v %s", err, out)
+				}
+			}
+			if initial == "done" {
+				write("agent-turn-start", "A", "")
+				write("agent-turn-complete", "A", "===AGENTDECK_DONE=== status=ok summary=first")
+			}
+			observer := &Instance{ID: id, Tool: "codex", CodexSessionID: "thread", Status: StatusWaiting, LastStartedAt: time.Now().Add(-time.Minute), tmuxSession: &tmux.Session{Name: "missing"}, paneDeadExitStatusForTest: func() (int, bool) { return 0, false }, serverHasSessionsForTest: func() bool { return true }}
+			observer.terminatedCommitBarrierForTest = func() {
+				write("agent-turn-start", "B", "")
+				write("agent-turn-complete", "B", "===AGENTDECK_DONE=== status=ok summary=second")
+				h := readHookStatusFile(id)
+				if h == nil || h.DoneStatus != "ok" {
+					t.Fatalf("writer did not publish proof: %+v", h)
+				}
+			}
+			observer.mu.Lock()
+			observer.applyTerminatedPaneStatus()
+			got := observer.Status
+			observer.mu.Unlock()
+			if got != StatusStopped {
+				t.Fatalf("late current-launch DONE classified %s, want stopped", got)
+			}
+		})
+	}
+}
+
+func TestReview2115SameSecondCompletion(t *testing.T) {
+	now := time.Now().Truncate(time.Second).Add(900 * time.Millisecond)
+	started := now.Add(-500 * time.Millisecond)
+	proof := &HookStatus{CompletionLaunchAt: started, TimestampKnown: true, HookGeneration: "G", SessionID: "thread", Sequence: 2, DoneStatus: "ok", Status: "waiting", DoneAt: now.Add(-100 * time.Millisecond), UpdatedAt: now.Truncate(time.Second)}
+	if !validTerminatedCompletion(proof, "claude", "G", "thread", started, now) {
+		t.Fatal("valid same-second assistant completion rejected by truncated status timestamp")
+	}
+}
+
+func TestReview2115LegacyDeadSpawnOwnerRemainsUnsupported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
+	child := exec.Command("sh", "-c", "exit 0")
+	if err := child.Run(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := instanceSpawnLockPath("review2115-dead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(fmt.Sprint(child.Process.Pid)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	release, ok := tryTerminatedStatusCommit("review2115-dead")
+	if ok {
+		release()
+		t.Fatal("unversioned legacy owner unexpectedly reclaimed")
+	}
+}
+
+func TestReview2115LiveOldSpawnOwner(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	review2115Activate(t)
+	path, err := instanceSpawnLockPath("review2115-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(fmt.Sprint(os.Getpid())), 0600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if release, ok := tryTerminatedStatusCommit("review2115-live"); ok {
+		release()
+		t.Fatal("live owner reclaimed by age")
+	}
+	if _, err := os.Stat(filepath.Clean(path)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/session/terminated_completion.go
+++ b/internal/session/terminated_completion.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -12,6 +13,9 @@ import (
 )
 
 const terminatedCompletionMaxAge = 30 * time.Second
+
+// Set only by TestMain to a real CLI built from this checkout.
+var completionExecutableForTests string
 
 func completionHookTool(tool string) bool {
 	return IsClaudeCompatible(tool) || IsCodexCompatible(tool)
@@ -36,7 +40,29 @@ func (i *Instance) bindCompletionLaunchCommand(command string) string {
 	generation := i.hookLaunchGeneration
 	i.mu.RUnlock()
 	if completionHookTool(i.Tool) && generation != "" && !i.IsSSH() {
-		return "export AGENTDECK_HOOK_GENERATION=" + shellescape.Quote(generation) + "; " + command
+		prefix := "export AGENTDECK_HOOK_GENERATION=" + shellescape.Quote(generation) + "; "
+		// Before the operator-declared quiescent activation, preserve ordinary
+		// launch behavior and keep completion fallback disabled.
+		if !completionProtocolActive() {
+			return prefix + command
+		}
+		// Sandboxed containers do not provide the matching Deck executable.
+		// Preserve launch behavior, but leave the boundary absent so fallback
+		// remains fail-closed.
+		if i.IsSandboxed() {
+			return prefix + command
+		}
+		executable, err := os.Executable()
+		if completionExecutableForTests != "" {
+			executable, err = completionExecutableForTests, nil
+		}
+		if i.completionExecutableForTest != "" {
+			executable, err = i.completionExecutableForTest, nil
+		}
+		if err != nil {
+			return prefix + "exit 1"
+		}
+		return prefix + shellescape.Quote(executable) + " completion-launch " + shellescape.Quote(i.ID) + " " + shellescape.Quote(generation) + " || exit $?; " + command
 	}
 	return command
 }
@@ -59,15 +85,19 @@ func validTerminatedCompletion(hook *HookStatus, tool, generation, sessionID str
 		hook.DoneStatus != "ok" || hook.Status != "waiting" {
 		return false
 	}
+	boundary := hook.CompletionLaunchAt
+	if boundary.IsZero() || boundary.After(now) {
+		return false
+	}
 	// A newly invoked Stop must not refresh a prior launch's transcript sentinel.
-	if IsClaudeCompatible(tool) && (hook.DoneAt.IsZero() || hook.DoneAt.Before(started) || hook.DoneAt.After(now)) {
+	if IsClaudeCompatible(tool) && (hook.DoneAt.IsZero() || hook.DoneAt.Before(boundary) || hook.DoneAt.After(now)) {
 		return false
 	}
 	if IsCodexCompatible(tool) && (hook.codexCompletionConsumed || hook.CodexStartedGeneration == "" ||
 		hook.CodexStartedGeneration != hook.CodexCompletedGeneration || hook.CodexStartedSessionID != sessionID || hook.CodexCompletedSessionID != sessionID) {
 		return false
 	}
-	return !hook.UpdatedAt.Before(started) && !hook.UpdatedAt.After(now) && now.Sub(hook.UpdatedAt) <= terminatedCompletionMaxAge
+	return !hook.UpdatedAt.Before(boundary.Truncate(time.Second)) && !hook.UpdatedAt.After(now) && now.Sub(hook.UpdatedAt) <= terminatedCompletionMaxAge
 }
 
 // Called with i.mu held: acquisition must never wait for a producer. The
@@ -118,6 +148,7 @@ func readSequencedCompletionLocked(instanceID string) *HookStatus {
 	root := GetHooksDir()
 	authorityPath, generation := "", ""
 	var sequence uint64
+	var launchAt time.Time
 	for _, dir := range []string{root, filepath.Join(root, "sandbox", instanceID)} {
 		path := filepath.Join(dir, instanceID+".generation.json")
 		info, err := os.Lstat(path)
@@ -129,14 +160,16 @@ func readSequencedCompletionLocked(instanceID string) *HookStatus {
 		}
 		data, err := readStatusFileNoFollow(path)
 		var control struct {
-			Generation   string  `json:"generation"`
-			NextSequence *uint64 `json:"next_sequence"`
+			Generation   string    `json:"generation"`
+			NextSequence *uint64   `json:"next_sequence"`
+			LaunchAt     time.Time `json:"launch_at"`
 		}
 		if err != nil || json.Unmarshal(data, &control) != nil || control.Generation == "" || control.NextSequence == nil || *control.NextSequence == 0 {
 			return nil
 		}
 		authorityPath = filepath.Join(dir, instanceID+".json")
 		generation, sequence = control.Generation, *control.NextSequence
+		launchAt = control.LaunchAt
 	}
 	if authorityPath == "" || hookStatusFilePath(instanceID) != authorityPath {
 		return nil
@@ -154,5 +187,50 @@ func readSequencedCompletionLocked(instanceID string) *HookStatus {
 	if hook == nil || hook.HookGeneration != generation || hook.Sequence != sequence {
 		return nil
 	}
+	hook.CompletionLaunchAt = launchAt
 	return hook
+}
+
+// RecordCompletionLaunch runs in the replacement process, before the tool.
+// The parent may still own the spawn marker; only hook writer locks are taken.
+// A missing boundary never authorizes completion, and an existing boundary is
+// never refreshed by a repeated or delayed helper.
+func RecordCompletionLaunch(instanceID, generation string) error {
+	if !hermesHookInstanceIDPattern.MatchString(instanceID) || strings.Contains(instanceID, "..") || generation == "" {
+		return fmt.Errorf("invalid completion launch identity")
+	}
+	locks, ok := tryCompletionWriterLocks(instanceID)
+	if !ok {
+		return fmt.Errorf("completion writer busy or unavailable")
+	}
+	defer locks.release()
+	var path string
+	var control hermesHookControl
+	for _, dir := range []string{GetHooksDir(), filepath.Join(GetHooksDir(), "sandbox", instanceID)} {
+		candidate := filepath.Join(dir, instanceID+".generation.json")
+		info, err := os.Lstat(candidate)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil || !info.Mode().IsRegular() || path != "" {
+			return fmt.Errorf("ambiguous completion authority")
+		}
+		data, err := readStatusFileNoFollow(candidate)
+		var seed struct {
+			Generation   string          `json:"generation"`
+			NextSequence *uint64         `json:"next_sequence"`
+			LaunchAt     json.RawMessage `json:"launch_at"`
+		}
+		if err != nil || json.Unmarshal(data, &seed) != nil || seed.NextSequence == nil || *seed.NextSequence != 0 ||
+			json.Unmarshal(data, &control) != nil || control.Generation != generation || !control.LaunchAt.IsZero() ||
+			string(seed.LaunchAt) == "null" {
+			return fmt.Errorf("invalid or already bound completion authority")
+		}
+		path = candidate
+	}
+	if path == "" {
+		return fmt.Errorf("missing completion authority")
+	}
+	control.LaunchAt = time.Now().UTC()
+	return atomicHermesJSON(path, control)
 }

--- a/internal/session/terminated_completion.go
+++ b/internal/session/terminated_completion.go
@@ -1,7 +1,11 @@
 package session
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
@@ -64,4 +68,91 @@ func validTerminatedCompletion(hook *HookStatus, tool, generation, sessionID str
 		return false
 	}
 	return !hook.UpdatedAt.Before(started) && !hook.UpdatedAt.After(now) && now.Sub(hook.UpdatedAt) <= terminatedCompletionMaxAge
+}
+
+// Called with i.mu held: acquisition must never wait for a producer. The
+// root-then-scoped order matches launch seeding; spawn ownership excludes a
+// concurrent scope migration. Reject symlinked directories and lock files.
+func tryCompletionWriterLocks(instanceID string) (*hermesHookLocks, bool) {
+	root := GetHooksDir()
+	dirs := []string{root}
+	for _, dir := range []string{root, filepath.Join(root, "sandbox"), filepath.Join(root, "sandbox", instanceID)} {
+		info, err := os.Lstat(dir)
+		if os.IsNotExist(err) && dir != root {
+			break
+		}
+		if err != nil || !info.IsDir() {
+			return nil, false
+		}
+		if dir == filepath.Join(root, "sandbox", instanceID) {
+			dirs = append(dirs, dir)
+		}
+	}
+	locks := &hermesHookLocks{}
+	for _, dir := range dirs {
+		f, err := os.OpenFile(filepath.Join(dir, instanceID+".lock"), os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
+		if err != nil {
+			locks.release()
+			return nil, false
+		}
+		info, err := f.Stat()
+		if err != nil || !info.Mode().IsRegular() {
+			_ = f.Close()
+			locks.release()
+			return nil, false
+		}
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			_ = f.Close()
+			locks.release()
+			return nil, false
+		}
+		locks.files = append(locks.files, f)
+	}
+	return locks, true
+}
+
+// All possible writer scopes must be locked. A single authoritative control
+// must match the selected status scope and sequence exactly; a newer control
+// with an old DONE record is a torn publication, not completion evidence.
+func readSequencedCompletionLocked(instanceID string) *HookStatus {
+	root := GetHooksDir()
+	authorityPath, generation := "", ""
+	var sequence uint64
+	for _, dir := range []string{root, filepath.Join(root, "sandbox", instanceID)} {
+		path := filepath.Join(dir, instanceID+".generation.json")
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil || !info.Mode().IsRegular() || authorityPath != "" {
+			return nil
+		}
+		data, err := readStatusFileNoFollow(path)
+		var control struct {
+			Generation   string  `json:"generation"`
+			NextSequence *uint64 `json:"next_sequence"`
+		}
+		if err != nil || json.Unmarshal(data, &control) != nil || control.Generation == "" || control.NextSequence == nil || *control.NextSequence == 0 {
+			return nil
+		}
+		authorityPath = filepath.Join(dir, instanceID+".json")
+		generation, sequence = control.Generation, *control.NextSequence
+	}
+	if authorityPath == "" || hookStatusFilePath(instanceID) != authorityPath {
+		return nil
+	}
+	for _, dir := range []string{root, filepath.Join(root, "sandbox", instanceID)} {
+		path := filepath.Join(dir, instanceID+".json")
+		if path == authorityPath {
+			continue
+		}
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			return nil
+		}
+	}
+	hook := readHookStatusFile(instanceID)
+	if hook == nil || hook.HookGeneration != generation || hook.Sequence != sequence {
+		return nil
+	}
+	return hook
 }

--- a/internal/session/terminated_completion.go
+++ b/internal/session/terminated_completion.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"fmt"
+	"time"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+const terminatedCompletionMaxAge = 30 * time.Second
+
+func completionHookTool(tool string) bool {
+	return IsClaudeCompatible(tool) || IsCodexCompatible(tool)
+}
+
+// Publish before a start/resume can signal the old process. A remote hook
+// directory is not local authority, so SSH sessions retain the old fallback.
+func (i *Instance) seedCompletionLaunch() error {
+	if !completionHookTool(i.Tool) || i.IsSSH() {
+		return nil
+	}
+	// Veto in-flight probes before durable publication can block on a hook writer.
+	i.spawnGen.Add(1)
+	if _, err := i.seedHookGeneration("starting", false); err != nil {
+		return fmt.Errorf("seed completion launch: %w", err)
+	}
+	return nil
+}
+
+func (i *Instance) bindCompletionLaunchCommand(command string) string {
+	i.mu.RLock()
+	generation := i.hookLaunchGeneration
+	i.mu.RUnlock()
+	if completionHookTool(i.Tool) && generation != "" && !i.IsSSH() {
+		return "export AGENTDECK_HOOK_GENERATION=" + shellescape.Quote(generation) + "; " + command
+	}
+	return command
+}
+
+func (i *Instance) completionSessionIDLocked() string {
+	if IsClaudeCompatible(i.Tool) {
+		return i.ClaudeSessionID
+	}
+	if IsCodexCompatible(i.Tool) {
+		return i.CodexSessionID
+	}
+	return i.GenericSessionID
+}
+
+// Ordinary Stop/waiting is never completion proof. Both launch and
+// conversation identities are mandatory, including after observer reload.
+func validTerminatedCompletion(hook *HookStatus, tool, generation, sessionID string, started, now time.Time) bool {
+	if hook == nil || !hook.TimestampKnown || generation == "" || sessionID == "" || started.IsZero() ||
+		hook.HookGeneration != generation || hook.SessionID != sessionID || hook.Sequence == 0 ||
+		hook.DoneStatus != "ok" || hook.Status != "waiting" {
+		return false
+	}
+	// A newly invoked Stop must not refresh a prior launch's transcript sentinel.
+	if IsClaudeCompatible(tool) && (hook.DoneAt.IsZero() || hook.DoneAt.Before(started) || hook.DoneAt.After(now)) {
+		return false
+	}
+	if IsCodexCompatible(tool) && (hook.codexCompletionConsumed || hook.CodexStartedGeneration == "" ||
+		hook.CodexStartedGeneration != hook.CodexCompletedGeneration || hook.CodexStartedSessionID != sessionID || hook.CodexCompletedSessionID != sessionID) {
+		return false
+	}
+	return !hook.UpdatedAt.Before(started) && !hook.UpdatedAt.After(now) && now.Sub(hook.UpdatedAt) <= terminatedCompletionMaxAge
+}

--- a/internal/session/testhelper_test.go
+++ b/internal/session/testhelper_test.go
@@ -1,0 +1,162 @@
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// These flags exist only in the test binary. Re-exec children reuse the exact
+// CLI built by their parent; runtime HOME remains independently isolated.
+var (
+	inheritedTestHelper        = flag.String("session-test-completion-helper", "", "parent-owned completion CLI")
+	inheritedTestHelperDigest  = flag.String("session-test-completion-helper-sha256", "", "SHA-256 of parent-owned CLI")
+	completionTestHelperDigest string
+)
+
+func validateSessionTestHelper(path, digest string) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("helper path must be absolute")
+	}
+	expected, err := hex.DecodeString(digest)
+	if err != nil || len(expected) != sha256.Size {
+		return fmt.Errorf("helper digest must be SHA-256")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat inherited helper: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0111 == 0 {
+		return fmt.Errorf("helper must be a regular executable")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read inherited helper: %w", err)
+	}
+	actual := sha256.Sum256(data)
+	if hex.EncodeToString(actual[:]) != digest {
+		return fmt.Errorf("inherited helper digest mismatch")
+	}
+	return nil
+}
+
+func provisionSessionTestHelper() (func(), error) {
+	if *inheritedTestHelper != "" || *inheritedTestHelperDigest != "" {
+		if err := validateSessionTestHelper(*inheritedTestHelper, *inheritedTestHelperDigest); err != nil {
+			return nil, err
+		}
+		completionExecutableForTests = *inheritedTestHelper
+		completionTestHelperDigest = *inheritedTestHelperDigest
+		return func() {}, nil // The parent owns this helper until all children exit.
+	}
+	root, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	projectRoot := filepath.Clean(filepath.Join(root, "../.."))
+	if _, err := os.Stat(filepath.Join(projectRoot, "cmd", "agent-deck")); err != nil {
+		return nil, err
+	}
+	dir, err := os.MkdirTemp("", "agent-deck-test-helper-")
+	if err != nil {
+		return nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	out := filepath.Join(dir, "agent-deck")
+	cmd := exec.Command("go", "build", "-p", "1", "-o", out, "./cmd/agent-deck")
+	cmd.Dir = projectRoot
+	if output, err := cmd.CombinedOutput(); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("build matching CLI: %w: %s", err, output)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	if err := os.Chmod(out, 0555); err != nil {
+		cleanup()
+		return nil, err
+	}
+	digest := sha256.Sum256(data)
+	completionExecutableForTests = out
+	completionTestHelperDigest = hex.EncodeToString(digest[:])
+	return cleanup, nil
+}
+
+func sessionTestChildCommand(t *testing.T, testName string) *exec.Cmd {
+	t.Helper()
+	if err := validateSessionTestHelper(completionExecutableForTests, completionTestHelperDigest); err != nil {
+		t.Fatal(err)
+	}
+	return exec.Command(os.Args[0], "-test.run=^"+regexp.QuoteMeta(testName)+"$",
+		"-session-test-completion-helper="+completionExecutableForTests,
+		"-session-test-completion-helper-sha256="+completionTestHelperDigest)
+}
+
+func TestSessionTestHelperChild(t *testing.T) {
+	if *inheritedTestHelper == "" {
+		return
+	}
+	if completionExecutableForTests != *inheritedTestHelper || completionTestHelperDigest != *inheritedTestHelperDigest {
+		t.Fatal("child did not retain the parent helper identity")
+	}
+	if err := validateSessionTestHelper(completionExecutableForTests, completionTestHelperDigest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSessionTestHelperInheritance(t *testing.T) {
+	bin := t.TempDir()
+	marker := filepath.Join(bin, "go-was-invoked")
+	// Any child build is an explicit failure, even with a warm Go cache.
+	if err := os.WriteFile(filepath.Join(bin, "go"), []byte("#!/bin/sh\nprintf invoked > \"$SESSION_TEST_GO_MARKER\"\nexit 97\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SESSION_TEST_GO_MARKER", marker)
+	nonexec := filepath.Join(bin, "non-executable")
+	if err := os.WriteFile(nonexec, []byte("invalid"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct{ name, path, digest, want string }{
+		{"same-parent-helper", completionExecutableForTests, completionTestHelperDigest, ""},
+		{"missing-path", "", completionTestHelperDigest, "helper path must be absolute"},
+		{"missing-digest", completionExecutableForTests, "", "helper digest must be SHA-256"},
+		{"relative-path", "agent-deck", completionTestHelperDigest, "helper path must be absolute"},
+		{"missing-file", filepath.Join(bin, "missing"), completionTestHelperDigest, "stat inherited helper"},
+		{"directory", bin, completionTestHelperDigest, "helper must be a regular executable"},
+		{"non-executable", nonexec, completionTestHelperDigest, "helper must be a regular executable"},
+		{"wrong-digest", completionExecutableForTests, strings.Repeat("0", 64), "inherited helper digest mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := sessionTestChildCommand(t, "TestSessionTestHelperChild")
+			cmd.Args[2] = "-session-test-completion-helper=" + tt.path
+			cmd.Args[3] = "-session-test-completion-helper-sha256=" + tt.digest
+			cmd.Env = append(os.Environ(), "HOME="+t.TempDir(), "TMPDIR="+t.TempDir())
+			output, err := cmd.CombinedOutput()
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("inherited child failed: %v: %s", err, output)
+				}
+			} else if err == nil || !strings.Contains(string(output), tt.want) {
+				t.Fatalf("invalid inheritance: error=%v output=%s; want %q", err, output, tt.want)
+			}
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("child invoked Go: %v", err)
+			}
+		})
+	}
+	// No child may remove the shared helper, including rejected children.
+	if err := validateSessionTestHelper(completionExecutableForTests, completionTestHelperDigest); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/session/testhelper_test.go
+++ b/internal/session/testhelper_test.go
@@ -48,7 +48,13 @@ func validateSessionTestHelper(path, digest string) error {
 }
 
 func provisionSessionTestHelper() (func(), error) {
-	if *inheritedTestHelper != "" || *inheritedTestHelperDigest != "" {
+	inherited := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "session-test-completion-helper" || f.Name == "session-test-completion-helper-sha256" {
+			inherited = true
+		}
+	})
+	if inherited {
 		if err := validateSessionTestHelper(*inheritedTestHelper, *inheritedTestHelperDigest); err != nil {
 			return nil, err
 		}
@@ -129,6 +135,9 @@ func TestSessionTestHelperInheritance(t *testing.T) {
 	tests := []struct{ name, path, digest, want string }{
 		{"same-parent-helper", completionExecutableForTests, completionTestHelperDigest, ""},
 		{"missing-path", "", completionTestHelperDigest, "helper path must be absolute"},
+		{"empty-path-only", "", "", "helper path must be absolute"},
+		{"empty-digest-only", "", "", "helper path must be absolute"},
+		{"both-empty", "", "", "helper path must be absolute"},
 		{"missing-digest", completionExecutableForTests, "", "helper digest must be SHA-256"},
 		{"relative-path", "agent-deck", completionTestHelperDigest, "helper path must be absolute"},
 		{"missing-file", filepath.Join(bin, "missing"), completionTestHelperDigest, "stat inherited helper"},
@@ -141,6 +150,11 @@ func TestSessionTestHelperInheritance(t *testing.T) {
 			cmd := sessionTestChildCommand(t, "TestSessionTestHelperChild")
 			cmd.Args[2] = "-session-test-completion-helper=" + tt.path
 			cmd.Args[3] = "-session-test-completion-helper-sha256=" + tt.digest
+			if tt.name == "empty-path-only" {
+				cmd.Args = cmd.Args[:3]
+			} else if tt.name == "empty-digest-only" {
+				cmd.Args = append(cmd.Args[:2], cmd.Args[3])
+			}
 			cmd.Env = append(os.Environ(), "HOME="+t.TempDir(), "TMPDIR="+t.TempDir())
 			output, err := cmd.CombinedOutput()
 			if tt.want == "" {

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -245,6 +245,33 @@ func runTestMain(m *testing.M) int {
 	// See CLAUDE.md: "2025-12-11 Incident: Tests with AGENTDECK_PROFILE=work overwrote ALL 36 production sessions"
 	os.Setenv("AGENTDECK_PROFILE", "_test")
 
+	// Build one matching CLI helper for tests that exercise the launch prelude.
+	// This is test-only state; production always uses os.Executable().
+	helperRoot, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "test helper source discovery failed: %v\n", err)
+		return 1
+	}
+	projectRoot := filepath.Clean(filepath.Join(helperRoot, "../.."))
+	if _, err := os.Stat(filepath.Join(projectRoot, "cmd", "agent-deck")); err != nil {
+		fmt.Fprintf(os.Stderr, "test helper source discovery failed: %v\n", err)
+		return 1
+	}
+	helperDir, err := os.MkdirTemp("", "agent-deck-test-helper-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "test helper temp directory failed: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(helperDir)
+	out := filepath.Join(helperDir, "agent-deck")
+	cmd := exec.Command("go", "build", "-p", "1", "-o", out, "./cmd/agent-deck")
+	cmd.Dir = projectRoot
+	if output, buildErr := cmd.CombinedOutput(); buildErr != nil {
+		fmt.Fprintf(os.Stderr, "test helper build failed: %v: %s\n", buildErr, output)
+		return 1
+	}
+	completionExecutableForTests = out
+
 	// Run tests
 	code := m.Run()
 

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -213,6 +214,7 @@ func TestMain(m *testing.M) {
 // TMUX_TMPDIR is removed. Skipping this leaked a tmux server (1 pty) on every
 // run — the 2026-06-07 pty-exhaustion incident.
 func runTestMain(m *testing.M) int {
+	flag.Parse()
 	// Isolate HOME+XDG FIRST so every path this package resolves (config.json,
 	// profiles/<p>/state.db, worker-scratch, logs) lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
@@ -245,32 +247,12 @@ func runTestMain(m *testing.M) int {
 	// See CLAUDE.md: "2025-12-11 Incident: Tests with AGENTDECK_PROFILE=work overwrote ALL 36 production sessions"
 	os.Setenv("AGENTDECK_PROFILE", "_test")
 
-	// Build one matching CLI helper for tests that exercise the launch prelude.
-	// This is test-only state; production always uses os.Executable().
-	helperRoot, err := os.Getwd()
+	cleanupHelper, err := provisionSessionTestHelper()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "test helper source discovery failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "test helper provisioning failed: %v\n", err)
 		return 1
 	}
-	projectRoot := filepath.Clean(filepath.Join(helperRoot, "../.."))
-	if _, err := os.Stat(filepath.Join(projectRoot, "cmd", "agent-deck")); err != nil {
-		fmt.Fprintf(os.Stderr, "test helper source discovery failed: %v\n", err)
-		return 1
-	}
-	helperDir, err := os.MkdirTemp("", "agent-deck-test-helper-")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "test helper temp directory failed: %v\n", err)
-		return 1
-	}
-	defer os.RemoveAll(helperDir)
-	out := filepath.Join(helperDir, "agent-deck")
-	cmd := exec.Command("go", "build", "-p", "1", "-o", out, "./cmd/agent-deck")
-	cmd.Dir = projectRoot
-	if output, buildErr := cmd.CombinedOutput(); buildErr != nil {
-		fmt.Fprintf(os.Stderr, "test helper build failed: %v: %s\n", buildErr, output)
-		return 1
-	}
-	completionExecutableForTests = out
+	defer cleanupHelper()
 
 	// Run tests
 	code := m.Run()

--- a/internal/session/transcript_done_scan.go
+++ b/internal/session/transcript_done_scan.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // This file holds the transcript-tail scan behind completion-sentinel
@@ -20,6 +21,7 @@ import (
 // transcriptContentMessage extracts the assistant message content blocks from
 // a transcript line, for completion-sentinel detection.
 type transcriptContentMessage struct {
+	Timestamp   string `json:"timestamp"`
 	Type        string `json:"type"`
 	IsSidechain bool   `json:"isSidechain"`
 	Message     struct {
@@ -101,6 +103,7 @@ func ScanTranscriptTailForDone(path string) (sig DoneSignal, found bool, pending
 		switch msg.Type {
 		case "assistant":
 			sig, found = ScanDoneSentinel(transcriptText(msg.Message.Content))
+			sig.Timestamp, _ = time.Parse(time.RFC3339Nano, msg.Timestamp)
 			return sig, found, false
 		case "user":
 			return DoneSignal{}, false, true

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -957,20 +957,21 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		return nil
 	}
 	var raw struct {
-		Status                   string `json:"status"`
-		SessionID                string `json:"session_id"`
-		Event                    string `json:"event"`
-		Timestamp                int64  `json:"ts"`
-		DoneStatus               string `json:"done_status"`
-		DoneSummary              string `json:"done_summary"`
-		TranscriptPath           string `json:"transcript_path"`
-		Cwd                      string `json:"cwd"`
-		CodexStartedGeneration   string `json:"codex_started_generation"`
-		CodexCompletedGeneration string `json:"codex_completed_generation"`
-		CodexStartedSessionID    string `json:"codex_started_session_id"`
-		CodexCompletedSessionID  string `json:"codex_completed_session_id"`
-		HookGeneration           string `json:"hook_generation"`
-		Sequence                 uint64 `json:"sequence"`
+		Status                   string    `json:"status"`
+		SessionID                string    `json:"session_id"`
+		Event                    string    `json:"event"`
+		Timestamp                int64     `json:"ts"`
+		DoneAt                   time.Time `json:"done_at"`
+		DoneStatus               string    `json:"done_status"`
+		DoneSummary              string    `json:"done_summary"`
+		TranscriptPath           string    `json:"transcript_path"`
+		Cwd                      string    `json:"cwd"`
+		CodexStartedGeneration   string    `json:"codex_started_generation"`
+		CodexCompletedGeneration string    `json:"codex_completed_generation"`
+		CodexStartedSessionID    string    `json:"codex_started_session_id"`
+		CodexCompletedSessionID  string    `json:"codex_completed_session_id"`
+		HookGeneration           string    `json:"hook_generation"`
+		Sequence                 uint64    `json:"sequence"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
@@ -986,10 +987,12 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
 	hookStatus := &HookStatus{
+		TimestampKnown:           raw.Timestamp > 0,
 		Status:                   raw.Status,
 		SessionID:                raw.SessionID,
 		Event:                    raw.Event,
 		UpdatedAt:                updatedAt,
+		DoneAt:                   raw.DoneAt,
 		DoneStatus:               raw.DoneStatus,
 		DoneSummary:              raw.DoneSummary,
 		TranscriptPath:           raw.TranscriptPath,


### PR DESCRIPTION
## What problem does this solve?

When a pane disappears, status can incorrectly report an error even though the current Claude or Codex launch published a valid completion during the probe.

## Why this change

The final decision probes server presence independently, rereads the latest sequenced record under writer locks, and binds freshness to a precise replacement-process launch boundary. Completion fallback is enabled only after an operator-declared quiescent upgrade of every controller sharing the namespace. Legacy and unsupported environments fail closed.

## User impact

Claude and Codex local launches can receive accurate completion classification after activation. Pi has no supported producer and remains fail-closed. Sandboxed launches without a matching helper preserve ordinary launch behavior and do not receive positive completion fallback.

Activation is a coordinated operational boundary. All Deck TUIs, watchers, CLI jobs, automation, and SSH launch paths sharing the state and locks namespace must be upgraded and quiesced first. Agent and tmux sessions need not be killed. The declaration is not continuous proof against later legacy invocation. Missing, malformed, unsupported, or ambiguous activation disables positive fallback.

## Evidence

The baseline reproduced late DONE, same-second timestamp, and dead-owner failures. Focused race controls passed with real Claude and Codex producers, private tmux, cold observers, stale callbacks, torn records, activation gating, and guarded ownership. All 40 required test and subtest checks passed with no skips or test failures. The outer receipt detected a helper directory left by the deliberately killed child. A subsequent cleanup-only correction passed both child-process cases and the no-leftovers check. An earlier green receipt used a partial selector and is retained as partial coverage only. The exact main-integrated candidate `1528d56c` passed the full contributor gate: 14 PASS, 0 FAIL, 2 WARN. All 46 required controls ran and passed, including ordinary restart/persistence tests, all completion/activation cases, the permission-error controls and isolation sentinels. The full suite reported no failures; 182 existing optional skips are retained in the receipt, with no required control skipped. Source identity remained unchanged. This full-suite receipt remains bound to `1528d56c`; later published-head validation is described below.

The protocol uses a permanent guard inode for participating controllers, nonblocking status acquisition, versioned nonce/PID ownership, ESRCH-only reclamation, and owned release checks. Age, EPERM, malformed, legacy, and ambiguous markers defer classification.

The two gate warnings are the combined implementation size (+2112/-119) and the generic revert check failing to compile new APIs on the old base. Separate behavioral red controls establish the original defects. The protocol, launch helper and concurrency controls are kept together because accepting a partial generation/ownership protocol would leave stale completion races.

The first integrated full run failed the unchanged permission fixture under a long temporary path. Matched main/candidate controls reproduced the failure with 130-byte socket paths and passed with short paths; direct tmux stderr confirmed the path-length error. The passing full run uses a short private temp directory, without changing source or removing tests. The failed run remains preserved.

CI on `1528d56c` identified two unreferenced legacy marker helpers. Follow-up `ace7497c` removes only those 19 lines; the full-suite receipt above remains bound to `1528d56c`, and fresh CI validates the cleanup head. No runtime path or test changed.

CI on `ace7497c` then failed three self-exec child scenarios: both guard-process cases and the atomic-append SIGKILL case missed their unchanged five-second readiness boundary. An exact-source focused reproduction under an unprivileged user with `GOPATH`, `GOCACHE`, and `GOMODCACHE` unset reproduced all three failures and readonly module-cache cleanup errors inside the child HOME. Process evidence showed four actual CLI builds, one parent and three children.

Test-only correction `79e0d93d` makes both child call sites explicitly inherit the parent's matching CLI path and SHA-256 through registered test flags. Children validate the absolute regular executable and digest without rebuilding or deleting the parent's helper. Parent ownership, HOME/XDG isolation, production executable binding, and the original readiness deadlines remain unchanged. Invalid inheritance fails closed. Follow-up `0fbef9a3` also rejects explicitly empty flags.

The same unprivileged focused run on `79e0d93d` produced 35 PASS events, zero failures and zero skips: all three original child scenarios, five persistence/conductor cases, six real-producer cases, nine launch-boundary cases and eight helper-inheritance cases passed. The final empty-flag-only correction was verified with a narrow inheritance run on `0fbef9a3`: 12 PASS events covering the parent and eleven cases, with zero failures or skips. A failing, recording Go executable on child PATH proved the children did not invoke Go even independently of cache warmth; process evidence showed one actual helper build, the parent only. Both runs used race test binaries and unchanged tracked source. No new full-suite run is claimed for these test-only changes; fresh CI on `0fbef9a3` is pending.

A bounded before/after timing sample used the same prebuilt harness and fixture on each revision: five warmups followed by 50 `UpdateStatus` calls for a missing server with no hook proof, before protocol activation. Builds were excluded. An untimed transparent probe confirmed both versions used the same private socket and tmux command sequence; timed calls used the real binary without instrumentation.

| Revision | Mean per call | Median per call |
| --- | ---: | ---: |
| Published baseline `23d16b68` | 5.609 ms | 5.632 ms |
| Integrated correction `1528d56c` | 10.321 ms | 10.395 ms |

These are aggregate timings for this narrow failure path, including tmux and coordination work. The sample was slower on the corrected version; it does not isolate lock overhead or establish a general performance change. CI's performance-smoke checks on `1528d56c` passed. The dead-code cleanup does not change this measured runtime path.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-6-astra, gpt-5.6-luna

**Prompt / session log (optional):** Root-directed implementation and independent source review are recorded in the maintainer evidence packet.

## What actually bothered you

From issue #2091: “False `error` status on successfully completed sessions.”

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: exact `1528d56c` contributor gate passed; fresh CI on `0fbef9a3` pending
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->
