### PR TITLE
docs(ci): list the real required PR checks in workflows README and pr-intake

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,15 +8,34 @@ actionable regression.
 
 ## Active PR gates (block merge)
 
-These run on pull requests and **must go green** before merge.
+The `main-protection` ruleset requires exactly these four status check
+contexts on the current tip of every PR. The context name is the **job id**
+(or the job's `name:` when one is set), so renaming a job here silently drops
+it from the gate; keep the ruleset and this table in lockstep.
 
-| Workflow | Trigger | What it gates |
+| Context | Workflow (job) | What it gates |
 |---|---|---|
-| `session-persistence.yml` | PR touching tmux/session lifecycle paths, or `workflow_dispatch` | The eight `TestPersistence_*` tests (race-detector on) plus `scripts/verify-session-persistence.sh` end-to-end. Covers the class of bug where a single SSH logout destroys every managed tmux session on Linux+systemd. See the "Session persistence: mandatory test coverage" section in the root `CLAUDE.md`. |
-| `lighthouse-ci.yml` | PR touching `internal/web/**`, `.lighthouserc.json`, `tests/lighthouse/**`, or the workflow itself; also re-runs on `labeled` / `unlabeled` so the override below is reactive | Two-layer Lighthouse gate against `agent-deck web --no-tui`: (1) absolute thresholds in `.lighthouserc.json` (`total-byte-weight`, `resource-summary:script:size`, `cumulative-layout-shift` as hard error; FCP/LCP/TBT/Speed Index as soft warn); (2) bundle-delta gate (`tests/lighthouse/compare-deltas.mjs`) that fails if a single PR grows `total-byte-weight` or `script:size` by more than 5% vs the base ref. Reinstated in v1.7.70 after the `--no-tui` flag fixed the bubbletea/headless-CI start failure that disabled the gate in v1.7.42. **Maintainer override on the delta gate**: apply the `lighthouse-regression-acknowledged` label (auto-created by the workflow) to acknowledge an intentional regression — the workflow re-runs on the `labeled` event and the check turns green. The absolute thresholds in layer (1) do not participate in the override. |
+| `intake` | `pr-intake.yml` (`intake`) | PR description format against the contract in `.github/INTAKE.md`: required headings, one AI-disclosure box, a real "What actually bothered you" section. Labels `intake:clean` or `needs-info` and posts one comment; it never closes or requests changes. The job itself exits green in both outcomes, so what the ruleset enforces today is that `intake` has reported on the current tip; a `needs-info` body is surfaced by label and comment for the human merger. |
+| `Full test suite (PR gate)` | `go-test.yml` (`full-test-suite`) | The exact release-gate test step (`gotestsum`, `-race ./...`) on every PR, no path filter, short-circuiting when the diff touches nothing Go-related. |
+| `golangci` | `golangci-lint.yml` (`golangci`) | `golangci-lint` over the whole module. |
+| `analyze` | `codeql.yml` (`analyze`) | CodeQL security analysis of the Go code. |
 
-Any other red on a PR is either a pre-release workflow (see below) or a bug —
+Any other red on a PR is either a pre-release workflow (see below) or a bug:
 file an issue and fix it, don't merge through it.
+
+## Runs on PRs but does not block
+
+These run on pull requests and are worth reading when red, but the ruleset does
+not require them. A path-filtered workflow cannot be a required check: when the
+PR touches none of its paths it never reports at all, and a required context
+that never reports blocks the merge forever (see the header comment in
+`go-test.yml`).
+
+| Workflow (job) | Trigger | Why it does not block |
+|---|---|---|
+| `session-persistence.yml` | PR touching tmux/session lifecycle paths, or `workflow_dispatch` | Path filter. Runs the eight `TestPersistence_*` tests (race-detector on) plus `scripts/verify-session-persistence.sh` end-to-end. Covers the class of bug where a single SSH logout destroys every managed tmux session on Linux+systemd. See the "Session persistence: mandatory test coverage" section in the root `CLAUDE.md`. The same tests also run inside `Full test suite (PR gate)`, which is required. |
+| `lighthouse-ci.yml` | PR touching `internal/web/**`, `.lighthouserc.json`, `tests/lighthouse/**`, or the workflow itself; also re-runs on `labeled` / `unlabeled` so the override below is reactive | Path filter. Two-layer Lighthouse gate against `agent-deck web --no-tui`: (1) absolute thresholds in `.lighthouserc.json` (`total-byte-weight`, `resource-summary:script:size`, `cumulative-layout-shift` as hard error; FCP/LCP/TBT/Speed Index as soft warn); (2) bundle-delta gate (`tests/lighthouse/compare-deltas.mjs`) that fails if a single PR grows `total-byte-weight` or `script:size` by more than 5% vs the base ref. Reinstated in v1.7.70 after the `--no-tui` flag fixed the bubbletea/headless-CI start failure that disabled the gate in v1.7.42. **Maintainer override on the delta gate**: apply the `lighthouse-regression-acknowledged` label (auto-created by the workflow) to acknowledge an intentional regression; the workflow re-runs on the `labeled` event and the check turns green. The absolute thresholds in layer (1) do not participate in the override. |
+| `go-test.yml` (`native-ssh`, `native-ssh-macos`) | Every PR, same trigger as `full-test-suite` | Not a ruleset context. Runs `scripts/ci-native-ssh.sh` against a real sshd on Linux and macOS and uploads the evidence artifact. Despite the "Required" in the job display name, only `Full test suite (PR gate)` from this workflow is in the ruleset. |
 
 ## Release automation (tag-triggered)
 
@@ -111,7 +130,7 @@ fixtures.
 
 | Workflow | Status |
 |---|---|
-| `lighthouse-ci.yml` | **Reinstated in v1.7.70.** Listed under "Active PR gates" above. Thresholds re-baselined against the current webui bundle (`./tests/lighthouse/calibrate.sh` output) and the `--no-tui` flag is wired through `.lighthouserc.json`, `tests/lighthouse/*.sh`, and `weekly-regression.yml`. |
+| `lighthouse-ci.yml` | **Reinstated in v1.7.70.** Listed under "Runs on PRs but does not block" above. Thresholds re-baselined against the current webui bundle (`./tests/lighthouse/calibrate.sh` output) and the `--no-tui` flag is wired through `.lighthouserc.json`, `tests/lighthouse/*.sh`, and `weekly-regression.yml`. |
 | `visual-regression.yml` | **Still removed.** The server-start issue is fixed by `--no-tui`, but the screenshot baselines under `tests/e2e/visual/__screenshots__/` were never re-baselined and the suite still flakes on shared runners. The same matrix continues to run weekly via `weekly-regression.yml` (now reliably, since `--no-tui` lets the server bind). |
 
 Reach the repo at commits before v1.7.42 (`a4b7079^`) if you need the

--- a/.github/workflows/pr-intake.yml
+++ b/.github/workflows/pr-intake.yml
@@ -1,10 +1,17 @@
-name: PR Intake Gate (observe-only)
+name: PR Intake Gate
 
-# Reads the PR body against the intake contract in .github/INTAKE.md, applies
-# advisory labels, and posts ONE kind comment. This is OBSERVE-ONLY: it never
-# closes, blocks, or requests changes — it only labels and explains. The visible
-# template sections are authoritative; the trailing gate marker is a parse-stable
-# confirmation. See PR-GATE-PLAN.md for the rollout design.
+# Required status check on PR description format. The `main-protection`
+# ruleset lists the `intake` job id as a required context, so no PR can merge
+# until this job has reported on its current tip. Do not rename the `intake`
+# job id. The job exits green in both outcomes; a body that misses the contract
+# in .github/INTAKE.md is surfaced by the `needs-info` label and the comment,
+# not by a red check.
+#
+# What it does: reads the PR body against .github/INTAKE.md, applies the
+# `intake:clean` or `needs-info` label, and posts ONE kind comment explaining
+# what is missing. It never closes the PR, never requests changes, and never
+# touches PR code. The visible template sections are authoritative; the
+# trailing gate marker is a parse-stable confirmation.
 #
 # Security posture: pull_request_target runs in the base-repo context (needed to
 # label/comment on fork PRs), so this job is metadata-only. It never checks out,


### PR DESCRIPTION
## What problem does this solve?

Closes #2129. `.github/workflows/README.md` told contributors that `session-persistence.yml` and `lighthouse-ci.yml` were the active PR gates, while the live `main-protection` ruleset actually requires `intake`, `Full test suite (PR gate)`, `golangci` and `analyze`. `pr-intake.yml` still called itself "observe-only" even though `intake` is a required context. Contributors and the conductor reasoned from the wrong gate list.

## Why this change

Docs only. The README "Active PR gates" table now lists exactly the four ruleset contexts with their workflow file and job id. The path-filtered workflows (`session-persistence.yml`, `lighthouse-ci.yml`) and the `native-ssh` / `native-ssh-macos` jobs of `go-test.yml` move to a new "Runs on PRs but does not block" table with the reason, pointing at the `go-test.yml` header comment on why a path-filtered check cannot be required. The `pr-intake.yml` header and display name now say it is a required status check on PR description format, link `.github/INTAKE.md`, and drop the reference to the missing `PR-GATE-PLAN.md`. The `intake` job id is untouched because the ruleset matches on it.

One accuracy note: the intake job script never calls `core.setFailed`, so it exits green whether the body is clean or `needs-info`. The docs say so explicitly rather than claiming a `needs-info` body turns the check red. Making `needs-info` fail the job would be a behavior change and belongs in its own issue.

## User impact

None for people running agent-deck. Contributors and the conductor get the correct list of merge-blocking checks.

## Evidence

Live ruleset, queried on this branch:

```
$ gh api repos/asheshgoplani/agent-deck/rulesets --jq '.[].id'
19154467
$ gh api repos/asheshgoplani/agent-deck/rulesets/19154467 --jq '.rules[] | select(.type=="required_status_checks")'
{"parameters":{"do_not_enforce_on_create":false,"required_status_checks":[{"context":"intake"},{"context":"Full test suite (PR gate)"},{"context":"golangci"},{"context":"analyze"}],"strict_required_status_checks_policy":false},"type":"required_status_checks"}
```

Job ids confirmed from the workflow files: `go-test.yml` job `full-test-suite` with `name: Full test suite (PR gate)`, `golangci-lint.yml` job `golangci`, `codeql.yml` job `analyze`, `pr-intake.yml` job `intake`.

```
$ python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('yaml ok')" .github/workflows/pr-intake.yml
yaml ok
$ gofmt -l ./cmd ./internal      (no output)
$ go build ./...                 ok
$ go vet ./...                   ok
```

Local go test is disallowed on this host; full suite runs in CI on this PR.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

https://claude.ai/code/session_01VqZQYv7fcPCDxFJ1yHHjzA

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
