### PR TITLE
refactor(web): register panes and feature routes in one table each

### DIFF
--- a/internal/web/handlers_command_center.go
+++ b/internal/web/handlers_command_center.go
@@ -677,3 +677,14 @@ func firstLine(s string) string {
 	}
 	return s
 }
+
+// Command Center (the embedded live fleet god-view — see
+// conductor/agent-deck/COMMAND-CENTER-DESIGN.md). Two read endpoints and
+// one write endpoint, all behind the existing authorize/CSRF/mutation gates.
+func init() {
+	registerFeatureRoutes(func(s *Server, mux *http.ServeMux) {
+		mux.HandleFunc("/api/command-center/status", s.handleCommandCenterStatus)
+		mux.HandleFunc("/events/command-center", s.handleCommandCenterEvents)
+		mux.HandleFunc("POST /api/command-center/ask", s.handleCommandCenterAsk)
+	})
+}

--- a/internal/web/handlers_costs.go
+++ b/internal/web/handlers_costs.go
@@ -611,3 +611,17 @@ func (s *Server) computeBatchCosts(ids []string) map[string]float64 {
 func microToUSD(microdollars int64) float64 {
 	return float64(microdollars) / 1_000_000
 }
+
+func init() {
+	registerFeatureRoutes(func(s *Server, mux *http.ServeMux) {
+		mux.HandleFunc("/api/costs/summary", s.handleCostsSummary)
+		mux.HandleFunc("/api/costs/daily", s.handleCostsDaily)
+		mux.HandleFunc("/api/costs/sessions", s.handleCostsSessions)
+		mux.HandleFunc("/api/costs/models", s.handleCostsModels)
+		mux.HandleFunc("/api/costs/export", s.handleCostsExport)
+		mux.HandleFunc("/api/costs/groups", s.handleCostsGroups)
+		mux.HandleFunc("/api/costs/session", s.handleCostsSessionDetail)
+		mux.HandleFunc("/api/costs/batch", s.handleCostsBatch)
+		mux.HandleFunc("/api/costs/stream", s.handleCostsStream)
+	})
+}

--- a/internal/web/handlers_mcps.go
+++ b/internal/web/handlers_mcps.go
@@ -648,3 +648,15 @@ func filterDefined(names []string) []string {
 type errInvalidScope string
 
 func (e errInvalidScope) Error() string { return "invalid MCP scope: " + string(e) }
+
+// MCP management (Web UI parity with TUI `m` key dialog). Closes the
+// four MISSING rows under "MCP MANAGEMENT" in PARITY_MATRIX.md.
+func init() {
+	registerFeatureRoutes(func(s *Server, mux *http.ServeMux) {
+		mux.HandleFunc("/api/mcps", s.handleMCPsCatalog)
+		mux.HandleFunc("GET /api/sessions/{id}/mcps", s.handleSessionMCPsRouter)
+		mux.HandleFunc("POST /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
+		mux.HandleFunc("DELETE /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
+		mux.HandleFunc("PATCH /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
+	})
+}

--- a/internal/web/handlers_skills.go
+++ b/internal/web/handlers_skills.go
@@ -209,3 +209,9 @@ func (s *Server) skillsServiceOrDefault() SkillsService {
 	}
 	return defaultSkillsService{}
 }
+
+func init() {
+	registerFeatureRoutes(func(s *Server, mux *http.ServeMux) {
+		mux.HandleFunc("/api/skills", s.handleSkillsCatalog)
+	})
+}

--- a/internal/web/handlers_system.go
+++ b/internal/web/handlers_system.go
@@ -67,3 +67,9 @@ func (s *Server) handleSystemStats(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, resp)
 }
+
+func init() {
+	registerFeatureRoutes(func(s *Server, mux *http.ServeMux) {
+		mux.HandleFunc("/api/system/stats", s.handleSystemStats)
+	})
+}

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -1,0 +1,19 @@
+package web
+
+import "net/http"
+
+// featureRoutes collects per-feature route registrations. A handlers_<feature>.go
+// file appends its own routes from an init() so the wiring for a feature lives
+// next to its handlers instead of in newServer. Core routes (index, static,
+// sessions, groups, settings, push, events, ws) stay in server.go.
+var featureRoutes []func(s *Server, mux *http.ServeMux)
+
+func registerFeatureRoutes(fn func(s *Server, mux *http.ServeMux)) {
+	featureRoutes = append(featureRoutes, fn)
+}
+
+func (s *Server) mountFeatureRoutes(mux *http.ServeMux) {
+	for _, fn := range featureRoutes {
+		fn(s, mux)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -263,34 +263,9 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("/events/menu", s.handleMenuEvents)
 	mux.HandleFunc("/ws/session/", s.handleSessionWS)
 
-	// Command Center (the embedded live fleet god-view — see
-	// conductor/agent-deck/COMMAND-CENTER-DESIGN.md). Two read endpoints and
-	// one write endpoint, all behind the existing authorize/CSRF/mutation gates.
-	mux.HandleFunc("/api/command-center/status", s.handleCommandCenterStatus)
-	mux.HandleFunc("/events/command-center", s.handleCommandCenterEvents)
-	mux.HandleFunc("POST /api/command-center/ask", s.handleCommandCenterAsk)
-
-	mux.HandleFunc("/api/costs/summary", s.handleCostsSummary)
-	mux.HandleFunc("/api/costs/daily", s.handleCostsDaily)
-	mux.HandleFunc("/api/costs/sessions", s.handleCostsSessions)
-	mux.HandleFunc("/api/costs/models", s.handleCostsModels)
-	mux.HandleFunc("/api/costs/export", s.handleCostsExport)
-	mux.HandleFunc("/api/costs/groups", s.handleCostsGroups)
-	mux.HandleFunc("/api/costs/session", s.handleCostsSessionDetail)
-	mux.HandleFunc("/api/costs/batch", s.handleCostsBatch)
-	mux.HandleFunc("/api/costs/stream", s.handleCostsStream)
-
-	mux.HandleFunc("/api/system/stats", s.handleSystemStats)
-
-	mux.HandleFunc("/api/skills", s.handleSkillsCatalog)
-
-	// MCP management (Web UI parity with TUI `m` key dialog). Closes the
-	// four MISSING rows under "MCP MANAGEMENT" in PARITY_MATRIX.md.
-	mux.HandleFunc("/api/mcps", s.handleMCPsCatalog)
-	mux.HandleFunc("GET /api/sessions/{id}/mcps", s.handleSessionMCPsRouter)
-	mux.HandleFunc("POST /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
-	mux.HandleFunc("DELETE /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
-	mux.HandleFunc("PATCH /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
+	// Feature routes (command center, costs, system, skills, MCPs) register
+	// themselves from their handlers_<feature>.go files; see routes.go.
+	s.mountFeatureRoutes(mux)
 
 	handler := withRecover(s.csrfProtect(mux))
 

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -15,15 +15,7 @@ import { RightRail } from './RightRail.js'
 import { MobileTabs } from './MobileTabs.js'
 import { CommandPalette } from './CommandPalette.js'
 import { TweaksPanel } from './TweaksPanel.js'
-import { TerminalPane } from './panes/TerminalPane.js'
-import { CostsPane } from './panes/CostsPane.js'
-import { FleetPane } from './panes/FleetPane.js'
-import { CommandCenterPane } from './panes/CommandCenterPane.js'
-import { ArchivedPane } from './panes/ArchivedPane.js'
-import { StubPane } from './panes/StubPane.js'
-import { SearchPane } from './panes/SearchPane.js'
-import { McpPane } from './panes/McpPane.js'
-import { SkillsPane } from './panes/SkillsPane.js'
+import { PANES, resolvePane } from './paneRegistry.js'
 import { Icon, ICONS } from './icons.js'
 import { menuModelSignal } from './dataModel.js'
 import {
@@ -99,22 +91,19 @@ function WorkHead() {
 // when another tab is active. This preserves the xterm.js + WebSocket lifecycle
 // across tab switches; unmounting would trigger a reconnect storm and lose
 // scrollback. Other panes are cheap enough to mount/unmount on demand.
+//
+// Which panes exist, and what each renders, lives in paneRegistry.js.
 function Panes({ tab }) {
+  const terminal = resolvePane('terminal')
   return html`
     <div style=${{ display: tab === 'terminal' ? 'flex' : 'none', flex: 1, minHeight: 0, flexDirection: 'column' }}>
-      <${TerminalPane}/>
+      <${terminal.component} ...${terminal.props}/>
     </div>
-    ${tab === 'command-center' && html`<${CommandCenterPane}/>`}
-    ${tab === 'fleet'     && html`<${FleetPane}/>`}
-    ${tab === 'costs'     && html`<${CostsPane}/>`}
-    ${tab === 'search'    && html`<${SearchPane}/>`}
-    ${tab === 'archived'  && html`<${ArchivedPane}/>`}
-    ${tab === 'mcp'       && html`<${McpPane}/>`}
-    ${tab === 'skills'    && html`<${SkillsPane}/>`}
-    ${tab === 'conductor' && html`<${StubPane} title="Conductor"
-                              message="Conductor orchestration view is TUI-only. The web API does not expose child topology, bridges, or NEED escalation."/>`}
-    ${tab === 'watchers'  && html`<${StubPane} title="Watchers"
-                              message="Watcher framework events are routed in the backend; the web API does not surface event streams or routing config."/>`}
+    ${Object.keys(PANES).map(id => {
+      if (id === 'terminal' || id !== tab) return null
+      const pane = resolvePane(id)
+      return html`<${pane.component} key=${id} ...${pane.props}/>`
+    })}
   `
 }
 

--- a/internal/web/static/app/Topbar.js
+++ b/internal/web/static/app/Topbar.js
@@ -13,19 +13,10 @@ import {
   railSignal, profileSignal,
 } from './uiState.js'
 import { ToastHistoryDrawerToggle } from './ToastHistoryDrawer.js'
+import { tabStrip } from './paneRegistry.js'
 
-const TABS = [
-  { id: 'command-center', label: 'Command Center' },
-  { id: 'fleet',     label: 'Fleet'     },
-  { id: 'terminal',  label: 'Terminal'  },
-  { id: 'mcp',       label: 'MCPs'      },
-  { id: 'skills',    label: 'Skills'    },
-  { id: 'conductor', label: 'Conductor' },
-  { id: 'watchers',  label: 'Watchers'  },
-  { id: 'costs',     label: 'Costs'     },
-  { id: 'search',    label: 'Search'    },
-  { id: 'archived',  label: 'Archived'  },
-]
+// Tab order and labels come from the pane registry (issue #2137).
+const TABS = tabStrip()
 
 export function Topbar() {
   const activeTab = activeTabSignal.value

--- a/internal/web/static/app/paneRegistry.js
+++ b/internal/web/static/app/paneRegistry.js
@@ -1,0 +1,65 @@
+// paneRegistry.js -- Single wiring table for the WebUI panes.
+//
+// PANES maps a tab id to { component, label, requiresCapability, props }.
+// Insertion order is the tab-strip order in Topbar. AppShell iterates the
+// same map, so adding or removing a pane means editing this file only.
+//
+// requiresCapability names a backend capability the pane depends on. When
+// it is missing from the capability set the shell renders StubPane with the
+// entry's `props` (title, message, hotkey) instead of the component.
+import { TerminalPane } from './panes/TerminalPane.js'
+import { CostsPane } from './panes/CostsPane.js'
+import { FleetPane } from './panes/FleetPane.js'
+import { CommandCenterPane } from './panes/CommandCenterPane.js'
+import { ArchivedPane } from './panes/ArchivedPane.js'
+import { StubPane } from './panes/StubPane.js'
+import { SearchPane } from './panes/SearchPane.js'
+import { McpPane } from './panes/McpPane.js'
+import { SkillsPane } from './panes/SkillsPane.js'
+
+// Capabilities the web API exposes today. Conductor topology and watcher
+// event streams are TUI-only (see tests/web/PARITY_MATRIX.md), so they are
+// absent here and their panes fall back to StubPane.
+export const WEB_CAPABILITIES = new Set([
+  'command-center', 'fleet', 'terminal', 'mcp', 'skills', 'costs', 'search', 'archived',
+])
+
+export const PANES = {
+  'command-center': { component: CommandCenterPane, label: 'Command Center', requiresCapability: 'command-center' },
+  fleet:     { component: FleetPane,    label: 'Fleet',    requiresCapability: 'fleet' },
+  terminal:  { component: TerminalPane, label: 'Terminal', requiresCapability: 'terminal' },
+  mcp:       { component: McpPane,      label: 'MCPs',     requiresCapability: 'mcp' },
+  skills:    { component: SkillsPane,   label: 'Skills',   requiresCapability: 'skills' },
+  conductor: {
+    component: null, label: 'Conductor', requiresCapability: 'conductor',
+    props: {
+      title: 'Conductor',
+      message: 'Conductor orchestration view is TUI-only. The web API does not expose child topology, bridges, or NEED escalation.',
+    },
+  },
+  watchers: {
+    component: null, label: 'Watchers', requiresCapability: 'watchers',
+    props: {
+      title: 'Watchers',
+      message: 'Watcher framework events are routed in the backend; the web API does not surface event streams or routing config.',
+    },
+  },
+  costs:     { component: CostsPane,    label: 'Costs',    requiresCapability: 'costs' },
+  search:    { component: SearchPane,   label: 'Search',   requiresCapability: 'search' },
+  archived:  { component: ArchivedPane, label: 'Archived', requiresCapability: 'archived' },
+}
+
+// Tab strip entries in display order.
+export function tabStrip(panes = PANES) {
+  return Object.entries(panes).map(([id, p]) => ({ id, label: p.label }))
+}
+
+// Resolve a tab id to the component and props the shell should mount.
+// Returns null for unknown ids. An unmet capability yields StubPane.
+export function resolvePane(id, capabilities = WEB_CAPABILITIES, panes = PANES) {
+  const entry = panes[id]
+  if (!entry) return null
+  const met = !entry.requiresCapability || capabilities.has(entry.requiresCapability)
+  if (met && entry.component) return { component: entry.component, props: entry.props || {} }
+  return { component: StubPane, props: entry.props || { title: entry.label, message: '' } }
+}

--- a/tests/web/helpers/xtermStub.js
+++ b/tests/web/helpers/xtermStub.js
@@ -1,0 +1,17 @@
+// helpers/xtermStub.js -- Stand-in for the @xterm packages under Vitest.
+//
+// The browser resolves @xterm/* through the import map in index.html to
+// /static/vendor/*.mjs; that map does not exist in Node. Component modules
+// that import TerminalPanel.js (directly or via paneRegistry.js) only need
+// the specifiers to resolve, so alias them here. No test drives a terminal.
+export class Terminal {
+  constructor() { this.options = {} }
+  loadAddon() {}
+  open() {}
+  write() {}
+  dispose() {}
+  onData() { return { dispose() {} } }
+  onResize() { return { dispose() {} } }
+}
+export class FitAddon { fit() {} dispose() {} }
+export class WebglAddon { dispose() {} }

--- a/tests/web/unit/__snapshots__/paneRegistry.test.js.snap
+++ b/tests/web/unit/__snapshots__/paneRegistry.test.js.snap
@@ -1,0 +1,46 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`paneRegistry > renders the same tab names in the same order as before 1`] = `
+[
+  {
+    "id": "command-center",
+    "label": "Command Center",
+  },
+  {
+    "id": "fleet",
+    "label": "Fleet",
+  },
+  {
+    "id": "terminal",
+    "label": "Terminal",
+  },
+  {
+    "id": "mcp",
+    "label": "MCPs",
+  },
+  {
+    "id": "skills",
+    "label": "Skills",
+  },
+  {
+    "id": "conductor",
+    "label": "Conductor",
+  },
+  {
+    "id": "watchers",
+    "label": "Watchers",
+  },
+  {
+    "id": "costs",
+    "label": "Costs",
+  },
+  {
+    "id": "search",
+    "label": "Search",
+  },
+  {
+    "id": "archived",
+    "label": "Archived",
+  },
+]
+`;

--- a/tests/web/unit/paneRegistry.test.js
+++ b/tests/web/unit/paneRegistry.test.js
@@ -1,0 +1,77 @@
+// Pins the pane wiring table introduced for issue #2137. AppShell and Topbar
+// both read PANES, so the tab strip order here is the order users see, and a
+// pane whose backend capability is missing must fall back to StubPane with
+// the same title/message it rendered before the registry existed.
+import { describe, expect, it } from 'vitest'
+
+const registryPath = '../../../internal/web/static/app/paneRegistry.js'
+const stubPath = '../../../internal/web/static/app/panes/StubPane.js'
+
+// Exactly the TABS list Topbar.js carried before the registry.
+const EXPECTED_TAB_STRIP = [
+  { id: 'command-center', label: 'Command Center' },
+  { id: 'fleet',     label: 'Fleet'     },
+  { id: 'terminal',  label: 'Terminal'  },
+  { id: 'mcp',       label: 'MCPs'      },
+  { id: 'skills',    label: 'Skills'    },
+  { id: 'conductor', label: 'Conductor' },
+  { id: 'watchers',  label: 'Watchers'  },
+  { id: 'costs',     label: 'Costs'     },
+  { id: 'search',    label: 'Search'    },
+  { id: 'archived',  label: 'Archived'  },
+]
+
+describe('paneRegistry', () => {
+  it('renders the same tab names in the same order as before', async () => {
+    const { tabStrip } = await import(registryPath)
+    expect(tabStrip()).toEqual(EXPECTED_TAB_STRIP)
+    expect(tabStrip()).toMatchSnapshot()
+  })
+
+  it('resolves a pane with a met capability to its component', async () => {
+    const { resolvePane, PANES } = await import(registryPath)
+    const { StubPane } = await import(stubPath)
+    for (const id of ['command-center', 'fleet', 'terminal', 'mcp', 'skills', 'costs', 'search', 'archived']) {
+      const pane = resolvePane(id)
+      expect(pane.component).toBe(PANES[id].component)
+      expect(pane.component).not.toBe(StubPane)
+      expect(pane.props).toEqual({})
+    }
+  })
+
+  it('falls back to StubPane with the legacy props when a capability is unmet', async () => {
+    const { resolvePane } = await import(registryPath)
+    const { StubPane } = await import(stubPath)
+
+    const conductor = resolvePane('conductor')
+    expect(conductor.component).toBe(StubPane)
+    expect(conductor.props).toEqual({
+      title: 'Conductor',
+      message: 'Conductor orchestration view is TUI-only. The web API does not expose child topology, bridges, or NEED escalation.',
+    })
+
+    const watchers = resolvePane('watchers')
+    expect(watchers.component).toBe(StubPane)
+    expect(watchers.props).toEqual({
+      title: 'Watchers',
+      message: 'Watcher framework events are routed in the backend; the web API does not surface event streams or routing config.',
+    })
+  })
+
+  it('stubs a real pane when its capability is removed from the set', async () => {
+    const { resolvePane, WEB_CAPABILITIES, PANES } = await import(registryPath)
+    const { StubPane } = await import(stubPath)
+
+    const without = new Set(WEB_CAPABILITIES)
+    without.delete('costs')
+    const pane = resolvePane('costs', without)
+    expect(pane.component).toBe(StubPane)
+    expect(pane.props).toEqual({ title: 'Costs', message: '' })
+    expect(resolvePane('costs').component).toBe(PANES.costs.component)
+  })
+
+  it('returns null for an unknown tab id', async () => {
+    const { resolvePane } = await import(registryPath)
+    expect(resolvePane('nope')).toBe(null)
+  })
+})

--- a/tests/web/vitest.config.js
+++ b/tests/web/vitest.config.js
@@ -59,6 +59,10 @@ export default defineConfig({
       'htm/preact': aliasFor('htm/preact'),
       '@preact/signals': aliasFor('@preact/signals'),
       '@preact/signals-core': aliasFor('@preact/signals-core'),
+      // xterm ships via the index.html import map, not npm; see helpers/xtermStub.js.
+      '@xterm/xterm': resolve(import.meta.dirname, 'helpers', 'xtermStub.js'),
+      '@xterm/addon-fit': resolve(import.meta.dirname, 'helpers', 'xtermStub.js'),
+      '@xterm/addon-webgl': resolve(import.meta.dirname, 'helpers', 'xtermStub.js'),
     },
   },
 })


### PR DESCRIPTION
## What problem does this solve?

`internal/web/static/app/AppShell.js` dispatched panes with an inline `tab === 'x' && <Component/>` chain, so adding or removing a web panel meant editing shared shell code, and StubPane (already used for panes with backend gaps) was wired the same ad hoc way. On the Go side every `handlers_<feature>.go` file relied on `server.go` to list its routes.

Closes #2137

## Why this change

A registry is the wiring table the existing structure was missing. `paneRegistry.js` holds a `PANES` map (tab id to `{ component, label, requiresCapability, props }`); AppShell iterates it and Topbar derives its tab strip from it, so the tab order is defined once. `resolvePane(id, capabilities)` returns StubPane with the entry's props whenever `requiresCapability` is not in `WEB_CAPABILITIES`, which is exactly how Conductor and Watchers were rendered before. TerminalPane keeps its always-mounted, CSS-hidden wrapper so the xterm and WebSocket lifecycle is untouched.

For Go, `routes.go` adds a `featureRoutes` slice plus `registerFeatureRoutes`; the command center, costs, system, skills and MCP handler files register their routes from `init()` and `NewServer` mounts them with one call. Core routes (index, static, sessions, groups, settings, push, events, ws) stay in `server.go`. Go 1.22+ ServeMux matches by pattern specificity, not registration order, so moving these registrations does not change routing.

## User impact

None, internal only. The rendered DOM for every existing tab is identical (same components, same StubPane title/message, same tab names in the same order).

## Evidence

Vitest (`tests/web`, `npm ci` then `npx vitest run`), including the new `unit/paneRegistry.test.js` which pins the pre-change tab strip as an exact list and a snapshot, and asserts the StubPane fallback for Conductor, Watchers and for a real pane whose capability is removed:

    ✓ unit/paneRegistry.test.js (5 tests) 184ms
    Snapshots  1 written
    Test Files  14 passed (14)
         Tests  154 passed (154)

Go:

    $ gofmt -l ./cmd ./internal      # prints nothing
    $ go build ./...                 # ok
    $ go vet ./...                   # ok

Local go test is disallowed on this host; full suite runs in CI on this PR.

Note on test infra: `paneRegistry.js` imports TerminalPane, which imports `@xterm/*`. Those resolve through the import map in `index.html` in the browser but not under Node, so `vitest.config.js` now aliases them to `tests/web/helpers/xtermStub.js`. Without that, no test could import the registry.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
