### PR TITLE
feat(tui): pick and switch the Claude account from the TUI (#924)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ configured under `[profiles.<name>.claude].config_dir`.
 
 `agent-deck session switch-account <session> <account>` moves an existing session to another Claude account — **conversation included**. The session stops, its conversation file is migrated into the target account's config dir (copy-only, with a destination backup and size verification), the account is set, and the session restarts with `--resume`. `session set <session> account <name>` auto-migrates too.
 
+The TUI exposes the same two moments. The **New Session** dialog's Claude options
+carry an `Account` row (`←`/`→` or `Space` to cycle, `inherit` = today's
+conductor/group/env chain), so a session can be created straight onto the right
+login. The **Edit Session** dialog (`e`) carries a `Claude account` row for a
+session that already exists; committing it runs the same
+migrate-and-resume flow as `session switch-account`, and the session card's
+`[account:"…"]` badge follows. Both rows are hidden when no
+`[profiles.<name>.claude].config_dir` blocks are configured.
+
 ### Session naming
 
 Titles and groups answer different questions — "what is this, at a glance?" versus "why do these sessions belong together?" — and each has its own controls.

--- a/cmd/agent-deck/accounts_cmd.go
+++ b/cmd/agent-deck/accounts_cmd.go
@@ -14,6 +14,10 @@ import (
 type accountListEntry struct {
 	Name      string `json:"name"`
 	ConfigDir string `json:"config_dir"`
+	// Exists reports whether ConfigDir is present on disk. A configured
+	// account whose directory has never been created is not logged in yet:
+	// `CLAUDE_CONFIG_DIR=<dir> claude` then `/login` creates it.
+	Exists bool `json:"exists"`
 }
 
 func configuredAccountSlots(config *session.UserConfig) []accountListEntry {
@@ -23,7 +27,12 @@ func configuredAccountSlots(config *session.UserConfig) []accountListEntry {
 	}
 	for name := range config.Profiles {
 		if dir := config.GetProfileClaudeConfigDir(name); dir != "" {
-			accounts = append(accounts, accountListEntry{Name: name, ConfigDir: dir})
+			info, statErr := os.Stat(dir)
+			accounts = append(accounts, accountListEntry{
+				Name:      name,
+				ConfigDir: dir,
+				Exists:    statErr == nil && info.IsDir(),
+			})
 		}
 	}
 	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Name < accounts[j].Name })
@@ -38,6 +47,10 @@ func handleAccounts(args []string) {
 		fmt.Fprintln(fs.Output(), "Usage: agent-deck accounts [--json]")
 		fmt.Fprintln(fs.Output())
 		fmt.Fprintln(fs.Output(), "List named account slots configured as [profiles.<name>.claude].config_dir.")
+		fmt.Fprintln(fs.Output())
+		fmt.Fprintln(fs.Output(), "These names are the valid values for `launch --account`, `session set <id>")
+		fmt.Fprintln(fs.Output(), "account` and `session switch-account`, and for the account row in the TUI's")
+		fmt.Fprintln(fs.Output(), "New Session and Edit Session dialogs.")
 		fmt.Fprintln(fs.Output())
 		fs.PrintDefaults()
 	}
@@ -67,9 +80,14 @@ func handleAccounts(args []string) {
 	}
 	if len(accounts) == 0 {
 		fmt.Println("No named account slots configured.")
+		fmt.Printf("Add one as [profiles.<name>.claude].config_dir in %s.\n", effectiveUserConfigPathForHelp())
 		return
 	}
 	for _, account := range accounts {
-		fmt.Printf("%-20s %s\n", account.Name, account.ConfigDir)
+		status := "ok"
+		if !account.Exists {
+			status = "not created — log in with: CLAUDE_CONFIG_DIR=" + account.ConfigDir + " claude"
+		}
+		fmt.Printf("%-20s %-40s %s\n", account.Name, account.ConfigDir, status)
 	}
 }

--- a/cmd/agent-deck/session_switch_account.go
+++ b/cmd/agent-deck/session_switch_account.go
@@ -5,10 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 	"strings"
-	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -17,6 +14,10 @@ import (
 // account (#924) and migrates the conversation file into the target account's
 // config dir, so the restarted session resumes with full context. The
 // migration is copy-only: the old account keeps its copy.
+//
+// The flow itself lives in session.SwitchAccount, shared with the TUI's Edit
+// Session dialog; this handler only parses flags, resolves the session,
+// persists the result and renders output.
 func handleSessionSwitchAccount(profile string, args []string) {
 	fs := flag.NewFlagSet("session switch-account", flag.ExitOnError)
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
@@ -30,6 +31,7 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		fmt.Println("Switch a Claude session to another account and carry the conversation over.")
 		fmt.Println()
 		fmt.Printf("<account> must have a [profiles.<account>.claude].config_dir block in %s.\n", effectiveUserConfigPathForHelp())
+		fmt.Println("Run `agent-deck accounts` to list the configured accounts.")
 		fmt.Println("The conversation file is COPIED into the target account's config dir (the")
 		fmt.Println("source account keeps its copy), the session's account field is updated, and")
 		fmt.Println("a running session is restarted so `claude --resume` continues the")
@@ -64,17 +66,6 @@ func handleSessionSwitchAccount(profile string, args []string) {
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
 	userConfig, _ := session.LoadUserConfig()
-	targetDir := userConfig.GetProfileClaudeConfigDir(account)
-	if targetDir == "" {
-		available := configuredAccountNames(userConfig)
-		hint := "none configured"
-		if len(available) > 0 {
-			hint = strings.Join(available, ", ")
-		}
-		out.Error(fmt.Sprintf("account %q has no [profiles.%s.claude].config_dir in %s (configured accounts: %s)",
-			account, account, effectiveUserConfigPathForHelp(), hint), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
 
 	storage, instances, groups, err := loadSessionData(profile)
 	if err != nil {
@@ -90,122 +81,18 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		os.Exit(1)
 		return // unreachable, satisfies staticcheck SA5011
 	}
-	if inst.Tool != "claude" {
-		out.Error(fmt.Sprintf("switch-account only supports claude sessions (tool: %s)", inst.Tool), ErrCodeInvalidOperation)
+
+	result, switchErr := session.SwitchAccount(userConfig, inst, account, session.AccountSwitchOptions{
+		NoRestart: *noRestart,
+	})
+	if result == nil {
+		// Every abort path leaves the instance untouched, so there is nothing
+		// to persist.
+		out.Error(switchErr.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
-
-	// IDs are synced from tmux (same pattern as `stop`) BEFORE the ambiguity
-	// preflight below, since that check reads inst.ClaudeSessionID.
-	wasRunning := inst.Exists()
-	if wasRunning {
-		inst.SyncSessionIDsFromTmux()
-	}
-
-	// Capture the source dir BEFORE mutating the account field — afterwards
-	// the resolver would already return the target.
-	srcDir := session.GetClaudeConfigDirForInstance(inst)
-	// #1571: a pre-account-tracking session (empty account field) resolves to
-	// env/profile/global defaults, which can equal the target dir — the old
-	// code then declared "nothing to migrate" and the restarted resume died
-	// with "No conversation found". The disk is authoritative: scan every
-	// configured config dir for the conversation file and treat the dir that
-	// actually contains it as the source.
-	//
-	// Review finding on #1830: this ambiguity preflight runs BEFORE the
-	// running session is stopped below. Locating the conversation is a
-	// read-only disk scan that does not need the session dead, and running
-	// it first means an ambiguous-discovery abort leaves the session
-	// untouched instead of stopping it for a switch that never happens.
-	locatedDir, locatedSID, srcSize := session.LocateConversationConfigDir(userConfig, inst, srcDir)
-	if locatedDir != "" {
-		srcDir = locatedDir
-		if inst.ClaudeSessionID == "" && locatedSID != "" {
-			// #1815: with no recorded id, this is "the newest conversation in
-			// the project dir" — a guess that a shared working directory can
-			// answer with a NEIGHBOURING session's transcript. Copying first
-			// and refusing to resume later is not good enough: the copy has
-			// already carried someone else's conversation into another
-			// account's config dir. Ambiguous discovery copies nothing.
-			//
-			// The operator can resolve the ambiguity explicitly and re-run.
-			out.Error(fmt.Sprintf(
-				"cannot identify %s's conversation: it has no recorded conversation id, and the only "+
-					"candidate is the newest transcript in its working directory (%s), which may belong "+
-					"to another session there. Nothing was copied and the account was NOT switched, "+
-					"and the session was left running untouched. "+
-					"Name the conversation explicitly if it is this session's own "+
-					"(agent-deck session set claude-session-id <uuid> %s) and re-run.",
-				inst.Title, locatedSID, inst.Title), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-	}
-
-	// Stop a running session so its conversation file is final before the
-	// copy, now that the ambiguity preflight above has passed.
-	if wasRunning {
-		if err := inst.Kill(); err != nil {
-			out.Error(fmt.Sprintf("failed to stop session before switch: %v", err), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-		// Re-locate for the final, post-stop size: Kill flushes the
-		// transcript, so the preflight's size snapshot may be stale.
-		if locatedDir != "" {
-			if freshDir, _, freshSize := session.LocateConversationConfigDir(userConfig, inst, srcDir); freshDir != "" {
-				locatedDir, srcDir, srcSize = freshDir, freshDir, freshSize
-			}
-		}
-	}
-	migrated, migErr := session.MigrateConversationFrom(inst, srcDir, targetDir)
-	if migErr != nil && !errors.Is(migErr, session.ErrNoConversation) {
-		// Conversation intact in the source account; account field unchanged.
-		out.Error(fmt.Sprintf("conversation migration failed, account not switched: %v", migErr), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
-
-	// Post-switch verification (#1571): when a source conversation demonstrably
-	// exists on disk, the target dir must contain it (size within ~1%) before
-	// the account field flips. Fresh sessions (no conversation anywhere) keep
-	// the lenient path.
-	if locatedDir != "" {
-		if verifyErr := session.VerifyConversationInDir(inst, targetDir, srcSize); verifyErr != nil {
-			out.Error(fmt.Sprintf("conversation not verified in target config dir, account not switched: %v", verifyErr), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-	}
-
-	// #1815 Guard 2: a failed transcript verification must STOP the sequence,
-	// not annotate it.
-	if blocked, why := switchAccountRestartUnsafe(inst, locatedDir, wasRunning, *noRestart); blocked {
-		out.Error(fmt.Sprintf("conversation verification failed for %s: %s", inst.Title, why), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
-
-	// Pre-seed the folder-trust entry for (target config dir, project path)
-	// (#1571 root cause 4): the first launch of a fresh (config_dir, cwd)
-	// pair blocks interactively on "Do you trust this folder?", stalling the
-	// restarted session. Best-effort — a warning must not abort the switch.
-	if trustErr := session.PreAcceptClaudeTrust(filepath.Join(targetDir, ".claude.json"), inst.EffectiveWorkingDir()); trustErr != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not pre-accept folder trust in target config dir: %v\n", trustErr)
-	}
-
-	oldAccount, postCommit, setErr := session.SetField(inst, session.FieldAccount, account, nil)
-	if setErr != nil {
-		out.Error(setErr.Error(), ErrCodeInvalidOperation)
-		os.Exit(1)
-		return // unreachable, satisfies staticcheck SA5011
-	}
-	if postCommit != nil {
-		postCommit()
-	}
-
-	restarted := false
-	var startErr error
-	if wasRunning && !*noRestart {
-		if startErr = inst.Start(); startErr == nil {
-			inst.LastStartedAt = time.Now()
-			restarted = true
-		}
+	for _, warning := range result.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", warning)
 	}
 
 	if err := saveSessionData(storage, instances, groups); err != nil {
@@ -213,80 +100,27 @@ func handleSessionSwitchAccount(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	if startErr != nil {
-		out.Error(fmt.Sprintf("account switched to %q and conversation migrated, but restart failed: %v (start it manually with: agent-deck session start %s)",
-			account, startErr, inst.Title), ErrCodeInvalidOperation)
+	if switchErr != nil {
+		// The account WAS switched and the conversation migrated (both now
+		// persisted); only the restart failed.
+		if errors.Is(switchErr, session.ErrAccountSwitchRestartFailed) {
+			out.Error(fmt.Sprintf("account switched to %q and conversation migrated, but %v", account, switchErr),
+				ErrCodeInvalidOperation)
+		} else {
+			out.Error(switchErr.Error(), ErrCodeInvalidOperation)
+		}
 		os.Exit(1)
 	}
 
-	conversation := "no conversation to migrate (fresh session)"
-	if migrated != "" {
-		conversation = fmt.Sprintf("conversation migrated to %s", migrated)
-	} else if migErr == nil {
-		if locatedDir != "" {
-			conversation = "conversation already present in the target config dir (nothing to migrate)"
-		} else {
-			conversation = "no conversation found on disk (nothing to migrate)"
-		}
-	}
-	out.Success(fmt.Sprintf("Switched %s: account %q -> %q; %s", inst.Title, oldAccount, account, conversation), map[string]interface{}{
-		"success":           true,
-		"id":                inst.ID,
-		"title":             inst.Title,
-		"old_account":       oldAccount,
-		"new_account":       account,
-		"migrated_path":     migrated,
-		"claude_session_id": inst.ClaudeSessionID,
-		"restarted":         restarted,
-	})
-}
-
-// switchAccountRestartUnsafe reports whether switch-account must ABORT rather
-// than restart the session, and why (#1815 Guard 2).
-//
-// In the reported incident the switch correctly diagnosed that it had no
-// transcript to move ("no conversation to migrate, fresh session") for a
-// session that had demonstrably been running a conversation — and then
-// restarted it anyway. The restart's disk-discovery prelude, with no id to
-// work from, adopted the newest transcript filed under the shared working
-// directory (one belonging to a different session) and resumed it. A failed
-// verification has to stop the sequence.
-//
-// The discriminator is ClaudeDetectedAt: a session that never bound a
-// conversation id has nothing to lose and nothing to hijack (the Start
-// prelude's #608 gate skips discovery for it). A session that HAS run,
-// arriving here with no recorded id and no conversation located in ANY
-// configured config dir, is exactly the unsafe state.
-//
-// The abort is scoped to the case where this command would itself perform the
-// restart; --no-restart (or an already-stopped session) is the documented way
-// through, and the resume-time identity guard covers the later manual start.
-func switchAccountRestartUnsafe(inst *session.Instance, locatedDir string, wasRunning, noRestart bool) (bool, string) {
-	if inst == nil || !wasRunning || noRestart {
-		return false, ""
-	}
-	if locatedDir != "" || inst.ClaudeSessionID != "" || inst.ClaudeDetectedAt.IsZero() {
-		return false, ""
-	}
-	return true, "this session previously held a Claude conversation, but none was found in any " +
-		"configured config dir and it has no recorded conversation id; account not switched and " +
-		"session NOT restarted (restarting in this state can adopt a transcript belonging to another " +
-		"session in the same directory). Re-run with --no-restart to switch the account only, then " +
-		"start it manually once the conversation is located"
-}
-
-// configuredAccountNames lists profile names that have a Claude config_dir —
-// i.e. the valid <account> values for switch-account / `set account`.
-func configuredAccountNames(cfg *session.UserConfig) []string {
-	if cfg == nil {
-		return nil
-	}
-	var names []string
-	for name := range cfg.Profiles {
-		if cfg.GetProfileClaudeConfigDir(name) != "" {
-			names = append(names, name)
-		}
-	}
-	sort.Strings(names)
-	return names
+	out.Success(fmt.Sprintf("Switched %s: account %q -> %q; %s", inst.Title, result.OldAccount, result.NewAccount, result.Conversation),
+		map[string]interface{}{
+			"success":           true,
+			"id":                inst.ID,
+			"title":             inst.Title,
+			"old_account":       result.OldAccount,
+			"new_account":       result.NewAccount,
+			"migrated_path":     result.MigratedPath,
+			"claude_session_id": inst.ClaudeSessionID,
+			"restarted":         result.Restarted,
+		})
 }

--- a/internal/session/account_switch.go
+++ b/internal/session/account_switch.go
@@ -1,0 +1,267 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Sentinel errors for the account-switch flow. Callers use errors.Is to tell
+// the "nothing happened" aborts apart from the one partial-success case where
+// the account WAS switched but the restart failed.
+var (
+	// ErrUnknownAccount reports that <account> has no
+	// [profiles.<account>.claude].config_dir block in config.toml.
+	ErrUnknownAccount = errors.New("unknown account slot")
+	// ErrAccountSwitchUnsupported reports a non-claude session.
+	ErrAccountSwitchUnsupported = errors.New("account switch unsupported for this tool")
+	// ErrAccountSwitchRestartFailed reports that the account was switched and
+	// the conversation migrated, but the session could not be restarted. The
+	// returned result is still valid and MUST be persisted by the caller.
+	ErrAccountSwitchRestartFailed = errors.New("restart after account switch failed")
+)
+
+// AccountSwitchOptions tunes the switch flow.
+type AccountSwitchOptions struct {
+	// NoRestart leaves a previously-running session stopped after the switch
+	// instead of restarting it with `claude --resume`.
+	NoRestart bool
+}
+
+// AccountSwitchResult describes a completed switch. It is returned (non-nil)
+// only once the account field has actually been committed on the instance, so
+// a non-nil result always means the caller must persist session state — even
+// when the accompanying error is ErrAccountSwitchRestartFailed.
+type AccountSwitchResult struct {
+	OldAccount   string
+	NewAccount   string
+	MigratedPath string
+	// Conversation is a human-readable summary of what happened to the
+	// conversation file ("conversation migrated to ...", "no conversation ...").
+	Conversation string
+	Restarted    bool
+	// Warnings collects non-fatal problems (e.g. folder-trust pre-seeding
+	// failed). Callers surface these without treating the switch as failed.
+	Warnings []string
+}
+
+// ConfiguredAccountNames lists profile names that have a Claude config_dir —
+// i.e. the valid <account> values for SwitchAccount and `session set account`.
+func ConfiguredAccountNames(cfg *UserConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	var names []string
+	for name := range cfg.Profiles {
+		if cfg.GetProfileClaudeConfigDir(name) != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// userConfigPathForMessages renders the config.toml path used in error text.
+func userConfigPathForMessages() string {
+	path, err := GetUserConfigPath()
+	if err != nil {
+		return "config.toml"
+	}
+	return path
+}
+
+// SwitchAccount moves a Claude session to another named account (#924) and
+// carries its conversation over, so the restarted session resumes with full
+// context under the new account's auth.
+//
+// The sequence is: validate the account → locate the conversation on disk →
+// stop a running session → copy the conversation into the target config dir →
+// verify the copy → pre-accept folder trust → commit the account field →
+// restart. Every step before the commit aborts with a nil result, leaving the
+// instance untouched; the caller then has nothing to persist.
+//
+// The migration is copy-only: the source account keeps its copy.
+func SwitchAccount(cfg *UserConfig, inst *Instance, account string, opts AccountSwitchOptions) (*AccountSwitchResult, error) {
+	if inst == nil {
+		return nil, errors.New("no session")
+	}
+	account = strings.TrimSpace(account)
+	targetDir := cfg.GetProfileClaudeConfigDir(account)
+	if targetDir == "" {
+		hint := "none configured"
+		if available := ConfiguredAccountNames(cfg); len(available) > 0 {
+			hint = strings.Join(available, ", ")
+		}
+		return nil, fmt.Errorf("%w: account %q has no [profiles.%s.claude].config_dir in %s (configured accounts: %s)",
+			ErrUnknownAccount, account, account, userConfigPathForMessages(), hint)
+	}
+	if inst.Tool != "claude" {
+		return nil, fmt.Errorf("%w: switch-account only supports claude sessions (tool: %s)",
+			ErrAccountSwitchUnsupported, inst.Tool)
+	}
+
+	// IDs are synced from tmux (same pattern as `stop`) BEFORE the ambiguity
+	// preflight below, since that check reads inst.ClaudeSessionID.
+	wasRunning := inst.Exists()
+	if wasRunning {
+		inst.SyncSessionIDsFromTmux()
+	}
+
+	// Capture the source dir BEFORE mutating the account field — afterwards
+	// the resolver would already return the target.
+	srcDir := GetClaudeConfigDirForInstance(inst)
+	// #1571: a pre-account-tracking session (empty account field) resolves to
+	// env/profile/global defaults, which can equal the target dir — the old
+	// code then declared "nothing to migrate" and the restarted resume died
+	// with "No conversation found". The disk is authoritative: scan every
+	// configured config dir for the conversation file and treat the dir that
+	// actually contains it as the source.
+	//
+	// Review finding on #1830: this ambiguity preflight runs BEFORE the
+	// running session is stopped below. Locating the conversation is a
+	// read-only disk scan that does not need the session dead, and running
+	// it first means an ambiguous-discovery abort leaves the session
+	// untouched instead of stopping it for a switch that never happens.
+	locatedDir, locatedSID, srcSize := LocateConversationConfigDir(cfg, inst, srcDir)
+	if locatedDir != "" {
+		srcDir = locatedDir
+		if inst.ClaudeSessionID == "" && locatedSID != "" {
+			// #1815: with no recorded id, this is "the newest conversation in
+			// the project dir" — a guess that a shared working directory can
+			// answer with a NEIGHBOURING session's transcript. Copying first
+			// and refusing to resume later is not good enough: the copy has
+			// already carried someone else's conversation into another
+			// account's config dir. Ambiguous discovery copies nothing.
+			return nil, fmt.Errorf(
+				"cannot identify %s's conversation: it has no recorded conversation id, and the only "+
+					"candidate is the newest transcript in its working directory (%s), which may belong "+
+					"to another session there. Nothing was copied and the account was NOT switched, "+
+					"and the session was left running untouched. "+
+					"Name the conversation explicitly if it is this session's own "+
+					"(agent-deck session set claude-session-id <uuid> %s) and re-run.",
+				inst.Title, locatedSID, inst.Title)
+		}
+	}
+
+	// Stop a running session so its conversation file is final before the
+	// copy, now that the ambiguity preflight above has passed.
+	if wasRunning {
+		if err := inst.Kill(); err != nil {
+			return nil, fmt.Errorf("failed to stop session before switch: %w", err)
+		}
+		// Re-locate for the final, post-stop size: Kill flushes the
+		// transcript, so the preflight's size snapshot may be stale.
+		if locatedDir != "" {
+			if freshDir, _, freshSize := LocateConversationConfigDir(cfg, inst, srcDir); freshDir != "" {
+				locatedDir, srcDir, srcSize = freshDir, freshDir, freshSize
+			}
+		}
+	}
+
+	migrated, migErr := MigrateConversationFrom(inst, srcDir, targetDir)
+	if migErr != nil && !errors.Is(migErr, ErrNoConversation) {
+		// Conversation intact in the source account; account field unchanged.
+		return nil, fmt.Errorf("conversation migration failed, account not switched: %w", migErr)
+	}
+
+	// Post-switch verification (#1571): when a source conversation demonstrably
+	// exists on disk, the target dir must contain it (size within ~1%) before
+	// the account field flips. Fresh sessions (no conversation anywhere) keep
+	// the lenient path.
+	if locatedDir != "" {
+		if verifyErr := VerifyConversationInDir(inst, targetDir, srcSize); verifyErr != nil {
+			return nil, fmt.Errorf("conversation not verified in target config dir, account not switched: %w", verifyErr)
+		}
+	}
+
+	// #1815 Guard 2: a failed transcript verification must STOP the sequence,
+	// not annotate it.
+	if blocked, why := AccountSwitchRestartUnsafe(inst, locatedDir, wasRunning, opts.NoRestart); blocked {
+		return nil, fmt.Errorf("conversation verification failed for %s: %s", inst.Title, why)
+	}
+
+	result := &AccountSwitchResult{NewAccount: account, MigratedPath: migrated}
+
+	// Pre-seed the folder-trust entry for (target config dir, project path)
+	// (#1571 root cause 4): the first launch of a fresh (config_dir, cwd)
+	// pair blocks interactively on "Do you trust this folder?", stalling the
+	// restarted session. Best-effort — a warning must not abort the switch.
+	if trustErr := PreAcceptClaudeTrust(filepath.Join(targetDir, ".claude.json"), inst.EffectiveWorkingDir()); trustErr != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("could not pre-accept folder trust in target config dir: %v", trustErr))
+	}
+
+	oldAccount, postCommit, setErr := SetField(inst, FieldAccount, account, nil)
+	if setErr != nil {
+		return nil, setErr
+	}
+	if postCommit != nil {
+		postCommit()
+	}
+	result.OldAccount = oldAccount
+	result.Conversation = describeMigration(migrated, migErr, locatedDir)
+
+	if wasRunning && !opts.NoRestart {
+		if startErr := inst.Start(); startErr != nil {
+			// The account IS switched and the conversation IS migrated; the
+			// caller must still persist that. Signal the partial state.
+			return result, fmt.Errorf("%w: %v (start it manually with: agent-deck session start %s)",
+				ErrAccountSwitchRestartFailed, startErr, inst.Title)
+		}
+		inst.LastStartedAt = time.Now()
+		result.Restarted = true
+	}
+	return result, nil
+}
+
+// describeMigration renders the human summary of what happened to the
+// conversation file.
+func describeMigration(migrated string, migErr error, locatedDir string) string {
+	if migrated != "" {
+		return fmt.Sprintf("conversation migrated to %s", migrated)
+	}
+	if migErr != nil {
+		return "no conversation to migrate (fresh session)"
+	}
+	if locatedDir != "" {
+		return "conversation already present in the target config dir (nothing to migrate)"
+	}
+	return "no conversation found on disk (nothing to migrate)"
+}
+
+// AccountSwitchRestartUnsafe reports whether SwitchAccount must ABORT rather
+// than restart the session, and why (#1815 Guard 2).
+//
+// In the reported incident the switch correctly diagnosed that it had no
+// transcript to move ("no conversation to migrate, fresh session") for a
+// session that had demonstrably been running a conversation — and then
+// restarted it anyway. The restart's disk-discovery prelude, with no id to
+// work from, adopted the newest transcript filed under the shared working
+// directory (one belonging to a different session) and resumed it. A failed
+// verification has to stop the sequence.
+//
+// The discriminator is ClaudeDetectedAt: a session that never bound a
+// conversation id has nothing to lose and nothing to hijack (the Start
+// prelude's #608 gate skips discovery for it). A session that HAS run,
+// arriving here with no recorded id and no conversation located in ANY
+// configured config dir, is exactly the unsafe state.
+//
+// The abort is scoped to the case where this flow would itself perform the
+// restart; NoRestart (or an already-stopped session) is the documented way
+// through, and the resume-time identity guard covers the later manual start.
+func AccountSwitchRestartUnsafe(inst *Instance, locatedDir string, wasRunning, noRestart bool) (bool, string) {
+	if inst == nil || !wasRunning || noRestart {
+		return false, ""
+	}
+	if locatedDir != "" || inst.ClaudeSessionID != "" || inst.ClaudeDetectedAt.IsZero() {
+		return false, ""
+	}
+	return true, "this session previously held a Claude conversation, but none was found in any " +
+		"configured config dir and it has no recorded conversation id; account not switched and " +
+		"session NOT restarted (restarting in this state can adopt a transcript belonging to another " +
+		"session in the same directory). Re-run with --no-restart to switch the account only, then " +
+		"start it manually once the conversation is located"
+}

--- a/internal/session/account_switch_guard_test.go
+++ b/internal/session/account_switch_guard_test.go
@@ -1,25 +1,23 @@
-package main
+package session
 
 import (
 	"testing"
 	"time"
-
-	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// #1815 Guard 2: switch-account already produced the right diagnosis ("no
+// #1815 Guard 2: SwitchAccount already produced the right diagnosis ("no
 // conversation to migrate, fresh session") and then let the restart proceed.
 // A failed transcript verification must STOP the sequence.
 func TestSwitchAccountRestartUnsafe(t *testing.T) {
-	ranBefore := func() *session.Instance {
-		inst := session.NewInstanceWithTool("switch-guard", t.TempDir(), "claude")
+	ranBefore := func() *Instance {
+		inst := NewInstanceWithTool("switch-guard", t.TempDir(), "claude")
 		inst.ClaudeSessionID = ""
 		inst.ClaudeDetectedAt = time.Now() // this session HAS held a conversation
 		return inst
 	}
 
 	t.Run("aborts when a session that has run cannot be located", func(t *testing.T) {
-		blocked, why := switchAccountRestartUnsafe(ranBefore(), "", true, false)
+		blocked, why := AccountSwitchRestartUnsafe(ranBefore(), "", true, false)
 		if !blocked {
 			t.Fatal("#1815: verification failed (no conversation located, no recorded id) — the restart must be aborted, not annotated")
 		}
@@ -29,7 +27,7 @@ func TestSwitchAccountRestartUnsafe(t *testing.T) {
 	})
 
 	t.Run("allows the switch when the conversation was located", func(t *testing.T) {
-		if blocked, _ := switchAccountRestartUnsafe(ranBefore(), "/some/config/dir", true, false); blocked {
+		if blocked, _ := AccountSwitchRestartUnsafe(ranBefore(), "/some/config/dir", true, false); blocked {
 			t.Fatal("a located conversation is the verified path and must proceed")
 		}
 	})
@@ -37,7 +35,7 @@ func TestSwitchAccountRestartUnsafe(t *testing.T) {
 	t.Run("allows a session with a recorded conversation id", func(t *testing.T) {
 		inst := ranBefore()
 		inst.ClaudeSessionID = "aaaaaaaa-1111-4222-8333-444444444444"
-		if blocked, _ := switchAccountRestartUnsafe(inst, "", true, false); blocked {
+		if blocked, _ := AccountSwitchRestartUnsafe(inst, "", true, false); blocked {
 			t.Fatal("a recorded conversation id is enough for the resume-time guard to verify identity")
 		}
 	})
@@ -45,16 +43,16 @@ func TestSwitchAccountRestartUnsafe(t *testing.T) {
 	t.Run("allows a session that never held a conversation", func(t *testing.T) {
 		inst := ranBefore()
 		inst.ClaudeDetectedAt = time.Time{}
-		if blocked, _ := switchAccountRestartUnsafe(inst, "", true, false); blocked {
+		if blocked, _ := AccountSwitchRestartUnsafe(inst, "", true, false); blocked {
 			t.Fatal("a never-bound session has nothing to lose and nothing to hijack")
 		}
 	})
 
 	t.Run("no restart to block", func(t *testing.T) {
-		if blocked, _ := switchAccountRestartUnsafe(ranBefore(), "", true, true); blocked {
+		if blocked, _ := AccountSwitchRestartUnsafe(ranBefore(), "", true, true); blocked {
 			t.Fatal("--no-restart is the documented way through: nothing is restarted, nothing to guard")
 		}
-		if blocked, _ := switchAccountRestartUnsafe(ranBefore(), "", false, false); blocked {
+		if blocked, _ := AccountSwitchRestartUnsafe(ranBefore(), "", false, false); blocked {
 			t.Fatal("a session that was not running is not restarted by switch-account")
 		}
 	})

--- a/internal/session/account_switch_test.go
+++ b/internal/session/account_switch_test.go
@@ -1,0 +1,123 @@
+package session
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const twoAccountConfig = `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[profiles.personal.claude]
+config_dir = "~/.claude-personal"
+`
+
+// SwitchAccount is the single implementation behind the CLI's
+// `session switch-account` and the TUI's account row. An unknown slot must
+// abort with nothing committed, and the message must name the slots that DO
+// exist — otherwise the operator has to go read config.toml to find out.
+func TestSwitchAccountRejectsUnknownSlot(t *testing.T) {
+	withTempAgentDeckHome(t, twoAccountConfig)
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	inst := NewInstanceWithTool("unknown-slot", t.TempDir(), "claude")
+	result, switchErr := SwitchAccount(cfg, inst, "nope", AccountSwitchOptions{})
+	if result != nil {
+		t.Fatal("an unknown slot must commit nothing: result must be nil so the caller does not persist")
+	}
+	if !errors.Is(switchErr, ErrUnknownAccount) {
+		t.Fatalf("error must wrap ErrUnknownAccount, got: %v", switchErr)
+	}
+	for _, want := range []string{"work", "personal"} {
+		if !strings.Contains(switchErr.Error(), want) {
+			t.Errorf("error must list the configured accounts (missing %q): %v", want, switchErr)
+		}
+	}
+	if inst.Account != "" {
+		t.Errorf("account field must be untouched, got %q", inst.Account)
+	}
+}
+
+// The conversation migration is Claude-specific (claude --resume reading a
+// .jsonl out of the config dir). Other tools must be refused rather than
+// half-switched.
+func TestSwitchAccountRejectsNonClaudeTool(t *testing.T) {
+	withTempAgentDeckHome(t, twoAccountConfig)
+	cfg, _ := LoadUserConfig()
+
+	inst := NewInstanceWithTool("codex-session", t.TempDir(), "codex")
+	result, switchErr := SwitchAccount(cfg, inst, "work", AccountSwitchOptions{})
+	if result != nil {
+		t.Fatal("a non-claude session must commit nothing")
+	}
+	if !errors.Is(switchErr, ErrAccountSwitchUnsupported) {
+		t.Fatalf("error must wrap ErrAccountSwitchUnsupported, got: %v", switchErr)
+	}
+}
+
+// A session that has never held a conversation is the common case for the
+// TUI picker (switch first, work later). It must commit the account field and
+// report that there was nothing to migrate — not fail.
+func TestSwitchAccountFreshSessionCommitsSlot(t *testing.T) {
+	home := withTempAgentDeckHome(t, twoAccountConfig)
+	cfg, _ := LoadUserConfig()
+
+	inst := NewInstanceWithTool("fresh", t.TempDir(), "claude")
+	result, switchErr := SwitchAccount(cfg, inst, "work", AccountSwitchOptions{})
+	if switchErr != nil {
+		t.Fatalf("fresh session switch must succeed, got: %v", switchErr)
+	}
+	if result.NewAccount != "work" || result.OldAccount != "" {
+		t.Errorf("result accounts = %q -> %q, want \"\" -> \"work\"", result.OldAccount, result.NewAccount)
+	}
+	if inst.Account != "work" {
+		t.Errorf("instance account = %q, want \"work\"", inst.Account)
+	}
+	if result.Restarted {
+		t.Error("a session that was not running must not be started by a switch")
+	}
+	if !strings.Contains(result.Conversation, "no conversation") {
+		t.Errorf("conversation summary = %q, want it to report nothing was migrated", result.Conversation)
+	}
+
+	// The resolver must now route this session at the target account's dir.
+	if got := GetClaudeConfigDirForInstance(inst); got != filepath.Join(home, ".claude-work") {
+		t.Errorf("resolved config dir = %q, want the work account dir", got)
+	}
+}
+
+// ConfiguredAccountNames is what both the CLI error text and the TUI pickers
+// enumerate. A profile without a Claude config_dir is not a Claude account.
+func TestConfiguredAccountNamesOnlyListsClaudeSlots(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[profiles.personal.claude]
+config_dir = "~/.claude-personal"
+
+[profiles.codexonly.codex]
+config_dir = "~/.codex-only"
+`)
+	cfg, _ := LoadUserConfig()
+
+	got := ConfiguredAccountNames(cfg)
+	want := []string{"personal", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("names = %v, want %v (sorted, claude slots only)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("names = %v, want %v", got, want)
+		}
+	}
+	if ConfiguredAccountNames(nil) != nil {
+		t.Error("a nil config must yield no accounts, not panic")
+	}
+}

--- a/internal/ui/account_picker_test.go
+++ b/internal/ui/account_picker_test.go
@@ -1,0 +1,472 @@
+package ui
+
+// #924 follow-up — picking a Claude account from the TUI.
+//
+// The CLI could already create a session under a named account
+// (`launch --account`) and move one between accounts
+// (`session switch-account`), but the TUI could only DISPLAY the slot on the
+// session card. These tests lock the two selection surfaces: the account row
+// in the New Session dialog's Claude options panel, and the account row in the
+// Edit Session dialog.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// withAccountsConfig points the config loader at a temp HOME whose config.toml
+// declares the named accounts, and returns the loaded config.
+func withAccountsConfig(t *testing.T, accounts ...string) *session.UserConfig {
+	t.Helper()
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, ".config"))
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	if err := os.MkdirAll(filepath.Join(tempDir, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := &session.UserConfig{Profiles: map[string]session.ProfileSettings{}}
+	for _, name := range accounts {
+		cfg.Profiles[name] = session.ProfileSettings{
+			Claude: session.ProfileClaudeSettings{ConfigDir: filepath.Join(tempDir, ".claude-"+name)},
+		}
+	}
+	if err := session.SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	loaded, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	return loaded
+}
+
+// A machine with a single login has nothing to choose between, so the row must
+// not exist at all — no dead control, and no shifted focus indices for the
+// options that were there before.
+func TestClaudeOptionsAccountRowHiddenWithoutAccounts(t *testing.T) {
+	p := NewClaudeOptionsPanel()
+	before := p.getFocusCount()
+
+	p.SetAccounts(nil)
+	if p.hasAccountRow() {
+		t.Fatal("no configured accounts must mean no account row")
+	}
+	if got := p.getFocusCount(); got != before {
+		t.Errorf("focus count = %d, want %d unchanged when the row is hidden", got, before)
+	}
+	if strings.Contains(p.View(), "Account:") {
+		t.Error("the panel must not render an account row it cannot populate")
+	}
+	if p.GetAccount() != "" {
+		t.Errorf("GetAccount() = %q, want empty", p.GetAccount())
+	}
+}
+
+// The row defaults to "inherit" (no per-session slot) so opening the dialog
+// and pressing Enter keeps today's behaviour, and cycles through every
+// configured account.
+func TestClaudeOptionsAccountRowCycles(t *testing.T) {
+	p := NewClaudeOptionsPanel()
+	p.SetAccounts([]string{"personal", "work"})
+
+	if !p.hasAccountRow() {
+		t.Fatal("configured accounts must produce an account row")
+	}
+	if p.GetAccount() != "" {
+		t.Errorf("default selection = %q, want inherit (empty)", p.GetAccount())
+	}
+
+	// Focus the row: it is the last focusable control in the panel.
+	p.focusIndex = p.getFocusCount() - 1
+	if got := p.getFocusType(); got != "account" {
+		t.Fatalf("focus type at last index = %q, want \"account\"", got)
+	}
+
+	p.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := p.GetAccount(); got != "personal" {
+		t.Errorf("after one right: %q, want \"personal\"", got)
+	}
+	p.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := p.GetAccount(); got != "work" {
+		t.Errorf("after two rights: %q, want \"work\"", got)
+	}
+	// Wraps back to inherit rather than sticking on the last account.
+	p.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got := p.GetAccount(); got != "" {
+		t.Errorf("after wrapping: %q, want inherit (empty)", got)
+	}
+	p.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := p.GetAccount(); got != "work" {
+		t.Errorf("left from inherit: %q, want \"work\" (wrap backwards)", got)
+	}
+
+	view := p.View()
+	for _, want := range []string{"Account:", "inherit", "personal", "work"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("View() missing %q; got:\n%s", want, view)
+		}
+	}
+}
+
+// Space toggles every other control in this panel; the account row must follow
+// the same convention rather than being keyboard-reachable but inert.
+func TestClaudeOptionsAccountRowSpaceCycles(t *testing.T) {
+	p := NewClaudeOptionsPanel()
+	p.SetAccounts([]string{"work"})
+	p.focusIndex = p.getFocusCount() - 1
+
+	p.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
+	if got := p.GetAccount(); got != "work" {
+		t.Errorf("space on the account row: %q, want \"work\"", got)
+	}
+}
+
+// SetDefaults is the panel's one config hook, so the New Session dialog picks
+// up configured accounts without any extra wiring at the call site.
+func TestClaudeOptionsSetDefaultsLoadsAccounts(t *testing.T) {
+	cfg := withAccountsConfig(t, "work", "personal")
+
+	p := NewClaudeOptionsPanel()
+	p.SetDefaults(cfg)
+
+	if !p.hasAccountRow() {
+		t.Fatal("SetDefaults must populate the account row from [profiles.*.claude].config_dir")
+	}
+	p.SetAccount("work")
+	if got := p.GetAccount(); got != "work" {
+		t.Errorf("SetAccount/GetAccount round trip = %q, want \"work\"", got)
+	}
+	// An account that is no longer configured falls back to inherit rather
+	// than selecting some unrelated neighbour.
+	p.SetAccount("deleted-account")
+	if got := p.GetAccount(); got != "" {
+		t.Errorf("unknown account = %q, want inherit (empty)", got)
+	}
+}
+
+// Fork inherits the parent session's slot, so the fork panel must stay as it
+// was — no extra row, no shifted focus indices.
+func TestClaudeOptionsAccountRowAbsentInForkMode(t *testing.T) {
+	p := NewClaudeOptionsPanelForFork()
+	p.SetAccounts([]string{"work"})
+	if p.hasAccountRow() {
+		t.Error("fork mode must not offer an account row")
+	}
+	if strings.Contains(p.View(), "Account:") {
+		t.Error("fork view must not render an account row")
+	}
+}
+
+// The Edit dialog is the only place a RUNNING session's account can be
+// changed. The row must appear for claude sessions once accounts exist, and
+// report the change through GetChanges so the commit path can route it into
+// session.SwitchAccount.
+func TestEditSessionDialogAccountRow(t *testing.T) {
+	withAccountsConfig(t, "work", "personal")
+
+	inst := sampleInstance()
+	inst.Account = "personal"
+
+	d := NewEditSessionDialog()
+	d.Show(inst)
+
+	idx := -1
+	for i, f := range d.fields {
+		if f.key == session.FieldAccount {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		t.Fatal("a claude session on a machine with configured accounts must get an account row")
+	}
+	field := d.fields[idx]
+	if got := field.pillOptions[field.pillCursor]; got != "personal" {
+		t.Errorf("preselected account = %q, want the session's stored slot \"personal\"", got)
+	}
+	if got := field.pillLabels[0]; got != "inherit" {
+		t.Errorf("first pill label = %q, want \"inherit\"", got)
+	}
+
+	// No edit → no change (a save-without-touching must not rewrite the slot).
+	for _, c := range d.GetChanges(inst) {
+		if c.Field == session.FieldAccount {
+			t.Fatalf("untouched account row produced a change to %q", c.Value)
+		}
+	}
+
+	// Move the pill to "work" and confirm it surfaces as a restart-required
+	// change — the running process keeps the login it launched with.
+	d.focusIndex = idx
+	d.Update(tea.KeyMsg{Type: tea.KeyRight})
+	var found *Change
+	for i, c := range d.GetChanges(inst) {
+		if c.Field == session.FieldAccount {
+			found = &d.GetChanges(inst)[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("moving the account pill must produce an account change")
+	}
+	if found.Value != "work" {
+		t.Errorf("changed account = %q, want \"work\"", found.Value)
+	}
+	if found.IsLive {
+		t.Error("an account change needs a restart; it must not be reported as live")
+	}
+}
+
+// Without configured accounts the Edit dialog stays exactly as it was.
+func TestEditSessionDialogAccountRowHiddenWithoutAccounts(t *testing.T) {
+	withAccountsConfig(t)
+
+	d := NewEditSessionDialog()
+	d.Show(sampleInstance())
+	for _, f := range d.fields {
+		if f.key == session.FieldAccount {
+			t.Fatal("no configured accounts must mean no account row")
+		}
+	}
+}
+
+// The conversation migration only makes sense for `claude --resume`, so a
+// non-claude session must not be offered the row (SwitchAccount would refuse
+// it at commit time).
+func TestEditSessionDialogAccountRowClaudeOnly(t *testing.T) {
+	withAccountsConfig(t, "work")
+
+	inst := sampleInstance()
+	inst.Tool = "codex"
+	inst.Command = "codex"
+
+	d := NewEditSessionDialog()
+	d.Show(inst)
+	for _, f := range d.fields {
+		if f.key == session.FieldAccount {
+			t.Fatal("a non-claude session must not get the account row")
+		}
+	}
+}
+
+// The Edit dialog's commit path must NOT write the account through the
+// generic SetField loop: a bare field write leaves the conversation in the old
+// account's config dir and the restarted `claude --resume` finds nothing. This
+// locks the routing — the submit produces a command that runs the full
+// session.SwitchAccount flow and reports back as an accountSwitchedMsg.
+func TestEditSessionDialogCommitRoutesAccountThroughSwitch(t *testing.T) {
+	withAccountsConfig(t, "work", "personal")
+
+	home := NewHome()
+	home.width, home.height = 120, 40
+
+	inst := session.NewInstanceWithTool("acct-commit", t.TempDir(), "claude")
+	inst.Account = "personal"
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	home.editSessionDialog.SetSize(home.width, home.height)
+	home.editSessionDialog.Show(inst)
+
+	idx := -1
+	for i, f := range home.editSessionDialog.fields {
+		if f.key == session.FieldAccount {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		t.Fatal("expected an account row on a claude session with configured accounts")
+	}
+	home.editSessionDialog.focusIndex = idx
+	home.editSessionDialog.Update(tea.KeyMsg{Type: tea.KeyRight}) // personal -> work
+
+	_, cmd := home.handleEditSessionDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("committing an account change must return the switch command")
+	}
+	// The switch flow captures the SOURCE config dir from the pre-switch
+	// account. If the generic SetField loop wrote the field first, that capture
+	// would read the already-switched account, decide there was nothing to
+	// migrate, and resume with no conversation.
+	if inst.Account != "personal" {
+		t.Fatalf("account = %q before the switch runs; the ordered SetField loop must not write it", inst.Account)
+	}
+	if _, ok := home.resumingSessions[inst.ID]; !ok {
+		t.Error("commit must mark the session resuming so the spinner runs during the switch")
+	}
+	if home.editSessionDialog.IsVisible() {
+		t.Error("the dialog must close on commit")
+	}
+
+	msg, ok := cmd().(accountSwitchedMsg)
+	if !ok {
+		t.Fatalf("commit produced %T, want accountSwitchedMsg", cmd())
+	}
+	if msg.err != nil {
+		t.Fatalf("switch failed: %v", msg.err)
+	}
+	if !msg.committed {
+		t.Error("a successful switch must report committed so the caller persists it")
+	}
+	if msg.account != "work" {
+		t.Errorf("switched to %q, want \"work\"", msg.account)
+	}
+	if inst.Account != "work" {
+		t.Errorf("instance account = %q, want \"work\" (the switch flow owns the write)", inst.Account)
+	}
+}
+
+// Clearing the slot back to "inherit" is a supported mutation everywhere else
+// (SetField treats "" as "drop the override"), so the TUI must be able to undo
+// an account assignment. It is NOT a switch: there is no target config dir to
+// migrate into, and routing it through SwitchAccount would fail with
+// "unknown account slot".
+func TestEditSessionDialogClearingAccountIsNotASwitch(t *testing.T) {
+	withAccountsConfig(t, "work", "personal")
+
+	home := NewHome()
+	home.width, home.height = 120, 40
+
+	inst := session.NewInstanceWithTool("acct-clear", t.TempDir(), "claude")
+	inst.Account = "work"
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	home.editSessionDialog.SetSize(home.width, home.height)
+	home.editSessionDialog.Show(inst)
+	home.editSessionDialog.focusIndex = accountFieldIndex(t, home.editSessionDialog)
+	// options are ["", personal, work]; cursor sits on "work" (index 2).
+	home.editSessionDialog.Update(tea.KeyMsg{Type: tea.KeyRight}) // wrap to "" (inherit)
+
+	_, cmd := home.handleEditSessionDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if inst.Account != "" {
+		t.Fatalf("account = %q after clearing to inherit, want empty", inst.Account)
+	}
+	if cmd != nil {
+		if _, isSwitch := cmd().(accountSwitchedMsg); isSwitch {
+			t.Error("clearing the slot must not run the switch flow — there is no target dir to migrate into")
+		}
+	}
+}
+
+// A stored slot whose profile was removed from config.toml must stay
+// selectable, so opening the dialog for an unrelated edit and saving does not
+// silently rewrite the account (and does not swallow the restart the other
+// edits needed).
+func TestEditSessionDialogKeepsUnconfiguredAccountPill(t *testing.T) {
+	withAccountsConfig(t, "work", "personal")
+
+	inst := sampleInstance()
+	inst.Account = "removed-slot"
+
+	d := NewEditSessionDialog()
+	d.Show(inst)
+
+	idx := accountFieldIndex(t, d)
+	field := d.fields[idx]
+	if got := field.pillOptions[field.pillCursor]; got != "removed-slot" {
+		t.Errorf("selected pill = %q, want the stored slot \"removed-slot\"", got)
+	}
+	if !strings.Contains(field.pillLabels[field.pillCursor], "not configured") {
+		t.Errorf("label = %q, want it to mark the slot as no longer configured", field.pillLabels[field.pillCursor])
+	}
+	for _, c := range d.GetChanges(inst) {
+		if c.Field == session.FieldAccount {
+			t.Fatalf("save-without-editing rewrote the account to %q", c.Value)
+		}
+	}
+}
+
+// Switching account and changing tool in one submit cannot both apply: the
+// switch is claude-only. Refuse the pair before anything is written rather
+// than persisting the tool and then failing the switch.
+func TestEditSessionDialogRefusesAccountSwitchWithToolChange(t *testing.T) {
+	withAccountsConfig(t, "work", "personal")
+
+	home := NewHome()
+	home.width, home.height = 120, 40
+
+	inst := session.NewInstanceWithTool("acct-tool", t.TempDir(), "claude")
+	inst.Account = "personal"
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	home.editSessionDialog.SetSize(home.width, home.height)
+	home.editSessionDialog.Show(inst)
+
+	// Move the account row to "work" and the tool row to shell.
+	home.editSessionDialog.focusIndex = accountFieldIndex(t, home.editSessionDialog)
+	home.editSessionDialog.Update(tea.KeyMsg{Type: tea.KeyRight})
+	for i, f := range home.editSessionDialog.fields {
+		if f.key == session.FieldTool {
+			home.editSessionDialog.focusIndex = i
+			home.editSessionDialog.fields[i].pillCursor = 0 // shell
+		}
+	}
+
+	_, cmd := home.handleEditSessionDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("the conflicting submit must not start a switch")
+	}
+	if !home.editSessionDialog.IsVisible() {
+		t.Error("the dialog must stay open so the user can resolve the conflict")
+	}
+	if inst.Account != "personal" || inst.Tool != "claude" {
+		t.Errorf("nothing must be written: account=%q tool=%q", inst.Account, inst.Tool)
+	}
+}
+
+// The account pick is per-session, like the start query (#741): a session
+// created on "work" must not silently put the NEXT one on "work" too.
+func TestNewDialogAccountDoesNotLeakAcrossOpenings(t *testing.T) {
+	withAccountsConfig(t, "work", "personal")
+
+	d := NewNewDialog()
+	d.SetDefaultTool("claude")
+	d.SetSize(120, 50)
+	d.ShowInGroup("projects", "Projects", "/tmp", nil, "")
+	d.claudeOptions.SetAccount("work")
+	if got := d.GetClaudeAccount(); got != "work" {
+		t.Fatalf("GetClaudeAccount() = %q, want \"work\"", got)
+	}
+
+	d.Hide()
+	d.ShowInGroup("projects", "Projects", "/tmp", nil, "")
+	if got := d.GetClaudeAccount(); got != "" {
+		t.Errorf("reopened dialog carries account %q; each opening must start at inherit", got)
+	}
+}
+
+// accountFieldIndex returns the index of the account row, failing the test
+// when it is absent.
+func accountFieldIndex(t *testing.T, d *EditSessionDialog) int {
+	t.Helper()
+	for i, f := range d.fields {
+		if f.key == session.FieldAccount {
+			return i
+		}
+	}
+	t.Fatal("expected an account row")
+	return -1
+}

--- a/internal/ui/claudeoptions.go
+++ b/internal/ui/claudeoptions.go
@@ -32,6 +32,13 @@ type ClaudeOptionsPanel struct {
 	useTeammateMode      bool
 	// Focus tracking
 	focusIndex int
+	// Named Claude account slots (#924) configured as
+	// [profiles.<name>.claude].config_dir, sorted. Empty means the machine
+	// has no named accounts and the row is hidden entirely.
+	accounts []string
+	// accountCursor indexes accounts+1: 0 selects "inherit" (no per-session
+	// slot, i.e. the conductor/group/env chain), i+1 selects accounts[i].
+	accountCursor int
 	// Whether this panel is for fork dialog (fewer options)
 	isForkMode bool
 	// Total number of focusable elements
@@ -96,7 +103,57 @@ func (p *ClaudeOptionsPanel) SetDefaults(config *session.UserConfig) {
 		p.SetExtraArgs(config.Claude.ExtraArgs)
 		p.useChrome = config.Claude.UseChrome
 		p.useTeammateMode = config.Claude.UseTeammateMode
+		p.SetAccounts(session.ConfiguredAccountNames(config))
 	}
+}
+
+// SetAccounts populates the account row. Callers pass the configured Claude
+// account slots; an empty list hides the row, so a machine with a single
+// login never sees a control it cannot use.
+func (p *ClaudeOptionsPanel) SetAccounts(accounts []string) {
+	p.accounts = accounts
+	if p.accountCursor > len(accounts) {
+		p.accountCursor = 0
+	}
+	p.focusCount = p.getFocusCount()
+}
+
+// SetAccount preselects a slot by name. An unknown name (or "") lands on
+// "inherit", matching what an unset Instance.Account resolves to.
+func (p *ClaudeOptionsPanel) SetAccount(account string) {
+	p.accountCursor = 0
+	for i, name := range p.accounts {
+		if name == account {
+			p.accountCursor = i + 1
+			return
+		}
+	}
+}
+
+// GetAccount returns the selected account slot, or "" for "inherit". The
+// caller assigns it to Instance.Account, which the Claude config-dir resolver
+// reads as the most specific level of the chain (#924).
+func (p *ClaudeOptionsPanel) GetAccount() string {
+	if p.accountCursor <= 0 || p.accountCursor > len(p.accounts) {
+		return ""
+	}
+	return p.accounts[p.accountCursor-1]
+}
+
+// hasAccountRow reports whether the account selector is rendered and
+// focusable. Fork inherits the parent session's slot, so the row is
+// NewDialog-only.
+func (p *ClaudeOptionsPanel) hasAccountRow() bool {
+	return !p.isForkMode && len(p.accounts) > 0
+}
+
+// cycleAccount advances the selection, wrapping through "inherit".
+func (p *ClaudeOptionsPanel) cycleAccount(step int) {
+	span := len(p.accounts) + 1
+	if span <= 1 {
+		return
+	}
+	p.accountCursor = ((p.accountCursor+step)%span + span) % span
 }
 
 // SetFromOptions applies persisted ClaudeOptions to the panel fields.
@@ -276,6 +333,15 @@ func (p *ClaudeOptionsPanel) Update(msg tea.Msg) tea.Cmd {
 			return nil
 
 		case "left", "right":
+			// Account slot pills (#924)
+			if p.getFocusType() == "account" {
+				if msg.String() == "left" {
+					p.cycleAccount(-1)
+				} else {
+					p.cycleAccount(1)
+				}
+				return nil
+			}
 			// For session mode radio buttons
 			if !p.isForkMode && p.focusIndex == 0 {
 				if msg.String() == "left" {
@@ -338,6 +404,8 @@ func (p *ClaudeOptionsPanel) handleSpaceKey() {
 			p.useChrome = !p.useChrome
 		case "teammateMode":
 			p.useTeammateMode = !p.useTeammateMode
+		case "account":
+			p.cycleAccount(1)
 		}
 	}
 }
@@ -392,6 +460,10 @@ func (p *ClaudeOptionsPanel) getFocusType() string {
 		if idx == 6 {
 			return "startQueryInput"
 		}
+		// 8: account slot (#924), only when accounts are configured
+		if idx == 7 && p.hasAccountRow() {
+			return "account"
+		}
 	}
 	return ""
 }
@@ -405,6 +477,9 @@ func (p *ClaudeOptionsPanel) getFocusCount() int {
 	count := 7 // session mode, skip, auto, chrome, teammate, extra-args, start-query
 	if p.sessionMode == 2 {
 		count++ // resume input
+	}
+	if p.hasAccountRow() {
+		count++ // account slot selector
 	}
 	return count
 }
@@ -551,8 +626,28 @@ func (p *ClaudeOptionsPanel) viewNewMode(labelStyle, activeStyle, dimStyle, head
 	} else {
 		content += "    Start query: " + p.startQueryInput.View() + "\n"
 	}
+	focusIdx++
+
+	// Account slot (#924): which Claude login this session runs under.
+	// Hidden when no [profiles.<name>.claude].config_dir blocks exist.
+	if p.hasAccountRow() {
+		label := "    Account: "
+		if p.focusIndex == focusIdx {
+			label = activeStyle.Render("  ▶ Account: ")
+		}
+		content += label + renderLabelPills(accountPillLabels(p.accounts), p.accountCursor) + "\n"
+	}
 
 	return content
+}
+
+// accountPillLabels renders the account row's options: the inherit slot
+// first, then every configured account in config order.
+func accountPillLabels(accounts []string) []string {
+	labels := make([]string, 0, len(accounts)+1)
+	labels = append(labels, "inherit")
+	labels = append(labels, accounts...)
+	return labels
 }
 
 // renderCheckboxMark renders a checkbox mark [x] or [ ] with consistent styling.

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -63,6 +63,7 @@ type ConfirmDialog struct {
 	pendingToolOptionsJSON   json.RawMessage // Generic tool options (claude, codex, etc.)
 	pendingClaudeExtraArgs   []string        // User-supplied claude CLI tokens
 	pendingClaudeStartQuery  string          // Per-session claude startup query (v1.7.67, #725)
+	pendingClaudeAccount     string          // Per-session named account slot (#924)
 	pendingLaunchModelID     string          // Optional per-session model/version override.
 	pendingParentSessionID   string
 	pendingParentProjectPath string
@@ -209,6 +210,7 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	toolOptionsJSON json.RawMessage,
 	claudeExtraArgs []string,
 	claudeStartQuery string,
+	claudeAccount string,
 	launchModelID string,
 	parentSessionID string,
 	parentProjectPath string,
@@ -224,6 +226,7 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	c.pendingToolOptionsJSON = toolOptionsJSON
 	c.pendingClaudeExtraArgs = claudeExtraArgs
 	c.pendingClaudeStartQuery = claudeStartQuery
+	c.pendingClaudeAccount = claudeAccount
 	c.pendingLaunchModelID = launchModelID
 	c.pendingParentSessionID = parentSessionID
 	c.pendingParentProjectPath = parentProjectPath
@@ -253,8 +256,8 @@ func (c *ConfirmDialog) ShowInstallHermesHooks(configPath string, events []strin
 }
 
 // GetPendingSession returns the pending session creation data
-func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, claudeExtraArgs []string, claudeStartQuery, launchModelID string, parentSessionID, parentProjectPath string) {
-	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
+func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, claudeExtraArgs []string, claudeStartQuery, claudeAccount, launchModelID string, parentSessionID, parentProjectPath string) {
+	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingClaudeAccount, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
 }
 
 // Hide hides the dialog.

--- a/internal/ui/edit_session_dialog.go
+++ b/internal/ui/edit_session_dialog.go
@@ -78,6 +78,25 @@ func (d *EditSessionDialog) Show(inst *session.Instance) {
 			pillLabels:  []string{"Off", "Top", "Bottom"},
 			pillCursor:  pinCursorFor(inst.Pin)},
 	}
+	// Named account slot (#924). Strictly claude-only: committing this row
+	// runs session.SwitchAccount, whose conversation migration is specific to
+	// `claude --resume` reading a .jsonl out of the account's config dir.
+	// Hidden when the machine has no [profiles.<name>.claude].config_dir
+	// blocks — there would be nothing to switch between.
+	if inst.Tool == "claude" {
+		cfg, _ := session.LoadUserConfig()
+		if accounts := session.ConfiguredAccountNames(cfg); len(accounts) > 0 {
+			opts, labels, cursor := accountPillsForInstance(inst.Account, accounts)
+			d.fields = append(d.fields, editField{
+				key:         session.FieldAccount,
+				label:       "Claude account (restart, moves the conversation)",
+				kind:        editFieldPills,
+				pillOptions: opts,
+				pillLabels:  labels,
+				pillCursor:  cursor,
+			})
+		}
+	}
 	if session.IsClaudeCompatible(inst.Tool) {
 		skip, auto := readClaudeFlags(inst)
 		d.fields = append(d.fields,
@@ -124,6 +143,31 @@ func readClaudeFlags(inst *session.Instance) (skip, auto bool) {
 		return false, false
 	}
 	return cfg.Claude.GetDangerousMode(), cfg.Claude.AutoMode
+}
+
+// accountPillsForInstance returns the account row's options, their display
+// labels, and the cursor for the session's stored slot. Index 0 is always
+// "inherit" (the empty slot, i.e. the conductor/group/env chain).
+//
+// A stored slot whose profile has since been dropped from config.toml is
+// appended as its own pill rather than folded into "inherit" — the same guard
+// toolPillsForInstance applies to an unknown tool, and for the same reason: a
+// save-without-editing must stay a no-op instead of silently rewriting the
+// field to whatever slot 0 happens to be.
+func accountPillsForInstance(account string, accounts []string) (opts, labels []string, cursor int) {
+	opts = append([]string{""}, accounts...)
+	labels = append([]string{"inherit"}, accounts...)
+	for i, name := range accounts {
+		if name == account {
+			return opts, labels, i + 1
+		}
+	}
+	if account != "" {
+		opts = append(opts, account)
+		labels = append(labels, account+" (not configured)")
+		return opts, labels, len(opts) - 1
+	}
+	return opts, labels, 0
 }
 
 // displayGroupName returns the human label for a group path. Mirrors
@@ -281,6 +325,8 @@ func fieldInitialValue(inst *session.Instance, field string) string {
 		return strconv.FormatBool(auto)
 	case session.FieldPin:
 		return string(inst.Pin)
+	case session.FieldAccount:
+		return inst.Account
 	}
 	return ""
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6384,6 +6384,36 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.forceSaveInstances()
 		return h, nil
 
+	case accountSwitchedMsg:
+		delete(h.resumingSessions, msg.sessionID)
+		if msg.committed {
+			// The slot (and any conversation move) is already applied in
+			// memory; persist it and repaint the row's account badge.
+			h.rebuildFlatItems()
+			h.forceSaveInstances()
+			h.invalidatePreviewCache(msg.sessionID)
+		}
+		for _, warning := range msg.warnings {
+			uiLog.Warn("account_switch_warning", slog.String("session_id", msg.sessionID), slog.String("detail", warning))
+		}
+		if msg.err != nil {
+			// A refused switch explains why in a paragraph the footer banner
+			// would clip, and the session may be left stopped — show it in the
+			// modal instead, where it cannot be missed.
+			h.confirmDialog.ShowNotice("Account switch failed", msg.err.Error())
+			return h, nil
+		}
+		if len(msg.warnings) > 0 {
+			// The CLI prints these on stderr; dropping them here would leave a
+			// failed folder-trust pre-seed to surface as a session that stalls
+			// on a trust prompt with no explanation.
+			h.confirmDialog.ShowNotice("Account switched with warnings",
+				fmt.Sprintf("Switched to %q — %s\n\n%s", msg.account, msg.summary, strings.Join(msg.warnings, "\n")))
+			return h, nil
+		}
+		h.setError(fmt.Errorf("account switched to %q — %s", msg.account, msg.summary))
+		return h, nil
+
 	case sessionRestartedMsg:
 		if msg.err != nil {
 			// Restart failed - clear resuming animation immediately so user can retry.
@@ -8103,6 +8133,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		var toolOptionsJSON json.RawMessage
 		var claudeExtraArgs []string
 		var claudeStartQuery string
+		var claudeAccount string
 		if command == "claude" && claudeOpts != nil {
 			toolOptionsJSON, _ = session.MarshalToolOptions(claudeOpts)
 			claudeExtraArgs = h.newDialog.GetClaudeExtraArgs()
@@ -8121,6 +8152,14 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			toolOptionsJSON, _ = session.MarshalToolOptions(hermesOpts)
 		}
 
+		// The account row is offered for every claude-compatible tool (the
+		// options panel's own gate), so harvest it on the same terms rather
+		// than only for the literal "claude" preset — otherwise a custom
+		// claude-compatible tool silently drops the pick.
+		if session.IsClaudeCompatible(command) {
+			claudeAccount = h.newDialog.GetClaudeAccount()
+		}
+
 		parentSessionID := h.newDialog.GetParentSessionID()
 		parentProjectPath := h.newDialog.GetParentProjectPath()
 
@@ -8128,7 +8167,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !worktreeEnabled {
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				h.newDialog.Hide()
-				h.confirmDialog.ShowCreateDirectory(path, name, command, groupPath, toolOptionsJSON, claudeExtraArgs, claudeStartQuery, launchModelID, parentSessionID, parentProjectPath)
+				h.confirmDialog.ShowCreateDirectory(path, name, command, groupPath, toolOptionsJSON, claudeExtraArgs, claudeStartQuery, claudeAccount, launchModelID, parentSessionID, parentProjectPath)
 				return h, nil
 			}
 		}
@@ -8181,6 +8220,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			toolOptionsJSON,
 			claudeExtraArgs,
 			claudeStartQuery,
+			claudeAccount,
 			launchModelID,
 			multiRepoEnabled,
 			additionalPaths,
@@ -10392,7 +10432,7 @@ func (h *Home) confirmAction() tea.Cmd {
 
 // confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
 func (h *Home) confirmCreateDirectory() tea.Cmd {
-	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingLaunchModelID, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
+	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingAccount, pendingLaunchModelID, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
 	h.confirmDialog.Hide()
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		h.setError(fmt.Errorf("failed to create directory: %w", err))
@@ -10411,6 +10451,7 @@ func (h *Home) confirmCreateDirectory() tea.Cmd {
 		pendingToolOpts,
 		pendingExtraArgs,
 		pendingStartQuery,
+		pendingAccount,
 		pendingLaunchModelID,
 		false,
 		nil,
@@ -11138,13 +11179,46 @@ func (h *Home) handleEditSessionDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return h, nil
 		}
 
+		// The account slot is NOT a plain field write: moving a session to
+		// another Claude login has to carry its conversation into that
+		// account's config dir, or the restarted `claude --resume` finds no
+		// conversation. It is pulled out here and handed to
+		// session.SwitchAccount (the same flow as `agent-deck session
+		// switch-account`) once the ordinary field writes are persisted.
+		// Clearing the slot back to "inherit" is NOT a switch: there is no
+		// target config dir to migrate into, and SetField already treats an
+		// empty value as "drop the override" (back to the conductor/group/env
+		// chain). Only a named target goes through the switch flow; the empty
+		// value stays in the ordinary field loop below.
+		accountSwitch := ""
+		switchAccount := false
+		for _, c := range changes {
+			if c.Field == session.FieldAccount && strings.TrimSpace(c.Value) != "" {
+				accountSwitch, switchAccount = c.Value, true
+			}
+		}
+
+		// A switch to another Claude account and a change of tool cannot both
+		// land in one submit: session.SwitchAccount only supports claude, so
+		// applying the tool first would persist it and then refuse the switch,
+		// leaving the session half-edited and unrestarted. Refuse the pair up
+		// front, with nothing written.
+		if switchAccount {
+			for _, c := range changes {
+				if c.Field == session.FieldTool && c.Value != "claude" {
+					h.editSessionDialog.SetError("an account switch only applies to claude sessions — change the tool and the account in separate edits")
+					return h, nil
+				}
+			}
+		}
+
 		// Apply Tool last so claude-only validation (Skip/Auto/ExtraArgs)
 		// sees the pre-edit Tool — otherwise Tool=claude→shell with a
 		// Skip toggle in the same submit fails IsClaudeCompatible on
 		// the toggle.
 		orderedChanges := make([]Change, 0, len(changes))
 		for _, c := range changes {
-			if c.Field != session.FieldTool {
+			if c.Field != session.FieldTool && !(c.Field == session.FieldAccount && switchAccount) {
 				orderedChanges = append(orderedChanges, c)
 			}
 		}
@@ -11195,6 +11269,17 @@ func (h *Home) handleEditSessionDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.forceSaveInstances()
 
 		h.editSessionDialog.Hide()
+
+		// An account change owns the restart: SwitchAccount stops the
+		// session, migrates the conversation and starts it again, so the
+		// generic restart below would either double-start it or race the
+		// migration. Every other edit in the same submit is already saved
+		// above, so the switch's restart picks those up too.
+		if switchAccount {
+			h.resumingSessions[sessionID] = time.Now()
+			return h, h.switchSessionAccount(sessionID, accountSwitch)
+		}
+
 		// Auto-restart on restart-required edits — Tool/Skip/Auto/ExtraArgs
 		// only take effect on next launch, so deferring would just leave
 		// the user staring at old behavior. Mirrors the manual `R` path,
@@ -12061,6 +12146,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	toolOptionsJSON json.RawMessage,
 	claudeExtraArgs []string,
 	claudeStartQuery string,
+	claudeAccount string,
 	launchModelID string,
 	multiRepoEnabled bool,
 	additionalPaths []string,
@@ -12192,6 +12278,15 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		// single shell-quoted positional arg on the new-session command.
 		if tool == "claude" && claudeStartQuery != "" {
 			inst.StartupQuery = claudeStartQuery
+		}
+
+		// Apply the named account slot (#924). The Claude config-dir resolver
+		// reads Instance.Account as the most specific level of the chain, so a
+		// session created under an account spawns on that login's auth. A new
+		// session has no conversation yet, so there is nothing to migrate —
+		// changing the slot LATER goes through session.SwitchAccount.
+		if claudeAccount != "" && session.IsClaudeCompatible(tool) {
+			inst.Account = claudeAccount
 		}
 
 		// Apply sandbox config.
@@ -12651,6 +12746,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		geminiYoloMode, false, toolOptionsJSON,
 		nil,        // no extra claude args (recent-session path)
 		"",         // no claude startup query (recent-session path)
+		"",         // no account slot (inherit)
 		"",         // no explicit model override
 		false, nil, // no multi-repo
 		"", "", // no parent
@@ -12775,6 +12871,7 @@ func (h *Home) quickCreateSessionAt(projectPath string) tea.Cmd {
 		false, false, nil,
 		nil, // no extra claude args
 		"",  // no claude startup query
+		"",  // no account slot (inherit)
 		"",  // no explicit model override
 		false, nil,
 		"", "",
@@ -13654,6 +13751,54 @@ func (h *Home) bulkRemoveErrored() tea.Cmd {
 }
 
 // sessionRestartedMsg signals that a session was restarted.
+// accountSwitchedMsg reports the outcome of a TUI account switch (#924).
+// committed says whether the account field was actually changed on the
+// instance — the caller must persist session state exactly when it is true,
+// including the partial case where the switch succeeded but the restart did
+// not.
+type accountSwitchedMsg struct {
+	sessionID string
+	account   string
+	summary   string
+	committed bool
+	warnings  []string
+	err       error
+}
+
+// switchSessionAccount moves a session to another named Claude account,
+// carrying its conversation across, and reports the outcome as an
+// accountSwitchedMsg. Same flow as `agent-deck session switch-account`: it
+// stops the session, copies the conversation into the target account's config
+// dir, verifies the copy, commits the slot and restarts with `--resume`.
+//
+// Runs as a tea.Cmd because the stop/copy/start sequence talks to tmux and the
+// filesystem; doing it inline would freeze the UI for the duration.
+func (h *Home) switchSessionAccount(sessionID, account string) tea.Cmd {
+	return func() tea.Msg {
+		// Resolve by ID at execution time: a storage reload can replace the
+		// pointer captured when the dialog was submitted.
+		h.instancesMu.RLock()
+		inst := h.instanceByID[sessionID]
+		h.instancesMu.RUnlock()
+		if inst == nil {
+			return accountSwitchedMsg{sessionID: sessionID, account: account, err: fmt.Errorf("session no longer exists")}
+		}
+
+		cfg, cfgErr := session.LoadUserConfig()
+		if cfgErr != nil {
+			return accountSwitchedMsg{sessionID: sessionID, account: account, err: cfgErr}
+		}
+		result, err := session.SwitchAccount(cfg, inst, account, session.AccountSwitchOptions{})
+		msg := accountSwitchedMsg{sessionID: sessionID, account: account, err: err}
+		if result != nil {
+			msg.committed = true
+			msg.summary = result.Conversation
+			msg.warnings = result.Warnings
+		}
+		return msg
+	}
+}
+
 type sessionRestartedMsg struct {
 	sessionID  string
 	err        error

--- a/internal/ui/issue1607_explicit_title_lock_test.go
+++ b/internal/ui/issue1607_explicit_title_lock_test.go
@@ -69,6 +69,7 @@ func createIssue1607Session(t *testing.T, title string, autoName bool) *session.
 		nil,
 		"",
 		"",
+		"",
 		false,
 		nil,
 		"", "",

--- a/internal/ui/issue1706_relative_path_test.go
+++ b/internal/ui/issue1706_relative_path_test.go
@@ -62,7 +62,7 @@ func TestIssue1706_SubmitAnchorsRelativePathToAbsolute(t *testing.T) {
 		t.Fatalf("confirmType = %v, want ConfirmCreateDirectory", got)
 	}
 
-	_, pendingPath, _, _, _, _, _, _, _, _ := home.confirmDialog.GetPendingSession()
+	_, pendingPath, _, _, _, _, _, _, _, _, _ := home.confirmDialog.GetPendingSession()
 	if !filepath.IsAbs(pendingPath) {
 		t.Fatalf("pending session path = %q, want an absolute path (#1706: a relative path is created next to the TUI's cwd but tmux resolves it against the tmux server's cwd)", pendingPath)
 	}

--- a/internal/ui/issue1830_tui_resume_by_id_test.go
+++ b/internal/ui/issue1830_tui_resume_by_id_test.go
@@ -45,6 +45,7 @@ func TestIssue1830_TUICreateResumeByIDVouchesOwnership(t *testing.T) {
 		nil,
 		"",
 		"",
+		"",
 		false,
 		nil,
 		"", "",

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -529,6 +529,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.modelInput.Blur()
 	d.claudeOptions.Blur()
 	d.claudeOptions.ResetStartQuery() // #741: per-session query must not leak across openings
+	d.claudeOptions.SetAccount("")    // #924: the account pick is per-session too
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
 	if d.branchPicker != nil {
@@ -1445,6 +1446,16 @@ func (d *NewDialog) GetClaudeStartQuery() string {
 		return ""
 	}
 	return d.claudeOptions.GetStartQuery()
+}
+
+// GetClaudeAccount returns the named account slot picked in the options
+// panel (#924), or "" when the session should inherit the existing
+// conductor/group/env chain. Assigned by the caller to Instance.Account.
+func (d *NewDialog) GetClaudeAccount() string {
+	if !d.isClaudeSelected() {
+		return ""
+	}
+	return d.claudeOptions.GetAccount()
 }
 
 // isClaudeSelected returns true if the selected command is Claude or a claude-compatible custom tool

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -817,6 +817,12 @@ Move a session — conversation included — to a different Claude account (work
   config_dir = "~/.claude-team"
 ```
 
+**In the TUI:** the New Session dialog's Claude options carry an `Account` row
+(`←`/`→` or `Space` to cycle; `inherit` keeps the conductor/group/env chain), and
+the Edit Session dialog (`e`) carries a `Claude account` row that runs the full
+switch — conversation migration and `--resume` restart included — on save. Both
+rows are hidden when no accounts are configured.
+
 **Commands:**
 
 ```bash

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -96,7 +96,9 @@ Notes:
 agent-deck accounts [--json]
 ```
 
-Lists profiles that configure a Claude `config_dir`; these names are accepted by `add --account` and `launch --account`.
+Lists profiles that configure a Claude `config_dir`; these names are accepted by `add --account`, `launch --account`, `session set <id> account`, `session switch-account`, and the account rows in the TUI's New Session and Edit Session dialogs.
+
+Each row reports the slot name, its config dir, and whether that directory exists yet — a configured account with no directory has never been logged in (`CLAUDE_CONFIG_DIR=<dir> claude`, then `/login`). The `--json` form carries the same three fields (`name`, `config_dir`, `exists`).
 
 ### list - List sessions
 


### PR DESCRIPTION
## What problem does this solve?

Named Claude accounts (#924) are CLI-only in practice. `launch --account` can
create a session on a named slot and `session switch-account` can move an
existing one (conversation included), but the TUI can only *display* the slot
as an `[account:"…"]` badge. There is no way to pick an account when creating a
session, and no way to move a running session to another login, without
dropping to the CLI.

## Why this change

Both selection moments now exist in the TUI:

- **New Session dialog** — an `Account` row in the Claude options panel
  (`←`/`→` or `Space` to cycle; `inherit` = today's conductor/group/env chain).
  The pick lands on `Instance.Account`, which the Claude config-dir resolver
  already reads as the most specific level of the chain. A new session has no
  conversation yet, so nothing has to move.
- **Edit Session dialog** (`P`) — a `Claude account` row for claude sessions.
  This one deliberately does NOT go through the dialog's generic `SetField`
  loop: a bare account write leaves the conversation in the old account's
  config dir, and the restarted `claude --resume` then finds nothing. The row
  is pulled out of the change set and run through the full switch flow
  asynchronously, and it owns the restart for that submit so nothing
  double-starts or races the migration.

Both rows are hidden when no `[profiles.<name>.claude].config_dir` blocks
exist, so a single-login machine sees no dead controls. Fork mode has no row —
a fork inherits its parent's slot.

To avoid a second implementation of a flow with this many failure modes, the
switch moves out of `cmd/agent-deck` into `session.SwitchAccount` (locate the
conversation → stop → copy into the target config dir → verify → pre-accept
folder trust → commit the slot → restart). The CLI handler now only parses
flags, resolves the session, persists and renders. The #1815 restart guard
moved with it, along with its test. The contract that keeps the partial state
honest: a non-nil result means the slot WAS committed and the caller must
persist it, including the case where only the restart failed
(`ErrAccountSwitchRestartFailed`); every earlier abort returns a nil result and
leaves the instance untouched.

`agent-deck accounts` also reports whether each configured config dir exists
yet, so a slot that has never been logged into is visible instead of looking
identical to a working one.

## User impact

Creating a session on a specific Claude account, and moving an existing session
between accounts, are now possible from the TUI. Nothing changes for anyone
with no configured accounts (no new rows), and the CLI commands behave exactly
as before — same messages, same exit codes, same JSON keys.

## Evidence

Live run of the built binary against a sandboxed HOME with three configured
accounts.

New Session dialog, Claude options:

    ─ Claude Options ─
      Session: (•) New  ( ) Continue  ( ) Resume
      [x] Skip permissions
      ...
        Account:   inherit    buddii    personal    work

Edit Session dialog on a session stored with `account="work"`:

    ▶ Claude account (restart, moves the conversation):
        inherit    buddii    personal    work

Selecting `personal` and pressing Enter, then reading the state back:

    $ agent-deck list
    TITLE        GROUP   PATH    ID             ACCOUNT
    acct-demo    tmp     /tmp    548135ff-178   "personal"

and the session row's badge repainted to `[account:"personal"]`.

`agent-deck accounts` (new status column and `exists` JSON field):

    buddii     /Users/…/.claude-buddii     ok
    personal   /Users/…/.claude            ok
    work       /Users/…/.claude-work       ok

Sandboxed suite: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
fails in 5 packages (`cmd/agent-deck`, `internal/agents`, `internal/session`,
`internal/tmux`, `internal/tmuxutf8`). I ran the identical command on a clean
`origin/main` worktree and got the same 5 packages with the same test names
(`TestForbidigo_BansRawOSEnvironInSpawnPath`, the three remote-boundary /
remote-cd tests, `TestCheckHealthFreshAndStale`, the `IsLiveTmuxClientOrServer`
set), so these are pre-existing on this machine and not caused by this change.
Every package this PR touches that passes on main still passes, including
`internal/ui`.

Revert-check: the new tests reference symbols that do not exist on base
(`SwitchAccount`, `ConfiguredAccountNames`, `SetAccounts`/`GetAccount`, the
`FieldAccount` row), so they fail to compile there rather than failing an
assertion — the self-check flags this as the acceptable "new symbols" case.

A 4-dimension adversarial review (correctness, simplification, TUI
consistency, tests) ran over this diff: 36 claims, 9 surviving verification.
All are fixed in this commit, each with a regression test — clearing the slot
back to `inherit` used to be routed into the switch flow and refused
(`unknown account slot: ""`); a stored slot missing from config.toml used to
collapse onto `inherit` and emit a spurious account change on every submit; an
account change combined with a tool change is now refused up front instead of
persisting the tool and then failing the switch; the account pick no longer
leaks into the next New Session dialog; non-fatal switch warnings now surface
in the TUI the way the CLI prints them; and a claude-compatible custom tool no
longer has its pick silently dropped at create time.

Diff size is over the review-quality threshold. Most of it is the
extraction: `cmd/agent-deck/session_switch_account.go` loses 232 lines that
reappear in `internal/session/account_switch.go`, and a test file moves
packages. The genuinely new code is the two dialog rows and their tests.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

**Prompt / session log (optional):** —

## What actually bothered you

My human asked for a way to "select which claude account to open" from the
config, "in which if enabled the user can basically select the config of the
account", with "info of all the accounts we have" in config, so they "can then
select / switch which config the sessions are for", noting the CLI side "we
might already have".

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed — 5 packages fail identically on clean
      `origin/main` on this machine (see Evidence); no new failures
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included — not a hot path; dialog code and an explicitly-triggered switch
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
