### PR TITLE
fix(tui): preserve rapid SSH input and require native macOS acceptance

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -146,3 +146,41 @@ jobs:
           path: ${{ env.NATIVE_SSH_ARTIFACT_DIR }}
           if-no-files-found: error
 
+
+  native-ssh-macos:
+    name: Required macOS native SSH acceptance
+    runs-on: macos-latest
+    timeout-minutes: 25
+    env:
+      NATIVE_SSH_EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ env.NATIVE_SSH_EXPECTED_SHA }}
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: go.mod
+      - name: Prepare disposable runner tools and evidence
+        run: |
+          evidence=$(python3 -c 'import os; print(os.path.realpath(os.environ["RUNNER_TEMP"]) + "/native-ssh-macos-evidence")')
+          mkdir "$evidence"
+          echo "NATIVE_SSH_ARTIFACT_DIR=$evidence" >> "$GITHUB_ENV"
+          id > "$evidence/runner-user.txt"
+          sw_vers > "$evidence/os.txt"
+          uname -m >> "$evidence/os.txt"
+          if ! command -v tmux; then brew install tmux; fi
+          tmux -V > "$evidence/tmux-version.txt"
+          command -v tmux > "$evidence/tmux-path.txt"
+      - name: Require real native SSH execution
+        timeout-minutes: 20
+        run: bash scripts/ci-native-ssh.sh
+      - name: Retain macOS native SSH evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-ssh-macos-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.NATIVE_SSH_ARTIFACT_DIR }}
+          if-no-files-found: error

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,9 +92,13 @@ func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 		}
 		t.Fatalf("real sshd required: %v", err)
 	}
-	if _, err := os.Stat("/usr/bin/cat"); err != nil {
+	authorizedCommand := "/usr/bin/cat"
+	if runtime.GOOS == "darwin" {
+		authorizedCommand = "/bin/cat"
+	}
+	if _, err := os.Stat(authorizedCommand); err != nil {
 		if os.IsNotExist(err) {
-			nativeSSHMissingTool(t, "/usr/bin/cat")
+			nativeSSHMissingTool(t, authorizedCommand)
 		}
 		t.Fatalf("authorized key command required: %v", err)
 	}
@@ -140,7 +145,7 @@ func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 	wrapper := write("remote-command", []byte("#!/bin/sh\nunset XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME TMUX AGENTDECK_PROFILE CLAUDE_CONFIG_DIR\nexport HOME="+quote(remoteHome)+"\nexport PATH="+quote(os.Getenv("PATH"))+"\ncd "+quote(remoteHome)+" || exit 1\nexec /bin/sh -c \"$SSH_ORIGINAL_COMMAND\"\n"))
 	// Read only the disposable key without requiring /tmp ancestry to pass StrictModes.
 	// sshd validates that the absolute command is root-owned and not publicly writable.
-	config := write("sshd_config", []byte(fmt.Sprintf("Port %d\nListenAddress 127.0.0.1\nHostKey %s\nPidFile %s\nAuthorizedKeysFile none\nAuthorizedKeysCommand /usr/bin/cat %s\nAuthorizedKeysCommandUser %s\nStrictModes yes\nUsePAM no\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nPubkeyAuthentication yes\nPermitUserEnvironment no\nAllowUsers %s\nForceCommand %s\nLogLevel VERBOSE\n", port, hostFile, filepath.Join(binDir, "sshd.pid"), authorized, account.Username, account.Username, wrapper)))
+	config := write("sshd_config", []byte(fmt.Sprintf("Port %d\nListenAddress 127.0.0.1\nHostKey %s\nPidFile %s\nAuthorizedKeysFile none\nAuthorizedKeysCommand %s %s\nAuthorizedKeysCommandUser %s\nStrictModes yes\nUsePAM no\nPasswordAuthentication no\nKbdInteractiveAuthentication no\nPubkeyAuthentication yes\nPermitUserEnvironment no\nAllowUsers %s\nForceCommand %s\nLogLevel VERBOSE\n", port, hostFile, filepath.Join(binDir, "sshd.pid"), authorizedCommand, authorized, account.Username, account.Username, wrapper)))
 	logFile, err := os.Create(filepath.Join(binDir, "sshd.log"))
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/agent-deck/native_tui_ssh_test.go
+++ b/cmd/agent-deck/native_tui_ssh_test.go
@@ -180,6 +180,12 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 		nativeRetainFile(t, name, path)
 	}
 	t.Cleanup(func() {
+		_ = filepath.WalkDir(remote, func(path string, entry os.DirEntry, err error) error {
+			if err == nil && !entry.IsDir() && entry.Name() == "debug.log" {
+				nativeRetainFile(t, "tui-debug.log", path)
+			}
+			return nil
+		})
 		if t.Failed() {
 			retain("failure-grid.txt")
 		}
@@ -191,8 +197,7 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 	})
 	retain("initial-grid.txt")
 	firstTUIProcess := readTUIProcess()
-	tmux("send-keys", "-t", "full-tui:0.0", "/")
-	tmux("send-keys", "-l", "-t", "full-tui:0.0", "Beta")
+	tmux("send-keys", "-l", "-t", "full-tui:0.0", "/Beta")
 	wait("actual TUI search filters rows", func() bool { g := grid(); return strings.Contains(g, second) && !strings.Contains(g, first) })
 	retain("search-grid.txt")
 	tmux("send-keys", "-t", "full-tui:0.0", "Escape")

--- a/cmd/agent-deck/native_tui_ssh_test.go
+++ b/cmd/agent-deck/native_tui_ssh_test.go
@@ -3,15 +3,15 @@ package main
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -147,22 +147,30 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 		}
 	})
 	tmux("set-option", "-t", "full-tui", "remain-on-exit", "on")
-	launchNumber:=0
+	launchNumber := 0
 	var pidFile string
 	start := func() {
 		launchNumber++
-		pidFile=filepath.Join(remote,fmt.Sprintf("full-tui-%d.pid",launchNumber))
+		pidFile = filepath.Join(remote, fmt.Sprintf("full-tui-%d.pid", launchNumber))
 		// Each launch has a new exclusive private PID file. exec preserves the
 		// shell PID through env into the exact built full-TUI executable.
-		remoteCommand:="umask 077; set -C; printf '%s' \"$$\" > "+quote(pidFile)+" || exit 1; exec env TERM=xterm-256color AGENTDECK_ACCOUNT=alice "+quote(bin)+" -p default"
-		sshCommand:=quote(filepath.Join(shim,"ssh"))+" -tt test-host "+quote(remoteCommand)
+		remoteCommand := "umask 077; set -C; printf '%s' \"$$\" > " + quote(pidFile) + " || exit 1; exec env TERM=xterm-256color AGENTDECK_ACCOUNT=alice " + quote(bin) + " -p default"
+		sshCommand := quote(filepath.Join(shim, "ssh")) + " -tt test-host " + quote(remoteCommand)
 		tmux("respawn-pane", "-k", "-t", "full-tui:0.0", sshCommand)
 	}
-	readTUIProcess:=func()int {
+	readTUIProcess := func() int {
 		t.Helper()
-		raw,err:=os.ReadFile(pidFile);if err!=nil{t.Fatal(err)}
-		pid,err:=strconv.Atoi(string(raw));if err!=nil || pid<=1{t.Fatalf("invalid private TUI PID: %q %v",raw,err)}
-		if err:=syscall.Kill(pid,0);err!=nil{t.Fatalf("source-defined full TUI process not alive: %d %v",pid,err)}
+		raw, err := os.ReadFile(pidFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pid, err := strconv.Atoi(string(raw))
+		if err != nil || pid <= 1 {
+			t.Fatalf("invalid private TUI PID: %q %v", raw, err)
+		}
+		if err := syscall.Kill(pid, 0); err != nil {
+			t.Fatalf("source-defined full TUI process not alive: %d %v", pid, err)
+		}
 		return pid
 	}
 	grid := func() string { return tmux("capture-pane", "-p", "-t", "full-tui:0.0") }
@@ -182,7 +190,7 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 		return strings.Contains(g, first) && strings.Contains(g, second) && strings.Contains(g, "alice")
 	})
 	retain("initial-grid.txt")
-	firstTUIProcess:=readTUIProcess()
+	firstTUIProcess := readTUIProcess()
 	tmux("send-keys", "-t", "full-tui:0.0", "/")
 	tmux("send-keys", "-l", "-t", "full-tui:0.0", "Beta")
 	wait("actual TUI search filters rows", func() bool { g := grid(); return strings.Contains(g, second) && !strings.Contains(g, first) })
@@ -311,7 +319,7 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 	wait("SSH disconnect exits full TUI client", func() bool {
 		return strings.TrimSpace(tmux("display-message", "-p", "-t", "full-tui:0.0", "#{pane_dead}")) == "1"
 	})
-	wait("source-defined server TUI process reaped after SSH loss",func()bool{return errors.Is(syscall.Kill(firstTUIProcess,0),syscall.ESRCH)})
+	wait("source-defined server TUI process reaped after SSH loss", func() bool { return errors.Is(syscall.Kill(firstTUIProcess, 0), syscall.ESRCH) })
 	assertPreserved()
 	start()
 	wait("reconnected full TUI current list", func() bool {
@@ -319,16 +327,18 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 		return strings.Contains(g, first) && strings.Contains(g, second) && strings.Contains(g, "alice")
 	})
 	retain("reconnected-grid.txt")
-	secondTUIProcess:=readTUIProcess()
-	if firstTUIProcess==secondTUIProcess {t.Fatal("reconnect did not create a distinct TUI process")}
+	secondTUIProcess := readTUIProcess()
+	if firstTUIProcess == secondTUIProcess {
+		t.Fatal("reconnect did not create a distinct TUI process")
+	}
 	wait("persisted selected row restored", func() bool { return selected(grid(), second) })
 	assertPreserved()
 	tmux("send-keys", "-t", "full-tui:0.0", "q")
 	wait("graceful full TUI quit", func() bool {
 		return strings.TrimSpace(tmux("display-message", "-p", "-t", "full-tui:0.0", "#{pane_dead}")) == "1"
 	})
-	wait("source-defined server TUI process reaped after quit",func()bool{return errors.Is(syscall.Kill(secondTUIProcess,0),syscall.ESRCH)})
+	wait("source-defined server TUI process reaped after quit", func() bool { return errors.Is(syscall.Kill(secondTUIProcess, 0), syscall.ESRCH) })
 	assertPreserved()
-	t.Logf("full TUI exec PIDs %d and%d both reached ESRCH after their client lifetime",firstTUIProcess,secondTUIProcess)
+	t.Logf("full TUI exec PIDs %d and%d both reached ESRCH after their client lifetime", firstTUIProcess, secondTUIProcess)
 	t.Logf("preserved registry=%v tmux=%s nonce=%s", before, beforeIdentity, nonce)
 }

--- a/cmd/agent-deck/native_tui_ssh_test.go
+++ b/cmd/agent-deck/native_tui_ssh_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// This starts the full TUI, not the separate session-attach command. An outer
+// private tmux supplies both a real terminal and a current rendered cell grid.
+func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
+	for _, tool := range []string{"ssh", "tmux"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			nativeSSHMissingTool(t, tool)
+		}
+	}
+	if dir := os.Getenv("NATIVE_SSH_RECEIPT_DIR"); dir != "" {
+		t.Setenv("NATIVE_SSH_RECEIPT_DIR", filepath.Join(dir, "full-tui"))
+	}
+	bin := channelsCLIBinary(t)
+	remote, controller, shim := t.TempDir(), t.TempDir(), t.TempDir()
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	quote := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
+	env := func(home string) []string {
+		var out []string
+		for _, item := range os.Environ() {
+			key, _, _ := strings.Cut(item, "=")
+			if key == "HOME" || key == "TERM" || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "TMUX") || strings.HasPrefix(key, "AGENTDECK_") || key == "CLAUDE_CONFIG_DIR" || key == "CODEX_HOME" {
+				continue
+			}
+			out = append(out, item)
+		}
+		return append(out, "HOME="+home, "TERM=xterm-256color", "AGENTDECK_TELEMETRY=0")
+	}
+	command := func(home, executable string, args ...string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, executable, args...)
+		cmd.WaitDelay = time.Second
+		cmd.Dir, cmd.Env = home, env(home)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+	run := func(home, executable string, args ...string) string {
+		t.Helper()
+		out, err := command(home, executable, args...)
+		if err != nil {
+			t.Fatalf("%s %v: %v\n%s", executable, args, err, out)
+		}
+		return out
+	}
+	inner := fmt.Sprintf("nt-in-%d", time.Now().UnixNano())
+	outer := fmt.Sprintf("nt-out-%d", time.Now().UnixNano())
+	write(filepath.Join(remote, ".config", "agent-deck", "config.toml"), "[telemetry]\ndisabled = true\n[claude]\nhooks_enabled = false\n[tmux]\nsocket_name = '"+inner+"'\n[profiles.alice.claude]\nconfig_dir = '"+filepath.Join(remote, "claude-alice")+"'\n")
+	proxy := startNativeSSH(t, remote, shim)
+	cli := func(args ...string) string {
+		t.Helper()
+		return run(remote, bin, append([]string{"-p", "default"}, args...)...)
+	}
+	first, second := "Alpha界", "Betaé"
+	nonce := fmt.Sprintf("TUI-NONCE-%d", time.Now().UnixNano())
+	receiver := filepath.Join(remote, "receiver.sh")
+	write(receiver, "#!/bin/sh\nprintf '%s\\n' "+quote(nonce)+"\nexec sleep 600\n")
+	cli("add", remote, "--title", first, "--cmd", "shell", "--wrapper", "sh "+quote(receiver), "--account", "alice", "--json")
+	cli("add", remote, "--title", second, "--cmd", "shell", "--account", "alice", "--json")
+	cli("session", "start", first, "--json")
+	t.Cleanup(func() {
+		out, err := command(remote, bin, "-p", "default", "session", "stop", first)
+		if err != nil {
+			t.Errorf("owned session cleanup: %v %s", err, out)
+		}
+	})
+	registry := func() map[string]string {
+		t.Helper()
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(cli("list", "--json")), &rows); err != nil {
+			t.Fatal(err)
+		}
+		result := make(map[string]string)
+		for _, row := range rows {
+			id, ok := row["id"].(string)
+			if !ok || id == "" || row["account"] != "alice" {
+				t.Fatalf("invalid registry identity/account: %v", row)
+			}
+			result[fmt.Sprint(row["title"])] = fmt.Sprint(row["id"]) + ":" + fmt.Sprint(row["account"])
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected two independently registered sessions: %v", result)
+		}
+		return result
+	}
+	before := registry()
+	identity := func() string {
+		return strings.TrimSpace(run(remote, "tmux", "-L", inner, "list-panes", "-a", "-F", "#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"))
+	}
+	beforeIdentity := identity()
+	wait := func(label string, condition func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			if condition() {
+				return
+			}
+			time.Sleep(40 * time.Millisecond)
+		}
+		t.Fatalf("timed out: %s", label)
+	}
+	hasNonce := func() bool {
+		for _, line := range strings.Split(cli("session", "output", first), "\n") {
+			if strings.TrimSpace(ansi.Strip(line)) == nonce {
+				return true
+			}
+		}
+		return false
+	}
+	wait("executed standalone startup nonce", hasNonce)
+	tmux := func(args ...string) string {
+		t.Helper()
+		return run(controller, "tmux", append([]string{"-L", outer}, args...)...)
+	}
+	tmux("new-session", "-d", "-s", "full-tui", "-x", "140", "-y", "45", "sleep 600")
+	t.Cleanup(func() {
+		out, err := command(controller, "tmux", "-L", outer, "kill-session", "-t", "full-tui")
+		if err != nil {
+			t.Errorf("owned terminal cleanup: %v %s", err, out)
+		}
+	})
+	tmux("set-option", "-t", "full-tui", "remain-on-exit", "on")
+	launchNumber:=0
+	var pidFile string
+	start := func() {
+		launchNumber++
+		pidFile=filepath.Join(remote,fmt.Sprintf("full-tui-%d.pid",launchNumber))
+		// Each launch has a new exclusive private PID file. exec preserves the
+		// shell PID through env into the exact built full-TUI executable.
+		remoteCommand:="umask 077; set -C; printf '%s' \"$$\" > "+quote(pidFile)+" || exit 1; exec env TERM=xterm-256color AGENTDECK_ACCOUNT=alice "+quote(bin)+" -p default"
+		sshCommand:=quote(filepath.Join(shim,"ssh"))+" -tt test-host "+quote(remoteCommand)
+		tmux("respawn-pane", "-k", "-t", "full-tui:0.0", sshCommand)
+	}
+	readTUIProcess:=func()int {
+		t.Helper()
+		raw,err:=os.ReadFile(pidFile);if err!=nil{t.Fatal(err)}
+		pid,err:=strconv.Atoi(string(raw));if err!=nil || pid<=1{t.Fatalf("invalid private TUI PID: %q %v",raw,err)}
+		if err:=syscall.Kill(pid,0);err!=nil{t.Fatalf("source-defined full TUI process not alive: %d %v",pid,err)}
+		return pid
+	}
+	grid := func() string { return tmux("capture-pane", "-p", "-t", "full-tui:0.0") }
+	retain := func(name string) {
+		path := filepath.Join(controller, name)
+		write(path, grid())
+		nativeRetainFile(t, name, path)
+	}
+	t.Cleanup(func() {
+		if t.Failed() {
+			retain("failure-grid.txt")
+		}
+	})
+	start()
+	wait("full TUI current session list and account", func() bool {
+		g := grid()
+		return strings.Contains(g, first) && strings.Contains(g, second) && strings.Contains(g, "alice")
+	})
+	retain("initial-grid.txt")
+	firstTUIProcess:=readTUIProcess()
+	tmux("send-keys", "-t", "full-tui:0.0", "/")
+	tmux("send-keys", "-l", "-t", "full-tui:0.0", "Beta")
+	wait("actual TUI search filters rows", func() bool { g := grid(); return strings.Contains(g, second) && !strings.Contains(g, first) })
+	retain("search-grid.txt")
+	tmux("send-keys", "-t", "full-tui:0.0", "Escape")
+	wait("escape restores both rows", func() bool { g := grid(); return strings.Contains(g, first) && strings.Contains(g, second) })
+	// Navigate to a non-default row through the real terminal, then wait until
+	// the application's periodic save commits it. Unsaved last-keystroke state
+	// is not promised after a dropped connection.
+	selected := func(g, title string) bool {
+		for _, line := range strings.Split(g, "\n") {
+			if strings.Contains(line, "▶") && strings.Contains(line, title) {
+				return true
+			}
+		}
+		return false
+	}
+	tmux("send-keys", "-t", "full-tui:0.0", "End", "Up")
+	wait("navigation selects running first session", func() bool { return selected(grid(), first) })
+	tmux("send-keys", "-t", "full-tui:0.0", "Enter")
+	wait("TUI Enter attaches actual running pane", func() bool {
+		g := grid()
+		if strings.Contains(g, second) || strings.Contains(g, "SESSIONS") {
+			return false
+		}
+		for _, line := range strings.Split(g, "\n") {
+			if strings.TrimSpace(line) == nonce {
+				return true
+			}
+		}
+		return false
+	})
+	retain("entered-running-pane.txt")
+	if got := identity(); got != beforeIdentity {
+		t.Fatalf("Enter attached replacement identity %s", got)
+	}
+	tmux("send-keys", "-t", "full-tui:0.0", "C-q")
+	wait("CtrlQ returns from actual pane to full TUI", func() bool {
+		g := grid()
+		return strings.Contains(g, "SESSIONS") && strings.Contains(g, first) && strings.Contains(g, second)
+	})
+	if got := identity(); got != beforeIdentity || !hasNonce() {
+		t.Fatal("CtrlQ changed running pane or transcript")
+	}
+	retain("returned-tui.txt")
+	tmux("send-keys", "-t", "full-tui:0.0", "End")
+	wait("navigation selects second session", func() bool { return selected(grid(), second) })
+	var dbPath string
+	if err := filepath.WalkDir(remote, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Name() == "state.db" {
+			if dbPath != "" {
+				return fmt.Errorf("multiple fixture databases")
+			}
+			dbPath = path
+		}
+		return nil
+	}); err != nil || dbPath == "" {
+		t.Fatalf("find fixture registry: %v %q", err, dbPath)
+	}
+	db, err := sql.Open("sqlite", (&url.URL{Scheme: "file", Path: dbPath}).String()+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	wait("selected session persisted before disconnect", func() bool {
+		var raw string
+		if err := db.QueryRow("SELECT value FROM metadata WHERE key=?", "ui_state").Scan(&raw); err != nil {
+			return false
+		}
+		var state struct {
+			Cursor string `json:"cursor_session_id"`
+		}
+		if json.Unmarshal([]byte(raw), &state) != nil {
+			return false
+		}
+		return state.Cursor == strings.TrimSuffix(before[second], ":alice")
+	})
+	oldGrid := grid()
+	dividerColumn := func(g string) int {
+		for _, line := range strings.Split(g, "\n") {
+			if strings.Contains(line, "SESSIONS") && strings.Contains(line, "PREVIEW") {
+				before, _, ok := strings.Cut(line, "│")
+				if ok {
+					return ansi.StringWidth(before)
+				}
+			}
+		}
+		return -1
+	}
+	oldDivider := dividerColumn(oldGrid)
+	if oldDivider < 1 {
+		t.Fatal("initial application divider absent")
+	}
+	tmux("resize-window", "-t", "full-tui:0", "-x", "180", "-y", "52")
+	wait("full TUI resized rendered layout", func() bool {
+		g := grid()
+		// Resizing the outer tmux alone cannot extend the application's old
+		// 140-cell footer to 180 cells or move its SESSIONS/PREVIEW divider.
+		footer := false
+		for _, line := range strings.Split(g, "\n") {
+			if strings.TrimSpace(line) == strings.Repeat("─", 180) {
+				footer = true
+			}
+		}
+		return footer && dividerColumn(g) > oldDivider && g != oldGrid && strings.Contains(g, first) && strings.Contains(g, second) && strings.Contains(g, "alice") && len(strings.Split(strings.TrimSuffix(g, "\n"), "\n")) == 52
+	})
+	t.Logf("application divider moved from column%d to%d; full-width footer180 cells", oldDivider, dividerColumn(grid()))
+	retain("resized-grid.txt")
+	assertPreserved := func() {
+		t.Helper()
+		after := registry()
+		if len(after) != len(before) || after[first] != before[first] || after[second] != before[second] {
+			t.Fatalf("registry identity/account changed: before=%v after=%v", before, after)
+		}
+		if got := identity(); got != beforeIdentity {
+			t.Fatalf("server/session/pane/PID changed: %s != %s", got, beforeIdentity)
+		}
+		if !hasNonce() {
+			t.Fatal("transcript nonce lost")
+		}
+	}
+	proxy.drop()
+	wait("SSH disconnect exits full TUI client", func() bool {
+		return strings.TrimSpace(tmux("display-message", "-p", "-t", "full-tui:0.0", "#{pane_dead}")) == "1"
+	})
+	wait("source-defined server TUI process reaped after SSH loss",func()bool{return errors.Is(syscall.Kill(firstTUIProcess,0),syscall.ESRCH)})
+	assertPreserved()
+	start()
+	wait("reconnected full TUI current list", func() bool {
+		g := grid()
+		return strings.Contains(g, first) && strings.Contains(g, second) && strings.Contains(g, "alice")
+	})
+	retain("reconnected-grid.txt")
+	secondTUIProcess:=readTUIProcess()
+	if firstTUIProcess==secondTUIProcess {t.Fatal("reconnect did not create a distinct TUI process")}
+	wait("persisted selected row restored", func() bool { return selected(grid(), second) })
+	assertPreserved()
+	tmux("send-keys", "-t", "full-tui:0.0", "q")
+	wait("graceful full TUI quit", func() bool {
+		return strings.TrimSpace(tmux("display-message", "-p", "-t", "full-tui:0.0", "#{pane_dead}")) == "1"
+	})
+	wait("source-defined server TUI process reaped after quit",func()bool{return errors.Is(syscall.Kill(secondTUIProcess,0),syscall.ESRCH)})
+	assertPreserved()
+	t.Logf("full TUI exec PIDs %d and%d both reached ESRCH after their client lifetime",firstTUIProcess,secondTUIProcess)
+	t.Logf("preserved registry=%v tmux=%s nonce=%s", before, beforeIdentity, nonce)
+}

--- a/internal/ui/coalesced_input_test.go
+++ b/internal/ui/coalesced_input_test.go
@@ -1,0 +1,132 @@
+package ui
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestCoalescedInputOpensSearchAndPreservesText(t *testing.T) {
+	for _, burst := range []bool{false, true} {
+		name := "sequential"
+		if burst {
+			name = "coalesced"
+		}
+		t.Run(name, func(t *testing.T) {
+			home := NewHome()
+			home.width, home.height = 100, 30
+			home.globalSearchIndex = nil
+			text := "/Betaé界"
+			if burst {
+				home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(text)})
+			} else {
+				for _, r := range text {
+					home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+				}
+			}
+			if !home.search.IsVisible() {
+				t.Fatal("ordered slash plus query did not open search")
+			}
+			if got := home.search.input.Value(); got != "Betaé界" {
+				t.Fatalf("query = %q, want exact Unicode query", got)
+			}
+		})
+	}
+}
+
+func TestCoalescedInputPreservesModalTextAndFlags(t *testing.T) {
+	for _, mode := range []string{"search", "dialog", "alt", "paste"} {
+		t.Run(mode, func(t *testing.T) {
+			h := NewHome()
+			h.width, h.height = 100, 30
+			key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Betaé界")}
+			switch mode {
+			case "search":
+				h.search.Show()
+			case "dialog":
+				h.groupDialog.ShowCreateSubgroup("", "")
+			case "alt":
+				key.Alt = true
+				key.Runes = []rune("/Beta")
+			case "paste":
+				key.Paste = true
+				key.Runes = []rune("/Beta")
+			}
+			h.Update(key)
+			switch mode {
+			case "search":
+				if h.search.input.Value() != "Betaé界" {
+					t.Fatal("search text changed")
+				}
+			case "dialog":
+				if h.groupDialog.nameInput.Value() != "Betaé界" {
+					t.Fatal("dialog text changed")
+				}
+			default:
+				if h.search.IsVisible() {
+					t.Fatal("Alt or bracketed paste incorrectly became shortcut sequence")
+				}
+			}
+		})
+	}
+}
+
+func TestCoalescedInputQuitStopsTailAndRetainsCommand(t *testing.T) {
+	h := NewHome()
+	_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q/Beta")})
+	if !h.isQuitting || h.search.IsVisible() {
+		t.Fatal("quit must stop remaining shortcut/query")
+	}
+	if cmd == nil {
+		t.Fatal("quit command lost")
+	}
+	if _, ok := cmd().(quitMsg); !ok {
+		t.Fatalf("quit command changed: %T", cmd())
+	}
+}
+
+func TestCoalescedInputConfirmationContinues(t *testing.T) {
+	h := NewHome()
+	h.confirmDialog.ShowQuitWithPool(1)
+	h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("lh")})
+	if h.isQuitting || !h.confirmDialog.IsVisible() || h.confirmDialog.GetFocusedButton() != 0 {
+		t.Fatal("confirmation navigation lost or reordered")
+	}
+}
+
+func TestCoalescedInputNavigationRetainsFocusAndRepaintCommands(t *testing.T) {
+	items := scrollTestItems()
+	for i := range items {
+		items[i].Session = session.NewInstance(fmt.Sprintf("focus%d", i), t.TempDir())
+	}
+	h := newTestHomeWithItems(100, 30, items)
+	h.fullRepaint = true
+	_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("jjk")})
+	if h.cursor != 1 {
+		t.Fatalf("ordered navigation cursor=%d, want1", h.cursor)
+	}
+	if cmd == nil {
+		t.Fatal("repaint commands lost")
+	}
+	// Bubble Tea's Sequence message is private. Inspect its command collection
+	// only in this test, then execute owned redraw/preview commands as its loop does.
+	v := reflect.ValueOf(cmd())
+	if v.Kind() != reflect.Slice || v.Len() != 3 {
+		t.Fatalf("each key's command must be retained, got %v", v)
+	}
+	for i := 0; i < v.Len(); i++ {
+		c, ok := v.Index(i).Interface().(tea.Cmd)
+		if !ok || !containsClearScreen(c) {
+			t.Fatalf("key%d lost repaint (%s)", i, fmt.Sprint(v.Index(i)))
+		}
+	}
+	h.focusMu.Lock()
+	name := h.focusedSessionName
+	h.focusMu.Unlock()
+	if want := items[1].Session.GetTmuxSession().Name; name != want {
+		t.Fatalf("focused session = %q, want %q", name, want)
+	}
+}

--- a/internal/ui/coalesced_input_test.go
+++ b/internal/ui/coalesced_input_test.go
@@ -130,3 +130,50 @@ func TestCoalescedInputNavigationRetainsFocusAndRepaintCommands(t *testing.T) {
 		t.Fatalf("focused session = %q, want %q", name, want)
 	}
 }
+
+// A remote row deliberately has no local Instance. Both search and a subsequent
+// creation dialog must retain that routing context while processing a burst.
+func TestCoalescedInputRemoteRowPreservesSearchAndCreationTarget(t *testing.T) {
+	for _, burst := range []bool{false, true} {
+		name := "sequential"
+		if burst {
+			name = "coalesced"
+		}
+		t.Run(name, func(t *testing.T) {
+			setXDGTestHome(t)
+			h := NewHome()
+			h.width, h.height = 100, 30
+			h.globalSearchIndex = nil
+			remote := session.RemoteSessionInfo{ID: "remote-proof", Title: "Remoteé界", RemoteName: "shared", Tool: "shell"}
+			h.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "shared"}}
+			h.cursor = 0
+			input := func(text string) {
+				if burst {
+					h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(text)})
+				} else {
+					for _, r := range text {
+						h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+					}
+				}
+			}
+			input("/Remoteé界")
+			if !h.search.IsVisible() || h.search.input.Value() != "Remoteé界" {
+				t.Fatal("remote-row search lost shortcut or Unicode query")
+			}
+			h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			if h.search.IsVisible() || len(h.flatItems) != 1 || h.flatItems[h.cursor].RemoteSession != &remote {
+				t.Fatal("search escape lost remote selection")
+			}
+			input("nDrafté界")
+			if !h.newDialog.IsVisible() || h.pendingRemoteName != "shared" {
+				t.Fatalf("creation lost remote routing: visible=%v remote=%q", h.newDialog.IsVisible(), h.pendingRemoteName)
+			}
+			if got := h.newDialog.nameInput.Value(); got != "Drafté界" {
+				t.Fatalf("remote dialog title=%q", got)
+			}
+			if len(h.instances) != 0 || remote.Title != "Remoteé界" {
+				t.Fatal("remote input mutated a local instance or existing remote title")
+			}
+		})
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5493,6 +5493,20 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 // clears (issue #607). Under the default (full_repaint = false) this wrapper
 // is a pass-through — no regression for users who never opt in.
 func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Terminal reads may combine rapid printable keystrokes. Route them in
+	// order so a shortcut can open the text field that receives the tail.
+	// Bracketed paste and Alt input retain their original event semantics.
+	if key, ok := msg.(tea.KeyMsg); ok && key.Type == tea.KeyRunes && len(key.Runes) > 1 && !key.Alt && !key.Paste {
+		var commands []tea.Cmd
+		for _, r := range key.Runes {
+			_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+			commands = append(commands, cmd)
+			if h.isQuitting {
+				break
+			}
+		}
+		return h, tea.Sequence(commands...)
+	}
 	defer h.recordFocusedSession()
 	model, cmd := h.updateInner(msg)
 	if !h.fullRepaint {

--- a/scripts/ci-native-ssh.sh
+++ b/scripts/ci-native-ssh.sh
@@ -65,15 +65,18 @@ export NATIVE_SSHD=/usr/sbin/sshd NATIVE_SSH_RECEIPT_DIR="$run/receipts"
 set +e
 go test -json -p 1 -count=1 -timeout 10m ./cmd/agent-deck -run '^TestNativeSSHAttachLifecycle$' > "$run/lifecycle.jsonl" 2> "$run/lifecycle.stderr"
 lifecycle=$?
+go test -json -p 1 -count=1 -timeout 5m ./cmd/agent-deck -run '^TestNativeSSHTUIRegistryLifecycle$' > "$run/tui.jsonl" 2> "$run/tui.stderr"
+tui=$?
 go test -json -p 1 -count=1 -timeout 5m ./internal/session -run '^TestSSHAttachPortableTERM$' > "$run/term.jsonl" 2> "$run/term.stderr"
 term=$?
 printf '%s\n' "$lifecycle" > "$run/lifecycle.exit"
+printf '%s\n' "$tui" > "$run/tui.exit"
 printf '%s\n' "$term" > "$run/term.exit"
 set -e
 python3 - "$run" <<'PY'
 import json,pathlib,sys
 root=pathlib.Path(sys.argv[1]); inventory={}
-required={'lifecycle':['TestNativeSSHAttachLifecycle'],'term':['TestSSHAttachPortableTERM','TestSSHAttachPortableTERM/xterm-256color','TestSSHAttachPortableTERM/screen','TestSSHAttachPortableTERM/tmux-256color','TestSSHAttachPortableTERM/xterm-ghostty','TestSSHAttachPortableTERM/#00','TestSSHAttachPortableTERM/x;_touch_/unwanted']}
+required={'tui':['TestNativeSSHTUIRegistryLifecycle'],'lifecycle':['TestNativeSSHAttachLifecycle'],'term':['TestSSHAttachPortableTERM','TestSSHAttachPortableTERM/xterm-256color','TestSSHAttachPortableTERM/screen','TestSSHAttachPortableTERM/tmux-256color','TestSSHAttachPortableTERM/xterm-ghostty','TestSSHAttachPortableTERM/#00','TestSSHAttachPortableTERM/x;_touch_/unwanted']}
 for name,tests in required.items():
  rows=[json.loads(line) for line in (root/(name+'.jsonl')).read_text().splitlines()]
  assert rows and (root/(name+'.exit')).read_text().strip()=='0',name

--- a/scripts/ci-native-ssh.sh
+++ b/scripts/ci-native-ssh.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 export GOTOOLCHAIN=local
 : "${NATIVE_SSH_ARTIFACT_DIR:?Set an absolute artifact directory outside the checkout}"
 : "${NATIVE_SSH_EXPECTED_SHA:?Set the exact reviewed source commit}"
-test "$(uname -s)" = Linux
+case "$(uname -s)" in
+  Linux) hash=(sha256sum); authorized_cat=/usr/bin/cat ;;
+  Darwin) hash=(shasum -a 256); authorized_cat=/bin/cat ;;
+  *) echo "Native SSH acceptance requires Linux or macOS" >&2; exit 1 ;;
+esac
+export NATIVE_SSH_AUTHORIZED_CAT="$authorized_cat"
 test "$(id -u)" -ne 0
 root=$(git rev-parse --show-toplevel)
 cd "$root"
@@ -24,21 +29,21 @@ finish() {
  result=$?
  trap - EXIT
  set +e
- sha256sum -c "$run/source.sha256" > "$run/source-check.log" 2>&1
+ "${hash[@]}" -c "$run/source.sha256" > "$run/source-check.log" 2>&1
  check=$?
  git status --porcelain > "$run/source-status.txt"
  if test "$check" -ne 0 || test -s "$run/source-status.txt"; then result=94; fi
  printf '%s\n' "$result" > "$run/exit"
  exit "$result"
 }
-git ls-files -z | xargs -0 sha256sum > "$run/source.sha256"
+git ls-files -z | xargs -0 "${hash[@]}" > "$run/source.sha256"
 trap finish EXIT
 git rev-parse HEAD 'HEAD^{tree}' > "$run/source"
-sha256sum "$0" > "$run/runner.sha256"
+"${hash[@]}" "$0" > "$run/runner.sha256"
 for tool in go tmux ssh ssh-keygen python3; do command -v "$tool"; done
 python3 - <<'PY'
 import os,stat
-for p in ['/usr/sbin/sshd','/usr/bin/cat']:
+for p in ['/usr/sbin/sshd',os.environ['NATIVE_SSH_AUTHORIZED_CAT']]:
  s=os.stat(p)
  assert s.st_uid==0 and not s.st_mode & 0o022 and os.access(p,os.X_OK),p
 # The acceptance fixture uses this production namespace. Refuse active sockets.


### PR DESCRIPTION
## What problem does this solve?

Rapid printable keys arriving together over SSH could be ignored by the TUI. For example, `/Beta` in one terminal event did not open search or enter the query. The native SSH CI test reproduced this on the previous head.

## Why this change

Route coalesced printable keys through the existing update handler in order, preserving returned commands and stopping after quit. Bracketed paste and Alt events keep their existing semantics. Require real OpenSSH/sshd acceptance on both Linux and macOS using disposable keys, HOME and private tmux fixtures.

## User impact

Search, navigation and text dialogs receive rapid printable input consistently. Required native tests cover Unicode rows and account slots, Enter-to-attach, Ctrl+Q return, resize, reconnect, retained session identity, pane process and transcript integrity. Selection restoration is checked after its periodic save; unsaved selection after disconnect is not promised.

## Evidence

The previous public head 63b03b72472def3047df927e9b98bb59464b68e0 failed native CI at search. A real SSH input trace confirmed `/Beta` arrived as one event. The sequential unit control passed while the coalesced control failed on the original behavior.

Corrected source 53d303c5454255b82a2f1ab76647d968ff0398b3 passed 11 unit test/subtest entries with the race detector, zero failures or skips. The actual SSH burst, attach/detach, resize and reconnect fixture passed in 19.55 seconds. Both server TUI PIDs reached ESRCH. All 2262 source files matched before and after execution. Native proof used identical production/test files; the later unit-only import/Mutex correction is documented separately. An earlier unit compile failure is retained and receives no test credit.

The integrated head additionally enables a required macOS hosted job and selects the platform's root-owned authorized-key helper and SHA-256 utility. Source review, gofmt inspection, shell syntax and diff checks pass. Fresh integrated-head full-suite, Linux native and macOS native CI remain required. Prior Linux receipts do not establish Darwin runtime behavior. No tests ran on a live user host.

The integrated production head 5da205315552950d82d6540e7e448c9a77609779 passed the hosted full suite, Linux and macOS native acceptance, lint and security checks. Downloaded artifacts bind both OS runs to that exact commit/tree with clean source and zero skipped tests.

Review follow-up 9ac7c0e338ae201237487d2e9eafabf7fb6590d6 adds only RemoteSession-row coverage: sequential and coalesced Unicode search, Escape selection retention, and subsequent remote creation-dialog routing without a local Instance. Three focused race entries passed, zero failures/skips; source manifests matched. Fresh published-head CI is pending for this test-only follow-up.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** Codex; exact model unverified (unsure).

## What actually bothered you

The owner required that a shared deck reached over SSH feel like working locally. The real acceptance test exposed dropped search input, so this change repairs the behavior and exercises the target macOS platform as well as Linux.

## Checklist

- [x] Focused meaningful regression and real SSH proof
- [x] Sandboxed HOME and unprivileged fixture user
- [x] Independent source review and preserved failed receipts
- [ ] Fresh integrated-head full suite and Linux/macOS native CI
- [x] CHANGELOG.md untouched
- [x] AI assistance disclosed with source-bound evidence

<!-- gate:ai=authored model=unsure intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of rapidly entered or pasted text in search and modal fields.
  - Preserved navigation focus, confirmation behavior, and screen updates when multiple keystrokes arrive together.

- **Tests**
  - Expanded SSH terminal coverage for search, navigation, reconnects, resizing, selection restoration, and clean shutdown.
  - Added validation for native SSH workflows on macOS alongside Linux.
  - Added coverage for Unicode input, modal interactions, remote-row actions, and quit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->