### PR TITLE
feat(ui): archive and unarchive remote sessions from the TUI

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1440,6 +1440,11 @@ func handleAdd(profile string, args []string) {
 		return nil
 	})
 
+	// --create-dir is what the TUI's remote new-session dialog forwards after
+	// the user confirms creating a missing directory on the server; the local
+	// dialog asks the same question and calls os.MkdirAll itself.
+	createDir := fs.Bool("create-dir", false, "Create the project directory when it does not exist (like mkdir -p)")
+
 	// Sandbox flags
 	sandbox := fs.Bool("sandbox", false, "Run session in Docker sandbox")
 	sandboxImage := fs.String("sandbox-image", "", "Docker image for sandbox (overrides config default)")
@@ -1725,6 +1730,13 @@ func handleAdd(profile string, args []string) {
 		path = localPlaceholder
 	} else {
 		info, err := os.Stat(path)
+		if err != nil && *createDir {
+			if mkErr := os.MkdirAll(path, 0o755); mkErr != nil {
+				fmt.Printf("Error: failed to create directory %s: %v\n", path, mkErr)
+				os.Exit(1)
+			}
+			info, err = os.Stat(path)
+		}
 		if err != nil {
 			fmt.Printf("Error: path does not exist: %s\n", path)
 			os.Exit(1)

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -123,7 +123,7 @@ func printRemoteUsage() {
 	fmt.Println("Manage remote agent-deck instances.")
 	fmt.Println("Run commands: agent-deck remote <name> <command> [arguments]")
 	fmt.Println("  Use remote exec <name> <command> when a name matches a management command.")
-	fmt.Println("  list/status, show/output/send, add/launch, session start/stop/restart,")
+	fmt.Println("  list/status, show/output/send, add/launch, session start/stop/restart/archive/unarchive,")
 	fmt.Println("  worktree list/info/cleanup, mcp attach, skill attach")
 	fmt.Println()
 	fmt.Println("Commands:")

--- a/cmd/agent-deck/remote_exec.go
+++ b/cmd/agent-deck/remote_exec.go
@@ -24,7 +24,7 @@ func remoteCommandArgs(args []string) ([]string, error) {
 		case "session":
 			if len(args) > 1 {
 				switch args[1] {
-				case "show", "output", "send", "start", "stop", "restart":
+				case "show", "output", "send", "start", "stop", "restart", "archive", "unarchive":
 					return append([]string(nil), args...), nil
 				}
 			}

--- a/cmd/agent-deck/remote_exec_test.go
+++ b/cmd/agent-deck/remote_exec_test.go
@@ -101,6 +101,7 @@ func TestRemoteCommandParity(t *testing.T) {
 		{"list", "--json"}, {"status", "--json"}, {"session", "show", title, "--json"},
 		{"session", "output", "missing", "--json"}, {"session", "start", "missing", "--json"},
 		{"session", "stop", "missing", "--json"}, {"session", "restart", "missing", "--json"},
+		{"session", "archive", "missing", "--json"}, {"session", "unarchive", "missing", "--json"},
 		{"worktree", "info", "missing", "--json"}, {"mcp", "attach", "missing", "none", "--json"},
 		{"skill", "attach", "missing", "none"},
 	} {
@@ -391,4 +392,18 @@ func TestRemoteCommandParity(t *testing.T) {
 		t.Errorf("explicit exec: %d %q %q", code, out, stderr)
 	}
 
+}
+
+// The passthrough allow-list must admit the session archive/unarchive verbs
+// the TUI forwards, and keep refusing anything it does not name.
+func TestRemoteCommandArgsSessionArchiveVerbs(t *testing.T) {
+	for _, args := range [][]string{{"session", "archive", "id"}, {"session", "unarchive", "id", "--json"}} {
+		got, err := remoteCommandArgs(args)
+		if err != nil || !reflect.DeepEqual(got, args) {
+			t.Fatalf("remoteCommandArgs(%v) = %v, %v; want the args unchanged", args, got, err)
+		}
+	}
+	if _, err := remoteCommandArgs([]string{"session", "remove", "id"}); err == nil {
+		t.Fatal("session remove must stay unsupported")
+	}
 }

--- a/docs/REMOTE-COMMANDS.md
+++ b/docs/REMOTE-COMMANDS.md
@@ -49,6 +49,7 @@ Pressing `n` on a remote group or session opens the same new-session dialog as f
 | Docker sandbox | `-sandbox`; the image comes from the server's config |
 | Worktree | `-w <branch>`; the worktree and, when missing, the branch are created in the server's repository. An auto-filled branch travels as the bare slug and the server applies its own `[worktree].branch_prefix` once; a branch you type is sent as entered |
 | Codex and Gemini YOLO | `--yolo` |
+| A path that does not exist on the server | the server refuses the create; the TUI then asks "create this directory on remote `<name>`?" and, only if you confirm, retries with `--create-dir` so the server runs the equivalent of `mkdir -p`. A remote running an agent-deck older than `--create-dir` refuses the retry with an unknown-flag error; create the directory there by hand |
 
 Because the server applies its own defaults, the dialog opens with these options cleared for a remote target instead of pre-filled from your local `config.toml`; a local `[claude].dangerous_mode` or `default_model` never reaches a remote unless you set it in the dialog.
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -258,7 +258,13 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("ssh command failed: %w: %s", err, stderr.String())
+		// The remote CLI reports refusals such as "path does not exist" on
+		// stdout; fall back to it so the failure is not a bare exit status.
+		detail := stderr.String()
+		if strings.TrimSpace(detail) == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		return nil, fmt.Errorf("ssh command failed: %w: %s", err, detail)
 	}
 
 	return stdout.Bytes(), nil
@@ -1127,6 +1133,21 @@ type RemoteAddOptions struct {
 	// WorktreeBranch creates the session in a git worktree for this branch on
 	// the server (-w); the branch is created there when it does not exist.
 	WorktreeBranch string
+	// CreateDir asks the server to create a missing Path (--create-dir). The
+	// TUI sets it only after the server reported the path missing and the
+	// user confirmed; a remote too old for the flag refuses the command.
+	CreateDir bool
+}
+
+// remoteMissingPathMarker is the text the remote `add` prints when its
+// project directory does not exist (see the add command's os.Stat check).
+const remoteMissingPathMarker = "path does not exist"
+
+// IsRemotePathMissing reports whether a remote create failed because the
+// project directory does not exist on the server, so the caller can offer to
+// create it and retry with RemoteAddOptions.CreateDir.
+func IsRemotePathMissing(err error) bool {
+	return err != nil && strings.Contains(err.Error(), remoteMissingPathMarker)
 }
 
 // remoteAddArgs builds the `agent-deck add` argument list for creating a
@@ -1186,6 +1207,9 @@ func remoteAddArgs(o RemoteAddOptions) ([]string, error) {
 	}
 	if b := strings.TrimSpace(o.WorktreeBranch); b != "" {
 		args = append(args, "-w", b)
+	}
+	if o.CreateDir {
+		args = append(args, "--create-dir")
 	}
 	if p := strings.TrimSpace(o.Path); p != "" && p != "." {
 		args = append(args, p)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -684,6 +685,69 @@ func (r *SSHRunner) FetchSessionPane(ctx context.Context, sessionID string) (str
 	}
 
 	return parseRemoteSessionOutput(output)
+}
+
+// groupListJSON mirrors the subset of `agent-deck group list --json` output
+// the TUI needs: the recursive group path tree. Counts and status are
+// ignored — a group with zero sessions is still a valid move/create target.
+type groupListJSON struct {
+	Groups []groupListEntryJSON `json:"groups"`
+}
+
+type groupListEntryJSON struct {
+	Path     string               `json:"path"`
+	Children []groupListEntryJSON `json:"children,omitempty"`
+}
+
+// FetchGroupPaths retrieves the remote's full group path list from its own
+// state DB via `agent-deck group list --json`. Unlike session-derived group
+// buckets (which can only ever contain groups that currently hold sessions),
+// the remote's group list includes EMPTY groups, so the local move dialog (M
+// key on a remote session) can still offer a folder after every session has
+// been moved out of it. Paths are normalized, deduped and sorted.
+//
+// Returns nil with no error when the remote returns empty output (older
+// agent-deck builds that predate the JSON shape); callers fall back to the
+// groups observed on the fetched sessions.
+func (r *SSHRunner) FetchGroupPaths(ctx context.Context) ([]string, error) {
+	output, err := r.Run(ctx, "group", "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, nil
+	}
+
+	var parsed groupListJSON
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse remote group list: %w", err)
+	}
+
+	return parseGroupListPaths(parsed), nil
+}
+
+// parseGroupListPaths flattens the recursive group tree from `group list
+// --json` into normalized, deduped, sorted group paths. Extracted as a pure
+// function so the parsing is unit-testable without an SSH round-trip.
+func parseGroupListPaths(parsed groupListJSON) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	var walk func(entries []groupListEntryJSON)
+	walk = func(entries []groupListEntryJSON) {
+		for _, e := range entries {
+			p := strings.Trim(strings.TrimSpace(e.Path), "/")
+			if p != "" && !seen[p] {
+				seen[p] = true
+				paths = append(paths, p)
+			}
+			walk(e.Children)
+		}
+	}
+	walk(parsed.Groups)
+	sort.Strings(paths)
+	return paths
 }
 
 // FetchCostSummary retrieves the remote agent-deck's cost summary as JSON.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1284,6 +1284,21 @@ func (r *SSHRunner) RestartSession(ctx context.Context, sessionID string) error 
 	return err
 }
 
+// ArchiveSession stops a session on the remote host and marks it archived
+// there (the remote's own `session archive`), so the remote's archived list
+// is the one source of truth and the next `list --json` reports it archived.
+func (r *SSHRunner) ArchiveSession(ctx context.Context, sessionID string) error {
+	_, err := r.Run(ctx, "session", "archive", sessionID)
+	return err
+}
+
+// UnarchiveSession clears the archive flag on the remote host without
+// restarting the session (the remote's own `session unarchive`).
+func (r *SSHRunner) UnarchiveSession(ctx context.Context, sessionID string) error {
+	_, err := r.Run(ctx, "session", "unarchive", sessionID)
+	return err
+}
+
 // RemoteSessionInfo represents a session from a remote agent-deck instance.
 type RemoteSessionInfo struct {
 	ID        string `json:"id"`

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -572,5 +573,69 @@ func TestSSHRunnerCreateSessionWithOptions_RefusedValueNeverContactsRemote(t *te
 	}
 	if calls != 0 {
 		t.Fatalf("remote contacted %d times for a refused value, want 0", calls)
+	}
+}
+
+// TestParseGroupListPaths pins the group-list flattener that backs
+// SSHRunner.FetchGroupPaths: `group list --json` returns a recursive tree
+// whose paths (including EMPTY groups — session_count 0) must all surface,
+// deduped and sorted, for the remote move/create dialogs.
+func TestParseGroupListPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty list",
+			input: `{"groups":[],"total_groups":0,"total_sessions":0}`,
+			want:  []string{},
+		},
+		{
+			name: "flat groups incl. an empty one",
+			input: `{"groups":[
+				{"name":"emptytest","path":"emptytest","session_count":0},
+				{"name":"work","path":"work","session_count":3}
+			],"total_groups":2,"total_sessions":3}`,
+			want: []string{"emptytest", "work"},
+		},
+		{
+			name: "nested children flattened with full paths",
+			input: `{"groups":[
+				{"name":"my-sessions","path":"my-sessions","session_count":7,
+				 "children":[
+					{"name":"done","path":"my-sessions/done","session_count":6,
+					 "children":[
+						{"name":"deep","path":"my-sessions/done/deep","session_count":0}
+					 ]}
+				 ]}
+			],"total_groups":3,"total_sessions":7}`,
+			want: []string{"my-sessions", "my-sessions/done", "my-sessions/done/deep"},
+		},
+		{
+			name: "slashes and whitespace normalized",
+			input: `{"groups":[
+				{"name":"a","path":"/a/","session_count":0}
+			],"total_groups":1,"total_sessions":0}`,
+			want: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var parsed groupListJSON
+			if err := json.Unmarshal([]byte(tt.input), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := parseGroupListPaths(parsed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseGroupListPaths = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseGroupListPaths[%d] = %q, want %q (all: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
 	}
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -197,6 +197,11 @@ func TestRemoteAddArgs(t *testing.T) {
 			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "/srv/project"},
 		},
 		{
+			name: "create a missing remote directory only after confirmation",
+			opts: RemoteAddOptions{Tool: "codex", Title: "fix", Path: "/srv/new", CreateDir: true},
+			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "--create-dir", "/srv/new"},
+		},
+		{
 			name: "tool without title auto-names via --quick",
 			opts: RemoteAddOptions{Tool: "pi"},
 			want: []string{"add", "--json", "--quick", "-c", "pi"},
@@ -637,5 +642,19 @@ func TestParseGroupListPaths(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The remote `add` reports a missing project directory on stdout; the TUI
+// recognises that refusal to offer creating the directory, and nothing else.
+func TestIsRemotePathMissing(t *testing.T) {
+	if !IsRemotePathMissing(errors.New("ssh command failed: exit status 1: Error: path does not exist: /srv/new")) {
+		t.Fatal("missing-path refusal not recognised")
+	}
+	if IsRemotePathMissing(errors.New("ssh command failed: exit status 255: connection refused")) {
+		t.Fatal("unrelated failure treated as a missing path")
+	}
+	if IsRemotePathMissing(nil) {
+		t.Fatal("nil error treated as a missing path")
 	}
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -658,3 +658,37 @@ func TestIsRemotePathMissing(t *testing.T) {
 		t.Fatal("nil error treated as a missing path")
 	}
 }
+
+// Archive/unarchive forward to the remote's own `session archive` /
+// `session unarchive` verbs with the session id as the only operand, so the
+// remote's archived list stays the single source of truth.
+func TestSSHRunnerArchiveSession_ForwardsRemoteVerbs(t *testing.T) {
+	var calls [][]string
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			return []byte(`{"success":true}`), nil
+		},
+	}
+	if err := runner.ArchiveSession(context.Background(), "abc123"); err != nil {
+		t.Fatalf("ArchiveSession: %v", err)
+	}
+	if err := runner.UnarchiveSession(context.Background(), "abc123"); err != nil {
+		t.Fatalf("UnarchiveSession: %v", err)
+	}
+	want := "session archive abc123|session unarchive abc123"
+	got := make([]string, 0, len(calls))
+	for _, c := range calls {
+		got = append(got, strings.Join(c, " "))
+	}
+	if strings.Join(got, "|") != want {
+		t.Fatalf("remote commands = %q, want %q", strings.Join(got, "|"), want)
+	}
+
+	failing := &SSHRunner{runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, errors.New("session 'abc123' is already archived")
+	}}
+	if err := failing.ArchiveSession(context.Background(), "abc123"); err == nil {
+		t.Fatal("a remote refusal must surface as an error")
+	}
+}

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -21,6 +21,8 @@ const (
 	ConfirmInstallHooks
 	ConfirmDeleteRemoteSession
 	ConfirmCloseRemoteSession
+	ConfirmArchiveRemoteSession
+	ConfirmUnarchiveRemoteSession
 	ConfirmRemoveSession     // status-gated registry-only remove (TUI 'X')
 	ConfirmBulkRemoveErrored // bulk remove of all errored sessions (TUI Ctrl+X)
 	ConfirmArchiveSession
@@ -132,6 +134,29 @@ func (c *ConfirmDialog) ShowDeleteRemoteSession(remoteName, sessionID, sessionNa
 func (c *ConfirmDialog) ShowCloseRemoteSession(remoteName, sessionID, sessionName string) {
 	c.visible = true
 	c.confirmType = ConfirmCloseRemoteSession
+	c.targetID = sessionID
+	c.targetName = sessionName
+	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
+}
+
+// ShowArchiveRemoteSession shows the archive confirmation for a remote session.
+// Same wording and keys as the local archive dialog, plus the remote name.
+func (c *ConfirmDialog) ShowArchiveRemoteSession(remoteName, sessionID, sessionName string) {
+	c.visible = true
+	c.confirmType = ConfirmArchiveRemoteSession
+	c.targetID = sessionID
+	c.targetName = sessionName
+	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
+}
+
+// ShowUnarchiveRemoteSession shows the unarchive confirmation for a remote session.
+func (c *ConfirmDialog) ShowUnarchiveRemoteSession(remoteName, sessionID, sessionName string) {
+	c.visible = true
+	c.confirmType = ConfirmUnarchiveRemoteSession
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.remoteName = remoteName
@@ -385,10 +410,15 @@ func (c *ConfirmDialog) View() string {
 		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
 			hintStyle.Render("y delete · n cancel · ←/→ navigate · Enter select · Esc"))
 
-	case ConfirmArchiveSession:
+	case ConfirmArchiveSession, ConfirmArchiveRemoteSession:
 		title = "Archive Session?"
 		warning = fmt.Sprintf("Archive this session:\n\n  \"%s\"", c.targetName)
 		details = "• The tmux process will be stopped\n• The session will move to the archived list\n• You can unarchive later (^ view, Shift+U restore)"
+		if c.confirmType == ConfirmArchiveRemoteSession {
+			title = "Archive Remote Session?"
+			warning = fmt.Sprintf("Archive this session:\n\n  \"%s\" on %s", c.targetName, c.remoteName)
+			details = "• The remote tmux process will be stopped\n• The session will move to the remote's archived list\n• You can unarchive later (^ view, Shift+U restore)"
+		}
 		borderColor = ColorYellow
 		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
 			renderButton("Archive", ColorYellow, c.focusedButton == 0), "  ",
@@ -396,9 +426,13 @@ func (c *ConfirmDialog) View() string {
 		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
 			hintStyle.Render("y archive · n cancel · ←/→ navigate · Enter select · Esc"))
 
-	case ConfirmUnarchiveSession:
+	case ConfirmUnarchiveSession, ConfirmUnarchiveRemoteSession:
 		title = "Unarchive Session?"
 		warning = fmt.Sprintf("Restore this session to the active list:\n\n  \"%s\"", c.targetName)
+		if c.confirmType == ConfirmUnarchiveRemoteSession {
+			title = "Unarchive Remote Session?"
+			warning = fmt.Sprintf("Restore this session to the active list:\n\n  \"%s\" on %s", c.targetName, c.remoteName)
+		}
 		details = "• Metadata returns to the main session list\n• The process is not started automatically"
 		borderColor = ColorGreen
 		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -260,6 +260,19 @@ func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath stri
 	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingClaudeAccount, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
 }
 
+// ShowCreateRemoteDirectory asks whether to create a directory the remote
+// reported missing (see session.IsRemotePathMissing) and retry the create
+// there with --create-dir. The pending dialog values stay on Home.
+func (c *ConfirmDialog) ShowCreateRemoteDirectory(remoteName, path string) {
+	c.visible = true
+	c.confirmType = ConfirmCreateDirectory
+	c.targetID = path
+	c.targetName = path
+	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
+}
+
 // Hide hides the dialog.
 func (c *ConfirmDialog) Hide() {
 	c.visible = false
@@ -477,6 +490,9 @@ func (c *ConfirmDialog) View() string {
 	case ConfirmCreateDirectory:
 		title = "📁  Directory Not Found"
 		warning = fmt.Sprintf("The path does not exist:\n\n  %s", c.targetName)
+		if c.remoteName != "" {
+			warning = fmt.Sprintf("The path does not exist on remote %s:\n\n  %s", c.remoteName, c.targetName)
+		}
 		details = "Create this directory and start the session?"
 		borderColor = ColorAccent
 		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -38,6 +38,12 @@ type GroupDialog struct {
 	// Tab toggle between Root and Subgroup modes (Issue #111)
 	contextParentPath string // Original cursor context parent path (for toggling back)
 	contextParentName string // Original cursor context parent name (for toggling back)
+
+	// remoteName is non-empty when the dialog was opened on a REMOTE row
+	// (g key on a remote session/group header). The group is then created in
+	// the remote's own state DB via SSH instead of the local group tree; the
+	// create handler in home.go uses RemoteName() to pick the routing.
+	remoteName string
 }
 
 // NewGroupDialog creates a new group dialog
@@ -64,7 +70,8 @@ func NewGroupDialog() *GroupDialog {
 func (g *GroupDialog) Show() {
 	g.visible = true
 	g.mode = GroupDialogCreate
-	g.groupPath = "" // No parent = root level
+	g.remoteName = "" // local
+	g.groupPath = ""  // No parent = root level
 	g.parentName = ""
 	g.validationErr = ""
 	g.nameInput.SetValue("")
@@ -77,6 +84,7 @@ func (g *GroupDialog) Show() {
 func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = ""        // local
 	g.groupPath = parentPath // Parent path for the new subgroup
 	g.parentName = parentName
 	g.validationErr = ""
@@ -92,6 +100,7 @@ func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 func (g *GroupDialog) ShowCreateWithContext(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = "" // local
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
 	g.validationErr = ""
@@ -119,6 +128,57 @@ func (g *GroupDialog) ShowCreateWithContextDefaultRoot(parentPath, parentName st
 	g.mode = GroupDialogCreate
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
+	g.remoteName = "" // local
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	// Default to root mode, Tab toggles to subgroup
+	g.groupPath = ""
+	g.parentName = ""
+}
+
+// ShowCreateRemoteWithContext opens the create dialog for a REMOTE context
+// (g key on a remote group header): the new group is created on the remote
+// host via SSH (see home.go createRemoteGroup), with parentPath set to the
+// header's own group path so the remote creates a subgroup under it. Pass an
+// empty parentPath for the level-0 host header (root-level remote group).
+func (g *GroupDialog) ShowCreateRemoteWithContext(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	if parentPath != "" {
+		// Default to subgroup mode
+		g.groupPath = parentPath
+		g.parentName = parentName
+	} else {
+		// Root mode, no toggle
+		g.groupPath = ""
+		g.parentName = ""
+	}
+}
+
+// ShowCreateRemoteWithContextDefaultRoot is the remote counterpart of
+// ShowCreateWithContextDefaultRoot: opens the create dialog defaulting to
+// root mode on the remote, storing the cursor context so Tab can toggle to
+// subgroup mode under the session's current group. The created group is
+// routed to the remote's own state DB (home.go createRemoteGroup).
+func (g *GroupDialog) ShowCreateRemoteWithContextDefaultRoot(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
@@ -157,6 +217,7 @@ func (g *GroupDialog) ToggleRootSubgroup() {
 func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRename
+	g.remoteName = "" // not a create
 	g.groupPath = currentPath
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -170,6 +231,7 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 func (g *GroupDialog) ShowMove(groupPaths []string) {
 	g.visible = true
 	g.mode = GroupDialogMove
+	g.remoteName = "" // not a create; reset any stale remote create context
 	g.validationErr = ""
 	g.groupPaths = groupPaths
 	g.selected = 0
@@ -179,6 +241,7 @@ func (g *GroupDialog) ShowMove(groupPaths []string) {
 func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRenameSession
+	g.remoteName = "" // not a create
 	g.sessionID = sessionID
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -193,9 +256,17 @@ func (g *GroupDialog) GetSessionID() string {
 	return g.sessionID
 }
 
+// RemoteName returns the remote the create dialog is scoped to (g key on a
+// remote row), or "" when the dialog creates a LOCAL group. The create
+// handler routes to the remote's own state DB via SSH when non-empty.
+func (g *GroupDialog) RemoteName() string {
+	return g.remoteName
+}
+
 // Hide hides the dialog
 func (g *GroupDialog) Hide() {
 	g.visible = false
+	g.remoteName = ""
 	g.nameInput.Blur()
 }
 
@@ -399,6 +470,15 @@ func (g *GroupDialog) View() string {
 		} else {
 			title = "Create New Group"
 			content = fields
+		}
+
+		// Remote create (g on a remote row): make the routing explicit so the
+		// user knows the group will be created on the remote host, not locally.
+		if g.remoteName != "" {
+			remoteInfo := lipgloss.NewStyle().
+				Foreground(ColorCyan).
+				Render("Remote: " + g.remoteName)
+			content = remoteInfo + "\n\n" + content
 		}
 
 		// Add Root/Subgroup toggle indicator when Tab toggle is available

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -624,9 +624,15 @@ type Home struct {
 	uiStateSaveTicks     int      // Counter for periodic UI state saves in tick handler
 
 	// Remote sessions (Phase 2: Agent-Deck Remotes)
-	remoteSessions     map[string][]session.RemoteSessionInfo // remoteName -> sessions
-	remoteFromCache    map[string]bool                        // remoteName -> data is a startup cache snapshot, not live yet
-	remoteFetchedAt    map[string]time.Time                   // remoteName -> when its sessions last came from a live fetch
+	remoteSessions map[string][]session.RemoteSessionInfo // remoteName -> sessions
+	// remoteGroups holds each remote's FULL group path list as reported by
+	// its own state DB (`agent-deck group list --json`, fetched on the same
+	// fleet poll). Unlike session-derived buckets it includes EMPTY groups,
+	// so the M move dialog can still offer a remote folder after every
+	// session has been moved out of it. Guarded by remoteSessionsMu.
+	remoteGroups       map[string][]string  // remoteName -> sorted group paths (incl. empty groups)
+	remoteFromCache    map[string]bool      // remoteName -> data is a startup cache snapshot, not live yet
+	remoteFetchedAt    map[string]time.Time // remoteName -> when its sessions last came from a live fetch
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
@@ -1396,6 +1402,14 @@ type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
 	// #1101: per-remote cost summary collected on the same SSH fanout.
 	costs map[string]*costs.RemoteCostSummary
+	// groups holds each remote's FULL group path list (incl. empty groups)
+	// from `group list --json`, so the move/create dialogs can offer folders
+	// that currently hold no sessions. Only remotes that reported a fresh
+	// list appear here.
+	groups map[string][]string
+	// groupsFailed marks remotes whose group-list fetch errored this round;
+	// the handler keeps their last-good cached group paths.
+	groupsFailed map[string]bool
 	// failed marks remotes whose fetch errored this round (issue #1170).
 	// The handler keeps their last-good sessions instead of wiping them,
 	// so one slow/offline remote can't flicker the whole list.
@@ -2120,21 +2134,31 @@ func (h *Home) scopedGroupPaths() []string {
 	return scoped
 }
 
-// remoteGroupPaths returns the distinct, normalized group paths currently
-// observed on a remote, sorted for the move dialog (M key on a remote
-// session). These are the only groups the remote knows about; a remote move
-// is executed with `agent-deck group move <id> <group>` on that host.
+// remoteGroupPaths returns the distinct, normalized group paths available as
+// move targets on a remote, sorted for the move dialog (M key on a remote
+// session). The remote's own group list (fetched on the fleet poll via
+// `group list --json`) is the primary source: unlike session-derived buckets
+// it includes EMPTY groups, so a folder that currently holds no sessions is
+// still offered after every session has been moved out of it. Groups observed
+// on the fetched sessions are unioned in as a fallback for remotes whose
+// group-list fetch failed or predates the JSON shape.
 func (h *Home) remoteGroupPaths(remoteName string) []string {
 	h.remoteSessionsMu.RLock()
 	defer h.remoteSessionsMu.RUnlock()
 	seen := make(map[string]bool)
 	var paths []string
-	for _, s := range h.remoteSessions[remoteName] {
-		p := normalizeRemoteGroupPath(s.Group)
+	add := func(p string) {
+		p = normalizeRemoteGroupPath(p)
 		if !seen[p] {
 			seen[p] = true
 			paths = append(paths, p)
 		}
+	}
+	for _, p := range h.remoteGroups[remoteName] {
+		add(p)
+	}
+	for _, s := range h.remoteSessions[remoteName] {
+		add(s.Group)
 	}
 	sort.Strings(paths)
 	return paths
@@ -3538,6 +3562,14 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	// as "remote contributes zero" so a single broken remote can't poison
 	// the displayed total.
 	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
+	// Remote group lists (group list --json) ride the same fanout so the
+	// move/create dialogs can offer EMPTY remote folders — a folder that
+	// currently holds no sessions is invisible to session-derived buckets
+	// but is still a valid target. Successful fetches land in groupResults;
+	// failures in groupsFailed keep last-good cache entries (same contract
+	// as the sessions map, issue #1170).
+	groupResults := make(map[string][]string, len(config.Remotes))
+	groupsFailed := make(map[string]bool, len(config.Remotes))
 	// #1170: track remotes that errored so the handler keeps their last-good
 	// sessions instead of dropping them.
 	failed := make(map[string]bool, len(config.Remotes))
@@ -3563,6 +3595,8 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			if err != nil {
 				mu.Lock()
 				failed[name] = true
+				// The group list can't be trusted either — keep last-good.
+				groupsFailed[name] = true
 				mu.Unlock()
 				return
 			}
@@ -3576,17 +3610,33 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			summary, costErr := runner.FetchCostSummary(costCtx)
 			costCancel()
 
+			// Group list fetch has the same isolation: a slow `group list`
+			// on one remote must not starve the session/cost data of any
+			// other remote, and a failure degrades to the session-derived
+			// group fallback in remoteGroupPaths.
+			groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+			groupPaths, groupErr := runner.FetchGroupPaths(groupCtx)
+			groupCancel()
+
 			mu.Lock()
 			results[name] = sessions
 			if costErr == nil && summary != nil {
 				costResults[name] = summary
+			}
+			if groupErr == nil {
+				if groupPaths == nil {
+					groupPaths = []string{}
+				}
+				groupResults[name] = groupPaths
+			} else {
+				groupsFailed[name] = true
 			}
 			mu.Unlock()
 		}(name, rc)
 	}
 	wg.Wait()
 
-	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, failed: failed}
+	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -6571,6 +6621,26 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// #1170: merge rather than wholesale-replace so a remote that errored
 		// this round keeps its last-good sessions instead of flickering out.
 		h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
+		// Remote group lists: replace wholesale for remotes that reported a
+		// fresh list; failed remotes keep their last-good cached paths so the
+		// move dialog doesn't lose empty-group targets on a transient SSH
+		// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
+		for name, paths := range msg.groups {
+			h.remoteGroups[name] = paths
+			keepGroups[name] = true
+		}
+		for name := range msg.groupsFailed {
+			keepGroups[name] = true
+		}
+		for name := range h.remoteGroups {
+			if !keepGroups[name] {
+				delete(h.remoteGroups, name)
+			}
+		}
 		for name := range msg.sessions {
 			if !msg.failed[name] {
 				delete(h.remoteFromCache, name)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1362,6 +1362,17 @@ type maintenanceCompleteMsg struct {
 	result session.MaintenanceResult
 }
 
+// remoteMoveResultMsg reports the outcome of an SSH-routed "move to group"
+// for a remote session (M key → GroupDialogMove). The session's row lives in
+// the remote's own state DB, so the move is executed there and the local
+// fleet cache is patched only after the remote confirms.
+type remoteMoveResultMsg struct {
+	remoteName string
+	sessionID  string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2107,6 +2118,55 @@ func (h *Home) scopedGroupPaths() []string {
 		}
 	}
 	return scoped
+}
+
+// remoteGroupPaths returns the distinct, normalized group paths currently
+// observed on a remote, sorted for the move dialog (M key on a remote
+// session). These are the only groups the remote knows about; a remote move
+// is executed with `agent-deck group move <id> <group>` on that host.
+func (h *Home) remoteGroupPaths(remoteName string) []string {
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	seen := make(map[string]bool)
+	var paths []string
+	for _, s := range h.remoteSessions[remoteName] {
+		p := normalizeRemoteGroupPath(s.Group)
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// moveRemoteSessionToGroup routes a TUI "move to group" for a remote session
+// over SSH: the session's row lives in the remote's own state DB, so the
+// local tree cannot move it. Runs `agent-deck group move <id> <group>` on the
+// remote (the same command the remote's own TUI would run) and returns a
+// remoteMoveResultMsg so the fleet cache is updated only on remote
+// confirmation. Mirrors the remote-rename path in GroupDialogRenameSession.
+func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGroupPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': failed to load remotes config: %v", title, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': remote '%s' is not configured", title, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := runner.RunCommand(ctx, "group", "move", sessionID, targetGroupPath); err != nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("failed to move '%s' on %s: %v", title, remoteName, err)}
+		}
+		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
+	}
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6627,6 +6687,29 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case remoteMoveResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed; patch the local fleet cache so the row moves
+		// groups immediately, before the next poll re-fetches the truth.
+		// The persisted local order overlay for the old bucket is harmless:
+		// applyRemoteSessionOrder skips overlay IDs the remote no longer
+		// reports in that bucket.
+		h.remoteSessionsMu.Lock()
+		if sessions, ok := h.remoteSessions[msg.remoteName]; ok {
+			for i := range sessions {
+				if sessions[i].ID == msg.sessionID {
+					sessions[i].Group = msg.groupPath
+					break
+				}
+			}
+		}
+		h.remoteSessionsMu.Unlock()
+		h.rebuildFlatItems()
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9450,6 +9533,13 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.setError(errSessionStillCreating)
 			} else if item.Type == session.ItemTypeSession {
 				h.groupDialog.ShowMove(h.scopedGroupPaths())
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote sessions live in the remote's own state DB, so the
+				// local tree cannot move them. Offer the group paths currently
+				// observed on that remote (the only groups the remote knows
+				// about); the confirmed move is routed over SSH in
+				// GroupDialogMove (see moveRemoteSessionToGroup).
+				h.groupDialog.ShowMove(h.remoteGroupPaths(item.RemoteName))
 			}
 		}
 		return h, nil
@@ -11630,6 +11720,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
+		// moveCmd is set when the confirmed action is a remote-session move,
+		// which runs over SSH and reports back via remoteMoveResultMsg.
+		var moveCmd tea.Cmd
+
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
@@ -11700,6 +11794,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.instancesMu.Unlock()
 					h.rebuildFlatItems()
 					h.saveInstances()
+				} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && item.RemoteName != "" {
+					// The row lives in the remote's own DB; run
+					// `agent-deck group move` there over SSH (mirrors the
+					// remote-rename path) and refresh the fleet cache when the
+					// remote confirms via remoteMoveResultMsg.
+					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11788,7 +11888,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, nil
+		return h, moveCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -719,6 +719,9 @@ type Home struct {
 	// dropped otherwise, so a slow answer for an earlier opening can never
 	// replace the slot list the user is choosing from now.
 	remoteAccountsGen uint64
+	// pendingRemoteCreate holds the remote create whose path the server
+	// reported missing, while the create-directory confirmation is open.
+	pendingRemoteCreate *remoteCreateDirNeededMsg
 	// insertKeySender is the persistent dispatch path opened on
 	// enterInsertMode and closed on exitInsertMode (#1102 perf fix +
 	// remote support). Local sessions get a tmux.KeySender (control-mode
@@ -6767,6 +6770,15 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.applyRemoteAccounts(msg)
 		return h, nil
 
+	case remoteCreateDirNeededMsg:
+		// The server refused the path; ask before retrying with --create-dir
+		// so a typo never silently creates a directory on the remote.
+		pending := msg
+		h.pendingRemoteCreate = &pending
+		h.confirmDialog.ShowCreateRemoteDirectory(msg.remoteName, msg.opts.Path)
+		h.beginAttachReturnGrace(time.Now())
+		return h, tea.Batch(tea.EnableMouseCellMotion, RestoreLegacyKeyboardCmd(os.Stdout), tea.WindowSize())
+
 	case remoteSessionCreatedMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
@@ -10672,9 +10684,11 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if h.confirmDialog.GetFocusedButton() == 0 {
 				return h, h.confirmCreateDirectory()
 			}
+			h.pendingRemoteCreate = nil
 			h.confirmDialog.Hide()
 			return h, nil
 		case "n", "N", "esc":
+			h.pendingRemoteCreate = nil
 			h.confirmDialog.Hide()
 			return h, nil
 		}
@@ -10799,6 +10813,17 @@ func (h *Home) confirmAction() tea.Cmd {
 
 // confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
 func (h *Home) confirmCreateDirectory() tea.Cmd {
+	if pending := h.pendingRemoteCreate; pending != nil {
+		h.pendingRemoteCreate = nil
+		h.confirmDialog.Hide()
+		opts := pending.opts
+		opts.CreateDir = true
+		create := h.createRemoteSessionWithOptions
+		if h.remoteCreateSink != nil {
+			create = h.remoteCreateSink
+		}
+		return create(pending.remoteName, opts)
+	}
 	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingAccount, pendingLaunchModelID, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
 	h.confirmDialog.Hide()
 	if err := os.MkdirAll(path, 0o755); err != nil {
@@ -14341,6 +14366,14 @@ type remoteSessionCreatedMsg struct {
 	err error
 }
 
+// remoteCreateDirNeededMsg reports a remote create refused because the
+// dialog's path does not exist on the server; Home offers to create it.
+type remoteCreateDirNeededMsg struct {
+	remoteName string
+	opts       session.RemoteAddOptions
+	err        error
+}
+
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	return func() tea.Msg {
@@ -14761,6 +14794,9 @@ func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.Re
 			var attachErr remoteAttachFailedError
 			if errors.As(err, &attachErr) {
 				return remoteSessionCreatedMsg{err: fmt.Errorf("failed to attach to remote session after creating it: %w", attachErr)}
+			}
+			if !opts.CreateDir && strings.TrimSpace(opts.Path) != "" && session.IsRemotePathMissing(err) {
+				return remoteCreateDirNeededMsg{remoteName: remoteName, opts: opts, err: err}
 			}
 			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1379,6 +1379,16 @@ type remoteMoveResultMsg struct {
 	err        error
 }
 
+// remoteGroupResultMsg reports the outcome of an SSH-routed "create group"
+// for a remote context (g key on a remote row → GroupDialogCreate). The
+// group must be created in the remote's own state DB; groupPath is the full
+// path the remote assigned (parent/name, or name for a root-level group).
+type remoteGroupResultMsg struct {
+	remoteName string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2191,6 +2201,56 @@ func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGrou
 		}
 		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
 	}
+}
+
+// createRemoteGroup routes a TUI "create group" (g key on a remote row) over
+// SSH: the group must be created in the remote's own state DB, not the local
+// tree. Runs `agent-deck group create <name> [--parent <parent>]` on the
+// remote and returns a remoteGroupResultMsg so the local group-path cache is
+// updated only on remote confirmation. Mirrors moveRemoteSessionToGroup and
+// the remote-rename path in GroupDialogRenameSession.
+func (h *Home) createRemoteGroup(name, remoteName, parentPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': failed to load remotes config: %v", name, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': remote '%s' is not configured", name, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		args := []string{"group", "create", name}
+		if parentPath != "" {
+			args = append(args, "--parent", parentPath)
+		}
+		if _, err := runner.RunCommand(ctx, args...); err != nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("failed to create group '%s' on %s: %v", name, remoteName, err)}
+		}
+		full := name
+		if parentPath != "" {
+			full = parentPath + "/" + name
+		}
+		return remoteGroupResultMsg{remoteName: remoteName, groupPath: full}
+	}
+}
+
+// remoteGroupPathFromItem extracts the remote-relative group path from a
+// remote group header's Item.Path ("remotes/<name>/<group-path>"); returns
+// "" for the level-0 host header (Path == "remotes/<name>"). Used by the g
+// key handler to decide the parent for a remote subgroup create.
+func remoteGroupPathFromItem(item session.Item) string {
+	prefix := "remotes/" + item.RemoteName + "/"
+	p := strings.TrimPrefix(item.Path, prefix)
+	if p == item.Path {
+		return "" // level-0 host header
+	}
+	return p
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6780,6 +6840,35 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.rebuildFlatItems()
 		return h, nil
 
+	case remoteGroupResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed the group exists; add it to the cached group list
+		// so the M move dialog (and subsequent subgroup creates) offer it
+		// immediately, before the next fleet poll re-confirms from the
+		// remote's own DB. The sessions map is untouched — creating a group
+		// moves no sessions.
+		h.remoteSessionsMu.Lock()
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		seen := false
+		for _, p := range h.remoteGroups[msg.remoteName] {
+			if p == msg.groupPath {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			h.remoteGroups[msg.remoteName] = append(h.remoteGroups[msg.remoteName], msg.groupPath)
+			sort.Strings(h.remoteGroups[msg.remoteName])
+		}
+		h.remoteSessionsMu.Unlock()
+		h.setError(fmt.Errorf("created group '%s' on %s", msg.groupPath, msg.remoteName))
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9696,7 +9785,32 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		} else if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeGroup {
+			if item.Type == session.ItemTypeRemoteGroup {
+				// Remote group header (incl. the level-0 host header): create
+				// the group on the remote itself. The parent defaults to the
+				// header's own group path so Enter creates a remote subgroup;
+				// Tab toggles to root-level remote create (issue #111 parity).
+				parentPath := remoteGroupPathFromItem(item)
+				parentName := parentPath
+				if idx := strings.LastIndex(parentPath, "/"); idx >= 0 {
+					parentName = parentPath[idx+1:]
+				}
+				h.groupDialog.ShowCreateRemoteWithContext(parentPath, parentName, item.RemoteName)
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote session: default to a root-level group on the remote;
+				// Tab toggles to a subgroup under the session's current group.
+				if gPath := item.RemoteSession.Group; gPath != "" {
+					gName := gPath
+					if idx := strings.LastIndex(gPath, "/"); idx >= 0 {
+						gName = gPath[idx+1:]
+					}
+					h.groupDialog.ShowCreateRemoteWithContextDefaultRoot(gPath, gName, item.RemoteName)
+				} else {
+					// Ungrouped remote session: root only, no toggle (mirrors
+					// the local ungrouped case below).
+					h.groupDialog.ShowCreateRemoteWithContext("", "", item.RemoteName)
+				}
+			} else if item.Type == session.ItemTypeGroup {
 				// On group header: default to subgroup mode
 				h.groupDialog.ShowCreateWithContext(item.Group.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.GroupPath != "" {
@@ -11790,14 +11904,29 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
-		// moveCmd is set when the confirmed action is a remote-session move,
-		// which runs over SSH and reports back via remoteMoveResultMsg.
-		var moveCmd tea.Cmd
+		// remoteCmd is set when the confirmed action runs over SSH against a
+		// remote's own state DB (remote-session move, remote group create) and
+		// reports back via remoteMoveResultMsg / remoteGroupResultMsg.
+		var remoteCmd tea.Cmd
 
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
 			if name != "" {
+				if remoteName := h.groupDialog.RemoteName(); remoteName != "" {
+					// g was pressed on a REMOTE row: the group must be created
+					// in the remote's own state DB, not the local tree. Run
+					// `agent-deck group create` there over SSH (mirrors the
+					// remote-move and remote-rename paths); the local group
+					// path cache updates when the remote confirms via
+					// remoteGroupResultMsg.
+					parentPath := ""
+					if h.groupDialog.HasParent() {
+						parentPath = h.groupDialog.GetParentPath()
+					}
+					remoteCmd = h.createRemoteGroup(name, remoteName, parentPath)
+					break
+				}
 				// Seed the new-group default from [group_defaults].max_concurrent.
 				if cfg, _ := session.LoadUserConfig(); cfg != nil {
 					h.groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
@@ -11869,7 +11998,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					// `agent-deck group move` there over SSH (mirrors the
 					// remote-rename path) and refresh the fleet cache when the
 					// remote confirms via remoteMoveResultMsg.
-					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
+					remoteCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11958,7 +12087,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, moveCmd
+		return h, remoteCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2759,8 +2759,21 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 	remoteNames := make([]string, 0, len(h.remoteSessions))
 	remotes := make(map[string][]session.RemoteSessionInfo, len(h.remoteSessions))
 	for name, sessions := range h.remoteSessions {
+		// Partition remote rows the way local ones were above: the active
+		// view hides remote sessions the remote reports archived, and the ^
+		// archived view shows only those. A remote with nothing on the
+		// current side of that split contributes no rows, header included.
+		partitioned := make([]session.RemoteSessionInfo, 0, len(sessions))
+		for _, remote := range sessions {
+			if remote.Archived == viewArchived {
+				partitioned = append(partitioned, remote)
+			}
+		}
+		if len(partitioned) == 0 {
+			continue
+		}
 		remoteNames = append(remoteNames, name)
-		remotes[name] = append([]session.RemoteSessionInfo(nil), sessions...)
+		remotes[name] = partitioned
 	}
 	h.remoteSessionsMu.RUnlock()
 	sort.Strings(remoteNames)
@@ -2793,16 +2806,14 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 				}
 			}
 		}
-		if !viewArchived {
-			for _, sessions := range remotes {
-				for _, remote := range sessions {
-					hasCandidates = true
-					if remoteMatchesTime(remote) {
-						if activity, known := remote.LastActivity(); known {
-							h.recordTimeFilterExpiry(activity, now)
-						}
-						hasMatches = true
+		for _, sessions := range remotes {
+			for _, remote := range sessions {
+				hasCandidates = true
+				if remoteMatchesTime(remote) {
+					if activity, known := remote.LastActivity(); known {
+						h.recordTimeFilterExpiry(activity, now)
 					}
+					hasMatches = true
 				}
 			}
 		}
@@ -2914,7 +2925,7 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 		h.flatItems = expanded
 	}
 
-	if len(remotes) > 0 && h.statusFilter != FilterModeArchived {
+	if len(remotes) > 0 {
 		for _, remoteName := range remoteNames {
 			sessions := remotes[remoteName]
 			if h.timeFilter != session.TimeFilterAll {
@@ -6756,6 +6767,18 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.setError(fmt.Errorf("closed '%s' on %s", msg.title, msg.remoteName))
 		return h, h.fetchRemoteSessions
 
+	case remoteSessionArchivedMsg:
+		verb := "archive"
+		if !msg.archived {
+			verb = "unarchive"
+		}
+		if msg.err != nil {
+			h.setError(fmt.Errorf("failed to %s remote session: %w", verb, msg.err))
+			return h, nil
+		}
+		h.setError(fmt.Errorf("%sd '%s' on %s", verb, msg.title, msg.remoteName))
+		return h, h.fetchRemoteSessions
+
 	case remoteSessionRestartedMsg:
 		delete(h.remoteRestarting, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		delete(h.resumingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
@@ -10121,6 +10144,8 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil && !item.Session.IsArchived() {
 				h.confirmDialog.ShowArchiveSession(item.Session.ID, item.Session.Title)
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && !item.RemoteSession.Archived {
+				h.confirmDialog.ShowArchiveRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
 			}
 		}
 		return h, nil
@@ -10133,6 +10158,8 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.IsArchived() {
 				h.confirmDialog.ShowUnarchiveSession(item.Session.ID, item.Session.Title)
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && item.RemoteSession.Archived {
+				h.confirmDialog.ShowUnarchiveRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
 			}
 		}
 		return h, nil
@@ -10797,6 +10824,13 @@ func (h *Home) confirmAction() tea.Cmd {
 		title := h.confirmDialog.targetName
 		h.confirmDialog.Hide()
 		return h.closeRemoteSession(remoteName, sessionID, title)
+	case ConfirmArchiveRemoteSession, ConfirmUnarchiveRemoteSession:
+		sessionID := h.confirmDialog.GetTargetID()
+		remoteName := h.confirmDialog.GetRemoteName()
+		title := h.confirmDialog.targetName
+		archive := h.confirmDialog.GetConfirmType() == ConfirmArchiveRemoteSession
+		h.confirmDialog.Hide()
+		return h.setRemoteSessionArchived(remoteName, sessionID, title, archive)
 	case ConfirmRemoveSession:
 		sessionID := h.confirmDialog.GetTargetID()
 		if inst := h.getInstanceByID(sessionID); inst != nil {
@@ -14351,6 +14385,16 @@ type remoteSessionClosedMsg struct {
 	err        error
 }
 
+// remoteSessionArchivedMsg reports the outcome of a remote archive (archived
+// true) or unarchive (archived false).
+type remoteSessionArchivedMsg struct {
+	remoteName string
+	sessionID  string
+	title      string
+	archived   bool
+	err        error
+}
+
 type remoteSessionRestartedMsg struct {
 	remoteName string
 	sessionID  string
@@ -14429,6 +14473,35 @@ func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 		defer cancel()
 		err = runner.StopSession(ctx, sessionID)
 		return remoteSessionClosedMsg{remoteName: remoteName, sessionID: sessionID, title: title, err: err}
+	}
+}
+
+// setRemoteSessionArchived archives (archive true) or unarchives a remote
+// session through the remote's own `session archive` / `session unarchive`,
+// then refreshes the remote list so the row moves between the active and
+// archived (^) views the way a local session does.
+func (h *Home) setRemoteSessionArchived(remoteName, sessionID, title string, archive bool) tea.Cmd {
+	return func() tea.Msg {
+		result := remoteSessionArchivedMsg{remoteName: remoteName, sessionID: sessionID, title: title, archived: archive}
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			result.err = fmt.Errorf("failed to load remote config")
+			return result
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			result.err = fmt.Errorf("remote '%s' not found", remoteName)
+			return result
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if archive {
+			result.err = runner.ArchiveSession(ctx, sessionID)
+		} else {
+			result.err = runner.UnarchiveSession(ctx, sessionID)
+		}
+		return result
 	}
 }
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3443,7 +3443,7 @@ func TestRebuildFlatItemsCollapsedGroupKeepsHeaderInArchivedView(t *testing.T) {
 	}
 }
 
-func TestRebuildFlatItemsArchivedViewOmitsRemoteSessions(t *testing.T) {
+func TestRebuildFlatItemsArchivedViewPartitionsRemoteSessions(t *testing.T) {
 	h := NewHome()
 	h.statusFilter = FilterModeArchived
 
@@ -3459,16 +3459,108 @@ func TestRebuildFlatItemsArchivedViewOmitsRemoteSessions(t *testing.T) {
 
 	h.remoteSessionsMu.Lock()
 	h.remoteSessions = map[string][]session.RemoteSessionInfo{
-		"dev": {{ID: "remote-1", Title: "remote-session", RemoteName: "dev"}},
+		"dev":  {{ID: "remote-1", Title: "remote-live", RemoteName: "dev"}, {ID: "remote-2", Title: "remote-archived", RemoteName: "dev", Archived: true}},
+		"live": {{ID: "remote-3", Title: "live-only", RemoteName: "live"}},
 	}
 	h.remoteSessionsMu.Unlock()
 
-	h.rebuildFlatItems()
-
-	for _, item := range h.flatItems {
-		if item.Type == session.ItemTypeRemoteGroup || item.Type == session.ItemTypeRemoteSession {
-			t.Fatalf("archived view should omit remote rows, got %+v", item)
+	remoteRows := func() (sessions []string, headers []string) {
+		for _, item := range h.flatItems {
+			switch item.Type {
+			case session.ItemTypeRemoteSession:
+				sessions = append(sessions, item.RemoteSession.ID)
+			case session.ItemTypeRemoteGroup:
+				if item.Level == 0 {
+					headers = append(headers, item.RemoteName)
+				}
+			}
 		}
+		return sessions, headers
+	}
+
+	// Archived view: only the remote sessions the remote reports archived, and
+	// only headers for remotes that have one (mirrors the local group rule).
+	h.rebuildFlatItems()
+	sessions, headers := remoteRows()
+	if strings.Join(sessions, ",") != "remote-2" {
+		t.Fatalf("archived view remote sessions = %v, want [remote-2]", sessions)
+	}
+	if strings.Join(headers, ",") != "dev" {
+		t.Fatalf("archived view remote headers = %v, want [dev]", headers)
+	}
+
+	// Active view: the archived remote session is hidden, like a local one.
+	h.statusFilter = ""
+	h.rebuildFlatItems()
+	sessions, headers = remoteRows()
+	if strings.Join(sessions, ",") != "remote-1,remote-3" {
+		t.Fatalf("active view remote sessions = %v, want [remote-1 remote-3]", sessions)
+	}
+	if strings.Join(headers, ",") != "dev,live" {
+		t.Fatalf("active view remote headers = %v, want [dev live]", headers)
+	}
+}
+
+// A / Shift+U on a remote row open the same archive / unarchive confirmation
+// the local row gets, scoped to the remote, and confirming returns a command
+// (the SSH round trip) instead of touching any local instance.
+func TestRemoteArchiveAndUnarchiveUseConfirmDialog(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	live := session.RemoteSessionInfo{ID: "remote-123", Title: "remote-session", RemoteName: "myserver"}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &live, RemoteName: "myserver"}}
+	home.cursor = 0
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	h := model.(*Home)
+	if !h.confirmDialog.IsVisible() {
+		t.Fatal("A on a remote row should show the archive confirmation")
+	}
+	if got := h.confirmDialog.GetConfirmType(); got != ConfirmArchiveRemoteSession {
+		t.Fatalf("confirm type after A = %v, want %v", got, ConfirmArchiveRemoteSession)
+	}
+	if got := h.confirmDialog.GetRemoteName(); got != "myserver" {
+		t.Fatalf("remote name after A = %q, want %q", got, "myserver")
+	}
+	if got := h.confirmDialog.GetTargetID(); got != "remote-123" {
+		t.Fatalf("target id after A = %q, want %q", got, "remote-123")
+	}
+	if cmd := h.confirmAction(); cmd == nil {
+		t.Fatal("confirming a remote archive should return the SSH command")
+	}
+	if h.confirmDialog.IsVisible() {
+		t.Fatal("confirming should hide the dialog")
+	}
+
+	// Shift+U is gated on the archived view, exactly like the local path.
+	archived := session.RemoteSessionInfo{ID: "remote-456", Title: "old-session", RemoteName: "myserver", Archived: true}
+	h.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &archived, RemoteName: "myserver"}}
+	model, _ = h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'U'}})
+	h = model.(*Home)
+	if h.confirmDialog.IsVisible() {
+		t.Fatal("Shift+U outside the archived view must not open a dialog")
+	}
+	h.statusFilter = FilterModeArchived
+	model, _ = h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'U'}})
+	h = model.(*Home)
+	if got := h.confirmDialog.GetConfirmType(); !h.confirmDialog.IsVisible() || got != ConfirmUnarchiveRemoteSession {
+		t.Fatalf("Shift+U on an archived remote row: visible=%v type=%v, want %v", h.confirmDialog.IsVisible(), got, ConfirmUnarchiveRemoteSession)
+	}
+	if got := h.confirmDialog.GetRemoteName(); got != "myserver" {
+		t.Fatalf("remote name after Shift+U = %q, want %q", got, "myserver")
+	}
+	if cmd := h.confirmAction(); cmd == nil {
+		t.Fatal("confirming a remote unarchive should return the SSH command")
+	}
+
+	// A on a row the remote already reports archived is a no-op.
+	h.confirmDialog.Hide()
+	model, _ = h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	h = model.(*Home)
+	if h.confirmDialog.IsVisible() {
+		t.Fatal("A on an already archived remote row must not open a dialog")
 	}
 }
 

--- a/internal/ui/remote_create_dir_test.go
+++ b/internal/ui/remote_create_dir_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// A remote create whose path the server reports missing must not end as a
+// bare error in the footer: the TUI asks whether to create the directory on
+// that remote and, only on confirmation, retries with CreateDir set so the
+// server's `add --create-dir` makes it.
+
+func newRemoteDirNeededHome(t *testing.T) (*Home, *remoteCreateCapture) {
+	t.Helper()
+	setXDGTestHome(t)
+	h := newTestHomeWithItems(100, 30, nil)
+	capture := &remoteCreateCapture{}
+	h.remoteCreateSink = capture.sink
+	return h, capture
+}
+
+func missingDirMsg() remoteCreateDirNeededMsg {
+	return remoteCreateDirNeededMsg{
+		remoteName: "lab",
+		opts:       session.RemoteAddOptions{Tool: "claude", Title: "new work", Path: "/srv/new-project"},
+		err:        errors.New("ssh command failed: exit status 1: Error: path does not exist: /srv/new-project"),
+	}
+}
+
+func TestRemoteCreateMissingDir_ConfirmRetriesWithCreateDir(t *testing.T) {
+	h, capture := newRemoteDirNeededHome(t)
+
+	model, _ := h.Update(missingDirMsg())
+	h = model.(*Home)
+	if !h.confirmDialog.IsVisible() || h.confirmDialog.GetConfirmType() != ConfirmCreateDirectory {
+		t.Fatalf("missing remote path must open the create-directory confirmation, got visible=%v type=%v",
+			h.confirmDialog.IsVisible(), h.confirmDialog.GetConfirmType())
+	}
+	if got := h.confirmDialog.GetRemoteName(); got != "lab" {
+		t.Fatalf("confirmation remote = %q, want lab", got)
+	}
+	if capture.calls != 0 {
+		t.Fatalf("remote contacted %d times before the user confirmed, want 0", capture.calls)
+	}
+
+	model, _ = h.handleConfirmDialogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	h = model.(*Home)
+	if capture.calls != 1 {
+		t.Fatalf("remote create calls after confirm = %d, want 1", capture.calls)
+	}
+	if capture.remoteName != "lab" || !capture.opts.CreateDir || capture.opts.Path != "/srv/new-project" || capture.opts.Title != "new work" {
+		t.Fatalf("retry forwarded remote=%q opts=%+v; want the same dialog values on lab with CreateDir", capture.remoteName, capture.opts)
+	}
+	if h.confirmDialog.IsVisible() || h.pendingRemoteCreate != nil {
+		t.Fatal("confirmation must close and clear the pending create after retrying")
+	}
+}
+
+func TestRemoteCreateMissingDir_CancelCreatesNothing(t *testing.T) {
+	h, capture := newRemoteDirNeededHome(t)
+
+	model, _ := h.Update(missingDirMsg())
+	h = model.(*Home)
+	model, _ = h.handleConfirmDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	h = model.(*Home)
+	if capture.calls != 0 {
+		t.Fatalf("remote contacted %d times after cancel, want 0", capture.calls)
+	}
+	if h.confirmDialog.IsVisible() || h.pendingRemoteCreate != nil {
+		t.Fatal("cancel must close the confirmation and drop the pending create")
+	}
+}

--- a/internal/ui/remote_create_group_test.go
+++ b/internal/ui/remote_create_group_test.go
@@ -1,0 +1,221 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "g (create group) only creates LOCAL groups, even when
+// the cursor is on a remote row".
+//
+// The g-key dispatch in handleMainKey offered the create dialog without any
+// remote awareness, so confirming it created the group in the local tree via
+// GroupDialogCreate → groupTree.CreateGroup even though the cursor sat on a
+// remote session/header whose groups live in the remote's own state DB. These
+// tests pin the remote create path at the same dispatch boundary used by the
+// remote-move (#2081) and remote-shift-enter (#1100) tests: the dialog must
+// carry the remote name, and Enter must return an SSH-routed tea.Cmd instead
+// of mutating the local tree.
+
+// TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH pins the dispatch:
+// g on a remote-session row must open the create dialog scoped to that remote
+// (RemoteName == "lab"), and confirming it must return the SSH-routed create
+// cmd without touching the local group tree.
+func TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote session did not open the create dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogCreate {
+		t.Fatalf("expected GroupDialogCreate mode, got %v", home.groupDialog.Mode())
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	// The helper's cursor session lives in group "work", so the dialog
+	// defaults to root mode with Tab toggling to a subgroup under "work".
+	if home.groupDialog.CanToggle() {
+		if got := home.groupDialog.GetParentPath(); got != "" {
+			t.Fatalf("root-mode create should have no parent, got %q", got)
+		}
+	} else {
+		t.Fatal("grouped remote session create dialog should offer the Root/Subgroup toggle")
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the group lives on the remote.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote group create: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup pins the
+// header path: g on a remote group header opens the create dialog scoped to
+// that remote WITH the header's group as the parent (subgroup mode), so Enter
+// runs `group create <name> --parent <header>` on the remote.
+func TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Cursor sits on the "work" group header of remote "lab" (the session
+	// row keeps the header present in the flat list, as in the real TUI).
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			Path:       "remotes/lab/work",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab/work", Level: 1},
+	}
+	home.cursor = 1
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote group header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if !home.groupDialog.HasParent() {
+		t.Fatal("remote group header create should default to subgroup mode")
+	}
+	if got := home.groupDialog.GetParentPath(); got != "work" {
+		t.Fatalf("create dialog parent path = %q, want \"work\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("sub")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote subgroup create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup pins the
+// level-0 host-header path: g on "remotes/<name>" (the host header itself)
+// opens a root-level remote create with no parent.
+func TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab", Level: 0},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on the remote host header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if home.groupDialog.HasParent() {
+		t.Fatalf("host-header create should be root-level, got parent %q", home.groupDialog.GetParentPath())
+	}
+}
+
+// TestRemoteCreateGroup_LocalSessionStillCreatesLocally guards the other side
+// of the branch: g on a LOCAL session keeps creating the group in the local
+// tree, with no remote name and no SSH cmd.
+func TestRemoteCreateGroup_LocalSessionStillCreatesLocally(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.groupTree = session.NewGroupTree([]*session.Instance{})
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a local session did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "" {
+		t.Fatalf("local create dialog remoteName = %q, want \"\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local group create returned a non-nil cmd %v; local creates are synchronous", cmd)
+	}
+}
+
+// TestRemoteGroupResultMsgPatchesCache pins the create confirmation: when the
+// remote reports a successful `group create`, the new path is added to the
+// cached group list so the M move dialog offers it immediately (before the
+// next fleet poll re-confirms from the remote's own DB).
+func TestRemoteGroupResultMsgPatchesCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{"lab": {"work"}}
+	home.remoteSessionsMu.Unlock()
+
+	model, _ := home.Update(remoteGroupResultMsg{remoteName: "lab", groupPath: "work/newgroup"})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"work", "work/newgroup"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "M (move to group) does nothing on remote sessions".
+//
+// The M-key dispatch in handleMainKey only offered the move dialog for
+// ItemTypeSession, so pressing M on a remote-session row was a silent no-op
+// even though the remote-rename path (GroupDialogRenameSession) already knows
+// how to mutate a remote session over SSH. These tests pin the remote move
+// path at the same dispatch boundary used by the #1100 remote-shift-enter
+// tests.
+
+// armHomeWithOneRemoteSessionInGroups sets up a Home whose cursor sits on a
+// remote session row, with a populated remote fleet cache so remoteGroupPaths
+// has something to offer. The remote is declared in $HOME's config.toml so
+// any executed SSH command can resolve it (tests that would execute SSH only
+// assert the returned tea.Cmd is non-nil and never run it).
+func armHomeWithOneRemoteSessionInGroups(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Remote fleet cache: two sessions across two groups, plus the row the
+	// cursor will sit on.
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"lab": {
+			{ID: "remote-id-xyz", Title: "remote session", Group: "work"},
+			{ID: "remote-id-abc", Title: "other session", Group: "personal"},
+			{ID: "remote-id-ungrouped", Title: "loose session", Group: ""},
+		},
+	}
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+	}
+	home.cursor = 0
+	return home
+}
+
+// TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups pins the dispatch:
+// pressing M on a remote-session row must open the move dialog (the same one
+// local sessions get) with the groups observed on that remote.
+func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogMove {
+		t.Fatalf("expected GroupDialogMove mode, got %v", home.groupDialog.Mode())
+	}
+
+	// The dialog must offer the remote's own groups (normalized, sorted,
+	// deduped) — not the local group tree, which knows nothing about the
+	// remote. Empty remote group normalizes to the default group path.
+	want := []string{"my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
+// the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
+// must NOT mutate the local group tree.
+func TestRemoteMoveToGroup_EnterReturnsMoveCmd(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote move dialog returned a nil cmd; expected the SSH-routed move")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the remote row is not a local
+	// instance, so MoveSessionToGroup must never have been called.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote move: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree guards the other side
+// of the branch: moving a LOCAL session must keep using the local tree and
+// return no SSH cmd.
+func TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a local session did not open the move dialog")
+	}
+
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local move returned a non-nil cmd %v; local moves are synchronous", cmd)
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -89,6 +89,79 @@ func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
 	}
 }
 
+// TestRemoteMoveToGroup_MKeyIncludesEmptyGroups pins the empty-folder fix:
+// the move dialog must offer groups that currently hold NO sessions on the
+// remote (a folder left empty after every session was moved out of it).
+// Session-derived buckets can never contain an empty group, so this relies on
+// the fleet poll's cached `group list --json` (Home.remoteGroups) being
+// unioned into remoteGroupPaths.
+func TestRemoteMoveToGroup_MKeyIncludesEmptyGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	// The remote's own group DB reports an extra EMPTY folder (no sessions):
+	// it must still be offered as a move target.
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{
+		"lab": {"empty-folder", "personal", "work"},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	// Union of the remote's own group list (incl. the empty folder) and the
+	// session-derived groups (empty remote group normalizes to my-sessions).
+	want := []string{"empty-folder", "my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteSessionsFetchedMsgPopulatesGroupCache pins the fleet-poll wiring:
+// the remote group lists carried on remoteSessionsFetchedMsg land in
+// Home.remoteGroups (guarded by remoteSessionsMu), which is what the M move
+// dialog reads to offer empty remote folders.
+func TestRemoteSessionsFetchedMsgPopulatesGroupCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"lab": {{ID: "x", Title: "s", Group: "work"}},
+		},
+		groups: map[string][]string{
+			"lab": {"empty-folder", "work"},
+		},
+	})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"empty-folder", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 // TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
 // the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
 // must NOT mutate the local group tree.


### PR DESCRIPTION
## What problem does this solve?

Archiving is one of the few session actions you cannot do on a remote row from the TUI: `A` does nothing on a remote session, `Shift+U` ignores remote rows, and the archived (`^`) view drops every remote entirely, so a session archived on the remote sits in the active list with a stale glyph. Part of #2156.

## Why this change

Same forwarding shape as #2155 and #2157: TUI key handler and confirm dialog, then an `SSHRunner` method, then the remote's own CLI verb. The remote's `list --json` already reports `archived` per session (`RemoteSessionInfo.Archived`), so the archived view can be fed from the existing fetch with no new server-side data; the row partition simply mirrors what `rebuildFlatItems` already does for local sessions. The remote's `session archive` / `session unarchive` stay the single source of truth, so nothing is written locally.

## User impact

- `A` on a remote session opens the archive confirmation (same wording and keys, plus the remote name); confirming runs `session archive` on the remote and refreshes the list.
- `Shift+U` in the `^` view on an archived remote session opens the unarchive confirmation and runs `session unarchive` on the remote.
- The `^` archived view now lists archived remote sessions under their remote header; the active view hides them, like local archived sessions. Remotes with nothing on the current side of the split contribute no rows.
- `agent-deck remote <name> session archive|unarchive <id>` is admitted by the passthrough allow-list, and the remote usage text lists the verbs.
- Nothing changes for users without remotes.

## Evidence

Local go test is disallowed on this host; full suite runs in CI on this PR.

`gofmt -l`, `go build ./...` and `go vet ./internal/ui ./internal/session ./cmd/agent-deck` are clean. New tests: `TestRemoteArchiveAndUnarchiveUseConfirmDialog` (key dispatch, archived-view gate, confirm routing returns the SSH command), `TestRebuildFlatItemsArchivedViewPartitionsRemoteSessions` (replaces the test that pinned the old "archived view omits remotes" behavior), `TestSSHRunnerArchiveSession_ForwardsRemoteVerbs` (argument vectors via the stubbed runner), `TestRemoteCommandArgsSessionArchiveVerbs`, and the two verbs added to the SSH parity table in `TestRemoteCommandParity`.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

**Prompt / session log (optional):**

## What actually bothered you

My human asked: "can I use the remote side from the TUI seamlessly like I would do locally? That is the idea, from the TUI please."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
