### PR TITLE
ci(go-test): name failing tests and flake status in the job summary

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -35,6 +35,8 @@ on:
       - '.github/workflows/go-test.yml'
       - 'scripts/ci-native-ssh.sh'
       - 'scripts/ci-shared-state-proof.sh'
+      - 'scripts/ci-test-summary.py'
+      - 'tests/known-flaky.txt'
 
 # One in-flight run per PR (or per branch on push). Rapid follow-up pushes
 # cancel the stale run instead of stacking 20-minute jobs.
@@ -66,7 +68,7 @@ jobs:
             echo "go=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           base="${{ github.event.pull_request.base.sha }}"
-          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$|^scripts/ci-shared-state-proof\.sh$)'; then
+          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$|^scripts/ci-shared-state-proof\.sh$|^scripts/ci-test-summary\.py$|^tests/known-flaky\.txt$)'; then
             echo "go=true" >> "$GITHUB_OUTPUT"
           else
             echo "go=false" >> "$GITHUB_OUTPUT"
@@ -101,7 +103,25 @@ jobs:
           PERF_BUDGET_MULTIPLIER: '2.0'
         run: |
           go install gotest.tools/gotestsum@v1.13.0
-          gotestsum --rerun-fails=2 --rerun-fails-abort-on-data-race --packages="./..." -- -race -timeout 20m
+          gotestsum --rerun-fails=2 --rerun-fails-abort-on-data-race --jsonfile test-output.json --packages="./..." -- -race -timeout 20m
+
+      # Name the failing tests in the job summary (#2133) so a red run says
+      # whether it was a known flake or a real break, with the exact repro
+      # line. Reads only the JSON above; never changes the job's result.
+      - name: Summarise failing tests
+        if: always() && steps.gochanges.outputs.go == 'true'
+        run: |
+          bash tests/ci/ci-test-summary.test.sh
+          python3 scripts/ci-test-summary.py --json test-output.json --known-flaky tests/known-flaky.txt
+
+      - name: Upload gotestsum JSON
+        if: always() && steps.gochanges.outputs.go == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: go-test-output-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-output.json
+          retention-days: 7
+          if-no-files-found: ignore
 
       # The ordinary suite above covers shared-state and real-process tests.
       # This bounded additional gate includes the test-only observer lock fixture.

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -37,6 +37,7 @@ on:
       - 'scripts/ci-shared-state-proof.sh'
       - 'scripts/ci-test-summary.py'
       - 'tests/known-flaky.txt'
+      - 'tests/ci/ci-test-summary.test.sh'
 
 # One in-flight run per PR (or per branch on push). Rapid follow-up pushes
 # cancel the stale run instead of stacking 20-minute jobs.
@@ -68,7 +69,7 @@ jobs:
             echo "go=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
           base="${{ github.event.pull_request.base.sha }}"
-          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$|^scripts/ci-shared-state-proof\.sh$|^scripts/ci-test-summary\.py$|^tests/known-flaky\.txt$)'; then
+          if git diff --name-only "$base"...HEAD | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/go-test\.yml$|^scripts/ci-shared-state-proof\.sh$|^scripts/ci-test-summary\.py$|^tests/known-flaky\.txt$|^tests/ci/ci-test-summary\.test\.sh$)'; then
             echo "go=true" >> "$GITHUB_OUTPUT"
           else
             echo "go=false" >> "$GITHUB_OUTPUT"

--- a/scripts/ci-test-summary.py
+++ b/scripts/ci-test-summary.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Summarise gotestsum JSON output as a GitHub job summary.
+
+Reads the go test -json stream that gotestsum wrote via --jsonfile, finds
+every test whose final outcome is a failure, labels it "known flake" when it
+appears in tests/known-flaky.txt, and appends a Markdown table with an exact
+reproduction command to $GITHUB_STEP_SUMMARY (stdout when unset).
+
+This script never changes the job's pass/fail result: it always exits 0.
+Standard library only.
+
+Usage:
+    ci-test-summary.py [--json test-output.json] [--known-flaky tests/known-flaky.txt]
+                       [--go-mod go.mod]
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+FINAL_ACTIONS = ("pass", "fail", "skip")
+
+
+def read_module_path(go_mod):
+    try:
+        with open(go_mod, encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) == 2 and parts[0] == "module":
+                    return parts[1]
+    except OSError:
+        pass
+    return ""
+
+
+def relative_package(pkg, module):
+    if module and pkg == module:
+        return "."
+    if module and pkg.startswith(module + "/"):
+        return "./" + pkg[len(module) + 1:]
+    return pkg
+
+
+def load_known_flaky(path):
+    """Return a set of ("<pkg>" or "", "<TopLevelTest>") tuples."""
+    entries = set()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.split("#", 1)[0].strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if len(parts) == 1:
+                    entries.add(("", parts[0]))
+                else:
+                    pkg = parts[0]
+                    if not pkg.startswith("./") and pkg != ".":
+                        pkg = "./" + pkg
+                    entries.add((pkg, parts[1]))
+    except OSError:
+        pass
+    return entries
+
+
+def is_known_flaky(entries, rel_pkg, test):
+    top = test.split("/", 1)[0]
+    return ("", top) in entries or (rel_pkg, top) in entries
+
+
+def run_regex(test):
+    return "/".join("^" + re.escape(seg) + "$" for seg in test.split("/"))
+
+
+def repro_line(rel_pkg, test):
+    if test:
+        return "go test %s -run '%s' -race -count=1" % (rel_pkg, run_regex(test))
+    return "go test %s -race -count=1" % rel_pkg
+
+
+def collect(events):
+    """Map (package, test) -> final action, plus the set that ever failed."""
+    final = {}
+    ever_failed = set()
+    for ev in events:
+        action = ev.get("Action")
+        if action not in FINAL_ACTIONS:
+            continue
+        key = (ev.get("Package", ""), ev.get("Test", ""))
+        final[key] = action
+        if action == "fail":
+            ever_failed.add(key)
+    return final, ever_failed
+
+
+def read_events(path):
+    events = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except ValueError:
+                continue
+    return events
+
+
+def render(final, ever_failed, module, known):
+    failed = sorted(k for k, a in final.items() if a == "fail")
+    # A package-level failure with no named failing test (build error, panic
+    # outside a test, timeout) still needs a row; otherwise the package row is
+    # redundant with its tests.
+    named_failures = {pkg for pkg, test in failed if test}
+    rows = [(pkg, test) for pkg, test in failed if test or pkg not in named_failures]
+    recovered = sorted(k for k in ever_failed if final.get(k) == "pass" and k[1])
+
+    out = ["## Go test failures", ""]
+    if not rows:
+        out.append("No failing tests in the final gotestsum result.")
+    else:
+        new = 0
+        out.append("| Package | Test | Status | Reproduce |")
+        out.append("|---|---|---|---|")
+        for pkg, test in rows:
+            rel = relative_package(pkg, module)
+            flaky = bool(test) and is_known_flaky(known, rel, test)
+            status = "known flake" if flaky else "new failure"
+            new += 0 if flaky else 1
+            out.append("| `%s` | `%s` | %s | `%s` |" % (
+                rel, test or "(package)", status, repro_line(rel, test)))
+        out.append("")
+        out.append("%d failing, %d not in `tests/known-flaky.txt`." % (len(rows), new))
+    if recovered:
+        out.append("")
+        out.append("Failed at least once but passed on rerun (flake candidates):")
+        out.append("")
+        for pkg, test in recovered:
+            out.append("- `%s` `%s`" % (relative_package(pkg, module), test))
+    out.append("")
+    return "\n".join(out)
+
+
+def write_summary(text):
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(text)
+    else:
+        sys.stdout.write(text)
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--json", default="test-output.json")
+    ap.add_argument("--known-flaky", default="tests/known-flaky.txt")
+    ap.add_argument("--go-mod", default="go.mod")
+    args = ap.parse_args(argv)
+
+    if not os.path.isfile(args.json):
+        write_summary("## Go test failures\n\nNo gotestsum JSON at `%s`; "
+                      "the test step did not produce output.\n" % args.json)
+        return 0
+
+    events = read_events(args.json)
+    final, ever_failed = collect(events)
+    text = render(final, ever_failed, read_module_path(args.go_mod),
+                  load_known_flaky(args.known_flaky))
+    write_summary(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/ci/ci-test-summary.test.sh
+++ b/tests/ci/ci-test-summary.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ci-test-summary.test.sh — Tests for scripts/ci-test-summary.py (#2133), the
+# job summary writer behind the go-test workflow's "Summarise failing tests"
+# step. Feeds a synthetic gotestsum JSON stream and checks the rendered table:
+# final-fail tests get a row, known flakes are labelled, rerun-passed tests are
+# listed as candidates, package-only failures get a package row, and the repro
+# line is exact. Exit 0 on pass, 1 on any failure. Needs only python3.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUMMARY="$SCRIPT_DIR/../../scripts/ci-test-summary.py"
+ERRORS=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+check() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qF -- "$pattern" "$file"; then
+    echo "ok   $label"
+  else
+    echo "FAIL $label: expected to find: $pattern"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+check_absent() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qF -- "$pattern" "$file"; then
+    echo "FAIL $label: did not expect: $pattern"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "ok   $label"
+  fi
+}
+
+echo 'module example.com/mod' > "$TMP/go.mod"
+printf '# comment\nTestFlaky\ninternal/b TestScoped\n' > "$TMP/known-flaky.txt"
+
+M=example.com/mod
+cat > "$TMP/out.json" <<JSON
+{"Action":"run","Package":"$M/internal/a","Test":"TestFlaky"}
+{"Action":"fail","Package":"$M/internal/a","Test":"TestFlaky"}
+{"Action":"fail","Package":"$M/internal/a","Test":"TestNew"}
+{"Action":"fail","Package":"$M/internal/a","Test":"TestNew/sub case"}
+{"Action":"fail","Package":"$M/internal/a"}
+{"Action":"fail","Package":"$M/internal/b","Test":"TestScoped"}
+{"Action":"fail","Package":"$M/internal/b","Test":"TestRecover"}
+{"Action":"fail","Package":"$M/internal/b"}
+{"Action":"pass","Package":"$M/internal/b","Test":"TestRecover"}
+{"Action":"pass","Package":"$M/internal/c","Test":"TestFine"}
+{"Action":"pass","Package":"$M/internal/c"}
+{"Action":"fail","Package":"$M/internal/d"}
+not json at all
+JSON
+
+OUT="$TMP/summary.md"
+GITHUB_STEP_SUMMARY="$OUT" python3 "$SUMMARY" --json "$TMP/out.json" \
+  --known-flaky "$TMP/known-flaky.txt" --go-mod "$TMP/go.mod"
+
+check "bare-name known flake" '| `./internal/a` | `TestFlaky` | known flake |' "$OUT"
+check "new failure" '| `./internal/a` | `TestNew` | new failure |' "$OUT"
+check "subtest repro" "go test ./internal/a -run '^TestNew$/^sub\\ case$' -race -count=1" "$OUT"
+check "top-level repro" "go test ./internal/a -run '^TestNew$' -race -count=1" "$OUT"
+check "package-scoped known flake" '| `./internal/b` | `TestScoped` | known flake |' "$OUT"
+check "package-only failure row" '| `./internal/d` | `(package)` | new failure | `go test ./internal/d -race -count=1` |' "$OUT"
+check_absent "no package row when tests named" '| `./internal/a` | `(package)`' "$OUT"
+check "rerun recovery listed" '`./internal/b` `TestRecover`' "$OUT"
+check_absent "recovered test not in table" '| `TestRecover` |' "$OUT"
+check_absent "passing test absent" 'TestFine' "$OUT"
+check "counts" '5 failing, 3 not in `tests/known-flaky.txt`.' "$OUT"
+
+# Missing JSON: still exits 0 and writes a note.
+OUT2="$TMP/missing.md"
+GITHUB_STEP_SUMMARY="$OUT2" python3 "$SUMMARY" --json "$TMP/nope.json" --go-mod "$TMP/go.mod"
+check "missing json note" 'No gotestsum JSON' "$OUT2"
+
+# All green: says so.
+echo "{\"Action\":\"pass\",\"Package\":\"$M/internal/c\",\"Test\":\"TestFine\"}" > "$TMP/green.json"
+OUT3="$TMP/green.md"
+GITHUB_STEP_SUMMARY="$OUT3" python3 "$SUMMARY" --json "$TMP/green.json" --go-mod "$TMP/go.mod"
+check "green summary" 'No failing tests' "$OUT3"
+
+if [ "$ERRORS" -ne 0 ]; then
+  echo "$ERRORS check(s) failed"; cat "$OUT"; exit 1
+fi
+echo "all checks passed"

--- a/tests/known-flaky.txt
+++ b/tests/known-flaky.txt
@@ -1,0 +1,11 @@
+# Known-flaky Go tests for the go-test workflow's failure summary.
+#
+# One entry per line. Either a bare test name (TestFoo, matched against the
+# top-level test in any package) or "<relative package> <TestName>"
+# (internal/tui TestFoo) to scope it to one package. Lines starting with "#"
+# and blank lines are ignored.
+#
+# Listing a test here changes NOTHING about pass/fail: the job still fails
+# when the test fails. It only labels the row "known flake" in the job summary
+# so a retry is an informed decision rather than a blind re-push. Remove an
+# entry as soon as the flake is fixed.


### PR DESCRIPTION
## What problem does this solve?

When the full race suite fails after `gotestsum --rerun-fails=2` gives up, the required check only says "failed". Contributors and the conductor re-push blind to learn whether it was a known flake or a real break (`test/full-tui-ssh` burned three CI cycles over 8 h that way). Closes #2133.

## Why this change

The job summary is already linked from the check, so it is the cheapest place to put the signal without PR comment noise. gotestsum already emits `go test -json`; `--jsonfile test-output.json` keeps a copy, and a stdlib-only script (`scripts/ci-test-summary.py`) reads it after the test step with `if: always()`. It lists every test whose final outcome is `fail`, labels it `known flake` when its top-level name is in `tests/known-flaky.txt` (created empty, header comment only) or `new failure` otherwise, and prints the exact `go test ./<pkg> -run '^<Test>$' -race -count=1` repro line. Tests that failed once and passed on rerun are listed separately as flake candidates so the allowlist can be curated from real data. Package-only failures (build error, panic, timeout) get a `(package)` row. The script always exits 0, so pass/fail semantics and the required check name `Full test suite (PR gate)` are unchanged, and the docs-only short-circuit is intact (the new steps are gated on `steps.gochanges.outputs.go == 'true'` as well as `always()`). The raw JSON is uploaded as an artifact with 7 day retention. The native SSH jobs and `scripts/ci-native-ssh.sh` are not touched.

## User impact

None for agent-deck users. Contributors get a table naming the failing test and its flake status in the go-test job summary.

## Evidence

Synthetic gotestsum stream through the script (`tests/ci/ci-test-summary.test.sh`, also run in the workflow step):

    ok   bare-name known flake
    ok   new failure
    ok   subtest repro
    ok   top-level repro
    ok   package-scoped known flake
    ok   package-only failure row
    ok   no package row when tests named
    ok   rerun recovery listed
    ok   recovered test not in table
    ok   passing test absent
    ok   counts
    ok   missing json note
    ok   green summary
    all checks passed

Rendered summary for that input:

    | Package | Test | Status | Reproduce |
    |---|---|---|---|
    | `./internal/a` | `TestFlaky` | known flake | `go test ./internal/a -run '^TestFlaky$' -race -count=1` |
    | `./internal/a` | `TestNew` | new failure | `go test ./internal/a -run '^TestNew$' -race -count=1` |
    | `./internal/d` | `(package)` | new failure | `go test ./internal/d -race -count=1` |

Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`). `gofmt -l ./cmd ./internal` prints nothing, `go build ./...` and `go vet ./...` pass (no Go files changed). Local go test is disallowed on this host; full suite runs in CI on this PR.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

https://claude.ai/code/session_01VqZQYv7fcPCDxFJ1yHHjzA

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
