### PR TITLE
ci(intake): auto-label newly opened issues with triage and a type hint

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -81,8 +81,9 @@ token), not that the release is bad.
 |---|---|---|
 | `issue-notify.yml` | issue opened | Posts issue context (title, body, labels, related issues, recent commits) to the configured ntfy topic so the conductor picks it up. |
 | `pr-notify.yml` | PR opened or marked ready-for-review | Posts PR context (files, commits, reviews, comments) to the same ntfy topic. |
+| `issue-intake.yml` | issue opened | Adds `triage` plus one advisory type label (`bug`, `feature`, `documentation`, `question`) from the same keyword heuristic as `issue-notify.yml`, only when the issue has no labels at all. Never removes labels, never comments. Needs no secret. (#2128) |
 
-Both expect `secrets.NTFY_TOPIC` to be set on the repo. Neither blocks
+The two notify workflows expect `secrets.NTFY_TOPIC` to be set on the repo. None of these block
 anything — they can fail silently without affecting merges.
 
 ## Schedule-only (alert-only, not a PR gate)

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -1,0 +1,72 @@
+name: Issue Intake
+
+# Auto-labels newly opened issues so nothing sits unlabeled and invisible to
+# the drain sweeps (#2128). Only issues with zero labels are touched: they get
+# "triage" plus one advisory type label from the same keyword heuristic that
+# issue-notify.yml uses. Labels are only ever added, never removed, and no
+# comment is posted.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add triage and advisory type labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            // Re-read labels from the API so a label applied between the
+            // event firing and this job running is respected.
+            const { data: live } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+            });
+            const existing = live.labels.map(l => l.name);
+            if (existing.length > 0) {
+              core.info(`#${issue.number} already labeled (${existing.join(', ')}); leaving it alone.`);
+              return;
+            }
+
+            // Type heuristic: keep identical to issue-notify.yml so both agree.
+            const labels = existing.map(l => l.toLowerCase());
+            const titleLower = issue.title.toLowerCase();
+            const bodyLower = (issue.body || '').toLowerCase();
+
+            let issueType = 'unknown';
+            if (labels.includes('bug') || titleLower.includes('bug') || titleLower.includes('fix') || bodyLower.includes('error') || bodyLower.includes('crash')) {
+              issueType = 'bug';
+            } else if (labels.includes('enhancement') || labels.includes('feature') || titleLower.includes('feature') || titleLower.includes('add')) {
+              issueType = 'feature';
+            } else if (labels.includes('documentation') || labels.includes('docs')) {
+              issueType = 'docs';
+            } else if (labels.includes('question') || titleLower.includes('how') || titleLower.includes('?')) {
+              issueType = 'support';
+            }
+
+            // Advisory type label, mapped onto labels that already exist in the repo.
+            const typeLabel = {
+              bug: 'bug',
+              feature: 'feature',
+              docs: 'documentation',
+              support: 'question',
+            }[issueType];
+
+            const toAdd = ['triage'];
+            if (typeLabel) toAdd.push(typeLabel);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: toAdd,
+            });
+            core.info(`#${issue.number}: added ${toAdd.join(', ')} (detected type: ${issueType}).`);


### PR DESCRIPTION
## What problem does this solve?

Closes #2128. New issues sit unlabeled for days (15 of 25 open issues had no label; #1892 waited 23 days), which keeps them invisible to the drain goal and the conductor's sweeps. `issue-notify.yml` already computes a type heuristic and then discards it.

## Why this change

A separate `issue-intake.yml` workflow on `issues: opened` keeps labeling independent of the ntfy push so either can be disabled alone (the alternative of extending `issue-notify.yml` in place was rejected in the issue). The keyword heuristic is copied verbatim from `issue-notify.yml` so both workflows agree on the detected type. Labels are re-read from the API at run time rather than trusting the event payload, so an issue that gets labeled between the event and the job run is left alone.

Behavior:
- zero labels: add `triage` plus one advisory type label mapped to existing repo labels (`bug`, `feature`, `documentation`, `question`); unknown type adds only `triage`
- any existing label: do nothing
- never removes a label, never comments, never closes
- `permissions: issues: write` only; `actions/github-script` pinned to the same v9 SHA used by `pr-intake.yml`

## User impact

None for people running agent-deck. Repository only: newly opened issues get a `triage` label and a type hint within seconds instead of days.

## Evidence

```
$ python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('yaml ok')" .github/workflows/issue-intake.yml
yaml ok
$ diff <(heuristic block from issue-notify.yml) <(heuristic block from issue-intake.yml) && echo HEURISTIC_IDENTICAL
HEURISTIC_IDENTICAL
$ gofmt -l ./cmd ./internal        # prints nothing
$ go build ./... && go vet ./... && echo BUILD_VET_OK
BUILD_VET_OK
$ gh label list                    # confirms triage, bug, feature, documentation, question all exist
```

Local go test is disallowed on this host; full suite runs in CI on this PR.

The workflow itself only fires on `issues: opened`, so its first live run happens on the next issue opened after merge. No Go code is touched, so no Go tests apply.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic issue intake processing when new issues are opened.
  - Issues without existing labels are classified using title and description details.
  - Automatically applies a triage label and an advisory category label for bugs, features, documentation requests, or questions.
  - Existing labels are preserved, and no comments are posted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->