### PR TITLE
ci(workflows): surface PRs stuck in action_required

### DIFF
--- a/.github/scripts/ci-stalled-notify.cjs
+++ b/.github/scripts/ci-stalled-notify.cjs
@@ -1,0 +1,61 @@
+// ci-stalled-notify.cjs -- pure decision logic for .github/workflows/ci-stalled-notify.yml
+//
+// Kept outside the workflow so it can be unit tested with `node --test`
+// (tests/ci/ci-stalled-notify.test.cjs) and required from github-script.
+//
+// Two reconciliation rules the review asked for:
+//   1. A workflow_run event carries the head sha it ran for. If the PR has
+//      moved on to a newer head, the event is stale and must not touch the
+//      label, otherwise a delayed completion for head A clears a stall that
+//      is real on head B.
+//   2. Completion of one gating workflow must not clear the label while
+//      another gating workflow on the same head is still action_required.
+//      The caller passes every run for the current head; the label is
+//      removed only when none of them is waiting for approval.
+
+'use strict'
+
+const STALLED = 'action_required'
+
+/**
+ * Decide what to do with the stall label for one PR.
+ *
+ * @param {object} input
+ * @param {string} input.runHeadSha        head sha the workflow_run event ran for
+ * @param {string} input.runConclusion     conclusion of that run ('action_required', 'success', ...)
+ * @param {string} input.prHeadSha         live head sha of the PR
+ * @param {boolean} input.labeled          whether the PR currently carries the stall label
+ * @param {Array<{name:string, head_sha:string, conclusion:string|null}>} input.currentHeadRuns
+ *        every run known for prHeadSha (any workflow); filtered here by gatingWorkflows
+ * @param {string[]} input.gatingWorkflows workflow display names that count as gates
+ * @returns {{action: 'add'|'remove'|'none', reason: string}}
+ */
+function reconcile({ runHeadSha, runConclusion, prHeadSha, labeled, currentHeadRuns, gatingWorkflows }) {
+  if (!runHeadSha || !prHeadSha) {
+    return { action: 'none', reason: 'missing head sha' }
+  }
+  if (runHeadSha !== prHeadSha) {
+    return { action: 'none', reason: `stale event: run head ${short(runHeadSha)} != PR head ${short(prHeadSha)}` }
+  }
+
+  if (runConclusion === STALLED) {
+    if (labeled) return { action: 'none', reason: 'already labeled' }
+    return { action: 'add', reason: 'a gating run on the current head is action_required' }
+  }
+
+  const gates = new Set(gatingWorkflows || [])
+  const stillWaiting = (currentHeadRuns || []).filter(r =>
+    r && r.head_sha === prHeadSha && gates.has(r.name) && r.conclusion === STALLED)
+  if (stillWaiting.length > 0) {
+    const names = [...new Set(stillWaiting.map(r => r.name))].join(', ')
+    return { action: 'none', reason: `other gating run(s) still action_required on this head: ${names}` }
+  }
+  if (labeled) return { action: 'remove', reason: 'no gating run on the current head is action_required' }
+  return { action: 'none', reason: 'not labeled and nothing waiting' }
+}
+
+function short(sha) {
+  return String(sha).slice(0, 8)
+}
+
+module.exports = { reconcile, STALLED }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,9 +101,10 @@ token), not that the release is bad.
 | `issue-notify.yml` | issue opened | Posts issue context (title, body, labels, related issues, recent commits) to the configured ntfy topic so the conductor picks it up. |
 | `pr-notify.yml` | PR opened or marked ready-for-review | Posts PR context (files, commits, reviews, comments) to the same ntfy topic. |
 | `issue-intake.yml` | issue opened | Adds `triage` plus one advisory type label (`bug`, `feature`, `documentation`, `question`) from the same keyword heuristic as `issue-notify.yml`, only when the issue has no labels at all. Never removes labels, never comments. Needs no secret. (#2128) |
+| `ci-stalled-notify.yml` | `workflow_run` (completed) for `Go tests`, `golangci-lint`, `CodeQL`; plus a `selftest` job on PRs touching it | When a gating run for an open PR's current head is `action_required` (fork PR waiting for "Approve and run"), adds the `needs-ci` label and posts `CI needs approval: #<n>` to the same ntfy topic; removes the label only when no gating run for that head is still waiting. Stale events for an older head are ignored. Never comments on the PR. (#2130) |
 
-The two notify workflows expect `secrets.NTFY_TOPIC` to be set on the repo. None of these block
-anything — they can fail silently without affecting merges.
+The notify workflows and `ci-stalled-notify.yml` expect `secrets.NTFY_TOPIC` to be set on the repo. None of these block
+anything; they can fail silently without affecting merges.
 
 ## Schedule-only (alert-only, not a PR gate)
 

--- a/.github/workflows/ci-stalled-notify.yml
+++ b/.github/workflows/ci-stalled-notify.yml
@@ -1,0 +1,122 @@
+name: CI stalled notify
+
+# Fork PRs from first-time contributors sit with every workflow at
+# `action_required` until a maintainer clicks "Approve and run". Nothing else
+# surfaces that state; the PR just looks like CI never reported. This workflow
+# listens to the gating workflows, labels the PR `needs-ci` while a run is
+# waiting for approval, posts to the same ntfy topic pr-notify.yml uses, and
+# clears the label once any run for that head completes. It never comments on
+# the PR.
+
+on:
+  workflow_run:
+    workflows: ["Go tests", "golangci-lint", "CodeQL"]
+    types: [requested, completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+env:
+  STALL_LABEL: needs-ci
+
+jobs:
+  stalled:
+    runs-on: ubuntu-latest
+    # Only two states matter: a run waiting for approval, or a run that finished.
+    # A plain `requested` event with no conclusion yet is a normal start.
+    if: >-
+      github.event.workflow_run.conclusion == 'action_required' ||
+      github.event.action == 'completed'
+    steps:
+      - name: Find PR and reconcile label
+        id: reconcile
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const label = process.env.STALL_LABEL;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Prefer the PRs GitHub attached to the run. That list is empty for
+            // fork PRs, which is exactly the case this workflow exists for, so
+            // fall back to the open PRs whose head sha matches the run.
+            let prs = (run.pull_requests || []).map(p => p.number);
+            if (prs.length === 0) {
+              const open = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+              prs = open.filter(p => p.head.sha === run.head_sha).map(p => p.number);
+            }
+            if (prs.length === 0) {
+              const found = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} is:pr is:open sha:${run.head_sha}`,
+                per_page: 5,
+              });
+              prs = found.data.items.map(i => i.number);
+            }
+            if (prs.length === 0) {
+              core.info(`No open PR for ${run.head_sha} (${run.name} #${run.run_number}); nothing to do.`);
+              core.setOutput('notify', 'false');
+              return;
+            }
+
+            const stalled = run.conclusion === 'action_required';
+            const notify = [];
+
+            for (const number of prs) {
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+              if (pr.state !== 'open') continue;
+              const labeled = pr.labels.some(l => l.name === label);
+
+              if (stalled) {
+                if (labeled) {
+                  core.info(`#${number} already labeled ${label}; skipping duplicate notification.`);
+                  continue;
+                }
+                await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [label] });
+                core.info(`Labeled #${number} ${label} (${run.name} is action_required).`);
+                notify.push({
+                  type: 'ci_stalled',
+                  number,
+                  title: pr.title,
+                  url: pr.html_url,
+                  author: pr.user.login,
+                  head_branch: pr.head.ref,
+                  head_sha: run.head_sha,
+                  workflow: run.name,
+                  run_url: run.html_url,
+                  conclusion: run.conclusion,
+                });
+              } else if (labeled) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: label });
+                core.info(`Removed ${label} from #${number} (${run.name} concluded ${run.conclusion}).`);
+              }
+            }
+
+            core.setOutput('notify', notify.length > 0 ? 'true' : 'false');
+            // Base64 so the JSON survives the outputs boundary unchanged, as pr-notify.yml does.
+            core.setOutput('context_b64', Buffer.from(JSON.stringify(notify)).toString('base64'));
+
+      - name: Send to ntfy
+        if: steps.reconcile.outputs.notify == 'true'
+        env:
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          CONTEXT_B64: ${{ steps.reconcile.outputs.context_b64 }}
+        run: |
+          # Decode the list; one notification per newly labeled PR.
+          CONTEXT=$(echo "$CONTEXT_B64" | base64 -d)
+
+          echo "$CONTEXT" | jq -c '.[]' | while read -r ITEM; do
+            PR_NUM=$(echo "$ITEM" | jq -r '.number')
+            PR_TITLE=$(echo "$ITEM" | jq -r '.title')
+
+            curl -s \
+              -H "Title: CI needs approval: #${PR_NUM} ${PR_TITLE}" \
+              -H "Priority: high" \
+              -H "Tags: github,ci,approval" \
+              -d "$ITEM" \
+              "https://ntfy.sh/${NTFY_TOPIC}"
+          done

--- a/.github/workflows/ci-stalled-notify.yml
+++ b/.github/workflows/ci-stalled-notify.yml
@@ -3,15 +3,29 @@ name: CI stalled notify
 # Fork PRs from first-time contributors sit with every workflow at
 # `action_required` until a maintainer clicks "Approve and run". Nothing else
 # surfaces that state; the PR just looks like CI never reported. This workflow
-# listens to the gating workflows, labels the PR `needs-ci` while a run is
-# waiting for approval, posts to the same ntfy topic pr-notify.yml uses, and
-# clears the label once any run for that head completes. It never comments on
-# the PR.
+# listens to the gating workflows, labels the PR `needs-ci` while a gating run
+# on the PR's current head is waiting for approval, posts to the same ntfy
+# topic pr-notify.yml uses, and clears the label only when no gating run on
+# that head is waiting any more. It never comments on the PR.
+#
+# Reconciliation rules (decision logic lives in
+# .github/scripts/ci-stalled-notify.cjs, unit tested by
+# tests/ci/ci-stalled-notify.test.cjs and the `selftest` job below):
+#   - an event whose head sha is not the PR's live head is stale and ignored,
+#     so a delayed completion for an old head cannot clear a real stall;
+#   - the label is removed only when every gating run for the current head
+#     has left action_required, not when any single run completes.
 
 on:
   workflow_run:
     workflows: ["Go tests", "golangci-lint", "CodeQL"]
     types: [requested, completed]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/ci-stalled-notify.yml'
+      - '.github/scripts/ci-stalled-notify.cjs'
+      - 'tests/ci/ci-stalled-notify.test.cjs'
 
 permissions:
   pull-requests: write
@@ -20,23 +34,38 @@ permissions:
 
 env:
   STALL_LABEL: needs-ci
+  GATING_WORKFLOWS: '["Go tests", "golangci-lint", "CodeQL"]'
 
 jobs:
-  stalled:
+  # Runs on PRs that touch this workflow or its logic, so the reconciliation
+  # rules are exercised by CI before they are trusted on workflow_run events.
+  selftest:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    # Only two states matter: a run waiting for approval, or a run that finished.
-    # A plain `requested` event with no conclusion yet is a normal start.
-    if: >-
-      github.event.workflow_run.conclusion == 'action_required' ||
-      github.event.action == 'completed'
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Unit test the reconciliation logic
+        run: node --test tests/ci/ci-stalled-notify.test.cjs
+
+  stalled:
+    # Only completed events carry a conclusion (action_required included);
+    # a plain `requested` event is a normal run start.
+    if: github.event_name == 'workflow_run' && github.event.action == 'completed'
+    runs-on: ubuntu-latest
+    steps:
+      # The script is read from the default branch, never from the PR head.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Find PR and reconcile label
         id: reconcile
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
+            const path = require('path');
+            const { reconcile } = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/ci-stalled-notify.cjs'));
             const run = context.payload.workflow_run;
             const label = process.env.STALL_LABEL;
+            const gatingWorkflows = JSON.parse(process.env.GATING_WORKFLOWS);
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
@@ -63,21 +92,30 @@ jobs:
               return;
             }
 
-            const stalled = run.conclusion === 'action_required';
             const notify = [];
-
             for (const number of prs) {
               const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
               if (pr.state !== 'open') continue;
               const labeled = pr.labels.some(l => l.name === label);
 
-              if (stalled) {
-                if (labeled) {
-                  core.info(`#${number} already labeled ${label}; skipping duplicate notification.`);
-                  continue;
-                }
+              // Every run for the PR's live head, so one completion cannot
+              // clear the label while another gate is still waiting.
+              const currentHeadRuns = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                owner, repo, head_sha: pr.head.sha, per_page: 100,
+              });
+
+              const decision = reconcile({
+                runHeadSha: run.head_sha,
+                runConclusion: run.conclusion,
+                prHeadSha: pr.head.sha,
+                labeled,
+                currentHeadRuns: currentHeadRuns.map(r => ({ name: r.name, head_sha: r.head_sha, conclusion: r.conclusion })),
+                gatingWorkflows,
+              });
+              core.info(`#${number}: ${decision.action} (${decision.reason})`);
+
+              if (decision.action === 'add') {
                 await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [label] });
-                core.info(`Labeled #${number} ${label} (${run.name} is action_required).`);
                 notify.push({
                   type: 'ci_stalled',
                   number,
@@ -85,14 +123,13 @@ jobs:
                   url: pr.html_url,
                   author: pr.user.login,
                   head_branch: pr.head.ref,
-                  head_sha: run.head_sha,
+                  head_sha: pr.head.sha,
                   workflow: run.name,
                   run_url: run.html_url,
                   conclusion: run.conclusion,
                 });
-              } else if (labeled) {
+              } else if (decision.action === 'remove') {
                 await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: label });
-                core.info(`Removed ${label} from #${number} (${run.name} concluded ${run.conclusion}).`);
               }
             }
 
@@ -111,7 +148,7 @@ jobs:
 
           echo "$CONTEXT" | jq -c '.[]' | while read -r ITEM; do
             PR_NUM=$(echo "$ITEM" | jq -r '.number')
-            PR_TITLE=$(echo "$ITEM" | jq -r '.title')
+            PR_TITLE=$(echo "$ITEM" | jq -r '.title' | tr -d '\r\n')
 
             curl -s \
               -H "Title: CI needs approval: #${PR_NUM} ${PR_TITLE}" \

--- a/tests/ci/ci-stalled-notify.test.cjs
+++ b/tests/ci/ci-stalled-notify.test.cjs
@@ -1,0 +1,114 @@
+// tests/ci/ci-stalled-notify.test.cjs -- unit tests for the stall-label
+// reconciliation used by .github/workflows/ci-stalled-notify.yml.
+// Run: node --test tests/ci/ci-stalled-notify.test.cjs
+
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { reconcile } = require('../../.github/scripts/ci-stalled-notify.cjs')
+
+const GATES = ['Go tests', 'golangci-lint', 'CodeQL']
+const A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+function run(name, head_sha, conclusion) {
+  return { name, head_sha, conclusion }
+}
+
+test('stalled run on the current head adds the label', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'action_required', prHeadSha: A, labeled: false,
+    currentHeadRuns: [run('Go tests', A, 'action_required')], gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'add')
+})
+
+test('stalled run on an already labeled PR does nothing', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'action_required', prHeadSha: A, labeled: true,
+    currentHeadRuns: [], gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'none')
+  assert.match(r.reason, /already labeled/)
+})
+
+test('delayed completion for an old head never clears a stall on the new head', () => {
+  // Head A finished late; the PR has moved to head B, which is stalled.
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'success', prHeadSha: B, labeled: true,
+    currentHeadRuns: [run('Go tests', B, 'action_required')], gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'none')
+  assert.match(r.reason, /stale event/)
+})
+
+test('a stale action_required event for an old head does not add the label either', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'action_required', prHeadSha: B, labeled: false,
+    currentHeadRuns: [run('Go tests', B, 'success')], gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'none')
+  assert.match(r.reason, /stale event/)
+})
+
+test('one gate completing keeps the label while another gate on the same head still waits', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'success', prHeadSha: A, labeled: true,
+    currentHeadRuns: [
+      run('golangci-lint', A, 'success'),
+      run('Go tests', A, 'action_required'),
+      run('CodeQL', A, 'success'),
+    ],
+    gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'none')
+  assert.match(r.reason, /Go tests/)
+})
+
+test('label is removed once every gate on the current head has left action_required', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'success', prHeadSha: A, labeled: true,
+    currentHeadRuns: [
+      run('golangci-lint', A, 'success'),
+      run('Go tests', A, 'failure'),
+      run('CodeQL', A, 'success'),
+    ],
+    gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'remove')
+})
+
+test('non-gating workflows waiting for approval do not hold the label', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'success', prHeadSha: A, labeled: true,
+    currentHeadRuns: [
+      run('Go tests', A, 'success'),
+      run('Structure advisory', A, 'action_required'),
+    ],
+    gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'remove')
+})
+
+test('runs recorded for another head are ignored when aggregating', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'success', prHeadSha: A, labeled: true,
+    currentHeadRuns: [run('Go tests', B, 'action_required'), run('Go tests', A, 'success')],
+    gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'remove')
+})
+
+test('completion on an unlabeled PR with nothing waiting is a no-op', () => {
+  const r = reconcile({
+    runHeadSha: A, runConclusion: 'success', prHeadSha: A, labeled: false,
+    currentHeadRuns: [], gatingWorkflows: GATES,
+  })
+  assert.equal(r.action, 'none')
+})
+
+test('missing shas never mutate labels', () => {
+  assert.equal(reconcile({ runHeadSha: '', runConclusion: 'action_required', prHeadSha: A, labeled: false, currentHeadRuns: [], gatingWorkflows: GATES }).action, 'none')
+  assert.equal(reconcile({ runHeadSha: A, runConclusion: 'success', prHeadSha: undefined, labeled: true, currentHeadRuns: [], gatingWorkflows: GATES }).action, 'none')
+})


### PR DESCRIPTION
## What problem does this solve?

Fork PRs from first-time contributors sit with every workflow at `action_required` (0 s elapsed) until the maintainer clicks "Approve and run". Nothing in the repo or the conductor pipeline surfaces that state, so the PR just looks like CI never reported. Closes #2130.

## Why this change

A repo workflow on `workflow_run` is always running, unlike the conductor (the issue rejected polling `gh run list` for that reason). The new `.github/workflows/ci-stalled-notify.yml` listens to the three gating workflows by their exact `name:` values (`Go tests`, `golangci-lint`, `CodeQL`) with `types: [requested, completed]`. In `actions/github-script@v9` it resolves the open PR for the run's head sha (`workflow_run.pull_requests` first, which is empty for fork PRs, then open PRs matched by `head.sha`, then a `sha:` search). If the run's conclusion is `action_required` it adds the existing `needs-ci` label and posts to ntfy the same way `pr-notify.yml` does (same `NTFY_TOPIC` secret, `Title: CI needs approval: #<n> <title>`, `Priority: high`, `Tags: github,ci,approval`). On a `completed` event with any other conclusion it removes `needs-ci` if present. It never comments on the PR.

Two small design choices: the notification is only sent when the label was newly added, so three stalled workflows on one push produce one ntfy post instead of three; and a `requested` event with no conclusion yet is filtered at the job `if`, since that is a normal run start. Permissions are least privilege: `pull-requests: write`, `actions: read`, `contents: read`.

## User impact

None for agent-deck users; this is repo CI only. The maintainer gets a `needs-ci` label and an ntfy push whenever a fork PR is waiting for workflow approval, and the label clears itself once CI runs.

## Evidence

Local checks in the worktree:

    $ python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('yaml ok')" .github/workflows/ci-stalled-notify.yml
    yaml ok
    $ gh label list -R asheshgoplani/agent-deck --search needs-ci
    needs-ci    Accepted in principle; blocked on the author greening CI    #fbca04
    $ gofmt -l ./cmd ./internal      # printed nothing
    $ go build ./...                 # ok
    $ go vet ./...                   # ok

No Go code changed. Local go test is disallowed on this host; full suite runs in CI on this PR.

The workflow itself cannot be exercised from a branch: `workflow_run` triggers only run from the default branch, so the first real verification is the next fork PR after this lands. The `action_required` shape it keys on was observed twice in the last 50 runs on `fix/remote-sandbox-flag` per the issue.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests awaiting approval for required CI checks are now labeled `needs-ci`.
  - High-priority notifications are sent when required CI approval is pending.
  - The `needs-ci` label is removed only after all relevant checks for the latest pull request revision no longer require approval.
  - Pull requests are not updated with comments as part of this process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->