### PR TITLE
feat(doctor): warn about shared named Claude account directories

### DIFF
--- a/cmd/agent-deck/doctor_cmd.go
+++ b/cmd/agent-deck/doctor_cmd.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func handleDoctor(args []string) {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	jsonOutput := fs.Bool("json", false, "Output account directory diagnostics as JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: agent-deck doctor [--json]\n\nCheck named Claude slots configured as [profiles.<name>.claude].config_dir.\nWarn when slots share a directory; missing or unreadable paths remain unknown.\nThis reads directory metadata only and does not verify live login identities.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return
+		}
+		os.Exit(2)
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "doctor does not accept positional arguments")
+		os.Exit(2)
+	}
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: load config: %q\n", err.Error())
+		os.Exit(1)
+	}
+	slots := session.DiagnoseClaudeAccountDirectories(config)
+	if *jsonOutput {
+		report := struct {
+			AccountSlots []session.AccountDirectoryDiagnostic `json:"account_slots"`
+		}{slots}
+		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: encode diagnostics: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	fmt.Println("Named Claude account directories:")
+	if len(slots) == 0 {
+		fmt.Println("No named Claude account slots configured.")
+		return
+	}
+	for _, slot := range slots {
+		fmt.Printf("%s slot %q: %q (path: %s)", strings.ToUpper(slot.State), slot.Name, slot.ConfigDir, slot.PathState)
+		if len(slot.SharedWith) > 0 {
+			fmt.Print("; shared with")
+			for _, name := range slot.SharedWith {
+				fmt.Printf(" %q", name)
+			}
+		}
+		if slot.Reason != "" {
+			fmt.Printf("; %s", slot.Reason)
+		}
+		fmt.Println()
+	}
+}

--- a/cmd/agent-deck/doctor_cmd_test.go
+++ b/cmd/agent-deck/doctor_cmd_test.go
@@ -117,14 +117,35 @@ config_dir = '~/missing'
 
 func TestDoctorRemoteNeverRunsLocally(t *testing.T) {
 	home := t.TempDir()
+	configDir := filepath.Join(home, ".agent-deck")
+	if err := os.Mkdir(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	config := "[remotes.example]\nhost='unused.invalid'\n[profiles.local.claude]\nconfig_dir='~/local'\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(home, "bin")
+	if err := os.Mkdir(shim, 0700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(home, "ssh-called")
+	if err := os.WriteFile(filepath.Join(shim, "ssh"), []byte("#!/bin/sh\nprintf called > \"$DOCTOR_SSH_SENTINEL\"\nexit 99\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shim+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCTOR_SSH_SENTINEL", sentinel)
 	before := snapshotTree(t, home)
 	stdout, stderr, code := runAgentDeck(t, home, "remote", "example", "doctor", "--json")
 	out := strings.ToLower(stdout + stderr)
-	if code == 0 || !strings.Contains(out, "remote") || (!strings.Contains(out, "unknown") && !strings.Contains(out, "unsupported") && !strings.Contains(out, "not supported")) {
-		t.Fatalf("remote must reject unsupported doctor: exit %d: %s", code, out)
+	if code != 2 || !strings.Contains(out, `unsupported remote command "doctor --json"`) {
+		t.Fatalf("configured remote must explicitly reject doctor: exit %d: %s", code, out)
 	}
 	if strings.Contains(out, "account_slots") || strings.Contains(out, "named claude account directories") {
 		t.Fatalf("remote ran doctor locally: %s", out)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("unsupported doctor called SSH: %v", err)
 	}
 	if after := snapshotTree(t, home); !reflect.DeepEqual(before, after) {
 		t.Fatalf("remote rejection changed HOME")

--- a/cmd/agent-deck/doctor_cmd_test.go
+++ b/cmd/agent-deck/doctor_cmd_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDoctorSharedAccountCLI(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "shared")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	configDir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	config := []byte("[profiles.first.claude]\nconfig_dir='~/shared'\n[profiles.second.claude]\nconfig_dir='$HOME/shared'\n")
+	path := filepath.Join(configDir, "config.toml")
+	if err := os.WriteFile(path, config, 0600); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTree(t, home)
+	stdout, stderr, code := runAgentDeck(t, home, "doctor", "--json")
+	if code != 0 {
+		t.Fatalf("doctor exit %d: %s %s", code, stdout, stderr)
+	}
+	var report struct {
+		AccountSlots []struct {
+			Name       string   `json:"name"`
+			State      string   `json:"state"`
+			SharedWith []string `json:"shared_with"`
+		} `json:"account_slots"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("doctor JSON: %v: %s", err, stdout)
+	}
+	if len(report.AccountSlots) != 2 {
+		t.Fatalf("expected two diagnosed slots: %s", stdout)
+	}
+	for _, slot := range report.AccountSlots {
+		if slot.State != "warning" || len(slot.SharedWith) != 1 {
+			t.Fatalf("missing duplicate warning: %s", stdout)
+		}
+	}
+	stdout, stderr, code = runAgentDeck(t, home, "doctor")
+	if code != 0 || !strings.Contains(stdout, "WARNING") || !strings.Contains(stdout, `"first"`) || !strings.Contains(stdout, `"second"`) {
+		t.Fatalf("human warning absent: exit %d: %s %s", code, stdout, stderr)
+	}
+	after := snapshotTree(t, home)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("doctor changed HOME: before=%v after=%v", before, after)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != string(config) {
+		t.Fatalf("doctor changed config: %v", err)
+	}
+}
+
+func TestDoctorHelpAndArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		code int
+	}{
+		{"help", []string{"doctor", "--help"}, 0},
+		{"short_help", []string{"doctor", "-h"}, 0},
+		{"positional", []string{"doctor", "unexpected"}, 2},
+		{"unknown_flag", []string{"doctor", "--unexpected"}, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			before := snapshotTree(t, home)
+			stdout, stderr, code := runAgentDeck(t, home, tc.args...)
+			if code != tc.code {
+				t.Fatalf("exit %d expected %d: %s %s", code, tc.code, stdout, stderr)
+			}
+			if tc.code == 0 && !strings.Contains(stdout+stderr, "named Claude") {
+				t.Fatalf("help missing diagnostic scope: %s %s", stdout, stderr)
+			}
+			if after := snapshotTree(t, home); !reflect.DeepEqual(before, after) {
+				t.Fatalf("command changed HOME")
+			}
+		})
+	}
+}
+
+func TestDoctorQuotesSlotControls(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".agent-deck")
+	if err := os.Mkdir(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	config := `[profiles."bad\u001b\u0007\u000a".claude]
+config_dir = '~/missing'
+[profiles.other.claude]
+config_dir = '~/missing'
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := runAgentDeck(t, home, "doctor")
+	if code != 0 {
+		t.Fatalf("exit %d: %s %s", code, stdout, stderr)
+	}
+	if strings.ContainsAny(stdout, "\x1b\a") || !strings.Contains(stdout, `"bad\x1b\a\n"`) {
+		t.Fatalf("unsafe or unquoted diagnostic: %q", stdout)
+	}
+	if !strings.Contains(stdout, "WARNING") || !strings.Contains(stdout, "path: unknown") {
+		t.Fatalf("missing duplicate/unknown distinction: %s", stdout)
+	}
+}
+
+func TestDoctorRemoteNeverRunsLocally(t *testing.T) {
+	home := t.TempDir()
+	before := snapshotTree(t, home)
+	stdout, stderr, code := runAgentDeck(t, home, "remote", "example", "doctor", "--json")
+	out := strings.ToLower(stdout + stderr)
+	if code == 0 || !strings.Contains(out, "remote") || (!strings.Contains(out, "unknown") && !strings.Contains(out, "unsupported") && !strings.Contains(out, "not supported")) {
+		t.Fatalf("remote must reject unsupported doctor: exit %d: %s", code, out)
+	}
+	if strings.Contains(out, "account_slots") || strings.Contains(out, "named claude account directories") {
+		t.Fatalf("remote ran doctor locally: %s", out)
+	}
+	if after := snapshotTree(t, home); !reflect.DeepEqual(before, after) {
+		t.Fatalf("remote rejection changed HOME")
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -391,6 +391,9 @@ func main() {
 		case "launch":
 			handleLaunch(profile, args[1:])
 			return
+		case "doctor":
+			handleDoctor(args[1:])
+			return
 		case "accounts":
 			handleAccounts(args[1:])
 			return
@@ -1047,7 +1050,7 @@ func main() {
 // (launch/add --parent, group move --position) is not shadowed by the global
 // profile flag. KEEP IN SYNC with the switch in main().
 var commandRegistry = map[string]bool{
-	"add": true, "accounts": true, "list": true, "ls": true, "remove": true, "rm": true,
+	"add": true, "accounts": true, "doctor": true, "list": true, "ls": true, "remove": true, "rm": true,
 	"rename": true, "mv": true, "status": true, "profile": true, "update": true,
 	"session": true, "fleet": true, "mcp": true, "plugin": true, "skill": true, "mcp-proxy": true,
 	"group": true, "try": true, "launch": true, "conductor": true,
@@ -3630,6 +3633,7 @@ func printHelp() {
 	fmt.Println("  add <path>       Add a new session")
 	fmt.Println("  launch [path]    Add, start, and optionally send a message in one step")
 	fmt.Println("  accounts         List configured named account slots")
+	fmt.Println("  doctor           Check named Claude account directory sharing")
 	fmt.Println("  try <name>       Quick experiment (create/find dated folder + session)")
 	fmt.Println("  list, ls         List all sessions")
 	fmt.Println("  remove, rm       Remove a session")

--- a/internal/session/account_doctor.go
+++ b/internal/session/account_doctor.go
@@ -64,7 +64,9 @@ func DiagnoseClaudeAccountDirectories(config *UserConfig) []AccountDirectoryDiag
 						report.Reason = "directory cannot be opened"
 					} else {
 						closeErr := directory.Close()
-						if closeErr != nil || info.Mode().Perm()&0111 == 0 {
+						// Keep the literal suffix: cleaning it would bypass the kernel search check.
+						_, searchErr := os.Stat(resolved + string(os.PathSeparator) + ".")
+						if closeErr != nil || searchErr != nil {
 							report.Reason = "directory access is unknown"
 						} else {
 							report.State = "ok"

--- a/internal/session/account_doctor.go
+++ b/internal/session/account_doctor.go
@@ -1,0 +1,96 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// AccountDirectoryDiagnostic describes configuration, not a live login identity.
+// PathState is independent of State: equal missing paths still prove a shared
+// configuration target, even though the directory's accessibility is unknown.
+type AccountDirectoryDiagnostic struct {
+	Name       string   `json:"name"`
+	ConfigDir  string   `json:"config_dir"`
+	State      string   `json:"state"`
+	PathState  string   `json:"path_state"`
+	SharedWith []string `json:"shared_with"`
+	Reason     string   `json:"reason,omitempty"`
+}
+
+type accountDirectoryObservation struct {
+	target string
+	info   os.FileInfo
+}
+
+// DiagnoseClaudeAccountDirectories reads directory metadata only. It neither
+// opens credential files nor creates directories or changes configuration.
+func DiagnoseClaudeAccountDirectories(config *UserConfig) []AccountDirectoryDiagnostic {
+	reports := make([]AccountDirectoryDiagnostic, 0)
+	if config == nil {
+		return reports
+	}
+	names := make([]string, 0, len(config.Profiles))
+	for name, profile := range config.Profiles {
+		if profile.Claude.ConfigDir != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	observations := make([]accountDirectoryObservation, 0, len(names))
+	for _, name := range names {
+		report := AccountDirectoryDiagnostic{Name: name, ConfigDir: config.GetProfileClaudeConfigDir(name), State: "unknown", PathState: "unknown", SharedWith: []string{}}
+		observation := accountDirectoryObservation{}
+		if report.ConfigDir == "" {
+			report.Reason = "configured path expands to empty"
+		} else if !filepath.IsAbs(report.ConfigDir) {
+			report.Reason = "relative directory depends on the launch working directory"
+		} else {
+			// Preserve symlink/.. traversal exactly as the launch environment does.
+			// filepath.Abs/Clean would change its target before EvalSymlinks.
+			target := report.ConfigDir
+			observation.target = target
+			resolved, err := filepath.EvalSymlinks(target)
+			if err != nil {
+				report.Reason = "directory is missing or cannot be resolved"
+			} else {
+				info, err := os.Stat(resolved)
+				if err != nil || !info.IsDir() {
+					report.Reason = "target is not an accessible directory"
+				} else {
+					observation.info = info
+					directory, err := os.Open(resolved)
+					if err != nil {
+						report.Reason = "directory cannot be opened"
+					} else {
+						closeErr := directory.Close()
+						if closeErr != nil || info.Mode().Perm()&0111 == 0 {
+							report.Reason = "directory access is unknown"
+						} else {
+							report.State = "ok"
+							report.PathState = "accessible"
+						}
+					}
+				}
+			}
+		}
+		reports = append(reports, report)
+		observations = append(observations, observation)
+	}
+	for i := range reports {
+		for j := i + 1; j < len(reports); j++ {
+			a, b := observations[i], observations[j]
+			same := a.target != "" && a.target == b.target
+			if !same && a.info != nil && b.info != nil {
+				same = os.SameFile(a.info, b.info)
+			}
+			if same {
+				reports[i].SharedWith = append(reports[i].SharedWith, reports[j].Name)
+				reports[j].SharedWith = append(reports[j].SharedWith, reports[i].Name)
+				reports[i].State = "warning"
+				reports[j].State = "warning"
+			}
+		}
+	}
+	return reports
+}

--- a/internal/session/account_doctor_test.go
+++ b/internal/session/account_doctor_test.go
@@ -1,14 +1,24 @@
 package session
 
 import (
+	"context"
+	"io"
+	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestAccountDoctorDirectories(t *testing.T) {
+	if accountDoctorUnprivileged(t) {
+		return
+	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("DOCTOR_DIR", filepath.Join(home, "shared"))
@@ -78,4 +88,92 @@ func TestAccountDoctorSymlinkParentSemantics(t *testing.T) {
 			require.Equal(t, tc.want, got[0].State)
 		})
 	}
+}
+
+func TestAccountDoctorEffectiveSearchPermission(t *testing.T) {
+	if accountDoctorUnprivileged(t) {
+		return
+	}
+	home := t.TempDir()
+	dir := filepath.Join(home, "read-without-owner-search")
+	require.NoError(t, os.Mkdir(dir, 0700))
+	require.NoError(t, os.Chmod(dir, 0401))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+	f, err := os.Open(dir)
+	require.NoError(t, err, "fixture must permit directory read")
+	require.NoError(t, f.Close())
+	_, err = os.Stat(dir + string(os.PathSeparator) + ".")
+	require.Error(t, err, "fixture must deny effective-identity search")
+	cfg := &UserConfig{Profiles: map[string]ProfileSettings{"owner": {Claude: ProfileClaudeSettings{ConfigDir: dir}}}}
+	got := DiagnoseClaudeAccountDirectories(cfg)
+	require.Equal(t, "unknown", got[0].State)
+	require.Equal(t, "unknown", got[0].PathState)
+}
+
+// Run permission fixtures as an ordinary identity even when the suite is root.
+func accountDoctorUnprivileged(t *testing.T) bool {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		if os.Getenv("DOCTOR_PERMISSION_CHILD") == "1" {
+			require.Equal(t, 65534, os.Geteuid())
+			require.Equal(t, 65534, os.Getegid())
+			groups, err := os.Getgroups()
+			require.NoError(t, err)
+			require.Empty(t, groups)
+			t.Log("permission child verified: uid=65534 gid=65534 supplemental groups empty")
+		}
+		return false
+	}
+	sandbox, err := os.MkdirTemp("/tmp", "doctor-permission-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Only walk this freshly created sandbox. Restore directory ownership before
+		// descending, including leftovers from a timed-out unprivileged child.
+		err := filepath.WalkDir(sandbox, func(path string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				if err := os.Chown(path, 0, 0); err != nil {
+					return err
+				}
+				return os.Chmod(path, 0700)
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.RemoveAll(sandbox))
+	})
+	binary := filepath.Join(sandbox, "session.test")
+	executable, err := os.Executable()
+	require.NoError(t, err)
+	source, err := os.Open(executable)
+	require.NoError(t, err)
+	target, err := os.OpenFile(binary, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
+	require.NoError(t, err)
+	_, copyErr := io.Copy(target, source)
+	require.NoError(t, source.Close())
+	require.NoError(t, target.Close())
+	require.NoError(t, copyErr)
+	require.NoError(t, os.Chmod(binary, 0755))
+	require.NoError(t, os.Chown(sandbox, 65534, 65534))
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, "-test.run=^"+t.Name()+"$", "-test.v", "-test.timeout=30s")
+	cmd.WaitDelay = 2 * time.Second
+	cmd.Dir = sandbox
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "AGENTDECK_") || strings.HasPrefix(key, "XDG_") || key == "HOME" || key == "TMPDIR" || key == "CODEX_HOME" || key == "CLAUDE_CONFIG_DIR" || key == "TMUX" || key == "TMUX_TMPDIR" || key == "DOCTOR_PERMISSION_CHILD" {
+			continue
+		}
+		cmd.Env = append(cmd.Env, entry)
+	}
+	cmd.Env = append(cmd.Env, "HOME="+sandbox, "TMPDIR="+sandbox, "XDG_CONFIG_HOME="+sandbox, "XDG_DATA_HOME="+sandbox, "XDG_CACHE_HOME="+sandbox, "DOCTOR_PERMISSION_CHILD=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: 65534, Gid: 65534, Groups: []uint32{}}}
+	output, err := cmd.CombinedOutput()
+	t.Log(string(output))
+	require.NoError(t, err, "unprivileged permission controls must execute")
+	require.Contains(t, string(output), "permission child verified:")
+	return true
 }

--- a/internal/session/account_doctor_test.go
+++ b/internal/session/account_doctor_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountDoctorDirectories(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOCTOR_DIR", filepath.Join(home, "shared"))
+	t.Setenv("DOCTOR_EMPTY", "")
+	shared := filepath.Join(home, "shared")
+	distinct := filepath.Join(home, "distinct")
+	locked := filepath.Join(home, "locked")
+	for _, p := range []string{shared, distinct, locked} {
+		require.NoError(t, os.Mkdir(p, 0700))
+	}
+	require.NoError(t, os.Symlink(shared, filepath.Join(home, "alias")))
+	require.NoError(t, os.Chmod(locked, 0))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0700) })
+	f, err := os.Open(locked)
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("permission preflight invalid: mode000 directory accessible")
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(home, "file"), []byte("not credentials"), 0600))
+	for _, tc := range []struct{ name, a, b, state, pathState string }{
+		{"tilde_env", "~/shared", "$DOCTOR_DIR", "warning", "accessible"},
+		{"symlink", "~/shared", "~/alias", "warning", "accessible"},
+		{"clean", "~/shared/../shared", "~/shared", "warning", "accessible"},
+		{"distinct", "~/shared", "~/distinct", "ok", "accessible"},
+		{"same_missing", "~/missing", "~/missing", "warning", "unknown"},
+		{"different_missing", "~/missing", "~/other-missing", "unknown", "unknown"},
+		{"same_unreadable", "~/locked", "~/locked", "warning", "unknown"},
+		{"file", "~/file", "~/distinct", "unknown", "unknown"},
+		{"empty_expansion", "$DOCTOR_EMPTY", "$DOCTOR_EMPTY", "unknown", "unknown"},
+		{"relative", "shared", "shared", "unknown", "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &UserConfig{Profiles: map[string]ProfileSettings{"a": {Claude: ProfileClaudeSettings{ConfigDir: tc.a}}, "b": {Claude: ProfileClaudeSettings{ConfigDir: tc.b}}, "codex-only": {Codex: ProfileCodexSettings{ConfigDir: "~/shared"}}, "empty": {}}}
+			got := DiagnoseClaudeAccountDirectories(cfg)
+			require.Len(t, got, 2)
+			require.Equal(t, "a", got[0].Name)
+			require.Equal(t, tc.state, got[0].State)
+			require.Equal(t, tc.pathState, got[0].PathState)
+			if tc.state == "warning" {
+				require.Equal(t, []string{"b"}, got[0].SharedWith)
+				require.Equal(t, []string{"a"}, got[1].SharedWith)
+			} else {
+				require.Empty(t, got[0].SharedWith)
+			}
+		})
+	}
+	require.Empty(t, DiagnoseClaudeAccountDirectories(nil))
+	require.Empty(t, DiagnoseClaudeAccountDirectories(&UserConfig{}))
+}
+
+func TestAccountDoctorSymlinkParentSemantics(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, "other", "nested")
+	for _, p := range []string{target, filepath.Join(home, "shared"), filepath.Join(home, "other", "shared")} {
+		require.NoError(t, os.MkdirAll(p, 0700))
+	}
+	require.NoError(t, os.Symlink(target, filepath.Join(home, "link")))
+	throughLink := home + "/link/../shared"
+	for _, tc := range []struct{ name, other, want string }{
+		{"not_lexical_parent", filepath.Join(home, "shared"), "ok"},
+		{"actual_parent", filepath.Join(home, "other", "shared"), "warning"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &UserConfig{Profiles: map[string]ProfileSettings{"a": {Claude: ProfileClaudeSettings{ConfigDir: throughLink}}, "b": {Claude: ProfileClaudeSettings{ConfigDir: tc.other}}}}
+			require.Equal(t, throughLink, cfg.GetProfileClaudeConfigDir("a"), "runtime must preserve absolute symlink-parent spelling")
+			got := DiagnoseClaudeAccountDirectories(cfg)
+			require.Equal(t, tc.want, got[0].State)
+		})
+	}
+}


### PR DESCRIPTION
Current candidate: `1f5f2e7b3b872eb0172113de791b3dc3cb2e7b95`. Fresh CI is required before merge.

## What problem does this solve?

Named Claude account slots can accidentally share a config directory, so two people expecting separate accounts may use the same files. `agent-deck doctor [--json]` now reports shared configured directories and actual symlink aliases without reading credentials or changing configuration.

## Behavior

Diagnostics are scoped to `[profiles.<name>.claude].config_dir` and use existing environment-variable and tilde expansion. Missing, unreadable and relative directories remain unknown. Equal missing absolute paths still warn about shared configuration; relative paths are not guessed from the command's current directory. Symlink-parent traversal is preserved instead of lexically collapsed. Human output quotes slot names and paths; JSON exposes stable slot names, state, path_state and shared_with.

Existing `accounts` output is unchanged. Doctor can run directly in an SSH login on the shared host. Forwarded `remote <name> doctor` is explicitly rejected before SSH or any local diagnosis. Other tools' account directories and live login identity are outside this command's documented scope.

## Validation

The real CLI regression first failed because doctor did not exist. Independent review identified symlink-parent resolution problems; both wrong-target controls failed on that candidate and passed after correction. Scoped CLI and account-diagnostic race controls passed with zero skips, including duplicate/missing/unreadable/relative/empty paths, aliases, terminal controls, help and HOME/config preservation. Current-main integration received a fresh CLI composition run with a configured remote and SSH sentinel proving unsupported doctor cannot run remotely or locally. Source manifests and affected vet passed; final exact-head CI remains required before merge. Detailed counts and source identities are recorded in the final receipt.

Earlier source-bound validation: `8cec231a824f454d4601e48fda1dde7c79a34fb1` was integrated with main `e92323e8`. The corrected scoped race receipt has 27 passing test/subtest entries and the final CLI composition receipt has 13 passing entries, each with zero failures/skips. These overlap and are not summed. All 2,249 committed files match the final source manifest.


## Permission review correction

Review found that mode bits alone could report a readable directory as accessible even when the caller could not search it. A mode 0401 regression reproduced this on the original candidate. The corrected diagnostic asks the kernel to traverse a literal trailing `/.` after the existing directory-read check, preserving effective-identity permission behavior without opening credentials.

Permission fixtures now execute as a verified unprivileged identity when the suite runs as root. Both mode 000 read denial and mode 0401 search denial remain actual assertions. The final affected race run passed 18 outer test/subtest entries with zero failures or skips, including real CLI controls and the child-run directory matrix; affected vet passed. All 2,249 tracked source files matched the immutable before/after manifest. A failed intermediate fixture setup receipt is retained and is not counted as acceptance.

Current candidate is `1f5f2e7b3b872eb0172113de791b3dc3cb2e7b95`. The original candidate's full CI passed; fresh CI on this correction is required before merge. Latest main `921525dc` has no doctor or session TestMain overlap. No repeated local full suite was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `doctor` command to check configured Claude account directories.
  * Reports shared, missing, inaccessible, invalid, and duplicate directory configurations.
  * Supports both human-readable output and machine-readable JSON with `--json`.
  * Added validation for command arguments and helpful usage guidance.
  * Remote configurations are clearly identified as unsupported for local diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->