### PR TITLE
ci(deps): auto-merge Dependabot patch and minor bumps on green CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,6 +85,12 @@ token), not that the release is bad.
 Both expect `secrets.NTFY_TOPIC` to be set on the repo. Neither blocks
 anything — they can fail silently without affecting merges.
 
+## Merge automation (no gate, no build)
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `dependabot-automerge.yml` | `pull_request_target` opened or synchronized by `dependabot[bot]` | Enables GitHub auto-merge (squash) on Dependabot PRs whose `dependabot/fetch-metadata` update-type is `semver-patch` or `semver-minor` and that touch nothing under `.github/`. It never approves the PR and never bypasses the ruleset: the merge still waits for the required human review and the four required checks (`intake`, `Full test suite (PR gate)`, `golangci`, `analyze`). Major bumps and `.github/` changes are skipped and keep the normal review path (#2131). |
+
 ## Schedule-only (alert-only, not a PR gate)
 
 | Workflow | Trigger | What it does |

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,81 @@
+name: Dependabot auto-merge
+
+# Enables GitHub auto-merge (squash) on Dependabot pull requests that only bump
+# a dependency by a patch or minor version, so they land the moment CI is green
+# instead of waiting days for a human to press the button (#2131).
+#
+# What this workflow does NOT do:
+#   - It never approves the PR. The ruleset's required review is still supplied
+#     by a human. The workflow only flips the auto-merge flag, and GitHub merges
+#     the PR once the required review and all four required status checks
+#     (intake, Full test suite (PR gate), golangci, analyze) are satisfied.
+#   - It never bypasses or edits the ruleset. Auto-merge honours every branch
+#     rule exactly as a manual merge would.
+#   - It skips major bumps and any PR that touches .github/ (workflows, actions,
+#     intake config); those keep the normal review path.
+#
+# Security posture: pull_request_target runs with base-repo permissions. This
+# job never checks out or executes PR code. It reads PR metadata via
+# dependabot/fetch-metadata and the gh CLI, and it is gated on the actor being
+# dependabot[bot], so a fork PR from anyone else is a no-op.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Decide whether the bump qualifies for auto-merge
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "update-type: ${UPDATE_TYPE}"
+          case "${UPDATE_TYPE}" in
+            version-update:semver-patch|version-update:semver-minor) ;;
+            *)
+              echo "Not a patch or minor bump; leaving the PR on the normal review path."
+              echo "eligible=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+          changed="$(gh pr diff "${PR_NUMBER}" --repo "${REPO}" --name-only)"
+          echo "Changed files:"
+          echo "${changed}"
+          if printf '%s\n' "${changed}" | grep -q '^\.github/'; then
+            echo "PR touches .github/; leaving the PR on the normal review path."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge (squash)
+        if: steps.decide.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          gh pr merge --auto --squash "${PR_URL}"
+          echo "Auto-merge enabled. GitHub merges once the required review and required checks pass."


### PR DESCRIPTION
## What problem does this solve?

Closes #2131. Dependabot patch and minor bumps sat open for a median of 133 hours (19 of the last 400 PRs), the same as a human-authored external PR, even though they pass the same four required checks and carry no decision value. They inflate the open count and eat review attention.

## Why this change

A dedicated `pull_request_target` workflow gated on `github.actor == 'dependabot[bot]'` reads `dependabot/fetch-metadata`'s `update-type`. For `version-update:semver-patch` and `version-update:semver-minor` it confirms via `gh pr diff --name-only` that nothing under `.github/` changed, then runs `gh pr merge --auto --squash`. Major bumps and `.github/` changes are skipped and keep the normal review path.

The workflow deliberately does not approve the PR and does not touch the ruleset. GitHub auto-merge honours every branch rule, so the merge still waits for the required human review plus the four required checks (`intake`, `Full test suite (PR gate)`, `golangci`, `analyze`). The maintainer's one click on Approve is now the only manual step; the merge follows automatically once CI is green. The job never checks out or executes PR code, and `dependabot/fetch-metadata` is pinned to a commit SHA (v2), matching the SHA-pinned style already used in `pr-intake.yml`.

`.github/dependabot.yml` already groups gomod and github-actions minor/patch updates, so it is left unchanged; grouped PRs report the highest update-type in the group, which is what the gate keys on.

## User impact

None for people running agent-deck. Repo automation only: Dependabot patch and minor PRs merge as soon as review and CI are satisfied, and the open PR count drops.

## Evidence

    $ python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('yaml ok')" .github/workflows/dependabot-automerge.yml
    yaml ok
    $ gofmt -l ./cmd ./internal      # printed nothing
    $ go build ./...                 # ok
    $ go vet ./...                   # ok
    $ gh api repos/asheshgoplani/agent-deck/rulesets/19154467   # confirmed: squash only, 1 required approval, required checks intake / Full test suite (PR gate) / golangci / analyze

Local go test is disallowed on this host; full suite runs in CI on this PR.

The workflow itself cannot be exercised from a branch: `pull_request_target` runs the version on `main`, so the first real proof is the next Dependabot PR after this merges. Expected log lines on that run: `update-type: version-update:semver-...`, the changed file list, and `Auto-merge enabled.`

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated handling for eligible Dependabot updates.
  * Patch and minor dependency updates may now be automatically squash-merged when they do not modify workflow configuration.
  * Updates outside these criteria continue through the standard review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->