### PR TITLE
feat(ui): source tool icon and color from the tool registry

### DIFF
--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -25,6 +25,13 @@ type builtinTool struct {
 	// focused — see PR open questions).
 	Icon string
 
+	// Color is the brand color slot the TUI paints this tool with. It names a
+	// theme palette slot ("orange", "purple", "cyan", "accent", "yellow",
+	// "red") rather than a literal color so it follows live theme switches.
+	// Empty means "no brand color": the UI falls back to its default dim text.
+	// Mirrors the arms of the former ToolColor() switch in internal/ui/styles.go.
+	Color string
+
 	// detectSubstrings are case-insensitive strings.Contains fragments against
 	// the command string — the exact arms of the legacy detectTool() switch.
 	detectSubstrings []string
@@ -55,24 +62,24 @@ type builtinTool struct {
 //   - "shell" is the catch-all fallback, never matched by a pattern.
 func builtinTools() []builtinTool {
 	return []builtinTool{
-		{Name: "claude", Icon: "🤖", detectSubstrings: []string{"claude"}},
+		{Name: "claude", Icon: "🤖", Color: "orange", detectSubstrings: []string{"claude"}},
 		{Name: "opencode", Icon: "🌐", detectSubstrings: []string{"opencode", "open-code"}},
-		{Name: "gemini", Icon: "✨", detectSubstrings: []string{"gemini"}},
-		{Name: "codex", Icon: "💻", detectSubstrings: []string{"codex"}},
-		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
-		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
-		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
+		{Name: "gemini", Icon: "✨", Color: "purple", detectSubstrings: []string{"gemini"}},
+		{Name: "codex", Icon: "💻", Color: "cyan", detectSubstrings: []string{"codex"}},
+		{Name: "pi", Icon: "π", Color: "accent", detectTokens: []string{"pi"}},
+		{Name: "copilot", Icon: "🐙", Color: "accent", detectSubstrings: []string{"copilot"}},
+		{Name: "crush", Icon: "💘", Color: "purple", detectSubstrings: []string{"crush"}},
 		// detectTokens includes bare "agent" (standalone Cursor Agent CLI).
 		// Token match only: substring "agent" would false-match "agent-deck".
-		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}, detectTokens: []string{"agent"}},
-		{Name: "hermes", Icon: "☤", detectSubstrings: []string{"hermes"}},
+		{Name: "cursor", Icon: "📝", Color: "accent", detectSubstrings: []string{"cursor"}, detectTokens: []string{"agent"}},
+		{Name: "hermes", Icon: "☤", Color: "yellow", detectSubstrings: []string{"hermes"}},
 		// DeepSeek Harness. The tool is named for the vendor; the binary is
 		// `dsh`, so the substring alone would never match a real command line.
 		// "dsh" is a token match, not a substring: as a substring it would
 		// false-match "dshell", "fdsh", and any path containing those three
 		// letters — the same reason "pi" is token-matched.
-		{Name: "deepseek", Icon: "🐋", detectSubstrings: []string{"deepseek"}, detectTokens: []string{"dsh"}},
-		{Name: "aider", Icon: "🐚"},
+		{Name: "deepseek", Icon: "🐋", Color: "cyan", detectSubstrings: []string{"deepseek"}, detectTokens: []string{"dsh"}},
+		{Name: "aider", Icon: "🐚", Color: "red"},
 		{Name: "shell", Icon: "🐚"},
 	}
 }

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -227,6 +227,34 @@ func (r *Registry) Get(name string) *ToolDef {
 	return nil
 }
 
+// Icon returns the display icon for name: a custom tool's configured icon
+// when set, otherwise the built-in icon, otherwise "" for names the registry
+// does not know. Callers treat "" as "use your own fallback".
+func (r *Registry) Icon(name string) string {
+	if def, ok := r.custom[name]; ok && def.Icon != "" {
+		return def.Icon
+	}
+	if bt, ok := r.builtins[name]; ok {
+		return bt.Icon
+	}
+	return ""
+}
+
+// Color returns the display color for name. For custom tools it is the
+// [tools.<name>] color value verbatim (a lipgloss color such as "#ff9e64");
+// for built-ins it is a theme palette slot name (see builtinTool.Color).
+// "" means the registry has no color for name and the caller should use its
+// default.
+func (r *Registry) Color(name string) string {
+	if def, ok := r.custom[name]; ok && def.Color != "" {
+		return def.Color
+	}
+	if bt, ok := r.builtins[name]; ok {
+		return bt.Color
+	}
+	return ""
+}
+
 // Match resolves a command string to a tool name. Replaces detectTool().
 //
 // Resolution order, preserving the legacy semantics exactly:
@@ -414,6 +442,18 @@ func currentRegistry() *Registry {
 // dialogs would hide (issue #1259 non-goal: display filter only, not a gate).
 func MatchTool(cmd string) string {
 	return currentRegistry().Match(cmd)
+}
+
+// ToolIconFor returns the process registry's icon for name ("" if unknown).
+// It is the seam internal/ui's ToolIcon() reads before its static fallback.
+func ToolIconFor(name string) string {
+	return currentRegistry().Icon(name)
+}
+
+// ToolColorFor returns the process registry's color for name ("" if unknown).
+// It is the seam internal/ui's ToolColor() reads before its static fallback.
+func ToolColorFor(name string) string {
+	return currentRegistry().Color(name)
 }
 
 // --- process-wide show_only_installed_tools accessors (issue #1259) ----------

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -224,3 +224,38 @@ func TestRegistry_MatchTokenByPath(t *testing.T) {
 		})
 	}
 }
+
+func TestRegistry_IconAndColor(t *testing.T) {
+	r := Init(map[string]ToolDef{
+		"mywrap":  {Command: "mywrap", Icon: "🧪", Color: "#ff00ff"},
+		"nostyle": {Command: "nostyle"},
+	})
+
+	if got := r.Icon("claude"); got != "🤖" {
+		t.Errorf("Icon(claude) = %q, want 🤖", got)
+	}
+	if got := r.Color("claude"); got != "orange" {
+		t.Errorf("Color(claude) = %q, want orange", got)
+	}
+	if got := r.Color("shell"); got != "" {
+		t.Errorf("Color(shell) = %q, want empty (no brand color)", got)
+	}
+	if got := r.Icon("mywrap"); got != "🧪" {
+		t.Errorf("Icon(mywrap) = %q, want 🧪", got)
+	}
+	if got := r.Color("mywrap"); got != "#ff00ff" {
+		t.Errorf("Color(mywrap) = %q, want #ff00ff", got)
+	}
+	if got := r.Icon("nostyle"); got != "" {
+		t.Errorf("Icon(nostyle) = %q, want empty", got)
+	}
+	if got := r.Color("nostyle"); got != "" {
+		t.Errorf("Color(nostyle) = %q, want empty", got)
+	}
+	if got := r.Icon("unknown"); got != "" {
+		t.Errorf("Icon(unknown) = %q, want empty", got)
+	}
+	if got := r.Color("unknown"); got != "" {
+		t.Errorf("Color(unknown) = %q, want empty", got)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2440,6 +2440,11 @@ type ToolDef struct {
 	// Icon is the emoji/symbol to display
 	Icon string `toml:"icon,omitempty"`
 
+	// Color is an optional lipgloss color value (hex like "#ff9e64" or an
+	// ANSI index like "208") the TUI paints this tool's name with. Empty
+	// keeps the default dim text color.
+	Color string `toml:"color,omitempty"`
+
 	// BusyPatterns are strings that indicate the tool is busy
 	BusyPatterns []string `toml:"busy_patterns,omitempty"`
 
@@ -4796,6 +4801,7 @@ auto_cleanup = true
 # Each tool can have:
 #   command      - The shell command to run
 #   icon         - Emoji/symbol shown in the UI
+#   color        - Optional lipgloss color for the tool name (hex like "#ff9e64" or ANSI index)
 #   compatible_with - Built-in compatibility to mirror ("claude" or "codex")
 #   busy_patterns - Strings that indicate the tool is processing
 

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -588,12 +589,14 @@ func StatusIndicator(status string) string {
 	}
 }
 
-// ToolIcon returns the icon for a given tool
-// Checks user config for custom tools first, then falls back to built-ins
+// ToolIcon returns the icon for a given tool.
+// The tool registry (built-ins plus [tools.<name>] custom entries) is the
+// source of truth; the switch below is the fallback for names the registry
+// does not know (issue #2136).
 func ToolIcon(tool string) string {
-	// Use session.GetToolIcon which handles custom + built-in
-	// Import would be circular, so we duplicate the logic here
-	// Custom icons are handled by the session layer's GetToolDef
+	if icon := session.ToolIconFor(tool); icon != "" {
+		return icon
+	}
 	switch tool {
 	case "claude":
 		return IconClaude
@@ -624,7 +627,15 @@ func ToolIcon(tool string) string {
 
 // ToolColor returns the brand color for a given tool
 // Claude=orange (Anthropic), Gemini=purple (Google AI), Codex=cyan, Pi=accent, Aider=red
+//
+// The tool registry is the source of truth: built-ins carry a palette slot
+// name that is resolved against the active theme here, and custom tools may
+// set color = "<lipgloss value>" in config. The switch below is the fallback
+// for names the registry does not know (issue #2136).
 func ToolColor(tool string) lipgloss.Color {
+	if c, ok := paletteColor(session.ToolColorFor(tool)); ok {
+		return c
+	}
 	switch tool {
 	case "claude":
 		return ColorOrange // Anthropic's orange
@@ -648,6 +659,31 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorRed // Red for Aider
 	default:
 		return ColorTextDim // Default gray
+	}
+}
+
+// paletteColor resolves a registry color value to a lipgloss color. Palette
+// slot names map to the active theme's variables so live theme switches keep
+// working; any other non-empty value is passed to lipgloss verbatim (custom
+// tool hex or ANSI colors). "" reports false so callers use their fallback.
+func paletteColor(value string) (lipgloss.Color, bool) {
+	switch value {
+	case "":
+		return "", false
+	case "orange":
+		return ColorOrange, true
+	case "purple":
+		return ColorPurple, true
+	case "cyan":
+		return ColorCyan, true
+	case "accent":
+		return ColorAccent, true
+	case "yellow":
+		return ColorYellow, true
+	case "red":
+		return ColorRed, true
+	default:
+		return lipgloss.Color(value), true
 	}
 }
 

--- a/internal/ui/styles_registry_test.go
+++ b/internal/ui/styles_registry_test.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestToolIconColor_RegistryMatchesLegacySwitch pins the exact icon and color
+// the former hardcoded switches in styles.go returned for every built-in tool.
+// ToolIcon/ToolColor now read the tool registry first (issue #2136); this test
+// guards that the registry data reproduces the legacy output byte for byte.
+// The expected values are the literal arms of the old switches, not derived
+// from the registry, so drift in either direction fails here.
+func TestToolIconColor_RegistryMatchesLegacySwitch(t *testing.T) {
+	InitTheme("dark")
+
+	legacy := map[string]struct {
+		icon  string
+		color lipgloss.Color
+	}{
+		"claude":   {"🤖", ColorOrange},
+		"gemini":   {"✨", ColorPurple},
+		"opencode": {"🌐", ColorTextDim},
+		"codex":    {"💻", ColorCyan},
+		"pi":       {"π", ColorAccent},
+		"copilot":  {"🐙", ColorAccent},
+		"crush":    {"💘", ColorPurple},
+		"cursor":   {"📝", ColorAccent},
+		"hermes":   {"☤", ColorYellow},
+		"deepseek": {"🐋", ColorCyan},
+		"aider":    {"🐚", ColorRed},
+		"shell":    {"🐚", ColorTextDim},
+	}
+
+	builtins := session.Init(nil).All()
+	if len(builtins) != len(legacy) {
+		t.Fatalf("registry has %d built-ins, legacy table has %d; add the new tool to this table", len(builtins), len(legacy))
+	}
+	for _, def := range builtins {
+		name := def.Command
+		want, ok := legacy[name]
+		if !ok {
+			t.Errorf("built-in %q has no legacy expectation in this table", name)
+			continue
+		}
+		if got := ToolIcon(name); got != want.icon {
+			t.Errorf("ToolIcon(%q) = %q, want %q", name, got, want.icon)
+		}
+		if got := ToolColor(name); got != want.color {
+			t.Errorf("ToolColor(%q) = %q, want %q", name, got, want.color)
+		}
+	}
+}
+
+// TestToolIconColor_UnknownFallsBackToSwitch keeps the legacy default arms for
+// names the registry does not know.
+func TestToolIconColor_UnknownFallsBackToSwitch(t *testing.T) {
+	InitTheme("dark")
+	if got := ToolIcon("no-such-tool"); got != IconShell {
+		t.Errorf("ToolIcon(unknown) = %q, want %q", got, IconShell)
+	}
+	if got := ToolColor("no-such-tool"); got != ColorTextDim {
+		t.Errorf("ToolColor(unknown) = %q, want %q", got, ColorTextDim)
+	}
+}
+
+// TestPaletteColor covers the slot-name resolution and the verbatim passthrough
+// used for custom [tools.<name>] color values.
+func TestPaletteColor(t *testing.T) {
+	InitTheme("dark")
+	cases := []struct {
+		in   string
+		want lipgloss.Color
+		ok   bool
+	}{
+		{"", "", false},
+		{"orange", ColorOrange, true},
+		{"purple", ColorPurple, true},
+		{"cyan", ColorCyan, true},
+		{"accent", ColorAccent, true},
+		{"yellow", ColorYellow, true},
+		{"red", ColorRed, true},
+		{"#ff00ff", lipgloss.Color("#ff00ff"), true},
+		{"208", lipgloss.Color("208"), true},
+	}
+	for _, tc := range cases {
+		got, ok := paletteColor(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("paletteColor(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

`internal/ui/styles.go` carried two hand-maintained `switch tool {}` blocks (icon and color per tool name) that duplicated data the tool registry already holds. Every new first-class tool had to touch both, which is part of why #2054 and #2095 fanned out across so many files. Closes #2136.

## Why this change

`Registry` now exposes `Icon(name)` and `Color(name)`. Icon reads `builtinTool.Icon` or the custom `ToolDef.Icon`. Color reads a new `builtinTool.Color` palette slot ("orange", "purple", "cyan", "accent", "yellow", "red") or a new optional `[tools.<name>] color = "<lipgloss value>"`. Built-ins carry a slot name rather than a hex value so live theme switches keep resolving against the active palette in the UI. `ToolIcon` and `ToolColor` consult the registry first through `session.ToolIconFor` / `session.ToolColorFor` and keep the old switch as the fallback for any name the registry returns nothing for. A new tool now needs one line in `builtins.go` instead of edits in two switches.

## User impact

None for any built-in tool: icons and colors render exactly as before. Custom `[tools.<name>]` entries that set `icon` are now honored in the session list too (previously only the dialogs used it), and they may set `color` to paint the tool name.

## Evidence

Local verification in the worktree:

    $ gofmt -l ./cmd ./internal      # printed nothing
    $ go build ./...                  # ok
    $ go vet ./...                    # ok

`internal/ui/styles_registry_test.go` embeds the literal values of the old switches for all 12 built-ins (claude, opencode, gemini, codex, pi, copilot, crush, cursor, hermes, deepseek, aider, shell) and asserts `ToolIcon` / `ToolColor` still return them, plus the unknown-name fallback and the palette slot resolution. `TestRegistry_IconAndColor` covers custom icon and color lookups in the session package.

Local go test is disallowed on this host; full suite runs in CI on this PR.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

https://claude.ai/code/session_01VqZQYv7fcPCDxFJ1yHHjzA

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
