### PR TITLE
feat(conductor): ship the GitHub event watcher as an opt-in daemon

### DIFF
--- a/conductor/gh-watcher/README.md
+++ b/conductor/gh-watcher/README.md
@@ -1,0 +1,155 @@
+# gh-watcher: GitHub event poller for the conductor
+
+An opt-in polling watcher that rings the conductor's doorbell when something
+happens on a GitHub repository. It follows the pattern in
+[`docs/WATCHER-SETUP.md`](../../docs/WATCHER-SETUP.md): the watcher notices,
+dedupes and forwards a tiny trigger; the conductor decides what to do.
+
+It is off by default. Nothing here runs until you enable it in `config.toml`
+and rerun `conductor/setup.sh`.
+
+## What it does
+
+Every `cadence.events_seconds` (default 30) `scripts/tick.sh` runs:
+
+1. `poll-events.sh`: `gh api /repos/<owner>/<repo>/events` with an ETag. A 304
+   costs nothing and does not count against the rate limit.
+2. `ingest-events.py`: new event ids go into `gh_events_seen` (SQLite, WAL).
+   Dedup is the primary key, so a re-delivered event never fires twice.
+3. `classify.py`: `classes.json` maps each event type to `immediate`,
+   `paced`, `paced-coalesced`, `paced-digest` or `suppressed`, and builds the
+   trigger text. Review comments on the same PR coalesce into one row.
+4. `dispatcher.sh`: pops at most one row per tick. Immediate rows bypass the
+   pacing gate; paced rows wait `dispatcher.min_interval_seconds` between
+   sends. Rows are marked `sent` only after delivery succeeds (at least once).
+5. `digest-flush.sh`: once a day at `dispatcher.digest_flush_local_time`,
+   the digest bucket (green workflow runs and anything classed `paced-digest`) becomes one low
+   priority row.
+
+Authentication is whatever `gh` already has: `gh auth login` or `GH_TOKEN`.
+No token is stored by the watcher.
+
+## Trigger format
+
+Triggers are lean, per `docs/WATCHER-SETUP.md`: at most 200 characters, an
+identifier the conductor can fetch, no payload.
+
+```
+[github:<type>:<owner>/<repo>#<n>] <short hint>
+
+[github:issue_opened:example-org/example-repo#2134] conductor: ship the GitHub event watcher
+[github:pr_opened:example-org/example-repo#2140] fix(tui): preserve rapid SSH input
+[github:pr_review_submitted:example-org/example-repo#2140] state=approved
+[github:coalesced:example-org/example-repo#2140] 4 review events
+[github:digest:example-org/example-repo] stars x7 in last 24h
+```
+
+`<type>` is the event name (`issue`, `pr`, `issue_comment`, `pr_review`,
+`workflow_run`, ...) plus the GitHub action when there is one
+(`issue_opened`, `pr_closed`). Push and workflow events identify by
+`<owner>/<repo>@<sha7>`.
+
+### Burst summary
+
+When more than `dispatcher.high_water` rows are pending (a backfill, a bot
+storm, the conductor was down), the dispatcher does not drip them out one by
+one. It sends a single summary listing counts and item numbers, marks every
+summarized row as sent, and the conductor triages from the live API:
+
+```
+[github:burst:example-org/example-repo] 31 pending: pr x14 (#2101 #2103 #2105 ...), issue x9 (#2130 #2131 ...), issue_comment x8
+```
+
+This is the one trigger allowed past 200 characters (capped at 400).
+
+## Modes
+
+| `mode`     | Behaviour |
+|------------|-----------|
+| `log`      | Default. Polls, classifies, queues and pops rows, but only writes `would send: ...` lines to `task-log.md`. Nothing reaches the conductor. Run this first for a day and read the log. |
+| `dispatch` | `agent-deck -p <profile> session send <conductor> "<trigger>" --no-wait` for each popped row. |
+
+`mode` lives in `watcher.toml` under `[watcher]`. The `[conductor.github_watcher]`
+table in `config.toml` carries a `mode` key as well so the Go binary and
+`setup.sh` can report it; keep the two in sync (the watcher scripts read only
+`watcher.toml`).
+
+## Enabling it
+
+1. In `~/.agent-deck/config.toml` (or your XDG config path):
+
+   ```toml
+   [conductor.github_watcher]
+   enabled = true
+   mode = "log"
+   ```
+
+2. Run `conductor/setup.sh`. With `enabled = true` it copies this directory to
+   `<conductor dir>/gh-watcher/`, writes `watcher.toml` from
+   `watcher.example.toml` if none exists, and installs the scheduler:
+   * macOS: `~/Library/LaunchAgents/com.agentdeck.gh-watcher.plist`
+     (`StartInterval` = `cadence.events_seconds`), loaded immediately.
+   * Linux: `~/.config/systemd/user/agent-deck-gh-watcher.{service,timer}`,
+     then `systemctl --user daemon-reload && systemctl --user enable --now agent-deck-gh-watcher.timer`.
+
+   With `enabled = false` (or no table) setup.sh prints one line and does
+   nothing else.
+
+3. Edit `<conductor dir>/gh-watcher/watcher.toml`: `[repo]` owner and name,
+   `[routing]` profile and the exact conductor session title.
+
+4. Watch `task-log.md` for a while in `log` mode, then switch `mode = "dispatch"`.
+
+Run a tick by hand at any time: `AD_GH_WATCHER_HOME=<conductor dir>/gh-watcher scripts/tick.sh`.
+
+`conductor/teardown.sh` unloads and removes the launchd unit.
+
+## Liveness
+
+Every successful round trip to GitHub (200 or 304) writes the epoch time to
+`liveness_path` (`last-poll` next to `watcher.toml`). A quiet repository keeps
+the file fresh; only a dead scheduler, a broken `gh` login or a network outage
+let it age.
+
+`scripts/status.sh` prints one line and exits 2 when the file is older than
+`cadence.stale_after_seconds` (default 3 x `events_seconds`):
+
+```
+gh-watcher repo=example-org/example-repo mode=log last_poll_age=12s liveness=fresh pending=0
+```
+
+A heartbeat rule can call it and raise a NEED line on exit 2, for example:
+`NEED: gh-watcher stale (last poll 412s ago); check launchctl list com.agentdeck.gh-watcher`.
+
+## Files
+
+```
+watcher.example.toml           copy to watcher.toml; every path and name comes from here or env
+schema.sql                     SQLite tables (own db file, not the agent-deck store)
+classes.json                   event type -> delivery class and priority
+com.agentdeck.gh-watcher.plist launchd template (setup.sh substitutes __PLACEHOLDERS__)
+systemd/                       service + timer templates for Linux
+scripts/watcherlib.py              config loader; `--shell` prints GHW_* exports for bash
+scripts/tick.sh                    poll + dispatch + daily digest flush
+scripts/poll-events.sh             ETag poll, liveness stamp, ingest, classify
+scripts/ingest-events.py           JSON events -> gh_events_seen
+scripts/classify.py                delivery class, trigger text, queue/digest routing
+scripts/dispatcher.sh              pacing, immediate override, high_water burst
+scripts/burst-summary.py           the burst message
+scripts/digest-flush.sh            daily digest bucket -> one queue row
+scripts/send.sh                    mode gate; GHW_SEND_CMD override for tests
+scripts/status.sh                  liveness + queue depth, exit 2 when stale
+```
+
+Environment overrides: `AD_GH_WATCHER_CONFIG` (path to a `watcher.toml`),
+`AD_GH_WATCHER_HOME` (directory holding `watcher.toml`), `GHW_SEND_CMD`
+(replacement send command, used by tests).
+
+## Why it was retired before
+
+A maintainer-side copy of this poller ran on 2026-04-19 and was retired the
+same day together with the webhook based `github-watcher`. The task logs do
+not record a reason; the poller's own log ends with normal paced sends. The
+retired webhook watcher's log shows it re-firing on one test issue for hours,
+which is the kind of noise the `log` mode and the ETag dedup here are meant
+to surface before anything reaches a conductor. Run `log` mode first.

--- a/conductor/gh-watcher/classes.json
+++ b/conductor/gh-watcher/classes.json
@@ -1,0 +1,32 @@
+{
+  "IssuesEvent":                   { "class": "paced",           "priority": 10 },
+  "IssueCommentEvent":             { "class": "paced",           "priority": 10 },
+  "PullRequestEvent":              { "class": "paced",           "priority": 10 },
+  "PullRequestReviewEvent":        { "class": "paced",           "priority": 10 },
+  "PullRequestReviewCommentEvent": { "class": "paced-coalesced", "priority": 10, "parent_key": "pr_review" },
+  "PullRequestReviewThreadEvent":  { "class": "paced-coalesced", "priority": 10, "parent_key": "pr_review" },
+  "DiscussionEvent":               { "class": "paced",           "priority": 10 },
+  "DiscussionCommentEvent":        { "class": "paced",           "priority": 10 },
+
+  "SecurityAdvisoryEvent":         { "class": "immediate",       "priority": 0  },
+  "MentionsEvent":                 { "class": "immediate",       "priority": 0  },
+
+  "ReleaseEvent":                  { "class": "suppressed" },
+  "PublicEvent":                   { "class": "suppressed" },
+  "WorkflowRunEvent":              { "class": "suppressed" },
+  "CheckRunEvent":                 { "class": "suppressed" },
+  "CheckSuiteEvent":               { "class": "suppressed" },
+  "StatusEvent":                   { "class": "suppressed" },
+  "PushEvent":                     { "class": "suppressed" },
+  "DeploymentEvent":               { "class": "suppressed" },
+  "DeploymentStatusEvent":         { "class": "suppressed" },
+  "CommitCommentEvent":            { "class": "suppressed" },
+  "MemberEvent":                   { "class": "suppressed" },
+  "CreateEvent":                   { "class": "suppressed" },
+  "DeleteEvent":                   { "class": "suppressed" },
+  "GollumEvent":                   { "class": "suppressed" },
+  "WatchEvent":                    { "class": "suppressed" },
+  "ForkEvent":                     { "class": "suppressed" },
+
+  "_default":                      { "class": "suppressed" }
+}

--- a/conductor/gh-watcher/com.agentdeck.gh-watcher.plist
+++ b/conductor/gh-watcher/com.agentdeck.gh-watcher.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.agentdeck.gh-watcher</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__TICK_PATH__</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>AD_GH_WATCHER_HOME</key>
+        <string>__WATCHER_HOME__</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>__INTERVAL__</integer>
+
+    <key>StandardOutPath</key>
+    <string>__LOG_PATH__</string>
+
+    <key>StandardErrorPath</key>
+    <string>__LOG_PATH__</string>
+
+    <key>WorkingDirectory</key>
+    <string>__WATCHER_HOME__</string>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/conductor/gh-watcher/schema.sql
+++ b/conductor/gh-watcher/schema.sql
@@ -1,0 +1,48 @@
+-- gh-watcher schema. Lives in its own SQLite file (db_path in watcher.toml).
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS gh_events_seen (
+  event_id       TEXT PRIMARY KEY,
+  created_at     TEXT NOT NULL,
+  event_type     TEXT NOT NULL,
+  subtype        TEXT,
+  delivery_class TEXT NOT NULL,
+  payload_json   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS gh_poll_cursor (
+  name       TEXT PRIMARY KEY,
+  etag       TEXT,
+  last_id    TEXT,
+  since      TEXT,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS gh_deliver_queue (
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+  enqueued_at TEXT NOT NULL,
+  event_id    TEXT NOT NULL,
+  parent_key  TEXT,
+  priority    INTEGER NOT NULL,
+  items_count INTEGER DEFAULT 1,
+  message     TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'pending',
+  sent_at     TEXT,
+  UNIQUE(event_id, parent_key)
+);
+
+CREATE INDEX IF NOT EXISTS ix_queue_pending
+  ON gh_deliver_queue(status, priority, enqueued_at);
+
+CREATE TABLE IF NOT EXISTS gh_digest (
+  class        TEXT NOT NULL,
+  window_start TEXT NOT NULL,
+  event_id     TEXT NOT NULL,
+  summary      TEXT NOT NULL,
+  PRIMARY KEY (class, event_id)
+);
+
+CREATE TABLE IF NOT EXISTS gh_dispatch_state (
+  k TEXT PRIMARY KEY,
+  v TEXT NOT NULL
+);

--- a/conductor/gh-watcher/scripts/burst-summary.py
+++ b/conductor/gh-watcher/scripts/burst-summary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Collapse every pending queue row into one digest trigger.
+
+Called by dispatcher.sh when pending depth exceeds high_water. Emits
+`[github:burst:<owner>/<repo>] N pending: issue x3 (#12 #13 #14), pr x2 (#15 #16)`,
+sends it through send.sh, then marks all summarized rows as sent with the
+burst's items_count so the queue drains in one step.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from watcherlib import Config
+
+BURST_MAX = 400  # a burst is the one trigger allowed past the 200 char rule
+_TAG = re.compile(r"^\[github:([^:\]]+):[^\]#]*(?:#(\d+))?\]")
+
+
+def summarize(rows: list[tuple[int, str]]) -> tuple[str, list[int]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for _seq, message in rows:
+        m = _TAG.match(message)
+        ttype = m.group(1) if m else "other"
+        base = ttype.split("_", 1)[0] if ttype not in ("issue_comment", "pr_review") else ttype
+        groups[base].append(f"#{m.group(2)}" if m and m.group(2) else "")
+    parts = []
+    for base, items in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+        numbers = sorted({i for i in items if i}, key=lambda s: int(s[1:]))
+        part = f"{base} x{len(items)}"
+        if numbers:
+            part += " (" + " ".join(numbers) + ")"
+        parts.append(part)
+    return ", ".join(parts), [seq for seq, _ in rows]
+
+
+def main() -> int:
+    cfg = Config()
+    con = sqlite3.connect(str(cfg.db), timeout=30)
+    rows = con.execute(
+        "SELECT seq, message FROM gh_deliver_queue WHERE status='pending' ORDER BY enqueued_at ASC"
+    ).fetchall()
+    if not rows:
+        return 0
+    body, seqs = summarize(rows)
+    msg = f"[github:burst:{cfg.repo}] {len(rows)} pending: {body}"
+    if len(msg) > BURST_MAX:
+        msg = msg[: BURST_MAX - 1] + "…"
+
+    send = Path(__file__).resolve().parent / "send.sh"
+    rc = subprocess.run([str(send), msg], capture_output=True).returncode
+    stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    if rc != 0:
+        with cfg.log.open("a") as fh:
+            fh.write(f"{stamp} [dispatcher] WARN burst send failed depth={len(rows)} (will retry next tick)\n")
+        return 1
+
+    placeholders = ",".join("?" * len(seqs))
+    con.execute(
+        f"UPDATE gh_deliver_queue SET status='sent', sent_at=datetime('now') WHERE seq IN ({placeholders})", seqs
+    )
+    con.execute(
+        "INSERT INTO gh_dispatch_state(k,v) VALUES('last_send_ts',?) ON CONFLICT(k) DO UPDATE SET v=excluded.v",
+        (str(int(time.time())),),
+    )
+    con.commit()
+    with cfg.log.open("a") as fh:
+        fh.write(f"{stamp} [dispatcher] burst sent items={len(rows)} mode={cfg.mode} high_water={cfg.high_water}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conductor/gh-watcher/scripts/classify.py
+++ b/conductor/gh-watcher/scripts/classify.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Classify unclassified gh_events_seen rows; route to the delivery queue or the digest bucket.
+
+Triggers follow docs/WATCHER-SETUP.md: `[github:<type>:<owner>/<repo>#<n>] <hint>`,
+at most TRIGGER_MAX characters, no payload. The conductor fetches details itself.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from watcherlib import Config
+
+TRIGGER_MAX = 200
+CLASSES = json.loads((Path(__file__).resolve().parent.parent / "classes.json").read_text())
+
+# GitHub event type -> short trigger type. Anything else falls back to the
+# lowercased event name without the "Event" suffix.
+TYPE_NAMES = {
+    "IssuesEvent": "issue",
+    "IssueCommentEvent": "issue_comment",
+    "PullRequestEvent": "pr",
+    "PullRequestReviewEvent": "pr_review",
+    "PullRequestReviewCommentEvent": "pr_review_comment",
+    "PullRequestReviewThreadEvent": "pr_review_thread",
+    "DiscussionEvent": "discussion",
+    "DiscussionCommentEvent": "discussion_comment",
+    "SecurityAdvisoryEvent": "security_advisory",
+    "WorkflowRunEvent": "workflow_run",
+    "ReleaseEvent": "release",
+    "PushEvent": "push",
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def trigger_type(event_type: str, subtype: str) -> str:
+    base = TYPE_NAMES.get(event_type) or event_type.removesuffix("Event").lower()
+    return f"{base}_{subtype}" if subtype else base
+
+
+def item_number(event_type: str, payload: dict) -> int | None:
+    for key in ("issue", "pull_request", "discussion"):
+        n = (payload.get(key) or {}).get("number")
+        if n:
+            return int(n)
+    n = payload.get("number")
+    return int(n) if n else None
+
+
+def clip(text: str) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= TRIGGER_MAX else text[: TRIGGER_MAX - 1] + "…"
+
+
+def format_message(cfg: Config, event_type: str, subtype: str, payload: dict) -> str:
+    ttype = trigger_type(event_type, subtype)
+    number = item_number(event_type, payload)
+    ident = f"{cfg.repo}#{number}" if number else cfg.repo
+    hint = ""
+    if event_type in ("IssuesEvent", "PullRequestEvent", "DiscussionEvent"):
+        hint = (payload.get("issue") or payload.get("pull_request") or payload.get("discussion") or {}).get("title", "")
+    elif event_type == "PullRequestReviewEvent":
+        hint = "state=" + str((payload.get("review") or {}).get("state", ""))
+    elif event_type == "WorkflowRunEvent":
+        run = payload.get("workflow_run") or payload
+        hint = f"{run.get('name', '')} on {run.get('head_branch', '')} -> {run.get('conclusion', '')}"
+        ident = f"{cfg.repo}@{str(run.get('head_sha', ''))[:7]}"
+    elif event_type == "PushEvent":
+        ident = f"{cfg.repo}@{str(payload.get('head', ''))[:7]}"
+        hint = payload.get("ref", "")
+    elif event_type == "ReleaseEvent":
+        hint = (payload.get("release") or {}).get("tag_name", "")
+    return clip(f"[github:{ttype}:{ident}] {hint}".rstrip())
+
+
+def parent_key_for(event_type: str, payload: dict) -> str | None:
+    pk = CLASSES.get(event_type, {}).get("parent_key")
+    if pk == "pr_review":
+        n = item_number(event_type, payload)
+        return f"pr_review:{n}" if n else None
+    if pk == "commit_sha":
+        sha = payload.get("sha") or (payload.get("check_run") or {}).get("head_sha") or (payload.get("check_suite") or {}).get("head_sha")
+        return f"commit_sha:{sha}" if sha else None
+    return None
+
+
+def conditional_class(event_type: str, payload: dict) -> tuple[str, int]:
+    if event_type == "WorkflowRunEvent":
+        run = payload.get("workflow_run") or payload
+        conclusion = run.get("conclusion") or ""
+        if conclusion not in ("success", "") and run.get("head_branch") in ("main", "master"):
+            return ("immediate", 0)
+        if conclusion == "success":
+            return ("paced-digest", 15)
+    return ("paced", 10)
+
+
+def coalesced_message(cfg: Config, parent_key: str, items_count: int) -> str:
+    _, _, tail = parent_key.partition(":")
+    return clip(f"[github:coalesced:{cfg.repo}#{tail}] {items_count} review events")
+
+
+def classify_one(cfg: Config, con: sqlite3.Connection, row: tuple) -> str:
+    event_id, _created_at, event_type, subtype, payload_str = row
+    payload = json.loads(payload_str)
+    spec = CLASSES.get(event_type, CLASSES["_default"])
+    klass = spec["class"]
+    priority = spec.get("priority", 10)
+    if klass == "conditional":
+        klass, priority = conditional_class(event_type, payload)
+
+    msg = format_message(cfg, event_type, subtype or "", payload)
+    pk = parent_key_for(event_type, payload)
+    cur = con.cursor()
+    cur.execute("UPDATE gh_events_seen SET delivery_class=? WHERE event_id=?", (klass, event_id))
+
+    if klass == "suppressed":
+        return "suppressed"
+
+    if klass in ("paced-digest", "daily-digest"):
+        digest_class = {"WatchEvent": "stars", "ForkEvent": "forks"}.get(event_type, klass)
+        cur.execute(
+            "INSERT OR IGNORE INTO gh_digest(class, window_start, event_id, summary) VALUES (?, ?, ?, ?)",
+            (digest_class, now_iso()[:10], event_id, msg),
+        )
+        return f"digest:{digest_class}"
+
+    if klass == "paced-coalesced" and pk:
+        existing = cur.execute(
+            "SELECT seq, items_count FROM gh_deliver_queue WHERE parent_key=? AND status='pending'", (pk,)
+        ).fetchone()
+        if existing:
+            seq, items = existing
+            cur.execute(
+                "UPDATE gh_deliver_queue SET items_count=?, message=? WHERE seq=?",
+                (items + 1, coalesced_message(cfg, pk, items + 1), seq),
+            )
+            return f"coalesced:{pk}:{items + 1}"
+        cur.execute(
+            "INSERT OR IGNORE INTO gh_deliver_queue(enqueued_at, event_id, parent_key, priority, items_count, message) "
+            "VALUES (?, ?, ?, ?, 1, ?)",
+            (now_iso(), event_id, pk, priority, msg),
+        )
+        return f"coalesced-new:{pk}"
+
+    cur.execute(
+        "INSERT OR IGNORE INTO gh_deliver_queue(enqueued_at, event_id, parent_key, priority, items_count, message) "
+        "VALUES (?, ?, NULL, ?, 1, ?)",
+        (now_iso(), event_id, priority, msg),
+    )
+    return f"queued:{klass}:p{priority}"
+
+
+def main() -> int:
+    cfg = Config()
+    con = sqlite3.connect(str(cfg.db), timeout=30)
+    con.execute("PRAGMA journal_mode=WAL;")
+    rows = con.execute(
+        "SELECT event_id, created_at, event_type, subtype, payload_json "
+        "FROM gh_events_seen WHERE delivery_class='unclassified' ORDER BY created_at ASC"
+    ).fetchall()
+    for row in rows:
+        try:
+            result = classify_one(cfg, con, row)
+            print(f"{row[0]} {row[2]} -> {result}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            print(f"WARN classify {row[0]}: {exc}", file=sys.stderr)
+    con.commit()
+    con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conductor/gh-watcher/scripts/digest-flush.sh
+++ b/conductor/gh-watcher/scripts/digest-flush.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Flush gh_digest into one low priority queue row per class, then clear the bucket.
+# tick.sh calls this once per day at dispatcher.digest_flush_local_time.
+set -euo pipefail
+BIN="$(cd "$(dirname "$0")" && pwd)"
+eval "$(python3 "$BIN/watcherlib.py" --shell)"
+python3 - "$GHW_DB" "$GHW_REPO" "$GHW_LOG" <<'PY'
+import sqlite3, sys
+from datetime import datetime, timezone
+db, repo, log = sys.argv[1:4]
+con = sqlite3.connect(db, timeout=30)
+stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+for (cls,) in con.execute("SELECT DISTINCT class FROM gh_digest").fetchall():
+    items = con.execute("SELECT summary FROM gh_digest WHERE class=?", (cls,)).fetchall()
+    if not items:
+        continue
+    msg = f"[github:digest:{repo}] {cls} x{len(items)} in last 24h"
+    con.execute(
+        "INSERT OR IGNORE INTO gh_deliver_queue(enqueued_at, event_id, parent_key, priority, items_count, message) "
+        "VALUES (datetime('now'), ?, NULL, 15, ?, ?)",
+        (f"digest-{cls}-{stamp[:10]}", len(items), msg),
+    )
+    con.execute("DELETE FROM gh_digest WHERE class=?", (cls,))
+    with open(log, "a") as fh:
+        fh.write(f"{stamp} [digest-flush] flushed class={cls} count={len(items)}\n")
+con.commit()
+PY

--- a/conductor/gh-watcher/scripts/dispatcher.sh
+++ b/conductor/gh-watcher/scripts/dispatcher.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Deliver at most one message per invocation.
+#  - priority=0 (immediate) bypasses the pacing gate.
+#  - priority>=10 only when (now - last_send_ts) >= min_interval_seconds.
+#  - pending depth above high_water: one burst summary replaces the whole queue.
+# At-least-once: rows are marked 'sent' only after the send succeeds.
+set -euo pipefail
+
+BIN="$(cd "$(dirname "$0")" && pwd)"
+eval "$(python3 "$BIN/watcherlib.py" --shell)"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "$(ts) [dispatcher] $*" >> "$GHW_LOG"; }
+
+[ -f "$GHW_DB" ] || exit 0
+
+NOW=$(date +%s)
+LAST=$(sqlite3 "$GHW_DB" "SELECT v FROM gh_dispatch_state WHERE k='last_send_ts';" 2>/dev/null || echo "0")
+LAST=${LAST:-0}
+SINCE=$(( NOW - LAST ))
+DEPTH=$(sqlite3 "$GHW_DB" "SELECT COUNT(*) FROM gh_deliver_queue WHERE status='pending';")
+
+# Burst summary: one message with counts and item numbers instead of popping a row.
+if [ "$DEPTH" -gt "$GHW_HIGH_WATER" ]; then
+  python3 "$BIN/burst-summary.py"
+  exit $?
+fi
+
+SEQ=$(sqlite3 "$GHW_DB" "SELECT seq FROM gh_deliver_queue WHERE status='pending' AND priority=0
+                         ORDER BY enqueued_at ASC LIMIT 1;")
+if [ -z "$SEQ" ]; then
+  [ "$SINCE" -lt "$GHW_MIN_INTERVAL" ] && exit 0
+  SEQ=$(sqlite3 "$GHW_DB" "SELECT seq FROM gh_deliver_queue WHERE status='pending' AND priority>=10
+                           ORDER BY priority ASC, enqueued_at ASC LIMIT 1;")
+  [ -z "$SEQ" ] && exit 0
+fi
+
+MSG=$(sqlite3 "$GHW_DB" "SELECT message FROM gh_deliver_queue WHERE seq=$SEQ;")
+if [ -z "$MSG" ]; then
+  log "ERROR seq=$SEQ has empty message; marking sent to avoid a loop"
+  sqlite3 "$GHW_DB" "UPDATE gh_deliver_queue SET status='sent', sent_at=datetime('now') WHERE seq=$SEQ;"
+  exit 0
+fi
+
+if "$BIN/send.sh" "$MSG" >/dev/null 2>&1; then
+  sqlite3 "$GHW_DB" "UPDATE gh_deliver_queue SET status='sent', sent_at=datetime('now') WHERE seq=$SEQ;
+                     INSERT INTO gh_dispatch_state(k,v) VALUES('last_send_ts','$NOW')
+                     ON CONFLICT(k) DO UPDATE SET v=excluded.v;"
+  log "sent seq=$SEQ mode=$GHW_MODE depth_was=$DEPTH"
+else
+  log "WARN send failed seq=$SEQ (will retry next tick)"
+  exit 1
+fi

--- a/conductor/gh-watcher/scripts/ingest-events.py
+++ b/conductor/gh-watcher/scripts/ingest-events.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Read a JSON array of GitHub events on stdin; INSERT OR IGNORE into gh_events_seen."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+
+from watcherlib import Config
+
+
+def main() -> int:
+    cfg = Config()
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return 0
+    try:
+        events = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"ingest-events: bad json: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(events, list):
+        print(f"ingest-events: expected list, got {type(events).__name__}", file=sys.stderr)
+        return 1
+
+    con = sqlite3.connect(str(cfg.db), timeout=30)
+    con.execute("PRAGMA journal_mode=WAL;")
+    cur = con.cursor()
+    inserted = skipped = 0
+    for evt in events:
+        if not isinstance(evt, dict):
+            continue
+        event_id = str(evt.get("id", ""))
+        if not event_id:
+            continue
+        if cur.execute("SELECT 1 FROM gh_events_seen WHERE event_id=?", (event_id,)).fetchone():
+            skipped += 1
+            continue
+        cur.execute(
+            "INSERT OR IGNORE INTO gh_events_seen "
+            "(event_id, created_at, event_type, subtype, delivery_class, payload_json) "
+            "VALUES (?, ?, ?, ?, 'unclassified', ?)",
+            (
+                event_id,
+                evt.get("created_at", ""),
+                evt.get("type", "UnknownEvent"),
+                (evt.get("payload") or {}).get("action", ""),
+                json.dumps(evt.get("payload") or {}),
+            ),
+        )
+        inserted += 1
+    con.commit()
+    con.close()
+    if inserted:
+        print(f"ingested={inserted} skipped={skipped}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conductor/gh-watcher/scripts/poll-events.sh
+++ b/conductor/gh-watcher/scripts/poll-events.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Poll /repos/<owner>/<repo>/events with ETag dedup, ingest new rows, classify.
+# Idempotent: a 304 short-circuits. Every successful round trip (200 or 304)
+# refreshes the liveness file so the heartbeat can tell "quiet" from "dead".
+set -euo pipefail
+
+BIN="$(cd "$(dirname "$0")" && pwd)"
+eval "$(python3 "$BIN/watcherlib.py" --shell)"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "$(ts) [poll-events] $*" >> "$GHW_LOG"; }
+mark_alive() { date +%s > "$GHW_LIVENESS"; }
+
+mkdir -p "$(dirname "$GHW_DB")" "$(dirname "$GHW_LOG")" "$(dirname "$GHW_LIVENESS")"
+sqlite3 "$GHW_DB" < "$BIN/../schema.sql" >/dev/null
+
+ETAG=$(sqlite3 "$GHW_DB" "SELECT COALESCE(etag,'') FROM gh_poll_cursor WHERE name='events';" 2>/dev/null || echo "")
+
+HDR=()
+[ -n "$ETAG" ] && HDR+=(-H "If-None-Match: $ETAG")
+
+# Overwritten every tick; kept on disk so the last raw response is inspectable.
+RESP_FILE="$GHW_HOME/.last-response"
+
+# gh api exits non-zero on 304; inspect the status line before treating that as an error.
+set +e
+# ${HDR[@]+...} keeps bash 3.2 happy with an empty array under set -u.
+gh api ${HDR[@]+"${HDR[@]}"} -i "/repos/$GHW_REPO/events?per_page=100" > "$RESP_FILE" 2>/dev/null
+RC=$?
+set -e
+STATUS=$(head -n1 "$RESP_FILE" | awk '{print $2}')
+if [ "$STATUS" = "304" ]; then
+  mark_alive
+  exit 0
+fi
+if [ "$RC" -ne 0 ] || [ "$STATUS" != "200" ]; then
+  log "ERROR gh api rc=$RC status=${STATUS:-none}"
+  exit 1
+fi
+
+HDR_END=$(grep -n -m1 '^[[:space:]]*$' "$RESP_FILE" | cut -d: -f1 || echo 0)
+if [ "${HDR_END:-0}" -eq 0 ]; then
+  log "ERROR no header/body split"
+  exit 1
+fi
+
+NEW_ETAG=$(head -n "$HDR_END" "$RESP_FILE" | awk 'BEGIN{IGNORECASE=1} /^etag:/ {print $2; exit}' | tr -d '\r"')
+if [ -n "$NEW_ETAG" ]; then
+  sqlite3 "$GHW_DB" "INSERT INTO gh_poll_cursor(name,etag,updated_at) VALUES('events','$NEW_ETAG',CURRENT_TIMESTAMP)
+                     ON CONFLICT(name) DO UPDATE SET etag=excluded.etag, updated_at=CURRENT_TIMESTAMP;" || true
+fi
+mark_alive
+
+BODY=$(tail -n +$((HDR_END + 1)) "$RESP_FILE")
+if [ -z "$BODY" ] || [ "$BODY" = "[]" ]; then
+  exit 0
+fi
+
+echo "$BODY" | python3 "$BIN/ingest-events.py" 2>>"$GHW_LOG" || log "ingest failed"
+python3 "$BIN/classify.py" 2>>"$GHW_LOG" || log "classify failed"

--- a/conductor/gh-watcher/scripts/send.sh
+++ b/conductor/gh-watcher/scripts/send.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Deliver one trigger honoring mode. In "log" mode nothing leaves the machine.
+# Override GHW_SEND_CMD to capture sends in tests.
+set -euo pipefail
+BIN="$(cd "$(dirname "$0")" && pwd)"
+eval "$(python3 "$BIN/watcherlib.py" --shell)"
+MSG="$1"
+if [ "$GHW_MODE" = "log" ]; then
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [send] mode=log would send: $MSG" >> "$GHW_LOG"
+  exit 0
+fi
+if [ -n "${GHW_SEND_CMD:-}" ]; then
+  exec bash -c "$GHW_SEND_CMD \"\$1\"" _ "$MSG"
+fi
+exec agent-deck -p "$GHW_PROFILE" session send "$GHW_CONDUCTOR" "$MSG" --no-wait

--- a/conductor/gh-watcher/scripts/status.sh
+++ b/conductor/gh-watcher/scripts/status.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Liveness and queue snapshot. Exit 0 when the last successful poll is fresh,
+# exit 2 when stale (older than cadence.stale_after_seconds) so a heartbeat
+# rule can turn it into a NEED line.
+set -euo pipefail
+BIN="$(cd "$(dirname "$0")" && pwd)"
+eval "$(python3 "$BIN/watcherlib.py" --shell)"
+
+NOW=$(date +%s)
+LAST=$(cat "$GHW_LIVENESS" 2>/dev/null || echo 0)
+AGE=$(( NOW - LAST ))
+DEPTH=$(sqlite3 "$GHW_DB" "SELECT COUNT(*) FROM gh_deliver_queue WHERE status='pending';" 2>/dev/null || echo 0)
+STATE=fresh
+[ "$AGE" -gt "$GHW_STALE_AFTER" ] && STATE=stale
+echo "gh-watcher repo=$GHW_REPO mode=$GHW_MODE last_poll_age=${AGE}s liveness=$STATE pending=$DEPTH"
+[ "$STATE" = "fresh" ]  || exit 2

--- a/conductor/gh-watcher/scripts/tick.sh
+++ b/conductor/gh-watcher/scripts/tick.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# One scheduler tick: poll, dispatch, and flush the digest once a day.
+# launchd (StartInterval) or a systemd timer runs this every cadence.events_seconds.
+set -uo pipefail
+BIN="$(cd "$(dirname "$0")" && pwd)"
+eval "$(python3 "$BIN/watcherlib.py" --shell)"
+
+"$BIN/poll-events.sh"
+"$BIN/dispatcher.sh"
+
+TODAY=$(date +%F)
+LAST_FLUSH=$(sqlite3 "$GHW_DB" "SELECT v FROM gh_dispatch_state WHERE k='last_digest_flush';" 2>/dev/null || echo "")
+if [ "$LAST_FLUSH" != "$TODAY" ] && [[ "$(date +%H:%M)" > "$GHW_DIGEST_FLUSH_TIME" || "$(date +%H:%M)" == "$GHW_DIGEST_FLUSH_TIME" ]]; then
+  "$BIN/digest-flush.sh" && sqlite3 "$GHW_DB" "INSERT INTO gh_dispatch_state(k,v) VALUES('last_digest_flush','$TODAY')
+                                               ON CONFLICT(k) DO UPDATE SET v=excluded.v;"
+fi

--- a/conductor/gh-watcher/scripts/watcherlib.py
+++ b/conductor/gh-watcher/scripts/watcherlib.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Shared config loader for the gh-watcher scripts.
+
+Resolution order for the config file:
+  1. $AD_GH_WATCHER_CONFIG
+  2. $AD_GH_WATCHER_HOME/watcher.toml
+  3. <this file>/../watcher.toml
+
+Run as a script with --shell to print KEY=value lines for `eval` in bash.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib as _toml
+
+    def _load(path: Path) -> dict:
+        with path.open("rb") as fh:
+            return _toml.load(fh)
+except ModuleNotFoundError:  # pragma: no cover
+    import toml as _toml  # type: ignore
+
+    def _load(path: Path) -> dict:
+        return _toml.load(str(path))
+
+
+def config_path() -> Path:
+    if os.environ.get("AD_GH_WATCHER_CONFIG"):
+        return Path(os.environ["AD_GH_WATCHER_CONFIG"]).expanduser()
+    home = os.environ.get("AD_GH_WATCHER_HOME")
+    if home:
+        return Path(home).expanduser() / "watcher.toml"
+    return Path(__file__).resolve().parent.parent / "watcher.toml"
+
+
+class Config:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or config_path()
+        if not self.path.is_file():
+            raise SystemExit(f"gh-watcher: config not found: {self.path}")
+        raw = _load(self.path)
+        self.home = self.path.parent
+        repo = raw.get("repo", {})
+        self.owner = repo.get("owner", "")
+        self.name = repo.get("name", "")
+        if not self.owner or not self.name:
+            raise SystemExit("gh-watcher: [repo] owner and name are required")
+        routing = raw.get("routing", {})
+        self.profile = routing.get("profile", "default")
+        self.conductor = routing.get("conductor", f"conductor-{self.profile}")
+        watcher = raw.get("watcher", {})
+        self.mode = watcher.get("mode", "log")
+        if self.mode not in ("log", "dispatch"):
+            raise SystemExit(f"gh-watcher: mode must be log or dispatch, got {self.mode!r}")
+        self.db = self._resolve(watcher.get("db_path", "watcher.db"))
+        self.log = self._resolve(watcher.get("log_path", "task-log.md"))
+        self.liveness = self._resolve(watcher.get("liveness_path", "last-poll"))
+        cadence = raw.get("cadence", {})
+        self.events_seconds = int(cadence.get("events_seconds", 30))
+        self.stale_after_seconds = int(cadence.get("stale_after_seconds", 3 * self.events_seconds))
+        disp = raw.get("dispatcher", {})
+        self.min_interval_seconds = int(disp.get("min_interval_seconds", 30))
+        self.high_water = int(disp.get("high_water", 25))
+        self.digest_flush_local_time = str(disp.get("digest_flush_local_time", "18:00"))
+
+    @property
+    def repo(self) -> str:
+        return f"{self.owner}/{self.name}"
+
+    def _resolve(self, value: str) -> Path:
+        p = Path(os.path.expanduser(os.path.expandvars(value)))
+        return p if p.is_absolute() else self.home / p
+
+    def shell_exports(self) -> str:
+        items = {
+            "GHW_HOME": str(self.home),
+            "GHW_REPO": self.repo,
+            "GHW_PROFILE": self.profile,
+            "GHW_CONDUCTOR": self.conductor,
+            "GHW_MODE": self.mode,
+            "GHW_DB": str(self.db),
+            "GHW_LOG": str(self.log),
+            "GHW_LIVENESS": str(self.liveness),
+            "GHW_EVENTS_SECONDS": str(self.events_seconds),
+            "GHW_STALE_AFTER": str(self.stale_after_seconds),
+            "GHW_MIN_INTERVAL": str(self.min_interval_seconds),
+            "GHW_HIGH_WATER": str(self.high_water),
+            "GHW_DIGEST_FLUSH_TIME": self.digest_flush_local_time,
+        }
+        return "\n".join(f"{k}={shlex.quote(v)}" for k, v in items.items())
+
+
+if __name__ == "__main__":
+    cfg = Config()
+    if "--shell" in sys.argv:
+        print(cfg.shell_exports())
+    else:
+        print(cfg.path)

--- a/conductor/gh-watcher/systemd/agent-deck-gh-watcher.service
+++ b/conductor/gh-watcher/systemd/agent-deck-gh-watcher.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=agent-deck GitHub event watcher tick (poll, classify, dispatch)
+
+[Service]
+Type=oneshot
+Environment=AD_GH_WATCHER_HOME=__WATCHER_HOME__
+ExecStart=/bin/bash __TICK_PATH__
+StandardOutput=append:__LOG_PATH__
+StandardError=append:__LOG_PATH__

--- a/conductor/gh-watcher/systemd/agent-deck-gh-watcher.timer
+++ b/conductor/gh-watcher/systemd/agent-deck-gh-watcher.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the agent-deck GitHub event watcher every cadence.events_seconds
+
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=__INTERVAL__
+AccuracySec=5
+
+[Install]
+WantedBy=timers.target

--- a/conductor/gh-watcher/watcher.example.toml
+++ b/conductor/gh-watcher/watcher.example.toml
@@ -1,0 +1,36 @@
+# conductor/gh-watcher example config.
+# Copy to <conductor dir>/gh-watcher/watcher.toml and edit. No secrets live here:
+# GitHub auth comes from `gh auth login` or the GH_TOKEN environment variable.
+
+[repo]
+owner = "example-org"
+name  = "example-repo"
+
+[routing]
+# agent-deck profile and the exact title of the conductor session to ring.
+profile   = "default"
+conductor = "conductor-default"
+
+[watcher]
+# "log": poll, classify and queue, but only write "would send" lines to the log.
+# "dispatch": actually run `agent-deck session send` for each queued trigger.
+mode = "log"
+
+# Relative paths resolve against the directory holding watcher.toml.
+db_path       = "watcher.db"
+log_path      = "task-log.md"
+liveness_path = "last-poll"
+
+[cadence]
+# How often the poll runs (the launchd StartInterval / systemd timer period).
+events_seconds = 30
+# Liveness is stale when last-poll is older than this. Default 3 x events_seconds.
+stale_after_seconds = 90
+
+[dispatcher]
+# Paced (priority >= 10) triggers wait at least this long between sends.
+min_interval_seconds = 30
+# Above this many pending rows one burst summary replaces one-by-one delivery.
+high_water = 25
+# Once a day, local time HH:MM, flush the digest bucket as one low priority row.
+digest_flush_local_time = "18:00"

--- a/conductor/setup.sh
+++ b/conductor/setup.sh
@@ -10,6 +10,8 @@ CONFIG_PATH="${AGENT_DECK_DIR}/config.toml"
 PLIST_NAME="com.agentdeck.conductor-bridge"
 PLIST_DIR="${HOME}/Library/LaunchAgents"
 PLIST_PATH="${PLIST_DIR}/${PLIST_NAME}.plist"
+GHW_PLIST_NAME="com.agentdeck.gh-watcher"
+GHW_PLIST_PATH="${PLIST_DIR}/${GHW_PLIST_NAME}.plist"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Colors
@@ -237,6 +239,66 @@ if launchctl list | grep -q "${PLIST_NAME}" 2>/dev/null; then
 fi
 launchctl load "${PLIST_PATH}"
 ok "Daemon loaded and running"
+
+# --------------------------------------------------------------------------
+# Step 6: GitHub event watcher (opt-in, issue #2134)
+# --------------------------------------------------------------------------
+# Only acts when config.toml carries [conductor.github_watcher] enabled = true.
+# Files go to ${CONDUCTOR_DIR}/gh-watcher; an existing watcher.toml is kept.
+
+GHW_ENABLED=$(python3 -c "
+import toml
+cfg = toml.load('${CONFIG_PATH}').get('conductor', {}).get('github_watcher', {})
+print('true' if cfg.get('enabled') else 'false')
+" 2>/dev/null || echo "false")
+
+if [[ "${GHW_ENABLED}" == "true" ]]; then
+    GHW_SRC="${SCRIPT_DIR}/gh-watcher"
+    GHW_HOME="${CONDUCTOR_DIR}/gh-watcher"
+    info "GitHub watcher enabled in config; installing to ${GHW_HOME}"
+    mkdir -p "${GHW_HOME}/scripts"
+    cp "${GHW_SRC}"/scripts/* "${GHW_HOME}/scripts/"
+    cp "${GHW_SRC}/schema.sql" "${GHW_SRC}/classes.json" "${GHW_SRC}/README.md" "${GHW_HOME}/"
+    if [[ ! -f "${GHW_HOME}/watcher.toml" ]]; then
+        cp "${GHW_SRC}/watcher.example.toml" "${GHW_HOME}/watcher.toml"
+        warn "  Wrote ${GHW_HOME}/watcher.toml from the example; set [repo] and [routing] before the first tick"
+    fi
+    GHW_INTERVAL=$(python3 -c "
+import toml
+print(int(toml.load('${GHW_HOME}/watcher.toml').get('cadence', {}).get('events_seconds', 30)))
+" 2>/dev/null || echo 30)
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        sed \
+            -e "s|__TICK_PATH__|${GHW_HOME}/scripts/tick.sh|g" \
+            -e "s|__WATCHER_HOME__|${GHW_HOME}|g" \
+            -e "s|__LOG_PATH__|${GHW_HOME}/launchd.log|g" \
+            -e "s|__INTERVAL__|${GHW_INTERVAL}|g" \
+            -e "s|__HOME__|${HOME}|g" \
+            "${GHW_SRC}/${GHW_PLIST_NAME}.plist" > "${GHW_PLIST_PATH}"
+        if launchctl list | grep -q "${GHW_PLIST_NAME}" 2>/dev/null; then
+            launchctl unload "${GHW_PLIST_PATH}" 2>/dev/null || true
+        fi
+        launchctl load "${GHW_PLIST_PATH}"
+        ok "gh-watcher launchd unit loaded (every ${GHW_INTERVAL}s): ${GHW_PLIST_PATH}"
+    else
+        GHW_UNIT_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user"
+        mkdir -p "${GHW_UNIT_DIR}"
+        for unit in agent-deck-gh-watcher.service agent-deck-gh-watcher.timer; do
+            sed \
+                -e "s|__TICK_PATH__|${GHW_HOME}/scripts/tick.sh|g" \
+                -e "s|__WATCHER_HOME__|${GHW_HOME}|g" \
+                -e "s|__LOG_PATH__|${GHW_HOME}/systemd.log|g" \
+                -e "s|__INTERVAL__|${GHW_INTERVAL}|g" \
+                "${GHW_SRC}/systemd/${unit}" > "${GHW_UNIT_DIR}/${unit}"
+        done
+        ok "gh-watcher systemd units written to ${GHW_UNIT_DIR}"
+        echo "  Enable with: systemctl --user daemon-reload && systemctl --user enable --now agent-deck-gh-watcher.timer"
+    fi
+    echo "  Mode and liveness: ${GHW_HOME}/scripts/status.sh (see ${GHW_HOME}/README.md)"
+else
+    info "GitHub watcher not enabled ([conductor.github_watcher] enabled = false); skipping"
+fi
 
 # --------------------------------------------------------------------------
 # Done

--- a/conductor/teardown.sh
+++ b/conductor/teardown.sh
@@ -9,6 +9,7 @@ CONDUCTOR_DIR="${AGENT_DECK_DIR}/conductor"
 CONFIG_PATH="${AGENT_DECK_DIR}/config.toml"
 PLIST_NAME="com.agentdeck.conductor-bridge"
 PLIST_PATH="${HOME}/Library/LaunchAgents/${PLIST_NAME}.plist"
+GHW_PLIST_PATH="${HOME}/Library/LaunchAgents/com.agentdeck.gh-watcher.plist"
 
 # Colors
 RED='\033[0;31m'
@@ -32,6 +33,13 @@ if [[ -f "${PLIST_PATH}" ]]; then
     ok "Daemon stopped and plist removed"
 else
     info "No daemon plist found (already removed)"
+fi
+
+# Opt-in GitHub watcher unit (issue #2134); present only when it was enabled.
+if [[ -f "${GHW_PLIST_PATH}" ]]; then
+    launchctl unload "${GHW_PLIST_PATH}" 2>/dev/null || true
+    /usr/bin/trash "${GHW_PLIST_PATH}" 2>/dev/null || true
+    ok "gh-watcher unit stopped and plist moved to Trash"
 fi
 
 # --------------------------------------------------------------------------

--- a/docs/WATCHER-SETUP.md
+++ b/docs/WATCHER-SETUP.md
@@ -248,6 +248,22 @@ Four things matter, in order:
    conductor is worse than useless — nobody notices. Log every successful
    send, alert if the send count drops to zero for an hour.
 
+### Shipped polling watcher: `conductor/gh-watcher/`
+
+The GitHub *events* poller ships in the repo as an opt-in daemon. It polls
+`/repos/<owner>/<repo>/events` with an ETag every 30 s, dedupes in SQLite,
+paces delivery, collapses bursts above a high-water mark into one summary,
+and writes a `last-poll` liveness file the heartbeat can check. Enable it with
+
+```toml
+[conductor.github_watcher]
+enabled = true
+mode = "log"      # "dispatch" once the log looks right
+```
+
+and rerun `conductor/setup.sh`. Full description, trigger format, modes and
+liveness: [`conductor/gh-watcher/README.md`](../conductor/gh-watcher/README.md).
+
 ### Two reference watchers (informal, maintainer-side)
 
 These do not ship in the repo because they're tied to one user's

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -91,6 +91,11 @@ type ConductorSettings struct {
 	// Discord defines Discord bot integration settings
 	Discord DiscordSettings `toml:"discord,omitempty"`
 
+	// GitHubWatcher configures the opt-in GitHub event watcher that lives in
+	// conductor/gh-watcher/ (issue #2134). The Go binary only parses this table;
+	// conductor/setup.sh reads it to decide whether to install the poller unit.
+	GitHubWatcher GitHubWatcherSettings `toml:"github_watcher,omitempty"`
+
 	// Dir overrides the base conductor directory. Empty = default
 	// (<data-dir>/conductor with legacy ~/.agent-deck/conductor fallback).
 	// Tilde and $VAR are expanded.
@@ -105,6 +110,34 @@ type ConductorSettings struct {
 	// 'conductor migrate-dir'). The bridge daemon similarly freezes
 	// AGENT_DECK_CONDUCTOR_DIR at install time.
 	Dir string `toml:"dir,omitempty"`
+}
+
+// GitHubWatcherMode values accepted by [conductor.github_watcher].mode.
+const (
+	// GitHubWatcherModeLog records classified events without sending anything.
+	GitHubWatcherModeLog = "log"
+	// GitHubWatcherModeDispatch sends the lean [github:...] trigger to the conductor.
+	GitHubWatcherModeDispatch = "dispatch"
+)
+
+// GitHubWatcherSettings is the [conductor.github_watcher] table. Both keys are
+// optional: Enabled defaults to false and Mode defaults to "log", so a config
+// without the table changes nothing.
+type GitHubWatcherSettings struct {
+	// Enabled turns the poller on. conductor/setup.sh installs the launchd or
+	// systemd unit only when this is true.
+	Enabled bool `toml:"enabled,omitempty"`
+
+	// Mode is "log" (default) or "dispatch". Use EffectiveMode to read it.
+	Mode string `toml:"mode,omitempty"`
+}
+
+// EffectiveMode returns Mode with the "log" default applied.
+func (g GitHubWatcherSettings) EffectiveMode() string {
+	if g.Mode == "" {
+		return GitHubWatcherModeLog
+	}
+	return g.Mode
 }
 
 // ConductorID is a Telegram/Discord bot identifier used by the conductor

--- a/internal/session/conductor_github_watcher_test.go
+++ b/internal/session/conductor_github_watcher_test.go
@@ -1,0 +1,54 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Issue #2134: [conductor.github_watcher] is parsed but not acted on by the
+// binary. Absent table means disabled and mode "log".
+
+func decodeConductor(t *testing.T, src string) ConductorSettings {
+	t.Helper()
+	var cfg struct {
+		Conductor ConductorSettings `toml:"conductor"`
+	}
+	if _, err := toml.Decode(src, &cfg); err != nil {
+		t.Fatalf("decode: %v\nconfig:\n%s", err, src)
+	}
+	return cfg.Conductor
+}
+
+func TestGitHubWatcherSettings_DefaultsWhenAbsent(t *testing.T) {
+	c := decodeConductor(t, "[conductor]\nheartbeat_interval = 15\n")
+	if c.GitHubWatcher.Enabled {
+		t.Fatalf("expected github_watcher.enabled=false when the table is absent")
+	}
+	if got := c.GitHubWatcher.EffectiveMode(); got != GitHubWatcherModeLog {
+		t.Fatalf("expected default mode %q, got %q", GitHubWatcherModeLog, got)
+	}
+	if c.HeartbeatInterval == nil || *c.HeartbeatInterval != 15 {
+		t.Fatalf("heartbeat_interval must still decode alongside the new table")
+	}
+}
+
+func TestGitHubWatcherSettings_ParsesSubTable(t *testing.T) {
+	c := decodeConductor(t, "[conductor]\nheartbeat_interval = 15\n\n[conductor.github_watcher]\nenabled = true\nmode = \"dispatch\"\n")
+	if !c.GitHubWatcher.Enabled {
+		t.Fatalf("expected enabled=true")
+	}
+	if got := c.GitHubWatcher.EffectiveMode(); got != GitHubWatcherModeDispatch {
+		t.Fatalf("expected mode %q, got %q", GitHubWatcherModeDispatch, got)
+	}
+}
+
+func TestGitHubWatcherSettings_EnabledWithoutModeDefaultsToLog(t *testing.T) {
+	c := decodeConductor(t, "[conductor.github_watcher]\nenabled = true\n")
+	if !c.GitHubWatcher.Enabled {
+		t.Fatalf("expected enabled=true")
+	}
+	if got := c.GitHubWatcher.EffectiveMode(); got != GitHubWatcherModeLog {
+		t.Fatalf("enabled without mode must default to %q, got %q", GitHubWatcherModeLog, got)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Nothing wakes the conductor when a PR or issue arrives, so external PRs wait until the maintainer primes the conductor by hand (median 114 h to merge versus 0.5 h for the maintainer's own). The GitHub events poller that did this job was retired on 2026-04-19 and never replaced. This PR ships it in the repo as an opt-in daemon under `conductor/gh-watcher/`. Closes #2134.

## Why this change

Polling `/repos/<owner>/<repo>/events` with an ETag is near free (a 304 does not count against the rate limit) and needs no public endpoint, unlike a webhook receiver. The retired scripts were adapted rather than rewritten: every path, repo and session name now comes from `watcher.toml` or `AD_GH_WATCHER_*` env, nothing is hardcoded. Three things the issue asked for that the old copy lacked are added:

* Burst summary: above `dispatcher.high_water` pending rows the dispatcher sends one `[github:burst:<repo>] N pending: pr x14 (#… ), issue x9 (#…)` message and marks all summarized rows sent, instead of dripping them out one per tick.
* Liveness: every successful poll (200 or 304) writes an epoch stamp to `last-poll`; `scripts/status.sh` exits 2 when it is older than `cadence.stale_after_seconds` (default 3 x interval) so a heartbeat rule can raise a NEED line.
* Modes: `mode = "log"` (default) only writes `would send:` lines; `mode = "dispatch"` runs `agent-deck -p <profile> session send <conductor> "<trigger>" --no-wait`. Triggers follow docs/WATCHER-SETUP.md (`[github:<type>:<owner>/<repo>#<n>] hint`, 200 char cap).

The Go side only parses `[conductor.github_watcher]` (`enabled` default false, `mode` default `"log"`) with unit tests; no binary behavior changes. `conductor/setup.sh` already installs a launchd plist for the bridge, so it follows that pattern and installs `com.agentdeck.gh-watcher.plist` (or writes systemd user units on Linux) only when `enabled = true`; otherwise it prints one line and does nothing. `teardown.sh` unloads the plist if present.

The scripts live under `conductor/gh-watcher/scripts/` rather than `bin/` because the repo's `.gitignore` ignores `bin/`.

## User impact

None unless opted in. With the table absent or `enabled = false`, `setup.sh` behaves as before apart from one info line. With `enabled = true` a scheduler unit runs `scripts/tick.sh` every `cadence.events_seconds`; in the default `log` mode nothing reaches the conductor.

## Evidence

Local `go test` is disallowed on this host; full suite runs in CI on this PR.

    $ gofmt -l ./cmd ./internal      # printed nothing
    $ go build ./...                 # BUILD_OK
    $ go vet ./...                   # VET_OK
    $ bash -n on all shell scripts, python3 -m py_compile on all python: OK
    $ plutil -lint <rendered plist>  # OK (template has an __INTERVAL__ placeholder in an integer, so lint the rendered file)

End to end with a stub `gh` on PATH serving 32 canned events then 304, `high_water = 25`, `mode = "log"`:

    $ scripts/tick.sh; scripts/status.sh
    gh-watcher repo=acme/widgets mode=log last_poll_age=1s liveness=fresh pending=0
    task-log.md:
    2026-09-06T03:08:38Z [send] mode=log would send: [github:burst:acme/widgets] 30 pending: pr x20 (#2101 #2102 #2104 … #2129), issue x10 (#2103 #2106 … #2130)
    2026-09-06T03:08:38+00:00 [dispatcher] burst sent items=30 mode=log high_water=25
    queue: sent|30   events_seen: paced|30 suppressed|2 (PushEvent, WatchEvent)
    $ echo 1 > last-poll; scripts/status.sh; echo rc=$?
    gh-watcher repo=acme/widgets mode=log last_poll_age=1788664047s liveness=stale pending=0
    rc=2

Same harness, 4 events, `mode = "dispatch"`, `GHW_SEND_CMD` capturing to a file, four ticks (tick 2 blocked by the 30 s pacing gate, `last_send_ts` reset by hand before ticks 3 and 4):

    [github:security_advisory_published:acme/widgets]                       <- priority 0, sent first, bypassed pacing
    [github:issue_opened:acme/widgets#2134] conductor: ship the GitHub event watcher as an opt-in daemon
    [github:coalesced:acme/widgets#2140] 2 review events                    <- two PullRequestReviewCommentEvents on one PR
    all three under 200 chars; digest-flush turned 2 gh_digest rows into one priority 15 row and emptied the bucket

Two portability bugs surfaced by the harness on macOS and fixed before commit: bash 3.2 rejects an empty `"${HDR[@]}"` under `set -u`, and BSD `date -Is` prints nothing (now `date -u +%Y-%m-%dT%H:%M:%SZ`).

Why it was retired on 2026-04-19 (issue's open question): nothing is recorded. `~/.agent-deck/watcher/gh-agent-deck/task-log.md` ends at 07:34 that day with normal paced sends and no error; `~/.agent-deck/conductor/agent-deck/task-log.md` has no entry dated 2026-04-19 at all. The only nearby clue is `watcher/github-watcher.retired-20260419/task-log.md`, where the webhook based watcher logged `[opened] #99: Integration test issue` dozens of times over the preceding hours, which looks like a dedup failure on a test issue. That is why this PR defaults to `log` mode and the README asks for a day in that mode before switching to `dispatch`.

Not verified: `setup.sh` Step 6 was not executed on this machine (it would install a launchd unit under the maintainer's real `~/Library/LaunchAgents`). The plist rendering was verified by running the same `sed` on the template and linting the result.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "see our current workflow with the agent conductor, how the PRs and issues come in, how much time each takes, and make the pipeline smooth so the open count stays near zero and it can go into the next release"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

https://claude.ai/code/session_01VqZQYv7fcPCDxFJ1yHHjzA

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
