### PR TITLE
feat(session): add exact --id resolution for show and send

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -805,6 +805,26 @@ func ResolveSession(identifier string, instances []*session.Instance) (*session.
 	return nil, fmt.Sprintf("session '%s' not found", identifier), ErrCodeNotFound
 }
 
+// ResolveSessionByExactID resolves a session by ID equality only — never by
+// title, prefix, or path. ResolveSession tries an exact title match ahead of
+// ID matching, so a session merely TITLED with another session's id captures
+// operations meant for that id (measured live: `session show <A-id>` returned
+// a different session titled with A's id, and a send to a stopped session's
+// id was silently delivered to a live impostor). A programmatic caller that
+// already has an exact id from a prior `--json` response needs a resolver
+// that cannot be redirected by title text it never asked to match.
+func ResolveSessionByExactID(id string, instances []*session.Instance) (*session.Instance, string, string) {
+	if id == "" {
+		return nil, "session id is required", ErrCodeNotFound
+	}
+	for _, inst := range instances {
+		if inst.ID == id {
+			return inst, "", ""
+		}
+	}
+	return nil, fmt.Sprintf("session '%s' not found", id), ErrCodeNotFound
+}
+
 // GetCurrentSessionID detects the current agent-deck session from tmux environment
 // Returns session ID or empty string if not in an agent-deck session
 func GetCurrentSessionID() string {

--- a/cmd/agent-deck/exact_session_id_test.go
+++ b/cmd/agent-deck/exact_session_id_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// The collision these tests exist for: a session's TITLE is free text, so it
+// can be set to another session's ID. ResolveSession tries titles before ids,
+// which lets the title holder answer for an id it does not own.
+func collidingInstances() []*session.Instance {
+	return []*session.Instance{
+		{ID: "aaaa1111-1", Title: "worker"},
+		{ID: "bbbb2222-2", Title: "aaaa1111-1"},
+	}
+}
+
+func TestExactSessionIDIsNotRedirectedByACollidingTitle(t *testing.T) {
+	instances := collidingInstances()
+
+	inst, errMsg, _ := ResolveSessionByExactID("aaaa1111-1", instances)
+	if inst == nil {
+		t.Fatalf("ResolveSessionByExactID(aaaa1111-1) found nothing: %s", errMsg)
+	}
+	if inst.ID != "aaaa1111-1" {
+		t.Fatalf("ResolveSessionByExactID(aaaa1111-1) = %s, want the id holder", inst.ID)
+	}
+
+	// The contrast that says why the exact form is needed at all: the flexible
+	// form answers the same identifier with the session merely titled after it.
+	redirected, _, _ := ResolveSession("aaaa1111-1", instances)
+	if redirected == nil || redirected.ID != "bbbb2222-2" {
+		t.Fatal("ResolveSession no longer prefers a colliding title; the exact form's premise changed")
+	}
+}
+
+func TestExactSessionIDDoesNotFallBackToAMatchingTitle(t *testing.T) {
+	// Only the title holder exists, so the id itself is genuinely absent.
+	instances := []*session.Instance{{ID: "bbbb2222-2", Title: "aaaa1111-1"}}
+
+	inst, _, code := ResolveSessionByExactID("aaaa1111-1", instances)
+	if inst != nil {
+		t.Fatalf("ResolveSessionByExactID(aaaa1111-1) = %s, want no match", inst.ID)
+	}
+	if code != ErrCodeNotFound {
+		t.Fatalf("code = %q, want %q", code, ErrCodeNotFound)
+	}
+}
+
+func TestExactSessionIDDoesNotPrefixMatch(t *testing.T) {
+	instances := []*session.Instance{{ID: "aaaa1111-1", Title: "worker"}}
+
+	if inst, _, code := ResolveSessionByExactID("aaaa1111", instances); inst != nil {
+		t.Fatalf("ResolveSessionByExactID(aaaa1111) = %s, want no match on a prefix", inst.ID)
+	} else if code != ErrCodeNotFound {
+		t.Fatalf("code = %q, want %q", code, ErrCodeNotFound)
+	}
+
+	// The control: the flexible form does resolve that prefix, so the case is
+	// reachable and the exact form is what refuses it.
+	if inst, _, _ := ResolveSession("aaaa1111", instances); inst == nil || inst.ID != "aaaa1111-1" {
+		t.Fatal("ResolveSession no longer prefix-matches; this test no longer proves the difference")
+	}
+}
+
+func TestExactSessionIDRequiresAnID(t *testing.T) {
+	inst, errMsg, code := ResolveSessionByExactID("", collidingInstances())
+	if inst != nil {
+		t.Fatalf("ResolveSessionByExactID(\"\") = %s, want no match", inst.ID)
+	}
+	if code != ErrCodeNotFound {
+		t.Fatalf("code = %q, want %q", code, ErrCodeNotFound)
+	}
+	if errMsg == "" {
+		t.Fatal("an empty id must still explain itself")
+	}
+}
+
+// The positional form is what every human caller and documented workflow types.
+// Adding an exact form must not change any of it.
+func TestPositionalResolutionIsUnchanged(t *testing.T) {
+	instances := []*session.Instance{
+		{ID: "aaaa1111-1", Title: "worker"},
+		{ID: "bbbb2222-2", Title: "other"},
+	}
+
+	if inst, _, _ := ResolveSession("worker", instances); inst == nil || inst.ID != "aaaa1111-1" {
+		t.Fatal("ResolveSession no longer resolves an exact title")
+	}
+	if inst, _, _ := ResolveSession("bbbb2222", instances); inst == nil || inst.ID != "bbbb2222-2" {
+		t.Fatal("ResolveSession no longer resolves an id prefix when no title matches")
+	}
+
+	shared := []*session.Instance{
+		{ID: "aaaa1111-1", Title: "twin"},
+		{ID: "bbbb2222-2", Title: "twin"},
+	}
+	if _, _, code := ResolveSession("twin", shared); code != ErrCodeAmbiguous {
+		t.Fatalf("a title two sessions share reported %q, want %q", code, ErrCodeAmbiguous)
+	}
+}
+
+// Under --id every positional is message text, so no positional is left to stop flag parsing at a
+// message that begins with a dash. The caller's own separator has to survive hoisting for that
+// text to reach the session as a message rather than an undefined flag.
+func TestSendSplitsTheCallerSeparatorBeforeHoisting(t *testing.T) {
+	split := func(args []string) (flagArgs, literal []string) {
+		flagArgs = args
+		for i, arg := range args {
+			if arg == "--" {
+				return args[:i], args[i+1:]
+			}
+		}
+		return flagArgs, nil
+	}
+
+	flagArgs, literal := split([]string{"--json", "--id", "aaaa1111-1", "--", "--not-a-flag"})
+	if !reflect.DeepEqual(flagArgs, []string{"--json", "--id", "aaaa1111-1"}) {
+		t.Fatalf("flagArgs = %q, want the flags before the separator", flagArgs)
+	}
+	if !reflect.DeepEqual(literal, []string{"--not-a-flag"}) {
+		t.Fatalf("literal = %q, want the dash-leading message intact", literal)
+	}
+
+	// The legacy form keeps both of its positionals, in order.
+	flagArgs, literal = split([]string{"--json", "--", "my-project", "hello"})
+	if !reflect.DeepEqual(flagArgs, []string{"--json"}) {
+		t.Fatalf("flagArgs = %q, want only the flag", flagArgs)
+	}
+	if !reflect.DeepEqual(literal, []string{"my-project", "hello"}) {
+		t.Fatalf("literal = %q, want session ref then message", literal)
+	}
+
+	// A caller that wrote no separator is unaffected.
+	flagArgs, literal = split([]string{"my-project", "hello", "--json"})
+	if literal != nil {
+		t.Fatalf("literal = %q, want none without a separator", literal)
+	}
+	if len(flagArgs) != 3 {
+		t.Fatalf("flagArgs = %q, want every argument left to hoisting", flagArgs)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1570,6 +1570,7 @@ func handleSessionShow(profile string, args []string) {
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	idFlag := fs.String("id", "", "Resolve only this exact session id; never matches titles")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session show [id|title] [options]")
@@ -1577,6 +1578,7 @@ func handleSessionShow(profile string, args []string) {
 		fmt.Println("Show session details. If no ID is provided, auto-detects current session.")
 		fmt.Println("Account: shows the quoted stored account slot, not a resolved account or login identity.")
 		fmt.Println(`JSON always includes the raw "account" string, including "" when no slot is stored.`)
+		fmt.Println("Use --id to resolve an exact session id without the flexible title/prefix/path matching.")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -1597,11 +1599,24 @@ func handleSessionShow(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Resolve session (allow current session detection)
-	inst, errMsg, errCode := ResolveSessionOrCurrent(identifier, instances)
+	// Resolve session (allow current session detection). --id is the exact
+	// form: it takes the id alone, so pairing it with a positional would leave
+	// which one was meant ambiguous.
+	var inst *session.Instance
+	var errMsg, errCode string
+	if *idFlag != "" {
+		if identifier != "" {
+			out.Error("--id takes the exact id; do not also pass a positional session", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		inst, errMsg, errCode = ResolveSessionByExactID(*idFlag, instances)
+	} else {
+		inst, errMsg, errCode = ResolveSessionOrCurrent(identifier, instances)
+	}
 	if inst == nil {
-		// If no identifier was provided and we're in tmux, try fallback detection
-		if identifier == "" && os.Getenv("TMUX") != "" {
+		// If no identifier was provided and we're in tmux, try fallback detection.
+		// An exact id names one session or none, so it never auto-detects.
+		if *idFlag == "" && identifier == "" && os.Getenv("TMUX") != "" {
 			// First try current profile
 			inst = findSessionByTmux(instances)
 			if inst == nil {
@@ -2703,11 +2718,13 @@ func handleSessionSend(profile string, args []string) {
 	streamIdle := fs.Duration("stream-idle", 10*time.Second, "Max idle time before --stream aborts with error")
 	streamCharBudget := fs.Int("stream-char-budget", 4000, "Char budget for text flush in --stream mode")
 	streamToolBudget := fs.Int("stream-tool-budget", 3, "Tool-event budget for text flush in --stream mode")
+	idFlag := fs.String("id", "", "Resolve only this exact session id; never matches titles (message is then the whole positional)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session send <id|title> <message> [options]")
 		fmt.Println()
 		fmt.Println("Send a message to a running session.")
+		fmt.Println("Use --id to resolve an exact session id; the session positional is then omitted and every remaining positional is the message.")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -2721,19 +2738,43 @@ func handleSessionSend(profile string, args []string) {
 		fmt.Println("  agent-deck session send my-project --message-file answer.md   # long reply from file")
 		fmt.Println("  git diff | agent-deck session send my-project --message-file -   # message from stdin")
 		fmt.Println("  agent-deck session send parent \"child done\" --defer-if-busy --defer-timeout 30m")
+		fmt.Println("  agent-deck session send --id abc123... \"exact id, never a title\"")
 	}
 
-	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+	// Split on the caller's own separator before hoisting, because normalizeArgs consumes it.
+	// Under --id every positional is message text, so no positional is left to stop flag parsing
+	// at a message that begins with a dash, and that text would parse as an undefined flag.
+	flagArgs, literal := args, []string(nil)
+	for i, arg := range args {
+		if arg == "--" {
+			flagArgs, literal = args[:i], args[i+1:]
+			break
+		}
+	}
+	if err := fs.Parse(normalizeArgs(fs, flagArgs)); err != nil {
 		os.Exit(1)
 	}
-	remaining := fs.Args()
+	remaining := append(fs.Args(), literal...)
 
 	out := NewCLIOutput(*jsonOutput, *quiet)
 
+	// --id carries the session, so it removes the session positional rather
+	// than adding a flag beside it: with it, every remaining token is message.
 	needPositionalMessage := *messageFile == ""
-	if len(remaining) < 1 || (needPositionalMessage && len(remaining) < 2) {
+	required := 0
+	if *idFlag == "" {
+		required++
+	}
+	if needPositionalMessage {
+		required++
+	}
+	if len(remaining) < required {
 		fs.Usage()
-		out.Error("session and message (or --message-file) are required", ErrCodeInvalidOperation)
+		if *idFlag != "" {
+			out.Error("a message (or --message-file) is required", ErrCodeInvalidOperation)
+		} else {
+			out.Error("session and message (or --message-file) are required", ErrCodeInvalidOperation)
+		}
 		os.Exit(1)
 	}
 
@@ -2754,8 +2795,15 @@ func handleSessionSend(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	sessionRef := remaining[0]
-	message, err := resolveMessageInput(strings.Join(remaining[1:], " "), *messageFile, os.Stdin)
+	var sessionRef, rawMessage string
+	if *idFlag != "" {
+		sessionRef = *idFlag
+		rawMessage = strings.Join(remaining, " ")
+	} else {
+		sessionRef = remaining[0]
+		rawMessage = strings.Join(remaining[1:], " ")
+	}
+	message, err := resolveMessageInput(rawMessage, *messageFile, os.Stdin)
 	if err != nil {
 		out.Error(err.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
@@ -2768,8 +2816,14 @@ func handleSessionSend(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Resolve session
-	inst, errMsg, errCode := ResolveSession(sessionRef, instances)
+	// Resolve session. --id never matches a title; see ResolveSessionByExactID.
+	var inst *session.Instance
+	var errMsg, errCode string
+	if *idFlag != "" {
+		inst, errMsg, errCode = ResolveSessionByExactID(*idFlag, instances)
+	} else {
+		inst, errMsg, errCode = ResolveSession(sessionRef, instances)
+	}
 	if inst == nil {
 		out.Error(errMsg, errCode)
 		if errCode == ErrCodeNotFound {


### PR DESCRIPTION
A session TITLE is free text, so it can be set to another session's ID. `ResolveSession` tries an exact title match before ID matching, so the title holder answers for an id it does not own.

Measured against v1.15.0, with the id holder healthy and running:

```
session show <A-id>                    -> A
add a session titled "<A-id>"
session show <A-id>                    -> the new session, not A
```

For a programmatic caller this is not a preference but a correctness problem: a caller holding an exact id from a prior `--json` reply has no way to say "this id, not whatever is titled after it". In our case a message addressed to a stopped session was delivered to a live session merely titled with that id.

## What this adds

- `ResolveSessionByExactID`, matching stored id equality only: no title, prefix, path, or location fallback.
- `--id <session-id>` on `session show` and `session send`, which uses it.

Under `--id`, `session send` takes no session positional, so every remaining token is message text. The caller's own `--` separator is split off before hoisting, because with no positional left to stop flag parsing, a message beginning with a dash would be read as an undefined flag.

**The positional form is unchanged.** Every existing invocation resolves exactly as before, and the exact resolver is wired to nothing else — lifecycle commands are untouched.

## Tests

`cmd/agent-deck/exact_session_id_test.go` covers: a colliding title cannot redirect an exact read (with the contrast assertion showing `ResolveSession` still prefers the title, so the premise is checked rather than assumed); a missing exact id never falls back to a matching title; no prefix matching; an empty id is refused; and a characterization test that positional title, prefix, and ambiguity behaviour are unchanged.

Verified with `go build ./cmd/...`, `go vet`, and `go test ./cmd/agent-deck/`. Three `TestCleanup*` failures in that package reproduce identically on an untouched checkout of this base, so they are pre-existing and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an exact session ID option for showing session details and sending messages.
  - Session IDs are matched exactly, without title, prefix, or path-based matching.
  - Added support for using `--` to preserve dash-leading message text when sending.

- **Bug Fixes**
  - Prevented sessions with colliding titles from capturing operations intended for a specific ID.
  - Improved handling of empty, unmatched, and ambiguous session identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->