### PR TITLE
feat(ui): f (quick fork) on a remote session forks it on the remote

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1440,6 +1440,11 @@ func handleAdd(profile string, args []string) {
 		return nil
 	})
 
+	// --create-dir is what the TUI's remote new-session dialog forwards after
+	// the user confirms creating a missing directory on the server; the local
+	// dialog asks the same question and calls os.MkdirAll itself.
+	createDir := fs.Bool("create-dir", false, "Create the project directory when it does not exist (like mkdir -p)")
+
 	// Sandbox flags
 	sandbox := fs.Bool("sandbox", false, "Run session in Docker sandbox")
 	sandboxImage := fs.String("sandbox-image", "", "Docker image for sandbox (overrides config default)")
@@ -1725,6 +1730,13 @@ func handleAdd(profile string, args []string) {
 		path = localPlaceholder
 	} else {
 		info, err := os.Stat(path)
+		if err != nil && *createDir {
+			if mkErr := os.MkdirAll(path, 0o755); mkErr != nil {
+				fmt.Printf("Error: failed to create directory %s: %v\n", path, mkErr)
+				os.Exit(1)
+			}
+			info, err = os.Stat(path)
+		}
 		if err != nil {
 			fmt.Printf("Error: path does not exist: %s\n", path)
 			os.Exit(1)

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -123,7 +123,7 @@ func printRemoteUsage() {
 	fmt.Println("Manage remote agent-deck instances.")
 	fmt.Println("Run commands: agent-deck remote <name> <command> [arguments]")
 	fmt.Println("  Use remote exec <name> <command> when a name matches a management command.")
-	fmt.Println("  list/status, show/output/send, add/launch, session start/stop/restart,")
+	fmt.Println("  list/status, show/output/send, add/launch, session start/stop/restart/fork,")
 	fmt.Println("  worktree list/info/cleanup, mcp attach, skill attach")
 	fmt.Println()
 	fmt.Println("Commands:")

--- a/cmd/agent-deck/remote_exec.go
+++ b/cmd/agent-deck/remote_exec.go
@@ -24,7 +24,7 @@ func remoteCommandArgs(args []string) ([]string, error) {
 		case "session":
 			if len(args) > 1 {
 				switch args[1] {
-				case "show", "output", "send", "start", "stop", "restart":
+				case "show", "output", "send", "start", "stop", "restart", "fork":
 					return append([]string(nil), args...), nil
 				}
 			}

--- a/cmd/agent-deck/remote_exec_test.go
+++ b/cmd/agent-deck/remote_exec_test.go
@@ -101,6 +101,7 @@ func TestRemoteCommandParity(t *testing.T) {
 		{"list", "--json"}, {"status", "--json"}, {"session", "show", title, "--json"},
 		{"session", "output", "missing", "--json"}, {"session", "start", "missing", "--json"},
 		{"session", "stop", "missing", "--json"}, {"session", "restart", "missing", "--json"},
+		{"session", "fork", "missing", "--json"},
 		{"worktree", "info", "missing", "--json"}, {"mcp", "attach", "missing", "none", "--json"},
 		{"skill", "attach", "missing", "none"},
 	} {

--- a/docs/REMOTE-COMMANDS.md
+++ b/docs/REMOTE-COMMANDS.md
@@ -49,6 +49,7 @@ Pressing `n` on a remote group or session opens the same new-session dialog as f
 | Docker sandbox | `-sandbox`; the image comes from the server's config |
 | Worktree | `-w <branch>`; the worktree and, when missing, the branch are created in the server's repository. An auto-filled branch travels as the bare slug and the server applies its own `[worktree].branch_prefix` once; a branch you type is sent as entered |
 | Codex and Gemini YOLO | `--yolo` |
+| A path that does not exist on the server | the server refuses the create; the TUI then asks "create this directory on remote `<name>`?" and, only if you confirm, retries with `--create-dir` so the server runs the equivalent of `mkdir -p`. A remote running an agent-deck older than `--create-dir` refuses the retry with an unknown-flag error; create the directory there by hand |
 
 Because the server applies its own defaults, the dialog opens with these options cleared for a remote target instead of pre-filled from your local `config.toml`; a local `[claude].dangerous_mode` or `default_model` never reaches a remote unless you set it in the dialog.
 

--- a/docs/REMOTE-COMMANDS.md
+++ b/docs/REMOTE-COMMANDS.md
@@ -23,6 +23,7 @@ Run the same command through `remote lab`. Output, JSON fields, diagnostics and 
 | `session start task` | `remote lab session start task` |
 | `session stop task` | `remote lab session stop task` |
 | `session restart task` | `remote lab session restart task` |
+| `session fork task -t "task 2"` | `remote lab session fork task -t "task 2"` |
 | `worktree list --json` | `remote lab worktree list --json` |
 | `worktree info task --json` | `remote lab worktree info task --json` |
 | `worktree cleanup --json` | `remote lab worktree cleanup --json` |

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1284,6 +1284,28 @@ func (r *SSHRunner) RestartSession(ctx context.Context, sessionID string) error 
 	return err
 }
 
+// ForkSession forks a session on the remote host through the remote's own
+// `session fork` and returns the new session's ID. Title and group are left
+// to the server (parent title with a "-fork" suffix, parent's group), so the
+// result matches what `agent-deck remote <name> session fork <id>` produces;
+// the server also decides whether the tool is forkable and starts the fork.
+func (r *SSHRunner) ForkSession(ctx context.Context, sessionID string) (string, error) {
+	output, err := r.Run(ctx, "session", "fork", "--json", sessionID)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		NewID string `json:"new_id"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(output), &result); err != nil {
+		return "", fmt.Errorf("failed to parse remote fork output: %w", err)
+	}
+	if result.NewID == "" {
+		return "", fmt.Errorf("remote fork returned empty session ID")
+	}
+	return result.NewID, nil
+}
+
 // RemoteSessionInfo represents a session from a remote agent-deck instance.
 type RemoteSessionInfo struct {
 	ID        string `json:"id"`

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -258,7 +258,13 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("ssh command failed: %w: %s", err, stderr.String())
+		// The remote CLI reports refusals such as "path does not exist" on
+		// stdout; fall back to it so the failure is not a bare exit status.
+		detail := stderr.String()
+		if strings.TrimSpace(detail) == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		return nil, fmt.Errorf("ssh command failed: %w: %s", err, detail)
 	}
 
 	return stdout.Bytes(), nil
@@ -1127,6 +1133,21 @@ type RemoteAddOptions struct {
 	// WorktreeBranch creates the session in a git worktree for this branch on
 	// the server (-w); the branch is created there when it does not exist.
 	WorktreeBranch string
+	// CreateDir asks the server to create a missing Path (--create-dir). The
+	// TUI sets it only after the server reported the path missing and the
+	// user confirmed; a remote too old for the flag refuses the command.
+	CreateDir bool
+}
+
+// remoteMissingPathMarker is the text the remote `add` prints when its
+// project directory does not exist (see the add command's os.Stat check).
+const remoteMissingPathMarker = "path does not exist"
+
+// IsRemotePathMissing reports whether a remote create failed because the
+// project directory does not exist on the server, so the caller can offer to
+// create it and retry with RemoteAddOptions.CreateDir.
+func IsRemotePathMissing(err error) bool {
+	return err != nil && strings.Contains(err.Error(), remoteMissingPathMarker)
 }
 
 // remoteAddArgs builds the `agent-deck add` argument list for creating a
@@ -1186,6 +1207,9 @@ func remoteAddArgs(o RemoteAddOptions) ([]string, error) {
 	}
 	if b := strings.TrimSpace(o.WorktreeBranch); b != "" {
 		args = append(args, "-w", b)
+	}
+	if o.CreateDir {
+		args = append(args, "--create-dir")
 	}
 	if p := strings.TrimSpace(o.Path); p != "" && p != "." {
 		args = append(args, p)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -684,6 +685,69 @@ func (r *SSHRunner) FetchSessionPane(ctx context.Context, sessionID string) (str
 	}
 
 	return parseRemoteSessionOutput(output)
+}
+
+// groupListJSON mirrors the subset of `agent-deck group list --json` output
+// the TUI needs: the recursive group path tree. Counts and status are
+// ignored — a group with zero sessions is still a valid move/create target.
+type groupListJSON struct {
+	Groups []groupListEntryJSON `json:"groups"`
+}
+
+type groupListEntryJSON struct {
+	Path     string               `json:"path"`
+	Children []groupListEntryJSON `json:"children,omitempty"`
+}
+
+// FetchGroupPaths retrieves the remote's full group path list from its own
+// state DB via `agent-deck group list --json`. Unlike session-derived group
+// buckets (which can only ever contain groups that currently hold sessions),
+// the remote's group list includes EMPTY groups, so the local move dialog (M
+// key on a remote session) can still offer a folder after every session has
+// been moved out of it. Paths are normalized, deduped and sorted.
+//
+// Returns nil with no error when the remote returns empty output (older
+// agent-deck builds that predate the JSON shape); callers fall back to the
+// groups observed on the fetched sessions.
+func (r *SSHRunner) FetchGroupPaths(ctx context.Context) ([]string, error) {
+	output, err := r.Run(ctx, "group", "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, nil
+	}
+
+	var parsed groupListJSON
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse remote group list: %w", err)
+	}
+
+	return parseGroupListPaths(parsed), nil
+}
+
+// parseGroupListPaths flattens the recursive group tree from `group list
+// --json` into normalized, deduped, sorted group paths. Extracted as a pure
+// function so the parsing is unit-testable without an SSH round-trip.
+func parseGroupListPaths(parsed groupListJSON) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	var walk func(entries []groupListEntryJSON)
+	walk = func(entries []groupListEntryJSON) {
+		for _, e := range entries {
+			p := strings.Trim(strings.TrimSpace(e.Path), "/")
+			if p != "" && !seen[p] {
+				seen[p] = true
+				paths = append(paths, p)
+			}
+			walk(e.Children)
+		}
+	}
+	walk(parsed.Groups)
+	sort.Strings(paths)
+	return paths
 }
 
 // FetchCostSummary retrieves the remote agent-deck's cost summary as JSON.

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -658,3 +658,60 @@ func TestIsRemotePathMissing(t *testing.T) {
 		t.Fatal("nil error treated as a missing path")
 	}
 }
+
+// ForkSession forwards exactly the remote's own `session fork --json <id>`
+// (title and group stay server decisions) and returns the new_id it reports.
+func TestSSHRunnerForkSession_ForwardsForkVerb(t *testing.T) {
+	var calls [][]string
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			return []byte(`{"success":true,"parent_id":"parent-abc","new_id":"child-def","new_title":"task-fork"}` + "\n"), nil
+		},
+	}
+
+	newID, err := runner.ForkSession(context.Background(), "parent-abc")
+	if err != nil {
+		t.Fatalf("ForkSession: %v", err)
+	}
+	if newID != "child-def" {
+		t.Fatalf("new ID = %q, want child-def", newID)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one remote call, got %v", calls)
+	}
+	want := []string{"session", "fork", "--json", "parent-abc"}
+	if strings.Join(calls[0], " ") != strings.Join(want, " ") {
+		t.Fatalf("forwarded args = %v, want %v", calls[0], want)
+	}
+}
+
+// A remote fork that fails (unforkable tool, unknown session, SSH error) must
+// surface the error and never report a session ID.
+func TestSSHRunnerForkSession_ErrorsAreNotIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		err    error
+	}{
+		{name: "ssh error", err: errors.New("session 'x' is not a forkable session (tool: gemini)")},
+		{name: "empty id", output: `{"success":true,"new_id":""}`},
+		{name: "not json", output: "Forked session: a -> b (c)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &SSHRunner{
+				runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+					return []byte(tt.output), tt.err
+				},
+			}
+			newID, err := runner.ForkSession(context.Background(), "parent-abc")
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if newID != "" {
+				t.Fatalf("new ID = %q on error, want empty", newID)
+			}
+		})
+	}
+}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -572,5 +573,69 @@ func TestSSHRunnerCreateSessionWithOptions_RefusedValueNeverContactsRemote(t *te
 	}
 	if calls != 0 {
 		t.Fatalf("remote contacted %d times for a refused value, want 0", calls)
+	}
+}
+
+// TestParseGroupListPaths pins the group-list flattener that backs
+// SSHRunner.FetchGroupPaths: `group list --json` returns a recursive tree
+// whose paths (including EMPTY groups — session_count 0) must all surface,
+// deduped and sorted, for the remote move/create dialogs.
+func TestParseGroupListPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty list",
+			input: `{"groups":[],"total_groups":0,"total_sessions":0}`,
+			want:  []string{},
+		},
+		{
+			name: "flat groups incl. an empty one",
+			input: `{"groups":[
+				{"name":"emptytest","path":"emptytest","session_count":0},
+				{"name":"work","path":"work","session_count":3}
+			],"total_groups":2,"total_sessions":3}`,
+			want: []string{"emptytest", "work"},
+		},
+		{
+			name: "nested children flattened with full paths",
+			input: `{"groups":[
+				{"name":"my-sessions","path":"my-sessions","session_count":7,
+				 "children":[
+					{"name":"done","path":"my-sessions/done","session_count":6,
+					 "children":[
+						{"name":"deep","path":"my-sessions/done/deep","session_count":0}
+					 ]}
+				 ]}
+			],"total_groups":3,"total_sessions":7}`,
+			want: []string{"my-sessions", "my-sessions/done", "my-sessions/done/deep"},
+		},
+		{
+			name: "slashes and whitespace normalized",
+			input: `{"groups":[
+				{"name":"a","path":"/a/","session_count":0}
+			],"total_groups":1,"total_sessions":0}`,
+			want: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var parsed groupListJSON
+			if err := json.Unmarshal([]byte(tt.input), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := parseGroupListPaths(parsed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseGroupListPaths = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseGroupListPaths[%d] = %q, want %q (all: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
 	}
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -197,6 +197,11 @@ func TestRemoteAddArgs(t *testing.T) {
 			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "/srv/project"},
 		},
 		{
+			name: "create a missing remote directory only after confirmation",
+			opts: RemoteAddOptions{Tool: "codex", Title: "fix", Path: "/srv/new", CreateDir: true},
+			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "--create-dir", "/srv/new"},
+		},
+		{
 			name: "tool without title auto-names via --quick",
 			opts: RemoteAddOptions{Tool: "pi"},
 			want: []string{"add", "--json", "--quick", "-c", "pi"},
@@ -637,5 +642,19 @@ func TestParseGroupListPaths(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The remote `add` reports a missing project directory on stdout; the TUI
+// recognises that refusal to offer creating the directory, and nothing else.
+func TestIsRemotePathMissing(t *testing.T) {
+	if !IsRemotePathMissing(errors.New("ssh command failed: exit status 1: Error: path does not exist: /srv/new")) {
+		t.Fatal("missing-path refusal not recognised")
+	}
+	if IsRemotePathMissing(errors.New("ssh command failed: exit status 255: connection refused")) {
+		t.Fatal("unrelated failure treated as a missing path")
+	}
+	if IsRemotePathMissing(nil) {
+		t.Fatal("nil error treated as a missing path")
 	}
 }

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -260,6 +260,19 @@ func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath stri
 	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingClaudeAccount, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
 }
 
+// ShowCreateRemoteDirectory asks whether to create a directory the remote
+// reported missing (see session.IsRemotePathMissing) and retry the create
+// there with --create-dir. The pending dialog values stay on Home.
+func (c *ConfirmDialog) ShowCreateRemoteDirectory(remoteName, path string) {
+	c.visible = true
+	c.confirmType = ConfirmCreateDirectory
+	c.targetID = path
+	c.targetName = path
+	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
+}
+
 // Hide hides the dialog.
 func (c *ConfirmDialog) Hide() {
 	c.visible = false
@@ -477,6 +490,9 @@ func (c *ConfirmDialog) View() string {
 	case ConfirmCreateDirectory:
 		title = "📁  Directory Not Found"
 		warning = fmt.Sprintf("The path does not exist:\n\n  %s", c.targetName)
+		if c.remoteName != "" {
+			warning = fmt.Sprintf("The path does not exist on remote %s:\n\n  %s", c.remoteName, c.targetName)
+		}
 		details = "Create this directory and start the session?"
 		borderColor = ColorAccent
 		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -38,6 +38,12 @@ type GroupDialog struct {
 	// Tab toggle between Root and Subgroup modes (Issue #111)
 	contextParentPath string // Original cursor context parent path (for toggling back)
 	contextParentName string // Original cursor context parent name (for toggling back)
+
+	// remoteName is non-empty when the dialog was opened on a REMOTE row
+	// (g key on a remote session/group header). The group is then created in
+	// the remote's own state DB via SSH instead of the local group tree; the
+	// create handler in home.go uses RemoteName() to pick the routing.
+	remoteName string
 }
 
 // NewGroupDialog creates a new group dialog
@@ -64,7 +70,8 @@ func NewGroupDialog() *GroupDialog {
 func (g *GroupDialog) Show() {
 	g.visible = true
 	g.mode = GroupDialogCreate
-	g.groupPath = "" // No parent = root level
+	g.remoteName = "" // local
+	g.groupPath = ""  // No parent = root level
 	g.parentName = ""
 	g.validationErr = ""
 	g.nameInput.SetValue("")
@@ -77,6 +84,7 @@ func (g *GroupDialog) Show() {
 func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = ""        // local
 	g.groupPath = parentPath // Parent path for the new subgroup
 	g.parentName = parentName
 	g.validationErr = ""
@@ -92,6 +100,7 @@ func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 func (g *GroupDialog) ShowCreateWithContext(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = "" // local
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
 	g.validationErr = ""
@@ -119,6 +128,57 @@ func (g *GroupDialog) ShowCreateWithContextDefaultRoot(parentPath, parentName st
 	g.mode = GroupDialogCreate
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
+	g.remoteName = "" // local
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	// Default to root mode, Tab toggles to subgroup
+	g.groupPath = ""
+	g.parentName = ""
+}
+
+// ShowCreateRemoteWithContext opens the create dialog for a REMOTE context
+// (g key on a remote group header): the new group is created on the remote
+// host via SSH (see home.go createRemoteGroup), with parentPath set to the
+// header's own group path so the remote creates a subgroup under it. Pass an
+// empty parentPath for the level-0 host header (root-level remote group).
+func (g *GroupDialog) ShowCreateRemoteWithContext(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	if parentPath != "" {
+		// Default to subgroup mode
+		g.groupPath = parentPath
+		g.parentName = parentName
+	} else {
+		// Root mode, no toggle
+		g.groupPath = ""
+		g.parentName = ""
+	}
+}
+
+// ShowCreateRemoteWithContextDefaultRoot is the remote counterpart of
+// ShowCreateWithContextDefaultRoot: opens the create dialog defaulting to
+// root mode on the remote, storing the cursor context so Tab can toggle to
+// subgroup mode under the session's current group. The created group is
+// routed to the remote's own state DB (home.go createRemoteGroup).
+func (g *GroupDialog) ShowCreateRemoteWithContextDefaultRoot(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
@@ -157,6 +217,7 @@ func (g *GroupDialog) ToggleRootSubgroup() {
 func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRename
+	g.remoteName = "" // not a create
 	g.groupPath = currentPath
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -170,6 +231,7 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 func (g *GroupDialog) ShowMove(groupPaths []string) {
 	g.visible = true
 	g.mode = GroupDialogMove
+	g.remoteName = "" // not a create; reset any stale remote create context
 	g.validationErr = ""
 	g.groupPaths = groupPaths
 	g.selected = 0
@@ -179,6 +241,7 @@ func (g *GroupDialog) ShowMove(groupPaths []string) {
 func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRenameSession
+	g.remoteName = "" // not a create
 	g.sessionID = sessionID
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -193,9 +256,17 @@ func (g *GroupDialog) GetSessionID() string {
 	return g.sessionID
 }
 
+// RemoteName returns the remote the create dialog is scoped to (g key on a
+// remote row), or "" when the dialog creates a LOCAL group. The create
+// handler routes to the remote's own state DB via SSH when non-empty.
+func (g *GroupDialog) RemoteName() string {
+	return g.remoteName
+}
+
 // Hide hides the dialog
 func (g *GroupDialog) Hide() {
 	g.visible = false
+	g.remoteName = ""
 	g.nameInput.Blur()
 }
 
@@ -399,6 +470,15 @@ func (g *GroupDialog) View() string {
 		} else {
 			title = "Create New Group"
 			content = fields
+		}
+
+		// Remote create (g on a remote row): make the routing explicit so the
+		// user knows the group will be created on the remote host, not locally.
+		if g.remoteName != "" {
+			remoteInfo := lipgloss.NewStyle().
+				Foreground(ColorCyan).
+				Render("Remote: " + g.remoteName)
+			content = remoteInfo + "\n\n" + content
 		}
 
 		// Add Root/Subgroup toggle indicator when Tab toggle is available

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -624,9 +624,15 @@ type Home struct {
 	uiStateSaveTicks     int      // Counter for periodic UI state saves in tick handler
 
 	// Remote sessions (Phase 2: Agent-Deck Remotes)
-	remoteSessions     map[string][]session.RemoteSessionInfo // remoteName -> sessions
-	remoteFromCache    map[string]bool                        // remoteName -> data is a startup cache snapshot, not live yet
-	remoteFetchedAt    map[string]time.Time                   // remoteName -> when its sessions last came from a live fetch
+	remoteSessions map[string][]session.RemoteSessionInfo // remoteName -> sessions
+	// remoteGroups holds each remote's FULL group path list as reported by
+	// its own state DB (`agent-deck group list --json`, fetched on the same
+	// fleet poll). Unlike session-derived buckets it includes EMPTY groups,
+	// so the M move dialog can still offer a remote folder after every
+	// session has been moved out of it. Guarded by remoteSessionsMu.
+	remoteGroups       map[string][]string  // remoteName -> sorted group paths (incl. empty groups)
+	remoteFromCache    map[string]bool      // remoteName -> data is a startup cache snapshot, not live yet
+	remoteFetchedAt    map[string]time.Time // remoteName -> when its sessions last came from a live fetch
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
@@ -1396,6 +1402,14 @@ type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
 	// #1101: per-remote cost summary collected on the same SSH fanout.
 	costs map[string]*costs.RemoteCostSummary
+	// groups holds each remote's FULL group path list (incl. empty groups)
+	// from `group list --json`, so the move/create dialogs can offer folders
+	// that currently hold no sessions. Only remotes that reported a fresh
+	// list appear here.
+	groups map[string][]string
+	// groupsFailed marks remotes whose group-list fetch errored this round;
+	// the handler keeps their last-good cached group paths.
+	groupsFailed map[string]bool
 	// failed marks remotes whose fetch errored this round (issue #1170).
 	// The handler keeps their last-good sessions instead of wiping them,
 	// so one slow/offline remote can't flicker the whole list.
@@ -2120,21 +2134,31 @@ func (h *Home) scopedGroupPaths() []string {
 	return scoped
 }
 
-// remoteGroupPaths returns the distinct, normalized group paths currently
-// observed on a remote, sorted for the move dialog (M key on a remote
-// session). These are the only groups the remote knows about; a remote move
-// is executed with `agent-deck group move <id> <group>` on that host.
+// remoteGroupPaths returns the distinct, normalized group paths available as
+// move targets on a remote, sorted for the move dialog (M key on a remote
+// session). The remote's own group list (fetched on the fleet poll via
+// `group list --json`) is the primary source: unlike session-derived buckets
+// it includes EMPTY groups, so a folder that currently holds no sessions is
+// still offered after every session has been moved out of it. Groups observed
+// on the fetched sessions are unioned in as a fallback for remotes whose
+// group-list fetch failed or predates the JSON shape.
 func (h *Home) remoteGroupPaths(remoteName string) []string {
 	h.remoteSessionsMu.RLock()
 	defer h.remoteSessionsMu.RUnlock()
 	seen := make(map[string]bool)
 	var paths []string
-	for _, s := range h.remoteSessions[remoteName] {
-		p := normalizeRemoteGroupPath(s.Group)
+	add := func(p string) {
+		p = normalizeRemoteGroupPath(p)
 		if !seen[p] {
 			seen[p] = true
 			paths = append(paths, p)
 		}
+	}
+	for _, p := range h.remoteGroups[remoteName] {
+		add(p)
+	}
+	for _, s := range h.remoteSessions[remoteName] {
+		add(s.Group)
 	}
 	sort.Strings(paths)
 	return paths
@@ -3538,6 +3562,14 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	// as "remote contributes zero" so a single broken remote can't poison
 	// the displayed total.
 	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
+	// Remote group lists (group list --json) ride the same fanout so the
+	// move/create dialogs can offer EMPTY remote folders — a folder that
+	// currently holds no sessions is invisible to session-derived buckets
+	// but is still a valid target. Successful fetches land in groupResults;
+	// failures in groupsFailed keep last-good cache entries (same contract
+	// as the sessions map, issue #1170).
+	groupResults := make(map[string][]string, len(config.Remotes))
+	groupsFailed := make(map[string]bool, len(config.Remotes))
 	// #1170: track remotes that errored so the handler keeps their last-good
 	// sessions instead of dropping them.
 	failed := make(map[string]bool, len(config.Remotes))
@@ -3563,6 +3595,8 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			if err != nil {
 				mu.Lock()
 				failed[name] = true
+				// The group list can't be trusted either — keep last-good.
+				groupsFailed[name] = true
 				mu.Unlock()
 				return
 			}
@@ -3576,17 +3610,33 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			summary, costErr := runner.FetchCostSummary(costCtx)
 			costCancel()
 
+			// Group list fetch has the same isolation: a slow `group list`
+			// on one remote must not starve the session/cost data of any
+			// other remote, and a failure degrades to the session-derived
+			// group fallback in remoteGroupPaths.
+			groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+			groupPaths, groupErr := runner.FetchGroupPaths(groupCtx)
+			groupCancel()
+
 			mu.Lock()
 			results[name] = sessions
 			if costErr == nil && summary != nil {
 				costResults[name] = summary
+			}
+			if groupErr == nil {
+				if groupPaths == nil {
+					groupPaths = []string{}
+				}
+				groupResults[name] = groupPaths
+			} else {
+				groupsFailed[name] = true
 			}
 			mu.Unlock()
 		}(name, rc)
 	}
 	wg.Wait()
 
-	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, failed: failed}
+	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -6571,6 +6621,26 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// #1170: merge rather than wholesale-replace so a remote that errored
 		// this round keeps its last-good sessions instead of flickering out.
 		h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
+		// Remote group lists: replace wholesale for remotes that reported a
+		// fresh list; failed remotes keep their last-good cached paths so the
+		// move dialog doesn't lose empty-group targets on a transient SSH
+		// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
+		for name, paths := range msg.groups {
+			h.remoteGroups[name] = paths
+			keepGroups[name] = true
+		}
+		for name := range msg.groupsFailed {
+			keepGroups[name] = true
+		}
+		for name := range h.remoteGroups {
+			if !keepGroups[name] {
+				delete(h.remoteGroups, name)
+			}
+		}
 		for name := range msg.sessions {
 			if !msg.failed[name] {
 				delete(h.remoteFromCache, name)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1362,6 +1362,17 @@ type maintenanceCompleteMsg struct {
 	result session.MaintenanceResult
 }
 
+// remoteMoveResultMsg reports the outcome of an SSH-routed "move to group"
+// for a remote session (M key → GroupDialogMove). The session's row lives in
+// the remote's own state DB, so the move is executed there and the local
+// fleet cache is patched only after the remote confirms.
+type remoteMoveResultMsg struct {
+	remoteName string
+	sessionID  string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2107,6 +2118,55 @@ func (h *Home) scopedGroupPaths() []string {
 		}
 	}
 	return scoped
+}
+
+// remoteGroupPaths returns the distinct, normalized group paths currently
+// observed on a remote, sorted for the move dialog (M key on a remote
+// session). These are the only groups the remote knows about; a remote move
+// is executed with `agent-deck group move <id> <group>` on that host.
+func (h *Home) remoteGroupPaths(remoteName string) []string {
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	seen := make(map[string]bool)
+	var paths []string
+	for _, s := range h.remoteSessions[remoteName] {
+		p := normalizeRemoteGroupPath(s.Group)
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// moveRemoteSessionToGroup routes a TUI "move to group" for a remote session
+// over SSH: the session's row lives in the remote's own state DB, so the
+// local tree cannot move it. Runs `agent-deck group move <id> <group>` on the
+// remote (the same command the remote's own TUI would run) and returns a
+// remoteMoveResultMsg so the fleet cache is updated only on remote
+// confirmation. Mirrors the remote-rename path in GroupDialogRenameSession.
+func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGroupPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': failed to load remotes config: %v", title, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': remote '%s' is not configured", title, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := runner.RunCommand(ctx, "group", "move", sessionID, targetGroupPath); err != nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("failed to move '%s' on %s: %v", title, remoteName, err)}
+		}
+		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
+	}
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6627,6 +6687,29 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case remoteMoveResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed; patch the local fleet cache so the row moves
+		// groups immediately, before the next poll re-fetches the truth.
+		// The persisted local order overlay for the old bucket is harmless:
+		// applyRemoteSessionOrder skips overlay IDs the remote no longer
+		// reports in that bucket.
+		h.remoteSessionsMu.Lock()
+		if sessions, ok := h.remoteSessions[msg.remoteName]; ok {
+			for i := range sessions {
+				if sessions[i].ID == msg.sessionID {
+					sessions[i].Group = msg.groupPath
+					break
+				}
+			}
+		}
+		h.remoteSessionsMu.Unlock()
+		h.rebuildFlatItems()
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9450,6 +9533,13 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.setError(errSessionStillCreating)
 			} else if item.Type == session.ItemTypeSession {
 				h.groupDialog.ShowMove(h.scopedGroupPaths())
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote sessions live in the remote's own state DB, so the
+				// local tree cannot move them. Offer the group paths currently
+				// observed on that remote (the only groups the remote knows
+				// about); the confirmed move is routed over SSH in
+				// GroupDialogMove (see moveRemoteSessionToGroup).
+				h.groupDialog.ShowMove(h.remoteGroupPaths(item.RemoteName))
 			}
 		}
 		return h, nil
@@ -11630,6 +11720,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
+		// moveCmd is set when the confirmed action is a remote-session move,
+		// which runs over SSH and reports back via remoteMoveResultMsg.
+		var moveCmd tea.Cmd
+
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
@@ -11700,6 +11794,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.instancesMu.Unlock()
 					h.rebuildFlatItems()
 					h.saveInstances()
+				} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && item.RemoteName != "" {
+					// The row lives in the remote's own DB; run
+					// `agent-deck group move` there over SSH (mirrors the
+					// remote-rename path) and refresh the fleet cache when the
+					// remote confirms via remoteMoveResultMsg.
+					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11788,7 +11888,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, nil
+		return h, moveCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -719,6 +719,9 @@ type Home struct {
 	// dropped otherwise, so a slow answer for an earlier opening can never
 	// replace the slot list the user is choosing from now.
 	remoteAccountsGen uint64
+	// pendingRemoteCreate holds the remote create whose path the server
+	// reported missing, while the create-directory confirmation is open.
+	pendingRemoteCreate *remoteCreateDirNeededMsg
 	// insertKeySender is the persistent dispatch path opened on
 	// enterInsertMode and closed on exitInsertMode (#1102 perf fix +
 	// remote support). Local sessions get a tmux.KeySender (control-mode
@@ -6767,6 +6770,15 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.applyRemoteAccounts(msg)
 		return h, nil
 
+	case remoteCreateDirNeededMsg:
+		// The server refused the path; ask before retrying with --create-dir
+		// so a typo never silently creates a directory on the remote.
+		pending := msg
+		h.pendingRemoteCreate = &pending
+		h.confirmDialog.ShowCreateRemoteDirectory(msg.remoteName, msg.opts.Path)
+		h.beginAttachReturnGrace(time.Now())
+		return h, tea.Batch(tea.EnableMouseCellMotion, RestoreLegacyKeyboardCmd(os.Stdout), tea.WindowSize())
+
 	case remoteSessionCreatedMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
@@ -10672,9 +10684,11 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if h.confirmDialog.GetFocusedButton() == 0 {
 				return h, h.confirmCreateDirectory()
 			}
+			h.pendingRemoteCreate = nil
 			h.confirmDialog.Hide()
 			return h, nil
 		case "n", "N", "esc":
+			h.pendingRemoteCreate = nil
 			h.confirmDialog.Hide()
 			return h, nil
 		}
@@ -10799,6 +10813,17 @@ func (h *Home) confirmAction() tea.Cmd {
 
 // confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
 func (h *Home) confirmCreateDirectory() tea.Cmd {
+	if pending := h.pendingRemoteCreate; pending != nil {
+		h.pendingRemoteCreate = nil
+		h.confirmDialog.Hide()
+		opts := pending.opts
+		opts.CreateDir = true
+		create := h.createRemoteSessionWithOptions
+		if h.remoteCreateSink != nil {
+			create = h.remoteCreateSink
+		}
+		return create(pending.remoteName, opts)
+	}
 	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingAccount, pendingLaunchModelID, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
 	h.confirmDialog.Hide()
 	if err := os.MkdirAll(path, 0o755); err != nil {
@@ -14341,6 +14366,14 @@ type remoteSessionCreatedMsg struct {
 	err error
 }
 
+// remoteCreateDirNeededMsg reports a remote create refused because the
+// dialog's path does not exist on the server; Home offers to create it.
+type remoteCreateDirNeededMsg struct {
+	remoteName string
+	opts       session.RemoteAddOptions
+	err        error
+}
+
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	return func() tea.Msg {
@@ -14761,6 +14794,9 @@ func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.Re
 			var attachErr remoteAttachFailedError
 			if errors.As(err, &attachErr) {
 				return remoteSessionCreatedMsg{err: fmt.Errorf("failed to attach to remote session after creating it: %w", attachErr)}
+			}
+			if !opts.CreateDir && strings.TrimSpace(opts.Path) != "" && session.IsRemotePathMissing(err) {
+				return remoteCreateDirNeededMsg{remoteName: remoteName, opts: opts, err: err}
 			}
 			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6766,6 +6766,15 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.setError(fmt.Errorf("restarted '%s' on %s", msg.title, msg.remoteName))
 		return h, h.fetchRemoteSessions
 
+	case remoteSessionForkedMsg:
+		delete(h.forkingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
+		if msg.err != nil {
+			h.setError(fmt.Errorf("failed to fork remote session: %w", msg.err))
+			return h, nil
+		}
+		h.setError(fmt.Errorf("forked '%s' on %s", msg.title, msg.remoteName))
+		return h, h.fetchRemoteSessions
+
 	case remoteAccountsFetchedMsg:
 		h.applyRemoteAccounts(msg)
 		return h, nil
@@ -9655,6 +9664,17 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				if item.Session.CanFork() {
 					return h, h.quickForkSession(item.Session)
 				}
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote session: fork it on the remote itself through its own
+				// `session fork`. The remote decides title, group and whether
+				// the tool is forkable; the row appears on the next fetch.
+				forkID := remoteRestartAnimationID(item.RemoteName, item.RemoteSession.ID)
+				if _, forking := h.forkingSessions[forkID]; forking {
+					h.setError(fmt.Errorf("remote session is forking, please wait..."))
+					return h, nil
+				}
+				h.forkingSessions[forkID] = time.Now()
+				return h, h.forkRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
 			}
 		}
 		return h, nil
@@ -9677,6 +9697,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				if item.Session.CanFork() {
 					return h, h.forkSessionWithDialog(item.Session)
 				}
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// The fork dialog inspects local git state for its worktree
+				// and branch fields, which does not apply to a remote checkout.
+				h.setError(fmt.Errorf("fork dialog is not available for remote sessions; press f to fork on %s", item.RemoteName))
 			}
 		}
 		return h, nil
@@ -14366,6 +14390,16 @@ type remoteSessionCreatedMsg struct {
 	err error
 }
 
+// remoteSessionForkedMsg reports the outcome of an SSH-routed quick fork (f
+// key on a remote session row). newID is the session the remote created.
+type remoteSessionForkedMsg struct {
+	remoteName string
+	sessionID  string
+	title      string
+	newID      string
+	err        error
+}
+
 // remoteCreateDirNeededMsg reports a remote create refused because the
 // dialog's path does not exist on the server; Home offers to create it.
 type remoteCreateDirNeededMsg struct {
@@ -14429,6 +14463,31 @@ func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 		defer cancel()
 		err = runner.StopSession(ctx, sessionID)
 		return remoteSessionClosedMsg{remoteName: remoteName, sessionID: sessionID, title: title, err: err}
+	}
+}
+
+// forkRemoteSession forks a remote session through the remote's own
+// `session fork` (mirrors restartRemoteSession). Title, group and tool
+// eligibility are decided on the server; the fleet list is refreshed when
+// the remote confirms via remoteSessionForkedMsg so the new row appears.
+func (h *Home) forkRemoteSession(remoteName, sessionID, title string) tea.Cmd {
+	return func() tea.Msg {
+		result := remoteSessionForkedMsg{remoteName: remoteName, sessionID: sessionID, title: title}
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			result.err = fmt.Errorf("failed to load remote config")
+			return result
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			result.err = fmt.Errorf("remote '%s' not found", remoteName)
+			return result
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		result.newID, result.err = runner.ForkSession(ctx, sessionID)
+		return result
 	}
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1379,6 +1379,16 @@ type remoteMoveResultMsg struct {
 	err        error
 }
 
+// remoteGroupResultMsg reports the outcome of an SSH-routed "create group"
+// for a remote context (g key on a remote row → GroupDialogCreate). The
+// group must be created in the remote's own state DB; groupPath is the full
+// path the remote assigned (parent/name, or name for a root-level group).
+type remoteGroupResultMsg struct {
+	remoteName string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2191,6 +2201,56 @@ func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGrou
 		}
 		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
 	}
+}
+
+// createRemoteGroup routes a TUI "create group" (g key on a remote row) over
+// SSH: the group must be created in the remote's own state DB, not the local
+// tree. Runs `agent-deck group create <name> [--parent <parent>]` on the
+// remote and returns a remoteGroupResultMsg so the local group-path cache is
+// updated only on remote confirmation. Mirrors moveRemoteSessionToGroup and
+// the remote-rename path in GroupDialogRenameSession.
+func (h *Home) createRemoteGroup(name, remoteName, parentPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': failed to load remotes config: %v", name, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': remote '%s' is not configured", name, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		args := []string{"group", "create", name}
+		if parentPath != "" {
+			args = append(args, "--parent", parentPath)
+		}
+		if _, err := runner.RunCommand(ctx, args...); err != nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("failed to create group '%s' on %s: %v", name, remoteName, err)}
+		}
+		full := name
+		if parentPath != "" {
+			full = parentPath + "/" + name
+		}
+		return remoteGroupResultMsg{remoteName: remoteName, groupPath: full}
+	}
+}
+
+// remoteGroupPathFromItem extracts the remote-relative group path from a
+// remote group header's Item.Path ("remotes/<name>/<group-path>"); returns
+// "" for the level-0 host header (Path == "remotes/<name>"). Used by the g
+// key handler to decide the parent for a remote subgroup create.
+func remoteGroupPathFromItem(item session.Item) string {
+	prefix := "remotes/" + item.RemoteName + "/"
+	p := strings.TrimPrefix(item.Path, prefix)
+	if p == item.Path {
+		return "" // level-0 host header
+	}
+	return p
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6780,6 +6840,35 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.rebuildFlatItems()
 		return h, nil
 
+	case remoteGroupResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed the group exists; add it to the cached group list
+		// so the M move dialog (and subsequent subgroup creates) offer it
+		// immediately, before the next fleet poll re-confirms from the
+		// remote's own DB. The sessions map is untouched — creating a group
+		// moves no sessions.
+		h.remoteSessionsMu.Lock()
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		seen := false
+		for _, p := range h.remoteGroups[msg.remoteName] {
+			if p == msg.groupPath {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			h.remoteGroups[msg.remoteName] = append(h.remoteGroups[msg.remoteName], msg.groupPath)
+			sort.Strings(h.remoteGroups[msg.remoteName])
+		}
+		h.remoteSessionsMu.Unlock()
+		h.setError(fmt.Errorf("created group '%s' on %s", msg.groupPath, msg.remoteName))
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9696,7 +9785,32 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		} else if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeGroup {
+			if item.Type == session.ItemTypeRemoteGroup {
+				// Remote group header (incl. the level-0 host header): create
+				// the group on the remote itself. The parent defaults to the
+				// header's own group path so Enter creates a remote subgroup;
+				// Tab toggles to root-level remote create (issue #111 parity).
+				parentPath := remoteGroupPathFromItem(item)
+				parentName := parentPath
+				if idx := strings.LastIndex(parentPath, "/"); idx >= 0 {
+					parentName = parentPath[idx+1:]
+				}
+				h.groupDialog.ShowCreateRemoteWithContext(parentPath, parentName, item.RemoteName)
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote session: default to a root-level group on the remote;
+				// Tab toggles to a subgroup under the session's current group.
+				if gPath := item.RemoteSession.Group; gPath != "" {
+					gName := gPath
+					if idx := strings.LastIndex(gPath, "/"); idx >= 0 {
+						gName = gPath[idx+1:]
+					}
+					h.groupDialog.ShowCreateRemoteWithContextDefaultRoot(gPath, gName, item.RemoteName)
+				} else {
+					// Ungrouped remote session: root only, no toggle (mirrors
+					// the local ungrouped case below).
+					h.groupDialog.ShowCreateRemoteWithContext("", "", item.RemoteName)
+				}
+			} else if item.Type == session.ItemTypeGroup {
 				// On group header: default to subgroup mode
 				h.groupDialog.ShowCreateWithContext(item.Group.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.GroupPath != "" {
@@ -11790,14 +11904,29 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
-		// moveCmd is set when the confirmed action is a remote-session move,
-		// which runs over SSH and reports back via remoteMoveResultMsg.
-		var moveCmd tea.Cmd
+		// remoteCmd is set when the confirmed action runs over SSH against a
+		// remote's own state DB (remote-session move, remote group create) and
+		// reports back via remoteMoveResultMsg / remoteGroupResultMsg.
+		var remoteCmd tea.Cmd
 
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
 			if name != "" {
+				if remoteName := h.groupDialog.RemoteName(); remoteName != "" {
+					// g was pressed on a REMOTE row: the group must be created
+					// in the remote's own state DB, not the local tree. Run
+					// `agent-deck group create` there over SSH (mirrors the
+					// remote-move and remote-rename paths); the local group
+					// path cache updates when the remote confirms via
+					// remoteGroupResultMsg.
+					parentPath := ""
+					if h.groupDialog.HasParent() {
+						parentPath = h.groupDialog.GetParentPath()
+					}
+					remoteCmd = h.createRemoteGroup(name, remoteName, parentPath)
+					break
+				}
 				// Seed the new-group default from [group_defaults].max_concurrent.
 				if cfg, _ := session.LoadUserConfig(); cfg != nil {
 					h.groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
@@ -11869,7 +11998,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					// `agent-deck group move` there over SSH (mirrors the
 					// remote-rename path) and refresh the fleet cache when the
 					// remote confirms via remoteMoveResultMsg.
-					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
+					remoteCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11958,7 +12087,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, moveCmd
+		return h, remoteCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/remote_create_dir_test.go
+++ b/internal/ui/remote_create_dir_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// A remote create whose path the server reports missing must not end as a
+// bare error in the footer: the TUI asks whether to create the directory on
+// that remote and, only on confirmation, retries with CreateDir set so the
+// server's `add --create-dir` makes it.
+
+func newRemoteDirNeededHome(t *testing.T) (*Home, *remoteCreateCapture) {
+	t.Helper()
+	setXDGTestHome(t)
+	h := newTestHomeWithItems(100, 30, nil)
+	capture := &remoteCreateCapture{}
+	h.remoteCreateSink = capture.sink
+	return h, capture
+}
+
+func missingDirMsg() remoteCreateDirNeededMsg {
+	return remoteCreateDirNeededMsg{
+		remoteName: "lab",
+		opts:       session.RemoteAddOptions{Tool: "claude", Title: "new work", Path: "/srv/new-project"},
+		err:        errors.New("ssh command failed: exit status 1: Error: path does not exist: /srv/new-project"),
+	}
+}
+
+func TestRemoteCreateMissingDir_ConfirmRetriesWithCreateDir(t *testing.T) {
+	h, capture := newRemoteDirNeededHome(t)
+
+	model, _ := h.Update(missingDirMsg())
+	h = model.(*Home)
+	if !h.confirmDialog.IsVisible() || h.confirmDialog.GetConfirmType() != ConfirmCreateDirectory {
+		t.Fatalf("missing remote path must open the create-directory confirmation, got visible=%v type=%v",
+			h.confirmDialog.IsVisible(), h.confirmDialog.GetConfirmType())
+	}
+	if got := h.confirmDialog.GetRemoteName(); got != "lab" {
+		t.Fatalf("confirmation remote = %q, want lab", got)
+	}
+	if capture.calls != 0 {
+		t.Fatalf("remote contacted %d times before the user confirmed, want 0", capture.calls)
+	}
+
+	model, _ = h.handleConfirmDialogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	h = model.(*Home)
+	if capture.calls != 1 {
+		t.Fatalf("remote create calls after confirm = %d, want 1", capture.calls)
+	}
+	if capture.remoteName != "lab" || !capture.opts.CreateDir || capture.opts.Path != "/srv/new-project" || capture.opts.Title != "new work" {
+		t.Fatalf("retry forwarded remote=%q opts=%+v; want the same dialog values on lab with CreateDir", capture.remoteName, capture.opts)
+	}
+	if h.confirmDialog.IsVisible() || h.pendingRemoteCreate != nil {
+		t.Fatal("confirmation must close and clear the pending create after retrying")
+	}
+}
+
+func TestRemoteCreateMissingDir_CancelCreatesNothing(t *testing.T) {
+	h, capture := newRemoteDirNeededHome(t)
+
+	model, _ := h.Update(missingDirMsg())
+	h = model.(*Home)
+	model, _ = h.handleConfirmDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	h = model.(*Home)
+	if capture.calls != 0 {
+		t.Fatalf("remote contacted %d times after cancel, want 0", capture.calls)
+	}
+	if h.confirmDialog.IsVisible() || h.pendingRemoteCreate != nil {
+		t.Fatal("cancel must close the confirmation and drop the pending create")
+	}
+}

--- a/internal/ui/remote_create_group_test.go
+++ b/internal/ui/remote_create_group_test.go
@@ -1,0 +1,221 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "g (create group) only creates LOCAL groups, even when
+// the cursor is on a remote row".
+//
+// The g-key dispatch in handleMainKey offered the create dialog without any
+// remote awareness, so confirming it created the group in the local tree via
+// GroupDialogCreate → groupTree.CreateGroup even though the cursor sat on a
+// remote session/header whose groups live in the remote's own state DB. These
+// tests pin the remote create path at the same dispatch boundary used by the
+// remote-move (#2081) and remote-shift-enter (#1100) tests: the dialog must
+// carry the remote name, and Enter must return an SSH-routed tea.Cmd instead
+// of mutating the local tree.
+
+// TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH pins the dispatch:
+// g on a remote-session row must open the create dialog scoped to that remote
+// (RemoteName == "lab"), and confirming it must return the SSH-routed create
+// cmd without touching the local group tree.
+func TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote session did not open the create dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogCreate {
+		t.Fatalf("expected GroupDialogCreate mode, got %v", home.groupDialog.Mode())
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	// The helper's cursor session lives in group "work", so the dialog
+	// defaults to root mode with Tab toggling to a subgroup under "work".
+	if home.groupDialog.CanToggle() {
+		if got := home.groupDialog.GetParentPath(); got != "" {
+			t.Fatalf("root-mode create should have no parent, got %q", got)
+		}
+	} else {
+		t.Fatal("grouped remote session create dialog should offer the Root/Subgroup toggle")
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the group lives on the remote.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote group create: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup pins the
+// header path: g on a remote group header opens the create dialog scoped to
+// that remote WITH the header's group as the parent (subgroup mode), so Enter
+// runs `group create <name> --parent <header>` on the remote.
+func TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Cursor sits on the "work" group header of remote "lab" (the session
+	// row keeps the header present in the flat list, as in the real TUI).
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			Path:       "remotes/lab/work",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab/work", Level: 1},
+	}
+	home.cursor = 1
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote group header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if !home.groupDialog.HasParent() {
+		t.Fatal("remote group header create should default to subgroup mode")
+	}
+	if got := home.groupDialog.GetParentPath(); got != "work" {
+		t.Fatalf("create dialog parent path = %q, want \"work\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("sub")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote subgroup create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup pins the
+// level-0 host-header path: g on "remotes/<name>" (the host header itself)
+// opens a root-level remote create with no parent.
+func TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab", Level: 0},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on the remote host header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if home.groupDialog.HasParent() {
+		t.Fatalf("host-header create should be root-level, got parent %q", home.groupDialog.GetParentPath())
+	}
+}
+
+// TestRemoteCreateGroup_LocalSessionStillCreatesLocally guards the other side
+// of the branch: g on a LOCAL session keeps creating the group in the local
+// tree, with no remote name and no SSH cmd.
+func TestRemoteCreateGroup_LocalSessionStillCreatesLocally(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.groupTree = session.NewGroupTree([]*session.Instance{})
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a local session did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "" {
+		t.Fatalf("local create dialog remoteName = %q, want \"\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local group create returned a non-nil cmd %v; local creates are synchronous", cmd)
+	}
+}
+
+// TestRemoteGroupResultMsgPatchesCache pins the create confirmation: when the
+// remote reports a successful `group create`, the new path is added to the
+// cached group list so the M move dialog offers it immediately (before the
+// next fleet poll re-confirms from the remote's own DB).
+func TestRemoteGroupResultMsgPatchesCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{"lab": {"work"}}
+	home.remoteSessionsMu.Unlock()
+
+	model, _ := home.Update(remoteGroupResultMsg{remoteName: "lab", groupPath: "work/newgroup"})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"work", "work/newgroup"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/ui/remote_fork_test.go
+++ b/internal/ui/remote_fork_test.go
@@ -1,0 +1,161 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "f (quick fork) does nothing on remote sessions".
+//
+// The f-key dispatch in handleMainKey only forked ItemTypeSession rows, so
+// pressing f on a remote-session row was a silent no-op. These tests pin the
+// remote fork path at the same dispatch boundary used by the remote move and
+// remote group-create tests: the key must return the SSH-routed cmd, guard
+// against a duplicate fork while one is in flight, and refresh the fleet
+// list once the remote confirms. The SSH arguments themselves are covered by
+// TestSSHRunnerForkSession_* in the session package.
+
+func armHomeWithOneRemoteSessionForFork(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"lab": {{ID: "remote-id-xyz", Title: "remote session", Group: "work", Tool: "claude"}},
+	}
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+				Tool:  "claude",
+			},
+		},
+	}
+	home.cursor = 0
+	return home
+}
+
+// TestRemoteFork_FKeyReturnsForkCmd pins the dispatch: f on a remote-session
+// row must return the SSH-routed fork cmd, mark the row as forking, and must
+// not touch the local instance list.
+func TestRemoteFork_FKeyReturnsForkCmd(t *testing.T) {
+	home := armHomeWithOneRemoteSessionForFork(t)
+
+	model, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd == nil {
+		t.Fatal("f on a remote session returned a nil cmd; expected the SSH-routed fork")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+	if _, forking := home.forkingSessions[remoteRestartAnimationID("lab", "remote-id-xyz")]; !forking {
+		t.Fatal("remote row was not marked as forking")
+	}
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote fork: %d rows", len(home.instances))
+	}
+	if home.forkDialog.IsVisible() {
+		t.Fatal("quick fork on a remote session must not open the fork dialog")
+	}
+}
+
+// TestRemoteFork_SecondFIsRefusedWhileInFlight pins the duplicate guard: a
+// second f while the remote has not answered yet must not issue another fork.
+func TestRemoteFork_SecondFIsRefusedWhileInFlight(t *testing.T) {
+	home := armHomeWithOneRemoteSessionForFork(t)
+
+	if _, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}}); cmd == nil {
+		t.Fatal("first f returned a nil cmd")
+	}
+	if _, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}}); cmd != nil {
+		t.Fatal("second f while forking returned a cmd; expected the in-flight guard to refuse it")
+	}
+	if home.err == nil {
+		t.Fatal("second f while forking did not explain why it was refused")
+	}
+}
+
+// TestRemoteFork_ForkedMsgRefreshesFleet pins the confirmation path: once the
+// remote reports the fork, the in-flight guard clears and the remote session
+// list is fetched again so the new row appears.
+func TestRemoteFork_ForkedMsgRefreshesFleet(t *testing.T) {
+	home := armHomeWithOneRemoteSessionForFork(t)
+	forkID := remoteRestartAnimationID("lab", "remote-id-xyz")
+	if _, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}}); cmd == nil {
+		t.Fatal("f returned a nil cmd")
+	}
+
+	model, cmd := home.Update(remoteSessionForkedMsg{remoteName: "lab", sessionID: "remote-id-xyz", title: "remote session", newID: "child-1"})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+	if cmd == nil {
+		t.Fatal("successful remote fork returned a nil cmd; expected a remote session refresh")
+	}
+	if _, forking := h.forkingSessions[forkID]; forking {
+		t.Fatal("in-flight guard not cleared after the remote confirmed the fork")
+	}
+
+	// A second f must be accepted again now that the first fork finished.
+	if _, cmd := h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}}); cmd == nil {
+		t.Fatal("f after a finished fork returned a nil cmd")
+	}
+}
+
+// TestRemoteFork_ForkedMsgErrorClearsGuard pins the failure path: the error
+// is shown, the guard clears, and no refresh is issued for a fork that never
+// happened.
+func TestRemoteFork_ForkedMsgErrorClearsGuard(t *testing.T) {
+	home := armHomeWithOneRemoteSessionForFork(t)
+	forkID := remoteRestartAnimationID("lab", "remote-id-xyz")
+	if _, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}}); cmd == nil {
+		t.Fatal("f returned a nil cmd")
+	}
+
+	model, cmd := home.Update(remoteSessionForkedMsg{remoteName: "lab", sessionID: "remote-id-xyz", title: "remote session", err: errors.New("not a forkable session (tool: gemini)")})
+	h := model.(*Home)
+	if cmd != nil {
+		t.Fatal("failed remote fork returned a cmd; expected no refresh")
+	}
+	if _, forking := h.forkingSessions[forkID]; forking {
+		t.Fatal("in-flight guard not cleared after the remote refused the fork")
+	}
+	if h.err == nil {
+		t.Fatal("remote fork failure was not surfaced")
+	}
+}
+
+// TestRemoteFork_ShiftFExplainsInsteadOfDialog guards the other fork key: F
+// (fork dialog) on a remote row must not open the local-git-backed dialog and
+// must point at f instead.
+func TestRemoteFork_ShiftFExplainsInsteadOfDialog(t *testing.T) {
+	home := armHomeWithOneRemoteSessionForFork(t)
+
+	_, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
+	if cmd != nil {
+		t.Fatal("F on a remote session returned a cmd")
+	}
+	if home.forkDialog.IsVisible() {
+		t.Fatal("F on a remote session opened the local fork dialog")
+	}
+	if home.err == nil {
+		t.Fatal("F on a remote session gave no hint")
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "M (move to group) does nothing on remote sessions".
+//
+// The M-key dispatch in handleMainKey only offered the move dialog for
+// ItemTypeSession, so pressing M on a remote-session row was a silent no-op
+// even though the remote-rename path (GroupDialogRenameSession) already knows
+// how to mutate a remote session over SSH. These tests pin the remote move
+// path at the same dispatch boundary used by the #1100 remote-shift-enter
+// tests.
+
+// armHomeWithOneRemoteSessionInGroups sets up a Home whose cursor sits on a
+// remote session row, with a populated remote fleet cache so remoteGroupPaths
+// has something to offer. The remote is declared in $HOME's config.toml so
+// any executed SSH command can resolve it (tests that would execute SSH only
+// assert the returned tea.Cmd is non-nil and never run it).
+func armHomeWithOneRemoteSessionInGroups(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Remote fleet cache: two sessions across two groups, plus the row the
+	// cursor will sit on.
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"lab": {
+			{ID: "remote-id-xyz", Title: "remote session", Group: "work"},
+			{ID: "remote-id-abc", Title: "other session", Group: "personal"},
+			{ID: "remote-id-ungrouped", Title: "loose session", Group: ""},
+		},
+	}
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+	}
+	home.cursor = 0
+	return home
+}
+
+// TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups pins the dispatch:
+// pressing M on a remote-session row must open the move dialog (the same one
+// local sessions get) with the groups observed on that remote.
+func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogMove {
+		t.Fatalf("expected GroupDialogMove mode, got %v", home.groupDialog.Mode())
+	}
+
+	// The dialog must offer the remote's own groups (normalized, sorted,
+	// deduped) — not the local group tree, which knows nothing about the
+	// remote. Empty remote group normalizes to the default group path.
+	want := []string{"my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
+// the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
+// must NOT mutate the local group tree.
+func TestRemoteMoveToGroup_EnterReturnsMoveCmd(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote move dialog returned a nil cmd; expected the SSH-routed move")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the remote row is not a local
+	// instance, so MoveSessionToGroup must never have been called.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote move: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree guards the other side
+// of the branch: moving a LOCAL session must keep using the local tree and
+// return no SSH cmd.
+func TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a local session did not open the move dialog")
+	}
+
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local move returned a non-nil cmd %v; local moves are synchronous", cmd)
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -89,6 +89,79 @@ func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
 	}
 }
 
+// TestRemoteMoveToGroup_MKeyIncludesEmptyGroups pins the empty-folder fix:
+// the move dialog must offer groups that currently hold NO sessions on the
+// remote (a folder left empty after every session was moved out of it).
+// Session-derived buckets can never contain an empty group, so this relies on
+// the fleet poll's cached `group list --json` (Home.remoteGroups) being
+// unioned into remoteGroupPaths.
+func TestRemoteMoveToGroup_MKeyIncludesEmptyGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	// The remote's own group DB reports an extra EMPTY folder (no sessions):
+	// it must still be offered as a move target.
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{
+		"lab": {"empty-folder", "personal", "work"},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	// Union of the remote's own group list (incl. the empty folder) and the
+	// session-derived groups (empty remote group normalizes to my-sessions).
+	want := []string{"empty-folder", "my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteSessionsFetchedMsgPopulatesGroupCache pins the fleet-poll wiring:
+// the remote group lists carried on remoteSessionsFetchedMsg land in
+// Home.remoteGroups (guarded by remoteSessionsMu), which is what the M move
+// dialog reads to offer empty remote folders.
+func TestRemoteSessionsFetchedMsgPopulatesGroupCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"lab": {{ID: "x", Title: "s", Group: "work"}},
+		},
+		groups: map[string][]string{
+			"lab": {"empty-folder", "work"},
+		},
+	})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"empty-folder", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 // TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
 // the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
 // must NOT mutate the local group tree.


### PR DESCRIPTION
## What problem does this solve?

Pressing `f` (quick fork) on a remote session row in the TUI did nothing, even though the remote's own CLI can fork that session. Part of #2156.

## Why this change

Same forwarding pattern as #2155 and #2157: the TUI key handler routes the action over SSH to the remote's own CLI verb (`session fork --json <id>`) through a new `SSHRunner.ForkSession`, and `fork` joins the `remote <name> session` passthrough allow-list so the CLI form works too. Title, group and tool eligibility stay server decisions (parent title with `-fork`, parent's group), so the TUI result is exactly what `agent-deck remote lab session fork <id>` produces; no client-side guessing about the remote's tool state or git checkout. The `F` fork dialog stays local only, since its worktree and branch fields inspect local git state; on a remote row it now says so and points at `f`. After the remote confirms, the remote session list is fetched again so the new row appears. No data model change on either side.

## User impact

`f` on a remote session forks it on that remote; `F` on a remote row explains why the dialog is not offered. `agent-deck remote <name> session fork <id> [flags]` is now accepted on the command line. Nothing changes for users without remotes.

## Evidence

Local go test is disallowed on this host; full suite runs in CI on this PR.

Build and vet on the branch:

```
$ gofmt -l ./cmd ./internal
$ go build ./... && go vet ./internal/session/ ./internal/ui/ ./cmd/agent-deck/
VET_OK
```

New tests: `TestSSHRunnerForkSession_ForwardsForkVerb` and `TestSSHRunnerForkSession_ErrorsAreNotIDs` (stubbed runner: exact forwarded args `session fork --json <id>`, `new_id` parsing, errors never yield an ID), `TestRemoteFork_*` in `internal/ui/remote_fork_test.go` (dispatch returns the SSH cmd, in-flight guard, success refreshes the fleet list, failure clears the guard, `F` hint), plus `session fork missing --json` added to the remote command parity list.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

**Prompt / session log (optional):**

## What actually bothered you

My human asked: "can I use the remote side from the TUI seamlessly like I would do locally? That is the idea, from the TUI please."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
