### PR TITLE
fix(ssh): report native attach failures and normalize TERM

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -107,7 +107,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      NATIVE_SSH_ARTIFACT_DIR: ${{ runner.temp }}/native-ssh-evidence
       NATIVE_SSH_EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Checkout exact candidate
@@ -118,6 +117,8 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version-file: go.mod
+      - name: Set native evidence path
+        run: echo "NATIVE_SSH_ARTIFACT_DIR=$RUNNER_TEMP/native-ssh-evidence" >> "$GITHUB_ENV"
       - name: Install real SSH fixture tools
         run: |
           mkdir -p "$NATIVE_SSH_ARTIFACT_DIR"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -33,6 +33,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/go-test.yml'
+      - 'scripts/ci-native-ssh.sh'
 
 # One in-flight run per PR (or per branch on push). Rapid follow-up pushes
 # cancel the stale run instead of stacking 20-minute jobs.
@@ -100,3 +101,36 @@ jobs:
         run: |
           go install gotest.tools/gotestsum@v1.13.0
           gotestsum --rerun-fails=2 --rerun-fails-abort-on-data-race --packages="./..." -- -race -timeout 20m
+
+  native-ssh:
+    name: Required native SSH acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NATIVE_SSH_ARTIFACT_DIR: ${{ runner.temp }}/native-ssh-evidence
+      NATIVE_SSH_EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ env.NATIVE_SSH_EXPECTED_SHA }}
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: go.mod
+      - name: Install real SSH fixture tools
+        run: |
+          mkdir -p "$NATIVE_SSH_ARTIFACT_DIR"
+          id | tee "$NATIVE_SSH_ARTIFACT_DIR/runner-user.txt"
+          sudo apt-get update -qq 2>&1 | tee "$NATIVE_SSH_ARTIFACT_DIR/apt-update.log"
+          sudo apt-get install -y --no-install-recommends openssh-server openssh-client tmux python3 2>&1 | tee "$NATIVE_SSH_ARTIFACT_DIR/apt-install.log"
+          dpkg-query -W openssh-server openssh-client tmux python3 > "$NATIVE_SSH_ARTIFACT_DIR/packages.txt"
+      - name: Require real native SSH execution
+        run: bash scripts/ci-native-ssh.sh
+      - name: Retain native SSH evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-ssh-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.NATIVE_SSH_ARTIFACT_DIR }}
+          if-no-files-found: error

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ env.NATIVE_SSH_EXPECTED_SHA }}
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
@@ -127,6 +128,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends openssh-server openssh-client tmux python3 2>&1 | tee "$NATIVE_SSH_ARTIFACT_DIR/apt-install.log"
           dpkg-query -W openssh-server openssh-client tmux python3 > "$NATIVE_SSH_ARTIFACT_DIR/packages.txt"
       - name: Require real native SSH execution
+        timeout-minutes: 18
         run: bash scripts/ci-native-ssh.sh
       - name: Retain native SSH evidence
         if: always()

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -132,7 +132,9 @@ func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 	port := reserve.Addr().(*net.TCPAddr).Port
 	_ = reserve.Close()
 	wrapper := write("remote-command", []byte("#!/bin/sh\nunset XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME TMUX AGENTDECK_PROFILE CLAUDE_CONFIG_DIR\nexport HOME="+quote(remoteHome)+"\nexport PATH="+quote(os.Getenv("PATH"))+"\ncd "+quote(remoteHome)+" || exit 1\nexec /bin/sh -c \"$SSH_ORIGINAL_COMMAND\"\n"))
-	config := write("sshd_config", []byte(fmt.Sprintf("Port %d\nListenAddress 127.0.0.1\nHostKey %s\nPidFile %s\nAuthorizedKeysFile %s\nStrictModes yes\nUsePAM no\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nPubkeyAuthentication yes\nPermitUserEnvironment no\nAllowUsers %s\nForceCommand %s\nLogLevel VERBOSE\n", port, hostFile, filepath.Join(binDir, "sshd.pid"), authorized, account.Username, wrapper)))
+	// Read only the disposable key without requiring /tmp ancestry to pass StrictModes.
+	// sshd validates that the absolute command is root-owned and not publicly writable.
+	config := write("sshd_config", []byte(fmt.Sprintf("Port %d\nListenAddress 127.0.0.1\nHostKey %s\nPidFile %s\nAuthorizedKeysFile none\nAuthorizedKeysCommand /usr/bin/cat %s\nAuthorizedKeysCommandUser %s\nStrictModes yes\nUsePAM no\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nPubkeyAuthentication yes\nPermitUserEnvironment no\nAllowUsers %s\nForceCommand %s\nLogLevel VERBOSE\n", port, hostFile, filepath.Join(binDir, "sshd.pid"), authorized, account.Username, account.Username, wrapper)))
 	logFile, err := os.Create(filepath.Join(binDir, "sshd.log"))
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -91,6 +91,12 @@ func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 		}
 		t.Fatalf("real sshd required: %v", err)
 	}
+	if _, err := os.Stat("/usr/bin/cat"); err != nil {
+		if os.IsNotExist(err) {
+			nativeSSHMissingTool(t, "/usr/bin/cat")
+		}
+		t.Fatalf("authorized key command required: %v", err)
+	}
 	account, err := user.Current()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -224,7 +224,7 @@ func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 	proxyPort := listener.Addr().(*net.TCPAddr).Port
 	known := write("known_hosts", []byte(fmt.Sprintf("[127.0.0.1]:%d %s", proxyPort, ssh.MarshalAuthorizedKey(hostKey))))
 	clientConfig := write("ssh_config", []byte("Host test-host\n HostName 127.0.0.1\n User "+account.Username+"\n Port "+strconv.Itoa(proxyPort)+"\n IdentityFile "+clientFile+"\n UserKnownHostsFile "+known+"\n StrictHostKeyChecking yes\n IdentitiesOnly yes\n"))
-	write("ssh", []byte("#!/bin/sh\nexec "+quote(realSSH)+" -F "+quote(clientConfig)+" -o ControlMaster=no -o ControlPath=none \"$@\"\n"))
+	write("ssh", []byte("#!/bin/sh\nif [ \"$NATIVE_SSH_MULTIPLEX\" = true ]; then\nexec "+quote(realSSH)+" -F "+quote(clientConfig)+" \"$@\"\nfi\nexec "+quote(realSSH)+" -F "+quote(clientConfig)+" -o ControlMaster=no -o ControlPath=none \"$@\"\n"))
 	return p
 }
 

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -86,6 +86,9 @@ func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 		sshd = "/usr/sbin/sshd"
 	}
 	if _, err := os.Stat(sshd); err != nil {
+		if os.IsNotExist(err) && os.Getenv("NATIVE_SSHD") == "" {
+			nativeSSHMissingTool(t, sshd)
+		}
 		t.Fatalf("real sshd required: %v", err)
 	}
 	account, err := user.Current()
@@ -253,4 +256,14 @@ func nativeRetainFile(t *testing.T, name, source string) {
 	if _, err := io.Copy(output, input); err != nil {
 		t.Error(err)
 	}
+}
+
+// Ordinary developer runs may lack SSH server tools. Acceptance runs opt in
+// explicitly and also verify that this test ran, so a skip cannot certify them.
+func nativeSSHMissingTool(t *testing.T, tool string) {
+	t.Helper()
+	if os.Getenv("NATIVE_SSH_REQUIRED") == "1" {
+		t.Fatalf("native SSH acceptance requires %s", tool)
+	}
+	t.Skipf("native SSH integration requires %s", tool)
 }

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// nativeSSHProxy can blackhole existing streams without disconnecting them.
+// Faults affect only this fixture's loopback connections.
+type nativeSSHProxy struct {
+	mu          sync.Mutex
+	paused      bool
+	stopped     bool
+	connections map[net.Conn]bool
+	changed     chan struct{}
+	listener    net.Listener
+	wg          sync.WaitGroup
+}
+
+func (p *nativeSSHProxy) pause(paused bool) {
+	p.mu.Lock()
+	p.paused = paused
+	close(p.changed)
+	p.changed = make(chan struct{})
+	p.mu.Unlock()
+}
+
+func (p *nativeSSHProxy) drop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for c := range p.connections {
+		_ = c.Close()
+	}
+}
+
+func (p *nativeSSHProxy) copy(dst, src net.Conn) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			for {
+				p.mu.Lock()
+				paused, stopped, changed := p.paused, p.stopped, p.changed
+				p.mu.Unlock()
+				if stopped {
+					return
+				}
+				if !paused {
+					break
+				}
+				<-changed
+			}
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
+	t.Helper()
+	realSSH, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshd := os.Getenv("NATIVE_SSHD")
+	if sshd == "" {
+		sshd = "/usr/sbin/sshd"
+	}
+	if _, err := os.Stat(sshd); err != nil {
+		t.Fatalf("real sshd required: %v", err)
+	}
+	account, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	quote := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
+	write := func(name string, data []byte) string {
+		t.Helper()
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, data, 0700); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	makeKey := func(name string) (string, ssh.PublicKey) {
+		t.Helper()
+		public, private, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key, err := ssh.NewPublicKey(public)
+		if err != nil {
+			t.Fatal(err)
+		}
+		block, err := ssh.MarshalPrivateKey(private, "native SSH fixture")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return write(name, pem.EncodeToMemory(block)), key
+	}
+	hostFile, hostKey := makeKey("host-key")
+	clientFile, clientKey := makeKey("client-key")
+	authorized := write("authorized_keys", ssh.MarshalAuthorizedKey(clientKey))
+	// Reserve a loopback port, then hand it to sshd. Readiness below detects bind failures.
+	reserve, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := reserve.Addr().String()
+	port := reserve.Addr().(*net.TCPAddr).Port
+	_ = reserve.Close()
+	wrapper := write("remote-command", []byte("#!/bin/sh\nunset XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME TMUX AGENTDECK_PROFILE CLAUDE_CONFIG_DIR\nexport HOME="+quote(remoteHome)+"\nexport PATH="+quote(os.Getenv("PATH"))+"\ncd "+quote(remoteHome)+" || exit 1\nexec /bin/sh -c \"$SSH_ORIGINAL_COMMAND\"\n"))
+	config := write("sshd_config", []byte(fmt.Sprintf("Port %d\nListenAddress 127.0.0.1\nHostKey %s\nPidFile %s\nAuthorizedKeysFile %s\nStrictModes yes\nUsePAM no\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nPubkeyAuthentication yes\nPermitUserEnvironment no\nAllowUsers %s\nForceCommand %s\nLogLevel VERBOSE\n", port, hostFile, filepath.Join(binDir, "sshd.pid"), authorized, account.Username, wrapper)))
+	logFile, err := os.Create(filepath.Join(binDir, "sshd.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(sshd, "-D", "-e", "-f", config)
+	command.Stdout, command.Stderr = logFile, logFile
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	sshdDone := make(chan error, 1)
+	go func() { sshdDone <- command.Wait() }()
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		select {
+		case <-sshdDone:
+		case <-time.After(3 * time.Second):
+			t.Error("sshd cleanup timed out")
+		}
+		_ = logFile.Close()
+		nativeRetainFile(t, "sshd.log", filepath.Join(binDir, "sshd.log"))
+	})
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c, err := net.DialTimeout("tcp", target, 100*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sshd not listening: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &nativeSSHProxy{connections: make(map[net.Conn]bool), changed: make(chan struct{}), listener: listener}
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		for {
+			client, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			server, err := net.DialTimeout("tcp", target, time.Second)
+			if err != nil {
+				_ = client.Close()
+				continue
+			}
+			p.mu.Lock()
+			if p.stopped {
+				p.mu.Unlock()
+				_ = client.Close()
+				_ = server.Close()
+				return
+			}
+			p.connections[client], p.connections[server] = true, true
+			p.mu.Unlock()
+			p.wg.Add(1)
+			go func() {
+				defer p.wg.Done()
+				done := make(chan struct{})
+				go func() { p.copy(server, client); _ = server.Close(); _ = client.Close(); close(done) }()
+				p.copy(client, server)
+				_ = client.Close()
+				_ = server.Close()
+				<-done
+				p.mu.Lock()
+				delete(p.connections, client)
+				delete(p.connections, server)
+				p.mu.Unlock()
+			}()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		p.mu.Lock()
+		p.stopped = true
+		close(p.changed)
+		p.mu.Unlock()
+		p.drop()
+		done := make(chan struct{})
+		go func() { p.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Error("proxy cleanup timed out")
+		}
+	})
+	proxyPort := listener.Addr().(*net.TCPAddr).Port
+	known := write("known_hosts", []byte(fmt.Sprintf("[127.0.0.1]:%d %s", proxyPort, ssh.MarshalAuthorizedKey(hostKey))))
+	clientConfig := write("ssh_config", []byte("Host test-host\n HostName 127.0.0.1\n User "+account.Username+"\n Port "+strconv.Itoa(proxyPort)+"\n IdentityFile "+clientFile+"\n UserKnownHostsFile "+known+"\n StrictHostKeyChecking yes\n IdentitiesOnly yes\n"))
+	write("ssh", []byte("#!/bin/sh\nexec "+quote(realSSH)+" -F "+quote(clientConfig)+" -o ControlMaster=no -o ControlPath=none \"$@\"\n"))
+	return p
+}
+
+func nativeRetainFile(t *testing.T, name, source string) {
+	t.Helper()
+	dir := os.Getenv("NATIVE_SSH_RECEIPT_DIR")
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Error(err)
+		return
+	}
+	input, err := os.Open(source)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer input.Close()
+	output, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer output.Close()
+	if _, err := io.Copy(output, input); err != nil {
+		t.Error(err)
+	}
+}

--- a/cmd/agent-deck/native_attach_test.go
+++ b/cmd/agent-deck/native_attach_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -49,12 +50,14 @@ func TestNativeSSHAttachLifecycle(t *testing.T) {
 	socket := fmt.Sprintf("native-%d", time.Now().UnixNano())
 	write(filepath.Join(remote, ".config", "agent-deck", "config.toml"), "[tmux]\nsocket_name = '"+socket+"'\n")
 	receiver := filepath.Join(remote, "receiver.py")
-	write(receiver, `import os, tty, hashlib, uuid
+	write(receiver, `import os, tty, hashlib, uuid, sys
 # Raw receiver acknowledges bytes without canonical line limits. This is transport
 # evidence; rendered cell widths and physical-terminal behavior need a renderer.
 tty.setraw(0)
 generation = str(uuid.uuid4())
-print("\033[?2004h\033[32mREADY café 世界 e\u0301\033[0m APP:" + str(os.getpid()) + ":" + generation, flush=True)
+banner = "\033[32mREADY café 世界 e\u0301\033[0m APP:" + str(os.getpid()) + ":" + generation
+sys.stdout.write("\033[?2004h" + banner + "\r\n\033[31;44mA界e\u0301Z\033[0m")
+sys.stdout.flush()
 buf = bytearray()
 escape = bytearray()
 pasting = False
@@ -75,6 +78,10 @@ while True:
             escape.clear()
             continue
         if byte in (10, 13) and not pasting:
+            if buf == b"@identity":
+                print("\r\n" + banner, flush=True)
+                buf.clear()
+                continue
             count += 1
             print("\r\nRX:" + hashlib.sha256(buf).hexdigest() + ":" + str(len(buf)) + ":COUNT:" + str(count), flush=True)
             buf.clear()
@@ -95,7 +102,9 @@ while True:
 	}
 	run := func(args ...string) string {
 		t.Helper()
-		cmd := exec.Command(bin, args...)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, bin, args...)
 		cmd.Env = envFor(remote)
 		cmd.Dir = remote
 		out, err := cmd.CombinedOutput()
@@ -117,7 +126,9 @@ while True:
 			args = append(args, "-t", tmuxName)
 		}
 		args = append(args, format)
-		cmd := exec.Command("tmux", args...)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "tmux", args...)
 		cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + remote}
 		out, err := cmd.Output()
 		if err != nil {
@@ -155,11 +166,18 @@ while True:
 			t.Fatal(err)
 		}
 	}
+	directSSH := false
+	multiplex := false
+	lastFrame := "READY café 世界"
 	attachNumber := 0
 	attach := func() (*os.File, *exec.Cmd, func() string, <-chan error) {
 		t.Helper()
 		cmd := exec.Command(bin, "remote", "attach", "lab", "native")
-		cmd.Env = envFor(controller)
+		if directSSH {
+			quote := func(value string) string { return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'" }
+			cmd = exec.Command(shimPath, "-tt", "test-host", "TERM=xterm-256color "+quote(bin)+" session attach native")
+		}
+		cmd.Env = append(envFor(controller), fmt.Sprintf("NATIVE_SSH_MULTIPLEX=%t", multiplex))
 		terminal, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 120, Rows: 40})
 		if err != nil {
 			t.Fatal(err)
@@ -232,7 +250,11 @@ while True:
 				t.Logf("attach output: %q", snapshot())
 			}
 		})
-		waitFor("remote first frame", func() bool { return strings.Contains(snapshot(), "READY café 世界") })
+		waitFor("remote first frame", func() bool { return strings.Contains(snapshot(), lastFrame) })
+		if lastFrame != "READY café 世界" {
+			writeInput(terminal, "@identity\r")
+			waitFor("fresh application banner", func() bool { return strings.Contains(snapshot(), "READY café 世界") })
+		}
 		if !strings.Contains(snapshot(), "[32m") {
 			t.Errorf("remote colors missing: %q", snapshot())
 		}
@@ -246,11 +268,48 @@ while True:
 		t.Fatal("missing application identity")
 	}
 	waitFor("initial attach dimensions", func() bool { return probe("#{window_width}x#{window_height}") == "120x39" })
+	captureGrid := func(escaped bool) string {
+		t.Helper()
+		args := []string{"-L", socket, "capture-pane", "-p", "-t", tmuxName}
+		if escaped {
+			args = append(args, "-e")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "tmux", args...)
+		cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + remote}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("grid capture: %v: %s", err, output)
+		}
+		return string(output)
+	}
+	waitFor("initial Unicode grid", func() bool { return strings.Contains(captureGrid(false), "A界e\u0301Z") })
+	if cursor := probe("#{cursor_x}:#{cursor_y}"); cursor != "5:1" {
+		t.Errorf("wide/combining cell cursor=%s want5:1", cursor)
+	}
+	grid := captureGrid(true)
+	foreground := regexp.MustCompile(`\x1b\[[0-9;]*31[;m]`)
+	background := regexp.MustCompile(`\x1b\[[0-9;]*44[;m]`)
+	if !foreground.MatchString(grid) || !background.MatchString(grid) {
+		t.Errorf("tmux color attributes missing: %q", grid)
+	}
+	t.Logf("initial tmux rendered grid: %q; server cells only, physical client rendering untested", grid)
 	if err := pty.Setsize(terminal, &pty.Winsize{Cols: 150, Rows: 45}); err != nil {
 		t.Fatal(err)
 	}
 	client.Process.Signal(syscall.SIGWINCH)
 	waitFor("remote resize", func() bool { return probe("#{window_width}x#{window_height}") == "150x44" })
+	for _, size := range []pty.Winsize{{Cols: 100, Rows: 35}, {Cols: 140, Rows: 48}, {Cols: 150, Rows: 45}} {
+		if err := pty.Setsize(terminal, &size); err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Process.Signal(syscall.SIGWINCH); err != nil {
+			t.Fatal(err)
+		}
+		expected := fmt.Sprintf("%dx%d", size.Cols, size.Rows-1)
+		waitFor("repeated remote resize", func() bool { return probe("#{window_width}x#{window_height}") == expected })
+	}
 	// A terminal-generated OSC reply must not become application input.
 	writeInput(terminal, "\x1b]11;rgb:abcd/0000/ffff\a")
 	writeInput(terminal, "ordered-input\r")
@@ -400,4 +459,119 @@ while True:
 	case <-time.After(10 * time.Second):
 		t.Fatal("final detach hung")
 	}
+	terminal.Close()
+	lastFrame = receipt("alive-after-blackhole")
+	// Matched measurements use the same OpenSSH configuration, proxy, remote
+	// tmux pane and receiver. A 50ms p95 delta guards a new polling delay;
+	// absolute bounds remain deliberately loose for a shared test runner.
+	measure := func(label string) []time.Duration {
+		t.Helper()
+		terminal, _, snapshot, done = attach()
+		samples := make([]time.Duration, 0, 30)
+		for index := 0; index < 30; index++ {
+			frame := fmt.Sprintf("latency-%s-%02d", label, index)
+			start := time.Now()
+			writeInput(terminal, frame+"\r")
+			waitFor("latency receipt", func() bool { return strings.Contains(snapshot(), receipt(frame)) })
+			samples = append(samples, time.Since(start))
+			lastFrame = receipt(frame)
+		}
+		writeInput(terminal, "\x11")
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("%s latency detach: %v", label, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("latency detach hung")
+		}
+		terminal.Close()
+		sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+		t.Logf("latency %s sorted=%v median=%v p95=%v max=%v", label, samples, samples[15], samples[28], samples[29])
+		return samples
+	}
+	directSSH = true
+	direct := measure("direct")
+	directSSH = false
+	deck := measure("deck")
+	if deck[28] > direct[28]+50*time.Millisecond {
+		t.Errorf("Agent Deck p95=%v exceeds directSSH=%v plus50ms", deck[28], direct[28])
+	}
+	if deck[29] > time.Second {
+		t.Errorf("Agent Deck max latency=%v exceeds1s", deck[29])
+	}
+	// Exercise the production ControlMaster options after the isolated
+	// no-master fault tests. The runner owns the whole socket namespace.
+	multiplex = true
+	control := func(operation string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		command := exec.CommandContext(ctx, shimPath, "-O", operation, "-o", "ControlPath=/tmp/agent-deck-ssh/%r@%h:%p", "test-host")
+		command.Env = append(envFor(controller), "NATIVE_SSH_MULTIPLEX=true")
+		out, err := command.CombinedOutput()
+		return string(out), err
+	}
+	t.Cleanup(func() { output, err := control("exit"); t.Logf("fixture master exit: %v %s", err, output) })
+	terminal, _, snapshot, done = attach()
+	master, err := control("check")
+	if err != nil {
+		t.Fatalf("production master not active: %v %s", err, master)
+	}
+	t.Logf("production master: %s", master)
+	writeInput(terminal, "multiplex-first\r")
+	waitFor("multiplex input", func() bool { return strings.Contains(snapshot(), receipt("multiplex-first")) })
+	lastFrame = receipt("multiplex-first")
+	writeInput(terminal, "\x1b[113;5u")
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("CSI-u detach: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("CSI-u detach hung")
+	}
+	terminal.Close()
+	terminal, _, snapshot, done = attach()
+	reconnectMaster, err := control("check")
+	if err != nil || reconnectMaster != master {
+		t.Errorf("master changed on reconnect: %v %q want%q", err, reconnectMaster, master)
+	}
+	writeInput(terminal, "multiplex-reconnect\r")
+	waitFor("multiplex reconnect", func() bool { return strings.Contains(snapshot(), receipt("multiplex-reconnect")) })
+	lastFrame = receipt("multiplex-reconnect")
+	writeInput(terminal, "\x1b[27;5;113~")
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("modifyOtherKeys detach: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("modifyOtherKeys detach hung")
+	}
+	terminal.Close()
+	terminal, _, snapshot, done = attach()
+	// Separate writes with a transport round-trip-sized gap force the native
+	// pump to encounter a partial escape sequence before its completion.
+	writeInput(terminal, "\x1b[113;")
+	time.Sleep(100 * time.Millisecond)
+	writeInput(terminal, "5u")
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("fragmented CSI-u detach: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("fragmented CSI-u CtrlQ was forwarded instead of detaching")
+		writeInput(terminal, "\x11")
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("fallback detach hung")
+		}
+	}
+	terminal.Close()
+	if got := probe("#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"); got != identity {
+		t.Errorf("final session identity changed: %s != %s", got, identity)
+	}
+
 }

--- a/cmd/agent-deck/native_attach_test.go
+++ b/cmd/agent-deck/native_attach_test.go
@@ -24,7 +24,7 @@ import (
 func TestNativeSSHAttachLifecycle(t *testing.T) {
 	for _, tool := range []string{"ssh", "tmux", "python3"} {
 		if _, err := exec.LookPath(tool); err != nil {
-			t.Fatal(tool + " required for native SSH acceptance")
+			nativeSSHMissingTool(t, tool)
 		}
 	}
 	bin := channelsCLIBinary(t)

--- a/cmd/agent-deck/native_attach_test.go
+++ b/cmd/agent-deck/native_attach_test.go
@@ -56,7 +56,7 @@ func TestNativeSSHAttachLifecycle(t *testing.T) {
 tty.setraw(0)
 generation = str(uuid.uuid4())
 banner = "\033[32mREADY café 世界 e\u0301\033[0m APP:" + str(os.getpid()) + ":" + generation
-sys.stdout.write("\033[?2004h" + banner + "\r\n\033[31;44mA界e\u0301Z\033[0m")
+sys.stdout.write("\033[2J\033[H\033[?2004h" + banner + "\r\n\033[31;44mA界e\u0301Z\033[0m")
 sys.stdout.flush()
 buf = bytearray()
 escape = bytearray()
@@ -78,8 +78,9 @@ while True:
             escape.clear()
             continue
         if byte in (10, 13) and not pasting:
-            if buf == b"@identity":
-                print("\r\n" + banner, flush=True)
+            if buf.startswith(b"@identity "):
+                nonce = bytes(buf[len(b"@identity "):]).decode("ascii")
+                print("\r\nID:" + nonce + " APP:" + str(os.getpid()) + ":" + generation, flush=True)
                 buf.clear()
                 continue
             count += 1
@@ -116,7 +117,17 @@ while True:
 	}
 	run("add", remote, "--title", "native", "--cmd", "shell", "--wrapper", "python3 -u "+receiver, "--json")
 	run("session", "start", "native", "--json")
-	t.Cleanup(func() { cmd := exec.Command(bin, "session", "stop", "native"); cmd.Env = envFor(remote); cmd.Run() })
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		command := exec.CommandContext(ctx, bin, "session", "stop", "native")
+		command.Env = envFor(remote)
+		output, err := command.CombinedOutput()
+		t.Logf("session cleanup: %v %s", err, output)
+		if ctx.Err() != nil {
+			t.Error("session cleanup timed out")
+		}
+	})
 	var tmuxName string
 	// The name is stable and avoids relying on a registry title-to-tmux mapping.
 	probe := func(format string) string {
@@ -169,6 +180,8 @@ while True:
 	directSSH := false
 	multiplex := false
 	lastFrame := "READY café 世界"
+	appPattern := regexp.MustCompile(`APP:[0-9]+:[a-f0-9-]{36}`)
+	var appIdentity string
 	attachNumber := 0
 	attach := func() (*os.File, *exec.Cmd, func() string, <-chan error) {
 		t.Helper()
@@ -186,7 +199,9 @@ while True:
 		thisAttach := attachNumber
 		var mu sync.Mutex
 		var output bytes.Buffer
+		readerDone := make(chan struct{})
 		go func() {
+			defer close(readerDone)
 			buf := make([]byte, 8192)
 			var pending []byte
 			for {
@@ -223,14 +238,26 @@ while True:
 		}()
 		snapshot := func() string { mu.Lock(); defer mu.Unlock(); return output.String() }
 		done := make(chan error, 1)
-		go func() { done <- cmd.Wait() }()
+		processDone := make(chan struct{})
+		go func() { done <- cmd.Wait(); close(processDone) }()
 		t.Cleanup(func() {
-			terminal.Close()
+			_ = terminal.Close()
 			if cmd.Process != nil {
-				cmd.Process.Kill()
+				_ = cmd.Process.Kill()
 			}
-		})
-		t.Cleanup(func() {
+			// Dedicated completion channels are safe after the test has already
+			// consumed the process error from done.
+			select {
+			case <-processDone:
+			case <-time.After(3 * time.Second):
+				t.Error("attach process cleanup timed out")
+			}
+			select {
+			case <-readerDone:
+			case <-time.After(3 * time.Second):
+				t.Error("attach output cleanup timed out")
+			}
+
 			if dir := os.Getenv("NATIVE_SSH_RECEIPT_DIR"); dir != "" {
 				if err := os.MkdirAll(dir, 0700); err != nil {
 					t.Error(err)
@@ -251,22 +278,22 @@ while True:
 			}
 		})
 		waitFor("remote first frame", func() bool { return strings.Contains(snapshot(), lastFrame) })
-		if lastFrame != "READY café 世界" {
-			writeInput(terminal, "@identity\r")
-			waitFor("fresh application banner", func() bool { return strings.Contains(snapshot(), "READY café 世界") })
-		}
-		if !strings.Contains(snapshot(), "[32m") {
-			t.Errorf("remote colors missing: %q", snapshot())
+		if thisAttach == 1 {
+			waitFor("initial application identity", func() bool { return appPattern.MatchString(snapshot()) })
+			appIdentity = appPattern.FindString(snapshot())
+			if !strings.Contains(snapshot(), "[32m") {
+				t.Error("initial remote color missing")
+			}
+		} else {
+			nonce := fmt.Sprintf("attach-%02d", thisAttach)
+			expected := "ID:" + nonce + " " + appIdentity
+			writeInput(terminal, "@identity "+nonce+"\r")
+			waitFor("fresh matching application identity", func() bool { return strings.Contains(snapshot(), expected) })
+			t.Logf("reconnect identity: %s", expected)
 		}
 		return terminal, cmd, snapshot, done
 	}
 	terminal, client, snapshot, done := attach()
-	appPattern := regexp.MustCompile(`APP:[0-9]+:[a-f0-9-]{36}`)
-	waitFor("application identity", func() bool { return appPattern.MatchString(snapshot()) })
-	appIdentity := appPattern.FindString(snapshot())
-	if appIdentity == "" {
-		t.Fatal("missing application identity")
-	}
 	waitFor("initial attach dimensions", func() bool { return probe("#{window_width}x#{window_height}") == "120x39" })
 	captureGrid := func(escaped bool) string {
 		t.Helper()
@@ -318,7 +345,8 @@ while True:
 		t.Errorf("terminal reply reached application: %q", snapshot())
 	}
 
-	// Deliberately fragment UTF-8 and bytes around the pump's 256-byte read size.
+	// Fragment writes across UTF-8 and payload sizes around the pump buffer.
+	// The OS may coalesce writes; this does not prove individual read boundaries.
 	var latencies []time.Duration
 	for index, size := range []int{1, 255, 256, 257, 511, 512, 513} {
 		frame := fmt.Sprintf("frame-%02d-世界-", index) + strings.Repeat("x", size)
@@ -351,7 +379,19 @@ while True:
 	// The CLI send path must submit its own 4KB message even with --no-wait.
 	sendMessage := strings.Repeat("wxyz", 1024)
 	run("session", "send", "native", sendMessage, "--no-wait", "--json")
-	waitFor("4KB no-wait send receipt", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)) })
+	waitFor("4KB no-wait send receipt", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)+":COUNT:11") })
+	barrier := "after-cli-send-barrier"
+	writeInput(terminal, barrier+"\r")
+	waitFor("exactly-once CLI send barrier", func() bool { return strings.Contains(snapshot(), receipt(barrier)+":COUNT:12") })
+	// Repaints may repeat the same receipt bytes; a different receiver count
+	// for this payload is an actual duplicate submission.
+	cliReceipts := regexp.MustCompile(regexp.QuoteMeta(receipt(sendMessage)) + `:COUNT:([0-9]+)`)
+	for _, match := range cliReceipts.FindAllStringSubmatch(snapshot(), -1) {
+		if match[1] != "11" {
+			t.Errorf("CLI payload submitted again at receiver count%s", match[1])
+		}
+	}
+	lastFrame = receipt(barrier)
 	writeInput(terminal, "\x11")
 	select {
 	case err := <-done:
@@ -369,6 +409,7 @@ while True:
 	waitFor("reconnect transcript", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)) })
 	writeInput(terminal, "alive-after-detach\r")
 	waitFor("live after detach", func() bool { return strings.Contains(snapshot(), receipt("alive-after-detach")) })
+	lastFrame = receipt("alive-after-detach")
 	pidBytes, err := os.ReadFile(pidFile)
 	if err != nil {
 		t.Fatal(err)
@@ -401,15 +442,14 @@ while True:
 	waitFor("SSH reconnect transcript", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)) })
 	writeInput(terminal, "alive-after-ssh-loss\r")
 	waitFor("live receiver after SSH reconnect", func() bool { return strings.Contains(snapshot(), receipt("alive-after-ssh-loss")) })
+	lastFrame = receipt("alive-after-ssh-loss")
 	if output := run("session", "show", "native", "--json"); !strings.Contains(output, "\"status\": \"idle\"") {
 		t.Errorf("unexpected status after reconnect: %s", output)
 	}
 	if got := probe("#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"); got != identity {
 		t.Fatalf("identity changed: %s != %s", got, identity)
 	}
-	if !strings.Contains(snapshot(), appIdentity) {
-		t.Fatal("application identity changed after reconnect")
-	}
+
 	proxy.drop()
 	select {
 	case err := <-done:
@@ -423,6 +463,7 @@ while True:
 	terminal, _, snapshot, done = attach()
 	writeInput(terminal, "alive-after-network-close\r")
 	waitFor("live after network close", func() bool { return strings.Contains(snapshot(), receipt("alive-after-network-close")) })
+	lastFrame = receipt("alive-after-network-close")
 	proxy.pause(true)
 	writeInput(terminal, "held-during-blackhole\r")
 	// Hold the transport long enough to establish a real interrupted interval.
@@ -432,6 +473,7 @@ while True:
 	}
 	proxy.pause(false)
 	waitFor("restored network", func() bool { return strings.Contains(snapshot(), receipt("held-during-blackhole")) })
+	lastFrame = receipt("held-during-blackhole")
 	proxy.pause(true)
 	writeInput(terminal, "\x11")
 	select {
@@ -447,12 +489,11 @@ while True:
 	terminal, _, snapshot, done = attach()
 	writeInput(terminal, "alive-after-blackhole\r")
 	waitFor("live after blackhole reconnect", func() bool { return strings.Contains(snapshot(), receipt("alive-after-blackhole")) })
+	lastFrame = receipt("alive-after-blackhole")
 	if got := probe("#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"); got != identity {
 		t.Fatalf("network fault changed identity: %s != %s", got, identity)
 	}
-	if !strings.Contains(snapshot(), appIdentity) {
-		t.Fatal("network fault changed application identity")
-	}
+
 	writeInput(terminal, "\x11")
 	select {
 	case <-done:
@@ -550,8 +591,8 @@ while True:
 	}
 	terminal.Close()
 	terminal, _, snapshot, done = attach()
-	// Separate writes with a transport round-trip-sized gap force the native
-	// pump to encounter a partial escape sequence before its completion.
+	// A delayed split exercises escape-sequence handling across transport
+	// writes. The kernel may coalesce reads; no particular read boundary is assumed.
 	writeInput(terminal, "\x1b[113;")
 	time.Sleep(100 * time.Millisecond)
 	writeInput(terminal, "5u")
@@ -561,7 +602,7 @@ while True:
 			t.Errorf("fragmented CSI-u detach: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Error("fragmented CSI-u CtrlQ was forwarded instead of detaching")
+		t.Error("delayed-split CSI-u CtrlQ did not detach within2s")
 		writeInput(terminal, "\x11")
 		select {
 		case <-done:

--- a/cmd/agent-deck/native_attach_test.go
+++ b/cmd/agent-deck/native_attach_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+func TestNativeSSHAttachLifecycle(t *testing.T) {
+	for _, tool := range []string{"ssh", "tmux", "python3"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Fatal(tool + " required for native SSH acceptance")
+		}
+	}
+	bin := channelsCLIBinary(t)
+	controller, remote, shim := t.TempDir(), t.TempDir(), t.TempDir()
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	proxy := startNativeSSH(t, remote, shim)
+	pidFile := filepath.Join(controller, "ssh-client.pid")
+	shimPath := filepath.Join(shim, "ssh")
+	shimBody, err := os.ReadFile(shimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(shimPath, strings.Replace(string(shimBody), "#!/bin/sh\n", "#!/bin/sh\nprintf '%s' \"$$\" > \"$NATIVE_SSH_PID_FILE\"\n", 1))
+	write(filepath.Join(controller, ".config", "agent-deck", "config.toml"), fmt.Sprintf("[remotes.lab]\nhost = 'test-host'\nagent_deck_path = '%s'\n", bin))
+	socket := fmt.Sprintf("native-%d", time.Now().UnixNano())
+	write(filepath.Join(remote, ".config", "agent-deck", "config.toml"), "[tmux]\nsocket_name = '"+socket+"'\n")
+	receiver := filepath.Join(remote, "receiver.py")
+	write(receiver, `import os, tty, hashlib, uuid
+# Raw receiver acknowledges bytes without canonical line limits. This is transport
+# evidence; rendered cell widths and physical-terminal behavior need a renderer.
+tty.setraw(0)
+generation = str(uuid.uuid4())
+print("\033[?2004h\033[32mREADY café 世界 e\u0301\033[0m APP:" + str(os.getpid()) + ":" + generation, flush=True)
+buf = bytearray()
+escape = bytearray()
+pasting = False
+count = 0
+while True:
+    data = os.read(0, 8192)
+    if not data: break
+    for byte in data:
+        if escape or byte == 27:
+            escape.append(byte)
+            if bytes(escape) in (b"\x1b[200~", b"\x1b[201~"):
+                pasting = bytes(escape) == b"\x1b[200~"
+                escape.clear()
+                continue
+            if any(marker.startswith(bytes(escape)) for marker in (b"\x1b[200~", b"\x1b[201~")):
+                continue
+            buf.extend(escape)
+            escape.clear()
+            continue
+        if byte in (10, 13) and not pasting:
+            count += 1
+            print("\r\nRX:" + hashlib.sha256(buf).hexdigest() + ":" + str(len(buf)) + ":COUNT:" + str(count), flush=True)
+            buf.clear()
+        else:
+            buf.append(byte)
+`)
+	localTERM := "xterm-256color"
+	envFor := func(home string) []string {
+		var env []string
+		for _, kv := range os.Environ() {
+			key := strings.SplitN(kv, "=", 2)[0]
+			if key == "HOME" || key == "PATH" || key == "TERM" || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "AGENTDECK_") || strings.HasPrefix(key, "TMUX") {
+				continue
+			}
+			env = append(env, kv)
+		}
+		return append(env, "HOME="+home, "PATH="+shim+":"+os.Getenv("PATH"), "TERM="+localTERM, "NATIVE_SSH_PID_FILE="+pidFile)
+	}
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(bin, args...)
+		cmd.Env = envFor(remote)
+		cmd.Dir = remote
+		out, err := cmd.CombinedOutput()
+		t.Logf("CLI %v: exit=%v output=%s", args, err, out)
+		if err != nil {
+			t.Fatalf("CLI %v: %v %s", args, err, out)
+		}
+		return string(out)
+	}
+	run("add", remote, "--title", "native", "--cmd", "shell", "--wrapper", "python3 -u "+receiver, "--json")
+	run("session", "start", "native", "--json")
+	t.Cleanup(func() { cmd := exec.Command(bin, "session", "stop", "native"); cmd.Env = envFor(remote); cmd.Run() })
+	var tmuxName string
+	// The name is stable and avoids relying on a registry title-to-tmux mapping.
+	probe := func(format string) string {
+		t.Helper()
+		args := []string{"-L", socket, "display-message", "-p"}
+		if tmuxName != "" {
+			args = append(args, "-t", tmuxName)
+		}
+		args = append(args, format)
+		cmd := exec.Command("tmux", args...)
+		cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + remote}
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("tmux probe: %v", err)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	tmuxName = probe("#{session_name}")
+	panePID := probe("#{pane_pid}")
+	identity := probe("#{pid}:#{session_id}:#{pane_id}:#{pane_pid}")
+	changed := make(chan struct{}, 1)
+	waitFor := func(what string, ready func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if ready() {
+				return
+			}
+			select {
+			case <-changed:
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+		t.Fatalf("timed out: %s", what)
+	}
+	receipt := func(message string) string {
+		return fmt.Sprintf("RX:%x:%d", sha256.Sum256([]byte(message)), len(message))
+	}
+	var writeMu sync.Mutex
+	writeInput := func(terminal *os.File, input string) {
+		t.Helper()
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		if _, err := io.WriteString(terminal, input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	attachNumber := 0
+	attach := func() (*os.File, *exec.Cmd, func() string, <-chan error) {
+		t.Helper()
+		cmd := exec.Command(bin, "remote", "attach", "lab", "native")
+		cmd.Env = envFor(controller)
+		terminal, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 120, Rows: 40})
+		if err != nil {
+			t.Fatal(err)
+		}
+		attachNumber++
+		thisAttach := attachNumber
+		var mu sync.Mutex
+		var output bytes.Buffer
+		go func() {
+			buf := make([]byte, 8192)
+			var pending []byte
+			for {
+				n, err := terminal.Read(buf)
+				if n > 0 {
+					pending = append(pending, buf[:n]...)
+					for _, query := range []struct{ request, response string }{
+						{"\x1b]11;?\x1b\\", "\x1b]11;rgb:0000/0000/0000\x1b\\"},
+						{"\x1b]11;?\a", "\x1b]11;rgb:0000/0000/0000\x1b\\"},
+						{"\x1b[6n", "\x1b[1;1R"},
+					} {
+						for bytes.Contains(pending, []byte(query.request)) {
+							writeMu.Lock()
+							_, _ = io.WriteString(terminal, query.response)
+							writeMu.Unlock()
+							pending = bytes.Replace(pending, []byte(query.request), nil, 1)
+						}
+					}
+					if len(pending) > 64 {
+						pending = pending[len(pending)-64:]
+					}
+					mu.Lock()
+					output.Write(buf[:n])
+					mu.Unlock()
+					select {
+					case changed <- struct{}{}:
+					default:
+					}
+				}
+				if err != nil {
+					return
+				}
+			}
+		}()
+		snapshot := func() string { mu.Lock(); defer mu.Unlock(); return output.String() }
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		t.Cleanup(func() {
+			terminal.Close()
+			if cmd.Process != nil {
+				cmd.Process.Kill()
+			}
+		})
+		t.Cleanup(func() {
+			if dir := os.Getenv("NATIVE_SSH_RECEIPT_DIR"); dir != "" {
+				if err := os.MkdirAll(dir, 0700); err != nil {
+					t.Error(err)
+				}
+				file, err := os.OpenFile(filepath.Join(dir, fmt.Sprintf("attach-%02d.txt", thisAttach)), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+				if err != nil {
+					t.Error(err)
+				} else {
+					_, err = file.WriteString(snapshot())
+					if err != nil {
+						t.Error(err)
+					}
+					file.Close()
+				}
+			}
+			if t.Failed() {
+				t.Logf("attach output: %q", snapshot())
+			}
+		})
+		waitFor("remote first frame", func() bool { return strings.Contains(snapshot(), "READY café 世界") })
+		if !strings.Contains(snapshot(), "[32m") {
+			t.Errorf("remote colors missing: %q", snapshot())
+		}
+		return terminal, cmd, snapshot, done
+	}
+	terminal, client, snapshot, done := attach()
+	appPattern := regexp.MustCompile(`APP:[0-9]+:[a-f0-9-]{36}`)
+	waitFor("application identity", func() bool { return appPattern.MatchString(snapshot()) })
+	appIdentity := appPattern.FindString(snapshot())
+	if appIdentity == "" {
+		t.Fatal("missing application identity")
+	}
+	waitFor("initial attach dimensions", func() bool { return probe("#{window_width}x#{window_height}") == "120x39" })
+	if err := pty.Setsize(terminal, &pty.Winsize{Cols: 150, Rows: 45}); err != nil {
+		t.Fatal(err)
+	}
+	client.Process.Signal(syscall.SIGWINCH)
+	waitFor("remote resize", func() bool { return probe("#{window_width}x#{window_height}") == "150x44" })
+	// A terminal-generated OSC reply must not become application input.
+	writeInput(terminal, "\x1b]11;rgb:abcd/0000/ffff\a")
+	writeInput(terminal, "ordered-input\r")
+	waitFor("ordered input receipt", func() bool { return strings.Contains(snapshot(), receipt("ordered-input")) })
+	if !strings.Contains(snapshot(), receipt("ordered-input")) {
+		t.Errorf("terminal reply reached application: %q", snapshot())
+	}
+
+	// Deliberately fragment UTF-8 and bytes around the pump's 256-byte read size.
+	var latencies []time.Duration
+	for index, size := range []int{1, 255, 256, 257, 511, 512, 513} {
+		frame := fmt.Sprintf("frame-%02d-世界-", index) + strings.Repeat("x", size)
+		started := time.Now()
+		for position := 0; position < len(frame); {
+			end := position + 7
+			if end > len(frame) {
+				end = len(frame)
+			}
+			writeInput(terminal, frame[position:end])
+			position = end
+		}
+		writeInput(terminal, "\r")
+		waitFor("fragmented frame", func() bool { return strings.Contains(snapshot(), receipt(frame)+fmt.Sprintf(":COUNT:%d", index+2)) })
+		latencies = append(latencies, time.Since(started))
+	}
+	sorted := append([]time.Duration(nil), latencies...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	t.Logf("fragmented input latency samples=%v median=%v max=%v; characterization only, no direct-SSH baseline or acceptance budget", latencies, sorted[len(sorted)/2], sorted[len(sorted)-1])
+	paste := strings.Repeat("世a\n", 819) + "x" // 819*5+1 = 4096 UTF-8 bytes.
+	writeInput(terminal, "\x1b[200~"+paste+"\x1b[201~")
+	if strings.Contains(snapshot(), receipt(paste)) {
+		t.Fatal("paste submitted without Enter")
+	}
+	writeInput(terminal, "\r")
+	waitFor("bracketed 4KB paste", func() bool { return strings.Contains(snapshot(), receipt(paste)+":COUNT:9") })
+	message := strings.Repeat("abcd", 1024)
+	writeInput(terminal, message+"\r")
+	waitFor("4KB interactive receipt", func() bool { return strings.Contains(snapshot(), receipt(message)+":COUNT:10") })
+	// The CLI send path must submit its own 4KB message even with --no-wait.
+	sendMessage := strings.Repeat("wxyz", 1024)
+	run("session", "send", "native", sendMessage, "--no-wait", "--json")
+	waitFor("4KB no-wait send receipt", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)) })
+	writeInput(terminal, "\x11")
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Ctrl+Q detach: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Ctrl+Q did not detach")
+	}
+	if got := probe("#{pane_pid}"); got != panePID {
+		t.Fatalf("detach restarted application: %s != %s", got, panePID)
+	}
+	terminal.Close()
+	terminal, _, snapshot, done = attach()
+	waitFor("reconnect transcript", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)) })
+	writeInput(terminal, "alive-after-detach\r")
+	waitFor("live after detach", func() bool { return strings.Contains(snapshot(), receipt("alive-after-detach")) })
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(pidBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshClient, err := os.FindProcess(pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sshClient.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("SSH loss incorrectly reported success")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("SSH client loss hung attach")
+	}
+	if got := probe("#{pane_pid}"); got != panePID {
+		t.Fatalf("SSH loss restarted application: %s != %s", got, panePID)
+	}
+	terminal.Close()
+	localTERM = "xterm-ghostty"
+	terminal, _, snapshot, done = attach()
+	waitFor("SSH reconnect transcript", func() bool { return strings.Contains(snapshot(), receipt(sendMessage)) })
+	writeInput(terminal, "alive-after-ssh-loss\r")
+	waitFor("live receiver after SSH reconnect", func() bool { return strings.Contains(snapshot(), receipt("alive-after-ssh-loss")) })
+	if output := run("session", "show", "native", "--json"); !strings.Contains(output, "\"status\": \"idle\"") {
+		t.Errorf("unexpected status after reconnect: %s", output)
+	}
+	if got := probe("#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"); got != identity {
+		t.Fatalf("identity changed: %s != %s", got, identity)
+	}
+	if !strings.Contains(snapshot(), appIdentity) {
+		t.Fatal("application identity changed after reconnect")
+	}
+	proxy.drop()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("abrupt network close reported success")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("abrupt network close hung attach")
+	}
+	terminal.Close()
+	terminal, _, snapshot, done = attach()
+	writeInput(terminal, "alive-after-network-close\r")
+	waitFor("live after network close", func() bool { return strings.Contains(snapshot(), receipt("alive-after-network-close")) })
+	proxy.pause(true)
+	writeInput(terminal, "held-during-blackhole\r")
+	// Hold the transport long enough to establish a real interrupted interval.
+	time.Sleep(250 * time.Millisecond)
+	if strings.Contains(snapshot(), receipt("held-during-blackhole")) {
+		t.Fatal("blackhole forwarded receipt")
+	}
+	proxy.pause(false)
+	waitFor("restored network", func() bool { return strings.Contains(snapshot(), receipt("held-during-blackhole")) })
+	proxy.pause(true)
+	writeInput(terminal, "\x11")
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("blackhole manual detach: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("blackhole manual detach hung")
+	}
+	terminal.Close()
+	proxy.pause(false)
+	terminal, _, snapshot, done = attach()
+	writeInput(terminal, "alive-after-blackhole\r")
+	waitFor("live after blackhole reconnect", func() bool { return strings.Contains(snapshot(), receipt("alive-after-blackhole")) })
+	if got := probe("#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"); got != identity {
+		t.Fatalf("network fault changed identity: %s != %s", got, identity)
+	}
+	if !strings.Contains(snapshot(), appIdentity) {
+		t.Fatal("network fault changed application identity")
+	}
+	writeInput(terminal, "\x11")
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("final detach hung")
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -334,6 +335,7 @@ func (r *SSHRunner) Attach(sessionID string) error {
 	sigwinch <- syscall.SIGWINCH
 
 	detachCh := make(chan struct{})
+	input := sshAttachInput{writer: ptmx}
 	outputDone := make(chan struct{})
 
 	// Copy PTY output to stdout.
@@ -391,15 +393,12 @@ func (r *SSHRunner) Attach(sessionID string) error {
 			}
 			data := buf[:n]
 
-			if idx := tmux.IndexCtrlQ(data); idx >= 0 {
-				if idx > 0 {
-					_, _ = ptmx.Write(data[:idx])
-				}
+			detached, err := input.forward(data)
+			if detached {
 				close(detachCh)
 				return
 			}
-
-			if _, err := ptmx.Write(data); err != nil {
+			if err != nil {
 				break
 			}
 		}
@@ -456,10 +455,32 @@ func (r *SSHRunner) Attach(sessionID string) error {
 		_ = p.Signal(syscall.SIGWINCH)
 	}
 
-	if attachErr != nil {
+	if attachErr = input.result(attachErr); attachErr != nil {
 		return fmt.Errorf("ssh attach failed: %w", attachErr)
 	}
 	return nil
+}
+
+// sshAttachInput owns input forwarding and intentional-detach state for one attach.
+// Keeping the writer explicit allows blocked-write ordering to be exercised.
+type sshAttachInput struct {
+	writer          io.Writer
+	detachRequested atomic.Bool
+}
+
+func (input *sshAttachInput) forward(data []byte) (bool, error) {
+	if idx := tmux.IndexCtrlQ(data); idx >= 0 {
+		if idx > 0 {
+			_, _ = input.writer.Write(data[:idx])
+		}
+		return true, nil
+	}
+	_, err := input.writer.Write(data)
+	return false, err
+}
+
+func (input *sshAttachInput) result(err error) error {
+	return err
 }
 
 // RunCommand executes an arbitrary agent-deck command on the remote.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -414,9 +414,10 @@ func (r *SSHRunner) Attach(sessionID string) error {
 	}()
 
 	// Block until detach or SSH exit.
+	var attachErr error
 	select {
 	case <-detachCh:
-	case <-cmdDone:
+	case attachErr = <-cmdDone:
 	}
 
 	// Cleanup: close PTY and wait for output to drain.
@@ -455,6 +456,9 @@ func (r *SSHRunner) Attach(sessionID string) error {
 		_ = p.Signal(syscall.SIGWINCH)
 	}
 
+	if attachErr != nil {
+		return fmt.Errorf("ssh attach failed: %w", attachErr)
+	}
 	return nil
 }
 
@@ -942,9 +946,21 @@ func (r *SSHRunner) sshBaseArgs(remoteCmd string) []string {
 // ConnectTimeout, so an unknown host key could hang on a prompt instead of
 // failing fast). "-tt" forces a remote PTY.
 func (r *SSHRunner) buildAttachArgs(sessionID string) []string {
-	remoteCmd := r.buildRemoteCommand("session", "attach", sessionID)
+	remoteCmd := "TERM=" + shellQuote(remoteAttachTERM()) + " " + r.buildRemoteCommand("session", "attach", sessionID)
 	args := append([]string{"-tt"}, r.sshConnOpts()...)
 	return append(args, r.Host, remoteCmd)
+}
+
+// Modern local terminals may name terminfo entries absent on the SSH host.
+// Retain portable terminal types and use the common 256-color entry otherwise.
+func remoteAttachTERM() string {
+	terminal := os.Getenv("TERM")
+	switch terminal {
+	case "xterm", "xterm-256color", "screen", "screen-256color", "tmux", "tmux-256color", "linux", "vt100", "ansi", "dumb":
+		return terminal
+	default:
+		return "xterm-256color"
+	}
 }
 
 // CreateSession creates and starts a quick new session on the remote, returning its ID.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -470,6 +470,8 @@ type sshAttachInput struct {
 
 func (input *sshAttachInput) forward(data []byte) (bool, error) {
 	if idx := tmux.IndexCtrlQ(data); idx >= 0 {
+		// Record intent before forwarding can block or SSH can exit.
+		input.detachRequested.Store(true)
 		if idx > 0 {
 			_, _ = input.writer.Write(data[:idx])
 		}
@@ -480,6 +482,9 @@ func (input *sshAttachInput) forward(data []byte) (bool, error) {
 }
 
 func (input *sshAttachInput) result(err error) error {
+	if input.detachRequested.Load() {
+		return nil
+	}
 	return err
 }
 
@@ -967,7 +972,7 @@ func (r *SSHRunner) sshBaseArgs(remoteCmd string) []string {
 // ConnectTimeout, so an unknown host key could hang on a prompt instead of
 // failing fast). "-tt" forces a remote PTY.
 func (r *SSHRunner) buildAttachArgs(sessionID string) []string {
-	remoteCmd := "TERM=" + shellQuote(remoteAttachTERM()) + " " + r.buildRemoteCommand("session", "attach", sessionID)
+	remoteCmd := "env TERM=" + shellQuote(remoteAttachTERM()) + " " + r.buildRemoteCommand("session", "attach", sessionID)
 	args := append([]string{"-tt"}, r.sshConnOpts()...)
 	return append(args, r.Host, remoteCmd)
 }

--- a/internal/session/ssh_attach_command_test.go
+++ b/internal/session/ssh_attach_command_test.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSSHAttachCommandExecution(t *testing.T) {
+	for _, tc := range []struct{ name, terminal, want string }{
+		{"portable", "screen", "screen"},
+		{"unknown", "xterm-ghostty", "xterm-256color"},
+		{"hostile", "x; touch /unwanted", "xterm-256color"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TERM", tc.terminal)
+			executable := filepath.Join(t.TempDir(), "capture executable")
+			if err := os.WriteFile(executable, []byte("#!/bin/sh\nprintf '%s\\n' \"$TERM\" \"$@\"\n"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			runner := &SSHRunner{Host: "fixture", AgentDeckPath: executable, Profile: "profile ' quoted"}
+			args := runner.buildAttachArgs("session ' quoted")
+			output, err := exec.Command("/bin/sh", "-c", args[len(args)-1]).CombinedOutput()
+			if err != nil {
+				t.Fatalf("command failed: %v: %s", err, output)
+			}
+			want := []string{tc.want, "-p", "profile ' quoted", "session", "attach", "session ' quoted"}
+			got := strings.Split(strings.TrimSuffix(string(output), "\n"), "\n")
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("captured = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/session/ssh_attach_ordering_test.go
+++ b/internal/session/ssh_attach_ordering_test.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+type sshAttachBarrierWriter struct {
+	entered chan struct{}
+	release chan struct{}
+	bytes   bytes.Buffer
+}
+
+func (w *sshAttachBarrierWriter) Write(p []byte) (int, error) {
+	close(w.entered)
+	<-w.release
+	return w.bytes.Write(p)
+}
+
+func TestSSHAttachDetachOrdering(t *testing.T) {
+	failure := errors.New("SSH transport closed")
+	t.Run("buffered_write_completion", func(t *testing.T) {
+		writer := &sshAttachBarrierWriter{entered: make(chan struct{}), release: make(chan struct{})}
+		input := sshAttachInput{writer: writer}
+		done := make(chan bool, 1)
+		go func() { detached, _ := input.forward([]byte("prefix\x11discard")); done <- detached }()
+		select {
+		case <-writer.entered:
+		case <-time.After(time.Second):
+			close(writer.release)
+			t.Fatal("input did not reach writer barrier")
+		}
+		// The error arrives while prefix forwarding is blocked, before the
+		// caller can close its detach-notification channel.
+		if got := input.result(failure); got != nil {
+			t.Errorf("detected detach reported failure during write: %v", got)
+		}
+		close(writer.release)
+		select {
+		case detached := <-done:
+			if !detached {
+				t.Error("Ctrl+Q was not intercepted")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("input did not finish")
+		}
+		if got := writer.bytes.String(); got != "prefix" {
+			t.Errorf("forwarded %q, want only prefix", got)
+		}
+	})
+	t.Run("both_ready_command_result", func(t *testing.T) {
+		var output bytes.Buffer
+		input := sshAttachInput{writer: &output}
+		detached, err := input.forward([]byte{0x11})
+		if err != nil || !detached {
+			t.Fatalf("detach = %v, %v", detached, err)
+		}
+		detachCh := make(chan struct{})
+		close(detachCh)
+		cmdDone := make(chan error, 1)
+		cmdDone <- failure
+		// Both events are ready. Force the legal command-completion outcome
+		// instead of hoping that select happens to choose it in this run.
+		select {
+		case <-detachCh:
+		default:
+			t.Fatal("detach notification not ready")
+		}
+		if got := input.result(<-cmdDone); got != nil {
+			t.Fatalf("intentional detach reported command error: %v", got)
+		}
+		if output.Len() != 0 {
+			t.Fatalf("Ctrl+Q forwarded %q", output.String())
+		}
+	})
+	t.Run("transport_failure_without_detach", func(t *testing.T) {
+		input := sshAttachInput{writer: io.Discard}
+		if got := input.result(failure); !errors.Is(got, failure) {
+			t.Fatalf("transport failure lost: %v", got)
+		}
+	})
+	t.Run("successful_remote_exit", func(t *testing.T) {
+		input := sshAttachInput{writer: io.Discard}
+		if got := input.result(nil); got != nil {
+			t.Fatal(got)
+		}
+	})
+	t.Run("ordinary_input", func(t *testing.T) {
+		var output bytes.Buffer
+		input := sshAttachInput{writer: &output}
+		detached, err := input.forward([]byte("ordinary input"))
+		if err != nil || detached || output.String() != "ordinary input" {
+			t.Fatalf("forward = %v, %v, %q", detached, err, output.String())
+		}
+		if got := input.result(failure); !errors.Is(got, failure) {
+			t.Fatalf("ordinary input suppressed error: %v", got)
+		}
+	})
+}

--- a/internal/session/ssh_attach_term_test.go
+++ b/internal/session/ssh_attach_term_test.go
@@ -1,0 +1,27 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSSHAttachPortableTERM(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{{"xterm-256color", "xterm-256color"}, {"screen", "screen"}, {"tmux-256color", "tmux-256color"}, {"xterm-ghostty", "xterm-256color"}, {"", "xterm-256color"}, {"x; touch /unwanted", "xterm-256color"}} {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Setenv("TERM", tc.input)
+			r := &SSHRunner{Host: "fixture"}
+			args := r.buildAttachArgs("quoted ' session")
+			if command := args[len(args)-1]; !strings.HasPrefix(command, "TERM="+shellQuote(tc.want)+" ") {
+				t.Fatalf("remote command: %q", command)
+			}
+		})
+	}
+}
+
+func BenchmarkSSHAttachArgs(b *testing.B) {
+	b.Setenv("TERM", "xterm-256color")
+	runner := &SSHRunner{Host: "fixture"}
+	for i := 0; i < b.N; i++ {
+		runner.buildAttachArgs("session")
+	}
+}

--- a/internal/session/ssh_attach_term_test.go
+++ b/internal/session/ssh_attach_term_test.go
@@ -11,7 +11,7 @@ func TestSSHAttachPortableTERM(t *testing.T) {
 			t.Setenv("TERM", tc.input)
 			r := &SSHRunner{Host: "fixture"}
 			args := r.buildAttachArgs("quoted ' session")
-			if command := args[len(args)-1]; !strings.HasPrefix(command, "TERM="+shellQuote(tc.want)+" ") {
+			if command := args[len(args)-1]; !strings.HasPrefix(command, "env TERM="+shellQuote(tc.want)+" ") {
 				t.Fatalf("remote command: %q", command)
 			}
 		})

--- a/scripts/ci-native-ssh.sh
+++ b/scripts/ci-native-ssh.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Run only the required native SSH acceptance tests as an unprivileged user.
+set -euo pipefail
+export GOTOOLCHAIN=local
+: "${NATIVE_SSH_ARTIFACT_DIR:?Set an absolute artifact directory outside the checkout}"
+: "${NATIVE_SSH_EXPECTED_SHA:?Set the exact reviewed source commit}"
+test "$(uname -s)" = Linux
+test "$(id -u)" -ne 0
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+test "$(git rev-parse HEAD)" = "$NATIVE_SSH_EXPECTED_SHA"
+test -z "$(git status --porcelain)"
+python3 - "$root" "$NATIVE_SSH_ARTIFACT_DIR" <<'PY'
+import pathlib,sys
+root=pathlib.Path(sys.argv[1]).resolve()
+p=pathlib.Path(sys.argv[2])
+assert p.is_absolute() and p.resolve()==p and not p.is_relative_to(root)
+PY
+mkdir -p "$NATIVE_SSH_ARTIFACT_DIR"
+run="$NATIVE_SSH_ARTIFACT_DIR/run"
+mkdir "$run"
+exec > >(tee "$run/commands.log") 2>&1
+finish() {
+ result=$?
+ trap - EXIT
+ set +e
+ sha256sum -c "$run/source.sha256" > "$run/source-check.log" 2>&1
+ check=$?
+ git status --porcelain > "$run/source-status.txt"
+ if test "$check" -ne 0 || test -s "$run/source-status.txt"; then result=94; fi
+ printf '%s\n' "$result" > "$run/exit"
+ exit "$result"
+}
+git ls-files -z | xargs -0 sha256sum > "$run/source.sha256"
+trap finish EXIT
+git rev-parse HEAD 'HEAD^{tree}' > "$run/source"
+sha256sum "$0" > "$run/runner.sha256"
+for tool in go tmux ssh ssh-keygen python3; do command -v "$tool"; done
+python3 - <<'PY'
+import os,stat
+for p in ['/usr/sbin/sshd','/usr/bin/cat']:
+ s=os.stat(p)
+ assert s.st_uid==0 and not s.st_mode & 0o022 and os.access(p,os.X_OK),p
+# The acceptance fixture uses this production namespace. Refuse active sockets.
+p='/tmp/agent-deck-ssh'
+if os.path.lexists(p):
+ s=os.lstat(p)
+ assert stat.S_ISDIR(s.st_mode) and s.st_uid==os.getuid() and s.st_mode & 0o077==0
+ assert not any(stat.S_ISSOCK(os.lstat(e.path).st_mode) for e in os.scandir(p))
+PY
+id
+go version
+tmux -V
+ssh -V
+/usr/sbin/sshd -V
+sandbox=$(mktemp -d /tmp/ns.XXXXXX)
+mkdir "$sandbox/home" "$sandbox/tmp" "$run/receipts"
+printf '%s\n' "$sandbox" > "$run/sandbox-path"
+export GOMODCACHE="$(go env GOMODCACHE)" GOCACHE="$(go env GOCACHE)"
+export HOME="$sandbox/home" TMPDIR="$sandbox/tmp"
+export XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= XDG_STATE_HOME= XDG_RUNTIME_DIR=
+unset TMUX SSH_AUTH_SOCK SSH_AGENT_PID AGENTDECK_PROFILE CLAUDE_CONFIG_DIR CODEX_HOME DBUS_SESSION_BUS_ADDRESS
+export GOMAXPROCS=2 GOFLAGS=-p=1 GOTOOLCHAIN=local NATIVE_SSH_REQUIRED=1
+export NATIVE_SSHD=/usr/sbin/sshd NATIVE_SSH_RECEIPT_DIR="$run/receipts"
+set +e
+go test -json -p 1 -count=1 -timeout 10m ./cmd/agent-deck -run '^TestNativeSSHAttachLifecycle$' > "$run/lifecycle.jsonl" 2> "$run/lifecycle.stderr"
+lifecycle=$?
+go test -json -p 1 -count=1 -timeout 5m ./internal/session -run '^TestSSHAttachPortableTERM$' > "$run/term.jsonl" 2> "$run/term.stderr"
+term=$?
+printf '%s\n' "$lifecycle" > "$run/lifecycle.exit"
+printf '%s\n' "$term" > "$run/term.exit"
+set -e
+python3 - "$run" <<'PY'
+import json,pathlib,sys
+root=pathlib.Path(sys.argv[1]); inventory={}
+required={'lifecycle':['TestNativeSSHAttachLifecycle'],'term':['TestSSHAttachPortableTERM','TestSSHAttachPortableTERM/xterm-256color','TestSSHAttachPortableTERM/screen','TestSSHAttachPortableTERM/tmux-256color','TestSSHAttachPortableTERM/xterm-ghostty','TestSSHAttachPortableTERM/#00','TestSSHAttachPortableTERM/x;_touch_/unwanted']}
+for name,tests in required.items():
+ rows=[json.loads(line) for line in (root/(name+'.jsonl')).read_text().splitlines()]
+ assert rows and (root/(name+'.exit')).read_text().strip()=='0',name
+ assert all(e['Action'] not in ('fail','skip') for e in rows),name
+ assert any(e['Action']=='pass' and 'Test' not in e for e in rows),name
+ inventory[name]={}
+ for test in tests:
+  actions=[e['Action'] for e in rows if e.get('Test')==test and e['Action']!='output']
+  inventory[name][test]=actions
+  assert actions==['run','pass'],(test,actions)
+(root/'required-tests.json').write_text(json.dumps(inventory,indent=2)+'\n')
+PY


### PR DESCRIPTION
## What problem does this solve?

Remote attach can report success after an SSH failure, reject an unsupported local terminal name, or report an intentional Ctrl+Q detach as a transport failure when buffered input and SSH completion race. POSIX-only TERM assignment also breaks remote accounts using other login shells.

## Why this change

Preserve the SSH process error through input/terminal cleanup and return it for genuine failures. Record detach intent before forwarding buffered input and reconcile the result after input quiescence. Construct the remote command with quoted `env TERM=...` and a bounded portable TERM fallback. Host-key verification and shared connection policy remain unchanged.

## User impact

SSH failures are visible to callers, while intentional detach remains successful and leaves the session running. Unsupported local terminal names use `xterm-256color` for attach. The fallback is a compatibility policy, not detection of every remote terminfo database.

## Evidence

Baseline actual-SSH tests reproduced lost transport errors and unknown-TERM attach failure. Separate deterministic race controls reproduced the buffered-write and both-ready detach failures before the correction. These failures and all earlier setup/compiler failures are preserved.

Accepted source `22c3fa9ae0bbdad5be4a6ba9849df2ae04b191d7`, composed with main `169699009cd3d80a410ba3a1c829ae1f7a502827`, passed all **51 required checks, zero failures and zero skips** in an unprivileged Docker sandbox:

- 8 native SSH lifecycle/TERM nodes using actual OpenSSH client and server, PTYs and tmux.
- 16 ordering, executable-argv and SSH safety nodes under the race detector.
- 22 terminal-feature and input-pump nodes under the race detector, including the repaired stale-absence control.
- 5 isolation/bootstrap nodes without race instrumentation.

The gate used Go 1.25.14, OpenSSH 9.2p1 client/9.2 server, tmux 3.5a, Python 3.11.2, short private HOME/TMPDIR and UID-owned caches. All 2,229 source hashes stayed unchanged, the Git worktree stayed clean, and before/after tool hashes matched. The gate took 338.672 seconds including fresh-cache builds. Every required node has explicit RUN/PASS evidence; incidental parent/subtest events are not added to the 51 count.

The native harness verifies ordered Unicode/input receipts, terminal colors, resize, raw and bracketed 4 KB submission, Ctrl+Q detach, killed SSH client, interrupted transport, reconnect to the same application identity, production ControlMaster reuse and matched direct-SSH latency controls. Strict latency thresholds and exclusive receipt creation remain enforced. Acceptance runs use fresh receipt directories. Missing optional tools never count as native acceptance.

The original standard non-race full-suite gate passed on the earlier source, with its documented size warning and audited baseline-red substitution for generic revert. It was not repeated for this composition. Earlier Agentbox positive observations were withheld after unexplained source-integrity discrepancies; the complete 51-node gate above ran separately on verified source and trusted compute.

Publication candidate `bbdba6148e36fe62633b76a35873454040107ddd` additionally merges main `6bb9eb9d76bfada50eecec38b34401e85b1e1c94`. That source-only composition adds the already-landed CLI account visibility changes. The tested SSH implementation, native fixtures, CI runner and terminal/input-pump sources are byte-identical to the accepted gate source. Exact publication-head CI remains required; the 51-node result is not presented as a new full-suite run on this head.

The required native CI job enforces actual lifecycle/TERM execution, no skips and source-integrity receipts. Earlier exact-head native CI passed at `6fc5a44b` in [run 33962179762](https://github.com/asheshgoplani/agent-deck/actions/runs/33962179762); new-head checks must run after this update.

Physical Mac rendering/laptop sleep and actual csh/tcsh/fish execution remain untested. Portable command construction has source review and real `/bin/sh` argv controls. Network blackhole recovery remains manual detach or restored transport; this does not introduce automatic keepalive detection or claim systemd persistence.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** GPT-6, with independent review.

## What actually bothered you

> A rented Mac running one agent-deck, reached over SSH by two people, must feel exactly like working locally.

## Checklist

- [x] Scoped attach correction with meaningful baseline-red and corrected-green evidence
- [x] All 51 required composed-source controls executed without skips
- [x] Prior full-suite evidence distinguished from focused composition verification
- [x] Strict latency thresholds and source-integrity checks preserved
- [x] CHANGELOG.md untouched
- [x] AI work disclosed
- [x] Existing published commit history preserved without force-push
- [ ] Exact publication-head CI complete

<!-- gate:ai=authored model=gpt-6 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native SSH attach reliability during disconnects, reconnects, and interrupted connections.
  * Ctrl+Q detachment now takes precedence over SSH transport errors, preventing misleading failure messages.
  * Improved handling of fragmented input, bracketed paste, larger interactive sends, and terminal resizing.
  * Preserved terminal identity and rendering compatibility across supported and unknown terminal types.
* **Testing**
  * Added comprehensive native SSH integration coverage, including connection failures and multiplexed sessions.
  * Added automated continuous-integration validation using real SSH environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Native SSH CI hardening

Follow-up `733d68c` disables persisted checkout credentials in the native SSH job and limits its acceptance step to 18 minutes. The command, candidate ref and read-only workflow permission are unchanged. YAML parsing, exact semantic-delta validation and whitespace checks passed; independent diff review approved the two-line change. Runtime tests were not rerun locally for this workflow-only correction; the new exact-head CI must pass before merge. The 18-minute step limit improves the opportunity to retain evidence but does not guarantee upload time within the 20-minute job if setup exceeds two minutes.
