### PR TITLE
fix(cli): expose stored account slots in list and show

### DIFF
--- a/cmd/agent-deck/account_visibility_help_test.go
+++ b/cmd/agent-deck/account_visibility_help_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCLIAccountHelpExplainsStoredSlot(t *testing.T) {
+	for _, tc := range []struct {
+		name, field string
+		args        []string
+	}{
+		{"list", "ACCOUNT", []string{"list"}},
+		{"all_profiles", "ACCOUNT", []string{"list", "--all"}},
+		{"show", "Account:", []string{"session", "show"}},
+	} {
+		for _, flag := range []string{"--help", "-h"} {
+			t.Run(tc.name+"/"+flag, func(t *testing.T) {
+				home := t.TempDir()
+				before := snapshotTree(t, home)
+				args := append(append([]string{}, tc.args...), flag)
+				stdout, stderr, code := runAgentDeck(t, home, args...)
+				out := stdout + stderr
+				if code != 0 {
+					t.Fatalf("help exit %d: %s", code, out)
+				}
+				for _, want := range []string{tc.field, "quoted stored account slot", "not a resolved account or login identity", `JSON always includes the raw "account" string`, `including "" when no slot is stored`} {
+					if !strings.Contains(out, want) {
+						t.Errorf("help omits %q: %s", want, out)
+					}
+				}
+				if after := snapshotTree(t, home); !reflect.DeepEqual(before, after) {
+					t.Errorf("help changed HOME: before=%v after=%v", before, after)
+				}
+			})
+		}
+	}
+}

--- a/cmd/agent-deck/account_visibility_test.go
+++ b/cmd/agent-deck/account_visibility_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+ "context"
+ "encoding/json"
+ "fmt"
+ "os/exec"
+ "path/filepath"
+ "strconv"
+ "strings"
+ "testing"
+ "time"
+
+ "github.com/asheshgoplani/agent-deck/internal/statedb"
+ "github.com/stretchr/testify/require"
+)
+
+// Exercise the public CLI with persisted metadata, including legacy slots that
+// need not resolve to a configured account. No provider is launched.
+func TestCLIStoredAccountVisibility(t *testing.T) {
+ home := t.TempDir()
+ run := func(t *testing.T, args ...string) string {
+  t.Helper()
+  ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+  defer cancel()
+  cmd := exec.CommandContext(ctx, channelsCLIBinary(t), args...)
+  for _, kv := range cliEnvForIssue1031(home) {
+   if !strings.HasPrefix(kv, "XDG_") { cmd.Env = append(cmd.Env, kv) }
+  }
+  cmd.Env = append(cmd.Env, "XDG_CONFIG_HOME="+filepath.Join(home,".config"),
+   "XDG_DATA_HOME="+filepath.Join(home,".local","share"),
+   "XDG_CACHE_HOME="+filepath.Join(home,".cache"), "AGENTDECK_ACCOUNT=fake-env-slot")
+  started := time.Now()
+  out, err := cmd.CombinedOutput()
+  t.Logf("CLI %v elapsed=%s", args, time.Since(started))
+  require.NoError(t, err, "%v: %s", args, out)
+  return string(out)
+ }
+ slots := []string{"", "personal", "work", "legacy-unknown", "  \u65e5\u672c e\u0301 \U0001f680  ", "quote\"slash\\", "\x1b[31m\a\r\n\u0085\u202e", `literal\n`}
+ profiles := []string{"ch_support_test", "other-slots"}
+ type fixture struct { id, profile, account string }
+ var fixtures []fixture
+ for p, profile := range profiles {
+  run(t, "-p", profile, "list", "--json")
+  db, err := statedb.Open(filepath.Join(home,".local","share","agent-deck","profiles",profile,"state.db"))
+  require.NoError(t, err)
+  for i, account := range slots {
+   id := fmt.Sprintf("slot%d%03d", p, i)
+   require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID:id, Title:"same-title", ProjectPath:home, Tool:"shell", Status:"idle", Account:account, CreatedAt:time.Now()}))
+   fixtures = append(fixtures, fixture{id, profile, account})
+  }
+  require.NoError(t, db.Close())
+ }
+ checkJSON := func(t *testing.T, row map[string]any, f fixture) {
+  t.Helper()
+  value, present := row["account"]
+  require.True(t, present, "%s: missing account key (empty must be explicit)", f.id)
+  require.IsType(t, "", value)
+  require.Equal(t, f.account, value, "%s raw stored account", f.id)
+  require.Equal(t, f.profile, row["profile"])
+ }
+ for _, all := range []bool{false,true} {
+  name := "single"
+  if all { name = "all" }
+  t.Run(name+"_json", func(t *testing.T) {
+   for _, profile := range profiles {
+    args := []string{"-p",profile,"list","--json"}
+    if all { args = append(args,"--all") }
+    var rows []map[string]any
+    require.NoError(t,json.Unmarshal([]byte(run(t,args...)),&rows))
+    byID := map[string]map[string]any{}
+    for _, row := range rows { byID[row["id"].(string)] = row }
+    count := 0
+    for _, f := range fixtures {
+     if all || f.profile == profile { count++; checkJSON(t,byID[f.id],f) }
+    }
+    require.Len(t, rows, count)
+    if all { break }
+   }
+  })
+  t.Run(name+"_human", func(t *testing.T) {
+   for _, profile := range profiles {
+    args := []string{"-p",profile,"list"}
+    if all { args = append(args,"--all") }
+    out := run(t,args...)
+    require.Contains(t,out,"ACCOUNT")
+    for _, f := range fixtures {
+     if !all && f.profile != profile { continue }
+     matched := 0
+     for _, line := range strings.Split(out,"\n") {
+      if strings.Contains(line, f.id) {
+       matched++
+       require.True(t,strings.HasSuffix(line," "+strconv.Quote(f.account)),"unsafe or wrong account row: %q",line)
+      }
+     }
+     require.Equal(t,1,matched,"one logical row for %s",f.id)
+    }
+    require.NotContains(t,out,"\x1b[31m")
+    require.NotContains(t,out,"\a")
+    require.NotContains(t,out,"\r")
+    if all { break }
+   }
+  })
+ }
+ t.Run("show_json",func(t *testing.T) {
+  for _, f := range fixtures {
+   var row map[string]any
+   require.NoError(t,json.Unmarshal([]byte(run(t,"-p",f.profile,"session","show",f.id,"--json")),&row))
+   checkJSON(t,row,f)
+  }
+ })
+ t.Run("show_human",func(t *testing.T) {
+  for _, f := range fixtures {
+   out := run(t,"-p",f.profile,"session","show",f.id)
+   found := 0
+   for _, line := range strings.Split(out,"\n") {
+    if strings.HasPrefix(line,"Account:") { found++; require.Equal(t,strconv.Quote(f.account),strings.TrimSpace(strings.TrimPrefix(line,"Account:"))) }
+   }
+   require.Equal(t,1,found,"missing Account line: %s",out)
+  }
+ })
+ t.Run("metadata_retained",func(t *testing.T) {
+  for _, profile := range profiles {
+   db, err := statedb.Open(filepath.Join(home,".local","share","agent-deck","profiles",profile,"state.db"))
+   require.NoError(t,err)
+   rows, err := db.LoadInstances()
+   require.NoError(t,err)
+   require.NoError(t,db.Close())
+   got := map[string]string{}
+   for _, row := range rows { got[row.ID] = row.Account }
+   require.Len(t,got,len(slots))
+   for _, f := range fixtures { if f.profile == profile { require.Equal(t,f.account,got[f.id]) } }
+  }
+ })
+}

--- a/cmd/agent-deck/account_visibility_test.go
+++ b/cmd/agent-deck/account_visibility_test.go
@@ -1,135 +1,163 @@
 package main
 
 import (
- "context"
- "encoding/json"
- "fmt"
- "os/exec"
- "path/filepath"
- "strconv"
- "strings"
- "testing"
- "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
 
- "github.com/asheshgoplani/agent-deck/internal/statedb"
- "github.com/stretchr/testify/require"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
 )
 
 // Exercise the public CLI with persisted metadata, including legacy slots that
 // need not resolve to a configured account. No provider is launched.
 func TestCLIStoredAccountVisibility(t *testing.T) {
- home := t.TempDir()
- run := func(t *testing.T, args ...string) string {
-  t.Helper()
-  ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-  defer cancel()
-  cmd := exec.CommandContext(ctx, channelsCLIBinary(t), args...)
-  for _, kv := range cliEnvForIssue1031(home) {
-   if !strings.HasPrefix(kv, "XDG_") { cmd.Env = append(cmd.Env, kv) }
-  }
-  cmd.Env = append(cmd.Env, "XDG_CONFIG_HOME="+filepath.Join(home,".config"),
-   "XDG_DATA_HOME="+filepath.Join(home,".local","share"),
-   "XDG_CACHE_HOME="+filepath.Join(home,".cache"), "AGENTDECK_ACCOUNT=fake-env-slot")
-  started := time.Now()
-  out, err := cmd.CombinedOutput()
-  t.Logf("CLI %v elapsed=%s", args, time.Since(started))
-  require.NoError(t, err, "%v: %s", args, out)
-  return string(out)
- }
- slots := []string{"", "personal", "work", "legacy-unknown", "  \u65e5\u672c e\u0301 \U0001f680  ", "quote\"slash\\", "\x1b[31m\a\r\n\u0085\u202e", `literal\n`}
- profiles := []string{"ch_support_test", "other-slots"}
- type fixture struct { id, profile, account string }
- var fixtures []fixture
- for p, profile := range profiles {
-  run(t, "-p", profile, "list", "--json")
-  db, err := statedb.Open(filepath.Join(home,".local","share","agent-deck","profiles",profile,"state.db"))
-  require.NoError(t, err)
-  for i, account := range slots {
-   id := fmt.Sprintf("slot%d%03d", p, i)
-   require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID:id, Title:"same-title", ProjectPath:home, Tool:"shell", Status:"idle", Account:account, CreatedAt:time.Now()}))
-   fixtures = append(fixtures, fixture{id, profile, account})
-  }
-  require.NoError(t, db.Close())
- }
- checkJSON := func(t *testing.T, row map[string]any, f fixture) {
-  t.Helper()
-  value, present := row["account"]
-  require.True(t, present, "%s: missing account key (empty must be explicit)", f.id)
-  require.IsType(t, "", value)
-  require.Equal(t, f.account, value, "%s raw stored account", f.id)
-  require.Equal(t, f.profile, row["profile"])
- }
- for _, all := range []bool{false,true} {
-  name := "single"
-  if all { name = "all" }
-  t.Run(name+"_json", func(t *testing.T) {
-   for _, profile := range profiles {
-    args := []string{"-p",profile,"list","--json"}
-    if all { args = append(args,"--all") }
-    var rows []map[string]any
-    require.NoError(t,json.Unmarshal([]byte(run(t,args...)),&rows))
-    byID := map[string]map[string]any{}
-    for _, row := range rows { byID[row["id"].(string)] = row }
-    count := 0
-    for _, f := range fixtures {
-     if all || f.profile == profile { count++; checkJSON(t,byID[f.id],f) }
-    }
-    require.Len(t, rows, count)
-    if all { break }
-   }
-  })
-  t.Run(name+"_human", func(t *testing.T) {
-   for _, profile := range profiles {
-    args := []string{"-p",profile,"list"}
-    if all { args = append(args,"--all") }
-    out := run(t,args...)
-    require.Contains(t,out,"ACCOUNT")
-    for _, f := range fixtures {
-     if !all && f.profile != profile { continue }
-     matched := 0
-     for _, line := range strings.Split(out,"\n") {
-      if strings.Contains(line, f.id) {
-       matched++
-       require.True(t,strings.HasSuffix(line," "+strconv.Quote(f.account)),"unsafe or wrong account row: %q",line)
-      }
-     }
-     require.Equal(t,1,matched,"one logical row for %s",f.id)
-    }
-    require.NotContains(t,out,"\x1b[31m")
-    require.NotContains(t,out,"\a")
-    require.NotContains(t,out,"\r")
-    if all { break }
-   }
-  })
- }
- t.Run("show_json",func(t *testing.T) {
-  for _, f := range fixtures {
-   var row map[string]any
-   require.NoError(t,json.Unmarshal([]byte(run(t,"-p",f.profile,"session","show",f.id,"--json")),&row))
-   checkJSON(t,row,f)
-  }
- })
- t.Run("show_human",func(t *testing.T) {
-  for _, f := range fixtures {
-   out := run(t,"-p",f.profile,"session","show",f.id)
-   found := 0
-   for _, line := range strings.Split(out,"\n") {
-    if strings.HasPrefix(line,"Account:") { found++; require.Equal(t,strconv.Quote(f.account),strings.TrimSpace(strings.TrimPrefix(line,"Account:"))) }
-   }
-   require.Equal(t,1,found,"missing Account line: %s",out)
-  }
- })
- t.Run("metadata_retained",func(t *testing.T) {
-  for _, profile := range profiles {
-   db, err := statedb.Open(filepath.Join(home,".local","share","agent-deck","profiles",profile,"state.db"))
-   require.NoError(t,err)
-   rows, err := db.LoadInstances()
-   require.NoError(t,err)
-   require.NoError(t,db.Close())
-   got := map[string]string{}
-   for _, row := range rows { got[row.ID] = row.Account }
-   require.Len(t,got,len(slots))
-   for _, f := range fixtures { if f.profile == profile { require.Equal(t,f.account,got[f.id]) } }
-  }
- })
+	home := t.TempDir()
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, channelsCLIBinary(t), args...)
+		for _, kv := range cliEnvForIssue1031(home) {
+			if !strings.HasPrefix(kv, "XDG_") {
+				cmd.Env = append(cmd.Env, kv)
+			}
+		}
+		cmd.Env = append(cmd.Env, "XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+			"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+			"XDG_CACHE_HOME="+filepath.Join(home, ".cache"), "AGENTDECK_ACCOUNT=fake-env-slot")
+		started := time.Now()
+		out, err := cmd.CombinedOutput()
+		t.Logf("CLI %v elapsed=%s", args, time.Since(started))
+		require.NoError(t, err, "%v: %s", args, out)
+		return string(out)
+	}
+	slots := []string{"", "personal", "work", "legacy-unknown", "  \u65e5\u672c e\u0301 \U0001f680  ", "quote\"slash\\", "\x1b[31m\a\r\n\u0085\u202e", `literal\n`}
+	profiles := []string{"ch_support_test", "other-slots"}
+	type fixture struct{ id, profile, account string }
+	var fixtures []fixture
+	for p, profile := range profiles {
+		run(t, "-p", profile, "list", "--json")
+		db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", profile, "state.db"))
+		require.NoError(t, err)
+		for i, account := range slots {
+			id := fmt.Sprintf("slot%d%03d", p, i)
+			require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: id, Title: "same-title", ProjectPath: home, Tool: "shell", Status: "idle", Account: account, CreatedAt: time.Now()}))
+			fixtures = append(fixtures, fixture{id, profile, account})
+		}
+		require.NoError(t, db.Close())
+	}
+	checkJSON := func(t *testing.T, row map[string]any, f fixture) {
+		t.Helper()
+		value, present := row["account"]
+		require.True(t, present, "%s: missing account key (empty must be explicit)", f.id)
+		require.IsType(t, "", value)
+		require.Equal(t, f.account, value, "%s raw stored account", f.id)
+		require.Equal(t, f.profile, row["profile"])
+	}
+	for _, all := range []bool{false, true} {
+		name := "single"
+		if all {
+			name = "all"
+		}
+		t.Run(name+"_json", func(t *testing.T) {
+			for _, profile := range profiles {
+				args := []string{"-p", profile, "list", "--json"}
+				if all {
+					args = append(args, "--all")
+				}
+				var rows []map[string]any
+				require.NoError(t, json.Unmarshal([]byte(run(t, args...)), &rows))
+				byID := map[string]map[string]any{}
+				for _, row := range rows {
+					byID[row["id"].(string)] = row
+				}
+				count := 0
+				for _, f := range fixtures {
+					if all || f.profile == profile {
+						count++
+						checkJSON(t, byID[f.id], f)
+					}
+				}
+				require.Len(t, rows, count)
+				if all {
+					break
+				}
+			}
+		})
+		t.Run(name+"_human", func(t *testing.T) {
+			for _, profile := range profiles {
+				args := []string{"-p", profile, "list"}
+				if all {
+					args = append(args, "--all")
+				}
+				out := run(t, args...)
+				require.Contains(t, out, "ACCOUNT")
+				for _, f := range fixtures {
+					if !all && f.profile != profile {
+						continue
+					}
+					matched := 0
+					for _, line := range strings.Split(out, "\n") {
+						if strings.Contains(line, f.id) {
+							matched++
+							require.True(t, strings.HasSuffix(line, " "+strconv.Quote(f.account)), "unsafe or wrong account row: %q", line)
+						}
+					}
+					require.Equal(t, 1, matched, "one logical row for %s", f.id)
+				}
+				require.NotContains(t, out, "\x1b[31m")
+				require.NotContains(t, out, "\a")
+				require.NotContains(t, out, "\r")
+				if all {
+					break
+				}
+			}
+		})
+	}
+	t.Run("show_json", func(t *testing.T) {
+		for _, f := range fixtures {
+			var row map[string]any
+			require.NoError(t, json.Unmarshal([]byte(run(t, "-p", f.profile, "session", "show", f.id, "--json")), &row))
+			checkJSON(t, row, f)
+		}
+	})
+	t.Run("show_human", func(t *testing.T) {
+		for _, f := range fixtures {
+			out := run(t, "-p", f.profile, "session", "show", f.id)
+			found := 0
+			for _, line := range strings.Split(out, "\n") {
+				if strings.HasPrefix(line, "Account:") {
+					found++
+					require.Equal(t, strconv.Quote(f.account), strings.TrimSpace(strings.TrimPrefix(line, "Account:")))
+				}
+			}
+			require.Equal(t, 1, found, "missing Account line: %s", out)
+		}
+	})
+	t.Run("metadata_retained", func(t *testing.T) {
+		for _, profile := range profiles {
+			db, err := statedb.Open(filepath.Join(home, ".local", "share", "agent-deck", "profiles", profile, "state.db"))
+			require.NoError(t, err)
+			rows, err := db.LoadInstances()
+			require.NoError(t, err)
+			require.NoError(t, db.Close())
+			got := map[string]string{}
+			for _, row := range rows {
+				got[row.ID] = row.Account
+			}
+			require.Len(t, got, len(slots))
+			for _, f := range fixtures {
+				if f.profile == profile {
+					require.Equal(t, f.account, got[f.id])
+				}
+			}
+		}
+	})
 }

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2282,6 +2282,8 @@ func handleList(profile string, args []string) {
 		fmt.Println("Usage: agent-deck list [options]")
 		fmt.Println()
 		fmt.Println("List all sessions.")
+		fmt.Println("ACCOUNT shows the quoted stored account slot, not a resolved account or login identity.")
+		fmt.Println(`JSON always includes the raw "account" string, including "" when no slot is stored.`)
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -2328,6 +2329,7 @@ func handleList(profile string, args []string) {
 			Path              string    `json:"path"`
 			Group             string    `json:"group"`
 			Tool              string    `json:"tool"`
+			Account           string    `json:"account"`
 			Command           string    `json:"command,omitempty"`
 			ModelID           string    `json:"model_id,omitempty"`
 			Model             string    `json:"model,omitempty"`
@@ -2360,6 +2362,7 @@ func handleList(profile string, args []string) {
 				Path:              inst.ProjectPath,
 				Group:             inst.GroupPath,
 				Tool:              inst.Tool,
+				Account:           inst.Account,
 				Command:           inst.Command,
 				Status:            StatusString(inst.Status),
 				Substate:          string(inst.Substate()),
@@ -2394,7 +2397,7 @@ func handleList(profile string, args []string) {
 
 	// Table output
 	fmt.Printf("Profile: %s\n\n", storage.Profile())
-	fmt.Printf("%-*s %-*s %-*s %s\n", tableColTitle, "TITLE", tableColGroup, "GROUP", tableColPath, "PATH", "ID")
+	fmt.Printf("%-*s %-*s %-*s %-*s %s\n", tableColTitle, "TITLE", tableColGroup, "GROUP", tableColPath, "PATH", tableColIDDisplay, "ID", "ACCOUNT")
 	fmt.Println(strings.Repeat("-", tableColTitle+tableColGroup+tableColPath+tableColIDDisplay+5))
 	for _, inst := range instances {
 		title := truncate(inst.Title, tableColTitle)
@@ -2405,7 +2408,7 @@ func handleList(profile string, args []string) {
 		if len(idDisplay) > tableColIDDisplay {
 			idDisplay = idDisplay[:tableColIDDisplay]
 		}
-		fmt.Printf("%-*s %-*s %-*s %s\n", tableColTitle, title, tableColGroup, group, tableColPath, path, idDisplay)
+		fmt.Printf("%-*s %-*s %-*s %-*s %s\n", tableColTitle, title, tableColGroup, group, tableColPath, path, tableColIDDisplay, idDisplay, strconv.Quote(inst.Account))
 	}
 	fmt.Printf("\nTotal: %d sessions\n", len(instances))
 
@@ -2435,6 +2438,7 @@ func handleListAllProfiles(jsonOutput bool) {
 			Path              string    `json:"path"`
 			Group             string    `json:"group"`
 			Tool              string    `json:"tool"`
+			Account           string    `json:"account"`
 			Command           string    `json:"command,omitempty"`
 			Profile           string    `json:"profile"`
 			CreatedAt         time.Time `json:"created_at"`
@@ -2461,6 +2465,7 @@ func handleListAllProfiles(jsonOutput bool) {
 					Path:              inst.ProjectPath,
 					Group:             inst.GroupPath,
 					Tool:              inst.Tool,
+					Account:           inst.Account,
 					Command:           inst.Command,
 					Profile:           profileName,
 					CreatedAt:         inst.CreatedAt,
@@ -2496,7 +2501,7 @@ func handleListAllProfiles(jsonOutput bool) {
 		}
 
 		fmt.Printf("\n═══ Profile: %s ═══\n\n", profileName)
-		fmt.Printf("%-*s %-*s %-*s %s\n", tableColTitle, "TITLE", tableColGroup, "GROUP", tableColPath, "PATH", "ID")
+		fmt.Printf("%-*s %-*s %-*s %-*s %s\n", tableColTitle, "TITLE", tableColGroup, "GROUP", tableColPath, "PATH", tableColIDDisplay, "ID", "ACCOUNT")
 		fmt.Println(strings.Repeat("-", tableColTitle+tableColGroup+tableColPath+tableColIDDisplay+5))
 
 		for _, inst := range instances {
@@ -2507,7 +2512,7 @@ func handleListAllProfiles(jsonOutput bool) {
 			if len(idDisplay) > tableColIDDisplay {
 				idDisplay = idDisplay[:tableColIDDisplay]
 			}
-			fmt.Printf("%-*s %-*s %-*s %s\n", tableColTitle, title, tableColGroup, group, tableColPath, path, idDisplay)
+			fmt.Printf("%-*s %-*s %-*s %-*s %s\n", tableColTitle, title, tableColGroup, group, tableColPath, path, tableColIDDisplay, idDisplay, strconv.Quote(inst.Account))
 		}
 		fmt.Printf("(%d sessions)\n", len(instances))
 		totalSessions += len(instances)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1575,6 +1575,8 @@ func handleSessionShow(profile string, args []string) {
 		fmt.Println("Usage: agent-deck session show [id|title] [options]")
 		fmt.Println()
 		fmt.Println("Show session details. If no ID is provided, auto-detects current session.")
+		fmt.Println("Account: shows the quoted stored account slot, not a resolved account or login identity.")
+		fmt.Println(`JSON always includes the raw "account" string, including "" when no slot is stored.`)
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1650,6 +1651,7 @@ func handleSessionShow(profile string, args []string) {
 		"no_transition_notify": inst.NoTransitionNotify,
 		"title_locked":         inst.TitleLocked,
 		"tool":                 inst.Tool,
+		"account":              inst.Account,
 		"created_at":           inst.CreatedAt.Format(time.RFC3339),
 	}
 	// Honest Status v2: additive substate refinement (omit when none so the
@@ -1754,6 +1756,7 @@ func handleSessionShow(profile string, args []string) {
 	}
 
 	sb.WriteString(fmt.Sprintf("Tool:    %s\n", inst.Tool))
+	sb.WriteString(fmt.Sprintf("Account: %s\n", strconv.Quote(inst.Account)))
 	if modelInfo.ModelID != "" {
 		if modelInfo.Model != "" {
 			sb.WriteString(fmt.Sprintf("Model:   %s\n", modelInfo.Model))

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -105,6 +105,8 @@ agent-deck list [--json] [--all]
 agent-deck ls  # Alias
 ```
 
+Both JSON forms always include `account`: the exact stored per-session slot, including an empty string when no slot is explicitly stored. Human tables show the slot in a quoted `ACCOUNT` column, escaping controls. This is stored metadata, not a resolved account or login identity.
+
 ### remove - Remove session
 
 ```bash
@@ -230,6 +232,7 @@ Auto-detects current session if no ID provided.
 
 **JSON output includes:**
 - Session details (id, title, status, path, group, tool)
+- `account`: the exact stored slot, always present including an empty string. Human output shows a quoted, control-escaped `Account:` field; neither form resolves login identity.
 - Claude/Gemini session ID
 - Attached MCPs (local, global, project)
 - tmux session name


### PR DESCRIPTION
## What problem does this solve?

Session list and show omit the stored account slot, so users cannot distinguish an explicitly selected slot from an empty per-session value. Both list JSON emitters and show now always include the raw stored `account` string, including `""`.

## Why this change

Copy `Instance.Account` directly into the three explicit JSON outputs. Quote human values with `strconv.Quote` so control characters cannot inject terminal actions or additional rows. No account resolution or credential access is added.

## User impact

`list` and `list --all` gain an `ACCOUNT` column; human `session show` gains an `Account:` field. Their command help now documents stored-slot semantics, quoted human values and raw empty JSON values, addressing review comment 3940631533. JSON retains exact stored Unicode, whitespace and control values after decoding. Empty means no explicit stored session slot, not a resolved account or login identity. Unknown stored slots remain visible. Long quoted human values may wrap.

This change does not add TUI account display or complete the remaining SSH point3 acceptance. No issue closure is requested.

## Evidence

Exact candidate `19c6af2` preserves the accepted output change `59c45f6`, its test-only baseline `d64a206`, and the help-only baseline `10c7433` in its ancestry. The original output change is +12/-4 across two CLI files; the followup adds four help lines and 39 test lines. Source-only comparison with main `169699` found the new recency serialization independent of the account fields; the composition has no merge conflicts. This comparison is not a new runtime test.

The actual baseline public CLI run failed all six account output surfaces because their key or human field was absent. The metadata-retention control passed; no tests skipped. The corrected output run at `59c45f6` passed all 12 test/subtest nodes, plus the package, with zero failures or skips. Coverage includes single/all-profile list JSON, show JSON, all human forms, raw empty and unknown slots, Unicode/controls, conflicting fake account environment, retained metadata, and existing list-parent/show-wrapper regressions.

Verification ran in an isolated Linux Docker environment with sandbox HOME/XDG and short TMPDIR, four CPUs, `GOMAXPROCS=4`, and package concurrency limited to one. Package vet and gofmt passed. All 2,219 tracked source hashes matched before and after each run. Independent source, simplifier and evidence review accepted the output change.

For the help-only followup, six actual CLI cases (list, all-profile list and show, each with `--help` and `-h`) failed only for absent text on the preserved baseline. The same six cases plus their parent passed at `19c6af2`, with zero failures or skips and unchanged sandbox HOME. Gofmt passed and all 2,220 tracked hashes remained unchanged. Independent source, simplifier and evidence review accepted that exact followup. The original 12 output checks and full suite were not repeated for these four help lines. These are distinct focused nonrace runs; hosted full CI for the updated head is pending.

Observed baseline/candidate timings from those runs: populated single-profile JSON list 26.3/25.8 ms; all-profile JSON 25.8/23.6 ms; single-profile human list 790.5/672.3 ms; all-profile human 25.1/18.6 ms. These are individual observations, not statistical performance claims.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-6-astra

## What actually bothered you

> Include both list JSON emitters and show, raw account key always present including empty, terminal-safe human field, no identity inference or credential access.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: full repository suite awaits hosted CI
- [x] If this touches a hot path: before/after timing evidence included
- [x] CHANGELOG.md untouched
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [ ] "Allow edits from maintainers": not applicable to this same-repository branch; GitHub exposes this setting only for cross-repository PRs

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session listings now display each session’s stored account slot.
  - Account details are available in JSON and human-readable output for single-profile and all-profile views.
  - Account values are safely quoted and escaped, including special and non-ASCII characters.
  - `session show` now includes the stored account in both output formats.
  - Help text documents account fields, including empty values and the distinction between stored slots and login identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->