### PR TITLE
fix(tmux): preserve sizing policy for Deck shell windows

### DIFF
--- a/internal/tmux/shell_window_size_test.go
+++ b/internal/tmux/shell_window_size_test.go
@@ -1,0 +1,183 @@
+package tmux
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise the same Start -> NewShellWindow path used by Open Shell Here.
+// A later Deck window must keep the sizing policy selected for the session.
+func TestSession_NewShellWindowSizePolicy(t *testing.T) {
+	requireTmux(t)
+	for _, tc := range []struct {
+		name      string
+		overrides map[string]string
+		wantSize  string
+		wantAgg   string
+		hook      bool
+	}{
+		{"defaults", nil, "largest", "on", false},
+		{"explicit overrides", map[string]string{"window-size": "smallest", "aggressive-resize": "off"}, "smallest", "off", false},
+		{"size override", map[string]string{"window-size": "smallest"}, "smallest", "on", false},
+		{"resize override", map[string]string{"aggressive-resize": "off"}, "largest", "off", false},
+		{"hook selects another window", nil, "largest", "on", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			socket, unrelated := makeIsolatedServer(t)
+			ctl := func(args ...string) string {
+				t.Helper()
+				out, err := exec.Command("tmux", append([]string{"-L", socket}, args...)...).CombinedOutput()
+				require.NoError(t, err, "%s", out)
+				return strings.TrimSpace(string(out))
+			}
+			ctl("set-option", "-gw", "window-size", "latest")
+			ctl("set-option", "-gw", "aggressive-resize", "off")
+			s := NewSession("size-policy", t.TempDir())
+			s.SocketName = socket
+			s.OptionOverrides = tc.overrides
+			require.NoError(t, s.Start(""))
+			initial := ctl("display-message", "-p", "-t", s.Name, "#{window_id}")
+			check := func(target, wantSize, wantAgg string) {
+				t.Helper()
+				size := ctl("show-options", "-wAv", "-t", target, "window-size")
+				agg := ctl("show-options", "-wAv", "-t", target, "aggressive-resize")
+				t.Logf("target=%s size=%s aggressive=%s geometry=%s", target, size, agg,
+					ctl("display-message", "-p", "-t", target, "#{window_width}x#{window_height}"))
+				assert.Equal(t, wantSize, size, "window-size for %s", target)
+				assert.Equal(t, wantAgg, agg, "aggressive-resize for %s", target)
+			}
+			check(initial, tc.wantSize, tc.wantAgg)
+			if tc.hook {
+				// User hooks can emit stdout and change selection before creation
+				// returns. Neither may redirect our settings to the initial window.
+				ctl("set-hook", "-t", s.Name, "after-new-window", "display-message -p hook-output ; select-window -t "+initial)
+				ctl("set-option", "-w", "-t", initial, "window-size", "manual")
+			}
+			for range 2 {
+				before := ctl("list-windows", "-t", s.Name, "-F", "#{window_id}")
+				started := time.Now()
+				require.NoError(t, s.NewShellWindow(t.TempDir()))
+				t.Logf("NewShellWindow elapsed=%s", time.Since(started))
+				after := strings.Split(ctl("list-windows", "-t", s.Name, "-F", "#{window_id}"), "\n")
+				created := 0
+				for _, id := range after {
+					if !strings.Contains("\n"+before+"\n", "\n"+id+"\n") {
+						created++
+						check(id, tc.wantSize, tc.wantAgg)
+					}
+				}
+				require.Equal(t, 1, created, "each call must create exactly one window")
+			}
+			if tc.hook {
+				tc.wantSize = "manual"
+			}
+			check(initial, tc.wantSize, tc.wantAgg)
+			check(unrelated, "latest", "off")
+			assert.Equal(t, "latest", ctl("show-options", "-gwv", "window-size"))
+			assert.Equal(t, "off", ctl("show-options", "-gwv", "aggressive-resize"))
+		})
+	}
+}
+
+func TestSession_NewShellWindowPreservesHookOptions(t *testing.T) {
+	requireTmux(t)
+	for _, tc := range []struct{ name, hook, want string }{
+		{"both", "set-option -w window-size manual ; set-option -w aggressive-resize off", "manual/0"},
+		{"size only", "set-option -w window-size manual", "manual/1"},
+		{"resize only", "set-option -w aggressive-resize off", "smallest/0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			socket, target := makeIsolatedServer(t)
+			// A user's hook is more specific than Deck's default or configured values.
+			out, err := exec.Command("tmux", "-L", socket, "set-hook", "-t", target, "after-new-window", tc.hook).CombinedOutput()
+			require.NoError(t, err, "%s", out)
+			s := &Session{Name: target, SocketName: socket, OptionOverrides: map[string]string{"window-size": "smallest"}}
+			require.NoError(t, s.NewShellWindow(t.TempDir()))
+			out, err = exec.Command("tmux", "-L", socket, "display-message", "-p", "-t", target, "#{window-size}/#{aggressive-resize}").CombinedOutput()
+			require.NoError(t, err, "%s", out)
+			assert.Equal(t, tc.want, strings.TrimSpace(string(out)))
+		})
+	}
+}
+
+func TestSession_NewShellWindowInvalidOverrideStillCreatesOneWindow(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+	s := &Session{Name: target, SocketName: socket, OptionOverrides: map[string]string{"window-size": ""}}
+	// Match Start's key-presence and best-effort option semantics. An empty
+	// override is not replaced with largest, nor mistaken for creation failure.
+	require.NoError(t, s.NewShellWindow(t.TempDir()))
+	out, err := exec.Command("tmux", "-L", socket, "list-windows", "-t", target, "-F", "#{window_id}").CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	assert.Len(t, strings.Fields(string(out)), 2)
+	out, err = exec.Command("tmux", "-L", socket, "show-options", "-wv", "-t", target, "window-size").CombinedOutput()
+	require.NoError(t, err, "%s", out)
+	assert.Empty(t, strings.TrimSpace(string(out)), "invalid override must not silently install a local default")
+
+	s.Name = "missing-window-policy-session"
+	require.Error(t, s.NewShellWindow(t.TempDir()), "actual creation failure must still be returned")
+}
+
+// This control isolates the secondary report's size-less-client hypothesis.
+// It does not establish behavior on the reporter's tmux 3.7a/macOS platform.
+func TestSession_SizeLessControlClientGeometry(t *testing.T) {
+	requireTmux(t)
+	for _, policy := range []string{"latest", "largest"} {
+		t.Run(policy, func(t *testing.T) {
+			socket, target := makeIsolatedServer(t)
+			ctl := func(args ...string) string {
+				t.Helper()
+				out, err := exec.Command("tmux", append([]string{"-L", socket}, args...)...).CombinedOutput()
+				require.NoError(t, err, "%s", out)
+				return strings.TrimSpace(string(out))
+			}
+			ctl("set-option", "-w", "-t", target, "window-size", policy)
+			ctl("set-option", "-t", target, "status", "off")
+			cmd := exec.Command("tmux", "-L", socket, "attach-session", "-t", target)
+			cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+			terminal, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 200, Rows: 54})
+			require.NoError(t, err)
+			var terminalOutput bytes.Buffer
+			outputDone := make(chan struct{})
+			go func() { _, _ = io.Copy(&terminalOutput, terminal); close(outputDone) }()
+			closed := false
+			closeTerminal := func() {
+				if !closed {
+					_ = terminal.Close()
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+					<-outputDone
+					closed = true
+				}
+			}
+			t.Cleanup(closeTerminal)
+			geometry := func() string {
+				return ctl("display-message", "-p", "-t", target, "#{window_width}x#{window_height}")
+			}
+			if !assert.Eventually(t, func() bool { return geometry() == "200x54" }, 5*time.Second, 20*time.Millisecond) {
+				closeTerminal()
+				t.Fatalf("native attach failed before observer setup: output=%q geometry=%s", terminalOutput.String(), geometry())
+			}
+			sender, err := OpenKeySender(socket, target)
+			require.NoError(t, err)
+			defer sender.Close()
+			t.Logf("native+observer: %s; clients=%s", geometry(), ctl("list-clients", "-t", target, "-F", "#{client_width}x#{client_height} #{client_flags}"))
+			assert.Equal(t, "200x54", geometry())
+			closeTerminal()
+			require.Eventually(t, func() bool {
+				return ctl("list-clients", "-t", target, "-F", "#{client_control_mode}") == "1"
+			}, 5*time.Second, 20*time.Millisecond)
+			t.Logf("observer only: %s; clients=%s", geometry(), ctl("list-clients", "-t", target, "-F", "#{client_width}x#{client_height} #{client_flags}"))
+			assert.Equal(t, "200x54", geometry())
+		})
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6143,12 +6143,39 @@ func (s *Session) NewShellWindow(workdir string) error {
 	if shell == "" {
 		shell = "/bin/sh"
 	}
-	args := []string{"new-window", "-t", s.Name}
+	args := []string{"new-window", "-P", "-F", "#{window_id}", "-t", s.Name}
 	if workdir != "" {
 		args = append(args, "-c", workdir)
 	}
 	args = append(args, shell)
-	return tmuxExec(s.SocketName, args...).Run()
+	out, err := tmuxExec(s.SocketName, args...).Output()
+	if err != nil {
+		return err
+	}
+	// new-window prints its ID before running after-new-window hooks, which
+	// may print more output or select another window. Configure that exact ID.
+	windowID, _, _ := strings.Cut(string(out), "\n")
+	args = nil
+	for _, option := range []struct{ key, value string }{
+		{"window-size", "largest"},
+		{"aggressive-resize", "on"},
+	} {
+		if value, ok := s.OptionOverrides[option.key]; ok {
+			option.value = value
+		}
+		if len(args) > 0 {
+			args = append(args, ";")
+		}
+		// Like Start, apply Deck's defaults/configuration, but preserve any
+		// local option a user's after-new-window hook explicitly installed.
+		args = append(args, "set-window-option", "-oq", "-t", windowID, option.key, option.value)
+	}
+	// Creation succeeded. As in Start, option configuration is best effort;
+	// an invalid override must not report failure and invite a duplicate tab.
+	if err := s.runBoundedMutation(args...); err != nil {
+		statusLog.Warn("shell_window_options_failed", slog.String("window", windowID), slog.String("error", err.Error()))
+	}
+	return nil
 }
 
 // ListAllSessions returns all Agent Deck tmux sessions

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -230,18 +230,21 @@ terminal-features = "*:hyperlinks:extkeys"
 
 ### One tmux Window Stuck at 80x24 While Its Siblings Are Full Width
 
-`window-size` is a tmux **window** option, and agent-deck sets its
-`window-size largest` default with a *session* target at session start — which
-lands on the window that exists at that moment. A window created later in the
-same session (by the agent, or by hand with `prefix c`) keeps tmux's global
-default, `latest`, so it is sized by whichever client most recently sent input
-instead of by the largest attached client. With a mix of client sizes that shows
-up as one window clipped to 80x24 while its siblings are full width, and the
-resize cycle bakes wrong wrap points into scrollback that replay as corruption
-later.
+`window-size` is a tmux **window** option. Agent Deck applies `largest` and
+`aggressive-resize on` to the initial session window and windows created by
+**Open Shell Here** in window mode. Explicit `[tmux.options]` values replace
+those defaults. For a new shell window, a local option installed by your
+`after-new-window` hook takes precedence.
 
-Until agent-deck propagates the policy to later windows, set the default for
-every window yourself:
+Windows created outside that Deck action, including `prefix c` or an agent's
+own `tmux new-window`, still inherit tmux's global window defaults. If that
+default is `latest`, windows with different active clients can have different
+sizes. This policy difference does not by itself establish that a size-less
+control client caused a collapse to 80x24; capture window dimensions and client
+flags when diagnosing that symptom.
+
+To choose `largest` for all newly created windows, including native tmux
+windows, set your own global default:
 
 ```conf
 # ~/.tmux.conf


### PR DESCRIPTION
## What problem does this solve?

Open Shell Here in window mode loses the managed session's sizing policy: the initial window has `largest/on`, while the new shell window inherits `latest/off`. Explicit sizing overrides are also lost. This addresses the Deck-created-window portion of #2061, reported by @rafi-rr (Rafi Rainshtein).

## Why this change

Configure the exact window ID returned by `new-window`, using the same two sizing defaults and explicit option values as session creation. `set-window-option -oq` preserves local options installed by a user's hook while allowing the next option to run. Hook output or a changed active window cannot redirect configuration. Actual creation errors remain errors; optional configuration failures are logged after successful creation.

## User impact

Deck-created shell windows retain their intended policy. Global defaults and existing windows remain untouched. Native `prefix c` and agent-created windows retain the documented user-managed global-default workaround. The reporter's tmux 3.7a/macOS height-collapse observation remains tracked in #2061.

## Evidence

- Original source `bf6d9e12`: real Start-to-NewShellWindow baseline red demonstrated default and explicit-override loss. Independent source/code-simplifier reviews accepted the repair. The standard contributor gate passed **16 PASS, 0 FAIL, 0 WARN**, including vet, build and the full affected tmux package: **1122 PASS, 0 FAIL, 44 declared SKIP**. Counts include test/subtest parents.
- Tested current-main composition `b64c84a8`, tree `6b5270253c4307fb32e5fe75126383aca834b249`: all **15 window/options/hooks/workdir/geometry controls** passed in 1.201s. Separately, all **five mandatory static/runtime isolation checks**, including both bootstrap children, passed in 21.616s. Every required check has actual RUN/PASS, zero failures/skips. Non-race, Go `-p 1`, GOMAXPROCS=4, Docker init/four CPUs/DAC_OVERRIDE dropped, private HOME/XDG/short TMPDIR; tmux 3.3a and Go 1.25.14.
- Published source `aae99e9e2d59ee7b3fdd474d2e186fac691ee8b3`, tree `0dbda1badfda36613c00aa50c5dac99e4dfb2f43`, incorporates actual main `778a26bb`. The incoming help/registry changes are disjoint; all three repair blobs match the tested source and every other blob matches main. This last composition received source-only verification. Final-head hosted CI is pending. Earlier runtime evidence retains its original commit attribution.
- Ten measured shell-window creations had candidate/baseline medians of 11.26ms/6.24ms, reflecting one additional bounded tmux subprocess. These are bounded observations, not a general performance guarantee.

Original failing receipts remain preserved: the missing-TERM geometry fixture failed before native attachment; a hook-only override exposed `-o` aborting the batch and became green with `-oq`. An expanded `AGENTDECK_TEST_PROFILE=1` gate failed the unchanged `TestSession_SetsUpActivityMonitoring` on both candidate and baseline. The standard gate leaves that opt-in unset; its declared skip is included above. That legacy expectation remains a separate follow-up. The standard revert also had a separate baseline private-server startup failure in `TestTerminalFeatures_StaleAbsenceOnReplacementServer`, alongside the intended sizing failures. The candidate passed it, and incoming main retains its later fixture correction. Independent original red supplies regression proof without relying on that unrelated failure.

Linux/tmux 3.3a retained 200x54 with a sized native client plus Deck's size-less observer, then with only the observer, under both policies. The macOS/tmux 3.7a resize cycle remains unreproduced. The 93 original immutable receipts and the separate current-main packet were supplied to the maintainer. No broad runtime suite was repeated for the disjoint help merge.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted
- [x] AI-authored

**Model(s), if AI helped:** gpt-6-astra for implementation and separate independent source/code-simplifier reviews. Commits retain Ashesh Goplani's authorship; the issue report is credited above.

## What actually bothered you

The owner requested: "design minimal window-option propagation fix only if actual Deck behavior reproduces."

## Checklist

- [x] Targeted diff: one problem, three files
- [x] Meaningful real-tmux regression tests and independent review
- [x] Sandboxed affected-package gate and bounded current-main controls pass at the commits stated above
- [x] CHANGELOG.md untouched
- [x] AI assistance and remaining evidence limits disclosed
- [x] Allow edits from maintainers

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shell windows now apply configured window-size and aggressive-resize policies to the exact window being created.
  - Explicit option overrides are honored while preserving existing user settings.

- **Bug Fixes**
  - Improved window creation behavior helps maintain stable session geometry across native and control-mode clients.
  - Option-application issues no longer prevent an otherwise successful shell window from being created.

- **Tests**
  - Added coverage for sizing policies, overrides, user hooks, invalid settings, creation failures, and repeated window creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->