### PR TITLE
ci(workflows): daily comment-only nudge for silent needs-info PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -90,6 +90,7 @@ anything — they can fail silently without affecting merges.
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `weekly-regression.yml` | Sunday 00:00 UTC cron, or `workflow_dispatch` | Runs the Playwright visual-regression suite (`tests/e2e/pw-visual-regression.config.ts`) and Lighthouse CI (`.lighthouserc.json`) against a freshly built `agent-deck web` server. On failure, opens or appends to a single `Weekly regression check: … [date]` issue labelled `regression,automated` (idempotent — no duplicate issues on back-to-back failures). **Alert-only** — does not block any PR. |
+| `needs-info-nudge.yml` | Daily 06:00 UTC cron, or `workflow_dispatch` | Day-10 step of the intake silence ladder (#2132). For each open PR labelled `needs-info` (and not `keep-open`) whose last activity (PR update, last commit, last author comment) is older than 10 days, posts one gentle reminder comment linking `.github/INTAKE.md`. Idempotent via the `<!-- needs-info-nudge -->` marker. **Comment-only**: no label changes, no closing. |
 
 > **Note on the v1.7.70 fix:** the bubbletea cancel-reader failure that broke
 > `agent-deck web` on headless CI (`error creating cancelreader: bubbletea:

--- a/.github/workflows/needs-info-nudge.yml
+++ b/.github/workflows/needs-info-nudge.yml
@@ -1,0 +1,107 @@
+name: Needs-info nudge (comment-only)
+
+# Day-10 step of the intake silence ladder from PR-GATE-PLAN.md. Once a day it
+# looks at open PRs still labelled `needs-info` and, when nothing has happened
+# for NUDGE_AFTER_DAYS, posts ONE gentle reminder. It never changes labels and
+# never closes anything; the `keep-open` label suppresses the nudge entirely.
+# Idempotent via the HTML marker below: a PR that already carries a nudge
+# comment is skipped. The auto-close step is intentionally not implemented
+# until this has run for a full cycle (see #2132).
+#
+# Security posture: metadata-only. It never checks out or runs PR code.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: needs-info-nudge
+  cancel-in-progress: false
+
+env:
+  NUDGE_AFTER_DAYS: '10'
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Nudge silent needs-info PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const MARKER = '<!-- needs-info-nudge -->';
+            const NUDGE_LABEL = 'needs-info';
+            const SUPPRESS_LABEL = 'keep-open';
+            const days = Number(process.env.NUDGE_AFTER_DAYS) || 10;
+            const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+
+            const nudgeBody = [
+              MARKER,
+              'Gentle nudge: this is still waiting on the info above. If you are still on it, just reply or edit',
+              'the PR body and it stays open. If not, no worries; it stays open for now and you can pick it up',
+              'whenever you have a minute.',
+              '',
+              'The intake contract (required sections, disclosure box, gate marker) is spelled out in',
+              '[`.github/INTAKE.md`](https://github.com/' + owner + '/' + repo + '/blob/main/.github/INTAKE.md).',
+              'The intake gate comment on this PR lists exactly which pieces are missing.',
+            ].join('\n');
+
+            const openPRs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+
+            let nudged = 0;
+            for (const pr of openPRs) {
+              const labels = new Set((pr.labels || []).map(l => l.name));
+              if (!labels.has(NUDGE_LABEL) || labels.has(SUPPRESS_LABEL)) continue;
+
+              const number = pr.number;
+              const author = pr.user && pr.user.login;
+
+              // Last activity = latest of PR updated_at, last commit date, last author comment.
+              let last = Date.parse(pr.updated_at) || 0;
+
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner, repo, pull_number: number, per_page: 100,
+              });
+              for (const c of commits) {
+                const d = c.commit && c.commit.committer && c.commit.committer.date;
+                const t = Date.parse(d || '') || 0;
+                if (t > last) last = t;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: number, per_page: 100,
+              });
+              let alreadyNudged = false;
+              for (const c of comments) {
+                if ((c.body || '').includes(MARKER)) alreadyNudged = true;
+                if (c.user && c.user.login === author) {
+                  const t = Date.parse(c.created_at) || 0;
+                  if (t > last) last = t;
+                }
+              }
+
+              const ageDays = Math.floor((Date.now() - last) / (24 * 60 * 60 * 1000));
+              if (alreadyNudged) {
+                core.info(`#${number}: already nudged, skipping`);
+                continue;
+              }
+              if (last > cutoff) {
+                core.info(`#${number}: active ${ageDays}d ago, under ${days}d, skipping`);
+                continue;
+              }
+
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: number, body: nudgeBody,
+              });
+              nudged++;
+              core.info(`#${number}: nudged (silent for ${ageDays}d)`);
+            }
+            core.info(`Done: ${nudged} PR(s) nudged`);


### PR DESCRIPTION
## What problem does this solve?

PRs labelled `needs-info` by the intake gate sit open forever with no follow-up; seven are open right now, the oldest over two weeks, none with author activity. This adds the day-10 comment-only nudge from the silence ladder so authors get one kind reminder. Closes #2132.

## Why this change

A scheduled `actions/github-script` job is the smallest thing that does exactly what the issue asks: list open PRs with `needs-info` and without `keep-open`, compute last activity as the latest of PR `updated_at`, last commit date and last comment by the PR author, and post one comment carrying the `<!-- needs-info-nudge -->` marker when that is older than 10 days. A PR already carrying the marker is skipped, so the workflow is idempotent across daily runs. No label changes and no closing; `actions/stale` was rejected because it closes by default. The auto-close rung stays out of scope until this has run a full cycle.

The nudge text reuses the day-10 wording from PR-GATE-PLAN.md with one edit: the plan's line promising a close "in a week" is dropped, since closing is deliberately not implemented here and the comment should not promise something the pipeline does not do. It links `.github/INTAKE.md` and points at the intake gate comment for the specific missing pieces.

## User impact

None for people running agent-deck. Contributors with a stalled `needs-info` PR receive one reminder comment after 10 quiet days.

## Evidence

Workflow file validated:

    $ python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" .github/workflows/needs-info-nudge.yml && echo yaml ok
    yaml ok
    $ node -e "...wrap the script block in an AsyncFunction..."
    js syntax ok

Dry run of the selection filter against the live repo (open, `needs-info`, not `keep-open`) shows the seven PRs the issue describes; six of them are already past the 10 day cutoff and would be nudged on the first run, #2081 (updated 2026-08-29) would not yet:

    $ gh api "repos/asheshgoplani/agent-deck/pulls?state=open&per_page=100" --paginate --jq '.[] | select(any(.labels[]; .name=="needs-info")) | select(all(.labels[]; .name!="keep-open")) | "\(.number) updated=\(.updated_at)"'
    2081 updated=2026-08-29T11:21:29Z
    2080 updated=2026-08-27T06:59:59Z
    2072 updated=2026-08-25T10:09:49Z
    2064 updated=2026-08-24T13:16:24Z
    2043 updated=2026-08-24T10:55:02Z
    2018 updated=2026-08-23T15:25:00Z
    2011 updated=2026-08-22T19:52:59Z

`actions/github-script` is pinned to the same SHA (v9) that `pr-intake.yml` uses. Permissions are `contents: read` and `pull-requests: write` only. No Go code is touched, so `gofmt -l ./cmd ./internal` prints nothing (unchanged tree). Local go test is disallowed on this host; full suite runs in CI on this PR.

Not verified: an actual scheduled run. The first real run is on the next 06:00 UTC cron, or via `workflow_dispatch` once merged.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

https://claude.ai/code/session_01VqZQYv7fcPCDxFJ1yHHjzA

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an automated daily reminder for open pull requests labeled “needs-info” that have been inactive for at least 10 days.
  - Reminders avoid duplicate comments and skip pull requests marked to remain open.
  - The workflow can also be triggered manually and does not modify labels or close pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->