### PR TITLE
fix(remote): forward Docker sandbox checkbox to remote session creation

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -991,14 +991,16 @@ func remoteAttachTERM() string {
 
 // CreateSession creates and starts a quick new session on the remote, returning its ID.
 func (r *SSHRunner) CreateSession(ctx context.Context) (string, error) {
-	return r.CreateSessionWithOptions(ctx, "", "", "", "")
+	return r.CreateSessionWithOptions(ctx, "", "", "", "", false)
 }
 
 // remoteAddArgs builds the `agent-deck add` argument list for creating a
 // session on a remote with explicit dialog values (#1353). Empty values fall
 // back to remote defaults: no -c means shell, no -t means --quick
 // (auto-generated name), and an empty or "." path means remote CWD.
-func remoteAddArgs(tool, title, path, group string) []string {
+// sandbox forwards the dialog's "Run in Docker sandbox" checkbox as -sandbox;
+// the image and other Docker settings come from the remote's own config.
+func remoteAddArgs(tool, title, path, group string, sandbox bool) []string {
 	args := []string{"add", "--json"}
 	if t := strings.TrimSpace(title); t != "" {
 		args = append(args, "-t", t)
@@ -1011,6 +1013,9 @@ func remoteAddArgs(tool, title, path, group string) []string {
 	if c := strings.TrimSpace(tool); c != "" {
 		args = append(args, "-c", c)
 	}
+	if sandbox {
+		args = append(args, "-sandbox")
+	}
 	if p := strings.TrimSpace(path); p != "" && p != "." {
 		args = append(args, p)
 	}
@@ -1018,11 +1023,11 @@ func remoteAddArgs(tool, title, path, group string) []string {
 }
 
 // CreateSessionWithOptions creates and starts a new session on the remote with
-// an explicit tool/title/path/group from the new-session dialog (#1353),
+// an explicit tool/title/path/group/sandbox from the new-session dialog (#1353),
 // returning its ID. Empty values fall back to remote defaults (see remoteAddArgs).
-func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path, group string) (string, error) {
+func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path, group string, sandbox bool) (string, error) {
 	// Step 1: Create the session
-	output, err := r.Run(ctx, remoteAddArgs(tool, title, path, group)...)
+	output, err := r.Run(ctx, remoteAddArgs(tool, title, path, group, sandbox)...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create remote session: %w", err)
 	}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -174,6 +174,7 @@ func TestRemoteAddArgs(t *testing.T) {
 	cases := []struct {
 		name                     string
 		tool, title, path, group string
+		sandbox                  bool
 		want                     []string
 	}{
 		{
@@ -205,16 +206,26 @@ func TestRemoteAddArgs(t *testing.T) {
 			tool: "  ", title: " ", group: " ", path: " . ",
 			want: []string{"add", "--json", "--quick"},
 		},
+		{
+			name: "docker sandbox checkbox is forwarded before the path",
+			tool: "claude", title: "sandboxed", path: "/srv/project", sandbox: true,
+			want: []string{"add", "--json", "-t", "sandboxed", "-c", "claude", "-sandbox", "/srv/project"},
+		},
+		{
+			name: "docker sandbox with quick name and remote CWD",
+			tool: "claude", sandbox: true,
+			want: []string{"add", "--json", "--quick", "-c", "claude", "-sandbox"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := remoteAddArgs(tc.tool, tc.title, tc.path, tc.group)
+			got := remoteAddArgs(tc.tool, tc.title, tc.path, tc.group, tc.sandbox)
 			if len(got) != len(tc.want) {
-				t.Fatalf("remoteAddArgs(%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, got, tc.want)
+				t.Fatalf("remoteAddArgs(%q,%q,%q,%q,%v) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, tc.sandbox, got, tc.want)
 			}
 			for i := range got {
 				if got[i] != tc.want[i] {
-					t.Fatalf("remoteAddArgs(%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, got, tc.want)
+					t.Fatalf("remoteAddArgs(%q,%q,%q,%q,%v) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, tc.sandbox, got, tc.want)
 				}
 			}
 		})
@@ -236,7 +247,7 @@ func TestSSHRunnerCreateSessionWithOptions_UsesDialogValues(t *testing.T) {
 		},
 	}
 
-	id, err := runner.CreateSessionWithOptions(context.Background(), "codex", "Remote Work", "~/project", "work")
+	id, err := runner.CreateSessionWithOptions(context.Background(), "codex", "Remote Work", "~/project", "work", true)
 	if err != nil {
 		t.Fatalf("CreateSessionWithOptions unexpected error: %v", err)
 	}
@@ -247,7 +258,7 @@ func TestSSHRunnerCreateSessionWithOptions_UsesDialogValues(t *testing.T) {
 		t.Fatalf("calls = %v, want add and start", calls)
 	}
 	add := strings.Join(calls[0], " ")
-	for _, want := range []string{"add", "--json", "-t", "Remote Work", "-g", "work", "-c", "codex", "~/project"} {
+	for _, want := range []string{"add", "--json", "-t", "Remote Work", "-g", "work", "-c", "codex", "-sandbox", "~/project"} {
 		if !strings.Contains(add, want) {
 			t.Fatalf("remote add call = %q, want token %q", add, want)
 		}
@@ -276,7 +287,7 @@ func TestSSHRunnerCreateSessionWithOptions_QueuedStartIsNotAttachable(t *testing
 		},
 	}
 
-	_, err := runner.CreateSessionWithOptions(context.Background(), "claude", "", "", "")
+	_, err := runner.CreateSessionWithOptions(context.Background(), "claude", "", "", "", false)
 	if err == nil || !strings.Contains(err.Error(), "queued") {
 		t.Fatalf("CreateSessionWithOptions error = %v, want queued error", err)
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8015,12 +8015,15 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			remoteName := h.pendingRemoteName
 			name, path, command := h.newDialog.GetRemoteValues()
 			groupPath := h.newDialog.GetSelectedGroup()
+			// The sandbox checkbox applies to the remote too: the remote runs
+			// the container with its own Docker config and image.
+			sandbox := h.newDialog.IsSandboxEnabled()
 			// Remember the submitted tool for the next dialog open (UX top-3 #2).
 			rememberTool(h.stateDB(), command)
 			h.newDialog.Hide()
 			h.pendingRemoteName = ""
 			h.clearError()
-			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path, groupPath)
+			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path, groupPath, sandbox)
 		}
 
 		// Get values including worktree settings.
@@ -14126,7 +14129,7 @@ func (a attachCmd) SetStderr(w io.Writer) {}
 // createRemoteSession creates a new session on a remote and auto-attaches to it.
 // Used by quick-create (N): auto-generated name, remote defaults (shell).
 func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
-	return h.createRemoteSessionWithOptions(remoteName, "", "", "", "")
+	return h.createRemoteSessionWithOptions(remoteName, "", "", "", "", false)
 }
 
 // remoteCreateAndAttachCmd creates a session on the remote, then attaches to it.
@@ -14136,6 +14139,7 @@ type remoteCreateAndAttachCmd struct {
 	title     string
 	path      string
 	group     string
+	sandbox   bool
 	createCtx context.Context
 	// onExit: same contract as attachCmd.onExit (#1753) — clear the attach flag
 	// while Bubble Tea's loop is still parked, so the first View() after resume
@@ -14165,7 +14169,7 @@ func (r remoteCreateAndAttachCmd) Run() error {
 	}
 	ctx, cancel := context.WithTimeout(baseCtx, 20*time.Second)
 	defer cancel()
-	sessionID, err := r.runner.CreateSessionWithOptions(ctx, r.tool, r.title, r.path, r.group)
+	sessionID, err := r.runner.CreateSessionWithOptions(ctx, r.tool, r.title, r.path, r.group, r.sandbox)
 	if err != nil {
 		return err
 	}
@@ -14182,8 +14186,9 @@ func (r remoteCreateAndAttachCmd) SetStderr(writer io.Writer) {}
 // createRemoteSessionWithOptions creates a new session on a remote with an
 // explicit tool/title/path/group from the new-session dialog (#1353), then
 // auto-attaches to it. Empty values fall back to remote defaults (shell,
-// auto-generated name, remote CWD).
-func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, group string) tea.Cmd {
+// auto-generated name, remote CWD). sandbox forwards the dialog's Docker
+// sandbox checkbox so the remote creates the session with -sandbox.
+func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, group string, sandbox bool) tea.Cmd {
 	config, err := session.LoadUserConfig()
 	if err != nil || config == nil || config.Remotes == nil {
 		return func() tea.Msg {
@@ -14199,7 +14204,7 @@ func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, gro
 	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
 	return tea.Exec(remoteCreateAndAttachCmd{
-		runner: runner, tool: tool, title: title, path: path, group: group, createCtx: h.ctx,
+		runner: runner, tool: tool, title: title, path: path, group: group, sandbox: sandbox, createCtx: h.ctx,
 		// Clear the flag inside Run(), before Bubble Tea restores the terminal
 		// and resumes the loop (#1753); the callback below is only the belt for
 		// the path where Run() never executes.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -701,6 +701,10 @@ type Home struct {
 	// (Backspace, arrows, Tab, Ctrl-C, Ctrl-D — #1094). When nil, named keys
 	// are sent via the session's tmux pane (SendNamedKey).
 	insertNamedKeySink func(inst *session.Instance, key string) error
+	// remoteCreateSink is an optional override used by tests to capture what
+	// the new-session dialog forwards to the remote-create path (#1353) without
+	// opening an SSH connection. When nil, createRemoteSessionWithOptions runs.
+	remoteCreateSink func(remoteName, tool, title, path, group string, sandbox bool) tea.Cmd
 	// insertKeySender is the persistent dispatch path opened on
 	// enterInsertMode and closed on exitInsertMode (#1102 perf fix +
 	// remote support). Local sessions get a tmux.KeySender (control-mode
@@ -8023,7 +8027,11 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			h.newDialog.Hide()
 			h.pendingRemoteName = ""
 			h.clearError()
-			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path, groupPath, sandbox)
+			create := h.createRemoteSessionWithOptions
+			if h.remoteCreateSink != nil {
+				create = h.remoteCreateSink
+			}
+			return h, create(remoteName, command, name, path, groupPath, sandbox)
 		}
 
 		// Get values including worktree settings.
@@ -14159,6 +14167,10 @@ func (e remoteAttachFailedError) Unwrap() error {
 	return e.err
 }
 
+// Run creates the session on the remote with the dialog's tool, title, path,
+// group and sandbox choice, then attaches to it. A create failure is returned
+// as-is; an attach failure after a successful create is wrapped in
+// remoteAttachFailedError so the caller can tell the two apart.
 func (r remoteCreateAndAttachCmd) Run() error {
 	if r.onExit != nil {
 		defer r.onExit()

--- a/internal/ui/remote_sandbox_forwarding_test.go
+++ b/internal/ui/remote_sandbox_forwarding_test.go
@@ -1,0 +1,110 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// The new-session dialog opened on a remote target (#1353) shows the
+// "Run in Docker sandbox" checkbox, but the remote-create path used to read
+// only tool/title/path/group and dropped the checkbox: the session started on
+// the remote host unsandboxed. These tests drive the real dialog and capture
+// what the submit handler forwards to the remote-create path.
+
+type remoteCreateCapture struct {
+	calls                                int
+	remoteName, tool, title, path, group string
+	sandbox                              bool
+}
+
+func (c *remoteCreateCapture) sink(remoteName, tool, title, path, group string, sandbox bool) tea.Cmd {
+	c.calls++
+	c.remoteName, c.tool, c.title, c.path, c.group, c.sandbox = remoteName, tool, title, path, group, sandbox
+	return nil
+}
+
+// openRemoteDialogAndTypeName opens the dialog via `n` on a remote group and
+// types a session name, leaving focus on the Name field.
+func openRemoteDialogAndTypeName(t *testing.T, remoteName, name string) (*Home, *remoteCreateCapture) {
+	t.Helper()
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem(remoteName)}
+	home.cursor = 0
+	capture := &remoteCreateCapture{}
+	home.remoteCreateSink = capture.sink
+
+	h := pressN(t, home)
+	if !h.newDialog.IsVisible() {
+		t.Fatal("precondition: n on a remote group must open the dialog")
+	}
+	for _, r := range name {
+		h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return h, capture
+}
+
+func submitRemoteDialog(t *testing.T, h *Home) *Home {
+	t.Helper()
+	model, _ := h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyCtrlS})
+	home := model.(*Home)
+	if home.newDialog.IsVisible() {
+		t.Fatal("submit must close the dialog")
+	}
+	return home
+}
+
+// TestRemoteDialog_SandboxCheckbox_ForwardedToRemoteCreate: with the checkbox
+// enabled, the submit handler must hand sandbox=true to the remote-create path
+// together with the other dialog values.
+func TestRemoteDialog_SandboxCheckbox_ForwardedToRemoteCreate(t *testing.T) {
+	h, capture := openRemoteDialogAndTypeName(t, "myserver", "sandboxed-task")
+	if h.newDialog.IsSandboxEnabled() {
+		t.Fatal("precondition: remote dialog must start with the sandbox checkbox off")
+	}
+	h.newDialog.ToggleSandbox()
+	if !h.newDialog.IsSandboxEnabled() {
+		t.Fatal("precondition: ToggleSandbox must enable the checkbox")
+	}
+
+	h = submitRemoteDialog(t, h)
+
+	if capture.calls != 1 {
+		t.Fatalf("remote create called %d times, want 1", capture.calls)
+	}
+	if capture.remoteName != "myserver" {
+		t.Fatalf("remoteName = %q, want myserver", capture.remoteName)
+	}
+	if capture.title != "sandboxed-task" {
+		t.Fatalf("title = %q, want sandboxed-task", capture.title)
+	}
+	if !capture.sandbox {
+		t.Fatal("sandbox checkbox was enabled in the dialog but not forwarded to the remote create")
+	}
+	if len(h.instances) != 0 {
+		t.Fatalf("local create must not run for remote targets; got %d instances", len(h.instances))
+	}
+}
+
+// TestRemoteDialog_SandboxUnchecked_NotForwarded: leaving the checkbox off must
+// keep the remote create unsandboxed, so existing behaviour is unchanged.
+func TestRemoteDialog_SandboxUnchecked_NotForwarded(t *testing.T) {
+	h, capture := openRemoteDialogAndTypeName(t, "myserver", "plain-task")
+
+	submitRemoteDialog(t, h)
+
+	if capture.calls != 1 {
+		t.Fatalf("remote create called %d times, want 1", capture.calls)
+	}
+	if capture.sandbox {
+		t.Fatal("sandbox must stay off when the checkbox was not enabled")
+	}
+	if capture.title != "plain-task" {
+		t.Fatalf("title = %q, want plain-task", capture.title)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Creating a session on a remote from the TUI (cursor on a `remotes/<name>` group, `n`) with **Run in Docker sandbox** checked produces an unsandboxed session on the remote host. The checkbox is shown and can be toggled in remote mode, but its value never reaches the remote `agent-deck add` call, so Claude (or any tool) starts directly on the remote machine instead of inside a container.

## Why this change

The remote create path (`createRemoteSessionWithOptions` -> `SSHRunner.CreateSessionWithOptions` -> `remoteAddArgs`, introduced for #1353) only carried tool, title, path and group. The dialog already exposes `IsSandboxEnabled()`, and the remote CLI already accepts `-sandbox`, so the smallest correct fix is to thread one boolean through those three layers and append `-sandbox` to the remote `add` argv. Image, CPU/memory limits and other Docker settings deliberately stay with the remote's own config, exactly as a local `agent-deck add -sandbox` on that host would behave. Quick-create (`N`) keeps passing `false`, unchanged.

## User impact

Checking "Run in Docker sandbox" in the remote-mode new-session dialog now creates a sandboxed session on the remote. Unchecked behaviour is identical to before. No config or CLI changes.

## Evidence

Before (v1.15.0, laptop TUI -> remote `server`, checkbox ticked). The remote registry shows the session without a sandbox and no container exists:

```
$ agent-deck remote sessions server
  TITLE                TOOL            STATUS     ID
  testdir              claude          waiting    5bb27342
$ ssh server 'docker ps -a --format "{{.Names}}"'
(empty)
$ ssh server 'pgrep -lf "^claude"'
9757 claude --session-id 9d2bf7e9-7022-4a56-8271-1c708fe1f233    # running on the host, not in a container
```

Same session created on the remote with the flag the dialog should have sent works as expected:

```
$ ssh server 'agent-deck add /Users/joosts/Development/projects/testdir -c claude -t testdir -sandbox && agent-deck session start testdir'
✓ Added session: testdir
  Sandbox: enabled
✓ Started session: testdir
$ ssh server 'docker ps --format "{{.Names}} {{.Status}}"'
agent-deck-testdir-a0273929 Up 48 seconds
```

After (this branch), the remote add argv now carries `-sandbox`:

```
$ go test ./internal/session -run 'RemoteAdd|CreateSession' -count=1 -v | grep -E '^(=== RUN|\s*--- (PASS|FAIL))' | grep -i sandbox
=== RUN   TestRemoteAddArgs/docker_sandbox_checkbox_is_forwarded_before_the_path
=== RUN   TestRemoteAddArgs/docker_sandbox_with_quick_name_and_remote_CWD
    --- PASS: TestRemoteAddArgs/docker_sandbox_checkbox_is_forwarded_before_the_path (0.00s)
    --- PASS: TestRemoteAddArgs/docker_sandbox_with_quick_name_and_remote_CWD (0.00s)
```

`TestSSHRunnerCreateSessionWithOptions_UsesDialogValues` now asserts the `-sandbox` token in the recorded remote `add` call.

Sandboxed suite (`HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`, macOS 15 / Apple Silicon, tmux 3.7b): every package ok except `internal/tmux`, `internal/tmuxutf8` and three tests in `internal/session` (`TestEnsureClaudeSessionIDFromDiskForRestart_RemoteNeverAdoptsLocalUUID`, `TestFindLatestClaudeTranscriptOnDisk_RemoteRefuses`, `TestRemoteCDPrefix_IdentityAndExecutionAgree`). All of those fail identically on an untouched `upstream/main` worktree (40e3a6de) in the same environment: `/proc` lookups, tmux socket path length under a `mktemp` HOME, and `/var` vs `/private/var` canonicalisation. `internal/ui` and the changed session tests pass sandboxed; `tests/eval/harness` failed once under full parallel load and passed 3/3 when rerun.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1 (Claude Code)

**Prompt / session log (optional):** n/a

## What actually bothered you

I set up an always-on Mac as an agent-deck remote with Colima for Docker. Every session I created from my laptop's TUI with the sandbox box ticked ended up running Claude straight on the host. After asking "is testdir now running in Docker?" and hearing no for the third time, my ask was: "kun je een PR aanmaken voor agent-deck om het te fixen?" ("can you open a PR for agent-deck to fix it?").

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to create remote sessions in a Docker sandbox.
  - The new-session dialog now includes a Docker sandbox setting for remote sessions.
  - The selected sandbox setting is forwarded when creating a remote session.
  - Quick-create sessions continue to use the standard, non-sandboxed setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->