### PR TITLE
feat(conductor): record per-PR stage timestamps as JSONL

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Compatibility test suite
         run: python -m pytest conductor/tests/test_python_compat.py -v
 
+      - name: Stage report tests
+        run: python -m pytest conductor/tests/test_stage_report.py -v
+
   watchdog-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/conductor/README.md
+++ b/conductor/README.md
@@ -25,3 +25,11 @@ embedded canonical file is the only place to change the bridge. Tests under
 `conductor/tests/` load that same canonical file (see
 `conductor/tests/conftest.py`), so the tested bytes are exactly the deployed
 bytes.
+
+## Stage events
+
+Per-PR pipeline timing is recorded as JSONL, one line per stage transition,
+instead of per-merge receipts and metrics prose. The schema, the
+`scripts/stage-event.sh` recorder and the `scripts/stage-report.py` summary
+(median and p90 per transition, maintainer versus external) are documented in
+[STAGE-EVENTS.md](STAGE-EVENTS.md).

--- a/conductor/STAGE-EVENTS.md
+++ b/conductor/STAGE-EVENTS.md
@@ -1,0 +1,70 @@
+# Stage events
+
+One JSON object per line, appended to a JSONL file as a PR moves through the
+pipeline. This replaces per-merge receipts, hash readbacks and metrics prose:
+the conductor records one line per transition and `stage-report.py` turns the
+file into cycle time, ready-to-merge wait and blocked time after the fact.
+
+## Schema
+
+| Field   | Type   | Required | Meaning |
+|---------|--------|----------|---------|
+| `pr`    | int    | yes      | Pull request number |
+| `stage` | string | yes      | One of the stages below |
+| `ts`    | string | yes      | RFC3339 timestamp in UTC, e.g. `2026-09-06T14:03:11Z` |
+| `actor` | string | yes      | GitHub login of whoever caused the transition (or the conductor's name) |
+| `repo`  | string | yes      | `owner/name` |
+| `note`  | string | no       | Free text, kept short |
+
+Stages, in the order a PR normally passes through them:
+
+| Stage            | When to record it |
+|------------------|-------------------|
+| `arrived`        | The PR was opened (use the GitHub `created_at` time when backfilling) |
+| `discovered`     | The conductor first saw the PR |
+| `triaged`        | Intake label applied or a human decided what to do with it |
+| `review_started` | Review work actually began |
+| `verdict`        | A review verdict was posted (approve, changes requested, close) |
+| `ci_green`       | Required checks passed on the head that will merge |
+| `merged`         | The PR was merged |
+| `closed`         | The PR was closed without merging |
+
+Unknown stage names are rejected by `stage-event.sh`. A PR can carry several
+events with the same stage (for example two `verdict` lines after a re-review);
+the report uses the first occurrence of each stage per PR.
+
+## Example
+
+```jsonl
+{"pr": 2135, "stage": "arrived", "ts": "2026-09-06T09:12:40Z", "actor": "contributor", "repo": "asheshgoplani/agent-deck"}
+{"pr": 2135, "stage": "discovered", "ts": "2026-09-06T09:20:02Z", "actor": "conductor", "repo": "asheshgoplani/agent-deck"}
+{"pr": 2135, "stage": "merged", "ts": "2026-09-06T11:41:19Z", "actor": "asheshgoplani", "repo": "asheshgoplani/agent-deck", "note": "squash"}
+```
+
+## Recording an event
+
+```bash
+conductor/scripts/stage-event.sh <pr> <stage> [note]
+```
+
+The script validates the stage, stamps `ts` with the current UTC time and
+appends one line. Configuration comes from the environment:
+
+| Variable             | Default                                       |
+|----------------------|-----------------------------------------------|
+| `STAGE_EVENTS_FILE`  | `./stage-events.jsonl` in the current directory |
+| `STAGE_EVENTS_ACTOR` | `$GITHUB_ACTOR`, then `$USER`, then `conductor` |
+| `STAGE_EVENTS_REPO`  | `$GITHUB_REPOSITORY`, then `asheshgoplani/agent-deck` |
+
+## Reporting
+
+```bash
+python3 conductor/scripts/stage-report.py stage-events.jsonl \
+    --maintainer asheshgoplani --since 2026-09-01 --until 2026-09-08
+```
+
+The report prints, for each consecutive stage transition, the median and p90
+duration in hours, split into rows where the later event's `actor` is the
+maintainer and rows where it is anyone else. It also prints open-to-merge
+(`arrived` to `merged`) and discovered-to-merge (`discovered` to `merged`).
+Only stdlib is used, so it runs anywhere `python3` does.

--- a/conductor/conductor-claude.md
+++ b/conductor/conductor-claude.md
@@ -207,6 +207,14 @@ When you first start (or after a restart):
 5. If any sessions are in error state, try to restart them
 6. Reply: "Conductor ({PROFILE}) online. N sessions tracked (X running, Y waiting)."
 
+## Stage events
+
+Record pipeline timing with `conductor/scripts/stage-event.sh <pr> <stage> [note]` at every transition (`arrived`, `discovered`, `triaged`, `review_started`, `verdict`, `ci_green`, `merged`, `closed`).
+One line per transition is the whole record: do not write per-merge receipts, hash readbacks or metrics prose.
+Set `STAGE_EVENTS_FILE` to the events file for this repo, otherwise it appends to `./stage-events.jsonl` in the current directory.
+Summaries come from `python3 conductor/scripts/stage-report.py <file> --maintainer <login> --since <date>`.
+Schema and details: `conductor/STAGE-EVENTS.md`.
+
 ## Important Notes
 
 - You cannot directly access other sessions' files. Use `session output` to read their latest response.

--- a/conductor/conductor-hermes.md
+++ b/conductor/conductor-hermes.md
@@ -266,6 +266,14 @@ When you first start (or after a restart):
 6. If any sessions are in error state, try to restart them
 7. Reply: "Conductor ({PROFILE}) online. N sessions tracked (X running, Y waiting). K kanban tasks active."
 
+## Stage events
+
+Record pipeline timing with `conductor/scripts/stage-event.sh <pr> <stage> [note]` at every transition (`arrived`, `discovered`, `triaged`, `review_started`, `verdict`, `ci_green`, `merged`, `closed`).
+One line per transition is the whole record: do not write per-merge receipts, hash readbacks or metrics prose.
+Set `STAGE_EVENTS_FILE` to the events file for this repo, otherwise it appends to `./stage-events.jsonl` in the current directory.
+Summaries come from `python3 conductor/scripts/stage-report.py <file> --maintainer <login> --since <date>`.
+Schema and details: `conductor/STAGE-EVENTS.md`.
+
 ## Important Notes
 
 - You cannot directly access other sessions' files. Use `session output` to read their latest response.

--- a/conductor/scripts/stage-event.sh
+++ b/conductor/scripts/stage-event.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Append one stage event for a PR to the stage events JSONL file.
+# Usage: stage-event.sh <pr> <stage> [note]
+# Schema and stage list: conductor/STAGE-EVENTS.md
+set -euo pipefail
+
+STAGES="arrived discovered triaged review_started verdict ci_green merged closed"
+
+usage() {
+    echo "usage: $(basename "$0") <pr> <stage> [note]" >&2
+    echo "stages: ${STAGES}" >&2
+    exit 2
+}
+
+[ $# -ge 2 ] && [ $# -le 3 ] || usage
+
+pr="$1"
+stage="$2"
+note="${3:-}"
+
+case "$pr" in
+    ''|*[!0-9]*) echo "error: pr must be a positive integer, got '$pr'" >&2; exit 2 ;;
+esac
+
+valid=0
+for s in $STAGES; do
+    [ "$s" = "$stage" ] && valid=1
+done
+if [ "$valid" -ne 1 ]; then
+    echo "error: unknown stage '$stage'" >&2
+    echo "stages: ${STAGES}" >&2
+    exit 2
+fi
+
+events_file="${STAGE_EVENTS_FILE:-./stage-events.jsonl}"
+actor="${STAGE_EVENTS_ACTOR:-${GITHUB_ACTOR:-${USER:-conductor}}}"
+repo="${STAGE_EVENTS_REPO:-${GITHUB_REPOSITORY:-asheshgoplani/agent-deck}}"
+
+mkdir -p "$(dirname "$events_file")"
+
+PR="$pr" STAGE="$stage" NOTE="$note" ACTOR="$actor" REPO="$repo" \
+python3 - >> "$events_file" <<'PY'
+import datetime
+import json
+import os
+
+event = {
+    "pr": int(os.environ["PR"]),
+    "stage": os.environ["STAGE"],
+    "ts": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "actor": os.environ["ACTOR"],
+    "repo": os.environ["REPO"],
+}
+if os.environ.get("NOTE"):
+    event["note"] = os.environ["NOTE"]
+print(json.dumps(event, separators=(", ", ": ")))
+PY

--- a/conductor/scripts/stage-report.py
+++ b/conductor/scripts/stage-report.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Summarize per-PR stage events (see conductor/STAGE-EVENTS.md).
+
+Reads a JSONL file of stage events and prints median and p90 hours for every
+consecutive stage transition, split by whether the later event's actor is the
+maintainer, plus open-to-merge (arrived to merged) and discovered-to-merge.
+
+Stdlib only. Compatible with Python 3.8+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from typing import Dict, Iterable, List, Optional, Tuple
+
+STAGES = [
+    "arrived",
+    "discovered",
+    "triaged",
+    "review_started",
+    "verdict",
+    "ci_green",
+    "merged",
+    "closed",
+]
+
+# Transitions reported one by one, in pipeline order.
+TRANSITIONS: List[Tuple[str, str]] = [
+    ("arrived", "discovered"),
+    ("discovered", "triaged"),
+    ("triaged", "review_started"),
+    ("review_started", "verdict"),
+    ("verdict", "ci_green"),
+    ("ci_green", "merged"),
+]
+
+SUMMARIES: List[Tuple[str, str, str]] = [
+    ("open-to-merge", "arrived", "merged"),
+    ("discovered-to-merge", "discovered", "merged"),
+]
+
+
+def parse_ts(value: str) -> datetime.datetime:
+    """Parse an RFC3339 timestamp; a trailing Z means UTC."""
+    text = value.strip()
+    if text.endswith("Z") or text.endswith("z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
+
+
+def parse_date_bound(value: Optional[str], end: bool) -> Optional[datetime.datetime]:
+    """Accept YYYY-MM-DD or a full timestamp. A bare date for --until is inclusive."""
+    if not value:
+        return None
+    if len(value) == 10:
+        day = datetime.date.fromisoformat(value)
+        if end:
+            day = day + datetime.timedelta(days=1)
+        return datetime.datetime.combine(
+            day, datetime.time.min, tzinfo=datetime.timezone.utc
+        )
+    return parse_ts(value)
+
+
+def read_events(lines: Iterable[str]) -> List[dict]:
+    events = []
+    for lineno, raw in enumerate(lines, 1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print("skipping line %d: %s" % (lineno, exc), file=sys.stderr)
+            continue
+        missing = [k for k in ("pr", "stage", "ts", "actor") if k not in event]
+        if missing:
+            print(
+                "skipping line %d: missing %s" % (lineno, ", ".join(missing)),
+                file=sys.stderr,
+            )
+            continue
+        if event["stage"] not in STAGES:
+            print(
+                "skipping line %d: unknown stage %r" % (lineno, event["stage"]),
+                file=sys.stderr,
+            )
+            continue
+        try:
+            event["_ts"] = parse_ts(str(event["ts"]))
+        except ValueError as exc:
+            print("skipping line %d: bad ts (%s)" % (lineno, exc), file=sys.stderr)
+            continue
+        events.append(event)
+    return events
+
+
+def first_by_stage(events: List[dict]) -> Dict[int, Dict[str, dict]]:
+    """Map pr -> stage -> earliest event for that stage."""
+    per_pr: Dict[int, Dict[str, dict]] = {}
+    for event in sorted(events, key=lambda e: e["_ts"]):
+        stages = per_pr.setdefault(int(event["pr"]), {})
+        stages.setdefault(event["stage"], event)
+    return per_pr
+
+
+def in_range(
+    ts: datetime.datetime,
+    since: Optional[datetime.datetime],
+    until: Optional[datetime.datetime],
+) -> bool:
+    if since is not None and ts < since:
+        return False
+    if until is not None and ts >= until:
+        return False
+    return True
+
+
+def durations(
+    per_pr: Dict[int, Dict[str, dict]],
+    start: str,
+    end: str,
+    maintainer: Optional[str],
+    since: Optional[datetime.datetime],
+    until: Optional[datetime.datetime],
+) -> Dict[str, List[float]]:
+    """Hours from first `start` to first `end` per PR, bucketed by actor group.
+
+    A transition is in range when its end event falls inside [since, until).
+    """
+    buckets: Dict[str, List[float]] = {"maintainer": [], "external": []}
+    for stages in per_pr.values():
+        if start not in stages or end not in stages:
+            continue
+        a, b = stages[start], stages[end]
+        if not in_range(b["_ts"], since, until):
+            continue
+        hours = (b["_ts"] - a["_ts"]).total_seconds() / 3600.0
+        if hours < 0:
+            continue
+        group = "maintainer" if maintainer and b["actor"] == maintainer else "external"
+        buckets[group].append(hours)
+    return buckets
+
+
+def percentile(values: List[float], pct: float) -> float:
+    """Nearest-rank percentile; median is pct=50."""
+    if not values:
+        raise ValueError("no values")
+    ordered = sorted(values)
+    if pct <= 0:
+        return ordered[0]
+    rank = int(-(-pct * len(ordered) // 100))  # ceil(pct/100 * n)
+    return ordered[min(max(rank, 1), len(ordered)) - 1]
+
+
+def median(values: List[float]) -> float:
+    ordered = sorted(values)
+    n = len(ordered)
+    if n == 0:
+        raise ValueError("no values")
+    mid = n // 2
+    if n % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def format_row(label: str, group: str, values: List[float]) -> str:
+    if not values:
+        return "%-24s %-11s %5s %9s %9s" % (label, group, 0, "-", "-")
+    return "%-24s %-11s %5d %9.1f %9.1f" % (
+        label,
+        group,
+        len(values),
+        median(values),
+        percentile(values, 90),
+    )
+
+
+def build_report(
+    events: List[dict],
+    maintainer: Optional[str],
+    since: Optional[datetime.datetime],
+    until: Optional[datetime.datetime],
+) -> str:
+    per_pr = first_by_stage(events)
+    lines = []
+    lines.append("%-24s %-11s %5s %9s %9s" % ("transition", "actor", "n", "median_h", "p90_h"))
+    for start, end in TRANSITIONS:
+        label = "%s->%s" % (start, end)
+        buckets = durations(per_pr, start, end, maintainer, since, until)
+        for group in ("maintainer", "external"):
+            lines.append(format_row(label, group, buckets[group]))
+    lines.append("")
+    for label, start, end in SUMMARIES:
+        buckets = durations(per_pr, start, end, maintainer, since, until)
+        for group in ("maintainer", "external"):
+            lines.append(format_row(label, group, buckets[group]))
+        lines.append(format_row(label, "all", buckets["maintainer"] + buckets["external"]))
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("events_file", help="path to stage-events.jsonl")
+    parser.add_argument("--maintainer", help="GitHub login counted as the maintainer")
+    parser.add_argument("--since", help="only transitions ending on or after this date (YYYY-MM-DD or RFC3339)")
+    parser.add_argument("--until", help="only transitions ending before the end of this date (YYYY-MM-DD or RFC3339)")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.events_file, "r", encoding="utf-8") as fh:
+            events = read_events(fh)
+    except OSError as exc:
+        print("error: %s" % exc, file=sys.stderr)
+        return 1
+
+    since = parse_date_bound(args.since, end=False)
+    until = parse_date_bound(args.until, end=True)
+    print(build_report(events, args.maintainer, since, until))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conductor/tests/test_stage_report.py
+++ b/conductor/tests/test_stage_report.py
@@ -1,0 +1,150 @@
+"""Tests for conductor/scripts/stage-report.py and stage-event.sh.
+
+The report script is stdlib only, so it is loaded straight from disk by path
+(the file name has a dash, so it is not importable by module name).
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+REPORT = SCRIPTS / "stage-report.py"
+EVENT_SH = SCRIPTS / "stage-event.sh"
+
+
+def _load_report():
+    spec = importlib.util.spec_from_file_location("stage_report", REPORT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+report = _load_report()
+
+
+def _line(pr, stage, ts, actor, **extra):
+    event = {"pr": pr, "stage": stage, "ts": ts, "actor": actor, "repo": "o/r"}
+    event.update(extra)
+    return json.dumps(event)
+
+
+SAMPLE = [
+    # PR 1: external contributor arrives, maintainer merges 10h later.
+    _line(1, "arrived", "2026-09-01T00:00:00Z", "alice"),
+    _line(1, "discovered", "2026-09-01T02:00:00Z", "conductor"),
+    _line(1, "merged", "2026-09-01T10:00:00Z", "maint"),
+    # PR 2: takes 30h open-to-merge, 20h discovered-to-merge, merged by external.
+    _line(2, "arrived", "2026-09-02T00:00:00Z", "bob"),
+    _line(2, "discovered", "2026-09-02T10:00:00Z", "conductor"),
+    _line(2, "merged", "2026-09-03T06:00:00Z", "bob"),
+    # PR 3: duplicate merged events; the first one counts. Out of --until range.
+    _line(3, "arrived", "2026-09-10T00:00:00Z", "carol"),
+    _line(3, "merged", "2026-09-10T04:00:00Z", "maint"),
+    _line(3, "merged", "2026-09-10T09:00:00Z", "maint"),
+]
+
+
+def test_parse_ts_accepts_z_and_offsets():
+    z = report.parse_ts("2026-09-01T00:00:00Z")
+    off = report.parse_ts("2026-09-01T02:00:00+02:00")
+    assert z == off
+    assert z.tzinfo is not None
+
+
+def test_read_events_skips_bad_lines(capsys):
+    lines = SAMPLE + ["not json", json.dumps({"pr": 9, "stage": "nope", "ts": "x", "actor": "a"}), ""]
+    events = report.read_events(lines)
+    assert len(events) == len(SAMPLE)
+    err = capsys.readouterr().err
+    assert "skipping line" in err
+
+
+def test_median_and_percentile():
+    assert report.median([1.0, 3.0]) == 2.0
+    assert report.median([5.0, 1.0, 3.0]) == 3.0
+    assert report.percentile([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], 90) == 9.0
+    with pytest.raises(ValueError):
+        report.median([])
+
+
+def test_durations_split_by_maintainer_and_first_occurrence():
+    per_pr = report.first_by_stage(report.read_events(SAMPLE))
+    buckets = report.durations(per_pr, "arrived", "merged", "maint", None, None)
+    assert buckets["maintainer"] == [10.0, 4.0]
+    assert buckets["external"] == [30.0]
+    disc = report.durations(per_pr, "discovered", "merged", "maint", None, None)
+    assert disc["maintainer"] == [8.0]
+    assert disc["external"] == [20.0]
+
+
+def test_date_range_filters_on_end_event():
+    per_pr = report.first_by_stage(report.read_events(SAMPLE))
+    since = report.parse_date_bound("2026-09-01", end=False)
+    until = report.parse_date_bound("2026-09-03", end=True)
+    buckets = report.durations(per_pr, "arrived", "merged", "maint", since, until)
+    assert buckets["maintainer"] == [10.0]
+    assert buckets["external"] == [30.0]
+    assert until == datetime.datetime(2026, 9, 4, tzinfo=datetime.timezone.utc)
+
+
+def test_build_report_lists_every_transition_and_summary():
+    text = report.build_report(report.read_events(SAMPLE), "maint", None, None)
+    for a, b in report.TRANSITIONS:
+        assert "%s->%s" % (a, b) in text
+    assert "open-to-merge" in text
+    assert "discovered-to-merge" in text
+    rows = [l for l in text.splitlines() if l.startswith("open-to-merge")]
+    assert rows[0].split()[1:3] == ["maintainer", "2"]
+    assert rows[1].split()[1:3] == ["external", "1"]
+    assert rows[2].split()[1:3] == ["all", "3"]
+
+
+def test_cli_end_to_end(tmp_path):
+    events = tmp_path / "events.jsonl"
+    events.write_text("\n".join(SAMPLE) + "\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(REPORT), str(events), "--maintainer", "maint", "--since", "2026-09-01", "--until", "2026-09-05"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "open-to-merge" in proc.stdout
+    rows = [l for l in proc.stdout.splitlines() if l.startswith("open-to-merge")]
+    assert rows[2].split()[1:3] == ["all", "2"]
+
+
+def test_stage_event_sh_appends_valid_line(tmp_path):
+    events = tmp_path / "nested" / "events.jsonl"
+    env = dict(os.environ, STAGE_EVENTS_FILE=str(events), STAGE_EVENTS_ACTOR="tester", STAGE_EVENTS_REPO="o/r")
+    subprocess.run([str(EVENT_SH), "42", "merged", 'note with "quotes"'], env=env, check=True)
+    subprocess.run([str(EVENT_SH), "42", "closed"], env=env, check=True)
+    lines = events.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["pr"] == 42
+    assert first["stage"] == "merged"
+    assert first["actor"] == "tester"
+    assert first["repo"] == "o/r"
+    assert first["note"] == 'note with "quotes"'
+    report.parse_ts(first["ts"])
+    assert "note" not in json.loads(lines[1])
+
+
+def test_stage_event_sh_rejects_bad_input(tmp_path):
+    events = tmp_path / "events.jsonl"
+    env = dict(os.environ, STAGE_EVENTS_FILE=str(events))
+    bad_stage = subprocess.run([str(EVENT_SH), "1", "shipped"], env=env, capture_output=True, text=True)
+    assert bad_stage.returncode == 2
+    assert "unknown stage" in bad_stage.stderr
+    bad_pr = subprocess.run([str(EVENT_SH), "abc", "merged"], env=env, capture_output=True, text=True)
+    assert bad_pr.returncode == 2
+    assert not events.exists()


### PR DESCRIPTION
## What problem does this solve?

WORKFLOW-METRICS.md says cycle time, ready-to-merge wait and blocked time are unknown because only merge spacing is recorded, while each merge still costs 10 to 18 minutes of receipts, hash readbacks and metrics prose. This adds a JSONL stage log plus a reporter so those numbers come out of one line per transition. Closes #2135.

## Why this change

A public schema in `conductor/STAGE-EVENTS.md` (pr, stage, ts, actor, repo, optional note) keeps the record machine readable and backfillable from GitHub timestamps. `scripts/stage-event.sh` validates the stage and appends one line through python3 so JSON escaping is correct; the file path comes from `STAGE_EVENTS_FILE` (default `./stage-events.jsonl`). `scripts/stage-report.py` is stdlib only and prints median and p90 hours per transition, split maintainer versus external, plus open-to-merge and discovered-to-merge for an optional date range. Deriving this from the GitHub API afterwards would only give open-to-merge, not discovery or triage time.

## User impact

None for agent-deck users. Conductor operators get a `## Stage events` section in `conductor-claude.md` and `conductor-hermes.md` telling the conductor to call `stage-event.sh` at each transition instead of writing receipts, and `conductor/README.md` points at the schema doc.

## Evidence

    $ python3 -m pytest conductor/tests/test_stage_report.py -q
    9 passed in 0.44s

    $ STAGE_EVENTS_FILE=/tmp/x/e.jsonl STAGE_EVENTS_ACTOR=demo conductor/scripts/stage-event.sh 2135 discovered "first seen"
    $ cat /tmp/x/e.jsonl
    {"pr": 2135, "stage": "discovered", "ts": "2026-09-06T03:02:43Z", "actor": "demo", "repo": "asheshgoplani/agent-deck", "note": "first seen"}
    $ python3 conductor/scripts/stage-report.py /tmp/x/e.jsonl --maintainer asheshgoplani | head -3
    transition               actor           n  median_h     p90_h
    arrived->discovered      maintainer      0         -         -
    arrived->discovered      external        0         -         -

    $ gofmt -l ./cmd ./internal   # no output
    $ go build ./... && go vet ./...   # ok

Local go test is disallowed on this host; full suite runs in CI on this PR. No Go code changed.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
