### PR TITLE
fix(pi): select output from the persisted conversation branch

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8221,7 +8221,7 @@ func (i *Instance) getPiLastResponse() (*ResponseOutput, error) {
 	return parsePiLastAssistantMessage(data)
 }
 
-func parsePiLastAssistantMessage(data []byte) (*ResponseOutput, error) {
+func parsePiLastAssistantMessageLinear(data []byte) (*ResponseOutput, error) {
 	type contentPart struct {
 		Type string `json:"type"`
 		Text string `json:"text"`

--- a/internal/session/pi_branch_output_test.go
+++ b/internal/session/pi_branch_output_test.go
@@ -1,0 +1,227 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These fixtures follow Pi session-manager.ts at 2b768ba42cdbd7336474d6986a3ef1efbb0a44f7:
+// persisted entries carry id/parentId; the last persisted entry is the leaf.
+const piBranchHistory = `{"type":"session","version":3,"id":"pi-branches"}
+{"type":"message","id":"u1","parentId":null,"message":{"role":"user","content":"first question"}}
+{"type":"message","id":"a1","parentId":"u1","timestamp":"2026-09-05T01:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"ACTIVE ANSWER"},{"type":"text","text":"second block"}]}}
+{"type":"message","id":"u2","parentId":"a1","message":{"role":"user","content":"abandoned question"}}
+{"type":"message","id":"a2","parentId":"u2","timestamp":"2026-09-05T02:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"INACTIVE ANSWER"}]}}
+`
+
+func TestPiResponseUsesPersistedBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		append  string
+		content string
+		stamp   string
+		wantErr bool
+	}{
+		{
+			name:    "unchanged persisted leaf remains authoritative",
+			content: "INACTIVE ANSWER", stamp: "2026-09-05T02:00:00Z",
+		},
+		{
+			name:    "user leaf selects earlier assistant",
+			append:  `{"type":"message","id":"u3","parentId":"a1","message":{"role":"user","content":"new branch"}}`,
+			content: "ACTIVE ANSWER\nsecond block", stamp: "2026-09-05T01:00:00Z",
+		},
+		{
+			name:    "summary uses parent not abandoned fromId",
+			append:  `{"type":"branch_summary","id":"s1","parentId":"a1","fromId":"a2","summary":"abandoned context"}`,
+			content: "ACTIVE ANSWER\nsecond block", stamp: "2026-09-05T01:00:00Z",
+		},
+		{
+			name:    "metadata leaf follows the same branch",
+			append:  `{"type":"session_info","id":"n1","parentId":"a1","name":"renamed branch"}`,
+			content: "ACTIVE ANSWER\nsecond block", stamp: "2026-09-05T01:00:00Z",
+		},
+		{
+			name: "nonmessage ancestor remains in chain",
+			append: `{"type":"model_change","id":"m1","parentId":"a1","provider":"fixture","modelId":"fixture"}
+{"type":"message","id":"u3","parentId":"m1","message":{"role":"user","content":"new branch"}}`,
+			content: "ACTIVE ANSWER\nsecond block", stamp: "2026-09-05T01:00:00Z",
+		},
+		{
+			name:    "tool only assistant falls back within branch",
+			append:  `{"type":"message","id":"a3","parentId":"a1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"hidden"},{"type":"toolCall","name":"read"}]}}`,
+			content: "ACTIVE ANSWER\nsecond block", stamp: "2026-09-05T01:00:00Z",
+		},
+		{
+			name:    "new active assistant wins regardless of timestamp order",
+			append:  `{"type":"message","id":"a3","parentId":"a1","timestamp":"2026-09-05T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"NEW ACTIVE ANSWER"}]}}`,
+			content: "NEW ACTIVE ANSWER", stamp: "2026-09-05T00:00:00Z",
+		},
+		{
+			name: "partial tree append cannot revive previous branch",
+			append: `{"type":"message","id":"u3","parentId":"a1","message":{"role":"user","content":"new branch"}}
+{"type":"message","id":"partial",`,
+			wantErr: true,
+		},
+		{
+			name:    "reset to new root does not borrow old assistant",
+			append:  `{"type":"message","id":"u3","parentId":null,"message":{"role":"user","content":"fresh root"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "summary at root does not expose abandoned assistant",
+			append:  `{"type":"branch_summary","id":"s1","parentId":null,"fromId":"a2","summary":"abandoned context"}`,
+			wantErr: true,
+		},
+		{
+			name:    "dangling parent cannot borrow file last assistant",
+			append:  `{"type":"message","id":"u3","parentId":"missing","message":{"role":"user","content":"new branch"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "assistant leaf still validates its parent",
+			append:  `{"type":"message","id":"a3","parentId":"missing","message":{"role":"assistant","content":[{"type":"text","text":"UNPROVEN ANSWER"}]}}`,
+			wantErr: true,
+		},
+		{
+			name:    "self cycle is not a valid ancestry",
+			append:  `{"type":"message","id":"a3","parentId":"a3","message":{"role":"assistant","content":[{"type":"text","text":"CYCLIC ANSWER"}]}}`,
+			wantErr: true,
+		},
+		{
+			name: "two node cycle is rejected",
+			append: `{"type":"message","id":"u3","parentId":"a3","message":{"role":"user","content":"cycle"}}
+{"type":"message","id":"a3","parentId":"u3","message":{"role":"assistant","content":[{"type":"text","text":"CYCLIC ANSWER"}]}}`,
+			wantErr: true,
+		},
+		{
+			name: "duplicate ID cannot replace an ancestor",
+			append: `{"type":"message","id":"a1","parentId":"a2","message":{"role":"assistant","content":[{"type":"text","text":"AMBIGUOUS ANSWER"}]}}
+{"type":"message","id":"u3","parentId":"a1","message":{"role":"user","content":"new branch"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing parent field is not null root",
+			append:  `{"type":"message","id":"u3","message":{"role":"user","content":"unknown parent"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "nonstring parent is invalid",
+			append:  `{"type":"message","id":"u3","parentId":42,"message":{"role":"user","content":"unknown parent"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing leaf ID cannot select an old branch",
+			append:  `{"type":"message","parentId":"a1","message":{"role":"user","content":"unknown leaf"}}`,
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePiLastAssistantMessage([]byte(piBranchHistory + tc.append))
+			if tc.wantErr {
+				if err == nil || got != nil {
+					t.Fatalf("unproven branch returned a response: %+v, %v", got, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := ResponseOutput{Tool: "pi", Role: "assistant", Content: tc.content, Timestamp: tc.stamp, SessionID: "pi-branches"}
+			if *got != want {
+				t.Fatalf("response from wrong persisted ancestry: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestPiResponsePreservesLegacyLinearSessions(t *testing.T) {
+	for _, header := range []string{"", `{"type":"session","id":"legacy"}`, `{"type":"session","id":"legacy","version":1}`} {
+		t.Run("header"+header, func(t *testing.T) {
+			data := fmt.Sprintf(`%s
+{"type":"message","timestamp":"old","message":{"role":"assistant","content":[{"type":"text","text":"first"}]}}
+{"type":"message","timestamp":"last","message":{"role":"assistant","content":[{"type":"text","text":"legacy last"}]}}
+{"type":"message","message":{"role":"assistant","content":[{"type":"toolCall","name":"read"}]}}
+{"type":"message",`, header)
+			got, err := parsePiLastAssistantMessage([]byte(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := ResponseOutput{Tool: "pi", Role: "assistant", Content: "legacy last", Timestamp: "last"}
+			if header != "" {
+				want.SessionID = "legacy"
+			}
+			if *got != want {
+				t.Fatalf("legacy linear behavior changed: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestPiLastResponseReadsPersistedBranchFromDisk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".pi", "agent-deck", "branch-output")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data := piBranchHistory + `{"type":"message","id":"u3","parentId":"a1","message":{"role":"user","content":"new branch"}}`
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := (&Instance{ID: "branch-output", Tool: "pi"}).GetLastResponse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ResponseOutput{Tool: "pi", Role: "assistant", Content: "ACTIVE ANSWER\nsecond block", Timestamp: "2026-09-05T01:00:00Z", SessionID: "pi-branches"}
+	if *got != want {
+		t.Fatalf("public response API selected an inactive branch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestPiResponseTreeFormatCannotDowngradeToLinear(t *testing.T) {
+	leaf := `{"type":"message","id":"u3","parentId":"a1","message":{"role":"user","content":"new branch"}}`
+	for _, tc := range []struct {
+		name string
+		data string
+	}{
+		{"tree without header", strings.SplitN(piBranchHistory, "\n", 2)[1] + leaf},
+		{"tree with missing version", strings.Replace(piBranchHistory, `"version":3,`, "", 1) + leaf},
+		{"tree with legacy version", strings.Replace(piBranchHistory, `"version":3`, `"version":1`, 1) + leaf},
+		{"empty header identity", strings.Replace(piBranchHistory, `"id":"pi-branches"`, `"id":""`, 1)},
+		{"nonstring header identity", strings.Replace(piBranchHistory, `"id":"pi-branches"`, `"id":42`, 1)},
+		{"duplicate header", piBranchHistory + `{"type":"session","version":3,"id":"different-session"}` + "\n" + leaf},
+		{"empty leaf identity", piBranchHistory + strings.Replace(leaf, `"id":"u3"`, `"id":""`, 1)},
+		{"nonstring leaf identity", piBranchHistory + strings.Replace(leaf, `"id":"u3"`, `"id":42`, 1)},
+		{"empty parent identity", piBranchHistory + strings.Replace(leaf, `"parentId":"a1"`, `"parentId":""`, 1)},
+		{"corrupt ancestor below text assistant", strings.Replace(piBranchHistory, `"id":"u1","parentId":null`, `"id":"u1","parentId":"missing"`, 1) + leaf},
+		{"version two without tree identities", `{"type":"session","version":2,"id":"malformed"}
+{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"UNPROVEN ANSWER"}]}}`},
+		{"complete malformed tree record", piBranchHistory + "not-json\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := parsePiLastAssistantMessage([]byte(tc.data)); err == nil || got != nil {
+				t.Fatalf("malformed tree fell back to linear response: %+v, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestPiResponseVersionTwoAndMetadataLeaves(t *testing.T) {
+	for _, kind := range []string{"custom", "label", "compaction"} {
+		t.Run(kind, func(t *testing.T) {
+			data := strings.Replace(piBranchHistory, `"version":3`, `"version":2`, 1) + fmt.Sprintf(`{"type":%q,"id":"leaf","parentId":"a1"}`, kind)
+			got, err := parsePiLastAssistantMessage([]byte(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := ResponseOutput{Tool: "pi", Role: "assistant", Content: "ACTIVE ANSWER\nsecond block", Timestamp: "2026-09-05T01:00:00Z", SessionID: "pi-branches"}
+			if *got != want {
+				t.Fatalf("metadata lost version-two ancestry: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}

--- a/internal/session/pi_branch_output_test.go
+++ b/internal/session/pi_branch_output_test.go
@@ -225,3 +225,11 @@ func TestPiResponseVersionTwoAndMetadataLeaves(t *testing.T) {
 		})
 	}
 }
+
+func TestPiResponseRejectsExplicitNullVersion(t *testing.T) {
+	data := []byte(`{"type":"session","id":"null-version","version":null}
+{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"UNPROVEN VERSION"}]}}`)
+	if got, err := parsePiLastAssistantMessage(data); err == nil || got != nil {
+		t.Fatalf("explicit null version was treated as legacy: %+v, %v", got, err)
+	}
+}

--- a/internal/session/pi_output.go
+++ b/internal/session/pi_output.go
@@ -1,0 +1,118 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// parsePiLastAssistantMessage resolves the last persisted branch, not Pi's
+// in-memory leaf pointer, which can change without an appended JSONL entry.
+func parsePiLastAssistantMessage(data []byte) (*ResponseOutput, error) {
+	type entry struct {
+		Type     json.RawMessage `json:"type"`
+		ID       json.RawMessage `json:"id"`
+		ParentID json.RawMessage `json:"parentId"`
+		Version  json.RawMessage `json:"version"`
+		raw      []byte
+		kind     string
+	}
+	var entries []entry
+	var header entry
+	var tree, malformed, invalidHeader bool
+	headerCount, version := 0, 1
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var e entry
+		if err := json.Unmarshal(line, &e); err != nil {
+			malformed = true
+			continue
+		}
+		e.raw = line
+		if err := json.Unmarshal(e.Type, &e.kind); err != nil {
+			malformed = true
+		}
+		if e.kind == "session" {
+			headerCount++
+			if headerCount != 1 || len(entries) != 0 {
+				invalidHeader = true
+			}
+			header = e
+			version = 1
+			if len(e.Version) != 0 {
+				if err := json.Unmarshal(e.Version, &version); err != nil || version < 1 || version > 3 {
+					invalidHeader = true
+				}
+			}
+			if version >= 2 {
+				tree = true
+			}
+			continue
+		}
+		if len(e.ID) != 0 || len(e.ParentID) != 0 {
+			tree = true
+		}
+		entries = append(entries, e)
+	}
+	// Legacy records have no tree identities. Preserve their linear selection
+	// and partial-tail tolerance, but never downgrade a mixed/tree transcript.
+	if !tree && !invalidHeader {
+		return parsePiLastAssistantMessageLinear(data)
+	}
+	if malformed || invalidHeader || headerCount != 1 || version < 2 {
+		return nil, fmt.Errorf("invalid Pi tree transcript: incomplete records or session header")
+	}
+	var sessionID string
+	if err := json.Unmarshal(header.ID, &sessionID); err != nil || sessionID == "" {
+		return nil, fmt.Errorf("invalid Pi tree session identity")
+	}
+	byID := make(map[string]int, len(entries))
+	parents := make([]*string, len(entries))
+	for n, e := range entries {
+		var id string
+		if err := json.Unmarshal(e.ID, &id); err != nil || id == "" || e.kind == "" {
+			return nil, fmt.Errorf("invalid Pi tree entry identity at record %d", n+1)
+		}
+		if _, duplicate := byID[id]; duplicate {
+			return nil, fmt.Errorf("duplicate Pi tree entry identity %q", id)
+		}
+		byID[id] = n
+		if len(e.ParentID) == 0 {
+			return nil, fmt.Errorf("missing Pi tree parent for %q", id)
+		}
+		if err := json.Unmarshal(e.ParentID, &parents[n]); err != nil || (parents[n] != nil && *parents[n] == "") {
+			return nil, fmt.Errorf("invalid Pi tree parent for %q", id)
+		}
+	}
+	var response *ResponseOutput
+	visited := make(map[int]bool)
+	for n := len(entries) - 1; n >= 0; {
+		if visited[n] {
+			return nil, fmt.Errorf("cycle in Pi tree ancestry")
+		}
+		visited[n] = true
+		if response == nil {
+			// Reuse the existing assistant text-block decoder; generic user and
+			// metadata payloads cannot prevent their parent links being followed.
+			if got, err := parsePiLastAssistantMessageLinear(entries[n].raw); err == nil {
+				got.SessionID = sessionID
+				response = got
+			}
+		}
+		if parents[n] == nil {
+			break
+		}
+		parent, found := byID[*parents[n]]
+		if !found {
+			return nil, fmt.Errorf("missing Pi tree ancestor %q", *parents[n])
+		}
+		n = parent
+	}
+	// Validate the entire chain before returning even a qualifying leaf reply.
+	if response == nil {
+		return nil, fmt.Errorf("no assistant response found in Pi session")
+	}
+	return response, nil
+}

--- a/internal/session/pi_output.go
+++ b/internal/session/pi_output.go
@@ -42,6 +42,8 @@ func parsePiLastAssistantMessage(data []byte) (*ResponseOutput, error) {
 			header = e
 			version = 1
 			if len(e.Version) != 0 {
+				// A present null must not inherit the omitted-field v1 default.
+				version = 0
 				if err := json.Unmarshal(e.Version, &version); err != nil || version < 1 || version > 3 {
 					invalidHeader = true
 				}


### PR DESCRIPTION
## What problem does this solve?

Pi persists a branching conversation history. Scanning the last assistant line can return a response from an abandoned branch. Select the latest assistant text on the persisted active leaf's ancestry instead.

## Why this change

Validate the session header and parent graph, then walk the persisted leaf's ancestry through user, tool and metadata entries. Keep compatible legacy linear transcripts. Reject missing parents, cycles, malformed tree records and invalid explicit versions, including null.

## User impact

Session output follows the saved conversation branch. This covers persisted history, not a live in-memory Pi leaf or agent completion classification. The separate completion-adapter work remains open in #2091.

## Evidence

Candidate 4265a3ccd7b43275800f8f86bb06ae486e66592b, tree25e8e16decafb7842a633aa358389c48d4d9b4e9:

- Meaningful behavioral baseline failures preserved; reverting the parser with final tests produces36 Pi failures and no non-Pi failures.
- Focused race:50 test/subtest passes, no failures or skips.
- Full contributor gate:16 PASS,0 FAIL,0 WARN. All55 required controls explicitly ran and passed, including isolation controls. Existing optional suite skips are inventoried separately.
- Independent source review approved the parser and explicit-null correction.

Published35f985853aefcf4fa655faf4b124c2448b5f95f4 is the clean normal merge of that candidate with mainb06ad50f. The composed tree is f6c54870a2fad472af4c70a6f5a88b6ca94984e1. The local full receipt is bound to4265; no duplicate full-suite execution is claimed for the composition. Published-head CI provides separate integration validation.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

Models: GPT-6 Astra for implementation and independent review; GPT-5.6 Luna assisted publication.

## What actually bothered you

The maintenance audit found that persisted Pi branch switches could display a response from another branch. The owner asked to fix and verify the issue as part of the repository maintenance work.

## Checklist

- [x] Targeted parser change with behavioral regression tests
- [x] Sandboxed contributor gate and independent review completed
- [x] Runtime evidence and later composition are distinguished
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->
