### PR TITLE
fix: refresh shared session state without losing concurrent updates

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -34,6 +34,7 @@ on:
       - 'go.sum'
       - '.github/workflows/go-test.yml'
       - 'scripts/ci-native-ssh.sh'
+      - 'scripts/ci-shared-state-proof.sh'
 
 # One in-flight run per PR (or per branch on push). Rapid follow-up pushes
 # cancel the stale run instead of stacking 20-minute jobs.
@@ -65,7 +66,7 @@ jobs:
             echo "go=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           base="${{ github.event.pull_request.base.sha }}"
-          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$)'; then
+          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$|^scripts/ci-shared-state-proof\.sh$)'; then
             echo "go=true" >> "$GITHUB_OUTPUT"
           else
             echo "go=false" >> "$GITHUB_OUTPUT"
@@ -102,6 +103,13 @@ jobs:
           go install gotest.tools/gotestsum@v1.13.0
           gotestsum --rerun-fails=2 --rerun-fails-abort-on-data-race --packages="./..." -- -race -timeout 20m
 
+      # The ordinary suite above covers shared-state and real-process tests.
+      # This bounded additional gate includes the test-only observer lock fixture.
+      - name: Verify shared-state ordering proofs
+        if: steps.gochanges.outputs.go == 'true'
+        timeout-minutes: 5
+        run: bash scripts/ci-shared-state-proof.sh
+
   native-ssh:
     name: Required native SSH acceptance
     runs-on: ubuntu-latest
@@ -137,3 +145,4 @@ jobs:
           name: native-ssh-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.NATIVE_SSH_ARTIFACT_DIR }}
           if-no-files-found: error
+

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -1124,18 +1124,24 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 
 // LoadWithGroups reads instances and groups from SQLite, reconnects tmux sessions.
 func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
+	instances, groups, _, err := s.LoadWithGroupsSnapshot()
+	return instances, groups, err
+}
+
+// LoadWithGroupsSnapshot carries the exact persisted snapshot for reload acknowledgement.
+func (s *Storage) LoadWithGroupsSnapshot() ([]*Instance, []*GroupData, *statedb.RegistrySnapshotResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.db == nil {
 		storageLog.Debug("load_db_not_initialized", slog.String("profile", s.profile))
-		return []*Instance{}, nil, nil
+		return []*Instance{}, nil, nil, nil
 	}
 
 	// Load from SQLite
 	snapshot, err := s.db.LoadRegistrySnapshot()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	dbRows, dbGroups := snapshot.Instances, snapshot.Groups
 
@@ -1253,7 +1259,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 		for _, inst := range instances {
 			original, convertErr := instanceToRow(inst)
 			if convertErr != nil {
-				return nil, nil, convertErr
+				return nil, nil, nil, convertErr
 			}
 			stored := byID[inst.ID]
 			if stored != nil && stored.GroupPath == DefaultGroupName {
@@ -1269,7 +1275,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 		}
 		if legacy := groupsByPath[DefaultGroupName]; legacy != nil {
 			if groupsByPath[DefaultGroupPath] != nil {
-				return nil, nil, fmt.Errorf("legacy default group migration conflicts with existing %q group", DefaultGroupPath)
+				return nil, nil, nil, fmt.Errorf("legacy default group migration conflicts with existing %q group", DefaultGroupPath)
 			}
 			groupsByPath[DefaultGroupPath] = legacy
 		}
@@ -1283,7 +1289,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 				original: original, stored: statedb.CloneGroupRow(stored)}
 		}
 	}
-	return instances, groups, err
+	return instances, groups, snapshot, err
 }
 
 // SaveRecentSession captures a deleted session's config for quick re-creation.

--- a/internal/statedb/registry_observer.go
+++ b/internal/statedb/registry_observer.go
@@ -1,0 +1,141 @@
+package statedb
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// RegistryObserver owns one live read-only connection. data_version values are
+// connection-local, so this connection must never be borrowed from a pool.
+type RegistryObserver struct {
+	mu     sync.Mutex
+	db     *sql.DB
+	conn   *sql.Conn
+	ctx    context.Context
+	cancel context.CancelFunc
+	once   sync.Once
+	epoch  uint64
+}
+
+func (s *StateDB) NewRegistryObserver() (*RegistryObserver, error) {
+	u := url.URL{Scheme: "file", Path: s.path}
+	q := u.Query()
+	q.Set("mode", "ro")
+	q.Add("_pragma", "query_only(1)")
+	u.RawQuery = q.Encode()
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	probe, done := context.WithTimeout(ctx, 2*time.Second)
+	defer done()
+	conn, err := db.Conn(probe)
+	if err != nil {
+		cancel()
+		_ = db.Close()
+		return nil, err
+	}
+	o := &RegistryObserver{db: db, conn: conn, ctx: ctx, cancel: cancel, epoch: 1}
+	if _, err := o.Version(); err != nil {
+		_ = o.Close()
+		return nil, err
+	}
+	return o, nil
+}
+
+func (o *RegistryObserver) Version() (int64, error) {
+	version, _, err := o.Probe()
+	return version, err
+}
+
+// Probe binds its value to a connection epoch. Reconnection is conservative:
+// the failed observation remains an error, and the next probe uses a new epoch.
+func (o *RegistryObserver) Probe() (int64, uint64, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	ctx, cancel := context.WithTimeout(o.ctx, 2*time.Second)
+	defer cancel()
+	var version int64
+	var err error
+	if o.conn == nil {
+		err = o.reconnectLocked()
+	}
+	if err == nil {
+		err = o.conn.QueryRowContext(ctx, "PRAGMA data_version").Scan(&version)
+	}
+	epoch := o.epoch
+	if err != nil && o.ctx.Err() == nil {
+		_ = o.reconnectLocked()
+	}
+	return version, epoch, err
+}
+func (o *RegistryObserver) reconnectLocked() error {
+	if o.conn != nil {
+		_ = o.conn.Close()
+		o.conn = nil
+	}
+	ctx, cancel := context.WithTimeout(o.ctx, 2*time.Second)
+	defer cancel()
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	o.conn = conn
+	o.epoch++
+	return nil
+}
+
+// Snapshot returns persisted rows, never converted process-local runtime state.
+func (o *RegistryObserver) Snapshot() (*RegistrySnapshotResult, int64, int64, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.conn == nil {
+		return nil, 0, 0, sql.ErrConnDone
+	}
+	ctx, cancel := context.WithTimeout(o.ctx, 2*time.Second)
+	defer cancel()
+	var before, after int64
+	if err := o.conn.QueryRowContext(ctx, "PRAGMA data_version").Scan(&before); err != nil {
+		return nil, 0, 0, err
+	}
+	tx, err := o.conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := loadInstances(tx.Query)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	groups, err := loadGroups(tx.Query)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, 0, 0, err
+	}
+	if err = o.conn.QueryRowContext(ctx, "PRAGMA data_version").Scan(&after); err != nil {
+		return nil, 0, 0, err
+	}
+	return &RegistrySnapshotResult{Instances: rows, Groups: groups}, before, after, nil
+}
+
+func (o *RegistryObserver) Close() error {
+	var err error
+	o.once.Do(func() {
+		o.cancel()
+		o.mu.Lock()
+		defer o.mu.Unlock()
+		if o.conn != nil {
+			err = o.conn.Close()
+		}
+		if e := o.db.Close(); err == nil {
+			err = e
+		}
+	})
+	return err
+}

--- a/internal/statedb/registry_observer_proof.go
+++ b/internal/statedb/registry_observer_proof.go
@@ -1,0 +1,10 @@
+//go:build watcher_proof
+
+package statedb
+
+// HoldRegistryObserverForProof blocks probes without timers or DB scheduling.
+// It exists only in the explicitly tagged behavioral proof fixture.
+func HoldRegistryObserverForProof(o *RegistryObserver) func() {
+	o.mu.Lock()
+	return o.mu.Unlock
+}

--- a/internal/statedb/registry_observer_test.go
+++ b/internal/statedb/registry_observer_test.go
@@ -1,0 +1,60 @@
+package statedb
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestRegistryObserverLiveCommitAndReadOnly(t *testing.T) {
+	db := newTestDB(t)
+	observer, err := db.NewRegistryObserver()
+	require.NoError(t, err)
+	defer observer.Close()
+	before, err := observer.Version()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveInstance(&InstanceRow{ID: "external", Title: "external", Status: "running"}))
+	snapshot, _, after, err := observer.Snapshot()
+	require.NoError(t, err)
+	require.NotEqual(t, before, after)
+	require.Len(t, snapshot.Instances, 1)
+	require.Equal(t, "running", snapshot.Instances[0].Status)
+	_, err = observer.conn.ExecContext(context.Background(), "UPDATE instances SET title='forbidden'")
+	require.Error(t, err)
+}
+func TestRegistryObserverCloseCancelsAndStopsReads(t *testing.T) {
+	db := newTestDB(t)
+	observer, err := db.NewRegistryObserver()
+	require.NoError(t, err)
+	done := make(chan error, 1)
+	go func() { done <- observer.Close() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close blocked")
+	}
+	_, err = observer.Version()
+	require.Error(t, err)
+	require.NoError(t, observer.Close())
+}
+
+func TestRegistryObserverReconnectChangesEpoch(t *testing.T) {
+	db := newTestDB(t)
+	o, err := db.NewRegistryObserver()
+	require.NoError(t, err)
+	defer o.Close()
+	_, old, err := o.Probe()
+	require.NoError(t, err)
+	require.NoError(t, o.conn.Close())
+	_, _, err = o.Probe()
+	require.Error(t, err, "failed read must not become a success during recovery")
+	_, next, err := o.Probe()
+	require.NoError(t, err)
+	require.Greater(t, next, old)
+	require.NoError(t, db.SaveInstance(&InstanceRow{ID: "recovered", Title: "recovered"}))
+	snap, _, _, err := o.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snap.Instances, 1)
+}

--- a/internal/ui/group_mutation_reload_race_test.go
+++ b/internal/ui/group_mutation_reload_race_test.go
@@ -47,8 +47,8 @@ func TestGroupCreate_SurvivesReloadRace(t *testing.T) {
 	if _, ok := h.groupTree.Groups["home"]; !ok {
 		t.Fatalf("group 'home' was lost after the reload race; reapply did not restore it")
 	}
-	if len(h.pendingGroupOps) != 0 {
-		t.Errorf("pendingGroupOps should be cleared after reapply, got %d", len(h.pendingGroupOps))
+	if len(h.pendingGroupOps) != 1 {
+		t.Errorf("without a storage save, reapplied intent must remain pending; got %d", len(h.pendingGroupOps))
 	}
 }
 
@@ -82,8 +82,8 @@ func TestGroupRename_SurvivesReloadRace(t *testing.T) {
 	if _, ok := h.groupTree.Groups["work"]; ok {
 		t.Errorf("stale 'work' group still present after reapplied rename")
 	}
-	if len(h.pendingGroupOps) != 0 {
-		t.Errorf("pendingGroupOps should be cleared after reapply, got %d", len(h.pendingGroupOps))
+	if len(h.pendingGroupOps) != 1 {
+		t.Errorf("without a storage save, reapplied intent must remain pending; got %d", len(h.pendingGroupOps))
 	}
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -437,7 +437,8 @@ type Home struct {
 	clearOnCompactSent map[string]time.Time // instanceID -> last /clear send time (debounce)
 
 	// File watcher for external changes (auto-reload)
-	storageWatcher *StorageWatcher
+	storageWatcher      *StorageWatcher
+	sessionLoadSequence uint64 // issued only by the UI event loop
 
 	// Optional in-memory web menu data sink for web mode.
 	webMenuData   *web.MemoryMenuData
@@ -1216,13 +1217,17 @@ func (h *Home) stackedPreviewTopY() int {
 
 // Messages
 type loadSessionsMsg struct {
-	instances    []*session.Instance
-	groups       []*session.GroupData
-	err          error
-	restoreState *reloadState // Optional state to restore after reload
-	poolProxies  int          // Number of socket proxies started
-	poolError    error        // Pool initialization error
-	loadMtime    time.Time    // File mtime at load time (for external change detection)
+	loadSequence      uint64
+	loadWatcher       *StorageWatcher
+	watcherTicket     *storageLoadTicket
+	persistedSnapshot *statedb.RegistrySnapshotResult
+	instances         []*session.Instance
+	groups            []*session.GroupData
+	err               error
+	restoreState      *reloadState // Optional state to restore after reload
+	poolProxies       int          // Number of socket proxies started
+	poolError         error        // Pool initialization error
+	loadMtime         time.Time    // File mtime at load time (for external change detection)
 }
 
 type sessionCreatedMsg struct {
@@ -1241,6 +1246,7 @@ type sessionForkedMsg struct {
 }
 
 type refreshMsg struct{}
+type importReloadMsg struct{}
 
 type statusUpdateMsg struct {
 	attachedSessionID string // Session that just returned from attach (if local attach)
@@ -3194,7 +3200,7 @@ func (h *Home) Init() tea.Cmd {
 	}
 
 	cmds := []tea.Cmd{
-		h.loadSessions,
+		h.sessionLoadCmd(nil, true),
 
 		h.tick(),
 		h.reviverTick(),
@@ -3600,31 +3606,60 @@ func (h *Home) measureRemoteLatencies() tea.Msg {
 
 // loadSessions loads sessions from storage and initializes the pool
 func (h *Home) loadSessions() tea.Msg {
-	if h.storage == nil {
-		return loadSessionsMsg{instances: []*session.Instance{}, err: fmt.Errorf("storage not initialized")}
+	return h.sessionLoadCmd(nil, true)()
+}
+
+// sessionLoadCmd issues ordering without database I/O. The returned command
+// probes and reads the captured storage asynchronously, including initial loads.
+func (h *Home) sessionLoadCmd(restore *reloadState, initializePool bool) tea.Cmd {
+	h.sessionLoadSequence++
+	sequence := h.sessionLoadSequence
+	storage, watcher := h.storage, h.storageWatcher
+	var issuedTicket storageLoadTicket
+	if watcher != nil {
+		issuedTicket = watcher.issueLoad()
 	}
-
-	// Capture file mtime BEFORE loading to detect external changes later
-	loadMtime, _ := h.storage.GetFileMtime()
-
-	instances, groups, err := h.storage.LoadWithGroups()
-	msg := loadSessionsMsg{instances: instances, groups: groups, err: err, loadMtime: loadMtime}
-
-	// Initialize pool AFTER sessions are loaded
-	userConfig, configErr := session.LoadUserConfig()
-	if configErr == nil && userConfig != nil && userConfig.MCPPool.Enabled {
-		pool, poolErr := session.InitializeGlobalPool(h.ctx, userConfig, instances)
-		if poolErr != nil {
-			mcpUILog.Warn("pool_init_failed", slog.String("error", poolErr.Error()))
-			msg.poolError = poolErr
-		} else if pool != nil {
-			proxies := pool.ListServers()
-			mcpUILog.Info("pool_initialized", slog.Int("proxies", len(proxies)))
-			msg.poolProxies = len(proxies)
+	return func() tea.Msg {
+		ticket := issuedTicket
+		msg := loadSessionsMsg{loadSequence: sequence, loadWatcher: watcher, restoreState: restore}
+		if storage == nil {
+			msg.err = fmt.Errorf("storage not initialized")
+			return msg
 		}
+		if watcher != nil {
+			var err error
+			ticket, err = watcher.probeLoad(ticket)
+			msg.watcherTicket = &ticket
+			if err != nil {
+				msg.err = err
+				return msg
+			}
+		}
+		msg.loadMtime, _ = storage.GetFileMtime()
+		msg.instances, msg.groups, msg.persistedSnapshot, msg.err = storage.LoadWithGroupsSnapshot()
+		if watcher != nil {
+			finished, err := watcher.endLoad(ticket)
+			msg.watcherTicket = &finished
+			if msg.err == nil {
+				msg.err = err
+			}
+		}
+		if initializePool {
+			userConfig, configErr := session.LoadUserConfig()
+			if configErr == nil && userConfig != nil && userConfig.MCPPool.Enabled {
+				pool, poolErr := session.InitializeGlobalPool(h.ctx, userConfig, msg.instances)
+				if poolErr != nil {
+					mcpUILog.Warn("pool_init_failed", slog.String("error", poolErr.Error()))
+					msg.poolError = poolErr
+				} else if pool != nil {
+					proxies := pool.ListServers()
+					mcpUILog.Info("pool_initialized", slog.Int("proxies", len(proxies)))
+					msg.poolProxies = len(proxies)
+				}
+			}
+		}
+		return msg
 	}
-
-	return msg
 }
 
 // SetHeadless marks this Home as backing a headless (`web --no-tui`) server.
@@ -5646,10 +5681,19 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, h.fetchPreview(inst, key, winIdx)
 
 	case loadSessionsMsg:
+		if msg.loadSequence != 0 && (msg.loadSequence != h.sessionLoadSequence || msg.loadWatcher != h.storageWatcher) {
+			return h, nil
+		}
+		if msg.watcherTicket != nil && h.storageWatcher != nil && !h.storageWatcher.current(*msg.watcherTicket) {
+			return h, nil
+		}
+		if msg.watcherTicket != nil && h.storageWatcher != nil {
+			h.storageWatcher.acknowledge(*msg.watcherTicket, msg.persistedSnapshot, msg.err == nil)
+		}
 		// Clear loading indicators and store file mtime for external change detection
 		h.reloadMu.Lock()
 		h.isReloading = false
-		if !msg.loadMtime.IsZero() {
+		if msg.err == nil && !msg.loadMtime.IsZero() {
 			h.lastLoadMtime = msg.loadMtime
 		}
 		h.reloadMu.Unlock()
@@ -5750,7 +5794,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Using tea.Cmd pattern ensures save is triggered after detection completes
 			var detectionCmds []tea.Cmd
 			for _, inst := range h.instances {
-				if inst.Tool == "opencode" && inst.OpenCodeSessionID == "" {
+				if inst.Tool == "opencode" && inst.OpenCodeSessionID == "" && (msg.restoreState == nil || inst.OpenCodeDetectedAt.IsZero()) {
 					detectionCmds = append(detectionCmds, h.detectOpenCodeSessionCmd(inst))
 				}
 			}
@@ -5826,7 +5870,6 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 				// Clear pending changes and persist if any were re-applied
-				h.pendingTitleChanges = make(map[string]pendingTitle)
 				if applied {
 					h.forceSaveInstances()
 				}
@@ -6281,6 +6324,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, h.fetchPreview(msg.instance, msg.instance.ID, -1)
 
 	case openCodeDetectionCompleteMsg:
+		if msg.sessionID == "" {
+			if inst := h.getInstanceByID(msg.instanceID); inst != nil && !inst.OpenCodeDetectedAt.IsZero() {
+				return h, nil
+			}
+		}
 		// OpenCode session detection completed
 		// CRITICAL: Find the CURRENT instance by ID and update it
 		// The original pointer may have been replaced by storage watcher reload
@@ -6606,7 +6654,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case refreshMsg:
-		return h, h.loadSessions
+		return h, h.sessionLoadCmd(nil, true)
+	case importReloadMsg:
+		state := h.preserveState()
+		return h, h.sessionLoadCmd(&state, false)
 
 	case systemThemeMsg:
 		theme := "light"
@@ -6641,20 +6692,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Preserve UI state before reload
 		state := h.preserveState()
 
-		// Reload from disk
-		cmd := func() tea.Msg {
-			// Capture file mtime BEFORE loading to detect external changes later
-			loadMtime, _ := h.storage.GetFileMtime()
-			instances, groups, err := h.storage.LoadWithGroups()
-			uiLog.Debug("reload_load_with_groups", slog.Int("instances", len(instances)), slog.Any("error", err))
-			return loadSessionsMsg{
-				instances:    instances,
-				groups:       groups,
-				err:          err,
-				restoreState: &state, // Pass state to restore after load
-				loadMtime:    loadMtime,
-			}
-		}
+		cmd := h.sessionLoadCmd(&state, false)
 
 		// Continue listening for next change
 		return h, tea.Batch(cmd, listenForReloads(h.storageWatcher))
@@ -10028,20 +10066,9 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "ctrl+r":
-		// Manual refresh (useful if watcher fails or for user preference)
+		// Manual refresh follows the same ordering as initial and watcher loads.
 		state := h.preserveState()
-
-		cmd := func() tea.Msg {
-			instances, groups, err := h.storage.LoadWithGroups()
-			return loadSessionsMsg{
-				instances:    instances,
-				groups:       groups,
-				err:          err,
-				restoreState: &state,
-			}
-		}
-
-		return h, cmd
+		return h, h.sessionLoadCmd(&state, false)
 
 	case "ctrl+s":
 		// Open the session switcher from the overview too, with the same key
@@ -11318,7 +11345,9 @@ func (h *Home) reapplyPendingGroupOps() bool {
 	defer func() { h.groupTree.DefaultMaxConcurrent = savedDefaultMaxConcurrent }()
 
 	applied := false
+	pending := make([]pendingGroupOp, 0, len(h.pendingGroupOps))
 	for _, op := range h.pendingGroupOps {
+		opApplied := false
 		switch op.kind {
 		case groupOpCreate:
 			h.groupTree.DefaultMaxConcurrent = op.maxConcurrent
@@ -11328,7 +11357,7 @@ func (h *Home) reapplyPendingGroupOps() bool {
 				if op.defaultPath != "" {
 					h.groupTree.SetDefaultPathForGroup(g.Path, op.defaultPath)
 				}
-				applied = true
+				opApplied = true
 				uiLog.Info("pending_group_reapplied", slog.String("kind", "create"), slog.String("name", op.name))
 			}
 		case groupOpCreateSub:
@@ -11339,7 +11368,7 @@ func (h *Home) reapplyPendingGroupOps() bool {
 				if op.defaultPath != "" {
 					h.groupTree.SetDefaultPathForGroup(g.Path, op.defaultPath)
 				}
-				applied = true
+				opApplied = true
 				uiLog.Info("pending_group_reapplied", slog.String("kind", "createSub"), slog.String("name", op.name))
 			}
 		case groupOpRename:
@@ -11363,7 +11392,7 @@ func (h *Home) reapplyPendingGroupOps() bool {
 				h.instancesMu.Lock()
 				h.instances = h.groupTree.GetAllInstances()
 				h.instancesMu.Unlock()
-				applied = true
+				opApplied = true
 				uiLog.Info("pending_group_reapplied", slog.String("kind", "rename"), slog.String("old_path", op.oldPath), slog.String("name", op.name))
 			}
 		case groupOpMove:
@@ -11372,12 +11401,16 @@ func (h *Home) reapplyPendingGroupOps() bool {
 				h.instancesMu.Lock()
 				h.instances = h.groupTree.GetAllInstances()
 				h.instancesMu.Unlock()
-				applied = true
+				opApplied = true
 				uiLog.Info("pending_group_reapplied", slog.String("kind", "move"), slog.String("session_id", op.sessionID), slog.String("target", op.targetPath))
 			}
 		}
+		if opApplied {
+			pending = append(pending, op)
+			applied = true
+		}
 	}
-	h.pendingGroupOps = nil
+	h.pendingGroupOps = pending
 	return applied
 }
 
@@ -14359,8 +14392,6 @@ func (h *Home) importSessions() tea.Msg {
 
 	h.instancesMu.Lock()
 	h.instances = append(h.instances, discovered...)
-	instancesCopy := make([]*session.Instance, len(h.instances))
-	copy(instancesCopy, h.instances)
 	h.instancesMu.Unlock()
 
 	// Add discovered sessions to group tree before saving
@@ -14369,8 +14400,7 @@ func (h *Home) importSessions() tea.Msg {
 	}
 	// Save both instances AND groups (critical fix: was losing groups!)
 	h.saveInstances()
-	state := h.preserveState()
-	return loadSessionsMsg{instances: instancesCopy, restoreState: &state}
+	return importReloadMsg{}
 }
 
 // countSessionStatuses counts sessions by status for the logo display

--- a/internal/ui/storage_watcher.go
+++ b/internal/ui/storage_watcher.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"log/slog"
+	"reflect"
 	"sync"
 	"time"
 
@@ -11,59 +12,49 @@ import (
 
 var watcherLog = logging.ForComponent(logging.CompStorage)
 
-// StorageWatcher monitors the SQLite database for external changes
-// by polling the metadata.last_modified timestamp.
-// Replaces the previous fsnotify-based watcher which had reliability issues
-// on certain filesystems (9p, NFS, WSL).
-type StorageWatcher struct {
-	db        *statedb.StateDB
-	reloadCh  chan struct{}
-	closeCh   chan struct{}
-	closeOnce sync.Once
-
-	// lastModified tracks the last seen modification timestamp
-	lastModified int64
-	modMu        sync.RWMutex
-
-	// Tracks when TUI saved, to ignore self-triggered changes
-	lastSaveTime time.Time
-	saveMu       sync.RWMutex
-}
-
-// ignoreWindow is the time window after NotifySave during which changes are ignored.
-// Must be > pollInterval so the first poll after a self-save always falls within the window.
-const ignoreWindow = 3 * time.Second
-
-// pollInterval is how often we check for external changes.
 const pollInterval = 2 * time.Second
 
-// NewStorageWatcher creates a watcher that polls the SQLite metadata for changes.
+// StorageWatcher observes committed material registry changes on a dedicated
+// live SQLite connection. Own writes are conservatively reloaded too.
+type StorageWatcher struct {
+	observer       *statedb.RegistryObserver
+	reloadCh       chan struct{}
+	closeCh        chan struct{}
+	closeOnce      sync.Once
+	mu             sync.Mutex
+	acknowledged   *statedb.RegistrySnapshotResult
+	scannedVersion int64
+	scannedEpoch   uint64
+	pending        bool
+	sequence       uint64
+	closed         bool
+}
+
+type storageLoadTicket struct {
+	sequence                uint64
+	before, after           int64
+	beforeEpoch, afterEpoch uint64
+}
+
 func NewStorageWatcher(db *statedb.StateDB) (*StorageWatcher, error) {
 	if db == nil {
 		return nil, nil
 	}
-
-	// Get initial modification timestamp
-	lastMod, _ := db.LastModified()
-
-	return &StorageWatcher{
-		db:           db,
-		lastModified: lastMod,
-		reloadCh:     make(chan struct{}, 1), // Buffered to prevent blocking
-		closeCh:      make(chan struct{}),
-	}, nil
+	observer, err := db.NewRegistryObserver()
+	if err != nil {
+		return nil, err
+	}
+	snapshot, _, after, err := observer.Snapshot()
+	if err != nil {
+		_ = observer.Close()
+		return nil, err
+	}
+	return &StorageWatcher{observer: observer, reloadCh: make(chan struct{}, 1), closeCh: make(chan struct{}), acknowledged: snapshot, scannedVersion: after, pending: true}, nil
 }
-
-// Start begins polling for changes (non-blocking).
-func (sw *StorageWatcher) Start() {
-	go sw.pollLoop()
-}
-
-// pollLoop checks the metadata timestamp periodically.
+func (sw *StorageWatcher) Start() { go sw.pollLoop() }
 func (sw *StorageWatcher) pollLoop() {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
-
 	for {
 		select {
 		case <-sw.closeCh:
@@ -73,88 +64,113 @@ func (sw *StorageWatcher) pollLoop() {
 		}
 	}
 }
-
-// checkAndNotify checks if the metadata timestamp has changed and notifies if so.
+func (sw *StorageWatcher) signalLocked() {
+	if sw.closed {
+		return
+	}
+	select {
+	case sw.reloadCh <- struct{}{}:
+	default:
+	}
+}
 func (sw *StorageWatcher) checkAndNotify() {
-	ts, err := sw.db.LastModified()
+	version, epoch, err := sw.observer.Probe()
 	if err != nil {
 		watcherLog.Debug("watcher_poll_failed", slog.String("error", err.Error()))
+		sw.mu.Lock()
+		sw.pending = true
+		sw.signalLocked()
+		sw.mu.Unlock()
 		return
 	}
-
-	sw.modMu.Lock()
-	changed := ts > sw.lastModified
-	if changed {
-		sw.lastModified = ts
-	}
-	sw.modMu.Unlock()
-
-	if !changed {
+	sw.mu.Lock()
+	unchanged := version == sw.scannedVersion && epoch == sw.scannedEpoch && !sw.pending
+	closed := sw.closed
+	sw.mu.Unlock()
+	if unchanged || closed {
 		return
 	}
-
-	// Check if we should ignore this change (TUI's own save).
-	// The ignore window must be >= pollInterval so a self-triggered change
-	// is always caught on the first poll after the save.
-	sw.saveMu.RLock()
-	lastSave := sw.lastSaveTime
-	sw.saveMu.RUnlock()
-
-	if time.Since(lastSave) < ignoreWindow {
-		watcherLog.Debug("watcher_ignoring_own_save")
+	snapshot, before, after, err := sw.observer.Snapshot()
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	if sw.closed {
 		return
 	}
-
-	watcherLog.Debug("watcher_db_changed", slog.Int64("timestamp", ts))
-
-	// Non-blocking send (drop if channel full)
-	select {
-	case sw.reloadCh <- struct{}{}:
-	default:
-		watcherLog.Debug("watcher_reload_channel_full")
+	if err != nil {
+		sw.pending = true
+		sw.signalLocked()
+		return
+	}
+	sw.scannedVersion = after
+	sw.scannedEpoch = epoch
+	if before != after || !reflect.DeepEqual(snapshot, sw.acknowledged) {
+		sw.pending = true
+	}
+	if sw.pending {
+		sw.signalLocked()
 	}
 }
+func (sw *StorageWatcher) ReloadChannel() <-chan struct{} { return sw.reloadCh }
 
-// ReloadChannel returns the channel that signals when reload is needed.
-func (sw *StorageWatcher) ReloadChannel() <-chan struct{} {
-	return sw.reloadCh
-}
-
-// NotifySave should be called by the TUI right before it saves to storage.
-// This marks the current time so the watcher can ignore the resulting change.
-func (sw *StorageWatcher) NotifySave() {
-	sw.saveMu.Lock()
-	sw.lastSaveTime = time.Now()
-	sw.saveMu.Unlock()
-}
-
-// TriggerReload sends a reload signal.
-// Used as a manual trigger for reload (e.g., after CLI command changes).
+// NotifySave remains compatible with callers. Intent is not commit provenance;
+// it never suppresses unrelated writes.
+func (sw *StorageWatcher) NotifySave() {}
 func (sw *StorageWatcher) TriggerReload() {
-	// Update lastModified to current to prevent re-triggering
-	if ts, err := sw.db.LastModified(); err == nil {
-		sw.modMu.Lock()
-		sw.lastModified = ts
-		sw.modMu.Unlock()
-	}
-	// Non-blocking send to reload channel
-	select {
-	case sw.reloadCh <- struct{}{}:
-		watcherLog.Debug("watcher_trigger_reload")
-	default:
-		watcherLog.Debug("watcher_trigger_reload_channel_full")
-	}
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	sw.pending = true
+	sw.signalLocked()
+}
+func (sw *StorageWatcher) issueLoad() storageLoadTicket {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	sw.sequence++
+	return storageLoadTicket{sequence: sw.sequence}
 }
 
-// Warning returns empty string. SQLite polling works on all filesystems.
-func (sw *StorageWatcher) Warning() string {
-	return ""
+func (sw *StorageWatcher) beginLoad() (storageLoadTicket, error) {
+	return sw.probeLoad(sw.issueLoad())
 }
 
-// Close stops the watcher and releases resources. Safe to call multiple times.
+func (sw *StorageWatcher) probeLoad(ticket storageLoadTicket) (storageLoadTicket, error) {
+	version, epoch, err := sw.observer.Probe()
+	ticket.beforeEpoch = epoch
+	ticket.before = version
+	return ticket, err
+}
+func (sw *StorageWatcher) endLoad(ticket storageLoadTicket) (storageLoadTicket, error) {
+	version, epoch, err := sw.observer.Probe()
+	ticket.afterEpoch = epoch
+	ticket.after = version
+	return ticket, err
+}
+func (sw *StorageWatcher) current(ticket storageLoadTicket) bool {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return !sw.closed && ticket.sequence == sw.sequence
+}
+func (sw *StorageWatcher) acknowledge(ticket storageLoadTicket, snapshot *statedb.RegistrySnapshotResult, success bool) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	if sw.closed || ticket.sequence != sw.sequence {
+		return
+	}
+	if !success || snapshot == nil {
+		sw.pending = true
+		return
+	}
+	sw.acknowledged = snapshot
+	// Never acknowledge a version observed after the load's own boundary.
+	sw.pending = ticket.before != ticket.after || ticket.beforeEpoch != ticket.afterEpoch || sw.scannedEpoch != ticket.beforeEpoch || sw.scannedVersion != ticket.before
+	sw.scannedVersion = ticket.before
+	sw.scannedEpoch = ticket.beforeEpoch
+	if sw.pending {
+		sw.signalLocked()
+	}
+}
+func (sw *StorageWatcher) Warning() string { return "" }
 func (sw *StorageWatcher) Close() error {
-	sw.closeOnce.Do(func() {
-		close(sw.closeCh)
-	})
-	return nil
+	var err error
+	sw.closeOnce.Do(func() { sw.mu.Lock(); sw.closed = true; close(sw.closeCh); sw.mu.Unlock(); err = sw.observer.Close() })
+	return err
 }

--- a/internal/ui/storage_watcher_account_composition_test.go
+++ b/internal/ui/storage_watcher_account_composition_test.go
@@ -1,0 +1,39 @@
+package ui
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestStorageWatcherAccountOneRefreshComposition(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	w, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer w.Close()
+	h.storageWatcher = w
+	settleWatcherInitialLoad(t, w, storage.GetDB())
+	old := h.sessionLoadCmd(nil, false)()
+	writer, err := statedb.Open(storage.Path())
+	require.NoError(t, err)
+	defer writer.Close()
+	_, err = writer.DB().Exec("UPDATE instances SET account=? WHERE id=?", "reviewer", inst.ID)
+	require.NoError(t, err)
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	_, batch := h.Update(storageChangedMsg{})
+	commands := batch().(tea.BatchMsg)
+	_, _ = h.Update(commands[0]())
+	loaded := h.getInstanceByID(inst.ID)
+	require.Equal(t, "reviewer", loaded.GetAccountThreadSafe())
+	require.Equal(t, "reviewer", h.getSessionRenderState(loaded).account)
+	var row strings.Builder
+	h.renderSessionItem(&row, session.Item{Type: session.ItemTypeSession, Session: loaded, Level: 1, Path: "work", IsLastInGroup: true}, false, h.getSessionRenderSnapshot(), 240)
+	require.Contains(t, row.String(), `[account:"reviewer"]`)
+	require.Contains(t, h.renderSessionInfoCard(loaded, 240, 40), `"reviewer"`)
+	_, _ = h.Update(old)
+	require.Equal(t, "reviewer", h.getSessionRenderState(h.getInstanceByID(inst.ID)).account, "late old load reverted account snapshot")
+}

--- a/internal/ui/storage_watcher_external_revision_test.go
+++ b/internal/ui/storage_watcher_external_revision_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+// This regression deliberately does not start the polling goroutine. Each
+// check is one refresh, and the second handle performs a real durable write.
+func TestStorageWatcherExternalWriteInsideOwnSaveWindow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	reader, err := statedb.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reader.Close() })
+	require.NoError(t, reader.Migrate())
+	writer, err := statedb.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writer.Close() })
+	watcher, err := NewStorageWatcher(reader)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = watcher.Close() })
+	settleWatcherInitialLoad(t, watcher, reader)
+
+	watcher.NotifySave()
+	require.NoError(t, writer.SaveInstance(&statedb.InstanceRow{
+		ID: "external", Title: "external committed title", Tool: "claude",
+		Status: "stopped", ProjectPath: t.TempDir(), CreatedAt: time.Now(),
+	}))
+	require.NoError(t, writer.Touch())
+	committed, err := reader.LoadInstanceByID("external")
+	require.NoError(t, err)
+	require.NotNil(t, committed)
+	require.Equal(t, "external committed title", committed.Title)
+
+	watcher.checkAndNotify()
+	select {
+	case <-watcher.ReloadChannel():
+		requireWatcherAppliedRow(t, watcher, reader, "external", "external committed title")
+	default:
+		t.Error("first refresh lost a committed external write inside the own-save window")
+	}
+
+	// No further writes are needed for the required first-refresh notification.
+}

--- a/internal/ui/storage_watcher_gap_proof_test.go
+++ b/internal/ui/storage_watcher_gap_proof_test.go
@@ -1,0 +1,63 @@
+//go:build watcher_proof
+
+package ui
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestStorageWatcherProofSynchronousIssuanceDoesNotProbe(t *testing.T) {
+	h, storage, _ := newWatcherEffectsHome(t)
+	w, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer w.Close()
+	h.storageWatcher = w
+	release := statedb.HoldRegistryObserverForProof(w.observer)
+	done := make(chan struct{})
+	go func() { _, _ = h.Update(storageChangedMsg{}); close(done) }()
+	// A held mutex is the deterministic cause, not a slow database or sleep.
+	select {
+	case <-done:
+		release()
+	case <-time.After(time.Second):
+		release()
+		<-done
+		t.Fatal("Update waited for observer I/O lock before returning its command")
+	}
+}
+
+func TestStorageWatcherProofDelayedUnticketedLoad(t *testing.T) {
+	for _, kind := range []string{"initial", "manual"} {
+		t.Run(kind, func(t *testing.T) {
+			h, storage, inst := newWatcherEffectsHome(t)
+			inst.Tool = "shell"
+			require.NoError(t, storage.SaveWithGroups(h.instances, h.groupTree))
+			w, err := NewStorageWatcher(storage.GetDB())
+			require.NoError(t, err)
+			defer w.Close()
+			h.storageWatcher = w
+			var old tea.Msg
+			if kind == "initial" {
+				old = h.loadSessions()
+			} else {
+				_, cmd := h.handleMainKey(tea.KeyMsg{Type: tea.KeyCtrlR})
+				require.NotNil(t, cmd)
+				old = cmd()
+			}
+			// Deliver the old asynchronous result only after a newer watcher result.
+			require.NoError(t, storage.GetDB().SaveInstance(&statedb.InstanceRow{ID: inst.ID, Title: "newest", Tool: "shell", Status: "stopped", ProjectPath: inst.ProjectPath}))
+			_, batch := h.Update(storageChangedMsg{})
+			require.NotNil(t, batch)
+			commands := batch().(tea.BatchMsg)
+			require.NotEmpty(t, commands)
+			_, _ = h.Update(commands[0]())
+			require.Equal(t, "newest", h.getInstanceByID(inst.ID).GetTitleThreadSafe())
+			_, _ = h.Update(old)
+			require.Equal(t, "newest", h.getInstanceByID(inst.ID).GetTitleThreadSafe(), "old persisted load replaced newer applied state")
+		})
+	}
+}

--- a/internal/ui/storage_watcher_observer_test.go
+++ b/internal/ui/storage_watcher_observer_test.go
@@ -1,0 +1,149 @@
+package ui
+
+import (
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func requireWatcherSignal(t *testing.T, w *StorageWatcher) {
+	t.Helper()
+	select {
+	case <-w.ReloadChannel():
+	default:
+		t.Fatal("expected reload")
+	}
+}
+func requireNoWatcherSignal(t *testing.T, w *StorageWatcher) {
+	t.Helper()
+	select {
+	case <-w.ReloadChannel():
+		t.Fatal("unexpected reload")
+	default:
+	}
+}
+func acknowledgeWatcher(t *testing.T, w *StorageWatcher, db *statedb.StateDB) {
+	t.Helper()
+	ticket, err := w.beginLoad()
+	require.NoError(t, err)
+	snapshot, err := db.LoadRegistrySnapshot()
+	require.NoError(t, err)
+	ticket, err = w.endLoad(ticket)
+	require.NoError(t, err)
+	w.acknowledge(ticket, snapshot, true)
+}
+func TestStorageWatcherMaterialChangesIgnoreTimestamp(t *testing.T) {
+	for _, stamp := range []string{"0", "100", "-1"} {
+		t.Run(stamp, func(t *testing.T) {
+			db := newTestDB(t)
+			require.NoError(t, db.SetMeta("last_modified", stamp))
+			w, err := NewStorageWatcher(db)
+			require.NoError(t, err)
+			defer w.Close()
+			settleWatcherInitialLoad(t, w, db)
+			require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "a", Title: "one", Status: "stopped"}))
+			require.NoError(t, db.SetMeta("last_modified", stamp))
+			w.checkAndNotify()
+			requireWatcherSignal(t, w)
+			requireWatcherAppliedRow(t, w, db, "a", "one")
+			w.checkAndNotify()
+			requireNoWatcherSignal(t, w)
+			require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "a", Title: "one", Status: "running"}))
+			w.checkAndNotify()
+			requireWatcherSignal(t, w)
+			row, err := db.LoadInstanceByID("a")
+			require.NoError(t, err)
+			require.Equal(t, "running", row.Status)
+			requireWatcherAppliedRow(t, w, db, "a", "one")
+		})
+	}
+}
+func TestStorageWatcherMetadataOnlyDoesNotReload(t *testing.T) {
+	db := newTestDB(t)
+	w, err := NewStorageWatcher(db)
+	require.NoError(t, err)
+	defer w.Close()
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	acknowledgeWatcher(t, w, db)
+	require.NoError(t, db.Touch())
+	w.checkAndNotify()
+	requireNoWatcherSignal(t, w)
+}
+func TestStorageWatcherFailedAndStaleLoadCannotAcknowledge(t *testing.T) {
+	db := newTestDB(t)
+	w, err := NewStorageWatcher(db)
+	require.NoError(t, err)
+	defer w.Close()
+	old, err := w.beginLoad()
+	require.NoError(t, err)
+	latest, err := w.beginLoad()
+	require.NoError(t, err)
+	require.False(t, w.current(old))
+	require.True(t, w.current(latest))
+	w.acknowledge(latest, nil, false)
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	w.acknowledge(old, &statedb.RegistrySnapshotResult{}, true)
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	acknowledgeWatcher(t, w, db)
+	w.checkAndNotify()
+	requireNoWatcherSignal(t, w)
+}
+func TestStorageWatcherCommitDuringLoadSurvivesAck(t *testing.T) {
+	db := newTestDB(t)
+	w, err := NewStorageWatcher(db)
+	require.NoError(t, err)
+	defer w.Close()
+	ticket, err := w.beginLoad()
+	require.NoError(t, err)
+	snapshot, err := db.LoadRegistrySnapshot()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "late", Title: "late"}))
+	ticket, err = w.endLoad(ticket)
+	require.NoError(t, err)
+	w.acknowledge(ticket, snapshot, true)
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	acknowledgeWatcher(t, w, db)
+	w.checkAndNotify()
+	requireNoWatcherSignal(t, w)
+}
+func TestStorageWatcherCloseIsIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	w, err := NewStorageWatcher(db)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, w.Close())
+	w.TriggerReload()
+	w.checkAndNotify()
+	requireNoWatcherSignal(t, w)
+}
+
+func TestStorageWatcherInitialUnboundLoadRequiresRefresh(t *testing.T) {
+	db := newTestDB(t)
+	w, err := NewStorageWatcher(db)
+	require.NoError(t, err)
+	defer w.Close()
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	acknowledgeWatcher(t, w, db)
+	w.checkAndNotify()
+	requireNoWatcherSignal(t, w)
+}
+func TestStorageWatcherEpochChangeCannotAcknowledge(t *testing.T) {
+	db := newTestDB(t)
+	w, err := NewStorageWatcher(db)
+	require.NoError(t, err)
+	defer w.Close()
+	ticket, err := w.beginLoad()
+	require.NoError(t, err)
+	snap, err := db.LoadRegistrySnapshot()
+	require.NoError(t, err)
+	ticket, err = w.endLoad(ticket)
+	require.NoError(t, err)
+	ticket.afterEpoch++
+	w.acknowledge(ticket, snap, true)
+	requireWatcherSignal(t, w)
+}

--- a/internal/ui/storage_watcher_ordering_test.go
+++ b/internal/ui/storage_watcher_ordering_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageWatcherHomeOrdersLoadsWithoutWatcher(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	older := h.sessionLoadCmd(nil, false)
+	oldResult := older()
+	require.NoError(t, storage.GetDB().SaveInstance(&statedb.InstanceRow{ID: inst.ID, Title: "newer", Tool: "shell", Status: "stopped", ProjectPath: inst.ProjectPath}))
+	newer := h.sessionLoadCmd(nil, false)
+	_, _ = h.Update(newer())
+	_, _ = h.Update(oldResult)
+	require.Equal(t, "newer", h.getInstanceByID(inst.ID).GetTitleThreadSafe())
+}
+
+func TestStorageWatcherHomeIssuancePrecedesCommandExecution(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	w, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer w.Close()
+	h.storageWatcher = w
+	older := h.sessionLoadCmd(nil, false)
+	newer := h.sessionLoadCmd(nil, false)
+	newResult := newer().(loadSessionsMsg)
+	// Even if an older command executes later, it must not acquire a newer ticket.
+	oldResult := older().(loadSessionsMsg)
+	require.True(t, w.current(*newResult.watcherTicket))
+	require.False(t, w.current(*oldResult.watcherTicket))
+	_, _ = h.Update(newResult)
+	_, _ = h.Update(oldResult)
+	require.Equal(t, inst.ID, h.instances[0].ID)
+}
+
+func TestStorageWatcherHomeRejectsReplacedWatcher(t *testing.T) {
+	h, storage, _ := newWatcherEffectsHome(t)
+	first, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer first.Close()
+	h.storageWatcher = first
+	cmd := h.sessionLoadCmd(nil, false)
+	msg := cmd().(loadSessionsMsg)
+	second, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer second.Close()
+	h.storageWatcher = second
+	h.instances = nil
+	_, _ = h.Update(msg)
+	require.Empty(t, h.instances, "message from replaced watcher applied")
+}
+
+func TestStorageWatcherImportCompletionUsesOrderedRead(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	older := h.sessionLoadCmd(nil, false)
+	oldResult := older()
+	require.NoError(t, storage.GetDB().SaveInstance(&statedb.InstanceRow{ID: inst.ID, Title: "after import", Tool: "shell", Status: "stopped", ProjectPath: inst.ProjectPath}))
+	_, cmd := h.Update(importReloadMsg{})
+	require.NotNil(t, cmd)
+	_, _ = h.Update(cmd())
+	_, _ = h.Update(oldResult)
+	require.Equal(t, "after import", h.getInstanceByID(inst.ID).GetTitleThreadSafe())
+}
+
+func TestStorageWatcherImportFailureDoesNotAcknowledge(t *testing.T) {
+	h, storage, _ := newWatcherEffectsHome(t)
+	w, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer w.Close()
+	h.storageWatcher = w
+	acknowledged := w.acknowledged
+	_, _ = h.Update(loadSessionsMsg{err: errors.New("discovery failed")})
+	require.Same(t, acknowledged, w.acknowledged)
+	require.True(t, w.pending)
+	require.NoError(t, storage.Close())
+	_, cmd := h.Update(importReloadMsg{})
+	_, _ = h.Update(cmd())
+	require.Same(t, acknowledged, w.acknowledged)
+	require.True(t, w.pending)
+	require.Error(t, h.err)
+}

--- a/internal/ui/storage_watcher_process_test.go
+++ b/internal/ui/storage_watcher_process_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/stretchr/testify/require"
@@ -73,7 +75,10 @@ var watcherBuildCaches map[string]string
 var watcherBuildCacheErr error
 
 func resolveWatcherBuildCaches(env []string) (map[string]string, error) {
-	cmd := exec.Command("go", "env", "-json", "GOCACHE", "GOMODCACHE")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "env", "-json", "GOCACHE", "GOMODCACHE")
+	cmd.WaitDelay = time.Second
 	cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
@@ -115,7 +120,11 @@ func TestStorageWatcherBuildCacheDefaultsSurviveHomeIsolation(t *testing.T) {
 	caches, err := resolveWatcherBuildCaches(env)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(harness, "go", "pkg", "mod"), caches["GOMODCACHE"])
-	require.Equal(t, filepath.Join(harness, ".cache", "go-build"), caches["GOCACHE"])
+	t.Setenv("HOME", harness)
+	t.Setenv("XDG_CACHE_HOME", "")
+	cacheRoot, err := os.UserCacheDir()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(cacheRoot, "go-build"), caches["GOCACHE"])
 	require.NoError(t, watcherBuildCacheErr)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("GOMODCACHE", "")

--- a/internal/ui/storage_watcher_process_test.go
+++ b/internal/ui/storage_watcher_process_test.go
@@ -1,9 +1,12 @@
 package ui
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
@@ -22,6 +25,8 @@ func TestStorageWatcherExternalProcessHelper(t *testing.T) {
 	require.NoError(t, err) // Deliberately no Touch: legacy metadata is unchanged.
 }
 func TestStorageWatcherRealProcessesOneRefresh(t *testing.T) {
+	require.NoError(t, watcherBuildCacheErr)
+	t.Setenv("GOMODCACHE", "") // Reproduce CI with no explicit cache after HOME changes.
 	h, storage, inst := newWatcherEffectsHome(t)
 	w, err := NewStorageWatcher(storage.GetDB())
 	require.NoError(t, err)
@@ -50,10 +55,68 @@ func TestStorageWatcherRealProcessesOneRefresh(t *testing.T) {
 	applyRefresh("raw-process-title")
 	binary := filepath.Join(t.TempDir(), "agent-deck")
 	build := exec.Command("go", "build", "-p", "1", "-o", binary, "../../cmd/agent-deck")
+	build.Env = watcherBuildEnvironment(os.Environ())
 	out, err = build.CombinedOutput()
 	require.NoError(t, err, string(out))
 	cli := exec.Command(binary, "-p", h.profile, "session", "set", inst.ID, "title", "cli-process-title")
 	out, err = cli.CombinedOutput()
 	require.NoError(t, err, string(out))
 	applyRefresh("cli-process-title")
+}
+
+var watcherBuildCaches map[string]string
+var watcherBuildCacheErr error
+
+func resolveWatcherBuildCaches(env []string) (map[string]string, error) {
+	cmd := exec.Command("go", "env", "-json", "GOCACHE", "GOMODCACHE")
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("resolve test build caches: %w", err)
+	}
+	var caches map[string]string
+	if err = json.Unmarshal(out, &caches); err != nil {
+		return nil, err
+	}
+	for _, key := range []string{"GOCACHE", "GOMODCACHE"} {
+		if !filepath.IsAbs(caches[key]) {
+			return nil, fmt.Errorf("invalid %s for test build", key)
+		}
+	}
+	return caches, nil
+}
+func watcherBuildEnvironment(base []string) []string {
+	env := make([]string, 0, len(base)+2)
+	for _, value := range base {
+		key, _, _ := strings.Cut(value, "=")
+		if key != "GOCACHE" && key != "GOMODCACHE" {
+			env = append(env, value)
+		}
+	}
+	return append(env, "GOCACHE="+watcherBuildCaches["GOCACHE"], "GOMODCACHE="+watcherBuildCaches["GOMODCACHE"])
+}
+func TestStorageWatcherBuildCacheDefaultsSurviveHomeIsolation(t *testing.T) {
+	harness := t.TempDir()
+	var env []string
+	for _, value := range os.Environ() {
+		key, _, _ := strings.Cut(value, "=")
+		switch key {
+		case "HOME", "GOPATH", "GOCACHE", "GOMODCACHE", "XDG_CACHE_HOME":
+			continue
+		}
+		env = append(env, value)
+	}
+	env = append(env, "HOME="+harness, "GOPATH="+filepath.Join(harness, "go"))
+	caches, err := resolveWatcherBuildCaches(env)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(harness, "go", "pkg", "mod"), caches["GOMODCACHE"])
+	require.Equal(t, filepath.Join(harness, ".cache", "go-build"), caches["GOCACHE"])
+	require.NoError(t, watcherBuildCacheErr)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GOMODCACHE", "")
+	t.Setenv("GOCACHE", "")
+	buildEnv := watcherBuildEnvironment(os.Environ())
+	require.Contains(t, buildEnv, "GOMODCACHE="+watcherBuildCaches["GOMODCACHE"])
+	require.Contains(t, buildEnv, "GOCACHE="+watcherBuildCaches["GOCACHE"])
+	require.NotEqual(t, filepath.Join(os.Getenv("HOME"), "go", "pkg", "mod"), watcherBuildCaches["GOMODCACHE"])
 }

--- a/internal/ui/storage_watcher_process_test.go
+++ b/internal/ui/storage_watcher_process_test.go
@@ -53,6 +53,9 @@ func TestStorageWatcherRealProcessesOneRefresh(t *testing.T) {
 		require.Equal(t, want, h.getInstanceByID(inst.ID).GetTitleThreadSafe())
 	}
 	applyRefresh("raw-process-title")
+	perTestModules := filepath.Join(os.Getenv("HOME"), "go", "pkg", "mod")
+	_, err = os.Stat(perTestModules)
+	require.True(t, os.IsNotExist(err), "control HOME already contains modules")
 	binary := filepath.Join(t.TempDir(), "agent-deck")
 	build := exec.Command("go", "build", "-p", "1", "-o", binary, "../../cmd/agent-deck")
 	build.Env = watcherBuildEnvironment(os.Environ())
@@ -62,6 +65,8 @@ func TestStorageWatcherRealProcessesOneRefresh(t *testing.T) {
 	out, err = cli.CombinedOutput()
 	require.NoError(t, err, string(out))
 	applyRefresh("cli-process-title")
+	_, err = os.Stat(perTestModules)
+	require.True(t, os.IsNotExist(err), "go build populated per-test HOME with modules; normal cleanup would be unsafe")
 }
 
 var watcherBuildCaches map[string]string

--- a/internal/ui/storage_watcher_process_test.go
+++ b/internal/ui/storage_watcher_process_test.go
@@ -1,0 +1,59 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageWatcherExternalProcessHelper(t *testing.T) {
+	path := os.Getenv("WATCHER_PROCESS_DB")
+	if path == "" {
+		return
+	}
+	db, err := statedb.Open(path)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.DB().Exec("UPDATE instances SET title = ? WHERE id = ?", "raw-process-title", os.Getenv("WATCHER_PROCESS_ID"))
+	require.NoError(t, err) // Deliberately no Touch: legacy metadata is unchanged.
+}
+func TestStorageWatcherRealProcessesOneRefresh(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	w, err := NewStorageWatcher(storage.GetDB())
+	require.NoError(t, err)
+	defer w.Close()
+	h.storageWatcher = w
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	acknowledgeWatcher(t, w, storage.GetDB())
+	child := exec.Command(os.Args[0], "-test.run=^TestStorageWatcherExternalProcessHelper$", "-test.timeout=30s")
+	child.Env = append(os.Environ(), "WATCHER_PROCESS_DB="+storage.Path(), "WATCHER_PROCESS_ID="+inst.ID)
+	out, err := child.CombinedOutput()
+	require.NoError(t, err, string(out))
+	applyRefresh := func(want string) {
+		w.checkAndNotify()
+		requireWatcherSignal(t, w)
+		ticket, err := w.beginLoad()
+		require.NoError(t, err)
+		instances, groups, raw, err := storage.LoadWithGroupsSnapshot()
+		require.NoError(t, err)
+		ticket, err = w.endLoad(ticket)
+		require.NoError(t, err)
+		state := h.preserveState()
+		_, _ = h.Update(loadSessionsMsg{instances: instances, groups: groups, persistedSnapshot: raw, watcherTicket: &ticket, restoreState: &state})
+		require.Equal(t, want, h.getInstanceByID(inst.ID).GetTitleThreadSafe())
+	}
+	applyRefresh("raw-process-title")
+	binary := filepath.Join(t.TempDir(), "agent-deck")
+	build := exec.Command("go", "build", "-p", "1", "-o", binary, "../../cmd/agent-deck")
+	out, err = build.CombinedOutput()
+	require.NoError(t, err, string(out))
+	cli := exec.Command(binary, "-p", h.profile, "session", "set", inst.ID, "title", "cli-process-title")
+	out, err = cli.CombinedOutput()
+	require.NoError(t, err, string(out))
+	applyRefresh("cli-process-title")
+}

--- a/internal/ui/storage_watcher_reload_effects_test.go
+++ b/internal/ui/storage_watcher_reload_effects_test.go
@@ -1,0 +1,90 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func newWatcherEffectsHome(t *testing.T) (*Home, *session.Storage, *session.Instance) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	storage, err := session.NewStorageWithProfile("_watcher_effects")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storage.Close() })
+	h := NewHome()
+	if h.storageWatcher != nil {
+		_ = h.storageWatcher.Close()
+	}
+	h.storageWatcher = nil
+	h.storage = storage
+	h.profile = "_watcher_effects"
+	h.width, h.height = 100, 30
+	inst := session.NewInstanceWithTool("original", t.TempDir(), "opencode")
+	inst.OpenCodeDetectedAt = time.Now().Add(-time.Minute)
+	h.instances = []*session.Instance{inst}
+	h.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	h.groupTree = session.NewGroupTree(h.instances)
+	require.NoError(t, storage.SaveWithGroups(h.instances, h.groupTree))
+	return h, storage, inst
+}
+
+// Repeated unsuccessful detection is the save-producing edge of the reload
+// feedback cycle. A completed identical negative result must be idempotent.
+func TestStorageWatcherRepeatedNegativeDetectionDoesNotSave(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	before, err := storage.GetDB().LastModified()
+	require.NoError(t, err)
+	completedAt := inst.OpenCodeDetectedAt
+	_, _ = h.Update(openCodeDetectionCompleteMsg{instanceID: inst.ID})
+	after, err := storage.GetDB().LastModified()
+	require.NoError(t, err)
+	require.Equal(t, before, after, "identical negative detection must not create another watcher revision")
+	require.Equal(t, completedAt, inst.OpenCodeDetectedAt, "completed negative result must not refresh its timestamp on every reload")
+}
+
+// A real closed database makes the reapplied save fail deterministically.
+// The pending intent must survive so a successful later retry can persist it.
+func TestStorageWatcherReloadFailedSaveRetainsPendingTitle(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	inst.Tool = "shell" // this control is independent of OpenCode detection
+	h.pendingTitleChanges = map[string]pendingTitle{
+		inst.ID: {title: "operator pending rename", locked: true},
+	}
+	state := h.preserveState()
+	require.NoError(t, storage.Close())
+	_, _ = h.Update(loadSessionsMsg{instances: []*session.Instance{inst}, restoreState: &state})
+	require.Error(t, h.err, "control must reach the failing storage save")
+	require.Equal(t, "operator pending rename", h.getInstanceByID(inst.ID).GetTitleThreadSafe())
+	pending, exists := h.pendingTitleChanges[inst.ID]
+	require.True(t, exists, "failed save discarded the only durable-retry intent")
+	require.Equal(t, "operator pending rename", pending.title)
+}
+
+func TestStorageWatcherNegativeThenExplicitPositive(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	_, _ = h.Update(openCodeDetectionCompleteMsg{instanceID: inst.ID, sessionID: "explicit-later-session"})
+	row, err := storage.GetDB().LoadInstanceByID(inst.ID)
+	require.NoError(t, err)
+	require.Contains(t, string(row.ToolData), "explicit-later-session")
+}
+
+func TestStorageWatcherReloadFailedSaveRetainsPendingGroup(t *testing.T) {
+	h, storage, inst := newWatcherEffectsHome(t)
+	inst.Tool = "shell"
+	h.pendingGroupOps = []pendingGroupOp{{kind: groupOpCreate, name: "pending-group"}}
+	state := h.preserveState()
+	require.NoError(t, storage.Close())
+	_, _ = h.Update(loadSessionsMsg{instances: []*session.Instance{inst}, restoreState: &state})
+	require.Error(t, h.err)
+	require.NotNil(t, h.groupTree.Groups["pending-group"])
+	require.Len(t, h.pendingGroupOps, 1, "failed save must retain group retry intent")
+}

--- a/internal/ui/storage_watcher_test.go
+++ b/internal/ui/storage_watcher_test.go
@@ -32,43 +32,37 @@ func TestStorageWatcher_DetectsChanges(t *testing.T) {
 	watcher, err := NewStorageWatcher(db)
 	require.NoError(t, err)
 	defer watcher.Close()
+	settleWatcherInitialLoad(t, watcher, db)
 
 	watcher.Start()
 
 	// Simulate an external change (another instance touching the metadata)
 	time.Sleep(50 * time.Millisecond)
-	require.NoError(t, db.Touch())
+	require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "changed", Title: "changed"}))
 
 	// Should receive reload signal within the poll interval
 	select {
 	case <-watcher.ReloadChannel():
-		// Success
+		requireWatcherAppliedRow(t, watcher, db, "changed", "changed")
 	case <-time.After(5 * time.Second):
 		t.Fatal("Expected reload signal but got timeout")
 	}
 }
 
-func TestStorageWatcher_NotifySaveIgnoresOwnChanges(t *testing.T) {
+func TestStorageWatcher_NotifySaveDoesNotSuppressOwnChanges(t *testing.T) {
 	db := newTestDB(t)
 	watcher, err := NewStorageWatcher(db)
 	require.NoError(t, err)
 	defer watcher.Close()
-
-	watcher.Start()
-
-	// Notify that we're about to save (simulating TUI save)
+	settleWatcherInitialLoad(t, watcher, db)
 	watcher.NotifySave()
-
-	// Touch metadata (this simulates TUI's own save via storage.SaveWithGroups)
-	time.Sleep(10 * time.Millisecond)
-	require.NoError(t, db.Touch())
-
-	// Should NOT receive reload signal (within ignore window)
+	require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "own", Title: "own"}))
+	watcher.checkAndNotify()
 	select {
 	case <-watcher.ReloadChannel():
-		t.Fatal("Should not receive reload signal for TUI's own save")
-	case <-time.After(3 * time.Second):
-		// Success: no reload signal received
+		requireWatcherAppliedRow(t, watcher, db, "own", "own")
+	default:
+		t.Fatal("own material change must conservatively reload")
 	}
 }
 
@@ -77,6 +71,7 @@ func TestStorageWatcher_ExternalChangesStillDetected(t *testing.T) {
 	watcher, err := NewStorageWatcher(db)
 	require.NoError(t, err)
 	defer watcher.Close()
+	settleWatcherInitialLoad(t, watcher, db)
 
 	watcher.Start()
 
@@ -87,12 +82,12 @@ func TestStorageWatcher_ExternalChangesStillDetected(t *testing.T) {
 	time.Sleep(4 * time.Second)
 
 	// Now an external change should be detected
-	require.NoError(t, db.Touch())
+	require.NoError(t, db.SaveInstance(&statedb.InstanceRow{ID: "changed", Title: "changed"}))
 
 	// Should receive reload signal (outside ignore window)
 	select {
 	case <-watcher.ReloadChannel():
-		// Success
+		requireWatcherAppliedRow(t, watcher, db, "changed", "changed")
 	case <-time.After(5 * time.Second):
 		t.Fatal("Expected reload signal for external change but got timeout")
 	}
@@ -108,6 +103,7 @@ func TestStorageWatcher_CrossProfileIsolation(t *testing.T) {
 	watcher1, err := NewStorageWatcher(db1)
 	require.NoError(t, err)
 	defer watcher1.Close()
+	settleWatcherInitialLoad(t, watcher1, db1)
 	watcher1.Start()
 
 	// Touch db2's metadata (simulating another profile saving)
@@ -123,11 +119,11 @@ func TestStorageWatcher_CrossProfileIsolation(t *testing.T) {
 	}
 
 	// Watcher1 SHOULD fire when its own database changes
-	require.NoError(t, db1.Touch())
+	require.NoError(t, db1.SaveInstance(&statedb.InstanceRow{ID: "changed", Title: "changed"}))
 
 	select {
 	case <-watcher1.ReloadChannel():
-		// Success
+		requireWatcherAppliedRow(t, watcher1, db1, "changed", "changed")
 	case <-time.After(5 * time.Second):
 		t.Fatal("Watcher1 should have detected change to its own database")
 	}
@@ -137,4 +133,32 @@ func TestStorageWatcher_NilDB(t *testing.T) {
 	watcher, err := NewStorageWatcher(nil)
 	require.NoError(t, err)
 	require.Nil(t, watcher)
+}
+
+// Establish the applied startup snapshot before testing a later mutation.
+func settleWatcherInitialLoad(t *testing.T, w *StorageWatcher, db *statedb.StateDB) {
+	t.Helper()
+	w.checkAndNotify()
+	requireWatcherSignal(t, w)
+	acknowledgeWatcher(t, w, db)
+	w.checkAndNotify()
+	requireNoWatcherSignal(t, w)
+}
+func requireWatcherAppliedRow(t *testing.T, w *StorageWatcher, db *statedb.StateDB, id, title string) {
+	t.Helper()
+	ticket, err := w.beginLoad()
+	require.NoError(t, err)
+	snapshot, err := db.LoadRegistrySnapshot()
+	require.NoError(t, err)
+	ticket, err = w.endLoad(ticket)
+	require.NoError(t, err)
+	found := false
+	for _, row := range snapshot.Instances {
+		if row.ID == id {
+			require.Equal(t, title, row.Title)
+			found = true
+		}
+	}
+	require.True(t, found, "refresh did not contain committed row")
+	w.acknowledge(ticket, snapshot, true)
 }

--- a/internal/ui/testmain_test.go
+++ b/internal/ui/testmain_test.go
@@ -24,6 +24,8 @@ func TestMain(m *testing.M) {
 // the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
 // pty-exhaustion incident class).
 func runTestMain(m *testing.M) int {
+	// Resolve tool caches before HOME isolation; only the build-dependent proof uses them.
+	watcherBuildCaches, watcherBuildCacheErr = resolveWatcherBuildCaches(os.Environ())
 	// Isolate HOME+XDG FIRST. This package was the concrete trigger of the
 	// 2026-06-04 data-loss incident (S5): it set AGENTDECK_PROFILE=_test but did
 	// NOT override HOME/XDG, so an un-sandboxed `go test ./internal/ui/...`

--- a/scripts/ci-shared-state-proof.sh
+++ b/scripts/ci-shared-state-proof.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run only in CI or an isolated container, never against a developer's live deck.
+set -euo pipefail
+if [[ "${CI:-}" != "true" && ! -f /.dockerenv ]]; then
+  echo 'Shared-state proof tests require CI or an isolated container.' >&2
+  exit 2
+fi
+# Resolve caches before isolating HOME so setup-go's populated cache is reused.
+export GOCACHE="$(go env GOCACHE)" GOMODCACHE="$(go env GOMODCACHE)"
+sandbox=$(mktemp -d /tmp/adwp.XXXXXX)
+export HOME="$sandbox/home" TMPDIR="$sandbox/tmp"
+mkdir -p "$HOME" "$TMPDIR"
+export XDG_CONFIG_HOME="$HOME/config" XDG_DATA_HOME="$HOME/data" XDG_CACHE_HOME="$HOME/cache"
+unset CLAUDE_CONFIG_DIR AGENTDECK_ACCOUNT AGENTDECK_INSTANCE_ID CODEX_HOME CODEX_THREAD_ID TMUX TMUX_TMPDIR
+export GOMAXPROCS=2
+receipt="$sandbox/proof.jsonl"
+go test -json -race -tags watcher_proof -count=1 -p 1 -timeout 3m ./internal/ui -run '^TestStorageWatcherProof' | tee "$receipt"
+python3 - "$receipt" <<'PY'
+import json
+import sys
+
+expected = {
+    "TestStorageWatcherProofSynchronousIssuanceDoesNotProbe",
+    "TestStorageWatcherProofDelayedUnticketedLoad",
+    "TestStorageWatcherProofDelayedUnticketedLoad/initial",
+    "TestStorageWatcherProofDelayedUnticketedLoad/manual",
+}
+ran, passed = set(), set()
+with open(sys.argv[1], encoding="utf-8") as stream:
+    for line in stream:
+        event = json.loads(line)
+        action, test = event.get("Action"), event.get("Test")
+        if action in {"skip", "fail", "build-fail"}:
+            raise SystemExit(f"Required proof did not pass: {event}")
+        if test and action == "run":
+            ran.add(test)
+        if test and action == "pass":
+            passed.add(test)
+if ran != expected or passed != expected:
+    raise SystemExit(f"Required proof coverage mismatch: ran={ran}, passed={passed}")
+print("Shared-state proofs: all required controls ran and passed; zero skips.")
+PY


### PR DESCRIPTION
## Problem and behavior

Two running Deck controllers could lose a shared session update when another process committed during the watcher's own-save suppression window. Reloads could also trigger repeated identical OpenCode saves or discard pending rename/group intent after a failed save.

This change observes committed registry changes through a live read-only SQLite connection and compares persisted snapshots. Loads receive ordered identities before asynchronous work starts, so an older initial, manual, or watcher result cannot replace a newer applied result. Database probing runs off the UI event loop. Connection epochs prevent a reconnected observer from acknowledging an older connection's version. Pending title/group operations survive unsuccessful persistence.

## Verification

- Preserved three behavioral baseline failures and separate regressions for blocked UI issuance and delayed initial/manual results overwriting newer state.
- Bounded race verification covers actual separate CLI and raw-SQL writers (including a writer that does not update legacy metadata), pending title/group recovery, restart interactions, read-only observation, reconnect/epoch boundaries, and load ordering.
- The first bounded candidate run exposed a cross-profile fixture consuming the intentional initial refresh. The corrected fixtures explicitly apply/acknowledge startup, then assert profile isolation and the actual committed row after a subsequent refresh. The affected race subset passes. These receipts are overlapping scopes, not additive test counts.
- The existing ordinary CI suite covers the standard regressions. An additional bounded CI step runs the tagged observer-lock and delayed-result proofs, requiring every named control to run and pass with zero skips. Its receipt validator rejects missing, skipped and failed controls.

A subsequent bounded race run on the composition with current main verifies account-slot mutation through the watcher into the displayed row/card, the account render/concurrency controls, and actual CLI/raw-SQL refresh. The child build resolves its tool caches before HOME isolation; a missing-cache control confirms no module cache is created under the per-test HOME and normal cleanup succeeds. The repository-owned tagged CI proof script also passes on that exact tree. This combined Linux race run executed 14 required top-level controls with 81 passing test/subtest events and zero skips.

A subsequent test-only portability correction derives the build-cache default from the platform cache directory and bounds the cache probe. Its one affected control was rerun on Linux and passed; the prior combined run was not repeated or counted twice. This is not a claim of a Darwin runtime test.

The earlier hosted eval failure from a module cache created under temporary HOME is retained and corrected. Exact new-head CI remains required before merge. No full-suite pass or completed SSH release is claimed by this PR.
