### PR TITLE
fix(ui): show stored account slots in session rows

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -936,6 +936,15 @@ func (inst *Instance) GetAccountThreadSafe() string {
 	return inst.Account
 }
 
+// setAccountThreadSafe exchanges the stored slot under the snapshot reader's lock.
+func (inst *Instance) setAccountThreadSafe(account string) string {
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	old := inst.Account
+	inst.Account = account
+	return old
+}
+
 // GetTitleThreadSafe returns the session title with read-lock protection.
 // Use this when reading Title from a goroutine concurrent with title syncs
 // (SetField, ReconcileTitleFromClaude, pending-title reapplication) — those

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -929,6 +929,13 @@ func (inst *Instance) GetToolThreadSafe() string {
 	return t
 }
 
+// GetAccountThreadSafe returns the stored slot, not a resolved login identity.
+func (inst *Instance) GetAccountThreadSafe() string {
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.Account
+}
+
 // GetTitleThreadSafe returns the session title with read-lock protection.
 // Use this when reading Title from a goroutine concurrent with title syncs
 // (SetField, ReconcileTitleFromClaude, pending-title reapplication) — those

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -434,14 +434,13 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 	case FieldAccount:
 		candidate := strings.TrimSpace(value)
 		if err := ValidateAccountSlot(candidate, inst.accountTool()); err != nil {
-			return inst.Account, nil, &MutationError{Field: field, Msg: err.Error()}
+			return inst.GetAccountThreadSafe(), nil, &MutationError{Field: field, Msg: err.Error()}
 		}
 		// #924 per-session named account slot, validated before assignment.
 		// Empty string clears the override (back to conductor/group/env).
 		// Restart required (see RestartPolicyFor) — the in-flight
 		// conversation is lost, that's the documented Option 1 tradeoff.
-		oldValue = inst.Account
-		inst.Account = candidate
+		oldValue = inst.setAccountThreadSafe(candidate)
 
 	case FieldIdleTimeout:
 		// #1143: parses a Go duration like "30m"; 0 (or "0", "") disables.

--- a/internal/ui/account_slot_label.go
+++ b/internal/ui/account_slot_label.go
@@ -10,24 +10,45 @@ func storedAccountLabel(account string) string {
 	return strconv.Quote(account)
 }
 
+const storedAccountPrefix = " [account:"
+
+// Immutable presentation travels with the raw slot in the render snapshot.
+// Width-independent quoting is shared across rows with the same stored slot.
+type accountPresentation struct {
+	label  string
+	badge  string
+	width  int
+	quoted bool
+}
+
+func newAccountPresentation(account string) accountPresentation {
+	label := storedAccountLabel(account)
+	return accountPresentation{
+		label:  label,
+		badge:  storedAccountPrefix + label + "]",
+		width:  len(storedAccountPrefix) + cellWidth(label) + 1,
+		quoted: account != "",
+	}
+}
+
 // Quote before styling/truncation so terminal controls cannot become commands.
 // Keep the delimiters visible even when a long account needs an ellipsis.
-func storedAccountBadge(account string, budget int) string {
-	const prefix = " [account:"
-	label := storedAccountLabel(account)
-	available := budget - cellWidth(prefix) - 1
+func (p accountPresentation) fit(budget int) (string, int) {
+	if p.width <= budget {
+		return p.badge, p.width
+	}
+	available := budget - len(storedAccountPrefix) - 1
 	if available < 1 {
-		return ""
+		return "", 0
 	}
-	if cellWidth(label) > available {
-		if account != "" {
-			if available < 3 {
-				return ""
-			}
-			label = "\"" + cellTruncate(label[1:len(label)-1], available-2, "…") + "\""
-		} else {
-			label = cellTruncate(label, available, "…")
+	label := p.label
+	if p.quoted {
+		if available < 3 {
+			return "", 0
 		}
+		label = "\"" + cellTruncate(label[1:len(label)-1], available-2, "…") + "\""
+	} else {
+		label = cellTruncate(label, available, "…")
 	}
-	return prefix + label + "]"
+	return storedAccountPrefix + label + "]", len(storedAccountPrefix) + cellWidth(label) + 1
 }

--- a/internal/ui/account_slot_label.go
+++ b/internal/ui/account_slot_label.go
@@ -1,0 +1,33 @@
+package ui
+
+import "strconv"
+
+// Empty metadata means no explicit slot, not a claim about the running login.
+func storedAccountLabel(account string) string {
+	if account == "" {
+		return "inherited"
+	}
+	return strconv.Quote(account)
+}
+
+// Quote before styling/truncation so terminal controls cannot become commands.
+// Keep the delimiters visible even when a long account needs an ellipsis.
+func storedAccountBadge(account string, budget int) string {
+	const prefix = " [account:"
+	label := storedAccountLabel(account)
+	available := budget - cellWidth(prefix) - 1
+	if available < 1 {
+		return ""
+	}
+	if cellWidth(label) > available {
+		if account != "" {
+			if available < 3 {
+				return ""
+			}
+			label = "\"" + cellTruncate(label[1:len(label)-1], available-2, "…") + "\""
+		} else {
+			label = cellTruncate(label, available, "…")
+		}
+	}
+	return prefix + label + "]"
+}

--- a/internal/ui/account_slot_race_test.go
+++ b/internal/ui/account_slot_race_test.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise the actual mutation entry point concurrently with the actual render
+// snapshot refresher. Empty is always a valid stored slot and needs no config.
+func TestStoredAccountConcurrentMutationSnapshot(t *testing.T) {
+	h := NewHome()
+	inst := &session.Instance{ID: "concurrent-slot", Title: "title", Tool: "shell", Status: session.StatusIdle, Account: "initial"}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	errs := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for n := 0; n < 2000; n++ {
+			if _, _, err := session.SetField(inst, session.FieldAccount, "", nil); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	close(start)
+	for n := 0; n < 2000; n++ {
+		h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	}
+	wg.Wait()
+	select {
+	case err := <-errs:
+		require.NoError(t, err)
+	default:
+	}
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	require.Equal(t, "", h.getSessionRenderState(inst).account)
+}

--- a/internal/ui/account_slot_remote_test.go
+++ b/internal/ui/account_slot_remote_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// RemoteSessionInfo does not transport Account. A local snapshot with the same
+// ID must not invent a remote slot or label unknown remote metadata inherited.
+func TestStoredAccountRemoteRowDoesNotInventSlot(t *testing.T) {
+	for _, width := range []int{40, 120} {
+		for _, selected := range []bool{false, true} {
+			h := NewHome()
+			h.width, h.height = width, 40
+			h.refreshSessionRenderSnapshot([]*session.Instance{{ID: "same-id", Title: "local", Tool: "shell", Account: "private-local-slot"}})
+			remote := session.RemoteSessionInfo{ID: "same-id", Title: "remote日本", Tool: "shell", Status: "idle", RemoteName: "dev"}
+			var b strings.Builder
+			h.renderRemoteSessionItem(&b, session.Item{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "dev"}, selected)
+			row := strings.TrimSuffix(b.String(), "\n")
+			require.Contains(t, row, "remote日本")
+			require.NotContains(t, row, "[account:")
+			require.NotContains(t, row, "private-local-slot")
+			require.NotContains(t, row, "inherited")
+			require.True(t, utf8.ValidString(row))
+			require.LessOrEqual(t, cellWidth(row), width)
+			require.Equal(t, 1, strings.Count(b.String(), "\n"))
+		}
+	}
+}

--- a/internal/ui/account_slot_render_test.go
+++ b/internal/ui/account_slot_render_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// These controls intentionally use only pre-existing rendering entry points.
+// They must reproduce missing stored-slot output on the unmodified baseline.
+func TestStoredAccountRenderBaseline(t *testing.T) {
+	slots := []string{"personal", "work", "", "inherited", " 日本 e\u0301 🚀 ", "quote\"slash\\", "\x1b]0;injected\a\r\n\u0085\u202e"}
+	for _, account := range slots {
+		t.Run(strconv.Quote(account), func(t *testing.T) {
+			inst := &session.Instance{ID: "account-render", Title: "same-title", Tool: "shell", Status: session.StatusIdle, Account: account}
+			label := strconv.Quote(account)
+			if account == "" {
+				label = "inherited"
+			}
+			for _, refreshed := range []bool{false, true} {
+				name := "fallback"
+				if refreshed {
+					name = "snapshot"
+				}
+				t.Run(name, func(t *testing.T) {
+					h := NewHome()
+					h.width, h.height = 240, 40
+					if refreshed {
+						h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+					}
+					for _, selected := range []bool{false, true} {
+						var b strings.Builder
+						h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, h.getSessionRenderSnapshot(), 240)
+						row := b.String()
+						require.Contains(t, row, "[account:"+label+"]", "stored slot must be visible on each session row")
+						require.Equal(t, 1, strings.Count(row, "\n"), "account controls cannot add logical rows")
+						require.NotContains(t, row, "\x1b]0;injected")
+						require.NotContains(t, row, "\a")
+					}
+				})
+				t.Run(name+"_card", func(t *testing.T) {
+					h := NewHome()
+					if refreshed {
+						h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+					}
+					card := h.renderSessionInfoCard(inst, 240, 40)
+					require.Contains(t, card, "Account slot:")
+					require.Contains(t, card, label)
+					require.NotContains(t, card, "\x1b]0;injected")
+				})
+			}
+		})
+	}
+}
+
+func TestStoredAccountBaselineKeepsTitleAndRecency(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 240, 40
+	h.showSessionTimestamps = true
+	inst := &session.Instance{ID: "account-control", Title: "existing-title", Tool: "shell", Status: session.StatusIdle, Account: "personal"}
+	var b strings.Builder
+	h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, false, nil, 240)
+	require.Contains(t, b.String(), "existing-title")
+	require.Equal(t, 1, strings.Count(b.String(), "\n"))
+}

--- a/internal/ui/account_slot_width_test.go
+++ b/internal/ui/account_slot_width_test.go
@@ -18,7 +18,7 @@ func TestStoredAccountWidthMatrix(t *testing.T) {
 					h := NewHome()
 					h.width, h.height = width, 40
 					inst := &session.Instance{ID: "width", Title: strings.Repeat("Title日本e\u0301", 8), Tool: "shell", Status: session.StatusIdle, Account: slot}
-					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
+					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, accountDisplay: newAccountPresentation(slot), autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
 					for _, selected := range []bool{false, true} {
 						var b strings.Builder
 						h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, map[string]sessionRenderState{inst.ID: state}, width)
@@ -45,6 +45,8 @@ func TestStoredAccountSnapshotIsAuthoritative(t *testing.T) {
 	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
 	inst.Account = "second" // Sequential controlled mutation; no concurrent writer.
 	require.Equal(t, "first", h.getSessionRenderState(inst).account)
+	require.Equal(t, `"first"`, h.getSessionRenderState(inst).accountDisplay.label)
 	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
 	require.Equal(t, "second", h.getSessionRenderState(inst).account)
+	require.Equal(t, `"second"`, h.getSessionRenderState(inst).accountDisplay.label)
 }

--- a/internal/ui/account_slot_width_test.go
+++ b/internal/ui/account_slot_width_test.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoredAccountWidthMatrix(t *testing.T) {
+	for _, slot := range []string{"", "personal", strings.Repeat("日本e\u03011️⃣🚀", 20), "\x1b]0;bad\a\r\n\u202e"} {
+		for _, width := range []int{24, 40, 72, 120} {
+			for _, auto := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%q/%d/auto=%v", slot, width, auto), func(t *testing.T) {
+					h := NewHome()
+					h.width, h.height = width, 40
+					inst := &session.Instance{ID: "width", Title: strings.Repeat("Title日本e\u0301", 8), Tool: "shell", Status: session.StatusIdle, Account: slot}
+					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
+					for _, selected := range []bool{false, true} {
+						var b strings.Builder
+						h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, map[string]sessionRenderState{inst.ID: state}, width)
+						line := strings.TrimSuffix(b.String(), "\n")
+						require.True(t, utf8.ValidString(line))
+						require.LessOrEqual(t, cellWidth(line), width)
+						require.NotContains(t, line, "\x1b]0;bad")
+						require.NotContains(t, line, "\a")
+						require.NotContains(t, line, "\r")
+						require.NotContains(t, line, "\n")
+						if width >= 40 {
+							require.Contains(t, line, "[account:")
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestStoredAccountSnapshotIsAuthoritative(t *testing.T) {
+	h := NewHome()
+	inst := &session.Instance{ID: "snapshot", Title: "title", Tool: "shell", Status: session.StatusIdle, Account: "first"}
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	inst.Account = "second" // Sequential controlled mutation; no concurrent writer.
+	require.Equal(t, "first", h.getSessionRenderState(inst).account)
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+	require.Equal(t, "second", h.getSessionRenderState(inst).account)
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4201,6 +4201,7 @@ type sessionRenderState struct {
 	// the residual "Ctrl+Q → black screen" on large decks with a big group
 	// expanded. Carrying the labels in the snapshot makes row rendering
 	// lock-free.
+	account      string // Stored slot; empty means inherited, not a login identity.
 	title        string // Instance.Title at snapshot time
 	autoName     bool   // session displays a captured/live task description
 	autoNameDesc string // last persisted auto-name description (fallback when paneTitle empty)
@@ -4343,6 +4344,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 			// through GetTitleThreadSafe because SetField/ReconcileTitleFromClaude/
 			// pending-title reapply can mutate it concurrently from the Bubble
 			// Tea event-loop goroutine.
+			account:      inst.GetAccountThreadSafe(),
 			title:        inst.GetTitleThreadSafe(),
 			autoName:     inst.GetAutoName(),
 			autoNameDesc: inst.GetAutoNameDescription(),
@@ -4389,6 +4391,7 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 	return sessionRenderState{
 		status:       inst.GetStatusThreadSafe(),
 		tool:         inst.GetToolThreadSafe(),
+		account:      inst.GetAccountThreadSafe(),
 		title:        inst.GetTitleThreadSafe(),
 		autoName:     inst.GetAutoName(),
 		autoNameDesc: inst.GetAutoNameDescription(),
@@ -17402,18 +17405,29 @@ func (h *Home) renderSessionItem(
 	if isMaestro {
 		displayTitle = "⬢ " + displayTitle
 	}
-	if instState.autoName && listWidth > 0 {
-		// Task descriptions can be long; truncate to the row's free width so the
-		// tool label and badges stay on-row. Keep the reserved terms below in
-		// sync with the row format that follows.
-		reserved := leftGutterWidth + cellWidth(baseIndent) + cellWidth(selectionPrefix) +
-			cellWidth(treeStyle.Render(treeConnector)) + cellWidth(windowChevron) +
-			cellWidth(status) + 1 /* space before title */ + cellWidth(tool) +
-			cellWidth(maestroBadge) + cellWidth(yoloBadge) + cellWidth(worktreeBadge) +
-			cellWidth(sandboxBadge) + cellWidth(multiRepoBadge) + cellWidth(sshBadge) +
-			cellWidth(agentBadge) + cellWidth(timestampBadge)
-		budget := listWidth - reserved - 1 // -1 trailing margin
-		if budget > 0 && cellWidth(displayTitle) > budget {
+	// Include the stored slot in the existing badge/title cell budget. Normal
+	// titles need the same reservation as auto-names so the badge stays visible.
+	reserved := leftGutterWidth + cellWidth(baseIndent) + cellWidth(selectionPrefix) +
+		cellWidth(treeStyle.Render(treeConnector)) + cellWidth(windowChevron) +
+		cellWidth(status) + 1 + cellWidth(tool) +
+		cellWidth(maestroBadge) + cellWidth(yoloBadge) + cellWidth(worktreeBadge) +
+		cellWidth(sandboxBadge) + cellWidth(multiRepoBadge) + cellWidth(sshBadge) +
+		cellWidth(agentBadge) + cellWidth(timestampBadge)
+	accountBudget := cellWidth(" [account:" + storedAccountLabel(instState.account) + "]")
+	if listWidth > 0 {
+		accountBudget = min(accountBudget, max(0, listWidth-reserved-2))
+	}
+	accountBadge := storedAccountBadge(instState.account, accountBudget)
+	if accountBadge != "" {
+		accountStyle := DimStyle
+		if selected {
+			accountStyle = SessionStatusSelStyle
+		}
+		accountBadge = accountStyle.Render(accountBadge)
+	}
+	if listWidth > 0 {
+		budget := max(0, listWidth-reserved-cellWidth(accountBadge)-1)
+		if cellWidth(displayTitle) > budget {
 			displayTitle = cellTruncate(displayTitle, budget, "…")
 		}
 	}
@@ -17423,7 +17437,7 @@ func (h *Home) renderSessionItem(
 	// The leading gutter (leftGutterWidth) keeps sessions aligned with group
 	// rows, which reserve the same gutter for root hotkey numbers.
 	row := fmt.Sprintf(
-		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s%s%s",
 		strings.Repeat(" ", leftGutterWidth),
 		baseIndent,
 		selectionPrefix,
@@ -17439,6 +17453,7 @@ func (h *Home) renderSessionItem(
 		multiRepoBadge,
 		sshBadge,
 		agentBadge,
+		accountBadge,
 		timestampBadge,
 	)
 
@@ -18136,6 +18151,11 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 
 	// Tool
 	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Tool:"), valueStyle.Render(cardTool)))
+
+	// Use the same cached metadata as the row; no account/config resolution.
+	account := storedAccountLabel(h.getSessionRenderState(inst).account)
+	account = cellTruncate(account, max(0, width-cellWidth("Account slot: ")), "…")
+	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Account slot:"), valueStyle.Render(account)))
 
 	// Session ID (if available) - Claude, Gemini, OpenCode, or generic (Hermes/custom tools)
 	sessionID := inst.ClaudeSessionID

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4201,10 +4201,11 @@ type sessionRenderState struct {
 	// the residual "Ctrl+Q → black screen" on large decks with a big group
 	// expanded. Carrying the labels in the snapshot makes row rendering
 	// lock-free.
-	account      string // Stored slot; empty means inherited, not a login identity.
-	title        string // Instance.Title at snapshot time
-	autoName     bool   // session displays a captured/live task description
-	autoNameDesc string // last persisted auto-name description (fallback when paneTitle empty)
+	account        string // Stored slot; empty means inherited, not a login identity.
+	accountDisplay accountPresentation
+	title          string // Instance.Title at snapshot time
+	autoName       bool   // session displays a captured/live task description
+	autoNameDesc   string // last persisted auto-name description (fallback when paneTitle empty)
 }
 
 // displaySessionTitle returns the label to render for a session row. For an
@@ -4331,6 +4332,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 	}
 
 	snap := make(map[string]sessionRenderState, len(instances))
+	accounts := make(map[string]accountPresentation)
 	for _, inst := range instances {
 		if inst == nil {
 			continue
@@ -4349,6 +4351,12 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 			autoName:     inst.GetAutoName(),
 			autoNameDesc: inst.GetAutoNameDescription(),
 		}
+		display, ok := accounts[state.account]
+		if !ok {
+			display = newAccountPresentation(state.account)
+			accounts[state.account] = display
+		}
+		state.accountDisplay = display
 		// Look up pane title from the already-refreshed tmux cache.
 		// Only RefreshPaneInfoCache (called from backgroundStatusUpdate) keeps
 		// the cache fresh; processStatusUpdate and other rebuild paths run on
@@ -4388,13 +4396,15 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 	// Fallback for newly-added sessions before snapshot refresh. This path DOES
 	// take Instance.mu (briefly, as a reader); it is bounded to sessions that a
 	// snapshot refresh has not seen yet, never the steady-state whole list.
+	account := inst.GetAccountThreadSafe()
 	return sessionRenderState{
-		status:       inst.GetStatusThreadSafe(),
-		tool:         inst.GetToolThreadSafe(),
-		account:      inst.GetAccountThreadSafe(),
-		title:        inst.GetTitleThreadSafe(),
-		autoName:     inst.GetAutoName(),
-		autoNameDesc: inst.GetAutoNameDescription(),
+		status:         inst.GetStatusThreadSafe(),
+		tool:           inst.GetToolThreadSafe(),
+		account:        account,
+		accountDisplay: newAccountPresentation(account),
+		title:          inst.GetTitleThreadSafe(),
+		autoName:       inst.GetAutoName(),
+		autoNameDesc:   inst.GetAutoNameDescription(),
 	}
 }
 
@@ -17413,11 +17423,11 @@ func (h *Home) renderSessionItem(
 		cellWidth(maestroBadge) + cellWidth(yoloBadge) + cellWidth(worktreeBadge) +
 		cellWidth(sandboxBadge) + cellWidth(multiRepoBadge) + cellWidth(sshBadge) +
 		cellWidth(agentBadge) + cellWidth(timestampBadge)
-	accountBudget := cellWidth(" [account:" + storedAccountLabel(instState.account) + "]")
+	accountBudget := instState.accountDisplay.width
 	if listWidth > 0 {
 		accountBudget = min(accountBudget, max(0, listWidth-reserved-2))
 	}
-	accountBadge := storedAccountBadge(instState.account, accountBudget)
+	accountBadge, accountWidth := instState.accountDisplay.fit(accountBudget)
 	if accountBadge != "" {
 		accountStyle := DimStyle
 		if selected {
@@ -17426,7 +17436,7 @@ func (h *Home) renderSessionItem(
 		accountBadge = accountStyle.Render(accountBadge)
 	}
 	if listWidth > 0 {
-		budget := max(0, listWidth-reserved-cellWidth(accountBadge)-1)
+		budget := max(0, listWidth-reserved-accountWidth-1)
 		if cellWidth(displayTitle) > budget {
 			displayTitle = cellTruncate(displayTitle, budget, "…")
 		}
@@ -18153,7 +18163,7 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Tool:"), valueStyle.Render(cardTool)))
 
 	// Use the same cached metadata as the row; no account/config resolution.
-	account := storedAccountLabel(h.getSessionRenderState(inst).account)
+	account := h.getSessionRenderState(inst).accountDisplay.label
 	account = cellTruncate(account, max(0, width-cellWidth("Account slot: ")), "…")
 	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Account slot:"), valueStyle.Render(account)))
 


### PR DESCRIPTION
## What problem does this solve?

Two people sharing a deck cannot see which stored account slot belongs to a session in the home TUI. Session rows now show a quoted account badge, and the session info card exposes the same stored value.

## Why this change

Carry the slot through the existing render snapshot, with a locked getter during refresh and the existing missing-snapshot fallback. Steady-state row rendering adds no account lock or subprocess. Quote controls before styling and budget the badge in terminal cells alongside title and timestamp space.

## User impact

Rows display labels such as `[account:"personal"]`. Empty metadata displays `inherited`, meaning no explicit stored override. This does not identify a running login. Narrow rows truncate the account label or omit the badge when it cannot fit; the info card retains the account field. Remote fleet account transport and other shared-deck acceptance remain separate.

## Evidence

Against unchanged main `169699`, 28 output leaf controls fail because account rows/cards are absent; 36 failures include parent nodes, with one existing-output positive control and no skips. Corrected source has 154 UI race test/subtest passes and 16 separate nonrace isolation/bootstrap passes, zero failures/skips. The matrix covers stored empty/Unicode/control slots, fallback/snapshot, selected rows, width, existing pane titles and recency behavior. UI/session vet and source-hash checks pass. Independent source/code-simplifier review passes the exact five file hashes.

No full repository suite or current-head hosted CI is claimed. Before/after rendering timing is still pending; this packet is not a release-complete claim.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** unsure

## What actually bothered you

The owner requested: "list/show/TUI display the account slot per session" for two SSH users sharing one deck. This change implements the local TUI row/info-card portion.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Full test suite passes sandboxed
- [ ] Before/after hot-path timing evidence included
- [x] CHANGELOG.md untouched
- [x] AI involvement disclosed with validation evidence
- [ ] Allow edits from maintainers enabled

<!-- gate:ai=authored model=unsure intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session listings display the stored account slot in compact badges and session details.
  * Long account labels are automatically truncated to fit available space.

* **Bug Fixes**
  * Session rendering now preserves layout width and valid text for Unicode, quoted, and control-character account names.
  * Remote session rows no longer display unrelated local account information.
  * Account information remains consistent while session data is updated concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Account synchronization correction

The review found that the account setter did not share the snapshot reader's mutex. The correction synchronizes the actual mutation and invalid-value read, preserving validation and restart behavior. A regression using the real setter concurrently with snapshot refresh reproduced the race before the fix and passes afterward. A remote-row control also prevents inventing an account from unrelated local metadata.

Validation on correction `6013caa8`: affected UI race run has 156 test/subtest entries passing, zero failures or skips; separate isolation controls have 16 passing entries, zero failures or skips. Affected package vet and source manifests pass. These counts include parent entries and replace, rather than add to, the earlier overlapping receipt. Earlier evidence did not exercise the newly reported race. Independent source and recovery provenance review passed. Exact-head CI and rendering timing remain pending before merge.


## Render-cost follow-up

Candidate `1006266c` integrates current main and caches quoted account presentation and cell width in the existing immutable render snapshot. Rows sharing a slot reuse presentation within a refresh. The same escaping, truncation, selection and info-card behavior remain covered. Independent source review and the affected 156-entry race and 16-entry isolation checks pass with zero skips or failures; package vet and source manifests pass.

A bounded three-round synthetic comparison against the main-integrated uncached implementation measured about 16% less time rendering all 1,000 rows. The 100-row results were mixed: narrow rows improved, while wide rows added about 0.49 ms per complete 100-row render. Snapshot preparation added about 5–13 microseconds per 100 rows and 101–135 microseconds per 1,000 rows. These are small-sample full-list microbenchmarks, not a blanket speedup or measured visible-frame/network latency. Exact-head CI remains required before merge.
